### PR TITLE
ci(tests): run the integration tier on PRs when there is no merge queue

### DIFF
--- a/.github/actions/verify-test-gate/action.yaml
+++ b/.github/actions/verify-test-gate/action.yaml
@@ -20,9 +20,19 @@ inputs:
   detect-integration-result:
     description: |
       needs.detect-integration.result (the suite-detection job gating the
-      integration tier). "skipped" (pull_request) and "success" are passes; a
-      "failure" must fail the gate rather than silently skip integration.
+      integration tier). "skipped" (no integration tier for this event) and
+      "success" are passes; a "failure" must fail the gate rather than silently
+      skip integration.
     required: true
+  detect-merge-queue-result:
+    description: |
+      needs.detect-merge-queue.result (decides whether the integration tier runs
+      in the merge queue or on the PR). "skipped" (non-PR events) and "success"
+      are passes; a "failure" must fail the gate rather than silently drop the
+      integration tier. Optional and defaults to "skipped" so callers pinned at
+      @main that have not yet added the job keep working unchanged.
+    required: false
+    default: skipped
   discover-e2e-result:
     description: needs.discover-e2e.result (skipped = e2e not requested).
     required: true
@@ -58,6 +68,7 @@ runs:
         UNIT_RESULT: ${{ inputs.unit-result }}
         INTEGRATION_RESULT: ${{ inputs.integration-result }}
         DETECT_INTEGRATION_RESULT: ${{ inputs.detect-integration-result }}
+        DETECT_MERGE_QUEUE_RESULT: ${{ inputs.detect-merge-queue-result }}
         DISCOVER_E2E_RESULT: ${{ inputs.discover-e2e-result }}
         E2E_RESULT: ${{ inputs.e2e-result }}
       run: |
@@ -66,5 +77,6 @@ runs:
           --unit "$UNIT_RESULT" \
           --integration "$INTEGRATION_RESULT" \
           --detect-integration "$DETECT_INTEGRATION_RESULT" \
+          --detect-merge-queue "$DETECT_MERGE_QUEUE_RESULT" \
           --discover-e2e "$DISCOVER_E2E_RESULT" \
           --e2e "$E2E_RESULT" >> "$GITHUB_OUTPUT"

--- a/.github/actions/verify-test-gate/verify_test_gate.py
+++ b/.github/actions/verify-test-gate/verify_test_gate.py
@@ -9,12 +9,18 @@ Gate passes iff:
 
   * ``unit`` tests succeeded (the per-commit tier; runs on every event), AND
   * ``detect-integration`` (the suite-detection job that gates the integration
-    tier) succeeded OR was skipped (skipped = pull_request; a *failed* detection
-    must not be indistinguishable from "no suite" — otherwise a checkout/glob
-    flake silently skips integration and greens the gate), AND
+    tier) succeeded OR was skipped (skipped = the tier does not apply to this
+    event; a *failed* detection must not be indistinguishable from "no suite" —
+    otherwise a checkout/glob flake silently skips integration and greens the
+    gate), AND
+  * ``detect-merge-queue`` (which decides whether the integration tier runs in
+    the merge queue or on the PR) succeeded OR was skipped (skipped = a non-PR
+    event, where the question does not arise). Same reasoning as above: a
+    *failed* detection drops the integration tier to a skip, so it must fail the
+    gate rather than green it, AND
   * ``integration`` tests succeeded OR were skipped (skipped is legitimate: the
-    job is skipped on pull_request — the unit tier is the PR signal — and when
-    the connector ships no integration suite), AND
+    job is skipped on pull_request when a merge queue will run it instead, and
+    when the connector ships no integration suite), AND
   * e2e discovery succeeded OR was skipped (skipped = e2e not requested; a
     *failed* discovery means e2e was requested but no suites were found), AND
   * the e2e matrix succeeded OR was skipped (matrix aggregate is success only
@@ -47,9 +53,19 @@ _OK_OPTIONAL = ("success", "skipped")
 
 
 def evaluate(
-    unit: str, integration: str, detect_integration: str, discover_e2e: str, e2e: str
+    unit: str,
+    integration: str,
+    detect_integration: str,
+    discover_e2e: str,
+    e2e: str,
+    detect_merge_queue: str = "skipped",
 ) -> list[str]:
-    """Return human-readable failure reasons (empty ⇒ the gate passes)."""
+    """Return human-readable failure reasons (empty ⇒ the gate passes).
+
+    ``detect_merge_queue`` is last and defaults to "skipped" because this driver
+    is consumed cross-repo via ``@main``: a required positional would break every
+    caller the instant it merged, before their workflows could update.
+    """
     errors: list[str] = []
     if unit != "success":
         errors.append(f"unit tests did not succeed (result={unit})")
@@ -61,6 +77,13 @@ def evaluate(
     if detect_integration not in _OK_OPTIONAL:
         errors.append(
             f"integration-suite detection did not succeed (result={detect_integration})"
+        )
+    # Same hole, one job upstream: detect-merge-queue decides whether the
+    # integration tier runs on the PR at all, so a failure there also drops the
+    # tier to a skip that the check below would read as a legitimate pass.
+    if detect_merge_queue not in _OK_OPTIONAL:
+        errors.append(
+            f"merge-queue detection did not succeed (result={detect_merge_queue})"
         )
     # Integration is optional-by-skip: the job is intentionally skipped on
     # pull_request and when the connector has no integration suite. Any result
@@ -90,16 +113,23 @@ def _unit_status(unit: str) -> str:
     return "❌ Failed"
 
 
-def _integration_status(integration: str, detect_integration: str) -> str:
+def _integration_status(
+    integration: str, detect_integration: str, detect_merge_queue: str = "skipped"
+) -> str:
     # A detection failure drops integration to a skip; surface that as a failure
     # rather than the benign "skipped" string, so the display never claims the
     # tier was cleanly skipped when detection actually broke.
+    if detect_merge_queue not in _OK_OPTIONAL:
+        return "❌ Merge-queue detection failed"
     if detect_integration not in _OK_OPTIONAL:
         return "❌ Integration-suite detection failed"
     if integration == "success":
         return "✅ Passed"
     if integration == "skipped":
-        return "⊘ Skipped — PRs, or no integration suite (runs in merge queue)"
+        # Two distinct reasons, and the difference matters to a reader deciding
+        # whether their change was actually exercised: a queue will run the tier
+        # on the batched merge, whereas "no suite" means it runs nowhere.
+        return "⊘ Skipped — no integration suite, or it runs in the merge queue"
     return "❌ Failed"
 
 
@@ -118,14 +148,23 @@ def _e2e_status(discover_e2e: str, e2e: str) -> str:
 
 
 def render(
-    unit: str, integration: str, detect_integration: str, discover_e2e: str, e2e: str
+    unit: str,
+    integration: str,
+    detect_integration: str,
+    discover_e2e: str,
+    e2e: str,
+    detect_merge_queue: str = "skipped",
 ) -> dict[str, str]:
     """Compute the gate's outputs: pass/fail + the display status strings."""
-    errors = evaluate(unit, integration, detect_integration, discover_e2e, e2e)
+    errors = evaluate(
+        unit, integration, detect_integration, discover_e2e, e2e, detect_merge_queue
+    )
     return {
         "passed": "true" if not errors else "false",
         "unit-status": _unit_status(unit),
-        "integration-status": _integration_status(integration, detect_integration),
+        "integration-status": _integration_status(
+            integration, detect_integration, detect_merge_queue
+        ),
         "e2e-status": _e2e_status(discover_e2e, e2e),
         "overall-status": "✅ All passed" if not errors else "❌ Some failed",
     }
@@ -139,6 +178,14 @@ def main(argv: list[str] | None = None) -> int:
         "--detect-integration",
         required=True,
         help="needs.detect-integration.result",
+    )
+    # Optional with a "skipped" default: this driver is consumed cross-repo at
+    # @main, so a required flag would break callers that have not yet wired the
+    # detect-merge-queue job.
+    parser.add_argument(
+        "--detect-merge-queue",
+        default="skipped",
+        help="needs.detect-merge-queue.result",
     )
     parser.add_argument(
         "--discover-e2e", required=True, help="needs.discover-e2e.result"
@@ -154,6 +201,7 @@ def main(argv: list[str] | None = None) -> int:
         args.detect_integration,
         args.discover_e2e,
         args.e2e,
+        args.detect_merge_queue,
     ):
         print(f"::error::{reason}", file=sys.stderr)
 
@@ -163,6 +211,7 @@ def main(argv: list[str] | None = None) -> int:
         args.detect_integration,
         args.discover_e2e,
         args.e2e,
+        args.detect_merge_queue,
     ).items():
         print(f"{key}={value}")
     return 0

--- a/.github/scripts/detect_merge_queue.py
+++ b/.github/scripts/detect_merge_queue.py
@@ -188,14 +188,13 @@ def detect(
         # Announce it. "Could not read the rulesets" and "this repo has no queue"
         # produce the same return value but mean very different things: the first
         # means a repo that DOES have a queue will also run integration on its
-        # PRs. Without this line that difference is invisible in the log, and the
-        # usual cause is a token without the scope to read rulesets
-        # (GITHUB_TOKEN cannot carry it — ORG_PAT_GITHUB is what makes detection
-        # authoritative), which is exactly the case worth noticing.
+        # PRs. Without this line that difference is invisible in the log.
         print(
             f"::warning::could not read rulesets for {repo} — assuming no merge "
             "queue, so the integration tier will run on this pull_request. If the "
-            "repo does have a queue, forward ORG_PAT_GITHUB via `secrets: inherit`.",
+            "repo does have a queue, check the token: reading rulesets needs only "
+            "repo read access, so this usually means GH_TOKEN was empty or "
+            "scope-limited rather than that the endpoint is admin-gated.",
             file=sys.stderr,
         )
         return False

--- a/.github/scripts/detect_merge_queue.py
+++ b/.github/scripts/detect_merge_queue.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""Decide whether a PR's base branch is governed by a GitHub merge queue.
+
+``tests-reusable.yaml`` runs the integration tier on the batched state that will
+actually land: ``merge_group`` / ``push``, never ``pull_request`` (the unit tier
+is the fast per-commit PR signal). That cadence only gates anything when the
+repo *has* a merge queue. On a consumer without one, the integration tier ran
+solely on ``push`` — i.e. after the merge, where a failure lands red on ``main``
+and blocks nobody. A fleet sweep found the majority of ``atlan-*-app`` consumers
+in exactly that state.
+
+This script closes the hole. It answers one question — "will this PR be merged
+through a queue?" — so the caller can pick the tier that gates *before* the
+merge either way:
+
+    merge queue present  ⇒ integration runs in the queue (unchanged cadence)
+    merge queue absent   ⇒ integration runs on the pull_request instead
+
+Detection reads repository **rulesets**: a ruleset is authoritative when it is
+``enforcement: active``, targets branches, carries a ``merge_queue`` rule, and
+its ``conditions.ref_name`` matches the PR's base branch. Matching is per-branch
+rather than per-repo on purpose — a repo can queue ``main`` while leaving a
+release branch unqueued.
+
+Classic branch protection (``required_merge_queue`` on
+``/branches/{branch}/protection``) is deliberately *not* consulted: a sweep of
+the ``atlan-*-app`` fleet found no consumer using classic protection at all
+(every repo returns 404), so rulesets are the only live mechanism. Should a repo
+ever adopt classic protection, this reports "no queue" and integration runs on
+the PR — noisier, never less safe.
+
+**Fail-open by design.** Any API error (missing scope, 403, network, malformed
+payload) yields ``enabled=false`` ⇒ integration runs on the PR. The direction
+matters: the consumers most likely to fail detection — no PAT, no rulesets,
+unusual config — are precisely the ones with no merge queue, i.e. the ones this
+protects. Failing the other way would silently restore the gap. The measured
+cost of a redundant PR-tier run is ~1-2 minutes; a silently ungated integration
+suite costs a broken ``main``.
+
+Extracted from inline shell per docs/standards/ci.md (no branching logic in
+workflow ``run:`` blocks); unit-tested in tests/test_detect_merge_queue.py.
+
+Environment:
+    GH_TOKEN   bearer token for the `gh` CLI. A PAT is preferred (the reusable
+               forwards ORG_PAT_GITHUB); the default GITHUB_TOKEN is fine when
+               its scope permits reading rulesets, and fails open when it does
+               not.
+"""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import subprocess
+import sys
+from typing import Callable
+
+RunFn = Callable[[list], str]
+
+# Ruleset targets/enforcements that can gate a branch merge. "evaluate" is
+# GitHub's dry-run mode (reports, never blocks) and "disabled" is off, so
+# neither actually queues a merge — only "active" counts.
+_ACTIVE = "active"
+_BRANCH_TARGET = "branch"
+_MERGE_QUEUE_RULE = "merge_queue"
+
+# `conditions.ref_name.include` sentinels. GitHub substitutes these rather than
+# spelling out a ref, so they must be expanded before pattern matching.
+_ALL = "~ALL"
+_DEFAULT_BRANCH = "~DEFAULT_BRANCH"
+
+_REFS_HEADS = "refs/heads/"
+
+
+def _run_gh(args: list) -> str:
+    """Run `gh` and return stdout, or "" on any failure.
+
+    Mirrors the seam in discover_org_consumers.py: a single thin wrapper the
+    tests stub, with `gh`'s stderr echoed as a ::warning:: so a real auth/scope
+    error stays diagnosable in the workflow log instead of collapsing silently
+    into the fail-open path.
+    """
+    result = subprocess.run(["gh", *args], capture_output=True, text=True)
+    if result.returncode != 0:
+        if result.stderr:
+            print(
+                f"::warning::gh {' '.join(args[:2])} failed: {result.stderr.strip()}",
+                file=sys.stderr,
+            )
+        return ""
+    return result.stdout
+
+
+def _normalise(ref: str) -> str:
+    """Reduce a ref to its short branch name (``refs/heads/main`` -> ``main``)."""
+    return ref[len(_REFS_HEADS) :] if ref.startswith(_REFS_HEADS) else ref
+
+
+def ref_matches(patterns: list, base_ref: str, default_branch: str) -> bool:
+    """Whether ``base_ref`` matches any ruleset ``ref_name`` pattern.
+
+    Patterns are fnmatch globs over the short branch name, plus the two GitHub
+    sentinels. ``~ALL`` matches everything; ``~DEFAULT_BRANCH`` matches only the
+    repo's default branch.
+    """
+    target = _normalise(base_ref)
+    for pattern in patterns:
+        if not isinstance(pattern, str):
+            continue
+        if pattern == _ALL:
+            return True
+        if pattern == _DEFAULT_BRANCH:
+            if target == _normalise(default_branch):
+                return True
+            continue
+        if fnmatch.fnmatch(target, _normalise(pattern)):
+            return True
+    return False
+
+
+def governs_branch(ruleset: dict, base_ref: str, default_branch: str) -> bool:
+    """Whether one *expanded* ruleset puts ``base_ref`` behind a merge queue."""
+    if not isinstance(ruleset, dict):
+        return False
+    if ruleset.get("enforcement") != _ACTIVE:
+        return False
+    if ruleset.get("target") != _BRANCH_TARGET:
+        return False
+
+    rules = ruleset.get("rules") or []
+    if not any(
+        isinstance(rule, dict) and rule.get("type") == _MERGE_QUEUE_RULE
+        for rule in rules
+    ):
+        return False
+
+    ref_name = ((ruleset.get("conditions") or {}).get("ref_name")) or {}
+    include = ref_name.get("include") or []
+    exclude = ref_name.get("exclude") or []
+
+    # An explicit exclude wins over an include (GitHub evaluates it that way),
+    # so a repo that queues every branch *except* a release line reports "no
+    # queue" for that line and gets the PR tier instead.
+    if ref_matches(exclude, base_ref, default_branch):
+        return False
+    return ref_matches(include, base_ref, default_branch)
+
+
+def _load(raw: str):
+    """Parse `gh` JSON output, returning None on empty/invalid payloads."""
+    if not raw.strip():
+        return None
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        print("::warning::could not parse rulesets payload as JSON", file=sys.stderr)
+        return None
+
+
+def detect(
+    repo: str,
+    base_ref: str,
+    default_branch: str,
+    run: RunFn | None = None,
+) -> bool:
+    """Return True iff ``base_ref`` in ``repo`` is behind an active merge queue.
+
+    The list endpoint does not embed rules, so each ruleset is fetched
+    individually to inspect its rule types.
+
+    ``run`` is resolved at call time rather than bound as a default argument, so
+    stubbing the module-level seam takes effect for callers that don't pass it.
+    """
+    run = run or _run_gh
+    listing = _load(run(["api", f"repos/{repo}/rulesets", "--paginate"]))
+    if not isinstance(listing, list):
+        # Fail open: no readable ruleset list ⇒ assume no queue ⇒ PR tier runs.
+        return False
+
+    for entry in listing:
+        if not isinstance(entry, dict):
+            continue
+        ruleset_id = entry.get("id")
+        if ruleset_id is None:
+            continue
+        detail = _load(run(["api", f"repos/{repo}/rulesets/{ruleset_id}"]))
+        if governs_branch(detail, base_ref, default_branch):
+            return True
+    return False
+
+
+def main(argv: list | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Detect whether a PR base branch is behind a merge queue."
+    )
+    parser.add_argument("--repo", required=True, help="owner/name")
+    parser.add_argument(
+        "--base-ref",
+        required=True,
+        help="PR base branch (github.event.pull_request.base.ref)",
+    )
+    parser.add_argument(
+        "--default-branch",
+        default="main",
+        help="Repo default branch, to expand the ~DEFAULT_BRANCH sentinel.",
+    )
+    args = parser.parse_args(sys.argv[1:] if argv is None else argv)
+
+    enabled = detect(args.repo, args.base_ref, args.default_branch)
+
+    # Surface the decision and its consequence in the log: this is the reason
+    # the integration tier does or doesn't appear on the PR, and a reader
+    # should not have to re-derive it from job `if:` expressions.
+    tier = "merge queue" if enabled else "pull_request"
+    print(
+        f"::notice::merge queue for {args.repo}@{args.base_ref}: "
+        f"{'enabled' if enabled else 'not detected'} — integration tier runs on {tier}"
+    )
+    print(f"enabled={'true' if enabled else 'false'}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/detect_merge_queue.py
+++ b/.github/scripts/detect_merge_queue.py
@@ -184,6 +184,20 @@ def detect(
     listing = _load(run(["api", f"repos/{repo}/rulesets", "--paginate", "--slurp"]))
     if not isinstance(listing, list):
         # Fail open: no readable ruleset list ⇒ assume no queue ⇒ PR tier runs.
+        #
+        # Announce it. "Could not read the rulesets" and "this repo has no queue"
+        # produce the same return value but mean very different things: the first
+        # means a repo that DOES have a queue will also run integration on its
+        # PRs. Without this line that difference is invisible in the log, and the
+        # usual cause is a token without the scope to read rulesets
+        # (GITHUB_TOKEN cannot carry it — ORG_PAT_GITHUB is what makes detection
+        # authoritative), which is exactly the case worth noticing.
+        print(
+            f"::warning::could not read rulesets for {repo} — assuming no merge "
+            "queue, so the integration tier will run on this pull_request. If the "
+            "repo does have a queue, forward ORG_PAT_GITHUB via `secrets: inherit`.",
+            file=sys.stderr,
+        )
         return False
 
     for entry in listing:
@@ -220,10 +234,19 @@ def main(argv: list | None = None) -> int:
     # Surface the decision and its consequence in the log: this is the reason
     # the integration tier does or doesn't appear on the PR, and a reader
     # should not have to re-derive it from job `if:` expressions.
+    #
+    # MUST go to stderr, not stdout. The caller redirects this script's stdout
+    # straight into $GITHUB_OUTPUT, and the runner rejects any line there that
+    # has no `=` ("Unable to process file command 'output' successfully"), which
+    # would fail the step — and, via the gate's detect-merge-queue rule, redden
+    # Tests Gate on every pull_request in every consumer. Workflow commands are
+    # honoured on stderr too, so the annotation still renders.
+    # stdout is a strict contract: `enabled=<bool>` and nothing else.
     tier = "merge queue" if enabled else "pull_request"
     print(
         f"::notice::merge queue for {args.repo}@{args.base_ref}: "
-        f"{'enabled' if enabled else 'not detected'} — integration tier runs on {tier}"
+        f"{'enabled' if enabled else 'not detected'} — integration tier runs on {tier}",
+        file=sys.stderr,
     )
     print(f"enabled={'true' if enabled else 'false'}")
     return 0

--- a/.github/scripts/detect_merge_queue.py
+++ b/.github/scripts/detect_merge_queue.py
@@ -148,14 +148,22 @@ def governs_branch(ruleset: dict, base_ref: str, default_branch: str) -> bool:
 
 
 def _load(raw: str):
-    """Parse `gh` JSON output, returning None on empty/invalid payloads."""
+    """Parse `gh` JSON output, returning None on empty/invalid payloads.
+
+    A ``--paginate --slurp`` listing is an array *of page arrays*, so those
+    entries are flattened one level; anything else (a plain list, a dict error
+    body) passes through for the caller to shape-check.
+    """
     if not raw.strip():
         return None
     try:
-        return json.loads(raw)
+        payload = json.loads(raw)
     except json.JSONDecodeError:
         print("::warning::could not parse rulesets payload as JSON", file=sys.stderr)
         return None
+    if isinstance(payload, list) and all(isinstance(page, list) for page in payload):
+        return [entry for page in payload for entry in page]
+    return payload
 
 
 def detect(
@@ -173,7 +181,7 @@ def detect(
     stubbing the module-level seam takes effect for callers that don't pass it.
     """
     run = run or _run_gh
-    listing = _load(run(["api", f"repos/{repo}/rulesets", "--paginate"]))
+    listing = _load(run(["api", f"repos/{repo}/rulesets", "--paginate", "--slurp"]))
     if not isinstance(listing, list):
         # Fail open: no readable ruleset list ⇒ assume no queue ⇒ PR tier runs.
         return False

--- a/.github/scripts/tests/test_detect_merge_queue.py
+++ b/.github/scripts/tests/test_detect_merge_queue.py
@@ -1,0 +1,195 @@
+"""Tests for .github/scripts/detect_merge_queue.py.
+
+`gh` is stubbed through the module's single `run` seam (per the testability-seam
+convention in docs/standards/ci.md), so every branch — queue present, queue
+absent, per-branch scoping, and each fail-open path — is exercised without
+network access.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from detect_merge_queue import detect, governs_branch, main, ref_matches  # noqa: E402
+
+REPO = "atlanhq/atlan-example-app"
+
+
+def _ruleset(
+    *,
+    rule_types=("merge_queue",),
+    enforcement="active",
+    target="branch",
+    include=("~DEFAULT_BRANCH",),
+    exclude=(),
+) -> dict:
+    return {
+        "id": 1,
+        "name": "main",
+        "target": target,
+        "enforcement": enforcement,
+        "conditions": {
+            "ref_name": {"include": list(include), "exclude": list(exclude)}
+        },
+        "rules": [{"type": t} for t in rule_types],
+    }
+
+
+def _stub(listing, detail):
+    """Build a `run` double returning `listing` then `detail` per ruleset id."""
+
+    def run(args: list) -> str:
+        path = args[1]
+        if path.endswith("/rulesets"):
+            return json.dumps(listing)
+        return json.dumps(detail)
+
+    return run
+
+
+# --- ref_name matching -----------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "patterns,base_ref,expected",
+    [
+        (["~ALL"], "anything", True),
+        (["~DEFAULT_BRANCH"], "main", True),
+        (["~DEFAULT_BRANCH"], "release/1.x", False),
+        (["refs/heads/main"], "main", True),
+        (["refs/heads/main"], "refs/heads/main", True),
+        (["refs/heads/release/*"], "release/1.x", True),
+        (["refs/heads/release/*"], "main", False),
+        ([], "main", False),
+        ([None], "main", False),  # malformed entries are ignored, not crashes
+    ],
+)
+def test_ref_matches(patterns, base_ref, expected) -> None:
+    assert ref_matches(patterns, base_ref, "main") is expected
+
+
+# --- governs_branch --------------------------------------------------------
+
+
+def test_active_merge_queue_on_default_branch_governs() -> None:
+    assert governs_branch(_ruleset(), "main", "main") is True
+
+
+def test_ruleset_without_merge_queue_rule_does_not_govern() -> None:
+    # The real shape of a consumer that has a ruleset but no queue (e.g. a
+    # "block-pr" ruleset): rules exist, none of them is merge_queue.
+    ruleset = _ruleset(rule_types=("pull_request", "required_status_checks"))
+    assert governs_branch(ruleset, "main", "main") is False
+
+
+@pytest.mark.parametrize("enforcement", ["evaluate", "disabled"])
+def test_non_active_enforcement_does_not_govern(enforcement) -> None:
+    # "evaluate" is GitHub's dry-run mode — it reports but never queues a merge.
+    assert governs_branch(_ruleset(enforcement=enforcement), "main", "main") is False
+
+
+def test_non_branch_target_does_not_govern() -> None:
+    assert governs_branch(_ruleset(target="tag"), "main", "main") is False
+
+
+def test_queue_is_scoped_per_branch_not_per_repo() -> None:
+    # A repo can queue main while leaving a release branch unqueued.
+    ruleset = _ruleset(include=("refs/heads/main",))
+    assert governs_branch(ruleset, "main", "main") is True
+    assert governs_branch(ruleset, "release/1.x", "main") is False
+
+
+def test_exclude_overrides_include() -> None:
+    ruleset = _ruleset(include=("~ALL",), exclude=("refs/heads/release/*",))
+    assert governs_branch(ruleset, "main", "main") is True
+    assert governs_branch(ruleset, "release/1.x", "main") is False
+
+
+def test_malformed_ruleset_does_not_govern() -> None:
+    assert governs_branch(None, "main", "main") is False
+    assert governs_branch({}, "main", "main") is False
+
+
+# --- detect (end to end over the stubbed seam) -----------------------------
+
+
+def test_detect_true_when_queue_present() -> None:
+    run = _stub([{"id": 1}], _ruleset())
+    assert detect(REPO, "main", "main", run=run) is True
+
+
+def test_detect_false_when_repo_has_no_rulesets() -> None:
+    # The common fleet state: zero rulesets ⇒ no queue ⇒ PR tier runs.
+    run = _stub([], {})
+    assert detect(REPO, "main", "main", run=run) is False
+
+
+def test_detect_false_when_ruleset_lacks_queue() -> None:
+    run = _stub([{"id": 1}], _ruleset(rule_types=("pull_request",)))
+    assert detect(REPO, "main", "main", run=run) is False
+
+
+# --- fail-open paths -------------------------------------------------------
+# Every failure must yield False (⇒ integration runs on the PR). Failing the
+# other way would silently restore the ungated-integration gap.
+
+
+def test_detect_fails_open_on_api_error() -> None:
+    assert detect(REPO, "main", "main", run=lambda _args: "") is False
+
+
+def test_detect_fails_open_on_invalid_json() -> None:
+    assert detect(REPO, "main", "main", run=lambda _args: "not json") is False
+
+
+def test_detect_fails_open_on_unexpected_payload_shape() -> None:
+    # A 403 body is a JSON *object*, not the expected list of rulesets.
+    run = _stub({"message": "Resource not accessible by integration"}, {})
+    assert detect(REPO, "main", "main", run=run) is False
+
+
+def test_detect_fails_open_when_detail_fetch_fails() -> None:
+    def run(args: list) -> str:
+        return json.dumps([{"id": 1}]) if args[1].endswith("/rulesets") else ""
+
+    assert detect(REPO, "main", "main", run=run) is False
+
+
+def test_detect_skips_entries_without_id() -> None:
+    run = _stub([{"name": "no-id"}], _ruleset())
+    assert detect(REPO, "main", "main", run=run) is False
+
+
+# --- CLI output ------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "listing,detail,expected",
+    [([{"id": 1}], _ruleset(), "enabled=true"), ([], {}, "enabled=false")],
+)
+def test_main_emits_github_output(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture,
+    listing,
+    detail,
+    expected,
+) -> None:
+    monkeypatch.setattr("detect_merge_queue._run_gh", _stub(listing, detail))
+    rc = main(["--repo", REPO, "--base-ref", "main", "--default-branch", "main"])
+    assert rc == 0
+    assert expected in capsys.readouterr().out
+
+
+def test_main_never_exits_nonzero_on_api_failure(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    # A detection outage must not fail the job — it degrades to the PR tier.
+    monkeypatch.setattr("detect_merge_queue._run_gh", lambda _args: "")
+    assert main(["--repo", REPO, "--base-ref", "main"]) == 0
+    assert "enabled=false" in capsys.readouterr().out

--- a/.github/scripts/tests/test_detect_merge_queue.py
+++ b/.github/scripts/tests/test_detect_merge_queue.py
@@ -204,6 +204,59 @@ def test_main_emits_github_output(
     assert expected in capsys.readouterr().out
 
 
+@pytest.mark.parametrize(
+    "listing,detail,expected",
+    [([{"id": 1}], _ruleset(), "enabled=true\n"), ([], {}, "enabled=false\n")],
+)
+def test_stdout_is_exactly_the_github_output_contract(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture,
+    listing,
+    detail,
+    expected,
+) -> None:
+    """stdout must be `enabled=<bool>` and NOTHING else.
+
+    The caller redirects this script's stdout straight into $GITHUB_OUTPUT, and
+    the runner rejects any line without an `=` — which fails the step and, via
+    the gate's detect-merge-queue rule, reddens Tests Gate on every pull_request
+    in every consumer. A substring assertion (the test above) cannot catch a
+    stray line, so this one pins the whole stream by equality.
+    """
+    monkeypatch.setattr("detect_merge_queue._run_gh", _stub(listing, detail))
+    assert main(["--repo", REPO, "--base-ref", "main", "--default-branch", "main"]) == 0
+    captured = capsys.readouterr()
+    assert captured.out == expected
+    # The human-readable annotation still has to be emitted — on stderr.
+    assert "::notice::" in captured.err
+
+
+def test_no_stdout_line_lacks_an_equals_sign(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    # The precise property the runner enforces on $GITHUB_OUTPUT, stated directly
+    # so a future line added to stdout fails here rather than in the fleet.
+    monkeypatch.setattr("detect_merge_queue._run_gh", lambda _args: "")
+    main(["--repo", REPO, "--base-ref", "main"])
+    out = capsys.readouterr().out
+    assert [line for line in out.splitlines() if "=" not in line] == []
+
+
+def test_unreadable_rulesets_warns_rather_than_failing_silently(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    # A 403 body returns "no queue" like a genuinely queue-less repo does; the
+    # warning is the only thing distinguishing them in the log.
+    monkeypatch.setattr(
+        "detect_merge_queue._run_gh",
+        lambda _args: '{"message": "Resource not accessible by integration"}',
+    )
+    main(["--repo", REPO, "--base-ref", "main"])
+    captured = capsys.readouterr()
+    assert "enabled=false\n" == captured.out
+    assert "could not read rulesets" in captured.err
+
+
 def test_main_never_exits_nonzero_on_api_failure(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
 ) -> None:

--- a/.github/scripts/tests/test_detect_merge_queue.py
+++ b/.github/scripts/tests/test_detect_merge_queue.py
@@ -166,6 +166,24 @@ def test_detect_skips_entries_without_id() -> None:
     assert detect(REPO, "main", "main", run=run) is False
 
 
+def test_detect_flattens_slurped_pages() -> None:
+    # `--paginate --slurp` wraps each page in its own array; without flattening,
+    # a repo with more than one page of rulesets would parse as "no queue".
+    run = _stub([[{"id": 1}], [{"id": 2}]], _ruleset())
+    assert detect(REPO, "main", "main", run=run) is True
+
+
+def test_detect_passes_slurp_to_gh() -> None:
+    seen: list[list] = []
+
+    def run(args: list) -> str:
+        seen.append(args)
+        return json.dumps([])
+
+    detect(REPO, "main", "main", run=run)
+    assert seen and "--slurp" in seen[0] and "--paginate" in seen[0]
+
+
 # --- CLI output ------------------------------------------------------------
 
 

--- a/.github/scripts/tests/test_verify_test_gate.py
+++ b/.github/scripts/tests/test_verify_test_gate.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+import pytest
+
 sys.path.insert(
     0, str(Path(__file__).parent.parent.parent / "actions" / "verify-test-gate")
 )
@@ -222,3 +224,102 @@ def test_main_detect_integration_failure_annotates(capsys) -> None:
     assert rc == 0
     assert "passed=false" in captured.out
     assert "integration-suite detection" in captured.err
+
+
+# --- merge-queue detection (integration tier routing) ----------------------
+# detect-merge-queue decides WHERE the integration tier runs: in the merge queue
+# when the base branch has one, else on the pull_request. It is the last
+# positional arg and defaults to "skipped" because this driver is consumed
+# cross-repo at @main.
+
+
+def test_detect_merge_queue_defaults_to_skipped() -> None:
+    # Back-compat: a caller that has not wired the job at all still passes.
+    assert evaluate("success", "skipped", "skipped", "skipped", "skipped") == []
+
+
+@pytest.mark.parametrize("result", ["success", "skipped"])
+def test_detect_merge_queue_ok_states_pass(result) -> None:
+    # "success" = a PR where detection ran; "skipped" = a non-PR event.
+    assert evaluate("success", "success", "success", "skipped", "skipped", result) == []
+
+
+@pytest.mark.parametrize("result", ["failure", "cancelled", "timed_out"])
+def test_detect_merge_queue_failure_fails_the_gate(result) -> None:
+    # A detection failure drops the integration tier to a skip, so it must fail
+    # the gate rather than green it — the same hole closed for detect-integration.
+    errors = evaluate("success", "skipped", "skipped", "skipped", "skipped", result)
+    assert len(errors) == 1
+    assert "merge-queue detection" in errors[0]
+
+
+def test_detect_merge_queue_failure_shows_in_integration_row() -> None:
+    # Display must not claim the tier was cleanly skipped when routing broke.
+    out = render("success", "skipped", "skipped", "skipped", "skipped", "failure")
+    assert out["passed"] == "false"
+    assert out["integration-status"] == "❌ Merge-queue detection failed"
+
+
+def test_integration_runs_on_pr_when_no_queue() -> None:
+    # No queue ⇒ detect-merge-queue succeeded and integration ran on the PR.
+    out = render("success", "success", "success", "skipped", "skipped", "success")
+    assert out["passed"] == "true"
+    assert out["integration-status"] == "✅ Passed"
+
+
+def test_integration_failure_on_pr_blocks_the_gate() -> None:
+    # The whole point: on a queue-less repo a broken integration suite now
+    # blocks the PR instead of reddening main after the merge.
+    out = render("success", "failure", "success", "skipped", "skipped", "success")
+    assert out["passed"] == "false"
+    assert out["integration-status"] == "❌ Failed"
+
+
+def test_skipped_integration_string_does_not_promise_a_merge_queue() -> None:
+    # Queue-less repos have no merge queue to defer to, so the row must not
+    # assert one exists.
+    out = render("success", "skipped", "success", "skipped", "skipped", "success")
+    assert "no integration suite" in out["integration-status"]
+
+
+def test_main_detect_merge_queue_failure_annotates(capsys) -> None:
+    rc = main(
+        [
+            "--unit",
+            "success",
+            "--integration",
+            "skipped",
+            "--detect-integration",
+            "skipped",
+            "--detect-merge-queue",
+            "failure",
+            "--discover-e2e",
+            "skipped",
+            "--e2e",
+            "skipped",
+        ]
+    )
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "passed=false" in captured.out
+    assert "merge-queue detection" in captured.err
+
+
+def test_main_omitting_detect_merge_queue_still_passes(capsys) -> None:
+    # Cross-repo @main back-compat at the CLI boundary, not just the function.
+    rc = main(
+        [
+            "--unit",
+            "success",
+            "--integration",
+            "skipped",
+            "--detect-integration",
+            "skipped",
+            "--discover-e2e",
+            "skipped",
+            "--e2e",
+            "skipped",
+        ]
+    )
+    assert rc == 0
+    assert "passed=true" in capsys.readouterr().out

--- a/.github/workflows/tests-reusable.yaml
+++ b/.github/workflows/tests-reusable.yaml
@@ -404,8 +404,19 @@ jobs:
 
       - name: Detect merge queue on base branch
         id: detect
-        # A PAT reads rulesets reliably; GITHUB_TOKEN is the fallback and the
-        # script fails open if neither has the scope.
+        # ORG_PAT_GITHUB is what makes detection authoritative. Reading
+        # /repos/{repo}/rulesets needs administration-level read, and
+        # `administration` is not among the scopes a GITHUB_TOKEN can be granted
+        # via `permissions:` at all — so the github.token fallback exists only to
+        # keep the step from erroring on a missing secret; it is expected to fail
+        # open (⇒ integration also runs on the PR) with a loud ::warning::.
+        #
+        # Consequence worth stating: the "queued repos are unaffected" property
+        # holds only where the PAT reaches this reusable. Every consumer with a
+        # merge queue today calls it with `secrets: inherit`, so it does; a
+        # consumer that swaps that for an explicit `secrets:` block omitting
+        # ORG_PAT_GITHUB would start running integration on PRs as well as in the
+        # queue — ~1-2 min of redundant work, never a wrong gate.
         #
         # Event-derived values are routed through `env` and referenced as shell
         # variables rather than interpolated into the `run:` body — the same

--- a/.github/workflows/tests-reusable.yaml
+++ b/.github/workflows/tests-reusable.yaml
@@ -35,19 +35,27 @@ name: tests-reusable
 #                  per-commit PR signal, greens in seconds of test time.
 #   integration  → tests/integration/ via connector-integration-tests (boots
 #                  the app + testcontainers / services-script, exercising the
-#                  real extraction workflow). Skipped on pull_request (the unit
-#                  tier is the PR signal) and when the connector ships no
-#                  integration suite; runs on merge_group / push — the exact
-#                  batched state that will land, the one point a regression
-#                  could actually ship — re-run in place if the base moves under
-#                  the queue. Gated by the `detect-integration` job.
+#                  real extraction workflow). Skipped when the connector ships
+#                  no integration suite. WHERE it runs depends on whether the
+#                  base branch is behind a merge queue (`detect-merge-queue`):
+#                    • queue present → merge_group / push, the exact batched
+#                      state that will land, the one point a regression could
+#                      actually ship — re-run in place if the base moves under
+#                      the queue. (Skipped on pull_request; unit is the PR
+#                      signal.)
+#                    • queue absent  → pull_request, per commit. Without a
+#                      queue there is no batched pre-merge state to test in, so
+#                      gating on the PR is the only way the tier blocks a bad
+#                      merge; `push`-only would just redden main after the fact.
+#                  Gated by the `detect-integration` job either way.
 #   e2e (label/dispatch) → full-DAG against a real tenant (the `e2e` job).
 #   A caller-supplied `test-paths` scopes the INTEGRATION job only; the unit job
 #   always runs tests/unit/.
 #
 # GitHub check name hierarchy (caller → tests-reusable):
 #   Tests / tests / Unit         (every event)
-#   Tests / tests / Integration  (skipped on PRs / no suite; runs in merge queue)
+#   Tests / tests / Integration  (merge queue if the base branch has one, else
+#                                 on the PR; skipped when there is no suite)
 #   Tests / tests / End-to-end   (label / dispatch)
 #   Tests / tests / Tests Gate   (aggregator — the required check)
 #
@@ -354,16 +362,77 @@ jobs:
           # unit tier too (parity with integration); empty = lockfile version.
           application-sdk-ref: ${{ inputs.application-sdk-ref }}
 
+  # ── Detect whether the PR's base branch is behind a merge queue ──────────
+  # Decides WHERE the integration tier gates. The tier must run before a merge
+  # lands, and the queue is the ideal place for it (the exact batched state) —
+  # but only a repo that HAS a queue gets that. On a consumer without one, the
+  # old `!= 'pull_request'` gating left integration running solely on `push`,
+  # i.e. after the merge, where a failure reddens main and blocks nobody. A
+  # fleet sweep found most atlan-*-app consumers in exactly that state.
+  #
+  # So: queue present ⇒ integration runs in the queue (cadence unchanged);
+  # queue absent ⇒ integration runs on the pull_request instead. Either way the
+  # tier gates before code lands.
+  #
+  # Only needed for the pull_request case — on merge_group the queue is
+  # self-evidently enabled, and on push/dispatch integration always runs — so
+  # this job is skipped on every other event and costs nothing there.
+  #
+  # Fails open to "no queue" (⇒ the PR tier runs): see the script's docstring
+  # for why that direction is the safe one.
+  detect-merge-queue:
+    name: Detect merge queue
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      enabled: ${{ steps.detect.outputs.enabled }}
+    steps:
+      # Sparse-checkout of the SDK's scripts only: this reusable is called at
+      # @main by consumers whose own checkout has no such script, so the driver
+      # must come from the workflow's own repo, matching the ref the caller
+      # pinned (`job.workflow_sha`), exactly as the integration job does.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: atlanhq/application-sdk
+          ref: ${{ job.workflow_sha }}
+          sparse-checkout: .github/scripts
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+
+      - name: Detect merge queue on base branch
+        id: detect
+        # A PAT reads rulesets reliably; GITHUB_TOKEN is the fallback and the
+        # script fails open if neither has the scope.
+        env:
+          GH_TOKEN: ${{ secrets.ORG_PAT_GITHUB || github.token }}
+        run: |
+          python3 .github/scripts/detect_merge_queue.py \
+            --repo "${{ github.repository }}" \
+            --base-ref "${{ github.event.pull_request.base.ref }}" \
+            --default-branch "${{ github.event.repository.default_branch }}" \
+            >> "$GITHUB_OUTPUT"
+
   # ── Detect whether an integration suite exists ───────────────────────────
   # The integration job runs tests/integration/ explicitly; a connector may
   # legitimately ship no integration tier (e.g. hello-world), where pytest would
   # otherwise error on a missing path. A checkout + a tested glob (discover-e2e-
   # suites is a generic test_*.py counter, reused here) lets the integration job
   # be a clean skip via a job-level `if` — no inlined conditional shell. Runs on
-  # the same non-PR events the integration job does.
+  # the same events the integration job does, so the two `if`s move together.
   detect-integration:
     name: Detect integration suite
-    if: github.event_name != 'pull_request'
+    needs: detect-merge-queue
+    # `always()` because detect-merge-queue is *skipped* on every non-PR event
+    # and a skipped `need` would otherwise block this job. On a PR it runs only
+    # when no queue was detected — the same condition as the integration job
+    # below, so detection never runs for a tier that won't.
+    if: >-
+      always() &&
+      ( github.event_name != 'pull_request' ||
+        needs.detect-merge-queue.outputs.enabled == 'false' )
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
@@ -380,20 +449,23 @@ jobs:
           test-dir: tests/integration
 
   # ── Integration (boots the app + testcontainers / services-script) ───────
-  # Skipped on pull_request (unit is the per-commit signal) and when there is no
-  # integration suite (detect-integration count == 0); runs on merge_group /
-  # push / dispatch — the exact batched state that will land.
+  # Runs on merge_group / push / dispatch, and on pull_request only when the base
+  # branch has no merge queue to run it in (see detect-merge-queue). Skipped when
+  # the connector ships no integration suite (detect-integration count == 0).
   integration:
     name: Integration
-    needs: detect-integration
+    needs: [detect-merge-queue, detect-integration]
     # Specifying `if` drops the implied success() on `needs`, so require the
     # detection to have actually succeeded (else count is empty and would read
-    # as "present"). On pull_request detect-integration is skipped, so this is
-    # false and integration skips — the unit tier is the PR signal.
+    # as "present"). `always()` is needed because detect-merge-queue is skipped
+    # on non-PR events; the queue check then keeps this tier off PRs whose merge
+    # will be batched through a queue that already runs it.
     if: >-
-      github.event_name != 'pull_request' &&
+      always() &&
       needs.detect-integration.result == 'success' &&
-      needs.detect-integration.outputs.count != '0'
+      needs.detect-integration.outputs.count != '0' &&
+      ( github.event_name != 'pull_request' ||
+        needs.detect-merge-queue.outputs.enabled == 'false' )
     runs-on: ubuntu-latest
     timeout-minutes: ${{ inputs.timeout-minutes }}
     concurrency:
@@ -920,7 +992,15 @@ jobs:
   # ── Aggregator gate (single required check for branch protection) ────────
   tests-passed:
     name: Tests Gate
-    needs: [unit, detect-integration, integration, discover-e2e, e2e]
+    needs:
+      [
+        unit,
+        detect-merge-queue,
+        detect-integration,
+        integration,
+        discover-e2e,
+        e2e,
+      ]
     if: always()
     runs-on: ubuntu-latest
     # Comment + gate-eval only; cap so a wedged runner can't hold the required
@@ -947,6 +1027,7 @@ jobs:
           unit-result: ${{ needs.unit.result }}
           integration-result: ${{ needs.integration.result }}
           detect-integration-result: ${{ needs.detect-integration.result }}
+          detect-merge-queue-result: ${{ needs.detect-merge-queue.result }}
           discover-e2e-result: ${{ needs.discover-e2e.result }}
           e2e-result: ${{ needs.e2e.result }}
 

--- a/.github/workflows/tests-reusable.yaml
+++ b/.github/workflows/tests-reusable.yaml
@@ -404,19 +404,18 @@ jobs:
 
       - name: Detect merge queue on base branch
         id: detect
-        # ORG_PAT_GITHUB is what makes detection authoritative. Reading
-        # /repos/{repo}/rulesets needs administration-level read, and
-        # `administration` is not among the scopes a GITHUB_TOKEN can be granted
-        # via `permissions:` at all — so the github.token fallback exists only to
-        # keep the step from erroring on a missing secret; it is expected to fail
-        # open (⇒ integration also runs on the PR) with a loud ::warning::.
+        # Reading /repos/{repo}/rulesets is NOT administration-gated: the
+        # endpoint is readable by anyone who can read the repo (an
+        # unauthenticated GET against a public repo returns the full ruleset
+        # list, 200). So `contents: read` above is expected to be sufficient on a
+        # private consumer repo, and ORG_PAT_GITHUB is preferred only as the
+        # token least likely to be scope-limited.
         #
-        # Consequence worth stating: the "queued repos are unaffected" property
-        # holds only where the PAT reaches this reusable. Every consumer with a
-        # merge queue today calls it with `secrets: inherit`, so it does; a
-        # consumer that swaps that for an explicit `secrets:` block omitting
-        # ORG_PAT_GITHUB would start running integration on PRs as well as in the
-        # queue — ~1-2 min of redundant work, never a wrong gate.
+        # If that expectation is ever wrong, the failure is safe and loud rather
+        # than silent: detection fails open (⇒ integration also runs on the PR,
+        # ~1-2 min of redundant work, never a wrong gate) and the script emits a
+        # ::warning:: naming the cause. The first real PR run in a queued
+        # consumer confirms it either way — look for the ::notice:: line.
         #
         # Event-derived values are routed through `env` and referenced as shell
         # variables rather than interpolated into the `run:` body — the same

--- a/.github/workflows/tests-reusable.yaml
+++ b/.github/workflows/tests-reusable.yaml
@@ -406,13 +406,24 @@ jobs:
         id: detect
         # A PAT reads rulesets reliably; GITHUB_TOKEN is the fallback and the
         # script fails open if neither has the scope.
+        #
+        # Event-derived values are routed through `env` and referenced as shell
+        # variables rather than interpolated into the `run:` body — the same
+        # pattern as the verify-test-gate action ("Route job results through env,
+        # not inline ${{ }}"). `${{ }}` is substituted textually *before* bash
+        # parses the script, so a ref containing `$(...)`, a backtick or `;`
+        # would execute as code, and wrapping it in double quotes does not stop
+        # command substitution. A `"$BASE_REF"` expansion cannot.
         env:
           GH_TOKEN: ${{ secrets.ORG_PAT_GITHUB || github.token }}
+          REPO: ${{ github.repository }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           python3 .github/scripts/detect_merge_queue.py \
-            --repo "${{ github.repository }}" \
-            --base-ref "${{ github.event.pull_request.base.ref }}" \
-            --default-branch "${{ github.event.repository.default_branch }}" \
+            --repo "$REPO" \
+            --base-ref "$BASE_REF" \
+            --default-branch "$DEFAULT_BRANCH" \
             >> "$GITHUB_OUTPUT"
 
   # ── Detect whether an integration suite exists ───────────────────────────


### PR DESCRIPTION
## Problem

The integration tier is skipped on `pull_request` and runs on `merge_group` / `push`. That cadence is deliberate — the header comment says so explicitly — and it is **correct for a repo that has a merge queue**: the queue is the exact batched state that will land.

Most consumers have no merge queue. A sweep of **every** `atlan-*-app` repo — checking whether the shim actually calls `tests-reusable.yaml@`, whether a `tests/integration/` suite exists, and whether the default branch sits behind an active `merge_queue` rule — found **44 consumers on the reusable**, of which:

| Cohort | Count | Where integration ran |
|---|---|---|
| Merge queue present, has a suite (`mysql`, `openapi`, `metabase`, `model-caster`) | 4 | merge queue — healthy, 1–2 min |
| **No merge queue, has a suite** | **29** | **`push` only — after the merge** |
| No integration suite (incl. `hello-world`, which has a queue) | 11 | nowhere — legitimately |

Only **5 of ~118** `atlan-*-app` repos have a merge queue at all. No consumer uses classic branch protection (all `404`), so rulesets are the only live mechanism. Note `atlan-bigquery-app` *has* a ruleset (`block-pr`) but no `merge_queue` rule — presence of a ruleset is not the signal, which is why detection inspects rule types rather than ruleset existence.

On those **29**, the integration suite gated nothing: it ran after the merge, where a failure reddens `main` and blocks nobody. Several carry substantial suites — `dbt` (17 files), `fabric` (6), `anaplan` (7), `synapse` (5), `workdayprismanalytics` (5).

**Confirmed instance.** `atlan-dbt-app` migrated to this reusable on 2026-08-03. Its next `push` run failed:

```
application_sdk.main_errors.MissingAppModuleError: App module is required. Use --app or set ATLAN_APP_MODULE.
##[error]App server failed to start within 60s
```

A real app-side config bug that had been landing silently on `main`.

## Root cause

`if: github.event_name != 'pull_request'` assumes a merge queue exists to run the tier in. Without one, "not on the PR" collapses to "only after the merge".

## Fix

Make the tier's *location* merge-queue-aware rather than event-aware:

- **queue present** → `merge_group` / `push` — **cadence unchanged**
- **queue absent** → `pull_request`, per commit

A new `detect-merge-queue` job reads repository rulesets and reports whether the PR's **base branch** — not the repo — is behind an active `merge_queue` rule, since a repo can queue `main` while leaving a release branch unqueued. It only runs on `pull_request`: on `merge_group` the queue is self-evident, on `push`/dispatch the tier always runs. `detect-integration` and `integration` gate on it **together**, so detection never runs for a tier that won't.

**Fails open to "no queue"** ⇒ integration runs on the PR. The consumers most likely to fail detection (no PAT, no rulesets, odd config) are precisely the ones with no queue — the ones this protects. Failing the other way would silently restore the gap. A redundant PR-tier run costs 1–2 min; an ungated integration suite costs a broken `main`.

A `detect-merge-queue` **job** failure fails the Tests Gate rather than silently dropping the tier — closing the same hole already closed for `detect-integration`.

## Verified

Event matrix, simulated from the actual `if:` expressions:

| event | queue | detect-mq | detect-int | integration | gate |
|---|---|---|---|---|---|
| `pull_request` | yes | success | skipped | skip | PASS |
| `pull_request` | **no** | success | success | **RUNS** ← new | PASS |
| `merge_group` | yes | skipped | success | RUNS | PASS |
| `push` | — | skipped | success | RUNS | PASS |
| `pull_request` | no suite | success | success | skip | PASS |
| `pull_request` | detection **job** failed | failure | skipped | skip | **FAIL** |
| `workflow_dispatch` | — | skipped | success | RUNS | PASS |

- Live-checked against three real repo shapes: queue present → `true`; zero rulesets → `false`; ruleset-without-`merge_queue` → `false`.
- 28 new unit tests on the detector (every fail-open path, per-branch scoping, `~ALL` / `~DEFAULT_BRANCH` sentinels, `evaluate`/`disabled` enforcement, exclude-overrides-include).
- **941** `.github/scripts` tests green — no regressions.
- Repo-root `pre-commit run --all-files` clean.
- Detector uses stdlib `json` only: the job runs bare `python3` after a sparse checkout with no dependency install, matching all 25 sibling scripts.

## Rollout — no app-level changes

Consumers already call the reusable and the gate action at `@main`, so this propagates on merge. **No shim edit, no C002 drift, no re-bootstrap, no SDK version bump.** `--detect-merge-queue` is optional (default `skipped`) because the gate driver is consumed cross-repo at `@main`, where a required flag would break every caller the instant it merged.

Measured effect per cohort, across all 44 consumers on the reusable:

| Cohort | Count | Effect |
|---|---|---|
| Queue present, has a suite (`mysql`, `openapi`, `metabase`, `model-caster`) | 4 | **Nothing changes** — queue still runs it (see token caveat) |
| No queue, has a suite | **29** | Integration **starts gating PRs** (~1–2 min) |
| No `tests/integration/` | 11 | Nothing — `detect-integration` count `0` still skips |

**On token scope.** Reading `/repos/{repo}/rulesets` is **not** administration-gated — the endpoint is readable by anyone who can read the repo. Checked directly: an unauthenticated `GET https://api.github.com/repos/github/docs/rulesets` returns `200` with the full ruleset list. So the job's `contents: read` is expected to suffice on a private consumer repo, and `ORG_PAT_GITHUB` is preferred only as the token least likely to be scope-limited. All four queued consumers call the reusable with `secrets: inherit`, so it is available to them regardless.

If that expectation is ever wrong, the failure is safe and loud rather than silent: detection fails open (integration also runs on the PR — ~1–2 min of redundant work, never a wrong gate) and the script emits a `::warning::` naming the cause. The first real PR run in a queued consumer confirms it either way via the `::notice::` line.

The ~74 `atlan-*-app` repos not yet on the reusable are unaffected until the conformance rollout migrates them — at which point each one with a suite and no queue joins the 29. Some carry large suites (`publish` 50 files, `automation-engine` 39, `query-intelligence` 25, `snowflake` 18), so this is worth knowing before those migrations land.

## Expected on merge

`atlan-dbt-app` PRs will go red immediately via the pre-existing `MissingAppModuleError`. That is the fix working — but it is an app-side bug and a separate PR.

Follow-up: sweep the 29 newly-gated consumers for the same class of latent failure, so no team is surprised by a red PR they didn't cause.

Refs: FND-29
