### PR TITLE
feat(main): default workflow execution timeout to 72 hours

### DIFF
--- a/application_sdk/handler/service.py
+++ b/application_sdk/handler/service.py
@@ -2294,11 +2294,12 @@ def create_app_handler_service(
             Rust-core metrics endpoint. Defaults to the SDK constant.
         workflow_max_timeout_hours: Optional ceiling on workflow execution time in
             hours. When set, passed as ``execution_timeout`` to Temporal on every
-            ``/workflows/v1/start`` and ``/events/v1/{event_id}`` call. ``None``
-            (the default) means no SDK-level ceiling — the Temporal namespace
-            default applies. Reads ``ATLAN_WORKFLOW_MAX_TIMEOUT_HOURS`` env var
-            when constructed via :class:`AppConfig`; non-positive values are
-            treated as ``None`` with a boot-time warning.
+            ``/workflows/v1/start`` and ``/events/v1/{event_id}`` call. Reads
+            ``ATLAN_WORKFLOW_MAX_TIMEOUT_HOURS`` env var when constructed via
+            :class:`AppConfig`, defaulting to 72 hours when unset. ``None``
+            means no SDK-level ceiling — the Temporal namespace default
+            applies; pass ``ATLAN_WORKFLOW_MAX_TIMEOUT_HOURS=0`` to opt out.
+            Negative values are treated as ``None`` with a boot-time warning.
 
     Returns:
         Configured FastAPI application.

--- a/application_sdk/main.py
+++ b/application_sdk/main.py
@@ -60,6 +60,15 @@ faulthandler.enable()
 # Used by the SIGUSR1 debug handler to snapshot asyncio tasks.
 _worker_event_loop: asyncio.AbstractEventLoop | None = None
 
+#: Default ceiling on workflow execution time, in hours, when
+#: ``ATLAN_WORKFLOW_MAX_TIMEOUT_HOURS`` is unset. Previously unset meant "no
+#: SDK-level cap", which left the Temporal namespace ceiling as the only
+#: backstop — a hung workflow could sit in RUNNING indefinitely. 72 hours is
+#: generous enough for the longest whale-tenant crawl + transform + miner run
+#: while still guaranteeing every workflow eventually reaches a terminal
+#: state. Set the env var to ``0`` to opt out and restore "no SDK cap".
+DEFAULT_WORKFLOW_MAX_TIMEOUT_HOURS = 72
+
 
 def _debug_dump_handler(signum: int, frame: object) -> None:
     """Dump thread stacks and asyncio tasks to /tmp/debug-dump-<pid>.txt on SIGUSR1."""
@@ -218,11 +227,13 @@ class AppConfig:
     """Maximum concurrent object-store uploads/downloads.
     Reads same env var as constants.MAX_CONCURRENT_STORAGE_TRANSFERS."""
 
-    workflow_max_timeout_hours: int | None = None
+    workflow_max_timeout_hours: int | None = DEFAULT_WORKFLOW_MAX_TIMEOUT_HOURS
     """Maximum workflow execution timeout in hours. When set, passed as
     execution_timeout to Temporal on every /workflows/v1/start call.
-    Reads env var ATLAN_WORKFLOW_MAX_TIMEOUT_HOURS. None means no SDK-level
-    ceiling (Temporal namespace default applies)."""
+    Reads env var ATLAN_WORKFLOW_MAX_TIMEOUT_HOURS, defaulting to
+    DEFAULT_WORKFLOW_MAX_TIMEOUT_HOURS (72) when unset. None means no
+    SDK-level ceiling (Temporal namespace default applies) — set the env var
+    to 0 to opt out."""
 
     def __post_init__(self) -> None:
         """Derive task_queue from app_module when not explicitly set."""
@@ -677,8 +688,15 @@ def _derive_task_queue(app_module: str) -> str:
 
 
 def _parse_workflow_max_timeout_hours() -> int | None:
-    """Parse ATLAN_WORKFLOW_MAX_TIMEOUT_HOURS, returning None for unset or non-positive values."""
-    hours = _env_int("ATLAN_WORKFLOW_MAX_TIMEOUT_HOURS", 0)
+    """Parse ATLAN_WORKFLOW_MAX_TIMEOUT_HOURS.
+
+    Unset falls back to ``DEFAULT_WORKFLOW_MAX_TIMEOUT_HOURS`` (72). Explicit
+    non-positive values return None, i.e. no SDK-level cap — ``0`` is the
+    documented opt-out and stays silent, negatives warn.
+    """
+    hours = _env_int(
+        "ATLAN_WORKFLOW_MAX_TIMEOUT_HOURS", DEFAULT_WORKFLOW_MAX_TIMEOUT_HOURS
+    )
     if hours <= 0:
         if hours < 0:
             logger.warning(

--- a/docs/concepts/handlers.md
+++ b/docs/concepts/handlers.md
@@ -280,13 +280,13 @@ class MySQLHandler(Handler):
 
 ## Workflow Execution Timeout
 
-By default the Temporal namespace ceiling applies to workflows started by the handler service. To cap execution time at the SDK level, set `ATLAN_WORKFLOW_MAX_TIMEOUT_HOURS` in your deployment environment:
+Workflows started by the handler service are capped at **72 hours** by default, so a hung run always reaches a terminal state instead of sitting in `RUNNING` until the Temporal namespace ceiling (if any) fires. Override with `ATLAN_WORKFLOW_MAX_TIMEOUT_HOURS` in your deployment environment:
 
 | Env var | Default | Effect |
 |---|---|---|
-| `ATLAN_WORKFLOW_MAX_TIMEOUT_HOURS` | unset (no SDK cap) | Maximum wall-clock hours a workflow may run before Temporal terminates it. Applies to every workflow started via `/workflows/v1/start` and `/events/v1/event/{event_id}`. |
+| `ATLAN_WORKFLOW_MAX_TIMEOUT_HOURS` | `72` | Maximum wall-clock hours a workflow may run before Temporal terminates it. Applies to every workflow started via `/workflows/v1/start` and `/events/v1/event/{event_id}`. |
 
-Non-positive values (`0`, negative numbers) are treated as unset and emit a boot-time warning. Set in `atlan.yaml`:
+Set `0` to opt out of the SDK cap entirely and fall back to the Temporal namespace default. Negative values are also treated as no-cap but emit a boot-time warning. Set in `atlan.yaml`:
 
 ```yaml
 # atlan.yaml
@@ -294,6 +294,10 @@ env:
   - name: ATLAN_WORKFLOW_MAX_TIMEOUT_HOURS
     value: "4"   # workflows are capped at 4 hours
 ```
+
+The effective ceiling is still bounded by the Temporal namespace's own
+`workflow_execution_timeout` maximum — if the namespace caps runs below 72
+hours, that lower value wins.
 
 ## Per-Entry-Point Handlers
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -14,6 +14,7 @@ from unittest.mock import ANY, AsyncMock, MagicMock, patch
 import pytest
 
 from application_sdk.main import (
+    DEFAULT_WORKFLOW_MAX_TIMEOUT_HOURS,
     AppConfig,
     _create_infrastructure,
     _derive_service_name,
@@ -385,7 +386,7 @@ class TestParseWorkflowMaxTimeoutHours:
         assert _parse_workflow_max_timeout_hours() == 4
 
     def test_zero_returns_none_silently(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Zero is treated as unset — returns None without a warning."""
+        """Zero is the documented opt-out — returns None without a warning."""
         monkeypatch.setenv("ATLAN_WORKFLOW_MAX_TIMEOUT_HOURS", "0")
         with patch("application_sdk.main.logger") as mock_log:
             result = _parse_workflow_max_timeout_hours()
@@ -403,10 +404,16 @@ class TestParseWorkflowMaxTimeoutHours:
         mock_log.warning.assert_called_once()
         assert "ATLAN_WORKFLOW_MAX_TIMEOUT_HOURS" in mock_log.warning.call_args[0][0]
 
-    def test_unset_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Unset env var returns None."""
+    def test_unset_returns_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Unset env var falls back to the 72-hour default cap."""
         monkeypatch.delenv("ATLAN_WORKFLOW_MAX_TIMEOUT_HOURS", raising=False)
-        assert _parse_workflow_max_timeout_hours() is None
+        assert _parse_workflow_max_timeout_hours() == DEFAULT_WORKFLOW_MAX_TIMEOUT_HOURS
+        assert DEFAULT_WORKFLOW_MAX_TIMEOUT_HOURS == 72
+
+    def test_appconfig_default_matches_constant(self) -> None:
+        """A directly-constructed AppConfig carries the same default cap."""
+        config = AppConfig(mode="worker", app_module="pkg.apps:MyApp")
+        assert config.workflow_max_timeout_hours == DEFAULT_WORKFLOW_MAX_TIMEOUT_HOURS
 
 
 class TestRunMain:


### PR DESCRIPTION
### Changelog
- `ATLAN_WORKFLOW_MAX_TIMEOUT_HOURS` now defaults to **72 hours** instead of `0`. `0` mapped to `None` in `_parse_workflow_max_timeout_hours()`, i.e. *no SDK-level ceiling* — so the Temporal namespace ceiling was the only backstop and a wedged workflow could sit in `RUNNING` indefinitely with no terminal state to alert on.
- New `DEFAULT_WORKFLOW_MAX_TIMEOUT_HOURS = 72` constant in `application_sdk/main.py`, used both as the `_env_int` fallback **and** as the `AppConfig.workflow_max_timeout_hours` field default, so dev scripts that construct `AppConfig` directly inherit the same cap as production.
- Explicit `0` remains the documented opt-out and still yields `None`, so any deployment that genuinely wants no cap keeps that behaviour with a one-line env var. Negative values still warn.
- Refreshed the `create_app_handler_service` docstring and `docs/concepts/handlers.md`, and noted that the Temporal namespace's own `workflow_execution_timeout` maximum still wins if it is lower than 72 h.

### Additional context (e.g. screenshots, logs, links)
- **Behaviour change with SDK-wide blast radius:** every app on this SDK that does not set `ATLAN_WORKFLOW_MAX_TIMEOUT_HOURS` goes from "uncapped" to "capped at 72 h". Intended — the point is that a workflow always reaches a terminal state — but worth a deliberate reviewer look for any app that legitimately runs longer than 72 h.
- **Namespace ceiling caveat:** if a Temporal namespace caps `workflow_execution_timeout` below 72 h, that lower value wins and this change is a no-op there. Worth confirming against the production namespace config before assuming 72 h is live.
- Companion connector PRs pin the same value explicitly at the deploy layer:
  - atlanhq/atlan-snowflake-app (8 h → 72 h)
  - atlanhq/atlan-bigquery-app (10 h → 72 h)
  - atlanhq/atlan-redshift-app (unset → 72 h)

### Checklist
- [x] Additional tests added
- [ ] All CI checks passed
- [x] Relevant documentation updated

Tests: `tests/unit/test_main.py` (143 passed) and `tests/unit/handler/test_service.py` — 447 passed together. `test_unset_returns_none` became `test_unset_returns_default`; added `test_appconfig_default_matches_constant`. The `create_app(workflow_max_timeout_hours=None)` plumbing tests are unchanged and still pass — `None` still means no cap at that layer.

---

### Copyleft License Compliance

- [ ] Have you used any code that is subject to a Copyleft license (e.g., GPL, AGPL, LGPL)?
- [ ] If yes, have you modified the code in the context of this project? please share additional details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)