### PR TITLE
ci(e2e): echo GM's registered source_repo on the version create

### DIFF
--- a/.github/scripts/e2e_tenant_app.py
+++ b/.github/scripts/e2e_tenant_app.py
@@ -226,6 +226,64 @@ def _installed_version(client: TenantClient, app_id: str) -> str:
     return _extract_version(response.data())
 
 
+def _app_info(client: TenantClient, app_id: str) -> dict[str, object]:
+    """Return the app's info payload, or ``{}`` when it cannot be read."""
+    response = client.get(APP_INFO_PATH.format(app_id=path_segment(app_id)))
+    return response.data() if response.ok else {}
+
+
+def _registered_source_repo(info: dict[str, object]) -> str:
+    """Return the repo GM has on file for this app, or "" if it has none.
+
+    GM's version-create guard is exactly (``global-marketplace``,
+    ``core/app/service.py``)::
+
+        if repo:                          # sets, or UPDATES, app.source_repo
+            ...
+        elif app.source_repo:             # no repo sent, but app is CI/CD-managed
+            raise "This app's versions are managed by CI/CD..."
+
+    So an app that has a ``source_repo`` rejects any version-create that omits
+    ``repo``. Reading it back and echoing it is what makes this work without
+    asking a caller to know it: the value matches, so GM takes neither the "set"
+    nor the "update" branch.
+    """
+    for key in ("source_repo", "sourceRepo"):
+        value = info.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    for nest in ("app", "catalog", "data"):
+        inner = info.get(nest)
+        if isinstance(inner, dict):
+            found = _registered_source_repo(inner)
+            if found:
+                return found
+    return ""
+
+
+def _resolve_repo_url(registered: str, supplied: str) -> str:
+    """Decide which ``repo`` to send, refusing to rewrite an app's provenance.
+
+    GM does not merely validate ``repo`` — on a mismatch within the same GitHub
+    org it **updates** ``app.source_repo`` to whatever was sent. So passing the
+    repo of whichever CI happens to be running (rather than the app's own) would
+    silently repoint the app's provenance and break the real CI/CD publish
+    gating. That is a destructive side effect of a call that looks read-ish, so a
+    disagreement is an error here rather than something to resolve by guessing.
+    """
+    registered, supplied = registered.strip(), supplied.strip()
+    if registered and supplied and registered != supplied:
+        raise TenantAppError(
+            f"refusing to publish: GM has this app's source_repo as {registered!r} "
+            f"but --repo-url is {supplied!r}. GM would UPDATE the app's "
+            "source_repo to the supplied value (it only blocks cross-org "
+            "changes), silently repointing the app's provenance and breaking its "
+            "real CI/CD publish gating. Pass the app's own repo, or omit "
+            "--repo-url and let the registered value be echoed back."
+        )
+    return registered or supplied
+
+
 def _extract_version(payload: dict[str, object]) -> str:
     """Pull a version string out of an info/install payload."""
     for key in _VERSION_KEYS:
@@ -256,6 +314,16 @@ def _render_body(body: object) -> str:
     if len(rendered) > _ERROR_BODY_CHARS:
         rendered = f"{rendered[:_ERROR_BODY_CHARS]}…(truncated)"
     return rendered
+
+
+def _looks_like_cicd_managed(response: Response) -> bool:
+    """True when a failed publish is GM's CI/CD-managed version guard.
+
+    Matched on the rendered body: Heracles wraps GM's 409 inside its own 400, so
+    the status alone does not identify it.
+    """
+    rendered = json.dumps(response.body).lower() if response.body else ""
+    return "managed by ci/cd" in rendered or "cicd_managed" in rendered
 
 
 def _looks_like_scan_gate(response: Response) -> bool:
@@ -325,6 +393,19 @@ def _publish(client: TenantClient, request: PublishRequest) -> tuple[str, str]:
                 " Publish authorises on the OAuth client pair "
                 "(E2E_OAUTH_CLIENT_ID/SECRET), not on ATLAN_API_KEY — check that "
                 f"pair. Token realm roles: {client.token_roles() or 'none visible'}."
+            )
+        elif _looks_like_cicd_managed(response):
+            # GM rejects a version-create that omits `repo` when the app has a
+            # source_repo on file. Reaching here means the echo-back above found
+            # nothing, so say which read failed rather than restating GM's
+            # message, which points at atlan.yaml and is misleading here.
+            hint = (
+                " GM refuses a version-create without `repo` for an app that has "
+                "a source_repo on file. This normally self-resolves by echoing "
+                "GM's registered source_repo back, so reaching this means "
+                "/marketplace/apps/<id>/info did not expose it — check that read, "
+                "or pass --repo-url with the APP'S OWN repo (not the repo whose "
+                "CI is running: GM would repoint the app's provenance to it)."
             )
         raise TenantAppError(
             f"marketplace publish failed with HTTP {response.status}.{hint}\n"
@@ -438,7 +519,12 @@ def install(args: argparse.Namespace) -> InstallOutcome:
     base_url = validate_tenant_base_url(args.base_url)
     publish_client, read_client = _clients(base_url)
 
-    current = _installed_version(read_client, app_id)
+    # One info read serves two purposes: the installed version (to converge on)
+    # and the repo GM has on file (which the version-create needs echoed back).
+    info = _app_info(read_client, app_id)
+    if not info:
+        print(f"::notice::app info unreadable for {app_id} — treating as not installed")
+    current = _extract_version(info)
     if current and current == args.version:
         print(f"tenant already runs {app_id} at {args.version} — nothing to do")
         return InstallOutcome(
@@ -449,12 +535,20 @@ def install(args: argparse.Namespace) -> InstallOutcome:
     else:
         print(f"{app_id} is not installed on this tenant; installing {args.version}")
 
+    # Echo GM's own source_repo back on the version-create. Omitting `repo` is
+    # rejected outright for any app that has one ("versions are managed by
+    # CI/CD"), and sending a *different* one makes GM rewrite the app's
+    # provenance — so the registered value is the only safe thing to send.
+    repo_url = _resolve_repo_url(_registered_source_repo(info), args.repo_url)
+    if repo_url:
+        print(f"publishing with repo={repo_url}")
+
     request = PublishRequest(
         app_id=app_id,
         image=args.image,
         version=args.version,
         branch=args.branch,
-        repo_url=args.repo_url,
+        repo_url=repo_url,
         # The whole registration is scoped to this one tenant, so a per-PR build
         # can never become visible to a real one.
         allowed_tenants=(args.tenant,),

--- a/.github/scripts/e2e_tenant_app.py
+++ b/.github/scripts/e2e_tenant_app.py
@@ -261,6 +261,20 @@ def _registered_source_repo(info: dict[str, object]) -> str:
     return ""
 
 
+def _normalize_repo_url(value: str) -> str:
+    """Canonicalize a repo URL for *comparison only* — never for sending.
+
+    GitHub repo URLs are case-insensitive and may carry a trailing ``/`` or
+    ``.git``. Two spellings of the same repo must not trip the mismatch guard
+    (the GM-registered value is always what gets sent, so normalization here
+    only decides whether to refuse, never what to publish).
+    """
+    normalized = value.strip().lower().rstrip("/")
+    if normalized.endswith(".git"):
+        normalized = normalized[: -len(".git")]
+    return normalized.rstrip("/")
+
+
 def _resolve_repo_url(registered: str, supplied: str) -> str:
     """Decide which ``repo`` to send, refusing to rewrite an app's provenance.
 
@@ -272,7 +286,11 @@ def _resolve_repo_url(registered: str, supplied: str) -> str:
     disagreement is an error here rather than something to resolve by guessing.
     """
     registered, supplied = registered.strip(), supplied.strip()
-    if registered and supplied and registered != supplied:
+    if (
+        registered
+        and supplied
+        and _normalize_repo_url(registered) != _normalize_repo_url(supplied)
+    ):
         raise TenantAppError(
             f"refusing to publish: GM has this app's source_repo as {registered!r} "
             f"but --repo-url is {supplied!r}. GM would UPDATE the app's "
@@ -281,6 +299,9 @@ def _resolve_repo_url(registered: str, supplied: str) -> str:
             "real CI/CD publish gating. Pass the app's own repo, or omit "
             "--repo-url and let the registered value be echoed back."
         )
+    # Send the registered value when present — byte-for-byte what GM has on
+    # file — so the publish can neither trip the CI/CD guard nor rewrite
+    # provenance. Normalization above only decided *whether* to refuse.
     return registered or supplied
 
 

--- a/.github/scripts/tests/test_e2e_tenant_app.py
+++ b/.github/scripts/tests/test_e2e_tenant_app.py
@@ -582,6 +582,42 @@ def test_registered_repo_is_echoed_back_on_publish(
     assert transport.body_for("/marketplace/publish")["repo"] == repo
 
 
+@pytest.mark.parametrize(
+    "supplied",
+    [
+        # Same repo, different spelling: case, trailing slash, .git suffix.
+        # These must NOT trip the mismatch guard — GitHub treats them as
+        # identical, and GM's registered value is still what gets sent.
+        "HTTPS://GITHUB.COM/AtlanHQ/Atlan-OpenAPI-App",
+        "https://github.com/atlanhq/atlan-openapi-app/",
+        "https://github.com/atlanhq/atlan-openapi-app.git",
+        "https://github.com/atlanhq/atlan-openapi-app/.git",
+    ],
+)
+def test_equivalent_repo_spelling_is_not_a_mismatch(
+    monkeypatch: pytest.MonkeyPatch, supplied: str
+) -> None:
+    registered = "https://github.com/atlanhq/atlan-openapi-app"
+    transport = _wire(
+        monkeypatch,
+        StubTransport(
+            routes=[
+                StubRoute("GET", "/info", _ok({"source_repo": registered})),
+                StubRoute("POST", "/marketplace/publish", _ok({"version_id": "v1"})),
+                StubRoute("POST", "/install", _ok({"deployment_id": "d1"})),
+                StubRoute(
+                    "GET", "/deployments/", _ok({"deployment_status": "SUCCEEDED"})
+                ),
+                StubRoute("GET", "/info", _ok({"version": _VERSION})),
+            ],
+            sticky=[StubRoute("GET", "/releases/", Response(status=404, body={}))],
+        ),
+    )
+    app.install(_install_args(repo_url=supplied))
+    # The registered value is sent back byte-for-byte, not the supplied spelling.
+    assert transport.body_for("/marketplace/publish")["repo"] == registered
+
+
 def test_mismatched_repo_is_refused_rather_than_repointing_provenance(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/.github/scripts/tests/test_e2e_tenant_app.py
+++ b/.github/scripts/tests/test_e2e_tenant_app.py
@@ -517,6 +517,144 @@ def test_atlan_yaml_without_an_app_id_fails_loudly(
         app.resolve_app_id("")
 
 
+# ── GM's CI/CD-managed version guard ─────────────────────────────────────────
+# GM (core/app/service.py) rejects a version-create that omits `repo` when the app
+# has a source_repo on file — every first-party app. And on a *mismatched* repo it
+# UPDATES app.source_repo rather than rejecting, so sending the wrong one silently
+# repoints the app's provenance. Echoing GM's own value back avoids both.
+
+
+@pytest.mark.parametrize(
+    "info, expected",
+    [
+        (
+            {"source_repo": "https://github.com/atlanhq/atlan-openapi-app"},
+            "https://github.com/atlanhq/atlan-openapi-app",
+        ),
+        (
+            {"sourceRepo": "https://github.com/atlanhq/x"},
+            "https://github.com/atlanhq/x",
+        ),
+        (
+            {"app": {"source_repo": "https://github.com/atlanhq/y"}},
+            "https://github.com/atlanhq/y",
+        ),
+        (
+            {"data": {"app": {"source_repo": "https://github.com/atlanhq/z"}}},
+            "https://github.com/atlanhq/z",
+        ),
+        ({}, ""),
+        ({"source_repo": "  "}, ""),
+        ({"source_repo": 7}, ""),
+    ],
+)
+def test_registered_source_repo_extraction(
+    info: dict[str, object], expected: str
+) -> None:
+    assert app._registered_source_repo(info) == expected
+
+
+def test_registered_repo_is_echoed_back_on_publish(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The publish body must carry the repo GM already has on file.
+
+    Without it GM returns "This app's versions are managed by CI/CD" — the actual
+    failure observed on the first live run.
+    """
+    repo = "https://github.com/atlanhq/atlan-openapi-app"
+    transport = _wire(
+        monkeypatch,
+        StubTransport(
+            routes=[
+                StubRoute("GET", "/info", _ok({"source_repo": repo})),
+                StubRoute("POST", "/marketplace/publish", _ok({"version_id": "v1"})),
+                StubRoute("POST", "/install", _ok({"deployment_id": "d1"})),
+                StubRoute(
+                    "GET", "/deployments/", _ok({"deployment_status": "SUCCEEDED"})
+                ),
+                StubRoute("GET", "/info", _ok({"version": _VERSION})),
+            ],
+            sticky=[StubRoute("GET", "/releases/", Response(status=404, body={}))],
+        ),
+    )
+    app.install(_install_args(repo_url=""))
+    assert transport.body_for("/marketplace/publish")["repo"] == repo
+
+
+def test_mismatched_repo_is_refused_rather_than_repointing_provenance(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # GM only blocks CROSS-ORG source_repo changes; a same-org mismatch is
+    # silently applied. Sending the running repo instead of the app's would
+    # repoint the app and break its real CI/CD gating, so this must not proceed.
+    _wire(
+        monkeypatch,
+        StubTransport(
+            routes=[
+                StubRoute(
+                    "GET",
+                    "/info",
+                    _ok(
+                        {"source_repo": "https://github.com/atlanhq/atlan-openapi-app"}
+                    ),
+                )
+            ]
+        ),
+    )
+    with pytest.raises(app.TenantAppError, match="source_repo"):
+        app.install(
+            _install_args(repo_url="https://github.com/atlanhq/application-sdk")
+        )
+
+
+def test_supplied_repo_used_when_gm_has_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    # An app with no source_repo is not CI/CD-managed; GM's `if repo:` branch then
+    # SETS it, which is the intended first-registration path.
+    supplied = "https://github.com/atlanhq/atlan-openapi-app"
+    transport = _wire(
+        monkeypatch,
+        StubTransport(
+            routes=[
+                StubRoute("GET", "/info", _ok({})),
+                StubRoute("POST", "/marketplace/publish", _ok({"version_id": "v1"})),
+                StubRoute("POST", "/install", _ok({"deployment_id": "d1"})),
+                StubRoute(
+                    "GET", "/deployments/", _ok({"deployment_status": "SUCCEEDED"})
+                ),
+                StubRoute("GET", "/info", _ok({"version": _VERSION})),
+            ],
+            sticky=[StubRoute("GET", "/releases/", Response(status=404, body={}))],
+        ),
+    )
+    app.install(_install_args(repo_url=supplied))
+    assert transport.body_for("/marketplace/publish")["repo"] == supplied
+
+
+def test_cicd_managed_rejection_is_recognised_and_explained(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    detail = (
+        "GM returned 409 creating version: This app's versions are managed by "
+        "CI/CD. Edit atlan.yaml in the app's repo and merge it."
+    )
+    _wire(
+        monkeypatch,
+        StubTransport(
+            routes=[
+                StubRoute("GET", "/info", _ok({})),
+                StubRoute(
+                    "POST",
+                    "/marketplace/publish",
+                    Response(status=400, body={"detail": detail}),
+                ),
+            ]
+        ),
+    )
+    with pytest.raises(app.TenantAppError, match="source_repo on file"):
+        app.install(_install_args(repo_url=""))
+
+
 # ── Version extraction across LM shapes ──────────────────────────────────────
 
 


### PR DESCRIPTION
### Changelog

- `e2e_tenant_app.py`: read the app's registered `source_repo` from `/marketplace/apps/<id>/info` and echo it back on the version create.
- Refuse to publish when a supplied `--repo-url` disagrees with GM's registered value, instead of letting GM silently repoint the app's provenance.
- Recognise GM's CI/CD-managed rejection and explain it (`_looks_like_cicd_managed`).
- 6 new tests.

### What happened

The first live `E2E Tenant Install` run failed at **publish**, before reaching the install — so it did not answer the scan-gate question (FND-31 spike (b)), which remains open.

```
marketplace publish failed with HTTP 400.
response={'detail': 'GM returned 409 creating version: {"detail":
  "This app'"'"'s versions are managed by CI/CD. Edit atlan.yaml in the app'"'"'s repo and merge it."}'}
```

### Root cause, from GM source

Settled from `global-marketplace/core/app/service.py` rather than by iterating CI runs:

```python
if repo:
    if not repo.startswith("https://github.com/"): raise ValueError(...)
    if not app.source_repo:      await set_source_repo(app.id, repo)
    elif app.source_repo != repo:
        # only cross-org changes are blocked
        await update_source_repo(app.id, repo)     # ← silently APPLIED
else:
    if app.source_repo:
        raise ValueError("This app's versions are managed by CI/CD. ...")
```

The guard is precisely **"no `repo` sent AND the app has a `source_repo` on file"** — true of every first-party app. The dispatch workflow never passed `--repo-url`, so the builder omitted `repo` and GM refused. My bug.

### The fix, and why it needs no new input

Read the app's registered `source_repo` back from `info` and send *that*. It matches GM's stored value, so neither the set nor the update branch is taken. `source_repo` is part of the `CatalogApp` projection, so `info` exposes it.

### The more serious half

GM only blocks **cross-org** `source_repo` changes; a same-org mismatch is silently **applied**. So passing the repo of whichever CI happens to be running — `application-sdk`, for the dispatch workflow — would have repointed `atlan-openapi-app`'s provenance inside GM and broken its real CI/CD publish gating, as a side effect of a call that reads like a publish. Both repos are in `atlanhq`, so the org check would not have saved us.

A disagreement between the registered repo and `--repo-url` is therefore now a hard error rather than something resolved by guessing.

### #3023 was already correct, now explicitly so

The `prepare-tenant` job passes `${{ github.repository }}`, and because `tests-reusable.yaml` is called by the *app's own* `tests.yaml`, that is the app's repo. Correct by construction — this change makes it correct by intent, and guards the case where it stops being true.

### A misleading comment, corrected

`atlan-cli/pkg/atlan/app_workflow.go` claims:

> Absence is fine: marketplace treats a missing field as "no repo info," not as "you forgot to send it."

Per the source above that is false for any app with a `source_repo` — i.e. all of them. It sent me toward the wrong theory initially; worth fixing in the CLI separately.

### Deliberately not resolved here

Neither has been reached yet, so neither is confirmed to bite:

- GM's `CreateBuildRequest` documents `version` as *"7-char SHA + abcd suffix (e.g. `1126c15abcd`)"*; we send `sdr-test-<sha8>`.
- It documents `allowed_tenants` as *"used when `target_channel` is 'specific'"*, while we send `allowed_tenants` alone — which is exactly what `build-and-publish-app.yaml` does in production. The doc and the shipping behaviour disagree, so I followed the shipping behaviour.

The next live run will say whether either matters. Both are cheap to fix if so.

### Checklist

- [x] Additional tests added
- [ ] All CI checks passed
- [ ] Relevant documentation updated <!-- n/a -->

Local: `test_e2e_tenant_app.py` 43 passed; pre-commit clean.

---

### Copyleft License Compliance

- [ ] Have you used any code that is subject to a Copyleft license (e.g., GPL, AGPL, LGPL)?
- [ ] If yes, have you modified the code in the context of this project? please share additional details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
