### PR TITLE
feat(conformance): detect silent auto-merge-not-armed PRs in fleet scanner

### DIFF
--- a/.github/scripts/renovate_fleet_scan.py
+++ b/.github/scripts/renovate_fleet_scan.py
@@ -50,6 +50,7 @@ isDraft
 body
 mergeable
 reviewDecision
+autoMergeRequest { enabledAt }
 repository { nameWithOwner }
 labels(first: 20) { nodes { name } }
 files(first: 100) { nodes { path } }
@@ -219,6 +220,8 @@ def normalize_open_pr(pr: dict) -> dict:
         ],
         "mergeable": pr.get("mergeable") or "UNKNOWN",
         "reviewDecision": pr.get("reviewDecision"),
+        # autoMergeRequest is non-null iff GitHub-native auto-merge is armed.
+        "autoMergeEnabled": pr.get("autoMergeRequest") is not None,
         "statusCheckRollup": _status_rollup_to_list(pr),
         "files": [
             {"path": f["path"]} for f in (pr.get("files") or {}).get("nodes") or []

--- a/.github/scripts/tests/test_renovate_fleet_scan.py
+++ b/.github/scripts/tests/test_renovate_fleet_scan.py
@@ -212,6 +212,7 @@ def test_normalize_open_pr_full_shape():
         "labels": {"nodes": [{"name": "update:minor"}]},
         "mergeable": "MERGEABLE",
         "reviewDecision": "APPROVED",
+        "autoMergeRequest": {"enabledAt": "2026-06-01T01:00:00Z"},
         "files": {"nodes": [{"path": "uv.lock"}]},
         "createdAt": "2026-06-01T00:00:00Z",
         "updatedAt": "2026-06-02T00:00:00Z",
@@ -228,6 +229,7 @@ def test_normalize_open_pr_full_shape():
         "labels": [{"name": "update:minor"}],
         "mergeable": "MERGEABLE",
         "reviewDecision": "APPROVED",
+        "autoMergeEnabled": True,
         "statusCheckRollup": [],
         "files": [{"path": "uv.lock"}],
         "createdAt": "2026-06-01T00:00:00Z",
@@ -253,6 +255,8 @@ def test_normalize_open_pr_defaults_for_missing_optional_fields():
     assert out["statusCheckRollup"] == []
     assert out["isDraft"] is False
     assert out["body"] == ""
+    # No autoMergeRequest in the node → auto-merge is not armed.
+    assert out["autoMergeEnabled"] is False
     # Never emit a bare None for fields conformance.renovate.scan reads with two-arg
     # dict.get(key, default) — an explicit null would bypass that default.
     for key in (
@@ -263,6 +267,7 @@ def test_normalize_open_pr_defaults_for_missing_optional_fields():
         "isDraft",
         "body",
         "statusCheckRollup",
+        "autoMergeEnabled",
     ):
         assert out[key] is not None
 

--- a/packages/conformance/conformance/renovate/classify.py
+++ b/packages/conformance/conformance/renovate/classify.py
@@ -180,26 +180,31 @@ def blocking_reason(
     if pr.checks_state == ChecksState.PENDING:
         return BlockingReason.CHECKS_PENDING
 
-    # Eligible, non-conflicting, dep-only, checks green. Is anything actually
-    # driving it to merge?
-    approved = pr.review_decision == "APPROVED"
+    # Eligible, non-conflicting, dep-only. Both auto-merge signals below describe
+    # a PR whose every gate is *green* yet nothing is driving it to merge, so they
+    # only fire on GREEN. FAILING/PENDING are already handled above; UNKNOWN
+    # (checks rollup couldn't be determined) must not masquerade as green-but-
+    # parked — it falls through to AWAITING_APPROVAL as it did before these
+    # signals existed. Is anything actually driving a green PR to merge?
+    if pr.checks_state == ChecksState.GREEN:
+        approved = pr.review_decision == "APPROVED"
 
-    # Precise signal: approval is in and every gate is green, yet auto-merge was
-    # never armed. With a required merge queue nothing will ever merge it — the
-    # dangerous "looks healthy, parked forever" case. Detected immediately (no
-    # age threshold) because there is nothing left to wait for.
-    if approved and not pr.auto_merge_enabled:
-        return BlockingReason.AUTOMERGE_NOT_ARMED
+        # Precise signal: approval is in and every gate is green, yet auto-merge
+        # was never armed. With a required merge queue nothing will ever merge it
+        # — the dangerous "looks healthy, parked forever" case. Detected
+        # immediately (no age threshold) because there is nothing left to wait for.
+        if approved and not pr.auto_merge_enabled:
+            return BlockingReason.AUTOMERGE_NOT_ARMED
 
-    # Age backstop: green + eligible but still open past the staleness threshold.
-    # Not gated on approval or armed-state so it also catches a down approval
-    # workflow and wedged merge queues — any stuck mode, including ones not
-    # modelled above.
-    if age_days >= STALE_AFTER_DAYS:
-        return BlockingReason.AUTOMERGE_STALE
+        # Age backstop: green + eligible but still open past the staleness
+        # threshold. Not gated on approval or armed-state so it also catches a
+        # down approval workflow and wedged merge queues — any stuck mode,
+        # including ones not modelled above.
+        if age_days >= STALE_AFTER_DAYS:
+            return BlockingReason.AUTOMERGE_STALE
 
-    # Recently eligible; expected to merge imminently (approval pending or freshly
-    # armed and awaiting the queue).
+    # Recently eligible (or checks state not yet determinable); expected to merge
+    # imminently (approval pending or freshly armed and awaiting the queue).
     return BlockingReason.AWAITING_APPROVAL
 
 

--- a/packages/conformance/conformance/renovate/classify.py
+++ b/packages/conformance/conformance/renovate/classify.py
@@ -52,6 +52,14 @@ _DEP_FILE_RE = re.compile(
 )
 
 
+# Age backstop for the "genuinely wedged" signal. An auto-merge-eligible, green
+# PR still open this many days after creation is treated as stuck regardless of
+# the specific mechanism — the auto-approve → auto-merge → queue pipeline runs on
+# a cadence of hours, so a full day open means something is broken. Deliberately
+# conservative to avoid flagging PRs the pipeline is still legitimately carrying.
+STALE_AFTER_DAYS = 1
+
+
 def _non_dep_files(files: list[str]) -> list[str]:
     return [f for f in files if not _DEP_FILE_RE.match(f)]
 
@@ -145,11 +153,17 @@ def blocking_reason(
     pr: RenovatePR,
     category: Category,
     update_type: UpdateType,
+    age_days: int = 0,
 ) -> BlockingReason:
     """
     Why has this open PR not merged?
 
-    Mirrors the conditions in renovate-auto-approve-reusable.yml.
+    Mirrors the conditions in renovate-auto-approve-reusable.yml, then adds two
+    signals for the silent-stuck case a green/approved/mergeable PR can fall into
+    when GitHub-native auto-merge is never armed (see PR #2828 postmortem).
+
+    ``age_days`` is threaded in explicitly rather than read off ``pr`` because
+    classify() computes it after the model is first constructed.
     """
     if not auto_merge_expected(category, update_type):
         return BlockingReason.AWAITING_HUMAN_REVIEW
@@ -166,7 +180,26 @@ def blocking_reason(
     if pr.checks_state == ChecksState.PENDING:
         return BlockingReason.CHECKS_PENDING
 
-    # All conditions satisfied — atlan-ci approval just hasn't been posted yet.
+    # Eligible, non-conflicting, dep-only, checks green. Is anything actually
+    # driving it to merge?
+    approved = pr.review_decision == "APPROVED"
+
+    # Precise signal: approval is in and every gate is green, yet auto-merge was
+    # never armed. With a required merge queue nothing will ever merge it — the
+    # dangerous "looks healthy, parked forever" case. Detected immediately (no
+    # age threshold) because there is nothing left to wait for.
+    if approved and not pr.auto_merge_enabled:
+        return BlockingReason.AUTOMERGE_NOT_ARMED
+
+    # Age backstop: green + eligible but still open past the staleness threshold.
+    # Not gated on approval or armed-state so it also catches a down approval
+    # workflow and wedged merge queues — any stuck mode, including ones not
+    # modelled above.
+    if age_days >= STALE_AFTER_DAYS:
+        return BlockingReason.AUTOMERGE_STALE
+
+    # Recently eligible; expected to merge imminently (approval pending or freshly
+    # armed and awaiting the queue).
     return BlockingReason.AWAITING_APPROVAL
 
 
@@ -180,7 +213,6 @@ def classify(pr: RenovatePR) -> RenovatePR:
     cat = categorize(pr)
     ut = derive_update_type(pr)
     ame = auto_merge_expected(cat, ut)
-    br = blocking_reason(pr, cat, ut)
 
     now = datetime.now(timezone.utc)
     # pr.created_at may be tz-aware or naive; normalise.
@@ -190,6 +222,9 @@ def classify(pr: RenovatePR) -> RenovatePR:
 
         created = created.replace(tzinfo=_tz.utc)
     age = max(0, (now - created).days)
+
+    # age feeds the staleness backstop, so it must be computed before classifying.
+    br = blocking_reason(pr, cat, ut, age)
 
     # dataclass is frozen=True; use replace pattern.
     import dataclasses

--- a/packages/conformance/conformance/renovate/models.py
+++ b/packages/conformance/conformance/renovate/models.py
@@ -39,8 +39,24 @@ class BlockingReason(str, Enum):
     CHECKS_PENDING = "checks_pending"  # required CI checks still running
     MERGE_CONFLICT = "merge_conflict"  # mergeable=CONFLICTING
     NON_DEP_FILES = "non_dep_files"  # changed files outside auto-approve allowlist
+    AUTOMERGE_NOT_ARMED = (
+        # Eligible, every gate green, and code-owner approval is in — but
+        # GitHub-native auto-merge was never enabled on the PR. With a required
+        # merge queue nothing else will merge it, so it sits green-and-approved
+        # forever with no visible fault. Precise signal: autoMergeRequest is null.
+        "automerge_not_armed"
+    )
+    AUTOMERGE_STALE = (
+        # Age backstop: an auto-merge-eligible, green PR still open well past when
+        # the auto-approve → auto-merge → queue pipeline should have carried it.
+        # Catches wedged merge queues, a down approval workflow, and failure modes
+        # not modelled explicitly — without flagging freshly-opened PRs.
+        "automerge_stale"
+    )
     AWAITING_APPROVAL = (
-        "awaiting_approval"  # eligible; atlan-ci approval not yet posted
+        # Transient: recently became eligible and is expected to merge imminently
+        # (atlan-ci approval pending, or freshly armed and awaiting the queue).
+        "awaiting_approval"
     )
     UNKNOWN = "unknown"
 
@@ -69,6 +85,10 @@ class RenovatePR:
     updated_at: datetime
     is_draft: bool
     body: str
+    # Raw: GitHub-native auto-merge armed (GraphQL autoMergeRequest non-null).
+    # Defaulted so pre-existing RenovatePR constructions stay valid; scan._parse_pr
+    # populates it from the fetched field.
+    auto_merge_enabled: bool = False
     # populated by classify()
     category: Category = Category.UNKNOWN
     update_type: UpdateType = UpdateType.UNKNOWN

--- a/packages/conformance/conformance/renovate/scan.py
+++ b/packages/conformance/conformance/renovate/scan.py
@@ -108,6 +108,7 @@ def _parse_pr(raw: dict) -> Optional[RenovatePR]:
             updated_at=updated,
             is_draft=raw.get("isDraft", False),
             body=raw.get("body") or "",
+            auto_merge_enabled=bool(raw.get("autoMergeEnabled") or False),
         )
     except (KeyError, ValueError) as exc:
         print(f"Warning: skipping malformed PR record: {exc}", file=sys.stderr)
@@ -202,6 +203,7 @@ def _pr_to_dict(pr: RenovatePR) -> dict:
         "category": pr.category.value,
         "updateType": pr.update_type.value,
         "autoMergeExpected": pr.auto_merge_expected,
+        "autoMergeEnabled": pr.auto_merge_enabled,
         "blockingReason": pr.blocking_reason.value,
         "mergeable": pr.mergeable,
         "checksState": pr.checks_state.value,

--- a/packages/conformance/tests/test_renovate_classify.py
+++ b/packages/conformance/tests/test_renovate_classify.py
@@ -37,6 +37,7 @@ def make_pr(
     updated_at: datetime = _NOW,
     is_draft: bool = False,
     body: str = "",
+    auto_merge_enabled: bool = False,
 ) -> RenovatePR:
     """Construct an unclassified RenovatePR with sane defaults for one scenario."""
     return RenovatePR(
@@ -53,6 +54,7 @@ def make_pr(
         updated_at=updated_at,
         is_draft=is_draft,
         body=body,
+        auto_merge_enabled=auto_merge_enabled,
     )
 
 
@@ -195,16 +197,93 @@ def test_blocking_non_dep_files() -> None:
 
 
 def test_blocking_awaiting_approval() -> None:
-    # github-actions, all green, no conflict, only dep files changed.
+    # github-actions, all green, no conflict, dep-only, freshly opened and not yet
+    # approved → transient wait for the atlan-ci approval, not stuck.
     pr = classify(
         make_pr(
             labels=["update:github-actions"],
             files=[".github/workflows/test.yaml"],
             mergeable="MERGEABLE",
             checks_state=ChecksState.GREEN,
+            review_decision="",
+            created_at=_NOW,
         )
     )
     assert pr.blocking_reason is BlockingReason.AWAITING_APPROVAL
+
+
+def test_blocking_awaiting_approval_armed_and_young() -> None:
+    # Approved + auto-merge armed + freshly opened → in-flight, expected to merge
+    # via the queue imminently. Not stuck.
+    pr = classify(
+        make_pr(
+            labels=["update:github-actions"],
+            files=[".github/workflows/test.yaml"],
+            review_decision="APPROVED",
+            auto_merge_enabled=True,
+            created_at=_NOW,
+        )
+    )
+    assert pr.blocking_reason is BlockingReason.AWAITING_APPROVAL
+
+
+def test_blocking_automerge_not_armed() -> None:
+    # The #2828 silent-stuck case: eligible, green, dep-only, code-owner approved,
+    # but GitHub-native auto-merge was never enabled → nothing will merge it.
+    # Flagged immediately (age 0), no staleness wait.
+    pr = classify(
+        make_pr(
+            labels=["update:github-actions"],
+            files=[".github/workflows/test.yaml"],
+            review_decision="APPROVED",
+            auto_merge_enabled=False,
+            created_at=_NOW,
+        )
+    )
+    assert pr.blocking_reason is BlockingReason.AUTOMERGE_NOT_ARMED
+
+
+def test_blocking_automerge_not_armed_wins_over_stale() -> None:
+    # Precise not-armed signal takes priority over the age backstop when both hold.
+    pr = classify(
+        make_pr(
+            labels=["update:github-actions"],
+            files=[".github/workflows/test.yaml"],
+            review_decision="APPROVED",
+            auto_merge_enabled=False,
+            created_at=_OLD,
+        )
+    )
+    assert pr.blocking_reason is BlockingReason.AUTOMERGE_NOT_ARMED
+
+
+def test_blocking_automerge_stale_unapproved_old() -> None:
+    # Age backstop: eligible + green but still open past the threshold and never
+    # approved → the auto-approval pipeline is likely down. Caught without needing
+    # to model the specific failure. (Backstop is not gated on approval.)
+    pr = classify(
+        make_pr(
+            labels=["update:github-actions"],
+            files=[".github/workflows/test.yaml"],
+            review_decision="",
+            created_at=_OLD,
+        )
+    )
+    assert pr.blocking_reason is BlockingReason.AUTOMERGE_STALE
+
+
+def test_blocking_automerge_stale_armed_but_wedged() -> None:
+    # Armed and approved but still open past the threshold → merge queue wedged.
+    pr = classify(
+        make_pr(
+            labels=["update:github-actions"],
+            files=[".github/workflows/test.yaml"],
+            review_decision="APPROVED",
+            auto_merge_enabled=True,
+            created_at=_OLD,
+        )
+    )
+    assert pr.blocking_reason is BlockingReason.AUTOMERGE_STALE
 
 
 # ── Non-dep file detection ───────────────────────────────────────────────────

--- a/packages/conformance/tests/test_renovate_classify.py
+++ b/packages/conformance/tests/test_renovate_classify.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 
-from conformance.renovate.classify import classify
+from conformance.renovate.classify import STALE_AFTER_DAYS, classify
 from conformance.renovate.models import (
     BlockingReason,
     Category,
@@ -284,6 +284,36 @@ def test_blocking_automerge_stale_armed_but_wedged() -> None:
         )
     )
     assert pr.blocking_reason is BlockingReason.AUTOMERGE_STALE
+
+
+def test_blocking_automerge_stale_at_exact_threshold() -> None:
+    # Boundary: age == STALE_AFTER_DAYS must trip the backstop (the `>=` in
+    # classify.py). Anchored to STALE_AFTER_DAYS so a future `>=` → `>` regression
+    # fails here. Unapproved so the not-armed branch is skipped and the stale
+    # backstop is isolated.
+    pr = classify(
+        make_pr(
+            labels=["update:github-actions"],
+            files=[".github/workflows/test.yaml"],
+            review_decision="",
+            created_at=_NOW - timedelta(days=STALE_AFTER_DAYS),
+        )
+    )
+    assert pr.blocking_reason is BlockingReason.AUTOMERGE_STALE
+
+
+def test_blocking_automerge_not_stale_just_under_threshold() -> None:
+    # Boundary: just under a full day (age 0 after `.days` truncation) is NOT
+    # stale yet — the freshly-eligible PR is still expected to merge imminently.
+    pr = classify(
+        make_pr(
+            labels=["update:github-actions"],
+            files=[".github/workflows/test.yaml"],
+            review_decision="",
+            created_at=_NOW - timedelta(hours=23),
+        )
+    )
+    assert pr.blocking_reason is BlockingReason.AWAITING_APPROVAL
 
 
 def test_blocking_unknown_checks_not_flagged_as_automerge() -> None:

--- a/packages/conformance/tests/test_renovate_classify.py
+++ b/packages/conformance/tests/test_renovate_classify.py
@@ -286,6 +286,24 @@ def test_blocking_automerge_stale_armed_but_wedged() -> None:
     assert pr.blocking_reason is BlockingReason.AUTOMERGE_STALE
 
 
+def test_blocking_unknown_checks_not_flagged_as_automerge() -> None:
+    # UNKNOWN checks state is not green: the auto-merge-not-armed / stale signals
+    # both assert every gate is green, so an eligible + approved + old PR whose
+    # checks rollup can't be determined must NOT be reported as AUTOMERGE_* —
+    # it falls through to AWAITING_APPROVAL as it did before these signals existed.
+    pr = classify(
+        make_pr(
+            labels=["update:github-actions"],
+            files=[".github/workflows/test.yaml"],
+            review_decision="APPROVED",
+            auto_merge_enabled=False,
+            checks_state=ChecksState.UNKNOWN,
+            created_at=_OLD,
+        )
+    )
+    assert pr.blocking_reason is BlockingReason.AWAITING_APPROVAL
+
+
 # ── Non-dep file detection ───────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Problem

A Renovate dependency PR can be **fully green, code-owner approved, and mergeable** yet sit open forever — when GitHub-native auto-merge was never *armed* on it. With a required merge queue nothing else will merge it, and Renovate only arms auto-merge at PR-creation/rebase time, so a single missed arm-call strands the PR silently.

This is the most dangerous class of stuck for a fleet operator: **nothing looks wrong**. It is not failing CI, not conflicted, and is a dep PR — so it is invisible to anyone who can't inspect every repo by hand. (Concrete instance: application-sdk#2828 — green, approved, `autoMergeRequest: null`, never enqueued.)

The fleet scanner had no way to represent this. Such a PR fell through `blocking_reason()`'s gate checks to `AWAITING_APPROVAL`, which asserts *"atlan-ci approval not yet posted"* — wrong: the approval **is** present.

## Detection — two signals

- **Precise:** `autoMergeRequest` is null on an eligible + green + approved PR → `BlockingReason.AUTOMERGE_NOT_ARMED`, flagged **immediately** (nothing left to wait for).
- **Age backstop:** any eligible + green PR still open past `STALE_AFTER_DAYS` (=1) → `BlockingReason.AUTOMERGE_STALE`. Deliberately **not** gated on approval/armed-state, so it also catches a down approval workflow, a wedged merge queue, and stuck modes not modelled explicitly — the net that keeps working when a future failure mode appears.

## Changes

| Layer | File | Change |
|---|---|---|
| Fetch | `.github/scripts/renovate_fleet_scan.py` | add `autoMergeRequest { enabledAt }` to the open-PR GraphQL query; `normalize_open_pr` emits `autoMergeEnabled` |
| Model | `renovate/models.py` | `RenovatePR.auto_merge_enabled`; `BlockingReason.AUTOMERGE_NOT_ARMED` + `AUTOMERGE_STALE`; broadened `AWAITING_APPROVAL` doc |
| Classify | `renovate/classify.py` | thread `age_days` into `blocking_reason()` (computed before classifying); two new branches; `STALE_AFTER_DAYS` |
| Scan | `renovate/scan.py` | parse `auto_merge_enabled`; emit `autoMergeEnabled` per PR |

Both new reasons already count toward `autoMergeEligibleButStuck`, and flow into `repos/<slug>.json` / `fleet.json` `byBlockingReason`.

## Verification

- `test_renovate_classify.py` / `test_renovate_fleet_scan.py`: 66 passing, incl. new cases for not-armed (immediate), not-armed-wins-over-stale, stale-unapproved-old, stale-armed-but-wedged, and armed-and-young (not stuck).
- End-to-end: ran the scanner on a synthetic #2828-like PR → `blockingReason: automerge_not_armed`, `eligibleButStuck: 1`.
- `pre-commit` clean (ruff, ruff-format, isort, pyright).

## Follow-up (separate repo)

Surfacing these in the **connector-pulse** "Stuck PRs" headline is a companion change there: add the two reasons to `STUCK_BLOCKING_REASONS` (`fleet_freshness_service.py`) and the frontend `stuck` sum (`FleetFreshness.tsx`), with labels/descriptions. The per-repo "stuck" pill already trips via `autoMergeEligibleButStuck`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
