### PR TITLE
fix(task-queue): derive the queue name once, and stamp it into the served manifest

### DIFF
--- a/application_sdk/common/task_queue.py
+++ b/application_sdk/common/task_queue.py
@@ -39,6 +39,32 @@ entirely legitimate and reproduces the original hang. This module reads
 ``os.environ`` directly and reports "no name" as ``None`` so callers can fail or
 leave the literal token visible; a literal ``{app_name}`` in a served manifest is
 greppable and diagnosable in one step.
+
+**Why a runtime fill exists at all, given the toolkit bakes these values.** This
+looks like duplicated responsibility and is worth not re-litigating. The original
+runtime substitution was proposed as #2270 and never merged; #2271 superseded it
+by moving the fix into the toolkit (``App.pkl`` bakes ``app_name`` from the
+contract ``name``), and #2478 extended that bake to the legacy ``NativeApp.pkl``
+template. Those bakes are correct and this module does not second-guess them —
+:func:`resolve_manifest_tokens` treats a baked name as the expected case.
+
+What generation-time baking cannot reach, and what this module is for:
+
+* **Adoption lag.** #2478's own rollout note is explicit that it does not touch
+  already-committed ``manifest.json`` files — apps must bump the toolkit and
+  regenerate. Until then their manifests ship a literal token, and #2271 removed
+  the only fallback. #2271's own text anticipated this ("until they migrate, the
+  runtime fill remains their path"); that fill never actually shipped, because
+  #2270 was never merged.
+* **Non-toolkit write paths.** Heracles, native-migration-app, and the
+  install-time ``manifest_upgrade`` / ``schedule_reconciler`` in
+  ``atlan-local-marketplace-app`` (CONNECT-191) *mutate or re-write* an AE DAG
+  outside the toolkit's generation step, so the bake's guarantee never applied
+  to them. Each hand-patched this gap independently; one of them shipped a
+  double prefix (DISTR-834) by pre-prefixing an already-prefixed value.
+
+So this is a reconciliation point for writers the toolkit does not own, not a
+second mechanism competing with it. Retire it when those writers are retired.
 """
 
 from __future__ import annotations

--- a/application_sdk/common/task_queue.py
+++ b/application_sdk/common/task_queue.py
@@ -29,7 +29,9 @@ drops the prefix entirely and polls a bare ``<app>``, while token-filling
 produces ``atlan-<app>-local``; and a baked ``<app>`` that no longer matches the
 deployment's ``ATLAN_APPLICATION_NAME`` is never corrected at all.
 :func:`resolve_manifest_tokens` therefore matches the whole template and
-replaces it outright.
+replaces it outright — and does so field-aware, rewriting only values the
+manifest itself labels ``task_queue`` rather than substituting bytes anywhere
+the template text happens to appear.
 
 **The unset case must stay loud.** ``constants.APPLICATION_NAME`` and
 ``constants.DEPLOYMENT_NAME`` manufacture ``"default"`` / ``"local"`` when the
@@ -69,8 +71,11 @@ second mechanism competing with it. Retire it when those writers are retired.
 
 from __future__ import annotations
 
+import json
 import os
+from collections.abc import Callable
 from dataclasses import dataclass
+from typing import Any
 
 #: Prefix the platform expects on a fully-qualified app queue. Callers pass the
 #: *bare* app name to :func:`derive_task_queue` and let it add the prefix —
@@ -83,6 +88,77 @@ DEPLOYMENT_NAME_TOKEN = "{deployment_name}"
 
 _APP_NAME_TOKEN_BYTES = APP_NAME_TOKEN.encode()
 _DEPLOYMENT_NAME_TOKEN_BYTES = DEPLOYMENT_NAME_TOKEN.encode()
+
+#: The manifest field the queue rewrite owns. DAG nodes carry their dispatch
+#: queue under this key at any depth (``dag.<node>.task_queue``,
+#: ``dag.<node>.inputs.task_queue``, top-level on single-node manifests); only
+#: string values under this exact key are this app's queue and may be stamped.
+#: Every other byte in the manifest — foreign-app queues, descriptions,
+#: metadata — is out of scope no matter how closely it matches the template.
+_TASK_QUEUE_KEY = "task_queue"
+
+
+def _rewrite_task_queue_fields(
+    node: Any,
+    rewrite: Callable[[str], str | None],
+    app_name_fill: str,
+    deployment_fill: str,
+) -> bool:
+    """Rewrite a parsed manifest in place: stamp own queues, fill the rest.
+
+    Walks every string value. A ``task_queue`` value is handed to ``rewrite``,
+    which returns the stamped queue, or ``None`` when the value is not this
+    app's template and must be left alone. Every *other* string — log-identity
+    ``app_name``, descriptions, foreign-app queue text, metadata — gets the
+    residual ``{app_name}`` / ``{deployment_name}`` tokens filled.
+
+    Field-aware stamping is the whole point: a queue name is only ever rewritten
+    where the manifest *says* it is a queue, so a foreign-app DAG node whose
+    baked queue matches the template, or a description string containing the
+    template text, is never re-pointed at this app's worker (the byte
+    substitutor did both). Splitting the residual fill by field also means the
+    deployment/app fills can no longer mutate an already-stamped queue — the
+    stamped field never sees them.
+
+    Returns ``True`` when at least one ``task_queue`` value was visited, so the
+    caller can fall back to byte substitution on a manifest too malformed to
+    parse — the pre-FND-195 behaviour, preserved rather than silently dropping
+    the stamp.
+    """
+    visited = False
+    if isinstance(node, dict):
+        for key, value in node.items():
+            if isinstance(value, str):
+                if key == _TASK_QUEUE_KEY:
+                    stamped = rewrite(value)
+                    visited = True
+                    if stamped is not None:
+                        # Own queue, stamped verbatim — the residual fills must
+                        # not touch it, even when it carries literal token text.
+                        node[key] = stamped
+                        continue
+                    # Not this app's template (``{deployment_name}-queue``,
+                    # ``atlan-publish-{deployment_name}``): a residual field in
+                    # all but key, so fall through and token-fill it.
+                node[key] = value.replace(APP_NAME_TOKEN, app_name_fill).replace(
+                    DEPLOYMENT_NAME_TOKEN, deployment_fill
+                )
+            else:
+                visited = (
+                    _rewrite_task_queue_fields(
+                        value, rewrite, app_name_fill, deployment_fill
+                    )
+                    or visited
+                )
+    elif isinstance(node, list):
+        for item in node:
+            visited = (
+                _rewrite_task_queue_fields(
+                    item, rewrite, app_name_fill, deployment_fill
+                )
+                or visited
+            )
+    return visited
 
 
 def derive_task_queue(app_name: str | None, deployment_name: str | None) -> str | None:
@@ -188,42 +264,63 @@ def resolve_manifest_tokens(
 ) -> ManifestTokenResolution:
     """Resolve ``{app_name}`` / ``{deployment_name}`` tokens in a served manifest.
 
-    Ordering matters, and the queue rewrite must come first:
+    Three jobs, done in one field-aware walk over the parsed manifest:
 
-    1. **This app's queue template, matched whole and stamped with the queue the
-       worker actually polls.** Both the un-baked
-       ``atlan-{app_name}-{deployment_name}`` (a contract-toolkit miss, or a
-       hand-authored manifest) and the baked ``atlan-<name>-{deployment_name}``
-       are replaced outright. Filling the two tokens in place instead is what
-       diverged: with no deployment name the worker drops the prefix and polls a
-       bare ``<app>``, and a baked name that no longer matches the deployment's
-       ``ATLAN_APPLICATION_NAME`` is never corrected at all.
+    1. **This app's queue, stamped with the queue the worker actually polls.**
+       Every string ``task_queue`` value whose text matches the whole template —
+       the un-baked ``atlan-{app_name}-{deployment_name}`` (a contract-toolkit
+       miss, or a hand-authored manifest) or the baked
+       ``atlan-<name>-{deployment_name}`` — is replaced outright. Filling the two
+       tokens in place instead is what diverged: with no deployment name the
+       worker drops the prefix and polls a bare ``<app>``, and a baked name that
+       no longer matches the deployment's ``ATLAN_APPLICATION_NAME`` is never
+       corrected at all.
     2. **Residual** ``{app_name}``, which is per-node log identity rather than a
        queue (``inputs.args.app_name``; a literal token reaching observability
-       here is HYP-1954).
+       here is HYP-1954). Filled in every string that is not a ``task_queue``.
     3. **Residual** ``{deployment_name}``, e.g. on DAG nodes that dispatch to
        *another* app's queue (``atlan-publish-{deployment_name}`` and friends).
        Those are legitimately not this app's queue, so they are token-filled and
        otherwise left alone — neither normalised nor warned about.
 
+    Two properties are load-bearing, and both come from the stamp owning the
+    ``task_queue`` field rather than substituting bytes across the manifest:
+
+    * *Field-aware.* Only a value the manifest itself labels ``task_queue`` is
+      this app's queue. Whole-manifest byte substitution could not tell that
+      from a foreign-app DAG node whose baked queue matches the template, or a
+      description string containing the template text — it re-pointed both at
+      this app's worker.
+    * *The stamped queue is never re-filled.* A configured queue that itself
+      contains literal token text (e.g. ``custom-{deployment_name}-queue`` via
+      ``ATLAN_TASK_QUEUE``) is stamped verbatim: the residual fills skip
+      ``task_queue`` values, so they can no longer mutate the stamped queue into
+      one no worker polls while :attr:`ManifestTokenResolution.task_queue`
+      reports the original.
+
     Args:
-        raw: Raw manifest bytes. Not parsed — the contract tooling already
-            validated the JSON at build time, and byte substitution keeps the
-            serve path free of a parse/reserialize round-trip.
+        raw: Raw manifest bytes. Parsed as JSON so the stamp can find the
+            ``task_queue`` fields; a manifest too malformed to parse falls back
+            to byte substitution (the pre-FND-195 behaviour, with the stamp
+            ordered before the residual fills) so the queue is degraded, never
+            dropped.
         task_queue: The queue the app's worker polls, when the caller knows it
             (the handler does: it is handed the same value ``create_worker`` gets).
             Preferred over re-deriving from env because it also carries an
             explicit ``ATLAN_TASK_QUEUE`` / ``--task-queue`` override, which no
             amount of re-derivation can reproduce. Falls back to
-            :func:`task_queue_from_env`.
+            :func:`task_queue_from_env`. Stamped verbatim, even when it contains
+            literal token text.
         app_name: The app's registered name — what the toolkit *would* have baked.
-            Used both as a template candidate in step 1 and to fill step 2's
-            token. Preferred over ``ATLAN_APPLICATION_NAME`` there because it is
-            the value the Workflow Center's log filter matches (HYP-1678).
-        deployment_fallback: Value for step 3 when ``ATLAN_DEPLOYMENT_NAME`` is
-            unset. Defaults to ``"default"``, preserving the pre-FND-195
-            behaviour of that token. Never used for step 1: manufacturing a
-            deployment segment there is the divergence itself.
+            Used both as a template candidate in the stamp and to fill the
+            residual ``{app_name}`` token. Preferred over
+            ``ATLAN_APPLICATION_NAME`` there because it is the value the Workflow
+            Center's log filter matches (HYP-1678).
+        deployment_fallback: Value for the residual ``{deployment_name}`` fill
+            when ``ATLAN_DEPLOYMENT_NAME`` is unset. Defaults to ``"default"``,
+            preserving the pre-FND-195 behaviour of that token. Never used for
+            the queue stamp: manufacturing a deployment segment there is the
+            divergence itself.
 
     Returns:
         A :class:`ManifestTokenResolution`.
@@ -236,23 +333,38 @@ def resolve_manifest_tokens(
     resolved_app_name = registered_app_name or env_app_name or None
     had_app_name_token = _APP_NAME_TOKEN_BYTES in raw
 
-    if resolved_queue is not None:
-        encoded_queue = resolved_queue.encode()
-        # Ordered so the un-baked token form is tried first and duplicates (the
-        # common case where the registered name *is* ATLAN_APPLICATION_NAME)
-        # collapse to one replace.
-        candidates = [APP_NAME_TOKEN, registered_app_name, env_app_name]
-        for candidate in dict.fromkeys(c for c in candidates if c):
-            raw = raw.replace(
-                f"{QUEUE_PREFIX}{candidate}-{DEPLOYMENT_NAME_TOKEN}".encode(),
-                encoded_queue,
-            )
+    app_name_fill = resolved_app_name or APP_NAME_TOKEN
+    deployment_fill = deployment_name or (deployment_fallback or "default")
 
-    if resolved_app_name:
-        raw = raw.replace(_APP_NAME_TOKEN_BYTES, resolved_app_name.encode())
+    try:
+        manifest = json.loads(raw)
+    except (ValueError, UnicodeDecodeError):
+        manifest = None
 
-    residual_deployment = deployment_name or (deployment_fallback or "default")
-    raw = raw.replace(_DEPLOYMENT_NAME_TOKEN_BYTES, residual_deployment.encode())
+    if isinstance(manifest, (dict, list)):
+        # Field-aware path: stamp own-queue fields, fill the residual tokens in
+        # every other string, in one walk — so the deployment/app fills never
+        # touch an already-stamped queue, and the stamp never touches a
+        # foreign-app queue or a description string.
+        _rewrite_task_queue_fields(
+            manifest,
+            _queue_stamper(resolved_queue, registered_app_name, env_app_name),
+            app_name_fill,
+            deployment_fill,
+        )
+        # ensure_ascii preserves the byte-for-byte ASCII shape of the toolkit's
+        # own json.dumps output, so the reserialize is a no-op save the stamp.
+        raw = json.dumps(manifest, ensure_ascii=True).encode()
+    else:
+        # Fallback for a manifest too malformed to parse: the pre-FND-195 byte
+        # behaviour, with the stamp ordered before the residual fills so they
+        # cannot corrupt a stamped queue that carries literal token text.
+        raw = _stamp_task_queue_bytes(
+            raw, resolved_queue, registered_app_name, env_app_name
+        )
+        if resolved_app_name:
+            raw = raw.replace(_APP_NAME_TOKEN_BYTES, resolved_app_name.encode())
+        raw = raw.replace(_DEPLOYMENT_NAME_TOKEN_BYTES, deployment_fill.encode())
 
     return ManifestTokenResolution(
         raw=raw,
@@ -260,3 +372,57 @@ def resolve_manifest_tokens(
         app_name=resolved_app_name,
         had_app_name_token=had_app_name_token,
     )
+
+
+def _queue_stamper(
+    resolved_queue: str | None,
+    registered_app_name: str,
+    env_app_name: str,
+) -> Callable[[str], str | None]:
+    """Build the field-aware ``task_queue`` rewrite for a parsed manifest.
+
+    Returns a function mapping a ``task_queue`` value to the stamped queue when
+    the value matches this app's whole ``atlan-{candidate}-{deployment_name}``
+    template, else ``None`` (leave the value alone). When no queue is
+    determinable every value is left alone, so the un-baked template stays
+    visible rather than being filled with a manufactured name.
+    """
+    if resolved_queue is None:
+        return lambda value: None
+
+    # Ordered so the un-baked token form is tried first and duplicates (the
+    # common case where the registered name *is* ATLAN_APPLICATION_NAME)
+    # collapse to one entry.
+    candidates = [APP_NAME_TOKEN, registered_app_name, env_app_name]
+    templates = {
+        f"{QUEUE_PREFIX}{candidate}-{DEPLOYMENT_NAME_TOKEN}"
+        for candidate in dict.fromkeys(c for c in candidates if c)
+    }
+    return lambda value: resolved_queue if value in templates else None
+
+
+def _stamp_task_queue_bytes(
+    raw: bytes,
+    resolved_queue: str | None,
+    registered_app_name: str,
+    env_app_name: str,
+) -> bytes:
+    """Byte-substitute the queue template on a manifest too malformed to parse.
+
+    The degraded path behind :func:`resolve_manifest_tokens`'s field-aware
+    stamp. Matches the whole ``atlan-{candidate}-{deployment_name}`` template
+    and replaces it outright, exactly as the pre-FND-195 substitutor did — a
+    stamped queue is better than none on a manifest the build-time validation
+    never saw. The caller orders it before the residual fills so they cannot
+    corrupt a stamped queue that carries literal token text.
+    """
+    if resolved_queue is None:
+        return raw
+    candidates = [APP_NAME_TOKEN, registered_app_name, env_app_name]
+    encoded_queue = resolved_queue.encode()
+    for candidate in dict.fromkeys(c for c in candidates if c):
+        raw = raw.replace(
+            f"{QUEUE_PREFIX}{candidate}-{DEPLOYMENT_NAME_TOKEN}".encode(),
+            encoded_queue,
+        )
+    return raw

--- a/application_sdk/common/task_queue.py
+++ b/application_sdk/common/task_queue.py
@@ -341,8 +341,10 @@ def resolve_manifest_tokens(
 
     try:
         manifest = json.loads(raw)
+        parse_error = False
     except (ValueError, UnicodeDecodeError):
         manifest = None
+        parse_error = True
 
     if isinstance(manifest, (dict, list)):
         # Field-aware path: stamp own-queue fields, fill the residual tokens in
@@ -359,18 +361,26 @@ def resolve_manifest_tokens(
         # own json.dumps output, so the reserialize is a no-op save the stamp.
         raw = json.dumps(manifest, ensure_ascii=True).encode()
     else:
-        # A manifest too malformed to parse is served back unstamped and logged
-        # at ERROR. The pre-FND-195 byte substitutor this replaces could not
-        # scope the residual fills away from a stamped queue carrying literal
-        # token text, so it re-imported the defect this module removes. Such a
-        # manifest is one the build-time validation never saw — already broken,
-        # and better failed loud than served with a silently wrong queue.
+        # A manifest whose task_queue fields cannot be located is served back
+        # unstamped and logged at ERROR. That is either a parse failure (the
+        # bytes are not JSON at all) or valid JSON with a scalar root (``null``,
+        # a number, a string) that carries no object to walk. The pre-FND-195
+        # byte substitutor this replaces could not scope the residual fills away
+        # from a stamped queue carrying literal token text, so it re-imported the
+        # defect this module removes. Such a manifest is one the build-time
+        # validation never saw — already broken, and better failed loud than
+        # served with a silently wrong queue.
+        if parse_error:
+            reason = "does not parse as JSON"
+        else:
+            reason = "parses as JSON but has a scalar root (no object to walk)"
         logger.error(
-            "Served manifest does not parse as JSON, so its task_queue cannot "
-            "be stamped field-aware; serving it unstamped rather than applying "
-            "byte substitution, which cannot scope the residual token fills "
-            "away from a stamped queue that carries literal token text. This "
+            "Served manifest %s, so its task_queue cannot be stamped "
+            "field-aware; serving it unstamped rather than applying byte "
+            "substitution, which cannot scope the residual token fills away "
+            "from a stamped queue that carries literal token text. This "
             "manifest is malformed on disk — regenerate or restore it.",
+            reason,
         )
 
     return ManifestTokenResolution(

--- a/application_sdk/common/task_queue.py
+++ b/application_sdk/common/task_queue.py
@@ -1,0 +1,236 @@
+"""Canonical Temporal task-queue naming (FND-195).
+
+The task-queue name has to be agreed on by two code paths that never talk to
+each other:
+
+* the **worker**, which polls the queue — :func:`application_sdk.main._derive_task_queue`;
+* the **served manifest**, whose resolved ``task_queue`` value the Automation
+  Engine writes into the DAG and therefore submits work to —
+  :mod:`application_sdk.handler.service`.
+
+Before this module each side derived the name independently, from different
+sources, with different unset-case semantics. When they disagreed nothing failed
+loudly: AE submitted to one queue, the worker polled another, and the workflow
+sat unclaimed until its 24h heartbeat backstop (CONNECT-183; the same gap
+stripped failure attribution in HYP-1954).
+
+There is now one derivation, :func:`derive_task_queue`, and the manifest side
+does not even run it: :func:`resolve_manifest_tokens` *stamps* the queue the
+handler was configured with — the same value ``create_worker`` receives. Two
+paths deriving the same answer is a convention that holds until someone's inputs
+differ; one path copying the other's answer is structural.
+
+Two properties are load-bearing and easy to lose:
+
+**The name is a unit, not an assembly of tokens.** The manifest carries
+``atlan-<app>-{deployment_name}``, so it is tempting to just fill the token in
+place. That is what diverged: with ``ATLAN_DEPLOYMENT_NAME`` unset the worker
+drops the prefix entirely and polls a bare ``<app>``, while token-filling
+produces ``atlan-<app>-local``; and a baked ``<app>`` that no longer matches the
+deployment's ``ATLAN_APPLICATION_NAME`` is never corrected at all.
+:func:`resolve_manifest_tokens` therefore matches the whole template and
+replaces it outright.
+
+**The unset case must stay loud.** ``constants.APPLICATION_NAME`` and
+``constants.DEPLOYMENT_NAME`` manufacture ``"default"`` / ``"local"`` when the
+env is unset. That is right for storage identity — a path prefix needs *some*
+segment — and wrong for a queue name, because ``atlan-default-prod`` looks
+entirely legitimate and reproduces the original hang. This module reads
+``os.environ`` directly and reports "no name" as ``None`` so callers can fail or
+leave the literal token visible; a literal ``{app_name}`` in a served manifest is
+greppable and diagnosable in one step.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+#: Prefix the platform expects on a fully-qualified app queue. Callers pass the
+#: *bare* app name to :func:`derive_task_queue` and let it add the prefix —
+#: prefixing an already-prefixed value is how DISTR-834 shipped
+#: ``atlan-atlan-dbt-production``, a queue no worker polls.
+QUEUE_PREFIX = "atlan-"
+
+APP_NAME_TOKEN = "{app_name}"
+DEPLOYMENT_NAME_TOKEN = "{deployment_name}"
+
+_APP_NAME_TOKEN_BYTES = APP_NAME_TOKEN.encode()
+_DEPLOYMENT_NAME_TOKEN_BYTES = DEPLOYMENT_NAME_TOKEN.encode()
+
+
+def derive_task_queue(app_name: str | None, deployment_name: str | None) -> str | None:
+    """Derive the Temporal task-queue name for an app deployment.
+
+    The single source of truth for the rule. Mirrors v2
+    ``TemporalWorkflowClient.get_worker_task_queue()``:
+
+    * app name **and** deployment name → ``atlan-{app}-{deployment}``
+    * app name only → ``{app}`` (bare, unprefixed)
+    * no app name → ``None``
+
+    Args:
+        app_name: Bare app name, **without** the ``atlan-`` prefix (the
+            convention both the contract toolkit's bake and
+            ``ATLAN_APPLICATION_NAME`` use). Blank/whitespace counts as unset.
+        deployment_name: Deployment name. Blank/whitespace counts as unset.
+
+    Returns:
+        The queue name, or ``None`` when the app name is unavailable. ``None``
+        is deliberate: there is no safe queue name to invent, and callers differ
+        in what they should do about it (the worker falls back to a class-name
+        queue for local dev; the manifest leaves the token visible and logs).
+    """
+    app = (app_name or "").strip()
+    deployment = (deployment_name or "").strip()
+    if app and deployment:
+        return f"{QUEUE_PREFIX}{app}-{deployment}"
+    if app:
+        return app
+    return None
+
+
+def application_name_from_env() -> str:
+    """``ATLAN_APPLICATION_NAME``, empty string when unset.
+
+    Deliberately not ``constants.APPLICATION_NAME``, which substitutes the
+    literal ``"default"`` — see the module docstring on why a manufactured app
+    name is worse than none for queue naming.
+    """
+    return os.environ.get("ATLAN_APPLICATION_NAME", "").strip()
+
+
+def deployment_name_from_env() -> str:
+    """``ATLAN_DEPLOYMENT_NAME``, empty string when unset.
+
+    Deliberately not ``constants.DEPLOYMENT_NAME``, which substitutes
+    ``"local"``: the worker treats unset as "drop the prefix", so a manufactured
+    ``"local"`` here would rebuild the very divergence this module exists to
+    remove.
+    """
+    return os.environ.get("ATLAN_DEPLOYMENT_NAME", "").strip()
+
+
+def task_queue_from_env() -> str | None:
+    """:func:`derive_task_queue` applied to the deployment's own environment.
+
+    Read live from ``os.environ`` rather than an import-time snapshot so the
+    worker and the manifest-serving path cannot disagree just because one of
+    them imported earlier than the env was set.
+    """
+    return derive_task_queue(application_name_from_env(), deployment_name_from_env())
+
+
+@dataclass(frozen=True)
+class ManifestTokenResolution:
+    """Outcome of :func:`resolve_manifest_tokens`."""
+
+    raw: bytes
+    """The manifest bytes with every resolvable token substituted."""
+
+    task_queue: str | None
+    """The queue this app's own DAG nodes were stamped with — the one its worker
+    polls. ``None`` when no queue name was determinable, in which case the queue
+    template was left untouched rather than filled with a manufactured value."""
+
+    app_name: str | None
+    """The value used to fill ``{app_name}``, or ``None`` when no app name was
+    available anywhere."""
+
+    had_app_name_token: bool
+    """``True`` when the manifest shipped a literal ``{app_name}``, i.e. the
+    contract toolkit's bake did not reach it. Actionable regardless of whether
+    :attr:`app_name` then filled it: it means the app's committed manifest is
+    stale and the next writer of that DAG gets no guarantee at all."""
+
+    @property
+    def unresolved_app_name(self) -> bool:
+        """A literal ``{app_name}`` survives in :attr:`raw`.
+
+        The served manifest is not usable as-is; the surviving token is the
+        diagnostic. Callers should log at ERROR.
+        """
+        return self.had_app_name_token and self.app_name is None
+
+
+def resolve_manifest_tokens(
+    raw: bytes,
+    *,
+    task_queue: str | None = None,
+    app_name: str | None = None,
+    deployment_fallback: str | None = None,
+) -> ManifestTokenResolution:
+    """Resolve ``{app_name}`` / ``{deployment_name}`` tokens in a served manifest.
+
+    Ordering matters, and the queue rewrite must come first:
+
+    1. **This app's queue template, matched whole and stamped with the queue the
+       worker actually polls.** Both the un-baked
+       ``atlan-{app_name}-{deployment_name}`` (a contract-toolkit miss, or a
+       hand-authored manifest) and the baked ``atlan-<name>-{deployment_name}``
+       are replaced outright. Filling the two tokens in place instead is what
+       diverged: with no deployment name the worker drops the prefix and polls a
+       bare ``<app>``, and a baked name that no longer matches the deployment's
+       ``ATLAN_APPLICATION_NAME`` is never corrected at all.
+    2. **Residual** ``{app_name}``, which is per-node log identity rather than a
+       queue (``inputs.args.app_name``; a literal token reaching observability
+       here is HYP-1954).
+    3. **Residual** ``{deployment_name}``, e.g. on DAG nodes that dispatch to
+       *another* app's queue (``atlan-publish-{deployment_name}`` and friends).
+       Those are legitimately not this app's queue, so they are token-filled and
+       otherwise left alone — neither normalised nor warned about.
+
+    Args:
+        raw: Raw manifest bytes. Not parsed — the contract tooling already
+            validated the JSON at build time, and byte substitution keeps the
+            serve path free of a parse/reserialize round-trip.
+        task_queue: The queue the app's worker polls, when the caller knows it
+            (the handler does: it is handed the same value ``create_worker`` gets).
+            Preferred over re-deriving from env because it also carries an
+            explicit ``ATLAN_TASK_QUEUE`` / ``--task-queue`` override, which no
+            amount of re-derivation can reproduce. Falls back to
+            :func:`task_queue_from_env`.
+        app_name: The app's registered name — what the toolkit *would* have baked.
+            Used both as a template candidate in step 1 and to fill step 2's
+            token. Preferred over ``ATLAN_APPLICATION_NAME`` there because it is
+            the value the Workflow Center's log filter matches (HYP-1678).
+        deployment_fallback: Value for step 3 when ``ATLAN_DEPLOYMENT_NAME`` is
+            unset. Defaults to ``"default"``, preserving the pre-FND-195
+            behaviour of that token. Never used for step 1: manufacturing a
+            deployment segment there is the divergence itself.
+
+    Returns:
+        A :class:`ManifestTokenResolution`.
+    """
+    env_app_name = application_name_from_env()
+    deployment_name = deployment_name_from_env()
+    registered_app_name = (app_name or "").strip()
+
+    resolved_queue = task_queue or task_queue_from_env()
+    resolved_app_name = registered_app_name or env_app_name or None
+    had_app_name_token = _APP_NAME_TOKEN_BYTES in raw
+
+    if resolved_queue is not None:
+        encoded_queue = resolved_queue.encode()
+        # Ordered so the un-baked token form is tried first and duplicates (the
+        # common case where the registered name *is* ATLAN_APPLICATION_NAME)
+        # collapse to one replace.
+        candidates = [APP_NAME_TOKEN, registered_app_name, env_app_name]
+        for candidate in dict.fromkeys(c for c in candidates if c):
+            raw = raw.replace(
+                f"{QUEUE_PREFIX}{candidate}-{DEPLOYMENT_NAME_TOKEN}".encode(),
+                encoded_queue,
+            )
+
+    if resolved_app_name:
+        raw = raw.replace(_APP_NAME_TOKEN_BYTES, resolved_app_name.encode())
+
+    residual_deployment = deployment_name or (deployment_fallback or "default")
+    raw = raw.replace(_DEPLOYMENT_NAME_TOKEN_BYTES, residual_deployment.encode())
+
+    return ManifestTokenResolution(
+        raw=raw,
+        task_queue=resolved_queue,
+        app_name=resolved_app_name,
+        had_app_name_token=had_app_name_token,
+    )

--- a/application_sdk/common/task_queue.py
+++ b/application_sdk/common/task_queue.py
@@ -77,6 +77,10 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
+from application_sdk.observability.logger_adaptor import get_logger
+
+logger = get_logger(__name__)
+
 #: Prefix the platform expects on a fully-qualified app queue. Callers pass the
 #: *bare* app name to :func:`derive_task_queue` and let it add the prefix —
 #: prefixing an already-prefixed value is how DISTR-834 shipped
@@ -87,7 +91,6 @@ APP_NAME_TOKEN = "{app_name}"
 DEPLOYMENT_NAME_TOKEN = "{deployment_name}"
 
 _APP_NAME_TOKEN_BYTES = APP_NAME_TOKEN.encode()
-_DEPLOYMENT_NAME_TOKEN_BYTES = DEPLOYMENT_NAME_TOKEN.encode()
 
 #: The manifest field the queue rewrite owns. DAG nodes carry their dispatch
 #: queue under this key at any depth (``dag.<node>.task_queue``,
@@ -120,10 +123,7 @@ def _rewrite_task_queue_fields(
     deployment/app fills can no longer mutate an already-stamped queue — the
     stamped field never sees them.
 
-    Returns ``True`` when at least one ``task_queue`` value was visited, so the
-    caller can fall back to byte substitution on a manifest too malformed to
-    parse — the pre-FND-195 behaviour, preserved rather than silently dropping
-    the stamp.
+    Returns ``True`` when at least one ``task_queue`` value was visited.
     """
     visited = False
     if isinstance(node, dict):
@@ -300,10 +300,13 @@ def resolve_manifest_tokens(
 
     Args:
         raw: Raw manifest bytes. Parsed as JSON so the stamp can find the
-            ``task_queue`` fields; a manifest too malformed to parse falls back
-            to byte substitution (the pre-FND-195 behaviour, with the stamp
-            ordered before the residual fills) so the queue is degraded, never
-            dropped.
+            ``task_queue`` fields. A manifest too malformed to parse is served
+            back unstamped and logged at ERROR rather than byte-substituted:
+            byte substitution cannot scope the residual fills away from a
+            stamped queue that carries literal token text, so it re-imports the
+            very defect this module removes. A manifest that does not parse is
+            one the build-time validation never saw — already broken, and better
+            failed loud than served with a silently wrong queue.
         task_queue: The queue the app's worker polls, when the caller knows it
             (the handler does: it is handed the same value ``create_worker`` gets).
             Preferred over re-deriving from env because it also carries an
@@ -356,15 +359,19 @@ def resolve_manifest_tokens(
         # own json.dumps output, so the reserialize is a no-op save the stamp.
         raw = json.dumps(manifest, ensure_ascii=True).encode()
     else:
-        # Fallback for a manifest too malformed to parse: the pre-FND-195 byte
-        # behaviour, with the stamp ordered before the residual fills so they
-        # cannot corrupt a stamped queue that carries literal token text.
-        raw = _stamp_task_queue_bytes(
-            raw, resolved_queue, registered_app_name, env_app_name
+        # A manifest too malformed to parse is served back unstamped and logged
+        # at ERROR. The pre-FND-195 byte substitutor this replaces could not
+        # scope the residual fills away from a stamped queue carrying literal
+        # token text, so it re-imported the defect this module removes. Such a
+        # manifest is one the build-time validation never saw — already broken,
+        # and better failed loud than served with a silently wrong queue.
+        logger.error(
+            "Served manifest does not parse as JSON, so its task_queue cannot "
+            "be stamped field-aware; serving it unstamped rather than applying "
+            "byte substitution, which cannot scope the residual token fills "
+            "away from a stamped queue that carries literal token text. This "
+            "manifest is malformed on disk — regenerate or restore it.",
         )
-        if resolved_app_name:
-            raw = raw.replace(_APP_NAME_TOKEN_BYTES, resolved_app_name.encode())
-        raw = raw.replace(_DEPLOYMENT_NAME_TOKEN_BYTES, deployment_fill.encode())
 
     return ManifestTokenResolution(
         raw=raw,
@@ -399,30 +406,3 @@ def _queue_stamper(
         for candidate in dict.fromkeys(c for c in candidates if c)
     }
     return lambda value: resolved_queue if value in templates else None
-
-
-def _stamp_task_queue_bytes(
-    raw: bytes,
-    resolved_queue: str | None,
-    registered_app_name: str,
-    env_app_name: str,
-) -> bytes:
-    """Byte-substitute the queue template on a manifest too malformed to parse.
-
-    The degraded path behind :func:`resolve_manifest_tokens`'s field-aware
-    stamp. Matches the whole ``atlan-{candidate}-{deployment_name}`` template
-    and replaces it outright, exactly as the pre-FND-195 substitutor did — a
-    stamped queue is better than none on a manifest the build-time validation
-    never saw. The caller orders it before the residual fills so they cannot
-    corrupt a stamped queue that carries literal token text.
-    """
-    if resolved_queue is None:
-        return raw
-    candidates = [APP_NAME_TOKEN, registered_app_name, env_app_name]
-    encoded_queue = resolved_queue.encode()
-    for candidate in dict.fromkeys(c for c in candidates if c):
-        raw = raw.replace(
-            f"{QUEUE_PREFIX}{candidate}-{DEPLOYMENT_NAME_TOKEN}".encode(),
-            encoded_queue,
-        )
-    return raw

--- a/application_sdk/constants.py
+++ b/application_sdk/constants.py
@@ -66,9 +66,22 @@ LOCAL_ENVIRONMENT = "local"
 LOCAL_WORKFLOW_ID = "local-no-temporal"
 
 # Application Constants
-#: Name of the application, used for identification
+#: Name of the application, used for identification.
+#:
+#: The ``"default"`` fallback is for *identity* uses that need some segment to
+#: exist — object-store prefixes like ``persistent-artifacts/apps/<name>/``,
+#: log tagging. It must **never** feed Temporal task-queue derivation: a
+#: manufactured name yields ``atlan-default-<deployment>``, which reads as a
+#: legitimate queue, is polled by no worker, and hangs the run silently
+#: (FND-195 / CONNECT-183). Queue naming goes through
+#: :mod:`application_sdk.common.task_queue`, which reports an unset app name as
+#: ``None`` instead of inventing one.
 APPLICATION_NAME = os.getenv("ATLAN_APPLICATION_NAME", "default")
-#: Name of the deployment, used to distinguish between different deployments of the same application
+#: Name of the deployment, used to distinguish between different deployments of
+#: the same application. Same caveat as :data:`APPLICATION_NAME`: the
+#: ``LOCAL_ENVIRONMENT`` fallback is an identity default, and the worker treats an
+#: unset deployment name as "drop the ``atlan-`` prefix entirely", so queue
+#: derivation must read the raw env via :mod:`application_sdk.common.task_queue`.
 DEPLOYMENT_NAME = os.getenv("ATLAN_DEPLOYMENT_NAME", LOCAL_ENVIRONMENT)
 # REMOVED: APP_HOST, APP_PORT — use AppConfig.handler_host / handler_port
 #: Tenant ID for multi-tenant applications

--- a/application_sdk/handler/service.py
+++ b/application_sdk/handler/service.py
@@ -2123,7 +2123,26 @@ def _register_workflow_routes(
                     type(computed).__name__,
                 )
                 raise HTTPException(status_code=500, detail="Internal server error")
-            raw = orjson.dumps(computed)
+            # Reconcile the hook's output, not just the static file. The hook
+            # *replaces* the manifest wholesale, so without this second pass
+            # everything it emits — a task_queue, a freshly generated node, a
+            # token it re-introduced — is served unreconciled, and FND-195's
+            # guarantee silently does not hold for exactly the apps that need it
+            # most: a bundle's marketplace entry points have their DAG computed
+            # per submission by this hook.
+            #
+            # Idempotent, so the pre-hook pass above stays (the hook should see
+            # resolved values it may key on): after that pass no template
+            # remains, so this one is a no-op unless the hook introduced
+            # something new. Note it catches unresolved *tokens*, not a hook
+            # that hardcodes a concrete-but-wrong queue — that string has no
+            # token to match, and normalising every `atlan-*` queue would
+            # rewrite the legitimate cross-app dispatch nodes this deliberately
+            # leaves alone. Conformance O005 is the guard for that shape.
+            raw = _resolve_manifest_placeholders(
+                orjson.dumps(computed),
+                f"entrypoint {entrypoint_name!r} (compute_manifest output)",
+            )
 
         return Response(content=raw, media_type="application/json")
 

--- a/application_sdk/handler/service.py
+++ b/application_sdk/handler/service.py
@@ -2145,9 +2145,18 @@ def _register_workflow_routes(
 
         # No entrypoint param: single-entrypoint path
         if manifest is not None:
-            return Response(
-                content=manifest.model_dump_json(), media_type="application/json"
+            # Same reconciliation as the disk branches. A programmatic
+            # AppManifest is the one shape with no contract-toolkit bake behind
+            # it — the DAG was hand-built in Python — so every argument for
+            # "the toolkit already resolved this" is inapplicable here, and it
+            # is the branch most likely to carry an unresolved template rather
+            # than the least. Serving it verbatim also left this route with two
+            # behaviours across three manifest sources, which is the drift this
+            # module exists to remove (FND-195).
+            raw = _resolve_manifest_placeholders(
+                manifest.model_dump_json().encode(), "programmatic manifest"
             )
+            return Response(content=raw, media_type="application/json")
         manifest_path = CONTRACT_GENERATED_DIR / "manifest.json"
         if manifest_path.exists():
             # Disk: contract-generated file — serve raw bytes with placeholder

--- a/application_sdk/handler/service.py
+++ b/application_sdk/handler/service.py
@@ -54,6 +54,10 @@ from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel as PydanticBaseModel
 from temporalio.client import WorkflowFailureError
 
+from application_sdk.common.task_queue import (
+    resolve_manifest_tokens,
+    task_queue_from_env,
+)
 from application_sdk.constants import CONTRACT_GENERATED_DIR as _CONTRACT_GENERATED_DIR
 from application_sdk.constants import DEPLOYMENT_NAME, LOCAL_ENVIRONMENT
 from application_sdk.errors import AppError
@@ -1970,10 +1974,64 @@ def _register_workflow_routes(
     # Manifest endpoint
     # ------------------------------------------------------------------
 
+    def _resolve_manifest_placeholders(raw: bytes, source: str) -> bytes:
+        """Substitute the manifest's ``{app_name}`` / ``{deployment_name}`` tokens.
+
+        Delegates to :func:`application_sdk.common.task_queue.resolve_manifest_tokens`,
+        handing it the queue this process was configured with — the same value
+        ``create_worker`` receives, in every mode. The served ``task_queue`` is
+        therefore *stamped from* what the worker polls rather than independently
+        re-derived from the same env and hoped to match. Re-deriving is what let
+        AE submit to a queue nothing polled (FND-195 / CONNECT-183).
+
+        An ``{app_name}`` token means the app's committed manifest predates the
+        toolkit's bake (#2271 / #2478) — worth a WARNING even when this fills it,
+        because any other writer of that DAG gets no such backstop. With nothing
+        to fill it from, the token is served as-is and logged at ERROR:
+        deliberately not papered over with ``constants.APPLICATION_NAME``'s
+        ``"default"``, since ``atlan-default-<deployment>`` reads as a legitimate
+        queue and hangs the run silently, whereas a literal ``{app_name}`` in the
+        DAG is greppable and immediately diagnosable.
+        """
+        resolution = resolve_manifest_tokens(
+            raw,
+            task_queue=_workflow_config.task_queue or None,
+            # _workflow_config.app_name is populated from app_class._app_name and
+            # is empty for a handler served without an app class; the app_name
+            # argument carries the same value in that case.
+            app_name=_workflow_config.app_name or app_name or None,
+            deployment_fallback=DEPLOYMENT_NAME or "default",
+        )
+        if resolution.unresolved_app_name:
+            # conformance: ignore[L009] not a request-boundary handler — the manifest is
+            # still served (the token is the diagnostic); this log is the operator's signal.
+            logger.error(
+                "Manifest for %s carries an unresolved {app_name} token and no app "
+                "name is available (neither a registered app class nor "
+                "ATLAN_APPLICATION_NAME), so the SDK is serving the literal token "
+                "rather than inventing a name that would look legitimate and be "
+                "polled by nobody. Failure attribution for runs started from this "
+                "manifest will be blank, and any task_queue the SDK could not stamp "
+                "(stamped queue: %r) targets no worker. Set ATLAN_APPLICATION_NAME "
+                "on the deployment, or regenerate the contract so the toolkit bakes "
+                "the app name.",
+                source,
+                resolution.task_queue,
+            )
+        elif resolution.had_app_name_token:
+            logger.warning(
+                "Manifest for %s shipped an unbaked {app_name} token; filled with "
+                "%r for this response. The committed manifest is stale — bump the "
+                "contract toolkit and regenerate contracts, since any writer of "
+                "this DAG that does not go through this route gets no such fallback.",
+                source,
+                resolution.app_name,
+            )
+        return resolution.raw
+
     async def _serve_entrypoint_manifest(
         entrypoint_name: str,
         fe_inputs: str | dict[str, Any] | None,
-        deployment: bytes,
     ) -> Response:
         """Read <entrypoint>/manifest.json, substitute placeholders, run the
         optional ``compute_manifest`` hook, and return the Response.
@@ -2014,10 +2072,9 @@ def _register_workflow_routes(
                     status_code=404,
                     detail=f"No manifest found for entrypoint {entrypoint_name!r}",
                 )
-        raw = ep_manifest.read_bytes()
-        # app_name is baked into the generated manifest by the contract toolkit
-        # (from the contract `name`); only the per-deployment token is substituted here.
-        raw = raw.replace(b"{deployment_name}", deployment)
+        raw = _resolve_manifest_placeholders(
+            ep_manifest.read_bytes(), f"entrypoint {entrypoint_name!r}"
+        )
 
         # Dynamic-manifest hook: if the app defines
         # `app.<entrypoint_snake>.core.compute_manifest`, hand the
@@ -2080,13 +2137,11 @@ def _register_workflow_routes(
         body dict. Everything downstream is identical and lives here once so the
         two methods cannot drift.
         """
-        deployment = (DEPLOYMENT_NAME or "default").encode()
-
         if entrypoint:
             # Guard 1 (400): reject obviously-malformed names before touching disk.
             if not _ENTRYPOINT_NAME_RE.match(entrypoint):
                 raise HTTPException(status_code=400, detail="Invalid entrypoint name")
-            return await _serve_entrypoint_manifest(entrypoint, fe_inputs, deployment)
+            return await _serve_entrypoint_manifest(entrypoint, fe_inputs)
 
         # No entrypoint param: single-entrypoint path
         if manifest is not None:
@@ -2098,10 +2153,9 @@ def _register_workflow_routes(
             # Disk: contract-generated file — serve raw bytes with placeholder
             # substitution. No parse/reserialize: the file is already valid JSON,
             # validated at build time by the contract tooling.
-            raw = manifest_path.read_bytes()
-            # app_name is baked into the manifest by the toolkit; only the
-            # per-deployment token is substituted here (see note above).
-            raw = raw.replace(b"{deployment_name}", deployment)
+            raw = _resolve_manifest_placeholders(
+                manifest_path.read_bytes(), "root manifest"
+            )
             return Response(content=raw, media_type="application/json")
 
         # Default-entrypoint fallback (aligns with PR #1965 semantics used
@@ -2164,7 +2218,7 @@ def _register_workflow_routes(
 
         for cand in candidates:
             try:
-                return await _serve_entrypoint_manifest(cand, fe_inputs, deployment)
+                return await _serve_entrypoint_manifest(cand, fe_inputs)
             except HTTPException as exc:
                 if exc.status_code != 404:
                     raise
@@ -2376,7 +2430,10 @@ def create_app_handler_service(
         app_class: App class for workflow execution (enables /start, /stop, etc.).
         temporal_host: Temporal server address (e.g., "localhost:7233").
         temporal_namespace: Temporal namespace.
-        task_queue: Task queue name (default: "{app_name}-queue").
+        task_queue: Task queue name. Defaults to the deployment's canonical queue
+            (``atlan-{ATLAN_APPLICATION_NAME}-{ATLAN_DEPLOYMENT_NAME}``, see
+            :func:`application_sdk.common.task_queue.derive_task_queue`), falling
+            back to ``"{app_name}-queue"`` when that env is absent.
         data_converter: Optional custom Temporal DataConverter.
         secret_store: Optional secret store for credential resolution.
         storage: Optional obstore store for file uploads.
@@ -2418,7 +2475,16 @@ def create_app_handler_service(
     _workflow_config = WorkflowClientConfig(
         host=temporal_host,
         namespace=temporal_namespace,
-        task_queue=task_queue or f"{app_name}-queue",
+        # Env derivation before the {app_name}-queue default: this value is what
+        # the manifest route stamps into the DAG, so a handler constructed
+        # directly (without main.py passing the worker's queue through) must still
+        # land on the queue a worker started from the same env would poll — not on
+        # a fifth, locally-invented shape (FND-195).
+        task_queue=task_queue
+        or task_queue_from_env()
+        # Guarded on app_name: an unnamed handler would otherwise manufacture a
+        # bare "-queue", and the manifest route would stamp that into the DAG.
+        or (f"{app_name}-queue" if app_name else ""),
         app_name=getattr(app_class, "_app_name", "") if app_class is not None else "",
         app_class=app_class,
         data_converter=data_converter,

--- a/application_sdk/main.py
+++ b/application_sdk/main.py
@@ -39,6 +39,7 @@ from typing import TYPE_CHECKING, Any, NoReturn
 import orjson
 
 from application_sdk.common._env import env_int as _env_int
+from application_sdk.common.task_queue import task_queue_from_env
 from application_sdk.discovery import (
     load_app_class,
     load_handler_class,
@@ -662,18 +663,15 @@ def _derive_service_name(app_module: str) -> str:
 def _derive_task_queue(app_module: str) -> str:
     """Derive the default task queue name.
 
-    Mirrors v2 TemporalWorkflowClient.get_worker_task_queue():
-    - If ATLAN_APPLICATION_NAME + ATLAN_DEPLOYMENT_NAME are set → atlan-{app}-{deployment}
-    - If only ATLAN_APPLICATION_NAME is set → {app}
-    - Otherwise fall back to class-name derivation → {ClassName}-queue
+    The env-var rule itself lives in
+    :func:`application_sdk.common.task_queue.task_queue_from_env` — the same
+    function the manifest-serving path consults, so the queue this worker polls
+    and the queue AE submits to cannot drift apart (FND-195). Only the
+    no-app-name fallback is local to the worker: ``{ClassName}-queue`` predates
+    the env-var convention and is load-bearing for local dev, where nothing reads
+    the manifest's queue anyway.
     """
-    app_name = os.environ.get("ATLAN_APPLICATION_NAME", "")
-    deployment_name = os.environ.get("ATLAN_DEPLOYMENT_NAME", "")
-    if app_name and deployment_name:
-        return f"atlan-{app_name}-{deployment_name}"
-    if app_name:
-        return app_name
-    return f"{_derive_service_name(app_module)}-queue"
+    return task_queue_from_env() or f"{_derive_service_name(app_module)}-queue"
 
 
 def _parse_workflow_max_timeout_hours() -> int | None:

--- a/application_sdk/testing/e2e/base.py
+++ b/application_sdk/testing/e2e/base.py
@@ -44,6 +44,12 @@ from typing import Any, ClassVar
 import orjson
 import pytest
 
+from application_sdk.common.task_queue import (
+    QUEUE_PREFIX,
+    application_name_from_env,
+    deployment_name_from_env,
+    derive_task_queue,
+)
 from application_sdk.contracts.types import ConnectionRef
 from application_sdk.observability.logger_adaptor import get_logger
 from application_sdk.testing.e2e._errors import (
@@ -603,10 +609,15 @@ class BaseE2ETest:
         """
         if self.mode is RunMode.DIRECT:
             return None
-        app_name = os.environ.get("ATLAN_APPLICATION_NAME", "")
-        deployment_name = os.environ.get("ATLAN_DEPLOYMENT_NAME", "")
-        if app_name and deployment_name:
-            return AgentSpec(agent_name=f"{app_name}-{deployment_name}")
+        app_name = application_name_from_env()
+        deployment_name = deployment_name_from_env()
+        # Strip the prefix the canonical deriver adds rather than re-assembling
+        # the pair here: _extract_task_queue puts "atlan-" back on, and going
+        # through derive_task_queue keeps this mirror pinned to the worker's rule
+        # instead of being a second implementation of it (FND-195).
+        worker_queue = derive_task_queue(app_name, deployment_name)
+        if worker_queue is not None and worker_queue.startswith(QUEUE_PREFIX):
+            return AgentSpec(agent_name=worker_queue.removeprefix(QUEUE_PREFIX))
         # Local fallback: no CI-exported deployment env. Reproduce the exact
         # {connector}-{connection_name_prefix}-{run_id} shape connectors used to
         # hard-code in a working local override, so a local run lands on its own

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -12,8 +12,8 @@ Set variables in your shell environment, a `.env` file at the project root, or D
 |----------|---------|-------------|
 | `ATLAN_APP_MODULE` | _(required)_ | App class to load: `module.path:ClassName` (e.g. `app.app:MyExtractor`). Startup fails without it. Set in your `Dockerfile` as `ENV ATLAN_APP_MODULE=…` or pass via `--app` CLI flag. |
 | `ATLAN_APP_MODE` | `combined` | Run mode: `worker`, `handler`, or `combined`. Determines which subsystems start; override via `--mode` CLI flag. **v2-compat fallback:** `APPLICATION_MODE` (deprecated; mapped at startup to the equivalent v3 mode). |
-| `ATLAN_APPLICATION_NAME` | `default` | Application name. Used in object-store paths, logging, and workflow identification. |
-| `ATLAN_DEPLOYMENT_NAME` | `local` | Deployment name. Distinguishes dev / staging / prod deployments of the same app. |
+| `ATLAN_APPLICATION_NAME` | `default` | Application name. Used in object-store paths, logging, and workflow identification. The `default` fallback applies to those *identity* uses only — task-queue derivation treats the variable as genuinely unset (see [Task-queue naming](#task-queue-naming)). Set it as the **bare** name, with no `atlan-` prefix; the SDK adds the prefix. |
+| `ATLAN_DEPLOYMENT_NAME` | `local` | Deployment name. Distinguishes dev / staging / prod deployments of the same app. As with `ATLAN_APPLICATION_NAME`, the `local` fallback is an identity default and does not apply to task-queue derivation. |
 | `ATLAN_TENANT_ID` | `default` | Tenant identifier for multi-tenant deployments. |
 | `ATLAN_DOMAIN_NAME` | `atlan.com` | Tenant domain name. |
 | `ATLAN_TEMPORARY_PATH` | `./local/tmp/` | Path for intermediate files during processing. |
@@ -42,9 +42,30 @@ Injected by the Local Marketplace into the Helm release at deploy time, and expo
 |----------|---------|-------------|
 | `ATLAN_TEMPORAL_HOST` | `localhost:7233` | Temporal server address (`host:port`). **v2-compat fallback:** if unset, the SDK constructs the address from `ATLAN_WORKFLOW_HOST` + `ATLAN_WORKFLOW_PORT` (deprecated; remove when all deployments set `ATLAN_TEMPORAL_HOST`). |
 | `ATLAN_TEMPORAL_NAMESPACE` | `default` | Temporal namespace. **v2-compat fallback:** `ATLAN_WORKFLOW_NAMESPACE`. |
-| `ATLAN_TASK_QUEUE` | _(derived)_ | Temporal task queue name. Defaults to `atlan-{ATLAN_APPLICATION_NAME}-{ATLAN_DEPLOYMENT_NAME}` when both are set, or just the app name when only `ATLAN_APPLICATION_NAME` is set, or `{ClassName}-queue` (kebab-case) when neither is set. |
+| `ATLAN_TASK_QUEUE` | _(derived)_ | Temporal task queue name. Defaults to `atlan-{ATLAN_APPLICATION_NAME}-{ATLAN_DEPLOYMENT_NAME}` when both are set, or just the bare app name (**no** `atlan-` prefix) when only `ATLAN_APPLICATION_NAME` is set, or `{ClassName}-queue` (kebab-case) when neither is set. Setting this explicitly also changes the queue the served manifest advertises, so a worker on an overridden queue and the Automation Engine stay in step. See [Task-queue naming](#task-queue-naming). |
 | `ATLAN_TEMPORAL_PROMETHEUS_BIND_ADDRESS` | `127.0.0.1:9464` | Bind address for the Temporal SDK Prometheus endpoint (~40 built-in metrics). Loopback-only by default — operators should not scrape this port directly; combined-mode FastAPI `/metrics` proxies it in-process. See [Monitoring](concepts/monitoring.md). |
 | `ATLAN_PREFLIGHT_GATE_MODE` | _(unset)_ | Deploy-time preflight gate posture override, read once at worker build. Only the literal `hard` enforces (blocks a `NOT_READY` run); any other set value resolves to soft. Empty or unset defers to the app's declared `App.preflight_gate_mode`. Set on the worker deployment; no app release needed. See [Apps](concepts/apps.md#preflight-gate-posture). |
+
+### Task-queue naming
+
+The queue name has to be agreed on by two things that never talk to each other: the **worker**, which polls it, and the **served manifest**, whose resolved `task_queue` the Automation Engine writes into the DAG and submits work to. When they disagree nothing fails loudly — AE submits to one queue, the worker polls another, and the run sits unclaimed until its 24h heartbeat backstop.
+
+There is now one derivation, `application_sdk.common.task_queue.derive_task_queue`, and the manifest route does not re-run it — it stamps the queue the handler was configured with, which is the same value the worker was started on. Two paths deriving the same answer is a convention; one path copying the other's answer is structural.
+
+The rule itself:
+
+| `ATLAN_APPLICATION_NAME` | `ATLAN_DEPLOYMENT_NAME` | Queue |
+|---|---|---|
+| `dbt` | `prod` | `atlan-dbt-prod` |
+| `dbt` | _(unset)_ | `dbt` — bare, **no** prefix |
+| _(unset)_ | anything | no queue name exists; the worker falls back to `{ClassName}-queue` for local dev, and the manifest stamps that same queue. With no app name available anywhere, the served manifest leaves the literal `{app_name}` token in place and logs at ERROR |
+
+Two consequences worth internalising when writing or rewriting an AE DAG outside the toolkit:
+
+- **Pass the bare app name.** `derive_task_queue` adds the `atlan-` prefix. Prefixing a value that is already prefixed produces `atlan-atlan-dbt-production`, a queue nothing polls.
+- **Never invent a name for the unset case.** `atlan-default-prod` reads as a legitimate queue and reproduces the original silent hang; a literal `{app_name}` in the DAG is greppable and diagnosable in one step. That is why `ATLAN_APPLICATION_NAME`'s `default` fallback is scoped to identity uses and excluded here.
+
+Nodes that dispatch to a *different* app's queue (`atlan-publish-{deployment_name}` and friends) are legitimately not this app's queue: their `{deployment_name}` token is filled and the value is otherwise left alone.
 
 ### Worker Versioning
 

--- a/tests/unit/common/test_task_queue.py
+++ b/tests/unit/common/test_task_queue.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
+from unittest.mock import patch
 
 import pytest
 
@@ -488,13 +489,38 @@ class TestQueueStampIsFieldAware:
         assert served["dag"]["extract"]["task_queue"] == "atlan-dbt-prod"
         assert served["dag"]["extract"]["inputs"]["task_queue"] == "atlan-dbt-prod"
 
-    def test_unparseable_manifest_falls_back_to_byte_substitution(
+    def test_unparseable_manifest_is_served_unstamped_and_logged(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """A manifest too malformed to parse still gets its queue stamped — the
-        pre-FND-195 byte behaviour, degraded rather than dropped."""
+        """A manifest too malformed to parse is served back byte-for-byte and
+        logged at ERROR, not byte-substituted. Byte substitution cannot scope the
+        residual fills away from a stamped queue carrying literal token text, so
+        it re-imports the defect this module removes — a loud failure beats a
+        silently wrong queue."""
         DeploymentEnv("dbt", "prod").apply(monkeypatch)
-        raw = resolve_manifest_tokens(
-            b'{"dag": {"extract": {"task_queue": "atlan-dbt-{deployment_name}"'
-        ).raw
-        assert b"atlan-dbt-prod" in raw
+        malformed = b'{"dag": {"extract": {"task_queue": "atlan-dbt-{deployment_name}"'
+        with patch("application_sdk.common.task_queue.logger.error") as mock_error:
+            resolution = resolve_manifest_tokens(malformed)
+        assert resolution.raw == malformed
+        assert resolution.task_queue == "atlan-dbt-prod"
+        mock_error.assert_called_once()
+        assert "does not parse as JSON" in mock_error.call_args.args[0]
+
+    def test_unparseable_manifest_with_token_carrying_override_is_not_mutated(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Regression: an override carrying literal token text through the
+        malformed path must survive untouched. The old byte fallback stamped the
+        template and then ran the residual fills over the result, rewriting the
+        stamped ``custom-{deployment_name}-queue`` to ``custom-prod-queue`` while
+        ``resolution.task_queue`` still reported the original — the served
+        manifest and the worker disagreed on the queue. Serving unstamped removes
+        the divergence: the bytes never change, so there is no second answer."""
+        DeploymentEnv("dbt", "prod").apply(monkeypatch)
+        malformed = b'{"task_queue": "atlan-dbt-{deployment_name}"'
+        resolution = resolve_manifest_tokens(
+            malformed, task_queue="custom-{deployment_name}-queue"
+        )
+        assert resolution.raw == malformed
+        assert b"custom-prod-queue" not in resolution.raw
+        assert resolution.task_queue == "custom-{deployment_name}-queue"

--- a/tests/unit/common/test_task_queue.py
+++ b/tests/unit/common/test_task_queue.py
@@ -97,6 +97,66 @@ class TestWorkerFallback:
         assert _derive_task_queue("pkg.apps:DbtApp") == "dbt-app-queue"
 
 
+class TestPrecedenceIndependentOracle:
+    """Hard-coded expectations for every precedence row, no shared oracle.
+
+    The equality tests above prove worker and manifest *agree*; they cannot
+    catch both sides drifting together, because ``_derive_task_queue`` and the
+    resolver's fallback both bottom out in ``task_queue_from_env``. These rows
+    assert the concrete queue each precedence case must produce, so a drift in
+    the shared rule fails here even when the two paths still agree.
+    """
+
+    @pytest.mark.parametrize(
+        ("env", "expected_queue"),
+        [
+            # Both set → prefixed pair.
+            pytest.param(DeploymentEnv("dbt", "prod"), "atlan-dbt-prod", id="both"),
+            # App only → bare, unprefixed (never atlan-dbt-default).
+            pytest.param(DeploymentEnv("dbt", None), "dbt", id="app-only"),
+            # Deployment only → no name determinable.
+            pytest.param(DeploymentEnv(None, "prod"), None, id="deployment-only"),
+            # Neither → no name determinable.
+            pytest.param(DeploymentEnv(None, None), None, id="neither"),
+        ],
+    )
+    def test_env_derivation(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        env: DeploymentEnv,
+        expected_queue: str | None,
+    ) -> None:
+        env.apply(monkeypatch)
+        assert task_queue_from_env() == expected_queue
+        resolution = resolve_manifest_tokens(
+            _manifest_bytes("atlan-dbt-{deployment_name}")
+        )
+        assert resolution.task_queue == expected_queue
+
+    def test_explicit_override_beats_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``ATLAN_TASK_QUEUE`` / ``--task-queue`` is authoritative over any
+        env-derived value — the row re-derivation can never reproduce."""
+        DeploymentEnv("dbt", "prod").apply(monkeypatch)
+        resolution = resolve_manifest_tokens(
+            _manifest_bytes("atlan-dbt-{deployment_name}"),
+            task_queue="atlan-dbt-ci",
+        )
+        assert resolution.task_queue == "atlan-dbt-ci"
+        assert _served_queue(resolution.raw) == "atlan-dbt-ci"
+
+    def test_env_beats_registered_name_in_the_template(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A baked name that no longer matches the deployment's env is corrected
+        to the env queue — the divergence the stamp exists to close."""
+        DeploymentEnv("dbt-v3", "prod").apply(monkeypatch)
+        resolution = resolve_manifest_tokens(
+            _manifest_bytes("atlan-dbt-{deployment_name}"), app_name="dbt"
+        )
+        assert resolution.task_queue == "atlan-dbt-v3-prod"
+        assert _served_queue(resolution.raw) == "atlan-dbt-v3-prod"
+
+
 class TestManifestAgreesWithWorker:
     """The three rows of FND-195's divergence table."""
 
@@ -293,3 +353,148 @@ class TestManifestResidualTokens:
             deployment_fallback="ignored",
         ).raw
         assert _served_queue(raw) == "prod-queue"
+
+
+class TestQueueStampIsFieldAware:
+    """The stamp owns ``task_queue`` fields only, and runs after the token fills.
+
+    Both findings below are the same class — unscoped byte substitution — that
+    the whole-manifest replace used to commit: it mutated the stamped queue with
+    the later token passes, and it re-pointed bytes that were never this app's
+    queue to begin with.
+    """
+
+    def test_a_configured_queue_containing_token_text_is_stamped_verbatim(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An explicit ``ATLAN_TASK_QUEUE`` / ``--task-queue`` override may
+        legitimately contain literal token text (``custom-{deployment_name}-queue``).
+        The residual passes must not rewrite it post-stamp into a queue no worker
+        polls while ``resolution.task_queue`` still reports the original."""
+        DeploymentEnv("dbt", "prod").apply(monkeypatch)
+        resolution = resolve_manifest_tokens(
+            _manifest_bytes("atlan-dbt-{deployment_name}"),
+            task_queue="custom-{deployment_name}-queue",
+        )
+        assert _served_queue(resolution.raw) == "custom-{deployment_name}-queue"
+        assert resolution.task_queue == "custom-{deployment_name}-queue"
+
+    def test_a_foreign_app_node_matching_the_template_is_not_repointed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A DAG node that dispatches to *another* app's queue keeps it. The byte
+        substitutor matched ``atlan-{candidate}-{deployment_name}`` anywhere in the
+        manifest — including a foreign node whose baked queue equals this app's env
+        name — and re-pointed it at this app's worker."""
+        DeploymentEnv("dbt", "prod").apply(monkeypatch)
+        manifest = json.dumps(
+            {
+                "execution_mode": "dag",
+                "dag": {
+                    "extract": {
+                        "activity_name": "execute_workflow",
+                        "task_queue": "atlan-dbt-{deployment_name}",
+                    },
+                    # A node that hands off to the dbt app's own queue, baked.
+                    # It matches a candidate but is not this node's own stamp.
+                    "notify_dbt": {
+                        "activity_name": "execute_workflow",
+                        "task_queue": "atlan-dbt-prod",
+                    },
+                },
+            }
+        ).encode()
+        served = json.loads(resolve_manifest_tokens(manifest).raw)["dag"]
+        assert served["extract"]["task_queue"] == "atlan-dbt-prod"
+        # The foreign node is token-filled like any residual, never normalised
+        # to this app's stamped queue — and crucially never double-stamped.
+        assert served["notify_dbt"]["task_queue"] == "atlan-dbt-prod"
+
+    def test_template_text_in_a_description_is_not_rewritten(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Free-text fields are not queues. A description mentioning the template
+        must pass through untouched even though it matches the byte pattern."""
+        DeploymentEnv("dbt", "prod").apply(monkeypatch)
+        manifest = json.dumps(
+            {
+                "execution_mode": "dag",
+                "dag": {
+                    "extract": {
+                        "activity_name": "execute_workflow",
+                        "description": "polls atlan-dbt-{deployment_name} for work",
+                        "task_queue": "atlan-dbt-{deployment_name}",
+                    }
+                },
+            }
+        ).encode()
+        node = json.loads(resolve_manifest_tokens(manifest).raw)["dag"]["extract"]
+        assert node["task_queue"] == "atlan-dbt-prod"
+        # The description is a residual field, not a queue: its {deployment_name}
+        # is token-filled like any other, but it is never *stamped* — had it been
+        # treated as a queue it would also have been rewritten when the stamped
+        # queue differed from the template fill (see the override test above).
+        assert node["description"] == "polls atlan-dbt-prod for work"
+
+    def test_template_text_in_a_description_is_never_stamped(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Stronger form: when the stamped queue differs from the template fill
+        (an explicit override), a description holding the template must not track
+        the stamp — only a real ``task_queue`` field may."""
+        DeploymentEnv("dbt", "prod").apply(monkeypatch)
+        manifest = json.dumps(
+            {
+                "execution_mode": "dag",
+                "dag": {
+                    "extract": {
+                        "activity_name": "execute_workflow",
+                        "description": "polls atlan-dbt-{deployment_name} for work",
+                        "task_queue": "atlan-dbt-{deployment_name}",
+                    }
+                },
+            }
+        ).encode()
+        node = json.loads(
+            resolve_manifest_tokens(manifest, task_queue="atlan-dbt-ci").raw
+        )["dag"]["extract"]
+        # The real queue field is stamped with the override...
+        assert node["task_queue"] == "atlan-dbt-ci"
+        # ...but the description is only token-filled, never re-pointed at it.
+        assert node["description"] == "polls atlan-dbt-prod for work"
+
+    def test_queue_fields_are_stamped_at_any_depth(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Real manifests carry the queue at ``dag.<node>.task_queue``,
+        ``dag.<node>.inputs.task_queue``, and top level; the field-aware stamp
+        reaches all of them, not just the first nesting level."""
+        DeploymentEnv("dbt", "prod").apply(monkeypatch)
+        manifest = json.dumps(
+            {
+                "execution_mode": "dag",
+                "task_queue": "atlan-dbt-{deployment_name}",
+                "dag": {
+                    "extract": {
+                        "activity_name": "execute_workflow",
+                        "task_queue": "atlan-dbt-{deployment_name}",
+                        "inputs": {"task_queue": "atlan-dbt-{deployment_name}"},
+                    }
+                },
+            }
+        ).encode()
+        served = json.loads(resolve_manifest_tokens(manifest).raw)
+        assert served["task_queue"] == "atlan-dbt-prod"
+        assert served["dag"]["extract"]["task_queue"] == "atlan-dbt-prod"
+        assert served["dag"]["extract"]["inputs"]["task_queue"] == "atlan-dbt-prod"
+
+    def test_unparseable_manifest_falls_back_to_byte_substitution(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A manifest too malformed to parse still gets its queue stamped — the
+        pre-FND-195 byte behaviour, degraded rather than dropped."""
+        DeploymentEnv("dbt", "prod").apply(monkeypatch)
+        raw = resolve_manifest_tokens(
+            b'{"dag": {"extract": {"task_queue": "atlan-dbt-{deployment_name}"'
+        ).raw
+        assert b"atlan-dbt-prod" in raw

--- a/tests/unit/common/test_task_queue.py
+++ b/tests/unit/common/test_task_queue.py
@@ -1,0 +1,295 @@
+"""Tests for the canonical task-queue derivation (FND-195).
+
+The point of the module under test is that the worker and the served manifest
+agree byte-for-byte. The tests are written the same way: the divergence cases
+from FND-195 are asserted as *equality between the two paths*, not as two
+independently hard-coded expectations, so a future change to the rule can't
+satisfy one side and quietly break the other.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+
+import pytest
+
+from application_sdk.common.task_queue import (
+    derive_task_queue,
+    resolve_manifest_tokens,
+    task_queue_from_env,
+)
+from application_sdk.main import _derive_task_queue
+
+
+@dataclass(frozen=True)
+class DeploymentEnv:
+    """The two env vars the queue name is derived from."""
+
+    application_name: str | None
+    deployment_name: str | None
+
+    def apply(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        for key, value in (
+            ("ATLAN_APPLICATION_NAME", self.application_name),
+            ("ATLAN_DEPLOYMENT_NAME", self.deployment_name),
+        ):
+            if value is None:
+                monkeypatch.delenv(key, raising=False)
+            else:
+                monkeypatch.setenv(key, value)
+
+
+def _manifest_bytes(task_queue: str, app_name: str = "{app_name}") -> bytes:
+    """A minimal DAG manifest in the shape the contract toolkit emits."""
+    return json.dumps(
+        {
+            "execution_mode": "dag",
+            "dag": {
+                "extract": {
+                    "activity_name": "execute_workflow",
+                    "app_name": app_name,
+                    "inputs": {"args": {"app_name": app_name}},
+                    "task_queue": task_queue,
+                }
+            },
+        }
+    ).encode()
+
+
+def _served_queue(raw: bytes) -> str:
+    return json.loads(raw)["dag"]["extract"]["task_queue"]
+
+
+class TestDeriveTaskQueue:
+    def test_app_and_deployment_are_prefixed(self) -> None:
+        assert derive_task_queue("dbt", "prod") == "atlan-dbt-prod"
+
+    def test_app_only_is_bare_and_unprefixed(self) -> None:
+        """DISTR-834 shipped a double prefix by pre-prefixing an already-prefixed
+        value; the bare shape is deliberate, not an oversight."""
+        assert derive_task_queue("dbt", None) == "dbt"
+        assert derive_task_queue("dbt", "") == "dbt"
+
+    def test_no_app_name_invents_nothing(self) -> None:
+        assert derive_task_queue(None, "prod") is None
+        assert derive_task_queue("", "prod") is None
+        assert derive_task_queue("   ", "prod") is None
+
+    def test_whitespace_is_stripped(self) -> None:
+        assert derive_task_queue(" dbt ", " prod ") == "atlan-dbt-prod"
+
+
+class TestWorkerFallback:
+    """``_derive_task_queue`` adds exactly one thing to the shared rule."""
+
+    def test_delegates_when_app_name_is_set(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        DeploymentEnv("dbt", "prod").apply(monkeypatch)
+        assert _derive_task_queue("pkg.apps:DbtApp") == task_queue_from_env()
+
+    def test_class_name_queue_only_when_app_name_is_unset(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        DeploymentEnv(None, "prod").apply(monkeypatch)
+        assert task_queue_from_env() is None
+        assert _derive_task_queue("pkg.apps:DbtApp") == "dbt-app-queue"
+
+
+class TestManifestAgreesWithWorker:
+    """The three rows of FND-195's divergence table."""
+
+    @pytest.mark.parametrize(
+        "env",
+        [
+            pytest.param(DeploymentEnv("dbt", "prod"), id="both-set"),
+            pytest.param(DeploymentEnv("dbt", None), id="no-deployment-name"),
+        ],
+    )
+    @pytest.mark.parametrize(
+        "template",
+        [
+            pytest.param("atlan-{app_name}-{deployment_name}", id="unbaked"),
+            pytest.param("atlan-dbt-{deployment_name}", id="toolkit-baked"),
+        ],
+    )
+    def test_served_queue_equals_worker_queue(
+        self, monkeypatch: pytest.MonkeyPatch, env: DeploymentEnv, template: str
+    ) -> None:
+        env.apply(monkeypatch)
+        resolution = resolve_manifest_tokens(_manifest_bytes(template))
+        assert _served_queue(resolution.raw) == _derive_task_queue("pkg.apps:DbtApp")
+        assert resolution.task_queue == _derive_task_queue("pkg.apps:DbtApp")
+        assert not resolution.unresolved_app_name
+
+    def test_no_deployment_name_collapses_to_the_bare_queue(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Row 2 of the table: token-filling gave ``atlan-dbt-default`` while the
+        worker polled a bare ``dbt``. Resolving the template as a unit fixes it."""
+        DeploymentEnv("dbt", None).apply(monkeypatch)
+        raw = resolve_manifest_tokens(
+            _manifest_bytes("atlan-dbt-{deployment_name}")
+        ).raw
+        assert _served_queue(raw) == "dbt"
+
+    def test_unset_app_name_leaves_the_token_visible(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Row 3: the manifest must not manufacture ``atlan-default-prod``, which
+        reads as legitimate and reproduces the CONNECT-183 hang."""
+        DeploymentEnv(None, "prod").apply(monkeypatch)
+        resolution = resolve_manifest_tokens(
+            _manifest_bytes("atlan-{app_name}-{deployment_name}")
+        )
+        assert resolution.task_queue is None
+        assert resolution.unresolved_app_name
+        served = _served_queue(resolution.raw)
+        assert "{app_name}" in served
+        assert "default" not in served
+
+    def test_a_known_worker_queue_is_stamped_even_with_no_app_name(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Stamping the queue the worker actually polls is not invention, so it
+        applies even here — but the log-identity token stays visible, because
+        there is still nothing truthful to fill it with."""
+        DeploymentEnv(None, "prod").apply(monkeypatch)
+        resolution = resolve_manifest_tokens(
+            _manifest_bytes("atlan-{app_name}-{deployment_name}"),
+            task_queue="some-app-queue",
+        )
+        assert _served_queue(resolution.raw) == "some-app-queue"
+        assert resolution.unresolved_app_name
+        assert "{app_name}" in resolution.raw.decode()
+
+
+class TestWorkerQueueIsStampedNotRederived:
+    """The handler knows the queue its worker polls, so it stamps that value.
+
+    This is the part re-derivation cannot reach: an explicit ``ATLAN_TASK_QUEUE``
+    override, or a baked name that no longer matches the deployment's env.
+    """
+
+    def test_explicit_worker_queue_wins_over_the_env_derivation(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        DeploymentEnv("dbt", "prod").apply(monkeypatch)
+        resolution = resolve_manifest_tokens(
+            _manifest_bytes("atlan-dbt-{deployment_name}"),
+            task_queue="atlan-dbt-ci",
+        )
+        assert _served_queue(resolution.raw) == "atlan-dbt-ci"
+        assert resolution.task_queue == "atlan-dbt-ci"
+
+    def test_baked_name_disagreeing_with_env_is_corrected(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A manifest baked as ``dbt`` on a deployment renamed to ``dbt-v3`` used
+        to serve ``atlan-dbt-prod`` while the worker polled ``atlan-dbt-v3-prod``
+        — plausible-looking, and dead."""
+        DeploymentEnv("dbt-v3", "prod").apply(monkeypatch)
+        resolution = resolve_manifest_tokens(
+            _manifest_bytes("atlan-dbt-{deployment_name}"), app_name="dbt"
+        )
+        assert _served_queue(resolution.raw) == "atlan-dbt-v3-prod"
+
+    def test_registered_name_resolves_the_queue_with_no_env_at_all(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Local dev: no deployment env, so the worker polls ``{ClassName}-queue``.
+        The manifest now advertises that same queue instead of a manufactured
+        ``atlan-minimal-local`` nothing polls."""
+        DeploymentEnv(None, None).apply(monkeypatch)
+        resolution = resolve_manifest_tokens(
+            _manifest_bytes("atlan-minimal-{deployment_name}"),
+            task_queue="minimal-app-queue",
+            app_name="minimal",
+        )
+        assert _served_queue(resolution.raw) == "minimal-app-queue"
+
+
+class TestManifestResidualTokens:
+    def test_app_name_log_identity_is_substituted(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """HYP-1954: a literal ``{app_name}`` in ``inputs.args`` reached
+        observability and stripped failure attribution."""
+        DeploymentEnv("dbt", "prod").apply(monkeypatch)
+        resolution = resolve_manifest_tokens(_manifest_bytes("atlan-dbt-prod"))
+        node = json.loads(resolution.raw)["dag"]["extract"]
+        assert node["app_name"] == "dbt"
+        assert node["inputs"]["args"]["app_name"] == "dbt"
+        # Filled, but still reported: the committed manifest is stale.
+        assert resolution.had_app_name_token
+        assert not resolution.unresolved_app_name
+
+    def test_registered_name_fills_the_token_over_the_env_value(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The registered name is what the toolkit would have baked, and what the
+        Workflow Center's log filter matches (HYP-1678)."""
+        DeploymentEnv("dbt-v3", "prod").apply(monkeypatch)
+        resolution = resolve_manifest_tokens(
+            _manifest_bytes("atlan-dbt-prod"), app_name="dbt"
+        )
+        assert resolution.app_name == "dbt"
+        assert json.loads(resolution.raw)["dag"]["extract"]["app_name"] == "dbt"
+
+    def test_baked_app_name_passes_through(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The toolkit's baked value is what Workflow Center's log filter matches
+        (HYP-1678); it is never overwritten with the env value."""
+        DeploymentEnv("dbt", "prod").apply(monkeypatch)
+        raw = resolve_manifest_tokens(
+            _manifest_bytes("atlan-dbt-prod", app_name="baked-name")
+        ).raw
+        assert json.loads(raw)["dag"]["extract"]["app_name"] == "baked-name"
+
+    def test_another_apps_queue_is_token_filled_not_normalised(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Platform nodes legitimately dispatch to other apps' queues
+        (``atlan-publish-{deployment_name}``). Those are not this app's queue and
+        must be left alone rather than rewritten to it."""
+        DeploymentEnv("dbt", "prod").apply(monkeypatch)
+        raw = resolve_manifest_tokens(
+            _manifest_bytes("atlan-publish-{deployment_name}")
+        ).raw
+        assert _served_queue(raw) == "atlan-publish-prod"
+
+    def test_deployment_fallback_applies_only_to_residual_tokens(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The fallback keeps the pre-FND-195 behaviour of a bare
+        ``{deployment_name}``, but must not leak into queue derivation — that
+        manufactured segment is the divergence itself."""
+        DeploymentEnv("dbt", None).apply(monkeypatch)
+        resolution = resolve_manifest_tokens(
+            _manifest_bytes("atlan-dbt-{deployment_name}"),
+            deployment_fallback="prod-deploy",
+        )
+        assert _served_queue(resolution.raw) == "dbt"
+        assert resolution.task_queue == "dbt"
+
+    def test_residual_deployment_token_uses_the_fallback(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        DeploymentEnv("dbt", None).apply(monkeypatch)
+        raw = resolve_manifest_tokens(
+            _manifest_bytes("{deployment_name}-queue"),
+            deployment_fallback="prod-deploy",
+        ).raw
+        assert _served_queue(raw) == "prod-deploy-queue"
+
+    def test_env_deployment_wins_over_the_fallback(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        DeploymentEnv("dbt", "prod").apply(monkeypatch)
+        raw = resolve_manifest_tokens(
+            _manifest_bytes("{deployment_name}-queue"),
+            deployment_fallback="ignored",
+        ).raw
+        assert _served_queue(raw) == "prod-queue"

--- a/tests/unit/common/test_task_queue.py
+++ b/tests/unit/common/test_task_queue.py
@@ -504,7 +504,25 @@ class TestQueueStampIsFieldAware:
         assert resolution.raw == malformed
         assert resolution.task_queue == "atlan-dbt-prod"
         mock_error.assert_called_once()
-        assert "does not parse as JSON" in mock_error.call_args.args[0]
+        message = mock_error.call_args.args[0] % mock_error.call_args.args[1:]
+        assert "does not parse as JSON" in message
+
+    def test_scalar_root_manifest_is_served_unstamped_with_accurate_log(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Valid JSON with a scalar root (``null``, a number, a string) has no
+        object to walk, so it takes the same unstamped path — but the log must
+        not claim a syntax error that isn't there. The message distinguishes
+        \"scalar root\" from \"does not parse\" so an operator is not sent
+        hunting a malformed manifest that is in fact well-formed JSON."""
+        DeploymentEnv("dbt", "prod").apply(monkeypatch)
+        with patch("application_sdk.common.task_queue.logger.error") as mock_error:
+            resolution = resolve_manifest_tokens(b"null")
+        assert resolution.raw == b"null"
+        mock_error.assert_called_once()
+        message = mock_error.call_args.args[0] % mock_error.call_args.args[1:]
+        assert "scalar root" in message
+        assert "does not parse as JSON" not in message
 
     def test_unparseable_manifest_with_token_carrying_override_is_not_mutated(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/handler/test_service.py
+++ b/tests/unit/handler/test_service.py
@@ -5879,6 +5879,107 @@ class TestComputeManifestHook:
         finally:
             svc_module.CONTRACT_GENERATED_DIR = original
 
+    def test_hook_output_is_reconciled_not_served_verbatim(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """FND-195: the hook *replaces* the manifest, so its output needs the same
+        queue reconciliation as the static file — otherwise the guarantee is void
+        for precisely the apps that need it, since a bundle's marketplace entry
+        points have their DAG computed per submission by this hook.
+
+        The static file here carries no queue at all; the template appears only
+        in what the hook emits, so a pre-hook-only substitution cannot catch it.
+        """
+        from application_sdk.handler import service as svc_module
+
+        contract_dir = tmp_path / "generated"
+        ep_dir = contract_dir / "hook-ep"
+        ep_dir.mkdir(parents=True)
+        (ep_dir / "manifest.json").write_text(json.dumps({"dag": {}}))
+
+        async def compute_manifest(manifest: dict, fe_inputs: dict) -> dict:
+            # A per-submission DAG built at request time, carrying the un-baked
+            # template — nothing baked this, the hook just wrote it.
+            return {
+                "dag": {
+                    "extract": {
+                        "app_name": "{app_name}",
+                        "inputs": {"task_queue": "atlan-{app_name}-{deployment_name}"},
+                    }
+                }
+            }
+
+        self._install_fake_core(monkeypatch, "hook-ep", compute_manifest)
+        monkeypatch.setenv("ATLAN_APPLICATION_NAME", "dbt-v3")
+        monkeypatch.setenv("ATLAN_DEPLOYMENT_NAME", "prod")
+
+        worker_queue = "atlan-dbt-v3-prod"
+        original = svc_module.CONTRACT_GENERATED_DIR
+        svc_module.CONTRACT_GENERATED_DIR = contract_dir
+        try:
+            app = create_app_handler_service(
+                _TestHandler(), app_name="dbt-v3", task_queue=worker_queue
+            )
+            response = TestClient(app).get(
+                "/workflows/v1/manifest", params={"entrypoint": "hook-ep"}
+            )
+            assert response.status_code == 200
+            node = response.json()["dag"]["extract"]
+            assert node["inputs"]["task_queue"] == worker_queue
+            assert node["app_name"] == "dbt-v3"
+        finally:
+            svc_module.CONTRACT_GENERATED_DIR = original
+
+    def test_hook_output_unresolvable_app_name_keeps_the_token_visible(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """With no app name available the hook's output must not have one
+        manufactured for it either — same contract as the static paths.
+
+        Asserts the *graded* outcome, not just the surviving token: the
+        deployment token is filled (proving the reconciliation pass ran on the
+        hook's output at all) while ``{app_name}`` is left visible. Checking only
+        for the surviving token would pass against a build that never reconciles
+        the hook output, since serving it verbatim also leaves the token in.
+        """
+        from application_sdk.handler import service as svc_module
+
+        contract_dir = tmp_path / "generated"
+        ep_dir = contract_dir / "hook-ep"
+        ep_dir.mkdir(parents=True)
+        (ep_dir / "manifest.json").write_text(json.dumps({"dag": {}}))
+
+        async def compute_manifest(manifest: dict, fe_inputs: dict) -> dict:
+            return {
+                "dag": {
+                    "extract": {
+                        "inputs": {"task_queue": "atlan-{app_name}-{deployment_name}"}
+                    }
+                }
+            }
+
+        self._install_fake_core(monkeypatch, "hook-ep", compute_manifest)
+        monkeypatch.delenv("ATLAN_APPLICATION_NAME", raising=False)
+        monkeypatch.setenv("ATLAN_DEPLOYMENT_NAME", "prod")
+
+        original = svc_module.CONTRACT_GENERATED_DIR
+        svc_module.CONTRACT_GENERATED_DIR = contract_dir
+        try:
+            app = create_app_handler_service(_TestHandler(), app_name="")
+            response = TestClient(app).get(
+                "/workflows/v1/manifest", params={"entrypoint": "hook-ep"}
+            )
+            assert response.status_code == 200
+            served = response.json()["dag"]["extract"]["inputs"]["task_queue"]
+            # The pass ran: the deployment token resolved.
+            assert "{deployment_name}" not in served
+            assert "prod" in served
+            # ...but nothing was invented for the app name.
+            assert "{app_name}" in served
+            assert "default" not in served
+        finally:
+            svc_module.CONTRACT_GENERATED_DIR = original
+
     def test_async_hook_is_awaited(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/unit/handler/test_service.py
+++ b/tests/unit/handler/test_service.py
@@ -2602,6 +2602,90 @@ class TestManifestEndpoint:
         finally:
             svc_module.CONTRACT_GENERATED_DIR = original_dir
 
+    def test_manifest_programmatic_queue_matches_the_configured_worker_queue(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A programmatic ``AppManifest`` gets the same reconciliation as the disk
+        branches — it is the shape with no toolkit bake behind it at all, so it is
+        the *most* likely to carry an unresolved template, not the least.
+
+        Asserted as equality with the configured worker queue rather than a
+        hard-coded string, so the programmatic path cannot drift from the disk
+        paths the way it did before FND-195.
+        """
+        from application_sdk.handler.manifest import (
+            AppManifest,
+            DagNode,
+            ExecuteWorkflowInputs,
+        )
+
+        worker_queue = "atlan-dbt-v3-prod"
+        manifest = AppManifest(
+            execution_mode="dag",
+            dag={
+                "extract": DagNode(
+                    activity_name="execute_workflow",
+                    activity_display_name="Extract",
+                    app_name="{app_name}",
+                    inputs=ExecuteWorkflowInputs(
+                        workflow_type="extraction",
+                        # Un-baked template: the toolkit never ran on this one.
+                        task_queue="atlan-{app_name}-{deployment_name}",
+                    ),
+                ),
+            },
+        )
+        monkeypatch.setenv("ATLAN_APPLICATION_NAME", "dbt-v3")
+        monkeypatch.setenv("ATLAN_DEPLOYMENT_NAME", "prod")
+
+        app = create_app_handler_service(
+            _TestHandler(),
+            app_name="dbt-v3",
+            task_queue=worker_queue,
+            manifest=manifest,
+        )
+        response = TestClient(app).get("/workflows/v1/manifest")
+        assert response.status_code == 200
+        node = response.json()["dag"]["extract"]
+        assert node["inputs"]["task_queue"] == worker_queue
+        # Residual {app_name} is per-node log identity (HYP-1954), filled too.
+        assert node["app_name"] == "dbt-v3"
+
+    def test_manifest_programmatic_unresolvable_app_name_keeps_the_token_visible(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """With no app name available the programmatic path must not manufacture
+        one either — same contract as the disk branches."""
+        from application_sdk.handler.manifest import (
+            AppManifest,
+            DagNode,
+            ExecuteWorkflowInputs,
+        )
+
+        manifest = AppManifest(
+            execution_mode="dag",
+            dag={
+                "extract": DagNode(
+                    activity_name="execute_workflow",
+                    activity_display_name="Extract",
+                    app_name="{app_name}",
+                    inputs=ExecuteWorkflowInputs(
+                        workflow_type="extraction",
+                        task_queue="atlan-{app_name}-{deployment_name}",
+                    ),
+                ),
+            },
+        )
+        monkeypatch.delenv("ATLAN_APPLICATION_NAME", raising=False)
+        monkeypatch.setenv("ATLAN_DEPLOYMENT_NAME", "prod")
+
+        app = create_app_handler_service(_TestHandler(), app_name="", manifest=manifest)
+        response = TestClient(app).get("/workflows/v1/manifest")
+        assert response.status_code == 200
+        served = response.json()["dag"]["extract"]["inputs"]["task_queue"]
+        assert "{app_name}" in served
+        assert "default" not in served
+
     def test_manifest_programmatic_takes_priority(self, tmp_path: Path) -> None:
         """When both programmatic and disk manifest exist, programmatic wins."""
         from application_sdk.handler import service as svc_module

--- a/tests/unit/handler/test_service.py
+++ b/tests/unit/handler/test_service.py
@@ -2528,6 +2528,80 @@ class TestManifestEndpoint:
             svc_module.CONTRACT_GENERATED_DIR = original_dir
             svc_module.DEPLOYMENT_NAME = original_dep
 
+    def test_manifest_queue_matches_the_configured_worker_queue(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """FND-195: the served queue is stamped from the queue this process was
+        configured with, not re-derived from env and hoped to match.
+
+        The baked name here (``dbt``) disagrees with the deployment's app name
+        (``dbt-v3``) — the shape that used to serve a plausible ``atlan-dbt-prod``
+        that no worker polled, hanging the run to its 24h backstop (CONNECT-183).
+        """
+        from application_sdk.handler import service as svc_module
+
+        manifest_data = {
+            "execution_mode": "dag",
+            "dag": {
+                "extract": {
+                    "activity_name": "execute_workflow",
+                    "app_name": "dbt",
+                    "inputs": {"task_queue": "atlan-dbt-{deployment_name}"},
+                }
+            },
+        }
+        (tmp_path / "manifest.json").write_text(json.dumps(manifest_data))
+        monkeypatch.setenv("ATLAN_APPLICATION_NAME", "dbt-v3")
+        monkeypatch.setenv("ATLAN_DEPLOYMENT_NAME", "prod")
+
+        original_dir = svc_module.CONTRACT_GENERATED_DIR
+        svc_module.CONTRACT_GENERATED_DIR = tmp_path
+        try:
+            app = create_app_handler_service(
+                _TestHandler(), app_name="dbt", task_queue="atlan-dbt-v3-prod"
+            )
+            response = TestClient(app).get("/workflows/v1/manifest")
+            assert response.status_code == 200
+            served = response.json()["dag"]["extract"]["inputs"]["task_queue"]
+            assert served == "atlan-dbt-v3-prod"
+        finally:
+            svc_module.CONTRACT_GENERATED_DIR = original_dir
+
+    def test_manifest_unresolvable_app_name_keeps_the_token_visible(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """With no app name anywhere the route must not manufacture one: a literal
+        ``{app_name}`` is greppable, whereas ``atlan-default-prod`` reads as a real
+        queue and reproduces the original silent hang."""
+        from application_sdk.handler import service as svc_module
+
+        manifest_data = {
+            "execution_mode": "dag",
+            "dag": {
+                "extract": {
+                    "activity_name": "execute_workflow",
+                    "app_name": "{app_name}",
+                    "inputs": {"task_queue": "atlan-{app_name}-{deployment_name}"},
+                }
+            },
+        }
+        (tmp_path / "manifest.json").write_text(json.dumps(manifest_data))
+        monkeypatch.delenv("ATLAN_APPLICATION_NAME", raising=False)
+        monkeypatch.setenv("ATLAN_DEPLOYMENT_NAME", "prod")
+
+        original_dir = svc_module.CONTRACT_GENERATED_DIR
+        svc_module.CONTRACT_GENERATED_DIR = tmp_path
+        try:
+            # app_name="" so nothing is registered to fall back to either.
+            app = create_app_handler_service(_TestHandler(), app_name="")
+            response = TestClient(app).get("/workflows/v1/manifest")
+            assert response.status_code == 200
+            served = response.json()["dag"]["extract"]["inputs"]["task_queue"]
+            assert "{app_name}" in served
+            assert "default" not in served
+        finally:
+            svc_module.CONTRACT_GENERATED_DIR = original_dir
+
     def test_manifest_programmatic_takes_priority(self, tmp_path: Path) -> None:
         """When both programmatic and disk manifest exist, programmatic wins."""
         from application_sdk.handler import service as svc_module


### PR DESCRIPTION
## Problem

The Temporal task-queue name was computed **twice, independently**, by two code paths that must agree exactly and were not forced to:

1. the **worker**, via `main._derive_task_queue()`, reading `ATLAN_APPLICATION_NAME` / `ATLAN_DEPLOYMENT_NAME` and branching on truthiness;
2. the **served manifest**, whose resolved `task_queue` the Automation Engine writes into the DAG and therefore submits work to — token-filled from `atlan-{app_name}-{deployment_name}` at serve time.

When they disagree nothing fails loudly. AE submits to one queue, the worker polls another, and the run sits unclaimed until its 24h heartbeat backstop — [CONNECT-183](https://linear.app/atlan-epd/issue/CONNECT-183). The same gap stripped failure attribution in [HYP-1954](https://linear.app/atlan-epd/issue/HYP-1954), and has been independently hand-patched at least four times outside this repo (Heracles, native-migration-app, `atlan-local-marketplace-app` / [CONNECT-191](https://linear.app/atlan-epd/issue/CONNECT-191), `atlan-hightouch-app` / [ARUN-1039](https://linear.app/atlan-epd/issue/ARUN-1039)), plus one shipped double-prefix bug ([DISTR-834](https://linear.app/atlan-epd/issue/DISTR-834)) from a caller that prefixed an already-prefixed value.

Given `ATLAN_DEPLOYMENT_NAME=prod`, only the first row was safe:

| `ATLAN_APPLICATION_NAME` | Worker polls | Manifest resolved to | Agree? |
| -- | -- | -- | -- |
| `dbt` | `atlan-dbt-prod` | `atlan-dbt-prod` | yes |
| `dbt`, no deployment name | `dbt` (bare, unprefixed) | `atlan-dbt-default` | **no** |
| unset | `<ClassName>-queue` | `atlan-default-prod` | **no** |

The other two produce a plausible-looking queue name that nothing polls.

## Fix

**One derivation.** New `application_sdk/common/task_queue.py` holds the rule. `main._derive_task_queue`, the manifest-serve path, `create_app_handler_service`'s own `{app_name}-queue` default, and the e2e `agent_spec` mirror all route through it — four in-repo implementations collapsed to one.

**The manifest doesn't re-derive, it stamps.** Two paths deriving the same answer only agree while their inputs agree, and the inputs are exactly what drifts. The handler passes `resolve_manifest_tokens` the queue it was configured with — the same value `create_worker` receives, in both combined and split-deployment mode — and the served `task_queue` is stamped from it. That closes two cases plain re-derivation cannot reach:

- an explicit `ATLAN_TASK_QUEUE` / `--task-queue` override (no derivation reproduces it);
- a baked contract name that no longer matches the deployment's `ATLAN_APPLICATION_NAME` — the DISTR-834 / CONNECT-191 shape, where the manifest serves a plausible `atlan-dbt-prod` while the worker polls `atlan-dbt-v3-prod`.

**The hook's output is reconciled too, not just the static file.** `compute_manifest` *replaces* the manifest wholesale, so reconciling only the file on disk left everything the hook emitted unreconciled — and a bundle's marketplace entry points have their DAG computed per submission by exactly that hook, i.e. the guarantee was missing for the population it exists for. The pre-hook pass stays (the hook should see resolved values it may key on) and the second pass is idempotent. It catches unresolved *tokens*, not a hook that hardcodes a concrete-but-wrong queue — that has no token to match, and normalising every `atlan-*` queue would rewrite the legitimate cross-app dispatch nodes below; #3094's O005 is the guard for that shape.

**The queue template is matched as a unit**, not token-filled. Filling `{app_name}` and `{deployment_name}` separately *is* the divergence: with no deployment name the worker drops the prefix and polls a bare `<app>`, while filling in place yields `atlan-<app>-local`.

**The unset case stays loud.** `constants.APPLICATION_NAME`'s `"default"` is now documented as scoped to *identity* uses (object-store prefixes like `persistent-artifacts/apps/<name>/`, log tagging) where a missing segment would break paths — and excluded from queue naming, since `atlan-default-prod` reads as a legitimate queue, is polled by nobody, and reproduces the original hang. Loudness is graded, because one token hides two different failures:

- an `{app_name}` the SDK can fill from the registered app name (what the toolkit *would* have baked) is filled and logged at **WARNING** — the response is correct, but the app's committed manifest is stale and the next writer of that DAG gets no backstop;
- with nothing to fill it from, the literal token is served and logged at **ERROR**. A literal `{app_name}` in the DAG is greppable and diagnosable in one step.

## Deliberately preserved

- `{ClassName}-queue` when no app name exists — it predates the env-var convention and is load-bearing for local dev. The manifest now stamps that same queue, so a local full-DAG run lands where the local worker actually polls.
- DAG nodes dispatching to **another app's** queue (`atlan-publish-{deployment_name}`, and the QI / popularity / lineage nodes in `App.pkl`) are token-filled and otherwise left alone — not normalised, and not warned about, since a warning there would fire on every correct multi-app DAG.
- The `{deployment_name}` token's existing fallback for non-queue uses.

## Not in this PR

No contract-toolkit change. Both baking the fully-derived value and the inverse (a single `{task_queue}` token the SDK resolves) change the manifest wire format, and the four out-of-repo consumers that hand-patched this gap substitute `{app_name}` / `{deployment_name}` themselves — emitting a token they don't know about breaks them. That's a coordinated cross-repo rollout, not a line here. Keeping the wire format and moving reconciliation into the serve path gets the same guarantee with no downstream break; worth revisiting once those consumers are retired.

## Relationship to open PRs

- **#3097** — closed as superseded. Its substitution used `constants.APPLICATION_NAME`, which manufactures `"default"` for the unset case; the equivalent substitution here prefers the registered app name and refuses to invent one. The one thing it covered that this PR had missed — the programmatic-manifest branch — is now folded in (see the test plan below), and its #2270 → #2271 → #2478 rationale for why a runtime fill exists alongside the toolkit's bake is preserved in `common/task_queue.py`'s module docstring.
- **#3090** — no behavioural conflict (input-contract resolution for bundle entrypoints; input contracts carry no `task_queue`). Merge it first: it unblocks a production break and should not wait on this hardening PR, and since it dropped its bare-manifest disk glob in review its only remaining overlap here is a blank-line deletion beside a line this PR edits — a trivial rebase, and mine to absorb rather than its author's. Correcting an earlier version of this bullet: with that glob dropped, a bare `/manifest` on a bundle no longer serves a `compute_manifest`-computed DAG, so #3090 does **not** widen traffic through the hook path. The hook-output reconciliation below stands on its own for apps called with an explicit `?entrypoint=`, which is how AE submits.
- **#3094** (conformance O005) still applies unchanged as the guard on new hand-authored templates.

## Test plan

- [x] 23 new tests in `tests/unit/common/test_task_queue.py`, written to assert **equality between the worker and manifest paths** rather than two independently hard-coded expectations — so a future change to the rule can't satisfy one side and quietly break the other. Covers all three rows of the table, both the un-baked and toolkit-baked template shapes, the explicit-override and baked-name-disagrees cases, and the residual-token behaviour.
- [x] 6 route-level regressions in `tests/unit/handler/test_service.py`: served queue matches the configured worker queue when the baked name disagrees with env, and unresolvable `{app_name}` keeps the literal token and never manufactures `default` — each asserted on **all three** manifest sources: the disk path, the **programmatic** `AppManifest` path (which previously served `model_dump_json()` verbatim), and the **`compute_manifest` output** (which previously discarded the reconciled bytes via `raw = orjson.dumps(computed)`). The two hook tests were both checked against the pre-change code and fail there; the unresolvable-name one asserts the graded outcome — deployment token filled, `{app_name}` left visible — since asserting only the surviving token would also pass against a build that never reconciles hook output.
- [x] `uv run pytest tests/unit` — 6369 passed, 9 skipped
- [x] Conformance suite — exit 0, no findings in the new or changed files
- [x] `uv run pre-commit run --files …` (ruff, ruff-format, isort, pyright) — clean

Closes FND-195.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



