### PR TITLE
feat(conformance): add K013/K014 manifest app_name consistency rules

### DIFF
--- a/packages/conformance/conformance/docs/rules/contract-toolkit.md
+++ b/packages/conformance/conformance/docs/rules/contract-toolkit.md
@@ -519,3 +519,66 @@ header line (or the line above). Only justified for an app that is genuinely nev
 published through the marketplace pipeline.
 
 ---
+
+## K013 — `ManifestNodeAppNameMismatch` {#k013}
+
+**Tier:** `block` · **Scope:** `app` · **Category:** `app-name-alignment` · **Autofixable:** — · **Since:** 0.18.0
+
+> A DAG node's inputs.args.app_name disagrees with its top-level app_name / inputs.app_name in a generated manifest.json
+
+**Rationale:** The CNCT-129 fix makes the SDK stamp each DAG node's logs and metrics with
+that node's own app_name, resolved from its `inputs.args.app_name` (the value the contract
+toolkit now emits). The tenant UI / Heracles query a node's logs by its `app_name` — an
+equality filter on the lakehouse `app_name` column. If a node's `inputs.args.app_name` (what
+the SDK stamps) diverges from its top-level `app_name` / `inputs.app_name` (what the UI
+queries), the node's logs are written under one identity and looked up under another, so they
+never appear in the panel — the exact CNCT-129 failure. pkl compiles the manifest before any
+Python runs and no existing gate diffs these three copies of the value, so the drift is
+invisible until a customer reports missing logs.
+
+Within a single generated `manifest.json` DAG node (under `app/generated/` or
+`contract/generated/`), the three places an `app_name` can appear must all agree:
+
+- the node's top-level `app_name` (what the tenant UI reads as `node.app_name` and queries logs by),
+- `inputs.app_name` (Automation Engine metadata),
+- `inputs.args.app_name` (the runtime input the SDK reads and stamps onto every log line and metric).
+
+**No-op when:** a node has no `inputs.args.app_name` at all. Apps not yet regenerated onto the
+app_name-emitting toolkit carry no such key, and the SDK correctly falls back to the
+process-wide `ATLAN_APPLICATION_NAME` env value — so an absent key is never a violation. The
+rule fires only once the key is present and disagrees.
+
+**Fix:** never hand-edit the generated `manifest.json` (it is a `pkl eval` output; K004/K005
+catch hand edits). Set a single `appName` per node in `contract/app.pkl` / `NativeApp.pkl` and
+re-run `pkl eval` so the node's top-level `app_name`, `inputs.app_name` and
+`inputs.args.app_name` are all derived from the same value.
+
+---
+
+## K014 — `ManifestNodeAppNameCollision` {#k014}
+
+**Tier:** `warn` · **Scope:** `app` · **Category:** `app-name-alignment` · **Autofixable:** — · **Since:** 0.18.0
+
+> Two different DAG nodes in one manifest.json share the same app_name, so their logs overlap in the tenant UI
+
+**Rationale:** The tenant UI / Heracles query a run's logs by `(correlation_id, app_name)` with
+no per-node discriminator in the filter. If two different DAG nodes in the same manifest declare
+the same app_name, their logs land under one identity and overlap in the run panel — a viewer
+cannot tell which node a line came from. Because `DAGNode.appName` defaults to a shared value
+(`automation-engine`), a DAG with two default-appName nodes silently collides. Warned rather
+than blocked: a DAG may legitimately run two nodes as the same app, so this is a
+graduation-tracked advisory the author can suppress with a reason.
+
+This is scoped **per manifest**: a bundle's `crawler` and `miner` manifests are separate
+entrypoint runs, so the `publish` node's `app_name` recurring across them is expected and never
+compared. The rule only compares nodes within a single manifest file.
+
+**No-op when:** a node carries no top-level `app_name` (nothing to collide), or no two nodes
+share one.
+
+**Fix:** give each node a distinct `appName` in `contract/app.pkl` / `NativeApp.pkl` (a node
+left at the default `automation-engine` while another node also defaults is the common cause),
+then re-run `pkl eval`. If two nodes genuinely run as the same app and the overlap is
+acceptable, suppress with a documented reason.
+
+---

--- a/packages/conformance/conformance/suite/checks/manifest_app_name/__init__.py
+++ b/packages/conformance/conformance/suite/checks/manifest_app_name/__init__.py
@@ -1,0 +1,47 @@
+"""K013 ManifestNodeAppNameMismatch / K014 ManifestNodeAppNameCollision.
+
+Per-node ``app_name`` invariants over the committed generated DAG —
+``app/generated/**/manifest.json`` or ``contract/generated/**/manifest.json``
+(CNCT-129):
+
+* **K013 (block):** within a node, ``app_name`` / ``inputs.app_name`` /
+  ``inputs.args.app_name`` must agree (no-op when ``inputs.args.app_name`` is
+  absent — not-yet-regenerated apps fall back to the env value).
+* **K014 (warn):** no two distinct nodes in the same manifest may share an
+  ``app_name`` (their logs would overlap in the tenant UI).
+
+Both are **cross-artifact** checks that read generated JSON, not Python source,
+so per-file ``scan_path`` is a no-op and ``scan_all`` does all the work —
+mirrors ``manifest_contract`` (K006).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from conformance.suite.checks._ast_common import discover, make_cli_main
+from conformance.suite.schema.findings import Finding
+
+from ._check import scan_all
+
+SERIES = "K"
+
+__all__ = ["SERIES", "discover", "main", "scan_all", "scan_path"]
+
+
+def scan_path(path: Path, root: Path) -> list[Finding]:  # noqa: ARG001
+    """No-op: these rules need cross-artifact analysis; use :func:`scan_all`."""
+    return []
+
+
+main = make_cli_main(
+    scan_all=scan_all,
+    description=(
+        "K013/K014: per-node app_name consistency (block) and cross-node "
+        "distinctness (warn) in app/generated/**/manifest.json (CNCT-129)."
+    ),
+)
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/conformance/conformance/suite/checks/manifest_app_name/_check.py
+++ b/packages/conformance/conformance/suite/checks/manifest_app_name/_check.py
@@ -1,0 +1,186 @@
+"""K013 / K014 — per-node ``app_name`` consistency inside generated manifests.
+
+The CNCT-129 fix makes the SDK stamp each DAG node's own ``app_name`` onto its
+logs and metrics, resolved from that node's ``inputs.args.app_name`` (the value
+the contract toolkit now emits). The tenant UI / Heracles query a node's logs by
+its ``app_name`` (an equality filter on the lakehouse ``app_name`` column). Two
+manifest-shaped invariants keep that path correct; both are checked here off the
+committed generated DAG — ``app/generated/**/manifest.json`` or, for apps that
+generate under ``contract/generated/`` (e.g. powerbi), that root:
+
+* **K013 (block) — internal consistency.** Within a node, the three places an
+  ``app_name`` can appear — the node's top-level ``app_name``, ``inputs.app_name``
+  and ``inputs.args.app_name`` — must agree. If ``inputs.args.app_name`` (what the
+  SDK stamps) diverges from the node's ``app_name`` (what the UI queries), the
+  node's logs are stamped one value and queried under another: they vanish from
+  the panel. This is exactly the CNCT-129 failure, one static diff away.
+  No-op guard: a node with **no** ``inputs.args.app_name`` is never flagged —
+  apps not yet regenerated onto the new toolkit carry no args key and fall back
+  to the ``ATLAN_APPLICATION_NAME`` env value at runtime, which is correct.
+
+* **K014 (warn) — cross-node distinctness, per manifest.** Two *different* DAG
+  nodes in the *same* manifest must not share an ``app_name``: the UI keys logs
+  on ``(correlation_id, app_name)`` with no per-node discriminator, so two
+  co-running nodes with the same ``app_name`` overlap in the panel. Scoped per
+  manifest on purpose — a bundle's ``crawler`` and ``miner`` manifests are
+  separate runs, so the ``publish`` node's ``app_name`` recurring across them is
+  fine and never compared.
+
+Both no-op cleanly when neither generated root exists (SDK / library repos), when
+a manifest has no parseable ``dag``, or when a node carries no ``app_name`` at
+all.
+"""
+
+from __future__ import annotations
+
+import json
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+from conformance.suite.schema.findings import Finding
+
+_MISMATCH_RULE_ID = "K013"
+_COLLISION_RULE_ID = "K014"
+
+
+def _str_or_none(value: Any) -> str | None:
+    """Return *value* iff it is a non-empty ``str``, else ``None``."""
+    return value if isinstance(value, str) and value else None
+
+
+def _node_app_names(
+    node_data: dict[str, Any],
+) -> tuple[str | None, str | None, str | None]:
+    """Return ``(top, inputs_app, args_app)`` string values present on a node."""
+    top = _str_or_none(node_data.get("app_name"))
+    inputs = node_data.get("inputs")
+    if not isinstance(inputs, dict):
+        return top, None, None
+    inputs_app = _str_or_none(inputs.get("app_name"))
+    args = inputs.get("args")
+    args_app = _str_or_none(args.get("app_name")) if isinstance(args, dict) else None
+    return top, inputs_app, args_app
+
+
+def _scan_manifest(path: Path, root: Path) -> list[Finding]:
+    """Emit K013/K014 findings for a single ``manifest.json``.
+
+    Conservative on shape: a missing/unreadable/malformed file, or one with no
+    ``dag`` object, yields no findings (mirrors K006's tolerance of a
+    partially-generated manifest).
+    """
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return []
+    dag = data.get("dag")
+    if not isinstance(dag, dict):
+        return []
+
+    try:
+        rel = str(path.relative_to(root))
+    except ValueError:
+        rel = str(path)
+
+    findings: list[Finding] = []
+    # node id -> its declared (queried) app_name, for the per-manifest collision pass.
+    top_by_node: dict[str, str] = {}
+
+    for node_id, node_data in dag.items():
+        if not isinstance(node_data, dict):
+            continue
+        top, inputs_app, args_app = _node_app_names(node_data)
+
+        if top is not None:
+            top_by_node[str(node_id)] = top
+
+        # K013: only fires once the SDK-stamped args value is present AND it
+        # disagrees with another present value for the same node.
+        if args_app is not None:
+            present = [v for v in (top, inputs_app, args_app) if v is not None]
+            if len(set(present)) > 1:
+                findings.append(
+                    Finding(
+                        rule_id=_MISMATCH_RULE_ID,
+                        file=rel,
+                        line=1,
+                        column=1,
+                        message=(
+                            f"DAG node '{node_id}' has inconsistent app_name: "
+                            f"inputs.args.app_name='{args_app}'"
+                            + (f", app_name='{top}'" if top is not None else "")
+                            + (
+                                f", inputs.app_name='{inputs_app}'"
+                                if inputs_app is not None
+                                else ""
+                            )
+                            + ". The SDK stamps logs/metrics from "
+                            "inputs.args.app_name, while the tenant UI / Heracles "
+                            "query the node's app_name — when they differ the "
+                            "node's logs are stamped one value and queried under "
+                            "another, so they never appear (CNCT-129). All three "
+                            "must be equal. Do not hand-edit the generated "
+                            "manifest: fix the node's appName in contract/app.pkl "
+                            "and re-run pkl eval so every app_name for the node "
+                            "agrees."
+                        ),
+                    )
+                )
+
+    # K014: within THIS manifest, no two distinct nodes may share an app_name.
+    nodes_by_app: dict[str, list[str]] = defaultdict(list)
+    for node_id, app in top_by_node.items():
+        nodes_by_app[app].append(node_id)
+    for app, node_ids in nodes_by_app.items():
+        if len(node_ids) > 1:
+            joined = ", ".join(sorted(node_ids))
+            findings.append(
+                Finding(
+                    rule_id=_COLLISION_RULE_ID,
+                    file=rel,
+                    line=1,
+                    column=1,
+                    message=(
+                        f"DAG nodes [{joined}] all declare app_name='{app}' in the "
+                        "same manifest. The tenant UI queries logs by "
+                        "(correlation_id, app_name) with no per-node discriminator, "
+                        "so these nodes' logs overlap in the panel and cannot be "
+                        "told apart. Give each node a distinct app_name (set a "
+                        "distinct appName per node in contract/app.pkl). If two "
+                        "nodes genuinely run as the same app, suppress this warning "
+                        "with a documented reason."
+                    ),
+                )
+            )
+
+    return findings
+
+
+def scan_all(paths: list[Path], root: Path) -> list[Finding]:  # noqa: ARG001
+    """Scan every committed generated ``manifest.json`` for app_name drift.
+
+    Apps emit their generated manifests to one of two roots depending on how
+    ``poe generate`` is wired: most use ``app/generated/`` (mysql, metabase,
+    openapi, hightouch), but some — including powerbi, the app that motivated
+    these rules — use ``contract/generated/`` (its task is
+    ``cd contract && pkl eval -m generated app.pkl``). Both roots are scanned so
+    the rules never silently skip an app because of where it generates.
+
+    No-ops only when NEITHER root exists (SDK / library repos). Reads the
+    generated manifests directly (not the Python source in ``paths``), so the
+    per-file ``paths`` argument is unused. Relative-path reporting is anchored at
+    ``root`` regardless of which generated root a manifest came from.
+    """
+    findings: list[Finding] = []
+    seen: set[Path] = set()
+    for generated in (root / "app" / "generated", root / "contract" / "generated"):
+        if not generated.is_dir():
+            continue
+        for manifest_path in sorted(generated.glob("**/manifest.json")):
+            resolved = manifest_path.resolve()
+            if resolved in seen:  # defensive: same file reachable via both roots
+                continue
+            seen.add(resolved)
+            findings.extend(_scan_manifest(manifest_path, root))
+    return findings

--- a/packages/conformance/conformance/suite/rules/contract_toolkit.py
+++ b/packages/conformance/conformance/suite/rules/contract_toolkit.py
@@ -840,4 +840,120 @@ RULES: tuple[RuleDefinition, ...] = (
             "packages/conformance/conformance/docs/rules/contract-toolkit.md#k012"
         ),
     ),
+    RuleDefinition(
+        id="K013",
+        scope=RuleScope.APP,
+        name="ManifestNodeAppNameMismatch",
+        tier=EnforcementTier.BLOCK,
+        mechanism=RuleMechanism.STATIC,
+        category="app-name-alignment",
+        autofixable=False,
+        since="0.18.0",
+        rationale=(
+            "The CNCT-129 fix makes the SDK stamp each DAG node's logs and "
+            "metrics with that node's own app_name, resolved from its "
+            "inputs.args.app_name (the value the contract toolkit now emits). The "
+            "tenant UI / Heracles query a node's logs by its app_name — an "
+            "equality filter on the lakehouse app_name column. If a node's "
+            "inputs.args.app_name (what the SDK stamps) diverges from its "
+            "top-level app_name / inputs.app_name (what the UI queries), the "
+            "node's logs are written under one identity and looked up under "
+            "another, so they never appear in the panel — the exact CNCT-129 "
+            "failure. pkl compiles the manifest before any Python runs and no "
+            "existing gate diffs these three copies of the value, so the drift is "
+            "invisible until a customer reports missing logs."
+        ),
+        short_description=(
+            "A DAG node's inputs.args.app_name disagrees with its top-level "
+            "app_name / inputs.app_name in a generated manifest.json"
+        ),
+        full_description=(
+            "Within a single generated ``manifest.json`` DAG node (under "
+            "``app/generated/`` or ``contract/generated/``), the "
+            "three places an ``app_name`` can appear must all agree:\n"
+            "\n"
+            "* the node's top-level ``app_name`` (what the tenant UI reads as "
+            "``node.app_name`` and queries logs by),\n"
+            "* ``inputs.app_name`` (Automation Engine metadata),\n"
+            "* ``inputs.args.app_name`` (the runtime input the SDK reads and "
+            "stamps onto every log line and metric for the node).\n"
+            "\n"
+            "When ``inputs.args.app_name`` differs from the node's own "
+            "``app_name``, the SDK stamps the node's logs with one value while the "
+            "UI queries them under another; Heracles applies ``app_name`` as an "
+            "equality filter, so the lookup returns nothing and the node's logs "
+            "are invisible in the run panel (CNCT-129).\n"
+            "\n"
+            "**No-op when:** a node has no ``inputs.args.app_name`` at all. Apps "
+            "not yet regenerated onto the app_name-emitting toolkit carry no such "
+            "key, and the SDK correctly falls back to the process-wide "
+            "``ATLAN_APPLICATION_NAME`` env value — so an absent key is never a "
+            "violation. The rule fires only once the key is present and "
+            "disagrees.\n"
+            "\n"
+            "**Fix:** never hand-edit the generated ``manifest.json`` (it is a "
+            "``pkl eval`` output; K004/K005 catch hand edits). Set a single "
+            "``appName`` per node in ``contract/app.pkl`` / ``NativeApp.pkl`` and "
+            "re-run ``pkl eval`` so the node's top-level ``app_name``, "
+            "``inputs.app_name`` and ``inputs.args.app_name`` are all derived from "
+            "the same value.\n"
+        ),
+        help_uri=(
+            "https://github.com/atlanhq/application-sdk/blob/main/"
+            "packages/conformance/conformance/docs/rules/contract-toolkit.md#k013"
+        ),
+    ),
+    RuleDefinition(
+        id="K014",
+        scope=RuleScope.APP,
+        name="ManifestNodeAppNameCollision",
+        tier=EnforcementTier.WARN,
+        mechanism=RuleMechanism.STATIC,
+        category="app-name-alignment",
+        autofixable=False,
+        since="0.18.0",
+        rationale=(
+            "The tenant UI / Heracles query a node's logs by "
+            "(correlation_id, app_name) with no per-node discriminator in the "
+            "filter. If two different DAG nodes in the same manifest declare the "
+            "same app_name, their logs land under one identity and overlap in the "
+            "run panel — a viewer cannot tell which node a line came from. Because "
+            "DAGNode.appName defaults to a shared value (automation-engine), a DAG "
+            "with two default-appName nodes silently collides. Warned rather than "
+            "blocked: a DAG may legitimately run two nodes as the same app, so "
+            "this is a graduation-tracked advisory the author can suppress with a "
+            "reason."
+        ),
+        short_description=(
+            "Two different DAG nodes in one manifest.json share the same app_name, "
+            "so their logs overlap in the tenant UI"
+        ),
+        full_description=(
+            "The tenant UI queries a run's logs by ``(correlation_id, app_name)`` "
+            "and applies ``app_name`` as an equality filter, with no per-node key "
+            "in the query. When two distinct DAG nodes in the **same** "
+            "``manifest.json`` declare the same top-level ``app_name``, their log "
+            "lines are stamped identically and overlap in the panel — a viewer "
+            "cannot attribute a line to a specific node.\n"
+            "\n"
+            "This is scoped **per manifest**: a bundle's ``crawler`` and ``miner`` "
+            "manifests are separate entrypoint runs, so the ``publish`` node's "
+            "``app_name`` recurring across them is expected and never compared. "
+            "The rule only compares nodes within a single manifest file.\n"
+            "\n"
+            "**No-op when:** a node carries no top-level ``app_name`` (nothing to "
+            "collide), or no two nodes share one.\n"
+            "\n"
+            "**Fix:** give each node a distinct ``appName`` in "
+            "``contract/app.pkl`` / ``NativeApp.pkl`` (a node left at the default "
+            "``automation-engine`` while another node also defaults is the common "
+            "cause), then re-run ``pkl eval``. If two nodes genuinely run as the "
+            "same app and the overlap is acceptable, suppress with a documented "
+            "reason.\n"
+        ),
+        help_uri=(
+            "https://github.com/atlanhq/application-sdk/blob/main/"
+            "packages/conformance/conformance/docs/rules/contract-toolkit.md#k014"
+        ),
+    ),
 )

--- a/packages/conformance/conformance/suite/runner.py
+++ b/packages/conformance/conformance/suite/runner.py
@@ -47,6 +47,7 @@ from conformance.suite.checks import (
     integration_deselect,
     integration_marking,
     legacy_contract,
+    manifest_app_name,
     manifest_contract,
     optimizations,
     orchestration,
@@ -231,6 +232,12 @@ _CHECKS: list[CheckRegistration] = [
         discover=manifest_contract.discover,
         scan_path=manifest_contract.scan_path,
         scan_all=manifest_contract.scan_all,
+    ),
+    CheckRegistration(
+        series=manifest_app_name.SERIES,
+        discover=manifest_app_name.discover,
+        scan_path=manifest_app_name.scan_path,
+        scan_all=manifest_app_name.scan_all,
     ),
     CheckRegistration(
         series=release_contract.SERIES,

--- a/packages/conformance/tests/test_catalog.py
+++ b/packages/conformance/tests/test_catalog.py
@@ -226,6 +226,8 @@ def test_catalog_app_scoped_rules_are_the_expected_set() -> None:
         "K010",
         "K011",
         "K012",
+        "K013",
+        "K014",
         "P004",
         "P005",
         "P008",
@@ -525,6 +527,8 @@ def test_catalog_k_series_present() -> None:
         "K010",
         "K011",
         "K012",
+        "K013",
+        "K014",
     }
     missing = expected - k_ids
     assert not missing, f"Missing K-series rules: {missing}"

--- a/packages/conformance/tests/test_manifest_app_name.py
+++ b/packages/conformance/tests/test_manifest_app_name.py
@@ -1,0 +1,251 @@
+"""Tests for K013 ManifestNodeAppNameMismatch / K014 ManifestNodeAppNameCollision.
+
+Both rules read the committed generated DAG directly (``app/generated/`` or
+``contract/generated/``, no Python source), so the tests only need to write
+manifest JSON under a temp repo root and call :func:`scan_all`.
+
+Helpers
+-------
+``_node``: build one DAG node with configurable ``app_name`` in the three
+places it can appear (top-level, ``inputs.app_name``, ``inputs.args.app_name``);
+pass ``None`` to omit a given slot.
+``_run``: write ``{relative_manifest_path: dag_dict}`` under
+``tmp_path/app/generated/`` and return :func:`scan_all`'s findings.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from conformance.suite.checks.manifest_app_name import scan_all
+from conformance.suite.rules import get_rule
+from conformance.suite.schema.disposition import EnforcementTier, RuleScope
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _node(
+    top: str | None = None,
+    inputs_app: str | None = None,
+    args_app: str | None = None,
+    workflow_type: str = "MyWorkflow",
+) -> dict:
+    node: dict = {"activity_name": "execute_workflow"}
+    if top is not None:
+        node["app_name"] = top
+    inputs: dict = {"workflow_type": workflow_type}
+    if inputs_app is not None:
+        inputs["app_name"] = inputs_app
+    args: dict = {"credential": "{{credential}}"}
+    if args_app is not None:
+        args["app_name"] = args_app
+    inputs["args"] = args
+    node["inputs"] = inputs
+    return node
+
+
+def _run(
+    tmp_path: Path,
+    manifests: dict[str, dict],
+    base: str = "app/generated",
+) -> list:
+    """Write manifests under ``tmp_path/<base>/`` and return scan_all's findings.
+
+    ``base`` selects the generated root — ``app/generated`` (default, most apps)
+    or ``contract/generated`` (powerbi and friends).
+    """
+    generated = tmp_path / base
+    for rel, dag in manifests.items():
+        p = generated / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(json.dumps({"dag": dag}), encoding="utf-8")
+    return scan_all([], tmp_path)
+
+
+def _ids(findings: list, rule_id: str) -> list:
+    return [f for f in findings if f.rule_id == rule_id]
+
+
+# ---------------------------------------------------------------------------
+# Rule metadata
+# ---------------------------------------------------------------------------
+
+
+def test_k013_metadata() -> None:
+    rule = get_rule("K013")
+    assert rule.name == "ManifestNodeAppNameMismatch"
+    assert rule.tier == EnforcementTier.BLOCK
+    assert rule.scope == RuleScope.APP
+
+
+def test_k014_metadata() -> None:
+    rule = get_rule("K014")
+    assert rule.name == "ManifestNodeAppNameCollision"
+    assert rule.tier == EnforcementTier.WARN
+    assert rule.scope == RuleScope.APP
+
+
+# ---------------------------------------------------------------------------
+# (a) consistent + distinct → both pass
+# ---------------------------------------------------------------------------
+
+
+def test_consistent_and_distinct_is_clean(tmp_path: Path) -> None:
+    dag = {
+        "extract": _node("powerbi-crawler", "powerbi-crawler", "powerbi-crawler"),
+        "publish": _node("publish", "publish", "publish"),
+    }
+    assert _run(tmp_path, {"manifest.json": dag}) == []
+
+
+# ---------------------------------------------------------------------------
+# (b) inputs.args.app_name != top-level → K013 BLOCK
+# ---------------------------------------------------------------------------
+
+
+def test_args_app_name_mismatch_flags_k013(tmp_path: Path) -> None:
+    # SDK would stamp "powerbi" while the UI queries "powerbi-crawler".
+    dag = {"extract": _node("powerbi-crawler", "powerbi-crawler", "powerbi")}
+    findings = _run(tmp_path, {"manifest.json": dag})
+    k013 = _ids(findings, "K013")
+    assert len(k013) == 1
+    assert "extract" in k013[0].message
+    assert "powerbi-crawler" in k013[0].message and "powerbi" in k013[0].message
+    assert _ids(findings, "K014") == []
+
+
+def test_inputs_app_name_mismatch_flags_k013(tmp_path: Path) -> None:
+    # args present and agrees with top, but inputs.app_name diverges → still flagged.
+    dag = {"extract": _node("crawler", "stale", "crawler")}
+    assert len(_ids(_run(tmp_path, {"manifest.json": dag}), "K013")) == 1
+
+
+# ---------------------------------------------------------------------------
+# (c) two distinct nodes sharing an app_name in one manifest → K014 WARN
+# ---------------------------------------------------------------------------
+
+
+def test_shared_app_name_across_nodes_flags_k014(tmp_path: Path) -> None:
+    # Each node is internally consistent (no K013), but they collide (K014).
+    dag = {
+        "extract": _node("dup", "dup", "dup"),
+        "notify": _node("dup", "dup", "dup"),
+    }
+    findings = _run(tmp_path, {"manifest.json": dag})
+    k014 = _ids(findings, "K014")
+    assert len(k014) == 1
+    assert "extract" in k014[0].message and "notify" in k014[0].message
+    assert "dup" in k014[0].message
+    assert _ids(findings, "K013") == []
+
+
+# ---------------------------------------------------------------------------
+# (d) inputs.args.app_name absent everywhere → K013 no-op
+# ---------------------------------------------------------------------------
+
+
+def test_absent_args_app_name_is_k013_noop(tmp_path: Path) -> None:
+    # top and inputs disagree, but NO args.app_name → not-yet-regenerated app,
+    # falls back to env at runtime; must not be flagged.
+    dag = {"extract": _node("powerbi-crawler", "something-else", None)}
+    findings = _run(tmp_path, {"manifest.json": dag})
+    assert _ids(findings, "K013") == []
+
+
+def test_no_app_name_at_all_is_clean(tmp_path: Path) -> None:
+    dag = {"extract": _node(None, None, None)}
+    assert _run(tmp_path, {"manifest.json": dag}) == []
+
+
+# ---------------------------------------------------------------------------
+# (e) same app_name across SEPARATE manifests → K014 does NOT fire
+# ---------------------------------------------------------------------------
+
+
+def test_collision_is_scoped_per_manifest(tmp_path: Path) -> None:
+    crawler = {
+        "extract": _node("powerbi-crawler", "powerbi-crawler", "powerbi-crawler"),
+        "publish": _node("publish", "publish", "publish"),
+    }
+    miner = {
+        "extract": _node("powerbi-miner", "powerbi-miner", "powerbi-miner"),
+        "publish": _node("publish", "publish", "publish"),
+    }
+    findings = _run(
+        tmp_path,
+        {"crawler/manifest.json": crawler, "miner/manifest.json": miner},
+    )
+    # 'publish' recurs across the two entrypoint manifests — separate runs, no overlap.
+    assert _ids(findings, "K014") == []
+    assert _ids(findings, "K013") == []
+
+
+# ---------------------------------------------------------------------------
+# No-op / robustness
+# ---------------------------------------------------------------------------
+
+
+def test_noop_when_neither_generated_dir(tmp_path: Path) -> None:
+    # Neither app/generated/ nor contract/generated/ exists (SDK / library repo).
+    assert scan_all([], tmp_path) == []
+
+
+# ---------------------------------------------------------------------------
+# contract/generated/ layout (powerbi and friends) — both rules fire there too
+# ---------------------------------------------------------------------------
+
+
+def test_contract_generated_layout_flags_k013(tmp_path: Path) -> None:
+    # powerbi generates to contract/generated/<entrypoint>/manifest.json.
+    crawler = {
+        # SDK would stamp "powerbi" while the UI queries "powerbi-crawler".
+        "extract": _node("powerbi-crawler", "powerbi-crawler", "powerbi"),
+        "publish": _node("publish", "publish", "publish"),
+    }
+    findings = _run(
+        tmp_path, {"crawler/manifest.json": crawler}, base="contract/generated"
+    )
+    k013 = _ids(findings, "K013")
+    assert len(k013) == 1
+    assert "extract" in k013[0].message
+    # relative-path reporting anchored at repo root, from the contract/ root.
+    assert k013[0].file == "contract/generated/crawler/manifest.json"
+
+
+def test_contract_generated_layout_flags_k014(tmp_path: Path) -> None:
+    dag = {
+        "extract": _node("dup", "dup", "dup"),
+        "notify": _node("dup", "dup", "dup"),
+    }
+    findings = _run(tmp_path, {"miner/manifest.json": dag}, base="contract/generated")
+    k014 = _ids(findings, "K014")
+    assert len(k014) == 1
+    assert k014[0].file == "contract/generated/miner/manifest.json"
+
+
+def test_contract_generated_consistent_is_clean(tmp_path: Path) -> None:
+    crawler = {
+        "extract": _node("powerbi-crawler", "powerbi-crawler", "powerbi-crawler"),
+        "publish": _node("publish", "publish", "publish"),
+    }
+    assert (
+        _run(tmp_path, {"crawler/manifest.json": crawler}, base="contract/generated")
+        == []
+    )
+
+
+def test_malformed_manifest_is_ignored(tmp_path: Path) -> None:
+    generated = tmp_path / "app" / "generated"
+    generated.mkdir(parents=True)
+    (generated / "manifest.json").write_text("{ not json", encoding="utf-8")
+    assert scan_all([], tmp_path) == []
+
+
+def test_manifest_without_dag_is_ignored(tmp_path: Path) -> None:
+    generated = tmp_path / "app" / "generated"
+    generated.mkdir(parents=True)
+    (generated / "manifest.json").write_text(json.dumps({"execution_mode": "x"}))
+    assert scan_all([], tmp_path) == []


### PR DESCRIPTION
## Why

The CNCT-129 fix makes the SDK stamp each DAG node's own `app_name` (from `inputs.args.app_name`) onto its logs/metrics, and the tenant UI / Heracles query a node's logs by its `app_name`. Two manifest-shaped invariants keep that path correct; nothing guarded them, so they could silently drift (logs vanish) or collide (logs overlap). These two static rules close that gap.

## Rules

### K013 `ManifestNodeAppNameMismatch` — BLOCK, scope APP
Within a DAG node, the three places `app_name` can appear — top-level `app_name`, `inputs.app_name`, `inputs.args.app_name` — must all agree. If `inputs.args.app_name` (what the SDK stamps) diverges from the node's `app_name` (what the UI queries), the node's logs are stamped one value and queried under another → they never appear. That's the exact CNCT-129 failure, one static diff away.

**No-op guard (fleet-safe):** fires *only* when `inputs.args.app_name` is present **and** disagrees. Apps not yet regenerated onto the new toolkit carry no args key and fall back to `ATLAN_APPLICATION_NAME` at runtime — those stay green, so this is safe to ship as BLOCK.

### K014 `ManifestNodeAppNameCollision` — WARN, scope APP
Per manifest, two *different* DAG nodes must not share an `app_name`: the UI keys logs on `(correlation_id, app_name)` with no per-node discriminator, so co-running nodes with the same `app_name` overlap in the panel. **Scoped per-manifest** on purpose — a bundle's `crawler` and `miner` manifests are separate runs, so a `publish` node recurring across them is fine and never compared. WARN (not BLOCK): rare same-service DAGs are legitimate.

## Coverage

Scans **both** generated roots — `app/generated/` (mysql/metabase/openapi/hightouch) **and** `contract/generated/` (powerbi, the motivating app). No-ops when neither exists (SDK / library repos) or a manifest has no parseable `dag`.

## Relationship to P025

Complementary, different granularity: **P025** reconciles the *single* app-level name across code / `atlan.yaml` / `.env.example` (and deliberately no-ops on bundles). **K013/K014** validate the *per-node* `app_name`s inside a generated manifest's DAG — the layer P025 doesn't touch, which is exactly where the bundle bug lived.

## Note

Generated manifests are JSON (no comment host), so these findings have no inline-`# conformance: ignore` path — K013 only fires on genuine drift (safe BLOCK) and K014 is WARN-only. Remediation is always "fix the node's `appName` in `contract/app.pkl` and re-run `pkl eval`."

## Tests

16 new tests + catalog: consistent+distinct → clean; `args` mismatch → K013; shared `app_name` → K014; absent `args.app_name` → K013 no-op; cross-manifest recurrence → no K014; both generated layouts. Full conformance suite: **2086 passed**. pre-commit (ruff/isort/pyright) green; `scan_all` on the SDK repo returns `[]`.