### PR TITLE
ci(e2e): read LM's real info shape, and require the app's repo on publish

### DIFF
--- a/.github/scripts/e2e_tenant_app.py
+++ b/.github/scripts/e2e_tenant_app.py
@@ -370,6 +370,19 @@ def _repo_from_image(image: str) -> str:
     return f"https://github.com/{parts[1]}/{parts[-1]}"
 
 
+def _is_ghcr_image(image: str) -> bool:
+    """True when the image reference is on GHCR, the confirmed e2e registry.
+
+    Compared on the host with any explicit port stripped (``ghcr.io:443/...`` is
+    still a GHCR reference), and case-insensitively — the fail-closed mismatch
+    guard keys on this, so the one spelling variant that would otherwise slip
+    into the warn-only path must not.
+    """
+    ref = image.split("@", 1)[0]
+    authority = ref.split("/", 1)[0]
+    return authority.rsplit(":", 1)[0].lower() == "ghcr.io"
+
+
 #: How deep the recursive payload walks below may descend. Both LM walks start
 #: at depth 0 and their nest lists are one level long, so real payloads never go
 #: past depth 1; the bound exists so a pathological (deeply nested or, via
@@ -663,7 +676,7 @@ def install(args: argparse.Namespace) -> InstallOutcome:
             "repoint the app's source_repo to it and break its CI/CD publish "
             "gating."
         )
-        if args.image.split("@", 1)[0].split("/", 1)[0].lower() == "ghcr.io":
+        if _is_ghcr_image(args.image):
             raise TenantAppError(
                 f"refusing to publish: {explanation} The image is a ghcr.io "
                 "reference, where image name == repo name holds across the "

--- a/.github/scripts/e2e_tenant_app.py
+++ b/.github/scripts/e2e_tenant_app.py
@@ -99,7 +99,31 @@ _SCAN_POLL_SECONDS = 10
 #: Keys an install/info response may carry the installed version under. LM has
 #: not committed to one name across versions, so check the plausible set rather
 #: than hard-coding a guess that silently reads None and compares equal to None.
-_VERSION_KEYS = ("version", "installed_version", "app_version", "current_version")
+#: ``version_text`` first: that is the field LM actually populates. Its
+#: ``/apps/{id}/info`` returns ``{app_id, catalog, installed}`` where ``installed``
+#: is an ``InstalledApp``
+#: (``atlan-local-marketplace-app``, ``tenant_apps_manager/models/service.py``)::
+#:
+#:     app_id, version_id, version_text, installed_at, last_modified_on,
+#:     deployment_name
+#:
+#: The rest are kept as tolerated aliases rather than removed — LM has not
+#: committed to this shape across versions, and reading the wrong key returns ""
+#: which is indistinguishable from "not installed", so a silent miss here reads as
+#: a successful no-op instead of a broken check. Confirmed against the source
+#: rather than guessed at: the original guess-list matched none of these fields,
+#: so the version read never worked.
+_VERSION_KEYS = (
+    "version_text",
+    "version",
+    "installed_version",
+    "app_version",
+    "current_version",
+)
+
+#: Nests to search for the installed-version payload. ``installed`` is LM's real
+#: envelope; the others are tolerated aliases.
+_VERSION_NESTS = ("installed", "install", "installation", "deployment", "data")
 
 
 class TenantAppError(RuntimeError):
@@ -244,9 +268,16 @@ def _registered_source_repo(info: dict[str, object]) -> str:
             raise "This app's versions are managed by CI/CD..."
 
     So an app that has a ``source_repo`` rejects any version-create that omits
-    ``repo``. Reading it back and echoing it is what makes this work without
-    asking a caller to know it: the value matches, so GM takes neither the "set"
-    nor the "update" branch.
+    ``repo``. Echoing GM's own value back would take neither the "set" nor the
+    "update" branch — but **LM does not expose it**, so this almost always returns
+    "" in practice and the caller has to supply the repo instead.
+
+    Kept anyway, for two reasons: it costs one dict walk on a payload already
+    fetched, and if LM ever surfaces the field the mismatch guard in
+    :func:`_resolve_repo_url` starts catching a wrong ``--repo-url`` instead of
+    merely warning about it. Verified against LM's router: ``/apps/{id}/info``
+    returns ``{app_id, catalog, installed}`` and neither sub-object carries
+    ``source_repo`` today.
     """
     for key in ("source_repo", "sourceRepo"):
         value = info.get(key)
@@ -299,25 +330,62 @@ def _resolve_repo_url(registered: str, supplied: str) -> str:
             "real CI/CD publish gating. Pass the app's own repo, or omit "
             "--repo-url and let the registered value be echoed back."
         )
+    if not registered and not supplied:
+        raise TenantAppError(
+            "cannot publish without a repo: GM refuses a version-create that "
+            "omits `repo` for any app that has a source_repo on file, which is "
+            "every first-party app. LM's /apps/<id>/info does not expose the "
+            "registered value, so it has to be supplied — pass --repo-url with "
+            "the APP'S OWN repo (e.g. https://github.com/atlanhq/atlan-<x>-app).\n"
+            "It must be the app's repo, NOT the repo whose CI is running: GM "
+            "only blocks CROSS-ORG source_repo changes, so a same-org value is "
+            "silently applied and would repoint the app's provenance."
+        )
     # Send the registered value when present — byte-for-byte what GM has on
     # file — so the publish can neither trip the CI/CD guard nor rewrite
     # provenance. Normalization above only decided *whether* to refuse.
     return registered or supplied
 
 
+def _repo_from_image(image: str) -> str:
+    """Best-effort guess of the app's GitHub repo from its image reference.
+
+    ``ghcr.io/atlanhq/atlan-openapi-app:tag`` -> ``https://github.com/atlanhq/atlan-openapi-app``.
+
+    A cross-check only, never a source. The convention (GHCR image name == repo
+    name) holds across the connector fleet but is a convention, not a guarantee,
+    so a disagreement warns rather than fails — the caller's value is still what
+    gets sent. It exists because the one destructive mistake available here is
+    passing the wrong repo, and that mistake is usually visible in exactly this
+    comparison.
+    """
+    ref = image.split("@", 1)[0]
+    path = ref.rsplit(":", 1)[0] if ":" in ref.rsplit("/", 1)[-1] else ref
+    parts = [p for p in path.split("/") if p]
+    if len(parts) < 3 or "." not in parts[0]:
+        return ""
+    return f"https://github.com/{parts[1]}/{parts[-1]}"
+
+
 def _extract_version(payload: dict[str, object]) -> str:
-    """Pull a version string out of an info/install payload."""
-    for key in _VERSION_KEYS:
-        value = payload.get(key)
-        if isinstance(value, str) and value.strip():
-            return value.strip()
-    # Some shapes nest the install state one level down.
-    for nest in ("install", "installation", "deployment"):
+    """Pull the installed version out of an ``/apps/{id}/info`` payload.
+
+    Searches the nests BEFORE the top-level keys. LM's envelope carries the
+    installed state under ``installed``, while the sibling ``catalog`` block
+    describes the app in general — so a top-level-first search risks reading a
+    catalogue-level version and reporting it as what the tenant is running, which
+    would make the version check pass against the wrong thing.
+    """
+    for nest in _VERSION_NESTS:
         inner = payload.get(nest)
         if isinstance(inner, dict):
             found = _extract_version(inner)
             if found:
                 return found
+    for key in _VERSION_KEYS:
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
     return ""
 
 
@@ -556,13 +624,26 @@ def install(args: argparse.Namespace) -> InstallOutcome:
     else:
         print(f"{app_id} is not installed on this tenant; installing {args.version}")
 
-    # Echo GM's own source_repo back on the version-create. Omitting `repo` is
-    # rejected outright for any app that has one ("versions are managed by
-    # CI/CD"), and sending a *different* one makes GM rewrite the app's
-    # provenance — so the registered value is the only safe thing to send.
+    # `repo` is mandatory in practice: GM rejects a version-create without it for
+    # any app that has a source_repo on file. It prefers GM's own registered value
+    # when readable (byte-for-byte, so no provenance rewrite), and otherwise takes
+    # the caller's --repo-url, because LM's info does not expose it.
     repo_url = _resolve_repo_url(_registered_source_repo(info), args.repo_url)
-    if repo_url:
-        print(f"publishing with repo={repo_url}")
+    print(f"publishing with repo={repo_url}")
+
+    # Cross-check against the repo the image implies. Passing the wrong repo is
+    # the one destructive mistake available here — GM would repoint the app's
+    # provenance — and it usually shows up as exactly this disagreement. A warning
+    # rather than an error: image-name == repo-name is a fleet convention, not a
+    # guarantee, so a legitimate exception must not be blocked.
+    implied = _repo_from_image(args.image)
+    if implied and _normalize_repo_url(implied) != _normalize_repo_url(repo_url):
+        print(
+            f"::warning::repo {repo_url} does not match the repo implied by the "
+            f"image ({implied}). If {repo_url} is not this app's own repo, GM will "
+            "repoint the app's source_repo to it and break its CI/CD publish "
+            "gating. Double-check before relying on this run."
+        )
 
     request = PublishRequest(
         app_id=app_id,

--- a/.github/scripts/e2e_tenant_app.py
+++ b/.github/scripts/e2e_tenant_app.py
@@ -256,7 +256,7 @@ def _app_info(client: TenantClient, app_id: str) -> dict[str, object]:
     return response.data() if response.ok else {}
 
 
-def _registered_source_repo(info: dict[str, object]) -> str:
+def _registered_source_repo(info: dict[str, object], _depth: int = 0) -> str:
     """Return the repo GM has on file for this app, or "" if it has none.
 
     GM's version-create guard is exactly (``global-marketplace``,
@@ -279,6 +279,8 @@ def _registered_source_repo(info: dict[str, object]) -> str:
     returns ``{app_id, catalog, installed}`` and neither sub-object carries
     ``source_repo`` today.
     """
+    if _depth >= _WALK_MAX_DEPTH:
+        return ""
     for key in ("source_repo", "sourceRepo"):
         value = info.get(key)
         if isinstance(value, str) and value.strip():
@@ -286,7 +288,7 @@ def _registered_source_repo(info: dict[str, object]) -> str:
     for nest in ("app", "catalog", "data"):
         inner = info.get(nest)
         if isinstance(inner, dict):
-            found = _registered_source_repo(inner)
+            found = _registered_source_repo(inner, _depth + 1)
             if found:
                 return found
     return ""
@@ -354,10 +356,11 @@ def _repo_from_image(image: str) -> str:
 
     A cross-check only, never a source. The convention (GHCR image name == repo
     name) holds across the connector fleet but is a convention, not a guarantee,
-    so a disagreement warns rather than fails — the caller's value is still what
-    gets sent. It exists because the one destructive mistake available here is
-    passing the wrong repo, and that mistake is usually visible in exactly this
-    comparison.
+    so a disagreement fails closed only for ``ghcr.io`` references — the
+    confirmed e2e registry, where the convention does hold — and warns otherwise,
+    so a legitimate exception off GHCR can still publish. It exists because the
+    one destructive mistake available here is passing the wrong repo, and that
+    mistake is usually visible in exactly this comparison.
     """
     ref = image.split("@", 1)[0]
     path = ref.rsplit(":", 1)[0] if ":" in ref.rsplit("/", 1)[-1] else ref
@@ -367,19 +370,32 @@ def _repo_from_image(image: str) -> str:
     return f"https://github.com/{parts[1]}/{parts[-1]}"
 
 
-def _extract_version(payload: dict[str, object]) -> str:
+#: How deep the recursive payload walks below may descend. Both LM walks start
+#: at depth 0 and their nest lists are one level long, so real payloads never go
+#: past depth 1; the bound exists so a pathological (deeply nested or, via
+#: ``data``, self-referential) payload degrades to "" — which the callers already
+#: treat as "field absent" — instead of crashing the step with a RecursionError
+#: traceback. The nests walked are exactly the keys a JSON wrapper envelope uses
+#: for self-similar nesting, so an unbounded walk is not theoretical.
+_WALK_MAX_DEPTH = 3
+
+
+def _extract_version(payload: dict[str, object], _depth: int = 0) -> str:
     """Pull the installed version out of an ``/apps/{id}/info`` payload.
 
     Searches the nests BEFORE the top-level keys. LM's envelope carries the
     installed state under ``installed``, while the sibling ``catalog`` block
     describes the app in general — so a top-level-first search risks reading a
     catalogue-level version and reporting it as what the tenant is running, which
-    would make the version check pass against the wrong thing.
+    would make the version check pass against the wrong thing. Recursion is
+    depth-bounded (see ``_WALK_MAX_DEPTH``).
     """
+    if _depth >= _WALK_MAX_DEPTH:
+        return ""
     for nest in _VERSION_NESTS:
         inner = payload.get(nest)
         if isinstance(inner, dict):
-            found = _extract_version(inner)
+            found = _extract_version(inner, _depth + 1)
             if found:
                 return found
     for key in _VERSION_KEYS:
@@ -633,17 +649,28 @@ def install(args: argparse.Namespace) -> InstallOutcome:
 
     # Cross-check against the repo the image implies. Passing the wrong repo is
     # the one destructive mistake available here — GM would repoint the app's
-    # provenance — and it usually shows up as exactly this disagreement. A warning
-    # rather than an error: image-name == repo-name is a fleet convention, not a
-    # guarantee, so a legitimate exception must not be blocked.
+    # provenance — and it usually shows up as exactly this disagreement. Fail
+    # closed when the image is a ghcr.io reference: GHCR is the confirmed e2e
+    # registry, and there image-name == repo-name holds, so a disagreement is a
+    # provenance-rewrite attempt, not a legitimate exception. Any other registry
+    # only warns — the convention is not guaranteed to hold there, so a real
+    # exception must still be able to publish.
     implied = _repo_from_image(args.image)
     if implied and _normalize_repo_url(implied) != _normalize_repo_url(repo_url):
-        print(
-            f"::warning::repo {repo_url} does not match the repo implied by the "
-            f"image ({implied}). If {repo_url} is not this app's own repo, GM will "
+        explanation = (
+            f"repo {repo_url} does not match the repo implied by the image "
+            f"({implied}). If {repo_url} is not this app's own repo, GM will "
             "repoint the app's source_repo to it and break its CI/CD publish "
-            "gating. Double-check before relying on this run."
+            "gating."
         )
+        if args.image.split("@", 1)[0].split("/", 1)[0].lower() == "ghcr.io":
+            raise TenantAppError(
+                f"refusing to publish: {explanation} The image is a ghcr.io "
+                "reference, where image name == repo name holds across the "
+                "fleet, so this disagreement is a wrong --repo-url, not a "
+                "legitimate exception. Pass the app's own repo."
+            )
+        print(f"::warning::{explanation} Double-check before relying on this run.")
 
     request = PublishRequest(
         app_id=app_id,

--- a/.github/scripts/tests/test_e2e_tenant_app.py
+++ b/.github/scripts/tests/test_e2e_tenant_app.py
@@ -790,16 +790,34 @@ def test_repo_inferred_from_image(image: str, expected: str) -> None:
     assert app._repo_from_image(image) == expected
 
 
-def test_repo_image_mismatch_warns_but_proceeds(
+def test_ghcr_repo_image_mismatch_fails_closed_before_publishing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A ghcr.io image whose implied repo disagrees with --repo-url is a wrong
+    repo, not a legitimate exception — image name == repo name holds on GHCR, so
+    the publish (which would repoint the app's provenance) must never happen.
+    """
+    transport = _wire(
+        monkeypatch,
+        StubTransport(routes=[StubRoute("GET", "/info", _ok({}))]),
+    )
+    with pytest.raises(
+        app.TenantAppError, match="does not match the repo implied by the image"
+    ):
+        app.install(
+            _install_args(repo_url="https://github.com/atlanhq/application-sdk")
+        )
+    assert transport.paths("POST") == []
+
+
+def test_non_ghcr_repo_image_mismatch_warns_but_proceeds(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    """A wrong repo is the one destructive mistake here, so it must be visible.
-
-    Warned rather than blocked: image-name == repo-name is a fleet convention,
-    not a guarantee, so a legitimate exception must still be able to publish. The
-    caller's value is what gets sent either way.
+    """Off GHCR the image-name == repo-name convention is not guaranteed, so a
+    disagreement stays warn-only: a legitimate exception must still be able to
+    publish, and the caller's value is what gets sent.
     """
-    _wire(
+    transport = _wire(
         monkeypatch,
         StubTransport(
             routes=[
@@ -814,10 +832,22 @@ def test_repo_image_mismatch_warns_but_proceeds(
             sticky=[StubRoute("GET", "/releases/", Response(status=404, body={}))],
         ),
     )
-    app.install(_install_args(repo_url="https://github.com/atlanhq/application-sdk"))
+    app.install(
+        _install_args(
+            image=(
+                "123456789012.dkr.ecr.us-east-1.amazonaws.com"
+                "/atlanhq/atlan-openapi-app:tag"
+            ),
+            repo_url="https://github.com/atlanhq/application-sdk",
+        )
+    )
     out = capsys.readouterr().out
     assert (
         "::warning::" in out and "does not match the repo implied by the image" in out
+    )
+    assert (
+        transport.body_for("/marketplace/publish")["repo"]
+        == "https://github.com/atlanhq/application-sdk"
     )
 
 
@@ -840,6 +870,37 @@ def test_repo_image_mismatch_warns_but_proceeds(
 )
 def test_version_extraction(payload: dict[str, object], expected: str) -> None:
     assert app._extract_version(payload) == expected
+
+
+def test_version_extraction_degrades_on_a_self_referential_payload() -> None:
+    """``data`` is exactly the key a JSON wrapper envelope uses for self-similar
+    nesting, so the walk must be depth-bounded: a cyclic payload reads as "not
+    installed" ("") rather than crashing the step with a RecursionError.
+    """
+    payload: dict[str, object] = {"app_id": _APP_ID}
+    payload["data"] = payload
+    assert app._extract_version(payload) == ""
+
+
+def test_version_extraction_reads_a_version_within_the_depth_bound() -> None:
+    """The bound must not throw away a findable version: nests are searched at
+    every level up to it."""
+    payload: dict[str, object] = {"data": None}
+    inner = payload
+    for _ in range(app._WALK_MAX_DEPTH - 1):
+        nested: dict[str, object] = {}
+        inner["data"] = nested
+        inner = nested
+    inner["version"] = "1.2.3"
+    assert app._extract_version(payload) == "1.2.3"
+
+
+def test_registered_source_repo_degrades_on_a_self_referential_payload() -> None:
+    """Same bound on the repo walk: a cyclic ``data`` envelope reads as "no
+    registered repo" ("") instead of a RecursionError."""
+    info: dict[str, object] = {"app_id": _APP_ID}
+    info["data"] = info
+    assert app._registered_source_repo(info) == ""
 
 
 # ── Outputs ──────────────────────────────────────────────────────────────────

--- a/.github/scripts/tests/test_e2e_tenant_app.py
+++ b/.github/scripts/tests/test_e2e_tenant_app.py
@@ -25,6 +25,7 @@ _TENANT = "https://example-tenant.atlan.test"
 _APP_ID = "019d1f6b-6fea-7db3-96d8-e61e159d0351"
 _IMAGE = "ghcr.io/atlanhq/atlan-openapi-app:sdr-test-abc12345"
 _VERSION = "sdr-test-abc12345"
+_REPO = "https://github.com/atlanhq/atlan-openapi-app"
 
 
 # ── Typed HTTP stub ──────────────────────────────────────────────────────────
@@ -123,7 +124,7 @@ def _install_args(**overrides: object) -> argparse.Namespace:
         "version": _VERSION,
         "branch": "chrishehim/fnd-31",
         "tenant": "example-tenant",
-        "repo_url": "",
+        "repo_url": _REPO,
         "deploy_config": "",
         "self_deployed_runtime": False,
         "sdk_version": "",
@@ -578,7 +579,7 @@ def test_registered_repo_is_echoed_back_on_publish(
             sticky=[StubRoute("GET", "/releases/", Response(status=404, body={}))],
         ),
     )
-    app.install(_install_args(repo_url=""))
+    app.install(_install_args(repo_url=repo))
     assert transport.body_for("/marketplace/publish")["repo"] == repo
 
 
@@ -688,7 +689,136 @@ def test_cicd_managed_rejection_is_recognised_and_explained(
         ),
     )
     with pytest.raises(app.TenantAppError, match="source_repo on file"):
+        app.install(_install_args())
+
+
+# ── LM's real /apps/{id}/info shape ──────────────────────────────────────────
+# LM returns {app_id, catalog, installed}, where `installed` is an InstalledApp
+# carrying `version_text` (atlan-local-marketplace-app,
+# tenant_apps_manager/models/service.py). Neither that nest nor that key was in
+# the original guess-list, so the installed-version read never worked — it always
+# returned "", which is indistinguishable from "not installed" and therefore read
+# as a successful no-op rather than a broken check.
+
+
+def _lm_info(
+    version_text: str, catalog: dict[str, object] | None = None
+) -> dict[str, object]:
+    """The real envelope, so these tests pin the shipping contract."""
+    return {
+        "app_id": _APP_ID,
+        "catalog": catalog if catalog is not None else {"name": "openapi"},
+        "installed": {
+            "app_id": _APP_ID,
+            "version_id": "01930000-0000-7000-8000-000000000000",
+            "version_text": version_text,
+            "installed_at": "2026-08-06T00:00:00Z",
+            "last_modified_on": "2026-08-06T00:00:00Z",
+            "deployment_name": "atlan",
+        },
+    }
+
+
+def test_installed_version_read_from_lm_envelope() -> None:
+    assert app._extract_version(_lm_info("1.2.3")) == "1.2.3"
+
+
+def test_installed_nest_wins_over_a_catalog_version() -> None:
+    """`installed` must be preferred over the sibling `catalog` block.
+
+    `catalog` describes the app in general; a top-level-or-catalog-first search
+    would report a catalogue version as what the tenant is running, and the
+    version check would then pass against the wrong thing — the precise failure
+    this whole change exists to prevent.
+    """
+    info = _lm_info("1.2.3", catalog={"name": "openapi", "version": "9.9.9"})
+    assert app._extract_version(info) == "1.2.3"
+
+
+def test_absent_install_block_reads_as_not_installed() -> None:
+    assert (
+        app._extract_version({"app_id": _APP_ID, "catalog": {}, "installed": None})
+        == ""
+    )
+
+
+def test_converge_uses_the_real_envelope(monkeypatch: pytest.MonkeyPatch) -> None:
+    # End-to-end through install(): the no-op path must trigger off the shape LM
+    # actually returns, not just off a flat {"version": ...}.
+    transport = _wire(
+        monkeypatch,
+        StubTransport(routes=[StubRoute("GET", "/info", _ok(_lm_info(_VERSION)))]),
+    )
+    outcome = app.install(_install_args())
+    assert outcome.skipped is True
+    assert transport.paths("POST") == []
+
+
+# ── repo is mandatory, and must be the app's own ──────────────────────────────
+
+
+def test_publish_without_any_repo_is_refused_before_the_call(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # GM would reject it anyway; failing here says why, and names --repo-url.
+    _wire(monkeypatch, StubTransport(routes=[StubRoute("GET", "/info", _ok({}))]))
+    with pytest.raises(app.TenantAppError, match="--repo-url"):
         app.install(_install_args(repo_url=""))
+
+
+@pytest.mark.parametrize(
+    "image, expected",
+    [
+        (
+            "ghcr.io/atlanhq/atlan-openapi-app:sdr-test-abc12345",
+            "https://github.com/atlanhq/atlan-openapi-app",
+        ),
+        (
+            "ghcr.io/atlanhq/atlan-mysql-app:main-1234567",
+            "https://github.com/atlanhq/atlan-mysql-app",
+        ),
+        (
+            "ghcr.io/atlanhq/atlan-openapi-app@sha256:" + "0" * 64,
+            "https://github.com/atlanhq/atlan-openapi-app",
+        ),
+        # No registry host -> cannot infer; must not guess.
+        ("atlan-openapi-app:tag", ""),
+        ("", ""),
+    ],
+)
+def test_repo_inferred_from_image(image: str, expected: str) -> None:
+    assert app._repo_from_image(image) == expected
+
+
+def test_repo_image_mismatch_warns_but_proceeds(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A wrong repo is the one destructive mistake here, so it must be visible.
+
+    Warned rather than blocked: image-name == repo-name is a fleet convention,
+    not a guarantee, so a legitimate exception must still be able to publish. The
+    caller's value is what gets sent either way.
+    """
+    _wire(
+        monkeypatch,
+        StubTransport(
+            routes=[
+                StubRoute("GET", "/info", _ok({})),
+                StubRoute("POST", "/marketplace/publish", _ok({"version_id": "v1"})),
+                StubRoute("POST", "/install", _ok({"deployment_id": "d1"})),
+                StubRoute(
+                    "GET", "/deployments/", _ok({"deployment_status": "SUCCEEDED"})
+                ),
+                StubRoute("GET", "/info", _ok(_lm_info(_VERSION))),
+            ],
+            sticky=[StubRoute("GET", "/releases/", Response(status=404, body={}))],
+        ),
+    )
+    app.install(_install_args(repo_url="https://github.com/atlanhq/application-sdk"))
+    out = capsys.readouterr().out
+    assert (
+        "::warning::" in out and "does not match the repo implied by the image" in out
+    )
 
 
 # ── Version extraction across LM shapes ──────────────────────────────────────

--- a/.github/scripts/tests/test_e2e_tenant_app.py
+++ b/.github/scripts/tests/test_e2e_tenant_app.py
@@ -790,6 +790,26 @@ def test_repo_inferred_from_image(image: str, expected: str) -> None:
     assert app._repo_from_image(image) == expected
 
 
+@pytest.mark.parametrize(
+    "image, expected",
+    [
+        ("ghcr.io/atlanhq/atlan-openapi-app:tag", True),
+        # An explicit port is still a GHCR reference — the spelling that must
+        # not slip past the fail-closed guard into the warn-only path.
+        ("ghcr.io:443/atlanhq/atlan-openapi-app:tag", True),
+        ("GHCR.IO/atlanhq/atlan-openapi-app:tag", True),
+        ("ghcr.io/atlanhq/atlan-openapi-app@sha256:" + "0" * 64, True),
+        ("123456789012.dkr.ecr.us-east-1.amazonaws.com/atlanhq/app:tag", False),
+        # ghcr.io in the path is not ghcr.io in the registry seat.
+        ("myregistry.com/ghcr.io/app:tag", False),
+        ("atlan-openapi-app:tag", False),
+        ("", False),
+    ],
+)
+def test_ghcr_image_classification(image: str, expected: bool) -> None:
+    assert app._is_ghcr_image(image) is expected
+
+
 def test_ghcr_repo_image_mismatch_fails_closed_before_publishing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -806,6 +826,29 @@ def test_ghcr_repo_image_mismatch_fails_closed_before_publishing(
     ):
         app.install(
             _install_args(repo_url="https://github.com/atlanhq/application-sdk")
+        )
+    assert transport.paths("POST") == []
+
+
+def test_ghcr_image_with_an_explicit_port_still_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``ghcr.io:443/...`` is the same registry as ``ghcr.io/...`` — the exact
+    spelling that used to fall through to warn-only and let a wrong same-org
+    repo publish. The port must not turn the guard off.
+    """
+    transport = _wire(
+        monkeypatch,
+        StubTransport(routes=[StubRoute("GET", "/info", _ok({}))]),
+    )
+    with pytest.raises(
+        app.TenantAppError, match="does not match the repo implied by the image"
+    ):
+        app.install(
+            _install_args(
+                image="ghcr.io:443/atlanhq/atlan-openapi-app:tag",
+                repo_url="https://github.com/atlanhq/application-sdk",
+            )
         )
     assert transport.paths("POST") == []
 

--- a/.github/scripts/tests/test_e2e_tenant_install_workflow.py
+++ b/.github/scripts/tests/test_e2e_tenant_install_workflow.py
@@ -64,6 +64,9 @@ def test_inputs_used_by_scripts_arrive_through_env(workflow: dict) -> None:
             "IMAGE",
             "VERSION",
             "BRANCH",
+            # GM rejects a version-create without `repo` for any app with a
+            # source_repo on file, and LM does not expose the registered value.
+            "REPO_URL",
             "SCAN_WAIT_SECONDS",
             "TIMEOUT_SECONDS",
         },

--- a/.github/workflows/e2e-tenant-install.yaml
+++ b/.github/workflows/e2e-tenant-install.yaml
@@ -59,6 +59,17 @@ on:
         description: "Git ref the image was built from, recorded on the GM version."
         required: true
         type: string
+      repo_url:
+        description: >-
+          The APP'S OWN repo, e.g. https://github.com/atlanhq/atlan-openapi-app.
+          Required: GM refuses a version-create that omits `repo` for any app
+          with a source_repo on file (every first-party app), and LM's
+          /apps/<id>/info does not expose the registered value to echo back.
+          Must be the app's repo, NOT this one — GM only blocks CROSS-ORG
+          source_repo changes, so a same-org value is silently applied and would
+          repoint the app's provenance.
+        required: true
+        type: string
       scan_wait_seconds:
         description: >-
           Seconds to wait for GM's release scan before installing. 0 (default)
@@ -135,11 +146,12 @@ jobs:
       # expression again just to be renamed — every hop is a hop it can be
       # mishandled on. Those are the OAuth client pair the marketplace publish
       # route authorises on, NOT ATLAN_API_KEY (the harness's API key).
+      #
       # Every dispatch input reaches the shell through env:, never through
-        # `${{ }}` inside run:. A workflow_dispatch input is attacker-influenced
-        # free text, and direct interpolation splices it into the script before
-        # bash sees a quote — so a crafted `version` would execute rather than be
-        # compared. Via env:, bash receives it as data.
+      # `${{ }}` inside run:. A workflow_dispatch input is attacker-influenced
+      # free text, and direct interpolation splices it into the script before
+      # bash sees a quote — so a crafted `version` would execute rather than be
+      # compared. Via env:, bash receives it as data.
       - name: Install onto the tenant
         id: install
         env:
@@ -147,6 +159,7 @@ jobs:
           IMAGE: ${{ inputs.image }}
           VERSION: ${{ inputs.version }}
           BRANCH: ${{ inputs.branch }}
+          REPO_URL: ${{ inputs.repo_url }}
           SCAN_WAIT_SECONDS: ${{ inputs.scan_wait_seconds }}
           TIMEOUT_SECONDS: ${{ inputs.timeout_seconds }}
         run: |
@@ -157,6 +170,7 @@ jobs:
             --image "$IMAGE" \
             --version "$VERSION" \
             --branch "$BRANCH" \
+            --repo-url "$REPO_URL" \
             --tenant "$SDR_TEST_TENANT" \
             --scan-wait-seconds "$SCAN_WAIT_SECONDS" \
             --timeout-seconds "$TIMEOUT_SECONDS"


### PR DESCRIPTION
### Changelog

- Read the installed version from LM's real envelope: `installed.version_text`, searching nests **before** top-level keys.
- `repo` is now caller-supplied and required — new `repo_url` input on `E2E Tenant Install`, with a clear error when nothing is available.
- Warn when the supplied repo disagrees with the repo implied by the image reference.
- 11 new tests.

### What the second run told us

The same `cicd_managed` rejection, but the self-explaining error added in #3027 pointed straight at the cause: *"reaching this means /apps/<id>/info did not expose it"*. It didn't, and there was no `publishing with repo=` line to prove it.

So I checked LM instead of guessing a third time. `GET /marketplace/apps/{id}/info` (`atlan-local-marketplace-app`, `marketplace_api/v1/router.py`) returns:

```json
{ "app_id": "...", "catalog": {...}, "installed": {...} }
```

### The worse bug this exposed

`installed` is an `InstalledApp` (`tenant_apps_manager/models/service.py`):

```
app_id, version_id, version_text, installed_at, last_modified_on, deployment_name
```

**Neither that nest (`installed`) nor that key (`version_text`) was in my guess-list.** So the installed-version read never worked at all. It always returned `""` — indistinguishable from "not installed" — which means:

- converge-by-version always re-published instead of no-op'ing, and
- **the per-leg verify from #3023 would have failed every single time it was switched on.**

A silent miss here reads as a successful no-op. That is precisely the class of failure FND-31 exists to remove, and I shipped it. It was masked because the feature is off by default and the app genuinely isn't installed on the Azure tenant, so "not installed" was also the correct answer for the wrong reason.

Fixed, and **nests are now searched before top-level keys**: `catalog` is a sibling of `installed` and describes the app in general, so a top-level-first search could report a catalogue version as what the tenant is running — letting the version check pass against the wrong thing. There's a test for exactly that precedence.

### The repo half

Neither sub-object carries `source_repo`, so #3027's echo-back cannot work. `repo` is mandatory in practice (GM rejects a version-create without it for any app that has one), so it has to be supplied: new **required** `repo_url` input, and a clear error naming `--repo-url` when nothing is available.

The lookup is kept rather than deleted — it costs one dict walk on a payload already fetched, and if LM ever surfaces the field the mismatch guard upgrades from a warning to a hard error for free.

### The hazard this re-opens, and the mitigation

Because the value is now caller-supplied, the destructive mistake is live again: GM only blocks **cross-org** `source_repo` changes, so a wrong same-org repo is silently applied and repoints the app's provenance.

Mitigated by inferring the repo from the image reference (`ghcr.io/atlanhq/atlan-openapi-app:tag` → `https://github.com/atlanhq/atlan-openapi-app`) and warning on disagreement. A **warning, not an error**: image-name == repo-name is a fleet convention, not a guarantee, so a legitimate exception must still be able to publish. The caller's value is what gets sent either way.

The automatic `prepare-tenant` path is unaffected — it runs in the app's own repo, so `github.repository` is already correct.

### Still unanswered

The scan-gate question (FND-31 spike (b)). Neither live run has reached the install step yet. Next run should.

### Checklist

- [x] Additional tests added
- [ ] All CI checks passed
- [ ] Relevant documentation updated <!-- n/a -->

Local: 1203 script tests pass; `pre-commit run --all-files` clean.

---

### Copyleft License Compliance

- [ ] Have you used any code that is subject to a Copyleft license (e.g., GPL, AGPL, LGPL)?
- [ ] If yes, have you modified the code in the context of this project? please share additional details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
