### PR TITLE
ci: make tests-reusable usable by real-source and private-dep connectors

### DIFF
--- a/.github/actions/connector-integration-tests/action.yaml
+++ b/.github/actions/connector-integration-tests/action.yaml
@@ -354,6 +354,12 @@ runs:
     # hook (which may compose config from them), the app server and pytest.
     # Straight-line call into a tested script per docs/standards/ci.md; the
     # heredoc form it emits is what makes multi-line values survive $GITHUB_ENV.
+    #
+    # No live caller yet: tests-reusable.yaml exports the same payload inline
+    # because it pins this action @main, so `extra-env` is invisible to it until
+    # this merges. The relative script path below is asserted by
+    # test_composite_action_invokes_this_script_at_a_real_path; collapsing the
+    # duplication is tracked in that test's TODO(follow-up).
     - name: Export caller-supplied env
       if: inputs.extra-env != ''
       shell: bash

--- a/.github/actions/connector-integration-tests/action.yaml
+++ b/.github/actions/connector-integration-tests/action.yaml
@@ -189,6 +189,20 @@ inputs:
       inside a reusable/composite workflow: they resolve against the
       reusable's repo, not the caller's.
     default: ""
+  extra-env:
+    description: |
+      JSON object of extra environment variables to export before the
+      services-script hook, the app server and pytest run.  The hook for a
+      connector's SOURCE credentials when the calling job cannot set them as
+      job-level ``env:`` — notably tests-reusable.yaml, where the job is owned
+      by the SDK and the credential names are per-connector.
+
+      Values must be JSON-encoded by the caller (``toJSON(secrets.NAME)``):
+      a key-pair PEM or service-account key is multi-line, and ``$GITHUB_ENV``
+      needs the heredoc form for those.  Empty (the default) is a no-op, so
+      callers that already set job-level env are unaffected.
+    required: false
+    default: ""
 
 runs:
   using: "composite"
@@ -335,6 +349,19 @@ runs:
           curl -sf http://localhost:3500/v1.0/metadata >/dev/null 2>&1 && break
           sleep 1
         done
+
+    # Caller-supplied source credentials, exported before the services-script
+    # hook (which may compose config from them), the app server and pytest.
+    # Straight-line call into a tested script per docs/standards/ci.md; the
+    # heredoc form it emits is what makes multi-line values survive $GITHUB_ENV.
+    - name: Export caller-supplied env
+      if: inputs.extra-env != ''
+      shell: bash
+      env:
+        EXTRA_ENV: ${{ inputs.extra-env }}
+      run: |
+        python3 "${{ github.action_path }}/../../scripts/export_extra_env.py" \
+          --json "$EXTRA_ENV" >> "$GITHUB_ENV"
 
     - name: Start runtime services (services-script hook)
       if: inputs.services-script != ''

--- a/.github/actions/sdr-e2e/action.yaml
+++ b/.github/actions/sdr-e2e/action.yaml
@@ -240,6 +240,20 @@ inputs:
       Leave "false" (default) for the pure-SDR / worker-up pipelines.
     required: false
     default: "false"
+  extra-env:
+    description: |
+      JSON object of extra environment variables to export before the secrets
+      bundle is generated and pytest runs. This is how a caller that cannot set
+      job-level `env:` — notably tests-reusable.yaml, where the job is owned by
+      the SDK and the connector's SOURCE credential names are unknowable — gets
+      them to the secrets-script and the test class.
+
+      Values must be JSON-encoded by the caller (`toJSON(secrets.NAME)`): a
+      key-pair PEM or service-account JSON is multi-line, and $GITHUB_ENV needs
+      the heredoc form for those. Empty (the default) is a no-op, so callers
+      that already set job-level env are unaffected.
+    required: false
+    default: ""
   ghcr-token:
     description: |
       Optional token used to authenticate the GHCR login for the test-image
@@ -585,6 +599,20 @@ runs:
           --config test-config.yaml \
           --output ./ci-deploy \
           --overwrite
+
+    # Caller-supplied connector SOURCE credentials, exported before the secrets
+    # bundle is written (the script below reads them) and therefore visible to
+    # every later step, pytest included. Straight-line call into a tested script
+    # per docs/standards/ci.md; the heredoc form it emits is what makes
+    # multi-line values (PEM, service-account JSON) survive $GITHUB_ENV.
+    - name: Export caller-supplied env
+      if: inputs.extra-env != ''
+      shell: bash
+      env:
+        EXTRA_ENV: ${{ inputs.extra-env }}
+      run: |
+        python3 "${{ github.action_path }}/../../scripts/export_extra_env.py" \
+          --json "$EXTRA_ENV" >> "$GITHUB_ENV"
 
     - name: Generate secrets bundle
       shell: bash

--- a/.github/actions/sdr-e2e/action.yaml
+++ b/.github/actions/sdr-e2e/action.yaml
@@ -605,6 +605,12 @@ runs:
     # every later step, pytest included. Straight-line call into a tested script
     # per docs/standards/ci.md; the heredoc form it emits is what makes
     # multi-line values (PEM, service-account JSON) survive $GITHUB_ENV.
+    #
+    # No live caller yet: tests-reusable.yaml exports the same payload inline
+    # because it pins this action @main, so `extra-env` is invisible to it until
+    # this merges. The relative script path below is asserted by
+    # test_composite_action_invokes_this_script_at_a_real_path; collapsing the
+    # duplication is tracked in that test's TODO(follow-up).
     - name: Export caller-supplied env
       if: inputs.extra-env != ''
       shell: bash

--- a/.github/scripts/export_extra_env.py
+++ b/.github/scripts/export_extra_env.py
@@ -1,0 +1,108 @@
+"""Export a caller-supplied JSON env map to ``$GITHUB_ENV``.
+
+Why this exists
+---------------
+``tests-reusable.yaml``'s e2e job owns the tenant-side secrets (SDR_TEST_TENANT,
+SDR_CLIENT_ID/SECRET, ATLAN_API_KEY), but the *source* credentials a connector
+crawls with are per-connector and unknowable to the reusable: snowflake needs
+``SNOWFLAKE_E2E_ACCOUNT/USER/PRIVATE_KEY``, saphana needs
+``E2E_SAPHANA_HOST/PORT/...``, glue needs AWS keys. The ``sdr-e2e`` action
+documents these as the caller's responsibility — which, for a repo on the thin
+caller, means they have to arrive through a reusable-workflow input.
+
+A ``KEY=VALUE``-per-line input cannot carry them: a Snowflake key-pair secret is
+a multi-line PEM, and ``$GITHUB_ENV`` needs the heredoc form for any value
+containing a newline. So the input is a JSON object instead, which the caller
+builds with ``toJSON(secrets.X)`` so escaping is GitHub's job, and this script
+re-emits it in the heredoc form.
+
+Values are registered secrets in the calling job (``secrets: inherit``), so the
+runner's log masking still applies to anything echoed downstream.
+
+Usage::
+
+    python export_extra_env.py --json "$EXTRA_ENV" >> "$GITHUB_ENV"
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import uuid
+
+
+class ExtraEnvError(ValueError):
+    """The caller-supplied extra-env payload is not usable."""
+
+
+def render(payload: str) -> str:
+    """Return ``$GITHUB_ENV`` lines for the JSON object in *payload*.
+
+    Every value is emitted in the heredoc form, not ``KEY=VALUE``: it is correct
+    for single-line values too, so there is no branch that only multi-line
+    values exercise. The delimiter embeds a random token so a value that itself
+    contains the delimiter cannot terminate the block early — the documented
+    injection concern for ``$GITHUB_ENV``.
+    """
+    payload = payload.strip()
+    if not payload:
+        return ""
+    try:
+        parsed = json.loads(payload)
+    except json.JSONDecodeError as exc:
+        raise ExtraEnvError(
+            f"extra-env is not valid JSON ({exc}). Build it with "
+            'toJSON(secrets.NAME) per value, e.g. {"E2E_HOST": ${{ '
+            "toJSON(secrets.E2E_HOST) }}}."
+        ) from exc
+    if not isinstance(parsed, dict):
+        raise ExtraEnvError(
+            f"extra-env must be a JSON object, got {type(parsed).__name__}."
+        )
+
+    lines: list[str] = []
+    for name, value in parsed.items():
+        if not name or not isinstance(name, str):
+            raise ExtraEnvError(f"extra-env keys must be non-empty strings: {name!r}")
+        if any(ch in name for ch in "\r\n= "):
+            raise ExtraEnvError(
+                f"extra-env key {name!r} contains whitespace or '=' — not a "
+                "valid environment variable name."
+            )
+        if value is None:
+            # A caller referencing an unset secret gets an empty string from
+            # GitHub, but tolerate an explicit null the same way rather than
+            # writing the literal "None".
+            value = ""
+        if not isinstance(value, (str, int, float, bool)):
+            raise ExtraEnvError(
+                f"extra-env value for {name!r} must be a scalar, got "
+                f"{type(value).__name__}."
+            )
+        text = str(value)
+        delimiter = f"__EXTRA_ENV_{uuid.uuid4().hex}__"
+        while delimiter in text:  # pragma: no cover - uuid collision guard
+            delimiter = f"__EXTRA_ENV_{uuid.uuid4().hex}__"
+        lines.append(f"{name}<<{delimiter}\n{text}\n{delimiter}")
+    return "\n".join(lines) + "\n" if lines else ""
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--json",
+        default="",
+        help="JSON object of environment variables. Empty is a no-op.",
+    )
+    args = parser.parse_args()
+    try:
+        sys.stdout.write(render(args.json))
+    except ExtraEnvError as exc:
+        print(f"::error::{exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/export_extra_env.py
+++ b/.github/scripts/export_extra_env.py
@@ -28,8 +28,18 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import sys
 import uuid
+
+# A whitelist, not a blacklist of hostile characters. The runner splits a
+# ``$GITHUB_ENV`` heredoc header on the FIRST ``<<``, so a name containing
+# ``<<`` would leave it hunting for a delimiter the closing line never matches
+# ("Invalid value. Matching delimiter not found"). Enumerating characters to
+# reject keeps missing cases like that one, so only POSIX-shaped names pass.
+# Matched with ``fullmatch``: an anchored ``$`` would still admit a trailing
+# newline.
+_VALID_NAME = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
 
 
 class ExtraEnvError(ValueError):
@@ -65,10 +75,10 @@ def render(payload: str) -> str:
     for name, value in parsed.items():
         if not name or not isinstance(name, str):
             raise ExtraEnvError(f"extra-env keys must be non-empty strings: {name!r}")
-        if any(ch in name for ch in "\r\n= "):
+        if not _VALID_NAME.fullmatch(name):
             raise ExtraEnvError(
-                f"extra-env key {name!r} contains whitespace or '=' — not a "
-                "valid environment variable name."
+                f"extra-env key {name!r} is not a valid environment variable "
+                "name (expected ^[A-Za-z_][A-Za-z0-9_]*$)."
             )
         if value is None:
             # A caller referencing an unset secret gets an empty string from

--- a/.github/scripts/tests/test_export_extra_env.py
+++ b/.github/scripts/tests/test_export_extra_env.py
@@ -92,12 +92,76 @@ def test_non_object_json_is_rejected():
         render('["E2E_HOST"]')
 
 
-@pytest.mark.parametrize("bad", ["", "A B", "A=B", "A\nB"])
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "",
+        "A B",
+        "A=B",
+        "A\nB",
+        # The runner splits the heredoc header on the FIRST `<<`, so a name
+        # carrying its own `<<` makes it look for the wrong delimiter and the
+        # step dies with "Matching delimiter not found".
+        "A<<X",
+        "A<B",
+        # `$` in an anchored regex still matches before a trailing newline, so
+        # this shape is the one a `.match()` whitelist would wrongly admit.
+        "A\n",
+        "A\r",
+        # Not POSIX-shaped: a leading digit or a hyphen is not a valid name.
+        "1ABC",
+        "A-B",
+    ],
+)
 def test_invalid_names_are_rejected(bad: str):
     with pytest.raises(ExtraEnvError):
         render('{%s: "v"}' % __import__("json").dumps(bad))
 
 
+@pytest.mark.parametrize(
+    "good", ["A", "_A", "E2E_HOST", "_", "A1", "SNOWFLAKE_E2E_USER"]
+)
+def test_posix_shaped_names_are_accepted(good: str):
+    assert _parse(render('{%s: "v"}' % __import__("json").dumps(good))) == {good: "v"}
+
+
 def test_structured_values_are_rejected():
     with pytest.raises(ExtraEnvError, match="must be a scalar"):
         render('{"A": {"nested": 1}}')
+
+
+# ── Composite-action wiring ──────────────────────────────────────────────────
+# Both composites invoke this script through a path relative to
+# `github.action_path`. tests-reusable.yaml currently exports the same payload
+# inline instead of passing `extra-env` (every action it calls is pinned @main,
+# so a new input is invisible until this merges), which leaves the composites'
+# own wiring with no live CI caller. Assert it here so the relative path and the
+# input declaration are covered by *something*, and so moving either the script
+# or an action directory fails loudly.
+#
+# TODO(follow-up): once these actions can be pinned past this merge, collapse
+# the duplication — drop the inline sparse-checkout + export steps from
+# tests-reusable.yaml and pass `extra-env: ${{ secrets.E2E_SOURCE_ENV_JSON }}`
+# to each composite instead.
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+@pytest.mark.parametrize("action", ["connector-integration-tests", "sdr-e2e"])
+def test_composite_action_invokes_this_script_at_a_real_path(action: str):
+    action_dir = _REPO_ROOT / ".github" / "actions" / action
+    action_yaml = (action_dir / "action.yaml").read_text()
+
+    assert re.search(
+        r"^  extra-env:", action_yaml, re.M
+    ), f"{action}/action.yaml no longer declares the extra-env input"
+
+    match = re.search(
+        r"\$\{\{ github\.action_path \}\}/(\S+?export_extra_env\.py)", action_yaml
+    )
+    assert match, f"{action}/action.yaml no longer invokes export_extra_env.py"
+
+    resolved = (action_dir / match.group(1)).resolve()
+    assert (
+        resolved == _MODULE_PATH
+    ), f"{action} resolves export_extra_env.py to {resolved}, not {_MODULE_PATH}"
+    assert resolved.is_file()

--- a/.github/scripts/tests/test_export_extra_env.py
+++ b/.github/scripts/tests/test_export_extra_env.py
@@ -1,0 +1,103 @@
+"""Tests for .github/scripts/export_extra_env.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+from pathlib import Path
+
+import pytest
+
+_MODULE_PATH = Path(__file__).resolve().parents[1] / "export_extra_env.py"
+_spec = importlib.util.spec_from_file_location("export_extra_env", _MODULE_PATH)
+assert _spec and _spec.loader
+export_extra_env = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(export_extra_env)
+
+render = export_extra_env.render
+ExtraEnvError = export_extra_env.ExtraEnvError
+
+
+def _parse(rendered: str) -> dict[str, str]:
+    """Interpret rendered output the way the runner reads $GITHUB_ENV."""
+    env: dict[str, str] = {}
+    lines = rendered.splitlines()
+    i = 0
+    while i < len(lines):
+        header = lines[i]
+        assert "<<" in header, f"expected heredoc header, got {header!r}"
+        name, delimiter = header.split("<<", 1)
+        i += 1
+        collected: list[str] = []
+        while lines[i] != delimiter:
+            collected.append(lines[i])
+            i += 1
+        env[name] = "\n".join(collected)
+        i += 1
+    return env
+
+
+def test_empty_input_is_a_noop():
+    assert render("") == ""
+    assert render("   \n ") == ""
+
+
+def test_single_line_values_round_trip():
+    out = render('{"E2E_HOST": "db.example.com", "E2E_PORT": "1433"}')
+    assert _parse(out) == {"E2E_HOST": "db.example.com", "E2E_PORT": "1433"}
+
+
+def test_multiline_pem_round_trips():
+    """The case a KEY=VALUE input cannot express at all."""
+    pem = "-----BEGIN PRIVATE KEY-----\nAAAA\nBBBB\n-----END PRIVATE KEY-----"
+    out = render('{"KEY": %s}' % __import__("json").dumps(pem))
+    assert _parse(out)["KEY"] == pem
+
+
+def test_scalars_are_stringified():
+    out = render('{"A": 1, "B": 2.5, "C": true}')
+    assert _parse(out) == {"A": "1", "B": "2.5", "C": "True"}
+
+
+def test_null_becomes_empty_string():
+    """An unset secret reference should not write the literal "None"."""
+    assert _parse(render('{"MISSING": null}')) == {"MISSING": ""}
+
+
+def test_delimiter_is_unique_per_variable():
+    out = render('{"A": "1", "B": "2"}')
+    delimiters = re.findall(r"<<(__EXTRA_ENV_[0-9a-f]+__)", out)
+    assert len(delimiters) == 2
+    assert len(set(delimiters)) == 2
+
+
+def test_value_cannot_terminate_its_own_block():
+    """A value containing a delimiter-shaped line must not break out.
+
+    This is the $GITHUB_ENV injection shape: if the value could close the
+    heredoc, everything after it would be interpreted as further assignments.
+    """
+    hostile = "__EXTRA_ENV_deadbeef__\nINJECTED=yes"
+    out = render('{"A": %s}' % __import__("json").dumps(hostile))
+    assert _parse(out) == {"A": hostile}
+
+
+def test_invalid_json_is_rejected():
+    with pytest.raises(ExtraEnvError, match="not valid JSON"):
+        render("E2E_HOST=db.example.com")
+
+
+def test_non_object_json_is_rejected():
+    with pytest.raises(ExtraEnvError, match="must be a JSON object"):
+        render('["E2E_HOST"]')
+
+
+@pytest.mark.parametrize("bad", ["", "A B", "A=B", "A\nB"])
+def test_invalid_names_are_rejected(bad: str):
+    with pytest.raises(ExtraEnvError):
+        render('{%s: "v"}' % __import__("json").dumps(bad))
+
+
+def test_structured_values_are_rejected():
+    with pytest.raises(ExtraEnvError, match="must be a scalar"):
+        render('{"A": {"nested": 1}}')

--- a/.github/workflows/conformance-reusable.yaml
+++ b/.github/workflows/conformance-reusable.yaml
@@ -367,11 +367,6 @@ jobs:
         with:
           version: "0.12.0"
 
-      # Only the D-series leg materialises the environment (the detect action's
-      # needs-env `uv sync`), but gating on the input alone keeps this a
-      # one-second no-op on the other legs rather than duplicating the series
-      # condition. --global writes ~/.gitconfig, so it applies to the clone uv
-      # performs inside the action.
       # The flag promises a token; with ORG_PAT_GITHUB absent the rewrite below
       # would redirect every atlanhq URL — including the caller checkout above —
       # to an unauthenticated token URL, failing far from the cause. Condition
@@ -383,6 +378,11 @@ jobs:
           echo "::error::private-git-deps is true but ORG_PAT_GITHUB is unset"
           exit 1
 
+      # Only the D-series leg materialises the environment (the detect action's
+      # needs-env `uv sync`), but gating on the input and the token — rather
+      # than also duplicating the series condition — keeps this a one-second
+      # no-op on the other legs. --global writes ~/.gitconfig, so it applies to
+      # the clone uv performs inside the action.
       - name: "Authenticate private atlanhq git dependencies"
         if: inputs.private-git-deps && env.GIT_TOKEN != ''
         shell: bash

--- a/.github/workflows/conformance-reusable.yaml
+++ b/.github/workflows/conformance-reusable.yaml
@@ -193,6 +193,18 @@ on:
         required: false
         default: false
         type: boolean
+      private-git-deps:
+        description: >
+          Set true when the app's lockfile pins a PRIVATE atlanhq git dependency
+          (e.g. query-redaction).  The D-series leg is the only one that
+          materialises the environment (`uv sync`, via the detect action's
+          needs-env step), and an unauthenticated clone of a private atlanhq repo
+          fails there — so with this flag the suite job rewrites atlanhq remotes
+          to a token URL (ORG_PAT_GITHUB) first.  Requires the caller to pass
+          `secrets: inherit`.  Leave false for apps with only public deps.
+        required: false
+        default: false
+        type: boolean
       exit-zero:
         description: >
           When true, the detect command exits 0 even when blocking violations are
@@ -340,6 +352,20 @@ jobs:
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           version: "0.12.0"
+
+      # Only the D-series leg materialises the environment (the detect action's
+      # needs-env `uv sync`), but gating on the input alone keeps this a
+      # one-second no-op on the other legs rather than duplicating the series
+      # condition. --global writes ~/.gitconfig, so it applies to the clone uv
+      # performs inside the action.
+      - name: "Authenticate private atlanhq git dependencies"
+        if: inputs.private-git-deps
+        shell: bash
+        env:
+          GIT_TOKEN: ${{ secrets.ORG_PAT_GITHUB }}
+        run: |
+          git config --global url."https://x-access-token:${GIT_TOKEN}@github.com/atlanhq/".insteadOf "https://github.com/atlanhq/"
+          git config --global --add url."https://x-access-token:${GIT_TOKEN}@github.com/atlanhq/".insteadOf "ssh://git@github.com/atlanhq/"
 
       - name: "Run ${{ matrix.series }}-series checks"
         if: steps.changes.outputs.relevant == 'true' || inputs.event_name == 'push' || inputs.force-all

--- a/.github/workflows/conformance-reusable.yaml
+++ b/.github/workflows/conformance-reusable.yaml
@@ -215,6 +215,15 @@ on:
         required: false
         default: false
         type: boolean
+    secrets:
+      ORG_PAT_GITHUB:
+        required: false
+        description: >
+          Token used to reach PRIVATE atlanhq git dependencies when
+          `private-git-deps` is true.  Optional: a caller with only public deps
+          passes nothing.  Declared so a caller that maps secrets EXPLICITLY
+          (rather than `secrets: inherit`) is validated at parse time instead of
+          silently supplying an empty token.
 
 permissions:
   contents: read
@@ -230,6 +239,11 @@ jobs:
   suite:
     name: ${{ matrix.name }}
     runs-on: ubuntu-latest
+    env:
+      # Surfaced as env because a step-level `if:` cannot read the secrets
+      # context, and the rewrite step must gate on the credential being
+      # present rather than on the flag alone.
+      GIT_TOKEN: ${{ secrets.ORG_PAT_GITHUB }}
     strategy:
       fail-fast: false
       matrix:
@@ -358,11 +372,20 @@ jobs:
       # one-second no-op on the other legs rather than duplicating the series
       # condition. --global writes ~/.gitconfig, so it applies to the clone uv
       # performs inside the action.
-      - name: "Authenticate private atlanhq git dependencies"
-        if: inputs.private-git-deps
+      # The flag promises a token; with ORG_PAT_GITHUB absent the rewrite below
+      # would redirect every atlanhq URL — including the caller checkout above —
+      # to an unauthenticated token URL, failing far from the cause. Condition
+      # stays in `if:`, never in the shell (docs/standards/ci.md).
+      - name: "Require ORG_PAT_GITHUB when private-git-deps is set"
+        if: inputs.private-git-deps && env.GIT_TOKEN == ''
         shell: bash
-        env:
-          GIT_TOKEN: ${{ secrets.ORG_PAT_GITHUB }}
+        run: |
+          echo "::error::private-git-deps is true but ORG_PAT_GITHUB is unset"
+          exit 1
+
+      - name: "Authenticate private atlanhq git dependencies"
+        if: inputs.private-git-deps && env.GIT_TOKEN != ''
+        shell: bash
         run: |
           git config --global url."https://x-access-token:${GIT_TOKEN}@github.com/atlanhq/".insteadOf "https://github.com/atlanhq/"
           git config --global --add url."https://x-access-token:${GIT_TOKEN}@github.com/atlanhq/".insteadOf "ssh://git@github.com/atlanhq/"

--- a/.github/workflows/tests-reusable.yaml
+++ b/.github/workflows/tests-reusable.yaml
@@ -209,6 +209,31 @@ on:
           otherwise fails (or wastes minutes) during `uv sync`.  Leave false
           for connectors that genuinely need their LFS content at test time
           (the same reason build-and-publish takes an explicit `lfs` input).
+      e2e-extra-env:
+        required: false
+        type: string
+        default: ""
+        description: |
+          JSON object of extra environment variables exported to the e2e job
+          before the sdr-e2e action runs. This is the hook for the connector's
+          SOURCE credentials — the ones the app's secrets-script and test class
+          read, which the sdr-e2e action documents as the caller's
+          responsibility. The tenant-side secrets (SDR_TEST_TENANT,
+          SDR_CLIENT_ID/SECRET, ATLAN_API_KEY) are already set by this workflow;
+          these are the per-connector ones it cannot know the names of
+          (SNOWFLAKE_E2E_ACCOUNT, E2E_SAPHANA_HOST, AWS keys, …).
+
+          Build each value with `toJSON(secrets.NAME)` so GitHub does the
+          escaping — a key-pair or service-account secret is multi-line and
+          cannot survive a KEY=VALUE input:
+
+              e2e-extra-env: |
+                {"E2E_DB_HOST": ${{ toJSON(secrets.E2E_DB_HOST) }},
+                 "E2E_DB_KEY":  ${{ toJSON(secrets.E2E_DB_KEY) }}}
+
+          The values are registered secrets in this job via the caller's
+          `secrets: inherit`, so runner log masking still applies. Connectors
+          with a hermetic container source (the mysql shape) need none of this.
       container-health-timeout-seconds:
         required: false
         type: string
@@ -541,6 +566,10 @@ jobs:
           base-image-ref: ${{ inputs.base-image-ref }}
           enable-two-store: ${{ inputs.two-store }}
           source-available: ${{ inputs.source-available }}
+          # Connector SOURCE credentials the secrets-script + test class read.
+          # This job's env can only carry the tenant-side secrets; the
+          # per-connector names are the caller's to supply.
+          extra-env: ${{ inputs.e2e-extra-env }}
           # Push the test image with the org PAT (same identity build-and-publish
           # uses) so it can write PAT-published connector packages — a plain
           # GITHUB_TOKEN 403s on those (e.g. atlan-redshift-app). Available here

--- a/.github/workflows/tests-reusable.yaml
+++ b/.github/workflows/tests-reusable.yaml
@@ -209,6 +209,21 @@ on:
           otherwise fails (or wastes minutes) during `uv sync`.  Leave false
           for connectors that genuinely need their LFS content at test time
           (the same reason build-and-publish takes an explicit `lfs` input).
+      sdk-scripts-ref:
+        required: false
+        type: string
+        default: "main"
+        description: |
+          Ref of atlanhq/application-sdk to take .github/scripts from for the
+          source-credential export. Defaults to main, which is correct for every
+          caller on `@main`.
+
+          Set it ONLY while validating a change to this workflow from a branch:
+          there is no expression for "the ref of the reusable workflow I am"
+          (github.job_workflow_sha is an OIDC claim, not a context property), so
+          a caller pinned at `...tests-reusable.yaml@my-branch` must name that
+          same branch here or the export step would run main's scripts. Drop it
+          in the same edit that flips the `uses:` back to `@main`.
       container-health-timeout-seconds:
         required: false
         type: string
@@ -417,11 +432,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: atlanhq/application-sdk
-          # The commit of THIS reusable workflow file, so the script is always
-          # the one this logic was written against. Without it checkout defaults
-          # to the SDK's default branch, and a branch under review would run
-          # main's scripts — or, for a newly added script, none at all.
-          ref: ${{ github.job_workflow_sha }}
+          ref: ${{ inputs.sdk-scripts-ref }}
           sparse-checkout: .github/scripts
           sparse-checkout-cone-mode: false
           path: application-sdk-scripts
@@ -567,11 +578,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: atlanhq/application-sdk
-          # The commit of THIS reusable workflow file, so the script is always
-          # the one this logic was written against. Without it checkout defaults
-          # to the SDK's default branch, and a branch under review would run
-          # main's scripts — or, for a newly added script, none at all.
-          ref: ${{ github.job_workflow_sha }}
+          ref: ${{ inputs.sdk-scripts-ref }}
           sparse-checkout: .github/scripts
           sparse-checkout-cone-mode: false
           path: application-sdk-scripts

--- a/.github/workflows/tests-reusable.yaml
+++ b/.github/workflows/tests-reusable.yaml
@@ -420,6 +420,11 @@ jobs:
           application-sdk-ref: ${{ inputs.application-sdk-ref }}
           force-external-runtime: ${{ inputs.force-external-runtime }}
           health-check-timeout-seconds: ${{ inputs.health-check-timeout-seconds }}
+          # Source credentials for a connector whose integration tier talks to a
+          # real source. Same declared secret the e2e job uses — without it that
+          # tier silently degrades to dummy credentials when a repo moves off a
+          # bespoke workflow that set them as job-level env.
+          extra-env: ${{ secrets.E2E_SOURCE_ENV_JSON }}
 
   # ── Discover e2e suites → matrix ─────────────────────────────────────────
   # Globs the connector's tests/e2e/test_*.py into a strategy.matrix so the

--- a/.github/workflows/tests-reusable.yaml
+++ b/.github/workflows/tests-reusable.yaml
@@ -209,21 +209,6 @@ on:
           otherwise fails (or wastes minutes) during `uv sync`.  Leave false
           for connectors that genuinely need their LFS content at test time
           (the same reason build-and-publish takes an explicit `lfs` input).
-      sdk-scripts-ref:
-        required: false
-        type: string
-        default: "main"
-        description: |
-          Ref of atlanhq/application-sdk to take .github/scripts from for the
-          source-credential export. Defaults to main, which is correct for every
-          caller on `@main`.
-
-          Set it ONLY while validating a change to this workflow from a branch:
-          there is no expression for "the ref of the reusable workflow I am"
-          (github.job_workflow_sha is an OIDC claim, not a context property), so
-          a caller pinned at `...tests-reusable.yaml@my-branch` must name that
-          same branch here or the export step would run main's scripts. Drop it
-          in the same edit that flips the `uses:` back to `@main`.
       container-health-timeout-seconds:
         required: false
         type: string
@@ -328,18 +313,32 @@ jobs:
       # Empty (the default) leaves the smudge filter enabled, exactly as
       # before; git-lfs only skips on an explicit "1".
       GIT_LFS_SKIP_SMUDGE: ${{ inputs.git-lfs-skip-smudge && '1' || '' }}
+      # Surfaced as env, like E2E_SOURCE_ENV_JSON below, because a step-level
+      # `if:` cannot read the secrets context — and the rewrite step must gate
+      # on the credential actually being present, not just on the flag.
+      GIT_TOKEN: ${{ secrets.ORG_PAT_GITHUB }}
     steps:
       - name: echo distinct-id ${{ inputs.distinct-id }}
         if: inputs.distinct-id != ''
         run: echo "Dispatched; SDK ref=${{ inputs.application-sdk-ref }}"
 
+      # The flag promises a token. With ORG_PAT_GITHUB absent, GIT_TOKEN expands
+      # empty and the rewrite below would still install a global redirect of
+      # every atlanhq URL to an unauthenticated token URL — which then also
+      # applies to the connector's own repo checkout, so the job fails far from
+      # the cause. Fail here instead, naming the missing secret. The condition
+      # stays in `if:`, never in the shell (docs/standards/ci.md).
+      - name: Require ORG_PAT_GITHUB when private-git-deps is set
+        if: inputs.private-git-deps && env.GIT_TOKEN == ''
+        run: |
+          echo "::error::private-git-deps is true but ORG_PAT_GITHUB is unset"
+          exit 1
+
       # Private atlanhq git deps must be reachable before the deps action's
       # `uv sync`. --global writes ~/.gitconfig, so it applies to the clone uv
       # performs later in this job and needs no checkout of its own.
       - name: Authenticate private atlanhq git dependencies
-        if: inputs.private-git-deps
-        env:
-          GIT_TOKEN: ${{ secrets.ORG_PAT_GITHUB }}
+        if: inputs.private-git-deps && env.GIT_TOKEN != ''
         run: |
           git config --global url."https://x-access-token:${GIT_TOKEN}@github.com/atlanhq/".insteadOf "https://github.com/atlanhq/"
           git config --global --add url."https://x-access-token:${GIT_TOKEN}@github.com/atlanhq/".insteadOf "ssh://git@github.com/atlanhq/"
@@ -410,15 +409,22 @@ jobs:
       # Surfaced as env because a step-level `if:` cannot read the secrets
       # context, and the export steps below are gated on it being set.
       E2E_SOURCE_ENV_JSON: ${{ secrets.E2E_SOURCE_ENV_JSON }}
+      # Same reason: the rewrite step gates on the credential, not the flag.
+      GIT_TOKEN: ${{ secrets.ORG_PAT_GITHUB }}
     steps:
       - name: echo distinct-id ${{ inputs.distinct-id }}
         if: inputs.distinct-id != ''
         run: echo "Dispatched; SDK ref=${{ inputs.application-sdk-ref }}"
 
+      # See the unit job for why this gates on the token, not just the flag.
+      - name: Require ORG_PAT_GITHUB when private-git-deps is set
+        if: inputs.private-git-deps && env.GIT_TOKEN == ''
+        run: |
+          echo "::error::private-git-deps is true but ORG_PAT_GITHUB is unset"
+          exit 1
+
       - name: Authenticate private atlanhq git dependencies
-        if: inputs.private-git-deps
-        env:
-          GIT_TOKEN: ${{ secrets.ORG_PAT_GITHUB }}
+        if: inputs.private-git-deps && env.GIT_TOKEN != ''
         run: |
           git config --global url."https://x-access-token:${GIT_TOKEN}@github.com/atlanhq/".insteadOf "https://github.com/atlanhq/"
           git config --global --add url."https://x-access-token:${GIT_TOKEN}@github.com/atlanhq/".insteadOf "ssh://git@github.com/atlanhq/"
@@ -432,7 +438,16 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: atlanhq/application-sdk
-          ref: ${{ inputs.sdk-scripts-ref }}
+          # `job.workflow_sha` is "the commit SHA of the workflow file that
+          # defines the current job" — i.e. THIS reusable, at whatever ref the
+          # caller pinned — so the script always matches the workflow running
+          # it, and no caller-supplied ref reaches a checkout whose payload is
+          # then executed. `repository:` stays hardcoded rather than paired with
+          # `job.workflow_repository` to keep that payload provenance-pinned.
+          # Caveat: the `job.workflow_*` properties do not exist on GitHub
+          # Enterprise Server (no effect on github.com callers), and actionlint
+          # <=1.7.7 predates them, so it reports a false "property not defined".
+          ref: ${{ job.workflow_sha }}
           sparse-checkout: .github/scripts
           sparse-checkout-cone-mode: false
           path: application-sdk-scripts
@@ -559,6 +574,7 @@ jobs:
       GIT_LFS_SKIP_SMUDGE: ${{ inputs.git-lfs-skip-smudge && '1' || '' }}
       # See the integration job: needed as env for the step-level `if:` gates.
       E2E_SOURCE_ENV_JSON: ${{ secrets.E2E_SOURCE_ENV_JSON }}
+      GIT_TOKEN: ${{ secrets.ORG_PAT_GITHUB }}
     steps:
       - name: distinct-id ${{ inputs.distinct-id }}
         if: inputs.distinct-id != ''
@@ -578,7 +594,8 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: atlanhq/application-sdk
-          ref: ${{ inputs.sdk-scripts-ref }}
+          # See the integration job above for why this is job.workflow_sha.
+          ref: ${{ job.workflow_sha }}
           sparse-checkout: .github/scripts
           sparse-checkout-cone-mode: false
           path: application-sdk-scripts
@@ -591,13 +608,18 @@ jobs:
           python3 application-sdk-scripts/.github/scripts/export_extra_env.py \
             --json "$E2E_SOURCE_ENV_JSON" >> "$GITHUB_ENV"
 
+      # See the unit job for why this gates on the token, not just the flag.
+      - name: Require ORG_PAT_GITHUB when private-git-deps is set
+        if: inputs.private-git-deps && env.GIT_TOKEN == ''
+        run: |
+          echo "::error::private-git-deps is true but ORG_PAT_GITHUB is unset"
+          exit 1
+
       # The sdr-e2e action runs `uv sync` on the RUNNER as well as in the image
       # build, so the token rewrite is needed here too — `git-token` below only
       # reaches the Docker build.
       - name: Authenticate private atlanhq git dependencies
-        if: inputs.private-git-deps
-        env:
-          GIT_TOKEN: ${{ secrets.ORG_PAT_GITHUB }}
+        if: inputs.private-git-deps && env.GIT_TOKEN != ''
         run: |
           git config --global url."https://x-access-token:${GIT_TOKEN}@github.com/atlanhq/".insteadOf "https://github.com/atlanhq/"
           git config --global --add url."https://x-access-token:${GIT_TOKEN}@github.com/atlanhq/".insteadOf "ssh://git@github.com/atlanhq/"

--- a/.github/workflows/tests-reusable.yaml
+++ b/.github/workflows/tests-reusable.yaml
@@ -209,6 +209,16 @@ on:
           otherwise fails (or wastes minutes) during `uv sync`.  Leave false
           for connectors that genuinely need their LFS content at test time
           (the same reason build-and-publish takes an explicit `lfs` input).
+      container-health-timeout-seconds:
+        required: false
+        type: string
+        default: "120"
+        description: |
+          Forwarded to the sdr-e2e action: how long to wait for the e2e worker
+          container's /server/health before failing. Raise for connectors whose
+          image boots slowly (heavy native / analytics deps). Must stay strictly
+          greater than the SDK's ATLAN_DAPR_SIDECAR_WAIT_TIMEOUT, or the gate is
+          a coin-flip — see the action's own note (CNCT-66).
       force-external-runtime:
         required: false
         type: boolean
@@ -504,7 +514,18 @@ jobs:
           config-dir: .github/e2e
           # Bump the container-health wait because the worker has to establish
           # the Temporal connection with TLS + auth before /server/health greens.
-          container-health-timeout-seconds: "120"
+          container-health-timeout-seconds: ${{ inputs.container-health-timeout-seconds }}
+          # This job IS the full-DAG pipeline, so layer the SDK-owned
+          # queue-alignment overlay (docker-compose.full-dag.yml): it passes the
+          # per-leg ATLAN_DEPLOYMENT_NAME through to the worker so it registers
+          # on the queue the harness dispatches the extract node to. Without it,
+          # alignment depends entirely on the app carrying a byte-identical
+          # per-app overlay — and a connector with no `.github/e2e/
+          # e2e-full-docker-compose.yaml` (the chain builder skips a missing
+          # overlay silently) gets no alignment at all, surfacing 90 minutes
+          # later as "No Workers Running". App overlays layer ABOVE this one, so
+          # connectors that already carry theirs are unaffected.
+          full-dag: "true"
           # `-s` streams the harness poll-loop output in real time — each leg is
           # a single sequential pytest process, so this is live per-job again.
           pytest-extra-args: "-s"

--- a/.github/workflows/tests-reusable.yaml
+++ b/.github/workflows/tests-reusable.yaml
@@ -256,13 +256,10 @@ on:
           a secret at all (the `secrets` context is not available in that
           block).
 
-          Build it in the caller's `secrets:` mapping with toJSON() per value,
-          which is where the `secrets` context IS available:
-
-              secrets:
-                E2E_SOURCE_ENV_JSON: |
-                  {"E2E_DB_HOST": ${{ toJSON(secrets.E2E_DB_HOST) }},
-                   "E2E_DB_KEY":  ${{ toJSON(secrets.E2E_DB_KEY) }}}
+          Build it in the caller's `secrets:` mapping, wrapping each value in
+          toJSON(...) — that mapping is where the `secrets` context IS available.
+          One JSON object, one line per credential, values written as
+          toJSON(secrets.NAME) expressions.
 
           JSON rather than KEY=VALUE lines because a key-pair PEM or
           service-account key is multi-line. Connectors with a hermetic
@@ -284,6 +281,15 @@ on:
         description: |
           Org PAT used for the GHCR push, the connector image build's private
           git dependency, and the private-git-deps token rewrite.
+      FLEET_APP_ID:
+        required: false
+        description: |
+          GitHub App id used by the cross-repo callback job to mint a token for
+          the dispatching application-sdk repo. Only the SDK-dispatch path uses
+          it; connector-triggered runs leave it unset.
+      FLEET_APP_PRIVATE_KEY:
+        required: false
+        description: Private key paired with FLEET_APP_ID.
 
 jobs:
 

--- a/.github/workflows/tests-reusable.yaml
+++ b/.github/workflows/tests-reusable.yaml
@@ -22,6 +22,8 @@ name: tests-reusable
 #   - connector-integration-tests composite with services-script hook (no-op
 #     by default; used when source systems need CI-level startup rather than
 #     pytest fixtures — see openapi's .github/test/setup-services.sh)
+#   - Optional pre-sync token rewrite for private atlanhq git dependencies
+#     (`private-git-deps`), plus `git-token` forwarded to the e2e image build
 #   - Label/dispatch-gated full-DAG e2e job (inlined here — see the `e2e` job;
 #     it was previously delegated to e2e-full-reusable.yaml, now folded in so
 #     the whole suite is one reusable + one Tests Gate)
@@ -182,6 +184,49 @@ on:
           worker-up-only check (assert the worker deploys + serves
           /server/health) and skips extraction/publish/Atlas assertions,
           until the owner provisions a source.
+      private-git-deps:
+        required: false
+        type: boolean
+        default: false
+        description: |
+          Set true when the connector's lockfile pins a PRIVATE atlanhq git
+          dependency (e.g. query-redaction, pinned via `ssh://` or `https://`
+          in [tool.uv.sources]).  Every tier of this reusable runs `uv sync` on
+          the runner, and an unauthenticated clone of a private atlanhq repo
+          fails there — so with this flag each job rewrites atlanhq remotes to
+          a token URL (ORG_PAT_GITHUB, available via the caller's
+          `secrets: inherit`) BEFORE the deps action syncs.  The Docker build
+          is covered separately: `git-token` is always forwarded to sdr-e2e.
+          Leave false for connectors with only public dependencies.
+      git-lfs-skip-smudge:
+        required: false
+        type: boolean
+        default: false
+        description: |
+          Set true to export GIT_LFS_SKIP_SMUDGE=1 in every job, so clones do
+          not download LFS objects.  Use when a private git dependency
+          LFS-tracks large artifacts the tests never need — the smudge filter
+          otherwise fails (or wastes minutes) during `uv sync`.  Leave false
+          for connectors that genuinely need their LFS content at test time
+          (the same reason build-and-publish takes an explicit `lfs` input).
+      force-external-runtime:
+        required: false
+        type: boolean
+        default: false
+        description: |
+          Forwarded to the connector-integration-tests action: force the
+          external daprd + Temporal steps even when the installed SDK reports
+          embedded-runtime support.  Set only while the connector's main.py
+          still expects external daprd at :3500 / Temporal at :7233; the
+          embedded runtime is the preferred end state.
+      health-check-timeout-seconds:
+        required: false
+        type: string
+        default: "60"
+        description: |
+          Forwarded to the connector-integration-tests action: how long to wait
+          for the app server to become healthy in the INTEGRATION tier.  Raise
+          for connectors with slow imports (heavy native/analytics deps).
 
 jobs:
 
@@ -201,10 +246,25 @@ jobs:
       contents: read
     outputs:
       summary: ${{ steps.unit.outputs.summary }}
+    env:
+      # Empty (the default) leaves the smudge filter enabled, exactly as
+      # before; git-lfs only skips on an explicit "1".
+      GIT_LFS_SKIP_SMUDGE: ${{ inputs.git-lfs-skip-smudge && '1' || '' }}
     steps:
       - name: echo distinct-id ${{ inputs.distinct-id }}
         if: inputs.distinct-id != ''
         run: echo "Dispatched; SDK ref=${{ inputs.application-sdk-ref }}"
+
+      # Private atlanhq git deps must be reachable before the deps action's
+      # `uv sync`. --global writes ~/.gitconfig, so it applies to the clone uv
+      # performs later in this job and needs no checkout of its own.
+      - name: Authenticate private atlanhq git dependencies
+        if: inputs.private-git-deps
+        env:
+          GIT_TOKEN: ${{ secrets.ORG_PAT_GITHUB }}
+        run: |
+          git config --global url."https://x-access-token:${GIT_TOKEN}@github.com/atlanhq/".insteadOf "https://github.com/atlanhq/"
+          git config --global --add url."https://x-access-token:${GIT_TOKEN}@github.com/atlanhq/".insteadOf "ssh://git@github.com/atlanhq/"
 
       - name: Run unit tests
         id: unit
@@ -267,10 +327,20 @@ jobs:
       contents: read
     outputs:
       summary: ${{ steps.integration.outputs.summary }}
+    env:
+      GIT_LFS_SKIP_SMUDGE: ${{ inputs.git-lfs-skip-smudge && '1' || '' }}
     steps:
       - name: echo distinct-id ${{ inputs.distinct-id }}
         if: inputs.distinct-id != ''
         run: echo "Dispatched; SDK ref=${{ inputs.application-sdk-ref }}"
+
+      - name: Authenticate private atlanhq git dependencies
+        if: inputs.private-git-deps
+        env:
+          GIT_TOKEN: ${{ secrets.ORG_PAT_GITHUB }}
+        run: |
+          git config --global url."https://x-access-token:${GIT_TOKEN}@github.com/atlanhq/".insteadOf "https://github.com/atlanhq/"
+          git config --global --add url."https://x-access-token:${GIT_TOKEN}@github.com/atlanhq/".insteadOf "ssh://git@github.com/atlanhq/"
 
       # Unit runs in its own job; integration defaults to tests/integration/.
       # A caller test-paths override scopes THIS job only. The ternary is a
@@ -285,6 +355,8 @@ jobs:
           pytest-args: ${{ inputs.pytest-args }}
           services-script: ${{ inputs.services-script }}
           application-sdk-ref: ${{ inputs.application-sdk-ref }}
+          force-external-runtime: ${{ inputs.force-external-runtime }}
+          health-check-timeout-seconds: ${{ inputs.health-check-timeout-seconds }}
 
   # ── Discover e2e suites → matrix ─────────────────────────────────────────
   # Globs the connector's tests/e2e/test_*.py into a strategy.matrix so the
@@ -381,6 +453,7 @@ jobs:
       ATLAN_API_KEY: ${{ secrets.ATLAN_API_KEY }}
       # Derived so ATLAN_BASE_URL is always the same tenant as SDR_TEST_TENANT.
       ATLAN_BASE_URL: https://${{ secrets.SDR_TEST_TENANT }}
+      GIT_LFS_SKIP_SMUDGE: ${{ inputs.git-lfs-skip-smudge && '1' || '' }}
     steps:
       - name: distinct-id ${{ inputs.distinct-id }}
         if: inputs.distinct-id != ''
@@ -390,6 +463,17 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+
+      # The sdr-e2e action runs `uv sync` on the RUNNER as well as in the image
+      # build, so the token rewrite is needed here too — `git-token` below only
+      # reaches the Docker build.
+      - name: Authenticate private atlanhq git dependencies
+        if: inputs.private-git-deps
+        env:
+          GIT_TOKEN: ${{ secrets.ORG_PAT_GITHUB }}
+        run: |
+          git config --global url."https://x-access-token:${GIT_TOKEN}@github.com/atlanhq/".insteadOf "https://github.com/atlanhq/"
+          git config --global --add url."https://x-access-token:${GIT_TOKEN}@github.com/atlanhq/".insteadOf "ssh://git@github.com/atlanhq/"
 
       # uv on the host for the sdr-e2e action's `uv run pytest` + summary steps.
       # The action self-installs uv only when application-sdk-ref is set
@@ -441,6 +525,11 @@ jobs:
           # GITHUB_TOKEN 403s on those (e.g. atlan-redshift-app). Available here
           # because callers invoke this reusable with `secrets: inherit`.
           ghcr-token: ${{ secrets.ORG_PAT_GITHUB }}
+          # Forwarded to the image build as the `git_token` build secret so a
+          # Dockerfile whose `uv sync` clones a private atlanhq dependency can
+          # authenticate. Same identity/availability rationale as ghcr-token; a
+          # Dockerfile that declares no such secret mount simply ignores it.
+          git-token: ${{ secrets.ORG_PAT_GITHUB }}
 
   # ── Callback: report the result back to the application-sdk PR/commit ────
   # that dispatched this run. application-sdk's e2e-apps composite

--- a/.github/workflows/tests-reusable.yaml
+++ b/.github/workflows/tests-reusable.yaml
@@ -209,31 +209,6 @@ on:
           otherwise fails (or wastes minutes) during `uv sync`.  Leave false
           for connectors that genuinely need their LFS content at test time
           (the same reason build-and-publish takes an explicit `lfs` input).
-      e2e-extra-env:
-        required: false
-        type: string
-        default: ""
-        description: |
-          JSON object of extra environment variables exported to the e2e job
-          before the sdr-e2e action runs. This is the hook for the connector's
-          SOURCE credentials — the ones the app's secrets-script and test class
-          read, which the sdr-e2e action documents as the caller's
-          responsibility. The tenant-side secrets (SDR_TEST_TENANT,
-          SDR_CLIENT_ID/SECRET, ATLAN_API_KEY) are already set by this workflow;
-          these are the per-connector ones it cannot know the names of
-          (SNOWFLAKE_E2E_ACCOUNT, E2E_SAPHANA_HOST, AWS keys, …).
-
-          Build each value with `toJSON(secrets.NAME)` so GitHub does the
-          escaping — a key-pair or service-account secret is multi-line and
-          cannot survive a KEY=VALUE input:
-
-              e2e-extra-env: |
-                {"E2E_DB_HOST": ${{ toJSON(secrets.E2E_DB_HOST) }},
-                 "E2E_DB_KEY":  ${{ toJSON(secrets.E2E_DB_KEY) }}}
-
-          The values are registered secrets in this job via the caller's
-          `secrets: inherit`, so runner log masking still applies. Connectors
-          with a hermetic container source (the mysql shape) need none of this.
       container-health-timeout-seconds:
         required: false
         type: string
@@ -262,6 +237,53 @@ on:
           Forwarded to the connector-integration-tests action: how long to wait
           for the app server to become healthy in the INTEGRATION tier.  Raise
           for connectors with slow imports (heavy native/analytics deps).
+
+    secrets:
+      # Declared so a caller that maps secrets EXPLICITLY (instead of
+      # `secrets: inherit`) gets parse-time validation. Everything here is
+      # optional, so `secrets: inherit` callers are unaffected — inherited
+      # secrets arrive under their own names either way.
+      E2E_SOURCE_ENV_JSON:
+        required: false
+        description: |
+          JSON object of the connector's SOURCE credentials, exported as
+          environment variables in the e2e job before the secrets bundle is
+          written — so both the app's secrets-script and the test class see
+          them. This exists because the source credential NAMES are
+          per-connector and unknowable here (SNOWFLAKE_E2E_ACCOUNT,
+          E2E_SAPHANA_HOST, AWS keys, …) while the tenant-side secrets below
+          are fixed; and because a reusable-workflow `with:` input cannot carry
+          a secret at all (the `secrets` context is not available in that
+          block).
+
+          Build it in the caller's `secrets:` mapping with toJSON() per value,
+          which is where the `secrets` context IS available:
+
+              secrets:
+                E2E_SOURCE_ENV_JSON: |
+                  {"E2E_DB_HOST": ${{ toJSON(secrets.E2E_DB_HOST) }},
+                   "E2E_DB_KEY":  ${{ toJSON(secrets.E2E_DB_KEY) }}}
+
+          JSON rather than KEY=VALUE lines because a key-pair PEM or
+          service-account key is multi-line. Connectors with a hermetic
+          container source (the mysql shape) need none of this.
+      SDR_TEST_TENANT:
+        required: false
+        description: CI test tenant host for the e2e job (also derives ATLAN_BASE_URL).
+      SDR_CLIENT_ID:
+        required: false
+        description: OAuth client id the e2e worker authenticates to the tenant with.
+      SDR_CLIENT_SECRET:
+        required: false
+        description: OAuth client secret paired with SDR_CLIENT_ID.
+      ATLAN_API_KEY:
+        required: false
+        description: Tenant API key the e2e harness drives Automation Engine + Atlas with.
+      ORG_PAT_GITHUB:
+        required: false
+        description: |
+          Org PAT used for the GHCR push, the connector image build's private
+          git dependency, and the private-git-deps token rewrite.
 
 jobs:
 
@@ -567,9 +589,10 @@ jobs:
           enable-two-store: ${{ inputs.two-store }}
           source-available: ${{ inputs.source-available }}
           # Connector SOURCE credentials the secrets-script + test class read.
-          # This job's env can only carry the tenant-side secrets; the
-          # per-connector names are the caller's to supply.
-          extra-env: ${{ inputs.e2e-extra-env }}
+          # A `with:` input cannot carry these — the `secrets` context is not
+          # available in a reusable-call `with:` block — so they arrive as a
+          # declared secret and are exported to the job env inside the action.
+          extra-env: ${{ secrets.E2E_SOURCE_ENV_JSON }}
           # Push the test image with the org PAT (same identity build-and-publish
           # uses) so it can write PAT-published connector packages — a plain
           # GITHUB_TOKEN 403s on those (e.g. atlan-redshift-app). Available here

--- a/.github/workflows/tests-reusable.yaml
+++ b/.github/workflows/tests-reusable.yaml
@@ -392,6 +392,9 @@ jobs:
       summary: ${{ steps.integration.outputs.summary }}
     env:
       GIT_LFS_SKIP_SMUDGE: ${{ inputs.git-lfs-skip-smudge && '1' || '' }}
+      # Surfaced as env because a step-level `if:` cannot read the secrets
+      # context, and the export steps below are gated on it being set.
+      E2E_SOURCE_ENV_JSON: ${{ secrets.E2E_SOURCE_ENV_JSON }}
     steps:
       - name: echo distinct-id ${{ inputs.distinct-id }}
         if: inputs.distinct-id != ''
@@ -404,6 +407,27 @@ jobs:
         run: |
           git config --global url."https://x-access-token:${GIT_TOKEN}@github.com/atlanhq/".insteadOf "https://github.com/atlanhq/"
           git config --global --add url."https://x-access-token:${GIT_TOKEN}@github.com/atlanhq/".insteadOf "ssh://git@github.com/atlanhq/"
+
+      # Connector SOURCE credentials (E2E_SOURCE_ENV_JSON). Exported here rather
+      # than passed to the composite action below, because every action this
+      # workflow calls is pinned @main: an input added on a feature branch is
+      # silently ignored until it lands. Sparse-checks-out only .github/scripts.
+      - name: Fetch SDK CI scripts (source-credential export)
+        if: env.E2E_SOURCE_ENV_JSON != ''
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: atlanhq/application-sdk
+          sparse-checkout: .github/scripts
+          sparse-checkout-cone-mode: false
+          path: application-sdk-scripts
+          token: ${{ secrets.ORG_PAT_GITHUB }}
+          persist-credentials: false
+
+      - name: Export connector source credentials
+        if: env.E2E_SOURCE_ENV_JSON != ''
+        run: |
+          python3 application-sdk-scripts/.github/scripts/export_extra_env.py \
+            --json "$E2E_SOURCE_ENV_JSON" >> "$GITHUB_ENV"
 
       # Unit runs in its own job; integration defaults to tests/integration/.
       # A caller test-paths override scopes THIS job only. The ternary is a
@@ -420,11 +444,6 @@ jobs:
           application-sdk-ref: ${{ inputs.application-sdk-ref }}
           force-external-runtime: ${{ inputs.force-external-runtime }}
           health-check-timeout-seconds: ${{ inputs.health-check-timeout-seconds }}
-          # Source credentials for a connector whose integration tier talks to a
-          # real source. Same declared secret the e2e job uses — without it that
-          # tier silently degrades to dummy credentials when a repo moves off a
-          # bespoke workflow that set them as job-level env.
-          extra-env: ${{ secrets.E2E_SOURCE_ENV_JSON }}
 
   # ── Discover e2e suites → matrix ─────────────────────────────────────────
   # Globs the connector's tests/e2e/test_*.py into a strategy.matrix so the
@@ -522,6 +541,8 @@ jobs:
       # Derived so ATLAN_BASE_URL is always the same tenant as SDR_TEST_TENANT.
       ATLAN_BASE_URL: https://${{ secrets.SDR_TEST_TENANT }}
       GIT_LFS_SKIP_SMUDGE: ${{ inputs.git-lfs-skip-smudge && '1' || '' }}
+      # See the integration job: needed as env for the step-level `if:` gates.
+      E2E_SOURCE_ENV_JSON: ${{ secrets.E2E_SOURCE_ENV_JSON }}
     steps:
       - name: distinct-id ${{ inputs.distinct-id }}
         if: inputs.distinct-id != ''
@@ -531,6 +552,27 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+
+      # Connector SOURCE credentials (E2E_SOURCE_ENV_JSON). Exported here rather
+      # than passed to the composite action below, because every action this
+      # workflow calls is pinned @main: an input added on a feature branch is
+      # silently ignored until it lands. Sparse-checks-out only .github/scripts.
+      - name: Fetch SDK CI scripts (source-credential export)
+        if: env.E2E_SOURCE_ENV_JSON != ''
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: atlanhq/application-sdk
+          sparse-checkout: .github/scripts
+          sparse-checkout-cone-mode: false
+          path: application-sdk-scripts
+          token: ${{ secrets.ORG_PAT_GITHUB }}
+          persist-credentials: false
+
+      - name: Export connector source credentials
+        if: env.E2E_SOURCE_ENV_JSON != ''
+        run: |
+          python3 application-sdk-scripts/.github/scripts/export_extra_env.py \
+            --json "$E2E_SOURCE_ENV_JSON" >> "$GITHUB_ENV"
 
       # The sdr-e2e action runs `uv sync` on the RUNNER as well as in the image
       # build, so the token rewrite is needed here too — `git-token` below only
@@ -599,11 +641,6 @@ jobs:
           base-image-ref: ${{ inputs.base-image-ref }}
           enable-two-store: ${{ inputs.two-store }}
           source-available: ${{ inputs.source-available }}
-          # Connector SOURCE credentials the secrets-script + test class read.
-          # A `with:` input cannot carry these — the `secrets` context is not
-          # available in a reusable-call `with:` block — so they arrive as a
-          # declared secret and are exported to the job env inside the action.
-          extra-env: ${{ secrets.E2E_SOURCE_ENV_JSON }}
           # Push the test image with the org PAT (same identity build-and-publish
           # uses) so it can write PAT-published connector packages — a plain
           # GITHUB_TOKEN 403s on those (e.g. atlan-redshift-app). Available here

--- a/.github/workflows/tests-reusable.yaml
+++ b/.github/workflows/tests-reusable.yaml
@@ -417,6 +417,11 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: atlanhq/application-sdk
+          # The commit of THIS reusable workflow file, so the script is always
+          # the one this logic was written against. Without it checkout defaults
+          # to the SDK's default branch, and a branch under review would run
+          # main's scripts — or, for a newly added script, none at all.
+          ref: ${{ github.job_workflow_sha }}
           sparse-checkout: .github/scripts
           sparse-checkout-cone-mode: false
           path: application-sdk-scripts
@@ -562,6 +567,11 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: atlanhq/application-sdk
+          # The commit of THIS reusable workflow file, so the script is always
+          # the one this logic was written against. Without it checkout defaults
+          # to the SDK's default branch, and a branch under review would run
+          # main's scripts — or, for a newly added script, none at all.
+          ref: ${{ github.job_workflow_sha }}
           sparse-checkout: .github/scripts
           sparse-checkout-cone-mode: false
           path: application-sdk-scripts


### PR DESCRIPTION
## Why

`tests-reusable.yaml` is the canonical connector CI caller, but four structural gaps meant a **real-source** connector could not use it at all — only a connector with a hermetic container source (the mysql case) fit. Each gap below was found by a failing run while migrating five connectors onto the caller, not by reading the file.

| Gap | Symptom | Fix |
|---|---|---|
| No hook for the connector's **source credentials** in the SDK-owned jobs. The `sdr-e2e` action documents them as the caller's responsibility, which for a thin caller means they must arrive through the workflow. | `KeyError: 'SNOWFLAKE_E2E_USER'` in the app's secrets-script. glue's integration tier silently degraded to **dummy AWS keys** — passing, against nothing. | new secret **`E2E_SOURCE_ENV_JSON`** |
| The e2e job never passed **`full-dag: true`** to `sdr-e2e`, so the SDK-owned queue-alignment overlay was not layered. The compose-chain builder skips a missing app overlay *silently*, so a connector without `.github/e2e/e2e-full-docker-compose.yaml` got no `ATLAN_DEPLOYMENT_NAME` passthrough. | Worker registers on one queue, harness dispatches to another; the run stalls until the 90-minute poll budget expires. | passed unconditionally |
| A **private atlanhq git dependency** is unreachable: every tier runs `uv sync` on the runner. | snowflake + bigquery cannot resolve `query-redaction`; both were stuck on bespoke workflows solely because of this. | **`private-git-deps`**, **`git-lfs-skip-smudge`**, plus `git-token` now always forwarded to the image build |
| No passthrough for the integration tier's runtime posture. | A caller migrating off a bespoke workflow silently loses external-daprd and its raised health waits — surfacing as a flaky tier, not a config error. | **`force-external-runtime`**, **`health-check-timeout-seconds`**, **`container-health-timeout-seconds`** |

## How the source credentials get in

Three GitHub context rules constrain this, and each cost a failed run:

1. **`secrets` is not available in a reusable-call `with:` block** — the first attempt used an input, which made the whole workflow *fail to load* (a jobless failed run named after the file path, on an event the triggers don't select). So it is a declared **secret**, populated from the caller's `secrets:` mapping where the context *is* available.
2. **`secrets` is not available in a step-level `if:`** either — the payload is surfaced as job-level `env:` and the gate reads `env.`.
3. **The script checkout is version-locked to the workflow it runs from.** `github.job_workflow_sha` is an OIDC claim rather than a context property and renders empty, and `github.workflow_sha` resolves to the *caller's* file. But the **`job`** context carries `job.workflow_sha` — "the commit SHA of the workflow file that defines the current job", i.e. this reusable — and it is available in a step `with:`. The checkout uses it, so the executed script always matches the workflow definition running it, no caller-supplied ref reaches a checkout whose payload is then executed, and there is no input to remember to drop on merge. This is GitHub's own documented idiom for a reusable checking out its own source; `repository:` stays hardcoded rather than paired with `job.workflow_repository` so the payload is provenance-pinned to this repo. Caveats: `job.workflow_*` is unavailable on GitHub Enterprise Server (no effect on github.com callers), and `actionlint` <=1.7.7 does not know these properties yet, so it reports a false "property not defined".

The payload is a **JSON object**, not `KEY=VALUE` lines, because a key-pair PEM or service-account key is multi-line and `$GITHUB_ENV` needs the heredoc form for those. `export_extra_env.py` emits that form with a random per-variable delimiter so a value cannot terminate its own block. Values are registered secrets in the job, so runner log masking still applies.

Every secret this workflow reads is now declared (including `FLEET_APP_ID` / `FLEET_APP_PRIVATE_KEY`, which the callback job uses). To be precise about why: declaring a `secrets:` block does **not** close the set — a `secrets: inherit` caller can still reference secrets that are not declared under `on`. What the complete declaration buys is parse-time validation for a caller that maps secrets **explicitly**, which would otherwise pass nothing for the names it omits.

## Compatibility

Every input defaults to today's behaviour and every new secret is optional, so `secrets: inherit` callers on `@main` render identically. The one unconditional change is `full-dag: true`; app overlays layer **above** the SDK one, so connectors carrying their own (mysql, snowflake) are unaffected.

## Tests

`.github/scripts/tests/test_export_extra_env.py` — 14 cases: round-trip, multi-line PEM, scalar coercion, null→empty, delimiter uniqueness, the delimiter-injection attempt, and each rejection path.

Validated with **`actionlint`**, which is what caught an expression inside a `description` string, both context violations above, and the closed-secrets-set regression. A YAML parse passes on all four.

## Consumers

Five connector PRs point their caller at this branch and flip to `@main` when it lands (each has a `TODO(before merge)` on the `uses:` line): atlan-snowflake-app#487, atlan-bigquery-app#246, atlan-glue-app#150, atlan-saphana-app#106, atlan-db2-app#52.

> **Note for those five PRs:** `sdk-scripts-ref` no longer exists (see point 3 above — `job.workflow_sha` replaced it). A caller still passing that input will fail to load, so drop it in the same edit that flips `uses:` to `@main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



