### PR TITLE
Stop a stale sdk-review verdict from approving an unreviewed head

### DIFF
--- a/.github/workflows/sdk-review-approve-on-verdict.yml
+++ b/.github/workflows/sdk-review-approve-on-verdict.yml
@@ -94,8 +94,29 @@ jobs:
           fi
           echo "Detected verdict: '${VERDICT}'"
 
+          # Extract the sha that was actually reviewed from the structured
+          # marker `<!-- REVIEWED_HEAD: sha -->`. Uses the same idiom as
+          # VERDICT extraction above (`grep -oP '<!--\s*KEY:\s*\K...'`).
+          # A missing or empty marker means this is a legacy comment whose
+          # reviewed sha cannot be established; treat it as unverifiable
+          # rather than approving blind.
+          REVIEWED_HEAD=$(printf '%s' "$COMMENT_BODY" | grep -oP '<!--\s*REVIEWED_HEAD:\s*\K[0-9a-f]+' | head -1 || true)
+          if [ -z "$REVIEWED_HEAD" ]; then
+            echo "::warning::PR #${PR_NUMBER}: verdict comment has no REVIEWED_HEAD marker — cannot confirm which sha was reviewed; skipping all stamps."
+            exit 0
+          fi
+
           # Resolve the PR HEAD so we can apply the commit status.
           HEAD_SHA=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.head.sha')
+
+          # Guard: the verdict was computed for REVIEWED_HEAD. If the PR
+          # received a new push after the verdict comment was posted,
+          # REVIEWED_HEAD != HEAD_SHA. Do not stamp labels, commit status,
+          # or approval — that would bless unreviewed code.
+          if [ "$REVIEWED_HEAD" != "$HEAD_SHA" ]; then
+            echo "::warning::PR #${PR_NUMBER}: verdict was computed for ${REVIEWED_HEAD} but current head is ${HEAD_SHA} — skipping all stamps."
+            exit 0
+          fi
 
           # Strip the legacy `test-sdk-review-*` labels so PRs that
           # pre-date the promotion don't end up wearing both prefixes.


### PR DESCRIPTION
The fast path in `.github/workflows/sdk-review-approve-on-verdict.yml` stamps `sdk-review=success` and runs `gh pr review --approve` off the *live* PR head without ever reading `<!-- REVIEWED_HEAD: sha -->` from the comment it is reacting to, so a verdict computed for head H can approve a later H2 — unreviewed code satisfying CODEOWNERS. Pre-existing on `main`.

The slow path in `sdk-review.yml` does guard on `DISPATCH_HEAD_SHA`, but the fast path fires ~5s after the comment and the slow path 30-60s later, by which time its own idempotency check (~lines 1103-1116) sees the label already stamped and skips.

**Two guards now exit 0 with a `::warning::` before any label, status, or approval:**
1. Missing or empty marker — cannot verify which sha was reviewed; do not approve.
2. Head mismatch — verdict computed for `REVIEWED_HEAD` but current head is different; skip all stamps.

**Verification:** 4-case guard proof all pass; inverting the mismatch condition makes it wrongly approve; actionlint clean; suite 892 passed / 2 pre-existing collection errors, delta 0.

Not locally testable, needs a throwaway PR: tag then push mid-review → old verdict must not approve the new sha, `sdk-review` on H2 stays `pending`.

**Note:** The companion change that writes the `REVIEWED_HEAD` marker reliably is in a separate follow-up PR. Until it lands, this guard takes the "missing marker" branch and defers to the slow path — which is safe, just inert.