### PR TITLE
feat(ci): run every e2e suite against an AWS/Azure/GCP tenant matrix

### DIFF
--- a/.github/actions/discover-e2e-suites/action.yaml
+++ b/.github/actions/discover-e2e-suites/action.yaml
@@ -6,19 +6,48 @@ description: |
   so the SDK never hard-codes a connector's suites. The driver is co-located
   with this action (checked out with it in consumer repos).
 
+  Set `clouds` to cross every suite with a cloud provider (FND-6), so each
+  suite runs once per CSP tenant. Leaving it empty keeps the single-tenant
+  shape, which is what a caller without the tenant-matrix secret wants.
+
 inputs:
   test-dir:
     description: Directory to glob for test_*.py e2e suites.
     required: false
     default: tests/e2e
+  clouds:
+    description: |
+      Comma-separated cloud providers to cross each discovered suite with
+      (e.g. "aws,azure,gcp"). Each leg's `cloud` selects which tenant the e2e
+      job resolves its credentials for.
+
+      Empty means the driver's default list, NOT "no clouds" — an untouched
+      GitHub input arrives as "", and that must not silently opt a repo out of
+      the matrix. Pass "none" to disable the cloud dimension.
+
+      Defaulted to "none" here so a caller that says nothing at all gets the
+      pre-FND-6 behaviour: an action input is easy to forget, and tripling a
+      caller's matrix by default is the wrong direction to fail in.
+    required: false
+    default: "none"
+  clouds-only:
+    description: |
+      "true" emits only the cloud dimension, with no file dimension, for
+      callers that pass a whole directory to pytest rather than fanning out
+      per suite (e2e-full-reusable.yaml). `test-dir` is unused in that mode.
+    required: false
+    default: "false"
 
 outputs:
   matrix:
-    description: JSON include-list for strategy.matrix; each entry has file and name.
+    description: JSON include-list for strategy.matrix; each entry has file and name (plus suite and cloud when `clouds` is set).
     value: ${{ steps.discover.outputs.matrix }}
   count:
-    description: Number of discovered suites (0 means the e2e job should skip).
+    description: Number of discovered suites (0 means the e2e job should skip). Independent of the cloud fan-out.
     value: ${{ steps.discover.outputs.count }}
+  leg-count:
+    description: Number of matrix legs emitted (suites × clouds).
+    value: ${{ steps.discover.outputs.leg-count }}
 
 runs:
   using: composite
@@ -26,12 +55,19 @@ runs:
     - name: Discover suites
       id: discover
       shell: bash
-      # Route the caller-supplied input through env (quoted below) rather than
+      # Route the caller-supplied inputs through env (quoted below) rather than
       # interpolating ${{ }} into the command string. github.action_path is a
-      # trusted GitHub context, so it stays inline.
+      # trusted GitHub context, so it stays inline. The --clouds-only flag is
+      # selected by a step-level expression rather than an `if` in the shell,
+      # per docs/standards/ci.md; it is deliberately unquoted below so the
+      # empty case expands to no argument at all.
       env:
         TEST_DIR: ${{ inputs.test-dir }}
+        CLOUDS: ${{ inputs.clouds }}
+        CLOUDS_ONLY_FLAG: ${{ inputs.clouds-only == 'true' && '--clouds-only' || '' }}
       run: |
         set -euo pipefail
         python3 "${{ github.action_path }}/discover_e2e_suites.py" \
-          --test-dir "$TEST_DIR" >> "$GITHUB_OUTPUT"
+          --test-dir "$TEST_DIR" \
+          --clouds "$CLOUDS" \
+          ${CLOUDS_ONLY_FLAG} >> "$GITHUB_OUTPUT"

--- a/.github/actions/discover-e2e-suites/discover_e2e_suites.py
+++ b/.github/actions/discover-e2e-suites/discover_e2e_suites.py
@@ -3,14 +3,46 @@
 The full-DAG e2e job fans out one matrix leg per test *file* under the
 connector's e2e directory (default ``tests/e2e/``), so independent suites run
 as separate jobs — parallel, with live per-job logs, per-suite re-run, and
-isolation. This driver globs the files and prints the two outputs the workflow
+isolation. This driver globs the files and prints the three outputs the workflow
 consumes:
 
-  matrix — a JSON object ``{"include": [{"file": ..., "name": ...}, ...]}``
-           suitable for ``strategy.matrix``. ``name`` is a sanitized, unique
-           label used for the job name and the per-leg artifact suffix (so
-           upload-artifact names don't collide across legs).
-  count  — number of discovered suites (0 ⇒ the e2e job is skipped).
+  matrix    — a JSON object ``{"include": [{"file": ..., "name": ...}, ...]}``
+              suitable for ``strategy.matrix``. ``name`` is a sanitized, unique
+              label used for the job name and the per-leg artifact suffix (so
+              upload-artifact names don't collide across legs).
+  count     — number of discovered *suites* (0 ⇒ the e2e job is skipped). This
+              stays the suite count, not the leg count: the caller's "requested
+              but nothing found" guard is about suites, and a cloud fan-out over
+              zero suites is still zero suites.
+  leg-count — number of matrix legs actually emitted (suites × clouds).
+
+Cross-CSP fan-out (FND-6)
+-------------------------
+``--clouds aws,azure,gcp`` crosses every discovered suite with a cloud
+provider, so each suite runs against one tenant per CSP and cloud-specific
+nuances (the objectstore binding the configurator emits, blobstorage proxy
+behaviour, Temporal host resolution) are exercised before release. The cloud
+lands in the leg ``name``, which the caller threads into the job name, the
+concurrency group, the artifact suffix, and — via ``derive_deployment_name.py``
+— ``ATLAN_DEPLOYMENT_NAME``, so legs stay isolated on all four axes for free.
+
+Three ``--clouds`` values, and the reason the empty one is not "no clouds":
+
+* ``aws,azure,gcp`` — an explicit list.
+* ``""`` — the default list, :data:`DEFAULT_CLOUDS`. Every app repo's
+  ``tests.yaml`` forwards an operator-supplied ``e2e_clouds`` dispatch input
+  straight through, and a GitHub input the operator left alone arrives as ``""``.
+  Were that "no clouds", the entire fleet would silently opt out of the matrix
+  the day the input was scaffolded. Making it mean "whatever the SDK currently
+  ships" also keeps the list defined in exactly one place: adding a fourth CSP
+  is an edit here, not in fifteen app repos.
+* ``none`` — no cloud dimension. Reproduces the pre-FND-6 output byte for byte,
+  for a caller without the tenant-matrix secret, or an operator deliberately
+  falling back to the single legacy tenant.
+
+``--clouds-only`` emits the cloud dimension *without* the file dimension, for
+callers that target a whole directory rather than fanning out per file
+(``e2e-full-reusable.yaml``).
 
 Co-located with the composite action — NOT under ``.github/scripts/`` — so it
 is checked out alongside the action when consumed from another repo (mirrors
@@ -28,6 +60,16 @@ from pathlib import Path
 
 _SANITIZE_RE = re.compile(r"[^a-z0-9]+")
 
+# The canonical cross-CSP fan-out. One tenant per cloud, per FND-6. Defined here
+# rather than as a workflow-input default so a fourth CSP is one edit, not one
+# per consumer repo — see the module docstring on why "" means this list.
+DEFAULT_CLOUDS = ("aws", "azure", "gcp")
+
+# Opt out of the cloud dimension entirely. A word rather than "" because "" is
+# what an untouched GitHub input sends, and silently disabling the matrix on
+# every un-customised run is the failure this sentinel exists to prevent.
+NO_CLOUDS = "none"
+
 
 def _leg_name(path: Path) -> str:
     """Derive a stable, filesystem-safe leg label from a test file path.
@@ -42,17 +84,51 @@ def _leg_name(path: Path) -> str:
     return _SANITIZE_RE.sub("-", stem.lower()).strip("-") or "e2e"
 
 
-def discover(test_dir: str) -> list[dict[str, str]]:
+def parse_clouds(raw: str) -> list[str]:
+    """Return the ordered, de-duplicated cloud list for a ``--clouds`` value.
+
+    Accepts the comma-separated form the workflow input carries. ``""`` yields
+    :data:`DEFAULT_CLOUDS` and ``"none"`` yields no clouds — see the module
+    docstring for why round that way. Blank entries inside a list are dropped so
+    a trailing comma is a no-op rather than a leg named "". Order is the
+    caller's, not sorted: the operator writes ``aws,azure,gcp`` and the legs
+    should read in that order.
+    """
+    stripped = raw.strip()
+    if not stripped:
+        return list(DEFAULT_CLOUDS)
+    if stripped.lower() == NO_CLOUDS:
+        return []
+
+    out: list[str] = []
+    for token in raw.split(","):
+        cloud = _SANITIZE_RE.sub("-", token.strip().lower()).strip("-")
+        if cloud and cloud not in out:
+            out.append(cloud)
+    return out
+
+
+def discover(test_dir: str, clouds: list[str] | None = None) -> list[dict[str, str]]:
     """Return the ordered matrix ``include`` entries for *test_dir*.
 
-    One entry per ``test_*.py`` directly under *test_dir*. Sorted for a stable
-    leg order. Leg names are de-duplicated defensively (two files sanitizing to
-    the same label get a numeric suffix) so artifact names stay unique.
+    One entry per ``test_*.py`` directly under *test_dir*, crossed with *clouds*
+    when given. Sorted for a stable leg order. Leg names are de-duplicated
+    defensively (two files sanitizing to the same label get a numeric suffix) so
+    artifact names stay unique.
+
+    Suites are the outer loop and clouds the inner one, so the legs read as
+    "suite A on each cloud, then suite B on each cloud" — the order an operator
+    scans when one suite is failing everywhere versus one cloud failing
+    everywhere.
+
+    With no *clouds* the entries keep the pre-FND-6 ``{file, name}`` shape
+    exactly: no ``suite``/``cloud`` keys are added, so ``matrix.cloud`` is empty
+    in the caller and the tenant resolver takes its single-tenant fallback path.
     """
     root = Path(test_dir)
     files = sorted(p for p in root.glob("test_*.py") if p.is_file())
 
-    entries: list[dict[str, str]] = []
+    suites: list[tuple[Path, str]] = []
     seen: dict[str, int] = {}
     for path in files:
         name = _leg_name(path)
@@ -61,8 +137,21 @@ def discover(test_dir: str) -> list[dict[str, str]]:
             name = f"{name}-{seen[name]}"
         else:
             seen[name] = 1
-        entries.append({"file": path.as_posix(), "name": name})
-    return entries
+        suites.append((path, name))
+
+    if not clouds:
+        return [{"file": path.as_posix(), "name": name} for path, name in suites]
+
+    return [
+        {
+            "file": path.as_posix(),
+            "suite": name,
+            "cloud": cloud,
+            "name": f"{name}-{cloud}",
+        }
+        for path, name in suites
+        for cloud in clouds
+    ]
 
 
 def _nested_only(test_dir: str) -> list[Path]:
@@ -82,9 +171,46 @@ def _nested_only(test_dir: str) -> list[Path]:
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Discover e2e suites for a matrix.")
     parser.add_argument("--test-dir", default="tests/e2e")
+    parser.add_argument(
+        "--clouds",
+        default="",
+        help=(
+            "Comma-separated cloud providers to cross every discovered suite "
+            f"with (e.g. aws,azure,gcp). Empty = the default list "
+            f"({','.join(DEFAULT_CLOUDS)}); '{NO_CLOUDS}' = no cloud dimension, "
+            "which reproduces the pre-FND-6 single-tenant matrix shape."
+        ),
+    )
+    parser.add_argument(
+        "--clouds-only",
+        action="store_true",
+        help=(
+            "Emit only the cloud dimension (no file dimension), for callers "
+            "that pass a whole directory to pytest instead of fanning out per "
+            "suite. --test-dir is not read in this mode."
+        ),
+    )
     args = parser.parse_args(sys.argv[1:] if argv is None else argv)
 
-    entries = discover(args.test_dir)
+    clouds = parse_clouds(args.clouds)
+
+    if args.clouds_only:
+        # No suites to count in this mode: the caller runs one pytest target per
+        # cloud, so the suite count IS the cloud count and a zero there means
+        # "no clouds configured" — which the caller's guard should still catch.
+        entries = [{"cloud": cloud, "name": cloud} for cloud in clouds]
+        print(
+            f"Cloud-only matrix: {len(entries)} leg(s) [{', '.join(clouds) or 'none'}]",
+            file=sys.stderr,
+        )
+        matrix = json.dumps({"include": entries}, separators=(",", ":"))
+        print(f"matrix={matrix}")
+        print(f"count={len(entries)}")
+        print(f"leg-count={len(entries)}")
+        return 0
+
+    suites = discover(args.test_dir)
+    entries = discover(args.test_dir, clouds)
 
     nested = _nested_only(args.test_dir)
     if nested:
@@ -98,11 +224,20 @@ def main(argv: list[str] | None = None) -> int:
         )
 
     matrix = json.dumps({"include": entries}, separators=(",", ":"))
-    print(f"Discovered {len(entries)} e2e suite(s) in {args.test_dir}", file=sys.stderr)
+    # State the fan-out explicitly. A silent "4 suites" line when 12 legs are
+    # about to run (or when the cloud list quietly collapsed to one) reads as
+    # full coverage either way.
+    print(
+        f"Discovered {len(suites)} e2e suite(s) in {args.test_dir} × "
+        f"{len(clouds) or 1} cloud(s) [{', '.join(clouds) or 'default tenant'}] "
+        f"= {len(entries)} leg(s)",
+        file=sys.stderr,
+    )
     for e in entries:
         print(f"  - {e['name']}: {e['file']}", file=sys.stderr)
     print(f"matrix={matrix}")
-    print(f"count={len(entries)}")
+    print(f"count={len(suites)}")
+    print(f"leg-count={len(entries)}")
     return 0
 
 

--- a/.github/scripts/resolve_e2e_tenant.py
+++ b/.github/scripts/resolve_e2e_tenant.py
@@ -1,0 +1,236 @@
+"""Resolve one e2e matrix leg's tenant + credentials into ``$GITHUB_ENV``.
+
+Why this exists
+---------------
+Before FND-6 the e2e job pinned a single tenant into its ``env:`` block from
+four flat secrets (``SDR_TEST_TENANT``, ``SDR_CLIENT_ID``, ``SDR_CLIENT_SECRET``,
+``ATLAN_API_KEY``), so every connector's e2e ran against one cloud and
+CSP-specific behaviour — the objectstore binding ``atlan-configurator`` emits,
+blobstorage proxy behaviour, Temporal host resolution — was never exercised
+before release.
+
+The matrix now carries a ``cloud`` per leg, but a ``strategy.matrix`` value
+cannot index the ``secrets`` context, and ``tests-reusable.yaml`` declares its
+``workflow_call`` secrets explicitly, so a per-cloud *name* per credential would
+have to be declared (and re-declared in every reusable) for every cloud added.
+Instead one secret carries the whole map — the same shape ``E2E_SOURCE_ENV_JSON``
+already uses for per-connector source credentials::
+
+    {
+      "aws":   {"tenant": "…", "client_id": "…", "client_secret": "…", "api_key": "…"},
+      "azure": {…},
+      "gcp":   {…}
+    }
+
+and this script extracts exactly one cloud's entry. Adding a fourth CSP is a
+secret edit; no workflow, app repo, or code change.
+
+Least privilege by construction: only the requested cloud's entry is ever
+rendered, so a leg never sees the other tenants' credentials at all.
+
+Masking
+-------
+Registering ``E2E_TENANT_MATRIX_JSON`` as a secret does **not** redact the
+values inside it — the runner's masker matches registered strings, not
+substrings of one. The two-pass ``--mask-only``-then-write protocol and the
+mask rendering itself are ``export_extra_env``'s, imported rather than
+reimplemented so both call sites share one audited implementation (and
+``test_every_env_write_call_site_masks_first`` polices the ordering)::
+
+    python3 resolve_e2e_tenant.py --matrix-json "$E2E_TENANT_MATRIX_JSON" --cloud "$E2E_CLOUD" --mask-only
+    python3 resolve_e2e_tenant.py --matrix-json "$E2E_TENANT_MATRIX_JSON" --cloud "$E2E_CLOUD" >> "$GITHUB_ENV"
+
+Fallback
+--------
+An empty ``--matrix-json`` (secret not shared with this repo) or an empty
+``--cloud`` (matrix leg with no cloud dimension) emits the ``--fallback-*``
+values instead, so a caller that has not adopted the tenant matrix keeps the
+pre-FND-6 single-tenant behaviour exactly. The fallback values come in as flags
+rather than being read from the environment so that both modes see identical
+inputs and the mask pass cannot diverge from the write pass.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from export_extra_env import ExtraEnvError, render, render_masks
+
+# The tenant entry's JSON keys, mapped to the environment variables the sdr-e2e
+# action and the pytest harness read. ATLAN_BASE_URL is NOT here: it is derived
+# from the tenant below rather than configured, so it can never name a different
+# tenant than SDR_TEST_TENANT does.
+_FIELD_TO_ENV = {
+    "tenant": "SDR_TEST_TENANT",
+    "client_id": "SDR_CLIENT_ID",
+    "client_secret": "SDR_CLIENT_SECRET",
+    "api_key": "ATLAN_API_KEY",
+}
+
+# Optional. Overrides BaseE2ETest.tenant_deployment_name, which resolves
+# "{deployment_name}" when the harness addresses a tenant's system apps. Absent
+# for a tenant that deploys them under the "production" default.
+_DEPLOYMENT_NAME_FIELD = "deployment_name"
+_DEPLOYMENT_NAME_ENV = "E2E_TENANT_DEPLOYMENT_NAME"
+
+# Values excluded from ::add-mask::. Everything else is masked, including the
+# tenant host and its derived base URL — those are secrets today and staying
+# masked is not a change in posture.
+#
+# The deployment name is not a credential, and masking it would be actively
+# harmful: it is a short common word ("production", "staging"), and the runner's
+# masker does substring replacement, so registering it redacts every unrelated
+# occurrence in the log — including the queue names an operator reads to work out
+# where a leg's activities went.
+_UNMASKED_ENV = frozenset({_DEPLOYMENT_NAME_ENV})
+
+
+class TenantMatrixError(ValueError):
+    """The tenant matrix payload or the requested cloud is not usable."""
+
+
+def _entry(matrix_json: str, cloud: str) -> dict[str, str]:
+    """Return the credential fields for *cloud* from the *matrix_json* map.
+
+    Every error message names cloud KEYS only, never a value: these strings are
+    printed to the CI log, and the values are credentials.
+    """
+    try:
+        parsed = json.loads(matrix_json)
+    except json.JSONDecodeError as exc:
+        raise TenantMatrixError(
+            f"E2E_TENANT_MATRIX_JSON is not valid JSON ({exc}). Expected an "
+            'object of {"<cloud>": {"tenant": …, "client_id": …, '
+            '"client_secret": …, "api_key": …}}.'
+        ) from exc
+    if not isinstance(parsed, dict):
+        raise TenantMatrixError(
+            "E2E_TENANT_MATRIX_JSON must be a JSON object keyed by cloud, got "
+            f"{type(parsed).__name__}."
+        )
+
+    if cloud not in parsed:
+        available = ", ".join(sorted(parsed)) or "none"
+        raise TenantMatrixError(
+            f"cloud {cloud!r} is not in E2E_TENANT_MATRIX_JSON (available: "
+            f"{available}). A cloud named in the workflow's e2e-clouds input "
+            "but missing from the secret is a coverage hole, not a leg to skip."
+        )
+
+    entry = parsed[cloud]
+    if not isinstance(entry, dict):
+        raise TenantMatrixError(
+            f"E2E_TENANT_MATRIX_JSON[{cloud!r}] must be an object, got "
+            f"{type(entry).__name__}."
+        )
+
+    missing = [
+        field for field in _FIELD_TO_ENV if not str(entry.get(field, "") or "").strip()
+    ]
+    if missing:
+        raise TenantMatrixError(
+            f"E2E_TENANT_MATRIX_JSON[{cloud!r}] is missing or blank for: "
+            f"{', '.join(missing)}."
+        )
+
+    resolved = {env: str(entry[field]) for field, env in _FIELD_TO_ENV.items()}
+    deployment_name = str(entry.get(_DEPLOYMENT_NAME_FIELD, "") or "").strip()
+    if deployment_name:
+        resolved[_DEPLOYMENT_NAME_ENV] = deployment_name
+    return resolved
+
+
+def resolve(
+    matrix_json: str,
+    cloud: str,
+    fallback: dict[str, str] | None = None,
+) -> dict[str, str]:
+    """Return the environment map for one matrix leg.
+
+    Takes the tenant matrix when both *matrix_json* and *cloud* are set, and the
+    *fallback* single-tenant values otherwise. ``ATLAN_BASE_URL`` is derived from
+    the resolved tenant in both paths, so it is always the same tenant as
+    ``SDR_TEST_TENANT`` — the property the pre-FND-6 job-level ``env:`` block
+    guaranteed by string-interpolating one from the other.
+    """
+    matrix_json = matrix_json.strip()
+    cloud = cloud.strip()
+
+    if matrix_json and cloud:
+        resolved = _entry(matrix_json, cloud)
+    else:
+        resolved = {k: v for k, v in (fallback or {}).items() if v}
+
+    tenant = resolved.get("SDR_TEST_TENANT", "").strip()
+    if not tenant:
+        raise TenantMatrixError(
+            "no e2e tenant resolved: E2E_TENANT_MATRIX_JSON is unset (or this "
+            "leg has no cloud) and the fallback SDR_TEST_TENANT is empty too. "
+            "Share the tenant-matrix secret with this repo, or set the legacy "
+            "single-tenant secrets."
+        )
+    resolved["ATLAN_BASE_URL"] = f"https://{tenant}"
+    return resolved
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--matrix-json",
+        default="",
+        help="E2E_TENANT_MATRIX_JSON: cloud -> credential map. Empty = fallback.",
+    )
+    parser.add_argument(
+        "--cloud",
+        default="",
+        help="Matrix leg's cloud key (aws/azure/gcp). Empty = fallback.",
+    )
+    parser.add_argument("--fallback-tenant", default="")
+    parser.add_argument("--fallback-client-id", default="")
+    parser.add_argument("--fallback-client-secret", default="")
+    parser.add_argument("--fallback-api-key", default="")
+    parser.add_argument(
+        "--mask-only",
+        action="store_true",
+        help=(
+            "Print only ::add-mask:: commands for the resolved values, and no "
+            "$GITHUB_ENV lines. Run this first, with stdout going to the log, "
+            "before the env-writing invocation redirects stdout into "
+            "$GITHUB_ENV. See export_extra_env for why the two are separate."
+        ),
+    )
+    args = parser.parse_args(sys.argv[1:] if argv is None else argv)
+
+    fallback = {
+        "SDR_TEST_TENANT": args.fallback_tenant,
+        "SDR_CLIENT_ID": args.fallback_client_id,
+        "SDR_CLIENT_SECRET": args.fallback_client_secret,
+        "ATLAN_API_KEY": args.fallback_api_key,
+    }
+
+    try:
+        resolved = resolve(args.matrix_json, args.cloud, fallback)
+    except TenantMatrixError as exc:
+        print(f"::error::{exc}", file=sys.stderr)
+        return 1
+
+    # Hand the rendering to export_extra_env so the heredoc form, the delimiter
+    # collision guard, and the per-line mask registration are the same audited
+    # code both call sites use. The mask pass sees a subset (see _UNMASKED_ENV);
+    # the env pass always writes everything.
+    try:
+        if args.mask_only:
+            secrets = {k: v for k, v in resolved.items() if k not in _UNMASKED_ENV}
+            sys.stdout.write(render_masks(json.dumps(secrets)))
+        else:
+            sys.stdout.write(render(json.dumps(resolved)))
+    except ExtraEnvError as exc:  # pragma: no cover - resolved names are ours
+        print(f"::error::{exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/tests/test_discover_e2e_suites.py
+++ b/.github/scripts/tests/test_discover_e2e_suites.py
@@ -11,11 +11,23 @@ import json
 import sys
 from pathlib import Path
 
+import pytest
+
 sys.path.insert(
     0, str(Path(__file__).parent.parent.parent / "actions" / "discover-e2e-suites")
 )
 
-from discover_e2e_suites import discover, main  # noqa: E402
+from discover_e2e_suites import (  # noqa: E402
+    DEFAULT_CLOUDS,
+    discover,
+    main,
+    parse_clouds,
+)
+
+
+def _matrix(out: str) -> dict:
+    line = next(ln for ln in out.splitlines() if ln.startswith("matrix="))
+    return json.loads(line[len("matrix=") :])
 
 
 def _mk(dir_: Path, *names: str) -> None:
@@ -70,7 +82,7 @@ def test_missing_dir_yields_no_entries(tmp_path: Path) -> None:
 def test_main_emits_matrix_and_count(capsys, tmp_path: Path) -> None:
     e2e = tmp_path / "tests" / "e2e"
     _mk(e2e, "test_one.py", "test_two.py")
-    rc = main(["--test-dir", str(e2e)])
+    rc = main(["--test-dir", str(e2e), "--clouds", "none"])
     out = capsys.readouterr().out
     assert rc == 0
     matrix_line = next(ln for ln in out.splitlines() if ln.startswith("matrix="))
@@ -83,7 +95,7 @@ def test_main_warns_on_nested_suites(capsys, tmp_path: Path) -> None:
     e2e = tmp_path / "tests" / "e2e"
     _mk(e2e, "test_flat.py")
     _mk(e2e / "sub", "test_nested.py")
-    rc = main(["--test-dir", str(e2e)])
+    rc = main(["--test-dir", str(e2e), "--clouds", "none"])
     captured = capsys.readouterr()
     assert rc == 0
     # Flat suite is in the matrix; nested one is NOT, but is warned about.
@@ -99,7 +111,7 @@ def test_main_warns_on_nested_suites(capsys, tmp_path: Path) -> None:
 def test_main_no_warning_when_flat_only(capsys, tmp_path: Path) -> None:
     e2e = tmp_path / "tests" / "e2e"
     _mk(e2e, "test_a.py", "test_b.py")
-    main(["--test-dir", str(e2e)])
+    main(["--test-dir", str(e2e), "--clouds", "none"])
     assert "::warning::" not in capsys.readouterr().err
 
 
@@ -110,5 +122,140 @@ def test_main_count_zero_for_empty(capsys, tmp_path: Path) -> None:
     out = capsys.readouterr().out
     assert rc == 0
     assert "count=0" in out
-    matrix_line = next(ln for ln in out.splitlines() if ln.startswith("matrix="))
-    assert json.loads(matrix_line[len("matrix=") :]) == {"include": []}
+    assert _matrix(out) == {"include": []}
+
+
+# ── Cross-CSP cloud dimension (FND-6) ────────────────────────────────────────
+
+
+def test_parse_clouds_orders_dedupes_and_drops_blanks() -> None:
+    assert parse_clouds("aws,azure,gcp") == ["aws", "azure", "gcp"]
+    # Caller order is preserved (not sorted), blanks and repeats are dropped.
+    assert parse_clouds(" GCP , aws ,,aws, ") == ["gcp", "aws"]
+
+
+@pytest.mark.parametrize("raw", ["", "   "])
+def test_empty_clouds_means_the_default_list_not_none(raw: str) -> None:
+    # An untouched GitHub input arrives as "". If that meant "no clouds", every
+    # app repo forwarding the dispatch input would silently opt out of the
+    # matrix — the exact regression this rounding prevents.
+    assert parse_clouds(raw) == list(DEFAULT_CLOUDS)
+
+
+@pytest.mark.parametrize("raw", ["none", "NONE", "  None  "])
+def test_none_sentinel_disables_the_cloud_dimension(raw: str) -> None:
+    assert parse_clouds(raw) == []
+
+
+def test_default_clouds_is_the_three_csps() -> None:
+    # Pinned so widening the fleet's default fan-out is a deliberate edit with a
+    # failing test, not a drive-by.
+    assert DEFAULT_CLOUDS == ("aws", "azure", "gcp")
+
+
+def test_no_clouds_reproduces_legacy_entry_shape(tmp_path: Path) -> None:
+    # The single-tenant fallback path must stay byte-identical: no `suite` or
+    # `cloud` keys, so matrix.cloud is empty and the tenant resolver falls back.
+    e2e = tmp_path / "tests" / "e2e"
+    _mk(e2e, "test_one.py")
+    assert discover(str(e2e)) == discover(str(e2e), []) == discover(str(e2e), None)
+    (entry,) = discover(str(e2e))
+    assert set(entry) == {"file", "name"}
+
+
+def test_clouds_cross_product_cardinality_and_order(tmp_path: Path) -> None:
+    e2e = tmp_path / "tests" / "e2e"
+    _mk(e2e, "test_one.py", "test_two.py")
+    entries = discover(str(e2e), ["aws", "azure", "gcp"])
+    # Suites outer, clouds inner.
+    assert [e["name"] for e in entries] == [
+        "one-aws",
+        "one-azure",
+        "one-gcp",
+        "two-aws",
+        "two-azure",
+        "two-gcp",
+    ]
+    assert all(e["suite"] in {"one", "two"} for e in entries)
+    assert {e["cloud"] for e in entries} == {"aws", "azure", "gcp"}
+
+
+def test_clouds_leg_names_stay_unique_when_suite_names_collide(
+    tmp_path: Path,
+) -> None:
+    # Both files sanitize to "a-b"; the de-dup suffix must survive the cross
+    # product or two legs would collide on artifact name AND Temporal queue.
+    e2e = tmp_path / "tests" / "e2e"
+    _mk(e2e, "test_a_b.py", "test_a-b.py")
+    names = [e["name"] for e in discover(str(e2e), ["aws", "gcp"])]
+    assert len(names) == len(set(names)) == 4
+
+
+def test_main_count_is_suites_and_leg_count_is_legs(capsys, tmp_path: Path) -> None:
+    e2e = tmp_path / "tests" / "e2e"
+    _mk(e2e, "test_one.py", "test_two.py")
+    rc = main(["--test-dir", str(e2e), "--clouds", "aws,azure,gcp"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    # count stays the SUITE count — the caller's "requested but nothing found"
+    # guard is about suites, not legs.
+    assert "count=2" in out.splitlines()
+    assert "leg-count=6" in out.splitlines()
+    assert len(_matrix(out)["include"]) == 6
+
+
+def test_main_logs_the_fan_out_explicitly(capsys, tmp_path: Path) -> None:
+    e2e = tmp_path / "tests" / "e2e"
+    _mk(e2e, "test_one.py")
+    main(["--test-dir", str(e2e), "--clouds", "aws,azure,gcp"])
+    err = capsys.readouterr().err
+    assert "3 cloud(s)" in err
+    assert "aws, azure, gcp" in err
+    assert "3 leg(s)" in err
+
+
+def test_main_zero_suites_with_clouds_still_counts_zero(capsys, tmp_path: Path) -> None:
+    e2e = tmp_path / "tests" / "e2e"
+    e2e.mkdir(parents=True)
+    main(["--test-dir", str(e2e), "--clouds", "aws,azure,gcp"])
+    out = capsys.readouterr().out
+    assert "count=0" in out.splitlines()
+    assert "leg-count=0" in out.splitlines()
+    assert _matrix(out) == {"include": []}
+
+
+def test_clouds_only_emits_cloud_dimension_without_files(
+    capsys, tmp_path: Path
+) -> None:
+    # --test-dir is not read in this mode; point it at a populated dir to prove
+    # the file dimension really is absent rather than coincidentally empty.
+    e2e = tmp_path / "tests" / "e2e"
+    _mk(e2e, "test_one.py", "test_two.py")
+    rc = main(["--test-dir", str(e2e), "--clouds", "aws,azure,gcp", "--clouds-only"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert _matrix(out) == {
+        "include": [
+            {"cloud": "aws", "name": "aws"},
+            {"cloud": "azure", "name": "azure"},
+            {"cloud": "gcp", "name": "gcp"},
+        ]
+    }
+    assert "count=3" in out.splitlines()
+    assert "leg-count=3" in out.splitlines()
+
+
+def test_clouds_only_with_none_is_empty(capsys, tmp_path: Path) -> None:
+    # count=0 is what tells e2e-full-reusable.yaml to fall back to its
+    # single-leg `{"include":[{}]}` matrix rather than running nothing.
+    rc = main(["--test-dir", str(tmp_path), "--clouds", "none", "--clouds-only"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert _matrix(out) == {"include": []}
+    assert "count=0" in out.splitlines()
+
+
+def test_clouds_only_with_empty_uses_the_default_list(capsys, tmp_path: Path) -> None:
+    main(["--test-dir", str(tmp_path), "--clouds", "", "--clouds-only"])
+    out = capsys.readouterr().out
+    assert [e["cloud"] for e in _matrix(out)["include"]] == list(DEFAULT_CLOUDS)

--- a/.github/scripts/tests/test_export_extra_env.py
+++ b/.github/scripts/tests/test_export_extra_env.py
@@ -579,9 +579,27 @@ _PROSE_ONLY_FILES = {".github/workflows/scripts-tests.yaml"}
 # contain literal `>> "$GITHUB_ENV"` invocations — in the module docstring's usage
 # example and in this file's parametrized fixtures — which are not comments and so
 # would be audited as unmasked call sites once the glob reaches .py files.
+#
+# resolve_e2e_tenant.py is the third: it `import`s this module in-process to reuse
+# `render`/`render_masks` rather than shelling out to it, so the ordering guarantee
+# for its own callers is enforced by its own two-mode CLI — audited by the twin
+# guard in test_resolve_e2e_tenant.py, which discovers *its* call sites the same
+# way this one does. Auditing it here would look for a shell invocation that does
+# not exist, and the `>> "$GITHUB_ENV"` lines in its docstring and its tests would
+# read as unmasked writes.
+#
 # Computed rather than spelled out: the paths cannot drift, and the exclusion
-# cannot quietly widen to cover some third file.
-_NOT_A_CALLER = frozenset({_MODULE_PATH.resolve(), Path(__file__).resolve()})
+# cannot quietly widen to cover some fourth file.
+_RESOLVE_TENANT_MODULE = _MODULE_PATH.parent / "resolve_e2e_tenant.py"
+_RESOLVE_TENANT_TESTS = Path(__file__).parent / "test_resolve_e2e_tenant.py"
+_NOT_A_CALLER = frozenset(
+    {
+        _MODULE_PATH.resolve(),
+        Path(__file__).resolve(),
+        _RESOLVE_TENANT_MODULE.resolve(),
+        _RESOLVE_TENANT_TESTS.resolve(),
+    }
+)
 
 
 def _live_mentions(text: str) -> list[str]:

--- a/.github/scripts/tests/test_resolve_e2e_tenant.py
+++ b/.github/scripts/tests/test_resolve_e2e_tenant.py
@@ -1,0 +1,353 @@
+"""Tests for .github/scripts/resolve_e2e_tenant.py."""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+_REPO_ROOT = _SCRIPTS_DIR.parents[1]
+_MODULE_PATH = _SCRIPTS_DIR / "resolve_e2e_tenant.py"
+
+# Plain sys.path insertion rather than importlib: the module under test itself
+# does `from export_extra_env import …`, so its sibling directory has to be
+# importable anyway — which is exactly what the runner gives it (sys.path[0] is
+# the script's own directory).
+sys.path.insert(0, str(_SCRIPTS_DIR))
+
+from resolve_e2e_tenant import TenantMatrixError, main, resolve  # noqa: E402
+
+_MATRIX = {
+    "aws": {
+        "tenant": "e2e-aws-main.example.com",
+        "client_id": "aws-client",
+        "client_secret": "aws-secret",
+        "api_key": "aws-key",
+    },
+    "azure": {
+        "tenant": "e2e-azure-main.example.com",
+        "client_id": "azure-client",
+        "client_secret": "azure-secret",
+        "api_key": "azure-key",
+    },
+    "gcp": {
+        "tenant": "e2e-gcp-main1.example.com",
+        "client_id": "gcp-client",
+        "client_secret": "gcp-secret",
+        "api_key": "gcp-key",
+        "deployment_name": "staging",
+    },
+}
+
+_FALLBACK = {
+    "SDR_TEST_TENANT": "legacy.example.com",
+    "SDR_CLIENT_ID": "legacy-client",
+    "SDR_CLIENT_SECRET": "legacy-secret",
+    "ATLAN_API_KEY": "legacy-key",
+}
+
+
+def _json(matrix: object = None) -> str:
+    return json.dumps(_MATRIX if matrix is None else matrix)
+
+
+def _parse_env(rendered: str) -> dict[str, str]:
+    """Parse the ``NAME<<delim\\nvalue\\ndelim`` heredoc blocks back to a dict."""
+    out: dict[str, str] = {}
+    lines = rendered.split("\n")
+    i = 0
+    while i < len(lines):
+        if "<<" not in lines[i]:
+            i += 1
+            continue
+        name, delimiter = lines[i].split("<<", 1)
+        j = i + 1
+        value: list[str] = []
+        while lines[j] != delimiter:
+            value.append(lines[j])
+            j += 1
+        out[name] = "\n".join(value)
+        i = j + 1
+    return out
+
+
+# ── resolve() ────────────────────────────────────────────────────────────────
+
+
+def test_selects_the_requested_cloud() -> None:
+    assert resolve(_json(), "azure") == {
+        "SDR_TEST_TENANT": "e2e-azure-main.example.com",
+        "SDR_CLIENT_ID": "azure-client",
+        "SDR_CLIENT_SECRET": "azure-secret",
+        "ATLAN_API_KEY": "azure-key",
+        "ATLAN_BASE_URL": "https://e2e-azure-main.example.com",
+    }
+
+
+def test_other_clouds_credentials_never_appear() -> None:
+    """Least privilege: a leg must not carry the other tenants' credentials."""
+    rendered = json.dumps(resolve(_json(), "aws"))
+    for cloud in ("azure", "gcp"):
+        for value in _MATRIX[cloud].values():
+            assert value not in rendered
+
+
+def test_base_url_is_derived_from_the_resolved_tenant() -> None:
+    # Never configured separately: ATLAN_BASE_URL cannot name a different tenant
+    # than SDR_TEST_TENANT, which is what the pre-FND-6 env: block guaranteed.
+    for cloud in _MATRIX:
+        env = resolve(_json(), cloud)
+        assert env["ATLAN_BASE_URL"] == f"https://{env['SDR_TEST_TENANT']}"
+
+
+def test_optional_deployment_name_is_emitted_only_when_present() -> None:
+    assert resolve(_json(), "gcp")["E2E_TENANT_DEPLOYMENT_NAME"] == "staging"
+    assert "E2E_TENANT_DEPLOYMENT_NAME" not in resolve(_json(), "aws")
+
+
+def test_blank_deployment_name_is_treated_as_absent() -> None:
+    matrix = {"aws": {**_MATRIX["aws"], "deployment_name": "  "}}
+    assert "E2E_TENANT_DEPLOYMENT_NAME" not in resolve(_json(matrix), "aws")
+
+
+@pytest.mark.parametrize("cloud", ["", "   "])
+def test_empty_cloud_falls_back_to_the_single_tenant(cloud: str) -> None:
+    env = resolve(_json(), cloud, _FALLBACK)
+    assert env["SDR_TEST_TENANT"] == "legacy.example.com"
+    assert env["ATLAN_BASE_URL"] == "https://legacy.example.com"
+
+
+@pytest.mark.parametrize("matrix_json", ["", "   "])
+def test_empty_matrix_falls_back_to_the_single_tenant(matrix_json: str) -> None:
+    env = resolve(matrix_json, "aws", _FALLBACK)
+    assert env["SDR_TEST_TENANT"] == "legacy.example.com"
+    assert env["SDR_CLIENT_ID"] == "legacy-client"
+
+
+def test_unknown_cloud_is_an_error_not_a_skipped_leg() -> None:
+    # A typo in the e2e-clouds input must fail loudly. Quietly dropping the leg
+    # would show a green gate for coverage that never ran.
+    with pytest.raises(TenantMatrixError) as exc:
+        resolve(_json(), "aws-2", _FALLBACK)
+    assert "aws, azure, gcp" in str(exc.value)
+
+
+@pytest.mark.parametrize("field", ["tenant", "client_id", "client_secret", "api_key"])
+def test_missing_or_blank_required_field_is_rejected(field: str) -> None:
+    matrix = {"aws": {**_MATRIX["aws"], field: ""}}
+    with pytest.raises(TenantMatrixError) as exc:
+        resolve(_json(matrix), "aws")
+    assert field in str(exc.value)
+
+    matrix = {"aws": {k: v for k, v in _MATRIX["aws"].items() if k != field}}
+    with pytest.raises(TenantMatrixError):
+        resolve(_json(matrix), "aws")
+
+
+def test_invalid_json_is_rejected() -> None:
+    with pytest.raises(TenantMatrixError):
+        resolve("{not json", "aws")
+
+
+def test_non_object_payloads_are_rejected() -> None:
+    with pytest.raises(TenantMatrixError):
+        resolve(json.dumps(["aws"]), "aws")
+    with pytest.raises(TenantMatrixError):
+        resolve(json.dumps({"aws": "e2e-aws.example.com"}), "aws")
+
+
+def test_no_tenant_anywhere_is_an_error() -> None:
+    with pytest.raises(TenantMatrixError) as exc:
+        resolve("", "", {})
+    assert "no e2e tenant resolved" in str(exc.value)
+
+
+def test_error_messages_never_carry_a_credential_value() -> None:
+    """These strings are printed to the CI log."""
+    secrets = [
+        v
+        for entry in _MATRIX.values()
+        for k, v in entry.items()
+        if k
+        != "tenant"  # the tenant host is named nowhere either, but is not a credential
+    ]
+    for bad in ("aws-2", "nope"):
+        with pytest.raises(TenantMatrixError) as exc:
+            resolve(_json(), bad, _FALLBACK)
+        for secret in secrets:
+            assert secret not in str(exc.value)
+
+
+# ── CLI ──────────────────────────────────────────────────────────────────────
+
+
+def test_main_writes_heredoc_env_lines(capsys) -> None:
+    rc = main(["--matrix-json", _json(), "--cloud", "gcp"])
+    assert rc == 0
+    env = _parse_env(capsys.readouterr().out)
+    assert env == {
+        "SDR_TEST_TENANT": "e2e-gcp-main1.example.com",
+        "SDR_CLIENT_ID": "gcp-client",
+        "SDR_CLIENT_SECRET": "gcp-secret",
+        "ATLAN_API_KEY": "gcp-key",
+        "E2E_TENANT_DEPLOYMENT_NAME": "staging",
+        "ATLAN_BASE_URL": "https://e2e-gcp-main1.example.com",
+    }
+
+
+def test_main_mask_only_emits_masks_and_no_env_lines(capsys) -> None:
+    rc = main(["--matrix-json", _json(), "--cloud", "aws", "--mask-only"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "<<" not in out, "--mask-only must not write $GITHUB_ENV lines"
+    masked = {ln[len("::add-mask::") :] for ln in out.splitlines()}
+    # Every resolved value is registered, including the derived base URL.
+    for value in resolve(_json(), "aws").values():
+        assert value in masked
+
+
+def test_deployment_name_is_written_but_not_masked(capsys) -> None:
+    # It is not a credential, and it is a short common word — the runner masks by
+    # substring, so registering "staging" would redact unrelated log text
+    # (including the queue names an operator reads to trace a leg).
+    main(["--matrix-json", _json(), "--cloud", "gcp", "--mask-only"])
+    masked = {ln[len("::add-mask::") :] for ln in capsys.readouterr().out.splitlines()}
+    assert "staging" not in masked
+    # Still masks the actual credentials on the same leg.
+    assert "gcp-secret" in masked
+
+    main(["--matrix-json", _json(), "--cloud", "gcp"])
+    assert _parse_env(capsys.readouterr().out)["E2E_TENANT_DEPLOYMENT_NAME"] == (
+        "staging"
+    )
+
+
+def test_main_fallback_flags_reproduce_the_single_tenant_shape(capsys) -> None:
+    rc = main(
+        [
+            "--matrix-json",
+            "",
+            "--cloud",
+            "",
+            "--fallback-tenant",
+            "legacy.example.com",
+            "--fallback-client-id",
+            "legacy-client",
+            "--fallback-client-secret",
+            "legacy-secret",
+            "--fallback-api-key",
+            "legacy-key",
+        ]
+    )
+    assert rc == 0
+    env = _parse_env(capsys.readouterr().out)
+    assert env == {**_FALLBACK, "ATLAN_BASE_URL": "https://legacy.example.com"}
+
+
+def test_main_reports_errors_as_workflow_commands(capsys) -> None:
+    rc = main(["--matrix-json", _json(), "--cloud", "bogus"])
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert captured.out == "", "nothing may reach $GITHUB_ENV on the error path"
+    assert captured.err.startswith("::error::")
+
+
+def test_mask_and_write_passes_agree_on_the_value_set(capsys) -> None:
+    """Every credential written to $GITHUB_ENV was registered by the mask pass.
+
+    azure carries no deployment_name, so here the two sets are exactly equal —
+    nothing is written that was not masked first.
+    """
+    main(["--matrix-json", _json(), "--cloud", "azure", "--mask-only"])
+    masked = {ln[len("::add-mask::") :] for ln in capsys.readouterr().out.splitlines()}
+    main(["--matrix-json", _json(), "--cloud", "azure"])
+    written = set(_parse_env(capsys.readouterr().out).values())
+    assert written <= masked
+
+
+# ── Call-site ordering guard (twin of test_export_extra_env's) ───────────────
+#
+# resolve_e2e_tenant.py has the same leak shape as export_extra_env.py: a call
+# site that keeps only the `>> "$GITHUB_ENV"` invocation puts unregistered
+# credentials into the environment of every later step. The guard there
+# discovers its callers rather than listing them; this one does the same for
+# this script, so a new caller is covered the day it is added.
+
+_CALL_SITE_INVOCATION = re.compile(
+    r"resolve_e2e_tenant\.py\"?[ \t]*\\\n"
+    r"(?:\s*--[a-z-]+[ \t]+\"?\$?\{?[^\n\"]*\"?[ \t]*\\\n)*"
+    r"\s*(?P<mode>--mask-only|>>[ \t]*\"\$GITHUB_ENV\")"
+)
+
+_SCRIPT_MENTION = "resolve_e2e_tenant"
+_CALL_SITE_SUFFIXES = ("*.y*ml", "*.sh", "*.py")
+# The script and this file are the implementation, not callers. So is
+# test_export_extra_env.py: it names this module in its own `_NOT_A_CALLER`
+# exclusion (the twin guard has to know this one exists), which is a live
+# non-comment mention but never an invocation.
+_NOT_A_CALLER = frozenset(
+    {
+        _MODULE_PATH.resolve(),
+        Path(__file__).resolve(),
+        (Path(__file__).parent / "test_export_extra_env.py").resolve(),
+    }
+)
+
+
+def _live_mentions(text: str) -> list[str]:
+    return [
+        line
+        for line in text.split("\n")
+        if _SCRIPT_MENTION in line and not line.lstrip().startswith("#")
+    ]
+
+
+def _call_site_files() -> list[Path]:
+    found: list[Path] = []
+    for pattern in _CALL_SITE_SUFFIXES:
+        for path in (_REPO_ROOT / ".github").rglob(pattern):
+            text = path.read_text()
+            if _SCRIPT_MENTION not in text:
+                continue
+            if path.resolve() in _NOT_A_CALLER:
+                continue
+            found.append(path)
+    assert found, "no call site found — did the script move or lose its callers?"
+    return sorted(set(found))
+
+
+def test_call_sites_are_the_expected_files() -> None:
+    """Fails loudly if a call site appears somewhere this PR did not audit."""
+    relative = {p.relative_to(_REPO_ROOT).as_posix() for p in _call_site_files()}
+    assert relative == {
+        ".github/workflows/e2e-full-reusable.yaml",
+        ".github/workflows/tests-reusable.yaml",
+    }
+
+
+def test_every_env_write_call_site_masks_first() -> None:
+    for path in _call_site_files():
+        text = path.read_text()
+        where = path.relative_to(_REPO_ROOT).as_posix()
+
+        calls = list(_CALL_SITE_INVOCATION.finditer(text))
+        live = [ln for ln in _live_mentions(text) if "resolve_e2e_tenant.py" in ln]
+        assert len(calls) == len(live), (
+            f"{where} names the script on {len(live)} non-comment line(s) but "
+            f"only {len(calls)} match a checkable invocation. Rewrite it in the "
+            "backslash-continued flag shape, or teach _CALL_SITE_INVOCATION the "
+            f"new shape. Unreadable lines: {live}"
+        )
+
+        modes = ["mask" if c["mode"] == "--mask-only" else "write" for c in calls]
+        assert modes, f"{where} has no recognisable invocation"
+        assert len(modes) % 2 == 0, f"{where} has an unpaired invocation: {modes}"
+        assert modes == ["mask", "write"] * (len(modes) // 2), (
+            f"{where} does not mask before writing $GITHUB_ENV: {modes}. Values "
+            "written to $GITHUB_ENV before ::add-mask:: registers them leak in "
+            "cleartext from the next step that renders its env: group."
+        )

--- a/.github/scripts/tests/test_resolve_e2e_tenant.py
+++ b/.github/scripts/tests/test_resolve_e2e_tenant.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import re
 import sys
 from pathlib import Path
 
@@ -276,12 +275,19 @@ def test_mask_and_write_passes_agree_on_the_value_set(capsys) -> None:
 # credentials into the environment of every later step. The guard there
 # discovers its callers rather than listing them; this one does the same for
 # this script, so a new caller is covered the day it is added.
+#
+# Where the two differ: export_extra_env's invocation is a fixed two-line shape,
+# so a regex reads it safely. This script takes a variable number of
+# backslash-continued flag lines, and the regex for that needs a repeated group
+# whose leading whitespace class overlaps the previous iteration's trailing one
+# — exponential backtracking (CodeQL py/redos, which flagged exactly that on the
+# first version of this guard). So the continuation is walked line by line
+# instead, which is linear and closer to what the shell does anyway.
 
-_CALL_SITE_INVOCATION = re.compile(
-    r"resolve_e2e_tenant\.py\"?[ \t]*\\\n"
-    r"(?:\s*--[a-z-]+[ \t]+\"?\$?\{?[^\n\"]*\"?[ \t]*\\\n)*"
-    r"\s*(?P<mode>--mask-only|>>[ \t]*\"\$GITHUB_ENV\")"
-)
+# How an invocation ends, and what that means. The write form is matched on the
+# exact redirect so a `>> "$SOMETHING_ELSE"` cannot pass as a masked write.
+_MASK_TOKEN = "--mask-only"
+_WRITE_TOKEN = '>> "$GITHUB_ENV"'
 
 _SCRIPT_MENTION = "resolve_e2e_tenant"
 _CALL_SITE_SUFFIXES = ("*.y*ml", "*.sh", "*.py")
@@ -304,6 +310,43 @@ def _live_mentions(text: str) -> list[str]:
         for line in text.split("\n")
         if _SCRIPT_MENTION in line and not line.lstrip().startswith("#")
     ]
+
+
+def _invocation_modes(text: str) -> list[tuple[str, str | None]]:
+    """Return ``(invoking line, "mask" | "write" | None)`` per invocation.
+
+    Line-oriented rather than a single regex. The invocation spans a variable
+    number of backslash-continued flag lines, and a regex for that shape needs a
+    repeated group whose leading whitespace class overlaps the previous
+    iteration's trailing one — ambiguity that backtracks exponentially on a
+    crafted input, which is what CodeQL's py/redos flagged on the first version
+    of this guard. Walking the continuation explicitly is linear, and it is a
+    closer description of what the shell actually does with a trailing ``\\``.
+
+    ``None`` means the invocation was found but its terminator was not
+    recognised; the caller fails on that rather than skipping it, so an
+    unparseable call site can never be silently treated as absent.
+    """
+    lines = text.split("\n")
+    out: list[tuple[str, str | None]] = []
+    for index, line in enumerate(lines):
+        if f"{_SCRIPT_MENTION}.py" not in line or line.lstrip().startswith("#"):
+            continue
+
+        # Consume the backslash continuation to find the line that terminates
+        # this command. Bounded by the file, so no unbounded scan.
+        cursor = index
+        while cursor < len(lines) - 1 and lines[cursor].rstrip().endswith("\\"):
+            cursor += 1
+        terminator = lines[cursor]
+
+        if _MASK_TOKEN in terminator:
+            out.append((line, "mask"))
+        elif _WRITE_TOKEN in terminator:
+            out.append((line, "write"))
+        else:
+            out.append((line, None))
+    return out
 
 
 def _call_site_files() -> list[Path]:
@@ -329,21 +372,37 @@ def test_call_sites_are_the_expected_files() -> None:
     }
 
 
-def test_every_env_write_call_site_masks_first() -> None:
+def _assert_call_sites_mask_first() -> None:
+    """The ordering audit, as a plain helper.
+
+    Extracted for the same reason as its twin in test_export_extra_env.py: the
+    negative test below asserts it raises, and calling a test function directly
+    would turn a fixture added later into a TypeError where an AssertionError
+    was expected.
+    """
     for path in _call_site_files():
         text = path.read_text()
         where = path.relative_to(_REPO_ROOT).as_posix()
 
-        calls = list(_CALL_SITE_INVOCATION.finditer(text))
-        live = [ln for ln in _live_mentions(text) if "resolve_e2e_tenant.py" in ln]
-        assert len(calls) == len(live), (
+        found = _invocation_modes(text)
+
+        # Parity, not just presence: every non-comment mention of the script has
+        # to belong to an invocation this guard could classify. Anything else
+        # would be *discovered* but silently unaudited.
+        unreadable = [line for line, mode in found if mode is None]
+        assert not unreadable, (
+            f"{where} invokes the script on {len(unreadable)} line(s) whose "
+            'terminator is neither --mask-only nor >> "$GITHUB_ENV". Rewrite '
+            "them in the backslash-continued flag shape, or teach "
+            f"_invocation_modes the new shape. Unreadable lines: {unreadable}"
+        )
+        live = [ln for ln in _live_mentions(text) if f"{_SCRIPT_MENTION}.py" in ln]
+        assert len(found) == len(live), (
             f"{where} names the script on {len(live)} non-comment line(s) but "
-            f"only {len(calls)} match a checkable invocation. Rewrite it in the "
-            "backslash-continued flag shape, or teach _CALL_SITE_INVOCATION the "
-            f"new shape. Unreadable lines: {live}"
+            f"only {len(found)} were parsed as invocations."
         )
 
-        modes = ["mask" if c["mode"] == "--mask-only" else "write" for c in calls]
+        modes = [mode for _line, mode in found]
         assert modes, f"{where} has no recognisable invocation"
         assert len(modes) % 2 == 0, f"{where} has an unpaired invocation: {modes}"
         assert modes == ["mask", "write"] * (len(modes) // 2), (
@@ -351,3 +410,65 @@ def test_every_env_write_call_site_masks_first() -> None:
             "written to $GITHUB_ENV before ::add-mask:: registers them leak in "
             "cleartext from the next step that renders its env: group."
         )
+
+
+def test_every_env_write_call_site_masks_first() -> None:
+    _assert_call_sites_mask_first()
+
+
+def _invocation(*flags: str, mode: str) -> str:
+    """A backslash-continued invocation, as it appears in a workflow `run:`."""
+    lines = ["          python3 scripts/resolve_e2e_tenant.py \\"]
+    lines += [f"            {flag} \\" for flag in flags]
+    lines.append(f"            {mode}")
+    return "\n".join(lines) + "\n"
+
+
+_WRITE_ONLY = _invocation('--matrix-json "$M"', '--cloud "$C"', mode=_WRITE_TOKEN)
+_INVERTED = _invocation('--matrix-json "$M"', mode=_WRITE_TOKEN) + _invocation(
+    '--matrix-json "$M"', mode=_MASK_TOKEN
+)
+_UNPARSEABLE = '          python3 resolve_e2e_tenant.py --matrix-json "$M" | tee out\n'
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected"),
+    [
+        pytest.param(_WRITE_ONLY, "unpaired invocation", id="write-with-no-mask"),
+        pytest.param(_INVERTED, "does not mask before writing", id="wrong-order"),
+        pytest.param(_UNPARSEABLE, "terminator is neither", id="unreadable-shape"),
+    ],
+)
+def test_a_leaky_caller_is_never_discovered_green(
+    payload: str, expected: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The guard must actually fail on the shapes it exists to catch.
+
+    Without this, a discovery predicate that quietly matched nothing would let
+    every real call site through with the suite still green — the failure mode
+    a discovery-based guard is most prone to.
+    """
+    workflows = tmp_path / ".github" / "workflows"
+    workflows.mkdir(parents=True)
+    (workflows / "leaky.yaml").write_text(
+        f"jobs:\n  x:\n    steps:\n      - run: |\n{payload}"
+    )
+    monkeypatch.setattr(sys.modules[__name__], "_REPO_ROOT", tmp_path)
+    with pytest.raises(AssertionError, match=expected):
+        _assert_call_sites_mask_first()
+
+
+def test_the_real_call_sites_are_what_the_negative_tests_model(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The correct shape passes — otherwise the tests above prove nothing."""
+    workflows = tmp_path / ".github" / "workflows"
+    workflows.mkdir(parents=True)
+    good = _invocation(
+        '--matrix-json "$M"', '--cloud "$C"', mode=_MASK_TOKEN
+    ) + _invocation('--matrix-json "$M"', '--cloud "$C"', mode=_WRITE_TOKEN)
+    (workflows / "good.yaml").write_text(
+        f"jobs:\n  x:\n    steps:\n      - run: |\n{good}"
+    )
+    monkeypatch.setattr(sys.modules[__name__], "_REPO_ROOT", tmp_path)
+    _assert_call_sites_mask_first()

--- a/.github/workflows/e2e-full-reusable.yaml
+++ b/.github/workflows/e2e-full-reusable.yaml
@@ -184,30 +184,117 @@ on:
         required: false
         type: boolean
         default: true
+      clouds:
+        description: |
+          Cross-CSP fan-out (FND-6). Comma-separated cloud keys; this workflow
+          runs once per cloud, against that cloud's tenant from the
+          E2E_TENANT_MATRIX_JSON secret. Unlike tests-reusable.yaml this
+          workflow targets a whole directory rather than fanning out per suite,
+          so the cloud is the only matrix dimension.
+
+          Empty (the default) means the SDK's current cloud list, which lives in
+          discover_e2e_suites.py's DEFAULT_CLOUDS. Pass "none" to collapse back
+          to the single legacy tenant. Forced to "none" when
+          E2E_TENANT_MATRIX_JSON is not available to the calling repo, which
+          keeps un-onboarded repos on today's behaviour.
+        required: false
+        type: string
+        default: ""
     secrets:
+      # Resolved per leg by .github/scripts/resolve_e2e_tenant.py — see the
+      # equivalent comment in tests-reusable.yaml for why the pointer is here
+      # rather than in the description.
+      E2E_TENANT_MATRIX_JSON:
+        description: |
+          Cross-CSP tenant map (FND-6): a JSON object keyed by cloud, each entry
+          carrying tenant / client_id / client_secret / api_key (plus an optional
+          deployment_name). See tests-reusable.yaml's secrets block for the full
+          rationale and shape.
+
+          Unset = the four single-tenant secrets below are used and the cloud
+          fan-out is skipped, which is exactly the pre-FND-6 behaviour.
+        required: false
+      # The four below were `required: true` before FND-6, when they were the
+      # only way to name a tenant. They are now the fallback for a caller that
+      # has not been granted the tenant map, so they cannot be mandatory —
+      # `required: true` would fail a matrix-configured caller at workflow-call
+      # validation, before any leg runs.
       SDR_TEST_TENANT:
-        description: Tenant FQDN (e.g. devex.atlan.com — no https:// prefix). ATLAN_BASE_URL is derived from this.
-        required: true
+        description: |
+          Single-tenant fallback FQDN (e.g. devex.atlan.com — no https:// prefix),
+          used when E2E_TENANT_MATRIX_JSON is unset. ATLAN_BASE_URL is derived
+          from whichever tenant resolves.
+        required: false
       SDR_CLIENT_ID:
-        description: OAuth client id — used by the configurator and for runtime auth (Temporal, objectstore).
-        required: true
+        description: OAuth client id — used by the configurator and for runtime auth (Temporal, objectstore). Fallback path.
+        required: false
       SDR_CLIENT_SECRET:
-        description: OAuth client secret matching SDR_CLIENT_ID.
-        required: true
+        description: OAuth client secret matching SDR_CLIENT_ID. Fallback path.
+        required: false
       ATLAN_API_KEY:
         description: |
           API key for AE-management calls (/automation/api/v1/*) and
-          pyatlan asset queries. Required because the API-key service
+          pyatlan asset queries. Needed because the API-key service
           account carries realm-admin which the OAuth client does not.
-        required: true
+          Fallback path.
+        required: false
 
 jobs:
+  # ── Plan the cloud fan-out ───────────────────────────────────────────────
+  # A strategy.matrix cannot read the `secrets` context, so whether the tenant
+  # map is available has to be decided in a job and handed down as an output.
+  # `--clouds-only` gives the cloud dimension without the per-suite one this
+  # workflow does not use.
+  plan-clouds:
+    name: Plan cloud matrix
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      matrix: ${{ steps.plan.outputs.matrix }}
+      count: ${{ steps.plan.outputs.count }}
+    env:
+      HAS_TENANT_MATRIX: ${{ secrets.E2E_TENANT_MATRIX_JSON != '' && 'true' || '' }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Plan clouds
+        id: plan
+        uses: atlanhq/application-sdk/.github/actions/discover-e2e-suites@main
+        with:
+          clouds-only: "true"
+          # Without the tenant map every leg would resolve the same fallback
+          # tenant, so N legs would masquerade as N clouds of coverage. Written
+          # negated for the same reason as in tests-reusable.yaml: "" is falsy in
+          # GitHub expressions, and it is the default here.
+          clouds: ${{ secrets.E2E_TENANT_MATRIX_JSON == '' && 'none' || inputs.clouds }}
+
+      - name: Warn that the cross-CSP matrix is unavailable
+        if: inputs.clouds != 'none' && env.HAS_TENANT_MATRIX == ''
+        shell: bash
+        run: |
+          echo "::warning::This run asked for the cross-CSP e2e matrix (clouds='${{ inputs.clouds }}'; empty means the SDK default list) but E2E_TENANT_MATRIX_JSON is not available to this repository, so it falls back to a single run against SDR_TEST_TENANT. Cross-CSP coverage for this run is NOT what the workflow asked for."
+
   e2e-full:
-    name: End-to-end
+    name: End-to-end${{ matrix.cloud && format(' ({0})', matrix.cloud) || '' }}
+    needs: plan-clouds
+    strategy:
+      # One cloud's tenant being down must not cancel the others; "Re-run failed
+      # jobs" then re-runs only that cloud.
+      fail-fast: false
+      # No clouds (no tenant map, or clouds: "none") still has to produce exactly
+      # one leg — the legacy single-tenant run — so the include-list falls back
+      # to a single entry with an empty `cloud`, which is precisely what makes
+      # the resolver take its fallback path. The key is spelled out rather than
+      # left as `{}` so the entry defines a matrix variable: `matrix.cloud` is
+      # then a defined-but-empty string in the job name and env below.
+      matrix: ${{ fromJson(needs.plan-clouds.outputs.count != '0' && needs.plan-clouds.outputs.matrix || '{"include":[{"cloud":""}]}') }}
     runs-on: ubuntu-latest
     timeout-minutes: ${{ inputs.timeout-minutes }}
     concurrency:
-      group: e2e-full-${{ github.workflow }}-${{ github.ref }}
+      # Per-cloud group: a shared group would serialise the legs.
+      group: e2e-full-${{ github.workflow }}-${{ github.ref }}-${{ matrix.cloud || 'default' }}
       cancel-in-progress: false
     permissions:
       pull-requests: write
@@ -215,12 +302,15 @@ jobs:
       statuses: write
       packages: write
     env:
-      SDR_TEST_TENANT: ${{ secrets.SDR_TEST_TENANT }}
-      SDR_CLIENT_ID: ${{ secrets.SDR_CLIENT_ID }}
-      SDR_CLIENT_SECRET: ${{ secrets.SDR_CLIENT_SECRET }}
-      ATLAN_API_KEY: ${{ secrets.ATLAN_API_KEY }}
-      # Derived so ATLAN_BASE_URL is always the same tenant as SDR_TEST_TENANT.
-      ATLAN_BASE_URL: https://${{ secrets.SDR_TEST_TENANT }}
+      # Written per-leg by the resolver step below rather than pinned here — see
+      # the equivalent block in tests-reusable.yaml for why there is exactly one
+      # writer of the tenant env.
+      E2E_TENANT_MATRIX_JSON: ${{ secrets.E2E_TENANT_MATRIX_JSON }}
+      E2E_CLOUD: ${{ matrix.cloud }}
+      FALLBACK_SDR_TEST_TENANT: ${{ secrets.SDR_TEST_TENANT }}
+      FALLBACK_SDR_CLIENT_ID: ${{ secrets.SDR_CLIENT_ID }}
+      FALLBACK_SDR_CLIENT_SECRET: ${{ secrets.SDR_CLIENT_SECRET }}
+      FALLBACK_ATLAN_API_KEY: ${{ secrets.ATLAN_API_KEY }}
     steps:
       # No-op step whose name correlates this dispatched run back to the SDK PR
       # that fired it. Nothing reads the step name: codex-/return-dispatch v3
@@ -234,6 +324,43 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+
+      # The tenant resolver is an SDK script, and this workflow runs in the
+      # caller's repo, so it has to be fetched. Sparse, so only .github/scripts
+      # lands. Pinned to job.workflow_sha for the same reason as the equivalent
+      # checkout in tests-reusable.yaml: a PR editing this workflow must run its
+      # own version of the script, not main's.
+      - name: Fetch SDK CI scripts (tenant resolution)
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: atlanhq/application-sdk
+          ref: ${{ job.workflow_sha }}
+          sparse-checkout: .github/scripts
+          sparse-checkout-cone-mode: false
+          path: application-sdk-scripts
+          persist-credentials: false
+
+      # This leg's tenant — see the equivalent step in tests-reusable.yaml for
+      # why it is two invocations and why the mask pass has to come first.
+      - name: Resolve e2e tenant for this leg
+        run: |
+          set -euo pipefail
+          python3 application-sdk-scripts/.github/scripts/resolve_e2e_tenant.py \
+            --matrix-json "$E2E_TENANT_MATRIX_JSON" \
+            --cloud "$E2E_CLOUD" \
+            --fallback-tenant "$FALLBACK_SDR_TEST_TENANT" \
+            --fallback-client-id "$FALLBACK_SDR_CLIENT_ID" \
+            --fallback-client-secret "$FALLBACK_SDR_CLIENT_SECRET" \
+            --fallback-api-key "$FALLBACK_ATLAN_API_KEY" \
+            --mask-only
+          python3 application-sdk-scripts/.github/scripts/resolve_e2e_tenant.py \
+            --matrix-json "$E2E_TENANT_MATRIX_JSON" \
+            --cloud "$E2E_CLOUD" \
+            --fallback-tenant "$FALLBACK_SDR_TEST_TENANT" \
+            --fallback-client-id "$FALLBACK_SDR_CLIENT_ID" \
+            --fallback-client-secret "$FALLBACK_SDR_CLIENT_SECRET" \
+            --fallback-api-key "$FALLBACK_ATLAN_API_KEY" \
+            >> "$GITHUB_ENV"
 
       - name: Resolve agent-name
         id: agent
@@ -265,6 +392,11 @@ jobs:
           # operators can watch the colour-emoji DAG progression
           # instead of waiting for a final dump.
           pytest-extra-args: "-s"
+          # Unique per-leg artifact name so parallel cloud legs don't collide on
+          # upload-artifact (which rejects duplicate names within a run). Empty
+          # on the single-tenant fallback, which keeps the pre-FND-6 artifact
+          # name and the bare `e2e-full-ci-<run_id>` deployment name.
+          artifact-suffix: ${{ matrix.cloud }}
           application-sdk-ref: ${{ inputs.application-sdk-ref }}
           runtime-sdk-ref: ${{ inputs.runtime-sdk-ref }}
           harness-sdk-ref: ${{ inputs.harness-sdk-ref }}

--- a/.github/workflows/tests-reusable.yaml
+++ b/.github/workflows/tests-reusable.yaml
@@ -120,6 +120,28 @@ on:
         type: boolean
         default: true
         description: Set to false to skip the e2e job entirely (e.g. hello-world).
+      e2e-clouds:
+        required: false
+        type: string
+        default: ""
+        description: |
+          Cross-CSP e2e fan-out (FND-6). Comma-separated cloud keys; every
+          discovered e2e suite runs once per cloud, against that cloud's tenant
+          from the E2E_TENANT_MATRIX_JSON secret. Each cloud is a required leg:
+          the matrix is fail-fast:false and Tests Gate reads the aggregate, so
+          any cloud failing reds the gate.
+
+          Empty (the default) means the SDK's current cloud list, which lives in
+          discover_e2e_suites.py's DEFAULT_CLOUDS — deliberately NOT restated
+          here, so adding a fourth CSP is one edit rather than one per repo, and
+          so an app forwarding an untouched dispatch input doesn't opt out of
+          the matrix by accident.
+
+          Narrow it to re-run one cloud ("aws"), or pass "none" to collapse back
+          to the single legacy tenant — the escape hatch when a tenant is down
+          and the fleet should not be blocked on it. Forced to "none" when
+          E2E_TENANT_MATRIX_JSON is not shared with the calling repo, which is
+          what keeps un-onboarded repos on their existing behaviour.
       timeout-minutes:
         required: false
         type: number
@@ -264,18 +286,47 @@ on:
           JSON rather than KEY=VALUE lines because a key-pair PEM or
           service-account key is multi-line. Connectors with a hermetic
           container source (the mysql shape) need none of this.
+      # Resolved per leg by .github/scripts/resolve_e2e_tenant.py. The pointer
+      # lives in a YAML comment rather than in the description below because
+      # test_resolve_e2e_tenant.py's call-site guard treats any non-comment
+      # mention of that script as an invocation it must be able to parse and
+      # check for mask-before-write ordering — deliberately, so a real caller can
+      # never hide behind prose.
+      E2E_TENANT_MATRIX_JSON:
+        required: false
+        description: |
+          Cross-CSP tenant map for the e2e matrix (FND-6): a JSON object keyed
+          by cloud, each entry carrying tenant / client_id / client_secret /
+          api_key (plus an optional deployment_name when the tenant's system
+          apps are not deployed under "production").
+
+              {"aws": {"tenant": "…", "client_id": "…", "client_secret": "…",
+                       "api_key": "…"}, "azure": {…}, "gcp": {…}}
+
+          One secret rather than four per cloud because a strategy.matrix value
+          cannot index the `secrets` context and this workflow declares its
+          workflow_call secrets explicitly — so per-cloud names would have to be
+          re-declared here for every cloud ever added. Same shape and same
+          masking protocol as E2E_SOURCE_ENV_JSON above; the resolver named in
+          the comment above extracts only the leg's own cloud, so a leg never
+          holds the other tenants' credentials.
+
+          Unset = the four single-tenant secrets below are used and the cloud
+          fan-out is skipped, which is exactly the pre-FND-6 behaviour.
       SDR_TEST_TENANT:
         required: false
-        description: CI test tenant host for the e2e job (also derives ATLAN_BASE_URL).
+        description: |
+          Single-tenant fallback host for the e2e job, used when
+          E2E_TENANT_MATRIX_JSON is unset (also derives ATLAN_BASE_URL).
       SDR_CLIENT_ID:
         required: false
-        description: OAuth client id the e2e worker authenticates to the tenant with.
+        description: OAuth client id the e2e worker authenticates to the tenant with (fallback path).
       SDR_CLIENT_SECRET:
         required: false
-        description: OAuth client secret paired with SDR_CLIENT_ID.
+        description: OAuth client secret paired with SDR_CLIENT_ID (fallback path).
       ATLAN_API_KEY:
         required: false
-        description: Tenant API key the e2e harness drives Automation Engine + Atlas with.
+        description: Tenant API key the e2e harness drives Automation Engine + Atlas with (fallback path).
       ORG_PAT_GITHUB:
         required: false
         description: |
@@ -491,12 +542,17 @@ jobs:
           force-external-runtime: ${{ inputs.force-external-runtime }}
           health-check-timeout-seconds: ${{ inputs.health-check-timeout-seconds }}
 
-  # ── Discover e2e suites → matrix ─────────────────────────────────────────
+  # ── Discover e2e suites × clouds → matrix ────────────────────────────────
   # Globs the connector's tests/e2e/test_*.py into a strategy.matrix so the
   # e2e job fans out one leg per suite (parallel, live per-job logs, per-suite
   # re-run, isolation). Connector-agnostic: the SDK never hard-codes a
   # connector's suites — the discovery script scans the checked-out tree.
   # Same label/dispatch gate the e2e job used to carry.
+  #
+  # Each suite is then crossed with `e2e-clouds` (FND-6), so every scenario runs
+  # against one tenant per CSP and cloud-specific behaviour — the objectstore
+  # binding atlan-configurator emits, blobstorage proxy behaviour, Temporal host
+  # resolution — is exercised before release rather than after.
   discover-e2e:
     name: Discover e2e suites
     runs-on: ubuntu-latest
@@ -516,6 +572,11 @@ jobs:
     outputs:
       matrix: ${{ steps.discover.outputs.matrix }}
       count: ${{ steps.discover.outputs.count }}
+      leg-count: ${{ steps.discover.outputs.leg-count }}
+    env:
+      # Job-level so the step-level `if:` below can read it — a step condition
+      # cannot reference the `secrets` context directly.
+      HAS_TENANT_MATRIX: ${{ secrets.E2E_TENANT_MATRIX_JSON != '' && 'true' || '' }}
     steps:
       # Human breadcrumb correlating this dispatched run back to the SDK PR that
       # fired it. Emitted here (the first job in the e2e path) so it is visible
@@ -536,6 +597,28 @@ jobs:
         uses: atlanhq/application-sdk/.github/actions/discover-e2e-suites@main
         with:
           test-dir: ${{ inputs.e2e-test-path }}
+          # The cloud dimension is only meaningful when the tenant map exists;
+          # without it every leg would resolve the same fallback tenant, so N
+          # identical runs would masquerade as N clouds of coverage. Collapsing
+          # to the legacy single leg is the honest degradation — and it is the
+          # warning below, not silence, that says so.
+          #
+          # Written `<no secret> && 'none' || <input>` rather than the more
+          # natural `<secret> && <input> || 'none'`: GitHub treats "" as falsy,
+          # so the natural form collapses the default (empty = SDK cloud list)
+          # into "none" and quietly disables the matrix on every un-customised
+          # caller. The negated form never evaluates the input for truthiness.
+          clouds: ${{ secrets.E2E_TENANT_MATRIX_JSON == '' && 'none' || inputs.e2e-clouds }}
+
+      # A repo that has not been granted the tenant-matrix secret silently gets
+      # one cloud's worth of coverage from a workflow that asked for three.
+      # Nothing downstream can tell the difference — the gate goes green either
+      # way — so say it out loud at the point the fan-out is decided.
+      - name: Warn that the cross-CSP matrix is unavailable
+        if: inputs.e2e-clouds != 'none' && env.HAS_TENANT_MATRIX == ''
+        shell: bash
+        run: |
+          echo "::warning::This run asked for the cross-CSP e2e matrix (e2e-clouds='${{ inputs.e2e-clouds }}'; empty means the SDK default list) but E2E_TENANT_MATRIX_JSON is not available to this repository, so it falls back to a single run against SDR_TEST_TENANT. Cross-CSP coverage for this run is NOT what the workflow asked for. Share the org secret with this repo to enable it."
 
       # This job only runs when e2e was explicitly requested (label / run-e2e),
       # so zero discovered suites means "requested but nothing found" — a
@@ -550,14 +633,20 @@ jobs:
           exit 1
 
   # ── Full-DAG e2e (system apps — extract→qi→publish→lineage) ─────────────
-  # One matrix leg per discovered suite. fail-fast:false so one suite's failure
-  # doesn't cancel the others, and "Re-run failed jobs" re-runs only the failed
-  # leg. Each leg spins its own worker container on its OWN Temporal queue: the
-  # sdr-e2e action derives a per-leg ATLAN_DEPLOYMENT_NAME (base + artifact-
-  # suffix) so legs don't co-serve one queue — under the two-store posture a
-  # shared queue lets Temporal split a workflow's activities across leg-workers
-  # with per-container localstorage, hiding artifacts cross-worker. 120-min
-  # timeout (> ae_poll + atlas_poll + build/setup overhead).
+  # One matrix leg per discovered suite × cloud. fail-fast:false so one leg's
+  # failure doesn't cancel the others, and "Re-run failed jobs" re-runs only the
+  # failed leg. Each leg spins its own worker container on its OWN Temporal
+  # queue: the sdr-e2e action derives a per-leg ATLAN_DEPLOYMENT_NAME (base +
+  # artifact-suffix) so legs don't co-serve one queue — under the two-store
+  # posture a shared queue lets Temporal split a workflow's activities across
+  # leg-workers with per-container localstorage, hiding artifacts cross-worker.
+  # 120-min timeout (> ae_poll + atlas_poll + build/setup overhead).
+  #
+  # The cloud rides in `matrix.name`, which is already the artifact suffix, the
+  # concurrency key and the job name — so adding the CSP dimension needed no new
+  # isolation machinery: deployment names, queues and artifact names all pick it
+  # up. Legs on different clouds hit different tenants (and therefore different
+  # Temporal servers) besides.
   e2e:
     name: End-to-end (${{ matrix.name }})
     needs: discover-e2e
@@ -581,12 +670,19 @@ jobs:
       statuses: write
       packages: write
     env:
-      SDR_TEST_TENANT: ${{ secrets.SDR_TEST_TENANT }}
-      SDR_CLIENT_ID: ${{ secrets.SDR_CLIENT_ID }}
-      SDR_CLIENT_SECRET: ${{ secrets.SDR_CLIENT_SECRET }}
-      ATLAN_API_KEY: ${{ secrets.ATLAN_API_KEY }}
-      # Derived so ATLAN_BASE_URL is always the same tenant as SDR_TEST_TENANT.
-      ATLAN_BASE_URL: https://${{ secrets.SDR_TEST_TENANT }}
+      # SDR_TEST_TENANT / SDR_CLIENT_ID / SDR_CLIENT_SECRET / ATLAN_API_KEY /
+      # ATLAN_BASE_URL are deliberately NOT set here any more. They are written
+      # per-leg by the resolver step below, from whichever source applies to this
+      # leg. Setting them here as well would leave the runner's job-env-versus-
+      # $GITHUB_ENV precedence load-bearing for whether a leg hits the right
+      # tenant — a silent wrong-tenant run is indistinguishable from a right one
+      # in the logs, since the host is masked. One writer, no precedence.
+      E2E_TENANT_MATRIX_JSON: ${{ secrets.E2E_TENANT_MATRIX_JSON }}
+      E2E_CLOUD: ${{ matrix.cloud }}
+      FALLBACK_SDR_TEST_TENANT: ${{ secrets.SDR_TEST_TENANT }}
+      FALLBACK_SDR_CLIENT_ID: ${{ secrets.SDR_CLIENT_ID }}
+      FALLBACK_SDR_CLIENT_SECRET: ${{ secrets.SDR_CLIENT_SECRET }}
+      FALLBACK_ATLAN_API_KEY: ${{ secrets.ATLAN_API_KEY }}
       GIT_LFS_SKIP_SMUDGE: ${{ inputs.git-lfs-skip-smudge && '1' || '' }}
       # See the integration job: needed as env for the step-level `if:` gates.
       E2E_SOURCE_ENV_JSON: ${{ secrets.E2E_SOURCE_ENV_JSON }}
@@ -601,12 +697,15 @@ jobs:
         with:
           persist-credentials: false
 
-      # Connector SOURCE credentials (E2E_SOURCE_ENV_JSON). Exported here rather
-      # than passed to the composite action below, because every action this
-      # workflow calls is pinned @main: an input added on a feature branch is
-      # silently ignored until it lands. Sparse-checks-out only .github/scripts.
-      - name: Fetch SDK CI scripts (source-credential export)
-        if: env.E2E_SOURCE_ENV_JSON != ''
+      # SDK CI scripts. Used here rather than passing the payloads to the
+      # composite action below, because every action this workflow calls is
+      # pinned @main: an input added on a feature branch is silently ignored
+      # until it lands. Sparse-checks-out only .github/scripts.
+      #
+      # Unconditional since FND-6: resolve_e2e_tenant.py lives in the same sparse
+      # path and every leg needs it, whereas export_extra_env.py is only needed
+      # when the connector declares source credentials.
+      - name: Fetch SDK CI scripts (tenant resolution, source-credential export)
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: atlanhq/application-sdk
@@ -617,6 +716,36 @@ jobs:
           path: application-sdk-scripts
           token: ${{ secrets.ORG_PAT_GITHUB }}
           persist-credentials: false
+
+      # This leg's tenant. Takes E2E_TENANT_MATRIX_JSON[E2E_CLOUD] when both are
+      # set and the FALLBACK_* values otherwise, then writes SDR_TEST_TENANT,
+      # SDR_CLIENT_ID, SDR_CLIENT_SECRET, ATLAN_API_KEY and the derived
+      # ATLAN_BASE_URL — the env the sdr-e2e action and the pytest harness read.
+      # Must precede every step that touches the tenant, so it sits ahead of the
+      # source-credential export as well as the action itself.
+      #
+      # Two invocations for the same reason as the export below: `--mask-only`
+      # writes ::add-mask:: to the log, and the second call's stdout is the env
+      # file. Masks first, so nothing reaches $GITHUB_ENV before it is redactable.
+      - name: Resolve e2e tenant for this leg
+        run: |
+          set -euo pipefail
+          python3 application-sdk-scripts/.github/scripts/resolve_e2e_tenant.py \
+            --matrix-json "$E2E_TENANT_MATRIX_JSON" \
+            --cloud "$E2E_CLOUD" \
+            --fallback-tenant "$FALLBACK_SDR_TEST_TENANT" \
+            --fallback-client-id "$FALLBACK_SDR_CLIENT_ID" \
+            --fallback-client-secret "$FALLBACK_SDR_CLIENT_SECRET" \
+            --fallback-api-key "$FALLBACK_ATLAN_API_KEY" \
+            --mask-only
+          python3 application-sdk-scripts/.github/scripts/resolve_e2e_tenant.py \
+            --matrix-json "$E2E_TENANT_MATRIX_JSON" \
+            --cloud "$E2E_CLOUD" \
+            --fallback-tenant "$FALLBACK_SDR_TEST_TENANT" \
+            --fallback-client-id "$FALLBACK_SDR_CLIENT_ID" \
+            --fallback-client-secret "$FALLBACK_SDR_CLIENT_SECRET" \
+            --fallback-api-key "$FALLBACK_ATLAN_API_KEY" \
+            >> "$GITHUB_ENV"
 
       # See the integration job above for why this is two invocations, why the
       # `--mask-only` pass has to come first, and why `set -e` is explicit.

--- a/.github/workflows/tests-reusable.yaml
+++ b/.github/workflows/tests-reusable.yaml
@@ -714,7 +714,15 @@ jobs:
           sparse-checkout: .github/scripts
           sparse-checkout-cone-mode: false
           path: application-sdk-scripts
-          token: ${{ secrets.ORG_PAT_GITHUB }}
+          # Falls back to the run's own token because this step became
+          # unconditional. It used to run only when the caller declared
+          # E2E_SOURCE_ENV_JSON — a repo that already had ORG_PAT_GITHUB — so an
+          # empty PAT was unreachable; now every e2e leg hits it, and passing
+          # `token: ''` explicitly overrides checkout's own default and 403s on
+          # the clone. application-sdk is public, so github.token is sufficient
+          # and this is a strictly wider set of callers that can fetch, not a
+          # privilege escalation.
+          token: ${{ secrets.ORG_PAT_GITHUB || github.token }}
           persist-credentials: false
 
       # This leg's tenant. Takes E2E_TENANT_MATRIX_JSON[E2E_CLOUD] when both are

--- a/application_sdk/testing/e2e/base.py
+++ b/application_sdk/testing/e2e/base.py
@@ -201,6 +201,11 @@ class BaseE2ETest:
     # or the entrypoint name differs from the manifest subdir. Empty resolved value
     # => single-entrypoint app, no selector sent (AE fetches the bare manifest).
     entrypoint: ClassVar[str] = ""
+    # Deployment name the tenant's SYSTEM apps (publish, quality, lineage) are
+    # registered under, substituted for ``{deployment_name}`` when the harness
+    # addresses them. Read via :meth:`resolved_tenant_deployment_name` rather
+    # than directly, so a CI run against a tenant that diverges from
+    # "production" is an env var on that leg rather than a code change here.
     tenant_deployment_name: ClassVar[str] = "production"
     extract_workflow_type: ClassVar[str] = ""
     # Credential-config name for the ``credential-guid.credential-type`` routing
@@ -707,6 +712,26 @@ class BaseE2ETest:
         """
         return None
 
+    def resolved_tenant_deployment_name(self) -> str:
+        """Deployment name to substitute for ``{deployment_name}``.
+
+        ``E2E_TENANT_DEPLOYMENT_NAME`` wins over the :attr:`tenant_deployment_name`
+        class default when set. The class attribute is a property of the *suite*,
+        but the value it needs is a property of the *tenant* — and since FND-6 one
+        suite runs against several tenants in one CI run, so it cannot be fixed in
+        the class. A tenant whose system apps are not registered under
+        "production" is then a per-leg env var (supplied by the tenant-matrix
+        secret's optional ``deployment_name`` field) rather than an edit here.
+
+        Blank is treated as unset: an unset GitHub Actions env var arrives as an
+        empty string, and an empty deployment name would address ``atlan-publish-``
+        and fail far from its cause.
+        """
+        return (
+            os.environ.get("E2E_TENANT_DEPLOYMENT_NAME", "").strip()
+            or self.tenant_deployment_name
+        )
+
     def _resolved_entrypoint(self) -> str:
         """App-entrypoint for AE's manifest fetch: explicit ``entrypoint`` if set,
         else derived from ``manifest_path`` (``.../generated/<ep>/manifest.json`` ->
@@ -785,10 +810,12 @@ class BaseE2ETest:
                 location=str(path),
             )
 
+        deployment_name = self.resolved_tenant_deployment_name()
+
         def _sub_queue(node_name: str, raw: str) -> str:
             if node_name == "extract":
                 return extract_task_queue
-            return raw.replace("{deployment_name}", self.tenant_deployment_name)
+            return raw.replace("{deployment_name}", deployment_name)
 
         for name, node in dag.items():
             inputs = node.get("inputs")

--- a/application_sdk/testing/full_dag/base.py
+++ b/application_sdk/testing/full_dag/base.py
@@ -206,8 +206,10 @@ class BaseFullDAGE2ETest:
     # task queues of the qi / publish / lineage / lineage-publish
     # nodes (everything that's NOT the extract worker). Defaults to
     # ``production`` because the devex tenant's system apps listen on
-    # ``atlan-publish-production`` etc. Override for tenants that use
-    # a different deployment name.
+    # ``atlan-publish-production`` etc. Read via
+    # :meth:`resolved_tenant_deployment_name` rather than directly, so a
+    # tenant that uses a different deployment name is a per-leg env var
+    # rather than an override here.
     tenant_deployment_name: ClassVar[str] = "production"
 
     # Override when the connector's worker registers a non-default
@@ -387,6 +389,26 @@ class BaseFullDAGE2ETest:
             admin_roles=self.connection_admin_roles,
         )
 
+    def resolved_tenant_deployment_name(self) -> str:
+        """Deployment name to substitute for ``{deployment_name}``.
+
+        ``E2E_TENANT_DEPLOYMENT_NAME`` wins over the :attr:`tenant_deployment_name`
+        class default when set. The class attribute is a property of the *suite*,
+        but the value it needs is a property of the *tenant* — and since FND-6 one
+        suite runs against several tenants in one CI run, so it cannot be fixed in
+        the class. A tenant whose system apps are not registered under
+        "production" is then a per-leg env var (supplied by the tenant-matrix
+        secret's optional ``deployment_name`` field) rather than an edit here.
+
+        Blank is treated as unset: an unset GitHub Actions env var arrives as an
+        empty string, and an empty deployment name would address ``atlan-publish-``
+        and fail far from its cause.
+        """
+        return (
+            os.environ.get("E2E_TENANT_DEPLOYMENT_NAME", "").strip()
+            or self.tenant_deployment_name
+        )
+
     # ------------------------------------------------------------------
     # Seed DAG — loaded from the connector's manifest.json
     # ------------------------------------------------------------------
@@ -448,13 +470,15 @@ class BaseFullDAGE2ETest:
                 location=str(path),
             )
 
+        deployment_name = self.resolved_tenant_deployment_name()
+
         def _sub_queue(node_name: str, raw: str) -> str:
             if node_name == "extract":
                 # extract goes to the agent / CI worker queue; manifest's
                 # `{deployment_name}` template is irrelevant here because
                 # CI doesn't use the tenant's deployment identity.
                 return extract_task_queue
-            return raw.replace("{deployment_name}", self.tenant_deployment_name)
+            return raw.replace("{deployment_name}", deployment_name)
 
         # Pass 1: curly-brace `{...}` substitutions on the per-node
         # metadata (app_name, task_queue).

--- a/docs/standards/connector-ci-e2e.md
+++ b/docs/standards/connector-ci-e2e.md
@@ -96,6 +96,8 @@ jobs:
       agent-name-override:      # OPTIONAL. Default ci-<run_id>.
       application-sdk-ref:      # OPTIONAL. Cross-repo dispatch SDK pin.
       distinct-id:              # OPTIONAL. codex-/return-dispatch correlation id.
+      clouds:                   # OPTIONAL. Default "" = the SDK's cloud list.
+                                # See Cross-CSP matrix below; "none" disables it.
     secrets: inherit
 ```
 
@@ -103,11 +105,81 @@ Threaded secrets the reusable workflow expects on the caller side:
 
 | Secret | Required | Used by |
 |---|---|---|
-| `SDR_TEST_TENANT` | yes | configurator |
-| `SDR_CLIENT_ID` / `SDR_CLIENT_SECRET` | yes | configurator OAuth |
-| `ATLAN_BASE_URL` | yes | full-DAG harness |
-| `ATLAN_API_KEY` | yes | full-DAG AE-management (`/automation/api/v1/*`). Service account must carry `realm-admin` which the OAuth client does not. |
+| `E2E_TENANT_MATRIX_JSON` | for the cross-CSP matrix | Per-leg tenant + credentials. See [Cross-CSP matrix](#cross-csp-matrix). Org-level; shared with `application-sdk` and every `atlan-*-app`. |
+| `SDR_TEST_TENANT` | fallback only | configurator |
+| `SDR_CLIENT_ID` / `SDR_CLIENT_SECRET` | fallback only | configurator OAuth |
+| `ATLAN_API_KEY` | fallback only | full-DAG AE-management (`/automation/api/v1/*`). Service account must carry `realm-admin` which the OAuth client does not. |
 | `SDR_OAUTH_CLIENT_ID` / `SDR_OAUTH_CLIENT_SECRET` | no | Dapr S3 binding + pyatlan asset queries. Falls back to API-key when absent. |
+
+`ATLAN_BASE_URL` is **not** a secret you set: it is always derived as
+`https://<resolved tenant>` so it can never name a different tenant than the rest
+of the leg's credentials do.
+
+The four `SDR_*` / `ATLAN_API_KEY` entries were the only way to name a tenant
+before the cross-CSP matrix. They are now the fallback used when
+`E2E_TENANT_MATRIX_JSON` is not available to the repo, which is what keeps a
+repo that has not been onboarded running exactly as it did before.
+
+## Cross-CSP matrix
+
+Every e2e suite runs once per cloud provider, against that cloud's tenant, so
+CSP-specific behaviour — the objectstore binding `atlan-configurator` emits, the
+tenant's blobstorage proxy, Temporal host resolution — is exercised before
+release rather than after. This is FND-6.
+
+**The secret.** One org secret, `E2E_TENANT_MATRIX_JSON`, keyed by cloud:
+
+```json
+{
+  "aws":   {"tenant": "…", "client_id": "…", "client_secret": "…", "api_key": "…"},
+  "azure": {"tenant": "…", "client_id": "…", "client_secret": "…", "api_key": "…"},
+  "gcp":   {"tenant": "…", "client_id": "…", "client_secret": "…", "api_key": "…"}
+}
+```
+
+One secret rather than four per cloud because a `strategy.matrix` value cannot
+index the `secrets` context, and the reusable workflows declare their
+`workflow_call` secrets explicitly — so per-cloud names would have to be
+re-declared for every cloud ever added. Adding a fourth CSP is a secret edit and
+a one-line change to `DEFAULT_CLOUDS`; no app repo changes at all.
+
+Each entry may also carry `"deployment_name"` when that tenant's system apps
+(publish / quality / lineage) are not registered under `production`. It reaches
+the harness as `E2E_TENANT_DEPLOYMENT_NAME`, which
+`BaseE2ETest.resolved_tenant_deployment_name()` prefers over the class default.
+
+**Per-leg resolution.** `.github/scripts/resolve_e2e_tenant.py` extracts only the
+leg's own cloud and writes `SDR_TEST_TENANT`, `SDR_CLIENT_ID`,
+`SDR_CLIENT_SECRET`, `ATLAN_API_KEY` and the derived `ATLAN_BASE_URL` to
+`$GITHUB_ENV`. A leg therefore never holds the other tenants' credentials. It
+runs in two passes (`--mask-only`, then the env write) for the same reason
+`export_extra_env.py` does: registering the blob as a secret does not redact the
+values inside it.
+
+**Leg naming and isolation.** The cloud rides in the matrix leg `name`
+(`<suite>-<cloud>`), which is already the job name, the concurrency-group key and
+the `artifact-suffix` — and `artifact-suffix` is what `derive_deployment_name.py`
+folds into `ATLAN_DEPLOYMENT_NAME`. So queues, artifacts, concurrency and job
+names all pick up the cloud with no new machinery.
+
+**Selecting clouds.** `e2e-clouds` on `tests-reusable.yaml` (`clouds` on
+`e2e-full-reusable.yaml`), surfaced as the `e2e_clouds` `workflow_dispatch` input
+on each app's `tests.yaml`:
+
+| Value | Meaning |
+|---|---|
+| `""` (default) | The SDK's current list — `DEFAULT_CLOUDS` in `discover_e2e_suites.py`. Deliberately not "no clouds": an untouched GitHub input arrives as `""`, and that must not silently opt a repo out. |
+| `aws` (or any subset) | Just those clouds. Use this to re-run one cloud, or to keep the fleet moving while one tenant is down. |
+| `none` | No cloud dimension — one leg against the single fallback tenant. |
+
+Every cloud is a **required** leg: the matrix is `fail-fast: false` and the Tests
+Gate reads `needs.e2e.result`, the matrix aggregate, so any cloud failing reds the
+gate. Narrowing `e2e-clouds` is the escape hatch, and trimming the secret to one
+key is the org-wide one.
+
+When the secret is not available to a repo, `clouds` is forced to `none` and the
+`Discover e2e suites` job emits a `::warning::` saying so — a run that asked for
+three clouds and got one must not look identical to one that got three.
 
 ## Cross-repo dispatch
 

--- a/docs/standards/testing.md
+++ b/docs/standards/testing.md
@@ -35,8 +35,12 @@
     the SDK provides hermetic paths for it (embedded Temporal, testcontainers,
     mocked infra) (T011).
   - **End-to-end** — the full pipeline including system apps, in SDR mode
-    against a real tenant. Needs only one representative run, not
-    scenario-level coverage (T012).
+    against a real tenant. Needs only one representative *scenario*, not
+    scenario-level coverage (T012) — but that scenario runs against one
+    tenant per cloud provider, because the CSP-specific parts of the stack
+    (the objectstore binding the configurator emits, blobstorage proxy
+    behaviour, Temporal host resolution) are exactly what no other tier
+    touches. See `docs/standards/connector-ci-e2e.md#cross-csp-matrix`.
   - **UI** — see above; front-end rendering bugs (lineage display,
     description fields) belong to the front-end team, so one connector
     proving the UI renders is sufficient — the rest validate data via API.

--- a/packages/conformance/conformance/bootstrap/templates/tests.yaml
+++ b/packages/conformance/conformance/bootstrap/templates/tests.yaml
@@ -67,6 +67,15 @@ on:
         required: false
         default: ""
         type: string
+      e2e_clouds:
+        description: |
+          Cloud providers to run the e2e suites against, comma-separated
+          (default aws,azure,gcp — every suite runs once per CSP tenant).
+          Narrow it to re-run a single cloud, e.g. when one tenant was down.
+          Empty here means "use the SDK default", not "no clouds".
+        required: false
+        default: ""
+        type: string
 
 jobs:
   tests:
@@ -93,6 +102,13 @@ jobs:
       run-e2e: ${{ inputs.run_e2e }}
       base-image-ref: ${{ inputs.base_image_ref }}
       agent-name-override: ${{ inputs.agent_name_override }}
+      # Cross-CSP e2e matrix (FND-6): every e2e suite runs once per cloud
+      # provider, against that cloud's tenant. Forwarded empty on every
+      # non-dispatch event, which the SDK reads as "use the current default
+      # cloud list" — so the list stays defined in application-sdk and this
+      # file never needs an edit when a fourth CSP is added. Pass "none" on a
+      # dispatch to fall back to the single legacy tenant.
+      e2e-clouds: ${{ inputs.e2e_clouds }}
       # ADR-0014 two-store SDR posture (docs/adr/0014-two-store-storage-
       # architecture.md in application-sdk): the e2e job's `objectstore`
       # is forced to the SDK-default CI-local binding and

--- a/tests/unit/testing/e2e/test_base_e2e.py
+++ b/tests/unit/testing/e2e/test_base_e2e.py
@@ -194,6 +194,42 @@ class TestSeedDagFromManifest:
         result = self.harness._seed_dag_from_manifest("atlan-openapi-agent-1")
         assert result["publish"]["inputs"]["task_queue"] == "atlan-publish-production"
 
+    def test_env_overrides_the_class_deployment_name(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A tenant whose system apps are not registered under "production" is a
+        # per-leg env var (from the cross-CSP tenant matrix), not a code change.
+        monkeypatch.setenv("E2E_TENANT_DEPLOYMENT_NAME", "staging")
+        dag = {
+            "publish": {
+                "node_type": "workflow",
+                "app_name": "publish",
+                "app_task_queue": "atlan-publish-{deployment_name}",
+                "inputs": {
+                    "task_queue": "atlan-publish-{deployment_name}",
+                    "args": {},
+                },
+            }
+        }
+        self.harness.manifest_path = str(_write_manifest(tmp_path, dag))  # type: ignore[attr-defined]
+        result = self.harness._seed_dag_from_manifest("atlan-openapi-agent-1")
+        assert result["publish"]["inputs"]["task_queue"] == "atlan-publish-staging"
+
+    @pytest.mark.parametrize("value", ["", "   "])
+    def test_blank_env_falls_back_to_the_class_default(
+        self, value: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # An unset GitHub Actions env var arrives as "", and an empty deployment
+        # name would address `atlan-publish-` and fail far from its cause.
+        monkeypatch.setenv("E2E_TENANT_DEPLOYMENT_NAME", value)
+        assert self.harness.resolved_tenant_deployment_name() == "production"
+
+    def test_unset_env_falls_back_to_the_class_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("E2E_TENANT_DEPLOYMENT_NAME", raising=False)
+        assert self.harness.resolved_tenant_deployment_name() == "production"
+
     def test_app_name_placeholder_substituted(self, tmp_path: Path) -> None:
         dag = {
             "extract": {

--- a/tests/unit/testing/full_dag/test_base.py
+++ b/tests/unit/testing/full_dag/test_base.py
@@ -218,6 +218,40 @@ def test_seed_dag_tenant_deployment_name_override(
     assert dag["publish"]["inputs"]["task_queue"] == "atlan-publish-staging"
 
 
+def test_seed_dag_env_overrides_tenant_deployment_name(
+    manifest_file: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``E2E_TENANT_DEPLOYMENT_NAME`` wins over the class default.
+
+    One suite now runs against several tenants in a single CI run, so the value
+    has to come from the leg rather than from the class.
+    """
+    _bootstrap_env(monkeypatch)
+    monkeypatch.setenv("E2E_TENANT_DEPLOYMENT_NAME", "staging")
+    cls = _make_test(str(manifest_file))
+    instance = cls()
+    instance.setup_method()
+
+    dag = instance._seed_dag_from_manifest(extract_task_queue="atlan-mysql-test")
+
+    assert dag["qi"]["inputs"]["task_queue"] == "atlan-query-intelligence-staging"
+    assert dag["publish"]["inputs"]["task_queue"] == "atlan-publish-staging"
+
+
+@pytest.mark.parametrize("value", ["", "   "])
+def test_blank_deployment_name_env_falls_back_to_the_class_default(
+    value: str, manifest_file: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # An unset GitHub Actions env var arrives as "", and an empty deployment
+    # name would address `atlan-publish-` and fail far from its cause.
+    _bootstrap_env(monkeypatch)
+    monkeypatch.setenv("E2E_TENANT_DEPLOYMENT_NAME", value)
+    instance = _make_test(str(manifest_file))()
+    instance.setup_method()
+
+    assert instance.resolved_tenant_deployment_name() == "production"
+
+
 def test_seed_dag_substitutes_mustache_placeholders(
     manifest_file: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
### Changelog

- Cross every discovered e2e suite with a cloud dimension, so each suite runs once per CSP against that cloud's tenant (`aws` / `azure` / `gcp`). Closes [FND-6](https://linear.app/atlan-epd/issue/FND-6/add-cross-csp-test-matrix-to-e2e-scaffold).
- `discover_e2e_suites.py`: new `--clouds` / `--clouds-only`, plus a `leg-count` output. Legs are named `<suite>-<cloud>`; `count` stays the *suite* count so the caller's "requested but nothing found" guard keeps its meaning.
- New `.github/scripts/resolve_e2e_tenant.py`: resolves one leg's tenant + credentials from a single org secret `E2E_TENANT_MATRIX_JSON`, keyed by cloud. Reuses `export_extra_env`'s audited two-pass masking rather than reimplementing it, and carries a twin call-site guard that discovers its own callers and fails if one writes `$GITHUB_ENV` without masking first.
- `tests-reusable.yaml`: new `e2e-clouds` input and `E2E_TENANT_MATRIX_JSON` secret; the four tenant secrets move out of the e2e job's `env:` and are written per-leg by the resolver.
- `e2e-full-reusable.yaml` (still live for `atlan-domo-app`): same treatment via a cloud-only `plan-clouds` matrix, plus `artifact-suffix: ${{ matrix.cloud }}` so parallel legs don't collide on `upload-artifact`.
- `tenant_deployment_name` moves behind `resolved_tenant_deployment_name()` / `E2E_TENANT_DEPLOYMENT_NAME`, with an optional `deployment_name` key per cloud in the secret.
- Scaffolded `tests.yaml` gains an `e2e_clouds` dispatch input (WARN-only C002 drift until repos re-bootstrap); docs updated in `connector-ci-e2e.md` and `testing.md`.

### Additional context

**Why one file covers the whole fleet.** `application-sdk` has no tenant-facing e2e of its own — `tests/e2e/` is a fixture scaffold. Its e2e signal is `pull_request.yaml`'s `connector-tests` job dispatching `tests.yaml` into the connector repos, and those `tests.yaml` files are conformance-scaffolded thin callers of `tests-reusable.yaml` with `secrets: inherit` and no tenant input. So the fan-out lands in `tests-reusable.yaml` and needs **no change in any app repo** — the scaffolded `e2e_clouds` input is a convenience for narrowing a dispatch, not a requirement.

**Why one JSON secret rather than four per cloud.** A `strategy.matrix` value cannot index the `secrets` context, and both reusables declare their `workflow_call` secrets explicitly — so per-cloud names would have to be re-declared in every reusable for every cloud ever added. One map-shaped secret matches the existing `E2E_SOURCE_ENV_JSON` precedent, and the resolver extracts only the leg's own cloud, so a leg never holds the other tenants' credentials.

**Seams worth a reviewer's attention:**

- The cloud rides in the matrix leg `name`, which was already the job name, the concurrency key, and the `artifact-suffix` that `derive_deployment_name.py` folds into `ATLAN_DEPLOYMENT_NAME`. Queue, artifact and concurrency isolation therefore picked up the new dimension with no new machinery, and T016/T017 stay satisfied.
- The tenant env now has exactly **one** writer. Layering the resolver on top of the old job-level `env:` would leave job-env-versus-`$GITHUB_ENV` precedence load-bearing for whether a leg hits the right tenant — and a wrong-tenant run is indistinguishable from a right one in a log where the host is masked.
- Empty `e2e-clouds` means **the default list, not "no clouds"**. An untouched GitHub input arrives as `""`; rounding that to "no clouds" would silently opt the fleet out. `"none"` is the explicit off switch. The list lives once, in `DEFAULT_CLOUDS`.
- The `clouds:` expression is written `<no secret> && 'none' || <input>` rather than the more natural inverse, because `""` is falsy in GitHub expressions and the natural form collapses the default into `none`.
- The `Fetch SDK CI scripts` checkout is now unconditional — the resolver lives in that sparse path and every leg needs it.

**Blocking prerequisite.** `E2E_TENANT_MATRIX_JSON` must be provisioned as an org secret and shared with `application-sdk` and every `atlan-*-app`, mapping each cloud to `{tenant, client_id, client_secret, api_key}` for `e2e-aws-main`, `e2e-azure-main` and `e2e-gcp-main1`. Until then every repo takes the single-tenant fallback and emits a `::warning::` saying the cross-CSP coverage is not what the workflow asked for.

> [!CAUTION]
> All three clouds are **required** legs from day one: the matrix is `fail-fast: false` and `Tests Gate` reads the aggregate. Azure and GCP have never carried this suite, so the first genuine cross-CSP gap will block every `e2e`-labelled connector PR in the fleet. Recommend dispatching `atlan-mysql-app`'s `tests.yaml` with `run_e2e=true` and `e2e_clouds=azure`, then `=gcp`, **before merging** — that surfaces any real nuance on one connector instead of the whole fleet. Escape hatches need no code change: narrow `e2e_clouds`, set it to `none`, or trim the secret to one key.

**Verification run locally:** 6172 unit tests, 3012 CI-script + conformance tests, `pre-commit run --all-files` clean. Matrix generation dry-run against `atlan-openapi-app/tests/e2e` yields the expected 2 suites × 3 clouds = 6 legs. Not yet exercised against a live tenant — that needs the secret.

### Checklist

- [x] Additional tests added
- [ ] All CI checks passed
- [x] Relevant documentation updated

---

### Copyleft License Compliance

- [ ] Have you used any code that is subject to a Copyleft license (e.g., GPL, AGPL, LGPL)?
- [ ] If yes, have you modified the code in the context of this project? please share additional details.
