### PR TITLE
feat(conformance): add P037/P038/P039 SDR-readiness rules

### DIFF
--- a/packages/conformance/CHANGELOG.md
+++ b/packages/conformance/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to `atlan-application-sdk-conformance` are documented here.
 
+## [Unreleased]
+
+### Features
+
+- add P037 `SdrAgentJsonNotConsumed` (warn) and P038 `SdrArtifactMisrooted` (warn) SDR-readiness rules — P037 flags an app that resolves credentials by `credential_guid` only and never routes through an agent-aware resolver (`agent_json` ignored → zero assets in agent mode); P038 flags an object-store output prefix rooted from the empty-defaulting workflow-input `application_name` field instead of `APPLICATION_NAME` (mis-rooted artifacts → zero assets published)
+- add P039 `SdrAgentJsonDroppedByInputContract` (warn) SDR-readiness rule — flags an app whose generated manifest declares `{{agent-json}}` (P029-clean) but whose generated extract-input contract (`AppInputContract`) subclasses the bare `Input` base, declares no `agent_json` field, and rejects extra fields, so Pydantic silently drops the forwarded `agent_json` and credentials never resolve (`PipelineContractError` / zero assets); contracts that subclass the SDK `*ExtractionInput` family or set `allow_unbounded_fields=True`/`extra="allow"` are exempt
+
 ## [0.15.0] - 2026-07-20
 
 ### Features

--- a/packages/conformance/conformance/docs/rules/prescriptions.md
+++ b/packages/conformance/conformance/docs/rules/prescriptions.md
@@ -5,7 +5,7 @@
 
 # Prescription Rules (P-series)
 
-**36 rules** · Checker: `suite.checks.prescriptions` (P001–P003, P008–P015), `suite.checks.orchestration` (P004–P007, scans test files too), `suite.checks.entrypoint_alignment` (P016), `suite.checks.entrypoint` (P017–P018, scans test files too), `suite.checks.client_seam` (P019), `suite.checks.determinism` (P020–P024, P031), `suite.checks.app_name_alignment` (P025) (all AST-based / cross-artifact)
+**39 rules** · Checker: `suite.checks.prescriptions` (P001–P003, P008–P015), `suite.checks.orchestration` (P004–P007, scans test files too), `suite.checks.entrypoint_alignment` (P016), `suite.checks.entrypoint` (P017–P018, scans test files too), `suite.checks.client_seam` (P019), `suite.checks.determinism` (P020–P024, P031), `suite.checks.app_name_alignment` (P025), `suite.checks.sdr` (P029/P030, P037/P038/P039) (all AST-based / cross-artifact)
 
 Suppress a finding on the violating line or the line directly above it:
 
@@ -59,6 +59,9 @@ reassigned.
 | [P034](#p034) | `UntypedPreflightCheckFailure` | `warn` | `app` | `preflight-gate` | — | 0.15.0 |
 | [P035](#p035) | `PreflightMetadataContractParity` | `warn` | `app` | `preflight-gate` | — | 0.15.0 |
 | [P036](#p036) | `HandRolledProcessIsolation` | `warn` | `both` | `async-correctness` | — | 0.15.0 |
+| [P037](#p037) | `SdrAgentJsonNotConsumed` | `warn` | `app` | `sdr-readiness` | — | 0.16.0 |
+| [P038](#p038) | `SdrArtifactMisrooted` | `warn` | `app` | `sdr-readiness` | — | 0.16.0 |
+| [P039](#p039) | `SdrAgentJsonDroppedByInputContract` | `warn` | `app` | `sdr-readiness` | — | 0.16.0 |
 
 ---
 
@@ -1195,5 +1198,146 @@ lives.
 Remediation is a restructure (route through the seam), so findings route to residue.
 Land as `WARN`; suppress a reviewed exception (e.g. a deliberate CPU-bound pool that
 never touches the worker) with `# conformance: ignore[P036] <reason>`.
+
+---
+
+## P037 — `SdrAgentJsonNotConsumed` {#p037}
+
+**Tier:** `warn` · **Scope:** `app` · **Category:** `sdr-readiness` · **Autofixable:** — · **Since:** 0.16.0
+
+> SDR app resolves credentials by credential_guid only and never routes through an agent-aware resolver — agent_json is ignored
+
+**Rationale:** In SDR (agent) mode the platform forwards agent_json on the workflow input; the SDK's
+agent-aware resolvers (CredentialRef.resolve / CredentialRef.from_workflow_args) consume
+it to route the credential fetch through the customer-side agent. An app that instead
+resolves credentials with a custom, GUID-only path — a hand-rolled vault read plus
+resolve_credential_raw, or a bare CredentialRef(credential_guid=...) — ignores
+agent_json entirely. Its manifest can be P029-clean, but in agent mode the credential
+never resolves and the workflow writes zero assets while reporting 'success' (observed
+for a table-format connector in fleet testing).
+
+For apps declaring `self_deployed_runtime: true` in `atlan.yaml`, credential resolution
+must be able to consume `agent_json` — the agent-mode routing spec the platform forwards
+on the workflow input.
+
+This rule fires when an app performs *custom* credential resolution — a bare
+`CredentialRef(credential_guid=...)` construction or a `resolve_credential_raw(...)`
+call — but NEVER routes through an agent-aware resolver entry point anywhere in its
+source:
+
+* `CredentialRef.resolve(input)` — reads `input.agent_json` and   picks the agent vs.
+direct-GUID route. * `CredentialRef.from_workflow_args(workflow_args)` — the same,
+reading `agent_json` off the args payload.
+
+An app that resolves strictly by `credential_guid` (a custom local vault read that only
+ever builds `CredentialRef(name=guid, credential_guid=guid)`) ignores `agent_json`, so
+in agent mode the credential never resolves and zero assets are written — a silent
+failure invisible to status-only pipelines.
+
+Apps that lean on the SDK's transparent resolution (they build no `CredentialRef` and
+call no `resolve_credential_raw`) are not gated in and never flagged.
+
+This is a WARN (not BLOCK): the static heuristic recognises the two sanctioned resolver
+entry points and a direct `agent_spec`-carrying ref, but an app could resolve
+`agent_json` through a bespoke helper the heuristic does not know about.  Review before
+suppressing.
+
+**Remediation:** route credential resolution through `CredentialRef.resolve(input)` or
+`CredentialRef.from_workflow_args(workflow_args)` (both consume `agent_json` and pick
+the correct route), keeping the direct `credential_guid` path only as a fallback after
+the agent-aware call.
+
+---
+
+## P038 — `SdrArtifactMisrooted` {#p038}
+
+**Tier:** `warn` · **Scope:** `app` · **Category:** `sdr-readiness` · **Autofixable:** — · **Since:** 0.16.0
+
+> SDR object-store prefix rooted from the empty-defaulting input application_name field instead of APPLICATION_NAME
+
+**Rationale:** The object-store output prefix must be rooted from the SDK app identity
+(APPLICATION_NAME / self._app_name), which the SDK's own WORKFLOW_OUTPUT_PATH_TEMPLATE
+does correctly. An app that instead roots 'artifacts/apps/<identity>/...' from the
+workflow-input application_name field mis-roots: that field's contract default is '' and
+AE forwards only manifest-declared args, so it stays empty and artifacts land under
+'artifacts/apps//workflows/...' (empty app segment). self.upload() then succeeds but 0
+assets publish — P030 passes the app (upload IS called), so this distinct rule catches
+the wrong-root case (observed for a document-store connector in fleet testing).
+
+For apps declaring `self_deployed_runtime: true` in `atlan.yaml`, the object-store
+output path/prefix (`artifacts/apps/<identity>/workflows/...`) must be rooted from the
+SDK app identity — the `APPLICATION_NAME` constant, `self._app_name`, or the SDK's
+`WORKFLOW_OUTPUT_PATH_TEMPLATE` (which fills `application_name` from the app identity).
+
+This rule fires when the app instead builds that path from a *workflow-input*
+`application_name` field — read as `input_data.get("application_name", ...)`,
+`input_data["application_name"]`, or `input.application_name` — and interpolates it
+(directly or via a local variable) into an f-string whose literal contains
+`artifacts/apps`.  The contract default of that field is `""` and AE forwards only
+manifest-declared args, so the value stays empty; the artifacts then land under
+`artifacts/apps//workflows/...` (note the empty app segment). `self.upload()` reports
+success but the publish app finds 0 assets at the expected prefix.
+
+This is complementary to P030: P030 checks that `self.upload()` is *called*; P038 checks
+that what it uploads is rooted correctly.  An app can pass P030 and still fail P038.
+
+This is a WARN (not BLOCK): the failure is a silent zero-asset publish, not a hard
+crash, and the heuristic is deliberately narrow (it keys on the `application_name` input
+field feeding an `artifacts/apps` literal).  It does NOT catch every mis-rooting — an
+app that forwards an empty `output_prefix` input field without an `artifacts/apps`
+literal is indistinguishable from a correct app statically and is left to runtime/e2e
+detection.
+
+**Remediation:** root the object-store prefix from `APPLICATION_NAME` / `self._app_name`
+(or use `WORKFLOW_OUTPUT_PATH_TEMPLATE.format( application_name=APPLICATION_NAME,
+...)`), or default the contract field to the app name; never derive it from an
+empty-defaulting workflow arg.
+
+---
+
+## P039 — `SdrAgentJsonDroppedByInputContract` {#p039}
+
+**Tier:** `warn` · **Scope:** `app` · **Category:** `sdr-readiness` · **Autofixable:** — · **Since:** 0.16.0
+
+> SDR generated extract-input contract drops the forwarded agent_json (bare Input subclass, no agent_json field, extra fields rejected)
+
+**Rationale:** In SDR (agent) mode the platform forwards agent_json on the extract input. A generated
+extract-input contract that subclasses the bare Input base, declares no agent_json
+field, and rejects extra fields makes Pydantic silently drop that forwarded agent_json —
+the extract input's credential_ref is then None and extraction fails with
+PipelineContractError and 0 assets, even though the manifest is P029-clean (declares
+{{agent-json}}). This is distinct from P029 (manifest side) and P037 (code resolves by
+guid only): here the manifest and code are fine but the typed contract eats the field
+(observed for a BI connector in fleet testing).
+
+For apps declaring `self_deployed_runtime: true` in `atlan.yaml` whose generated
+manifest declares agent routing (the `{{agent-json}}` placeholder at the extract-args
+top level — i.e. P029 passes), the generated extract-input contract model must be able
+to *receive* the forwarded `agent_json`.
+
+This rule fires when the generated extract-input contract (`AppInputContract` in a
+generated `_input.py`):
+
+* subclasses the bare `Input` base (NOT the SDK `*ExtractionInput`   family, which
+declares `agent_json`), AND * declares no `agent_json` field of its own, AND * rejects
+extra fields (no `allow_unbounded_fields=True` class keyword,   no `extra="allow"` in
+the model config).
+
+In that shape Pydantic silently drops the forwarded `agent_json` at model construction.
+The extract input's `credential_ref` is then `None` and extraction fails with
+`PipelineContractError` ("No credential_ref or inline_credentials on input") — 0 assets
+— while the manifest and the connector code both look correct.
+
+This is orthogonal to P029 (which checks the *manifest*) and P037 (which checks that the
+*code* consumes `agent_json`): all three must be clean.
+
+This is a WARN (not BLOCK): the heuristic reads the generated contract's declared bases,
+fields, and model config; an app that receives `agent_json` through a base the heuristic
+does not recognise could be flagged.  Review before suppressing.
+
+**Remediation:** declare `agent_json` on the extract-input contract in
+`contract/app.pkl` and regenerate, subclass the SDK `ExtractionInput` family (which
+declares it), or set `allow_unbounded_fields=True` on the contract — as the passing
+counterexample connectors in fleet testing do.
 
 ---

--- a/packages/conformance/conformance/programs/areas/prescriptions.prose.md
+++ b/packages/conformance/conformance/programs/areas/prescriptions.prose.md
@@ -388,9 +388,9 @@ drafting.
   — route to residue with the proposed shape; do not mechanically rename the
   class.  Leave `AsyncAtlanClient` usage untouched.
 
-**SDR-readiness rules (P029–P030, DISTR-752)** — all suggest-only, scope=app;
-`classification` is always `"judgment"`.  Both gate on `self_deployed_runtime: true`
-in `atlan.yaml`.
+**SDR-readiness rules (P029/P030, P037/P038/P039)** — all suggest-only,
+scope=app; `classification` is always `"judgment"`.  All gate on
+`self_deployed_runtime: true` in `atlan.yaml`.
 
 - **P029 SdrManifestMissingAgentJson** (BLOCK) — a `manifest.json` under
   `app/generated/` is missing the `agent_json` key in `dag.extract.inputs.args`.
@@ -414,3 +414,54 @@ in `atlan.yaml`.
   structure first — some apps delegate upload to a base class or a helper method
   that the scanner cannot see; if that is the case, note it in residue rather
   than adding a redundant call.  Route to residue for human confirmation.
+
+- **P037 SdrAgentJsonNotConsumed** (WARN) — the app performs custom credential
+  resolution (a bare `CredentialRef(credential_guid=...)` construction or a
+  `resolve_credential_raw(...)` call) but never routes through an agent-aware
+  resolver entry point (`CredentialRef.resolve(input)` /
+  `CredentialRef.from_workflow_args(workflow_args)`, or a `CredentialRef` built
+  with an `agent_spec`/`agent_json` kwarg).  Resolving strictly by
+  `credential_guid` ignores the forwarded `agent_json`, so in agent (SDR) mode
+  the credential never resolves and the workflow writes zero assets while
+  reporting "success".  The finding is app-level, anchored at
+  the first custom-resolution call site.  Apps that lean on the SDK's transparent
+  resolution (no `CredentialRef` / `resolve_credential_raw`) are not gated in.
+  Draft a proposal that
+  routes resolution through `CredentialRef.resolve(input)` /
+  `CredentialRef.from_workflow_args(workflow_args)`, keeping the direct
+  `credential_guid` path only as a fallback; route to residue for confirmation.
+
+- **P038 SdrArtifactMisrooted** (WARN) — the object-store output path/prefix
+  (`artifacts/apps/<identity>/...`) is rooted from the *workflow-input*
+  `application_name` field (read as `input_data.get("application_name", ...)`,
+  `input_data["application_name"]`, or `input.application_name`) instead of the
+  SDK app identity (`APPLICATION_NAME` / `self._app_name`).  That field's contract
+  default is `""` and AE forwards only manifest-declared args, so it stays empty
+  and artifacts land under `artifacts/apps//workflows/...` (empty app segment);
+  `self.upload()` succeeds but the publish app finds 0 assets (complementary to
+  P030 — the upload IS called, but mis-rooted).  The
+  finding is anchored at the offending f-string.  The heuristic is deliberately
+  narrow (it keys on the `application_name` input field feeding an
+  `artifacts/apps` literal); it does not catch every mis-rooting — an app that
+  forwards an empty `output_prefix` input field without an `artifacts/apps`
+  literal is statically indistinguishable from a correct app and is left to
+  runtime/e2e detection.  Draft a proposal that roots the prefix from
+  `APPLICATION_NAME` / `self._app_name` (or `WORKFLOW_OUTPUT_PATH_TEMPLATE`);
+  route to residue for confirmation.
+
+- **P039 SdrAgentJsonDroppedByInputContract** (WARN) — the generated manifest
+  declares `{{agent-json}}` at the extract-args top level (P029 passes), but the
+  generated extract-input contract model (`AppInputContract` in a generated
+  `_input.py`) subclasses the bare `Input` base, declares no `agent_json` field,
+  and rejects extra fields — so Pydantic silently drops the forwarded
+  `agent_json` at model construction.  The extract input's `credential_ref` is
+  then `None` and extraction fails with `PipelineContractError` / 0 assets even
+  though the manifest and connector code look correct.  This is
+  orthogonal to P029 (manifest side) and P037 (code resolves by guid only) — all
+  three must be clean.  The finding is anchored at the `AppInputContract` class.
+  Contracts that subclass the SDK `*ExtractionInput` family (which declares
+  `agent_json`) or set `allow_unbounded_fields=True` / `extra="allow"` are exempt.
+  The remedy is a
+  Pkl-layer change: declare `agent_json` on the extract-input contract in
+  `contract/app.pkl` (or set `allow_unbounded_fields=True`) and regenerate; do
+  not hand-edit the generated `_input.py`.  Route to residue for confirmation.

--- a/packages/conformance/conformance/suite/checks/sdr.py
+++ b/packages/conformance/conformance/suite/checks/sdr.py
@@ -1,7 +1,7 @@
-"""P-series SDR-readiness checks (P029–P030, DISTR-752).
+"""P-series SDR-readiness checks (P029, P030, P037, P038, P039).
 
 Cross-artifact checks that gate on ``self_deployed_runtime: true`` in
-``atlan.yaml`` and verify two structural invariants:
+``atlan.yaml`` and verify five structural invariants:
 
 * ``P029`` — an agent extraction manifest under ``app/generated/`` must surface
   ``agent_json`` AND ``extraction_method`` at the TOP LEVEL of
@@ -21,10 +21,41 @@ Cross-artifact checks that gate on ``self_deployed_runtime: true`` in
   ``dag.publish`` node, and has nowhere for ``self.upload()`` to hand
   extracted assets off to — P030 is skipped for those apps.
 
+* ``P037`` — an SDR app that resolves source credentials with a *custom*,
+  GUID-only path (a hand-rolled vault read + ``resolve_credential_raw`` or a
+  bare ``CredentialRef(credential_guid=...)`` construction) but NEVER routes
+  through an agent-aware resolver entry point (``CredentialRef.resolve`` /
+  ``CredentialRef.from_workflow_args`` / an ``agent_spec``-carrying ref).  Its
+  manifest can be P029-clean and ``agent_json`` forwarded, yet the connector
+  code ignores it and resolves strictly by ``credential_guid`` — so in agent
+  (SDR) mode credentials never resolve and it writes zero assets
+  (observed for a table-format connector in fleet testing).  WARN.
+
+* ``P038`` — an SDR app that roots its object-store output path/prefix
+  (``artifacts/apps/<identity>/...``) from a *workflow-input* ``application_name``
+  field (contract default ``""``) instead of the SDK app identity
+  (``APPLICATION_NAME`` / ``self._app_name``).  Because AE forwards only
+  manifest-declared args, that field stays empty and artifacts land under a
+  mis-rooted path (``artifacts/apps//workflows/...`` — empty app segment), so
+  ``self.upload()`` succeeds but 0 assets publish (observed for a document-store
+  connector in fleet testing).
+  P030 passes these apps (upload IS called); P038 catches the wrong-root case.
+  WARN.
+
+* ``P039`` — an SDR app whose generated manifest declares ``{{agent-json}}`` at
+  the extract-args top level (so P029 passes), but whose generated extract-input
+  contract model (``AppInputContract`` in a generated ``_input.py``) subclasses
+  the bare ``Input`` base, declares no ``agent_json`` field, and rejects extra
+  fields — so Pydantic silently DROPS the forwarded ``agent_json`` and the
+  extract input resolves no credentials (``PipelineContractError`` / 0 assets;
+  observed for a BI connector in fleet testing).  Contracts that subclass the SDK
+  ``*ExtractionInput`` family (which declares ``agent_json``) or set
+  ``allow_unbounded_fields=True`` / ``extra="allow"`` are exempt.  WARN.
+
 P026–P028 are reserved by a concurrent PR (GetattrOnTypedContractField,
 AppStateAsCrossTaskChannel, ManualQualifiedNameFString — PR #2417).
 
-Both are APP-scoped: the SDK itself never declares ``self_deployed_runtime``
+All are APP-scoped: the SDK itself never declares ``self_deployed_runtime``
 and is always skipped.
 
 ``scan_path`` is a no-op — SDR checks are cross-artifact and require the full
@@ -33,6 +64,7 @@ path list plus the repo root.  The runner must call ``scan_all``.
 
 from __future__ import annotations
 
+import ast
 import json
 import re
 import sys
@@ -44,6 +76,9 @@ from conformance.suite.schema.findings import Finding
 SERIES = "P"
 RULE_P029 = "P029"
 RULE_P030 = "P030"
+RULE_P037 = "P037"
+RULE_P038 = "P038"
+RULE_P039 = "P039"
 
 _SDR_FLAG_RE = re.compile(
     r"^self_deployed_runtime:\s*(true|false)\b",
@@ -255,21 +290,472 @@ def _check_p030(paths: list[Path]) -> list[Finding]:
     ]
 
 
+# ── P037: agent_json ignored by a custom GUID-only credential path ──────────
+
+#: SDK entry points that consume the full workflow input/args and therefore pick
+#: up ``agent_json`` (the agent-mode credential-routing spec).  ``resolve`` is
+#: additionally gated on the ``CredentialRef`` receiver; the others are
+#: distinctive enough on the method name alone.
+_AGENT_AWARE_RESOLVER_ATTRS = frozenset(
+    {"from_workflow_args", "resolve_agent_credential", "resolve_agent_json"}
+)
+
+
+def _classify_credential_calls(tree: ast.AST) -> tuple[tuple[int, str] | None, bool]:
+    """Scan one module AST for the two P037 signals.
+
+    Returns ``(custom_site, agent_aware)`` where:
+
+    * ``custom_site`` is the ``(lineno, callee)`` of the first *custom* credential
+      resolution call — a bare ``CredentialRef(...)`` construction or a
+      ``resolve_credential_raw(...)`` call — or ``None`` if there is none.
+    * ``agent_aware`` is True if any *agent-aware* resolver entry point is called
+      (``CredentialRef.resolve`` / ``CredentialRef.from_workflow_args`` /
+      ``resolve_agent_credential`` / ``resolve_agent_json``) or a
+      ``CredentialRef(...)`` is built with an ``agent_spec``/``agent_json`` kwarg.
+
+    Using the AST (not text) keeps docstring/comment mentions of
+    ``CredentialRef(...)`` from registering as real resolution calls.
+    """
+    custom_site: tuple[int, str] | None = None
+    agent_aware = False
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        # Direct constructor: CredentialRef(...)
+        if isinstance(func, ast.Name) and func.id == "CredentialRef":
+            if custom_site is None:
+                custom_site = (node.lineno, "CredentialRef(...)")
+            if any(kw.arg in ("agent_spec", "agent_json") for kw in node.keywords):
+                agent_aware = True
+        elif isinstance(func, ast.Attribute):
+            attr = func.attr
+            if attr == "resolve_credential_raw":
+                if custom_site is None:
+                    custom_site = (node.lineno, "resolve_credential_raw(...)")
+            elif attr in _AGENT_AWARE_RESOLVER_ATTRS:
+                agent_aware = True
+            elif (
+                attr == "resolve"
+                and isinstance(func.value, ast.Name)
+                and func.value.id == "CredentialRef"
+            ):
+                agent_aware = True
+    return custom_site, agent_aware
+
+
+def _check_p037(paths: list[Path], root: Path) -> list[Finding]:
+    """P037: custom GUID-only credential resolution that bypasses agent routing.
+
+    App-level (a single finding).  Fires when the app performs custom credential
+    resolution somewhere (a bare ``CredentialRef(...)`` construction or a
+    ``resolve_credential_raw`` call) but NEVER routes through an agent-aware
+    resolver entry point.  Such an app resolves strictly by ``credential_guid``,
+    so ``agent_json`` is ignored and agent-mediated credentials never resolve in
+    SDR mode — a silent zero-asset failure.
+
+    Apps that rely on the SDK's transparent resolution (they build no
+    ``CredentialRef`` and call no ``resolve_credential_raw``) are not gated in.
+    Apps that DO call an agent-aware resolver (via ``CredentialRef.resolve`` or
+    ``CredentialRef.from_workflow_args``) are exempt even when they also keep a
+    GUID fallback.
+    """
+    first_custom: tuple[str, int, str] | None = None
+    agent_aware_anywhere = False
+    for path in paths:
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except (OSError, SyntaxError, ValueError):
+            continue
+        custom_site, agent_aware = _classify_credential_calls(tree)
+        if agent_aware:
+            agent_aware_anywhere = True
+        if custom_site is not None and first_custom is None:
+            try:
+                rel = str(path.relative_to(root))
+            except ValueError:
+                rel = str(path)
+            first_custom = (rel, custom_site[0], custom_site[1])
+
+    if first_custom is None or agent_aware_anywhere:
+        return []
+
+    rel, line, callee = first_custom
+    return [
+        Finding(
+            rule_id=RULE_P037,
+            file=rel,
+            line=line,
+            column=1,
+            message=(
+                f"{rel}:{line}: credentials are resolved via a custom GUID-only path "
+                f"({callee}) and no agent-aware resolver "
+                "(CredentialRef.resolve / CredentialRef.from_workflow_args) is called "
+                "anywhere in the app. The manifest may forward agent_json, but code "
+                "that resolves strictly by credential_guid ignores it, so in SDR "
+                "(agent) mode credentials never resolve and the workflow writes zero "
+                "assets while reporting 'success'. Route "
+                "credential resolution through CredentialRef.resolve(input) or "
+                "CredentialRef.from_workflow_args(workflow_args) — which consume "
+                "agent_json and pick the agent vs. GUID route — keeping the direct "
+                "credential_guid path only as a fallback."
+            ),
+        )
+    ]
+
+
+# ── P038: object-store prefix mis-rooted from an empty-defaulting input ──────
+
+#: Object-store root convention. An ``artifacts/apps/{identity}/...`` prefix
+#: whose ``{identity}`` segment comes from a workflow-input ``application_name``
+#: field (contract default ``""``) mis-roots to ``artifacts/apps//...``.
+_OBJECT_STORE_ROOT_LITERAL = "artifacts/apps"
+
+#: The workflow-input field whose empty default causes the mis-rooting.
+_APP_IDENTITY_INPUT_FIELD = "application_name"
+
+
+def _is_app_name_input_read(node: ast.AST) -> bool:
+    """Whether *node* reads the ``application_name`` field off a workflow input.
+
+    Matches the three shapes an app uses to pull the field off ``input`` /
+    ``input_data`` / ``workflow_args``:
+
+    * ``<obj>.get("application_name", ...)``  (dict access with a default)
+    * ``<obj>["application_name"]``           (dict subscript)
+    * ``<name>.application_name``             (attribute access)
+
+    The SDK app-identity constant is the bare ``Name`` ``APPLICATION_NAME`` — it
+    is never spelled ``.application_name`` — so this never matches the correct
+    rooting source.
+    """
+    if (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "get"
+        and node.args
+        and isinstance(node.args[0], ast.Constant)
+        and node.args[0].value == _APP_IDENTITY_INPUT_FIELD
+    ):
+        return True
+    if isinstance(node, ast.Subscript):
+        sl = node.slice
+        if isinstance(sl, ast.Constant) and sl.value == _APP_IDENTITY_INPUT_FIELD:
+            return True
+    return bool(
+        isinstance(node, ast.Attribute)
+        and node.attr == _APP_IDENTITY_INPUT_FIELD
+        and isinstance(node.value, ast.Name)
+    )
+
+
+def _joinedstr_literal(js: ast.JoinedStr) -> str:
+    """The concatenation of the constant (literal) segments of an f-string."""
+    return "".join(
+        v.value
+        for v in js.values
+        if isinstance(v, ast.Constant) and isinstance(v.value, str)
+    )
+
+
+def _check_p038(paths: list[Path], root: Path) -> list[Finding]:
+    """P038: object-store prefix rooted from an empty-defaulting input field.
+
+    Flags an object-store path f-string (its literal segments contain
+    ``artifacts/apps``) whose interpolated app-identity segment is derived from a
+    workflow-input ``application_name`` read — directly, or via a local variable
+    bound to one within the same function — rather than the SDK ``APPLICATION_NAME``
+    constant / ``self._app_name``.
+
+    Scope is per-function so taint does not leak between unrelated defs. Findings
+    are de-duplicated by ``(file, line)``.
+    """
+    findings: list[Finding] = []
+    seen: set[tuple[str, int]] = set()
+    for path in paths:
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except (OSError, SyntaxError, ValueError):
+            continue
+        try:
+            rel = str(path.relative_to(root))
+        except ValueError:
+            rel = str(path)
+
+        for fn in [
+            n
+            for n in ast.walk(tree)
+            if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+        ]:
+            # Locals bound to an application_name input read.
+            tainted: set[str] = set()
+            for n in ast.walk(fn):
+                if (
+                    isinstance(n, ast.Assign)
+                    and len(n.targets) == 1
+                    and isinstance(n.targets[0], ast.Name)
+                    and _is_app_name_input_read(n.value)
+                ):
+                    tainted.add(n.targets[0].id)
+
+            for js in [n for n in ast.walk(fn) if isinstance(n, ast.JoinedStr)]:
+                if _OBJECT_STORE_ROOT_LITERAL not in _joinedstr_literal(js):
+                    continue
+                for fv in js.values:
+                    if not isinstance(fv, ast.FormattedValue):
+                        continue
+                    val = fv.value
+                    if (
+                        isinstance(val, ast.Name) and val.id in tainted
+                    ) or _is_app_name_input_read(val):
+                        key = (rel, js.lineno)
+                        if key in seen:
+                            continue
+                        seen.add(key)
+                        findings.append(
+                            Finding(
+                                rule_id=RULE_P038,
+                                file=rel,
+                                line=js.lineno,
+                                column=1,
+                                message=(
+                                    f"{rel}:{js.lineno}: object-store output path "
+                                    "('artifacts/apps/...') is rooted from the "
+                                    "workflow-input 'application_name' field, whose "
+                                    "contract default is '' — AE forwards only "
+                                    "manifest-declared args, so it stays empty and "
+                                    "artifacts land under a mis-rooted path "
+                                    "('artifacts/apps//workflows/...', empty app "
+                                    "segment). self.upload() then succeeds but 0 "
+                                    "assets publish. Root the "
+                                    "prefix from the SDK app identity — APPLICATION_NAME "
+                                    "/ self._app_name (or WORKFLOW_OUTPUT_PATH_TEMPLATE) "
+                                    "— not from an empty-defaulting workflow arg."
+                                ),
+                            )
+                        )
+    return findings
+
+
+# ── P039: agent_json silently dropped by the generated input contract ───────
+
+#: The class name the Pkl generator emits for the extract-input contract model.
+_GENERATED_INPUT_CLASS = "AppInputContract"
+
+
+def _manifest_carries_agent_routing(manifest_path: Path) -> bool:
+    """Whether a manifest's extract args carry the ``{{agent-json}}`` placeholder."""
+    try:
+        data = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return False
+    dag = data.get("dag", {})
+    args = dag.get("extract", {}).get("inputs", {}).get("args", {})
+    return isinstance(args, dict) and _carries_agent_routing(args)
+
+
+def _class_base_names(node: ast.ClassDef) -> list[str]:
+    """Simple names of a class's bases (``Name.id`` / ``Attribute.attr``)."""
+    names: list[str] = []
+    for base in node.bases:
+        if isinstance(base, ast.Name):
+            names.append(base.id)
+        elif isinstance(base, ast.Attribute):
+            names.append(base.attr)
+    return names
+
+
+def _class_allows_extra_fields(node: ast.ClassDef) -> bool:
+    """Whether the model opts out of Pydantic payload-safety (accepts extra keys).
+
+    Recognises the three shapes an app uses: the ``allow_unbounded_fields=True``
+    class keyword (the SDK's opt-out), a Pydantic ``extra="allow"`` class keyword,
+    a ``model_config`` set to ``ConfigDict(extra="allow")`` / ``{"extra": "allow"}``,
+    or a nested ``class Config: extra = "allow"``.
+    """
+    for kw in node.keywords:
+        if (
+            kw.arg == "allow_unbounded_fields"
+            and isinstance(kw.value, ast.Constant)
+            and kw.value.value is True
+        ):
+            return True
+        if (
+            kw.arg == "extra"
+            and isinstance(kw.value, ast.Constant)
+            and kw.value.value == "allow"
+        ):
+            return True
+    for stmt in node.body:
+        if isinstance(stmt, (ast.Assign, ast.AnnAssign)):
+            target = stmt.targets[0] if isinstance(stmt, ast.Assign) else stmt.target
+            if (
+                isinstance(target, ast.Name)
+                and target.id == "model_config"
+                and stmt.value is not None
+            ):
+                value = stmt.value
+                if isinstance(value, ast.Call):
+                    for kw in value.keywords:
+                        if (
+                            kw.arg == "extra"
+                            and isinstance(kw.value, ast.Constant)
+                            and kw.value.value == "allow"
+                        ):
+                            return True
+                if isinstance(value, ast.Dict):
+                    for key, val in zip(value.keys, value.values):
+                        if (
+                            isinstance(key, ast.Constant)
+                            and key.value == "extra"
+                            and isinstance(val, ast.Constant)
+                            and val.value == "allow"
+                        ):
+                            return True
+        if isinstance(stmt, ast.ClassDef) and stmt.name == "Config":
+            for inner in stmt.body:
+                if isinstance(inner, ast.Assign):
+                    for t in inner.targets:
+                        if (
+                            isinstance(t, ast.Name)
+                            and t.id == "extra"
+                            and isinstance(inner.value, ast.Constant)
+                            and inner.value.value == "allow"
+                        ):
+                            return True
+    return False
+
+
+def _class_declares_agent_json(node: ast.ClassDef) -> bool:
+    """Whether the class body declares an ``agent_json`` field."""
+    for stmt in node.body:
+        if (
+            isinstance(stmt, ast.AnnAssign)
+            and isinstance(stmt.target, ast.Name)
+            and stmt.target.id == "agent_json"
+        ):
+            return True
+        if isinstance(stmt, ast.Assign):
+            for t in stmt.targets:
+                if isinstance(t, ast.Name) and t.id == "agent_json":
+                    return True
+    return False
+
+
+def _generated_input_contract_findings(path: Path, rel: str) -> list[tuple[int, bool]]:
+    """Analyse the ``AppInputContract`` class in a generated ``_input.py``.
+
+    Returns ``(lineno, unsafe)`` for each ``AppInputContract`` definition, where
+    ``unsafe`` is True iff the model subclasses the bare ``Input`` base (not the
+    ``*ExtractionInput`` family, which declares ``agent_json``), declares no
+    ``agent_json`` field of its own, and does not accept extra fields — the shape
+    that silently drops a forwarded ``agent_json``.
+    """
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+    except (OSError, SyntaxError, ValueError):
+        return []
+    results: list[tuple[int, bool]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ClassDef) or node.name != _GENERATED_INPUT_CLASS:
+            continue
+        bases = _class_base_names(node)
+        # The *ExtractionInput family (SDK templates) declares agent_json → safe.
+        in_extraction_family = any(b.endswith("ExtractionInput") for b in bases)
+        extends_bare_input = "Input" in bases
+        safe = (
+            in_extraction_family
+            or _class_declares_agent_json(node)
+            or _class_allows_extra_fields(node)
+        )
+        unsafe = extends_bare_input and not safe
+        results.append((node.lineno, unsafe))
+    return results
+
+
+def _check_p039(manifests: list[Path], root: Path) -> list[Finding]:
+    """P039: agent_json dropped by a closed generated extract-input contract.
+
+    Precondition: at least one generated manifest declares agent routing (the
+    ``{{agent-json}}`` placeholder in the extract args) — i.e. it is P029-clean on
+    the manifest side. Fires when the generated extract-input contract model
+    (``AppInputContract`` in a generated ``_input.py``) subclasses the bare
+    ``Input`` base, declares no ``agent_json`` field, and rejects extra fields:
+    Pydantic then silently drops the forwarded ``agent_json`` and the extract
+    input resolves no credentials (``PipelineContractError`` / 0 assets;
+    observed for a BI connector in fleet testing).
+
+    Apps whose contract subclasses the SDK ``*ExtractionInput`` family (which
+    declares ``agent_json``) or that set ``allow_unbounded_fields=True`` /
+    ``extra="allow"`` are not flagged.
+    """
+    agent_manifests = [m for m in manifests if _manifest_carries_agent_routing(m)]
+    if not agent_manifests:
+        return []
+
+    findings: list[Finding] = []
+    inspected: set[Path] = set()
+    for manifest_path in agent_manifests:
+        sibling = manifest_path.parent / "_input.py"
+        candidates = (
+            [sibling]
+            if sibling.is_file()
+            else sorted((root / "app").rglob("_input.py"))
+        )
+        for input_py in candidates:
+            if input_py in inspected:
+                continue
+            inspected.add(input_py)
+            try:
+                rel = str(input_py.relative_to(root))
+            except ValueError:
+                rel = str(input_py)
+            for lineno, unsafe in _generated_input_contract_findings(input_py, rel):
+                if not unsafe:
+                    continue
+                findings.append(
+                    Finding(
+                        rule_id=RULE_P039,
+                        file=rel,
+                        line=lineno,
+                        column=1,
+                        message=(
+                            f"{rel}:{lineno}: the generated extract-input contract "
+                            "'AppInputContract' subclasses the bare Input base, "
+                            "declares no agent_json field, and rejects extra fields — "
+                            "so the agent_json the platform forwards in SDR (agent) "
+                            "mode is silently dropped by Pydantic. The extract input's "
+                            "credential_ref is then None and extraction fails with "
+                            "PipelineContractError / 0 assets, even though the manifest "
+                            "declares {{agent-json}}. Declare "
+                            "agent_json on the contract (in contract/app.pkl, "
+                            "regenerated), subclass the SDK ExtractionInput family "
+                            "(which declares it), or set allow_unbounded_fields=True."
+                        ),
+                    )
+                )
+    return findings
+
+
 def scan_path(path: Path, root: Path) -> list[Finding]:  # noqa: ARG001
-    """No-op: P029/P030 require cross-artifact analysis; use scan_all."""
+    """No-op: the SDR checks require cross-artifact analysis; use scan_all."""
     return []
 
 
 def scan_all(paths: list[Path], root: Path) -> list[Finding]:
-    """Check P029 and P030 for the repo at root.
+    """Check the SDR-readiness rules (P029, P030, P037, P038, P039) for the repo.
 
     Parameters
     ----------
     paths:
         Python source files to inspect (as returned by :func:`discover`).
-        These are the files checked by P030 for a ``self.upload(`` call.
+        These are the files checked by P030 for a ``self.upload(`` call, by
+        P037 for the credential-resolution shape, and by P038 for the
+        object-store prefix rooting.
     root:
-        Repo root — used to locate ``atlan.yaml`` and ``app/generated/``.
+        Repo root — used to locate ``atlan.yaml`` and ``app/generated/`` (P039
+        also inspects the generated ``_input.py`` contract models).
     """
     if not _is_sdr_app(root):
         return []
@@ -280,14 +766,19 @@ def scan_all(paths: list[Path], root: Path) -> list[Finding]:
     findings.extend(_check_p029(manifests, root))
     if _app_has_publish_stage(manifests):
         findings.extend(_check_p030(paths))
+    findings.extend(_check_p037(paths, root))
+    findings.extend(_check_p038(paths, root))
+    findings.extend(_check_p039(manifests, root))
     return findings
 
 
 main = make_cli_main(
     scan_all=scan_all,
     description=(
-        "P029/P030: SDR-readiness checks — manifest agent_json slot (P029) "
-        "and upload call presence (P030)."
+        "SDR-readiness checks — manifest agent_json slot (P029), "
+        "upload call presence (P030), agent-aware credential resolution (P037), "
+        "object-store prefix rooting (P038), and agent_json input-contract "
+        "consumption (P039)."
     ),
 )
 

--- a/packages/conformance/conformance/suite/rules/sdr.py
+++ b/packages/conformance/conformance/suite/rules/sdr.py
@@ -1,7 +1,7 @@
-"""SDR-readiness rule definitions (P029–P030, DISTR-752).
+"""SDR-readiness rule definitions (P029, P030, P037, P038, P039).
 
 Apps that declare ``self_deployed_runtime: true`` in ``atlan.yaml`` must satisfy
-two structural invariants before they can be considered SDR-ready:
+five structural invariants before they can be considered SDR-ready:
 
 * ``P029`` — every ``manifest.json`` under ``app/generated/`` must include an
   ``agent_json`` key inside ``dag.extract.inputs.args``.  Missing this field
@@ -19,7 +19,32 @@ two structural invariants before they can be considered SDR-ready:
   ``contract/app.pkl``, reflected as no ``dag.publish`` node in the generated
   manifest) — there is nowhere for such an app to hand extracted assets off to.
 
-Both rules are APP-scoped (the SDK itself does not declare ``self_deployed_runtime``
+* ``P037`` — an app that resolves source credentials with a custom, GUID-only
+  path (a hand-rolled vault read + ``resolve_credential_raw`` or a bare
+  ``CredentialRef(credential_guid=...)`` construction) but never routes through
+  an agent-aware resolver (``CredentialRef.resolve`` /
+  ``CredentialRef.from_workflow_args``).  The manifest can be P029-clean and
+  ``agent_json`` forwarded, but code that resolves strictly by
+  ``credential_guid`` ignores it, so agent-mode credentials never resolve and
+  the app writes zero assets (observed for a table-format connector in fleet
+  testing).
+
+* ``P038`` — an app that roots its object-store output prefix
+  (``artifacts/apps/<identity>/...``) from a workflow-input ``application_name``
+  field (contract default ``""``) instead of the SDK app identity.  AE forwards
+  only manifest-declared args, so the field stays empty and artifacts land under
+  a mis-rooted path (empty app segment); ``self.upload()`` succeeds but 0 assets
+  publish (observed for a document-store connector in fleet testing).
+
+* ``P039`` — an app whose generated manifest declares ``{{agent-json}}`` (so P029
+  passes) but whose generated extract-input contract (``AppInputContract`` in a
+  generated ``_input.py``) subclasses the bare ``Input`` base, declares no
+  ``agent_json`` field, and rejects extra fields — so Pydantic silently drops the
+  forwarded ``agent_json`` and credentials never resolve (``PipelineContractError``
+  / 0 assets; observed for a BI connector in fleet testing).  Contracts that
+  subclass the SDK ``*ExtractionInput`` family or allow extra fields are exempt.
+
+All rules are APP-scoped (the SDK itself does not declare ``self_deployed_runtime``
 and is therefore always skipped) and gate on ``self_deployed_runtime: true``
 being present in ``atlan.yaml``.
 """
@@ -152,6 +177,207 @@ RULES: tuple[RuleDefinition, ...] = (
         help_uri=(
             "https://github.com/atlanhq/application-sdk/blob/main/"
             "packages/conformance/conformance/docs/rules/prescriptions.md#p030"
+        ),
+    ),
+    RuleDefinition(
+        id="P037",
+        scope=RuleScope.APP,
+        name="SdrAgentJsonNotConsumed",
+        tier=EnforcementTier.WARN,
+        mechanism=RuleMechanism.STATIC,
+        category="sdr-readiness",
+        autofixable=False,
+        orthogonal_gate="tests",
+        since="0.16.0",
+        rationale=(
+            "In SDR (agent) mode the platform forwards agent_json on the workflow "
+            "input; the SDK's agent-aware resolvers (CredentialRef.resolve / "
+            "CredentialRef.from_workflow_args) consume it to route the credential "
+            "fetch through the customer-side agent. An app that instead resolves "
+            "credentials with a custom, GUID-only path — a hand-rolled vault read "
+            "plus resolve_credential_raw, or a bare CredentialRef(credential_guid=...) "
+            "— ignores agent_json entirely. Its manifest can be P029-clean, but in "
+            "agent mode the credential never resolves and the workflow writes zero "
+            "assets while reporting 'success' (observed for a table-format connector "
+            "in fleet testing)."
+        ),
+        short_description=(
+            "SDR app resolves credentials by credential_guid only and never routes "
+            "through an agent-aware resolver — agent_json is ignored"
+        ),
+        full_description=(
+            "For apps declaring ``self_deployed_runtime: true`` in ``atlan.yaml``,\n"
+            "credential resolution must be able to consume ``agent_json`` — the\n"
+            "agent-mode routing spec the platform forwards on the workflow input.\n"
+            "\n"
+            "This rule fires when an app performs *custom* credential resolution —\n"
+            "a bare ``CredentialRef(credential_guid=...)`` construction or a\n"
+            "``resolve_credential_raw(...)`` call — but NEVER routes through an\n"
+            "agent-aware resolver entry point anywhere in its source:\n"
+            "\n"
+            "* ``CredentialRef.resolve(input)`` — reads ``input.agent_json`` and\n"
+            "  picks the agent vs. direct-GUID route.\n"
+            "* ``CredentialRef.from_workflow_args(workflow_args)`` — the same,\n"
+            "  reading ``agent_json`` off the args payload.\n"
+            "\n"
+            "An app that resolves strictly by ``credential_guid`` (a custom local\n"
+            "vault read that only ever builds ``CredentialRef(name=guid,\n"
+            "credential_guid=guid)``) ignores ``agent_json``, so in agent mode the\n"
+            "credential never resolves and zero assets are written — a silent\n"
+            "failure invisible to status-only pipelines.\n"
+            "\n"
+            "Apps that lean on the SDK's transparent resolution (they build no\n"
+            "``CredentialRef`` and call no ``resolve_credential_raw``) are not gated\n"
+            "in and never flagged.\n"
+            "\n"
+            "This is a WARN (not BLOCK): the static heuristic recognises the two\n"
+            "sanctioned resolver entry points and a direct ``agent_spec``-carrying\n"
+            "ref, but an app could resolve ``agent_json`` through a bespoke helper\n"
+            "the heuristic does not know about.  Review before suppressing.\n"
+            "\n"
+            "**Remediation:** route credential resolution through\n"
+            "``CredentialRef.resolve(input)`` or\n"
+            "``CredentialRef.from_workflow_args(workflow_args)`` (both consume\n"
+            "``agent_json`` and pick the correct route), keeping the direct\n"
+            "``credential_guid`` path only as a fallback after the agent-aware call.\n"
+        ),
+        help_uri=(
+            "https://github.com/atlanhq/application-sdk/blob/main/"
+            "packages/conformance/conformance/docs/rules/prescriptions.md#p037"
+        ),
+    ),
+    RuleDefinition(
+        id="P038",
+        scope=RuleScope.APP,
+        name="SdrArtifactMisrooted",
+        tier=EnforcementTier.WARN,
+        mechanism=RuleMechanism.STATIC,
+        category="sdr-readiness",
+        autofixable=False,
+        orthogonal_gate="tests",
+        since="0.16.0",
+        rationale=(
+            "The object-store output prefix must be rooted from the SDK app identity "
+            "(APPLICATION_NAME / self._app_name), which the SDK's own "
+            "WORKFLOW_OUTPUT_PATH_TEMPLATE does correctly. An app that instead roots "
+            "'artifacts/apps/<identity>/...' from the workflow-input application_name "
+            "field mis-roots: that field's contract default is '' and AE forwards "
+            "only manifest-declared args, so it stays empty and artifacts land under "
+            "'artifacts/apps//workflows/...' (empty app segment). self.upload() then "
+            "succeeds but 0 assets publish — P030 passes the app (upload IS called), "
+            "so this distinct rule catches the wrong-root case (observed for a "
+            "document-store connector in fleet testing)."
+        ),
+        short_description=(
+            "SDR object-store prefix rooted from the empty-defaulting input "
+            "application_name field instead of APPLICATION_NAME"
+        ),
+        full_description=(
+            "For apps declaring ``self_deployed_runtime: true`` in ``atlan.yaml``,\n"
+            "the object-store output path/prefix\n"
+            "(``artifacts/apps/<identity>/workflows/...``) must be rooted from the\n"
+            "SDK app identity — the ``APPLICATION_NAME`` constant, ``self._app_name``,\n"
+            "or the SDK's ``WORKFLOW_OUTPUT_PATH_TEMPLATE`` (which fills\n"
+            "``application_name`` from the app identity).\n"
+            "\n"
+            "This rule fires when the app instead builds that path from a\n"
+            "*workflow-input* ``application_name`` field — read as\n"
+            '``input_data.get("application_name", ...)``,\n'
+            '``input_data["application_name"]``, or ``input.application_name`` — and\n'
+            "interpolates it (directly or via a local variable) into an f-string\n"
+            "whose literal contains ``artifacts/apps``.  The contract default of\n"
+            'that field is ``""`` and AE forwards only manifest-declared args, so\n'
+            "the value stays empty; the artifacts then land under\n"
+            "``artifacts/apps//workflows/...`` (note the empty app segment).\n"
+            "``self.upload()`` reports success but the publish app finds 0 assets at\n"
+            "the expected prefix.\n"
+            "\n"
+            "This is complementary to P030: P030 checks that ``self.upload()`` is\n"
+            "*called*; P038 checks that what it uploads is rooted correctly.  An app\n"
+            "can pass P030 and still fail P038.\n"
+            "\n"
+            "This is a WARN (not BLOCK): the failure is a silent zero-asset publish,\n"
+            "not a hard crash, and the heuristic is deliberately narrow (it keys on\n"
+            "the ``application_name`` input field feeding an ``artifacts/apps``\n"
+            "literal).  It does NOT catch every mis-rooting — an app that forwards an\n"
+            "empty ``output_prefix`` input field without an ``artifacts/apps`` literal\n"
+            "is indistinguishable from a correct app statically and is left to\n"
+            "runtime/e2e detection.\n"
+            "\n"
+            "**Remediation:** root the object-store prefix from ``APPLICATION_NAME`` /\n"
+            "``self._app_name`` (or use ``WORKFLOW_OUTPUT_PATH_TEMPLATE.format(\n"
+            "application_name=APPLICATION_NAME, ...)``), or default the contract field\n"
+            "to the app name; never derive it from an empty-defaulting workflow arg.\n"
+        ),
+        help_uri=(
+            "https://github.com/atlanhq/application-sdk/blob/main/"
+            "packages/conformance/conformance/docs/rules/prescriptions.md#p038"
+        ),
+    ),
+    RuleDefinition(
+        id="P039",
+        scope=RuleScope.APP,
+        name="SdrAgentJsonDroppedByInputContract",
+        tier=EnforcementTier.WARN,
+        mechanism=RuleMechanism.STATIC,
+        category="sdr-readiness",
+        autofixable=False,
+        orthogonal_gate="tests",
+        since="0.16.0",
+        rationale=(
+            "In SDR (agent) mode the platform forwards agent_json on the extract "
+            "input. A generated extract-input contract that subclasses the bare Input "
+            "base, declares no agent_json field, and rejects extra fields makes "
+            "Pydantic silently drop that forwarded agent_json — the extract input's "
+            "credential_ref is then None and extraction fails with PipelineContractError "
+            "and 0 assets, even though the manifest is P029-clean (declares "
+            "{{agent-json}}). This is distinct from P029 (manifest side) and P037 "
+            "(code resolves by guid only): here the manifest and code are fine but the "
+            "typed contract eats the field (observed for a BI connector in fleet "
+            "testing)."
+        ),
+        short_description=(
+            "SDR generated extract-input contract drops the forwarded agent_json "
+            "(bare Input subclass, no agent_json field, extra fields rejected)"
+        ),
+        full_description=(
+            "For apps declaring ``self_deployed_runtime: true`` in ``atlan.yaml``\n"
+            "whose generated manifest declares agent routing (the ``{{agent-json}}``\n"
+            "placeholder at the extract-args top level — i.e. P029 passes), the\n"
+            "generated extract-input contract model must be able to *receive* the\n"
+            "forwarded ``agent_json``.\n"
+            "\n"
+            "This rule fires when the generated extract-input contract\n"
+            "(``AppInputContract`` in a generated ``_input.py``):\n"
+            "\n"
+            "* subclasses the bare ``Input`` base (NOT the SDK ``*ExtractionInput``\n"
+            "  family, which declares ``agent_json``), AND\n"
+            "* declares no ``agent_json`` field of its own, AND\n"
+            "* rejects extra fields (no ``allow_unbounded_fields=True`` class keyword,\n"
+            '  no ``extra="allow"`` in the model config).\n'
+            "\n"
+            "In that shape Pydantic silently drops the forwarded ``agent_json`` at\n"
+            "model construction. The extract input's ``credential_ref`` is then\n"
+            '``None`` and extraction fails with ``PipelineContractError`` ("No\n'
+            'credential_ref or inline_credentials on input") — 0 assets — while the\n'
+            "manifest and the connector code both look correct.\n"
+            "\n"
+            "This is orthogonal to P029 (which checks the *manifest*) and P037 (which\n"
+            "checks that the *code* consumes ``agent_json``): all three must be clean.\n"
+            "\n"
+            "This is a WARN (not BLOCK): the heuristic reads the generated contract's\n"
+            "declared bases, fields, and model config; an app that receives\n"
+            "``agent_json`` through a base the heuristic does not recognise could be\n"
+            "flagged.  Review before suppressing.\n"
+            "\n"
+            "**Remediation:** declare ``agent_json`` on the extract-input contract in\n"
+            "``contract/app.pkl`` and regenerate, subclass the SDK ``ExtractionInput``\n"
+            "family (which declares it), or set ``allow_unbounded_fields=True`` on the\n"
+            "contract — as the passing counterexample connectors in fleet testing do.\n"
+        ),
+        help_uri=(
+            "https://github.com/atlanhq/application-sdk/blob/main/"
+            "packages/conformance/conformance/docs/rules/prescriptions.md#p039"
         ),
     ),
 )

--- a/packages/conformance/conformance/tools/generate_rule_docs.py
+++ b/packages/conformance/conformance/tools/generate_rule_docs.py
@@ -134,7 +134,8 @@ _SERIES_META: list[SeriesMeta] = [
             "`suite.checks.entrypoint` (P017–P018, scans test files too), "
             "`suite.checks.client_seam` (P019), "
             "`suite.checks.determinism` (P020–P024, P031), "
-            "`suite.checks.app_name_alignment` (P025) "
+            "`suite.checks.app_name_alignment` (P025), "
+            "`suite.checks.sdr` (P029/P030, P037/P038/P039) "
             "(all AST-based / cross-artifact)"
         ),
         suppression_example="# conformance: ignore[P001] intentional: generic cleanup payload",

--- a/packages/conformance/tests/test_catalog.py
+++ b/packages/conformance/tests/test_catalog.py
@@ -146,8 +146,8 @@ def test_catalog_app_scoped_rules_are_the_expected_set() -> None:
     # (BLDX-1499).
     # P025: app-name alignment — only apps have an atlan.yaml and .env.example;
     # the SDK has neither, so this check is meaningless there (BLDX-1491).
-    # P029/P030: SDR-readiness — only apps declare self_deployed_runtime; the SDK
-    # itself never does, so these are APP-scoped (DISTR-752).
+    # P029/P030 + P037/P038/P039: SDR-readiness — only apps declare
+    # self_deployed_runtime; the SDK itself never does, so these are APP-scoped.
     # P032–P035: preflight-gate authoring — only apps register @task activities,
     # define Handler.preflight_check, construct PreflightCheck results, and declare
     # the entrypoint Input contracts the gate rebuilds metadata from; the SDK
@@ -249,6 +249,9 @@ def test_catalog_app_scoped_rules_are_the_expected_set() -> None:
         "P033",
         "P034",
         "P035",
+        "P037",
+        "P038",
+        "P039",
         "T002",
         "T003",
         "T004",
@@ -406,6 +409,11 @@ def test_catalog_p_series_present() -> None:
     P036 is HandRolledProcessIsolation — a bare ProcessPoolExecutor /
     multiprocessing child instead of the run_fault_isolated() / run_best_effort()
     seam (CNCT-85).
+    P037 is SdrAgentJsonNotConsumed (credentials resolved by GUID only, agent_json
+    ignored), P038 is SdrArtifactMisrooted (object-store prefix rooted from an
+    empty-defaulting input field), and P039 is SdrAgentJsonDroppedByInputContract
+    (the generated extract-input contract silently drops the forwarded agent_json)
+    — the follow-on SDR-readiness rules.
     A stray or renumbered P-id would slip past a subset check while
     breaking fleet-wide ``# conformance: ignore[Pxxx]`` suppressions.
     """
@@ -448,6 +456,9 @@ def test_catalog_p_series_present() -> None:
         "P034",
         "P035",
         "P036",
+        "P037",
+        "P038",
+        "P039",
     }
     missing = expected - p_ids
     assert not missing, f"Missing P-series rules: {missing}"

--- a/packages/conformance/tests/test_sdr.py
+++ b/packages/conformance/tests/test_sdr.py
@@ -1,4 +1,4 @@
-"""Meta-tests for the P-series SDR-readiness checks (P029–P030, DISTR-752).
+"""Meta-tests for the P-series SDR-readiness checks (P029/P030, P037/P038/P039).
 
 P029 catches the MSSQL regression pattern: an SDR app whose manifest.json is
 missing agent_json in dag.extract.inputs.args.  The SDR worker starts, the
@@ -8,7 +8,24 @@ P030 catches apps that never call self.upload(): the ENABLE_ATLAN_UPLOAD gate
 is structurally unreachable, so assets never land in the Atlan tenant bucket
 even when the flag is true.
 
-Both rules gate on self_deployed_runtime: true in atlan.yaml — non-SDR apps
+P037 catches the custom-GUID-resolution pattern: an app that resolves credentials
+by credential_guid only (custom vault read + resolve_credential_raw, or a bare
+CredentialRef(credential_guid=...)) and never routes through an agent-aware
+resolver (CredentialRef.resolve / CredentialRef.from_workflow_args), so
+agent_json is ignored and agent-mode credentials never resolve.
+
+P038 catches the mis-rooted-prefix pattern: an app that roots its object-store
+output prefix ('artifacts/apps/{...}') from a workflow-input application_name
+field (contract default '') instead of APPLICATION_NAME, so artifacts land under
+a mis-rooted path (empty app segment) and 0 assets publish.
+
+P039 catches the dropped-agent_json pattern: a manifest that declares
+{{agent-json}} (P029 passes) but a generated extract-input contract
+(AppInputContract) that subclasses the bare Input base with no agent_json field
+and no extra-allow, so Pydantic silently drops the forwarded agent_json and
+credentials never resolve.
+
+All rules gate on self_deployed_runtime: true in atlan.yaml — non-SDR apps
 are always skipped.  Tests cover the fire path, the silent path, and the
 non-SDR skip path for each rule.
 """
@@ -552,6 +569,420 @@ def test_p030_multi_ep_silent_when_no_manifest_has_publish(tmp_path: Path) -> No
     )
     findings = _run(tmp_path)
     assert not any(f.rule_id == "P030" for f in findings)
+
+
+# ── P037: agent_json ignored by a custom GUID-only credential path ──────────
+
+# GUID-only resolution: custom ref + resolve_credential_raw, no agent-aware entry.
+_CREDS_GUID_ONLY = (
+    "from application_sdk.credentials.ref import CredentialRef\n"
+    "\n"
+    "async def _resolve(context, guid):\n"
+    "    ref = CredentialRef(name=guid, credential_guid=guid)\n"
+    "    return await context.resolve_credential_raw(ref)\n"
+)
+
+# Agent-aware via CredentialRef.resolve(input) (postgres/alloydb/bigquery shape).
+_CREDS_RESOLVE = (
+    "from application_sdk.credentials.ref import CredentialRef\n"
+    "\n"
+    "def _resolve(input_obj):\n"
+    "    return CredentialRef.resolve(input_obj)\n"
+)
+
+# Agent-aware via from_workflow_args, even with a GUID fallback (mongodb shape).
+_CREDS_FROM_WORKFLOW_ARGS = (
+    "from application_sdk.credentials import CredentialRef\n"
+    "\n"
+    "async def _resolve(context, workflow_args):\n"
+    "    ref = CredentialRef.from_workflow_args(workflow_args)\n"
+    "    return await context.resolve_credential_raw(ref)\n"
+)
+
+# Direct construction WITH an agent_spec kwarg is agent-aware.
+_CREDS_AGENT_SPEC = (
+    "from application_sdk.credentials.ref import CredentialRef\n"
+    "\n"
+    "def _make(agent):\n"
+    "    return CredentialRef(agent_spec=agent)\n"
+)
+
+# No custom credential resolution at all (mysql/mssql — rely on SDK base).
+_NO_CREDS = "class Connector:\n    async def run(self):\n        return None\n"
+
+# A docstring mentioning CredentialRef(...) must NOT register as a real call.
+_CREDS_ONLY_IN_DOCSTRING = (
+    "def helper():\n"
+    '    """The SDK wraps a guid as CredentialRef(credential_guid=guid)."""\n'
+    "    return None\n"
+)
+
+
+def test_p037_rule_metadata() -> None:
+    rule = get_rule("P037")
+    assert rule.name == "SdrAgentJsonNotConsumed"
+    assert rule.tier == EnforcementTier.WARN
+    assert rule.scope == RuleScope.APP
+    assert rule.autofixable is False
+    assert rule.rationale.strip()
+    assert rule.since == "0.16.0"
+    assert rule.category == "sdr-readiness"
+
+
+def test_p037_fires_on_guid_only_resolution(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        {"atlan.yaml": _SDR_ATLAN_YAML, "app/connector.py": _CREDS_GUID_ONLY},
+    )
+    p037 = [f for f in _run(tmp_path) if f.rule_id == "P037"]
+    assert len(p037) == 1
+    assert "credential_guid" in p037[0].message
+    assert p037[0].column == 1
+
+
+def test_p037_silent_when_credential_ref_resolve_used(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        {"atlan.yaml": _SDR_ATLAN_YAML, "app/connector.py": _CREDS_RESOLVE},
+    )
+    assert not any(f.rule_id == "P037" for f in _run(tmp_path))
+
+
+def test_p037_silent_when_from_workflow_args_used(tmp_path: Path) -> None:
+    # mongodb shape: agent-aware factory present alongside a GUID fallback → exempt.
+    _write(
+        tmp_path,
+        {"atlan.yaml": _SDR_ATLAN_YAML, "app/connector.py": _CREDS_FROM_WORKFLOW_ARGS},
+    )
+    assert not any(f.rule_id == "P037" for f in _run(tmp_path))
+
+
+def test_p037_silent_when_agent_spec_construction(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        {"atlan.yaml": _SDR_ATLAN_YAML, "app/connector.py": _CREDS_AGENT_SPEC},
+    )
+    assert not any(f.rule_id == "P037" for f in _run(tmp_path))
+
+
+def test_p037_silent_when_no_custom_resolution(tmp_path: Path) -> None:
+    # No CredentialRef / resolve_credential_raw at all → not gated in.
+    _write(
+        tmp_path,
+        {"atlan.yaml": _SDR_ATLAN_YAML, "app/connector.py": _NO_CREDS},
+    )
+    assert not any(f.rule_id == "P037" for f in _run(tmp_path))
+
+
+def test_p037_ignores_docstring_only_mention(tmp_path: Path) -> None:
+    # A CredentialRef(...) mention inside a docstring is not a real call.
+    _write(
+        tmp_path,
+        {"atlan.yaml": _SDR_ATLAN_YAML, "app/connector.py": _CREDS_ONLY_IN_DOCSTRING},
+    )
+    assert not any(f.rule_id == "P037" for f in _run(tmp_path))
+
+
+def test_p037_agent_aware_in_any_file_exempts(tmp_path: Path) -> None:
+    # GUID-only in one file, agent-aware resolve in another → app-level exempt.
+    _write(
+        tmp_path,
+        {
+            "atlan.yaml": _SDR_ATLAN_YAML,
+            "app/guid.py": _CREDS_GUID_ONLY,
+            "app/resolve.py": _CREDS_RESOLVE,
+        },
+    )
+    assert not any(f.rule_id == "P037" for f in _run(tmp_path))
+
+
+def test_p037_silent_on_non_sdr_app(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        {"atlan.yaml": _NON_SDR_ATLAN_YAML, "app/connector.py": _CREDS_GUID_ONLY},
+    )
+    assert not _run(tmp_path)
+
+
+# ── P038: object-store prefix mis-rooted from an empty-defaulting input ──────
+
+# app_name pulled from the input, then interpolated into an artifacts/apps path.
+_PATH_MISROOTED_VIA_VAR = (
+    "from application_sdk.constants import APPLICATION_NAME\n"
+    "\n"
+    "def _paths(input_data):\n"
+    '    app_name = input_data.get("application_name", APPLICATION_NAME)\n'
+    '    workflow_id = input_data.get("workflow_id", "local")\n'
+    '    return f"artifacts/apps/{app_name}/workflows/{workflow_id}"\n'
+)
+
+# input.application_name interpolated directly into the path f-string.
+_PATH_MISROOTED_DIRECT = (
+    "def _paths(input):\n"
+    '    return f"artifacts/apps/{input.application_name}/workflows/x"\n'
+)
+
+# Correct: rooted from the APPLICATION_NAME constant.
+_PATH_CORRECT_CONST = (
+    "from application_sdk.constants import APPLICATION_NAME\n"
+    "\n"
+    "def _paths():\n"
+    '    return f"artifacts/apps/{APPLICATION_NAME}/workflows/x"\n'
+)
+
+# Correct (iceberg-style): persistent-artifacts/apps/{APPLICATION_NAME} — the
+# literal contains the "artifacts/apps" substring but interpolates the constant,
+# not an input field, so it must NOT fire.
+_PATH_CORRECT_PERSISTENT = (
+    "from application_sdk.constants import APPLICATION_NAME\n"
+    "\n"
+    "def _vault(guid):\n"
+    '    return f"persistent-artifacts/apps/{APPLICATION_NAME}/credentials/{guid}"\n'
+)
+
+# Correct: application_name read from input but used as a DB/connection param,
+# not in an artifacts/apps path → no finding.
+_PATH_APP_NAME_NOT_IN_PATH = (
+    "def _client_params(input_data):\n"
+    '    return {"application_name": input_data.get("application_name", "Atlan")}\n'
+)
+
+
+def test_p038_rule_metadata() -> None:
+    rule = get_rule("P038")
+    assert rule.name == "SdrArtifactMisrooted"
+    assert rule.tier == EnforcementTier.WARN
+    assert rule.scope == RuleScope.APP
+    assert rule.autofixable is False
+    assert rule.rationale.strip()
+    assert rule.since == "0.16.0"
+    assert rule.category == "sdr-readiness"
+
+
+def test_p038_fires_when_prefix_rooted_from_input_var(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        {"atlan.yaml": _SDR_ATLAN_YAML, "app/connector.py": _PATH_MISROOTED_VIA_VAR},
+    )
+    p038 = [f for f in _run(tmp_path) if f.rule_id == "P038"]
+    assert len(p038) == 1
+    assert "application_name" in p038[0].message
+    assert p038[0].column == 1
+
+
+def test_p038_fires_when_prefix_rooted_from_input_directly(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        {"atlan.yaml": _SDR_ATLAN_YAML, "app/connector.py": _PATH_MISROOTED_DIRECT},
+    )
+    assert any(f.rule_id == "P038" for f in _run(tmp_path))
+
+
+def test_p038_silent_when_rooted_from_constant(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        {"atlan.yaml": _SDR_ATLAN_YAML, "app/connector.py": _PATH_CORRECT_CONST},
+    )
+    assert not any(f.rule_id == "P038" for f in _run(tmp_path))
+
+
+def test_p038_silent_on_persistent_artifacts_with_constant(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        {"atlan.yaml": _SDR_ATLAN_YAML, "app/connector.py": _PATH_CORRECT_PERSISTENT},
+    )
+    assert not any(f.rule_id == "P038" for f in _run(tmp_path))
+
+
+def test_p038_silent_when_app_name_not_in_object_store_path(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        {"atlan.yaml": _SDR_ATLAN_YAML, "app/connector.py": _PATH_APP_NAME_NOT_IN_PATH},
+    )
+    assert not any(f.rule_id == "P038" for f in _run(tmp_path))
+
+
+def test_p038_silent_on_non_sdr_app(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        {
+            "atlan.yaml": _NON_SDR_ATLAN_YAML,
+            "app/connector.py": _PATH_MISROOTED_VIA_VAR,
+        },
+    )
+    assert not _run(tmp_path)
+
+
+# ── P039: agent_json dropped by a closed generated input contract ───────────
+
+# Generated extract-input contract on the bare Input base, no agent_json field,
+# no extra-allow → drops the forwarded agent_json (the sigma failing shape).
+_INPUT_BARE_CLOSED = (
+    "from application_sdk.contracts.base import Input\n"
+    "\n"
+    "class AppInputContract(Input):\n"
+    "    extraction_method: str = 'direct'\n"
+    "    credential_guid: str = ''\n"
+)
+
+# Bare Input but opts out of payload safety → agent_json passes through.
+_INPUT_BARE_UNBOUNDED = (
+    "from application_sdk.contracts.base import Input\n"
+    "\n"
+    "class AppInputContract(Input, allow_unbounded_fields=True):\n"
+    "    extraction_method: str = 'direct'\n"
+)
+
+# Bare Input but declares agent_json explicitly → safe.
+_INPUT_BARE_WITH_AGENT_JSON = (
+    "from typing import Any\n"
+    "from application_sdk.contracts.base import Input\n"
+    "\n"
+    "class AppInputContract(Input):\n"
+    "    extraction_method: str = 'direct'\n"
+    "    agent_json: dict[str, Any] | None = None\n"
+)
+
+# Subclasses the SDK ExtractionInput family (which declares agent_json) → safe.
+_INPUT_EXTRACTION_FAMILY = (
+    "from application_sdk.templates.contracts import ExtractionInput\n"
+    "\n"
+    "class AppInputContract(ExtractionInput):\n"
+    "    preflight_check: str = ''\n"
+)
+
+# Bare Input, closed, but with model_config extra='allow' → safe.
+_INPUT_MODEL_CONFIG_ALLOW = (
+    "from pydantic import ConfigDict\n"
+    "from application_sdk.contracts.base import Input\n"
+    "\n"
+    "class AppInputContract(Input):\n"
+    "    model_config = ConfigDict(extra='allow')\n"
+    "    extraction_method: str = 'direct'\n"
+)
+
+_MANIFEST_AGENT_TOPLEVEL = _MANIFEST_WITH_AGENT_JSON  # carries {{agent-json}}
+
+
+def test_p039_rule_metadata() -> None:
+    rule = get_rule("P039")
+    assert rule.name == "SdrAgentJsonDroppedByInputContract"
+    assert rule.tier == EnforcementTier.WARN
+    assert rule.scope == RuleScope.APP
+    assert rule.autofixable is False
+    assert rule.rationale.strip()
+    assert rule.since == "0.16.0"
+    assert rule.category == "sdr-readiness"
+
+
+def test_p039_fires_on_closed_bare_input_contract(tmp_path: Path) -> None:
+    # The dropped-agent_json failing shape: manifest declares {{agent-json}}, but
+    # the generated contract is a closed bare-Input subclass with no agent_json.
+    _write(
+        tmp_path,
+        {
+            "atlan.yaml": _SDR_ATLAN_YAML,
+            "app/generated/manifest.json": _MANIFEST_AGENT_TOPLEVEL,
+            "app/generated/_input.py": _INPUT_BARE_CLOSED,
+            "app/connector.py": "class C:\n    async def run(self):\n        await self.upload('o')\n",
+        },
+    )
+    p039 = [f for f in _run(tmp_path) if f.rule_id == "P039"]
+    assert len(p039) == 1
+    assert "agent_json" in p039[0].message
+    assert p039[0].file == "app/generated/_input.py"
+
+
+def test_p039_silent_when_contract_allows_unbounded(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        {
+            "atlan.yaml": _SDR_ATLAN_YAML,
+            "app/generated/manifest.json": _MANIFEST_AGENT_TOPLEVEL,
+            "app/generated/_input.py": _INPUT_BARE_UNBOUNDED,
+        },
+    )
+    assert not any(f.rule_id == "P039" for f in _run(tmp_path))
+
+
+def test_p039_silent_when_contract_declares_agent_json(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        {
+            "atlan.yaml": _SDR_ATLAN_YAML,
+            "app/generated/manifest.json": _MANIFEST_AGENT_TOPLEVEL,
+            "app/generated/_input.py": _INPUT_BARE_WITH_AGENT_JSON,
+        },
+    )
+    assert not any(f.rule_id == "P039" for f in _run(tmp_path))
+
+
+def test_p039_silent_when_contract_extends_extraction_family(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        {
+            "atlan.yaml": _SDR_ATLAN_YAML,
+            "app/generated/manifest.json": _MANIFEST_AGENT_TOPLEVEL,
+            "app/generated/_input.py": _INPUT_EXTRACTION_FAMILY,
+        },
+    )
+    assert not any(f.rule_id == "P039" for f in _run(tmp_path))
+
+
+def test_p039_silent_when_model_config_allows_extra(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        {
+            "atlan.yaml": _SDR_ATLAN_YAML,
+            "app/generated/manifest.json": _MANIFEST_AGENT_TOPLEVEL,
+            "app/generated/_input.py": _INPUT_MODEL_CONFIG_ALLOW,
+        },
+    )
+    assert not any(f.rule_id == "P039" for f in _run(tmp_path))
+
+
+def test_p039_silent_when_manifest_has_no_agent_routing(tmp_path: Path) -> None:
+    # No {{agent-json}} in the manifest → precondition false (P029's domain,
+    # not this rule) even though the contract is a closed bare-Input subclass.
+    _write(
+        tmp_path,
+        {
+            "atlan.yaml": _SDR_ATLAN_YAML,
+            "app/generated/manifest.json": _MANIFEST_NON_AGENT,
+            "app/generated/_input.py": _INPUT_BARE_CLOSED,
+        },
+    )
+    assert not any(f.rule_id == "P039" for f in _run(tmp_path))
+
+
+def test_p039_fires_per_agent_entrypoint_sibling_input(tmp_path: Path) -> None:
+    # Multi-entrypoint: the agent crawler's sibling _input.py is closed → fires;
+    # a non-agent miner entrypoint alongside it is not considered.
+    _write(
+        tmp_path,
+        {
+            "atlan.yaml": _SDR_ATLAN_YAML,
+            "app/generated/crawler/manifest.json": _MANIFEST_AGENT_TOPLEVEL,
+            "app/generated/crawler/_input.py": _INPUT_BARE_CLOSED,
+            "app/generated/miner/manifest.json": _MANIFEST_NON_AGENT,
+            "app/generated/miner/_input.py": _INPUT_BARE_CLOSED,
+        },
+    )
+    p039 = [f for f in _run(tmp_path) if f.rule_id == "P039"]
+    assert len(p039) == 1
+    assert "crawler" in p039[0].file
+
+
+def test_p039_silent_on_non_sdr_app(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        {
+            "atlan.yaml": _NON_SDR_ATLAN_YAML,
+            "app/generated/manifest.json": _MANIFEST_AGENT_TOPLEVEL,
+            "app/generated/_input.py": _INPUT_BARE_CLOSED,
+        },
+    )
+    assert not _run(tmp_path)
 
 
 # ── scan_path no-op ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds three static SDR-readiness rules to the conformance suite (`packages/conformance`), mirroring the existing P029/P030. All catch **silent zero-asset** failure modes observed in SDR fleet testing, are **WARN**, APP-scoped, and gate on `self_deployed_runtime: true`. AST-based.

> Rule IDs: the next free P-numbers on `main` are **P037/P038/P039** (P031–P036 are already claimed). Rule IDs are a permanent contract, so these are non-contiguous with P029/P030 by design.

### P037 `SdrAgentJsonNotConsumed` (warn)
Resolves credentials via a **custom, GUID-only path** (bare `CredentialRef(credential_guid=...)` or `resolve_credential_raw`) and **never** routes through an agent-aware resolver (`CredentialRef.resolve` / `CredentialRef.from_workflow_args`, or an `agent_spec`-carrying ref). The forwarded `agent_json` is ignored → 0 assets in agent mode. **Heuristic:** gate on a `CredentialRef(...)` constructor or `resolve_credential_raw` call; fire only if no agent-aware entry point is called anywhere in the app source. Apps relying on the SDK's transparent resolution (no such calls) are never gated in.

### P038 `SdrArtifactMisrooted` (warn)
Roots the object-store prefix (`artifacts/apps/<identity>/...`) from the **workflow-input `application_name` field** (contract default `""`) instead of `APPLICATION_NAME`/`self._app_name`. AE forwards only manifest-declared args, so it stays empty → mis-rooted path (empty app segment) → 0 assets. P030 passes these apps (upload IS called). **Heuristic:** per-function taint — an f-string containing `artifacts/apps` whose interpolation derives from an `application_name` input read.

### P039 `SdrAgentJsonDroppedByInputContract` (warn)
Manifest declares `{{agent-json}}` (P029 passes), but the **generated extract-input contract** (`AppInputContract` in a generated `_input.py`) subclasses the **bare `Input`** base, declares **no `agent_json` field**, and **rejects extra fields** — so Pydantic silently drops the forwarded `agent_json`, `credential_ref` is `None`, and extraction fails with `PipelineContractError` / 0 assets. Orthogonal to P029 (manifest) and P037 (code): all three must be clean. **Heuristic:** precondition = a generated manifest carries `{{agent-json}}`; then inspect the sibling generated `_input.py` (fallback: app-wide). A contract is **safe** if it subclasses the SDK `*ExtractionInput` family (which declares `agent_json`), declares its own `agent_json`, or accepts extra fields (`allow_unbounded_fields=True` / `extra="allow"` / model config). Flag only a **closed bare-`Input`** contract.

## Validation (real connector repos across the fleet)

Ran the implemented `scan_all` against real connector repositories spanning BI, document-store, table-format, SQL, and warehouse connectors, plus reconstructed failing-shape fixtures. Summary:

| Connector under test | Result | Why |
|----------------------|--------|-----|
| table-format connector (custom GUID vault) | **P037 FLAG** | builds guid-only `CredentialRef`, no agent-aware resolve |
| document-store connector (misrooted prefix) | **P038 FLAG** | `artifacts/apps/{...}` rooted from input `application_name` |
| reconstructed closed-contract shape | **P039 FLAG** | closed bare-`Input` `AppInputContract`, manifest has `{{agent-json}}` |
| SQL / warehouse connectors (passing) | clean | resolve via the agent-aware resolver; root from `APPLICATION_NAME` |
| BI connector (passing counterexample) | clean | contract declares `agent_json` / allows extra fields |
| connectors subclassing SDK `*ExtractionInput` | clean (P039) | inherit `agent_json` from the SDK base |
| connector whose manifest lacks `{{agent-json}}` | clean (P039) | precondition false — that gap is P029's domain |

**Zero false-positives** on every passing connector.

### Honest notes
- **P039 target already remediated upstream:** the connector that originally exhibited the dropped-`agent_json` bug has since been fixed on its main branch (contract now sets `allow_unbounded_fields=True`, and it is currently marked non-SDR), so `scan_all` correctly does **not** flag the live repo. I proved the rule fires on the documented failing shape via a reconstructed fixture (flagged at `app/generated/_input.py`) and a should-flag meta-test. The separating signal is "subclasses bare `Input` and closes the model" — **not** merely "no `agent_json` reference" — because the SDK's `ExtractionInput` family already declares `agent_json`, so connectors extending it are correctly exempt.
- **P038 has a documented limitation:** a connector that forwards an empty `output_prefix` input field *without* an `artifacts/apps` literal is statically indistinguishable from a correct connector (a passing SQL connector uses the identical construct), so P038 is scoped to the precise, separable signature and that variant is left to runtime/e2e detection. Documented in the rule + prose.

## Registration
`suite/rules/sdr.py`, `suite/checks/sdr.py`, regenerated `docs/rules/prescriptions.md` (staleness clean), `programs/areas/prescriptions.prose.md`, `tools/generate_rule_docs.py`, `tests/test_catalog.py`, `tests/test_sdr.py` (metadata + should-flag/should-not-flag fixtures), `CHANGELOG.md`. `since="0.16.0"`.

## Test + lint results
- `uv run pytest tests/` → **1938 passed, 1 xfailed** (excluding 2 pre-existing, unrelated failures that require the parent SDK installed in the test venv: `test_sdk_contract_mixins.py` + `test_app_name_alignment::test_sdk_base_names_matches_templates_all`, both `ModuleNotFoundError: application_sdk.*`).
- `uv run pre-commit run --files <changed>` → **green** (ruff, ruff-format, pyright, isort).
- `gen-rule-docs --check` → up to date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)