### PR TITLE
ci(e2e): install the app under test onto every cloud's tenant before the legs

### DIFF
--- a/.github/actions/sdr-e2e/action.yaml
+++ b/.github/actions/sdr-e2e/action.yaml
@@ -287,6 +287,27 @@ inputs:
       it invokes this action; nothing here waits for a push.
     required: false
     default: ""
+  expected-app-version:
+    description: |
+      GM version string the target tenant must be running for this leg to be
+      meaningful. When set, the action asserts the tenant reports exactly this
+      version immediately before pytest, and fails the leg naming both versions
+      if it does not.
+
+      Why a re-check when the caller already installed it: the installation is
+      tenant-scoped (one per app per tenant) and GitHub has no cross-job lease, so
+      a concurrent run — or a hand-deploy — can replace it between the install and
+      the assertions. Since Heracles fetches the DAG from the tenant-deployed pod
+      at AE submit, testing against a replaced version silently exercises somebody
+      else's code. This turns that into a loud failure (FND-31).
+
+      Empty (the default) skips the check entirely, so the repos that call this
+      action directly without an install step are completely unaffected.
+
+      Requires the leg's tenant env (ATLAN_BASE_URL + the OAuth pair) to already
+      be resolved, which the reusable workflows do before invoking this action.
+    required: false
+    default: ""
   expected-python-version:
     description: |
       The Python major.minor the built worker image is expected to ship — the
@@ -697,6 +718,27 @@ runs:
           fi
           sleep 1
         done
+
+    # Last gate before the assertions: prove the tenant is still running the
+    # version this leg is testing. Placed here rather than earlier on purpose —
+    # the window that matters is the one immediately before the DAG is submitted,
+    # since Heracles fetches the manifest from the tenant-deployed pod at submit
+    # and that DAG is what executes. Checking any sooner leaves a gap a concurrent
+    # run can slip through.
+    #
+    # Self-skips when `expected-app-version` is empty, which is every caller that
+    # does not install to the tenant (FND-31).
+    - name: Verify the tenant runs the version under test
+      if: inputs.expected-app-version != ''
+      shell: bash
+      env:
+        EXPECTED: ${{ inputs.expected-app-version }}
+        SDR_E2E_ROOT: ${{ steps.action_root.outputs.path }}
+      run: |
+        set -euo pipefail
+        python3 "$SDR_E2E_ROOT/../../scripts/e2e_tenant_app.py" verify \
+          --base-url "$ATLAN_BASE_URL" \
+          --expected "$EXPECTED"
 
     - name: Run SDR integration tests
       id: tests

--- a/.github/scripts/e2e_tenant_app.py
+++ b/.github/scripts/e2e_tenant_app.py
@@ -66,6 +66,7 @@ import os
 import sys
 import time
 from dataclasses import dataclass
+from pathlib import Path
 
 from e2e_tenant_api import (
     APP_FAILURE_PATH,
@@ -145,6 +146,45 @@ def _env(*names: str) -> str:
         if value:
             return value
     return ""
+
+
+def resolve_app_id(explicit: str) -> str:
+    """Return *explicit* if set, else read ``app_id`` from ``atlan.yaml`` in cwd.
+
+    Mirrors what the ``atlan`` CLI does (``resolveAppIDFromYaml``), and exists so a
+    workflow step does not have to scrape another script's stdout to pass an id
+    this one can read itself.
+
+    ``yaml`` is imported lazily: the module is otherwise stdlib-only so it can run
+    before the SDK is installed, and this fallback is the only path that needs a
+    parser. A missing PyYAML is reported as such rather than as an ImportError
+    traceback.
+    """
+    if explicit.strip():
+        return explicit.strip()
+
+    path = Path("atlan.yaml")
+    if not path.is_file():
+        raise TenantAppError(
+            "no --app-id given and no atlan.yaml in the working directory "
+            f"({Path.cwd()}). Pass --app-id, or run from the app repo root."
+        )
+    try:
+        import yaml  # noqa: PLC0415 — lazy: only this fallback path needs it
+    except ModuleNotFoundError as exc:  # pragma: no cover - present on CI runners
+        raise TenantAppError(
+            "reading app_id from atlan.yaml needs PyYAML, which is not importable. "
+            "Pass --app-id explicitly instead."
+        ) from exc
+
+    parsed = yaml.safe_load(path.read_text(encoding="utf-8"))
+    app_id = parsed.get("app_id", "") if isinstance(parsed, dict) else ""
+    if not str(app_id).strip():
+        raise TenantAppError(
+            "atlan.yaml has no app_id. The app has not been registered in the "
+            "marketplace yet, so there is nothing to install or verify against."
+        )
+    return str(app_id).strip()
 
 
 def _clients(base_url: str) -> tuple[TenantClient, TenantClient]:
@@ -390,7 +430,11 @@ def install(args: argparse.Namespace) -> InstallOutcome:
     """Register + install + wait, converging by version."""
     # app_id is a free-text workflow input that lands in request paths; the
     # base URL takes the OAuth secret. Validate both before any API call.
-    app_id = validate_app_id(args.app_id)
+    #
+    # Resolve BEFORE validating: an app_id read out of atlan.yaml must clear the
+    # same UUID check as one passed on argv, or the fallback becomes a way around
+    # the validator.
+    app_id = validate_app_id(resolve_app_id(args.app_id))
     base_url = validate_tenant_base_url(args.base_url)
     publish_client, read_client = _clients(base_url)
 
@@ -460,7 +504,8 @@ def install(args: argparse.Namespace) -> InstallOutcome:
 
 def verify(args: argparse.Namespace) -> str:
     """Assert the tenant runs ``--expected``. Returns the installed version."""
-    app_id = validate_app_id(args.app_id)
+    # See install(): resolve from atlan.yaml first, then validate the result.
+    app_id = validate_app_id(resolve_app_id(args.app_id))
     base_url = validate_tenant_base_url(args.base_url)
     _, read_client = _clients(base_url)
     installed = _installed_version(read_client, app_id)
@@ -493,7 +538,11 @@ def _write_outputs(outputs: dict[str, str]) -> None:
 
 def _add_common(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--base-url", required=True, help="https://<tenant>")
-    parser.add_argument("--app-id", required=True, help="GM app UUID from atlan.yaml")
+    parser.add_argument(
+        "--app-id",
+        default="",
+        help="GM app UUID. Omit to read app_id from atlan.yaml in the cwd.",
+    )
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/.github/scripts/tests/test_e2e_tenant_app.py
+++ b/.github/scripts/tests/test_e2e_tenant_app.py
@@ -468,6 +468,55 @@ def test_verify_fails_when_nothing_is_installed(
         app.verify(_verify_args(_VERSION))
 
 
+# ── app_id resolution ────────────────────────────────────────────────────────
+# The verify step inside sdr-e2e passes no --app-id: it runs from the app repo
+# root, so the script reads atlan.yaml itself rather than a workflow step
+# scraping another script's stdout to hand it over.
+
+
+def test_explicit_app_id_wins() -> None:
+    assert app.resolve_app_id(_APP_ID) == _APP_ID
+
+
+def test_app_id_read_from_atlan_yaml(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    (tmp_path / "atlan.yaml").write_text(
+        f"name: openapi\ntype: connector\napp_id: {_APP_ID}\n", encoding="utf-8"
+    )
+    monkeypatch.chdir(tmp_path)
+    assert app.resolve_app_id("") == _APP_ID
+
+
+def test_missing_atlan_yaml_names_the_directory(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    with pytest.raises(app.TenantAppError, match="no atlan.yaml"):
+        app.resolve_app_id("")
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        "name: openapi\n",
+        "name: openapi\napp_id: ''\n",
+        "name: openapi\napp_id: '   '\n",
+        "- not-a-mapping\n",
+    ],
+)
+def test_atlan_yaml_without_an_app_id_fails_loudly(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, body: str
+) -> None:
+    # An app with no app_id is not registered in the marketplace, so there is
+    # nothing to install or verify against — that must not read as "app_id ''"
+    # and then compare equal to an equally-absent installed version.
+    (tmp_path / "atlan.yaml").write_text(body, encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    with pytest.raises(app.TenantAppError, match="app_id"):
+        app.resolve_app_id("")
+
+
 # ── Version extraction across LM shapes ──────────────────────────────────────
 
 

--- a/.github/scripts/tests/test_prepare_tenant_wiring.py
+++ b/.github/scripts/tests/test_prepare_tenant_wiring.py
@@ -65,21 +65,48 @@ def test_e2e_needs_prepare_tenant(jobs: dict) -> None:  # type: ignore[type-arg]
 
 
 def test_e2e_tolerates_skipped_but_not_failed_prepare(jobs: dict) -> None:  # type: ignore[type-arg]
+    """The e2e legs must run when the new jobs are SKIPPED, and not when FAILED.
+
+    Both halves are load-bearing and it is easy to get exactly one of them:
+
+    * A job's `needs` gate is evaluated separately from its `if:`. With no
+      status-check function, GitHub applies an implicit success() over every
+      `needs` entry, a skipped need does not satisfy it, and the job is skipped
+      before the `if:` is consulted. So the explicit `== 'skipped'` clauses are
+      dead without a status-check override, and the legs disappear on the default
+      path — which is every existing caller.
+    * A bare `always()` with no result gates swings the other way and runs the
+      legs after a FAILED install, testing whatever version the tenant happens to
+      run.
+
+    The correct shape is `always() && <explicit success-or-skipped gates>`, which
+    is what `connector-tests` in pull_request.yaml already does over its own
+    skippable need.
+
+    An earlier version of this guard asserted `"always()" not in condition` — it
+    codified the first bug and forbade the fix. Found by @sdk-review on #3023.
+    """
     condition = " ".join(jobs["e2e"]["if"].split())
 
-    # Skipped is the off path and must be allowed through.
-    assert "needs.prepare-tenant.result == 'skipped'" in condition
-    assert "needs.prepare-tenant.result == 'success'" in condition
-
-    # always() would run the legs even when the install FAILED, which means
-    # testing against whatever version the tenant happens to run — precisely the
-    # silent-wrong-version failure this work removes.
-    assert "always()" not in condition, (
-        "the e2e legs must not run on a FAILED prepare-tenant; always() would "
-        "let a leg test an arbitrary tenant version and report it as a pass"
+    # 1. A status-check function must override the implicit success()-over-needs.
+    has_override = "always()" in condition or "!cancelled()" in condition
+    assert has_override, (
+        "the e2e `if:` has no status-check function, so GitHub's implicit "
+        "success() over `needs` skips the job whenever build-e2e-image or "
+        "prepare-tenant is skipped — which is the default path for every "
+        "existing caller. The `== 'skipped'` clauses below are dead without it."
     )
-    # `failure()`/`cancelled()` would have the same effect.
-    assert "failure()" not in condition and "cancelled()" not in condition
+
+    # 2. The explicit gates must still be there, or the override runs the legs on
+    #    a FAILED install.
+    for job in ("prepare-tenant", "build-e2e-image"):
+        for result in ("success", "skipped"):
+            expected = f"needs.{job}.result == '{result}'"
+            assert expected in condition, (
+                f"missing `{expected}`. With a status-check override present, "
+                "these gates are the only thing stopping the legs from running "
+                f"after a FAILED {job}."
+            )
 
 
 # ── The matrix-output trap ───────────────────────────────────────────────────

--- a/.github/scripts/tests/test_prepare_tenant_wiring.py
+++ b/.github/scripts/tests/test_prepare_tenant_wiring.py
@@ -1,0 +1,227 @@
+"""Guards for the prepare-tenant wiring in tests-reusable.yaml (FND-31).
+
+Every assertion here protects something whose failure mode is a *silent wrong
+version* rather than a red build — which is the entire problem FND-31 exists to
+fix, so a regression that reintroduces it must not be able to pass CI.
+
+Deliberately YAML-shape assertions: the behaviour being protected is GitHub
+Actions' own (job-result propagation, matrix output semantics, concurrency
+grouping) and cannot be exercised without a runner.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_WORKFLOW = _REPO_ROOT / ".github/workflows/tests-reusable.yaml"
+_SDR_ACTION = _REPO_ROOT / ".github/actions/sdr-e2e/action.yaml"
+
+
+@pytest.fixture(scope="module")
+def workflow() -> dict:  # type: ignore[type-arg]
+    return yaml.safe_load(_WORKFLOW.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def jobs(workflow: dict) -> dict:  # type: ignore[type-arg]
+    return workflow["jobs"]
+
+
+# ── Opt-in, so unadopted repos are untouched ─────────────────────────────────
+
+
+def test_install_is_off_by_default(workflow: dict) -> None:  # type: ignore[type-arg]
+    # Turning this on makes tenant health a gate. 25+ repos consume this
+    # workflow; it must not switch on under them.
+    #
+    # `workflow[True]`: YAML 1.1 resolves the bare key `on` to the boolean true,
+    # so safe_load never yields the string "on". Both spellings are accepted here
+    # so the guard survives a future quoted `"on":`.
+    triggers = workflow.get("on", workflow.get(True))
+    spec = triggers["workflow_call"]["inputs"]["install-app-to-tenant"]
+    assert spec["default"] is False
+    assert spec["type"] == "boolean"
+
+
+@pytest.mark.parametrize("job", ["build-e2e-image", "prepare-tenant"])
+def test_new_jobs_are_gated_on_the_input(jobs: dict, job: str) -> None:  # type: ignore[type-arg]
+    assert "inputs.install-app-to-tenant" in jobs[job]["if"], (
+        f"{job} must not run when install-app-to-tenant is off — otherwise every "
+        "existing caller pays for a build and an install it did not ask for"
+    )
+
+
+# ── A failed prepare-tenant must STOP the legs ───────────────────────────────
+
+
+def test_e2e_needs_prepare_tenant(jobs: dict) -> None:  # type: ignore[type-arg]
+    needs = jobs["e2e"]["needs"]
+    assert "prepare-tenant" in needs and "build-e2e-image" in needs
+
+
+def test_e2e_tolerates_skipped_but_not_failed_prepare(jobs: dict) -> None:  # type: ignore[type-arg]
+    condition = " ".join(jobs["e2e"]["if"].split())
+
+    # Skipped is the off path and must be allowed through.
+    assert "needs.prepare-tenant.result == 'skipped'" in condition
+    assert "needs.prepare-tenant.result == 'success'" in condition
+
+    # always() would run the legs even when the install FAILED, which means
+    # testing against whatever version the tenant happens to run — precisely the
+    # silent-wrong-version failure this work removes.
+    assert "always()" not in condition, (
+        "the e2e legs must not run on a FAILED prepare-tenant; always() would "
+        "let a leg test an arbitrary tenant version and report it as a pass"
+    )
+    # `failure()`/`cancelled()` would have the same effect.
+    assert "failure()" not in condition and "cancelled()" not in condition
+
+
+# ── The matrix-output trap ───────────────────────────────────────────────────
+
+
+def test_expected_version_does_not_come_from_the_matrix_job(jobs: dict) -> None:  # type: ignore[type-arg]
+    """`expected-app-version` must be read from the single build job.
+
+    prepare-tenant is a matrix job (one leg per cloud) and matrix job outputs are
+    last-writer-wins in GitHub Actions — the legs would silently read whichever
+    cloud happened to finish last. The version is cloud-independent (every cloud
+    installs the same image), so the non-matrix build job is the only correct
+    source.
+    """
+    step = _sdr_step(jobs)
+    value = step["with"]["expected-app-version"]
+    assert "needs.build-e2e-image.outputs.version" in value
+    assert "prepare-tenant" not in value
+
+
+def test_legs_reuse_the_prebuilt_image(jobs: dict) -> None:  # type: ignore[type-arg]
+    step = _sdr_step(jobs)
+    assert "needs.build-e2e-image.outputs.image" in step["with"]["prebuilt-image"]
+
+
+def _sdr_step(jobs: dict) -> dict:  # type: ignore[type-arg]
+    for step in jobs["e2e"]["steps"]:
+        if "sdr-e2e" in str(step.get("uses", "")):
+            return step
+    raise AssertionError("the e2e job no longer invokes the sdr-e2e action")
+
+
+# ── Tenant-scoped concurrency ────────────────────────────────────────────────
+
+
+def test_prepare_tenant_serialises_per_tenant_not_per_ref(jobs: dict) -> None:  # type: ignore[type-arg]
+    concurrency = jobs["prepare-tenant"]["concurrency"]
+    group = concurrency["group"]
+
+    # The installation is tenant-scoped, so the group has to identify the TENANT
+    # (app + cloud). Keying on github.ref would let two PRs install different
+    # versions to the same tenant concurrently, and the loser is silently what
+    # the tenant ends up running.
+    assert "inputs.app-name" in group and "matrix.cloud" in group
+    assert "github.ref" not in group, (
+        "keying on the ref permits concurrent installs to the same tenant from "
+        "different refs, which is the race this group exists to narrow"
+    )
+    # Cancelling mid-install abandons the deployment and leaves the tenant in
+    # whatever state LM reached.
+    assert concurrency["cancel-in-progress"] is False
+
+
+# ── The two cloud fan-outs must agree ────────────────────────────────────────
+
+
+def test_suite_and_cloud_discovery_use_the_same_clouds_expression() -> None:
+    """A prepare-tenant that missed a cloud the legs then ran against is a
+    silent coverage hole, not a visible failure — so the two `clouds:` inputs
+    are asserted identical rather than merely both present."""
+    text = _WORKFLOW.read_text(encoding="utf-8")
+    exprs = [
+        line.split("clouds:", 1)[1].strip()
+        for line in text.splitlines()
+        if line.strip().startswith("clouds:")
+    ]
+    assert len(exprs) == 2, f"expected exactly two `clouds:` inputs, found {len(exprs)}"
+    assert exprs[0] == exprs[1], (
+        "the suite fan-out and the cloud fan-out resolve different cloud lists; "
+        f"{exprs[0]!r} vs {exprs[1]!r}"
+    )
+
+
+def test_cloud_matrix_output_is_exposed(jobs: dict) -> None:  # type: ignore[type-arg]
+    outputs = jobs["discover-e2e"]["outputs"]
+    assert "cloud-matrix" in outputs
+    assert "discover-clouds" in outputs["cloud-matrix"]
+
+
+# ── No expression interpolation into run: in the jobs this change adds ───────
+# Scoped to the two new jobs, not the whole file: tests-reusable.yaml already
+# carries ~6 pre-existing instances of the pattern in jobs this change does not
+# own, and ~49 exist across the repo. Guarding only what is added keeps this
+# assertion true from birth instead of born-disabled.
+
+
+@pytest.mark.parametrize("job", ["build-e2e-image", "prepare-tenant"])
+def test_new_jobs_route_values_through_env_not_into_run(jobs: dict, job: str) -> None:  # type: ignore[type-arg]
+    """`github.head_ref` is attacker-controlled on a fork PR; `deploy_config` is
+    multi-line YAML that would break the command outright. Both must arrive as
+    env vars and be referenced as quoted shell variables."""
+    offenders: list[str] = []
+    for step in jobs[job].get("steps") or []:
+        script = step.get("run")
+        if not isinstance(script, str):
+            continue
+        for match in re.findall(r"\$\{\{[^}]*\}\}", script):
+            offenders.append(f"{step.get('name', '?')}: {match.strip()}")
+    assert not offenders, (
+        f"{job} interpolates expressions directly into run:, which splices "
+        "attacker-influenced or multi-line values into the shell. Pass them via "
+        f'env: and reference quoted "$VARS". Offenders: {offenders}'
+    )
+
+
+def test_install_step_does_not_thread_app_id(jobs: dict) -> None:  # type: ignore[type-arg]
+    """app_id has one source: atlan.yaml, read (and validated) by the script.
+
+    Threading it through a step output as well would give the value two sources
+    that can disagree, for no gain — the job already runs from the repo root.
+    """
+    install = [
+        s
+        for s in jobs["prepare-tenant"]["steps"]
+        if str(s.get("name", "")) == "Install the app under test"
+    ]
+    assert len(install) == 1
+    assert "--app-id" not in install[0]["run"]
+
+
+# ── The action-side verify self-skips ────────────────────────────────────────
+
+
+def test_verify_step_self_skips_when_no_version_expected() -> None:
+    """Empty `expected-app-version` must skip the check entirely.
+
+    17 repos call this action directly with no install step. They are
+    deliberately left alone for now, so the verify must be inert for them
+    rather than reding their e2e.
+    """
+    action = yaml.safe_load(_SDR_ACTION.read_text(encoding="utf-8"))
+    assert action["inputs"]["expected-app-version"]["default"] == ""
+
+    steps = action["runs"]["steps"]
+    verify = [s for s in steps if "Verify the tenant runs" in str(s.get("name", ""))]
+    assert len(verify) == 1, "expected exactly one tenant-version verify step"
+    assert verify[0]["if"] == "inputs.expected-app-version != ''"
+
+    # It has to sit before pytest: the window that matters is the one immediately
+    # before the DAG is submitted, since Heracles fetches the manifest from the
+    # deployed pod at submit time.
+    names = [str(s.get("name", "")) for s in steps]
+    assert names.index(str(verify[0]["name"])) < names.index(
+        "Run SDR integration tests"
+    ), "the version check must run before pytest, not after"

--- a/.github/workflows/tests-reusable.yaml
+++ b/.github/workflows/tests-reusable.yaml
@@ -992,14 +992,28 @@ jobs:
 
   e2e:
     name: End-to-end (${{ matrix.name }})
-    # prepare-tenant is in `needs` unconditionally so the legs cannot start before
-    # it; the `if` tolerates it being SKIPPED (install-app-to-tenant off), which is
-    # what keeps unadopted repos on their current behaviour. `always()` is
-    # deliberately NOT used — a FAILED prepare-tenant must stop the legs, because
-    # continuing would test whatever version the tenant happens to run, which is
-    # the exact failure FND-31 exists to remove.
+    # build-e2e-image and prepare-tenant are in `needs` so the legs cannot start
+    # before them, but both are SKIPPED on the default path
+    # (install-app-to-tenant off — every existing caller). That combination needs
+    # `always() &&`:
+    #
+    # A job's `needs` gate is evaluated SEPARATELY from its `if:`. Without a
+    # status-check function, GitHub applies an implicit success() over every
+    # `needs` entry, a skipped need does not satisfy it, and the job is skipped
+    # before the `if:` is even consulted — so the explicit `== 'skipped'` clauses
+    # below would be dead code and the e2e legs would vanish on the off path.
+    #
+    # `always()` does NOT reintroduce run-on-failure: the explicit gates still
+    # require each need to be success-or-skipped, so a FAILED prepare-tenant stops
+    # the legs, which is essential — continuing would test whatever version the
+    # tenant happens to run, the exact failure FND-31 removes.
+    #
+    # Same shape as `connector-tests` in pull_request.yaml, which pairs
+    # `always() &&` with `success' || 'skipped'` gates over a skippable
+    # build-sdk-base-image need. Found by @sdk-review on #3023.
     needs: [discover-e2e, build-e2e-image, prepare-tenant]
     if: |
+      always() &&
       needs.discover-e2e.result == 'success' &&
       needs.discover-e2e.outputs.count != '0' &&
       (needs.prepare-tenant.result == 'success' || needs.prepare-tenant.result == 'skipped') &&

--- a/.github/workflows/tests-reusable.yaml
+++ b/.github/workflows/tests-reusable.yaml
@@ -128,6 +128,26 @@ on:
         type: boolean
         default: true
         description: Set to false to skip the e2e job entirely (e.g. hello-world).
+      install-app-to-tenant:
+        required: false
+        type: boolean
+        default: false
+        description: |
+          Install the app under test onto each cloud's e2e tenant before the
+          legs run, and fail a leg whose tenant is not on that version (FND-31).
+
+          Why this matters more than it sounds: at AE submit, Heracles re-fetches
+          the manifest from the TENANT-DEPLOYED POD and that DAG is what executes
+          (`processAutomationEngineWorkflow`). The harness's local seed DAG
+          establishes the workflow record, not the graph. So with this off, a
+          full-DAG e2e exercises whatever version was last deployed to that
+          tenant — which is nobody's PR — and a manifest/DAG/entrypoint change
+          can go green against an older contract, or red for an unrelated reason.
+
+          Off by default because turning it on makes tenant health a gate: a
+          tenant that cannot be installed to reds the leg rather than quietly
+          testing the wrong version. Adopt it per repo once that trade is
+          understood.
       e2e-clouds:
         required: false
         type: string
@@ -666,6 +686,12 @@ jobs:
       matrix: ${{ steps.discover.outputs.matrix }}
       count: ${{ steps.discover.outputs.count }}
       leg-count: ${{ steps.discover.outputs.leg-count }}
+      # The cloud dimension alone, for prepare-tenant (one install per cloud, not
+      # per suite × cloud). Derived from the same `clouds` expression as the full
+      # matrix below, so the two can never disagree about which clouds are in play
+      # — a prepare-tenant that missed a cloud the legs then ran against would be
+      # a silent coverage hole, not a visible failure.
+      cloud-matrix: ${{ steps.discover-clouds.outputs.matrix }}
     env:
       # Job-level so the step-level `if:` below can read it — a step condition
       # cannot reference the `secrets` context directly.
@@ -701,6 +727,23 @@ jobs:
           # so the natural form collapses the default (empty = SDK cloud list)
           # into "none" and quietly disables the matrix on every un-customised
           # caller. The negated form never evaluates the input for truthiness.
+          clouds: ${{ secrets.E2E_TENANT_MATRIX_JSON == '' && 'none' || inputs.e2e-clouds }}
+
+      # The same fan-out, cloud dimension only, for prepare-tenant. A second
+      # invocation rather than deriving the unique clouds out of the matrix above:
+      # the `clouds` expression is duplicated verbatim, so the two calls cannot
+      # drift, whereas a hand-rolled uniq over the full matrix would be new
+      # untested logic doing what --clouds-only already does.
+      #
+      # Runs unconditionally (not gated on install-app-to-tenant) so the output
+      # exists whenever discovery ran. It is seconds of work, and gating it would
+      # mean prepare-tenant's matrix expression had to cope with an empty output
+      # on a path where it is skipped anyway.
+      - name: Discover clouds
+        id: discover-clouds
+        uses: atlanhq/application-sdk/.github/actions/discover-e2e-suites@main
+        with:
+          clouds-only: "true"
           clouds: ${{ secrets.E2E_TENANT_MATRIX_JSON == '' && 'none' || inputs.e2e-clouds }}
 
       # A repo that has not been granted the tenant-matrix secret silently gets
@@ -740,10 +783,227 @@ jobs:
   # isolation machinery: deployment names, queues and artifact names all pick it
   # up. Legs on different clouds hit different tenants (and therefore different
   # Temporal servers) besides.
+  # ── Build the image ONCE, ahead of the matrix ────────────────────────────
+  # The test-image tag is deterministic (`sdr-test-<short-sha>`), so every cloud
+  # leg used to rebuild the identical image. It has to exist before prepare-tenant
+  # can install it, so the build is hoisted here and every leg reuses the
+  # reference via sdr-e2e's `prebuilt-image` input.
+  #
+  # Only runs on the install path: with install-app-to-tenant off, each leg keeps
+  # building its own image exactly as before, so an unadopted repo sees no change
+  # at all (not even a different build ordering).
+  build-e2e-image:
+    name: Build e2e image
+    needs: discover-e2e
+    if: |
+      inputs.install-app-to-tenant &&
+      needs.discover-e2e.result == 'success' &&
+      needs.discover-e2e.outputs.count != '0'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      image: ${{ steps.build.outputs.image }}
+      # The GM version string == the image tag. Emitted from THIS job rather than
+      # read off prepare-tenant, because prepare-tenant is a matrix job and matrix
+      # outputs are last-writer-wins — the legs would read whichever cloud
+      # finished last. The version is cloud-independent (every cloud installs the
+      # same image), so the single build job is the correct source.
+      version: ${{ steps.version.outputs.tag }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - id: build
+        uses: atlanhq/application-sdk/.github/actions/build-app-image@main
+        with:
+          app-name: ${{ inputs.app-name }}
+          app-image-name: ${{ inputs.app-image-name }}
+          application-sdk-ref: ${{ inputs.application-sdk-ref }}
+          base-image-ref: ${{ inputs.base-image-ref }}
+          git-token: ${{ secrets.ORG_PAT_GITHUB }}
+          ghcr-token: ${{ secrets.ORG_PAT_GITHUB }}
+
+      # Straight-line parameter expansion, no branching — ci.md-compliant.
+      - name: Derive the GM version from the image tag
+        id: version
+        env:
+          IMAGE: ${{ steps.build.outputs.image }}
+        run: echo "tag=${IMAGE##*:}" >> "$GITHUB_OUTPUT"
+
+  # ── Install the app under test onto each cloud's tenant ──────────────────
+  # One leg per CLOUD, not per suite × cloud: the installation is tenant-scoped
+  # (one per app per tenant), so installing once per cloud is both sufficient and
+  # the only thing that makes sense — every suite in a run wants the same image.
+  #
+  # `--clouds-only` gives the cloud dimension without the file dimension, and the
+  # `clouds` expression is the same one discover-e2e uses, so this job and the
+  # legs can never disagree about which clouds are in play.
+  prepare-tenant:
+    name: Prepare tenant (${{ matrix.cloud || 'default' }})
+    needs: [discover-e2e, build-e2e-image]
+    if: inputs.install-app-to-tenant && needs.build-e2e-image.result == 'success'
+    strategy:
+      # One cloud's tenant being uninstallable must not cancel the others; the
+      # legs for that cloud fail on their own version check.
+      fail-fast: false
+      matrix: ${{ fromJson(needs.discover-e2e.outputs.cloud-matrix || '{"include":[{"cloud":""}]}') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    concurrency:
+      # Keyed on the TENANT (app + cloud), not the ref: the installation is
+      # tenant-scoped, so two runs installing different versions concurrently
+      # would race and the loser is silently what the tenant ends up running.
+      # cancel-in-progress:false because cancelling mid-install leaves the tenant
+      # in whatever state LM reached.
+      #
+      # This narrows the race; it does not close it. GitHub has no cross-job
+      # lease, so another run can still install between this job and the legs
+      # below — which is exactly why each leg re-verifies the version rather than
+      # trusting this job's outcome.
+      group: e2e-prepare-tenant-${{ inputs.app-name }}-${{ matrix.cloud || 'default' }}
+      cancel-in-progress: false
+    permissions:
+      contents: read
+    env:
+      E2E_TENANT_MATRIX_JSON: ${{ secrets.E2E_TENANT_MATRIX_JSON }}
+      E2E_CLOUD: ${{ matrix.cloud }}
+      FALLBACK_SDR_TEST_TENANT: ${{ secrets.SDR_TEST_TENANT }}
+      FALLBACK_SDR_CLIENT_ID: ${{ secrets.SDR_CLIENT_ID }}
+      FALLBACK_SDR_CLIENT_SECRET: ${{ secrets.SDR_CLIENT_SECRET }}
+      FALLBACK_ATLAN_API_KEY: ${{ secrets.ATLAN_API_KEY }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # This workflow runs in the caller's repo, so the SDK drivers have to be
+      # fetched. Sparse + pinned to job.workflow_sha for the same reason as the
+      # equivalent checkout in the e2e job: a PR editing these scripts must run
+      # its own version, not main's.
+      - name: Fetch SDK CI scripts
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: atlanhq/application-sdk
+          ref: ${{ job.workflow_sha }}
+          sparse-checkout: .github/scripts
+          sparse-checkout-cone-mode: false
+          path: application-sdk-scripts
+          persist-credentials: false
+
+      # Two invocations, mask pass first — see the equivalent step in the e2e job
+      # for why registering the matrix blob as a secret does not redact the values
+      # inside it.
+      - name: Resolve e2e tenant for this cloud
+        run: |
+          set -euo pipefail
+          python3 application-sdk-scripts/.github/scripts/resolve_e2e_tenant.py \
+            --matrix-json "$E2E_TENANT_MATRIX_JSON" \
+            --cloud "$E2E_CLOUD" \
+            --fallback-tenant "$FALLBACK_SDR_TEST_TENANT" \
+            --fallback-client-id "$FALLBACK_SDR_CLIENT_ID" \
+            --fallback-client-secret "$FALLBACK_SDR_CLIENT_SECRET" \
+            --fallback-api-key "$FALLBACK_ATLAN_API_KEY" \
+            --mask-only
+          python3 application-sdk-scripts/.github/scripts/resolve_e2e_tenant.py \
+            --matrix-json "$E2E_TENANT_MATRIX_JSON" \
+            --cloud "$E2E_CLOUD" \
+            --fallback-tenant "$FALLBACK_SDR_TEST_TENANT" \
+            --fallback-client-id "$FALLBACK_SDR_CLIENT_ID" \
+            --fallback-client-secret "$FALLBACK_SDR_CLIENT_SECRET" \
+            --fallback-api-key "$FALLBACK_ATLAN_API_KEY" \
+            >> "$GITHUB_ENV"
+
+      # app_id / deploy_config / entrypoints / sdk_version all come from
+      # atlan.yaml, which parse_atlan_yaml.py already reads for the release path.
+      # Reused rather than re-parsed so the e2e registration and the release
+      # registration cannot disagree about what the app declares.
+      - name: Read atlan.yaml
+        id: atlan_yaml
+        run: python3 application-sdk-scripts/.github/scripts/parse_atlan_yaml.py
+
+      # Everything reaches the shell through env:, nothing through `${{ }}` inside
+      # run:. Three reasons, in descending order of severity:
+      #
+      #   * `github.head_ref` is the PR's branch name — attacker-controlled on a
+      #     fork PR. Interpolated into run:, a crafted branch name is spliced into
+      #     the script before bash sees a quote and executes.
+      #   * `deploy_config` is multi-line YAML read out of atlan.yaml.
+      #     Interpolating multi-line content into a backslash-continued command is
+      #     not merely unsafe, it is broken — the newline ends the command.
+      #   * `entrypoints` is JSON, so it carries the quotes that would terminate
+      #     whichever quoting style wrapped it.
+      #
+      # Same finding sdk-review raised against e2e-tenant-install.yaml; applied
+      # here at the point of writing rather than waiting to be told twice.
+      #
+      # --app-id is deliberately omitted: the script reads app_id from atlan.yaml
+      # in the working directory (and validates the result either way), so the id
+      # has one source rather than being threaded through a step output.
+      - name: Install the app under test
+        id: install
+        env:
+          IMAGE: ${{ needs.build-e2e-image.outputs.image }}
+          VERSION: ${{ needs.build-e2e-image.outputs.version }}
+          BRANCH: ${{ github.head_ref || github.ref_name }}
+          REPO_URL: ${{ github.server_url }}/${{ github.repository }}
+          DEPLOY_CONFIG: ${{ steps.atlan_yaml.outputs.deploy_config }}
+          SDK_VERSION: ${{ steps.atlan_yaml.outputs.sdk_version }}
+          ENTRYPOINTS: ${{ steps.atlan_yaml.outputs.entrypoints }}
+          RELEASE_MODEL: ${{ steps.atlan_yaml.outputs.release_model }}
+          CREATED_BY: ${{ github.triggering_actor }}
+        run: |
+          set -euo pipefail
+          python3 application-sdk-scripts/.github/scripts/e2e_tenant_app.py install \
+            --base-url "$ATLAN_BASE_URL" \
+            --image "$IMAGE" \
+            --version "$VERSION" \
+            --branch "$BRANCH" \
+            --tenant "$SDR_TEST_TENANT" \
+            --repo-url "$REPO_URL" \
+            --deploy-config "$DEPLOY_CONFIG" \
+            --sdk-version "$SDK_VERSION" \
+            --entrypoints "$ENTRYPOINTS" \
+            --release-model "$RELEASE_MODEL" \
+            --created-by "$CREATED_BY"
+
+      - name: Summarise
+        if: always()
+        env:
+          IMAGE: ${{ needs.build-e2e-image.outputs.image }}
+          SKIPPED: ${{ steps.install.outputs.skipped }}
+          RELEASE_STATUS: ${{ steps.install.outputs.release_status }}
+          INSTALLED: ${{ steps.install.outputs.installed_version }}
+          CLOUD: ${{ matrix.cloud || 'default' }}
+        run: |
+          {
+            echo "### Tenant prepared — ${CLOUD}"
+            echo ""
+            echo "| Field | Value |"
+            echo "|---|---|"
+            echo "| Image | \`${IMAGE}\` |"
+            echo "| Already current (no-op) | \`${SKIPPED:-unknown}\` |"
+            echo "| Release status at install | \`${RELEASE_STATUS:-unreadable}\` |"
+            echo "| Tenant reports installed | \`${INSTALLED:-unreported}\` |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
   e2e:
     name: End-to-end (${{ matrix.name }})
-    needs: discover-e2e
-    if: needs.discover-e2e.result == 'success' && needs.discover-e2e.outputs.count != '0'
+    # prepare-tenant is in `needs` unconditionally so the legs cannot start before
+    # it; the `if` tolerates it being SKIPPED (install-app-to-tenant off), which is
+    # what keeps unadopted repos on their current behaviour. `always()` is
+    # deliberately NOT used — a FAILED prepare-tenant must stop the legs, because
+    # continuing would test whatever version the tenant happens to run, which is
+    # the exact failure FND-31 exists to remove.
+    needs: [discover-e2e, build-e2e-image, prepare-tenant]
+    if: |
+      needs.discover-e2e.result == 'success' &&
+      needs.discover-e2e.outputs.count != '0' &&
+      (needs.prepare-tenant.result == 'success' || needs.prepare-tenant.result == 'skipped') &&
+      (needs.build-e2e-image.result == 'success' || needs.build-e2e-image.result == 'skipped')
     strategy:
       fail-fast: false
       # Fallback to an empty matrix when discovery was skipped (no label / not
@@ -889,6 +1149,16 @@ jobs:
         with:
           app-name: ${{ inputs.app-name }}
           app-image-name: ${{ inputs.app-image-name }}
+          # Reuse the image build-e2e-image already pushed and prepare-tenant
+          # already installed, instead of rebuilding the identical deterministic
+          # tag per leg. Empty on the non-install path, which keeps each leg
+          # building its own image exactly as before.
+          prebuilt-image: ${{ needs.build-e2e-image.outputs.image }}
+          # Re-assert the tenant version immediately before pytest. prepare-tenant
+          # already verified it, but the installation is tenant-scoped and there is
+          # no cross-job lease — another run can replace it in between. Empty
+          # disables the check, so an unadopted repo is untouched.
+          expected-app-version: ${{ needs.build-e2e-image.outputs.version }}
           # One suite per leg (the matrix file), not the whole e2e directory.
           test-path: ${{ matrix.file }}
           # Full-DAG defaults carried over from e2e-full-reusable.yaml. The


### PR DESCRIPTION
> #3020 has merged, so this now targets `main` directly and the diff is just the prepare-tenant work.
>
> Rebased after that merge rather than merged-forward: #3020 was **squash**-merged, so this branch's copies of
> its commits were no longer ancestors of `main` and git reported conflicts against changes `main` already had.
> Replaying only this branch's own commit onto `main` applied cleanly with no conflicts, which confirms the
> squash preserved the content exactly.

### Changelog

- `tests-reusable.yaml`: two new jobs — `build-e2e-image` (build once per run) and `prepare-tenant` (install onto each cloud's tenant), plus a `cloud-matrix` output on `discover-e2e`.
- `sdr-e2e`: new `expected-app-version` input and a verify step that runs immediately before pytest.
- `e2e_tenant_app.py`: `app_id` falls back to reading `atlan.yaml`, so no workflow step has to thread it through.
- New input `install-app-to-tenant`, **default false**.
- `test_prepare_tenant_wiring.py` — 14 guards over the wiring.

```
discover-e2e → build-e2e-image → prepare-tenant (per cloud) → e2e legs
```

### Additional context

Completes the automatic path for [FND-31](https://linear.app/atlan-epd/issue/FND-31/e2e-tests-must-deploy-the-app-under-test-to-the-target-tenant).

At AE submit, Heracles re-fetches the manifest from the **tenant-deployed pod** and *that* DAG is what executes (`processAutomationEngineWorkflow`, `heracles/handler/workflow.go`). The harness's local seed DAG establishes the workflow record, not the graph. So without this, a full-DAG e2e exercises whatever version was last hand-deployed to that tenant — nobody's PR — and a manifest / DAG / entrypoint change can go green against an older contract, or red for a reason unrelated to the change.

**Off by default.** Turning it on makes tenant health a gate: a tenant that cannot be installed to reds the leg rather than quietly testing the wrong version. With it off, nothing changes for any existing caller — not even the build ordering.

### Decisions worth a reviewer's attention

**Placement is `tests-reusable.yaml`, not `e2e-full-reusable.yaml` as the plan said.** I checked consumption rather than assuming: `e2e-full-reusable.yaml` has exactly one live consumer, while 25+ app repos go through `tests-reusable.yaml`. The 17 repos that call the `sdr-e2e` action directly are deliberately left alone — they are mid-migration to the canonical path, and the verify self-skips on an empty `expected-app-version`, so they are untouched.

**`expected-app-version` comes from `build-e2e-image`, not `prepare-tenant`.** `prepare-tenant` is a matrix job, and matrix job outputs are last-writer-wins in GitHub Actions — the legs would silently read whichever cloud finished last. The version is cloud-independent (every cloud installs the same image), so the non-matrix build job is the only correct source. Guarded.

**The legs tolerate a SKIPPED `prepare-tenant` but not a FAILED one.** `always()` would let a leg run against an arbitrary tenant version and report it as a pass — the exact failure this work removes. Guarded, including against `failure()`/`cancelled()` creeping in later.

**`prepare-tenant` concurrency is keyed on the tenant (app + cloud), not the ref.** Keying on `github.ref` would let two PRs install different versions to the same tenant concurrently, and the loser is silently what the tenant ends up running. `cancel-in-progress: false` because cancelling mid-install leaves the tenant in whatever state LM reached.

This narrows the race but **does not close it** — GitHub has no cross-job lease, so another run can still install between `prepare-tenant` and the legs. That is why each leg re-verifies immediately before pytest: the drift becomes a loud failure naming both versions instead of a silent wrong-version pass.

**Nothing is interpolated into a `run:` block.** `github.head_ref` is attacker-controlled on a fork PR, and `deploy_config` is multi-line YAML that would break a backslash-continued command outright. Both arrive via `env:` as quoted shell vars. Same finding sdk-review raised against `e2e-tenant-install.yaml` in #3020 — applied here at the point of writing rather than waiting to be told twice.

**`app_id` has one source.** The script reads it from `atlan.yaml` and validates the result, so the fallback cannot bypass the UUID check that #3020 added. The alternative — a workflow step scraping another script's stdout — was written and then removed as too fragile.

### Reuse

`parse_atlan_yaml.py` for the registration fields (same source the release path uses, so the two cannot disagree about what the app declares); `resolve_e2e_tenant.py` with its two-pass mask-then-write protocol for the tenant; `discover-e2e-suites --clouds-only` for the cloud fan-out, invoked with the **same** `clouds` expression as the suite fan-out so the two can never resolve different cloud lists. That last one is asserted equal rather than merely both-present: a `prepare-tenant` that missed a cloud the legs then ran against is a silent coverage hole, not a visible failure.

### Still open after this

- **Does GM install a release still in `scan_pending`?** Unanswered — needs one live run. `--scan-wait-seconds` defaults to 0 (a base-image CVE must not red an unrelated PR) and a scan-gate rejection is recognised and names the flag, so either answer is self-explaining.
- **Phase 4's DAG-identity check** (comparing the published, pod-derived DAG against the local manifest) is not in this PR.
- **`e2e-full-reusable.yaml`** does not get `prepare-tenant`; its one consumer is expected to migrate to `tests-reusable.yaml`.

### Checklist

- [x] Additional tests added
- [ ] All CI checks passed
- [ ] Relevant documentation updated <!-- connector-ci-e2e.md lands with the turn-on -->

Local: `.github/scripts/tests` 1175 passed. The one failure, `test_validate_allowlist.py::test_already_expired_fails`, is unrelated and pre-existing — it mixes clocks (local `date.today()` in the test vs `datetime.now(UTC).date()` in the validator), so it only fires when the local date differs from UTC and is invisible on CI. Fixed separately in #3024.

---

### Copyleft License Compliance

- [ ] Have you used any code that is subject to a Copyleft license (e.g., GPL, AGPL, LGPL)?
- [ ] If yes, have you modified the code in the context of this project? please share additional details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
