### PR TITLE
chore(make-contract): rewrite skill adaptive for App.pkl, migrations, and app_name floor

### DIFF
--- a/.agents/skills/make-contract/SKILL.md
+++ b/.agents/skills/make-contract/SKILL.md
@@ -26,8 +26,13 @@ authoritative sources in this repo instead of trusting any list baked below:
 - Changelog / when something changed: `contract-toolkit/CHANGELOG.md`.
 - The real example set: `git ls-files 'contract-toolkit/examples/*/app.pkl'`
   (untracked `generated/` and `__pycache__` leftover dirs are **not** examples).
-- Latest toolkit version: `git tag --list 'contract-toolkit-v*' | sort -V | tail -1`.
+- Latest toolkit version (bare semver, from the SDK checkout root):
+  `git tag --list 'contract-toolkit-v*' | sort -V | tail -1 | sed 's/^contract-toolkit-v//'`.
 - The template source of truth: `contract-toolkit/src/App.pkl`.
+
+These `contract-toolkit/...`, `git ls-files`, and `git tag` lookups only resolve
+from an `atlanhq/application-sdk` checkout — run them there (or `git -C
+<sdk-repo>`). From a consuming app repo they return nothing, silently.
 
 **`contract-toolkit/AGENTS.md` is stale** (still describes the pre-consolidation
 `NativeApp.pkl` world and references examples that no longer exist). Do not use
@@ -119,7 +124,7 @@ Route the app by what Discovery found:
 - **Archived toolkit source** — `PklProject` points at the old standalone
   toolkit URL (`package://atlanhq.github.io/app-contract-toolkit/...`) instead
   of the SDK-hosted one. Propose switching the URL and bumping the version.
-- **Below the version floor** — SDK `< 3.21.0` or toolkit `< 0.16.1`. Propose
+- **Below the version floor** — SDK `< 3.21.0` or toolkit `< 0.17.0`. Propose
   raising both (this is what keeps logs visible — see the `app_name` invariant).
 
 Migrations are opt-in and incremental. Detect, propose, get a yes, then apply
@@ -127,12 +132,12 @@ one at a time — never silently redesign.
 
 ## Version Floor (why it exists)
 
-**Enforce SDK `>= 3.21.0` and contract-toolkit `>= 0.16.1`.** Below this, an
+**Enforce SDK `>= 3.21.0` and contract-toolkit `>= 0.17.0`.** Below this, an
 app's failure logs can silently fail to surface in the Workflow Center. Hard-fail
 generation/validation guidance if the app is below the floor and the user has
 not explicitly opted to stay.
 
-Why 3.21.0 / 0.16.1 (not 3.18):
+Why 3.21.0 / 0.17.0 (not 3.18):
 
 - `app_name` is the app's **log-correlation identity**. Logs are *written*
   tagged with `app_name` = `ATLAN_APPLICATION_NAME` (from `atlan.yaml`). The UI
@@ -148,9 +153,9 @@ Why 3.21.0 / 0.16.1 (not 3.18):
   construction:
   - SDK `3.19.0` / toolkit `0.14.2` — core bake for `App.pkl` apps.
   - SDK `3.20.2` — output-path derivation prefers the resolved app name.
-  - SDK `3.21.0` / toolkit `0.16.1` — same bake applied to the legacy
+  - SDK `3.21.0` / toolkit `0.17.0` — same bake applied to the legacy
     `NativeApp.pkl` crossover template.
-- `3.21.0` / `0.16.1` is the single floor that covers both the `App.pkl` and
+- `3.21.0` / `0.17.0` is the single floor that covers both the `App.pkl` and
   `NativeApp.pkl` families. `3.18.0` carries none of these fixes.
 
 ## The `app_name` invariant (same name everywhere)
@@ -178,9 +183,9 @@ Verify after every generate:
 NAME=$(grep -E '^\s*name\s*=' contract/app.pkl | head -1 | sed -E 's/.*"([^"]+)".*/\1/')
 echo "contract name = $NAME"
 # No literal placeholder may survive in generated manifests (smoking gun):
-grep -rn '"{app_name}"' app/generated/ && echo "FAIL: unbaked placeholder — regenerate on toolkit >= 0.16.1"
+grep -rn '"{app_name}"' app/generated/ && echo "FAIL: unbaked placeholder — regenerate on toolkit >= 0.17.0"
 # Every baked app_name must equal $NAME:
-grep -rn '"app_name"' app/generated/**/manifest.json app/generated/manifest.json 2>/dev/null
+grep -rn '"app_name"' app/generated/ 2>/dev/null
 # atlan.yaml packaging name must equal $NAME:
 grep -rn "name" atlan.yaml app/generated/atlan.yaml 2>/dev/null
 # Generated filenames must be {name}.json / atlan-connectors-{name}.json:
@@ -207,15 +212,18 @@ dependencies {
 ```
 
 Prefer `atlan app contract update-toolkit -p . --version <LATEST>` if the CLI is
-available; it refreshes `PklProject.deps.json`. Get `<LATEST>` from
-`git tag --list 'contract-toolkit-v*' | sort -V | tail -1`.
+available; it refreshes `PklProject.deps.json`. Get the bare-semver `<LATEST>`
+(from the SDK checkout) with
+`git tag --list 'contract-toolkit-v*' | sort -V | tail -1 | sed 's/^contract-toolkit-v//'`.
 
 ### `NativeApp.pkl` / `NativeAppBundle.pkl` -> `App.pkl`
 
 - Change the amend line to `amends "@app-contract-toolkit/App.pkl"`.
-- Credential primitives (`CredentialInput`, `FieldSpec`, `AuthOption`,
-  `ConditionalFieldSpec`, `NamedWidget`, `NamedProperty`) are now defined in
-  `App.pkl` — they carry over by name, no separate import.
+- Credential field primitives (`FieldSpec`, `AuthOption`, `ConditionalFieldSpec`,
+  `NamedWidget`, `NamedProperty`) are now defined in `App.pkl`, and the
+  `Widgets.CredentialInput` widget is re-exported by it — all reachable by name,
+  no separate import. (`CredentialInput` is a `uiConfig` widget, not a credential
+  field entry — don't use it inside `credentialAuthOptions`.)
 - Widgets come from `Widgets.*` (re-exported by `App.pkl`); `Connectors.pkl`
   still needs an explicit `import`.
 - Single-entrypoint: leave `entrypoints` empty; set `uiConfig` + `pipeline`.
@@ -230,7 +238,7 @@ Confirm the exact current field names against `contract-toolkit/README.md` and
 
 ### Raise to the version floor
 
-Bump the SDK dependency to `>= 3.21.0` and the toolkit to `>= 0.16.1`, then
+Bump the SDK dependency to `>= 3.21.0` and the toolkit to `>= 0.17.0`, then
 regenerate so the manifest bakes a literal `app_name`. Re-run the `app_name`
 invariant checks.
 
@@ -316,9 +324,11 @@ Note each one's caveat — they are pattern references, not version references
   Caveat: still on legacy `NativeApp.pkl` and the archived toolkit URL — it is
   itself a migration candidate, so read it for the SQL/DAG patterns, not the
   primitive or the dependency URL.
-- **`atlanhq/atlan-metabase-app`** — best modern `App.pkl` multi-entrypoint +
-  REST auth + rich DAG. Caveat: uses the **deprecated** `emitEntrypoints = false`
-  single-card collapse — do not copy that; use per-entrypoint `packageId`.
+- **`atlanhq/atlan-metabase-app`** — best modern `App.pkl` reference: REST auth,
+  a rich multi-node DAG, and the correct "two code `@entrypoint`s, one marketplace
+  card" shape via single-entrypoint contract mode (no `entrypoints` listing, so
+  the `marketplaceCard` default applies). It has already migrated off the
+  deprecated `emitEntrypoints = false` workaround — copy this pattern, not that.
 - **`atlanhq/atlan-openapi-app`** — URL-vs-cloud import modes plus an app-owned
   external object-store credential contract (a `Credential.pkl` amend). Caveat:
   task-only (no DAG/publish) and on an older toolkit.
@@ -338,7 +348,7 @@ Direct `pkl` fallback (what this repo guarantees):
 
 ```bash
 pkl project resolve contract
-pkl eval -m app/generated contract/app.pkl   # from the app root
+pkl eval -m . contract/app.pkl   # from the app root; -m . matches the contract's own output paths
 ```
 
 Then verify generated output and invariants:
@@ -346,7 +356,7 @@ Then verify generated output and invariants:
 ```bash
 ls app/generated
 python -m py_compile app/generated/_input.py
-ruby -rjson -e 'ARGV.each { |f| JSON.parse(File.read(f)); puts "OK #{f}" }' app/generated/*.json
+find app/generated -name '*.json' -print0 | xargs -0 -I{} python -c 'import json,sys; json.load(open(sys.argv[1])); print("OK", sys.argv[1])' {}
 ```
 
 - Generated JSON filenames match the contract `name`.

--- a/.agents/skills/make-contract/SKILL.md
+++ b/.agents/skills/make-contract/SKILL.md
@@ -1,153 +1,266 @@
 ---
 name: make-contract
-description: Create, migrate, update, generate, or validate Atlan native app Pkl contracts with app-contract-toolkit and the Atlan CLI. Use when an agent is helping an app author produce contract/app.pkl, contract/PklProject, app/generated artifacts, atlan.yaml decisions, SDK input contracts, and contract validation.
+description: Create, migrate, update, generate, or validate an Atlan native app Pkl contract with app-contract-toolkit and the Atlan CLI. Use when helping an app author produce contract/app.pkl, contract/PklProject, app/generated artifacts, atlan.yaml decisions, and SDK input contracts — including migrating a legacy app onto the canonical App.pkl template, moving it off the archived toolkit repo, and raising it to the SDK floor that keeps its logs visible.
 ---
 
 # make-contract
 
 Use this skill when the user asks to create, migrate, update, generate, or
-validate an Atlan native app contract. The goal is to produce a correct Pkl
-contract and regenerated SDK artifacts, not to hand-edit generated JSON.
+validate an Atlan native app contract. The goal is a correct Pkl contract and
+regenerated SDK artifacts — never hand-edited generated JSON.
+
+This skill is **adaptive and incremental**. You inspect the app you are running
+in, classify what shape it is already in, propose a small plan, ask only
+blocking questions, then apply and verify one step at a time. You do not force a
+redesign on an app that does not need one.
+
+## Ground yourself in live sources first — do not trust memory or this file's snapshots
+
+The toolkit moves. Earlier versions of this skill went stale because they
+hard-coded facts (which primitive to amend, the example list, a version-lookup
+recipe) that later changed. **Derive volatile facts at runtime** from the
+authoritative sources in this repo instead of trusting any list baked below:
+
+- Primitive model, widgets, credential shapes, migration notes:
+  `contract-toolkit/README.md` and `contract-toolkit/CLAUDE.md` are current.
+- Changelog / when something changed: `contract-toolkit/CHANGELOG.md`.
+- The real example set: `git ls-files 'contract-toolkit/examples/*/app.pkl'`
+  (untracked `generated/` and `__pycache__` leftover dirs are **not** examples).
+- Latest toolkit version: `git tag --list 'contract-toolkit-v*' | sort -V | tail -1`.
+- The template source of truth: `contract-toolkit/src/App.pkl`.
+
+**`contract-toolkit/AGENTS.md` is stale** (still describes the pre-consolidation
+`NativeApp.pkl` world and references examples that no longer exist). Do not use
+it as the source of truth; trust `README.md` + `CLAUDE.md` + `CHANGELOG.md` +
+`src/App.pkl`.
 
 ## Hard Rules
 
 - Treat `atlanhq/application-sdk` as the canonical source for this skill. The
   repo-local copies live at `.agents/skills/make-contract/SKILL.md` and
-  `.claude/skills/make-contract/SKILL.md`; mirror any edits between them and do
-  not add nested `make-contract` skill copies under `contract-toolkit/` or app
-  repos.
+  `.claude/skills/make-contract/SKILL.md`; mirror any edit between them
+  byte-for-byte, and do not add nested `make-contract` copies under
+  `contract-toolkit/` or app repos.
+- **`App.pkl` is the canonical template. `NativeApp.pkl` and
+  `NativeAppBundle.pkl` are frozen legacy.** Author every new contract by
+  amending `App.pkl`. Only touch the legacy modules when reading an app that
+  still uses them (to migrate it, or to preserve it when the user declines).
 - Use the Atlan CLI contract commands first. Fall back to direct `pkl` commands
-  only when the CLI is missing, too old, or cannot support the requested change.
-- Do not expose internal service, repository, or implementation details in
-  generated guidance, examples, comments, or docs.
+  when the CLI is missing, too old, or cannot support the requested change.
 - Do not hand-edit generated files under `app/generated/` except to inspect or
-  compare output. Fix `contract/app.pkl`, then regenerate.
-- Keep examples public and generic. Prefer examples in this SDK repo under
-  `contract-toolkit/examples/`.
-- Preserve existing app behavior unless the user explicitly asks for a contract
-  redesign.
+  compare. Fix `contract/app.pkl`, then regenerate.
+- Keep examples public and generic. Prefer the tracked examples under
+  `contract-toolkit/examples/`; test-only scenarios live under
+  `contract-toolkit/tests/fixtures/`.
+- Preserve existing app behavior unless the user explicitly asks for a redesign.
 - Never put secrets, real tokens, passwords, or tenant-specific data in
-  contracts, examples, generated artifacts, or validation notes.
+  contracts, examples, generated artifacts, or notes.
 
-## Agent Workflow for App Authors
+## Adaptive Workflow
 
-Most users are not asking for a PKL lecture; they are asking the agent to get a
-working contract into their app. Work in this order:
+Work in this loop. Keep the main thread short; state a plan before you edit.
 
-1. Inspect the repo and infer the app shape before asking questions.
-2. State the inferred contract plan in plain terms: app type, generated path,
-   credential form, workflow setup fields, DAG shape, publish behavior, and
-   `atlan.yaml` ownership.
-3. Ask only blocking questions, usually no more than three at a time. Prefer
-   concrete choices with a recommended default over broad open-ended prompts.
-4. Implement in `contract/app.pkl` and `contract/PklProject`, then regenerate.
-5. Verify the generated value flow from workflow config to manifest to
-   `_input.py` to runtime expectations.
-6. Finish with changed source files, generated artifacts, validation commands,
-   and any assumptions or skipped checks.
+1. **Detect** the app you are in (Discovery below).
+2. **Classify** its rollout bucket (Classification below) — fresh, legacy
+   primitive, archived toolkit source, or below the version floor. An app can be
+   in several buckets at once.
+3. **State the plan** in plain terms: app type, primitive, single- vs
+   multi-entrypoint, credential form, DAG/publish, generated path, `atlan.yaml`
+   ownership, and which migrations (if any) apply. Name the version floor and
+   whether the app clears it.
+4. **Ask only blocking questions** — usually no more than three at a time, with
+   concrete choices and a recommended default. Ask only where local repo
+   evidence cannot settle a behavior-preserving choice.
+5. **Apply one step at a time** in `contract/app.pkl` / `contract/PklProject`,
+   then regenerate.
+6. **Verify** the value flow and the `app_name` invariant (below).
+7. **Finish** with changed source files, generated artifacts, validation
+   commands run, and any assumption or skipped check.
 
 When the user is unsure, choose the simplest behavior-preserving contract:
-single entrypoint, `contract/app.pkl`, generated output in `app/generated`, root
-`atlan.yaml` as the packaging source of truth, and default `extract -> publish`
-only for asset-producing connectors.
+single entrypoint, `contract/app.pkl` amending `App.pkl`, generated output in
+`app/generated`, root `atlan.yaml` as packaging source of truth, and default
+`extract -> publish` only for asset-producing connectors.
 
-## Expected Layout
-
-For a normal single-entrypoint app:
-
-```text
-contract/
-|-- PklProject
-|-- PklProject.deps.json
-`-- app.pkl
-app/generated/
-|-- __init__.py
-|-- _input.py
-|-- {name}.json
-|-- atlan-connectors-{name}.json
-`-- manifest.json
-```
-
-Bundle contracts can also render `app/generated/atlan.yaml` and per-entrypoint
-folders. The root `atlan.yaml` in the app repo remains the packaging source of
-truth unless the app has an explicit sync step.
-
-## CLI Commands
-
-Check the installed CLI before making assumptions:
-
-```bash
-command -v atlan
-atlan app contract --help
-atlan app contract init --help
-atlan app contract generate --help
-atlan app contract validate --help
-atlan app contract update-toolkit --help
-```
-
-Common commands:
-
-```bash
-# Create a new contract scaffold in an app repo.
-atlan app contract init <app-name> -p <app-dir> -c <connector-name>
-
-# Validate Pkl without writing generated artifacts.
-atlan app contract validate -p <app-dir>
-
-# Generate app/generated artifacts from contract/app.pkl.
-atlan app contract generate -p <app-dir>
-
-# Update the toolkit dependency and refresh PklProject.deps.json.
-atlan app contract update-toolkit -p <app-dir>
-atlan app contract update-toolkit -p <app-dir> --version <semver>
-```
-
-The toolkit package is named `app-contract-toolkit`, but latest-version lookup
-must come from the SDK repo releases, not the old standalone toolkit repo:
-
-```bash
-gh release list --repo atlanhq/application-sdk --limit 50 --json tagName --jq '[.[] | select(.tagName | startswith("contract-toolkit-v"))][0].tagName | sub("^contract-toolkit-v"; "")'
-```
-
-If the CLI cannot be used, say why and use the smallest fallback:
-
-```bash
-pkl project resolve <app-dir>/contract
-pkl eval -m <app-dir>/app/generated <app-dir>/contract/app.pkl
-```
-
-If editing `contract/PklProject` manually, use the SDK-hosted package URL:
-
-```pkl
-dependencies {
-  ["app-contract-toolkit"] {
-    uri = "package://atlanhq.github.io/application-sdk/contracts/app-contract-toolkit@<VERSION>"
-  }
-}
-```
-
-## Discovery Checklist
+## Discovery
 
 Before editing, inspect the app shape:
 
 ```bash
 git status --short --branch
-find . -maxdepth 3 -name app.pkl -o -name PklProject -o -name atlan.yaml
-rg -n "ATLAN_CONTRACT_GENERATED_DIR|app/generated|contract/generated|AppInputContract|ExtractionInput|CredentialInput|workflowType|workflow_type|manifest.json"
-rg -n "get_configmap|get_manifest|/workflows/v1/configmap|/manifest" app application_sdk tests
+find . -maxdepth 3 \( -name app.pkl -o -name PklProject -o -name atlan.yaml \)
+# Which primitive does the contract amend?
+grep -rn "amends" contract/*.pkl 2>/dev/null
+# Toolkit dependency + URL
+grep -rn "app-contract-toolkit" contract/PklProject contract/PklProject.deps.json 2>/dev/null
+# SDK version the app pins
+grep -REh "atlan-application-sdk" pyproject.toml uv.lock requirements*.txt 2>/dev/null | head
+# Runtime wiring
+rg -n "ATLAN_CONTRACT_GENERATED_DIR|app/generated|AppInputContract|@entrypoint|@task|workflowType|manifest.json"
 ```
 
-Also check:
+Also answer:
 
-- Is this a new contract or migration from existing templates?
-- Is it single-entrypoint or bundle-shaped?
+- New contract, or migration from an existing one?
+- Single-entrypoint or multi-entrypoint/bundle?
 - Which generated directory does the app actually serve?
-- Is root `atlan.yaml` already present and intentionally maintained?
-- Does the app need credential config, preflight, publish controls, connection
+- Is root `atlan.yaml` present and intentionally maintained?
+- Does it need credential config, preflight, publish controls, connection
   reference, multiple auth modes, or custom runtime steps?
 
-Ask the user only when local repo evidence cannot answer a behavior-preserving
-choice.
+## Classification (rollout buckets)
+
+Route the app by what Discovery found:
+
+- **Fresh** — no contract yet, or already amends `App.pkl` on a current toolkit
+  and clears the version floor. Author/edit directly; no migration.
+- **Legacy primitive** — `contract/app.pkl` amends `NativeApp.pkl` or
+  `NativeAppBundle.pkl`. Propose migration to `App.pkl` (see Migrations).
+- **Archived toolkit source** — `PklProject` points at the old standalone
+  toolkit URL (`package://atlanhq.github.io/app-contract-toolkit/...`) instead
+  of the SDK-hosted one. Propose switching the URL and bumping the version.
+- **Below the version floor** — SDK `< 3.21.0` or toolkit `< 0.16.1`. Propose
+  raising both (this is what keeps logs visible — see the `app_name` invariant).
+
+Migrations are opt-in and incremental. Detect, propose, get a yes, then apply
+one at a time — never silently redesign.
+
+## Version Floor (why it exists)
+
+**Enforce SDK `>= 3.21.0` and contract-toolkit `>= 0.16.1`.** Below this, an
+app's failure logs can silently fail to surface in the Workflow Center. Hard-fail
+generation/validation guidance if the app is below the floor and the user has
+not explicitly opted to stay.
+
+Why 3.21.0 / 0.16.1 (not 3.18):
+
+- `app_name` is the app's **log-correlation identity**. Logs are *written*
+  tagged with `app_name` = `ATLAN_APPLICATION_NAME` (from `atlan.yaml`). The UI
+  *reads* logs back by filtering on the `app_name` value baked into the served
+  manifest.
+- Pre-fix, the manifest shipped a literal `"{app_name}"` placeholder that the
+  SDK substituted **at serve time from the runtime class name** (`GlueApp` ->
+  `glue-app`), not the contract `name` (`glue`). Write-identity != read-identity
+  -> the log query matches zero rows -> the panel shows "no logs" though logging
+  worked. This is the failure signature the fix addresses.
+- The fix bakes `app_name` from the contract `name` **at generate time** and
+  removes the runtime placeholder, so read-identity equals write-identity by
+  construction:
+  - SDK `3.19.0` / toolkit `0.14.2` — core bake for `App.pkl` apps.
+  - SDK `3.20.2` — output-path derivation prefers the resolved app name.
+  - SDK `3.21.0` / toolkit `0.16.1` — same bake applied to the legacy
+    `NativeApp.pkl` crossover template.
+- `3.21.0` / `0.16.1` is the single floor that covers both the `App.pkl` and
+  `NativeApp.pkl` families. `3.18.0` carries none of these fixes.
+
+## The `app_name` invariant (same name everywhere)
+
+The contract `name` (kebab-case) is the single root identity. The toolkit
+derives everything from it, and every surface must stay byte-identical:
+
+| Surface | Must equal |
+|---|---|
+| contract `name` in `contract/app.pkl` | the root value |
+| generated `{name}.json` and `atlan-connectors-{name}.json` filenames | `name` |
+| manifest `app_name` (top-level and `inputs.app_name`) | `name` |
+| task-queue prefix `atlan-{name}-...` | `name` |
+| `atlan.yaml` app name -> `ATLAN_APPLICATION_NAME` -> the log tag | `name` |
+| runtime app identity (`_app_name` / resolved app name) | `name` |
+
+If `atlan.yaml` name diverges from the contract `name`, the log write-tag and
+the manifest read-filter disagree and **logs stop surfacing**. Fix the divergent
+surface to match the intended kebab-case identity — correct `contract/app.pkl`
+`name` or `atlan.yaml`, never hand-edit `app/generated/`.
+
+Verify after every generate:
+
+```bash
+NAME=$(grep -E '^\s*name\s*=' contract/app.pkl | head -1 | sed -E 's/.*"([^"]+)".*/\1/')
+echo "contract name = $NAME"
+# No literal placeholder may survive in generated manifests (smoking gun):
+grep -rn '"{app_name}"' app/generated/ && echo "FAIL: unbaked placeholder — regenerate on toolkit >= 0.16.1"
+# Every baked app_name must equal $NAME:
+grep -rn '"app_name"' app/generated/**/manifest.json app/generated/manifest.json 2>/dev/null
+# atlan.yaml packaging name must equal $NAME:
+grep -rn "name" atlan.yaml app/generated/atlan.yaml 2>/dev/null
+# Generated filenames must be {name}.json / atlan-connectors-{name}.json:
+ls app/generated | grep -E "^(${NAME}|atlan-connectors-${NAME})\.json$"
+```
+
+## Migrations
+
+Each migration is small and mechanical. Propose, confirm, apply, regenerate,
+verify.
+
+### Archived toolkit URL -> SDK-hosted package
+
+The toolkit was once a standalone repo. It is now hosted from the SDK repo. If
+`contract/PklProject` points at the old standalone URL, switch it and pin the
+latest version:
+
+```pkl
+dependencies {
+  ["app-contract-toolkit"] {
+    uri = "package://atlanhq.github.io/application-sdk/contracts/app-contract-toolkit@<LATEST>"
+  }
+}
+```
+
+Prefer `atlan app contract update-toolkit -p . --version <LATEST>` if the CLI is
+available; it refreshes `PklProject.deps.json`. Get `<LATEST>` from
+`git tag --list 'contract-toolkit-v*' | sort -V | tail -1`.
+
+### `NativeApp.pkl` / `NativeAppBundle.pkl` -> `App.pkl`
+
+- Change the amend line to `amends "@app-contract-toolkit/App.pkl"`.
+- Credential primitives (`CredentialInput`, `FieldSpec`, `AuthOption`,
+  `ConditionalFieldSpec`, `NamedWidget`, `NamedProperty`) are now defined in
+  `App.pkl` — they carry over by name, no separate import.
+- Widgets come from `Widgets.*` (re-exported by `App.pkl`); `Connectors.pkl`
+  still needs an explicit `import`.
+- Single-entrypoint: leave `entrypoints` empty; set `uiConfig` + `pipeline`.
+  `App.pkl` synthesises the implicit entrypoint.
+- Multi-entrypoint / bundle: replace the `NativeAppBundle.pkl` root plus N
+  `NativeApp.pkl` per-entrypoint contracts with one `App.pkl` root that
+  populates `entrypoints`, each pointing at a per-entrypoint contract that also
+  amends `App.pkl`.
+
+Confirm the exact current field names against `contract-toolkit/README.md` and
+`src/App.pkl` before writing — do not trust this summary over the live source.
+
+### Raise to the version floor
+
+Bump the SDK dependency to `>= 3.21.0` and the toolkit to `>= 0.16.1`, then
+regenerate so the manifest bakes a literal `app_name`. Re-run the `app_name`
+invariant checks.
+
+## Primitive Model (App.pkl)
+
+- One `amends "@app-contract-toolkit/App.pkl"` line is all any contract needs.
+- **Single- vs multi-entrypoint is `entrypoints` empty vs populated** — not two
+  different modules.
+- Marketplace-card presence: single-entrypoint uses `marketplaceCard: Boolean`;
+  multi-entrypoint controls each card via the entrypoint's `packageId` (set it
+  to make the entrypoint a card; omit to keep it routable-only).
+- `emitEntrypoints` is **deprecated** and slated for removal — do not adopt it in
+  new work; use per-entrypoint `packageId` instead. (An existing app that sets it
+  is a pattern to migrate off, not to copy.)
+- Keep `flatManifestArgs = true` unless an existing app intentionally reads
+  metadata-wrapped args; changing it changes the runtime payload shape — call it
+  out.
+
+Prefer typed toolkit APIs over raw JSON: typed widgets from `Widgets.*`, typed
+credential primitives from `App.pkl`, `Connectors.pkl` constants, SQL/JDBC
+helpers (`JDBCUrlAuthOption`, `AdvancedJDBCUrlGroup`, `SqlTree`), and runtime
+graph nodes (`PublishNode`, `QueryIntelligenceNode`, `PopularityNode`,
+`LineageNode`, `LineagePublishNode`), dropping to raw `DAGNode` only when a typed
+node does not fit.
+
+> **FileReference and App.upload():** If your contract carries a `FileReference`
+> that must reach a downstream Atlan system app (publish, lineage, quality), the
+> connector must call `App.upload()` explicitly from `run()` — the task-to-task
+> activity interceptor only writes to the customer-owned `objectstore`. See
+> [ADR-0014](../../../docs/adr/0014-two-store-storage-architecture.md).
 
 ## Value-Flow Rules
 
@@ -160,82 +273,75 @@ credential field -> credential config -> workflow credential reference -> runtim
 DAG node id -> dependency condition -> manifest node -> runtime workflow/activity
 ```
 
-Rules for stable contracts:
+- Prefer typed properties over arbitrary string keys; use a node's typed
+  property instead of `extraArgs` or raw `DAGNode.args`.
+- Do not expose a runtime default as a setup field just to pass the same value
+  through; omit it and let the runtime own its default.
+- Placeholders must be exact workflow field names like `"{{include-filter}}"`;
+  no dotted placeholders unless the consuming runtime supports them.
+- Every manifest placeholder must have a matching workflow/credential field, or
+  be intentionally supplied by the SDK/runtime and documented in the final note.
+- Boolean and numeric controls use typed widgets and typed node properties —
+  avoid stringly-typed contracts a user can typo into a runtime-only failure.
 
-- Prefer typed properties over arbitrary string keys. If a node has a typed
-  property, use it instead of `extraArgs` or raw `DAGNode.args`.
-- Do not expose runtime defaults as setup fields just to pass through the same
-  value. Omit them and let the runtime app own its defaults.
-- Placeholders must be exact workflow field names like `"{{include-filter}}"`.
-  Do not use dotted placeholders unless the consuming runtime explicitly
-  supports them.
-- Every manifest placeholder must have a matching workflow or credential field,
-  or be intentionally supplied by the SDK/Heracles/runtime and documented in the
-  final note.
-- Boolean and numeric controls should use typed widgets and typed node
-  properties. Avoid “stringly typed” contracts where the user can typo a key and
-  only discover it at runtime.
-- Keep user-facing labels clear and app-author friendly. Avoid exposing internal
-  system names unless they are the stable public contract.
+## Examples (derive the current set at runtime)
 
-## Authoring Rules
+The tracked examples all amend `App.pkl` and are the public reference. **List
+them live** — do not trust a baked list:
 
-Prefer typed toolkit APIs over raw JSON:
+```bash
+git ls-files 'contract-toolkit/examples/*/app.pkl' | sed 's#.*/examples/##;s#/app.pkl##'
+```
 
-- `NativeApp.pkl` for standard single-entrypoint contracts.
-- `NativeAppBundle.pkl` for apps with multiple entrypoints.
-- `Config.pkl` widgets for workflow form fields.
-- `Connectors.pkl` constants where available.
-- Native credentials from `NativeApp.pkl`: `CredentialInput`, `FieldSpec`,
-  `AuthOption`, `ConditionalFieldSpec`, `NamedWidget`, and `NamedProperty`.
-- SQL/JDBC helpers where applicable: `JDBCUrlAuthOption`,
-  `AdvancedJDBCUrlGroup`, `SqlTree`, and related filter widgets.
-- Runtime graph helpers where applicable: `PublishNode`,
-  `QueryIntelligenceNode`, `PopularityNode`, `LineageNode`,
-  `LineagePublishNode`, then raw `DAGNode` only when typed nodes do not fit.
+At the time of writing the tracked set is: `minimal` (smallest contract, start
+here), `full` (every overridable feature), `bundle` (multi-entrypoint), `card-split`
+(multi-entrypoint where only one entrypoint is a card), `connection-ref`
+(ConnectionRefInput), `publish-controls` (publish toggles), `fanin` (fan-in via
+`dependsOn`), `deploy` (single-pool KEDA/resources), `pools` (named worker
+pools), `scheduled` (cron background job), `behind-the-scenes`
+(`marketplaceCard = false`), `agent-e2e` (agent-mode codegen). Re-run the command
+above to catch additions or removals.
 
-Do not use legacy credential modules for new native credentials unless preserving
-an existing contract requires it.
+Node-specific coverage (popularity, query-intelligence placeholders) lives in
+`contract-toolkit/tests/fixtures/*.pkl`, not in `examples/`.
 
-Keep `flatManifestArgs = true` unless an existing app intentionally reads
-metadata-wrapped args. If changing this, call it out explicitly because it
-changes the runtime payload shape.
+## Canonical Apps (public first-party references)
 
-## Public Examples
+When you need a real, end-to-end reference, inspect these public connector apps.
+Note each one's caveat — they are pattern references, not version references
+(none is on the current floor yet):
 
-Use the curated open-source examples in this repo. They are intentionally
-generic and stable; app-specific wiring examples should live with sample apps or
-the owning app repo, and test-only scenarios should live under
-`contract-toolkit/tests/fixtures`.
-
-- `contract-toolkit/examples/connection-ref`: selected connection object input.
-- `contract-toolkit/examples/fanin`: dependency and fan-in graph behavior.
-- `contract-toolkit/examples/openapi`: URL/cloud modes and extra credential
-  output.
-- `contract-toolkit/examples/postgres`: basic SQL/JDBC datasource.
-- `contract-toolkit/examples/publish-controls`: publish toggle behavior.
-- `contract-toolkit/examples/trino`: multi-catalog SQL tree and auth options.
-
-For node-specific or app-wiring coverage, inspect fixtures instead of copying a
-real app contract into public examples:
-
-- `contract-toolkit/tests/fixtures/popularity_default.pkl`
-- `contract-toolkit/tests/fixtures/popularity_dynamic_overrides.pkl`
-- `contract-toolkit/tests/fixtures/qi_node_placeholders.pkl`
-
-Do not point users at private app repos or internal consumer repos from this
-skill.
+- **`atlanhq/atlan-mysql-app`** — canonical SQL/JDBC single-entrypoint with
+  multi-mode auth (basic + IAM user + IAM role) and a full lineage-publish DAG.
+  Caveat: still on legacy `NativeApp.pkl` and the archived toolkit URL — it is
+  itself a migration candidate, so read it for the SQL/DAG patterns, not the
+  primitive or the dependency URL.
+- **`atlanhq/atlan-metabase-app`** — best modern `App.pkl` multi-entrypoint +
+  REST auth + rich DAG. Caveat: uses the **deprecated** `emitEntrypoints = false`
+  single-card collapse — do not copy that; use per-entrypoint `packageId`.
+- **`atlanhq/atlan-openapi-app`** — URL-vs-cloud import modes plus an app-owned
+  external object-store credential contract (a `Credential.pkl` amend). Caveat:
+  task-only (no DAG/publish) and on an older toolkit.
 
 ## Validation
 
-For app repos, run the CLI validation and generation:
+Prefer the Atlan CLI (external tool — check it first, it is not defined in this
+repo, so confirm the current flags with `--help` rather than assuming):
 
 ```bash
+command -v atlan && atlan app contract --help
 atlan app contract validate -p .
 atlan app contract generate -p .
 ```
 
-Then verify generated output:
+Direct `pkl` fallback (what this repo guarantees):
+
+```bash
+pkl project resolve contract
+pkl eval -m app/generated contract/app.pkl   # from the app root
+```
+
+Then verify generated output and invariants:
 
 ```bash
 ls app/generated
@@ -243,26 +349,27 @@ python -m py_compile app/generated/_input.py
 ruby -rjson -e 'ARGV.each { |f| JSON.parse(File.read(f)); puts "OK #{f}" }' app/generated/*.json
 ```
 
-Check contract-specific invariants before finishing:
-
 - Generated JSON filenames match the contract `name`.
+- No `"{app_name}"` literal survives in `app/generated/`, and every baked
+  `app_name` plus the `atlan.yaml` name equals the contract `name`.
 - `manifest.json` placeholders match fields emitted by workflow and credential
   config.
-- Credential config name matches the credential input type used by the workflow.
-- SQL tree credential type and credential field names line up.
+- Credential config name matches the credential input type the workflow uses.
+- SQL tree credential type and field names line up.
 - Optional publish controls match the app's expected output behavior.
 - Root `atlan.yaml` and generated artifacts agree on entrypoint names.
 - `app/generated/_input.py` imports cleanly in the app's active environment.
 
-For toolkit repo changes under `contract-toolkit/`, use the toolkit validation
-commands from `contract-toolkit/AGENTS.md` and keep examples, tests, and docs in
-sync.
+For toolkit changes under `contract-toolkit/`, use the validation commands in
+`contract-toolkit/CLAUDE.md` and keep examples, tests, and docs in sync.
 
 ## Finish
 
 Summarize:
 
-- What contract source changed.
+- What contract source changed and which migrations were applied.
 - Which generated artifacts changed.
-- Which CLI validation and generation commands ran.
+- Which CLI/`pkl` validation and generation commands ran, and the `app_name`
+  invariant result.
+- The SDK/toolkit versions before and after, relative to the floor.
 - Any skipped validation and the concrete reason.

--- a/.claude/skills/make-contract/SKILL.md
+++ b/.claude/skills/make-contract/SKILL.md
@@ -26,8 +26,13 @@ authoritative sources in this repo instead of trusting any list baked below:
 - Changelog / when something changed: `contract-toolkit/CHANGELOG.md`.
 - The real example set: `git ls-files 'contract-toolkit/examples/*/app.pkl'`
   (untracked `generated/` and `__pycache__` leftover dirs are **not** examples).
-- Latest toolkit version: `git tag --list 'contract-toolkit-v*' | sort -V | tail -1`.
+- Latest toolkit version (bare semver, from the SDK checkout root):
+  `git tag --list 'contract-toolkit-v*' | sort -V | tail -1 | sed 's/^contract-toolkit-v//'`.
 - The template source of truth: `contract-toolkit/src/App.pkl`.
+
+These `contract-toolkit/...`, `git ls-files`, and `git tag` lookups only resolve
+from an `atlanhq/application-sdk` checkout — run them there (or `git -C
+<sdk-repo>`). From a consuming app repo they return nothing, silently.
 
 **`contract-toolkit/AGENTS.md` is stale** (still describes the pre-consolidation
 `NativeApp.pkl` world and references examples that no longer exist). Do not use
@@ -119,7 +124,7 @@ Route the app by what Discovery found:
 - **Archived toolkit source** — `PklProject` points at the old standalone
   toolkit URL (`package://atlanhq.github.io/app-contract-toolkit/...`) instead
   of the SDK-hosted one. Propose switching the URL and bumping the version.
-- **Below the version floor** — SDK `< 3.21.0` or toolkit `< 0.16.1`. Propose
+- **Below the version floor** — SDK `< 3.21.0` or toolkit `< 0.17.0`. Propose
   raising both (this is what keeps logs visible — see the `app_name` invariant).
 
 Migrations are opt-in and incremental. Detect, propose, get a yes, then apply
@@ -127,12 +132,12 @@ one at a time — never silently redesign.
 
 ## Version Floor (why it exists)
 
-**Enforce SDK `>= 3.21.0` and contract-toolkit `>= 0.16.1`.** Below this, an
+**Enforce SDK `>= 3.21.0` and contract-toolkit `>= 0.17.0`.** Below this, an
 app's failure logs can silently fail to surface in the Workflow Center. Hard-fail
 generation/validation guidance if the app is below the floor and the user has
 not explicitly opted to stay.
 
-Why 3.21.0 / 0.16.1 (not 3.18):
+Why 3.21.0 / 0.17.0 (not 3.18):
 
 - `app_name` is the app's **log-correlation identity**. Logs are *written*
   tagged with `app_name` = `ATLAN_APPLICATION_NAME` (from `atlan.yaml`). The UI
@@ -148,9 +153,9 @@ Why 3.21.0 / 0.16.1 (not 3.18):
   construction:
   - SDK `3.19.0` / toolkit `0.14.2` — core bake for `App.pkl` apps.
   - SDK `3.20.2` — output-path derivation prefers the resolved app name.
-  - SDK `3.21.0` / toolkit `0.16.1` — same bake applied to the legacy
+  - SDK `3.21.0` / toolkit `0.17.0` — same bake applied to the legacy
     `NativeApp.pkl` crossover template.
-- `3.21.0` / `0.16.1` is the single floor that covers both the `App.pkl` and
+- `3.21.0` / `0.17.0` is the single floor that covers both the `App.pkl` and
   `NativeApp.pkl` families. `3.18.0` carries none of these fixes.
 
 ## The `app_name` invariant (same name everywhere)
@@ -178,9 +183,9 @@ Verify after every generate:
 NAME=$(grep -E '^\s*name\s*=' contract/app.pkl | head -1 | sed -E 's/.*"([^"]+)".*/\1/')
 echo "contract name = $NAME"
 # No literal placeholder may survive in generated manifests (smoking gun):
-grep -rn '"{app_name}"' app/generated/ && echo "FAIL: unbaked placeholder — regenerate on toolkit >= 0.16.1"
+grep -rn '"{app_name}"' app/generated/ && echo "FAIL: unbaked placeholder — regenerate on toolkit >= 0.17.0"
 # Every baked app_name must equal $NAME:
-grep -rn '"app_name"' app/generated/**/manifest.json app/generated/manifest.json 2>/dev/null
+grep -rn '"app_name"' app/generated/ 2>/dev/null
 # atlan.yaml packaging name must equal $NAME:
 grep -rn "name" atlan.yaml app/generated/atlan.yaml 2>/dev/null
 # Generated filenames must be {name}.json / atlan-connectors-{name}.json:
@@ -207,15 +212,18 @@ dependencies {
 ```
 
 Prefer `atlan app contract update-toolkit -p . --version <LATEST>` if the CLI is
-available; it refreshes `PklProject.deps.json`. Get `<LATEST>` from
-`git tag --list 'contract-toolkit-v*' | sort -V | tail -1`.
+available; it refreshes `PklProject.deps.json`. Get the bare-semver `<LATEST>`
+(from the SDK checkout) with
+`git tag --list 'contract-toolkit-v*' | sort -V | tail -1 | sed 's/^contract-toolkit-v//'`.
 
 ### `NativeApp.pkl` / `NativeAppBundle.pkl` -> `App.pkl`
 
 - Change the amend line to `amends "@app-contract-toolkit/App.pkl"`.
-- Credential primitives (`CredentialInput`, `FieldSpec`, `AuthOption`,
-  `ConditionalFieldSpec`, `NamedWidget`, `NamedProperty`) are now defined in
-  `App.pkl` — they carry over by name, no separate import.
+- Credential field primitives (`FieldSpec`, `AuthOption`, `ConditionalFieldSpec`,
+  `NamedWidget`, `NamedProperty`) are now defined in `App.pkl`, and the
+  `Widgets.CredentialInput` widget is re-exported by it — all reachable by name,
+  no separate import. (`CredentialInput` is a `uiConfig` widget, not a credential
+  field entry — don't use it inside `credentialAuthOptions`.)
 - Widgets come from `Widgets.*` (re-exported by `App.pkl`); `Connectors.pkl`
   still needs an explicit `import`.
 - Single-entrypoint: leave `entrypoints` empty; set `uiConfig` + `pipeline`.
@@ -230,7 +238,7 @@ Confirm the exact current field names against `contract-toolkit/README.md` and
 
 ### Raise to the version floor
 
-Bump the SDK dependency to `>= 3.21.0` and the toolkit to `>= 0.16.1`, then
+Bump the SDK dependency to `>= 3.21.0` and the toolkit to `>= 0.17.0`, then
 regenerate so the manifest bakes a literal `app_name`. Re-run the `app_name`
 invariant checks.
 
@@ -316,9 +324,11 @@ Note each one's caveat — they are pattern references, not version references
   Caveat: still on legacy `NativeApp.pkl` and the archived toolkit URL — it is
   itself a migration candidate, so read it for the SQL/DAG patterns, not the
   primitive or the dependency URL.
-- **`atlanhq/atlan-metabase-app`** — best modern `App.pkl` multi-entrypoint +
-  REST auth + rich DAG. Caveat: uses the **deprecated** `emitEntrypoints = false`
-  single-card collapse — do not copy that; use per-entrypoint `packageId`.
+- **`atlanhq/atlan-metabase-app`** — best modern `App.pkl` reference: REST auth,
+  a rich multi-node DAG, and the correct "two code `@entrypoint`s, one marketplace
+  card" shape via single-entrypoint contract mode (no `entrypoints` listing, so
+  the `marketplaceCard` default applies). It has already migrated off the
+  deprecated `emitEntrypoints = false` workaround — copy this pattern, not that.
 - **`atlanhq/atlan-openapi-app`** — URL-vs-cloud import modes plus an app-owned
   external object-store credential contract (a `Credential.pkl` amend). Caveat:
   task-only (no DAG/publish) and on an older toolkit.
@@ -338,7 +348,7 @@ Direct `pkl` fallback (what this repo guarantees):
 
 ```bash
 pkl project resolve contract
-pkl eval -m app/generated contract/app.pkl   # from the app root
+pkl eval -m . contract/app.pkl   # from the app root; -m . matches the contract's own output paths
 ```
 
 Then verify generated output and invariants:
@@ -346,7 +356,7 @@ Then verify generated output and invariants:
 ```bash
 ls app/generated
 python -m py_compile app/generated/_input.py
-ruby -rjson -e 'ARGV.each { |f| JSON.parse(File.read(f)); puts "OK #{f}" }' app/generated/*.json
+find app/generated -name '*.json' -print0 | xargs -0 -I{} python -c 'import json,sys; json.load(open(sys.argv[1])); print("OK", sys.argv[1])' {}
 ```
 
 - Generated JSON filenames match the contract `name`.

--- a/.claude/skills/make-contract/SKILL.md
+++ b/.claude/skills/make-contract/SKILL.md
@@ -1,153 +1,266 @@
 ---
 name: make-contract
-description: Create, migrate, update, generate, or validate Atlan native app Pkl contracts with app-contract-toolkit and the Atlan CLI. Use when an agent is helping an app author produce contract/app.pkl, contract/PklProject, app/generated artifacts, atlan.yaml decisions, SDK input contracts, and contract validation.
+description: Create, migrate, update, generate, or validate an Atlan native app Pkl contract with app-contract-toolkit and the Atlan CLI. Use when helping an app author produce contract/app.pkl, contract/PklProject, app/generated artifacts, atlan.yaml decisions, and SDK input contracts — including migrating a legacy app onto the canonical App.pkl template, moving it off the archived toolkit repo, and raising it to the SDK floor that keeps its logs visible.
 ---
 
 # make-contract
 
 Use this skill when the user asks to create, migrate, update, generate, or
-validate an Atlan native app contract. The goal is to produce a correct Pkl
-contract and regenerated SDK artifacts, not to hand-edit generated JSON.
+validate an Atlan native app contract. The goal is a correct Pkl contract and
+regenerated SDK artifacts — never hand-edited generated JSON.
+
+This skill is **adaptive and incremental**. You inspect the app you are running
+in, classify what shape it is already in, propose a small plan, ask only
+blocking questions, then apply and verify one step at a time. You do not force a
+redesign on an app that does not need one.
+
+## Ground yourself in live sources first — do not trust memory or this file's snapshots
+
+The toolkit moves. Earlier versions of this skill went stale because they
+hard-coded facts (which primitive to amend, the example list, a version-lookup
+recipe) that later changed. **Derive volatile facts at runtime** from the
+authoritative sources in this repo instead of trusting any list baked below:
+
+- Primitive model, widgets, credential shapes, migration notes:
+  `contract-toolkit/README.md` and `contract-toolkit/CLAUDE.md` are current.
+- Changelog / when something changed: `contract-toolkit/CHANGELOG.md`.
+- The real example set: `git ls-files 'contract-toolkit/examples/*/app.pkl'`
+  (untracked `generated/` and `__pycache__` leftover dirs are **not** examples).
+- Latest toolkit version: `git tag --list 'contract-toolkit-v*' | sort -V | tail -1`.
+- The template source of truth: `contract-toolkit/src/App.pkl`.
+
+**`contract-toolkit/AGENTS.md` is stale** (still describes the pre-consolidation
+`NativeApp.pkl` world and references examples that no longer exist). Do not use
+it as the source of truth; trust `README.md` + `CLAUDE.md` + `CHANGELOG.md` +
+`src/App.pkl`.
 
 ## Hard Rules
 
 - Treat `atlanhq/application-sdk` as the canonical source for this skill. The
   repo-local copies live at `.agents/skills/make-contract/SKILL.md` and
-  `.claude/skills/make-contract/SKILL.md`; mirror any edits between them and do
-  not add nested `make-contract` skill copies under `contract-toolkit/` or app
-  repos.
+  `.claude/skills/make-contract/SKILL.md`; mirror any edit between them
+  byte-for-byte, and do not add nested `make-contract` copies under
+  `contract-toolkit/` or app repos.
+- **`App.pkl` is the canonical template. `NativeApp.pkl` and
+  `NativeAppBundle.pkl` are frozen legacy.** Author every new contract by
+  amending `App.pkl`. Only touch the legacy modules when reading an app that
+  still uses them (to migrate it, or to preserve it when the user declines).
 - Use the Atlan CLI contract commands first. Fall back to direct `pkl` commands
-  only when the CLI is missing, too old, or cannot support the requested change.
-- Do not expose internal service, repository, or implementation details in
-  generated guidance, examples, comments, or docs.
+  when the CLI is missing, too old, or cannot support the requested change.
 - Do not hand-edit generated files under `app/generated/` except to inspect or
-  compare output. Fix `contract/app.pkl`, then regenerate.
-- Keep examples public and generic. Prefer examples in this SDK repo under
-  `contract-toolkit/examples/`.
-- Preserve existing app behavior unless the user explicitly asks for a contract
-  redesign.
+  compare. Fix `contract/app.pkl`, then regenerate.
+- Keep examples public and generic. Prefer the tracked examples under
+  `contract-toolkit/examples/`; test-only scenarios live under
+  `contract-toolkit/tests/fixtures/`.
+- Preserve existing app behavior unless the user explicitly asks for a redesign.
 - Never put secrets, real tokens, passwords, or tenant-specific data in
-  contracts, examples, generated artifacts, or validation notes.
+  contracts, examples, generated artifacts, or notes.
 
-## Agent Workflow for App Authors
+## Adaptive Workflow
 
-Most users are not asking for a PKL lecture; they are asking the agent to get a
-working contract into their app. Work in this order:
+Work in this loop. Keep the main thread short; state a plan before you edit.
 
-1. Inspect the repo and infer the app shape before asking questions.
-2. State the inferred contract plan in plain terms: app type, generated path,
-   credential form, workflow setup fields, DAG shape, publish behavior, and
-   `atlan.yaml` ownership.
-3. Ask only blocking questions, usually no more than three at a time. Prefer
-   concrete choices with a recommended default over broad open-ended prompts.
-4. Implement in `contract/app.pkl` and `contract/PklProject`, then regenerate.
-5. Verify the generated value flow from workflow config to manifest to
-   `_input.py` to runtime expectations.
-6. Finish with changed source files, generated artifacts, validation commands,
-   and any assumptions or skipped checks.
+1. **Detect** the app you are in (Discovery below).
+2. **Classify** its rollout bucket (Classification below) — fresh, legacy
+   primitive, archived toolkit source, or below the version floor. An app can be
+   in several buckets at once.
+3. **State the plan** in plain terms: app type, primitive, single- vs
+   multi-entrypoint, credential form, DAG/publish, generated path, `atlan.yaml`
+   ownership, and which migrations (if any) apply. Name the version floor and
+   whether the app clears it.
+4. **Ask only blocking questions** — usually no more than three at a time, with
+   concrete choices and a recommended default. Ask only where local repo
+   evidence cannot settle a behavior-preserving choice.
+5. **Apply one step at a time** in `contract/app.pkl` / `contract/PklProject`,
+   then regenerate.
+6. **Verify** the value flow and the `app_name` invariant (below).
+7. **Finish** with changed source files, generated artifacts, validation
+   commands run, and any assumption or skipped check.
 
 When the user is unsure, choose the simplest behavior-preserving contract:
-single entrypoint, `contract/app.pkl`, generated output in `app/generated`, root
-`atlan.yaml` as the packaging source of truth, and default `extract -> publish`
-only for asset-producing connectors.
+single entrypoint, `contract/app.pkl` amending `App.pkl`, generated output in
+`app/generated`, root `atlan.yaml` as packaging source of truth, and default
+`extract -> publish` only for asset-producing connectors.
 
-## Expected Layout
-
-For a normal single-entrypoint app:
-
-```text
-contract/
-|-- PklProject
-|-- PklProject.deps.json
-`-- app.pkl
-app/generated/
-|-- __init__.py
-|-- _input.py
-|-- {name}.json
-|-- atlan-connectors-{name}.json
-`-- manifest.json
-```
-
-Bundle contracts can also render `app/generated/atlan.yaml` and per-entrypoint
-folders. The root `atlan.yaml` in the app repo remains the packaging source of
-truth unless the app has an explicit sync step.
-
-## CLI Commands
-
-Check the installed CLI before making assumptions:
-
-```bash
-command -v atlan
-atlan app contract --help
-atlan app contract init --help
-atlan app contract generate --help
-atlan app contract validate --help
-atlan app contract update-toolkit --help
-```
-
-Common commands:
-
-```bash
-# Create a new contract scaffold in an app repo.
-atlan app contract init <app-name> -p <app-dir> -c <connector-name>
-
-# Validate Pkl without writing generated artifacts.
-atlan app contract validate -p <app-dir>
-
-# Generate app/generated artifacts from contract/app.pkl.
-atlan app contract generate -p <app-dir>
-
-# Update the toolkit dependency and refresh PklProject.deps.json.
-atlan app contract update-toolkit -p <app-dir>
-atlan app contract update-toolkit -p <app-dir> --version <semver>
-```
-
-The toolkit package is named `app-contract-toolkit`, but latest-version lookup
-must come from the SDK repo releases, not the old standalone toolkit repo:
-
-```bash
-gh release list --repo atlanhq/application-sdk --limit 50 --json tagName --jq '[.[] | select(.tagName | startswith("contract-toolkit-v"))][0].tagName | sub("^contract-toolkit-v"; "")'
-```
-
-If the CLI cannot be used, say why and use the smallest fallback:
-
-```bash
-pkl project resolve <app-dir>/contract
-pkl eval -m <app-dir>/app/generated <app-dir>/contract/app.pkl
-```
-
-If editing `contract/PklProject` manually, use the SDK-hosted package URL:
-
-```pkl
-dependencies {
-  ["app-contract-toolkit"] {
-    uri = "package://atlanhq.github.io/application-sdk/contracts/app-contract-toolkit@<VERSION>"
-  }
-}
-```
-
-## Discovery Checklist
+## Discovery
 
 Before editing, inspect the app shape:
 
 ```bash
 git status --short --branch
-find . -maxdepth 3 -name app.pkl -o -name PklProject -o -name atlan.yaml
-rg -n "ATLAN_CONTRACT_GENERATED_DIR|app/generated|contract/generated|AppInputContract|ExtractionInput|CredentialInput|workflowType|workflow_type|manifest.json"
-rg -n "get_configmap|get_manifest|/workflows/v1/configmap|/manifest" app application_sdk tests
+find . -maxdepth 3 \( -name app.pkl -o -name PklProject -o -name atlan.yaml \)
+# Which primitive does the contract amend?
+grep -rn "amends" contract/*.pkl 2>/dev/null
+# Toolkit dependency + URL
+grep -rn "app-contract-toolkit" contract/PklProject contract/PklProject.deps.json 2>/dev/null
+# SDK version the app pins
+grep -REh "atlan-application-sdk" pyproject.toml uv.lock requirements*.txt 2>/dev/null | head
+# Runtime wiring
+rg -n "ATLAN_CONTRACT_GENERATED_DIR|app/generated|AppInputContract|@entrypoint|@task|workflowType|manifest.json"
 ```
 
-Also check:
+Also answer:
 
-- Is this a new contract or migration from existing templates?
-- Is it single-entrypoint or bundle-shaped?
+- New contract, or migration from an existing one?
+- Single-entrypoint or multi-entrypoint/bundle?
 - Which generated directory does the app actually serve?
-- Is root `atlan.yaml` already present and intentionally maintained?
-- Does the app need credential config, preflight, publish controls, connection
+- Is root `atlan.yaml` present and intentionally maintained?
+- Does it need credential config, preflight, publish controls, connection
   reference, multiple auth modes, or custom runtime steps?
 
-Ask the user only when local repo evidence cannot answer a behavior-preserving
-choice.
+## Classification (rollout buckets)
+
+Route the app by what Discovery found:
+
+- **Fresh** — no contract yet, or already amends `App.pkl` on a current toolkit
+  and clears the version floor. Author/edit directly; no migration.
+- **Legacy primitive** — `contract/app.pkl` amends `NativeApp.pkl` or
+  `NativeAppBundle.pkl`. Propose migration to `App.pkl` (see Migrations).
+- **Archived toolkit source** — `PklProject` points at the old standalone
+  toolkit URL (`package://atlanhq.github.io/app-contract-toolkit/...`) instead
+  of the SDK-hosted one. Propose switching the URL and bumping the version.
+- **Below the version floor** — SDK `< 3.21.0` or toolkit `< 0.16.1`. Propose
+  raising both (this is what keeps logs visible — see the `app_name` invariant).
+
+Migrations are opt-in and incremental. Detect, propose, get a yes, then apply
+one at a time — never silently redesign.
+
+## Version Floor (why it exists)
+
+**Enforce SDK `>= 3.21.0` and contract-toolkit `>= 0.16.1`.** Below this, an
+app's failure logs can silently fail to surface in the Workflow Center. Hard-fail
+generation/validation guidance if the app is below the floor and the user has
+not explicitly opted to stay.
+
+Why 3.21.0 / 0.16.1 (not 3.18):
+
+- `app_name` is the app's **log-correlation identity**. Logs are *written*
+  tagged with `app_name` = `ATLAN_APPLICATION_NAME` (from `atlan.yaml`). The UI
+  *reads* logs back by filtering on the `app_name` value baked into the served
+  manifest.
+- Pre-fix, the manifest shipped a literal `"{app_name}"` placeholder that the
+  SDK substituted **at serve time from the runtime class name** (`GlueApp` ->
+  `glue-app`), not the contract `name` (`glue`). Write-identity != read-identity
+  -> the log query matches zero rows -> the panel shows "no logs" though logging
+  worked. This is the failure signature the fix addresses.
+- The fix bakes `app_name` from the contract `name` **at generate time** and
+  removes the runtime placeholder, so read-identity equals write-identity by
+  construction:
+  - SDK `3.19.0` / toolkit `0.14.2` — core bake for `App.pkl` apps.
+  - SDK `3.20.2` — output-path derivation prefers the resolved app name.
+  - SDK `3.21.0` / toolkit `0.16.1` — same bake applied to the legacy
+    `NativeApp.pkl` crossover template.
+- `3.21.0` / `0.16.1` is the single floor that covers both the `App.pkl` and
+  `NativeApp.pkl` families. `3.18.0` carries none of these fixes.
+
+## The `app_name` invariant (same name everywhere)
+
+The contract `name` (kebab-case) is the single root identity. The toolkit
+derives everything from it, and every surface must stay byte-identical:
+
+| Surface | Must equal |
+|---|---|
+| contract `name` in `contract/app.pkl` | the root value |
+| generated `{name}.json` and `atlan-connectors-{name}.json` filenames | `name` |
+| manifest `app_name` (top-level and `inputs.app_name`) | `name` |
+| task-queue prefix `atlan-{name}-...` | `name` |
+| `atlan.yaml` app name -> `ATLAN_APPLICATION_NAME` -> the log tag | `name` |
+| runtime app identity (`_app_name` / resolved app name) | `name` |
+
+If `atlan.yaml` name diverges from the contract `name`, the log write-tag and
+the manifest read-filter disagree and **logs stop surfacing**. Fix the divergent
+surface to match the intended kebab-case identity — correct `contract/app.pkl`
+`name` or `atlan.yaml`, never hand-edit `app/generated/`.
+
+Verify after every generate:
+
+```bash
+NAME=$(grep -E '^\s*name\s*=' contract/app.pkl | head -1 | sed -E 's/.*"([^"]+)".*/\1/')
+echo "contract name = $NAME"
+# No literal placeholder may survive in generated manifests (smoking gun):
+grep -rn '"{app_name}"' app/generated/ && echo "FAIL: unbaked placeholder — regenerate on toolkit >= 0.16.1"
+# Every baked app_name must equal $NAME:
+grep -rn '"app_name"' app/generated/**/manifest.json app/generated/manifest.json 2>/dev/null
+# atlan.yaml packaging name must equal $NAME:
+grep -rn "name" atlan.yaml app/generated/atlan.yaml 2>/dev/null
+# Generated filenames must be {name}.json / atlan-connectors-{name}.json:
+ls app/generated | grep -E "^(${NAME}|atlan-connectors-${NAME})\.json$"
+```
+
+## Migrations
+
+Each migration is small and mechanical. Propose, confirm, apply, regenerate,
+verify.
+
+### Archived toolkit URL -> SDK-hosted package
+
+The toolkit was once a standalone repo. It is now hosted from the SDK repo. If
+`contract/PklProject` points at the old standalone URL, switch it and pin the
+latest version:
+
+```pkl
+dependencies {
+  ["app-contract-toolkit"] {
+    uri = "package://atlanhq.github.io/application-sdk/contracts/app-contract-toolkit@<LATEST>"
+  }
+}
+```
+
+Prefer `atlan app contract update-toolkit -p . --version <LATEST>` if the CLI is
+available; it refreshes `PklProject.deps.json`. Get `<LATEST>` from
+`git tag --list 'contract-toolkit-v*' | sort -V | tail -1`.
+
+### `NativeApp.pkl` / `NativeAppBundle.pkl` -> `App.pkl`
+
+- Change the amend line to `amends "@app-contract-toolkit/App.pkl"`.
+- Credential primitives (`CredentialInput`, `FieldSpec`, `AuthOption`,
+  `ConditionalFieldSpec`, `NamedWidget`, `NamedProperty`) are now defined in
+  `App.pkl` — they carry over by name, no separate import.
+- Widgets come from `Widgets.*` (re-exported by `App.pkl`); `Connectors.pkl`
+  still needs an explicit `import`.
+- Single-entrypoint: leave `entrypoints` empty; set `uiConfig` + `pipeline`.
+  `App.pkl` synthesises the implicit entrypoint.
+- Multi-entrypoint / bundle: replace the `NativeAppBundle.pkl` root plus N
+  `NativeApp.pkl` per-entrypoint contracts with one `App.pkl` root that
+  populates `entrypoints`, each pointing at a per-entrypoint contract that also
+  amends `App.pkl`.
+
+Confirm the exact current field names against `contract-toolkit/README.md` and
+`src/App.pkl` before writing — do not trust this summary over the live source.
+
+### Raise to the version floor
+
+Bump the SDK dependency to `>= 3.21.0` and the toolkit to `>= 0.16.1`, then
+regenerate so the manifest bakes a literal `app_name`. Re-run the `app_name`
+invariant checks.
+
+## Primitive Model (App.pkl)
+
+- One `amends "@app-contract-toolkit/App.pkl"` line is all any contract needs.
+- **Single- vs multi-entrypoint is `entrypoints` empty vs populated** — not two
+  different modules.
+- Marketplace-card presence: single-entrypoint uses `marketplaceCard: Boolean`;
+  multi-entrypoint controls each card via the entrypoint's `packageId` (set it
+  to make the entrypoint a card; omit to keep it routable-only).
+- `emitEntrypoints` is **deprecated** and slated for removal — do not adopt it in
+  new work; use per-entrypoint `packageId` instead. (An existing app that sets it
+  is a pattern to migrate off, not to copy.)
+- Keep `flatManifestArgs = true` unless an existing app intentionally reads
+  metadata-wrapped args; changing it changes the runtime payload shape — call it
+  out.
+
+Prefer typed toolkit APIs over raw JSON: typed widgets from `Widgets.*`, typed
+credential primitives from `App.pkl`, `Connectors.pkl` constants, SQL/JDBC
+helpers (`JDBCUrlAuthOption`, `AdvancedJDBCUrlGroup`, `SqlTree`), and runtime
+graph nodes (`PublishNode`, `QueryIntelligenceNode`, `PopularityNode`,
+`LineageNode`, `LineagePublishNode`), dropping to raw `DAGNode` only when a typed
+node does not fit.
+
+> **FileReference and App.upload():** If your contract carries a `FileReference`
+> that must reach a downstream Atlan system app (publish, lineage, quality), the
+> connector must call `App.upload()` explicitly from `run()` — the task-to-task
+> activity interceptor only writes to the customer-owned `objectstore`. See
+> [ADR-0014](../../../docs/adr/0014-two-store-storage-architecture.md).
 
 ## Value-Flow Rules
 
@@ -160,88 +273,75 @@ credential field -> credential config -> workflow credential reference -> runtim
 DAG node id -> dependency condition -> manifest node -> runtime workflow/activity
 ```
 
-Rules for stable contracts:
+- Prefer typed properties over arbitrary string keys; use a node's typed
+  property instead of `extraArgs` or raw `DAGNode.args`.
+- Do not expose a runtime default as a setup field just to pass the same value
+  through; omit it and let the runtime own its default.
+- Placeholders must be exact workflow field names like `"{{include-filter}}"`;
+  no dotted placeholders unless the consuming runtime supports them.
+- Every manifest placeholder must have a matching workflow/credential field, or
+  be intentionally supplied by the SDK/runtime and documented in the final note.
+- Boolean and numeric controls use typed widgets and typed node properties —
+  avoid stringly-typed contracts a user can typo into a runtime-only failure.
 
-- Prefer typed properties over arbitrary string keys. If a node has a typed
-  property, use it instead of `extraArgs` or raw `DAGNode.args`.
-- Do not expose runtime defaults as setup fields just to pass through the same
-  value. Omit them and let the runtime app own its defaults.
-- Placeholders must be exact workflow field names like `"{{include-filter}}"`.
-  Do not use dotted placeholders unless the consuming runtime explicitly
-  supports them.
-- Every manifest placeholder must have a matching workflow or credential field,
-  or be intentionally supplied by the SDK/Heracles/runtime and documented in the
-  final note.
-- Boolean and numeric controls should use typed widgets and typed node
-  properties. Avoid “stringly typed” contracts where the user can typo a key and
-  only discover it at runtime.
-- Keep user-facing labels clear and app-author friendly. Avoid exposing internal
-  system names unless they are the stable public contract.
+## Examples (derive the current set at runtime)
 
-## Authoring Rules
+The tracked examples all amend `App.pkl` and are the public reference. **List
+them live** — do not trust a baked list:
 
-> **FileReference and App.upload():** If your contract carries a `FileReference` that must
-> reach a downstream Atlan system app (publish, lineage, quality), the connector must call
-> `App.upload()` explicitly from `run()` — the task-to-task activity interceptor only writes
-> to the customer-owned `objectstore`. See
-> [ADR-0014](../../docs/adr/0014-two-store-storage-architecture.md).
+```bash
+git ls-files 'contract-toolkit/examples/*/app.pkl' | sed 's#.*/examples/##;s#/app.pkl##'
+```
 
-Prefer typed toolkit APIs over raw JSON:
+At the time of writing the tracked set is: `minimal` (smallest contract, start
+here), `full` (every overridable feature), `bundle` (multi-entrypoint), `card-split`
+(multi-entrypoint where only one entrypoint is a card), `connection-ref`
+(ConnectionRefInput), `publish-controls` (publish toggles), `fanin` (fan-in via
+`dependsOn`), `deploy` (single-pool KEDA/resources), `pools` (named worker
+pools), `scheduled` (cron background job), `behind-the-scenes`
+(`marketplaceCard = false`), `agent-e2e` (agent-mode codegen). Re-run the command
+above to catch additions or removals.
 
-- `NativeApp.pkl` for standard single-entrypoint contracts.
-- `NativeAppBundle.pkl` for apps with multiple entrypoints.
-- `Config.pkl` widgets for workflow form fields.
-- `Connectors.pkl` constants where available.
-- Native credentials from `NativeApp.pkl`: `CredentialInput`, `FieldSpec`,
-  `AuthOption`, `ConditionalFieldSpec`, `NamedWidget`, and `NamedProperty`.
-- SQL/JDBC helpers where applicable: `JDBCUrlAuthOption`,
-  `AdvancedJDBCUrlGroup`, `SqlTree`, and related filter widgets.
-- Runtime graph helpers where applicable: `PublishNode`,
-  `QueryIntelligenceNode`, `PopularityNode`, `LineageNode`,
-  `LineagePublishNode`, then raw `DAGNode` only when typed nodes do not fit.
+Node-specific coverage (popularity, query-intelligence placeholders) lives in
+`contract-toolkit/tests/fixtures/*.pkl`, not in `examples/`.
 
-Do not use legacy credential modules for new native credentials unless preserving
-an existing contract requires it.
+## Canonical Apps (public first-party references)
 
-Keep `flatManifestArgs = true` unless an existing app intentionally reads
-metadata-wrapped args. If changing this, call it out explicitly because it
-changes the runtime payload shape.
+When you need a real, end-to-end reference, inspect these public connector apps.
+Note each one's caveat — they are pattern references, not version references
+(none is on the current floor yet):
 
-## Public Examples
-
-Use the curated open-source examples in this repo. They are intentionally
-generic and stable; app-specific wiring examples should live with sample apps or
-the owning app repo, and test-only scenarios should live under
-`contract-toolkit/tests/fixtures`.
-
-- `contract-toolkit/examples/connection-ref`: selected connection object input.
-- `contract-toolkit/examples/fanin`: dependency and fan-in graph behavior.
-- `contract-toolkit/examples/openapi`: URL/cloud modes and extra credential
-  output.
-- `contract-toolkit/examples/postgres`: basic SQL/JDBC datasource.
-- `contract-toolkit/examples/publish-controls`: publish toggle behavior.
-- `contract-toolkit/examples/trino`: multi-catalog SQL tree and auth options.
-
-For node-specific or app-wiring coverage, inspect fixtures instead of copying a
-real app contract into public examples:
-
-- `contract-toolkit/tests/fixtures/popularity_default.pkl`
-- `contract-toolkit/tests/fixtures/popularity_dynamic_overrides.pkl`
-- `contract-toolkit/tests/fixtures/qi_node_placeholders.pkl`
-
-Do not point users at private app repos or internal consumer repos from this
-skill.
+- **`atlanhq/atlan-mysql-app`** — canonical SQL/JDBC single-entrypoint with
+  multi-mode auth (basic + IAM user + IAM role) and a full lineage-publish DAG.
+  Caveat: still on legacy `NativeApp.pkl` and the archived toolkit URL — it is
+  itself a migration candidate, so read it for the SQL/DAG patterns, not the
+  primitive or the dependency URL.
+- **`atlanhq/atlan-metabase-app`** — best modern `App.pkl` multi-entrypoint +
+  REST auth + rich DAG. Caveat: uses the **deprecated** `emitEntrypoints = false`
+  single-card collapse — do not copy that; use per-entrypoint `packageId`.
+- **`atlanhq/atlan-openapi-app`** — URL-vs-cloud import modes plus an app-owned
+  external object-store credential contract (a `Credential.pkl` amend). Caveat:
+  task-only (no DAG/publish) and on an older toolkit.
 
 ## Validation
 
-For app repos, run the CLI validation and generation:
+Prefer the Atlan CLI (external tool — check it first, it is not defined in this
+repo, so confirm the current flags with `--help` rather than assuming):
 
 ```bash
+command -v atlan && atlan app contract --help
 atlan app contract validate -p .
 atlan app contract generate -p .
 ```
 
-Then verify generated output:
+Direct `pkl` fallback (what this repo guarantees):
+
+```bash
+pkl project resolve contract
+pkl eval -m app/generated contract/app.pkl   # from the app root
+```
+
+Then verify generated output and invariants:
 
 ```bash
 ls app/generated
@@ -249,26 +349,27 @@ python -m py_compile app/generated/_input.py
 ruby -rjson -e 'ARGV.each { |f| JSON.parse(File.read(f)); puts "OK #{f}" }' app/generated/*.json
 ```
 
-Check contract-specific invariants before finishing:
-
 - Generated JSON filenames match the contract `name`.
+- No `"{app_name}"` literal survives in `app/generated/`, and every baked
+  `app_name` plus the `atlan.yaml` name equals the contract `name`.
 - `manifest.json` placeholders match fields emitted by workflow and credential
   config.
-- Credential config name matches the credential input type used by the workflow.
-- SQL tree credential type and credential field names line up.
+- Credential config name matches the credential input type the workflow uses.
+- SQL tree credential type and field names line up.
 - Optional publish controls match the app's expected output behavior.
 - Root `atlan.yaml` and generated artifacts agree on entrypoint names.
 - `app/generated/_input.py` imports cleanly in the app's active environment.
 
-For toolkit repo changes under `contract-toolkit/`, use the toolkit validation
-commands from `contract-toolkit/AGENTS.md` and keep examples, tests, and docs in
-sync.
+For toolkit changes under `contract-toolkit/`, use the validation commands in
+`contract-toolkit/CLAUDE.md` and keep examples, tests, and docs in sync.
 
 ## Finish
 
 Summarize:
 
-- What contract source changed.
+- What contract source changed and which migrations were applied.
 - Which generated artifacts changed.
-- Which CLI validation and generation commands ran.
+- Which CLI/`pkl` validation and generation commands ran, and the `app_name`
+  invariant result.
+- The SDK/toolkit versions before and after, relative to the floor.
 - Any skipped validation and the concrete reason.


### PR DESCRIPTION
TL;DR: the make-contract skill had drifted stale. It still told agents to author with `NativeApp.pkl`, pointed at examples that no longer exist, shipped a version-lookup command that returns nothing, and named a version floor that carries none of the fixes it claimed. This rewrites it into an adaptive skill that detects the app it's in, migrates legacy shapes forward, and enforces the floor that actually keeps an app's logs visible.

### Why
The skill was originally derived from `contract-toolkit/AGENTS.md`, which is itself stale (pre-`App.pkl` consolidation). So its core guidance had gone wrong on several axes at once, and the two mirror copies (`.claude/` and `.agents/`) had drifted apart.

### What changed
- **`App.pkl` is now canonical.** Since toolkit 0.10.0 the `NativeApp.pkl` / `NativeAppBundle.pkl` pair is frozen legacy. Rewrote the authoring and primitive guidance around `App.pkl`: single- vs multi-entrypoint is now `entrypoints` empty vs populated, credential primitives + widgets come from `App.pkl`/`Widgets.*`, `emitEntrypoints` is flagged deprecated.
- **Adaptive workflow.** Detect the app → classify (fresh / legacy primitive / archived toolkit URL / below floor) → propose a plan → ask only blocking questions → apply one step at a time → verify.
- **Migrations.** Archived standalone toolkit URL → SDK-hosted package; `NativeApp`/`NativeAppBundle` → `App.pkl`; version bump to the floor.
- **`app_name` / log-visibility.** Documented the substitution bug: logs are written tagged from `atlan.yaml`, but the UI reads them via the manifest `app_name`, which pre-fix was filled at serve time from the runtime class name — mismatch means zero matches and a "no logs" panel. Added the cross-surface consistency table and verify commands. Floor is **SDK >=3.21.0 / toolkit >=0.16.1** (3.18 has none of the fixes; 3.19/3.20.2/3.21 land them incrementally).
- **Self-refreshing.** The skill now derives volatile facts at runtime — the example set via `git ls-files`, the latest toolkit version via `git tag` — instead of hard-coding them, so it can't rot the same way.
- **Fixed broken facts.** The example list named phantom dirs (`openapi`/`postgres`/`trino` are untracked `generated/` leftovers, not examples); the `gh release list` version lookup returns empty (toolkit versions are git tags, not GitHub releases); a broken ADR-0014 relative link (`../../` → `../../../`).
- **Flagged `contract-toolkit/AGENTS.md` as stale** so future edits don't re-import the drift.
- **Canonical app references** (`atlan-mysql-app`, `atlan-metabase-app`, `atlan-openapi-app`) with per-app caveats (mysql is itself a migration candidate; metabase uses the deprecated `emitEntrypoints`; openapi is task-only on an older toolkit).
- **Re-synced the two mirror copies** — now byte-identical.

Docs-only change to the skill file; no code or generated artifacts touched.
