### PR TITLE
fix(manifest): defensively substitute unresolved {app_name} placeholder

### DIFF
--- a/application_sdk/handler/service.py
+++ b/application_sdk/handler/service.py
@@ -54,6 +54,7 @@ from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel as PydanticBaseModel
 from temporalio.client import WorkflowFailureError
 
+from application_sdk.constants import APPLICATION_NAME
 from application_sdk.constants import CONTRACT_GENERATED_DIR as _CONTRACT_GENERATED_DIR
 from application_sdk.constants import DEPLOYMENT_NAME, LOCAL_ENVIRONMENT
 from application_sdk.errors import AppError
@@ -2015,9 +2016,18 @@ def _register_workflow_routes(
                     detail=f"No manifest found for entrypoint {entrypoint_name!r}",
                 )
         raw = ep_manifest.read_bytes()
-        # app_name is baked into the generated manifest by the contract toolkit
-        # (from the contract `name`); only the per-deployment token is substituted here.
+        # app_name is normally baked into the generated manifest by the contract
+        # toolkit (from the contract `name`) — this is a defensive fallback for a
+        # contract-toolkit miss or a hand-authored template that left the token
+        # unresolved. A literal "{app_name}" reaching a downstream AE write freezes
+        # into task_queue = "atlan-{app_name}-<deployment>", a queue no worker
+        # polls (CONNECT-183: hung dbt:process to its 24h heartbeat backstop).
+        # APPLICATION_NAME is the bare name (no "atlan-" prefix) — the same
+        # convention _derive_task_queue() uses to build "atlan-{app}-{deployment}"
+        # in main.py; substituting a pre-prefixed value here would double it
+        # (the exact bug Heracles shipped once, DISTR-834).
         raw = raw.replace(b"{deployment_name}", deployment)
+        raw = raw.replace(b"{app_name}", (APPLICATION_NAME or "default").encode())
 
         # Dynamic-manifest hook: if the app defines
         # `app.<entrypoint_snake>.core.compute_manifest`, hand the
@@ -2099,9 +2109,10 @@ def _register_workflow_routes(
             # substitution. No parse/reserialize: the file is already valid JSON,
             # validated at build time by the contract tooling.
             raw = manifest_path.read_bytes()
-            # app_name is baked into the manifest by the toolkit; only the
-            # per-deployment token is substituted here (see note above).
+            # app_name is normally baked into the manifest by the toolkit; this is
+            # a defensive fallback for an unresolved token (see note above).
             raw = raw.replace(b"{deployment_name}", deployment)
+            raw = raw.replace(b"{app_name}", (APPLICATION_NAME or "default").encode())
             return Response(content=raw, media_type="application/json")
 
         # Default-entrypoint fallback (aligns with PR #1965 semantics used

--- a/application_sdk/handler/service.py
+++ b/application_sdk/handler/service.py
@@ -2100,9 +2100,14 @@ def _register_workflow_routes(
 
         # No entrypoint param: single-entrypoint path
         if manifest is not None:
-            return Response(
-                content=manifest.model_dump_json(), media_type="application/json"
-            )
+            # Programmatic manifest — apply the same defensive placeholder
+            # substitution as the disk branches below so a caller-passed
+            # AppManifest carrying a literal "{app_name}"/"{deployment_name}"
+            # token is not served verbatim (CONNECT-183 / DISTR-834).
+            raw = manifest.model_dump_json().encode()
+            raw = raw.replace(b"{deployment_name}", deployment)
+            raw = raw.replace(b"{app_name}", (APPLICATION_NAME or "default").encode())
+            return Response(content=raw, media_type="application/json")
         manifest_path = CONTRACT_GENERATED_DIR / "manifest.json"
         if manifest_path.exists():
             # Disk: contract-generated file — serve raw bytes with placeholder

--- a/tests/unit/handler/test_service.py
+++ b/tests/unit/handler/test_service.py
@@ -2528,6 +2528,51 @@ class TestManifestEndpoint:
             svc_module.CONTRACT_GENERATED_DIR = original_dir
             svc_module.DEPLOYMENT_NAME = original_dep
 
+    def test_manifest_disk_substitutes_unresolved_app_name_placeholder(
+        self, tmp_path: Path
+    ) -> None:
+        """A hand-authored/toolkit-miss manifest that left a literal '{app_name}'
+        token is defensively resolved, not served verbatim. A leftover token
+        reaching an AE write freezes into task_queue = "atlan-{app_name}-<deploy>",
+        a queue no worker polls (CONNECT-183: hung dbt:process to its 24h
+        heartbeat backstop)."""
+        from application_sdk.handler import service as svc_module
+
+        manifest_data = {
+            "execution_mode": "dag",
+            "dag": {
+                "extract": {
+                    "activity_name": "execute_workflow",
+                    "activity_display_name": "Extract",
+                    "inputs": {
+                        "workflow_type": "extraction",
+                        "task_queue": "atlan-{app_name}-{deployment_name}",
+                    },
+                }
+            },
+        }
+        (tmp_path / "manifest.json").write_text(__import__("json").dumps(manifest_data))
+
+        original_dir = svc_module.CONTRACT_GENERATED_DIR
+        original_dep = svc_module.DEPLOYMENT_NAME
+        original_app = svc_module.APPLICATION_NAME
+        svc_module.CONTRACT_GENERATED_DIR = tmp_path
+        svc_module.DEPLOYMENT_NAME = "prod-deploy"
+        svc_module.APPLICATION_NAME = "dbt"
+        try:
+            client = _make_client()
+            response = client.get("/workflows/v1/manifest")
+            assert response.status_code == 200
+            body = response.json()
+            assert (
+                body["dag"]["extract"]["inputs"]["task_queue"]
+                == "atlan-dbt-prod-deploy"
+            )
+        finally:
+            svc_module.CONTRACT_GENERATED_DIR = original_dir
+            svc_module.DEPLOYMENT_NAME = original_dep
+            svc_module.APPLICATION_NAME = original_app
+
     def test_manifest_programmatic_takes_priority(self, tmp_path: Path) -> None:
         """When both programmatic and disk manifest exist, programmatic wins."""
         from application_sdk.handler import service as svc_module
@@ -3370,6 +3415,36 @@ class TestEntrypointManifestResolution:
         finally:
             svc_module.CONTRACT_GENERATED_DIR = original_dir
             svc_module.DEPLOYMENT_NAME = original_dep
+
+    def test_manifest_substitutes_unresolved_app_name_for_entrypoint(
+        self, tmp_path: Path
+    ) -> None:
+        """Entrypoint manifest with a leftover literal '{app_name}' token is
+        defensively resolved, matching the root-manifest behavior."""
+        from application_sdk.handler import service as svc_module
+
+        contract_dir = tmp_path / "generated"
+        ep_dir = contract_dir / "ep1"
+        ep_dir.mkdir(parents=True)
+        manifest_data = {"task_queue": "atlan-{app_name}-{deployment_name}"}
+        (ep_dir / "manifest.json").write_text(json.dumps(manifest_data))
+
+        original_dir = svc_module.CONTRACT_GENERATED_DIR
+        original_dep = svc_module.DEPLOYMENT_NAME
+        original_app = svc_module.APPLICATION_NAME
+        svc_module.CONTRACT_GENERATED_DIR = contract_dir
+        svc_module.DEPLOYMENT_NAME = "prod-deploy"
+        svc_module.APPLICATION_NAME = "dbt"
+        try:
+            client = _make_client()
+            response = client.get("/workflows/v1/manifest?entrypoint=ep1")
+            assert response.status_code == 200
+            body = response.json()
+            assert body["task_queue"] == "atlan-dbt-prod-deploy"
+        finally:
+            svc_module.CONTRACT_GENERATED_DIR = original_dir
+            svc_module.DEPLOYMENT_NAME = original_dep
+            svc_module.APPLICATION_NAME = original_app
 
     def test_valid_but_unknown_entrypoint_returns_404(self, tmp_path: Path) -> None:
         """Well-formed name with no matching subdir on disk returns 404."""

--- a/tests/unit/handler/test_service.py
+++ b/tests/unit/handler/test_service.py
@@ -2608,6 +2608,52 @@ class TestManifestEndpoint:
         finally:
             svc_module.CONTRACT_GENERATED_DIR = original
 
+    def test_manifest_programmatic_substitutes_unresolved_placeholders(self) -> None:
+        """A programmatic AppManifest carrying literal '{app_name}'/
+        '{deployment_name}' tokens gets the same defensive substitution as the
+        disk branches — not served verbatim."""
+        from application_sdk.handler import service as svc_module
+        from application_sdk.handler.manifest import (
+            AppManifest,
+            DagNode,
+            ExecuteWorkflowInputs,
+        )
+
+        manifest = AppManifest(
+            execution_mode="dag",
+            dag={
+                "extract": DagNode(
+                    activity_name="execute_workflow",
+                    activity_display_name="Extract",
+                    app_name="{app_name}",
+                    inputs=ExecuteWorkflowInputs(
+                        workflow_type="extraction",
+                        task_queue="atlan-{app_name}-{deployment_name}",
+                    ),
+                ),
+            },
+        )
+        app = create_app_handler_service(
+            _TestHandler(), app_name="test-app", manifest=manifest
+        )
+        client = TestClient(app)
+
+        original_dep = svc_module.DEPLOYMENT_NAME
+        original_app = svc_module.APPLICATION_NAME
+        svc_module.DEPLOYMENT_NAME = "prod-deploy"
+        svc_module.APPLICATION_NAME = "dbt"
+        try:
+            response = client.get("/workflows/v1/manifest")
+            assert response.status_code == 200
+            body = response.json()
+            assert (
+                body["dag"]["extract"]["inputs"]["task_queue"]
+                == "atlan-dbt-prod-deploy"
+            )
+        finally:
+            svc_module.DEPLOYMENT_NAME = original_dep
+            svc_module.APPLICATION_NAME = original_app
+
     def test_manifest_404_when_none(self, tmp_path: Path) -> None:
         """Returns 404 when no manifest param and no manifest.json on disk."""
         from application_sdk.handler import service as svc_module


### PR DESCRIPTION
## Summary
- `app_name` is normally baked into the generated manifest by the contract toolkit; the manifest-serve path (`handler/service.py`) only ever substituted `{deployment_name}`, leaving a contract-toolkit miss or hand-authored template's literal `"{app_name}"` token to reach downstream AE writes unchanged.
- That exact shape froze `task_queue = "atlan-{app_name}-<deployment>"` into a queue no worker polls, hanging `dbt:process` to its 24h heartbeat backstop — [CONNECT-183](https://linear.app/atlan-epd/issue/CONNECT-183). The same underlying gap also caused [HYP-1954](https://linear.app/atlan-epd/issue/HYP-1954) — a literal `{app_name}` reaching observability, stripping failure attribution across Postgres, dbt, QuickSight, and Fabric runs.
- The same gap has been independently hand-rolled at least 4 times across separate codebases because this defense didn't exist at the source: Heracles (Go), native-migration-app, `atlan-local-marketplace-app` (CONNECT-191, [#539](https://github.com/atlanhq/atlan-local-marketplace-app/pull/539)), and `atlan-hightouch-app` (ARUN-1039). This PR closes the gap centrally instead of waiting for a 5th.

## Important history — this is NOT reverting #2271/#2478's design
This exact runtime substitution was tried once before as [#2270](https://github.com/atlanhq/application-sdk/pull/2270) (never merged) and explicitly **superseded** by [#2271](https://github.com/atlanhq/application-sdk/pull/2271), which moved the fix to the *toolkit* instead: `App.pkl` now bakes `app_name` from the contract `name` at generation time, and #2271 deliberately dropped the SDK-side runtime substitution on the assumption toolkit-baking would make it unnecessary. [#2478](https://github.com/atlanhq/application-sdk/pull/2478) later extended the same bake to the legacy `NativeApp.pkl` template (dbt, quicksight, postgres, …), closing HYP-1954.

**The toolkit generation logic is already correct — checked both `App.pkl` and `NativeApp.pkl`, both bake the bare, unprefixed contract `name`, the same convention this PR substitutes with.** No toolkit change is needed or intended here.

What toolkit-baking *can't* reach, and what this PR is actually for:
1. **Adoption lag** — #2478's own rollout note is explicit: "this PR does not touch their already-committed `manifest.json`... apps must bump the toolkit and regenerate contracts." Any app that hasn't done that yet still ships a manifest with a literal, permanently-unresolved `{app_name}`, with no fallback since #2271 removed it.
2. **Non-toolkit write paths** — `atlan-local-marketplace-app`'s install-time `manifest_upgrade`/`schedule_reconciler` (CONNECT-191's actual root cause), Heracles, and native-migration-app all *mutate or re-write* an AE DAG outside the toolkit's own generation step, so the toolkit's guarantee never applied there to begin with.

This PR is a defensive safety net for those two gaps, not a return to the pre-#2271 primary mechanism — resurfacing exactly what #2271's own text anticipated ("until they [migrate], the runtime fill... remains their path") but which never actually shipped since #2270 was never merged.

Substitutes using `APPLICATION_NAME` (the bare name, no `atlan-` prefix) — the same convention `main.py`'s `_derive_task_queue()` and the toolkit's own bake both use. Deliberately **not** a pre-prefixed value: that's the exact double-prefix bug Heracles shipped once ([DISTR-834](https://linear.app/atlan-epd/issue/DISTR-834)).

Ref: FND-184 (support-patterns tracking ticket) · companion conformance rule: #3094 (O005, catches new hand-authored templates that skip this defense going forward — this PR is the actual fix, that PR is the guard)

## Test plan
- [x] Two new regression tests mirroring the existing `{deployment_name}` substitution tests exactly — root-manifest and per-entrypoint-manifest paths, both asserting `atlan-{app_name}-{deployment_name}` resolves to `atlan-dbt-prod-deploy` given `APPLICATION_NAME="dbt"` / `DEPLOYMENT_NAME="prod-deploy"`
- [x] `uv run pytest tests/unit/handler/test_service.py -q` — 315 passed
- [x] `uv run ruff check application_sdk/handler/service.py tests/unit/handler/test_service.py` — clean

## Not covered by this PR
- Does not add or change anything in `contract-toolkit/` — its bake (`App.pkl` + `NativeApp.pkl`) is already correct.
- Does not touch the 4 downstream codebases that already independently patched around this gap (Heracles, native-migration-app, atlan-local-marketplace-app, atlan-hightouch-app) — those fixes stay in place; this closes the gap at the source for any future writer.
- Does not retroactively fix any manifest already served/persisted with an unresolved token before this change ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)