### PR TITLE
ci(docs): drop the unworkable remedy from the Harbor-unreachable error

### DIFF
--- a/.github/scripts/resolve_base_redirect.py
+++ b/.github/scripts/resolve_base_redirect.py
@@ -457,8 +457,9 @@ def decide(
             f"{harbor_repo}:{tag} could not be resolved, so cross-registry "
             "parity cannot be verified — this build would ride the GHCR "
             "redirect on an unproven base. Harbor unreachable is treated like "
-            "skew: re-run once Harbor recovers, or unset use_ghcr_base to build "
-            "without the redirect — see docs/standards/build-security.md."
+            "skew: re-run once Harbor recovers. Unsetting use_ghcr_base does "
+            "not help while Harbor is down — it moves the failure from this "
+            "check to the base-image pull. See docs/standards/build-security.md."
         )
         return decision
 

--- a/.github/scripts/tests/test_resolve_base_redirect.py
+++ b/.github/scripts/tests/test_resolve_base_redirect.py
@@ -188,6 +188,11 @@ def test_unresolvable_harbor_fails_closed():
     assert not decision.ok
     assert decision.build_contexts == ""
     assert "parity cannot be verified" in decision.errors[0]
+    # The remedy is a re-run, and the message must say so without offering the
+    # flag as a way out: with Harbor down, building without the redirect just
+    # moves the failure to the base-image pull.
+    assert "re-run once Harbor recovers" in decision.errors[0]
+    assert "does not help" in decision.errors[0]
 
 
 # ── Registry client ───────────────────────────────────────────────────────────

--- a/docs/standards/build-security.md
+++ b/docs/standards/build-security.md
@@ -67,7 +67,8 @@ A registry that cannot be reached is *unknown*, not skew. GHCR-unreachable degra
 pre-redirect Harbor pull instead of blocking an app release. Harbor-unreachable is the one
 exception: with the redirect's source down there is no baseline to verify the GHCR tag
 against, so an unverified redirect is indistinguishable from a stale one and the build fails
-closed. Re-run once Harbor recovers, or unset `use_ghcr_base` to build without the redirect.
+closed. Re-run once Harbor recovers — unsetting `use_ghcr_base` does not route around a
+Harbor outage, it just moves the failure from the preflight to the base-image pull.
 
 ## Consuming Dapr components in an app repo
 


### PR DESCRIPTION
Follow-up to #3035.

## The problem

The base-redirect preflight fails closed when Harbor cannot be resolved — correct, since Harbor is the redirect's source and without it there is no baseline to verify the GHCR tag against. But the error it raises offered two remedies:

> Harbor unreachable is treated like skew: re-run once Harbor recovers, **or unset `use_ghcr_base` to build without the redirect** — see docs/standards/build-security.md.

The second one doesn't work. Without the redirect, the build pulls its base from Harbor — the registry that is, by hypothesis, unreachable. Unsetting the flag moves the failure from the preflight to the base-image pull; it doesn't route around the outage.

The code comment immediately above the message already said so:

```python
# Degrading to a Harbor pull is not an option either — Harbor is the
# unreachable side — so the parity gate fails closed here, exactly as it
# does on proven skew. Only GHCR-unresolvable degrades (above).
```

So the guidance contradicted its own stated rationale, three lines apart. The cost is a dead end for whoever reads the annotation mid-incident, when they are least inclined to re-derive it.

## The fix

Re-running once Harbor recovers is the only remedy, so the message now says that and explains why the flag is not a way out:

> Harbor unreachable is treated like skew: re-run once Harbor recovers. Unsetting use_ghcr_base does not help while Harbor is down — it moves the failure from this check to the base-image pull. See docs/standards/build-security.md.

Same correction to the decision table in `docs/standards/build-security.md`, which carried the identical advice.

## Scope

Guidance text only — no behaviour change. The gate still fails closed on Harbor-unreachable exactly as before.

The *other* occurrence of "unset `use_ghcr_base`" in this file is untouched and still correct: it belongs to the match-coverage error, where Harbor is reachable and unsetting the flag genuinely lets the build proceed.

`test_unresolvable_harbor_fails_closed` now pins both halves of the corrected guidance, so a future edit cannot quietly reintroduce the dead end. 37/37 pass; pre-commit clean.
