### PR TITLE
fix(conformance): only re-run e2e when the e2e label is the one just added

### DIFF
--- a/.github/scripts/tests/_gha_expr.py
+++ b/.github/scripts/tests/_gha_expr.py
@@ -1,0 +1,433 @@
+"""A GitHub Actions expression evaluator, for testing workflow `if:` gates.
+
+Job gates are conditional logic. `docs/standards/ci.md` says conditional logic
+must be testable, and for a *shell* branch the answer is "move it into a Python
+script". A job-level `if:` cannot move — GitHub evaluates it before any step
+runs — so the only way to regression-test one is to evaluate the real expression,
+lifted verbatim out of the workflow YAML, against synthetic event payloads.
+
+That is what this module is for. It is deliberately NOT a general GHA
+implementation: it covers the operators and functions the repo's gates actually
+use, and raises :class:`UnsupportedExpression` on anything else. Refusing loudly
+is the whole safety property — a partial evaluator that silently treated an
+unknown construct as null would let a broken gate pass its own test, which is
+worse than having no test.
+
+Modelled on the documented semantics in
+https://docs.github.com/actions/reference/workflows-and-actions/expressions —
+the fiddly parts being that `&&`/`||` return an *operand* rather than a boolean,
+that `==` on two strings is case-insensitive, and that mismatched types are cast
+to numbers (with NaN comparing false against everything, itself included).
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from typing import Any, Callable, Iterable, Sequence
+
+__all__ = [
+    "UnknownContext",
+    "UnsupportedExpression",
+    "evaluate",
+    "truthy",
+]
+
+
+class UnsupportedExpression(Exception):
+    """The expression uses syntax or a function this evaluator does not model."""
+
+
+class UnknownContext(Exception):
+    """The expression reads a context root the caller did not supply.
+
+    Raised rather than resolved to null so a test cannot pass vacuously: if a
+    gate starts consulting ``needs`` or ``vars``, every scenario must say what
+    that context holds instead of silently inheriting "absent, therefore false".
+    """
+
+
+# ── Lexer ────────────────────────────────────────────────────────────────────
+
+# Order matters: two-character operators must be tried before their prefixes,
+# or `!=` lexes as `!` followed by a stray `=`.
+_TOKEN_RE = re.compile(
+    r"""
+    (?P<space>\s+)
+  | (?P<string>'(?:[^']|'')*')
+  | (?P<number>0[xX][0-9a-fA-F]+|[0-9]+(?:\.[0-9]+)?(?:[eE][-+]?[0-9]+)?)
+  | (?P<op>==|!=|<=|>=|&&|\|\||[<>!])
+  | (?P<punct>[().,\[\]*])
+    # Context keys may contain '-' (`inputs.enable-e2e`). Safe because GitHub
+    # expressions have no arithmetic operators, so '-' is never infix.
+  | (?P<ident>[A-Za-z_][A-Za-z0-9_-]*)
+    """,
+    re.VERBOSE,
+)
+
+
+def _lex(source: str) -> list[tuple[str, str]]:
+    tokens: list[tuple[str, str]] = []
+    position = 0
+    while position < len(source):
+        match = _TOKEN_RE.match(source, position)
+        if match is None:
+            raise UnsupportedExpression(
+                f"cannot lex {source[position:position + 20]!r} at offset {position}"
+            )
+        position = match.end()
+        kind = match.lastgroup
+        assert kind is not None
+        if kind == "space":
+            continue
+        tokens.append((kind, match.group()))
+    return tokens
+
+
+# ── Parser (recursive descent, GHA precedence) ───────────────────────────────
+#
+# Lowest to highest: || < && < ==/!= < </<=/>/>= < ! < postfix (.x, .*, [i]).
+# Nodes are plain tuples so the evaluator below is a flat dispatch.
+
+_Node = tuple[Any, ...]
+
+
+class _Parser:
+    def __init__(self, tokens: Sequence[tuple[str, str]], source: str) -> None:
+        self._tokens = tokens
+        self._source = source
+        self._index = 0
+
+    # -- token helpers --
+
+    def _peek(self) -> tuple[str, str] | None:
+        return self._tokens[self._index] if self._index < len(self._tokens) else None
+
+    def _take(self) -> tuple[str, str]:
+        token = self._peek()
+        if token is None:
+            raise UnsupportedExpression(
+                f"unexpected end of expression: {self._source!r}"
+            )
+        self._index += 1
+        return token
+
+    def _accept(self, value: str) -> bool:
+        token = self._peek()
+        if token is not None and token[1] == value:
+            self._index += 1
+            return True
+        return False
+
+    def _expect(self, value: str) -> None:
+        if not self._accept(value):
+            raise UnsupportedExpression(
+                f"expected {value!r} at token {self._index} of {self._source!r}"
+            )
+
+    # -- grammar --
+
+    def parse(self) -> _Node:
+        node = self._or()
+        if self._peek() is not None:
+            raise UnsupportedExpression(
+                f"trailing tokens after a complete expression in {self._source!r}"
+            )
+        return node
+
+    def _or(self) -> _Node:
+        node = self._and()
+        while self._accept("||"):
+            node = ("or", node, self._and())
+        return node
+
+    def _and(self) -> _Node:
+        node = self._equality()
+        while self._accept("&&"):
+            node = ("and", node, self._equality())
+        return node
+
+    def _equality(self) -> _Node:
+        node = self._comparison()
+        while True:
+            token = self._peek()
+            if token is None or token[1] not in ("==", "!="):
+                return node
+            self._index += 1
+            node = (token[1], node, self._comparison())
+
+    def _comparison(self) -> _Node:
+        node = self._unary()
+        while True:
+            token = self._peek()
+            if token is None or token[1] not in ("<", "<=", ">", ">="):
+                return node
+            self._index += 1
+            node = (token[1], node, self._unary())
+
+    def _unary(self) -> _Node:
+        if self._accept("!"):
+            return ("not", self._unary())
+        return self._postfix()
+
+    def _postfix(self) -> _Node:
+        node = self._primary()
+        while True:
+            if self._accept("."):
+                kind, text = self._take()
+                if text == "*":
+                    node = ("star", node)
+                elif kind == "ident":
+                    node = ("prop", node, text)
+                else:
+                    raise UnsupportedExpression(
+                        f"expected a property name after '.' in {self._source!r}"
+                    )
+            elif self._accept("["):
+                index = self._or()
+                self._expect("]")
+                node = ("index", node, index)
+            else:
+                return node
+
+    def _primary(self) -> _Node:
+        kind, text = self._take()
+        if text == "(":
+            node = self._or()
+            self._expect(")")
+            return node
+        if kind == "string":
+            # GHA escapes a single quote by doubling it.
+            return ("lit", text[1:-1].replace("''", "'"))
+        if kind == "number":
+            if text.lower().startswith("0x"):
+                return ("lit", float(int(text, 16)))
+            return ("lit", float(text))
+        if kind == "ident":
+            lowered = text.lower()
+            if lowered == "true":
+                return ("lit", True)
+            if lowered == "false":
+                return ("lit", False)
+            if lowered == "null":
+                return ("lit", None)
+            if self._accept("("):
+                arguments: list[_Node] = []
+                if not self._accept(")"):
+                    arguments.append(self._or())
+                    while self._accept(","):
+                        arguments.append(self._or())
+                    self._expect(")")
+                return ("call", text, tuple(arguments))
+            return ("context", text)
+        raise UnsupportedExpression(f"unexpected token {text!r} in {self._source!r}")
+
+
+# ── Value semantics ──────────────────────────────────────────────────────────
+
+_NAN = float("nan")
+
+
+def truthy(value: Any) -> bool:
+    """GHA's cast-to-boolean: only null, false, 0, NaN and '' are falsy.
+
+    Note what is *not* falsy: an empty array, an empty object, and the strings
+    ``'0'`` and ``'false'``. That last one is the classic workflow footgun — a
+    `workflow_dispatch` input arrives as a string, so a bare `if: inputs.flag`
+    is true even when the flag reads "false".
+    """
+    if value is None or value is False:
+        return False
+    if value is True:
+        return True
+    if isinstance(value, (int, float)):
+        return value != 0 and not math.isnan(value)
+    if isinstance(value, str):
+        return value != ""
+    return True
+
+
+def _number(value: Any) -> float:
+    if value is None:
+        return 0.0
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        text = value.strip()
+        if text == "":
+            return 0.0
+        try:
+            if text.lower().startswith(("0x", "-0x", "+0x")):
+                return float(int(text, 16))
+            return float(text)
+        except ValueError:
+            return _NAN
+    return _NAN
+
+
+def _loose_eq(left: Any, right: Any) -> bool:
+    if isinstance(left, str) and isinstance(right, str):
+        # Documented: string comparison is case-insensitive.
+        return left.casefold() == right.casefold()
+    if isinstance(left, (list, dict)) or isinstance(right, (list, dict)):
+        # Objects and arrays compare by reference, never by content.
+        return left is right
+    a, b = _number(left), _number(right)
+    if math.isnan(a) or math.isnan(b):
+        return False
+    return a == b
+
+
+def _property(value: Any, name: str) -> Any:
+    if isinstance(value, dict):
+        return value.get(name)
+    if isinstance(value, list):
+        # `labels.*.name` — a property read across a filtered array collects the
+        # property from each element, dropping those that don't have it.
+        return [e[name] for e in value if isinstance(e, dict) and name in e]
+    return None
+
+
+def _star(value: Any) -> Any:
+    if isinstance(value, list):
+        return list(value)
+    if isinstance(value, dict):
+        return list(value.values())
+    return None
+
+
+def _contains(haystack: Any, needle: Any) -> bool:
+    if isinstance(haystack, str):
+        return str(_stringify(needle)).casefold() in haystack.casefold()
+    if isinstance(haystack, list):
+        return any(_loose_eq(item, needle) for item in haystack)
+    return False
+
+
+def _stringify(value: Any) -> str:
+    if value is None:
+        return ""
+    if value is True:
+        return "true"
+    if value is False:
+        return "false"
+    if isinstance(value, float) and value.is_integer():
+        return str(int(value))
+    return str(value)
+
+
+def _starts_with(text: Any, prefix: Any) -> bool:
+    return _stringify(text).casefold().startswith(_stringify(prefix).casefold())
+
+
+def _ends_with(text: Any, suffix: Any) -> bool:
+    return _stringify(text).casefold().endswith(_stringify(suffix).casefold())
+
+
+def _join(values: Any, separator: Any = ",") -> str:
+    items: Iterable[Any] = values if isinstance(values, list) else [values]
+    return _stringify(separator).join(_stringify(v) for v in items)
+
+
+#: Functions this evaluator models. `success()` / `failure()` / `cancelled()` are
+#: deliberately absent: their value depends on runtime job state that a static
+#: payload cannot express, so a gate using one must be tested another way rather
+#: than against a guessed default.
+_FUNCTIONS: dict[str, Callable[..., Any]] = {
+    "contains": _contains,
+    "startswith": _starts_with,
+    "endswith": _ends_with,
+    "join": _join,
+    "always": lambda: True,
+    "format": lambda template, *args: re.sub(
+        r"\{(\d+)\}", lambda m: _stringify(args[int(m.group(1))]), _stringify(template)
+    ),
+}
+
+
+# ── Evaluation ───────────────────────────────────────────────────────────────
+
+
+def _eval(node: _Node, contexts: dict[str, Any]) -> Any:
+    kind = node[0]
+    if kind == "lit":
+        return node[1]
+    if kind == "context":
+        root = node[1]
+        if root not in contexts:
+            raise UnknownContext(
+                f"the expression reads the {root!r} context, which this scenario "
+                f"does not supply (supplied: {sorted(contexts)}). Add it to the "
+                "payload rather than letting it resolve to null."
+            )
+        return contexts[root]
+    if kind == "prop":
+        return _property(_eval(node[1], contexts), node[2])
+    if kind == "star":
+        return _star(_eval(node[1], contexts))
+    if kind == "index":
+        target = _eval(node[1], contexts)
+        key = _eval(node[2], contexts)
+        if isinstance(target, list):
+            position = _number(key)
+            if math.isnan(position) or position != int(position):
+                return None
+            position = int(position)
+            return target[position] if 0 <= position < len(target) else None
+        return _property(target, _stringify(key))
+    if kind == "not":
+        return not truthy(_eval(node[1], contexts))
+    if kind == "and":
+        left = _eval(node[1], contexts)
+        # `&&` yields an operand, not a boolean — `'' && 'x'` is ''.
+        return left if not truthy(left) else _eval(node[2], contexts)
+    if kind == "or":
+        left = _eval(node[1], contexts)
+        return left if truthy(left) else _eval(node[2], contexts)
+    if kind == "==":
+        return _loose_eq(_eval(node[1], contexts), _eval(node[2], contexts))
+    if kind == "!=":
+        return not _loose_eq(_eval(node[1], contexts), _eval(node[2], contexts))
+    if kind in ("<", "<=", ">", ">="):
+        a = _number(_eval(node[1], contexts))
+        b = _number(_eval(node[2], contexts))
+        if math.isnan(a) or math.isnan(b):
+            return False
+        return {
+            "<": a < b,
+            "<=": a <= b,
+            ">": a > b,
+            ">=": a >= b,
+        }[kind]
+    if kind == "call":
+        name = node[1].casefold()
+        function = _FUNCTIONS.get(name)
+        if function is None:
+            raise UnsupportedExpression(
+                f"function {node[1]}() is not modelled by this evaluator; add it to "
+                "_FUNCTIONS with its documented semantics, or test that gate another way"
+            )
+        arguments = [_eval(argument, contexts) for argument in node[2]]
+        return function(*arguments)
+    raise UnsupportedExpression(f"unhandled node {kind!r}")
+
+
+def evaluate(expression: str, contexts: dict[str, Any]) -> bool:
+    """Evaluate a workflow `if:` expression and return whether the job runs.
+
+    ``expression`` is the raw YAML value, with or without the surrounding
+    ``${{ }}`` GitHub allows in an `if:`. ``contexts`` maps each context root the
+    expression reads (``github``, ``inputs``, ``needs``, …) to its value; a root
+    the expression reads but the caller omits raises :class:`UnknownContext`.
+    """
+    source = expression.strip()
+    if source.startswith("${{") and source.endswith("}}"):
+        source = source[3:-2].strip()
+    if "${{" in source:
+        raise UnsupportedExpression(
+            f"partially-interpolated expressions are not supported: {expression!r}"
+        )
+    node = _Parser(_lex(source), source).parse()
+    return truthy(_eval(node, contexts))

--- a/.github/scripts/tests/_gha_expr.py
+++ b/.github/scripts/tests/_gha_expr.py
@@ -30,6 +30,7 @@ __all__ = [
     "UnknownContext",
     "UnsupportedExpression",
     "evaluate",
+    "evaluate_operand",
     "truthy",
 ]
 
@@ -414,6 +415,17 @@ def _eval(node: _Node, contexts: dict[str, Any]) -> Any:
     raise UnsupportedExpression(f"unhandled node {kind!r}")
 
 
+def _parse(expression: str) -> _Node:
+    source = expression.strip()
+    if source.startswith("${{") and source.endswith("}}"):
+        source = source[3:-2].strip()
+    if "${{" in source:
+        raise UnsupportedExpression(
+            f"partially-interpolated expressions are not supported: {expression!r}"
+        )
+    return _Parser(_lex(source), source).parse()
+
+
 def evaluate(expression: str, contexts: dict[str, Any]) -> bool:
     """Evaluate a workflow `if:` expression and return whether the job runs.
 
@@ -422,12 +434,14 @@ def evaluate(expression: str, contexts: dict[str, Any]) -> bool:
     expression reads (``github``, ``inputs``, ``needs``, …) to its value; a root
     the expression reads but the caller omits raises :class:`UnknownContext`.
     """
-    source = expression.strip()
-    if source.startswith("${{") and source.endswith("}}"):
-        source = source[3:-2].strip()
-    if "${{" in source:
-        raise UnsupportedExpression(
-            f"partially-interpolated expressions are not supported: {expression!r}"
-        )
-    node = _Parser(_lex(source), source).parse()
-    return truthy(_eval(node, contexts))
+    return truthy(_eval(_parse(expression), contexts))
+
+
+def evaluate_operand(expression: str, contexts: dict[str, Any]) -> Any:
+    """Evaluate like :func:`evaluate` but return the operand, not its truthiness.
+
+    ``&&``/``||`` return an operand rather than a boolean in GHA, so this is the
+    way to pin that semantics directly — ``evaluate`` alone would mask a broken
+    evaluator that coerced the result to a boolean.
+    """
+    return _eval(_parse(expression), contexts)

--- a/.github/scripts/tests/test_gha_expr.py
+++ b/.github/scripts/tests/test_gha_expr.py
@@ -1,0 +1,219 @@
+"""Tests for the GHA expression evaluator that test_label_trigger_gates.py uses.
+
+The gate guards are only as trustworthy as this evaluator, so its own semantics
+are pinned here — especially the ones that differ from Python's: case-insensitive
+string equality, `&&`/`||` returning an operand rather than a boolean, `'false'`
+being truthy, and NaN comparing false against everything.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _gha_expr import (  # noqa: E402
+    UnknownContext,
+    UnsupportedExpression,
+    evaluate,
+    truthy,
+)
+
+
+def _eval(expression: str, **contexts: object) -> bool:
+    return evaluate(expression, dict(contexts))
+
+
+# ── Literals and truthiness ──────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("value", "negated"),
+    [
+        # `negated` is the value of `!x.v`, i.e. the opposite of truthiness.
+        (None, True),
+        (False, True),
+        (0, True),
+        ("", True),
+        ("false", False),  # the classic footgun: a non-empty string is truthy
+        ("0", False),
+        ([], False),  # an empty array is an object, and objects are truthy
+        ({}, False),
+    ],
+)
+def test_truthiness_matches_githubs_cast_not_pythons(
+    value: object, negated: bool
+) -> None:
+    assert _eval("!x.v", x={"v": value}) is negated
+
+
+def test_a_bare_context_is_its_own_condition() -> None:
+    assert _eval("inputs.flag", inputs={"flag": True}) is True
+    assert _eval("inputs.flag", inputs={"flag": False}) is False
+    # A workflow_dispatch input arrives as a string, so "false" runs the job.
+    assert _eval("inputs.flag", inputs={"flag": "false"}) is True
+
+
+def test_truthy_is_exported_for_callers_inspecting_operand_results() -> None:
+    assert truthy([]) is True
+    assert truthy("") is False
+
+
+# ── Equality ─────────────────────────────────────────────────────────────────
+
+
+def test_string_equality_is_case_insensitive() -> None:
+    assert _eval("github.ref == 'REFS/HEADS/MAIN'", github={"ref": "refs/heads/main"})
+
+
+def test_missing_property_is_null_and_compares_equal_to_false_and_zero() -> None:
+    assert _eval("github.event.nope == false", github={"event": {}})
+    assert _eval("github.event.nope == 0", github={"event": {}})
+    # …and unequal to true, which is what the `fork != true` gate term relies on
+    # for a payload where `fork` is simply absent.
+    assert _eval("github.event.nope != true", github={"event": {}})
+
+
+def test_fork_false_and_fork_absent_both_pass_the_fork_guard() -> None:
+    for repo in ({"fork": False}, {}):
+        assert _eval("g.repo.fork != true", g={"repo": repo}), repo
+    assert not _eval("g.repo.fork != true", g={"repo": {"fork": True}})
+
+
+def test_non_numeric_string_compares_false_against_a_number() -> None:
+    # Mismatched types cast to number; a non-numeric string yields NaN, and NaN
+    # is equal to nothing. Note this only bites across types — two strings take
+    # the string path and compare normally, however non-numeric they are.
+    assert not _eval("x.a == 1", x={"a": "abc"})
+    assert not _eval("x.a == true", x={"a": "abc"})
+    assert _eval("x.a == x.a", x={"a": "abc"})
+
+
+def test_arrays_compare_by_reference_not_content() -> None:
+    shared: list[str] = ["a"]
+    assert _eval("x.a == x.b", x={"a": shared, "b": shared})
+    assert not _eval("x.a == x.b", x={"a": ["a"], "b": ["a"]})
+
+
+# ── Operators ────────────────────────────────────────────────────────────────
+
+
+def test_and_binds_tighter_than_or() -> None:
+    # false && false || true  →  (false && false) || true  →  true
+    assert _eval("x.f && x.f || x.t", x={"f": False, "t": True})
+    # If precedence were the other way this would be false.
+    assert _eval("x.t || x.f && x.f", x={"f": False, "t": True})
+
+
+def test_parentheses_override_precedence() -> None:
+    assert not _eval("x.t && (x.f || x.f)", x={"f": False, "t": True})
+
+
+def test_and_or_return_an_operand_so_a_falsy_right_hand_side_wins() -> None:
+    # `'' || 'fallback'` is the documented default-value idiom.
+    assert _eval("x.empty || x.fallback", x={"empty": "", "fallback": "v"})
+    assert not _eval("x.set && x.empty", x={"set": "v", "empty": ""})
+
+
+def test_not_yields_a_boolean() -> None:
+    assert _eval("!x.empty", x={"empty": ""})
+    assert not _eval("!x.set", x={"set": "v"})
+
+
+@pytest.mark.parametrize(
+    ("expression", "expected"),
+    [
+        ("x.a < x.b", True),
+        ("x.a > x.b", False),
+        ("x.a <= x.a", True),
+        ("x.b >= x.a", True),
+    ],
+)
+def test_ordering_comparisons(expression: str, expected: bool) -> None:
+    assert _eval(expression, x={"a": 1, "b": 2}) is expected
+
+
+# ── Property access, object filters, indexing ────────────────────────────────
+
+
+def test_object_filter_collects_a_property_across_an_array() -> None:
+    payload = {"labels": [{"name": "e2e"}, {"name": "size/M"}]}
+    assert _eval("pr.labels.*.name != null", pr=payload)
+    assert _eval("contains(pr.labels.*.name, 'size/M')", pr=payload)
+
+
+def test_object_filter_on_an_empty_array_matches_nothing() -> None:
+    assert not _eval("contains(pr.labels.*.name, 'e2e')", pr={"labels": []})
+
+
+def test_property_access_through_a_null_stays_null_rather_than_erroring() -> None:
+    # `github.event.label.name` on a non-`labeled` event: `label` is absent.
+    assert _eval("github.event.label.name != 'e2e'", github={"event": {}})
+
+
+def test_index_access_on_arrays_and_objects() -> None:
+    assert _eval("x.a[1] == 'b'", x={"a": ["a", "b"]})
+    assert _eval("x.a['k'] == 'v'", x={"a": {"k": "v"}})
+    assert _eval("x.a[9] == null", x={"a": ["a"]})
+
+
+# ── Functions ────────────────────────────────────────────────────────────────
+
+
+def test_contains_is_membership_on_arrays_not_substring() -> None:
+    labels = {"labels": [{"name": "e2e-full"}]}
+    assert not _eval("contains(pr.labels.*.name, 'e2e')", pr=labels)
+    assert _eval("contains(pr.labels.*.name, 'e2e-full')", pr=labels)
+
+
+def test_contains_is_substring_on_strings() -> None:
+    assert _eval("contains(github.ref, 'heads')", github={"ref": "refs/heads/main"})
+
+
+def test_string_helpers_are_case_insensitive() -> None:
+    assert _eval("startsWith(github.ref, 'REFS/')", github={"ref": "refs/heads/main"})
+    assert _eval("endsWith(github.ref, 'MAIN')", github={"ref": "refs/heads/main"})
+
+
+def test_always_is_modelled_but_runtime_status_functions_are_not() -> None:
+    assert _eval("always()")
+    with pytest.raises(UnsupportedExpression, match="success"):
+        _eval("success()")
+
+
+def test_format_and_join() -> None:
+    assert _eval("format('{0}-{1}', 'a', 'b') == 'a-b'")
+    assert _eval("join(x.a, '-') == 'a-b'", x={"a": ["a", "b"]})
+
+
+# ── Refusals ─────────────────────────────────────────────────────────────────
+
+
+def test_an_unsupplied_context_root_raises_instead_of_resolving_to_null() -> None:
+    """The property that stops a scenario from passing vacuously."""
+    with pytest.raises(UnknownContext, match="needs"):
+        _eval("needs.build.result == 'success'", github={})
+
+
+def test_unknown_functions_and_unparseable_input_raise() -> None:
+    with pytest.raises(UnsupportedExpression, match="fromJSON"):
+        _eval("fromJSON('[]')")
+    with pytest.raises(UnsupportedExpression):
+        _eval("x.a ===== x.b", x={})
+    with pytest.raises(UnsupportedExpression):
+        _eval("(x.a", x={})
+    with pytest.raises(UnsupportedExpression, match="trailing"):
+        _eval("x.a x.b", x={})
+
+
+def test_the_optional_surrounding_interpolation_is_stripped() -> None:
+    assert _eval("${{ github.ref == 'main' }}", github={"ref": "main"})
+    with pytest.raises(UnsupportedExpression, match="partially-interpolated"):
+        _eval("a-${{ github.ref }}-b", github={"ref": "main"})
+
+
+def test_quotes_are_unescaped_by_doubling() -> None:
+    assert _eval("x.a == 'it''s'", x={"a": "it's"})

--- a/.github/scripts/tests/test_gha_expr.py
+++ b/.github/scripts/tests/test_gha_expr.py
@@ -19,6 +19,7 @@ from _gha_expr import (  # noqa: E402
     UnknownContext,
     UnsupportedExpression,
     evaluate,
+    evaluate_operand,
     truthy,
 )
 
@@ -116,6 +117,24 @@ def test_and_or_return_an_operand_so_a_falsy_right_hand_side_wins() -> None:
     # `'' || 'fallback'` is the documented default-value idiom.
     assert _eval("x.empty || x.fallback", x={"empty": "", "fallback": "v"})
     assert not _eval("x.set && x.empty", x={"set": "v", "empty": ""})
+
+
+def test_and_or_return_the_selected_operand_not_a_boolean() -> None:
+    # Value-level: pin the operand itself, not just its truthiness, so an
+    # evaluator that returned booleans instead would fail here even though it
+    # would still pass the truthy-only assertions above.
+    assert (
+        evaluate_operand("x.empty || x.fallback", {"x": {"empty": "", "fallback": "v"}})
+        == "v"
+    )
+    assert evaluate_operand("x.set && x.empty", {"x": {"set": "v", "empty": ""}}) == ""
+    assert (
+        evaluate_operand("x.set || x.fallback", {"x": {"set": "v", "fallback": "w"}})
+        == "v"
+    )
+    assert (
+        evaluate_operand("x.set && x.other", {"x": {"set": "v", "other": "w"}}) == "w"
+    )
 
 
 def test_not_yields_a_boolean() -> None:

--- a/.github/scripts/tests/test_label_trigger_gates.py
+++ b/.github/scripts/tests/test_label_trigger_gates.py
@@ -1,0 +1,351 @@
+"""Guards for label-gated job conditions (FND-48).
+
+`contains(github.event.pull_request.labels.*.name, 'x')` asks whether the PR
+carries `x` *right now*. That is the right question for `opened`, `synchronize`
+and `reopened`, and the wrong one for `labeled`: GitHub has no trigger-level
+filter for which label fired, so on a PR that already carries `x` any unrelated
+label add — the size/, area/, dependency and review-state labels bots churn
+constantly — satisfies the state check and re-runs the job. For the `e2e` gates
+that meant a 20–40 minute live-tenant suite, multiplied by the cross-CSP matrix
+and queued rather than replaced (`cancel-in-progress: false` is deliberate, so
+each spurious add stacked behind the last).
+
+The fix is one extra term per gate:
+
+    (github.event.action != 'labeled' || github.event.label.name == 'x')
+
+Two layers of guard here, because each catches what the other cannot:
+
+* :func:`test_every_label_gate_reachable_by_a_labeled_event_is_event_aware`
+  sweeps every workflow, so a *new* label gate cannot land without the term. It
+  is textual, so it proves presence but not correctness.
+* The behavioural tests lift each real gate expression out of the YAML and
+  evaluate it against synthetic payloads. Those prove the term is wired in at
+  the right precedence — `&&` binds tighter than `||` in GHA, so a term added
+  one paren out is a silently no-op gate that a presence check would pass.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+from typing import Any, Iterator
+
+import pytest
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _gha_expr import evaluate  # noqa: E402
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_WORKFLOW_DIR = _REPO_ROOT / ".github/workflows"
+
+#: The state check that is only half a gate on a `labeled`-triggered workflow.
+_LABEL_STATE_CHECK = re.compile(
+    r"contains\(\s*github\.event\.pull_request\.labels\.\*\.name\s*,\s*'([^']+)'\s*\)"
+)
+
+
+def _load(path: Path) -> dict[str, Any]:
+    return yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+
+
+def _load_or_skip(path: Path) -> dict[str, Any] | None:
+    """Load a workflow for the repo-wide sweep, tolerating unparseable files.
+
+    `.github/workflows/scheduled-trivy-scan.yml` does not parse as YAML on main
+    (a heredoc body inside a `run: |` block sits at column 0, which terminates
+    the block scalar). GitHub cannot run an invalid workflow either, so it cannot
+    exhibit the bug this sweep looks for — and repairing it here would silently
+    start a daily security scan that files tickets, which is not this change's to
+    make. Tolerated rather than asserted against, for the same reason
+    test_e2e_tenant_install_workflow.py scopes its own guard: a check born
+    red on pre-existing debt gets disabled instead of fixed.
+    """
+    try:
+        return _load(path)
+    except yaml.YAMLError:
+        return None
+
+
+def _triggers(workflow: dict[str, Any]) -> dict[str, Any]:
+    # PyYAML resolves the bare key `on` to the boolean True (YAML 1.1 truthiness),
+    # so a workflow's trigger block is under one key or the other.
+    raw = workflow.get("on", workflow.get(True)) or {}
+    return raw if isinstance(raw, dict) else {}
+
+
+def _event_aware_term(label: str) -> re.Pattern[str]:
+    return re.compile(
+        r"github\.event\.action\s*!=\s*'labeled'\s*\|\|\s*"
+        rf"github\.event\.label\.name\s*==\s*'{re.escape(label)}'"
+    )
+
+
+def _conditions(workflow: dict[str, Any]) -> Iterator[tuple[str, str]]:
+    """Yield (where, expression) for every job- and step-level `if:`."""
+    for job_name, job in (workflow.get("jobs") or {}).items():
+        if not isinstance(job, dict):
+            continue
+        if "if" in job:
+            yield job_name, str(job["if"])
+        for step in job.get("steps") or []:
+            if isinstance(step, dict) and "if" in step:
+                yield f"{job_name} → {step.get('name', '?')}", str(step["if"])
+
+
+def _can_receive_a_labeled_event(workflow: dict[str, Any]) -> bool:
+    """Whether a `labeled` action can reach this workflow's gates.
+
+    A reusable (`workflow_call`) workflow cannot see its callers' trigger lists,
+    and the SDK's own bootstrap template ships `labeled` in every connector's
+    `tests.yaml`, so a reusable must always be treated as reachable. A workflow
+    with its own `pull_request` trigger is judged on its declared types; one that
+    lists only `closed` (the release-on-merge shape) genuinely cannot be hit.
+    """
+    triggers = _triggers(workflow)
+    if "workflow_call" in triggers:
+        return True
+    pull_request = triggers.get("pull_request")
+    if pull_request is None:
+        return False
+    types = (pull_request or {}).get("types")
+    # No `types:` means GitHub's default set, which does not include `labeled`.
+    return bool(types) and "labeled" in types
+
+
+def test_every_label_gate_reachable_by_a_labeled_event_is_event_aware() -> None:
+    offenders: list[str] = []
+    checked = 0
+    for path in sorted(_WORKFLOW_DIR.glob("*.y*ml")):
+        workflow = _load_or_skip(path)
+        if workflow is None or not _can_receive_a_labeled_event(workflow):
+            continue
+        for where, expression in _conditions(workflow):
+            flat = " ".join(expression.split())
+            for label in _LABEL_STATE_CHECK.findall(flat):
+                checked += 1
+                if not _event_aware_term(label).search(flat):
+                    offenders.append(f"{path.name}: {where} (label {label!r})")
+    assert checked, (
+        "this guard found no label-gated jobs at all — the detection regex has "
+        "drifted from how the gates are written, so it is passing vacuously"
+    )
+    assert not offenders, (
+        "these gates test whether the PR carries the label rather than whether "
+        "that label was the one just added, so every unrelated label add re-runs "
+        "them (FND-48). Add `(github.event.action != 'labeled' || "
+        "github.event.label.name == '<label>')` to the same `&&` chain — and if a "
+        "gate genuinely must fire on any label change, say so here with a reason "
+        f"rather than leaving it looking like this bug. Offenders: {offenders}"
+    )
+
+
+# ── Behavioural coverage of the real gates ───────────────────────────────────
+
+
+def _gate(workflow_file: str, job: str) -> str:
+    workflow = _load(_WORKFLOW_DIR / workflow_file)
+    jobs = workflow.get("jobs") or {}
+    assert job in jobs, f"job {job!r} is gone from {workflow_file}; update this guard"
+    condition = jobs[job].get("if")
+    assert condition, f"{workflow_file}:{job} lost its `if:` gate entirely"
+    return str(condition)
+
+
+def _pull_request(
+    action: str,
+    labels: tuple[str, ...],
+    *,
+    added: str | None = None,
+    fork: bool = False,
+    login: str = "a-human",
+) -> dict[str, Any]:
+    """A `pull_request` github context, shaped like the real webhook payload."""
+    event: dict[str, Any] = {
+        "action": action,
+        "pull_request": {
+            "labels": [{"name": name} for name in labels],
+            "head": {"repo": {"fork": fork}},
+            "user": {"login": login},
+        },
+    }
+    if added is not None:
+        # Only a `labeled`/`unlabeled` payload carries `label`; on every other
+        # action the key is simply absent, which is what makes the guard term
+        # inert outside the case it exists for.
+        event["label"] = {"name": added}
+    return {"event_name": "pull_request", "event": event}
+
+
+def _merge_group() -> dict[str, Any]:
+    return {"event_name": "merge_group", "event": {"action": "checks_requested"}}
+
+
+#: The acceptance table from FND-48, expressed once and reused for every gate.
+#: `LABEL` is substituted with the gate's own label.
+_SCENARIOS: tuple[tuple[str, str, tuple[str, ...], str | None, bool], ...] = (
+    # description,                        action,        labels,       added,       runs
+    ("opened carrying the label", "opened", ("LABEL",), None, True),
+    ("a real push", "synchronize", ("LABEL",), None, True),
+    ("reopened carrying the label", "reopened", ("LABEL",), None, True),
+    ("the label being added", "labeled", ("LABEL",), "LABEL", True),
+    ("the label re-added after a removal", "labeled", ("LABEL",), "LABEL", True),
+    # The regression this ticket exists for.
+    (
+        "an unrelated label added alongside it",
+        "labeled",
+        ("LABEL", "size/M"),
+        "size/M",
+        False,
+    ),
+    ("an unrelated label on a PR without it", "labeled", ("size/M",), "size/M", False),
+    ("opened without the label", "opened", (), None, False),
+    ("a push without the label", "synchronize", ("size/M",), None, False),
+)
+
+
+def _scenarios(label: str) -> Iterator[tuple[str, dict[str, Any], bool]]:
+    for description, action, labels, added, runs in _SCENARIOS:
+        github = _pull_request(
+            action,
+            tuple(label if name == "LABEL" else name for name in labels),
+            added=label if added == "LABEL" else added,
+        )
+        yield description, github, runs
+
+
+def _assert_gate(expression: str, label: str, extra: dict[str, Any]) -> None:
+    for description, github, expected in _scenarios(label):
+        actual = evaluate(expression, {"github": github, **extra})
+        assert actual is expected, (
+            f"gate for {label!r} on {description}: expected the job to "
+            f"{'run' if expected else 'be skipped'}, got the opposite"
+        )
+
+
+# `needs` values that are otherwise-green, so each scenario isolates the label
+# behaviour rather than accidentally being skipped by an unrelated term.
+_CHANGES_SDK = {
+    "changes": {"outputs": {"sdk": "true", "container": "false", "ci": "false"}}
+}
+
+
+def test_discover_e2e_only_reacts_to_the_e2e_label_being_added() -> None:
+    """tests-reusable.yaml — the gate 17 connector repos consume."""
+    _assert_gate(
+        _gate("tests-reusable.yaml", "discover-e2e"),
+        "e2e",
+        {"inputs": {"enable-e2e": True, "run-e2e": ""}},
+    )
+
+
+def test_build_sdk_base_image_only_reacts_to_the_e2e_label_being_added() -> None:
+    _assert_gate(
+        _gate("pull_request.yaml", "build-sdk-base-image"),
+        "e2e",
+        {"needs": _CHANGES_SDK},
+    )
+
+
+def test_connector_tests_only_reacts_to_the_e2e_label_being_added() -> None:
+    _assert_gate(
+        _gate("pull_request.yaml", "connector-tests"),
+        "e2e",
+        {
+            "needs": {
+                **_CHANGES_SDK,
+                "matrix-builder": {"result": "success"},
+                "build-sdk-base-image": {"result": "success"},
+            }
+        },
+    )
+
+
+def test_sdr_k8s_e2e_only_reacts_to_the_e2e_label_being_added() -> None:
+    _assert_gate(
+        _gate("pull_request.yaml", "sdr-k8s-e2e"), "e2e", {"needs": _CHANGES_SDK}
+    )
+
+
+def test_storage_integration_only_reacts_to_its_own_label_being_added() -> None:
+    _assert_gate(
+        _gate("pull_request.yaml", "storage-integration"), "storage-integration", {}
+    )
+
+
+# ── The paths the fix must not disturb ───────────────────────────────────────
+
+
+def test_a_workflow_dispatch_with_run_e2e_still_runs_the_suite() -> None:
+    """Cross-repo dispatch from an SDK PR never sees a `labeled` action at all."""
+    expression = _gate("tests-reusable.yaml", "discover-e2e")
+    contexts = {
+        "github": {"event_name": "workflow_dispatch", "event": {}},
+        "inputs": {"enable-e2e": True, "run-e2e": "true"},
+    }
+    assert evaluate(expression, contexts) is True
+    contexts["inputs"] = {"enable-e2e": True, "run-e2e": "false"}
+    assert evaluate(expression, contexts) is False
+    # enable-e2e is the connector's opt-out and must still win outright.
+    contexts["inputs"] = {"enable-e2e": False, "run-e2e": "true"}
+    assert evaluate(expression, contexts) is False
+
+
+@pytest.mark.parametrize("job", ["connector-tests", "sdr-k8s-e2e"])
+def test_the_merge_queue_path_is_unaffected_by_the_label_term(job: str) -> None:
+    """merge_group has no labels and no `labeled` action; it must still run."""
+    contexts = {
+        "github": _merge_group(),
+        "needs": {
+            **_CHANGES_SDK,
+            "matrix-builder": {"result": "success"},
+            # Skipped on the merge-queue path — the gate tolerates that by design.
+            "build-sdk-base-image": {"result": "skipped"},
+        },
+    }
+    assert evaluate(_gate("pull_request.yaml", job), contexts) is True
+
+
+@pytest.mark.parametrize(
+    ("job", "extra"),
+    [
+        ("build-sdk-base-image", {"needs": _CHANGES_SDK}),
+        ("sdr-k8s-e2e", {"needs": _CHANGES_SDK}),
+    ],
+)
+def test_forks_and_dependabot_are_still_excluded(
+    job: str, extra: dict[str, Any]
+) -> None:
+    """The fix adds a term; it must not have loosened the existing ones."""
+    expression = _gate("pull_request.yaml", job)
+    fork = _pull_request("labeled", ("e2e",), added="e2e", fork=True)
+    assert evaluate(expression, {"github": fork, **extra}) is False
+    bot = _pull_request("labeled", ("e2e",), added="e2e", login="dependabot[bot]")
+    assert evaluate(expression, {"github": bot, **extra}) is False
+
+
+def test_the_e2e_concurrency_groups_still_refuse_to_cancel_in_progress() -> None:
+    """FND-48 deliberately did not touch this; pin it so the pairing stays visible.
+
+    Making the gate event-aware removes the *spurious* triggers that made the
+    queueing painful. Whether a *genuine* re-trigger should cancel an in-flight
+    e2e is a separate decision, and it cannot be taken until an abandoned live
+    Automation Engine run has a cleanup path — cancelling mid-run today leaves
+    tenant state behind. If this assertion is what fails, that decision is being
+    made implicitly.
+    """
+    workflow = _load(_WORKFLOW_DIR / "tests-reusable.yaml")
+    e2e_jobs = [
+        name
+        for name, job in workflow["jobs"].items()
+        if isinstance(job, dict)
+        and "e2e" in str(job.get("concurrency", {}).get("group", ""))
+    ]
+    assert e2e_jobs, "no e2e concurrency group found; the guard has drifted"
+    for name in e2e_jobs:
+        assert (
+            workflow["jobs"][name]["concurrency"]["cancel-in-progress"] is False
+        ), name

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -230,10 +230,25 @@ jobs:
     # sdk OR container: a Dockerfile-only PR (the prime base-image use case,
     # e.g. a daprd / base bump) is container==true / sdk==false — it must
     # still rebuild the base so the connector e2e exercises the new image.
+    #
+    # The `github.event.action != 'labeled'` term is the FND-48 gate and appears
+    # on every `e2e`-labelled job in this workflow. `contains(...labels...)` is a
+    # STATE check — "does the PR carry `e2e` right now" — but this workflow also
+    # triggers on `labeled`, and GitHub offers no trigger-level filter for WHICH
+    # label. So on a PR that already carries `e2e`, any unrelated label add (bots
+    # churn size/, area/, dependency and review-state labels constantly) satisfies
+    # the state check and re-fires the whole cross-repo e2e fan-out. Making the
+    # `labeled` event count only when `e2e` is the label just added leaves every
+    # other event type alone: a real push is `synchronize`, so it still
+    # re-triggers, and re-adding `e2e` still triggers. The workflow RUN is still
+    # created either way — the jobs now skip in seconds instead of dispatching
+    # live-tenant suites. Enforced repo-wide by
+    # .github/scripts/tests/test_label_trigger_gates.py.
     if: |
       (needs.changes.outputs.sdk == 'true' || needs.changes.outputs.container == 'true') &&
       github.event_name == 'pull_request' &&
       contains(github.event.pull_request.labels.*.name, 'e2e') &&
+      (github.event.action != 'labeled' || github.event.label.name == 'e2e') &&
       github.event.pull_request.head.repo.fork != true &&
       github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
@@ -319,6 +334,7 @@ jobs:
         (
           github.event_name == 'pull_request' &&
           contains(github.event.pull_request.labels.*.name, 'e2e') &&
+          (github.event.action != 'labeled' || github.event.label.name == 'e2e') &&
           github.event.pull_request.head.repo.fork != true &&
           github.event.pull_request.user.login != 'dependabot[bot]'
         )
@@ -410,6 +426,7 @@ jobs:
       (
         github.event_name == 'pull_request' &&
         contains(github.event.pull_request.labels.*.name, 'e2e') &&
+        (github.event.action != 'labeled' || github.event.label.name == 'e2e') &&
         github.event.pull_request.head.repo.fork != true &&
         github.event.pull_request.user.login != 'dependabot[bot]'
       )
@@ -535,11 +552,15 @@ jobs:
   # Fork PRs are excluded (no secrets). Nightly counterpart lives in schedule.yaml.
   storage-integration:
     name: Storage Integration Tests (S3 / Azure / GCS)
+    # Same FND-48 shape as the e2e gates above — see build-sdk-base-image for the
+    # full rationale. The previous form OR'd the event check with the state check,
+    # which made the event arm redundant: `contains(...)` alone was already true
+    # for the label-just-added case, so every unrelated label add on a PR carrying
+    # `storage-integration` re-ran the real-cloud suite. AND-ing it is the fix.
     if: |
-      (
-        (github.event.action == 'labeled' && github.event.label.name == 'storage-integration') ||
-        contains(github.event.pull_request.labels.*.name, 'storage-integration')
-      ) && github.event.pull_request.head.repo.fork != true
+      contains(github.event.pull_request.labels.*.name, 'storage-integration') &&
+      (github.event.action != 'labeled' || github.event.label.name == 'storage-integration') &&
+      github.event.pull_request.head.repo.fork != true
     runs-on: ubuntu-latest
     timeout-minutes: 15
     # Keyless: all three clouds authenticate via GitHub OIDC (no static secrets).

--- a/.github/workflows/tests-reusable.yaml
+++ b/.github/workflows/tests-reusable.yaml
@@ -672,12 +672,25 @@ jobs:
     # Just a checkout + a seconds-long glob; cap it so a wedged runner can't
     # hold the required check pending for GitHub's 6-hour default.
     timeout-minutes: 10
+    # The `contains(...labels...)` term asks "does the PR carry `e2e` right now",
+    # which is the right question for `opened`/`synchronize`/`reopened` but the
+    # wrong one for `labeled`: on a PR that already carries `e2e`, adding ANY
+    # other label (size/, area/, dependency, review-state — bots add and remove
+    # these constantly) satisfies it and re-runs the whole suite. Crossed with
+    # the cross-CSP matrix that is suites × clouds live tenants per spurious
+    # add, and `cancel-in-progress: false` below means each one queues behind
+    # the last rather than replacing it. The added term makes a `labeled` event
+    # count only when `e2e` is the label that was just added; every other event
+    # type is unaffected, so a real push still re-triggers. GitHub has no
+    # trigger-level label filter, so the workflow RUN is still created — it now
+    # skips in seconds instead of holding tenants for 20–40 minutes. FND-48.
     if: |
       inputs.enable-e2e && (
         (github.event_name == 'workflow_dispatch' && inputs.run-e2e == 'true') ||
         (
           github.event_name == 'pull_request' &&
           contains(github.event.pull_request.labels.*.name, 'e2e') &&
+          (github.event.action != 'labeled' || github.event.label.name == 'e2e') &&
           github.event.pull_request.head.repo.fork != true &&
           github.event.pull_request.user.login != 'dependabot[bot]'
         )

--- a/docs/standards/ci.md
+++ b/docs/standards/ci.md
@@ -58,6 +58,61 @@ failure mode. Because it now concludes on every PR, it can be added to branch
 protection directly, without the always-concluding-gate wrapper that
 path-filtered required checks need (see `sdk-gate.yaml` for that pattern).
 
+## Label gates must be event-aware
+
+**Rule:** if a workflow can receive a `labeled` event, every job gated on a
+label must check *which* label fired, not only whether the PR carries it:
+
+```yaml
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+
+jobs:
+  expensive-thing:
+    if: |
+      contains(github.event.pull_request.labels.*.name, 'e2e') &&
+      (github.event.action != 'labeled' || github.event.label.name == 'e2e')
+```
+
+**Why:** `contains(...labels...)` is a **state** check — "does this PR carry
+`e2e` right now". On `opened` / `synchronize` / `reopened` that is exactly
+right. On `labeled` it is wrong, because GitHub offers no way to filter the
+trigger by which label was added: on a PR that already carries `e2e`, adding
+*any* other label satisfies the state check and re-runs the job. Bots add and
+remove size, area, dependency and review-state labels constantly, so in practice
+this fires repeatedly and at random. FND-48 was the e2e case — a 20–40 minute
+live-tenant suite, multiplied by the cross-CSP matrix, and queued rather than
+replaced because `cancel-in-progress: false` is deliberate there.
+
+The added term is inert on every other event: only a `labeled` payload carries
+`github.event.label`, so a real push (`synchronize`) still re-triggers, and
+adding — or re-adding — the label still triggers.
+
+**What it does not fix:** the workflow *run* is still created, because the
+filter is at job level and GitHub has no trigger-level label filter. The jobs
+skip within seconds, so no tenant time or runner minutes are consumed, but a
+stream of skipped runs still appears in the Actions list. Removing those means
+dropping `labeled` for an explicit signal (`workflow_dispatch`, a `/e2e`
+comment command, a re-run button) — more work, and it changes how everyone
+triggers the suite today.
+
+**Reusable workflows always count as reachable.** A `workflow_call` workflow
+cannot see its callers' trigger lists, and the connector `tests.yaml` this repo
+scaffolds ships `labeled`, so a gate inside a reusable must carry the term
+unconditionally.
+
+Both halves are enforced by
+[`test_label_trigger_gates.py`](../../.github/scripts/tests/test_label_trigger_gates.py):
+a repo-wide sweep fails any new label gate that omits the term, and a
+behavioural layer lifts each real gate out of the YAML and evaluates it against
+synthetic payloads. The second layer exists because presence is not
+correctness — `&&` binds tighter than `||` in GitHub expressions, so a term
+added one parenthesis out is a no-op that a textual check waves through.
+Evaluation uses [`_gha_expr.py`](../../.github/scripts/tests/_gha_expr.py), a
+deliberately partial evaluator that raises on anything it does not model rather
+than guessing.
+
 ## Mask secrets before writing them to `$GITHUB_ENV`
 
 **Rule:** if a step derives secret values from something else — unpacking a

--- a/docs/standards/connector-ci-e2e.md
+++ b/docs/standards/connector-ci-e2e.md
@@ -21,9 +21,37 @@ This doc covers what the SDK ships — the composite action, the reusable workfl
 | Pipeline | What it validates | Stack | Wall time | Triggers |
 |---|---|---|---|---|
 | **SDR Integration Tests (testcontainer)** | Credential → secret-store → connector-client chain. Auth / preflight / extract polled to `COMPLETED` on CI tenant Temporal. | Hermetic — testcontainer DB + worker + Dapr + Temporal. | ~3 min | Auto on every connector PR push |
-| **E2E Full Tests (system apps)** | Full DAG: connector extract → publish → query-intelligence → lineage-app → lineage-publish. Asset counts + lineage assertions in Atlas. | Live — configurator-generated compose, worker on a dynamic Temporal queue against the CI tenant's full Atlan stack. | ~20–40 min | Label-gated (`e2e-full`) |
+| **E2E Full Tests (system apps)** | Full DAG: connector extract → publish → query-intelligence → lineage-app → lineage-publish. Asset counts + lineage assertions in Atlas. | Live — configurator-generated compose, worker on a dynamic Temporal queue against the CI tenant's full Atlan stack. | ~20–40 min | Label-gated (`e2e`) — see below |
 
 Both call the same composite action; difference is test target, Dapr components, compose overlay, and secret-bundle shape.
+
+### What the `e2e` label actually gates
+
+Adding the `e2e` label starts the suite; a subsequent push (`synchronize`) on a
+PR still carrying it re-runs the suite. What does **not** re-run it is an
+unrelated label add — `size/`, `area/`, dependency and review-state labels churn
+constantly on an open PR, and every one of those used to re-fire the whole
+matrix (FND-48).
+
+The `Discover e2e suites` gate in `tests-reusable.yaml` therefore asks two
+questions, not one:
+
+```yaml
+contains(github.event.pull_request.labels.*.name, 'e2e') &&
+(github.event.action != 'labeled' || github.event.label.name == 'e2e')
+```
+
+You will still see a *workflow run* appear for every label add — GitHub has no
+trigger-level label filter, so the run is created and then skips within seconds.
+That is expected; it costs no tenant time and nothing queues behind it. Do not
+"fix" it by removing `labeled` from your `tests.yaml` trigger list: that is what
+makes adding the label start a run in the first place. See
+[`docs/standards/ci.md`](ci.md#label-gates-must-be-event-aware).
+
+Note that a genuine re-trigger still **queues** behind an in-flight run rather
+than cancelling it (`cancel-in-progress: false`). That is deliberate —
+cancelling mid-run abandons a live Automation Engine run and leaves tenant state
+behind — and it is a separate decision from the gating above.
 
 ## SDR composite action inputs
 

--- a/packages/conformance/conformance/bootstrap/templates/tests.yaml
+++ b/packages/conformance/conformance/bootstrap/templates/tests.yaml
@@ -23,6 +23,12 @@ on:
       - main
   pull_request:
     types:
+      # `labeled` is what makes adding the `e2e` label start a run. GitHub has
+      # no trigger-level filter for WHICH label, so an unrelated label add
+      # creates a run here too — the SDK's reusable workflow gates on
+      # `github.event.label.name` so those runs skip in seconds instead of
+      # re-running the live-tenant suite (FND-48). Keep the type; the filtering
+      # is not this file's job.
       - opened
       - synchronize
       - reopened


### PR DESCRIPTION
Closes FND-48.

## Problem

Any label added to a PR that already carries `e2e` re-fired the entire full-DAG e2e suite. The gate asked whether the PR **carries** the label, not whether `e2e` was the label just **added** — and GitHub has no trigger-level filter for which label fired. So the size/, area/, dependency and review-state labels bots churn constantly each re-queued a 20–40 minute live-tenant run, with no relation to the change under test.

Two things compound it: the cross-CSP matrix (FND-6) makes every spurious trigger suites × clouds live tenants, and `cancel-in-progress: false` — deliberate, since cancelling mid-run abandons a live AE run — means each one *stacks* behind the last rather than replacing it.

## Fix

One term on every label gate reachable by a `labeled` event:

```yaml
(github.event.action != 'labeled' || github.event.label.name == '<label>')
```

Only a `labeled` payload carries `github.event.label`, so the term is inert on every other event: a real push (`synchronize`) still re-triggers, and adding — or re-adding — the label still triggers.

Five gates, not one:

| Workflow | Job | Label |
|---|---|---|
| `tests-reusable.yaml` | `discover-e2e` | `e2e` |
| `pull_request.yaml` | `build-sdk-base-image` | `e2e` |
| `pull_request.yaml` | `connector-tests` | `e2e` |
| `pull_request.yaml` | `sdr-k8s-e2e` | `e2e` |
| `pull_request.yaml` | `storage-integration` | `storage-integration` |

`storage-integration` had the identical defect in a subtler form — it OR'd the event check with the state check, which made the event arm dead code, since `contains(...)` alone is already true when the label was just added. AND-ing it is the fix.

`e2e-full-reusable.yaml` (the second pointer on the ticket) needed nothing: it is `workflow_dispatch`-only and carries no label gate.

## What this does and does not remove

Tenant time and queueing: gone. The skipped runs in the Actions list: still there — the filter is at job level, and GitHub has no trigger-level label filter, so the run is still created and then skips within seconds. Removing that noise means dropping `labeled` for an explicit signal (`workflow_dispatch`, a `/e2e` comment, a re-run button), which changes muscle memory for everyone using the label today. Out of scope here.

## Testing

The gate is a single expression, so per `docs/standards/ci.md` it stays inline — but "regression-tested" needs more than a grep. Two layers, because neither catches the other's failure mode:

1. **Repo-wide sweep** (`test_every_label_gate_reachable_by_a_labeled_event_is_event_aware`) — every workflow a `labeled` event can reach; any `contains(...labels...)` gate missing the term fails. This is the layer that catches the *next* one, which matters given the trigger shape is spreading across 17 connector repos. Textual, so it proves presence, not correctness.
2. **Behavioural** — lifts each real gate verbatim out of the YAML and evaluates it against synthetic webhook payloads (the acceptance table from the ticket: opened / synchronize / reopened / label added / label re-added / unrelated label added / no label, plus fork, dependabot and merge_group).

Layer 2 exists because `&&` binds tighter than `||` in GitHub expressions, so a term added one parenthesis out is a silently no-op gate. Mutation-checked both layers against a pre-fix gate and against a deliberately misplaced term:

| | sweep | behavioural |
|---|---|---|
| term missing entirely | catches | catches |
| term present, wrong precedence | **misses** | catches |

Layer 2 needed a GHA expression evaluator (`.github/scripts/tests/_gha_expr.py`, ~200 lines, 36 tests of its own). It models the operators and functions this repo's gates use and **raises** on everything else — a partial evaluator that silently treated an unknown construct as null would let a broken gate pass its own test, which is worse than no test. Same for context roots: reading one a scenario didn't supply raises rather than resolving to null, so a scenario cannot pass vacuously. Its tests also pin the GHA semantics that differ from Python's (case-insensitive `==`, `&&`/`||` returning an operand rather than a boolean, `'false'` being truthy).

Verified the downstream state is not new: a skipped `discover-e2e` is `_OK_OPTIONAL` in `verify_test_gate.py`, and a skipped `connector-tests` / `build-sdk-base-image` passes `verify_connector_gate_upstream.py`. Both are already the daily state on a PR without the label, so no required check changes colour.

Full `.github/scripts/tests` suite: 1357 passed. Pre-commit clean.

## Deliberately not done

**Concurrency.** `cancel-in-progress: false` untouched. Whether a *genuine* re-trigger should cancel an in-flight e2e is the separate decision the ticket flags, and it needs a cleanup path for an abandoned AE run to exist first. Added a test pinning it to `false` with that rationale recorded, so the decision cannot be made implicitly by someone flipping it in passing.

## Flagged, not fixed

`.github/workflows/scheduled-trivy-scan.yml` **is not valid YAML on `main`** — a heredoc body inside a `run: |` block sits at column 0, which terminates the block scalar. GitHub cannot run an invalid workflow, so the daily Trivy scan has presumably not been running since the Renovate bump in #2926. Not repaired here: fixing it *starts* a scan that files Linear tickets, which should not ride along on a CI-gating change. The repo-wide sweep tolerates the file rather than crashing on it, with the reason recorded inline. Worth its own ticket.

## Docs

- `docs/standards/ci.md` — new "Label gates must be event-aware" section (rule, why, what it does not fix, and why reusable workflows always count as reachable).
- `docs/standards/connector-ci-e2e.md` — connector-facing explanation, including "do not 'fix' the skipped runs by removing `labeled` from your trigger list", which would break the label workflow entirely.
- Bootstrap `tests.yaml` template — same warning as a comment. **Note:** C002 compares text, so this comment-only edit will show as WARN-only drift on already-bootstrapped connectors until they re-run bootstrap.

Also corrected one stale word in `connector-ci-e2e.md`: the pipeline table said the full-DAG suite is gated on an `e2e-full` label. No such label gate exists anywhere in the repo — it is `e2e` — and that row sits directly above the new section, so leaving it would have been a visible contradiction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
