### PR TITLE
ci(sdk-review): enforce the reviewer's time budget with an actual clock

### DIFF
--- a/.github/workflows/sdk-review.yml
+++ b/.github/workflows/sdk-review.yml
@@ -709,9 +709,27 @@ jobs:
                     # Unhandled event name. mothership forwards `system` and
                     # `stderr` unmapped, and can add types later; the case
                     # had no fallback, so those were dropped on the floor
-                    # with no trace. Print a bounded preview and count it as
-                    # proof of life.
-                    echo "[${EVENT}]  ${DATA:0:200}"
+                    # with no trace.
+                    #
+                    # `system` dominates the log in practice (sub-agent
+                    # task_started / task_progress / task_notification), and
+                    # the raw frame is a JSON string nested inside .content.
+                    # Render "<subtype>: <description>" when we can and fall
+                    # back to a bounded raw preview otherwise.
+                    SYS=$(printf '%s' "$DATA" | jq -r '
+                      (.content // "") as $c
+                      | ($c | fromjson? // null) as $j
+                      | (if $j == null then $c
+                         else (($j.subtype // $j.type // "")
+                               + (if ($j.description // "") != ""
+                                  then ": " + ($j.description | tostring) else "" end))
+                         end)
+                      | gsub("\\s+"; " ") | .[0:140]' 2>/dev/null) || SYS=""
+                    if [ -n "$SYS" ]; then
+                      echo "[${EVENT}]     ${SYS}"
+                    else
+                      echo "[${EVENT}]     ${DATA:0:200}"
+                    fi
                     LAST_ACTION_TS=$NOW_TS
                     LAST_ACTION_NAME="$EVENT"
                     IDLE_WARNED=0

--- a/.mothership/pr-review/ORCHESTRATION.md
+++ b/.mothership/pr-review/ORCHESTRATION.md
@@ -1,7 +1,8 @@
 # SDK Review — Orchestration Playbook
 
 Follow these phases EXACTLY. Do not skip phases. Do not reorder.
-Print `[Phase N complete]` after each phase.
+Print `[Phase N complete]` after each phase, followed by `bash /tmp/budget.sh`
+(see Time Budgets — the elapsed number is measured, never estimated).
 
 ## Time Budgets
 
@@ -26,6 +27,30 @@ If the sandbox has been running past the hard stop, finalize immediately
 with whatever findings you have. Post the review summary + commit
 status — never exit without posting to the PR.
 
+### Measuring the budget (MANDATORY — these numbers are not decorative)
+
+You cannot feel elapsed wall-clock time. Every budget rule below — the
+degradation priority in §2a, the "over 70% consumed" skip in §2b, and the
+hard stop above — is a condition you MUST measure, not estimate. Until
+this section existed there was no clock anywhere in this playbook, so
+those rules were unevaluable and never fired: a Small-tier PR (15 min
+hard stop) ran **62 minutes** because nothing told the agent it was over.
+
+Phase 0 stamps the start time and writes `/tmp/budget.sh`. Run it at
+**every phase boundary** and immediately before §2b:
+
+```bash
+bash /tmp/budget.sh
+# [budget] elapsed 8m 12s / hard stop 15m (54%) — OK
+# [budget] elapsed 11m 40s / hard stop 15m (77%) — OVER 70%: skip adversarial Wave 2
+# [budget] elapsed 16m 02s / hard stop 15m (106%) — OVER HARD STOP: finalize now
+```
+
+Act on what it prints. `OVER 70%` and `OVER HARD STOP` are instructions,
+not warnings. If `/tmp/budget.sh` is missing (a resumed session that
+skipped Phase 0), recreate it with the Phase 0 step 1b snippet before
+continuing — never proceed with an unmeasured budget.
+
 ---
 
 ## Phase 0: Orient (~30s)
@@ -46,6 +71,33 @@ COMMENTER, COMMENT_ID, COMMENTER_INTENT
    # Background: install deps so uv run pre-commit/pytest don't wait
    uv sync --all-extras 2>/dev/null &
    ```
+
+1b. **Start the budget clock** — do this before any other work, so the
+    elapsed number covers the whole run. Defaults to the Small hard stop;
+    step 12 raises it once the tier is known.
+
+Run this block **exactly as written, unindented**. The heredoc terminator
+must sit at column 0 or `cat` never closes it and the shell hangs waiting
+for input:
+
+```bash
+date +%s > /tmp/REVIEW_START_TS
+echo 900 > /tmp/REVIEW_HARD_STOP_S   # 15 min, Small tier default
+
+cat > /tmp/budget.sh <<'BUDGET'
+START=$(cat /tmp/REVIEW_START_TS 2>/dev/null || echo 0)
+CAP=$(cat /tmp/REVIEW_HARD_STOP_S 2>/dev/null || echo 900)
+[ "$START" -gt 0 ] || { echo "[budget] no start stamp — rerun Phase 0 step 1b"; exit 0; }
+E=$(( $(date +%s) - START ))
+PCT=$(( E * 100 / CAP ))
+if   [ "$PCT" -ge 100 ]; then VERDICT="OVER HARD STOP: finalize now"
+elif [ "$PCT" -ge 70 ];  then VERDICT="OVER 70%: skip adversarial Wave 2"
+else                          VERDICT="OK"
+fi
+printf '[budget] elapsed %dm %02ds / hard stop %dm (%d%%) — %s\n' \
+  "$((E/60))" "$((E%60))" "$((CAP/60))" "$PCT" "$VERDICT"
+BUDGET
+```
 
 2. **Auth setup** — `$GITHUB_TOKEN` is injected by mothership from its
    GitHub App installation (see snapshots/_base). Make `gh` use it:
@@ -271,12 +323,14 @@ COMMENTER, COMMENT_ID, COMMENTER_INTENT
      to `full`.)
    - Otherwise → `review_scope=full` (correctness + quality + structure)
 
-12. Check diff size for tier:
-    - < 2000 lines → `review_tier = "full"`
-    - 2000-20000 → `review_tier = "partitioned"`
-    - > 20000 → `review_tier = "staged"`
+12. Check diff size for tier, and raise the budget cap to match it
+    (step 1b defaulted to the Small hard stop):
+    - < 2000 lines → `review_tier = "full"` → `echo 900 > /tmp/REVIEW_HARD_STOP_S`
+    - 2000-20000 → `review_tier = "partitioned"` → `echo 1500 > /tmp/REVIEW_HARD_STOP_S`
+    - > 20000 → `review_tier = "staged"` → `echo 2100 > /tmp/REVIEW_HARD_STOP_S`
 
-Print: `[Phase 0 complete] PR #<N>, scope=<scope>, tier=<tier>`
+Print: `[Phase 0 complete] PR #<N>, scope=<scope>, tier=<tier>` followed by
+`bash /tmp/budget.sh`
 
 ---
 
@@ -609,6 +663,7 @@ If despite all truncation the context STILL exceeds limits:
 **A truncated review is always better than a failed review.**
 
 Print: `[Phase 1 complete] <N> files assessed, tier=<tier>, <M> files truncated`
+then `bash /tmp/budget.sh` — act on its verdict before entering Phase 2.
 
 ---
 
@@ -658,10 +713,17 @@ For `toolkit-review.md`, also pass `contract-toolkit/AGENTS.md`,
 present. The toolkit agent must not include private consumer repo names, paths,
 or SHAs in public findings.
 
-**Degradation priority** (if running over time budget):
-1. Drop STRUCTURE agent first (holistic opinions, least urgent)
-2. Drop QUALITY agent second (code patterns, pre-commit catches most)
-3. CORRECTNESS is ALWAYS kept (catches guardrail violations G1-G5)
+**Degradation priority** — run `bash /tmp/budget.sh` BEFORE dispatching
+Wave 1 and drop agents by the measured percentage, not by feel:
+
+| Measured | Action |
+|---|---|
+| < 70% | Dispatch all agents for the scope |
+| ≥ 70% | Drop STRUCTURE (holistic opinions, least urgent) |
+| ≥ 85% | Also drop QUALITY (code patterns; pre-commit catches most) |
+| ≥ 100% | CORRECTNESS only, then go straight to Phase 3 |
+
+CORRECTNESS is ALWAYS kept — it carries guardrail coverage G1-G5.
 
 Parse JSON findings from each agent response.
 
@@ -674,7 +736,11 @@ After Wave 1, call GPT to challenge your findings.
 - `review_scope` is contract-toolkit and toolkit-review.md produced zero findings
 - `review_tier` is "staged" (massive PR — too much context for one GPT call)
 - Wave 1 produced zero findings (nothing to challenge)
-- Time budget already over 70% consumed
+- Time budget already over 70% consumed — run `bash /tmp/budget.sh` here
+  and skip whenever it prints `OVER 70%` or `OVER HARD STOP`. This is the
+  single most expensive optional step in the run (a full GPT-5.3-codex
+  call over the whole diff plus every Wave 1 finding), so it is the first
+  thing an over-budget run must give up.
 
 If not skipped:
 
@@ -878,6 +944,7 @@ monotonicity, actionability) — they keep the write-side resolver's
 `### Findings`-empty loop terminating.
 
 Print: `[Phase 2 complete] <N> findings across <C> classes, verdict=<verdict>`
+then `bash /tmp/budget.sh`.
 
 ---
 


### PR DESCRIPTION
Follow-up to #2953. That PR made the run *observable*; this one makes it *bounded*.

## The problem

`ORCHESTRATION.md` has always carried per-tier budgets and told the agent to degrade when over them:

- `**Degradation priority** (if running over time budget):`
- `- Time budget already over 70% consumed`

**Nothing in the playbook measured elapsed time.** No start stamp, no `date +%s`, nothing anywhere in 1000+ lines. Both rules asked the agent to evaluate a condition it had no way to observe, so neither ever fired.

PR #2951 is 1,331 lines → **Small tier: ~10 min budget, 15 min hard stop**. [Run 30611673165](https://github.com/atlanhq/application-sdk/actions/runs/30611673165) took **62 minutes** and still ran the full Wave 1 fan-out plus the GPT-5.3-codex adversarial pass. The healthy comparison run was 50m 36s at **$47.93**. Every run, 2–4× its own stated ceiling.

## The fix

Phase 0 step 1b stamps `/tmp/REVIEW_START_TS` and writes `/tmp/budget.sh`:

```
[budget] elapsed 8m 12s / hard stop 15m (54%) — OK
[budget] elapsed 11m 40s / hard stop 15m (77%) — OVER 70%: skip adversarial Wave 2
[budget] elapsed 16m 02s / hard stop 15m (106%) — OVER HARD STOP: finalize now
```

Step 12 raises the cap once the tier is known (900 / 1500 / 2100s). Every phase boundary and the §2b adversarial gate run it and act on the verdict.

The two prose rules are rewritten against the measured number:

- **§2a** degrades by band — ≥70% drop STRUCTURE, ≥85% also drop QUALITY, ≥100% CORRECTNESS only (G1–G5 coverage is never dropped).
- **§2b** skips the adversarial wave on `OVER 70%`. It's a full GPT-5.3-codex call over the whole diff plus every Wave 1 finding — the most expensive optional step in the run, so it's the first thing an over-budget run gives up.

The step 1b block is deliberately unindented: the heredoc terminator must sit at column 0 or `cat` never closes and the shell blocks on stdin. I got that wrong first and caught it before committing.

## Also: compact `system` events

With #2953 live I could finally read a real run — and `[system]` frames turned out to be the dominant line, dumped as raw nested JSON. Now rendered as `subtype: description`:

```
[system]     task_started: cd /tmp/toolkit-review-consumers/… && uv run pytest -q
[system]     task_notification
[stderr]     warning: something on stderr     ← plain .content, not the JSON wrapper
```

## Verification

The budget block was extracted from `ORCHESTRATION.md` and executed as written (not as intended):

| Scenario | Output |
|---|---|
| t=0, Small | `0m 03s / 15m (0%) — OK` |
| 11 min, Small | `11m 01s / 15m (73%) — OVER 70%: skip adversarial Wave 2` |
| **62 min, Small (the real run)** | **`62m 02s / 15m (413%) — OVER HARD STOP: finalize now`** |
| 62 min, Massive | `62m 03s / 35m (177%) — OVER HARD STOP` |
| missing stamp | `no start stamp — rerun Phase 0 step 1b` |

Log rendering verified by replaying fixtures through the parser loop extracted from the YAML. actionlint + pre-commit clean.

## Rollout note

`sdk-review.yml` runs from the **default branch** (`issue_comment` always does), so the log changes take effect immediately on merge. `ORCHESTRATION.md` is read from the **PR head ref** inside the sandbox — so the budget clock only applies to a PR once its branch contains this commit. Existing open PRs need a rebase onto main to get it.

Refs BLDX-1604

🤖 Generated with [Claude Code](https://claude.com/claude-code)