### PR TITLE
feat(testing): let integration scenarios declare which app entrypoint they exercise

### DIFF
--- a/application_sdk/testing/integration/models.py
+++ b/application_sdk/testing/integration/models.py
@@ -129,6 +129,13 @@ class Scenario:
             Maps to PreflightInput.checks_to_run. Empty list = run all checks.
         preflight_timeout: Timeout in seconds for preflight checks.
             Maps to PreflightInput.timeout_seconds. Defaults to 60.
+        entrypoint: Name of the app ``@entrypoint`` this scenario exercises, e.g.
+            ``"crawler"`` or ``"miner"``. Only meaningful for ``api="workflow"``
+            scenarios. Multi-entrypoint apps MUST set it — otherwise the app's
+            default entrypoint is started, which is silently wrong for every
+            workflow but one. Declaring it also makes the scenario's coverage
+            machine-readable: which product workflow a test exercises is
+            otherwise recoverable only by reading the test's source.
         validate_assets: Override the test class's ``validate_assets`` for this
             scenario. ``None`` (default) inherits the class setting (on by default
             for workflow scenarios with a resolvable extracted-output path).
@@ -165,6 +172,7 @@ class Scenario:
     preflight_timeout: int = 60
     validate_assets: bool | None = None
     asset_validation_strict: bool | None = None
+    entrypoint: str | None = None
 
     def __post_init__(self):
         """Validate the scenario after initialization."""

--- a/application_sdk/testing/integration/runner.py
+++ b/application_sdk/testing/integration/runner.py
@@ -33,6 +33,7 @@ import os
 import time
 from datetime import UTC, datetime
 from typing import Any
+from urllib.parse import quote
 
 import orjson
 import pytest
@@ -222,6 +223,9 @@ class BaseIntegrationTest:
         server_host: Base URL of the app server (auto-discovered from env if not set).
         server_version: API version prefix (default: "v1").
         workflow_endpoint: Default endpoint for workflow API (default: "/start").
+        entrypoint: Default app ``@entrypoint`` for this suite's workflow
+            scenarios (e.g. "crawler"). Multi-entrypoint apps must set it here
+            or per-scenario; see ``Scenario.entrypoint``.
         timeout: Request timeout in seconds (default: 30).
         default_credentials: Extra credential fields merged with auto-discovered ones.
         default_metadata: Default metadata for preflight/workflow tests.
@@ -245,6 +249,10 @@ class BaseIntegrationTest:
     server_host: str = ""
     server_version: str = "v1"
     workflow_endpoint: str = "/start"
+    # Default app ``@entrypoint`` for this suite's workflow scenarios. A single
+    # scenario may override it via ``Scenario.entrypoint``. Left empty the app's
+    # own default entrypoint is started — correct only for single-entrypoint apps.
+    entrypoint: str = ""
     timeout: int = 30
 
     # Default values merged with auto-discovered credentials
@@ -525,6 +533,29 @@ class BaseIntegrationTest:
 
         return args
 
+    def _resolve_workflow_endpoint(self, scenario: Scenario) -> str:
+        """Endpoint for a workflow scenario, with the declared entrypoint applied.
+
+        Precedence: an explicit ``Scenario.endpoint`` wins outright — it is a
+        full override and may already carry its own query string. Otherwise the
+        suite's ``workflow_endpoint`` is used, with ``?entrypoint=<name>``
+        appended when the scenario or the class declares one.
+
+        Declaring the entrypoint rather than hardcoding the query string is what
+        makes a suite's coverage machine-readable: which product workflow a test
+        exercises is otherwise recoverable only by reading its source.
+        """
+        if scenario.endpoint:
+            return scenario.endpoint
+
+        endpoint = self.workflow_endpoint
+        entrypoint = scenario.entrypoint or self.entrypoint
+        if not entrypoint:
+            return endpoint
+
+        separator = "&" if "?" in endpoint else "?"
+        return f"{endpoint}{separator}entrypoint={quote(entrypoint, safe='')}"
+
     def _execute_scenario(self, scenario: Scenario) -> ScenarioResult:
         """Execute a single scenario and return the result.
 
@@ -556,7 +587,7 @@ class BaseIntegrationTest:
             logger.debug("Built args for %s", scenario.name)
 
             # Step 2: Call the API
-            endpoint = scenario.endpoint or self.workflow_endpoint
+            endpoint = self._resolve_workflow_endpoint(scenario)
             response = self.client.call_api(
                 api=scenario.api,
                 args=args,

--- a/packages/conformance/conformance/docs/rules/tests.md
+++ b/packages/conformance/conformance/docs/rules/tests.md
@@ -5,7 +5,7 @@
 
 # Test-Quality Rules (T-series)
 
-**19 rules** · Checker: `suite.checks.integration_marking` (T001), `suite.checks.sdr_test_checks` (T002-T003), `suite.checks.dev_entrypoint` (T004), `suite.checks.test_quality` (T005-T009), `suite.checks.test_structure` (T010-T013), `suite.checks.coverage_config` (T014-T015), `suite.checks.e2e_deployment_name` (T016), `suite.checks.e2e_agent_spec` (T017), `suite.checks.integration_deselect` (T018), and `suite.checks.asyncio_loop_scope` (T019) (AST/TOML/YAML-based)
+**20 rules** · Checker: `suite.checks.integration_marking` (T001), `suite.checks.sdr_test_checks` (T002-T003), `suite.checks.dev_entrypoint` (T004), `suite.checks.test_quality` (T005-T009), `suite.checks.test_structure` (T010-T013), `suite.checks.coverage_config` (T014-T015), `suite.checks.e2e_deployment_name` (T016), `suite.checks.e2e_agent_spec` (T017), `suite.checks.integration_deselect` (T018), and `suite.checks.asyncio_loop_scope` (T019) (AST/TOML/YAML-based)
 
 Suppress a finding on the violating line or the line directly above it:
 
@@ -34,6 +34,7 @@ Suppress a finding on the violating line or the line directly above it:
 | [T017](#t017) | `E2EAgentSpecPinsQueue` | `warn` | `app` | `e2e-ci` | — | 0.13.0 |
 | [T018](#t018) | `IntegrationTierDeselectedByAddopts` | `warn` | `app` | `test-collection` | — | 0.16.0 |
 | [T019](#t019) | `AsyncioTestLoopScopeUnset` | `warn` | `both` | `test-async-config` | — | 0.17.0 |
+| [T020](#t020) | `UndeclaredWorkflowEntrypoint` | `warn` | `app` | `test-coverage-attribution` | — | 0.18.0 |
 
 ---
 
@@ -907,5 +908,36 @@ Suppress with `# conformance: ignore[T019] <reason>` on the
 `asyncio_default_fixture_loop_scope` line only when the mismatch is deliberate — e.g.
 every async fixture is loop-agnostic and no test drives fixture-owned work in-body — and
 state that reason.
+
+---
+
+## T020 — `UndeclaredWorkflowEntrypoint` {#t020}
+
+**Tier:** `warn` · **Scope:** `app` · **Category:** `test-coverage-attribution` · **Autofixable:** — · **Since:** 0.18.0
+
+> Workflow scenario does not declare which app entrypoint it exercises
+
+**Rationale:** A Scenario with api="workflow" means 'POST /workflows/v1/start'. It does not say which
+@entrypoint gets started. On an app declaring more than one, an undeclared scenario
+silently starts the app's default entrypoint - so a suite believing it exercises the
+miner may in fact be running the crawler, and passing. The second cost is attribution:
+which product workflow a suite covers becomes recoverable only by reading the test's
+source and resolving base-class defaults through the MRO, so no tooling can report
+per-workflow integration coverage. A survey of ten connectors found two tests out of
+roughly two thousand stating it in any machine-readable form. Declaring it costs one
+line and makes both problems go away.
+
+A `Scenario(api="workflow", ...)` in an app that declares more than one `@entrypoint`
+passes neither `entrypoint=` nor an explicit `endpoint=`, and its enclosing `Test*`
+class sets no class-level `entrypoint`.
+
+Only fires for multi-entrypoint apps - on a single-entrypoint app the target is
+unambiguous and declaring it would be noise.
+
+**Remediation:** set `entrypoint="crawler"` (or whichever) on the scenario, or a
+class-level `entrypoint` on the suite when every scenario in it targets the same
+workflow.
+
+Suppress with `# conformance: ignore[T020] <reason>` on the `Scenario(` line.
 
 ---

--- a/packages/conformance/conformance/suite/checks/workflow_entrypoint_declared.py
+++ b/packages/conformance/conformance/suite/checks/workflow_entrypoint_declared.py
@@ -1,0 +1,275 @@
+"""T020 UndeclaredWorkflowEntrypoint — a workflow scenario must name its entrypoint.
+
+``Scenario(api="workflow", ...)`` means "POST /workflows/v1/start". It does not
+say *which* ``@entrypoint`` gets started. On an app that declares more than one,
+an undeclared scenario silently starts the app's default entrypoint — so a suite
+believing it covers the miner may in fact be exercising the crawler, and passing.
+
+The second cost is that coverage becomes unreadable. Which product workflow a
+suite exercises is recoverable only by reading the test's source and resolving
+base-class defaults through the MRO. A survey of ten connectors found 2 tests out
+of ~2000 stating it in any machine-readable form, which is why no tooling can
+report per-workflow integration coverage today.
+
+``Scenario.entrypoint`` (or the suite-wide ``BaseIntegrationTest.entrypoint``)
+fixes both. This rule flags workflow scenarios that declare neither.
+
+Scope
+-----
+Only fires for apps that declare **more than one** ``@entrypoint``. On a
+single-entrypoint app the target is unambiguous and declaring it is noise, so
+those repos see nothing.
+
+A scenario is considered to declare its entrypoint when it passes
+``entrypoint=``, when it passes an explicit ``endpoint=`` (a full override,
+already unambiguous), or when its enclosing ``Test*`` class sets a class-level
+``entrypoint``.
+
+Inline suppression
+------------------
+``# conformance: ignore[T020] <reason>`` on the ``Scenario(`` line or the
+comment-only line directly above it.
+
+Known coverage limits (intentional — biased toward zero false positives):
+
+* Resolution is syntactic. A scenario built by a helper function, or spread via
+  ``**kwargs`` / list comprehension, is not inspected and never flagged.
+* Class-level inheritance is resolved only within the same file; a suite whose
+  ``entrypoint`` comes from a base class in another module is not flagged
+  (the app-level entrypoint count already gates most of that noise).
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from conformance.suite.checks._ast_common import _parse_directives
+from conformance.suite.checks._ast_common import is_test_class as _is_test_class
+from conformance.suite.checks._ast_common import make_cli_main, make_finding
+from conformance.suite.schema.findings import Finding
+
+SERIES = "T"
+RULE_T020 = "T020"
+
+#: Decorator that declares a product workflow on an App subclass.
+_ENTRYPOINT_DECORATOR = "entrypoint"
+
+#: Keywords on a ``Scenario(...)`` call that make the target unambiguous.
+_DECLARING_KEYWORDS = frozenset({"entrypoint", "endpoint"})
+
+__all__ = [
+    "SERIES",
+    "app_entrypoint_count",
+    "discover",
+    "main",
+    "scan_all",
+    "scan_path",
+    "scan_text",
+]
+
+
+# ---------------------------------------------------------------------------
+# App-side: how many entrypoints does this app declare?
+# ---------------------------------------------------------------------------
+
+
+def _has_entrypoint_decorator(node: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+    for dec in node.decorator_list:
+        target = dec.func if isinstance(dec, ast.Call) else dec
+        name = (
+            target.attr
+            if isinstance(target, ast.Attribute)
+            else getattr(target, "id", None)
+        )
+        if name == _ENTRYPOINT_DECORATOR:
+            return True
+    return False
+
+
+def app_entrypoint_count(root: Path) -> int:
+    """Number of distinct ``@entrypoint`` methods the app declares.
+
+    Returns ``0`` when there is no ``app/`` package, which makes the rule
+    no-op for non-app repos.
+    """
+    app_dir = root / "app"
+    if not app_dir.is_dir():
+        return 0
+
+    names: set[str] = set()
+    for path in app_dir.rglob("*.py"):
+        if any(p in {"__pycache__", ".venv", "node_modules"} for p in path.parts):
+            continue
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except (SyntaxError, UnicodeDecodeError, OSError):
+            continue
+        for node in ast.walk(tree):
+            if isinstance(
+                node, (ast.FunctionDef, ast.AsyncFunctionDef)
+            ) and _has_entrypoint_decorator(node):
+                names.add(node.name)
+    return len(names)
+
+
+# ---------------------------------------------------------------------------
+# Test-side: does this workflow scenario declare its target?
+# ---------------------------------------------------------------------------
+
+
+def _is_scenario_call(node: ast.AST) -> bool:
+    if not isinstance(node, ast.Call):
+        return False
+    func = node.func
+    name = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", None)
+    return name == "Scenario"
+
+
+def _keyword_str(call: ast.Call, name: str) -> str | None:
+    for kw in call.keywords:
+        if kw.arg == name and isinstance(kw.value, ast.Constant):
+            value = kw.value.value
+            return value if isinstance(value, str) else None
+    return None
+
+
+def _declares_entrypoint(call: ast.Call) -> bool:
+    return any(
+        kw.arg in _DECLARING_KEYWORDS and kw.value is not None for kw in call.keywords
+    )
+
+
+def _classes_declaring_entrypoint(tree: ast.AST) -> set[int]:
+    """Line ranges of ``Test*`` classes that set a class-level ``entrypoint``."""
+    covered: set[int] = set()
+    for node in ast.walk(tree):
+        if not _is_test_class(node):
+            continue
+        declares = any(
+            isinstance(stmt, (ast.Assign, ast.AnnAssign))
+            and any(
+                getattr(t, "id", None) == "entrypoint"
+                for t in (
+                    stmt.targets if isinstance(stmt, ast.Assign) else [stmt.target]
+                )
+            )
+            for stmt in node.body
+        )
+        if declares:
+            end = getattr(node, "end_lineno", node.lineno) or node.lineno
+            covered.update(range(node.lineno, end + 1))
+    return covered
+
+
+def scan_text(source: str, filename: str, *, entrypoint_count: int) -> list[Finding]:
+    """Flag workflow scenarios with no declared entrypoint.
+
+    ``entrypoint_count`` is the app's declared ``@entrypoint`` total; the rule
+    is a no-op below two.
+    """
+    if entrypoint_count < 2:
+        return []
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return []
+
+    directives = _parse_directives(source)
+    covered_by_class = _classes_declaring_entrypoint(tree)
+    findings: list[Finding] = []
+
+    for node in ast.walk(tree):
+        if not _is_scenario_call(node):
+            continue
+        if _keyword_str(node, "api") != "workflow":
+            continue
+        if _declares_entrypoint(node) or node.lineno in covered_by_class:
+            continue
+
+        name = _keyword_str(node, "name") or "<unnamed>"
+        findings.append(
+            make_finding(
+                filename=filename,
+                rule_id=RULE_T020,
+                node=node,
+                message=(
+                    f"workflow scenario {name!r} does not declare which app "
+                    f"entrypoint it exercises, and this app declares "
+                    f"{entrypoint_count}. It will start the app's default "
+                    f"entrypoint. Set entrypoint=... on the Scenario, or a "
+                    f"class-level entrypoint on the suite."
+                ),
+                directives=directives,
+            )
+        )
+
+    return findings
+
+
+def scan_path(path: Path, root: Path) -> list[Finding]:
+    """Scan one test file, resolving the app's entrypoint count from ``root``."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return []
+    try:
+        rel = path.relative_to(root)
+    except ValueError:
+        rel = path
+    return scan_text(text, str(rel), entrypoint_count=app_entrypoint_count(root))
+
+
+def discover(root: Path) -> list[Path]:
+    """Discover pytest test files under ``tests/``.
+
+    Scenario suites are not confined to ``tests/integration/`` — several
+    connectors keep them under ``tests/e2e/`` or ``tests/sdr/`` — so this walks
+    the whole tree rather than one tier.
+    """
+    base = root / "tests"
+    if not base.is_dir():
+        return []
+    paths: list[Path] = []
+    for path in base.rglob("*.py"):
+        if "__pycache__" in path.parts:
+            continue
+        name = path.name
+        if name.startswith("test_") or name.endswith("_test.py"):
+            paths.append(path)
+    return sorted(paths)
+
+
+def scan_all(paths: list[Path], root: Path) -> list[Finding]:
+    """Scan every discovered test file, resolving the entrypoint count once.
+
+    The app-side count is repo-global, so computing it per file would re-walk
+    ``app/`` for every test module.
+    """
+    count = app_entrypoint_count(root)
+    if count < 2:
+        return []
+
+    findings: list[Finding] = []
+    for path in paths:
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        try:
+            rel = path.relative_to(root)
+        except ValueError:
+            rel = path
+        findings.extend(scan_text(text, str(rel), entrypoint_count=count))
+    return findings
+
+
+main = make_cli_main(
+    scan_all=scan_all,
+    discover=discover,
+    description=__doc__,
+)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/packages/conformance/conformance/suite/rules/tests.py
+++ b/packages/conformance/conformance/suite/rules/tests.py
@@ -1341,4 +1341,50 @@ RULES: tuple[RuleDefinition, ...] = (
             "packages/conformance/conformance/docs/rules/tests.md#t019"
         ),
     ),
+    RuleDefinition(
+        id="T020",
+        scope=RuleScope.APP,
+        name="UndeclaredWorkflowEntrypoint",
+        tier=EnforcementTier.WARN,
+        mechanism=RuleMechanism.STATIC,
+        category="test-coverage-attribution",
+        autofixable=False,
+        since="0.18.0",
+        rationale=(
+            "A Scenario with api=\"workflow\" means 'POST /workflows/v1/start'. It "
+            "does not say which @entrypoint gets started. On an app declaring more "
+            "than one, an undeclared scenario silently starts the app's default "
+            "entrypoint - so a suite believing it exercises the miner may in fact "
+            "be running the crawler, and passing. The second cost is attribution: "
+            "which product workflow a suite covers becomes recoverable only by "
+            "reading the test's source and resolving base-class defaults through "
+            "the MRO, so no tooling can report per-workflow integration coverage. "
+            "A survey of ten connectors found two tests out of roughly two thousand "
+            "stating it in any machine-readable form. Declaring it costs one line "
+            "and makes both problems go away."
+        ),
+        short_description=(
+            "Workflow scenario does not declare which app entrypoint it exercises"
+        ),
+        full_description=(
+            'A ``Scenario(api="workflow", ...)`` in an app that declares more\n'
+            "than one ``@entrypoint`` passes neither ``entrypoint=`` nor an\n"
+            "explicit ``endpoint=``, and its enclosing ``Test*`` class sets no\n"
+            "class-level ``entrypoint``.\n"
+            "\n"
+            "Only fires for multi-entrypoint apps - on a single-entrypoint app the\n"
+            "target is unambiguous and declaring it would be noise.\n"
+            "\n"
+            '**Remediation:** set ``entrypoint="crawler"`` (or whichever) on the\n'
+            "scenario, or a class-level ``entrypoint`` on the suite when every\n"
+            "scenario in it targets the same workflow.\n"
+            "\n"
+            "Suppress with ``# conformance: ignore[T020] <reason>`` on the\n"
+            "``Scenario(`` line.\n"
+        ),
+        help_uri=(
+            "https://github.com/atlanhq/application-sdk/blob/main/"
+            "packages/conformance/conformance/docs/rules/tests.md#t020"
+        ),
+    ),
 )

--- a/packages/conformance/conformance/suite/runner.py
+++ b/packages/conformance/conformance/suite/runner.py
@@ -56,6 +56,7 @@ from conformance.suite.checks import (
     security,
     test_quality,
     test_structure,
+    workflow_entrypoint_declared,
 )
 from conformance.suite.checks._ast_common import TOOL_VERSION, detect_scope
 from conformance.suite.rules import CATALOG, assert_registry_consistent, get_rule
@@ -81,6 +82,12 @@ class CheckRegistration:
 
 
 _CHECKS: list[CheckRegistration] = [
+    CheckRegistration(
+        series=workflow_entrypoint_declared.SERIES,
+        discover=workflow_entrypoint_declared.discover,
+        scan_path=workflow_entrypoint_declared.scan_path,
+        scan_all=workflow_entrypoint_declared.scan_all,
+    ),
     CheckRegistration(
         series=actions_pinning.SERIES,
         discover=actions_pinning.discover,

--- a/packages/conformance/tests/test_catalog.py
+++ b/packages/conformance/tests/test_catalog.py
@@ -202,6 +202,9 @@ def test_catalog_app_scoped_rules_are_the_expected_set() -> None:
     # T017: e2e agent_spec() override must inherit the per-leg deployment queue —
     # only connector apps subclass the e2e harness and (may) override agent_spec;
     # the SDK ships the env-derived default, it doesn't hard-code a connector queue.
+    # T020: a workflow Scenario must declare which app @entrypoint it exercises —
+    # only connector apps declare @entrypoint methods and run Scenario suites
+    # against them; the SDK ships the field, it is not a subject of the rule.
     assert app_scoped == {
         "B001",
         "C002",
@@ -272,6 +275,7 @@ def test_catalog_app_scoped_rules_are_the_expected_set() -> None:
         "I004",
         "I005",
         "S002",
+        "T020",
     }, app_scoped
     # SDK-only rules: the SDK must keep Temporal contained behind its seam
     # (P006/P007, BLDX-1417) and declare its deprecations correctly (B002–B004).
@@ -481,11 +485,12 @@ def test_catalog_t_series_present() -> None:
     marking), T002/T003 (SDR test-quality), T004 (dev-entrypoint), T005-T009
     (assertion/collection quality), T010-T013 (tier structure), T014/T015
     (coverage-config), T016/T017 (e2e-CI queue isolation), T018
-    (integration tier deselected by addopts), and T019 (asyncio test-loop scope
-    unset relative to a broadened fixture loop scope)."""
+    (integration tier deselected by addopts), T019 (asyncio test-loop scope
+    unset relative to a broadened fixture loop scope), and T020 (workflow
+    scenario not declaring which app entrypoint it exercises)."""
     rules = load_catalog()
     t_ids = {r.id for r in rules if r.id.startswith("T")}
-    expected = {f"T{n:03d}" for n in range(1, 20)}
+    expected = {f"T{n:03d}" for n in range(1, 21)}
     missing = expected - t_ids
     assert not missing, f"Missing T-series rules: {missing}"
     extra = t_ids - expected

--- a/packages/conformance/tests/test_workflow_entrypoint_declared.py
+++ b/packages/conformance/tests/test_workflow_entrypoint_declared.py
@@ -1,0 +1,205 @@
+"""Tests for T020 UndeclaredWorkflowEntrypoint."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+from conformance.suite.checks.workflow_entrypoint_declared import (
+    app_entrypoint_count,
+    discover,
+    scan_path,
+    scan_text,
+)
+
+_MULTI = 2
+
+
+def _scan(source: str, count: int = _MULTI):
+    return scan_text(
+        textwrap.dedent(source), "tests/integration/test_x.py", entrypoint_count=count
+    )
+
+
+# ---------------------------------------------------------------- app side
+
+
+def _write_app(tmp_path: Path, source: str) -> Path:
+    app = tmp_path / "app"
+    app.mkdir(parents=True, exist_ok=True)
+    (app / "main.py").write_text(textwrap.dedent(source))
+    return tmp_path
+
+
+def test_counts_distinct_entrypoints(tmp_path):
+    repo = _write_app(
+        tmp_path,
+        """
+        class MyApp(App):
+            @entrypoint
+            async def crawler(self, i): ...
+
+            @entrypoint(name="miner")
+            async def miner(self, i): ...
+
+            @task
+            async def fetch(self, i): ...
+        """,
+    )
+    assert app_entrypoint_count(repo) == 2
+
+
+def test_no_app_package_counts_zero(tmp_path):
+    assert app_entrypoint_count(tmp_path) == 0
+
+
+# ------------------------------------------------------------- rule scope
+
+
+def test_single_entrypoint_app_is_never_flagged():
+    """Declaring is noise when there is only one possible target."""
+    findings = _scan(
+        """
+        Scenario(name="run", api="workflow", assert_that={})
+        """,
+        count=1,
+    )
+    assert findings == []
+
+
+def test_non_workflow_scenarios_are_ignored():
+    findings = _scan(
+        """
+        Scenario(name="auth", api="auth", assert_that={})
+        Scenario(name="pre", api="preflight", assert_that={})
+        """
+    )
+    assert findings == []
+
+
+# ------------------------------------------------------------- detection
+
+
+def test_undeclared_workflow_scenario_is_flagged():
+    findings = _scan(
+        """
+        Scenario(name="crawl", api="workflow", assert_that={})
+        """
+    )
+    assert len(findings) == 1
+    assert findings[0].rule_id == "T020"
+    assert "crawl" in findings[0].message
+    assert "declares 2" in findings[0].message
+
+
+def test_declared_entrypoint_satisfies_the_rule():
+    findings = _scan(
+        """
+        Scenario(name="crawl", api="workflow", assert_that={}, entrypoint="crawler")
+        """
+    )
+    assert findings == []
+
+
+def test_explicit_endpoint_override_satisfies_the_rule():
+    """An explicit endpoint is already unambiguous."""
+    findings = _scan(
+        """
+        Scenario(name="crawl", api="workflow", assert_that={},
+                 endpoint="/start?entrypoint=miner")
+        """
+    )
+    assert findings == []
+
+
+def test_class_level_entrypoint_covers_its_scenarios():
+    findings = _scan(
+        """
+        class TestSuite(BaseIntegrationTest):
+            entrypoint = "crawler"
+            scenarios = [
+                Scenario(name="crawl", api="workflow", assert_that={}),
+            ]
+        """
+    )
+    assert findings == []
+
+
+def test_class_without_entrypoint_does_not_cover_its_scenarios():
+    findings = _scan(
+        """
+        class TestSuite(BaseIntegrationTest):
+            timeout = 30
+            scenarios = [
+                Scenario(name="crawl", api="workflow", assert_that={}),
+            ]
+        """
+    )
+    assert len(findings) == 1
+
+
+def test_each_undeclared_scenario_is_reported_separately():
+    findings = _scan(
+        """
+        Scenario(name="a", api="workflow", assert_that={})
+        Scenario(name="b", api="workflow", assert_that={}, entrypoint="miner")
+        Scenario(name="c", api="workflow", assert_that={})
+        """
+    )
+    assert [f.message.split("'")[1] for f in findings] == ["a", "c"]
+
+
+def test_inline_suppression_is_honoured():
+    findings = _scan(
+        """
+        # conformance: ignore[T020] single-workflow suite, tracked in X-123
+        Scenario(name="crawl", api="workflow", assert_that={})
+        """
+    )
+    assert all(f.suppressed for f in findings)
+
+
+def test_unparseable_file_is_skipped():
+    assert scan_text("def broken(:\n", "tests/x.py", entrypoint_count=_MULTI) == []
+
+
+# -------------------------------------------------------------- discovery
+
+
+def test_discover_walks_every_test_tier(tmp_path):
+    """Scenario suites live under e2e/ and sdr/ too, not just integration/."""
+    for rel in [
+        "tests/integration/test_a.py",
+        "tests/e2e/test_b.py",
+        "tests/sdr/test_c.py",
+        "tests/unit/helpers.py",
+    ]:
+        p = tmp_path / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("")
+    found = {p.name for p in discover(tmp_path)}
+    assert found == {"test_a.py", "test_b.py", "test_c.py"}
+
+
+def test_discover_returns_empty_without_tests(tmp_path):
+    assert discover(tmp_path) == []
+
+
+def test_scan_path_resolves_the_apps_entrypoint_count(tmp_path):
+    repo = _write_app(
+        tmp_path,
+        """
+        class MyApp(App):
+            @entrypoint
+            async def crawler(self, i): ...
+
+            @entrypoint
+            async def miner(self, i): ...
+        """,
+    )
+    test = repo / "tests" / "integration" / "test_x.py"
+    test.parent.mkdir(parents=True, exist_ok=True)
+    test.write_text('Scenario(name="crawl", api="workflow", assert_that={})\n')
+    findings = scan_path(test, repo)
+    assert len(findings) == 1
+    assert findings[0].file == "tests/integration/test_x.py"

--- a/tests/unit/testing/integration/test_scenario_entrypoint.py
+++ b/tests/unit/testing/integration/test_scenario_entrypoint.py
@@ -1,0 +1,94 @@
+"""Tests for declaring which app entrypoint an integration scenario exercises.
+
+Multi-entrypoint apps previously had no way to say this in the Scenario
+framework: ``api="workflow"`` only means "POST /start". Which product workflow a
+suite covered was recoverable only by reading the test's source, and every
+scenario silently hit the app's default entrypoint.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from application_sdk.testing.integration.assertions import equals
+from application_sdk.testing.integration.models import Scenario
+from application_sdk.testing.integration.runner import BaseIntegrationTest
+
+
+def _scenario(**kwargs) -> Scenario:
+    base = {"name": "wf", "api": "workflow", "assert_that": {"success": equals(True)}}
+    base.update(kwargs)
+    return Scenario(**base)
+
+
+class _Suite(BaseIntegrationTest):
+    __test__ = False
+    scenarios: list[Scenario] = []
+
+
+def _resolve(suite_cls, scenario: Scenario) -> str:
+    return BaseIntegrationTest._resolve_workflow_endpoint(suite_cls, scenario)  # type: ignore[arg-type]
+
+
+def test_no_entrypoint_declared_keeps_the_bare_endpoint():
+    """Single-entrypoint apps must keep working untouched."""
+    assert _resolve(_Suite, _scenario()) == "/start"
+
+
+def test_scenario_entrypoint_is_appended():
+    assert _resolve(_Suite, _scenario(entrypoint="miner")) == "/start?entrypoint=miner"
+
+
+def test_class_level_entrypoint_applies_to_every_scenario():
+    class Suite(_Suite):
+        __test__ = False
+        entrypoint = "crawler"
+
+    assert _resolve(Suite, _scenario()) == "/start?entrypoint=crawler"
+
+
+def test_scenario_overrides_the_class_default():
+    class Suite(_Suite):
+        __test__ = False
+        entrypoint = "crawler"
+
+    assert _resolve(Suite, _scenario(entrypoint="miner")) == "/start?entrypoint=miner"
+
+
+def test_explicit_endpoint_still_wins_outright():
+    """``endpoint`` is a full override and may carry its own query string."""
+    scenario = _scenario(endpoint="/start?entrypoint=custom&foo=1", entrypoint="miner")
+    assert _resolve(_Suite, scenario) == "/start?entrypoint=custom&foo=1"
+
+
+def test_appends_with_ampersand_when_endpoint_already_has_a_query():
+    class Suite(_Suite):
+        __test__ = False
+        workflow_endpoint = "/start?dry_run=true"
+        entrypoint = "clean"
+
+    assert _resolve(Suite, _scenario()) == "/start?dry_run=true&entrypoint=clean"
+
+
+@pytest.mark.parametrize(
+    ("raw", "encoded"),
+    [("extract-metadata", "extract-metadata"), ("a b", "a%20b"), ("a/b", "a%2Fb")],
+)
+def test_entrypoint_is_url_encoded(raw, encoded):
+    assert _resolve(_Suite, _scenario(entrypoint=raw)) == f"/start?entrypoint={encoded}"
+
+
+def test_entrypoint_defaults_to_none_on_the_scenario():
+    assert _scenario().entrypoint is None
+
+
+def test_entrypoint_survives_a_full_scenario_construction():
+    """Guards the field against being dropped by a future dataclass edit."""
+    scenario = Scenario(
+        name="crawl",
+        api="workflow",
+        assert_that={"success": equals(True)},
+        entrypoint="crawler",
+        schema_base_path="tests/integration/schema/crawler/transformed",
+    )
+    assert scenario.entrypoint == "crawler"


### PR DESCRIPTION
## What

Adds `Scenario.entrypoint` (and a suite-wide `BaseIntegrationTest.entrypoint` default), plus a WARN-tier conformance rule that flags multi-entrypoint apps whose workflow scenarios don't declare one.

Two commits. Fully backward compatible — with nothing declared, the emitted endpoint is byte-identical to today.

## Why

`Scenario(api="workflow", ...)` means "POST /workflows/v1/start". It does **not** say which `@entrypoint` gets started. The dataclass has 25 fields and no workflow identifier — the framework cannot express a multi-entrypoint app.

**Correctness cost.** On an app with several entrypoints, every undeclared workflow scenario starts the *default* one. A suite believing it exercises the miner may in fact be running the crawler, and passing. Nothing surfaces the mismatch. Today suites work around this by hardcoding `endpoint="/start?entrypoint=miner"` or overriding the request in a repo-local base class:

```python
# atlan-snowflake-app/tests/integration/base.py:241
params={"entrypoint": "crawler"}
# atlan-databricks-app/tests/e2e/databricks_e2e_base.py:112
def run_workflow(self, data, entrypoint: str = "crawler"):
# atlan-dbt-app/tests/integration/base.py:176
params={"entrypoint": "extract-metadata"}
```

**Attribution cost.** Which product workflow a suite covers is recoverable only by reading its source and resolving base-class defaults through the MRO. A survey of ten connectors found **2 tests out of ~2000** stating it in any machine-readable form (tableau's and powerbi's full-DAG harnesses, via `manifest_path`). That's why no tooling can report per-workflow integration coverage — the data doesn't exist.

## Resolution order

| | |
|---|---|
| `scenario.endpoint` | full override, wins outright (may carry its own query string) — unchanged |
| `scenario.entrypoint` | appended to `workflow_endpoint` |
| `cls.entrypoint` | suite-wide default |
| neither | bare `workflow_endpoint`, exactly as today |

Value is URL-encoded; `&` is used when `workflow_endpoint` already has a query.

## T020 UndeclaredWorkflowEntrypoint

WARN tier, deliberately narrow:

- Fires **only** when the app declares 2+ `@entrypoint` methods. On a single-entrypoint app the target is unambiguous and declaring it would be noise, so those repos see nothing.
- Satisfied by `entrypoint=`, an explicit `endpoint=`, or a class-level `entrypoint` on the enclosing suite.
- Resolution is syntactic — scenarios built by helper functions or spread via `**kwargs` are never flagged.

**It currently fires nowhere in the fleet.** No connector uses the SDK Scenario workflow API on a multi-entrypoint app; they all hand-rolled base classes instead. The rule guards suites as they migrate onto the declared field. That's the honest state, not a claim of impact.

Uses `scan_all` so the app-side entrypoint count is computed once per repo rather than re-walking `app/` per test module.

## Follow-on

This unblocks per-workflow integration coverage reporting (#3029, draft) — with the entrypoint declared, which workflow a suite covers becomes derivable instead of hand-maintained.

## Testing

- 11 tests on endpoint resolution (precedence, encoding, query-string merging, backward compatibility)
- 15 tests on T020 (scope gating, detection, class-level coverage, suppression, discovery)
- Full conformance suite: 2094 passed. The one failure (`test_app_name_alignment.py`, `ModuleNotFoundError: application_sdk`) is pre-existing on `main` in this venv — verified by stashing.
- `uv run pre-commit run` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
