### PR TITLE
feat(conformance): add T018 — integration tier deselected by addopts

### DIFF
--- a/docs/guides/integration-testing.md
+++ b/docs/guides/integration-testing.md
@@ -187,6 +187,32 @@ uv run pytest tests/integration/ -v
 
 In CI: the `tests` job in your `.github/workflows/tests.yaml` uses [`connector-integration-tests@main`](../standards/connector-ci-e2e.md) which runs exactly this command, with the env vars wired from repo secrets.
 
+## Markers and CI tiering — the directory *is* the boundary
+
+The reusable Tests workflow runs the two tiers as **separate, directory-scoped jobs**: the unit job runs `pytest tests/unit`, and the integration job runs `pytest tests/integration/`. Neither re-selects by marker. Two rules follow from that:
+
+- **Mark integration tests with the single standard `integration` marker** (conformance **T001**). It documents intent and lets a developer skip the heavy tier locally with `-m "not integration"`. Use one marker, not a family of bespoke ones (`s3_integration`, `azure_integration`, …).
+- **Do _not_ `addopts`-deselect that marker** (conformance **T018**). Because the integration job selects by path, an `addopts = "-m 'not integration'"` in `pyproject.toml` is applied to `pytest tests/integration/` too and removes those tests from the only job meant to run them. If it deselects *every* test in the directory, the job collects nothing and fails with **pytest exit code 5** (`no tests ran`); if it deselects some, they silently run in no tier at all.
+
+```toml
+# pyproject.toml — the standard shape (see atlan-mysql-app, atlan-metabase-app)
+[tool.pytest.ini_options]
+markers = ["integration: requires external services; deselect locally with -m 'not integration'"]
+# NO addopts '-m not ...' deselection — the directory is the tier boundary.
+```
+
+**Tests that need an external service** (an emulator, a live source) should **self-skip at runtime** when it is unavailable — a module-scoped autouse fixture that probes the endpoint and calls `pytest.skip(...)`:
+
+```python
+@pytest.fixture(scope="module", autouse=True)
+def require_minio() -> None:
+    """Skip this module's tests when MinIO isn't reachable (bare local run)."""
+    if not _reachable(os.environ.get("AWS_ENDPOINT_URL", "http://localhost:9000")):
+        pytest.skip("MinIO not reachable; CI provisions it via services-script")
+```
+
+This keeps a bare local `pytest tests/integration/` green without the service while CI (which provisions it) runs the tests — without hiding anything from the CI tier, which an `addopts` deselect would. See [`atlan-openapi-app`](https://github.com/atlanhq/atlan-openapi-app/blob/main/tests/integration/test_s3_download.py) for the `require_minio` / `require_azurite` pattern.
+
 ## What to test
 
 | Scenario | What to assert |

--- a/packages/conformance/conformance/docs/rules/tests.md
+++ b/packages/conformance/conformance/docs/rules/tests.md
@@ -5,7 +5,7 @@
 
 # Test-Quality Rules (T-series)
 
-**17 rules** · Checker: `suite.checks.integration_marking` (T001), `suite.checks.sdr_test_checks` (T002-T003), `suite.checks.dev_entrypoint` (T004), `suite.checks.test_quality` (T005-T009), `suite.checks.test_structure` (T010-T013), `suite.checks.coverage_config` (T014-T015), `suite.checks.e2e_deployment_name` (T016), and `suite.checks.e2e_agent_spec` (T017) (AST/TOML/YAML-based)
+**18 rules** · Checker: `suite.checks.integration_marking` (T001), `suite.checks.sdr_test_checks` (T002-T003), `suite.checks.dev_entrypoint` (T004), `suite.checks.test_quality` (T005-T009), `suite.checks.test_structure` (T010-T013), `suite.checks.coverage_config` (T014-T015), `suite.checks.e2e_deployment_name` (T016), `suite.checks.e2e_agent_spec` (T017), and `suite.checks.integration_deselect` (T018) (AST/TOML/YAML-based)
 
 Suppress a finding on the violating line or the line directly above it:
 
@@ -32,6 +32,7 @@ Suppress a finding on the violating line or the line directly above it:
 | [T015](#t015) | `CoverageOmitsProductCode` | `warn` | `app` | `coverage-config` | — | 0.12.0 |
 | [T016](#t016) | `E2EDeploymentNameNotInherited` | `warn` | `app` | `e2e-ci` | — | 0.13.0 |
 | [T017](#t017) | `E2EAgentSpecPinsQueue` | `warn` | `app` | `e2e-ci` | — | 0.13.0 |
+| [T018](#t018) | `IntegrationTierDeselectedByAddopts` | `warn` | `app` | `test-collection` | — | 0.16.0 |
 
 ---
 
@@ -746,5 +747,79 @@ overlay and the agent_spec together, never one alone.
 Suppress with `# conformance: ignore[T017] <reason>` on the `def agent_spec` line only
 when the hard-coded queue is deliberate (e.g. a single-leg suite that never fans out and
 whose overlay also hard-codes the same un-suffixed value).
+
+---
+
+## T018 — `IntegrationTierDeselectedByAddopts` {#t018}
+
+**Tier:** `warn` · **Scope:** `app` · **Category:** `test-collection` · **Autofixable:** — · **Since:** 0.16.0
+
+> pyproject addopts '-m not <marker>' deselects tests under tests/integration/, emptying or thinning the directory-scoped integration CI job
+
+**Rationale:** The reusable Tests workflow (application-sdk#2852) runs the integration tier by
+directory — the CI job invokes 'pytest tests/integration/' with no '-m' selection,
+because the unit tier is a separate directory-scoped job ('pytest tests/unit'), not a
+full-suite run that deselects integration via markers. A
+[tool.pytest.ini_options].addopts '-m not <marker>' expression is still applied to every
+pytest invocation, including that integration job — so if it deselects a marker carried
+by tests under tests/integration/, those tests are removed from the one job meant to run
+them. When the deselection matches every collectable test in the directory, the job
+collects zero tests and pytest exits 5 (a hard CI failure); when it matches only some,
+those are silently dropped from all tiers (the unit job never sees tests/integration/,
+and the integration job just deselected them). This surfaced on a canonical connector
+whose integration tests had in fact never executed in CI: pre-split, the single job
+collected tests/unit + tests/integration together, the unit tests made the run
+non-empty, and the addopts-deselected integration tests were silently skipped on every
+run. This is the inverse of T001: keep the marker present (T001), but do not
+addopts-deselect it — the directory is the tier boundary.
+
+`[tool.pytest.ini_options].addopts` in `pyproject.toml` contains a `-m 'not <marker>'`
+selection expression, and one or more collectable tests under `tests/integration/` carry
+a deselected marker.
+
+The reusable Tests workflow runs the integration tier **by directory** (`pytest
+tests/integration/`) with no `-m` re-selection — the unit tier is a separate `pytest
+tests/unit` job, so integration tests no longer need a marker to be kept *out* of the
+unit job. But `addopts` applies to every pytest run, so a `-m 'not <marker>'`
+deselection is still applied to the integration job and removes any `tests/integration/`
+test carrying that marker from the only job meant to run it:
+
+* **All deselected** — the integration job collects nothing and fails   with `pytest`
+exit code 5 (`no tests ran`). * **Some deselected** — those tests run in no tier at all
+(the unit job   never collects `tests/integration/`; the integration job deselects
+them), so they silently stop contributing any signal.
+
+This is the inverse of **T001**, which wants integration tests to *carry* the
+`integration` marker. Both hold at once: keep the marker, but do **not**
+`addopts`-deselect it.
+
+**Remediation:** remove the `-m 'not …'` deselection from `addopts` and mark integration
+tests with the standard `integration` marker (T001) — the directory is the tier
+boundary, exactly as `atlan-mysql-app` / `atlan-metabase-app` do (marker present, no
+`addopts` deselect). Before:
+
+```toml
+[tool.pytest.ini_options]
+markers = ["s3_integration: ...", "azure_integration: ..."]
+addopts = "-m 'not s3_integration and not azure_integration'"
+```
+
+After:
+
+```toml
+[tool.pytest.ini_options]
+markers = ["integration: requires external services; deselect locally with -m 'not integration'"]
+# no addopts -m deselection
+```
+
+For tests that need an external service (an emulator, a live source), self-skip at
+runtime when it is unavailable — a module-scoped autouse fixture that probes the
+endpoint and calls `pytest.skip(...)` — so a bare local `pytest tests/integration/`
+stays green without the service while CI (which provisions it) runs the tests. Do not
+fall back to an `addopts` deselect for this: it hides the tests from the CI tier too.
+
+Suppress with `# conformance: ignore[T018] <reason>` on the `addopts` line only when the
+deselection is deliberate and the deselected tests are run by some other
+explicitly-configured CI job (rare — prefer the directory + runtime-skip pattern above).
 
 ---

--- a/packages/conformance/conformance/programs/areas/tests.prose.md
+++ b/packages/conformance/conformance/programs/areas/tests.prose.md
@@ -6,8 +6,10 @@ description: >
   test-quality conformance findings: unmarked integration tests (T001), SDR
   test-coverage gaps (T002-T003), dev-entrypoint delegation (T004), assertion
   meaningfulness and silent non-execution (T005-T009), test-tier structure and
-  placement (T010-T013), coverage-config integrity (T014-T015), and e2e CI
-  queue isolation (T016 worker-side overlay + T017 harness-side agent_spec).
+  placement (T010-T013), coverage-config integrity (T014-T015), e2e CI
+  queue isolation (T016 worker-side overlay + T017 harness-side agent_spec), and
+  the directory-scoped integration tier being deselected by pyproject addopts
+  (T018).
   Every rule in this series classifies as "judgment" — each fix requires reading
   the test's I/O intent, the app's manifest/contract, or the app's App subclass
   before a fix can be proposed with confidence.  T014/T015 are the most
@@ -16,7 +18,9 @@ description: >
   confirming an omit pattern is legitimate still requires judgment.  T016/T017
   are a matched pair (the worker queue and the harness queue must agree);
   T016 edits a file under `.github/` (outside write-scope) and T017 edits a file
-  under `tests/` (also outside write-scope), so both route to residue.
+  under `tests/` (also outside write-scope), so both route to residue.  T018
+  edits `pyproject.toml` (within write-scope), but whether an integration-tier
+  deselect is legitimate is a judgment call, so it routes to residue too.
 ---
 
 ### Maintains
@@ -430,6 +434,59 @@ to residue):
 
   `classification` is always `"judgment"` (edits a file outside write-scope;
   routed to residue for a human to apply).
+
+- **T018 IntegrationTierDeselectedByAddopts** — `[tool.pytest.ini_options].addopts`
+  in `pyproject.toml` carries a `-m 'not <marker>'` selection expression, and one
+  or more collectable tests under `tests/integration/` carry that deselected
+  marker. The reusable Tests workflow (application-sdk#2852) runs the integration
+  tier **by directory** (`pytest tests/integration/`, no `-m` re-selection), but
+  `addopts` applies to every pytest run, so the deselect is still applied to the
+  integration job and removes those tests from the only job meant to run them.
+  When it deselects every collectable test the job collects nothing and pytest
+  exits 5 (a hard CI failure); when it deselects only some, those run in no tier
+  at all (the unit job never collects `tests/integration/`; the integration job
+  deselects them), so they silently stop contributing signal. This is the inverse
+  of T001: keep the `integration` marker present (T001), but do **not**
+  `addopts`-deselect it — the directory is the tier boundary.
+
+  The fix is to remove the `-m 'not …'` deselection from `addopts` and rely on
+  the directory boundary plus the standard `integration` marker (T001), exactly
+  as `atlan-mysql-app` / `atlan-metabase-app` do. Before:
+
+  ```toml
+  [tool.pytest.ini_options]
+  markers = ["s3_integration: ...", "azure_integration: ..."]
+  addopts = "-m 'not s3_integration and not azure_integration'"
+  ```
+
+  After:
+
+  ```toml
+  [tool.pytest.ini_options]
+  markers = ["integration: requires external services; deselect locally with -m 'not integration'"]
+  # no addopts -m deselection
+  ```
+
+  For tests that need an external service (an emulator, a live source), self-skip
+  at runtime when it is unavailable — a module-scoped autouse fixture that probes
+  the endpoint and calls `pytest.skip(...)` — so a bare local
+  `pytest tests/integration/` stays green without the service while CI (which
+  provisions it) runs the tests. Do not fall back to an `addopts` deselect for
+  this: it hides the tests from the CI tier too.
+
+  **Route to residue** with the suggested edit. Unlike T016/T017 the target file
+  (`pyproject.toml`) is within write-scope, but deciding whether a given deselect
+  is legitimate — versus one that silently drops a real integration tier — is a
+  judgment call series-typical for the T-series, so T018 is not auto-applied.
+
+  Suppress with `# conformance: ignore[T018] <reason>` on the `addopts` line only
+  when the deselection is deliberate and the deselected tests are run by some
+  other explicitly-configured CI job (rare — prefer the directory + runtime-skip
+  pattern above); state that reason explicitly.
+
+  `classification` is always `"judgment"` (whether an integration-tier deselect
+  is legitimate requires reading the app's CI jobs and test intent; routed to
+  residue for a human to confirm).
 
 **Suppress outcome (strict mode only, WARNING-tier findings)**:
 

--- a/packages/conformance/conformance/suite/checks/integration_deselect.py
+++ b/packages/conformance/conformance/suite/checks/integration_deselect.py
@@ -1,0 +1,308 @@
+"""T018 IntegrationTierDeselectedByAddopts — flag an ``addopts`` ``-m`` filter
+that removes tests from the directory-scoped integration tier.
+
+Since the Unit/Integration split (application-sdk#2852), the reusable Tests
+workflow runs the integration tier **by directory** — the CI job invokes
+``pytest tests/integration/`` with no ``-m`` re-selection (the unit tier is a
+separate ``pytest tests/unit`` job). A ``[tool.pytest.ini_options].addopts``
+``-m 'not <marker>'`` deselection still applies to *that* invocation, so any
+test under ``tests/integration/`` carrying a deselected marker is removed from
+the only job meant to run it:
+
+* deselecting **every** collectable integration test → the job collects nothing
+  and fails with ``pytest`` exit 5 (``no tests ran``);
+* deselecting **some** → those tests run in no tier at all (the unit job never
+  collects ``tests/integration/``; the integration job deselects them).
+
+This is the inverse of :mod:`integration_marking` (T001), which wants the
+``integration`` marker *present*. Both hold at once: keep the marker, but don't
+``addopts``-deselect it — the directory is the tier boundary (see
+``atlan-mysql-app`` / ``atlan-metabase-app``: marker present, no deselect).
+
+Reuse
+-----
+The ``-m`` deselection parser and the per-test marker resolution are the
+canonical implementations in :mod:`integration_marking` (T001), imported here so
+both rules read markers identically rather than diverging.
+
+Inline suppression
+------------------
+Add ``# conformance: ignore[T018] <reason>`` on the ``addopts`` line (or the
+line directly above it).
+
+Known coverage limits (intentional — biased toward zero false positives at WARN
+tier; documented rather than silently capped):
+
+* **``-m`` handling is syntactic**, inherited from T001: only ``not <marker>``
+  terms are extracted (the standard ``not a and not b`` deselection form). A
+  non-standard selection expression that doesn't use ``not`` is treated as
+  deselecting nothing.
+* **Marker resolution is syntactic** (module ``pytestmark`` / class decorator or
+  ``pytestmark`` / function decorator); dynamically applied markers
+  (``add_marker``, ``pytest.param(marks=...)``) are not resolved.
+* **Collection mirrors pytest defaults** (``test*`` functions, ``Test*``
+  classes, ``test_*.py`` / ``*_test.py`` files under ``tests/integration/``).
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+import sys
+import tomllib
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+
+from conformance.suite.checks._ast_common import (
+    is_test_class,
+    is_test_function,
+    make_cli_main,
+    make_toml_finding,
+    parse_toml_suppressions,
+)
+
+# Canonical marker/addopts parsers live in the T001 check — import them so the
+# two rules never diverge on how a marker or a `-m` deselection is read.
+from conformance.suite.checks.integration_marking import (
+    _decorator_markers,
+    _deselected_markers,
+    _pytestmark_markers_in_body,
+)
+from conformance.suite.checks.integration_marking import discover as _discover_tests
+from conformance.suite.schema.findings import Finding
+
+SERIES = "T"
+RULE_T018 = "T018"
+
+# ``addopts = ...`` assignment line (for anchoring the finding + suppressions).
+_ADDOPTS_LINE_RE = re.compile(r"^\s*addopts\s*=")
+
+# Cap how many test labels are listed in the message so a whole-suite
+# deselection doesn't produce an unreadable wall of names.
+_MAX_LISTED = 5
+
+__all__ = [
+    "SERIES",
+    "IntegrationTest",
+    "deselected_labels",
+    "discover",
+    "main",
+    "scan_all",
+    "scan_path",
+    "scan_text",
+]
+
+
+@dataclass(frozen=True)
+class IntegrationTest:
+    """A collectable test under ``tests/integration/`` and its effective markers.
+
+    ``markers`` is the union of module ``pytestmark``, enclosing-class markers,
+    and the test's own decorator markers — mirroring pytest's marker hierarchy.
+    """
+
+    label: str
+    markers: frozenset[str]
+
+
+# ---------------------------------------------------------------------------
+# Pure core (filesystem-free — unit-testable)
+# ---------------------------------------------------------------------------
+
+
+def deselected_labels(
+    tests: Iterable[IntegrationTest], deselected_markers: Iterable[str]
+) -> list[str]:
+    """Labels of *tests* removed by a ``-m 'not …'`` *deselected_markers* set.
+
+    A test is removed when it carries at least one deselected marker — the
+    behaviour of the standard ``not a and not b`` conjunction form.
+    """
+    deselected = frozenset(deselected_markers)
+    if not deselected:
+        return []
+    return [t.label for t in tests if t.markers & deselected]
+
+
+def _message(deselected_markers: frozenset[str], removed: list[str], total: int) -> str:
+    markers = ", ".join(sorted(deselected_markers))
+    if removed and len(removed) >= total:
+        impact = (
+            f"deselects all {total} collectable test(s) under tests/integration/, "
+            "so the directory-scoped integration CI job "
+            "('pytest tests/integration/') collects nothing and fails with pytest "
+            "exit code 5 (no tests ran)"
+        )
+    else:
+        impact = (
+            f"deselects {len(removed)} of {total} collectable test(s) under "
+            "tests/integration/, so those tests run in no tier at all (the unit "
+            "job never collects tests/integration/, and the integration job "
+            "deselects them)"
+        )
+    listed = ", ".join(removed[:_MAX_LISTED])
+    if len(removed) > _MAX_LISTED:
+        listed += f", … (+{len(removed) - _MAX_LISTED} more)"
+    return (
+        f"pyproject addopts '-m not …' (markers: {markers}) {impact}. "
+        f"Removed: {listed}. Remove the addopts '-m' deselection and mark "
+        "integration tests with the standard 'integration' marker — the directory "
+        "is the tier boundary (see atlan-mysql-app / atlan-metabase-app). "
+        "Service-dependent tests should self-skip at runtime, not be "
+        "addopts-deselected. See T018."
+    )
+
+
+# ---------------------------------------------------------------------------
+# TOML / filesystem helpers
+# ---------------------------------------------------------------------------
+
+
+def _addopts_value(text: str) -> object | None:
+    """Return ``[tool.pytest.ini_options].addopts`` from *text*, or ``None``."""
+    try:
+        data = tomllib.loads(text)
+    except tomllib.TOMLDecodeError:
+        return None
+    if not isinstance(data, dict):
+        return None
+    tool = data.get("tool")
+    pytest_tbl = tool.get("pytest") if isinstance(tool, dict) else None
+    ini = pytest_tbl.get("ini_options") if isinstance(pytest_tbl, dict) else None
+    return ini.get("addopts") if isinstance(ini, dict) else None
+
+
+def _addopts_line(text: str) -> int:
+    for i, line in enumerate(text.splitlines(), start=1):
+        if _ADDOPTS_LINE_RE.match(line):
+            return i
+    return 1
+
+
+def _integration_tests(root: Path) -> list[IntegrationTest]:
+    """Collect ``tests/integration/`` tests and their effective markers.
+
+    Reuses T001's ``discover`` (pytest default globs under tests/integration/)
+    and its marker resolution so the two checks agree test-for-test.
+    """
+    tests: list[IntegrationTest] = []
+    for path in _discover_tests(root):
+        try:
+            src = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        try:
+            tree = ast.parse(src, filename=str(path))
+        except SyntaxError:
+            continue
+        try:
+            rel = path.relative_to(root)
+        except ValueError:
+            rel = path
+        module_markers = _pytestmark_markers_in_body(tree.body)
+        for node in tree.body:
+            if is_test_function(node):
+                markers = module_markers | _decorator_markers(node)
+                tests.append(IntegrationTest(f"{rel}::{node.name}", frozenset(markers)))
+            elif is_test_class(node):
+                class_markers = (
+                    module_markers
+                    | _decorator_markers(node)
+                    | _pytestmark_markers_in_body(node.body)
+                )
+                for sub in node.body:
+                    if is_test_function(sub):
+                        markers = class_markers | _decorator_markers(sub)
+                        tests.append(
+                            IntegrationTest(
+                                f"{rel}::{node.name}::{sub.name}", frozenset(markers)
+                            )
+                        )
+    return tests
+
+
+# ---------------------------------------------------------------------------
+# Scan API
+# ---------------------------------------------------------------------------
+
+
+def scan_text(
+    text: str,
+    file: str,
+    *,
+    integration_tests: Iterable[IntegrationTest] | None = None,
+) -> list[Finding]:
+    """Scan a ``pyproject.toml`` *text* for T018.
+
+    *integration_tests* supplies the tests/integration/ collectables + markers
+    (from the filesystem via :func:`scan_path`); a caller with only the TOML text
+    (e.g. a unit test) passes them explicitly. When it is ``None`` the check has
+    no test context and no-ops — the deselection is only a problem relative to
+    what lives under ``tests/integration/``.
+    """
+    deselected = _deselected_markers(_addopts_value(text))
+    if not deselected:
+        return []
+    tests = list(integration_tests) if integration_tests is not None else []
+    removed = deselected_labels(tests, deselected)
+    if not removed:
+        return []
+    return [
+        make_toml_finding(
+            rule_id=RULE_T018,
+            file=file,
+            line=_addopts_line(text),
+            column=1,
+            message=_message(deselected, removed, len(tests)),
+            suppressions=parse_toml_suppressions(text),
+        )
+    ]
+
+
+def scan_path(path: Path, root: Path) -> list[Finding]:
+    """Scan the repo-root ``pyproject.toml`` for T018.
+
+    Resolves the ``tests/integration/`` collectables from *root* so the finding
+    reflects the real interaction between the app's ``addopts`` and its suite.
+    """
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return []
+    try:
+        rel = path.relative_to(root)
+    except ValueError:
+        rel = path
+    return scan_text(text, str(rel), integration_tests=_integration_tests(root))
+
+
+def scan_all(paths: list[Path], root: Path) -> list[Finding]:
+    """Cross-file entry point (used by the standalone CLI)."""
+    findings: list[Finding] = []
+    for path in paths:
+        if path.name == "pyproject.toml":
+            findings.extend(scan_path(path, root))
+    return findings
+
+
+def discover(root: Path) -> list[Path]:
+    """Discover the repo-root ``pyproject.toml`` (``[]`` when absent → no-op)."""
+    pyproject = root / "pyproject.toml"
+    return [pyproject] if pyproject.is_file() else []
+
+
+main = make_cli_main(
+    scan_all=scan_all,
+    description=(
+        "T018: flag a pyproject addopts '-m not <marker>' filter that deselects "
+        "tests under tests/integration/ from the directory-scoped integration job."
+    ),
+    discover=discover,
+    default_scan_paths=("pyproject.toml",),
+)
+"""CLI entry point for the T018 integration-deselect check."""
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/conformance/conformance/suite/rules/tests.py
+++ b/packages/conformance/conformance/suite/rules/tests.py
@@ -128,6 +128,19 @@ harness's queue must agree; remediate both together, never one alone):
   inherits the leg-suffixed value (T016), the two diverge and the run hangs —
   the atlan-metabase-app regression where the overlay was fixed but the
   agent_spec was left hard-coded.
+
+Directory-scoped tiering (the Unit/Integration split, application-sdk#2852):
+
+* ``T018`` — the reusable Tests workflow now runs the integration tier by
+  *directory* (``pytest tests/integration/``) with no ``-m`` re-selection, so a
+  ``[tool.pytest.ini_options].addopts`` ``-m 'not <marker>'`` deselection that
+  matches tests living under ``tests/integration/`` removes them from the only
+  job meant to run them.  When it deselects *every* such test the integration
+  job collects nothing and hard-fails (pytest exit 5); a partial deselection
+  silently drops those tests from all tiers.  This is the inverse of T001 (which
+  wants the ``integration`` marker *present*): keep the marker, but do **not**
+  ``addopts``-deselect it — the directory is the tier boundary, exactly as
+  atlan-mysql-app / atlan-metabase-app already do (marker present, no deselect).
 """
 
 from __future__ import annotations
@@ -1108,6 +1121,102 @@ RULES: tuple[RuleDefinition, ...] = (
         help_uri=(
             "https://github.com/atlanhq/application-sdk/blob/main/"
             "packages/conformance/conformance/docs/rules/tests.md#t017"
+        ),
+    ),
+    RuleDefinition(
+        id="T018",
+        scope=RuleScope.APP,
+        name="IntegrationTierDeselectedByAddopts",
+        tier=EnforcementTier.WARN,
+        mechanism=RuleMechanism.STATIC,
+        category="test-collection",
+        autofixable=False,
+        since="0.16.0",
+        rationale=(
+            "The reusable Tests workflow (application-sdk#2852) runs the "
+            "integration tier by directory — the CI job invokes "
+            "'pytest tests/integration/' with no '-m' selection, because the unit "
+            "tier is a separate directory-scoped job ('pytest tests/unit'), not a "
+            "full-suite run that deselects integration via markers. A "
+            "[tool.pytest.ini_options].addopts '-m not <marker>' expression is "
+            "still applied to every pytest invocation, including that integration "
+            "job — so if it deselects a marker carried by tests under "
+            "tests/integration/, those tests are removed from the one job meant to "
+            "run them. When the deselection matches every collectable test in the "
+            "directory, the job collects zero tests and pytest exits 5 (a hard CI "
+            "failure); when it matches only some, those are silently dropped from "
+            "all tiers (the unit job never sees tests/integration/, and the "
+            "integration job just deselected them). This surfaced on a canonical "
+            "connector whose integration tests had in fact never executed in CI: "
+            "pre-split, the single job collected tests/unit + tests/integration "
+            "together, the unit tests made the run non-empty, and the "
+            "addopts-deselected integration tests were silently skipped on every "
+            "run. This is the inverse of T001: keep the marker present (T001), but "
+            "do not addopts-deselect it — the directory is the tier boundary."
+        ),
+        short_description=(
+            "pyproject addopts '-m not <marker>' deselects tests under "
+            "tests/integration/, emptying or thinning the directory-scoped "
+            "integration CI job"
+        ),
+        full_description=(
+            "``[tool.pytest.ini_options].addopts`` in ``pyproject.toml`` contains a\n"
+            "``-m 'not <marker>'`` selection expression, and one or more collectable\n"
+            "tests under ``tests/integration/`` carry a deselected marker.\n"
+            "\n"
+            "The reusable Tests workflow runs the integration tier **by directory**\n"
+            "(``pytest tests/integration/``) with no ``-m`` re-selection — the unit\n"
+            "tier is a separate ``pytest tests/unit`` job, so integration tests no\n"
+            "longer need a marker to be kept *out* of the unit job. But ``addopts``\n"
+            "applies to every pytest run, so a ``-m 'not <marker>'`` deselection is\n"
+            "still applied to the integration job and removes any ``tests/integration/``\n"
+            "test carrying that marker from the only job meant to run it:\n"
+            "\n"
+            "* **All deselected** — the integration job collects nothing and fails\n"
+            "  with ``pytest`` exit code 5 (``no tests ran``).\n"
+            "* **Some deselected** — those tests run in no tier at all (the unit job\n"
+            "  never collects ``tests/integration/``; the integration job deselects\n"
+            "  them), so they silently stop contributing any signal.\n"
+            "\n"
+            "This is the inverse of **T001**, which wants integration tests to *carry*\n"
+            "the ``integration`` marker. Both hold at once: keep the marker, but do\n"
+            "**not** ``addopts``-deselect it.\n"
+            "\n"
+            "**Remediation:** remove the ``-m 'not …'`` deselection from ``addopts``\n"
+            "and mark integration tests with the standard ``integration`` marker\n"
+            "(T001) — the directory is the tier boundary, exactly as\n"
+            "``atlan-mysql-app`` / ``atlan-metabase-app`` do (marker present, no\n"
+            "``addopts`` deselect). Before:\n"
+            "\n"
+            ".. code-block:: toml\n"
+            "\n"
+            "    [tool.pytest.ini_options]\n"
+            '    markers = ["s3_integration: ...", "azure_integration: ..."]\n'
+            "    addopts = \"-m 'not s3_integration and not azure_integration'\"\n"
+            "\n"
+            "After:\n"
+            "\n"
+            ".. code-block:: toml\n"
+            "\n"
+            "    [tool.pytest.ini_options]\n"
+            "    markers = [\"integration: requires external services; deselect locally with -m 'not integration'\"]\n"
+            "    # no addopts -m deselection\n"
+            "\n"
+            "For tests that need an external service (an emulator, a live source),\n"
+            "self-skip at runtime when it is unavailable — a module-scoped autouse\n"
+            "fixture that probes the endpoint and calls ``pytest.skip(...)`` — so a\n"
+            "bare local ``pytest tests/integration/`` stays green without the service\n"
+            "while CI (which provisions it) runs the tests. Do not fall back to an\n"
+            "``addopts`` deselect for this: it hides the tests from the CI tier too.\n"
+            "\n"
+            "Suppress with ``# conformance: ignore[T018] <reason>`` on the ``addopts``\n"
+            "line only when the deselection is deliberate and the deselected tests\n"
+            "are run by some other explicitly-configured CI job (rare — prefer the\n"
+            "directory + runtime-skip pattern above).\n"
+        ),
+        help_uri=(
+            "https://github.com/atlanhq/application-sdk/blob/main/"
+            "packages/conformance/conformance/docs/rules/tests.md#t018"
         ),
     ),
 )

--- a/packages/conformance/conformance/suite/runner.py
+++ b/packages/conformance/conformance/suite/runner.py
@@ -43,6 +43,7 @@ from conformance.suite.checks import (
     error_handling,
     generated_freshness,
     gitignore_entries,
+    integration_deselect,
     integration_marking,
     legacy_contract,
     manifest_contract,
@@ -163,6 +164,11 @@ _CHECKS: list[CheckRegistration] = [
         series=coverage_config.SERIES,
         discover=coverage_config.discover,
         scan_path=coverage_config.scan_path,
+    ),
+    CheckRegistration(
+        series=integration_deselect.SERIES,
+        discover=integration_deselect.discover,
+        scan_path=integration_deselect.scan_path,
     ),
     CheckRegistration(
         series=e2e_deployment_name.SERIES,

--- a/packages/conformance/conformance/tools/generate_rule_docs.py
+++ b/packages/conformance/conformance/tools/generate_rule_docs.py
@@ -162,8 +162,9 @@ _SERIES_META: list[SeriesMeta] = [
             "`suite.checks.test_quality` (T005-T009), "
             "`suite.checks.test_structure` (T010-T013), "
             "`suite.checks.coverage_config` (T014-T015), "
-            "`suite.checks.e2e_deployment_name` (T016), and "
-            "`suite.checks.e2e_agent_spec` (T017) (AST/TOML/YAML-based)"
+            "`suite.checks.e2e_deployment_name` (T016), "
+            "`suite.checks.e2e_agent_spec` (T017), and "
+            "`suite.checks.integration_deselect` (T018) (AST/TOML/YAML-based)"
         ),
         suppression_example=(
             "# conformance: ignore[T001] intentional: marked dynamically via add_marker"

--- a/packages/conformance/tests/test_catalog.py
+++ b/packages/conformance/tests/test_catalog.py
@@ -262,6 +262,7 @@ def test_catalog_app_scoped_rules_are_the_expected_set() -> None:
         "T015",
         "T016",
         "T017",
+        "T018",
         "O002",
         "O003",
         "O004",
@@ -479,10 +480,11 @@ def test_catalog_t_series_present() -> None:
     """The T-series test-quality rules are all present: T001 (integration
     marking), T002/T003 (SDR test-quality), T004 (dev-entrypoint), T005-T009
     (assertion/collection quality), T010-T013 (tier structure), T014/T015
-    (coverage-config), and T016/T017 (e2e-CI queue isolation)."""
+    (coverage-config), T016/T017 (e2e-CI queue isolation), and T018
+    (integration tier deselected by addopts)."""
     rules = load_catalog()
     t_ids = {r.id for r in rules if r.id.startswith("T")}
-    expected = {f"T{n:03d}" for n in range(1, 18)}
+    expected = {f"T{n:03d}" for n in range(1, 19)}
     missing = expected - t_ids
     assert not missing, f"Missing T-series rules: {missing}"
     extra = t_ids - expected

--- a/packages/conformance/tests/test_integration_deselect.py
+++ b/packages/conformance/tests/test_integration_deselect.py
@@ -1,0 +1,173 @@
+"""Meta-tests for the T018 integration-deselect check.
+
+T018 fires when a ``[tool.pytest.ini_options].addopts`` ``-m 'not <marker>'``
+deselection removes tests living under ``tests/integration/`` from the
+directory-scoped integration CI job (``pytest tests/integration/``) — emptying
+it (pytest exit 5) or silently thinning it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from conformance.suite.checks.integration_deselect import (
+    IntegrationTest,
+    deselected_labels,
+    scan_path,
+    scan_text,
+)
+from conformance.suite.rules import get_rule
+from conformance.suite.schema.disposition import EnforcementTier, RuleScope
+
+# ── Rule metadata ────────────────────────────────────────────────────────────
+
+
+def test_t018_rule_metadata() -> None:
+    rule = get_rule("T018")
+    assert rule.name == "IntegrationTierDeselectedByAddopts"
+    assert rule.tier == EnforcementTier.WARN
+    assert rule.scope == RuleScope.APP
+    assert rule.category == "test-collection"
+
+
+# ── Pure core: deselected_labels ─────────────────────────────────────────────
+
+
+def test_deselected_labels_matches_carriers() -> None:
+    tests = [
+        IntegrationTest("t.py::a", frozenset({"cloud_integration"})),
+        IntegrationTest("t.py::b", frozenset({"integration"})),
+        IntegrationTest("t.py::c", frozenset()),
+    ]
+    assert deselected_labels(tests, {"cloud_integration"}) == ["t.py::a"]
+
+
+def test_deselected_labels_empty_when_no_deselection() -> None:
+    tests = [IntegrationTest("t.py::a", frozenset({"cloud_integration"}))]
+    assert deselected_labels(tests, set()) == []
+
+
+# ── scan_text with injected integration tests ────────────────────────────────
+
+_ALL_MARKED = [
+    IntegrationTest(
+        "tests/integration/test_s3.py::T::a", frozenset({"s3_integration"})
+    ),
+    IntegrationTest(
+        "tests/integration/test_az.py::T::b", frozenset({"azure_integration"})
+    ),
+]
+
+
+def test_fires_and_reports_exit5_when_all_deselected() -> None:
+    text = (
+        "[tool.pytest.ini_options]\n"
+        "addopts = \"-m 'not s3_integration and not azure_integration'\"\n"
+    )
+    findings = scan_text(text, "pyproject.toml", integration_tests=_ALL_MARKED)
+    assert [f.rule_id for f in findings] == ["T018"]
+    # Whole tier deselected → message calls out the pytest exit-5 hard failure.
+    assert "exit code 5" in findings[0].message
+
+
+def test_fires_partial_when_some_deselected() -> None:
+    text = "[tool.pytest.ini_options]\naddopts = \"-m 'not s3_integration'\"\n"
+    findings = scan_text(text, "pyproject.toml", integration_tests=_ALL_MARKED)
+    assert [f.rule_id for f in findings] == ["T018"]
+    assert "1 of 2" in findings[0].message
+    assert "exit code 5" not in findings[0].message
+
+
+def test_silent_when_deselection_misses_integration_tier() -> None:
+    # addopts deselects a marker no integration test carries → harmless.
+    text = "[tool.pytest.ini_options]\naddopts = \"-m 'not slow'\"\n"
+    assert scan_text(text, "pyproject.toml", integration_tests=_ALL_MARKED) == []
+
+
+def test_silent_when_no_dash_m_deselection() -> None:
+    text = '[tool.pytest.ini_options]\naddopts = "-ra -q --tb=short"\n'
+    assert scan_text(text, "pyproject.toml", integration_tests=_ALL_MARKED) == []
+
+
+def test_silent_when_no_addopts_at_all() -> None:
+    assert scan_text('[project]\nname = "x"\n', "pyproject.toml") == []
+
+
+def test_noop_without_test_context() -> None:
+    # No integration_tests supplied (text-only caller): nothing to compare against.
+    text = "[tool.pytest.ini_options]\naddopts = \"-m 'not s3_integration'\"\n"
+    assert scan_text(text, "pyproject.toml") == []
+
+
+def test_anchored_on_addopts_line() -> None:
+    text = (
+        "[tool.pytest.ini_options]\n"
+        'asyncio_mode = "auto"\n'
+        "addopts = \"-m 'not s3_integration'\"\n"
+    )
+    findings = scan_text(text, "pyproject.toml", integration_tests=_ALL_MARKED)
+    assert findings[0].line == 3
+
+
+def test_suppressed_on_addopts_line() -> None:
+    text = (
+        "[tool.pytest.ini_options]\n"
+        "addopts = \"-m 'not s3_integration'\"  "
+        "# conformance: ignore[T018] scoped to a bespoke CI job\n"
+    )
+    findings = scan_text(text, "pyproject.toml", integration_tests=_ALL_MARKED)
+    # The finding is still produced but flagged suppressed (the runner drops it).
+    assert [f.rule_id for f in findings] == ["T018"]
+    assert findings[0].suppressed is True
+    assert findings[0].suppression_justification == "scoped to a bespoke CI job"
+
+
+# ── Filesystem end-to-end via scan_path ──────────────────────────────────────
+
+
+def _write_repo(root: Path, addopts: str, test_body: str) -> None:
+    (root / "pyproject.toml").write_text(
+        f"[tool.pytest.ini_options]\naddopts = {addopts}\n", encoding="utf-8"
+    )
+    integ = root / "tests" / "integration"
+    integ.mkdir(parents=True)
+    (integ / "__init__.py").write_text("", encoding="utf-8")
+    (integ / "test_thing.py").write_text(test_body, encoding="utf-8")
+
+
+def test_scan_path_fires_on_real_repo(tmp_path: Path) -> None:
+    _write_repo(
+        tmp_path,
+        "\"-m 'not cloud_integration'\"",
+        "import pytest\n\n"
+        "pytestmark = pytest.mark.cloud_integration\n\n"
+        "def test_a():\n    assert True\n",
+    )
+    findings = scan_path(tmp_path / "pyproject.toml", tmp_path)
+    assert [f.rule_id for f in findings] == ["T018"]
+    assert "exit code 5" in findings[0].message
+
+
+def test_scan_path_silent_on_standard_repo(tmp_path: Path) -> None:
+    # Standard shape: `integration` marker, no addopts deselect (mysql/metabase).
+    (tmp_path / "pyproject.toml").write_text(
+        '[tool.pytest.ini_options]\nmarkers = ["integration: ..."]\n',
+        encoding="utf-8",
+    )
+    integ = tmp_path / "tests" / "integration"
+    integ.mkdir(parents=True)
+    (integ / "test_thing.py").write_text(
+        "import pytest\n\n"
+        "pytestmark = pytest.mark.integration\n\n"
+        "def test_a():\n    assert True\n",
+        encoding="utf-8",
+    )
+    assert scan_path(tmp_path / "pyproject.toml", tmp_path) == []
+
+
+def test_scan_path_noop_without_integration_dir(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text(
+        "[tool.pytest.ini_options]\naddopts = \"-m 'not integration'\"\n",
+        encoding="utf-8",
+    )
+    assert scan_path(tmp_path / "pyproject.toml", tmp_path) == []


### PR DESCRIPTION
## What

Adds conformance rule **T018 IntegrationTierDeselectedByAddopts** (T-series, WARN, APP scope) and documents the underlying standard, so the failure mode that broke atlan-openapi-app's integration tier after the Unit/Integration split is caught fleet-wide.

## Why

The reusable Tests split (#2852) runs the integration tier **by directory** — the CI job is `pytest tests/integration/` with no `-m` re-selection (the unit tier is a separate `pytest tests/unit` job). But a `[tool.pytest.ini_options].addopts` `-m 'not <marker>'` deselection is applied to *every* pytest invocation, including that integration job. So an app that deselects a marker its `tests/integration/` tests carry removes them from the only job meant to run them:

- **all deselected** → the job collects nothing and fails with **pytest exit 5** (`no tests ran`);
- **some deselected** → those tests run in no tier at all (silent).

This is exactly what happened on atlan-openapi-app (atlan-openapi-app#273): its integration tests were `addopts`-deselected and had, in fact, **never executed in CI** — the pre-split single job collected `tests/unit` + `tests/integration` together, the unit tests kept the run non-empty, and the marked integration tests were silently skipped every run.

## What's in the rule

T018 is the **inverse of T001**: T001 wants the `integration` marker *present*; T018 says don't `addopts`-deselect it. Both hold at once — the standard shape (atlan-mysql-app / atlan-metabase-app) is *marker present, no deselect*.

- **Check** `suite/checks/integration_deselect.py` — parses the `addopts` `-m` deselection (reusing T001's canonical parser so the two never diverge) and the `tests/integration/` markers; fires when the deselection removes any of those tests. The message distinguishes the whole-tier exit-5 case from a partial silent drop and lists the removed tests. Pure, filesystem-free core (`deselected_labels`, typed `IntegrationTest`) for unit-testing.
- **Rule definition** in `suite/rules/tests.py` with full remediation guidance (remove the deselect, use the `integration` marker, self-skip service-dependent tests at runtime).
- **Wiring**: registered in the runner; doc-generator checker attribution updated; `docs/rules/tests.md` regenerated (now 18 rules).
- **Guide**: `docs/guides/integration-testing.md` gains a "Markers and CI tiering — the directory *is* the boundary" section.

## Testing

- `tests/test_integration_deselect.py` — 14 tests: rule metadata, pure-core `deselected_labels`, `scan_text` (all-deselected → exit-5 message; partial; misses-tier no-op; no-`-m`; no-addopts; no-test-context; anchor line; suppression), and filesystem `scan_path` (fires on a real repo, silent on the standard shape, no-op without `tests/integration/`).
- Full conformance suite green (1735 passed; the 18 unrelated failures are pre-existing `jsonschema`-not-installed SARIF-validation tests in this venv). `gen-rule-docs --check` clean; registry/catalog consistency tests pass.

## Related

- #2852 — the Unit/Integration split this rule backstops.
- atlan-openapi-app#273 — the connector fix that motivated it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)