### PR TITLE
chore(adr): ADR-0018 progress-aware stall watchdog and duration-backstop timeouts

### DIFF
--- a/docs/adr/0018-progress-aware-heartbeat.md
+++ b/docs/adr/0018-progress-aware-heartbeat.md
@@ -78,9 +78,13 @@ that same observability *holistically and, wherever possible, automatically*:
 - **Automatic (no developer action):** built-in progress signals on the paths the
   SDK already owns — the streaming writer/emission/transfer loops, and anything
   run through `run_in_thread`.
-- **Explicit (developer chooses one mechanism):** for the residual spots the SDK
-  cannot see — a custom async loop, or a raw opaque `await` — the developer makes
-  it observable with a manual beat or a scoped bracket.
+- **Explicit (developer chooses one mechanism):** for the spots the SDK cannot see
+  — a custom async loop, or an opaque single `await` against the connector's own
+  source client — the developer makes it observable with a manual beat or a scoped
+  bracket. This is not a rare edge: because the async source path has no mandatory
+  SDK seam (unlike blocking calls, which all go through `run_in_thread`), the
+  explicit bracket is expected in nearly every connector (see *The async escape
+  hatch* below).
 
 This framing matters for expectations: **the residual work never disappears.** The
 ADR shrinks it to a small, auditable set and automates the common paths, but a task
@@ -221,12 +225,13 @@ little the app author has to do:
    Anything offloaded through `run_in_thread` is bracketed by the SDK itself, so a
    legitimate long blocking call is never false-killed (details below).
 3. **Manual `context.heartbeat(...)` or `holding_progress(...)` (explicit, app
-   action).** The residual: a custom async loop, or a raw opaque `await` that never
-   touches an SDK-instrumented path. `context.heartbeat()` already exists and now
-   also bumps progress (still carrying resume details for
-   `get_last_heartbeat_details()`); `holding_progress()` is the async analogue of
-   the blocking bracket. This is the only mechanism that asks the author to *do*
-   something — and the audit step in *Rollout* exists to find exactly these spots.
+   action).** The residual: a custom async loop, or an opaque single `await`
+   against the connector's own source client (see the asymmetry below — this is
+   *not* a rare case). `context.heartbeat()` already exists and now also bumps
+   progress (still carrying resume details for `get_last_heartbeat_details()`);
+   `holding_progress()` is the async analogue of the blocking bracket. This is the
+   mechanism that asks the author to *do* something — and the audit step in
+   *Rollout* exists to find exactly these spots.
 
 ### The blocking bracket — bounded by the call's own timeout
 
@@ -276,7 +281,7 @@ silently guess:
    multiple of `heartbeat_timeout` and emit a WARNING, so the missing timeout
    surfaces during the opt-in audit rather than hiding until a wedge.
 
-### The async escape hatch — and why authors won't have to remember it everywhere
+### The async escape hatch — and the asymmetry that makes it common
 
 For an async-opaque single `await` with no progress signal, `holding_progress()` is
 the explicit analogue of the blocking bracket:
@@ -286,15 +291,41 @@ async with self.context.holding_progress("snapshot metadata query", timeout=120)
     rows = await long_single_query(...)   # its own statement_timeout is the watchdog
 ```
 
-**Q: "Making people use it *always* might become a problem."** Correct — and the
-answer is the same one that makes the streaming hooks free: *don't rely on people
-for the common path.* The SDK's own async SQL/HTTP clients enter the bracket
-**themselves**, so an author using the standard clients gets coverage
-automatically, exactly as the write loops call `mark_progress()` for them.
-`holding_progress()` is then only ever needed for a *raw* `await` the app issues
-outside those clients — a small, auditable surface, and a **required** step for
-such calls, not a nice-to-have (a forgotten bracket false-kills at the tail; see
-*Migration*). The manual mechanism is the floor, not the plan.
+**Q: "Making people use it *always* might become a problem."** This is the most
+important open ergonomics question, and we should not pretend it away. There is a
+real asymmetry between the blocking and async paths:
+
+- **Blocking source calls are auto-covered.** `run_in_thread` is a *mandatory
+  seam* — every blocking call already goes through it (ADR-0010), so the SDK
+  brackets it for the author with no extra code.
+- **Async source calls have no equivalent mandatory seam.** A connector connects
+  to its *own* source system with its *own* async client (an async SQLAlchemy
+  engine, an `httpx.AsyncClient`, a vendor SDK). **The SDK's internal SQL/HTTP
+  clients are for the SDK's own purposes; they do not, and are not meant to, sit on
+  the connector→source path** — so there is no SDK-owned wrapper we can transparently
+  instrument for that call. Auto-bracketing "the SDK clients" would cover almost
+  none of the real source I/O.
+
+Two things soften this, but neither eliminates it:
+
+1. **Interleaved streaming reads are already covered by the write side.** The
+   common extraction shape — fetch a page, write a batch, repeat — ticks
+   `mark_progress()` on every batch write, so the read loop is covered as long as
+   one fetch+write cycle stays under the no-progress budget. `holding_progress()`
+   is *not* needed there.
+2. The residual is the genuinely **opaque single async call** — one large metadata
+   query, one slow list/export API call that returns everything at once. Those
+   emit nothing until they complete.
+
+So the honest expectation: **`holding_progress()` will very likely be needed in
+almost every connector**, because almost every connector makes at least one such
+opaque async call against its source. It is a *standard part of writing a
+long-running async task*, not a rare escape hatch. We make that acceptable by (a)
+keeping it a one-line context manager whose `timeout` is just the client timeout
+the author already sets, (b) documenting it as expected rather than exceptional,
+and (c) having the opt-in audit specifically hunt source-side opaque async calls. A
+forgotten bracket false-kills at the tail (see *Migration*), so for such calls it
+is **required**, not advisory.
 
 ## Options Considered
 
@@ -379,18 +410,36 @@ the heartbeat is progress-aware.
 
 ## Migration & backward compatibility — "what if I do nothing?"
 
-The first question every consumer asks: *if I don't touch my code, do I suddenly
-start getting "no forward progress" kills?* The answer has a reassuring half and a
-sharp half, and both must be stated plainly.
+The first question every consumer asks: *if I don't touch my code, what changes?*
+Precisely because two knobs are in play, the answer must separate them — one is
+safe to ship on upgrade, the other is not.
 
-**Upgrading the SDK alone changes nothing.** Two properties guarantee it:
+**The progress-gating flag — safe, changes nothing on upgrade.** Progress-gating is
+**flag-gated, default off** (see *Rollout*), and the framework `mark_progress()`
+hooks are **inert while the flag is off** — they bump a counter nobody reads. So
+merely bumping the SDK version produces no new "no forward progress" kill.
 
-- The behavior is **flag-gated, default off** (see *Rollout*). Progress-gating
-  activates only on explicit per-app opt-in.
-- The framework `mark_progress()` hooks are **inert while the flag is off** — they
-  bump a counter nobody reads. So merely bumping the SDK version cannot produce a
-  single new kill. There is no silent exposure; **flipping the flag is the migration
-  action.**
+**The `start_to_close` default (600s → 24h) — this one DOES change behavior, and
+must NOT ship at plain upgrade.** If the 24h default landed as part of the base
+upgrade, here is what would happen to an app that does nothing:
+
+- Apps that set `timeout_seconds` explicitly per task (including every app in the
+  failure dashboard) are unaffected — the default never reaches them. Their
+  StartToClose kills persist until they lower/remove those values and/or opt in.
+- Apps **relying on the 600s default** would get a 24h ceiling *while still running
+  the old unconditional keepalive* (because progress-gating is off). That is the
+  exact unsafe pairing from *Context*: `heartbeat_timeout` cannot catch a wedge, so
+  a **wedged-but-alive activity would squat its worker slot for up to 24h**, doing
+  no real work — starving the ~100-slot pool and badly delaying legitimate work.
+
+The 24h backstop is only safe **once the progress-aware watchdog is active for that
+app.** Therefore the default bump is **coupled to the opt-in flip** (Rollout step 4
+is per-app-gated, not a global default change at upgrade): you never get the 24h
+ceiling without the minutes-scale watchdog that makes it safe. Shipping the ceiling
+fleet-wide for fast StartToClose relief is tempting, but it buys relief for
+default-relying apps at the cost of a fleet-wide 24h-wedge exposure window — so it
+is explicitly rejected as the default path. **Flipping the flag (which brings both
+halves together) is the migration action.**
 
 **On opt-in, whether unchanged code survives depends on its shape.** This is the
 sharp half — for the last two rows, do-nothing code *will* start hitting
@@ -404,7 +453,7 @@ wedged one):
 | Already calls `context.heartbeat()` | Covered — bumps progress | none |
 | Opaque blocking call via `run_in_thread` | Covered — bracket vouches to its timeout | none (set `blocking_timeout` if not derivable) |
 | **Custom async loop doing its own I/O, never through an instrumented SDK path** | **False-killed** if any gap > `heartbeat_timeout` | add a beat/bracket |
-| **Raw opaque `await` outside an SDK client** | **False-killed** at the tail | wrap in `holding_progress()` |
+| **Opaque single `await` against the source (connector's own async client)** | **False-killed** at the tail | wrap in `holding_progress()` — expected in ~every connector |
 
 Two consequences fall out of this and are load-bearing for a safe rollout:
 
@@ -429,12 +478,16 @@ killed at `heartbeat_timeout`. Sequence:
 2. **Gate behind a flag** — `progress_aware_heartbeat` on `@task` /
    `TaskMetadata`, defaulting **off**, plus an env kill-switch.
 3. **Flip per-app after verification** — with hooks in place, the migration work is
-   auditing the two at-risk shapes from *Migration* (custom async loops, raw opaque
-   awaits) and adding a beat/bracket, and verifying against a **large-tenant / tail
-   profile**. The `heartbeat_timeout` default moves to 300s as part of this flip so
-   its new meaning and its value change together.
-4. **Then** raise the `start_to_close` default (e.g. → 24h) and retire the
-   per-task duration constants — safely, because the watchdog is now real.
+   auditing the two at-risk shapes from *Migration* (custom async loops, opaque
+   source awaits) and adding a beat/bracket, and verifying against a
+   **large-tenant / tail profile**. The `heartbeat_timeout` default moves to 300s as
+   part of this flip so its new meaning and its value change together.
+4. **Couple the 24h `start_to_close` backstop to that same per-app flip** — an app
+   gets the 24h ceiling *and* the progress-aware watchdog together, never one
+   without the other. The **global** default only changes at the very end, once the
+   flag is retired and progress-aware is universal; raising it fleet-wide any
+   earlier would expose default-relying, non-opted apps to 24h wedges (see
+   *Migration*). At that point the per-task duration constants are retired.
 
 The AE-orchestrated DAG node timeouts (`errorHandling.startToCloseTimeoutSeconds`
 in the contract toolkit, defaulting 24h/72h) are a *separate layer* consumed by

--- a/docs/adr/0018-progress-aware-heartbeat.md
+++ b/docs/adr/0018-progress-aware-heartbeat.md
@@ -64,36 +64,91 @@ else" must be the heartbeat — and today it can't do the job.
 
 ## Decision
 
-Make the auto-heartbeat **progress-aware**, then invert the timeout model:
+### The mental model: make quiet spots observable
+
+The core realization: **a healthy-but-quiet task is indistinguishable from a
+wedged one.** Both emit nothing. A watchdog that kills on silence cannot tell them
+apart — so the only durable fix is to make every quiet spot *observable*, i.e.
+emit a signal of forward progress that the watchdog can see.
+
+The SDK already ships one observability primitive for this: the manual beat
+(`context.heartbeat()`). This ADR does **not** invent a new concept — it extends
+that same observability *holistically and, wherever possible, automatically*:
+
+- **Automatic (no developer action):** built-in progress signals on the paths the
+  SDK already owns — the streaming writer/emission/transfer loops, and anything
+  run through `run_in_thread`.
+- **Explicit (developer chooses one mechanism):** for the residual spots the SDK
+  cannot see — a custom async loop, or a raw opaque `await` — the developer makes
+  it observable with a manual beat or a scoped bracket.
+
+This framing matters for expectations: **the residual work never disappears.** The
+ADR shrinks it to a small, auditable set and automates the common paths, but a task
+that does long work through code the SDK can't see will still need one of the three
+mechanisms. "Zero effort" is true only for the covered paths; everything else is a
+deliberate, one-line observability choice.
+
+### Inverting the timeout model
+
+With observability in place, invert the two timeouts:
 
 1. The auto-heartbeat loop sends a beat **only when a progress token advanced**
-   since the last tick (or a sanctioned blocking op is in flight). A stall stops
+   since the last tick (or a bounded blocking op is in flight). A stall stops
    the beats, so `heartbeat_timeout` fires `heartbeat_timeout` seconds after the
    *last real progress*.
 2. `heartbeat_timeout` is redefined as **"maximum acceptable time making zero
    forward progress"** — a roughly workload-independent number (minutes), unlike
-   total duration.
+   total duration. **Its default rises from 60s to 300s** in the same change that
+   flips the semantics (see *Migration*): 60s under the new meaning would be a live
+   tripwire that even well-instrumented apps trip between coarse-grained signals.
 3. `start_to_close` becomes a **pure backstop** (e.g. 24h) that authors never tune.
 4. Opaque single blocking calls that emit no progress (one long query/API call)
-   are kept alive by an explicit, scoped **liveness bracket**, with a
-   resource-level timeout (DB `statement_timeout`, `httpx` timeout) as their real
-   watchdog — consistent with ADR-0010's "blocking code must own its timeout."
+   are kept alive by an explicit, scoped **liveness bracket** that is **bounded by
+   the blocking call's own declared timeout** — the DB `statement_timeout` / `httpx`
+   timeout ADR-0010 already mandates. The bracket vouches for the call only until
+   that bound elapses; past it, the beats stop and `heartbeat_timeout` fires. This
+   keeps the "blocking code owns its timeout" contract *and* closes the hole where
+   a wedged blocking call would otherwise be unguarded until the 24h backstop.
 
 This shifts tuning off the hard knob (duration) onto two answerable ones: *"how
 long is no progress acceptable?"* (uniform default) and *"how long should one
-query take?"* (a property of the resource).
+query take?"* (a property of the resource, which the call already declares).
+
+### What counts as "progress"
+
+Progress is defined operationally, not by intuition — this is the question a
+reviewer asks first, so it must be crisp:
+
+> **Progress = one observable unit of work completing** — a batch written, a chunk
+> or file transferred, a page fetched, or an explicit `context.heartbeat()`.
+
+It is emphatically **not** wall-clock time and **not** event-loop liveness — that
+was the old unconditional keepalive this ADR removes. The single rule an author
+needs follows directly from the definition:
+
+> **If any one step can run longer than the no-progress budget (`heartbeat_timeout`,
+> default 300s) without emitting a signal, that step must be made observable** — it
+> is already covered by a framework hook, or the author adds a manual beat or a
+> bracket.
+
+By construction, **any gap between progress signals longer than `heartbeat_timeout`
+is treated as a stall.** That is the intended behavior, not a corner case: it is
+exactly how a wedged-but-quiet activity gets caught. The design's job is to ensure
+the *legitimate* quiet spots are the small, known set that the automatic hooks and
+the bracket already cover.
 
 ### The progress token
 
 `TemporalHeartbeatController` (`execution/heartbeat.py`) gains a monotonic
-progress generation and a blocking-depth counter:
+progress generation and a blocking **deadline** (not just a depth counter — the
+deadline is what bounds the bracket, see below):
 
 ```python
 class TemporalHeartbeatController:
     def __init__(self) -> None:
         self._last_details: tuple[Any, ...] = ()
-        self._progress_gen: int = 0      # bumped on every real progress signal
-        self._blocking_depth: int = 0    # >0 while inside a sanctioned blocking op
+        self._progress_gen: int = 0            # bumped on every real progress signal
+        self._blocking_deadlines: list[float] = []  # monotonic deadlines of in-flight blocking ops
 
     def mark_progress(self) -> None:
         """Framework + app signal for real forward progress."""
@@ -105,8 +160,20 @@ class TemporalHeartbeatController:
         self._progress_gen += 1
         activity.heartbeat(*details)
 
-    def enter_blocking(self) -> None: self._blocking_depth += 1
-    def exit_blocking(self)  -> None: self._blocking_depth -= 1
+    def enter_blocking(self, timeout: float) -> None:
+        # Vouch for a blocking op only until its own declared timeout elapses.
+        self._blocking_deadlines.append(time.monotonic() + timeout)
+
+    def exit_blocking(self) -> None:
+        if self._blocking_deadlines:
+            self._blocking_deadlines.pop()
+
+    def blocking_active(self) -> bool:
+        # A blocking op is vouched-for only while its deadline is in the future;
+        # once a call overruns its own timeout we stop beating for it and let
+        # heartbeat_timeout fire (the thread itself can't be killed — see below).
+        now = time.monotonic()
+        return any(d > now for d in self._blocking_deadlines)
 
     def heartbeat_keepalive(self) -> None:
         activity.heartbeat(*self._last_details)   # unchanged: the raw send
@@ -124,7 +191,7 @@ while not stop_event.is_set():
 
     beat = (
         hb.progress_gen != last_seen_gen     # real progress since last tick
-        or hb.blocking_depth > 0             # legit opaque op in flight
+        or hb.blocking_active()              # bounded opaque op still within its timeout
     )
     if beat:
         last_seen_gen = hb.progress_gen
@@ -139,41 +206,95 @@ while not stop_event.is_set():
 
 That `else` branch is the entire behavioral change.
 
-### Feeding the token (three sources, in priority order)
+### Feeding the token (three mechanisms, most-automatic first)
 
-1. **Framework hooks (zero app effort).** Call `hb.mark_progress()` wherever the
-   SDK already loops over units of work: the batched output writers, the
-   record/statistics emission path, and the `ObjectStore` transfer loops
-   (`storage/transfer.py`, `storage/chunked.py`, `storage/file_ref_sync.py`).
-   This covers the streaming majority automatically.
-2. **Manual `context.heartbeat(...)`** — already exists; now also bumps progress
-   and still carries resume details for `get_last_heartbeat_details()`.
-3. **The blocking bracket** — below.
+These are the three observability mechanisms from the mental model, ordered by how
+little the app author has to do:
 
-### The opaque-call escape hatch
+1. **Framework hooks (automatic, no app action).** Call `hb.mark_progress()`
+   wherever the SDK already loops over units of work: the batched output writers,
+   the record/statistics emission path, and the `ObjectStore` transfer loops
+   (`storage/transfer.py`, `storage/chunked.py`, `storage/file_ref_sync.py`). This
+   covers the streaming majority — the bulk of connector runtime — with no code
+   change in the app.
+2. **The blocking bracket around `run_in_thread` (automatic for blocking work).**
+   Anything offloaded through `run_in_thread` is bracketed by the SDK itself, so a
+   legitimate long blocking call is never false-killed (details below).
+3. **Manual `context.heartbeat(...)` or `holding_progress(...)` (explicit, app
+   action).** The residual: a custom async loop, or a raw opaque `await` that never
+   touches an SDK-instrumented path. `context.heartbeat()` already exists and now
+   also bumps progress (still carrying resume details for
+   `get_last_heartbeat_details()`); `holding_progress()` is the async analogue of
+   the blocking bracket. This is the only mechanism that asks the author to *do*
+   something — and the audit step in *Rollout* exists to find exactly these spots.
 
-`run_in_thread` is already the sanctioned wrapper for blocking work and already
-mandates an internal timeout (ADR-0010). Bracket it so a legitimate long single
-call is not false-killed; hang-detection is delegated to the internal timeout,
-with `start_to_close` as the ultimate backstop:
+### The blocking bracket — bounded by the call's own timeout
+
+Two questions from review shape this design:
+
+**Q: If my blocking code goes through `run_in_thread`, does it just beat forever?**
+Not anymore. A naive "beat while `blocking_depth > 0`" would keep a *wedged*
+blocking call alive until the 24h backstop — reintroducing the exact hole this ADR
+closes for async code. Instead the bracket is **bounded by the blocking call's own
+declared timeout** and stops vouching once that elapses:
 
 ```python
-async def run_in_thread(func, *args, **kwargs):
+async def run_in_thread(func, *args, blocking_timeout: float | None = None, **kwargs):
     hb = _current_heartbeat_controller()
-    if hb: hb.enter_blocking()
+    bound = blocking_timeout if blocking_timeout is not None else _derive_timeout(func, kwargs)
+    if hb and bound is not None:
+        hb.enter_blocking(bound)
     try:
         return await loop.run_in_executor(_BLOCKING_EXECUTOR, ...)
     finally:
-        if hb: hb.exit_blocking()
+        if hb and bound is not None:
+            hb.exit_blocking()
 ```
 
-For async-opaque single awaits with no progress signal, expose the same bracket
-explicitly:
+Effective kill time for a wedged blocking call therefore drops from ~24h to
+`blocking_timeout + heartbeat_timeout`. (The Python thread itself cannot be
+cancelled — that is `run_in_thread`'s known limitation; only `run_fault_isolated`
+kills via a child process. The bracket doesn't kill the thread; it stops *lying to
+Temporal* about it, so the slot is reclaimed and the activity fails/retries.)
+
+**Where does the bound come from? Reuse the number the call already declares.**
+ADR-0010 already mandates that blocking code owns a timeout
+(`requests.get(url, timeout=30)`, `httpx` timeout, DB `statement_timeout`). The
+bracket bound is *that* number — not a new one to invent, which keeps faith with
+this ADR's whole thesis of eliminating guessed durations. Layered so we never
+silently guess:
+
+1. **Explicit is the contract:** `run_in_thread(func, ..., blocking_timeout=30)`.
+2. **Convenience derivation** (`_derive_timeout`): if omitted, best-effort read a
+   `timeout=` / `timeout_seconds=` kwarg off the call and reuse it, logging at
+   DEBUG what was derived. Covers the common `requests`/`httpx` case with zero
+   boilerplate — the author already typed the number once. *Caveats made explicit
+   so no one over-trusts it:* it is heuristic — units vary (s vs ms), `requests`
+   uses a `(connect, read)` tuple, and some callees don't name the arg `timeout`
+   at all. Derivation is a convenience over the explicit arg, never a replacement.
+3. **Conservative fallback, never 24h:** if no bound is found, cap at a small
+   multiple of `heartbeat_timeout` and emit a WARNING, so the missing timeout
+   surfaces during the opt-in audit rather than hiding until a wedge.
+
+### The async escape hatch — and why authors won't have to remember it everywhere
+
+For an async-opaque single `await` with no progress signal, `holding_progress()` is
+the explicit analogue of the blocking bracket:
 
 ```python
-async with self.context.holding_progress("snapshot metadata query"):
+async with self.context.holding_progress("snapshot metadata query", timeout=120):
     rows = await long_single_query(...)   # its own statement_timeout is the watchdog
 ```
+
+**Q: "Making people use it *always* might become a problem."** Correct — and the
+answer is the same one that makes the streaming hooks free: *don't rely on people
+for the common path.* The SDK's own async SQL/HTTP clients enter the bracket
+**themselves**, so an author using the standard clients gets coverage
+automatically, exactly as the write loops call `mark_progress()` for them.
+`holding_progress()` is then only ever needed for a *raw* `await` the app issues
+outside those clients — a small, auditable surface, and a **required** step for
+such calls, not a nice-to-have (a forgotten bracket false-kills at the tail; see
+*Migration*). The manual mechanism is the floor, not the plan.
 
 ## Options Considered
 
@@ -205,7 +326,9 @@ stalls fast; make `start_to_close` a backstop. Detailed above.
 **Pros:**
 - Eliminates the unguessable knob; the surviving knobs don't scale with tenant size.
 - Kills wedged activities in minutes instead of a day → no slot exhaustion.
-- Streaming work is covered automatically via framework hooks — zero app effort.
+- Streaming work and `run_in_thread` blocking work are covered automatically; the
+  residual (custom async loops, raw opaque awaits) shrinks to a small, auditable
+  set that needs one explicit observability call.
 - Reuses the existing `heartbeat_timeout` knob and single auto-loop send site;
   small, localized change.
 
@@ -219,7 +342,10 @@ stalls fast; make `start_to_close` a backstop. Detailed above.
 
 Disable auto-heartbeat; require `context.heartbeat()` everywhere. Rejected for the
 same reasons as ADR-0010 Option 3 — easy to forget, and it cannot heartbeat during
-a single long opaque call. Progress hooks give the same signal without the discipline tax.
+a single long opaque call. The chosen option keeps the manual beat as one of three
+mechanisms but removes the tax on the common paths: framework hooks and the
+`run_in_thread` bracket cover the streaming and blocking majority automatically, so
+manual observability is the small, audited residual — not the whole burden.
 
 ## Rationale
 
@@ -238,8 +364,9 @@ the heartbeat is progress-aware.
 | --- | --- | --- |
 | Event loop fully blocked (no `run_in_thread`) | auto-loop starved → killed at `heartbeat_timeout` | unchanged — still correct |
 | Streaming work, healthy | beats unconditionally | beats on real throughput via hooks |
-| Wedged-but-looping (the gap today) | only `start_to_close` (→ 24h under the naive proposal) | **killed at `heartbeat_timeout` after last progress** |
-| Legit long opaque call | keepalive keeps it alive; bounded by `start_to_close` | blocking bracket keeps it alive; internal/resource timeout is the watchdog |
+| Wedged-but-looping async (the gap today) | only `start_to_close` (→ 24h under the naive proposal) | **killed at `heartbeat_timeout` after last progress** |
+| Legit long opaque call | keepalive keeps it alive; bounded by `start_to_close` | bracket vouches for it until its declared timeout; resource timeout is the watchdog |
+| **Wedged blocking call in `run_in_thread`** | keepalive beats forever → only `start_to_close` (24h) | **bracket stops at the call's timeout → killed at `blocking_timeout + heartbeat_timeout`** (thread orphaned; slot reclaimed) |
 | `run_best_effort` child-process work (ADR-0017) | parent awaits; keepalive beats | parent awaits via `run_in_thread`/await → bracket keeps beating |
 
 ### What authors tune afterward
@@ -247,8 +374,49 @@ the heartbeat is progress-aware.
 | Knob | Before | After |
 | --- | --- | --- |
 | `start_to_close` | the number everyone guesses wrong | 24h backstop, never tuned |
-| `heartbeat_timeout` | "how often do I beat" (coupled to keepalive) | **"max no-progress window"** — ~5–10 min, roughly app-independent |
-| opaque-call bound | none / `start_to_close` | resource-level timeout (DB `statement_timeout`, `httpx` timeout) |
+| `heartbeat_timeout` | "how often do I beat" (coupled to keepalive) | **"max no-progress window"** — default 300s, roughly app-independent |
+| opaque-call bound | none / `start_to_close` | resource-level timeout (DB `statement_timeout`, `httpx` timeout), reused as the bracket bound |
+
+## Migration & backward compatibility — "what if I do nothing?"
+
+The first question every consumer asks: *if I don't touch my code, do I suddenly
+start getting "no forward progress" kills?* The answer has a reassuring half and a
+sharp half, and both must be stated plainly.
+
+**Upgrading the SDK alone changes nothing.** Two properties guarantee it:
+
+- The behavior is **flag-gated, default off** (see *Rollout*). Progress-gating
+  activates only on explicit per-app opt-in.
+- The framework `mark_progress()` hooks are **inert while the flag is off** — they
+  bump a counter nobody reads. So merely bumping the SDK version cannot produce a
+  single new kill. There is no silent exposure; **flipping the flag is the migration
+  action.**
+
+**On opt-in, whether unchanged code survives depends on its shape.** This is the
+sharp half — for the last two rows, do-nothing code *will* start hitting
+no-progress kills, and that is the design working as intended (those paths emit
+nothing the SDK can see, i.e. a healthy-but-quiet task it cannot distinguish from a
+wedged one):
+
+| Existing code shape | Outcome on opt-in | Author action |
+| --- | --- | --- |
+| Streaming through SDK batch writers / stats / `ObjectStore` transfer | Covered — hooks tick | none |
+| Already calls `context.heartbeat()` | Covered — bumps progress | none |
+| Opaque blocking call via `run_in_thread` | Covered — bracket vouches to its timeout | none (set `blocking_timeout` if not derivable) |
+| **Custom async loop doing its own I/O, never through an instrumented SDK path** | **False-killed** if any gap > `heartbeat_timeout` | add a beat/bracket |
+| **Raw opaque `await` outside an SDK client** | **False-killed** at the tail | wrap in `holding_progress()` |
+
+Two consequences fall out of this and are load-bearing for a safe rollout:
+
+1. **The `heartbeat_timeout` default must move to 300s in lockstep with the
+   semantic flip.** Apps that never touched it — left it at the old 60s — are the
+   *most* exposed, not the least: under the new meaning, 60s of no SDK-observable
+   signal (one coarse batch, one slow page) would trip even a fully instrumented
+   app. The bump is not optional polish; it is part of the semantic change.
+2. **Opt-in verification must exercise a large-tenant / tail profile, not a smoke
+   test.** A small tenant's fast steps hide the very gaps that only open at the
+   tail — the same tail that produced the original `StartToClose` failures. Signing
+   off on a small run and flipping the flag would just relocate the tail failure.
 
 ## Rollout
 
@@ -260,9 +428,11 @@ killed at `heartbeat_timeout`. Sequence:
    transfer loops) so the streaming majority is covered before anyone opts in.
 2. **Gate behind a flag** — `progress_aware_heartbeat` on `@task` /
    `TaskMetadata`, defaulting **off**, plus an env kill-switch.
-3. **Flip per-app after verification** — with hooks in place, the only migration
-   work is auditing opaque single-call tasks and wrapping them in the bracket (or
-   giving them a resource-level timeout).
+3. **Flip per-app after verification** — with hooks in place, the migration work is
+   auditing the two at-risk shapes from *Migration* (custom async loops, raw opaque
+   awaits) and adding a beat/bracket, and verifying against a **large-tenant / tail
+   profile**. The `heartbeat_timeout` default moves to 300s as part of this flip so
+   its new meaning and its value change together.
 4. **Then** raise the `start_to_close` default (e.g. → 24h) and retire the
    per-task duration constants — safely, because the watchdog is now real.
 

--- a/docs/adr/0018-progress-aware-heartbeat.md
+++ b/docs/adr/0018-progress-aware-heartbeat.md
@@ -1,0 +1,301 @@
+# ADR-0018: Progress-Aware Heartbeat and Duration-Backstop Timeouts
+
+## Status
+**Proposed**
+
+## Context
+
+Every SDK `@task` becomes a Temporal activity carrying two timeouts (see
+`application_sdk/app/task.py`, `application_sdk/execution/_temporal/activities.py`):
+
+- **`start_to_close`** — the hard bound on a single activity attempt. Temporal
+  *requires* either this or `schedule_to_close` on every activity; the SDK makes
+  `timeout_seconds` non-nullable and defaults it to **600s** (`ATLAN_START_TO_CLOSE_TIMEOUT_SECONDS`).
+- **`heartbeat_timeout`** — the max gap allowed between heartbeats. Optional in
+  Temporal; the SDK defaults it to **60s** (`ATLAN_HEARTBEAT_TIMEOUT_SECONDS`) and
+  runs a background **auto-heartbeat loop** every 10s so app authors get liveness
+  for free (`auto_heartbeat_loop` in `execution/heartbeat.py`).
+
+The two timeouts catch *orthogonal* failure modes and neither subsumes the other:
+
+- `heartbeat_timeout` detects **unresponsiveness** (crash, deadlock, network loss,
+  event-loop starvation) — it only fires when heartbeats *stop*.
+- `start_to_close` detects **taking too long while healthy** — an activity that
+  keeps heartbeating but runs longer than allowed. It is the *only* bound on a
+  healthy-but-slow or wedged-but-alive attempt.
+
+### The problem: `start_to_close` is an unguessable number
+
+`start_to_close` forces app authors to answer *"how long should this whole
+activity take?"* — a number that scales with tenant size from seconds to days and
+is data-dependent. In practice authors guess it, weight-class it, and still guess
+wrong at the tail. A production failure dashboard (13-day window) showed a steady
+trickle of `activity StartToClose timeout` failures across multiple connectors —
+extraction, query-history, and processing activities — despite each app having
+already tuned per-task timeouts (e.g. 5-minute "light", 2-hour "medium", 6-hour
+"heavy" classes). The tuning is educated guessing, and the tail always exceeds it.
+
+The intuitive fix — *"raise the `start_to_close` default to something enormous
+like 24h and stop guessing"* — is directionally right (a generous
+`start_to_close` backstop plus a fast watchdog is Temporal's own recommended
+pattern for long-running work) but **unsafe as-is**, because of how the
+auto-heartbeat currently works.
+
+### Why a large `start_to_close` is unsafe today
+
+The auto-heartbeat is an **unconditional keepalive**: `heartbeat_keepalive()`
+calls `activity.heartbeat()` every 10s regardless of whether the activity is
+making any real progress. It proves the *event loop is alive*, not that *work is
+advancing*. Consequences:
+
+1. `heartbeat_timeout` cannot catch a **wedged-but-alive** activity (an infinite
+   async retry loop, a fetch that streams forever, a driver stuck in a
+   yield-friendly wait). Heartbeats keep arriving, so only `start_to_close` ever
+   stops it.
+2. Therefore, if we raise `start_to_close` to 24h and keep the unconditional
+   keepalive, a wedged activity is guarded by **nothing** for a full day →
+   worker-slot exhaustion (Temporal's Python worker defaults to ~100 concurrent
+   activity slots; a handful of stuck activities can starve the pool) and
+   day-long non-detection.
+
+The number that is genuinely hard to guess (total duration) cannot simply be made
+huge unless *something else* reliably kills a stuck activity fast. That "something
+else" must be the heartbeat — and today it can't do the job.
+
+## Decision
+
+Make the auto-heartbeat **progress-aware**, then invert the timeout model:
+
+1. The auto-heartbeat loop sends a beat **only when a progress token advanced**
+   since the last tick (or a sanctioned blocking op is in flight). A stall stops
+   the beats, so `heartbeat_timeout` fires `heartbeat_timeout` seconds after the
+   *last real progress*.
+2. `heartbeat_timeout` is redefined as **"maximum acceptable time making zero
+   forward progress"** — a roughly workload-independent number (minutes), unlike
+   total duration.
+3. `start_to_close` becomes a **pure backstop** (e.g. 24h) that authors never tune.
+4. Opaque single blocking calls that emit no progress (one long query/API call)
+   are kept alive by an explicit, scoped **liveness bracket**, with a
+   resource-level timeout (DB `statement_timeout`, `httpx` timeout) as their real
+   watchdog — consistent with ADR-0010's "blocking code must own its timeout."
+
+This shifts tuning off the hard knob (duration) onto two answerable ones: *"how
+long is no progress acceptable?"* (uniform default) and *"how long should one
+query take?"* (a property of the resource).
+
+### The progress token
+
+`TemporalHeartbeatController` (`execution/heartbeat.py`) gains a monotonic
+progress generation and a blocking-depth counter:
+
+```python
+class TemporalHeartbeatController:
+    def __init__(self) -> None:
+        self._last_details: tuple[Any, ...] = ()
+        self._progress_gen: int = 0      # bumped on every real progress signal
+        self._blocking_depth: int = 0    # >0 while inside a sanctioned blocking op
+
+    def mark_progress(self) -> None:
+        """Framework + app signal for real forward progress."""
+        self._progress_gen += 1
+
+    def heartbeat(self, *details: Any) -> None:
+        # A manual heartbeat is, by definition, progress.
+        self._last_details = details
+        self._progress_gen += 1
+        activity.heartbeat(*details)
+
+    def enter_blocking(self) -> None: self._blocking_depth += 1
+    def exit_blocking(self)  -> None: self._blocking_depth -= 1
+
+    def heartbeat_keepalive(self) -> None:
+        activity.heartbeat(*self._last_details)   # unchanged: the raw send
+```
+
+### Gating the loop
+
+Only the *send* becomes conditional; the existing event-loop-block warning and
+memory-pressure sampling still run every tick:
+
+```python
+last_seen_gen = -1
+while not stop_event.is_set():
+    ...  # existing wait_for(stop_event) + block-detection warning + memory sampling
+
+    beat = (
+        hb.progress_gen != last_seen_gen     # real progress since last tick
+        or hb.blocking_depth > 0             # legit opaque op in flight
+    )
+    if beat:
+        last_seen_gen = hb.progress_gen
+        hb.heartbeat_keepalive()
+    else:
+        logger.debug(
+            "No progress in last %.0fs for '%s'; withholding keepalive so "
+            "heartbeat_timeout can fire if the stall persists",
+            interval_seconds, task_name,
+        )
+```
+
+That `else` branch is the entire behavioral change.
+
+### Feeding the token (three sources, in priority order)
+
+1. **Framework hooks (zero app effort).** Call `hb.mark_progress()` wherever the
+   SDK already loops over units of work: the batched output writers, the
+   record/statistics emission path, and the `ObjectStore` transfer loops
+   (`storage/transfer.py`, `storage/chunked.py`, `storage/file_ref_sync.py`).
+   This covers the streaming majority automatically.
+2. **Manual `context.heartbeat(...)`** — already exists; now also bumps progress
+   and still carries resume details for `get_last_heartbeat_details()`.
+3. **The blocking bracket** — below.
+
+### The opaque-call escape hatch
+
+`run_in_thread` is already the sanctioned wrapper for blocking work and already
+mandates an internal timeout (ADR-0010). Bracket it so a legitimate long single
+call is not false-killed; hang-detection is delegated to the internal timeout,
+with `start_to_close` as the ultimate backstop:
+
+```python
+async def run_in_thread(func, *args, **kwargs):
+    hb = _current_heartbeat_controller()
+    if hb: hb.enter_blocking()
+    try:
+        return await loop.run_in_executor(_BLOCKING_EXECUTOR, ...)
+    finally:
+        if hb: hb.exit_blocking()
+```
+
+For async-opaque single awaits with no progress signal, expose the same bracket
+explicitly:
+
+```python
+async with self.context.holding_progress("snapshot metadata query"):
+    rows = await long_single_query(...)   # its own statement_timeout is the watchdog
+```
+
+## Options Considered
+
+### Option 1: Raise the `start_to_close` default to 24h and delete per-task tuning (Rejected as-is)
+
+The originating proposal: stop guessing durations by making the default enormous
+and removing the per-task constants.
+
+**Why rejected on its own:** with today's unconditional keepalive, nothing kills a
+wedged-but-alive activity for 24h → worker-slot exhaustion and day-long
+non-detection (see Context). It also does not even fix the observed failures: the
+apps in the dashboard *already* override the default on every task, so bumping the
+default reaches none of them. This option is the *cosmetic half* of the real fix
+and is only safe once Option 3 is in place.
+
+### Option 2: Keep guessing, tune per-task durations harder (Rejected)
+
+Continue the status quo — better per-task `timeout_seconds` guesses.
+
+**Cons:** the number is fundamentally unguessable (scales with tenant/data); the
+dashboard shows thoughtful guesses still failing at the tail. Unbounded tuning
+that never converges.
+
+### Option 3: Progress-aware heartbeat + duration backstop (Chosen)
+
+Redefine the heartbeat as a progress watchdog so `heartbeat_timeout` catches
+stalls fast; make `start_to_close` a backstop. Detailed above.
+
+**Pros:**
+- Eliminates the unguessable knob; the surviving knobs don't scale with tenant size.
+- Kills wedged activities in minutes instead of a day → no slot exhaustion.
+- Streaming work is covered automatically via framework hooks — zero app effort.
+- Reuses the existing `heartbeat_timeout` knob and single auto-loop send site;
+  small, localized change.
+
+**Cons:**
+- Requires framework hooks at the right loops, and an audit of opaque single-call
+  tasks to bracket them (migration cost).
+- Turning it on globally without the hooks would false-kill pure-async tasks that
+  emit no progress → must be flag-gated during rollout.
+
+### Option 4: Manual heartbeating only (Rejected)
+
+Disable auto-heartbeat; require `context.heartbeat()` everywhere. Rejected for the
+same reasons as ADR-0010 Option 3 — easy to forget, and it cannot heartbeat during
+a single long opaque call. Progress hooks give the same signal without the discipline tax.
+
+## Rationale
+
+### The asymmetry that makes the inversion work
+
+*"How long should the whole thing take?"* is workload-specific and unbounded.
+*"How long is it acceptable to make zero forward progress?"* is roughly
+workload-independent — a few minutes for almost any connector. One sane global
+number can express the second; no global number can express the first. That
+asymmetry is the entire reason a large `start_to_close` default becomes safe once
+the heartbeat is progress-aware.
+
+### Failure detection is preserved or improved for every mode
+
+| Scenario | Before | After |
+| --- | --- | --- |
+| Event loop fully blocked (no `run_in_thread`) | auto-loop starved → killed at `heartbeat_timeout` | unchanged — still correct |
+| Streaming work, healthy | beats unconditionally | beats on real throughput via hooks |
+| Wedged-but-looping (the gap today) | only `start_to_close` (→ 24h under the naive proposal) | **killed at `heartbeat_timeout` after last progress** |
+| Legit long opaque call | keepalive keeps it alive; bounded by `start_to_close` | blocking bracket keeps it alive; internal/resource timeout is the watchdog |
+| `run_best_effort` child-process work (ADR-0017) | parent awaits; keepalive beats | parent awaits via `run_in_thread`/await → bracket keeps beating |
+
+### What authors tune afterward
+
+| Knob | Before | After |
+| --- | --- | --- |
+| `start_to_close` | the number everyone guesses wrong | 24h backstop, never tuned |
+| `heartbeat_timeout` | "how often do I beat" (coupled to keepalive) | **"max no-progress window"** — ~5–10 min, roughly app-independent |
+| opaque-call bound | none / `start_to_close` | resource-level timeout (DB `statement_timeout`, `httpx` timeout) |
+
+## Rollout
+
+Progress-gating cannot be turned on globally in one step: any existing task doing
+pure-async work that never hits a framework hook or manual beat would start being
+killed at `heartbeat_timeout`. Sequence:
+
+1. **Ship the framework `mark_progress()` hooks first** (writers, emission,
+   transfer loops) so the streaming majority is covered before anyone opts in.
+2. **Gate behind a flag** — `progress_aware_heartbeat` on `@task` /
+   `TaskMetadata`, defaulting **off**, plus an env kill-switch.
+3. **Flip per-app after verification** — with hooks in place, the only migration
+   work is auditing opaque single-call tasks and wrapping them in the bracket (or
+   giving them a resource-level timeout).
+4. **Then** raise the `start_to_close` default (e.g. → 24h) and retire the
+   per-task duration constants — safely, because the watchdog is now real.
+
+The AE-orchestrated DAG node timeouts (`errorHandling.startToCloseTimeoutSeconds`
+in the contract toolkit, defaulting 24h/72h) are a *separate layer* consumed by
+Automation Engine and are out of scope here; this ADR governs SDK-native `@task`
+activities. The same "backstop + progress watchdog" philosophy could later be
+applied there.
+
+## Consequences
+
+**Positive:**
+- App authors stop guessing an unguessable duration; `start_to_close` becomes a
+  set-and-forget backstop.
+- Wedged-but-alive activities are detected in minutes, removing the slot-exhaustion
+  risk that blocks a large `start_to_close` default.
+- Streaming connectors get correct behavior with no code changes (framework hooks).
+- Change is localized to `execution/heartbeat.py` (controller + loop +
+  `run_in_thread`), the `activities.py` wiring, and one-line `mark_progress()` calls
+  in existing SDK write/transfer loops.
+
+**Negative:**
+- Opaque single-call tasks must be audited and either bracketed or given a
+  resource-level timeout — a one-time migration per app.
+- A new default semantics for `heartbeat_timeout` must be documented so authors
+  read it as "no-progress budget," not "beat interval."
+- During rollout, the flag adds a temporary branch that must be removed once
+  progress-aware heartbeat is the default (per the "delete v3-prep workarounds"
+  discipline).
+
+## Related
+
+- **ADR-0010** — Async-First Design and Blocking Code Pitfalls (blocking code owns
+  its timeout; `run_in_thread` keeps the loop responsive). This ADR builds directly
+  on it: the blocking bracket reuses `run_in_thread`'s existing internal-timeout contract.
+- **ADR-0017** — Native Execution Isolation (`run_best_effort` / `run_fault_isolated`).

--- a/docs/adr/0018-progress-aware-heartbeat.md
+++ b/docs/adr/0018-progress-aware-heartbeat.md
@@ -1,7 +1,9 @@
 # ADR-0018: Progress-Aware Stall Watchdog and Duration-Backstop Timeouts
 
 ## Status
-**Proposed**
+**Accepted** — signed off in review on application-sdk PR #2865 (FND-38), including
+both positions in *Decisions taken*. Implementation lands in the stages described in
+*Rollout*.
 
 ## Context
 
@@ -340,7 +342,7 @@ activity fails differently, no knob changes meaning, and the added cost is telem
 The same telemetry settles every sizing parameter at once — where holds go, what each
 allowance should be, what `max_no_progress_seconds` should be, and whether long stalls
 occur in practice at all (currently argued from recollection on both sides). None of
-those are design questions to be decided in review; see *What this needs agreement on*.
+those are design questions — they are measurements; see *Decisions taken*.
 
 ### Failing the activity, and what the failure looks like
 
@@ -919,10 +921,9 @@ removal is part of the work, not a follow-up.
   category before an app enforces.
 - During rollout the flag adds a temporary branch that must be removed.
 
-## What this needs agreement on
+## Decisions taken
 
-Not a list of decisions to make — two stated positions to accept or reject. Everything
-else in this ADR follows from them.
+Two positions carried the review, and everything else in this ADR follows from them.
 
 1. **We start with a 24h attempt and the existing 3-attempt retry policy — a 72h
    worst case per activity, where today it is 30 minutes.** Detection stays in minutes

--- a/docs/adr/0018-progress-aware-heartbeat.md
+++ b/docs/adr/0018-progress-aware-heartbeat.md
@@ -255,15 +255,23 @@ while not stop_event.is_set():
 
     stalled = progress.stalled_for()
     if budget_seconds is not None and stalled >= budget_seconds:
-        logger.warning(
-            "Task '%s' made no observable progress for %.0fs (budget %.0fs); last "
-            "signal was '%s'%s",
-            task_name, stalled, budget_seconds, progress.last_label or "<none>",
-            " — failing the activity" if mode is Mode.ENFORCE else " (warn mode: not failing)",
-        )
+        # Always a metric; the log level differs by mode. In warn mode this is an
+        # expected observation on a fleet-wide default, so it must NOT be WARNING
+        # — see "Warn mode is the default".
+        _no_progress_gap.record(stalled, task=task_name, label=progress.last_label)
         if mode is Mode.ENFORCE:
+            logger.warning(
+                "Task '%s' made no observable progress for %.0fs (budget %.0fs); "
+                "last signal was '%s' — failing the activity",
+                task_name, stalled, budget_seconds, progress.last_label or "<none>",
+            )
             on_stall(stalled, progress.last_label)
             return   # cancel-and-return: the activity's finally awaits this task
+        logger.info(
+            "Task '%s' made no observable progress for %.0fs (budget %.0fs); last "
+            "signal was '%s' — not failing (warn mode)",
+            task_name, stalled, budget_seconds, progress.last_label or "<none>",
+        )
         progress.mark_progress()   # re-arm so warn mode reports each gap once
 ```
 
@@ -280,9 +288,10 @@ a per-site number, guessed up front, by hand.
 
 So the flag has **three states, not two** — `off`, `warn`, `enforce`:
 
-- **`off`** — hooks are inert, nothing observes anything. Behaviour identical to today.
-- **`warn`** — the watchdog runs and reports, but never fails the activity. This is
-  the audit tool.
+- **`off`** — hooks are inert, nothing observes anything. Byte-identical to today.
+  Retained as a kill-switch, not as the normal state.
+- **`warn`** — the watchdog runs and reports, but can never fail an activity. This is
+  the audit tool, and the **default**.
 - **`enforce`** — as described above.
 
 Warn mode emits the two things an author needs, and they map to the two shapes that
@@ -295,18 +304,43 @@ need action:
    because it is auto-vouched-for; these are the sites that want an explicit
    allowance instead of relying on the backstop.
 
-One run against a large tenant therefore produces a ranked work-list, and the author
+A run against a large tenant therefore produces a ranked work-list, and the author
 wraps the sites that exceeded the budget and ignores the rest — which is most of the
 app. The whole-codebase audit collapses into reading a report.
 
-This is not extra machinery: the rollout already gates opt-in on a large-tenant
-tail-profile run, and already needs stall telemetry to tell whether the change
-helped. Warn mode makes that same run the audit, and means **an app's first
-exposure to this design is a report, not a behaviour change.**
+#### Warn mode is the default, fleet-wide
+
+Because warn mode cannot fail an activity, there is no reason to make apps opt into
+it — and two reasons not to:
+
+- **It removes a per-app coordination step from the critical path.** Asking ~20
+  connector teams to each turn a flag on is exactly the shape of work that FND-165
+  documents stalling (nine teams independently re-tuning a number over five months).
+  Defaulting to `warn` means the evidence arrives without anyone being asked to care.
+- **It makes the migration an *eventual optimisation* rather than an upgrade task.**
+  On upgrade an app does nothing, and keeps doing nothing until someone chooses to
+  look at its report. `holding_progress()` becomes work you do when you want the
+  stronger guarantee, not a precondition for taking the version.
+
+Two constraints come with defaulting it on:
+
+- **Warn-mode findings must not be WARNING-level.** A stall observation in warn mode
+  is an expected observation on a fleet-wide default, not an actionable failure.
+  Emitting it at WARNING would manufacture fleet-wide alert noise — the same class of
+  noise this ADR is trying to reduce. It is a metric plus an INFO log; dashboards and
+  the per-app report read the metric.
+- **Hooks go on batch, chunk and page boundaries — never per record.** `mark_progress()`
+  is cheap, but "cheap" in a per-record loop is still a hot-path cost for no extra
+  signal: one batch is already the unit of observable work.
+
+"No behaviour change on upgrade" is therefore precise rather than absolute: no
+activity fails differently, no knob changes meaning, and the added cost is telemetry.
+`off` exists for anyone who needs even that gone.
 
 The same telemetry answers all three open sizing questions at once: where holds go,
 what each allowance should be, and what the global `max_no_progress_seconds` default
-should be (Open question 1).
+should be (Open question 1) — and, per the RFC discussion, whether long stalls occur
+in practice at all, which is currently argued from recollection on both sides.
 
 ### Failing the activity, and what the failure looks like
 
@@ -695,16 +729,18 @@ stall watchdog exists.
 
 The first question every consumer asks: *if I don't touch my code, what changes?*
 
-**On upgrade: nothing.** The watchdog is flag-gated, default off (see *Rollout*);
-`mark_progress()` hooks are inert while the flag is off; `heartbeat_timeout` keeps
-its meaning and its 60s default; `start_to_close` keeps its 600s default. There is
-no coupled default bump, because no existing knob changes meaning. This is the main
-practical advantage over Option 5.
+**On upgrade you land in warn mode, and nothing fails differently.** No activity is
+killed that wasn't before, `heartbeat_timeout` keeps its meaning and its 60s default,
+`start_to_close` keeps its 600s default, and there is no coupled default bump because
+no existing knob changes meaning. What you gain is a report about your own code. This
+is the main practical advantage over Option 5, which could not be defaulted on at all.
 
-**In warn mode: still nothing changes, but you get the work-list.** Warn mode is the
-intermediate state every app passes through, and it cannot fail an activity. The two
-at-risk shapes below show up as report lines instead of kills, which is what makes
-the migration a reading exercise rather than a code audit.
+**So there is no migration task on upgrade — only an eventual optimisation.** An app
+does nothing, indefinitely, and stays correct: warn mode cannot fail an activity, and
+the pre-existing timeouts still apply. Declaring holds is work an app takes on when it
+wants the stronger guarantee (a wedge caught in minutes instead of at the backstop), at
+a time of its choosing, guided by its own report. Nothing about taking the SDK version
+requires touching connector code.
 
 **In enforce mode, whether unchanged code survives depends on its shape.** For the
 last two rows, do-nothing code *will* hit stall kills, and that is the design working
@@ -719,16 +755,18 @@ it cannot distinguish from a wedged one:
 | **Custom async loop doing its own I/O, never through an instrumented SDK path** | reported as a no-progress gap | **False-killed** if any gap > budget | add a beat or a hold |
 | **Opaque single `await` against the source (connector's own async client)** | reported as a no-progress gap | **False-killed** at the tail | wrap in `holding_progress()` — expected in ~every connector |
 
-**The `start_to_close` 24h backstop is coupled to the same opt-in flip.** An app
-gets the 24h ceiling *and* the stall watchdog together, never one without the other:
-the ceiling without the watchdog is the unsafe pairing from *Context*. The global
-default only changes at the very end, once the flag is retired.
+**The `start_to_close` 24h backstop is coupled to `enforce`, not to warn.** An app
+gets the 24h ceiling *and* an enforcing stall watchdog together, never one without the
+other: the ceiling without a watchdog that can actually kill is the unsafe pairing
+from *Context*. Warn mode deliberately buys no ceiling relief — it only buys evidence.
+The global default changes at the very end, once the flag is retired.
 
-**Opt-in verification must exercise a large-tenant / tail profile, not a smoke
-test.** A small tenant's fast steps hide the very gaps that only open at the tail —
-the same tail that produced the original failures. Signing off on a small run and
-flipping the flag would just relocate the tail failure, and with non-retryable
-stalls and no checkpointing, relocating it is worse than leaving it.
+**Flipping to `enforce` must be verified against a large-tenant / tail profile, not a
+smoke test.** A small tenant's fast steps hide the very gaps that only open at the
+tail — the same tail that produced the original failures. Flipping on the strength of
+a small run would just relocate the tail failure, and with non-retryable stalls and no
+checkpointing, relocating it is worse than leaving it. Warn mode is what makes this
+checkable rather than aspirational.
 
 ## Rollout
 
@@ -738,28 +776,32 @@ stalls and no checkpointing, relocating it is worse than leaving it.
    mechanism on top. This is sequencing, not scope creep: the warn-mode signal in
    step 3 is unreadable while starvation dominates it.
 2. **Ship the framework `mark_progress()` hooks** (writers, emission, transfer
-   loops) so the streaming majority is covered before anyone observes anything.
-   Inert while the flag is off. Land CNCT-10's timeout-subtype classification
-   alongside, so stall kills are distinguishable from starvation kills in the
-   fleet-wide numbers.
-3. **Run every app in `warn` first.** Warn mode is both the measurement and the
-   audit: it produces the per-app work-list (no-progress gaps, long unbounded holds)
-   and the fleet-wide gap distribution that sets the
-   `max_no_progress_seconds` default. Nothing can be killed in this state, so it is
-   safe to turn on broadly and early — and it means the first thing an app team sees
-   is a report about their own code, not a behaviour change.
+   loops) so the streaming majority is covered before anything observes anything.
+   Land CNCT-10's timeout-subtype classification alongside, so stall kills are
+   distinguishable from starvation kills in the fleet-wide numbers.
+3. **Ship `warn` as the default — no per-app step.** Warn mode cannot fail an
+   activity, so it needs no opt-in: on upgrade every app starts producing its own
+   work-list (no-progress gaps, long unbounded holds) and contributing to the
+   fleet-wide gap distribution that sets the `max_no_progress_seconds` default.
+   This is deliberately *not* a step that requires ~20 teams to each do something.
+   `off` ships alongside as an env kill-switch.
 4. **Ship the conformance rule and the toolkit floor.** Both are independent of the
    `@task` work and both deliver immediately: the floor stops the next app shipping
-   a 2h node timeout, and the rule keeps un-held opaque sites visible after the
-   warn-mode pass has cleared the backlog. Pair with the AE ask to drop its own
+   a 2h node timeout, and the rule keeps un-held opaque sites visible once teams
+   start working through their reports. Pair with the AE ask to drop its own
    default.
-5. **Flip per-app to `enforce` once that app's warn report is clean** — i.e. its
-   remaining gaps are all inside declared holds or under budget, verified against a
-   **large-tenant / tail profile**, not a smoke test. The flag (`progress_watchdog`
-   on `@task` / `TaskMetadata`) carries an env kill-switch back to `warn`.
-6. **Couple the 24h `start_to_close` backstop (and its `schedule_to_close`
+5. **Read the fleet data before committing to `enforce` at all.** If long stalls
+   turn out to be rare, that is an argument for a generous budget — or for leaving
+   the fleet in warn and taking only the AE/backstop half of this ADR. Deciding this
+   from measurement rather than from either side's recollection is the point of
+   getting warn out early.
+6. **Flip per-app to `enforce` when that app wants the guarantee** — its remaining
+   gaps inside declared holds or under budget, verified against a **large-tenant /
+   tail profile**, not a smoke test. The flag is `progress_watchdog` on `@task` /
+   `TaskMetadata`.
+7. **Couple the 24h `start_to_close` backstop (and its `schedule_to_close`
    product) to that same per-app flip.** The global default changes only at the end,
-   once the flag is retired and the watchdog is universal; at that point the
+   once the flag is retired and enforcement is universal; at that point the
    per-task duration constants are retired.
 
 Per the "delete v3-prep workarounds" discipline, the flag is temporary and its
@@ -776,9 +818,12 @@ removal is part of the work, not a follow-up.
   upgrade is behaviourally identical until an app opts in.
 - Stalls surface as a typed error naming the last progress signal, which is both
   better for the operator and what makes the rollout measurable.
-- The per-app migration is mechanical rather than manual: warn mode produces the
-  work-list and the evidence for each allowance, so nobody has to read a whole
-  codebase deciding where a hold belongs or invent a number for it.
+- The per-app migration is mechanical rather than manual, and it is not on the
+  upgrade path at all: warn mode ships on by default, produces the work-list and the
+  evidence for each allowance, and declaring holds becomes an optimisation an app
+  takes on when it wants the stronger guarantee.
+- Whether long stalls actually happen becomes a measured question rather than an
+  argued one, fleet-wide, before anything can be killed for it.
 - Streaming connectors get correct behavior with no code changes.
 - Change is localized to `execution/heartbeat.py` (tracker + loop + hold plumbing),
   the `activities.py` wiring and cancellation branch, one new error leaf, and

--- a/docs/adr/0018-progress-aware-heartbeat.md
+++ b/docs/adr/0018-progress-aware-heartbeat.md
@@ -1,4 +1,4 @@
-# ADR-0018: Progress-Aware Heartbeat and Duration-Backstop Timeouts
+# ADR-0018: Progress-Aware Stall Watchdog and Duration-Backstop Timeouts
 
 ## Status
 **Proposed**
@@ -16,15 +16,15 @@ Every SDK `@task` becomes a Temporal activity carrying two timeouts (see
   runs a background **auto-heartbeat loop** every 10s so app authors get liveness
   for free (`auto_heartbeat_loop` in `execution/heartbeat.py`).
 
-The two timeouts catch *orthogonal* failure modes and neither subsumes the other:
+The two timeouts catch *different* failure modes and neither subsumes the other:
 
-- `heartbeat_timeout` detects **unresponsiveness** (crash, deadlock, network loss,
-  event-loop starvation) — it only fires when heartbeats *stop*.
-- `start_to_close` detects **taking too long while healthy** — an activity that
-  keeps heartbeating but runs longer than allowed. It is the *only* bound on a
-  healthy-but-slow or wedged-but-alive attempt.
+- `heartbeat_timeout` detects **nothing is beating** — process crash, OOM kill,
+  node loss, network partition, event-loop starvation. It fires ~`heartbeat_timeout`
+  after the worker stops being able to beat.
+- `start_to_close` detects **taking too long while beating**. It is the *only*
+  bound on a healthy-but-slow or wedged-but-alive attempt.
 
-### The problem: `start_to_close` is an unguessable number
+### Problem 1: `start_to_close` is an unguessable number
 
 `start_to_close` forces app authors to answer *"how long should this whole
 activity take?"* — a number that scales with tenant size from seconds to days and
@@ -35,11 +35,22 @@ extraction, query-history, and processing activities — despite each app having
 already tuned per-task timeouts (e.g. 5-minute "light", 2-hour "medium", 6-hour
 "heavy" classes). The tuning is educated guessing, and the tail always exceeds it.
 
-The intuitive fix — *"raise the `start_to_close` default to something enormous
-like 24h and stop guessing"* — is directionally right (a generous
-`start_to_close` backstop plus a fast watchdog is Temporal's own recommended
-pattern for long-running work) but **unsafe as-is**, because of how the
-auto-heartbeat currently works.
+### Problem 2: heartbeat timeouts are the *larger* failure mode today
+
+This ADR must be honest that `StartToClose` is the smaller half of the evidence.
+Per FND-165, the `activity Heartbeat timeout` pattern re-alerted **18× since
+Aug 3**, hitting **five connectors/tenants in a trailing 24h**, and **at least
+nine teams** have independently re-tuned a heartbeat or timeout number since March
+rather than fixing the mechanism (CONNECT-728 ThoughtSpot, CONNECT-141 dbt,
+SHA-838/1318 publish, CAS-61/62 Context Agents — which needed **30 minutes**,
+SHA-327 QI, LH-1097 Lakehouse).
+
+Those heartbeat timeouts are, today, overwhelmingly *event-loop starvation*: the
+auto-loop cannot run because blocking work is holding the loop, so no beat is sent
+even though the activity is healthy. That is an ADR-0010 adoption problem, not a
+timeout-semantics problem, and **it is not what this ADR fixes.** It matters here
+for sequencing: any design that puts more weight on the heartbeat mechanism lands
+on top of a mechanism that is already the top failure. See *Rollout*.
 
 ### Why a large `start_to_close` is unsafe today
 
@@ -48,19 +59,18 @@ calls `activity.heartbeat()` every 10s regardless of whether the activity is
 making any real progress. It proves the *event loop is alive*, not that *work is
 advancing*. Consequences:
 
-1. `heartbeat_timeout` cannot catch a **wedged-but-alive** activity (an infinite
-   async retry loop, a fetch that streams forever, a driver stuck in a
-   yield-friendly wait). Heartbeats keep arriving, so only `start_to_close` ever
-   stops it.
-2. Therefore, if we raise `start_to_close` to 24h and keep the unconditional
-   keepalive, a wedged activity is guarded by **nothing** for a full day →
-   worker-slot exhaustion (Temporal's Python worker defaults to ~100 concurrent
-   activity slots; a handful of stuck activities can starve the pool) and
-   day-long non-detection.
+1. Nothing catches a **wedged-but-alive** activity (an infinite async retry loop,
+   a fetch that streams forever, a driver stuck in a yield-friendly wait).
+   Heartbeats keep arriving, so only `start_to_close` ever stops it.
+2. Therefore, if we raise `start_to_close` to 24h and change nothing else, a
+   wedged activity is guarded by **nothing** for a full day → worker-slot
+   exhaustion (Temporal's Python worker defaults to ~100 concurrent activity
+   slots; a handful of stuck activities can starve the pool) and day-long
+   non-detection.
 
 The number that is genuinely hard to guess (total duration) cannot simply be made
-huge unless *something else* reliably kills a stuck activity fast. That "something
-else" must be the heartbeat — and today it can't do the job.
+huge unless *something else* reliably kills a stuck activity fast. Today nothing
+does.
 
 ## Decision
 
@@ -81,9 +91,9 @@ that same observability *holistically and, wherever possible, automatically*:
 - **Explicit (developer chooses one mechanism):** for the spots the SDK cannot see
   — a custom async loop, or an opaque single `await` against the connector's own
   source client — the developer makes it observable with a manual beat or a scoped
-  bracket. This is not a rare edge: because the async source path has no mandatory
+  hold. This is not a rare edge: because the async source path has no mandatory
   SDK seam (unlike blocking calls, which all go through `run_in_thread`), the
-  explicit bracket is expected in nearly every connector (see *The async escape
+  explicit hold is expected in nearly every connector (see *The async escape
   hatch* below).
 
 This framing matters for expectations: **the residual work never disappears.** The
@@ -92,31 +102,52 @@ that does long work through code the SDK can't see will still need one of the th
 mechanisms. "Zero effort" is true only for the covered paths; everything else is a
 deliberate, one-line observability choice.
 
-### Inverting the timeout model
+### The watchdog runs in-process, and `heartbeat_timeout` keeps its meaning
 
-With observability in place, invert the two timeouts:
+Given a progress signal, the obvious move is to make the heartbeat *conditional* —
+beat only on progress, and let Temporal's `heartbeat_timeout` do the killing. This
+ADR deliberately **does not** do that (see *Option 5*, rejected). Instead:
 
-1. The auto-heartbeat loop sends a beat **only when a progress token advanced**
-   since the last tick (or a bounded blocking op is in flight). A stall stops
-   the beats, so `heartbeat_timeout` fires `heartbeat_timeout` seconds after the
-   *last real progress*.
-2. `heartbeat_timeout` is redefined as **"maximum acceptable time making zero
-   forward progress"** — a roughly workload-independent number (minutes), unlike
-   total duration. **Its default rises from 60s to 300s** in the same change that
-   flips the semantics (see *Migration*): 60s under the new meaning would be a live
-   tripwire that even well-instrumented apps trip between coarse-grained signals.
+1. The auto-heartbeat loop keeps sending its **unconditional** keepalive.
+   `heartbeat_timeout` keeps its current meaning and its current 60s default: it
+   detects *nothing is beating* — crash, OOM kill, node loss, partition,
+   event-loop starvation.
+2. The same loop gains a **stall watchdog**: it tracks a progress token, and when
+   the token has been flat for **`max_no_progress_seconds`** it **fails the
+   activity itself, in-process**, with a typed error naming the last progress
+   signal and the elapsed stall.
 3. `start_to_close` becomes a **pure backstop** (e.g. 24h) that authors never tune.
-4. Opaque single blocking calls that emit no progress (one long query/API call)
-   are kept alive by an explicit, scoped **liveness bracket** that is **bounded by
-   the blocking call's own declared timeout** — the DB `statement_timeout` / `httpx`
-   timeout ADR-0010 already mandates. The bracket vouches for the call only until
-   that bound elapses; past it, the beats stop and `heartbeat_timeout` fires. This
-   keeps the "blocking code owns its timeout" contract *and* closes the hole where
-   a wedged blocking call would otherwise be unguarded until the 24h backstop.
+4. Long single operations that emit no progress — one big query, one slow API call,
+   blocking or async — are covered by an explicit scoped **hold**
+   (`holding_progress()`), which vouches for them for a duration the author
+   declares. The SDK never derives or invents that duration (see *Holds*).
+
+Why one operator concept and two enforcement points: *"it stopped doing anything"*
+is a single idea, and the operator should see a single failure story. But the two
+underlying situations want very different reaction times, and one number would have
+to be the slower of the two:
+
+- Nothing will ever beat again (OOM, SIGKILL, node loss): the attempt is already
+  dead. Reclaim and retry **now** — 60s.
+- Wedged-but-alive, or healthy-but-quiet: a legitimate quiet spell must be waited
+  out first — **minutes**.
+
+Collapsing these into one knob means a crash-killed worker's activities sit idle
+for the whole no-progress budget before Temporal reclaims them. Graceful evictions
+(KEDA scale-down, VPA, spot reclaim) don't pay that cost — the SIGTERM path
+(`WORKER_EVICTED_TYPE`, `execution/_temporal/eviction_retry.py`) fires immediately
+— but SIGKILL/OOM/node-loss has no path other than `heartbeat_timeout`. OOM is a
+leading failure mode for exactly these connectors, so keeping 60s crash detection
+is not conservatism; it is the point.
+
+Keeping the two enforcement points separate also means the mechanisms cover each
+other's blind spot exactly: the in-process watchdog cannot fire when the event loop
+is starved — and that is precisely when `heartbeat_timeout` does.
 
 This shifts tuning off the hard knob (duration) onto two answerable ones: *"how
-long is no progress acceptable?"* (uniform default) and *"how long should one
-query take?"* (a property of the resource, which the call already declares).
+long is no progress acceptable?"* (roughly workload-independent, one default) and
+*"how long should this one operation take?"* (declared at the one call site that
+knows).
 
 ### What counts as "progress"
 
@@ -127,192 +158,237 @@ reviewer asks first, so it must be crisp:
 > or file transferred, a page fetched, or an explicit `context.heartbeat()`.
 
 It is emphatically **not** wall-clock time and **not** event-loop liveness — that
-was the old unconditional keepalive this ADR removes. The single rule an author
-needs follows directly from the definition:
+is what the unconditional keepalive already proves, and it is why the keepalive
+cannot double as the stall detector. The single rule an author needs follows
+directly from the definition:
 
-> **If any one step can run longer than the no-progress budget (`heartbeat_timeout`,
-> default 300s) without emitting a signal, that step must be made observable** — it
-> is already covered by a framework hook, or the author adds a manual beat or a
-> bracket.
+> **If any one step can run longer than the no-progress budget
+> (`max_no_progress_seconds`) without emitting a signal, that step must be made
+> observable** — it is already covered by a framework hook, or the author adds a
+> manual beat or a hold.
 
-By construction, **any gap between progress signals longer than `heartbeat_timeout`
-is treated as a stall.** That is the intended behavior, not a corner case: it is
+By construction, **any gap between progress signals longer than the budget is
+treated as a stall.** That is the intended behavior, not a corner case: it is
 exactly how a wedged-but-quiet activity gets caught. The design's job is to ensure
 the *legitimate* quiet spots are the small, known set that the automatic hooks and
-the bracket already cover.
+holds already cover.
 
-### The progress token
+### The progress tracker
 
-`TemporalHeartbeatController` (`execution/heartbeat.py`) gains a monotonic
-progress generation and a blocking **deadline** (not just a depth counter — the
-deadline is what bounds the bracket, see below):
+Progress tracking is a **new object, not a change to `HeartbeatController`.** The
+controller's job (send beats to Temporal) is unchanged, so its Protocol and
+`NoopHeartbeatController` keep their current contract. The tracker has no Temporal
+dependency, which means local and test execution exercise the same code path as
+production — and, usefully, a task with `heartbeat_timeout_seconds=None` still gets
+a stall watchdog.
 
 ```python
-class TemporalHeartbeatController:
-    def __init__(self) -> None:
-        self._last_details: tuple[Any, ...] = ()
-        self._progress_gen: int = 0            # bumped on every real progress signal
-        self._blocking_deadlines: list[float] = []  # monotonic deadlines of in-flight blocking ops
+class ProgressTracker:
+    """Observed forward progress for one activity attempt."""
 
-    def mark_progress(self) -> None:
+    def __init__(self, clock: Callable[[], float] = time.monotonic) -> None:
+        # Injected clock, not a patched global: an asyncio loop shares
+        # time.monotonic, so patching it globally in tests makes the loop itself
+        # misbehave.
+        self._clock = clock
+        self._last_label: str = ""
+        self._last_at: float = clock()
+        self._holds: dict[int, float | None] = {}  # token -> deadline (None = unbounded)
+        self._next_token: int = 0
+
+    def mark_progress(self, label: str = "") -> None:
         """Framework + app signal for real forward progress."""
-        self._progress_gen += 1
+        self._last_at = self._clock()
+        if label:
+            self._last_label = label
 
-    def heartbeat(self, *details: Any) -> None:
-        # A manual heartbeat is, by definition, progress.
-        self._last_details = details
-        self._progress_gen += 1
-        activity.heartbeat(*details)
+    def enter_hold(self, deadline: float | None) -> int:
+        """Vouch for an in-flight opaque operation. Returns a token."""
+        token = self._next_token
+        self._next_token += 1
+        self._holds[token] = deadline
+        return token
 
-    def enter_blocking(self, timeout: float) -> None:
-        # Vouch for a blocking op only until its own declared timeout elapses.
-        self._blocking_deadlines.append(time.monotonic() + timeout)
+    def exit_hold(self, token: int) -> None:
+        # Keyed by token, not popped off a stack: concurrent holds in one
+        # activity (asyncio.gather over several run_in_thread calls) must not
+        # release each other's deadlines.
+        self._holds.pop(token, None)
 
-    def exit_blocking(self) -> None:
-        if self._blocking_deadlines:
-            self._blocking_deadlines.pop()
+    def held(self) -> bool:
+        now = self._clock()
+        return any(d is None or d > now for d in self._holds.values())
 
-    def blocking_active(self) -> bool:
-        # A blocking op is vouched-for only while its deadline is in the future;
-        # once a call overruns its own timeout we stop beating for it and let
-        # heartbeat_timeout fire (the thread itself can't be killed — see below).
-        now = time.monotonic()
-        return any(d > now for d in self._blocking_deadlines)
-
-    def heartbeat_keepalive(self) -> None:
-        activity.heartbeat(*self._last_details)   # unchanged: the raw send
+    def stalled_for(self) -> float:
+        """Seconds since the last observable progress, 0 while vouched-for."""
+        return 0.0 if self.held() else self._clock() - self._last_at
 ```
 
-### Gating the loop
+### The watchdog in the loop
 
-Only the *send* becomes conditional; the existing event-loop-block warning and
-memory-pressure sampling still run every tick:
+The existing send, event-loop-block warning and memory sampling are unchanged. The
+watchdog is additive:
 
 ```python
-last_seen_gen = -1
 while not stop_event.is_set():
     ...  # existing wait_for(stop_event) + block-detection warning + memory sampling
 
-    beat = (
-        hb.progress_gen != last_seen_gen     # real progress since last tick
-        or hb.blocking_active()              # bounded opaque op still within its timeout
-    )
-    if beat:
-        last_seen_gen = hb.progress_gen
-        hb.heartbeat_keepalive()
-    else:
-        logger.debug(
-            "No progress in last %.0fs for '%s'; withholding keepalive so "
-            "heartbeat_timeout can fire if the stall persists",
-            interval_seconds, task_name,
+    hb.heartbeat_keepalive()          # unchanged, unconditional: the crash detector
+
+    stalled = progress.stalled_for()
+    if budget_seconds is not None and stalled >= budget_seconds:
+        logger.warning(
+            "Task '%s' made no observable progress for %.0fs (budget %.0fs); last "
+            "signal was '%s' — failing the activity",
+            task_name, stalled, budget_seconds, progress.last_label or "<none>",
         )
+        on_stall(stalled, progress.last_label)
+        return   # cancel-and-return: the activity's finally awaits this task
 ```
 
-That `else` branch is the entire behavioral change.
+`on_stall` is injected by `activities.py`, the same way `heartbeat_fn` already is,
+so `heartbeat.py` stays free of activity/Temporal semantics and the watchdog is
+unit-testable without a worker.
 
-### Feeding the token (three mechanisms, most-automatic first)
+### Failing the activity, and what the failure looks like
 
-These are the three observability mechanisms from the mental model, ordered by how
-little the app author has to do:
+`activities.py` captures `asyncio.current_task()` before it creates the heartbeat
+task (`activities.py:196-207`), and `on_stall` flags the tracker and cancels that
+task. The cancellation lands at the activity's next `await` and hits the existing
+`except asyncio.CancelledError` handler (`activities.py:259`).
 
-1. **Framework hooks (automatic, no app action).** Call `hb.mark_progress()`
-   wherever the SDK already loops over units of work: the batched output writers,
-   the record/statistics emission path, and the `ObjectStore` transfer loops
+That handler gains a branch **ahead of** the `is_worker_shutting_down()` check,
+which raises a typed `AppError` — a new `TaskStalledError` alongside
+`AppTimeoutError` in `errors/leaves.py` — carrying `stalled_for_seconds` and
+`last_progress_label` as dataclass fields, so redaction stays at the
+`FailureDetails` wire layer rather than being achieved by withholding context.
+
+Three details that matter:
+
+- **Flag-check order.** A stall and a SIGTERM can coincide. The stall branch must
+  come first, or a stalled activity is mislabelled `WorkerEvicted` and re-dispatched
+  by the eviction-retry loop (`app/base.py:2447`) *outside* the normal retry budget.
+- **Cancel and return.** The watchdog *is* `heartbeat_task`, and the activity's
+  `finally` (`activities.py:334-347`) sets `stop_event` and awaits it with a 1s
+  bound. The watchdog must return immediately after cancelling, not keep looping.
+- **Translation is shared, not duplicated.** The `AppError → ApplicationError(*FailureDetails)`
+  translation in the `except Exception` branch (`activities.py:299-331`) already
+  handles the non-serialisable-evidence guard, `_sever_cause_chain` (BLDX-1512) and
+  `non_retryable=not e.effective_retryable`. Factor it into a helper both branches
+  call.
+
+**`TaskStalledError` is non-retryable by default.** A wedge usually re-wedges, and
+without activity-level checkpointing (REQ-1609) a retry restarts from zero — so an
+automatic retry mostly buys another full stall. This is a deliberate decision, cheap
+to revisit once REQ-1609 lands. See *Bounding total time*.
+
+Detection latency is `max_no_progress_seconds` plus at most one loop tick (10s).
+
+### Feeding the tracker (three mechanisms, most-automatic first)
+
+1. **Framework hooks (automatic, no app action).** Call `mark_progress()` wherever
+   the SDK already loops over units of work: the batched output writers, the
+   record/statistics emission path, and the `ObjectStore` transfer loops
    (`storage/transfer.py`, `storage/chunked.py`, `storage/file_ref_sync.py`). This
    covers the streaming majority — the bulk of connector runtime — with no code
    change in the app.
-2. **The blocking bracket around `run_in_thread` (automatic for blocking work).**
-   Anything offloaded through `run_in_thread` is bracketed by the SDK itself, so a
-   legitimate long blocking call is never false-killed (details below).
+2. **`run_in_thread` auto-holds (automatic for blocking work).** Anything offloaded
+   through `run_in_thread` is wrapped in an **unbounded** hold by the SDK, so a
+   legitimate long blocking call is never false-killed and behaviour on upgrade is
+   unchanged. An unbounded hold means the stall watchdog is inactive for the
+   duration of the call and the 24h backstop is the only bound — a real, documented
+   residual, which the conformance rule below is what shrinks.
 3. **Manual `context.heartbeat(...)` or `holding_progress(...)` (explicit, app
    action).** The residual: a custom async loop, or an opaque single `await`
    against the connector's own source client (see the asymmetry below — this is
-   *not* a rare case). `context.heartbeat()` already exists and now also bumps
-   progress (still carrying resume details for `get_last_heartbeat_details()`);
-   `holding_progress()` is the async analogue of the blocking bracket. This is the
-   mechanism that asks the author to *do* something — and the audit step in
-   *Rollout* exists to find exactly these spots.
+   *not* a rare case). `context.heartbeat()` already exists and now also marks
+   progress (still carrying resume details for `get_last_heartbeat_details()`).
 
-### The blocking bracket — bounded by the call's own timeout
+The tracker reaches `run_in_thread` and `holding_progress` through a ContextVar set
+by `activities.py`. There is no such ContextVar today — the controller is passed
+into `TaskExecutionContext` — so this is new plumbing, and it must cover the
+module-level `run_in_thread` (`execution/heartbeat.py:234`), not only the
+`TaskExecutionContext` wrapper, since both are used.
 
-Two questions from review shape this design:
+### Holds: the SDK never invents a duration
 
-**Q: If my blocking code goes through `run_in_thread`, does it just beat forever?**
-Not anymore. A naive "beat while `blocking_depth > 0`" would keep a *wedged*
-blocking call alive until the 24h backstop — reintroducing the exact hole this ADR
-closes for async code. Instead the bracket is **bounded by the blocking call's own
-declared timeout** and stops vouching once that elapses:
+One mechanism covers both blocking and async opaque work:
 
 ```python
-async def run_in_thread(func, *args, blocking_timeout: float | None = None, **kwargs):
-    hb = _current_heartbeat_controller()
-    bound = blocking_timeout if blocking_timeout is not None else _derive_timeout(func, kwargs)
-    if hb and bound is not None:
-        hb.enter_blocking(bound)
-    try:
-        return await loop.run_in_executor(_BLOCKING_EXECUTOR, ...)
-    finally:
-        if hb and bound is not None:
-            hb.exit_blocking()
+# async: the connector's own client
+async with self.context.holding_progress("snapshot metadata query", timeout=1800):
+    rows = await long_single_query(...)
+
+# blocking: the same wrapper around the offload
+async with self.context.holding_progress("full table scan", timeout=7200):
+    rows = await self.context.run_in_thread(cursor.execute, sql)
 ```
 
-Effective kill time for a wedged blocking call therefore drops from ~24h to
-`blocking_timeout + heartbeat_timeout`. (The Python thread itself cannot be
-cancelled — that is `run_in_thread`'s known limitation; only `run_fault_isolated`
-kills via a child process. The bracket doesn't kill the thread; it stops *lying to
-Temporal* about it, so the slot is reclaimed and the activity fails/retries.)
+An earlier draft of this ADR proposed *deriving* the hold's bound from the
+`timeout=` kwarg the call already carries, on the theory that ADR-0010 already
+mandates that number and reusing it avoids inventing a new one. **That is rejected**,
+for two reasons:
 
-**Where does the bound come from? Reuse the number the call already declares.**
-ADR-0010 already mandates that blocking code owns a timeout
-(`requests.get(url, timeout=30)`, `httpx` timeout, DB `statement_timeout`). The
-bracket bound is *that* number — not a new one to invent, which keeps faith with
-this ADR's whole thesis of eliminating guessed durations. Layered so we never
-silently guess:
+1. **`timeout=` almost never means "wall-clock bound on this call."** It is
+   per-operation: `requests`' read timeout bounds the gap between socket reads (a
+   streaming download legitimately runs for hours without exceeding it), `httpx`
+   is the same shape, DB `statement_timeout` is per *statement* (a call issuing
+   forty statements is bounded at forty times the limit), socket timeouts are per
+   recv. A successfully derived number is therefore systematically *smaller* than
+   the call's legitimate duration, so bracketing on it false-kills healthy work.
+2. **A derived bound is a total-duration guess wearing a disguise** — the exact
+   knob this ADR exists to abolish, reintroduced for blocking calls.
 
-1. **Explicit is the contract:** `run_in_thread(func, ..., blocking_timeout=30)`.
-2. **Convenience derivation** (`_derive_timeout`): if omitted, best-effort read a
-   `timeout=` / `timeout_seconds=` kwarg off the call and reuse it, logging at
-   DEBUG what was derived. Covers the common `requests`/`httpx` case with zero
-   boilerplate — the author already typed the number once. *Caveats made explicit
-   so no one over-trusts it:* it is heuristic — units vary (s vs ms), `requests`
-   uses a `(connect, read)` tuple, and some callees don't name the arg `timeout`
-   at all. Derivation is a convenience over the explicit arg, never a replacement.
-3. **Conservative fallback, never 24h:** if no bound is found, cap at a small
-   multiple of `heartbeat_timeout` and emit a WARNING, so the missing timeout
-   surfaces during the opt-in audit rather than hiding until a wedge.
+The dominant real shape makes it worse: `run_in_thread(cursor.execute, sql)` has
+no `timeout=` kwarg at all (the bound lives on the connection), so derivation
+fails and a fallback takes over. Any fallback tight enough to be useful as a
+watchdog — "a small multiple of the no-progress budget" — is *tighter than the
+status quo*, where the same call is bounded by the task's `start_to_close` of 2h or
+6h. Opt-in would then make legitimate long blocking work fail sooner than before,
+in precisely the apps most likely to opt in.
+
+(As a mechanical note, `blocking_timeout=` could not have been a `run_in_thread`
+kwarg anyway: `run_in_thread(func, *args, **kwargs)` forwards every kwarg to
+`func`, so the name would collide. The context manager sidesteps that too.)
+
+So there are exactly two honest paths at a call the SDK cannot see into, both
+explicit and both greppable:
+
+- The author declares a real wall-clock allowance and `holding_progress` honours it.
+  Past it, the hold lapses, the watchdog resumes, and the stall fires
+  `max_no_progress_seconds` later. Effective kill time for a wedged call is
+  `timeout + budget` instead of 24h.
+- The author declares nothing, the hold is unbounded, and the 24h backstop owns it —
+  an accepted residual, surfaced by the conformance rule rather than hidden.
+
+Opaque operations are the one place a duration bound is genuinely unavoidable,
+because there is nothing to observe from outside a blocked thread. The ADR's
+position is to say so, and to let a human state the number at the one site that
+knows it — never to let the SDK guess it.
 
 ### The async escape hatch — and the asymmetry that makes it common
-
-For an async-opaque single `await` with no progress signal, `holding_progress()` is
-the explicit analogue of the blocking bracket:
-
-```python
-async with self.context.holding_progress("snapshot metadata query", timeout=120):
-    rows = await long_single_query(...)   # its own statement_timeout is the watchdog
-```
 
 **Q: "Making people use it *always* might become a problem."** This is the most
 important open ergonomics question, and we should not pretend it away. There is a
 real asymmetry between the blocking and async paths:
 
-- **Blocking source calls are auto-covered.** `run_in_thread` is a *mandatory
-  seam* — every blocking call already goes through it (ADR-0010), so the SDK
-  brackets it for the author with no extra code.
+- **Blocking source calls are auto-held.** `run_in_thread` is a *mandatory seam* —
+  every blocking call already goes through it (ADR-0010), so the SDK holds for the
+  author with no extra code.
 - **Async source calls have no equivalent mandatory seam.** A connector connects
   to its *own* source system with its *own* async client (an async SQLAlchemy
   engine, an `httpx.AsyncClient`, a vendor SDK). **The SDK's internal SQL/HTTP
   clients are for the SDK's own purposes; they do not, and are not meant to, sit on
   the connector→source path** — so there is no SDK-owned wrapper we can transparently
-  instrument for that call. Auto-bracketing "the SDK clients" would cover almost
-  none of the real source I/O.
+  instrument for that call. Auto-holding "the SDK clients" would cover almost none
+  of the real source I/O.
 
 Two things soften this, but neither eliminates it:
 
 1. **Interleaved streaming reads are already covered by the write side.** The
-   common extraction shape — fetch a page, write a batch, repeat — ticks
-   `mark_progress()` on every batch write, so the read loop is covered as long as
-   one fetch+write cycle stays under the no-progress budget. `holding_progress()`
-   is *not* needed there.
+   common extraction shape — fetch a page, write a batch, repeat — marks progress
+   on every batch write, so the read loop is covered as long as one fetch+write
+   cycle stays under the budget. `holding_progress()` is *not* needed there.
 2. The residual is the genuinely **opaque single async call** — one large metadata
    query, one slow list/export API call that returns everything at once. Those
    emit nothing until they complete.
@@ -321,11 +397,84 @@ So the honest expectation: **`holding_progress()` will very likely be needed in
 almost every connector**, because almost every connector makes at least one such
 opaque async call against its source. It is a *standard part of writing a
 long-running async task*, not a rare escape hatch. We make that acceptable by (a)
-keeping it a one-line context manager whose `timeout` is just the client timeout
-the author already sets, (b) documenting it as expected rather than exceptional,
-and (c) having the opt-in audit specifically hunt source-side opaque async calls. A
-forgotten bracket false-kills at the tail (see *Migration*), so for such calls it
-is **required**, not advisory.
+keeping it a one-line context manager, (b) documenting it as expected rather than
+exceptional, and (c) having the conformance rule and the opt-in audit specifically
+hunt source-side opaque async calls. A forgotten hold false-kills at the tail (see
+*Migration*), so for such calls it is **required**, not advisory.
+
+## Bounding total time
+
+Removing the duration knob removes the only wall-clock bound the system has, and
+the ADR must say what replaces it — "nothing" is not an answer that survives an
+incident.
+
+**Retries multiply the backstop.** `get_activity_options`
+(`execution/_temporal/activities.py:418-420`) returns only `start_to_close_timeout`
+and a retry policy — **no `schedule_to_close`**. With the default
+`retry_max_attempts=3`, a 24h backstop is a **72h** worst case per activity. Today
+that product is 30 minutes. Options, in preference order:
+
+1. **Set `schedule_to_close` as the real backstop** and let `start_to_close` bound
+   one attempt. The SDK already has precedent for a budget-shaped pair in
+   `gate_timeouts` (`app/base.py:1902`), which derives both from one budget and a
+   max-attempts count.
+2. Keep `start_to_close` only, and cap attempts at 1 for backstop-class tasks.
+
+Either way the ADR's claim must be about the *product*, not one attempt.
+
+**Retries without checkpointing are expensive.** REQ-1609 (activity-level
+checkpointing) is not a nice-to-have adjacent to this work: without it, a stall kill
+at hour 5 of a 6-hour extraction restarts from zero. The watchdog makes failure
+*faster to detect* but not *cheaper to recover*, and a false kill at the tail is
+catastrophic rather than annoying. That is the main reason `TaskStalledError`
+defaults to non-retryable, and the main reason the tail-profile verification in
+*Rollout* is a gate rather than a suggestion.
+
+**A run with no duration bound anywhere still needs a duration signal.** Once the
+AE layer drops its timeouts (below) and `start_to_close` is a 24h backstop, a run
+that wedges while dribbling small amounts of progress is effectively unbounded. The
+replacement for a duration *kill* is a duration *alert* — an SLA on run length in
+the observability stack — so "remove the timeouts" does not quietly become "nobody
+notices for a week."
+
+## The Automation Engine layer
+
+An earlier draft declared the AE-orchestrated DAG-node timeouts out of scope. That
+is wrong in effect: the failures operators actually report — a connector run killed
+at exactly 2h — come from *that* layer, not from `@task`. Scoping it out while the
+symptom lives there makes this ADR look like a fix for something it does not touch.
+
+**AE should hold no duration opinion at all.** Connector DAG nodes are child-workflow
+invocations, not activities: `DAGNode.nodeType` defaults to `"workflow"`
+(`contract-toolkit/src/App.pkl:686`) because `renderNode` always emits
+`activity_name = "execute_workflow"`, and the toolkit *rejects*
+`heartbeatTimeoutSeconds` on workflow nodes (`App.pkl:716-720`) precisely because
+it is activity-only. Temporal requires no timeout on a workflow —
+`workflow_execution_timeout` and `workflow_run_timeout` both default to unlimited;
+only `workflow_task_timeout` has a mandatory default, and that bounds task dispatch,
+not run duration. So there is nothing structurally forcing a number, and the
+unguessability argument applies with full force one layer up.
+
+Three pieces of work follow, none of which are `@task` changes:
+
+1. **AE drops its default.** The toolkit cannot fix this by omission: setting
+   `errorHandling = null` falls back to *AE's own source default of 2h*
+   (`App.pkl:706-714`) — the number the toolkit already raised to 1d/72h to work
+   around. AE has to stop applying a duration to workflow nodes.
+2. **The toolkit floors the override.** `startToCloseTimeoutSeconds` is currently
+   `Int(isBetween(1, 864000))` (`App.pkl:740`) — a cap with no floor, which is how
+   an app ships 7200. Give it a floor so an app cannot tune *below* the generous
+   default.
+3. **A conformance rule makes it permanent.** A rule that flags an app-level node
+   timeout below the floor runs across every connector repo in seconds, reports
+   through connector-pulse, and is a regression guard forever — rather than a
+   one-off sweep repeated by hand each time this resurfaces. The same rule carries
+   the `@task` side: opaque `run_in_thread` / source-await sites with no declared
+   hold (see *Holds*).
+
+With all three, the picture is consistent at every layer: **no layer holds a
+duration opinion; the only watchdog is progress, inside the app; duration is an
+alert, not a kill.**
 
 ## Options Considered
 
@@ -334,49 +483,100 @@ is **required**, not advisory.
 The originating proposal: stop guessing durations by making the default enormous
 and removing the per-task constants.
 
-**Why rejected on its own:** with today's unconditional keepalive, nothing kills a
-wedged-but-alive activity for 24h → worker-slot exhaustion and day-long
-non-detection (see Context). It also does not even fix the observed failures: the
-apps in the dashboard *already* override the default on every task, so bumping the
-default reaches none of them. This option is the *cosmetic half* of the real fix
-and is only safe once Option 3 is in place.
+**Why rejected on its own:** with today's unconditional keepalive and no stall
+watchdog, nothing kills a wedged-but-alive activity for 24h → worker-slot
+exhaustion and day-long non-detection (see Context). It also does not even fix the
+observed failures: the apps in the dashboard *already* override the default on
+every task, so bumping the default reaches none of them. This option is the
+*cosmetic half* of the real fix and is only safe once Option 3 is in place.
 
 ### Option 2: Keep guessing, tune per-task durations harder (Rejected)
 
 Continue the status quo — better per-task `timeout_seconds` guesses.
 
 **Cons:** the number is fundamentally unguessable (scales with tenant/data); the
-dashboard shows thoughtful guesses still failing at the tail. Unbounded tuning
-that never converges.
+dashboard shows thoughtful guesses still failing at the tail; FND-165 documents
+nine teams doing this independently without convergence. Unbounded tuning that
+never converges.
 
-### Option 3: Progress-aware heartbeat + duration backstop (Chosen)
+### Option 3: In-process stall watchdog + duration backstop (Chosen)
 
-Redefine the heartbeat as a progress watchdog so `heartbeat_timeout` catches
-stalls fast; make `start_to_close` a backstop. Detailed above.
+Keep the unconditional keepalive and `heartbeat_timeout` as-is; add a progress
+tracker and an in-process watchdog on its own budget; make `start_to_close` a
+backstop. Detailed above.
 
 **Pros:**
 - Eliminates the unguessable knob; the surviving knobs don't scale with tenant size.
 - Kills wedged activities in minutes instead of a day → no slot exhaustion.
-- Streaming work and `run_in_thread` blocking work are covered automatically; the
-  residual (custom async loops, raw opaque awaits) shrinks to a small, auditable
-  set that needs one explicit observability call.
-- Reuses the existing `heartbeat_timeout` knob and single auto-loop send site;
-  small, localized change.
+- Crash/OOM reclaim stays at 60s.
+- No semantic change to an existing knob, so no "same field, new meaning"
+  migration and no coupled default bump.
+- The failure is a typed SDK error naming the last progress signal, not Temporal's
+  generic timeout string — which is also what makes the rollout measurable.
+- Streaming work and `run_in_thread` blocking work keep working with no code
+  changes; the residual shrinks to a small, conformance-auditable set.
 
 **Cons:**
-- Requires framework hooks at the right loops, and an audit of opaque single-call
-  tasks to bracket them (migration cost).
-- Turning it on globally without the hooks would false-kill pure-async tasks that
-  emit no progress → must be flag-gated during rollout.
+- Cancelling the activity task from a sibling task technically violates asyncio's
+  cancellation protocol — the same trade-off, with the same rationale, that
+  `activities.py:259-291` already documents for the worker-shutdown path.
+- A CPU-bound wedge with no `await` cannot receive the cancellation (covered by
+  `heartbeat_timeout`, which is exactly why it is kept).
+- A wedged blocking thread is still not killable — the hold lapses, the slot is
+  reclaimed, the thread is orphaned. Unchanged from today; `run_fault_isolated` is
+  the only tool that kills.
+- Requires framework hooks at the right loops and an audit of opaque calls
+  (migration cost).
 
 ### Option 4: Manual heartbeating only (Rejected)
 
 Disable auto-heartbeat; require `context.heartbeat()` everywhere. Rejected for the
 same reasons as ADR-0010 Option 3 — easy to forget, and it cannot heartbeat during
 a single long opaque call. The chosen option keeps the manual beat as one of three
-mechanisms but removes the tax on the common paths: framework hooks and the
-`run_in_thread` bracket cover the streaming and blocking majority automatically, so
-manual observability is the small, audited residual — not the whole burden.
+mechanisms but removes the tax on the common paths.
+
+### Option 5: Progress-gate the heartbeat and let `heartbeat_timeout` kill (Rejected)
+
+The most tempting variant, and the one an earlier draft of this ADR chose: send a
+beat only when the progress token advanced, redefine `heartbeat_timeout` as "max
+acceptable time making zero forward progress," and raise its default from 60s to
+300s in the same change.
+
+It does work mechanically. Temporal's Rust Core spawns local heartbeat and
+`start_to_close` timers per activity task specifically so that "activities can still
+get cleaned up even if the user isn't heartbeating"
+(`sdk-core/src/worker/activities.rs`), issuing a cancel with reason
+`ActivityCancelReason::TimedOut`. That behaviour is present across the SDK's
+declared `temporalio>=1.25.0` floor (verified in 1.23 and 1.30), so withholding
+beats really does get the activity cancelled and the slot reclaimed — this is not
+the reason it is rejected.
+
+**Why rejected:**
+
+- **It spends crash-recovery latency to buy the semantic merge.** One knob must be
+  sized for the *slower* case, so raising it to 300s (or the 1800s some apps have
+  needed) is also raising the time an OOM-killed worker's activities sit
+  unreclaimed, from 60s to the whole budget. OOM is a leading failure mode for
+  these connectors.
+- **It loads more weight onto the mechanism that is already the top failure.**
+  Heartbeat timeout is the dominant production alert (Problem 2). Progress-gating
+  adds a second, independent way to trip the same timeout, and the resulting
+  failure is indistinguishable from the existing loop-starvation one — precisely
+  when CNCT-10 is trying to split timeout subtypes apart.
+- **The kill produces a bare `CancelledError`.** `activities.py:259` only
+  translates cancellation for worker shutdown, so a stall would surface with no
+  explanation, no last-progress context, and no way to measure the rollout.
+- **The migration is riskier for no gain.** Redefining a live knob's meaning forces
+  a coupled default bump, and apps that never touched `heartbeat_timeout` are the
+  *most* exposed rather than the least. An in-process watchdog on its own new knob
+  needs neither.
+- **It silently changes what existing constraints mean.** The toolkit caps
+  `heartbeatTimeoutSeconds` at 3600 and asserts `heartbeat < startToClose`
+  (`App.pkl:742-748`); both were written against the current meaning.
+
+Under Option 3, Core's local timers remain a useful backstop-of-the-backstop for
+the case the in-process watchdog cannot cover (a starved loop), which is exactly
+the division of labour we want.
 
 ## Rationale
 
@@ -386,139 +586,147 @@ manual observability is the small, audited residual — not the whole burden.
 *"How long is it acceptable to make zero forward progress?"* is roughly
 workload-independent — a few minutes for almost any connector. One sane global
 number can express the second; no global number can express the first. That
-asymmetry is the entire reason a large `start_to_close` default becomes safe once
-the heartbeat is progress-aware.
+asymmetry is the entire reason a large `start_to_close` default becomes safe once a
+stall watchdog exists.
 
 ### Failure detection is preserved or improved for every mode
 
 | Scenario | Before | After |
 | --- | --- | --- |
-| Event loop fully blocked (no `run_in_thread`) | auto-loop starved → killed at `heartbeat_timeout` | unchanged — still correct |
-| Streaming work, healthy | beats unconditionally | beats on real throughput via hooks |
-| Wedged-but-looping async (the gap today) | only `start_to_close` (→ 24h under the naive proposal) | **killed at `heartbeat_timeout` after last progress** |
-| Legit long opaque call | keepalive keeps it alive; bounded by `start_to_close` | bracket vouches for it until its declared timeout; resource timeout is the watchdog |
-| **Wedged blocking call in `run_in_thread`** | keepalive beats forever → only `start_to_close` (24h) | **bracket stops at the call's timeout → killed at `blocking_timeout + heartbeat_timeout`** (thread orphaned; slot reclaimed) |
-| `run_best_effort` child-process work (ADR-0017) | parent awaits; keepalive beats | parent awaits via `run_in_thread`/await → bracket keeps beating |
+| Worker OOM-killed / node lost / partition | killed at `heartbeat_timeout` (60s) | **unchanged (60s)** — keepalive stays unconditional |
+| Graceful pod eviction (SIGTERM) | `WorkerEvicted` → re-dispatched | unchanged |
+| Event loop fully blocked (no `run_in_thread`) | auto-loop starved → killed at `heartbeat_timeout` | unchanged — still correct, still the only detector for this |
+| Streaming work, healthy | beats unconditionally | beats unconditionally; hooks mark progress |
+| Wedged-but-looping async (the gap today) | only `start_to_close` (→ 24h under Option 1) | **`TaskStalledError` at `max_no_progress_seconds`** |
+| Legit long opaque call, hold declared | keepalive keeps it alive; bounded by `start_to_close` | hold vouches to the declared allowance; then stall fires |
+| Legit long opaque call, no hold declared | bounded by `start_to_close` | unbounded hold → 24h backstop; flagged by conformance |
+| Wedged blocking call in `run_in_thread`, hold declared | keepalive beats forever → only `start_to_close` | killed at `timeout + budget`; thread orphaned, slot reclaimed |
+| `run_best_effort` child-process work (ADR-0017) | parent awaits; keepalive beats | parent's await is inside a hold |
 
 ### What authors tune afterward
 
 | Knob | Before | After |
 | --- | --- | --- |
-| `start_to_close` | the number everyone guesses wrong | 24h backstop, never tuned |
-| `heartbeat_timeout` | "how often do I beat" (coupled to keepalive) | **"max no-progress window"** — default 300s, roughly app-independent |
-| opaque-call bound | none / `start_to_close` | resource-level timeout (DB `statement_timeout`, `httpx` timeout), reused as the bracket bound |
+| `start_to_close` | the number everyone guesses wrong | 24h backstop, never tuned (with `schedule_to_close` bounding the retry product) |
+| `heartbeat_timeout` | "how often do I beat" | **unchanged** — 60s, "nothing is beating" |
+| `max_no_progress_seconds` | — | **new**: "max no-progress window", roughly app-independent |
+| opaque-operation allowance | none / `start_to_close` | declared once, at the call site, in `holding_progress(timeout=…)` |
+| AE node duration | app-set, often *below* the toolkit default | none (see *The Automation Engine layer*) |
 
 ## Migration & backward compatibility — "what if I do nothing?"
 
 The first question every consumer asks: *if I don't touch my code, what changes?*
-Precisely because two knobs are in play, the answer must separate them — one is
-safe to ship on upgrade, the other is not.
 
-**The progress-gating flag — safe, changes nothing on upgrade.** Progress-gating is
-**flag-gated, default off** (see *Rollout*), and the framework `mark_progress()`
-hooks are **inert while the flag is off** — they bump a counter nobody reads. So
-merely bumping the SDK version produces no new "no forward progress" kill.
+**On upgrade: nothing.** The watchdog is flag-gated, default off (see *Rollout*);
+`mark_progress()` hooks are inert while the flag is off; `heartbeat_timeout` keeps
+its meaning and its 60s default; `start_to_close` keeps its 600s default. There is
+no coupled default bump, because no existing knob changes meaning. This is the main
+practical advantage over Option 5.
 
-**The `start_to_close` default (600s → 24h) — this one DOES change behavior, and
-must NOT ship at plain upgrade.** If the 24h default landed as part of the base
-upgrade, here is what would happen to an app that does nothing:
-
-- Apps that set `timeout_seconds` explicitly per task (including every app in the
-  failure dashboard) are unaffected — the default never reaches them. Their
-  StartToClose kills persist until they lower/remove those values and/or opt in.
-- Apps **relying on the 600s default** would get a 24h ceiling *while still running
-  the old unconditional keepalive* (because progress-gating is off). That is the
-  exact unsafe pairing from *Context*: `heartbeat_timeout` cannot catch a wedge, so
-  a **wedged-but-alive activity would squat its worker slot for up to 24h**, doing
-  no real work — starving the ~100-slot pool and badly delaying legitimate work.
-
-The 24h backstop is only safe **once the progress-aware watchdog is active for that
-app.** Therefore the default bump is **coupled to the opt-in flip** (Rollout step 4
-is per-app-gated, not a global default change at upgrade): you never get the 24h
-ceiling without the minutes-scale watchdog that makes it safe. Shipping the ceiling
-fleet-wide for fast StartToClose relief is tempting, but it buys relief for
-default-relying apps at the cost of a fleet-wide 24h-wedge exposure window — so it
-is explicitly rejected as the default path. **Flipping the flag (which brings both
-halves together) is the migration action.**
-
-**On opt-in, whether unchanged code survives depends on its shape.** This is the
-sharp half — for the last two rows, do-nothing code *will* start hitting
-no-progress kills, and that is the design working as intended (those paths emit
-nothing the SDK can see, i.e. a healthy-but-quiet task it cannot distinguish from a
-wedged one):
+**On opt-in, whether unchanged code survives depends on its shape.** For the last
+two rows, do-nothing code *will* start hitting stall kills, and that is the design
+working as intended — those paths emit nothing the SDK can see, i.e. a
+healthy-but-quiet task it cannot distinguish from a wedged one:
 
 | Existing code shape | Outcome on opt-in | Author action |
 | --- | --- | --- |
-| Streaming through SDK batch writers / stats / `ObjectStore` transfer | Covered — hooks tick | none |
-| Already calls `context.heartbeat()` | Covered — bumps progress | none |
-| Opaque blocking call via `run_in_thread` | Covered — bracket vouches to its timeout | none (set `blocking_timeout` if not derivable) |
-| **Custom async loop doing its own I/O, never through an instrumented SDK path** | **False-killed** if any gap > `heartbeat_timeout` | add a beat/bracket |
+| Streaming through SDK batch writers / stats / `ObjectStore` transfer | Covered — hooks mark progress | none |
+| Already calls `context.heartbeat()` | Covered — marks progress | none |
+| Opaque blocking call via `run_in_thread` | Covered — unbounded auto-hold | none; declare a hold to get a real bound |
+| **Custom async loop doing its own I/O, never through an instrumented SDK path** | **False-killed** if any gap > budget | add a beat or a hold |
 | **Opaque single `await` against the source (connector's own async client)** | **False-killed** at the tail | wrap in `holding_progress()` — expected in ~every connector |
 
-Two consequences fall out of this and are load-bearing for a safe rollout:
+**The `start_to_close` 24h backstop is coupled to the same opt-in flip.** An app
+gets the 24h ceiling *and* the stall watchdog together, never one without the other:
+the ceiling without the watchdog is the unsafe pairing from *Context*. The global
+default only changes at the very end, once the flag is retired.
 
-1. **The `heartbeat_timeout` default must move to 300s in lockstep with the
-   semantic flip.** Apps that never touched it — left it at the old 60s — are the
-   *most* exposed, not the least: under the new meaning, 60s of no SDK-observable
-   signal (one coarse batch, one slow page) would trip even a fully instrumented
-   app. The bump is not optional polish; it is part of the semantic change.
-2. **Opt-in verification must exercise a large-tenant / tail profile, not a smoke
-   test.** A small tenant's fast steps hide the very gaps that only open at the
-   tail — the same tail that produced the original `StartToClose` failures. Signing
-   off on a small run and flipping the flag would just relocate the tail failure.
+**Opt-in verification must exercise a large-tenant / tail profile, not a smoke
+test.** A small tenant's fast steps hide the very gaps that only open at the tail —
+the same tail that produced the original failures. Signing off on a small run and
+flipping the flag would just relocate the tail failure, and with non-retryable
+stalls and no checkpointing, relocating it is worse than leaving it.
 
 ## Rollout
 
-Progress-gating cannot be turned on globally in one step: any existing task doing
-pure-async work that never hits a framework hook or manual beat would start being
-killed at `heartbeat_timeout`. Sequence:
+1. **Fix the loop-starvation failures first.** Heartbeat timeout is today's
+   dominant alert (Problem 2) and it is an ADR-0010 adoption gap, not a semantics
+   gap. Audit and fix the blocking-on-the-loop sites before adding a second
+   mechanism on top. This is sequencing, not scope creep: the measurement in step 2
+   is unreadable while starvation dominates the signal.
+2. **Land the measurement before the mechanism.** CNCT-10's timeout-subtype
+   classification, plus a counter for stall kills and observed no-progress gap
+   distribution. Without a baseline there is no way to tell whether the flip helped,
+   and *"verify against a tail profile"* in step 5 is not checkable.
+3. **Ship the framework `mark_progress()` hooks** (writers, emission, transfer
+   loops) so the streaming majority is covered before anyone opts in. Inert while
+   the flag is off.
+4. **Ship the conformance rule and the toolkit floor.** Both are independent of the
+   `@task` work and both deliver immediately: the floor stops the next app shipping
+   a 2h node timeout, and the rule finds the opaque-call sites step 5 has to audit.
+   Pair with the AE ask to drop its own default.
+5. **Gate behind a flag and flip per-app after verification** —
+   `progress_watchdog` on `@task` / `TaskMetadata`, defaulting **off**, plus an env
+   kill-switch. Per-app work is auditing the two at-risk shapes from *Migration* and
+   declaring holds, then verifying against a **large-tenant / tail profile**.
+6. **Couple the 24h `start_to_close` backstop (and its `schedule_to_close`
+   product) to that same per-app flip.** The global default changes only at the end,
+   once the flag is retired and the watchdog is universal; at that point the
+   per-task duration constants are retired.
 
-1. **Ship the framework `mark_progress()` hooks first** (writers, emission,
-   transfer loops) so the streaming majority is covered before anyone opts in.
-2. **Gate behind a flag** — `progress_aware_heartbeat` on `@task` /
-   `TaskMetadata`, defaulting **off**, plus an env kill-switch.
-3. **Flip per-app after verification** — with hooks in place, the migration work is
-   auditing the two at-risk shapes from *Migration* (custom async loops, opaque
-   source awaits) and adding a beat/bracket, and verifying against a
-   **large-tenant / tail profile**. The `heartbeat_timeout` default moves to 300s as
-   part of this flip so its new meaning and its value change together.
-4. **Couple the 24h `start_to_close` backstop to that same per-app flip** — an app
-   gets the 24h ceiling *and* the progress-aware watchdog together, never one
-   without the other. The **global** default only changes at the very end, once the
-   flag is retired and progress-aware is universal; raising it fleet-wide any
-   earlier would expose default-relying, non-opted apps to 24h wedges (see
-   *Migration*). At that point the per-task duration constants are retired.
-
-The AE-orchestrated DAG node timeouts (`errorHandling.startToCloseTimeoutSeconds`
-in the contract toolkit, defaulting 24h/72h) are a *separate layer* consumed by
-Automation Engine and are out of scope here; this ADR governs SDK-native `@task`
-activities. The same "backstop + progress watchdog" philosophy could later be
-applied there.
+Per the "delete v3-prep workarounds" discipline, the flag is temporary and its
+removal is part of the work, not a follow-up.
 
 ## Consequences
 
 **Positive:**
 - App authors stop guessing an unguessable duration; `start_to_close` becomes a
-  set-and-forget backstop.
+  set-and-forget backstop, at both the `@task` and AE layers.
 - Wedged-but-alive activities are detected in minutes, removing the slot-exhaustion
   risk that blocks a large `start_to_close` default.
-- Streaming connectors get correct behavior with no code changes (framework hooks).
-- Change is localized to `execution/heartbeat.py` (controller + loop +
-  `run_in_thread`), the `activities.py` wiring, and one-line `mark_progress()` calls
-  in existing SDK write/transfer loops.
+- Crash/OOM detection latency is unchanged, and no existing knob changes meaning —
+  upgrade is behaviourally identical until an app opts in.
+- Stalls surface as a typed error naming the last progress signal, which is both
+  better for the operator and what makes the rollout measurable.
+- Streaming connectors get correct behavior with no code changes.
+- Change is localized to `execution/heartbeat.py` (tracker + loop + hold plumbing),
+  the `activities.py` wiring and cancellation branch, one new error leaf, and
+  one-line `mark_progress()` calls in existing SDK write/transfer loops.
 
 **Negative:**
-- Opaque single-call tasks must be audited and either bracketed or given a
-  resource-level timeout — a one-time migration per app.
-- A new default semantics for `heartbeat_timeout` must be documented so authors
-  read it as "no-progress budget," not "beat interval."
-- During rollout, the flag adds a temporary branch that must be removed once
-  progress-aware heartbeat is the default (per the "delete v3-prep workarounds"
-  discipline).
+- Opaque single-operation calls must be audited and given a declared hold — a
+  one-time migration per app, and `holding_progress()` is expected in nearly every
+  connector rather than being a rare escape hatch.
+- A third timeout-ish knob exists (`max_no_progress_seconds`), and the docs must be
+  clear that it is *not* the beat interval and *not* a duration budget.
+- Cancelling the activity task from the watchdog carries the documented asyncio
+  protocol caveat.
+- Stall kills are non-retryable until REQ-1609 lands, so a false kill costs the
+  whole activity.
+- During rollout the flag adds a temporary branch that must be removed.
+
+## Open questions
+
+1. **The default for `max_no_progress_seconds`.** 300s was the earlier proposal;
+   the FND-165 evidence (apps needing 1800s under the *easier* unconditional
+   regime) argues for something larger, and a too-tight default is a false-kill
+   generator at the tail. Proposal: start at **900s**, and treat the observed
+   no-progress gap distribution from Rollout step 2 as the evidence that sets it.
+2. **`schedule_to_close` vs capped attempts** for bounding the retry product
+   (see *Bounding total time*).
+3. **Whether REQ-1609 (checkpointing) gates the per-app flip** or merely informs
+   the retryability default.
+4. **Sign-off on the AE ask** — dropping the workflow-node duration default is a
+   cross-team change, not an SDK one.
 
 ## Related
 
 - **ADR-0010** — Async-First Design and Blocking Code Pitfalls (blocking code owns
   its timeout; `run_in_thread` keeps the loop responsive). This ADR builds directly
-  on it: the blocking bracket reuses `run_in_thread`'s existing internal-timeout contract.
+  on it, and *Holds* explains why ADR-0010's per-operation timeout cannot be reused
+  as a wall-clock bound.
 - **ADR-0017** — Native Execution Isolation (`run_best_effort` / `run_fault_isolated`).
+- **REQ-1609** — Activity-level checkpointing. Determines whether a stall kill is
+  cheap or catastrophic.
+- **CNCT-10** — Timeout-error subtype classification. The measurement dependency.
+- **FND-165** — The production evidence for both failure modes.

--- a/docs/adr/0018-progress-aware-heartbeat.md
+++ b/docs/adr/0018-progress-aware-heartbeat.md
@@ -183,6 +183,13 @@ production — and, usefully, a task with `heartbeat_timeout_seconds=None` still
 a stall watchdog.
 
 ```python
+@dataclass(frozen=True)
+class _Hold:
+    label: str
+    started_at: float
+    deadline: float | None   # None = unbounded
+
+
 class ProgressTracker:
     """Observed forward progress for one activity attempt."""
 
@@ -193,7 +200,7 @@ class ProgressTracker:
         self._clock = clock
         self._last_label: str = ""
         self._last_at: float = clock()
-        self._holds: dict[int, float | None] = {}  # token -> deadline (None = unbounded)
+        self._holds: dict[int, _Hold] = {}
         self._next_token: int = 0
 
     def mark_progress(self, label: str = "") -> None:
@@ -202,22 +209,33 @@ class ProgressTracker:
         if label:
             self._last_label = label
 
-    def enter_hold(self, deadline: float | None) -> int:
+    def enter_hold(self, label: str, timeout: float | None) -> int:
         """Vouch for an in-flight opaque operation. Returns a token."""
         token = self._next_token
         self._next_token += 1
-        self._holds[token] = deadline
+        now = self._clock()
+        self._holds[token] = _Hold(
+            label, now, None if timeout is None else now + timeout
+        )
         return token
 
     def exit_hold(self, token: int) -> None:
         # Keyed by token, not popped off a stack: concurrent holds in one
         # activity (asyncio.gather over several run_in_thread calls) must not
         # release each other's deadlines.
-        self._holds.pop(token, None)
+        hold = self._holds.pop(token, None)
+        if hold is not None:
+            # A completed operation *is* progress. The observed duration also
+            # feeds the warn-mode report: a long *unbounded* hold is a site that
+            # wants an explicit allowance (see Warn mode).
+            _observe_hold_closed(hold, duration=self._clock() - hold.started_at)
+            self.mark_progress(hold.label)
 
     def held(self) -> bool:
         now = self._clock()
-        return any(d is None or d > now for d in self._holds.values())
+        return any(
+            h.deadline is None or h.deadline > now for h in self._holds.values()
+        )
 
     def stalled_for(self) -> float:
         """Seconds since the last observable progress, 0 while vouched-for."""
@@ -239,16 +257,56 @@ while not stop_event.is_set():
     if budget_seconds is not None and stalled >= budget_seconds:
         logger.warning(
             "Task '%s' made no observable progress for %.0fs (budget %.0fs); last "
-            "signal was '%s' — failing the activity",
+            "signal was '%s'%s",
             task_name, stalled, budget_seconds, progress.last_label or "<none>",
+            " — failing the activity" if mode is Mode.ENFORCE else " (warn mode: not failing)",
         )
-        on_stall(stalled, progress.last_label)
-        return   # cancel-and-return: the activity's finally awaits this task
+        if mode is Mode.ENFORCE:
+            on_stall(stalled, progress.last_label)
+            return   # cancel-and-return: the activity's finally awaits this task
+        progress.mark_progress()   # re-arm so warn mode reports each gap once
 ```
 
 `on_stall` is injected by `activities.py`, the same way `heartbeat_fn` already is,
 so `heartbeat.py` stays free of activity/Temporal semantics and the watchdog is
 unit-testable without a worker.
+
+### Warn mode: the watchdog is its own audit tool
+
+The obvious question from any app author is *"how do I find every place in my
+codebase that needs a hold, and what allowance do I put on each one?"* Answering
+that with "audit your code" would reintroduce this ADR's own problem one level down:
+a per-site number, guessed up front, by hand.
+
+So the flag has **three states, not two** — `off`, `warn`, `enforce`:
+
+- **`off`** — hooks are inert, nothing observes anything. Behaviour identical to today.
+- **`warn`** — the watchdog runs and reports, but never fails the activity. This is
+  the audit tool.
+- **`enforce`** — as described above.
+
+Warn mode emits the two things an author needs, and they map to the two shapes that
+need action:
+
+1. **No-progress gaps with no hold in force** — task, last progress signal, gap
+   duration. These are the sites that need a beat or a hold.
+2. **Long *unbounded* holds** — recorded by `exit_hold` above. Without this, a
+   blocking call through `run_in_thread` would be invisible to the audit precisely
+   because it is auto-vouched-for; these are the sites that want an explicit
+   allowance instead of relying on the backstop.
+
+One run against a large tenant therefore produces a ranked work-list, and the author
+wraps the sites that exceeded the budget and ignores the rest — which is most of the
+app. The whole-codebase audit collapses into reading a report.
+
+This is not extra machinery: the rollout already gates opt-in on a large-tenant
+tail-profile run, and already needs stall telemetry to tell whether the change
+helped. Warn mode makes that same run the audit, and means **an app's first
+exposure to this design is a report, not a behaviour change.**
+
+The same telemetry answers all three open sizing questions at once: where holds go,
+what each allowance should be, and what the global `max_no_progress_seconds` default
+should be (Open question 1).
 
 ### Failing the activity, and what the failure looks like
 
@@ -297,7 +355,8 @@ Detection latency is `max_no_progress_seconds` plus at most one loop tick (10s).
    legitimate long blocking call is never false-killed and behaviour on upgrade is
    unchanged. An unbounded hold means the stall watchdog is inactive for the
    duration of the call and the 24h backstop is the only bound — a real, documented
-   residual, which the conformance rule below is what shrinks.
+   residual. Warn mode surfaces each one with its observed duration, and the
+   conformance rule keeps them visible afterwards.
 3. **Manual `context.heartbeat(...)` or `holding_progress(...)` (explicit, app
    action).** The residual: a custom async loop, or an opaque single `await`
    against the connector's own source client (see the asymmetry below — this is
@@ -366,6 +425,24 @@ because there is nothing to observe from outside a blocked thread. The ADR's
 position is to say so, and to let a human state the number at the one site that
 knows it — never to let the SDK guess it.
 
+### Choosing the allowance
+
+Asking an author for a number is only defensible if the question is answerable, so
+it has to be framed precisely. The allowance is **not** a prediction of how long the
+operation takes. It is *how long you would let this one operation run before you
+would rather it failed.* That is answerable at the call site in a way that "how long
+should this whole activity take?" never was, because it is a property of one
+operation against one resource rather than of a tenant's data volume.
+
+Two things make it safe to answer:
+
+- **Warn mode gives you the evidence.** Use the observed p99 for that site plus
+  headroom, rather than a number invented at the desk.
+- **The error is asymmetric, so err generous.** Too generous only delays detection
+  toward the backstop — mildly worse observability. Too tight kills a healthy run,
+  and with stall kills non-retryable and no checkpointing (REQ-1609) that costs the
+  whole activity. Anyone unsure should round up.
+
 ### The async escape hatch — and the asymmetry that makes it common
 
 **Q: "Making people use it *always* might become a problem."** This is the most
@@ -398,9 +475,10 @@ almost every connector**, because almost every connector makes at least one such
 opaque async call against its source. It is a *standard part of writing a
 long-running async task*, not a rare escape hatch. We make that acceptable by (a)
 keeping it a one-line context manager, (b) documenting it as expected rather than
-exceptional, and (c) having the conformance rule and the opt-in audit specifically
-hunt source-side opaque async calls. A forgotten hold false-kills at the tail (see
-*Migration*), so for such calls it is **required**, not advisory.
+exceptional, and (c) never asking anyone to find these by reading code — warn mode
+names the sites and sizes their allowances, and the conformance rule keeps them
+visible afterwards. A forgotten hold false-kills at the tail (see *Migration*), so
+for such calls it is **required**, not advisory.
 
 ## Bounding total time
 
@@ -623,18 +701,23 @@ its meaning and its 60s default; `start_to_close` keeps its 600s default. There 
 no coupled default bump, because no existing knob changes meaning. This is the main
 practical advantage over Option 5.
 
-**On opt-in, whether unchanged code survives depends on its shape.** For the last
-two rows, do-nothing code *will* start hitting stall kills, and that is the design
-working as intended — those paths emit nothing the SDK can see, i.e. a
-healthy-but-quiet task it cannot distinguish from a wedged one:
+**In warn mode: still nothing changes, but you get the work-list.** Warn mode is the
+intermediate state every app passes through, and it cannot fail an activity. The two
+at-risk shapes below show up as report lines instead of kills, which is what makes
+the migration a reading exercise rather than a code audit.
 
-| Existing code shape | Outcome on opt-in | Author action |
-| --- | --- | --- |
-| Streaming through SDK batch writers / stats / `ObjectStore` transfer | Covered — hooks mark progress | none |
-| Already calls `context.heartbeat()` | Covered — marks progress | none |
-| Opaque blocking call via `run_in_thread` | Covered — unbounded auto-hold | none; declare a hold to get a real bound |
-| **Custom async loop doing its own I/O, never through an instrumented SDK path** | **False-killed** if any gap > budget | add a beat or a hold |
-| **Opaque single `await` against the source (connector's own async client)** | **False-killed** at the tail | wrap in `holding_progress()` — expected in ~every connector |
+**In enforce mode, whether unchanged code survives depends on its shape.** For the
+last two rows, do-nothing code *will* hit stall kills, and that is the design working
+as intended — those paths emit nothing the SDK can see, i.e. a healthy-but-quiet task
+it cannot distinguish from a wedged one:
+
+| Existing code shape | Warn mode | Enforce mode | Author action |
+| --- | --- | --- | --- |
+| Streaming through SDK batch writers / stats / `ObjectStore` transfer | silent | Covered — hooks mark progress | none |
+| Already calls `context.heartbeat()` | silent | Covered — marks progress | none |
+| Opaque blocking call via `run_in_thread` | reported as a long unbounded hold | Covered — unbounded auto-hold; backstop is the only bound | declare an allowance to get a real bound |
+| **Custom async loop doing its own I/O, never through an instrumented SDK path** | reported as a no-progress gap | **False-killed** if any gap > budget | add a beat or a hold |
+| **Opaque single `await` against the source (connector's own async client)** | reported as a no-progress gap | **False-killed** at the tail | wrap in `holding_progress()` — expected in ~every connector |
 
 **The `start_to_close` 24h backstop is coupled to the same opt-in flip.** An app
 gets the 24h ceiling *and* the stall watchdog together, never one without the other:
@@ -652,23 +735,28 @@ stalls and no checkpointing, relocating it is worse than leaving it.
 1. **Fix the loop-starvation failures first.** Heartbeat timeout is today's
    dominant alert (Problem 2) and it is an ADR-0010 adoption gap, not a semantics
    gap. Audit and fix the blocking-on-the-loop sites before adding a second
-   mechanism on top. This is sequencing, not scope creep: the measurement in step 2
-   is unreadable while starvation dominates the signal.
-2. **Land the measurement before the mechanism.** CNCT-10's timeout-subtype
-   classification, plus a counter for stall kills and observed no-progress gap
-   distribution. Without a baseline there is no way to tell whether the flip helped,
-   and *"verify against a tail profile"* in step 5 is not checkable.
-3. **Ship the framework `mark_progress()` hooks** (writers, emission, transfer
-   loops) so the streaming majority is covered before anyone opts in. Inert while
-   the flag is off.
+   mechanism on top. This is sequencing, not scope creep: the warn-mode signal in
+   step 3 is unreadable while starvation dominates it.
+2. **Ship the framework `mark_progress()` hooks** (writers, emission, transfer
+   loops) so the streaming majority is covered before anyone observes anything.
+   Inert while the flag is off. Land CNCT-10's timeout-subtype classification
+   alongside, so stall kills are distinguishable from starvation kills in the
+   fleet-wide numbers.
+3. **Run every app in `warn` first.** Warn mode is both the measurement and the
+   audit: it produces the per-app work-list (no-progress gaps, long unbounded holds)
+   and the fleet-wide gap distribution that sets the
+   `max_no_progress_seconds` default. Nothing can be killed in this state, so it is
+   safe to turn on broadly and early — and it means the first thing an app team sees
+   is a report about their own code, not a behaviour change.
 4. **Ship the conformance rule and the toolkit floor.** Both are independent of the
    `@task` work and both deliver immediately: the floor stops the next app shipping
-   a 2h node timeout, and the rule finds the opaque-call sites step 5 has to audit.
-   Pair with the AE ask to drop its own default.
-5. **Gate behind a flag and flip per-app after verification** —
-   `progress_watchdog` on `@task` / `TaskMetadata`, defaulting **off**, plus an env
-   kill-switch. Per-app work is auditing the two at-risk shapes from *Migration* and
-   declaring holds, then verifying against a **large-tenant / tail profile**.
+   a 2h node timeout, and the rule keeps un-held opaque sites visible after the
+   warn-mode pass has cleared the backlog. Pair with the AE ask to drop its own
+   default.
+5. **Flip per-app to `enforce` once that app's warn report is clean** — i.e. its
+   remaining gaps are all inside declared holds or under budget, verified against a
+   **large-tenant / tail profile**, not a smoke test. The flag (`progress_watchdog`
+   on `@task` / `TaskMetadata`) carries an env kill-switch back to `warn`.
 6. **Couple the 24h `start_to_close` backstop (and its `schedule_to_close`
    product) to that same per-app flip.** The global default changes only at the end,
    once the flag is retired and the watchdog is universal; at that point the
@@ -688,6 +776,9 @@ removal is part of the work, not a follow-up.
   upgrade is behaviourally identical until an app opts in.
 - Stalls surface as a typed error naming the last progress signal, which is both
   better for the operator and what makes the rollout measurable.
+- The per-app migration is mechanical rather than manual: warn mode produces the
+  work-list and the evidence for each allowance, so nobody has to read a whole
+  codebase deciding where a hold belongs or invent a number for it.
 - Streaming connectors get correct behavior with no code changes.
 - Change is localized to `execution/heartbeat.py` (tracker + loop + hold plumbing),
   the `activities.py` wiring and cancellation branch, one new error leaf, and
@@ -710,8 +801,9 @@ removal is part of the work, not a follow-up.
 1. **The default for `max_no_progress_seconds`.** 300s was the earlier proposal;
    the FND-165 evidence (apps needing 1800s under the *easier* unconditional
    regime) argues for something larger, and a too-tight default is a false-kill
-   generator at the tail. Proposal: start at **900s**, and treat the observed
-   no-progress gap distribution from Rollout step 2 as the evidence that sets it.
+   generator at the tail. Proposal: start at **900s**, and let the gap distribution
+   from the warn-mode pass (Rollout step 3) set the final number — this question is
+   answered by data, not by argument, and warn mode is how we get it.
 2. **`schedule_to_close` vs capped attempts** for bounding the retry product
    (see *Bounding total time*).
 3. **Whether REQ-1609 (checkpointing) gates the per-app flip** or merely informs

--- a/docs/adr/0018-progress-aware-heartbeat.md
+++ b/docs/adr/0018-progress-aware-heartbeat.md
@@ -369,10 +369,31 @@ Three details that matter:
   `non_retryable=not e.effective_retryable`. Factor it into a helper both branches
   call.
 
-**`TaskStalledError` is non-retryable by default.** A wedge usually re-wedges, and
-without activity-level checkpointing (REQ-1609) a retry restarts from zero — so an
-automatic retry mostly buys another full stall. This is a deliberate decision, cheap
-to revisit once REQ-1609 lands. See *Bounding total time*.
+**`TaskStalledError` is retryable.** The instinct is to make it non-retryable — a
+wedge re-wedges, and without checkpointing (REQ-1609) a retry restarts from zero. That
+instinct is wrong about what a stall usually *is*. Sort the causes:
+
+| Cause of the stall | Retry outcome |
+| --- | --- |
+| Source-side hang: dropped connection, source overloaded, socket read with no timeout, exhausted pool | **Usually succeeds.** The likely majority: apps whose error handling never surfaced a transient source problem, so the symptom is silence rather than an exception. |
+| Genuine code wedge: infinite retry loop, app-level deadlock | Re-stalls, costing up to 3 × `max_no_progress_seconds` (minutes) — not 3 × the backstop |
+| Timing-dependent deadlock on a shared resource | May well succeed on different timing |
+| Missing instrumentation (healthy, quiet, no hold declared) | **False kill, amplified** — retries waste the same partial work again |
+
+The dominant category is transient and self-heals on retry, and the failure the fleet
+actually sees today is exactly that shape: a source stops responding and the app has no
+way to say so. Refusing to retry would convert those into failed runs needing a manual
+re-run — which restarts from zero anyway, just slower and with a human in the loop. So
+non-retryable buys nothing there and costs a lot.
+
+That leaves the last row as the real risk, and it is bounded by process rather than by
+policy: eliminating missing instrumentation is precisely what the warn-mode pass does
+before an app enforces.
+
+A refinement worth considering later, not for v1: a stall *inside a lapsed hold* means
+the source exceeded an allowance a human declared for it — almost definitionally the
+transient case — whereas a stall with no hold at all is likelier to be missing
+instrumentation. The two could carry different retry policies.
 
 Detection latency is `max_no_progress_seconds` plus at most one loop tick (10s).
 
@@ -473,9 +494,9 @@ Two things make it safe to answer:
 - **Warn mode gives you the evidence.** Use the observed p99 for that site plus
   headroom, rather than a number invented at the desk.
 - **The error is asymmetric, so err generous.** Too generous only delays detection
-  toward the backstop — mildly worse observability. Too tight kills a healthy run,
-  and with stall kills non-retryable and no checkpointing (REQ-1609) that costs the
-  whole activity. Anyone unsure should round up.
+  toward the backstop — mildly worse observability. Too tight kills a healthy run, and
+  because stall kills retry, a too-tight allowance burns the same wasted work up to
+  three times before failing. Anyone unsure should round up.
 
 ### The async escape hatch — and the asymmetry that makes it common
 
@@ -535,10 +556,10 @@ looks alarming in isolation, and is defensible for three reasons:
    visible within `max_no_progress_seconds` and alerts on it. The 72h is the outer
    bound on *automatic* termination, not on *detection* — and it replaces a world where
    a wedge is never diagnosed at all, only accidentally killed by a small ceiling.
-2. **The product collapses once an app enforces.** `TaskStalledError` is
-   non-retryable, so an enforcing app's wedge terminates on the first attempt at
-   `max_no_progress_seconds`, not at 3 × 24h. The 72h is the warn-mode worst case,
-   shrinking as apps enforce.
+2. **The product collapses once an app enforces.** An enforcing app's wedge is caught
+   at `max_no_progress_seconds` per attempt, so the worst case becomes 3 × minutes
+   rather than 3 × 24h — roughly 45 minutes at a 900s budget. The 72h is the warn-mode
+   worst case, and it shrinks by three orders of magnitude as apps enforce.
 3. **Bounding it now would be another guessed number.** Picking a `schedule_to_close`
    budget today means guessing a total duration — the exact move this ADR exists to
    remove. The warn-mode data gives a real distribution to size it from, if it turns
@@ -549,13 +570,18 @@ If the data shows the product matters, the fix is already scoped: set
 following the budget-shaped pair the SDK already uses in `gate_timeouts`
 (`app/base.py:1902`), or cap attempts at 1 for backstop-class tasks.
 
-**Retries without checkpointing are expensive.** REQ-1609 (activity-level
-checkpointing) is not a nice-to-have adjacent to this work: without it, a stall kill
-at hour 5 of a 6-hour extraction restarts from zero. The watchdog makes failure
-*faster to detect* but not *cheaper to recover*, and a false kill at the tail is
-catastrophic rather than annoying. That is the main reason `TaskStalledError`
-defaults to non-retryable, and the main reason the tail-profile verification in
-*Rollout* is a gate rather than a suggestion.
+**Retries without checkpointing are expensive, but not uniquely so.** Without
+REQ-1609 (activity-level checkpointing), a stall kill at hour 5 of a 6-hour extraction
+restarts from zero. The watchdog makes failure *faster to detect* without making it
+*cheaper to recover*. This is the main reason the tail-profile verification in *Rollout*
+is a gate rather than a suggestion.
+
+It is worth being precise about what checkpointing does and does not gate, though.
+Restarting from zero is what already happens on every `StartToClose` retry today, and
+it is also what happens when a human re-runs a failed workflow — so it is not a cost
+this ADR introduces, and it is not an argument for refusing to retry stalls (see
+*Failing the activity*). REQ-1609 makes both the existing and the new paths cheaper.
+That downgrades it from a correctness gate to an efficiency one.
 
 **A run with no duration bound anywhere still needs a duration signal.** Once the
 AE layer drops its timeouts (below) and `start_to_close` is a 24h backstop, a run
@@ -804,10 +830,10 @@ still come at the very end.
 
 **Flipping to `enforce` must be verified against a large-tenant / tail profile, not a
 smoke test.** A small tenant's fast steps hide the very gaps that only open at the
-tail — the same tail that produced the original failures. Flipping on the strength of
-a small run would just relocate the tail failure, and with non-retryable stalls and no
-checkpointing, relocating it is worse than leaving it. Warn mode is what makes this
-checkable rather than aspirational.
+tail — the same tail that produced the original failures. Flipping on the strength of a
+small run would just relocate the tail failure, and because stall kills retry, an
+under-instrumented app would burn the same wasted work up to three times before failing.
+Warn mode is what makes this checkable rather than aspirational.
 
 ## Rollout
 
@@ -888,8 +914,9 @@ removal is part of the work, not a follow-up.
   clear that it is *not* the beat interval and *not* a duration budget.
 - Cancelling the activity task from the watchdog carries the documented asyncio
   protocol caveat.
-- Stall kills are non-retryable until REQ-1609 lands, so a false kill costs the
-  whole activity.
+- Stall kills retry, so a false kill in an under-instrumented app repeats the same
+  wasted work up to three times before failing. Warn mode exists to clear that
+  category before an app enforces.
 - During rollout the flag adds a temporary branch that must be removed.
 
 ## What this needs agreement on
@@ -908,9 +935,10 @@ else in this ADR follows from them.
    conformance rule exist to stop the bound creeping back in per-app (see *The
    Automation Engine layer*). This one needs a cross-team owner to land.
 
-One question arrives later, before any app moves to `enforce`: whether REQ-1609
-(checkpointing) gates it, or merely informs the retryability default. Warn mode never
-kills, so it does not block the first release.
+REQ-1609 (checkpointing) is no longer framed as a gate on either of these. Retrying
+from zero is what already happens on every `StartToClose` retry and on every manual
+re-run, so checkpointing makes the existing and the new paths cheaper without deciding
+whether the new path is correct (see *Bounding total time*).
 
 Parameters set by measurement, recorded here so nobody tries to settle them by
 argument:
@@ -931,7 +959,8 @@ argument:
   on it, and *Holds* explains why ADR-0010's per-operation timeout cannot be reused
   as a wall-clock bound.
 - **ADR-0017** — Native Execution Isolation (`run_best_effort` / `run_fault_isolated`).
-- **REQ-1609** — Activity-level checkpointing. Determines whether a stall kill is
-  cheap or catastrophic.
+- **REQ-1609** — Activity-level checkpointing. Governs how expensive a retry is —
+  including, but not only, a stall kill's retry. An efficiency dependency, not a
+  correctness one.
 - **CNCT-10** — Timeout-error subtype classification. The measurement dependency.
 - **FND-165** — The production evidence for both failure modes.

--- a/docs/adr/0018-progress-aware-heartbeat.md
+++ b/docs/adr/0018-progress-aware-heartbeat.md
@@ -337,10 +337,10 @@ Two constraints come with defaulting it on:
 activity fails differently, no knob changes meaning, and the added cost is telemetry.
 `off` exists for anyone who needs even that gone.
 
-The same telemetry answers all three open sizing questions at once: where holds go,
-what each allowance should be, and what the global `max_no_progress_seconds` default
-should be (Open question 1) — and, per the RFC discussion, whether long stalls occur
-in practice at all, which is currently argued from recollection on both sides.
+The same telemetry settles every sizing parameter at once — where holds go, what each
+allowance should be, what `max_no_progress_seconds` should be, and whether long stalls
+occur in practice at all (currently argued from recollection on both sides). None of
+those are design questions to be decided in review; see *Open questions*.
 
 ### Failing the activity, and what the failure looks like
 
@@ -755,11 +755,37 @@ it cannot distinguish from a wedged one:
 | **Custom async loop doing its own I/O, never through an instrumented SDK path** | reported as a no-progress gap | **False-killed** if any gap > budget | add a beat or a hold |
 | **Opaque single `await` against the source (connector's own async client)** | reported as a no-progress gap | **False-killed** at the tail | wrap in `holding_progress()` — expected in ~every connector |
 
-**The `start_to_close` 24h backstop is coupled to `enforce`, not to warn.** An app
-gets the 24h ceiling *and* an enforcing stall watchdog together, never one without the
-other: the ceiling without a watchdog that can actually kill is the unsafe pairing
-from *Context*. Warn mode deliberately buys no ceiling relief — it only buys evidence.
-The global default changes at the very end, once the flag is retired.
+**The `start_to_close` backstop lands *with* warn mode, not after it.** This is a
+deliberate change of position and the one place this ADR accepts a real regression, so
+it deserves the argument in full.
+
+Coupling the backstop to `enforce` would mean warn mode delivers no relief at all:
+apps would still be killed at their guessed 2h/6h ceilings while the fleet gathers
+data, so every team keeps tuning numbers — precisely the loop FND-165 documents. The
+"no upgrade task" property would buy nobody anything.
+
+What coupling it to warn costs: today's small `start_to_close` is *accidentally* the
+only thing that kills a wedged activity. Raising it to 24h removes that accident, and
+warn mode cannot kill. So a wedge holds a worker slot until the backstop, and the
+containment is an alert on the stall metric plus a human, rather than an automatic
+kill. That is worse than today for a wedge, and better than today for every
+legitimate long run.
+
+Why it is an acceptable trade, and bounded:
+
+- The exposure scales with the **wedge rate**, which is the exact unknown warn mode
+  exists to measure. If wedges turn out to be common, the data says so within days and
+  enforcement follows; if they are rare — the position argued in the RFC thread — the
+  exposure was never real.
+- Detection does not regress even though containment does: a wedge is *visible* within
+  `max_no_progress_seconds` via the stall metric, where today nothing detects it at all
+  (it dies at `start_to_close` by luck, not by diagnosis).
+- Slot exhaustion needs roughly a hundred concurrent wedges on one worker. That is a
+  function of the same rate, and the metric is the early warning.
+
+The alert on the stall metric is therefore **not optional** while the fleet is in warn
+— it is what stands in for the kill. The global default change and retiring the flag
+still come at the very end.
 
 **Flipping to `enforce` must be verified against a large-tenant / tail profile, not a
 smoke test.** A small tenant's fast steps hide the very gaps that only open at the
@@ -779,11 +805,15 @@ checkable rather than aspirational.
    loops) so the streaming majority is covered before anything observes anything.
    Land CNCT-10's timeout-subtype classification alongside, so stall kills are
    distinguishable from starvation kills in the fleet-wide numbers.
-3. **Ship `warn` as the default — no per-app step.** Warn mode cannot fail an
-   activity, so it needs no opt-in: on upgrade every app starts producing its own
-   work-list (no-progress gaps, long unbounded holds) and contributing to the
-   fleet-wide gap distribution that sets the `max_no_progress_seconds` default.
-   This is deliberately *not* a step that requires ~20 teams to each do something.
+3. **Ship `warn` as the default, together with the `start_to_close` backstop and a
+   bounded retry product — no per-app step.** Warn mode cannot fail an activity, so it
+   needs no opt-in: on upgrade every app starts producing its own work-list
+   (no-progress gaps, long unbounded holds) and contributing to the fleet-wide gap
+   distribution that sets the `max_no_progress_seconds` value. The backstop ships here
+   because this is where the relief is (see *Migration*), which makes two things
+   prerequisites of this step rather than later work: **the retry product must be
+   bounded** (24h × 3 attempts is otherwise 72h — Open question 1), and **the stall
+   metric must be alertable**, since it stands in for the kill while nothing enforces.
    `off` ships alongside as an env kill-switch.
 4. **Ship the conformance rule and the toolkit floor.** Both are independent of the
    `@task` work and both deliver immediately: the floor stops the next app shipping
@@ -799,10 +829,9 @@ checkable rather than aspirational.
    gaps inside declared holds or under budget, verified against a **large-tenant /
    tail profile**, not a smoke test. The flag is `progress_watchdog` on `@task` /
    `TaskMetadata`.
-7. **Couple the 24h `start_to_close` backstop (and its `schedule_to_close`
-   product) to that same per-app flip.** The global default changes only at the end,
-   once the flag is retired and enforcement is universal; at that point the
-   per-task duration constants are retired.
+7. **Retire the flag and the per-task duration constants** once enforcement is
+   universal (or once the warn data justifies enforcing fleet-wide with a generous
+   budget, which may make step 6 a formality rather than twenty separate flips).
 
 Per the "delete v3-prep workarounds" discipline, the flag is temporary and its
 removal is part of the work, not a follow-up.
@@ -812,10 +841,12 @@ removal is part of the work, not a follow-up.
 **Positive:**
 - App authors stop guessing an unguessable duration; `start_to_close` becomes a
   set-and-forget backstop, at both the `@task` and AE layers.
-- Wedged-but-alive activities are detected in minutes, removing the slot-exhaustion
-  risk that blocks a large `start_to_close` default.
-- Crash/OOM detection latency is unchanged, and no existing knob changes meaning —
-  upgrade is behaviourally identical until an app opts in.
+- Wedged-but-alive activities are *detected* in minutes fleet-wide from the first
+  release, and *killed* in minutes wherever an app enforces.
+- Crash/OOM detection latency is unchanged, and no existing knob changes meaning.
+- Relief arrives on upgrade rather than after a per-app migration: the backstop lands
+  with warn mode, so legitimately long runs stop dying at a guessed ceiling
+  immediately.
 - Stalls surface as a typed error naming the last progress signal, which is both
   better for the operator and what makes the rollout measurable.
 - The per-app migration is mechanical rather than manual, and it is not on the
@@ -830,9 +861,15 @@ removal is part of the work, not a follow-up.
   one-line `mark_progress()` calls in existing SDK write/transfer loops.
 
 **Negative:**
-- Opaque single-operation calls must be audited and given a declared hold — a
-  one-time migration per app, and `holding_progress()` is expected in nearly every
-  connector rather than being a rare escape hatch.
+- **Wedge containment regresses while the fleet is in warn.** Today's small
+  `start_to_close` is accidentally the only thing that kills a wedged activity;
+  raising it to a backstop replaces that automatic kill with an alert and a human
+  until an app enforces. Accepted deliberately, bounded by measurement — see
+  *Migration*. It makes the stall-metric alert mandatory, not optional.
+- Opaque single-operation calls need a declared hold to get the stronger guarantee,
+  and `holding_progress()` is expected in nearly every connector rather than being a
+  rare escape hatch — though this is now optional work an app schedules for itself,
+  not a migration gate.
 - A third timeout-ish knob exists (`max_no_progress_seconds`), and the docs must be
   clear that it is *not* the beat interval and *not* a duration budget.
 - Cancelling the activity task from the watchdog carries the documented asyncio
@@ -843,18 +880,31 @@ removal is part of the work, not a follow-up.
 
 ## Open questions
 
-1. **The default for `max_no_progress_seconds`.** 300s was the earlier proposal;
-   the FND-165 evidence (apps needing 1800s under the *easier* unconditional
-   regime) argues for something larger, and a too-tight default is a false-kill
-   generator at the tail. Proposal: start at **900s**, and let the gap distribution
-   from the warn-mode pass (Rollout step 3) set the final number — this question is
-   answered by data, not by argument, and warn mode is how we get it.
-2. **`schedule_to_close` vs capped attempts** for bounding the retry product
-   (see *Bounding total time*).
-3. **Whether REQ-1609 (checkpointing) gates the per-app flip** or merely informs
-   the retryability default.
-4. **Sign-off on the AE ask** — dropping the workflow-node duration default is a
-   cross-team change, not an SDK one.
+Blocking the first release (they ship with the backstop, per *Rollout* step 3):
+
+1. **`schedule_to_close` vs capped attempts** for bounding the retry product. 24h × 3
+   attempts is otherwise 72h where today it is 30 minutes (see *Bounding total time*).
+   This was deferrable while the backstop was coupled to `enforce`; it is not now.
+2. **Sign-off on the AE ask** — dropping the workflow-node duration default is a
+   cross-team change, not an SDK one, and it needs an owner.
+
+Before any app enforces:
+
+3. **Whether REQ-1609 (checkpointing) gates enforcement** or merely informs the
+   retryability default. Warn mode never kills, so this does not block the first
+   release.
+
+Not open questions — parameters set by measurement, recorded here so nobody tries to
+settle them by argument:
+
+- **`max_no_progress_seconds`.** Starts at **900s** (300s was an earlier proposal;
+  FND-165's evidence of apps needing 1800s under the *easier* unconditional regime
+  argues for something larger, and a too-tight value is a false-kill generator at the
+  tail). The warn-mode gap distribution sets the final value before anything enforces.
+- **Per-site hold allowances.** Set from each site's observed p99 — see *Choosing the
+  allowance*.
+- **Whether long stalls occur at all**, and therefore whether fleet-wide enforcement
+  is warranted or a generous budget suffices.
 
 ## Related
 

--- a/docs/adr/0018-progress-aware-heartbeat.md
+++ b/docs/adr/0018-progress-aware-heartbeat.md
@@ -340,7 +340,7 @@ activity fails differently, no knob changes meaning, and the added cost is telem
 The same telemetry settles every sizing parameter at once — where holds go, what each
 allowance should be, what `max_no_progress_seconds` should be, and whether long stalls
 occur in practice at all (currently argued from recollection on both sides). None of
-those are design questions to be decided in review; see *Open questions*.
+those are design questions to be decided in review; see *What this needs agreement on*.
 
 ### Failing the activity, and what the failure looks like
 
@@ -520,19 +520,34 @@ Removing the duration knob removes the only wall-clock bound the system has, and
 the ADR must say what replaces it — "nothing" is not an answer that survives an
 incident.
 
-**Retries multiply the backstop.** `get_activity_options`
-(`execution/_temporal/activities.py:418-420`) returns only `start_to_close_timeout`
-and a retry policy — **no `schedule_to_close`**. With the default
-`retry_max_attempts=3`, a 24h backstop is a **72h** worst case per activity. Today
-that product is 30 minutes. Options, in preference order:
+**Retries multiply the backstop, and we are accepting that product as-is to start.**
+`get_activity_options` (`execution/_temporal/activities.py:418-420`) returns only
+`start_to_close_timeout` and a retry policy — **no `schedule_to_close`**. With the
+default `retry_max_attempts=3`, a 24h backstop is a **72h worst case per activity,
+where today that product is 30 minutes.** A `StartToClose` timeout is retryable in
+Temporal, so a wedge that survives to the ceiling three times really does consume the
+full 72h.
 
-1. **Set `schedule_to_close` as the real backstop** and let `start_to_close` bound
-   one attempt. The SDK already has precedent for a budget-shaped pair in
-   `gate_timeouts` (`app/base.py:1902`), which derives both from one budget and a
-   max-attempts count.
-2. Keep `start_to_close` only, and cap attempts at 1 for backstop-class tasks.
+**Decision: start there deliberately, rather than bounding it up front.** The number
+looks alarming in isolation, and is defensible for three reasons:
 
-Either way the ADR's claim must be about the *product*, not one attempt.
+1. **Nobody is blind for 72h.** From the first release the stall metric makes a wedge
+   visible within `max_no_progress_seconds` and alerts on it. The 72h is the outer
+   bound on *automatic* termination, not on *detection* — and it replaces a world where
+   a wedge is never diagnosed at all, only accidentally killed by a small ceiling.
+2. **The product collapses once an app enforces.** `TaskStalledError` is
+   non-retryable, so an enforcing app's wedge terminates on the first attempt at
+   `max_no_progress_seconds`, not at 3 × 24h. The 72h is the warn-mode worst case,
+   shrinking as apps enforce.
+3. **Bounding it now would be another guessed number.** Picking a `schedule_to_close`
+   budget today means guessing a total duration — the exact move this ADR exists to
+   remove. The warn-mode data gives a real distribution to size it from, if it turns
+   out to need sizing at all.
+
+If the data shows the product matters, the fix is already scoped: set
+`schedule_to_close` as the real backstop and let `start_to_close` bound one attempt,
+following the budget-shaped pair the SDK already uses in `gate_timeouts`
+(`app/base.py:1902`), or cap attempts at 1 for backstop-class tasks.
 
 **Retries without checkpointing are expensive.** REQ-1609 (activity-level
 checkpointing) is not a nice-to-have adjacent to this work: without it, a stall kill
@@ -805,16 +820,15 @@ checkable rather than aspirational.
    loops) so the streaming majority is covered before anything observes anything.
    Land CNCT-10's timeout-subtype classification alongside, so stall kills are
    distinguishable from starvation kills in the fleet-wide numbers.
-3. **Ship `warn` as the default, together with the `start_to_close` backstop and a
-   bounded retry product — no per-app step.** Warn mode cannot fail an activity, so it
-   needs no opt-in: on upgrade every app starts producing its own work-list
-   (no-progress gaps, long unbounded holds) and contributing to the fleet-wide gap
-   distribution that sets the `max_no_progress_seconds` value. The backstop ships here
-   because this is where the relief is (see *Migration*), which makes two things
-   prerequisites of this step rather than later work: **the retry product must be
-   bounded** (24h × 3 attempts is otherwise 72h — Open question 1), and **the stall
-   metric must be alertable**, since it stands in for the kill while nothing enforces.
-   `off` ships alongside as an env kill-switch.
+3. **Ship `warn` as the default, together with the 24h `start_to_close` backstop — no
+   per-app step.** Warn mode cannot fail an activity, so it needs no opt-in: on upgrade
+   every app starts producing its own work-list (no-progress gaps, long unbounded
+   holds) and contributing to the fleet-wide gap distribution that sets the
+   `max_no_progress_seconds` value. The backstop ships here because this is where the
+   relief is (see *Migration*), at the accepted 72h retry product (see *Bounding total
+   time*). One hard prerequisite of this step: **the stall metric must be alertable**,
+   since it stands in for the kill while nothing enforces. `off` ships alongside as an
+   env kill-switch.
 4. **Ship the conformance rule and the toolkit floor.** Both are independent of the
    `@task` work and both deliver immediately: the floor stops the next app shipping
    a 2h node timeout, and the rule keeps un-held opaque sites visible once teams
@@ -878,24 +892,28 @@ removal is part of the work, not a follow-up.
   whole activity.
 - During rollout the flag adds a temporary branch that must be removed.
 
-## Open questions
+## What this needs agreement on
 
-Blocking the first release (they ship with the backstop, per *Rollout* step 3):
+Not a list of decisions to make — two stated positions to accept or reject. Everything
+else in this ADR follows from them.
 
-1. **`schedule_to_close` vs capped attempts** for bounding the retry product. 24h × 3
-   attempts is otherwise 72h where today it is 30 minutes (see *Bounding total time*).
-   This was deferrable while the backstop was coupled to `enforce`; it is not now.
-2. **Sign-off on the AE ask** — dropping the workflow-node duration default is a
-   cross-team change, not an SDK one, and it needs an owner.
+1. **We start with a 24h attempt and the existing 3-attempt retry policy — a 72h
+   worst case per activity, where today it is 30 minutes.** Detection stays in minutes
+   via the stall metric, the product collapses to a single attempt wherever an app
+   enforces, and bounding it up front would mean guessing a total duration (see
+   *Bounding total time*).
+2. **We remove connector time-bounds from AE entirely** — no execution or run timeout
+   on connector DAG nodes, which are child-workflow invocations that Temporal requires
+   no timeout for. Duration becomes an alert, not a kill. The toolkit floor and the
+   conformance rule exist to stop the bound creeping back in per-app (see *The
+   Automation Engine layer*). This one needs a cross-team owner to land.
 
-Before any app enforces:
+One question arrives later, before any app moves to `enforce`: whether REQ-1609
+(checkpointing) gates it, or merely informs the retryability default. Warn mode never
+kills, so it does not block the first release.
 
-3. **Whether REQ-1609 (checkpointing) gates enforcement** or merely informs the
-   retryability default. Warn mode never kills, so this does not block the first
-   release.
-
-Not open questions — parameters set by measurement, recorded here so nobody tries to
-settle them by argument:
+Parameters set by measurement, recorded here so nobody tries to settle them by
+argument:
 
 - **`max_no_progress_seconds`.** Starts at **900s** (300s was an earlier proposal;
   FND-165's evidence of apps needing 1800s under the *easier* unconditional regime

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -21,3 +21,4 @@ ADRs capture the architectural decisions behind the Application SDK — what was
 | [ADR-0015](0015-directory-listing-race-fix.md) | Directory Listing Race Fix (safe_list_directory primitive) |
 | [ADR-0016](0016-multi-pool-worker-routing.md) | Multi-Pool Worker Routing (N pools per app, @task(pool=...) static affinity) |
 | [ADR-0017](0017-native-execution-isolation.md) | Native Execution Isolation (best-effort work in an isolated process; run_fault_isolated / run_best_effort, conformance rule P036) |
+| [ADR-0018](0018-progress-aware-heartbeat.md) | Progress-Aware Heartbeat and Duration-Backstop Timeouts (heartbeat = no-progress watchdog; start_to_close = backstop) |

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -21,4 +21,4 @@ ADRs capture the architectural decisions behind the Application SDK — what was
 | [ADR-0015](0015-directory-listing-race-fix.md) | Directory Listing Race Fix (safe_list_directory primitive) |
 | [ADR-0016](0016-multi-pool-worker-routing.md) | Multi-Pool Worker Routing (N pools per app, @task(pool=...) static affinity) |
 | [ADR-0017](0017-native-execution-isolation.md) | Native Execution Isolation (best-effort work in an isolated process; run_fault_isolated / run_best_effort, conformance rule P036) |
-| [ADR-0018](0018-progress-aware-heartbeat.md) | Progress-Aware Heartbeat and Duration-Backstop Timeouts (heartbeat = no-progress watchdog; start_to_close = backstop) |
+| [ADR-0018](0018-progress-aware-heartbeat.md) | Progress-Aware Stall Watchdog and Duration-Backstop Timeouts (in-process no-progress watchdog; heartbeat_timeout unchanged; start_to_close = backstop) |


### PR DESCRIPTION
## Summary

Adds **ADR-0018 (Accepted)** — a redesign of SDK `@task` activity timeouts, plus the companion asks at the Automation Engine layer.

**Problem, half one.** `start_to_close` forces app authors to guess an unguessable per-task duration (it scales with tenant/data size, seconds → days). A production failure dashboard shows a steady trickle of `activity StartToClose timeout` failures across connectors *despite* apps already weight-class-tuning their timeouts — the guesses fail at the tail. The intuitive fix (raise the default to ~24h and stop guessing) is unsafe today: the auto-heartbeat is an *unconditional keepalive*, so nothing catches a wedged-but-alive activity and a large `start_to_close` would leave stalls unguarded for the whole backstop window (worker-slot exhaustion).

**Problem, half two — and it's the larger half.** Per FND-165, `activity Heartbeat timeout` is the *dominant* production alert (18× since Aug 3; five connectors/tenants in a trailing 24h), and at least nine teams have independently re-tuned a heartbeat/timeout number since March rather than fixing the mechanism. Those failures are overwhelmingly event-loop starvation — an ADR-0010 adoption gap, not a timeout-semantics one. This ADR doesn't fix them, but it can't ignore them either: any design that puts *more* weight on the heartbeat mechanism lands on top of the thing that is already failing most.

## Proposal

- **`heartbeat_timeout` and the unconditional keepalive stay exactly as they are** (60s). They remain the "nothing is beating" detector — crash, OOM kill, node loss, partition, starved event loop.
- **Add an in-process stall watchdog** on its own new budget, `max_no_progress_seconds`. The auto-heartbeat loop tracks a progress token and, when it has been flat for the budget, **fails the activity itself** with a typed `TaskStalledError` naming the last progress signal and the elapsed stall.
- **Demote `start_to_close` to a backstop** (24h) authors never tune — with the *retry product* bounded, not just the single attempt.
- Feed the progress token from **framework hooks** (write/emission/transfer loops) so streaming work is covered with no app effort, plus the existing manual `context.heartbeat()`.
- Cover long opaque operations — blocking or async — with one **`holding_progress()`** context manager whose allowance the author declares. The SDK never derives or invents a duration.
- **A three-state flag — `off` / `warn` / `enforce` — where `warn` is the default and the audit tool.** The watchdog runs and reports but never kills, emitting the two shapes that need action: no-progress gaps with no hold in force, and long unbounded holds. Because it can't fail an activity there's no reason to make apps opt in, so every app gets its own ranked work-list on upgrade without anyone auditing a codebase by hand or inventing an allowance at the desk. Declaring holds becomes an *eventual optimisation*, not an upgrade task.
- **Rollout**: fix the starvation sites, ship the hooks, then ship `warn` on by default *together with the backstop* so relief arrives on upgrade rather than after a migration; read the fleet data; then flip per app to `enforce` when that app wants the guarantee.

## What changed in review

**2nd commit** — resolved reviewer questions on "what counts as meaningful progress / how do we keep authors from having to think about it": reframed around one mental model (a healthy-but-quiet task is indistinguishable from a wedged one, so quiet spots must be made *observable*), defined progress operationally, and made the residual explicit and auditable rather than claiming zero effort.

**3rd commit** — the mechanism changed after a sense-check against the SDK code, the contract toolkit, and Temporal's vendored Core.

*Progress-gating the heartbeat is now Option 5, rejected.* It does work mechanically — Temporal's Rust Core spawns per-activity local heartbeat and `start_to_close` timers specifically so that "activities can still get cleaned up even if the user isn't heartbeating", issuing a cancel with reason `TimedOut` (verified present across the declared `temporalio>=1.25.0` floor, in 1.23 and 1.30). So withholding beats really does reclaim the slot. It's rejected because:

- **It spends crash-recovery latency to buy the semantic merge.** One knob has to be sized for the slower case, so a 300s (or 1800s) budget also raises the time an OOM-killed worker's activities sit unreclaimed, from 60s to the whole budget. Graceful evictions don't pay this (the SIGTERM/`WorkerEvicted` path fires immediately); SIGKILL/OOM/node-loss has no other path, and OOM is a leading failure mode for these connectors.
- It loads more weight onto the mechanism that is already the top alert, producing a failure indistinguishable from the existing starvation one — right when CNCT-10 is trying to split timeout subtypes apart.
- The kill surfaces as a bare `CancelledError` (`activities.py:259` only translates cancellation for worker shutdown), so there's no last-progress context and no way to measure the rollout.
- Redefining a live knob's meaning forces a coupled default bump, and apps that never touched `heartbeat_timeout` are the *most* exposed rather than the least.

The in-process watchdog needs none of that: no existing knob changes meaning, upgrade is behaviourally identical, and the two mechanisms cover each other's blind spot exactly — the watchdog can't fire on a starved loop, which is precisely when `heartbeat_timeout` does.

*Timeout derivation is dropped.* An earlier draft derived the hold's bound from the `timeout=` kwarg the call already carries. The problem isn't that derivation is heuristic about units and `(connect, read)` tuples — it's that **`timeout=` is per-operation, not a wall-clock bound on the call**: a `requests` read timeout bounds the gap between socket reads (a streaming download legitimately runs for hours), `statement_timeout` is per statement. A derived bound is systematically smaller than the call's legitimate duration, and is itself a total-duration guess — the exact knob this ADR abolishes. The fallback made it worse: the dominant shape `run_in_thread(cursor.execute, sql)` has no `timeout=` at all, so most calls would land on "a small multiple of the budget" ≈ 15 min, *tighter* than the 2h/6h `start_to_close` they have today. Now there are two explicit paths — declare a real allowance, or the backstop owns the call — with conformance surfacing the second.

*The AE layer is now in scope.* Connector DAG nodes are child-workflow invocations (`DAGNode.nodeType` defaults to `"workflow"`; the toolkit *rejects* `heartbeatTimeoutSeconds` there because it's activity-only), and Temporal requires no timeout on a workflow. So AE should hold no duration opinion at all, and the unguessability argument applies with full force one layer up. Three asks, none of them `@task` changes: AE drops its 2h source default (the toolkit can't fix this by omission — `errorHandling = null` falls back to exactly that default); the toolkit *floors* `startToCloseTimeoutSeconds`, which is currently a cap with no floor and is how an app ships 7200; and a conformance rule makes it a permanent, connector-pulse-reportable regression guard instead of a hand-repeated sweep.

*New section on bounding total time.* `get_activity_options` returns only `start_to_close_timeout` and a retry policy — no `schedule_to_close` — so a 24h backstop with `retry_max_attempts=3` is a 72h product where today it's 30 minutes. And without REQ-1609 (activity checkpointing) a stall kill at hour 5 of a 6-hour extraction restarts from zero, so the watchdog detects failure faster without making recovery cheaper — which is why tail-profile verification is a gate rather than a suggestion.

*Rollout resequenced.* Fix the starvation sites and ship the hooks first; then everything runs in `warn` before anything runs in `enforce`. The conformance rule and toolkit floor ship independently and deliver immediately.

**4th commit** — added warn mode, because the design had a gap it couldn't afford: telling authors to wrap their opaque calls and pick an allowance for each is a per-site number, guessed up front, by hand — this ADR's own problem one level down. The watchdog already observes exactly what that audit would look for, so it gains a report-only state. Recording closed-hold durations is what makes the second shape visible (a `run_in_thread` call is auto-vouched-for, so it would otherwise be invisible to the audit *because* it is covered). Allowance guidance is now answerable rather than a guess: not a prediction of how long the operation takes, but how long you'd let it run before you'd rather it failed — p99 from warn mode plus headroom, erring generous, since too generous only delays detection while too tight kills a healthy run. The same telemetry sets the `max_no_progress_seconds` default, making open question 1 a data question.

**5th commit** — warn mode defaults *on*, fleet-wide. It can't fail an activity, so making apps opt in buys nothing and costs a ~20-team coordination step of exactly the kind FND-165 documents stalling. Defaulting it on means the evidence arrives without anyone being asked to care, and demotes the migration from an upgrade task to an eventual optimisation: an app can do nothing indefinitely and stay correct. Two constraints come with it — warn findings are a metric plus an INFO log, never WARNING (a stall observation on a fleet-wide default is expected, not actionable, and WARNING would manufacture the alert noise this ADR is trying to reduce), and hooks go on batch/chunk/page boundaries rather than per record. "No behaviour change on upgrade" is now stated precisely: nothing fails differently and no knob changes meaning, but the added cost is telemetry; `off` remains as a kill-switch. Rollout also gains a step *before* enforcement — read the fleet data first, since if long stalls prove rare that argues for a generous budget, or for leaving the fleet in warn and taking only the AE/backstop half.

**6th commit** — the backstop lands *with* warn mode rather than with `enforce`. Coupling it to enforcement meant warn mode delivered no relief: apps would keep dying at guessed ceilings while the fleet gathered data, so "no upgrade task" would buy nobody anything. This accepts one real regression, stated rather than buried — today's small `start_to_close` is *accidentally* the only thing that kills a wedge, and warn mode can't kill, so containment becomes an alert plus a human until an app enforces. It's bounded by the exposure scaling with the wedge rate, which is exactly what warn mode measures, and detection doesn't regress even though containment does. That makes the stall-metric alert mandatory, and makes the retry-product bound a prerequisite of the first release rather than later work.

**7th commit** — the remaining open questions became stated positions, because framing them as questions invites the group to guess numbers rather than agree a direction. There are now two things to accept or reject: (1) we start with a 24h attempt and the existing 3-attempt retry policy — a **72h worst case per activity where today it is 30 minutes**, accepted deliberately because detection stays in minutes via the stall metric, the product collapses to roughly 45 minutes wherever an app enforces (each attempt is caught at the budget), and bounding it now would mean guessing a total duration; and (2) we **remove connector time-bounds from AE entirely**, with the toolkit floor and conformance rule stopping the bound creeping back in per-app.

**8th commit** — `TaskStalledError` is now **retryable**. The non-retryable default was reasoned from the wrong dominant cause: it assumed a stall means a code wedge that re-wedges, when far likelier is a transient source-side problem (dropped connection, overloaded source, socket read with no timeout, exhausted pool) in an app whose error handling never surfaced it — so the symptom is silence rather than an exception. That self-heals on retry, and refusing to retry converts it into a failed run needing a manual re-run, which restarts from zero anyway. A genuine wedge costs at most 3 × the budget (minutes), not 3 × the backstop. The real cost is a false kill in an under-instrumented app repeating wasted work up to three times, and clearing that category is exactly what the warn-mode pass does before an app enforces. Knock-on: REQ-1609 stops being a correctness gate — restarting from zero already happens on every `StartToClose` retry and every manual re-run, so checkpointing makes existing and new paths cheaper without deciding whether the new path is right.

**9th commit** — status **Proposed → Accepted**, on review sign-off for both positions. The section that framed them as things to accept or reject is now *Decisions taken*, and the warn-mode sentence that deferred the sizing parameters to review says plainly that they are measurements. No design content changed.

## Status

**Accepted** — design doc, no code changes. The two positions are signed off: the 24h attempt with the existing 3-attempt retry policy, and removing connector time-bounds from AE entirely. The earlier open question about reusing `heartbeat_timeout`'s semantics was dissolved rather than answered — nothing about that knob changes.

Still needs an owner rather than a decision: the AE half is cross-team (drop the 2h source default, floor `startToCloseTimeoutSeconds` in the toolkit, add the conformance rule). Implementation follows the ADR's *Rollout* order — fix the starvation sites, ship the hooks, then `warn` on by default together with the backstop.

Never open questions, and recorded in the ADR as such: `max_no_progress_seconds` (starts at 900s, warn data sets the final value), per-site hold allowances (observed p99), and whether long stalls happen at all. Those are measurements, not decisions.

## Related

- ADR-0010 (async-first / blocking code) — and why its per-operation timeout mandate can't be reused as a wall-clock bound.
- ADR-0017 (native execution isolation).
- REQ-1609 (checkpointing), CNCT-10 (timeout subtypes), FND-38, FND-165.

