### PR TITLE
feat(conformance): add T019 AsyncioTestLoopScopeUnset test-quality rule

### DIFF
--- a/packages/conformance/conformance/docs/rules/tests.md
+++ b/packages/conformance/conformance/docs/rules/tests.md
@@ -829,7 +829,7 @@ explicitly-configured CI job (rare — prefer the directory + runtime-skip patte
 
 **Tier:** `warn` · **Scope:** `both` · **Category:** `test-async-config` · **Autofixable:** — · **Since:** 0.17.0
 
-> pyproject sets asyncio_default_fixture_loop_scope to a broadened scope but leaves asyncio_default_test_loop_scope unset (defaults to 'function'), so in-body async tests can hang on fixture-owned resources
+> pyproject sets asyncio_default_fixture_loop_scope to a broadened scope with asyncio_default_test_loop_scope unset (defaults to 'function') AND a test drives workflow execution from its body, so that test hangs on the fixture-owned worker/client
 
 **Rationale:** pytest-asyncio has two independent loop-scope knobs in [tool.pytest.ini_options]:
 asyncio_default_fixture_loop_scope (the loop async fixtures default to) and
@@ -846,8 +846,13 @@ failure is silent by construction — tests that only read a value a fixture alr
 computed pass, so the mismatch hides until someone writes the first test that awaits
 fixture-owned work in-body. It surfaced on a canonical connector whose sole in-body
 Temporal test (a REUSE integration case) hung for the full pytest-timeout while every
-sibling test, which read a class-fixture result, passed. Keep the two scopes consistent:
-when fixtures are broadened, set the test scope explicitly too.
+sibling test, which read a class-fixture result, passed. Like T018 (which fires only
+when an addopts deselect removes tests that exist), this rule is correlated, not
+config-only: it fires only when the risky config coincides with a collectable test whose
+body actually drives workflow execution via an awaited
+execute_app/execute_workflow/start_workflow call. A suite that runs all execution inside
+fixtures and only asserts on the result in test bodies is on the safe path and is not
+flagged.
 
 `[tool.pytest.ini_options]` in `pyproject.toml` sets
 `asyncio_default_fixture_loop_scope` to a broadened scope (`session` / `package` /
@@ -866,6 +871,13 @@ The failure is silent by construction. Tests that only *read* a value a fixture 
 computed (the common case) pass, so the mismatch stays hidden until the first test that
 awaits fixture-owned work in-body is written — at which point it hangs, not fails, which
 is far costlier to diagnose.
+
+**Correlated, not config-only.** Like **T018**, this rule fires only when the risky
+config *and* real evidence coincide: a collectable test *function* (not a fixture) whose
+body awaits `execute_app` / `execute_workflow` / `start_workflow` — the SDK's
+workflow-submission surface. A suite with the mismatched config but all execution behind
+session/class-scoped fixtures (test bodies only assert on the result) is on the safe
+path and is **not** flagged.
 
 **Remediation:** set `asyncio_default_test_loop_scope` explicitly — usually to the same
 scope as the fixtures — so tests and their fixtures share a loop. Before:

--- a/packages/conformance/conformance/docs/rules/tests.md
+++ b/packages/conformance/conformance/docs/rules/tests.md
@@ -5,7 +5,7 @@
 
 # Test-Quality Rules (T-series)
 
-**18 rules** · Checker: `suite.checks.integration_marking` (T001), `suite.checks.sdr_test_checks` (T002-T003), `suite.checks.dev_entrypoint` (T004), `suite.checks.test_quality` (T005-T009), `suite.checks.test_structure` (T010-T013), `suite.checks.coverage_config` (T014-T015), `suite.checks.e2e_deployment_name` (T016), `suite.checks.e2e_agent_spec` (T017), and `suite.checks.integration_deselect` (T018) (AST/TOML/YAML-based)
+**19 rules** · Checker: `suite.checks.integration_marking` (T001), `suite.checks.sdr_test_checks` (T002-T003), `suite.checks.dev_entrypoint` (T004), `suite.checks.test_quality` (T005-T009), `suite.checks.test_structure` (T010-T013), `suite.checks.coverage_config` (T014-T015), `suite.checks.e2e_deployment_name` (T016), `suite.checks.e2e_agent_spec` (T017), `suite.checks.integration_deselect` (T018), and `suite.checks.asyncio_loop_scope` (T019) (AST/TOML/YAML-based)
 
 Suppress a finding on the violating line or the line directly above it:
 
@@ -33,6 +33,7 @@ Suppress a finding on the violating line or the line directly above it:
 | [T016](#t016) | `E2EDeploymentNameNotInherited` | `warn` | `app` | `e2e-ci` | — | 0.13.0 |
 | [T017](#t017) | `E2EAgentSpecPinsQueue` | `warn` | `app` | `e2e-ci` | — | 0.13.0 |
 | [T018](#t018) | `IntegrationTierDeselectedByAddopts` | `warn` | `app` | `test-collection` | — | 0.16.0 |
+| [T019](#t019) | `AsyncioTestLoopScopeUnset` | `warn` | `both` | `test-async-config` | — | 0.17.0 |
 
 ---
 
@@ -821,5 +822,78 @@ fall back to an `addopts` deselect for this: it hides the tests from the CI tier
 Suppress with `# conformance: ignore[T018] <reason>` on the `addopts` line only when the
 deselection is deliberate and the deselected tests are run by some other
 explicitly-configured CI job (rare — prefer the directory + runtime-skip pattern above).
+
+---
+
+## T019 — `AsyncioTestLoopScopeUnset` {#t019}
+
+**Tier:** `warn` · **Scope:** `both` · **Category:** `test-async-config` · **Autofixable:** — · **Since:** 0.17.0
+
+> pyproject sets asyncio_default_fixture_loop_scope to a broadened scope but leaves asyncio_default_test_loop_scope unset (defaults to 'function'), so in-body async tests can hang on fixture-owned resources
+
+**Rationale:** pytest-asyncio has two independent loop-scope knobs in [tool.pytest.ini_options]:
+asyncio_default_fixture_loop_scope (the loop async fixtures default to) and
+asyncio_default_test_loop_scope (the loop async tests default to), and the latter
+defaults to 'function' when unset. Setting the fixture scope to a broadened value
+(session/package/module/class) without also setting the test scope puts fixtures and
+tests on different loops: async fixtures share one long-lived loop while each test runs
+on its own function-scoped loop. A fixture that owns a live resource bound to its loop —
+a Temporal worker/client, an async DB engine/pool, an httpx.AsyncClient — is then
+invisible to a test that drives that resource from the test body: the test awaits work
+the fixture's loop must service, but that loop is not being driven while the test's loop
+runs, so nothing progresses and the test hangs until the suite timeout fires. The
+failure is silent by construction — tests that only read a value a fixture already
+computed pass, so the mismatch hides until someone writes the first test that awaits
+fixture-owned work in-body. It surfaced on a canonical connector whose sole in-body
+Temporal test (a REUSE integration case) hung for the full pytest-timeout while every
+sibling test, which read a class-fixture result, passed. Keep the two scopes consistent:
+when fixtures are broadened, set the test scope explicitly too.
+
+`[tool.pytest.ini_options]` in `pyproject.toml` sets
+`asyncio_default_fixture_loop_scope` to a broadened scope (`session` / `package` /
+`module` / `class`) but does not set `asyncio_default_test_loop_scope`, which **defaults
+to `function`**.
+
+Async fixtures then share one long-lived event loop, while each test runs on its own
+function-scoped loop. A fixture that owns a live resource bound to *its* loop — a
+Temporal worker/client, an async DB engine/pool, an `httpx.AsyncClient`, a broker
+consumer — is invisible to a test that drives that resource **from the test body**: the
+test awaits work the fixture's loop must service, but that loop is idle while the test's
+loop runs, so the await never completes and the test hangs until the suite timeout
+fires.
+
+The failure is silent by construction. Tests that only *read* a value a fixture already
+computed (the common case) pass, so the mismatch stays hidden until the first test that
+awaits fixture-owned work in-body is written — at which point it hangs, not fails, which
+is far costlier to diagnose.
+
+**Remediation:** set `asyncio_default_test_loop_scope` explicitly — usually to the same
+scope as the fixtures — so tests and their fixtures share a loop. Before:
+
+```toml
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "session"
+# asyncio_default_test_loop_scope unset -> defaults to 'function'
+```
+
+After:
+
+```toml
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "session"
+asyncio_default_test_loop_scope = "session"
+```
+
+Restructuring the offending test to run its async work inside a same-scope fixture
+(letting the test body only assert on the result) also removes the hang, and matches how
+most suites already drive workflow execution — but it leaves the config trap in place
+for the next author, so prefer the explicit test-scope setting as the durable fix.
+
+Suppress with `# conformance: ignore[T019] <reason>` on the
+`asyncio_default_fixture_loop_scope` line only when the mismatch is deliberate — e.g.
+every async fixture is loop-agnostic and no test drives fixture-owned work in-body — and
+state that reason.
 
 ---

--- a/packages/conformance/conformance/programs/areas/tests.prose.md
+++ b/packages/conformance/conformance/programs/areas/tests.prose.md
@@ -7,9 +7,10 @@ description: >
   test-coverage gaps (T002-T003), dev-entrypoint delegation (T004), assertion
   meaningfulness and silent non-execution (T005-T009), test-tier structure and
   placement (T010-T013), coverage-config integrity (T014-T015), e2e CI
-  queue isolation (T016 worker-side overlay + T017 harness-side agent_spec), and
+  queue isolation (T016 worker-side overlay + T017 harness-side agent_spec),
   the directory-scoped integration tier being deselected by pyproject addopts
-  (T018).
+  (T018), and a broadened pytest-asyncio fixture loop scope with no matching test
+  loop scope (T019).
   Every rule in this series classifies as "judgment" — each fix requires reading
   the test's I/O intent, the app's manifest/contract, or the app's App subclass
   before a fix can be proposed with confidence.  T014/T015 are the most
@@ -18,9 +19,10 @@ description: >
   confirming an omit pattern is legitimate still requires judgment.  T016/T017
   are a matched pair (the worker queue and the harness queue must agree);
   T016 edits a file under `.github/` (outside write-scope) and T017 edits a file
-  under `tests/` (also outside write-scope), so both route to residue.  T018
-  edits `pyproject.toml` (within write-scope), but whether an integration-tier
-  deselect is legitimate is a judgment call, so it routes to residue too.
+  under `tests/` (also outside write-scope), so both route to residue.  T018 and
+  T019 both edit `pyproject.toml` (within write-scope), but whether an
+  integration-tier deselect is legitimate (T018), and which test-loop scope a
+  suite should adopt (T019), are judgment calls, so both route to residue too.
 ---
 
 ### Maintains
@@ -487,6 +489,59 @@ to residue):
   `classification` is always `"judgment"` (whether an integration-tier deselect
   is legitimate requires reading the app's CI jobs and test intent; routed to
   residue for a human to confirm).
+
+- **T019 AsyncioTestLoopScopeUnset** — `[tool.pytest.ini_options]` in
+  `pyproject.toml` sets `asyncio_default_fixture_loop_scope` to a broadened scope
+  (`session` / `package` / `module` / `class`) but does not set
+  `asyncio_default_test_loop_scope`, which defaults to `function`. Async fixtures
+  then share one long-lived event loop while each test runs on its own
+  function-scoped loop. A fixture that owns a live resource bound to *its* loop —
+  a Temporal worker/client, an async DB engine/pool, an `httpx.AsyncClient` — is
+  invisible to a test that drives that resource from the test body: the test
+  awaits work the fixture's loop must service, but that loop is idle while the
+  test's loop runs, so the await never completes and the test hangs until the
+  suite timeout fires. The trap is silent — tests that only read a value a
+  fixture already computed pass, so it hides until the first in-body async test
+  is written.
+
+  The durable fix is a one-line config edit: set `asyncio_default_test_loop_scope`
+  explicitly, usually to the same scope as the fixtures, so tests and fixtures
+  share a loop. Before:
+
+  ```toml
+  [tool.pytest.ini_options]
+  asyncio_mode = "auto"
+  asyncio_default_fixture_loop_scope = "session"
+  # asyncio_default_test_loop_scope unset -> defaults to 'function'
+  ```
+
+  After:
+
+  ```toml
+  [tool.pytest.ini_options]
+  asyncio_mode = "auto"
+  asyncio_default_fixture_loop_scope = "session"
+  asyncio_default_test_loop_scope = "session"
+  ```
+
+  Restructuring the offending test so its async work runs inside a same-scope
+  fixture (the test body only asserts on the result) also removes the hang and
+  matches how most suites already drive workflow execution — but it leaves the
+  config trap for the next author, so prefer the explicit test-scope setting.
+
+  **Route to residue** with the suggested edit. The target file
+  (`pyproject.toml`) is within write-scope, but choosing the right test-loop
+  scope — and confirming the broadened fixture scope is itself intended — is a
+  judgment call series-typical for the T-series, so T019 is not auto-applied.
+
+  Suppress with `# conformance: ignore[T019] <reason>` on the
+  `asyncio_default_fixture_loop_scope` line only when the mismatch is deliberate
+  (e.g. every async fixture is loop-agnostic and no test drives fixture-owned
+  work in-body); state that reason explicitly.
+
+  `classification` is always `"judgment"` (the correct test-loop scope depends on
+  how the suite's async fixtures and tests interact, which the finding alone
+  doesn't say; routed to residue for a human to confirm).
 
 **Suppress outcome (strict mode only, WARNING-tier findings)**:
 

--- a/packages/conformance/conformance/programs/areas/tests.prose.md
+++ b/packages/conformance/conformance/programs/areas/tests.prose.md
@@ -493,16 +493,17 @@ to residue):
 - **T019 AsyncioTestLoopScopeUnset** — `[tool.pytest.ini_options]` in
   `pyproject.toml` sets `asyncio_default_fixture_loop_scope` to a broadened scope
   (`session` / `package` / `module` / `class`) but does not set
-  `asyncio_default_test_loop_scope`, which defaults to `function`. Async fixtures
-  then share one long-lived event loop while each test runs on its own
-  function-scoped loop. A fixture that owns a live resource bound to *its* loop —
-  a Temporal worker/client, an async DB engine/pool, an `httpx.AsyncClient` — is
-  invisible to a test that drives that resource from the test body: the test
-  awaits work the fixture's loop must service, but that loop is idle while the
-  test's loop runs, so the await never completes and the test hangs until the
-  suite timeout fires. The trap is silent — tests that only read a value a
-  fixture already computed pass, so it hides until the first in-body async test
-  is written.
+  `asyncio_default_test_loop_scope`, which defaults to `function` — **and** a
+  collectable test's body awaits `execute_app` / `execute_workflow` /
+  `start_workflow` (the finding message names the offending tests). Async
+  fixtures then share one long-lived event loop while each test runs on its own
+  function-scoped loop. The named test drives a fixture-owned Temporal
+  worker/client (bound to the fixture loop) from its own body: it awaits work the
+  fixture's loop must service, but that loop is idle while the test's loop runs,
+  so the await never completes and the test hangs until the suite timeout fires.
+  The trap is silent — tests that only read a value a fixture already computed
+  pass. Like T018, the rule is correlated, not config-only: a suite with the
+  mismatched config but all execution inside fixtures is not flagged.
 
   The durable fix is a one-line config edit: set `asyncio_default_test_loop_scope`
   explicitly, usually to the same scope as the fixtures, so tests and fixtures

--- a/packages/conformance/conformance/suite/checks/asyncio_loop_scope.py
+++ b/packages/conformance/conformance/suite/checks/asyncio_loop_scope.py
@@ -1,5 +1,6 @@
 """T019 AsyncioTestLoopScopeUnset — flag a broadened pytest-asyncio *fixture*
-loop scope with no matching *test* loop scope.
+loop scope with no matching *test* loop scope, **when a test actually drives
+fixture-owned workflow execution from its own body**.
 
 ``pytest-asyncio`` has two independent knobs in
 ``[tool.pytest.ini_options]``:
@@ -13,55 +14,68 @@ Setting the fixture scope to ``session`` / ``package`` / ``module`` / ``class``
 without also setting the test scope leaves the two on *different* loops: async
 fixtures share one long-lived loop, but each test runs on its own
 function-scoped loop. A session-scoped fixture that owns a live resource bound
-to *its* loop — a Temporal worker/client, an async DB engine/pool, an
-``httpx.AsyncClient``, a message-broker consumer — is then invisible to a test
-that drives that resource **from its own body**: the test awaits work the
-fixture's loop must service, but that loop is not being driven while the test's
-loop runs, so nothing progresses and the test hangs until the suite's timeout
-fires.
-
-The failure is silent by construction: tests that only *read* values a fixture
-already computed (the common case) pass, so the mismatch hides until someone
-writes the first test that awaits fixture-owned work in-body. That is exactly
-how it surfaced on a canonical connector — a single ``REUSE`` integration test
-that submitted a Temporal workflow from the test body hung for the full
+to *its* loop — a Temporal worker/client — is then invisible to a test that
+drives that resource **from its own body**: the test awaits work the fixture's
+loop must service, but that loop is not being driven while the test's loop runs,
+so nothing progresses and the test hangs until the suite timeout fires. It
+surfaced on a canonical connector — a single ``REUSE`` integration test that
+submitted a Temporal workflow from the test body hung for the full
 ``pytest-timeout`` while every sibling test (which read a class-fixture result)
 passed.
 
+Correlated, not config-only
+----------------------------
+The config mismatch alone is *not* a defect: a suite that runs all workflow
+execution inside fixtures (session/class-scoped async fixtures) and only asserts
+on the result in test bodies is on the safe path even with the test scope left
+implicit. So — exactly like **T018**, which fires only when an ``addopts``
+deselect actually removes tests that exist — this rule fires only when the risky
+config **and** real evidence coincide: at least one collectable test *function*
+(not a fixture) whose body drives workflow execution via an awaited
+``execute_app`` / ``execute_workflow`` / ``start_workflow`` call. A repo with the
+mismatched config but all execution behind fixtures (the metabase/mysql shape)
+is left silent.
+
 Remediation is a one-line config edit: set ``asyncio_default_test_loop_scope``
 explicitly — usually to the same scope as the fixtures — so tests and their
-fixtures share a loop. Restructuring the offending test to run its async work
-inside a same-scope fixture also removes the *hang*, but leaves the config trap
-in place for the next author; the config fix is the durable one.
+fixtures share a loop. Moving the offending call into a same-scope fixture (the
+test body only asserts on the result) also removes the hang and is the
+prevailing pattern, but leaves the config trap for the next author; the config
+fix is the durable one.
 
 Inline suppression
 ------------------
 Add ``# conformance: ignore[T019] <reason>`` on the
 ``asyncio_default_fixture_loop_scope`` line (or the line directly above it) when
-the mismatch is deliberate — e.g. every async fixture is loop-agnostic and no
-test drives fixture-owned work in-body — and state that reason.
+the in-body driver is deliberately loop-safe and state that reason.
 
 Known coverage limits (intentional — biased toward zero false positives at WARN
 tier):
 
-* **pyproject-only.** Reads ``[tool.pytest.ini_options]`` from the repo-root
-  ``pyproject.toml`` (the fleet convention). A ``pytest.ini`` / ``setup.cfg`` /
-  ``tox.ini`` ``[pytest]`` section carrying the same keys is not scanned.
-* **Config-level, not usage-level.** The rule fires on the risky *configuration*
-  (broad fixture scope, implicit test scope); it does not attempt to prove a
-  test actually drives fixture-owned work in-body. A repo that keeps all async
-  infra access inside fixtures is currently safe but still warned — suppress
-  with a justification, or set the test scope explicitly.
+* **pyproject-only config.** Reads ``[tool.pytest.ini_options]`` from the
+  repo-root ``pyproject.toml`` (the fleet convention). A ``pytest.ini`` /
+  ``setup.cfg`` / ``tox.ini`` ``[pytest]`` section is not scanned.
+* **Driver detection is syntactic and name-based.** Only awaited calls whose
+  terminal name is ``execute_app`` / ``execute_workflow`` / ``start_workflow``
+  (the SDK's workflow-submission surface) count as an in-body driver. A test
+  that reaches the same infra through a differently-named helper is not matched
+  (a documented false negative, consistent with T001/T018's syntactic limits).
+  Collection mirrors pytest defaults (``test*`` functions, ``Test*`` classes,
+  ``test_*.py`` / ``*_test.py`` files under ``tests/``).
 """
 
 from __future__ import annotations
 
+import ast
 import re
 import sys
 import tomllib
+from collections.abc import Iterable
 from pathlib import Path
 
 from conformance.suite.checks._ast_common import (
+    is_test_class,
+    is_test_function,
     make_cli_main,
     make_toml_finding,
     parse_toml_suppressions,
@@ -80,13 +94,25 @@ _TEST_SCOPE_KEY = "asyncio_default_test_loop_scope"
 # test's loop, which is only safe if tests share that loop too.
 _VALID_SCOPES = frozenset({"session", "package", "module", "class", "function"})
 
+# SDK workflow-submission surface: an awaited call to one of these from a *test
+# body* is what turns the config mismatch into a real hang (the resource lives
+# on the fixture loop; the await runs on the test's function loop). Kept as a
+# named set so the recognised entry points are explicit and extensible.
+_WORKFLOW_DRIVER_NAMES = frozenset(
+    {"execute_app", "execute_workflow", "start_workflow"}
+)
+
 # ``asyncio_default_fixture_loop_scope = ...`` assignment line (for anchoring the
 # finding + its suppression directive).
 _FIXTURE_SCOPE_LINE_RE = re.compile(rf"^\s*{re.escape(_FIXTURE_SCOPE_KEY)}\s*=")
 
+# Cap how many driver test labels are listed in the message.
+_MAX_LISTED = 5
+
 __all__ = [
     "SERIES",
     "discover",
+    "in_body_workflow_drivers",
     "main",
     "scan_all",
     "scan_path",
@@ -113,48 +139,106 @@ def _ini_options(text: str) -> dict[str, object] | None:
     return ini if isinstance(ini, dict) else None
 
 
-def _fixture_scope_line(text: str) -> int:
-    for i, line in enumerate(text.splitlines(), start=1):
-        if _FIXTURE_SCOPE_LINE_RE.match(line):
-            return i
-    return 1
+def _broadened_fixture_scope(text: str) -> str | None:
+    """Return the broadened fixture loop scope iff the config is risky.
 
-
-def _message(fixture_scope: str) -> str:
-    return (
-        f"pyproject sets {_FIXTURE_SCOPE_KEY}='{fixture_scope}' but leaves "
-        f"{_TEST_SCOPE_KEY} unset (it defaults to 'function'): async fixtures "
-        f"share one '{fixture_scope}'-scoped event loop while each test runs on "
-        "its own function-scoped loop. A test that drives a fixture-owned "
-        "resource bound to the fixture loop — a Temporal worker/client, an async "
-        "DB engine/pool, an httpx.AsyncClient — from its own body then awaits "
-        "work that loop never runs, so it hangs until the suite timeout fires. "
-        f"Set {_TEST_SCOPE_KEY} explicitly (usually '{fixture_scope}', to match "
-        "the fixtures) so tests and their fixtures share a loop. See T019."
-    )
-
-
-def scan_text(text: str, file: str) -> list[Finding]:
-    """Scan a ``pyproject.toml`` *text* for T019.
-
-    Fires when ``asyncio_default_fixture_loop_scope`` is set to a valid
+    "Risky" = ``asyncio_default_fixture_loop_scope`` set to a valid
     non-``function`` scope while ``asyncio_default_test_loop_scope`` is absent.
-    Self-contained — the risk is entirely in the config, so no filesystem/test
-    context is needed (contrast T018).
+    Returns the fixture-scope string in that case, else ``None`` (an explicit
+    test scope, a ``function`` fixture scope, an invalid value pytest-asyncio
+    would itself reject, or no pytest table at all).
     """
     ini = _ini_options(text)
     if ini is None:
-        return []
+        return None
     fixture_scope = ini.get(_FIXTURE_SCOPE_KEY)
-    # Only a *broadened*, valid fixture scope is a risk; "function" (or an
-    # invalid value pytest-asyncio would itself reject) is not.
     if not isinstance(fixture_scope, str) or fixture_scope not in _VALID_SCOPES:
-        return []
+        return None
     if fixture_scope == "function":
-        return []
-    # An explicit test scope — any value — means the author made a deliberate
-    # choice; the trap is only the *implicit* function default.
+        return None
     if _TEST_SCOPE_KEY in ini:
+        return None
+    return fixture_scope
+
+
+def _call_name(call: ast.Call) -> str | None:
+    """Terminal name of a call target: ``f()`` -> 'f', ``a.b.f()`` -> 'f'."""
+    func = call.func
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    return None
+
+
+def _drives_workflow_in_body(func: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+    """True if *func*'s body awaits a workflow-submission call.
+
+    Matches ``await <...>execute_app(...)`` / ``execute_workflow`` /
+    ``start_workflow`` anywhere in the function subtree — the in-body drive that
+    turns the loop-scope mismatch into a hang.
+    """
+    for node in ast.walk(func):
+        if not isinstance(node, ast.Await):
+            continue
+        value = node.value
+        if isinstance(value, ast.Call) and _call_name(value) in _WORKFLOW_DRIVER_NAMES:
+            return True
+    return False
+
+
+def _drivers_in_module(tree: ast.Module, rel: str) -> list[str]:
+    """Labels of test functions in *tree* that drive a workflow in-body."""
+    labels: list[str] = []
+    for node in tree.body:
+        if is_test_function(node):
+            if _drives_workflow_in_body(node):
+                labels.append(f"{rel}::{node.name}")
+        elif is_test_class(node):
+            for sub in node.body:
+                if is_test_function(sub) and _drives_workflow_in_body(sub):
+                    labels.append(f"{rel}::{node.name}::{sub.name}")
+    return labels
+
+
+def _message(fixture_scope: str, drivers: list[str]) -> str:
+    listed = ", ".join(drivers[:_MAX_LISTED])
+    if len(drivers) > _MAX_LISTED:
+        listed += f", … (+{len(drivers) - _MAX_LISTED} more)"
+    return (
+        f"pyproject sets {_FIXTURE_SCOPE_KEY}='{fixture_scope}' but leaves "
+        f"{_TEST_SCOPE_KEY} unset (it defaults to 'function'), and "
+        f"{len(drivers)} test(s) drive workflow execution from the test body "
+        f"(await execute_app/execute_workflow/start_workflow): {listed}. Those "
+        f"tests run on a function-scoped loop while the fixture-owned worker/"
+        f"client lives on the '{fixture_scope}'-scoped loop, so the awaited work "
+        "is never polled and the test hangs until the suite timeout fires. Set "
+        f"{_TEST_SCOPE_KEY} explicitly (usually '{fixture_scope}', to match the "
+        "fixtures), or move the workflow call into a same-scope fixture and "
+        "assert on its result. See T019."
+    )
+
+
+def scan_text(
+    text: str,
+    file: str,
+    *,
+    in_body_drivers: Iterable[str] | None = None,
+) -> list[Finding]:
+    """Scan a ``pyproject.toml`` *text* for T019.
+
+    Fires only when the config is risky (:func:`_broadened_fixture_scope`) **and**
+    *in_body_drivers* is non-empty — the labels of tests that drive workflow
+    execution in-body (supplied from the filesystem by :func:`scan_path`). A
+    text-only caller that passes nothing gets no findings: the mismatch is only a
+    hazard relative to a test that actually drives fixture-owned work in-body
+    (mirrors T018's test-context requirement).
+    """
+    fixture_scope = _broadened_fixture_scope(text)
+    if fixture_scope is None:
+        return []
+    drivers = list(in_body_drivers) if in_body_drivers is not None else []
+    if not drivers:
         return []
     return [
         make_toml_finding(
@@ -162,10 +246,17 @@ def scan_text(text: str, file: str) -> list[Finding]:
             file=file,
             line=_fixture_scope_line(text),
             column=1,
-            message=_message(fixture_scope),
+            message=_message(fixture_scope, drivers),
             suppressions=parse_toml_suppressions(text),
         )
     ]
+
+
+def _fixture_scope_line(text: str) -> int:
+    for i, line in enumerate(text.splitlines(), start=1):
+        if _FIXTURE_SCOPE_LINE_RE.match(line):
+            return i
+    return 1
 
 
 # ---------------------------------------------------------------------------
@@ -173,8 +264,44 @@ def scan_text(text: str, file: str) -> list[Finding]:
 # ---------------------------------------------------------------------------
 
 
+def in_body_workflow_drivers(root: Path) -> list[str]:
+    """Collect ``tests/`` test functions that drive a workflow in-body.
+
+    Walks pytest's default test files (``test_*.py`` / ``*_test.py``) under
+    ``root/tests`` and returns ``file::test`` / ``file::Class::test`` labels for
+    those whose body awaits ``execute_app`` / ``execute_workflow`` /
+    ``start_workflow``. Fixtures never match (they are not ``test*`` functions),
+    so the safe "execute inside a fixture" pattern is correctly ignored.
+    """
+    tests_dir = root / "tests"
+    if not tests_dir.is_dir():
+        return []
+    labels: list[str] = []
+    for path in sorted(tests_dir.rglob("*.py")):
+        if not (path.name.startswith("test_") or path.name.endswith("_test.py")):
+            continue
+        try:
+            src = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        try:
+            tree = ast.parse(src, filename=str(path))
+        except SyntaxError:
+            continue
+        try:
+            rel = path.relative_to(root)
+        except ValueError:
+            rel = path
+        labels.extend(_drivers_in_module(tree, str(rel)))
+    return labels
+
+
 def scan_path(path: Path, root: Path) -> list[Finding]:
-    """Scan the repo-root ``pyproject.toml`` for T019."""
+    """Scan the repo-root ``pyproject.toml`` for T019.
+
+    Resolves the in-body workflow drivers from *root* so the finding reflects the
+    real interaction between the app's loop-scope config and its test suite.
+    """
     try:
         text = path.read_text(encoding="utf-8")
     except OSError:
@@ -183,7 +310,7 @@ def scan_path(path: Path, root: Path) -> list[Finding]:
         rel = path.relative_to(root)
     except ValueError:
         rel = path
-    return scan_text(text, str(rel))
+    return scan_text(text, str(rel), in_body_drivers=in_body_workflow_drivers(root))
 
 
 def scan_all(paths: list[Path], root: Path) -> list[Finding]:
@@ -206,8 +333,8 @@ main = make_cli_main(
     description=(
         "T019: flag a broadened pytest-asyncio fixture loop scope "
         "(asyncio_default_fixture_loop_scope) with no matching "
-        "asyncio_default_test_loop_scope, which can hang tests that drive "
-        "fixture-owned async resources from the test body."
+        "asyncio_default_test_loop_scope when a test drives workflow execution "
+        "from the test body — which hangs on the fixture-owned worker/client."
     ),
     discover=discover,
     default_scan_paths=("pyproject.toml",),

--- a/packages/conformance/conformance/suite/checks/asyncio_loop_scope.py
+++ b/packages/conformance/conformance/suite/checks/asyncio_loop_scope.py
@@ -1,0 +1,219 @@
+"""T019 AsyncioTestLoopScopeUnset — flag a broadened pytest-asyncio *fixture*
+loop scope with no matching *test* loop scope.
+
+``pytest-asyncio`` has two independent knobs in
+``[tool.pytest.ini_options]``:
+
+* ``asyncio_default_fixture_loop_scope`` — the event loop async **fixtures**
+  default to.
+* ``asyncio_default_test_loop_scope`` — the event loop async **tests** default
+  to. **When unset it defaults to ``"function"``** (a fresh loop per test).
+
+Setting the fixture scope to ``session`` / ``package`` / ``module`` / ``class``
+without also setting the test scope leaves the two on *different* loops: async
+fixtures share one long-lived loop, but each test runs on its own
+function-scoped loop. A session-scoped fixture that owns a live resource bound
+to *its* loop — a Temporal worker/client, an async DB engine/pool, an
+``httpx.AsyncClient``, a message-broker consumer — is then invisible to a test
+that drives that resource **from its own body**: the test awaits work the
+fixture's loop must service, but that loop is not being driven while the test's
+loop runs, so nothing progresses and the test hangs until the suite's timeout
+fires.
+
+The failure is silent by construction: tests that only *read* values a fixture
+already computed (the common case) pass, so the mismatch hides until someone
+writes the first test that awaits fixture-owned work in-body. That is exactly
+how it surfaced on a canonical connector — a single ``REUSE`` integration test
+that submitted a Temporal workflow from the test body hung for the full
+``pytest-timeout`` while every sibling test (which read a class-fixture result)
+passed.
+
+Remediation is a one-line config edit: set ``asyncio_default_test_loop_scope``
+explicitly — usually to the same scope as the fixtures — so tests and their
+fixtures share a loop. Restructuring the offending test to run its async work
+inside a same-scope fixture also removes the *hang*, but leaves the config trap
+in place for the next author; the config fix is the durable one.
+
+Inline suppression
+------------------
+Add ``# conformance: ignore[T019] <reason>`` on the
+``asyncio_default_fixture_loop_scope`` line (or the line directly above it) when
+the mismatch is deliberate — e.g. every async fixture is loop-agnostic and no
+test drives fixture-owned work in-body — and state that reason.
+
+Known coverage limits (intentional — biased toward zero false positives at WARN
+tier):
+
+* **pyproject-only.** Reads ``[tool.pytest.ini_options]`` from the repo-root
+  ``pyproject.toml`` (the fleet convention). A ``pytest.ini`` / ``setup.cfg`` /
+  ``tox.ini`` ``[pytest]`` section carrying the same keys is not scanned.
+* **Config-level, not usage-level.** The rule fires on the risky *configuration*
+  (broad fixture scope, implicit test scope); it does not attempt to prove a
+  test actually drives fixture-owned work in-body. A repo that keeps all async
+  infra access inside fixtures is currently safe but still warned — suppress
+  with a justification, or set the test scope explicitly.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+from conformance.suite.checks._ast_common import (
+    make_cli_main,
+    make_toml_finding,
+    parse_toml_suppressions,
+)
+from conformance.suite.schema.findings import Finding
+
+SERIES = "T"
+RULE_T019 = "T019"
+
+# The two pytest-asyncio ini keys this rule reasons about.
+_FIXTURE_SCOPE_KEY = "asyncio_default_fixture_loop_scope"
+_TEST_SCOPE_KEY = "asyncio_default_test_loop_scope"
+
+# Valid pytest-asyncio loop scopes (see pytest_asyncio.plugin._ScopeName). Any
+# value other than "function" is "broadened" — fixtures then outlive a single
+# test's loop, which is only safe if tests share that loop too.
+_VALID_SCOPES = frozenset({"session", "package", "module", "class", "function"})
+
+# ``asyncio_default_fixture_loop_scope = ...`` assignment line (for anchoring the
+# finding + its suppression directive).
+_FIXTURE_SCOPE_LINE_RE = re.compile(rf"^\s*{re.escape(_FIXTURE_SCOPE_KEY)}\s*=")
+
+__all__ = [
+    "SERIES",
+    "discover",
+    "main",
+    "scan_all",
+    "scan_path",
+    "scan_text",
+]
+
+
+# ---------------------------------------------------------------------------
+# Pure core (filesystem-free — unit-testable)
+# ---------------------------------------------------------------------------
+
+
+def _ini_options(text: str) -> dict[str, object] | None:
+    """Return ``[tool.pytest.ini_options]`` from *text*, or ``None``."""
+    try:
+        data = tomllib.loads(text)
+    except tomllib.TOMLDecodeError:
+        return None
+    if not isinstance(data, dict):
+        return None
+    tool = data.get("tool")
+    pytest_tbl = tool.get("pytest") if isinstance(tool, dict) else None
+    ini = pytest_tbl.get("ini_options") if isinstance(pytest_tbl, dict) else None
+    return ini if isinstance(ini, dict) else None
+
+
+def _fixture_scope_line(text: str) -> int:
+    for i, line in enumerate(text.splitlines(), start=1):
+        if _FIXTURE_SCOPE_LINE_RE.match(line):
+            return i
+    return 1
+
+
+def _message(fixture_scope: str) -> str:
+    return (
+        f"pyproject sets {_FIXTURE_SCOPE_KEY}='{fixture_scope}' but leaves "
+        f"{_TEST_SCOPE_KEY} unset (it defaults to 'function'): async fixtures "
+        f"share one '{fixture_scope}'-scoped event loop while each test runs on "
+        "its own function-scoped loop. A test that drives a fixture-owned "
+        "resource bound to the fixture loop — a Temporal worker/client, an async "
+        "DB engine/pool, an httpx.AsyncClient — from its own body then awaits "
+        "work that loop never runs, so it hangs until the suite timeout fires. "
+        f"Set {_TEST_SCOPE_KEY} explicitly (usually '{fixture_scope}', to match "
+        "the fixtures) so tests and their fixtures share a loop. See T019."
+    )
+
+
+def scan_text(text: str, file: str) -> list[Finding]:
+    """Scan a ``pyproject.toml`` *text* for T019.
+
+    Fires when ``asyncio_default_fixture_loop_scope`` is set to a valid
+    non-``function`` scope while ``asyncio_default_test_loop_scope`` is absent.
+    Self-contained — the risk is entirely in the config, so no filesystem/test
+    context is needed (contrast T018).
+    """
+    ini = _ini_options(text)
+    if ini is None:
+        return []
+    fixture_scope = ini.get(_FIXTURE_SCOPE_KEY)
+    # Only a *broadened*, valid fixture scope is a risk; "function" (or an
+    # invalid value pytest-asyncio would itself reject) is not.
+    if not isinstance(fixture_scope, str) or fixture_scope not in _VALID_SCOPES:
+        return []
+    if fixture_scope == "function":
+        return []
+    # An explicit test scope — any value — means the author made a deliberate
+    # choice; the trap is only the *implicit* function default.
+    if _TEST_SCOPE_KEY in ini:
+        return []
+    return [
+        make_toml_finding(
+            rule_id=RULE_T019,
+            file=file,
+            line=_fixture_scope_line(text),
+            column=1,
+            message=_message(fixture_scope),
+            suppressions=parse_toml_suppressions(text),
+        )
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Filesystem scan API
+# ---------------------------------------------------------------------------
+
+
+def scan_path(path: Path, root: Path) -> list[Finding]:
+    """Scan the repo-root ``pyproject.toml`` for T019."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return []
+    try:
+        rel = path.relative_to(root)
+    except ValueError:
+        rel = path
+    return scan_text(text, str(rel))
+
+
+def scan_all(paths: list[Path], root: Path) -> list[Finding]:
+    """Cross-file entry point (used by the standalone CLI)."""
+    findings: list[Finding] = []
+    for path in paths:
+        if path.name == "pyproject.toml":
+            findings.extend(scan_path(path, root))
+    return findings
+
+
+def discover(root: Path) -> list[Path]:
+    """Discover the repo-root ``pyproject.toml`` (``[]`` when absent → no-op)."""
+    pyproject = root / "pyproject.toml"
+    return [pyproject] if pyproject.is_file() else []
+
+
+main = make_cli_main(
+    scan_all=scan_all,
+    description=(
+        "T019: flag a broadened pytest-asyncio fixture loop scope "
+        "(asyncio_default_fixture_loop_scope) with no matching "
+        "asyncio_default_test_loop_scope, which can hang tests that drive "
+        "fixture-owned async resources from the test body."
+    ),
+    discover=discover,
+    default_scan_paths=("pyproject.toml",),
+)
+"""CLI entry point for the T019 asyncio-loop-scope check."""
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/conformance/conformance/suite/rules/tests.py
+++ b/packages/conformance/conformance/suite/rules/tests.py
@@ -141,6 +141,17 @@ Directory-scoped tiering (the Unit/Integration split, application-sdk#2852):
   wants the ``integration`` marker *present*): keep the marker, but do **not**
   ``addopts``-deselect it — the directory is the tier boundary, exactly as
   atlan-mysql-app / atlan-metabase-app already do (marker present, no deselect).
+
+* ``T019`` — ``pytest-asyncio``'s ``asyncio_default_fixture_loop_scope`` is set
+  to a broadened scope (``session`` / ``package`` / ``module`` / ``class``) while
+  ``asyncio_default_test_loop_scope`` is left unset (it defaults to
+  ``function``).  Async fixtures then share one long-lived loop but each test
+  runs on its own function-scoped loop, so a test that drives a fixture-owned
+  resource (a Temporal worker/client, an async DB pool) *from its own body*
+  awaits work the fixture's loop must service while that loop is idle — and hangs
+  until the suite timeout.  The failure is silent until the first in-body async
+  test is written; set ``asyncio_default_test_loop_scope`` explicitly (usually to
+  match the fixtures) so tests and fixtures share a loop.
 """
 
 from __future__ import annotations
@@ -1217,6 +1228,102 @@ RULES: tuple[RuleDefinition, ...] = (
         help_uri=(
             "https://github.com/atlanhq/application-sdk/blob/main/"
             "packages/conformance/conformance/docs/rules/tests.md#t018"
+        ),
+    ),
+    RuleDefinition(
+        id="T019",
+        scope=RuleScope.BOTH,
+        name="AsyncioTestLoopScopeUnset",
+        tier=EnforcementTier.WARN,
+        mechanism=RuleMechanism.STATIC,
+        category="test-async-config",
+        autofixable=False,
+        since="0.17.0",
+        rationale=(
+            "pytest-asyncio has two independent loop-scope knobs in "
+            "[tool.pytest.ini_options]: asyncio_default_fixture_loop_scope (the "
+            "loop async fixtures default to) and asyncio_default_test_loop_scope "
+            "(the loop async tests default to), and the latter defaults to "
+            "'function' when unset. Setting the fixture scope to a broadened value "
+            "(session/package/module/class) without also setting the test scope "
+            "puts fixtures and tests on different loops: async fixtures share one "
+            "long-lived loop while each test runs on its own function-scoped loop. "
+            "A fixture that owns a live resource bound to its loop — a Temporal "
+            "worker/client, an async DB engine/pool, an httpx.AsyncClient — is then "
+            "invisible to a test that drives that resource from the test body: the "
+            "test awaits work the fixture's loop must service, but that loop is not "
+            "being driven while the test's loop runs, so nothing progresses and the "
+            "test hangs until the suite timeout fires. The failure is silent by "
+            "construction — tests that only read a value a fixture already computed "
+            "pass, so the mismatch hides until someone writes the first test that "
+            "awaits fixture-owned work in-body. It surfaced on a canonical "
+            "connector whose sole in-body Temporal test (a REUSE integration case) "
+            "hung for the full pytest-timeout while every sibling test, which read "
+            "a class-fixture result, passed. Keep the two scopes consistent: when "
+            "fixtures are broadened, set the test scope explicitly too."
+        ),
+        short_description=(
+            "pyproject sets asyncio_default_fixture_loop_scope to a broadened scope "
+            "but leaves asyncio_default_test_loop_scope unset (defaults to "
+            "'function'), so in-body async tests can hang on fixture-owned "
+            "resources"
+        ),
+        full_description=(
+            "``[tool.pytest.ini_options]`` in ``pyproject.toml`` sets\n"
+            "``asyncio_default_fixture_loop_scope`` to a broadened scope\n"
+            "(``session`` / ``package`` / ``module`` / ``class``) but does not set\n"
+            "``asyncio_default_test_loop_scope``, which **defaults to ``function``**.\n"
+            "\n"
+            "Async fixtures then share one long-lived event loop, while each test\n"
+            "runs on its own function-scoped loop. A fixture that owns a live\n"
+            "resource bound to *its* loop — a Temporal worker/client, an async DB\n"
+            "engine/pool, an ``httpx.AsyncClient``, a broker consumer — is invisible\n"
+            "to a test that drives that resource **from the test body**: the test\n"
+            "awaits work the fixture's loop must service, but that loop is idle while\n"
+            "the test's loop runs, so the await never completes and the test hangs\n"
+            "until the suite timeout fires.\n"
+            "\n"
+            "The failure is silent by construction. Tests that only *read* a value a\n"
+            "fixture already computed (the common case) pass, so the mismatch stays\n"
+            "hidden until the first test that awaits fixture-owned work in-body is\n"
+            "written — at which point it hangs, not fails, which is far costlier to\n"
+            "diagnose.\n"
+            "\n"
+            "**Remediation:** set ``asyncio_default_test_loop_scope`` explicitly —\n"
+            "usually to the same scope as the fixtures — so tests and their fixtures\n"
+            "share a loop. Before:\n"
+            "\n"
+            ".. code-block:: toml\n"
+            "\n"
+            "    [tool.pytest.ini_options]\n"
+            "    asyncio_mode = \"auto\"\n"
+            "    asyncio_default_fixture_loop_scope = \"session\"\n"
+            "    # asyncio_default_test_loop_scope unset -> defaults to 'function'\n"
+            "\n"
+            "After:\n"
+            "\n"
+            ".. code-block:: toml\n"
+            "\n"
+            "    [tool.pytest.ini_options]\n"
+            "    asyncio_mode = \"auto\"\n"
+            "    asyncio_default_fixture_loop_scope = \"session\"\n"
+            "    asyncio_default_test_loop_scope = \"session\"\n"
+            "\n"
+            "Restructuring the offending test to run its async work inside a\n"
+            "same-scope fixture (letting the test body only assert on the result)\n"
+            "also removes the hang, and matches how most suites already drive\n"
+            "workflow execution — but it leaves the config trap in place for the\n"
+            "next author, so prefer the explicit test-scope setting as the durable\n"
+            "fix.\n"
+            "\n"
+            "Suppress with ``# conformance: ignore[T019] <reason>`` on the\n"
+            "``asyncio_default_fixture_loop_scope`` line only when the mismatch is\n"
+            "deliberate — e.g. every async fixture is loop-agnostic and no test\n"
+            "drives fixture-owned work in-body — and state that reason.\n"
+        ),
+        help_uri=(
+            "https://github.com/atlanhq/application-sdk/blob/main/"
+            "packages/conformance/conformance/docs/rules/tests.md#t019"
         ),
     ),
 )

--- a/packages/conformance/conformance/suite/rules/tests.py
+++ b/packages/conformance/conformance/suite/rules/tests.py
@@ -1296,8 +1296,8 @@ RULES: tuple[RuleDefinition, ...] = (
             ".. code-block:: toml\n"
             "\n"
             "    [tool.pytest.ini_options]\n"
-            "    asyncio_mode = \"auto\"\n"
-            "    asyncio_default_fixture_loop_scope = \"session\"\n"
+            '    asyncio_mode = "auto"\n'
+            '    asyncio_default_fixture_loop_scope = "session"\n'
             "    # asyncio_default_test_loop_scope unset -> defaults to 'function'\n"
             "\n"
             "After:\n"
@@ -1305,9 +1305,9 @@ RULES: tuple[RuleDefinition, ...] = (
             ".. code-block:: toml\n"
             "\n"
             "    [tool.pytest.ini_options]\n"
-            "    asyncio_mode = \"auto\"\n"
-            "    asyncio_default_fixture_loop_scope = \"session\"\n"
-            "    asyncio_default_test_loop_scope = \"session\"\n"
+            '    asyncio_mode = "auto"\n'
+            '    asyncio_default_fixture_loop_scope = "session"\n'
+            '    asyncio_default_test_loop_scope = "session"\n'
             "\n"
             "Restructuring the offending test to run its async work inside a\n"
             "same-scope fixture (letting the test body only assert on the result)\n"

--- a/packages/conformance/conformance/suite/rules/tests.py
+++ b/packages/conformance/conformance/suite/rules/tests.py
@@ -147,11 +147,13 @@ Directory-scoped tiering (the Unit/Integration split, application-sdk#2852):
   ``asyncio_default_test_loop_scope`` is left unset (it defaults to
   ``function``).  Async fixtures then share one long-lived loop but each test
   runs on its own function-scoped loop, so a test that drives a fixture-owned
-  resource (a Temporal worker/client, an async DB pool) *from its own body*
-  awaits work the fixture's loop must service while that loop is idle — and hangs
-  until the suite timeout.  The failure is silent until the first in-body async
-  test is written; set ``asyncio_default_test_loop_scope`` explicitly (usually to
-  match the fixtures) so tests and fixtures share a loop.
+  resource (a Temporal worker/client) *from its own body* awaits work the
+  fixture's loop must service while that loop is idle — and hangs until the suite
+  timeout.  Correlated like T018: fires only when the risky config coincides with
+  a collectable test whose body awaits ``execute_app`` / ``execute_workflow`` /
+  ``start_workflow`` (a suite that runs all execution inside fixtures is not
+  flagged).  Set ``asyncio_default_test_loop_scope`` explicitly (usually to match
+  the fixtures) so tests and fixtures share a loop.
 """
 
 from __future__ import annotations
@@ -1259,14 +1261,19 @@ RULES: tuple[RuleDefinition, ...] = (
             "awaits fixture-owned work in-body. It surfaced on a canonical "
             "connector whose sole in-body Temporal test (a REUSE integration case) "
             "hung for the full pytest-timeout while every sibling test, which read "
-            "a class-fixture result, passed. Keep the two scopes consistent: when "
-            "fixtures are broadened, set the test scope explicitly too."
+            "a class-fixture result, passed. Like T018 (which fires only when an "
+            "addopts deselect removes tests that exist), this rule is correlated, "
+            "not config-only: it fires only when the risky config coincides with a "
+            "collectable test whose body actually drives workflow execution via an "
+            "awaited execute_app/execute_workflow/start_workflow call. A suite that "
+            "runs all execution inside fixtures and only asserts on the result in "
+            "test bodies is on the safe path and is not flagged."
         ),
         short_description=(
             "pyproject sets asyncio_default_fixture_loop_scope to a broadened scope "
-            "but leaves asyncio_default_test_loop_scope unset (defaults to "
-            "'function'), so in-body async tests can hang on fixture-owned "
-            "resources"
+            "with asyncio_default_test_loop_scope unset (defaults to 'function') "
+            "AND a test drives workflow execution from its body, so that test hangs "
+            "on the fixture-owned worker/client"
         ),
         full_description=(
             "``[tool.pytest.ini_options]`` in ``pyproject.toml`` sets\n"
@@ -1288,6 +1295,14 @@ RULES: tuple[RuleDefinition, ...] = (
             "hidden until the first test that awaits fixture-owned work in-body is\n"
             "written — at which point it hangs, not fails, which is far costlier to\n"
             "diagnose.\n"
+            "\n"
+            "**Correlated, not config-only.** Like **T018**, this rule fires only when\n"
+            "the risky config *and* real evidence coincide: a collectable test\n"
+            "*function* (not a fixture) whose body awaits ``execute_app`` /\n"
+            "``execute_workflow`` / ``start_workflow`` — the SDK's workflow-submission\n"
+            "surface. A suite with the mismatched config but all execution behind\n"
+            "session/class-scoped fixtures (test bodies only assert on the result) is\n"
+            "on the safe path and is **not** flagged.\n"
             "\n"
             "**Remediation:** set ``asyncio_default_test_loop_scope`` explicitly —\n"
             "usually to the same scope as the fixtures — so tests and their fixtures\n"

--- a/packages/conformance/conformance/suite/runner.py
+++ b/packages/conformance/conformance/suite/runner.py
@@ -29,6 +29,7 @@ import conformance.suite.checks.sdr_test_checks as sdr_test_checks
 from conformance.suite.checks import (
     actions_pinning,
     app_name_alignment,
+    asyncio_loop_scope,
     bootstrap_drift,
     client_seam,
     coverage_config,
@@ -84,6 +85,11 @@ _CHECKS: list[CheckRegistration] = [
         series=actions_pinning.SERIES,
         discover=actions_pinning.discover,
         scan_path=actions_pinning.scan_path,
+    ),
+    CheckRegistration(
+        series=asyncio_loop_scope.SERIES,
+        discover=asyncio_loop_scope.discover,
+        scan_path=asyncio_loop_scope.scan_path,
     ),
     CheckRegistration(
         series=bootstrap_drift.SERIES,

--- a/packages/conformance/conformance/tools/generate_rule_docs.py
+++ b/packages/conformance/conformance/tools/generate_rule_docs.py
@@ -163,8 +163,9 @@ _SERIES_META: list[SeriesMeta] = [
             "`suite.checks.test_structure` (T010-T013), "
             "`suite.checks.coverage_config` (T014-T015), "
             "`suite.checks.e2e_deployment_name` (T016), "
-            "`suite.checks.e2e_agent_spec` (T017), and "
-            "`suite.checks.integration_deselect` (T018) (AST/TOML/YAML-based)"
+            "`suite.checks.e2e_agent_spec` (T017), "
+            "`suite.checks.integration_deselect` (T018), and "
+            "`suite.checks.asyncio_loop_scope` (T019) (AST/TOML/YAML-based)"
         ),
         suppression_example=(
             "# conformance: ignore[T001] intentional: marked dynamically via add_marker"

--- a/packages/conformance/tests/test_asyncio_loop_scope.py
+++ b/packages/conformance/tests/test_asyncio_loop_scope.py
@@ -1,0 +1,161 @@
+"""Meta-tests for the T019 asyncio-loop-scope check.
+
+T019 fires when ``[tool.pytest.ini_options].asyncio_default_fixture_loop_scope``
+is set to a broadened scope (``session`` / ``package`` / ``module`` / ``class``)
+while ``asyncio_default_test_loop_scope`` is left unset (it defaults to
+``function``) — the mismatch that hangs a test which drives a fixture-owned
+async resource from the test body.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from conformance.suite.checks.asyncio_loop_scope import scan_path, scan_text
+from conformance.suite.rules import get_rule
+from conformance.suite.schema.disposition import EnforcementTier, RuleScope
+
+# ── Rule metadata ────────────────────────────────────────────────────────────
+
+
+def test_t019_rule_metadata() -> None:
+    rule = get_rule("T019")
+    assert rule.name == "AsyncioTestLoopScopeUnset"
+    assert rule.tier == EnforcementTier.WARN
+    assert rule.scope == RuleScope.BOTH
+    assert rule.category == "test-async-config"
+
+
+# ── scan_text: fires on the risky config ─────────────────────────────────────
+
+
+def test_fires_when_fixture_scope_broadened_and_test_scope_unset() -> None:
+    text = (
+        "[tool.pytest.ini_options]\n"
+        'asyncio_mode = "auto"\n'
+        'asyncio_default_fixture_loop_scope = "session"\n'
+    )
+    findings = scan_text(text, "pyproject.toml")
+    assert [f.rule_id for f in findings] == ["T019"]
+    # Message names both keys and the silent 'function' default.
+    assert "asyncio_default_test_loop_scope" in findings[0].message
+    assert "function" in findings[0].message
+
+
+def test_fires_for_each_broadened_scope() -> None:
+    for scope in ("session", "package", "module", "class"):
+        text = (
+            "[tool.pytest.ini_options]\n"
+            f'asyncio_default_fixture_loop_scope = "{scope}"\n'
+        )
+        findings = scan_text(text, "pyproject.toml")
+        assert [f.rule_id for f in findings] == ["T019"], scope
+        assert f"'{scope}'" in findings[0].message
+
+
+# ── scan_text: silent when the config is safe ────────────────────────────────
+
+
+def test_silent_when_test_scope_set_explicitly() -> None:
+    # The author made a deliberate choice → no trap.
+    text = (
+        "[tool.pytest.ini_options]\n"
+        'asyncio_default_fixture_loop_scope = "session"\n'
+        'asyncio_default_test_loop_scope = "session"\n'
+    )
+    assert scan_text(text, "pyproject.toml") == []
+
+
+def test_silent_when_test_scope_set_to_function_explicitly() -> None:
+    # Explicit function test scope is still an explicit, deliberate choice.
+    text = (
+        "[tool.pytest.ini_options]\n"
+        'asyncio_default_fixture_loop_scope = "session"\n'
+        'asyncio_default_test_loop_scope = "function"\n'
+    )
+    assert scan_text(text, "pyproject.toml") == []
+
+
+def test_silent_when_fixture_scope_is_function() -> None:
+    # Fixtures already default to the per-test loop → tests and fixtures agree.
+    text = (
+        '[tool.pytest.ini_options]\nasyncio_default_fixture_loop_scope = "function"\n'
+    )
+    assert scan_text(text, "pyproject.toml") == []
+
+
+def test_silent_when_fixture_scope_unset() -> None:
+    # Only asyncio_mode set (SDK / conformance-package shape) → not using the
+    # broadened-fixture pattern, nothing to warn about.
+    text = '[tool.pytest.ini_options]\nasyncio_mode = "auto"\n'
+    assert scan_text(text, "pyproject.toml") == []
+
+
+def test_silent_when_no_pytest_table() -> None:
+    assert scan_text('[project]\nname = "x"\n', "pyproject.toml") == []
+
+
+def test_silent_on_invalid_scope_value() -> None:
+    # A typo pytest-asyncio would itself reject — not this rule's concern.
+    text = '[tool.pytest.ini_options]\nasyncio_default_fixture_loop_scope = "sesion"\n'
+    assert scan_text(text, "pyproject.toml") == []
+
+
+def test_silent_on_malformed_toml() -> None:
+    assert scan_text("[tool.pytest.ini_options\n = = =", "pyproject.toml") == []
+
+
+# ── Anchoring + suppression ──────────────────────────────────────────────────
+
+
+def test_anchored_on_fixture_scope_line() -> None:
+    text = (
+        "[tool.pytest.ini_options]\n"
+        'asyncio_mode = "auto"\n'
+        'asyncio_default_fixture_loop_scope = "session"\n'
+    )
+    findings = scan_text(text, "pyproject.toml")
+    assert findings[0].line == 3
+
+
+def test_suppressed_on_fixture_scope_line() -> None:
+    text = (
+        "[tool.pytest.ini_options]\n"
+        'asyncio_default_fixture_loop_scope = "session"  '
+        "# conformance: ignore[T019] every async fixture is loop-agnostic\n"
+    )
+    findings = scan_text(text, "pyproject.toml")
+    assert [f.rule_id for f in findings] == ["T019"]
+    assert findings[0].suppressed is True
+    assert (
+        findings[0].suppression_justification == "every async fixture is loop-agnostic"
+    )
+
+
+# ── Filesystem end-to-end via scan_path ──────────────────────────────────────
+
+
+def test_scan_path_fires_on_real_repo(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text(
+        "[tool.pytest.ini_options]\n"
+        'asyncio_mode = "auto"\n'
+        'asyncio_default_fixture_loop_scope = "session"\n',
+        encoding="utf-8",
+    )
+    findings = scan_path(tmp_path / "pyproject.toml", tmp_path)
+    assert [f.rule_id for f in findings] == ["T019"]
+
+
+def test_scan_path_silent_on_consistent_repo(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text(
+        "[tool.pytest.ini_options]\n"
+        'asyncio_mode = "auto"\n'
+        'asyncio_default_fixture_loop_scope = "session"\n'
+        'asyncio_default_test_loop_scope = "session"\n',
+        encoding="utf-8",
+    )
+    assert scan_path(tmp_path / "pyproject.toml", tmp_path) == []
+
+
+def test_scan_path_noop_without_pyproject(tmp_path: Path) -> None:
+    assert scan_path(tmp_path / "pyproject.toml", tmp_path) == []

--- a/packages/conformance/tests/test_asyncio_loop_scope.py
+++ b/packages/conformance/tests/test_asyncio_loop_scope.py
@@ -2,18 +2,34 @@
 
 T019 fires when ``[tool.pytest.ini_options].asyncio_default_fixture_loop_scope``
 is set to a broadened scope (``session`` / ``package`` / ``module`` / ``class``)
-while ``asyncio_default_test_loop_scope`` is left unset (it defaults to
-``function``) — the mismatch that hangs a test which drives a fixture-owned
-async resource from the test body.
+while ``asyncio_default_test_loop_scope`` is unset (defaults to ``function``)
+**and** a collectable test drives workflow execution from its body (an awaited
+``execute_app`` / ``execute_workflow`` / ``start_workflow``). Like T018 it is
+correlated with the real suite — the config mismatch alone does not fire.
 """
 
 from __future__ import annotations
 
+import ast
 from pathlib import Path
 
-from conformance.suite.checks.asyncio_loop_scope import scan_path, scan_text
+from conformance.suite.checks.asyncio_loop_scope import (
+    _broadened_fixture_scope,
+    _drives_workflow_in_body,
+    in_body_workflow_drivers,
+    scan_path,
+    scan_text,
+)
 from conformance.suite.rules import get_rule
 from conformance.suite.schema.disposition import EnforcementTier, RuleScope
+
+_RISKY_CFG = (
+    "[tool.pytest.ini_options]\n"
+    'asyncio_mode = "auto"\n'
+    'asyncio_default_fixture_loop_scope = "session"\n'
+)
+_DRIVER = ["tests/integration/test_x.py::test_drives"]
+
 
 # ── Rule metadata ────────────────────────────────────────────────────────────
 
@@ -26,96 +42,125 @@ def test_t019_rule_metadata() -> None:
     assert rule.category == "test-async-config"
 
 
-# ── scan_text: fires on the risky config ─────────────────────────────────────
+# ── Config detection: _broadened_fixture_scope ───────────────────────────────
 
 
-def test_fires_when_fixture_scope_broadened_and_test_scope_unset() -> None:
-    text = (
-        "[tool.pytest.ini_options]\n"
-        'asyncio_mode = "auto"\n'
-        'asyncio_default_fixture_loop_scope = "session"\n'
-    )
-    findings = scan_text(text, "pyproject.toml")
-    assert [f.rule_id for f in findings] == ["T019"]
-    # Message names both keys and the silent 'function' default.
-    assert "asyncio_default_test_loop_scope" in findings[0].message
-    assert "function" in findings[0].message
-
-
-def test_fires_for_each_broadened_scope() -> None:
+def test_broadened_scope_detected_for_each_nonfunction_scope() -> None:
     for scope in ("session", "package", "module", "class"):
         text = (
             "[tool.pytest.ini_options]\n"
             f'asyncio_default_fixture_loop_scope = "{scope}"\n'
         )
-        findings = scan_text(text, "pyproject.toml")
-        assert [f.rule_id for f in findings] == ["T019"], scope
-        assert f"'{scope}'" in findings[0].message
+        assert _broadened_fixture_scope(text) == scope
 
 
-# ── scan_text: silent when the config is safe ────────────────────────────────
-
-
-def test_silent_when_test_scope_set_explicitly() -> None:
-    # The author made a deliberate choice → no trap.
+def test_not_risky_when_test_scope_set_explicitly() -> None:
     text = (
         "[tool.pytest.ini_options]\n"
         'asyncio_default_fixture_loop_scope = "session"\n'
         'asyncio_default_test_loop_scope = "session"\n'
     )
-    assert scan_text(text, "pyproject.toml") == []
+    assert _broadened_fixture_scope(text) is None
 
 
-def test_silent_when_test_scope_set_to_function_explicitly() -> None:
-    # Explicit function test scope is still an explicit, deliberate choice.
+def test_not_risky_when_test_scope_set_to_function() -> None:
     text = (
         "[tool.pytest.ini_options]\n"
         'asyncio_default_fixture_loop_scope = "session"\n'
         'asyncio_default_test_loop_scope = "function"\n'
     )
-    assert scan_text(text, "pyproject.toml") == []
+    assert _broadened_fixture_scope(text) is None
 
 
-def test_silent_when_fixture_scope_is_function() -> None:
-    # Fixtures already default to the per-test loop → tests and fixtures agree.
-    text = (
-        '[tool.pytest.ini_options]\nasyncio_default_fixture_loop_scope = "function"\n'
+def test_not_risky_when_fixture_scope_function_or_unset() -> None:
+    assert (
+        _broadened_fixture_scope(
+            '[tool.pytest.ini_options]\nasyncio_default_fixture_loop_scope = "function"\n'
+        )
+        is None
     )
-    assert scan_text(text, "pyproject.toml") == []
+    assert (
+        _broadened_fixture_scope('[tool.pytest.ini_options]\nasyncio_mode = "auto"\n')
+        is None
+    )
 
 
-def test_silent_when_fixture_scope_unset() -> None:
-    # Only asyncio_mode set (SDK / conformance-package shape) → not using the
-    # broadened-fixture pattern, nothing to warn about.
-    text = '[tool.pytest.ini_options]\nasyncio_mode = "auto"\n'
-    assert scan_text(text, "pyproject.toml") == []
-
-
-def test_silent_when_no_pytest_table() -> None:
-    assert scan_text('[project]\nname = "x"\n', "pyproject.toml") == []
-
-
-def test_silent_on_invalid_scope_value() -> None:
+def test_not_risky_on_invalid_scope_or_malformed_toml() -> None:
     # A typo pytest-asyncio would itself reject — not this rule's concern.
-    text = '[tool.pytest.ini_options]\nasyncio_default_fixture_loop_scope = "sesion"\n'
-    assert scan_text(text, "pyproject.toml") == []
+    assert (
+        _broadened_fixture_scope(
+            '[tool.pytest.ini_options]\nasyncio_default_fixture_loop_scope = "sesion"\n'
+        )
+        is None
+    )
+    assert _broadened_fixture_scope("[tool.pytest.ini_options\n = = =") is None
 
 
-def test_silent_on_malformed_toml() -> None:
-    assert scan_text("[tool.pytest.ini_options\n = = =", "pyproject.toml") == []
+# ── In-body driver detection ─────────────────────────────────────────────────
 
 
-# ── Anchoring + suppression ──────────────────────────────────────────────────
+def _fn(src: str) -> ast.FunctionDef | ast.AsyncFunctionDef:
+    node = ast.parse(src).body[0]
+    assert isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    return node
+
+
+def test_driver_detected_for_each_submission_name() -> None:
+    for call in ("execute_app", "execute_workflow", "start_workflow"):
+        fn = _fn(
+            f"async def test_x(ex):\n    r = await ex.{call}(App, inp)\n    assert r\n"
+        )
+        assert _drives_workflow_in_body(fn) is True, call
+
+
+def test_driver_detected_for_bare_name_call() -> None:
+    fn = _fn("async def test_x():\n    r = await execute_workflow(w)\n    assert r\n")
+    assert _drives_workflow_in_body(fn) is True
+
+
+def test_no_driver_when_awaiting_unrelated_call() -> None:
+    # httpx/DB reads etc. that are not the workflow-submission surface.
+    fn = _fn("async def test_x(c):\n    r = await c.load(creds)\n    assert r\n")
+    assert _drives_workflow_in_body(fn) is False
+
+
+def test_no_driver_when_call_not_awaited() -> None:
+    fn = _fn("def test_x(ex):\n    ex.execute_app(App, inp)\n")
+    assert _drives_workflow_in_body(fn) is False
+
+
+# ── scan_text: correlation of config + drivers ───────────────────────────────
+
+
+def test_fires_when_config_risky_and_driver_present() -> None:
+    findings = scan_text(_RISKY_CFG, "pyproject.toml", in_body_drivers=_DRIVER)
+    assert [f.rule_id for f in findings] == ["T019"]
+    assert "asyncio_default_test_loop_scope" in findings[0].message
+    assert "test_drives" in findings[0].message
+
+
+def test_silent_when_config_risky_but_no_driver() -> None:
+    # CONFIG-ONLY: mismatched config, but all execution lives in fixtures.
+    assert scan_text(_RISKY_CFG, "pyproject.toml", in_body_drivers=[]) == []
+
+
+def test_silent_when_driver_present_but_config_safe() -> None:
+    safe = (
+        "[tool.pytest.ini_options]\n"
+        'asyncio_default_fixture_loop_scope = "session"\n'
+        'asyncio_default_test_loop_scope = "session"\n'
+    )
+    assert scan_text(safe, "pyproject.toml", in_body_drivers=_DRIVER) == []
+
+
+def test_noop_without_driver_context() -> None:
+    # Text-only caller (no filesystem context) never fires (mirrors T018).
+    assert scan_text(_RISKY_CFG, "pyproject.toml") == []
 
 
 def test_anchored_on_fixture_scope_line() -> None:
-    text = (
-        "[tool.pytest.ini_options]\n"
-        'asyncio_mode = "auto"\n'
-        'asyncio_default_fixture_loop_scope = "session"\n'
-    )
-    findings = scan_text(text, "pyproject.toml")
-    assert findings[0].line == 3
+    findings = scan_text(_RISKY_CFG, "pyproject.toml", in_body_drivers=_DRIVER)
+    assert findings[0].line == 3  # the asyncio_default_fixture_loop_scope line
 
 
 def test_suppressed_on_fixture_scope_line() -> None:
@@ -124,7 +169,7 @@ def test_suppressed_on_fixture_scope_line() -> None:
         'asyncio_default_fixture_loop_scope = "session"  '
         "# conformance: ignore[T019] every async fixture is loop-agnostic\n"
     )
-    findings = scan_text(text, "pyproject.toml")
+    findings = scan_text(text, "pyproject.toml", in_body_drivers=_DRIVER)
     assert [f.rule_id for f in findings] == ["T019"]
     assert findings[0].suppressed is True
     assert (
@@ -135,26 +180,69 @@ def test_suppressed_on_fixture_scope_line() -> None:
 # ── Filesystem end-to-end via scan_path ──────────────────────────────────────
 
 
-def test_scan_path_fires_on_real_repo(tmp_path: Path) -> None:
-    (tmp_path / "pyproject.toml").write_text(
-        "[tool.pytest.ini_options]\n"
-        'asyncio_mode = "auto"\n'
-        'asyncio_default_fixture_loop_scope = "session"\n',
-        encoding="utf-8",
+def _write(root: Path, pyproject: str, test_rel: str, test_src: str) -> None:
+    (root / "pyproject.toml").write_text(pyproject, encoding="utf-8")
+    p = root / test_rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(test_src, encoding="utf-8")
+
+
+def test_scan_path_fires_on_in_body_driver_repo(tmp_path: Path) -> None:
+    # HANG-RISK shape (microstrategy): await execute_app in a test body.
+    _write(
+        tmp_path,
+        _RISKY_CFG,
+        "tests/integration/test_conn.py",
+        "async def test_extraction(executor):\n"
+        "    result = await executor.execute_app(App, inp)\n"
+        "    assert result\n",
     )
     findings = scan_path(tmp_path / "pyproject.toml", tmp_path)
     assert [f.rule_id for f in findings] == ["T019"]
+    assert "tests/integration/test_conn.py::test_extraction" in findings[0].message
 
 
-def test_scan_path_silent_on_consistent_repo(tmp_path: Path) -> None:
-    (tmp_path / "pyproject.toml").write_text(
-        "[tool.pytest.ini_options]\n"
-        'asyncio_mode = "auto"\n'
-        'asyncio_default_fixture_loop_scope = "session"\n'
-        'asyncio_default_test_loop_scope = "session"\n',
-        encoding="utf-8",
+def test_scan_path_silent_on_fixture_only_repo(tmp_path: Path) -> None:
+    # CONFIG-ONLY shape (metabase/mysql): execution in a fixture, tests assert.
+    _write(
+        tmp_path,
+        _RISKY_CFG,
+        "tests/integration/test_conn.py",
+        "import pytest\n\n"
+        '@pytest.fixture(scope="class")\n'
+        "async def extraction_result(executor):\n"
+        "    return await executor.execute_app(App, inp)\n\n"
+        "def test_completes(extraction_result):\n"
+        "    assert extraction_result is not None\n",
     )
     assert scan_path(tmp_path / "pyproject.toml", tmp_path) == []
+
+
+def test_scan_path_silent_when_scopes_consistent(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        "[tool.pytest.ini_options]\n"
+        'asyncio_default_fixture_loop_scope = "session"\n'
+        'asyncio_default_test_loop_scope = "session"\n',
+        "tests/integration/test_conn.py",
+        "async def test_extraction(executor):\n"
+        "    assert await executor.execute_app(App, inp)\n",
+    )
+    assert scan_path(tmp_path / "pyproject.toml", tmp_path) == []
+
+
+def test_in_body_workflow_drivers_finds_class_methods(tmp_path: Path) -> None:
+    (tmp_path / "tests" / "integration").mkdir(parents=True)
+    (tmp_path / "tests" / "integration" / "test_conn.py").write_text(
+        "class TestX:\n"
+        "    async def test_a(self, ex):\n"
+        "        assert await ex.execute_workflow(w)\n"
+        "    async def test_b(self, extraction_result):\n"
+        "        assert extraction_result\n",
+        encoding="utf-8",
+    )
+    labels = in_body_workflow_drivers(tmp_path)
+    assert labels == ["tests/integration/test_conn.py::TestX::test_a"]
 
 
 def test_scan_path_noop_without_pyproject(tmp_path: Path) -> None:

--- a/packages/conformance/tests/test_catalog.py
+++ b/packages/conformance/tests/test_catalog.py
@@ -480,11 +480,12 @@ def test_catalog_t_series_present() -> None:
     """The T-series test-quality rules are all present: T001 (integration
     marking), T002/T003 (SDR test-quality), T004 (dev-entrypoint), T005-T009
     (assertion/collection quality), T010-T013 (tier structure), T014/T015
-    (coverage-config), T016/T017 (e2e-CI queue isolation), and T018
-    (integration tier deselected by addopts)."""
+    (coverage-config), T016/T017 (e2e-CI queue isolation), T018
+    (integration tier deselected by addopts), and T019 (asyncio test-loop scope
+    unset relative to a broadened fixture loop scope)."""
     rules = load_catalog()
     t_ids = {r.id for r in rules if r.id.startswith("T")}
-    expected = {f"T{n:03d}" for n in range(1, 19)}
+    expected = {f"T{n:03d}" for n in range(1, 20)}
     missing = expected - t_ids
     assert not missing, f"Missing T-series rules: {missing}"
     extra = t_ids - expected


### PR DESCRIPTION
## What

Adds test-quality conformance rule **T019 `AsyncioTestLoopScopeUnset`** — a `pytest-asyncio` loop-scope footgun where `asyncio_default_fixture_loop_scope` is broadened (`session`/`package`/`module`/`class`) while `asyncio_default_test_loop_scope` is left unset (it silently defaults to `function`).

## Why — the bug it encodes

In `atlan-openapi-app` one `REUSE` integration test submitted a Temporal workflow **from the test body** and hung for the full `pytest-timeout`, while every sibling test passed. Root cause was the loop-scope mismatch: session-scoped `worker`/`client` fixtures live on the session loop, but each test defaults to its own function loop. A test that drives the fixture-owned worker in-body awaits work the session loop must poll — but that loop is idle while the test's loop runs, so it hangs. (Tell: the workflow's logs appeared exactly at the timeout instant.) The failure is silent — tests that only read a fixture result pass — so it stays hidden until the first in-body async test is written.

## Correlated, not config-only (addresses false positives)

The config mismatch **alone** is not a defect: a suite that runs all workflow execution inside fixtures and only asserts on the result in test bodies is safe even with the test scope implicit. So T019 mirrors **T018**'s design (which fires only when an `addopts` deselect removes tests that actually exist): it fires only when the risky config **and** real evidence coincide — a collectable test **function** (not a fixture) whose body awaits `execute_app` / `execute_workflow` / `start_workflow` (the SDK's workflow-submission surface). AST detection walks `tests/` for those in-body drivers; the finding names the offending tests. A repo with the mismatched config but all execution behind fixtures is **not** flagged.

**Validated across the fleet's `session`-fixture-scope repos:**

| Repo | Shape | T019 |
|---|---|---|
| atlan-microstrategy-app | `await executor.execute_app(...)` in a test body | **fires** (real hang) |
| atlan-metabase-app, atlan-mysql-app | execution in a class-scoped fixture | silent |
| atlan-hello-world-app, atlan-snowflake-app | no in-body workflow-submission | silent |
| atlan-openapi-app | in-body test moved to a fixture (#273) | silent |

## Rule shape

WARN · STATIC · scope BOTH · category `test-async-config` · `autofixable=False` · classified `"judgment"` (routes to residue) — consistent with the T-series. Anchored on the `asyncio_default_fixture_loop_scope` line in `pyproject.toml`. **Remediation:** set `asyncio_default_test_loop_scope` explicitly (usually to match the fixtures), or move the workflow call into a same-scope fixture.

## Changes (all six T-series layers)

- `suite/checks/asyncio_loop_scope.py` — TOML config check + AST in-body-driver detection; filesystem-free `scan_text` core.
- `suite/rules/tests.py` — `RuleDefinition` for T019 + module-docstring bullet.
- `suite/runner.py` — import + `CheckRegistration`.
- `tools/generate_rule_docs.py` — T-series `checker=` string; **`docs/rules/tests.md` regenerated** (`#t019` + summary-table row).
- `programs/areas/tests.prose.md` — Fix Prescription bullet + frontmatter/`Maintains`.
- `tests/test_asyncio_loop_scope.py` — config/driver/correlation/filesystem tests; `test_catalog.py` T-series range → T019.

## Verification

- Full conformance suite: **2022 passed, 1 xfailed**.
- `gen-rule-docs --check` clean; `ruff check` clean on touched files.
- End-to-end runner confirms the table above (microstrategy fires; metabase/mysql/hello-world/snowflake/openapi silent).

## Related

- The openapi hang + test-restructuring fix: atlanhq/atlan-openapi-app#273 (merged).
- Preventive config pin for openapi: atlanhq/atlan-openapi-app#274.
- Sibling test-tier rule (same correlated design): T018 `IntegrationTierDeselectedByAddopts`.
- Follow-up: **atlan-microstrategy-app** is the one repo T019 flags as a real latent hang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
