### PR TITLE
ci(renovate): stop native auto-merge landing toolkit bumps over red checks

### DIFF
--- a/renovate-config/default.json
+++ b/renovate-config/default.json
@@ -48,7 +48,7 @@
       "enabled": false
     },
     {
-      "description": "app-contract-toolkit (Pkl): minor+patch in one PR; auto-merge on green. Matched by the regex customManager below. postUpgradeTasks re-resolves contract/PklProject.deps.json and regenerates app/generated/** (+ atlan.yaml/app.yaml) in-branch via the shared renovate-pkl-sync driver, so the bump lands as a self-contained PR with no follow-up glue workflow. Runs ONLY under self-hosted Renovate: postUpgradeTasks commands are gated by the allowedCommands admin allowlist (set in application-sdk's central renovate workflow), so this block is an inert no-op under the Mend-hosted app. The driver is installed as a bare PATH command by that workflow (Renovate does NOT shell-expand the command, so it must not contain ${VARS}); --no-commit leaves the fileFilters commit to Renovate.",
+      "description": "app-contract-toolkit (Pkl): minor+patch in one PR; auto-merge on green. Matched by the regex customManager below. postUpgradeTasks re-resolves contract/PklProject.deps.json and regenerates app/generated/** (+ atlan.yaml/app.yaml) in-branch via the shared renovate-pkl-sync driver, so the bump lands as a self-contained PR with no follow-up glue workflow. Runs ONLY under self-hosted Renovate: postUpgradeTasks commands are gated by the allowedCommands admin allowlist (set in application-sdk's central renovate workflow), so this block is an inert no-op under the Mend-hosted app. The driver is installed as a bare PATH command by that workflow (Renovate does NOT shell-expand the command, so it must not contain ${VARS}); --no-commit leaves the fileFilters commit to Renovate. platformAutomerge is deliberately FALSE here: GitHub's native auto-merge only waits for checks that branch protection marks required, and fleet app repos have no branch protection at all (`GET /branches/main/protection` returns 404), so native auto-merge merges on approval alone no matter how many checks are red. Renovate's own docs make this a precondition — 'You must select at least one status check in the Require status checks to pass before merging section of your branch protection rules on GitHub, if you match all three conditions: automerge=true, platformAutomerge=true'. That precondition is unmet fleet-wide. With platformAutomerge false, Renovate performs the merge itself and 'will not automerge until it sees passing status checks / check runs for the branch', which covers the freshness check run and the renovate/artifacts status — the two signals that went red, and were merged over, when a stale-lockfile bump reached main and later blocked a release publish. Re-enable only once branch protection with required checks exists.",
       "matchManagers": [
         "custom.regex"
       ],
@@ -59,7 +59,7 @@
       "groupName": "app-contract-toolkit",
       "automerge": true,
       "automergeType": "pr",
-      "platformAutomerge": true,
+      "platformAutomerge": false,
       "addLabels": [
         "contract-toolkit-update"
       ],


### PR DESCRIPTION
## Problem

The `app-contract-toolkit` packageRule sets `automerge: true` + `platformAutomerge: true`, which hands the merge to **GitHub's native auto-merge**. GitHub only waits for checks that **branch protection marks required** — and fleet app repos have no branch protection at all:

```
GET /repos/atlanhq/<app>/branches/main/protection
→ 404 Branch not protected
```

With zero required checks, native auto-merge merges on approval alone, no matter how many checks are red.

Renovate's own docs make this an explicit precondition:

> "You must select at least one status check in the *Require status checks to pass before merging* section of your branch protection rules on GitHub, if you match all three conditions: `automerge=true`, `platformAutomerge=true`..."

The fleet meets the first two conditions and not the third, so the option is being used outside its documented contract.

## This already caused an outage-shaped failure

On a recent toolkit bump PR in one app:

| Time | Event |
|---|---|
| `04:43:54` | PR opened by the fleet bot |
| `04:43:57` | `auto_merge_enabled` — **3 seconds later** |
| — | `freshness / Generated Artifact Freshness` → **red**, `renovate/artifacts` → **red** ("Artifact file update failure") |
| `04:50:06` | **merged** |

The `postUpgradeTasks` driver had failed to refresh `contract/PklProject.deps.json`, so the PR shipped a declared `0.20.0` against a resolved `0.19.2`. Pkl refuses to evaluate a project whose declared version is newer than its resolved one, so `poe generate` failed on `main` for three days — surfacing only when a release publish blocked on contract drift. The `freshness` gate had printed the exact diagnosis, verbatim, at the time of the bump. Nothing consulted it.

Two apps were left in this state.

## Fix

`platformAutomerge: false` on the `app-contract-toolkit` rule. Renovate then performs the merge itself and, per the docs, "will not automerge until it sees passing status checks / check runs for the branch" — which covers both the `freshness` check run and the `renovate/artifacts` status.

Auto-merge is **not** disabled; green toolkit bumps still land unattended. Only red ones stop.

## Scope

Deliberately narrow. These rules in the same file carry `platformAutomerge: true` and have the identical exposure, but are **not** touched here so this change stays reviewable:

- `lockFileMaintenance`
- the `github-actions` group rule
- the `atlan-application-sdk-conformance` minor/patch rule

Happy to extend in a follow-up if we want the whole fleet policy consistent.

## The durable fix

This is a **stopgap**. No Renovate-config setting is as robust as a required-check gate — this change only compensates for an absent one. The real fix is branch protection on `main` across the fleet with the certification checks marked required, at which point `platformAutomerge` can be restored. Tracked on FND-148.

## Verified against the shipped source, not just the docs

The docs never actually answer whether Renovate's own automerge waits for *all* checks or only the required ones — so this was confirmed by reading **renovate@43.265.3**, the exact version `.github/workflows/renovate.yaml` installs:

- `dist/workers/repository/update/pr/automerge.js` → `checkAutoMerge` (the `automergeType: "pr"` path this rule uses) calls `resolveBranchStatus` and returns `prAutomergeBlockReason: "BranchNotGreen"` unless the status is green.
- `dist/modules/platform/github/index.js` → `getBranchStatus` reads the combined commit-status API **plus** `repos/<repo>/commits/<sha>/check-runs?per_page=100`, then:

```js
if (commitStatus.state === "failure" || checkRuns.some((run) => run.conclusion === "failure")) return "red";
```

There is **no filtering to branch-protection-required contexts anywhere on that path**. Both signals that were merged over therefore block the merge: `freshness` (a check run with `conclusion: "failure"`) and `renovate/artifacts` (a commit status with `state: "failure"`).

## A failed artifact step is permanent, not self-healing

Worth knowing when weighing this change: Renovate does **not** repair a stale lockfile on later passes. The two affected apps stayed broken across every subsequent Renovate run, including several merged `lockFileMaintenance` PRs. A third app in the same batch only *looked* self-healed — its lockfile was regenerated as a side effect of an unrelated human contract PR.

So blocking the bad merge is the only automatic remedy; otherwise it sits until a human happens to regenerate.

## Verification

- `renovate-config-validator` passes against **renovate@43.265.3**, the exact version pinned in `.github/workflows/renovate.yaml`.
  (Note: an unpinned `npx renovate-config-validator` resolves to renovate@37 and reports false errors on `managerFilePatterns`, which is a newer option.)
- `pre-commit` clean on the changed file.

Refs [FND-148](https://linear.app/atlan-epd/issue/FND-148/fleet-renovate-platformautomerge-merges-toolkit-bumps-over-red-checks), [FND-147](https://linear.app/atlan-epd/issue/FND-147/atlan-metabase-app-stale-pkl-lockfile-blocks-release-publish-toolkit)

