### PR TITLE
chore(ci): Make @sdk-review produce exactly one review and never approve an unreviewed head

### DIFF
--- a/.github/scripts/sdk_review_gate.py
+++ b/.github/scripts/sdk_review_gate.py
@@ -166,7 +166,9 @@ def main(runner: Runner = subprocess.run) -> int:
         set_output("decision", "proceed")
         set_output("reason", "head-resolution-failed")
         set_output("message", message)
-        print(f"::notice::sdk-review gate: proceed (head-resolution-failed) — {message}")
+        print(
+            f"::notice::sdk-review gate: proceed (head-resolution-failed) — {message}"
+        )
         return 0
 
     reviewed_head: str | None = None

--- a/.github/scripts/sdk_review_gate.py
+++ b/.github/scripts/sdk_review_gate.py
@@ -12,17 +12,25 @@ A human tagging `@sdk-review` always dispatches, even on an unchanged HEAD:
 re-reading the same diff is a legitimate thing to ask for, and second-guessing
 it would make the tag feel broken.
 
+If head resolution (the `gh api` call that fetches the PR's current HEAD SHA)
+fails after all retries, we emit `decision=proceed` with
+`reason=head-resolution-failed`. Reviewing is always the safe default; a
+missing review is the harmful outcome.
+
 Decision logic lives here rather than inlined in the workflow, per
 docs/standards/ci.md.
 
 Environment:
-    REPO           owner/repo (e.g. atlanhq/application-sdk)
-    PR_NUMBER      pull request number
-    HEAD_SHA       40-char sha this trigger would review
-    EVENT_NAME     issue_comment | workflow_dispatch
-    TRIGGER_ACTOR  login of the commenter ("" for workflow_dispatch)
-    GH_TOKEN       consumed by `gh` for auth (not read here directly)
-    GITHUB_OUTPUT  path to the step-output file (optional; falls back to stdout)
+    REPO            owner/repo (e.g. atlanhq/application-sdk)
+    PR_NUMBER       pull request number
+    HEAD_SHA        40-char sha this trigger would review (empty when
+                    HEAD_RESOLVED=false)
+    EVENT_NAME      issue_comment | workflow_dispatch
+    TRIGGER_ACTOR   login of the commenter ("" for workflow_dispatch)
+    HEAD_RESOLVED   true (default) | false — set by the workflow when all
+                    head-resolution retries are exhausted
+    GH_TOKEN        consumed by `gh` for auth (not read here directly)
+    GITHUB_OUTPUT   path to the step-output file (optional; falls back to stdout)
 
 Outputs:
     decision  proceed | skip
@@ -137,6 +145,21 @@ def main(runner: Runner = subprocess.run) -> int:
     head_sha = os.environ.get("HEAD_SHA", "")
     event_name = os.environ.get("EVENT_NAME", "issue_comment")
     actor = os.environ.get("TRIGGER_ACTOR", "")
+    head_resolved = os.environ.get("HEAD_RESOLVED", "true")
+
+    # If all head-resolution retries were exhausted, proceed fail-open.
+    # A missing review is always worse than an extra review.
+    if head_resolved != "true":
+        message = (
+            "Head SHA could not be resolved after 3 attempts "
+            "(transient GitHub API error). Proceeding fail-open — "
+            "reviewing is the safe default."
+        )
+        set_output("decision", "proceed")
+        set_output("reason", "head-resolution-failed")
+        set_output("message", message)
+        print(f"::notice::sdk-review gate: proceed (head-resolution-failed) — {message}")
+        return 0
 
     reviewed_head: str | None = None
     # Only a bot trigger can be gated, so skip the API call entirely otherwise.

--- a/.github/scripts/sdk_review_gate.py
+++ b/.github/scripts/sdk_review_gate.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Decide whether an `@sdk-review` trigger should dispatch a review.
+
+Every comment on a PR fires `sdk-review.yml`. Most are filtered by the job's
+`if:`, but one case survives it and costs a full review run: the resolver
+(`mothership-ai[bot]`) posts `@sdk-review` again on a HEAD that has already
+been reviewed. The PR then carries two summaries for the same sha, written by
+two runs, differing only in wording — indistinguishable to a reader from the
+duplicate a crashed-and-replayed run produces.
+
+A human tagging `@sdk-review` always dispatches, even on an unchanged HEAD:
+re-reading the same diff is a legitimate thing to ask for, and second-guessing
+it would make the tag feel broken.
+
+Decision logic lives here rather than inlined in the workflow, per
+docs/standards/ci.md.
+
+Environment:
+    REPO           owner/repo (e.g. atlanhq/application-sdk)
+    PR_NUMBER      pull request number
+    HEAD_SHA       40-char sha this trigger would review
+    EVENT_NAME     issue_comment | workflow_dispatch
+    TRIGGER_ACTOR  login of the commenter ("" for workflow_dispatch)
+    GH_TOKEN       consumed by `gh` for auth (not read here directly)
+    GITHUB_OUTPUT  path to the step-output file (optional; falls back to stdout)
+
+Outputs:
+    decision  proceed | skip
+    reason    machine-readable slug
+    message   one line suitable for a PR comment or a ::notice::
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+from collections.abc import Callable
+
+# Logins the workflow's `if:` lets through besides OWNER/MEMBER/COLLABORATOR
+# humans. These are the automated re-triggers worth gating.
+BOT_TRIGGERS = frozenset({"mothership-ai[bot]", "atlan-ci"})
+
+SUMMARY_MARKER = "<!-- SDK_REVIEW -->"
+REVIEWED_HEAD_RE = re.compile(r"<!--\s*REVIEWED_HEAD:\s*([0-9a-f]{40})\s*-->")
+
+Runner = Callable[..., subprocess.CompletedProcess]
+
+
+def fetch_comments(repo: str, pr_number: str, runner: Runner = subprocess.run) -> list[dict]:
+    """Every comment on the PR, or [] if the query fails.
+
+    `--slurp` returns one array per page wrapped in an outer array; it is used
+    instead of `--jq` deliberately. The naive `--jq '.[] | select(...) | .body'`
+    form collapses a multiline body to its first line, which for a review
+    summary is the HTML marker alone — the REVIEWED_HEAD stamp is on line 3 and
+    would be silently dropped.
+    """
+    result = runner(
+        [
+            "gh",
+            "api",
+            f"repos/{repo}/issues/{pr_number}/comments",
+            "--paginate",
+            "--slurp",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        print(f"::warning::could not list PR comments (exit {result.returncode}) — not gating")
+        return []
+    try:
+        pages = json.loads(result.stdout or "[]")
+    except json.JSONDecodeError as e:
+        print(f"::warning::could not parse PR comments ({e}) — not gating")
+        return []
+    comments: list[dict] = []
+    for page in pages:
+        # A single un-paginated response is a bare array of comments; --slurp
+        # wraps it in one more level. Tolerate both shapes.
+        if isinstance(page, list):
+            comments.extend(c for c in page if isinstance(c, dict))
+        elif isinstance(page, dict):
+            comments.append(page)
+    return comments
+
+
+def last_reviewed_head(comments: list[dict]) -> str | None:
+    """The REVIEWED_HEAD stamped by the most recent SDK review summary."""
+    for comment in reversed(comments):
+        body = comment.get("body") or ""
+        if SUMMARY_MARKER not in body:
+            continue
+        match = REVIEWED_HEAD_RE.search(body)
+        return match.group(1) if match else None
+    return None
+
+
+def decide(
+    event_name: str,
+    actor: str,
+    head_sha: str,
+    reviewed_head: str | None,
+) -> tuple[str, str, str]:
+    """Return (decision, reason, message)."""
+    if event_name != "issue_comment":
+        return "proceed", "manual-dispatch", "Manual dispatch — reviewing."
+    if actor not in BOT_TRIGGERS:
+        return "proceed", "human-trigger", f"Human trigger by @{actor} — reviewing."
+    if reviewed_head and head_sha and reviewed_head == head_sha:
+        return (
+            "skip",
+            "unchanged-head-bot-retrigger",
+            f"Skipping: `{head_sha[:7]}` already has an SDK review and this trigger came "
+            f"from @{actor}, not a human. Push a commit, or tag `@sdk-review` yourself to "
+            f"force a re-review.",
+        )
+    return "proceed", "bot-trigger-new-head", f"Bot trigger by @{actor} on a new HEAD — reviewing."
+
+
+def set_output(key: str, value: str) -> None:
+    path = os.environ.get("GITHUB_OUTPUT")
+    line = f"{key}={value}\n"
+    if path:
+        with open(path, "a") as handle:
+            handle.write(line)
+    else:
+        print(f"OUTPUT: {key}={value}")
+
+
+def main(runner: Runner = subprocess.run) -> int:
+    repo = os.environ.get("REPO", "")
+    pr_number = os.environ.get("PR_NUMBER", "")
+    head_sha = os.environ.get("HEAD_SHA", "")
+    event_name = os.environ.get("EVENT_NAME", "issue_comment")
+    actor = os.environ.get("TRIGGER_ACTOR", "")
+
+    reviewed_head: str | None = None
+    # Only a bot trigger can be gated, so skip the API call entirely otherwise.
+    if event_name == "issue_comment" and actor in BOT_TRIGGERS and repo and pr_number:
+        reviewed_head = last_reviewed_head(fetch_comments(repo, pr_number, runner))
+
+    decision, reason, message = decide(event_name, actor, head_sha, reviewed_head)
+
+    set_output("decision", decision)
+    set_output("reason", reason)
+    set_output("message", message)
+    print(f"::notice::sdk-review gate: {decision} ({reason}) — {message}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/sdk_review_gate.py
+++ b/.github/scripts/sdk_review_gate.py
@@ -56,7 +56,9 @@ REVIEWED_HEAD_RE = re.compile(r"<!--\s*REVIEWED_HEAD:\s*([0-9a-f]{40})\s*-->")
 Runner = Callable[..., subprocess.CompletedProcess]
 
 
-def fetch_comments(repo: str, pr_number: str, runner: Runner = subprocess.run) -> list[dict]:
+def fetch_comments(
+    repo: str, pr_number: str, runner: Runner = subprocess.run
+) -> list[dict]:
     """Every comment on the PR, or [] if the query fails.
 
     `--slurp` returns one array per page wrapped in an outer array; it is used
@@ -78,7 +80,9 @@ def fetch_comments(repo: str, pr_number: str, runner: Runner = subprocess.run) -
         check=False,
     )
     if result.returncode != 0:
-        print(f"::warning::could not list PR comments (exit {result.returncode}) — not gating")
+        print(
+            f"::warning::could not list PR comments (exit {result.returncode}) — not gating"
+        )
         return []
     try:
         pages = json.loads(result.stdout or "[]")
@@ -126,7 +130,11 @@ def decide(
             f"from @{actor}, not a human. Push a commit, or tag `@sdk-review` yourself to "
             f"force a re-review.",
         )
-    return "proceed", "bot-trigger-new-head", f"Bot trigger by @{actor} on a new HEAD — reviewing."
+    return (
+        "proceed",
+        "bot-trigger-new-head",
+        f"Bot trigger by @{actor} on a new HEAD — reviewing.",
+    )
 
 
 def set_output(key: str, value: str) -> None:

--- a/.github/scripts/tests/test_sdk_review_gate.py
+++ b/.github/scripts/tests/test_sdk_review_gate.py
@@ -1,0 +1,162 @@
+"""Tests for the @sdk-review re-trigger gate."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+SPEC = importlib.util.spec_from_file_location(
+    "sdk_review_gate", Path(__file__).resolve().parents[1] / "sdk_review_gate.py"
+)
+gate = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(gate)
+
+
+HEAD = "0cab6b6e4eff94f28f249e1319ab74d55e1f7abc"
+OTHER = "51c160b06a2a350289c7d779f4ab887503f98685"
+
+
+def summary(head: str) -> dict:
+    return {
+        "body": (
+            "<!-- SDK_REVIEW -->\n"
+            "<!-- VERDICT: READY_TO_MERGE -->\n"
+            f"<!-- REVIEWED_HEAD: {head} -->\n"
+            "## SDK Review (mothership)\n\n### Verdict: READY TO MERGE\n"
+        )
+    }
+
+
+def fake_runner(payload, returncode: int = 0):
+    def _run(*_args, **_kwargs):
+        return subprocess.CompletedProcess(
+            args=[], returncode=returncode, stdout=json.dumps(payload), stderr=""
+        )
+
+    return _run
+
+
+# --- decide() ------------------------------------------------------------
+
+
+def test_human_proceeds_even_when_head_already_reviewed():
+    decision, reason, _ = gate.decide("issue_comment", "vaibhavatlan", HEAD, HEAD)
+    assert decision == "proceed"
+    assert reason == "human-trigger"
+
+
+def test_bot_skips_when_head_already_reviewed():
+    decision, reason, _ = gate.decide("issue_comment", "mothership-ai[bot]", HEAD, HEAD)
+    assert decision == "skip"
+    assert reason == "unchanged-head-bot-retrigger"
+
+
+def test_bot_proceeds_when_head_moved():
+    decision, _, _ = gate.decide("issue_comment", "mothership-ai[bot]", HEAD, OTHER)
+    assert decision == "proceed"
+
+
+def test_bot_proceeds_when_pr_has_no_prior_review():
+    decision, _, _ = gate.decide("issue_comment", "mothership-ai[bot]", HEAD, None)
+    assert decision == "proceed"
+
+
+def test_manual_dispatch_always_proceeds():
+    decision, reason, _ = gate.decide("workflow_dispatch", "", HEAD, HEAD)
+    assert decision == "proceed"
+    assert reason == "manual-dispatch"
+
+
+def test_skip_message_names_the_escape_hatch():
+    _, _, message = gate.decide("issue_comment", "atlan-ci", HEAD, HEAD)
+    assert "@sdk-review" in message
+    assert HEAD[:7] in message
+
+
+# --- last_reviewed_head() ------------------------------------------------
+
+
+def test_reads_head_from_the_most_recent_summary():
+    comments = [summary(OTHER), {"body": "unrelated chatter"}, summary(HEAD)]
+    assert gate.last_reviewed_head(comments) == HEAD
+
+
+def test_ignores_non_summary_comments():
+    assert gate.last_reviewed_head([{"body": "@sdk-review"}, {"body": "lgtm"}]) is None
+
+
+def test_returns_none_when_summary_predates_the_marker():
+    """A summary from before REVIEWED_HEAD existed must not gate anything."""
+    assert gate.last_reviewed_head([{"body": "<!-- SDK_REVIEW -->\n## SDK Review"}]) is None
+
+
+def test_tolerates_missing_body_key():
+    assert gate.last_reviewed_head([{}, summary(HEAD)]) == HEAD
+
+
+# --- fetch_comments() ----------------------------------------------------
+
+
+def test_flattens_slurped_pages():
+    pages = [[summary(OTHER)], [summary(HEAD)]]
+    comments = gate.fetch_comments("o/r", "1", fake_runner(pages))
+    assert len(comments) == 2
+    assert gate.last_reviewed_head(comments) == HEAD
+
+
+def test_gh_failure_returns_empty_so_the_gate_fails_open():
+    assert gate.fetch_comments("o/r", "1", fake_runner([], returncode=1)) == []
+
+
+def test_malformed_json_returns_empty_so_the_gate_fails_open():
+    def _run(*_args, **_kwargs):
+        return subprocess.CompletedProcess(args=[], returncode=0, stdout="not json", stderr="")
+
+    assert gate.fetch_comments("o/r", "1", _run) == []
+
+
+def test_fail_open_means_a_bot_retrigger_still_reviews():
+    """An API outage must never silently stop reviews from running."""
+    reviewed = gate.last_reviewed_head(gate.fetch_comments("o/r", "1", fake_runner([], returncode=1)))
+    decision, _, _ = gate.decide("issue_comment", "mothership-ai[bot]", HEAD, reviewed)
+    assert decision == "proceed"
+
+
+# --- main() --------------------------------------------------------------
+
+
+def test_main_writes_outputs(tmp_path, monkeypatch: pytest.MonkeyPatch):
+    out = tmp_path / "gh_output"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(out))
+    monkeypatch.setenv("REPO", "atlanhq/application-sdk")
+    monkeypatch.setenv("PR_NUMBER", "2987")
+    monkeypatch.setenv("HEAD_SHA", HEAD)
+    monkeypatch.setenv("EVENT_NAME", "issue_comment")
+    monkeypatch.setenv("TRIGGER_ACTOR", "mothership-ai[bot]")
+
+    assert gate.main(fake_runner([[summary(HEAD)]])) == 0
+
+    written = out.read_text()
+    assert "decision=skip" in written
+    assert "reason=unchanged-head-bot-retrigger" in written
+
+
+def test_main_does_not_query_github_for_a_human_trigger(tmp_path, monkeypatch: pytest.MonkeyPatch):
+    """The gate must cost nothing on the common path."""
+    monkeypatch.setenv("GITHUB_OUTPUT", str(tmp_path / "gh_output"))
+    monkeypatch.setenv("REPO", "atlanhq/application-sdk")
+    monkeypatch.setenv("PR_NUMBER", "2987")
+    monkeypatch.setenv("HEAD_SHA", HEAD)
+    monkeypatch.setenv("EVENT_NAME", "issue_comment")
+    monkeypatch.setenv("TRIGGER_ACTOR", "vaibhavatlan")
+
+    def _explode(*_args, **_kwargs):
+        raise AssertionError("gate queried GitHub on a human trigger")
+
+    assert gate.main(_explode) == 0
+    assert "decision=proceed" in (tmp_path / "gh_output").read_text()

--- a/.github/scripts/tests/test_sdk_review_gate.py
+++ b/.github/scripts/tests/test_sdk_review_gate.py
@@ -109,6 +109,23 @@ def test_flattens_slurped_pages():
     assert gate.last_reviewed_head(comments) == HEAD
 
 
+def test_prior_review_load_last_across_pages():
+    """S5: the §6b bootstrap uses --paginate --slurp so `last` picks the
+    genuinely newest SDK_REVIEW comment across ALL pages, not the last one
+    on page 1 (which is what --paginate --jq returns when jq runs per page).
+
+    Invariant: given two SDK_REVIEW comments on separate pages — an older
+    one on page 1 and a newer one on page 2 — fetch_comments+last_reviewed_head
+    returns the page-2 sha, not the page-1 sha.
+    """
+    non_review = {"body": "LGTM, looks good!"}
+    page1 = [non_review, summary(OTHER), non_review]  # older SDK_REVIEW on p1
+    page2 = [non_review, summary(HEAD)]                # newer SDK_REVIEW on p2
+    comments = gate.fetch_comments("o/r", "1", fake_runner([page1, page2]))
+    # Must return HEAD (page 2), not OTHER (page 1).
+    assert gate.last_reviewed_head(comments) == HEAD
+
+
 def test_gh_failure_returns_empty_so_the_gate_fails_open():
     assert gate.fetch_comments("o/r", "1", fake_runner([], returncode=1)) == []
 

--- a/.github/scripts/tests/test_sdk_review_gate.py
+++ b/.github/scripts/tests/test_sdk_review_gate.py
@@ -92,7 +92,10 @@ def test_ignores_non_summary_comments():
 
 def test_returns_none_when_summary_predates_the_marker():
     """A summary from before REVIEWED_HEAD existed must not gate anything."""
-    assert gate.last_reviewed_head([{"body": "<!-- SDK_REVIEW -->\n## SDK Review"}]) is None
+    assert (
+        gate.last_reviewed_head([{"body": "<!-- SDK_REVIEW -->\n## SDK Review"}])
+        is None
+    )
 
 
 def test_tolerates_missing_body_key():
@@ -120,7 +123,7 @@ def test_prior_review_load_last_across_pages():
     """
     non_review = {"body": "LGTM, looks good!"}
     page1 = [non_review, summary(OTHER), non_review]  # older SDK_REVIEW on p1
-    page2 = [non_review, summary(HEAD)]                # newer SDK_REVIEW on p2
+    page2 = [non_review, summary(HEAD)]  # newer SDK_REVIEW on p2
     comments = gate.fetch_comments("o/r", "1", fake_runner([page1, page2]))
     # Must return HEAD (page 2), not OTHER (page 1).
     assert gate.last_reviewed_head(comments) == HEAD
@@ -132,14 +135,18 @@ def test_gh_failure_returns_empty_so_the_gate_fails_open():
 
 def test_malformed_json_returns_empty_so_the_gate_fails_open():
     def _run(*_args, **_kwargs):
-        return subprocess.CompletedProcess(args=[], returncode=0, stdout="not json", stderr="")
+        return subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="not json", stderr=""
+        )
 
     assert gate.fetch_comments("o/r", "1", _run) == []
 
 
 def test_fail_open_means_a_bot_retrigger_still_reviews():
     """An API outage must never silently stop reviews from running."""
-    reviewed = gate.last_reviewed_head(gate.fetch_comments("o/r", "1", fake_runner([], returncode=1)))
+    reviewed = gate.last_reviewed_head(
+        gate.fetch_comments("o/r", "1", fake_runner([], returncode=1))
+    )
     decision, _, _ = gate.decide("issue_comment", "mothership-ai[bot]", HEAD, reviewed)
     assert decision == "proceed"
 
@@ -163,7 +170,9 @@ def test_main_writes_outputs(tmp_path, monkeypatch: pytest.MonkeyPatch):
     assert "reason=unchanged-head-bot-retrigger" in written
 
 
-def test_main_does_not_query_github_for_a_human_trigger(tmp_path, monkeypatch: pytest.MonkeyPatch):
+def test_main_does_not_query_github_for_a_human_trigger(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+):
     """The gate must cost nothing on the common path."""
     monkeypatch.setenv("GITHUB_OUTPUT", str(tmp_path / "gh_output"))
     monkeypatch.setenv("REPO", "atlanhq/application-sdk")
@@ -182,7 +191,9 @@ def test_main_does_not_query_github_for_a_human_trigger(tmp_path, monkeypatch: p
 # --- head-resolution failure (B3) ----------------------------------------
 
 
-def test_head_resolution_failure_emits_proceed(tmp_path, monkeypatch: pytest.MonkeyPatch):
+def test_head_resolution_failure_emits_proceed(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+):
     """Exhausted head-resolution retries must never silently drop the tag."""
     out = tmp_path / "gh_output"
     monkeypatch.setenv("GITHUB_OUTPUT", str(out))

--- a/.github/scripts/tests/test_sdk_review_gate.py
+++ b/.github/scripts/tests/test_sdk_review_gate.py
@@ -160,3 +160,64 @@ def test_main_does_not_query_github_for_a_human_trigger(tmp_path, monkeypatch: p
 
     assert gate.main(_explode) == 0
     assert "decision=proceed" in (tmp_path / "gh_output").read_text()
+
+
+# --- head-resolution failure (B3) ----------------------------------------
+
+
+def test_head_resolution_failure_emits_proceed(tmp_path, monkeypatch: pytest.MonkeyPatch):
+    """Exhausted head-resolution retries must never silently drop the tag."""
+    out = tmp_path / "gh_output"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(out))
+    monkeypatch.setenv("REPO", "atlanhq/application-sdk")
+    monkeypatch.setenv("PR_NUMBER", "2987")
+    monkeypatch.setenv("HEAD_SHA", "")
+    monkeypatch.setenv("EVENT_NAME", "issue_comment")
+    monkeypatch.setenv("TRIGGER_ACTOR", "mothership-ai[bot]")
+    monkeypatch.setenv("HEAD_RESOLVED", "false")
+
+    def _should_not_be_called(*_args, **_kwargs):
+        raise AssertionError("gate queried GitHub when head-resolution failed")
+
+    assert gate.main(_should_not_be_called) == 0
+
+    written = out.read_text()
+    assert "decision=proceed" in written
+    assert "reason=head-resolution-failed" in written
+
+
+def test_head_resolution_failure_human_trigger_also_proceeds(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+):
+    """Even human triggers proceed (trivially) when head resolution failed."""
+    out = tmp_path / "gh_output"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(out))
+    monkeypatch.setenv("REPO", "atlanhq/application-sdk")
+    monkeypatch.setenv("PR_NUMBER", "2987")
+    monkeypatch.setenv("HEAD_SHA", "")
+    monkeypatch.setenv("EVENT_NAME", "issue_comment")
+    monkeypatch.setenv("TRIGGER_ACTOR", "vaibhavatlan")
+    monkeypatch.setenv("HEAD_RESOLVED", "false")
+
+    assert gate.main(fake_runner([])) == 0
+    written = out.read_text()
+    assert "decision=proceed" in written
+    assert "reason=head-resolution-failed" in written
+
+
+def test_head_resolved_true_uses_normal_flow(tmp_path, monkeypatch: pytest.MonkeyPatch):
+    """HEAD_RESOLVED=true must not short-circuit to fail-open."""
+    out = tmp_path / "gh_output"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(out))
+    monkeypatch.setenv("REPO", "atlanhq/application-sdk")
+    monkeypatch.setenv("PR_NUMBER", "2987")
+    monkeypatch.setenv("HEAD_SHA", HEAD)
+    monkeypatch.setenv("EVENT_NAME", "issue_comment")
+    monkeypatch.setenv("TRIGGER_ACTOR", "mothership-ai[bot]")
+    monkeypatch.setenv("HEAD_RESOLVED", "true")
+
+    assert gate.main(fake_runner([[summary(HEAD)]])) == 0
+
+    written = out.read_text()
+    assert "decision=skip" in written
+    assert "reason=unchanged-head-bot-retrigger" in written

--- a/.github/workflows/sdk-review-approve-on-verdict.yml
+++ b/.github/workflows/sdk-review-approve-on-verdict.yml
@@ -239,9 +239,11 @@ jobs:
           # S2: pin the review to commit_id=HEAD_SHA so GitHub associates
           # the approval with the specific commit we verified. If a push
           # lands between our REVIEWED_HEAD check and this POST, GitHub
-          # attaches the review to the OLD commit and branch protection's
-          # dismiss_stale_reviews_on_push dismisses it — the unreviewed
-          # HEAD is never auto-approved.
+          # attaches the approval to the OLD (reviewed) commit rather than
+          # the new HEAD. Full protection against that window additionally
+          # requires `dismiss_stale_reviews_on_push` enabled on the main
+          # branch protection rule — that setting could not be verified from
+          # a non-admin token; confirm it is ON before relying on this guard.
           # Residual TOCTOU: label writes above are PR-scoped (no sha
           # param in the labels API). A push after label-write leaves a
           # stale label until sdk-review-reset-on-push.yml clears it —

--- a/.github/workflows/sdk-review-approve-on-verdict.yml
+++ b/.github/workflows/sdk-review-approve-on-verdict.yml
@@ -61,6 +61,17 @@ jobs:
         contains(github.event.comment.body, '<!-- SDK_REVIEW -->')
         || contains(github.event.comment.body, '<!-- TEST_SDK_REVIEW -->')
       )
+    # S3: serialize verdict processing per PR. Without a concurrency group,
+    # two verdict comments posted close together (e.g., a NEEDS_FIXES
+    # followed by READY_TO_MERGE on a retry) can race — the earlier run
+    # may complete AFTER the later one and overwrite its label writes.
+    # `cancel-in-progress: false` is required: we must not cancel the
+    # newer run. GitHub queues the blocked run; by the time it starts, the
+    # freshness check below ensures it either acts on the newest comment or
+    # no-ops if a different verdict comment has since landed.
+    concurrency:
+      group: sdk-review-approve-${{ github.event.issue.number }}
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -70,6 +81,7 @@ jobs:
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.issue.number }}
           COMMENT_BODY: ${{ github.event.comment.body }}
+          TRIGGERING_COMMENT_ID: ${{ github.event.comment.id }}
         run: |
           set -euo pipefail
 
@@ -115,6 +127,26 @@ jobs:
           # or approval — that would bless unreviewed code.
           if [ "$REVIEWED_HEAD" != "$HEAD_SHA" ]; then
             echo "::warning::PR #${PR_NUMBER}: verdict was computed for ${REVIEWED_HEAD} but current head is ${HEAD_SHA} — skipping all stamps."
+            exit 0
+          fi
+
+          # S3 freshness check: verify the triggering comment is the NEWEST
+          # SDK_REVIEW summary on this PR. The concurrency group above
+          # serializes runs, but GitHub's queue is not event-time ordered —
+          # after waiting in queue, this run may execute after a NEWER
+          # verdict comment has already been processed. If so, skip to avoid
+          # overwriting a more-recent verdict's labels/status/approval.
+          #
+          # Fetch the id of the most-recent SDK_REVIEW comment using the
+          # same --paginate --slurp idiom used in sdk-review.yml. The
+          # TRIGGERING_COMMENT_ID is the event payload's comment id
+          # (integer). If a newer comment exists, its id will be larger
+          # (GitHub ids are monotonically increasing).
+          NEWEST_SDK_COMMENT_ID=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+            --paginate --slurp 2>/dev/null \
+            | jq -r '[.[][] | select((.body | contains("<!-- SDK_REVIEW -->")) or (.body | contains("<!-- TEST_SDK_REVIEW -->")))] | last | .id // 0')
+          if [ "${NEWEST_SDK_COMMENT_ID:-0}" -gt "${TRIGGERING_COMMENT_ID:-0}" ]; then
+            echo "::notice::PR #${PR_NUMBER}: a newer SDK_REVIEW comment (id=${NEWEST_SDK_COMMENT_ID}) exists after this one (id=${TRIGGERING_COMMENT_ID}) — that run will/did process the final verdict; skipping."
             exit 0
           fi
 
@@ -167,15 +199,35 @@ jobs:
           # Only READY_TO_MERGE gets a formal atlan-ci approval.
           if [ "$VERDICT" != "READY_TO_MERGE" ]; then
             echo "Verdict '${VERDICT}' is not READY TO MERGE — labels applied, no approval posted."
+            # S3: dismiss any existing bot approval. sdk-review-dismiss-on-human.yml
+            # only fires on HUMAN activity — it will not run here. When a newer
+            # verdict (e.g. NEEDS_FIXES after a second review of the same HEAD)
+            # supersedes a prior READY_TO_MERGE, the prior atlan-ci approval must be
+            # dismissed so the merge gate returns to requiring a fresh approval.
+            # Reuse the same selector used by sdk-review-dismiss-on-human.yml.
+            STALE_IDS=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews" \
+              --paginate --slurp 2>/dev/null \
+              | jq -r '[.[][] | select(.user.login == "atlan-ci" and .state == "APPROVED" and ((.body // "") | startswith("**SDK reviewer'"'"'s verdict:**")))] | .[].id' 2>/dev/null || true)
+            if [ -n "$STALE_IDS" ]; then
+              DISMISS_MSG="Newer SDK review verdict (${VERDICT}) supersedes the prior bot approval — auto-dismissing. Re-run \`@sdk-review\` when ready for re-approval."
+              for rid in $STALE_IDS; do
+                gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews/${rid}/dismissals" \
+                  -X PUT -f message="$DISMISS_MSG" 2>/dev/null || true
+                echo "Dismissed stale atlan-ci approval ${rid} (newer verdict: ${VERDICT})."
+              done
+            fi
             exit 0
           fi
 
           # Idempotency guard: don't post a second atlan-ci approval if
           # one already exists with our signature. Otherwise the slow-path
           # approve step in sdk-review.yml would double-approve.
-          EXISTING=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews" --paginate \
-            --jq '[.[] | select(.user.login == "atlan-ci" and .state == "APPROVED" and ((.body // "") | startswith("**SDK reviewer'"'"'s verdict:**")))] | length')
-          if [ "$EXISTING" != "0" ]; then
+          # --slurp collapses pages into one array so the count is a single
+          # number. --paginate --jq runs jq per page and concatenates numbers.
+          EXISTING=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews" \
+            --paginate --slurp 2>/dev/null \
+            | jq '[.[][] | select(.user.login == "atlan-ci" and .state == "APPROVED" and ((.body // "") | startswith("**SDK reviewer'"'"'s verdict:**")))] | length' 2>/dev/null || echo "0")
+          if [ "${EXISTING:-0}" != "0" ]; then
             echo "atlan-ci has already approved PR #${PR_NUMBER} with the bot signature — skipping."
             exit 0
           fi
@@ -183,10 +235,29 @@ jobs:
           # NOTE: the leading line of the body is a STABLE SIGNATURE used
           # by sdk-review-dismiss-on-human.yml to identify approvals
           # posted by the bot. Keep this in sync with sdk-review.yml.
+          #
+          # S2: pin the review to commit_id=HEAD_SHA so GitHub associates
+          # the approval with the specific commit we verified. If a push
+          # lands between our REVIEWED_HEAD check and this POST, GitHub
+          # attaches the review to the OLD commit and branch protection's
+          # dismiss_stale_reviews_on_push dismisses it — the unreviewed
+          # HEAD is never auto-approved.
+          # Residual TOCTOU: label writes above are PR-scoped (no sha
+          # param in the labels API). A push after label-write leaves a
+          # stale label until sdk-review-reset-on-push.yml clears it —
+          # this is the known irreducible window. Labels are display-only;
+          # branch protection gates on the review + commit status, both of
+          # which are sha-pinned.
+          # `gh pr review --approve` does not expose commit_id; use the
+          # raw API instead.
           APPROVE_BODY=$(printf '%s\n' \
             "**SDK reviewer's verdict:** READY TO MERGE." \
             "" \
             "Full review summary is in the comment posted on this PR." \
             "")
-          gh pr review "$PR_NUMBER" --repo "$REPO" --approve --body "$APPROVE_BODY"
-          echo "Approved PR #${PR_NUMBER} as atlan-ci (fast path)."
+          gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews" \
+            -X POST \
+            -f commit_id="$HEAD_SHA" \
+            -f event=APPROVE \
+            -f body="$APPROVE_BODY"
+          echo "Approved PR #${PR_NUMBER} as atlan-ci (fast path, commit_id=${HEAD_SHA})."

--- a/.github/workflows/sdk-review-approve-on-verdict.yml
+++ b/.github/workflows/sdk-review-approve-on-verdict.yml
@@ -94,8 +94,29 @@ jobs:
           fi
           echo "Detected verdict: '${VERDICT}'"
 
+          # Extract the sha that was actually reviewed from the structured
+          # marker `<!-- REVIEWED_HEAD: sha -->`. Uses the same idiom as
+          # VERDICT extraction above (`grep -oP '<!--\s*KEY:\s*\K...'`).
+          # A missing or empty marker means this is a legacy comment whose
+          # reviewed sha cannot be established; treat it as unverifiable
+          # rather than approving blind.
+          REVIEWED_HEAD=$(printf '%s' "$COMMENT_BODY" | grep -oP '<!--\s*REVIEWED_HEAD:\s*\K[0-9a-f]+' | head -1 || true)
+          if [ -z "$REVIEWED_HEAD" ]; then
+            echo "::warning::PR #${PR_NUMBER}: verdict comment has no REVIEWED_HEAD marker — cannot confirm which sha was reviewed; skipping all stamps."
+            exit 0
+          fi
+
           # Resolve the PR HEAD so we can apply the commit status.
           HEAD_SHA=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.head.sha')
+
+          # Guard: the verdict was computed for REVIEWED_HEAD. If the PR
+          # received a new push after the verdict comment was posted,
+          # REVIEWED_HEAD != HEAD_SHA. Do not stamp labels, commit status,
+          # or approval — that would bless unreviewed code.
+          if [ "$REVIEWED_HEAD" != "$HEAD_SHA" ]; then
+            echo "::warning::PR #${PR_NUMBER}: verdict was computed for ${REVIEWED_HEAD} but current head is ${HEAD_SHA} — skipping all stamps."
+            exit 0
+          fi
 
           # Strip the legacy `test-sdk-review-*` labels so PRs that
           # pre-date the promotion don't end up wearing both prefixes.

--- a/.github/workflows/sdk-review.yml
+++ b/.github/workflows/sdk-review.yml
@@ -119,9 +119,22 @@ jobs:
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.issue.number || inputs.pr_number }}
         run: |
-          set -euo pipefail
-          SHA=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.head.sha')
-          echo "head_sha=${SHA}" >> "$GITHUB_OUTPUT"
+          # 3 attempts, 5 s / 10 s backoff. On exhaustion emit head_resolved=false
+          # rather than failing the job — the gate script then proceeds fail-open
+          # (reviewing is the safe default; a missing review is the harmful outcome).
+          for attempt in 1 2 3; do
+            if SHA=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.head.sha' 2>/dev/null) \
+               && [ -n "$SHA" ]; then
+              echo "head_sha=${SHA}" >> "$GITHUB_OUTPUT"
+              echo "head_resolved=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            echo "::warning::Head resolution attempt ${attempt}/3 failed"
+            [ "$attempt" -lt 3 ] && sleep $((attempt * 5))
+          done
+          echo "::warning::All 3 head-resolution attempts failed — gate will proceed fail-open"
+          echo "head_sha=" >> "$GITHUB_OUTPUT"
+          echo "head_resolved=false" >> "$GITHUB_OUTPUT"
 
       - name: Decide whether to review
         id: gate
@@ -130,9 +143,39 @@ jobs:
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.issue.number || inputs.pr_number }}
           HEAD_SHA: ${{ steps.head.outputs.head_sha }}
+          HEAD_RESOLVED: ${{ steps.head.outputs.head_resolved }}
           EVENT_NAME: ${{ github.event_name }}
           TRIGGER_ACTOR: ${{ github.event.comment.user.login }}
         run: python3 .github/scripts/sdk_review_gate.py
+
+      # If the gate job itself fails (e.g. checkout failure, unexpected error in
+      # the gate script), post a comment on the PR so the author knows to re-tag.
+      # Head-resolution exhaustion is handled inside the gate script (fail-open),
+      # so this step fires only for unexpected failures.
+      - name: Post gate-failure comment on PR
+        if: always() && failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.issue.number || inputs.pr_number }}
+          GHA_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        with:
+          script: |
+            const prNumber = parseInt(process.env.PR_NUMBER, 10);
+            if (!prNumber) return;
+            const runUrl = process.env.GHA_RUN_URL;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body: [
+                `⚠️ **SDK Review gate encountered an unexpected error** and could not decide whether to dispatch.`,
+                ``,
+                `[View the failing workflow run](${runUrl}) for details.`,
+                ``,
+                `Please retry by commenting \`@sdk-review\` again. If it keeps failing, reach out to the platform team.`,
+              ].join('\n'),
+            });
 
   sdk-review-dispatch:
     needs: gate

--- a/.github/workflows/sdk-review.yml
+++ b/.github/workflows/sdk-review.yml
@@ -1296,8 +1296,12 @@ jobs:
                 #
                 # S2: pin to commit_id=DISPATCH_HEAD_SHA (which we verified ==
                 # REVIEWED_HEAD above). If a push landed between our checks and
-                # this POST, branch protection's dismiss_stale_reviews_on_push
-                # dismisses the review — the unreviewed HEAD is never approved.
+                # this POST, GitHub attaches the approval to the OLD (reviewed)
+                # commit rather than the new HEAD. Full protection against that
+                # window additionally requires `dismiss_stale_reviews_on_push`
+                # enabled on the main branch protection rule — that setting could
+                # not be verified from a non-admin token; confirm it is ON before
+                # relying on this guard.
                 # `gh pr review --approve` does not expose commit_id; use raw API.
                 APPROVE_BODY=$(printf '%s\n' \
                   "**SDK reviewer's verdict:** READY TO MERGE." \

--- a/.github/workflows/sdk-review.yml
+++ b/.github/workflows/sdk-review.yml
@@ -177,6 +177,40 @@ jobs:
               ].join('\n'),
             });
 
+  # When the gate skips a bot-trigger, react to the original comment so the
+  # PR shows the trigger was seen and consciously declined. Without this, a
+  # skipped trigger is invisible: the `@sdk-review` comment gets no reaction
+  # and no starting comment — indistinguishable to the resolver from the
+  # reviewer being dead.
+  #
+  # `::notice::` is already emitted by the gate script for all decisions
+  # (including skip), so the run log has a record. This reaction surfaces it
+  # on the PR timeline without adding a new comment that the resolver may
+  # re-read as pending work.
+  react-on-skip:
+    needs: gate
+    # Only on issue_comment triggers — workflow_dispatch has no comment to react to.
+    # Humans are never skipped (the gate always proceeds on human triggers).
+    if: >-
+      needs.gate.outputs.decision == 'skip'
+      && github.event_name == 'issue_comment'
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: React to skipped trigger
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        with:
+          script: |
+            // React with 'eyes' so the PR shows the trigger was acknowledged.
+            // No new PR comment — that would be noise the resolver may re-read
+            // as a new review request.
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: 'eyes',
+            });
+
   sdk-review-dispatch:
     needs: gate
     if: needs.gate.outputs.decision == 'proceed'

--- a/.github/workflows/sdk-review.yml
+++ b/.github/workflows/sdk-review.yml
@@ -240,15 +240,23 @@ jobs:
       # session id silently fails to stop anything, which is exactly the
       # bug it exists to prevent. Compute once, read twice.
       #
-      # Unique per run, not per HEAD. It used to end at HEAD_SHA_SHORT, so two
-      # triggers on an unchanged HEAD sent the same session id — and mothership
-      # reads a supplied session_id as a follow-up (`is_follow_up =
+      # Unique per attempt, not just per run. It used to end at HEAD_SHA_SHORT,
+      # so two triggers on an unchanged HEAD sent the same session id — and
+      # mothership reads a supplied session_id as a follow-up (`is_follow_up =
       # request.session_id is not None`), so the second dispatch tried to RESUME
       # a conversation that had been cancelled or had already finished. That is
       # the "No conversation found with session" failure on #2987 and the
-      # zero-SSE death on #2989. GITHUB_RUN_ID makes every dispatch a fresh
+      # zero-SSE death on #2989. GITHUB_RUN_ID makes every NEW dispatch a fresh
       # session; the HEAD stays in the id purely so the sandbox is legible in
       # Cloudflare logs.
+      #
+      # GITHUB_RUN_ID is stable across re-runs of the same workflow run (docs:
+      # "does not change if you re-run the workflow run"). GITHUB_RUN_ATTEMPT
+      # increments with every re-run (1 on the first run, 2 on the first re-run,
+      # etc.). Without the attempt suffix, clicking "Re-run failed jobs" on a
+      # failed SDK Review would dispatch the same session id into a sandbox that
+      # mothership may still have in its DB — causing the same resume-of-a-dead-
+      # session failure the RUN_ID addition fixed for multi-trigger cases.
       - name: Compute mothership session id
         id: session
         env:
@@ -256,9 +264,10 @@ jobs:
           HEAD_SHA_SHORT: ${{ steps.pr.outputs.head_sha_short }}
           REPO_FULL_NAME: ${{ github.repository }}
           RUN_ID: ${{ github.run_id }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
         run: |
           set -euo pipefail
-          echo "session_id=sdk-review-${REPO_FULL_NAME//\//-}-${PR_NUMBER}-${HEAD_SHA_SHORT}-${RUN_ID}" >> "$GITHUB_OUTPUT"
+          echo "session_id=sdk-review-${REPO_FULL_NAME//\//-}-${PR_NUMBER}-${HEAD_SHA_SHORT}-${RUN_ID}-${RUN_ATTEMPT}" >> "$GITHUB_OUTPUT"
 
       - name: Post 'review starting' notice to PR
         id: starter

--- a/.github/workflows/sdk-review.yml
+++ b/.github/workflows/sdk-review.yml
@@ -75,7 +75,14 @@ permissions:
   checks: write
 
 jobs:
-  sdk-review-dispatch:
+  # Cheap pre-flight: decide whether this trigger deserves a review at all,
+  # before spending a VPN connect and a sandbox on it. The only trigger this
+  # turns away is an automated re-request (`mothership-ai[bot]` / `atlan-ci`)
+  # for a HEAD that already carries an SDK review — the resolver does this a
+  # couple of minutes after a review lands, and the result is two summaries
+  # for one sha that read like a bug. A human tagging `@sdk-review` always
+  # reviews, unchanged HEAD or not.
+  gate:
     if: >-
       github.event_name == 'workflow_dispatch'
       || (
@@ -90,13 +97,58 @@ jobs:
         )
       )
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      decision: ${{ steps.gate.outputs.decision }}
+      reason: ${{ steps.gate.outputs.reason }}
+    steps:
+      - name: Checkout repo (for the gate script)
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Resolve PR head
+        id: head
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.issue.number || inputs.pr_number }}
+        run: |
+          set -euo pipefail
+          SHA=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.head.sha')
+          echo "head_sha=${SHA}" >> "$GITHUB_OUTPUT"
+
+      - name: Decide whether to review
+        id: gate
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.issue.number || inputs.pr_number }}
+          HEAD_SHA: ${{ steps.head.outputs.head_sha }}
+          EVENT_NAME: ${{ github.event_name }}
+          TRIGGER_ACTOR: ${{ github.event.comment.user.login }}
+        run: python3 .github/scripts/sdk_review_gate.py
+
+  sdk-review-dispatch:
+    needs: gate
+    if: needs.gate.outputs.decision == 'proceed'
+    runs-on: ubuntu-latest
     # Total budget: 5 min for orient + retries + dispatch.
     # The sandbox itself runs for up to 2h (max_timeout_seconds: 7200),
     # but `curl --max-time 7200` blocks this job for that duration.
     timeout-minutes: 130
     concurrency:
       group: sdk-review-${{ github.event.issue.number || inputs.pr_number }}
-      cancel-in-progress: true
+      # NEVER cancel a review that is already running. `cancel-in-progress: true`
+      # meant a second `@sdk-review` killed the first one mid-flight — on #2989 a
+      # human tag at 16:42 destroyed a run that was 28m23s in and had not yet
+      # posted. Worse, the replacement dispatched the SAME session id the
+      # terminator was tearing down, so it died 63s later with zero SSE events;
+      # the same collision produced "No conversation found with session" on #2987.
+      #
+      # With this false, GitHub keeps at most one run in progress and one
+      # pending per PR, and a newer trigger replaces the pending one — an
+      # effective cap of two, which is the behaviour we want: the in-flight
+      # review finishes and posts, the newest re-tag runs after it.
+      cancel-in-progress: false
     steps:
       - name: Checkout repo (for local globalprotect-connect action)
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -188,18 +240,25 @@ jobs:
       # session id silently fails to stop anything, which is exactly the
       # bug it exists to prevent. Compute once, read twice.
       #
-      # Deterministic on the PR head: a new commit produces a new HEAD_SHA
-      # → fresh sandbox; a re-trigger on the same HEAD resumes the same
-      # session (mothership serialises those on a per-session lock).
+      # Unique per run, not per HEAD. It used to end at HEAD_SHA_SHORT, so two
+      # triggers on an unchanged HEAD sent the same session id — and mothership
+      # reads a supplied session_id as a follow-up (`is_follow_up =
+      # request.session_id is not None`), so the second dispatch tried to RESUME
+      # a conversation that had been cancelled or had already finished. That is
+      # the "No conversation found with session" failure on #2987 and the
+      # zero-SSE death on #2989. GITHUB_RUN_ID makes every dispatch a fresh
+      # session; the HEAD stays in the id purely so the sandbox is legible in
+      # Cloudflare logs.
       - name: Compute mothership session id
         id: session
         env:
           PR_NUMBER: ${{ steps.parse.outputs.pr_number }}
           HEAD_SHA_SHORT: ${{ steps.pr.outputs.head_sha_short }}
           REPO_FULL_NAME: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
         run: |
           set -euo pipefail
-          echo "session_id=sdk-review-${REPO_FULL_NAME//\//-}-${PR_NUMBER}-${HEAD_SHA_SHORT}" >> "$GITHUB_OUTPUT"
+          echo "session_id=sdk-review-${REPO_FULL_NAME//\//-}-${PR_NUMBER}-${HEAD_SHA_SHORT}-${RUN_ID}" >> "$GITHUB_OUTPUT"
 
       - name: Post 'review starting' notice to PR
         id: starter

--- a/.github/workflows/sdk-review.yml
+++ b/.github/workflows/sdk-review.yml
@@ -795,15 +795,6 @@ jobs:
             if [ "${SUMMARY_COUNT:-0}" -gt 0 ]; then
               VERDICT_POSTED=1
             fi
-            # One trigger must produce exactly one summary. More than one means
-            # the run posted twice — mothership recovered a dropped stream by
-            # re-running the prompt from the top in the same sandbox, and the
-            # replay guard in ORCHESTRATION.md §6b did not stop it. This block
-            # only ever asked "is there at least one summary", so a double-post
-            # looked identical to a clean delivery. Surface it.
-            if [ "${SUMMARY_COUNT:-0}" -gt 1 ]; then
-              echo "::warning::PR #${PR_NUMBER} received ${SUMMARY_COUNT} SDK_REVIEW summaries from this single run — duplicate review (stream-recovery replay). Check the ORCHESTRATION.md §6b replay guard."
-            fi
           fi
 
           # Export the run summary fields BEFORE the failure checks below

--- a/.github/workflows/sdk-review.yml
+++ b/.github/workflows/sdk-review.yml
@@ -1209,6 +1209,26 @@ jobs:
             exit 0
           fi
 
+          # S1 guard — REVIEWED_HEAD: belt-and-suspenders over the
+          # DISPATCH_HEAD_SHA vs CURRENT_HEAD check above (line ~1169).
+          # That check verifies the PR HEAD didn't move while the sandbox
+          # ran. This check verifies the summary comment explicitly claims
+          # to have reviewed DISPATCH_HEAD_SHA — catching the (rare but
+          # possible) case where the sandbox checked out a different commit
+          # (e.g., the REVIEWED_HEAD placeholder was not substituted, or the
+          # sandbox started from a stale snapshot). If REVIEWED_HEAD is
+          # absent the comment pre-dates the marker; treat it as unverifiable
+          # rather than approving blind, matching the fast-path behaviour.
+          REVIEWED_HEAD=$(printf '%s' "$SUMMARY" | grep -oP '<!--\s*REVIEWED_HEAD:\s*\K[0-9a-f]+' | head -1 || true)
+          if [ -z "$REVIEWED_HEAD" ]; then
+            echo "::warning::PR #${PR_NUMBER}: verdict comment has no REVIEWED_HEAD marker — cannot confirm which sha was reviewed; skipping all stamps."
+            exit 0
+          fi
+          if [ "$REVIEWED_HEAD" != "$DISPATCH_HEAD_SHA" ]; then
+            echo "::warning::PR #${PR_NUMBER}: verdict was computed for ${REVIEWED_HEAD} but this run was dispatched for ${DISPATCH_HEAD_SHA} — skipping all stamps."
+            exit 0
+          fi
+
           # Extract the verdict. Prefer the structured marker
           # `<!-- VERDICT: READY_TO_MERGE -->` (deterministic, formatting-
           # invariant). Fall back to the `### Verdict:` grep for legacy
@@ -1273,13 +1293,23 @@ jobs:
                 # by the dismiss-on-human workflow to identify approvals posted
                 # by this flow. Keep this in sync with
                 # sdk-review-approve-on-verdict.yml.
+                #
+                # S2: pin to commit_id=DISPATCH_HEAD_SHA (which we verified ==
+                # REVIEWED_HEAD above). If a push landed between our checks and
+                # this POST, branch protection's dismiss_stale_reviews_on_push
+                # dismisses the review — the unreviewed HEAD is never approved.
+                # `gh pr review --approve` does not expose commit_id; use raw API.
                 APPROVE_BODY=$(printf '%s\n' \
                   "**SDK reviewer's verdict:** READY TO MERGE." \
                   "" \
                   "Full review summary is in the comment posted on this PR." \
                   "")
-                gh pr review "$PR_NUMBER" --repo "$REPO" --approve --body "$APPROVE_BODY"
-                echo "Approved PR #${PR_NUMBER} as atlan-ci (slow path fallback)."
+                gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews" \
+                  -X POST \
+                  -f commit_id="$DISPATCH_HEAD_SHA" \
+                  -f event=APPROVE \
+                  -f body="$APPROVE_BODY"
+                echo "Approved PR #${PR_NUMBER} as atlan-ci (slow path fallback, commit_id=${DISPATCH_HEAD_SHA})."
               fi
               ;;
             "NEEDS_HUMAN")

--- a/.github/workflows/sdk-review.yml
+++ b/.github/workflows/sdk-review.yml
@@ -795,6 +795,15 @@ jobs:
             if [ "${SUMMARY_COUNT:-0}" -gt 0 ]; then
               VERDICT_POSTED=1
             fi
+            # One trigger must produce exactly one summary. More than one means
+            # the run posted twice — mothership recovered a dropped stream by
+            # re-running the prompt from the top in the same sandbox, and the
+            # replay guard in ORCHESTRATION.md §6b did not stop it. This block
+            # only ever asked "is there at least one summary", so a double-post
+            # looked identical to a clean delivery. Surface it.
+            if [ "${SUMMARY_COUNT:-0}" -gt 1 ]; then
+              echo "::warning::PR #${PR_NUMBER} received ${SUMMARY_COUNT} SDK_REVIEW summaries from this single run — duplicate review (stream-recovery replay). Check the ORCHESTRATION.md §6b replay guard."
+            fi
           fi
 
           # Export the run summary fields BEFORE the failure checks below

--- a/.github/workflows/sdk-review.yml
+++ b/.github/workflows/sdk-review.yml
@@ -82,6 +82,13 @@ jobs:
   # couple of minutes after a review lands, and the result is two summaries
   # for one sha that read like a bug. A human tagging `@sdk-review` always
   # reviews, unchanged HEAD or not.
+  #
+  # NOTE — this job is an OPTIMIZATION, not the authority. It runs outside
+  # the per-PR concurrency group (sdk-review-$PR), so two concurrent bot
+  # triggers can both pass it ("no review yet") and both reach the sandbox.
+  # The authoritative dedupe check lives inside the sandbox (ORCHESTRATION.md
+  # Phase 0 §6b bot-trigger dedupe guard), which runs under the concurrency
+  # lock and sees true post-lock comment state.
   gate:
     if: >-
       github.event_name == 'workflow_dispatch'

--- a/.github/workflows/sdk-review.yml
+++ b/.github/workflows/sdk-review.yml
@@ -201,14 +201,16 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
-            // React with 'eyes' so the PR shows the trigger was acknowledged.
-            // No new PR comment — that would be noise the resolver may re-read
-            // as a new review request.
+            // React with 'confused' (😕) to signal "seen, consciously declined".
+            // The dispatch job uses 'eyes' (👀) for proceed — keeping distinct
+            // reactions means a user can tell "seen and running" (👀) from "seen
+            // and skipped" (😕) without reading the workflow log.
+            // No new PR comment — that would be noise the resolver may re-read.
             await github.rest.reactions.createForIssueComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               comment_id: context.payload.comment.id,
-              content: 'eyes',
+              content: 'confused',
             });
 
   sdk-review-dispatch:

--- a/.mothership/pr-review/ORCHESTRATION.md
+++ b/.mothership/pr-review/ORCHESTRATION.md
@@ -1209,7 +1209,12 @@ after `VERDICT:` MUST be one of: `READY_TO_MERGE`, `NEEDS_FIXES`,
 `<!-- REVIEWED_HEAD: <sha> -->` records the 40-char HEAD this review
 ran against — step 6c reads it on the next round to compute the
 re-review delta; omitting it forces the next round back to a full
-review. For toolkit scopes, the fourth marker
+review. **Substitute `<HEAD_SHA>` with the verbatim 40-character hex
+SHA from the prompt header — write the raw hex characters, never the
+literal placeholder text `<HEAD_SHA>`.** The §3f submit step adds a
+shell-level safety net (`sed`) in case the LLM writes the placeholder,
+but the correct value must come from the reviewed HEAD, not a live
+re-fetch. For toolkit scopes, the fourth marker
 `<!-- TOOLKIT_ARTIFACT_HASH: <sha256> -->` records the PR-generated
 artifact hash from Phase 1b-toolkit so the next round can carry
 consumer validation forward; omit the line entirely for non-toolkit
@@ -1368,6 +1373,16 @@ gh api "repos/$REPO/statuses/$HEAD_SHA" \
   -f state="$STATE" \
   -f description="$DESCRIPTION"
 # where STATE ∈ success|failure|pending and DESCRIPTION ≤ 140 chars
+
+# Stamp the reviewed HEAD SHA into the REVIEWED_HEAD marker — safety
+# net in case the LLM wrote the `<HEAD_SHA>` placeholder literally
+# rather than substituting the actual value. headRefOid was fetched
+# from the authoritative PR metadata in Phase 0 step 3 and has not
+# changed (the stale-SHA guard in step 5 would have exited if it had).
+# The sed is idempotent: if the LLM already wrote the real SHA the
+# pattern finds no match and the file is unchanged.
+HEAD_SHA_STAMPED=$(jq -r '.headRefOid' /tmp/PR.json)
+sed -i "s|<!-- REVIEWED_HEAD: <HEAD_SHA> -->|<!-- REVIEWED_HEAD: ${HEAD_SHA_STAMPED} -->|" /tmp/review-summary.md
 
 # Summary comment (the body built in 3a, including the
 # <!-- SDK_REVIEW --> marker and the <!-- REVIEW_DATA --> JSON) — LAST:

--- a/.mothership/pr-review/ORCHESTRATION.md
+++ b/.mothership/pr-review/ORCHESTRATION.md
@@ -158,9 +158,15 @@ BUDGET
     carried forward, downgraded, or re-checked given the current HEAD.
 
     ```bash
+    # S5: use --paginate --slurp and pipe into standalone jq. The naive
+    # --paginate --jq idiom runs the jq filter once PER PAGE, so `last`
+    # picks the last match on the FIRST page, not the last match across all
+    # pages. On PRs with many comments spanning multiple API pages this
+    # would silently load an older review. --slurp collapses pages into one
+    # outer array; `.[][]` flattens into a single stream before `last`.
     PRIOR_REVIEW=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
-      --paginate \
-      --jq '[.[] | select(.body | contains("<!-- SDK_REVIEW -->"))] | last | .body // ""')
+      --paginate --slurp 2>/dev/null \
+      | jq -r '[.[][] | select(.body | contains("<!-- SDK_REVIEW -->"))] | last | .body // ""')
 
     if [ -n "$PRIOR_REVIEW" ]; then
       printf '%s\n' "$PRIOR_REVIEW" > /tmp/PRIOR_REVIEW.md
@@ -171,11 +177,15 @@ BUDGET
     fi
     ```
 
-    **CRITICAL — jq idiom:** wrap the selection in `[ ... ] | last`
-    and take `.body` from the array element. A naive
-    `--jq '.[] | select(...) | .body' | head -1` collapses the raw
-    multiline body to its first line (the `<!-- SDK_REVIEW -->`
-    HTML marker) and silently drops the entire review content.
+    **CRITICAL — jq idiom:** two mistakes to avoid:
+    - `--jq '.[] | select(...) | .body' | head -1` collapses the raw
+      multiline body to its first line (the `<!-- SDK_REVIEW -->`
+      HTML marker) and silently drops the entire review content.
+    - `--paginate --jq '[.[] | select(...)] | last'` runs the jq filter
+      ONCE PER PAGE, so `last` picks the final match on page 1, not
+      across all pages. On a PR with enough comments to span pages,
+      this returns a stale older review. Always use `--paginate --slurp`
+      and pipe into standalone `jq -r '[.[][] | select(...)] | last'`.
 
     Every subsequent phase that reasons about the PR (Phase 2 agents,
     cross-model debias, verdict determination) should treat
@@ -245,6 +255,28 @@ BUDGET
         | grep -oE '[0-9a-f]{40}' || true)
       if [ -n "$NEWEST_REVIEWED_HEAD" ] && [ "$NEWEST_REVIEWED_HEAD" = "$HEAD_SHA" ]; then
         echo "SKIP: bot-trigger dedupe — @${COMMENTER} re-triggered on HEAD ${HEAD_SHA} which the newest summary already reviewed. Gate was not authoritative (runs outside the concurrency lock). Stopping without posting."
+        # S4: Restore the commit status so the dispatch run's pending state
+        # does not linger after this no-op. The dispatch run always sets
+        # sdk-review to "pending" before the sandbox starts. If the sandbox
+        # exits here without posting a new verdict comment, the fast-path
+        # approve workflow never fires, and the pending status persists —
+        # which is misleading (the review was already delivered). Re-apply
+        # the status implied by the prior verdict.
+        PRIOR_VERDICT=$(grep -oE '<!-- VERDICT: [A-Z_]+ -->' /tmp/PRIOR_REVIEW.md \
+          | grep -oE '[A-Z_]+' | head -1 || true)
+        case "$PRIOR_VERDICT" in
+          "READY_TO_MERGE")
+            gh api "repos/${REPO}/statuses/${HEAD_SHA}" -X POST \
+              -f state=success -f context=sdk-review \
+              -f description="Approved (bot-retrigger skipped: already reviewed this HEAD)" 2>/dev/null || true;;
+          "")
+            : # No prior verdict found — leave status as-is to avoid stomping
+            ;;
+          *)
+            gh api "repos/${REPO}/statuses/${HEAD_SHA}" -X POST \
+              -f state=failure -f context=sdk-review \
+              -f description="Verdict: ${PRIOR_VERDICT} (bot-retrigger skipped: already reviewed this HEAD)" 2>/dev/null || true;;
+        esac
         exit 0
       fi
     fi

--- a/.mothership/pr-review/ORCHESTRATION.md
+++ b/.mothership/pr-review/ORCHESTRATION.md
@@ -221,6 +221,35 @@ BUDGET
     re-trigger against an unchanged HEAD comes from a *different* run and
     must still produce a review.
 
+    **Bot-trigger dedupe guard — run immediately after the replay guard.**
+    The `gate` job in `sdk-review.yml` is an *optimization*, not the
+    authority: it runs outside the per-PR concurrency group, so two
+    automated triggers can both pass it concurrently ("no review for this
+    HEAD yet") and both reach the sandbox. The sandbox runs inside the
+    concurrency lock and is the only place that sees true comment state.
+
+    Check: if `COMMENTER` is an automated trigger (`mothership-ai[bot]`
+    or `atlan-ci`) **and** the newest summary's `<!-- REVIEWED_HEAD -->`
+    equals `HEAD_SHA`, this run is a duplicate. Stop without posting.
+    Humans (`COMMENTER` is any other login) are never stopped by this
+    guard — re-reading the same diff is a legitimate human request.
+
+    Use "newest summary" (the body already in `/tmp/PRIOR_REVIEW.md`),
+    never the oldest.
+
+    ```bash
+    # COMMENTER and HEAD_SHA are from the prompt header.
+    BOT_TRIGGERS="mothership-ai[bot] atlan-ci"
+    if echo "$BOT_TRIGGERS" | grep -qF "$COMMENTER"; then
+      NEWEST_REVIEWED_HEAD=$(grep -oE '<!-- REVIEWED_HEAD: [0-9a-f]{40} -->' /tmp/PRIOR_REVIEW.md \
+        | grep -oE '[0-9a-f]{40}' || true)
+      if [ -n "$NEWEST_REVIEWED_HEAD" ] && [ "$NEWEST_REVIEWED_HEAD" = "$HEAD_SHA" ]; then
+        echo "SKIP: bot-trigger dedupe — @${COMMENTER} re-triggered on HEAD ${HEAD_SHA} which the newest summary already reviewed. Gate was not authoritative (runs outside the concurrency lock). Stopping without posting."
+        exit 0
+      fi
+    fi
+    ```
+
 6c. **Compute the re-review delta (scope-cutter).** Each review summary
     stamps the HEAD it reviewed as `<!-- REVIEWED_HEAD: <sha> -->` (§3e).
     On a re-review, use it to scope Phase 1–2 to what actually changed —

--- a/.mothership/pr-review/ORCHESTRATION.md
+++ b/.mothership/pr-review/ORCHESTRATION.md
@@ -196,16 +196,21 @@ BUDGET
     different wording from a single `@sdk-review` trigger, and the
     workflow's soft-success check passes because *a* summary exists.
 
-    The prior summary's footer carries the run URL that produced it
-    (§3e). If it is **this** run's URL, this process is a replay of work
-    that already landed:
+    Every summary's footer carries the run URL that produced it (§3e),
+    and §3f posts the summary **last**, after the inline comments and the
+    commit status — so a summary bearing this run's URL means this run's
+    submission completed in full. Check *every* summary on the PR, not
+    just the one 6b loaded: that one is only the latest, and an unrelated
+    review landing between the first pass and the replay would hide this
+    run's footer behind it.
 
     ```bash
     # GHA_RUN_URL is given in the session prompt — substitute it literally,
     # shell variables do not persist between Bash calls.
-    if grep -qF '<GHA_RUN_URL>' /tmp/PRIOR_REVIEW.md; then
-      echo "REPLAY: this run already posted its review summary"
-    fi
+    gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --paginate --slurp 2>/dev/null \
+      | jq -r '[.[][] | select(.body | contains("<!-- SDK_REVIEW -->")) | .body] | join("\n")' \
+      | grep -qF '<GHA_RUN_URL>' \
+      && echo "REPLAY: this run already posted its review summary"
     ```
 
     If that prints `REPLAY`, **stop the entire run here**: post nothing,
@@ -1335,9 +1340,17 @@ if [ "$review_scope" = "contract-toolkit" ] || [ "$review_scope" = "mixed-sdk-to
   done
 fi
 
-# Summary comment (the body built in 3a, including the
-# <!-- SDK_REVIEW --> marker and the <!-- REVIEW_DATA --> JSON):
-gh pr comment "$PR_NUMBER" --repo "$REPO" --body-file /tmp/review-summary.md
+# ORDER MATTERS — the summary comment goes LAST, after the inline
+# comments and the commit status.
+#
+# The summary is the completion signal that everything downstream keys
+# off: `sdk-review-approve-on-verdict.yml` fires on it, the workflow's
+# soft-success check treats its presence as "the review was delivered",
+# and the Phase 0 §6b replay guard reads its footer to decide whether a
+# recovered run has already done this work. Post it first and all three
+# read a partial submission — inline findings still unposted, status
+# unset — as a completed one. Posting it last makes its presence mean
+# what every consumer already assumes it means.
 
 # Inline finding comments — post one per finding via
 # `gh api repos/$REPO/pulls/$PR_NUMBER/comments` so each can target a
@@ -1355,6 +1368,10 @@ gh api "repos/$REPO/statuses/$HEAD_SHA" \
   -f state="$STATE" \
   -f description="$DESCRIPTION"
 # where STATE ∈ success|failure|pending and DESCRIPTION ≤ 140 chars
+
+# Summary comment (the body built in 3a, including the
+# <!-- SDK_REVIEW --> marker and the <!-- REVIEW_DATA --> JSON) — LAST:
+gh pr comment "$PR_NUMBER" --repo "$REPO" --body-file /tmp/review-summary.md
 ```
 
 Retry once on 5xx from the GitHub API. On 422 (malformed inline
@@ -1371,9 +1388,10 @@ Print: `[Phase 3 complete] Review submitted`
 
 ## If You Cannot Finish
 
-Always post the summary comment + set the commit status before
-exiting (see Phase 3f). A PR with no review comment
-and no status update is the worst outcome.
+Always set the commit status + post the summary comment before
+exiting (see Phase 3f — status first, summary last, same order as the
+happy path). A PR with no review comment and no status update is the
+worst outcome.
 
 Submit minimal:
 ```json

--- a/.mothership/pr-review/ORCHESTRATION.md
+++ b/.mothership/pr-review/ORCHESTRATION.md
@@ -185,6 +185,37 @@ BUDGET
     threads) the human's response, which materially changes what
     counts as a "new" finding vs a known-and-discussed one.
 
+    **Same-run replay guard — run this immediately after loading
+    `/tmp/PRIOR_REVIEW.md`, before anything else.** When the Claude
+    stream drops mid-run (sandbox VPN reconnect, container eviction,
+    transient API error), mothership recovers by re-running this prompt
+    **from the top in the same sandbox** — a fresh run, not a `--resume`.
+    If the first pass had already posted its summary, that retry loads
+    its own summary as `PRIOR_REVIEW`, sees an empty delta, and posts a
+    SECOND summary for the same HEAD. The PR then shows two reviews with
+    different wording from a single `@sdk-review` trigger, and the
+    workflow's soft-success check passes because *a* summary exists.
+
+    The prior summary's footer carries the run URL that produced it
+    (§3e). If it is **this** run's URL, this process is a replay of work
+    that already landed:
+
+    ```bash
+    # GHA_RUN_URL is given in the session prompt — substitute it literally,
+    # shell variables do not persist between Bash calls.
+    if grep -qF '<GHA_RUN_URL>' /tmp/PRIOR_REVIEW.md; then
+      echo "REPLAY: this run already posted its review summary"
+    fi
+    ```
+
+    If that prints `REPLAY`, **stop the entire run here**: post nothing,
+    set no commit status, resolve no threads, do not continue to Phase 1.
+    The review was already delivered by the pass that died.
+
+    Key the guard on the run URL, never on `HEAD_SHA` alone — a genuine
+    re-trigger against an unchanged HEAD comes from a *different* run and
+    must still produce a review.
+
 6c. **Compute the re-review delta (scope-cutter).** Each review summary
     stamps the HEAD it reviewed as `<!-- REVIEWED_HEAD: <sha> -->` (§3e).
     On a re-review, use it to scope Phase 1–2 to what actually changed —


### PR DESCRIPTION
## What users saw

Measured over one afternoon: 100 workflow runs, 28 real, of those 19 success / 6 failure / 3 cancelled, every cancel followed by a failure. Four distinct misbehaviours — two reviews for one tag; a human tag killing a run 28 minutes in that had not yet posted; the retry after a cancel failing with `No conversation found with session`; and a verdict computed for head H approving a later H2, so unreviewed code satisfied CODEOWNERS.

## What this changes

Consolidates two PRs and fixes five defects an adversarial review found in them:

**Provenance.** Both approval paths — the fast path in `sdk-review-approve-on-verdict.yml` and the slow path in `sdk-review.yml` — now require `REVIEWED_HEAD` from the verdict comment to equal the live head before any label, status or approval write. A missing marker means "cannot verify" and does not approve. This is only safe as a pair with `cancel-in-progress: false`: keeping older runs alive is what lets a late verdict arrive, and this guard is what rejects it. Shipping either alone is worse than neither, which is why they are one PR.

**The marker is actually written.** The `REVIEWED_HEAD` template used a `<HEAD_SHA>` placeholder with no substitution instruction, so the sandbox could emit the literal text. There is now an explicit instruction plus an idempotent `sed` safety net from `/tmp/PR.json`'s `.headRefOid` before the summary posts. Without this the guard above is inert.

**Approval is pinned to the reviewed sha.** The head check alone is TOCTOU: a push can land between the check and the write, and the label is PR-scoped while the commit status is sha-scoped. Both paths now POST to the reviews API with `commit_id` set to the reviewed sha rather than calling `gh pr review --approve`. Caveat stated honestly: full protection against a mid-check push additionally requires `dismiss_stale_reviews_on_push` on `main`'s protection rule, which could not be verified — `gh api .../branches/main/protection` returns 404 from a non-admin token. Please confirm that setting. Label writes remain PR-scoped with no sha-conditional API; that residual window is documented, not closed.

**Freshness, not just identity.** The sha check passes for every verdict on the same head, so a delayed older `READY_TO_MERGE` could execute after a newer `NEEDS_FIXES` and restore the approval. Verdict processing is now serialized per PR, the triggering comment must still be the newest sdk summary, and a non-ready verdict dismisses any prior bot approval.

**A deduped duplicate no longer degrades PR state.** The authoritative dedupe in ORCHESTRATION.md §6b ran after the starter comment and the `pending` status were written, so a correctly-skipped duplicate could leave a well-reviewed PR stuck pending. The skip path now restores the prior verdict's commit status.

**Pagination.** `gh api --paginate --jq` runs the filter once per page and concatenates results, so the newest-summary extraction returned multiple `REVIEWED_HEAD` values and the equality check silently never matched — duplicate reviews returned on any PR whose comments span pages. Fixed in both places it occurred, with a two-page fixture test. The earlier mutation suite used single-page fixtures and could not see this.

**Retry after cancel.** The mothership session id now includes `github.run_attempt`; `GITHUB_RUN_ID` does not change on a re-run, so re-running a failed review used to resend a dead session id.

**A skip is visible.** A skipped bot trigger reacts `confused` — distinct from `eyes` on proceed — with no new PR comment for the resolver to re-read.

**A gate failure never swallows a tag.** Head resolution retries three times with backoff and then fails open with `reason=head-resolution-failed`, plus an `if: always() && failure()` step that comments naming the failure. Reviewing is the safe default; a missing review is the harmful outcome. Humans are never gated at any layer.

## Verification

Gate suite 1015 passed locally (`test_release.py` collection error is pre-existing, missing `semver`). Mutations: forward-instead-of-reversed comment scan kills 3 tests; disabling page flattening kills 4; the three established gate mutations still hold — invert the skip rule 5, remove the human bypass exactly 1, oldest-instead-of-newest 3. `actionlint` clean on both workflows.

## Cannot be tested locally

GitHub Actions concurrency, cancel semantics and cross-workflow ordering have no local harness. Needs a throwaway PR: tag twice 10s apart on one head; tag then push mid-review; re-run a failed review from the UI; resolver tags an unchanged head; revoke the gate's token to force a `gh api` failure.
