### PR TITLE
ci: credit release contributors alongside the merger in the GM Slack message

### DIFF
--- a/.github/scripts/marketplace_publish_body.py
+++ b/.github/scripts/marketplace_publish_body.py
@@ -71,7 +71,11 @@ class PublishRequest:
         app_configs: base64-encoded JSON of the connector form files under
             ``app/generated/``. LM materialises each entry as a ConfigMap.
         release_model: ``semver`` or empty.
-        created_by: Actor attribution.
+        created_by: Actor attribution — the human who merged the release.
+        authored_by: Contributors credited alongside ``created_by`` in GM's
+            Slack approval message. Display-only: GM must never consult it for
+            approval rights, or a release with five contributors becomes
+            unapprovable by five people.
     """
 
     app_id: str
@@ -88,6 +92,7 @@ class PublishRequest:
     app_configs: str = ""
     release_model: str = ""
     created_by: str = ""
+    authored_by: tuple[str, ...] = ()
 
 
 class PublishBodyError(ValueError):
@@ -161,6 +166,10 @@ def build(request: PublishRequest) -> dict[str, object]:
     if request.created_by.strip():
         body["created_by"] = request.created_by.strip()
 
+    authored_by = [a.strip() for a in request.authored_by if a.strip()]
+    if authored_by:
+        body["authored_by"] = authored_by
+
     return body
 
 
@@ -186,6 +195,11 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--app-configs", default="")
     parser.add_argument("--release-model", default="")
     parser.add_argument("--created-by", default="")
+    parser.add_argument(
+        "--authored-by",
+        default="",
+        help="Comma-separated contributor logins credited alongside --created-by.",
+    )
     args = parser.parse_args(argv)
 
     request = PublishRequest(
@@ -203,6 +217,7 @@ def main(argv: list[str] | None = None) -> int:
         app_configs=args.app_configs,
         release_model=args.release_model,
         created_by=args.created_by,
+        authored_by=tuple(a for a in args.authored_by.split(",") if a.strip()),
     )
     try:
         print(json.dumps(build(request), indent=2, sort_keys=True))

--- a/.github/scripts/resolve_release_actor.py
+++ b/.github/scripts/resolve_release_actor.py
@@ -53,6 +53,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import subprocess
 import sys
 from collections.abc import Callable
@@ -63,6 +64,26 @@ Runner = Callable[..., subprocess.CompletedProcess]
 #: Events where the run was started by a person doing something on purpose, so
 #: the triggering actor outranks anything inferred from git history.
 DELIBERATE_EVENTS = frozenset({"workflow_dispatch", "schedule", "repository_dispatch"})
+
+#: Machine accounts that commit as ordinary users — no ``[bot]`` suffix and
+#: ``type: "User"`` — so ``is_bot`` cannot see them. Only the *contributor* list
+#: filters on this: `atlan-ci` authors the version-bump commit in every release
+#: range, and crediting it as a contributor is pure noise.
+#:
+#: Deliberately NOT applied to the merger chain. GM maps `atlan-ci` to a real
+#: Slack ID, and if a release genuinely was cut by it, naming it beats naming
+#: nobody. Keeping the two filters separate also means this list cannot change
+#: who `created_by` resolves to.
+AUTOMATION_LOGINS = frozenset({"atlan-ci", "atlan-bot", "web-flow"})
+
+#: Slack renders a long mention list as an unreadable wall, and Block Kit caps
+#: `section.fields` at 10 entries. Truncation is reported, never silent.
+MAX_CONTRIBUTORS = 8
+
+#: `compare` returns at most 250 commits. A range that large means the tag
+#: walk found the wrong base, so treat it as unusable rather than crediting
+#: a year of history to one release.
+COMPARE_COMMIT_LIMIT = 250
 
 
 def is_bot(user: dict[str, Any] | None) -> bool:
@@ -142,6 +163,115 @@ def find_pull_request(
     return full if isinstance(full, dict) else chosen
 
 
+_SEMVER = re.compile(r"^v?(\d+)\.(\d+)\.(\d+)(?:-(.+))?$")
+
+
+def parse_semver(tag: str) -> tuple[int, int, int, int, str] | None:
+    """Parse ``v1.2.3`` / ``v1.2.3-rc1`` into a sortable key, or None.
+
+    The prerelease slot sorts *below* the same version's final release (0 vs 1),
+    matching semver — so ``v1.2.3-rc1`` is a valid predecessor of ``v1.2.3``.
+    """
+    m = _SEMVER.match((tag or "").strip())
+    if not m:
+        return None
+    major, minor, patch, pre = m.groups()
+    return (int(major), int(minor), int(patch), 0 if pre else 1, pre or "")
+
+
+def previous_tag(
+    repo: str, current_tag: str, runner: Runner = subprocess.run
+) -> str | None:
+    """Return the semver tag immediately preceding ``current_tag``.
+
+    Sorts by parsed semver rather than trusting list order: the tags endpoint
+    is not semver-ordered (``v0.10.0`` would sort before ``v0.9.0``
+    lexically), and the releases endpoint reorders on re-cut because
+    ``tag-and-release.yaml`` deletes and recreates a release of the same
+    version.
+
+    Bounded to the first 100 tags — enough to find the immediate predecessor
+    of the newest tag. Returns None if the current tag isn't in that window,
+    so the caller degrades instead of comparing against a wrong base.
+    """
+    current = parse_semver(current_tag)
+    if not repo or not current:
+        return None
+    tags = gh_api(f"repos/{repo}/tags?per_page=100", runner)
+    if not isinstance(tags, list):
+        return None
+
+    parsed = []
+    for t in tags:
+        if not isinstance(t, dict):
+            continue
+        name = str(t.get("name") or "")
+        key = parse_semver(name)
+        if key:
+            parsed.append((key, name))
+
+    earlier = sorted({p for p in parsed if p[0] < current})
+    if not earlier:
+        print(
+            f"::warning::No tag older than {current_tag} found — skipping contributors."
+        )
+        return None
+    return earlier[-1][1]
+
+
+def resolve_contributors(
+    repo: str,
+    base_tag: str,
+    head_sha: str,
+    exclude: set[str],
+    runner: Runner = subprocess.run,
+) -> list[str]:
+    """Human logins who authored commits in ``base_tag..head_sha``.
+
+    One ``compare`` call, the same endpoint ``update_changelog.py`` walks to
+    build the release's CHANGELOG section — so the people credited in Slack and
+    the people credited in the release notes are derived from the same range by
+    construction.
+
+    ``exclude`` drops the merger, who is already named as ``created_by`` and
+    almost always also authored commits in the range.
+    """
+    if not repo or not base_tag or not head_sha:
+        return []
+    data = gh_api(f"repos/{repo}/compare/{base_tag}...{head_sha}", runner)
+    if not isinstance(data, dict):
+        return []
+
+    total = data.get("total_commits")
+    if isinstance(total, int) and total > COMPARE_COMMIT_LIMIT:
+        print(
+            f"::warning::{base_tag}...{head_sha} spans {total} commits — "
+            "base tag looks wrong, skipping contributors."
+        )
+        return []
+
+    ordered: list[str] = []
+    for commit in data.get("commits") or []:
+        if not isinstance(commit, dict):
+            continue
+        author = commit.get("author")
+        if not isinstance(author, dict) or is_bot(author):
+            continue
+        login = str(author.get("login") or "").strip()
+        if not login or login in AUTOMATION_LOGINS or login in exclude:
+            continue
+        if login not in ordered:
+            ordered.append(login)
+
+    if len(ordered) > MAX_CONTRIBUTORS:
+        print(
+            f"::warning::{len(ordered)} contributors in {base_tag}...{head_sha} — "
+            f"crediting the first {MAX_CONTRIBUTORS}."
+        )
+        ordered = ordered[:MAX_CONTRIBUTORS]
+    return ordered
+
+
 def public_email(login: str, runner: Runner = subprocess.run) -> str:
     """Return the user's public GitHub email, or "" when they publish none.
 
@@ -185,18 +315,56 @@ def resolve_actor(
     return ""
 
 
+def contributors_for_event(
+    repo: str,
+    sha: str,
+    release_tag: str,
+    merger_login: str,
+    runner: Runner = subprocess.run,
+) -> list[str]:
+    """Humans whose work ships in this release, excluding the merger.
+
+    Semver releases carry a tag, so the range is the previous tag to this
+    commit — every PR merged since the last release. A CD (untagged) publish
+    ships exactly one merge, so the range collapses to that PR's author.
+    """
+    exclude = {merger_login} if merger_login else set()
+
+    if release_tag:
+        base = previous_tag(repo, release_tag, runner)
+        if base:
+            return resolve_contributors(repo, base, sha, exclude, runner)
+        return []
+
+    pr = find_pull_request(repo, sha, runner)
+    author = pr.get("user") if isinstance(pr, dict) else None
+    if isinstance(author, dict) and not is_bot(author):
+        login = str(author.get("login") or "").strip()
+        if login and login not in exclude and login not in AUTOMATION_LOGINS:
+            return [login]
+    return []
+
+
 def main(runner: Runner = subprocess.run) -> int:
     repo = os.environ.get("GITHUB_REPOSITORY", "").strip()
     sha = os.environ.get("GITHUB_SHA", "").strip()
     event_name = os.environ.get("GITHUB_EVENT_NAME", "").strip()
     triggering_actor = os.environ.get("TRIGGERING_ACTOR", "").strip()
+    release_tag = os.environ.get("RELEASE_TAG", "").strip()
 
+    login = ""
     try:
         login = resolve_actor(repo, sha, event_name, triggering_actor, runner)
         created_by = public_email(login, runner) or login if login else ""
     except Exception as e:  # never block a release on attribution
         print(f"::warning::release actor resolution failed: {e}")
         created_by = ""
+
+    try:
+        contributors = contributors_for_event(repo, sha, release_tag, login, runner)
+    except Exception as e:  # contributors are a nicety; the merger is the point
+        print(f"::warning::contributor resolution failed: {e}")
+        contributors = []
 
     if created_by:
         print(f"Attributing release to {created_by}")
@@ -205,13 +373,17 @@ def main(runner: Runner = subprocess.run) -> int:
             "::warning::No human could be attributed to this release — the Slack "
             "approval message will show no @-mention."
         )
+    if contributors:
+        print(f"Crediting contributors: {', '.join(contributors)}")
 
     out = os.environ.get("GITHUB_OUTPUT")
     if out:
         with open(out, "a", encoding="utf-8") as fh:
             fh.write(f"created_by={created_by}\n")
+            fh.write(f"authored_by={','.join(contributors)}\n")
     else:
         print(created_by)
+        print(",".join(contributors))
     return 0
 
 

--- a/.github/scripts/tests/test_marketplace_publish_body.py
+++ b/.github/scripts/tests/test_marketplace_publish_body.py
@@ -84,6 +84,7 @@ def test_channel_used_when_no_tenants() -> None:
         ("app_configs", "app_configs"),
         ("release_model", "release_model"),
         ("created_by", "created_by"),
+        ("authored_by", "authored_by"),
         ("entrypoints", "entrypoints"),
     ],
 )
@@ -161,6 +162,7 @@ def test_field_set_matches_the_release_workflow() -> None:
                 app_configs="e30=",
                 release_model="semver",
                 created_by="someone",
+                authored_by=("someone-else",),
             )
         )
     )

--- a/.github/scripts/tests/test_resolve_release_actor.py
+++ b/.github/scripts/tests/test_resolve_release_actor.py
@@ -59,6 +59,23 @@ def pr_path(number: int) -> str:
     return f"repos/{REPO}/pulls/{number}"
 
 
+def tags_path() -> str:
+    return f"repos/{REPO}/tags?per_page=100"
+
+
+def compare_path(base: str = "v1.0.0", head: str = SHA) -> str:
+    return f"repos/{REPO}/compare/{base}...{head}"
+
+
+def commits(*logins: str, total: int | None = None) -> dict:
+    """A /compare payload authored by the given logins, in order."""
+    cs = [
+        {"author": {"login": lg, "type": "Bot" if lg.endswith("[bot]") else "User"}}
+        for lg in logins
+    ]
+    return {"total_commits": len(cs) if total is None else total, "commits": cs}
+
+
 # ── is_bot ──────────────────────────────────────────────────────────────────
 
 
@@ -323,7 +340,7 @@ def test_main_writes_login_when_email_is_private(monkeypatch, tmp_path):
         }
     )
     assert rra.main(runner) == 0
-    assert out.read_text().strip() == "created_by=example-merger"
+    assert "created_by=example-merger\n" in out.read_text()
 
 
 def test_main_prefers_public_email_over_login(monkeypatch, tmp_path):
@@ -336,7 +353,7 @@ def test_main_prefers_public_email_over_login(monkeypatch, tmp_path):
         }
     )
     assert rra.main(runner) == 0
-    assert out.read_text().strip() == "created_by=dev@example.com"
+    assert "created_by=dev@example.com\n" in out.read_text()
 
 
 def test_main_emits_empty_and_exits_zero_when_unresolvable(monkeypatch, tmp_path):
@@ -344,15 +361,215 @@ def test_main_emits_empty_and_exits_zero_when_unresolvable(monkeypatch, tmp_path
     out = _set_env(monkeypatch, tmp_path)
     runner = make_runner({pulls_path(): None})
     assert rra.main(runner) == 0
-    assert out.read_text().strip() == "created_by="
+    assert out.read_text() == "created_by=\nauthored_by=\n"
 
 
 def test_main_exits_zero_when_resolution_raises(monkeypatch, tmp_path):
     out = _set_env(monkeypatch, tmp_path)
+    runner = make_runner({pulls_path(): []})
 
     def boom(*_a, **_k):
         raise RuntimeError("unexpected")
 
     monkeypatch.setattr(rra, "resolve_actor", boom)
-    assert rra.main() == 0
-    assert out.read_text().strip() == "created_by="
+    assert rra.main(runner) == 0
+    assert "created_by=" in out.read_text()
+
+
+# ── parse_semver / previous_tag ─────────────────────────────────────────────
+
+
+def test_parse_semver_accepts_v_prefix_and_bare():
+    assert rra.parse_semver("v1.2.3")[:3] == (1, 2, 3)
+    assert rra.parse_semver("1.2.3")[:3] == (1, 2, 3)
+
+
+@pytest.mark.parametrize("tag", ["", "latest", "v1.2", "release-1", "v1.2.3.4"])
+def test_parse_semver_rejects_non_semver(tag):
+    assert rra.parse_semver(tag) is None
+
+
+def test_prerelease_sorts_below_its_final_release():
+    assert rra.parse_semver("v1.2.3-rc1") < rra.parse_semver("v1.2.3")
+
+
+def test_previous_tag_sorts_by_semver_not_list_order():
+    """v0.10.0 > v0.9.0 numerically but sorts lower lexically."""
+    runner = make_runner(
+        {
+            tags_path(): [
+                {"name": "v0.9.0"},
+                {"name": "v0.11.0"},
+                {"name": "v0.10.0"},
+                {"name": "not-a-tag"},
+            ]
+        }
+    )
+    assert rra.previous_tag(REPO, "v0.11.0", runner) == "v0.10.0"
+
+
+def test_previous_tag_none_when_nothing_older():
+    runner = make_runner({tags_path(): [{"name": "v1.0.0"}]})
+    assert rra.previous_tag(REPO, "v1.0.0", runner) is None
+
+
+def test_previous_tag_none_for_unparseable_current_tag():
+    def runner(*_a, **_k):
+        raise AssertionError("should not call the API")
+
+    assert rra.previous_tag(REPO, "latest", runner) is None
+
+
+def test_previous_tag_none_when_tags_call_fails():
+    runner = make_runner({tags_path(): None})
+    assert rra.previous_tag(REPO, "v1.0.0", runner) is None
+
+
+# ── resolve_contributors ────────────────────────────────────────────────────
+
+
+def test_contributors_dedupe_preserving_first_appearance():
+    runner = make_runner({compare_path(): commits("dev-a", "dev-b", "dev-a")})
+    assert rra.resolve_contributors(REPO, "v1.0.0", SHA, set(), runner) == [
+        "dev-a",
+        "dev-b",
+    ]
+
+
+def test_contributors_exclude_the_merger():
+    """The merger is already named as created_by — don't credit them twice."""
+    runner = make_runner({compare_path(): commits("dev-a", "example-merger")})
+    got = rra.resolve_contributors(REPO, "v1.0.0", SHA, {"example-merger"}, runner)
+    assert got == ["dev-a"]
+
+
+def test_contributors_drop_automation_and_bots():
+    """atlan-ci authors the bump commit in every release range."""
+    runner = make_runner(
+        {
+            compare_path(): commits(
+                "atlan-ci", "atlan-app-fleet[bot]", "dev-a", "web-flow"
+            )
+        }
+    )
+    assert rra.resolve_contributors(REPO, "v1.0.0", SHA, set(), runner) == ["dev-a"]
+
+
+def test_contributors_capped():
+    many = [f"dev-{i}" for i in range(rra.MAX_CONTRIBUTORS + 4)]
+    runner = make_runner({compare_path(): commits(*many)})
+    got = rra.resolve_contributors(REPO, "v1.0.0", SHA, set(), runner)
+    assert got == many[: rra.MAX_CONTRIBUTORS]
+
+
+def test_contributors_empty_when_range_is_implausibly_large():
+    """A huge range means the base tag is wrong — don't credit a year of history."""
+    runner = make_runner(
+        {compare_path(): commits("dev-a", total=rra.COMPARE_COMMIT_LIMIT + 1)}
+    )
+    assert rra.resolve_contributors(REPO, "v1.0.0", SHA, set(), runner) == []
+
+
+def test_contributors_empty_when_compare_fails():
+    runner = make_runner({compare_path(): None})
+    assert rra.resolve_contributors(REPO, "v1.0.0", SHA, set(), runner) == []
+
+
+def test_contributors_skip_commits_with_no_github_author():
+    """A commit from an unlinked email address has author: null."""
+    payload = {
+        "total_commits": 2,
+        "commits": [{"author": None}, {"author": {"login": "dev-a", "type": "User"}}],
+    }
+    runner = make_runner({compare_path(): payload})
+    assert rra.resolve_contributors(REPO, "v1.0.0", SHA, set(), runner) == ["dev-a"]
+
+
+# ── contributors_for_event ──────────────────────────────────────────────────
+
+
+def test_release_event_credits_everyone_since_the_previous_tag():
+    runner = make_runner(
+        {
+            tags_path(): [{"name": "v1.1.0"}, {"name": "v1.0.0"}],
+            compare_path("v1.0.0"): commits("dev-a", "atlan-ci", "example-merger"),
+        }
+    )
+    got = rra.contributors_for_event(REPO, SHA, "v1.1.0", "example-merger", runner)
+    assert got == ["dev-a"]
+
+
+def test_release_event_with_no_previous_tag_credits_nobody():
+    runner = make_runner({tags_path(): [{"name": "v1.0.0"}]})
+    got = rra.contributors_for_event(REPO, SHA, "v1.0.0", "example-merger", runner)
+    assert got == []
+
+
+def test_cd_push_credits_the_pr_author():
+    """An untagged publish ships one merge — the range collapses to its author."""
+    runner = make_runner(
+        {
+            pulls_path(): [{"number": 8, "user": HUMAN_AUTHOR}],
+            pr_path(8): {"number": 8, "user": HUMAN_AUTHOR, "merged_by": HUMAN_MERGER},
+        }
+    )
+    got = rra.contributors_for_event(REPO, SHA, "", "example-merger", runner)
+    assert got == ["example-author"]
+
+
+def test_cd_push_credits_nobody_when_the_pr_is_bot_authored():
+    """The bump PR on the CD path — bot author, nothing to credit."""
+    runner = make_runner(
+        {
+            pulls_path(): [{"number": 8, "user": FLEET_BOT}],
+            pr_path(8): {"number": 8, "user": FLEET_BOT, "merged_by": HUMAN_MERGER},
+        }
+    )
+    assert rra.contributors_for_event(REPO, SHA, "", "example-merger", runner) == []
+
+
+def test_cd_push_does_not_credit_the_merger_twice():
+    runner = make_runner(
+        {
+            pulls_path(): [{"number": 8, "user": HUMAN_MERGER}],
+            pr_path(8): {"number": 8, "user": HUMAN_MERGER, "merged_by": HUMAN_MERGER},
+        }
+    )
+    assert rra.contributors_for_event(REPO, SHA, "", "example-merger", runner) == []
+
+
+# ── main: authored_by output ────────────────────────────────────────────────
+
+
+def test_main_writes_authored_by(monkeypatch, tmp_path):
+    out = _set_env(monkeypatch, tmp_path, RELEASE_TAG="v1.1.0")
+    runner = make_runner(
+        {
+            pulls_path(): [{"number": 500, "user": FLEET_BOT}],
+            pr_path(500): {"number": 500, "user": FLEET_BOT, "merged_by": HUMAN_MERGER},
+            "users/example-merger": {"email": None},
+            tags_path(): [{"name": "v1.1.0"}, {"name": "v1.0.0"}],
+            compare_path("v1.0.0"): commits("dev-a", "dev-b", "example-merger"),
+        }
+    )
+    assert rra.main(runner) == 0
+    written = out.read_text()
+    assert "created_by=example-merger" in written
+    assert "authored_by=dev-a,dev-b" in written
+
+
+def test_main_still_emits_created_by_when_contributors_fail(monkeypatch, tmp_path):
+    """Contributors are a nicety — their failure must not lose the merger."""
+    out = _set_env(monkeypatch, tmp_path, RELEASE_TAG="v1.1.0")
+    runner = make_runner(
+        {
+            pulls_path(): [{"number": 500, "user": FLEET_BOT}],
+            pr_path(500): {"number": 500, "user": FLEET_BOT, "merged_by": HUMAN_MERGER},
+            "users/example-merger": {"email": None},
+            tags_path(): None,
+        }
+    )
+    assert rra.main(runner) == 0
+    written = out.read_text()
+    assert "created_by=example-merger" in written
+    assert "authored_by=\n" in written

--- a/.github/workflows/build-and-publish-app.yaml
+++ b/.github/workflows/build-and-publish-app.yaml
@@ -915,6 +915,7 @@ jobs:
       dockerhub_image:  ${{ steps.tags.outputs.dockerhub_image }}
       release_tags:     ${{ steps.tags.outputs.release_tags }}
       created_by:       ${{ steps.actor.outputs.created_by }}
+      authored_by:      ${{ steps.actor.outputs.authored_by }}
 
     steps:
       - name: Checkout
@@ -970,6 +971,10 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.actor-token.outputs.token || github.token }}
           TRIGGERING_ACTOR: ${{ github.triggering_actor }}
+          # Present only on semver releases. When set, contributors are the
+          # authors of everything merged since the previous tag; when absent
+          # (CD publish) the range collapses to the single PR being published.
+          RELEASE_TAG: ${{ inputs.release_tag }}
         run: python3 .sdk-entrypoint/.github/scripts/resolve_release_actor.py
 
       - name: Read atlan.yaml
@@ -1426,6 +1431,10 @@ jobs:
           # when no human could be attributed; the body builder then omits
           # created_by, which GM renders as an un-mentioned plain-text line.
           CREATED_BY: ${{ needs.prepare.outputs.created_by }}
+          # Comma-separated logins of the humans whose work ships in this
+          # release, excluding the merger (already named by CREATED_BY).
+          # Display-only on GM: never consulted by the approval gate.
+          AUTHORED_BY: ${{ needs.prepare.outputs.authored_by }}
         run: |
           set -euo pipefail
 
@@ -1522,6 +1531,16 @@ jobs:
           created_by = os.environ.get("CREATED_BY", "").strip()
           if created_by:
               body["created_by"] = created_by
+
+          # Contributors credited alongside created_by in the GM Slack approval
+          # message. Sent as a list (mirrors allowed_tenants) so GM validates
+          # each login separately; omitted when empty, since GM distinguishes
+          # absent from empty here as it does on every other optional field.
+          authored_by = [
+              a.strip() for a in os.environ.get("AUTHORED_BY", "").split(",") if a.strip()
+          ]
+          if authored_by:
+              body["authored_by"] = authored_by
 
           if release_model:
               body["release_model"] = release_model


### PR DESCRIPTION
### Changelog

> **Stacked on #3082** — based on that branch, so this diff is only the contributor work. Merge #3082 first.
> **Blocked on two downstream PRs** — `authored_by` traverses Heracles → Local Marketplace → Global Marketplace before anything renders. LM and GM links to follow. Sending the field early is harmless (both sides treat it as optional), but nothing is user-visible until all three land.

- #3082 names **one** person — the human who merged the release. This names **the people whose work actually ships in the release**, so the `#app-releases` approval message credits contributors, not just the releaser.
- A **semver** release carries a tag, so the contributor set is every human who authored a commit between the previous tag and this one — the same `compare` range `update_changelog.py` already walks to build the release's CHANGELOG section. The people credited in Slack and the people credited in the release notes are therefore derived from one range by construction, not two calculations that can silently disagree.
- A **CD (untagged)** publish ships a single merge, so the range collapses to that PR's author.
- The base tag is found by **parsing and sorting tags as semver**, not by trusting list order. Both obvious shortcuts are wrong: the tags endpoint isn't semver-ordered (`v0.10.0` sorts below `v0.9.0` lexically), and `releases?per_page=2` reorders on a re-cut because `tag-and-release.yaml` deletes and recreates a release of the same version (and prereleases sit in that list too).
- Filtering, in order: bots → `AUTOMATION_LOGINS` → the merger (already named by `created_by`, and they almost always also authored commits in the range).
- Sent as a **list** `authored_by`, mirroring `allowed_tenants`, so GM validates each login separately rather than parsing a joined string.

### Additional context (e.g. screenshots, logs, links)

- Linear: [FND-146](https://linear.app/atlan-epd/issue/FND-146/release-slack-notification-tags-the-fleet-bot-instead-of-the-human-who)
- **`AUTOMATION_LOGINS` is deliberately separate from `is_bot`, and applies only to contributors.** `atlan-ci` is `type: User` with no `[bot]` suffix, so `is_bot` cannot see it; it authors the version-bump commit in *every* release range and is pure noise as a contributor. But it *is* a mapped Slack identity, so it must stay eligible as a merger — and keeping the lists separate means this filter cannot change who `created_by` resolves to (i.e. cannot regress #3082).
- **Display-only by contract.** `created_by` drives the self-approval block and audit attribution. `authored_by` must never be read by an approval predicate — with a *list* the failure mode is worse than a single field: a release with five contributors would become unapprovable by five people. The GM PR will carry a test asserting a populated `authored_by` does not change `can_user_approve`.
- **Blast-radius guards.** Contributor resolution is wrapped in its own try/except so its failure cannot lose the `created_by` that fixes the actual outage. The list is capped at 8 (Block Kit caps `section.fields` at 10) with a warning rather than silent truncation, and a range exceeding `compare`'s 250-commit ceiling is discarded rather than crediting a year of history to one release.
- **Verified against a real release**, `atlan-postgres-app` `v0.2.0...v0.2.1`:
  - merger → `fyzanshaik-atlan`, contributors → `tanishkhot`, `Dexters-Hub`
  - `atlan-ci` (bump commit) and `atlan-app-fleet[bot]` filtered; merger not double-credited
  - all three logins are present in GM's `GH_USERNAME_TO_SLACK_ID`, so the mentions will render
- The repo's own drift guard (`test_field_set_matches_the_release_workflow`) caught that the workflow was sending a field `marketplace_publish_body.py` didn't build — the e2e publish path is updated to match, which is exactly what that test exists to force.

### Checklist

- [x] Additional tests added
- [ ] All CI checks passed
- [x] Relevant documentation updated

<!-- 61 resolver tests; full .github/scripts suite green (1468 passed). Rationale lives in the module docstring and workflow step comments, per repo convention. -->

---

### Copyleft License Compliance

- [ ] Have you used any code that is subject to a Copyleft license (e.g., GPL, AGPL, LGPL)?
- [ ] If yes, have you modified the code in the context of this project? please share additional details.
