### PR TITLE
ci(conformance): exclude lock-file churn from the generated release changelog

### DIFF
--- a/.github/scripts/conformance_release.py
+++ b/.github/scripts/conformance_release.py
@@ -9,7 +9,8 @@ Usage:
     python conformance_release.py
 
 Exits 0 with "skip=true" written to GITHUB_OUTPUT when there are no
-unreleased commits touching packages/conformance/**. Exits non-zero on error.
+unreleased commits touching packages/conformance/** (lock files excluded — see
+PATHSPEC below). Exits non-zero on error.
 
 Environment:
     GITHUB_OUTPUT      - path to the GitHub Actions output file (optional for
@@ -29,7 +30,22 @@ VERSION_PY = "packages/conformance/conformance/__init__.py"
 CHANGELOG = "packages/conformance/CHANGELOG.md"
 RELEASE_NOTES_FILE = "/tmp/conformance-release-notes.md"
 TAG_PREFIX = "conformance-v"
-PATH_FILTER = "packages/conformance/**"
+PACKAGE_DIR = "packages/conformance"
+
+# Lock files under the package are regenerated wholesale by Renovate's
+# lockFileMaintenance and are not shipped in the wheel, so a commit that touches
+# nothing else is pure changelog noise — and on its own it was enough to count as
+# an "unreleased conformance commit" and trigger a version bump. Excluding them by
+# path rather than by commit subject keeps mixed commits intact: a PR that changes
+# a rule *and* refreshes uv.lock still appears. Real dependency changes move
+# packages/conformance/pyproject.toml, which stays in scope.
+# The `glob` magic makes `**/` match zero or more directories, so these cover both
+# packages/conformance/uv.lock and packages/conformance/conformance/package-lock.json.
+LOCK_FILES = ("uv.lock", "package-lock.json")
+PATHSPEC = [
+    f"{PACKAGE_DIR}/**",
+    *(f":(exclude,glob){PACKAGE_DIR}/**/{name}" for name in LOCK_FILES),
+]
 
 
 # ---------------------------------------------------------------------------
@@ -68,7 +84,7 @@ def tag_exists(tag):
 
 
 def commits_since_tag(tag):
-    """Return (subjects, bodies) for commits since tag touching packages/conformance/**."""
+    """Return (subjects, bodies) for commits since tag touching PATHSPEC."""
     subjects = _run(
         [
             "git",
@@ -76,7 +92,7 @@ def commits_since_tag(tag):
             f"{tag}..HEAD",
             "--format=%s",
             "--",
-            PATH_FILTER,
+            *PATHSPEC,
         ]
     )
     bodies = _run(
@@ -86,7 +102,7 @@ def commits_since_tag(tag):
             f"{tag}..HEAD",
             "--format=%B",
             "--",
-            PATH_FILTER,
+            *PATHSPEC,
         ]
     )
     return subjects, bodies
@@ -124,7 +140,7 @@ def get_commits(tag):
             f"{tag}..HEAD",
             "--format=%H%x00%s%x00%b%x1e",
             "--",
-            PATH_FILTER,
+            *PATHSPEC,
         ]
     )
     commits = []

--- a/.github/scripts/tests/test_conformance_release.py
+++ b/.github/scripts/tests/test_conformance_release.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import subprocess
 import sys
 from datetime import date
 from pathlib import Path
@@ -563,3 +564,153 @@ class TestUpdateVersionPy:
         monkeypatch.setattr(conformance_release, "VERSION_PY", str(p))
         with pytest.raises(SystemExit):
             conformance_release.update_version_py("1.0.0", "2.0.0")
+
+
+# ---------------------------------------------------------------------------
+# PATHSPEC — integration via a real temp git repo
+#
+# The lock-file exclusion depends on git pathspec magic (`:(exclude,glob)`), so
+# it can only be verified against real git — a stubbed _run would just assert
+# that we pass the strings we wrote.
+# ---------------------------------------------------------------------------
+
+BASE_TAG = "conformance-v0.1.0"
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.check_call(
+        ["git", *args],
+        cwd=repo,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+
+def _commit(repo: Path, subject: str, files: dict[str, str]) -> None:
+    for rel, content in files.items():
+        path = repo / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content)
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", subject)
+
+
+@pytest.fixture
+def git_repo(tmp_path: Path) -> Path:
+    """A temp repo with commits after conformance-v0.1.0 covering every case.
+
+    Included (real package content):
+      - feat(conformance): add O007 rule       — rule source
+      - chore(deps): bump ruff                 — package pyproject.toml
+      - fix(conformance): tighten O007         — rule source *and* uv.lock (mixed)
+
+    Excluded (noise):
+      - chore(deps): lock file maintenance     — packages/conformance/uv.lock only
+      - chore(deps): refresh npm lock          — nested package-lock.json only
+      - chore(deps): root lock                 — outside packages/conformance
+    """
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "test@example.com")
+    _git(tmp_path, "config", "user.name", "Test")
+    _git(tmp_path, "config", "commit.gpgsign", "false")
+
+    _commit(tmp_path, "chore: initial commit", {"README.md": "init\n"})
+    _git(tmp_path, "tag", BASE_TAG)
+
+    _commit(
+        tmp_path,
+        "feat(conformance): add O007 rule",
+        {"packages/conformance/conformance/rules/o007.py": "rule\n"},
+    )
+    _commit(
+        tmp_path,
+        "chore(deps): lock file maintenance",
+        {"packages/conformance/uv.lock": "lock-1\n"},
+    )
+    _commit(
+        tmp_path,
+        "chore(deps): refresh npm lock",
+        {"packages/conformance/conformance/package-lock.json": "{}\n"},
+    )
+    _commit(
+        tmp_path,
+        "chore(deps): root lock",
+        {"uv.lock": "root-lock\n"},
+    )
+    _commit(
+        tmp_path,
+        "chore(deps): bump ruff",
+        {"packages/conformance/pyproject.toml": 'version = "0.1.0"\n'},
+    )
+    _commit(
+        tmp_path,
+        "fix(conformance): tighten O007",
+        {
+            "packages/conformance/conformance/rules/o007.py": "rule-2\n",
+            "packages/conformance/uv.lock": "lock-2\n",
+        },
+    )
+    return tmp_path
+
+
+class TestPathspecExclusions:
+    def test_lock_only_commits_are_excluded(
+        self, git_repo: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(git_repo)
+        subjects, _bodies = conformance_release.commits_since_tag(BASE_TAG)
+        assert "lock file maintenance" not in subjects
+        assert "refresh npm lock" not in subjects
+        assert "root lock" not in subjects
+
+    def test_package_content_commits_are_kept(
+        self, git_repo: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(git_repo)
+        subjects, _bodies = conformance_release.commits_since_tag(BASE_TAG)
+        assert "feat(conformance): add O007 rule" in subjects
+        assert "chore(deps): bump ruff" in subjects
+
+    def test_mixed_commit_touching_a_lock_file_is_kept(
+        self, git_repo: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A commit that changes real files *and* a lock file must still appear."""
+        monkeypatch.chdir(git_repo)
+        subjects, _bodies = conformance_release.commits_since_tag(BASE_TAG)
+        assert "fix(conformance): tighten O007" in subjects
+
+    def test_get_commits_applies_the_same_exclusions(
+        self, git_repo: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The changelog walk and the bump walk must agree on what counts."""
+        monkeypatch.chdir(git_repo)
+        subjects = [
+            subject
+            for _sha, subject, _body in conformance_release.get_commits(BASE_TAG)
+        ]
+        assert subjects == [
+            "fix(conformance): tighten O007",
+            "chore(deps): bump ruff",
+            "feat(conformance): add O007 rule",
+        ]
+
+    def test_lock_only_history_yields_no_release(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Pure lock churn must not count as an unreleased commit (skip=true)."""
+        _git(tmp_path, "init")
+        _git(tmp_path, "config", "user.email", "test@example.com")
+        _git(tmp_path, "config", "user.name", "Test")
+        _git(tmp_path, "config", "commit.gpgsign", "false")
+        _commit(tmp_path, "chore: initial commit", {"README.md": "init\n"})
+        _git(tmp_path, "tag", BASE_TAG)
+        _commit(
+            tmp_path,
+            "chore(deps): lock file maintenance",
+            {"packages/conformance/uv.lock": "lock\n"},
+        )
+
+        monkeypatch.chdir(tmp_path)
+        subjects, bodies = conformance_release.commits_since_tag(BASE_TAG)
+        assert not subjects.strip()
+        assert not bodies.strip()

--- a/.github/workflows/conformance-release.yml
+++ b/.github/workflows/conformance-release.yml
@@ -6,6 +6,10 @@ name: Release Conformance Package
 # the last conformance-v* tag), bumps pyproject.toml + __init__.py, prepends a
 # new entry to packages/conformance/CHANGELOG.md, and creates or updates the
 # bump-version-conformance PR labeled release:conformance.
+# The script excludes lock files from that walk (see PATHSPEC), so a Renovate
+# lockFileMaintenance merge still fires this workflow — the paths filter below
+# can't express the exclusion — but the script no-ops with skip=true instead of
+# minting a release whose only content is lock churn.
 # Merging that PR triggers Publish Conformance Package (conformance-publish.yml),
 # which handles the PyPI publish and tag.
 


### PR DESCRIPTION
## Problem

Every Renovate `chore(deps): lock file maintenance` commit shows up in the generated conformance changelog (see the "Other changes" section of any recent conformance release PR). It's pure noise.

`.github/scripts/conformance_release.py` built both the version bump and the CHANGELOG block from:

```
git log <last conformance tag>..HEAD -- packages/conformance/**
```

Renovate's `lockFileMaintenance` PRs touch `packages/conformance/uv.lock` and `packages/conformance/conformance/package-lock.json`, so every one of them matched that filter. Two consequences:

1. They filled the changelog's "Other changes" section.
2. A lock-file-only merge counted as an unreleased conformance commit all on its own — enough to mint a release whose only content was lock churn.

## Fix

Exclude lock files from the pathspec:

```python
LOCK_FILES = ("uv.lock", "package-lock.json")
PATHSPEC = [
    f"{PACKAGE_DIR}/**",
    *(f":(exclude,glob){PACKAGE_DIR}/**/{name}" for name in LOCK_FILES),
]
```

Applied at all three `git log` call sites (`commits_since_tag` ×2, `get_commits`), so the bump walk and the changelog walk stay in agreement.

Excluding by **path** rather than by commit subject is deliberate:

- A mixed PR that changes a rule *and* refreshes `uv.lock` still appears.
- Real dependency changes still appear — they move `packages/conformance/pyproject.toml`, which stays in scope.
- Lock files are not shipped in the wheel, so nothing user-visible is being hidden.

This differs from the `_SUBPKG_RE` subject-line filter in `release.py`, which exists there because path-only exclusion can't cover a squash commit spanning the SDK and a sub-package. Here the mixed case *should* be kept, so no subject filter is needed.

## Effect

Over the current unreleased window (`conformance-v0.17.0..HEAD`): **50 commits → 17**. All 33 dropped are `chore(deps): lock file maintenance`.

## Tests

New `TestPathspecExclusions` builds a real temp git repo — the behaviour depends on git's `:(exclude,glob)` pathspec semantics, which a stubbed `_run` cannot exercise. It covers:

- lock-file-only commits excluded (package-level, nested, and outside the package)
- rule-source and `pyproject.toml` commits kept
- mixed rule + `uv.lock` commit kept
- `get_commits` and `commits_since_tag` agreeing
- lock-only history producing no release (`skip=true`)

54 tests pass in `.github/scripts/tests/test_conformance_release.py`.

## Follow-up after merge

This PR touches `.github/**`, not `packages/conformance/**`, so it won't re-trigger the release workflow. To clean the currently-open conformance release PR, run **Release Conformance Package** via `workflow_dispatch` — it force-pushes `bump-version-conformance` with a regenerated changelog block.

Already-released sections (0.17.0 and older) keep their existing entries; scrubbing those would mean hand-editing `CHANGELOG.md`, which the repo rule forbids and which rewrites published release notes.

## Not changed

- `contract_toolkit_release.py` — `contract-toolkit/` contains no lock files, so the exclusion would be dead code.
- Root `CHANGELOG.md` — `update_changelog.py` collects a `chores` category but never renders it, so the SDK changelog was never affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
