### PR TITLE
ci(tests): split reusable Tests check into separate Unit and Integration

### DIFF
--- a/.github/actions/connector-integration-tests/action.yaml
+++ b/.github/actions/connector-integration-tests/action.yaml
@@ -189,6 +189,18 @@ inputs:
       inside a reusable/composite workflow: they resolve against the
       reusable's repo, not the caller's.
     default: ""
+  emit-scorecard:
+    required: false
+    description: |
+      Whether to generate the test-readiness scorecard from this run's junit +
+      coverage evidence. Default "true" for direct callers that run the whole
+      suite in one job (the scorecard's per-tier junit slicing then sees every
+      tier). tests-reusable.yaml sets this to "false" for its split Integration
+      job: with unit and integration on separate runners this job's junit is
+      integration-only, so an inline scorecard would misreport the unit tier as
+      absent. Per-tier scorecard aggregation across both jobs lands in a
+      follow-up (per-tier coverage in the conformance package).
+    default: "true"
 
 runs:
   using: "composite"
@@ -395,7 +407,7 @@ runs:
     # rather than failing the job — the scorecard is observational, never a gate.
     # All scoring logic lives in the tested Python CLI; this stays straight-line.
     - name: Generate test-readiness scorecard
-      if: always()
+      if: always() && inputs.emit-scorecard == 'true'
       shell: bash
       env:
         REPO: ${{ github.repository }}

--- a/.github/actions/connector-unit-tests/action.yaml
+++ b/.github/actions/connector-unit-tests/action.yaml
@@ -39,6 +39,14 @@ inputs:
       step. CLI flag overrides `[tool.coverage.report].fail_under` in the
       consumer's pyproject.toml.
     default: "60"
+  application-sdk-ref:
+    required: false
+    description: |
+      Branch/SHA of atlanhq/application-sdk to pin before running tests.
+      Empty = use the lockfile version. Used by cross-repo dispatch from
+      application-sdk PRs so the unit tier exercises the SDK branch under
+      review too — parity with connector-integration-tests.
+    default: ""
 
 runs:
   using: "composite"
@@ -47,6 +55,23 @@ runs:
       uses: atlanhq/application-sdk/.github/actions/setup-deps@main
       with:
         python-version: ${{ inputs.python-version }}
+
+    - name: Pin application-sdk to dispatched ref
+      if: inputs.application-sdk-ref != ''
+      shell: bash
+      env:
+        SDK_REF: ${{ inputs.application-sdk-ref }}
+      # Reuse the integration action's repin script (a generic pyproject
+      # [tool.uv.sources] rewriter, not integration-specific) rather than
+      # keeping a third copy. Both actions are checked out together from the
+      # application-sdk tree, so the sibling path resolves — the same
+      # cross-action-file pattern connector-integration-tests already relies on
+      # for ../../scripts/ and ../../../application_sdk/version.py.
+      run: |
+        REPIN="${{ github.action_path }}/../connector-integration-tests/repin-application-sdk.sh"
+        chmod +x "$REPIN"
+        "$REPIN"
+        uv sync --all-extras --all-groups
 
     - name: Run unit tests with coverage
       id: tests

--- a/.github/actions/verify-test-gate/action.yaml
+++ b/.github/actions/verify-test-gate/action.yaml
@@ -17,6 +17,12 @@ inputs:
       pass: the job is skipped on pull_request and when the connector has no
       integration suite.
     required: true
+  detect-integration-result:
+    description: |
+      needs.detect-integration.result (the suite-detection job gating the
+      integration tier). "skipped" (pull_request) and "success" are passes; a
+      "failure" must fail the gate rather than silently skip integration.
+    required: true
   discover-e2e-result:
     description: needs.discover-e2e.result (skipped = e2e not requested).
     required: true
@@ -51,6 +57,7 @@ runs:
       env:
         UNIT_RESULT: ${{ inputs.unit-result }}
         INTEGRATION_RESULT: ${{ inputs.integration-result }}
+        DETECT_INTEGRATION_RESULT: ${{ inputs.detect-integration-result }}
         DISCOVER_E2E_RESULT: ${{ inputs.discover-e2e-result }}
         E2E_RESULT: ${{ inputs.e2e-result }}
       run: |
@@ -58,5 +65,6 @@ runs:
         python3 "${{ github.action_path }}/verify_test_gate.py" \
           --unit "$UNIT_RESULT" \
           --integration "$INTEGRATION_RESULT" \
+          --detect-integration "$DETECT_INTEGRATION_RESULT" \
           --discover-e2e "$DISCOVER_E2E_RESULT" \
           --e2e "$E2E_RESULT" >> "$GITHUB_OUTPUT"

--- a/.github/actions/verify-test-gate/action.yaml
+++ b/.github/actions/verify-test-gate/action.yaml
@@ -8,8 +8,14 @@ description: |
   Co-located driver, checked out with the action in consumer repos.
 
 inputs:
-  tests-result:
-    description: needs.tests.result (unit + integration job).
+  unit-result:
+    description: needs.unit.result (unit-tests job; runs on every event).
+    required: true
+  integration-result:
+    description: |
+      needs.integration.result (integration-tests job). "skipped" is a valid
+      pass: the job is skipped on pull_request and when the connector has no
+      integration suite.
     required: true
   discover-e2e-result:
     description: needs.discover-e2e.result (skipped = e2e not requested).
@@ -22,9 +28,12 @@ outputs:
   passed:
     description: '"true" when every required job passed, else "false".'
     value: ${{ steps.gate.outputs.passed }}
-  tests-status:
-    description: Human-readable status for the tests row.
-    value: ${{ steps.gate.outputs.tests-status }}
+  unit-status:
+    description: Human-readable status for the unit row.
+    value: ${{ steps.gate.outputs.unit-status }}
+  integration-status:
+    description: Human-readable status for the integration row.
+    value: ${{ steps.gate.outputs.integration-status }}
   e2e-status:
     description: Human-readable status for the e2e row.
     value: ${{ steps.gate.outputs.e2e-status }}
@@ -40,12 +49,14 @@ runs:
       shell: bash
       # Route job results through env (quoted below), not inline ${{ }}.
       env:
-        TESTS_RESULT: ${{ inputs.tests-result }}
+        UNIT_RESULT: ${{ inputs.unit-result }}
+        INTEGRATION_RESULT: ${{ inputs.integration-result }}
         DISCOVER_E2E_RESULT: ${{ inputs.discover-e2e-result }}
         E2E_RESULT: ${{ inputs.e2e-result }}
       run: |
         set -euo pipefail
         python3 "${{ github.action_path }}/verify_test_gate.py" \
-          --tests "$TESTS_RESULT" \
+          --unit "$UNIT_RESULT" \
+          --integration "$INTEGRATION_RESULT" \
           --discover-e2e "$DISCOVER_E2E_RESULT" \
           --e2e "$E2E_RESULT" >> "$GITHUB_OUTPUT"

--- a/.github/actions/verify-test-gate/verify_test_gate.py
+++ b/.github/actions/verify-test-gate/verify_test_gate.py
@@ -7,7 +7,10 @@ the enforced result can never drift.
 
 Gate passes iff:
 
-  * ``tests`` (unit + integration) succeeded, AND
+  * ``unit`` tests succeeded (the per-commit tier; runs on every event), AND
+  * ``integration`` tests succeeded OR were skipped (skipped is legitimate: the
+    job is skipped on pull_request — the unit tier is the PR signal — and when
+    the connector ships no integration suite), AND
   * e2e discovery succeeded OR was skipped (skipped = e2e not requested; a
     *failed* discovery means e2e was requested but no suites were found), AND
   * the e2e matrix succeeded OR was skipped (matrix aggregate is success only
@@ -31,11 +34,16 @@ import sys
 _OK_OPTIONAL = ("success", "skipped")
 
 
-def evaluate(tests: str, discover_e2e: str, e2e: str) -> list[str]:
+def evaluate(unit: str, integration: str, discover_e2e: str, e2e: str) -> list[str]:
     """Return human-readable failure reasons (empty ⇒ the gate passes)."""
     errors: list[str] = []
-    if tests != "success":
-        errors.append(f"tests job did not succeed (result={tests})")
+    if unit != "success":
+        errors.append(f"unit tests did not succeed (result={unit})")
+    # Integration is optional-by-skip: the job is intentionally skipped on
+    # pull_request and when the connector has no integration suite. Any result
+    # other than success/skipped (failure, cancelled, timed_out) fails the gate.
+    if integration not in _OK_OPTIONAL:
+        errors.append(f"integration tests did not succeed (result={integration})")
     if discover_e2e not in _OK_OPTIONAL:
         errors.append(f"e2e discovery did not succeed (result={discover_e2e})")
     if e2e not in _OK_OPTIONAL:
@@ -51,11 +59,19 @@ def evaluate(tests: str, discover_e2e: str, e2e: str) -> list[str]:
     return errors
 
 
-def _tests_status(tests: str) -> str:
-    if tests == "success":
+def _unit_status(unit: str) -> str:
+    if unit == "success":
         return "✅ Passed"
-    if tests == "skipped":
+    if unit == "skipped":
         return "⊘ Skipped"
+    return "❌ Failed"
+
+
+def _integration_status(integration: str) -> str:
+    if integration == "success":
+        return "✅ Passed"
+    if integration == "skipped":
+        return "⊘ Skipped — PRs, or no integration suite (runs in merge queue)"
     return "❌ Failed"
 
 
@@ -73,12 +89,13 @@ def _e2e_status(discover_e2e: str, e2e: str) -> str:
     return "❌ Failed"
 
 
-def render(tests: str, discover_e2e: str, e2e: str) -> dict[str, str]:
+def render(unit: str, integration: str, discover_e2e: str, e2e: str) -> dict[str, str]:
     """Compute the gate's outputs: pass/fail + the display status strings."""
-    errors = evaluate(tests, discover_e2e, e2e)
+    errors = evaluate(unit, integration, discover_e2e, e2e)
     return {
         "passed": "true" if not errors else "false",
-        "tests-status": _tests_status(tests),
+        "unit-status": _unit_status(unit),
+        "integration-status": _integration_status(integration),
         "e2e-status": _e2e_status(discover_e2e, e2e),
         "overall-status": "✅ All passed" if not errors else "❌ Some failed",
     }
@@ -86,7 +103,8 @@ def render(tests: str, discover_e2e: str, e2e: str) -> dict[str, str]:
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Evaluate + render the Tests Gate.")
-    parser.add_argument("--tests", required=True, help="needs.tests.result")
+    parser.add_argument("--unit", required=True, help="needs.unit.result")
+    parser.add_argument("--integration", required=True, help="needs.integration.result")
     parser.add_argument(
         "--discover-e2e", required=True, help="needs.discover-e2e.result"
     )
@@ -95,10 +113,12 @@ def main(argv: list[str] | None = None) -> int:
 
     # Annotate each failure reason (shows on the gate step regardless of the
     # zero exit; the job's enforce step turns `passed=false` into a red check).
-    for reason in evaluate(args.tests, args.discover_e2e, args.e2e):
+    for reason in evaluate(args.unit, args.integration, args.discover_e2e, args.e2e):
         print(f"::error::{reason}", file=sys.stderr)
 
-    for key, value in render(args.tests, args.discover_e2e, args.e2e).items():
+    for key, value in render(
+        args.unit, args.integration, args.discover_e2e, args.e2e
+    ).items():
         print(f"{key}={value}")
     return 0
 

--- a/.github/actions/verify-test-gate/verify_test_gate.py
+++ b/.github/actions/verify-test-gate/verify_test_gate.py
@@ -8,6 +8,10 @@ the enforced result can never drift.
 Gate passes iff:
 
   * ``unit`` tests succeeded (the per-commit tier; runs on every event), AND
+  * ``detect-integration`` (the suite-detection job that gates the integration
+    tier) succeeded OR was skipped (skipped = pull_request; a *failed* detection
+    must not be indistinguishable from "no suite" — otherwise a checkout/glob
+    flake silently skips integration and greens the gate), AND
   * ``integration`` tests succeeded OR were skipped (skipped is legitimate: the
     job is skipped on pull_request — the unit tier is the PR signal — and when
     the connector ships no integration suite), AND
@@ -15,6 +19,14 @@ Gate passes iff:
     *failed* discovery means e2e was requested but no suites were found), AND
   * the e2e matrix succeeded OR was skipped (matrix aggregate is success only
     if every leg passed).
+
+Note the asymmetry with e2e: ``discover-e2e`` *fails* on count=0 (it only runs
+when e2e was explicitly requested, so zero suites is a misconfig), which is why
+``discover-e2e == success and e2e == skipped`` is an anomaly. ``detect-
+integration`` *succeeds* on count=0 (a connector with no integration suite is
+legitimate) and ``integration`` then skips cleanly, so there is no analogous
+``detect-integration == success and integration == skipped`` check — that pair
+is the normal no-suite path.
 
 It emits GitHub Actions outputs (``passed`` + per-row/overall status strings)
 and, when failing, ``::error::`` annotations. It does NOT exit non-zero — the
@@ -34,11 +46,22 @@ import sys
 _OK_OPTIONAL = ("success", "skipped")
 
 
-def evaluate(unit: str, integration: str, discover_e2e: str, e2e: str) -> list[str]:
+def evaluate(
+    unit: str, integration: str, detect_integration: str, discover_e2e: str, e2e: str
+) -> list[str]:
     """Return human-readable failure reasons (empty ⇒ the gate passes)."""
     errors: list[str] = []
     if unit != "success":
         errors.append(f"unit tests did not succeed (result={unit})")
+    # detect-integration gates the integration job's `if`. A *failure* there
+    # (checkout/glob flake) drops integration to a skip, which the check below
+    # would read as a legitimate pass — so a failed detection must fail the gate
+    # here, exactly as a failed discover-e2e does. skipped (pull_request) and
+    # success (suite present or not) are both valid.
+    if detect_integration not in _OK_OPTIONAL:
+        errors.append(
+            f"integration-suite detection did not succeed (result={detect_integration})"
+        )
     # Integration is optional-by-skip: the job is intentionally skipped on
     # pull_request and when the connector has no integration suite. Any result
     # other than success/skipped (failure, cancelled, timed_out) fails the gate.
@@ -67,7 +90,12 @@ def _unit_status(unit: str) -> str:
     return "❌ Failed"
 
 
-def _integration_status(integration: str) -> str:
+def _integration_status(integration: str, detect_integration: str) -> str:
+    # A detection failure drops integration to a skip; surface that as a failure
+    # rather than the benign "skipped" string, so the display never claims the
+    # tier was cleanly skipped when detection actually broke.
+    if detect_integration not in _OK_OPTIONAL:
+        return "❌ Integration-suite detection failed"
     if integration == "success":
         return "✅ Passed"
     if integration == "skipped":
@@ -89,13 +117,15 @@ def _e2e_status(discover_e2e: str, e2e: str) -> str:
     return "❌ Failed"
 
 
-def render(unit: str, integration: str, discover_e2e: str, e2e: str) -> dict[str, str]:
+def render(
+    unit: str, integration: str, detect_integration: str, discover_e2e: str, e2e: str
+) -> dict[str, str]:
     """Compute the gate's outputs: pass/fail + the display status strings."""
-    errors = evaluate(unit, integration, discover_e2e, e2e)
+    errors = evaluate(unit, integration, detect_integration, discover_e2e, e2e)
     return {
         "passed": "true" if not errors else "false",
         "unit-status": _unit_status(unit),
-        "integration-status": _integration_status(integration),
+        "integration-status": _integration_status(integration, detect_integration),
         "e2e-status": _e2e_status(discover_e2e, e2e),
         "overall-status": "✅ All passed" if not errors else "❌ Some failed",
     }
@@ -106,6 +136,11 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--unit", required=True, help="needs.unit.result")
     parser.add_argument("--integration", required=True, help="needs.integration.result")
     parser.add_argument(
+        "--detect-integration",
+        required=True,
+        help="needs.detect-integration.result",
+    )
+    parser.add_argument(
         "--discover-e2e", required=True, help="needs.discover-e2e.result"
     )
     parser.add_argument("--e2e", required=True, help="needs.e2e.result")
@@ -113,11 +148,21 @@ def main(argv: list[str] | None = None) -> int:
 
     # Annotate each failure reason (shows on the gate step regardless of the
     # zero exit; the job's enforce step turns `passed=false` into a red check).
-    for reason in evaluate(args.unit, args.integration, args.discover_e2e, args.e2e):
+    for reason in evaluate(
+        args.unit,
+        args.integration,
+        args.detect_integration,
+        args.discover_e2e,
+        args.e2e,
+    ):
         print(f"::error::{reason}", file=sys.stderr)
 
     for key, value in render(
-        args.unit, args.integration, args.discover_e2e, args.e2e
+        args.unit,
+        args.integration,
+        args.detect_integration,
+        args.discover_e2e,
+        args.e2e,
     ).items():
         print(f"{key}={value}")
     return 0

--- a/.github/scripts/build_callback_summary.py
+++ b/.github/scripts/build_callback_summary.py
@@ -23,13 +23,22 @@ PASSING_E2E_RESULTS = {"success", "skipped"}
 # Integration is skipped on PRs and when a connector has no integration suite,
 # so "skipped" is a pass for it (mirrors the e2e optional-by-skip treatment).
 PASSING_INTEGRATION_RESULTS = {"success", "skipped"}
+# The suite-detection job gates the integration `if`. A *failure* there drops
+# integration to a skip, which PASSING_INTEGRATION_RESULTS would read as a pass
+# — so a failed detection must be its own failure signal here, exactly as the
+# Tests Gate treats it. skipped (pull_request) and success are passes.
+PASSING_DETECT_INTEGRATION_RESULTS = {"success", "skipped"}
 
 
 def determine_conclusion(
-    unit_result: str, integration_result: str, e2e_result: str
+    unit_result: str,
+    integration_result: str,
+    detect_integration_result: str,
+    e2e_result: str,
 ) -> str:
     if (
         unit_result == "success"
+        and detect_integration_result in PASSING_DETECT_INTEGRATION_RESULTS
         and integration_result in PASSING_INTEGRATION_RESULTS
         and e2e_result in PASSING_E2E_RESULTS
     ):
@@ -40,15 +49,28 @@ def determine_conclusion(
 def build_fallback_summary(
     unit_result: str,
     integration_result: str,
+    detect_integration_result: str,
     e2e_result: str,
     unit_summary: str,
     integration_summary: str,
 ) -> str:
+    # Show the integration line as a detection failure when detect-integration
+    # broke, so the summary never reports a clean "skipped" for a tier that was
+    # actually dropped by a failed detection.
+    if detect_integration_result not in PASSING_DETECT_INTEGRATION_RESULTS:
+        integration_line = (
+            f"**integration:** not run — suite detection "
+            f"{detect_integration_result}\n"
+        )
+    else:
+        integration_line = (
+            f"**integration:** {integration_result} "
+            f"({integration_summary or 'no summary'})\n"
+        )
     return (
         "## Tests Summary\n\n"
         f"**unit:** {unit_result} ({unit_summary or 'no summary'})\n"
-        f"**integration:** {integration_result} "
-        f"({integration_summary or 'no summary'})\n"
+        f"{integration_line}"
         f"**e2e:** {e2e_result}\n"
     )
 
@@ -58,6 +80,7 @@ def resolve_summary_file(
     fallback_path: str,
     unit_result: str,
     integration_result: str,
+    detect_integration_result: str,
     e2e_result: str,
     unit_summary: str,
     integration_summary: str,
@@ -69,6 +92,7 @@ def resolve_summary_file(
             build_fallback_summary(
                 unit_result,
                 integration_result,
+                detect_integration_result,
                 e2e_result,
                 unit_summary,
                 integration_summary,
@@ -81,6 +105,7 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--unit-result", required=True)
     parser.add_argument("--integration-result", required=True)
+    parser.add_argument("--detect-integration-result", required=True)
     parser.add_argument("--e2e-result", required=True)
     parser.add_argument("--unit-summary", default="")
     parser.add_argument("--integration-summary", default="")
@@ -91,13 +116,17 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     conclusion = determine_conclusion(
-        args.unit_result, args.integration_result, args.e2e_result
+        args.unit_result,
+        args.integration_result,
+        args.detect_integration_result,
+        args.e2e_result,
     )
     summary_file = resolve_summary_file(
         args.artifact_summary_path,
         args.fallback_path,
         args.unit_result,
         args.integration_result,
+        args.detect_integration_result,
         args.e2e_result,
         args.unit_summary,
         args.integration_summary,

--- a/.github/scripts/build_callback_summary.py
+++ b/.github/scripts/build_callback_summary.py
@@ -20,20 +20,35 @@ import os
 import sys
 
 PASSING_E2E_RESULTS = {"success", "skipped"}
+# Integration is skipped on PRs and when a connector has no integration suite,
+# so "skipped" is a pass for it (mirrors the e2e optional-by-skip treatment).
+PASSING_INTEGRATION_RESULTS = {"success", "skipped"}
 
 
-def determine_conclusion(tests_result: str, e2e_result: str) -> str:
-    if tests_result == "success" and e2e_result in PASSING_E2E_RESULTS:
+def determine_conclusion(
+    unit_result: str, integration_result: str, e2e_result: str
+) -> str:
+    if (
+        unit_result == "success"
+        and integration_result in PASSING_INTEGRATION_RESULTS
+        and e2e_result in PASSING_E2E_RESULTS
+    ):
         return "success"
     return "failure"
 
 
 def build_fallback_summary(
-    tests_result: str, e2e_result: str, tests_summary: str
+    unit_result: str,
+    integration_result: str,
+    e2e_result: str,
+    unit_summary: str,
+    integration_summary: str,
 ) -> str:
     return (
         "## Tests Summary\n\n"
-        f"**tests:** {tests_result} ({tests_summary or 'no summary'})\n"
+        f"**unit:** {unit_result} ({unit_summary or 'no summary'})\n"
+        f"**integration:** {integration_result} "
+        f"({integration_summary or 'no summary'})\n"
         f"**e2e:** {e2e_result}\n"
     )
 
@@ -41,35 +56,51 @@ def build_fallback_summary(
 def resolve_summary_file(
     artifact_summary_path: str,
     fallback_path: str,
-    tests_result: str,
+    unit_result: str,
+    integration_result: str,
     e2e_result: str,
-    tests_summary: str,
+    unit_summary: str,
+    integration_summary: str,
 ) -> str:
     if os.path.isfile(artifact_summary_path):
         return artifact_summary_path
     with open(fallback_path, "w", encoding="utf-8") as fh:
-        fh.write(build_fallback_summary(tests_result, e2e_result, tests_summary))
+        fh.write(
+            build_fallback_summary(
+                unit_result,
+                integration_result,
+                e2e_result,
+                unit_summary,
+                integration_summary,
+            )
+        )
     return fallback_path
 
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--tests-result", required=True)
+    parser.add_argument("--unit-result", required=True)
+    parser.add_argument("--integration-result", required=True)
     parser.add_argument("--e2e-result", required=True)
-    parser.add_argument("--tests-summary", default="")
+    parser.add_argument("--unit-summary", default="")
+    parser.add_argument("--integration-summary", default="")
     parser.add_argument(
         "--artifact-summary-path", default="connector-results/pr-comment-body.md"
     )
     parser.add_argument("--fallback-path", default="fallback-summary.md")
     args = parser.parse_args(argv)
 
-    conclusion = determine_conclusion(args.tests_result, args.e2e_result)
+    conclusion = determine_conclusion(
+        args.unit_result, args.integration_result, args.e2e_result
+    )
     summary_file = resolve_summary_file(
         args.artifact_summary_path,
         args.fallback_path,
-        args.tests_result,
+        args.unit_result,
+        args.integration_result,
         args.e2e_result,
-        args.tests_summary,
+        args.unit_summary,
+        args.integration_summary,
     )
 
     lines = [f"conclusion={conclusion}", f"summary_file={summary_file}"]

--- a/.github/scripts/tests/test_build_callback_summary.py
+++ b/.github/scripts/tests/test_build_callback_summary.py
@@ -10,24 +10,33 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 import build_callback_summary as mod
 
 
-def test_determine_conclusion_success_and_success():
-    assert mod.determine_conclusion("success", "success") == "success"
+def test_determine_conclusion_all_success():
+    assert mod.determine_conclusion("success", "success", "success") == "success"
 
 
-def test_determine_conclusion_success_and_skipped():
-    assert mod.determine_conclusion("success", "skipped") == "success"
+def test_determine_conclusion_integration_skipped_is_success():
+    # Integration skipped (PR / no suite) is a pass.
+    assert mod.determine_conclusion("success", "skipped", "success") == "success"
 
 
-def test_determine_conclusion_tests_failed():
-    assert mod.determine_conclusion("failure", "success") == "failure"
+def test_determine_conclusion_e2e_skipped_is_success():
+    assert mod.determine_conclusion("success", "success", "skipped") == "success"
+
+
+def test_determine_conclusion_unit_failed():
+    assert mod.determine_conclusion("failure", "success", "success") == "failure"
+
+
+def test_determine_conclusion_integration_failed():
+    assert mod.determine_conclusion("success", "failure", "success") == "failure"
 
 
 def test_determine_conclusion_e2e_failed():
-    assert mod.determine_conclusion("success", "failure") == "failure"
+    assert mod.determine_conclusion("success", "success", "failure") == "failure"
 
 
-def test_determine_conclusion_tests_cancelled():
-    assert mod.determine_conclusion("cancelled", "skipped") == "failure"
+def test_determine_conclusion_unit_cancelled():
+    assert mod.determine_conclusion("cancelled", "skipped", "skipped") == "failure"
 
 
 def test_resolve_summary_file_prefers_artifact(tmp_path):
@@ -36,7 +45,7 @@ def test_resolve_summary_file_prefers_artifact(tmp_path):
     fallback = tmp_path / "fallback.md"
 
     result = mod.resolve_summary_file(
-        str(artifact), str(fallback), "success", "success", ""
+        str(artifact), str(fallback), "success", "success", "success", "", ""
     )
 
     assert result == str(artifact)
@@ -48,18 +57,26 @@ def test_resolve_summary_file_falls_back_when_artifact_missing(tmp_path):
     fallback = tmp_path / "fallback.md"
 
     result = mod.resolve_summary_file(
-        str(artifact), str(fallback), "success", "skipped", "5 passed"
+        str(artifact),
+        str(fallback),
+        "success",
+        "skipped",
+        "skipped",
+        "12 passed",
+        "",
     )
 
     assert result == str(fallback)
     content = fallback.read_text()
-    assert "**tests:** success (5 passed)" in content
+    assert "**unit:** success (12 passed)" in content
+    assert "**integration:** skipped (no summary)" in content
     assert "**e2e:** skipped" in content
 
 
 def test_build_fallback_summary_defaults_when_no_summary():
-    body = mod.build_fallback_summary("failure", "success", "")
-    assert "**tests:** failure (no summary)" in body
+    body = mod.build_fallback_summary("failure", "success", "success", "", "3 passed")
+    assert "**unit:** failure (no summary)" in body
+    assert "**integration:** success (3 passed)" in body
 
 
 def test_main_writes_github_output(tmp_path, monkeypatch):
@@ -71,7 +88,9 @@ def test_main_writes_github_output(tmp_path, monkeypatch):
 
     rc = mod.main(
         [
-            "--tests-result",
+            "--unit-result",
+            "success",
+            "--integration-result",
             "success",
             "--e2e-result",
             "success",
@@ -93,8 +112,10 @@ def test_main_prints_when_no_github_output(tmp_path, monkeypatch, capsys):
 
     rc = mod.main(
         [
-            "--tests-result",
+            "--unit-result",
             "failure",
+            "--integration-result",
+            "skipped",
             "--e2e-result",
             "skipped",
             "--artifact-summary-path",

--- a/.github/scripts/tests/test_build_callback_summary.py
+++ b/.github/scripts/tests/test_build_callback_summary.py
@@ -1,4 +1,8 @@
-"""Tests for .github/scripts/build_callback_summary.py."""
+"""Tests for .github/scripts/build_callback_summary.py.
+
+Signature: determine_conclusion / build_fallback_summary / resolve_summary_file
+take (unit, integration, detect_integration, e2e, ...).
+"""
 
 from __future__ import annotations
 
@@ -11,32 +15,72 @@ import build_callback_summary as mod
 
 
 def test_determine_conclusion_all_success():
-    assert mod.determine_conclusion("success", "success", "success") == "success"
+    assert (
+        mod.determine_conclusion("success", "success", "success", "success")
+        == "success"
+    )
 
 
 def test_determine_conclusion_integration_skipped_is_success():
-    # Integration skipped (PR / no suite) is a pass.
-    assert mod.determine_conclusion("success", "skipped", "success") == "success"
+    # Integration skipped (PR / no suite) is a pass; on a PR detect-integration
+    # is skipped too — also a pass.
+    assert (
+        mod.determine_conclusion("success", "skipped", "skipped", "success")
+        == "success"
+    )
+
+
+def test_determine_conclusion_integration_skipped_no_suite_is_success():
+    # Non-PR, no integration suite: detect-integration succeeds, integration
+    # skips cleanly — a pass.
+    assert (
+        mod.determine_conclusion("success", "skipped", "success", "success")
+        == "success"
+    )
 
 
 def test_determine_conclusion_e2e_skipped_is_success():
-    assert mod.determine_conclusion("success", "success", "skipped") == "success"
+    assert (
+        mod.determine_conclusion("success", "success", "success", "skipped")
+        == "success"
+    )
 
 
 def test_determine_conclusion_unit_failed():
-    assert mod.determine_conclusion("failure", "success", "success") == "failure"
+    assert (
+        mod.determine_conclusion("failure", "success", "success", "success")
+        == "failure"
+    )
 
 
 def test_determine_conclusion_integration_failed():
-    assert mod.determine_conclusion("success", "failure", "success") == "failure"
+    assert (
+        mod.determine_conclusion("success", "failure", "success", "success")
+        == "failure"
+    )
+
+
+def test_determine_conclusion_detect_integration_failed():
+    # A detection failure drops integration to a skip; the callback must still
+    # report failure rather than a silent success.
+    assert (
+        mod.determine_conclusion("success", "skipped", "failure", "success")
+        == "failure"
+    )
 
 
 def test_determine_conclusion_e2e_failed():
-    assert mod.determine_conclusion("success", "success", "failure") == "failure"
+    assert (
+        mod.determine_conclusion("success", "success", "success", "failure")
+        == "failure"
+    )
 
 
 def test_determine_conclusion_unit_cancelled():
-    assert mod.determine_conclusion("cancelled", "skipped", "skipped") == "failure"
+    assert (
+        mod.determine_conclusion("cancelled", "skipped", "skipped", "skipped")
+        == "failure"
+    )
 
 
 def test_resolve_summary_file_prefers_artifact(tmp_path):
@@ -45,7 +89,7 @@ def test_resolve_summary_file_prefers_artifact(tmp_path):
     fallback = tmp_path / "fallback.md"
 
     result = mod.resolve_summary_file(
-        str(artifact), str(fallback), "success", "success", "success", "", ""
+        str(artifact), str(fallback), "success", "success", "success", "success", "", ""
     )
 
     assert result == str(artifact)
@@ -61,6 +105,7 @@ def test_resolve_summary_file_falls_back_when_artifact_missing(tmp_path):
         str(fallback),
         "success",
         "skipped",
+        "success",
         "skipped",
         "12 passed",
         "",
@@ -74,9 +119,21 @@ def test_resolve_summary_file_falls_back_when_artifact_missing(tmp_path):
 
 
 def test_build_fallback_summary_defaults_when_no_summary():
-    body = mod.build_fallback_summary("failure", "success", "success", "", "3 passed")
+    body = mod.build_fallback_summary(
+        "failure", "success", "success", "success", "", "3 passed"
+    )
     assert "**unit:** failure (no summary)" in body
     assert "**integration:** success (3 passed)" in body
+
+
+def test_build_fallback_summary_detect_integration_failed():
+    # When detection failed, the integration line reports that rather than a
+    # misleading "skipped".
+    body = mod.build_fallback_summary(
+        "success", "skipped", "failure", "skipped", "", ""
+    )
+    assert "suite detection failure" in body
+    assert "**integration:** skipped" not in body
 
 
 def test_main_writes_github_output(tmp_path, monkeypatch):
@@ -91,6 +148,8 @@ def test_main_writes_github_output(tmp_path, monkeypatch):
             "--unit-result",
             "success",
             "--integration-result",
+            "success",
+            "--detect-integration-result",
             "success",
             "--e2e-result",
             "success",
@@ -107,6 +166,31 @@ def test_main_writes_github_output(tmp_path, monkeypatch):
     assert f"summary_file={artifact}" in content
 
 
+def test_main_detect_integration_failure_reports_failure(tmp_path, monkeypatch, capsys):
+    monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+
+    rc = mod.main(
+        [
+            "--unit-result",
+            "success",
+            "--integration-result",
+            "skipped",
+            "--detect-integration-result",
+            "failure",
+            "--e2e-result",
+            "skipped",
+            "--artifact-summary-path",
+            str(tmp_path / "missing.md"),
+            "--fallback-path",
+            str(tmp_path / "fallback.md"),
+        ]
+    )
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "conclusion=failure" in out
+
+
 def test_main_prints_when_no_github_output(tmp_path, monkeypatch, capsys):
     monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
 
@@ -115,6 +199,8 @@ def test_main_prints_when_no_github_output(tmp_path, monkeypatch, capsys):
             "--unit-result",
             "failure",
             "--integration-result",
+            "skipped",
+            "--detect-integration-result",
             "skipped",
             "--e2e-result",
             "skipped",

--- a/.github/scripts/tests/test_verify_test_gate.py
+++ b/.github/scripts/tests/test_verify_test_gate.py
@@ -2,6 +2,8 @@
 
 Co-located module (checked out with the composite action in consumer repos);
 the test lives here with the other action-script tests.
+
+Signature: evaluate/render take (unit, integration, discover_e2e, e2e).
 """
 
 from __future__ import annotations
@@ -19,52 +21,64 @@ from verify_test_gate import evaluate, main, render  # noqa: E402
 
 
 def test_all_pass() -> None:
-    assert evaluate("success", "success", "success") == []
+    assert evaluate("success", "success", "success", "success") == []
 
 
-def test_all_skipped_e2e_not_requested() -> None:
-    # No `e2e` label: discovery + matrix skipped, unit tests pass.
-    assert evaluate("success", "skipped", "skipped") == []
+def test_integration_skipped_is_pass() -> None:
+    # Integration is skipped on PRs and when a connector has no integration
+    # suite — both legitimate. Unit passing + e2e not requested ⇒ gate passes.
+    assert evaluate("success", "skipped", "skipped", "skipped") == []
 
 
 # --- failing states --------------------------------------------------------
 
 
-def test_tests_fail() -> None:
-    errors = evaluate("failure", "skipped", "skipped")
+def test_unit_fail() -> None:
+    errors = evaluate("failure", "success", "skipped", "skipped")
     assert len(errors) == 1
-    assert "tests job" in errors[0]
+    assert "unit tests" in errors[0]
+
+
+def test_integration_fail() -> None:
+    errors = evaluate("success", "failure", "skipped", "skipped")
+    assert len(errors) == 1
+    assert "integration tests" in errors[0]
+
+
+def test_integration_cancelled_is_failure() -> None:
+    assert evaluate("success", "cancelled", "skipped", "skipped") != []
 
 
 def test_discover_fail_requested_but_empty() -> None:
     # discovery failed (e2e requested, zero suites); e2e leg then skipped.
-    errors = evaluate("success", "failure", "skipped")
+    errors = evaluate("success", "success", "failure", "skipped")
     assert len(errors) == 1
     assert "discovery" in errors[0]
 
 
 def test_e2e_leg_fail() -> None:
-    errors = evaluate("success", "success", "failure")
+    errors = evaluate("success", "success", "success", "failure")
     assert len(errors) == 1
     assert "e2e suites" in errors[0]
 
 
 def test_multiple_failures_all_reported() -> None:
-    errors = evaluate("failure", "failure", "failure")
-    assert len(errors) == 3
+    # unit, integration, discovery, e2e all bad → 4 reasons.
+    errors = evaluate("failure", "failure", "failure", "failure")
+    assert len(errors) == 4
 
 
 def test_e2e_cancelled_is_failure() -> None:
-    assert evaluate("success", "success", "cancelled") != []
+    assert evaluate("success", "success", "success", "cancelled") != []
 
 
 def test_e2e_skipped_when_discovery_succeeded_is_failure() -> None:
     # Discovery success ⇒ suites exist ⇒ the matrix must run. A skipped matrix
     # here (e.g. a future caller re-wired the e2e `if`) must not green the gate.
-    errors = evaluate("success", "success", "skipped")
+    errors = evaluate("success", "success", "success", "skipped")
     assert len(errors) == 1
     assert "matrix was skipped" in errors[0]
-    out = render("success", "success", "skipped")
+    out = render("success", "success", "success", "skipped")
     assert out["passed"] == "false"
     assert out["e2e-status"] == "❌ Matrix skipped despite discovered suites"
 
@@ -73,52 +87,82 @@ def test_e2e_skipped_when_discovery_succeeded_is_failure() -> None:
 
 
 def test_render_all_pass() -> None:
-    out = render("success", "success", "success")
+    out = render("success", "success", "success", "success")
     assert out["passed"] == "true"
-    assert out["tests-status"] == "✅ Passed"
+    assert out["unit-status"] == "✅ Passed"
+    assert out["integration-status"] == "✅ Passed"
     assert out["e2e-status"] == "✅ Passed"
     assert out["overall-status"] == "✅ All passed"
 
 
-def test_render_e2e_not_requested() -> None:
-    out = render("success", "skipped", "skipped")
+def test_render_integration_skipped() -> None:
+    out = render("success", "skipped", "skipped", "skipped")
     assert out["passed"] == "true"
+    assert "Skipped" in out["integration-status"]
     assert "add `e2e` label" in out["e2e-status"]
     assert out["overall-status"] == "✅ All passed"
 
 
 def test_render_discovery_failed_requested_but_empty() -> None:
-    out = render("success", "failure", "skipped")
+    out = render("success", "success", "failure", "skipped")
     assert out["passed"] == "false"
     assert out["e2e-status"] == "❌ No suites discovered (e2e was requested)"
     assert out["overall-status"] == "❌ Some failed"
 
 
 def test_render_e2e_leg_failed() -> None:
-    out = render("success", "success", "failure")
+    out = render("success", "success", "success", "failure")
     assert out["passed"] == "false"
     assert out["e2e-status"] == "❌ Failed"
 
 
-def test_render_tests_failed() -> None:
-    out = render("failure", "skipped", "skipped")
+def test_render_unit_failed() -> None:
+    out = render("failure", "skipped", "skipped", "skipped")
     assert out["passed"] == "false"
-    assert out["tests-status"] == "❌ Failed"
+    assert out["unit-status"] == "❌ Failed"
+
+
+def test_render_integration_failed() -> None:
+    out = render("success", "failure", "skipped", "skipped")
+    assert out["passed"] == "false"
+    assert out["integration-status"] == "❌ Failed"
 
 
 # --- CLI wrapper (emits outputs; never exits non-zero — job enforces) -------
 
 
 def test_main_always_exits_zero_and_emits_passed_true(capsys) -> None:
-    rc = main(["--tests", "success", "--discover-e2e", "skipped", "--e2e", "skipped"])
+    rc = main(
+        [
+            "--unit",
+            "success",
+            "--integration",
+            "skipped",
+            "--discover-e2e",
+            "skipped",
+            "--e2e",
+            "skipped",
+        ]
+    )
     out = capsys.readouterr().out
     assert rc == 0
     assert "passed=true" in out
-    assert "tests-status=✅ Passed" in out
+    assert "unit-status=✅ Passed" in out
 
 
 def test_main_emits_passed_false_and_annotates_on_fail(capsys) -> None:
-    rc = main(["--tests", "success", "--discover-e2e", "success", "--e2e", "failure"])
+    rc = main(
+        [
+            "--unit",
+            "success",
+            "--integration",
+            "success",
+            "--discover-e2e",
+            "success",
+            "--e2e",
+            "failure",
+        ]
+    )
     captured = capsys.readouterr()
     assert rc == 0  # never fails itself; the gate job enforces via `passed`
     assert "passed=false" in captured.out

--- a/.github/scripts/tests/test_verify_test_gate.py
+++ b/.github/scripts/tests/test_verify_test_gate.py
@@ -3,7 +3,8 @@
 Co-located module (checked out with the composite action in consumer repos);
 the test lives here with the other action-script tests.
 
-Signature: evaluate/render take (unit, integration, discover_e2e, e2e).
+Signature: evaluate/render take
+(unit, integration, detect_integration, discover_e2e, e2e).
 """
 
 from __future__ import annotations
@@ -21,64 +22,84 @@ from verify_test_gate import evaluate, main, render  # noqa: E402
 
 
 def test_all_pass() -> None:
-    assert evaluate("success", "success", "success", "success") == []
+    assert evaluate("success", "success", "success", "success", "success") == []
 
 
 def test_integration_skipped_is_pass() -> None:
     # Integration is skipped on PRs and when a connector has no integration
-    # suite — both legitimate. Unit passing + e2e not requested ⇒ gate passes.
-    assert evaluate("success", "skipped", "skipped", "skipped") == []
+    # suite — both legitimate. On a PR detect-integration is also skipped.
+    # Unit passing + e2e not requested ⇒ gate passes.
+    assert evaluate("success", "skipped", "skipped", "skipped", "skipped") == []
+
+
+def test_integration_skipped_no_suite_is_pass() -> None:
+    # Non-PR, connector ships no integration suite: detect-integration succeeds
+    # (count=0 is legitimate) and integration skips cleanly — a pass.
+    assert evaluate("success", "skipped", "success", "skipped", "skipped") == []
 
 
 # --- failing states --------------------------------------------------------
 
 
 def test_unit_fail() -> None:
-    errors = evaluate("failure", "success", "skipped", "skipped")
+    errors = evaluate("failure", "success", "success", "skipped", "skipped")
     assert len(errors) == 1
     assert "unit tests" in errors[0]
 
 
 def test_integration_fail() -> None:
-    errors = evaluate("success", "failure", "skipped", "skipped")
+    errors = evaluate("success", "failure", "success", "skipped", "skipped")
     assert len(errors) == 1
     assert "integration tests" in errors[0]
 
 
 def test_integration_cancelled_is_failure() -> None:
-    assert evaluate("success", "cancelled", "skipped", "skipped") != []
+    assert evaluate("success", "cancelled", "success", "skipped", "skipped") != []
+
+
+def test_detect_integration_fail_fails_gate() -> None:
+    # The core hole this closes: a detection failure drops integration to a
+    # skip (which on its own reads as a pass), so the failed detection must
+    # itself fail the gate.
+    errors = evaluate("success", "skipped", "failure", "skipped", "skipped")
+    assert len(errors) == 1
+    assert "integration-suite detection" in errors[0]
+
+
+def test_detect_integration_cancelled_is_failure() -> None:
+    assert evaluate("success", "skipped", "cancelled", "skipped", "skipped") != []
 
 
 def test_discover_fail_requested_but_empty() -> None:
     # discovery failed (e2e requested, zero suites); e2e leg then skipped.
-    errors = evaluate("success", "success", "failure", "skipped")
+    errors = evaluate("success", "success", "success", "failure", "skipped")
     assert len(errors) == 1
     assert "discovery" in errors[0]
 
 
 def test_e2e_leg_fail() -> None:
-    errors = evaluate("success", "success", "success", "failure")
+    errors = evaluate("success", "success", "success", "success", "failure")
     assert len(errors) == 1
     assert "e2e suites" in errors[0]
 
 
 def test_multiple_failures_all_reported() -> None:
-    # unit, integration, discovery, e2e all bad → 4 reasons.
-    errors = evaluate("failure", "failure", "failure", "failure")
-    assert len(errors) == 4
+    # unit, integration, detect-integration, discovery, e2e all bad → 5 reasons.
+    errors = evaluate("failure", "failure", "failure", "failure", "failure")
+    assert len(errors) == 5
 
 
 def test_e2e_cancelled_is_failure() -> None:
-    assert evaluate("success", "success", "success", "cancelled") != []
+    assert evaluate("success", "success", "success", "success", "cancelled") != []
 
 
 def test_e2e_skipped_when_discovery_succeeded_is_failure() -> None:
     # Discovery success ⇒ suites exist ⇒ the matrix must run. A skipped matrix
     # here (e.g. a future caller re-wired the e2e `if`) must not green the gate.
-    errors = evaluate("success", "success", "success", "skipped")
+    errors = evaluate("success", "success", "success", "success", "skipped")
     assert len(errors) == 1
     assert "matrix was skipped" in errors[0]
-    out = render("success", "success", "success", "skipped")
+    out = render("success", "success", "success", "success", "skipped")
     assert out["passed"] == "false"
     assert out["e2e-status"] == "❌ Matrix skipped despite discovered suites"
 
@@ -87,7 +108,7 @@ def test_e2e_skipped_when_discovery_succeeded_is_failure() -> None:
 
 
 def test_render_all_pass() -> None:
-    out = render("success", "success", "success", "success")
+    out = render("success", "success", "success", "success", "success")
     assert out["passed"] == "true"
     assert out["unit-status"] == "✅ Passed"
     assert out["integration-status"] == "✅ Passed"
@@ -96,34 +117,43 @@ def test_render_all_pass() -> None:
 
 
 def test_render_integration_skipped() -> None:
-    out = render("success", "skipped", "skipped", "skipped")
+    out = render("success", "skipped", "skipped", "skipped", "skipped")
     assert out["passed"] == "true"
     assert "Skipped" in out["integration-status"]
     assert "add `e2e` label" in out["e2e-status"]
     assert out["overall-status"] == "✅ All passed"
 
 
+def test_render_detect_integration_failed() -> None:
+    # A detection failure fails the gate and the integration row surfaces the
+    # detection failure rather than the benign "skipped" string.
+    out = render("success", "skipped", "failure", "skipped", "skipped")
+    assert out["passed"] == "false"
+    assert out["integration-status"] == "❌ Integration-suite detection failed"
+    assert out["overall-status"] == "❌ Some failed"
+
+
 def test_render_discovery_failed_requested_but_empty() -> None:
-    out = render("success", "success", "failure", "skipped")
+    out = render("success", "success", "success", "failure", "skipped")
     assert out["passed"] == "false"
     assert out["e2e-status"] == "❌ No suites discovered (e2e was requested)"
     assert out["overall-status"] == "❌ Some failed"
 
 
 def test_render_e2e_leg_failed() -> None:
-    out = render("success", "success", "success", "failure")
+    out = render("success", "success", "success", "success", "failure")
     assert out["passed"] == "false"
     assert out["e2e-status"] == "❌ Failed"
 
 
 def test_render_unit_failed() -> None:
-    out = render("failure", "skipped", "skipped", "skipped")
+    out = render("failure", "skipped", "skipped", "skipped", "skipped")
     assert out["passed"] == "false"
     assert out["unit-status"] == "❌ Failed"
 
 
 def test_render_integration_failed() -> None:
-    out = render("success", "failure", "skipped", "skipped")
+    out = render("success", "failure", "success", "skipped", "skipped")
     assert out["passed"] == "false"
     assert out["integration-status"] == "❌ Failed"
 
@@ -137,6 +167,8 @@ def test_main_always_exits_zero_and_emits_passed_true(capsys) -> None:
             "--unit",
             "success",
             "--integration",
+            "skipped",
+            "--detect-integration",
             "skipped",
             "--discover-e2e",
             "skipped",
@@ -157,6 +189,8 @@ def test_main_emits_passed_false_and_annotates_on_fail(capsys) -> None:
             "success",
             "--integration",
             "success",
+            "--detect-integration",
+            "success",
             "--discover-e2e",
             "success",
             "--e2e",
@@ -167,3 +201,24 @@ def test_main_emits_passed_false_and_annotates_on_fail(capsys) -> None:
     assert rc == 0  # never fails itself; the gate job enforces via `passed`
     assert "passed=false" in captured.out
     assert "::error::" in captured.err
+
+
+def test_main_detect_integration_failure_annotates(capsys) -> None:
+    rc = main(
+        [
+            "--unit",
+            "success",
+            "--integration",
+            "skipped",
+            "--detect-integration",
+            "failure",
+            "--discover-e2e",
+            "skipped",
+            "--e2e",
+            "skipped",
+        ]
+    )
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "passed=false" in captured.out
+    assert "integration-suite detection" in captured.err

--- a/.github/workflows/tests-reusable.yaml
+++ b/.github/workflows/tests-reusable.yaml
@@ -455,7 +455,7 @@ jobs:
   # empty on the connector's own same-repo pull_request/push runs.
   report-to-sdk:
     name: Report to application-sdk
-    needs: [unit, integration, e2e]
+    needs: [unit, detect-integration, integration, e2e]
     if: |
       always() &&
       github.event_name == 'workflow_dispatch' &&
@@ -552,6 +552,7 @@ jobs:
         env:
           UNIT_RESULT: ${{ needs.unit.result }}
           INTEGRATION_RESULT: ${{ needs.integration.result }}
+          DETECT_INTEGRATION_RESULT: ${{ needs.detect-integration.result }}
           E2E_RESULT: ${{ needs.e2e.result }}
           UNIT_SUMMARY: ${{ needs.unit.outputs.summary }}
           INTEGRATION_SUMMARY: ${{ needs.integration.outputs.summary }}
@@ -559,6 +560,7 @@ jobs:
           python3 application-sdk-scripts/.github/scripts/build_callback_summary.py \
             --unit-result "$UNIT_RESULT" \
             --integration-result "$INTEGRATION_RESULT" \
+            --detect-integration-result "$DETECT_INTEGRATION_RESULT" \
             --e2e-result "$E2E_RESULT" \
             --unit-summary "$UNIT_SUMMARY" \
             --integration-summary "$INTEGRATION_SUMMARY"
@@ -581,7 +583,7 @@ jobs:
   # ── Aggregator gate (single required check for branch protection) ────────
   tests-passed:
     name: Tests Gate
-    needs: [unit, integration, discover-e2e, e2e]
+    needs: [unit, detect-integration, integration, discover-e2e, e2e]
     if: always()
     runs-on: ubuntu-latest
     # Comment + gate-eval only; cap so a wedged runner can't hold the required
@@ -597,6 +599,9 @@ jobs:
       # Discovery skipped = e2e not requested (OK); discovery failed = requested
       # but empty (fail); the e2e matrix aggregate is success iff every leg
       # passed. Integration skipped (PR / no suite) is a pass; unit must succeed.
+      # detect-integration is gated too: a *failed* detection (not a PR skip)
+      # fails the gate, so a checkout/glob flake can't silently skip integration
+      # and green the required check.
       - name: Evaluate Tests Gate
         id: gate
         if: always()
@@ -604,6 +609,7 @@ jobs:
         with:
           unit-result: ${{ needs.unit.result }}
           integration-result: ${{ needs.integration.result }}
+          detect-integration-result: ${{ needs.detect-integration.result }}
           discover-e2e-result: ${{ needs.discover-e2e.result }}
           e2e-result: ${{ needs.e2e.result }}
 

--- a/.github/workflows/tests-reusable.yaml
+++ b/.github/workflows/tests-reusable.yaml
@@ -1,7 +1,9 @@
 name: tests-reusable
 
 # Reusable workflow for the standard connector tests + e2e scaffold.
-# Each connector's per-app tests.yaml collapses to a thin caller:
+# Each connector's per-app tests.yaml collapses to a thin caller — a single
+# job invoking this reusable; the tiered unit/integration jobs, the e2e
+# scaffold and the aggregator Tests Gate all live in here:
 #
 #     name: Tests
 #     jobs:
@@ -11,11 +13,6 @@ name: tests-reusable
 #           app-name: mysql
 #           ...
 #         secrets: inherit
-#       tests-gate:
-#         name: Tests Gate
-#         needs: [tests]
-#         if: always()
-#         ...  # gate logic using needs.tests.outputs.*
 #
 # Standard boilerplate baked in this reusable so apps don't copy-paste it:
 #   - 60-min job timeout (override via timeout-minutes input)
@@ -29,23 +26,28 @@ name: tests-reusable
 #     it was previously delegated to e2e-full-reusable.yaml, now folded in so
 #     the whole suite is one reusable + one Tests Gate)
 #
-# Test tiering (see the `tests` job's test-paths):
-#   pull_request          → tests/unit/ only. Fast per-commit signal (seconds
-#                           of tests + uv sync); no testcontainers / source
-#                           infra spun up, so the PR loop stays cheap.
-#   merge_group / push    → full suite (unit + integration, auto-discovered).
-#                           Integration (testcontainers / services-script,
-#                           exercising the real extraction workflow) runs on
-#                           the exact batched state that will land — the one
-#                           point a regression could actually ship — and is
-#                           re-run in place if the base moves under the queue.
-#   e2e (label/dispatch)  → full-DAG against a real tenant (the `e2e` job).
-#   A caller-supplied `test-paths` overrides this tiering entirely.
+# Test tiering (two separate jobs → two separate checks):
+#   unit         → tests/unit/ via the lightweight connector-unit-tests action
+#                  (setup-deps + pytest + coverage; NO app server / daprd /
+#                  Temporal / services-script). Runs on EVERY event — the fast
+#                  per-commit PR signal, greens in seconds of test time.
+#   integration  → tests/integration/ via connector-integration-tests (boots
+#                  the app + testcontainers / services-script, exercising the
+#                  real extraction workflow). Skipped on pull_request (the unit
+#                  tier is the PR signal) and when the connector ships no
+#                  integration suite; runs on merge_group / push — the exact
+#                  batched state that will land, the one point a regression
+#                  could actually ship — re-run in place if the base moves under
+#                  the queue. Gated by the `detect-integration` job.
+#   e2e (label/dispatch) → full-DAG against a real tenant (the `e2e` job).
+#   A caller-supplied `test-paths` scopes the INTEGRATION job only; the unit job
+#   always runs tests/unit/.
 #
 # GitHub check name hierarchy (caller → tests-reusable):
-#   Tests / tests / Unit and integration  (unit only on pull_request; + integration on merge_group)
-#   Tests / tests / End-to-end            (label / dispatch)
-#   Tests / tests / Tests Gate            (aggregator — the required check)
+#   Tests / tests / Unit         (every event)
+#   Tests / tests / Integration  (skipped on PRs / no suite; runs in merge queue)
+#   Tests / tests / End-to-end   (label / dispatch)
+#   Tests / tests / Tests Gate   (aggregator — the required check)
 #
 # Nested reusable depth: caller → tests-reusable = 2 (GitHub max is 4).
 # secrets: inherit chains from the caller; the inlined e2e job reads secrets.*.
@@ -71,12 +73,19 @@ on:
         type: string
         default: ""
         description: |
-          Space-separated pytest target paths.  Empty = event-tiered default
-          (see the `tests` job): tests/unit/ on pull_request, full auto-
-          discovered suite (honouring testpaths in pyproject.toml) on
-          merge_group / push.  Set a non-empty value to override the tiering
-          and force an exact path set on every event (e.g. "tests/unit/
-          tests/integration/").
+          Space-separated pytest target paths for the INTEGRATION job.  Empty =
+          tests/integration/ (the default).  The unit job always runs tests/unit/
+          via the connector-unit-tests action and is NOT affected by this input.
+          Set this only to scope integration to a subset (e.g. a single file).
+      unit-coverage-fail-under:
+        required: false
+        type: string
+        default: "0"
+        description: |
+          Minimum unit-test coverage percent enforced by the unit job (the
+          connector-unit-tests `fail-under`).  Default "0" preserves the
+          historical no-coverage-gate behaviour; raise it per-app to enforce a
+          coverage floor on the fast PR signal.
       pytest-args:
         required: false
         type: string
@@ -176,41 +185,110 @@ on:
 
 jobs:
 
-  # ── Unit + Integration (testcontainers or services-script hook) ──────────
-  tests:
-    name: Unit and integration
+  # ── Unit (lightweight: no app server / daprd / Temporal / services) ──────
+  # Runs on EVERY event as the fast per-commit signal. connector-unit-tests is
+  # setup-deps + pytest tests/unit + coverage — none of the runtime infra the
+  # integration job spins up, so a PR greens in seconds of test time.
+  unit:
+    name: Unit
     runs-on: ubuntu-latest
-    timeout-minutes: ${{ inputs.timeout-minutes }}
+    timeout-minutes: 20
     concurrency:
-      group: tests-${{ github.ref }}
+      group: tests-unit-${{ github.ref }}
       cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
     permissions:
-      pull-requests: write
+      pull-requests: write  # connector-unit-tests comments the coverage delta
       contents: read
     outputs:
-      summary: ${{ steps.tests.outputs.summary }}
+      summary: ${{ steps.unit.outputs.summary }}
     steps:
       - name: echo distinct-id ${{ inputs.distinct-id }}
         if: inputs.distinct-id != ''
         run: echo "Dispatched; SDK ref=${{ inputs.application-sdk-ref }}"
 
-      # Tiered by event so the expensive integration tier runs only where a
-      # regression could actually ship (see the "Test tiering" note in the
-      # header):
-      #   pull_request          → tests/unit/ only        (fast per-commit signal)
-      #   merge_group/push/etc. → '' = auto-discover full suite (unit + integration)
-      # A caller-supplied test-paths always wins (explicit override). The
-      # ternary is a workflow expression in a `with:` value — not inlined
-      # conditional shell — so it stays within the CI authoring rule.
-      - name: Run tests (unit on PRs; unit + integration in the merge queue)
-        id: tests
+      - name: Run unit tests
+        id: unit
+        uses: atlanhq/application-sdk/.github/actions/connector-unit-tests@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          # "0" by default (no coverage gate); apps opt up via the input.
+          fail-under: ${{ inputs.unit-coverage-fail-under }}
+          # Repin so a cross-repo SDK-PR dispatch exercises the SDK branch in the
+          # unit tier too (parity with integration); empty = lockfile version.
+          application-sdk-ref: ${{ inputs.application-sdk-ref }}
+
+  # ── Detect whether an integration suite exists ───────────────────────────
+  # The integration job runs tests/integration/ explicitly; a connector may
+  # legitimately ship no integration tier (e.g. hello-world), where pytest would
+  # otherwise error on a missing path. A checkout + a tested glob (discover-e2e-
+  # suites is a generic test_*.py counter, reused here) lets the integration job
+  # be a clean skip via a job-level `if` — no inlined conditional shell. Runs on
+  # the same non-PR events the integration job does.
+  detect-integration:
+    name: Detect integration suite
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      count: ${{ steps.detect.outputs.count }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Count integration suites
+        id: detect
+        uses: atlanhq/application-sdk/.github/actions/discover-e2e-suites@main
+        with:
+          test-dir: tests/integration
+
+  # ── Integration (boots the app + testcontainers / services-script) ───────
+  # Skipped on pull_request (unit is the per-commit signal) and when there is no
+  # integration suite (detect-integration count == 0); runs on merge_group /
+  # push / dispatch — the exact batched state that will land.
+  integration:
+    name: Integration
+    needs: detect-integration
+    # Specifying `if` drops the implied success() on `needs`, so require the
+    # detection to have actually succeeded (else count is empty and would read
+    # as "present"). On pull_request detect-integration is skipped, so this is
+    # false and integration skips — the unit tier is the PR signal.
+    if: >-
+      github.event_name != 'pull_request' &&
+      needs.detect-integration.result == 'success' &&
+      needs.detect-integration.outputs.count != '0'
+    runs-on: ubuntu-latest
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    concurrency:
+      group: tests-integration-${{ github.ref }}
+      cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+    permissions:
+      pull-requests: write
+      contents: read
+    outputs:
+      summary: ${{ steps.integration.outputs.summary }}
+    steps:
+      - name: echo distinct-id ${{ inputs.distinct-id }}
+        if: inputs.distinct-id != ''
+        run: echo "Dispatched; SDK ref=${{ inputs.application-sdk-ref }}"
+
+      # Unit runs in its own job; integration defaults to tests/integration/.
+      # A caller test-paths override scopes THIS job only. The ternary is a
+      # workflow expression in a `with:` value — not inlined conditional shell —
+      # so it stays within the CI authoring rule.
+      - name: Run integration tests
+        id: integration
         uses: atlanhq/application-sdk/.github/actions/connector-integration-tests@main
         with:
           app-name: ${{ inputs.app-name }}
-          test-paths: ${{ inputs.test-paths != '' && inputs.test-paths || (github.event_name == 'pull_request' && 'tests/unit/' || '') }}
+          test-paths: ${{ inputs.test-paths != '' && inputs.test-paths || 'tests/integration/' }}
           pytest-args: ${{ inputs.pytest-args }}
           services-script: ${{ inputs.services-script }}
           application-sdk-ref: ${{ inputs.application-sdk-ref }}
+          # Scorecard stays out of the split path: this job's junit is
+          # integration-only, so an inline scorecard would misreport the unit
+          # tier as absent. Per-tier aggregation lands in a follow-up.
+          emit-scorecard: "false"
 
   # ── Discover e2e suites → matrix ─────────────────────────────────────────
   # Globs the connector's tests/e2e/test_*.py into a strategy.matrix so the
@@ -377,7 +455,7 @@ jobs:
   # empty on the connector's own same-repo pull_request/push runs.
   report-to-sdk:
     name: Report to application-sdk
-    needs: [tests, e2e]
+    needs: [unit, integration, e2e]
     if: |
       always() &&
       github.event_name == 'workflow_dispatch' &&
@@ -472,14 +550,18 @@ jobs:
       - name: Determine conclusion + build summary
         id: report
         env:
-          TESTS_RESULT: ${{ needs.tests.result }}
+          UNIT_RESULT: ${{ needs.unit.result }}
+          INTEGRATION_RESULT: ${{ needs.integration.result }}
           E2E_RESULT: ${{ needs.e2e.result }}
-          TESTS_SUMMARY: ${{ needs.tests.outputs.summary }}
+          UNIT_SUMMARY: ${{ needs.unit.outputs.summary }}
+          INTEGRATION_SUMMARY: ${{ needs.integration.outputs.summary }}
         run: |
           python3 application-sdk-scripts/.github/scripts/build_callback_summary.py \
-            --tests-result "$TESTS_RESULT" \
+            --unit-result "$UNIT_RESULT" \
+            --integration-result "$INTEGRATION_RESULT" \
             --e2e-result "$E2E_RESULT" \
-            --tests-summary "$TESTS_SUMMARY"
+            --unit-summary "$UNIT_SUMMARY" \
+            --integration-summary "$INTEGRATION_SUMMARY"
 
       - name: Complete the check run on application-sdk
         env:
@@ -499,7 +581,7 @@ jobs:
   # ── Aggregator gate (single required check for branch protection) ────────
   tests-passed:
     name: Tests Gate
-    needs: [tests, discover-e2e, e2e]
+    needs: [unit, integration, discover-e2e, e2e]
     if: always()
     runs-on: ubuntu-latest
     # Comment + gate-eval only; cap so a wedged runner can't hold the required
@@ -514,13 +596,14 @@ jobs:
       # renders, so displayed status can't drift from the enforced result.
       # Discovery skipped = e2e not requested (OK); discovery failed = requested
       # but empty (fail); the e2e matrix aggregate is success iff every leg
-      # passed.
+      # passed. Integration skipped (PR / no suite) is a pass; unit must succeed.
       - name: Evaluate Tests Gate
         id: gate
         if: always()
         uses: atlanhq/application-sdk/.github/actions/verify-test-gate@main
         with:
-          tests-result: ${{ needs.tests.result }}
+          unit-result: ${{ needs.unit.result }}
+          integration-result: ${{ needs.integration.result }}
           discover-e2e-result: ${{ needs.discover-e2e.result }}
           e2e-result: ${{ needs.e2e.result }}
 
@@ -534,7 +617,8 @@ jobs:
 
             | Job | Status | Result |
             |---|---|---|
-            | tests | ${{ steps.gate.outputs.tests-status }} | `${{ needs.tests.outputs.summary || 'no summary' }}` |
+            | unit | ${{ steps.gate.outputs.unit-status }} | `${{ needs.unit.outputs.summary || 'no summary' }}` |
+            | integration | ${{ steps.gate.outputs.integration-status }} | `${{ needs.integration.outputs.summary || 'no summary' }}` |
             | e2e | ${{ steps.gate.outputs.e2e-status }} | per-suite results + live logs in the run |
 
             **Overall:** ${{ steps.gate.outputs.overall-status }} — [view run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})


### PR DESCRIPTION
## What

Follow-up to #2848. Splits the single `tests / Unit and integration` check into two separate checks, **`tests / Unit`** and **`tests / Integration`**, so the checks reflect what actually ran and the PR tier stays genuinely cheap.

## Why

#2848 introduced the tiering (unit per-commit on PRs, integration in the merge queue) but carried it in **one** job named "Unit and integration" that just narrowed `test-paths` by event. Two problems:

- The check name **lied on PRs** — only unit ran, but the check said "Unit and integration".
- The PR tier still ran the **heavy** `connector-integration-tests` composite (booting the app server + daprd + Temporal, and for openapi its source services via `setup-services.sh`) *just to run unit tests* — so the promised "fast per-commit signal, no infra spun up" wasn't actually delivered.

## What changed

Two jobs, each its own check:

| Job → check | Action | Runs on |
|---|---|---|
| `unit` → `tests / Unit` | `connector-unit-tests` (setup-deps + pytest + coverage; **no** app server / daprd / Temporal / services) | every event — the fast PR signal |
| `integration` → `tests / Integration` | `connector-integration-tests` (`tests/integration/`) | merge_group / push; **skipped on PRs and when no integration suite exists** |

- **`connector-unit-tests` was orphaned** (referenced only in docs) — this is its first real use. Added `application-sdk-ref`/repin to it for parity, so a cross-repo SDK-PR dispatch exercises the SDK branch in the unit tier too.
- New **`detect-integration`** job (reusing the generic `discover-e2e-suites` globber) gates the integration job, so a connector with no `tests/integration/` (e.g. `hello-world`) **skips cleanly** instead of failing on a missing path. All branching stays in job-level workflow expressions — no inlined conditional shell (per `docs/standards/ci.md`).
- **Gate/callback rewiring**: `verify-test-gate` + `build_callback_summary.py` now take unit + integration results separately (`integration=skipped` is a pass, mirroring the e2e optional-by-skip treatment). The Tests Gate PR-comment table gains an Integration row.
- **Coverage gate stays off** by default via a new `unit-coverage-fail-under` input (default `"0"`, preserving today's no-gate behaviour); apps can opt up.
- **Scorecard kept out of the split path**: the integration action gains an `emit-scorecard` input (default `true` for direct callers), set `false` here because this job's junit is integration-only and an inline scorecard would misreport the unit tier as absent. Per-tier coverage aggregation lands in a follow-up (coordinated with connector-pulse #596).

## No ruleset change required

The required check is the aggregator **`tests / Tests Gate`**, which is unchanged. All canonical rulesets require Tests Gate, not "Unit and integration".

## Consumer impact

Canonical callers pin `@main`, already declare `merge_group:`, and don't override `test-paths`, so they pick this up automatically — no per-app PRs needed. `hello-world` (no integration suite) will show `Integration ⊘ Skipped`.

## Testing

- 30 driver unit tests pass (`test_verify_test_gate.py`, `test_build_callback_summary.py`)
- `discover-e2e-suites` globber verified to return `count=0` / exit 0 on both missing and empty `tests/integration/`
- pre-commit clean (ruff / ruff-format / pyright / isort / check-yaml); YAML validated

🤖 Generated with [Claude Code](https://claude.com/claude-code)