### PR TITLE
feat(conformance): add O005 UnresolvedAppNamePlaceholder

### DIFF
--- a/packages/conformance/conformance/docs/rules/optimizations.md
+++ b/packages/conformance/conformance/docs/rules/optimizations.md
@@ -5,7 +5,7 @@
 
 # Optimisation / Recommendation Rules (O-series)
 
-**5 rules** · Checker: `suite.checks.optimizations` (AST-based)
+**6 rules** · Checker: `suite.checks.optimizations` (AST-based)
 
 Suppress a finding on the violating line or the line directly above it:
 
@@ -27,6 +27,7 @@ reassigned.
 | [O002](#o002) | `LegacyAssetSerialization` | `warn` | `app` | `asset-mapper` | — | 0.8.0 |
 | [O003](#o003) | `UntypedAssetMapperReturn` | `warn` | `app` | `asset-mapper` | — | 0.8.0 |
 | [O004](#o004) | `LegacyPyatlanAssetImport` | `warn` | `app` | `asset-mapper` | — | 0.8.0 |
+| [O005](#o005) | `UnresolvedAppNamePlaceholder` | `warn` | `both` | `dag-write-path` | — | 0.18.0 |
 | [O006](#o006) | `DirectRocksdictImport` | `warn` | `app` | `canonical-dependency` | — | 0.18.0 |
 
 ---
@@ -142,6 +143,67 @@ NOT autofixable: the v9 models are not a drop-in rename — attribute names and 
 serialization API differ (use `asset.to_nested_bytes()` rather than `.dict()`), so each
 construction site needs review. Suppress with `# conformance: ignore[O004] <reason>`
 when a connector is intentionally pinned to the legacy `AtlasTransformer` surface.
+
+---
+
+## O005 — `UnresolvedAppNamePlaceholder` {#o005}
+
+**Tier:** `warn` · **Scope:** `both` · **Category:** `dag-write-path` · **Autofixable:** — · **Since:** 0.18.0
+
+> Hardcoded '{app_name}' left unsubstituted in a plain string literal
+
+**Rationale:** A plain string literal carrying an unsubstituted '{app_name}' token freezes the literal
+token into whatever it's assigned to instead of the real app name — the exact shape that
+shipped a task queue no worker polls, hanging dbt:process to its 24h heartbeat backstop
+(CONNECT-183). The substitution was independently hand-rolled at least four times
+(Heracles, native-migration-app, atlan-local-marketplace-app CONNECT-191/#539,
+atlan-hightouch-app ARUN-1039), and one of those shipped a double prefix (DISTR-834). A
+canonical helper — application_sdk.common.task_queue (derive_task_queue,
+resolve_manifest_tokens) — lands in the SDK release that ships FND-195, so remediation
+then has a single target; this rule still checks the unresolved shape rather than a
+missing import, because the writers most worth catching are hand-authored templates that
+import nothing. WARN (not BLOCK): a template legitimately resolved by a caller in a
+different file cannot be seen from here, so each hit needs a human glance rather than an
+automatic fail.
+
+Flags a string `ast.Constant` containing the literal substring `{app_name}` when the
+token can actually **reach a value** — including the pieces of an escaped-brace
+f-string: `f"atlan-{{app_name}}-prod"` is *not* interpolated, its runtime value is the
+literal `atlan-{app_name}-prod`, so it freezes the token exactly like a plain literal. A
+token that only ever appears in prose or in a diagnostic cannot freeze into an
+identifier, and flagging it just teaches people to suppress the rule.
+
+Not flagged:
+
+* part of a *resolving* f-string (`f"...{app_name}..."` interpolates   at parse time and
+no `{app_name}` text survives into its pieces), * the receiver of a `.format(...)` call
+whose keywords include   `app_name=` (a proper, already-resolving substitution site), *
+**documentation** — the value of any bare string expression statement.   This covers
+module/class/function docstrings *and* PEP 257 attribute   docstrings, which are not the
+first statement of their class body, * **diagnostic text** — inside the arguments of a
+logging call,   `warnings.warn(...)`, or a `raise`; reporting on the token requires
+quoting it, * **a token sentinel or message constant** — bound to an `ALL_CAPS`   name
+where the literal is exactly the token (the token's own   definition, e.g.
+`APP_NAME_TOKEN`) or the name ends in a prose   segment (`_MESSAGE`, `START_MESSAGE`,
+`VALIDATION_RATIONALE`).
+
+The exclusions stay narrow: an `ALL_CAPS` name holding a real queue template
+(`TASK_QUEUE = "atlan-{app_name}-prod"`) is still flagged — and so is one whose name
+merely *contains* a prose fragment without a trailing boundary (`MESSAGE_QUEUE`,
+`HELP_QUEUE`) — as are keyword arguments, values at any depth in a DAG literal, and
+returned templates.
+
+Detection is shape-anchored rather than import-anchored, because the writers most worth
+catching are hand-authored templates outside the SDK that import nothing at all.
+Remediation: an f-string or `.format(app_name=...)` when the name is in scope; the
+shared `application_sdk.common.task_queue` helper (`derive_task_queue` /
+`resolve_manifest_tokens`) lands in the SDK release that ships FND-195 and is the
+canonical target once available.
+
+NOT autofixable: the correct fix depends on where `app_name` is actually available in
+scope — sometimes an f-string is right, sometimes the value needs threading in from a
+caller first. Suppress with `# conformance: ignore[O005] <reason>` for a template
+resolved by a caller in a different file than the one being scanned.
 
 ---
 

--- a/packages/conformance/conformance/programs/areas/optimizations.prose.md
+++ b/packages/conformance/conformance/programs/areas/optimizations.prose.md
@@ -180,6 +180,39 @@ lines around `finding.line` in `finding.file` before proposing a fix.
   serialize/deserialize helpers.  Classification is `"judgment"` (the
   key-type / `Options` / merge-semantics call requires reading the call site),
   so the edit is routed to residue for human confirmation.
+- **O005 UnresolvedAppNamePlaceholder** (dag-write-path, CONNECT-183) — a plain
+  string literal (or an escaped-brace f-string, `f"atlan-{{app_name}}-prod"`,
+  whose braces are *not* interpolated) still carries an unsubstituted
+  `{app_name}` token, so the literal token freezes into whatever it is assigned
+  to instead of the real app name.  This is never a mechanical fix — the right
+  resolution depends on where `app_name` is actually available, so
+  classification is always `"judgment"`:
+  - If the app name is already in scope at the literal's site (a variable, a
+    parameter, a manifest field), draft the smallest resolution: an f-string
+    (`f"atlan-{app_name}-prod"`) or `"atlan-{app_name}-prod".format(app_name=...)`.
+    Keep every other placeholder in the template untouched — a second
+    unresolved token (e.g. `{dep}`) is out of O005's scope and must not be
+    "fixed" by binding it to something wrong.
+  - If the name is *not* in scope, the value must be threaded in from the
+    caller that has it — draft that threading, or note in residue that the
+    call graph needs a human (the rule is WARN-tier precisely because this
+    judgment cannot be automated).
+  - **Shared helper (FND-195):** `application_sdk.common.task_queue`
+    (`derive_task_queue` / `resolve_manifest_tokens`) is the canonical
+    remediation target, but it ships only with the SDK release that carries
+    FND-195 — do **not** draft an import of it into a repo pinned to an
+    earlier SDK (the import would not exist).  Prefer the in-scope f-string /
+    `.format(app_name=...)` fix there, and note the helper as the follow-up
+    once the SDK is bumped.
+  - **Legitimate cross-file resolution:** if the template is deliberately
+    resolved by a caller in a *different* file than the one scanned (the
+    rule's known blind spot), propose an inline
+    `# conformance: ignore[O005] <reason naming the resolving caller>` instead
+    of an edit, and route it to residue for human audit — an escaped-brace
+    f-string (`f"{{app_name}}"`) is almost never legitimate, since nothing
+    downstream can interpolate it either.
+  - Never "resolve" the token by hardcoding a concrete app name: that hides
+    the finding while freezing the wrong value into every other tenant.
 
 **Suppress outcome (strict mode only, WARNING-tier findings)**:
 

--- a/packages/conformance/conformance/suite/checks/optimizations/__init__.py
+++ b/packages/conformance/conformance/suite/checks/optimizations/__init__.py
@@ -18,6 +18,11 @@ Currently implemented:
   returns it but has no return annotation.
 * ``O004`` LegacyPyatlanAssetImport — app code importing the legacy
   ``pyatlan.model.assets`` package (rather than ``pyatlan_v9.model.assets``).
+* ``O005`` UnresolvedAppNamePlaceholder — a plain string literal still carrying
+  an unsubstituted ``{app_name}`` token (not a resolving f-string, not a
+  ``.format(app_name=...)`` receiver, not a docstring). An escaped-brace
+  f-string (``f"{{app_name}}"``) *is* flagged: the braces are not interpolated,
+  so the token survives verbatim into the runtime value.
 * ``O006`` DirectRocksdictImport — app code importing ``rocksdict`` directly
   (rather than the SDK's ``SpillableDict``).
 
@@ -55,6 +60,7 @@ from conformance.suite.checks._ast_common import (
 )
 from conformance.suite.schema.findings import Finding
 
+from ._app_name_placeholder import check_o005
 from ._asset_mapper import check_o002, check_o003
 from ._pyatlan_v9 import check_o004
 from ._rocksdict import check_o006
@@ -93,6 +99,7 @@ def scan_text(text: str, file: str) -> list[Finding]:
         + check_o002(tree, file, directives)
         + check_o003(tree, file, directives)
         + check_o004(tree, file, directives)
+        + check_o005(tree, file, directives)
         + check_o006(tree, file, directives)
     )
 

--- a/packages/conformance/conformance/suite/checks/optimizations/_app_name_placeholder.py
+++ b/packages/conformance/conformance/suite/checks/optimizations/_app_name_placeholder.py
@@ -1,0 +1,129 @@
+"""O005 UnresolvedAppNamePlaceholder — flag a hardcoded, unsubstituted ``{app_name}`` token.
+
+The AE-DAG-write path builds identifiers (task-queue names, workflow-input
+fields, manifest values) that need ``app_name`` interpolated at write time.  A
+plain string literal containing the single-brace token ``{app_name}`` — one
+that is neither an f-string nor the receiver of a ``.format(app_name=...)``
+call — freezes the literal token into whatever it's assigned to instead of the
+real app name, e.g.::
+
+    task_queue = "atlan-{app_name}-production"   # never interpolated
+
+That exact shape shipped a queue no worker polls, hanging every child workflow
+routed through it until the 24h heartbeat backstop killed it (CONNECT-183).
+The substitution helper needed to fix it (``substitute_app_name_placeholder``)
+has been independently hand-rolled at least four times across separate
+codebases — Heracles (Go), native-migration-app, atlan-local-marketplace-app
+(CONNECT-191, ``atlan-local-marketplace-app#539``), and atlan-hightouch-app
+(ARUN-1039) — because no shared, obviously-discoverable utility exists yet.
+This check doesn't require that utility to exist: it flags the *unresolved*
+shape directly, so the next hand-authored template that skips substitution is
+caught before it ships, rather than after a workflow hangs to its timeout.
+
+Detection is shape-anchored, not name-anchored — no import or call target is
+required, since the SDK provides nothing canonical to import yet:
+
+* A string ``ast.Constant`` containing the literal substring ``{app_name}``.
+* Not part of an ``ast.JoinedStr`` (an f-string already interpolates at parse
+  time, so ``f"...{app_name}..."`` is never flagged).
+* Not the receiver of a ``.format(...)`` call whose keywords include
+  ``app_name=`` (a proper, already-resolving substitution site).
+* Not a module/class/function docstring (the first statement of a
+  ``Module``/``ClassDef``/``FunctionDef`` body, when it is a bare string
+  expression) — documentation and doctest examples are out of scope.
+"""
+
+from __future__ import annotations
+
+import ast
+
+from conformance.suite.checks._ast_common import _IgnoreDirective, make_finding
+from conformance.suite.schema.findings import Finding
+
+_TOKEN = "{app_name}"
+_MESSAGE = (
+    "Hardcoded '{app_name}' left unsubstituted in a plain string literal — this "
+    "freezes the literal token into whatever it's assigned to instead of the real "
+    "app name (the exact shape that hung dbt:process on a dead task queue for 24h, "
+    "CONNECT-183). Use an f-string or .format(app_name=...) to resolve it before "
+    "the value is written/dispatched."
+)
+
+
+def _is_docstring_node(const: ast.Constant, tree: ast.AST) -> bool:
+    """True if *const* is the bare string literal of a Module/ClassDef/FunctionDef docstring."""
+    for node in ast.walk(tree):
+        if not isinstance(
+            node, (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)
+        ):
+            continue
+        body = node.body
+        if not body:
+            continue
+        first = body[0]
+        if (
+            isinstance(first, ast.Expr)
+            and first.value is const
+            and isinstance(const.value, str)
+        ):
+            return True
+    return False
+
+
+def _resolving_format_receivers(tree: ast.AST) -> set[ast.Constant]:
+    """String-literal receivers of a ``.format(...)`` call that keyword-binds ``app_name``."""
+    receivers: set[ast.Constant] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not (isinstance(func, ast.Attribute) and func.attr == "format"):
+            continue
+        if not any(kw.arg == "app_name" for kw in node.keywords):
+            continue
+        receiver = func.value
+        if isinstance(receiver, ast.Constant) and isinstance(receiver.value, str):
+            receivers.add(receiver)
+    return receivers
+
+
+def _joined_str_children(tree: ast.AST) -> set[ast.Constant]:
+    """Constant nodes that are pieces of an f-string — never independently flagged."""
+    pieces: set[ast.Constant] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.JoinedStr):
+            for value in node.values:
+                if isinstance(value, ast.Constant):
+                    pieces.add(value)
+    return pieces
+
+
+def check_o005(
+    tree: ast.AST,
+    filename: str,
+    directives: dict[int, _IgnoreDirective],
+) -> list[Finding]:
+    """Emit O005 for a plain string literal that still carries an unresolved '{app_name}' token."""
+    findings: list[Finding] = []
+    resolving_receivers = _resolving_format_receivers(tree)
+    fstring_pieces = _joined_str_children(tree)
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Constant) or not isinstance(node.value, str):
+            continue
+        if _TOKEN not in node.value:
+            continue
+        if node in resolving_receivers or node in fstring_pieces:
+            continue
+        if _is_docstring_node(node, tree):
+            continue
+        findings.append(
+            make_finding(
+                filename=filename,
+                rule_id="O005",
+                node=node,
+                message=_MESSAGE,
+                directives=directives,
+            )
+        )
+    return findings

--- a/packages/conformance/conformance/suite/checks/optimizations/_app_name_placeholder.py
+++ b/packages/conformance/conformance/suite/checks/optimizations/_app_name_placeholder.py
@@ -12,18 +12,20 @@ real app name, e.g.::
 That exact shape shipped a queue no worker polls, hanging every child workflow
 routed through it until the 24h heartbeat backstop killed it (CONNECT-183).
 
-**Canonical fix.** ``application_sdk.common.task_queue`` is now the single
-source of truth for queue naming (FND-195): ``derive_task_queue`` applies the
-rule, and ``resolve_manifest_tokens`` reconciles a served manifest against the
-queue the worker actually polls. Prefer those over re-implementing the
-substitution — the helper this rule's earlier revisions described as missing has
-been independently hand-rolled at least four times across separate codebases
-(Heracles in Go, native-migration-app, atlan-local-marketplace-app per
-CONNECT-191, atlan-hightouch-app per ARUN-1039), and one of those shipped a
-double prefix (DISTR-834). This check still flags the *unresolved shape*
-directly rather than the absence of that import, because the writers that most
-need catching are hand-authored templates outside the SDK, where nothing is
-imported at all.
+**Canonical fix.** Resolve the token where the value is built: an f-string or
+``.format(app_name=...)`` when the app name is already in scope, or the shared
+substitution helper (``application_sdk.common.task_queue`` —
+``derive_task_queue`` applies the naming rule, ``resolve_manifest_tokens``
+reconciles a served manifest against the queue the worker actually polls) once
+the SDK release that ships FND-195 is available. Prefer those over
+re-implementing the substitution — the helper this rule's earliest revisions
+described as missing has been independently hand-rolled at least four times
+across separate codebases (Heracles in Go, native-migration-app,
+atlan-local-marketplace-app per CONNECT-191, atlan-hightouch-app per
+ARUN-1039), and one of those shipped a double prefix (DISTR-834). This check
+still flags the *unresolved shape* directly rather than the absence of that
+import, because the writers that most need catching are hand-authored templates
+outside the SDK, where nothing is imported at all.
 
 Detection anchors on the token **reaching a value**, not merely appearing in the
 source. A ``{app_name}`` that only ever appears in prose or in a diagnostic
@@ -31,8 +33,11 @@ cannot freeze into an identifier, and flagging it trains people to suppress the
 rule. Concretely, a string ``ast.Constant`` containing ``{app_name}`` is flagged
 unless it is:
 
-* part of an ``ast.JoinedStr`` (an f-string already interpolates at parse time,
-  so ``f"...{app_name}..."`` is never flagged);
+* part of an ``ast.JoinedStr`` whose **runtime value cannot carry the token** —
+  an f-string interpolates at parse time, so ``f"...{app_name}..."`` is never
+  flagged. ``f"...{{app_name}}..."`` is: the escaped braces evaluate to the
+  literal runtime text ``{app_name}``, which freezes into the identifier
+  exactly like a plain literal;
 * the receiver of a ``.format(...)`` call whose keywords include ``app_name=``
   (a proper, already-resolving substitution site);
 * **documentation** — the value of any bare string expression statement. This
@@ -46,9 +51,12 @@ unless it is:
 * **a declared token sentinel or message constant** — bound to an ``ALL_CAPS``
   name where either the literal is exactly the token (i.e. the definition of
   the token itself, such as ``APP_NAME_TOKEN = "{app_name}"``) or the name
-  reads as prose rather than an identifier (``_MESSAGE``, ``RATIONALE``, …).
-  An ``ALL_CAPS`` constant holding a genuine queue *template*
-  (``TASK_QUEUE = "atlan-{app_name}-prod"``) is still flagged.
+  reads as prose — one delimited segment *is* a prose word
+  (``START_MESSAGE``, ``VALIDATION_RATIONALE``). An ``ALL_CAPS`` constant
+  holding a genuine queue *template* (``TASK_QUEUE = "atlan-{app_name}-prod"``)
+  is still flagged, and so is one whose name merely *contains* a prose fragment
+  without a delimited boundary (``MESSAGE_QUEUE``, ``HELP_QUEUE`` — queue
+  templates, not message text).
 
 The last three exclusions exist because without them the rule fires on the very
 module that implements the correct behaviour: ``common/task_queue.py`` defines
@@ -70,13 +78,20 @@ _TOKEN = "{app_name}"
 # would make this module trip its own rule (the string is neither a docstring
 # nor a diagnostic argument, and _MESSAGE's exclusion should not have to carry
 # the checker's own source).
+#
+# The runtime SARIF message leads with fixes that work on any SDK version and
+# names the shared helper as upcoming: application_sdk.common.task_queue ships
+# with FND-195, which is not yet on main, so the message must not send users to
+# an import that does not exist in their release.
 _MESSAGE = (
     f"Hardcoded '{_TOKEN}' left unsubstituted in a plain string literal — this "
     "freezes the literal token into whatever it's assigned to instead of the real "
     "app name (the exact shape that hung dbt:process on a dead task queue for 24h, "
-    "CONNECT-183). Resolve it via application_sdk.common.task_queue "
-    "(derive_task_queue / resolve_manifest_tokens), or an f-string / "
-    ".format(app_name=...) if the value is already in scope."
+    "CONNECT-183). Resolve it with an f-string or .format(app_name=...) if the "
+    "value is already in scope; a shared substitution helper "
+    "(application_sdk.common.task_queue — derive_task_queue / "
+    "resolve_manifest_tokens) lands in the SDK release that ships FND-195 and is "
+    "the canonical target once available."
 )
 
 #: Attribute names that mean "this call is reporting, not dispatching".
@@ -84,9 +99,12 @@ _LOG_METHODS = frozenset(
     {"debug", "info", "warning", "warn", "error", "critical", "exception", "log"}
 )
 
-#: ``ALL_CAPS`` constants whose name reads as prose. A queue template assigned
-#: to an ALL_CAPS name is still flagged — only message-shaped names are exempt.
-_PROSE_NAME_PARTS = (
+#: Trailing identifier segments that make an ``ALL_CAPS`` name read as prose. A
+#: name is message-shaped only when it *ends* in one of these segments
+#: (``_MESSAGE``, ``START_MESSAGE``, ``VALIDATION_RATIONALE``), so a queue
+#: template whose name merely contains a prose fragment
+#: (``MESSAGE_QUEUE``, ``HELP_QUEUE``, ``DOC_QUEUE``) stays flagged.
+_PROSE_NAME_SUFFIXES = (
     "MESSAGE",
     "MSG",
     "RATIONALE",
@@ -136,7 +154,9 @@ def _diagnostic_constants(tree: ast.AST) -> set[int]:
 
     Code that reports an unresolved token has to quote it; that text is never
     dispatched as an identifier. Without this, the SDK's own WARNING/ERROR logs
-    naming the token they could not resolve are flagged.
+    naming the token they could not resolve are flagged. An f-string *inside*
+    one of these sinks still needs its pieces exempted here — the line-based
+    waiver in ``check_o005`` would otherwise re-flag its escaped braces.
     """
     found: set[int] = set()
     subtrees: list[ast.AST] = []
@@ -153,6 +173,64 @@ def _diagnostic_constants(tree: ast.AST) -> set[int]:
     return found
 
 
+def _diagnostic_joined_str_lines(tree: ast.AST) -> set[int]:
+    """Lines hosting a ``JoinedStr`` inside a logging/warning call or ``raise``.
+
+    Code that reports an unresolved token has to quote it; that text is never
+    dispatched as an identifier — and that holds for a *resolving* f-string
+    (``logger.info(f"queue atlan-{app_name}-prod")``) just as much as for a
+    plain literal. Without this, ``_unresolved_joined_str_lines`` would flag
+    every interpolated f-string that merely mentions the token in a log
+    message.
+
+    Line-keyed (not node-id-keyed) for the same reason as
+    ``_unresolved_joined_str_lines``: the SARIF emitter re-parses the source,
+    so only positions survive.
+    """
+    lines: set[int] = set()
+    subtrees: list[ast.AST] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and _is_diagnostic_call(node):
+            subtrees.extend(node.args)
+            subtrees.extend(kw.value for kw in node.keywords)
+        elif isinstance(node, ast.Raise):
+            subtrees.append(node)
+    for subtree in subtrees:
+        for inner in ast.walk(subtree):
+            if isinstance(inner, ast.JoinedStr):
+                lines.add(inner.lineno)
+    return lines
+
+
+def _unresolved_joined_str_lines(tree: ast.AST) -> set[int]:
+    """Lines hosting a ``JoinedStr`` whose runtime value still carries the token.
+
+    Python parses ``f"atlan-{{app_name}}-production"`` as a ``JoinedStr``, but
+    the escaped braces are *not* interpolated — the runtime string is the
+    literal ``atlan-{app_name}-production``, the exact frozen-token shape this
+    rule exists to catch (a real f-string, ``f"...{app_name}..."``, contains no
+    ``{app_name}`` substring anywhere in its ``ast.Constant`` pieces — the token
+    lives in the ``ast.FormattedValue`` — so it never lands here).
+
+    A ``JoinedStr`` containing an escaped-brace token inside a diagnostic call
+    or a docstring stays exempt (``check_o005`` subtracts both line-sets):
+    reporting on the token still is not dispatching it, and double-brace-
+    quoting it is a normal way to make the literal render inside an f-string.
+    """
+    lines: set[int] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.JoinedStr):
+            continue
+        if any(
+            isinstance(value, ast.Constant)
+            and isinstance(value.value, str)
+            and _TOKEN in value.value
+            for value in node.values
+        ):
+            lines.add(node.lineno)
+    return lines
+
+
 def _sentinel_or_prose_constants(tree: ast.AST) -> set[int]:
     """Token definitions and message constants bound to an ``ALL_CAPS`` name.
 
@@ -161,7 +239,10 @@ def _sentinel_or_prose_constants(tree: ast.AST) -> set[int]:
     * the literal is *exactly* the token — this is the declaration of the token
       being hunted (``APP_NAME_TOKEN = "{app_name}"``), not a frozen identifier;
     * the name reads as prose (``_MESSAGE``, ``RATIONALE``) — the string is
-      human-facing text that happens to quote the token.
+      human-facing text that happens to quote the token. Prose is matched on
+      the *trailing* delimited segment, not substrings: ``START_MESSAGE`` is
+      prose, while ``MESSAGE_QUEUE`` is a queue template that merely contains
+      the fragment.
 
     Deliberately narrow: ``TASK_QUEUE = "atlan-{app_name}-prod"`` is an
     ``ALL_CAPS`` name that is *not* prose-shaped and whose literal is *not* bare,
@@ -188,7 +269,7 @@ def _sentinel_or_prose_constants(tree: ast.AST) -> set[int]:
                 continue
             if value.value.strip() == _TOKEN:
                 found.add(id(value))
-            elif any(part in bare for part in _PROSE_NAME_PARTS):
+            elif any(bare.split("_")[-1] == part for part in _PROSE_NAME_SUFFIXES):
                 found.add(id(value))
     return found
 
@@ -235,13 +316,35 @@ def check_o005(
         | _diagnostic_constants(tree)
         | _sentinel_or_prose_constants(tree)
     )
+    # An f-string piece still carrying the token is the escaped-brace shape:
+    # ``f"{{app_name}}"`` is *not* interpolated — the runtime value freezes the
+    # token exactly like a plain literal, so exempting every JoinedStr child
+    # (above) must not cover it. The waiver is line-keyed (a JoinedStr and its
+    # Constant children share the f-string's line, and positions are the only
+    # handle that survives the SARIF emitter's re-parse); a docstring or a
+    # diagnostic f-string on that line stays exempt.
+    # A bare string *or f-string* expression statement is documentation — a
+    # docstring quoting the token with escaped braces (``f"...{{app_name}}..."``)
+    # parses as ``Expr(JoinedStr)``, not ``Expr(Constant)``, so both shapes
+    # contribute their line here.
+    doc_lines = {
+        node.value.lineno
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Expr)
+        and isinstance(node.value, (ast.Constant, ast.JoinedStr))
+    }
+    flagged_fstring_lines = (
+        _unresolved_joined_str_lines(tree)
+        - _diagnostic_joined_str_lines(tree)
+        - doc_lines
+    )
 
     for node in ast.walk(tree):
         if not isinstance(node, ast.Constant) or not isinstance(node.value, str):
             continue
         if _TOKEN not in node.value:
             continue
-        if id(node) in exempt:
+        if id(node) in exempt and node.lineno not in flagged_fstring_lines:
             continue
         findings.append(
             make_finding(

--- a/packages/conformance/conformance/suite/checks/optimizations/_app_name_placeholder.py
+++ b/packages/conformance/conformance/suite/checks/optimizations/_app_name_placeholder.py
@@ -11,26 +11,50 @@ real app name, e.g.::
 
 That exact shape shipped a queue no worker polls, hanging every child workflow
 routed through it until the 24h heartbeat backstop killed it (CONNECT-183).
-The substitution helper needed to fix it (``substitute_app_name_placeholder``)
-has been independently hand-rolled at least four times across separate
-codebases — Heracles (Go), native-migration-app, atlan-local-marketplace-app
-(CONNECT-191, ``atlan-local-marketplace-app#539``), and atlan-hightouch-app
-(ARUN-1039) — because no shared, obviously-discoverable utility exists yet.
-This check doesn't require that utility to exist: it flags the *unresolved*
-shape directly, so the next hand-authored template that skips substitution is
-caught before it ships, rather than after a workflow hangs to its timeout.
 
-Detection is shape-anchored, not name-anchored — no import or call target is
-required, since the SDK provides nothing canonical to import yet:
+**Canonical fix.** ``application_sdk.common.task_queue`` is now the single
+source of truth for queue naming (FND-195): ``derive_task_queue`` applies the
+rule, and ``resolve_manifest_tokens`` reconciles a served manifest against the
+queue the worker actually polls. Prefer those over re-implementing the
+substitution — the helper this rule's earlier revisions described as missing has
+been independently hand-rolled at least four times across separate codebases
+(Heracles in Go, native-migration-app, atlan-local-marketplace-app per
+CONNECT-191, atlan-hightouch-app per ARUN-1039), and one of those shipped a
+double prefix (DISTR-834). This check still flags the *unresolved shape*
+directly rather than the absence of that import, because the writers that most
+need catching are hand-authored templates outside the SDK, where nothing is
+imported at all.
 
-* A string ``ast.Constant`` containing the literal substring ``{app_name}``.
-* Not part of an ``ast.JoinedStr`` (an f-string already interpolates at parse
-  time, so ``f"...{app_name}..."`` is never flagged).
-* Not the receiver of a ``.format(...)`` call whose keywords include
-  ``app_name=`` (a proper, already-resolving substitution site).
-* Not a module/class/function docstring (the first statement of a
-  ``Module``/``ClassDef``/``FunctionDef`` body, when it is a bare string
-  expression) — documentation and doctest examples are out of scope.
+Detection anchors on the token **reaching a value**, not merely appearing in the
+source. A ``{app_name}`` that only ever appears in prose or in a diagnostic
+cannot freeze into an identifier, and flagging it trains people to suppress the
+rule. Concretely, a string ``ast.Constant`` containing ``{app_name}`` is flagged
+unless it is:
+
+* part of an ``ast.JoinedStr`` (an f-string already interpolates at parse time,
+  so ``f"...{app_name}..."`` is never flagged);
+* the receiver of a ``.format(...)`` call whose keywords include ``app_name=``
+  (a proper, already-resolving substitution site);
+* **documentation** — the value of any bare string expression statement. This
+  covers module, class and function docstrings *and* PEP 257 attribute
+  docstrings (a bare string after a field annotation), which are not the first
+  statement of their class body and so were previously flagged;
+* **diagnostic text** — inside the arguments of a logging call
+  (``logger.error(...)`` and friends), ``warnings.warn(...)``, or a ``raise``.
+  Code that reports on the token necessarily quotes it, and the message is
+  never dispatched as an identifier;
+* **a declared token sentinel or message constant** — bound to an ``ALL_CAPS``
+  name where either the literal is exactly the token (i.e. the definition of
+  the token itself, such as ``APP_NAME_TOKEN = "{app_name}"``) or the name
+  reads as prose rather than an identifier (``_MESSAGE``, ``RATIONALE``, …).
+  An ``ALL_CAPS`` constant holding a genuine queue *template*
+  (``TASK_QUEUE = "atlan-{app_name}-prod"``) is still flagged.
+
+The last three exclusions exist because without them the rule fires on the very
+module that implements the correct behaviour: ``common/task_queue.py`` defines
+the token it substitutes, documents its resolution fields as attribute
+docstrings, and ``handler/service.py`` logs at WARNING/ERROR naming the token it
+could not resolve. A rule that flags the fix is a rule people turn off.
 """
 
 from __future__ import annotations
@@ -41,38 +65,137 @@ from conformance.suite.checks._ast_common import _IgnoreDirective, make_finding
 from conformance.suite.schema.findings import Finding
 
 _TOKEN = "{app_name}"
+
+# Built from _TOKEN rather than spelled inline: a literal "{app_name}" here
+# would make this module trip its own rule (the string is neither a docstring
+# nor a diagnostic argument, and _MESSAGE's exclusion should not have to carry
+# the checker's own source).
 _MESSAGE = (
-    "Hardcoded '{app_name}' left unsubstituted in a plain string literal — this "
+    f"Hardcoded '{_TOKEN}' left unsubstituted in a plain string literal — this "
     "freezes the literal token into whatever it's assigned to instead of the real "
     "app name (the exact shape that hung dbt:process on a dead task queue for 24h, "
-    "CONNECT-183). Use an f-string or .format(app_name=...) to resolve it before "
-    "the value is written/dispatched."
+    "CONNECT-183). Resolve it via application_sdk.common.task_queue "
+    "(derive_task_queue / resolve_manifest_tokens), or an f-string / "
+    ".format(app_name=...) if the value is already in scope."
+)
+
+#: Attribute names that mean "this call is reporting, not dispatching".
+_LOG_METHODS = frozenset(
+    {"debug", "info", "warning", "warn", "error", "critical", "exception", "log"}
+)
+
+#: ``ALL_CAPS`` constants whose name reads as prose. A queue template assigned
+#: to an ALL_CAPS name is still flagged — only message-shaped names are exempt.
+_PROSE_NAME_PARTS = (
+    "MESSAGE",
+    "MSG",
+    "RATIONALE",
+    "DESCRIPTION",
+    "DOC",
+    "HELP",
+    "HINT",
+    "REMEDIATION",
+    "EXPLANATION",
 )
 
 
-def _is_docstring_node(const: ast.Constant, tree: ast.AST) -> bool:
-    """True if *const* is the bare string literal of a Module/ClassDef/FunctionDef docstring."""
+def _documentation_constants(tree: ast.AST) -> set[int]:
+    """Constants that are the value of a bare string expression statement.
+
+    Generalises the original module/class/function-docstring exclusion to any
+    bare string expression, which is what a PEP 257 attribute docstring is. A
+    string that is never bound to anything cannot be dispatched as an
+    identifier, so it is documentation by construction.
+    """
+    found: set[int] = set()
     for node in ast.walk(tree):
-        if not isinstance(
-            node, (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)
-        ):
+        if not isinstance(node, ast.Expr):
             continue
-        body = node.body
-        if not body:
-            continue
-        first = body[0]
-        if (
-            isinstance(first, ast.Expr)
-            and first.value is const
-            and isinstance(const.value, str)
-        ):
+        value = node.value
+        if isinstance(value, ast.Constant) and isinstance(value.value, str):
+            found.add(id(value))
+    return found
+
+
+def _is_diagnostic_call(node: ast.Call) -> bool:
+    """True for a logging call or ``warnings.warn`` — a reporting sink."""
+    func = node.func
+    if isinstance(func, ast.Attribute):
+        if func.attr in _LOG_METHODS:
             return True
+        # warnings.warn(...)
+        if func.attr == "warn":
+            return True
+    if isinstance(func, ast.Name) and func.id in {"warn", "print"}:
+        return True
     return False
 
 
-def _resolving_format_receivers(tree: ast.AST) -> set[ast.Constant]:
+def _diagnostic_constants(tree: ast.AST) -> set[int]:
+    """String constants inside a logging/warning call, or inside a ``raise``.
+
+    Code that reports an unresolved token has to quote it; that text is never
+    dispatched as an identifier. Without this, the SDK's own WARNING/ERROR logs
+    naming the token they could not resolve are flagged.
+    """
+    found: set[int] = set()
+    subtrees: list[ast.AST] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and _is_diagnostic_call(node):
+            subtrees.extend(node.args)
+            subtrees.extend(kw.value for kw in node.keywords)
+        elif isinstance(node, ast.Raise):
+            subtrees.append(node)
+    for subtree in subtrees:
+        for inner in ast.walk(subtree):
+            if isinstance(inner, ast.Constant) and isinstance(inner.value, str):
+                found.add(id(inner))
+    return found
+
+
+def _sentinel_or_prose_constants(tree: ast.AST) -> set[int]:
+    """Token definitions and message constants bound to an ``ALL_CAPS`` name.
+
+    Two shapes, both non-dispatching:
+
+    * the literal is *exactly* the token — this is the declaration of the token
+      being hunted (``APP_NAME_TOKEN = "{app_name}"``), not a frozen identifier;
+    * the name reads as prose (``_MESSAGE``, ``RATIONALE``) — the string is
+      human-facing text that happens to quote the token.
+
+    Deliberately narrow: ``TASK_QUEUE = "atlan-{app_name}-prod"`` is an
+    ``ALL_CAPS`` name that is *not* prose-shaped and whose literal is *not* bare,
+    so it stays flagged.
+    """
+    found: set[int] = set()
+    for node in ast.walk(tree):
+        targets: list[ast.expr] = []
+        if isinstance(node, ast.Assign):
+            targets = list(node.targets)
+        elif isinstance(node, (ast.AnnAssign, ast.AugAssign)):
+            targets = [node.target]
+        else:
+            continue
+        value = node.value
+        if not (isinstance(value, ast.Constant) and isinstance(value.value, str)):
+            continue
+        names = [t.id for t in targets if isinstance(t, ast.Name)]
+        if not names:
+            continue
+        for name in names:
+            bare = name.lstrip("_")
+            if not (bare.isupper() and bare):
+                continue
+            if value.value.strip() == _TOKEN:
+                found.add(id(value))
+            elif any(part in bare for part in _PROSE_NAME_PARTS):
+                found.add(id(value))
+    return found
+
+
+def _resolving_format_receivers(tree: ast.AST) -> set[int]:
     """String-literal receivers of a ``.format(...)`` call that keyword-binds ``app_name``."""
-    receivers: set[ast.Constant] = set()
+    receivers: set[int] = set()
     for node in ast.walk(tree):
         if not isinstance(node, ast.Call):
             continue
@@ -83,18 +206,18 @@ def _resolving_format_receivers(tree: ast.AST) -> set[ast.Constant]:
             continue
         receiver = func.value
         if isinstance(receiver, ast.Constant) and isinstance(receiver.value, str):
-            receivers.add(receiver)
+            receivers.add(id(receiver))
     return receivers
 
 
-def _joined_str_children(tree: ast.AST) -> set[ast.Constant]:
+def _joined_str_children(tree: ast.AST) -> set[int]:
     """Constant nodes that are pieces of an f-string — never independently flagged."""
-    pieces: set[ast.Constant] = set()
+    pieces: set[int] = set()
     for node in ast.walk(tree):
         if isinstance(node, ast.JoinedStr):
             for value in node.values:
                 if isinstance(value, ast.Constant):
-                    pieces.add(value)
+                    pieces.add(id(value))
     return pieces
 
 
@@ -105,17 +228,20 @@ def check_o005(
 ) -> list[Finding]:
     """Emit O005 for a plain string literal that still carries an unresolved '{app_name}' token."""
     findings: list[Finding] = []
-    resolving_receivers = _resolving_format_receivers(tree)
-    fstring_pieces = _joined_str_children(tree)
+    exempt = (
+        _resolving_format_receivers(tree)
+        | _joined_str_children(tree)
+        | _documentation_constants(tree)
+        | _diagnostic_constants(tree)
+        | _sentinel_or_prose_constants(tree)
+    )
 
     for node in ast.walk(tree):
         if not isinstance(node, ast.Constant) or not isinstance(node.value, str):
             continue
         if _TOKEN not in node.value:
             continue
-        if node in resolving_receivers or node in fstring_pieces:
-            continue
-        if _is_docstring_node(node, tree):
+        if id(node) in exempt:
             continue
         findings.append(
             make_finding(

--- a/packages/conformance/conformance/suite/checks/optimizations/_app_name_placeholder.py
+++ b/packages/conformance/conformance/suite/checks/optimizations/_app_name_placeholder.py
@@ -163,8 +163,8 @@ def _diagnostic_constants(tree: ast.AST) -> set[int]:
     Code that reports an unresolved token has to quote it; that text is never
     dispatched as an identifier. Without this, the SDK's own WARNING/ERROR logs
     naming the token they could not resolve are flagged. An f-string *inside*
-    one of these sinks still needs its pieces exempted here — the line-based
-    waiver in ``check_o005`` would otherwise re-flag its escaped braces.
+    one of these sinks still needs its pieces exempted here — the re-flag pass
+    in ``check_o005`` would otherwise re-flag its escaped braces.
     """
     found: set[int] = set()
     subtrees: list[ast.AST] = []

--- a/packages/conformance/conformance/suite/checks/optimizations/_app_name_placeholder.py
+++ b/packages/conformance/conformance/suite/checks/optimizations/_app_name_placeholder.py
@@ -123,7 +123,11 @@ def _documentation_constants(tree: ast.AST) -> set[int]:
     Generalises the original module/class/function-docstring exclusion to any
     bare string expression, which is what a PEP 257 attribute docstring is. A
     string that is never bound to anything cannot be dispatched as an
-    identifier, so it is documentation by construction.
+    identifier, so it is documentation by construction — and a docstring
+    quoting the token with escaped braces parses as ``Expr(JoinedStr)``, so an
+    f-string docstring's pieces are exempt here too. Node-keyed (not
+    line-keyed) so a *separate* literal that merely shares the docstring's
+    physical line is not exempted by collision.
     """
     found: set[int] = set()
     for node in ast.walk(tree):
@@ -132,6 +136,10 @@ def _documentation_constants(tree: ast.AST) -> set[int]:
         value = node.value
         if isinstance(value, ast.Constant) and isinstance(value.value, str):
             found.add(id(value))
+        elif isinstance(value, ast.JoinedStr):
+            for piece in value.values:
+                if isinstance(piece, ast.Constant) and isinstance(piece.value, str):
+                    found.add(id(piece))
     return found
 
 
@@ -173,21 +181,16 @@ def _diagnostic_constants(tree: ast.AST) -> set[int]:
     return found
 
 
-def _diagnostic_joined_str_lines(tree: ast.AST) -> set[int]:
-    """Lines hosting a ``JoinedStr`` inside a logging/warning call or ``raise``.
+def _diagnostic_joined_strs(tree: ast.AST) -> set[int]:
+    """``JoinedStr`` nodes inside a logging/warning call or ``raise``.
 
     Code that reports an unresolved token has to quote it; that text is never
     dispatched as an identifier — and that holds for a *resolving* f-string
     (``logger.info(f"queue atlan-{app_name}-prod")``) just as much as for a
-    plain literal. Without this, ``_unresolved_joined_str_lines`` would flag
-    every interpolated f-string that merely mentions the token in a log
-    message.
-
-    Line-keyed (not node-id-keyed) for the same reason as
-    ``_unresolved_joined_str_lines``: the SARIF emitter re-parses the source,
-    so only positions survive.
+    plain literal. Without this, ``_unresolved_joined_strs`` would flag every
+    interpolated f-string that merely mentions the token in a log message.
     """
-    lines: set[int] = set()
+    found: set[int] = set()
     subtrees: list[ast.AST] = []
     for node in ast.walk(tree):
         if isinstance(node, ast.Call) and _is_diagnostic_call(node):
@@ -198,12 +201,29 @@ def _diagnostic_joined_str_lines(tree: ast.AST) -> set[int]:
     for subtree in subtrees:
         for inner in ast.walk(subtree):
             if isinstance(inner, ast.JoinedStr):
-                lines.add(inner.lineno)
-    return lines
+                found.add(id(inner))
+    return found
 
 
-def _unresolved_joined_str_lines(tree: ast.AST) -> set[int]:
-    """Lines hosting a ``JoinedStr`` whose runtime value still carries the token.
+def _doc_joined_strs(tree: ast.AST) -> set[int]:
+    """``JoinedStr`` nodes that are the value of a bare expression statement.
+
+    A docstring quoting the token with escaped braces
+    (``f"...{{app_name}}..."``) parses as ``Expr(JoinedStr)``, so it never
+    reaches ``_documentation_constants`` — documentation is documentation in
+    either parse shape. (Its *pieces* are also exempt via
+    ``_documentation_constants``, which covers the same ``Expr(JoinedStr)``
+    node.)
+    """
+    found: set[int] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Expr) and isinstance(node.value, ast.JoinedStr):
+            found.add(id(node.value))
+    return found
+
+
+def _unresolved_joined_strs(tree: ast.AST) -> set[int]:
+    """``JoinedStr`` nodes whose runtime value still carries the token.
 
     Python parses ``f"atlan-{{app_name}}-production"`` as a ``JoinedStr``, but
     the escaped braces are *not* interpolated — the runtime string is the
@@ -213,11 +233,11 @@ def _unresolved_joined_str_lines(tree: ast.AST) -> set[int]:
     lives in the ``ast.FormattedValue`` — so it never lands here).
 
     A ``JoinedStr`` containing an escaped-brace token inside a diagnostic call
-    or a docstring stays exempt (``check_o005`` subtracts both line-sets):
-    reporting on the token still is not dispatching it, and double-brace-
-    quoting it is a normal way to make the literal render inside an f-string.
+    or a docstring is filtered out by the caller: reporting on the token still
+    is not dispatching it, and double-brace-quoting it is a normal way to make
+    the literal render inside an f-string.
     """
-    lines: set[int] = set()
+    found: set[int] = set()
     for node in ast.walk(tree):
         if not isinstance(node, ast.JoinedStr):
             continue
@@ -227,8 +247,8 @@ def _unresolved_joined_str_lines(tree: ast.AST) -> set[int]:
             and _TOKEN in value.value
             for value in node.values
         ):
-            lines.add(node.lineno)
-    return lines
+            found.add(id(node))
+    return found
 
 
 def _sentinel_or_prose_constants(tree: ast.AST) -> set[int]:
@@ -275,7 +295,14 @@ def _sentinel_or_prose_constants(tree: ast.AST) -> set[int]:
 
 
 def _resolving_format_receivers(tree: ast.AST) -> set[int]:
-    """String-literal receivers of a ``.format(...)`` call that keyword-binds ``app_name``."""
+    """String-literal receivers of a ``.format(...)`` call that keyword-binds ``app_name``.
+
+    An f-string receiver whose pieces still carry the token
+    (``f"atlan-{{app_name}}".format(app_name=a)``) resolves at runtime just like
+    a plain literal receiver, so its token-bearing pieces are exempted here too
+    — that keeps the escaped-brace waiver in ``check_o005`` from re-flagging a
+    site that *does* substitute the token.
+    """
     receivers: set[int] = set()
     for node in ast.walk(tree):
         if not isinstance(node, ast.Call):
@@ -288,6 +315,14 @@ def _resolving_format_receivers(tree: ast.AST) -> set[int]:
         receiver = func.value
         if isinstance(receiver, ast.Constant) and isinstance(receiver.value, str):
             receivers.add(id(receiver))
+        elif isinstance(receiver, ast.JoinedStr):
+            for piece in receiver.values:
+                if (
+                    isinstance(piece, ast.Constant)
+                    and isinstance(piece.value, str)
+                    and _TOKEN in piece.value
+                ):
+                    receivers.add(id(piece))
     return receivers
 
 
@@ -319,32 +354,53 @@ def check_o005(
     # An f-string piece still carrying the token is the escaped-brace shape:
     # ``f"{{app_name}}"`` is *not* interpolated — the runtime value freezes the
     # token exactly like a plain literal, so exempting every JoinedStr child
-    # (above) must not cover it. The waiver is line-keyed (a JoinedStr and its
-    # Constant children share the f-string's line, and positions are the only
-    # handle that survives the SARIF emitter's re-parse); a docstring or a
-    # diagnostic f-string on that line stays exempt.
-    # A bare string *or f-string* expression statement is documentation — a
-    # docstring quoting the token with escaped braces (``f"...{{app_name}}..."``)
-    # parses as ``Expr(JoinedStr)``, not ``Expr(Constant)``, so both shapes
-    # contribute their line here.
-    doc_lines = {
-        node.value.lineno
-        for node in ast.walk(tree)
-        if isinstance(node, ast.Expr)
-        and isinstance(node.value, (ast.Constant, ast.JoinedStr))
-    }
-    flagged_fstring_lines = (
-        _unresolved_joined_str_lines(tree)
-        - _diagnostic_joined_str_lines(tree)
-        - doc_lines
+    # (above) must not cover it. The waiver re-flags only that f-string's own
+    # token-bearing Constant pieces, and only those no *other* exclusion
+    # independently covers: a docstring/diagnostic f-string stays exempt, an
+    # unrelated exempt literal sharing the physical line is not re-flagged, and
+    # ``f"{{app_name}}".format(app_name=...)`` — a receiver the runtime still
+    # resolves — keeps its exclusion too.
+    #
+    # The pieces are collected by object *identity*, not id-keyed sets: an AST
+    # node's id is only stable while the object is alive, and sequential
+    # comprehensions let CPython recycle freed node ids onto fresh nodes —
+    # silently corrupting any id-set built in a second walk.
+    unresolved_ids = _unresolved_joined_strs(tree)
+    diagnostic_ids = _diagnostic_joined_strs(tree)
+    doc_ids = _doc_joined_strs(tree)
+    independent_ids = (
+        _documentation_constants(tree)
+        | _diagnostic_constants(tree)
+        | _resolving_format_receivers(tree)
     )
+    flagged_pieces: list[ast.Constant] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.JoinedStr):
+            continue
+        if id(node) not in unresolved_ids:
+            continue
+        if id(node) in diagnostic_ids or id(node) in doc_ids:
+            continue
+        for piece in node.values:
+            if (
+                isinstance(piece, ast.Constant)
+                and isinstance(piece.value, str)
+                and _TOKEN in piece.value
+                and id(piece) not in independent_ids
+            ):
+                flagged_pieces.append(piece)
+    # Every id-set membership above is resolved while the walked nodes are
+    # still alive inside their own pass, and the surviving piece *objects* are
+    # what this loop holds — the ids taken here cannot be recycled before the
+    # main loop reads them.
+    flagged_piece_ids = {id(p) for p in flagged_pieces}
 
     for node in ast.walk(tree):
         if not isinstance(node, ast.Constant) or not isinstance(node.value, str):
             continue
         if _TOKEN not in node.value:
             continue
-        if id(node) in exempt and node.lineno not in flagged_fstring_lines:
+        if id(node) in exempt and id(node) not in flagged_piece_ids:
             continue
         findings.append(
             make_finding(

--- a/packages/conformance/conformance/suite/rules/optimizations.py
+++ b/packages/conformance/conformance/suite/rules/optimizations.py
@@ -241,4 +241,84 @@ RULES: tuple[RuleDefinition, ...] = (
         ),
         help_uri="https://github.com/atlanhq/application-sdk/blob/main/packages/conformance/conformance/docs/rules/optimizations.md#o006",
     ),
+    RuleDefinition(
+        id="O005",
+        scope=RuleScope.BOTH,
+        name="UnresolvedAppNamePlaceholder",
+        tier=EnforcementTier.WARN,
+        mechanism=RuleMechanism.STATIC,
+        category="dag-write-path",
+        autofixable=False,
+        orthogonal_gate="tests",
+        since="0.18.0",
+        rationale=(
+            "A plain string literal carrying an unsubstituted '{app_name}' token "
+            "freezes the literal token into whatever it's assigned to instead of the "
+            "real app name — the exact shape that shipped a task queue no worker "
+            "polls, hanging dbt:process to its 24h heartbeat backstop (CONNECT-183). "
+            "The substitution was independently hand-rolled at least four times "
+            "(Heracles, native-migration-app, atlan-local-marketplace-app "
+            "CONNECT-191/#539, atlan-hightouch-app ARUN-1039), and one of those "
+            "shipped a double prefix (DISTR-834). A canonical helper — "
+            "application_sdk.common.task_queue (derive_task_queue, "
+            "resolve_manifest_tokens) — lands in the SDK release that ships "
+            "FND-195, so remediation then has a single target; this rule still "
+            "checks the unresolved shape rather than a missing "
+            "import, because the writers most worth catching are hand-authored "
+            "templates that import nothing. WARN (not BLOCK): a template legitimately "
+            "resolved by a caller in a different file cannot be seen from here, so "
+            "each hit needs a human glance rather than an automatic fail."
+        ),
+        short_description=(
+            "Hardcoded '{app_name}' left unsubstituted in a plain string literal"
+        ),
+        full_description=(
+            "Flags a string ``ast.Constant`` containing the literal substring\n"
+            "``{app_name}`` when the token can actually **reach a value** — including\n"
+            'the pieces of an escaped-brace f-string: ``f"atlan-{{app_name}}-prod"``\n'
+            "is *not* interpolated, its runtime value is the literal\n"
+            "``atlan-{app_name}-prod``, so it freezes the token exactly like a plain\n"
+            "literal. A token that only ever appears in prose or in a diagnostic\n"
+            "cannot freeze into an identifier, and flagging it just teaches people\n"
+            "to suppress the rule.\n"
+            "\n"
+            "Not flagged:\n"
+            "\n"
+            '* part of a *resolving* f-string (``f"...{app_name}..."`` interpolates\n'
+            "  at parse time and no ``{app_name}`` text survives into its pieces),\n"
+            "* the receiver of a ``.format(...)`` call whose keywords include\n"
+            "  ``app_name=`` (a proper, already-resolving substitution site),\n"
+            "* **documentation** — the value of any bare string expression statement.\n"
+            "  This covers module/class/function docstrings *and* PEP 257 attribute\n"
+            "  docstrings, which are not the first statement of their class body,\n"
+            "* **diagnostic text** — inside the arguments of a logging call,\n"
+            "  ``warnings.warn(...)``, or a ``raise``; reporting on the token requires\n"
+            "  quoting it,\n"
+            "* **a token sentinel or message constant** — bound to an ``ALL_CAPS``\n"
+            "  name where the literal is exactly the token (the token's own\n"
+            "  definition, e.g. ``APP_NAME_TOKEN``) or the name ends in a prose\n"
+            "  segment (``_MESSAGE``, ``START_MESSAGE``, ``VALIDATION_RATIONALE``).\n"
+            "\n"
+            "The exclusions stay narrow: an ``ALL_CAPS`` name holding a real queue\n"
+            'template (``TASK_QUEUE = "atlan-{app_name}-prod"``) is still flagged —\n'
+            "and so is one whose name merely *contains* a prose fragment without a\n"
+            "trailing boundary (``MESSAGE_QUEUE``, ``HELP_QUEUE``) — as are keyword\n"
+            "arguments, values at any depth in a DAG literal, and returned templates.\n"
+            "\n"
+            "Detection is shape-anchored rather than import-anchored, because the\n"
+            "writers most worth catching are hand-authored templates outside the SDK\n"
+            "that import nothing at all. Remediation: an f-string or\n"
+            "``.format(app_name=...)`` when the name is in scope; the shared\n"
+            "``application_sdk.common.task_queue`` helper (``derive_task_queue`` /\n"
+            "``resolve_manifest_tokens``) lands in the SDK release that ships\n"
+            "FND-195 and is the canonical target once available.\n"
+            "\n"
+            "NOT autofixable: the correct fix depends on where ``app_name`` is\n"
+            "actually available in scope — sometimes an f-string is right, sometimes\n"
+            "the value needs threading in from a caller first. Suppress with\n"
+            "``# conformance: ignore[O005] <reason>`` for a template resolved by a\n"
+            "caller in a different file than the one being scanned.\n"
+        ),
+        help_uri="https://github.com/atlanhq/application-sdk/blob/main/packages/conformance/conformance/docs/rules/optimizations.md#o005",
+    ),
 )

--- a/packages/conformance/tests/test_app_name_placeholder.py
+++ b/packages/conformance/tests/test_app_name_placeholder.py
@@ -1,0 +1,67 @@
+"""Tests for O005 UnresolvedAppNamePlaceholder (CONNECT-183/CONNECT-191).
+
+Exercised through the optimizations package ``scan_text`` so the real wiring
+(directive parsing, suppression handling) is covered, not just the bare
+detector.
+"""
+
+from __future__ import annotations
+
+from conformance.suite.checks.optimizations import scan_text as o_scan
+
+
+def _o_ids(src: str) -> list[str]:
+    return [f.rule_id for f in o_scan(src, "app/x.py") if not f.suppressed]
+
+
+def test_o005_fires_on_bare_literal_assignment() -> None:
+    assert "O005" in _o_ids('task_queue = "atlan-{app_name}-production"\n')
+
+
+def test_o005_fires_on_call_argument() -> None:
+    assert "O005" in _o_ids('register_queue("atlan-{app_name}-production")\n')
+
+
+def test_o005_fires_on_dict_value() -> None:
+    assert "O005" in _o_ids('inputs = {"task_queue": "atlan-{app_name}-production"}\n')
+
+
+def test_o005_silent_on_fstring() -> None:
+    assert "O005" not in _o_ids('task_queue = f"atlan-{app_name}-production"\n')
+
+
+def test_o005_silent_on_resolving_format_call() -> None:
+    assert "O005" not in _o_ids(
+        'task_queue = "atlan-{app_name}-production".format(app_name=app_name)\n'
+    )
+
+
+def test_o005_fires_on_format_call_missing_app_name_kwarg() -> None:
+    # .format() is called, but app_name is never bound — still unresolved.
+    assert "O005" in _o_ids(
+        'task_queue = "atlan-{app_name}-{deployment}".format(deployment=d)\n'
+    )
+
+
+def test_o005_silent_on_module_docstring() -> None:
+    assert "O005" not in _o_ids(
+        '"""Task queues follow the atlan-{app_name}-<deployment> convention."""\n'
+    )
+
+
+def test_o005_silent_on_function_docstring() -> None:
+    src = (
+        "def f():\n"
+        '    """Builds atlan-{app_name}-<deployment> queue names."""\n'
+        "    return None\n"
+    )
+    assert "O005" not in _o_ids(src)
+
+
+def test_o005_silent_without_token() -> None:
+    assert "O005" not in _o_ids('task_queue = "atlan-connector-production"\n')
+
+
+def test_o005_suppressed_inline() -> None:
+    src = 'task_queue = "atlan-{app_name}-production"  # conformance: ignore[O005] legacy template\n'
+    assert "O005" not in _o_ids(src)

--- a/packages/conformance/tests/test_app_name_placeholder.py
+++ b/packages/conformance/tests/test_app_name_placeholder.py
@@ -169,6 +169,42 @@ def test_o005_escaped_brace_fstring_suppressed_inline() -> None:
     assert "O005" not in _o_ids(src)
 
 
+# ── The escaped-brace waiver must not re-flag an already-resolved sibling ────
+#
+# The waiver re-flags only the escaped-brace f-string's own token-bearing
+# pieces — never an unrelated exempt literal that happens to share the
+# physical line (round-2 review nit).
+
+
+def _o_count(src: str) -> int:
+    return sum(
+        1 for f in o_scan(src, "app/x.py") if f.rule_id == "O005" and not f.suppressed
+    )
+
+
+def test_o005_sibling_resolved_format_receiver_not_reflagged() -> None:
+    """The `.format(app_name=...)` receiver on the same line as an escaped-brace
+    f-string is already resolved — only the f-string may be flagged."""
+    src = 'x = "atlan-{app_name}".format(app_name=a); y = f"{{app_name}}"\n'
+    assert _o_count(src) == 1
+
+
+def test_o005_sibling_diagnostic_literal_not_reflagged() -> None:
+    """A diagnostic message sharing a line with an escaped-brace f-string keeps
+    its diagnostic exemption — only the f-string may be flagged."""
+    src = 'logger.error("unresolved {app_name}"); y = f"{{app_name}}"\n'
+    assert _o_count(src) == 1
+
+
+def test_o005_silent_on_format_call_on_fstring_receiver() -> None:
+    """``f"{{app_name}}".format(app_name=a)`` resolves at runtime exactly like a
+    plain-literal receiver — the f-string parse shape is not a reason to flag
+    a site that *does* substitute the token."""
+    assert "O005" not in _o_ids(
+        'task_queue = f"atlan-{{app_name}}".format(app_name=a)\n'
+    )
+
+
 def test_o005_fires_on_bare_token_bound_to_identifier() -> None:
     """Only an ALL_CAPS binding reads as a token declaration; a lowercase one is
     a value that will be dispatched."""

--- a/packages/conformance/tests/test_app_name_placeholder.py
+++ b/packages/conformance/tests/test_app_name_placeholder.py
@@ -65,3 +65,74 @@ def test_o005_silent_without_token() -> None:
 def test_o005_suppressed_inline() -> None:
     src = 'task_queue = "atlan-{app_name}-production"  # conformance: ignore[O005] legacy template\n'
     assert "O005" not in _o_ids(src)
+
+
+# ── The token has to reach a value to be dangerous ───────────────────────────
+#
+# The exclusions below exist because without them the rule fires on the very
+# module that implements the correct behaviour (application_sdk.common.task_queue
+# defines the token it substitutes, documents its fields as attribute
+# docstrings, and the handler logs at WARNING/ERROR naming the token it could
+# not resolve). Each of these was a real finding against that code.
+
+
+def test_o005_silent_on_attribute_docstring() -> None:
+    """A PEP 257 attribute docstring is not ``body[0]`` of its class, so the
+    original first-statement-only exclusion missed it."""
+    src = 'class C:\n    x: int\n    """Holds the {app_name} token."""\n'
+    assert "O005" not in _o_ids(src)
+
+
+def test_o005_silent_on_logging_call() -> None:
+    """Code reporting an unresolved token has to quote it; a log message is
+    never dispatched as an identifier."""
+    src = 'logger.error("unresolved {app_name} token in manifest %s", source)\n'
+    assert "O005" not in _o_ids(src)
+
+
+def test_o005_silent_on_raise_message() -> None:
+    src = 'raise ValueError("unresolved {app_name} token")\n'
+    assert "O005" not in _o_ids(src)
+
+
+def test_o005_silent_on_token_sentinel_definition() -> None:
+    """Declaring the token itself is not freezing it into an identifier —
+    ``application_sdk.common.task_queue.APP_NAME_TOKEN`` is exactly this."""
+    assert "O005" not in _o_ids('APP_NAME_TOKEN = "{app_name}"\n')
+
+
+def test_o005_silent_on_prose_named_constant() -> None:
+    assert "O005" not in _o_ids(
+        '_MESSAGE = "the {app_name} token was left unresolved"\n'
+    )
+
+
+# ── ...but the exclusions must stay narrow ───────────────────────────────────
+
+
+def test_o005_fires_on_all_caps_queue_template() -> None:
+    """An ALL_CAPS name is not a free pass: this one is a genuine queue template,
+    neither bare-token nor prose-named, so the sentinel exclusion must not
+    swallow it."""
+    assert "O005" in _o_ids('TASK_QUEUE = "atlan-{app_name}-prod"\n')
+
+
+def test_o005_fires_on_bare_token_bound_to_identifier() -> None:
+    """Only an ALL_CAPS binding reads as a token declaration; a lowercase one is
+    a value that will be dispatched."""
+    assert "O005" in _o_ids('task_queue = "{app_name}"\n')
+
+
+def test_o005_fires_on_keyword_argument() -> None:
+    assert "O005" in _o_ids('submit(task_queue="atlan-{app_name}-prod")\n')
+
+
+def test_o005_fires_at_any_depth_in_a_dag_literal() -> None:
+    """AE DAG nodes nest the queue several levels down."""
+    src = 'dag = {"extract": {"inputs": {"task_queue": "atlan-{app_name}-prod"}}}\n'
+    assert "O005" in _o_ids(src)
+
+
+def test_o005_fires_on_returned_template() -> None:
+    src = 'def build():\n    return "atlan-{app_name}-prod"\n'
+    assert "O005" in _o_ids(src)

--- a/packages/conformance/tests/test_app_name_placeholder.py
+++ b/packages/conformance/tests/test_app_name_placeholder.py
@@ -107,6 +107,13 @@ def test_o005_silent_on_prose_named_constant() -> None:
     )
 
 
+def test_o005_silent_on_prefixed_prose_constant() -> None:
+    """A prose *suffix* reads as message text even with a qualifier prefix."""
+    assert "O005" not in _o_ids(
+        'START_MESSAGE = "the {app_name} token was left unresolved"\n'
+    )
+
+
 # ── ...but the exclusions must stay narrow ───────────────────────────────────
 
 
@@ -115,6 +122,51 @@ def test_o005_fires_on_all_caps_queue_template() -> None:
     neither bare-token nor prose-named, so the sentinel exclusion must not
     swallow it."""
     assert "O005" in _o_ids('TASK_QUEUE = "atlan-{app_name}-prod"\n')
+
+
+def test_o005_fires_on_prose_fragment_queue_templates() -> None:
+    """A queue template whose name merely *contains* a prose fragment is a
+    dispatch template, not message text: the prose exclusion matches the
+    trailing delimited segment, never a substring."""
+    for name in ("MESSAGE_QUEUE", "HELP_QUEUE", "DOC_QUEUE"):
+        assert "O005" in _o_ids(f'{name} = "atlan-{{app_name}}-prod"\n'), name
+
+
+def test_o005_fires_on_escaped_brace_fstring() -> None:
+    """``f"{{app_name}}"`` is *not* interpolated: the escaped braces evaluate to
+    the literal runtime text ``{app_name}``, which freezes into the identifier
+    exactly like a plain literal — the precise dangerous shape."""
+    src = 'task_queue = f"atlan-{{app_name}}-production"\n'
+    assert "O005" in _o_ids(src)
+
+
+def test_o005_fires_on_escaped_brace_fstring_call_argument() -> None:
+    assert "O005" in _o_ids('register_queue(f"atlan-{{app_name}}-production")\n')
+
+
+def test_o005_silent_on_interpolated_fstring_in_diagnostic() -> None:
+    """A *resolving* f-string quoting the token inside a log call is still a
+    diagnostic, not a dispatch — the f-string waiver must not re-flag it."""
+    assert "O005" not in _o_ids('logger.info(f"queue atlan-{app_name}-prod")\n')
+
+
+def test_o005_silent_on_escaped_brace_fstring_in_diagnostic() -> None:
+    """Double-brace-quoting the token is a normal way to make it render
+    literally inside an f-string log message; still not a dispatch."""
+    assert "O005" not in _o_ids('logger.info(f"queue atlan-{{app_name}}-prod")\n')
+
+
+def test_o005_silent_on_escaped_brace_fstring_docstring() -> None:
+    """An f-string docstring quoting the token with escaped braces is
+    documentation (``Expr(JoinedStr)``), not a value that can dispatch."""
+    assert "O005" not in _o_ids(
+        'f"""Queue names look like atlan-{{app_name}}-prod."""\n'
+    )
+
+
+def test_o005_escaped_brace_fstring_suppressed_inline() -> None:
+    src = 'task_queue = f"atlan-{{app_name}}-prod"  # conformance: ignore[O005] resolved by caller\n'
+    assert "O005" not in _o_ids(src)
 
 
 def test_o005_fires_on_bare_token_bound_to_identifier() -> None:

--- a/packages/conformance/tests/test_catalog.py
+++ b/packages/conformance/tests/test_catalog.py
@@ -477,7 +477,7 @@ def test_catalog_o_series_present() -> None:
     """The O-series optimisation rules are all present."""
     rules = load_catalog()
     o_ids = {r.id for r in rules if r.id.startswith("O")}
-    expected = {"O001", "O002", "O003", "O004", "O006"}
+    expected = {"O001", "O002", "O003", "O004", "O005", "O006"}
     missing = expected - o_ids
     assert not missing, f"Missing O-series rules: {missing}"
 


### PR DESCRIPTION
## Summary
- Adds **O005 `UnresolvedAppNamePlaceholder`** to the O-series conformance checks: flags a plain string literal that still carries an unsubstituted `{app_name}` token (not an f-string, not a `.format(app_name=...)` receiver, not a docstring).
- Motivating incident: CONNECT-183 — a task-queue name literally frozen as `"atlan-{app_name}-production"` meant no worker ever polled it, hanging `dbt:process` to its 24h heartbeat backstop before failing.
- The substitution helper this needs (`substitute_app_name_placeholder`) has been independently hand-rolled at least 4 times across separate codebases — Heracles (Go), native-migration-app, `atlan-local-marketplace-app` (CONNECT-191, [#539](https://github.com/atlanhq/atlan-local-marketplace-app/pull/539)), and `atlan-hightouch-app` (ARUN-1039) — because no shared, discoverable utility exists in the SDK yet. Detection here is deliberately **shape-anchored, not import-anchored**: it flags the unresolved literal directly rather than checking for a canonical helper call that doesn't exist yet.
- `WARN` tier, not autofixable (the correct fix depends on where `app_name` is actually available in scope — sometimes an f-string is right, sometimes the value needs threading in from a caller), suppressible via `# conformance: ignore[O005] <reason>`.

Ref: FND-184 (support-patterns tracking ticket)

## Test plan
- [x] New unit tests in `tests/test_app_name_placeholder.py` — fires on bare-literal assignment, call argument, dict value, and a `.format()` call missing the `app_name` kwarg; silent on f-strings, resolving `.format(app_name=...)` calls, module/function docstrings, and literals with no token; suppressed by inline directive
- [x] `test_catalog_o_series_present` updated to include O005
- [x] Docs regenerated via `atlan-application-sdk-conformance gen-rule-docs` (never hand-edited)
- [x] `uv run --with pytest pytest tests/ -q --ignore=tests/test_sdk_contract_mixins.py` — 2162 passed, 1 pre-existing unrelated failure (`test_app_name_alignment.py::test_sdk_base_names_matches_templates_all`, needs a sibling `application_sdk` install this standalone checkout doesn't have — documented pre-existing gap, not touched by this change)
- [x] `pyproject.toml` version and `CHANGELOG.md` deliberately left untouched (release-automation owned)

## Not covered by this PR
- Does not add the actual `substitute_app_name_placeholder` SDK helper — that's a separate, larger design decision (where does `app_name` come from at each call site) tracked as its own follow-up on FND-184.
- Does not retroactively find existing unresolved placeholders already shipped in consumer app repos — this only catches new code going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)