### PR TITLE
fix(app): offload cleanup_files fs I/O to a thread and cap its heartbeat timeout

### DIFF
--- a/application_sdk/app/base.py
+++ b/application_sdk/app/base.py
@@ -1364,6 +1364,18 @@ class App(ABC):
 
         path_results: dict[str, bool] = {}
 
+        async def _remove_path(path: str) -> None:
+            """Delete ``path`` (file or directory) off the event loop.
+
+            Offloaded because ``rmtree``/``remove`` over a large tracked
+            directory is syscall-bound and can run long enough to starve the
+            auto-heartbeat if it ran directly on the event loop.
+            """
+            if os.path.isdir(path):
+                await run_in_thread(shutil.rmtree, path)
+            else:
+                await run_in_thread(os.remove, path)
+
         # 1. Delete tracked FileReference local paths (+ .sha256 sidecars).
         tracked_refs = TaskStateAccessor().get(TRACKED_FILE_REFS_KEY)
         if tracked_refs:
@@ -1372,14 +1384,7 @@ class App(ABC):
                     for p in (ref.local_path, ref.local_path + ".sha256"):
                         try:
                             if os.path.exists(p):
-                                if os.path.isdir(p):
-                                    # Offloaded: rmtree over a large tracked
-                                    # directory is syscall-bound and can run
-                                    # long enough to starve the auto-heartbeat
-                                    # if it ran directly on the event loop.
-                                    await run_in_thread(shutil.rmtree, p)
-                                else:
-                                    await run_in_thread(os.remove, p)
+                                await _remove_path(p)
                             path_results[p] = True
                         except Exception:
                             _task_logger.warning(
@@ -1399,10 +1404,7 @@ class App(ABC):
         for base_path in dir_paths:
             try:
                 if os.path.exists(base_path):
-                    if os.path.isdir(base_path):
-                        await run_in_thread(shutil.rmtree, base_path)
-                    else:
-                        await run_in_thread(os.remove, base_path)
+                    await _remove_path(base_path)
                 path_results[base_path] = True
             except Exception:
                 _task_logger.warning(

--- a/application_sdk/app/base.py
+++ b/application_sdk/app/base.py
@@ -1332,7 +1332,7 @@ class App(ABC):
             store=store,
         )
 
-    @task(timeout_seconds=300, retry_max_attempts=3)
+    @task(timeout_seconds=300, retry_max_attempts=3, heartbeat_timeout_seconds=60)
     async def cleanup_files(self, input: CleanupInput) -> CleanupOutput:
         """Framework task: clean up local files after a workflow run.
 
@@ -1358,6 +1358,9 @@ class App(ABC):
         from application_sdk.execution import (  # noqa: PLC0415 — circular: execution/__init__.py loads _temporal which imports app.base
             build_output_path,
         )
+        from application_sdk.execution.heartbeat import (  # noqa: PLC0415 — circular: execution/__init__.py loads _temporal which imports app.base
+            run_in_thread,
+        )
 
         path_results: dict[str, bool] = {}
 
@@ -1370,9 +1373,13 @@ class App(ABC):
                         try:
                             if os.path.exists(p):
                                 if os.path.isdir(p):
-                                    shutil.rmtree(p)
+                                    # Offloaded: rmtree over a large tracked
+                                    # directory is syscall-bound and can run
+                                    # long enough to starve the auto-heartbeat
+                                    # if it ran directly on the event loop.
+                                    await run_in_thread(shutil.rmtree, p)
                                 else:
-                                    os.remove(p)
+                                    await run_in_thread(os.remove, p)
                             path_results[p] = True
                         except Exception:
                             _task_logger.warning(
@@ -1393,9 +1400,9 @@ class App(ABC):
             try:
                 if os.path.exists(base_path):
                     if os.path.isdir(base_path):
-                        shutil.rmtree(base_path)
+                        await run_in_thread(shutil.rmtree, base_path)
                     else:
-                        os.remove(base_path)
+                        await run_in_thread(os.remove, base_path)
                 path_results[base_path] = True
             except Exception:
                 _task_logger.warning(

--- a/tests/unit/app/test_cleanup_files.py
+++ b/tests/unit/app/test_cleanup_files.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import shutil
+import threading
 from dataclasses import dataclass
 from typing import Any
 from unittest import mock
@@ -16,6 +17,7 @@ from application_sdk.app.task import get_task_metadata
 from application_sdk.contracts.base import Input, Output
 from application_sdk.contracts.cleanup import CleanupInput, CleanupOutput
 from application_sdk.contracts.types import FileReference
+from application_sdk.execution import heartbeat
 
 
 @dataclass
@@ -179,53 +181,62 @@ class TestCleanupFiles:
         assert metadata.timeout_seconds == 300
 
     @pytest.mark.asyncio
-    async def test_file_removal_offloaded_to_thread(self, tmp_path: Any) -> None:
-        # Regression guard for HB-12: os.remove() must not run inline on the
-        # event loop (that starves the auto-heartbeat for the call's duration).
-        f = tmp_path / "output.parquet"
-        f.write_text("data")
-        ref = FileReference(local_path=str(f), storage_path="artifacts/x")
+    @pytest.mark.parametrize("section", ["tracked_ref", "extra_paths"])
+    @pytest.mark.parametrize("kind", ["file", "dir"])
+    async def test_removal_runs_off_the_event_loop(
+        self, tmp_path: Any, section: str, kind: str
+    ) -> None:
+        # Regression guard for HB-12: every removal cleanup_files performs must
+        # run off the event loop, or it starves the auto-heartbeat for the
+        # call's duration. Parametrised over both sections (tracked
+        # FileReference paths / extra_paths) and both branches (file / dir) so
+        # all four call sites are covered — re-inlining any one of them fails.
+        #
+        # This drives the real run_in_thread (real executor, real worker
+        # thread) and records where the fs call actually ran, so the assertion
+        # tracks the property the fix is about rather than merely which
+        # callable was handed to the wrapper.
+        if kind == "dir":
+            target = tmp_path / "workflow-artifacts"
+            target.mkdir()
+            (target / "some-file.txt").write_text("data")
+            expected_func: Any = shutil.rmtree
+        else:
+            target = tmp_path / "output.parquet"
+            target.write_text("data")
+            expected_func = os.remove
+
+        real_run_in_thread = heartbeat.run_in_thread
+        calls: list[tuple[Any, int]] = []
+
+        async def recording_run_in_thread(func: Any, *args: Any, **kwargs: Any) -> Any:
+            def wrapped(*a: Any, **kw: Any) -> Any:
+                calls.append((func, threading.get_ident()))
+                return func(*a, **kw)
+
+            return await real_run_in_thread(wrapped, *args, **kwargs)
+
+        tracked_refs = None
+        extra_paths = ["nonexistent-dir"]
+        if section == "tracked_ref":
+            tracked_refs = {
+                FileReference(local_path=str(target), storage_path="artifacts/x")
+            }
+        else:
+            extra_paths = [str(target)]
 
         app = _CleanupApp()
         with mock.patch(
             "application_sdk.app.base.TaskStateAccessor.get",
-            return_value={ref},
+            return_value=tracked_refs,
         ):
-            with mock.patch(
-                "application_sdk.execution.heartbeat.run_in_thread",
-                new_callable=mock.AsyncMock,
-                side_effect=lambda func, *a, **kw: func(*a, **kw),
-            ) as mock_run_in_thread:
-                result = await app.cleanup_files(
-                    CleanupInput(extra_paths=["nonexistent-dir"])
-                )
+            with mock.patch.object(heartbeat, "run_in_thread", recording_run_in_thread):
+                result = await app.cleanup_files(CleanupInput(extra_paths=extra_paths))
 
-        assert not f.exists()
-        assert result.path_results[str(f)] is True
-        offloaded_funcs = [call.args[0] for call in mock_run_in_thread.call_args_list]
-        assert os.remove in offloaded_funcs
-
-    @pytest.mark.asyncio
-    async def test_directory_removal_offloaded_to_thread(self, tmp_path: Any) -> None:
-        # Same regression guard as above, for the shutil.rmtree() directory branch.
-        test_dir = tmp_path / "workflow-artifacts"
-        test_dir.mkdir()
-        (test_dir / "some-file.txt").write_text("data")
-
-        app = _CleanupApp()
-        with mock.patch(
-            "application_sdk.app.base.TaskStateAccessor.get", return_value=None
-        ):
-            with mock.patch(
-                "application_sdk.execution.heartbeat.run_in_thread",
-                new_callable=mock.AsyncMock,
-                side_effect=lambda func, *a, **kw: func(*a, **kw),
-            ) as mock_run_in_thread:
-                result = await app.cleanup_files(
-                    CleanupInput(extra_paths=[str(test_dir)])
-                )
-
-        assert not test_dir.exists()
-        assert result.path_results[str(test_dir)] is True
-        offloaded_funcs = [call.args[0] for call in mock_run_in_thread.call_args_list]
-        assert shutil.rmtree in offloaded_funcs
+        assert not target.exists()
+        assert result.path_results[str(target)] is True
+        # Exactly one offload, using the branch-appropriate callable …
+        assert [func for func, _ in calls] == [expected_func]
+        # … and it did not execute on the event loop's thread.
+        loop_thread = threading.get_ident()
+        assert all(ident != loop_thread for _, ident in calls)

--- a/tests/unit/app/test_cleanup_files.py
+++ b/tests/unit/app/test_cleanup_files.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import os
+import shutil
 from dataclasses import dataclass
 from typing import Any
 from unittest import mock
@@ -10,6 +12,7 @@ import pytest
 
 from application_sdk.app.base import App, _app_state, _app_state_lock
 from application_sdk.app.registry import AppRegistry, TaskRegistry
+from application_sdk.app.task import get_task_metadata
 from application_sdk.contracts.base import Input, Output
 from application_sdk.contracts.cleanup import CleanupInput, CleanupOutput
 from application_sdk.contracts.types import FileReference
@@ -164,3 +167,65 @@ class TestCleanupFiles:
 
         # Error is captured — task does not raise
         assert result.path_results[str(f)] is False
+
+    def test_heartbeat_timeout_seconds_is_explicit(self) -> None:
+        # Regression guard for HB-12: cleanup_files must not silently inherit
+        # ATLAN_HEARTBEAT_TIMEOUT_SECONDS (which individual apps set anywhere
+        # from 60s to 7200s) — it needs its own small, explicit value that
+        # stays well under its own timeout_seconds=300.
+        metadata = get_task_metadata(App.cleanup_files)
+        assert metadata is not None
+        assert metadata.heartbeat_timeout_seconds == 60
+        assert metadata.timeout_seconds == 300
+
+    @pytest.mark.asyncio
+    async def test_file_removal_offloaded_to_thread(self, tmp_path: Any) -> None:
+        # Regression guard for HB-12: os.remove() must not run inline on the
+        # event loop (that starves the auto-heartbeat for the call's duration).
+        f = tmp_path / "output.parquet"
+        f.write_text("data")
+        ref = FileReference(local_path=str(f), storage_path="artifacts/x")
+
+        app = _CleanupApp()
+        with mock.patch(
+            "application_sdk.app.base.TaskStateAccessor.get",
+            return_value={ref},
+        ):
+            with mock.patch(
+                "application_sdk.execution.heartbeat.run_in_thread",
+                new_callable=mock.AsyncMock,
+                side_effect=lambda func, *a, **kw: func(*a, **kw),
+            ) as mock_run_in_thread:
+                result = await app.cleanup_files(
+                    CleanupInput(extra_paths=["nonexistent-dir"])
+                )
+
+        assert not f.exists()
+        assert result.path_results[str(f)] is True
+        offloaded_funcs = [call.args[0] for call in mock_run_in_thread.call_args_list]
+        assert os.remove in offloaded_funcs
+
+    @pytest.mark.asyncio
+    async def test_directory_removal_offloaded_to_thread(self, tmp_path: Any) -> None:
+        # Same regression guard as above, for the shutil.rmtree() directory branch.
+        test_dir = tmp_path / "workflow-artifacts"
+        test_dir.mkdir()
+        (test_dir / "some-file.txt").write_text("data")
+
+        app = _CleanupApp()
+        with mock.patch(
+            "application_sdk.app.base.TaskStateAccessor.get", return_value=None
+        ):
+            with mock.patch(
+                "application_sdk.execution.heartbeat.run_in_thread",
+                new_callable=mock.AsyncMock,
+                side_effect=lambda func, *a, **kw: func(*a, **kw),
+            ) as mock_run_in_thread:
+                result = await app.cleanup_files(
+                    CleanupInput(extra_paths=[str(test_dir)])
+                )
+
+        assert not test_dir.exists()
+        assert result.path_results[str(test_dir)] is True
+        offloaded_funcs = [call.args[0] for call in mock_run_in_thread.call_args_list]
+        assert shutil.rmtree in offloaded_funcs


### PR DESCRIPTION
## Context

Found via a fleet-wide audit (heartbeat-timeout-detector, `atlanhq/awesome-ai`) that independently flagged the same unwrapped-cleanup pattern in **34 downstream connector apps** pinned to application-sdk versions 3.13 through 3.25. All 34 findings trace back to one shared root cause in this SDK's `App.cleanup_files()`, so this PR fixes it once here rather than patching each app.

## Root cause (verified against current `main`, in `application_sdk/app/base.py`)

1. `App.on_complete()` unconditionally awaits `cleanup_files()` when cleanup is enabled (the default).
2. `cleanup_files()`'s body calls `shutil.rmtree()` / `os.remove()` directly on the activity's event-loop thread — no thread offload — which starves the framework's auto-heartbeat background task for the full duration of the call.
3. `cleanup_files()`'s `@task(...)` decorator did not set an explicit `heartbeat_timeout_seconds`, so it silently inherited whatever `ATLAN_HEARTBEAT_TIMEOUT_SECONDS` each individual app happens to set (observed 60s-7200s across the fleet) instead of a value sized to its own `timeout_seconds=300`.

`cleanup_storage()` was also checked: it already sets `heartbeat_timeout_seconds=None, auto_heartbeat_seconds=None` (heartbeating fully disabled for that task) and its body has no blocking filesystem calls — only `await`ed object-store deletes. It does not have this gap on current `main`, so it is **not modified** by this PR.

## Fix (two parts, both needed)

1. **Thread-offload**: wrap the `shutil.rmtree` / `os.remove` calls in `application_sdk.execution.heartbeat.run_in_thread` — the SDK's existing sanctioned offload primitive for exactly this problem (already used the same way in `clients/sql.py`, `clients/azure/auth.py`, `clients/azure/client.py`, `storage/transfer.py`, `observability/pushgateway.py`). This is filesystem I/O (syscall-bound, releases the GIL), so a plain thread-offload is sufficient — no process isolation or chunking needed. Reused the existing helper rather than a raw `asyncio.to_thread()` call so this stays on the SDK's own dedicated blocking-work executor pool (with contextvars propagation) instead of asyncio's default executor.
2. **Explicit `heartbeat_timeout_seconds=60`** on `cleanup_files`'s `@task(...)` decorator, decoupling it from whatever an app has set for `ATLAN_HEARTBEAT_TIMEOUT_SECONDS` globally. 60s is the SDK's own designed baseline default (`_DEFAULT_HEARTBEAT_TIMEOUT_SECONDS`, and matches the documented `auto_heartbeat_seconds` ratio of ~1/6 elsewhere in `task.py`), stays a healthy 5x under `cleanup_files`'s own `timeout_seconds=300`, and — now that removal is offloaded — no longer needs to accommodate how long a single large `rmtree` takes, since heartbeats keep flowing throughout regardless of call duration.

## Empirical verification

Per the task's own caveat that a to_thread fix verified elsewhere in this audit shouldn't be assumed to transfer without checking, I benchmarked this repo's actual `run_in_thread` against a 20k-file `shutil.rmtree`, with a concurrent 10ms-interval asyncio ticker standing in for the auto-heartbeat:

- **Direct/blocking** `shutil.rmtree` on the loop: ticker gap ≈ the entire call duration (e.g. 1315ms call → 1322ms max gap; 5994ms call → 5996ms max gap) — the loop is completely frozen for as long as the removal takes.
- **`run_in_thread(shutil.rmtree, ...)`**: max ticker gap stayed at 12-88ms regardless of call duration (1.3s-5.9s) — comfortably sub-100ms, consistent with normal scheduling jitter, not with the loop being blocked.

This confirms the offload keeps heartbeats flowing independent of how long the underlying removal takes.

## Tests

- Ran the full unit suite (`uv sync --all-extras --all-groups && uv run pytest tests/unit/`): **6165 passed, 0 failed, 9 skipped** (pre-existing skips).
- `ruff check` / `ruff format --check` / `isort --check-only` clean on both changed files, checked against the exact ruff version pinned in `.pre-commit-config.yaml` (0.6.4).
- Added 3 new tests to `tests/unit/app/test_cleanup_files.py`:
  - `test_heartbeat_timeout_seconds_is_explicit` — guards the new `heartbeat_timeout_seconds=60` task metadata.
  - `test_file_removal_offloaded_to_thread` / `test_directory_removal_offloaded_to_thread` — guard that `os.remove` / `shutil.rmtree` are actually invoked through `run_in_thread`, not inline.
- No changes needed to `tests/unit/app/test_cleanup_storage.py` — that task's behavior is unchanged.

## Scope

No refactoring, no unrelated cleanup — only the two things above, inside `cleanup_files`. `cleanup_storage` is untouched (see root cause section). Net diff: 12 lines in `application_sdk/app/base.py`.

## Downstream impact — please read

**Downstream apps pin their own application-sdk version and will NOT pick up this fix until they bump their dependency after this is released. This PR does not touch any downstream app — that is a separate, per-app decision (a version bump is not always a trivial pin change; see prior incidents where an SDK bump forced a larger migration).**

## Review

This touches shared infrastructure (`App.cleanup_files`) used by dozens of production connectors across the fleet — please route this to a maintainer/SDK-team review rather than a fast-path merge.