### PR TITLE
ci: attribute marketplace releases to the human who merged the release PR

### DIFF
--- a/.github/scripts/resolve_release_actor.py
+++ b/.github/scripts/resolve_release_actor.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Resolve the human to attribute a Global Marketplace release to.
+
+Why this exists
+---------------
+GM renders the ``created_by`` field of a publish body as the *Created by:* line
+of the "Release pending approval" Slack message, and @-mentions that person so
+the release actually reaches someone who can approve it. GM resolves the field
+as: work email -> Slack email lookup, else GitHub login -> its static
+``GH_USERNAME_TO_SLACK_ID`` map, else plain text with no mention.
+
+Every automated release in the fleet is cut by the ``atlan-app-fleet`` GitHub
+App: ``release-version-bump.yaml`` opens the bump PR as the App, and
+``tag-and-release.yaml`` creates the GitHub Release with the App's token. So on
+the ``release: published`` build that actually publishes, ``triggering_actor``
+is ``atlan-app-fleet[bot]`` — a login GM cannot map to a Slack user, which is
+why those messages mention nobody.
+
+The human in that chain is whoever *merged* the release PR. This script walks
+the build SHA back to its pull request and prefers that merger.
+
+Resolution chain
+----------------
+For ``workflow_dispatch``/``schedule`` the trigger is a deliberate human act, so
+the triggering actor is the most accurate attribution and is tried first. For
+every other event (``push``, ``release``) the trigger is automation, so the PR
+merger leads:
+
+    deliberate events:  triggering_actor -> merged_by -> PR author
+    automated events:   merged_by -> PR author -> triggering_actor
+
+Bots are skipped at every position; if nothing human is found the output is
+empty and the caller omits ``created_by`` entirely (GM already treats absent as
+"no attribution" and falls back to plain text).
+
+Note that ``GET /repos/{repo}/commits/{sha}/pulls`` does *not* carry
+``merged_by`` — only the single-PR endpoint does — hence the second call.
+
+This script never fails the build: a release must not be blocked because an
+attribution lookup 404'd. All errors degrade to a less specific actor, or to
+no actor at all.
+
+Environment:
+    GITHUB_REPOSITORY   ``owner/repo`` of the app being released
+    GITHUB_SHA          commit the build is for
+    GITHUB_EVENT_NAME   event that triggered the run
+    TRIGGERING_ACTOR    ``github.triggering_actor``
+    GH_TOKEN            consumed by ``gh`` for auth (not read here directly)
+    GITHUB_OUTPUT       written with ``created_by=<login-or-email>``
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from collections.abc import Callable
+from typing import Any
+
+Runner = Callable[..., subprocess.CompletedProcess]
+
+#: Events where the run was started by a person doing something on purpose, so
+#: the triggering actor outranks anything inferred from git history.
+DELIBERATE_EVENTS = frozenset({"workflow_dispatch", "schedule", "repository_dispatch"})
+
+
+def is_bot(user: dict[str, Any] | None) -> bool:
+    """True when a GitHub user object is a bot rather than a person.
+
+    Checks both signals because they disagree in practice: GitHub App identities
+    report ``type: "Bot"`` and carry a ``[bot]`` login suffix, but a login is all
+    we have when the actor came from ``github.triggering_actor`` and was never
+    looked up.
+    """
+    if not user:
+        return True
+    if str(user.get("type", "")).lower() == "bot":
+        return True
+    return str(user.get("login", "")).endswith("[bot]")
+
+
+def gh_api(path: str, runner: Runner = subprocess.run) -> Any | None:
+    """GET a GitHub API path, returning parsed JSON or None on any failure.
+
+    ``gh api`` writes its JSON *error* body to stdout on a non-2xx, so the
+    return code — not the presence of output — decides success. Without that
+    gate an error payload would parse cleanly and be mistaken for a result.
+    """
+    try:
+        result = runner(
+            ["gh", "api", path],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except OSError as e:  # gh missing from the runner image
+        print(f"::warning::gh api {path} could not run: {e}")
+        return None
+    if result.returncode != 0:
+        stderr = (result.stderr or "").strip().splitlines()
+        detail = stderr[-1] if stderr else f"exit {result.returncode}"
+        print(f"::warning::gh api {path} failed: {detail}")
+        return None
+    try:
+        return json.loads(result.stdout or "null")
+    except json.JSONDecodeError:
+        print(f"::warning::gh api {path} returned non-JSON output")
+        return None
+
+
+def find_pull_request(
+    repo: str, sha: str, runner: Runner = subprocess.run
+) -> dict[str, Any] | None:
+    """Return the full PR object for the PR that put ``sha`` on its branch.
+
+    Two calls: the list endpoint maps commit -> PR but omits ``merged_by``, so
+    the winning number is re-fetched through the single-PR endpoint.
+
+    The list can hold more than one PR when a commit is reachable from several
+    (e.g. a branch merged into another branch that was then merged to main), so
+    prefer the PR whose own merge commit *is* this SHA before falling back to
+    the first entry.
+    """
+    if not repo or not sha:
+        return None
+    candidates = gh_api(f"repos/{repo}/commits/{sha}/pulls", runner)
+    if not isinstance(candidates, list) or not candidates:
+        return None
+    exact = [
+        c
+        for c in candidates
+        if isinstance(c, dict) and c.get("merge_commit_sha") == sha
+    ]
+    chosen = (exact or candidates)[0]
+    number = chosen.get("number") if isinstance(chosen, dict) else None
+    if not number:
+        return None
+    full = gh_api(f"repos/{repo}/pulls/{number}", runner)
+    # Fall back to the list entry when the detail fetch fails — it still carries
+    # the PR author, which is one rung down the chain but better than nothing.
+    return full if isinstance(full, dict) else chosen
+
+
+def public_email(login: str, runner: Runner = subprocess.run) -> str:
+    """Return the user's public GitHub email, or "" when they publish none.
+
+    Worth the extra call even though most Atlan members keep their email
+    private: GM's email path resolves *any* Slack user, while the login path
+    only resolves logins present in its hand-maintained map. An email, when we
+    can get one, is strictly the better identifier.
+    """
+    if not login:
+        return ""
+    user = gh_api(f"users/{login}", runner)
+    if not isinstance(user, dict):
+        return ""
+    return str(user.get("email") or "").strip()
+
+
+def resolve_actor(
+    repo: str,
+    sha: str,
+    event_name: str,
+    triggering_actor: str,
+    runner: Runner = subprocess.run,
+) -> str:
+    """Return the login to attribute the release to, or "" if none is human."""
+    actor_user = {"login": triggering_actor} if triggering_actor else None
+
+    pr = find_pull_request(repo, sha, runner)
+    merger = pr.get("merged_by") if isinstance(pr, dict) else None
+    author = pr.get("user") if isinstance(pr, dict) else None
+
+    if event_name in DELIBERATE_EVENTS:
+        chain = [actor_user, merger, author]
+    else:
+        chain = [merger, author, actor_user]
+
+    for candidate in chain:
+        if isinstance(candidate, dict) and not is_bot(candidate):
+            login = str(candidate.get("login") or "").strip()
+            if login:
+                return login
+    return ""
+
+
+def main(runner: Runner = subprocess.run) -> int:
+    repo = os.environ.get("GITHUB_REPOSITORY", "").strip()
+    sha = os.environ.get("GITHUB_SHA", "").strip()
+    event_name = os.environ.get("GITHUB_EVENT_NAME", "").strip()
+    triggering_actor = os.environ.get("TRIGGERING_ACTOR", "").strip()
+
+    try:
+        login = resolve_actor(repo, sha, event_name, triggering_actor, runner)
+        created_by = public_email(login, runner) or login if login else ""
+    except Exception as e:  # never block a release on attribution
+        print(f"::warning::release actor resolution failed: {e}")
+        created_by = ""
+
+    if created_by:
+        print(f"Attributing release to {created_by}")
+    else:
+        print(
+            "::warning::No human could be attributed to this release — the Slack "
+            "approval message will show no @-mention."
+        )
+
+    out = os.environ.get("GITHUB_OUTPUT")
+    if out:
+        with open(out, "a", encoding="utf-8") as fh:
+            fh.write(f"created_by={created_by}\n")
+    else:
+        print(created_by)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/tests/test_resolve_release_actor.py
+++ b/.github/scripts/tests/test_resolve_release_actor.py
@@ -1,0 +1,358 @@
+"""Tests for .github/scripts/resolve_release_actor.py."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import resolve_release_actor as rra  # noqa: E402
+
+REPO = "atlanhq/example-app"
+SHA = "a" * 40
+
+FLEET_BOT = {"login": "atlan-app-fleet[bot]", "type": "Bot"}
+HUMAN_MERGER = {"login": "example-merger", "type": "User"}
+HUMAN_AUTHOR = {"login": "example-author", "type": "User"}
+
+
+def make_runner(responses: dict[str, object], *, calls: list[str] | None = None):
+    """Build a subprocess.run stand-in backed by a path -> payload table.
+
+    A path mapped to ``None`` simulates a failing ``gh api`` (non-zero exit with
+    an error body on stdout, which is what gh actually does); an unmapped path
+    is a test bug and raises.
+    """
+
+    def runner(cmd, **_kwargs):
+        assert cmd[:2] == ["gh", "api"], cmd
+        path = cmd[2]
+        if calls is not None:
+            calls.append(path)
+        if path not in responses:
+            raise AssertionError(f"unexpected gh api call: {path}")
+        payload = responses[path]
+        if payload is None:
+            return subprocess.CompletedProcess(
+                args=cmd,
+                returncode=1,
+                stdout='{"message": "Not Found"}',
+                stderr="gh: Not Found (HTTP 404)",
+            )
+        return subprocess.CompletedProcess(
+            args=cmd, returncode=0, stdout=json.dumps(payload), stderr=""
+        )
+
+    return runner
+
+
+def pulls_path(sha: str = SHA) -> str:
+    return f"repos/{REPO}/commits/{sha}/pulls"
+
+
+def pr_path(number: int) -> str:
+    return f"repos/{REPO}/pulls/{number}"
+
+
+# ── is_bot ──────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "user",
+    [
+        None,
+        {},
+        {"login": "atlan-app-fleet[bot]", "type": "Bot"},
+        # type alone is enough — a GitHub App without the suffix still is one.
+        {"login": "some-app", "type": "Bot"},
+        # login suffix alone is enough — triggering_actor arrives untyped.
+        {"login": "renovate[bot]"},
+    ],
+)
+def test_is_bot_true(user):
+    assert rra.is_bot(user) is True
+
+
+@pytest.mark.parametrize(
+    "user",
+    [
+        {"login": "example-merger", "type": "User"},
+        # atlan-ci is a plain user account, and GM maps it — treat it as human.
+        {"login": "atlan-ci", "type": "User"},
+        {"login": "example-merger"},
+    ],
+)
+def test_is_bot_false(user):
+    assert rra.is_bot(user) is False
+
+
+# ── gh_api ──────────────────────────────────────────────────────────────────
+
+
+def test_gh_api_returns_parsed_json():
+    runner = make_runner({"users/x": {"login": "x"}})
+    assert rra.gh_api("users/x", runner) == {"login": "x"}
+
+
+def test_gh_api_returns_none_on_error_exit_and_ignores_error_body():
+    """A non-2xx puts a JSON error body on stdout — it must not be returned."""
+    runner = make_runner({"users/x": None})
+    assert rra.gh_api("users/x", runner) is None
+
+
+def test_gh_api_returns_none_on_non_json():
+    def runner(cmd, **_kwargs):
+        return subprocess.CompletedProcess(
+            args=cmd, returncode=0, stdout="not json", stderr=""
+        )
+
+    assert rra.gh_api("users/x", runner) is None
+
+
+def test_gh_api_returns_none_when_gh_is_missing():
+    def runner(*_a, **_k):
+        raise FileNotFoundError("gh")
+
+    assert rra.gh_api("users/x", runner) is None
+
+
+# ── find_pull_request ───────────────────────────────────────────────────────
+
+
+def test_find_pull_request_refetches_for_merged_by():
+    """The list endpoint has no merged_by, so the PR must be re-fetched."""
+    calls: list[str] = []
+    runner = make_runner(
+        {
+            pulls_path(): [{"number": 500, "user": FLEET_BOT}],
+            pr_path(500): {"number": 500, "user": FLEET_BOT, "merged_by": HUMAN_MERGER},
+        },
+        calls=calls,
+    )
+    pr = rra.find_pull_request(REPO, SHA, runner)
+    assert pr["merged_by"] == HUMAN_MERGER
+    assert calls == [pulls_path(), pr_path(500)]
+
+
+def test_find_pull_request_prefers_exact_merge_commit_match():
+    runner = make_runner(
+        {
+            pulls_path(): [
+                {"number": 1, "merge_commit_sha": "b" * 40},
+                {"number": 2, "merge_commit_sha": SHA},
+            ],
+            pr_path(2): {"number": 2, "merged_by": HUMAN_MERGER},
+        }
+    )
+    assert rra.find_pull_request(REPO, SHA, runner)["number"] == 2
+
+
+def test_find_pull_request_falls_back_to_first_when_no_exact_match():
+    runner = make_runner(
+        {
+            pulls_path(): [{"number": 7}, {"number": 9}],
+            pr_path(7): {"number": 7, "merged_by": HUMAN_MERGER},
+        }
+    )
+    assert rra.find_pull_request(REPO, SHA, runner)["number"] == 7
+
+
+def test_find_pull_request_none_when_commit_has_no_pr():
+    runner = make_runner({pulls_path(): []})
+    assert rra.find_pull_request(REPO, SHA, runner) is None
+
+
+def test_find_pull_request_none_when_list_call_fails():
+    runner = make_runner({pulls_path(): None})
+    assert rra.find_pull_request(REPO, SHA, runner) is None
+
+
+def test_find_pull_request_degrades_to_list_entry_when_detail_fails():
+    """A failed detail fetch still leaves the PR author usable."""
+    runner = make_runner(
+        {pulls_path(): [{"number": 3, "user": HUMAN_AUTHOR}], pr_path(3): None}
+    )
+    pr = rra.find_pull_request(REPO, SHA, runner)
+    assert pr["user"] == HUMAN_AUTHOR
+    assert "merged_by" not in pr
+
+
+@pytest.mark.parametrize(("repo", "sha"), [("", SHA), (REPO, ""), ("", "")])
+def test_find_pull_request_none_without_repo_or_sha(repo, sha):
+    def runner(*_a, **_k):
+        raise AssertionError("should not call the API")
+
+    assert rra.find_pull_request(repo, sha, runner) is None
+
+
+# ── resolve_actor ───────────────────────────────────────────────────────────
+
+
+def test_release_event_attributes_to_merger_not_fleet_bot():
+    """The bug this script exists for: bot author, bot trigger, human merger."""
+    runner = make_runner(
+        {
+            pulls_path(): [{"number": 500, "user": FLEET_BOT}],
+            pr_path(500): {"number": 500, "user": FLEET_BOT, "merged_by": HUMAN_MERGER},
+        }
+    )
+    actor = rra.resolve_actor(REPO, SHA, "release", "atlan-app-fleet[bot]", runner)
+    assert actor == "example-merger"
+
+
+def test_push_event_prefers_merger_over_author():
+    runner = make_runner(
+        {
+            pulls_path(): [{"number": 8, "user": HUMAN_AUTHOR}],
+            pr_path(8): {"number": 8, "user": HUMAN_AUTHOR, "merged_by": HUMAN_MERGER},
+        }
+    )
+    actor = rra.resolve_actor(REPO, SHA, "push", "example-merger", runner)
+    assert actor == "example-merger"
+
+
+def test_bot_merger_falls_through_to_human_author():
+    """Merge-queue / auto-merge identities must not win the chain."""
+    runner = make_runner(
+        {
+            pulls_path(): [{"number": 8, "user": HUMAN_AUTHOR}],
+            pr_path(8): {"number": 8, "user": HUMAN_AUTHOR, "merged_by": FLEET_BOT},
+        }
+    )
+    actor = rra.resolve_actor(REPO, SHA, "push", "atlan-app-fleet[bot]", runner)
+    assert actor == "example-author"
+
+
+def test_falls_back_to_triggering_actor_when_commit_has_no_pr():
+    runner = make_runner({pulls_path(): []})
+    actor = rra.resolve_actor(REPO, SHA, "push", "example-merger", runner)
+    assert actor == "example-merger"
+
+
+def test_empty_when_every_candidate_is_a_bot():
+    runner = make_runner(
+        {
+            pulls_path(): [{"number": 8, "user": FLEET_BOT}],
+            pr_path(8): {"number": 8, "user": FLEET_BOT, "merged_by": FLEET_BOT},
+        }
+    )
+    assert rra.resolve_actor(REPO, SHA, "release", "atlan-app-fleet[bot]", runner) == ""
+
+
+def test_workflow_dispatch_prefers_the_person_who_clicked_run():
+    """A deliberate trigger outranks an unrelated older PR's merger."""
+    runner = make_runner(
+        {
+            pulls_path(): [{"number": 8, "user": HUMAN_AUTHOR}],
+            pr_path(8): {"number": 8, "user": HUMAN_AUTHOR, "merged_by": HUMAN_MERGER},
+        }
+    )
+    actor = rra.resolve_actor(REPO, SHA, "workflow_dispatch", "example-clicker", runner)
+    assert actor == "example-clicker"
+
+
+def test_workflow_dispatch_by_a_bot_still_falls_back_to_the_merger():
+    runner = make_runner(
+        {
+            pulls_path(): [{"number": 8, "user": HUMAN_AUTHOR}],
+            pr_path(8): {"number": 8, "user": HUMAN_AUTHOR, "merged_by": HUMAN_MERGER},
+        }
+    )
+    actor = rra.resolve_actor(
+        REPO, SHA, "workflow_dispatch", "atlan-app-fleet[bot]", runner
+    )
+    assert actor == "example-merger"
+
+
+# ── public_email ────────────────────────────────────────────────────────────
+
+
+def test_public_email_returns_address_when_published():
+    runner = make_runner({"users/example-merger": {"email": "dev@example.com"}})
+    assert rra.public_email("example-merger", runner) == "dev@example.com"
+
+
+def test_public_email_empty_when_private():
+    runner = make_runner({"users/example-merger": {"email": None}})
+    assert rra.public_email("example-merger", runner) == ""
+
+
+def test_public_email_empty_when_lookup_fails():
+    runner = make_runner({"users/example-merger": None})
+    assert rra.public_email("example-merger", runner) == ""
+
+
+def test_public_email_empty_for_empty_login():
+    def runner(*_a, **_k):
+        raise AssertionError("should not call the API")
+
+    assert rra.public_email("", runner) == ""
+
+
+# ── main ────────────────────────────────────────────────────────────────────
+
+
+def _set_env(monkeypatch, tmp_path, **overrides):
+    out = tmp_path / "gh_output"
+    out.touch()
+    env = {
+        "GITHUB_REPOSITORY": REPO,
+        "GITHUB_SHA": SHA,
+        "GITHUB_EVENT_NAME": "release",
+        "TRIGGERING_ACTOR": "atlan-app-fleet[bot]",
+        "GITHUB_OUTPUT": str(out),
+    }
+    env.update(overrides)
+    for k, v in env.items():
+        monkeypatch.setenv(k, v)
+    return out
+
+
+def test_main_writes_login_when_email_is_private(monkeypatch, tmp_path):
+    out = _set_env(monkeypatch, tmp_path)
+    runner = make_runner(
+        {
+            pulls_path(): [{"number": 500, "user": FLEET_BOT}],
+            pr_path(500): {"number": 500, "user": FLEET_BOT, "merged_by": HUMAN_MERGER},
+            "users/example-merger": {"email": None},
+        }
+    )
+    assert rra.main(runner) == 0
+    assert out.read_text().strip() == "created_by=example-merger"
+
+
+def test_main_prefers_public_email_over_login(monkeypatch, tmp_path):
+    out = _set_env(monkeypatch, tmp_path)
+    runner = make_runner(
+        {
+            pulls_path(): [{"number": 500, "user": FLEET_BOT}],
+            pr_path(500): {"number": 500, "user": FLEET_BOT, "merged_by": HUMAN_MERGER},
+            "users/example-merger": {"email": "dev@example.com"},
+        }
+    )
+    assert rra.main(runner) == 0
+    assert out.read_text().strip() == "created_by=dev@example.com"
+
+
+def test_main_emits_empty_and_exits_zero_when_unresolvable(monkeypatch, tmp_path):
+    """A release must never be blocked because attribution failed."""
+    out = _set_env(monkeypatch, tmp_path)
+    runner = make_runner({pulls_path(): None})
+    assert rra.main(runner) == 0
+    assert out.read_text().strip() == "created_by="
+
+
+def test_main_exits_zero_when_resolution_raises(monkeypatch, tmp_path):
+    out = _set_env(monkeypatch, tmp_path)
+
+    def boom(*_a, **_k):
+        raise RuntimeError("unexpected")
+
+    monkeypatch.setattr(rra, "resolve_actor", boom)
+    assert rra.main() == 0
+    assert out.read_text().strip() == "created_by="

--- a/.github/workflows/build-and-publish-app.yaml
+++ b/.github/workflows/build-and-publish-app.yaml
@@ -914,6 +914,7 @@ jobs:
       ghcr_branch_tag:  ${{ steps.tags.outputs.ghcr_branch_tag }}
       dockerhub_image:  ${{ steps.tags.outputs.dockerhub_image }}
       release_tags:     ${{ steps.tags.outputs.release_tags }}
+      created_by:       ${{ steps.actor.outputs.created_by }}
 
     steps:
       - name: Checkout
@@ -933,6 +934,43 @@ jobs:
           path: .sdk-entrypoint
           sparse-checkout: .github/scripts
           sparse-checkout-cone-mode: false
+
+      - name: Mint fleet App token for actor lookup
+        id: actor-token
+        # The resolver reads the app repo's pull requests. GITHUB_TOKEN is the
+        # fallback, but its pull-requests scope depends on the caller's own
+        # grant and org default-permissions — and a token that cannot read PRs
+        # fails *silently* here (the chain just degrades back to the fleet bot,
+        # i.e. the bug this step exists to fix). Mint the fleet App token, which
+        # already has PR access in every app repo, and keep GITHUB_TOKEN behind
+        # it. continue-on-error so a mint failure degrades rather than blocks.
+        if: inputs.publish
+        continue-on-error: true
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          app-id: ${{ secrets.FLEET_APP_ID }}
+          private-key: ${{ secrets.FLEET_APP_PRIVATE_KEY }}
+          owner: atlanhq
+          repositories: ${{ github.event.repository.name }}
+
+      - name: Resolve release actor
+        id: actor
+        # Who GM attributes the release to, and therefore who gets @-mentioned
+        # in the #app-releases approval message. Every automated release is cut
+        # by the atlan-app-fleet App (it opens the bump PR and creates the
+        # GitHub Release), so triggering_actor is a bot login GM cannot map to
+        # a Slack user — the human is whoever merged the release PR.
+        # See .sdk-entrypoint/.github/scripts/resolve_release_actor.py for the
+        # resolution chain, tests/test_resolve_release_actor.py for coverage.
+        # Emits an empty value rather than failing when no human is found:
+        # attribution must never block a publish.
+        # Only the publish job consumes this, and it shares the same condition —
+        # so non-publishing builds skip the lookup entirely.
+        if: inputs.publish
+        env:
+          GH_TOKEN: ${{ steps.actor-token.outputs.token || github.token }}
+          TRIGGERING_ACTOR: ${{ github.triggering_actor }}
+        run: python3 .sdk-entrypoint/.github/scripts/resolve_release_actor.py
 
       - name: Read atlan.yaml
         id: manifest
@@ -1383,7 +1421,11 @@ jobs:
           RELEASE_MODEL: ${{ needs.prepare.outputs.release_model }}
           APP_CONFIGS: ${{ needs.prepare.outputs.app_configs }}
           REPO_URL: ${{ github.server_url }}/${{ github.repository }}
-          GITHUB_ACTOR: ${{ github.triggering_actor }}
+          # Resolved in `prepare` by resolve_release_actor.py — the human who
+          # merged the release PR, not the fleet App that cut the tag. Empty
+          # when no human could be attributed; the body builder then omits
+          # created_by, which GM renders as an un-mentioned plain-text line.
+          CREATED_BY: ${{ needs.prepare.outputs.created_by }}
         run: |
           set -euo pipefail
 
@@ -1417,38 +1459,6 @@ jobs:
             } >> "${GITHUB_STEP_SUMMARY}"
             exit 1
           fi
-
-          # Resolve who to attribute as the release creator.
-          #
-          # For `push` events (the squash/merge-to-main auto-publish flow),
-          # github.triggering_actor is whoever clicked "Merge" — not the PR
-          # author — which surfaces the wrong person as "Created by:" in the
-          # GM Slack approval message. Look up the PR for the merge SHA via
-          # /commits/{sha}/pulls and use its author when available. Falls back
-          # to triggering_actor when there's no associated PR (direct push).
-          #
-          # For every other event (workflow_dispatch, release, schedule, …)
-          # the trigger is an explicit deliberate action — attribute to whoever
-          # initiated it. This preserves the pre-fix behavior for those paths.
-          #
-          # NOTE: `gh api` writes its JSON error body to stdout on non-2xx,
-          # so the assignment must be gated on the exit code — otherwise an
-          # error payload would contaminate PR_AUTHOR and break the fallback.
-          if [ "${GITHUB_EVENT_NAME}" = "push" ]; then
-              PR_AUTHOR=""
-              if RAW=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" \
-                           --jq '.[0].user.login // empty' 2>/dev/null); then
-                  PR_AUTHOR="${RAW}"
-              fi
-              ACTOR="${PR_AUTHOR:-${GITHUB_ACTOR}}"
-          else
-              ACTOR="${GITHUB_ACTOR}"
-          fi
-          GH_EMAIL=""
-          if EMAIL_RAW=$(gh api "users/${ACTOR}" --jq '.email // empty' 2>/dev/null); then
-              GH_EMAIL="${EMAIL_RAW}"
-          fi
-          export CREATED_BY="${GH_EMAIL:-${ACTOR}}"
 
           # Build JSON payload matching the CLI's registerInMarketplace format
           BODY=$(python3 - <<'PYEOF'


### PR DESCRIPTION
### Changelog

- **Fix: the GM release Slack message now @-mentions the human who merged the release PR, instead of the fleet bot.** GM turns the publish body's `created_by` into the `<@user>` mention (`pkg/utils/slack_resolver.py`: email → Slack lookup, else GitHub login → its static `GH_USERNAME_TO_SLACK_ID` map, else plain text). Every automated release is cut by the `atlan-app-fleet` App — it opens the bump PR *and* creates the GitHub Release — so `created_by` was `atlan-app-fleet[bot]`, a login GM cannot map. The approval message posted with no mention and nobody was told their release needed approval.
- Two defects, both in the `publish` job's "Publish version" step:
  - The actor-resolution block only attempted a PR lookup for `push` events; the `release` branch — the path that actually publishes for semver apps — assigned `triggering_actor` unconditionally and never looked for a human at all.
  - That step's `env:` set no `GH_TOKEN`, so every `gh api` call in it failed. The `push` lookup and the email lookup had **always** been dead code falling through to `triggering_actor`.
- New tested script `.github/scripts/resolve_release_actor.py`, run in `prepare` (which already checks out the SDK helper scripts) and passed to `publish` as a job output. It walks the build SHA to its PR and prefers the merger, skipping bots at every position:
  - automated events (`push`, `release`): `merged_by` → PR author → `triggering_actor`
  - deliberate events (`workflow_dispatch`, `schedule`, `repository_dispatch`): `triggering_actor` → `merged_by` → PR author, since clicking "Run workflow" *is* the deliberate human act
- `merged_by` requires the single-PR endpoint — `GET /repos/{repo}/commits/{sha}/pulls` omits it — hence the second call. A resolved login is upgraded to the user's public GitHub email when they publish one, since GM's email path resolves any Slack user while the login path only resolves logins present in its hand-maintained map.
- Removes the inlined conditional shell from the workflow, per `docs/standards/ci.md`.

### Additional context (e.g. screenshots, logs, links)

- Linear: [FND-146](https://linear.app/atlan-epd/issue/FND-146/release-slack-notification-tags-the-fleet-bot-instead-of-the-human-who)
- **Blast radius / safety.** This reusable workflow is consumed at `@main` by the whole app fleet, so there is no staged rollout. The script always exits 0: an unresolvable actor emits an empty value, the body builder omits `created_by`, and GM already treats absent as "no attribution". Attribution can never block a publish.
- **Token choice.** The lookup uses a minted `atlan-app-fleet` App token with `github.token` behind it. `GITHUB_TOKEN`'s pull-requests scope depends on the caller's own grant and org default-permissions, and a token that cannot read PRs fails *silently* here — the chain would degrade straight back to the fleet bot, i.e. a fleet-wide no-op with green tests. Both the mint (`continue-on-error`) and the lookup are gated on `inputs.publish`, so non-publishing builds skip them entirely.
- **Verified against real releases**, not just fixtures — the resolver was run standalone against production SHAs:
  - a release-event build whose `triggering_actor` was `atlan-app-fleet[bot]` → resolved to the human who merged the bump PR
  - a bump-PR merge commit on the push path → resolved to the human merger
  - both resolved logins are present in GM's `GH_USERNAME_TO_SLACK_ID` map, so the mention will render
- **Behavior change worth a reviewer's attention.** The comment this replaces stated PR-author was chosen *deliberately over* the merger. Merger-first is unambiguously correct for the bump-PR path (bot author, human merger), but for CD (non-semver) apps a feature-PR merge-to-main publish now attributes to whoever clicked Merge rather than the developer who wrote it.

### Checklist

- [x] Additional tests added
- [ ] All CI checks passed
- [x] Relevant documentation updated

<!-- 36 unit tests for the resolver; full .github/scripts suite green (1442 passed). Documentation: the rationale lives in the script's module docstring and the workflow step comments, which is where this repo documents CI behaviour. -->

---

### Copyleft License Compliance

- [ ] Have you used any code that is subject to a Copyleft license (e.g., GPL, AGPL, LGPL)?
- [ ] If yes, have you modified the code in the context of this project? please share additional details.
