### PR TITLE
fix(sql): keep unclassified SQL client read/query failures retryable at the Temporal boundary [CONAT-747]

### DIFF
--- a/application_sdk/clients/sql.py
+++ b/application_sdk/clients/sql.py
@@ -553,8 +553,10 @@ class BaseSQLClient(ClientInterface):
             raise
         # conformance: ignore[E004] exception re-raised immediately as typed SqlPandasResultError; cause chain preserved via `from e`
         except Exception as e:
+            # retryable=True: unclassified driver exception — do not override the
+            # activity's declared retry policy. See SqlPandasResultError docstring.
             raise SqlPandasResultError(
-                message="Error reading batched data from SQL", cause=e
+                message="Error reading batched data from SQL", cause=e, retryable=True
             ) from e
 
     async def get_results(self, query: str) -> "pd.DataFrame":
@@ -580,7 +582,9 @@ class BaseSQLClient(ClientInterface):
             raise
         # conformance: ignore[E004] exception re-raised immediately as typed SqlPandasResultError; cause chain preserved via `from e`
         except Exception as e:
-            raise SqlPandasResultError(cause=e) from e
+            # retryable=True: unclassified driver exception — do not override the
+            # activity's declared retry policy. See SqlPandasResultError docstring.
+            raise SqlPandasResultError(cause=e, retryable=True) from e
 
 
 class AsyncBaseSQLClient(BaseSQLClient):
@@ -725,8 +729,13 @@ class AsyncBaseSQLClient(BaseSQLClient):
                 raise
             # conformance: ignore[E004] exception re-raised immediately as typed SqlPandasResultError; cause chain preserved via `from e`
             except Exception as e:
+                # retryable=True: unclassified driver exception — do not override
+                # the activity's declared retry policy. A transient source-side
+                # condition (concurrent DDL, lock contention, dropped connection)
+                # is indistinguishable from a permanent one here.
+                # See SqlPandasResultError docstring.
                 raise SqlPandasResultError(
-                    message="Error executing SQL query", cause=e
+                    message="Error executing SQL query", cause=e, retryable=True
                 ) from e
             # Async connection automatically closed by context manager
 

--- a/application_sdk/clients/sql_errors.py
+++ b/application_sdk/clients/sql_errors.py
@@ -86,7 +86,26 @@ class InvalidSqlEngineTypeError(InternalError):
 
 @dataclass(kw_only=True)
 class SqlPandasResultError(InternalError):
-    """A SQL read operation failed to produce a valid pandas DataFrame result."""
+    """A SQL read operation failed to produce a valid pandas DataFrame result.
+
+    Raised in two distinct situations, which differ in retryability:
+
+    - **Invariant violation** (the read path returned a non-DataFrame). A bug in
+      our code; retrying cannot help. Keeps the ``INTERNAL`` default
+      ``retryable=False``.
+    - **Catch-and-rewrap of an unclassified driver exception** at the query
+      boundary. Here the SDK has *not* established what failed — a transient
+      source-side condition (concurrent DDL, lock contention, a dropped
+      connection) is wrapped identically to a permanent one. Those sites pass
+      ``retryable=True`` explicitly, which does not assert "this will succeed on
+      retry"; it declines to override the activity's own declared Temporal retry
+      policy for an error we never classified. Asserting ``retryable=False``
+      there marks the failure ``non_retryable`` on the wire and makes the
+      activity's declared ``maximum_attempts`` dead code (CONAT-747).
+
+    Errors that *are* classified never reach either site — the enclosing
+    ``except AppError: raise`` clauses re-raise them with their own retryability.
+    """
 
     code: ClassVar[str] = "INTERNAL_SQL_PANDAS"
     message: str = "Error reading data from SQL into a pandas DataFrame"

--- a/tests/unit/clients/test_async_sql_client.py
+++ b/tests/unit/clients/test_async_sql_client.py
@@ -313,3 +313,67 @@ async def test_run_query_escapes_colons_server_side(
 
     mock_text.assert_called_once_with("RLIKE '^(?\\:cdl)'")
     mock_connection_with_options.stream.assert_called_once_with("RLIKE '^(?\\:cdl)'")
+
+
+# ---------- retryability of the unclassified-exception wrap (CONAT-747) ----------
+
+
+@pytest.mark.asyncio
+@patch("sqlalchemy.text", side_effect=lambda q: q)  # type: ignore
+async def test_run_query_wrap_is_retryable_server_side(
+    mock_text: MagicMock,
+    async_sql_client: AsyncBaseSQLClient,
+    mock_async_engine_with_connection,
+):
+    """An unclassified driver exception must NOT be marked non-retryable.
+
+    The activity that calls run_query declares its own Temporal retry policy
+    (e.g. maximum_attempts=3). Wrapping every escaping exception as a
+    non-retryable InternalError made that policy dead code, so a transient
+    source-side failure became a hard failure on the first attempt.
+    """
+    mock_engine, _mock_connection, mock_connection_with_options = (
+        mock_async_engine_with_connection
+    )
+    async_sql_client.engine = mock_engine
+
+    mock_result = MagicMock()
+    mock_result.keys.side_effect = lambda: ["col1"]
+    # Mimics psycopg.errors.InternalError_: a transient concurrent-DDL race.
+    mock_result.fetchmany = AsyncMock(
+        side_effect=[Exception("could not open relation with OID 328245688")]
+    )
+    mock_connection_with_options.stream = AsyncMock(return_value=mock_result)
+    async_sql_client.use_server_side_cursor = True
+
+    with pytest.raises(SqlPandasResultError) as exc_info:
+        async for _ in async_sql_client.run_query("SELECT * FROM t"):
+            pass
+
+    assert exc_info.value.effective_retryable is True
+    assert exc_info.value.to_failure_details().retryable is True
+
+
+@pytest.mark.asyncio
+@patch("sqlalchemy.text", side_effect=lambda q: q)  # type: ignore
+async def test_run_query_wrap_is_retryable_client_side(
+    mock_text: MagicMock,
+    async_sql_client: AsyncBaseSQLClient,
+    mock_async_engine_with_connection,
+):
+    """The client-side cursor path carries the same retryability."""
+    mock_engine, mock_connection, _ = mock_async_engine_with_connection
+    async_sql_client.engine = mock_engine
+
+    mock_result = MagicMock()
+    mock_result.keys.side_effect = lambda: ["col1"]
+    mock_result.cursor = MagicMock()
+    mock_result.cursor.fetchmany = MagicMock(side_effect=Exception("connection lost"))
+    mock_connection.execute = AsyncMock(return_value=mock_result)
+    async_sql_client.use_server_side_cursor = False
+
+    with pytest.raises(SqlPandasResultError) as exc_info:
+        async for _ in async_sql_client.run_query("SELECT * FROM t"):
+            pass
+
+    assert exc_info.value.effective_retryable is True

--- a/tests/unit/clients/test_sql_client.py
+++ b/tests/unit/clients/test_sql_client.py
@@ -1318,3 +1318,67 @@ def test_add_connection_params_empty_dict_is_noop(sql_client_with_db_config):
     """An empty params dict must return the connection string unchanged."""
     base = "postgresql://u:p@h:5432/db"
     assert sql_client_with_db_config.add_connection_params(base, {}) == base
+
+
+# ---------- retryability split on SqlPandasResultError (CONAT-747) ----------
+
+
+@pytest.mark.asyncio
+async def test_get_batched_results_wrap_is_retryable(sql_client: BaseSQLClient):
+    """An unclassified read-path failure must not override the retry policy."""
+    sql_client.engine = MagicMock()
+    with (
+        patch.object(
+            sql_client,
+            "_execute_async_read_operation",
+            new=AsyncMock(
+                side_effect=RuntimeError("could not open relation with OID 1")
+            ),
+        ),
+        pytest.raises(SqlPandasResultError) as exc_info,
+    ):
+        await sql_client.get_batched_results("SELECT 1")
+    assert exc_info.value.effective_retryable is True
+
+
+@pytest.mark.asyncio
+async def test_get_results_wrap_is_retryable(sql_client: BaseSQLClient):
+    """Same for the single-DataFrame read path."""
+    sql_client.engine = MagicMock()
+    with (
+        patch.object(
+            sql_client,
+            "_execute_async_read_operation",
+            new=AsyncMock(side_effect=RuntimeError("connection reset by peer")),
+        ),
+        pytest.raises(SqlPandasResultError) as exc_info,
+    ):
+        await sql_client.get_results("SELECT 1")
+    assert exc_info.value.effective_retryable is True
+
+
+@pytest.mark.asyncio
+async def test_get_results_invariant_violation_stays_non_retryable(
+    sql_client: BaseSQLClient,
+):
+    """The invariant-violation raise is OUR bug — retrying cannot help.
+
+    Guards against over-broadening the fix by flipping the class default:
+    only the catch-and-rewrap sites opt into retryability.
+    """
+    sql_client.engine = MagicMock()
+    with (
+        patch.object(
+            sql_client,
+            "_execute_async_read_operation",
+            new=AsyncMock(return_value=iter([])),  # not a DataFrame
+        ),
+        pytest.raises(SqlPandasResultError) as exc_info,
+    ):
+        await sql_client.get_results("SELECT 1")
+    assert exc_info.value.effective_retryable is False
+
+
+def test_sql_pandas_result_error_class_default_is_non_retryable():
+    """The INTERNAL class default is unchanged; retryability is per-instance."""
+    assert SqlPandasResultError.default_retryable is False

--- a/tests/unit/execution/test_activities.py
+++ b/tests/unit/execution/test_activities.py
@@ -743,3 +743,84 @@ class TestActivityFnExecution:
             result = await activity_fn(ctx, _AfnIn(name="x"))
 
         assert result.captured_workflow_id == "wf-from-temporal"
+
+
+class TestSqlWrapRetryabilityReachesTheWire:
+    """End-to-end guard for CONAT-747.
+
+    The SQL client wraps unclassified driver exceptions in
+    ``SqlPandasResultError``; the activity wrapper then translates any AppError
+    into ``ApplicationError(non_retryable=not effective_retryable)``. If the
+    wrap asserts non-retryability, Temporal records
+    ``RETRY_STATE_NON_RETRYABLE_FAILURE`` and the activity's declared
+    ``maximum_attempts`` never applies. This asserts the whole chain, not just
+    the flag on the exception.
+    """
+
+    def setup_method(self) -> None:
+        AppRegistry.reset()
+        TaskRegistry.reset()
+
+    def teardown_method(self) -> None:
+        AppRegistry.reset()
+        TaskRegistry.reset()
+
+    async def _run_task_raising(self, err: Exception):
+        from application_sdk.execution.errors import ApplicationError
+
+        class _SqlFailApp(App):
+            @task(timeout_seconds=60)
+            async def crawl(self, input: _AfnIn) -> _AfnOut:
+                raise err
+
+            async def run(self, input: _AfnIn) -> _AfnOut:
+                return await self.crawl(input)
+
+        app_slug = "_sql-fail-app"
+        tasks = TaskRegistry.get_instance().get_tasks_for_app(app_slug)
+        activity_fn = create_activity_from_task(
+            next(t for t in tasks if t.name == "crawl")
+        )
+        ctx = TaskContext(
+            app_name=app_slug,
+            task_name="crawl",
+            run_id="run-1",
+            heartbeat_timeout_seconds=None,
+            auto_heartbeat_seconds=None,
+        )
+        with (
+            mock.patch.object(
+                activities_module.activity,
+                "info",
+                return_value=mock.MagicMock(workflow_id="wf-sql"),
+            ),
+            mock.patch(
+                "application_sdk.infrastructure.context.get_infrastructure",
+                return_value=None,
+            ),
+            pytest.raises(ApplicationError) as exc_info,
+        ):
+            await activity_fn(ctx, _AfnIn(name="x"))
+        return exc_info.value
+
+    @pytest.mark.asyncio
+    async def test_unclassified_sql_wrap_is_not_flagged_non_retryable(self) -> None:
+        from application_sdk.clients.sql_errors import SqlPandasResultError
+
+        err = SqlPandasResultError(
+            message="Error executing SQL query",
+            cause=Exception("could not open relation with OID 328245688"),
+            retryable=True,
+        )
+        app_err = await self._run_task_raising(err)
+        assert app_err.non_retryable is False
+
+    @pytest.mark.asyncio
+    async def test_sql_invariant_violation_is_flagged_non_retryable(self) -> None:
+        from application_sdk.clients.sql_errors import SqlPandasResultError
+
+        err = SqlPandasResultError(
+            invariant="_execute_async_read_operation must return a pd.DataFrame"
+        )
+        app_err = await self._run_task_raising(err)
+        assert app_err.non_retryable is True


### PR DESCRIPTION
## Root cause — problem class is SDK-wide (CONAT-747, finding 2 of the RCA)

Every unclassified SQL error in the SDK is delivered to Temporal as **hard non-retryable**, defeating the activity's own declared retry policy — fleet-wide, for every connector app.

Chain (verified at v3.26.1 and unchanged on main): the blanket `except Exception` wraps in `clients/sql.py` (`get_batched_results`, `get_results`, `run_query`) raise `SqlPandasResultError`, which inherits `InternalError.default_retryable = False`; `execution/_temporal/activities.py:330` then emits `ApplicationError(non_retryable=True)`. Observed at the I/O boundary on the incident run: `postgres:fetch_tables` declares `maximumAttempts: 3` / `nonRetryableErrorTypes: ["WorkerEvicted"]`, yet failed attempt 1 with `RETRY_STATE_NON_RETRYABLE_FAILURE` on a **provably transient** error (a Postgres dropped-relation race; 3/15 failing nights recovered on a later retry against the same source).

Full RCA: Linear Document on CONAT-747 ("CONAT-747 — RCA: postgres dropped-relation race").

## Why it broke now
Introduced by **#1754** ("feat(errors): strongly type all errors according to error hierarchy", 2026-05-18): before it, these sites re-raised via `rewrap(...)` as plain non-`AppError` exceptions, which took the bare `raise` branch — Temporal applied the declared policy normally. #1754's typing work flipped them to hard non-retryable as an unintended side effect. Consistent with the incident's observed onset window.

## The fix — scope: 3 wrap sites in clients/sql.py (fix-forward; reverting a 3-month-old repo-wide taxonomy migration is not viable)
The three wrap sites now pass `retryable=True` — restoring exactly the pre-#1754 retry semantics for *unclassified* errors while keeping the typed-error model. Deliberately unchanged: `SqlPandasResultError.default_retryable` (class default stays `False`), and the invariant-violation raise in `get_results` (genuinely our bug; retrying can't help) — both pinned by guard tests. `except AppError: raise` precedes every site, so correctly-classified errors keep their own retryability.

This does **not** yet hold for apps whose failures surface through the monolithic extractor's top-level handler — `SqlMetadataExtractionError` re-flattens retryability there. Tracked as a separate diff.

## Blast radius
- In-diff: the 3 wrap sites (the incident path — verified from the worker logs that `SqlPandasResultError` reached the activity boundary intact).
- Named follow-ups (same shape, deliberately separate diffs): `templates/sql_metadata_extractor.py:515` (workflow-boundary retryability — re-flattens for apps routing through the monolithic extractor, but runs only after the activity's attempts are spent, so it is a distinct failure mode from the activity-boundary bug fixed here; **off the incident path**, verified), `sql_query_extractor.py:160`, `incremental_sql_metadata_extractor.py:795`, `storage/formats/__init__.py:445/649/774`, `credentials/*` (5 sites), `clients/azure/client.py:204/324`, `common/aws_utils.py:140`, 2 incremental sites.
- Sibling repos: none — apps inherit via SDK bump.

## Scope note
This is the fleet-wide correctness fix, **not** the resolution of the customer's nightly failure on its own (immediate retry is ~20% effective for that cohort) — the durable fix is atlanhq/atlan-postgres-app#514 (finding 1, same ticket).

## Test evidence
- 8 new tests (pure appends; existing tests untouched — verified by independent numstat audit): wrap-site retryability (server- and client-side cursor paths), wire-boundary assertions through `create_activity_from_task`, plus guards pinning the class default and the invariant raise as still non-retryable.
- Red/green: exactly the 4 wrap-site tests fail with the fix reverted (4 failed, 107 passed); 111 passed on the branch. Guard honesty verified by mutation (flipping the class default breaks 3 guards).
- Full unit suite: 6256 passed, 9 skipped, 0 failed. Ruff + conformance E-series clean.
- Customer replay: the incident exception (`psycopg.errors.InternalError_('could not open relation with OID 328245688')`) driven through `run_query` → `create_activity_from_task` asserts `non_retryable is False` on the branch (and reproduces `True` on base).

## Reviewer notes (non-blocking)
- The two wire tests hand-construct the error (translator half only); the tester's end-to-end replay (`replay_conat747_test.py.txt` in the run's fix dir) is worth committing as a chained test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

