### PR TITLE
ci: auto-approve conformance-template dep bumps via caller allowlist

### DIFF
--- a/.github/workflows/renovate-auto-approve-reusable.yml
+++ b/.github/workflows/renovate-auto-approve-reusable.yml
@@ -81,6 +81,18 @@ on:
         required: false
         default: ""
         type: string
+      extra_dep_file_pattern:
+        description: >
+          Optional extra ERE alternation of repo-specific dependency file paths
+          to treat as auto-approvable, appended to the built-in allowlist (which
+          already covers .github/ and lock/manifest/contract files). Each branch
+          is whole-line matched (grep -vxE), so anchor to full workspace-relative
+          paths, e.g. 'packages/conformance/.../templates/.+\.ya?ml'. This is how
+          a repo declares its OWN dep-managed source paths without hard-coding any
+          app-specific path into this shared workflow.
+        required: false
+        default: ""
+        type: string
     secrets:
       org_pat:
         description: >
@@ -123,6 +135,7 @@ jobs:
           EVENT_NAME: ${{ inputs.event_name }}
           RUN_SHA: ${{ inputs.head_sha }}
           DISPATCH_PR: ${{ inputs.pr_number }}
+          EXTRA_DEP_PATTERN: ${{ inputs.extra_dep_file_pattern }}
         run: |
           set -euo pipefail
 
@@ -207,9 +220,16 @@ jobs:
               continue
             fi
 
+            #    A caller may extend the allowlist with its own dep-managed
+            #    source paths via extra_dep_file_pattern (kept out of this shared
+            #    workflow so no app-specific path is hard-coded here).
+            DEP_FILE_RE='(.*/)?uv\.lock|(.*/)?package-lock\.json|(.*/)?requirements\.txt|(.*/)?pyproject\.toml|(.*/)?contract/PklProject|(.*/)?contract/PklProject\.deps\.json|app/generated/.*|atlan\.yaml|app\.yaml'
+            if [ -n "${EXTRA_DEP_PATTERN:-}" ]; then
+              DEP_FILE_RE="${DEP_FILE_RE}|${EXTRA_DEP_PATTERN}"
+            fi
             NON_DEP_FILES=$(echo "$FILENAMES" \
               | grep -v '^\.github/' \
-              | grep -vxE '(.*/)?uv\.lock|(.*/)?package-lock\.json|(.*/)?requirements\.txt|(.*/)?pyproject\.toml|(.*/)?contract/PklProject|(.*/)?contract/PklProject\.deps\.json|app/generated/.*|atlan\.yaml|app\.yaml' \
+              | grep -vxE "$DEP_FILE_RE" \
               || true)
             if [ -n "$NON_DEP_FILES" ]; then
               echo "PR #${PR_NUM}: contains non-dependency files:"

--- a/.github/workflows/renovate-auto-approve.yml
+++ b/.github/workflows/renovate-auto-approve.yml
@@ -52,4 +52,10 @@ jobs:
       event_name: ${{ github.event_name }}
       head_sha: ${{ github.event.workflow_run.head_sha }}
       pr_number: ${{ inputs.pr_number }}
+      # application-sdk tracks the SHA-pinned actions in its shipped conformance
+      # bootstrap templates (Renovate config in renovate.json). Those live under
+      # packages/conformance/ source, outside the built-in allowlist, so declare
+      # them here as auto-approvable dependency files. Kept in this repo's caller
+      # rather than the shared reusable workflow — the path is SDK-specific.
+      extra_dep_file_pattern: 'packages/conformance/conformance/bootstrap/templates/.+\.ya?ml'
     secrets: inherit


### PR DESCRIPTION
## Problem

#2830 made Renovate track the SHA-pinned actions in the shipped **conformance bootstrap templates** (`packages/conformance/conformance/bootstrap/templates/`). Those live under `packages/conformance/` **source** — outside the auto-approve allowlist — so the `atlan-ci` auto-approval step skips them as *"non-dependency files"*, leaving the PRs in `REVIEW_REQUIRED` and unable to auto-merge (e.g. **#2835**, **#2836**).

Same root cause as the PR-title gate fixed in #2833: a **path-keyed gate that didn't know about the newly tracked location**. Two gates, one blind spot.

## Fix — parameterize, don't hard-code

The approval logic lives in the **fleet-shared** `renovate-auto-approve-reusable.yml`, so per [our rule](../blob/main/CLAUDE.md) I did **not** bake an application-sdk-specific path into it. Instead:

- **Reusable workflow**: new optional `extra_dep_file_pattern` input — an ERE alternation of repo-specific dep-managed source paths, appended to the built-in allowlist (`.github/` + lock/manifest/contract files). Whole-line matched (`grep -vxE`).
- **application-sdk's caller** (`renovate-auto-approve.yml`): passes the conformance-templates glob `packages/conformance/conformance/bootstrap/templates/.+\.ya?ml`.

Every other fleet repo passes nothing → the base allowlist is unchanged for them.

## Verification (grep logic reproduced locally)

| Input | Result |
|---|---|
| templates-only PR (#2836-like) | **empty** → auto-approvable ✅ |
| mixed: template + `src/foo.py` | flags only `src/foo.py` ✅ |
| `evil.py` in templates dir | still flagged (yaml-only) ✅ |
| no extra pattern (other repos) | base allowlist byte-for-byte unchanged ✅ |

YAML parses; pre-commit clean. (actionlint not available locally — CI will run it.)

## After merge

The auto-approve workflow fires on `workflow_run` completion of the required checks, so already-green PRs won't retroactively re-fire on their own. To approve #2835 / #2836 immediately, either dispatch `renovate-auto-approve.yml` with each `pr_number`, or tick their Renovate rebase/retry checkbox (new commit → checks re-run → auto-approve fires).

## Note

There's now a clear pattern: **any time we point Renovate at a new source path, both path-keyed gates (title convention + auto-approve allowlist) must learn about it.** Worth documenting so the next tracked-path addition doesn't rediscover this twice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
