### PR TITLE
feat(contract-toolkit): manifestStaticArgs — static literal DAG args (DISTR-844)

### DIFF
--- a/contract-toolkit/src/App.pkl
+++ b/contract-toolkit/src/App.pkl
@@ -383,6 +383,16 @@ manifestTopLevelArgs: Mapping<String, String> = new Mapping {
   ["connection"] = "connection"
 }
 
+/// Static literal args merged verbatim into the extract node's `inputs.args`.
+/// Unlike form-field args (rendered as `{{placeholder}}` and resolved per request),
+/// these are constants baked into the DAG — for config a workflow needs at dispatch
+/// that has no request context and isn't a credential or form field (e.g. an
+/// event-driven drain's `iceberg_table_name`, mirroring the AE bootstrap DAG it
+/// replaces). Emitted as-is; a reconciler (Local Marketplace) preserves them because
+/// they carry no `{{...}}` placeholder to strip. Keys must not collide with the
+/// credential/agent/form-field arg names.
+manifestStaticArgs: Mapping<String, Any> = new Mapping {}
+
 // ── PIPELINE ─────────────────────────────────────────────────────────────────
 
 /// Typed orchestration pipeline for the AE manifest.
@@ -2534,6 +2544,11 @@ local function generateExtractNode(): Mapping<String, Any> =
       ["argo_workflow_slug"] = ""
       ["task_queue"] = "\(taskQueuePrefix)-{deployment_name}"
       ["args"] = new Mapping {
+        // Static literal args (e.g. an event drain's iceberg_table_name) — constants
+        // baked into the DAG, no placeholder, so a reconciler keeps them verbatim.
+        for (staticKey, staticVal in manifestStaticArgs) {
+          [staticKey] = staticVal
+        }
         ["credential"] = "{{credential}}"
         // SDR / agent-mode credential slot. Emitted whenever the app does not
         // model `agent-json` — the gap that silently broke MSSQL's SDR rollout

--- a/contract-toolkit/src/NativeApp.pkl
+++ b/contract-toolkit/src/NativeApp.pkl
@@ -799,6 +799,16 @@ flatManifestArgs: Boolean = true
 /// `args.metadata`, preserving the mapping keys verbatim.
 manifestMetadataArgs: Mapping<String, String>?
 
+/// Static literal args merged verbatim into the extract node's `inputs.args`.
+/// Unlike form-field args (rendered as `{{placeholder}}` and resolved per request),
+/// these are constants baked into the DAG — for config a workflow needs at dispatch
+/// that has no request context and isn't a credential or form field (e.g. an
+/// event-driven drain's `iceberg_table_name`, mirroring the AE bootstrap DAG it
+/// replaces). Emitted as-is; a reconciler (Local Marketplace) preserves them because
+/// they carry no `{{...}}` placeholder to strip. Keys must not collide with the
+/// credential/agent/form-field arg names.
+manifestStaticArgs: Mapping<String, Any> = new Mapping {}
+
 // ---------------------------------------------------------------------------
 // DAG node definitions
 // ---------------------------------------------------------------------------
@@ -2752,6 +2762,11 @@ local function generateExtractNode(): Mapping<String, Any> =
       ["argo_workflow_slug"] = ""
       ["task_queue"] = "\(taskQueuePrefix)-{deployment_name}"
       ["args"] = new Mapping {
+        // Static literal args (e.g. an event drain's iceberg_table_name) — constants
+        // baked into the DAG, no placeholder, so a reconciler keeps them verbatim.
+        for (staticKey, staticVal in manifestStaticArgs) {
+          [staticKey] = staticVal
+        }
         ["credential"] = "{{credential}}"
         // SDR / agent-mode credential slot. Emitted whenever the app does not
         // model `agent-json` — the gap that silently broke MSSQL's SDR rollout

--- a/contract-toolkit/tests/schedules_test.pkl
+++ b/contract-toolkit/tests/schedules_test.pkl
@@ -37,6 +37,11 @@ local appWithSchedules = (App) {
   hasCredentialConfig = false
   uiConfig = appUiConfig
 
+  // Static DAG arg (constant, baked into inputs.args) alongside the placeholder args.
+  manifestStaticArgs {
+    ["iceberg_table_name"] = "app_events_table"
+  }
+
   pipeline {
     publish = null
   }
@@ -135,6 +140,11 @@ local nativeWithSchedules = (NativeApp) {
   workflowType = "NativeWithSchedulesWorkflow"
   hasPublishStep = false
   hasPublishInputFields = false
+
+  // Static DAG arg (constant, baked into inputs.args) — e.g. an event drain's table.
+  manifestStaticArgs {
+    ["iceberg_table_name"] = "native_events_table"
+  }
 
   schedules {
     new NativeApp.ScheduleSpec {
@@ -242,6 +252,10 @@ facts {
     appManifest["triggers"].containsKey("events")
   }
 
+  ["App renders manifestStaticArgs into the DAG's inputs.args (verbatim)"] {
+    appManifest["dag"]["extract"]["inputs"]["args"]["iceberg_table_name"] == "app_events_table"
+  }
+
   ["App events-only: renders triggers.events with schedules ABSENT"] {
     appEventsOnlyManifest["triggers"].containsKey("events")
     appEventsOnlyManifest["triggers"]["events"].length == 1
@@ -271,6 +285,10 @@ facts {
     nativeManifest["triggers"]["events"][0]["source"]["topic"] == "native.cdc.user_entity"
     nativeManifest["triggers"]["events"][0]["trigger_config"]["ack_paths"][0] == "$.sync.outputs.ack_path"
     nativeManifest["triggers"]["events"][0]["status"] == "ACTIVE"
+  }
+
+  ["NativeApp renders manifestStaticArgs into the DAG's inputs.args (verbatim)"] {
+    nativeManifest["dag"]["extract"]["inputs"]["args"]["iceberg_table_name"] == "native_events_table"
   }
 
   ["NativeApp events-only: renders triggers.events with schedules ABSENT"] {


### PR DESCRIPTION
## What
Adds **`manifestStaticArgs`** to `App.pkl` / `NativeApp.pkl` — a `Mapping<String, Any>` merged verbatim into the extract node's `inputs.args` in the generated manifest.

Unlike form-field args (rendered as `{{placeholder}}` and resolved per request), these are **constants baked into the DAG** — for config a workflow needs at dispatch that has no request context and isn't a credential or form field.

## Why
Fixes a regression found on-tenant while migrating auth-app EventSync off the AE bootstrap. The old bootstrap DAG carried `args: {"iceberg_table_name": "keycloak_iam_redis_sync"}` **statically**; the drain reads `iceberg_table_name` from its input to know which Iceberg table to sweep. The toolkit-generated DAG emitted `args: {}` (credential placeholders stripped for the credential-less event run), so the drain got `""` → **`Invalid Iceberg table name: ''`**.

`manifestStaticArgs` restores that static-arg mechanism declaratively. The value carries no `{{...}}` placeholder, so the Local Marketplace reconciler preserves it verbatim (it only strips unresolved placeholders + empty credentials).

## Tests
`pkl test tests/*.pkl` → 277 pass / 672 asserts (2 new: App + NativeApp render `manifestStaticArgs` into the DAG `inputs.args`).

## Consumer
`atlan-auth-app` #58 sets `manifestStaticArgs { ["iceberg_table_name"] = "atlan_auth_event_sync" }` on its `event-sync` contract (regen verified: the arg now appears in the DAG). Needs this released (bumps auth-app's toolkit pin).

---
**Linear:** [DISTR-844](https://linear.app/atlan-epd/issue/DISTR-844/migrate-atlan-auth-app-background-jobs-from-hardcoded-ae-workflows-to)

🤖 Generated with [Claude Code](https://claude.com/claude-code)