### PR TITLE
feat(contract-toolkit): render triggers.events filter_rules (DISTR-502)

### DIFF
--- a/contract-toolkit/src/App.pkl
+++ b/contract-toolkit/src/App.pkl
@@ -2267,14 +2267,63 @@ class EventTriggerConfig {
   ackPaths: Listing<String> = new Listing {}
 }
 
+/// One ingest-time filter rule. Mirrors AE's `FilterRule`: AE applies these when the
+/// event arrives and only persists matching events to the workflow's Iceberg events
+/// table. Rules AND together; `value` list members OR within a rule.
+///
+/// Without filter rules a trigger on a high-volume topic buffers the ENTIRE topic —
+/// on `ATLAS_ENTITIES` that is ~10^8 events/day into one table. Dedicated low-volume
+/// topics (e.g. `keycloak.cdc.*`) legitimately need no rules; a firehose topic does.
+///
+/// `field` is matched against the stored event payload **as it arrives on the wire** —
+/// AE stores the CloudEvent `data` unmodified. Atlas wraps every `ATLAS_ENTITIES`
+/// record in an `EntityNotification` envelope, so those paths must be rooted at
+/// `message.*` (e.g. `message.entity.typeName`), not at the bare attribute.
+///
+/// `operator` is AE's closed set. Comparison is **type-strict**: a String `value` does
+/// not match a numeric or boolean field. There is no prefix/regex/numeric-compare
+/// operator, and rules cannot OR across different fields — express that as multiple
+/// `EventTriggerSpec` entries on the same entrypoint.
+class FilterRuleSpec {
+  field: String(!isEmpty)
+  operator: "eq"|"neq"|"in"|"not_in"|"contains"|"exists"|"not_exists"
+  /// Match value(s). Omitted for `exists` / `not_exists`; required for every other
+  /// operator — AE rejects a null value there, so fail it at eval time instead.
+  value: (String|Listing<String>)?
+
+  hidden _valueShapeCheck: Any =
+    if ((operator == "exists" || operator == "not_exists") && value != null)
+      throw("FilterRuleSpec '\(field)': operator '\(operator)' takes no value; remove `value`.")
+    else if (operator != "exists" && operator != "not_exists" && value == null)
+      throw("FilterRuleSpec '\(field)': operator '\(operator)' requires a `value`.")
+    else null
+}
+
 /// One event trigger on a workflow. Renders to AE's `EventTrigger` shape
-/// (`name`, `source{name,topic}`, `trigger_config{max_retries,ack_paths}`, `status`).
+/// (`name`, `source{name,topic}`, `filter_rules[]`,
+/// `trigger_config{max_retries,ack_paths}`, `status`).
 class EventTriggerSpec {
   name: String
   source: EventSource
+  /// Ingest-time filters. Empty means "persist every event on the topic" — correct for
+  /// a dedicated topic, a footgun on a firehose. See `FilterRuleSpec`.
+  filterRules: Listing<FilterRuleSpec> = new Listing {}
   triggerConfig: EventTriggerConfig = new EventTriggerConfig {}
   status: "ACTIVE"|"PAUSED" = "ACTIVE"
 }
+
+local function renderFilterRule(rule: FilterRuleSpec): Mapping<String, Any> =
+  // Hidden properties are lazy — reference the validator so its `throw` fires at eval
+  // time rather than silently rendering an invalid rule.
+  let (_ruleCheck = rule._valueShapeCheck)
+  new Mapping {
+    ["field"] = rule.field
+    ["operator"] = rule.operator
+    // Omit `value` entirely for exists/not_exists rather than sending null.
+    when (rule.value != null) {
+      ["value"] = rule.value
+    }
+  }
 
 local manifestData: Mapping<String, Any> = new Mapping {
   ["execution_mode"] = "automation-engine"
@@ -2304,6 +2353,11 @@ local manifestData: Mapping<String, Any> = new Mapping {
               ["source"] = new Mapping {
                 ["name"] = e.source.name
                 ["topic"] = e.source.topic
+              }
+              // Omit the key when no rules are declared so manifests for existing
+              // filter-less entrypoints stay byte-identical (AE defaults it to []).
+              when (e.filterRules.length > 0) {
+                ["filter_rules"] = e.filterRules.toList().map((r) -> renderFilterRule(r))
               }
               ["trigger_config"] = new Mapping {
                 ["max_retries"] = e.triggerConfig.maxRetries

--- a/contract-toolkit/src/NativeApp.pkl
+++ b/contract-toolkit/src/NativeApp.pkl
@@ -2525,6 +2525,11 @@ local manifestData: Mapping<String, Any> = new Mapping {
                 ["name"] = e.source.name
                 ["topic"] = e.source.topic
               }
+              // Omit the key when no rules are declared so manifests for existing
+              // filter-less entrypoints stay byte-identical (AE defaults it to []).
+              when (e.filterRules.length > 0) {
+                ["filter_rules"] = e.filterRules.toList().map((r) -> renderFilterRule(r))
+              }
               ["trigger_config"] = new Mapping {
                 ["max_retries"] = e.triggerConfig.maxRetries
                 // AE rejects an empty ack_paths; render the fire-and-forget [""] when
@@ -2572,14 +2577,63 @@ class EventTriggerConfig {
   ackPaths: Listing<String> = new Listing {}
 }
 
+/// One ingest-time filter rule. Mirrors AE's `FilterRule`: AE applies these when the
+/// event arrives and only persists matching events to the workflow's Iceberg events
+/// table. Rules AND together; `value` list members OR within a rule.
+///
+/// Without filter rules a trigger on a high-volume topic buffers the ENTIRE topic —
+/// on `ATLAS_ENTITIES` that is ~10^8 events/day into one table. Dedicated low-volume
+/// topics (e.g. `keycloak.cdc.*`) legitimately need no rules; a firehose topic does.
+///
+/// `field` is matched against the stored event payload **as it arrives on the wire** —
+/// AE stores the CloudEvent `data` unmodified. Atlas wraps every `ATLAS_ENTITIES`
+/// record in an `EntityNotification` envelope, so those paths must be rooted at
+/// `message.*` (e.g. `message.entity.typeName`), not at the bare attribute.
+///
+/// `operator` is AE's closed set. Comparison is **type-strict**: a String `value` does
+/// not match a numeric or boolean field. There is no prefix/regex/numeric-compare
+/// operator, and rules cannot OR across different fields — express that as multiple
+/// `EventTriggerSpec` entries on the same entrypoint.
+class FilterRuleSpec {
+  field: String(!isEmpty)
+  operator: "eq"|"neq"|"in"|"not_in"|"contains"|"exists"|"not_exists"
+  /// Match value(s). Omitted for `exists` / `not_exists`; required for every other
+  /// operator — AE rejects a null value there, so fail it at eval time instead.
+  value: (String|Listing<String>)?
+
+  hidden _valueShapeCheck: Any =
+    if ((operator == "exists" || operator == "not_exists") && value != null)
+      throw("FilterRuleSpec '\(field)': operator '\(operator)' takes no value; remove `value`.")
+    else if (operator != "exists" && operator != "not_exists" && value == null)
+      throw("FilterRuleSpec '\(field)': operator '\(operator)' requires a `value`.")
+    else null
+}
+
 /// One event trigger on a workflow. Renders to AE's `EventTrigger` shape
-/// (`name`, `source{name,topic}`, `trigger_config{max_retries,ack_paths}`, `status`).
+/// (`name`, `source{name,topic}`, `filter_rules[]`,
+/// `trigger_config{max_retries,ack_paths}`, `status`).
 class EventTriggerSpec {
   name: String
   source: EventSource
+  /// Ingest-time filters. Empty means "persist every event on the topic" — correct for
+  /// a dedicated topic, a footgun on a firehose. See `FilterRuleSpec`.
+  filterRules: Listing<FilterRuleSpec> = new Listing {}
   triggerConfig: EventTriggerConfig = new EventTriggerConfig {}
   status: "ACTIVE"|"PAUSED" = "ACTIVE"
 }
+
+local function renderFilterRule(rule: FilterRuleSpec): Mapping<String, Any> =
+  // Hidden properties are lazy — reference the validator so its `throw` fires at eval
+  // time rather than silently rendering an invalid rule.
+  let (_ruleCheck = rule._valueShapeCheck)
+  new Mapping {
+    ["field"] = rule.field
+    ["operator"] = rule.operator
+    // Omit `value` entirely for exists/not_exists rather than sending null.
+    when (rule.value != null) {
+      ["value"] = rule.value
+    }
+  }
 
 local function generateDAG(): Mapping<String, Any> = new Mapping {
   ["extract"] = generateExtractNode()

--- a/contract-toolkit/tests/schedules_test.pkl
+++ b/contract-toolkit/tests/schedules_test.pkl
@@ -115,6 +115,52 @@ local appEventsOnly = (App) {
   }
 }
 
+// Firehose-sourced entrypoint with ingest filters (DISTR-502). Unlike the dedicated
+// `*.cdc.*` topics above, ATLAS_ENTITIES carries the whole fleet's entity traffic, so
+// the trigger MUST declare filter_rules or the workflow's Iceberg events table buffers
+// the entire topic. Paths are rooted at `message.*` — Atlas wraps each record in an
+// EntityNotification envelope and AE stores the CloudEvent data unmodified.
+local appFirehoseFilter = (App) {
+  name = "app-firehose-filter"
+  displayName = "App Firehose Filter"
+  icon = "https://example.com/icon.svg"
+  hasCredentialConfig = false
+  uiConfig = appUiConfig
+  pipeline {
+    publish = null
+  }
+
+  events {
+    new App.EventTriggerSpec {
+      name = "atlas-query-entities"
+      source = new App.EventSource {
+        name = "atlan-kafka"
+        topic = "ATLAS_ENTITIES"
+      }
+      filterRules {
+        new App.FilterRuleSpec {
+          field = "message.entity.typeName"
+          operator = "in"
+          value = new Listing { "Query" }
+        }
+        new App.FilterRuleSpec {
+          field = "message.operationType"
+          operator = "in"
+          value = new Listing { "ENTITY_CREATE"; "ENTITY_UPDATE"; "ENTITY_DELETE" }
+        }
+        new App.FilterRuleSpec {
+          field = "message.entity.guid"
+          operator = "exists"
+        }
+      }
+      triggerConfig = new App.EventTriggerConfig {
+        maxRetries = 5
+        ackPaths { "$.enrich.outputs.ack_path" }
+      }
+    }
+  }
+}
+
 local appManifest = parser.parse(
   appWithSchedules.output.files["app/generated/manifest.json"].text
 )
@@ -123,6 +169,9 @@ local appNoSchedManifest = parser.parse(
 )
 local appEventsOnlyManifest = parser.parse(
   appEventsOnly.output.files["app/generated/manifest.json"].text
+)
+local appFirehoseFilterManifest = parser.parse(
+  appFirehoseFilter.output.files["app/generated/manifest.json"].text
 )
 
 // ── NativeApp.pkl ───────────────────────────────────────────────────────────
@@ -197,8 +246,46 @@ local nativeManifest = parser.parse(
 local nativeNoSchedManifest = parser.parse(
   nativeNoSchedules.output.files["manifest.json"].text
 )
+// NativeApp firehose equivalent — same DISTR-502 case as appFirehoseFilter.
+local nativeFirehoseFilter = (NativeApp) {
+  name = "native-firehose-filter"
+  displayName = "Native Firehose Filter"
+  connector = Connectors.API
+  icon = "https://example.com/icon.svg"
+  workflowType = "NativeFirehoseFilterWorkflow"
+  hasPublishStep = false
+  hasPublishInputFields = false
+
+  events {
+    new NativeApp.EventTriggerSpec {
+      name = "atlas-query-entities"
+      source = new NativeApp.EventSource {
+        name = "atlan-kafka"
+        topic = "ATLAS_ENTITIES"
+      }
+      filterRules {
+        new NativeApp.FilterRuleSpec {
+          field = "message.entity.typeName"
+          operator = "eq"
+          value = "Query"
+        }
+        new NativeApp.FilterRuleSpec {
+          field = "message.entity.guid"
+          operator = "exists"
+        }
+      }
+      triggerConfig = new NativeApp.EventTriggerConfig {
+        ackPaths { "$.enrich.outputs.ack_path" }
+      }
+    }
+  }
+}
+
 local nativeEventsOnlyManifest = parser.parse(
   nativeEventsOnly.output.files["manifest.json"].text
+)
+local nativeFirehoseFilterManifest = parser.parse(
+  nativeFirehoseFilter.output.files["manifest.json"].text
 )
 
 facts {
@@ -253,6 +340,26 @@ facts {
     !appNoSchedManifest.containsKey("triggers")
   }
 
+  ["App renders filter_rules in AE FilterRule shape (field/operator/value)"] {
+    appFirehoseFilterManifest["triggers"]["events"][0]["filter_rules"].length == 3
+    appFirehoseFilterManifest["triggers"]["events"][0]["filter_rules"][0]["field"] == "message.entity.typeName"
+    appFirehoseFilterManifest["triggers"]["events"][0]["filter_rules"][0]["operator"] == "in"
+    appFirehoseFilterManifest["triggers"]["events"][0]["filter_rules"][0]["value"][0] == "Query"
+    // `in` values OR within the rule; rules AND across the list.
+    appFirehoseFilterManifest["triggers"]["events"][0]["filter_rules"][1]["value"].length == 3
+    appFirehoseFilterManifest["triggers"]["events"][0]["filter_rules"][1]["value"][2] == "ENTITY_DELETE"
+  }
+
+  ["App omits value for exists/not_exists rather than sending null"] {
+    appFirehoseFilterManifest["triggers"]["events"][0]["filter_rules"][2]["operator"] == "exists"
+    !appFirehoseFilterManifest["triggers"]["events"][0]["filter_rules"][2].containsKey("value")
+  }
+
+  ["App omits filter_rules entirely when none declared (existing manifests unchanged)"] {
+    !appEventsOnlyManifest["triggers"]["events"][0].containsKey("filter_rules")
+    !appManifest["triggers"]["events"][0].containsKey("filter_rules")
+  }
+
   // ── NativeApp.pkl ───────────────────────────────────────────────────────────
   ["NativeApp renders triggers.schedules from declared schedules"] {
     nativeManifest["triggers"]["schedules"].length == 1
@@ -282,5 +389,16 @@ facts {
 
   ["NativeApp omits triggers when neither schedules nor events are declared"] {
     !nativeNoSchedManifest.containsKey("triggers")
+  }
+
+  ["NativeApp renders filter_rules, scalar value inline, exists without value"] {
+    nativeFirehoseFilterManifest["triggers"]["events"][0]["filter_rules"].length == 2
+    nativeFirehoseFilterManifest["triggers"]["events"][0]["filter_rules"][0]["operator"] == "eq"
+    nativeFirehoseFilterManifest["triggers"]["events"][0]["filter_rules"][0]["value"] == "Query"
+    !nativeFirehoseFilterManifest["triggers"]["events"][0]["filter_rules"][1].containsKey("value")
+  }
+
+  ["NativeApp omits filter_rules entirely when none declared"] {
+    !nativeEventsOnlyManifest["triggers"]["events"][0].containsKey("filter_rules")
   }
 }


### PR DESCRIPTION
Render `filter_rules` on `triggers.events[]` so an app can declare an **ingest-time filtered** event trigger in its contract, instead of registering it out-of-band against AE's REST API and re-running that by hand on every tenant.

Additive and guarded: rendered only `when (e.filterRules.length > 0)`, so every existing app — including auth-app's ten filter-less triggers — renders byte-identically.

## Why this is needed

`triggers.events` already works end to end today — **atlan-auth-app ships it in production**: `contract/app.pkl` declares 10 Keycloak CDC topics, the toolkit renders `triggers.events`, and LM reconciles them into an AE workflow whose triggers the watchdog dispatches. No registration code in that app at all.

What it does **not** support is filtering, because it has never needed it: `keycloak.cdc.*` are dedicated topics, so persisting every event on them is correct.

`ATLAS_ENTITIES` is the opposite case. It carries the whole fleet's entity traffic (~1e8 events/day), and an unfiltered trigger buffers **all of it** into that workflow's Iceberg events table. So a firehose-topic consumer cannot use the contract path at all today — it has to hand-roll the AE 3-POST (`POST /v1/workflows` → `/versions` → `/versions/{v}/publish`) and re-run it per tenant, manually, forever.

## Named consumer

**atlanhq/atlan-system-workflows-app#36** (`sq-enricher`, DISTR-502) is that consumer. It currently carries `app/sq_enricher/register.py` + `ae_registration.py` purely because this gap exists, and the operational cost is concrete: the app is deployed on tenants where the enricher has **never run**, because publishing an image does not register a trigger.

With this merged, that app declares two filtered `ATLAS_ENTITIES` triggers in `contract/app.pkl`, and **both files delete**.

## What this changes

- `FilterRuleSpec` — `field`, `operator` (`eq|neq|in|not_in|contains|exists|not_exists`, matching AE's `FilterRule`), and `value: (String|Listing<String>)?` so `in`/`not_in` take lists and `eq` takes a scalar.
- Eval-time validation for the two shapes AE rejects: a `value` on `exists`/`not_exists`, and a missing `value` on everything else. Fails at `pkl eval` rather than at publish time. `renderFilterRule` forces the lazy hidden validator so the `throw` actually fires.
- `renderFilterRule` omits `value` entirely for `exists`/`not_exists` rather than emitting `null`.
- Rendered under `when (e.filterRules.length > 0)`, so **every existing filter-less entrypoint stays byte-identical** — including auth-app's ten.

## Two things a reviewer will reasonably ask

**Why duplicated across `App.pkl` and `NativeApp.pkl`?** Because that is the existing pattern, not a new one: `EventTriggerSpec`, `EventSource`, `EventTriggerConfig` and `ScheduleSpec` are all already defined 1:1 in both. `schedules_test.pkl`'s own header states it — *"the feature lives in BOTH schemas (App.pkl and NativeApp.pkl) while the toolkit migrates from NativeApp.pkl to App.pkl."* Factoring these into a shared module would be a sensible follow-up, but it should move all of them at once, not just this one.

**Why do the tests live in `schedules_test.pkl`?** That file is already the triggers test file rather than a schedules-only one — it has ~45 event references on `main`, including `"App renders triggers.events from declared events (AE EventTrigger shape)"`. The new filter tests sit next to their siblings. Renaming the file to `triggers_test.pkl` would be an improvement and is deliberately out of scope here.

## Verification

`pkl test tests/schedules_test.pkl` — **18 tests, 54 asserts, 100% pass** (Pkl 0.30.2), covering: AE FilterRule shape for `field`/`operator`/`value`, list values for `in`, `value` omitted for `exists`, and filter-less manifests unchanged — in both schemas.

Not verified here: the AE round-trip on a live tenant. That is exercised by the consumer PR, which has on-tenant runs on AWS, GCP and Azure.


## Verification

`pkl test tests/schedules_test.pkl` — **18 tests, 54 asserts, 100% pass** (Pkl 0.30.2), covering: AE FilterRule shape for `field`/`operator`/`value`, list values for `in`, `value` omitted for `exists`, and filter-less manifests unchanged — in both schemas.

Not verified here: the AE round-trip on a live tenant. That is exercised by the consumer PR, which has on-tenant runs on AWS, GCP and Azure.


## 2. Literal task queue for the extract node

The generated extract node hardcoded `"{taskQueuePrefix}-{deployment_name}"`, so a workflow that must run on a **dedicated worker pool** could not be expressed at all. A pool's queue is pinned in `atlan.yaml` under `workerPools[].taskQueue` and does not follow that shape — and the derivation can only append `-{deployment_name}`, so the pool queue is simply unreachable.

**The failure mode is silent, which is the reason this is worth fixing rather than working around.** AE dispatches to the app's *default* worker queue, and that worker happily executes the workflow — because every worker registers every entrypoint. It just runs on the wrong pod, losing whatever isolation the pool exists to provide. For the consumer below that means a DuckDB/Iceberg drain with a 3Gi limit landing on a 512Mi pod that also auto-pauses customer workflows and serves a read API.

- `App.pkl` — `ExtractStep.taskQueue: String?`
- `NativeApp.pkl` — module-level `extractNodeTaskQueue: String?` (its builder has no step object to hang it on)
- Both render `override ?? derived`.

This mirrors `DAGNode.taskQueue`, which explicitly-declared nodes **already** honour (`node.taskQueue ?? …`); it extends the same escape hatch to the generated node.

### Not included, because it turned out to already exist

I had this down as a third gap — bounding the generated node's timeout — and it isn't one. `App.pkl` supports it today via `pipeline.extract.errorHandling`, verified by eval:

```
error_handling: {'start_to_close_timeout_seconds': 2100}
```

It is simply named differently from `NativeApp.pkl`'s module-level `extractNodeErrorHandling`. Nothing needed here; noting it so the next person doesn't go looking.

## Verification

Full toolkit suite: **302 tests / 720 asserts, 100% pass** — no regression.

New coverage: AE FilterRule shape (`field`/`operator`/`value`), list values for `in`, `value` omitted for `exists`, and filter-less manifests unchanged — in both schemas.

### Scope correction

An earlier revision of this PR also added a literal task-queue override for the *generated* extract node. **That was unnecessary and has been dropped.** `DAGNode.taskQueue` already exists (App.pkl:699) and `renderNode` already honours it; a workflow needing a dedicated pool declares its node via `extraNodes` and sets `taskQueue` there, never touching the generated node — `pipeline.extract` is nullable and `generateDAG()` emits that node only `when (pipeline.extract != null)`. Verified against unpatched main: single-node DAG, `task_queue: atlan-system-workflows-sqe`, `errorHandling` and static `args` all rendering. Thanks to the reviewer who caught it.

Not verified here: the AE round-trip on a live tenant. The consumer PR carries on-tenant runs on AWS, GCP and Azure.
