### PR TITLE
ci(sdk-review): attribute this lane's LLM spend to its own key

### DIFF
--- a/.github/workflows/sdk-review.yml
+++ b/.github/workflows/sdk-review.yml
@@ -499,6 +499,7 @@ jobs:
               repositories: ["atlanhq/application-sdk"],
               base_branch: $base_branch,
               snapshot: "_base",
+              ai_gateway_key_name: "sdk_review",
               prompt: $prompt,
               max_timeout_seconds: 7200,
               idle_timeout_seconds: 1800,


### PR DESCRIPTION
## Problem

This lane's dispatch payload sends `snapshot: "_base"`, which pins no AI-gateway key, and no `ai_gateway_key_name`. Mothership's resolver (`harness/core/config/ai_gateway_resolver.py`) then falls through to `LITELLM_KEY_DEFAULT` — the break-glass key already shared with Linear and PR review — so sdk-review's LLM spend cannot be separated from theirs.

A dedicated key was provisioned on 2026-08-03 (alias `sdk_review`, $2000/30d, `metadata.owner: application-sdk`, `purpose: sdk-review lane via /api/sandbox/execute`). It shows `spend = 0.0` across its entire life despite this lane running daily, for two independent reasons: the env var was never mounted on the mothership deployment, and this payload never asked for the alias. The first is fixed in atlanhq/cloud-common#3762; this PR fixes the second.

## Change

One field on the existing payload:

```
ai_gateway_key_name: "sdk_review",
```

The resolver upper-cases the alias to `LITELLM_KEY_SDK_REVIEW`. Nothing else in the payload changes.

## Dependency and ordering

**Merge after atlanhq/cloud-common#3762 has synced.** If `LITELLM_KEY_SDK_REVIEW` is absent on the deployment, the resolver logs a warning and silently falls back to the shared key — the payload looks wired while nothing is actually attributed. That fail-open behaviour is deliberate on mothership's side (other lanes rely on the fallback) and is not changed here, so a typo in the alias would also fail quietly. Verify, don't assume.

## Verification

Extracted the patched jq program and ran it with real `--arg` values:

```
VALID JSON | 13 keys
ai_gateway_key_name = 'sdk_review'
snapshot = '_base'  mode = 'direct'  stream = True
metadata keys unchanged
```

`#` comments are legal inside a jq object literal — confirmed by execution, not assumed. Workflow file still parses as YAML.

Resolver behaviour confirmed against the real function, both directions:

```
alias -> env: LITELLM_KEY_SDK_REVIEW
env ABSENT  -> resolved alias: default     (logs AI_GATEWAY_FELL_THROUGH_TO_DEFAULT)
env PRESENT -> resolved alias: sdk_review
```

## Scope

Only this lane. The repo's other mothership dispatchers (`mothership_sandbox_dispatch.py` vuln-triage, `sdk_evolution_dispatch.py`, `sdk_resolve_dispatch.py`) also send no alias and stay on the shared key, so one runaway lane cannot starve this one's $2000/30d budget. Wiring them up needs its own key or an explicit decision to share this one.

## Post-merge check

After the next sdk-review run: `/key/info` on the `sdk_review` key should show `spend > 0`, and mothership logs should show `AI Gateway key resolved: sdk_review` with no `AI_GATEWAY_FELL_THROUGH_TO_DEFAULT`.