### PR TITLE
fix(conformance): revert unpublished 0.16.0 bump and hand-edited changelog

### DIFF
--- a/packages/conformance/CHANGELOG.md
+++ b/packages/conformance/CHANGELOG.md
@@ -2,13 +2,6 @@
 
 All notable changes to `atlan-application-sdk-conformance` are documented here.
 
-## [Unreleased]
-
-### Features
-
-- add P037 `SdrAgentJsonNotConsumed` (warn) and P038 `SdrArtifactMisrooted` (warn) SDR-readiness rules — P037 flags an app that resolves credentials by `credential_guid` only and never routes through an agent-aware resolver (`agent_json` ignored → zero assets in agent mode); P038 flags an object-store output prefix rooted from the empty-defaulting workflow-input `application_name` field instead of `APPLICATION_NAME` (mis-rooted artifacts → zero assets published)
-- add P039 `SdrAgentJsonDroppedByInputContract` (warn) SDR-readiness rule — flags an app whose generated manifest declares `{{agent-json}}` (P029-clean) but whose generated extract-input contract (`AppInputContract`) subclasses the bare `Input` base, declares no `agent_json` field, and rejects extra fields, so Pydantic silently drops the forwarded `agent_json` and credentials never resolve (`PipelineContractError` / zero assets); contracts that subclass the SDK `*ExtractionInput` family or set `allow_unbounded_fields=True`/`extra="allow"` are exempt
-
 ## [0.15.0] - 2026-07-20
 
 ### Features

--- a/packages/conformance/conformance/__init__.py
+++ b/packages/conformance/conformance/__init__.py
@@ -4,4 +4,4 @@ Dev-only package.  Provides the conformance validators, remediation programs,
 and CLI for the atlan-application-sdk ecosystem.
 """
 
-__version__ = "0.16.0"
+__version__ = "0.15.0"

--- a/packages/conformance/pyproject.toml
+++ b/packages/conformance/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "atlan-application-sdk-conformance"
-version = "0.16.0"
+version = "0.15.0"
 description = "Conformance suite, remediation programs, and CLI for the Atlan Application SDK"
 license = "Apache-2.0"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -432,7 +432,7 @@ test = [
 
 [[package]]
 name = "atlan-application-sdk-conformance"
-version = "0.16.0"
+version = "0.15.0"
 source = { directory = "packages/conformance" }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
## What & why

Recovers the conformance release pipeline, which has been **failing on every conformance merge** since PR #2819.

**Root cause:** #2819 (`test-readiness scorecard generator + CI publish`) hand-edited the conformance version `0.15.0 → 0.16.0` directly in its own diff, bypassing the `bump-version-conformance` release flow. No `conformance-v0.16.0` tag was ever created and `0.16.0` was never published (PyPI latest is `0.15.0`).

`conformance_release.py` requires the declared version to have a matching `conformance-v*` tag. With `0.16.0` declared but untagged it hard-errors:

```
ERROR: tag 'conformance-v0.16.0' not found but other conformance tags exist.
```

So the release workflow failed for #2819, #2824, #2825, #2832, #2835, #2836 — **none reached the changelog**, and PR #2795 (`release v0.15.1`) is a stale pre-break artifact.

## This PR

Reverts main to the last published state:
- version `0.16.0 → 0.15.0` in `pyproject.toml`, `__init__.py`, and the root `uv.lock` conformance entry (restores the invariant *declared version == latest published tag*).
- removes the hand-written `## [Unreleased]` section #2824 added to `packages/conformance/CHANGELOG.md`. The changelog is generated by the release automation from git; the manual section fights the generator's prepend and is regenerated from the #2824 commit on the next release.

## On merge

The release workflow recomputes the next version from conventional commits since `conformance-v0.15.0` (a **minor** bump → `0.16.0`, since features landed) and regenerates a clean release PR containing every merged conformance PR.

## Merge order

⚠️ **Merge this before #2843 (`ci: guard release-owned version and changelog files`).** That guard blocks version/changelog edits off the `bump-version-*` branch and has no per-PR bypass by design, so it would flag this recovery PR if it lands first.

Follow-up (separate): #2795 will be closed as stale — merging it would downgrade to `0.15.1` and publish it.

