### PR TITLE
ci(e2e): retry the install while LM's catalog snapshot catches up

### DIFF
--- a/.github/scripts/e2e_tenant_app.py
+++ b/.github/scripts/e2e_tenant_app.py
@@ -51,11 +51,16 @@ would red every leg of an unrelated PR, and release is gated separately. So the
 default here is ``--scan-wait-seconds 0`` — install immediately, report whatever
 the scan status happens to be.
 
-Whether GM *accepts* an install of a still-``scan_pending`` release is an open
-question at the time of writing (FND-31 spike (b)); the first live run of this
-script answers it. If GM rejects it, :func:`_looks_like_scan_gate` recognises
-the rejection and the error names the fix — raise ``--scan-wait-seconds`` — so
-the failure is self-explaining rather than an opaque 4xx.
+Answered empirically (FND-31 spike (b)), and not in the shape expected: GM does
+not refuse the install. The constraint is one layer down — **LM cannot see the
+release yet**. LM resolves an install against its own tenant-catalog snapshot,
+which excludes a release while it is ``scan_pending`` and only picks it up on the
+next scheduled sync (~5 min). A run that read ``active`` straight from GM still
+had its install miss, so waiting on GM's release status is not sufficient.
+
+Hence ``--install-retry-seconds`` (default 600): the install itself is retried
+while LM catches up. ``--scan-wait-seconds`` stays at 0 — waiting on the scan
+would not have helped, and a base-image CVE must not red an unrelated PR.
 """
 
 from __future__ import annotations
@@ -95,6 +100,8 @@ _SCAN_FAILED = "scan_failed"
 
 _DEPLOY_POLL_SECONDS = 10
 _SCAN_POLL_SECONDS = 10
+#: Gap between install retries while LM's catalog snapshot catches up.
+_INSTALL_RETRY_POLL_SECONDS = 20
 
 #: Keys an install/info response may carry the installed version under. LM has
 #: not committed to one name across versions, so check the plausible set rather
@@ -444,6 +451,20 @@ def _looks_like_cicd_managed(response: Response) -> bool:
     return "managed by ci/cd" in rendered or "cicd_managed" in rendered
 
 
+def _looks_like_scan_gate_text(text: str) -> bool:
+    """Scan-gate detection over a plain message string.
+
+    LM reports its outcome in the body rather than the HTTP status, so the
+    install path matches on the message while the publish path still matches on
+    a whole response.
+    """
+    lowered = text.lower()
+    return any(
+        marker in lowered
+        for marker in (_SCAN_PENDING, _SCAN_FAILED, "scan", "not active", "draft")
+    )
+
+
 def _looks_like_scan_gate(response: Response) -> bool:
     """True when a failed install looks like GM's release-scan gate refusing.
 
@@ -540,37 +561,147 @@ def _publish(client: TenantClient, request: PublishRequest) -> tuple[str, str]:
     return version_id, release_id
 
 
-def _install(client: TenantClient, app_id: str, version_id: str, scan_hint: str) -> str:
-    """Trigger the install. Returns the deployment id."""
-    response = client.post(
-        INSTALL_PATH.format(app_id=path_segment(app_id)),
-        body={"version_id": version_id, "force_install": True},
-    )
-    if not response.ok:
+@dataclass(frozen=True)
+class _InstallReply:
+    """LM's install response, whose HTTP status is not the whole story.
+
+    ``POST /tenant/default/apps/{id}/install`` answers **HTTP 200 with an
+    error-shaped envelope** for its two non-deploying outcomes
+    (``atlan-local-marketplace-app``, ``marketplace_api/v1/router.py``)::
+
+        {"status": "error",   "message": "App with ID '…' not found: …", "status_code": 404}
+        {"status": "success", "message": "App already installed",        "status_code": 200}
+
+    So ``response.ok`` alone would read a 404 as a success. The in-body
+    ``status_code`` is authoritative and is what this parses.
+    """
+
+    http_status: int
+    status: str
+    status_code: int
+    message: str
+    deployment_id: str
+    rendered_body: str
+
+    @classmethod
+    def parse(cls, response: Response) -> _InstallReply:
+        data = response.data() if isinstance(response.body, dict) else {}
+        raw_code = data.get("status_code")
+        # `message` is LM's 200-envelope field; `detail` is what Heracles/FastAPI
+        # put on a real HTTP error. Both have to be read, or a genuine 4xx loses
+        # its text and the failure stops being self-explaining.
+        message = str(data.get("message") or data.get("detail") or "").strip()
+        return cls(
+            http_status=response.status,
+            status=str(data.get("status") or "").strip().lower(),
+            # Fall back to the HTTP status when LM omits its own.
+            status_code=raw_code if isinstance(raw_code, int) else response.status,
+            message=message,
+            deployment_id=str(data.get("deployment_id") or ""),
+            rendered_body=_render_body(response.body),
+        )
+
+    @property
+    def failed(self) -> bool:
+        return self.status == "error" or self.status_code >= 400 or not self.http_ok
+
+    @property
+    def http_ok(self) -> bool:
+        return 200 <= self.http_status < 300
+
+    @property
+    def not_found(self) -> bool:
+        """The release is not resolvable in LM's tenant-catalog snapshot yet."""
+        return self.status_code == 404 or "not found" in self.message.lower()
+
+    @property
+    def already_installed(self) -> bool:
+        return not self.failed and "already installed" in self.message.lower()
+
+
+def _install(
+    client: TenantClient,
+    app_id: str,
+    version_id: str,
+    scan_hint: str,
+    *,
+    retry_seconds: int,
+) -> str:
+    """Trigger the install, tolerating LM's catalog-snapshot lag.
+
+    Returns the deployment id, or "" when LM reports the app is already
+    installed (it does not start a deployment, so there is nothing to poll).
+
+    The retry exists because a freshly published release is not immediately
+    installable, which LM documents against this very route: a release created
+    via ``POST /publish`` starts ``scan_pending`` and is excluded from GM's tenant
+    catalog, the publish-time refresh runs while it is still ``scan_pending``, and
+    it therefore does not enter LM's snapshot until the next scheduled sync
+    (~5 min). LM refreshes once inline on a miss, but that refresh can itself race
+    the flip to ``active``.
+
+    Waiting on GM's release status is NOT sufficient: the first run to get this
+    far read ``active`` from GM and the install still missed, because what install
+    resolves against is LM's snapshot, not GM.
+    """
+    deadline = time.monotonic() + max(retry_seconds, 0)
+    attempt = 0
+    while True:
+        attempt += 1
+        reply = _InstallReply.parse(
+            client.post(
+                INSTALL_PATH.format(app_id=path_segment(app_id)),
+                body={"version_id": version_id, "force_install": True},
+            )
+        )
+
+        if reply.already_installed:
+            print(f"LM reports the app already installed: {reply.message}")
+            return ""
+
+        if not reply.failed and reply.deployment_id:
+            return reply.deployment_id
+
+        if not reply.failed:
+            raise TenantAppError(
+                "install reported success but carried no deployment_id, so the "
+                f"deployment cannot be polled. message={reply.message!r} "
+                f"status={reply.status!r} status_code={reply.status_code}"
+            )
+
+        # Retryable: LM cannot see the release yet.
+        if reply.not_found and time.monotonic() < deadline:
+            remaining = int(deadline - time.monotonic())
+            print(
+                f"attempt {attempt}: LM cannot resolve the release yet "
+                f"({reply.message or 'not found'}) — its catalog snapshot lags a "
+                f"fresh publish by up to ~5 min; retrying for {remaining}s"
+            )
+            time.sleep(_INSTALL_RETRY_POLL_SECONDS)
+            continue
+
         hint = ""
-        if _looks_like_scan_gate(response):
+        if reply.not_found:
             hint = (
-                " This looks like GM's release-scan gate refusing a release that "
-                "has not finished scanning. e2e deliberately does not wait for "
-                "the scan (a base-image CVE must not red an unrelated PR); if GM "
-                "requires it, re-run with --scan-wait-seconds set."
-                + (
-                    f" Release status at install time: {scan_hint}."
-                    if scan_hint
-                    else ""
-                )
+                " LM never saw the release. Its tenant-catalog snapshot excludes a "
+                "release while it is scan_pending and only picks it up on the next "
+                "scheduled sync (~5 min), so a fresh publish is not immediately "
+                "installable. Raise --install-retry-seconds if the sync is slower "
+                "than the current budget."
+                + (f" GM release status was {scan_hint!r}." if scan_hint else "")
+            )
+        elif _looks_like_scan_gate_text(reply.message):
+            hint = (
+                " This looks like GM's release-scan gate. e2e deliberately does "
+                "not wait for the scan (a base-image CVE must not red an unrelated "
+                "PR); re-run with --scan-wait-seconds set if it is required."
             )
         raise TenantAppError(
-            f"install failed with HTTP {response.status}.{hint}\n"
-            f"response={_render_body(response.body)}"
+            f"install failed after {attempt} attempt(s): "
+            f"status={reply.status!r} status_code={reply.status_code} "
+            f"message={reply.message!r} (HTTP {reply.http_status}).{hint}\n"
+            f"response={reply.rendered_body}"
         )
-    deployment_id = str(response.data().get("deployment_id") or "")
-    if not deployment_id:
-        raise TenantAppError(
-            "install response carried no deployment_id, so the deployment cannot "
-            f"be polled (keys: {sorted(response.data())})"
-        )
-    return deployment_id
 
 
 def _poll_deployment(client: TenantClient, deployment_id: str, timeout: int) -> None:
@@ -717,14 +848,26 @@ def install(args: argparse.Namespace) -> InstallOutcome:
             "(not waiting for the scan by design)"
         )
 
-    deployment_id = _install(publish_client, app_id, version_id, status)
-    print(f"install accepted, deployment_id={deployment_id}")
-
-    try:
-        _poll_deployment(read_client, deployment_id, args.timeout_seconds)
-    except TenantAppError:
-        _dump_failure(read_client, app_id)
-        raise
+    deployment_id = _install(
+        publish_client,
+        app_id,
+        version_id,
+        status,
+        retry_seconds=args.install_retry_seconds,
+    )
+    # An empty deployment_id means LM reported the app already installed and
+    # started no deployment, so there is nothing to poll. The version read-back
+    # below is then the only thing that decides success — which is the right
+    # authority anyway.
+    if deployment_id:
+        print(f"install accepted, deployment_id={deployment_id}")
+        try:
+            _poll_deployment(read_client, deployment_id, args.timeout_seconds)
+        except TenantAppError:
+            _dump_failure(read_client, app_id)
+            raise
+    else:
+        print("no deployment started; relying on the version read-back below")
 
     installed = _installed_version(read_client, app_id)
     print(f"tenant reports installed version: {installed or '<unreported>'}")
@@ -811,6 +954,18 @@ def main(argv: list[str] | None = None) -> int:
             "Seconds to wait for GM's release scan before installing. 0 (the "
             "default) does not wait: a base-image CVE must not red an unrelated "
             "PR's e2e. Raise only if GM refuses to install an unscanned release."
+        ),
+    )
+    p_install.add_argument(
+        "--install-retry-seconds",
+        type=int,
+        default=600,
+        help=(
+            "How long to keep retrying the install while LM's tenant-catalog "
+            "snapshot catches up with a fresh publish. LM excludes a release "
+            "while it is scan_pending and picks it up on the next scheduled sync "
+            "(~5 min), so a just-published release is not immediately "
+            "installable. 0 disables the retry."
         ),
     )
     p_install.add_argument(

--- a/.github/scripts/tests/test_e2e_tenant_app.py
+++ b/.github/scripts/tests/test_e2e_tenant_app.py
@@ -133,6 +133,7 @@ def _install_args(**overrides: object) -> argparse.Namespace:
         "release_model": "",
         "created_by": "",
         "scan_wait_seconds": 0,
+        "install_retry_seconds": 0,
         "timeout_seconds": 600,
     }
     values.update(overrides)
@@ -892,6 +893,114 @@ def test_non_ghcr_repo_image_mismatch_warns_but_proceeds(
         transport.body_for("/marketplace/publish")["repo"]
         == "https://github.com/atlanhq/application-sdk"
     )
+
+
+# ── LM answers 200 with an error envelope ────────────────────────────────────
+# POST .../install returns HTTP 200 carrying {status, status_code, message} for
+# its two non-deploying outcomes, so response.ok alone reads a 404 as success.
+# LM's snapshot also lags a fresh publish by up to ~5 min, which is why the
+# install is retried rather than failed on first miss.
+
+
+def _install_reply(status: str, code: int, message: str) -> Response:
+    return Response(
+        status=200, body={"status": status, "status_code": code, "message": message}
+    )
+
+
+_NOT_FOUND = _install_reply(
+    "error", 404, "App with ID '019d1f6b-6fea-7db3-96d8-e61e159d0351' not found: x"
+)
+
+
+def _publish_then(*install_replies: Response) -> StubTransport:
+    """Transport that gets as far as the install, then serves the given replies."""
+    routes = [
+        StubRoute("GET", "/info", _ok({})),
+        StubRoute("POST", "/marketplace/publish", _ok({"version_id": "v1"})),
+    ]
+    routes += [StubRoute("POST", "/install", r) for r in install_replies]
+    routes += [
+        StubRoute("GET", "/deployments/", _ok({"deployment_status": "SUCCEEDED"})),
+        StubRoute("GET", "/info", _ok(_lm_info(_VERSION))),
+    ]
+    return StubTransport(
+        routes=routes,
+        sticky=[StubRoute("GET", "/releases/", Response(status=404, body={}))],
+    )
+
+
+def test_http_200_with_an_error_envelope_is_a_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The bug this guards: response.ok is True here. Only the in-body status_code
+    # says it failed.
+    _wire(monkeypatch, _publish_then(_NOT_FOUND))
+    with pytest.raises(app.TenantAppError, match="404"):
+        app.install(_install_args(install_retry_seconds=0))
+
+
+def test_install_retries_while_lm_catalog_catches_up(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A fresh publish is not immediately installable; the retry covers the lag."""
+    transport = _wire(
+        monkeypatch,
+        _publish_then(_NOT_FOUND, _NOT_FOUND, _ok({"deployment_id": "d1"})),
+    )
+    outcome = app.install(_install_args(install_retry_seconds=600))
+    assert outcome.deployment_id == "d1"
+    assert len([p for p in transport.paths("POST") if "/install" in p]) == 3
+
+
+def test_retry_budget_is_respected_and_the_error_explains_the_lag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _wire(monkeypatch, _publish_then(_NOT_FOUND))
+    with pytest.raises(app.TenantAppError) as excinfo:
+        app.install(_install_args(install_retry_seconds=0))
+    assert "snapshot" in str(excinfo.value) and "--install-retry-seconds" in str(
+        excinfo.value
+    )
+
+
+def test_already_installed_is_a_no_op_not_a_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # LM starts no deployment in this case, so there is nothing to poll; the
+    # version read-back is what decides success.
+    transport = _wire(
+        monkeypatch,
+        _publish_then(_install_reply("success", 200, "App already installed")),
+    )
+    outcome = app.install(_install_args())
+    assert outcome.deployment_id == ""
+    assert outcome.installed_version == _VERSION
+    assert not any("/deployments/" in p for p in transport.paths("GET"))
+
+
+def test_success_without_a_deployment_id_still_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Not "already installed", not an error, but nothing to poll either — that is
+    # unexplained, and must not read as a completed install.
+    _wire(monkeypatch, _publish_then(_install_reply("success", 200, "queued")))
+    with pytest.raises(app.TenantAppError, match="no deployment_id"):
+        app.install(_install_args())
+
+
+@pytest.mark.parametrize(
+    "code, message, expected_not_found",
+    [
+        (404, "App with ID 'x' not found: y", True),
+        (200, "App with ID 'x' not found: y", True),
+        (500, "internal error", False),
+        (200, "App already installed", False),
+    ],
+)
+def test_not_found_detection(code: int, message: str, expected_not_found: bool) -> None:
+    reply = app._InstallReply.parse(_install_reply("error", code, message))
+    assert reply.not_found is expected_not_found
 
 
 # ── Version extraction across LM shapes ──────────────────────────────────────

--- a/.github/scripts/tests/test_e2e_tenant_install_workflow.py
+++ b/.github/scripts/tests/test_e2e_tenant_install_workflow.py
@@ -68,6 +68,7 @@ def test_inputs_used_by_scripts_arrive_through_env(workflow: dict) -> None:
             # source_repo on file, and LM does not expose the registered value.
             "REPO_URL",
             "SCAN_WAIT_SECONDS",
+            "INSTALL_RETRY_SECONDS",
             "TIMEOUT_SECONDS",
         },
         "Verify the tenant reports the installed version": {"APP_ID", "VERSION"},

--- a/.github/workflows/e2e-tenant-install.yaml
+++ b/.github/workflows/e2e-tenant-install.yaml
@@ -78,6 +78,17 @@ on:
         required: false
         type: string
         default: "0"
+      install_retry_seconds:
+        description: >-
+          How long to keep retrying the install while LM's tenant-catalog
+          snapshot catches up with the fresh publish. LM excludes a release while
+          it is scan_pending and only picks it up on the next scheduled sync
+          (~5 min), so a just-published release is not immediately installable.
+          Waiting on GM's release status is NOT enough — a run that read `active`
+          from GM still had its install miss. 0 disables the retry.
+        required: false
+        type: string
+        default: "600"
       timeout_seconds:
         description: "Budget for the deployment to reconcile before failing."
         required: false
@@ -161,6 +172,7 @@ jobs:
           BRANCH: ${{ inputs.branch }}
           REPO_URL: ${{ inputs.repo_url }}
           SCAN_WAIT_SECONDS: ${{ inputs.scan_wait_seconds }}
+          INSTALL_RETRY_SECONDS: ${{ inputs.install_retry_seconds }}
           TIMEOUT_SECONDS: ${{ inputs.timeout_seconds }}
         run: |
           set -euo pipefail
@@ -173,6 +185,7 @@ jobs:
             --repo-url "$REPO_URL" \
             --tenant "$SDR_TEST_TENANT" \
             --scan-wait-seconds "$SCAN_WAIT_SECONDS" \
+            --install-retry-seconds "$INSTALL_RETRY_SECONDS" \
             --timeout-seconds "$TIMEOUT_SECONDS"
 
       # Independent read-back through the same check the e2e legs will run, so a

--- a/.github/workflows/tests-reusable.yaml
+++ b/.github/workflows/tests-reusable.yaml
@@ -969,6 +969,14 @@ jobs:
             --entrypoints "$ENTRYPOINTS" \
             --release-model "$RELEASE_MODEL" \
             --created-by "$CREATED_BY"
+        # --install-retry-seconds is left at its default (600). A freshly
+        # published release is not immediately installable: LM resolves the
+        # install against its tenant-catalog snapshot, which excludes a release
+        # while it is scan_pending and picks it up on the next scheduled sync
+        # (~5 min). Worst case here is therefore ~10 min of install retry plus
+        # ~10 min of deployment polling — keep this job's timeout-minutes above
+        # the sum of the two, or a slow sync reads as a job timeout instead of
+        # the actionable error the script would otherwise raise.
 
       - name: Summarise
         if: always()


### PR DESCRIPTION
### Changelog

- Treat LM's **in-body** `status_code` as authoritative — it answers HTTP 200 with an error-shaped envelope.
- Retry the install while LM's tenant-catalog snapshot catches up (`--install-retry-seconds`, default 600).
- Read `detail` as well as `message`, so a genuine HTTP 4xx keeps its text.
- `"App already installed"` is a success with nothing to poll.
- 9 new tests.

### This answers FND-31 spike (b) — but not in the shape predicted

The third live run reached the install for the first time:

```
publishing with repo=https://github.com/atlanhq/atlan-openapi-app
registered version_id=019fd678-… release_id=019fd678-…
release status at install time: active
```

…then returned keys `['message','status','status_code']` and no `deployment_id`.

**GM does not refuse the install. LM cannot see the release yet.** Two findings from `marketplace_api/v1/router.py`:

**1. LM answers HTTP 200 with an error-shaped envelope**

```python
{"status": "error",   "message": "App with ID '…' not found: …", "status_code": 404}
{"status": "success", "message": "App already installed",        "status_code": 200}
```

So `response.ok` reads a 404 as success — a correctness bug independent of this incident. The in-body `status_code` is authoritative now.

Ours must be the 404: the "already installed" branch is gated on `not force_install`, and we send `force_install: true`. LM had already refreshed once inline and still couldn't resolve it.

**2. Why it 404s is documented against that very route**

> a release created via `POST /publish` starts `scan_pending`… excluded from GM's tenant catalog… does not enter the snapshot until the next scheduled sync (**~5 min**)

So the scan gate *does* bite — one layer below where I was looking.

**Waiting on GM's release status is not sufficient.** This run read `active` straight from GM and the install still missed, because install resolves against **LM's snapshot**, not GM. So `--scan-wait-seconds` stays `0` (a base-image CVE must not red an unrelated PR) and the retry goes on the install itself.

### Three more defects, found while making that testable

- **`detail` vs `message`.** A real HTTP 4xx carries `detail` (Heracles/FastAPI); LM's 200-envelope carries `message`. Parsing only `message` dropped the text from genuine errors and silently disabled the scan-gate hint. Caught because an existing test started failing — I fixed the parser rather than the test.
- **`"App already installed"`** starts no deployment, so polling one would hang until timeout. Now skipped, with the version read-back as the authority.
- **success + no `deployment_id` + not "already installed"** stays an error. Unexplained is not the same as fine, and must not read as a completed install.

### Blast radius

`prepare-tenant` picks up the retry via the default. A comment there ties the job's `timeout-minutes` to the retry + poll budget, so a slow sync surfaces as the script's actionable error rather than an opaque job timeout.

### Checklist

- [x] Additional tests added
- [ ] All CI checks passed
- [ ] Relevant documentation updated <!-- connector-ci-e2e.md lands with the turn-on -->

Local: 1225 script tests pass; `pre-commit run --all-files` clean with no hook modifications.

---

### Copyleft License Compliance

- [ ] Have you used any code that is subject to a Copyleft license (e.g., GPL, AGPL, LGPL)?
- [ ] If yes, have you modified the code in the context of this project? please share additional details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
