### PR TITLE
ci(e2e): do not fail an install for a pod it never touched

### DIFF
--- a/.github/scripts/e2e_tenant_app.py
+++ b/.github/scripts/e2e_tenant_app.py
@@ -900,8 +900,14 @@ def _image_repository(reference: str) -> str:
     last colon only counts when a tag follows it.
     """
     reference = reference.strip().split("@", 1)[0]
-    head, sep, tag = reference.rpartition(":")
-    return head if sep and tag else reference
+    # The last colon is a tag separator only when it sits in the FINAL
+    # slash-segment (the heuristic `_repo_from_image` already uses): in
+    # ``ghcr.io:5000/org/repo`` the colon is the registry's port, and cutting
+    # there reads the repository as bare ``ghcr.io`` — which can read OUR
+    # failing image as foreign, the misread this module must never make.
+    if ":" not in reference.rsplit("/", 1)[-1]:
+        return reference
+    return reference.rpartition(":")[0]
 
 
 def _image_tag(reference: str) -> str:
@@ -913,6 +919,11 @@ def _image_tag(reference: str) -> str:
     back the whole string, which would read the repository AS the tag.
     """
     reference = _PINNED_IMAGE_RE.sub("", reference.strip())
+    # Same final-segment rule as `_image_repository`: a colon left of the last
+    # slash is a registry port (``ghcr.io:5000/org/repo``), not a tag, and
+    # reading ``5000/org/repo`` as the tag breaks the same-repository compare.
+    if ":" not in reference.rsplit("/", 1)[-1]:
+        return ""
     head, sep, tag = reference.rpartition(":")
     return tag if sep and head else ""
 

--- a/.github/scripts/e2e_tenant_app.py
+++ b/.github/scripts/e2e_tenant_app.py
@@ -68,6 +68,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import sys
 import time
 from dataclasses import dataclass
@@ -175,9 +176,43 @@ _PLATFORM_MISMATCH_MARKERS = (
     "does not match the specified platform",
 )
 
+#: Kubelet phrasings that mean "this pod could not get its image". Deliberately
+#: excludes ``successfully pulled``, which names an image that is FINE — reading
+#: it as a failure would invert the conclusion drawn from these.
+_PULL_FAILURE_MARKERS = (
+    "failed to pull image",
+    "back-off pulling image",
+    "imagepullbackoff",
+    "errimagepull",
+)
+
+#: An image reference in kubelet's quoted form, e.g. `pulling image "ghcr.io/x:y"`.
+_QUOTED_IMAGE_RE = re.compile(r'"([^"\s]+/[^"\s]+)"')
+
 
 class TenantAppError(RuntimeError):
     """The install or verification failed."""
+
+
+class DeploymentFailed(TenantAppError):
+    """LM reported ``deployment_status: FAILED``.
+
+    Separate from the base error because LM's verdict is **namespace-scoped**:
+    its health check reports "Pods failed in namespace <ns>: <pod>" for ANY
+    unhealthy pod in the app's namespace, including ones left behind by earlier
+    installs of other versions. A tenant carrying an orphaned broken pod
+    therefore fails every subsequent install regardless of whether the version
+    being installed is fine.
+
+    Observed on the first green multi-arch install: our own pods pulled the image
+    in 12.4s and were scaled to zero by KEDA as designed, while a pod from an
+    earlier attempt sat in ImagePullBackOff on a DIFFERENT tag
+    (``x1048 over 3h59m``) and took the verdict down with it.
+
+    So the caller checks whose pod is actually failing before deciding, and the
+    installed-version read-back becomes the authority. A timeout stays a plain
+    TenantAppError: nothing about it is somebody else's fault.
+    """
 
 
 @dataclass(frozen=True)
@@ -769,7 +804,10 @@ def _poll_deployment(client: TenantClient, deployment_id: str, timeout: int) -> 
                 return
             if status == _FAILED:
                 message = response.data().get("message")
-                raise TenantAppError(
+                # A distinct type, because the caller treats this differently
+                # from a timeout: LM's verdict is namespace-scoped and can be
+                # about somebody else's pod (see DeploymentFailed).
+                raise DeploymentFailed(
                     f"deployment {deployment_id} FAILED"
                     + (f": {message}" if message else "")
                 )
@@ -828,7 +866,46 @@ def _hint_platform_mismatch(text: str) -> None:
     )
 
 
-def _dump_failure(client: TenantClient, app_id: str) -> None:
+def failing_images(diagnostics: str) -> list[str]:
+    """Return the image references named by pull-failure lines, in order seen.
+
+    Kubernetes phrases these as ``Failed to pull image "<ref>": …`` and
+    ``Back-off pulling image "<ref>"``, both of which carry the ref in quotes. Only
+    failure lines are read: a ``Successfully pulled image "<ref>"`` line names an
+    image that is fine, and counting it would invert the conclusion.
+    """
+    found: list[str] = []
+    for line in diagnostics.splitlines():
+        lowered = line.lower()
+        if not any(marker in lowered for marker in _PULL_FAILURE_MARKERS):
+            continue
+        for ref in _QUOTED_IMAGE_RE.findall(line):
+            if ref not in found:
+                found.append(ref)
+    return found
+
+
+def foreign_failure(diagnostics: str, image: str) -> list[str]:
+    """Return failing images that are NOT *image*, or [] if ours is among them.
+
+    An empty list means "do not second-guess LM": either nothing identifiable is
+    failing, or our own image is one of the things failing. Only when every
+    failing image belongs to some other version does the caller get to treat the
+    verdict as being about somebody else's pod.
+
+    Compared on the full reference including the tag, because the whole point is
+    distinguishing two tags of the SAME repository.
+    """
+    failing = failing_images(diagnostics)
+    if not failing:
+        return []
+    ours = image.strip()
+    if any(ref == ours for ref in failing):
+        return []
+    return failing
+
+
+def _dump_failure(client: TenantClient, app_id: str) -> str:
     """Print LM's failure diagnostics. Best-effort — never masks the real error.
 
     Reads two routes, because they fail in different circumstances and the
@@ -904,7 +981,11 @@ def _dump_failure(client: TenantClient, app_id: str) -> None:
         else:
             print(f"::warning::live events read returned HTTP {events.status}")
 
-    _hint_platform_mismatch("\n".join(diagnostics))
+    collected = "\n".join(diagnostics)
+    _hint_platform_mismatch(collected)
+    # Returned so the caller can work out WHOSE pod failed without a second
+    # round of API calls: everything needed is already in this text.
+    return collected
 
 
 def install(args: argparse.Namespace) -> InstallOutcome:
@@ -1010,11 +1091,34 @@ def install(args: argparse.Namespace) -> InstallOutcome:
     # started no deployment, so there is nothing to poll. The version read-back
     # below is then the only thing that decides success — which is the right
     # authority anyway.
+    foreign: list[str] = []
     if deployment_id:
         print(f"install accepted, deployment_id={deployment_id}")
         try:
             _poll_deployment(read_client, deployment_id, args.timeout_seconds)
+        except DeploymentFailed as exc:
+            diagnostics = _dump_failure(read_client, app_id)
+            foreign = foreign_failure(diagnostics, args.image)
+            if not foreign:
+                raise
+            # LM's health check is namespace-scoped, so its FAILED verdict can be
+            # about a pod this install never touched — an orphan from an earlier
+            # version, which fails every subsequent install to that tenant until
+            # someone deletes it. Every failing image here belongs to a different
+            # version, so the verdict is not evidence about ours.
+            #
+            # NOT a pass on its own: the read-back below has to confirm the tenant
+            # actually serves the version we installed. Downgrading the verdict
+            # only moves the decision to direct evidence — it does not skip it.
+            print(
+                f"::warning::{exc} — but the failing pod(s) want "
+                f"{', '.join(foreign)}, not {args.image}. LM's health check is "
+                "namespace-scoped, so an orphaned pod from an earlier version "
+                "fails this check for every later install. Falling through to the "
+                "installed-version read-back, which decides."
+            )
         except TenantAppError:
+            # Timeout, or an unrelated failure. Nobody else's fault; fatal.
             _dump_failure(read_client, app_id)
             raise
     else:
@@ -1022,6 +1126,21 @@ def install(args: argparse.Namespace) -> InstallOutcome:
 
     installed = _installed_version(read_client, app_id)
     print(f"tenant reports installed version: {installed or '<unreported>'}")
+    if foreign and installed != args.version:
+        raise TenantAppError(
+            f"deployment reported FAILED and the tenant reports "
+            f"{installed or '<unreported>'} rather than {args.version}, so the "
+            "install did not take effect. The failing pod(s) want "
+            f"{', '.join(foreign)} — orphans from an earlier version, which are "
+            "worth deleting from the tenant's namespace either way — but with the "
+            "read-back disagreeing they are not the whole story here."
+        )
+    if foreign:
+        print(
+            f"::notice::tenant serves {installed}; the FAILED verdict was about "
+            f"{', '.join(foreign)}, not this install. Those pods should still be "
+            "cleaned up — they will fail this check on every future install."
+        )
     return InstallOutcome(
         version=args.version,
         version_id=version_id,

--- a/.github/scripts/e2e_tenant_app.py
+++ b/.github/scripts/e2e_tenant_app.py
@@ -189,6 +189,10 @@ _PULL_FAILURE_MARKERS = (
 #: An image reference in kubelet's quoted form, e.g. `pulling image "ghcr.io/x:y"`.
 _QUOTED_IMAGE_RE = re.compile(r'"([^"\s]+/[^"\s]+)"')
 
+#: A pinned image reference is the same reference with ``@sha256:…`` in place of
+#: the tag: `repo:tag@sha256:…`. Kubelet can report a pull failure in that form.
+_PINNED_IMAGE_RE = re.compile(r"@sha256:[0-9a-f]{64}$")
+
 
 class TenantAppError(RuntimeError):
     """The install or verification failed."""
@@ -885,23 +889,62 @@ def failing_images(diagnostics: str) -> list[str]:
     return found
 
 
+def _image_repository(reference: str) -> str:
+    """Return the part of an image reference before any ``@digest`` or ``:tag``.
+
+    Two references in the same repository are the same image at different
+    resolutions. ``reference.split("@")[0].rsplit(":", 1)[0]`` cannot express
+    that: an UNtagged reference ends in a colon-free final segment, and rsplit
+    would mistake that segment for a tag and cut it off — the safe direction of
+    a misread here is treating too MUCH as the same image, never less, so the
+    last colon only counts when a tag follows it.
+    """
+    reference = reference.strip().split("@", 1)[0]
+    head, sep, tag = reference.rpartition(":")
+    return head if sep and tag else reference
+
+
+def _image_tag(reference: str) -> str:
+    """Return the tag of an image reference, or "" when it carries none.
+
+    Digest-free first: ``repo:tag@sha256:…`` and ``repo@sha256:…`` both lose the
+    digest so only the ``repo[:tag]`` form is left. Then the last colon counts
+    only when a tag follows it — on a colon-free reference ``rpartition`` hands
+    back the whole string, which would read the repository AS the tag.
+    """
+    reference = _PINNED_IMAGE_RE.sub("", reference.strip())
+    head, sep, tag = reference.rpartition(":")
+    return tag if sep and head else ""
+
+
 def foreign_failure(diagnostics: str, image: str) -> list[str]:
     """Return failing images that are NOT *image*, or [] if ours is among them.
 
     An empty list means "do not second-guess LM": either nothing identifiable is
     failing, or our own image is one of the things failing. Only when every
-    failing image belongs to some other version does the caller get to treat the
-    verdict as being about somebody else's pod.
+    failing image is provably a different version does the caller get to treat
+    the verdict as being about somebody else's pod.
 
-    Compared on the full reference including the tag, because the whole point is
-    distinguishing two tags of the SAME repository.
+    Proven-different, not string-different: kubelet can report a pull failure
+    pinned (``…@sha256:…``, optionally with the tag in front) while ``--image``
+    arrives as a tag, and exact-equality reads that failure of OUR image as
+    foreign — the one misread this override must never make. So a failing
+    reference counts as ours whenever it shares our repository and its tag is
+    ours, a digest, or absent; only a different repository, or a resolvably
+    different tag of ours, is foreign.
     """
     failing = failing_images(diagnostics)
     if not failing:
         return []
     ours = image.strip()
-    if any(ref == ours for ref in failing):
-        return []
+    ours_repo = _image_repository(ours)
+    ours_tag = _image_tag(ours)
+    for ref in failing:
+        if _image_repository(ref) != ours_repo:
+            continue  # a different repository: provably somebody else's pod
+        ref_tag = _image_tag(ref)
+        if not ref_tag or not ours_tag or ref_tag == ours_tag:
+            return []  # same repository and tag, digest-pinned, or untagged
     return failing
 
 

--- a/.github/scripts/tests/test_e2e_tenant_app.py
+++ b/.github/scripts/tests/test_e2e_tenant_app.py
@@ -1396,3 +1396,150 @@ def test_a_section_within_budget_is_printed_whole(
 def test_an_empty_section_prints_no_header(capsys: pytest.CaptureFixture[str]) -> None:
     app._print_block("pod_logs", "   \n\n", 10)
     assert capsys.readouterr().out == ""
+
+
+# ── Whose pod is actually failing ────────────────────────────────────────────
+# LM's health check is namespace-scoped: it reports "Pods failed in namespace
+# <ns>: <pod>" for ANY unhealthy pod in the app's namespace, so an orphan left by
+# an earlier version fails every later install to that tenant. Observed on the
+# first green multi-arch install — our pods pulled the image in 12.4s and were
+# scaled to zero by KEDA, while a pod from an earlier attempt sat in
+# ImagePullBackOff on a different tag (x1048 over 3h59m) and took the verdict with
+# it.
+#
+# The direction that matters is the SAFE one: our own image among the failures, or
+# a read-back that disagrees, must still fail. The override is narrow.
+
+_ORPHAN = "ghcr.io/atlanhq/atlan-openapi-app:sdr-test-1c232889"
+_ORPHAN_EVENTS = (
+    f'9s Normal BackOff pod/openapi-d4849884b-7cwdp Back-off pulling image "{_ORPHAN}"\n'
+    f"20s Warning Failed pod/openapi-d4849884b-7cwdp Error: ImagePullBackOff\n"
+    f'75s Normal Pulled pod/openapi-worker-abc Successfully pulled image "{_IMAGE}" in 12.4s'
+)
+
+
+def test_a_successfully_pulled_image_is_not_read_as_failing() -> None:
+    """The inverting mistake: our image appears in the same event stream.
+
+    It is there on a `Successfully pulled` line. Counting that as a failure would
+    make every namespace look like ours is broken, which turns the override off
+    exactly when it is needed.
+    """
+    assert app.failing_images(_ORPHAN_EVENTS) == [_ORPHAN]
+    assert app.foreign_failure(_ORPHAN_EVENTS, _IMAGE) == [_ORPHAN]
+
+
+def test_our_own_image_failing_is_never_foreign() -> None:
+    events = f'Failed to pull image "{_IMAGE}": manifest unknown'
+    assert app.foreign_failure(events, _IMAGE) == [], (
+        "when our own image is among the failures the verdict IS about us, and "
+        "downgrading it would turn a real broken install into a green run"
+    )
+
+
+def test_a_mix_of_ours_and_an_orphan_is_never_foreign() -> None:
+    events = (
+        f'Back-off pulling image "{_ORPHAN}"\n'
+        f'Failed to pull image "{_IMAGE}": manifest unknown'
+    )
+    assert app.foreign_failure(events, _IMAGE) == []
+
+
+def test_unreadable_diagnostics_are_never_foreign() -> None:
+    # Nothing identifiable failing means no evidence to override LM with.
+    for text in ("", "deployment failed", "Pods failed in namespace openapi-app"):
+        assert app.foreign_failure(text, _IMAGE) == []
+
+
+def test_an_orphan_failure_passes_when_the_readback_agrees(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The workaround, and it still rests on direct evidence."""
+    _wire(
+        monkeypatch,
+        StubTransport(
+            routes=[
+                StubRoute("GET", "/info", Response(404, {})),
+                StubRoute("POST", "/marketplace/publish", _ok({"version_id": "v1"})),
+                StubRoute("POST", "/install", _ok({"deployment_id": "d1"})),
+                StubRoute(
+                    "GET",
+                    "/deployments/",
+                    _ok(
+                        {
+                            "deployment_status": "FAILED",
+                            "message": "Pods failed in namespace openapi-app: openapi-d4849884b-7cwdp",
+                        }
+                    ),
+                ),
+                StubRoute("GET", "/failure", Response(404, {})),
+                StubRoute("GET", "/events", _ok({"events": _ORPHAN_EVENTS})),
+                # The authority: the tenant really does serve what we installed.
+                StubRoute("GET", "/info", _ok({"version": _VERSION})),
+            ],
+            sticky=[StubRoute("GET", "/releases/", Response(404, {}))],
+        ),
+    )
+    outcome = app.install(_install_args())
+    assert outcome.installed_version == _VERSION
+    out = capsys.readouterr().out
+    assert "::warning::" in out and _ORPHAN in out
+    assert "cleaned up" in out, (
+        "a tolerated orphan must still be reported — it fails this check on "
+        "every future install until someone deletes it"
+    )
+
+
+def test_an_orphan_failure_still_fails_when_the_readback_disagrees(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The override moves the decision to the read-back; it does not skip it."""
+    _wire(
+        monkeypatch,
+        StubTransport(
+            routes=[
+                StubRoute("GET", "/info", Response(404, {})),
+                StubRoute("POST", "/marketplace/publish", _ok({"version_id": "v1"})),
+                StubRoute("POST", "/install", _ok({"deployment_id": "d1"})),
+                StubRoute("GET", "/deployments/", _ok({"deployment_status": "FAILED"})),
+                StubRoute("GET", "/failure", Response(404, {})),
+                StubRoute("GET", "/events", _ok({"events": _ORPHAN_EVENTS})),
+                # Tenant still on the old version: the install did NOT take.
+                StubRoute("GET", "/info", _ok({"version": "older"})),
+            ],
+            sticky=[StubRoute("GET", "/releases/", Response(404, {}))],
+        ),
+    )
+    with pytest.raises(app.TenantAppError, match="did not take effect"):
+        app.install(_install_args())
+
+
+def test_a_timeout_is_never_downgraded(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Only LM's FAILED verdict is namespace-scoped. A timeout is our problem.
+
+    `DeploymentFailed` exists to keep these apart: catching the base error here
+    would let an accepted-but-never-reconciled deploy pass whenever the namespace
+    happened to contain an orphan.
+    """
+    _wire(
+        monkeypatch,
+        StubTransport(
+            routes=[
+                StubRoute("GET", "/info", Response(404, {})),
+                StubRoute("POST", "/marketplace/publish", _ok({"version_id": "v1"})),
+                StubRoute("POST", "/install", _ok({"deployment_id": "d1"})),
+            ],
+            sticky=[
+                StubRoute("GET", "/releases/", Response(404, {})),
+                StubRoute("GET", "/failure", Response(404, {})),
+                StubRoute("GET", "/events", _ok({"events": _ORPHAN_EVENTS})),
+            ],
+        ),
+    )
+    with pytest.raises(app.TenantAppError, match="terminal state"):
+        app.install(_install_args(timeout_seconds=0))
+
+
+def test_deployment_failed_is_a_tenant_app_error() -> None:
+    # Callers catching TenantAppError (main(), the workflows) must keep working.
+    assert issubclass(app.DeploymentFailed, app.TenantAppError)

--- a/.github/scripts/tests/test_e2e_tenant_app.py
+++ b/.github/scripts/tests/test_e2e_tenant_app.py
@@ -1496,6 +1496,31 @@ def test_image_tag_extraction() -> None:
     assert app._image_tag(f"{repo}@{_DIGEST}") == ""
 
 
+def test_a_registry_port_is_never_read_as_a_tag() -> None:
+    """``ghcr.io:5000/org/repo`` carries its colon left of the final slash.
+
+    Reading that port colon as the tag separator parses the repository as bare
+    ``ghcr.io`` — which compares unequal to our own ported reference and reads
+    OUR failing image as foreign, the one misread the override must never make.
+    """
+    ported = "ghcr.io:5000/atlanhq/atlan-openapi-app"
+    assert app._image_repository(f"{ported}:sdr-test-abc123") == ported
+    assert app._image_repository(f"{ported}@{_DIGEST}") == ported
+    assert app._image_repository(f"{ported}:sdr-test-abc123@{_DIGEST}") == ported
+    assert app._image_repository(ported) == ported
+    assert app._image_tag(f"{ported}:sdr-test-abc123") == "sdr-test-abc123"
+    assert app._image_tag(f"{ported}@{_DIGEST}") == ""
+    assert app._image_tag(f"{ported}:sdr-test-abc123@{_DIGEST}") == "sdr-test-abc123"
+    assert app._image_tag(ported) == ""
+
+
+def test_our_ported_image_failing_by_digest_is_never_foreign() -> None:
+    """The ported-registry misread, end to end: tag-form --image, digest-form failure."""
+    ported = "ghcr.io:5000/atlanhq/atlan-openapi-app"
+    events = f'Failed to pull image "{ported}@{_DIGEST}": manifest unknown'
+    assert app.foreign_failure(events, f"{ported}:sdr-test-abc123") == []
+
+
 def test_a_mix_of_ours_and_an_orphan_is_never_foreign() -> None:
     events = (
         f'Back-off pulling image "{_ORPHAN}"\n'

--- a/.github/scripts/tests/test_e2e_tenant_app.py
+++ b/.github/scripts/tests/test_e2e_tenant_app.py
@@ -1437,6 +1437,65 @@ def test_our_own_image_failing_is_never_foreign() -> None:
     )
 
 
+_DIGEST = "sha256:" + "a1" * 32
+
+
+def test_our_image_failing_by_digest_is_never_foreign() -> None:
+    """Kubelet can report the failure pinned while --image arrives as a tag.
+
+    Exact string equality reads that as foreign — the one misread this override
+    must never make, since it turns a broken install of OUR image green.
+    """
+    repo = _IMAGE.rpartition(":")[0]
+    for pinned in (f"{repo}@{_DIGEST}", f"{_IMAGE}@{_DIGEST}"):
+        events = f'Failed to pull image "{pinned}": manifest unknown'
+        assert app.foreign_failure(events, _IMAGE) == []
+
+
+def test_our_image_failing_by_tag_is_never_foreign_when_we_pass_a_digest() -> None:
+    """The same ambiguity, mirrored: we hand over a digest, kubelet names the tag."""
+    repo, _, tag = _IMAGE.rpartition(":")
+    ours = f"{repo}@{_DIGEST}"
+    events = f'Back-off pulling image "{repo}:{tag}"'
+    assert app.foreign_failure(events, ours) == []
+
+
+def test_a_mix_of_our_digest_and_an_orphan_is_never_foreign() -> None:
+    """One ambiguous own failure keeps the whole verdict ours, orphans or not."""
+    repo = _IMAGE.rpartition(":")[0]
+    events = (
+        f'Back-off pulling image "{_ORPHAN}"\n'
+        f'Failed to pull image "{repo}@{_DIGEST}": manifest unknown'
+    )
+    assert app.foreign_failure(events, _IMAGE) == []
+
+
+def test_another_tag_of_our_own_repository_is_foreign() -> None:
+    """The override's whole point is distinguishing tags of the SAME repository."""
+    other_tag = _IMAGE.rpartition(":")[0] + ":sdr-test-older999"
+    events = f'Back-off pulling image "{other_tag}"'
+    assert app.foreign_failure(events, _IMAGE) == [other_tag]
+
+
+def test_image_repository_identity() -> None:
+    repo = _IMAGE.rpartition(":")[0]
+    assert app._image_repository(_IMAGE) == repo
+    assert app._image_repository(f"{repo}@{_DIGEST}") == repo
+    assert app._image_repository(f"{_IMAGE}@{_DIGEST}") == repo
+    # An untagged reference must not lose its final segment to the tag rule.
+    assert app._image_repository(repo) == repo
+
+
+def test_image_tag_extraction() -> None:
+    repo, _, tag = _IMAGE.rpartition(":")
+    assert app._image_tag(_IMAGE) == tag
+    assert app._image_tag(f"{_IMAGE}@{_DIGEST}") == tag
+    # A colon-free or digest-only reference has NO tag — rpartition on one hands
+    # back the whole string, which must not be read as a tag.
+    assert app._image_tag(repo) == ""
+    assert app._image_tag(f"{repo}@{_DIGEST}") == ""
+
+
 def test_a_mix_of_ours_and_an_orphan_is_never_foreign() -> None:
     events = (
         f'Back-off pulling image "{_ORPHAN}"\n'
@@ -1483,7 +1542,10 @@ def test_an_orphan_failure_passes_when_the_readback_agrees(
     outcome = app.install(_install_args())
     assert outcome.installed_version == _VERSION
     out = capsys.readouterr().out
-    assert "::warning::" in out and _ORPHAN in out
+    # The orphan must be named on the WARNING line itself: `_ORPHAN` also shows
+    # up in the echoed diagnostic events, so a whole-output `in` check passes
+    # even if the ::warning:: never mentioned the foreign image.
+    assert any("::warning::" in line and _ORPHAN in line for line in out.splitlines())
     assert "cleaned up" in out, (
         "a tolerated orphan must still be reported — it fails this check on "
         "every future install until someone deletes it"

--- a/docs/standards/connector-ci-e2e.md
+++ b/docs/standards/connector-ci-e2e.md
@@ -163,6 +163,35 @@ use the install path, and neither can the single-tenant fallback (which has no
 entry to add the field to); the `E2E Tenant Install` workflow's `tenant_id` input
 covers one-off runs in both cases.
 
+### When the FAILED verdict is about somebody else's pod
+
+LM's deployment health check is **namespace-scoped**: it reports `Pods failed in
+namespace <ns>: <pod>` for any unhealthy pod in the app's namespace, not just the
+ones belonging to the deployment it is reconciling. So a pod orphaned by an earlier
+install — stuck in `ImagePullBackOff` on a tag that no longer resolves, say — fails
+*every* later install to that tenant, however healthy the new version is.
+
+That is not hypothetical: it is how the first successful multi-arch install
+presented. Our pods pulled the image in 12.4s and were scaled to zero by KEDA as
+designed, while a pod from an earlier attempt sat on a different tag
+(`x1048 over 3h59m`) and took the verdict down with it.
+
+`e2e_tenant_app.py install` therefore reads the pod events before accepting the
+verdict:
+
+- If **our** image is among the ones failing to pull, the failure stands.
+- If every failing image belongs to some *other* version, the verdict is not
+  evidence about this install — so it falls through to the installed-version
+  read-back, which decides. A `::warning::` names the foreign images either way,
+  and a `::notice::` says they still need deleting, because they will fail this
+  check on every future install until someone does.
+- If the read-back **disagrees**, it still fails. The override moves the decision
+  to direct evidence; it never skips it.
+
+A timeout is never downgraded this way — an accepted-but-unreconciled deploy is
+nobody else's fault, and it is the silent wrong-version failure this whole
+mechanism exists to remove.
+
 `prepare-tenant` therefore **fails** on an unresolved `tenant_id`, immediately
 after tenant resolution and before it publishes anything — it does not skip the
 install. Skipping would leave the job green having done nothing, the tenant on

--- a/docs/standards/connector-ci-e2e.md
+++ b/docs/standards/connector-ci-e2e.md
@@ -179,8 +179,13 @@ designed, while a pod from an earlier attempt sat on a different tag
 `e2e_tenant_app.py install` therefore reads the pod events before accepting the
 verdict:
 
-- If **our** image is among the ones failing to pull, the failure stands.
-- If every failing image belongs to some *other* version, the verdict is not
+- If **our** image is among the ones failing to pull, the failure stands. Kubelet
+  can name an image by digest (`…@sha256:…`, with or without the tag) while
+  `--image` arrives as a tag, so "ours" is decided by repository identity, not
+  string equality: a failing reference in our repository counts as ours unless it
+  carries a resolvably *different* tag, and only a different repository or a
+  different tag of ours is foreign.
+- If every failing image is provably some *other* version, the verdict is not
   evidence about this install — so it falls through to the installed-version
   read-back, which decides. A `::warning::` names the foreign images either way,
   and a `::notice::` says they still need deleting, because they will fail this


### PR DESCRIPTION
See commit message — full detail there. Summary:

The first **successful** multi-arch install onto an ARM tenant reported `FAILED`, and the verdict was about somebody else's pod. From the run's own events ([31163061327](https://github.com/atlanhq/atlan-openapi-app/actions/runs/31163061327)):

```
Successfully pulled image "...:sdr-test-8680aa4e" in 12.378s   <- ours, fine
Back-off pulling image "...:sdr-test-1c232889"                 <- an orphan
Normal BackOff  9s (x1048 over 3h59m)
```

LM's health check is **namespace-scoped** — `Pods failed in namespace <ns>: <pod>` covers any unhealthy pod in the namespace, not just the deployment being reconciled. The failing pod was left by the *first* FND-31 attempt (amd64-only image), stuck four hours on a tag that isn't this install's. Ours pulled in 12.4s and were scaled to zero by KEDA as designed.

**Why code and not just a cleanup ticket:** one orphaned pod fails every subsequent install to that tenant, forever, however healthy the new version is.

So the events are read before the verdict is accepted:

- our image among the failing pulls → **the failure stands**
- every failing image belonging to another version → the verdict isn't evidence about this install, so fall through to the installed-version read-back
- read-back disagrees → **still fails**. The override moves the decision to direct evidence; it never skips it

A timeout is never downgraded — that needed a distinct `DeploymentFailed` type rather than a message check, because catching `TenantAppError` there would let an accepted-but-unreconciled deploy pass whenever the namespace happened to hold an orphan.

The classifier reads **failure lines only**: `Successfully pulled image "<ours>"` is in the same stream, and counting it would put our image in the failing set and disable the override exactly when it's needed. That's the direction that matters — a wrong "foreign" verdict turns a broken install green — and it's guarded.

A tolerated orphan is still reported twice: a `::warning::` naming the foreign images, and a `::notice::` saying they need deleting. Tolerating it in CI mustn't make it invisible.

6 mutations verified red, including all four unsafe directions. 1297 script tests pass; pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)