### PR TITLE
chore: track action pins in conformance & workflow templates via Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,13 @@
     "github>atlanhq/application-sdk//renovate-config/default.json"
   ],
   "semanticCommitType": "chore",
+  "github-actions": {
+    "description": "Also track SHA-pinned third-party actions in files outside the default github-actions fileMatch: the conformance bootstrap templates shipped in the package, and the .github/workflow-templates/ starter workflows (Renovate's default anchor for the latter is root-level workflow-templates/, so the nested copies are not matched by default). Scoped to those dirs so it never touches the .md doc examples or the actions_pinning test fixtures. Repo-local (not the fleet preset) because packages/conformance/ is SDK-specific.",
+    "managerFilePatterns": [
+      "/^packages/conformance/conformance/bootstrap/templates/.+\\.ya?ml$/",
+      "/^\\.github/workflow-templates/.+\\.ya?ml$/"
+    ]
+  },
   "ignorePaths": [
     "contract-toolkit/examples/**",
     "requirements.txt"


### PR DESCRIPTION
## What

Extend Renovate's `github-actions` manager to also track the SHA-pinned
third-party actions that live **outside** the default `fileMatch`:

- `packages/conformance/conformance/bootstrap/templates/*.{yml,yaml}` — the
  conformance bootstrap templates (e.g. `checks.yml`, `conformance-upload-sarif.yaml`),
  which pin `actions/checkout`, `pre-commit/action`, `actions/download-artifact`,
  `github/codeql-action`.
- `.github/workflow-templates/*.{yml,yaml}` — starter workflows
  (`dependency-review`, `trivy`, `stale`). Renovate's default anchor for these is
  root-level `workflow-templates/`, so the `.github/`-nested copies are not matched
  by default.

## Why

Renovate's github-actions manager only scans its default file matching
(`.github/workflows`, `.github/actions`). The action pins in the two dirs above
were therefore never bumped and drift behind the live workflows over time.

## How it behaves

- `managerFilePatterns` is **additive** to the manager defaults, so normal
  workflow scanning is unaffected.
- Scoped to those two dirs, so it deliberately does **not** touch the `.md` doc
  examples or the `packages/conformance/tests/test_actions_pinning.py` string
  fixtures (which pin intentionally-old versions as test data).
- The templates keep SHA pins, so Renovate updates **both** the digest and the
  `# vX.Y.Z` comment — keeping the C001 actions-pinning conformance check green.
- Bumps inherit the existing `github-actions` package rule (grouping + automerge).
- The `atlanhq/application-sdk/.github/...@main` reusable-workflow refs have no
  version to track and are left alone.

Placed in the repo-local `renovate.json` rather than the fleet preset
(`renovate-config/default.json`) because `packages/conformance/` is SDK-specific
and would be a dead pattern in every other `atlan-*-app` repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
