### PR TITLE
ci(e2e): install the app under test onto a target tenant

### DIFF
--- a/.github/scripts/e2e_tenant_api.py
+++ b/.github/scripts/e2e_tenant_api.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+"""Tenant HTTP client for the e2e marketplace flows: token mint + request helper.
+
+Why this exists
+---------------
+FND-31 makes the e2e pipeline install the app under test onto the target tenant,
+so the DAG the tests exercise is the version in the PR rather than whatever was
+last hand-deployed there. That needs three tenant calls (register a version,
+install it, poll the deployment) plus a credential the marketplace routes
+accept. This module owns the transport for all of them so the probe driver and
+the eventual install driver share ONE implementation of the awkward parts:
+which credential to use, how to mint it, and how to surface an API error.
+
+Deliberately stdlib-only. These run in CI jobs that have not yet installed the
+SDK (the install has to happen *before* the harness runs), so importing
+``application_sdk.credentials.oauth`` is not available at the point of use.
+
+Credentials
+-----------
+Two different credentials, and the distinction is load-bearing:
+
+* ``ATLAN_API_KEY`` — the long-lived API key. Used by the harness for AE and
+  Atlas calls. Its service account carries ``realm-admin``.
+* ``SDR_CLIENT_ID`` / ``SDR_CLIENT_SECRET`` — an OAuth client. **This** is the
+  credential the marketplace publish route expects; the API key is not
+  authorised for it.
+
+The token is minted with a ``client_credentials`` grant against the tenant's
+Keycloak, at the same URL the SDK uses (``application_sdk/credentials/atlan.py``,
+``application_sdk/execution/_temporal/auth.py``):
+
+    {base_url}/auth/realms/default/protocol/openid-connect/token
+
+Secret hygiene
+--------------
+The access token is a credential. It is never printed, never returned in a
+result object destined for the log, and never written to ``$GITHUB_ENV``. The
+only thing callers may surface is :meth:`TenantClient.token_roles`, which
+reports the *claim names* a token carries so an authorisation failure is
+diagnosable without exposing the bearer. Claims are read by base64-decoding the
+JWT payload segment WITHOUT signature verification — this is a diagnostic
+readout of a token we just minted ourselves, not an authentication decision, so
+there is nothing to verify against and no trust being extended.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass, field
+from typing import Literal
+
+_HTTP_TIMEOUT = 60
+_USER_AGENT = "atlan-application-sdk-e2e-tenant/1.0"
+
+#: Heracles mounts its service routes under this prefix.
+_SERVICE_PREFIX = "/api/service"
+
+#: Marketplace routes, mirroring `atlan-cli/pkg/voyager/endpoints.go` and
+#: `heracles/api/marketplace.json`. Kept as format strings so a caller cannot
+#: assemble a path by string-concatenating an unvalidated id into a URL.
+PUBLISH_PATH = f"{_SERVICE_PREFIX}/marketplace/publish"
+INSTALL_PATH = f"{_SERVICE_PREFIX}/marketplace/tenant/default/apps/{{app_id}}/install"
+APP_INFO_PATH = f"{_SERVICE_PREFIX}/marketplace/apps/{{app_id}}/info"
+DEPLOYMENT_PATH = f"{_SERVICE_PREFIX}/marketplace/apps/deployments/{{deployment_id}}"
+APP_EVENTS_PATH = f"{_SERVICE_PREFIX}/marketplace/apps/{{app_id}}/events"
+APP_FAILURE_PATH = f"{_SERVICE_PREFIX}/marketplace/apps/{{app_id}}/failure"
+RELEASE_SCAN_PATH = (
+    f"{_SERVICE_PREFIX}/marketplace/apps/{{app_id}}/releases/{{release_id}}"
+)
+
+#: AE submit / create. `submit=false` creates the workflow without executing it,
+#: which still drives Heracles' server-side manifest fetch from the deployed pod.
+PACKAGE_WORKFLOWS_PATH = f"{_SERVICE_PREFIX}/package-workflows"
+
+TOKEN_PATH = "/auth/realms/default/protocol/openid-connect/token"
+
+Method = Literal["GET", "POST", "PUT"]
+
+
+class TenantApiError(RuntimeError):
+    """A tenant call failed in a way the caller cannot recover from.
+
+    Carries the status and the parsed body so a driver can render a diagnosable
+    message. Never carries a credential.
+    """
+
+    def __init__(self, message: str, *, status: int = 0, body: object = None) -> None:
+        super().__init__(message)
+        self.status = status
+        self.body = body
+
+
+@dataclass(frozen=True)
+class Response:
+    """One tenant HTTP response.
+
+    ``body`` is the parsed JSON when the response was JSON, else the raw text.
+    Non-2xx is returned rather than raised: every caller here branches on the
+    status (a 409 on install means "already installed", a 4xx on publish means
+    "wrong credential"), so raising would just force it back out of an
+    exception.
+    """
+
+    status: int
+    body: object
+
+    @property
+    def ok(self) -> bool:
+        return 200 <= self.status < 300
+
+    def json(self) -> dict[str, object]:
+        """Return the body as a JSON object, or raise if it is not one."""
+        if isinstance(self.body, dict):
+            return self.body
+        raise TenantApiError(
+            f"expected a JSON object body, got {type(self.body).__name__}",
+            status=self.status,
+            body=self.body,
+        )
+
+    def data(self) -> dict[str, object]:
+        """Return the ``data`` envelope when present, else the whole object.
+
+        Heracles wraps some payloads in ``{"data": {...}}`` and returns others
+        bare; every caller wants the inner object either way.
+        """
+        parsed = self.json()
+        inner = parsed.get("data")
+        return inner if isinstance(inner, dict) else parsed
+
+
+@dataclass
+class TenantClient:
+    """Calls one tenant's Heracles routes with one bearer credential.
+
+    Args:
+        base_url: Tenant base URL, e.g. ``https://e2e-azure-main.atlan.com``.
+            A trailing slash is stripped.
+        bearer: The token to send. Use :meth:`with_oauth_token` to build a
+            client authenticated by the OAuth client pair (required for
+            publish), or pass the API key directly for routes that accept it.
+    """
+
+    base_url: str
+    bearer: str = field(repr=False)
+
+    def __post_init__(self) -> None:
+        self.base_url = self.base_url.rstrip("/")
+
+    # -- construction ---------------------------------------------------
+
+    @classmethod
+    def with_oauth_token(
+        cls, base_url: str, client_id: str, client_secret: str
+    ) -> TenantClient:
+        """Mint a ``client_credentials`` token and return a client using it.
+
+        This is the constructor the marketplace publish route needs: its
+        authorisation is on the OAuth client, not on the API key's service
+        account.
+        """
+        return cls(
+            base_url=base_url,
+            bearer=mint_oauth_token(base_url, client_id, client_secret),
+        )
+
+    # -- transport ------------------------------------------------------
+
+    def request(
+        self,
+        method: Method,
+        path: str,
+        *,
+        body: dict[str, object] | None = None,
+        timeout: int = _HTTP_TIMEOUT,
+    ) -> Response:
+        """Perform one request. Returns non-2xx rather than raising.
+
+        A transport-level failure (DNS, connection refused, timeout) IS raised:
+        unlike an HTTP status it carries no information the caller can branch
+        on, and retrying is the caller's decision to make explicitly.
+        """
+        url = f"{self.base_url}{path}"
+        data = json.dumps(body).encode() if body is not None else None
+        req = urllib.request.Request(url, data=data, method=method)  # noqa: S310 — https URL built from a validated base + a module-owned path constant
+        req.add_header("Authorization", f"Bearer {self.bearer}")
+        req.add_header("Accept", "application/json")
+        req.add_header("User-Agent", _USER_AGENT)
+        if data is not None:
+            req.add_header("Content-Type", "application/json")
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310 — see above
+                return Response(status=resp.status, body=_parse(resp.read()))
+        except urllib.error.HTTPError as exc:
+            return Response(status=exc.code, body=_parse(exc.read()))
+        except (urllib.error.URLError, TimeoutError, OSError) as exc:
+            raise TenantApiError(
+                f"{method} {path} could not reach {self.base_url}: {exc}"
+            ) from exc
+
+    def get(self, path: str, **kwargs: object) -> Response:
+        return self.request("GET", path, **kwargs)  # type: ignore[arg-type]
+
+    def post(self, path: str, **kwargs: object) -> Response:
+        return self.request("POST", path, **kwargs)  # type: ignore[arg-type]
+
+    # -- diagnostics ----------------------------------------------------
+
+    def token_roles(self) -> list[str]:
+        """Return the realm roles the bearer carries, for diagnostics only.
+
+        An empty list means the token has no ``realm_access.roles`` claim (or is
+        not a JWT — an opaque API key, say), NOT that it is unauthorised. Never
+        gate on this; it exists so a 401/403 on publish can be reported as
+        "the OAuth client's roles are X" instead of an unexplained rejection.
+        """
+        claims = _jwt_claims(self.bearer)
+        realm_access = claims.get("realm_access")
+        if not isinstance(realm_access, dict):
+            return []
+        roles = realm_access.get("roles")
+        if not isinstance(roles, list):
+            return []
+        return sorted(str(r) for r in roles)
+
+
+def mint_oauth_token(base_url: str, client_id: str, client_secret: str) -> str:
+    """Exchange a client-credentials pair for an access token.
+
+    Raises rather than returning an empty string: every caller needs the token,
+    and an empty bearer would fail later as an opaque 401 far from its cause.
+    """
+    missing = [
+        name
+        for name, value in (("client_id", client_id), ("client_secret", client_secret))
+        if not str(value or "").strip()
+    ]
+    if missing:
+        raise TenantApiError(
+            f"cannot mint an OAuth token: {', '.join(missing)} is empty. The "
+            "e2e leg resolves these from E2E_TENANT_MATRIX_JSON; an empty value "
+            "usually means the secret is not shared with this repository."
+        )
+
+    url = f"{base_url.rstrip('/')}{TOKEN_PATH}"
+    payload = urllib.parse.urlencode(
+        {
+            "grant_type": "client_credentials",
+            "client_id": client_id,
+            "client_secret": client_secret,
+        }
+    ).encode()
+    req = urllib.request.Request(url, data=payload, method="POST")  # noqa: S310 — https URL from the caller-validated tenant base
+    req.add_header("Content-Type", "application/x-www-form-urlencoded")
+    req.add_header("Accept", "application/json")
+    req.add_header("User-Agent", _USER_AGENT)
+    try:
+        with urllib.request.urlopen(req, timeout=_HTTP_TIMEOUT) as resp:  # noqa: S310 — see above
+            parsed = _parse(resp.read())
+    except urllib.error.HTTPError as exc:
+        # The error body can echo request parameters, so report only the status.
+        # A 401 here is a bad/rotated client secret; a 404 is usually a wrong
+        # realm or a tenant URL that isn't an Atlan tenant.
+        raise TenantApiError(
+            f"OAuth token mint rejected with HTTP {exc.code} at {url}. 401 means "
+            "the client id/secret pair is wrong or rotated; 404 means the realm "
+            "or tenant URL is wrong.",
+            status=exc.code,
+        ) from exc
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        raise TenantApiError(f"OAuth token mint could not reach {url}: {exc}") from exc
+
+    if not isinstance(parsed, dict):
+        raise TenantApiError("OAuth token response was not a JSON object")
+    token = parsed.get("access_token")
+    if not isinstance(token, str) or not token:
+        # Name the keys, never the values — a token response's values are
+        # credentials.
+        raise TenantApiError(
+            "OAuth token response carried no access_token " f"(keys: {sorted(parsed)})"
+        )
+    return token
+
+
+def _parse(raw: bytes) -> object:
+    """Parse a response body as JSON, falling back to text."""
+    try:
+        return json.loads(raw)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return raw.decode(errors="replace")
+
+
+def _jwt_claims(token: str) -> dict[str, object]:
+    """Base64-decode a JWT's payload segment. Returns {} for a non-JWT.
+
+    No signature verification, deliberately: this is a readout of a token this
+    process just minted, used only to name claims in a diagnostic. It makes no
+    authentication or authorisation decision, so there is no trust boundary here.
+    """
+    parts = token.split(".")
+    if len(parts) != 3:
+        return {}
+    payload = parts[1]
+    payload += "=" * (-len(payload) % 4)  # restore stripped base64url padding
+    try:
+        decoded = json.loads(base64.urlsafe_b64decode(payload))
+    except (ValueError, json.JSONDecodeError):
+        return {}
+    return decoded if isinstance(decoded, dict) else {}

--- a/.github/scripts/e2e_tenant_api.py
+++ b/.github/scripts/e2e_tenant_api.py
@@ -47,6 +47,7 @@ from __future__ import annotations
 
 import base64
 import json
+import re
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -60,8 +61,12 @@ _USER_AGENT = "atlan-application-sdk-e2e-tenant/1.0"
 _SERVICE_PREFIX = "/api/service"
 
 #: Marketplace routes, mirroring `atlan-cli/pkg/voyager/endpoints.go` and
-#: `heracles/api/marketplace.json`. Kept as format strings so a caller cannot
-#: assemble a path by string-concatenating an unvalidated id into a URL.
+#: `heracles/api/marketplace.json`. Format strings, filled only through
+#: :func:`path_segment`: ``str.format`` inserts a value verbatim, so a segment
+#: containing ``/``, ``?`` or ``#`` would rewrite the request path. Keeping the
+#: constants as format strings means a caller cannot assemble a path by
+#: string-concatenating an unvalidated id into a URL, and the quoting in
+#: :func:`path_segment` means a formatted-in value cannot either.
 PUBLISH_PATH = f"{_SERVICE_PREFIX}/marketplace/publish"
 INSTALL_PATH = f"{_SERVICE_PREFIX}/marketplace/tenant/default/apps/{{app_id}}/install"
 APP_INFO_PATH = f"{_SERVICE_PREFIX}/marketplace/apps/{{app_id}}/info"
@@ -80,6 +85,11 @@ TOKEN_PATH = "/auth/realms/default/protocol/openid-connect/token"
 
 Method = Literal["GET", "POST", "PUT"]
 
+#: A GM app id is a UUID (see ``app_id`` in any app's ``atlan.yaml``).
+_APP_ID_RE = re.compile(
+    r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-" r"[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+)
+
 
 class TenantApiError(RuntimeError):
     """A tenant call failed in a way the caller cannot recover from.
@@ -92,6 +102,60 @@ class TenantApiError(RuntimeError):
         super().__init__(message)
         self.status = status
         self.body = body
+
+
+def validate_tenant_base_url(base_url: str) -> str:
+    """Return ``base_url`` with any trailing slash stripped, or raise.
+
+    The client POSTs the OAuth client secret to, and sends every bearer token
+    to, ``{base_url}/...`` — so the base is validated before any request: an
+    ``https`` scheme (plaintext would leak the credentials), a non-empty host,
+    and no userinfo/query/fragment (which would redirect or mangle the token
+    endpoint). A misconfigured tenant-matrix value fails here, at construction,
+    rather than after the secret has gone to the wrong place.
+    """
+    candidate = base_url.strip().rstrip("/")
+    parsed = urllib.parse.urlparse(candidate)
+    if (
+        parsed.scheme != "https"
+        or not parsed.hostname
+        or parsed.username
+        or parsed.password
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise TenantApiError(
+            f"invalid tenant base URL {base_url!r}: expected a bare "
+            "https://<host> with no userinfo, query, or fragment. Check the "
+            "tenant value in E2E_TENANT_MATRIX_JSON / SDR_TEST_TENANT."
+        )
+    return candidate
+
+
+def validate_app_id(app_id: str) -> str:
+    """Return ``app_id`` when it has the GM UUID shape, or raise.
+
+    ``app_id`` is a free-text workflow input that lands in a request path, so
+    it is validated before any API call: a value containing ``/``, ``?`` or
+    ``#`` would rewrite the path on the live tenant, and ``str.format`` does
+    no escaping on its own.
+    """
+    value = app_id.strip()
+    if not _APP_ID_RE.fullmatch(value):
+        raise TenantApiError(
+            f"invalid app_id {app_id!r}: GM app ids are UUIDs (the app_id "
+            "field in the app's atlan.yaml)."
+        )
+    return value
+
+
+def path_segment(value: str) -> str:
+    """Quote one value for safe insertion into a path-constant format string.
+
+    Belt after the validators' braces: callers validate ids up front, and this
+    guarantees that even a caller that forgot cannot rewrite the request path.
+    """
+    return urllib.parse.quote(str(value), safe="")
 
 
 @dataclass(frozen=True)
@@ -139,7 +203,8 @@ class TenantClient:
 
     Args:
         base_url: Tenant base URL, e.g. ``https://e2e-azure-main.atlan.com``.
-            A trailing slash is stripped.
+            Validated by :func:`validate_tenant_base_url` before any request
+            can be made: https-only, a host, and no userinfo/query/fragment.
         bearer: The token to send. Use :meth:`with_oauth_token` to build a
             client authenticated by the OAuth client pair (required for
             publish), or pass the API key directly for routes that accept it.
@@ -149,7 +214,7 @@ class TenantClient:
     bearer: str = field(repr=False)
 
     def __post_init__(self) -> None:
-        self.base_url = self.base_url.rstrip("/")
+        self.base_url = validate_tenant_base_url(self.base_url)
 
     # -- construction ---------------------------------------------------
 
@@ -186,7 +251,7 @@ class TenantClient:
         """
         url = f"{self.base_url}{path}"
         data = json.dumps(body).encode() if body is not None else None
-        req = urllib.request.Request(url, data=data, method=method)  # noqa: S310 — https URL built from a validated base + a module-owned path constant
+        req = urllib.request.Request(url, data=data, method=method)  # noqa: S310 — https URL: base validated by validate_tenant_base_url + a module-owned path constant filled through path_segment
         req.add_header("Authorization", f"Bearer {self.bearer}")
         req.add_header("Accept", "application/json")
         req.add_header("User-Agent", _USER_AGENT)
@@ -234,6 +299,7 @@ def mint_oauth_token(base_url: str, client_id: str, client_secret: str) -> str:
     Raises rather than returning an empty string: every caller needs the token,
     and an empty bearer would fail later as an opaque 401 far from its cause.
     """
+    base_url = validate_tenant_base_url(base_url)
     missing = [
         name
         for name, value in (("client_id", client_id), ("client_secret", client_secret))
@@ -246,7 +312,7 @@ def mint_oauth_token(base_url: str, client_id: str, client_secret: str) -> str:
             "usually means the secret is not shared with this repository."
         )
 
-    url = f"{base_url.rstrip('/')}{TOKEN_PATH}"
+    url = f"{base_url}{TOKEN_PATH}"
     payload = urllib.parse.urlencode(
         {
             "grant_type": "client_credentials",
@@ -254,7 +320,7 @@ def mint_oauth_token(base_url: str, client_id: str, client_secret: str) -> str:
             "client_secret": client_secret,
         }
     ).encode()
-    req = urllib.request.Request(url, data=payload, method="POST")  # noqa: S310 — https URL from the caller-validated tenant base
+    req = urllib.request.Request(url, data=payload, method="POST")  # noqa: S310 — https URL: base validated above
     req.add_header("Content-Type", "application/x-www-form-urlencoded")
     req.add_header("Accept", "application/json")
     req.add_header("User-Agent", _USER_AGENT)

--- a/.github/scripts/e2e_tenant_app.py
+++ b/.github/scripts/e2e_tenant_app.py
@@ -78,6 +78,9 @@ from e2e_tenant_api import (
     TenantApiError,
     TenantClient,
     mint_oauth_token,
+    path_segment,
+    validate_app_id,
+    validate_tenant_base_url,
 )
 from marketplace_publish_body import PublishBodyError, PublishRequest, build
 
@@ -171,7 +174,7 @@ def _installed_version(client: TenantClient, app_id: str) -> str:
     treat those the same way: install. Distinguishing them would require LM to
     commit to a shape it has not.
     """
-    response = client.get(APP_INFO_PATH.format(app_id=app_id))
+    response = client.get(APP_INFO_PATH.format(app_id=path_segment(app_id)))
     if not response.ok:
         # Not fatal: a 404 is the "never installed on this tenant" case, which
         # FND-31 requirement 2 says to install rather than fail on.
@@ -199,6 +202,22 @@ def _extract_version(payload: dict[str, object]) -> str:
     return ""
 
 
+#: Cap on rendered response bodies in error messages. The token-mint path
+#: withholds bodies entirely because they can echo request parameters; the
+#: publish/install routes render a bounded prefix instead — enough of a live
+#: tenant error page to diagnose a 4xx, not enough to dump a verbose framework
+#: page (or anything auth-adjacent it carries) into the CI log unredacted.
+_ERROR_BODY_CHARS = 2000
+
+
+def _render_body(body: object) -> str:
+    """Render a response body for an error message, length-bounded."""
+    rendered = repr(body)
+    if len(rendered) > _ERROR_BODY_CHARS:
+        rendered = f"{rendered[:_ERROR_BODY_CHARS]}…(truncated)"
+    return rendered
+
+
 def _looks_like_scan_gate(response: Response) -> bool:
     """True when a failed install looks like GM's release-scan gate refusing.
 
@@ -222,7 +241,9 @@ def _release_status(client: TenantClient, app_id: str, release_id: str) -> str:
     if not release_id:
         return ""
     response = client.get(
-        RELEASE_SCAN_PATH.format(app_id=app_id, release_id=release_id)
+        RELEASE_SCAN_PATH.format(
+            app_id=path_segment(app_id), release_id=path_segment(release_id)
+        )
     )
     if not response.ok:
         return ""
@@ -267,7 +288,7 @@ def _publish(client: TenantClient, request: PublishRequest) -> tuple[str, str]:
             )
         raise TenantAppError(
             f"marketplace publish failed with HTTP {response.status}.{hint}\n"
-            f"response={response.body!r}"
+            f"response={_render_body(response.body)}"
         )
 
     data = response.data()
@@ -283,7 +304,7 @@ def _publish(client: TenantClient, request: PublishRequest) -> tuple[str, str]:
 def _install(client: TenantClient, app_id: str, version_id: str, scan_hint: str) -> str:
     """Trigger the install. Returns the deployment id."""
     response = client.post(
-        INSTALL_PATH.format(app_id=app_id),
+        INSTALL_PATH.format(app_id=path_segment(app_id)),
         body={"version_id": version_id, "force_install": True},
     )
     if not response.ok:
@@ -302,7 +323,7 @@ def _install(client: TenantClient, app_id: str, version_id: str, scan_hint: str)
             )
         raise TenantAppError(
             f"install failed with HTTP {response.status}.{hint}\n"
-            f"response={response.body!r}"
+            f"response={_render_body(response.body)}"
         )
     deployment_id = str(response.data().get("deployment_id") or "")
     if not deployment_id:
@@ -323,7 +344,9 @@ def _poll_deployment(client: TenantClient, deployment_id: str, timeout: int) -> 
     deadline = time.monotonic() + timeout
     last = ""
     while time.monotonic() < deadline:
-        response = client.get(DEPLOYMENT_PATH.format(deployment_id=deployment_id))
+        response = client.get(
+            DEPLOYMENT_PATH.format(deployment_id=path_segment(deployment_id))
+        )
         if response.ok:
             status = str(response.data().get("deployment_status") or "")
             if status != last:
@@ -354,7 +377,7 @@ def _poll_deployment(client: TenantClient, deployment_id: str, timeout: int) -> 
 def _dump_failure(client: TenantClient, app_id: str) -> None:
     """Print LM's failure diagnostics. Best-effort — never masks the real error."""
     try:
-        response = client.get(APP_FAILURE_PATH.format(app_id=app_id))
+        response = client.get(APP_FAILURE_PATH.format(app_id=path_segment(app_id)))
     except TenantApiError as exc:
         print(f"::warning::could not fetch failure diagnostics: {exc}")
         return
@@ -365,23 +388,25 @@ def _dump_failure(client: TenantClient, app_id: str) -> None:
 
 def install(args: argparse.Namespace) -> InstallOutcome:
     """Register + install + wait, converging by version."""
-    publish_client, read_client = _clients(args.base_url)
+    # app_id is a free-text workflow input that lands in request paths; the
+    # base URL takes the OAuth secret. Validate both before any API call.
+    app_id = validate_app_id(args.app_id)
+    base_url = validate_tenant_base_url(args.base_url)
+    publish_client, read_client = _clients(base_url)
 
-    current = _installed_version(read_client, args.app_id)
+    current = _installed_version(read_client, app_id)
     if current and current == args.version:
-        print(f"tenant already runs {args.app_id} at {args.version} — nothing to do")
+        print(f"tenant already runs {app_id} at {args.version} — nothing to do")
         return InstallOutcome(
             version=args.version, installed_version=current, skipped=True
         )
     if current:
         print(f"tenant runs {current}; installing {args.version}")
     else:
-        print(
-            f"{args.app_id} is not installed on this tenant; installing {args.version}"
-        )
+        print(f"{app_id} is not installed on this tenant; installing {args.version}")
 
     request = PublishRequest(
-        app_id=args.app_id,
+        app_id=app_id,
         image=args.image,
         version=args.version,
         branch=args.branch,
@@ -402,26 +427,26 @@ def install(args: argparse.Namespace) -> InstallOutcome:
 
     if args.scan_wait_seconds > 0:
         status = _wait_for_scan(
-            publish_client, args.app_id, release_id, args.scan_wait_seconds
+            publish_client, app_id, release_id, args.scan_wait_seconds
         )
         print(f"release status after waiting: {status or '<unreadable>'}")
     else:
-        status = _release_status(publish_client, args.app_id, release_id)
+        status = _release_status(publish_client, app_id, release_id)
         print(
             f"release status at install time: {status or '<unreadable>'} "
             "(not waiting for the scan by design)"
         )
 
-    deployment_id = _install(publish_client, args.app_id, version_id, status)
+    deployment_id = _install(publish_client, app_id, version_id, status)
     print(f"install accepted, deployment_id={deployment_id}")
 
     try:
         _poll_deployment(read_client, deployment_id, args.timeout_seconds)
     except TenantAppError:
-        _dump_failure(read_client, args.app_id)
+        _dump_failure(read_client, app_id)
         raise
 
-    installed = _installed_version(read_client, args.app_id)
+    installed = _installed_version(read_client, app_id)
     print(f"tenant reports installed version: {installed or '<unreported>'}")
     return InstallOutcome(
         version=args.version,
@@ -435,12 +460,14 @@ def install(args: argparse.Namespace) -> InstallOutcome:
 
 def verify(args: argparse.Namespace) -> str:
     """Assert the tenant runs ``--expected``. Returns the installed version."""
-    _, read_client = _clients(args.base_url)
-    installed = _installed_version(read_client, args.app_id)
+    app_id = validate_app_id(args.app_id)
+    base_url = validate_tenant_base_url(args.base_url)
+    _, read_client = _clients(base_url)
+    installed = _installed_version(read_client, app_id)
     if installed != args.expected:
         raise TenantAppError(
             f"tenant is running {installed or '<nothing / unreported>'} for app "
-            f"{args.app_id}, but this leg tests {args.expected}. Heracles fetches "
+            f"{app_id}, but this leg tests {args.expected}. Heracles fetches "
             "the DAG from the deployed pod at AE submit, so continuing would "
             "test a different version than the one under test. A concurrent e2e "
             "run against this tenant, or a manual deploy, is the usual cause."

--- a/.github/scripts/e2e_tenant_app.py
+++ b/.github/scripts/e2e_tenant_app.py
@@ -1,0 +1,530 @@
+#!/usr/bin/env python3
+"""Install the app under test onto an e2e tenant, and verify what is installed.
+
+FND-31. The full-DAG e2e suite runs against a live tenant but never deployed the
+app under test to it, so two things went wrong: where the app was installed the
+tests exercised whatever version was last hand-deployed there, and where it was
+not installed every leg died on a DNS lookup for a namespace that did not exist.
+
+This is why version identity matters more than it looks: at AE submit, Heracles
+re-fetches the manifest from the **tenant-deployed pod** and *that* DAG is what
+runs (``processAutomationEngineWorkflow``). The harness's local seed DAG
+establishes the workflow record, not the graph. So the DAG contract a full-DAG
+e2e exercises is whatever is installed on that tenant.
+
+Two subcommands:
+
+``install``
+    Register a tenant-targeted GM version for the PR image, install it, wait for
+    the deployment to reconcile, and read the installed version back. Converges
+    by version: when the tenant already runs the target version this is a no-op,
+    which is what makes it safe to run once per (run x cloud) and again on a
+    re-run.
+
+``verify``
+    Read the installed version and compare it to what was expected. Cheap enough
+    to run per leg immediately before pytest, which is the point — the
+    installation is tenant-scoped, so a concurrent run against the same tenant
+    can replace it between the install and the assertions. There is no
+    cross-job lease in GitHub Actions that closes that window, so the drift is
+    turned into a loud failure instead of a silent wrong-version pass.
+
+Credentials
+-----------
+Read from the environment, never from argv: argv is visible in process listings
+and in ``set -x`` output.
+
+* ``E2E_OAUTH_CLIENT_ID`` / ``E2E_OAUTH_CLIENT_SECRET``, falling back to
+  ``SDR_CLIENT_ID`` / ``SDR_CLIENT_SECRET`` — the OAuth client pair. **Publish
+  authorises on this**, not on the API key. The fallback names are what
+  the e2e tenant resolver already writes, so an e2e leg needs no re-interpolation
+  of the secret through a GitHub expression just to rename it.
+* ``ATLAN_API_KEY`` — used for the read-only info/deployment routes, which the
+  API key's ``realm-admin`` service account can reach. Falls back to the OAuth
+  token when unset.
+
+The release-scan gate
+---------------------
+``atlan app deploy`` waits up to 10 minutes for GM's async Snyk scan and refuses
+to install a ``scan_failed`` release. That is wrong for e2e: a base-image CVE
+would red every leg of an unrelated PR, and release is gated separately. So the
+default here is ``--scan-wait-seconds 0`` — install immediately, report whatever
+the scan status happens to be.
+
+Whether GM *accepts* an install of a still-``scan_pending`` release is an open
+question at the time of writing (FND-31 spike (b)); the first live run of this
+script answers it. If GM rejects it, :func:`_looks_like_scan_gate` recognises
+the rejection and the error names the fix — raise ``--scan-wait-seconds`` — so
+the failure is self-explaining rather than an opaque 4xx.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from dataclasses import dataclass
+
+from e2e_tenant_api import (
+    APP_FAILURE_PATH,
+    APP_INFO_PATH,
+    DEPLOYMENT_PATH,
+    INSTALL_PATH,
+    PUBLISH_PATH,
+    RELEASE_SCAN_PATH,
+    Response,
+    TenantApiError,
+    TenantClient,
+    mint_oauth_token,
+)
+from marketplace_publish_body import PublishBodyError, PublishRequest, build
+
+#: Terminal deployment states from LM.
+_SUCCEEDED = "SUCCEEDED"
+_FAILED = "FAILED"
+
+#: Release states GM reports while the Snyk scan is in flight / has failed.
+_SCAN_PENDING = "scan_pending"
+_SCAN_FAILED = "scan_failed"
+
+_DEPLOY_POLL_SECONDS = 10
+_SCAN_POLL_SECONDS = 10
+
+#: Keys an install/info response may carry the installed version under. LM has
+#: not committed to one name across versions, so check the plausible set rather
+#: than hard-coding a guess that silently reads None and compares equal to None.
+_VERSION_KEYS = ("version", "installed_version", "app_version", "current_version")
+
+
+class TenantAppError(RuntimeError):
+    """The install or verification failed."""
+
+
+@dataclass(frozen=True)
+class InstallOutcome:
+    """What an install actually did, for the step log and $GITHUB_OUTPUT."""
+
+    version: str
+    version_id: str = ""
+    release_id: str = ""
+    deployment_id: str = ""
+    installed_version: str = ""
+    release_status: str = ""
+    skipped: bool = False
+
+    def as_outputs(self) -> dict[str, str]:
+        return {
+            "version": self.version,
+            "version_id": self.version_id,
+            "release_id": self.release_id,
+            "deployment_id": self.deployment_id,
+            "installed_version": self.installed_version,
+            "release_status": self.release_status,
+            "skipped": "true" if self.skipped else "false",
+        }
+
+
+def _env(*names: str) -> str:
+    """Return the first non-empty value among ``names``.
+
+    Several names per credential so a call site does not have to re-interpolate a
+    secret through a GitHub expression just to rename it. The e2e tenant
+    resolver writes the leg's OAuth pair as ``SDR_CLIENT_ID`` /
+    ``SDR_CLIENT_SECRET``, so
+    those are accepted directly; the ``E2E_OAUTH_*`` names stay as the script's own
+    generic contract for callers outside the e2e legs. Every hop a secret takes is
+    a hop it can be mishandled on, so the fewer the better.
+    """
+    for name in names:
+        value = os.environ.get(name, "").strip()
+        if value:
+            return value
+    return ""
+
+
+def _clients(base_url: str) -> tuple[TenantClient, TenantClient]:
+    """Return ``(publish_client, read_client)``.
+
+    Two clients because two credentials: publish authorises on the OAuth client,
+    while the read routes are reachable with the API key. Falling the read client
+    back to the OAuth token keeps the script usable when only the pair is wired.
+    """
+    token = mint_oauth_token(
+        base_url,
+        _env("E2E_OAUTH_CLIENT_ID", "SDR_CLIENT_ID"),
+        _env("E2E_OAUTH_CLIENT_SECRET", "SDR_CLIENT_SECRET"),
+    )
+    publish_client = TenantClient(base_url=base_url, bearer=token)
+    api_key = _env("ATLAN_API_KEY")
+    read_client = (
+        TenantClient(base_url=base_url, bearer=api_key) if api_key else publish_client
+    )
+    return publish_client, read_client
+
+
+def _installed_version(client: TenantClient, app_id: str) -> str:
+    """Return the version the tenant currently reports for ``app_id``.
+
+    Empty means "not installed, or LM did not report a version" — the caller must
+    treat those the same way: install. Distinguishing them would require LM to
+    commit to a shape it has not.
+    """
+    response = client.get(APP_INFO_PATH.format(app_id=app_id))
+    if not response.ok:
+        # Not fatal: a 404 is the "never installed on this tenant" case, which
+        # FND-31 requirement 2 says to install rather than fail on.
+        print(
+            f"::notice::app info returned HTTP {response.status} for {app_id} — "
+            "treating as not installed"
+        )
+        return ""
+    return _extract_version(response.data())
+
+
+def _extract_version(payload: dict[str, object]) -> str:
+    """Pull a version string out of an info/install payload."""
+    for key in _VERSION_KEYS:
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    # Some shapes nest the install state one level down.
+    for nest in ("install", "installation", "deployment"):
+        inner = payload.get(nest)
+        if isinstance(inner, dict):
+            found = _extract_version(inner)
+            if found:
+                return found
+    return ""
+
+
+def _looks_like_scan_gate(response: Response) -> bool:
+    """True when a failed install looks like GM's release-scan gate refusing.
+
+    Matched on the rendered body rather than a status code: GM does not document
+    a distinct status for this, and a false positive only changes the wording of
+    an error that is failing anyway.
+    """
+    rendered = json.dumps(response.body).lower() if response.body else ""
+    return any(
+        marker in rendered
+        for marker in (_SCAN_PENDING, _SCAN_FAILED, "scan", "not active", "draft")
+    )
+
+
+def _release_status(client: TenantClient, app_id: str, release_id: str) -> str:
+    """Return GM's release status, or "" when it cannot be read.
+
+    Informational only — nothing gates on it. It is reported so the first live
+    run answers whether an install of a ``scan_pending`` release is accepted.
+    """
+    if not release_id:
+        return ""
+    response = client.get(
+        RELEASE_SCAN_PATH.format(app_id=app_id, release_id=release_id)
+    )
+    if not response.ok:
+        return ""
+    status = response.data().get("status")
+    return status.strip() if isinstance(status, str) else ""
+
+
+def _wait_for_scan(
+    client: TenantClient, app_id: str, release_id: str, budget: int
+) -> str:
+    """Poll the release scan until it leaves ``scan_pending`` or the budget ends.
+
+    Only called when ``--scan-wait-seconds`` is non-zero, i.e. when an operator
+    has deliberately opted back into waiting.
+    """
+    deadline = time.monotonic() + budget
+    status = _release_status(client, app_id, release_id)
+    while status == _SCAN_PENDING and time.monotonic() < deadline:
+        time.sleep(_SCAN_POLL_SECONDS)
+        status = _release_status(client, app_id, release_id)
+    return status
+
+
+def _publish(client: TenantClient, request: PublishRequest) -> tuple[str, str]:
+    """Register the version. Returns ``(version_id, release_id)``."""
+    try:
+        body = build(request)
+    except PublishBodyError as exc:
+        raise TenantAppError(str(exc)) from exc
+
+    response = client.post(PUBLISH_PATH, body=body)
+    if not response.ok:
+        # 401/403 here is the credential question: publish authorises on the
+        # OAuth client, so name that explicitly rather than leaving an operator
+        # to guess which of two credentials was rejected.
+        hint = ""
+        if response.status in (401, 403):
+            hint = (
+                " Publish authorises on the OAuth client pair "
+                "(E2E_OAUTH_CLIENT_ID/SECRET), not on ATLAN_API_KEY — check that "
+                f"pair. Token realm roles: {client.token_roles() or 'none visible'}."
+            )
+        raise TenantAppError(
+            f"marketplace publish failed with HTTP {response.status}.{hint}\n"
+            f"response={response.body!r}"
+        )
+
+    data = response.data()
+    version_id = str(data.get("version_id") or "")
+    release_id = str(data.get("release_id") or "")
+    if not version_id:
+        raise TenantAppError(
+            f"publish returned no version_id (keys: {sorted(data)}); cannot install"
+        )
+    return version_id, release_id
+
+
+def _install(client: TenantClient, app_id: str, version_id: str, scan_hint: str) -> str:
+    """Trigger the install. Returns the deployment id."""
+    response = client.post(
+        INSTALL_PATH.format(app_id=app_id),
+        body={"version_id": version_id, "force_install": True},
+    )
+    if not response.ok:
+        hint = ""
+        if _looks_like_scan_gate(response):
+            hint = (
+                " This looks like GM's release-scan gate refusing a release that "
+                "has not finished scanning. e2e deliberately does not wait for "
+                "the scan (a base-image CVE must not red an unrelated PR); if GM "
+                "requires it, re-run with --scan-wait-seconds set."
+                + (
+                    f" Release status at install time: {scan_hint}."
+                    if scan_hint
+                    else ""
+                )
+            )
+        raise TenantAppError(
+            f"install failed with HTTP {response.status}.{hint}\n"
+            f"response={response.body!r}"
+        )
+    deployment_id = str(response.data().get("deployment_id") or "")
+    if not deployment_id:
+        raise TenantAppError(
+            "install response carried no deployment_id, so the deployment cannot "
+            f"be polled (keys: {sorted(response.data())})"
+        )
+    return deployment_id
+
+
+def _poll_deployment(client: TenantClient, deployment_id: str, timeout: int) -> None:
+    """Wait for the deployment to reach a terminal state.
+
+    A timeout is a failure, not a pass-with-a-warning: an install that was
+    accepted but never reconciled is exactly the silent-wrong-version failure
+    this whole change exists to remove.
+    """
+    deadline = time.monotonic() + timeout
+    last = ""
+    while time.monotonic() < deadline:
+        response = client.get(DEPLOYMENT_PATH.format(deployment_id=deployment_id))
+        if response.ok:
+            status = str(response.data().get("deployment_status") or "")
+            if status != last:
+                print(f"deployment {deployment_id}: {status or '<no status>'}")
+                last = status
+            if status == _SUCCEEDED:
+                return
+            if status == _FAILED:
+                message = response.data().get("message")
+                raise TenantAppError(
+                    f"deployment {deployment_id} FAILED"
+                    + (f": {message}" if message else "")
+                )
+        else:
+            # Transient: keep polling rather than failing on one bad read.
+            print(
+                f"::warning::deployment status read returned HTTP {response.status}; retrying"
+            )
+        time.sleep(_DEPLOY_POLL_SECONDS)
+    raise TenantAppError(
+        f"deployment {deployment_id} did not reach a terminal state within "
+        f"{timeout}s (last status: {last or 'none'}). Not treating this as "
+        "installed — an accepted-but-unreconciled deploy is the silent "
+        "wrong-version failure this check exists to catch."
+    )
+
+
+def _dump_failure(client: TenantClient, app_id: str) -> None:
+    """Print LM's failure diagnostics. Best-effort — never masks the real error."""
+    try:
+        response = client.get(APP_FAILURE_PATH.format(app_id=app_id))
+    except TenantApiError as exc:
+        print(f"::warning::could not fetch failure diagnostics: {exc}")
+        return
+    if response.ok:
+        print("--- app failure diagnostics ---")
+        print(json.dumps(response.body, indent=2, sort_keys=True)[:8000])
+
+
+def install(args: argparse.Namespace) -> InstallOutcome:
+    """Register + install + wait, converging by version."""
+    publish_client, read_client = _clients(args.base_url)
+
+    current = _installed_version(read_client, args.app_id)
+    if current and current == args.version:
+        print(f"tenant already runs {args.app_id} at {args.version} — nothing to do")
+        return InstallOutcome(
+            version=args.version, installed_version=current, skipped=True
+        )
+    if current:
+        print(f"tenant runs {current}; installing {args.version}")
+    else:
+        print(
+            f"{args.app_id} is not installed on this tenant; installing {args.version}"
+        )
+
+    request = PublishRequest(
+        app_id=args.app_id,
+        image=args.image,
+        version=args.version,
+        branch=args.branch,
+        repo_url=args.repo_url,
+        # The whole registration is scoped to this one tenant, so a per-PR build
+        # can never become visible to a real one.
+        allowed_tenants=(args.tenant,),
+        deploy_config=args.deploy_config,
+        self_deployed_runtime=args.self_deployed_runtime,
+        sdk_version=args.sdk_version,
+        entrypoints=args.entrypoints,
+        app_configs=args.app_configs,
+        release_model=args.release_model,
+        created_by=args.created_by,
+    )
+    version_id, release_id = _publish(publish_client, request)
+    print(f"registered version_id={version_id} release_id={release_id}")
+
+    if args.scan_wait_seconds > 0:
+        status = _wait_for_scan(
+            publish_client, args.app_id, release_id, args.scan_wait_seconds
+        )
+        print(f"release status after waiting: {status or '<unreadable>'}")
+    else:
+        status = _release_status(publish_client, args.app_id, release_id)
+        print(
+            f"release status at install time: {status or '<unreadable>'} "
+            "(not waiting for the scan by design)"
+        )
+
+    deployment_id = _install(publish_client, args.app_id, version_id, status)
+    print(f"install accepted, deployment_id={deployment_id}")
+
+    try:
+        _poll_deployment(read_client, deployment_id, args.timeout_seconds)
+    except TenantAppError:
+        _dump_failure(read_client, args.app_id)
+        raise
+
+    installed = _installed_version(read_client, args.app_id)
+    print(f"tenant reports installed version: {installed or '<unreported>'}")
+    return InstallOutcome(
+        version=args.version,
+        version_id=version_id,
+        release_id=release_id,
+        deployment_id=deployment_id,
+        installed_version=installed,
+        release_status=status,
+    )
+
+
+def verify(args: argparse.Namespace) -> str:
+    """Assert the tenant runs ``--expected``. Returns the installed version."""
+    _, read_client = _clients(args.base_url)
+    installed = _installed_version(read_client, args.app_id)
+    if installed != args.expected:
+        raise TenantAppError(
+            f"tenant is running {installed or '<nothing / unreported>'} for app "
+            f"{args.app_id}, but this leg tests {args.expected}. Heracles fetches "
+            "the DAG from the deployed pod at AE submit, so continuing would "
+            "test a different version than the one under test. A concurrent e2e "
+            "run against this tenant, or a manual deploy, is the usual cause."
+        )
+    print(f"verified: tenant runs {installed}")
+    return installed
+
+
+def _write_outputs(outputs: dict[str, str]) -> None:
+    """Append to ``$GITHUB_OUTPUT``, or print when running outside Actions.
+
+    No masking pass is needed here, unlike the tenant resolver: every value
+    written is an id, a version or a status. No credential reaches this function.
+    """
+    target = os.environ.get("GITHUB_OUTPUT")
+    lines = "".join(f"{k}={v}\n" for k, v in outputs.items())
+    if not target:
+        sys.stdout.write(lines)
+        return
+    with open(target, "a") as handle:
+        handle.write(lines)
+
+
+def _add_common(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--base-url", required=True, help="https://<tenant>")
+    parser.add_argument("--app-id", required=True, help="GM app UUID from atlan.yaml")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_install = sub.add_parser("install", help="register + install + wait")
+    _add_common(p_install)
+    p_install.add_argument("--image", required=True)
+    p_install.add_argument(
+        "--version", required=True, help="GM version (the image tag)"
+    )
+    p_install.add_argument("--branch", required=True)
+    p_install.add_argument(
+        "--tenant", required=True, help="tenant id for allowed_tenants scoping"
+    )
+    p_install.add_argument("--repo-url", default="")
+    p_install.add_argument("--deploy-config", default="")
+    p_install.add_argument("--self-deployed-runtime", action="store_true")
+    p_install.add_argument("--sdk-version", default="")
+    p_install.add_argument("--entrypoints", default="")
+    p_install.add_argument("--app-configs", default="")
+    p_install.add_argument("--release-model", default="")
+    p_install.add_argument("--created-by", default="")
+    p_install.add_argument(
+        "--scan-wait-seconds",
+        type=int,
+        default=0,
+        help=(
+            "Seconds to wait for GM's release scan before installing. 0 (the "
+            "default) does not wait: a base-image CVE must not red an unrelated "
+            "PR's e2e. Raise only if GM refuses to install an unscanned release."
+        ),
+    )
+    p_install.add_argument(
+        "--timeout-seconds",
+        type=int,
+        default=600,
+        help="Budget for the deployment to reconcile. A timeout fails.",
+    )
+
+    p_verify = sub.add_parser("verify", help="assert the installed version")
+    _add_common(p_verify)
+    p_verify.add_argument("--expected", required=True)
+
+    args = parser.parse_args(argv)
+
+    try:
+        if args.command == "install":
+            outcome = install(args)
+            _write_outputs(outcome.as_outputs())
+        else:
+            _write_outputs({"installed_version": verify(args)})
+    except (TenantAppError, TenantApiError) as exc:
+        print(f"::error::{exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/marketplace_publish_body.py
+++ b/.github/scripts/marketplace_publish_body.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Build the ``POST /marketplace/publish`` request body.
+
+Why this is its own module
+--------------------------
+Two call sites register a GM version: the release path
+(``build-and-publish-app.yaml``, which builds the body in an inline Python
+heredoc) and the e2e path added for FND-31 (``e2e_tenant_app.py``). The whole
+point of FND-31 is that the tenant runs *the version under test* — so if the
+e2e path registered a differently-shaped version than the release path does,
+the e2e would be validating a registration shape that never ships. One builder,
+one shape.
+
+The release workflow is deliberately **not** switched over in the same change
+that introduces this: it is the path every app release goes through, and
+rewiring it to share code with a new e2e flow is the tail wagging the dog.
+Instead ``test_marketplace_publish_body.py`` asserts that the field set here
+matches the field set that workflow emits, so the two cannot drift unnoticed,
+and a follow-up can collapse the duplication safely.
+
+Fields that are conditional rather than always-present are conditional for a
+reason — GM distinguishes "absent" from "empty" on several of them (see the
+comments at each site), so this builder omits rather than blanks.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+
+#: Marks a registration as machine-originated. The release workflow sends the
+#: same literal; GM uses it for provenance, not for routing.
+SOURCE_CI_PUBLISH = "ci_publish"
+
+
+@dataclass(frozen=True)
+class PublishRequest:
+    """Everything needed to register one version of one app.
+
+    A frozen dataclass rather than a dict so a caller cannot silently misspell
+    a field into oblivion: the publish route ignores unknown keys, so a typo'd
+    ``allowed_tenants`` would publish to every tenant instead of failing.
+
+    Attributes:
+        app_id: GM app UUID, from the app's ``atlan.yaml``.
+        image: Full image reference the tenant will pull.
+        version: GM version string. The e2e path uses the image tag, so a
+            version is 1:1 with a build.
+        branch: Git ref the build came from.
+        repo_url: ``https://github.com/<org>/<repo>``. Omitted from the body
+            when empty — sending ``""`` makes GM's ``cicd_managed`` validation
+            409 for apps registered with a source repo, and carries no signal
+            otherwise.
+        allowed_tenants: Restrict the version to these tenants. This is what
+            keeps per-PR e2e versions from ever reaching a real tenant. When
+            empty, ``target_channel`` is sent instead — the two are mutually
+            exclusive on the wire.
+        target_channel: Channel to publish to when not tenant-targeted.
+        deploy_config: Opaque config YAML from ``atlan.yaml``'s ``deploy:``
+            block. GM stores it as raw TEXT and echoes it back in the tenant
+            catalog.
+        self_deployed_runtime: Prepends ``self_deployed_runtime: true`` to the
+            config, which is how SDR capability rides to LM without a GM schema
+            change.
+        sdk_version: application-sdk version resolved from the lockfile.
+        entrypoints: ``entrypoints:`` from ``atlan.yaml``. Without it LM's
+            catalog merger cannot bind a card to an entrypoint, so a
+            multi-entrypoint app serves the wrong form per card.
+        app_configs: base64-encoded JSON of the connector form files under
+            ``app/generated/``. LM materialises each entry as a ConfigMap.
+        release_model: ``semver`` or empty.
+        created_by: Actor attribution.
+    """
+
+    app_id: str
+    image: str
+    version: str
+    branch: str
+    repo_url: str = ""
+    allowed_tenants: tuple[str, ...] = ()
+    target_channel: str = ""
+    deploy_config: str = ""
+    self_deployed_runtime: bool = False
+    sdk_version: str = ""
+    entrypoints: str = ""
+    app_configs: str = ""
+    release_model: str = ""
+    created_by: str = ""
+
+
+class PublishBodyError(ValueError):
+    """The request cannot produce a valid publish body."""
+
+
+def build(request: PublishRequest) -> dict[str, object]:
+    """Return the JSON body for ``POST /api/service/marketplace/publish``."""
+    missing = [
+        name
+        for name in ("app_id", "image", "version", "branch")
+        if not str(getattr(request, name) or "").strip()
+    ]
+    if missing:
+        raise PublishBodyError(
+            f"cannot build a publish body without: {', '.join(missing)}. "
+            "app_id comes from atlan.yaml; image/version/branch come from the "
+            "build."
+        )
+
+    body: dict[str, object] = {
+        "app_id": request.app_id,
+        "image": request.image,
+        "version": request.version,
+        "branch": request.branch,
+        "source": SOURCE_CI_PUBLISH,
+    }
+
+    # Absence is meaningful — see the attribute docs.
+    if request.repo_url:
+        body["repo"] = request.repo_url
+
+    config = request.deploy_config.strip()
+    if request.self_deployed_runtime:
+        config = f"self_deployed_runtime: true\n{config}".strip()
+    if config:
+        body["config"] = config
+
+    if request.sdk_version.strip():
+        body["sdk_version"] = request.sdk_version.strip()
+
+    if request.entrypoints.strip():
+        try:
+            body["entrypoints"] = json.loads(request.entrypoints)
+        except json.JSONDecodeError as exc:
+            raise PublishBodyError(
+                f"entrypoints is not valid JSON ({exc}). It comes from "
+                "parse_atlan_yaml.py, which emits a JSON array."
+            ) from exc
+
+    # Mutually exclusive: tenant-targeting takes precedence over the channel,
+    # matching the release workflow and the atlan CLI. Sending both would let GM
+    # pick, and which one it picks decides whether a per-PR e2e build becomes
+    # visible to every tenant — not a coin worth flipping.
+    if request.allowed_tenants:
+        body["allowed_tenants"] = list(request.allowed_tenants)
+    elif request.target_channel.strip():
+        body["target_channel"] = request.target_channel.strip()
+    else:
+        raise PublishBodyError(
+            "a publish must be scoped: pass allowed_tenants (what e2e does, so "
+            "the version cannot reach a real tenant) or target_channel."
+        )
+
+    if request.app_configs.strip():
+        body["app_configs"] = request.app_configs.strip()
+
+    if request.release_model.strip():
+        body["release_model"] = request.release_model.strip()
+
+    if request.created_by.strip():
+        body["created_by"] = request.created_by.strip()
+
+    return body
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Print the body as JSON, for a workflow step that wants to inspect it."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--app-id", required=True)
+    parser.add_argument("--image", required=True)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--branch", required=True)
+    parser.add_argument("--repo-url", default="")
+    parser.add_argument(
+        "--tenant",
+        action="append",
+        default=[],
+        help="Restrict to this tenant. Repeatable. Omit to use --channel.",
+    )
+    parser.add_argument("--channel", default="")
+    parser.add_argument("--deploy-config", default="")
+    parser.add_argument("--self-deployed-runtime", action="store_true")
+    parser.add_argument("--sdk-version", default="")
+    parser.add_argument("--entrypoints", default="")
+    parser.add_argument("--app-configs", default="")
+    parser.add_argument("--release-model", default="")
+    parser.add_argument("--created-by", default="")
+    args = parser.parse_args(argv)
+
+    request = PublishRequest(
+        app_id=args.app_id,
+        image=args.image,
+        version=args.version,
+        branch=args.branch,
+        repo_url=args.repo_url,
+        allowed_tenants=tuple(args.tenant),
+        target_channel=args.channel,
+        deploy_config=args.deploy_config,
+        self_deployed_runtime=args.self_deployed_runtime,
+        sdk_version=args.sdk_version,
+        entrypoints=args.entrypoints,
+        app_configs=args.app_configs,
+        release_model=args.release_model,
+        created_by=args.created_by,
+    )
+    try:
+        print(json.dumps(build(request), indent=2, sort_keys=True))
+    except PublishBodyError as exc:
+        print(f"::error::{exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/tests/test_e2e_tenant_api.py
+++ b/.github/scripts/tests/test_e2e_tenant_api.py
@@ -1,0 +1,195 @@
+"""Tests for .github/scripts/e2e_tenant_api.py.
+
+Two things matter here beyond the obvious parsing: that a credential can never
+leak into a log line, and that an unreadable response fails loudly rather than
+silently reading as "no version" (which would compare equal to another absent
+version and pass).
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import sys
+import urllib.error
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import e2e_tenant_api as api  # noqa: E402
+
+_TENANT = "https://example-tenant.atlan.test"
+_SECRET = "super-secret-value"
+
+
+# ── Response ─────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "status, ok",
+    [(200, True), (201, True), (299, True), (300, False), (404, False), (500, False)],
+)
+def test_ok_covers_exactly_the_2xx_range(status: int, ok: bool) -> None:
+    assert api.Response(status=status, body={}).ok is ok
+
+
+def test_data_unwraps_the_envelope_when_present() -> None:
+    response = api.Response(status=200, body={"data": {"version_id": "v1"}})
+    assert response.data() == {"version_id": "v1"}
+
+
+def test_data_returns_the_object_when_there_is_no_envelope() -> None:
+    # Heracles wraps some payloads and returns others bare; both must work.
+    response = api.Response(status=200, body={"version_id": "v1"})
+    assert response.data() == {"version_id": "v1"}
+
+
+def test_data_ignores_a_non_object_envelope() -> None:
+    response = api.Response(status=200, body={"data": "not-an-object", "x": 1})
+    assert response.data() == {"data": "not-an-object", "x": 1}
+
+
+def test_json_raises_on_a_text_body() -> None:
+    # A gateway error page instead of JSON must not read as an empty object —
+    # that would look like "installed version absent" and compare equal to
+    # another absent version.
+    response = api.Response(status=502, body="<html>bad gateway</html>")
+    with pytest.raises(api.TenantApiError, match="JSON object"):
+        response.json()
+
+
+# ── Client basics ────────────────────────────────────────────────────────────
+
+
+def test_trailing_slash_is_stripped_so_paths_do_not_double_up() -> None:
+    assert api.TenantClient(base_url=f"{_TENANT}/", bearer="t").base_url == _TENANT
+
+
+def test_repr_never_contains_the_bearer() -> None:
+    client = api.TenantClient(base_url=_TENANT, bearer=_SECRET)
+    assert _SECRET not in repr(client)
+
+
+def test_transport_failure_names_the_host_not_the_credential(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _boom(*_a: object, **_k: object) -> None:
+        raise urllib.error.URLError("name resolution failed")
+
+    monkeypatch.setattr(api.urllib.request, "urlopen", _boom)
+    client = api.TenantClient(base_url=_TENANT, bearer=_SECRET)
+    with pytest.raises(api.TenantApiError) as excinfo:
+        client.get("/api/service/marketplace/apps/x/info")
+    message = str(excinfo.value)
+    assert _TENANT in message
+    assert _SECRET not in message
+
+
+# ── Token mint ───────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "client_id, client_secret, missing",
+    [("", "s", "client_id"), ("i", "", "client_secret"), ("  ", "s", "client_id")],
+)
+def test_mint_refuses_empty_credentials_naming_the_field(
+    client_id: str, client_secret: str, missing: str
+) -> None:
+    # An empty bearer would fail later as an opaque 401 far from its cause; the
+    # usual root cause is the tenant-matrix secret not being shared with the repo.
+    with pytest.raises(api.TenantApiError, match=missing):
+        api.mint_oauth_token(_TENANT, client_id, client_secret)
+
+
+def test_mint_error_reports_the_status_but_not_the_response_body(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A token endpoint's error body can echo request parameters, so only the
+    # status is safe to surface.
+    def _unauthorized(*_a: object, **_k: object) -> None:
+        raise urllib.error.HTTPError(
+            url=_TENANT,
+            code=401,
+            msg="Unauthorized",
+            hdrs=None,  # type: ignore[arg-type]
+            fp=None,
+        )
+
+    monkeypatch.setattr(api.urllib.request, "urlopen", _unauthorized)
+    with pytest.raises(api.TenantApiError) as excinfo:
+        api.mint_oauth_token(_TENANT, "client-id", _SECRET)
+    message = str(excinfo.value)
+    assert "401" in message
+    assert _SECRET not in message
+
+
+def test_mint_reports_key_names_when_access_token_is_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _Resp:
+        status = 200
+
+        def read(self) -> bytes:
+            return json.dumps({"refresh_token": _SECRET, "scope": "x"}).encode()
+
+        def __enter__(self) -> _Resp:
+            return self
+
+        def __exit__(self, *_a: object) -> None:
+            return None
+
+    monkeypatch.setattr(api.urllib.request, "urlopen", lambda *_a, **_k: _Resp())
+    with pytest.raises(api.TenantApiError) as excinfo:
+        api.mint_oauth_token(_TENANT, "client-id", "client-secret")
+    message = str(excinfo.value)
+    # Names the keys so the shape is diagnosable; never the values, one of which
+    # is itself a credential.
+    assert "refresh_token" in message
+    assert _SECRET not in message
+
+
+# ── Token role readout ───────────────────────────────────────────────────────
+
+
+def _jwt(payload: dict[str, object]) -> str:
+    encoded = (
+        base64.urlsafe_b64encode(json.dumps(payload).encode()).decode().rstrip("=")
+    )
+    return f"header.{encoded}.signature"
+
+
+def test_roles_are_reported_sorted() -> None:
+    token = _jwt({"realm_access": {"roles": ["b-role", "a-role"]}})
+    client = api.TenantClient(base_url=_TENANT, bearer=token)
+    assert client.token_roles() == ["a-role", "b-role"]
+
+
+@pytest.mark.parametrize(
+    "bearer",
+    [
+        "not-a-jwt",
+        "only.two",
+        "header.!!!not-base64!!!.sig",
+        pytest.param(_jwt({}), id="no-realm-access-claim"),
+        pytest.param(
+            _jwt({"realm_access": "wrong-type"}), id="realm-access-not-object"
+        ),
+        pytest.param(
+            _jwt({"realm_access": {"roles": "wrong-type"}}), id="roles-not-list"
+        ),
+    ],
+)
+def test_roles_degrade_to_empty_rather_than_raising(bearer: str) -> None:
+    # An opaque API key is not a JWT. This is a diagnostic only — never a gate —
+    # so an unreadable token must not break the call it was meant to explain.
+    assert api.TenantClient(base_url=_TENANT, bearer=bearer).token_roles() == []
+
+
+def test_padding_is_restored_for_base64url_without_it() -> None:
+    # Keycloak strips '=' padding; a naive decode raises on those tokens.
+    payload = {"realm_access": {"roles": ["r"]}, "pad": "abcde"}
+    token = _jwt(payload)
+    assert "=" not in token.split(".")[1]
+    assert api.TenantClient(base_url=_TENANT, bearer=token).token_roles() == ["r"]

--- a/.github/scripts/tests/test_e2e_tenant_api.py
+++ b/.github/scripts/tests/test_e2e_tenant_api.py
@@ -67,6 +67,67 @@ def test_trailing_slash_is_stripped_so_paths_do_not_double_up() -> None:
     assert api.TenantClient(base_url=f"{_TENANT}/", bearer="t").base_url == _TENANT
 
 
+# ── Base-URL validation ──────────────────────────────────────────────────────
+#
+# The client POSTs the OAuth client secret to {base_url}/... and sends every
+# bearer there, so a misconfigured matrix value must fail before any request.
+
+
+@pytest.mark.parametrize(
+    "base_url",
+    [
+        "http://example-tenant.atlan.test",  # plaintext would leak the pair
+        "https://",  # no host
+        "not-a-url",
+        "https://user:pw@example-tenant.atlan.test",  # userinfo
+        "https://example-tenant.atlan.test?x=1",  # query
+        "https://example-tenant.atlan.test#frag",  # fragment
+    ],
+)
+def test_base_url_is_rejected_before_any_request(base_url: str) -> None:
+    with pytest.raises(api.TenantApiError, match="invalid tenant base URL"):
+        api.TenantClient(base_url=base_url, bearer="t")
+
+
+def test_mint_rejects_a_plaintext_base_url() -> None:
+    with pytest.raises(api.TenantApiError, match="invalid tenant base URL"):
+        api.mint_oauth_token("http://example-tenant.atlan.test", "i", "s")
+
+
+# ── Path-segment handling ────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "app_id",
+    [
+        "019d1f6b-6fea-7db3-96d8-e61e159d0351",
+        "019D1F6B-6FEA-7DB3-96D8-E61E159D0351",  # upper-case hex is still a UUID
+    ],
+)
+def test_validate_app_id_accepts_uuid_shapes(app_id: str) -> None:
+    assert api.validate_app_id(app_id) == app_id
+
+
+@pytest.mark.parametrize(
+    "app_id",
+    [
+        "",
+        "not-a-uuid",
+        "../../admin",  # would rewrite the request path if formatted verbatim
+        "019d1f6b-6fea-7db3-96d8-e61e159d0351/extra",
+        "019d1f6b-6fea-7db3-96d8-e61e159d0351?force=true",
+    ],
+)
+def test_validate_app_id_rejects_non_uuid_shapes(app_id: str) -> None:
+    with pytest.raises(api.TenantApiError, match="invalid app_id"):
+        api.validate_app_id(app_id)
+
+
+def test_path_segment_quotes_everything_but_unreserved() -> None:
+    assert api.path_segment("a/b?c#d") == "a%2Fb%3Fc%23d"
+    assert api.path_segment("plain-value_1.2~3") == "plain-value_1.2~3"
+
+
 def test_repr_never_contains_the_bearer() -> None:
     client = api.TenantClient(base_url=_TENANT, bearer=_SECRET)
     assert _SECRET not in repr(client)

--- a/.github/scripts/tests/test_e2e_tenant_app.py
+++ b/.github/scripts/tests/test_e2e_tenant_app.py
@@ -567,3 +567,58 @@ def test_transport_failure_surfaces_as_an_error_not_a_traceback(
         == 1
     )
     assert "could not reach tenant" in capsys.readouterr().err
+
+
+# ── Driver-side input validation ─────────────────────────────────────────────
+#
+# app_id is a free-text workflow input that lands in a request path, and the
+# base URL takes the OAuth secret — both are validated before any API call.
+
+
+def test_install_rejects_a_malformed_app_id_before_any_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    transport = _wire(monkeypatch, StubTransport(routes=[]))
+    with pytest.raises(TenantApiError, match="invalid app_id"):
+        app.install(_install_args(app_id="../../admin"))
+    assert transport.calls == [], "no tenant call may leave before validation"
+
+
+def test_verify_rejects_a_plaintext_base_url_before_any_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    transport = _wire(monkeypatch, StubTransport(routes=[]))
+    with pytest.raises(TenantApiError, match="invalid tenant base URL"):
+        app.verify(
+            argparse.Namespace(base_url="http://x", app_id=_APP_ID, expected="1")
+        )
+    assert transport.calls == []
+
+
+# ── Error-body rendering ─────────────────────────────────────────────────────
+
+
+def test_render_body_truncates_a_verbose_error_page() -> None:
+    body = "x" * 10000
+    rendered = app._render_body(body)
+    assert len(rendered) <= app._ERROR_BODY_CHARS + len("…(truncated)")
+    assert rendered.endswith("…(truncated)")
+
+
+def test_render_body_leaves_a_short_body_intact() -> None:
+    assert app._render_body({"error": "nope"}) == repr({"error": "nope"})
+
+
+def test_publish_error_body_is_truncated(monkeypatch: pytest.MonkeyPatch) -> None:
+    _wire(
+        monkeypatch,
+        StubTransport(
+            routes=[
+                StubRoute("GET", "/info", Response(404, {})),
+                StubRoute("POST", "/publish", Response(500, "y" * 10000)),
+            ]
+        ),
+    )
+    with pytest.raises(app.TenantAppError) as excinfo:
+        app.install(_install_args())
+    assert len(str(excinfo.value)) < 5000

--- a/.github/scripts/tests/test_e2e_tenant_app.py
+++ b/.github/scripts/tests/test_e2e_tenant_app.py
@@ -1,0 +1,569 @@
+"""Tests for .github/scripts/e2e_tenant_app.py and e2e_tenant_api.py.
+
+The HTTP seam is stubbed at ``TenantClient.request`` — the single place every
+tenant call funnels through — so the branch logic (converge-by-version, the
+credential hint on 401, the scan-gate hint, terminal vs timed-out deployments,
+the version-mismatch failure) is exercised for real while nothing leaves the
+process.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import e2e_tenant_app as app  # noqa: E402
+from e2e_tenant_api import Response, TenantApiError, TenantClient  # noqa: E402
+
+_TENANT = "https://example-tenant.atlan.test"
+_APP_ID = "019d1f6b-6fea-7db3-96d8-e61e159d0351"
+_IMAGE = "ghcr.io/atlanhq/atlan-openapi-app:sdr-test-abc12345"
+_VERSION = "sdr-test-abc12345"
+
+
+# ── Typed HTTP stub ──────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class StubRoute:
+    """One canned response, matched on method + a path fragment."""
+
+    method: str
+    path_fragment: str
+    response: Response
+
+
+@dataclass
+class StubCall:
+    method: str
+    path: str
+    body: dict[str, object] | None
+
+
+@dataclass
+class StubTransport:
+    """Serves ``routes`` in order; each route is consumed once unless ``sticky``.
+
+    Ordered-and-consumed rather than a dict keyed by path so a test can script a
+    sequence against the SAME path — which is exactly what polling a deployment
+    to a terminal state looks like.
+    """
+
+    routes: list[StubRoute]
+    sticky: list[StubRoute] = field(default_factory=list)
+    calls: list[StubCall] = field(default_factory=list)
+
+    # No `self`-of-TenantClient parameter: assigning a BOUND method onto the
+    # class means attribute lookup returns an already-bound object, so the
+    # descriptor protocol never runs and the TenantClient instance is not
+    # prepended. `client.request("GET", path)` arrives here as
+    # `transport.request("GET", path)`.
+    def request(
+        self,
+        method: str,
+        path: str,
+        *,
+        body: dict[str, object] | None = None,
+        timeout: int = 60,
+    ) -> Response:
+        self.calls.append(StubCall(method=method, path=path, body=body))
+        for index, route in enumerate(self.routes):
+            if route.method == method and route.path_fragment in path:
+                return self.routes.pop(index).response
+        for route in self.sticky:
+            if route.method == method and route.path_fragment in path:
+                return route.response
+        raise AssertionError(f"unstubbed call: {method} {path}")
+
+    def paths(self, method: str) -> list[str]:
+        return [c.path for c in self.calls if c.method == method]
+
+    def body_for(self, fragment: str) -> dict[str, object]:
+        for call in self.calls:
+            if fragment in call.path and call.body is not None:
+                return call.body
+        raise AssertionError(f"no request body recorded for a path with {fragment!r}")
+
+
+def _ok(payload: dict[str, object]) -> Response:
+    return Response(status=200, body=payload)
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(app.time, "sleep", lambda _s: None)
+
+
+@pytest.fixture(autouse=True)
+def _creds(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("E2E_OAUTH_CLIENT_ID", "client-id")
+    monkeypatch.setenv("E2E_OAUTH_CLIENT_SECRET", "client-secret")
+    monkeypatch.delenv("ATLAN_API_KEY", raising=False)
+    monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+    # Never let a test reach a real token endpoint.
+    monkeypatch.setattr(app, "mint_oauth_token", lambda *_a, **_k: "stub.jwt.token")
+
+
+def _wire(monkeypatch: pytest.MonkeyPatch, transport: StubTransport) -> StubTransport:
+    monkeypatch.setattr(TenantClient, "request", transport.request)
+    return transport
+
+
+def _install_args(**overrides: object) -> argparse.Namespace:
+    values = {
+        "base_url": _TENANT,
+        "app_id": _APP_ID,
+        "image": _IMAGE,
+        "version": _VERSION,
+        "branch": "chrishehim/fnd-31",
+        "tenant": "example-tenant",
+        "repo_url": "",
+        "deploy_config": "",
+        "self_deployed_runtime": False,
+        "sdk_version": "",
+        "entrypoints": "",
+        "app_configs": "",
+        "release_model": "",
+        "created_by": "",
+        "scan_wait_seconds": 0,
+        "timeout_seconds": 600,
+    }
+    values.update(overrides)
+    return argparse.Namespace(**values)
+
+
+# ── Converge by version ──────────────────────────────────────────────────────
+
+
+def test_install_is_a_noop_when_the_tenant_already_runs_the_version(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    transport = _wire(
+        monkeypatch,
+        StubTransport(routes=[StubRoute("GET", "/info", _ok({"version": _VERSION}))]),
+    )
+    outcome = app.install(_install_args())
+
+    assert outcome.skipped is True
+    assert outcome.installed_version == _VERSION
+    assert transport.paths("POST") == [], (
+        "an already-current tenant must not be re-published or re-installed — "
+        "that is what makes running this once per (run x cloud) and again on a "
+        "re-run safe"
+    )
+
+
+def test_install_proceeds_when_the_app_is_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A 404 on info is the "never installed on this tenant" case — FND-31
+    # requirement 2 says install rather than fail.
+    transport = _wire(
+        monkeypatch,
+        StubTransport(
+            routes=[
+                StubRoute("GET", "/info", Response(status=404, body={})),
+                StubRoute(
+                    "POST",
+                    "/marketplace/publish",
+                    _ok({"version_id": "v1", "release_id": "r1"}),
+                ),
+                StubRoute("GET", "/releases/", _ok({"status": "scan_pending"})),
+                StubRoute("POST", "/install", _ok({"deployment_id": "d1"})),
+                StubRoute(
+                    "GET", "/deployments/", _ok({"deployment_status": "SUCCEEDED"})
+                ),
+                StubRoute("GET", "/info", _ok({"version": _VERSION})),
+            ]
+        ),
+    )
+    outcome = app.install(_install_args())
+
+    assert outcome.skipped is False
+    assert outcome.deployment_id == "d1"
+    assert outcome.installed_version == _VERSION
+    assert outcome.release_status == "scan_pending"
+    assert transport.body_for("/install") == {
+        "version_id": "v1",
+        "force_install": True,
+    }
+
+
+def test_install_scopes_the_registration_to_the_one_tenant(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    transport = _wire(
+        monkeypatch,
+        StubTransport(
+            routes=[
+                StubRoute("GET", "/info", _ok({"version": "older"})),
+                StubRoute("POST", "/marketplace/publish", _ok({"version_id": "v1"})),
+                StubRoute("POST", "/install", _ok({"deployment_id": "d1"})),
+                StubRoute(
+                    "GET", "/deployments/", _ok({"deployment_status": "SUCCEEDED"})
+                ),
+                StubRoute("GET", "/info", _ok({"version": _VERSION})),
+            ],
+            sticky=[StubRoute("GET", "/releases/", Response(status=404, body={}))],
+        ),
+    )
+    app.install(_install_args())
+
+    body = transport.body_for("/marketplace/publish")
+    assert body["allowed_tenants"] == [
+        "example-tenant"
+    ], "a per-PR e2e version must be reachable only by its own e2e tenant"
+    assert "target_channel" not in body
+
+
+# ── The scan gate ────────────────────────────────────────────────────────────
+
+
+def test_install_does_not_wait_for_the_scan_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    transport = _wire(
+        monkeypatch,
+        StubTransport(
+            routes=[
+                StubRoute("GET", "/info", Response(status=404, body={})),
+                StubRoute(
+                    "POST",
+                    "/marketplace/publish",
+                    _ok({"version_id": "v1", "release_id": "r1"}),
+                ),
+                StubRoute("GET", "/releases/", _ok({"status": "scan_pending"})),
+                StubRoute("POST", "/install", _ok({"deployment_id": "d1"})),
+                StubRoute(
+                    "GET", "/deployments/", _ok({"deployment_status": "SUCCEEDED"})
+                ),
+                StubRoute("GET", "/info", _ok({"version": _VERSION})),
+            ]
+        ),
+    )
+    app.install(_install_args(scan_wait_seconds=0))
+    # Exactly one release read (the informational one), no poll loop.
+    assert len([p for p in transport.paths("GET") if "/releases/" in p]) == 1
+
+
+def test_scan_rejection_names_the_flag_that_fixes_it(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _wire(
+        monkeypatch,
+        StubTransport(
+            routes=[
+                StubRoute("GET", "/info", Response(status=404, body={})),
+                StubRoute(
+                    "POST",
+                    "/marketplace/publish",
+                    _ok({"version_id": "v1", "release_id": "r1"}),
+                ),
+                StubRoute("GET", "/releases/", _ok({"status": "scan_pending"})),
+                StubRoute(
+                    "POST",
+                    "/install",
+                    Response(status=400, body={"detail": "release is scan_pending"}),
+                ),
+            ]
+        ),
+    )
+    with pytest.raises(app.TenantAppError, match="scan-wait-seconds"):
+        app.install(_install_args())
+
+
+def test_scan_wait_polls_until_the_scan_leaves_pending(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    transport = _wire(
+        monkeypatch,
+        StubTransport(
+            routes=[
+                StubRoute("GET", "/info", Response(status=404, body={})),
+                StubRoute(
+                    "POST",
+                    "/marketplace/publish",
+                    _ok({"version_id": "v1", "release_id": "r1"}),
+                ),
+                StubRoute("GET", "/releases/", _ok({"status": "scan_pending"})),
+                StubRoute("GET", "/releases/", _ok({"status": "scan_pending"})),
+                StubRoute("GET", "/releases/", _ok({"status": "active"})),
+                StubRoute("POST", "/install", _ok({"deployment_id": "d1"})),
+                StubRoute(
+                    "GET", "/deployments/", _ok({"deployment_status": "SUCCEEDED"})
+                ),
+                StubRoute("GET", "/info", _ok({"version": _VERSION})),
+            ]
+        ),
+    )
+    outcome = app.install(_install_args(scan_wait_seconds=300))
+    assert outcome.release_status == "active"
+    assert len([p for p in transport.paths("GET") if "/releases/" in p]) == 3
+
+
+# ── Credential diagnosis ─────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("status", [401, 403])
+def test_publish_rejection_names_the_oauth_pair_not_the_api_key(
+    monkeypatch: pytest.MonkeyPatch, status: int
+) -> None:
+    # The single most likely misconfiguration is reaching for ATLAN_API_KEY here.
+    # The error has to say which of two credentials was rejected.
+    _wire(
+        monkeypatch,
+        StubTransport(
+            routes=[
+                StubRoute("GET", "/info", Response(status=404, body={})),
+                StubRoute(
+                    "POST", "/marketplace/publish", Response(status=status, body={})
+                ),
+            ]
+        ),
+    )
+    with pytest.raises(app.TenantAppError, match="E2E_OAUTH_CLIENT_ID"):
+        app.install(_install_args())
+
+
+def test_publish_without_a_version_id_fails_rather_than_installing_nothing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _wire(
+        monkeypatch,
+        StubTransport(
+            routes=[
+                StubRoute("GET", "/info", Response(status=404, body={})),
+                StubRoute("POST", "/marketplace/publish", _ok({"release_id": "r1"})),
+            ]
+        ),
+    )
+    with pytest.raises(app.TenantAppError, match="version_id"):
+        app.install(_install_args())
+
+
+# ── Reconciliation ───────────────────────────────────────────────────────────
+
+
+def test_deployment_failure_is_fatal_and_pulls_diagnostics(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    transport = _wire(
+        monkeypatch,
+        StubTransport(
+            routes=[
+                StubRoute("GET", "/info", Response(status=404, body={})),
+                StubRoute("POST", "/marketplace/publish", _ok({"version_id": "v1"})),
+                StubRoute("POST", "/install", _ok({"deployment_id": "d1"})),
+                StubRoute(
+                    "GET",
+                    "/deployments/",
+                    _ok({"deployment_status": "FAILED", "message": "ImagePullBackOff"}),
+                ),
+                StubRoute("GET", "/failure", _ok({"reason": "ImagePullBackOff"})),
+            ],
+            sticky=[StubRoute("GET", "/releases/", Response(status=404, body={}))],
+        ),
+    )
+    with pytest.raises(app.TenantAppError, match="ImagePullBackOff"):
+        app.install(_install_args())
+    assert any("/failure" in p for p in transport.paths("GET")), (
+        "a failed deploy must pull LM's diagnostics into the step log — that is "
+        "the only pod-level detail CI can see without vcluster"
+    )
+
+
+def test_deployment_timeout_is_a_failure_not_a_warning(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # An accepted-but-unreconciled deploy IS the silent wrong-version failure this
+    # change exists to remove, so a timeout must never pass.
+    _wire(
+        monkeypatch,
+        StubTransport(
+            routes=[
+                StubRoute("GET", "/info", Response(status=404, body={})),
+                StubRoute("POST", "/marketplace/publish", _ok({"version_id": "v1"})),
+                StubRoute("POST", "/install", _ok({"deployment_id": "d1"})),
+            ],
+            sticky=[
+                StubRoute("GET", "/releases/", Response(status=404, body={})),
+                StubRoute("GET", "/failure", Response(status=404, body={})),
+            ],
+        ),
+    )
+    with pytest.raises(app.TenantAppError, match="terminal state"):
+        app.install(_install_args(timeout_seconds=0))
+
+
+def test_transient_deployment_read_is_retried_not_fatal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _wire(
+        monkeypatch,
+        StubTransport(
+            routes=[
+                StubRoute("GET", "/info", Response(status=404, body={})),
+                StubRoute("POST", "/marketplace/publish", _ok({"version_id": "v1"})),
+                StubRoute("POST", "/install", _ok({"deployment_id": "d1"})),
+                StubRoute(
+                    "GET", "/deployments/", Response(status=502, body="bad gateway")
+                ),
+                StubRoute(
+                    "GET", "/deployments/", _ok({"deployment_status": "SUCCEEDED"})
+                ),
+                StubRoute("GET", "/info", _ok({"version": _VERSION})),
+            ],
+            sticky=[StubRoute("GET", "/releases/", Response(status=404, body={}))],
+        ),
+    )
+    assert app.install(_install_args()).installed_version == _VERSION
+
+
+# ── verify ───────────────────────────────────────────────────────────────────
+
+
+def _verify_args(expected: str) -> argparse.Namespace:
+    return argparse.Namespace(base_url=_TENANT, app_id=_APP_ID, expected=expected)
+
+
+def test_verify_passes_on_a_match(monkeypatch: pytest.MonkeyPatch) -> None:
+    _wire(
+        monkeypatch,
+        StubTransport(routes=[StubRoute("GET", "/info", _ok({"version": _VERSION}))]),
+    )
+    assert app.verify(_verify_args(_VERSION)) == _VERSION
+
+
+def test_verify_fails_naming_both_versions(monkeypatch: pytest.MonkeyPatch) -> None:
+    _wire(
+        monkeypatch,
+        StubTransport(
+            routes=[StubRoute("GET", "/info", _ok({"version": "sdr-test-old"}))]
+        ),
+    )
+    with pytest.raises(app.TenantAppError) as excinfo:
+        app.verify(_verify_args(_VERSION))
+    message = str(excinfo.value)
+    assert (
+        "sdr-test-old" in message and _VERSION in message
+    ), "the whole point is that an operator can see the drift without digging"
+
+
+def test_verify_fails_when_nothing_is_installed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _wire(
+        monkeypatch,
+        StubTransport(
+            routes=[StubRoute("GET", "/info", Response(status=404, body={}))]
+        ),
+    )
+    with pytest.raises(app.TenantAppError, match="nothing"):
+        app.verify(_verify_args(_VERSION))
+
+
+# ── Version extraction across LM shapes ──────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "payload, expected",
+    [
+        ({"version": "a"}, "a"),
+        ({"installed_version": "b"}, "b"),
+        ({"app_version": "c"}, "c"),
+        ({"current_version": "d"}, "d"),
+        ({"install": {"version": "e"}}, "e"),
+        ({"deployment": {"installed_version": "f"}}, "f"),
+        ({}, ""),
+        ({"version": "   "}, ""),
+        ({"version": 3}, ""),
+    ],
+)
+def test_version_extraction(payload: dict[str, object], expected: str) -> None:
+    assert app._extract_version(payload) == expected
+
+
+# ── Outputs ──────────────────────────────────────────────────────────────────
+
+
+def test_outputs_are_written_to_github_output(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    target = tmp_path / "out"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(target))
+    _wire(
+        monkeypatch,
+        StubTransport(routes=[StubRoute("GET", "/info", _ok({"version": _VERSION}))]),
+    )
+
+    assert (
+        app.main(
+            [
+                "verify",
+                "--base-url",
+                _TENANT,
+                "--app-id",
+                _APP_ID,
+                "--expected",
+                _VERSION,
+            ]
+        )
+        == 0
+    )
+    assert f"installed_version={_VERSION}" in target.read_text()
+
+
+def test_main_returns_1_and_annotates_on_failure(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _wire(
+        monkeypatch,
+        StubTransport(
+            routes=[StubRoute("GET", "/info", _ok({"version": "sdr-test-old"}))]
+        ),
+    )
+    assert (
+        app.main(
+            [
+                "verify",
+                "--base-url",
+                _TENANT,
+                "--app-id",
+                _APP_ID,
+                "--expected",
+                _VERSION,
+            ]
+        )
+        == 1
+    )
+    assert "::error::" in capsys.readouterr().err
+
+
+def test_transport_failure_surfaces_as_an_error_not_a_traceback(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    def _boom(*_a: object, **_k: object) -> Response:
+        raise TenantApiError("could not reach tenant")
+
+    monkeypatch.setattr(TenantClient, "request", _boom)
+    assert (
+        app.main(
+            [
+                "verify",
+                "--base-url",
+                _TENANT,
+                "--app-id",
+                _APP_ID,
+                "--expected",
+                _VERSION,
+            ]
+        )
+        == 1
+    )
+    assert "could not reach tenant" in capsys.readouterr().err

--- a/.github/scripts/tests/test_e2e_tenant_install_workflow.py
+++ b/.github/scripts/tests/test_e2e_tenant_install_workflow.py
@@ -1,0 +1,96 @@
+"""Guards for .github/workflows/e2e-tenant-install.yaml.
+
+The workflow takes free-text `workflow_dispatch` inputs and installs an app onto
+a live tenant, so the shell-injection surface is the thing worth pinning: an
+input interpolated directly into a `run:` block is spliced into the script before
+bash ever sees a quote, so a crafted value executes instead of being compared.
+Routing every input through `env:` and referencing a quoted ``"$VAR"`` makes bash
+treat it as data.
+
+Scoped deliberately to this one workflow. A repo-wide sweep currently finds ~49
+pre-existing instances of the same pattern across unrelated workflows; asserting
+on all of them here would fail immediately on work this change does not own. That
+backlog is worth its own ticket, not a guard that has to be born disabled.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_WORKFLOW = _REPO_ROOT / ".github/workflows/e2e-tenant-install.yaml"
+
+#: Any `${{ inputs.* }}` reference, which is what must not appear inside `run:`.
+_INPUT_REF = re.compile(r"\$\{\{\s*inputs\.[A-Za-z0-9_-]+\s*\}\}")
+
+
+@pytest.fixture(scope="module")
+def workflow() -> dict:  # type: ignore[type-arg]
+    return yaml.safe_load(_WORKFLOW.read_text(encoding="utf-8"))
+
+
+def _steps(workflow: dict) -> list[dict]:  # type: ignore[type-arg]
+    steps: list[dict] = []  # type: ignore[type-arg]
+    for job in workflow["jobs"].values():
+        steps.extend(job.get("steps") or [])
+    return steps
+
+
+def test_no_dispatch_input_is_interpolated_into_a_run_block(workflow: dict) -> None:  # type: ignore[type-arg]
+    offenders: list[str] = []
+    for step in _steps(workflow):
+        script = step.get("run")
+        if not isinstance(script, str):
+            continue
+        for match in _INPUT_REF.findall(script):
+            offenders.append(f"{step.get('name', '?')}: {match}")
+    assert not offenders, (
+        "these run: blocks interpolate a workflow_dispatch input directly, which "
+        "splices attacker-influenced text into the shell. Pass it via env: and "
+        f'reference a quoted "$VAR" instead. Offenders: {offenders}'
+    )
+
+
+def test_inputs_used_by_scripts_arrive_through_env(workflow: dict) -> None:
+    """Every input the install/verify steps consume must be exported via env:."""
+    by_name = {str(s.get("name", "")): s for s in _steps(workflow)}
+    expectations = {
+        "Install onto the tenant": {
+            "APP_ID",
+            "IMAGE",
+            "VERSION",
+            "BRANCH",
+            "SCAN_WAIT_SECONDS",
+            "TIMEOUT_SECONDS",
+        },
+        "Verify the tenant reports the installed version": {"APP_ID", "VERSION"},
+    }
+    for step_name, required in expectations.items():
+        step = by_name.get(step_name)
+        assert step is not None, f"step {step_name!r} is gone; update this guard"
+        env = set(step.get("env") or {})
+        missing = required - env
+        assert not missing, f"{step_name} no longer exports {sorted(missing)} via env:"
+
+
+def test_install_requires_explicit_confirmation(workflow: dict) -> None:  # type: ignore[type-arg]
+    """Installing onto a tenant is a deployment; it must not run by default."""
+    triggers = workflow.get("on", workflow.get(True))
+    confirm = triggers["workflow_dispatch"]["inputs"]["confirm"]
+    assert confirm["default"] == "no"
+    assert set(confirm["options"]) == {"no", "yes"}
+    assert workflow["jobs"]["install"]["if"] == "inputs.confirm == 'yes'", (
+        "the confirmation gate must be a job-level if:, so an unconfirmed run is "
+        "visibly skipped rather than green-but-did-nothing"
+    )
+
+
+def test_concurrency_is_per_cloud_and_does_not_cancel(workflow: dict) -> None:  # type: ignore[type-arg]
+    concurrency = workflow["concurrency"]
+    assert "inputs.cloud" in concurrency["group"]
+    # Cancelling mid-install leaves the tenant in whatever state LM reached.
+    assert concurrency["cancel-in-progress"] is False

--- a/.github/scripts/tests/test_export_extra_env.py
+++ b/.github/scripts/tests/test_export_extra_env.py
@@ -573,7 +573,14 @@ _CALL_SITE_SUFFIXES = ("*.y*ml", "*.sh", "*.py")
 # a named exclusion rather than encoded into the predicate, and validated below:
 # if a mention here ever appears outside a comment, the exclusion stops applying
 # and the file is audited like any other caller.
-_PROSE_ONLY_FILES = {".github/workflows/scripts-tests.yaml"}
+_PROSE_ONLY_FILES = {
+    ".github/workflows/scripts-tests.yaml",
+    # FND-31. Names this script in a comment only, pointing at it as the
+    # explanation for why its own tenant-resolution step is two passes. It never
+    # invokes it. The "no live mention" assertion below is what keeps that true:
+    # if it ever starts invoking the script, it stops being excluded.
+    ".github/workflows/e2e-tenant-install.yaml",
+}
 
 # The script and its own tests are the implementation, not callers of it. Both
 # contain literal `>> "$GITHUB_ENV"` invocations — in the module docstring's usage

--- a/.github/scripts/tests/test_marketplace_publish_body.py
+++ b/.github/scripts/tests/test_marketplace_publish_body.py
@@ -1,0 +1,179 @@
+"""Tests for .github/scripts/marketplace_publish_body.py."""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from marketplace_publish_body import (  # noqa: E402
+    PublishBodyError,
+    PublishRequest,
+    build,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _minimal(**overrides: object) -> PublishRequest:
+    base = {
+        "app_id": "019d1f6b-6fea-7db3-96d8-e61e159d0351",
+        "image": "ghcr.io/atlanhq/atlan-openapi-app:sdr-test-abc12345",
+        "version": "sdr-test-abc12345",
+        "branch": "chrishehim/fnd-31",
+        "allowed_tenants": ("example-tenant",),
+    }
+    base.update(overrides)
+    return PublishRequest(**base)  # type: ignore[arg-type]
+
+
+# ── Required fields ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("field", ["app_id", "image", "version", "branch"])
+def test_missing_required_field_fails_naming_it(field: str) -> None:
+    with pytest.raises(PublishBodyError, match=field):
+        build(_minimal(**{field: ""}))
+
+
+def test_unscoped_publish_is_refused() -> None:
+    # Neither allowed_tenants nor target_channel: GM would decide, and which way
+    # it decides is whether a per-PR e2e build reaches every tenant.
+    with pytest.raises(PublishBodyError, match="scoped"):
+        build(_minimal(allowed_tenants=()))
+
+
+# ── Scoping ──────────────────────────────────────────────────────────────────
+
+
+def test_tenant_targeting_produces_allowed_tenants_and_no_channel() -> None:
+    body = build(_minimal(allowed_tenants=("example-tenant",)))
+    assert body["allowed_tenants"] == ["example-tenant"]
+    assert "target_channel" not in body
+
+
+def test_tenant_targeting_wins_over_channel() -> None:
+    body = build(_minimal(allowed_tenants=("example-tenant",), target_channel="all"))
+    assert body["allowed_tenants"] == ["example-tenant"]
+    assert "target_channel" not in body, (
+        "sending both lets GM choose; tenant-targeting must win so a per-PR "
+        "build cannot become visible to every tenant"
+    )
+
+
+def test_channel_used_when_no_tenants() -> None:
+    body = build(_minimal(allowed_tenants=(), target_channel="all"))
+    assert body["target_channel"] == "all"
+    assert "allowed_tenants" not in body
+
+
+# ── Optional fields: absent vs empty ─────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "field, wire_key",
+    [
+        ("repo_url", "repo"),
+        ("deploy_config", "config"),
+        ("sdk_version", "sdk_version"),
+        ("app_configs", "app_configs"),
+        ("release_model", "release_model"),
+        ("created_by", "created_by"),
+        ("entrypoints", "entrypoints"),
+    ],
+)
+def test_empty_optional_is_omitted_not_blanked(field: str, wire_key: str) -> None:
+    # GM distinguishes absent from empty on several of these — an empty `repo`
+    # 409s for apps registered with a source repo.
+    body = build(_minimal(**{field: ""}))
+    assert wire_key not in body
+
+
+def test_entrypoints_is_sent_as_parsed_json() -> None:
+    body = build(_minimal(entrypoints='[{"name": "openapi"}]'))
+    assert body["entrypoints"] == [{"name": "openapi"}]
+
+
+def test_invalid_entrypoints_json_fails_loudly() -> None:
+    with pytest.raises(PublishBodyError, match="entrypoints"):
+        build(_minimal(entrypoints="{not json"))
+
+
+def test_sdr_capability_is_prepended_to_config() -> None:
+    body = build(_minimal(deploy_config="key: value", self_deployed_runtime=True))
+    assert body["config"] == "self_deployed_runtime: true\nkey: value"
+
+
+def test_sdr_capability_alone_still_produces_a_config() -> None:
+    # SDR capability rides inside the opaque config blob, so it must survive an
+    # app with no deploy: block at all.
+    body = build(_minimal(deploy_config="", self_deployed_runtime=True))
+    assert body["config"] == "self_deployed_runtime: true"
+
+
+def test_source_marks_the_registration_as_ci() -> None:
+    assert build(_minimal())["source"] == "ci_publish"
+
+
+# ── Drift guard against the release path ─────────────────────────────────────
+
+
+def test_field_set_matches_the_release_workflow() -> None:
+    """The e2e path must register the same SHAPE the release path does.
+
+    FND-31 exists so the tenant runs the version under test. If e2e registered a
+    differently-shaped version than releases do, e2e would be validating a
+    registration shape that never ships.
+
+    build-and-publish-app.yaml still builds its body in an inline heredoc — it is
+    the path every release goes through, so it is deliberately not rewired in the
+    same change that introduces this module. This guard is what makes that safe:
+    the two cannot drift unnoticed. When the workflow is switched over to import
+    this module, delete this test.
+    """
+    workflow = (_REPO_ROOT / ".github/workflows/build-and-publish-app.yaml").read_text(
+        encoding="utf-8"
+    )
+    # Keys the workflow assigns into its publish body, either as a literal in the
+    # dict or via body["key"] = ....
+    workflow_keys = set(re.findall(r'body\["(\w+)"\]', workflow))
+    workflow_keys |= {
+        key
+        for key in re.findall(r'^\s{14}"(\w+)":', workflow, re.M)
+        # The literal dict is indented 14 spaces inside the heredoc; filter to the
+        # publish-body keys we know it declares there.
+        if key in {"app_id", "image", "version", "branch", "repo", "source"}
+    }
+
+    ours = set(build(_minimal(allowed_tenants=(), target_channel="all")))
+    ours |= set(
+        build(
+            _minimal(
+                repo_url="https://github.com/atlanhq/atlan-openapi-app",
+                deploy_config="k: v",
+                sdk_version="3.26.1",
+                entrypoints="[]",
+                app_configs="e30=",
+                release_model="semver",
+                created_by="someone",
+            )
+        )
+    )
+
+    missing = workflow_keys - ours
+    assert not missing, (
+        f"build-and-publish-app.yaml sends publish fields this builder does not: "
+        f"{sorted(missing)}. The e2e path would register a different shape than "
+        "releases do."
+    )
+
+
+def test_body_is_json_serialisable() -> None:
+    # It goes straight onto the wire; a non-serialisable value would fail at the
+    # request rather than here.
+    json.dumps(build(_minimal(entrypoints='[{"name": "openapi"}]')))

--- a/.github/scripts/tests/test_resolve_e2e_tenant.py
+++ b/.github/scripts/tests/test_resolve_e2e_tenant.py
@@ -368,6 +368,10 @@ def test_call_sites_are_the_expected_files() -> None:
     relative = {p.relative_to(_REPO_ROOT).as_posix() for p in _call_site_files()}
     assert relative == {
         ".github/workflows/e2e-full-reusable.yaml",
+        # FND-31: installs a given app image onto one e2e tenant, so it resolves
+        # that tenant the same way a leg does. Audited: it runs the two-pass
+        # --mask-only-then-write protocol, which the ordering guard below checks.
+        ".github/workflows/e2e-tenant-install.yaml",
         ".github/workflows/tests-reusable.yaml",
     }
 

--- a/.github/workflows/e2e-tenant-install.yaml
+++ b/.github/workflows/e2e-tenant-install.yaml
@@ -135,30 +135,45 @@ jobs:
       # expression again just to be renamed — every hop is a hop it can be
       # mishandled on. Those are the OAuth client pair the marketplace publish
       # route authorises on, NOT ATLAN_API_KEY (the harness's API key).
+      # Every dispatch input reaches the shell through env:, never through
+        # `${{ }}` inside run:. A workflow_dispatch input is attacker-influenced
+        # free text, and direct interpolation splices it into the script before
+        # bash sees a quote — so a crafted `version` would execute rather than be
+        # compared. Via env:, bash receives it as data.
       - name: Install onto the tenant
         id: install
+        env:
+          APP_ID: ${{ inputs.app_id }}
+          IMAGE: ${{ inputs.image }}
+          VERSION: ${{ inputs.version }}
+          BRANCH: ${{ inputs.branch }}
+          SCAN_WAIT_SECONDS: ${{ inputs.scan_wait_seconds }}
+          TIMEOUT_SECONDS: ${{ inputs.timeout_seconds }}
         run: |
           set -euo pipefail
           python3 .github/scripts/e2e_tenant_app.py install \
             --base-url "$ATLAN_BASE_URL" \
-            --app-id "${{ inputs.app_id }}" \
-            --image "${{ inputs.image }}" \
-            --version "${{ inputs.version }}" \
-            --branch "${{ inputs.branch }}" \
+            --app-id "$APP_ID" \
+            --image "$IMAGE" \
+            --version "$VERSION" \
+            --branch "$BRANCH" \
             --tenant "$SDR_TEST_TENANT" \
-            --scan-wait-seconds "${{ inputs.scan_wait_seconds }}" \
-            --timeout-seconds "${{ inputs.timeout_seconds }}"
+            --scan-wait-seconds "$SCAN_WAIT_SECONDS" \
+            --timeout-seconds "$TIMEOUT_SECONDS"
 
       # Independent read-back through the same check the e2e legs will run, so a
       # green install that somehow left the tenant on another version still fails
       # here rather than in a leg later.
       - name: Verify the tenant reports the installed version
+        env:
+          APP_ID: ${{ inputs.app_id }}
+          VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
           python3 .github/scripts/e2e_tenant_app.py verify \
             --base-url "$ATLAN_BASE_URL" \
-            --app-id "${{ inputs.app_id }}" \
-            --expected "${{ inputs.version }}"
+            --app-id "$APP_ID" \
+            --expected "$VERSION"
 
       # The findings, in the run summary rather than buried in step logs — this
       # workflow's first purpose is answering the scan-gate question, and the
@@ -166,19 +181,23 @@ jobs:
       - name: Summarise
         if: always()
         env:
+          CLOUD: ${{ inputs.cloud }}
+          APP_ID: ${{ inputs.app_id }}
+          IMAGE: ${{ inputs.image }}
+          VERSION: ${{ inputs.version }}
           RELEASE_STATUS: ${{ steps.install.outputs.release_status }}
           SKIPPED: ${{ steps.install.outputs.skipped }}
           INSTALLED: ${{ steps.install.outputs.installed_version }}
           DEPLOYMENT_ID: ${{ steps.install.outputs.deployment_id }}
         run: |
           {
-            echo "### E2E tenant install — ${{ inputs.cloud }}"
+            echo "### E2E tenant install — ${CLOUD}"
             echo ""
             echo "| Field | Value |"
             echo "|---|---|"
-            echo "| App | \`${{ inputs.app_id }}\` |"
-            echo "| Image | \`${{ inputs.image }}\` |"
-            echo "| Version | \`${{ inputs.version }}\` |"
+            echo "| App | \`${APP_ID}\` |"
+            echo "| Image | \`${IMAGE}\` |"
+            echo "| Version | \`${VERSION}\` |"
             echo "| Already current (no-op) | \`${SKIPPED:-unknown}\` |"
             echo "| Release status at install | \`${RELEASE_STATUS:-unreadable}\` |"
             echo "| Deployment | \`${DEPLOYMENT_ID:-none}\` |"

--- a/.github/workflows/e2e-tenant-install.yaml
+++ b/.github/workflows/e2e-tenant-install.yaml
@@ -1,0 +1,186 @@
+# Manually install a specific app image onto one e2e tenant.
+#
+# FND-31. Two jobs for this workflow:
+#
+# 1. It settles the last open spike question — will GM install a release that has
+#    not finished its Snyk scan? The e2e path deliberately does not wait for the
+#    scan (a base-image CVE must not red an unrelated PR's e2e), so this run
+#    reports the release status at install time and whether the install was
+#    accepted. `e2e_tenant_app.py` recognises a scan-gate rejection and names
+#    `--scan-wait-seconds` in the error, so either answer is self-explaining.
+#
+# 2. It stays as the manual escape hatch: re-point an e2e tenant at a known
+#    image without a full e2e run, which is what you want when a tenant has
+#    drifted or a leg failed its version check.
+#
+# WHY THIS IS workflow_dispatch AND NOT AUTOMATIC: installing an app onto a
+# tenant is a deployment. The manual trigger IS the human authorisation, and the
+# `confirm` input makes firing it at the wrong tenant a deliberate act rather
+# than a default. The automatic path (once per run per cloud, ahead of the e2e
+# matrix) lands separately in e2e-full-reusable.yaml.
+#
+# Credentials never leave CI. `resolve_e2e_tenant.py` writes the leg's tenant and
+# credentials into $GITHUB_ENV behind the two-pass mask protocol, and
+# `e2e_tenant_app.py` reads them from the environment rather than argv (argv is
+# visible in process listings and in `set -x` output). Nothing prints a token.
+name: E2E Tenant Install
+
+on:
+  workflow_dispatch:
+    inputs:
+      cloud:
+        description: "Which cloud's e2e tenant to install onto."
+        required: true
+        type: choice
+        options: [aws, azure, gcp]
+        default: aws
+      confirm:
+        description: "This INSTALLS an app onto a live tenant. Select yes to proceed."
+        required: true
+        type: choice
+        options: ["no", "yes"]
+        default: "no"
+      app_id:
+        description: "GM app UUID (the app_id field in the app repo's atlan.yaml)."
+        required: true
+        type: string
+      image:
+        description: "Full image reference, e.g. ghcr.io/atlanhq/atlan-openapi-app:sdr-test-abc12345"
+        required: true
+        type: string
+      version:
+        description: >-
+          GM version string. Required rather than derived from the image tag so
+          this workflow needs no conditional shell (docs/standards/ci.md) —
+          normally the image tag itself.
+        required: true
+        type: string
+      branch:
+        description: "Git ref the image was built from, recorded on the GM version."
+        required: true
+        type: string
+      scan_wait_seconds:
+        description: >-
+          Seconds to wait for GM's release scan before installing. 0 (default)
+          does not wait. Raise this only if a run shows GM refusing to install an
+          unscanned release.
+        required: false
+        type: string
+        default: "0"
+      timeout_seconds:
+        description: "Budget for the deployment to reconcile before failing."
+        required: false
+        type: string
+        default: "600"
+
+permissions:
+  contents: read
+
+concurrency:
+  # One install at a time per cloud: the installation is tenant-scoped (one per
+  # app per tenant), so two concurrent installs would race and the loser would
+  # silently be the version left running. Not cancel-in-progress — cancelling
+  # mid-install leaves the tenant in whatever state LM reached.
+  group: e2e-tenant-install-${{ inputs.cloud }}
+  cancel-in-progress: false
+
+jobs:
+  install:
+    name: Install onto ${{ inputs.cloud }}
+    # The gate is a job-level `if:` rather than a shell test so the job is
+    # visibly skipped instead of green-but-did-nothing.
+    if: inputs.confirm == 'yes'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      E2E_TENANT_MATRIX_JSON: ${{ secrets.E2E_TENANT_MATRIX_JSON }}
+      E2E_CLOUD: ${{ inputs.cloud }}
+      FALLBACK_SDR_TEST_TENANT: ${{ secrets.SDR_TEST_TENANT }}
+      FALLBACK_SDR_CLIENT_ID: ${{ secrets.SDR_CLIENT_ID }}
+      FALLBACK_SDR_CLIENT_SECRET: ${{ secrets.SDR_CLIENT_SECRET }}
+      FALLBACK_ATLAN_API_KEY: ${{ secrets.ATLAN_API_KEY }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # Two invocations: the mask pass must reach the log BEFORE the write pass
+      # redirects stdout into $GITHUB_ENV, because registering the matrix blob as
+      # a secret does not redact the values inside it. Same protocol as
+      # tests-reusable.yaml and e2e-full-reusable.yaml — see
+      # .github/scripts/export_extra_env.py for why the two passes are separate.
+      - name: Resolve the target tenant
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/resolve_e2e_tenant.py \
+            --matrix-json "$E2E_TENANT_MATRIX_JSON" \
+            --cloud "$E2E_CLOUD" \
+            --fallback-tenant "$FALLBACK_SDR_TEST_TENANT" \
+            --fallback-client-id "$FALLBACK_SDR_CLIENT_ID" \
+            --fallback-client-secret "$FALLBACK_SDR_CLIENT_SECRET" \
+            --fallback-api-key "$FALLBACK_ATLAN_API_KEY" \
+            --mask-only
+          python3 .github/scripts/resolve_e2e_tenant.py \
+            --matrix-json "$E2E_TENANT_MATRIX_JSON" \
+            --cloud "$E2E_CLOUD" \
+            --fallback-tenant "$FALLBACK_SDR_TEST_TENANT" \
+            --fallback-client-id "$FALLBACK_SDR_CLIENT_ID" \
+            --fallback-client-secret "$FALLBACK_SDR_CLIENT_SECRET" \
+            --fallback-api-key "$FALLBACK_ATLAN_API_KEY" \
+            >> "$GITHUB_ENV"
+
+      # No env: block re-exporting the credentials. The script reads
+      # SDR_CLIENT_ID / SDR_CLIENT_SECRET straight out of the environment the
+      # resolver wrote, so the secret is not interpolated through a GitHub
+      # expression again just to be renamed — every hop is a hop it can be
+      # mishandled on. Those are the OAuth client pair the marketplace publish
+      # route authorises on, NOT ATLAN_API_KEY (the harness's API key).
+      - name: Install onto the tenant
+        id: install
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/e2e_tenant_app.py install \
+            --base-url "$ATLAN_BASE_URL" \
+            --app-id "${{ inputs.app_id }}" \
+            --image "${{ inputs.image }}" \
+            --version "${{ inputs.version }}" \
+            --branch "${{ inputs.branch }}" \
+            --tenant "$SDR_TEST_TENANT" \
+            --scan-wait-seconds "${{ inputs.scan_wait_seconds }}" \
+            --timeout-seconds "${{ inputs.timeout_seconds }}"
+
+      # Independent read-back through the same check the e2e legs will run, so a
+      # green install that somehow left the tenant on another version still fails
+      # here rather than in a leg later.
+      - name: Verify the tenant reports the installed version
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/e2e_tenant_app.py verify \
+            --base-url "$ATLAN_BASE_URL" \
+            --app-id "${{ inputs.app_id }}" \
+            --expected "${{ inputs.version }}"
+
+      # The findings, in the run summary rather than buried in step logs — this
+      # workflow's first purpose is answering the scan-gate question, and the
+      # answer should be readable without opening a log.
+      - name: Summarise
+        if: always()
+        env:
+          RELEASE_STATUS: ${{ steps.install.outputs.release_status }}
+          SKIPPED: ${{ steps.install.outputs.skipped }}
+          INSTALLED: ${{ steps.install.outputs.installed_version }}
+          DEPLOYMENT_ID: ${{ steps.install.outputs.deployment_id }}
+        run: |
+          {
+            echo "### E2E tenant install — ${{ inputs.cloud }}"
+            echo ""
+            echo "| Field | Value |"
+            echo "|---|---|"
+            echo "| App | \`${{ inputs.app_id }}\` |"
+            echo "| Image | \`${{ inputs.image }}\` |"
+            echo "| Version | \`${{ inputs.version }}\` |"
+            echo "| Already current (no-op) | \`${SKIPPED:-unknown}\` |"
+            echo "| Release status at install | \`${RELEASE_STATUS:-unreadable}\` |"
+            echo "| Deployment | \`${DEPLOYMENT_ID:-none}\` |"
+            echo "| Tenant reports installed | \`${INSTALLED:-unreported}\` |"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
### Changelog

- `.github/scripts/e2e_tenant_api.py` — tenant HTTP client: OAuth `client_credentials` token mint, request helper, marketplace endpoint constants. Stdlib-only.
- `.github/scripts/marketplace_publish_body.py` — one builder for the `POST /marketplace/publish` body.
- `.github/scripts/e2e_tenant_app.py` — `install` (register tenant-targeted → install → wait for reconcile → read the version back) and `verify` (assert the installed version).
- `.github/workflows/e2e-tenant-install.yaml` — `workflow_dispatch` entry point.
- 75 new tests across the three modules.

### Additional context

[FND-31](https://linear.app/atlan-epd/issue/FND-31/e2e-tests-must-deploy-the-app-under-test-to-the-target-tenant). The full-DAG e2e suite runs against a live tenant but never deployed the app under test to it. Where the app happened to be installed, the tests exercised whatever version was last hand-deployed there; where it was not, every leg died on a DNS lookup for a namespace that did not exist — which is what the first cross-CSP matrix run hit on Azure and GCP.

That matters more than it looks: **at AE submit, Heracles re-fetches the manifest from the tenant-deployed pod and THAT DAG is what runs** (`processAutomationEngineWorkflow`). The harness's local seed DAG establishes the workflow record, not the graph. So the DAG contract a full-DAG e2e exercises is whatever version the tenant is running.

This PR adds the tenant-side machinery plus a manual entry point. The automatic path (once per run per cloud, ahead of the e2e matrix) lands separately — it needs the build-once seam from #3018 and the answer to the scan-gate question below.

#### Decisions worth a reviewer's attention

- **Publish authorises on the OAuth client pair, NOT `ATLAN_API_KEY`.** Reaching for the API key is the obvious wrong guess, so a 401/403 on publish says so explicitly and reports the token's realm roles.
- **Registration is scoped with `allowed_tenants`** to the one e2e tenant, so a SHA-keyed per-PR version can never reach a real tenant. Sending both `allowed_tenants` and `target_channel` would let GM pick, and which way it picks decides whether a per-PR build becomes visible to everyone — so the builder refuses to send both, and refuses an unscoped publish outright.
- **The Snyk release scan is deliberately NOT waited for.** `atlan app deploy` waits up to 10 minutes and refuses a `scan_failed` release; that is wrong here, because a base-image CVE would red every leg of an unrelated PR, and release is gated separately.
- **Install converges by version.** Already-current is a no-op, which is what makes running it once per (run × cloud) — and again on a re-run — safe.
- **A reconcile timeout FAILS.** An accepted-but-unreconciled deploy is the same silent wrong-version failure in a new costume.

#### Open question this PR is built to answer

Will GM install a release still in `scan_pending`? Unknown at time of writing. Rather than throwaway probe code, the first live run of `E2E Tenant Install` answers it: the run summary reports the release status at install time and whether the install was accepted. A scan-gate rejection is recognised and the error names `--scan-wait-seconds`, so either answer is self-explaining.

#### Secret hygiene

- Credentials are read from the environment, never argv (visible in process listings and under `set -x`).
- The access token is never printed and never written to `$GITHUB_ENV`. Only the token's realm-role *names* are surfaceable, so a 403 is diagnosable without exposing the bearer.
- The dispatch workflow reads the resolver's own `SDR_CLIENT_ID`/`SDR_CLIENT_SECRET` directly rather than re-interpolating them through a GitHub expression to rename them — every hop is a hop a secret can be mishandled on.
- Tenant resolution reuses `resolve_e2e_tenant.py` with its two-pass `--mask-only`-then-write protocol unchanged.

#### Why the entry point is `workflow_dispatch`

Installing an app onto a tenant is a deployment. The manual trigger *is* the human authorisation, and the `confirm` input makes firing it at the wrong tenant a deliberate act rather than a default.

#### On the two cross-file call-site guards

They flagged the new workflow, as designed. It is registered as a real `resolve_e2e_tenant` caller (audited — it runs the two-pass protocol) and as a comment-only mention of `export_extra_env`. Prose in the new modules was reworded rather than widening either guard.

#### Known duplication, deliberate

`build-and-publish-app.yaml` still builds its publish body in an inline heredoc. It is the path every app release goes through, and rewiring it to share code with a new e2e flow in the same change is the tail wagging the dog. Instead `test_marketplace_publish_body.py` asserts the field set matches the one that workflow emits, so the two cannot drift unnoticed, and a follow-up can collapse the duplication safely. That test carries its own deletion condition.

### Checklist

- [x] Additional tests added
- [ ] All CI checks passed
- [ ] Relevant documentation updated <!-- connector-ci-e2e.md is updated when the automatic prepare-tenant job lands -->

Local: `.github/scripts/tests` 1131 passed; `uv run pre-commit run` clean on every touched file.

---

### Copyleft License Compliance

- [ ] Have you used any code that is subject to a Copyleft license (e.g., GPL, AGPL, LGPL)?
- [ ] If yes, have you modified the code in the context of this project? please share additional details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
