### PR TITLE
fix(templates): raise the prime_sql_auth timeout from 60s to 120s

### DIFF
--- a/application_sdk/templates/sql_app.py
+++ b/application_sdk/templates/sql_app.py
@@ -86,6 +86,7 @@ from temporalio import workflow as _temporal_workflow
 from application_sdk.app.base import App
 from application_sdk.app.registry import AppRegistry
 from application_sdk.app.task import task
+from application_sdk.common._env import env_int
 from application_sdk.common.sql_filters import (
     normalize_filters,
     safe_substitute_placeholders,
@@ -132,6 +133,37 @@ _MapperFn = Callable[[dict[str, Any], str], Union["Asset", dict[str, Any]]]
 #: through ``client.run_query()``. Caps the in-flight set at
 #: ``_EXTRACT_BATCH_SIZE * row_size`` regardless of total result size.
 _EXTRACT_BATCH_SIZE: int = 10_000
+
+#: StartToClose budget for :meth:`SqlApp.prime_sql_auth`, overridable per
+#: deployment via ``ATLAN_PRIME_SQL_AUTH_TIMEOUT_SECONDS``.
+#:
+#: The probe itself — open one connection, ``SELECT 1``, close — is typically
+#: well under a second. But the activity's budget also covers everything
+#: ``_init_sql_client`` does first, including resolving credentials through the
+#: Dapr secret store. Where that resolution is slow (a remote cloud vault, a
+#: per-key lookup shape that probes several keys serially, a sidecar under
+#: contention) it can dominate the budget while the SQL connect stays in the
+#: hundreds of milliseconds — so the activity times out on credential
+#: resolution and never reaches the source. ``retry_max_attempts=1`` makes that
+#: terminal for the workflow attempt, and it fails the whole extraction DAG.
+#:
+#: The default is 120s rather than the original 60s because an observed
+#: production shape spent ~55s in credential resolution — ~92% of a 60s budget,
+#: so runs succeeded or failed on a few seconds of jitter. 120s is still modest
+#: next to the 1800s the ``extract_*`` tasks below carry.
+#:
+#: Safe with respect to heartbeating: ``@task`` leaves
+#: ``heartbeat_timeout_seconds`` at 60 and ``auto_heartbeat_seconds`` at 10, and
+#: ``auto_heartbeat_loop`` runs as a background asyncio task
+#: (``execution/_temporal/activities.py``), so an activity parked in an
+#: ``await`` for 120s keeps heartbeating and cannot trip the 60s heartbeat
+#: timeout ahead of StartToClose.
+#:
+#: Read once at import time, matching ``ATLAN_START_TO_CLOSE_TIMEOUT_SECONDS``
+#: and ``ATLAN_HEARTBEAT_TIMEOUT_SECONDS`` in ``application_sdk/app/task.py``.
+PRIME_SQL_AUTH_TIMEOUT_SECONDS: int = env_int(
+    "ATLAN_PRIME_SQL_AUTH_TIMEOUT_SECONDS", 120
+)
 
 
 def _orjson_default(obj: Any) -> Any:
@@ -249,7 +281,15 @@ class SqlApp(App):
     # ``retry_max_attempts=3`` (application_sdk/app/task.py), so we MUST
     # override explicitly. See application-sdk#1835 mothership review
     # comment-3287629972.
-    @task(timeout_seconds=60, retry_max_attempts=1)
+    # The budget is env-overridable (see PRIME_SQL_AUTH_TIMEOUT_SECONDS): the
+    # activity has to cover credential resolution as well as the probe, and on
+    # some deployments the former dominates. retry_max_attempts=1 means a
+    # timeout is terminal for the workflow attempt, so a merely-slow deployment
+    # needs a way to buy headroom without an SDK release.
+    @task(
+        timeout_seconds=PRIME_SQL_AUTH_TIMEOUT_SECONDS,
+        retry_max_attempts=1,
+    )
     async def prime_sql_auth(self, input: ExtractionTaskInput) -> PrimeAuthOutput:
         """Single sequential probe that primes the SQL server's auth cache
         before the parallel ``_extract_entity`` burst.

--- a/application_sdk/templates/sql_app.py
+++ b/application_sdk/templates/sql_app.py
@@ -133,31 +133,6 @@ _MapperFn = Callable[[dict[str, Any], str], Union["Asset", dict[str, Any]]]
 #: ``_EXTRACT_BATCH_SIZE * row_size`` regardless of total result size.
 _EXTRACT_BATCH_SIZE: int = 10_000
 
-#: StartToClose budget for :meth:`SqlApp.prime_sql_auth`.
-#:
-#: The probe itself — open one connection, ``SELECT 1``, close — is typically
-#: well under a second. But the activity's budget also covers everything
-#: ``_init_sql_client`` does first, including resolving credentials through the
-#: Dapr secret store. Where that resolution is slow (a remote cloud vault, a
-#: per-key lookup shape that probes several keys serially, a sidecar under
-#: contention) it can dominate the budget while the SQL connect stays in the
-#: hundreds of milliseconds — so the activity times out on credential
-#: resolution and never reaches the source. ``retry_max_attempts=1`` makes that
-#: terminal for the workflow attempt, and it fails the whole extraction DAG.
-#:
-#: 120s rather than the original 60s because an observed production shape
-#: spent ~55s in credential resolution — ~92% of a 60s budget, so runs
-#: succeeded or failed on a few seconds of jitter. 120s is still modest
-#: next to the 1800s the ``extract_*`` tasks below carry.
-#:
-#: Safe with respect to heartbeating: ``@task`` leaves
-#: ``heartbeat_timeout_seconds`` at 60 and ``auto_heartbeat_seconds`` at 10, and
-#: ``auto_heartbeat_loop`` runs as a background asyncio task
-#: (``execution/_temporal/activities.py``), so an activity parked in an
-#: ``await`` for 120s keeps heartbeating and cannot trip the 60s heartbeat
-#: timeout ahead of StartToClose.
-PRIME_SQL_AUTH_TIMEOUT_SECONDS: int = 120
-
 
 def _orjson_default(obj: Any) -> Any:
     """Fallback serialiser for orjson — covers types it doesn't handle natively.
@@ -274,15 +249,10 @@ class SqlApp(App):
     # ``retry_max_attempts=3`` (application_sdk/app/task.py), so we MUST
     # override explicitly. See application-sdk#1835 mothership review
     # comment-3287629972.
-    # The budget is 120s, not the @task default (see
-    # PRIME_SQL_AUTH_TIMEOUT_SECONDS): the activity has to cover credential
-    # resolution as well as the probe, and on some deployments the former
-    # dominates. retry_max_attempts=1 means a timeout is terminal for the
-    # workflow attempt, so the budget needs headroom.
-    @task(
-        timeout_seconds=PRIME_SQL_AUTH_TIMEOUT_SECONDS,
-        retry_max_attempts=1,
-    )
+    # The budget is 120s because the activity has to cover credential
+    # resolution (which can be slow on some deployments) as well as the probe,
+    # and retry_max_attempts=1 makes a timeout terminal for the workflow attempt.
+    @task(timeout_seconds=120, retry_max_attempts=1)
     async def prime_sql_auth(self, input: ExtractionTaskInput) -> PrimeAuthOutput:
         """Single sequential probe that primes the SQL server's auth cache
         before the parallel ``_extract_entity`` burst.

--- a/application_sdk/templates/sql_app.py
+++ b/application_sdk/templates/sql_app.py
@@ -86,7 +86,6 @@ from temporalio import workflow as _temporal_workflow
 from application_sdk.app.base import App
 from application_sdk.app.registry import AppRegistry
 from application_sdk.app.task import task
-from application_sdk.common._env import env_int
 from application_sdk.common.sql_filters import (
     normalize_filters,
     safe_substitute_placeholders,
@@ -134,8 +133,7 @@ _MapperFn = Callable[[dict[str, Any], str], Union["Asset", dict[str, Any]]]
 #: ``_EXTRACT_BATCH_SIZE * row_size`` regardless of total result size.
 _EXTRACT_BATCH_SIZE: int = 10_000
 
-#: StartToClose budget for :meth:`SqlApp.prime_sql_auth`, overridable per
-#: deployment via ``ATLAN_PRIME_SQL_AUTH_TIMEOUT_SECONDS``.
+#: StartToClose budget for :meth:`SqlApp.prime_sql_auth`.
 #:
 #: The probe itself — open one connection, ``SELECT 1``, close — is typically
 #: well under a second. But the activity's budget also covers everything
@@ -147,9 +145,9 @@ _EXTRACT_BATCH_SIZE: int = 10_000
 #: resolution and never reaches the source. ``retry_max_attempts=1`` makes that
 #: terminal for the workflow attempt, and it fails the whole extraction DAG.
 #:
-#: The default is 120s rather than the original 60s because an observed
-#: production shape spent ~55s in credential resolution — ~92% of a 60s budget,
-#: so runs succeeded or failed on a few seconds of jitter. 120s is still modest
+#: 120s rather than the original 60s because an observed production shape
+#: spent ~55s in credential resolution — ~92% of a 60s budget, so runs
+#: succeeded or failed on a few seconds of jitter. 120s is still modest
 #: next to the 1800s the ``extract_*`` tasks below carry.
 #:
 #: Safe with respect to heartbeating: ``@task`` leaves
@@ -158,12 +156,7 @@ _EXTRACT_BATCH_SIZE: int = 10_000
 #: (``execution/_temporal/activities.py``), so an activity parked in an
 #: ``await`` for 120s keeps heartbeating and cannot trip the 60s heartbeat
 #: timeout ahead of StartToClose.
-#:
-#: Read once at import time, matching ``ATLAN_START_TO_CLOSE_TIMEOUT_SECONDS``
-#: and ``ATLAN_HEARTBEAT_TIMEOUT_SECONDS`` in ``application_sdk/app/task.py``.
-PRIME_SQL_AUTH_TIMEOUT_SECONDS: int = env_int(
-    "ATLAN_PRIME_SQL_AUTH_TIMEOUT_SECONDS", 120
-)
+PRIME_SQL_AUTH_TIMEOUT_SECONDS: int = 120
 
 
 def _orjson_default(obj: Any) -> Any:
@@ -281,11 +274,11 @@ class SqlApp(App):
     # ``retry_max_attempts=3`` (application_sdk/app/task.py), so we MUST
     # override explicitly. See application-sdk#1835 mothership review
     # comment-3287629972.
-    # The budget is env-overridable (see PRIME_SQL_AUTH_TIMEOUT_SECONDS): the
-    # activity has to cover credential resolution as well as the probe, and on
-    # some deployments the former dominates. retry_max_attempts=1 means a
-    # timeout is terminal for the workflow attempt, so a merely-slow deployment
-    # needs a way to buy headroom without an SDK release.
+    # The budget is 120s, not the @task default (see
+    # PRIME_SQL_AUTH_TIMEOUT_SECONDS): the activity has to cover credential
+    # resolution as well as the probe, and on some deployments the former
+    # dominates. retry_max_attempts=1 means a timeout is terminal for the
+    # workflow attempt, so the budget needs headroom.
     @task(
         timeout_seconds=PRIME_SQL_AUTH_TIMEOUT_SECONDS,
         retry_max_attempts=1,

--- a/tests/unit/templates/test_sql_app.py
+++ b/tests/unit/templates/test_sql_app.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 from typing import Any, ClassVar
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -1798,6 +1799,87 @@ class TestPrimeSqlAuth:
         # ... but the password is gone and userinfo is collapsed to ***@.
         assert "s3cr3t" not in logged
         assert "postgresql://***@db.host" in logged
+
+    # ── Configurable budget ─────────────────────────────────────────────
+
+    def test_budget_is_wired_into_the_activity_and_defaults_to_120s(self):
+        """The durable guard, and the one that needs no module reload: whatever
+        the module constant resolves to *is* the activity's StartToClose."""
+        from application_sdk.app.task import get_task_metadata
+        from application_sdk.templates.sql_app import PRIME_SQL_AUTH_TIMEOUT_SECONDS
+
+        meta = get_task_metadata(SqlApp.prime_sql_auth)
+        assert meta is not None
+        assert meta.timeout_seconds == PRIME_SQL_AUTH_TIMEOUT_SECONDS
+        assert PRIME_SQL_AUTH_TIMEOUT_SECONDS == 120
+        assert meta.retry_max_attempts == 1, (
+            "making the budget configurable must not disturb the load-bearing "
+            "retry_max_attempts=1 — activity retry here would re-stack "
+            "failed_login_attempts on the source"
+        )
+
+    def test_budget_cannot_outlive_the_heartbeat(self):
+        """A 120s StartToClose is only reachable if the activity keeps
+        heartbeating: ``auto_heartbeat_loop`` runs as a background asyncio task
+        whenever both knobs are set, so an activity parked in an ``await`` still
+        beats. If either were disabled, the 60s heartbeat timeout would fire
+        first and the raised budget would be dead config."""
+        from application_sdk.app.task import get_task_metadata
+        from application_sdk.templates.sql_app import PRIME_SQL_AUTH_TIMEOUT_SECONDS
+
+        meta = get_task_metadata(SqlApp.prime_sql_auth)
+        assert meta is not None
+        assert meta.heartbeat_timeout_seconds is not None
+        assert meta.auto_heartbeat_seconds is not None
+        assert meta.auto_heartbeat_seconds < meta.heartbeat_timeout_seconds
+        assert PRIME_SQL_AUTH_TIMEOUT_SECONDS > meta.heartbeat_timeout_seconds, (
+            "this guard is only meaningful while the budget exceeds the "
+            "heartbeat timeout — if that stops being true, revisit it"
+        )
+
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ("180", 180),
+            ("not-a-number", 120),  # a typo in deploy config must not crash boot
+            ("", 120),
+        ],
+    )
+    def test_budget_env_var_parsing(self, raw: str, expected: int):
+        """The read itself, isolated from import-time wiring (covered above)."""
+        from application_sdk.common._env import env_int
+
+        with patch.dict(os.environ, {"ATLAN_PRIME_SQL_AUTH_TIMEOUT_SECONDS": raw}):
+            assert env_int("ATLAN_PRIME_SQL_AUTH_TIMEOUT_SECONDS", 120) == expected
+
+    def test_env_override_reaches_the_activity_end_to_end(self):
+        """Closes the loop the two tests above only imply: the env var really
+        does change the activity's StartToClose.
+
+        Needs a module reload because the constant is read at import time.
+        ``importlib.reload`` re-executes the module into its *existing*
+        namespace dict rather than making a new module object, so already-bound
+        method code objects keep resolving globals through that same dict — which
+        is why string-target patches in sibling tests still work afterwards. The
+        ``finally`` reload restores the default so ordering can't leak.
+        """
+        import importlib
+
+        import application_sdk.templates.sql_app as sql_app_mod
+        from application_sdk.app.task import get_task_metadata
+
+        try:
+            with patch.dict(
+                os.environ, {"ATLAN_PRIME_SQL_AUTH_TIMEOUT_SECONDS": "180"}
+            ):
+                importlib.reload(sql_app_mod)
+                assert sql_app_mod.PRIME_SQL_AUTH_TIMEOUT_SECONDS == 180
+                meta = get_task_metadata(sql_app_mod.SqlApp.prime_sql_auth)
+                assert meta is not None
+                assert meta.timeout_seconds == 180
+        finally:
+            importlib.reload(sql_app_mod)
+        assert sql_app_mod.PRIME_SQL_AUTH_TIMEOUT_SECONDS == 120
 
     # ── Bug-reproduction via call ordering ──────────────────────────────
 

--- a/tests/unit/templates/test_sql_app.py
+++ b/tests/unit/templates/test_sql_app.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import json
-import os
 from typing import Any, ClassVar
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -1800,11 +1799,11 @@ class TestPrimeSqlAuth:
         assert "s3cr3t" not in logged
         assert "postgresql://***@db.host" in logged
 
-    # ── Configurable budget ─────────────────────────────────────────────
+    # ── Budget ──────────────────────────────────────────────────────────
 
-    def test_budget_is_wired_into_the_activity_and_defaults_to_120s(self):
-        """The durable guard, and the one that needs no module reload: whatever
-        the module constant resolves to *is* the activity's StartToClose."""
+    def test_budget_is_wired_into_the_activity_and_is_120s(self):
+        """Whatever the module constant resolves to *is* the activity's
+        StartToClose."""
         from application_sdk.app.task import get_task_metadata
         from application_sdk.templates.sql_app import PRIME_SQL_AUTH_TIMEOUT_SECONDS
 
@@ -1813,7 +1812,7 @@ class TestPrimeSqlAuth:
         assert meta.timeout_seconds == PRIME_SQL_AUTH_TIMEOUT_SECONDS
         assert PRIME_SQL_AUTH_TIMEOUT_SECONDS == 120
         assert meta.retry_max_attempts == 1, (
-            "making the budget configurable must not disturb the load-bearing "
+            "raising the budget must not disturb the load-bearing "
             "retry_max_attempts=1 — activity retry here would re-stack "
             "failed_login_attempts on the source"
         )
@@ -1836,50 +1835,6 @@ class TestPrimeSqlAuth:
             "this guard is only meaningful while the budget exceeds the "
             "heartbeat timeout — if that stops being true, revisit it"
         )
-
-    @pytest.mark.parametrize(
-        ("raw", "expected"),
-        [
-            ("180", 180),
-            ("not-a-number", 120),  # a typo in deploy config must not crash boot
-            ("", 120),
-        ],
-    )
-    def test_budget_env_var_parsing(self, raw: str, expected: int):
-        """The read itself, isolated from import-time wiring (covered above)."""
-        from application_sdk.common._env import env_int
-
-        with patch.dict(os.environ, {"ATLAN_PRIME_SQL_AUTH_TIMEOUT_SECONDS": raw}):
-            assert env_int("ATLAN_PRIME_SQL_AUTH_TIMEOUT_SECONDS", 120) == expected
-
-    def test_env_override_reaches_the_activity_end_to_end(self):
-        """Closes the loop the two tests above only imply: the env var really
-        does change the activity's StartToClose.
-
-        Needs a module reload because the constant is read at import time.
-        ``importlib.reload`` re-executes the module into its *existing*
-        namespace dict rather than making a new module object, so already-bound
-        method code objects keep resolving globals through that same dict — which
-        is why string-target patches in sibling tests still work afterwards. The
-        ``finally`` reload restores the default so ordering can't leak.
-        """
-        import importlib
-
-        import application_sdk.templates.sql_app as sql_app_mod
-        from application_sdk.app.task import get_task_metadata
-
-        try:
-            with patch.dict(
-                os.environ, {"ATLAN_PRIME_SQL_AUTH_TIMEOUT_SECONDS": "180"}
-            ):
-                importlib.reload(sql_app_mod)
-                assert sql_app_mod.PRIME_SQL_AUTH_TIMEOUT_SECONDS == 180
-                meta = get_task_metadata(sql_app_mod.SqlApp.prime_sql_auth)
-                assert meta is not None
-                assert meta.timeout_seconds == 180
-        finally:
-            importlib.reload(sql_app_mod)
-        assert sql_app_mod.PRIME_SQL_AUTH_TIMEOUT_SECONDS == 120
 
     # ── Bug-reproduction via call ordering ──────────────────────────────
 

--- a/tests/unit/templates/test_sql_app.py
+++ b/tests/unit/templates/test_sql_app.py
@@ -1801,39 +1801,16 @@ class TestPrimeSqlAuth:
 
     # ── Budget ──────────────────────────────────────────────────────────
 
-    def test_budget_is_wired_into_the_activity_and_is_120s(self):
-        """Whatever the module constant resolves to *is* the activity's
-        StartToClose."""
+    def test_budget_is_120s_and_retry_stays_1(self):
         from application_sdk.app.task import get_task_metadata
-        from application_sdk.templates.sql_app import PRIME_SQL_AUTH_TIMEOUT_SECONDS
 
         meta = get_task_metadata(SqlApp.prime_sql_auth)
         assert meta is not None
-        assert meta.timeout_seconds == PRIME_SQL_AUTH_TIMEOUT_SECONDS
-        assert PRIME_SQL_AUTH_TIMEOUT_SECONDS == 120
+        assert meta.timeout_seconds == 120
         assert meta.retry_max_attempts == 1, (
             "raising the budget must not disturb the load-bearing "
             "retry_max_attempts=1 — activity retry here would re-stack "
             "failed_login_attempts on the source"
-        )
-
-    def test_budget_cannot_outlive_the_heartbeat(self):
-        """A 120s StartToClose is only reachable if the activity keeps
-        heartbeating: ``auto_heartbeat_loop`` runs as a background asyncio task
-        whenever both knobs are set, so an activity parked in an ``await`` still
-        beats. If either were disabled, the 60s heartbeat timeout would fire
-        first and the raised budget would be dead config."""
-        from application_sdk.app.task import get_task_metadata
-        from application_sdk.templates.sql_app import PRIME_SQL_AUTH_TIMEOUT_SECONDS
-
-        meta = get_task_metadata(SqlApp.prime_sql_auth)
-        assert meta is not None
-        assert meta.heartbeat_timeout_seconds is not None
-        assert meta.auto_heartbeat_seconds is not None
-        assert meta.auto_heartbeat_seconds < meta.heartbeat_timeout_seconds
-        assert PRIME_SQL_AUTH_TIMEOUT_SECONDS > meta.heartbeat_timeout_seconds, (
-            "this guard is only meaningful while the budget exceeds the "
-            "heartbeat timeout — if that stops being true, revisit it"
         )
 
     # ── Bug-reproduction via call ordering ──────────────────────────────


### PR DESCRIPTION
## Problem

`prime_sql_auth` was `@task(timeout_seconds=60, retry_max_attempts=1)`.

The probe it performs — open one connection, `SELECT 1`, close — is sub-second. But the activity's budget also covers everything `_init_sql_client` does first, and that includes **resolving credentials through the Dapr secret store**.

On deployments where that resolution is slow, it can consume most of the budget while the SQL connect stays in the hundreds of milliseconds. The activity times out having never contacted the source.

`retry_max_attempts=1` is load-bearing (activity retry here would re-stack `failed_login_attempts` on the source — the exact lockout this task exists to prevent), so that timeout is **terminal for the workflow attempt**, and it fails the whole extraction DAG. Downstream nodes then fail on unresolvable jsonpaths, which reads like a manifest bug rather than a credential-resolution timeout.

In an observed production shape, prime durations were ~55–57s against the 60s budget with the actual connect at 0.3–0.5s — so runs succeeded or failed on a few seconds of jitter.

## Change

`timeout_seconds=60` → `timeout_seconds=120`. That's it.

120s is still modest next to the 1800s the `extract_*` tasks in the same file carry, and it is reachable: the auto-heartbeat loop (`auto_heartbeat_seconds=10` against `heartbeat_timeout_seconds=60`) keeps the activity beating past 60s.

`retry_max_attempts=1` is untouched, with a test asserting it stays 1 so raising the budget can never silently re-enable activity retry.

This is a mitigation, not a root-cause fix — the slow credential resolution itself is addressed in #2916 (draft).

## Tests

`test_budget_is_120s_and_retry_stays_1` in `tests/unit/templates/test_sql_app.py`.

`uv run pytest tests/unit/templates/test_sql_app.py` — 76 passed. `pre-commit` — all hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
