### PR TITLE
fix(credentials): is_populated() requires a secret reference, not just a name

### DIFF
--- a/application_sdk/credentials/agent.py
+++ b/application_sdk/credentials/agent.py
@@ -149,7 +149,12 @@ async def resolve_agent_credential(
           substituted from it (the original v2 multi-key behavior).
         * Both empty: raw spec values are used as-is (no store
           lookup). Intended for dev/testing where ``agent_json``
-          carries literal credentials inline.
+          carries literal credentials inline. Only reachable via a
+          direct call to this function — the routed path never gets
+          here, because :meth:`AgentCredentialSpec.is_populated`
+          returns False without a fetch anchor (``secret-path`` or
+          ``key-type: single-key``) and routing falls through to
+          ``credential_guid`` instead.
     """
     raw = spec.to_raw_dict()
 

--- a/application_sdk/credentials/spec.py
+++ b/application_sdk/credentials/spec.py
@@ -165,5 +165,10 @@ class AgentCredentialSpec(BaseModel):
         return d
 
     def is_populated(self) -> bool:
-        """Return True if this spec carries a real agent payload."""
-        return bool(self.agent_name)
+        """True if this spec can resolve: a name plus a fetch anchor
+        (secret_path, or key_type "single-key"). Rejects the name-only AE
+        placeholder that would otherwise resolve to empty credentials.
+        """
+        return bool(self.agent_name) and (
+            bool(self.secret_path) or self.key_type == "single-key"
+        )

--- a/docs/concepts/handlers.md
+++ b/docs/concepts/handlers.md
@@ -104,6 +104,13 @@ It **must** be a `ClassVar`, not a pydantic field: declared as a field the gate
 reads `{}` and silently falls back to the single-credential path. Apps that
 declare nothing keep the unchanged single-credential path via `input.credentials`.
 
+An agent credential spec routes to agent resolution only when it is
+*populated*: `agent-name` plus a fetch anchor — `secret-path` (bundle fetch) or
+`key-type: single-key` (per-key fetch). A name-only spec (for example the
+Automation Engine placeholder `{"agent-name": "agent-name", ...}` stamped on
+non-agent runs) is not populated and falls through to `credential_guid`
+routing.
+
 #### Single-key secret resolution
 
 When a credential arrives as a flat dict of fields rather than a named ref, the

--- a/tests/unit/credentials/test_agent.py
+++ b/tests/unit/credentials/test_agent.py
@@ -196,6 +196,14 @@ class TestAgentCredentialSpec:
         )
         assert not spec.is_populated()
 
+    def test_multi_key_spec_without_secret_path_not_populated(self) -> None:
+        # Only single-key is a fetch anchor on its own; multi-key still
+        # needs secret_path to fetch the bundle from.
+        spec = AgentCredentialSpec.model_validate(
+            {"agent-name": "acme-prod-agent", "key-type": "multi-key"}
+        )
+        assert not spec.is_populated()
+
     def test_invalid_json_raises_parse_error(self) -> None:
         import pytest
 

--- a/tests/unit/credentials/test_agent.py
+++ b/tests/unit/credentials/test_agent.py
@@ -155,6 +155,47 @@ class TestAgentCredentialSpec:
         spec = AgentCredentialSpec.model_validate({})
         assert not spec.is_populated()
 
+    def test_ae_placeholder_agent_name_not_populated(self) -> None:
+        spec = AgentCredentialSpec.model_validate(
+            {
+                "agent-name": "agent-name",
+                "secret-manager": "",
+                "secret-path": "",
+                "auth-type": "",
+                "host": "",
+                "port": 0,
+            }
+        )
+        assert not spec.is_populated()
+
+    def test_agent_name_without_secret_ref_not_populated(self) -> None:
+        spec = AgentCredentialSpec.model_validate({"agent-name": "acme-prod-agent"})
+        assert not spec.is_populated()
+
+    def test_agent_spec_with_secret_ref_is_populated(self) -> None:
+        spec = AgentCredentialSpec.model_validate(
+            {"agent-name": "acme-prod-agent", "secret-path": "atlan/prod/acme"}
+        )
+        assert spec.is_populated()
+
+    def test_single_key_spec_without_secret_path_is_populated(self) -> None:
+        # single-key fetches per ref-key, so no secret_path is needed.
+        spec = AgentCredentialSpec.model_validate(
+            {
+                "agent-name": "acme-prod-agent",
+                "key-type": "single-key",
+                "basic.username": "SDR_MYSQL_USERNAME",
+            }
+        )
+        assert spec.is_populated()
+
+    def test_secret_manager_only_not_populated(self) -> None:
+        # secret_manager is not a fetch anchor.
+        spec = AgentCredentialSpec.model_validate(
+            {"agent-name": "acme-prod-agent", "secret-manager": "awssecretmanager"}
+        )
+        assert not spec.is_populated()
+
     def test_invalid_json_raises_parse_error(self) -> None:
         import pytest
 

--- a/tests/unit/credentials/test_ref.py
+++ b/tests/unit/credentials/test_ref.py
@@ -165,6 +165,29 @@ class TestCredentialRefResolve:
         assert ref.agent_spec is not None
         assert ref.credential_guid == ""
 
+    def test_resolve_ae_placeholder_spec_does_not_route_to_agent(self):
+        # Placeholder is not populated, so resolve won't route to agent (raises).
+        spec = AgentCredentialSpec.model_validate({"agent-name": "agent-name"})
+        inp = ExtractionInput(
+            extraction_method="agent",
+            agent_json=spec,
+            credential_guid="real-guid",
+        )
+        with pytest.raises(CredentialRoutingError):
+            CredentialRef.resolve(inp)
+
+    def test_resolve_or_none_ae_placeholder_falls_back_to_guid(self):
+        spec = AgentCredentialSpec.model_validate({"agent-name": "agent-name"})
+        inp = ExtractionInput(
+            extraction_method="agent",
+            agent_json=spec,
+            credential_guid="real-guid",
+        )
+        ref = CredentialRef.resolve_or_none(inp)
+        assert ref is not None
+        assert ref.credential_guid == "real-guid"
+        assert ref.agent_spec is None
+
     def test_resolve_direct_with_guid(self):
         inp = ExtractionInput(
             extraction_method="direct",


### PR DESCRIPTION
**Tracking:** CNCT-195

> **Draft — needs SDK-owner (Connectivity) review + e2e validation before merge.**

## TL;DR
The SDK treated a **hollow placeholder** `agent_json` as a real agent credential, which hijacked credential routing and produced empty credentials. This makes `is_populated()` require a **secret reference**, not just a name. It **fixes** a cross-connector auth failure and, by design, **does not break** real agent (SDR) runs.

## The issue
`AgentCredentialSpec.is_populated()` returned `bool(self.agent_name)`. The Automation Engine stamps a **name-only placeholder** — `{"agent-name": "agent-name", <every other field blank>}` — into the `agent-json` slot for **non-agent** runs. `"agent-name"` is non-empty, so the placeholder passed `is_populated()`.

`CredentialRef.resolve` / `resolve_or_none` (ref.py:143 / :275) and the SDR handler gate route the **agent branch** whenever `is_populated()` is true. So the placeholder:
1. routed to **agent** resolution (customer secret store) → nothing to fetch → a credential of **empty strings** (`authType=""`);
2. **shadowed** the connection's real `credential_guid` (direct-mode vault path);
3. surfaced as `SqlClientAuthFailedError` / `SqlCredentialsParseError` at the first source-touching activity.

Reproduced on a postgres connector: same connection + same placeholder, **SDK ≥3.19 worked** (`credential_ref: null` → real guid → 4,838 queries), **SDK ≥3.24 failed** (hollow agent ref). Extends the `is_populated()` gating added at the SDR call sites in #2877 (which didn't fix `is_populated()` itself).

## The change
```python
# before
return bool(self.agent_name)
# after
return bool(self.agent_name) and (
    bool(self.secret_path) or self.key_type == "single-key"
)
```
An agent spec can only resolve via a **fetch anchor** into the customer's secret store: `secret_path` (bundle fetch) or `key_type == "single-key"` (per-key fetch). `secret_manager` is *not* an anchor — it is a literal passthrough key, never used to fetch, so a manager-only spec still counts as not populated. No anchor → nothing to fetch → not a real agent spec → fall through to the `credential_guid` path. No magic-string match, so it is robust to whatever placeholder the platform emits.

## What it FIXES
| Scenario | Before | After |
|---|---|---|
| **Direct** connection carrying a placeholder `agent_json` | routes to agent → empty creds → **auth failure** | placeholder ignored → resolves real `credential_guid` → **works** |
| Same, at the **preflight gate** | placeholder "wins" over connection guid → gate soft-fails | falls through to connection `defaultCredentialGuid` → **gate passes** |
| Multiple connectors in the same situation | each hit the same failure | fixed at the shared layer for all at once |

Covers **crawler *and* miner** (and the preflight gate + SDR handler) — they all route through this one function.

## What it could BREAK (honest risk)
| Risk | Assessment |
|---|---|
| **Real SDR/agent runs** | **Not broken** — real specs carry a fetch anchor (`secret_path`, or `key-type: single-key` in the SDR/e2e harnesses), so they stay `populated`. Verified against the SDK fixtures and adopting connectors' PRs. |
| **Direct mode** (`credential_guid` → vault) | **Untouched** — never depended on `is_populated()`. |
| A name-only spec that used to count as populated | Reclassified to not-populated — but such a spec can't fetch a secret from anywhere, so it could never resolve a real credential. |
| **Verify before merge** | A downstream connector whose agent-spec **test fixture/helper** builds a name-only spec and asserts populated/agent-routing (e.g. a `_agent_spec()` default without `secret_path`) would see that **unit test** flip on SDK bump. Test-only, a sign of an unrealistic fixture — not a runtime break. This is the review-ask. |

**Net:** low runtime-break risk (only reclassifies specs that could never resolve), fixes a real cross-connector auth failure; the sole real check is downstream fixture compatibility.

## Tests
- Credentials + SDR suites green (330 passed), incl. placeholder / name-only / empty → not populated; secret-ref present → populated; `resolve` won't route a placeholder to agent; `resolve_or_none` falls back to the guid.
- **Not** e2e-tested yet (SDK + connector build on a tenant).

