### PR TITLE
feat(storage): make upload part size and concurrency configurable

### DIFF
--- a/application_sdk/constants.py
+++ b/application_sdk/constants.py
@@ -268,6 +268,16 @@ STORAGE_UPLOAD_PART_SIZE_BYTES = int(
     os.getenv("ATLAN_STORAGE_UPLOAD_PART_SIZE_BYTES", str(8 * 1024 * 1024))
 )
 
+#: True when a deployment has explicitly set the part size, in which case it
+#: overrides any ``chunk_size`` passed by calling code. The size that keeps a
+#: completion inside the destination's idle timeout depends on where the
+#: deployment writes, which the operator knows and an app — which cannot know
+#: the tenant it will land on — does not. Presence is what matters here, not
+#: value: a deployment that sets the default explicitly still means it.
+STORAGE_UPLOAD_PART_SIZE_OVERRIDDEN = (
+    "ATLAN_STORAGE_UPLOAD_PART_SIZE_BYTES" in os.environ
+)
+
 #: Number of parts uploaded concurrently (default 12, obstore's own default).
 #: Peak upload memory is roughly ``STORAGE_UPLOAD_PART_SIZE_BYTES`` times this,
 #: so a deployment that raises the part size to 64 MiB and leaves this at 12

--- a/application_sdk/constants.py
+++ b/application_sdk/constants.py
@@ -268,6 +268,15 @@ STORAGE_UPLOAD_PART_SIZE_BYTES = int(
     os.getenv("ATLAN_STORAGE_UPLOAD_PART_SIZE_BYTES", str(8 * 1024 * 1024))
 )
 
+#: True when a deployment has explicitly set the part size. It then overrides
+#: any ``chunk_size`` passed by calling code: the part size that keeps an
+#: upload under the destination's idle timeout is a property of where the
+#: deployment writes, which the operator knows and the caller does not. A
+#: connector hardcoding a part size must not be able to defeat that.
+STORAGE_UPLOAD_PART_SIZE_OVERRIDDEN = (
+    "ATLAN_STORAGE_UPLOAD_PART_SIZE_BYTES" in os.environ
+)
+
 #: Number of parts uploaded concurrently (default 12, obstore's own default).
 #: Peak upload memory is roughly ``STORAGE_UPLOAD_PART_SIZE_BYTES`` times this,
 #: so a deployment that raises the part size to 64 MiB and leaves this at 12

--- a/application_sdk/constants.py
+++ b/application_sdk/constants.py
@@ -268,15 +268,6 @@ STORAGE_UPLOAD_PART_SIZE_BYTES = int(
     os.getenv("ATLAN_STORAGE_UPLOAD_PART_SIZE_BYTES", str(8 * 1024 * 1024))
 )
 
-#: True when a deployment has explicitly set the part size. It then overrides
-#: any ``chunk_size`` passed by calling code: the part size that keeps an
-#: upload under the destination's idle timeout is a property of where the
-#: deployment writes, which the operator knows and the caller does not. A
-#: connector hardcoding a part size must not be able to defeat that.
-STORAGE_UPLOAD_PART_SIZE_OVERRIDDEN = (
-    "ATLAN_STORAGE_UPLOAD_PART_SIZE_BYTES" in os.environ
-)
-
 #: Number of parts uploaded concurrently (default 12, obstore's own default).
 #: Peak upload memory is roughly ``STORAGE_UPLOAD_PART_SIZE_BYTES`` times this,
 #: so a deployment that raises the part size to 64 MiB and leaves this at 12

--- a/application_sdk/constants.py
+++ b/application_sdk/constants.py
@@ -250,6 +250,33 @@ STORAGE_PROGRESS_LOG_INTERVAL_SECONDS = float(
     os.getenv("ATLAN_STORAGE_PROGRESS_LOG_INTERVAL_SECONDS", "30")
 )
 
+#: Multipart part size for uploads (default 8 MiB). Raise this per deployment
+#: when the destination makes *part count* expensive rather than part size.
+#: An S3 proxy fronting GCS is the motivating case (DISTR-899): GCS has no
+#: multipart upload on the JSON API its client libraries speak, so the proxy
+#: emulates one with ``compose``, which accepts at most 32 sources. Completing
+#: an upload therefore costs one sequential round trip per part, inside a
+#: single HTTP request that sends no response bytes while it runs. A 4.77 GiB
+#: object at 8 MiB parts is 611 parts and 65-98s of silence — long enough for
+#: a 60s gateway idle timeout to cut the connection, after which the client
+#: retries and the second completion races the first.
+#: Larger parts shorten that window roughly linearly: the same object at
+#: 32 MiB is 153 parts and ~19s. Note this is *not* free — see
+#: ``STORAGE_UPLOAD_MAX_CONCURRENCY``, since peak memory is the product of the
+#: two, not this value alone.
+STORAGE_UPLOAD_PART_SIZE_BYTES = int(
+    os.getenv("ATLAN_STORAGE_UPLOAD_PART_SIZE_BYTES", str(8 * 1024 * 1024))
+)
+
+#: Number of parts uploaded concurrently (default 12, obstore's own default).
+#: Peak upload memory is roughly ``STORAGE_UPLOAD_PART_SIZE_BYTES`` times this,
+#: so a deployment that raises the part size to 64 MiB and leaves this at 12
+#: budgets ~768 MiB of buffer. Lower it alongside a larger part size to hold
+#: peak memory steady.
+STORAGE_UPLOAD_MAX_CONCURRENCY = int(
+    os.getenv("ATLAN_STORAGE_UPLOAD_MAX_CONCURRENCY", "12")
+)
+
 #: Kill-switch for resumable chunked downloads (BLDX-1523). When enabled
 #: (default), an interrupted chunked download leaves its partial file plus a
 #: ``.transfer-state`` sidecar on disk, and a retry fetches only the missing

--- a/application_sdk/storage/ops.py
+++ b/application_sdk/storage/ops.py
@@ -483,12 +483,14 @@ async def upload_file(
         key: Destination object key.  Normalised by default.
         local_path: Path to the local file to upload.
         store: Target store, or ``None`` to use the infrastructure store.
-        chunk_size: Desired chunk / part size in bytes.  ``None`` (default)
-            takes ``ATLAN_STORAGE_UPLOAD_PART_SIZE_BYTES``, itself defaulting
-            to 8 MiB.  Increased automatically if the file is large enough to
-            exceed the 9,900-part safety limit.  Raise it per deployment when
-            the destination charges by part *count* — see the constant's
-            docstring for the S3-proxy-over-GCS case.
+        chunk_size: Desired chunk / part size in bytes, used only when
+            ``ATLAN_STORAGE_UPLOAD_PART_SIZE_BYTES`` is unset — when that is
+            set it wins, because the workable part size is a property of the
+            destination the deployment writes to, not of the calling code.
+            Defaults to 8 MiB when neither is given.  Increased automatically
+            if the file is large enough to exceed the 9,900-part safety limit.
+            See the constant's docstring for the S3-proxy-over-GCS case that
+            makes part *count* the thing that matters.
         normalize: When ``True`` (default), normalise *key* before use.
         retain_local_copy: When ``True`` (default), keep the local file after
             upload.  When ``False``, delete the local file after a successful
@@ -520,14 +522,31 @@ async def upload_file(
 
     from application_sdk.constants import (  # noqa: PLC0415
         STORAGE_UPLOAD_MAX_CONCURRENCY as _max_concurrency,
-        STORAGE_UPLOAD_PART_SIZE_BYTES as _default_part_size,
+        STORAGE_UPLOAD_PART_SIZE_BYTES as _env_part_size,
+        STORAGE_UPLOAD_PART_SIZE_OVERRIDDEN as _env_part_size_set,
+    )
+
+    # The environment wins over an explicit chunk_size. Part size is a property
+    # of the destination, not of the calling code: only the deployment knows
+    # what its object store is fronted by, so a connector must not be able to
+    # override the operator here.
+    if _env_part_size_set and chunk_size is not None and chunk_size != _env_part_size:
+        logger.debug(
+            "Overriding requested part size %d with "
+            "ATLAN_STORAGE_UPLOAD_PART_SIZE_BYTES=%d for key '%s'",
+            chunk_size,
+            _env_part_size,
+            key,
+        )
+    requested_chunk = (
+        _env_part_size
+        if (_env_part_size_set or chunk_size is None)
+        else chunk_size
     )
 
     path = Path(local_path)
     file_size = path.stat().st_size
-    effective_chunk = _compute_part_size(
-        file_size, _default_part_size if chunk_size is None else chunk_size
-    )
+    effective_chunk = _compute_part_size(file_size, requested_chunk)
 
     if file_size == 0:
         logger.warning(

--- a/application_sdk/storage/ops.py
+++ b/application_sdk/storage/ops.py
@@ -519,16 +519,15 @@ async def upload_file(
         key = normalize_key(key)
 
     from application_sdk.constants import (  # noqa: PLC0415
-        STORAGE_UPLOAD_MAX_CONCURRENCY as _max_concurrency,
-    )
-    from application_sdk.constants import (
-        STORAGE_UPLOAD_PART_SIZE_BYTES as _default_part_size,
+        STORAGE_UPLOAD_MAX_CONCURRENCY,
+        STORAGE_UPLOAD_PART_SIZE_BYTES,
     )
 
     path = Path(local_path)
     file_size = path.stat().st_size
     effective_chunk = _compute_part_size(
-        file_size, _default_part_size if chunk_size is None else chunk_size
+        file_size,
+        STORAGE_UPLOAD_PART_SIZE_BYTES if chunk_size is None else chunk_size,
     )
 
     if file_size == 0:
@@ -552,7 +551,7 @@ async def upload_file(
             resolved,
             key,
             buffer_size=effective_chunk,
-            max_concurrency=_max_concurrency,
+            max_concurrency=STORAGE_UPLOAD_MAX_CONCURRENCY,
             attributes=put_attributes,
         ) as writer:
             with path.open("rb") as fh:

--- a/application_sdk/storage/ops.py
+++ b/application_sdk/storage/ops.py
@@ -520,6 +520,8 @@ async def upload_file(
 
     from application_sdk.constants import (  # noqa: PLC0415
         STORAGE_UPLOAD_MAX_CONCURRENCY as _max_concurrency,
+    )
+    from application_sdk.constants import (
         STORAGE_UPLOAD_PART_SIZE_BYTES as _default_part_size,
     )
 

--- a/application_sdk/storage/ops.py
+++ b/application_sdk/storage/ops.py
@@ -483,12 +483,14 @@ async def upload_file(
         key: Destination object key.  Normalised by default.
         local_path: Path to the local file to upload.
         store: Target store, or ``None`` to use the infrastructure store.
-        chunk_size: Desired chunk / part size in bytes.  ``None`` (default)
-            takes ``ATLAN_STORAGE_UPLOAD_PART_SIZE_BYTES``, itself defaulting
-            to 8 MiB.  Increased automatically if the file is large enough to
-            exceed the 9,900-part safety limit.  Raise it per deployment when
-            the destination charges by part *count* — see the constant's
-            docstring for the S3-proxy-over-GCS case.
+        chunk_size: Desired chunk / part size in bytes, honoured only when
+            ``ATLAN_STORAGE_UPLOAD_PART_SIZE_BYTES`` is unset — a deployment
+            that sets it overrides the caller, since the workable part size
+            depends on the destination the deployment writes to rather than on
+            the app.  Defaults to 8 MiB when neither is given.  Increased
+            automatically if the file is large enough to exceed the 9,900-part
+            safety limit.  See the constant's docstring for the
+            S3-proxy-over-GCS case that makes part *count* what matters.
         normalize: When ``True`` (default), normalise *key* before use.
         retain_local_copy: When ``True`` (default), keep the local file after
             upload.  When ``False``, delete the local file after a successful
@@ -521,14 +523,33 @@ async def upload_file(
     from application_sdk.constants import (  # noqa: PLC0415
         STORAGE_UPLOAD_MAX_CONCURRENCY,
         STORAGE_UPLOAD_PART_SIZE_BYTES,
+        STORAGE_UPLOAD_PART_SIZE_OVERRIDDEN,
+    )
+
+    # A deployment that sets the part size overrides the caller. The size that
+    # keeps a completion inside the destination's idle timeout depends on where
+    # the deployment writes; an app cannot know which tenant it lands on, so it
+    # must not be able to pin a value the operator then cannot correct.
+    if (
+        STORAGE_UPLOAD_PART_SIZE_OVERRIDDEN
+        and chunk_size is not None
+        and chunk_size != STORAGE_UPLOAD_PART_SIZE_BYTES
+    ):
+        logger.debug(
+            "Using deployment part size %d instead of the requested %d " "for key '%s'",
+            STORAGE_UPLOAD_PART_SIZE_BYTES,
+            chunk_size,
+            key,
+        )
+    requested_chunk = (
+        STORAGE_UPLOAD_PART_SIZE_BYTES
+        if (STORAGE_UPLOAD_PART_SIZE_OVERRIDDEN or chunk_size is None)
+        else chunk_size
     )
 
     path = Path(local_path)
     file_size = path.stat().st_size
-    effective_chunk = _compute_part_size(
-        file_size,
-        STORAGE_UPLOAD_PART_SIZE_BYTES if chunk_size is None else chunk_size,
-    )
+    effective_chunk = _compute_part_size(file_size, requested_chunk)
 
     if file_size == 0:
         logger.warning(

--- a/application_sdk/storage/ops.py
+++ b/application_sdk/storage/ops.py
@@ -483,14 +483,12 @@ async def upload_file(
         key: Destination object key.  Normalised by default.
         local_path: Path to the local file to upload.
         store: Target store, or ``None`` to use the infrastructure store.
-        chunk_size: Desired chunk / part size in bytes, used only when
-            ``ATLAN_STORAGE_UPLOAD_PART_SIZE_BYTES`` is unset — when that is
-            set it wins, because the workable part size is a property of the
-            destination the deployment writes to, not of the calling code.
-            Defaults to 8 MiB when neither is given.  Increased automatically
-            if the file is large enough to exceed the 9,900-part safety limit.
-            See the constant's docstring for the S3-proxy-over-GCS case that
-            makes part *count* the thing that matters.
+        chunk_size: Desired chunk / part size in bytes.  ``None`` (default)
+            takes ``ATLAN_STORAGE_UPLOAD_PART_SIZE_BYTES``, itself defaulting
+            to 8 MiB.  Increased automatically if the file is large enough to
+            exceed the 9,900-part safety limit.  Raise it per deployment when
+            the destination charges by part *count* — see the constant's
+            docstring for the S3-proxy-over-GCS case.
         normalize: When ``True`` (default), normalise *key* before use.
         retain_local_copy: When ``True`` (default), keep the local file after
             upload.  When ``False``, delete the local file after a successful
@@ -522,31 +520,14 @@ async def upload_file(
 
     from application_sdk.constants import (  # noqa: PLC0415
         STORAGE_UPLOAD_MAX_CONCURRENCY as _max_concurrency,
-        STORAGE_UPLOAD_PART_SIZE_BYTES as _env_part_size,
-        STORAGE_UPLOAD_PART_SIZE_OVERRIDDEN as _env_part_size_set,
-    )
-
-    # The environment wins over an explicit chunk_size. Part size is a property
-    # of the destination, not of the calling code: only the deployment knows
-    # what its object store is fronted by, so a connector must not be able to
-    # override the operator here.
-    if _env_part_size_set and chunk_size is not None and chunk_size != _env_part_size:
-        logger.debug(
-            "Overriding requested part size %d with "
-            "ATLAN_STORAGE_UPLOAD_PART_SIZE_BYTES=%d for key '%s'",
-            chunk_size,
-            _env_part_size,
-            key,
-        )
-    requested_chunk = (
-        _env_part_size
-        if (_env_part_size_set or chunk_size is None)
-        else chunk_size
+        STORAGE_UPLOAD_PART_SIZE_BYTES as _default_part_size,
     )
 
     path = Path(local_path)
     file_size = path.stat().st_size
-    effective_chunk = _compute_part_size(file_size, requested_chunk)
+    effective_chunk = _compute_part_size(
+        file_size, _default_part_size if chunk_size is None else chunk_size
+    )
 
     if file_size == 0:
         logger.warning(

--- a/application_sdk/storage/ops.py
+++ b/application_sdk/storage/ops.py
@@ -465,7 +465,7 @@ async def upload_file(
     local_path: str | Path,
     store: BoundStore | ObjectStore | None = None,
     *,
-    chunk_size: int = 8 * 1024 * 1024,
+    chunk_size: int | None = None,
     normalize: bool = True,
     retain_local_copy: bool = True,
     compute_hash: bool = True,
@@ -483,9 +483,12 @@ async def upload_file(
         key: Destination object key.  Normalised by default.
         local_path: Path to the local file to upload.
         store: Target store, or ``None`` to use the infrastructure store.
-        chunk_size: Desired chunk / part size in bytes (default 8 MiB).
-            Increased automatically if the file is large enough to exceed
-            the 9,900-part safety limit.
+        chunk_size: Desired chunk / part size in bytes.  ``None`` (default)
+            takes ``ATLAN_STORAGE_UPLOAD_PART_SIZE_BYTES``, itself defaulting
+            to 8 MiB.  Increased automatically if the file is large enough to
+            exceed the 9,900-part safety limit.  Raise it per deployment when
+            the destination charges by part *count* — see the constant's
+            docstring for the S3-proxy-over-GCS case.
         normalize: When ``True`` (default), normalise *key* before use.
         retain_local_copy: When ``True`` (default), keep the local file after
             upload.  When ``False``, delete the local file after a successful
@@ -515,9 +518,16 @@ async def upload_file(
     if normalize:
         key = normalize_key(key)
 
+    from application_sdk.constants import (  # noqa: PLC0415
+        STORAGE_UPLOAD_MAX_CONCURRENCY as _max_concurrency,
+        STORAGE_UPLOAD_PART_SIZE_BYTES as _default_part_size,
+    )
+
     path = Path(local_path)
     file_size = path.stat().st_size
-    effective_chunk = _compute_part_size(file_size, chunk_size)
+    effective_chunk = _compute_part_size(
+        file_size, _default_part_size if chunk_size is None else chunk_size
+    )
 
     if file_size == 0:
         logger.warning(
@@ -537,7 +547,11 @@ async def upload_file(
     bytes_sent = 0
     try:
         async with obstore.open_writer_async(
-            resolved, key, buffer_size=effective_chunk, attributes=put_attributes
+            resolved,
+            key,
+            buffer_size=effective_chunk,
+            max_concurrency=_max_concurrency,
+            attributes=put_attributes,
         ) as writer:
             with path.open("rb") as fh:
                 while True:

--- a/docs/concepts/storage.md
+++ b/docs/concepts/storage.md
@@ -186,6 +186,8 @@ Both are called automatically by the default `on_complete()` implementation. Do 
 | `ATLAN_OBSTORE_TIMEOUT` | `30m` | Overall per-request wall-clock backstop |
 | `ATLAN_STORAGE_RESUME_DOWNLOADS` | `true` | Resume interrupted chunked downloads from their checkpoint sidecar |
 | `ATLAN_STORAGE_PROGRESS_LOG_INTERVAL_SECONDS` | `30` | Heartbeat log interval during long transfers (`0` disables) |
+| `ATLAN_STORAGE_UPLOAD_PART_SIZE_BYTES` | `8388608` (8 MiB) | Multipart part size for uploads. Raise it when the destination makes part *count* expensive (e.g. an S3 proxy fronting GCS, which emulates multipart with 32-source-capped `compose` round trips) |
+| `ATLAN_STORAGE_UPLOAD_MAX_CONCURRENCY` | `12` | Parts uploaded concurrently. Peak upload memory is roughly part size times this — lower it alongside a larger part size to hold memory steady |
 
 ---
 

--- a/tests/unit/storage/test_ops.py
+++ b/tests/unit/storage/test_ops.py
@@ -1946,9 +1946,37 @@ class TestUploadPartSizeConfiguration:
 
         assert writer.call_args.kwargs["buffer_size"] == 32 * 1024 * 1024
 
-    async def test_explicit_chunk_size_still_wins(
+    async def test_env_overrides_an_explicit_chunk_size(
         self, store, tmp_path, monkeypatch
     ) -> None:
+        """The operator outranks the caller: an app cannot know which tenant
+        it lands on, so it must not pin a size the operator cannot correct."""
+        monkeypatch.setattr(
+            "application_sdk.constants.STORAGE_UPLOAD_PART_SIZE_BYTES",
+            32 * 1024 * 1024,
+        )
+        monkeypatch.setattr(
+            "application_sdk.constants.STORAGE_UPLOAD_PART_SIZE_OVERRIDDEN", True
+        )
+        f = tmp_path / "b.bin"
+        f.write_bytes(b"x" * 1024)
+
+        with patch("application_sdk.storage.ops.obstore.open_writer_async") as writer:
+            writer.return_value.__aenter__ = AsyncMock()
+            writer.return_value.__aexit__ = AsyncMock(return_value=False)
+            await upload_file(
+                "k", f, store, chunk_size=5 * 1024 * 1024, normalize=False
+            )
+
+        assert writer.call_args.kwargs["buffer_size"] == 32 * 1024 * 1024
+
+    async def test_explicit_chunk_size_used_when_env_unset(
+        self, store, tmp_path, monkeypatch
+    ) -> None:
+        """With no deployment override, calling code still chooses."""
+        monkeypatch.setattr(
+            "application_sdk.constants.STORAGE_UPLOAD_PART_SIZE_OVERRIDDEN", False
+        )
         monkeypatch.setattr(
             "application_sdk.constants.STORAGE_UPLOAD_PART_SIZE_BYTES",
             32 * 1024 * 1024,

--- a/tests/unit/storage/test_ops.py
+++ b/tests/unit/storage/test_ops.py
@@ -1948,12 +1948,18 @@ class TestUploadPartSizeConfiguration:
 
         assert writer.call_args.kwargs["buffer_size"] == 32 * 1024 * 1024
 
-    async def test_explicit_chunk_size_still_wins(
+    async def test_env_overrides_an_explicit_chunk_size(
         self, store, tmp_path, monkeypatch
     ) -> None:
+        """The operator outranks the caller: only the deployment knows what
+        its object store is fronted by, so a connector hardcoding a part size
+        must not be able to defeat the env."""
         monkeypatch.setattr(
             "application_sdk.constants.STORAGE_UPLOAD_PART_SIZE_BYTES",
             32 * 1024 * 1024,
+        )
+        monkeypatch.setattr(
+            "application_sdk.constants.STORAGE_UPLOAD_PART_SIZE_OVERRIDDEN", True
         )
         f = tmp_path / "b.bin"
         f.write_bytes(b"x" * 1024)
@@ -1967,7 +1973,28 @@ class TestUploadPartSizeConfiguration:
                 "k", f, store, chunk_size=5 * 1024 * 1024, normalize=False
             )
 
-        assert writer.call_args.kwargs["buffer_size"] == 5 * 1024 * 1024
+        assert writer.call_args.kwargs["buffer_size"] == 32 * 1024 * 1024
+
+    async def test_explicit_chunk_size_used_when_env_unset(
+        self, store, tmp_path, monkeypatch
+    ) -> None:
+        """With no deployment override, calling code still chooses."""
+        monkeypatch.setattr(
+            "application_sdk.constants.STORAGE_UPLOAD_PART_SIZE_OVERRIDDEN", False
+        )
+        f = tmp_path / "b2.bin"
+        f.write_bytes(b"x" * 1024)
+
+        with patch(
+            "application_sdk.storage.ops.obstore.open_writer_async"
+        ) as writer:
+            writer.return_value.__aenter__ = AsyncMock()
+            writer.return_value.__aexit__ = AsyncMock(return_value=False)
+            await upload_file(
+                "k", f, store, chunk_size=16 * 1024 * 1024, normalize=False
+            )
+
+        assert writer.call_args.kwargs["buffer_size"] == 16 * 1024 * 1024
 
     async def test_max_concurrency_is_passed_through(
         self, store, tmp_path, monkeypatch

--- a/tests/unit/storage/test_ops.py
+++ b/tests/unit/storage/test_ops.py
@@ -1948,18 +1948,12 @@ class TestUploadPartSizeConfiguration:
 
         assert writer.call_args.kwargs["buffer_size"] == 32 * 1024 * 1024
 
-    async def test_env_overrides_an_explicit_chunk_size(
+    async def test_explicit_chunk_size_still_wins(
         self, store, tmp_path, monkeypatch
     ) -> None:
-        """The operator outranks the caller: only the deployment knows what
-        its object store is fronted by, so a connector hardcoding a part size
-        must not be able to defeat the env."""
         monkeypatch.setattr(
             "application_sdk.constants.STORAGE_UPLOAD_PART_SIZE_BYTES",
             32 * 1024 * 1024,
-        )
-        monkeypatch.setattr(
-            "application_sdk.constants.STORAGE_UPLOAD_PART_SIZE_OVERRIDDEN", True
         )
         f = tmp_path / "b.bin"
         f.write_bytes(b"x" * 1024)
@@ -1973,28 +1967,7 @@ class TestUploadPartSizeConfiguration:
                 "k", f, store, chunk_size=5 * 1024 * 1024, normalize=False
             )
 
-        assert writer.call_args.kwargs["buffer_size"] == 32 * 1024 * 1024
-
-    async def test_explicit_chunk_size_used_when_env_unset(
-        self, store, tmp_path, monkeypatch
-    ) -> None:
-        """With no deployment override, calling code still chooses."""
-        monkeypatch.setattr(
-            "application_sdk.constants.STORAGE_UPLOAD_PART_SIZE_OVERRIDDEN", False
-        )
-        f = tmp_path / "b2.bin"
-        f.write_bytes(b"x" * 1024)
-
-        with patch(
-            "application_sdk.storage.ops.obstore.open_writer_async"
-        ) as writer:
-            writer.return_value.__aenter__ = AsyncMock()
-            writer.return_value.__aexit__ = AsyncMock(return_value=False)
-            await upload_file(
-                "k", f, store, chunk_size=16 * 1024 * 1024, normalize=False
-            )
-
-        assert writer.call_args.kwargs["buffer_size"] == 16 * 1024 * 1024
+        assert writer.call_args.kwargs["buffer_size"] == 5 * 1024 * 1024
 
     async def test_max_concurrency_is_passed_through(
         self, store, tmp_path, monkeypatch

--- a/tests/unit/storage/test_ops.py
+++ b/tests/unit/storage/test_ops.py
@@ -1939,9 +1939,7 @@ class TestUploadPartSizeConfiguration:
         f = tmp_path / "a.bin"
         f.write_bytes(b"x" * 1024)
 
-        with patch(
-            "application_sdk.storage.ops.obstore.open_writer_async"
-        ) as writer:
+        with patch("application_sdk.storage.ops.obstore.open_writer_async") as writer:
             writer.return_value.__aenter__ = AsyncMock()
             writer.return_value.__aexit__ = AsyncMock(return_value=False)
             await upload_file("k", f, store, normalize=False)
@@ -1958,9 +1956,7 @@ class TestUploadPartSizeConfiguration:
         f = tmp_path / "b.bin"
         f.write_bytes(b"x" * 1024)
 
-        with patch(
-            "application_sdk.storage.ops.obstore.open_writer_async"
-        ) as writer:
+        with patch("application_sdk.storage.ops.obstore.open_writer_async") as writer:
             writer.return_value.__aenter__ = AsyncMock()
             writer.return_value.__aexit__ = AsyncMock(return_value=False)
             await upload_file(
@@ -1979,9 +1975,7 @@ class TestUploadPartSizeConfiguration:
         f = tmp_path / "c.bin"
         f.write_bytes(b"x" * 1024)
 
-        with patch(
-            "application_sdk.storage.ops.obstore.open_writer_async"
-        ) as writer:
+        with patch("application_sdk.storage.ops.obstore.open_writer_async") as writer:
             writer.return_value.__aenter__ = AsyncMock()
             writer.return_value.__aexit__ = AsyncMock(return_value=False)
             await upload_file("k", f, store, normalize=False)

--- a/tests/unit/storage/test_ops.py
+++ b/tests/unit/storage/test_ops.py
@@ -1917,3 +1917,73 @@ class TestIsAzureContainerNotFound:
             pytest.raises(StorageConfigError, match="pre-create the container"),
         ):
             await upload_file("key/data.json", src, store=store)
+
+
+class TestUploadPartSizeConfiguration:
+    """Part size and concurrency are deployment-tunable (DISTR-899).
+
+    A destination that emulates multipart with GCS ``compose`` pays one
+    sequential round trip per part while sending no response bytes, so part
+    *count* — not part size — decides whether an upload outruns a gateway idle
+    timeout.  Deployments behind such a proxy need to raise the part size
+    without a code change.
+    """
+
+    async def test_default_part_size_comes_from_constant(
+        self, store, tmp_path, monkeypatch
+    ) -> None:
+        monkeypatch.setattr(
+            "application_sdk.constants.STORAGE_UPLOAD_PART_SIZE_BYTES",
+            32 * 1024 * 1024,
+        )
+        f = tmp_path / "a.bin"
+        f.write_bytes(b"x" * 1024)
+
+        with patch(
+            "application_sdk.storage.ops.obstore.open_writer_async"
+        ) as writer:
+            writer.return_value.__aenter__ = AsyncMock()
+            writer.return_value.__aexit__ = AsyncMock(return_value=False)
+            await upload_file("k", f, store, normalize=False)
+
+        assert writer.call_args.kwargs["buffer_size"] == 32 * 1024 * 1024
+
+    async def test_explicit_chunk_size_still_wins(
+        self, store, tmp_path, monkeypatch
+    ) -> None:
+        monkeypatch.setattr(
+            "application_sdk.constants.STORAGE_UPLOAD_PART_SIZE_BYTES",
+            32 * 1024 * 1024,
+        )
+        f = tmp_path / "b.bin"
+        f.write_bytes(b"x" * 1024)
+
+        with patch(
+            "application_sdk.storage.ops.obstore.open_writer_async"
+        ) as writer:
+            writer.return_value.__aenter__ = AsyncMock()
+            writer.return_value.__aexit__ = AsyncMock(return_value=False)
+            await upload_file(
+                "k", f, store, chunk_size=5 * 1024 * 1024, normalize=False
+            )
+
+        assert writer.call_args.kwargs["buffer_size"] == 5 * 1024 * 1024
+
+    async def test_max_concurrency_is_passed_through(
+        self, store, tmp_path, monkeypatch
+    ) -> None:
+        """Peak memory is part_size * max_concurrency, so both must be tunable."""
+        monkeypatch.setattr(
+            "application_sdk.constants.STORAGE_UPLOAD_MAX_CONCURRENCY", 4
+        )
+        f = tmp_path / "c.bin"
+        f.write_bytes(b"x" * 1024)
+
+        with patch(
+            "application_sdk.storage.ops.obstore.open_writer_async"
+        ) as writer:
+            writer.return_value.__aenter__ = AsyncMock()
+            writer.return_value.__aexit__ = AsyncMock(return_value=False)
+            await upload_file("k", f, store, normalize=False)
+
+        assert writer.call_args.kwargs["max_concurrency"] == 4


### PR DESCRIPTION
Adds two env-driven constants so multipart uploads can be tuned per deployment:

| Env var | Default | Effect |
| --- | --- | --- |
| `ATLAN_STORAGE_UPLOAD_PART_SIZE_BYTES` | `8 MiB` (unchanged) | multipart part size |
| `ATLAN_STORAGE_UPLOAD_MAX_CONCURRENCY` | `12` (obstore's own default) | parts uploaded concurrently |

Defaults and default behaviour are exactly as today until a deployment sets one of these.

## This is a deployment knob, not an app one

No app code changes and no app rebuild — these are environment variables, set per deployment via Helm/configmap. Which is the point: the workable part size depends on **where the deployment writes**, and an app cannot know which tenant it will land on.

Precedence follows from that. `upload_file` keeps its `chunk_size` parameter, but when `ATLAN_STORAGE_UPLOAD_PART_SIZE_BYTES` is set it **overrides the caller** — otherwise an app could pin a value the operator is then unable to correct. A differing request is logged at debug so the substitution is visible. With the variable unset, behaviour is unchanged: the caller chooses, falling back to 8 MiB. Presence rather than value decides, so a deployment that sets the default explicitly still means it.

No in-tree caller passes `chunk_size` today.

## Why

`upload_file`'s part size was a hardcoded default and `max_concurrency` was never passed to `open_writer_async` at all, so neither could be adjusted for a destination where **part count** is what costs.

That destination is real — DISTR-899. An S3 proxy fronting GCS can't use a native multipart upload, because the JSON API that GCS client libraries speak doesn't have one. (GCS *does* have S3-compatible multipart — 10,000 parts, 5 MiB–5 GiB — but only on the **XML API**, which those libraries don't expose.) So the proxy emulates completion with `compose`, which accepts at most **32 source objects**.

Completion becomes one sequential round trip per part, inside a single HTTP request that writes **no response bytes** while it runs. Measured on a GCS tenant, for a 4.77 GiB object:

| Part size | Parts | Groups | GCS calls inside the completion | Completion window |
| --- | --- | --- | --- | --- |
| 8 MiB | 611 | 20 | ~1,307 | **65–98s** |
| 32 MiB | 153 | 5 | ~331 | ~19s |
| 64 MiB | 77 | 3 | ~180 | ~10s |

At 8 MiB that silence outlives a 60s gateway idle timeout. The gateway cuts the connection, the client retries the completion, and the retry races the still-running first attempt — surfacing as `MalformedXML`. Larger parts shorten the window roughly linearly.

## Why `max_concurrency` is in the same change

Peak upload memory is **part size × concurrency**, not part size. Raising parts to 64 MiB while concurrency stays at 12 budgets ~768 MiB of buffer — plausibly over a connector pod's limit. Exposing both lets a deployment trade part count for part size while holding peak memory steady.

For the motivating case, **32 MiB is the sweet spot**: completion drops from ~76s to ~19s at ~384 MiB peak.

## Scope

- `storage.ops.upload_file` only — the path `App.upload` → `transfer.upload` uses.
- `storage.cloud.CloudStore` still hardcodes 8 MiB. It targets customer-provided buckets rather than the Atlan object store, so it isn't affected by this failure mode. Happy to include it if reviewers prefer consistency.

## Testing

Four unit tests: env-driven default applied, env overrides an explicit `chunk_size`, explicit `chunk_size` still used when the env is unset, and `max_concurrency` reaches obstore. Full `tests/unit/storage/` suite passes — 783 passed, 3 skipped. `pre-commit` clean (ruff, ruff-format, isort, pyright).