### PR TITLE
ci(e2e): scope releases by tenant ID, not tenant hostname

### DIFF
--- a/.github/scripts/e2e_tenant_api.py
+++ b/.github/scripts/e2e_tenant_api.py
@@ -132,6 +132,42 @@ def validate_tenant_base_url(base_url: str) -> str:
     return candidate
 
 
+def validate_tenant_id(tenant_id: str) -> str:
+    """Return the tenant ID, or raise if it looks like a hostname.
+
+    ``allowed_tenants`` scopes a GM release, and GM matches it EXACTLY against
+    the tenant's own id — the **vcluster instance name** (``markeznp37``,
+    ``home-mt``), which Heracles reads from the ``atlan-defaults`` ConfigMap key
+    ``instance`` (``heracles/handler/marketplace.go``). It is deliberately not
+    taken from the JWT: the Keycloak realm is ``default`` for every tenant.
+
+    A hostname (``e2e-azure-main.atlan.com``) is therefore silently wrong: the
+    publish succeeds, the release is created, and it is visible to NO tenant —
+    so the install fails later with "version not found" and a list of the
+    versions the tenant *can* see. That took three live runs to diagnose; this
+    turns it into an immediate, actionable error.
+
+    The check is deliberately narrow (a dot or a scheme), because tenant ids are
+    otherwise free-form vcluster names and a stricter pattern would reject valid
+    ones.
+    """
+    value = tenant_id.strip()
+    if not value:
+        raise TenantApiError(
+            "no tenant id given. `allowed_tenants` needs the tenant's ID (its "
+            "vcluster instance name, e.g. 'markeznp37'), not its hostname."
+        )
+    if "." in value or "://" in value:
+        raise TenantApiError(
+            f"tenant id {value!r} looks like a hostname. GM matches "
+            "`allowed_tenants` against the tenant's vcluster instance name (e.g. "
+            "'markeznp37'), so a hostname produces a release visible to no "
+            "tenant — the publish succeeds and the install then fails with "
+            "'version not found'. Pass the tenant ID."
+        )
+    return value
+
+
 def validate_app_id(app_id: str) -> str:
     """Return ``app_id`` when it has the GM UUID shape, or raise.
 

--- a/.github/scripts/e2e_tenant_api.py
+++ b/.github/scripts/e2e_tenant_api.py
@@ -90,6 +90,12 @@ _APP_ID_RE = re.compile(
     r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-" r"[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
 )
 
+#: Host suffixes a tenant ID must not carry. Vcluster instance names are DNS
+#: subdomains and may legally contain dots (``team.a``), so "contains a dot" is
+#: too broad a check; what is never legitimate is a scheme or one of the known
+#: Atlan host suffixes, which only ever appear on a hostname.
+_ATLAN_HOST_SUFFIXES = (".atlan.com", ".atlan.dev")
+
 
 class TenantApiError(RuntimeError):
     """A tenant call failed in a way the caller cannot recover from.
@@ -147,9 +153,10 @@ def validate_tenant_id(tenant_id: str) -> str:
     versions the tenant *can* see. That took three live runs to diagnose; this
     turns it into an immediate, actionable error.
 
-    The check is deliberately narrow (a dot or a scheme), because tenant ids are
-    otherwise free-form vcluster names and a stricter pattern would reject valid
-    ones.
+    The check is deliberately narrow (a scheme, or a known Atlan host suffix),
+    because tenant ids are otherwise free-form vcluster names — which are DNS
+    subdomains and may legally contain dots (``team.a``) — and a stricter
+    pattern would reject valid ones.
     """
     value = tenant_id.strip()
     if not value:
@@ -164,7 +171,7 @@ def validate_tenant_id(tenant_id: str) -> str:
             "one-off run, and that is the only option on the single-tenant "
             "fallback path, which carries no matrix entry to add the field to."
         )
-    if "." in value or "://" in value:
+    if "://" in value or value.endswith(_ATLAN_HOST_SUFFIXES):
         raise TenantApiError(
             f"tenant id {value!r} looks like a hostname. GM matches "
             "`allowed_tenants` against the tenant's vcluster instance name (e.g. "

--- a/.github/scripts/e2e_tenant_api.py
+++ b/.github/scripts/e2e_tenant_api.py
@@ -154,8 +154,15 @@ def validate_tenant_id(tenant_id: str) -> str:
     value = tenant_id.strip()
     if not value:
         raise TenantApiError(
-            "no tenant id given. `allowed_tenants` needs the tenant's ID (its "
-            "vcluster instance name, e.g. 'markeznp37'), not its hostname."
+            "no tenant id given. `allowed_tenants` needs the tenant's ID — its "
+            "vcluster instance name, e.g. 'markeznp37' — not its hostname.\n"
+            "Where it comes from: a `tenant_id` field on this cloud's entry in "
+            "the E2E_TENANT_MATRIX_JSON secret, which the e2e tenant resolver "
+            "exports as E2E_TENANT_ID. Add it there (alongside `tenant`, "
+            "`client_id`, `client_secret`, `api_key`) to enable the install path. "
+            "The E2E Tenant Install workflow also takes a `tenant_id` input for a "
+            "one-off run, and that is the only option on the single-tenant "
+            "fallback path, which carries no matrix entry to add the field to."
         )
     if "." in value or "://" in value:
         raise TenantApiError(

--- a/.github/scripts/e2e_tenant_app.py
+++ b/.github/scripts/e2e_tenant_app.py
@@ -87,6 +87,7 @@ from e2e_tenant_api import (
     path_segment,
     validate_app_id,
     validate_tenant_base_url,
+    validate_tenant_id,
 )
 from marketplace_publish_body import PublishBodyError, PublishRequest, build
 
@@ -824,7 +825,7 @@ def install(args: argparse.Namespace) -> InstallOutcome:
         repo_url=repo_url,
         # The whole registration is scoped to this one tenant, so a per-PR build
         # can never become visible to a real one.
-        allowed_tenants=(args.tenant,),
+        allowed_tenants=(validate_tenant_id(args.tenant),),
         deploy_config=args.deploy_config,
         self_deployed_runtime=args.self_deployed_runtime,
         sdk_version=args.sdk_version,
@@ -936,7 +937,13 @@ def main(argv: list[str] | None = None) -> int:
     )
     p_install.add_argument("--branch", required=True)
     p_install.add_argument(
-        "--tenant", required=True, help="tenant id for allowed_tenants scoping"
+        "--tenant",
+        required=True,
+        help=(
+            "The tenant's ID for allowed_tenants scoping — its vcluster instance "
+            "name (e.g. 'markeznp37'), NOT its hostname. GM matches this exactly; "
+            "a hostname yields a release visible to no tenant."
+        ),
     )
     p_install.add_argument("--repo-url", default="")
     p_install.add_argument("--deploy-config", default="")

--- a/.github/scripts/e2e_tenant_app.py
+++ b/.github/scripts/e2e_tenant_app.py
@@ -51,11 +51,16 @@ would red every leg of an unrelated PR, and release is gated separately. So the
 default here is ``--scan-wait-seconds 0`` — install immediately, report whatever
 the scan status happens to be.
 
-Whether GM *accepts* an install of a still-``scan_pending`` release is an open
-question at the time of writing (FND-31 spike (b)); the first live run of this
-script answers it. If GM rejects it, :func:`_looks_like_scan_gate` recognises
-the rejection and the error names the fix — raise ``--scan-wait-seconds`` — so
-the failure is self-explaining rather than an opaque 4xx.
+Answered empirically (FND-31 spike (b)), and not in the shape expected: GM does
+not refuse the install. The constraint is one layer down — **LM cannot see the
+release yet**. LM resolves an install against its own tenant-catalog snapshot,
+which excludes a release while it is ``scan_pending`` and only picks it up on the
+next scheduled sync (~5 min). A run that read ``active`` straight from GM still
+had its install miss, so waiting on GM's release status is not sufficient.
+
+Hence ``--install-retry-seconds`` (default 600): the install itself is retried
+while LM catches up. ``--scan-wait-seconds`` stays at 0 — waiting on the scan
+would not have helped, and a base-image CVE must not red an unrelated PR.
 """
 
 from __future__ import annotations
@@ -95,6 +100,8 @@ _SCAN_FAILED = "scan_failed"
 
 _DEPLOY_POLL_SECONDS = 10
 _SCAN_POLL_SECONDS = 10
+#: Gap between install retries while LM's catalog snapshot catches up.
+_INSTALL_RETRY_POLL_SECONDS = 20
 
 #: Keys an install/info response may carry the installed version under. LM has
 #: not committed to one name across versions, so check the plausible set rather
@@ -444,6 +451,20 @@ def _looks_like_cicd_managed(response: Response) -> bool:
     return "managed by ci/cd" in rendered or "cicd_managed" in rendered
 
 
+def _looks_like_scan_gate_text(text: str) -> bool:
+    """Scan-gate detection over a plain message string.
+
+    LM reports its outcome in the body rather than the HTTP status, so the
+    install path matches on the message while the publish path still matches on
+    a whole response.
+    """
+    lowered = text.lower()
+    return any(
+        marker in lowered
+        for marker in (_SCAN_PENDING, _SCAN_FAILED, "scan", "not active", "draft")
+    )
+
+
 def _looks_like_scan_gate(response: Response) -> bool:
     """True when a failed install looks like GM's release-scan gate refusing.
 
@@ -540,37 +561,147 @@ def _publish(client: TenantClient, request: PublishRequest) -> tuple[str, str]:
     return version_id, release_id
 
 
-def _install(client: TenantClient, app_id: str, version_id: str, scan_hint: str) -> str:
-    """Trigger the install. Returns the deployment id."""
-    response = client.post(
-        INSTALL_PATH.format(app_id=path_segment(app_id)),
-        body={"version_id": version_id, "force_install": True},
-    )
-    if not response.ok:
+@dataclass(frozen=True)
+class _InstallReply:
+    """LM's install response, whose HTTP status is not the whole story.
+
+    ``POST /tenant/default/apps/{id}/install`` answers **HTTP 200 with an
+    error-shaped envelope** for its two non-deploying outcomes
+    (``atlan-local-marketplace-app``, ``marketplace_api/v1/router.py``)::
+
+        {"status": "error",   "message": "App with ID '…' not found: …", "status_code": 404}
+        {"status": "success", "message": "App already installed",        "status_code": 200}
+
+    So ``response.ok`` alone would read a 404 as a success. The in-body
+    ``status_code`` is authoritative and is what this parses.
+    """
+
+    http_status: int
+    status: str
+    status_code: int
+    message: str
+    deployment_id: str
+    rendered_body: str
+
+    @classmethod
+    def parse(cls, response: Response) -> _InstallReply:
+        data = response.data() if isinstance(response.body, dict) else {}
+        raw_code = data.get("status_code")
+        # `message` is LM's 200-envelope field; `detail` is what Heracles/FastAPI
+        # put on a real HTTP error. Both have to be read, or a genuine 4xx loses
+        # its text and the failure stops being self-explaining.
+        message = str(data.get("message") or data.get("detail") or "").strip()
+        return cls(
+            http_status=response.status,
+            status=str(data.get("status") or "").strip().lower(),
+            # Fall back to the HTTP status when LM omits its own.
+            status_code=raw_code if isinstance(raw_code, int) else response.status,
+            message=message,
+            deployment_id=str(data.get("deployment_id") or ""),
+            rendered_body=_render_body(response.body),
+        )
+
+    @property
+    def failed(self) -> bool:
+        return self.status == "error" or self.status_code >= 400 or not self.http_ok
+
+    @property
+    def http_ok(self) -> bool:
+        return 200 <= self.http_status < 300
+
+    @property
+    def not_found(self) -> bool:
+        """The release is not resolvable in LM's tenant-catalog snapshot yet."""
+        return self.status_code == 404 or "not found" in self.message.lower()
+
+    @property
+    def already_installed(self) -> bool:
+        return not self.failed and "already installed" in self.message.lower()
+
+
+def _install(
+    client: TenantClient,
+    app_id: str,
+    version_id: str,
+    scan_hint: str,
+    *,
+    retry_seconds: int,
+) -> str:
+    """Trigger the install, tolerating LM's catalog-snapshot lag.
+
+    Returns the deployment id, or "" when LM reports the app is already
+    installed (it does not start a deployment, so there is nothing to poll).
+
+    The retry exists because a freshly published release is not immediately
+    installable, which LM documents against this very route: a release created
+    via ``POST /publish`` starts ``scan_pending`` and is excluded from GM's tenant
+    catalog, the publish-time refresh runs while it is still ``scan_pending``, and
+    it therefore does not enter LM's snapshot until the next scheduled sync
+    (~5 min). LM refreshes once inline on a miss, but that refresh can itself race
+    the flip to ``active``.
+
+    Waiting on GM's release status is NOT sufficient: the first run to get this
+    far read ``active`` from GM and the install still missed, because what install
+    resolves against is LM's snapshot, not GM.
+    """
+    deadline = time.monotonic() + max(retry_seconds, 0)
+    attempt = 0
+    while True:
+        attempt += 1
+        reply = _InstallReply.parse(
+            client.post(
+                INSTALL_PATH.format(app_id=path_segment(app_id)),
+                body={"version_id": version_id, "force_install": True},
+            )
+        )
+
+        if reply.already_installed:
+            print(f"LM reports the app already installed: {reply.message}")
+            return ""
+
+        if not reply.failed and reply.deployment_id:
+            return reply.deployment_id
+
+        if not reply.failed:
+            raise TenantAppError(
+                "install reported success but carried no deployment_id, so the "
+                f"deployment cannot be polled. message={reply.message!r} "
+                f"status={reply.status!r} status_code={reply.status_code}"
+            )
+
+        # Retryable: LM cannot see the release yet.
+        if reply.not_found and time.monotonic() < deadline:
+            remaining = int(deadline - time.monotonic())
+            print(
+                f"attempt {attempt}: LM cannot resolve the release yet "
+                f"({reply.message or 'not found'}) — its catalog snapshot lags a "
+                f"fresh publish by up to ~5 min; retrying for {remaining}s"
+            )
+            time.sleep(_INSTALL_RETRY_POLL_SECONDS)
+            continue
+
         hint = ""
-        if _looks_like_scan_gate(response):
+        if reply.not_found:
             hint = (
-                " This looks like GM's release-scan gate refusing a release that "
-                "has not finished scanning. e2e deliberately does not wait for "
-                "the scan (a base-image CVE must not red an unrelated PR); if GM "
-                "requires it, re-run with --scan-wait-seconds set."
-                + (
-                    f" Release status at install time: {scan_hint}."
-                    if scan_hint
-                    else ""
-                )
+                " LM never saw the release. Its tenant-catalog snapshot excludes a "
+                "release while it is scan_pending and only picks it up on the next "
+                "scheduled sync (~5 min), so a fresh publish is not immediately "
+                "installable. Raise --install-retry-seconds if the sync is slower "
+                "than the current budget."
+                + (f" GM release status was {scan_hint!r}." if scan_hint else "")
+            )
+        elif _looks_like_scan_gate_text(reply.message):
+            hint = (
+                " This looks like GM's release-scan gate. e2e deliberately does "
+                "not wait for the scan (a base-image CVE must not red an unrelated "
+                "PR); re-run with --scan-wait-seconds set if it is required."
             )
         raise TenantAppError(
-            f"install failed with HTTP {response.status}.{hint}\n"
-            f"response={_render_body(response.body)}"
+            f"install failed after {attempt} attempt(s): "
+            f"status={reply.status!r} status_code={reply.status_code} "
+            f"message={reply.message!r} (HTTP {reply.http_status}).{hint}\n"
+            f"response={reply.rendered_body}"
         )
-    deployment_id = str(response.data().get("deployment_id") or "")
-    if not deployment_id:
-        raise TenantAppError(
-            "install response carried no deployment_id, so the deployment cannot "
-            f"be polled (keys: {sorted(response.data())})"
-        )
-    return deployment_id
 
 
 def _poll_deployment(client: TenantClient, deployment_id: str, timeout: int) -> None:
@@ -717,14 +848,26 @@ def install(args: argparse.Namespace) -> InstallOutcome:
             "(not waiting for the scan by design)"
         )
 
-    deployment_id = _install(publish_client, app_id, version_id, status)
-    print(f"install accepted, deployment_id={deployment_id}")
-
-    try:
-        _poll_deployment(read_client, deployment_id, args.timeout_seconds)
-    except TenantAppError:
-        _dump_failure(read_client, app_id)
-        raise
+    deployment_id = _install(
+        publish_client,
+        app_id,
+        version_id,
+        status,
+        retry_seconds=args.install_retry_seconds,
+    )
+    # An empty deployment_id means LM reported the app already installed and
+    # started no deployment, so there is nothing to poll. The version read-back
+    # below is then the only thing that decides success — which is the right
+    # authority anyway.
+    if deployment_id:
+        print(f"install accepted, deployment_id={deployment_id}")
+        try:
+            _poll_deployment(read_client, deployment_id, args.timeout_seconds)
+        except TenantAppError:
+            _dump_failure(read_client, app_id)
+            raise
+    else:
+        print("no deployment started; relying on the version read-back below")
 
     installed = _installed_version(read_client, app_id)
     print(f"tenant reports installed version: {installed or '<unreported>'}")
@@ -811,6 +954,18 @@ def main(argv: list[str] | None = None) -> int:
             "Seconds to wait for GM's release scan before installing. 0 (the "
             "default) does not wait: a base-image CVE must not red an unrelated "
             "PR's e2e. Raise only if GM refuses to install an unscanned release."
+        ),
+    )
+    p_install.add_argument(
+        "--install-retry-seconds",
+        type=int,
+        default=600,
+        help=(
+            "How long to keep retrying the install while LM's tenant-catalog "
+            "snapshot catches up with a fresh publish. LM excludes a release "
+            "while it is scan_pending and picks it up on the next scheduled sync "
+            "(~5 min), so a just-published release is not immediately "
+            "installable. 0 disables the retry."
         ),
     )
     p_install.add_argument(

--- a/.github/scripts/e2e_tenant_app.py
+++ b/.github/scripts/e2e_tenant_app.py
@@ -104,6 +104,15 @@ _SCAN_POLL_SECONDS = 10
 #: Gap between install retries while LM's catalog snapshot catches up.
 _INSTALL_RETRY_POLL_SECONDS = 20
 
+#: The two waits this script can spend, as module constants rather than argparse
+#: literals, because a caller's job `timeout-minutes` has to stay above their sum:
+#: if the runner's timeout fires first, a slow LM sync reports as "job cancelled"
+#: and the actionable error this script was about to print is never written. The
+#: workflows' guards assert their timeouts against these, so raising one here
+#: fails the guard rather than silently making a job timeout reachable.
+DEFAULT_INSTALL_RETRY_SECONDS = 600
+DEFAULT_DEPLOYMENT_TIMEOUT_SECONDS = 600
+
 #: Keys an install/info response may carry the installed version under. LM has
 #: not committed to one name across versions, so check the plausible set rather
 #: than hard-coding a guess that silently reads None and compares equal to None.
@@ -966,7 +975,7 @@ def main(argv: list[str] | None = None) -> int:
     p_install.add_argument(
         "--install-retry-seconds",
         type=int,
-        default=600,
+        default=DEFAULT_INSTALL_RETRY_SECONDS,
         help=(
             "How long to keep retrying the install while LM's tenant-catalog "
             "snapshot catches up with a fresh publish. LM excludes a release "
@@ -978,7 +987,7 @@ def main(argv: list[str] | None = None) -> int:
     p_install.add_argument(
         "--timeout-seconds",
         type=int,
-        default=600,
+        default=DEFAULT_DEPLOYMENT_TIMEOUT_SECONDS,
         help="Budget for the deployment to reconcile. A timeout fails.",
     )
 

--- a/.github/scripts/resolve_e2e_tenant.py
+++ b/.github/scripts/resolve_e2e_tenant.py
@@ -75,6 +75,19 @@ _FIELD_TO_ENV = {
 _DEPLOYMENT_NAME_FIELD = "deployment_name"
 _DEPLOYMENT_NAME_ENV = "E2E_TENANT_DEPLOYMENT_NAME"
 
+# Optional. The tenant's ID — its vcluster instance name ("markeznp37"), which is
+# what GM matches `allowed_tenants` against when a release is scoped to specific
+# tenants (heracles/handler/marketplace.go reads it from the atlan-defaults
+# ConfigMap key `instance`; it is deliberately NOT in the JWT, where the realm is
+# "default" for every tenant).
+#
+# Distinct from `tenant`, which is the HOSTNAME. Scoping a release with a hostname
+# publishes successfully and produces a release visible to no tenant, so the
+# install then fails with "version not found" — FND-31 lost three live runs to
+# exactly that. Absent for a caller that never publishes.
+_TENANT_ID_FIELD = "tenant_id"
+_TENANT_ID_ENV = "E2E_TENANT_ID"
+
 # Values excluded from ::add-mask::. Everything else is masked, including the
 # tenant host and its derived base URL — those are secrets today and staying
 # masked is not a change in posture.
@@ -139,6 +152,9 @@ def _entry(matrix_json: str, cloud: str) -> dict[str, str]:
     deployment_name = str(entry.get(_DEPLOYMENT_NAME_FIELD, "") or "").strip()
     if deployment_name:
         resolved[_DEPLOYMENT_NAME_ENV] = deployment_name
+    tenant_id = str(entry.get(_TENANT_ID_FIELD, "") or "").strip()
+    if tenant_id:
+        resolved[_TENANT_ID_ENV] = tenant_id
     return resolved
 
 

--- a/.github/scripts/tests/test_e2e_tenant_api.py
+++ b/.github/scripts/tests/test_e2e_tenant_api.py
@@ -148,6 +148,42 @@ def test_transport_failure_names_the_host_not_the_credential(
     assert _SECRET not in message
 
 
+# ── Tenant ID vs hostname ────────────────────────────────────────────────────
+# `allowed_tenants` is matched EXACTLY by GM against the tenant's vcluster
+# instance name. A hostname publishes fine and yields a release visible to no
+# tenant, so the failure lands much later as "version not found" on install —
+# three live runs were lost to that, hence a fail-fast check.
+
+
+@pytest.mark.parametrize("tenant_id", ["markeznp37", "home-mt", "e2e-azure-main"])
+def test_valid_tenant_ids_pass(tenant_id: str) -> None:
+    assert api.validate_tenant_id(tenant_id) == tenant_id
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "e2e-azure-main.atlan.com",
+        "https://e2e-azure-main.atlan.com",
+        "tenant.example.com",
+    ],
+)
+def test_hostname_shaped_tenant_ids_are_refused(bad: str) -> None:
+    with pytest.raises(api.TenantApiError, match="hostname"):
+        api.validate_tenant_id(bad)
+
+
+@pytest.mark.parametrize("empty", ["", "   "])
+def test_empty_tenant_id_is_refused(empty: str) -> None:
+    # Empty would publish a release scoped to nothing at all.
+    with pytest.raises(api.TenantApiError, match="tenant"):
+        api.validate_tenant_id(empty)
+
+
+def test_tenant_id_is_trimmed() -> None:
+    assert api.validate_tenant_id("  markeznp37  ") == "markeznp37"
+
+
 # ── Token mint ───────────────────────────────────────────────────────────────
 
 

--- a/.github/scripts/tests/test_e2e_tenant_api.py
+++ b/.github/scripts/tests/test_e2e_tenant_api.py
@@ -155,7 +155,18 @@ def test_transport_failure_names_the_host_not_the_credential(
 # three live runs were lost to that, hence a fail-fast check.
 
 
-@pytest.mark.parametrize("tenant_id", ["markeznp37", "home-mt", "e2e-azure-main"])
+@pytest.mark.parametrize(
+    "tenant_id",
+    [
+        "markeznp37",
+        "home-mt",
+        "e2e-azure-main",
+        # Vcluster instance names are DNS subdomains and may legally contain
+        # dots; only a scheme or a known Atlan host suffix marks a hostname.
+        "team.a",
+        "tenant.example.com",
+    ],
+)
 def test_valid_tenant_ids_pass(tenant_id: str) -> None:
     assert api.validate_tenant_id(tenant_id) == tenant_id
 
@@ -165,7 +176,7 @@ def test_valid_tenant_ids_pass(tenant_id: str) -> None:
     [
         "e2e-azure-main.atlan.com",
         "https://e2e-azure-main.atlan.com",
-        "tenant.example.com",
+        "e2e-azure-main.atlan.dev",
     ],
 )
 def test_hostname_shaped_tenant_ids_are_refused(bad: str) -> None:

--- a/.github/scripts/tests/test_e2e_tenant_app.py
+++ b/.github/scripts/tests/test_e2e_tenant_app.py
@@ -1188,3 +1188,25 @@ def test_publish_error_body_is_truncated(monkeypatch: pytest.MonkeyPatch) -> Non
     with pytest.raises(app.TenantAppError) as excinfo:
         app.install(_install_args())
     assert len(str(excinfo.value)) < 5000
+
+
+def test_install_refuses_a_hostname_as_the_tenant(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Fail before publishing, not after the install cannot find the version.
+
+    A hostname in `allowed_tenants` publishes successfully and produces a release
+    visible to no tenant, so the symptom appears one call later as "version not
+    found" — with the tenant's real versions listed, which reads like a lag rather
+    than a scoping mistake. Three live runs were spent on that.
+    """
+    transport = _wire(
+        monkeypatch,
+        StubTransport(routes=[StubRoute("GET", "/info", _ok({}))]),
+    )
+    with pytest.raises(TenantApiError, match="hostname"):
+        app.install(_install_args(tenant="e2e-azure-main.atlan.com"))
+    assert not any("/marketplace/publish" in p for p in transport.paths("POST")), (
+        "the bad tenant id must be caught BEFORE the publish, or it leaves a "
+        "release behind that is visible to nobody"
+    )

--- a/.github/scripts/tests/test_e2e_tenant_app.py
+++ b/.github/scripts/tests/test_e2e_tenant_app.py
@@ -133,6 +133,7 @@ def _install_args(**overrides: object) -> argparse.Namespace:
         "release_model": "",
         "created_by": "",
         "scan_wait_seconds": 0,
+        "install_retry_seconds": 0,
         "timeout_seconds": 600,
     }
     values.update(overrides)
@@ -892,6 +893,114 @@ def test_non_ghcr_repo_image_mismatch_warns_but_proceeds(
         transport.body_for("/marketplace/publish")["repo"]
         == "https://github.com/atlanhq/application-sdk"
     )
+
+
+# ── LM answers 200 with an error envelope ────────────────────────────────────
+# POST .../install returns HTTP 200 carrying {status, status_code, message} for
+# its two non-deploying outcomes, so response.ok alone reads a 404 as success.
+# LM's snapshot also lags a fresh publish by up to ~5 min, which is why the
+# install is retried rather than failed on first miss.
+
+
+def _install_reply(status: str, code: int, message: str) -> Response:
+    return Response(
+        status=200, body={"status": status, "status_code": code, "message": message}
+    )
+
+
+_NOT_FOUND = _install_reply(
+    "error", 404, "App with ID '019d1f6b-6fea-7db3-96d8-e61e159d0351' not found: x"
+)
+
+
+def _publish_then(*install_replies: Response) -> StubTransport:
+    """Transport that gets as far as the install, then serves the given replies."""
+    routes = [
+        StubRoute("GET", "/info", _ok({})),
+        StubRoute("POST", "/marketplace/publish", _ok({"version_id": "v1"})),
+    ]
+    routes += [StubRoute("POST", "/install", r) for r in install_replies]
+    routes += [
+        StubRoute("GET", "/deployments/", _ok({"deployment_status": "SUCCEEDED"})),
+        StubRoute("GET", "/info", _ok(_lm_info(_VERSION))),
+    ]
+    return StubTransport(
+        routes=routes,
+        sticky=[StubRoute("GET", "/releases/", Response(status=404, body={}))],
+    )
+
+
+def test_http_200_with_an_error_envelope_is_a_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The bug this guards: response.ok is True here. Only the in-body status_code
+    # says it failed.
+    _wire(monkeypatch, _publish_then(_NOT_FOUND))
+    with pytest.raises(app.TenantAppError, match="404"):
+        app.install(_install_args(install_retry_seconds=0))
+
+
+def test_install_retries_while_lm_catalog_catches_up(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A fresh publish is not immediately installable; the retry covers the lag."""
+    transport = _wire(
+        monkeypatch,
+        _publish_then(_NOT_FOUND, _NOT_FOUND, _ok({"deployment_id": "d1"})),
+    )
+    outcome = app.install(_install_args(install_retry_seconds=600))
+    assert outcome.deployment_id == "d1"
+    assert len([p for p in transport.paths("POST") if "/install" in p]) == 3
+
+
+def test_retry_budget_is_respected_and_the_error_explains_the_lag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _wire(monkeypatch, _publish_then(_NOT_FOUND))
+    with pytest.raises(app.TenantAppError) as excinfo:
+        app.install(_install_args(install_retry_seconds=0))
+    assert "snapshot" in str(excinfo.value) and "--install-retry-seconds" in str(
+        excinfo.value
+    )
+
+
+def test_already_installed_is_a_no_op_not_a_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # LM starts no deployment in this case, so there is nothing to poll; the
+    # version read-back is what decides success.
+    transport = _wire(
+        monkeypatch,
+        _publish_then(_install_reply("success", 200, "App already installed")),
+    )
+    outcome = app.install(_install_args())
+    assert outcome.deployment_id == ""
+    assert outcome.installed_version == _VERSION
+    assert not any("/deployments/" in p for p in transport.paths("GET"))
+
+
+def test_success_without_a_deployment_id_still_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Not "already installed", not an error, but nothing to poll either — that is
+    # unexplained, and must not read as a completed install.
+    _wire(monkeypatch, _publish_then(_install_reply("success", 200, "queued")))
+    with pytest.raises(app.TenantAppError, match="no deployment_id"):
+        app.install(_install_args())
+
+
+@pytest.mark.parametrize(
+    "code, message, expected_not_found",
+    [
+        (404, "App with ID 'x' not found: y", True),
+        (200, "App with ID 'x' not found: y", True),
+        (500, "internal error", False),
+        (200, "App already installed", False),
+    ],
+)
+def test_not_found_detection(code: int, message: str, expected_not_found: bool) -> None:
+    reply = app._InstallReply.parse(_install_reply("error", code, message))
+    assert reply.not_found is expected_not_found
 
 
 # ── Version extraction across LM shapes ──────────────────────────────────────

--- a/.github/scripts/tests/test_e2e_tenant_install_workflow.py
+++ b/.github/scripts/tests/test_e2e_tenant_install_workflow.py
@@ -93,6 +93,67 @@ def test_install_requires_explicit_confirmation(workflow: dict) -> None:  # type
     )
 
 
+def test_the_ghcr_check_can_actually_read_packages(workflow: dict) -> None:  # type: ignore[type-arg]
+    """The pre-publish image check needs a token with package scope.
+
+    `docker manifest inspect` runs against GHCR, and the login falls back to
+    `github.token` when ORG_PAT_GITHUB is unset. The workflow declares only
+    `contents: read` at the top level, so without a job-level grant that token has
+    no package scope at all and the check 401s on an image that exists — a
+    guardrail that false-blocks a legitimate install.
+
+    Necessary, not sufficient: GITHUB_TOKEN package access covers only packages
+    owned by or linked to this repo, and these images belong to the app repos. The
+    step's error text names authorisation as well as absence for that reason, which
+    is asserted here too — a false block that reads as "the tag was pruned" sends
+    the next person hunting the wrong cause, which is exactly how one live run was
+    spent.
+    """
+    permissions = workflow["jobs"]["install"].get("permissions") or {}
+    assert permissions.get("packages") == "read", (
+        "the install job needs `packages: read`, or the github.token fallback "
+        "cannot read GHCR and the image check blocks installs of images that exist"
+    )
+    # The top-level grant must survive: a job-level block replaces it wholesale.
+    assert permissions.get("contents") == "read"
+
+    check = [
+        s
+        for s in _steps(workflow)
+        if str(s.get("name", "")) == "Verify the image exists"
+    ]
+    assert len(check) == 1
+    error = check[0]["run"]
+    assert "ORG_PAT_GITHUB" in error, (
+        "the failure message must name the authorisation cause, not only the "
+        "pruned-tag one — a cross-repo GHCR read fails here even with the grant"
+    )
+
+
+def test_job_timeout_stays_above_the_two_waits_it_defaults_to(workflow: dict) -> None:  # type: ignore[type-arg]
+    """The runner's timeout must not be able to fire before the script's.
+
+    Both waits are dispatch inputs here, so the budget is read off their own
+    defaults rather than the script's: raising a default without raising the job
+    timeout would turn a slow LM sync into a bare "job cancelled", discarding the
+    actionable error the script was about to print.
+    """
+    inputs = workflow.get("on", workflow.get(True))["workflow_dispatch"]["inputs"]
+    waits = (
+        int(inputs["install_retry_seconds"]["default"])
+        + int(inputs["timeout_seconds"]["default"])
+    ) // 60
+    # Same 1/2 share as prepare-tenant: both waits can run to completion and the
+    # rest of the job still has as long again, so the runner's timeout is never the
+    # first to fire.
+    required = round(waits / 0.5)
+    actual = workflow["jobs"]["install"]["timeout-minutes"]
+    assert actual >= required, (
+        f"the install job allows {actual} min but its own input defaults permit "
+        f"{waits} min of waiting. Raise it to at least {required}."
+    )
+
+
 def test_concurrency_is_per_cloud_and_does_not_cancel(workflow: dict) -> None:  # type: ignore[type-arg]
     concurrency = workflow["concurrency"]
     assert "inputs.cloud" in concurrency["group"]

--- a/.github/scripts/tests/test_e2e_tenant_install_workflow.py
+++ b/.github/scripts/tests/test_e2e_tenant_install_workflow.py
@@ -68,6 +68,7 @@ def test_inputs_used_by_scripts_arrive_through_env(workflow: dict) -> None:
             # source_repo on file, and LM does not expose the registered value.
             "REPO_URL",
             "SCAN_WAIT_SECONDS",
+            "INSTALL_RETRY_SECONDS",
             "TIMEOUT_SECONDS",
         },
         "Verify the tenant reports the installed version": {"APP_ID", "VERSION"},

--- a/.github/scripts/tests/test_prepare_tenant_wiring.py
+++ b/.github/scripts/tests/test_prepare_tenant_wiring.py
@@ -12,14 +12,26 @@ grouping) and cannot be exercised without a runner.
 from __future__ import annotations
 
 import re
+import sys
 from pathlib import Path
 
 import pytest
 import yaml
 
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import e2e_tenant_app as app  # noqa: E402
+
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 _WORKFLOW = _REPO_ROOT / ".github/workflows/tests-reusable.yaml"
 _SDR_ACTION = _REPO_ROOT / ".github/actions/sdr-e2e/action.yaml"
+
+#: How much job budget the script's own two waits may account for. At 1/2, both
+#: waits can run to completion and the rest of the job still has as long again —
+#: so the runner's timeout is never the first thing to fire, whatever the checkout,
+#: publish and read-back cost on a slow runner. A ratio rather than a fixed margin
+#: because it stays correct if a wait's default changes.
+_MAX_WAIT_SHARE = 0.5
 
 
 @pytest.fixture(scope="module")
@@ -210,6 +222,82 @@ def test_new_jobs_route_values_through_env_not_into_run(jobs: dict, job: str) ->
         "attacker-influenced or multi-line values into the shell. Pass them via "
         f'env: and reference quoted "$VARS". Offenders: {offenders}'
     )
+
+
+# ── A tenant we cannot scope a release to is rejected up front ───────────────
+
+
+def test_a_missing_tenant_id_is_rejected_before_anything_is_published(
+    jobs: dict,
+) -> None:  # type: ignore[type-arg]
+    """The gate must sit between tenant resolution and the atlan.yaml parse.
+
+    The resolver exports ``E2E_TENANT_ID`` only from a matrix entry carrying
+    ``tenant_id``; the legacy single-tenant fallback has no entry to carry one.
+    Without this step the job got as far as the publish and then failed inside the
+    script on an empty ``--tenant``, several steps past the actual cause.
+
+    Failing rather than skipping is the deliberate half: a skipped install leaves
+    prepare-tenant green, the tenant on whatever version it was already running,
+    and every leg reding on its own version check — one confusing failure per leg
+    in place of one clear failure here.
+    """
+    names = [str(step.get("name", "")) for step in jobs["prepare-tenant"]["steps"]]
+    gate = [
+        step
+        for step in jobs["prepare-tenant"]["steps"]
+        if str(step.get("name", "")) == "Require a tenant ID before publishing anything"
+    ]
+    assert len(gate) == 1, "the tenant-ID gate is gone; the install would fail late"
+    assert gate[0]["if"] == "env.E2E_TENANT_ID == ''", (
+        "the gate must fire on an unresolved tenant ID specifically, and via the "
+        "env context so the branch stays out of the run: block (ci.md)"
+    )
+    assert "exit 1" in gate[0]["run"], (
+        "the gate must fail the job. A warning would leave the tenant unprepared "
+        "and push the failure into every leg's version check instead."
+    )
+
+    position = names.index("Require a tenant ID before publishing anything")
+    for later in ("Read atlan.yaml", "Install the app under test"):
+        assert position < names.index(later), (
+            f"the tenant-ID gate must run before {later!r} — the whole point is "
+            "rejecting the misconfiguration before any work or any publish"
+        )
+
+
+def test_job_timeout_stays_above_the_scripts_own_waits(jobs: dict) -> None:  # type: ignore[type-arg]
+    """The runner's timeout must not be able to fire before the script's.
+
+    The install retries while LM's catalog snapshot catches up, then polls the
+    deployment — both bounded by the script's defaults, since the step overrides
+    neither. If the job budget is under their sum, a slow sync reports as a bare
+    "job cancelled after Nm" and the actionable error the script was about to
+    print is never written: the diagnosis-hostile failure this whole job exists to
+    avoid. Derived from the script's constants, so raising one of those fails here
+    rather than silently making a job timeout reachable.
+    """
+    waits = (
+        app.DEFAULT_INSTALL_RETRY_SECONDS + app.DEFAULT_DEPLOYMENT_TIMEOUT_SECONDS
+    ) // 60
+    required = round(waits / _MAX_WAIT_SHARE)
+    actual = jobs["prepare-tenant"]["timeout-minutes"]
+    assert actual >= required, (
+        f"prepare-tenant allows {actual} min but the script can spend {waits} min "
+        "of it waiting, so a slow runner makes the GHA timeout reachable before "
+        f"the script's own. Raise it to at least {required}."
+    )
+
+    install = [
+        s
+        for s in jobs["prepare-tenant"]["steps"]
+        if str(s.get("name", "")) == "Install the app under test"
+    ][0]
+    for flag in ("--install-retry-seconds", "--timeout-seconds"):
+        assert flag not in install["run"], (
+            f"the step now passes {flag}, so the budget above is no longer the "
+            "script's default — compute the timeout from the passed value instead"
+        )
 
 
 def test_install_step_does_not_thread_app_id(jobs: dict) -> None:  # type: ignore[type-arg]

--- a/.github/workflows/e2e-tenant-install.yaml
+++ b/.github/workflows/e2e-tenant-install.yaml
@@ -168,6 +168,33 @@ jobs:
       # expression again just to be renamed — every hop is a hop it can be
       # mishandled on. Those are the OAuth client pair the marketplace publish
       # route authorises on, NOT ATLAN_API_KEY (the harness's API key).
+      # Prove the image exists BEFORE publishing. Otherwise a stale or pruned tag
+      # publishes fine, installs fine, and only surfaces ~2 minutes later as
+      # ImagePullBackOff in the tenant's cluster — with a GM version and release
+      # left behind pointing at an image nobody can pull. That is exactly how one
+      # live run was spent.
+      #
+      # The automatic prepare-tenant path cannot hit this: it builds the image in
+      # the same run. This check exists because THIS workflow accepts an arbitrary
+      # tag from a human.
+      - name: Log in to GHCR
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.ORG_PAT_GITHUB || github.token }}
+
+      - name: Verify the image exists
+        env:
+          IMAGE: ${{ inputs.image }}
+        run: |
+          set -euo pipefail
+          docker manifest inspect "$IMAGE" > /dev/null || {
+            echo "::error::$IMAGE is not pullable from GHCR. Publishing it would create a GM version and release pointing at an image that cannot be pulled, and the failure would surface minutes later as ImagePullBackOff on the tenant. sdr-test-* tags are built by e2e runs and may have been pruned — take a tag from a recent e2e build log, or re-run the app's e2e to produce one."
+            exit 1
+          }
+          echo "$IMAGE is pullable"
+
       #
       # Every dispatch input reaches the shell through env:, never through
       # `${{ }}` inside run:. A workflow_dispatch input is attacker-influenced

--- a/.github/workflows/e2e-tenant-install.yaml
+++ b/.github/workflows/e2e-tenant-install.yaml
@@ -59,6 +59,17 @@ on:
         description: "Git ref the image was built from, recorded on the GM version."
         required: true
         type: string
+      tenant_id:
+        description: >-
+          The tenant's ID — its vcluster instance name (e.g. "markeznp37"), NOT
+          its hostname. GM matches `allowed_tenants` against this exactly, so a
+          hostname publishes successfully but yields a release visible to no
+          tenant, and the install then fails with "version not found". Leave
+          empty to use E2E_TENANT_ID from the tenant-matrix secret, if that
+          entry carries one.
+        required: false
+        type: string
+        default: ""
       repo_url:
         description: >-
           The APP'S OWN repo, e.g. https://github.com/atlanhq/atlan-openapi-app.
@@ -171,6 +182,7 @@ jobs:
           VERSION: ${{ inputs.version }}
           BRANCH: ${{ inputs.branch }}
           REPO_URL: ${{ inputs.repo_url }}
+          TENANT_ID_INPUT: ${{ inputs.tenant_id }}
           SCAN_WAIT_SECONDS: ${{ inputs.scan_wait_seconds }}
           INSTALL_RETRY_SECONDS: ${{ inputs.install_retry_seconds }}
           TIMEOUT_SECONDS: ${{ inputs.timeout_seconds }}
@@ -183,7 +195,7 @@ jobs:
             --version "$VERSION" \
             --branch "$BRANCH" \
             --repo-url "$REPO_URL" \
-            --tenant "$SDR_TEST_TENANT" \
+            --tenant "${TENANT_ID_INPUT:-${E2E_TENANT_ID:-}}" \
             --scan-wait-seconds "$SCAN_WAIT_SECONDS" \
             --install-retry-seconds "$INSTALL_RETRY_SECONDS" \
             --timeout-seconds "$TIMEOUT_SECONDS"

--- a/.github/workflows/e2e-tenant-install.yaml
+++ b/.github/workflows/e2e-tenant-install.yaml
@@ -78,6 +78,17 @@ on:
         required: false
         type: string
         default: "0"
+      install_retry_seconds:
+        description: >-
+          How long to keep retrying the install while LM's tenant-catalog
+          snapshot catches up with the fresh publish. LM excludes a release while
+          it is scan_pending and only picks it up on the next scheduled sync
+          (~5 min), so a just-published release is not immediately installable.
+          Waiting on GM's release status is NOT enough — a run that read `active`
+          from GM still had its install miss. 0 disables the retry.
+        required: false
+        type: string
+        default: "600"
       timeout_seconds:
         description: "Budget for the deployment to reconcile before failing."
         required: false
@@ -161,6 +172,7 @@ jobs:
           BRANCH: ${{ inputs.branch }}
           REPO_URL: ${{ inputs.repo_url }}
           SCAN_WAIT_SECONDS: ${{ inputs.scan_wait_seconds }}
+          INSTALL_RETRY_SECONDS: ${{ inputs.install_retry_seconds }}
           TIMEOUT_SECONDS: ${{ inputs.timeout_seconds }}
         run: |
           set -euo pipefail
@@ -173,6 +185,7 @@ jobs:
             --repo-url "$REPO_URL" \
             --tenant "$SDR_TEST_TENANT" \
             --scan-wait-seconds "$SCAN_WAIT_SECONDS" \
+            --install-retry-seconds "$INSTALL_RETRY_SECONDS" \
             --timeout-seconds "$TIMEOUT_SECONDS"
 
       # Independent read-back through the same check the e2e legs will run, so a

--- a/.github/workflows/e2e-tenant-install.yaml
+++ b/.github/workflows/e2e-tenant-install.yaml
@@ -124,7 +124,26 @@ jobs:
     # visibly skipped instead of green-but-did-nothing.
     if: inputs.confirm == 'yes'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # Twice the script's own waits, not a shade over them. The install retries for
+    # up to install_retry_seconds (default 600) while LM's catalog snapshot catches
+    # up, then polls the deployment for up to timeout_seconds (default 600) — ~20
+    # minutes before the script decides anything. At 30 the runner's timeout can
+    # fire first on a slow sync, and a bare "job cancelled after 30m" replaces the
+    # actionable error the script was about to print.
+    timeout-minutes: 40
+    permissions:
+      contents: read
+      # For `docker manifest inspect` on the GHCR image below when ORG_PAT_GITHUB
+      # is unset and the login falls back to github.token: without this the token
+      # carries no package scope at all and the check 401s on an image that
+      # exists, false-blocking a legitimate install.
+      #
+      # Necessary but not always sufficient: GITHUB_TOKEN package access is
+      # scoped to packages owned by or linked to THIS repo, and the images this
+      # workflow installs belong to the app repos. Cross-repo reads still need
+      # ORG_PAT_GITHUB (or the package granting this repo read access) — which is
+      # why the error below names authorisation as well as absence.
+      packages: read
     env:
       E2E_TENANT_MATRIX_JSON: ${{ secrets.E2E_TENANT_MATRIX_JSON }}
       E2E_CLOUD: ${{ inputs.cloud }}
@@ -190,7 +209,7 @@ jobs:
         run: |
           set -euo pipefail
           docker manifest inspect "$IMAGE" > /dev/null || {
-            echo "::error::$IMAGE is not pullable from GHCR. Publishing it would create a GM version and release pointing at an image that cannot be pulled, and the failure would surface minutes later as ImagePullBackOff on the tenant. sdr-test-* tags are built by e2e runs and may have been pruned — take a tag from a recent e2e build log, or re-run the app's e2e to produce one."
+            echo "::error::$IMAGE could not be read from GHCR. Two causes, in likelihood order. (1) The tag does not exist: sdr-test-* tags are built by e2e runs and may have been pruned — take a tag from a recent e2e build log, or re-run the app's e2e to produce one. (2) This run cannot authorise it: with ORG_PAT_GITHUB unset the login falls back to github.token, whose package scope covers only packages owned by or linked to atlanhq/application-sdk, and these images belong to the app repos — set ORG_PAT_GITHUB. Either way the install is blocked here deliberately: publishing an unreadable image creates a GM version and release pointing at something the tenant cannot pull, and the failure would surface minutes later as ImagePullBackOff."
             exit 1
           }
           echo "$IMAGE is pullable"

--- a/.github/workflows/tests-reusable.yaml
+++ b/.github/workflows/tests-reusable.yaml
@@ -969,6 +969,14 @@ jobs:
             --entrypoints "$ENTRYPOINTS" \
             --release-model "$RELEASE_MODEL" \
             --created-by "$CREATED_BY"
+        # --install-retry-seconds is left at its default (600). A freshly
+        # published release is not immediately installable: LM resolves the
+        # install against its tenant-catalog snapshot, which excludes a release
+        # while it is scan_pending and picks it up on the next scheduled sync
+        # (~5 min). Worst case here is therefore ~10 min of install retry plus
+        # ~10 min of deployment polling — keep this job's timeout-minutes above
+        # the sum of the two, or a slow sync reads as a job timeout instead of
+        # the actionable error the script would otherwise raise.
 
       - name: Summarise
         if: always()

--- a/.github/workflows/tests-reusable.yaml
+++ b/.github/workflows/tests-reusable.yaml
@@ -852,7 +852,12 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(needs.discover-e2e.outputs.cloud-matrix || '{"include":[{"cloud":""}]}') }}
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # Twice the script's own waits, not a shade over them: the install retries for
+    # up to ~600s while LM's catalog snapshot catches up, then polls the deployment
+    # for up to ~600s. At 30 the runner's timeout can fire first on a slow sync,
+    # and a bare "job cancelled after 30m" replaces the actionable error the script
+    # was about to print — the diagnosis-hostile failure this job exists to avoid.
+    timeout-minutes: 40
     concurrency:
       # Keyed on the TENANT (app + cloud), not the ref: the installation is
       # tenant-scoped, so two runs installing different versions concurrently
@@ -916,6 +921,33 @@ jobs:
             --fallback-client-secret "$FALLBACK_SDR_CLIENT_SECRET" \
             --fallback-api-key "$FALLBACK_ATLAN_API_KEY" \
             >> "$GITHUB_ENV"
+
+      # Reject a tenant we cannot scope a release to, HERE — before atlan.yaml is
+      # parsed and before anything is published. The resolver only exports
+      # E2E_TENANT_ID from a matrix entry carrying `tenant_id`; the legacy
+      # single-tenant fallback path has no entry to carry one, so without this
+      # step the run got as far as the publish and then failed inside the script
+      # on an empty `--tenant`, several steps deeper than the actual cause.
+      #
+      # Failing rather than skipping the install, deliberately. Skipping would
+      # leave prepare-tenant green having done nothing, the tenant on whatever
+      # version it happened to be running, and every leg reding on its version
+      # check instead — one confusing failure per leg in place of one clear
+      # failure here. `install-app-to-tenant: true` is a deliberate opt-in, and a
+      # caller that has opted in without the tenant matrix cannot install at all,
+      # so this is a misconfiguration to surface, not a path to degrade into.
+      #
+      # A step-level `if:` on the env context rather than a shell `test`, so the
+      # branch lives in the expression layer and the `run:` stays straight-line
+      # (docs/standards/ci.md). The env context sees values earlier steps wrote to
+      # $GITHUB_ENV.
+      - name: Require a tenant ID before publishing anything
+        if: env.E2E_TENANT_ID == ''
+        env:
+          CLOUD: ${{ matrix.cloud || 'default' }}
+        run: |
+          echo "::error::no tenant ID resolved for cloud '${CLOUD}', so a release cannot be scoped to this tenant. GM matches allowed_tenants EXACTLY against the tenant's vcluster instance name (e.g. 'markeznp37') — not its hostname — so there is nothing to fall back to. Add a 'tenant_id' field to this cloud's entry in E2E_TENANT_MATRIX_JSON, alongside 'tenant', 'client_id', 'client_secret' and 'api_key' (see docs/standards/connector-ci-e2e.md). On the legacy single-tenant fallback path there is no matrix entry to add it to: either share the tenant-matrix secret with this repo, or leave install-app-to-tenant off and use the E2E Tenant Install workflow, whose tenant_id input covers the one-off case."
+          exit 1
 
       # app_id / deploy_config / entrypoints / sdk_version all come from
       # atlan.yaml, which parse_atlan_yaml.py already reads for the release path.

--- a/.github/workflows/tests-reusable.yaml
+++ b/.github/workflows/tests-reusable.yaml
@@ -962,7 +962,7 @@ jobs:
             --image "$IMAGE" \
             --version "$VERSION" \
             --branch "$BRANCH" \
-            --tenant "$SDR_TEST_TENANT" \
+            --tenant "${E2E_TENANT_ID:-}" \
             --repo-url "$REPO_URL" \
             --deploy-config "$DEPLOY_CONFIG" \
             --sdk-version "$SDK_VERSION" \

--- a/docs/standards/connector-ci-e2e.md
+++ b/docs/standards/connector-ci-e2e.md
@@ -136,9 +136,9 @@ release rather than after. This is FND-6.
 
 ```json
 {
-  "aws":   {"tenant": "…", "client_id": "…", "client_secret": "…", "api_key": "…"},
-  "azure": {"tenant": "…", "client_id": "…", "client_secret": "…", "api_key": "…"},
-  "gcp":   {"tenant": "…", "client_id": "…", "client_secret": "…", "api_key": "…"}
+  "aws":   {"tenant": "…", "client_id": "…", "client_secret": "…", "api_key": "…", "tenant_id": "…"},
+  "azure": {"tenant": "…", "client_id": "…", "client_secret": "…", "api_key": "…", "tenant_id": "…"},
+  "gcp":   {"tenant": "…", "client_id": "…", "client_secret": "…", "api_key": "…", "tenant_id": "…"}
 }
 ```
 
@@ -147,6 +147,21 @@ index the `secrets` context, and the reusable workflows declare their
 `workflow_call` secrets explicitly — so per-cloud names would have to be
 re-declared for every cloud ever added. Adding a fourth CSP is a secret edit and
 a one-line change to `DEFAULT_CLOUDS`; no app repo changes at all.
+
+`"tenant_id"` is the tenant's **vcluster instance name** (`markeznp37`, `home-mt`)
+— *not* its hostname, which is what `"tenant"` holds. It is required only by the
+tenant-install path (`install-app-to-tenant`, FND-31): GM matches a release's
+`allowed_tenants` against this id exactly, so scoping with a hostname publishes
+successfully and produces a release visible to **no** tenant, whose symptom
+appears one call later as `version not found` on install. It reaches the drivers
+as `E2E_TENANT_ID`.
+
+There is no way to derive it client-side — Heracles reads it from the
+`atlan-defaults` ConfigMap key `instance`, and deliberately not from the JWT,
+whose Keycloak realm is `default` for every tenant. So an entry without it cannot
+use the install path, and neither can the single-tenant fallback (which has no
+entry to add the field to); the `E2E Tenant Install` workflow's `tenant_id` input
+covers one-off runs in both cases.
 
 Each entry may also carry `"deployment_name"` when that tenant's system apps
 (publish / quality / lineage) are not registered under `production`. It reaches

--- a/docs/standards/connector-ci-e2e.md
+++ b/docs/standards/connector-ci-e2e.md
@@ -163,6 +163,14 @@ use the install path, and neither can the single-tenant fallback (which has no
 entry to add the field to); the `E2E Tenant Install` workflow's `tenant_id` input
 covers one-off runs in both cases.
 
+`prepare-tenant` therefore **fails** on an unresolved `tenant_id`, immediately
+after tenant resolution and before it publishes anything — it does not skip the
+install. Skipping would leave the job green having done nothing, the tenant on
+whatever version it was already running, and every leg reding on its own version
+check instead: one confusing failure per leg in place of one clear failure. Since
+`install-app-to-tenant` is opt-in, a caller that has opted in without a
+`tenant_id` is misconfigured rather than on a supported path.
+
 Each entry may also carry `"deployment_name"` when that tenant's system apps
 (publish / quality / lineage) are not registered under `production`. It reaches
 the harness as `E2E_TENANT_DEPLOYMENT_NAME`, which


### PR DESCRIPTION
> [!IMPORTANT]
> **Needs a secret update before it can work:** `E2E_TENANT_MATRIX_JSON` needs a `tenant_id` per cloud entry. Without it, the install now fails immediately with a clear message instead of after a 10-minute retry.

### Changelog

- `validate_tenant_id()` — refuse a hostname-shaped value **before** publishing.
- `resolve_e2e_tenant.py` — optional per-cloud `tenant_id`, exported as `E2E_TENANT_ID`.
- Both workflows pass the tenant **ID**, not the hostname; the manual one gains an explicit `tenant_id` input.
- 10 new tests.

### Root cause — diagnosed by @cmgrote, not by me

From GM's UI: releases created there carry a tenant **ID** (`markeznp37`-style), while we were sending the tenant **hostname**.

Confirmed from source. GM matches `allowed_tenants` exactly against the tenant's own id, and that id is the **vcluster instance name** — `heracles/handler/marketplace.go` reads it from the `atlan-defaults` ConfigMap key `instance`, with a comment noting the JWT is useless for this because the Keycloak realm is `default` for every tenant.

So `allowed_tenants: ["e2e-azure-main.atlan.com"]` produced a release visible to **no tenant**. The publish succeeded; the failure surfaced one call later:

```
Version 019fd678-… not found for app 019d1f6b-…
Available versions: v0.6.0, v0.5.3, v0.5.2, v0.5.1
```

That lists the tenant's *real* releases, so it reads like a propagation lag rather than a scoping mistake — which is exactly how I misread it in #3033. **My retry loop then retried it 30+ times over 10 minutes for something that could never succeed.**

### The fix

`validate_tenant_id()` rejects a dot or a scheme, pre-publish. Two reasons it belongs before the call rather than after a failure:

1. It converts a three-run diagnosis into an immediate, actionable error.
2. A bad value otherwise leaves an **orphan release** behind in GM.

Deliberately narrow — tenant ids are free-form vcluster names, so a stricter pattern would reject valid ones.

The ID comes from the matrix secret via an optional per-cloud `tenant_id`, mirroring the existing optional `deployment_name`: the secret is already where per-tenant facts live, and `resolve_e2e_tenant.py` stays the single writer.

### Also learned from that log

Publish is **idempotent per version string** — both runs returned `version_id 019fd678-…` — but mints a **new release each time**. So repeated runs accumulate releases, not versions. Worth knowing before anyone worries about version churn.

### Deliberately not fixed

The retry still cannot distinguish genuine snapshot lag from a permanently-invisible release: LM's message is identical in both cases ("version not found" plus the available list). The pre-publish validation removes the case we actually hit; a real discriminator would need LM to say *why* it can't resolve the version. Left as-is rather than papered over with a guess.

### Checklist

- [x] Additional tests added
- [ ] All CI checks passed
- [ ] Relevant documentation updated <!-- connector-ci-e2e.md lands with the turn-on -->

Local: 1235 script tests pass; `pre-commit run --all-files` clean.

---

### Copyleft License Compliance

- [ ] Have you used any code that is subject to a Copyleft license (e.g., GPL, AGPL, LGPL)?
- [ ] If yes, have you modified the code in the context of this project? please share additional details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
