### PR TITLE
ci(harbor-release): publish app-runtime-base to GHCR alongside Harbor

### DIFF
--- a/.github/workflows/harbor-release.yaml
+++ b/.github/workflows/harbor-release.yaml
@@ -73,8 +73,17 @@ jobs:
           #   - ghcr.io            : base for our own app CI. Harbor 307-redirects blobs
           #                          to S3, so every internal base pull bills as S3
           #                          DataTransfer-Out; GHCR pulls from GitHub-hosted
-          #                          runners are free. Same digest => the Trivy/Snyk gate
-          #                          and provenance cover the artifact both registries serve.
+          #                          runners are free. One push => both registries
+          #                          reference an identical manifest, so provenance and
+          #                          the Trivy report from secure-build-push-apps describe
+          #                          the same artifact wherever it is pulled from. That
+          #                          report is advisory and amd64-only (the action scans a
+          #                          separate single-platform build and runs in feedback
+          #                          mode) — it is not a gate on either registry.
+          # The push is NOT transactional across registries: if the GHCR leg fails after
+          # the Harbor names have landed, re-run this workflow run rather than cutting a
+          # new release — every tag is re-pushed to both registries, so the floating
+          # aliases cannot stay skewed. See docs/standards/build-security.md.
           REPOS="registry.atlan.com/public/app-runtime-base ghcr.io/atlanhq/app-runtime-base"
           : > /tmp/tags.txt
           for REPO in $REPOS; do

--- a/.github/workflows/harbor-release.yaml
+++ b/.github/workflows/harbor-release.yaml
@@ -68,27 +68,38 @@ jobs:
         run: |
           MAJOR=$(echo "$VERSION" | cut -d. -f1)
           MINOR=$(echo "$VERSION" | cut -d. -f1-2)
-          if [ "$EVENT_NAME" = "release" ] && echo "$VERSION" | grep -qvF '-'; then
-            # Stable release: publish full alias ladder (exact, minor, major, latest) + immutable sha
-            printf '%s\n' \
-              "registry.atlan.com/public/app-runtime-base:latest" \
-              "registry.atlan.com/public/app-runtime-base:${VERSION}" \
-              "registry.atlan.com/public/app-runtime-base:${MINOR}" \
-              "registry.atlan.com/public/app-runtime-base:${MAJOR}" \
-              "registry.atlan.com/public/app-runtime-base:sha-${SHA}" > /tmp/tags.txt
-          elif [ "$EVENT_NAME" = "release" ]; then
-            # Pre-release (rc/alpha/beta): exact version + sha only — no aliases that could
-            # cause :latest or major/minor tags to point at a non-stable image
-            printf '%s\n' \
-              "registry.atlan.com/public/app-runtime-base:${VERSION}" \
-              "registry.atlan.com/public/app-runtime-base:sha-${SHA}" > /tmp/tags.txt
-          else
-            # workflow_dispatch: prefix-scoped tags for branch/dev builds
-            printf '%s\n' \
-              "registry.atlan.com/public/app-runtime-base:${PREFIX}-latest" \
-              "registry.atlan.com/public/app-runtime-base:${PREFIX}-${VERSION}" \
-              "registry.atlan.com/public/app-runtime-base:sha-${SHA}" > /tmp/tags.txt
-          fi
+          # Publish the SAME digest to both registries in one buildx push:
+          #   - registry.atlan.com : external/partner + tenant distribution (S3-backed)
+          #   - ghcr.io            : base for our own app CI. Harbor 307-redirects blobs
+          #                          to S3, so every internal base pull bills as S3
+          #                          DataTransfer-Out; GHCR pulls from GitHub-hosted
+          #                          runners are free. Same digest => the Trivy/Snyk gate
+          #                          and provenance cover the artifact both registries serve.
+          REPOS="registry.atlan.com/public/app-runtime-base ghcr.io/atlanhq/app-runtime-base"
+          : > /tmp/tags.txt
+          for REPO in $REPOS; do
+            if [ "$EVENT_NAME" = "release" ] && echo "$VERSION" | grep -qvF '-'; then
+              # Stable release: publish full alias ladder (exact, minor, major, latest) + immutable sha
+              printf '%s\n' \
+                "${REPO}:latest" \
+                "${REPO}:${VERSION}" \
+                "${REPO}:${MINOR}" \
+                "${REPO}:${MAJOR}" \
+                "${REPO}:sha-${SHA}" >> /tmp/tags.txt
+            elif [ "$EVENT_NAME" = "release" ]; then
+              # Pre-release (rc/alpha/beta): exact version + sha only — no aliases that could
+              # cause :latest or major/minor tags to point at a non-stable image
+              printf '%s\n' \
+                "${REPO}:${VERSION}" \
+                "${REPO}:sha-${SHA}" >> /tmp/tags.txt
+            else
+              # workflow_dispatch: prefix-scoped tags for branch/dev builds
+              printf '%s\n' \
+                "${REPO}:${PREFIX}-latest" \
+                "${REPO}:${PREFIX}-${VERSION}" \
+                "${REPO}:sha-${SHA}" >> /tmp/tags.txt
+            fi
+          done
           DELIM=$(openssl rand -hex 8)
           { echo "value<<${DELIM}"; cat /tmp/tags.txt; echo "${DELIM}"; } >> "$GITHUB_OUTPUT"
 
@@ -98,6 +109,13 @@ jobs:
           registry: registry.atlan.com
           username: ${{ secrets.HARBOR_USERNAME }}
           password: ${{ secrets.HARBOR_PASSWORD }}
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.ORG_PAT_GITHUB }}
 
       - name: Log in to Chainguard Container Registry
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4

--- a/README.md
+++ b/README.md
@@ -53,8 +53,10 @@ docker pull registry.atlan.com/public/app-runtime-base:3.3.0
 docker pull registry.atlan.com/public/app-runtime-base:sha-49c027f
 ```
 
+Every release also publishes the **same digest** to GHCR at `ghcr.io/atlanhq/app-runtime-base`, with the same tag ladder. That mirror exists for Atlan's own app CI — GHCR pulls from GitHub-hosted runners avoid the S3 egress that a Harbor pull incurs — and is byte-identical to the Harbor image for a given tag.
+
 > [!NOTE]
-> Push-to-`main` CI builds are published to GHCR (`ghcr.io/atlanhq/app-runtime-base-main:sha-<sha7>`) and are intended for internal development use only. Use a versioned Harbor tag for app Dockerfiles.
+> Use `registry.atlan.com/public/app-runtime-base` in app Dockerfiles: it is the reference for external/partner and tenant use. The GHCR mirror above is for internal CI. Separately, push-to-`main` builds go to `ghcr.io/atlanhq/app-runtime-base-main:sha-<sha7>` (note the `-main` suffix — a different package) and are unversioned dev images, for internal development only.
 
 ## Contributing
 

--- a/docs/standards/build-security.md
+++ b/docs/standards/build-security.md
@@ -7,7 +7,36 @@
 - **Image base**: `cgr.dev/chainguard-private/python` -> golden images -> SDK -> apps
 - **Dapr runtime**: baked into the `app-framework-golden` base image via Chainguard Custom Assembly (0 CVEs). The container's daprd version is owned by the Custom Assembly config — the Dockerfile no longer installs it. (The `__dapr_version` pin in `application_sdk/version.py` governs only the local-dev auto-download, a separate path.)
 - **Dapr component YAMLs**: shipped inside the `atlan-application-sdk` wheel at `application_sdk/components/` (see `[tool.hatch.build.targets.wheel.force-include]` in `pyproject.toml`, mirroring this repo's own `components/` dir). Consumer apps get them for free from their existing `atlan-application-sdk` dependency — no network download needed, and they're always in sync with whatever SDK version is locked in that app's `uv.lock`.
-- **Registries**: Harbor (`registry.atlan.com`) for production, GHCR for CI
+- **Registries**: Harbor (`registry.atlan.com`) for production, GHCR for CI — see [Base image registries](#base-image-registries)
+
+## Base image registries
+
+`app-runtime-base` is published to two registries from a single `docker buildx --push`
+in `.github/workflows/harbor-release.yaml`, so both carry an **identical manifest digest**
+for a given tag:
+
+| Registry | Ref | Audience |
+|---|---|---|
+| Harbor | `registry.atlan.com/public/app-runtime-base` | External/partner and tenant distribution. The reference for app Dockerfiles. |
+| GHCR | `ghcr.io/atlanhq/app-runtime-base` | Atlan's own app CI only. |
+
+The GHCR mirror is a cost measure, not a second source of truth. Harbor is S3-backed with
+blob redirects on, so a base-image pull 307s to a presigned S3 URL and bills as
+`DataTransfer-Out`; GHCR pulls from GitHub-hosted runners are free. Because both refs
+resolve to the same digest, an app can be pointed at either without changing what it
+builds on.
+
+### If a release publish fails partway
+
+The push is not transactional across registries — buildkit pushes each name in sequence.
+A GHCR-side failure (PAT rotation, GHCR incident) can therefore fail the job *after* the
+Harbor tags have landed, leaving the floating aliases (`:latest`, `:MAJOR`, `:MAJOR.MINOR`)
+advanced on Harbor but not on GHCR.
+
+**Recovery: re-run the failed workflow run** (Actions → the failed run → *Re-run jobs*).
+Do not cut a new release. Every tag is re-pushed to both registries from one build, so the
+re-run restores parity; the tags are mutable, so the operation is idempotent. Cutting a new
+release instead would leave the skipped version permanently absent from GHCR.
 
 ## Consuming Dapr components in an app repo
 


### PR DESCRIPTION
Relates to DISTR-898.

## Why

Harbor is S3-backed and runs with blob redirects on, so a base-image pull returns **HTTP 307 to a presigned S3 URL** — the client downloads straight from S3 and it bills as `DataTransfer-Out`. The bytes never traverse Harbor, which is why nothing in the registry's own metrics shows it.

Two releases on Aug 3 (`3.26.0`) and Aug 4 (`3.26.1`) repointed the moving `:3` tag, invalidating the build cache of ~96 apps twice in 48h. S3 egress on `prod-apps-platform` went `~$6/day → $16.34 → $20.45`, and the account tripped its $50 budget alert two days running ($55.04, then $61.35).

Harbor's own metrics confirm the attribution — only the `public` project's pull count moved (2,390 → 3,710 → 4,425), every other project flat to the unit.

## What this PR does

Publishes the **same digest** to GHCR in the same buildx push — one build, one Snyk/Trivy gate, two registries. GHCR pulls from GitHub-hosted runners are free.

Note GHCR already receives this image today via `build-image.yaml`, but only as `app-runtime-base-<branch>:sha-<sha>` (one per main commit, dev-grade). This adds the **release ladder** under a clean `app-runtime-base` package, which is what apps can actually consume.

**Purely additive.** Harbor keeps every tag it has today; no consumer changes behaviour when this merges.

## Validation

| Check | Result |
|---|---|
| Publish run on this branch | [31084180972](https://github.com/atlanhq/application-sdk/actions/runs/31084180972) — success |
| Digest parity Harbor vs GHCR | identical — `sha256:4061fcff8df26233df1ccfaf2388fcb4c8eb945b1ca565be8900f6a744ad2029` |
| App pulls base from GHCR | [31084549961](https://github.com/atlanhq/atlan-publish-app/actions/runs/31084549961) — success |
| Works with GHCR package **private** | yes — existing `ORG_PAT_GITHUB` login suffices, no visibility change |
| Redirect via `build-contexts`, Dockerfile untouched | [31087716300](https://github.com/atlanhq/atlan-publish-app/actions/runs/31087716300) — success, multi-arch + Trivy green |

The `workflow_dispatch` test path emits only prefix-scoped tags, so `:3` / `:3.26` / `:latest` were never touched during validation.

## Follow-up, in order

1. Merge this.
2. **A real release must run** — `:3` only reaches GHCR on `release: published`; `workflow_dispatch` takes the prefix path.
3. Then a second PR adds one line to `build-and-publish-app.yaml`:
   ```yaml
   build-contexts: |
     registry.atlan.com/public/app-runtime-base:3=docker-image://ghcr.io/atlanhq/app-runtime-base:3
   ```
   That redirects **96 repos with zero Dockerfile changes** (validated above). 3 apps run their own build path and need direct edits: `atlan-data-product-score-app`, `atlan-policy-manager-app`, `atlan-user-admin-app`.
4. Dockerfile migration to explicit `FROM ghcr.io/…` at whatever pace, then drop the shim.

Landing 2 before a release seeds `:3` would break every app build on a missing tag — hence two PRs.

## Cleanup owed

Validation left `ghcr-test-latest`, `ghcr-test-3.26.1`, `sha-…` in Harbor's production `public` project (prefix-scoped, no consumer affected) and matching tags in GHCR. Both should be deleted.

## Not addressed here

`:3` stays a moving tag — deliberate, per the thread. Apps still re-pull on each release; it just costs nothing from GHCR.
