### PR TITLE
feat(conformance): add O006 DirectRocksdictImport rule

### DIFF
--- a/packages/conformance/conformance/docs/rules/optimizations.md
+++ b/packages/conformance/conformance/docs/rules/optimizations.md
@@ -5,7 +5,7 @@
 
 # Optimisation / Recommendation Rules (O-series)
 
-**4 rules** · Checker: `suite.checks.optimizations` (AST-based)
+**5 rules** · Checker: `suite.checks.optimizations` (AST-based)
 
 Suppress a finding on the violating line or the line directly above it:
 
@@ -27,6 +27,7 @@ reassigned.
 | [O002](#o002) | `LegacyAssetSerialization` | `warn` | `app` | `asset-mapper` | — | 0.8.0 |
 | [O003](#o003) | `UntypedAssetMapperReturn` | `warn` | `app` | `asset-mapper` | — | 0.8.0 |
 | [O004](#o004) | `LegacyPyatlanAssetImport` | `warn` | `app` | `asset-mapper` | — | 0.8.0 |
+| [O005](#o005) | `DirectRocksdictImport` | `warn` | `app` | `canonical-dependency` | — | 0.18.0 |
 
 ---
 
@@ -141,5 +142,48 @@ NOT autofixable: the v9 models are not a drop-in rename — attribute names and 
 serialization API differ (use `asset.to_nested_bytes()` rather than `.dict()`), so each
 construction site needs review. Suppress with `# conformance: ignore[O004] <reason>`
 when a connector is intentionally pinned to the legacy `AtlasTransformer` surface.
+
+---
+
+## O005 — `DirectRocksdictImport` {#o005}
+
+**Tier:** `warn` · **Scope:** `app` · **Category:** `canonical-dependency` · **Autofixable:** — · **Since:** 0.18.0
+
+> Imports rocksdict directly — prefer the SDK's SpillableDict (pickles values, no hand-rolled serialize/deserialize step)
+
+**Rationale:** SpillableDict (application_sdk.common.spillable_dict) already wraps rocksdict.Rdict as a
+MutableMapping and pickles values directly, so it carries none of the
+hand-rolled-serialization risk a from-scratch wrapper does. Two connectors
+(atlan-thoughtspot-app, atlan-aws-smus-app) independently hand-rolled the same
+RocksDB-backed DiskLookup with an asymmetric JSON serialize/deserialize step — put()
+special-cased str, get() unconditionally ran json.loads() — so a stored string that was
+also valid bare JSON (a numeric-looking name, 'true', 'null') silently came back as
+int/bool/None instead of str (CNCT-80, CNCT-191). WARN (not block) because a
+from-scratch wrapper may have a deliberate reason (custom RocksDB Options, a key type
+outside str/int/float/bool/bytes) that needs a human glance before migrating.
+
+Flags app code that imports the `rocksdict` package directly, in either import form:
+`from rocksdict import Rdict` or `import rocksdict`.  Detection is import-anchored (a
+direct `rocksdict` import is the unambiguous signal — nothing else pulls that dependency
+in).
+
+The SDK ships `application_sdk.common.spillable_dict.SpillableDict` — a
+`MutableMapping`-compatible, disk-backed dict built on the same `rocksdict.Rdict`, which
+pickles values directly rather than hand-rolling a serialize/deserialize step.  It
+exists specifically so connector apps stop reinventing this wrapper.
+
+Motivating incident: `atlan-thoughtspot-app` and `atlan-aws-smus-app` each independently
+wrote a `DiskLookup` class directly on `rocksdict.Rdict` with the identical bug — a
+value's `str` type was silently lost on a round-trip through JSON when the string
+happened to also be valid bare JSON.  Neither connector's hand-rolled wrapper was
+calling anything the SDK had a fleet-wide signal for at the time; this rule is that
+signal going forward.
+
+NOT autofixable: `SpillableDict`'s key type is restricted to `str | int | float | bool |
+bytes` and it has no equivalent to a custom `rocksdict.Options` tuning surface, so each
+call site needs review before migrating.  Suppress with `# conformance: ignore[O005]
+<reason>` when a from-scratch wrapper is deliberate (e.g. custom RocksDB tuning, or
+association-list output like `rocks_backed_dict.py`'s `append_to_key` that
+`SpillableDict` does not provide).
 
 ---

--- a/packages/conformance/conformance/docs/rules/optimizations.md
+++ b/packages/conformance/conformance/docs/rules/optimizations.md
@@ -27,7 +27,7 @@ reassigned.
 | [O002](#o002) | `LegacyAssetSerialization` | `warn` | `app` | `asset-mapper` | — | 0.8.0 |
 | [O003](#o003) | `UntypedAssetMapperReturn` | `warn` | `app` | `asset-mapper` | — | 0.8.0 |
 | [O004](#o004) | `LegacyPyatlanAssetImport` | `warn` | `app` | `asset-mapper` | — | 0.8.0 |
-| [O005](#o005) | `DirectRocksdictImport` | `warn` | `app` | `canonical-dependency` | — | 0.18.0 |
+| [O006](#o006) | `DirectRocksdictImport` | `warn` | `app` | `canonical-dependency` | — | 0.18.0 |
 
 ---
 
@@ -145,7 +145,7 @@ when a connector is intentionally pinned to the legacy `AtlasTransformer` surfac
 
 ---
 
-## O005 — `DirectRocksdictImport` {#o005}
+## O006 — `DirectRocksdictImport` {#o006}
 
 **Tier:** `warn` · **Scope:** `app` · **Category:** `canonical-dependency` · **Autofixable:** — · **Since:** 0.18.0
 
@@ -181,7 +181,7 @@ signal going forward.
 
 NOT autofixable: `SpillableDict`'s key type is restricted to `str | int | float | bool |
 bytes` and it has no equivalent to a custom `rocksdict.Options` tuning surface, so each
-call site needs review before migrating.  Suppress with `# conformance: ignore[O005]
+call site needs review before migrating.  Suppress with `# conformance: ignore[O006]
 <reason>` when a from-scratch wrapper is deliberate (e.g. custom RocksDB tuning, or
 association-list output like `rocks_backed_dict.py`'s `append_to_key` that
 `SpillableDict` does not provide).

--- a/packages/conformance/conformance/programs/areas/optimizations.prose.md
+++ b/packages/conformance/conformance/programs/areas/optimizations.prose.md
@@ -135,6 +135,50 @@ lines around `finding.line` in `finding.file` before proposing a fix.
   B001 deprecation nudge will steer the larger migration.  Classification is
   `"judgment"`.
 
+- **O006 DirectRocksdictImport** (canonical-dependency) — app code imports the
+  `rocksdict` package directly (`from rocksdict import Rdict`, `import
+  rocksdict`, or an aliased/submodule form) and hand-rolls its own RocksDB
+  wrapper.  The SDK already ships
+  `application_sdk.common.spillable_dict.SpillableDict` — a
+  `MutableMapping`-compatible dict built on the same `rocksdict.Rdict` — so the
+  finding is a nudge to stop reinventing the wrapper.  `SpillableDict` is **not**
+  a drop-in import swap, so this is never mechanical — judge the site first:
+
+  - **Values** — `SpillableDict` pickles values on write and unpickles on read,
+    so a hand-rolled JSON serialize/deserialize step (the shape that bit
+    CNCT-80/CNCT-191: `put()` special-cases `str`, `get()` unconditionally runs
+    `json.loads()`, and a stored string that is also valid bare JSON round-trips
+    as `int`/`bool`/`None`) is simply deleted, not translated.  If the wrapper's
+    only serialization is that hand-rolled JSON step, migrating to
+    `SpillableDict` removes the bug class outright.
+  - **Keys** — `SpillableDict` restricts keys to `str | int | float | bool |
+    bytes` and raises `TypeError` on anything else.  If the flagged wrapper keys
+    on a tuple, a `None`, or a custom object, a plain migration will not type —
+    either reshape the key into a supported primitive or suppress (below).
+  - **Options surface** — `SpillableDict` builds its own `rocksdict.Options`
+    internally and exposes no tuning surface.  A wrapper that passes a custom
+    `Options`/`BlockBasedOptions` (block cache, compaction style, prefix
+    extractors) has no equivalent knob — that is a deliberate-`Options` case,
+    so propose an inline `# conformance: ignore[O006] <reason>` naming the
+    tuning it depends on rather than migrating.
+  - **Association-list / merge semantics** — `SpillableDict.append_to_key` is a
+    read-modify-write list append (unpickle the whole list, append, repickle),
+    **not** RocksDB's atomic merge operator: it is not thread-safe and costs
+    O(K²) for K repeated appends to one key.  If the flagged wrapper relies on
+    a native `Rdict` merge/`append_to_key` for atomicity or for high-frequency
+    append throughput, that is a justified suppression —
+    `# conformance: ignore[O006] <reason>` naming the merge semantics
+    `SpillableDict` does not provide.
+
+  When none of those carve-outs applies (picklable values, keys already in
+  `str | int | float | bool | bytes`, no custom `Options`), draft the migration:
+  replace the `rocksdict` import and the hand-rolled wrapper class with
+  `from application_sdk.common.spillable_dict import SpillableDict`, route the
+  call sites through the `MutableMapping` API, and drop the now-dead
+  serialize/deserialize helpers.  Classification is `"judgment"` (the
+  key-type / `Options` / merge-semantics call requires reading the call site),
+  so the edit is routed to residue for human confirmation.
+
 **Suppress outcome (strict mode only, WARNING-tier findings)**:
 
 When `mode == "strict"` and the site legitimately needs stdlib `json` (e.g.

--- a/packages/conformance/conformance/programs/areas/optimizations.prose.md
+++ b/packages/conformance/conformance/programs/areas/optimizations.prose.md
@@ -154,7 +154,9 @@ lines around `finding.line` in `finding.file` before proposing a fix.
   - **Keys** — `SpillableDict` restricts keys to `str | int | float | bool |
     bytes` and raises `TypeError` on anything else.  If the flagged wrapper keys
     on a tuple, a `None`, or a custom object, a plain migration will not type —
-    either reshape the key into a supported primitive or suppress (below).
+    either reshape the key into a supported primitive, or suppress with
+    `# conformance: ignore[O006] <reason naming the non-primitive key type>`
+    (routed to residue).
   - **Options surface** — `SpillableDict` builds its own `rocksdict.Options`
     internally and exposes no tuning surface.  A wrapper that passes a custom
     `Options`/`BlockBasedOptions` (block cache, compaction style, prefix

--- a/packages/conformance/conformance/suite/checks/optimizations/__init__.py
+++ b/packages/conformance/conformance/suite/checks/optimizations/__init__.py
@@ -18,7 +18,7 @@ Currently implemented:
   returns it but has no return annotation.
 * ``O004`` LegacyPyatlanAssetImport — app code importing the legacy
   ``pyatlan.model.assets`` package (rather than ``pyatlan_v9.model.assets``).
-* ``O005`` DirectRocksdictImport — app code importing ``rocksdict`` directly
+* ``O006`` DirectRocksdictImport — app code importing ``rocksdict`` directly
   (rather than the SDK's ``SpillableDict``).
 
 Inline suppression
@@ -57,7 +57,7 @@ from conformance.suite.schema.findings import Finding
 
 from ._asset_mapper import check_o002, check_o003
 from ._pyatlan_v9 import check_o004
-from ._rocksdict import check_o005
+from ._rocksdict import check_o006
 from ._stdlib_json import OrjsonOverStdlibJsonChecker, _collect_json_bindings
 
 SERIES = "O"
@@ -93,7 +93,7 @@ def scan_text(text: str, file: str) -> list[Finding]:
         + check_o002(tree, file, directives)
         + check_o003(tree, file, directives)
         + check_o004(tree, file, directives)
-        + check_o005(tree, file, directives)
+        + check_o006(tree, file, directives)
     )
 
 

--- a/packages/conformance/conformance/suite/checks/optimizations/__init__.py
+++ b/packages/conformance/conformance/suite/checks/optimizations/__init__.py
@@ -18,6 +18,8 @@ Currently implemented:
   returns it but has no return annotation.
 * ``O004`` LegacyPyatlanAssetImport — app code importing the legacy
   ``pyatlan.model.assets`` package (rather than ``pyatlan_v9.model.assets``).
+* ``O005`` DirectRocksdictImport — app code importing ``rocksdict`` directly
+  (rather than the SDK's ``SpillableDict``).
 
 Inline suppression
 ------------------
@@ -55,6 +57,7 @@ from conformance.suite.schema.findings import Finding
 
 from ._asset_mapper import check_o002, check_o003
 from ._pyatlan_v9 import check_o004
+from ._rocksdict import check_o005
 from ._stdlib_json import OrjsonOverStdlibJsonChecker, _collect_json_bindings
 
 SERIES = "O"
@@ -90,6 +93,7 @@ def scan_text(text: str, file: str) -> list[Finding]:
         + check_o002(tree, file, directives)
         + check_o003(tree, file, directives)
         + check_o004(tree, file, directives)
+        + check_o005(tree, file, directives)
     )
 
 

--- a/packages/conformance/conformance/suite/checks/optimizations/_rocksdict.py
+++ b/packages/conformance/conformance/suite/checks/optimizations/_rocksdict.py
@@ -1,0 +1,93 @@
+"""O005 DirectRocksdictImport — flag app code importing ``rocksdict`` directly.
+
+The SDK ships ``application_sdk.common.spillable_dict.SpillableDict`` — a
+``MutableMapping``-compatible, disk-backed dict built on ``rocksdict.Rdict``
+that pickles values directly (no hand-rolled serialization step). It exists
+specifically so connector apps stop hand-rolling their own RocksDB wrapper.
+
+Detection is import-anchored (a direct ``rocksdict`` import is the unambiguous
+signal — nothing else pulls that dependency in) and, symmetrically with O004,
+scoped to app code only: ``application_sdk.common.spillable_dict`` and
+``application_sdk.common.incremental.storage.rocksdb_utils`` are themselves
+the intended callers of ``rocksdict`` and are not subject to this rule (see
+``RuleScope.APP`` on the catalog entry — the SDK is the publisher, not a
+consumer, of this seam).
+
+Motivating incident (CNCT-80/CNCT-191, 2026-08): ``atlan-thoughtspot-app`` and
+``atlan-aws-smus-app`` each independently hand-rolled a ``DiskLookup`` class
+directly on ``rocksdict.Rdict`` with a hand-rolled JSON serialize/deserialize
+step — ``put()`` special-cased ``str`` (stored raw), ``get()`` unconditionally
+ran ``json.loads()`` on every read. A stored string that happened to also be
+valid bare JSON (a numeric-looking name, ``"true"``, ``"null"``) silently came
+back as ``int``/``bool``/``None`` instead of ``str``, corrupting output columns
+and crashing the parquet writer downstream. Two connectors independently wrote
+the same bug because there was no fleet-wide signal nudging either one toward
+the SDK's existing, already-correct ``SpillableDict``.
+
+Three import forms are recognised, mirroring O004's shape:
+
+* ``from rocksdict import Rdict``        (from-import of the package)
+* ``import rocksdict``                   (module import)
+* ``from rocksdict import Rdict as X``   (aliased from-import)
+"""
+
+from __future__ import annotations
+
+import ast
+
+from conformance.suite.checks._ast_common import _IgnoreDirective, make_finding
+from conformance.suite.schema.findings import Finding
+
+_ROCKSDICT_MODULE = "rocksdict"
+_MESSAGE = (
+    "Imports 'rocksdict' directly — prefer "
+    "'application_sdk.common.spillable_dict.SpillableDict', the SDK's "
+    "MutableMapping-compatible disk-backed dict built on the same library. "
+    "Not a drop-in import swap: SpillableDict pickles values (no hand-rolled "
+    "JSON serialize/deserialize step to get wrong) and restricts keys to "
+    "str/int/float/bool/bytes — review call sites before migrating."
+)
+
+
+def _is_rocksdict_module(module: str | None) -> bool:
+    """True if *module* is the ``rocksdict`` package (or a submodule of it)."""
+    return module is not None and (
+        module == _ROCKSDICT_MODULE or module.startswith(f"{_ROCKSDICT_MODULE}.")
+    )
+
+
+def check_o005(
+    tree: ast.AST,
+    filename: str,
+    directives: dict[int, _IgnoreDirective],
+) -> list[Finding]:
+    """Emit O005 for any direct import of ``rocksdict`` in app code."""
+    findings: list[Finding] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            # `from rocksdict import Rdict[, Options, ...]`
+            if _is_rocksdict_module(node.module):
+                findings.append(
+                    make_finding(
+                        filename=filename,
+                        rule_id="O005",
+                        node=node,
+                        message=_MESSAGE,
+                        directives=directives,
+                    )
+                )
+        elif isinstance(node, ast.Import):
+            # `import rocksdict [as x]`
+            for alias in node.names:
+                if _is_rocksdict_module(alias.name):
+                    findings.append(
+                        make_finding(
+                            filename=filename,
+                            rule_id="O005",
+                            node=node,
+                            message=_MESSAGE,
+                            directives=directives,
+                        )
+                    )
+                    break
+    return findings

--- a/packages/conformance/conformance/suite/checks/optimizations/_rocksdict.py
+++ b/packages/conformance/conformance/suite/checks/optimizations/_rocksdict.py
@@ -1,4 +1,4 @@
-"""O005 DirectRocksdictImport — flag app code importing ``rocksdict`` directly.
+"""O006 DirectRocksdictImport — flag app code importing ``rocksdict`` directly.
 
 The SDK ships ``application_sdk.common.spillable_dict.SpillableDict`` — a
 ``MutableMapping``-compatible, disk-backed dict built on ``rocksdict.Rdict``
@@ -56,12 +56,12 @@ def _is_rocksdict_module(module: str | None) -> bool:
     )
 
 
-def check_o005(
+def check_o006(
     tree: ast.AST,
     filename: str,
     directives: dict[int, _IgnoreDirective],
 ) -> list[Finding]:
-    """Emit O005 for any direct import of ``rocksdict`` in app code."""
+    """Emit O006 for any direct import of ``rocksdict`` in app code."""
     findings: list[Finding] = []
     for node in ast.walk(tree):
         if isinstance(node, ast.ImportFrom):
@@ -70,7 +70,7 @@ def check_o005(
                 findings.append(
                     make_finding(
                         filename=filename,
-                        rule_id="O005",
+                        rule_id="O006",
                         node=node,
                         message=_MESSAGE,
                         directives=directives,
@@ -83,7 +83,7 @@ def check_o005(
                     findings.append(
                         make_finding(
                             filename=filename,
-                            rule_id="O005",
+                            rule_id="O006",
                             node=node,
                             message=_MESSAGE,
                             directives=directives,

--- a/packages/conformance/conformance/suite/rules/optimizations.py
+++ b/packages/conformance/conformance/suite/rules/optimizations.py
@@ -181,7 +181,7 @@ RULES: tuple[RuleDefinition, ...] = (
         help_uri="https://github.com/atlanhq/application-sdk/blob/main/packages/conformance/conformance/docs/rules/optimizations.md#o004",
     ),
     RuleDefinition(
-        id="O005",
+        id="O006",
         scope=RuleScope.APP,
         name="DirectRocksdictImport",
         tier=EnforcementTier.WARN,
@@ -234,11 +234,11 @@ RULES: tuple[RuleDefinition, ...] = (
             "``str | int | float | bool | bytes`` and it has no equivalent to a "
             "custom ``rocksdict.Options`` tuning surface, so each call site needs "
             "review before migrating.  Suppress with ``# conformance: "
-            "ignore[O005] <reason>`` when a from-scratch wrapper is deliberate "
+            "ignore[O006] <reason>`` when a from-scratch wrapper is deliberate "
             "(e.g. custom RocksDB tuning, or association-list output like "
             "``rocks_backed_dict.py``'s ``append_to_key`` that ``SpillableDict`` "
             "does not provide).\n"
         ),
-        help_uri="https://github.com/atlanhq/application-sdk/blob/main/packages/conformance/conformance/docs/rules/optimizations.md#o005",
+        help_uri="https://github.com/atlanhq/application-sdk/blob/main/packages/conformance/conformance/docs/rules/optimizations.md#o006",
     ),
 )

--- a/packages/conformance/conformance/suite/rules/optimizations.py
+++ b/packages/conformance/conformance/suite/rules/optimizations.py
@@ -180,4 +180,65 @@ RULES: tuple[RuleDefinition, ...] = (
         ),
         help_uri="https://github.com/atlanhq/application-sdk/blob/main/packages/conformance/conformance/docs/rules/optimizations.md#o004",
     ),
+    RuleDefinition(
+        id="O005",
+        scope=RuleScope.APP,
+        name="DirectRocksdictImport",
+        tier=EnforcementTier.WARN,
+        mechanism=RuleMechanism.STATIC,
+        category="canonical-dependency",
+        autofixable=False,
+        orthogonal_gate="tests",
+        since="0.18.0",
+        rationale=(
+            "SpillableDict (application_sdk.common.spillable_dict) already wraps "
+            "rocksdict.Rdict as a MutableMapping and pickles values directly, so it "
+            "carries none of the hand-rolled-serialization risk a from-scratch "
+            "wrapper does. Two connectors (atlan-thoughtspot-app, "
+            "atlan-aws-smus-app) independently hand-rolled the same RocksDB-backed "
+            "DiskLookup with an asymmetric JSON serialize/deserialize step — put() "
+            "special-cased str, get() unconditionally ran json.loads() — so a "
+            "stored string that was also valid bare JSON (a numeric-looking name, "
+            "'true', 'null') silently came back as int/bool/None instead of str "
+            "(CNCT-80, CNCT-191). WARN (not block) because a from-scratch wrapper "
+            "may have a deliberate reason (custom RocksDB Options, a key type "
+            "outside str/int/float/bool/bytes) that needs a human glance before "
+            "migrating."
+        ),
+        short_description=(
+            "Imports rocksdict directly — prefer the SDK's SpillableDict "
+            "(pickles values, no hand-rolled serialize/deserialize step)"
+        ),
+        full_description=(
+            "Flags app code that imports the ``rocksdict`` package directly, in "
+            "either import form: ``from rocksdict import Rdict`` or ``import "
+            "rocksdict``.  Detection is import-anchored (a direct ``rocksdict`` "
+            "import is the unambiguous signal — nothing else pulls that dependency "
+            "in).\n"
+            "\n"
+            "The SDK ships ``application_sdk.common.spillable_dict.SpillableDict`` "
+            "— a ``MutableMapping``-compatible, disk-backed dict built on the same "
+            "``rocksdict.Rdict``, which pickles values directly rather than "
+            "hand-rolling a serialize/deserialize step.  It exists specifically so "
+            "connector apps stop reinventing this wrapper.\n"
+            "\n"
+            "Motivating incident: ``atlan-thoughtspot-app`` and "
+            "``atlan-aws-smus-app`` each independently wrote a ``DiskLookup`` class "
+            "directly on ``rocksdict.Rdict`` with the identical bug — a value's "
+            "``str`` type was silently lost on a round-trip through JSON when the "
+            "string happened to also be valid bare JSON.  Neither connector's "
+            "hand-rolled wrapper was calling anything the SDK had a fleet-wide "
+            "signal for at the time; this rule is that signal going forward.\n"
+            "\n"
+            "NOT autofixable: ``SpillableDict``'s key type is restricted to "
+            "``str | int | float | bool | bytes`` and it has no equivalent to a "
+            "custom ``rocksdict.Options`` tuning surface, so each call site needs "
+            "review before migrating.  Suppress with ``# conformance: "
+            "ignore[O005] <reason>`` when a from-scratch wrapper is deliberate "
+            "(e.g. custom RocksDB tuning, or association-list output like "
+            "``rocks_backed_dict.py``'s ``append_to_key`` that ``SpillableDict`` "
+            "does not provide).\n"
+        ),
+        help_uri="https://github.com/atlanhq/application-sdk/blob/main/packages/conformance/conformance/docs/rules/optimizations.md#o005",
+    ),
 )

--- a/packages/conformance/tests/test_asset_mapper.py
+++ b/packages/conformance/tests/test_asset_mapper.py
@@ -1,6 +1,7 @@
-"""Tests for the asset-mapper usage rules (O002, O003, O004 — BLDX-1492).
+"""Tests for the asset-mapper usage rules (O002, O003, O004 — BLDX-1492) and the
+adjacent import-anchored canonical-dependency rule O005 (CNCT-80, CNCT-191).
 
-All three live in the optimizations check package.  Each is exercised through the
+All four live in the optimizations check package.  Each is exercised through the
 package ``scan_text`` so the real wiring (import collection, suppression handling)
 is covered, not just the bare detector.
 """
@@ -44,6 +45,47 @@ def test_o004_suppressed_inline() -> None:
         "# conformance: ignore[O004] legacy AtlasTransformer connector\n"
     )
     findings = [f for f in o_scan(src, "app/x.py") if f.rule_id == "O004"]
+    assert len(findings) == 1
+    assert findings[0].suppressed is True
+
+
+# ── O005 DirectRocksdictImport ──────────────────────────────────────────────────
+
+
+def test_o005_fires_on_from_import() -> None:
+    assert "O005" in _o_ids("from rocksdict import Rdict\n")
+
+
+def test_o005_fires_on_aliased_from_import() -> None:
+    assert "O005" in _o_ids("from rocksdict import Rdict as RD\n")
+
+
+def test_o005_fires_on_module_import() -> None:
+    assert "O005" in _o_ids("import rocksdict\n")
+
+
+def test_o005_fires_on_submodule_from_import() -> None:
+    # A hypothetical rocksdict.options submodule import must still match —
+    # the whole rocksdict namespace is the signal, not just the top-level Rdict.
+    assert "O005" in _o_ids("from rocksdict.options import Options\n")
+
+
+def test_o005_silent_on_spillable_dict_import() -> None:
+    assert "O005" not in _o_ids(
+        "from application_sdk.common.spillable_dict import SpillableDict\n"
+    )
+
+
+def test_o005_silent_on_unrelated_import() -> None:
+    assert "O005" not in _o_ids("import sqlite3\n")
+
+
+def test_o005_suppressed_inline() -> None:
+    src = (
+        "from rocksdict import Rdict  "
+        "# conformance: ignore[O005] custom Options tuning, reviewed\n"
+    )
+    findings = [f for f in o_scan(src, "app/x.py") if f.rule_id == "O005"]
     assert len(findings) == 1
     assert findings[0].suppressed is True
 

--- a/packages/conformance/tests/test_asset_mapper.py
+++ b/packages/conformance/tests/test_asset_mapper.py
@@ -1,5 +1,5 @@
 """Tests for the asset-mapper usage rules (O002, O003, O004 — BLDX-1492) and the
-adjacent import-anchored canonical-dependency rule O005 (CNCT-80, CNCT-191).
+adjacent import-anchored canonical-dependency rule O006 (CNCT-80, CNCT-191).
 
 All four live in the optimizations check package.  Each is exercised through the
 package ``scan_text`` so the real wiring (import collection, suppression handling)
@@ -49,43 +49,43 @@ def test_o004_suppressed_inline() -> None:
     assert findings[0].suppressed is True
 
 
-# ── O005 DirectRocksdictImport ──────────────────────────────────────────────────
+# ── O006 DirectRocksdictImport ──────────────────────────────────────────────────
 
 
-def test_o005_fires_on_from_import() -> None:
-    assert "O005" in _o_ids("from rocksdict import Rdict\n")
+def test_o006_fires_on_from_import() -> None:
+    assert "O006" in _o_ids("from rocksdict import Rdict\n")
 
 
-def test_o005_fires_on_aliased_from_import() -> None:
-    assert "O005" in _o_ids("from rocksdict import Rdict as RD\n")
+def test_o006_fires_on_aliased_from_import() -> None:
+    assert "O006" in _o_ids("from rocksdict import Rdict as RD\n")
 
 
-def test_o005_fires_on_module_import() -> None:
-    assert "O005" in _o_ids("import rocksdict\n")
+def test_o006_fires_on_module_import() -> None:
+    assert "O006" in _o_ids("import rocksdict\n")
 
 
-def test_o005_fires_on_submodule_from_import() -> None:
+def test_o006_fires_on_submodule_from_import() -> None:
     # A hypothetical rocksdict.options submodule import must still match —
     # the whole rocksdict namespace is the signal, not just the top-level Rdict.
-    assert "O005" in _o_ids("from rocksdict.options import Options\n")
+    assert "O006" in _o_ids("from rocksdict.options import Options\n")
 
 
-def test_o005_silent_on_spillable_dict_import() -> None:
-    assert "O005" not in _o_ids(
+def test_o006_silent_on_spillable_dict_import() -> None:
+    assert "O006" not in _o_ids(
         "from application_sdk.common.spillable_dict import SpillableDict\n"
     )
 
 
-def test_o005_silent_on_unrelated_import() -> None:
-    assert "O005" not in _o_ids("import sqlite3\n")
+def test_o006_silent_on_unrelated_import() -> None:
+    assert "O006" not in _o_ids("import sqlite3\n")
 
 
-def test_o005_suppressed_inline() -> None:
+def test_o006_suppressed_inline() -> None:
     src = (
         "from rocksdict import Rdict  "
-        "# conformance: ignore[O005] custom Options tuning, reviewed\n"
+        "# conformance: ignore[O006] custom Options tuning, reviewed\n"
     )
-    findings = [f for f in o_scan(src, "app/x.py") if f.rule_id == "O005"]
+    findings = [f for f in o_scan(src, "app/x.py") if f.rule_id == "O006"]
     assert len(findings) == 1
     assert findings[0].suppressed is True
 

--- a/packages/conformance/tests/test_catalog.py
+++ b/packages/conformance/tests/test_catalog.py
@@ -162,7 +162,7 @@ def test_catalog_app_scoped_rules_are_the_expected_set() -> None:
     # O002/O003/O004: asset-mapper usage — connectors build assets with pyatlan_v9,
     # serialize with to_nested_bytes, and type their mapper returns (BLDX-1492); the
     # SDK is the framework, not a connector.
-    # O005: direct rocksdict import — application_sdk.common.spillable_dict and
+    # O006: direct rocksdict import — application_sdk.common.spillable_dict and
     # application_sdk.common.incremental.storage.rocksdb_utils are themselves the
     # intended callers of rocksdict; the SDK is the publisher of this seam, not a
     # consumer of it (CNCT-80, CNCT-191).
@@ -271,7 +271,7 @@ def test_catalog_app_scoped_rules_are_the_expected_set() -> None:
         "O002",
         "O003",
         "O004",
-        "O005",
+        "O006",
         "I001",
         "I002",
         "I003",
@@ -477,7 +477,7 @@ def test_catalog_o_series_present() -> None:
     """The O-series optimisation rules are all present."""
     rules = load_catalog()
     o_ids = {r.id for r in rules if r.id.startswith("O")}
-    expected = {"O001", "O002", "O003", "O004", "O005"}
+    expected = {"O001", "O002", "O003", "O004", "O006"}
     missing = expected - o_ids
     assert not missing, f"Missing O-series rules: {missing}"
 

--- a/packages/conformance/tests/test_catalog.py
+++ b/packages/conformance/tests/test_catalog.py
@@ -162,6 +162,10 @@ def test_catalog_app_scoped_rules_are_the_expected_set() -> None:
     # O002/O003/O004: asset-mapper usage — connectors build assets with pyatlan_v9,
     # serialize with to_nested_bytes, and type their mapper returns (BLDX-1492); the
     # SDK is the framework, not a connector.
+    # O005: direct rocksdict import — application_sdk.common.spillable_dict and
+    # application_sdk.common.incremental.storage.rocksdb_utils are themselves the
+    # intended callers of rocksdict; the SDK is the publisher of this seam, not a
+    # consumer of it (CNCT-80, CNCT-191).
     # K001/K002: contract-toolkit conformance — only app repos have a contract/
     # directory with .pkl source files; the SDK has no contract/ dir to scan
     # (BLDX-1479).
@@ -267,6 +271,7 @@ def test_catalog_app_scoped_rules_are_the_expected_set() -> None:
         "O002",
         "O003",
         "O004",
+        "O005",
         "I001",
         "I002",
         "I003",
@@ -472,7 +477,7 @@ def test_catalog_o_series_present() -> None:
     """The O-series optimisation rules are all present."""
     rules = load_catalog()
     o_ids = {r.id for r in rules if r.id.startswith("O")}
-    expected = {"O001", "O002", "O003", "O004"}
+    expected = {"O001", "O002", "O003", "O004", "O005"}
     missing = expected - o_ids
     assert not missing, f"Missing O-series rules: {missing}"
 


### PR DESCRIPTION
## Linked issue
https://linear.app/atlan-epd/issue/FND-163/parquet-nulllarge-string-typing-two-duplicate-sdk-fixes-still-leaking

## Problem

`atlan-thoughtspot-app` and `atlan-aws-smus-app` each independently hand-rolled a RocksDB-backed `DiskLookup` class with an asymmetric JSON serialize/deserialize step:

```python
def put(self, key, value):
    serialized_value = json.dumps(value) if not isinstance(value, str) else value
    self._db[str(key)] = serialized_value

def get(self, key, default=None):
    value = self._db[str(key)]
    try:
        return json.loads(value)          # unconditional — no matching str-shortcut
    except (json.JSONDecodeError, TypeError):
        return value
```

`put()` special-cases `str` and stores it raw; `get()` unconditionally tries `json.loads()`. A stored string that also happens to be valid bare JSON (a numeric-looking name, `"true"`, `"null"`) silently round-trips back as `int`/`bool`/`None` instead of `str` — corrupting output columns and, in ThoughtSpot's case, crashing the downstream parquet writer (CNCT-191; the Teradata/Presto sibling bug is CNCT-80).

Neither connector had a fleet-wide signal nudging it toward `application_sdk.common.spillable_dict.SpillableDict`, which already wraps the same `rocksdict.Rdict` and pickles values directly — no hand-rolled serialize/deserialize step to get wrong. Two connectors independently wrote the same bug because nothing pointed either one at the SDK utility that already solves it.

## Fix

New O006 `DirectRocksdictImport` rule (WARN, `scope=app`), mirroring O004's import-anchored shape: flags any direct `from rocksdict import ...` / `import rocksdict` in app code, recommending `SpillableDict` instead. `application_sdk.common.spillable_dict` and `application_sdk.common.incremental.storage.rocksdb_utils` — the SDK's own intended callers of `rocksdict` — are excluded via the existing `scope=APP` mechanism (the SDK is the publisher of this seam, not a subject of the rule).

Numbered O006, not O005: #3094 (`UnresolvedAppNamePlaceholder`) claims O005 and merges first, so this rule takes the next free ID.

Not autofixable — `SpillableDict`'s key type is restricted to `str | int | float | bool | bytes` and it has no custom `rocksdict.Options` tuning surface, so each site needs review before migrating. Suppressible with `# conformance: ignore[O006] <reason>`.

## Test plan

- [x] `check_o006` unit tests: from-import, aliased from-import, module import, submodule from-import, silent on `SpillableDict`/unrelated imports, inline suppression (`test_asset_mapper.py`)
- [x] Catalog tests updated: `test_catalog_o_series_present`, `test_catalog_app_scoped_rules_are_the_expected_set`
- [x] Regenerated `docs/rules/optimizations.md` via `gen-rule-docs`
- [x] Full `packages/conformance` suite: 2159 passed (1 pre-existing failure unrelated to this change — `test_sdk_base_names_matches_templates_all` needs a sibling `application_sdk` install not present in this standalone checkout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
