### PR TITLE
ci(renovate): pin rebaseWhen so stale branches can't deadlock PR creation

### DIFF
--- a/renovate-config/default.json
+++ b/renovate-config/default.json
@@ -1,12 +1,16 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "description": "Atlan fleet upgrade policy for atlan-*-app repos. Extend via: {\"extends\": [\"github>atlanhq/application-sdk//renovate-config/default.json\"]}",
+  "description": [
+    "Atlan fleet upgrade policy for atlan-*-app repos. Extend via: {\"extends\": [\"github>atlanhq/application-sdk//renovate-config/default.json\"]}",
+    "rebaseWhen is pinned to behind-base-branch rather than left at the `auto` default. `auto` resolves to behind-base-branch ONLY when a rule requires the branch to be up to date (branch protection, or automerge on that branch). Fleet repos have neither: branch protection is absent org-wide (GET /branches/main/protection 404s), and soft-mode repos set automerge:false. So `auto` silently degraded to `conflicted` on every repo — the runner log reads `Converting rebaseWhen=auto to rebaseWhen=conflicted because no rule for behind-base-branch applies`. A non-conflicted stale branch was then reused as-is (`reuseExistingBranch: true`), recomputed to `No package files need updating`, produced no commit, and PR creation 422'd with 'no commits between main and branch' — leaving the branch in place to repeat the cycle forever. Open PRs hit the same wall from the other side: never rebased, so never re-resolved, frozen on whatever version was latest when they were opened. Set at the TOP LEVEL deliberately: the degradation is a repo-level decision affecting every branch (observed on renovate/app-contract-toolkit as well as renovate/lock-file-maintenance), so scoping it under lockFileMaintenance would leave the other managers broken. Cost is extra rebases/CI on branches that fall behind main; that is the price of having no branch protection to make `auto` work unaided."
+  ],
   "extends": [
     "config:recommended"
   ],
   "schedule": [
     "at any time"
   ],
+  "rebaseWhen": "behind-base-branch",
   "prHourlyLimit": 0,
   "prConcurrentLimit": 5,
   "labels": [


### PR DESCRIPTION
## Problem

Fleet repos silently stopped getting Renovate PRs. Not a merge-policy issue — the PRs were never being **created**. The runner already logs at `LOG_LEVEL: debug`, and it says exactly why:

```
Converting rebaseWhen=auto to rebaseWhen=conflicted because no rule for behind-base-branch applies
Branch already exists  →  Skipping behind base branch check
branch.isConflicted(): false  →  Using reuseExistingBranch: true
No package files need updating  →  No files to commit
Creating PR  →  POST /repos/atlanhq/atlan-hightouch-app/pulls = 422
```

`auto` resolves to `behind-base-branch` **only** when some rule requires the branch to be up to date — branch protection, or automerge on that branch. Fleet repos have neither: branch protection 404s org-wide (the same root condition as FND-148), and soft-mode repos set `automerge: false`. So `auto` degraded to `conflicted` on every repo.

From there it self-perpetuates:

1. A leftover `renovate/lock-file-maintenance` branch sits at `ahead=0` of `main`
2. Not conflicted → no rebase → Renovate **reuses the stale branch**
3. Recomputing against stale content yields "no changes" → nothing to commit
4. PR creation runs anyway → GitHub **422s** ("no commits between main and branch")
5. Branch survives → repeat every run, indefinitely

Open PRs fail the same way from the other side: never rebased, so never re-resolved, frozen on whatever version was latest when they were opened.

## Impact measured

Across 80 `atlan-*-app` repos, three days after `v3.27.0` shipped, **only 5 were on latest**:

| State | Repos |
|---|---|
| Open lock PR delivering v3.27.0 | 15 |
| Open lock PR frozen at v3.26.1 | 9 |
| Open lock PR not moving the SDK | 22 |
| No open lock PR at all | 34 (25 deadlocked, 3 legitimately current, 6 never discovered) |

Deadlock **confirmed in the runner logs** for `hightouch` and `sapase` (both reach the 422) and `adls`. The 25 share the precondition (stale branch, `ahead=0`, behind main) but weren't individually log-checked — so treat "up to 56 repos fixed" as a ceiling to confirm during rollout, not a measured result.

Ruled out: `prConcurrentLimit: 5` is **not** the cause — only 4 of the 34 are at the cap, and 12 have zero open Renovate PRs.

## Fix

```json
"rebaseWhen": "behind-base-branch"
```

**Top level, not under `lockFileMaintenance`.** The degradation is a repo-level decision affecting every branch — `adls` shows the identical line on `renovate/app-contract-toolkit` as well as `renovate/lock-file-maintenance` — so scoping it to one manager would leave the others broken. (It's also unverified whether `rebaseWhen` is honored inside the `lockFileMaintenance` object at all.)

## What this does NOT change

`automerge` is untouched and **soft mode stays soft**. This is a creation-side lever only: PRs get raised and refreshed, humans still merge them. No repo starts auto-merging as a result of this PR.

## Trade-off

`behind-base-branch` rebases any behind-base branch on every pass, so active repos will see more force-pushes to Renovate branches, and correspondingly more CI runs and notifications. That is the cost of having no branch protection to make `auto` work unaided. The better long-term fix is branch protection (FND-148), after which `auto` would resolve correctly on its own; the two are compatible.

## Validation

- `renovate-config-validator` from **renovate@43.265.3** — the exact version pinned in `.github/workflows/renovate.yaml` — passes.
- JSON parses; `description` converted to the array form (valid per Renovate schema) to carry the rationale inline, since JSON allows no comments.
- `pre-commit run --files renovate-config/default.json` clean.

## Rollout note

⚠️ Enabling rebasing will also **refresh `atlan-snowflake-app` #520**, which jumps `3.18.0 → 3.27.0` and crosses the v3.20.0 daft cliff while its off-daft migration PR #498 is still open. A refreshed PR looks current and merge-ready. Land a pre-check rejecting lock PRs that cross `3.19.x → 3.20.0+` before merging any of the unblocked PRs. It is the only cliff-crosser among the 24 today.

Suggested sequence: merge this → watch `hightouch` / `sapase` / `salesforce` on the next runner pass and confirm the 422 is gone → then sweep the resulting PRs.

## Not covered here

- The 6 repos never processed at all (`automation-engine`, `csa-uber-import`, `local-marketplace`, `query-intelligence`, `unified-lineage`, `workday-prism-analytics`) — their `renovate.json` doesn't extend this preset, so `discover_org_consumers.py` correctly excludes them. They hold the fleet's oldest pins (2.8.7, 3.4.0, 3.12.0, 3.15.1). Needs a one-line `extends` in each repo, or a recorded decision that they're out of scope.
- A dedicated `rangeStrategy: update-lockfile` rule for `atlan-application-sdk`, so the SDK gets its own named single-package PR instead of riding the anonymous batched lock refresh. Deliberately kept out of this PR so the rebase change can be evaluated and reverted independently.

Refs FND-154
