### PR TITLE
ci: install coverage transiently in connector-unit-tests action

### DIFF
--- a/.github/actions/connector-unit-tests/action.yaml
+++ b/.github/actions/connector-unit-tests/action.yaml
@@ -84,7 +84,12 @@ runs:
       run: |
         set +e
         mkdir -p results
-        uv run coverage run -m pytest tests/unit -v \
+        # `coverage` is installed transiently via `uv run --with` so callers do
+        # not need to declare it as a dependency — the same pattern the
+        # connector-integration-tests action uses for pytest-cov/pytest-xdist.
+        # The `.coverage` data file persists in the cwd between invocations, so
+        # the later xml/json/html/report calls read the same run's data.
+        uv run --with coverage coverage run -m pytest tests/unit -v \
           --junit-xml=results/test-results.xml 2>&1 | tee /tmp/unit-test-output.txt
         TEST_EXIT_CODE=${PIPESTATUS[0]}
         set -e
@@ -95,12 +100,12 @@ runs:
         # is the machine-readable form the test-readiness scorecard reads (the
         # aggregation job feeds it as --unit-coverage); xml/html stay for humans
         # and the PR coverage comment.
-        uv run coverage xml --fail-under=0 || true
-        uv run coverage json --fail-under=0 || true
-        uv run coverage html --fail-under=0 || true
+        uv run --with coverage coverage xml --fail-under=0 || true
+        uv run --with coverage coverage json --fail-under=0 || true
+        uv run --with coverage coverage html --fail-under=0 || true
         # Propagate pytest failure first; otherwise check coverage threshold.
         if [ $TEST_EXIT_CODE -ne 0 ]; then exit $TEST_EXIT_CODE; fi
-        uv run coverage report --fail-under=${{ inputs.fail-under }}
+        uv run --with coverage coverage report --fail-under=${{ inputs.fail-under }}
 
     - name: Comment coverage on PR
       if: github.event_name == 'pull_request'


### PR DESCRIPTION
## What

The `connector-unit-tests` composite action ran `uv run coverage run -m pytest` (and follow-up `coverage xml/json/html/report`) directly, but connector apps (e.g. `atlan-hello-world-app`) do not declare `coverage` as a dependency. So the `coverage` executable was absent from the app's venv and the unit job failed with:

```
error: Failed to spawn: `coverage`
  Caused by: No such file or directory (os error 2)
```

Example failing run: https://github.com/atlanhq/atlan-hello-world-app/actions/runs/29994302795/job/89232243794

## Root cause

This surfaced with the unit/integration test-tier split: the unit tier moved to a `coverage run` + `coverage xml/json/html/report` flow (to emit `coverage.json` for the test-readiness scorecard), which needs the `coverage` CLI directly rather than pytest-cov's `--cov` flag.

## Fix

Install `coverage` transiently via `uv run --with coverage` on every coverage invocation, mirroring how the sibling `connector-integration-tests` action already installs `pytest-cov`/`pytest-xdist`/`pytest-rerunfailures`. The `.coverage` data file persists in the cwd between invocations, so the xml/json/html/report calls read the same run's data. Callers need no dependency changes.

## Scope / audit

- **`connector-integration-tests`** — not affected: already installs its coverage tooling transiently (`uv run --with pytest-cov ...`).
- **scorecard aggregation job** — not affected: uses `uvx atlan-application-sdk-conformance` (self-contained) and is non-blocking.
- **`unit-tests`** (application-sdk's own suite) — not affected: this repo declares `coverage` in its dev dependencies.

## Testing

- `uv run pre-commit run --files .github/actions/connector-unit-tests/action.yaml` passes.
- YAML validates.
- Effect takes hold once merged to `main` (connector apps reference the action `@main`); re-running any connector's unit job then picks it up.

Linear: BLDX-1577