### PR TITLE
ci(sdk-resolve): kimi-k3 main lane, gpt-5.6-luna fast + sub-agent lanes

### DIFF
--- a/.github/scripts/sdk_resolve_dispatch.py
+++ b/.github/scripts/sdk_resolve_dispatch.py
@@ -17,7 +17,10 @@ Environment:
     HARNESS_TOKEN       bearer for /api/sandbox/execute
     PR_NUMBER           the open PR to drive to merge-ready
     MAX_ROUNDS          max @sdk-review rounds before stopping (default 8)
-    REVIEWERS           comma-separated GitHub handles to request + tag at the end
+    REVIEWERS           comma-separated GitHub handles to request + tag at the
+                        end; fed by vars.SDK_RESOLVE_REVIEWERS. Optional, no
+                        default — unset means no reviewer is requested and the
+                        run logs a warning.
     REQUESTER           login that invoked @sdk-resolve (also tagged)
     GHA_RUN_URL         this workflow run's URL
     RUN_DATE            ISO date (computed if absent)
@@ -50,6 +53,12 @@ READ_IDLE_TIMEOUT_SECONDS = 1900
 # keeping the last N bytes always preserves it.
 BUFFER_CAP_BYTES = 65536
 DEFAULT_MAX_ROUNDS = 8
+# Models this lane runs on, mirroring sdk-review.yml. Chosen on cost per TASK,
+# not per token: kimi-k3 (index 57.2, ~$0.85/task) vs claude-opus-5 (60.5,
+# ~$2.40) and gpt-5.6-luna (51.2, $0.20/Mtok in) vs claude-haiku-4-5 (29.6,
+# $1.00/Mtok) — better and cheaper on the fast lane. Reverting is a one-liner.
+MAIN_MODEL = "kimi-k3"
+FAST_MODEL = "gpt-5.6-luna"
 
 # --- Out-of-band hand-off backstop -----------------------------------------
 # The resolver runs in its OWN mothership sandbox; our SSE stream only observes
@@ -93,6 +102,22 @@ def build_prompt(
     # Reviewers to request + the requester who triggered the run — tagged at the
     # end so a human takes the merge from a green, review-requested PR.
     tag_list = ", ".join(f"@{h}" for h in _reviewer_handles(reviewers, requester))
+    # REVIEWERS comes from a repo variable and may be unset. Build the
+    # reviewer-request instruction from the cleaned list so an empty value
+    # can't produce an argument-less `gh pr edit --add-reviewer`, which fails
+    # and burns a round. Unset does NOT silently skip the hand-off: the
+    # resolver is told to state that no reviewer list is configured, and the
+    # dispatch step logs a ::warning:: as well. (CODEOWNERS auto-request only
+    # fires when a PR is opened, so it is not a fallback for a PR this
+    # resolver has been iterating on.)
+    request_list = ",".join(_reviewer_handles(reviewers, ""))
+    review_request = (
+        f"run `gh pr edit {pr_number} --add-reviewer {request_list}` "
+        '(ignore "can\'t request from the author" errors) and '
+        if request_list
+        else "state in the report that NO reviewer list is configured "
+        "(vars.SDK_RESOLVE_REVIEWERS is unset) so a human assigns one, then "
+    )
     return f"""You are running the SDK Resolver in a Cloudflare sandbox.
 
 Repository cloned at: /workspace/application-sdk.
@@ -118,10 +143,8 @@ verdict READY_TO_MERGE. You are the only writer — the reviewer runs in its own
 separate sandbox; you trigger it with `@sdk-review` (post as-is; the reviewer
 workflow now accepts the sandbox bot identity) and consume its comment.
 Do NOT `gh pr merge` — stop at merge-ready and hand back to a human. When you
-finish (merge-ready OR NEEDS_HUMAN), REQUEST HUMAN REVIEW: run
-`gh pr edit {pr_number} --add-reviewer {reviewers}` (ignore "can't request from
-the author" errors) and post the final report @-mentioning {tag_list} so they
-know it's their turn. Expect each push to reset the reviewer labels/status
+finish (merge-ready OR NEEDS_HUMAN), REQUEST HUMAN REVIEW: {review_request}post
+the final report @-mentioning {tag_list} so they know it's their turn. Expect each push to reset the reviewer labels/status
 (reset-on-push) — that is normal; key the loop off findings + CI, not labels.
 Stop after MAX_ROUNDS rounds, or if a dismissed finding is re-raised, and
 report. At the very end print the `=== SDK RESOLVE SUMMARY ===` block from
@@ -154,6 +177,16 @@ def build_payload(
         "repositories": ["atlanhq/application-sdk"],
         "base_branch": "main",
         "snapshot": "_base",
+        # Model pinning, same three lanes as sdk-review.yml (PR #2985). Without
+        # these the lane inherits mothership's DEFAULT_CLAUDE_MODEL
+        # (claude-opus-5) and `_base` leaves CLAUDE_CODE_SUBAGENT_MODEL on
+        # claude-sonnet-5, so Task/Explore legwork bills Claude rates whatever
+        # the main lane runs. `small_fast_model` must be pinned explicitly:
+        # mothership's model_routing_env does `fast = small_fast_model or model`,
+        # so pinning `model` alone would put the background lane on kimi-k3.
+        "model": MAIN_MODEL,
+        "small_fast_model": FAST_MODEL,
+        "env_vars": {"CLAUDE_CODE_SUBAGENT_MODEL": FAST_MODEL},
         "prompt": build_prompt(
             pr_number, gha_run_url, max_rounds, reviewers, requester
         ),
@@ -582,7 +615,17 @@ def main() -> int:
     gha_run_url = os.environ.get("GHA_RUN_URL", "")
     run_date = os.environ.get("RUN_DATE") or time.strftime("%Y-%m-%d", time.gmtime())
     max_rounds = _max_rounds()
-    reviewers = os.environ.get("REVIEWERS", "cmgrote,vaibhavatlan")
+    # No hardcoded handles: the list comes from the repo variable
+    # vars.SDK_RESOLVE_REVIEWERS via the workflow. Unset is tolerated but never
+    # silent — without it the run ends with no reviewer requested, which is the
+    # kind of thing that only gets noticed weeks later.
+    reviewers = os.environ.get("REVIEWERS", "")
+    if not _reviewer_handles(reviewers, ""):
+        print(
+            "::warning::SDK_RESOLVE_REVIEWERS is unset — no reviewer will be "
+            "requested when this PR reaches merge-ready. Set the repo variable "
+            "to a comma-separated list of GitHub handles."
+        )
     requester = os.environ.get("REQUESTER", "")
     github_token = os.environ.get("GITHUB_TOKEN", "")
     # Lower bound for matching *this* run's hand-off comment; captured before the

--- a/.github/scripts/tests/test_sdk_resolve_dispatch.py
+++ b/.github/scripts/tests/test_sdk_resolve_dispatch.py
@@ -22,39 +22,84 @@ def _stream(*lines: str):
 
 def test_payload_shape():
     p = sr.build_payload(
-        "1234", "http://run", 8, "2026-07-08", "cmgrote,vaibhavatlan", "octocat"
+        "1234",
+        "http://run",
+        8,
+        "2026-07-08",
+        "reviewer-one,reviewer-two",
+        "requester-login",
     )
     assert p["mode"] == "direct" and p["stream"] is True
     assert p["source_id"] == "sdk-resolve-1234-2026-07-08"
     assert p["repositories"] == ["atlanhq/application-sdk"]
     assert p["metadata"]["pr_number"] == "1234"
     assert p["metadata"]["max_rounds"] == 8
-    assert p["metadata"]["reviewers"] == "cmgrote,vaibhavatlan"
-    assert p["metadata"]["requester"] == "octocat"
+    assert p["metadata"]["reviewers"] == "reviewer-one,reviewer-two"
+    assert p["metadata"]["requester"] == "requester-login"
+
+
+def test_payload_pins_all_three_model_lanes():
+    # All three lanes must be pinned: leaving any unset silently falls back to
+    # mothership's Claude defaults (main -> claude-opus-5, sub-agent ->
+    # claude-sonnet-5), and `small_fast_model` unset resolves to `model`.
+    p = sr.build_payload("1", "u", 8, "2026-07-08", "reviewer-one", "requester-login")
+    assert p["model"] == "kimi-k3"
+    assert p["small_fast_model"] == "gpt-5.6-luna"
+    assert p["env_vars"]["CLAUDE_CODE_SUBAGENT_MODEL"] == "gpt-5.6-luna"
+    # Every pinned value must survive JSON encoding as a non-blank string —
+    # env_vars skips the API's model-id validation that `model` gets.
+    encoded = json.loads(json.dumps(p))
+    for value in (
+        encoded["model"],
+        encoded["small_fast_model"],
+        encoded["env_vars"]["CLAUDE_CODE_SUBAGENT_MODEL"],
+    ):
+        assert isinstance(value, str) and value == value.strip() and value
 
 
 def test_prompt_carries_pr_stop_line_and_review_request():
-    prompt = sr.build_prompt("42", "u", 8, "cmgrote,vaibhavatlan", "octocat")
+    prompt = sr.build_prompt(
+        "42", "u", 8, "reviewer-one,reviewer-two", "requester-login"
+    )
     assert "PR_NUMBER:    42" in prompt
     assert "MERGE-READY" in prompt
     assert "Do NOT `gh pr merge`" in prompt  # human merges
     assert "pr-resolve/ORCHESTRATION.md" in prompt
     # requests human review + tags reviewers AND the requester
-    assert "gh pr edit 42 --add-reviewer cmgrote,vaibhavatlan" in prompt
-    assert "@cmgrote" in prompt and "@vaibhavatlan" in prompt and "@octocat" in prompt
+    assert "gh pr edit 42 --add-reviewer reviewer-one,reviewer-two" in prompt
+    assert (
+        "@reviewer-one" in prompt
+        and "@reviewer-two" in prompt
+        and "@requester-login" in prompt
+    )
+
+
+def test_prompt_without_configured_reviewers_asks_for_a_human_assignment():
+    # REVIEWERS comes from a repo variable and may be unset. The prompt must not
+    # emit an argument-less `gh pr edit --add-reviewer`, which would fail — and
+    # it must not silently skip the hand-off either: the missing list is named
+    # in the report so someone assigns a reviewer.
+    prompt = sr.build_prompt("42", "u", 8, "", "requester-login")
+    assert "--add-reviewer" not in prompt
+    assert "NO reviewer list is configured" in prompt
+    assert "SDK_RESOLVE_REVIEWERS" in prompt
+    # the requester is still tagged so someone is pinged
+    assert "@requester-login" in prompt
+    # whitespace/comma-only values are treated as unset too
+    assert "--add-reviewer" not in sr.build_prompt("42", "u", 8, " , ", "")
 
 
 def test_reviewer_handles_dedupe_and_strip():
     # strips '@', de-dupes, appends requester, drops blanks
-    assert sr._reviewer_handles("@cmgrote, vaibhavatlan", "octocat") == [
-        "cmgrote",
-        "vaibhavatlan",
-        "octocat",
+    assert sr._reviewer_handles("@reviewer-one, reviewer-two", "requester-login") == [
+        "reviewer-one",
+        "reviewer-two",
+        "requester-login",
     ]
     # requester already in the reviewer list → not duplicated
-    assert sr._reviewer_handles("cmgrote,vaibhavatlan", "cmgrote") == [
-        "cmgrote",
-        "vaibhavatlan",
+    assert sr._reviewer_handles("reviewer-one,reviewer-two", "reviewer-one") == [
+        "reviewer-one",
+        "reviewer-two",
     ]
 
 

--- a/.github/workflows/sdk-resolve.yml
+++ b/.github/workflows/sdk-resolve.yml
@@ -20,6 +20,11 @@
 #   secrets.GLOBALPROTECT_PASSWORD  VPN auth.
 #   vars.GLOBALPROTECT_PORTAL_URL   VPN portal URL.
 #   vars.MOTHERSHIP_URL             e.g. https://mothership.atlan.dev
+#
+# Optional configuration:
+#   vars.SDK_RESOLVE_REVIEWERS      Comma-separated GitHub handles to request as
+#                                   reviewers at merge-ready. Unset → nobody is
+#                                   requested and the run logs a warning.
 
 name: SDK Resolve (mothership)
 
@@ -213,9 +218,13 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ steps.parse.outputs.pr_number }}
           MAX_ROUNDS: ${{ inputs.max_rounds || '8' }}
-          # Human reviewers to request + tag when the PR reaches merge-ready
-          # (Chris = cmgrote, Vaibhav = vaibhavatlan); the requester is added too.
-          REVIEWERS: cmgrote,vaibhavatlan
+          # Human reviewers to request + tag when the PR reaches merge-ready;
+          # the requester is tagged too. Comma-separated GitHub handles, held in
+          # a repo variable rather than named here so the list can change without
+          # a code change. Unset is tolerated but not silent: no reviewer is
+          # requested, the step logs a ::warning::, and the resolver's report
+          # says the list is missing.
+          REVIEWERS: ${{ vars.SDK_RESOLVE_REVIEWERS }}
           REQUESTER: ${{ steps.parse.outputs.requester }}
           GHA_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: python3 .github/scripts/sdk_resolve_dispatch.py


### PR DESCRIPTION
## Problem

`@sdk-resolve` sends no `model`, so it inherits mothership's `DEFAULT_CLAUDE_MODEL` — currently `claude-opus-5` — exactly the leak #2985 closed for `@sdk-review`. Sub-agents leak the same way: `snapshot: "_base"` pins no model, so `CLAUDE_CODE_SUBAGENT_MODEL` resolves to `claude-sonnet-5` and all Task/Explore legwork bills Claude rates whatever the main lane runs.

This lane is the more expensive of the two per invocation: it loops up to `MAX_ROUNDS` (default 8) review→fix→push rounds inside a 2h `max_timeout_seconds`, and each round triggers a full `@sdk-review` pass in its own sandbox. The reviewer's measured $27.21 on a 4-file PR is the *unit* the resolver multiplies.

## Change

Same three lanes as #2985, with the same rationale (cost per **task**, not per token — Artificial Analysis figures):

| Lane | Before | After | Why |
|---|---|---|---|
| main (`model`) | claude-opus-5 (60.5 index, $2.40/task) | **kimi-k3** (57.2, $0.85) | -65% cost for -5.5% index |
| fast (`small_fast_model`) | unset → resolved to `model` | **gpt-5.6-luna** (51.2, $0.20/Mtok in) | better *and* cheaper than claude-haiku-4-5 (29.6, $1.00/Mtok) |
| sub-agent (`env_vars`) | claude-sonnet-5 (53.3, $1.80/task) | **gpt-5.6-luna** | 10x cheaper per input token |

`small_fast_model` is pinned deliberately: mothership's `model_routing_env` does `fast = small_fast_model or model`, so pinning `model` alone would put the background lane on kimi-k3 at $3/Mtok.

Pinned in `build_payload()` in `sdk_resolve_dispatch.py`, not in workflow YAML — unlike sdk-review, this lane's dispatch payload lives in the tested script per `docs/standards/ci.md`. The three values sit in `MAIN_MODEL` / `FAST_MODEL` constants so a revert is a two-line change.

**No mothership change required** — same reasoning as #2985: `CLAUDE_CODE_SUBAGENT_MODEL` is not in `sandbox_api.py`'s `_BLOCKED_KEYS`, and the `setdefault` that injects the snapshot-derived default preserves a caller-supplied value.

## Also: no people's names in the resolver

`REVIEWERS` was a hardcoded `cmgrote,vaibhavatlan` in the workflow, with the same pair as a default in the script and throughout the test fixtures. It now comes from `vars.SDK_RESOLVE_REVIEWERS`, the script has **no** default, and the fixtures use synthetic handles (`reviewer-one` / `reviewer-two` / `requester-login`). The reviewer list can now change without a code change.

Unset is tolerated but **never silent** — three separate signals, because "no reviewer was requested" is the kind of regression that surfaces weeks later:

1. the prompt omits the `gh pr edit --add-reviewer` instruction entirely, rather than emitting it with no argument (which would fail and burn a round);
2. the dispatch step logs `::warning::SDK_RESOLVE_REVIEWERS is unset — no reviewer will be requested…`;
3. the resolver's own final report states the list is missing so a human assigns one.

CODEOWNERS is *not* treated as the fallback: its auto-request only fires when a PR is opened, and this resolver runs at the end of a loop on an already-open PR.

`.github/CODEOWNERS` still carries literal handles — GitHub requires them there, so placeholders aren't possible. Names are out of the workflow, the script, and the tests.

## ⚠️ Prerequisite before the next `@sdk-resolve` run

`vars.SDK_RESOLVE_REVIEWERS` **does not exist yet** (`gh variable list --repo atlanhq/application-sdk`). Until it is set, runs reach merge-ready with no reviewer requested — visible as the warning above, but still a behavior change from today's hardcoded pair. Set it when merging:

```
gh variable set SDK_RESOLVE_REVIEWERS --repo atlanhq/application-sdk --body '<handle>,<handle>'
```

## Testing

- `build_payload()` printed with real args: 14 keys, all three lanes set, every pre-existing field byte-identical.
- New `test_payload_pins_all_three_model_lanes` — asserts each lane *and* that every pinned value survives JSON encoding as a non-blank, non-padded string, since the `env_vars` path skips the model-id validation `model` and `small_fast_model` get at the API boundary.
- New `test_prompt_without_configured_reviewers_asks_for_a_human_assignment` — no `--add-reviewer` when the list is empty (including a whitespace/comma-only value), missing list named in the prompt, requester still tagged.
- Existing reviewer/prompt tests re-pointed at the synthetic handles. 37 tests pass; `scripts-tests.yaml` covers them in CI.
- `pre-commit` clean (ruff, ruff-format, isort, pyright); workflow parses as YAML.

## Not verified

No full sandbox **resolve** has run on kimi-k3 — the model evidence in #2985 covers the API contract and process health, not fix quality on a real diff, and nothing here re-tests it. Two lane-specific risks to watch on the first run:

- **Context ceiling.** `kimi-k3` declares no `max_input_tokens` in the catalog and the measured reviewer run peaked at 182,712 tokens in a single call. An 8-round resolver loop accumulates more than any reviewer pass, so this lane hits that ceiling first if it exists.
- **Write quality.** A reviewer that misses a bug costs a re-review; a resolver that pushes a wrong fix costs a revert. Watch the diffs the first one or two runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
