### PR TITLE
chore(renovate): title conformance-template action bumps as fix(conformance)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,6 +12,20 @@
       "/^\\.github/workflow-templates/.+\\.ya?ml$/"
     ]
   },
+  "packageRules": [
+    {
+      "description": "Action bumps inside the shipped conformance bootstrap templates are conformance-package source changes: the PR-title gate requires a fix(conformance) scope for anything under packages/conformance/ (except tests/ and lock files), and these bumps change the package's scaffolded output so they should version it. Give them their own group + semantic type/scope so the PR title is deterministic and never collides with plain .github/workflows or .github/workflow-templates action bumps (which stay chore(deps)). Repo-local packageRules are appended after the fleet preset, so this overrides both the preset's force-chore rule and its github-actions groupName — but only for deps whose file lives under the templates dir (matchFileNames).",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchFileNames": [
+        "packages/conformance/conformance/bootstrap/templates/**"
+      ],
+      "groupName": "conformance action templates",
+      "semanticCommitType": "fix",
+      "semanticCommitScope": "conformance"
+    }
+  ],
   "ignorePaths": [
     "contract-toolkit/examples/**",
     "requirements.txt"


### PR DESCRIPTION
## Problem

#2830 made Renovate track the SHA-pinned actions in the shipped **conformance bootstrap templates** (`packages/conformance/conformance/bootstrap/templates/`). Those files live under `packages/conformance/` **source**, so the **PR Title Convention** gate requires a `fix(conformance)` / `feat(conformance)` scope — but Renovate titles dependency bumps `chore(deps)`, so the resulting PRs are blocked:

- **#2831** (`checks.yml` only) — `chore(deps): update actions/checkout action to v7` ❌
- **#2828** — a *mixed* github-actions group: `.github/workflows/update-dashboard.yaml` **+** two conformance templates, all under one `chore(deps)` title ❌

## Answer: yes, Renovate gives us this control

Renovate resolves the semantic type/scope **per package rule**, matched by `matchFileNames` (the dependency's own file path). Add a repo-local rule scoped to the templates dir:

```jsonc
{
  "matchManagers": ["github-actions"],
  "matchFileNames": ["packages/conformance/conformance/bootstrap/templates/**"],
  "groupName": "conformance action templates",
  "semanticCommitType": "fix",
  "semanticCommitScope": "conformance"
}
```

- `semanticCommitType: fix` + `semanticCommitScope: conformance` → **`fix(conformance): …`** titles that satisfy the gate (and version the released conformance package, since the template is shipped output).
- **`groupName`** splits these into their own PR instead of being bundled with plain `.github/workflows` / `.github/workflow-templates` action bumps — which stay `chore(deps)`. This is what fixes the #2828 mixed-group collision: one PR can't be both `chore(deps)` and `fix(conformance)`, so we separate the paths.
- Repo-local packageRules are appended **after** the fleet preset, so this overrides both the preset's force-`chore` rule and its `github-actions` `groupName` — but only for deps whose file is under the templates dir.

## Effect on the open PRs

Once merged, on Renovate's next run:
- **#2828** loses the conformance templates from the github-actions group → back to `chore(deps)` with just the workflow file ✅, and a new **`fix(conformance): …`** PR appears for the templates.
- **#2831** regenerates as `fix(conformance): update actions/checkout action to v7` ✅.

(I retitled the two open PRs manually to unblock them immediately; Renovate will regenerate them cleanly under the new grouping.)

## Tradeoff worth a conscious call

`fix(conformance)` means every template action-pin bump triggers a **patch release of the conformance package**. That's the correct semantics if you treat the shipped templates as package output — but it is more release churn. The alternative would be to *exempt* Renovate-authored template bumps in the title gate (keep `chore`, no release). This PR takes the "version it" path per the request; easy to flip if the release noise isn't wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
