### PR TITLE
ci(conformance): fan out Renovate to consumers on release

### DIFF
--- a/.github/workflows/conformance-publish.yml
+++ b/.github/workflows/conformance-publish.yml
@@ -86,3 +86,34 @@ jobs:
       # No GitHub Release is created: conformance-v* releases would interleave
       # with SDK v* releases on the repo's releases page, which is confusing.
       # The annotated tag, PyPI publish, and CHANGELOG.md are the authoritative record.
+
+  fan-out:
+    # After a conformance release, trigger the self-hosted Renovate runner so
+    # consumers pick up the new atlan-application-sdk-conformance version within
+    # minutes rather than waiting for the next scheduled (4-hourly) run. Consumers
+    # pin conformance in-range, so this lands as an auto-merging lockFileMaintenance
+    # PR. Skipped automatically when `publish` is skipped (non-release PR) or fails.
+    name: Fan out Renovate to consumers
+    needs: [publish]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Mint fleet App token
+        id: app-token
+        continue-on-error: true
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          app-id: ${{ secrets.FLEET_APP_ID }}
+          private-key: ${{ secrets.FLEET_APP_PRIVATE_KEY }}
+          owner: atlanhq
+          repositories: application-sdk
+      - name: Trigger the self-hosted Renovate runner
+        # No dry_run/repos overrides: inherits renovate.yaml's live defaults (full
+        # discovery, dry_run=null). Soft-fail so a fan-out hiccup never fails the
+        # release — the 4-hourly schedule is the backstop.
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.ORG_PAT_GITHUB }}
+        run: |
+          gh workflow run renovate.yaml --repo atlanhq/application-sdk \
+          || echo "::warning::Could not trigger renovate.yaml — consumers will update on the next scheduled run."

--- a/.github/workflows/contract-toolkit-publish.yml
+++ b/.github/workflows/contract-toolkit-publish.yml
@@ -159,8 +159,9 @@ jobs:
           owner: atlanhq
           repositories: application-sdk
       - name: Trigger the self-hosted Renovate runner
-        # Inherits renovate.yaml defaults (full discovery; dry_run=full until PR2
-        # Stage 3 flips it live). Soft-fail so a fan-out hiccup never fails publish.
+        # Inherits renovate.yaml's live defaults (full discovery, dry_run=null).
+        # Soft-fail so a fan-out hiccup never fails publish — the 4-hourly
+        # schedule is the backstop.
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.ORG_PAT_GITHUB }}
         run: |

--- a/.github/workflows/tag-and-publish.yaml
+++ b/.github/workflows/tag-and-publish.yaml
@@ -126,10 +126,9 @@ jobs:
           owner: atlanhq
           repositories: application-sdk
       - name: Trigger the self-hosted Renovate runner
-        # No dry_run/repos overrides: inherits renovate.yaml's defaults (full
-        # discovery; dry_run=full until PR2 Stage 3 flips it live). So this is an
-        # inert rehearsal today and becomes the real post-release fan-out at
-        # go-live. Soft-fail so a fan-out hiccup never fails the release.
+        # No dry_run/repos overrides: inherits renovate.yaml's live defaults (full
+        # discovery, dry_run=null). Soft-fail so a fan-out hiccup never fails the
+        # release — the 4-hourly schedule is the backstop.
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.ORG_PAT_GITHUB }}
         run: |


### PR DESCRIPTION
## What

`conformance-publish.yml` was the **only** package publisher without a post-release fan-out job, so a new `atlan-application-sdk-conformance` version reached consumers only on the next scheduled (4-hourly) fleet sweep. SDK (`tag-and-publish.yaml`) and contract-toolkit (`contract-toolkit-publish.yml`) already dispatch the self-hosted Renovate runner on publish.

This adds the same `fan-out` job to `conformance-publish.yml` so **all three** releases (SDK, conformance, contract-toolkit) propagate immediately.

## Behaviour

- `needs: [publish]` → skipped on non-release PRs and never runs if publish fails.
- Mints the `atlan-app-fleet` App token (`continue-on-error`, `ORG_PAT_GITHUB` fallback) and soft-fails the `gh workflow run renovate.yaml` dispatch, so a fan-out hiccup never fails the release.
- Inherits `renovate.yaml`'s live defaults (full discovery, `dry_run=null`). Consumers pin conformance in-range, so the sweep lands it as an auto-merging `lockFileMaintenance` PR.
- The 4-hourly schedule remains the backstop (covers the brief PyPI `/simple` propagation window after publish).

## Also

Refreshes now-stale comments in the SDK and contract-toolkit fan-out jobs that still described the dispatch as an inert `dry_run=full` rehearsal pending go-live — the fleet runner is live (`dry_run=null`).

## Testing

- `python3 -c "import yaml; ..."` confirms all three workflows parse and each `fan-out` job is wired to its publish/release job.
- `uv run pre-commit run --files <the three workflows>` passes.
- No `.github/scripts/` + pytest needed: the fan-out is straight-line (`gh workflow run … || echo`), no branching — consistent with the two existing jobs.