### PR TITLE
ci(e2e): "unknown" is not a version, and say what the tenant did report

### DIFF
--- a/.github/scripts/e2e_tenant_app.py
+++ b/.github/scripts/e2e_tenant_app.py
@@ -144,6 +144,41 @@ _VERSION_KEYS = (
 #: envelope; the others are tolerated aliases.
 _VERSION_NESTS = ("installed", "install", "installation", "deployment", "data")
 
+#: Placeholders LM emits in place of a version. NOT versions, and treating them as
+#: one is worse than reading nothing: it turns "this tenant cannot tell us what it
+#: runs" into "this tenant runs something called 'unknown'", which reads like a
+#: mismatch and sends the next person looking for the wrong problem.
+#:
+#: ``unknown`` is a literal fallback in LM's own code — ``version_text =
+#: attributes.get("atlanAppCurrentVersion", "unknown")`` in
+#: ``tenant_apps_manager/store/tenant_app_store.py``, commented "Semantic version
+#: (if available)". The Atlas attribute is optional, so an install can reconcile
+#: perfectly and still report this. A live azure tenant did exactly that after a
+#: SUCCEEDED deployment.
+_PLACEHOLDER_VERSIONS = frozenset({"unknown", "none", "null", "n/a"})
+
+#: Fields worth seeing when the version is unreadable, and safe to print: app and
+#: version identifiers, not credentials or config blobs. ``catalog.app_version``
+#: is a ``MarketplaceAppVersion`` (``catalog_service/models/service.py``) carrying
+#: ``version_id`` / ``version`` / ``image_url``; ``installed`` is an
+#: ``InstalledApp`` carrying ``version_id`` / ``version_text``. Between them they
+#: should be enough to say what the tenant is actually running.
+_INFO_DIAGNOSTIC_FIELDS = (
+    "app_id",
+    "app_name",
+    "version_id",
+    "version",
+    "version_text",
+    "image_url",
+    "release_id",
+    "internal_id",
+    "installed_at",
+    "last_modified_on",
+    "deployment_name",
+    "target_channel",
+    "published_at",
+)
+
 #: LM's failure-snapshot fields (``deployment_orchestrator/failure_snapshot.py``),
 #: in the order they answer "why did this deployment not become ready", with a
 #: per-section line budget and which end to keep when it bites.
@@ -167,6 +202,7 @@ _FAILURE_SECTIONS: tuple[tuple[str, int, str], ...] = (
 
 _EVENTS_MAX_LINES = 200
 _OTHER_FIELDS_MAX_LINES = 80
+_INFO_DIAGNOSTIC_MAX_LINES = 40
 
 #: Registry and kubelet phrasings for "this image has no variant for my
 #: architecture", matched case-insensitively across everything printed above.
@@ -336,7 +372,21 @@ def _installed_version(client: TenantClient, app_id: str) -> str:
             "treating as not installed"
         )
         return ""
-    return _extract_version(response.data())
+    data = response.data()
+    version = _extract_version(data)
+    if not version:
+        # Readable payload, unreadable version: either nothing is installed, or
+        # LM has an install record whose version field is a placeholder. Those
+        # need different responses, and only the payload can tell them apart —
+        # so print what it actually contains rather than leaving the caller to
+        # infer from an empty string.
+        _print_block(
+            "app info (no version could be read)",
+            "\n".join(describe_info(data)) or "<no identifying fields present>",
+            _INFO_DIAGNOSTIC_MAX_LINES,
+            "head",
+        )
+    return version
 
 
 def _app_info(client: TenantClient, app_id: str) -> dict[str, object]:
@@ -502,9 +552,37 @@ def _extract_version(payload: dict[str, object], _depth: int = 0) -> str:
                 return found
     for key in _VERSION_KEYS:
         value = payload.get(key)
-        if isinstance(value, str) and value.strip():
-            return value.strip()
+        if not isinstance(value, str):
+            continue
+        found = value.strip()
+        # A placeholder is not a version. Returning it would satisfy "we read
+        # something" and then fail the comparison as if the tenant ran a version
+        # called "unknown" — see _PLACEHOLDER_VERSIONS.
+        if found and found.lower() not in _PLACEHOLDER_VERSIONS:
+            return found
     return ""
+
+
+def describe_info(payload: dict[str, object], _depth: int = 0) -> list[str]:
+    """Return ``path = value`` lines for the identifying fields in an info payload.
+
+    Printed when the version cannot be read, so the next step is decided from what
+    the tenant actually returned rather than from a guess about its shape. Scoped
+    to :data:`_INFO_DIAGNOSTIC_FIELDS` rather than dumping the payload: ``config``
+    and ``app_configs`` are whole YAML/JSON documents, and burying six useful
+    identifiers in them is how the last diagnostic gap happened.
+    """
+    if _depth >= _WALK_MAX_DEPTH:
+        return []
+    lines: list[str] = []
+    for key, value in payload.items():
+        if isinstance(value, dict):
+            lines.extend(
+                f"{key}.{nested}" for nested in describe_info(value, _depth + 1)
+            )
+        elif key in _INFO_DIAGNOSTIC_FIELDS and value not in (None, ""):
+            lines.append(f"{key} = {value!r}")
+    return lines
 
 
 #: Cap on rendered response bodies in error messages. The token-mint path
@@ -1213,12 +1291,27 @@ def verify(args: argparse.Namespace) -> str:
     _, read_client = _clients(base_url)
     installed = _installed_version(read_client, app_id)
     if installed != args.expected:
+        # Two different situations, and the message has to distinguish them or
+        # the reader chases the wrong one. An empty read means the tenant could
+        # not tell us what it runs — which is NOT the same as running the wrong
+        # thing, and LM reports it for a perfectly reconciled install whenever
+        # Atlas has no `atlanAppCurrentVersion` attribute (see
+        # _PLACEHOLDER_VERSIONS). The shape dump above says which.
+        cause = (
+            "the tenant did not report a version at all — see the info dump "
+            "above. LM falls back to a placeholder when Atlas carries no "
+            "`atlanAppCurrentVersion` attribute, so this can happen after a "
+            "deployment that reconciled fine; it means the version is "
+            "unverifiable here, not that the wrong one is installed."
+            if not installed
+            else "A concurrent e2e run against this tenant, or a manual deploy, "
+            "is the usual cause."
+        )
         raise TenantAppError(
             f"tenant is running {installed or '<nothing / unreported>'} for app "
             f"{app_id}, but this leg tests {args.expected}. Heracles fetches "
             "the DAG from the deployed pod at AE submit, so continuing would "
-            "test a different version than the one under test. A concurrent e2e "
-            "run against this tenant, or a manual deploy, is the usual cause."
+            f"test a different version than the one under test. {cause}"
         )
     print(f"verified: tenant runs {installed}")
     return installed

--- a/.github/scripts/tests/test_e2e_tenant_app.py
+++ b/.github/scripts/tests/test_e2e_tenant_app.py
@@ -1630,3 +1630,136 @@ def test_a_timeout_is_never_downgraded(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_deployment_failed_is_a_tenant_app_error() -> None:
     # Callers catching TenantAppError (main(), the workflows) must keep working.
     assert issubclass(app.DeploymentFailed, app.TenantAppError)
+
+
+# ── "unknown" is not a version ───────────────────────────────────────────────
+# LM's own code: `version_text = attributes.get("atlanAppCurrentVersion",
+# "unknown")` (tenant_apps_manager/store/tenant_app_store.py), commented
+# "Semantic version (if available)". The Atlas attribute is optional, so a
+# perfectly reconciled install can still report the placeholder — a live azure
+# tenant did exactly that after a SUCCEEDED deployment.
+
+
+@pytest.mark.parametrize("placeholder", ["unknown", "UNKNOWN", " unknown ", "n/a"])
+def test_a_placeholder_reads_as_no_version(placeholder: str) -> None:
+    payload = {"installed": {"version_text": placeholder}}
+    assert app._extract_version(payload) == "", (
+        "a placeholder must read as absent. Returning it turns 'the tenant "
+        "cannot tell us what it runs' into 'the tenant runs something called "
+        "unknown', which reads like a mismatch and hides the real problem"
+    )
+
+
+def test_a_real_version_alongside_a_placeholder_still_wins() -> None:
+    # Order matters: version_text is checked first and is the placeholder here.
+    payload = {"installed": {"version_text": "unknown", "version": _VERSION}}
+    assert app._extract_version(payload) == _VERSION
+
+
+def test_the_info_shape_is_dumped_when_no_version_can_be_read(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The whole point: decide the next step from the payload, not a guess."""
+    _wire(
+        monkeypatch,
+        StubTransport(
+            routes=[
+                StubRoute(
+                    "GET",
+                    "/info",
+                    _ok(
+                        {
+                            "app_id": _APP_ID,
+                            "catalog": {
+                                "app_name": "openapi",
+                                "app_version": {
+                                    "version_id": "019fdc06-dbe3-7992",
+                                    "version": _VERSION,
+                                    "image_url": _IMAGE,
+                                    "config": "a: 1\nb: 2\n",
+                                },
+                            },
+                            "installed": {
+                                "version_id": "019fdc06-dbe3-7992",
+                                "version_text": "unknown",
+                                "deployment_name": "production",
+                            },
+                        }
+                    ),
+                )
+            ]
+        ),
+    )
+    assert (
+        app._installed_version(TenantClient(base_url=_TENANT, bearer="t"), _APP_ID)
+        == ""
+    )
+    out = capsys.readouterr().out
+    assert "app info (no version could be read)" in out
+    # The identifiers that would let us resolve the version.
+    assert "installed.version_id = '019fdc06-dbe3-7992'" in out
+    assert f"catalog.app_version.version = '{_VERSION}'" in out
+    assert f"catalog.app_version.image_url = '{_IMAGE}'" in out
+    # NOT the config blob: burying the identifiers is how the last diagnostic
+    # gap happened.
+    assert "a: 1" not in out
+
+
+def test_no_dump_when_the_version_reads_fine(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _wire(
+        monkeypatch,
+        StubTransport(
+            routes=[
+                StubRoute(
+                    "GET", "/info", _ok({"installed": {"version_text": _VERSION}})
+                )
+            ]
+        ),
+    )
+    app._installed_version(TenantClient(base_url=_TENANT, bearer="t"), _APP_ID)
+    assert "no version could be read" not in capsys.readouterr().out
+
+
+def test_verify_distinguishes_unreadable_from_wrong(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unverifiable tenant and a wrong-version tenant need different hunts."""
+    _wire(
+        monkeypatch,
+        StubTransport(
+            routes=[
+                StubRoute(
+                    "GET", "/info", _ok({"installed": {"version_text": "unknown"}})
+                )
+            ]
+        ),
+    )
+    with pytest.raises(app.TenantAppError) as excinfo:
+        app.verify(
+            argparse.Namespace(base_url=_TENANT, app_id=_APP_ID, expected=_VERSION)
+        )
+    message = str(excinfo.value)
+    assert "did not report a version at all" in message
+    assert "concurrent e2e run" not in message, (
+        "the concurrent-run hint is for a genuine mismatch; offering it here "
+        "sends the reader after a race that did not happen"
+    )
+
+
+def test_verify_still_names_the_race_on_a_real_mismatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _wire(
+        monkeypatch,
+        StubTransport(
+            routes=[
+                StubRoute("GET", "/info", _ok({"installed": {"version_text": "older"}}))
+            ]
+        ),
+    )
+    with pytest.raises(app.TenantAppError, match="concurrent e2e run"):
+        app.verify(
+            argparse.Namespace(base_url=_TENANT, app_id=_APP_ID, expected=_VERSION)
+        )


### PR DESCRIPTION
Step 1 of 2 for the version read-back. **Diagnostic only** — the resolution follows once a live run shows what the payload actually holds.

## What happened

The first fully successful install (multi-arch build → merge → publish → install → `SUCCEEDED`) still red the e2e legs, at the per-leg version check:

```
tenant reports installed version: unknown
##[error] Verify the tenant runs the version under test
```

`unknown` is a literal fallback in LM's own code:

```python
version_text = attributes.get("atlanAppCurrentVersion", "unknown")   # "Semantic version (if available)"
version_uuid_raw = attributes.get("atlanAppCurrentVersionUUID")      # Version UUID
```
— `tenant_apps_manager/store/tenant_app_store.py`

The Atlas attribute is optional, so **the field this verification was built on is not a reliable identity signal**. That is my design mistake, not a tenant problem: an install can reconcile perfectly and still report a placeholder, and `sdr-test-<sha>` tags are not semantic versions, which is a plausible reason Atlas never carries one.

## What this changes

**1. Placeholders read as absent.** `unknown` is not a version, and returning it is worse than returning nothing — it turns *"this tenant cannot tell us what it runs"* into *"this tenant runs something called unknown"*, which reads like a mismatch and sends the reader after a drift that never happened.

**2. When no version can be read, print the identifying fields the payload does carry.** Scoped to app/version identifiers rather than dumping the response: `config` and `app_configs` are whole YAML/JSON documents, and burying six useful identifiers inside them is exactly how the last diagnostic gap happened.

LM's models say what to expect — `catalog.app_version` is a `MarketplaceAppVersion` (`version_id` / `version` / `image_url`), `installed` is an `InstalledApp` (`version_id` / `version_text`). So the dump should show whether `installed.version_id` can be resolved through the catalog to a real version string. **That is the intended fix, and this run is how I find out whether the shape supports it instead of assuming it does.**

`verify`'s error now distinguishes the two cases — an unreadable version and a wrong version need different investigations, and the old message offered the concurrent-run hint for both.

## Verification

5 mutations verified red: a placeholder accepted as a version, the diagnostic never printed, the diagnostic dumping config blobs too, nested fields not walked, and `verify` no longer distinguishing unreadable from wrong.

1318 script tests pass; `pre-commit --all-files` clean.

## Deliberately not fixed here

`prepare-tenant` passes while reporting no version, because it never compares. That is wrong, and it belongs with the resolution rather than bundled into a diagnostic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)