### PR TITLE
fix(e2e): honour retry_after on retryable responses instead of the fixed gap [FND-130]

### DIFF
--- a/application_sdk/testing/e2e/_errors.py
+++ b/application_sdk/testing/e2e/_errors.py
@@ -22,10 +22,19 @@ from application_sdk.errors.leaves import (
 
 @dataclass(kw_only=True)
 class AtlanApiHttpError(DependencyUnavailableError):
-    """Non-2xx response from the Atlan Automation Engine API."""
+    """Non-2xx response from the Atlan Automation Engine API.
+
+    ``retry_after_seconds`` carries the origin's own backoff request when the
+    response body supplied one (``{"retryable": true, "retry_after": 120}``).
+    Named to match :class:`~application_sdk.errors.leaves.RateLimitedError`'s
+    field of the same meaning. Retry loops honour it instead of their fixed
+    gap; on a terminal raise it stays attached so the operator can see the
+    wait the origin asked for versus the budget the harness had.
+    """
 
     code: ClassVar[str] = "DEPENDENCY_UNAVAILABLE_ATLAN_API"
     service: str | None = "atlan_api"
+    retry_after_seconds: float | None = None
 
 
 @dataclass(kw_only=True)

--- a/application_sdk/testing/e2e/client.py
+++ b/application_sdk/testing/e2e/client.py
@@ -35,6 +35,7 @@ node statuses, ``"Running" | "Pending" | "Scheduled"`` as in-flight.
 from __future__ import annotations
 
 import asyncio
+import math
 import time
 import urllib.error
 import urllib.request
@@ -86,6 +87,27 @@ _SUBMIT_TIMEOUT = 120
 _REQUEST_MAX_ATTEMPTS = 4
 _REQUEST_BACKOFF_SECONDS = 3
 
+# An overloaded tenant answers a retryable 5xx with its own estimate of how
+# long to wait before trying again:
+#
+#     {"retryable": true, "retry_after": 120,
+#      "what_you_should_do": "Wait and retry. Back off for at least 120 s."}
+#
+# The fixed inter-attempt gap used to ignore that, so a 5-attempt / 5 s budget
+# expired ~20 s into a 120 s window: the retry could not succeed by
+# construction whenever the origin was genuinely slow (it only ever helped for
+# blips shorter than the whole budget). We now honour the origin's number,
+# bounded two ways so a pathological value cannot hang a CI leg:
+#
+# * each individual wait is capped at ``_MAX_RETRY_AFTER_SECONDS``;
+# * the total honoured-above-the-fixed-gap wait within one retry loop is capped
+#   at ``_RETRY_AFTER_BUDGET_SECONDS``, after which the remaining attempts fall
+#   back to the caller's fixed gap.
+#
+# The attempt counts stay as they were — the gap was the wrong part.
+_MAX_RETRY_AFTER_SECONDS = 120
+_RETRY_AFTER_BUDGET_SECONDS = 300
+
 # Cadence for "still polling" heartbeat log lines in
 # ``poll_native_status`` — lineage stages take 2-5 min on small
 # datasets and the status string doesn't change during that time, so
@@ -118,6 +140,100 @@ _RUN_GLYPHS = {
     "TimedOut": "⏰",
     "Skipped": "⏭️",
 }
+
+
+# Keys an origin may use for the backoff hint, and the one-level envelopes we
+# have seen it wrapped in. Heracles puts it at the top level; AE's generic
+# error shape nests the detail under ``data`` / ``error``.
+_RETRY_AFTER_KEYS = ("retry_after", "retryAfter")
+_RETRY_AFTER_ENVELOPE_KEYS = ("data", "error", "detail")
+
+
+def _requested_retry_after(body: dict[str, Any] | str | None) -> int | None:
+    """Seconds the origin asked us to wait, or ``None`` when it didn't ask.
+
+    Reads ``retry_after`` from the response body — top level, or nested one
+    level inside a ``data`` / ``error`` / ``detail`` envelope. Fractional
+    values round up (a hint of 0.5 s means "at least half a second", so
+    truncating it to 0 would be wrong). Anything non-numeric or non-positive
+    is treated as absent: a hint we cannot act on must leave the caller's
+    fixed gap in place rather than collapse the wait to zero.
+    """
+    if not isinstance(body, dict):
+        return None
+    candidates: list[Any] = [body.get(key) for key in _RETRY_AFTER_KEYS]
+    for envelope_key in _RETRY_AFTER_ENVELOPE_KEYS:
+        envelope = body.get(envelope_key)
+        if isinstance(envelope, dict):
+            candidates.extend(envelope.get(key) for key in _RETRY_AFTER_KEYS)
+    for value in candidates:
+        # bool is an int subclass — `retryable: true` must not read as 1 s.
+        if isinstance(value, bool) or not isinstance(value, (int, float, str)):
+            continue
+        try:
+            seconds = math.ceil(float(value))
+        except (ValueError, OverflowError):
+            # Non-numeric string, or inf/nan. Benign: an unreadable hint just
+            # leaves the caller's fixed gap in place, so probe the next
+            # candidate key rather than failing the retry.
+            logger.debug(
+                "ignoring unusable retry_after value %r in response body",
+                value,
+                exc_info=True,
+            )
+            continue
+        if seconds > 0:
+            return seconds
+    return None
+
+
+@dataclass(frozen=True)
+class _RetryGap:
+    """How long to wait before the next attempt, and what the origin asked for."""
+
+    seconds: int
+    # What the body requested, before capping. ``None`` when it carried no
+    # hint, in which case ``seconds`` is the caller's fixed gap.
+    requested: int | None
+
+    @property
+    def origin_note(self) -> str:
+        """Log fragment naming the origin's request, empty when it made none."""
+        if self.requested is None:
+            return ""
+        if self.requested == self.seconds:
+            return " (origin asked for this)"
+        return f" (origin asked for {self.requested}s, capped)"
+
+
+def _retry_gap(
+    requested: float | None,
+    *,
+    default_seconds: int,
+    budget_left: int,
+) -> _RetryGap:
+    """Pick the wait before the next attempt, honouring the origin's request.
+
+    Returns the caller's ``default_seconds`` when the origin asked for nothing
+    usable. Otherwise returns the requested wait clamped to
+    ``_MAX_RETRY_AFTER_SECONDS`` and to ``budget_left`` — and never below
+    ``default_seconds``, so honouring a hint can only ever lengthen the gap,
+    never shorten it below what the loop already guaranteed.
+
+    Args:
+        requested: Seconds the origin asked for, from
+            :func:`_requested_retry_after` or an error's
+            ``retry_after_seconds``. ``None`` / non-positive means no request.
+        default_seconds: The loop's own fixed gap — the floor, and the answer
+            when there is no request.
+        budget_left: Seconds of above-the-floor waiting still permitted in
+            this loop. Zero (or less) degrades cleanly to ``default_seconds``.
+    """
+    if requested is None or requested <= 0:
+        return _RetryGap(seconds=default_seconds, requested=None)
+    wanted = math.ceil(requested)
+    allowed = min(wanted, _MAX_RETRY_AFTER_SECONDS, max(budget_left, 0))
+    return _RetryGap(seconds=max(default_seconds, allowed), requested=wanted)
 
 
 def _is_credential_name_conflict(status: int, body: dict[str, Any] | str) -> bool:
@@ -462,7 +578,12 @@ class AEWorkflowClient:
             path: URL path relative to ``self.tenant_url``.
             body: Optional JSON-serialisable request body.
             total_attempts: Maximum number of calls (1 initial + N retries).
-            sleep_seconds: Seconds to sleep between attempts.
+            sleep_seconds: Seconds to sleep between attempts. A response that
+                asks for a longer wait via ``retry_after`` overrides it for
+                that attempt, bounded by ``_MAX_RETRY_AFTER_SECONDS`` and the
+                per-call ``_RETRY_AFTER_BUDGET_SECONDS`` (see
+                :func:`_retry_gap`). A timeout has no body to read, so it
+                always uses the fixed gap.
             retryable: Called with ``(status, body)`` after each response.
                 Return True to retry — works for both non-2xx status codes
                 and 2xx responses with an unexpected body shape.  Return
@@ -478,6 +599,9 @@ class AEWorkflowClient:
                 server already accepted the request spawns a duplicate run.
         """
         last: tuple[int, dict[str, Any] | str] = (0, {})
+        # Seconds spent waiting *beyond* the fixed gap because the origin asked
+        # for longer. Bounds the total honoured backoff across the whole call.
+        honoured_seconds = 0
         for attempt in range(1, total_attempts + 1):
             try:
                 status, resp_body = self._request(
@@ -522,18 +646,25 @@ class AEWorkflowClient:
                     )
                 return last
             if is_retry and attempt < total_attempts:
+                gap = _retry_gap(
+                    _requested_retry_after(resp_body),
+                    default_seconds=sleep_seconds,
+                    budget_left=_RETRY_AFTER_BUDGET_SECONDS - honoured_seconds,
+                )
+                honoured_seconds += gap.seconds - sleep_seconds
                 logger.warning(
-                    "%s attempt %d/%d: HTTP %d — retrying in %ds  body=%r",
+                    "%s attempt %d/%d: HTTP %d — retrying in %ds%s  body=%r",
                     op_name,
                     attempt,
                     total_attempts,
                     status,
-                    sleep_seconds,
+                    gap.seconds,
+                    gap.origin_note,
                     resp_body,
                 )
                 if mutate_before_retry is not None:
                     mutate_before_retry(body)
-                time.sleep(sleep_seconds)
+                time.sleep(gap.seconds)
                 continue
             break
         return last
@@ -556,7 +687,10 @@ class AEWorkflowClient:
         existing workflow's slug.
 
         Retries on HTTP 5xx and timeout. 4 retries at 5s intervals covers
-        the typical AE recovery window without sitting on a hard failure.
+        the typical AE recovery window without sitting on a hard failure —
+        and when an overloaded origin names its own window via
+        ``retry_after``, the gap stretches to match it (see
+        :func:`_retry_gap`) instead of expiring the whole budget inside it.
 
         Returns:
             The workflow slug (used by subsequent version + submit calls).
@@ -581,6 +715,7 @@ class AEWorkflowClient:
         raise AtlanApiHttpError(
             message=f"create_workflow failed: HTTP {status}\nresponse={body!r}",
             target=f"POST /automation/api/v1/workflows HTTP {status}",
+            retry_after_seconds=_requested_retry_after(body),
         )
 
     def create_version(
@@ -621,6 +756,7 @@ class AEWorkflowClient:
         raise AtlanApiHttpError(
             message=f"create_version failed: HTTP {status}\nresponse={body!r}",
             target=f"POST /automation/api/v1/workflows/.../versions HTTP {status}",
+            retry_after_seconds=_requested_retry_after(body),
         )
 
     def publish_version(
@@ -651,6 +787,7 @@ class AEWorkflowClient:
         raise AtlanApiHttpError(
             message=f"publish_version failed after {retries} attempts: {body!r}",
             target="POST /automation/api/v1/workflows/.../versions/.../publish",
+            retry_after_seconds=_requested_retry_after(body),
         )
 
     def submit_workflow(
@@ -729,6 +866,7 @@ class AEWorkflowClient:
         raise AtlanApiHttpError(
             message=f"AE submit failed: HTTP {status}\nresponse={body!r}",
             target=f"POST /api/service/package-workflows?submit=true HTTP {status}",
+            retry_after_seconds=_requested_retry_after(body),
         )
 
     def get_native_status(self, run_id: str) -> DAGRunResult:
@@ -746,6 +884,9 @@ class AEWorkflowClient:
             raise AtlanApiHttpError(
                 message=f"native-status failed: HTTP {status}\nresponse={body!r}",
                 target=f"GET /api/service/package-workflows/native-status HTTP {status}",
+                # Carried so poll_native_status can back off for as long as the
+                # origin asked instead of its fixed poll cadence.
+                retry_after_seconds=_requested_retry_after(body),
             )
         nodes_raw = body.get("dag_nodes") or {}
         nodes = [
@@ -790,6 +931,11 @@ class AEWorkflowClient:
         on a single bad response. After ``max_transient_failures``
         consecutive errors we give up and re-raise — that's a
         sustained outage, not a blip, and there's no point waiting.
+        When the failing response names a ``retry_after``, the next poll
+        waits that long instead of ``interval_seconds``, so an origin asking
+        for a 2-minute backoff doesn't consume the whole failure streak
+        inside its own wait window. ``timeout_seconds`` still bounds the
+        loop — the longer sleeps count against it.
 
         Fail-fast stall guard: when ``stall_grace_seconds`` is a positive int
         (``None`` or any value ``<= 0`` disables it) and NO DAG node has left the
@@ -837,16 +983,28 @@ class AEWorkflowClient:
                         exc_info=True,
                     )
                     raise
+                # Back off for as long as the origin asked when it said so,
+                # rather than the poll cadence: an overloaded tenant answering
+                # "retry_after: 120" would otherwise burn the whole
+                # max_transient_failures streak inside its own wait window.
+                # ``elapsed`` advances by the real wait, so timeout_seconds
+                # still bounds the loop.
+                gap = _retry_gap(
+                    e.retry_after_seconds if isinstance(e, AtlanApiHttpError) else None,
+                    default_seconds=interval_seconds,
+                    budget_left=_RETRY_AFTER_BUDGET_SECONDS,
+                )
                 logger.warning(
-                    "native-status transient error (streak %d/%d): %s — sleeping %ds and retrying",
+                    "native-status transient error (streak %d/%d): %s — sleeping %ds%s and retrying",
                     transient_streak,
                     max_transient_failures,
                     e,
-                    interval_seconds,
+                    gap.seconds,
+                    gap.origin_note,
                     exc_info=True,
                 )
-                time.sleep(interval_seconds)
-                elapsed += interval_seconds
+                time.sleep(gap.seconds)
+                elapsed += gap.seconds
                 continue
             transient_streak = 0
             last_result = result

--- a/application_sdk/testing/e2e/client.py
+++ b/application_sdk/testing/e2e/client.py
@@ -203,6 +203,11 @@ class _RetryGap:
             return ""
         if self.requested == self.seconds:
             return " (origin asked for this)"
+        if self.requested < self.seconds:
+            # The wait is longer than the origin asked for: either the fixed
+            # gap floored it (small request) or the per-loop budget did. Never
+            # a cap — a cap can only shorten the wait, this one lengthened it.
+            return f" (origin asked for {self.requested}s; floored at {self.seconds}s)"
         return f" (origin asked for {self.requested}s, capped)"
 
 
@@ -934,8 +939,11 @@ class AEWorkflowClient:
         When the failing response names a ``retry_after``, the next poll
         waits that long instead of ``interval_seconds``, so an origin asking
         for a 2-minute backoff doesn't consume the whole failure streak
-        inside its own wait window. ``timeout_seconds`` still bounds the
-        loop — the longer sleeps count against it.
+        inside its own wait window. Honoured waiting is capped per poll loop
+        at ``_RETRY_AFTER_BUDGET_SECONDS`` (same accounting as
+        ``_post_with_retry``) and each sleep is clamped to the remaining
+        ``timeout_seconds`` budget, so the loop never sleeps past its own
+        deadline.
 
         Fail-fast stall guard: when ``stall_grace_seconds`` is a positive int
         (``None`` or any value ``<= 0`` disables it) and NO DAG node has left the
@@ -964,6 +972,10 @@ class AEWorkflowClient:
         last_summary: str | None = None
         last_result: DAGRunResult | None = None
         transient_streak = 0
+        # Seconds spent waiting *beyond* the poll interval because the origin
+        # asked for longer — same accounting ``_post_with_retry`` keeps, so
+        # both retry loops bound honoured backoff at _RETRY_AFTER_BUDGET_SECONDS.
+        honoured_seconds = 0
         last_log_elapsed = 0  # seconds since the last info log fired
         any_node_started = False  # any node reached Running/terminal (stall guard)
         last_progress_elapsed = (
@@ -992,19 +1004,24 @@ class AEWorkflowClient:
                 gap = _retry_gap(
                     e.retry_after_seconds if isinstance(e, AtlanApiHttpError) else None,
                     default_seconds=interval_seconds,
-                    budget_left=_RETRY_AFTER_BUDGET_SECONDS,
+                    budget_left=_RETRY_AFTER_BUDGET_SECONDS - honoured_seconds,
                 )
+                honoured_seconds += gap.seconds - interval_seconds
+                # Never sleep past the deadline: a 120s honoured wait against
+                # a 50s remaining budget must not block the full 120s before
+                # the timeout is re-checked.
+                sleep_for = min(gap.seconds, max(timeout_seconds - elapsed, 0))
                 logger.warning(
                     "native-status transient error (streak %d/%d): %s — sleeping %ds%s and retrying",
                     transient_streak,
                     max_transient_failures,
                     e,
-                    gap.seconds,
+                    sleep_for,
                     gap.origin_note,
                     exc_info=True,
                 )
-                time.sleep(gap.seconds)
-                elapsed += gap.seconds
+                time.sleep(sleep_for)
+                elapsed += sleep_for
                 continue
             transient_streak = 0
             last_result = result

--- a/tests/unit/testing/e2e/test_client.py
+++ b/tests/unit/testing/e2e/test_client.py
@@ -576,6 +576,9 @@ class TestRetryGap:
         gap = _retry_gap(1, default_seconds=10, budget_left=300)
         assert gap.seconds == 10
         assert gap.requested == 1
+        # The wait is the floor, not a cap — the note must not say "capped".
+        assert "floored" in gap.origin_note
+        assert "capped" not in gap.origin_note
 
     def test_caps_a_pathological_request(self):
         gap = _retry_gap(86400, default_seconds=5, budget_left=100_000)
@@ -749,9 +752,67 @@ class TestPollNativeStatusHonoursRetryAfter:
                 timeout_seconds=200,
                 max_transient_failures=5,
             )
-        # 120s per honoured backoff: two of them exhaust a 200s budget, so the
-        # loop exits on timeout rather than running the full failure streak.
-        assert [call.args[0] for call in mock_sleep.call_args_list] == [120, 120]
+        # Each honoured sleep is clamped to the remaining timeout budget:
+        # 120s requested against a 200s deadline sleeps 120s, then only 80s,
+        # so the loop exits exactly at the deadline rather than overshooting.
+        assert [call.args[0] for call in mock_sleep.call_args_list] == [120, 80]
+
+    def test_honoured_wait_is_clamped_to_the_remaining_timeout(self):
+        """timeout_seconds < retry_after: the first sleep stops at the deadline."""
+        client = _make_client()
+        err = AtlanApiHttpError(
+            message="native-status failed: HTTP 504",
+            target="GET /api/service/package-workflows/native-status HTTP 504",
+            retry_after_seconds=120,
+        )
+        with (
+            patch.object(client, "get_native_status", side_effect=[err] * 10),
+            patch("time.sleep") as mock_sleep,
+            pytest.raises(AtlanApiTimeoutError),
+        ):
+            client.poll_native_status(
+                _RUN_ID,
+                interval_seconds=10,
+                timeout_seconds=50,
+                max_transient_failures=5,
+            )
+        # 50s remain and the origin asked for 120s: one clamped 50s sleep
+        # reaches the deadline exactly; the loop never sleeps past it.
+        assert [call.args[0] for call in mock_sleep.call_args_list] == [50]
+
+    def test_honoured_backoff_is_budgeted_across_the_poll_loop(self):
+        """A tenant repeating retry_after: 120 exhausts the shared budget, then
+        the loop falls back to the poll cadence — same accounting as
+        _post_with_retry."""
+        client = _make_client()
+        err = AtlanApiHttpError(
+            message="native-status failed: HTTP 504",
+            target="GET /api/service/package-workflows/native-status HTTP 504",
+            retry_after_seconds=120,
+        )
+        with (
+            patch.object(client, "get_native_status", side_effect=[err] * 10),
+            patch("time.sleep") as mock_sleep,
+            pytest.raises(AtlanApiHttpError),
+        ):
+            client.poll_native_status(
+                _RUN_ID,
+                interval_seconds=10,
+                timeout_seconds=10000,
+                max_transient_failures=5,
+            )
+        # 110s honoured per wait against the 300s budget: two full 120s waits
+        # (110 + 110 honoured), a third clamped to the 80s of budget left
+        # (the budget caps the whole wait, not just the above-floor part, so
+        # 110 + 110 + 80 = 300), then the fixed 10s cadence once the budget
+        # is spent — no unbounded 120s waits. The fifth error hits the
+        # transient-failure cap and re-raises.
+        assert [call.args[0] for call in mock_sleep.call_args_list] == [
+            120,
+            120,
+            80,
+            10,
+        ]
 
 
 class _FakeResponse:

--- a/tests/unit/testing/e2e/test_client.py
+++ b/tests/unit/testing/e2e/test_client.py
@@ -21,7 +21,9 @@ from application_sdk.testing.e2e._errors import (
     NoWorkerOnTaskQueueError,
 )
 from application_sdk.testing.e2e.client import (
+    _MAX_RETRY_AFTER_SECONDS,
     _REQUEST_MAX_ATTEMPTS,
+    _RETRY_AFTER_BUDGET_SECONDS,
     AEWorkflowClient,
     DAGNodeResult,
     DAGNodeStatus,
@@ -29,6 +31,8 @@ from application_sdk.testing.e2e.client import (
     DAGRunStatus,
     _is_already_active_run,
     _is_credential_name_conflict,
+    _requested_retry_after,
+    _retry_gap,
     _rotate_submit_credential_name,
     _safe_node_status,
     _safe_run_status,
@@ -497,6 +501,257 @@ class TestPostWithRetry:
         assert status == 200
         assert isinstance(body, dict) and body.get("status") == "success"
         mock_sleep.assert_called_once()
+
+
+# The exact body an overloaded tenant returned behind the 504s in the incident
+# this behaviour was written for: five attempts 5s apart spent the whole retry
+# budget ~20s into the 120s window the origin had asked for.
+_OVERLOADED_504_BODY = {
+    "retryable": True,
+    "retry_after": 120,
+    "what_you_should_do": "**Wait and retry.** Back off for at least 120 seconds.",
+}
+
+
+class TestRequestedRetryAfter:
+    """_requested_retry_after: what counts as the origin asking us to wait."""
+
+    @pytest.mark.parametrize(
+        ("body", "expected"),
+        [
+            (_OVERLOADED_504_BODY, 120),
+            ({"retryAfter": 30}, 30),
+            ({"retry_after": "45"}, 45),
+            # Fractional hints round up — 0.5s means "at least half a second",
+            # so truncating to 0 would drop the hint entirely.
+            ({"retry_after": 0.5}, 1),
+            ({"retry_after": 1.2}, 2),
+            # One level of envelope nesting, as AE's generic error shape uses.
+            ({"data": {"retry_after": 60}}, 60),
+            ({"error": {"retryAfter": 15}}, 15),
+            ({"detail": {"retry_after": 7}}, 7),
+        ],
+    )
+    def test_extracts_hint(self, body, expected):
+        assert _requested_retry_after(body) == expected
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            {},
+            {"retryable": True},
+            {"retry_after": 0},
+            {"retry_after": -5},
+            {"retry_after": None},
+            {"retry_after": "soon"},
+            # bool is an int subclass — `retry_after: true` must not read as 1s.
+            {"retry_after": True},
+            # Nested more than one level deep: not a shape we've seen, and
+            # guessing at arbitrary depth risks reading an unrelated field.
+            {"data": {"error": {"retry_after": 60}}},
+            "504 Gateway Timeout",
+            None,
+        ],
+    )
+    def test_no_usable_hint(self, body):
+        assert _requested_retry_after(body) is None
+
+
+class TestRetryGap:
+    """_retry_gap: honour the origin's wait, bounded so it can't hang a leg."""
+
+    def test_no_request_uses_the_fixed_gap(self):
+        gap = _retry_gap(None, default_seconds=5, budget_left=300)
+        assert gap.seconds == 5
+        assert gap.requested is None
+        assert gap.origin_note == ""
+
+    def test_honours_the_requested_wait(self):
+        gap = _retry_gap(120, default_seconds=5, budget_left=300)
+        assert gap.seconds == 120
+        assert gap.requested == 120
+
+    def test_fixed_gap_is_a_floor_not_a_ceiling(self):
+        """A request shorter than the loop's own gap doesn't shorten it."""
+        gap = _retry_gap(1, default_seconds=10, budget_left=300)
+        assert gap.seconds == 10
+        assert gap.requested == 1
+
+    def test_caps_a_pathological_request(self):
+        gap = _retry_gap(86400, default_seconds=5, budget_left=100_000)
+        assert gap.seconds == _MAX_RETRY_AFTER_SECONDS
+        assert gap.requested == 86400
+        assert "capped" in gap.origin_note
+
+    def test_clamps_to_remaining_budget(self):
+        gap = _retry_gap(120, default_seconds=5, budget_left=70)
+        assert gap.seconds == 70
+
+    @pytest.mark.parametrize("budget_left", [0, -30])
+    def test_exhausted_budget_degrades_to_the_fixed_gap(self, budget_left):
+        gap = _retry_gap(120, default_seconds=5, budget_left=budget_left)
+        assert gap.seconds == 5
+
+
+class TestPostWithRetryHonoursRetryAfter:
+    """The regression this behaviour exists for: a 5xx that names its own window.
+
+    Before, ``_post_with_retry`` slept its fixed gap regardless, so the whole
+    attempt budget expired inside the window the origin had asked us to wait
+    out — the retry could not succeed by construction.
+    """
+
+    def test_sleeps_for_the_window_the_origin_asked_for(self):
+        client = _make_client()
+        with (
+            patch.object(
+                client,
+                "_request",
+                side_effect=[(504, _OVERLOADED_504_BODY), (200, {"ok": True})],
+            ),
+            patch("time.sleep") as mock_sleep,
+        ):
+            status, _ = client._post_with_retry(
+                "/some/path",
+                total_attempts=2,
+                sleep_seconds=5,
+                retryable=lambda s, b: s >= 500,
+                op_name="test_op",
+            )
+        assert status == 200
+        mock_sleep.assert_called_once_with(120)
+
+    def test_5xx_without_a_hint_still_uses_the_fixed_gap(self):
+        client = _make_client()
+        with (
+            patch.object(
+                client,
+                "_request",
+                side_effect=[(503, {"err": "overloaded"}), (200, {"ok": True})],
+            ),
+            patch("time.sleep") as mock_sleep,
+        ):
+            client._post_with_retry(
+                "/some/path",
+                total_attempts=2,
+                sleep_seconds=5,
+                retryable=lambda s, b: s >= 500,
+                op_name="test_op",
+            )
+        mock_sleep.assert_called_once_with(5)
+
+    def test_honoured_waiting_is_capped_per_call(self):
+        """A tenant asking for 120s on every attempt can't stall a leg forever.
+
+        The first attempts honour the request; once the per-call honoured
+        budget is spent the remaining attempts fall back to the fixed gap, so
+        total honoured-above-the-gap waiting stays at
+        ``_RETRY_AFTER_BUDGET_SECONDS``.
+        """
+        client = _make_client()
+        attempts = 5
+        fixed_gap = 5
+        with (
+            patch.object(client, "_request", return_value=(504, _OVERLOADED_504_BODY)),
+            patch("time.sleep") as mock_sleep,
+        ):
+            status, _ = client._post_with_retry(
+                "/some/path",
+                total_attempts=attempts,
+                sleep_seconds=fixed_gap,
+                retryable=lambda s, b: s >= 500,
+                op_name="test_op",
+            )
+        assert status == 504
+        slept = [call.args[0] for call in mock_sleep.call_args_list]
+        # One sleep per attempt except the last — the attempt count is
+        # unchanged by honouring the hint; only the gaps are.
+        assert len(slept) == attempts - 1
+        assert max(slept) == _MAX_RETRY_AFTER_SECONDS
+        honoured = sum(gap - fixed_gap for gap in slept)
+        assert honoured <= _RETRY_AFTER_BUDGET_SECONDS
+        # Two full 120s waits, a third clipped to what's left of the budget,
+        # then back on the fixed gap for the rest.
+        assert slept == [120, 120, 70, fixed_gap]
+
+    def test_terminal_error_carries_the_requested_wait(self):
+        """create_workflow's raise keeps the hint for the operator to see."""
+        client = _make_client()
+        with (
+            patch.object(client, "_request", return_value=(504, _OVERLOADED_504_BODY)),
+            patch("time.sleep"),
+            pytest.raises(AtlanApiHttpError) as excinfo,
+        ):
+            client.create_workflow("wf-name", retries=1, retry_sleep_seconds=1)
+        assert excinfo.value.retry_after_seconds == 120
+
+
+class TestPollNativeStatusHonoursRetryAfter:
+    """The same fixed-gap bug in the poll loop: a 120s hint must not burn the
+    transient-failure streak inside the origin's own wait window."""
+
+    def test_backs_off_for_the_requested_window(self):
+        client = _make_client()
+        err = AtlanApiHttpError(
+            message="native-status failed: HTTP 504",
+            target="GET /api/service/package-workflows/native-status HTTP 504",
+            retry_after_seconds=120,
+        )
+        with (
+            patch.object(
+                client, "get_native_status", side_effect=[err, _succeeded_result()]
+            ),
+            patch("time.sleep") as mock_sleep,
+        ):
+            result = client.poll_native_status(
+                _RUN_ID,
+                interval_seconds=10,
+                timeout_seconds=600,
+                max_transient_failures=5,
+            )
+        assert result.status == DAGRunStatus.SUCCEEDED
+        mock_sleep.assert_called_once_with(120)
+
+    def test_hintless_error_keeps_the_poll_cadence(self):
+        client = _make_client()
+        with (
+            patch.object(
+                client,
+                "get_native_status",
+                side_effect=[_http_error(), _succeeded_result()],
+            ),
+            patch("time.sleep") as mock_sleep,
+        ):
+            client.poll_native_status(
+                _RUN_ID,
+                interval_seconds=10,
+                timeout_seconds=600,
+                max_transient_failures=5,
+            )
+        mock_sleep.assert_called_once_with(10)
+
+    def test_long_backoff_counts_against_the_poll_timeout(self):
+        """Honouring a long wait must not let the loop outlive timeout_seconds."""
+        client = _make_client()
+        err = AtlanApiHttpError(
+            message="native-status failed: HTTP 504",
+            target="GET /api/service/package-workflows/native-status HTTP 504",
+            retry_after_seconds=120,
+        )
+        with (
+            patch.object(client, "get_native_status", side_effect=[err] * 10),
+            patch("time.sleep") as mock_sleep,
+            pytest.raises(AtlanApiTimeoutError),
+        ):
+            client.poll_native_status(
+                _RUN_ID,
+                interval_seconds=10,
+                timeout_seconds=200,
+                max_transient_failures=5,
+            )
+        # 120s per honoured backoff: two of them exhaust a 200s budget, so the
+        # loop exits on timeout rather than running the full failure streak.
+        assert [call.args[0] for call in mock_sleep.call_args_list] == [120, 120]
 
 
 class _FakeResponse:


### PR DESCRIPTION
### Changelog

- **`_post_with_retry` honours `retry_after`.** An overloaded tenant answers a retryable 5xx with its own backoff request (`{"retryable": true, "retry_after": 120}`). The harness ignored it and slept its fixed 5s gap, so a 5-attempt budget expired ~20s into the 120s window the origin had asked us to wait out — the retry could not succeed by construction whenever the origin was genuinely slow, only when the blip was shorter than the whole budget. Covers `create_workflow`, `create_version`, `publish_version`, `submit_workflow`.
- **`poll_native_status` honours it too** — a second instance of the same defect. At `interval_seconds=10` / `max_transient_failures=5`, an origin asking for 120s burnt the entire transient-failure streak in 50s and aborted a *live* run, which is worse than the create-path symptom: it kills a run mid-flight rather than at setup. The hint reaches the loop on a new `retry_after_seconds` field on `AtlanApiHttpError`, named after the existing `RateLimitedError.retry_after_seconds`, which already means exactly this. The longer sleeps count against `timeout_seconds`, so the poll stays bounded.
- **Attempt counts are unchanged** — only the gaps move.
- **Two bounds keep a pathological value from hanging a CI leg:** 120s per individual wait, *and* 300s of above-the-gap waiting per loop, after which the remaining attempts fall back to the fixed gap. A per-wait cap alone still lets `attempts × 120s` stack across four write calls into tens of minutes of wall-clock against a dead tenant.
- **A hint can only lengthen a gap, never shorten it** below what the loop already guaranteed — so a buggy `retry_after: 0.001` can't turn a retry into a hot loop.
- **Terminal `AtlanApiHttpError` raises keep the hint attached,** so a failure report shows the wait the origin asked for against the budget the harness had.
- Parsing tolerates `retry_after`/`retryAfter`, numeric strings, and one level of `data`/`error`/`detail` envelope; fractions round up. Non-numeric, non-positive, and `true` (bool is an int subclass) all read as "no hint".

### Additional context

- Linear: [FND-130](https://linear.app/atlan-epd/issue/FND-130/e2e-harness-ignores-retry-after-on-5xx-so-its-whole-retry-budget) — decisions and rationale are recorded there as a comment.
- Surfaced during the FND-31 pilot: `create_workflow attempt 1..4/5: HTTP 504 — retrying in 5s`, against a body explicitly asking for 120s. That run passed on a straight re-run, so this was never blocking — it just makes the suite fragile under exactly the tenant conditions it is most likely to meet.
- **Scoped out — the RFC `Retry-After` header.** Honouring it means changing `_request`'s return arity for every caller and test fake. The Cloudflare 504s we actually hit carry no such header, and 429 (where the header is the norm) isn't in any `retryable` predicate today. Worth revisiting if we start retrying 429s.
- Test-only surface: nothing here runs in a connector's production path.

### Checklist

- [x] Additional tests added
- [ ] All CI checks passed
- [x] Relevant documentation updated <!-- docstrings on the touched methods; no conceptual doc references these knobs -->

Verification run locally: 242 tests pass in `tests/unit/testing/e2e/` (20 new, including a regression test built on the exact 504 body from the incident run — asserts a 120s sleep, not 5s — and a budget-exhaustion test pinning the gap sequence `[120, 120, 70, 5]`). pre-commit clean (ruff, ruff-format, isort, pyright). `conformance detect` clean on the touched files; the four remaining hits there are pre-existing and already suppressed.

---

### Copyleft License Compliance

- [ ] Have you used any code that is subject to a Copyleft license (e.g., GPL, AGPL, LGPL)?
- [ ] If yes, have you modified the code in the context of this project? please share additional details.
