### PR TITLE
fix(async): offload pq.write_table() off the event loop in ParquetFileWriter

### DIFF
--- a/application_sdk/storage/formats/parquet.py
+++ b/application_sdk/storage/formats/parquet.py
@@ -848,8 +848,15 @@ class ParquetFileWriter(Writer):
                     len(table), 16_000_000 // max(1, table.nbytes // max(1, len(table)))
                 ),
             )
-            pq.write_table(
-                table, file_name, compression="snappy", row_group_size=row_group_size
+            # Offloaded: pq.write_table() is blocking disk I/O; running it
+            # inline stalls the event loop — including the auto-heartbeat —
+            # for the write's full duration on large chunks.
+            await run_in_thread(
+                pq.write_table,
+                table,
+                file_name,
+                compression="snappy",
+                row_group_size=row_group_size,
             )
             return
 
@@ -864,6 +871,10 @@ class ParquetFileWriter(Writer):
         row_group_size = max(
             1, min(len(table), 16_000_000 // max(1, table.nbytes // max(1, len(table))))
         )
-        pq.write_table(
-            table, file_name, compression="snappy", row_group_size=row_group_size
+        await run_in_thread(
+            pq.write_table,
+            table,
+            file_name,
+            compression="snappy",
+            row_group_size=row_group_size,
         )

--- a/tests/unit/storage/formats/writers/test_parquet_writer.py
+++ b/tests/unit/storage/formats/writers/test_parquet_writer.py
@@ -1172,3 +1172,26 @@ class TestWriteChunkNullColumns:
         assert combined.num_rows == 4
         extra_col = combined.column("extra").to_pylist()
         assert extra_col == [None, None, "foo", "bar"]
+
+    async def test_write_chunk_offloaded_to_thread(self, tmp_path) -> None:
+        """pq.write_table() must not run inline on the event loop.
+
+        A large chunk's disk write can take long enough to stall every other
+        coroutine — including the enclosing @task's auto-heartbeat — for the
+        write's full duration.
+        """
+        df = pd.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+        file_name = str(tmp_path / "offloaded.parquet")
+        writer = ParquetFileWriter(str(tmp_path / "output"))
+
+        with patch(
+            "application_sdk.storage.formats.parquet.run_in_thread",
+            new_callable=AsyncMock,
+            side_effect=lambda func, *a, **kw: func(*a, **kw),
+        ) as mock_offload:
+            await writer._write_chunk(df, file_name)
+
+        assert mock_offload.await_args_list, "pq.write_table was not offloaded"
+        assert mock_offload.await_args_list[0].args[0] is pq.write_table
+        table = pq.read_table(file_name)
+        assert table.num_rows == 3


### PR DESCRIPTION
## Summary

- `ParquetFileWriter._write_chunk()` offloads both `pq.write_table()` calls (fast path and null-cast slow path) onto a worker thread via `run_in_thread()`, instead of running them inline on the event loop.

## Problem

`pq.write_table()` is blocking disk I/O. Running it inside `async def _write_chunk()` with no offload stalls the event loop for the write's full duration on a large chunk — including the enclosing `@task`'s auto-heartbeat. This is the same bug class the sibling temp-folder cleanup had in this same file before #2987 fixed it (`SafeFileOps.rmtree` → `run_in_thread`); `_write_chunk`'s two `pq.write_table()` call sites were left un-offloaded.

Found while investigating a heartbeat-timeout pattern on a production tenant: a KEDA scale-to-zero worker combined with large per-chunk parquet writes produced multi-hour stalls that surfaced as either a heartbeat timeout or a downstream artifact-upload error depending on exactly when the worker got killed mid-write.

## Fix

Wrap both `pq.write_table()` calls in `run_in_thread()`, matching the existing import and idiom already used elsewhere in this file (`from application_sdk.execution.heartbeat import run_in_thread`).

## Test plan

- [x] Added `test_write_chunk_offloaded_to_thread`, mirroring the existing `test_temp_folder_removal_offloaded_to_thread` pattern — mocks `run_in_thread` and asserts `pq.write_table` is dispatched through it, then verifies the written file is still correct.
- [x] Ran the full `test_parquet_writer.py` suite: 46 passed, 0 failed (no regressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)