### PR TITLE
ci(e2e): load the built image locally instead of pulling it back

### DIFF
--- a/.github/actions/build-app-image/action.yaml
+++ b/.github/actions/build-app-image/action.yaml
@@ -258,6 +258,32 @@ runs:
           echo "Building for platforms: ${PLATFORMS}"
           BUILD_ARGS+=(--platform "${PLATFORMS}")
         fi
+        # Export into the local daemon as well as the registry, so the
+        # interpreter assert below finds the image locally.
+        #
+        # buildx's container driver (needed for the type=gha layer cache) exports
+        # only to the registry, so `docker run` had to fetch back the bytes this
+        # step had just uploaded — 22.7s on a measured amd64 leg, and a read of a
+        # tag the registry does not always serve yet: one live arm64 leg got
+        # `manifest unknown` 0.7s after its own push reported success. Measured
+        # over a full run (atlan-openapi-app 31139992280 vs 31141463008), --load
+        # costs ~10-18s of local import and removes 22.7s of pull, so the amd64
+        # leg went 89s -> 76s and the assert step 22.7s -> 0.17s. The bigger win
+        # is the second one: the build legs no longer read from the registry at
+        # all, so that race cannot occur here rather than being retried through.
+        #
+        # Single-platform only — the docker exporter cannot express a manifest
+        # list, so a caller naming two platforms in one build would fail outright.
+        # Multiple exporters need buildx >= 0.13; the runners ship v0.35.0 with
+        # BuildKit v0.31.2, so nothing needs pinning.
+        case "${PLATFORMS}" in
+          *,*)
+            echo "Multi-platform build: not loading locally (the docker exporter cannot hold a manifest list); the interpreter assert will pull instead"
+            ;;
+          *)
+            BUILD_ARGS+=(--load)
+            ;;
+        esac
         # --push pushes to GHCR; compose pulls from there at run-time
         # (atlan-configurator wires app_image into the generated
         # compose file as a pull target). --load would conflict with
@@ -313,12 +339,20 @@ runs:
     # logic lives in the tested script per docs/standards/ci.md (no branching in
     # inline shell).
     #
-    # On a multi-arch build this pulls and asserts the RUNNER's variant only —
-    # `docker run` resolves the index to the host architecture. That is deliberate
-    # rather than a gap: the interpreter comes from the same Dockerfile and golden
-    # base tag for every platform, so a per-arch difference would be a base-image
-    # bug, and emulating the other arch here would cost a QEMU round-trip to
-    # re-assert a constant.
+    # No pull: the build step above `--load`ed the image into the local daemon,
+    # so this is a local container start (0.17s measured, against 22.7s when it
+    # had to fetch the image back from GHCR). A caller building two platforms in
+    # one job gets no local copy — the docker exporter cannot hold a manifest list
+    # — and `docker run` falls back to pulling, which still works, just slower.
+    #
+    # This asserts the RUNNER's variant only, since `docker run` resolves an index
+    # to the host architecture. On the per-architecture install path that is a
+    # feature rather than the gap it looks like: each leg runs on a runner native
+    # to the image it built, so every architecture is asserted on its own leg.
+    # Worth having, because a multi-arch base is a manifest list whose arm64 entry
+    # is a SEPARATELY BUILT image — nothing guarantees its interpreter matches
+    # amd64's unless something checks — and the legs are parallel, so the second
+    # check costs no wall clock.
     - name: Assert worker image Python matches expected
       if: inputs.expected-python-version != ''
       shell: bash

--- a/.github/scripts/tests/test_build_app_image_action.py
+++ b/.github/scripts/tests/test_build_app_image_action.py
@@ -302,6 +302,90 @@ def test_the_merge_job_asserts_the_reference_the_tenant_pulls() -> None:
     assert "outputs.image-base" in yaml.safe_dump(job)
 
 
+# ── 5. Reading back a just-pushed tag is a race ──────────────────────────────
+# buildx's container driver (required for the gha layer cache) exports only to
+# the registry, so anything wanting to run the image it just built had to fetch
+# it back — 22.7s on a measured amd64 leg, and a read of a tag GHCR does not
+# always serve yet (`manifest unknown` 0.7s after a successful push, on a live
+# arm64 leg). `--load` removes the read; where a read is unavoidable, it retries.
+
+
+def test_a_single_platform_build_is_loaded_locally() -> None:
+    build = _step(_BUILD_ACTION, "Build and push PR image")
+    # The flag itself, not the substring: the comment above it explains --load at
+    # length, so `"--load" in run` stays true even after the flag is deleted.
+    assert "BUILD_ARGS+=(--load)" in build["run"], (
+        "the build must also export into the local daemon, or the interpreter "
+        "assert pays a registry round-trip for an image this step just built"
+    )
+    # Gated: the docker exporter cannot express a manifest list, so a caller
+    # naming two platforms in one build would fail outright.
+    assert "*,*)" in build["run"], (
+        "--load must be skipped for a multi-platform build, which cannot be "
+        "represented in the local daemon"
+    )
+
+
+def test_the_interpreter_assert_does_not_pull() -> None:
+    """The whole point of --load is that this step touches no registry."""
+    run = _step(_BUILD_ACTION, "Assert worker image Python matches expected")["run"]
+    assert "docker pull" not in run, (
+        "a docker pull here defeats --load: the image is already local, and "
+        "pulling reintroduces both the latency and the read-after-write race"
+    )
+    assert "docker run --rm --entrypoint python" in run
+
+
+def test_both_architectures_are_asserted_not_just_one() -> None:
+    """Neither leg may opt out of the interpreter check.
+
+    A multi-arch base is a manifest list whose arm64 entry is a SEPARATELY BUILT
+    image; nothing guarantees its interpreter matches amd64's unless something
+    checks. Each leg runs on a runner native to what it built, so each asserts its
+    own variant — and the legs are parallel, so the second check is free.
+    """
+    job = _reusable()["jobs"]["build-e2e-image"]
+    step = next(s for s in job["steps"] if "build-app-image" in str(s.get("uses", "")))
+    assert "expected-python-version" not in step.get("with", {}), (
+        "the install path pins expected-python-version per leg. Leave it at the "
+        "action's default so BOTH architectures are asserted — passing '' on one "
+        "leg silently skips that architecture's interpreter check."
+    )
+
+
+def test_the_merge_job_retries_its_manifest_read() -> None:
+    """The one read that --load cannot remove.
+
+    `imagetools create` is purely registry-side: the manifest list exists only in
+    the registry, so there is no local copy to inspect and reading it back a step
+    later is the same race that failed a build leg.
+    """
+    job = _reusable()["jobs"]["merge-e2e-image"]
+    inspect = next(
+        s for s in job["steps"] if "imagetools inspect" in str(s.get("run", ""))
+    )
+    run = inspect["run"]
+    assert "with-retry.sh" in run, (
+        "the merge job reads back a manifest it created one step earlier, and "
+        "unlike the build legs it has no local copy to fall back on"
+    )
+    # Captured into a variable, never piped straight into the assertion. Piping a
+    # RETRIED command concatenates every attempt's output into the reader's stdin
+    # — the second attempt's JSON lands appended to the first's, and the parse
+    # fails on valid data. Capturing completes all retries before anything reads.
+    assert "RAW=$(" in run and "printf " in run, (
+        "the retried inspect must be captured before it is parsed: piping "
+        "with-retry directly into the assertion concatenates the output of every "
+        "attempt, so a retry produces malformed JSON from a healthy registry"
+    )
+    for line in run.splitlines():
+        if "with-retry.sh" in line:
+            assert "assert_image_platforms.py" not in line, (
+                "retry the inspect, not the assertion: a genuinely single-arch "
+                "manifest must fail once rather than three times"
+            )
+
+
 def test_pkl_is_downloaded_for_the_runners_architecture() -> None:
     """`build-app-image` puts `regenerate-contract` on an arm64 runner.
 

--- a/.github/workflows/tests-reusable.yaml
+++ b/.github/workflows/tests-reusable.yaml
@@ -935,12 +935,25 @@ jobs:
       # and the tenant pulls. A leg that quietly built the wrong architecture
       # shows up here as a missing one — nothing downstream would catch it, since
       # GM accepts the version and LM accepts the install regardless.
+      #
+      # Retried, and this is the one place that genuinely needs it. The build legs
+      # avoid the read-after-write race entirely by loading their image locally
+      # (build-app-image's `--load`), but `imagetools create` is purely
+      # registry-side: the manifest list it writes exists ONLY in the registry, so
+      # there is no local copy to inspect and reading it back one step later is
+      # exactly the pattern that failed a build leg with `manifest unknown` 0.7s
+      # after its own push reported success.
+      #
+      # The retry wraps the inspect, not the assertion over its output, so a
+      # genuinely single-arch manifest still fails once rather than three times.
       - name: Assert the manifest serves both architectures
         env:
           IMAGE: ${{ needs.build-e2e-image.outputs.image-base }}
         run: |
           set -euo pipefail
-          docker buildx imagetools inspect --raw "$IMAGE" \
+          RAW=$(application-sdk-scripts/.github/scripts/with-retry.sh \
+            docker buildx imagetools inspect --raw "$IMAGE")
+          printf '%s' "$RAW" \
             | python3 application-sdk-scripts/.github/scripts/assert_image_platforms.py \
                 --expected linux/amd64,linux/arm64
 

--- a/docs/standards/connector-ci-e2e.md
+++ b/docs/standards/connector-ci-e2e.md
@@ -307,6 +307,25 @@ Three things this shape makes load-bearing, each of which fails *silently*:
   execute binary file`, several steps before anything mentions architecture. It now
   selects from `runner.arch`.
 
+**Reading back a just-pushed tag is a race, so the build legs don't.** buildx's
+container driver exports only to the registry, so `docker run` used to fetch back
+the image the same step had just uploaded — 22.7s on a measured amd64 leg, and a
+read the registry doesn't always serve yet (a live arm64 leg got `manifest
+unknown` 0.7s after its own push reported success). The build now also `--load`s
+into the local daemon, so the interpreter assert is a local container start: 0.17s,
+and no registry read to race. Measured end to end, the amd64 leg went 89s → 76s.
+
+`--load` is skipped for a multi-platform build, because the docker exporter can't
+express a manifest list; such a caller falls back to pulling, which still works.
+
+The one read that can't be avoided is `merge-e2e-image`'s: `imagetools create` is
+purely registry-side, so the manifest list exists *only* there and inspecting it a
+step later is inherently a fresh read. That one is wrapped in
+[`with-retry.sh`](../../.github/scripts/with-retry.sh) — around the *inspect*, and
+captured into a variable before parsing, because piping a retried command
+concatenates every attempt's output into the reader's stdin and would fail the
+parse on healthy data.
+
 `merge-e2e-image` then asserts the combined manifest serves both architectures
 (`assert_image_platforms.py`). That is the reference `prepare-tenant` publishes and
 the tenant pulls, so it is the one worth asserting: a leg that quietly built the


### PR DESCRIPTION
Supersedes #3047. Measured on two live runs of the same repo with the same warm caches — [31139992280](https://github.com/atlanhq/atlan-openapi-app/actions/runs/31139992280) (before) vs [31141463008](https://github.com/atlanhq/atlan-openapi-app/actions/runs/31141463008) (after):

| | before | after |
|---|---|---|
| amd64 build job | 89s | **76s** |
| arm64 build job | 66s | **61s** |
| interpreter assert | **22.7s** | **0.17s** |
| `Unable to find image … locally` | both legs | **neither leg** |

## What was happening

buildx's *container* driver — which we need for the `type=gha` layer cache — exports only to the registry. So `docker run --entrypoint python` had to fetch back over the network the very image that step had just uploaded, purely to read `python --version`. Adding `--load` puts it in the local daemon as well, and the assert becomes a local container start.

**The 13s is the smaller half.** The build legs now perform *no registry read at all*, so the read-after-write race that failed a live arm64 leg — `manifest unknown` 0.7s after its own push reported success — cannot occur there. Removed, not retried through.

`--load` is gated on a single-platform build: the docker exporter can't express a manifest list, so a caller naming two platforms in one job would fail outright. Those callers fall back to pulling, which still works.

Multiple exporters need buildx ≥ 0.13; the runners ship **v0.35.0 / BuildKit v0.31.2**, so nothing needs pinning. I'd previously framed this as a runner-version risk — @cmgrote pointed out we control that, and checking showed the concern was moot from the start.

## The one read that survives, and keeps its retry

`merge-e2e-image`'s. `imagetools create` is purely registry-side: the manifest list exists **only** in the registry, so there's no local copy to inspect, and reading it back one step later is the same fresh-tag read. That inspect goes through `with-retry.sh`.

One subtlety, which mutation testing caught rather than review: the retried inspect is **captured into a variable before being parsed**, never piped straight into the assert. Piping a *retried* command concatenates every attempt's output into the reader's stdin — a retry would hand the parser two JSON documents and fail on a perfectly healthy registry. There's now a guard for it.

## Verification

6 mutations verified red. Three initially survived, and all three were my fault rather than the code's:

1. a guard matching `--load` in the *explanatory comment* instead of the flag (same trap as an earlier PR in this series — asserted prose containing the literal)
2. an ineffective mutation that left in place the branch it claimed to delete
3. the piping defect above, which no guard covered until it surfaced this way

1293 script tests pass; `pre-commit --all-files` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
