### PR TITLE
ci(sdk-review): stop duplicate reviews and make @sdk-review non-destructive

### DIFF
--- a/.github/scripts/sdk_review_gate.py
+++ b/.github/scripts/sdk_review_gate.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Decide whether an `@sdk-review` trigger should dispatch a review.
+
+Every comment on a PR fires `sdk-review.yml`. Most are filtered by the job's
+`if:`, but one case survives it and costs a full review run: the resolver
+(`mothership-ai[bot]`) posts `@sdk-review` again on a HEAD that has already
+been reviewed. The PR then carries two summaries for the same sha, written by
+two runs, differing only in wording — indistinguishable to a reader from the
+duplicate a crashed-and-replayed run produces.
+
+A human tagging `@sdk-review` always dispatches, even on an unchanged HEAD:
+re-reading the same diff is a legitimate thing to ask for, and second-guessing
+it would make the tag feel broken.
+
+Decision logic lives here rather than inlined in the workflow, per
+docs/standards/ci.md.
+
+Environment:
+    REPO           owner/repo (e.g. atlanhq/application-sdk)
+    PR_NUMBER      pull request number
+    HEAD_SHA       40-char sha this trigger would review
+    EVENT_NAME     issue_comment | workflow_dispatch
+    TRIGGER_ACTOR  login of the commenter ("" for workflow_dispatch)
+    GH_TOKEN       consumed by `gh` for auth (not read here directly)
+    GITHUB_OUTPUT  path to the step-output file (optional; falls back to stdout)
+
+Outputs:
+    decision  proceed | skip
+    reason    machine-readable slug
+    message   one line suitable for a PR comment or a ::notice::
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+from collections.abc import Callable
+
+# Logins the workflow's `if:` lets through besides OWNER/MEMBER/COLLABORATOR
+# humans. These are the automated re-triggers worth gating.
+BOT_TRIGGERS = frozenset({"mothership-ai[bot]", "atlan-ci"})
+
+SUMMARY_MARKER = "<!-- SDK_REVIEW -->"
+REVIEWED_HEAD_RE = re.compile(r"<!--\s*REVIEWED_HEAD:\s*([0-9a-f]{40})\s*-->")
+
+Runner = Callable[..., subprocess.CompletedProcess]
+
+
+def fetch_comments(repo: str, pr_number: str, runner: Runner = subprocess.run) -> list[dict]:
+    """Every comment on the PR, or [] if the query fails.
+
+    `--slurp` returns one array per page wrapped in an outer array; it is used
+    instead of `--jq` deliberately. The naive `--jq '.[] | select(...) | .body'`
+    form collapses a multiline body to its first line, which for a review
+    summary is the HTML marker alone — the REVIEWED_HEAD stamp is on line 3 and
+    would be silently dropped.
+    """
+    result = runner(
+        [
+            "gh",
+            "api",
+            f"repos/{repo}/issues/{pr_number}/comments",
+            "--paginate",
+            "--slurp",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        print(f"::warning::could not list PR comments (exit {result.returncode}) — not gating")
+        return []
+    try:
+        pages = json.loads(result.stdout or "[]")
+    except json.JSONDecodeError as e:
+        print(f"::warning::could not parse PR comments ({e}) — not gating")
+        return []
+    comments: list[dict] = []
+    for page in pages:
+        # A single un-paginated response is a bare array of comments; --slurp
+        # wraps it in one more level. Tolerate both shapes.
+        if isinstance(page, list):
+            comments.extend(c for c in page if isinstance(c, dict))
+        elif isinstance(page, dict):
+            comments.append(page)
+    return comments
+
+
+def last_reviewed_head(comments: list[dict]) -> str | None:
+    """The REVIEWED_HEAD stamped by the most recent SDK review summary."""
+    for comment in reversed(comments):
+        body = comment.get("body") or ""
+        if SUMMARY_MARKER not in body:
+            continue
+        match = REVIEWED_HEAD_RE.search(body)
+        return match.group(1) if match else None
+    return None
+
+
+def decide(
+    event_name: str,
+    actor: str,
+    head_sha: str,
+    reviewed_head: str | None,
+) -> tuple[str, str, str]:
+    """Return (decision, reason, message)."""
+    if event_name != "issue_comment":
+        return "proceed", "manual-dispatch", "Manual dispatch — reviewing."
+    if actor not in BOT_TRIGGERS:
+        return "proceed", "human-trigger", f"Human trigger by @{actor} — reviewing."
+    if reviewed_head and head_sha and reviewed_head == head_sha:
+        return (
+            "skip",
+            "unchanged-head-bot-retrigger",
+            f"Skipping: `{head_sha[:7]}` already has an SDK review and this trigger came "
+            f"from @{actor}, not a human. Push a commit, or tag `@sdk-review` yourself to "
+            f"force a re-review.",
+        )
+    return "proceed", "bot-trigger-new-head", f"Bot trigger by @{actor} on a new HEAD — reviewing."
+
+
+def set_output(key: str, value: str) -> None:
+    path = os.environ.get("GITHUB_OUTPUT")
+    line = f"{key}={value}\n"
+    if path:
+        with open(path, "a") as handle:
+            handle.write(line)
+    else:
+        print(f"OUTPUT: {key}={value}")
+
+
+def main(runner: Runner = subprocess.run) -> int:
+    repo = os.environ.get("REPO", "")
+    pr_number = os.environ.get("PR_NUMBER", "")
+    head_sha = os.environ.get("HEAD_SHA", "")
+    event_name = os.environ.get("EVENT_NAME", "issue_comment")
+    actor = os.environ.get("TRIGGER_ACTOR", "")
+
+    reviewed_head: str | None = None
+    # Only a bot trigger can be gated, so skip the API call entirely otherwise.
+    if event_name == "issue_comment" and actor in BOT_TRIGGERS and repo and pr_number:
+        reviewed_head = last_reviewed_head(fetch_comments(repo, pr_number, runner))
+
+    decision, reason, message = decide(event_name, actor, head_sha, reviewed_head)
+
+    set_output("decision", decision)
+    set_output("reason", reason)
+    set_output("message", message)
+    print(f"::notice::sdk-review gate: {decision} ({reason}) — {message}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/sdk_review_gate.py
+++ b/.github/scripts/sdk_review_gate.py
@@ -48,7 +48,9 @@ REVIEWED_HEAD_RE = re.compile(r"<!--\s*REVIEWED_HEAD:\s*([0-9a-f]{40})\s*-->")
 Runner = Callable[..., subprocess.CompletedProcess]
 
 
-def fetch_comments(repo: str, pr_number: str, runner: Runner = subprocess.run) -> list[dict]:
+def fetch_comments(
+    repo: str, pr_number: str, runner: Runner = subprocess.run
+) -> list[dict]:
     """Every comment on the PR, or [] if the query fails.
 
     `--slurp` returns one array per page wrapped in an outer array; it is used
@@ -70,7 +72,9 @@ def fetch_comments(repo: str, pr_number: str, runner: Runner = subprocess.run) -
         check=False,
     )
     if result.returncode != 0:
-        print(f"::warning::could not list PR comments (exit {result.returncode}) — not gating")
+        print(
+            f"::warning::could not list PR comments (exit {result.returncode}) — not gating"
+        )
         return []
     try:
         pages = json.loads(result.stdout or "[]")
@@ -118,7 +122,11 @@ def decide(
             f"from @{actor}, not a human. Push a commit, or tag `@sdk-review` yourself to "
             f"force a re-review.",
         )
-    return "proceed", "bot-trigger-new-head", f"Bot trigger by @{actor} on a new HEAD — reviewing."
+    return (
+        "proceed",
+        "bot-trigger-new-head",
+        f"Bot trigger by @{actor} on a new HEAD — reviewing.",
+    )
 
 
 def set_output(key: str, value: str) -> None:

--- a/.github/scripts/tests/test_sdk_review_gate.py
+++ b/.github/scripts/tests/test_sdk_review_gate.py
@@ -1,0 +1,162 @@
+"""Tests for the @sdk-review re-trigger gate."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+SPEC = importlib.util.spec_from_file_location(
+    "sdk_review_gate", Path(__file__).resolve().parents[1] / "sdk_review_gate.py"
+)
+gate = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(gate)
+
+
+HEAD = "0cab6b6e4eff94f28f249e1319ab74d55e1f7abc"
+OTHER = "51c160b06a2a350289c7d779f4ab887503f98685"
+
+
+def summary(head: str) -> dict:
+    return {
+        "body": (
+            "<!-- SDK_REVIEW -->\n"
+            "<!-- VERDICT: READY_TO_MERGE -->\n"
+            f"<!-- REVIEWED_HEAD: {head} -->\n"
+            "## SDK Review (mothership)\n\n### Verdict: READY TO MERGE\n"
+        )
+    }
+
+
+def fake_runner(payload, returncode: int = 0):
+    def _run(*_args, **_kwargs):
+        return subprocess.CompletedProcess(
+            args=[], returncode=returncode, stdout=json.dumps(payload), stderr=""
+        )
+
+    return _run
+
+
+# --- decide() ------------------------------------------------------------
+
+
+def test_human_proceeds_even_when_head_already_reviewed():
+    decision, reason, _ = gate.decide("issue_comment", "vaibhavatlan", HEAD, HEAD)
+    assert decision == "proceed"
+    assert reason == "human-trigger"
+
+
+def test_bot_skips_when_head_already_reviewed():
+    decision, reason, _ = gate.decide("issue_comment", "mothership-ai[bot]", HEAD, HEAD)
+    assert decision == "skip"
+    assert reason == "unchanged-head-bot-retrigger"
+
+
+def test_bot_proceeds_when_head_moved():
+    decision, _, _ = gate.decide("issue_comment", "mothership-ai[bot]", HEAD, OTHER)
+    assert decision == "proceed"
+
+
+def test_bot_proceeds_when_pr_has_no_prior_review():
+    decision, _, _ = gate.decide("issue_comment", "mothership-ai[bot]", HEAD, None)
+    assert decision == "proceed"
+
+
+def test_manual_dispatch_always_proceeds():
+    decision, reason, _ = gate.decide("workflow_dispatch", "", HEAD, HEAD)
+    assert decision == "proceed"
+    assert reason == "manual-dispatch"
+
+
+def test_skip_message_names_the_escape_hatch():
+    _, _, message = gate.decide("issue_comment", "atlan-ci", HEAD, HEAD)
+    assert "@sdk-review" in message
+    assert HEAD[:7] in message
+
+
+# --- last_reviewed_head() ------------------------------------------------
+
+
+def test_reads_head_from_the_most_recent_summary():
+    comments = [summary(OTHER), {"body": "unrelated chatter"}, summary(HEAD)]
+    assert gate.last_reviewed_head(comments) == HEAD
+
+
+def test_ignores_non_summary_comments():
+    assert gate.last_reviewed_head([{"body": "@sdk-review"}, {"body": "lgtm"}]) is None
+
+
+def test_returns_none_when_summary_predates_the_marker():
+    """A summary from before REVIEWED_HEAD existed must not gate anything."""
+    assert gate.last_reviewed_head([{"body": "<!-- SDK_REVIEW -->\n## SDK Review"}]) is None
+
+
+def test_tolerates_missing_body_key():
+    assert gate.last_reviewed_head([{}, summary(HEAD)]) == HEAD
+
+
+# --- fetch_comments() ----------------------------------------------------
+
+
+def test_flattens_slurped_pages():
+    pages = [[summary(OTHER)], [summary(HEAD)]]
+    comments = gate.fetch_comments("o/r", "1", fake_runner(pages))
+    assert len(comments) == 2
+    assert gate.last_reviewed_head(comments) == HEAD
+
+
+def test_gh_failure_returns_empty_so_the_gate_fails_open():
+    assert gate.fetch_comments("o/r", "1", fake_runner([], returncode=1)) == []
+
+
+def test_malformed_json_returns_empty_so_the_gate_fails_open():
+    def _run(*_args, **_kwargs):
+        return subprocess.CompletedProcess(args=[], returncode=0, stdout="not json", stderr="")
+
+    assert gate.fetch_comments("o/r", "1", _run) == []
+
+
+def test_fail_open_means_a_bot_retrigger_still_reviews():
+    """An API outage must never silently stop reviews from running."""
+    reviewed = gate.last_reviewed_head(gate.fetch_comments("o/r", "1", fake_runner([], returncode=1)))
+    decision, _, _ = gate.decide("issue_comment", "mothership-ai[bot]", HEAD, reviewed)
+    assert decision == "proceed"
+
+
+# --- main() --------------------------------------------------------------
+
+
+def test_main_writes_outputs(tmp_path, monkeypatch: pytest.MonkeyPatch):
+    out = tmp_path / "gh_output"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(out))
+    monkeypatch.setenv("REPO", "atlanhq/application-sdk")
+    monkeypatch.setenv("PR_NUMBER", "2987")
+    monkeypatch.setenv("HEAD_SHA", HEAD)
+    monkeypatch.setenv("EVENT_NAME", "issue_comment")
+    monkeypatch.setenv("TRIGGER_ACTOR", "mothership-ai[bot]")
+
+    assert gate.main(fake_runner([[summary(HEAD)]])) == 0
+
+    written = out.read_text()
+    assert "decision=skip" in written
+    assert "reason=unchanged-head-bot-retrigger" in written
+
+
+def test_main_does_not_query_github_for_a_human_trigger(tmp_path, monkeypatch: pytest.MonkeyPatch):
+    """The gate must cost nothing on the common path."""
+    monkeypatch.setenv("GITHUB_OUTPUT", str(tmp_path / "gh_output"))
+    monkeypatch.setenv("REPO", "atlanhq/application-sdk")
+    monkeypatch.setenv("PR_NUMBER", "2987")
+    monkeypatch.setenv("HEAD_SHA", HEAD)
+    monkeypatch.setenv("EVENT_NAME", "issue_comment")
+    monkeypatch.setenv("TRIGGER_ACTOR", "vaibhavatlan")
+
+    def _explode(*_args, **_kwargs):
+        raise AssertionError("gate queried GitHub on a human trigger")
+
+    assert gate.main(_explode) == 0
+    assert "decision=proceed" in (tmp_path / "gh_output").read_text()

--- a/.github/scripts/tests/test_sdk_review_gate.py
+++ b/.github/scripts/tests/test_sdk_review_gate.py
@@ -92,7 +92,10 @@ def test_ignores_non_summary_comments():
 
 def test_returns_none_when_summary_predates_the_marker():
     """A summary from before REVIEWED_HEAD existed must not gate anything."""
-    assert gate.last_reviewed_head([{"body": "<!-- SDK_REVIEW -->\n## SDK Review"}]) is None
+    assert (
+        gate.last_reviewed_head([{"body": "<!-- SDK_REVIEW -->\n## SDK Review"}])
+        is None
+    )
 
 
 def test_tolerates_missing_body_key():
@@ -115,14 +118,18 @@ def test_gh_failure_returns_empty_so_the_gate_fails_open():
 
 def test_malformed_json_returns_empty_so_the_gate_fails_open():
     def _run(*_args, **_kwargs):
-        return subprocess.CompletedProcess(args=[], returncode=0, stdout="not json", stderr="")
+        return subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="not json", stderr=""
+        )
 
     assert gate.fetch_comments("o/r", "1", _run) == []
 
 
 def test_fail_open_means_a_bot_retrigger_still_reviews():
     """An API outage must never silently stop reviews from running."""
-    reviewed = gate.last_reviewed_head(gate.fetch_comments("o/r", "1", fake_runner([], returncode=1)))
+    reviewed = gate.last_reviewed_head(
+        gate.fetch_comments("o/r", "1", fake_runner([], returncode=1))
+    )
     decision, _, _ = gate.decide("issue_comment", "mothership-ai[bot]", HEAD, reviewed)
     assert decision == "proceed"
 
@@ -146,7 +153,9 @@ def test_main_writes_outputs(tmp_path, monkeypatch: pytest.MonkeyPatch):
     assert "reason=unchanged-head-bot-retrigger" in written
 
 
-def test_main_does_not_query_github_for_a_human_trigger(tmp_path, monkeypatch: pytest.MonkeyPatch):
+def test_main_does_not_query_github_for_a_human_trigger(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+):
     """The gate must cost nothing on the common path."""
     monkeypatch.setenv("GITHUB_OUTPUT", str(tmp_path / "gh_output"))
     monkeypatch.setenv("REPO", "atlanhq/application-sdk")

--- a/.github/workflows/sdk-review.yml
+++ b/.github/workflows/sdk-review.yml
@@ -75,7 +75,14 @@ permissions:
   checks: write
 
 jobs:
-  sdk-review-dispatch:
+  # Cheap pre-flight: decide whether this trigger deserves a review at all,
+  # before spending a VPN connect and a sandbox on it. The only trigger this
+  # turns away is an automated re-request (`mothership-ai[bot]` / `atlan-ci`)
+  # for a HEAD that already carries an SDK review — the resolver does this a
+  # couple of minutes after a review lands, and the result is two summaries
+  # for one sha that read like a bug. A human tagging `@sdk-review` always
+  # reviews, unchanged HEAD or not.
+  gate:
     if: >-
       github.event_name == 'workflow_dispatch'
       || (
@@ -90,13 +97,58 @@ jobs:
         )
       )
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      decision: ${{ steps.gate.outputs.decision }}
+      reason: ${{ steps.gate.outputs.reason }}
+    steps:
+      - name: Checkout repo (for the gate script)
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Resolve PR head
+        id: head
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.issue.number || inputs.pr_number }}
+        run: |
+          set -euo pipefail
+          SHA=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.head.sha')
+          echo "head_sha=${SHA}" >> "$GITHUB_OUTPUT"
+
+      - name: Decide whether to review
+        id: gate
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.issue.number || inputs.pr_number }}
+          HEAD_SHA: ${{ steps.head.outputs.head_sha }}
+          EVENT_NAME: ${{ github.event_name }}
+          TRIGGER_ACTOR: ${{ github.event.comment.user.login }}
+        run: python3 .github/scripts/sdk_review_gate.py
+
+  sdk-review-dispatch:
+    needs: gate
+    if: needs.gate.outputs.decision == 'proceed'
+    runs-on: ubuntu-latest
     # Total budget: 5 min for orient + retries + dispatch.
     # The sandbox itself runs for up to 2h (max_timeout_seconds: 7200),
     # but `curl --max-time 7200` blocks this job for that duration.
     timeout-minutes: 130
     concurrency:
       group: sdk-review-${{ github.event.issue.number || inputs.pr_number }}
-      cancel-in-progress: true
+      # NEVER cancel a review that is already running. `cancel-in-progress: true`
+      # meant a second `@sdk-review` killed the first one mid-flight — on #2989 a
+      # human tag at 16:42 destroyed a run that was 28m23s in and had not yet
+      # posted. Worse, the replacement dispatched the SAME session id the
+      # terminator was tearing down, so it died 63s later with zero SSE events;
+      # the same collision produced "No conversation found with session" on #2987.
+      #
+      # With this false, GitHub keeps at most one run in progress and one
+      # pending per PR, and a newer trigger replaces the pending one — an
+      # effective cap of two, which is the behaviour we want: the in-flight
+      # review finishes and posts, the newest re-tag runs after it.
+      cancel-in-progress: false
     steps:
       - name: Checkout repo (for local globalprotect-connect action)
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -188,18 +240,25 @@ jobs:
       # session id silently fails to stop anything, which is exactly the
       # bug it exists to prevent. Compute once, read twice.
       #
-      # Deterministic on the PR head: a new commit produces a new HEAD_SHA
-      # → fresh sandbox; a re-trigger on the same HEAD resumes the same
-      # session (mothership serialises those on a per-session lock).
+      # Unique per run, not per HEAD. It used to end at HEAD_SHA_SHORT, so two
+      # triggers on an unchanged HEAD sent the same session id — and mothership
+      # reads a supplied session_id as a follow-up (`is_follow_up =
+      # request.session_id is not None`), so the second dispatch tried to RESUME
+      # a conversation that had been cancelled or had already finished. That is
+      # the "No conversation found with session" failure on #2987 and the
+      # zero-SSE death on #2989. GITHUB_RUN_ID makes every dispatch a fresh
+      # session; the HEAD stays in the id purely so the sandbox is legible in
+      # Cloudflare logs.
       - name: Compute mothership session id
         id: session
         env:
           PR_NUMBER: ${{ steps.parse.outputs.pr_number }}
           HEAD_SHA_SHORT: ${{ steps.pr.outputs.head_sha_short }}
           REPO_FULL_NAME: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
         run: |
           set -euo pipefail
-          echo "session_id=sdk-review-${REPO_FULL_NAME//\//-}-${PR_NUMBER}-${HEAD_SHA_SHORT}" >> "$GITHUB_OUTPUT"
+          echo "session_id=sdk-review-${REPO_FULL_NAME//\//-}-${PR_NUMBER}-${HEAD_SHA_SHORT}-${RUN_ID}" >> "$GITHUB_OUTPUT"
 
       - name: Post 'review starting' notice to PR
         id: starter

--- a/.github/workflows/sdk-review.yml
+++ b/.github/workflows/sdk-review.yml
@@ -795,15 +795,6 @@ jobs:
             if [ "${SUMMARY_COUNT:-0}" -gt 0 ]; then
               VERDICT_POSTED=1
             fi
-            # One trigger must produce exactly one summary. More than one means
-            # the run posted twice — mothership recovered a dropped stream by
-            # re-running the prompt from the top in the same sandbox, and the
-            # replay guard in ORCHESTRATION.md §6b did not stop it. This block
-            # only ever asked "is there at least one summary", so a double-post
-            # looked identical to a clean delivery. Surface it.
-            if [ "${SUMMARY_COUNT:-0}" -gt 1 ]; then
-              echo "::warning::PR #${PR_NUMBER} received ${SUMMARY_COUNT} SDK_REVIEW summaries from this single run — duplicate review (stream-recovery replay). Check the ORCHESTRATION.md §6b replay guard."
-            fi
           fi
 
           # Export the run summary fields BEFORE the failure checks below

--- a/.github/workflows/sdk-review.yml
+++ b/.github/workflows/sdk-review.yml
@@ -795,6 +795,15 @@ jobs:
             if [ "${SUMMARY_COUNT:-0}" -gt 0 ]; then
               VERDICT_POSTED=1
             fi
+            # One trigger must produce exactly one summary. More than one means
+            # the run posted twice — mothership recovered a dropped stream by
+            # re-running the prompt from the top in the same sandbox, and the
+            # replay guard in ORCHESTRATION.md §6b did not stop it. This block
+            # only ever asked "is there at least one summary", so a double-post
+            # looked identical to a clean delivery. Surface it.
+            if [ "${SUMMARY_COUNT:-0}" -gt 1 ]; then
+              echo "::warning::PR #${PR_NUMBER} received ${SUMMARY_COUNT} SDK_REVIEW summaries from this single run — duplicate review (stream-recovery replay). Check the ORCHESTRATION.md §6b replay guard."
+            fi
           fi
 
           # Export the run summary fields BEFORE the failure checks below

--- a/.mothership/pr-review/ORCHESTRATION.md
+++ b/.mothership/pr-review/ORCHESTRATION.md
@@ -196,16 +196,21 @@ BUDGET
     different wording from a single `@sdk-review` trigger, and the
     workflow's soft-success check passes because *a* summary exists.
 
-    The prior summary's footer carries the run URL that produced it
-    (§3e). If it is **this** run's URL, this process is a replay of work
-    that already landed:
+    Every summary's footer carries the run URL that produced it (§3e),
+    and §3f posts the summary **last**, after the inline comments and the
+    commit status — so a summary bearing this run's URL means this run's
+    submission completed in full. Check *every* summary on the PR, not
+    just the one 6b loaded: that one is only the latest, and an unrelated
+    review landing between the first pass and the replay would hide this
+    run's footer behind it.
 
     ```bash
     # GHA_RUN_URL is given in the session prompt — substitute it literally,
     # shell variables do not persist between Bash calls.
-    if grep -qF '<GHA_RUN_URL>' /tmp/PRIOR_REVIEW.md; then
-      echo "REPLAY: this run already posted its review summary"
-    fi
+    gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --paginate --slurp 2>/dev/null \
+      | jq -r '[.[][] | select(.body | contains("<!-- SDK_REVIEW -->")) | .body] | join("\n")' \
+      | grep -qF '<GHA_RUN_URL>' \
+      && echo "REPLAY: this run already posted its review summary"
     ```
 
     If that prints `REPLAY`, **stop the entire run here**: post nothing,
@@ -1335,9 +1340,17 @@ if [ "$review_scope" = "contract-toolkit" ] || [ "$review_scope" = "mixed-sdk-to
   done
 fi
 
-# Summary comment (the body built in 3a, including the
-# <!-- SDK_REVIEW --> marker and the <!-- REVIEW_DATA --> JSON):
-gh pr comment "$PR_NUMBER" --repo "$REPO" --body-file /tmp/review-summary.md
+# ORDER MATTERS — the summary comment goes LAST, after the inline
+# comments and the commit status.
+#
+# The summary is the completion signal that everything downstream keys
+# off: `sdk-review-approve-on-verdict.yml` fires on it, the workflow's
+# soft-success check treats its presence as "the review was delivered",
+# and the Phase 0 §6b replay guard reads its footer to decide whether a
+# recovered run has already done this work. Post it first and all three
+# read a partial submission — inline findings still unposted, status
+# unset — as a completed one. Posting it last makes its presence mean
+# what every consumer already assumes it means.
 
 # Inline finding comments — post one per finding via
 # `gh api repos/$REPO/pulls/$PR_NUMBER/comments` so each can target a
@@ -1355,6 +1368,10 @@ gh api "repos/$REPO/statuses/$HEAD_SHA" \
   -f state="$STATE" \
   -f description="$DESCRIPTION"
 # where STATE ∈ success|failure|pending and DESCRIPTION ≤ 140 chars
+
+# Summary comment (the body built in 3a, including the
+# <!-- SDK_REVIEW --> marker and the <!-- REVIEW_DATA --> JSON) — LAST:
+gh pr comment "$PR_NUMBER" --repo "$REPO" --body-file /tmp/review-summary.md
 ```
 
 Retry once on 5xx from the GitHub API. On 422 (malformed inline
@@ -1371,9 +1388,10 @@ Print: `[Phase 3 complete] Review submitted`
 
 ## If You Cannot Finish
 
-Always post the summary comment + set the commit status before
-exiting (see Phase 3f). A PR with no review comment
-and no status update is the worst outcome.
+Always set the commit status + post the summary comment before
+exiting (see Phase 3f — status first, summary last, same order as the
+happy path). A PR with no review comment and no status update is the
+worst outcome.
 
 Submit minimal:
 ```json

--- a/.mothership/pr-review/ORCHESTRATION.md
+++ b/.mothership/pr-review/ORCHESTRATION.md
@@ -185,6 +185,37 @@ BUDGET
     threads) the human's response, which materially changes what
     counts as a "new" finding vs a known-and-discussed one.
 
+    **Same-run replay guard — run this immediately after loading
+    `/tmp/PRIOR_REVIEW.md`, before anything else.** When the Claude
+    stream drops mid-run (sandbox VPN reconnect, container eviction,
+    transient API error), mothership recovers by re-running this prompt
+    **from the top in the same sandbox** — a fresh run, not a `--resume`.
+    If the first pass had already posted its summary, that retry loads
+    its own summary as `PRIOR_REVIEW`, sees an empty delta, and posts a
+    SECOND summary for the same HEAD. The PR then shows two reviews with
+    different wording from a single `@sdk-review` trigger, and the
+    workflow's soft-success check passes because *a* summary exists.
+
+    The prior summary's footer carries the run URL that produced it
+    (§3e). If it is **this** run's URL, this process is a replay of work
+    that already landed:
+
+    ```bash
+    # GHA_RUN_URL is given in the session prompt — substitute it literally,
+    # shell variables do not persist between Bash calls.
+    if grep -qF '<GHA_RUN_URL>' /tmp/PRIOR_REVIEW.md; then
+      echo "REPLAY: this run already posted its review summary"
+    fi
+    ```
+
+    If that prints `REPLAY`, **stop the entire run here**: post nothing,
+    set no commit status, resolve no threads, do not continue to Phase 1.
+    The review was already delivered by the pass that died.
+
+    Key the guard on the run URL, never on `HEAD_SHA` alone — a genuine
+    re-trigger against an unchanged HEAD comes from a *different* run and
+    must still produce a review.
+
 6c. **Compute the re-review delta (scope-cutter).** Each review summary
     stamps the HEAD it reviewed as `<!-- REVIEWED_HEAD: <sha> -->` (§3e).
     On a re-review, use it to scope Phase 1–2 to what actually changed —


### PR DESCRIPTION
## What's wrong with `@sdk-review` today

One afternoon, 100 workflow runs: 72 skipped (every PR comment fires the workflow), and of the 28 real runs **19 success, 6 failure, 3 cancelled**. The failures sit right after the cancels:

```
14:27:00  30918997754  cancelled   PR 2987
14:27:27  30919036793  failure     PR 2987   "Stream ended without a 'complete' event"
16:13:25  30928081968  cancelled   PR 2989   (killed at 28m23s)
16:42:07  30930397181  failure     PR 2989   "Stream ended without a single SSE event"
12:54:04  30911198028  failure     PR 2987
13:02:46  30911893062  failure     PR 2987   "No conversation found with sess…"
```

Four distinct defects.

### 1. A stream drop makes the run review twice

Mothership recovers a dropped Claude stream by re-running the prompt **from the top in the same sandbox** — a fresh run, not a `--resume`. Five sequential `run-claude` calls landed on one session for #2987, and two of them produced a review:

```
13:13:05 → 13:13:20   run 1   claude.complete after 15s
13:13:20 → 13:27:07   run 2   ← summary posted 13:24:59
13:27:08             [error] code=unknown message=
13:28:38 → 13:33:29   run 3   ← summary posted 13:32:58
13:33:30 → 13:34:56   run 4
13:35:58 → 13:37:18   run 5
```

The replayed pass loads its own 8-minute-old summary as `PRIOR_REVIEW`, computes an empty delta, and posts a "verification-only re-review". Both comments cite the same Actions run in their footer. Same shape on #2977 (run 30895011755).

**Fix** — `ORCHESTRATION.md` §6b: stop the run when any `<!-- SDK_REVIEW -->` summary on the PR carries this run's own `GHA_RUN_URL`. Keyed on the run URL, not `HEAD_SHA`, so a genuine re-trigger still reviews. Checks every summary, not just the latest one §6b loads.

**Fix** — `ORCHESTRATION.md` §3f: the summary is now posted **last**, after the inline comments and the commit status. Previously it went first, which made it a premature completion signal — a death in that window left findings unposted while the guard, `sdk-review-approve-on-verdict.yml` and the workflow's soft-success check all read it as done.

### 2. Tagging cancelled a review that was already running

`cancel-in-progress: true` meant a second `@sdk-review` killed the first. On #2989 a human tag at 16:42 destroyed a run 28m23s in that had not yet posted.

**Fix** — `cancel-in-progress: false`. GitHub then keeps at most one run in progress and one pending per PR, and a newer trigger replaces the pending one. The in-flight review finishes and posts; the newest re-tag runs after it. Effective cap of two per PR.

### 3. Re-triggers resumed a dead session

The session id ended at `HEAD_SHA_SHORT`, so two triggers on an unchanged HEAD sent the same id — and mothership reads a supplied `session_id` as a follow-up (`is_follow_up = request.session_id is not None`), so the second dispatch tried to resume a conversation that had just been cancelled or had already finished. That is `No conversation found with session` on #2987 and the zero-SSE death on #2989, 63 seconds after that run's own terminator cancelled that exact session.

**Fix** — the id now carries `GITHUB_RUN_ID`. Every dispatch is a fresh session.

### 4. The resolver re-requested reviews for an already-reviewed HEAD

`sdk-resolve` posts `@sdk-review` with no check that the current HEAD already has a review — on #2987 it did so two minutes after one landed, producing two summaries for the same sha from two runs (15:04, 15:12).

**Fix** — a new `gate` job runs `.github/scripts/sdk_review_gate.py` before any VPN or sandbox spend. Automated re-triggers (`mothership-ai[bot]`, `atlan-ci`) on an unchanged HEAD are turned away. **Humans always review**, unchanged HEAD or not — re-reading the same diff is a legitimate ask, and refusing it would make the tag feel broken. The gate fails open: an API outage lets the review run.

Decision logic is a tested Python driver per `docs/standards/ci.md`, not inlined branching. 16 tests; verified by mutation — inverting the skip rule, the human bypass, or the newest-summary selection each fails the suite.

## Out of scope

The retry itself is mothership-side (`harness/core/agents/ticket/agents/sandbox_agent.py`): a recoverable stream error re-runs the full original prompt, and the only guard is `got_result_event` ("did Claude finish?") — nothing asks "did the dying attempt already publish?". That recovery ladder was built for the Linear lane, where a re-run just appends to a ticket stream. This PR makes the reviewer idempotent against it; the durable fix belongs in mothership.

Also found while investigating, filed separately:
- §2b calls `gpt-5.3-codex` on `chat/completions`, which OpenAI rejects (`Use the v1/responses endpoint instead`). Every successful adversarial call is `call_type: aresponses` — the agent improvising around the documented instruction.
- Reviews print `Models: Claude Opus` while billing shows the lane running `moonshotai/kimi-k3` since #2985.