### PR TITLE
ci: guard release-owned version and changelog files

### DIFF
--- a/.github/scripts/guard_release_files.py
+++ b/.github/scripts/guard_release_files.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""Release-owned file guard.
+
+The version and CHANGELOG of each independently-published package in this repo
+are owned *exclusively* by that package's automated release flow, which commits
+them on a dedicated ``bump-version-*`` branch:
+
+  * conformance       -> bump-version-conformance
+                         (packages/conformance/pyproject.toml,
+                          packages/conformance/conformance/__init__.py,
+                          packages/conformance/CHANGELOG.md)
+  * contract-toolkit  -> bump-version-contract-toolkit
+                         (contract-toolkit/src/PklProject,
+                          contract-toolkit/CHANGELOG.md)
+
+A human editing any of these files on a normal branch desyncs the package from
+its published state and wedges the release automation. The motivating incident:
+a feature PR hand-bumped the conformance version to a value that was never
+tagged/published, and conformance_release.py hard-errors when the declared
+version has no matching ``conformance-v*`` tag -- so *every* later conformance
+merge failed and nothing reached the changelog. A second PR hand-edited the
+conformance CHANGELOG's ``[Unreleased]`` section, which fights the generator's
+prepend.
+
+This guard fails a PR that, off the owning ``bump-version-*`` branch:
+  * changes a package's version line, or
+  * touches a package's CHANGELOG at all.
+
+The SDK itself is intentionally NOT guarded here: its release flow
+(.github/scripts/release.py) derives the previous version from ``git describe``
+rather than requiring the declared version to have a matching tag, so a stray
+manual edit degrades gracefully instead of wedging the pipeline.
+
+Usage:
+    python3 guard_release_files.py \
+        --diff <path to a unified diff of the PR> \
+        --head-ref <PR head branch> \
+        --comment-out <path to write the sticky-comment markdown on violation>
+
+Writes ``violation`` and ``error_message`` to $GITHUB_OUTPUT (or prints
+``key=value`` lines if unset). Always exits 0 -- the calling workflow gates on
+the ``violation`` output in a separate step, mirroring pr_title_convention.py.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from dataclasses import dataclass, field
+
+# `diff --git a/<path> b/<path>` -- group 2 is the post-image path, which is
+# the file's name for edits and renames alike (deletions set it to /dev/null,
+# which never matches a guarded path).
+DIFF_GIT_RE = re.compile(r"^diff --git a/(.*?) b/(.*)$")
+
+# Version-line matchers, keyed by the file they apply to. `version =` in a
+# pyproject [project] table is unindented; the toolkit's PklProject nests it
+# under the package block, so it is indented.
+_PYPROJECT_VERSION = re.compile(r"^version\s*=")
+_PY_DUNDER_VERSION = re.compile(r"^__version__\s*=")
+_PKL_VERSION = re.compile(r"^\s+version\s*=")
+
+
+@dataclass(frozen=True)
+class Package:
+    name: str
+    bump_branch: str
+    version_files: dict  # path -> compiled regex matching its version line
+    changelog_files: tuple = field(default_factory=tuple)
+
+    def owns_branch(self, head_ref: str) -> bool:
+        """True when ``head_ref`` is this package's release branch."""
+        return head_ref == self.bump_branch or head_ref.startswith(
+            self.bump_branch + "-"
+        )
+
+
+PACKAGES = (
+    Package(
+        name="conformance",
+        bump_branch="bump-version-conformance",
+        version_files={
+            "packages/conformance/pyproject.toml": _PYPROJECT_VERSION,
+            "packages/conformance/conformance/__init__.py": _PY_DUNDER_VERSION,
+        },
+        changelog_files=("packages/conformance/CHANGELOG.md",),
+    ),
+    Package(
+        name="contract-toolkit",
+        bump_branch="bump-version-contract-toolkit",
+        version_files={
+            "contract-toolkit/src/PklProject": _PKL_VERSION,
+        },
+        changelog_files=("contract-toolkit/CHANGELOG.md",),
+    ),
+)
+
+
+def parse_diff(diff_text: str) -> dict:
+    """Map each file in a unified diff to its changed content lines.
+
+    A changed line is an added/removed line with its leading ``+``/``-``
+    stripped; the ``+++``/``---`` file headers are skipped. A file that appears
+    in the diff is always a key (even with an empty list), so callers can detect
+    "this file was touched at all" independently of *what* changed.
+    """
+    files: dict = {}
+    current = None
+    for line in diff_text.splitlines():
+        m = DIFF_GIT_RE.match(line)
+        if m:
+            current = m.group(2).strip()
+            files.setdefault(current, [])
+            continue
+        if current is None:
+            continue
+        if line.startswith("+++") or line.startswith("---"):
+            continue
+        if line.startswith("+") or line.startswith("-"):
+            files[current].append(line[1:])
+    return files
+
+
+def evaluate(changed: dict, head_ref: str) -> list:
+    """Return a list of (path, reason) violations for a parsed diff.
+
+    ``changed`` is the mapping from :func:`parse_diff`; ``head_ref`` is the PR
+    head branch.
+    """
+    violations = []
+    for pkg in PACKAGES:
+        if pkg.owns_branch(head_ref):
+            continue
+        for path, version_re in pkg.version_files.items():
+            lines = changed.get(path)
+            if lines and any(version_re.match(line) for line in lines):
+                violations.append((path, f"{pkg.name} version line"))
+        for path in pkg.changelog_files:
+            if path in changed:
+                violations.append((path, f"{pkg.name} changelog"))
+    return violations
+
+
+_COMMENT = """\
+### \U0001f512 Release-owned files can only change on the release branch
+
+This PR edits a version or `CHANGELOG` that is owned by an automated release
+flow, and it is not on that package's `bump-version-*` branch:
+
+{items}
+
+These files are generated and committed **only** by the release automation
+(`.github/workflows/*-release.yml`, which pushes the `bump-version-*` branch).
+Hand-editing them on a feature branch desyncs the package from its published
+tags and wedges the release pipeline.
+
+**What to do instead:**
+- Version bump / release: let it happen automatically. Merging a normal change
+  under the package opens (or updates) the release PR, and merging *that* PR
+  publishes and tags. You never edit the version by hand.
+- Changelog: it is regenerated from your commit subjects on release — just write
+  a clear conventional-commit PR title; don't edit `CHANGELOG.md` directly.
+
+If you are doing one-off incident recovery on these files (e.g. reverting an
+unpublished bump), that correction must land **before** this guard becomes
+required, or a repo admin must override the check — by design there is no
+per-PR bypass.
+
+Pushing a commit that drops these file changes re-runs this check and clears
+this comment automatically.
+"""
+
+_ERROR_MESSAGE = (
+    "Release-owned files (package version / CHANGELOG) may only be changed on "
+    "the owning bump-version-* branch by the release automation: {paths}"
+)
+
+
+def _write_output(key: str, value: str) -> None:
+    github_output = os.environ.get("GITHUB_OUTPUT")
+    line = f"{key}={value}"
+    if github_output:
+        with open(github_output, "a") as fh:
+            fh.write(line + "\n")
+    else:
+        print(line)
+
+
+def run(diff_path: str, head_ref: str, comment_out_path: str):
+    """Core decision logic, returned as (violation, violations) for testing."""
+    with open(diff_path) as fh:
+        diff_text = fh.read()
+
+    changed = parse_diff(diff_text)
+    violations = evaluate(changed, head_ref)
+
+    if not violations:
+        print(f"No release-owned files changed off a bump branch ({head_ref}). ✅")
+        return False, violations
+
+    for path, reason in violations:
+        print(f"Violation: {path} ({reason})")
+
+    items = "\n".join(f"- `{path}` — {reason}" for path, reason in violations)
+    with open(comment_out_path, "w") as fh:
+        fh.write(_COMMENT.format(items=items))
+
+    return True, violations
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--diff", required=True, help="Path to the PR unified diff")
+    parser.add_argument("--head-ref", default="")
+    parser.add_argument(
+        "--comment-out",
+        required=True,
+        help="Path to write the sticky-comment markdown when the PR violates the guard",
+    )
+    args = parser.parse_args()
+
+    print(f"Head branch: {args.head_ref}")
+    violation, violations = run(args.diff, args.head_ref, args.comment_out)
+
+    _write_output("violation", "true" if violation else "false")
+    _write_output(
+        "error_message",
+        _ERROR_MESSAGE.format(paths=", ".join(p for p, _ in violations))
+        if violation
+        else "",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/guard_release_files.py
+++ b/.github/scripts/guard_release_files.py
@@ -51,8 +51,9 @@ import sys
 from dataclasses import dataclass, field
 
 # `diff --git a/<path> b/<path>` -- group 2 is the post-image path, which is
-# the file's name for edits and renames alike (deletions set it to /dev/null,
-# which never matches a guarded path).
+# the file's name for edits and renames alike. For a deletion the b-side is
+# still the real path; `/dev/null` only appears in the skipped `+++` header, so
+# deleted guarded files are correctly flagged.
 DIFF_GIT_RE = re.compile(r"^diff --git a/(.*?) b/(.*)$")
 
 # Version-line matchers, keyed by the file they apply to. `version =` in a

--- a/.github/scripts/tests/test_guard_release_files.py
+++ b/.github/scripts/tests/test_guard_release_files.py
@@ -1,0 +1,236 @@
+"""Tests for .github/scripts/guard_release_files.py."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import guard_release_files as grf
+
+# ---------------------------------------------------------------------------
+# Sample diffs
+# ---------------------------------------------------------------------------
+
+
+def _diff(*hunks: str) -> str:
+    return "\n".join(hunks) + "\n"
+
+
+CONFORMANCE_VERSION_DIFF = _diff(
+    "diff --git a/packages/conformance/pyproject.toml b/packages/conformance/pyproject.toml",
+    "index 111..222 100644",
+    "--- a/packages/conformance/pyproject.toml",
+    "+++ b/packages/conformance/pyproject.toml",
+    "@@ -5,7 +5,7 @@",
+    ' name = "atlan-application-sdk-conformance"',
+    '-version = "0.15.0"',
+    '+version = "0.16.0"',
+    ' description = "..."',
+)
+
+CONFORMANCE_DUNDER_DIFF = _diff(
+    "diff --git a/packages/conformance/conformance/__init__.py b/packages/conformance/conformance/__init__.py",
+    "--- a/packages/conformance/conformance/__init__.py",
+    "+++ b/packages/conformance/conformance/__init__.py",
+    "@@ -7 +7 @@",
+    '-__version__ = "0.15.0"',
+    '+__version__ = "0.16.0"',
+)
+
+CONFORMANCE_CHANGELOG_DIFF = _diff(
+    "diff --git a/packages/conformance/CHANGELOG.md b/packages/conformance/CHANGELOG.md",
+    "--- a/packages/conformance/CHANGELOG.md",
+    "+++ b/packages/conformance/CHANGELOG.md",
+    "@@ -3,0 +4,3 @@",
+    "+## [Unreleased]",
+    "+",
+    "+- hand-written note",
+)
+
+TOOLKIT_VERSION_DIFF = _diff(
+    "diff --git a/contract-toolkit/src/PklProject b/contract-toolkit/src/PklProject",
+    "--- a/contract-toolkit/src/PklProject",
+    "+++ b/contract-toolkit/src/PklProject",
+    "@@ -8 +8 @@",
+    '-  version = "0.19.0"',
+    '+  version = "0.20.0"',
+)
+
+TOOLKIT_CHANGELOG_DIFF = _diff(
+    "diff --git a/contract-toolkit/CHANGELOG.md b/contract-toolkit/CHANGELOG.md",
+    "--- a/contract-toolkit/CHANGELOG.md",
+    "+++ b/contract-toolkit/CHANGELOG.md",
+    "@@ -1 +1,2 @@",
+    "+manual edit",
+)
+
+# A dependency bump to the conformance pyproject that leaves the version line
+# untouched must NOT trip the guard.
+CONFORMANCE_DEP_ONLY_DIFF = _diff(
+    "diff --git a/packages/conformance/pyproject.toml b/packages/conformance/pyproject.toml",
+    "--- a/packages/conformance/pyproject.toml",
+    "+++ b/packages/conformance/pyproject.toml",
+    "@@ -20,7 +20,7 @@",
+    " dependencies = [",
+    '-    "jinja2>=3.1.0",',
+    '+    "jinja2>=3.1.5",',
+    " ]",
+)
+
+UNRELATED_DIFF = _diff(
+    "diff --git a/application_sdk/foo.py b/application_sdk/foo.py",
+    "--- a/application_sdk/foo.py",
+    "+++ b/application_sdk/foo.py",
+    "@@ -1 +1 @@",
+    "-x = 1",
+    "+x = 2",
+)
+
+# The SDK's own version is deliberately not guarded here.
+SDK_VERSION_DIFF = _diff(
+    "diff --git a/pyproject.toml b/pyproject.toml",
+    "--- a/pyproject.toml",
+    "+++ b/pyproject.toml",
+    "@@ -3 +3 @@",
+    '-version = "3.24.0"',
+    '+version = "3.25.0"',
+)
+
+
+# ---------------------------------------------------------------------------
+# parse_diff
+# ---------------------------------------------------------------------------
+
+
+class TestParseDiff:
+    def test_captures_changed_lines_without_prefix(self):
+        parsed = grf.parse_diff(CONFORMANCE_VERSION_DIFF)
+        path = "packages/conformance/pyproject.toml"
+        assert path in parsed
+        assert 'version = "0.15.0"' in parsed[path]
+        assert 'version = "0.16.0"' in parsed[path]
+
+    def test_skips_file_header_lines(self):
+        parsed = grf.parse_diff(CONFORMANCE_VERSION_DIFF)
+        lines = parsed["packages/conformance/pyproject.toml"]
+        assert not any(line.startswith("++ ") for line in lines)
+        assert not any("a/packages/conformance" in line for line in lines)
+
+    def test_touched_file_is_a_key_even_without_content(self):
+        parsed = grf.parse_diff(
+            _diff(
+                "diff --git a/packages/conformance/CHANGELOG.md b/packages/conformance/CHANGELOG.md",
+                "old mode 100644",
+                "new mode 100755",
+            )
+        )
+        assert "packages/conformance/CHANGELOG.md" in parsed
+
+    def test_multiple_files(self):
+        parsed = grf.parse_diff(CONFORMANCE_VERSION_DIFF + CONFORMANCE_CHANGELOG_DIFF)
+        assert "packages/conformance/pyproject.toml" in parsed
+        assert "packages/conformance/CHANGELOG.md" in parsed
+
+
+# ---------------------------------------------------------------------------
+# evaluate -- violations off the bump branch
+# ---------------------------------------------------------------------------
+
+
+class TestViolationsOffBumpBranch:
+    @pytest.mark.parametrize(
+        "diff,expected_path",
+        [
+            (CONFORMANCE_VERSION_DIFF, "packages/conformance/pyproject.toml"),
+            (
+                CONFORMANCE_DUNDER_DIFF,
+                "packages/conformance/conformance/__init__.py",
+            ),
+            (CONFORMANCE_CHANGELOG_DIFF, "packages/conformance/CHANGELOG.md"),
+            (TOOLKIT_VERSION_DIFF, "contract-toolkit/src/PklProject"),
+            (TOOLKIT_CHANGELOG_DIFF, "contract-toolkit/CHANGELOG.md"),
+        ],
+    )
+    def test_flags_release_owned_edits(self, diff, expected_path):
+        violations = grf.evaluate(grf.parse_diff(diff), "feature/whatever")
+        assert expected_path in [p for p, _ in violations]
+
+    def test_version_and_changelog_together(self):
+        parsed = grf.parse_diff(CONFORMANCE_VERSION_DIFF + CONFORMANCE_CHANGELOG_DIFF)
+        paths = [p for p, _ in grf.evaluate(parsed, "feature/x")]
+        assert "packages/conformance/pyproject.toml" in paths
+        assert "packages/conformance/CHANGELOG.md" in paths
+
+
+# ---------------------------------------------------------------------------
+# evaluate -- allowed cases
+# ---------------------------------------------------------------------------
+
+
+class TestAllowed:
+    def test_conformance_bump_branch_allows_conformance_files(self):
+        parsed = grf.parse_diff(
+            CONFORMANCE_VERSION_DIFF
+            + CONFORMANCE_DUNDER_DIFF
+            + CONFORMANCE_CHANGELOG_DIFF
+        )
+        assert grf.evaluate(parsed, "bump-version-conformance") == []
+
+    def test_toolkit_bump_branch_allows_toolkit_files(self):
+        parsed = grf.parse_diff(TOOLKIT_VERSION_DIFF + TOOLKIT_CHANGELOG_DIFF)
+        assert grf.evaluate(parsed, "bump-version-contract-toolkit") == []
+
+    def test_conformance_bump_branch_does_not_exempt_toolkit_files(self):
+        # A branch may only touch the files of the package it releases.
+        parsed = grf.parse_diff(TOOLKIT_VERSION_DIFF)
+        violations = grf.evaluate(parsed, "bump-version-conformance")
+        assert "contract-toolkit/src/PklProject" in [p for p, _ in violations]
+
+    def test_dependency_edit_leaves_version_line_untouched(self):
+        parsed = grf.parse_diff(CONFORMANCE_DEP_ONLY_DIFF)
+        assert grf.evaluate(parsed, "feature/bump-deps") == []
+
+    def test_unrelated_source_change(self):
+        assert grf.evaluate(grf.parse_diff(UNRELATED_DIFF), "feature/x") == []
+
+    def test_sdk_version_is_not_guarded(self):
+        assert grf.evaluate(grf.parse_diff(SDK_VERSION_DIFF), "feature/x") == []
+
+
+# ---------------------------------------------------------------------------
+# run -- output + sticky comment
+# ---------------------------------------------------------------------------
+
+
+class TestRun:
+    def test_run_clean(self, tmp_path):
+        diff = tmp_path / "pr.diff"
+        diff.write_text(UNRELATED_DIFF)
+        comment = tmp_path / "comment.md"
+        violation, violations = grf.run(str(diff), "feature/x", str(comment))
+        assert violation is False
+        assert violations == []
+        assert not comment.exists()
+
+    def test_run_violation_writes_comment(self, tmp_path):
+        diff = tmp_path / "pr.diff"
+        diff.write_text(CONFORMANCE_VERSION_DIFF)
+        comment = tmp_path / "comment.md"
+        violation, _ = grf.run(str(diff), "feature/x", str(comment))
+        assert violation is True
+        assert comment.exists()
+        body = comment.read_text()
+        assert "packages/conformance/pyproject.toml" in body
+        assert "release branch" in body
+
+    def test_run_violation_suppressed_on_bump_branch(self, tmp_path):
+        diff = tmp_path / "pr.diff"
+        diff.write_text(CONFORMANCE_VERSION_DIFF)
+        comment = tmp_path / "comment.md"
+        violation, _ = grf.run(str(diff), "bump-version-conformance", str(comment))
+        assert violation is False
+        assert not comment.exists()

--- a/.github/scripts/tests/test_guard_release_files.py
+++ b/.github/scripts/tests/test_guard_release_files.py
@@ -190,6 +190,13 @@ class TestAllowed:
         violations = grf.evaluate(parsed, "bump-version-conformance")
         assert "contract-toolkit/src/PklProject" in [p for p, _ in violations]
 
+    def test_toolkit_bump_branch_does_not_exempt_conformance_files(self):
+        # The symmetric inverse: the toolkit release branch must not exempt
+        # conformance's release-owned files.
+        parsed = grf.parse_diff(CONFORMANCE_VERSION_DIFF)
+        violations = grf.evaluate(parsed, "bump-version-contract-toolkit")
+        assert "packages/conformance/pyproject.toml" in [p for p, _ in violations]
+
     def test_dependency_edit_leaves_version_line_untouched(self):
         parsed = grf.parse_diff(CONFORMANCE_DEP_ONLY_DIFF)
         assert grf.evaluate(parsed, "feature/bump-deps") == []

--- a/.github/workflows/release-files-guard.yaml
+++ b/.github/workflows/release-files-guard.yaml
@@ -1,0 +1,101 @@
+name: Release Files Guard
+
+# Fails a PR that hand-edits a release-owned file (a package version line or a
+# package CHANGELOG) off that package's `bump-version-*` branch. Those files are
+# generated and committed only by the release automation; editing them on a
+# feature branch desyncs the package from its published tags and wedges the
+# release pipeline (the motivating incident: a feature PR hand-bumped the
+# conformance version to a never-tagged value, and conformance_release.py
+# hard-errors when the declared version has no matching conformance-v* tag, so
+# every later conformance merge failed).
+#
+# Covers conformance and contract-toolkit (both use a release script that
+# requires the declared version to have a matching tag). The SDK is intentionally
+# excluded: release.py derives the previous version from `git describe`, so a
+# stray manual edit degrades gracefully instead of wedging the pipeline.
+#
+# The decision logic lives in .github/scripts/guard_release_files.py
+# (unit-tested in .github/scripts/tests/test_guard_release_files.py), per
+# docs/standards/ci.md: a workflow `run:` block must not contain branching shell.
+#
+# Runs on every PR (no path filter) and no-ops when no guarded file changed, so
+# it can be a required check without sitting pending forever on unrelated PRs.
+# `merge_group` runs are a passing no-op — the same pattern pr-title-convention
+# uses so this can be REQUIRED without blocking the merge queue.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+  merge_group:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: release-files-guard-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  guard:
+    name: Guard release-owned files
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout scripts
+        if: github.event_name == 'pull_request'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          sparse-checkout: .github/scripts
+          sparse-checkout-cone-mode: false
+
+      - name: Evaluate PR diff against the guard
+        id: detect
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_REF: ${{ github.head_ref }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          echo "PR #${PR_NUMBER} (${HEAD_REF})"
+          gh pr diff "${PR_NUMBER}" --repo "${REPO}" > pr.diff
+          python3 .github/scripts/guard_release_files.py \
+            --diff pr.diff \
+            --head-ref "${HEAD_REF}" \
+            --comment-out release-files-comment.md
+
+      - name: Post sticky comment on violation
+        if: >-
+          github.event_name == 'pull_request'
+          && steps.detect.outputs.violation == 'true'
+          && github.event.pull_request.head.repo.fork == false
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
+        with:
+          header: release-files-guard
+          path: release-files-comment.md
+
+      - name: Clear sticky comment when resolved
+        if: >-
+          github.event_name == 'pull_request'
+          && steps.detect.outputs.violation == 'false'
+          && github.event.pull_request.head.repo.fork == false
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
+        with:
+          header: release-files-guard
+          delete: true
+
+      - name: Fail on violation
+        if: steps.detect.outputs.violation == 'true'
+        env:
+          ERROR_MESSAGE: ${{ steps.detect.outputs.error_message }}
+        run: |
+          echo "::error title=Release-owned file edited off the release branch::${ERROR_MESSAGE}"
+          exit 1
+
+      - name: Merge queue no-op
+        if: github.event_name == 'merge_group'
+        run: |
+          echo "merge_group event — release-owned files already validated at PR time; passing."


### PR DESCRIPTION
## What & why

Prevents a recurrence of the incident fixed in #2842: a feature PR hand-bumped the conformance version to a value that was never tagged/published, which **wedged the entire conformance release pipeline** (`conformance_release.py` hard-errors when the declared version has no matching `conformance-v*` tag), and a second PR hand-edited the CHANGELOG `[Unreleased]` section, which fights the generator's prepend.

## This PR

Adds a guard that **fails any PR editing a release-owned file off that package's `bump-version-*` branch**:

| Package | Guarded files | Owning branch |
|---|---|---|
| conformance | `pyproject.toml` / `__init__.py` version line, `CHANGELOG.md` | `bump-version-conformance` |
| contract-toolkit | `src/PklProject` version line, `CHANGELOG.md` | `bump-version-contract-toolkit` |

- Version files are matched at the **version line** (dependency edits to `pyproject.toml` are unaffected); CHANGELOGs are guarded against **any** edit.
- The **SDK is intentionally excluded** — its `release.py` derives the previous version from `git describe` rather than requiring a matching tag, so a stray edit degrades gracefully instead of wedging the pipeline.
- **The `bump-version-*` branch is the only exempt path — there is deliberately no per-PR bypass.**

## Design

Mirrors the existing `pr-title-convention` guard exactly:
- Decision logic in `.github/scripts/guard_release_files.py` (per `docs/standards/ci.md` — no branching shell in workflow YAML), unit-tested in `.github/scripts/tests/test_guard_release_files.py` (19 cases, run by the *CI script tests* workflow).
- Workflow runs on every PR, no-ops when no guarded file changed, and is a `merge_group` no-op — so it is safe to add to branch protection as a **required check**.

## Follow-ups (not in this PR)

- Add `Release Files Guard` to `main` branch protection as a required check to make it blocking.
- ⚠️ Merge **after** #2842 — this guard would otherwise flag that recovery PR (which edits the version/changelog off a bump branch), and there is no bypass.
