### PR TITLE
fix(infrastructure): cut the Dapr retry ladder back to its intended budget

### DIFF
--- a/application_sdk/infrastructure/_dapr/http.py
+++ b/application_sdk/infrastructure/_dapr/http.py
@@ -42,11 +42,27 @@ _T = TypeVar("_T")
 
 _DEFAULT_DAPR_HTTP_PORT = 3500
 _DEFAULT_TIMEOUT = 30.0
-# Retry budget spans the sidecar cold-start: with backoff_factor=1.0 the waits
-# are ~1+2+4+8s, so a Dapr call issued just before daprd is accepting requests
-# retries across ~15s rather than giving up in ~1.5s (the old total=3,
-# backoff=0.5). Retries only fire on failures; healthy calls are unaffected.
-_DEFAULT_RETRY_TOTAL = 5
+# Retry budget spans the sidecar cold-start: a Dapr call issued just before
+# daprd is accepting requests retries across ~14s rather than giving up
+# immediately. Retries only fire on failures; healthy calls are unaffected.
+#
+# The ladder is ``backoff_factor * 2**n`` for n in 1..total (httpx-retries
+# increments before sleeping), so total=3 at backoff_factor=1.0 is 2+4+8s
+# nominal across 4 requests — and ``backoff_jitter`` defaults to 1.0, which
+# scales each sleep by ``uniform(0, 1)``, giving ~2-12s in practice.
+#
+# Do NOT read the ladder as ``2**(n-1)`` starting at 1: total=5 was chosen
+# believing it bought ~15s (1+2+4+8) when it actually bought 62s nominal
+# (2+4+8+16+32), a 4x overshoot whose 32s tail sleep dominated everything
+# else. See test_retry_budget_spans_cold_start, which asserts the resulting
+# budget rather than this constant, so a future edit can't repeat that.
+#
+# Deeper cold-start coverage does not depend on this ladder: component
+# readiness is handled by retry_past_dapr_cold_start's 120s budget at the
+# layer that can read Dapr's errorCode, the connection race is closed by
+# wait_for_dapr_sidecar at startup, and every activity sits under Temporal's
+# own retry. A wider ladder here only delays those.
+_DEFAULT_RETRY_TOTAL = 3
 
 # ---------------------------------------------------------------------------
 # Metrics
@@ -254,7 +270,8 @@ async def wait_for_dapr_sidecar(
 #: :func:`retry_past_dapr_cold_start` caller shares this one budget, since
 #: they all race the same sidecar. This is a floor, not a hard ceiling: each
 #: retried ``call()`` can itself burn up to the transport's own internal
-#: retry budget (~15s, see ``_DEFAULT_RETRY_TOTAL`` above) before raising, so
+#: retry budget (~14s nominal, see ``_DEFAULT_RETRY_TOTAL`` above) before
+#: raising, so
 #: the worst-case total wait before final failure can exceed this value by
 #: up to one attempt's duration. Env-overridable for pathological runners.
 DAPR_COLD_START_MAX_WAIT_SECONDS: float = float(
@@ -414,9 +431,11 @@ class AsyncDaprClient:
                 # delete_state) keep the exact retry coverage they had before —
                 # listing leaf classes like ConnectError/ReadError would have
                 # narrowed it and dropped WriteError/WriteTimeout/CloseError.
-                # NOTE: these errors were already retried by default; the real
-                # change in this fix is the wider *budget* above (total 3->5,
-                # backoff 0.5->1.0, ~1.5s -> ~15s) that bridges a daprd cold start.
+                # NOTE: these errors were already retried by default; what the
+                # original fix changed was the *budget* above (raising
+                # backoff_factor to 1.0) to bridge a daprd cold start. See
+                # _DEFAULT_RETRY_TOTAL for the ladder arithmetic and why the
+                # accompanying total=5 was later cut back to 3.
                 retry_on_exceptions=[
                     httpx.TimeoutException,
                     httpx.NetworkError,

--- a/tests/unit/infrastructure/test_dapr_http.py
+++ b/tests/unit/infrastructure/test_dapr_http.py
@@ -401,8 +401,23 @@ class TestRetryConfiguration:
         assert retry.is_retryable_exception(httpx.WriteError("x")) is True
         assert retry.is_retryable_exception(httpx.WriteTimeout("x")) is True
         assert retry.is_retryable_exception(httpx.CloseError("x")) is True
-        assert _DEFAULT_RETRY_TOTAL >= 5
         assert retry.backoff_factor >= 1.0
+
+        # Assert the resulting *budget*, not the raw retry count. The count is
+        # a proxy that hid a 4x overshoot: total=5 was chosen believing the
+        # ladder was 1+2+4+8 (~15s), but httpx-retries increments before
+        # sleeping, so it is backoff_factor * 2**n for n in 1..total — 62s
+        # nominal, with a 32s final sleep. Bounding both ends means neither a
+        # regression to a tiny budget nor another silent widening can pass.
+        nominal_budget = sum(
+            retry.backoff_factor * 2**n for n in range(1, _DEFAULT_RETRY_TOTAL + 1)
+        )
+        assert 10.0 <= nominal_budget <= 20.0, (
+            f"nominal retry ladder is {nominal_budget}s across "
+            f"{_DEFAULT_RETRY_TOTAL + 1} requests — too short to bridge a "
+            "daprd cold start, or wide enough that a single tail sleep "
+            "dominates a caller's activity budget"
+        )
 
 
 class TestSidecarWaitTimeout:


### PR DESCRIPTION
### Changelog

- `_DEFAULT_RETRY_TOTAL` 5 → **3**, cutting the Dapr transport retry ladder from 62 s nominal across 6 requests to **14 s across 4** — which is what the constant's own comment has claimed all along.
- Rewrite the three comments in `_dapr/http.py` that documented the wrong ladder arithmetic.
- Replace the test's `_DEFAULT_RETRY_TOTAL >= 5` assertion with one on the resulting *budget*, bounded at both ends.

### Problem

This is a correction, not a tuning change. The comment above the constant says:

> with `backoff_factor=1.0` the waits are ~1+2+4+8s, so … retries across ~15s

That is not what the deployed config does. `httpx-retries` calls `retry.increment()` *before* `asleep()`, so the ladder is `backoff_factor * 2**n` for `n` in `1..total` — not `2**(n-1)` starting at 1. With `total=5`:

| | requests | nominal ladder | total |
|---|---|---|---|
| believed | 5 | `1+2+4+8` | ~15 s |
| **actual** | **6** | **`2+4+8+16+32`** | **62 s** |

So the budget shipped at roughly **4x its intent**, and a single 32 s tail sleep dominated everything before it. Measured against the real client config, a retried call costs 6 requests and 9–50 s once `backoff_jitter` (which defaults to `1.0`, i.e. `uniform(0, 1)` per sleep) is applied.

`total=3` restores the intended shape: `2+4+8` = **14 s nominal across 4 requests**, ~2–12 s with jitter. Verified with a counting transport against the exact `AsyncDaprClient` config.

### Why this does not reduce cold-start coverage

The ladder was widened to bridge a daprd cold start. It is not what actually does that job:

- **Component readiness** is handled by `retry_past_dapr_cold_start` on a **120 s** budget, at the layer that can read Dapr's `errorCode` — far wider than the transport's, and able to tell "not configured yet" from a definitive rejection.
- **The connection race** (daprd not yet accepting sockets) is closed at startup by `wait_for_dapr_sidecar`, which polls `/v1.0/healthz` for up to 60 s.
- **State store, bindings and pub/sub** are the paths with no Dapr-aware outer retry — but every one of them runs inside a Temporal activity, which has its own retry policy. A state write that fails after 14 s is retried at the activity level.

A 32 s tail sleep does not protect those paths. It delays a retry that would have succeeded sooner, and on any caller with a fixed activity budget it consumes that budget instead.

### Test change worth a reviewer's eye

`test_retry_budget_spans_cold_start` asserted `_DEFAULT_RETRY_TOTAL >= 5`. That assertion is exactly how the 4x overshoot survived: the retry *count* is a proxy for the budget, and the proxy moved in the wrong direction from what the author intended.

It now computes the nominal ladder and asserts `10 s <= budget <= 20 s`. Bounding **both** ends means neither a regression to a tiny budget (the original concern) nor another silent widening (what actually happened) can pass. The exception-coverage assertions in that test are unchanged.

### Additional context (e.g. screenshots, logs, links)

- BLDX-1594. In the production runs on that ticket, credential resolution consumed ~120 s and timed out a fixed activity budget while the actual SQL connect took 0.3–0.5 s. The retry ladder is the unit of cost being multiplied there, so shrinking it shrinks every path that pays it.
- Complements #2989 (probes run concurrently — fewer *repetitions* of the ladder) and #2916 (draft; a missing-key secrets GET stops being retried at all — fewer *paths* that pay it). This PR shrinks the ladder itself, and the three are independent: approving this does not depend on either.
- **Conflict note for #2916:** it edits the same `Retry(...)` block and its PR body contains a measured table asserting **6 requests** for the paths it deliberately leaves unchanged (state, `get_bulk_secret`, 502/503/504 on secrets). After this lands those become **4 requests**. That table and any count-shaped assertions in its `TestSecretsRetryScoping` will need updating on rebase — the *scoping* behaviour it tests is unaffected, only the absolute counts.

### Checklist

- [x] Additional tests added
- [ ] All CI checks passed
- [ ] Relevant documentation updated

`uv run pytest tests/unit/` — 6184 passed, 9 skipped. `uv run pre-commit run --files <changed>` — all hooks pass.

---

### Copyleft License Compliance

- [ ] Have you used any code that is subject to a Copyleft license (e.g., GPL, AGPL, LGPL)?
- [ ] If yes, have you modified the code in the context of this project? please share additional details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
