### PR TITLE
ci(e2e): resolve the installed version by UUID through the catalog

### DIFF
--- a/.github/scripts/e2e_tenant_app.py
+++ b/.github/scripts/e2e_tenant_app.py
@@ -602,7 +602,8 @@ def resolve_version_via_catalog(payload: dict[str, object]) -> str:
     if not version or version.lower() in _PLACEHOLDER_VERSIONS:
         return ""
     print(
-        f"::notice::tenant reports version_text='{installed.get('version_text')}', "
+        "::notice::tenant reports version_text="
+        f"{json.dumps(str(installed.get('version_text')))}, "
         f"resolved to '{version}' via catalog version_id={installed_id}. LM only "
         "populates version_text from an optional Atlas attribute; the UUID is the "
         "reliable identifier."
@@ -1184,7 +1185,10 @@ def install(args: argparse.Namespace) -> InstallOutcome:
     info = _app_info(read_client, app_id)
     if not info:
         print(f"::notice::app info unreadable for {app_id} — treating as not installed")
-    current = _extract_version(info)
+    # Resolve through the same catalog fallback the post-install read-back and
+    # verify() use, or a re-run against a placeholder-version tenant re-installs
+    # instead of taking the no-op path.
+    current = _extract_version(info) or resolve_version_via_catalog(info)
     if current and current == args.version:
         print(f"tenant already runs {app_id} at {args.version} — nothing to do")
         return InstallOutcome(

--- a/.github/scripts/e2e_tenant_app.py
+++ b/.github/scripts/e2e_tenant_app.py
@@ -373,7 +373,7 @@ def _installed_version(client: TenantClient, app_id: str) -> str:
         )
         return ""
     data = response.data()
-    version = _extract_version(data)
+    version = _extract_version(data) or resolve_version_via_catalog(data)
     if not version:
         # Readable payload, unreadable version: either nothing is installed, or
         # LM has an install record whose version field is a placeholder. Those
@@ -561,6 +561,53 @@ def _extract_version(payload: dict[str, object], _depth: int = 0) -> str:
         if found and found.lower() not in _PLACEHOLDER_VERSIONS:
             return found
     return ""
+
+
+def resolve_version_via_catalog(payload: dict[str, object]) -> str:
+    """Return the installed version string, resolved through the catalog by UUID.
+
+    LM's ``version_text`` is optional (see :data:`_PLACEHOLDER_VERSIONS`), but the
+    UUID beside it is not, and the same payload carries the catalog entry that
+    names it. From a live azure tenant whose ``version_text`` was ``unknown``::
+
+        catalog.app_version.version_id = '019fdc06-dbe3-7992-93a0-1791575164b3'
+        catalog.app_version.version    = 'sdr-test-1024d47f'
+        installed.version_id           = '019fdc06-dbe3-7992-93a0-1791575164b3'
+
+    Matching UUIDs make this exact identity rather than inference: the catalog
+    says which version that UUID *is*, and the install record says that UUID is
+    what is installed.
+
+    **Only when they match.** ``/apps/{id}/info`` calls ``get_app_info(app_id)``
+    with no version argument, so ``catalog`` describes the LATEST version, which
+    is not necessarily the installed one. Reading its string whenever
+    ``version_text`` is missing would report the newest version as installed —
+    a silent wrong-version pass, which is the single failure FND-31 exists to
+    prevent. A mismatch returns "" so the caller fails as unverifiable.
+    """
+    installed = payload.get("installed")
+    catalog = payload.get("catalog")
+    if not isinstance(installed, dict) or not isinstance(catalog, dict):
+        return ""
+    app_version = catalog.get("app_version")
+    if not isinstance(app_version, dict):
+        return ""
+
+    installed_id = str(installed.get("version_id") or "").strip()
+    catalog_id = str(app_version.get("version_id") or "").strip()
+    if not installed_id or installed_id != catalog_id:
+        return ""
+
+    version = str(app_version.get("version") or "").strip()
+    if not version or version.lower() in _PLACEHOLDER_VERSIONS:
+        return ""
+    print(
+        f"::notice::tenant reports version_text='{installed.get('version_text')}', "
+        f"resolved to '{version}' via catalog version_id={installed_id}. LM only "
+        "populates version_text from an optional Atlas attribute; the UUID is the "
+        "reliable identifier."
+    )
+    return version
 
 
 def describe_info(payload: dict[str, object], _depth: int = 0) -> list[str]:
@@ -1258,14 +1305,35 @@ def install(args: argparse.Namespace) -> InstallOutcome:
 
     installed = _installed_version(read_client, app_id)
     print(f"tenant reports installed version: {installed or '<unreported>'}")
-    if foreign and installed != args.version:
+    # Unconditional, not just on the foreign-pod path. This job exists to leave
+    # the tenant serving the version under test, so it has to confirm that before
+    # reporting success — otherwise every e2e leg rediscovers the same problem
+    # separately, which is exactly what happened when the read-back returned a
+    # placeholder: prepare-tenant went green and both legs then failed on their
+    # own version check. One clear failure here beats N confusing ones after.
+    if installed != args.version:
+        orphans = (
+            " The failing pod(s) want "
+            f"{', '.join(foreign)} — orphans from an earlier version, worth "
+            "deleting from the tenant's namespace either way, though with the "
+            "read-back disagreeing they are not the whole story."
+            if foreign
+            else ""
+        )
+        unverifiable = (
+            " The tenant reported no usable version: see the info dump above. "
+            "That is not the same as running the wrong one — LM's version_text "
+            "is an optional Atlas attribute, and the UUID fallback could not be "
+            "resolved through the catalog either."
+            if not installed
+            else ""
+        )
         raise TenantAppError(
-            f"deployment reported FAILED and the tenant reports "
-            f"{installed or '<unreported>'} rather than {args.version}, so the "
-            "install did not take effect. The failing pod(s) want "
-            f"{', '.join(foreign)} — orphans from an earlier version, which are "
-            "worth deleting from the tenant's namespace either way — but with the "
-            "read-back disagreeing they are not the whole story here."
+            f"the tenant reports {installed or '<unreported>'} rather than "
+            f"{args.version}, so this install cannot be confirmed. Heracles "
+            "fetches the DAG from the deployed pod at AE submit, so letting the "
+            "legs run now would test an unverified version."
+            f"{unverifiable}{orphans}"
         )
     if foreign:
         print(

--- a/.github/scripts/tests/test_e2e_tenant_app.py
+++ b/.github/scripts/tests/test_e2e_tenant_app.py
@@ -1597,7 +1597,7 @@ def test_an_orphan_failure_still_fails_when_the_readback_disagrees(
             sticky=[StubRoute("GET", "/releases/", Response(404, {}))],
         ),
     )
-    with pytest.raises(app.TenantAppError, match="did not take effect"):
+    with pytest.raises(app.TenantAppError, match="cannot be confirmed"):
         app.install(_install_args())
 
 
@@ -1656,6 +1656,96 @@ def test_a_real_version_alongside_a_placeholder_still_wins() -> None:
     assert app._extract_version(payload) == _VERSION
 
 
+# ── Resolving the version through the catalog ────────────────────────────────
+# Taken from a live azure tenant whose version_text was the placeholder:
+#
+#   catalog.app_version.version_id = '019fdc06-dbe3-7992-93a0-1791575164b3'
+#   catalog.app_version.version    = 'sdr-test-1024d47f'
+#   installed.version_id           = '019fdc06-dbe3-7992-93a0-1791575164b3'
+#
+# Matching UUIDs make this exact identity. A MISMATCH must never resolve: /info
+# describes the LATEST catalog version, so reading its string regardless would
+# report the newest version as installed — the silent wrong-version pass FND-31
+# exists to prevent.
+
+_UUID = "019fdc06-dbe3-7992-93a0-1791575164b3"
+
+
+def _info(installed_id: str, version: str = _VERSION, text: str = "unknown") -> dict:  # type: ignore[type-arg]
+    return {
+        "catalog": {"app_version": {"version_id": _UUID, "version": version}},
+        "installed": {"version_id": installed_id, "version_text": text},
+    }
+
+
+def test_a_matching_uuid_resolves_the_real_version() -> None:
+    assert app.resolve_version_via_catalog(_info(_UUID)) == _VERSION
+
+
+def test_a_mismatched_uuid_never_resolves() -> None:
+    assert app.resolve_version_via_catalog(_info("some-other-uuid")) == "", (
+        "the catalog describes the LATEST version, not necessarily the installed "
+        "one. Resolving on a mismatch would report the newest version as "
+        "installed — a silent wrong-version pass."
+    )
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"installed": {"version_id": _UUID}},  # no catalog
+        {
+            "catalog": {"app_version": {"version_id": _UUID, "version": "v"}}
+        },  # no installed
+        {"catalog": {"app_version": "not-a-dict"}, "installed": {"version_id": _UUID}},
+        {
+            "catalog": {"app_version": {"version": "v"}},
+            "installed": {"version_id": _UUID},
+        },
+    ],
+)
+def test_an_incomplete_payload_never_resolves(payload: dict) -> None:  # type: ignore[type-arg]
+    assert app.resolve_version_via_catalog(payload) == ""
+
+
+def test_an_absent_installed_uuid_never_resolves() -> None:
+    # Both sides empty would otherwise compare equal and resolve on nothing.
+    assert app.resolve_version_via_catalog(_info("")) == ""
+    assert (
+        app.resolve_version_via_catalog(
+            {
+                "catalog": {"app_version": {"version_id": "", "version": "v"}},
+                "installed": {"version_id": ""},
+            }
+        )
+        == ""
+    )
+
+
+def test_a_placeholder_in_the_catalog_does_not_resolve() -> None:
+    assert app.resolve_version_via_catalog(_info(_UUID, version="unknown")) == ""
+
+
+def test_the_readback_uses_the_catalog_when_version_text_is_a_placeholder(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """End to end: the exact shape the live tenant returned."""
+    _wire(
+        monkeypatch,
+        StubTransport(routes=[StubRoute("GET", "/info", _ok(_info(_UUID)))]),
+    )
+    resolved = app._installed_version(
+        TenantClient(base_url=_TENANT, bearer="t"), _APP_ID
+    )
+    assert resolved == _VERSION
+    out = capsys.readouterr().out
+    assert "resolved to" in out and "version_id" in out, (
+        "resolving via a fallback must say so — a reader comparing this against "
+        "the tenant UI should know which field the answer came from"
+    )
+    assert "no version could be read" not in out
+
+
 def test_the_info_shape_is_dumped_when_no_version_can_be_read(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
@@ -1679,8 +1769,12 @@ def test_the_info_shape_is_dumped_when_no_version_can_be_read(
                                     "config": "a: 1\nb: 2\n",
                                 },
                             },
+                            # A DIFFERENT UUID, so the catalog cannot resolve it
+                            # — the catalog only ever describes the latest
+                            # version. This is the unresolvable case, which is
+                            # exactly when the dump has to appear.
                             "installed": {
-                                "version_id": "019fdc06-dbe3-7992",
+                                "version_id": "a-different-uuid",
                                 "version_text": "unknown",
                                 "deployment_name": "production",
                             },
@@ -1696,8 +1790,8 @@ def test_the_info_shape_is_dumped_when_no_version_can_be_read(
     )
     out = capsys.readouterr().out
     assert "app info (no version could be read)" in out
-    # The identifiers that would let us resolve the version.
-    assert "installed.version_id = '019fdc06-dbe3-7992'" in out
+    # The identifiers a reader needs to work out what the tenant runs.
+    assert "installed.version_id = 'a-different-uuid'" in out
     assert f"catalog.app_version.version = '{_VERSION}'" in out
     assert f"catalog.app_version.image_url = '{_IMAGE}'" in out
     # NOT the config blob: burying the identifiers is how the last diagnostic
@@ -1746,6 +1840,62 @@ def test_verify_distinguishes_unreadable_from_wrong(
         "the concurrent-run hint is for a genuine mismatch; offering it here "
         "sends the reader after a race that did not happen"
     )
+
+
+def test_install_fails_when_it_cannot_confirm_the_version(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """prepare-tenant must fail here rather than leave it to every leg.
+
+    It went green while reporting a placeholder, and both e2e legs then failed on
+    their own version check — N confusing failures instead of one clear one. This
+    job's whole purpose is leaving the tenant on the version under test, so it has
+    to confirm that before reporting success.
+    """
+    _wire(
+        monkeypatch,
+        StubTransport(
+            routes=[
+                StubRoute("GET", "/info", Response(404, {})),
+                StubRoute("POST", "/marketplace/publish", _ok({"version_id": "v1"})),
+                StubRoute("POST", "/install", _ok({"deployment_id": "d1"})),
+                StubRoute(
+                    "GET", "/deployments/", _ok({"deployment_status": "SUCCEEDED"})
+                ),
+                # Reconciled fine, but reports a placeholder no catalog can resolve.
+                StubRoute("GET", "/info", _ok(_info("a-different-uuid"))),
+            ],
+            sticky=[StubRoute("GET", "/releases/", Response(404, {}))],
+        ),
+    )
+    with pytest.raises(app.TenantAppError) as excinfo:
+        app.install(_install_args())
+    message = str(excinfo.value)
+    assert "cannot be confirmed" in message
+    assert (
+        "no usable version" in message
+    ), "an unverifiable tenant and a wrong-version tenant need different hunts"
+
+
+def test_install_succeeds_when_the_catalog_resolves_the_version(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _wire(
+        monkeypatch,
+        StubTransport(
+            routes=[
+                StubRoute("GET", "/info", Response(404, {})),
+                StubRoute("POST", "/marketplace/publish", _ok({"version_id": "v1"})),
+                StubRoute("POST", "/install", _ok({"deployment_id": "d1"})),
+                StubRoute(
+                    "GET", "/deployments/", _ok({"deployment_status": "SUCCEEDED"})
+                ),
+                StubRoute("GET", "/info", _ok(_info(_UUID))),
+            ],
+            sticky=[StubRoute("GET", "/releases/", Response(404, {}))],
+        ),
+    )
+    assert app.install(_install_args()).installed_version == _VERSION
 
 
 def test_verify_still_names_the_race_on_a_real_mismatch(


### PR DESCRIPTION
Step 2 of 2. The diagnostic from #3062 answered the question on a live Azure tenant ([run 31180224111](https://github.com/atlanhq/atlan-openapi-app/actions/runs/31180224111)), and the hypothesis held:

```
catalog.app_version.version_id = "019fdc06-dbe3-7992-93a0-1791575164b3"
catalog.app_version.version    = "sdr-test-1024d47f"        <- the real string
catalog.app_version.image_url  = "...:sdr-test-1024d47f"
installed.version_id           = "019fdc06-dbe3-7992-93a0-1791575164b3"   <- same UUID
installed.version_text         = "unknown"
installed.deployment_name      = "atlan"
```

The UUIDs match, and the same payload already carries the real version string. So the resolution needs **no new input and no extra call**: when `version_text` is a placeholder, look up `installed.version_id` in the catalog and take that version’s string. Matching UUIDs make this exact identity rather than inference — the catalog says which version that UUID *is*, the install record says that UUID is what is installed.

## Only when they match

`/apps/{id}/info` calls `get_app_info(app_id)` with **no version argument**, so `catalog` describes the **latest** version, which is not necessarily the installed one. Reading its string whenever `version_text` is missing would report the newest version as installed — the silent wrong-version pass this whole change exists to prevent. A mismatch resolves to nothing and the caller fails as unverifiable.

That is the first mutation in the list below, and the one that matters.

## Bonus: why the tenant cannot report a version

`deployment_name = "atlan"` is LM’s *"default if typedef not deployed"* fallback, so the Atlas typedef carrying `atlanAppCurrentVersion` is absent on that tenant. Not something we can fix from here — and now not something we need to.

## The gap #3062 left open on purpose

`install()` now **requires** the read-back to match before reporting success, not only on the orphaned-pod path. It went green while reporting a placeholder and both e2e legs then failed on their own version checks — N confusing failures instead of one clear one, in the job whose entire purpose is leaving the tenant on the version under test.

The error distinguishes *"could not verify"* from *"wrong version"*. They need different investigations, and conflating them is what sent me looking for a concurrent-run race that had not happened.

## Verification

7 mutations verified red, including: resolving on a UUID mismatch, resolving when the installed UUID is absent (both sides empty compare equal), a catalog placeholder resolving, the resolution not being wired into the read-back, and `install()` no longer confirming at all.

1329 script tests pass; `pre-commit --all-files` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)