### PR TITLE
ci(dashboard): publish conformance history and every SARIF series, not 6 of 10

### DIFF
--- a/.github/scripts/fetch_conformance_sarif.py
+++ b/.github/scripts/fetch_conformance_sarif.py
@@ -216,7 +216,12 @@ def head_ref(repo: str, run_id: int, gh=run_gh) -> tuple[str, str]:
         payload = json.loads(out or "{}")
     except json.JSONDecodeError as exc:
         raise RuntimeError(f"unparseable gh run view payload for run {run_id}") from exc
-    return payload.get("headSha") or "", payload.get("headBranch") or ""
+    sha, branch = payload.get("headSha") or "", payload.get("headBranch") or ""
+    if not sha or not branch:
+        raise RuntimeError(
+            f"gh run view returned blank headSha/headBranch for run {run_id}"
+        )
+    return sha, branch
 
 
 def main(argv: list[str] | None = None, gh=run_gh) -> int:

--- a/.github/scripts/fetch_conformance_sarif.py
+++ b/.github/scripts/fetch_conformance_sarif.py
@@ -35,8 +35,14 @@ Outputs written to ``$GITHUB_OUTPUT``:
 
 Exits 0 in the "nothing to publish" cases (no candidate run, no live SARIF) —
 those are routine and gated downstream by ``has_run`` / ``has_artifacts``. A
-download that fails *after* the artifact was confirmed live is a real error and
-propagates, matching the test-readiness path.
+download that fails *after* the artifact was confirmed live is not fatal either:
+each series is fetched independently, a failure is logged as a ``::warning::``,
+and the step publishes whatever subset landed (``has_artifacts`` stays true).
+Only when *no* series is retrievable does the step skip (``has_artifacts=false``),
+still exiting 0. The one hard failure is the ``run view`` metadata lookup on an
+already-confirmed run — a blank ``commit_sha``/``branch`` would bake empty
+provenance into the dashboard JSON, so that propagates as nonzero, matching the
+prior ``set -euo pipefail`` shell.
 """
 
 from __future__ import annotations
@@ -194,15 +200,22 @@ def download(repo: str, run_id: int, series: list[str], dest: str, gh=run_gh):
 
 
 def head_ref(repo: str, run_id: int, gh=run_gh) -> tuple[str, str]:
+    """Head ``(sha, branch)`` of an already-confirmed run.
+
+    Raises ``RuntimeError`` when the lookup of a run we *already* confirmed has
+    live SARIF fails or returns unparseable JSON. The prior shell ran under
+    ``set -euo pipefail``, so this ``gh run view`` aborted the step on error;
+    swallowing it here would publish dashboard rows with blank provenance.
+    """
     rc, out = gh(
         ["run", "view", str(run_id), "--repo", repo, "--json", "headSha,headBranch"]
     )
     if rc != 0:
-        return "", ""
+        raise RuntimeError(f"gh run view failed for run {run_id}")
     try:
         payload = json.loads(out or "{}")
-    except json.JSONDecodeError:
-        return "", ""
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"unparseable gh run view payload for run {run_id}") from exc
     return payload.get("headSha") or "", payload.get("headBranch") or ""
 
 
@@ -233,7 +246,11 @@ def main(argv: list[str] | None = None, gh=run_gh) -> int:
         )
         return 0
 
-    sha, branch = head_ref(args.repo, run_id, gh=gh)
+    try:
+        sha, branch = head_ref(args.repo, run_id, gh=gh)
+    except RuntimeError as exc:
+        print(f"::error::{exc} — cannot publish provenance for run {run_id}")
+        return 1
     print(f"Conformance run: {run_id}  sha={sha}  branch={branch}")
     write_outputs(
         {

--- a/.github/scripts/fetch_conformance_sarif.py
+++ b/.github/scripts/fetch_conformance_sarif.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""Discover the newest Conformance run with live SARIF and download every series.
+
+Replaces the two inline shell blocks in the ``conformance`` job of
+``.github/workflows/update-dashboard.yaml`` (discover + download), per
+docs/standards/ci.md — both carried loops and conditionals that could not be
+regression-tested from YAML.
+
+Why this exists rather than the old loop
+----------------------------------------
+The download step used to iterate a **hardcoded list of 7 series slugs**::
+
+    for slug in ci error-handling prescriptions optimizations dependency logging tests
+
+The conformance suite has since grown past that list. A hive run on 2026-08-10
+published 10 live SARIF artifacts — ``deprecation``, ``container-image``,
+``contract-toolkit`` and ``security`` were silently dropped, ``dependency`` no
+longer exists at all, and the step cheerfully logged "Downloaded 6 / 7". Every
+per-repo conformance summary on the dashboard was therefore built from a subset
+of the evidence, with nothing anywhere reporting the shortfall.
+
+The series list is now derived from the run's own artifacts, so a new series
+reaches the dashboard the moment the suite emits it. The only naming contract
+is the ``conformance-<series>-sarif`` artifact name, which is asserted by the
+tests.
+
+Outputs written to ``$GITHUB_OUTPUT``:
+
+  * ``has_run``       — a run with live SARIF was found
+  * ``run_id``        — that run's id
+  * ``commit_sha``    — its head SHA
+  * ``branch``        — its head branch
+  * ``has_artifacts`` — at least one series actually downloaded
+  * ``series``        — space-separated series names that downloaded
+
+Exits 0 in the "nothing to publish" cases (no candidate run, no live SARIF) —
+those are routine and gated downstream by ``has_run`` / ``has_artifacts``. A
+download that fails *after* the artifact was confirmed live is a real error and
+propagates, matching the test-readiness path.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+
+ARTIFACT_PREFIX = "conformance-"
+ARTIFACT_SUFFIX = "-sarif"
+
+
+def run_gh(args: list[str]) -> tuple[int, str]:
+    """Invoke ``gh`` and return ``(returncode, stdout)``. Stderr is inherited."""
+    proc = subprocess.run(  # noqa: S603 - fixed argv, no shell
+        ["gh", *args], capture_output=True, text=True
+    )
+    if proc.stderr:
+        sys.stderr.write(proc.stderr)
+    return proc.returncode, proc.stdout
+
+
+def series_name(artifact_name: str) -> str | None:
+    """``conformance-<series>-sarif`` -> ``<series>``; None if it doesn't match.
+
+    Guards against a zero-length series (``conformance--sarif``) and against
+    the affixes overlapping on a too-short name.
+    """
+    if not artifact_name.startswith(ARTIFACT_PREFIX):
+        return None
+    if not artifact_name.endswith(ARTIFACT_SUFFIX):
+        return None
+    inner = artifact_name[len(ARTIFACT_PREFIX) : -len(ARTIFACT_SUFFIX)]
+    return inner or None
+
+
+def live_sarif_series(artifacts_payload: dict) -> list[str]:
+    """Series names of every non-expired conformance SARIF artifact in a run."""
+    out: list[str] = []
+    for artifact in artifacts_payload.get("artifacts", []) or []:
+        if artifact.get("expired"):
+            continue
+        name = series_name(artifact.get("name") or "")
+        if name and name not in out:
+            out.append(name)
+    return out
+
+
+def candidate_runs(payload: list[dict]) -> list[int]:
+    """Run ids worth probing — completed runs that either passed or failed.
+
+    A failing Conformance run still uploads its SARIF (the suite reports
+    findings by design), so ``failure`` is deliberately kept.
+    """
+    return [
+        entry["databaseId"]
+        for entry in payload or []
+        if entry.get("conclusion") in ("success", "failure")
+        and entry.get("databaseId") is not None
+    ]
+
+
+def write_outputs(pairs: dict[str, str]) -> None:
+    path = os.environ.get("GITHUB_OUTPUT", "")
+    lines = [f"{k}={v}" for k, v in pairs.items()]
+    if path:
+        with open(path, "a") as fh:
+            fh.write("\n".join(lines) + "\n")
+    else:
+        print("\n".join(lines))
+
+
+def discover(repo: str, workflow: str, branch: str, limit: int, gh=run_gh):
+    """Newest completed run carrying live SARIF -> ``(run_id, series)``.
+
+    Returns ``(None, [])`` when no run in the window has any. Probing newest
+    first — rather than trusting ``.[0]`` — keeps a repo publishable off an
+    older run when the newest one expired or died before uploading.
+    """
+    rc, out = gh(
+        [
+            "run",
+            "list",
+            "--repo",
+            repo,
+            f"--workflow={workflow}",
+            "--status=completed",
+            f"--branch={branch}",
+            f"--limit={limit}",
+            "--json",
+            "databaseId,conclusion",
+        ]
+    )
+    if rc != 0:
+        print(f"::warning::could not list {workflow} runs for {repo}")
+        return None, []
+
+    try:
+        payload = json.loads(out or "[]")
+    except json.JSONDecodeError:
+        print(f"::warning::unparseable run list for {repo}")
+        return None, []
+
+    for run_id in candidate_runs(payload):
+        rc, out = gh(["api", f"repos/{repo}/actions/runs/{run_id}/artifacts"])
+        if rc != 0:
+            print(f"Run {run_id}: artifact listing failed — trying older")
+            continue
+        try:
+            artifacts = json.loads(out or "{}")
+        except json.JSONDecodeError:
+            print(f"Run {run_id}: unparseable artifact listing — trying older")
+            continue
+        series = live_sarif_series(artifacts)
+        if series:
+            print(
+                f"Run {run_id} has {len(series)} live SARIF artifact(s) "
+                f"({', '.join(series)}) — using it"
+            )
+            return run_id, series
+        print(f"Run {run_id} has no live SARIF artifacts — trying older")
+
+    return None, []
+
+
+def download(repo: str, run_id: int, series: list[str], dest: str, gh=run_gh):
+    """Download one artifact per series. Returns the series that landed.
+
+    Each series is fetched separately so one unretrievable artifact does not
+    cost us the rest of the run's evidence.
+    """
+    os.makedirs(dest, exist_ok=True)
+    got: list[str] = []
+    for name in series:
+        rc, _ = gh(
+            [
+                "run",
+                "download",
+                str(run_id),
+                "--repo",
+                repo,
+                "--name",
+                f"{ARTIFACT_PREFIX}{name}{ARTIFACT_SUFFIX}",
+                "--dir",
+                dest,
+            ]
+        )
+        if rc == 0:
+            got.append(name)
+        else:
+            print(f"::warning::series '{name}' failed to download from run {run_id}")
+    return got
+
+
+def head_ref(repo: str, run_id: int, gh=run_gh) -> tuple[str, str]:
+    rc, out = gh(
+        ["run", "view", str(run_id), "--repo", repo, "--json", "headSha,headBranch"]
+    )
+    if rc != 0:
+        return "", ""
+    try:
+        payload = json.loads(out or "{}")
+    except json.JSONDecodeError:
+        return "", ""
+    return payload.get("headSha") or "", payload.get("headBranch") or ""
+
+
+def main(argv: list[str] | None = None, gh=run_gh) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--repo", required=True, help="owner/name")
+    ap.add_argument("--workflow", default="conformance.yaml")
+    ap.add_argument("--branch", default="main")
+    ap.add_argument("--limit", type=int, default=20)
+    ap.add_argument("--dir", default="/tmp/sarif")
+    args = ap.parse_args(argv)
+
+    run_id, series = discover(args.repo, args.workflow, args.branch, args.limit, gh=gh)
+    if run_id is None:
+        print(
+            f"::warning::No {args.workflow} run with live SARIF artifacts in the "
+            f"last {args.limit} completed runs — skipping conformance dashboard update"
+        )
+        write_outputs({"has_run": "false", "has_artifacts": "false"})
+        return 0
+
+    got = download(args.repo, run_id, series, args.dir, gh=gh)
+    print(f"Downloaded {len(got)} / {len(series)} series SARIF artifacts")
+    if not got:
+        print(f"::warning::No SARIF artifacts retrievable for run {run_id} — skipping")
+        write_outputs(
+            {"has_run": "true", "run_id": str(run_id), "has_artifacts": "false"}
+        )
+        return 0
+
+    sha, branch = head_ref(args.repo, run_id, gh=gh)
+    print(f"Conformance run: {run_id}  sha={sha}  branch={branch}")
+    write_outputs(
+        {
+            "has_run": "true",
+            "run_id": str(run_id),
+            "commit_sha": sha,
+            "branch": branch,
+            "has_artifacts": "true",
+            "series": " ".join(got),
+        }
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/tests/test_dashboard_history_append.py
+++ b/.github/scripts/tests/test_dashboard_history_append.py
@@ -1,0 +1,89 @@
+"""Guards the history-append invariant in .github/workflows/update-dashboard.yaml.
+
+All three dashboard jobs (security/Trivy, conformance, test-readiness) append a
+per-repo trend line to S3 with the same download -> merge -> upload sequence::
+
+    aws s3 cp s3://.../history/<slug>.jsonl /tmp/existing.jsonl 2>/dev/null || true
+    cat /tmp/existing.jsonl /tmp/.../history_<slug>.jsonl | sort -u > /tmp/merged.jsonl
+    aws s3 cp /tmp/merged.jsonl s3://.../history/<slug>.jsonl
+
+On a repo's FIRST publish the S3 object does not exist, so the `cp` no-ops
+(swallowed by `|| true`) and never creates the local file. `cat` then exits 1,
+and because the step runs under `set -euo pipefail` the whole step dies —
+*after* the summary upload has already succeeded. The repo shows up on the
+dashboard but never gets a single history line, and since the history object is
+never created the next run fails identically. It never self-heals.
+
+Only the test-readiness job had the `touch` guard; the Trivy and conformance
+jobs did not, which is why the Conformance tab had no trend data for any repo.
+This test asserts every `cat`-merge in the file is preceded by a `touch` of the
+file it reads.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+WORKFLOW = Path(__file__).parent.parent.parent / "workflows" / "update-dashboard.yaml"
+
+# `cat <existing> <generated> ... | sort -u` — capture the first operand, which
+# is the S3-sourced file that may legitimately not exist.
+_CAT_MERGE = re.compile(r"^\s*cat\s+(/tmp/[\w./${}-]+)", re.MULTILINE)
+
+
+def _text() -> str:
+    return WORKFLOW.read_text()
+
+
+def test_workflow_is_present():
+    assert WORKFLOW.is_file(), f"expected {WORKFLOW} to exist"
+
+
+def test_every_history_merge_touches_its_source_first():
+    text = _text()
+    merges = _CAT_MERGE.findall(text)
+
+    # Three dashboards, three merges. If this count changes, a fourth dashboard
+    # was added (or one removed) and its history path needs the same guard.
+    assert len(merges) == 3, f"expected 3 history merges, found {len(merges)}: {merges}"
+
+    for source in merges:
+        cat_at = text.index(f"cat {source}")
+        preamble = text[:cat_at]
+        assert f"touch {source}" in preamble, (
+            f"`cat {source}` is not preceded by `touch {source}` — a first "
+            f"publish will exit 1 under `set -euo pipefail` after the summary "
+            f"has already been uploaded, leaving the repo permanently without "
+            f"trend history"
+        )
+
+
+def test_each_dashboard_history_file_is_distinct():
+    """Guards against copy-paste that would make two jobs share a temp file."""
+    merges = _CAT_MERGE.findall(_text())
+    assert len(set(merges)) == len(merges), f"duplicate history temp files: {merges}"
+
+
+def test_history_downloads_still_tolerate_a_missing_object():
+    """`|| true` must stay — the touch guard replaces the crash, not the 404."""
+    text = _text()
+    for source in _CAT_MERGE.findall(text):
+        cp_line = next(
+            (ln for ln in text.splitlines() if source in ln and "aws s3 cp" in ln),
+            None,
+        )
+        # Some cp invocations are line-wrapped; fall back to a window search.
+        if cp_line is None:
+            idx = text.index(f"touch {source}")
+            window = text[max(0, idx - 400) : idx]
+            assert "|| true" in window, f"missing `|| true` guard near {source}"
+        else:
+            assert "|| true" in cp_line or "2>/dev/null" in cp_line
+
+
+def test_conformance_job_no_longer_hardcodes_sarif_series():
+    """The 7-slug loop must not come back — series come off the run itself."""
+    text = _text()
+    assert "for slug in ci error-handling" not in text
+    assert "fetch_conformance_sarif.py" in text

--- a/.github/scripts/tests/test_fetch_conformance_sarif.py
+++ b/.github/scripts/tests/test_fetch_conformance_sarif.py
@@ -313,6 +313,31 @@ def test_failed_run_view_aborts_instead_of_publishing_blank_provenance(
     assert "branch" not in out
 
 
+@pytest.mark.parametrize(
+    "head",
+    [
+        {"headSha": None, "headBranch": None},  # null fields
+        {"headSha": "", "headBranch": ""},  # empty strings
+        {"headSha": "0be829be"},  # headBranch missing entirely
+    ],
+)
+def test_blank_run_view_fields_abort_instead_of_publishing_blank_provenance(
+    head, tmp_path, monkeypatch
+):
+    """Regression: a ``gh run view`` that exits 0 with valid JSON but missing/
+    null/empty ``headSha``/``headBranch`` must also abort — returning ``("", "")``
+    here would publish the same blank provenance the rc!=0 guard rejects."""
+    gh = FakeGh(
+        runs=json.dumps([{"databaseId": 5, "conclusion": "success"}]),
+        artifacts_by_run={5: _artifacts([("conformance-ci-sarif", False)])},
+        head=head,
+    )
+    rc, out = _run_main(gh, tmp_path, monkeypatch)
+    assert rc == 1
+    assert "commit_sha" not in out
+    assert "branch" not in out
+
+
 def test_artifacts_land_in_the_requested_dir(tmp_path, monkeypatch):
     gh = FakeGh(
         runs=json.dumps([{"databaseId": 5, "conclusion": "success"}]),

--- a/.github/scripts/tests/test_fetch_conformance_sarif.py
+++ b/.github/scripts/tests/test_fetch_conformance_sarif.py
@@ -1,0 +1,300 @@
+"""Tests for .github/scripts/fetch_conformance_sarif.py.
+
+The regression these guard is the hardcoded 7-series download loop this script
+replaced: the conformance suite grew to 10 series, the loop kept asking for its
+own 7, and every per-repo dashboard summary was silently built from 6 of them.
+`test_downloads_every_series_the_run_published` is that case, using the real
+artifact names from the hive run that exposed it.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import fetch_conformance_sarif as fcs
+
+# The 10 series a real Conformance run published on 2026-08-10 (hive). The old
+# loop knew only: ci, error-handling, prescriptions, optimizations, dependency,
+# logging, tests — note "dependency" is not here at all, and 4 of these are new.
+LIVE_SERIES = [
+    "deprecation",
+    "error-handling",
+    "logging",
+    "tests",
+    "container-image",
+    "ci",
+    "contract-toolkit",
+    "prescriptions",
+    "security",
+    "optimizations",
+]
+
+
+def _artifacts(names_expired: list[tuple[str, bool]]) -> str:
+    return json.dumps(
+        {"artifacts": [{"name": n, "expired": e} for n, e in names_expired]}
+    )
+
+
+class FakeGh:
+    """Records argv and replays canned (rc, stdout) per gh subcommand."""
+
+    def __init__(self, runs="[]", artifacts_by_run=None, download_rc=0, head=None):
+        self.runs = runs
+        self.artifacts_by_run = artifacts_by_run or {}
+        self.download_rc = download_rc
+        self.head = head or {"headSha": "abc123", "headBranch": "main"}
+        self.calls: list[list[str]] = []
+
+    def __call__(self, args: list[str]):
+        self.calls.append(args)
+        if args[:2] == ["run", "list"]:
+            return 0, self.runs
+        if args[0] == "api":
+            run_id = args[1].split("/")[-2]
+            payload = self.artifacts_by_run.get(int(run_id))
+            if payload is None:
+                return 1, ""
+            return 0, payload
+        if args[:2] == ["run", "download"]:
+            rc = self.download_rc
+            if callable(rc):
+                rc = rc(args)
+            return rc, ""
+        if args[:2] == ["run", "view"]:
+            return 0, json.dumps(self.head)
+        raise AssertionError(f"unexpected gh call: {args}")
+
+    def downloaded_names(self) -> list[str]:
+        return [
+            c[c.index("--name") + 1] for c in self.calls if c[:2] == ["run", "download"]
+        ]
+
+
+# --------------------------------------------------------------------------
+# series_name / live_sarif_series
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "artifact,expected",
+    [
+        ("conformance-ci-sarif", "ci"),
+        ("conformance-error-handling-sarif", "error-handling"),
+        ("conformance-container-image-sarif", "container-image"),
+        ("unit-test-coverage", None),
+        ("conformance-ci", None),
+        ("ci-sarif", None),
+        ("conformance--sarif", None),
+        ("", None),
+    ],
+)
+def test_series_name_parses_only_the_contract(artifact, expected):
+    assert fcs.series_name(artifact) == expected
+
+
+def test_live_sarif_series_skips_expired_and_foreign_artifacts():
+    payload = json.loads(
+        _artifacts(
+            [
+                ("conformance-ci-sarif", False),
+                ("conformance-security-sarif", True),  # expired
+                ("unit-test-coverage", False),  # not SARIF
+                ("conformance-logging-sarif", False),
+            ]
+        )
+    )
+    assert fcs.live_sarif_series(payload) == ["ci", "logging"]
+
+
+def test_live_sarif_series_dedupes():
+    payload = json.loads(
+        _artifacts([("conformance-ci-sarif", False), ("conformance-ci-sarif", False)])
+    )
+    assert fcs.live_sarif_series(payload) == ["ci"]
+
+
+def test_live_sarif_series_handles_empty_and_null_payloads():
+    assert fcs.live_sarif_series({}) == []
+    assert fcs.live_sarif_series({"artifacts": None}) == []
+
+
+# --------------------------------------------------------------------------
+# candidate_runs
+# --------------------------------------------------------------------------
+
+
+def test_candidate_runs_keeps_failures_but_drops_cancelled():
+    payload = [
+        {"databaseId": 3, "conclusion": "success"},
+        {"databaseId": 2, "conclusion": "cancelled"},
+        {"databaseId": 1, "conclusion": "failure"},
+        {"databaseId": None, "conclusion": "success"},
+    ]
+    # failure is kept on purpose: a Conformance run that reports findings exits
+    # non-zero but still uploads its SARIF.
+    assert fcs.candidate_runs(payload) == [3, 1]
+
+
+# --------------------------------------------------------------------------
+# discover
+# --------------------------------------------------------------------------
+
+
+def test_discover_falls_back_to_an_older_run_when_newest_has_no_live_sarif():
+    gh = FakeGh(
+        runs=json.dumps(
+            [
+                {"databaseId": 99, "conclusion": "success"},
+                {"databaseId": 98, "conclusion": "failure"},
+            ]
+        ),
+        artifacts_by_run={
+            99: _artifacts([("conformance-ci-sarif", True)]),  # all expired
+            98: _artifacts([("conformance-ci-sarif", False)]),
+        },
+    )
+    run_id, series = fcs.discover("atlanhq/x", "conformance.yaml", "main", 20, gh=gh)
+    assert (run_id, series) == (98, ["ci"])
+
+
+def test_discover_returns_nothing_when_no_run_has_live_sarif():
+    gh = FakeGh(
+        runs=json.dumps([{"databaseId": 99, "conclusion": "success"}]),
+        artifacts_by_run={99: _artifacts([("unit-test-coverage", False)])},
+    )
+    assert fcs.discover("atlanhq/x", "conformance.yaml", "main", 20, gh=gh) == (
+        None,
+        [],
+    )
+
+
+def test_discover_survives_an_unlistable_run():
+    gh = FakeGh(
+        runs=json.dumps(
+            [
+                {"databaseId": 99, "conclusion": "success"},
+                {"databaseId": 98, "conclusion": "success"},
+            ]
+        ),
+        artifacts_by_run={98: _artifacts([("conformance-tests-sarif", False)])},
+    )  # 99 missing -> rc 1
+    assert fcs.discover("atlanhq/x", "conformance.yaml", "main", 20, gh=gh) == (
+        98,
+        ["tests"],
+    )
+
+
+# --------------------------------------------------------------------------
+# end-to-end via main()
+# --------------------------------------------------------------------------
+
+
+def _run_main(gh, tmp_path, monkeypatch, extra=None):
+    out = tmp_path / "gh_output"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(out))
+    rc = fcs.main(
+        ["--repo", "atlanhq/atlan-hive-app", "--dir", str(tmp_path / "sarif")]
+        + (extra or []),
+        gh=gh,
+    )
+    parsed = {}
+    if out.exists():
+        for line in out.read_text().splitlines():
+            if line:
+                k, _, v = line.partition("=")
+                parsed[k] = v
+    return rc, parsed
+
+
+def test_downloads_every_series_the_run_published(tmp_path, monkeypatch):
+    """The 7-vs-10 regression: all live series must be fetched, none assumed."""
+    gh = FakeGh(
+        runs=json.dumps([{"databaseId": 31363142757, "conclusion": "success"}]),
+        artifacts_by_run={
+            31363142757: _artifacts(
+                [(f"conformance-{s}-sarif", False) for s in LIVE_SERIES]
+            )
+        },
+    )
+    rc, out = _run_main(gh, tmp_path, monkeypatch)
+
+    assert rc == 0
+    assert out["has_artifacts"] == "true"
+    assert sorted(out["series"].split()) == sorted(LIVE_SERIES)
+    assert sorted(gh.downloaded_names()) == sorted(
+        f"conformance-{s}-sarif" for s in LIVE_SERIES
+    )
+    # The four series the old hardcoded loop dropped on the floor.
+    for missed in ("deprecation", "container-image", "contract-toolkit", "security"):
+        assert f"conformance-{missed}-sarif" in gh.downloaded_names()
+    # ...and the one it asked for that no longer exists.
+    assert "conformance-dependency-sarif" not in gh.downloaded_names()
+
+
+def test_partial_download_still_publishes_what_landed(tmp_path, monkeypatch):
+    def rc_for(args):
+        return 1 if "conformance-security-sarif" in args else 0
+
+    gh = FakeGh(
+        runs=json.dumps([{"databaseId": 5, "conclusion": "success"}]),
+        artifacts_by_run={
+            5: _artifacts(
+                [("conformance-ci-sarif", False), ("conformance-security-sarif", False)]
+            )
+        },
+        download_rc=rc_for,
+    )
+    rc, out = _run_main(gh, tmp_path, monkeypatch)
+    assert rc == 0
+    assert out["has_artifacts"] == "true"
+    assert out["series"] == "ci"
+
+
+def test_no_run_is_a_clean_skip_not_a_failure(tmp_path, monkeypatch):
+    gh = FakeGh(runs="[]")
+    rc, out = _run_main(gh, tmp_path, monkeypatch)
+    assert rc == 0
+    assert out == {"has_run": "false", "has_artifacts": "false"}
+
+
+def test_all_downloads_failing_is_a_clean_skip(tmp_path, monkeypatch):
+    gh = FakeGh(
+        runs=json.dumps([{"databaseId": 5, "conclusion": "success"}]),
+        artifacts_by_run={5: _artifacts([("conformance-ci-sarif", False)])},
+        download_rc=1,
+    )
+    rc, out = _run_main(gh, tmp_path, monkeypatch)
+    assert rc == 0
+    assert out["has_run"] == "true"
+    assert out["has_artifacts"] == "false"
+    assert "series" not in out
+
+
+def test_head_sha_and_branch_are_published(tmp_path, monkeypatch):
+    gh = FakeGh(
+        runs=json.dumps([{"databaseId": 5, "conclusion": "success"}]),
+        artifacts_by_run={5: _artifacts([("conformance-ci-sarif", False)])},
+        head={"headSha": "0be829be", "headBranch": "main"},
+    )
+    _, out = _run_main(gh, tmp_path, monkeypatch)
+    assert out["commit_sha"] == "0be829be"
+    assert out["branch"] == "main"
+    assert out["run_id"] == "5"
+
+
+def test_artifacts_land_in_the_requested_dir(tmp_path, monkeypatch):
+    gh = FakeGh(
+        runs=json.dumps([{"databaseId": 5, "conclusion": "success"}]),
+        artifacts_by_run={5: _artifacts([("conformance-ci-sarif", False)])},
+    )
+    _run_main(gh, tmp_path, monkeypatch)
+    dl = [c for c in gh.calls if c[:2] == ["run", "download"]][0]
+    assert dl[dl.index("--dir") + 1] == str(tmp_path / "sarif")
+    assert (tmp_path / "sarif").is_dir()

--- a/.github/scripts/tests/test_fetch_conformance_sarif.py
+++ b/.github/scripts/tests/test_fetch_conformance_sarif.py
@@ -45,11 +45,14 @@ def _artifacts(names_expired: list[tuple[str, bool]]) -> str:
 class FakeGh:
     """Records argv and replays canned (rc, stdout) per gh subcommand."""
 
-    def __init__(self, runs="[]", artifacts_by_run=None, download_rc=0, head=None):
+    def __init__(
+        self, runs="[]", artifacts_by_run=None, download_rc=0, head=None, head_rc=0
+    ):
         self.runs = runs
         self.artifacts_by_run = artifacts_by_run or {}
         self.download_rc = download_rc
         self.head = head or {"headSha": "abc123", "headBranch": "main"}
+        self.head_rc = head_rc
         self.calls: list[list[str]] = []
 
     def __call__(self, args: list[str]):
@@ -68,6 +71,8 @@ class FakeGh:
                 rc = rc(args)
             return rc, ""
         if args[:2] == ["run", "view"]:
+            if self.head_rc != 0:
+                return self.head_rc, ""
             return 0, json.dumps(self.head)
         raise AssertionError(f"unexpected gh call: {args}")
 
@@ -287,6 +292,25 @@ def test_head_sha_and_branch_are_published(tmp_path, monkeypatch):
     assert out["commit_sha"] == "0be829be"
     assert out["branch"] == "main"
     assert out["run_id"] == "5"
+
+
+def test_failed_run_view_aborts_instead_of_publishing_blank_provenance(
+    tmp_path, monkeypatch
+):
+    """Regression: the prior shell ran under ``set -euo pipefail``, so a failed
+    ``gh run view`` on an already-confirmed run aborted the step. Publishing
+    with empty ``commit_sha``/``branch`` would bake blank provenance into the
+    dashboard JSON — the lookup failure must propagate as a nonzero exit."""
+    gh = FakeGh(
+        runs=json.dumps([{"databaseId": 5, "conclusion": "success"}]),
+        artifacts_by_run={5: _artifacts([("conformance-ci-sarif", False)])},
+        head_rc=1,
+    )
+    rc, out = _run_main(gh, tmp_path, monkeypatch)
+    assert rc == 1
+    # Nothing is published: no blank commit_sha/branch rows reach the dashboard.
+    assert "commit_sha" not in out
+    assert "branch" not in out
 
 
 def test_artifacts_land_in_the_requested_dir(tmp_path, monkeypatch):

--- a/.github/workflows/update-dashboard.yaml
+++ b/.github/workflows/update-dashboard.yaml
@@ -363,6 +363,12 @@ jobs:
           # Append history (download existing, append, re-upload)
           HISTORY_FILE="history/${SLUG}.jsonl"
           aws s3 cp "s3://kryptonite-store/${{ inputs.dashboard_path }}/${HISTORY_FILE}" /tmp/existing_history.jsonl 2>/dev/null || true
+          # First publish for this repo has no history object yet, so the cp
+          # above no-ops without creating the file. Ensure it exists (empty) so
+          # the cat below does not exit 1 under `set -euo pipefail` — pipefail
+          # propagates cat's failure through the pipe even though sort succeeds,
+          # which aborts the step AFTER the summary has already been uploaded.
+          touch /tmp/existing_history.jsonl
           cat /tmp/existing_history.jsonl /tmp/dashboard-deploy/history_${SLUG}.jsonl 2>/dev/null | sort -u > /tmp/merged_history.jsonl
           aws s3 cp /tmp/merged_history.jsonl "s3://kryptonite-store/${{ inputs.dashboard_path }}/${HISTORY_FILE}"
 
@@ -380,94 +386,38 @@ jobs:
       group: conformance-dashboard-${{ github.repository }}
       cancel-in-progress: false
     steps:
-      - name: Discover latest Conformance run
-        id: discover
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          # The workflow_run trigger fires on "Vulnerability Scan", not
-          # "Conformance". Conformance artifacts live in a separate run —
-          # discover the latest completed one on the default branch.
-          #
-          # Pick the newest run that STILL HAS artifacts, not simply the newest
-          # run. Taking `.[0]` blindly meant that whenever the most recent
-          # Conformance run had no retrievable SARIF (artifacts expired, or the
-          # run died before uploading), the download step below found nothing,
-          # set has_artifacts=false, and the repo was skipped — even though an
-          # older run's SARIF was sitting right there, publishable. Repos that
-          # run Conformance infrequently could sit un-published indefinitely
-          # while every job in the chain reported success.
-          CANDIDATES=$(gh run list \
-            --repo "${{ github.repository }}" \
-            --workflow=conformance.yaml \
-            --status=completed \
-            --branch="${{ github.event.repository.default_branch || 'main' }}" \
-            --limit=20 \
-            --json databaseId,conclusion \
-            --jq '[.[] | select(.conclusion=="success" or .conclusion=="failure")] | .[].databaseId')
+      - name: Checkout SDK scripts
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: atlanhq/application-sdk
+          path: _sdk
+          sparse-checkout: .github/scripts
+          token: ${{ secrets.ORG_PAT_GITHUB || secrets.GITHUB_TOKEN }}
 
-          RUN_ID=""
-          for candidate in ${CANDIDATES}; do
-            # One artifacts call per candidate; count non-expired SARIF series.
-            SARIF_COUNT=$(gh api \
-              "repos/${{ github.repository }}/actions/runs/${candidate}/artifacts" \
-              --jq '[.artifacts[] | select(.expired == false) | select(.name | startswith("conformance-") and endswith("-sarif"))] | length' \
-              2>/dev/null || echo 0)
-            if [ "${SARIF_COUNT:-0}" -gt 0 ]; then
-              RUN_ID="${candidate}"
-              echo "Run ${candidate} has ${SARIF_COUNT} live SARIF artifact(s) — using it"
-              break
-            fi
-            echo "Run ${candidate} has no live SARIF artifacts — trying older"
-          done
-
-          if [ -z "${RUN_ID:-}" ] || [ "$RUN_ID" = "null" ]; then
-            echo "::warning::No Conformance run with live SARIF artifacts in the last 20 completed runs — skipping conformance dashboard update"
-            echo "has_run=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          COMMIT_SHA=$(gh run view "$RUN_ID" --repo "${{ github.repository }}" --json headSha  --jq '.headSha')
-          BRANCH=$(gh run view "$RUN_ID"     --repo "${{ github.repository }}" --json headBranch --jq '.headBranch')
-          echo "Conformance run: $RUN_ID  sha=$COMMIT_SHA  branch=$BRANCH"
-          echo "run_id=$RUN_ID"         >> "$GITHUB_OUTPUT"
-          echo "commit_sha=$COMMIT_SHA" >> "$GITHUB_OUTPUT"
-          echo "branch=$BRANCH"         >> "$GITHUB_OUTPUT"
-          echo "has_run=true"           >> "$GITHUB_OUTPUT"
-
-      - name: Download SARIF artifacts
+      # The workflow_run trigger fires on "Vulnerability Scan", not
+      # "Conformance" — the SARIF lives in a separate run, so it has to be
+      # discovered. The script probes newest-first for a run that STILL HAS
+      # live SARIF (rather than trusting `.[0]`, which left repos that run
+      # Conformance infrequently un-published indefinitely while every job
+      # reported success), then downloads EVERY series that run published.
+      # The series list used to be hardcoded to 7 slugs and had silently
+      # drifted to 6-of-10 fleet-wide; it is now read off the run itself.
+      - name: Discover + download Conformance SARIF
         id: download
-        if: steps.discover.outputs.has_run == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
-          RUN_ID: ${{ steps.discover.outputs.run_id }}
         run: |
           set -euo pipefail
-          mkdir -p /tmp/sarif
-          found=0
-          # All 7 series — download each separately so a missing slug
-          # (e.g. a repo scoped to sdk-only) doesn't fail the whole step.
-          for slug in ci error-handling prescriptions optimizations dependency logging tests; do
-            gh run download "$RUN_ID" \
-              --repo "${{ github.repository }}" \
-              --name "conformance-${slug}-sarif" \
-              --dir /tmp/sarif 2>/dev/null \
-              && found=$((found + 1)) || true
-          done
-          echo "Downloaded $found / 7 series SARIF artifacts"
-          if [ "$found" -eq 0 ]; then
-            echo "::warning::No SARIF artifacts found for run $RUN_ID (expired?) — skipping"
-            echo "has_artifacts=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "has_artifacts=true"  >> "$GITHUB_OUTPUT"
-          fi
+          python3 _sdk/.github/scripts/fetch_conformance_sarif.py \
+            --repo "${{ github.repository }}" \
+            --branch "${{ github.event.repository.default_branch || 'main' }}" \
+            --dir /tmp/sarif
 
       - name: Parse SARIF and generate per-repo summary
         if: steps.download.outputs.has_artifacts == 'true'
         env:
-          CONFORMANCE_SHA: ${{ steps.discover.outputs.commit_sha }}
-          CONFORMANCE_BRANCH: ${{ steps.discover.outputs.branch }}
+          CONFORMANCE_SHA: ${{ steps.download.outputs.commit_sha }}
+          CONFORMANCE_BRANCH: ${{ steps.download.outputs.branch }}
         run: |
           python3 - <<'PYEOF'
           import glob, json, os
@@ -631,6 +581,11 @@ jobs:
           aws s3 cp \
             "s3://kryptonite-store/${PREFIX}/${HISTORY_FILE}" \
             /tmp/existing_conformance_history.jsonl 2>/dev/null || true
+          # Same first-publish guard as the Trivy/test-readiness history paths:
+          # without it `cat` exits 1, pipefail kills the step, and the repo gets
+          # a summary in S3 but never a single history line — which is why the
+          # Conformance tab has no trend data for any repo.
+          touch /tmp/existing_conformance_history.jsonl
           cat /tmp/existing_conformance_history.jsonl \
             "/tmp/conformance-deploy/history_${SLUG}.jsonl" 2>/dev/null \
             | sort -u \


### PR DESCRIPTION
## What

Fleet Drift investigation: the Conformance and Test Maturity tabs list connectors as **"not onboarded"** that the Freshness tab shows as fully onboarded. The two tabs are fed by different pipelines — Freshness is published **centrally** from this repo (one identity, scans all 76 via API, so every repo always appears), while Conformance and Test-Readiness are published **per app repo** by each repo's own `update-dashboard.yml` calling this reusable. Anything that breaks the per-repo publish shows up as `not_onboarded` in connector-pulse, which pads its roster to the full 76.

Two of the causes are defects in this reusable, and both are fleet-wide. They are what this PR fixes.

### 1. Missing first-publish guard on the history append

The Trivy and conformance jobs download the existing history object with `|| true`, then `cat` it:

```bash
aws s3 cp "s3://.../history/${SLUG}.jsonl" /tmp/existing.jsonl 2>/dev/null || true
cat /tmp/existing.jsonl /tmp/.../history_${SLUG}.jsonl | sort -u > /tmp/merged.jsonl
```

On a repo's **first** publish the S3 object does not exist, the `cp` no-ops without creating the local file, `cat` exits 1, and `set -euo pipefail` kills the step — *after* the summary upload already succeeded. Because the history object is never created, the next run fails identically. **It never self-heals.**

Confirmed on three repos, all of which uploaded their summary and then died on that exact line:

| repo | run | outcome |
|---|---|---|
| `atlan-hive-app` | [31363180910](https://github.com/atlanhq/atlan-hive-app/actions/runs/31363180910) | summary + manifest uploaded, then exit 1 |
| `atlan-glue-app` | [31356307550](https://github.com/atlanhq/atlan-glue-app/actions/runs/31356307550) | same |
| `atlan-bridge-app` | [31363257663](https://github.com/atlanhq/atlan-bridge-app/actions/runs/31363257663) | same |

This is why the Conformance tab carries **no trend history for any repo** — and why the conformance job shows red fleet-wide even when the dashboard data lands. The `test-readiness` job already had the `touch` guard (added in #2819); the other two now match it.

### 2. Hardcoded SARIF series list — 6 of 10 series were being dropped

The download step iterated a fixed list of 7 slugs:

```bash
for slug in ci error-handling prescriptions optimizations dependency logging tests; do
```

The suite now publishes **10**. From hive's Conformance run [31363142757](https://github.com/atlanhq/atlan-hive-app/actions/runs/31363142757):

```
conformance-deprecation-sarif       ← dropped
conformance-container-image-sarif   ← dropped
conformance-contract-toolkit-sarif  ← dropped
conformance-security-sarif          ← dropped
conformance-error-handling-sarif    conformance-logging-sarif
conformance-tests-sarif             conformance-ci-sarif
conformance-prescriptions-sarif     conformance-optimizations-sarif
```

`dependency` no longer exists at all. The step logged `Downloaded 6 / 7 series SARIF artifacts` and carried on — so **every per-repo conformance summary on the dashboard was built from a subset of the evidence**, with nothing anywhere reporting the shortfall.

Each artifact holds a uniquely-named `<series>.sarif` and the parse step globs `/tmp/sarif/*.sarif`, so the dropped series are genuinely absent from the summary rather than overwriting one another — verified by downloading two of hive's artifacts side by side.

The shortfall is not fixed at 6-of-10 either; it varies by how many series a repo's Conformance run emitted. Athena's dispatched run today ([31375626648](https://github.com/atlanhq/atlan-athena-app/actions/runs/31375626648)) reported `Run 31363121373 has 11 live SARIF artifact(s)` and then `Downloaded 7 / 7` — 4 of 11 discarded.

Discovery + download move into `.github/scripts/fetch_conformance_sarif.py` per `docs/standards/ci.md` — both inline blocks carried loops and conditionals that could not be regression-tested from YAML, which is precisely how the 7-vs-10 drift went unnoticed. The series list is now read off the run's own artifacts, so a new series reaches the dashboard the moment the suite emits it. The only naming contract left is `conformance-<series>-sarif`, which the tests assert.

Behaviour deliberately preserved: newest-first probing for a run that still has live SARIF (rather than trusting `.[0]`), per-series download so one unretrievable artifact doesn't cost the rest, and clean `exit 0` on the routine "nothing to publish" paths.

## ⚠️ Expect published counts to rise fleet-wide

Once this lands, `failing` / `warning` counts on the Conformance tab will jump for **all 76 repos** as four previously-dropped series start contributing. **That is the first complete number, not a regression** — flagging it so nobody chases a phantom. Pulling in more artifacts may also surface `skew:<v1>,<v2>` toolVersion strings where series came from different runs; that signal is working as designed.

## Not in this PR

The remaining causes are outside this repo and are tracked separately:

- **AWS OIDC trust-policy gap** — `sts:AssumeRoleWithWebIdentity` on `kryptonite-store_FullAccess` is denied for `atlan-google-cloud-lineage-app` and `atlan-workdayprismanalytics-app`. Their jobs compute the data correctly and then cannot upload it. This is an IAM change, not a code change.
- **`atlan-bridge-app`** — bespoke `tests.yaml`, never migrated to `tests-reusable`, so it emits no `test-readiness-scorecard`.

## Tests

`.github/scripts/tests/test_fetch_conformance_sarif.py` (21) — series-name contract, expired/foreign artifact filtering, newest-first fallback, partial download, clean-skip paths, and the 7-vs-10 regression driven with hive's real artifact names (asserting the four dropped series are fetched and that the retired `dependency` slug is not).

`.github/scripts/tests/test_dashboard_history_append.py` (5) — asserts **every** `cat`-merge in the workflow is preceded by a `touch` of the file it reads, that the three dashboards use distinct temp files, that the `|| true` 404 tolerance stays, and that the hardcoded slug loop cannot return.

26/26 pass; pre-commit clean on all touched files.
