### PR TITLE
fix(infrastructure): stop blind-retrying a 500 on the Dapr secrets GET

### DIFF
--- a/application_sdk/infrastructure/_dapr/http.py
+++ b/application_sdk/infrastructure/_dapr/http.py
@@ -48,6 +48,40 @@ _DEFAULT_TIMEOUT = 30.0
 # backoff=0.5). Retries only fire on failures; healthy calls are unaffected.
 _DEFAULT_RETRY_TOTAL = 5
 
+#: Statuses the transport retries blindly, i.e. on the status code alone.
+_RETRYABLE_STATUSES = [500, 502, 503, 504]
+
+#: Same, minus 500, for the *secrets* GET path only.
+#:
+#: Dapr overloads HTTP 500 on the secrets API: it returns a plain 5xx
+#: (``ERR_SECRET_GET``) both for a genuinely-missing key in an already-ready
+#: store and for a store that isn't up yet (``ERR_SECRET_STORES_NOT_CONFIGURED``).
+#: The transport can only see the status code — :meth:`Retry.is_retryable_status_code`
+#: is not given the response body — so retrying 500 here means retrying a
+#: *definitive* "no such secret" for the full ~15s ladder.
+#:
+#: That is not hypothetical: single-key agent credentials
+#: (``credentials/agent.py::_fetch_per_key_bundle``) probe every non-literal
+#: field value as a candidate secret key, so "not found" is the common,
+#: expected outcome for any field holding a literal (a database name, a
+#: region). Each such probe paid ~15s, serially — enough to blow a fixed
+#: activity budget on credential resolution alone.
+#:
+#: Dropping 500 here does not lose cold-start coverage, it moves it to the
+#: layer that can actually discriminate:
+#: :func:`~application_sdk.infrastructure._dapr.client.classify_secret_fetch_error`
+#: reads the Dapr ``errorCode`` and maps ``ERR_SECRET_STORES_NOT_CONFIGURED``
+#: → :class:`SecretStoreUnavailableError` (a ``ColdStartRaceError``), which
+#: :func:`retry_past_dapr_cold_start` then retries on a *wider* budget
+#: (:data:`DAPR_COLD_START_MAX_WAIT_SECONDS`, 120s) than the transport's 15s.
+#: ``ERR_SECRET_GET`` maps to :class:`SecretNotFoundError` and returns
+#: immediately, which is the whole point.
+#:
+#: 502/503/504 stay retryable: those come from a proxy or a refusing socket,
+#: never from a Dapr component reporting on a specific key, so they carry no
+#: "not found" ambiguity. Transport-level exceptions are unchanged.
+_SECRETS_RETRYABLE_STATUSES = [502, 503, 504]
+
 # ---------------------------------------------------------------------------
 # Metrics
 # ---------------------------------------------------------------------------
@@ -402,32 +436,46 @@ class AsyncDaprClient:
         self._base_url = base_url or _dapr_base_url()
         transport = RetryTransport(
             transport=httpx.AsyncHTTPTransport(limits=_HTTP_POOL_LIMITS),
-            retry=Retry(
-                total=retries,
-                backoff_factor=1.0,
-                status_forcelist=[500, 502, 503, 504],
-                # Pin the retried transport errors to httpx-retries' own default
-                # set, stated explicitly so it can't silently narrow/widen if the
-                # library changes its default. These three base classes cover
-                # connect/read/WRITE/close/pool + protocol errors alike, so
-                # POST/DELETE calls (save_state/publish_event/invoke_binding/
-                # delete_state) keep the exact retry coverage they had before —
-                # listing leaf classes like ConnectError/ReadError would have
-                # narrowed it and dropped WriteError/WriteTimeout/CloseError.
-                # NOTE: these errors were already retried by default; the real
-                # change in this fix is the wider *budget* above (total 3->5,
-                # backoff 0.5->1.0, ~1.5s -> ~15s) that bridges a daprd cold start.
-                retry_on_exceptions=[
-                    httpx.TimeoutException,
-                    httpx.NetworkError,
-                    httpx.RemoteProtocolError,
-                ],
-            ),
+            retry=self._build_retry(retries, _RETRYABLE_STATUSES),
         )
+        # Per-request override consumed by RetryTransport via
+        # ``request.extensions.setdefault("retry", ...)``. Built once here so a
+        # custom ``retries=`` still applies to the secrets path.
+        self._secrets_retry = self._build_retry(retries, _SECRETS_RETRYABLE_STATUSES)
         self._client = httpx.AsyncClient(
             base_url=self._base_url,
             timeout=httpx.Timeout(timeout, pool=_HTTP_POOL_TIMEOUT_SECONDS),
             transport=transport,
+        )
+
+    @staticmethod
+    def _build_retry(total: int, status_forcelist: list[int]) -> Retry:
+        """Build a :class:`Retry` that differs only in which statuses it retries.
+
+        ``status_forcelist`` is the one axis that varies (see
+        :data:`_SECRETS_RETRYABLE_STATUSES`); every other knob is shared so the
+        secrets path and the default path can't drift apart.
+        """
+        return Retry(
+            total=total,
+            backoff_factor=1.0,
+            status_forcelist=status_forcelist,
+            # Pin the retried transport errors to httpx-retries' own default
+            # set, stated explicitly so it can't silently narrow/widen if the
+            # library changes its default. These three base classes cover
+            # connect/read/WRITE/close/pool + protocol errors alike, so
+            # POST/DELETE calls (save_state/publish_event/invoke_binding/
+            # delete_state) keep the exact retry coverage they had before —
+            # listing leaf classes like ConnectError/ReadError would have
+            # narrowed it and dropped WriteError/WriteTimeout/CloseError.
+            # NOTE: these errors were already retried by default; the real
+            # change in this fix is the wider *budget* above (total 3->5,
+            # backoff 0.5->1.0, ~1.5s -> ~15s) that bridges a daprd cold start.
+            retry_on_exceptions=[
+                httpx.TimeoutException,
+                httpx.NetworkError,
+                httpx.RemoteProtocolError,
+            ],
         )
 
     async def close(self) -> None:
@@ -471,8 +519,13 @@ class AsyncDaprClient:
     # ------------------------------------------------------------------
 
     async def get_secret(self, store_name: str, key: str) -> dict[str, str]:
+        # Do not blind-retry a 500 here — on the secrets API it is ambiguous
+        # between "no such key" and "store not up yet", and only
+        # ``classify_secret_fetch_error`` can tell them apart. See
+        # :data:`_SECRETS_RETRYABLE_STATUSES`.
         resp = await self._client.get(
-            SECRET_STORE_PATH.format(store_name=store_name, key=quote(key, safe=""))
+            SECRET_STORE_PATH.format(store_name=store_name, key=quote(key, safe="")),
+            extensions={"retry": self._secrets_retry},
         )
         resp.raise_for_status()
         return resp.json()

--- a/tests/unit/infrastructure/test_dapr_http.py
+++ b/tests/unit/infrastructure/test_dapr_http.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 
 from application_sdk.infrastructure._dapr.http import (
@@ -403,6 +404,142 @@ class TestRetryConfiguration:
         assert retry.is_retryable_exception(httpx.CloseError("x")) is True
         assert _DEFAULT_RETRY_TOTAL >= 5
         assert retry.backoff_factor >= 1.0
+
+
+class TestSecretsRetryScoping:
+    """A 500 on the *secrets* GET must not be blind-retried.
+
+    Dapr returns a plain 500 (``ERR_SECRET_GET``) for a key that simply isn't in
+    an already-ready store. Only ``classify_secret_fetch_error`` can tell that
+    apart from ``ERR_SECRET_STORES_NOT_CONFIGURED`` (a real cold start), because
+    ``Retry.is_retryable_status_code`` never sees the response body. Retrying it
+    at the transport burned the full ~15s ladder per lookup — and single-key
+    agent credentials probe every non-literal field as a candidate key, so
+    "not found" is the *expected* outcome for any field holding a literal.
+    """
+
+    @staticmethod
+    def _counting_client(status: int, body: dict, calls: list, **kwargs):
+        """An AsyncDaprClient whose underlying transport records every request."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            calls.append(request.url.path)
+            return httpx.Response(status, json=body)
+
+        client = AsyncDaprClient(base_url="http://localhost:3500", **kwargs)
+        client._client._transport._async_transport = httpx.MockTransport(handler)
+        return client
+
+    @pytest.fixture(autouse=True)
+    def _no_backoff_sleep(self):
+        """Keep the retry-positive cases fast — assert counts, not wall-clock."""
+
+        async def _noop(self, response):
+            return None
+
+        with patch("httpx_retries.Retry.asleep", _noop):
+            yield
+
+    async def test_secret_get_does_not_retry_missing_key_500(self):
+        """The regression this class exists for: exactly one request, not six."""
+        calls: list[str] = []
+        client = self._counting_client(
+            500,
+            {"errorCode": "ERR_SECRET_GET", "message": "failed to get secret"},
+            calls,
+        )
+        with pytest.raises(httpx.HTTPStatusError):
+            await client.get_secret("secretstore", "a-literal-database-name")
+        assert len(calls) == 1
+        await client.close()
+
+    async def test_secret_get_still_retries_gateway_statuses(self):
+        """502/503/504 come from a proxy or a refusing socket, never from a
+        component reporting on a specific key — no "not found" ambiguity, so
+        they must stay retryable."""
+        for status in (502, 503, 504):
+            calls: list[str] = []
+            client = self._counting_client(status, {"errorCode": "X"}, calls, retries=3)
+            with pytest.raises(httpx.HTTPStatusError):
+                await client.get_secret("secretstore", "key")
+            assert len(calls) == 4, f"status {status} should retry 3 times"
+            await client.close()
+
+    async def test_non_secret_paths_still_retry_500(self):
+        """The narrowing is scoped to the secrets GET. State/binding/pubsub have
+        no equivalent classifier above them, so their 500 retry is unchanged."""
+        calls: list[str] = []
+        client = self._counting_client(500, {"errorCode": "X"}, calls, retries=3)
+        with pytest.raises(httpx.HTTPStatusError):
+            await client.get_state("statestore", "key")
+        assert len(calls) == 4
+        await client.close()
+
+    async def test_bulk_secret_retry_unchanged(self):
+        """``get_bulk_secret`` isn't on the per-key probe path; left as-is so the
+        narrowing stays as small as the bug requires."""
+        calls: list[str] = []
+        client = self._counting_client(500, {"errorCode": "X"}, calls, retries=3)
+        with pytest.raises(httpx.HTTPStatusError):
+            await client.get_bulk_secret("secretstore")
+        assert len(calls) == 4
+        await client.close()
+
+    async def test_secrets_retry_shares_every_knob_but_statuses(self):
+        """Guard against the two Retry configs drifting apart."""
+        client = AsyncDaprClient(base_url="http://localhost:3500", retries=7)
+        default, secrets = client._client._transport.retry, client._secrets_retry
+        assert secrets.total == default.total == 7
+        assert secrets.backoff_factor == default.backoff_factor
+        assert secrets.retryable_exceptions == default.retryable_exceptions
+        assert secrets.allowed_methods == default.allowed_methods
+        assert secrets.is_retryable_status_code(500) is False
+        assert default.is_retryable_status_code(500) is True
+        for status in (502, 503, 504):
+            assert secrets.is_retryable_status_code(status) is True
+
+    async def test_missing_key_resolves_to_none_in_one_request(self):
+        """End-to-end through the classifier: a missing key is a fast, silent
+        ``None`` from ``get_optional`` — the contract ``_fetch_per_key_bundle``
+        relies on when probing non-secret fields."""
+        from application_sdk.infrastructure._dapr.client import DaprSecretStore
+
+        calls: list[str] = []
+        client = self._counting_client(500, {"errorCode": "ERR_SECRET_GET"}, calls)
+        store = DaprSecretStore(client, "secretstore")
+        assert await store.get_optional("a-literal-database-name") is None
+        assert len(calls) == 1
+        await client.close()
+
+    async def test_cold_start_500_still_classified_unavailable_and_retried(self):
+        """Cold-start coverage is not lost, it moves up a layer — to the one that
+        can read the Dapr error code, and whose budget (120s) is wider than the
+        transport's ~15s."""
+        import application_sdk.infrastructure._dapr.http as http_mod
+        from application_sdk.infrastructure._dapr.client import DaprSecretStore
+
+        calls: list[str] = []
+        client = self._counting_client(
+            500, {"errorCode": "ERR_SECRET_STORES_NOT_CONFIGURED"}, calls
+        )
+        store = DaprSecretStore(client, "secretstore")
+
+        # The one-shot readiness gates are module-level; clear them so this test
+        # exercises the retry loop rather than its short-circuit.
+        with (
+            patch.object(http_mod, "_dapr_sidecar_confirmed_ready", False),
+            patch.object(http_mod, "_dapr_component_confirmed_ready", set()),
+            patch.object(http_mod, "DAPR_COLD_START_MAX_WAIT_SECONDS", 0.3),
+            patch.object(http_mod, "DAPR_COLD_START_BASE_DELAY_SECONDS", 0.05),
+        ):
+            with pytest.raises(SecretStoreUnavailableError):
+                await http_mod.retry_past_dapr_cold_start(
+                    lambda: store.get("key"),
+                    description="probe",
+                    component="secretstore",
+                )
+        assert len(calls) > 1, "a real cold start must still be retried"
+        await client.close()
 
 
 class TestSidecarWaitTimeout:


### PR DESCRIPTION
## Problem

Dapr overloads HTTP 500 on the secrets API. It returns a plain 5xx both for:

- `ERR_SECRET_GET` — the key simply isn't present in an **already-ready** store, and
- `ERR_SECRET_STORES_NOT_CONFIGURED` — the store isn't up yet (a real cold start).

The retry transport can only see the status code (`Retry.is_retryable_status_code` is never handed the response body), so with `500` in `status_forcelist` it retried a **definitive** "no such secret" across the full ~15s ladder (`total=5`, `backoff_factor=1.0`).

`classify_secret_fetch_error` already discriminates the two correctly — but it runs on `resp.raise_for_status()`, i.e. *after* the transport has spent the ladder. The classifier was structurally too late to prevent the storm.

### Why this is a hot path, not a corner case

Single-key agent credentials (`credentials/agent.py::_fetch_per_key_bundle`) probe **every non-literal field value** as a candidate secret key. So "not found" is the common, *expected* outcome for any field holding a literal — a database name, a region. `host`/`port` are exempt via `_LITERAL_KEYS`; the rest are not.

Probes run **serially**, so three or four literal fields put credential resolution alone near a minute. In a production RCA this exhausted a fixed activity budget before the source was ever contacted — the actual SQL connect in those runs was 0.3–0.5s. Nothing warned: the probe failure is deliberately swallowed as "not a secret", so the only symptom was a timeout with no attributable cause.

## Fix

Scope the narrowing to the secrets GET, using the per-request retry override `RetryTransport` already supports (`request.extensions["retry"]`).

Cold-start coverage isn't lost — it moves to the layer that can actually discriminate. `ERR_SECRET_STORES_NOT_CONFIGURED` still classifies as `SecretStoreUnavailableError` (a `ColdStartRaceError`), and `retry_past_dapr_cold_start` retries it on a **wider** budget (`DAPR_COLD_START_MAX_WAIT_SECONDS`, 120s) than the transport's 15s.

Measured with a counting transport:

| call | status | before | after |
|---|---|---|---|
| `get_secret` | 500 `ERR_SECRET_GET` | 6 requests (~15s) | **1 request** |
| `get_secret` | 502/503/504 | 6 | 6 (unchanged) |
| `get_state` | 500 | 6 | 6 (unchanged) |
| `get_bulk_secret` | 500 | 6 | 6 (unchanged) |

## Deliberate non-goals

- **`502/503/504` stay retryable** on secrets — they come from a proxy or a refusing socket, never from a component reporting on a specific key, so they carry no "not found" ambiguity.
- **State, binding and pub/sub keep their 500 retry.** They have no equivalent classifier above them, so narrowing there would lose cold-start coverage outright.
- **`get_bulk_secret` untouched** — not on the probe path; keeps the change as small as the bug requires.
- **`_fetch_per_key_bundle` stays serial.** Concurrency would be defence-in-depth, but once a missing-key probe costs one round trip instead of ~15s it buys little, and parallel fan-out against a cloud vault invites throttling. Worth revisiting separately if it ever matters.

## Behaviour change worth a reviewer's eye

If a secrets `500` is *genuinely* transient **and** the component has already been confirmed ready, `retry_past_dapr_cold_start` short-circuits and no longer gets 15s of transport retries behind it — the error surfaces instead. That is the intended trade (`retry_past_dapr_cold_start`'s own docstring describes a later outage on a confirmed component as a steady-state failure), and `SecretStoreUnavailableError` remains Temporal-retryable. Flagging it because it is the one case that gets less retry than before.

## Tests

New `TestSecretsRetryScoping` in `tests/unit/infrastructure/test_dapr_http.py`, covering: no retry on a missing-key 500; 502/503/504 still retried; non-secret paths unchanged; bulk unchanged; the two `Retry` configs not drifting apart; `get_optional` resolving a missing key to `None` in one request; and a real cold-start 500 still being classified unavailable *and* retried by the cold-start loop.

`uv run pytest tests/unit/` — 6048 passed, 9 skipped. `uv run pre-commit run --files <changed>` — all hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)