### PR TITLE
ci(e2e): read app_id without PyYAML, which the e2e legs do not have

### DIFF
--- a/.github/scripts/e2e_tenant_app.py
+++ b/.github/scripts/e2e_tenant_app.py
@@ -297,6 +297,28 @@ def _env(*names: str) -> str:
     return ""
 
 
+#: A TOP-LEVEL ``app_id:`` line. Column-anchored deliberately: an indented
+#: ``app_id`` belongs to some nested block (a per-entrypoint or per-package
+#: stanza), and picking one of those up would install against the wrong app while
+#: looking entirely successful. Optional quotes are stripped and a trailing
+#: comment ignored.
+_APP_ID_LINE_RE = re.compile(r"^app_id[ \t]*:[ \t]*[\"']?([^\"'#\s]+)", re.MULTILINE)
+
+
+def _scan_app_id(text: str) -> str:
+    """Read a top-level ``app_id`` without a YAML parser.
+
+    Not a YAML implementation and not trying to be — it recognises exactly one
+    scalar key at column zero, which is the shape ``atlan.yaml`` uses (the same
+    field ``parse_atlan_yaml.py`` and the ``atlan`` CLI read). Anything it gets
+    wrong is caught immediately: every caller passes the result through
+    ``validate_app_id``, which requires a UUID, so a mis-scan is a loud error
+    rather than a wrong-app install.
+    """
+    match = _APP_ID_LINE_RE.search(text)
+    return match.group(1) if match else ""
+
+
 def resolve_app_id(explicit: str) -> str:
     """Return *explicit* if set, else read ``app_id`` from ``atlan.yaml`` in cwd.
 
@@ -304,10 +326,14 @@ def resolve_app_id(explicit: str) -> str:
     workflow step does not have to scrape another script's stdout to pass an id
     this one can read itself.
 
-    ``yaml`` is imported lazily: the module is otherwise stdlib-only so it can run
-    before the SDK is installed, and this fallback is the only path that needs a
-    parser. A missing PyYAML is reported as such rather than as an ImportError
-    traceback.
+    PyYAML is used when importable and a one-line scan when it is not, because
+    this module must not depend on the environment it happens to run in. It is
+    otherwise stdlib-only, and the two call sites do not share an interpreter: the
+    prepare-tenant job runs on the runner's system Python (PyYAML present), while
+    the per-leg verify runs after ``uv sync`` has put a project venv on PATH
+    (PyYAML absent unless the connector happens to depend on it). Requiring the
+    package meant the version check — the last gate before pytest — died on an
+    import in every e2e leg while working perfectly in the job before it.
     """
     if explicit.strip():
         return explicit.strip()
@@ -318,16 +344,14 @@ def resolve_app_id(explicit: str) -> str:
             "no --app-id given and no atlan.yaml in the working directory "
             f"({Path.cwd()}). Pass --app-id, or run from the app repo root."
         )
+    text = path.read_text(encoding="utf-8")
     try:
-        import yaml  # noqa: PLC0415 — lazy: only this fallback path needs it
-    except ModuleNotFoundError as exc:  # pragma: no cover - present on CI runners
-        raise TenantAppError(
-            "reading app_id from atlan.yaml needs PyYAML, which is not importable. "
-            "Pass --app-id explicitly instead."
-        ) from exc
-
-    parsed = yaml.safe_load(path.read_text(encoding="utf-8"))
-    app_id = parsed.get("app_id", "") if isinstance(parsed, dict) else ""
+        import yaml  # noqa: PLC0415 — lazy: preferred when the env happens to have it
+    except ModuleNotFoundError:
+        app_id = _scan_app_id(text)
+    else:
+        parsed = yaml.safe_load(text)
+        app_id = parsed.get("app_id", "") if isinstance(parsed, dict) else ""
     if not str(app_id).strip():
         raise TenantAppError(
             "atlan.yaml has no app_id. The app has not been registered in the "

--- a/.github/scripts/tests/test_e2e_tenant_app.py
+++ b/.github/scripts/tests/test_e2e_tenant_app.py
@@ -10,6 +10,7 @@ process.
 from __future__ import annotations
 
 import argparse
+import builtins
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -1654,6 +1655,103 @@ def test_a_real_version_alongside_a_placeholder_still_wins() -> None:
     # Order matters: version_text is checked first and is the placeholder here.
     payload = {"installed": {"version_text": "unknown", "version": _VERSION}}
     assert app._extract_version(payload) == _VERSION
+
+
+# ── Reading app_id without PyYAML ────────────────────────────────────────────
+# The two call sites do not share an interpreter: prepare-tenant runs on the
+# runner's system Python (PyYAML present), the per-leg verify runs after
+# `uv sync` has put a project venv on PATH (PyYAML absent). Requiring the package
+# meant the version check — the last gate before pytest — died on an import in
+# every e2e leg while working perfectly in the job before it.
+
+
+@pytest.fixture
+def _no_yaml(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make `import yaml` fail, as it does inside a connector's venv."""
+    real_import = builtins.__import__
+
+    def _fail(name: str, *args: object, **kwargs: object) -> object:
+        if name == "yaml":
+            raise ModuleNotFoundError("No module named 'yaml'")
+        return real_import(name, *args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(builtins, "__import__", _fail)
+
+
+@pytest.mark.usefixtures("_no_yaml")
+def test_app_id_is_read_without_pyyaml(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    (tmp_path / "atlan.yaml").write_text(
+        f"name: openapi\ndisplay_name: OpenAPI\napp_id: {_APP_ID}\n", encoding="utf-8"
+    )
+    monkeypatch.chdir(tmp_path)
+    assert app.resolve_app_id("") == _APP_ID
+
+
+@pytest.mark.parametrize(
+    "line, expected",
+    [
+        (f"app_id: {_APP_ID}", _APP_ID),
+        (f'app_id: "{_APP_ID}"', _APP_ID),
+        (f"app_id: '{_APP_ID}'", _APP_ID),
+        (f"app_id:    {_APP_ID}   # the registered id", _APP_ID),
+        (f"app_id:\t{_APP_ID}", _APP_ID),
+    ],
+)
+def test_the_scan_handles_the_shapes_atlan_yaml_uses(line: str, expected: str) -> None:
+    assert app._scan_app_id(f"name: openapi\n{line}\nport: 8000\n") == expected
+
+
+def test_an_indented_app_id_is_never_picked_up() -> None:
+    """The wrong-app direction, and the only one that could pass silently.
+
+    A nested `app_id` belongs to some inner stanza. Installing against it would
+    look entirely successful while targeting a different app.
+    """
+    text = "name: openapi\nentrypoints:\n  - name: sync\n    app_id: 00000000-dead-beef-0000-000000000000\n"
+    assert app._scan_app_id(text) == ""
+
+
+def test_a_commented_out_app_id_is_not_read() -> None:
+    assert app._scan_app_id(f"# app_id: {_APP_ID}\nname: openapi\n") == ""
+
+
+def test_a_missing_app_id_scans_to_empty() -> None:
+    assert app._scan_app_id("name: openapi\nport: 8000\n") == ""
+
+
+@pytest.mark.usefixtures("_no_yaml")
+def test_a_missing_app_id_still_errors_without_pyyaml(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # The fallback must not turn "no app_id" into a silent empty id.
+    (tmp_path / "atlan.yaml").write_text("name: openapi\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    with pytest.raises(app.TenantAppError, match="no app_id"):
+        app.resolve_app_id("")
+
+
+@pytest.mark.usefixtures("_no_yaml")
+def test_a_mis_scan_cannot_reach_a_request(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """validate_app_id is the backstop: a non-UUID never becomes a request path."""
+    (tmp_path / "atlan.yaml").write_text("app_id: not-a-uuid\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    with pytest.raises(TenantApiError, match="invalid app_id"):
+        app.verify(argparse.Namespace(base_url=_TENANT, app_id="", expected=_VERSION))
+
+
+def test_pyyaml_is_still_preferred_when_present(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # A real parser handles shapes the scan does not; it stays the primary path.
+    (tmp_path / "atlan.yaml").write_text(
+        f"app_id: {_APP_ID}\nnested:\n  app_id: wrong\n", encoding="utf-8"
+    )
+    monkeypatch.chdir(tmp_path)
+    assert app.resolve_app_id("") == _APP_ID
 
 
 # ── Resolving the version through the catalog ────────────────────────────────


### PR DESCRIPTION
The per-leg version check — the last gate before pytest — died at **0s in every e2e leg** ([run 31189457363](https://github.com/atlanhq/atlan-openapi-app/actions/runs/31189457363)):

```
##[error] reading app_id from atlan.yaml needs PyYAML, which is not importable.
          Pass --app-id explicitly instead.
```

…while the identical call in `prepare-tenant`, minutes earlier, worked fine.

## Why one worked and the other did not

The two call sites do not share an interpreter. `prepare-tenant` runs on the runner’s system Python, which has PyYAML. The leg runs **after `uv sync`** has put the connector’s venv on PATH, and PyYAML is only there if the connector happens to depend on it. `openapi` does not.

The module is **stdlib-only by design**, precisely so it can run before or outside an SDK install. Reaching for PyYAML gave it a dependency on whichever environment it landed in — that is the bug. The error message was even accurate, and still useless, because nothing in that step was ever going to pass `--app-id`.

## The fix

PyYAML when importable, a one-line scan when not. The scan is not a YAML implementation and does not try to be: it recognises exactly one scalar key at **column zero**, which is the shape `atlan.yaml` uses and the same field `parse_atlan_yaml.py` and the `atlan` CLI read.

**Column-anchored deliberately.** An indented `app_id` belongs to some nested stanza, and installing against one of those would look entirely successful while targeting a different app. That is the only direction here that could pass silently, so it is the first mutation below. Behind it, `validate_app_id` requires a UUID — so a mis-scan is a loud error rather than a wrong-app install, and there is a test asserting a non-UUID never reaches a request.

## Verification

4 mutations verified red: a nested `app_id` matched, the fallback removed, a missing `app_id` swallowed into empty-but-ok, and a commented-out `app_id` read.

1357 script tests pass; `pre-commit --all-files` clean.

## Where this leaves FND-31

Everything before this gate is now green on a live ARM tenant: multi-arch build → merge → publish → install → `SUCCEEDED` → version resolved and confirmed (`prepare-tenant` completed in **10s** on the converge-by-version no-op). This is the last plumbing failure between the install path and the DAG assertions actually running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)