### PR TITLE
fix(transformers): unify list[dict] keys; add migrate-off-daft skill

### DIFF
--- a/.claude/skills/adopt-preflight-gate/SKILL.md
+++ b/.claude/skills/adopt-preflight-gate/SKILL.md
@@ -37,7 +37,7 @@ staleness_days: 90
 inputs:
   - app_root: "auto-detected — the directory containing app/ and pyproject.toml"
 outputs:
-  - uv.lock + pyproject.toml (SDK floor raised and lockfile synced — >=3.24.0 for the gate itself; the no-verdict/budget semantics need the first release after CNCT-99, so read the changelog rather than assuming 3.24.0 covers them)
+  - uv.lock + pyproject.toml (floor raised to >=3.24.1 — the gate plus the budget knobs — then pinned to the resolved latest outside the release cooldown, with the whole lock refreshed via `uv lock --upgrade`; the no-verdict/budget semantics need the first release after CNCT-99, so read the changelog rather than assuming the floor covers them)
   - app/handler.py (status logic per the agreed check tree; typed errors on failed checks)
   - app/failures.py (every app-specific typed class in one module — created or extended, shared with /typed-failures)
   - app/<app>.py (preflight_gate_mode, plus preflight_gate_timeout_seconds / preflight_gate_max_attempts when the default budget does not fit)
@@ -374,15 +374,41 @@ Run these detections and report the bucket(s) before changing anything:
 
 ## Phase 1 — Bump and boot
 
-1. Bump `atlan-application-sdk` to the current gate-capable floor —
-   **`>=3.24.0`** — in `pyproject.toml`, then
-   `uv lock --upgrade-package atlan-application-sdk` and
-   `uv sync --all-extras --all-groups`. 3.24.0 is the baseline that carries the
-   gate, the multi-credential primitive (`preflight_credential_refs` /
-   `credentials_by_name`), and the per-entrypoint credential handling this skill
-   relies on. Raise the declared floor if it sits below `>=3.24.0`. (Earlier
-   revisions of this skill said "don't raise the floor" — that is retired; pin
-   `>=3.24.0` from now.) After the bump, confirm the surfaces landed:
+0. **Daft-cliff pre-check (mandatory when the lock resolves SDK <3.20.0).**
+   SDK v3.20.0 removed daft and moved the transformation layer to
+   DuckDB/pyarrow — the bump below drags the app across that cliff. Check
+   `uv.lock`'s resolved `atlan-application-sdk` version; if it is below
+   3.20.0, or `grep -rn "import daft" app/` hits, **invoke
+   `/migrate-off-daft` now** and complete it before proceeding — it owns the
+   breakage taxonomy (empty `[daft]` extra, changed transformer contracts,
+   missing `duckdb`, the silent literal-vs-column precedence flip) and its
+   done-bar is output parity: transformed output structurally identical, no
+   attribute lost. Only when its step-4 evidence is green does phase 1
+   continue; the daft migration and the gate adoption land as separable
+   changes, in that order.
+1. **Always resolve the current latest SDK first** —
+   `curl -s https://pypi.org/pypi/atlan-application-sdk/json | jq -r
+   .info.version` — and pin the newest version outside the 7-day release
+   cooldown that satisfies the gate floor —
+   **`>=3.24.1`** — in `pyproject.toml`. Then refresh the whole lock, not
+   just the SDK:
+   `uv lock --upgrade --exclude-newer "$(date -u -v-7d +%Y-%m-%dT%H:%M:%SZ)"`
+   (GNU date: `date -u -d '7 days ago' ...`) followed by
+   `uv sync --all-extras --all-groups` — the `--exclude-newer` bound keeps
+   every transitive pick inside the org's release-age cooldown, and the full
+   refresh means stale transitive pins don't surface as unrelated breakage
+   mid-adoption. (If the full upgrade drags in
+   an unrelated failure, bisect by falling back to
+   `uv lock --upgrade-package atlan-application-sdk` and report the
+   offending dep — but the full refresh is the default.)
+   3.24.0 carries the gate, the multi-credential primitive
+   (`preflight_credential_refs` / `credentials_by_name`), and the
+   per-entrypoint credential handling this skill relies on; **3.24.1 adds the
+   budget knobs** (`preflight_gate_timeout_seconds` /
+   `preflight_gate_max_attempts`), which the sizing steps below need — hence
+   the floor. Raise the declared floor if it sits below `>=3.24.1`. (Earlier
+   revisions of this skill said "don't raise the floor", then pinned
+   `>=3.24.0` — both retired.) After the bump, confirm the surfaces landed:
    `PreflightInput.credentials_by_name` / `preflight_credential_refs` must be
    importable, or the upgrade didn't take.
 2. **Boot the worker.** Boot is the collision detector.

--- a/.claude/skills/adopt-preflight-gate/SKILL.md
+++ b/.claude/skills/adopt-preflight-gate/SKILL.md
@@ -386,11 +386,15 @@ Run these detections and report the bucket(s) before changing anything:
    attribute lost. Only when its step-4 evidence is green does phase 1
    continue; the daft migration and the gate adoption land as separable
    changes, in that order.
-1. **Always resolve the current latest SDK first** —
+1. **Always resolve the current latest SDK first.** `.info.version` alone
+   may still be inside the release cooldown, so list versions with upload
+   dates and pick the newest one older than 7 days:
    `curl -s https://pypi.org/pypi/atlan-application-sdk/json | jq -r
-   .info.version` — and pin the newest version outside the 7-day release
-   cooldown that satisfies the gate floor —
-   **`>=3.24.1`** — in `pyproject.toml`. Then refresh the whole lock, not
+   '.releases | to_entries[] | [.key, .value[0].upload_time] | @tsv'`.
+   Pin that version — it must also satisfy the gate floor,
+   **`>=3.24.1`** — in `pyproject.toml`. (Pinning an in-cooldown version and
+   then locking with the `--exclude-newer` bound below is unsatisfiable and
+   fails with an unhelpful resolution error.) Then refresh the whole lock, not
    just the SDK:
    `uv lock --upgrade --exclude-newer "$(date -u -v-7d +%Y-%m-%dT%H:%M:%SZ)"`
    (GNU date: `date -u -d '7 days ago' ...`) followed by

--- a/.claude/skills/adopt-preflight-gate/SKILL.md
+++ b/.claude/skills/adopt-preflight-gate/SKILL.md
@@ -394,7 +394,14 @@ Run these detections and report the bucket(s) before changing anything:
    Pin that version — it must also satisfy the gate floor,
    **`>=3.24.1`** — in `pyproject.toml`. (Pinning an in-cooldown version and
    then locking with the `--exclude-newer` bound below is unsatisfiable and
-   fails with an unhelpful resolution error.) Then refresh the whole lock, not
+   fails with an unhelpful resolution error.)
+   **Tiebreak when the floor itself is still inside the cooldown** (no
+   version satisfies both): the floor wins. Adopt the in-cooldown version,
+   drop the `--exclude-newer` bound for the SDK only (keep it for everything
+   else via `uv lock --upgrade-package atlan-application-sdk` after the
+   bounded full refresh), and flag the fresh pick for human review in the PR
+   — per the org's fresh-dependency rule — noting the date the cooldown
+   clears. Then refresh the whole lock, not
    just the SDK:
    `uv lock --upgrade --exclude-newer "$(date -u -v-7d +%Y-%m-%dT%H:%M:%SZ)"`
    (GNU date: `date -u -d '7 days ago' ...`) followed by

--- a/.claude/skills/migrate-off-daft/SKILL.md
+++ b/.claude/skills/migrate-off-daft/SKILL.md
@@ -154,7 +154,7 @@ those sites (declared directly — see step 3's boundary policy) or replace
 them per step 2c; either way each site needs a decision with parity
 evidence, and no daft object may cross an SDK boundary afterwards.
 
-## Step 2 — The seven breakage classes (mechanism + fix)
+## Step 2 — The core breakage classes (1–7, plus 1b/2b; heavy-user classes 8–12 are in step 2c)
 
 ### 1. `[daft]` extra is declared but empty — daft silently leaves the lock
 
@@ -244,13 +244,19 @@ daft's `from_pylist` unified schemas across records, so apps never had to
 care.
 
 The SDK's own `list[dict]` coercion had this hazard until it was fixed to
-normalize records to the union of keys (`query/__init__.py:338`, test:
+build the table over the union of keys (the list branch of
+`QueryBasedTransformer.transform_metadata`; test:
 `tests/unit/transformers/query/test_sql_transformer.py::test_transform_metadata_list_input_unifies_keys_across_records`).
-**Check the app's pinned SDK actually contains that fix** (the test above, or
-read the coercion) — on older 3.2x pins, passing heterogeneous `list[dict]`
-is lossy and the app must guard: normalize keys itself or build the
-`pa.Table` with an explicit schema. App-side `pa.Table.from_pylist` calls the
-app writes are **always** the app's problem — same guard applies.
+The same fix keeps class-5 precedence sane: a colliding column that is
+entirely null still yields the template literal; a column with any real
+value wins deterministically, regardless of which record carries it (tests:
+`test_template_literal_wins_when_colliding_column_is_all_null`,
+`test_colliding_source_column_wins_over_template_literal`).
+**Check the app's pinned SDK actually contains that fix** (the tests above,
+or read the coercion) — on older 3.2x pins, passing heterogeneous
+`list[dict]` is lossy and the app must guard: normalize keys itself or build
+the `pa.Table` with an explicit schema. App-side `pa.Table.from_pylist`
+calls the app writes are **always** the app's problem — same guard applies.
 
 ### 1b. A pin that looks protective and isn't
 
@@ -360,7 +366,11 @@ rows = transformer.transform_metadata(dataframe=records, ...) or []
    `to_pylist()`.
 2. `pyproject.toml`: `[daft,...]` → the extras actually needed (`[sql]` for
    transformer users; keep `[pandas]`/`[workflows]` etc. as-is). Then
-   `uv lock` + `uv sync --all-extras --all-groups`, and **verify the lock**:
+   `uv lock --exclude-newer "$(date -u -v-7d +%Y-%m-%dT%H:%M:%SZ)"` (GNU
+   date: `date -u -d '7 days ago' ...`) + `uv sync --all-extras
+   --all-groups` — the extras change resolves fresh packages (duckdb and
+   friends), and the bound keeps them inside the release cooldown. Then
+   **verify the lock**:
    `grep -c 'name = "duckdb"' uv.lock` ≥1, `grep -c 'name = "daft"' uv.lock`
    = 0.
 3. Apply the class-6 guard if the pinned SDK predates the key-union fix, or

--- a/.claude/skills/migrate-off-daft/SKILL.md
+++ b/.claude/skills/migrate-off-daft/SKILL.md
@@ -1,0 +1,442 @@
+---
+name: migrate-off-daft
+description: >
+  Migrate a connector app across the SDK 3.20.0 daft cliff. In v3.20.0
+  (commit 41f32e1d, PR #2300) the SDK removed daft entirely and rerouted the
+  transformation layer to DuckDB + pyarrow + orjson, in one cut — any app
+  whose lockfile crosses 3.19.x → 3.20.0+ hits every break at once. The skill
+  resolves the latest published SDK version (never a hardcoded floor),
+  detects every daft dependency the app has — declared, transitive, or
+  behavioral — and classifies each site as wrapper vs compute against the
+  known breakage classes: empty [daft] extra (and override-dependencies
+  pins that silently stop protecting), changed transform_metadata
+  input/output contracts (direct or via SDK internals like
+  prepare_template_and_attributes), DuckDB engine without its extra,
+  literal-vs-column precedence flip, first-record schema inference, test
+  coupling — plus the heavy-user classes: python-object UDF columns with no
+  DuckDB equivalent, daft.sql caller-frame binding vs explicit register,
+  daft-planner-specific type coercions, daft-safety concurrency
+  architecture to retire deliberately, and live-daft golden oracles that
+  must be frozen to static fixtures before daft is removed. Drives the
+  fixes with the developer. Boundary policy: an app may keep daft for its
+  own compute (declared as a direct dependency, never via the SDK's empty
+  [daft] extra), but no daft object may cross an SDK boundary — every
+  SDK-facing usage is migrated safely (convert at the boundary or delete
+  the wrapper). Default fix stance for wrapper sites: delete the daft
+  wrapper and pass list[dict], guarded against schema loss. The done-bar
+  is output parity: the
+  migrated app's transformed output must be structurally identical to the
+  pre-3.20 output with no attribute lost — any observable difference is a
+  defect unless the developer explicitly accepts it. Run this BEFORE any
+  skill that bumps the SDK (adopt-preflight-gate, upgrade-v3) when the app
+  is below 3.20.0.
+mandatory_triggers:
+  - "/migrate-off-daft"
+  - "migrate off daft"
+  - "daft migration"
+  - "app breaks on daft after SDK bump"
+optional_triggers:
+  - "remove daft from this app"
+  - "duckdb pyarrow migration"
+  - "SDK bump broke transformers"
+owner: connector-platform-team
+last_updated: "2026-07-29"
+staleness_days: 90
+inputs:
+  - app_root: "auto-detected — the directory containing app/ and pyproject.toml"
+outputs:
+  - pyproject.toml (daft extra replaced with the extras the app actually needs — [sql] for QueryBasedTransformer users; daft declared directly only in the documented last-resort case)
+  - uv.lock (resynced; verified to contain duckdb when the app transforms, and daft only if deliberately kept)
+  - app code with the daft wrapper deleted (from_pylist/count_rows/to_pylist/iter_rows call sites) or bridged
+  - extractor/template fixes for literal-name collisions (the silent-corruption class)
+  - updated tests, including a heterogeneous-records regression test where list[dict] is passed
+---
+
+# Migrate off daft (the SDK 3.20.0 cliff)
+
+## The cliff, precisely
+
+One commit, one release: `41f32e1d` — *remove daft entirely, replace with
+pyarrow/orjson/duckdb* (#2300) — shipped in **v3.20.0** (2026-06-25). Nothing
+was staged in 3.19.x or 3.21.x, so an app crossing 3.19 → 3.20+ hits every
+change below simultaneously. Judge exposure from **`uv.lock`** (the resolved
+version), not the declared floor — floors are usually loose, and an app whose
+lock already resolves ≥3.20 is *already broken* regardless of what branch you
+are on; reverting a later bump fixes nothing.
+
+## Step 0 — Resolve the real target version (never hardcode)
+
+```bash
+curl -s https://pypi.org/pypi/atlan-application-sdk/json | jq -r .info.version
+```
+
+Then apply the org release-age cooldown: default to the newest version
+public ≥7 days (`jq -r '.releases[<ver>][0].upload_time'` gives the date).
+A version inside the cooldown window is only adoptable for a genuine security
+fix; otherwise pin the newest version outside the window and note the newer
+one for follow-up. Other skills' hardcoded floors (e.g. adopt-preflight-gate's
+`>=3.24.1`) are *minimums for their feature*, not the target — pin the
+resolved latest that satisfies both.
+
+## Step 1 — Detect every daft dependency (declared, transitive, behavioral)
+
+Run all of these; each maps to a breakage class in step 2. Report the full
+hit list to the developer before editing anything.
+
+```bash
+# (a) module-scope imports — fail at import/collection time once daft vanishes
+grep -rn "^import daft\|^from daft\|    import daft\|    from daft" app/ tests/
+
+# (b) the empty-extra trap — pyproject asks for [daft], lock has no daft
+grep -n "atlan-application-sdk\[" pyproject.toml
+grep -c 'name = "daft"' uv.lock   # 0 on any lock resolving SDK >=3.20
+
+# (c) deleted SDK surface
+grep -rn "_execute_query_daft" app/ tests/
+
+# (d) daft methods on transformer results — runtime AttributeError
+grep -rn "\.to_pylist()\|\.to_pydict()\|\.iter_rows()\|\.count_rows()\|\.to_arrow()" app/
+
+# (e) the deprecated enum (silently routes to pandas since 3.20)
+grep -rn "DataframeType.daft" app/ tests/
+
+# (f) dead config and dead error-code matching
+grep -rn "DAFT_" Dockerfile* helm/ .env* 2>/dev/null
+grep -rn "_DAFT_" app/ tests/
+
+# (g) engine dependency — QueryBasedTransformer now needs duckdb
+grep -rn "QueryBasedTransformer\|AtlasTransformer" app/
+# duckdb ships only in the SDK's [sql] and [incremental] extras — check yours
+
+# (h) literal-collision candidates (the silent-corruption class, step 2 #5)
+grep -rn "source_query: *\"'" app/transformers/*.yaml app/**/*.yaml 2>/dev/null
+
+# (i) pins that LOOK protective but aren't — uv override/constraint entries
+#     only constrain packages already in the graph; once the [daft] extra
+#     empties, an override-dependencies daft pin is a silent no-op
+grep -n "override-dependencies\|constraint-dependencies" pyproject.toml
+
+# (j) indirect SDK-contract exposure — apps that OVERRIDE transform_metadata
+#     but still call SDK internals; grep the helpers, not just the entrypoint
+grep -rn "prepare_template_and_attributes\|generate_sql_query\|get_grouped_dataframe_by_prefix" app/
+
+# (k) daft as a COMPUTE ENGINE, not a wrapper (step 2b classes)
+grep -rn "daft.sql(\|\.apply(\|DataType.python()\|daft.col(\|daft.lit(\|from_arrow(" app/
+
+# (l) daft-specific infrastructure: executors, exception classifiers,
+#     metrics, review rules — orphaned (not just dead) when daft goes
+grep -rn "DAFT_EXECUTOR\|DaftCoreException\|daft_executor\|_classify_daft" app/ tests/ REVIEW.md .claude/ 2>/dev/null
+
+# (m) parity/golden tests that compute their reference BY RUNNING daft live
+grep -rln "daft" tests/ | xargs grep -ln "golden\|parity\|_golden_records" 2>/dev/null
+```
+
+For (h), extract each literal column *name* (e.g. `status: source_query:
+"'ACTIVE'"` → `status`) and intersect it with the keys the app's extractors
+actually emit for that typename. Any intersection is a live corruption site.
+The membership check is **case-sensitive Python** (`in
+dataframe.schema.names`) while DuckDB resolves identifiers
+case-insensitively — a same-name-different-case pair is a latent trap even
+when today's casing is benign; note it in the report.
+
+Then **trace reachability**: for every module-scope `import daft`, walk the
+import chain from `main.py` / the App module. A daft import reachable from
+the entrypoint chain is a **worker-boot crash for every workflow** —
+including ones (e.g. a miner) that use no daft at all. Blast radius is the
+app, not the transform.
+
+Finally, **classify each daft call site as wrapper vs compute** — this
+drives the whole fix stance. Wrapper = the frame exists only to satisfy an
+SDK signature (list[dict] in, list[dict] out) → step 3's default deletion
+applies. Compute = daft does work of its own (UDFs, expressions, casts
+driven by daft's planner, its SQL entrypoint) → the app may keep daft for
+those sites (declared directly — see step 3's boundary policy) or replace
+them per step 2c; either way each site needs a decision with parity
+evidence, and no daft object may cross an SDK boundary afterwards.
+
+## Step 2 — The seven breakage classes (mechanism + fix)
+
+### 1. `[daft]` extra is declared but empty — daft silently leaves the lock
+
+Since 3.20 the SDK still `Provides-Extra: daft` with **zero** matching
+`Requires-Dist` entries (`pyproject.toml:73-75` documents it as a no-op alias,
+removed next major). An empty extra is not an error in uv — no warning, no
+resolution failure; daft just stops arriving while `pyproject.toml` still
+*looks* like it requests it. Module-scope `import daft` then fails at import
+time: the worker can't load the app module and pytest fails at **collection**,
+not at runtime.
+
+Lesson to state to the developer: **if you import it, declare it** — an extra
+on someone else's package is not a supply contract you control.
+
+Fix: don't reinstall daft to quiet the import (see class 2 for why). Delete
+the import with the wrapper (step 3). Replace `[daft,...]` in the app's
+extras with what it actually needs — `[sql]` supplies `duckdb` +
+`duckdb-engine` for transformer users.
+
+### 2. `transform_metadata` input contract: daft DataFrame → `pa.Table | pd.DataFrame | list[dict]`
+
+The coercion (`application_sdk/transformers/query/__init__.py:338-341`)
+converts lists and pandas frames; a daft DataFrame matches **neither branch
+and passes through unconverted** — there is no `else: raise`. It then dies
+inside `db.connection.register("dataframe", <daft df>)`, deep in DuckDB,
+reading like a data/schema problem rather than a version mismatch. That is
+why reinstalling daft makes diagnosis *worse*, not better: it moves a clean
+`ModuleNotFoundError` to an inscrutable engine error.
+
+Known misleading signature: `AttributeError: 'function' object has no
+attribute 'names'` = a daft DataFrame reached code expecting pyarrow.
+`pa.Table.schema` is a property; `daft.DataFrame.schema` is a **method**, so
+`.schema.names` asks a bound method for `.names`. The message never says
+"wrong dataframe type" — that is what happened.
+
+### 3. SQL engine is DuckDB now — and `duckdb` may not be installed
+
+3.19 executed the generated YAML-template SQL on daft-SQL (which bound the
+`FROM dataframe` identifier by *inspecting the caller's local variables*).
+3.20+ registers the table explicitly and executes on DuckDB
+(`query/__init__.py:367-378`). The `duckdb` import is **function-local**, so
+nothing fails at boot or import — the first real transform call raises
+`ModuleNotFoundError: duckdb`. Ships only in the SDK's `[sql]` and
+`[incremental]` extras.
+
+### 4. `transform_metadata` return contract: daft DataFrame → `list[dict] | None`
+
+Any `.to_pylist()` / `.to_pydict()` / `.iter_rows()` on the result raises
+`AttributeError: 'list' object has no attribute ...`. Items are dicts shaped
+`{"typeName": ..., "status": ..., "attributes": {...}}` — iterate them
+directly. Note the classes mask each other in order 2 → 3 → 4: fixing one
+surfaces the next; budget for the sequence, not one crash.
+
+### 5. Literal-vs-source-column precedence flipped — SILENT corruption
+
+The one that matters most, because nothing crashes. Mechanism (verified in
+SDK code, not folklore):
+
+- A quoted-literal template column (`status: source_query: "'ACTIVE'"`) is
+  classified as a literal and its SQL expression is emitted as
+  `"status" AS "status"` — a **self-reference to a dataframe column**, not
+  the literal (`query/__init__.py:119-120`, `:143-163`).
+- The literal's value is moved into `default_attributes`
+  (`query/__init__.py:296-306`) and appended as a constant column **only
+  `if col_name not in dataframe.schema.names`** (`:308-312`).
+- So when the extractor's records already carry a key with the same name,
+  the source column always wins and the template literal is silently
+  discarded. Under daft-SQL the literal won; the engine swap inverted it.
+
+Symptom seen live: every published entity of one typename carrying the
+source system's lifecycle status instead of the reserved Atlan `ACTIVE`.
+Fix at the **source of the collision**, not downstream: rename the extractor
+key (`record["analysisStatus"] = record.pop("status", None)`) so the reserved
+name is unambiguous. Run the step-1(h) intersection for *every* template ×
+extractor pair; blast radius is exactly the typenames whose records carry a
+colliding key.
+
+### 6. `pa.Table.from_pylist` infers schema from the FIRST record only
+
+```python
+pa.Table.from_pylist([{"a": 1}, {"a": 2, "b": 3}]).schema.names  # ['a'] — 'b' gone, no error
+```
+
+Any batch whose first record lacks an optional key drops that attribute for
+the whole batch — incomplete entities published, no exception anywhere.
+daft's `from_pylist` unified schemas across records, so apps never had to
+care.
+
+The SDK's own `list[dict]` coercion had this hazard until it was fixed to
+normalize records to the union of keys (`query/__init__.py:338`, test:
+`tests/unit/transformers/query/test_sql_transformer.py::test_transform_metadata_list_input_unifies_keys_across_records`).
+**Check the app's pinned SDK actually contains that fix** (the test above, or
+read the coercion) — on older 3.2x pins, passing heterogeneous `list[dict]`
+is lossy and the app must guard: normalize keys itself or build the
+`pa.Table` with an explicit schema. App-side `pa.Table.from_pylist` calls the
+app writes are **always** the app's problem — same guard applies.
+
+### 1b. A pin that looks protective and isn't
+
+An app may carry `override-dependencies = ["daft==0.7.x"]` (or a constraint
+entry) and treat it as a hard guardrail. uv overrides only constrain packages
+**already in the dependency graph** — once the SDK's `[daft]` extra empties,
+the override constrains nothing and daft leaves the lock anyway, with the
+pyproject still reading like it's pinned. Only a **direct dependency** keeps
+daft installed. Found live in atlan-snowflake-app (`override-dependencies`
+believed to be load-bearing; it wasn't).
+
+### 2b. Indirect contract exposure — overriding `transform_metadata` doesn't insulate you
+
+An app that fully overrides `transform_metadata` and never calls the SDK's
+still breaks if the override calls SDK **internals**:
+`prepare_template_and_attributes` / `generate_sql_query` read
+`dataframe.schema.names` (`query/__init__.py:141`), `len(dataframe)` and
+`.append_column` (`:309-312`) — none of which work on a daft frame — and
+`get_grouped_dataframe_by_prefix` now takes a `pa.Table` and returns
+`list[dict]`, so the override's own return type changes out from under its
+callers (class 4, one hop removed). Grep the helpers (step 1j), not just the
+entrypoint.
+
+### 7. Test coupling exposed by the fixes
+
+Parity/legacy tests that feed one shared dict to both the v3 transformer and
+a legacy renderer break the moment a fix mutates the record (e.g. the
+class-5 `pop`). The coupling was always fragile — it worked only while
+enrichment was purely additive. Fix by giving the legacy path its own copy of
+the raw record, with a comment saying why. Similarly, regression fixtures
+that exist to reproduce a *daft behavior* (e.g. daft's JSON reader producing
+`numpy.ndarray`) should keep their guarantee but synthesize the input
+directly (numpy) instead of via daft — never drop the assertion with the
+dependency.
+
+## Step 2c — Heavy users: when daft is a compute engine, not a wrapper
+
+Classes 1–7 model daft as an SDK-signature wrapper. Heavy users (reference:
+atlan-snowflake-app) also use it as an engine, and each of these needs a
+designed replacement, not a deletion:
+
+- **8. Python-object UDF columns have no DuckDB/pyarrow equivalent.**
+  `daft.col(c).apply(fn, return_dtype=daft.DataType.python())` holds
+  arbitrary Python objects (parsed JSON, lists of structs) mid-pipeline.
+  DuckDB has no python-object column type and `pa.Table` cannot hold one.
+  Relocate that logic to run **after** materialization to `list[dict]` —
+  and treat the move as an output-parity hazard, because it changes where
+  null/type coercion happens.
+- **9. `daft.sql()` binds tables by caller-frame magic; DuckDB needs an
+  explicit register.** `daft.sql("... FROM dataframe")` resolves the
+  identifier by inspecting the caller's local variables. The DuckDB
+  equivalent requires `conn.register("dataframe", table)` before execute —
+  a mechanical rewrite that misses the registration dies with
+  `Catalog Error: Table 'dataframe' does not exist`.
+- **10. Daft-planner-specific type coercions become wrong-shaped.** Casts
+  added to satisfy daft's plan-build-time type validation (Null→String,
+  Decimal→Int64, etc.) may be unnecessary under DuckDB — or actively change
+  results (e.g. a Null→String cast feeding a `CAST(col AS TIMESTAMP)` /
+  `DATE_TRUNC`). Audit every schema-driven cast helper against the new
+  engine's semantics instead of porting it verbatim; expect a per-dialect
+  override map, not a shared one.
+- **11. Concurrency architecture built for daft must be retired
+  deliberately.** Single-thread executors, plan-cache-corruption defences,
+  daft-exception classifiers, and their metrics/review rules exist because
+  daft 0.7.x's plan cache was not concurrency-safe. DuckDB is natively
+  multi-threaded: keeping the executor silently serializes the new engine
+  (throughput cap); deleting it uncorks concurrency the app's memory budget
+  was never sized for. Removing the guard and re-tuning the concurrency
+  setting are one decision, taken with the developer.
+- **12. Freeze golden fixtures BEFORE removing daft.** If parity tests
+  compute their reference by *running the daft path live* at test time,
+  deleting daft deletes the only proof the replacement engine matches.
+  First run the daft path once, commit its output as static fixtures, and
+  point the parity tests at them — then remove daft.
+
+Housekeeping the audit should also flag: stale ARCHITECTURE/CLAUDE docs
+describing daft code that no longer exists (they misdirect the migration),
+obsolete pyproject comments reasoning about daft's pyarrow ceiling (delete,
+don't adjust — verify the app's pyarrow window overlaps the SDK's
+`>=23.0.1,<24` first), and the fact that `QueryBasedTransformer` itself is
+deprecated for v4.0 — the daft migration and the asset-mapper migration are
+the same code, so at minimum record the follow-up so it isn't done twice.
+
+## Step 3 — The fix, in order
+
+Default stance for **wrapper** sites (per the step-1 wrapper-vs-compute
+classification): **delete daft, don't port it.** The records were
+`list[dict]` on the way in and `list[dict]` on the way out — the daft
+DataFrame existed only to satisfy the old signature. The migration is a
+deletion. **Compute** sites follow step 2c instead, and for heavy users the
+very first action — before any deletion — is freezing live-daft golden
+fixtures (class 12), or the parity bar in step 4 becomes unprovable:
+
+```python
+# before
+df = daft.from_pylist(records)
+if df.count_rows() > 0:
+    transformed = transformer.transform_metadata(dataframe=df, ...)
+    rows = transformed.to_pylist()
+
+# after
+rows = transformer.transform_metadata(dataframe=records, ...) or []
+```
+
+1. Delete `import daft`, `daft.from_pylist`, `count_rows()` (usually
+   redundant — records are already guarded non-empty upstream),
+   `to_pylist()`.
+2. `pyproject.toml`: `[daft,...]` → the extras actually needed (`[sql]` for
+   transformer users; keep `[pandas]`/`[workflows]` etc. as-is). Then
+   `uv lock` + `uv sync --all-extras --all-groups`, and **verify the lock**:
+   `grep -c 'name = "duckdb"' uv.lock` ≥1, `grep -c 'name = "daft"' uv.lock`
+   = 0.
+3. Apply the class-6 guard if the pinned SDK predates the key-union fix, or
+   if the app builds pyarrow tables itself.
+4. Fix every class-5 collision found in step 1(h), at the extractor.
+5. Update tests (class 7), and add the heterogeneous-records regression test
+   for any `list[dict]` handoff.
+
+**Keeping daft for the app's own compute is allowed — the boundary is the
+SDK.** The policy, stated plainly:
+
+- An app that genuinely uses daft as its own engine (UDFs, expressions, its
+  SQL — the step-2c classes) **may keep it**. It must declare
+  `daft>=0.7.15,<0.8` as a **direct dependency** — never via the SDK's
+  `[daft]` extra (empty) and never via an `override-dependencies` pin
+  (silent no-op, class 1b). If you import it, you declare it.
+- What is **not allowed to survive the bump** is daft crossing an SDK
+  boundary: a daft frame passed to `transform_metadata`, to SDK internals
+  (`prepare_template_and_attributes`, `get_grouped_dataframe_by_prefix`),
+  or to SDK readers/writers. Every such crossing must be migrated — either
+  convert at the boundary (`dataframe.to_arrow()` going in, and consume the
+  `list[dict]` return coming out) or take the default deletion where the
+  frame was only a wrapper. The SDK will never see or supply daft again.
+- Whichever path a kept-daft app takes, the step-4 output-parity bar and
+  the class-12 golden-freeze rule apply unchanged, and the PR records which
+  sites kept daft and why. Note the standing debt regardless: the
+  transformer path is deprecated for v4.0 (asset-mapper is the target), so
+  kept-daft compute will be revisited then.
+
+## Step 4 — Validate: the done-bar is OUTPUT PARITY
+
+The goal of this migration is that the app's transformed output is **the
+same** as it was on the pre-3.20 SDK — same entity structure, same
+attributes, same values for everything that matters. The engine swap is an
+implementation detail; any observable output change (a dropped attribute, a
+flipped literal, a reshaped record) is a defect, not an acceptable delta.
+The only allowed differences are ones the developer has explicitly reviewed
+and accepted (e.g. a class-5 fix that *corrects* a value the old engine got
+right by accident — state those in the PR).
+
+- **Parity check first-class**: transform a representative extract on the
+  migrated code and diff it against golden output from the pre-migration
+  branch (or the app's existing parity suite). Diff per typename; every
+  difference must be explained.
+- Full test suite; collection errors are class 1, `AttributeError`s are
+  classes 2/4, `ModuleNotFoundError: duckdb` is class 3.
+- Boot the worker (`uv run main.py`) — class 3 hides from boot, so also run
+  one real transform (or the parity suite) end-to-end.
+- Parity tests against golden output are the only net that catches class 5 —
+  if the app has none, at minimum assert the literal-declared attributes
+  (`status == "ACTIVE"` etc.) on transformed output for every typename whose
+  records carry a colliding key.
+- The deployed image gets exactly `uv.lock` (`uv sync --locked`), so a wrong
+  lock is a production outage, not a dev inconvenience — treat lock
+  verification as part of done.
+
+## Debugging discipline (from a real post-mortem)
+
+Change **one variable at a time**. The observed wrong turn: installing an
+unpinned daft while also on a new SDK, then attributing the failure to daft
+API drift. Killing the hypothesis took re-running the identical venv against
+the old SDK and the exact old daft pin. When a bump breaks an app, hold the
+app's other deps fixed at what main resolves and vary only the SDK — the
+lockfile diff between main and the branch is the complete list of what
+actually changed.
+
+## Agent protocol
+
+Two stops, developer decides at each:
+
+1. **After step 1** — the full detection report: every hit, its breakage
+   class, the literal-collision intersections, and the proposed fix stance
+   (default vs last-resort, with reasoning). No edits yet.
+2. **After step 4** — evidence: suite output, lock verification, worker
+   boot, and the class-5 assertion results. Then hand off for PR review.
+
+If the app is also below the preflight-gate floor, run this skill **first**,
+land it (or stack it), then `/adopt-preflight-gate` — its SDK bump assumes
+the daft cliff is already behind you.

--- a/.claude/skills/migrate-off-daft/SKILL.md
+++ b/.claude/skills/migrate-off-daft/SKILL.md
@@ -176,7 +176,8 @@ extras with what it actually needs — `[sql]` supplies `duckdb` +
 
 ### 2. `transform_metadata` input contract: daft DataFrame → `pa.Table | pd.DataFrame | list[dict]`
 
-The coercion (`application_sdk/transformers/query/__init__.py:338-341`)
+The coercion (the input-normalization branch at the top of
+`QueryBasedTransformer.transform_metadata`)
 converts lists and pandas frames; a daft DataFrame matches **neither branch
 and passes through unconverted** — there is no `else: raise`. It then dies
 inside `db.connection.register("dataframe", <daft df>)`, deep in DuckDB,
@@ -195,7 +196,8 @@ attribute 'names'` = a daft DataFrame reached code expecting pyarrow.
 3.19 executed the generated YAML-template SQL on daft-SQL (which bound the
 `FROM dataframe` identifier by *inspecting the caller's local variables*).
 3.20+ registers the table explicitly and executes on DuckDB
-(`query/__init__.py:367-378`). The `duckdb` import is **function-local**, so
+(the `DuckDBConnectionManager` block in `transform_metadata`). The
+`duckdb` import is **function-local**, so
 nothing fails at boot or import — the first real transform call raises
 `ModuleNotFoundError: duckdb`. Ships only in the SDK's `[sql]` and
 `[incremental]` extras.
@@ -216,9 +218,10 @@ SDK code, not folklore):
 - A quoted-literal template column (`status: source_query: "'ACTIVE'"`) is
   classified as a literal and its SQL expression is emitted as
   `"status" AS "status"` — a **self-reference to a dataframe column**, not
-  the literal (`query/__init__.py:119-120`, `:143-163`).
+  the literal (`convert_to_sql_expression(is_literal=True)` via
+  `get_sql_column_expressions`).
 - The literal's value is moved into `default_attributes`
-  (`query/__init__.py:296-306`) and appended as a constant column **only
+  (in `prepare_template_and_attributes`) and applied **only
   `if col_name not in dataframe.schema.names`** (`:308-312`).
 - So when the extractor's records already carry a key with the same name,
   the source column always wins and the template literal is silently
@@ -273,7 +276,7 @@ believed to be load-bearing; it wasn't).
 An app that fully overrides `transform_metadata` and never calls the SDK's
 still breaks if the override calls SDK **internals**:
 `prepare_template_and_attributes` / `generate_sql_query` read
-`dataframe.schema.names` (`query/__init__.py:141`), `len(dataframe)` and
+`dataframe.schema.names` (`get_sql_column_expressions`), `len(dataframe)` and
 `.append_column` (`:309-312`) — none of which work on a daft frame — and
 `get_grouped_dataframe_by_prefix` now takes a `pa.Table` and returns
 `list[dict]`, so the override's own return type changes out from under its

--- a/.claude/skills/migrate-off-daft/SKILL.md
+++ b/.claude/skills/migrate-off-daft/SKILL.md
@@ -133,7 +133,9 @@ grep -rln "daft" tests/ | xargs grep -ln "golden\|parity\|_golden_records" 2>/de
 
 For (h), extract each literal column *name* (e.g. `status: source_query:
 "'ACTIVE'"` → `status`) and intersect it with the keys the app's extractors
-actually emit for that typename. Any intersection is a live corruption site.
+actually emit for that typename. Any intersection is a live corruption site
+on SDKs predating the row-local precedence fix, and a design smell to review
+with the developer after it (see class 5 for the version split).
 The membership check is **case-sensitive Python** (`in
 dataframe.schema.names`) while DuckDB resolves identifiers
 case-insensitively — a same-name-different-case pair is a latent trap even
@@ -220,20 +222,37 @@ SDK code, not folklore):
   `"status" AS "status"` — a **self-reference to a dataframe column**, not
   the literal (`convert_to_sql_expression(is_literal=True)` via
   `get_sql_column_expressions`).
-- The literal's value is moved into `default_attributes`
-  (in `prepare_template_and_attributes`) and applied **only
-  `if col_name not in dataframe.schema.names`** (`:308-312`).
-- So when the extractor's records already carry a key with the same name,
-  the source column always wins and the template literal is silently
-  discarded. Under daft-SQL the literal won; the engine swap inverted it.
+- The literal's value is moved into `default_attributes` (in
+  `prepare_template_and_attributes`) and applied only where the table has no
+  source data for that name.
+- So when the extractor's records carry a genuine value under the same name,
+  the source value wins and the template literal does not apply. Under
+  daft-SQL the literal always won; the engine swap inverted it.
 
-Symptom seen live: every published entity of one typename carrying the
-source system's lifecycle status instead of the reserved Atlan `ACTIVE`.
-Fix at the **source of the collision**, not downstream: rename the extractor
-key (`record["analysisStatus"] = record.pop("status", None)`) so the reserved
-name is unambiguous. Run the step-1(h) intersection for *every* template ×
-extractor pair; blast radius is exactly the typenames whose records carry a
-colliding key.
+**How much wins depends on the SDK version** (same before/after split as
+class 6):
+
+- **Before the row-local fix** (3.20 through 3.24.x): the decision is
+  column-level — if the colliding key is in the table's schema, the literal
+  is discarded for the *whole batch*, including rows that had no value
+  (published as null). On pre-key-union pins it is also record-order
+  dependent. Symptom seen live: every published entity of one typename
+  carrying the source system's lifecycle status instead of the reserved
+  Atlan `ACTIVE`. Against these SDKs, **any** step-1(h) intersection is a
+  live corruption site.
+- **After the row-local fix** (first release carrying
+  `test_literal_precedence_is_row_local_on_colliding_column`): a genuine
+  source value wins for its own row, the literal fills the rows without
+  one, and a type-incompatible collision raises a typed
+  `IncompatibleDefaultTypeError` instead of corrupting. An intersection is
+  then a *design smell* to review with the developer, not automatic
+  corruption.
+
+Either way, fix collisions at the **source**, not downstream: rename the
+extractor key (`record["analysisStatus"] = record.pop("status", None)`) so
+the reserved name is unambiguous. Run the step-1(h) intersection for
+*every* template × extractor pair; blast radius is exactly the typenames
+whose records carry a colliding key.
 
 ### 6. `pa.Table.from_pylist` infers schema from the FIRST record only
 
@@ -250,11 +269,10 @@ The SDK's own `list[dict]` coercion had this hazard until it was fixed to
 build the table over the union of keys (the list branch of
 `QueryBasedTransformer.transform_metadata`; test:
 `tests/unit/transformers/query/test_sql_transformer.py::test_transform_metadata_list_input_unifies_keys_across_records`).
-The same fix keeps class-5 precedence sane: a colliding column that is
-entirely null still yields the template literal; a column with any real
-value wins deterministically, regardless of which record carries it (tests:
-`test_template_literal_wins_when_colliding_column_is_all_null`,
-`test_colliding_source_column_wins_over_template_literal`).
+The same fix keeps class-5 precedence sane and row-local: a genuine source
+value wins for its own row, the template literal fills the rows without one
+(tests: `test_template_literal_wins_when_colliding_column_is_all_null`,
+`test_literal_precedence_is_row_local_on_colliding_column`).
 **Check the app's pinned SDK actually contains that fix** (the tests above,
 or read the coercion) — on older 3.2x pins, passing heterogeneous
 `list[dict]` is lossy and the app must guard: normalize keys itself or build
@@ -277,7 +295,8 @@ An app that fully overrides `transform_metadata` and never calls the SDK's
 still breaks if the override calls SDK **internals**:
 `prepare_template_and_attributes` / `generate_sql_query` read
 `dataframe.schema.names` (`get_sql_column_expressions`), `len(dataframe)` and
-`.append_column` (`:309-312`) — none of which work on a daft frame — and
+`.append_column` (the default-attributes loop) — none of which work on a
+daft frame — and
 `get_grouped_dataframe_by_prefix` now takes a `pa.Table` and returns
 `list[dict]`, so the override's own return type changes out from under its
 callers (class 4, one hop removed). Grep the helpers (step 1j), not just the

--- a/.claude/skills/upgrade-v3/SKILL.md
+++ b/.claude/skills/upgrade-v3/SKILL.md
@@ -1325,7 +1325,7 @@ All blocking DB calls inside the loop must be wrapped in `self.run_in_thread()` 
 
 `orjson`, `temporalio`, and `dapr` are in the `[workflows]` optional extra, not core dependencies. Without it the container fails with `ModuleNotFoundError: No module named 'orjson'`.
 ```toml
-"atlan-application-sdk[daft,iam-auth,pandas,workflows]"
+"atlan-application-sdk[sql,iam-auth,pandas,workflows]"
 ```
 
 ### Seeding credentials for local dev
@@ -1380,17 +1380,17 @@ transform_kwargs = {
 
 ### Transformer output format
 
-`QueryBasedTransformer.transform_metadata()` returns a Daft DataFrame with columns `typeName`, `status`, `attributes` — NOT `entity`. Write JSONL by iterating these:
+`QueryBasedTransformer.transform_metadata()` returns `list[dict] | None`
+(since SDK 3.20.0 — it executes on DuckDB, not daft). Each item carries
+`typeName`, `status`, `attributes` keys — NOT `entity`. Write JSONL by
+iterating directly:
 ```python
-result_dict = transformed.to_pydict()
-for i in range(len(result_dict["typeName"])):
-    entity = {
-        "typeName": result_dict["typeName"][i],
-        "status": result_dict["status"][i],
-        "attributes": result_dict["attributes"][i],
-    }
-    f.write(json.dumps(entity).encode() + b"\n")
+rows = transformer.transform_metadata(...)
+for entity in rows or []:
+    f.write(orjson.dumps(entity) + b"\n")
 ```
+If upgrading an app whose lock resolved SDK <3.20.0, run `/migrate-off-daft`
+first — it owns the daft-removal breakage taxonomy.
 
 ### Output paths computed internally
 

--- a/application_sdk/transformers/query/__init__.py
+++ b/application_sdk/transformers/query/__init__.py
@@ -305,11 +305,19 @@ class QueryBasedTransformer(TransformerInterface):
             }
         )
 
-        # Append default attribute columns as constant arrays to the table
+        # Append default attribute columns as constant arrays to the table.
+        # A column that exists but is entirely null carries no source data,
+        # so the default/literal still wins there; a column with any real
+        # value is genuine source data and takes precedence.
         n = len(dataframe)
         for col_name, value in default_attributes.items():
-            if col_name not in dataframe.schema.names:
+            names = dataframe.schema.names
+            if col_name not in names:
                 dataframe = dataframe.append_column(col_name, pa.array([value] * n))
+            elif dataframe.column(col_name).null_count == n:
+                dataframe = dataframe.set_column(
+                    names.index(col_name), col_name, pa.array([value] * n)
+                )
 
         return dataframe, entity_sql_template
 
@@ -338,12 +346,11 @@ class QueryBasedTransformer(TransformerInterface):
         if isinstance(dataframe, list):
             if dataframe:
                 # pa.Table.from_pylist infers the schema from the first record
-                # only; normalize every record to the union of keys so an
-                # optional key missing from the first record is not silently
-                # dropped for the whole batch.
-                all_keys = {key: None for record in dataframe for key in record}
-                dataframe = pa.Table.from_pylist(
-                    [{key: record.get(key) for key in all_keys} for record in dataframe]
+                # only, silently dropping any key it lacks; build the table
+                # column-wise over the union of keys instead.
+                all_keys = dict.fromkeys(key for record in dataframe for key in record)
+                dataframe = pa.Table.from_pydict(
+                    {key: [record.get(key) for record in dataframe] for key in all_keys}
                 )
             else:
                 dataframe = None

--- a/application_sdk/transformers/query/__init__.py
+++ b/application_sdk/transformers/query/__init__.py
@@ -336,7 +336,17 @@ class QueryBasedTransformer(TransformerInterface):
         pd = sys.modules.get("pandas")
 
         if isinstance(dataframe, list):
-            dataframe = pa.Table.from_pylist(dataframe) if dataframe else None
+            if dataframe:
+                # pa.Table.from_pylist infers the schema from the first record
+                # only; normalize every record to the union of keys so an
+                # optional key missing from the first record is not silently
+                # dropped for the whole batch.
+                all_keys = {key: None for record in dataframe for key in record}
+                dataframe = pa.Table.from_pylist(
+                    [{key: record.get(key) for key in all_keys} for record in dataframe]
+                )
+            else:
+                dataframe = None
         elif pd is not None and isinstance(dataframe, pd.DataFrame):
             dataframe = pa.Table.from_pandas(dataframe, preserve_index=False)
         if dataframe is None or len(dataframe) == 0:

--- a/application_sdk/transformers/query/__init__.py
+++ b/application_sdk/transformers/query/__init__.py
@@ -305,19 +305,30 @@ class QueryBasedTransformer(TransformerInterface):
             }
         )
 
-        # Append default attribute columns as constant arrays to the table.
-        # A column that exists but is entirely null carries no source data,
-        # so the default/literal still wins there; a column with any real
-        # value is genuine source data and takes precedence.
+        # Append default attribute columns to the table. The decision is
+        # row-local: a genuine source value always wins for its row, and the
+        # default/literal fills the rows that have none — so the output does
+        # not depend on batch membership or record order.
+        import pyarrow.compute as pc  # noqa: PLC0415 — optional dep: pyarrow
+
         n = len(dataframe)
         for col_name, value in default_attributes.items():
             names = dataframe.schema.names
             if col_name not in names:
                 dataframe = dataframe.append_column(col_name, pa.array([value] * n))
-            elif dataframe.column(col_name).null_count == n:
-                dataframe = dataframe.set_column(
-                    names.index(col_name), col_name, pa.array([value] * n)
-                )
+                continue
+            column = dataframe.column(col_name)
+            if column.null_count == 0 or value is None:
+                continue
+            if column.null_count == n:
+                # rebuild rather than fill: also repairs a null-typed column,
+                # which fill_null cannot cast
+                replacement = pa.array([value] * n)
+            else:
+                replacement = pc.fill_null(column, value)
+            dataframe = dataframe.set_column(
+                names.index(col_name), col_name, replacement
+            )
 
         return dataframe, entity_sql_template
 

--- a/application_sdk/transformers/query/__init__.py
+++ b/application_sdk/transformers/query/__init__.py
@@ -25,6 +25,9 @@ from application_sdk.transformers.query.errors import (
     BuildStructPrefixRequiredError as BuildStructPrefixRequiredError,
 )
 from application_sdk.transformers.query.errors import (
+    IncompatibleDefaultTypeError as IncompatibleDefaultTypeError,
+)
+from application_sdk.transformers.query.errors import (
     SqlTransformNotRegisteredError as SqlTransformNotRegisteredError,
 )
 
@@ -325,7 +328,28 @@ class QueryBasedTransformer(TransformerInterface):
                 # which fill_null cannot cast
                 replacement = pa.array([value] * n)
             else:
-                replacement = pc.fill_null(column, value)
+                # fill_null does not type-check: a str default against a list
+                # column silently explodes into single characters. Cast first
+                # so representable defaults coerce and unrepresentable ones
+                # fail loudly, naming the collision.
+                try:
+                    fill = pa.scalar(value).cast(column.type)
+                except (
+                    pa.ArrowInvalid,
+                    pa.ArrowNotImplementedError,
+                    pa.ArrowTypeError,
+                ) as exc:
+                    raise IncompatibleDefaultTypeError(
+                        message=(
+                            f"default {col_name!r} ({type(value).__name__}) is "
+                            f"incompatible with source column type {column.type}; "
+                            "rename the colliding extractor key"
+                        ),
+                        column_name=col_name,
+                        column_type=str(column.type),
+                        default_type=type(value).__name__,
+                    ) from exc
+                replacement = pc.fill_null(column, fill)
             dataframe = dataframe.set_column(
                 names.index(col_name), col_name, replacement
             )

--- a/application_sdk/transformers/query/__init__.py
+++ b/application_sdk/transformers/query/__init__.py
@@ -323,15 +323,17 @@ class QueryBasedTransformer(TransformerInterface):
             column = dataframe.column(col_name)
             if column.null_count == 0 or value is None:
                 continue
-            if column.null_count == n:
-                # rebuild rather than fill: also repairs a null-typed column,
-                # which fill_null cannot cast
+            if pa.types.is_null(column.type):
+                # untyped all-null column: there is no source type to
+                # preserve, so the default legitimately defines the column
+                # (fill_null cannot cast a null-typed column)
                 replacement = pa.array([value] * n)
             else:
                 # fill_null does not type-check: a str default against a list
                 # column silently explodes into single characters. Cast first
                 # so representable defaults coerce and unrepresentable ones
-                # fail loudly, naming the collision.
+                # fail loudly, naming the collision — the same answer whatever
+                # the batch's null shape.
                 try:
                     fill = pa.scalar(value).cast(column.type)
                 except (
@@ -345,11 +347,16 @@ class QueryBasedTransformer(TransformerInterface):
                             f"incompatible with source column type {column.type}; "
                             "rename the colliding extractor key"
                         ),
-                        column_name=col_name,
-                        column_type=str(column.type),
-                        default_type=type(value).__name__,
+                        expectation=f"default castable to {column.type}",
+                        observed=type(value).__name__,
+                        location=col_name,
                     ) from exc
-                replacement = pc.fill_null(column, fill)
+                if column.null_count == n:
+                    # keep the column's type; a bare rebuild would re-infer
+                    # the default's own
+                    replacement = pa.array([fill.as_py()] * n, type=column.type)
+                else:
+                    replacement = pc.fill_null(column, fill)
             dataframe = dataframe.set_column(
                 names.index(col_name), col_name, replacement
             )

--- a/application_sdk/transformers/query/errors.py
+++ b/application_sdk/transformers/query/errors.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import ClassVar
 
-from application_sdk.errors.leaves import InternalError, UnimplementedError
+from application_sdk.errors.leaves import (
+    DataIntegrityError,
+    InternalError,
+    UnimplementedError,
+)
 
 
 @dataclass(kw_only=True)
@@ -23,14 +27,15 @@ class BuildStructPrefixRequiredError(InternalError):
 
 
 @dataclass(kw_only=True)
-class IncompatibleDefaultTypeError(InternalError):
-    code: ClassVar[str] = "INTERNAL_QUERY_DEFAULT_TYPE_MISMATCH"
+class IncompatibleDefaultTypeError(DataIntegrityError):
+    """An app-config collision: a template default cannot be represented in
+    the type of the extractor column sharing its name. Fixed by the app owner
+    renaming the colliding key — not an SDK invariant violation."""
+
+    code: ClassVar[str] = "DATA_INTEGRITY_QUERY_DEFAULT_TYPE_MISMATCH"
     message: str = (
         "Default value type is incompatible with the colliding source column type"
     )
-    column_name: str | None = None
-    column_type: str | None = None
-    default_type: str | None = None
 
 
 @dataclass(kw_only=True)

--- a/application_sdk/transformers/query/errors.py
+++ b/application_sdk/transformers/query/errors.py
@@ -23,6 +23,17 @@ class BuildStructPrefixRequiredError(InternalError):
 
 
 @dataclass(kw_only=True)
+class IncompatibleDefaultTypeError(InternalError):
+    code: ClassVar[str] = "INTERNAL_QUERY_DEFAULT_TYPE_MISMATCH"
+    message: str = (
+        "Default value type is incompatible with the colliding source column type"
+    )
+    column_name: str | None = None
+    column_type: str | None = None
+    default_type: str | None = None
+
+
+@dataclass(kw_only=True)
 class SqlTransformNotRegisteredError(UnimplementedError):
     code: ClassVar[str] = "UNIMPLEMENTED_QUERY_SQL_TRANSFORM"
     message: str = "No SQL transformation registered"

--- a/tests/unit/transformers/query/test_sql_transformer.py
+++ b/tests/unit/transformers/query/test_sql_transformer.py
@@ -9,6 +9,7 @@ from application_sdk.transformers.query import QueryBasedTransformer
 from application_sdk.transformers.query.errors import (
     BuildStructLevelRequiredError,
     BuildStructPrefixRequiredError,
+    IncompatibleDefaultTypeError,
 )
 
 
@@ -442,6 +443,65 @@ def test_literal_precedence_is_row_local_on_colliding_column(sql_transformer, tm
     )
 
     assert [row["status"] for row in result] == ["ACTIVE", "DELETED"]
+
+
+def test_castable_default_is_coerced_to_the_column_type(sql_transformer, tmp_path):
+    """An int template literal colliding with a string source column is cast
+    to the column's type and filled row-locally ('0', not a crash). Lossy but
+    representable casts are accepted deliberately; only unrepresentable
+    combinations raise (see the list-column test below)."""
+    template = tmp_path / "table.yaml"
+    template.write_text(
+        textwrap.dedent("""
+        columns:
+          status:
+            source_query: 0
+          attributes:
+            name:
+              source_query: table_name
+        """)
+    )
+    records = [
+        {"table_name": "t1", "status": None},
+        {"table_name": "t2", "status": "OK"},
+    ]
+
+    result = sql_transformer.transform_metadata(
+        "TABLE",
+        records,
+        "wf",
+        "run",
+        entity_class_definitions={"TABLE": str(template)},
+        connection_qualified_name="default/snowflake/1",
+    )
+
+    assert [row["status"] for row in result] == ["0", "OK"]
+
+
+def test_uncastable_default_raises_typed_error_not_silent_corruption(
+    sql_transformer, tmp_path
+):
+    """A string literal cannot fill a list-typed colliding column: pyarrow's
+    fill_null would explode 'ACTIVE' into single characters silently. The
+    guard must raise a typed error naming the column instead."""
+    template = tmp_path / "table.yaml"
+    template.write_text(LITERAL_STATUS_TEMPLATE)
+    records = [
+        {"table_name": "t1", "status": None},
+        {"table_name": "t2", "status": ["a", "b"]},
+    ]
+
+    with pytest.raises(IncompatibleDefaultTypeError) as exc_info:
+        sql_transformer.transform_metadata(
+            "TABLE",
+            records,
+            "wf",
+            "run",
+            entity_class_definitions={"TABLE": str(template)},
+            connection_qualified_name="default/snowflake/1",
+        )
+
+    assert "status" in str(exc_info.value)
 
 
 def test_reserved_default_fills_null_rows_of_colliding_column(

--- a/tests/unit/transformers/query/test_sql_transformer.py
+++ b/tests/unit/transformers/query/test_sql_transformer.py
@@ -386,6 +386,63 @@ def test_transform_metadata_list_input_unifies_keys_across_records(
     assert coerced.to_pylist()[1]["view_definition"] == "SELECT 1"
 
 
+LITERAL_STATUS_TEMPLATE = textwrap.dedent("""
+columns:
+  status:
+    source_query: "'ACTIVE'"
+  attributes:
+    name:
+      source_query: table_name
+""")
+
+
+def test_template_literal_wins_when_colliding_column_is_all_null(
+    sql_transformer, tmp_path
+):
+    """Records carrying only explicit Nones for a literal-declared name must
+    still get the template literal, not a null column."""
+    template = tmp_path / "table.yaml"
+    template.write_text(LITERAL_STATUS_TEMPLATE)
+    records = [
+        {"table_name": "t1", "status": None},
+        {"table_name": "t2", "status": None},
+    ]
+
+    result = sql_transformer.transform_metadata(
+        "TABLE",
+        records,
+        "wf",
+        "run",
+        entity_class_definitions={"TABLE": str(template)},
+        connection_qualified_name="default/snowflake/1",
+    )
+
+    assert [row["status"] for row in result] == ["ACTIVE", "ACTIVE"]
+
+
+def test_colliding_source_column_wins_over_template_literal(sql_transformer, tmp_path):
+    """A genuinely populated source column takes precedence over a template
+    literal (post-3.20 semantics), deterministically — regardless of which
+    record carries the value. Collisions belong fixed at the extractor."""
+    template = tmp_path / "table.yaml"
+    template.write_text(LITERAL_STATUS_TEMPLATE)
+    records = [
+        {"table_name": "t1"},
+        {"table_name": "t2", "status": "DELETED"},
+    ]
+
+    result = sql_transformer.transform_metadata(
+        "TABLE",
+        records,
+        "wf",
+        "run",
+        entity_class_definitions={"TABLE": str(template)},
+        connection_qualified_name="default/snowflake/1",
+    )
+
+    assert [row["status"] for row in result] == [None, "DELETED"]
+
+
 @patch(
     "application_sdk.transformers.query.QueryBasedTransformer.prepare_template_and_attributes"
 )

--- a/tests/unit/transformers/query/test_sql_transformer.py
+++ b/tests/unit/transformers/query/test_sql_transformer.py
@@ -478,23 +478,34 @@ def test_castable_default_is_coerced_to_the_column_type(sql_transformer, tmp_pat
     assert [row["status"] for row in result] == ["0", "OK"]
 
 
-def test_uncastable_default_raises_typed_error_not_silent_corruption(
-    sql_transformer, tmp_path
+@pytest.mark.parametrize(
+    "status_values",
+    [
+        pytest.param([None, ["a", "b"]], id="partially-null"),
+        pytest.param([None, None], id="all-null"),
+    ],
+)
+def test_uncastable_default_raises_regardless_of_null_shape(
+    sql_transformer, tmp_path, status_values
 ):
     """A string literal cannot fill a list-typed colliding column: pyarrow's
     fill_null would explode 'ACTIVE' into single characters silently. The
-    guard must raise a typed error naming the column instead."""
+    guard must raise a typed error naming the column — and the answer must
+    not depend on how many of the column's values happen to be null in this
+    batch."""
     template = tmp_path / "table.yaml"
     template.write_text(LITERAL_STATUS_TEMPLATE)
-    records = [
-        {"table_name": "t1", "status": None},
-        {"table_name": "t2", "status": ["a", "b"]},
-    ]
+    table = pa.table(
+        {
+            "table_name": ["t1", "t2"],
+            "status": pa.array(status_values, type=pa.list_(pa.string())),
+        }
+    )
 
     with pytest.raises(IncompatibleDefaultTypeError) as exc_info:
         sql_transformer.transform_metadata(
             "TABLE",
-            records,
+            table,
             "wf",
             "run",
             entity_class_definitions={"TABLE": str(template)},
@@ -502,6 +513,41 @@ def test_uncastable_default_raises_typed_error_not_silent_corruption(
         )
 
     assert "status" in str(exc_info.value)
+
+
+def test_compatible_default_fills_typed_all_null_column_preserving_type(
+    sql_transformer, tmp_path
+):
+    """A castable default filling a typed all-null column must keep the
+    column's Arrow type, not re-infer its own."""
+    template = tmp_path / "table.yaml"
+    template.write_text(
+        textwrap.dedent("""
+        columns:
+          status:
+            source_query: 0
+          attributes:
+            name:
+              source_query: table_name
+        """)
+    )
+    table = pa.table(
+        {
+            "table_name": ["t1", "t2"],
+            "status": pa.array([None, None], type=pa.string()),
+        }
+    )
+
+    prepared, _ = sql_transformer.prepare_template_and_attributes(
+        table,
+        "wf",
+        "run",
+        connection_qualified_name="default/snowflake/1",
+        entity_sql_template_path=str(template),
+    )
+
+    assert prepared.column("status").type == pa.string()
+    assert prepared.column("status").to_pylist() == ["0", "0"]
 
 
 def test_reserved_default_fills_null_rows_of_colliding_column(

--- a/tests/unit/transformers/query/test_sql_transformer.py
+++ b/tests/unit/transformers/query/test_sql_transformer.py
@@ -360,6 +360,38 @@ def test_transform_metadata_empty_dataframe(sql_transformer):
 @patch(
     "application_sdk.transformers.query.QueryBasedTransformer.get_grouped_dataframe_by_prefix"
 )
+def test_transform_metadata_list_input_unifies_keys_across_records(
+    mock_group, mock_prepare, sql_transformer
+):
+    """Keys absent from the first record must not be dropped from the batch.
+
+    pa.Table.from_pylist infers the schema from the first record only, so a
+    naive coercion silently loses any column the first record lacks.
+    """
+    records = [
+        {"table_name": "table1"},
+        {"table_name": "table2", "view_definition": "SELECT 1"},
+    ]
+    mock_prepare.side_effect = lambda dataframe, *a, **k: (
+        dataframe,
+        "SELECT * FROM dataframe",
+    )
+    mock_group.return_value = [{"typeName": "Table"}]
+
+    sql_transformer.transform_metadata("TABLE", records, "test_workflow", "test_run")
+
+    coerced = mock_prepare.call_args.args[0]
+    assert coerced.schema.names == ["table_name", "view_definition"]
+    assert coerced.to_pylist()[0]["view_definition"] is None
+    assert coerced.to_pylist()[1]["view_definition"] == "SELECT 1"
+
+
+@patch(
+    "application_sdk.transformers.query.QueryBasedTransformer.prepare_template_and_attributes"
+)
+@patch(
+    "application_sdk.transformers.query.QueryBasedTransformer.get_grouped_dataframe_by_prefix"
+)
 def test_transform_metadata(
     mock_group, mock_prepare, sql_transformer, sample_dataframe
 ):

--- a/tests/unit/transformers/query/test_sql_transformer.py
+++ b/tests/unit/transformers/query/test_sql_transformer.py
@@ -420,10 +420,11 @@ def test_template_literal_wins_when_colliding_column_is_all_null(
     assert [row["status"] for row in result] == ["ACTIVE", "ACTIVE"]
 
 
-def test_colliding_source_column_wins_over_template_literal(sql_transformer, tmp_path):
-    """A genuinely populated source column takes precedence over a template
-    literal (post-3.20 semantics), deterministically — regardless of which
-    record carries the value. Collisions belong fixed at the extractor."""
+def test_literal_precedence_is_row_local_on_colliding_column(sql_transformer, tmp_path):
+    """A genuine source value wins for its own row; rows without one get the
+    template literal. Row-local, so the outcome is independent of batch
+    membership and record order. Collisions still belong fixed at the
+    extractor."""
     template = tmp_path / "table.yaml"
     template.write_text(LITERAL_STATUS_TEMPLATE)
     records = [
@@ -440,7 +441,42 @@ def test_colliding_source_column_wins_over_template_literal(sql_transformer, tmp
         connection_qualified_name="default/snowflake/1",
     )
 
-    assert [row["status"] for row in result] == [None, "DELETED"]
+    assert [row["status"] for row in result] == ["ACTIVE", "DELETED"]
+
+
+def test_reserved_default_fills_null_rows_of_colliding_column(
+    sql_transformer, tmp_path
+):
+    """Reserved defaults (connection_qualified_name etc.) follow the same
+    row-local rule as template literals when records carry a colliding key."""
+    template = tmp_path / "table.yaml"
+    template.write_text(
+        textwrap.dedent("""
+        columns:
+          attributes:
+            qualifiedName:
+              source_query: concat(connection_qualified_name, '/', table_name)
+              source_columns: [connection_qualified_name, table_name]
+        """)
+    )
+    records = [
+        {"table_name": "t1", "connection_qualified_name": None},
+        {"table_name": "t2", "connection_qualified_name": "custom/cqn/2"},
+    ]
+
+    result = sql_transformer.transform_metadata(
+        "TABLE",
+        records,
+        "wf",
+        "run",
+        entity_class_definitions={"TABLE": str(template)},
+        connection_qualified_name="default/snowflake/1",
+    )
+
+    assert [row["attributes"]["qualifiedName"] for row in result] == [
+        "default/snowflake/1/t1",
+        "custom/cqn/2/t2",
+    ]
 
 
 @patch(


### PR DESCRIPTION
TL;DR: apps migrating off daft after the 3.20.0 removal are told to pass plain list[dict] to QueryBasedTransformer — but our own coercion silently drops any key the first record doesn't have. This fixes that, and adds a skill that owns the whole daft-cliff migration so SDK bump flows stop dragging apps across it blind.

## The transformer fix

`transform_metadata` coerces list input with `pa.Table.from_pylist(records)`, and pyarrow infers the schema from the first record only:

```python
pa.Table.from_pylist([{"a": 1}, {"a": 2, "b": 3}]).schema.names  # ['a'] — 'b' gone, no error
```

So any batch whose first record lacks an optional key drops that attribute for the entire batch — incomplete entities into publish, no exception anywhere. daft's `from_pylist` unified schemas across records, so apps coming off daft hit this exactly when they take the recommended migration path (delete the daft wrapper, pass records directly). Found while migrating consumer apps past 3.20.0.

Fix: build the table column-wise over the union of keys. Verified a strict no-op for homogeneous batches (record[0] carrying all keys reproduces the exact same column value lists).

### Literal precedence, made deterministic

Surfacing the union of keys interacts with template-literal handling: literals (e.g. `status: "'ACTIVE'"`) are applied only when the column is absent from the table, so a colliding key carried by any record would have suppressed the literal for the whole batch — including rows where the column was null. Handled explicitly:

- a colliding column that is entirely null still gets the template literal (no source data, literal wins)
- a colliding column with any real value wins deterministically, regardless of which record carries it — previously this depended on whether record[0] happened to carry the key, which made the documented literal-vs-source flip order-dependent

Three regression tests pin the union-of-keys behavior and both precedence outcomes. AtlasTransformer is unaffected — it iterates list rows directly.

## New skill: migrate-off-daft

3.20.0 removed daft in one cut (#2300). Consumer apps that constructed daft frames themselves break in ways we've now hit across three real migrations, so the taxonomy has a canonical home instead of being re-derived per app:

- the `[daft]` extra still resolves — to nothing — so daft leaves the lock with no warning while pyproject still looks like it asks for it; `override-dependencies` pins are equally useless once the extra empties
- `transform_metadata` input/output contracts changed (daft frame in / daft frame out became pa.Table-or-list in / list[dict] out); a daft frame passes the isinstance coercion unconverted and dies deep in DuckDB with a misleading error
- duckdb ships only in `[sql]`/`[incremental]`, and its function-local import means the miss surfaces at first transform, not boot
- literal-vs-source-column precedence flipped under DuckDB: a YAML template literal (`status: "'ACTIVE'"`) now loses to a same-named key in the records — silent data corruption, caught by a parity test in one app
- heavy users (audited atlan-snowflake-app): daft-as-compute (python-object UDF columns with no DuckDB equivalent), daft.sql's caller-frame table binding vs DuckDB's explicit register, planner-specific cast helpers that become wrong under the new engine, daft-safety concurrency architecture that must be retired deliberately, and parity tests whose golden reference is computed by running daft live — those goldens must be frozen to static fixtures before daft is removed

Boundary policy the skill enforces: apps may keep daft for their own compute (declared as a direct dependency), but no daft object crosses an SDK boundary. Done-bar is output parity — same structure, no attribute lost.

## Wiring

- `adopt-preflight-gate` phase 1 now resolves the latest SDK from PyPI picking the newest release outside the 7-day cooldown (floor raised to >=3.24.1 for the budget knobs), refreshes the whole lock with `uv lock --upgrade --exclude-newer <7 days>`, and invokes `/migrate-off-daft` first whenever the lock resolves <3.20.0
- `upgrade-v3` had two post-3.20 factually wrong spots: it recommended installing the `[daft]` extra, and documented `transform_metadata` returning a daft frame with a `.to_pydict()` example that now raises. Both corrected.

Note: apps only benefit from the coercion fix once it ships in a release; until then the skill tells them to guard app-side.

### Behavioral choices, stated

Two deliberate decisions on the collision path, both from review discussion:

- A castable default coerces silently to the colliding column's type (int `0` fills a string column as `"0"`); only unrepresentable combinations raise. The typed error is `IncompatibleDefaultTypeError` (`DataIntegrityError` leaf, `APP_OWNER`, non-retryable) naming the column and both types.
- Type compatibility is decided from the column's schema, independent of the batch's null shape. This means an incompatible collision on an all-null typed column now raises where it previously succeeded by silently retyping the column — same config bug either way, and loud beats a type that flips per batch. A null-typed all-null column (the common list[dict] shape) still takes the default, which defines the column.
