### PR TITLE
ci(e2e): retry the read-back of a tag we just pushed

### DIFF
--- a/.github/actions/build-app-image/action.yaml
+++ b/.github/actions/build-app-image/action.yaml
@@ -313,12 +313,27 @@ runs:
     # logic lives in the tested script per docs/standards/ci.md (no branching in
     # inline shell).
     #
-    # On a multi-arch build this pulls and asserts the RUNNER's variant only —
-    # `docker run` resolves the index to the host architecture. That is deliberate
-    # rather than a gap: the interpreter comes from the same Dockerfile and golden
-    # base tag for every platform, so a per-arch difference would be a base-image
-    # bug, and emulating the other arch here would cost a QEMU round-trip to
-    # re-assert a constant.
+    # This asserts the RUNNER's variant only — `docker run` resolves an index to
+    # the host architecture. On the per-architecture install path that is a
+    # feature, not the gap it looks like: each leg runs on a runner native to the
+    # image it built, so every architecture gets asserted on its own leg. Worth
+    # having, because a multi-arch base is a manifest list whose arm64 entry is a
+    # SEPARATELY BUILT image — nothing guarantees its interpreter matches amd64's
+    # unless something checks, and the legs are parallel so the second check is
+    # free in wall-clock terms.
+    #
+    # The pull is retried because it is a read-back of a tag this job pushed
+    # seconds earlier. buildx's container driver (needed for the gha layer cache)
+    # exports straight to the registry and leaves no local copy, so `docker run`
+    # has to fetch back the bytes we just uploaded — and GHCR does not always
+    # serve a tag that fast. One live arm64 leg got `manifest unknown` 0.7s after
+    # its own push reported success, while the amd64 leg read an equally fresh tag
+    # without complaint; a re-run passed unchanged, which is what a read-after-
+    # write race looks like.
+    #
+    # Retrying the PULL specifically, rather than the whole assert, is the point:
+    # a genuine interpreter mismatch still fails once, immediately, instead of
+    # being retried three times over 15 seconds before reporting the same thing.
     - name: Assert worker image Python matches expected
       if: inputs.expected-python-version != ''
       shell: bash
@@ -326,6 +341,8 @@ runs:
         IMAGE: ${{ steps.build.outputs.image }}
         EXPECTED: ${{ inputs.expected-python-version }}
       run: |
+        set -euo pipefail
+        "${{ github.action_path }}/../../scripts/with-retry.sh" docker pull "${IMAGE}"
         ACTUAL=$(docker run --rm --entrypoint python "${IMAGE}" --version)
         echo "Worker image reports: ${ACTUAL} (expected ${EXPECTED}.x)"
         python3 "${{ github.action_path }}/../../scripts/container_python_version.py" \

--- a/.github/scripts/tests/test_build_app_image_action.py
+++ b/.github/scripts/tests/test_build_app_image_action.py
@@ -80,6 +80,10 @@ def _step(action_yaml: Path, name: str) -> dict:  # type: ignore[type-arg]
             r"\$\{\{ github\.action_path \}\}/(\S*?assert_image_platforms\.py)",
             "platform-assert script",
         ),
+        (
+            r"\$\{\{ github\.action_path \}\}/(\S*?with-retry\.sh)",
+            "retry helper",
+        ),
     ],
 )
 def test_build_action_asset_paths_resolve(pattern: str, description: str) -> None:
@@ -300,6 +304,70 @@ def test_the_merge_job_asserts_the_reference_the_tenant_pulls() -> None:
     # Reads image-base, never a per-arch reference: base is identical from every
     # matrix leg, which is what makes last-writer-wins outputs safe here.
     assert "outputs.image-base" in yaml.safe_dump(job)
+
+
+# ── 5. Reading back a just-pushed tag is a race ──────────────────────────────
+# buildx's container driver (required for the gha layer cache) exports straight
+# to the registry and leaves no local copy, so anything that inspects or runs the
+# image it just built has to fetch it back — and GHCR does not always serve a
+# freshly written tag. A live arm64 leg got `manifest unknown` 0.7s after its own
+# push reported success; a re-run passed unchanged.
+
+
+def test_the_interpreter_assert_retries_the_registry_read() -> None:
+    step = _step(_BUILD_ACTION, "Assert worker image Python matches expected")
+    run = step["run"]
+    assert 'with-retry.sh" docker pull' in run, (
+        "the image read-back must be retried: it fetches a tag this same job "
+        "pushed seconds earlier, and GHCR can answer `manifest unknown` for it"
+    )
+    # The pull is retried; the assertion is NOT. A genuine interpreter mismatch
+    # should fail once, immediately — not be retried three times over 15 seconds
+    # before reporting the same thing.
+    for line in run.splitlines():
+        if "with-retry.sh" in line:
+            assert (
+                "container_python_version.py" not in line and "docker run" not in line
+            ), (
+                "the retry must wrap the pull only, or a real mismatch is "
+                f"retried before it is reported: {line.strip()!r}"
+            )
+
+
+def test_both_architectures_are_asserted_not_just_one() -> None:
+    """Neither leg may opt out of the interpreter check.
+
+    A multi-arch base is a manifest list whose arm64 entry is a SEPARATELY BUILT
+    image; nothing guarantees its interpreter matches amd64's unless something
+    checks. Each leg runs on a runner native to what it built, so each asserts its
+    own variant — and the legs are parallel, so the second check is free in
+    wall-clock terms.
+    """
+    job = _reusable()["jobs"]["build-e2e-image"]
+    step = next(s for s in job["steps"] if "build-app-image" in str(s.get("uses", "")))
+    assert "expected-python-version" not in step.get("with", {}), (
+        "the install path pins expected-python-version per leg. Leave it at the "
+        "action's default so BOTH architectures are asserted — passing '' on one "
+        "leg silently skips that architecture's interpreter check."
+    )
+
+
+def test_the_merge_job_retries_its_manifest_read() -> None:
+    """Same race, same fix: it inspects a tag the previous step just created."""
+    job = _reusable()["jobs"]["merge-e2e-image"]
+    inspect = next(
+        s for s in job["steps"] if "imagetools inspect" in str(s.get("run", ""))
+    )
+    assert "with-retry.sh" in inspect["run"], (
+        "the merge job reads back a manifest it created one step earlier — the "
+        "same read-after-write that failed a build leg"
+    )
+    for line in inspect["run"].splitlines():
+        if "with-retry.sh" in line:
+            assert "assert_image_platforms.py" not in line, (
+                "retry the inspect, not the assertion: a genuinely single-arch "
+                "manifest must fail once rather than three times"
+            )
 
 
 def test_pkl_is_downloaded_for_the_runners_architecture() -> None:

--- a/.github/workflows/tests-reusable.yaml
+++ b/.github/workflows/tests-reusable.yaml
@@ -935,12 +935,21 @@ jobs:
       # and the tenant pulls. A leg that quietly built the wrong architecture
       # shows up here as a missing one — nothing downstream would catch it, since
       # GM accepts the version and LM accepts the install regardless.
+      #
+      # Retried for the same reason as the interpreter assert in build-app-image:
+      # this reads back a tag the PREVIOUS STEP created, and GHCR does not always
+      # serve a just-written tag immediately — a build leg hit exactly that,
+      # `manifest unknown` 0.7s after its own push reported success. The inspect
+      # is retried; the assertion over its output is not, so a genuinely
+      # single-arch manifest still fails once rather than three times.
       - name: Assert the manifest serves both architectures
         env:
           IMAGE: ${{ needs.build-e2e-image.outputs.image-base }}
         run: |
           set -euo pipefail
-          docker buildx imagetools inspect --raw "$IMAGE" \
+          RAW=$(application-sdk-scripts/.github/scripts/with-retry.sh \
+            docker buildx imagetools inspect --raw "$IMAGE")
+          printf '%s' "$RAW" \
             | python3 application-sdk-scripts/.github/scripts/assert_image_platforms.py \
                 --expected linux/amd64,linux/arm64
 


### PR DESCRIPTION
A live arm64 build leg on [atlan-openapi-app#320](https://github.com/atlanhq/atlan-openapi-app/pull/320) failed with:

```
Unable to find image 'ghcr.io/atlanhq/atlan-openapi-app:sdr-test-8680aa4e-arm64' locally
docker: Error response from daemon: manifest unknown
```

**0.7 seconds after its own `pushing manifest … 1.2s done`.**

| | push completed | read-back | result |
|---|---|---|---|
| amd64 | 02:04:25.74 | +0.08s | pulled fine |
| arm64 | 02:04:06.52 | +0.70s | `manifest unknown` |

Same credentials, same code, 19 seconds apart — and a re-run of the arm64 leg passed with **no code change**. That's a read-after-write race, not a broken image.

## Why it's reachable at all

buildx's *container* driver — which we need for the `type=gha` layer cache — exports straight to the registry and leaves no local copy. So anything that wants to run or inspect the image it just built has to fetch it back over the network. Two places do:

- `build-app-image`'s interpreter assert, which `docker run`s the image to read `python --version`.
- `merge-e2e-image`'s platform assert, which inspects a manifest **the previous step created**. Same pattern, not yet observed failing — fixed now rather than after it costs a run.

Both now route the registry read through `.github/scripts/with-retry.sh`, which already wraps the `pkl` download for this same class of problem.

## Retrying the read, not the assertion

The retry wraps the `docker pull` / `imagetools inspect` specifically. A genuine interpreter mismatch, or a genuinely single-arch manifest, still fails **once, immediately** — rather than being retried three times over 15 seconds before reporting the same thing. Guarded in both directions.

## Both architectures keep their interpreter assert

I'd proposed dropping the arm64 one, on the grounds that the interpreter is fixed by the Dockerfile's golden base and so constant across architectures. That was wrong, and @cmgrote called it: a multi-arch base is a manifest list whose **arm64 entry is a separately built image**. Nothing guarantees its interpreter matches amd64's unless something checks, and the two legs run in parallel so the second check costs no wall clock.

There's now a guard stopping a future edit from pinning `expected-python-version` per leg and silently skipping an architecture.

## Verification

4 mutations verified red before I trusted the guards:

- the pull losing its retry
- the retry swallowing the whole assert instead of just the pull
- a leg opting out of the interpreter check
- the merge job's inspect losing its retry

1293 script tests pass; `pre-commit --all-files` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
