### PR TITLE
fix(handler): filesystem-resolve bundle marketplace entrypoints for input-contract and bare-manifest

### DIFF
--- a/.github/scripts/fetch_conformance_sarif.py
+++ b/.github/scripts/fetch_conformance_sarif.py
@@ -26,12 +26,17 @@ tests.
 
 Outputs written to ``$GITHUB_OUTPUT``:
 
-  * ``has_run``       — a run with live SARIF was found
-  * ``run_id``        — that run's id
-  * ``commit_sha``    — its head SHA
-  * ``branch``        — its head branch
-  * ``has_artifacts`` — at least one series actually downloaded
-  * ``series``        — space-separated series names that downloaded
+  * ``has_run``         — a run with live SARIF was found
+  * ``run_id``          — that run's id
+  * ``commit_sha``      — its head SHA
+  * ``branch``          — its head branch
+  * ``has_artifacts``   — at least one series actually downloaded
+  * ``series``          — space-separated series names that downloaded
+  * ``discovery_error`` — ``true`` when discovery *itself* failed (the
+    ``run list``/artifact-listing call errored or returned unparseable JSON),
+    as opposed to the routine "no qualifying run" case. Always ``false`` when a
+    run was found. Lets the workflow warn loudly on an operational fault
+    (auth/transport/API) without failing the best-effort publish red.
 
 Exits 0 in the "nothing to publish" cases (no candidate run, no live SARIF) —
 those are routine and gated downstream by ``has_run`` / ``has_artifacts``. A
@@ -118,11 +123,18 @@ def write_outputs(pairs: dict[str, str]) -> None:
 
 
 def discover(repo: str, workflow: str, branch: str, limit: int, gh=run_gh):
-    """Newest completed run carrying live SARIF -> ``(run_id, series)``.
+    """Newest completed run carrying live SARIF -> ``(run_id, series, error)``.
 
-    Returns ``(None, [])`` when no run in the window has any. Probing newest
-    first — rather than trusting ``.[0]`` — keeps a repo publishable off an
-    older run when the newest one expired or died before uploading.
+    Returns ``(None, [], False)`` when no run in the window has any — the
+    routine case. Probing newest first — rather than trusting ``.[0]`` — keeps
+    a repo publishable off an older run when the newest one expired or died
+    before uploading.
+
+    The third element flags an *operational* fault in discovery itself: the
+    ``run list`` call failing or returning unparseable JSON, or every probe of a
+    candidate run erroring. Those are auth/transport/API problems, not
+    "nothing to publish", so they surface separately (``discovery_error``) for
+    the workflow to warn on loudly, without turning the best-effort publish red.
     """
     rc, out = gh(
         [
@@ -140,34 +152,46 @@ def discover(repo: str, workflow: str, branch: str, limit: int, gh=run_gh):
     )
     if rc != 0:
         print(f"::warning::could not list {workflow} runs for {repo}")
-        return None, []
+        return None, [], True
 
     try:
         payload = json.loads(out or "[]")
     except json.JSONDecodeError:
         print(f"::warning::unparseable run list for {repo}")
-        return None, []
+        return None, [], True
 
-    for run_id in candidate_runs(payload):
+    candidates = candidate_runs(payload)
+    probed = 0
+    probe_errors = 0
+    for run_id in candidates:
         rc, out = gh(["api", f"repos/{repo}/actions/runs/{run_id}/artifacts"])
         if rc != 0:
             print(f"Run {run_id}: artifact listing failed — trying older")
+            probed += 1
+            probe_errors += 1
             continue
         try:
             artifacts = json.loads(out or "{}")
         except json.JSONDecodeError:
             print(f"Run {run_id}: unparseable artifact listing — trying older")
+            probed += 1
+            probe_errors += 1
             continue
+        probed += 1
         series = live_sarif_series(artifacts)
         if series:
             print(
                 f"Run {run_id} has {len(series)} live SARIF artifact(s) "
                 f"({', '.join(series)}) — using it"
             )
-            return run_id, series
+            return run_id, series, False
         print(f"Run {run_id} has no live SARIF artifacts — trying older")
 
-    return None, []
+    # Discovery errored only if EVERY candidate probe failed; at least one
+    # listing that parsed (even with zero live SARIF) means the API is healthy
+    # and this is the routine "nothing to publish" case.
+    error = probed > 0 and probe_errors == probed
+    return None, [], error
 
 
 def download(repo: str, run_id: int, series: list[str], dest: str, gh=run_gh):
@@ -233,13 +257,21 @@ def main(argv: list[str] | None = None, gh=run_gh) -> int:
     ap.add_argument("--dir", default="/tmp/sarif")
     args = ap.parse_args(argv)
 
-    run_id, series = discover(args.repo, args.workflow, args.branch, args.limit, gh=gh)
+    run_id, series, discovery_error = discover(
+        args.repo, args.workflow, args.branch, args.limit, gh=gh
+    )
     if run_id is None:
         print(
             f"::warning::No {args.workflow} run with live SARIF artifacts in the "
             f"last {args.limit} completed runs — skipping conformance dashboard update"
         )
-        write_outputs({"has_run": "false", "has_artifacts": "false"})
+        write_outputs(
+            {
+                "has_run": "false",
+                "has_artifacts": "false",
+                "discovery_error": "true" if discovery_error else "false",
+            }
+        )
         return 0
 
     got = download(args.repo, run_id, series, args.dir, gh=gh)

--- a/.github/scripts/tests/test_fetch_conformance_sarif.py
+++ b/.github/scripts/tests/test_fetch_conformance_sarif.py
@@ -165,8 +165,10 @@ def test_discover_falls_back_to_an_older_run_when_newest_has_no_live_sarif():
             98: _artifacts([("conformance-ci-sarif", False)]),
         },
     )
-    run_id, series = fcs.discover("atlanhq/x", "conformance.yaml", "main", 20, gh=gh)
-    assert (run_id, series) == (98, ["ci"])
+    run_id, series, error = fcs.discover(
+        "atlanhq/x", "conformance.yaml", "main", 20, gh=gh
+    )
+    assert (run_id, series, error) == (98, ["ci"], False)
 
 
 def test_discover_returns_nothing_when_no_run_has_live_sarif():
@@ -177,6 +179,7 @@ def test_discover_returns_nothing_when_no_run_has_live_sarif():
     assert fcs.discover("atlanhq/x", "conformance.yaml", "main", 20, gh=gh) == (
         None,
         [],
+        False,
     )
 
 
@@ -189,10 +192,80 @@ def test_discover_survives_an_unlistable_run():
             ]
         ),
         artifacts_by_run={98: _artifacts([("conformance-tests-sarif", False)])},
-    )  # 99 missing -> rc 1
+    )  # 99 missing -> rc 1, but 98 lists fine -> not an error
     assert fcs.discover("atlanhq/x", "conformance.yaml", "main", 20, gh=gh) == (
         98,
         ["tests"],
+        False,
+    )
+
+
+# --------------------------------------------------------------------------
+# discover: error signal
+# --------------------------------------------------------------------------
+
+
+class _FailingGh:
+    """Every gh call fails — simulates a transport/auth outage."""
+
+    def __call__(self, args: list[str]):
+        return 1, ""
+
+
+def test_discover_flags_error_when_run_list_fails():
+    assert fcs.discover(
+        "atlanhq/x", "conformance.yaml", "main", 20, gh=_FailingGh()
+    ) == (
+        None,
+        [],
+        True,
+    )
+
+
+def test_discover_flags_error_when_run_list_is_unparseable():
+    gh = FakeGh(runs="not json")
+    assert fcs.discover("atlanhq/x", "conformance.yaml", "main", 20, gh=gh) == (
+        None,
+        [],
+        True,
+    )
+
+
+def test_discover_flags_error_when_every_probe_fails():
+    # Two candidates, neither has a retrievable artifact listing -> operational
+    # fault, not "nothing to publish".
+    gh = FakeGh(
+        runs=json.dumps(
+            [
+                {"databaseId": 99, "conclusion": "success"},
+                {"databaseId": 98, "conclusion": "success"},
+            ]
+        ),
+        artifacts_by_run={},  # both runs unlistable -> rc 1 each
+    )
+    assert fcs.discover("atlanhq/x", "conformance.yaml", "main", 20, gh=gh) == (
+        None,
+        [],
+        True,
+    )
+
+
+def test_discover_no_error_when_a_probe_succeeds_with_zero_live_sarif():
+    # Newest run unlistable, older run lists fine but has no SARIF -> the API is
+    # healthy; this is the routine empty case, not an error.
+    gh = FakeGh(
+        runs=json.dumps(
+            [
+                {"databaseId": 99, "conclusion": "success"},
+                {"databaseId": 98, "conclusion": "success"},
+            ]
+        ),
+        artifacts_by_run={98: _artifacts([("conformance-ci-sarif", True)])},  # expired
+    )
+    assert fcs.discover("atlanhq/x", "conformance.yaml", "main", 20, gh=gh) == (
+        None,
+        [],
+        False,
     )
 
 
@@ -266,7 +339,22 @@ def test_no_run_is_a_clean_skip_not_a_failure(tmp_path, monkeypatch):
     gh = FakeGh(runs="[]")
     rc, out = _run_main(gh, tmp_path, monkeypatch)
     assert rc == 0
-    assert out == {"has_run": "false", "has_artifacts": "false"}
+    assert out == {
+        "has_run": "false",
+        "has_artifacts": "false",
+        "discovery_error": "false",
+    }
+
+
+def test_discovery_failure_sets_discovery_error_output(tmp_path, monkeypatch):
+    """An operational fault (run list fails) must surface as discovery_error=true
+    while still exiting 0 — the workflow warns loudly without failing the
+    best-effort publish red."""
+    rc, out = _run_main(_FailingGh(), tmp_path, monkeypatch)
+    assert rc == 0
+    assert out["has_run"] == "false"
+    assert out["has_artifacts"] == "false"
+    assert out["discovery_error"] == "true"
 
 
 def test_all_downloads_failing_is_a_clean_skip(tmp_path, monkeypatch):

--- a/.github/workflows/update-dashboard.yaml
+++ b/.github/workflows/update-dashboard.yaml
@@ -413,6 +413,16 @@ jobs:
             --branch "${{ github.event.repository.default_branch || 'main' }}" \
             --dir /tmp/sarif
 
+      # `has_artifacts == 'false'` is ambiguous on its own: it covers both
+      # "this repo genuinely has no conformance data yet" (benign) and "the
+      # `gh run list` / artifact probe itself errored" (the dashboard silently
+      # goes stale). The script separates the two via `discovery_error`; surface
+      # only the second so a stale panel is attributable.
+      - name: Warn on conformance discovery failure
+        if: steps.download.outputs.discovery_error == 'true'
+        run: |
+          echo "::warning::Conformance SARIF discovery failed (gh run list / artifact probe error) — dashboard may be stale."
+
       - name: Parse SARIF and generate per-repo summary
         if: steps.download.outputs.has_artifacts == 'true'
         env:

--- a/application_sdk/handler/service.py
+++ b/application_sdk/handler/service.py
@@ -959,6 +959,58 @@ def _published_input_contract(ep: Any) -> Any:
     return ep.input_type
 
 
+def _marketplace_entrypoint_contract(entrypoint_name: str) -> Any | None:
+    """Resolve a *marketplace* entry point's published input contract from disk.
+
+    Bundle ("uber") apps expose marketplace entry points as generated contract
+    directories — ``CONTRACT_GENERATED_DIR/<entrypoint>/manifest.json`` — whose
+    DAGs are computed per submission by ``compute_manifest``. Those entry
+    points are **not** ``@entrypoint`` workflow registrations (the registry
+    holds the DAG-node workflows, e.g. ``<entrypoint>-post``), so registry
+    resolution 404s on them and ``/v1/app`` creation breaks even though the
+    manifest and configmap routes — which are filesystem-first — serve them
+    fine. This gives the input-contract route the same filesystem authority.
+
+    The contract toolkit emits each bundle entry point's ``AppInputContract``
+    as ``_input.py``; because the kebab-named generated dir is not a Python
+    package, the bundle regen convention relocates it to
+    ``app/<entrypoint_snake>/_input.py``. Check the in-place generated path
+    first (parity with ``_published_input_contract``), then the relocation
+    path.
+
+    Returns ``None`` when the entry point has no generated contract dir or no
+    importable ``AppInputContract`` — callers fall back to their existing
+    behavior.
+    """
+    import importlib  # noqa: PLC0415 — cold path: only on /input-contract
+
+    from application_sdk.app.entrypoint import (  # noqa: PLC0415 — circular at module import time
+        entrypoint_module_segment,
+    )
+
+    if not (CONTRACT_GENERATED_DIR / entrypoint_name / "manifest.json").is_file():
+        return None
+    ep_module = entrypoint_module_segment(entrypoint_name)
+    for module_path in (
+        f"app.generated.{ep_module}._input",
+        f"app.{ep_module}._input",
+    ):
+        try:
+            module = importlib.import_module(module_path)
+        except ImportError:  # conformance: ignore[E008,E014] optional generated module; continue to next candidate
+            continue
+        contract = getattr(module, "AppInputContract", None)
+        if contract is not None and hasattr(contract, "model_json_schema"):
+            logger.debug(
+                "input-contract: using marketplace AppInputContract from %s "
+                "for entrypoint %s (filesystem-resolved bundle entry point)",
+                module_path,
+                entrypoint_name,
+            )
+            return contract
+    return None
+
+
 _WORKFLOW_SENSITIVE_FIELDS = {
     "username",
     "password",
@@ -2161,6 +2213,19 @@ def _register_workflow_routes(
                 for ep in sorted(app_meta.entry_points.values(), key=lambda e: e.name)
                 if not ep.implicit and ep.name not in candidates
             )
+        # Marketplace (bundle) entry points exist only as generated contract
+        # dirs — none of the registry-derived candidates above can serve them
+        # (a bundle's registry entrypoints are its DAG-node workflows, which
+        # have no manifest dirs). Append the on-disk entry points so a bare
+        # call on a bundle app serves a manifest deterministically
+        # (alphabetically) instead of 404-ing "No manifest available".
+        candidates.extend(
+            sorted(
+                p.parent.name
+                for p in CONTRACT_GENERATED_DIR.glob("*/manifest.json")
+                if p.parent.name not in candidates
+            )
+        )
 
         for cand in candidates:
             try:
@@ -2296,9 +2361,25 @@ def _register_workflow_routes(
         if entrypoint is not None and not _ENTRYPOINT_NAME_RE.match(entrypoint):
             raise HTTPException(status_code=400, detail="Invalid entrypoint name")
 
-        _, ep = _resolve_app_entrypoint(
-            _workflow_config.app_name, entrypoint, unknown_ep_status=404
-        )
+        try:
+            _, ep = _resolve_app_entrypoint(
+                _workflow_config.app_name, entrypoint, unknown_ep_status=404
+            )
+        except HTTPException as exc:
+            # Registry miss — the entry point may be a *marketplace* (bundle)
+            # entry point that exists only as a generated contract dir on disk
+            # (its registry entrypoints are the DAG-node workflows, not the
+            # marketplace name). Filesystem-resolve it like the manifest and
+            # configmap routes already do; re-raise when it isn't one.
+            if exc.status_code != 404 or not entrypoint:
+                raise
+            contract = _marketplace_entrypoint_contract(entrypoint)
+            if contract is None:
+                raise
+            return Response(
+                content=orjson.dumps(contract.model_json_schema()),
+                media_type="application/json",
+            )
 
         # Prefer the generated AppInputContract (rich, validatable, credential
         # refs) over the entry point's thin runtime input_type. See

--- a/application_sdk/handler/service.py
+++ b/application_sdk/handler/service.py
@@ -994,9 +994,13 @@ def _marketplace_entrypoint_contract(entrypoint_name: str) -> Any | None:
     # the no-traversal property locally provable (py/path-injection).
     if not _ENTRYPOINT_NAME_RE.match(entrypoint_name):
         return None
-    generated_root = CONTRACT_GENERATED_DIR.resolve()
-    ep_manifest = (generated_root / entrypoint_name / "manifest.json").resolve()
-    if not ep_manifest.is_relative_to(generated_root) or not ep_manifest.is_file():
+    generated_root = os.path.realpath(CONTRACT_GENERATED_DIR)
+    ep_manifest = os.path.realpath(
+        os.path.join(generated_root, entrypoint_name, "manifest.json")
+    )
+    if not ep_manifest.startswith(generated_root + os.sep):
+        return None
+    if not os.path.isfile(ep_manifest):
         return None
     ep_module = entrypoint_module_segment(entrypoint_name)
     for module_path in (

--- a/application_sdk/handler/service.py
+++ b/application_sdk/handler/service.py
@@ -2225,20 +2225,6 @@ def _register_workflow_routes(
                 for ep in sorted(app_meta.entry_points.values(), key=lambda e: e.name)
                 if not ep.implicit and ep.name not in candidates
             )
-        # Marketplace (bundle) entry points exist only as generated contract
-        # dirs — none of the registry-derived candidates above can serve them
-        # (a bundle's registry entrypoints are its DAG-node workflows, which
-        # have no manifest dirs). Append the on-disk entry points so a bare
-        # call on a bundle app serves a manifest deterministically
-        # (alphabetically) instead of 404-ing "No manifest available".
-        candidates.extend(
-            sorted(
-                p.parent.name
-                for p in CONTRACT_GENERATED_DIR.glob("*/manifest.json")
-                if p.parent.name not in candidates
-            )
-        )
-
         for cand in candidates:
             try:
                 return await _serve_entrypoint_manifest(cand, fe_inputs, deployment)

--- a/application_sdk/handler/service.py
+++ b/application_sdk/handler/service.py
@@ -988,7 +988,15 @@ def _marketplace_entrypoint_contract(entrypoint_name: str) -> Any | None:
         entrypoint_module_segment,
     )
 
-    if not (CONTRACT_GENERATED_DIR / entrypoint_name / "manifest.json").is_file():
+    # The route already validates the name, but this helper must be safe on
+    # its own: the name reaches both a filesystem path and an import path.
+    # The regex forbids path separators and dots; the containment check makes
+    # the no-traversal property locally provable (py/path-injection).
+    if not _ENTRYPOINT_NAME_RE.match(entrypoint_name):
+        return None
+    generated_root = CONTRACT_GENERATED_DIR.resolve()
+    ep_manifest = (generated_root / entrypoint_name / "manifest.json").resolve()
+    if not ep_manifest.is_relative_to(generated_root) or not ep_manifest.is_file():
         return None
     ep_module = entrypoint_module_segment(entrypoint_name)
     for module_path in (

--- a/tests/unit/handler/test_service.py
+++ b/tests/unit/handler/test_service.py
@@ -7261,11 +7261,12 @@ class TestBundleMarketplaceEntrypoints:
         finally:
             svc_module.CONTRACT_GENERATED_DIR = original
 
-    def test_bare_manifest_falls_back_to_disk_entrypoints(self, tmp_path: Path) -> None:
-        """A bare /manifest call on a bundle app serves the first on-disk
-        marketplace entry point (alphabetical) instead of 404 'No manifest
-        available' — the registry candidates (DAG-node workflows) have no
-        manifest dirs of their own."""
+    def test_bare_manifest_on_bundle_still_404s(self, tmp_path: Path) -> None:
+        """A bare /manifest call on a bundle app keeps 404-ing even when
+        marketplace entry-point dirs exist on disk. Serving one of N
+        marketplace manifests picked arbitrarily would be confidently wrong —
+        callers must name the entry point. (The declarative resolver that can
+        answer this properly is FND-180.)"""
         from application_sdk.handler import service as svc_module
 
         for name in ("beta-export", "alpha-export"):
@@ -7276,7 +7277,7 @@ class TestBundleMarketplaceEntrypoints:
         svc_module.CONTRACT_GENERATED_DIR = tmp_path
         try:
             resp = self._client(self._bundle_app()).get("/workflows/v1/manifest")
-            assert resp.status_code == 200
-            assert resp.json() == {"name": "alpha-export"}
+            assert resp.status_code == 404
+            assert resp.json()["detail"] == "No manifest available"
         finally:
             svc_module.CONTRACT_GENERATED_DIR = original

--- a/tests/unit/handler/test_service.py
+++ b/tests/unit/handler/test_service.py
@@ -7149,10 +7149,10 @@ class TestBundleMarketplaceEntrypoints:
     """Bundle ("uber") apps expose *marketplace* entry points only as generated
     contract dirs (``app/generated/<ep>/manifest.json``); their registry
     entrypoints are the DAG-node workflows (e.g. ``export-post``). The
-    input-contract route and the bare-manifest fallback must resolve the
-    marketplace names from disk instead of 404-ing (production RCA: /v1/app
-    creation failed for every bundle entry point with
-    'No input contract for entrypoint' → 'No manifest available')."""
+    input-contract route resolves the marketplace names from disk instead of
+    404-ing (production RCA: /v1/app creation failed for every bundle entry
+    point with 'No input contract for entrypoint'). Bare /manifest stays 404
+    by design until the declarative resolver (FND-180) can pick correctly."""
 
     def setup_method(self) -> None:
         from application_sdk.app.registry import AppRegistry, TaskRegistry

--- a/tests/unit/handler/test_service.py
+++ b/tests/unit/handler/test_service.py
@@ -7143,3 +7143,140 @@ class TestManifestPostTransport:
             assert response.json()["app_name"] == "static"
         finally:
             svc_module.CONTRACT_GENERATED_DIR = original
+
+
+class TestBundleMarketplaceEntrypoints:
+    """Bundle ("uber") apps expose *marketplace* entry points only as generated
+    contract dirs (``app/generated/<ep>/manifest.json``); their registry
+    entrypoints are the DAG-node workflows (e.g. ``export-post``). The
+    input-contract route and the bare-manifest fallback must resolve the
+    marketplace names from disk instead of 404-ing (production RCA: /v1/app
+    creation failed for every bundle entry point with
+    'No input contract for entrypoint' → 'No manifest available')."""
+
+    def setup_method(self) -> None:
+        from application_sdk.app.registry import AppRegistry, TaskRegistry
+
+        AppRegistry.reset()
+        TaskRegistry.reset()
+
+    def teardown_method(self) -> None:
+        from application_sdk.app.registry import AppRegistry, TaskRegistry
+
+        AppRegistry.reset()
+        TaskRegistry.reset()
+
+    @staticmethod
+    def _bundle_app() -> type:
+        from application_sdk.app.base import App
+        from application_sdk.app.entrypoint import entrypoint
+
+        class _BundleApp(App):
+            # Registry knows only the DAG-node workflows, never the
+            # marketplace entry point ("export") itself.
+            @entrypoint
+            async def export_post(self, input: _RoutingInput) -> _RoutingOutput:
+                return _RoutingOutput()
+
+            @entrypoint
+            async def export_build_raw_sql(
+                self, input: _RoutingInput
+            ) -> _RoutingOutput:
+                return _RoutingOutput()
+
+        return _BundleApp
+
+    def _client(self, app_cls: type) -> TestClient:
+        svc = create_app_handler_service(
+            _TestHandler(), app_name="bundle-test", app_class=app_cls
+        )
+        return TestClient(svc, raise_server_exceptions=False)
+
+    def test_input_contract_resolves_marketplace_entrypoint_from_disk(
+        self, tmp_path: Path
+    ) -> None:
+        """?entrypoint=<marketplace-name> misses the registry but has a
+        generated dir + relocated AppInputContract → 200 with its schema."""
+        import sys
+        import types
+
+        from pydantic import BaseModel
+
+        from application_sdk.handler import service as svc_module
+
+        (tmp_path / "export").mkdir()
+        (tmp_path / "export" / "manifest.json").write_text("{}")
+
+        class AppInputContract(BaseModel):
+            delivery_type: str = "DIRECT"
+
+        module = types.ModuleType("app.export._input")
+        module.AppInputContract = AppInputContract  # type: ignore[attr-defined]
+
+        original = svc_module.CONTRACT_GENERATED_DIR
+        svc_module.CONTRACT_GENERATED_DIR = tmp_path
+        sys.modules["app.export._input"] = module
+        try:
+            resp = self._client(self._bundle_app()).get(
+                "/workflows/v1/input-contract?entrypoint=export"
+            )
+            assert resp.status_code == 200
+            assert resp.json() == AppInputContract.model_json_schema()
+        finally:
+            svc_module.CONTRACT_GENERATED_DIR = original
+            del sys.modules["app.export._input"]
+
+    def test_input_contract_404_when_no_generated_dir(self, tmp_path: Path) -> None:
+        """A name with neither a registry entry nor a generated dir keeps the
+        existing 404 contract."""
+        from application_sdk.handler import service as svc_module
+
+        original = svc_module.CONTRACT_GENERATED_DIR
+        svc_module.CONTRACT_GENERATED_DIR = tmp_path
+        try:
+            resp = self._client(self._bundle_app()).get(
+                "/workflows/v1/input-contract?entrypoint=export"
+            )
+            assert resp.status_code == 404
+        finally:
+            svc_module.CONTRACT_GENERATED_DIR = original
+
+    def test_input_contract_404_when_dir_has_no_contract_module(
+        self, tmp_path: Path
+    ) -> None:
+        """A generated dir without an importable AppInputContract still 404s
+        (never a 500, never a wrong sibling's schema)."""
+        from application_sdk.handler import service as svc_module
+
+        (tmp_path / "export").mkdir()
+        (tmp_path / "export" / "manifest.json").write_text("{}")
+
+        original = svc_module.CONTRACT_GENERATED_DIR
+        svc_module.CONTRACT_GENERATED_DIR = tmp_path
+        try:
+            resp = self._client(self._bundle_app()).get(
+                "/workflows/v1/input-contract?entrypoint=export"
+            )
+            assert resp.status_code == 404
+        finally:
+            svc_module.CONTRACT_GENERATED_DIR = original
+
+    def test_bare_manifest_falls_back_to_disk_entrypoints(self, tmp_path: Path) -> None:
+        """A bare /manifest call on a bundle app serves the first on-disk
+        marketplace entry point (alphabetical) instead of 404 'No manifest
+        available' — the registry candidates (DAG-node workflows) have no
+        manifest dirs of their own."""
+        from application_sdk.handler import service as svc_module
+
+        for name in ("beta-export", "alpha-export"):
+            (tmp_path / name).mkdir()
+            (tmp_path / name / "manifest.json").write_text(json.dumps({"name": name}))
+
+        original = svc_module.CONTRACT_GENERATED_DIR
+        svc_module.CONTRACT_GENERATED_DIR = tmp_path
+        try:
+            resp = self._client(self._bundle_app()).get("/workflows/v1/manifest")
+            assert resp.status_code == 200
+            assert resp.json() == {"name": "alpha-export"}
+        finally:
+            svc_module.CONTRACT_GENERATED_DIR = original


### PR DESCRIPTION
## Problem

Bundle ("uber") apps expose **marketplace entry points** only as generated contract dirs (`app/generated/<ep>/manifest.json`) whose DAGs are computed per submission via `compute_manifest`. Their `@entrypoint` registrations are the **DAG-node workflows** (`<ep>-post`, `<ep>-build-raw-sql`, …) — never the marketplace name. Registry-driven resolution therefore fails on live bundles (reproduced on a tenant against the deployed app):

| Route | Result today |
|---|---|
| `GET /workflows/v1/manifest?entrypoint=<ep>` | 200 (filesystem glob) ✅ |
| `GET /workflows/v1/input-contract?entrypoint=<ep>` | **404 "No input contract for entrypoint"** ❌ |
| bare `GET /workflows/v1/input-contract` | 200 but serves a **DAG-node sibling's schema** ⚠️ |

The input-contract 404 breaks Heracles' `POST /v1/app` creation for every bundle entry point (Sev1 RCA): the create flow fetches the input contract with the entrypoint → 1003 → the eventual manifest fetch dies with "No manifest available".

## Fix (scoped per review)

**input-contract only**: on a registry miss for a named entrypoint whose generated dir exists, serve `AppInputContract` from `app.generated.<ep_snake>._input` (in-place) or `app.<ep_snake>._input` (the bundle regen relocation path — kebab generated dirs aren't importable, so regen scripts move `_input.py` into the entrypoint package). Entry-point names are regex-validated and containment-proven under `app/generated/` before touching disk.

Registry hits keep winning; apps without generated dirs are byte-for-byte unchanged — the fallback can only turn this specific 404 into a 200.

Per @cmgrote's review, the earlier bare-manifest disk-glob fallback was **dropped** (serving one of N marketplace manifests picked alphabetically is confidently wrong; the honest answer is the existing 404) — a regression test now pins that behavior. The durable design — toolkit-emitted `app/generated/entrypoints.json` + static JSON schemas, one declarative resolver, delete the #2764/#2776 fallbacks and this one — is **FND-180**.

## Tests

4 tests in `TestBundleMarketplaceEntrypoints` (disk-resolved contract, both 404-preservation cases, bare-manifest-stays-404). Full unit suite green.

## Validation

Deployed to a test tenant via a companion app build: all three bundle entry points' input contracts now serve 200 (were 404), unknown entrypoints still 404, manifest route unchanged — see the results table on atlanhq/atlan-csa-uber-app#171.

## Merge train (this PR is the head)

1. **This PR** → next SDK release. Blocks everything below.
2. atlanhq/atlan-csa-uber-app#171 — adds the `AppInputContract` classes this route serves; currently branch-pinned to this PR, swaps to the released SDK before merge.
3. atlanhq/atlan-python#1004 — the pyatlan v3 builder for asset-export-basic; its `/v1/app` path works once (2) is deployed on a tenant.