### PR TITLE
fix(transformers): use duckdb API valid across the declared version range

### DIFF
--- a/.claude/skills/adopt-preflight-gate/SKILL.md
+++ b/.claude/skills/adopt-preflight-gate/SKILL.md
@@ -386,6 +386,14 @@ Run these detections and report the bucket(s) before changing anything:
    attribute lost. Only when its step-4 evidence is green does phase 1
    continue; the daft migration and the gate adoption land as separable
    changes, in that order.
+
+   Applies to apps *already* past the cliff too: on every SDK release
+   3.20.0-3.25.0 the DuckDB transform raises `AttributeError:
+   DuckDBPyConnection ... has no attribute 'to_arrow_table'` when the lock
+   resolves `duckdb<1.5.0` (application-sdk#2940). The bump below cannot
+   escape it — the target version is inside that range. Pin
+   `duckdb>=1.5.0,<1.6.0` as a direct dependency, or wait for the release
+   carrying #2940; see `/migrate-off-daft` class 3b.
 1. **Always resolve the current latest SDK first.** `.info.version` alone
    may still be inside the release cooldown, so list versions with upload
    dates and pick the newest one older than 7 days:

--- a/.claude/skills/adopt-preflight-gate/SKILL.md
+++ b/.claude/skills/adopt-preflight-gate/SKILL.md
@@ -32,7 +32,7 @@ optional_triggers:
   - "will this app break on SDK bump"
   - "size the preflight budget"
 owner: connector-platform-team
-last_updated: "2026-07-27"
+last_updated: "2026-07-30"
 staleness_days: 90
 inputs:
   - app_root: "auto-detected — the directory containing app/ and pyproject.toml"

--- a/.claude/skills/migrate-off-daft/SKILL.md
+++ b/.claude/skills/migrate-off-daft/SKILL.md
@@ -14,7 +14,8 @@ description: >
   prepare_template_and_attributes), DuckDB engine without its extra, the
   SDK's own arrow-conversion call that only works on duckdb >=1.5.0 (broken
   on every release 3.20.0-3.25.0), literal-vs-column precedence flip,
-  first-record schema inference, test coupling — plus the heavy-user classes: python-object UDF columns with no
+  first-record schema inference, test coupling — plus the heavy-user
+  classes: python-object UDF columns with no
   DuckDB equivalent, daft.sql caller-frame binding vs explicit register,
   daft-planner-specific type coercions, daft-safety concurrency
   architecture to retire deliberately, and live-daft golden oracles that

--- a/.claude/skills/migrate-off-daft/SKILL.md
+++ b/.claude/skills/migrate-off-daft/SKILL.md
@@ -11,9 +11,10 @@ description: >
   known breakage classes: empty [daft] extra (and override-dependencies
   pins that silently stop protecting), changed transform_metadata
   input/output contracts (direct or via SDK internals like
-  prepare_template_and_attributes), DuckDB engine without its extra,
-  literal-vs-column precedence flip, first-record schema inference, test
-  coupling — plus the heavy-user classes: python-object UDF columns with no
+  prepare_template_and_attributes), DuckDB engine without its extra, the
+  SDK's own arrow-conversion call that only works on duckdb >=1.5.0 (broken
+  on every release 3.20.0-3.25.0), literal-vs-column precedence flip,
+  first-record schema inference, test coupling — plus the heavy-user classes: python-object UDF columns with no
   DuckDB equivalent, daft.sql caller-frame binding vs explicit register,
   daft-planner-specific type coercions, daft-safety concurrency
   architecture to retire deliberately, and live-daft golden oracles that
@@ -40,7 +41,7 @@ optional_triggers:
   - "duckdb pyarrow migration"
   - "SDK bump broke transformers"
 owner: connector-platform-team
-last_updated: "2026-07-29"
+last_updated: "2026-07-30"
 staleness_days: 90
 inputs:
   - app_root: "auto-detected — the directory containing app/ and pyproject.toml"
@@ -129,6 +130,12 @@ grep -rn "DAFT_EXECUTOR\|DaftCoreException\|daft_executor\|_classify_daft" app/ 
 
 # (m) parity/golden tests that compute their reference BY RUNNING daft live
 grep -rln "daft" tests/ | xargs grep -ln "golden\|parity\|_golden_records" 2>/dev/null
+
+# (n) class 3b — the SDK's own arrow conversion needs duckdb >=1.5.0. Read both
+#     resolved versions from the lock: SDK 3.20.0-3.25.0 + duckdb <1.5.0 = the
+#     transform cannot execute at all, whatever the app does.
+grep -A1 '^name = "atlan-application-sdk"$' uv.lock
+grep -A1 '^name = "duckdb"$' uv.lock
 ```
 
 For (h), extract each literal column *name* (e.g. `status: source_query:
@@ -156,7 +163,7 @@ those sites (declared directly — see step 3's boundary policy) or replace
 them per step 2c; either way each site needs a decision with parity
 evidence, and no daft object may cross an SDK boundary afterwards.
 
-## Step 2 — The core breakage classes (1–7, plus 1b/2b; heavy-user classes 8–12 are in step 2c)
+## Step 2 — The core breakage classes (1–7, plus 1b/2b/3b; heavy-user classes 8–12 are in step 2c)
 
 ### 1. `[daft]` extra is declared but empty — daft silently leaves the lock
 
@@ -204,12 +211,49 @@ nothing fails at boot or import — the first real transform call raises
 `ModuleNotFoundError: duckdb`. Ships only in the SDK's `[sql]` and
 `[incremental]` extras.
 
+### 3b. The SDK's own arrow conversion only works on duckdb >=1.5.0 — an SDK bug
+
+With classes 2 and 3 fixed, the transform can still die *inside the SDK*:
+
+```
+AttributeError: '_duckdb.DuckDBPyConnection' object has no attribute
+'to_arrow_table'. Did you mean: 'fetch_arrow_table'?
+```
+
+`transform_metadata` called `db.connection.execute(sql).to_arrow_table()`.
+`conn.execute()` returns the **connection**, not a relation, and
+`to_arrow_table` was added to `DuckDBPyConnection` only in **duckdb 1.5.0** —
+while the SDK's `[sql]` / `[incremental]` extras allow
+`duckdb>=1.1.3,<1.6.0`. Measured across the window: absent on 1.1.3, 1.3.2,
+1.4.4; present on 1.5.0+. So the YAML transform path is unusable on **every
+SDK release 3.20.0 through 3.25.0** for any app whose lock resolves duckdb
+below 1.5.0, and works only by luck above it. Fixed by PR #2940
+(`db.connection.sql(sql).to_arrow_table()` — a relation, where the method
+predates the whole range); unreleased as of 2026-07-30, so check the app's
+pinned SDK rather than assuming.
+
+Route around it, in order of preference:
+
+- **Pin duckdb up** — declare `duckdb>=1.5.0,<1.6.0` as a direct app
+  dependency. uv intersects it with the SDK's range, the method exists, and no
+  SDK code is touched. Delete the pin once the app is on the release carrying
+  #2940.
+- **Override `transform_metadata`** app-side with the one-line fix and a TODO
+  pointing at #2940. Heavier, and it re-exposes the app to class 2b.
+
+Do not chase this as an app-side dataframe problem: the input coercion has
+already succeeded by the time it fires, and the last app frame in the
+traceback is just the `transform_metadata` call. Note also that
+`execute(...).fetch_arrow_table()` — the other obvious repair — works at the
+floor but is **deprecated as of duckdb 1.5.0**, so it trades the crash for a
+`DeprecationWarning` on the versions most locks resolve.
+
 ### 4. `transform_metadata` return contract: daft DataFrame → `list[dict] | None`
 
 Any `.to_pylist()` / `.to_pydict()` / `.iter_rows()` on the result raises
 `AttributeError: 'list' object has no attribute ...`. Items are dicts shaped
 `{"typeName": ..., "status": ..., "attributes": {...}}` — iterate them
-directly. Note the classes mask each other in order 2 → 3 → 4: fixing one
+directly. Note the classes mask each other in order 2 → 3 → 3b → 4: fixing one
 surfaces the next; budget for the sequence, not one crash.
 
 ### 5. Literal-vs-source-column precedence flipped — SILENT corruption
@@ -396,7 +440,9 @@ rows = transformer.transform_metadata(dataframe=records, ...) or []
    `grep -c 'name = "duckdb"' uv.lock` ≥1, `grep -c 'name = "daft"' uv.lock`
    = 0.
 3. Apply the class-6 guard if the pinned SDK predates the key-union fix, or
-   if the app builds pyarrow tables itself.
+   if the app builds pyarrow tables itself. Same check for class 3b: if the
+   pinned SDK predates PR #2940, add the `duckdb>=1.5.0,<1.6.0` direct pin —
+   and verify the lock actually moved (`grep -A1 '^name = "duckdb"$' uv.lock`).
 4. Fix every class-5 collision found in step 1(h), at the extractor.
 5. Update tests (class 7), and add the heterogeneous-records regression test
    for any `list[dict]` handoff.
@@ -438,7 +484,9 @@ right by accident — state those in the PR).
   branch (or the app's existing parity suite). Diff per typename; every
   difference must be explained.
 - Full test suite; collection errors are class 1, `AttributeError`s are
-  classes 2/4, `ModuleNotFoundError: duckdb` is class 3.
+  classes 2/4, `ModuleNotFoundError: duckdb` is class 3, and
+  `DuckDBPyConnection has no attribute 'to_arrow_table'` is class 3b (an SDK
+  bug — check the pinned SDK before suspecting the app).
 - Boot the worker (`uv run main.py`) — class 3 hides from boot, so also run
   one real transform (or the parity suite) end-to-end.
 - Parity tests against golden output are the only net that catches class 5 —
@@ -458,6 +506,13 @@ the old SDK and the exact old daft pin. When a bump breaks an app, hold the
 app's other deps fixed at what main resolves and vary only the SDK — the
 lockfile diff between main and the branch is the complete list of what
 actually changed.
+
+Corollary from class 3b: **a declared version range is not a tested range.**
+The SDK shipped that call in six releases because its own lock resolved the
+newest duckdb in the window, where the method happens to exist — CI only ever
+exercises the ceiling. When a dependency's declared floor sits far below what
+the lock resolves, treat the gap as untested rather than supported — on the
+app's own dependencies too.
 
 ## Agent protocol
 

--- a/.claude/skills/signal-over-noise/agents/openai.yaml
+++ b/.claude/skills/signal-over-noise/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Signal Over Noise"
+  short_description: "Audit Python errors and logging quality"
+  default_prompt: "Use $signal-over-noise to audit this Python codebase for swallowed failures and noisy logging."
+
+policy:
+  allow_implicit_invocation: true

--- a/.claude/skills/signal-over-noise/agents/openai.yaml
+++ b/.claude/skills/signal-over-noise/agents/openai.yaml
@@ -1,7 +1,0 @@
-interface:
-  display_name: "Signal Over Noise"
-  short_description: "Audit Python errors and logging quality"
-  default_prompt: "Use $signal-over-noise to audit this Python codebase for swallowed failures and noisy logging."
-
-policy:
-  allow_implicit_invocation: true

--- a/.claude/skills/upgrade-v3/SKILL.md
+++ b/.claude/skills/upgrade-v3/SKILL.md
@@ -1392,6 +1392,12 @@ for entity in rows or []:
 If upgrading an app whose lock resolved SDK <3.20.0, run `/migrate-off-daft`
 first — it owns the daft-removal breakage taxonomy.
 
+On SDK 3.20.0-3.25.0 the DuckDB transform also cannot execute at all when the
+lock resolves `duckdb<1.5.0` (`AttributeError: DuckDBPyConnection ... has no
+attribute 'to_arrow_table'`, fixed by application-sdk#2940). Pin
+`duckdb>=1.5.0,<1.6.0` directly until the app is on a release carrying the
+fix — see `/migrate-off-daft` class 3b.
+
 ### Output paths computed internally
 
 Do not pass `output_path` or `output_prefix` via the run() Input contract. Compute them inside `run()` and pass to tasks:

--- a/application_sdk/transformers/query/__init__.py
+++ b/application_sdk/transformers/query/__init__.py
@@ -434,7 +434,7 @@ class QueryBasedTransformer(TransformerInterface):
         )
         with DuckDBConnectionManager() as db:
             db.connection.register("dataframe", dataframe)
-            result_table = db.connection.execute(entity_sql_template).to_arrow_table()
+            result_table = db.connection.sql(entity_sql_template).to_arrow_table()
 
         # Convert flat dot-notation columns into nested dicts
         return self.get_grouped_dataframe_by_prefix(result_table)

--- a/tests/unit/transformers/query/conftest.py
+++ b/tests/unit/transformers/query/conftest.py
@@ -1,0 +1,27 @@
+"""Shared inputs for the transformer tests that run a real transform.
+
+These are exposed as fixtures rather than importable constants so both modules
+read one source without depending on pytest's sys.path insertion.
+"""
+
+from typing import Any
+
+import pytest
+
+from application_sdk.transformers.query import QueryBasedTransformer
+
+
+@pytest.fixture
+def postgres_transformer() -> QueryBasedTransformer:
+    return QueryBasedTransformer(connector_name="postgres", tenant_id="default")
+
+
+@pytest.fixture
+def transform_args() -> dict[str, Any]:
+    """Workflow identity and connection every real transform here runs under."""
+    return {
+        "workflow_id": "79a40801-07c2-4852-86c4-9703bda3a840",
+        "workflow_run_id": "019667f9-31e9-77b0-b7c0-b901bd30d140",
+        "connection_qualified_name": "default/postgres/1745501106",
+        "connection_name": "dev",
+    }

--- a/tests/unit/transformers/query/test_sql_transformer_duckdb_floor.py
+++ b/tests/unit/transformers/query/test_sql_transformer_duckdb_floor.py
@@ -62,6 +62,8 @@ def duckdb_within_declared_range(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_transform_metadata_uses_only_range_safe_duckdb_api(
     duckdb_within_declared_range: None,
+    postgres_transformer: QueryBasedTransformer,
+    transform_args: dict[str, Any],
 ) -> None:
     resource = os.path.join(
         os.path.dirname(os.path.abspath(__file__)), "resources/raw/database.json"
@@ -69,15 +71,8 @@ def test_transform_metadata_uses_only_range_safe_duckdb_api(
     with open(resource, "r") as raw:
         records = [json.loads(line) for line in raw if line.strip()]
 
-    result = QueryBasedTransformer(
-        connector_name="postgres", tenant_id="default"
-    ).transform_metadata(
-        "DATABASE",
-        pa.Table.from_pylist(records),
-        "79a40801-07c2-4852-86c4-9703bda3a840",
-        "019667f9-31e9-77b0-b7c0-b901bd30d140",
-        connection_qualified_name="default/postgres/1745501106",
-        connection_name="dev",
+    result = postgres_transformer.transform_metadata(
+        "DATABASE", pa.Table.from_pylist(records), **transform_args
     )
 
     assert result is not None

--- a/tests/unit/transformers/query/test_sql_transformer_duckdb_floor.py
+++ b/tests/unit/transformers/query/test_sql_transformer_duckdb_floor.py
@@ -1,0 +1,84 @@
+"""Regression test pinning the transformer to duckdb API valid across our range.
+
+The ``[sql]`` / ``[incremental]`` extras allow ``duckdb>=1.1.3,<1.6.0``, but the
+lockfile CI runs against resolves the newest release in that window. Anything
+duckdb added late in the range therefore looks available in CI while breaking
+every consumer resolving lower — which is how
+``DuckDBPyConnection.to_arrow_table`` (added in duckdb 1.5.0) reached a release.
+
+This test hides the connection methods that are not valid across the whole
+declared range and drives the real transform, so the bounds are exercised on
+whatever duckdb is installed.
+"""
+
+import json
+import os
+from typing import Any
+
+import pyarrow as pa
+import pytest
+
+from application_sdk.common.incremental.storage import duckdb_utils
+from application_sdk.transformers.query import QueryBasedTransformer
+
+# Connection methods usable on only part of duckdb>=1.1.3,<1.6.0.
+CONNECTION_METHODS_OUTSIDE_RANGE = {
+    "to_arrow_table": "added in duckdb 1.5.0",
+    "fetch_arrow_table": "deprecated in duckdb 1.5.0",
+}
+
+
+class DeclaredRangeConnection:
+    """A duckdb connection exposing only API valid on every allowed duckdb."""
+
+    def __init__(self, connection: Any) -> None:
+        self._connection = connection
+
+    def __getattr__(self, name: str) -> Any:
+        reason = CONNECTION_METHODS_OUTSIDE_RANGE.get(name)
+        if reason:
+            raise AttributeError(f"DuckDBPyConnection.{name} is {reason}")
+        attribute = getattr(self._connection, name)
+        if not callable(attribute):
+            return attribute
+
+        def call(*args: Any, **kwargs: Any) -> Any:
+            result = attribute(*args, **kwargs)
+            # execute() returns the connection itself; keep it restricted.
+            return self if result is self._connection else result
+
+        return call
+
+
+@pytest.fixture
+def duckdb_within_declared_range(monkeypatch: pytest.MonkeyPatch) -> None:
+    real_connection = duckdb_utils.DuckDBConnectionManager.connection.fget
+    monkeypatch.setattr(
+        duckdb_utils.DuckDBConnectionManager,
+        "connection",
+        property(lambda self: DeclaredRangeConnection(real_connection(self))),
+    )
+
+
+def test_transform_metadata_uses_only_range_safe_duckdb_api(
+    duckdb_within_declared_range: None,
+) -> None:
+    resource = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), "resources/raw/database.json"
+    )
+    with open(resource, "r") as raw:
+        records = [json.loads(line) for line in raw if line.strip()]
+
+    result = QueryBasedTransformer(
+        connector_name="postgres", tenant_id="default"
+    ).transform_metadata(
+        "DATABASE",
+        pa.Table.from_pylist(records),
+        "79a40801-07c2-4852-86c4-9703bda3a840",
+        "019667f9-31e9-77b0-b7c0-b901bd30d140",
+        connection_qualified_name="default/postgres/1745501106",
+        connection_name="dev",
+    )
+
+    assert result is not None
+    assert len(result) == len(records)

--- a/tests/unit/transformers/query/test_sql_transformer_output_validation.py
+++ b/tests/unit/transformers/query/test_sql_transformer_output_validation.py
@@ -4,24 +4,11 @@ import os
 from typing import Any
 
 import pyarrow as pa
-import pytest
 
 from application_sdk.observability.logger_adaptor import get_logger
 from application_sdk.transformers.query import QueryBasedTransformer
 
 logger = get_logger(__name__)
-
-LAST_SYNC_WORKFLOW_NAME = "79a40801-07c2-4852-86c4-9703bda3a840"
-LAST_SYNC_RUN = "019667f9-31e9-77b0-b7c0-b901bd30d140"
-CONNECTOR_NAME = "postgres"
-TENANT_ID = "default"
-CONNECTION_QUALIFIED_NAME = "default/postgres/1745501106"
-CONNECTION_NAME = "dev"
-
-
-@pytest.fixture
-def sql_transformer():
-    return QueryBasedTransformer(connector_name=CONNECTOR_NAME, tenant_id=TENANT_ID)
 
 
 def get_raw_json_files():
@@ -41,7 +28,9 @@ def remove_run_time_sensitive_fields(row: dict[str, Any]):
     row["attributes"].pop("lastSyncRunAt")
 
 
-def test_transform_metadata_output_validation(sql_transformer):
+def test_transform_metadata_output_validation(
+    postgres_transformer: QueryBasedTransformer, transform_args: dict[str, Any]
+):
     """
     Test the complete transformation flow for all JSON files in resources:
     1. Read raw JSON from resources
@@ -62,13 +51,8 @@ def test_transform_metadata_output_validation(sql_transformer):
         input_df = pa.Table.from_pylist(records)
 
         # Transform using SQL transformer
-        result = sql_transformer.transform_metadata(
-            file_name,
-            input_df,
-            LAST_SYNC_WORKFLOW_NAME,
-            LAST_SYNC_RUN,
-            connection_qualified_name=CONNECTION_QUALIFIED_NAME,
-            connection_name=CONNECTION_NAME,
+        result = postgres_transformer.transform_metadata(
+            file_name, input_df, **transform_args
         )
 
         # Assert that the result is not None and has rows


### PR DESCRIPTION
## TL;DR

`QueryBasedTransformer.transform_metadata` calls `.to_arrow_table()` on a `DuckDBPyConnection`. That method landed in duckdb 1.5.0, but the `[sql]` / `[incremental]` extras allow `duckdb>=1.1.3,<1.6.0` — so the YAML transform path raises `AttributeError` for any consumer resolving below 1.5.0. Switches to `connection.sql(...).to_arrow_table()`, which is valid and non-deprecated across the whole range, and adds a test that exercises the range bounds instead of just whatever the lockfile resolves.

Fixes #2938. Unblocks atlanhq/atlan-fivetran-app#168.

## The bug

`application_sdk/transformers/query/__init__.py:437`:

```python
result_table = db.connection.execute(entity_sql_template).to_arrow_table()
```

`conn.execute()` returns the connection, not a relation. Measured across the declared range:

| duckdb | `conn.to_arrow_table` | `conn.fetch_arrow_table` |
| --- | --- | --- |
| 1.1.3 | absent | present |
| 1.3.2 | absent | present |
| 1.4.4 | absent | present |
| 1.5.0 / 1.5.5 | present | present, DeprecationWarning |

So not every allowed version is broken — everything below 1.5.0 is.

Worth noting for anyone reaching for the other obvious fix: `execute(...).fetch_arrow_table()` works at the floor but is deprecated as of 1.5.0, so it emits a `DeprecationWarning` on the version the lockfile actually resolves. `connection.sql(...).to_arrow_table()` returns a `DuckDBPyRelation`, where `to_arrow_table()` has existed since well before 1.1.3 — clean on every version in the window.

## Why CI never caught it

The line came in with 41f32e1d (#2300, daft removal). At that commit `uv.lock` already resolved duckdb **1.5.4**, so the method existed and the suite was green.

The transformer is not short on coverage — `tests/unit/transformers/test_reader_transformer_integration.py` and `tests/unit/transformers/query/test_sql_transformer_output_validation.py` both drive a real `DuckDBConnectionManager` with no mocking. They passed throughout. The gap is that CI only ever resolves the *newest* version in a declared range, so declared lower bounds are asserted and never exercised.

## The test

`tests/unit/transformers/query/test_sql_transformer_duckdb_floor.py` drives the real transform through a connection proxy that hides methods which aren't valid across the entire declared range — `to_arrow_table` (added 1.5.0) and `fetch_arrow_table` (deprecated 1.5.0). It fails on the old line and on the deprecated alternative, and makes the bounds testable on whatever duckdb is installed.

## Verification

- `tests/unit/transformers/` — 140 passed on the locked duckdb (1.5.5)
- `uv run --with duckdb==1.1.3 pytest tests/unit/transformers/query/` — 25 passed against the real floor
- pre-commit clean

## Follow-ups, not in this PR

- A `uv sync --resolution lowest-direct` job would catch this class of bug generally. Nothing in `.github/workflows/` resolves lowest today.
- `duckdb>=1.1.3` is a wide floor for a range we never test. Narrowing it to versions we actually run would shrink the surface either way.

## Skill updates in this PR

The daft-cliff migration taxonomy now carries this as **class 3b**, since any app crossing the cliff onto 3.20.0-3.25.0 hits it right after classes 2/3 are fixed:

- `migrate-off-daft` — new class 3b (symptom, mechanism, version table, both workarounds, and why `fetch_arrow_table` isn't the right one), a lock-inspection check in the detection step, the masking order updated to 2 → 3 → 3b → 4, and a note that a declared version range is not a tested range.
- `upgrade-v3` and `adopt-preflight-gate` — both bump apps *into* the broken range, so both now point at class 3b with the `duckdb>=1.5.0,<1.6.0` interim pin.

Recommended interim workaround for apps blocked today is the direct duckdb pin, not an app-side `transform_metadata` override: uv intersects it with the SDK's range, the method exists above 1.5.0, and no SDK code gets forked.
