### PR TITLE
ci(release): authenticate private atlanhq git deps before uv lock

### DIFF
--- a/.github/workflows/release-version-bump.yaml
+++ b/.github/workflows/release-version-bump.yaml
@@ -41,6 +41,11 @@ on:
         required: false
         type: string
         default: "main"
+      private_git_auth:
+        description: "Set true if the app has a private-org (atlanhq) git dependency that `uv lock` must resolve during the version bump. When true, atlanhq GitHub remotes are rewritten to token auth (via ORG_PAT_GITHUB) before `uv lock` runs, so resolution of the private git source succeeds. Default false — apps with only PyPI deps are unaffected. Mirrors the `private_git_auth` input in build-and-publish-app.yaml."
+        required: false
+        type: boolean
+        default: false
     secrets:
       ORG_PAT_GITHUB:
         required: true
@@ -100,6 +105,21 @@ jobs:
         run: |
           CURRENT=$(uvx --from=toml-cli toml get --toml-path=pyproject.toml project.version)
           echo "current=${CURRENT}" >> "$GITHUB_OUTPUT"
+
+      # `uv lock` (in "Bump version" below) re-resolves the full dependency
+      # graph after the version bump, which for a private-org git source
+      # (e.g. query-redaction in atlan-query-intelligence-app) requires cloning
+      # that repo. The default checkout has no auth for other atlanhq repos, so
+      # rewrite atlanhq remotes to token auth first. ORG_PAT_GITHUB (not the
+      # repo-scoped fleet App token minted above) is used because the dependency
+      # lives in a *different* repo. Mirrors build-and-publish-app.yaml.
+      - name: Configure git auth for private dependencies
+        if: ${{ inputs.private_git_auth }}
+        env:
+          GIT_TOKEN: ${{ secrets.ORG_PAT_GITHUB }}
+        run: |
+          git config --global url."https://x-access-token:${GIT_TOKEN}@github.com/atlanhq/".insteadOf "https://github.com/atlanhq/"
+          git config --global --add url."https://x-access-token:${GIT_TOKEN}@github.com/atlanhq/".insteadOf "ssh://git@github.com/atlanhq/"
 
       - name: Bump version
         id: bump


### PR DESCRIPTION
## Problem

The `release-version-bump.yaml` reusable workflow runs `uv lock` after bumping the root version in `pyproject.toml` (the bump invalidates the lock's root-package entry, so it must be regenerated). `uv lock` re-resolves the **full** dependency graph — and for a private-org git source it must clone that dependency's repo to read its metadata.

The bump job's checkout has no auth for *other* atlanhq repos, so any app with a private atlanhq git dependency hits:

```
× Failed to download and build `query-redaction @ git+ssh://git@github.com/atlanhq/atlan-query-intelligence-app.git@query-redaction-v0.2.2`
  git@github.com: Permission denied (publickey).
```

This blocks the entire semver release flow (no bump PR is ever opened) for any such app. First hit by `atlan-bigquery-app` after it adopted `release_model: semver`.

## Fix

Add a `private_git_auth` input (default `false`, backward compatible) that mirrors the existing input of the same name in `build-and-publish-app.yaml`. When `true`, atlanhq GitHub remotes are rewritten to token auth **before** `uv lock` runs.

Notes:
- Uses `ORG_PAT_GITHUB`, **not** the fleet App token minted in this job — that token is scoped to `repositories: ${{ github.event.repository.name }}` (the app's own repo) and cannot read the *other* repo the dependency lives in. `ORG_PAT_GITHUB` is already a declared, required secret here.
- The same `insteadOf` rewrite is already used in `atlan-bigquery-app`'s `e2e-test.yaml` for exactly this dependency — this brings the release-bump path in line with the build and e2e paths.
- Existing callers pass no input → step is skipped → no behavior change.

## Caller change

Apps with a private atlanhq git dep opt in from their `release.yaml`:

```yaml
    uses: atlanhq/application-sdk/.github/workflows/release-version-bump.yaml@main
    with:
      private_git_auth: true
    secrets: inherit
```

(Companion PR on `atlan-bigquery-app`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)