### PR TITLE
fix(conformance): mirror Input.app_name in SDK contract base registry

### DIFF
--- a/packages/conformance/conformance/suite/checks/_sdk_contract_mixins.py
+++ b/packages/conformance/conformance/suite/checks/_sdk_contract_mixins.py
@@ -36,6 +36,7 @@ SDK_CONTRACT_BASE_FIELDS: dict[str, tuple[SdkField, ...]] = {
     "Input": (
         SdkField("workflow_id", "str", "active"),
         SdkField("correlation_id", "str", "active"),
+        SdkField("app_name", "str", "active"),
     ),
     "Output": (
         SdkField("status", "OutputStatus", "active"),

--- a/packages/conformance/uv.lock
+++ b/packages/conformance/uv.lock
@@ -189,7 +189,7 @@ wheels = [
 
 [[package]]
 name = "atlan-application-sdk"
-version = "3.25.0"
+version = "3.25.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -212,9 +212,9 @@ dependencies = [
     { name = "temporalio" },
     { name = "uvloop", marker = "sys_platform != 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e8/5b/f5d6bcf59494a4e93273104dd77e073e9433d1b6abafdda7d74a276641fa/atlan_application_sdk-3.25.0.tar.gz", hash = "sha256:c4ff66078321650638ec0b8909e72366eb6574b9be0170d26ee2473e0e44ce68", size = 4669518, upload-time = "2026-07-29T17:17:31.881Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/11/43f32932c984c158cfa61dc7399534c2b71b613d31727b1ddabb771a3270/atlan_application_sdk-3.25.1.tar.gz", hash = "sha256:b2be83fe22f60915efe1dd20891ebcd360d679c89c668b8a7a3783e91c3e7dea", size = 4715892, upload-time = "2026-07-31T13:32:48.273Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5c/3e/11f099280e6ba4cbda0c021afbd2b9ad3e2225e3c56ea9e0419a39ee282c/atlan_application_sdk-3.25.0-py3-none-any.whl", hash = "sha256:258b494526234643ca2990bb2e3c93b6c3123a75582d1b65bdeaabc4812d759b", size = 1019472, upload-time = "2026-07-29T17:17:29.831Z" },
+    { url = "https://files.pythonhosted.org/packages/82/53/bd5b3405deab4321e3b6f26a6ee65ba88035fcc60415b13bee4e2d5a1f4d/atlan_application_sdk-3.25.1-py3-none-any.whl", hash = "sha256:5f13870bb1c416a9846188ec6c7e083f07b94b39564d138d5fab1618de5b62fb", size = 1022750, upload-time = "2026-07-31T13:32:46.577Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

`packages/conformance` hand-mirrors the fields of `application_sdk.contracts.base.Input` / `Output` / `PublishInputMixin` in `SDK_CONTRACT_BASE_FIELDS`, because those base classes live outside the scanned tree when a checker (or the ledger generator) runs against a consumer app. `resolve_contract_fields` falls back to that registry to resolve SDK-inherited fields.

#2951 added `app_name: str` to `Input` and it shipped in **v3.25.1**, but the registry was never updated alongside it.

The drift guard `test_registry_matches_live_sdk_source` only compares the registry against the `atlan-application-sdk` version **pinned in `packages/conformance/uv.lock`** — still `3.25.0`, which has no `app_name`. So the drift stayed latent on `main` and only surfaced when renovate's lock-file maintenance (#2961) bumped that pin to `3.25.1`:

```
application_sdk.contracts.base.Input drifted from the static registry in
_sdk_contract_mixins.py — update SDK_CONTRACT_BASE_FIELDS to match.
live={'workflow_id': ('str','active'), 'correlation_id': ('str','active'), 'app_name': ('str','active')}
registry={'workflow_id': ('str','active'), 'correlation_id': ('str','active')}
```

That failure also fails `SDK Gate` (`CONFORMANCE_PKG_RESULT: failure`), blocking #2961.

## Fix

Two changes that **must land together**:

- `_sdk_contract_mixins.py` — add `SdkField("app_name", "str", "active")` to `Input`, in declaration order after `correlation_id`.
- `packages/conformance/uv.lock` — move the `atlan-application-sdk` pin `3.25.0` → `3.25.1`.

> **Maintenance invariant:** the registry mirrors whatever version the conformance lock pins. Editing one without the other fails the drift guard in one direction or the other — adding `app_name` alone would have broken `main`, since `3.25.0` genuinely lacks the field. Keep the pin and the registry in the same commit.

No remediation wiring: this is a data table consumed by `_entrypoint_contract_fields`, not a rule, tier, or scope change.

## Verification

- Full conformance suite: **2071 passed, 0 failed, 1 xfailed** — reconciles exactly with CI's `2070 passed, 1 failed` on #2961.
- Repo-root `uv run pre-commit run --all-files`: **all 10 hooks pass** (pinned-version gate).
- Blast radius: `conformance/data/contract_schema.lock.json` already carries `app_name`, so `test_toolkit_baseline_drift` needed no change.

## Follow-up (not in this PR)

The guard reads the *pinned PyPI* SDK, so every future release touching `contracts/base.py` reproduces this on the next renovate lock PR. The durable fix is to have the test read the repo's own `application_sdk/contracts/base.py` when running inside the SDK repo, falling back to the installed package when the conformance package is used standalone.

## Merge order

This PR → renovate rebases #2961 → its drift test passes because the registry and the pin now agree at `3.25.1`. (#2961's lock diff will shrink to just the boto3/botocore lines. Its `dep-cooldown` check is separate and still needs a waiver.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)