### PR TITLE
ci(e2e): extract the image build into a build-app-image composite

### DIFF
--- a/.github/actions/build-app-image/action.yaml
+++ b/.github/actions/build-app-image/action.yaml
@@ -1,0 +1,240 @@
+name: Build App Image
+description: |
+  Build and push a connector's PR test image to GHCR, and assert its
+  interpreter matches the expected Python.
+
+  Extracted from `sdr-e2e` (FND-31) so the image can be built ONCE per run,
+  ahead of the e2e matrix, rather than rebuilt by every cloud leg. The
+  full-DAG pipeline needs the image before any leg starts — `prepare-tenant`
+  installs it onto the target tenant so the tenant serves the app under test
+  rather than whatever was last hand-deployed there.
+
+  The image reference is deterministic (`sdr-test-<short-sha>`), so a caller
+  that builds here and a caller that reads `image` back later agree without
+  passing anything around.
+
+  Caller is responsible for:
+  - Checking out the connector repo (this action does NOT call actions/checkout)
+  - Invoking this BEFORE any step that creates a host `.venv` — the Dockerfile's
+    `COPY . .` would otherwise pull in a virtualenv whose Python symlinks point
+    outside the image.
+
+  Self-testing caveat: `sdr-e2e` invokes this as a nested remote action
+  (`@main`), so on the LOCAL-action dispatch path
+  (`./.application-sdk/.github/actions/sdr-e2e`) these steps come from main,
+  not from the application-sdk PR under test. That is the same property
+  `regenerate-contract` and `setup-deps` already have inside this sequence — a
+  PR editing the build steps is exercised through the remote `@main` path and
+  the merge queue, not through a local-action dispatch. Kept explicit here so
+  the limitation is inherited knowingly rather than discovered.
+
+inputs:
+  app-name:
+    description: |
+      Connector short name (e.g. "mysql"). Used only as the buildx cache
+      scope and for log lines. Keep this stable: the scope is
+      `sdr-<app-name>`, and changing it silently discards the warm
+      `uv sync` layer cache.
+    required: true
+  app-image-name:
+    description: |
+      GHCR image name (e.g. "atlan-mysql-app"). The image is tagged
+      ghcr.io/atlanhq/<app-image-name>:sdr-test-<short-sha>.
+    required: true
+  application-sdk-ref:
+    description: |
+      Already-resolved application-sdk ref to repin before the build — the
+      RUNTIME side. Empty (default) builds from the connector's OWN
+      pinned/locked SDK, which is the usual case (the app is tested as
+      shipped).
+
+      This takes a resolved value rather than the runtime/harness/shared
+      triple: `sdr-e2e` owns that fallback because it also needs the harness
+      side after setup-deps, and duplicating the precedence here would give
+      the two sides two places to disagree.
+    required: false
+    default: ""
+  base-image-ref:
+    description: |
+      Optional runtime base image to build FROM, injected as the BASE_IMAGE
+      build-arg. Set by apps-sdk cross-repo dispatch to a freshly-built PR
+      base image so Dockerfile / base-image / daprd changes in the SDK PR are
+      exercised through a real connector build. Empty (the default) leaves
+      the connector Dockerfile's own default FROM untouched.
+    required: false
+    default: ""
+  git-token:
+    description: |
+      Optional GitHub token forwarded to the buildx build as the `git_token`
+      build secret, for connectors whose pyproject.toml declares git+ssh /
+      git+https dependencies on other private atlanhq repos. Empty (default)
+      appends no `--secret` flag, so PyPI-only connectors are unaffected.
+    required: false
+    default: ""
+  ghcr-token:
+    description: |
+      Optional token for the GHCR login. Some connector packages are
+      PAT-published and are NOT writable by the default `GITHUB_TOKEN`, so a
+      plain-token push 403s for those apps. Pass the org-scoped PAT
+      (typically `secrets.ORG_PAT_GITHUB`) to push with the package-owning
+      identity. Empty (default) falls back to `github.token`.
+    required: false
+    default: ""
+  expected-python-version:
+    description: |
+      The Python major.minor the built image is expected to ship — the
+      connector Dockerfile's golden base tag. Asserted against the built
+      image's interpreter so we never validate on one interpreter and ship on
+      another (the CNCT-85 failure mode). Empty disables the assertion; only
+      do that for a caller that has no interpreter expectation at all.
+    required: false
+    default: "3.13"
+
+outputs:
+  image:
+    description: The full image reference built and pushed for this run.
+    value: ${{ steps.build.outputs.image }}
+
+runs:
+  using: composite
+  steps:
+    - name: Log in to GHCR
+      uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        # Prefer the caller-supplied org PAT (writes PAT-published connector
+        # packages); fall back to github.token when unset.
+        password: ${{ inputs.ghcr-token != '' && inputs.ghcr-token || github.token }}
+
+    # Cross-repo dispatch from apps-sdk PRs hands us a specific SDK ref;
+    # rewrite the [tool.uv.sources] entry so the Docker build's COPY +
+    # uv sync resolves atlan-application-sdk to that ref.
+    #
+    # The Docker build runs `uv sync --locked`, which requires uv.lock and
+    # pyproject.toml to be consistent. The repin only modifies
+    # pyproject.toml, so install uv inline and `uv lock` before the build to
+    # keep them aligned. setup-uv isn't used because a composite can't
+    # invoke another action under a conditional `uses:` — the curl install is
+    # the simplest fallback that doesn't pin a runner image.
+    #
+    # The script is shared from the sibling action rather than copied a third
+    # time. Reaching across action dirs with `../` is the established pattern
+    # here (see connector-unit-tests/action.yaml, which reads
+    # connector-integration-tests' copy the same way). Note there are already
+    # two byte-identical copies of this script in the repo; consolidating them
+    # is worth doing, but not as a side effect of this change.
+    - name: Pin application-sdk to dispatched ref (pre-build)
+      if: inputs.application-sdk-ref != ''
+      shell: bash
+      env:
+        SDK_REF: ${{ inputs.application-sdk-ref }}
+      run: |
+        "${{ github.action_path }}/../sdr-e2e/repin-application-sdk.sh"
+        if ! command -v uv >/dev/null 2>&1; then
+          echo "Installing uv for the pre-build re-lock..."
+          curl -LsSf https://astral.sh/uv/0.7.3/install.sh | sh
+          export PATH="$HOME/.local/bin:$PATH"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+        fi
+        uv lock
+
+    # Regenerate app/generated/** (incl. manifest.json — the AE DAG) from
+    # contract/app.pkl BEFORE the image build, so the connector image bakes a
+    # manifest generated from the CURRENT contract + toolkit rather than a
+    # possibly-stale committed one (BLDX-1493). It must precede the buildx
+    # build below that COPYs the tree.
+    #
+    # This matters more than it used to. Heracles re-fetches the manifest from
+    # the tenant-deployed pod at AE submit time and THAT DAG is what runs
+    # (heracles/handler/workflow.go, processAutomationEngineWorkflow) — so the
+    # manifest baked in here is the contract the full-DAG e2e actually
+    # exercises once the image is installed on the tenant, not just a local
+    # seed. See FND-31.
+    #
+    # check-drift is false: uv/ruff aren't installed yet, so generated-Python
+    # formatting is skipped here; the warn-only drift gate lives in the
+    # connector-integration-tests job. Self-skips when no contract/app.pkl.
+    - name: Regenerate contract artifacts (manifest.json) before image build
+      uses: atlanhq/application-sdk/.github/actions/regenerate-contract@main
+      with:
+        application-sdk-ref: ${{ inputs.application-sdk-ref }}
+        check-drift: "false"
+
+    # Buildx is required for the GHA cache backend below.
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+
+    # `cache-from/cache-to: type=gha` plugs buildx into GitHub Actions'
+    # cache backend so the expensive `uv sync` layer (~2 min on a cold
+    # build) is reused across PR pushes. `mode=max` saves intermediate
+    # stages too, which matters here because the Dockerfile has a
+    # separate dependency-install layer ahead of the source copy.
+    # `scope:` is keyed on the connector so two repos sharing this
+    # action don't collide caches.
+    - name: Build and push PR image
+      id: build
+      shell: bash
+      env:
+        BASE_IMAGE_REF: ${{ inputs.base-image-ref }}
+        # Read by --secret id=git_token,env=GIT_TOKEN below. The env-var
+        # form (vs --secret-file) keeps the token out of the buildx
+        # command line and out of any tmpfile on the runner — buildx
+        # streams it directly into the build context.
+        GIT_TOKEN: ${{ inputs.git-token }}
+      run: |
+        SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-8)
+        IMAGE="ghcr.io/atlanhq/${{ inputs.app-image-name }}:sdr-test-${SHORT_SHA}"
+        # When a base-image-ref is supplied (apps-sdk cross-repo dispatch),
+        # build the connector FROM that image via the BASE_IMAGE build-arg
+        # so the SDK PR's rebuilt runtime base is exercised. Append the flag
+        # ONLY when non-empty — passing `BASE_IMAGE=` empty would clobber the
+        # Dockerfile's default FROM and break the non-e2e / merge-queue path.
+        BUILD_ARGS=()
+        if [ -n "${BASE_IMAGE_REF}" ]; then
+          echo "Building connector on dispatched base image: ${BASE_IMAGE_REF}"
+          BUILD_ARGS+=(--build-arg "BASE_IMAGE=${BASE_IMAGE_REF}")
+        fi
+        # When the caller supplies git-token, forward it as the
+        # `git_token` build secret so Dockerfiles that clone private
+        # atlanhq repos during `uv sync` can authenticate. Connectors
+        # with PyPI-only deps don't need this — leaving the input empty
+        # skips the flag entirely so their builds stay unchanged.
+        if [ -n "${GIT_TOKEN}" ]; then
+          echo "Forwarding git-token to docker build as 'git_token' secret"
+          BUILD_ARGS+=(--secret "id=git_token,env=GIT_TOKEN")
+        fi
+        # --push pushes to GHCR; compose pulls from there at run-time
+        # (atlan-configurator wires app_image into the generated
+        # compose file as a pull target). --load would conflict with
+        # --push under the standard buildx driver, and we don't need
+        # the image in the local daemon since compose handles the pull.
+        docker buildx build \
+          --tag "${IMAGE}" \
+          --push \
+          "${BUILD_ARGS[@]}" \
+          --cache-from "type=gha,scope=sdr-${{ inputs.app-name }}" \
+          --cache-to "type=gha,mode=max,scope=sdr-${{ inputs.app-name }}" \
+          .
+        echo "image=${IMAGE}" >> "$GITHUB_OUTPUT"
+
+    # The built worker image is what actually runs the connector; its Python is
+    # fixed by the Dockerfile's golden base, not by anything this runner
+    # installs. Assert it matches `expected-python-version` so we never validate
+    # on one interpreter and ship on another — the CNCT-85 failure mode, where a
+    # concurrent-decode segfault surfaced only on the container's Python.
+    # `--entrypoint python` bypasses the app entrypoint; the base interpreter's
+    # major.minor is the golden tag we assert (venv shares it). The comparison
+    # logic lives in the tested script per docs/standards/ci.md (no branching in
+    # inline shell).
+    - name: Assert worker image Python matches expected
+      if: inputs.expected-python-version != ''
+      shell: bash
+      env:
+        IMAGE: ${{ steps.build.outputs.image }}
+        EXPECTED: ${{ inputs.expected-python-version }}
+      run: |
+        ACTUAL=$(docker run --rm --entrypoint python "${IMAGE}" --version)
+        echo "Worker image reports: ${ACTUAL} (expected ${EXPECTED}.x)"
+        python3 "${{ github.action_path }}/../../scripts/container_python_version.py" \
+          check-interpreter --expected "${EXPECTED}" --actual "${ACTUAL}"

--- a/.github/actions/sdr-e2e/action.yaml
+++ b/.github/actions/sdr-e2e/action.yaml
@@ -270,6 +270,23 @@ inputs:
       callers that don't wire this stay on the previous behaviour.
     required: false
     default: ""
+  prebuilt-image:
+    description: |
+      Full image reference to use INSTEAD of building one here. When set, the
+      build/push (and the interpreter assertion that goes with it) is skipped
+      and this reference is used everywhere the built image would have been —
+      the configurator's `app_image`, and the action's `image` output.
+
+      Set by the full-DAG pipeline (FND-31): the image is built once per run,
+      ahead of the e2e matrix, so `prepare-tenant` can install it onto the
+      target tenant before any leg starts. Every cloud leg then reuses that
+      exact reference instead of rebuilding the same deterministic
+      `sdr-test-<short-sha>` tag N times.
+
+      The caller is responsible for the reference being present in GHCR before
+      it invokes this action; nothing here waits for a push.
+    required: false
+    default: ""
   expected-python-version:
     description: |
       The Python major.minor the built worker image is expected to ship — the
@@ -290,8 +307,10 @@ outputs:
     description: One-line pytest summary (e.g. "9 passed, 1 failed in 38s")
     value: ${{ steps.tests.outputs.summary }}
   image:
-    description: The full image reference built and pushed for this run.
-    value: ${{ steps.build.outputs.image }}
+    description: |
+      The full image reference used for this run — the one built here, or
+      `prebuilt-image` when the caller supplied it.
+    value: ${{ steps.image.outputs.ref }}
 
 runs:
   using: composite
@@ -306,20 +325,6 @@ runs:
         # for callers that don't pass ghcr-token).
         password: ${{ inputs.ghcr-token != '' && inputs.ghcr-token || github.token }}
 
-    # Cross-repo dispatch from apps-sdk PRs hands us a specific SDK ref;
-    # rewrite the [tool.uv.sources] entry so the Docker build's COPY +
-    # uv sync resolves atlan-application-sdk to that ref. Repeated again
-    # below after setup-deps re-checks-out the workspace (which wipes
-    # this edit) so the host pytest runtime also picks up the ref.
-    #
-    # The Docker build runs `uv sync --locked` which requires uv.lock and
-    # pyproject.toml to be consistent. The repin only modifies
-    # pyproject.toml, so install uv inline and run `uv lock` before the
-    # Docker build to keep them aligned. setup-uv@v5 (which installs uv
-    # the "official" way) isn't available here because the composite
-    # action can't invoke another action mid-sequence with conditional
-    # `uses:` — curl install is the simplest fallback that doesn't pin a
-    # specific runner image.
     # Stash the entire action directory to /tmp before setup-deps'
     # actions/checkout wipes the workspace. When this action is invoked
     # as a LOCAL action (uses: ./.application-sdk/.github/actions/sdr-e2e),
@@ -340,7 +345,11 @@ runs:
     # (runtime||shared) / (harness||shared) fallback isn't repeated as a GHA
     # `(a && a || b)` ternary at every call site. Plain `${VAR:-$SHARED}`
     # parameter expansion (straight-line, no branching — ci.md-compliant); an
-    # empty output means "no repin" and the dependent step is skipped via `if:`.
+    # empty output means "no repin" — the harness side skips via `if:` below,
+    # and the runtime side is handed to build-app-image, which skips its own
+    # repin on empty. The precedence lives here rather than in build-app-image
+    # because the harness side needs it too, and two owners would be two places
+    # for the sides to disagree.
     - name: Resolve effective application-sdk refs
       id: sdk_refs
       shell: bash
@@ -354,120 +363,57 @@ runs:
           echo "harness_ref=${HARNESS_SDK_REF:-$SHARED_SDK_REF}"
         } >> "$GITHUB_OUTPUT"
 
-    - name: Pin application-sdk to dispatched ref (pre-build)
-      # Runtime side: runtime-sdk-ref wins, else the shared application-sdk-ref,
-      # else empty = build the image from the connector's OWN pinned SDK.
-      if: steps.sdk_refs.outputs.runtime_ref != ''
-      shell: bash
-      env:
-        SDK_REF: ${{ steps.sdk_refs.outputs.runtime_ref }}
-      run: |
-        ${{ github.action_path }}/repin-application-sdk.sh
-        if ! command -v uv >/dev/null 2>&1; then
-          echo "Installing uv for the pre-build re-lock..."
-          curl -LsSf https://astral.sh/uv/0.7.3/install.sh | sh
-          export PATH="$HOME/.local/bin:$PATH"
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-        fi
-        uv lock
-
-    # Regenerate app/generated/** (incl. manifest.json — the AE DAG) from
-    # contract/app.pkl BEFORE the image build, so the connector image bakes a
-    # manifest generated from the CURRENT contract + toolkit rather than a
-    # possibly-stale committed one (BLDX-1493). This is the ONLY regeneration in
-    # this action — it must precede the buildx build below that COPYs the tree.
-    # check-drift is false: uv/ruff aren't installed until setup-deps (later), so
-    # generated-Python formatting is skipped here; the warn-only drift gate lives
-    # in the connector-integration-tests job. Self-skips when no contract/app.pkl.
-    - name: Regenerate contract artifacts (manifest.json) before image build
-      uses: atlanhq/application-sdk/.github/actions/regenerate-contract@main
-      with:
-        # Runtime side (baked into the image) — mirror the pre-build repin.
-        application-sdk-ref: ${{ steps.sdk_refs.outputs.runtime_ref }}
-        check-drift: "false"
-
-    # Buildx is required for the GHA cache backend below. Set up once
-    # per run, before the image build that uses `cache-from/cache-to`.
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
-
-    # Image build runs before setup-deps so the workspace is still pristine —
-    # no host .venv yet, so the Dockerfile's COPY . . won't pull in a
-    # host-built virtualenv whose Python symlinks point outside the image.
+    # Build the image (repin -> regenerate manifest -> buildx -> push ->
+    # interpreter assert). Lives in its own composite so the full-DAG pipeline
+    # can build ONCE per run, ahead of the e2e matrix, and install that image
+    # onto the target tenant before any leg starts (FND-31). Skipped entirely
+    # when the caller passes `prebuilt-image` — which is exactly what the
+    # full-DAG legs do, so they reuse the reference rather than rebuilding the
+    # same deterministic tag N times.
     #
-    # `cache-from/cache-to: type=gha` plugs buildx into GitHub Actions'
-    # cache backend so the expensive `uv sync` layer (~2 min on a cold
-    # build) is reused across PR pushes. `mode=max` saves intermediate
-    # stages too, which matters here because the Dockerfile has a
-    # separate dependency-install layer ahead of the source copy.
-    # `scope:` is keyed on the connector so two repos sharing this
-    # action don't collide caches.
+    # Runs before setup-deps so the workspace is still pristine — no host
+    # .venv yet, so the Dockerfile's COPY . . won't pull in a host-built
+    # virtualenv whose Python symlinks point outside the image.
+    #
+    # Runtime side: runtime-sdk-ref wins, else the shared application-sdk-ref,
+    # else empty = build from the connector's OWN pinned SDK.
     - name: Build and push PR image
       id: build
-      shell: bash
-      env:
-        BASE_IMAGE_REF: ${{ inputs.base-image-ref }}
-        # Read by --secret id=git_token,env=GIT_TOKEN below. The env-var
-        # form (vs --secret-file) keeps the token out of the buildx
-        # command line and out of any tmpfile on the runner — buildx
-        # streams it directly into the build context.
-        GIT_TOKEN: ${{ inputs.git-token }}
-      run: |
-        SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-8)
-        IMAGE="ghcr.io/atlanhq/${{ inputs.app-image-name }}:sdr-test-${SHORT_SHA}"
-        # When a base-image-ref is supplied (apps-sdk cross-repo dispatch),
-        # build the connector FROM that image via the BASE_IMAGE build-arg
-        # so the SDK PR's rebuilt runtime base is exercised. Append the flag
-        # ONLY when non-empty — passing `BASE_IMAGE=` empty would clobber the
-        # Dockerfile's default FROM and break the non-e2e / merge-queue path.
-        BUILD_ARGS=()
-        if [ -n "${BASE_IMAGE_REF}" ]; then
-          echo "Building connector on dispatched base image: ${BASE_IMAGE_REF}"
-          BUILD_ARGS+=(--build-arg "BASE_IMAGE=${BASE_IMAGE_REF}")
-        fi
-        # When the caller supplies git-token, forward it as the
-        # `git_token` build secret so Dockerfiles that clone private
-        # atlanhq repos during `uv sync` can authenticate. Connectors
-        # with PyPI-only deps don't need this — leaving the input empty
-        # skips the flag entirely so their builds stay unchanged.
-        if [ -n "${GIT_TOKEN}" ]; then
-          echo "Forwarding git-token to docker build as 'git_token' secret"
-          BUILD_ARGS+=(--secret "id=git_token,env=GIT_TOKEN")
-        fi
-        # --push pushes to GHCR; compose pulls from there at run-time
-        # (atlan-configurator wires app_image into the generated
-        # compose file as a pull target). --load would conflict with
-        # --push under the standard buildx driver, and we don't need
-        # the image in the local daemon since compose handles the pull.
-        docker buildx build \
-          --tag "${IMAGE}" \
-          --push \
-          "${BUILD_ARGS[@]}" \
-          --cache-from "type=gha,scope=sdr-${{ inputs.app-name }}" \
-          --cache-to "type=gha,mode=max,scope=sdr-${{ inputs.app-name }}" \
-          .
-        echo "image=${IMAGE}" >> "$GITHUB_OUTPUT"
+      if: inputs.prebuilt-image == ''
+      uses: atlanhq/application-sdk/.github/actions/build-app-image@main
+      with:
+        app-name: ${{ inputs.app-name }}
+        app-image-name: ${{ inputs.app-image-name }}
+        application-sdk-ref: ${{ steps.sdk_refs.outputs.runtime_ref }}
+        base-image-ref: ${{ inputs.base-image-ref }}
+        git-token: ${{ inputs.git-token }}
+        ghcr-token: ${{ inputs.ghcr-token }}
+        expected-python-version: ${{ inputs.expected-python-version }}
 
-    # The built worker image is what actually runs the connector; its Python is
-    # fixed by the Dockerfile's golden base, not by anything this runner
-    # installs. Assert it matches `expected-python-version` so we never validate
-    # on one interpreter and ship on another — the CNCT-85 failure mode, where a
-    # concurrent-decode segfault surfaced only on the container's Python.
-    # `--entrypoint python` bypasses the app entrypoint; the base interpreter's
-    # major.minor is the golden tag we assert (venv shares it). Runs before
-    # setup-deps wipes the workspace, so the SoT script under the action
-    # checkout is still reachable. The comparison logic lives in the tested
-    # script per docs/standards/ci.md (no branching in inline shell).
-    - name: Assert worker image Python matches expected
+    # One writer of the image reference, so no downstream step has to know
+    # whether it was built here or handed in. `${VAR:-$OTHER}` rather than a
+    # GHA ternary: straight-line parameter expansion, ci.md-compliant, and it
+    # reads the same on both paths.
+    #
+    # A skipped step's outputs are empty, so when `prebuilt-image` is set the
+    # build output is empty and the prebuilt reference wins; when it isn't, the
+    # build output is the only non-empty value. Both empty is a bug, not a
+    # degraded mode — fail rather than let the configurator template an empty
+    # app_image and surface as an opaque compose pull error.
+    - name: Resolve effective image reference
+      id: image
       shell: bash
       env:
-        IMAGE: ${{ steps.build.outputs.image }}
-        EXPECTED: ${{ inputs.expected-python-version }}
+        PREBUILT: ${{ inputs.prebuilt-image }}
+        BUILT: ${{ steps.build.outputs.image }}
       run: |
-        ACTUAL=$(docker run --rm --entrypoint python "${IMAGE}" --version)
-        echo "Worker image reports: ${ACTUAL} (expected ${EXPECTED}.x)"
-        python3 "${{ github.action_path }}/../../scripts/container_python_version.py" \
-          check-interpreter --expected "${EXPECTED}" --actual "${ACTUAL}"
+        REF="${PREBUILT:-$BUILT}"
+        test -n "$REF" || {
+          echo "::error::No image reference resolved: prebuilt-image is empty and the build produced no image. If the build step was skipped, pass prebuilt-image; if it ran, check its logs."
+          exit 1
+        }
+        echo "Using image: $REF"
+        echo "ref=$REF" >> "$GITHUB_OUTPUT"
 
     # Must run before atlan-configurator generates ci-deploy/ — setup-deps
     # uses actions/checkout internally which would wipe generated files.
@@ -573,7 +519,7 @@ runs:
       shell: bash
       env:
         APP_NAME: ${{ inputs.app-name }}
-        APP_IMAGE: ${{ steps.build.outputs.image }}
+        APP_IMAGE: ${{ steps.image.outputs.ref }}
       run: envsubst < "$APP_YAML_PATH" > app-resolved.yaml
 
     # Use the app's test-config template if it overrides the SDK default.

--- a/.github/scripts/tests/test_build_app_image_action.py
+++ b/.github/scripts/tests/test_build_app_image_action.py
@@ -1,0 +1,178 @@
+"""Structural guards for .github/actions/build-app-image and its sdr-e2e caller.
+
+The image build was extracted out of ``sdr-e2e`` (FND-31) so the full-DAG
+pipeline can build once per run, ahead of the e2e matrix, and install that
+image onto the target tenant before any leg starts. The extraction introduced
+three things that break *silently* rather than loudly, so each gets a guard
+here:
+
+1. **Cross-action asset paths.** ``build-app-image`` reads the repin script out
+   of the sibling ``sdr-e2e`` directory, and ``container_python_version.py``
+   out of ``.github/scripts``. Both are plain relative paths resolved at run
+   time — renaming or moving either directory leaves a path that only fails
+   inside a live e2e run, on a tenant, minutes in.
+
+2. **The prebuilt-image seam.** When a caller passes ``prebuilt-image`` the
+   build step is skipped, so ``steps.build.outputs.image`` is empty. Anything
+   still reading the build step's output directly would resolve to an empty
+   image reference; the configurator would template an empty ``app_image`` and
+   the failure would surface as an opaque compose pull error. The single
+   resolver step exists to prevent that, and the action's ``image`` output must
+   read *it*.
+
+3. **The buildx cache scope.** It is keyed ``sdr-<app-name>``. Changing the
+   string is invisible in review and merely makes every build cold — a ~2
+   minute regression per leg that no assertion would otherwise catch.
+
+These are YAML-shape assertions, deliberately. The behaviour they protect is
+GitHub Actions' own (skipped-step outputs, action path resolution), which
+cannot be exercised without a runner, so the contract is pinned at the point
+where a human edit would break it.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_ACTIONS = _REPO_ROOT / ".github" / "actions"
+_BUILD_ACTION_DIR = _ACTIONS / "build-app-image"
+_BUILD_ACTION = _BUILD_ACTION_DIR / "action.yaml"
+_SDR_ACTION = _ACTIONS / "sdr-e2e" / "action.yaml"
+
+
+def _steps(action_yaml: Path) -> list[dict]:  # type: ignore[type-arg]
+    parsed = yaml.safe_load(action_yaml.read_text(encoding="utf-8"))
+    return parsed["runs"]["steps"]
+
+
+def _step(action_yaml: Path, name: str) -> dict:  # type: ignore[type-arg]
+    for step in _steps(action_yaml):
+        if step.get("name") == name:
+            return step
+    raise AssertionError(f"{action_yaml.name} has no step named {name!r}")
+
+
+# ── 1. Cross-action asset paths resolve ──────────────────────────────────────
+# `${{ github.action_path }}/<rel>` is resolved against the action's own
+# directory at run time, so the same arithmetic is done here against
+# _BUILD_ACTION_DIR. Reaching into a sibling action is the established pattern
+# in this repo (connector-unit-tests reads connector-integration-tests' copy of
+# the repin script the same way), but nothing about it is checked by GitHub.
+
+
+@pytest.mark.parametrize(
+    "pattern, description",
+    [
+        (
+            r"\$\{\{ github\.action_path \}\}/(\S*?repin-application-sdk\.sh)",
+            "repin script",
+        ),
+        (
+            r"\$\{\{ github\.action_path \}\}/(\S*?container_python_version\.py)",
+            "interpreter-assert script",
+        ),
+    ],
+)
+def test_build_action_asset_paths_resolve(pattern: str, description: str) -> None:
+    text = _BUILD_ACTION.read_text(encoding="utf-8")
+    match = re.search(pattern, text)
+    assert match, f"build-app-image no longer references the {description}"
+
+    # Strip the quote the YAML uses around the interpolated path, if any.
+    relative = match.group(1).rstrip('"')
+    resolved = (_BUILD_ACTION_DIR / relative).resolve()
+    assert resolved.is_file(), (
+        f"build-app-image resolves the {description} to {resolved}, which does "
+        "not exist. An action or script directory moved without updating the "
+        "relative path — this fails only inside a live e2e run otherwise."
+    )
+
+
+# ── 2. The prebuilt-image seam ───────────────────────────────────────────────
+
+
+def test_sdr_e2e_declares_prebuilt_image_input() -> None:
+    parsed = yaml.safe_load(_SDR_ACTION.read_text(encoding="utf-8"))
+    assert "prebuilt-image" in parsed["inputs"], (
+        "sdr-e2e no longer declares prebuilt-image; the full-DAG legs would "
+        "each rebuild the image prepare-tenant already built and installed."
+    )
+    assert parsed["inputs"]["prebuilt-image"].get("default") == "", (
+        "prebuilt-image must default to empty so callers that do not set it "
+        "keep building their own image."
+    )
+
+
+def test_sdr_e2e_build_step_is_gated_on_prebuilt_image() -> None:
+    step = _step(_SDR_ACTION, "Build and push PR image")
+    assert step.get("if") == "inputs.prebuilt-image == ''", (
+        "the build step must be skipped when prebuilt-image is supplied, "
+        f"got if={step.get('if')!r}"
+    )
+    assert "build-app-image" in step["uses"], (
+        "sdr-e2e must delegate the build to build-app-image so prepare-tenant "
+        "and the legs share one implementation"
+    )
+    referenced = step["uses"].split("@")[0].rsplit("/", 1)[-1]
+    assert (
+        _ACTIONS / referenced / "action.yaml"
+    ).is_file(), f"sdr-e2e references the action {referenced!r}, which does not exist"
+
+
+def test_sdr_e2e_image_output_reads_the_resolver_not_the_build_step() -> None:
+    parsed = yaml.safe_load(_SDR_ACTION.read_text(encoding="utf-8"))
+    value = parsed["outputs"]["image"]["value"]
+    assert "steps.image.outputs.ref" in value, (
+        "sdr-e2e's `image` output must read the resolver step. Reading "
+        "steps.build.outputs.image directly returns EMPTY whenever "
+        "prebuilt-image is set, because a skipped step has no outputs."
+    )
+
+
+def test_no_step_reads_the_build_output_directly() -> None:
+    """Only the resolver may read the (possibly skipped) build step's output."""
+    offenders = [
+        step.get("name")
+        for step in _steps(_SDR_ACTION)
+        if step.get("name") != "Resolve effective image reference"
+        and "steps.build.outputs.image" in yaml.safe_dump(step)
+    ]
+    assert not offenders, (
+        f"these steps read steps.build.outputs.image directly: {offenders}. "
+        "That output is empty when prebuilt-image is set — read "
+        "steps.image.outputs.ref instead."
+    )
+
+
+def test_resolver_prefers_prebuilt_over_built() -> None:
+    step = _step(_SDR_ACTION, "Resolve effective image reference")
+    assert "${PREBUILT:-$BUILT}" in step["run"], (
+        "the resolver must prefer the caller-supplied prebuilt-image and fall "
+        "back to the built image"
+    )
+    # Both empty is a bug, not a degraded mode: an empty app_image reaches the
+    # configurator and surfaces as an opaque compose pull failure.
+    assert "exit 1" in step["run"], (
+        "the resolver must fail when neither an image was built nor one was "
+        "supplied, rather than emitting an empty reference"
+    )
+
+
+# ── 3. The buildx cache scope ────────────────────────────────────────────────
+
+
+def test_buildx_cache_scope_is_unchanged() -> None:
+    text = _BUILD_ACTION.read_text(encoding="utf-8")
+    # `[^"]` rather than `\S`: the scope interpolates `${{ inputs.app-name }}`,
+    # which contains spaces.
+    scopes = set(re.findall(r"scope=([^\"]+)\"", text))
+    assert scopes == {"sdr-${{ inputs.app-name }}"}, (
+        f"buildx cache scope changed to {scopes}. The scope was `sdr-<app-name>` "
+        "before the build was extracted from sdr-e2e; changing it silently "
+        "discards every connector's warm `uv sync` layer."
+    )

--- a/.github/scripts/tests/test_build_app_image_action.py
+++ b/.github/scripts/tests/test_build_app_image_action.py
@@ -176,3 +176,16 @@ def test_buildx_cache_scope_is_unchanged() -> None:
         "before the build was extracted from sdr-e2e; changing it silently "
         "discards every connector's warm `uv sync` layer."
     )
+    # The set comparison above catches a *changed* scope string but not a
+    # *deleted* cache direction — removing `--cache-from` entirely still leaves
+    # the `--cache-to` match, so the set stays a singleton and the test passes
+    # while every build goes cold-read. Pin both directions explicitly.
+    assert '--cache-from "type=gha,scope=sdr-${{ inputs.app-name }}"' in text, (
+        "the `--cache-from` line was removed. Builds would go cold-read on "
+        "every run, a ~2 minute regression per leg that no assertion would "
+        "otherwise catch."
+    )
+    assert '--cache-to "type=gha,mode=max,scope=sdr-${{ inputs.app-name }}"' in text, (
+        "the `--cache-to` line was removed (or `mode=max` was dropped). Builds "
+        "would never write the cache, so every leg goes cold on the next run."
+    )

--- a/.github/scripts/tests/test_container_python_version.py
+++ b/.github/scripts/tests/test_container_python_version.py
@@ -137,16 +137,25 @@ def test_print_version_reads_repo_dockerfile(
     assert out.count(".") == 1
 
 
-def test_sdr_e2e_default_matches_dockerfile() -> None:
-    # The sdr-e2e action's `expected-python-version` default is the E2E source
-    # of truth for connectors (which don't ship this SoT script). It must track
+@pytest.mark.parametrize("action", ["sdr-e2e", "build-app-image"])
+def test_action_python_default_matches_dockerfile(action: str) -> None:
+    # These actions' `expected-python-version` defaults are the E2E source of
+    # truth for connectors (which don't ship this SoT script). They must track
     # the SDK Dockerfile so a golden-image bump can't leave connector E2E
     # asserting — and pinning the host harness to — a stale version.
+    #
+    # Parametrised because the value is now declared in TWO places:
+    # build-app-image performs the assertion, and sdr-e2e both forwards it and
+    # pins the host harness to it. Two defaults are two chances to drift, so
+    # both are pinned to the Dockerfile here rather than only the one that
+    # happens to do the comparing.
     root = cpv._repo_root()
     dockerfile_version = cpv.parse_dockerfile_version(root / "Dockerfile")
-    action = (root / ".github/actions/sdr-e2e/action.yaml").read_text(encoding="utf-8")
-    match = re.search(
-        r"expected-python-version:.*?default:\s*\"([0-9.]+)\"", action, re.DOTALL
+    action_yaml = (root / ".github/actions" / action / "action.yaml").read_text(
+        encoding="utf-8"
     )
-    assert match, "expected-python-version default not found in sdr-e2e action.yaml"
+    match = re.search(
+        r"expected-python-version:.*?default:\s*\"([0-9.]+)\"", action_yaml, re.DOTALL
+    )
+    assert match, f"expected-python-version default not found in {action}/action.yaml"
     assert match.group(1) == dockerfile_version

--- a/docs/standards/connector-ci-e2e.md
+++ b/docs/standards/connector-ci-e2e.md
@@ -10,6 +10,7 @@ This doc covers what the SDK ships — the composite action, the reusable workfl
 | Component | Location | Purpose |
 |---|---|---|
 | `sdr-e2e` composite action | `.github/actions/sdr-e2e/action.yaml` | Build PR image, configurator + Dapr + Temporal stack-up, pytest, PR sticky comment, teardown. Used by both pipelines. |
+| `build-app-image` composite action | `.github/actions/build-app-image/action.yaml` | SDK-ref repin → manifest regeneration → buildx build/push → interpreter assert. Extracted from `sdr-e2e` so the image can be built **once per run** ahead of the e2e matrix (see [Building the image once](#building-the-image-once)). |
 | `e2e-full-reusable.yaml` reusable workflow | `.github/workflows/e2e-full-reusable.yaml` | Boilerplate (120-min timeout, concurrency group, env wiring, agent-name resolution) for the full-DAG pipeline. Connector repos `uses:` it as a 5-line wrapper. |
 | `e2e-apps` cross-repo dispatcher | `.github/actions/e2e-apps/action.yaml` | Fires `workflow_dispatch` on the connector repo with the apps-sdk PR's head SHA. Polls for completion, surfaces a sticky status comment on the SDK PR. |
 | `BaseSDRIntegrationTest` | `application_sdk/testing/sdr/` | pytest base for the SDR pipeline. Connector test class declares `Scenario(...)` instances. |
@@ -47,6 +48,10 @@ Both call the same composite action; difference is test target, Dapr components,
                         # before the docker build AND after setup-deps (so both
                         # the image and the host pytest runtime use the dispatched
                         # SDK).
+    prebuilt-image:     # OPTIONAL. Full image reference to use INSTEAD of
+                        # building one. Skips the build + interpreter assert and
+                        # uses this everywhere the built image would have been.
+                        # See "Building the image once" below.
     components-dir:     # OPTIONAL. App-level Dapr components dir. Defaults to
                         # $SDR_CONFIG_DIR/components. Override when SDR and
                         # full-DAG share one config dir but need different
@@ -208,6 +213,44 @@ Since v4 the action reads the dispatched run's id straight out of the `workflow_
 
 The SDR composite renders one PR-comment body, writes it to `results/pr-comment-body.md`, and uploads it as part of the test artifact. Both posting sides (connector PR + cross-repo SDK PR) read this same file and post it as a sticky-update comment, swapping the marker line so updates don't collide.
 
+## Building the image once
+
+The test image reference is deterministic — `ghcr.io/atlanhq/<app-image-name>:sdr-test-<short-sha>`
+— so every cloud leg of a run used to rebuild the identical tag. The build
+sequence (SDK-ref repin → manifest regeneration → buildx → push → interpreter
+assert) therefore lives in its own [`build-app-image`](../../.github/actions/build-app-image/action.yaml)
+composite, and `sdr-e2e` takes a `prebuilt-image` input that skips its own build
+and uses the supplied reference everywhere the built one would have gone (the
+configurator's `app_image`, and the action's `image` output).
+
+This exists for FND-31, not just to save build minutes: the full-DAG pipeline has
+to install the app under test **onto the target tenant before any leg starts**, so
+the image must exist before the matrix fans out. Saving N−1 duplicate builds is the
+side benefit.
+
+> **Why it matters that the tenant runs the app under test.** At AE submit,
+> Heracles re-fetches the manifest from the **tenant-deployed pod** and *that* DAG
+> is what executes (`processAutomationEngineWorkflow`); the harness's local
+> `manifest_path` seed DAG establishes the workflow record, not the graph. So the
+> DAG contract a full-DAG e2e exercises is whatever version is installed on that
+> tenant. Until FND-31 lands, that is whatever was last hand-deployed there.
+
+Two seams worth knowing about when editing either action:
+
+- **Skipped-step outputs are empty.** With `prebuilt-image` set, the build step is
+  skipped and `steps.build.outputs.image` is `""`. One resolver step
+  (`${PREBUILT:-$BUILT}`) is the single writer of the effective reference, and it
+  hard-fails when both are empty rather than letting an empty `app_image` reach the
+  configurator and surface as an opaque compose pull error. `test_build_app_image_action.py`
+  regression-guards this.
+- **Nested actions resolve at `@main`.** `sdr-e2e` invokes `build-app-image` as
+  `@main`, so on the local-action dispatch path
+  (`./.application-sdk/.github/actions/sdr-e2e`) the build steps come from main
+  rather than from the application-sdk PR under test. `regenerate-contract` and
+  `setup-deps` — both already inside this sequence — have the same property. A PR
+  editing the build steps is covered by the remote `@main` path and the merge
+  queue, not by a local-action dispatch.
+
 ## Contract regeneration before tests
 
 The e2e/integration tests consume `app/generated/manifest.json` (the Automation Engine DAG): the host-side harness reads the committed file, and the connector Docker image `COPY`s `app/generated/` at build time and serves `manifest.json` at runtime. Nothing used to regenerate that file from `contract/app.pkl`, so a Contract Toolkit change — at the app level (`contract/app.pkl`) or the SDK level (`contract-toolkit/src`) — ran against a possibly-stale committed manifest and was never actually exercised (BLDX-1493).
@@ -217,12 +260,12 @@ The shared [`regenerate-contract`](../../.github/actions/regenerate-contract/act
 | Where it runs | Placement | Drift gate |
 |---|---|---|
 | `connector-integration-tests` (always-on host harness) | after the SDK-ref repin, before the app server boots | **Warn-only** — annotates a stale committed `app/generated/`, never fails |
-| `sdr-e2e` (image-based, incl. the full-DAG path via `e2e-full-reusable`) | **before the image build** (bakes the fresh manifest into the connector image) | Off (`check-drift: "false"` — uv/ruff aren't installed yet; the integration job owns the gate) |
+| `build-app-image` (image-based; reached from `sdr-e2e`, incl. the full-DAG path via `e2e-full-reusable`) | **before the image build** (bakes the fresh manifest into the connector image) | Off (`check-drift: "false"` — uv/ruff aren't installed yet; the integration job owns the gate) |
 
 - **App-level** (default): regenerate from the app's pinned `@app-contract-toolkit` version, so a `contract/app.pkl` change is exercised even when the committed manifest was not regenerated.
 - **SDK-level** (cross-repo dispatch, `application-sdk-ref` set): the `@app-contract-toolkit` dependency is overridden to the SDK PR's `contract-toolkit/src`, so a toolkit change in the SDK PR is generated against the *real* connector contract end-to-end. Drift is expected, so the gate is skipped and a `pkl eval` failure is fatal.
 
-Because the e2e suite is matrixed one leg per test file and each leg builds its own image inside `sdr-e2e`, regeneration runs once per leg (it cannot be hoisted ahead of the matrix — the fresh `app/generated/` must exist in the workspace when each leg builds).
+Regeneration is bound to the build, so it runs wherever the build runs: once per leg while each leg builds its own image, and once per run for a caller that builds ahead of the matrix and passes `prebuilt-image` (see [Building the image once](#building-the-image-once)). The binding is the invariant — the fresh `app/generated/` must exist in the workspace at the moment the image is built — not the per-leg cardinality.
 
 ## Workspace-wipe defences (local-action mode)
 


### PR DESCRIPTION
### Changelog

- Extract `sdr-e2e`'s build sequence (SDK-ref repin → manifest regeneration → buildx → push → interpreter assert) into a new `.github/actions/build-app-image/` composite.
- Add a `prebuilt-image` input to `sdr-e2e` that skips its own build and uses the supplied reference everywhere the built one would have gone (the configurator's `app_image`, and the action's `image` output).
- Add `test_build_app_image_action.py` guarding the three silent-failure modes the extraction introduces.
- Extend the Dockerfile-drift guard to the new action, since `expected-python-version` now has two declarations.
- Document both in `docs/standards/connector-ci-e2e.md`.

**No behaviour change:** nothing passes `prebuilt-image` yet, so every existing caller builds exactly as before.

### Additional context

- [FND-31](https://linear.app/atlan-epd/issue/FND-31/e2e-tests-must-deploy-the-app-under-test-to-the-target-tenant) — this is the enabling refactor. FND-31 needs the app under test installed onto the target tenant *before* the e2e matrix fans out, so the image has to exist before any leg starts.
- Side benefit: the tag is deterministic (`sdr-test-<short-sha>`), so every cloud leg was rebuilding the identical image. A caller that builds once per run and passes `prebuilt-image` saves N−1 builds.

#### Why FND-31 needs this at all

At AE submit, Heracles re-fetches the manifest from the **tenant-deployed pod** and *that* DAG is what runs (`processAutomationEngineWorkflow`). The harness's local seed DAG establishes the workflow record, not the graph. So the DAG contract a full-DAG e2e exercises is whatever version is installed on that tenant — which today is whatever was last hand-deployed there.

#### Three things that fail silently, so each has a guard

- **A skipped step has no outputs.** With `prebuilt-image` set, `steps.build.outputs.image` is empty. One resolver step is the single writer of the effective reference and hard-fails when both sources are empty, rather than letting an empty `app_image` reach the configurator and surface as an opaque compose pull error.
- **Cross-action asset paths.** `build-app-image` reads the repin script from the sibling `sdr-e2e` dir and `container_python_version.py` from `.github/scripts`. Both are relative paths resolved at run time, so a directory move would only fail inside a live e2e run.
- **The buildx cache scope** (`sdr-<app-name>`) is invisible in review and merely makes every build cold if changed.

#### Two deliberate choices worth a reviewer's attention

1. **`repin-application-sdk.sh` is not relocated.** There are already two byte-identical copies (`sdr-e2e/`, `connector-integration-tests/`), and `connector-unit-tests/action.yaml` already reaches across action dirs with `../`. This follows that existing pattern rather than moving a delicate script through the `/tmp` stash. The duplication survives — consolidating it is worth a follow-up on its own, not a side effect of this change.
2. **Nested actions resolve at `@main`.** `sdr-e2e` invokes `build-app-image` as `@main`, so on the local-action dispatch path (`./.application-sdk/.github/actions/sdr-e2e`) the build steps come from main rather than the PR under test. `regenerate-contract` and `setup-deps` — both already inside this same sequence — have that property today, but it is a real reduction in self-testing, so it is stated in the action header and the docs rather than left to be discovered.

### Checklist

- [x] Additional tests added
- [ ] All CI checks passed
- [x] Relevant documentation updated

Local: `.github/scripts/tests` 1056 passed; `uv run pre-commit run` clean on every touched file.

---

### Copyleft License Compliance

- [ ] Have you used any code that is subject to a Copyleft license (e.g., GPL, AGPL, LGPL)?
- [ ] If yes, have you modified the code in the context of this project? please share additional details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
