### PR TITLE
fix(storage): stop casting all-null parquet columns to large_string (CNCT-80)

### DIFF
--- a/application_sdk/storage/formats/parquet.py
+++ b/application_sdk/storage/formats/parquet.py
@@ -28,6 +28,43 @@ logger = get_logger(__name__)
 
 if TYPE_CHECKING:
     import pandas as pd
+    import pyarrow as pa
+
+
+def _normalize_all_null_string_columns(table: "pa.Table") -> "pa.Table":
+    """Rewrite all-null ``string``/``large_string`` columns as Arrow ``null``.
+
+    A shard written before CNCT-80 persisted an all-null column as
+    ``large_string``. ``pa.concat_tables(..., promote_options="permissive")``
+    can promote ``null`` to any concrete sibling type, but cannot reconcile
+    ``large_string`` against a numeric sibling — so a prefix that mixes a
+    legacy all-null shard with a new numeric shard still fails to merge.
+    Rewriting the all-null string column as ``null`` restores that promotion
+    without touching columns that actually hold string data.
+    """
+    import pyarrow as pa  # noqa: PLC0415 — optional dep: pyarrow
+
+    if not isinstance(table, pa.Table) or table.num_rows == 0:
+        return table
+
+    fields = []
+    columns = []
+    changed = False
+    for i, field in enumerate(table.schema):
+        column = table.column(i)
+        if (
+            pa.types.is_string(field.type) or pa.types.is_large_string(field.type)
+        ) and column.null_count == table.num_rows:
+            fields.append(pa.field(field.name, pa.null()))
+            columns.append(pa.chunked_array([pa.nulls(table.num_rows, type=pa.null())]))
+            changed = True
+        else:
+            fields.append(field)
+            columns.append(column)
+
+    if not changed:
+        return table
+    return pa.Table.from_arrays(columns, schema=pa.schema(fields))
 
 
 class ParquetFileReader(Reader):
@@ -238,6 +275,10 @@ class ParquetFileReader(Reader):
                 import pandas as pd  # noqa: PLC0415 — optional dep: pandas
 
                 return pd.DataFrame()
+            # Normalize legacy all-null large_string shards (pre-CNCT-80
+            # writes) so permissive promotion can merge them against a
+            # sibling shard's concrete numeric type.
+            tables = [_normalize_all_null_string_columns(t) for t in tables]
             combined = pa.concat_tables(tables, promote_options="permissive")
             return combined.to_pandas()
         # An already-typed AppError carries its own category/audience/evidence

--- a/application_sdk/storage/formats/parquet.py
+++ b/application_sdk/storage/formats/parquet.py
@@ -827,50 +827,27 @@ class ParquetFileWriter(Writer):
         return FileReference.from_local(self.path)
 
     async def _write_chunk(self, chunk: "pd.DataFrame", file_name: str):
-        """Write a chunk to a Parquet file, casting null-typed columns to string.
+        """Write a chunk to a Parquet file.
 
-        When a pandas DataFrame has an all-null column, pyarrow infers the parquet
-        type as ``null``. This causes silent data loss when daft reads multiple
-        parquet files with mixed null/string column types — daft resolves the
-        conflict by using ``null`` for ALL rows, dropping actual data from files
-        that had the column typed as ``string``. See BLDX-837.
+        An all-null column is written with its natural pyarrow-inferred
+        ``null`` type rather than cast to ``large_string``. The cast was a
+        workaround for a daft merge bug (BLDX-837) that no longer applies —
+        daft was removed entirely in #2300. Leaving the column typed ``null``
+        lets the reader's ``pa.concat_tables(..., promote_options="permissive")``
+        promote it against a sibling shard's real type at merge time; casting
+        it to ``large_string`` instead made that promotion impossible whenever
+        a sibling shard was typed e.g. ``double`` (CNCT-80).
         """
         import pyarrow as pa  # noqa: PLC0415 — optional dep: pyarrow
         import pyarrow.parquet as pq  # noqa: PLC0415 — optional dep: pyarrow.parquet
 
         table = pa.Table.from_pandas(chunk, preserve_index=False)
-
-        # Fast path: no null-typed columns → write directly (O(cols) check)
-        if not any(pa.types.is_null(f.type) for f in table.schema):
-            row_group_size = max(
-                1,
-                min(
-                    len(table), 16_000_000 // max(1, table.nbytes // max(1, len(table)))
-                ),
-            )
-            # Offloaded: pq.write_table() is blocking disk I/O; running it
-            # inline stalls the event loop — including the auto-heartbeat —
-            # for the write's full duration on large chunks.
-            await run_in_thread(
-                pq.write_table,
-                table,
-                file_name,
-                compression="snappy",
-                row_group_size=row_group_size,
-            )
-            return
-
-        # Slow path: cast null-typed columns to large_string before writing
-        new_schema = pa.schema(
-            [
-                pa.field(f.name, pa.large_string()) if pa.types.is_null(f.type) else f
-                for f in table.schema
-            ]
-        )
-        table = table.cast(new_schema)
         row_group_size = max(
             1, min(len(table), 16_000_000 // max(1, table.nbytes // max(1, len(table))))
         )
+        # Offloaded: pq.write_table() is blocking disk I/O; running it
+        # inline stalls the event loop — including the auto-heartbeat —
+        # for the write's full duration on large chunks.
         await run_in_thread(
             pq.write_table,
             table,

--- a/application_sdk/storage/formats/parquet.py
+++ b/application_sdk/storage/formats/parquet.py
@@ -44,7 +44,7 @@ def _normalize_all_null_string_columns(table: "pa.Table") -> "pa.Table":
     """
     import pyarrow as pa  # noqa: PLC0415 — optional dep: pyarrow
 
-    if not isinstance(table, pa.Table) or table.num_rows == 0:
+    if not isinstance(table, pa.Table):
         return table
 
     fields = []
@@ -55,7 +55,9 @@ def _normalize_all_null_string_columns(table: "pa.Table") -> "pa.Table":
         if (
             pa.types.is_string(field.type) or pa.types.is_large_string(field.type)
         ) and column.null_count == table.num_rows:
-            fields.append(pa.field(field.name, pa.null()))
+            # null_count == num_rows already holds for an empty (0-row) string
+            # column, so legacy 0-row shards normalize here as well.
+            fields.append(field.with_type(pa.null()))
             columns.append(pa.chunked_array([pa.nulls(table.num_rows, type=pa.null())]))
             changed = True
         else:
@@ -64,7 +66,9 @@ def _normalize_all_null_string_columns(table: "pa.Table") -> "pa.Table":
 
     if not changed:
         return table
-    return pa.Table.from_arrays(columns, schema=pa.schema(fields))
+    return pa.Table.from_arrays(
+        columns, schema=pa.schema(fields, metadata=table.schema.metadata)
+    )
 
 
 class ParquetFileReader(Reader):

--- a/tests/unit/storage/formats/readers/test_parquet_reader.py
+++ b/tests/unit/storage/formats/readers/test_parquet_reader.py
@@ -707,6 +707,46 @@ class TestReadNonBatchedSchemaUnification:
         assert set(df["id"].tolist()) == {1, 2, 3, 4}
         assert set(df["tag"].tolist()) == {None, "a", "b"}
 
+    @pytest.mark.asyncio
+    async def test_read_merges_legacy_all_null_large_string_with_numeric(
+        self, tmp_path
+    ) -> None:
+        """CNCT-80: a legacy all-null ``large_string`` shard must merge with a new numeric shard.
+
+        Before CNCT-80 the writer persisted an all-null column as
+        ``large_string``. ``promote_options="permissive"`` cannot reconcile
+        ``large_string`` against a numeric sibling, so an upgraded prefix that
+        mixes an old all-null shard with a new numeric shard raised
+        ``ArrowTypeError`` on read. The reader now normalizes such columns to
+        Arrow ``null`` before concatenating.
+        """
+        f1 = _write_parquet(
+            tmp_path / "legacy.parquet",
+            pa.schema([("id", pa.int64()), ("extra", pa.large_string())]),
+            {"id": [1, 2], "extra": [None, None]},
+        )
+        f2 = _write_parquet(
+            tmp_path / "new.parquet",
+            pa.schema([("id", pa.int64()), ("extra", pa.int64())]),
+            {"id": [3, 4], "extra": [10, 18]},
+        )
+
+        async def _download(_path, _ext, _names=None):
+            return [f1, f2]
+
+        with patch(
+            "application_sdk.storage.formats.parquet._download_files",
+            side_effect=_download,
+        ):
+            reader = ParquetFileReader(path=str(tmp_path))
+            df = await reader.read()
+
+        assert len(df) == 4
+        assert set(df["id"].tolist()) == {1, 2, 3, 4}
+        # int64 + null promotes to double, so missing values round-trip as NaN.
+        assert df["extra"].isna().tolist() == [True, True, False, False]
+        assert df["extra"].dropna().tolist() == [10.0, 18.0]
+
 
 @pytest.mark.asyncio
 async def test_read_with_file_names(tmp_path: Path) -> None:

--- a/tests/unit/storage/formats/readers/test_parquet_reader.py
+++ b/tests/unit/storage/formats/readers/test_parquet_reader.py
@@ -747,6 +747,42 @@ class TestReadNonBatchedSchemaUnification:
         assert df["extra"].isna().tolist() == [True, True, False, False]
         assert df["extra"].dropna().tolist() == [10.0, 18.0]
 
+    @pytest.mark.asyncio
+    async def test_read_merges_zero_row_legacy_all_null_large_string_with_numeric(
+        self, tmp_path
+    ) -> None:
+        """CNCT-80: a 0-row legacy all-null ``large_string`` shard must merge too.
+
+        Filtered partitions / incremental windows / partial extracts can leave
+        a 0-row shard whose all-null column the pre-fix writer still cast to
+        ``large_string``. The reader must normalize it to Arrow ``null`` just
+        like a non-empty legacy shard, or the same ``ArrowTypeError`` fires.
+        """
+        f1 = _write_parquet(
+            tmp_path / "legacy-empty.parquet",
+            pa.schema([("id", pa.int64()), ("extra", pa.large_string())]),
+            {"id": [], "extra": []},
+        )
+        f2 = _write_parquet(
+            tmp_path / "new.parquet",
+            pa.schema([("id", pa.int64()), ("extra", pa.int64())]),
+            {"id": [3, 4], "extra": [10, 18]},
+        )
+
+        async def _download(_path, _ext, _names=None):
+            return [f1, f2]
+
+        with patch(
+            "application_sdk.storage.formats.parquet._download_files",
+            side_effect=_download,
+        ):
+            reader = ParquetFileReader(path=str(tmp_path))
+            df = await reader.read()
+
+        assert len(df) == 2
+        assert set(df["id"].tolist()) == {3, 4}
+        assert df["extra"].tolist() == [10.0, 18.0]
+
 
 @pytest.mark.asyncio
 async def test_read_with_file_names(tmp_path: Path) -> None:

--- a/tests/unit/storage/formats/writers/test_parquet_writer.py
+++ b/tests/unit/storage/formats/writers/test_parquet_writer.py
@@ -1132,9 +1132,7 @@ class TestWriteChunkNullColumns:
         assert table.num_rows == 3
         assert table.column("b").type == pa.string()
 
-    async def test_write_chunk_all_null_column_stays_null_typed(
-        self, tmp_path
-    ) -> None:
+    async def test_write_chunk_all_null_column_stays_null_typed(self, tmp_path) -> None:
         """All-null column is written with its natural null type, uncast."""
         df = pd.DataFrame({"a": [1, 2], "b": [None, None]})
         file_name = str(tmp_path / "with_nulls.parquet")

--- a/tests/unit/storage/formats/writers/test_parquet_writer.py
+++ b/tests/unit/storage/formats/writers/test_parquet_writer.py
@@ -1109,7 +1109,16 @@ class TestParquetFileWriterConsolidation:
 
 
 class TestWriteChunkNullColumns:
-    """Tests for _write_chunk handling of null-typed columns (BLDX-837)."""
+    """Tests for _write_chunk handling of null-typed columns (CNCT-80).
+
+    The old behavior (see git history, BLDX-837) cast an all-null column to
+    large_string on write — a workaround for a daft merge bug. daft was
+    removed entirely in #2300, but the cast stayed, which broke merging an
+    all-null shard against a sibling shard typed e.g. double (CNCT-80): a
+    permissive pa.concat_tables can promote null -> double directly, but
+    can't reconcile large_string against double. Leaving the column typed
+    null lets that promotion happen.
+    """
 
     async def test_write_chunk_no_nulls_uses_fast_path(self, tmp_path) -> None:
         """Normal DataFrame without all-null columns uses pandas fast path."""
@@ -1123,10 +1132,10 @@ class TestWriteChunkNullColumns:
         assert table.num_rows == 3
         assert table.column("b").type == pa.string()
 
-    async def test_write_chunk_all_null_column_cast_to_large_string(
+    async def test_write_chunk_all_null_column_stays_null_typed(
         self, tmp_path
     ) -> None:
-        """All-null column should be written as large_string, not null type."""
+        """All-null column is written with its natural null type, uncast."""
         df = pd.DataFrame({"a": [1, 2], "b": [None, None]})
         file_name = str(tmp_path / "with_nulls.parquet")
 
@@ -1135,7 +1144,7 @@ class TestWriteChunkNullColumns:
 
         schema = pq.read_schema(file_name)
         b_type = schema.field("b").type
-        assert b_type == pa.large_string(), f"Expected large_string, got {b_type}"
+        assert b_type == pa.null(), f"Expected null, got {b_type}"
 
     async def test_write_chunk_mixed_null_and_data_columns(self, tmp_path) -> None:
         """DataFrame with both null and non-null columns handles both correctly."""
@@ -1149,10 +1158,10 @@ class TestWriteChunkNullColumns:
 
         schema = pq.read_schema(file_name)
         assert schema.field("name").type == pa.string()
-        assert schema.field("notes").type == pa.large_string()
+        assert schema.field("notes").type == pa.null()
 
     async def test_multi_file_roundtrip_no_data_loss(self, tmp_path) -> None:
-        """Write two files (one with null col, one with data) — reading both back preserves data."""
+        """Write two files (one with null col, one with string data) — reading both back preserves data."""
         writer = ParquetFileWriter(str(tmp_path / "output"))
 
         # File 1: column 'extra' is all-null
@@ -1172,6 +1181,36 @@ class TestWriteChunkNullColumns:
         assert combined.num_rows == 4
         extra_col = combined.column("extra").to_pylist()
         assert extra_col == [None, None, "foo", "bar"]
+
+    async def test_multi_file_roundtrip_null_vs_numeric_no_longer_crashes(
+        self, tmp_path
+    ) -> None:
+        """CNCT-80 regression: all-null shard merged against a numeric shard.
+
+        This is the production failure signature: 'Unable to merge: Field X
+        has incompatible types: double vs large_string'. Before this fix, the
+        writer cast the all-null 'extra' column to large_string, which a
+        permissive concat cannot reconcile against the sibling shard's
+        double. Leaving it null-typed lets permissive promote null -> double.
+        """
+        writer = ParquetFileWriter(str(tmp_path / "output"))
+
+        # File 1: numeric metadata column entirely NULL (e.g. a batch of only
+        # non-numeric source columns).
+        df1 = pd.DataFrame({"id": [1, 2], "extra": [None, None]})
+        f1 = str(tmp_path / "chunk1.parquet")
+        await writer._write_chunk(df1, f1)
+
+        # File 2: same column populated with real numeric values.
+        df2 = pd.DataFrame({"id": [3, 4], "extra": [10, 18]})
+        f2 = str(tmp_path / "chunk2.parquet")
+        await writer._write_chunk(df2, f2)
+
+        t1 = pq.read_table(f1)
+        t2 = pq.read_table(f2)
+        combined = pa.concat_tables([t1, t2], promote_options="permissive")
+        assert combined.num_rows == 4
+        assert combined.column("extra").to_pylist() == [None, None, 10, 18]
 
     async def test_write_chunk_offloaded_to_thread(self, tmp_path) -> None:
         """pq.write_table() must not run inline on the event loop.


### PR DESCRIPTION
## Linked issue
https://linear.app/atlan-epd/issue/CNCT-80/sdk-parquet-writer-casts-all-null-columns-to-large-string-readers

## Problem

`ParquetFileWriter._write_chunk` casts any all-NULL column to `pa.large_string()` before writing. The reader (`_get_dataframe`) merges chunk files with `pa.concat_tables(tables, promote_options="permissive")`. Permissive promotion can widen `null -> any`, but **cannot** reconcile `large_string` against a sibling shard typed e.g. `double`. Any connector where one chunk has a numeric column entirely NULL and another chunk has real values in that column fails on read with:

```
pyarrow.lib.ArrowTypeError: Unable to merge: Field X has incompatible types: double vs large_string
```

Hit independently by:
- **atlan-teradata-app** — `numeric_precision`, azinpost tenant, recurring nightly since 2026-08-04 (root-caused in Linear CONAT-750; app-side workaround shipped separately in [atlan-teradata-app#108](https://github.com/atlanhq/atlan-teradata-app/pull/108), but that only fixes Teradata — this SDK bug is still live for every other connector on the affected path).
- **atlan-presto-app** — `decimal_digits`, SDK 3.21.2 (original CNCT-80 report; currently worked around app-side via `_normalize_numeric_columns`).

## Root cause

The `large_string` cast was a workaround for a **daft** merge bug (BLDX-837): daft resolved a null/string type conflict across files by dropping data from the non-null file. daft was removed entirely in #2300 ("remove daft entirely, replace with pyarrow/orjson/duckdb"), and `DataframeType.daft` is now just a deprecation shim that logs a warning and routes to the pandas path — no daft code executes anymore. The cast's justification is gone, but the cast itself stayed, and now actively breaks the merge case it wasn't protecting against in the first place (null vs. a *typed* column, not null vs. string).

## Fix

Stop casting. Leave an all-null column with its natural pyarrow-inferred `null` type. `pa.concat_tables(..., promote_options="permissive")` already promotes `null -> any` type correctly at merge time — that's what actually needed to happen here.

```diff
-        # Fast path: no null-typed columns → write directly (O(cols) check)
-        if not any(pa.types.is_null(f.type) for f in table.schema):
-            ...
-            return
-
-        # Slow path: cast null-typed columns to large_string before writing
-        new_schema = pa.schema(
-            [
-                pa.field(f.name, pa.large_string()) if pa.types.is_null(f.type) else f
-                for f in table.schema
-            ]
-        )
-        table = table.cast(new_schema)
-        ...
+        row_group_size = max(...)
+        await run_in_thread(pq.write_table, table, file_name, ...)
```

This also simplifies `_write_chunk` — the fast/slow path split existed only to special-case the now-removed cast.

## Test plan

- [x] Updated `TestWriteChunkNullColumns` (previously asserted the old behavior directly — `test_write_chunk_all_null_column_cast_to_large_string` expected `pa.large_string()`) to assert the new, correct `pa.null()` type.
- [x] Added `test_multi_file_roundtrip_null_vs_numeric_no_longer_crashes` — the actual production failure signature (null vs. `double`), which the existing suite never covered (it only had null-vs-*string* coverage, which was never broken — `large_string` merges fine against `string`, just not against `double`).
- [x] Full `tests/unit/storage/` suite: 785 passed, 3 skipped, zero regressions.
- [x] Confirmed no live daft code path remains that this cast could have still been protecting (`DataframeType.daft` is a deprecation-warning-and-reroute shim only; `daft` is not a dependency).

🤖 Generated with [Claude Code](https://claude.com/claude-code)