### PR TITLE
fix(config): ATLAN_SQL_USE_SERVER_SIDE_CURSOR opt-out was a no-op — parse the boolean properly [CONAT-747]

### DIFF
--- a/application_sdk/constants.py
+++ b/application_sdk/constants.py
@@ -375,8 +375,12 @@ def _load_worker_liveness_max_idle_seconds() -> float:
 WORKER_LIVENESS_MAX_IDLE_SECONDS = _load_worker_liveness_max_idle_seconds()
 
 # SQL Client Constants
-#: Whether to use server-side cursors for SQL operations
-USE_SERVER_SIDE_CURSOR = bool(os.getenv("ATLAN_SQL_USE_SERVER_SIDE_CURSOR", "true"))
+#: Whether to use server-side cursors for SQL operations.
+#: Enabled by default; set ATLAN_SQL_USE_SERVER_SIDE_CURSOR to any value other
+#: than "true" (e.g. "false") to opt out.
+USE_SERVER_SIDE_CURSOR = (
+    os.getenv("ATLAN_SQL_USE_SERVER_SIDE_CURSOR", "true").strip().lower() == "true"
+)
 
 # DAPR Constants
 #: Name of the state store component in DAPR

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -158,7 +158,7 @@ Used by `RedisCapacityPool` for distributed slot locking. Leave empty if you use
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `ATLAN_SQL_USE_SERVER_SIDE_CURSOR` | `true` | Use server-side cursors for SQL queries. Reduces memory for large result sets by streaming data row-by-row. Default: enabled. To disable, **explicitly set the variable to an empty string** (e.g. `ATLAN_SQL_USE_SERVER_SIDE_CURSOR=`). Any non-empty string, including `"false"`, is truthy and keeps it enabled. |
+| `ATLAN_SQL_USE_SERVER_SIDE_CURSOR` | `true` | Use server-side cursors for SQL queries. Reduces memory for large result sets by streaming data row-by-row. Default: enabled. To disable, set the variable to any value other than `true` (e.g. `ATLAN_SQL_USE_SERVER_SIDE_CURSOR=false`). Matching is case-insensitive and surrounding whitespace is ignored. |
 
 ---
 

--- a/tests/unit/test_constants.py
+++ b/tests/unit/test_constants.py
@@ -1,7 +1,10 @@
 """Unit tests for env-var loaders in :mod:`application_sdk.constants`."""
 
+import importlib
+
 import pytest
 
+import application_sdk.constants as constants
 from application_sdk.constants import _load_worker_liveness_max_idle_seconds
 
 
@@ -35,3 +38,58 @@ class TestLoadWorkerLivenessMaxIdleSeconds:
         monkeypatch.setenv("ATLAN_WORKER_LIVENESS_MAX_IDLE_SECONDS", "nan")
         with pytest.warns(UserWarning, match="not finite"):
             assert _load_worker_liveness_max_idle_seconds() == 0.0
+
+
+class TestUseServerSideCursor:
+    """Cover the ``ATLAN_SQL_USE_SERVER_SIDE_CURSOR`` opt-out.
+
+    The flag is a module-level constant evaluated at import time, so each case
+    reloads :mod:`application_sdk.constants` under a patched environment.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _restore_constants(self):
+        # Leave the module as the rest of the suite expects to find it.
+        yield
+        importlib.reload(constants)
+
+    def _reload(self) -> bool:
+        return importlib.reload(constants).USE_SERVER_SIDE_CURSOR
+
+    def test_default_enabled_when_unset(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.delenv("ATLAN_SQL_USE_SERVER_SIDE_CURSOR", raising=False)
+        assert self._reload() is True
+
+    @pytest.mark.parametrize("value", ["false", "False", "FALSE", " false ", "0", "no"])
+    def test_opt_out_disables(self, monkeypatch: pytest.MonkeyPatch, value: str):
+        # Regression: ``bool(os.getenv(...))`` made every non-empty string —
+        # including "false" — truthy, so the documented opt-out could not
+        # disable server-side cursors.
+        monkeypatch.setenv("ATLAN_SQL_USE_SERVER_SIDE_CURSOR", value)
+        assert self._reload() is False
+
+    @pytest.mark.parametrize("value", ["true", "True", "TRUE", " true "])
+    def test_explicit_true_enables(self, monkeypatch: pytest.MonkeyPatch, value: str):
+        monkeypatch.setenv("ATLAN_SQL_USE_SERVER_SIDE_CURSOR", value)
+        assert self._reload() is True
+
+    def test_empty_string_still_disables(self, monkeypatch: pytest.MonkeyPatch):
+        # The only opt-out that worked before the fix must keep working.
+        monkeypatch.setenv("ATLAN_SQL_USE_SERVER_SIDE_CURSOR", "")
+        assert self._reload() is False
+
+    def test_sql_client_default_follows_the_constant(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """BaseSQLClient binds the constant as its default at import time."""
+        monkeypatch.setenv("ATLAN_SQL_USE_SERVER_SIDE_CURSOR", "false")
+        importlib.reload(constants)
+
+        import application_sdk.clients.sql as sql_client_mod
+
+        try:
+            reloaded = importlib.reload(sql_client_mod)
+            assert reloaded.BaseSQLClient.use_server_side_cursor is False
+        finally:
+            importlib.reload(constants)
+            importlib.reload(sql_client_mod)


### PR DESCRIPTION
## Root cause — CONAT-747 (finding 3 of the RCA; independent latent defect)

The documented env opt-out for server-side cursors cannot disable them:

```python
# application_sdk/constants.py:379 — unchanged since the initial open-sourcing commit
USE_SERVER_SIDE_CURSOR = bool(os.getenv("ATLAN_SQL_USE_SERVER_SIDE_CURSOR", "true"))
```

`bool()` of **any non-empty string** is `True` — including `"false"`, `"0"`, `"no"`. Only an empty string disabled it, and `docs/configuration.md` had codified that workaround. This became load-bearing when server-side cursors became the SDK default and `atlan-postgres-app` removed its PART-665 per-app opt-out on the promise this env var covered it. (Not the cause of the CONAT-747 incident itself — the RCA refuted cursors as the cause — but found byte-confirmed while reading the path.)

Full RCA: Linear Document on CONAT-747.

## The fix
Parse with the file's own dominant boolean-env idiom (13+ sibling sites): `.strip().lower() == "true"`. Docs corrected. Default unchanged (unset ⇒ enabled); empty-string opt-out keeps working (backward compat).

## ⚠️ Behavior change (release note)
Deployments setting `ATLAN_SQL_USE_SERVER_SIDE_CURSOR=1`/`yes`/`on` (never documented values) were getting cursors enabled **by accident** and will now get them **disabled** — higher client memory on large result sets for those deployments. `=false`/`=0`/`=no` now genuinely disable, which is what those deployments asked for. Explicit `use_server_side_cursor=` kwargs are unaffected.

## Blast radius
- The constant + its transitively-corrected consumers `BaseSQLClient.use_server_side_cursor` (class attr + `__init__` default, `clients/sql.py:81/:86`).
- Repo-wide sweep for the `bool(os.getenv(...))` anti-pattern: exactly this one first-party instance (independently re-grepped by the reviewer).
- Sibling repos: none — apps inherit on the next SDK bump. `atlan-postgres-app` owners should know the env var now genuinely works (PART-665 context).

## Test evidence
- New `TestUseServerSideCursor` (13 cases, additive — zero deletions in `tests/`; the 2-line import hunk in the pre-existing test file was explicitly adjudicated by the independent reviewer as additive-only): 6 opt-out values, explicit-true, unset-default guard, empty-string backward compat, and a consumer test proving the fix reaches `BaseSQLClient`.
- Red/green: 7 fail with the expression reverted; 19 pass on the branch. Full unit suite: 6259 passed, 0 failed, 11 skipped.
- Clean-interpreter subprocess replay (no `importlib.reload` artifacts) across 4 consumer surfaces incl. `AsyncBaseSQLClient`: discriminating (fails on base, passes on branch).
- Reviewer note (non-blocking): if `pytest-randomly` is ever adopted, convert the reload-based consumer test to the subprocess pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
