### PR TITLE
perf: keep heavy imports off the server boot path [ARUN-942]

### DIFF
--- a/application_sdk/app/__init__.py
+++ b/application_sdk/app/__init__.py
@@ -53,14 +53,7 @@ never needs to import the underlying orchestrator directly::
             return PauseOutput(message=f"paused: {input.reason}")
 """
 
-from temporalio.workflow import HandlerUnfinishedPolicy as _HandlerUnfinishedPolicy
-from temporalio.workflow import now as _now
-from temporalio.workflow import query as _query
-from temporalio.workflow import signal as _signal
-from temporalio.workflow import sleep as _sleep
-from temporalio.workflow import update as _update
-from temporalio.workflow import uuid4 as _uuid4
-from temporalio.workflow import wait_condition as _wait_condition
+# BOOT-TIME: temporalio.workflow re-exports are lazy (see __getattr__ below).
 
 from application_sdk.app.base import App, AppError, NonRetryableError, RetryableError
 from application_sdk.app.context import AppContext
@@ -82,7 +75,7 @@ from application_sdk.server.mcp.decorators import mcp_tool
 # these in the capability manifest without needing wrapper functions.
 # ---------------------------------------------------------------------------
 
-signal = _signal
+# signal: lazy re-export of temporalio.workflow (PEP 562)
 """Declare a ``@signal`` runtime interaction on an App subclass.
 
 A signal is a **pure trigger** — it carries no payload and returns nothing.
@@ -108,7 +101,7 @@ Example::
             self.paused = False
 """
 
-query = _query
+# query: lazy re-export of temporalio.workflow (PEP 562)
 """Declare a ``@query`` runtime interaction that reads live state without mutation.
 
 A query is a **read-only probe** — the caller receives a typed snapshot of
@@ -136,7 +129,7 @@ Example::
             )
 """
 
-update = _update
+# update: lazy re-export of temporalio.workflow (PEP 562)
 """Declare a ``@update`` runtime interaction that mutates state and returns a typed response.
 
 An update is delivered **exactly once** and the caller waits synchronously for
@@ -180,7 +173,7 @@ Example::
 # App-run time / UUID / sleep / condition primitives
 # ---------------------------------------------------------------------------
 
-wait_condition = _wait_condition
+# wait_condition: lazy re-export of temporalio.workflow (PEP 562)
 """Suspend ``run()`` or a runtime interaction until a predicate becomes ``True``.
 
 Prefer this over polling with ``asyncio.sleep`` — it is deterministic,
@@ -195,7 +188,7 @@ Example::
     await wait_condition(lambda: not self.paused, timeout=timedelta(minutes=5))
 """
 
-now = _now
+# now: lazy re-export of temporalio.workflow (PEP 562)
 """Return the current time from the app run's perspective (deterministic).
 
 Use this instead of ``datetime.now()`` or ``time.time()`` inside ``run()``
@@ -207,7 +200,7 @@ Example::
     elapsed = (now() - self.started_at).total_seconds()
 """
 
-sleep = _sleep
+# sleep: lazy re-export of temporalio.workflow (PEP 562)
 """Sleep for a given duration inside an app run (deterministic).
 
 Use this instead of ``asyncio.sleep`` or ``time.sleep`` inside ``run()``
@@ -221,7 +214,7 @@ Example::
     await sleep(timedelta(milliseconds=100))  # yield between batches
 """
 
-uuid4 = _uuid4
+# uuid4: lazy re-export of temporalio.workflow (PEP 562)
 """Generate a determinism-safe v4 UUID inside an app run.
 
 Use this instead of ``uuid.uuid4()`` inside ``run()`` and runtime
@@ -234,7 +227,7 @@ Example::
     run_id = str(uuid4())
 """
 
-InteractionUnfinishedPolicy = _HandlerUnfinishedPolicy
+# InteractionUnfinishedPolicy: lazy re-export of temporalio.workflow (PEP 562)
 """Policy applied to in-flight runtime interactions when an app run exits.
 
 Controls what happens if the app run completes or is cancelled before
@@ -279,3 +272,28 @@ __all__ = [
     "uuid4",
     "wait_condition",
 ]
+
+
+_LAZY_TEMPORAL_EXPORTS = {
+    "signal": "signal",
+    "query": "query",
+    "update": "update",
+    "wait_condition": "wait_condition",
+    "now": "now",
+    "sleep": "sleep",
+    "uuid4": "uuid4",
+    "InteractionUnfinishedPolicy": "HandlerUnfinishedPolicy",
+}
+
+
+def __getattr__(name: str):
+    """BOOT-TIME: defer `import temporalio` until a workflow-side symbol is
+    actually requested. Handler-mode servers never touch these."""
+    target = _LAZY_TEMPORAL_EXPORTS.get(name)
+    if target is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    import temporalio.workflow
+
+    value = getattr(temporalio.workflow, target)
+    globals()[name] = value
+    return value

--- a/application_sdk/app/base.py
+++ b/application_sdk/app/base.py
@@ -28,8 +28,27 @@ from uuid import UUID
 
 import obstore as obs
 import orjson
-from temporalio import activity, workflow
-from temporalio.exceptions import FailureError
+class _LazyTemporalModule:
+    """BOOT-TIME: defers importing a temporalio submodule until first attribute
+    access. All uses of `workflow`/`activity` here run under a Temporal
+    worker/client, so handler-mode boot never pays the temporalio import."""
+
+    __slots__ = ("_modname", "_alias")
+
+    def __init__(self, modname: str, alias: str) -> None:
+        self._modname = modname
+        self._alias = alias
+
+    def __getattr__(self, attr: str):
+        import importlib
+
+        mod = importlib.import_module(self._modname)
+        globals()[self._alias] = mod
+        return getattr(mod, attr)
+
+
+workflow = _LazyTemporalModule("temporalio.workflow", "workflow")
+activity = _LazyTemporalModule("temporalio.activity", "activity")
 
 from application_sdk.app._ep_registration import (
     _apply_app_registration,
@@ -2125,6 +2144,7 @@ def generate_workflow_class(app_cls: "type[App]", ep: "EntryPointMetadata") -> t
                 ApplicationError,
             )
 
+            from temporalio.exceptions import FailureError  # noqa: PLC0415 — lazy: workflow error path
             if isinstance(e, FailureError):
                 raise
             if isinstance(e, _NewAppError):

--- a/application_sdk/app/base.py
+++ b/application_sdk/app/base.py
@@ -33,18 +33,25 @@ class _LazyTemporalModule:
     access. All uses of `workflow`/`activity` here run under a Temporal
     worker/client, so handler-mode boot never pays the temporalio import."""
 
-    __slots__ = ("_modname", "_alias")
+    __slots__ = ("_modname",)
 
     def __init__(self, modname: str, alias: str) -> None:
-        self._modname = modname
-        self._alias = alias
+        object.__setattr__(self, "_modname", modname)
 
-    def __getattr__(self, attr: str):
+    def _mod(self):
         import importlib
 
-        mod = importlib.import_module(self._modname)
-        globals()[self._alias] = mod
-        return getattr(mod, attr)
+        return importlib.import_module(self._modname)
+
+    def __getattr__(self, attr: str):
+        return getattr(self._mod(), attr)
+
+    def __setattr__(self, attr: str, value) -> None:
+        # forward so tests can patch e.g. base.workflow.now
+        setattr(self._mod(), attr, value)
+
+    def __delattr__(self, attr: str) -> None:
+        delattr(self._mod(), attr)
 
 
 workflow = _LazyTemporalModule("temporalio.workflow", "workflow")

--- a/application_sdk/app/context.py
+++ b/application_sdk/app/context.py
@@ -9,7 +9,7 @@ from uuid import uuid4
 
 # Low-level loguru import used only as the activity-context fallback below.
 from loguru import logger as _loguru_logger
-from temporalio import workflow as _workflow
+# BOOT-TIME: temporalio imported lazily at the single use site below.
 
 from application_sdk.app.base_errors import (
     SecretStoreNotConfiguredError,
@@ -110,6 +110,7 @@ class _WorkflowSafeLogger:
                 pass
 
         if _is_in_workflow():
+            from temporalio import workflow as _workflow  # noqa: PLC0415 — lazy: workflow ctx only
             wf_logger = _workflow.logger
             log_method = getattr(wf_logger, level)
 

--- a/application_sdk/app/context.py
+++ b/application_sdk/app/context.py
@@ -9,7 +9,23 @@ from uuid import uuid4
 
 # Low-level loguru import used only as the activity-context fallback below.
 from loguru import logger as _loguru_logger
-# BOOT-TIME: temporalio imported lazily at the single use site below.
+
+
+class _LazyWorkflowModule:
+    """BOOT-TIME: stands in for ``temporalio.workflow`` without importing it at
+    module import. Forwards attribute get/set to the real module so tests can
+    patch ``context._workflow``/its attributes as before."""
+
+    def _mod(self):
+        import importlib
+
+        return importlib.import_module("temporalio.workflow")
+
+    def __getattr__(self, attr: str):
+        return getattr(self._mod(), attr)
+
+
+_workflow = _LazyWorkflowModule()
 
 from application_sdk.app.base_errors import (
     SecretStoreNotConfiguredError,
@@ -110,7 +126,6 @@ class _WorkflowSafeLogger:
                 pass
 
         if _is_in_workflow():
-            from temporalio import workflow as _workflow  # noqa: PLC0415 — lazy: workflow ctx only
             wf_logger = _workflow.logger
             log_method = getattr(wf_logger, level)
 

--- a/application_sdk/common/__init__.py
+++ b/application_sdk/common/__init__.py
@@ -19,19 +19,50 @@ Note: ``application_sdk.common.error_codes`` is retained for back-compat with
 v2 connectors. Prefer ``application_sdk.errors`` for new code.
 """
 
-from application_sdk.common.concurrency import (
-    get_actual_cpu_count,
-    get_safe_num_threads,
-)
-from application_sdk.common.filter_matching import FilterPattern, filter_matches
-from application_sdk.common.models import TaskResult, TaskStatistics
-from application_sdk.common.sql_filters import (
-    normalize_filters,
-    prepare_filters,
-    prepare_query,
-    read_sql_files,
-)
-from application_sdk.common.types import DataframeType
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from application_sdk.common.concurrency import (
+        get_actual_cpu_count,
+        get_safe_num_threads,
+    )
+    from application_sdk.common.filter_matching import FilterPattern, filter_matches
+    from application_sdk.common.models import TaskResult, TaskStatistics
+    from application_sdk.common.sql_filters import (
+        normalize_filters,
+        prepare_filters,
+        prepare_query,
+        read_sql_files,
+    )
+    from application_sdk.common.types import DataframeType
+
+# BOOT-TIME: re-exports are lazy (PEP 562). Importing any submodule of
+# application_sdk.common executes this __init__; the eager version pulled
+# sql_filters -> errors -> pydantic wire models onto every boot path.
+_LAZY_EXPORTS = {
+    "read_sql_files": "application_sdk.common.sql_filters",
+    "prepare_query": "application_sdk.common.sql_filters",
+    "prepare_filters": "application_sdk.common.sql_filters",
+    "normalize_filters": "application_sdk.common.sql_filters",
+    "FilterPattern": "application_sdk.common.filter_matching",
+    "filter_matches": "application_sdk.common.filter_matching",
+    "get_actual_cpu_count": "application_sdk.common.concurrency",
+    "get_safe_num_threads": "application_sdk.common.concurrency",
+    "TaskStatistics": "application_sdk.common.models",
+    "TaskResult": "application_sdk.common.models",
+    "DataframeType": "application_sdk.common.types",
+}
+
+
+def __getattr__(name: str):
+    module_path = _LAZY_EXPORTS.get(name)
+    if module_path is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    import importlib
+
+    value = getattr(importlib.import_module(module_path), name)
+    globals()[name] = value
+    return value
 
 __all__ = [
     # SQL filter helpers

--- a/application_sdk/execution/__init__.py
+++ b/application_sdk/execution/__init__.py
@@ -1,65 +1,44 @@
-"""Execution layer for running Apps on Temporal."""
+"""Execution layer for running Apps on Temporal.
 
-# Re-export the temporalio Client as TemporalClient for app-side type annotations.
-from temporalio.client import Client as TemporalClient
-from temporalio.client import WorkflowFailureError as TemporalWorkflowFailureError
+BOOT-TIME: all re-exports are lazy (PEP 562). The eager version imported
+the full _temporal backend + temporalio (Rust bridge, grpc, protobuf) onto
+every boot path. Lazy exceptions still work in `except` clauses as long as
+they are imported (which triggers resolution) before use.
+"""
 
-# Re-export the client-side failure types apps need to catch around
-# `TemporalClient.execute_workflow(...)`. Renamed with a `Temporal` prefix (matching
-# `TemporalClient`) so they don't collide with unrelated SDK types of the same short
-# name, e.g. `application_sdk.common.error_codes.ActivityError` and
-# `application_sdk.errors.leaves.CancelledError`.
-#
-# These are raw temporalio exceptions for code awaiting `TemporalClient.execute_workflow(...)`
-# or a workflow handle. For SDK-classified domain failures inside `@task`/`@entrypoint` code,
-# raise/catch `application_sdk.errors.AppError` leaves (`CancelledError`, `AppTimeoutError`,
-# etc.) instead.
-from temporalio.exceptions import ActivityError as TemporalActivityError
-from temporalio.exceptions import CancelledError as TemporalCancelledError
-from temporalio.exceptions import ChildWorkflowError as TemporalChildWorkflowError
-from temporalio.exceptions import TerminatedError as TemporalTerminatedError
-from temporalio.exceptions import TimeoutError as TemporalTimeoutError
+_LAZY_EXPORTS = {
+    "AppWorker": ("application_sdk.execution._temporal.worker", "AppWorker"),
+    "ApplicationError": ("application_sdk.execution.errors", "ApplicationError"),
+    "RetryPolicy": ("application_sdk.execution.retry", "RetryPolicy"),
+    "TemporalActivityError": ("temporalio.exceptions", "ActivityError"),
+    "TemporalAuthConfig": ("application_sdk.execution._temporal.auth", "TemporalAuthConfig"),
+    "TemporalAuthManager": ("application_sdk.execution._temporal.auth", "TemporalAuthManager"),
+    "TemporalCancelledError": ("temporalio.exceptions", "CancelledError"),
+    "TemporalChildWorkflowError": ("temporalio.exceptions", "ChildWorkflowError"),
+    "TemporalClient": ("temporalio.client", "Client"),
+    "TemporalExecutorBackend": ("application_sdk.execution._temporal.backend", "TemporalExecutorBackend"),
+    "TemporalTerminatedError": ("temporalio.exceptions", "TerminatedError"),
+    "TemporalTimeoutError": ("temporalio.exceptions", "TimeoutError"),
+    "TemporalWorkflowFailureError": ("temporalio.client", "WorkflowFailureError"),
+    "build_output_path": ("application_sdk.execution._temporal.activity_utils", "build_output_path"),
+    "create_data_converter": ("application_sdk.execution._temporal.converter", "create_data_converter"),
+    "create_data_converter_for_app": ("application_sdk.execution._temporal.converter", "create_data_converter_for_app"),
+    "create_temporal_client": ("application_sdk.execution._temporal.backend", "create_temporal_client"),
+    "create_worker": ("application_sdk.execution._temporal.worker", "create_worker"),
+    "get_object_store_prefix": ("application_sdk.execution._temporal.activity_utils", "get_object_store_prefix"),
+    "needs_lock": ("application_sdk.execution.decorators", "needs_lock"),
+}
 
-from application_sdk.execution._temporal.activity_utils import (
-    build_output_path,
-    get_object_store_prefix,
-)
-from application_sdk.execution._temporal.auth import (
-    TemporalAuthConfig,
-    TemporalAuthManager,
-)
-from application_sdk.execution._temporal.backend import (
-    TemporalExecutorBackend,
-    create_temporal_client,
-)
-from application_sdk.execution._temporal.converter import (
-    create_data_converter,
-    create_data_converter_for_app,
-)
-from application_sdk.execution._temporal.worker import AppWorker, create_worker
-from application_sdk.execution.decorators import needs_lock
-from application_sdk.execution.errors import ApplicationError
-from application_sdk.execution.retry import RetryPolicy
+__all__ = list(_LAZY_EXPORTS)
 
-__all__ = [
-    "AppWorker",
-    "ApplicationError",
-    "RetryPolicy",
-    "TemporalActivityError",
-    "TemporalAuthConfig",
-    "TemporalAuthManager",
-    "TemporalCancelledError",
-    "TemporalChildWorkflowError",
-    "TemporalClient",
-    "TemporalExecutorBackend",
-    "TemporalTerminatedError",
-    "TemporalTimeoutError",
-    "TemporalWorkflowFailureError",
-    "build_output_path",
-    "create_data_converter",
-    "create_data_converter_for_app",
-    "create_temporal_client",
-    "create_worker",
-    "get_object_store_prefix",
-    "needs_lock",
-]
+
+def __getattr__(name: str):
+    entry = _LAZY_EXPORTS.get(name)
+    if entry is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    import importlib
+
+    module_path, attr = entry
+    value = getattr(importlib.import_module(module_path), attr)
+    globals()[name] = value
+    return value

--- a/application_sdk/handler/service.py
+++ b/application_sdk/handler/service.py
@@ -45,14 +45,12 @@ from typing import TYPE_CHECKING, Annotated, Any, cast
 from uuid import uuid4
 
 import orjson
-import temporalio.service
 from fastapi import FastAPI, File, Form, HTTPException
 from fastapi import Path as PathParam
 from fastapi import Query, Request, UploadFile
 from fastapi.responses import HTMLResponse, JSONResponse, Response
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel as PydanticBaseModel
-from temporalio.client import WorkflowFailureError
 
 from application_sdk.constants import CONTRACT_GENERATED_DIR as _CONTRACT_GENERATED_DIR
 from application_sdk.constants import DEPLOYMENT_NAME, LOCAL_ENVIRONMENT
@@ -84,6 +82,28 @@ from application_sdk.handler.service_errors import (
 from application_sdk.observability.logger_adaptor import get_logger
 
 logger = get_logger(__name__)
+
+
+class _TemporalioNotYetImported(Exception):
+    """BOOT-TIME placeholder. Never raised. Replaced by the real temporalio
+    WorkflowFailureError inside _get_temporal_client(), which always runs
+    before any workflow call can fail."""
+
+
+WorkflowFailureError: type[BaseException] = _TemporalioNotYetImported
+
+
+def _is_rpc_not_found(e: BaseException) -> bool:
+    """True iff e is a temporalio RPCError with NOT_FOUND status. Guarded via
+    sys.modules so handler boot never imports temporalio."""
+    import sys as _sys
+
+    ts = _sys.modules.get("temporalio.service")
+    return (
+        ts is not None
+        and isinstance(e, ts.RPCError)
+        and e.status == ts.RPCStatusCode.NOT_FOUND
+    )
 
 _CATEGORY_TO_HTTP: dict[FailureCategory, int] = {
     FailureCategory.AUTH: 401,
@@ -678,6 +698,24 @@ async def _get_temporal_client() -> Client:
         create_temporal_client,
     )
 
+    # BOOT-TIME: bind the real WorkflowFailureError now that temporalio is
+    # loading anyway; build the app data converter lazily (it was moved off
+    # the boot path in run_handler_mode).
+    global WorkflowFailureError
+    from temporalio.client import (  # noqa: PLC0415 — lazy: first workflow call
+        WorkflowFailureError as _RealWorkflowFailureError,
+    )
+
+    WorkflowFailureError = _RealWorkflowFailureError
+    if _workflow_config.data_converter is None and _workflow_config.app_class is not None:
+        from application_sdk.execution._temporal.converter import (  # noqa: PLC0415
+            create_data_converter_for_app,
+        )
+
+        _workflow_config.data_converter = create_data_converter_for_app(
+            _workflow_config.app_class
+        )
+
     api_key: str | None = None
     if _workflow_config.auth_enabled:
         from application_sdk.execution import (  # noqa: PLC0415 — circular: handler.service is the FastAPI entry point — execution/server modules load app.base which loads handler
@@ -1181,8 +1219,7 @@ def _register_workflow_routes(
             )
         except Exception as e:
             if (
-                isinstance(e, temporalio.service.RPCError)
-                and e.status == temporalio.service.RPCStatusCode.NOT_FOUND
+                _is_rpc_not_found(e)
             ):
                 raise HTTPException(
                     status_code=404, detail=f"Workflow not found: {workflow_id}"
@@ -1368,8 +1405,7 @@ def _register_workflow_routes(
 
         except Exception as e:
             if (
-                isinstance(e, temporalio.service.RPCError)
-                and e.status == temporalio.service.RPCStatusCode.NOT_FOUND
+                _is_rpc_not_found(e)
             ):
                 raise HTTPException(
                     status_code=404, detail=f"Workflow not found: {workflow_id}"
@@ -1421,8 +1457,7 @@ def _register_workflow_routes(
             )
         except Exception as e:
             if (
-                isinstance(e, temporalio.service.RPCError)
-                and e.status == temporalio.service.RPCStatusCode.NOT_FOUND
+                _is_rpc_not_found(e)
             ):
                 raise HTTPException(
                     status_code=404, detail=f"Workflow not found: {workflow_id}"

--- a/application_sdk/main.py
+++ b/application_sdk/main.py
@@ -1158,9 +1158,8 @@ def run_handler_mode(config: AppConfig) -> None:
     Loads the handler class (or DefaultHandler) and runs the FastAPI
     server via uvicorn. This is synchronous — uvicorn manages its own loop.
     """
-    from application_sdk.execution._temporal.converter import (  # noqa: PLC0415 — cold path: only loaded in worker mode (execution backend)
-        create_data_converter_for_app,
-    )
+    # BOOT-TIME: data converter creation moved into the handler's lazy
+    # Temporal-client factory — importing it here pulls temporalio at boot.
     from application_sdk.handler import (  # noqa: PLC0415 — cold path: only loaded in handler mode
         DefaultHandler,
         run_app_handler_service,
@@ -1204,7 +1203,7 @@ def run_handler_mode(config: AppConfig) -> None:
         )
 
     handler = handler_class()
-    data_converter = create_data_converter_for_app(app_class)
+    data_converter = None  # BOOT-TIME: built lazily at first workflow call
 
     run_app_handler_service(
         handler,

--- a/application_sdk/observability/logger_adaptor.py
+++ b/application_sdk/observability/logger_adaptor.py
@@ -8,7 +8,6 @@ from typing import Any, ClassVar
 
 from loguru import logger
 from opentelemetry._logs import LogRecord, SeverityNumber
-from opentelemetry.exporter.otlp.proto.grpc._log_exporter import OTLPLogExporter
 from opentelemetry.sdk._logs import LoggerProvider
 from opentelemetry.sdk._logs._internal.export import BatchLogRecordProcessor
 from opentelemetry.trace.span import TraceFlags
@@ -745,10 +744,19 @@ class AtlanLoggerAdapter(AtlanObservability[Any]):
         try:
             otlp_processors = []
 
+            def _otlp_log_exporter_cls():
+                # BOOT-TIME: grpc + OTLP exporter modules are heavy (native
+                # .so page-in); import only when an exporter is actually wired.
+                from opentelemetry.exporter.otlp.proto.grpc._log_exporter import (
+                    OTLPLogExporter,
+                )
+
+                return OTLPLogExporter
+
             if ENABLE_OTLP_LOGS or _has_remote_otlp_endpoint():
                 otlp_processors.append(
                     BatchLogRecordProcessor(
-                        OTLPLogExporter(
+                        _otlp_log_exporter_cls()(
                             endpoint=OTEL_EXPORTER_OTLP_ENDPOINT,
                             timeout=OTEL_EXPORTER_TIMEOUT_SECONDS,
                         ),
@@ -762,7 +770,7 @@ class AtlanLoggerAdapter(AtlanObservability[Any]):
             if ENABLE_OTLP_WORKFLOW_LOGS and OTEL_WORKFLOW_LOGS_ENDPOINT:
                 otlp_processors.append(
                     BatchLogRecordProcessor(
-                        OTLPLogExporter(
+                        _otlp_log_exporter_cls()(
                             endpoint=OTEL_WORKFLOW_LOGS_ENDPOINT,
                             timeout=OTEL_EXPORTER_TIMEOUT_SECONDS,
                         ),

--- a/application_sdk/observability/logger_adaptor.py
+++ b/application_sdk/observability/logger_adaptor.py
@@ -274,6 +274,11 @@ def _format_printf_args(msg: str, args: tuple[Any, ...]) -> tuple[str, tuple[Any
     return msg, args
 
 
+#: BOOT-TIME lazy-import sentinel — the real class is imported on first
+#: exporter construction; tests patch this name directly.
+OTLPLogExporter = None
+
+
 def _has_remote_otlp_endpoint() -> bool:
     """True when OTEL_EXPORTER_OTLP_ENDPOINT points to a real remote collector."""
     try:
@@ -746,12 +751,16 @@ class AtlanLoggerAdapter(AtlanObservability[Any]):
 
             def _otlp_log_exporter_cls():
                 # BOOT-TIME: grpc + OTLP exporter modules are heavy (native
-                # .so page-in); import only when an exporter is actually wired.
+                # .so page-in); import only when an exporter is actually
+                # wired. Tests may patch the module-level ``OTLPLogExporter``
+                # sentinel; honor it when set.
+                if OTLPLogExporter is not None:
+                    return OTLPLogExporter
                 from opentelemetry.exporter.otlp.proto.grpc._log_exporter import (
-                    OTLPLogExporter,
+                    OTLPLogExporter as _cls,
                 )
 
-                return OTLPLogExporter
+                return _cls
 
             if ENABLE_OTLP_LOGS or _has_remote_otlp_endpoint():
                 otlp_processors.append(

--- a/application_sdk/observability/traces_adaptor.py
+++ b/application_sdk/observability/traces_adaptor.py
@@ -5,12 +5,21 @@ import time
 from typing import Any, ClassVar, Dict, Optional
 
 from opentelemetry import trace
+#: BOOT-TIME lazy-import sentinel — the real class is imported on first
+#: exporter construction; tests patch this name directly.
+OTLPSpanExporter = None
+
+
 def _otlp_span_exporter_cls():
     # BOOT-TIME: grpc + OTLP exporter modules are heavy; import only when a
-    # span exporter is actually wired.
-    from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+    # span exporter is actually wired. Honor a test-patched module-level name.
+    if OTLPSpanExporter is not None:
+        return OTLPSpanExporter
+    from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
+        OTLPSpanExporter as _cls,
+    )
 
-    return OTLPSpanExporter
+    return _cls
 
 
 from opentelemetry.sdk.trace import TracerProvider

--- a/application_sdk/observability/traces_adaptor.py
+++ b/application_sdk/observability/traces_adaptor.py
@@ -5,7 +5,14 @@ import time
 from typing import Any, ClassVar, Dict, Optional
 
 from opentelemetry import trace
-from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+def _otlp_span_exporter_cls():
+    # BOOT-TIME: grpc + OTLP exporter modules are heavy; import only when a
+    # span exporter is actually wired.
+    from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+
+    return OTLPSpanExporter
+
+
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExporter
 from opentelemetry.trace import SpanKind
@@ -132,7 +139,7 @@ class AtlanTracesAdapter(AtlanObservability[TraceRecord]):
             # Add OTLP exporter if endpoint is configured
             if OTEL_EXPORTER_OTLP_ENDPOINT:
                 try:
-                    otlp_exporter = OTLPSpanExporter(
+                    otlp_exporter = _otlp_span_exporter_cls()(
                         endpoint=OTEL_EXPORTER_OTLP_ENDPOINT,
                         timeout=OTEL_EXPORTER_TIMEOUT_SECONDS,
                     )

--- a/application_sdk/templates/contracts/__init__.py
+++ b/application_sdk/templates/contracts/__init__.py
@@ -1,107 +1,66 @@
-"""Typed contracts for built-in App implementations."""
+"""Typed contracts for built-in App implementations.
 
-from application_sdk.templates.contracts.base_metadata_extraction import (
-    UploadInput,
-    UploadOutput,
-)
-from application_sdk.templates.contracts.incremental_sql import (
-    ExecuteColumnBatchInput,
-    ExecuteColumnBatchOutput,
-    FetchColumnsIncrementalInput,
-    FetchIncrementalMarkerInput,
-    FetchIncrementalMarkerOutput,
-    FetchTablesIncrementalInput,
-    IncrementalExtractionInput,
-    IncrementalExtractionOutput,
-    IncrementalRunContext,
-    IncrementalTaskInput,
-    PrepareColumnQueriesInput,
-    PrepareColumnQueriesOutput,
-    ReadCurrentStateInput,
-    ReadCurrentStateOutput,
-    UpdateMarkerInput,
-    UpdateMarkerOutput,
-    WriteCurrentStateInput,
-    WriteCurrentStateOutput,
-)
-from application_sdk.templates.contracts.sql_metadata import (
-    ExtractionInput,
-    ExtractionOutput,
-    ExtractionTaskInput,
-    ExtractionTaskOutput,
-    FetchColumnsInput,
-    FetchColumnsOutput,
-    FetchDatabasesInput,
-    FetchDatabasesOutput,
-    FetchProceduresInput,
-    FetchProceduresOutput,
-    FetchSchemasInput,
-    FetchSchemasOutput,
-    FetchTablesInput,
-    FetchTablesOutput,
-    FetchViewsInput,
-    FetchViewsOutput,
-    PrimeAuthOutput,
-    TransformInput,
-    TransformOutput,
-)
-from application_sdk.templates.contracts.sql_query import (
-    QueryBatchInput,
-    QueryBatchOutput,
-    QueryExtractionInput,
-    QueryExtractionOutput,
-    QueryFetchInput,
-    QueryFetchOutput,
-)
+BOOT-TIME: lazy re-exports (PEP 562) — eager version imported every SQL
+contract module even when a caller needed a single class.
+"""
 
-__all__ = [
-    # Base metadata extraction (deprecated upload_to_atlan task)
-    "UploadInput",
-    "UploadOutput",
-    # SQL metadata — base
-    "ExtractionInput",
-    "ExtractionOutput",
-    "ExtractionTaskInput",
-    "ExtractionTaskOutput",
-    "FetchColumnsInput",
-    "FetchColumnsOutput",
-    "FetchDatabasesInput",
-    "FetchDatabasesOutput",
-    "FetchProceduresInput",
-    "FetchProceduresOutput",
-    "FetchSchemasInput",
-    "FetchSchemasOutput",
-    "FetchTablesInput",
-    "FetchTablesOutput",
-    "FetchViewsInput",
-    "FetchViewsOutput",
-    "PrimeAuthOutput",
-    "TransformInput",
-    "TransformOutput",
-    # Incremental SQL
-    "ExecuteColumnBatchInput",
-    "ExecuteColumnBatchOutput",
-    "FetchColumnsIncrementalInput",
-    "FetchIncrementalMarkerInput",
-    "FetchIncrementalMarkerOutput",
-    "FetchTablesIncrementalInput",
-    "IncrementalExtractionInput",
-    "IncrementalExtractionOutput",
-    "IncrementalRunContext",
-    "IncrementalTaskInput",
-    "PrepareColumnQueriesInput",
-    "PrepareColumnQueriesOutput",
-    "ReadCurrentStateInput",
-    "ReadCurrentStateOutput",
-    "UpdateMarkerInput",
-    "UpdateMarkerOutput",
-    "WriteCurrentStateInput",
-    "WriteCurrentStateOutput",
-    # SQL query
-    "QueryBatchInput",
-    "QueryBatchOutput",
-    "QueryExtractionInput",
-    "QueryExtractionOutput",
-    "QueryFetchInput",
-    "QueryFetchOutput",
-]
+_LAZY_EXPORTS = {
+    "ExecuteColumnBatchInput": "application_sdk.templates.contracts.incremental_sql",
+    "ExecuteColumnBatchOutput": "application_sdk.templates.contracts.incremental_sql",
+    "ExtractionInput": "application_sdk.templates.contracts.sql_metadata",
+    "ExtractionOutput": "application_sdk.templates.contracts.sql_metadata",
+    "ExtractionTaskInput": "application_sdk.templates.contracts.sql_metadata",
+    "ExtractionTaskOutput": "application_sdk.templates.contracts.sql_metadata",
+    "FetchColumnsIncrementalInput": "application_sdk.templates.contracts.incremental_sql",
+    "FetchColumnsInput": "application_sdk.templates.contracts.sql_metadata",
+    "FetchColumnsOutput": "application_sdk.templates.contracts.sql_metadata",
+    "FetchDatabasesInput": "application_sdk.templates.contracts.sql_metadata",
+    "FetchDatabasesOutput": "application_sdk.templates.contracts.sql_metadata",
+    "FetchIncrementalMarkerInput": "application_sdk.templates.contracts.incremental_sql",
+    "FetchIncrementalMarkerOutput": "application_sdk.templates.contracts.incremental_sql",
+    "FetchProceduresInput": "application_sdk.templates.contracts.sql_metadata",
+    "FetchProceduresOutput": "application_sdk.templates.contracts.sql_metadata",
+    "FetchSchemasInput": "application_sdk.templates.contracts.sql_metadata",
+    "FetchSchemasOutput": "application_sdk.templates.contracts.sql_metadata",
+    "FetchTablesIncrementalInput": "application_sdk.templates.contracts.incremental_sql",
+    "FetchTablesInput": "application_sdk.templates.contracts.sql_metadata",
+    "FetchTablesOutput": "application_sdk.templates.contracts.sql_metadata",
+    "FetchViewsInput": "application_sdk.templates.contracts.sql_metadata",
+    "FetchViewsOutput": "application_sdk.templates.contracts.sql_metadata",
+    "IncrementalExtractionInput": "application_sdk.templates.contracts.incremental_sql",
+    "IncrementalExtractionOutput": "application_sdk.templates.contracts.incremental_sql",
+    "IncrementalRunContext": "application_sdk.templates.contracts.incremental_sql",
+    "IncrementalTaskInput": "application_sdk.templates.contracts.incremental_sql",
+    "PrepareColumnQueriesInput": "application_sdk.templates.contracts.incremental_sql",
+    "PrepareColumnQueriesOutput": "application_sdk.templates.contracts.incremental_sql",
+    "PrimeAuthOutput": "application_sdk.templates.contracts.sql_metadata",
+    "QueryBatchInput": "application_sdk.templates.contracts.sql_query",
+    "QueryBatchOutput": "application_sdk.templates.contracts.sql_query",
+    "QueryExtractionInput": "application_sdk.templates.contracts.sql_query",
+    "QueryExtractionOutput": "application_sdk.templates.contracts.sql_query",
+    "QueryFetchInput": "application_sdk.templates.contracts.sql_query",
+    "QueryFetchOutput": "application_sdk.templates.contracts.sql_query",
+    "ReadCurrentStateInput": "application_sdk.templates.contracts.incremental_sql",
+    "ReadCurrentStateOutput": "application_sdk.templates.contracts.incremental_sql",
+    "TransformInput": "application_sdk.templates.contracts.sql_metadata",
+    "TransformOutput": "application_sdk.templates.contracts.sql_metadata",
+    "UpdateMarkerInput": "application_sdk.templates.contracts.incremental_sql",
+    "UpdateMarkerOutput": "application_sdk.templates.contracts.incremental_sql",
+    "UploadInput": "application_sdk.templates.contracts.base_metadata_extraction",
+    "UploadOutput": "application_sdk.templates.contracts.base_metadata_extraction",
+    "WriteCurrentStateInput": "application_sdk.templates.contracts.incremental_sql",
+    "WriteCurrentStateOutput": "application_sdk.templates.contracts.incremental_sql",
+}
+
+__all__ = list(_LAZY_EXPORTS)
+
+
+def __getattr__(name: str):
+    module_path = _LAZY_EXPORTS.get(name)
+    if module_path is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    import importlib
+
+    value = getattr(importlib.import_module(module_path), name)
+    globals()[name] = value
+    return value


### PR DESCRIPTION
**DRAFT — part of ARUN-942 (App server cost & efficiency revamp).** Companion to the four per-app PRs (atlan-governance-app#130, atlan-enrichment-studio-app#439, atlan-data-quality-studio-app#97, atlan-memory-app#19) and the pool-pod PoC (common-app-server#1).

**Problem:** handler-mode server boot pays for imports the serve path never touches: `execution/__init__` eagerly imports the whole Temporal backend (temporalio Rust bridge + grpc + protobuf), `common/__init__` pulls sql_filters on any submodule import, and the OTLP gRPC exporters load even when disabled. Fresh-pod boot ~5-8s.

**Change (mechanical, no business logic):** PEP 562 lazy re-exports for `common/`, `templates/contracts/`, `execution/`, `app/` package inits; lazy module proxies for `workflow`/`activity` in `app/base`/`app/context` (set/get forwarding keeps tests' patching working); `handler/service` defers temporalio + data-converter creation to the existing lazy `_get_temporal_client()` (placeholder-exception swap keeps the `except WorkflowFailureError` semantics); OTLP log/span exporters import at construction, with module-level sentinels for test patching.

**Behavioral deltas reviewers should weigh:** import errors in lazy exports surface at first use instead of boot (suggest an import-sweep smoke test in CI); converter-construction failures surface on first workflow call instead of crash-looping at boot.

**Measured:** handler-mode boot ~5-8s → ~1s (fresh pod, bytecode precompiled); in-cluster (markeznp25 pool-pod PoC) cold spawn→ready 1.2-1.8s, cold workflow start 1.4s. Warm path unchanged.

**Tests:** full unit suite green — 5927 passed, 11 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)