### PR TITLE
ci(tests): run integration tests only in the merge queue

### DIFF
--- a/.github/workflows/tests-reusable.yaml
+++ b/.github/workflows/tests-reusable.yaml
@@ -29,10 +29,23 @@ name: tests-reusable
 #     it was previously delegated to e2e-full-reusable.yaml, now folded in so
 #     the whole suite is one reusable + one Tests Gate)
 #
+# Test tiering (see the `tests` job's test-paths):
+#   pull_request          → tests/unit/ only. Fast per-commit signal (seconds
+#                           of tests + uv sync); no testcontainers / source
+#                           infra spun up, so the PR loop stays cheap.
+#   merge_group / push    → full suite (unit + integration, auto-discovered).
+#                           Integration (testcontainers / services-script,
+#                           exercising the real extraction workflow) runs on
+#                           the exact batched state that will land — the one
+#                           point a regression could actually ship — and is
+#                           re-run in place if the base moves under the queue.
+#   e2e (label/dispatch)  → full-DAG against a real tenant (the `e2e` job).
+#   A caller-supplied `test-paths` overrides this tiering entirely.
+#
 # GitHub check name hierarchy (caller → tests-reusable):
-#   Tests / tests / Unit and integration  (pull_request)
-#   Tests / tests / End-to-end            (pull_request)
-#   Tests / tests / Tests Gate            (pull_request)
+#   Tests / tests / Unit and integration  (unit only on pull_request; + integration on merge_group)
+#   Tests / tests / End-to-end            (label / dispatch)
+#   Tests / tests / Tests Gate            (aggregator — the required check)
 #
 # Nested reusable depth: caller → tests-reusable = 2 (GitHub max is 4).
 # secrets: inherit chains from the caller; the inlined e2e job reads secrets.*.
@@ -58,9 +71,12 @@ on:
         type: string
         default: ""
         description: |
-          Space-separated pytest target paths.  Empty = auto-discover (honours
-          testpaths in pyproject.toml).  Override to scope to a subset
-          (e.g. "tests/unit/ tests/integration/").
+          Space-separated pytest target paths.  Empty = event-tiered default
+          (see the `tests` job): tests/unit/ on pull_request, full auto-
+          discovered suite (honouring testpaths in pyproject.toml) on
+          merge_group / push.  Set a non-empty value to override the tiering
+          and force an exact path set on every event (e.g. "tests/unit/
+          tests/integration/").
       pytest-args:
         required: false
         type: string
@@ -178,12 +194,20 @@ jobs:
         if: inputs.distinct-id != ''
         run: echo "Dispatched; SDK ref=${{ inputs.application-sdk-ref }}"
 
-      - name: Run unit + integration tests
+      # Tiered by event so the expensive integration tier runs only where a
+      # regression could actually ship (see the "Test tiering" note in the
+      # header):
+      #   pull_request          → tests/unit/ only        (fast per-commit signal)
+      #   merge_group/push/etc. → '' = auto-discover full suite (unit + integration)
+      # A caller-supplied test-paths always wins (explicit override). The
+      # ternary is a workflow expression in a `with:` value — not inlined
+      # conditional shell — so it stays within the CI authoring rule.
+      - name: Run tests (unit on PRs; unit + integration in the merge queue)
         id: tests
         uses: atlanhq/application-sdk/.github/actions/connector-integration-tests@main
         with:
           app-name: ${{ inputs.app-name }}
-          test-paths: ${{ inputs.test-paths }}
+          test-paths: ${{ inputs.test-paths != '' && inputs.test-paths || (github.event_name == 'pull_request' && 'tests/unit/' || '') }}
           pytest-args: ${{ inputs.pytest-args }}
           services-script: ${{ inputs.services-script }}
           application-sdk-ref: ${{ inputs.application-sdk-ref }}


### PR DESCRIPTION
## What

Tier the reusable tests workflow (`tests-reusable.yaml`) by event so the expensive integration tier runs only where a regression could actually ship:

- **`pull_request` → `tests/unit/` only** — fast per-commit signal (seconds of tests + `uv sync`); no testcontainers / source infra spun up on the PR loop.
- **`merge_group` / `push` → full suite** (unit + integration, auto-discovered) — *identical to today's behavior*. Integration (testcontainers / services-script exercising the real extraction workflow) runs on the exact batched state that will land, and is re-run in place if the base moves under the queue.
- A caller-supplied `test-paths` still overrides the tiering entirely.

The `Tests Gate` aggregator remains the single required check, so **no branch-protection changes are needed**: a PR goes green on unit; an integration failure ejects it from the merge queue rather than landing on `main`.

## Why

The genuinely expensive tier (full-DAG e2e vs a real tenant) is already deferred to the `e2e` label / release PR. This gives the fleet **one consistent pattern** — unit on every commit, integration in the merge queue — rather than every app running its full integration suite on every push. Canonical apps with purely hermetic testcontainers see a modest win (~2 min → the PR drops to ~40–50s); apps that stand up heavier infra outside the action see a much larger one.

### Empirical timing (canonical apps, recent CI runs)

| App | Unit tests | Integration tests |
|---|---|---|
| mysql | 132 tests · 4.0s exec | 23 tests · 114s exec |
| metabase | 343 tests · 2.9s exec | 10 tests · 66s exec |

Unit suites are hundreds of cases but seconds of execution; integration is a handful of cases but the entire cost (testcontainer boot + real extraction workflow).

## Blast radius / follow-ups

- **Fleet-wide behavior change** — every connector pinning the reusable `@main` stops running integration on PRs once this merges. Intended, but the thing to weigh in review.
- **App-repo READMEs will drift** — e.g. `atlan-mysql-app/tests/README.md` says integration runs "every PR"; those (and any bootstrap template) should be updated separately when this lands.
- **`services-script` apps (openapi)**: the hook still fires on unit-only PR runs — harmless, minor future optimization.

Companion: `site/release-process/` slide 5 is being updated to depict this split (separate change on `main`).