### PR TITLE
ci(e2e): a zero-leg prepare-tenant matrix deleted the whole e2e suite

### DIFF
--- a/.github/scripts/tests/test_prepare_tenant_wiring.py
+++ b/.github/scripts/tests/test_prepare_tenant_wiring.py
@@ -204,10 +204,62 @@ def test_suite_and_cloud_discovery_use_the_same_clouds_expression() -> None:
     )
 
 
+def test_the_cloud_fallback_is_guarded_on_the_count_not_the_string(jobs: dict) -> None:  # type: ignore[type-arg]
+    """An empty cloud list must yield ONE leg, never zero.
+
+    A repo without the tenant-matrix secret resolves to `--clouds none`, which
+    emits `{"include":[]}` — a perfectly non-empty string. So the natural
+    `matrix || fallback` never takes the fallback, the job expands to zero legs,
+    and a matrix job with zero legs is not a skipped job: it does not exist.
+    `needs.prepare-tenant.result` is then never success-or-skipped and every job
+    gated on it vanishes, which deleted an entire e2e matrix on the first live
+    install run.
+
+    The count is the only thing that carries the distinction, which is why
+    e2e-full-reusable.yaml has always guarded on it.
+    """
+    matrix = " ".join(jobs["prepare-tenant"]["strategy"]["matrix"].split())
+    assert "cloud-count != '0'" in matrix, (
+        "prepare-tenant's matrix falls back on the matrix STRING being empty, "
+        'which never happens — `{"include":[]}` is truthy. Guard on '
+        "`needs.discover-e2e.outputs.cloud-count != '0'` instead, or this job "
+        "expands to zero legs and takes the e2e legs with it."
+    )
+    assert '{"include":[{"cloud":""}]}' in matrix, (
+        "the fallback must be a single leg with a defined-but-empty `cloud` — "
+        "that is what makes the tenant resolver take its single-tenant path"
+    )
+
+
+def test_both_reusables_fall_back_the_same_way() -> None:
+    """The two cloud fan-outs must not drift in *mechanism*, only in wiring.
+
+    tests-reusable.yaml's version was written by copying the intent of
+    e2e-full-reusable.yaml's without its mechanism — the count guard — and that
+    is precisely the bug above. Pinning them together is cheaper than
+    rediscovering it on the next live run.
+    """
+    full = (_REPO_ROOT / ".github/workflows/e2e-full-reusable.yaml").read_text(
+        encoding="utf-8"
+    )
+    tests = _WORKFLOW.read_text(encoding="utf-8")
+    fallback = '{"include":[{"cloud":""}]}'
+    for name, text in (("e2e-full-reusable", full), ("tests-reusable", tests)):
+        assert fallback in text, f"{name} no longer carries the single-leg fallback"
+        assert "count != '0'" in text, (
+            f"{name}'s cloud matrix no longer guards on the count. Falling back "
+            "on the matrix string alone silently produces a zero-leg job."
+        )
+
+
 def test_cloud_matrix_output_is_exposed(jobs: dict) -> None:  # type: ignore[type-arg]
     outputs = jobs["discover-e2e"]["outputs"]
-    assert "cloud-matrix" in outputs
-    assert "discover-clouds" in outputs["cloud-matrix"]
+    # Both, and both from the same step: the matrix says which clouds, the count
+    # says whether there is a cloud dimension at all, and the consumer needs the
+    # second to interpret the first.
+    for key in ("cloud-matrix", "cloud-count"):
+        assert key in outputs, f"discover-e2e no longer exposes {key}"
+        assert "discover-clouds" in outputs[key]
 
 
 # ── No expression interpolation into run: in the jobs this change adds ───────

--- a/.github/scripts/tests/test_prepare_tenant_wiring.py
+++ b/.github/scripts/tests/test_prepare_tenant_wiring.py
@@ -238,15 +238,30 @@ def test_both_reusables_fall_back_the_same_way() -> None:
     e2e-full-reusable.yaml's without its mechanism — the count guard — and that
     is precisely the bug above. Pinning them together is cheaper than
     rediscovering it on the next live run.
+
+    Parsed, not grepped: `count != '0'` also guards three unrelated job gates
+    in tests-reusable.yaml, so a whole-file text search stays green even if the
+    fan-out matrix itself loses the guard. Asserting on the parsed
+    `strategy.matrix` of each cloud fan-out job binds the drift guard to the
+    expression that actually expands to zero legs.
     """
-    full = (_REPO_ROOT / ".github/workflows/e2e-full-reusable.yaml").read_text(
-        encoding="utf-8"
+    full = yaml.safe_load(
+        (_REPO_ROOT / ".github/workflows/e2e-full-reusable.yaml").read_text(
+            encoding="utf-8"
+        )
     )
-    tests = _WORKFLOW.read_text(encoding="utf-8")
+    tests = yaml.safe_load(_WORKFLOW.read_text(encoding="utf-8"))
     fallback = '{"include":[{"cloud":""}]}'
-    for name, text in (("e2e-full-reusable", full), ("tests-reusable", tests)):
-        assert fallback in text, f"{name} no longer carries the single-leg fallback"
-        assert "count != '0'" in text, (
+    fan_outs = (
+        ("e2e-full-reusable", full["jobs"]["e2e-full"]),
+        ("tests-reusable", tests["jobs"]["prepare-tenant"]),
+    )
+    for name, job in fan_outs:
+        matrix = " ".join(job["strategy"]["matrix"].split())
+        assert (
+            fallback in matrix
+        ), f"{name}'s cloud fan-out no longer carries the single-leg fallback"
+        assert "count != '0'" in matrix, (
             f"{name}'s cloud matrix no longer guards on the count. Falling back "
             "on the matrix string alone silently produces a zero-leg job."
         )

--- a/.github/workflows/tests-reusable.yaml
+++ b/.github/workflows/tests-reusable.yaml
@@ -692,6 +692,14 @@ jobs:
       # — a prepare-tenant that missed a cloud the legs then ran against would be
       # a silent coverage hole, not a visible failure.
       cloud-matrix: ${{ steps.discover-clouds.outputs.matrix }}
+      # Exposed alongside the matrix because the CONSUMER has to distinguish "no
+      # cloud dimension" (count 0, and one fallback leg is wanted) from "these
+      # clouds". The matrix string cannot carry that distinction: `{"include":[]}`
+      # is a perfectly non-empty string, so a `matrix || fallback` expression
+      # never takes the fallback and the job expands to zero legs instead of one.
+      # e2e-full-reusable.yaml's plan-clouds has always guarded on the count for
+      # exactly this reason.
+      cloud-count: ${{ steps.discover-clouds.outputs.count }}
     env:
       # Job-level so the step-level `if:` below can read it — a step condition
       # cannot reference the `secrets` context directly.
@@ -959,7 +967,21 @@ jobs:
       # One cloud's tenant being uninstallable must not cancel the others; the
       # legs for that cloud fail on their own version check.
       fail-fast: false
-      matrix: ${{ fromJson(needs.discover-e2e.outputs.cloud-matrix || '{"include":[{"cloud":""}]}') }}
+      # Guarded on the COUNT, not on the matrix string. `--clouds none` — which is
+      # what a repo without the tenant-matrix secret resolves to — emits
+      # `{"include":[]}`, a non-empty string, so `matrix || fallback` keeps the
+      # empty include and this job expands to ZERO legs. A matrix job with no legs
+      # is not a skipped job: it does not exist, `needs.prepare-tenant.result` is
+      # never success-or-skipped, and every job gated on it disappears. That
+      # deleted the whole e2e matrix on the first live install run — Tests Gate
+      # caught it ("discovery succeeded but the matrix was skipped"), nothing else
+      # would have.
+      #
+      # Same expression e2e-full-reusable.yaml's e2e-full has always used. The
+      # single fallback leg spells out `cloud: ""` rather than `{}` so
+      # `matrix.cloud` is a defined-but-empty string, which is what makes the
+      # tenant resolver take its single-tenant path.
+      matrix: ${{ fromJson(needs.discover-e2e.outputs.cloud-count != '0' && needs.discover-e2e.outputs.cloud-matrix || '{"include":[{"cloud":""}]}') }}
     runs-on: ubuntu-latest
     # Twice the script's own waits, not a shade over them: the install retries for
     # up to ~600s while LM's catalog snapshot catches up, then polls the deployment


### PR DESCRIPTION
Found by the first live run of the FND-31 install path ([atlan-openapi-app#320](https://github.com/atlanhq/atlan-openapi-app/pull/320)): `prepare-tenant` didn't appear in the job list at all, the e2e legs skipped, and `Tests Gate` failed with *"e2e discovery succeeded (suites found) but the matrix was skipped"*.

## The chain

`atlan-openapi-app` has not been granted `E2E_TENANT_MATRIX_JSON`, so the clouds expression resolves to `none` → `parse_clouds` returns `[]` → `--clouds-only` emits `{"include":[]}`. `prepare-tenant`'s matrix was:

```yaml
matrix: ${{ fromJson(needs.discover-e2e.outputs.cloud-matrix || '{"include":[{"cloud":""}]}') }}
```

`{"include":[]}` is a perfectly non-empty string, so the `||` never fired and the job expanded to **zero legs**.

A matrix job with zero legs is *not* a skipped job — it does not exist. `needs.prepare-tenant.result` is therefore never success-or-skipped, and every job gated on it disappears. An entire e2e matrix, deleted by a repo not having a secret. Nothing but `Tests Gate` would have noticed; the run would otherwise have been green-with-no-e2e.

## The fix

`e2e-full-reusable.yaml` has always had this right:

```yaml
matrix: ${{ fromJson(needs.plan-clouds.outputs.count != '0' && needs.plan-clouds.outputs.matrix || '<fallback>') }}
```

It guards on the **count**, because the count is the only output that distinguishes "no cloud dimension" from "these clouds" — the matrix string can't carry that. I wrote the `tests-reusable` version by copying that fallback's *intent* without its *mechanism*. So this exposes `cloud-count` from `discover-e2e` and guards on it, making the two expressions the same expression.

**Rejected alternative:** changing `discover_e2e_suites.py` to emit one default leg instead of zero. It would have worked, but `count=0` is a deliberate contract — an existing test says so in as many words — and `e2e-full-reusable` already depends on it. Changing the producer to fix one consumer's misuse would have moved the bug into the other consumer.

## Guards

Four, all mutation-verified red before I trusted them:

- the exact bug — falling back on the matrix string
- the fallback leg losing its defined-but-empty `cloud` key (which is what makes the tenant resolver take its single-tenant path)
- the `cloud-count` output being dropped
- **pinned across both files**: `e2e-full-reusable` losing its own count guard, so the two can't drift in mechanism again

## Not fixed here

`E2E_TENANT_MATRIX_JSON` is not shared with `atlan-openapi-app` — that's config, not code. Discovery already warns about it explicitly. With this change `prepare-tenant` now runs its single fallback leg and fails on the tenant-ID gate with an actionable message, instead of silently taking the e2e legs with it.

1289 script tests pass; `pre-commit --all-files` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
