### PR TITLE
chore(ci): preserve frontend/ under app/generated on prefixed swap

### DIFF
--- a/.github/scripts/pkl_contract_layout.py
+++ b/.github/scripts/pkl_contract_layout.py
@@ -349,16 +349,22 @@ def swap_outputs(
             dest: dest.read_bytes() for dest in skip if dest.is_relative_to(target)
         }
         reserved = _withhold_reserved_subdirs(target)
-        shutil.rmtree(target, ignore_errors=True)
-        target.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copytree(out_dir / "app" / "generated", target)
-        _copy_planned(
-            {d: s for d, s in plan.items() if not d.is_relative_to(target)}, skip
-        )
-        for dest, content in preserved.items():
-            dest.parent.mkdir(parents=True, exist_ok=True)
-            dest.write_bytes(content)
-        _restore_reserved_subdirs(target, reserved)
+        try:
+            shutil.rmtree(target, ignore_errors=True)
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copytree(out_dir / "app" / "generated", target)
+            _copy_planned(
+                {d: s for d, s in plan.items() if not d.is_relative_to(target)}, skip
+            )
+            for dest, content in preserved.items():
+                dest.parent.mkdir(parents=True, exist_ok=True)
+                dest.write_bytes(content)
+        finally:
+            # Restore even on a mid-swap failure: the withheld reserved subdirs
+            # live in a tempdir, so an exception here would otherwise strand the
+            # working tree without them. The swap failing still propagates; this
+            # just guarantees the restore runs.
+            _restore_reserved_subdirs(target, reserved)
         return True
 
     # Native: overwrite-only. The generated dir can hold app-owned files this

--- a/.github/scripts/pkl_contract_layout.py
+++ b/.github/scripts/pkl_contract_layout.py
@@ -47,7 +47,7 @@ files the toolkit does not own:
   * **Prefixed: replace the generated dir wholesale.** ``App.pkl`` emits every
     file under ``app/generated/`` including ``__init__.py``, so a
     rmtree+copytree is safe and clears orphans left by a removed or renamed
-    entrypoint.
+    entrypoint — with one carve-out, ``RESERVED_GENERATED_SUBDIRS`` below.
 
   * **Native: overwrite emitted files in place, never delete.** The generated
     dir here holds files pkl does not emit — e.g. the ``__init__.py`` an app's
@@ -66,6 +66,7 @@ from __future__ import annotations
 
 import shutil
 import subprocess
+import tempfile
 from pathlib import Path
 
 # Repo-root files both families emit at the top level of the eval output. They
@@ -75,6 +76,21 @@ ROOT_FILES = ("atlan.yaml", "app.yaml")
 # Where an app keeps its generated artifacts. The overwhelming default across
 # the fleet; apps that differ are refused rather than mis-written.
 GENERATED_DIR = "app/generated"
+
+# Subdirectory names under the generated dir that NO pkl contract, in any
+# family or toolkit version, ever emits into — so baseline/override detection
+# (which compares what a contract emitted then vs. now) can never see them and
+# the prefixed family's wholesale rmtree+copytree would otherwise delete them
+# on every regeneration.
+#
+# ``"frontend"``: ``create_app_handler_service``'s ``frontend_assets_path``
+# defaults to ``<generated_dir>/frontend/static``, populated by the
+# ``@atlanhq/app-playground`` CLI, not by any contract. Re-running that CLI to
+# restore the directory is not an option — its build output is not
+# byte-reproducible (fresh content hashes and a random build UUID every run,
+# confirmed against the same pinned package version), so a diff-based swap can
+# never converge; the only stable behavior is to leave it untouched.
+RESERVED_GENERATED_SUBDIRS = ("frontend",)
 
 # Optional app-owned script run after a successful swap, relative to the contract
 # dir. A convention rather than a per-workflow input on purpose: every
@@ -208,6 +224,49 @@ def overridden_files(
     return overridden
 
 
+def _withhold_reserved_subdirs(target: Path) -> dict[str, Path]:
+    """Move each existing ``RESERVED_GENERATED_SUBDIRS`` entry out of ``target``
+    into a temp holding dir, ahead of a wholesale rmtree.
+
+    Returns ``{name: backup_path}`` for every subdir that existed, to be handed
+    to ``_restore_reserved_subdirs``. Never raises: a reserved name that is not
+    a directory (or is absent) is simply skipped.
+    """
+    backups: dict[str, Path] = {}
+    for name in RESERVED_GENERATED_SUBDIRS:
+        src = target / name
+        if src.is_dir():
+            holding = Path(tempfile.mkdtemp())
+            backup = holding / name
+            shutil.move(str(src), str(backup))
+            backups[name] = backup
+    return backups
+
+
+def _restore_reserved_subdirs(target: Path, backups: dict[str, Path]) -> None:
+    """Move withheld reserved subdirs back under ``target`` and clean up.
+
+    Skips (and warns on) a name the fresh copytree unexpectedly recreated —
+    e.g. a future contract legitimately emitting that name — rather than
+    silently overwriting it; that would only happen if a contract started
+    emitting a key under a reserved name, which is a real change to surface,
+    not paper over.
+    """
+    for name, backup in backups.items():
+        dest = target / name
+        if dest.exists():
+            print(
+                f"::warning::pkl eval emitted '{name}' under the generated dir, "
+                "which collides with a reserved name normally left untouched "
+                f"(RESERVED_GENERATED_SUBDIRS); keeping the freshly emitted "
+                f"'{name}' and discarding the withheld copy."
+            )
+        else:
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            shutil.move(str(backup), str(dest))
+        shutil.rmtree(backup.parent, ignore_errors=True)
+
+
 def swap_outputs(
     out_dir: Path,
     generated_dir: str = GENERATED_DIR,
@@ -224,6 +283,10 @@ def swap_outputs(
     generated from. When given, files the app post-processes are detected and
     preserved — see ``overridden_files``. Omit it (the default) to overwrite
     everything the eval emitted.
+
+    In the prefixed family, any existing ``RESERVED_GENERATED_SUBDIRS`` entry
+    (e.g. ``frontend/``) survives the wholesale replace unconditionally — no
+    baseline needed, since pkl never emits into it in the first place.
 
     Returns False — touching nothing under ``generated_dir`` — when the output
     holds no generated artifacts (``root-only``/``empty``) or when the native
@@ -285,6 +348,7 @@ def swap_outputs(
         preserved = {
             dest: dest.read_bytes() for dest in skip if dest.is_relative_to(target)
         }
+        reserved = _withhold_reserved_subdirs(target)
         shutil.rmtree(target, ignore_errors=True)
         target.parent.mkdir(parents=True, exist_ok=True)
         shutil.copytree(out_dir / "app" / "generated", target)
@@ -294,6 +358,7 @@ def swap_outputs(
         for dest, content in preserved.items():
             dest.parent.mkdir(parents=True, exist_ok=True)
             dest.write_bytes(content)
+        _restore_reserved_subdirs(target, reserved)
         return True
 
     # Native: overwrite-only. The generated dir can hold app-owned files this

--- a/.github/scripts/tests/test_pkl_contract_layout.py
+++ b/.github/scripts/tests/test_pkl_contract_layout.py
@@ -87,6 +87,64 @@ def test_prefixed_creates_missing_target(tree):
     assert (tree / "app" / "generated" / "manifest.json").read_text() == "fresh\n"
 
 
+def test_prefixed_preserves_reserved_frontend_subdir(tree):
+    """`frontend/` (the app-playground install target) is not an orphan — no
+    pkl contract, in any family or version, ever emits it — so it must survive
+    the wholesale rmtree+copytree untouched, unlike `orphan.json` above."""
+    _write(tree / "app" / "generated" / "frontend" / "static" / "index.html", "ui\n")
+    _write(tree / "out" / "app" / "generated" / "manifest.json", "fresh\n")
+
+    assert mod.swap_outputs(tree / "out") is True
+
+    assert (tree / "app" / "generated" / "manifest.json").read_text() == "fresh\n"
+    assert (
+        tree / "app" / "generated" / "frontend" / "static" / "index.html"
+    ).read_text() == "ui\n"
+
+
+def test_prefixed_reserved_subdir_survives_alongside_override_protection(tree):
+    """Reserved-subdir preservation and baseline override protection are
+    independent mechanisms that must not interfere with each other."""
+    _write(tree / "app" / "generated" / "frontend" / "static" / "index.html", "ui\n")
+    _write(tree / "app" / "generated" / "manifest.json", "old-toolkit\n")
+    _write(tree / "app" / "generated" / "connector.json", "hand-maintained\n")
+    _write(tree / "base" / "app" / "generated" / "manifest.json", "old-toolkit\n")
+    _write(tree / "base" / "app" / "generated" / "connector.json", "toolkit-default\n")
+    _write(tree / "out" / "app" / "generated" / "manifest.json", "new-toolkit\n")
+    _write(tree / "out" / "app" / "generated" / "connector.json", "toolkit-v2\n")
+
+    assert mod.swap_outputs(tree / "out", baseline_dir=tree / "base") is True
+
+    gen = tree / "app" / "generated"
+    assert gen.joinpath("manifest.json").read_text() == "new-toolkit\n"
+    assert gen.joinpath("connector.json").read_text() == "hand-maintained\n"
+    assert gen.joinpath("frontend", "static", "index.html").read_text() == "ui\n"
+
+
+def test_prefixed_reserved_subdir_absent_is_a_noop(tree):
+    """No `frontend/` to preserve is the common case — must not error."""
+    _write(tree / "out" / "app" / "generated" / "manifest.json", "fresh\n")
+
+    assert mod.swap_outputs(tree / "out") is True
+
+    assert not (tree / "app" / "generated" / "frontend").exists()
+
+
+def test_prefixed_reserved_subdir_yields_to_a_real_emitted_key(tree, capsys):
+    """If a contract ever legitimately emits a `frontend` key, that is a real
+    change to surface, not something to silently clobber with the withheld
+    copy — the fresh output wins and a warning is printed."""
+    _write(tree / "app" / "generated" / "frontend" / "static" / "index.html", "old\n")
+    _write(tree / "out" / "app" / "generated" / "frontend" / "manifest.json", "fresh\n")
+
+    assert mod.swap_outputs(tree / "out") is True
+
+    gen = tree / "app" / "generated"
+    assert gen.joinpath("frontend", "manifest.json").read_text() == "fresh\n"
+    assert not gen.joinpath("frontend", "static", "index.html").exists()
+    assert "collides with a reserved name" in capsys.readouterr().out
+
+
 # ── swap_outputs: native family ──────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

- The prefixed contract family's `swap_outputs` replaces `app/generated/` wholesale (rmtree + copytree) on every regeneration entry point — the freshness check, Renovate's toolkit-bump sync, and the pre-test `regenerate_contract` step.
- `create_app_handler_service` defaults `frontend_assets_path` to `app/generated/frontend/static`, populated by the `@atlanhq/app-playground` CLI, not by any pkl contract. Any app combining a prefixed-family contract with that default frontend path has that directory deleted on every regeneration and permanently reads as drift in `Generated Artifact Freshness`.
- Reinstalling the frontend via the playground CLI in a `contract/post-generate.sh` hook (the existing escape hatch for app-owned post-processing) does not fix this: its build output is not byte-reproducible — different content hashes and a random build UUID on every run, confirmed even reinstalling the exact same pinned package version against a real app's committed bundle. A diff-based swap can never converge that way, so the only stable behavior is to leave the directory untouched.
- Adds `RESERVED_GENERATED_SUBDIRS` (currently just `("frontend",)`) to `pkl_contract_layout.py`: any existing entry is withheld before the wholesale rmtree and restored after the copytree, unconditionally — independent of (and compatible with) baseline override detection, since no contract in any family/version ever emits into it, so override detection could never see it in the first place. Yields (with a warning) to a real emitted key of the same name, rather than silently overwriting it.

Found while fixing the `Generated Artifact Freshness` failure on `atlanhq/atlan-sapdatasphere-app#44` — that PR's check was flagging ~46 files under `app/generated/frontend/static/**` as "stale," none of which are pkl-emitted.

## Test plan

- [x] `uv run pytest .github/scripts/tests/test_pkl_contract_layout.py -v` — added 5 new cases covering: reserved subdir preserved wholesale, coexistence with baseline override protection, no-op when absent, and yielding to a real emitted key.
- [x] `uv run pytest .github/scripts/tests/` (full suite) — 1293 passed, no regressions in `test_renovate_pkl_sync.py` / `test_check_generated_freshness.py`.
- [x] `uv run pre-commit run --files .github/scripts/pkl_contract_layout.py .github/scripts/tests/test_pkl_contract_layout.py` — clean.
- [x] Ran the patched `check_generated_freshness.py` against the real `atlan-sapdatasphere-app` PR #44 branch: the `app/generated/frontend/static/**` drift is gone entirely (down from ~46 flagged files to one unrelated, pre-existing stray `app/generated/.gitkeep` in that app, being cleaned up separately).