### PR TITLE
ci(fix): revert codex-/return-dispatch to v3.0.3 (v4 broke e2e-apps dispatch — SDR K8s E2E fails for every PR)

### DIFF
--- a/.github/actions/e2e-apps/action.yaml
+++ b/.github/actions/e2e-apps/action.yaml
@@ -158,7 +158,7 @@ runs:
       id: return_dispatch_callback
       if: inputs.wait-mode == 'callback'
       continue-on-error: true
-      uses: codex-/return-dispatch@2e404d40b641ba1deb44be941660bb34828e4f6d # v4
+      uses: codex-/return-dispatch@08365b69369e9eb639ce4c4cbbd29598bc52ca3a # v3.0.3
       with:
         token: "${{ inputs.github-token }}"
         ref: ${{ inputs.target-branch }}
@@ -189,7 +189,7 @@ runs:
     # ── poll mode (legacy): dispatch, busy-poll, fetch artifact, comment ──
     - name: Trigger E2E Integrations Tests
       if: inputs.wait-mode != 'callback'
-      uses: codex-/return-dispatch@2e404d40b641ba1deb44be941660bb34828e4f6d # v4
+      uses: codex-/return-dispatch@08365b69369e9eb639ce4c4cbbd29598bc52ca3a # v3.0.3
       id: return_dispatch
       with:
         token: "${{ inputs.github-token }}"


### PR DESCRIPTION
## What
Revert both `codex-/return-dispatch` pins in `.github/actions/e2e-apps/action.yaml` from v4 back to **v3.0.3** (`08365b69`).

## Why
PR #2923 (renovate) bumped this action v3→v4. **v4 removed the inputs `distinct_id`, `workflow_timeout_seconds`, `workflow_job_steps_retry_seconds`**, but both usages in `e2e-apps/action.yaml` still pass them. Result — every run errors at the dispatch step:

```
Unexpected input(s) 'workflow_timeout_seconds', 'workflow_job_steps_retry_seconds', 'distinct_id',
valid inputs are ['token','ref','repo','owner','workflow','workflow_inputs']
```

This breaks the **SDR K8s E2E (LM)** job for **any** PR that triggers it (fails ~6m in at dispatch/locate — not a genuine downstream test failure). Not caused by any feature PR.

## Fix
v3.0.3 (`08365b69`, the pin before #2923) is compatible with the inputs this action still passes. Two-line revert; no behavior change vs before #2923.

## Follow-up (not this PR)
A proper migration to v4's new no-polling dispatch model (drop those 3 inputs + adopt the returned run-id) is a separate change. Renovate will re-propose v4 — it should be held until that migration lands.

Flagged in #community / thread by `appframeworkclaw`; root cause confirmed against the repo (pins + PR #2923 merge timing + v3.0.3 tag SHA). Not auto-merging — leaving the merge call to a maintainer.