### PR TITLE
chore(adopt-preflight-gate): detect and fix non-routable extraction_method (query_history)

### DIFF
--- a/.claude/skills/adopt-preflight-gate/SKILL.md
+++ b/.claude/skills/adopt-preflight-gate/SKILL.md
@@ -226,6 +226,22 @@ Run these detections and report the bucket(s) before changing anything:
    entrypoint bodies for credential assignment or `defaultCredentialGuid` reads
    before the first extraction activity. Fix in phase 2 by lifting the
    derivation to input construction (see 2h). SDK-side fix tracked in CNCT-92.
+10. **Non-routable `extraction_method` class** — the credential router
+    (`CredentialRef.resolve`) reads `extraction_method` as the routing
+    *selector* and accepts only `direct` (+ `credential_guid`) or `agent`
+    (+ populated `agent_json`); anything else raises `CredentialRoutingError`.
+    Query-extraction / miner-family manifests commonly set `extraction-method`
+    to an extraction *kind* instead — e.g. `query_history` — which names what is
+    extracted, not how creds are routed. Left as-is, the gate's `resolve()`
+    raises on every run and survives **only** via the deprecated
+    `legacy_credential_ref` fallback (removed in SDK v4.0) — so it looks like it
+    works (a caught `CredentialRoutingError` stacktrace on every run) until v4.0
+    removes the fallback or the app flips to hard mode, at which point the gate
+    resolves `credentials=[]` and soft-skips or hard-aborts. Detect by grepping
+    the manifest (`app/generated/**/*.json`) and the input model for
+    `extraction-method` / `extraction_method` values that are not `direct` /
+    `agent`. Fix in phase 2 by normalizing it at input construction (see 2h).
+    Same SDK ticket: CNCT-92.
 
 ## Phase 1 — Bump and boot
 
@@ -540,6 +556,35 @@ This is an app-side stopgap. The connection-carries-its-default-guid pattern is
 platform-wide, so the durable fix is the gate resolving it directly (CNCT-92);
 when that lands, delete the validator.
 
+**Also normalize `extraction_method` if it isn't router-routable** (phase-0
+bucket 10). Lifting the guid is not enough if the router can't route it: the
+gate calls `CredentialRef.resolve`, which only accepts `direct` / `agent`. A
+manifest that sets `extraction-method` to an extraction *kind* (e.g.
+`query_history`) makes `resolve()` raise, and it limps along only on the
+deprecated `legacy_credential_ref` fallback. Map it to the routing selector at
+construction, mirroring `resolve()`'s own precedence (agent creds win over a
+guid):
+
+```python
+@model_validator(mode="after")
+def _route_extraction_method_for_gate(self):
+    if self.extraction_method not in ("direct", "agent"):
+        agent = self.agent_json
+        if agent is not None and agent.is_populated():
+            self.extraction_method = "agent"
+        elif self.credential_guid:
+            self.extraction_method = "direct"
+    return self
+```
+
+Leave it untouched when there's nothing to route (no guid, no agent) — let the
+gate decide on an empty credential rather than inventing a route. When it bites
+if skipped: works today via the caught fallback, but breaks at SDK v4.0 (fallback
+removed) or the hard-mode flip (every run aborts). Nothing reads the extraction
+*kind* value for behaviour, so remapping is safe — verify with a grep. Same
+durable SDK fix: `resolve()` should route "non-agent + guid → GUID" itself
+(CNCT-92), after which this validator is deleted too.
+
 ## Phase 3 — Tests (mandatory, thorough)
 
 Update or write unit tests so every verdict path is pinned. Minimum matrix:
@@ -598,6 +643,12 @@ gzipped JSONL) and confirm `outcome="proceeded"` with the entrypoint's checks in
   UI, to know what the gate actually did.
 - Mis-set `entrypoint` default in `preflight_check` → multi-entrypoint runs
   routed down the wrong branch (a miner silently running the crawler's checks).
+- `extraction_method` names an extraction *kind* (e.g. `query_history`), not a
+  routing selector → `CredentialRef.resolve` raises and the gate survives only
+  on the deprecated `legacy_credential_ref` fallback (removed in v4.0) / hard-
+  aborts under hard mode. Reads green today because the error is caught — a
+  false all-clear. Normalize to `direct`/`agent` at input construction (phase-0
+  bucket 10, 2h).
 
 ## Agent protocol — stop points and what to report at each
 


### PR DESCRIPTION
TL;DR: adds the second half of the miner preflight-gate credential lesson to the skill. PR #2863 taught lifting the connection guid at input construction (Bug 1); this adds the `extraction_method` routing-selector overload (Bug 2), which the postgres miner surfaced on the tenant.

## What changed

- **Phase 0 — new bucket 10 "Non-routable `extraction_method` class".** The credential router (`CredentialRef.resolve`) reads `extraction_method` as the routing selector and accepts only `direct`/`agent`. Query-extraction/miner-family manifests set it to an extraction *kind* (e.g. `query_history`), so `resolve()` raises and the gate survives only on the deprecated `legacy_credential_ref` fallback — a false all-clear that breaks at SDK v4.0 or the hard-mode flip. Includes detection (grep manifest + input model).
- **Phase 2h — normalization fix pattern.** A second `@model_validator` mapping `extraction_method` to the routing selector at construction (agent wins over guid, mirroring `resolve()`), with the "when it bites if skipped" note.
- **Pitfalls — one bullet** for the same trap.

## Why

The postgres miner gate resolved credentials only via a caught `CredentialRoutingError` + the deprecated fallback, because the manifest sends `extraction_method="query_history"`. It reads green today but is latent breakage. The skill already covered the guid-lift half; this closes the gap so the next miner-family adopter catches it in Phase 0. Durable fix stays SDK-side (CNCT-92); the app validator is a stopgap.
