### PR TITLE
ci(sdk-review): recover progress signal and make cancel stop the sandbox

### DIFF
--- a/.github/scripts/mothership_terminate_session.py
+++ b/.github/scripts/mothership_terminate_session.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Stop a mothership sandbox session after its GitHub Actions job is cancelled.
+
+Cancelling the `sdk-review` job does not stop the sandbox. mothership runs it
+on a thread-pool executor with a detached asyncio finalize task
+(``harness/api/routers/sandbox_api.py::_sse_execution_wrapper``), and its SSE
+queue drops on overflow instead of applying backpressure. Killing ``curl``
+only closes the client end of the stream — the run continues, keeps billing
+against ``max_timeout_seconds``, and still posts its review and commit status
+to the PR using the sandbox's own ``gh`` token, minutes after the workflow
+reports "cancelled".
+
+``DELETE /api/sandbox/session/{session_id}?destroy=true`` is the documented
+way to actually stop it (see mothership ``docs/reference/rover-direct-api.md``).
+
+This runs inside the cancellation grace period as best-effort cleanup, so it
+never exits non-zero: masking the real job outcome with a teardown error helps
+nobody. Every branch is reported as an annotation instead.
+
+Branching logic lives here (a tested script) rather than inlined in the
+workflow YAML, per docs/standards/ci.md.
+
+Environment:
+    MOTHERSHIP_URL   base URL, e.g. https://mothership.atlan.dev
+    HARNESS_TOKEN    bearer token for the sandbox API
+    SESSION_ID       session to stop, from the workflow's `session` step
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import urllib.error
+import urllib.request
+from typing import Callable
+
+TIMEOUT_SECONDS = 30
+BODY_PREVIEW_CHARS = 500
+
+# A urllib-shaped callable: (url, token) -> (status_code, body_text).
+Requester = Callable[[str, str], "tuple[int, str]"]
+
+
+def _default_requester(url: str, token: str) -> tuple[int, str]:
+    """DELETE `url` with a bearer token, returning (status, body).
+
+    Maps every failure mode onto a status code so callers never branch on
+    exception type: an HTTP error keeps its real code, and a transport
+    failure (DNS, VPN down, timeout) reports 0.
+    """
+    req = urllib.request.Request(url, method="DELETE")
+    req.add_header("Authorization", f"Bearer {token}")
+    try:
+        with urllib.request.urlopen(req, timeout=TIMEOUT_SECONDS) as resp:
+            return resp.status, resp.read().decode("utf-8", "replace")
+    except urllib.error.HTTPError as e:
+        return e.code, e.read().decode("utf-8", "replace")
+    except Exception as e:  # transport-level: DNS, VPN down, timeout
+        return 0, str(e)
+
+
+def terminate(
+    base_url: str,
+    token: str,
+    session_id: str,
+    requester: Requester | None = None,
+) -> str:
+    """Ask mothership to stop `session_id`; return a human-readable outcome.
+
+    Never raises: this is teardown. The returned string is what the caller
+    prints, and any annotation is emitted here.
+
+    `requester` is resolved at call time rather than bound as a default
+    argument so tests can substitute the module attribute and never reach
+    the network.
+    """
+    send = requester or _default_requester
+    url = f"{base_url.rstrip('/')}/api/sandbox/session/{session_id}?destroy=true"
+    status, body = send(url, token)
+
+    preview = body[:BODY_PREVIEW_CHARS].strip()
+    if preview:
+        print(preview)
+
+    if 200 <= status < 300:
+        return f"Sandbox termination requested for {session_id} (HTTP {status})."
+    if status == 404:
+        print(
+            f"::notice::Session {session_id} is unknown to mothership — "
+            "it already finished or never started."
+        )
+        return f"Nothing to stop for {session_id} (HTTP 404)."
+    print(
+        f"::warning::Could not stop sandbox {session_id} (HTTP {status}). "
+        "It may keep running and still post a review to this PR."
+    )
+    return f"Termination request failed for {session_id} (HTTP {status})."
+
+
+def main(argv: list[str] | None = None) -> int:
+    base_url = os.environ.get("MOTHERSHIP_URL", "").strip()
+    token = os.environ.get("HARNESS_TOKEN", "").strip()
+    session_id = os.environ.get("SESSION_ID", "").strip()
+
+    # Missing config is not a failure worth surfacing during teardown — the
+    # workflow gates this step on session_id already, and a token/URL gap is
+    # loud everywhere else in the job.
+    if not session_id:
+        print("::notice::No SESSION_ID — nothing to terminate.")
+        return 0
+    if not base_url or not token:
+        print(
+            "::warning::MOTHERSHIP_URL or HARNESS_TOKEN unset — cannot stop the sandbox."
+        )
+        return 0
+
+    print(f"Job cancelled — asking mothership to stop session {session_id}.")
+    print(terminate(base_url, token, session_id))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/tests/test_mothership_terminate_session.py
+++ b/.github/scripts/tests/test_mothership_terminate_session.py
@@ -1,0 +1,111 @@
+"""Tests for .github/scripts/mothership_terminate_session.py."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import mothership_terminate_session as mts
+
+SESSION = "sdk-review-atlanhq-application-sdk-1234-deadbeef"
+
+
+def _requester(status: int, body: str = ""):
+    """Build a requester that records the URL it was called with."""
+    calls: list[tuple[str, str]] = []
+
+    def request(url: str, token: str) -> tuple[int, str]:
+        calls.append((url, token))
+        return status, body
+
+    request.calls = calls  # type: ignore[attr-defined]
+    return request
+
+
+def test_builds_destroy_url_with_bearer_token():
+    req = _requester(200, "{}")
+    mts.terminate("https://mothership.example.dev", "tok", SESSION, req)
+    url, token = req.calls[0]  # type: ignore[attr-defined]
+    assert url == (
+        f"https://mothership.example.dev/api/sandbox/session/{SESSION}?destroy=true"
+    )
+    assert token == "tok"
+
+
+def test_trailing_slash_on_base_url_does_not_double_up():
+    req = _requester(200)
+    mts.terminate("https://mothership.example.dev/", "tok", SESSION, req)
+    url, _ = req.calls[0]  # type: ignore[attr-defined]
+    assert "//api/sandbox" not in url
+
+
+@pytest.mark.parametrize("status", [200, 202, 204])
+def test_success_statuses_report_termination(status, capsys):
+    out = mts.terminate("https://m.example.dev", "tok", SESSION, _requester(status))
+    assert "termination requested" in out.lower()
+    assert "::warning::" not in capsys.readouterr().out
+
+
+def test_404_is_a_notice_not_a_warning(capsys):
+    """An already-finished session is the expected race, not a problem."""
+    out = mts.terminate("https://m.example.dev", "tok", SESSION, _requester(404))
+    captured = capsys.readouterr().out
+    assert "::notice::" in captured
+    assert "::warning::" not in captured
+    assert "404" in out
+
+
+@pytest.mark.parametrize("status", [0, 401, 403, 500, 502])
+def test_failure_statuses_warn_that_the_sandbox_may_still_run(status, capsys):
+    out = mts.terminate("https://m.example.dev", "tok", SESSION, _requester(status))
+    captured = capsys.readouterr().out
+    assert "::warning::" in captured
+    assert "may keep running" in captured
+    assert "failed" in out.lower()
+
+
+def test_body_preview_is_bounded(capsys):
+    req = _requester(500, "x" * 5000)
+    mts.terminate("https://m.example.dev", "tok", SESSION, req)
+    printed = capsys.readouterr().out
+    assert "x" * mts.BODY_PREVIEW_CHARS in printed
+    assert "x" * (mts.BODY_PREVIEW_CHARS + 1) not in printed
+
+
+def test_terminate_never_raises_on_transport_failure():
+    """The default requester maps transport errors to status 0, not an exception."""
+
+    def boom(url: str, token: str) -> tuple[int, str]:
+        return 0, "VPN down"
+
+    assert mts.terminate("https://m.example.dev", "tok", SESSION, boom)
+
+
+def test_main_is_a_noop_without_session_id(monkeypatch, capsys):
+    monkeypatch.delenv("SESSION_ID", raising=False)
+    monkeypatch.setenv("MOTHERSHIP_URL", "https://m.example.dev")
+    monkeypatch.setenv("HARNESS_TOKEN", "tok")
+    assert mts.main() == 0
+    assert "::notice::" in capsys.readouterr().out
+
+
+def test_main_warns_but_succeeds_without_config(monkeypatch, capsys):
+    monkeypatch.setenv("SESSION_ID", SESSION)
+    monkeypatch.setenv("MOTHERSHIP_URL", "")
+    monkeypatch.setenv("HARNESS_TOKEN", "")
+    assert mts.main() == 0
+    assert "::warning::" in capsys.readouterr().out
+
+
+def test_main_always_exits_zero_even_when_termination_fails(monkeypatch, capsys):
+    """Teardown must never mask the job's real cancelled/failed outcome."""
+    monkeypatch.setenv("SESSION_ID", SESSION)
+    monkeypatch.setenv("MOTHERSHIP_URL", "https://m.example.dev")
+    monkeypatch.setenv("HARNESS_TOKEN", "tok")
+    monkeypatch.setattr(mts, "_default_requester", lambda url, token: (500, "boom"))
+    assert mts.main() == 0
+    assert "::warning::" in capsys.readouterr().out

--- a/.github/workflows/sdk-review.yml
+++ b/.github/workflows/sdk-review.yml
@@ -180,6 +180,27 @@ jobs:
             core.setOutput('base_ref', pr.base.ref);
             core.setOutput('html_url', pr.html_url);
 
+      # Single source of truth for the mothership session id.
+      #
+      # Two steps need it: the dispatch below, and the `if: cancelled()`
+      # terminator at the end of the job. Deriving it in both places would
+      # let the two copies drift — and a terminator that computes a *stale*
+      # session id silently fails to stop anything, which is exactly the
+      # bug it exists to prevent. Compute once, read twice.
+      #
+      # Deterministic on the PR head: a new commit produces a new HEAD_SHA
+      # → fresh sandbox; a re-trigger on the same HEAD resumes the same
+      # session (mothership serialises those on a per-session lock).
+      - name: Compute mothership session id
+        id: session
+        env:
+          PR_NUMBER: ${{ steps.parse.outputs.pr_number }}
+          HEAD_SHA_SHORT: ${{ steps.pr.outputs.head_sha_short }}
+          REPO_FULL_NAME: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          echo "session_id=sdk-review-${REPO_FULL_NAME//\//-}-${PR_NUMBER}-${HEAD_SHA_SHORT}" >> "$GITHUB_OUTPUT"
+
       - name: Post 'review starting' notice to PR
         id: starter
         env:
@@ -390,6 +411,7 @@ jobs:
           BASE_REF: ${{ steps.pr.outputs.base_ref }}
           PR_URL: ${{ steps.pr.outputs.html_url }}
           REPO_FULL_NAME: ${{ github.repository }}
+          SESSION_ID: ${{ steps.session.outputs.session_id }}
           GHA_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
@@ -450,10 +472,9 @@ jobs:
           PROMPT_END
           )
 
-          # Deterministic session_id ties this dispatch to the PR head.
-          # A new commit produces a new HEAD_SHA → fresh sandbox.
-          # A re-trigger on the same HEAD resumes the same sandbox session.
-          SESSION_ID="sdk-review-${REPO_FULL_NAME//\//-}-${PR_NUMBER}-${HEAD_SHA_SHORT}"
+          # Computed once by the `session` step so the `if: cancelled()`
+          # terminator addresses the exact same session (see that step).
+          SESSION_ID="${SESSION_ID:?session id not set by the session step}"
 
           # Build the dispatch payload.
           PAYLOAD=$(jq -n \
@@ -521,12 +542,20 @@ jobs:
           SESSION_FROM_STREAM=""
           SANDBOX_FROM_STREAM=""
 
-          # Heartbeat: track time since last `action` event. Mothership
-          # emits a `:` SSE comment every ~15s of silence which causes
-          # `read` to return — so we get a chance to check the idle
-          # threshold without spawning a watchdog. If we go > 5 min
-          # without an action, emit a single `::warning::` annotation
-          # so a stalled sandbox is visible on the workflow run page.
+          # Heartbeat: track time since the last content-bearing event.
+          # Mothership emits a `:` SSE comment every ~15s of silence which
+          # causes `read` to return — so we get a chance to check the idle
+          # threshold without spawning a watchdog. If we go > 5 min without
+          # progress, emit a `::warning::` annotation so a stalled sandbox
+          # is visible on the workflow run page.
+          #
+          # This used to key off `action` events only. In `mode: "direct"`
+          # an `action` event does not exist (see the `response` handler
+          # below), so the watchdog fired a guaranteed false positive at
+          # t+5min in EVERY run — including healthy ones — latched
+          # IDLE_WARNED=1, and was then disarmed for the rest of the run.
+          # The one signal meant to catch a real stall could never report
+          # one. Every content-bearing event now re-arms it.
           LOOP_START_TS=$(date +%s)
           LAST_ACTION_TS=$LOOP_START_TS
           LAST_ACTION_NAME="(none yet)"
@@ -590,7 +619,54 @@ jobs:
                     :
                     ;;
                   response)
-                    echo "[response]  (agent posted a response)"
+                    # `response` is the ONLY progress event this path ever
+                    # sees. In mode="direct" mothership's sandbox provider
+                    # hands the raw Claude CLI stream-json line to its
+                    # `on_event` with the raw type (system|assistant|result|
+                    # done|stderr), and the API layer remaps
+                    # {assistant,result,done} -> "response" verbatim. Tool
+                    # calls therefore never surface as `action` events —
+                    # they are buried in .content.message.content[] as
+                    # blocks with type "tool_use", and `action_name` is
+                    # always null on this path.
+                    #
+                    # So we unwrap it ourselves. This turns an hour of
+                    # byte-identical "(agent posted a response)" lines into
+                    # an actual trace of what the sandbox is doing, with no
+                    # mothership-side change required.
+                    #
+                    # `fromjson?` swallows payloads that are not JSON (e.g.
+                    # a stderr passthrough) and yields empty rather than
+                    # failing the pipeline under `set -e`.
+                    TOOLS=$(printf '%s' "$DATA" | jq -r '
+                      (.content // "") | (fromjson? // {})
+                      | [ (.message.content // [])[]
+                          | select(.type == "tool_use") | .name ]
+                      | join(", ")' 2>/dev/null) || TOOLS=""
+                    if [ -n "$TOOLS" ]; then
+                      echo "[action]    ${TOOLS}"
+                      LAST_ACTION_NAME="$TOOLS"
+                    else
+                      # Assistant text blocks, falling back to `.result`
+                      # (the terminal `result` message carries the final
+                      # output there rather than under .message.content).
+                      TEXT=$(printf '%s' "$DATA" | jq -r '
+                        (.content // "") | (fromjson? // {})
+                        | ([ (.message.content // [])[]
+                             | select(.type == "text") | .text ] | join(" ")) as $t
+                        | (if ($t | length) > 0 then $t else (.result // "") end)
+                        | tostring | gsub("\\s+"; " ") | .[0:160]' 2>/dev/null) || TEXT=""
+                      if [ -n "$TEXT" ]; then
+                        echo "[response]  ${TEXT}"
+                      else
+                        echo "[response]  (agent posted a response)"
+                      fi
+                      LAST_ACTION_NAME="response"
+                    fi
+                    # Any response is proof of life — re-arm the watchdog so
+                    # a LATER genuine stall is still reportable.
+                    LAST_ACTION_TS=$NOW_TS
+                    IDLE_WARNED=0
                     ;;
                   elicitation)
                     echo "[elicit]    sandbox requested user input — treating as error"
@@ -628,6 +704,17 @@ jobs:
                     # body from nginx. Print first 200 chars and move on; the
                     # post-loop check will fail if we never get a real event.
                     echo "[raw]       ${DATA:0:200}"
+                    ;;
+                  *)
+                    # Unhandled event name. mothership forwards `system` and
+                    # `stderr` unmapped, and can add types later; the case
+                    # had no fallback, so those were dropped on the floor
+                    # with no trace. Print a bounded preview and count it as
+                    # proof of life.
+                    echo "[${EVENT}]  ${DATA:0:200}"
+                    LAST_ACTION_TS=$NOW_TS
+                    LAST_ACTION_NAME="$EVENT"
+                    IDLE_WARNED=0
                     ;;
                 esac
                 ;;
@@ -749,6 +836,34 @@ jobs:
 
           echo "SDK Review (mothership) completed successfully (cost=${FINAL_COST})."
 
+      # Cancelling this job does NOT stop the sandbox.
+      #
+      # mothership runs the sandbox on a thread-pool executor with a
+      # DETACHED asyncio finalize task (harness/api/routers/sandbox_api.py
+      # `_sse_execution_wrapper`), and its SSE queue drops on overflow
+      # rather than applying backpressure. Killing `curl` therefore only
+      # closes our end of the stream: the run keeps going, keeps billing
+      # against max_timeout_seconds (7200), and still posts its review and
+      # commit status to the PR using the sandbox's own `gh` token —
+      # minutes after the workflow says "cancelled". That is why a cancel
+      # looked like it "triggered" a review: it never stopped anything.
+      #
+      # The documented way to actually stop it is the explicit cancel
+      # endpoint, so call it on the way out.
+      #
+      # `if: cancelled()` only — a failed dispatch has already lost the
+      # stream and mothership finalises it on its own; on success there is
+      # nothing left to stop. Never fail the job from here: this is
+      # best-effort cleanup running inside the cancellation grace period,
+      # and masking the real outcome with a teardown error helps nobody.
+      - name: Terminate mothership sandbox on cancel
+        if: cancelled() && steps.session.outputs.session_id != ''
+        env:
+          MOTHERSHIP_URL: ${{ vars.MOTHERSHIP_URL }}
+          HARNESS_TOKEN: ${{ secrets.HARNESS_TOKEN }}
+          SESSION_ID: ${{ steps.session.outputs.session_id }}
+        run: python3 .github/scripts/mothership_terminate_session.py
+
       # Stamp the run cost + duration + verdict status onto the starter
       # comment we posted at the start of this job. The PR scroll then
       # shows a single comment that opens with "🔍 triggered" and ends
@@ -789,9 +904,22 @@ jobs:
               }
             }
 
+            // A cancel is not a failure, and rendering it as 🟥 "ended
+            // without a clean completion" was actively misleading: this
+            // step is `always()`, so it rewrote the comment ~2s after the
+            // cancel while the sandbox was still running — and the real
+            // review then landed a minute later, making the 🟥 look like a
+            // lie. Give cancels their own verb and say what we did about
+            // the sandbox.
+            const cancelled = process.env.DISPATCH_OUTCOME === 'cancelled';
             const verb = finalStatus === 'completed' ? '✅ **Completed**' :
-                         (process.env.DISPATCH_OUTCOME === 'success' ? '✅ **Completed**' : '🟥 **Run ended without a clean completion**');
+                         process.env.DISPATCH_OUTCOME === 'success' ? '✅ **Completed**' :
+                         cancelled ? '🟡 **Cancelled**' :
+                         '🟥 **Run ended without a clean completion**';
             let footer = `\n\n---\n${verb} — status \`${finalStatus}\`, cost \`$${finalCost}\`, duration ${durationTxt}.`;
+            if (cancelled) {
+              footer += `\nThe sandbox was asked to stop (\`DELETE /api/sandbox/session\`). If that request did not land, a review comment may still arrive from the in-flight run — check the workflow log for a termination warning.`;
+            }
 
             // Surface the mothership-side error on the PR comment whenever
             // we have either a code or a message. This is the field most


### PR DESCRIPTION
## Why

An `@sdk-review` run ([30611673165](https://github.com/atlanhq/application-sdk/actions/runs/30611673165)) logged ~60 minutes of byte-identical `[response]  (agent posted a response)` lines, then a review comment appeared shortly after the job was cancelled — which read as if the cancel had flushed it.

It hadn't. Three separate defects, and the cancel wasn't the cause of any of them.

## What was wrong

**1. `action` events are unreachable in `mode: "direct"`.** mothership's sandbox provider passes the raw Claude CLI stream-json line to `on_event` with the raw type (`system|assistant|result|done|stderr`), and the API layer remaps `{assistant,result,done}` → `response` verbatim. Tool calls sit inside `.content.message.content[]` as `"tool_use"` blocks and `action_name` is always null on this path. Measured **0 action events against 326 responses**.

**2. The idle watchdog could never report a real stall.** `LAST_ACTION_TS` / `IDLE_WARNED` were reset only by `started` and `action`. Since `action` can never arrive, it fired a guaranteed false `Sandbox idle for ~300s (last action: started)` at t+5min in *every* run — the healthy 50-minute comparison run has the same warning — then latched `IDLE_WARNED=1` and stayed disarmed for the rest of the run.

**3. Cancelling the job stops nothing.** mothership runs the sandbox on a thread-pool executor with a detached finalize task, and its SSE queue drops on overflow rather than applying backpressure — so killing `curl` only closes our end. The run keeps going, keeps billing against `max_timeout_seconds`, and still posts its review and commit status from inside the sandbox (the recovered commit status on that run has `creator = mothership-ai[bot]`, not `github-actions[bot]`). What actually appeared "the moment I cancelled" was the `always()` stamper rewriting the starter comment to 🟥 **two seconds** after the cancel — while the sandbox was still running and the real review was 75s away.

## What this changes

- **`response` handler unwraps the payload mothership was already sending** and prints the tool names, falling back to a text / `.result` preview. No mothership-side change needed. Added a `*)` fallback so the `system` and `stderr` events forwarded unmapped stop vanishing silently.
- **Watchdog re-arms on any content-bearing event**, so a later genuine stall is still reportable.
- **`if: cancelled()` step calls `DELETE /api/sandbox/session/{id}?destroy=true`** — the documented cancel path. The session id moves into a single `session` step so the dispatcher and the terminator can never address different sessions.
- **The stamper renders a cancel as its own outcome** instead of a red "ended without a clean completion" written while the sandbox is still alive.

Termination logic lives in a tested script per `docs/standards/ci.md`.

## Verification

The parser loop was extracted from the YAML and driven against synthetic SSE streams, so these are the real code path, not a re-implementation:

```
[action]    Bash, Grep          ← was "[response]  (agent posted a response)"
[response]  Reading the diff now
[system]    {"subtype":"init"}  ← previously dropped on the floor
```

| Case | Before | After |
|---|---|---|
| 20 min of steady tool activity | 1 false idle warning, guaranteed | **0 warnings** |
| Real stall after a `Bash` action | unreportable (latched) | warns at 300s, `last action: Bash` |

- actionlint clean; YAML + `bash -n` on every `run:` block
- 855/855 `.github/scripts/tests` pass (16 new)
- pre-commit + pyright pass
- Session id verified byte-identical to the one the failing run produced

## Not covered

- The `DELETE` call is unit-tested only — it needs VPN + `HARNESS_TOKEN`, so its first real exercise is the next cancel. It never fails the job and warns loudly if the request doesn't land.
- **Runs take 50–60 min against ORCHESTRATION's own 15–35 min hard stop, at ~$48/run.** Nothing here explains that and nothing enforces the budget — it's prose in the prompt. With the log no longer blind, the next run should show where the time goes. Tracked in BLDX-1604 along with the optional mothership-side fixes (emit real `action` events; give `thought`/`action` their own debounce clock; correct the event table in `rover-direct-api.md`).

Refs BLDX-1604

🤖 Generated with [Claude Code](https://claude.com/claude-code)