### PR TITLE
ci(fix): report the connector's Tests Gate verdict on the dispatching SDK PR

### DIFF
--- a/.github/actions/secure-build-push-apps/action.yaml
+++ b/.github/actions/secure-build-push-apps/action.yaml
@@ -187,8 +187,16 @@ runs:
         no-cache: ${{ inputs.no-cache }}
         no-cache-filters: ${{ inputs.no-cache-filters }}
         outputs: ${{ inputs.outputs }}
-        # Build only for the runner's native platform for scanning
-        platforms: linux/amd64
+        # Build only for the runner's native platform for scanning.
+        #
+        # Derived from `runner.arch` rather than hardcoded to linux/amd64, which
+        # is what this said while claiming to be native. Every caller ran on an
+        # x64 runner, so the two agreed and the lie was invisible — until a
+        # caller moved a leg to `ubuntu-24.04-arm`, where the hardcode silently
+        # builds amd64 under QEMU for the scan and then scans an image that is
+        # not the one being pushed. A step-level expression, not conditional
+        # shell, so it stays within docs/standards/ci.md.
+        platforms: ${{ runner.arch == 'ARM64' && 'linux/arm64' || 'linux/amd64' }}
         provenance: ${{ inputs.provenance }}
         pull: ${{ inputs.pull }}
         sbom: ${{ inputs.sbom }}

--- a/.github/actions/verify-test-gate/action.yaml
+++ b/.github/actions/verify-test-gate/action.yaml
@@ -36,6 +36,30 @@ inputs:
   discover-e2e-result:
     description: needs.discover-e2e.result (skipped = e2e not requested).
     required: true
+  build-e2e-image-result:
+    description: |
+      needs.build-e2e-image.result (the per-arch image matrix). It gates the
+      manifest merge, which gates prepare-tenant, which gates the e2e matrix —
+      so a failure here drops e2e to a skip and must fail the gate rather than
+      read as "e2e not requested". "skipped" (install path off, or e2e not
+      requested) and "success" are passes. Optional, defaulting to "skipped",
+      so callers pinned at @main keep working before they wire it.
+    required: false
+    default: skipped
+  merge-e2e-image-result:
+    description: |
+      needs.merge-e2e-image.result (combines the per-arch images into the
+      manifest list the tenant pulls). Same reasoning and same default as
+      build-e2e-image-result.
+    required: false
+    default: skipped
+  prepare-tenant-result:
+    description: |
+      needs.prepare-tenant.result (installs the image under test onto each
+      cloud's tenant). The last of the three install-path jobs the e2e matrix
+      gates on. Same reasoning and same default as build-e2e-image-result.
+    required: false
+    default: skipped
   e2e-result:
     description: needs.e2e.result (matrix aggregate; skipped = not requested).
     required: true
@@ -44,6 +68,12 @@ outputs:
   passed:
     description: '"true" when every required job passed, else "false".'
     value: ${{ steps.gate.outputs.passed }}
+  conclusion:
+    description: |
+      The same verdict as `passed`, spelled as a GitHub Checks API conclusion
+      ("success" / "failure"). Lets the cross-repo callback complete the SDK-side
+      check run from this action directly, instead of re-deriving the verdict.
+    value: ${{ steps.gate.outputs.conclusion }}
   unit-status:
     description: Human-readable status for the unit row.
     value: ${{ steps.gate.outputs.unit-status }}
@@ -70,6 +100,9 @@ runs:
         DETECT_INTEGRATION_RESULT: ${{ inputs.detect-integration-result }}
         DETECT_MERGE_QUEUE_RESULT: ${{ inputs.detect-merge-queue-result }}
         DISCOVER_E2E_RESULT: ${{ inputs.discover-e2e-result }}
+        BUILD_E2E_IMAGE_RESULT: ${{ inputs.build-e2e-image-result }}
+        MERGE_E2E_IMAGE_RESULT: ${{ inputs.merge-e2e-image-result }}
+        PREPARE_TENANT_RESULT: ${{ inputs.prepare-tenant-result }}
         E2E_RESULT: ${{ inputs.e2e-result }}
       run: |
         set -euo pipefail
@@ -79,4 +112,7 @@ runs:
           --detect-integration "$DETECT_INTEGRATION_RESULT" \
           --detect-merge-queue "$DETECT_MERGE_QUEUE_RESULT" \
           --discover-e2e "$DISCOVER_E2E_RESULT" \
+          --build-e2e-image "$BUILD_E2E_IMAGE_RESULT" \
+          --merge-e2e-image "$MERGE_E2E_IMAGE_RESULT" \
+          --prepare-tenant "$PREPARE_TENANT_RESULT" \
           --e2e "$E2E_RESULT" >> "$GITHUB_OUTPUT"

--- a/.github/actions/verify-test-gate/verify_test_gate.py
+++ b/.github/actions/verify-test-gate/verify_test_gate.py
@@ -5,6 +5,15 @@ driver is both the pass/fail authority AND the source of the human-readable
 status strings the PR "Tests Summary" table shows, so the displayed status and
 the enforced result can never drift.
 
+It is also the authority for the CROSS-REPO callback: tests-reusable's
+report-to-sdk job completes the ``Connector E2E run / <app>`` check run on the
+dispatching application-sdk PR using this driver's ``conclusion`` output. That
+matters because it used to compute its own verdict from a strictly smaller set
+of job results (no discover-e2e, no anomaly rule), so a connector run whose
+Tests Gate was red could still report green on the SDK side — a failure in the
+triggered app invisible to the PR that triggered it. One driver, two consumers,
+no second implementation to drift.
+
 Gate passes iff:
 
   * ``unit`` tests succeeded (the per-commit tier; runs on every event), AND
@@ -23,6 +32,9 @@ Gate passes iff:
     when the connector ships no integration suite), AND
   * e2e discovery succeeded OR was skipped (skipped = e2e not requested; a
     *failed* discovery means e2e was requested but no suites were found), AND
+  * the per-arch e2e image build, the manifest merge and the tenant install
+    succeeded OR were skipped (skipped = the install path is off, or e2e was
+    not requested), AND
   * the e2e matrix succeeded OR was skipped (matrix aggregate is success only
     if every leg passed).
 
@@ -34,10 +46,21 @@ legitimate) and ``integration`` then skips cleanly, so there is no analogous
 ``detect-integration == success and integration == skipped`` check — that pair
 is the normal no-suite path.
 
-It emits GitHub Actions outputs (``passed`` + per-row/overall status strings)
-and, when failing, ``::error::`` annotations. It does NOT exit non-zero — the
-gate job enforces via a branch-free ``if: ... outputs.passed != 'true'`` step,
-keeping conditional logic out of inline shell per ``docs/standards/ci.md``.
+The three install-path jobs are checked for the same reason the detection jobs
+are: ``build-e2e-image``, ``merge-e2e-image`` and ``prepare-tenant`` are exactly
+the jobs the e2e matrix's own ``if`` gates on, so a failure in any of them drops
+the matrix to a skip. The anomaly rule above already refused to green that, but
+it named the symptom ("matrix skipped") rather than the cause ("the arm64 image
+build failed") — which is precisely what made the first real occurrence take a
+reading of four workflow files to explain. Checking them directly puts the cause
+in the annotation, and the anomaly rule then fires only when nothing upstream
+explains the skip.
+
+It emits GitHub Actions outputs (``passed`` + ``conclusion`` + per-row/overall
+status strings) and, when failing, ``::error::`` annotations. It does NOT exit
+non-zero — the gate job enforces via a branch-free
+``if: ... outputs.passed != 'true'`` step, keeping conditional logic out of
+inline shell per ``docs/standards/ci.md``.
 
 Co-located with the composite action (checked out with it in consumer repos).
 """
@@ -52,6 +75,27 @@ import sys
 _OK_OPTIONAL = ("success", "skipped")
 
 
+def _install_path(
+    build_e2e_image: str, merge_e2e_image: str, prepare_tenant: str
+) -> list[tuple[str, str, str]]:
+    """The jobs between discovery and the e2e matrix, in order.
+
+    Each entry is (annotation phrase, summary-row phrase, result). One list so
+    ``evaluate`` and ``_e2e_status`` cannot disagree about which jobs belong to
+    this leg, about their order, or about which one a reader is pointed at when
+    several fail together.
+    """
+    return [
+        ("the e2e image build", "e2e image build", build_e2e_image),
+        (
+            "the e2e image manifest merge",
+            "e2e image manifest merge",
+            merge_e2e_image,
+        ),
+        ("the tenant install", "Tenant install", prepare_tenant),
+    ]
+
+
 def evaluate(
     unit: str,
     integration: str,
@@ -59,12 +103,18 @@ def evaluate(
     discover_e2e: str,
     e2e: str,
     detect_merge_queue: str = "skipped",
+    build_e2e_image: str = "skipped",
+    merge_e2e_image: str = "skipped",
+    prepare_tenant: str = "skipped",
 ) -> list[str]:
     """Return human-readable failure reasons (empty ⇒ the gate passes).
 
-    ``detect_merge_queue`` is last and defaults to "skipped" because this driver
-    is consumed cross-repo via ``@main``: a required positional would break every
-    caller the instant it merged, before their workflows could update.
+    ``detect_merge_queue`` and the three install-path results are trailing and
+    default to "skipped" because this driver is consumed cross-repo via
+    ``@main``: a required positional would break every caller the instant it
+    merged, before their workflows could update. "skipped" is the neutral
+    default in every case — it is what a caller that does not run the job at
+    all would report.
     """
     errors: list[str] = []
     if unit != "success":
@@ -92,13 +142,35 @@ def evaluate(
         errors.append(f"integration tests did not succeed (result={integration})")
     if discover_e2e not in _OK_OPTIONAL:
         errors.append(f"e2e discovery did not succeed (result={discover_e2e})")
+    # The install path, in order. These are exactly the jobs the e2e matrix's own
+    # `if` gates on, so a failure in any of them silently drops the matrix to a
+    # skip. Named directly so the annotation reports the cause rather than the
+    # downstream symptom.
+    for annotation, _row, result in _install_path(
+        build_e2e_image, merge_e2e_image, prepare_tenant
+    ):
+        if result not in _OK_OPTIONAL:
+            errors.append(f"{annotation} did not succeed (result={result})")
     if e2e not in _OK_OPTIONAL:
         errors.append(f"one or more e2e suites did not succeed (result={e2e})")
     # Defensive: a successful discovery means suites exist (discover-e2e fails on
     # count=0), so the matrix should have run. A skipped matrix here is an
     # anomaly — this driver is consumed cross-repo via @main, so don't let a
     # future caller that re-wires the e2e `if` green the gate by skipping it.
-    if discover_e2e == "success" and e2e == "skipped":
+    #
+    # Suppressed when an install-path job already failed: that IS the explanation
+    # for the skip, and it is reported above with the failing job named. Firing
+    # both would bury the cause under the symptom.
+    if (
+        discover_e2e == "success"
+        and e2e == "skipped"
+        and all(
+            result in _OK_OPTIONAL
+            for _annotation, _row, result in _install_path(
+                build_e2e_image, merge_e2e_image, prepare_tenant
+            )
+        )
+    ):
         errors.append(
             "e2e discovery succeeded (suites found) but the matrix was skipped"
         )
@@ -133,11 +205,26 @@ def _integration_status(
     return "❌ Failed"
 
 
-def _e2e_status(discover_e2e: str, e2e: str) -> str:
+def _e2e_status(
+    discover_e2e: str,
+    e2e: str,
+    build_e2e_image: str = "skipped",
+    merge_e2e_image: str = "skipped",
+    prepare_tenant: str = "skipped",
+) -> str:
     if discover_e2e == "skipped":
         return "⊘ Skipped — add `e2e` label to trigger"
     if discover_e2e == "failure":
         return "❌ No suites discovered (e2e was requested)"
+    # Ahead of the success/skip checks: an install-path failure is WHY the matrix
+    # skipped, and the row must say so rather than report a benign skip. Reported
+    # in the same order and with the same labels as the annotations, from the one
+    # list, so the row and the error text always name the same job.
+    for _annotation, row, result in _install_path(
+        build_e2e_image, merge_e2e_image, prepare_tenant
+    ):
+        if result not in _OK_OPTIONAL:
+            return f"❌ {row} failed"
     if e2e == "success":
         return "✅ Passed"
     if discover_e2e == "success" and e2e == "skipped":
@@ -154,18 +241,39 @@ def render(
     discover_e2e: str,
     e2e: str,
     detect_merge_queue: str = "skipped",
+    build_e2e_image: str = "skipped",
+    merge_e2e_image: str = "skipped",
+    prepare_tenant: str = "skipped",
 ) -> dict[str, str]:
-    """Compute the gate's outputs: pass/fail + the display status strings."""
+    """Compute the gate's outputs: pass/fail + the display status strings.
+
+    ``conclusion`` is the same verdict as ``passed``, spelled as a GitHub Checks
+    API conclusion. It exists so the cross-repo callback can wire this driver
+    straight into ``complete_check_run.py --conclusion`` — mapping true/false to
+    success/failure in workflow YAML would put the decision back outside the one
+    tested authority, which is the drift this driver exists to prevent.
+    """
     errors = evaluate(
-        unit, integration, detect_integration, discover_e2e, e2e, detect_merge_queue
+        unit,
+        integration,
+        detect_integration,
+        discover_e2e,
+        e2e,
+        detect_merge_queue,
+        build_e2e_image,
+        merge_e2e_image,
+        prepare_tenant,
     )
     return {
         "passed": "true" if not errors else "false",
+        "conclusion": "success" if not errors else "failure",
         "unit-status": _unit_status(unit),
         "integration-status": _integration_status(
             integration, detect_integration, detect_merge_queue
         ),
-        "e2e-status": _e2e_status(discover_e2e, e2e),
+        "e2e-status": _e2e_status(
+            discover_e2e, e2e, build_e2e_image, merge_e2e_image, prepare_tenant
+        ),
         "overall-status": "✅ All passed" if not errors else "❌ Some failed",
     }
 
@@ -190,6 +298,22 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--discover-e2e", required=True, help="needs.discover-e2e.result"
     )
+    # Optional for the same cross-repo reason as --detect-merge-queue above.
+    parser.add_argument(
+        "--build-e2e-image",
+        default="skipped",
+        help="needs.build-e2e-image.result",
+    )
+    parser.add_argument(
+        "--merge-e2e-image",
+        default="skipped",
+        help="needs.merge-e2e-image.result",
+    )
+    parser.add_argument(
+        "--prepare-tenant",
+        default="skipped",
+        help="needs.prepare-tenant.result",
+    )
     parser.add_argument("--e2e", required=True, help="needs.e2e.result")
     args = parser.parse_args(sys.argv[1:] if argv is None else argv)
 
@@ -202,6 +326,9 @@ def main(argv: list[str] | None = None) -> int:
         args.discover_e2e,
         args.e2e,
         args.detect_merge_queue,
+        args.build_e2e_image,
+        args.merge_e2e_image,
+        args.prepare_tenant,
     ):
         print(f"::error::{reason}", file=sys.stderr)
 
@@ -212,6 +339,9 @@ def main(argv: list[str] | None = None) -> int:
         args.discover_e2e,
         args.e2e,
         args.detect_merge_queue,
+        args.build_e2e_image,
+        args.merge_e2e_image,
+        args.prepare_tenant,
     ).items():
         print(f"{key}={value}")
     return 0

--- a/.github/scripts/build_callback_summary.py
+++ b/.github/scripts/build_callback_summary.py
@@ -1,16 +1,33 @@
 #!/usr/bin/env python3
-"""Determine the check-run conclusion + summary body for the cross-repo e2e
-callback (tests-reusable.yaml's report-to-sdk job).
+"""Build the summary body for the cross-repo e2e callback (tests-reusable.yaml's
+report-to-sdk job).
 
-Moved out of an inlined `run:` block per docs/standards/ci.md: deciding the
-conclusion and picking which summary file to use are both branches, which
-belong in a tested driver rather than workflow YAML.
+Moved out of an inlined `run:` block per docs/standards/ci.md: picking which
+summary file to use is a branch, which belongs in a tested driver rather than
+workflow YAML.
 
 Prefers the e2e leg's already-rendered report (asset/lineage tables etc.,
 written by sdr-e2e's PR-comment step) over a plain fallback, which only
 applies when e2e was skipped or its artifact never materialised.
 
-Writes conclusion=<success|failure> and summary_file=<path> to $GITHUB_OUTPUT.
+`determine_conclusion` is NO LONGER the callback's verdict. It decided the
+conclusion from a strict subset of the Tests Gate's inputs — no discover-e2e,
+no image-build legs, no "discovery found suites but the matrix skipped" anomaly
+rule — so a connector run whose Tests Gate was red reported success on the
+dispatching SDK PR, which is the whole reason a triggered app's failure could go
+unnoticed there. The gate driver
+(.github/actions/verify-test-gate/verify_test_gate.py) is now the single
+authority for both, and report-to-sdk reads its `conclusion` output instead.
+
+It survives here only as a transitional shim: this script is checked out from
+the DISPATCHING SDK ref while the workflow always comes from `main`, so a
+pre-fix `main` workflow can still be pairing itself with a post-fix copy of this
+script and reading `conclusion=` out of $GITHUB_OUTPUT. Delete it — along with
+the `conclusion=` output line and its tests — in the next release after this
+lands on `main`, once no `main` workflow reads it.
+
+Writes conclusion=<success|failure> (deprecated, see above) and
+summary_file=<path> to $GITHUB_OUTPUT.
 """
 
 from __future__ import annotations
@@ -36,6 +53,13 @@ def determine_conclusion(
     detect_integration_result: str,
     e2e_result: str,
 ) -> str:
+    """DEPRECATED — the Tests Gate driver decides the callback's conclusion.
+
+    Kept only so a pre-fix `main` workflow paired with a post-fix copy of this
+    script still gets a `conclusion=` output. See the module docstring for the
+    removal trigger. Do not add inputs here: fix the gate driver instead, or the
+    two verdicts start diverging again.
+    """
     if (
         unit_result == "success"
         and detect_integration_result in PASSING_DETECT_INTEGRATION_RESULTS

--- a/.github/scripts/tests/test_build_app_image_action.py
+++ b/.github/scripts/tests/test_build_app_image_action.py
@@ -461,25 +461,30 @@ def _pull_request_workflow() -> dict:  # type: ignore[type-arg]
     )
 
 
+def _sdk_base_job() -> dict:  # type: ignore[type-arg]
+    return _pull_request_workflow()["jobs"]["build-sdk-base-image"]
+
+
 def _sdk_base_build_step() -> dict:  # type: ignore[type-arg]
-    job = _pull_request_workflow()["jobs"]["build-sdk-base-image"]
     return next(
-        s for s in job["steps"] if "secure-build-push-apps" in str(s.get("uses", ""))
+        s
+        for s in _sdk_base_job()["steps"]
+        if "secure-build-push-apps" in str(s.get("uses", ""))
     )
 
 
+def _legs(job: dict) -> dict:  # type: ignore[type-arg]
+    return {leg["arch"]: leg for leg in job["strategy"]["matrix"]["include"]}
+
+
 def test_the_pr_base_image_serves_every_arch_the_connector_matrix_builds() -> None:
-    """Derived from the matrix, not hardcoded, so adding a third architecture
-    cannot silently leave the base behind."""
+    """Both matrices are read from the YAML, so adding a third architecture to
+    the app image cannot silently leave the base behind."""
     consumed = {
         leg["platform"]
-        for leg in _reusable()["jobs"]["build-e2e-image"]["strategy"]["matrix"][
-            "include"
-        ]
+        for leg in _legs(_reusable()["jobs"]["build-e2e-image"]).values()
     }
-    published = {
-        p.strip() for p in _sdk_base_build_step()["with"]["platforms"].split(",")
-    }
+    published = {leg["platform"] for leg in _legs(_sdk_base_job()).values()}
 
     missing = consumed - published
     assert not missing, (
@@ -491,10 +496,81 @@ def test_the_pr_base_image_serves_every_arch_the_connector_matrix_builds() -> No
     )
 
 
+def test_the_base_image_legs_are_native_like_the_app_image_legs() -> None:
+    # Same property test_each_architecture_builds_on_a_runner_native_to_it pins
+    # for the app image, and it fails just as silently here: an emulated leg
+    # still succeeds, only slower, on a path that runs on every e2e-labelled PR.
+    job = _sdk_base_job()
+    assert job["runs-on"] == "${{ matrix.runner }}"
+    legs = _legs(job)
+    for arch, leg in legs.items():
+        assert leg["platform"] == f"linux/{arch}"
+    assert "arm" in legs["arm64"]["runner"]
+    assert "arm" not in legs["amd64"]["runner"]
+
+
+def test_the_base_image_legs_do_not_collide_in_the_tag_or_the_cache() -> None:
+    # The action defaults to an unscoped `type=gha`, so without an explicit
+    # per-arch scope the two legs overwrite each other's cache manifest and both
+    # go cold on every later run — silently.
+    with_ = _sdk_base_build_step()["with"]
+    assert with_["tags"].endswith("-${{ matrix.arch }}")
+    assert with_["platforms"] == "${{ matrix.platform }}"
+    assert "${{ matrix.arch }}" in with_["cache-from"]
+    assert "${{ matrix.arch }}" in with_["cache-to"]
+
+
 def test_the_base_image_build_is_reached_through_the_scanning_action() -> None:
-    # Multi-arch here rides on secure-build-push-apps scanning the runner's
-    # native arch and then building the full platform list for the push.
-    # Swapping in a raw docker/build-push-action would publish both unscanned.
+    # Swapping in a raw docker/build-push-action would publish unscanned images.
     step = _sdk_base_build_step()
     assert "secure-build-push-apps" in step["uses"]
     assert step["with"]["push"] is True
+
+
+def test_the_merge_job_asserts_the_reference_the_connector_builds_from() -> None:
+    """The per-arch legs cannot assert themselves — only the merged tag can be.
+
+    A leg that quietly built the wrong architecture produces an index with two
+    of the same, and the failure surfaces a repo away as the connector's
+    `no match for platform in manifest`.
+    """
+    job = _pull_request_workflow()["jobs"]["merge-sdk-base-image"]
+    scripts = " ".join(str(s.get("run", "")) for s in job["steps"])
+    assert "imagetools create" in scripts
+    assert "assert_image_platforms.py" in scripts
+    assert "linux/amd64,linux/arm64" in scripts
+    assert "with-retry.sh" in scripts, (
+        "`imagetools create` writes the manifest list only in the registry, so "
+        "reading it back a step later is a read-after-write race"
+    )
+
+
+def test_the_connector_dispatch_gates_on_both_base_image_jobs() -> None:
+    """A failed arch leg leaves the merge SKIPPED, not failed.
+
+    'skipped' is the benign value in these clauses, so gating on the merge alone
+    would dispatch connectors against a manifest tag that was never created.
+    """
+    gate = _pull_request_workflow()["jobs"]["connector-tests"]["if"]
+    for job in ("build-sdk-base-image", "merge-sdk-base-image"):
+        assert f"needs.{job}.result == 'success'" in gate
+        assert f"needs.{job}.result == 'skipped'" in gate
+
+
+def test_the_scan_step_builds_the_runners_own_architecture() -> None:
+    """Otherwise the native split moves the emulation into the Trivy scan.
+
+    The scan builds and `--load`s an image for Trivy, then the push builds the
+    requested platform. Hardcoding amd64 there means an arm64 leg scans an
+    emulated amd64 image that is not the artefact being pushed — the scan stops
+    describing the thing it gates.
+    """
+    action = yaml.safe_load(
+        (_ACTIONS / "secure-build-push-apps" / "action.yaml").read_text(
+            encoding="utf-8"
+        )
+    )
+    scan = next(s for s in action["runs"]["steps"] if s.get("id") == "build_for_scan")
+    assert (
+        "runner.arch" in scan["with"]["platforms"]
+    ), "the scan platform must follow the runner, not be hardcoded"

--- a/.github/scripts/tests/test_build_app_image_action.py
+++ b/.github/scripts/tests/test_build_app_image_action.py
@@ -557,6 +557,35 @@ def test_the_connector_dispatch_gates_on_both_base_image_jobs() -> None:
         assert f"needs.{job}.result == 'skipped'" in gate
 
 
+def test_the_container_filter_covers_the_action_that_builds_the_image() -> None:
+    """Otherwise the base-image jobs skip on the PRs most likely to break them.
+
+    `build-sdk-base-image` and `trivy-container` are gated on the `container`
+    paths-filter. A PR that changes only the action doing the building and
+    scanning matches nothing in that filter, so both jobs skip and the change
+    merges without either ever running against it — which is exactly what
+    happened to the per-arch split and the scan-platform fix on their own PR.
+
+    Derived from the build step rather than hardcoded, so pointing the base
+    image at a different action moves this assertion with it.
+    """
+    action = _sdk_base_build_step()["uses"].rstrip("/").rsplit("/", 1)[-1]
+    filters = yaml.safe_load(
+        next(
+            step
+            for step in _pull_request_workflow()["jobs"]["changes"]["steps"]
+            if "paths-filter" in str(step.get("uses", ""))
+        )["with"]["filters"]
+    )
+    covered = [p for p in filters["container"] if action in p]
+    assert covered, (
+        f"the `container` filter does not mention {action!r}, the action "
+        "build-sdk-base-image uses. A PR changing only that action skips both "
+        f"the base-image build and the container scan. Add "
+        f"'.github/actions/{action}/**'."
+    )
+
+
 def test_the_scan_step_builds_the_runners_own_architecture() -> None:
     """Otherwise the native split moves the emulation into the Trivy scan.
 

--- a/.github/scripts/tests/test_build_app_image_action.py
+++ b/.github/scripts/tests/test_build_app_image_action.py
@@ -441,3 +441,60 @@ def test_buildx_cache_scope_is_unchanged() -> None:
         "the `--cache-to` line was removed (or `mode=max` was dropped). Builds "
         "would never write the cache, so every leg goes cold on the next run."
     )
+
+
+# --- the PR-scoped SDK runtime base ----------------------------------------
+# `build-sdk-base-image` (pull_request.yaml) publishes a PR-scoped
+# app-runtime-base so an e2e-labelled SDK PR exercises its own Dockerfile /
+# daprd / base changes. Every leg of `build-e2e-image` above then does
+# `FROM <that image>`, which makes the two a cross-file contract: whatever
+# architectures the connector matrix builds, the base must serve. Nothing else
+# enforced it — the two live in different workflows, and the base build stayed
+# amd64-only after the matrix went two-arch, failing every e2e-labelled SDK PR's
+# arm64 leg on `no match for platform in manifest` before a single line of the
+# connector Dockerfile ran.
+
+
+def _pull_request_workflow() -> dict:  # type: ignore[type-arg]
+    return yaml.safe_load(
+        (_REPO_ROOT / ".github/workflows/pull_request.yaml").read_text(encoding="utf-8")
+    )
+
+
+def _sdk_base_build_step() -> dict:  # type: ignore[type-arg]
+    job = _pull_request_workflow()["jobs"]["build-sdk-base-image"]
+    return next(
+        s for s in job["steps"] if "secure-build-push-apps" in str(s.get("uses", ""))
+    )
+
+
+def test_the_pr_base_image_serves_every_arch_the_connector_matrix_builds() -> None:
+    """Derived from the matrix, not hardcoded, so adding a third architecture
+    cannot silently leave the base behind."""
+    consumed = {
+        leg["platform"]
+        for leg in _reusable()["jobs"]["build-e2e-image"]["strategy"]["matrix"][
+            "include"
+        ]
+    }
+    published = {
+        p.strip() for p in _sdk_base_build_step()["with"]["platforms"].split(",")
+    }
+
+    missing = consumed - published
+    assert not missing, (
+        f"build-e2e-image builds {sorted(consumed)} FROM the PR base image, but "
+        f"the base publishes only {sorted(published)}. The {sorted(missing)} "
+        "leg(s) fail on `no match for platform in manifest` — a failure that "
+        "happens before the Dockerfile runs and reads as nothing to do with the "
+        "base image."
+    )
+
+
+def test_the_base_image_build_is_reached_through_the_scanning_action() -> None:
+    # Multi-arch here rides on secure-build-push-apps scanning the runner's
+    # native arch and then building the full platform list for the push.
+    # Swapping in a raw docker/build-push-action would publish both unscanned.
+    step = _sdk_base_build_step()
+    assert "secure-build-push-apps" in step["uses"]
+    assert step["with"]["push"] is True

--- a/.github/scripts/tests/test_build_callback_summary.py
+++ b/.github/scripts/tests/test_build_callback_summary.py
@@ -2,6 +2,13 @@
 
 Signature: determine_conclusion / build_fallback_summary / resolve_summary_file
 take (unit, integration, detect_integration, e2e, ...).
+
+Also guards the WIRING of the report-to-sdk job that runs this script, because
+the bug this file's script was at the centre of was not a bug in any function
+here — it was that the callback answered "did the connector tests pass?" from a
+different, smaller input set than the Tests Gate did, and so reported success on
+the dispatching application-sdk PR for a connector run whose own gate was red.
+The guards below pin the two consumers to one driver and one input set.
 """
 
 from __future__ import annotations
@@ -9,9 +16,15 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+import pytest
+import yaml
+
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 import build_callback_summary as mod
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_REUSABLE = _REPO_ROOT / ".github" / "workflows" / "tests-reusable.yaml"
 
 
 def test_determine_conclusion_all_success():
@@ -215,3 +228,91 @@ def test_main_prints_when_no_github_output(tmp_path, monkeypatch, capsys):
     out = capsys.readouterr().out
     assert "conclusion=failure" in out
     assert "summary_file=" in out
+
+
+# --- report-to-sdk wiring --------------------------------------------------
+# The regression guards for the divergence itself. `Connector E2E run / <app>`
+# on the dispatching SDK PR reported success while the connector's own Tests
+# Gate reported failure, because the two verdicts were computed independently:
+# the gate from six job results plus an anomaly rule, the callback from four.
+# Nothing in either implementation was wrong on its own terms — the defect was
+# that there were two. These assert there is one.
+
+_GATE_ACTION = "atlanhq/application-sdk/.github/actions/verify-test-gate@main"
+
+
+@pytest.fixture(scope="module")
+def reusable() -> dict:  # type: ignore[type-arg]
+    return yaml.safe_load(_REUSABLE.read_text(encoding="utf-8"))
+
+
+def _gate_step(job: dict) -> dict:  # type: ignore[type-arg]
+    """The step in `job` that evaluates the shared Tests Gate driver."""
+    steps = [s for s in job["steps"] if s.get("uses") == _GATE_ACTION]
+    assert len(steps) == 1, (
+        f"expected exactly one {_GATE_ACTION} step, found {len(steps)}. Both the "
+        "gate job and the cross-repo callback must reach the verdict through "
+        "this action and nothing else."
+    )
+    return steps[0]
+
+
+def test_the_callback_reports_the_gates_verdict_not_its_own(reusable) -> None:
+    """The fix, stated directly.
+
+    `--conclusion` must be fed from the shared gate driver. Reading it back from
+    the summary-building step (which is what shipped, and which cannot see
+    discover-e2e or the image legs at all) is the bug: it lets a red connector
+    run complete the SDK-side check run as green.
+    """
+    job = reusable["jobs"]["report-to-sdk"]
+    gate_id = _gate_step(job)["id"]
+
+    complete = next(
+        s for s in job["steps"] if "complete_check_run.py" in str(s.get("run", ""))
+    )
+    assert f"steps.{gate_id}.outputs.conclusion" in complete["run"], (
+        "the check run on application-sdk must be completed with the Tests Gate "
+        "driver's conclusion. Any other source is a second implementation of "
+        "'did the connector tests pass', and the two will drift."
+    )
+    assert "steps.report.outputs.conclusion" not in complete["run"], (
+        "build_callback_summary.py's conclusion is a deprecated back-compat "
+        "shim, not the verdict — see that script's module docstring."
+    )
+
+
+def test_the_callback_and_the_gate_judge_the_same_inputs(reusable) -> None:
+    """One driver is only one verdict if both callers feed it the same thing.
+
+    A caller that omits an input gets its default ("skipped" — a pass), so
+    dropping `discover-e2e-result` here would silently restore the old blind
+    spot while still routing through the shared action.
+    """
+    callback_inputs = _gate_step(reusable["jobs"]["report-to-sdk"])["with"]
+    gate_inputs = _gate_step(reusable["jobs"]["tests-passed"])["with"]
+
+    assert callback_inputs == gate_inputs, (
+        "the cross-repo callback and the required Tests Gate must pass identical "
+        "inputs to the gate driver; they disagree on "
+        f"{sorted(set(callback_inputs) ^ set(gate_inputs)) or 'the values'}"
+    )
+
+
+@pytest.mark.parametrize("job_name", ["report-to-sdk", "tests-passed"])
+def test_every_judged_job_is_also_needed(reusable, job_name: str) -> None:
+    """`needs.<job>.result` is empty for a job absent from `needs`.
+
+    Empty is not one of the driver's pass states, so a missing `needs` entry
+    would fail closed rather than green — but it would fail EVERY run, and the
+    fix under pressure would be to drop the input rather than add the need. Pin
+    both halves together.
+    """
+    job = reusable["jobs"][job_name]
+    needed = set(job["needs"])
+    for value in _gate_step(job)["with"].values():
+        referenced = str(value).split("needs.")[1].split(".result")[0]
+        assert referenced in needed, (
+            f"{job_name} judges `{referenced}` but does not need it, so its "
+            "result is always empty"
+        )

--- a/.github/scripts/tests/test_label_trigger_gates.py
+++ b/.github/scripts/tests/test_label_trigger_gates.py
@@ -259,6 +259,7 @@ def test_connector_tests_only_reacts_to_the_e2e_label_being_added() -> None:
                 **_CHANGES_SDK,
                 "matrix-builder": {"result": "success"},
                 "build-sdk-base-image": {"result": "success"},
+                "merge-sdk-base-image": {"result": "success"},
             }
         },
     )
@@ -304,6 +305,7 @@ def test_the_merge_queue_path_is_unaffected_by_the_label_term(job: str) -> None:
             "matrix-builder": {"result": "success"},
             # Skipped on the merge-queue path — the gate tolerates that by design.
             "build-sdk-base-image": {"result": "skipped"},
+            "merge-sdk-base-image": {"result": "skipped"},
         },
     }
     assert evaluate(_gate("pull_request.yaml", job), contexts) is True

--- a/.github/scripts/tests/test_verify_connector_gate_upstream.py
+++ b/.github/scripts/tests/test_verify_connector_gate_upstream.py
@@ -5,50 +5,60 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+import pytest
+
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 import verify_connector_gate_upstream as mod
 
 
 def test_evaluate_fails_when_changes_did_not_succeed():
-    error, dispatched = mod.evaluate("failure", "success", "success", "success")
+    error, dispatched = mod.evaluate(
+        "failure", "success", "success", "success", "success"
+    )
     assert error is not None
     assert "Detect Changes" in error
     assert dispatched is False
 
 
 def test_evaluate_fails_when_matrix_did_not_succeed():
-    error, _ = mod.evaluate("success", "failure", "success", "success")
+    error, _ = mod.evaluate("success", "failure", "success", "success", "success")
     assert error is not None
     assert "Build Test Matrix" in error
 
 
 def test_evaluate_fails_when_base_image_failed():
-    error, _ = mod.evaluate("success", "success", "failure", "success")
+    error, _ = mod.evaluate("success", "success", "failure", "success", "skipped")
     assert error is not None
     assert "Build SDK base image" in error
 
 
 def test_evaluate_allows_base_image_skipped():
-    error, dispatched = mod.evaluate("success", "success", "skipped", "success")
+    error, dispatched = mod.evaluate(
+        "success", "success", "skipped", "success", "skipped"
+    )
     assert error is None
     assert dispatched is True
 
 
 def test_evaluate_fails_when_connector_tests_failed():
-    error, _ = mod.evaluate("success", "success", "success", "failure")
+    error, _ = mod.evaluate("success", "success", "success", "failure", "success")
     assert error is not None
     assert "Connector Tests dispatch" in error
 
 
 def test_evaluate_connector_skipped_is_ok_but_not_dispatched():
-    error, dispatched = mod.evaluate("success", "success", "success", "skipped")
+    error, dispatched = mod.evaluate(
+        "success", "success", "success", "skipped", "success"
+    )
     assert error is None
     assert dispatched is False
 
 
 def test_evaluate_connector_success_is_dispatched():
-    error, dispatched = mod.evaluate("success", "success", "success", "success")
+    error, dispatched = mod.evaluate(
+        "success", "success", "success", "success", "success"
+    )
     assert error is None
     assert dispatched is True
 
@@ -61,6 +71,8 @@ def test_main_exits_1_on_upstream_failure(capsys):
             "--matrix-result",
             "success",
             "--base-image-result",
+            "success",
+            "--merge-base-image-result",
             "success",
             "--connector-result",
             "success",
@@ -81,6 +93,8 @@ def test_main_writes_dispatched_true(tmp_path, monkeypatch):
             "--matrix-result",
             "success",
             "--base-image-result",
+            "success",
+            "--merge-base-image-result",
             "success",
             "--connector-result",
             "success",
@@ -103,6 +117,8 @@ def test_main_writes_dispatched_false_for_docs_only_skip(tmp_path, monkeypatch):
             "success",
             "--base-image-result",
             "skipped",
+            "--merge-base-image-result",
+            "skipped",
             "--connector-result",
             "skipped",
         ]
@@ -123,6 +139,8 @@ def test_main_prints_when_no_github_output(monkeypatch, capsys):
             "success",
             "--base-image-result",
             "success",
+            "--merge-base-image-result",
+            "success",
             "--connector-result",
             "success",
         ]
@@ -130,3 +148,64 @@ def test_main_prints_when_no_github_output(monkeypatch, capsys):
 
     assert rc == 0
     assert "dispatched=true" in capsys.readouterr().out
+
+
+# --- the manifest-merge job ------------------------------------------------
+# The PR base image is built by a per-arch matrix and combined by a separate
+# merge job. A failed arch leg leaves that merge SKIPPED rather than failed, and
+# "skipped" is the benign value for both jobs — so neither result on its own
+# separates "no base image was requested" (merge_group) from "the base image
+# never got built". The gate is fail-closed; this is where that has to hold.
+
+
+def test_evaluate_fails_when_the_manifest_merge_failed():
+    error, _ = mod.evaluate("success", "success", "success", "success", "failure")
+    assert error is not None
+    assert "Merge SDK base image manifest" in error
+
+
+def test_evaluate_fails_when_the_legs_passed_but_the_merge_was_skipped():
+    """The pair neither single check catches.
+
+    Both arch legs green ⇒ the merge should have run. If it did not, the
+    connectors were dispatched with `base_image_ref` pointing at a manifest tag
+    that was never created, and every connector build fails on a missing image
+    one repo away from the cause.
+    """
+    error, dispatched = mod.evaluate(
+        "success", "success", "success", "success", "skipped"
+    )
+    assert error is not None
+    assert "never created" in error
+    assert dispatched is False
+
+
+def test_evaluate_allows_both_base_image_jobs_skipped():
+    # The merge_group path: no PR base image is built at all, and connectors
+    # build FROM the released base. Still a legitimate dispatch.
+    error, dispatched = mod.evaluate(
+        "success", "success", "skipped", "success", "skipped"
+    )
+    assert error is None
+    assert dispatched is True
+
+
+def test_main_requires_the_merge_result(capsys):
+    """Omitting it must be a hard argparse error, not a defaulted pass.
+
+    A default of "skipped" would make a forgotten flag indistinguishable from
+    the merge_group path — the exact silent-pass this gate exists to refuse.
+    """
+    with pytest.raises(SystemExit):
+        mod.main(
+            [
+                "--changes-result",
+                "success",
+                "--matrix-result",
+                "success",
+                "--base-image-result",
+                "success",
+                "--connector-result",
+                "success",
+            ]
+        )

--- a/.github/scripts/tests/test_verify_test_gate.py
+++ b/.github/scripts/tests/test_verify_test_gate.py
@@ -323,3 +323,413 @@ def test_main_omitting_detect_merge_queue_still_passes(capsys) -> None:
     )
     assert rc == 0
     assert "passed=true" in capsys.readouterr().out
+
+
+# --- the install path ------------------------------------------------------
+# build-e2e-image (per-arch matrix) → merge-e2e-image (manifest list) →
+# prepare-tenant → e2e. Every one of those gates the next job's `if`, and all
+# three are named in the e2e matrix's own `if`, so a failure in any of them
+# drops the matrix to a *skip*. The anomaly rule above already refused to green
+# that, but it reported the symptom ("matrix skipped") rather than the cause,
+# and the cause is what a reviewer needs: the first real occurrence was one
+# architecture's `FROM` failing on a single-arch base image. Trailing kwargs
+# defaulting to "skipped" for cross-repo @main back-compat, as with
+# detect-merge-queue.
+
+# (evaluate/render positional order after e2e: detect_merge_queue,
+# build_e2e_image, merge_e2e_image, prepare_tenant.)
+_GREEN_UPTO_E2E = ("success", "success", "success", "success")
+
+
+def test_image_legs_default_to_skipped() -> None:
+    # A caller that has not wired the jobs at all still passes.
+    assert evaluate("success", "success", "success", "success", "success") == []
+
+
+@pytest.mark.parametrize("result", ["success", "skipped"])
+def test_install_path_ok_states_pass(result) -> None:
+    # "success" = the install path ran; "skipped" = install path off / no e2e.
+    assert (
+        evaluate(
+            *_GREEN_UPTO_E2E,
+            "success",
+            "skipped",
+            result,
+            result,
+            result,
+        )
+        == []
+    )
+
+
+def test_failed_image_build_fails_the_gate_and_names_the_cause() -> None:
+    # The exact shape of the real failure: one arch leg died, the merge and the
+    # matrix skipped behind it, and everything else was green.
+    errors = evaluate(
+        "success",
+        "success",
+        "success",
+        "success",
+        "skipped",
+        "success",
+        "failure",
+        "skipped",
+    )
+    assert len(errors) == 1, (
+        "the image-build failure explains the skipped matrix, so the anomaly "
+        f"rule must not also fire and bury it: {errors}"
+    )
+    assert "e2e image build" in errors[0]
+
+
+def test_failed_manifest_merge_fails_the_gate_and_names_the_cause() -> None:
+    errors = evaluate(
+        "success",
+        "success",
+        "success",
+        "success",
+        "skipped",
+        "success",
+        "success",
+        "failure",
+    )
+    assert len(errors) == 1
+    assert "manifest merge" in errors[0]
+
+
+@pytest.mark.parametrize("result", ["failure", "cancelled", "timed_out"])
+def test_image_build_non_success_states_all_fail(result) -> None:
+    assert (
+        evaluate(
+            "success",
+            "success",
+            "success",
+            "success",
+            "skipped",
+            "success",
+            result,
+            "skipped",
+        )
+        != []
+    )
+
+
+def test_failed_tenant_install_fails_the_gate_and_names_the_cause() -> None:
+    # The third install-path job, and the one the e2e legs care most about: a
+    # failed install leaves the tenant on whatever it was running, so legs that
+    # ran anyway would silently test the wrong version.
+    errors = evaluate(
+        *_GREEN_UPTO_E2E,
+        "skipped",
+        "success",
+        "success",
+        "success",
+        "failure",
+    )
+    assert len(errors) == 1
+    assert "tenant install" in errors[0]
+
+
+def test_anomaly_rule_still_fires_when_the_install_path_is_clean() -> None:
+    # Unexplained skip (e.g. a caller re-wired the e2e `if`) — the anomaly rule
+    # is the only thing standing between that and a green gate, so suppressing
+    # it must be strictly conditional on an install-path job having actually
+    # failed.
+    errors = evaluate(
+        *_GREEN_UPTO_E2E,
+        "skipped",
+        "success",
+        "success",
+        "success",
+        "success",
+    )
+    assert len(errors) == 1
+    assert "matrix was skipped" in errors[0]
+
+
+def test_every_install_path_job_is_judged() -> None:
+    """Each of the three, one at a time, must fail the gate on its own.
+
+    They are exactly the jobs named in the e2e matrix's `if`; a job present
+    there but absent here is a skip the gate would read as benign.
+    """
+    for position in range(3):
+        results = ["success", "success", "success"]
+        results[position] = "failure"
+        errors = evaluate(*_GREEN_UPTO_E2E, "skipped", "success", *results)
+        assert len(errors) == 1, f"install-path job {position} is not judged"
+        assert "matrix was skipped" not in errors[0], (
+            "the anomaly rule fired instead of the specific job — the cause is "
+            "buried under the symptom again"
+        )
+
+
+def test_render_image_build_failure_shows_in_the_e2e_row() -> None:
+    out = render(
+        "success",
+        "success",
+        "success",
+        "success",
+        "skipped",
+        "success",
+        "failure",
+        "skipped",
+    )
+    assert out["passed"] == "false"
+    assert out["e2e-status"] == "❌ e2e image build failed", (
+        "the row must not read as a benign skip when the image build is why "
+        "nothing ran"
+    )
+
+
+def test_render_manifest_merge_failure_shows_in_the_e2e_row() -> None:
+    out = render(
+        "success",
+        "success",
+        "success",
+        "success",
+        "skipped",
+        "success",
+        "success",
+        "failure",
+    )
+    assert out["passed"] == "false"
+    assert out["e2e-status"] == "❌ e2e image manifest merge failed"
+
+
+def test_render_tenant_install_failure_shows_in_the_e2e_row() -> None:
+    out = render(
+        *_GREEN_UPTO_E2E,
+        "skipped",
+        "success",
+        "success",
+        "success",
+        "failure",
+    )
+    assert out["passed"] == "false"
+    assert out["e2e-status"] == "❌ Tenant install failed"
+
+
+def test_the_e2e_row_names_the_first_install_path_job_that_failed() -> None:
+    # When the build fails, everything behind it skips — but a cancelled run can
+    # fail several at once. The row names the earliest, which is the one worth
+    # looking at; the annotations still list them all.
+    out = render(
+        *_GREEN_UPTO_E2E,
+        "skipped",
+        "success",
+        "failure",
+        "cancelled",
+        "cancelled",
+    )
+    assert out["e2e-status"] == "❌ e2e image build failed"
+    assert (
+        len(
+            evaluate(
+                *_GREEN_UPTO_E2E,
+                "skipped",
+                "success",
+                "failure",
+                "cancelled",
+                "cancelled",
+            )
+        )
+        == 3
+    )
+
+
+def test_main_image_build_failure_annotates(capsys) -> None:
+    rc = main(
+        [
+            "--unit",
+            "success",
+            "--integration",
+            "success",
+            "--detect-integration",
+            "success",
+            "--discover-e2e",
+            "success",
+            "--build-e2e-image",
+            "failure",
+            "--merge-e2e-image",
+            "skipped",
+            "--e2e",
+            "skipped",
+        ]
+    )
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "passed=false" in captured.out
+    assert "e2e image build" in captured.err
+
+
+def test_main_omitting_the_image_flags_still_passes(capsys) -> None:
+    # Cross-repo @main back-compat at the CLI boundary.
+    rc = main(
+        [
+            "--unit",
+            "success",
+            "--integration",
+            "skipped",
+            "--detect-integration",
+            "skipped",
+            "--discover-e2e",
+            "skipped",
+            "--e2e",
+            "skipped",
+        ]
+    )
+    assert rc == 0
+    assert "passed=true" in capsys.readouterr().out
+
+
+# --- conclusion output (what the cross-repo callback reports) --------------
+# report-to-sdk completes the `Connector E2E run / <app>` check run on the
+# dispatching application-sdk PR with this value. It exists so that mapping the
+# verdict onto a Checks API conclusion happens HERE rather than in workflow YAML
+# — a `passed == 'true' && 'success' || 'failure'` expression in the callback
+# would be a second place the verdict is decided.
+
+
+def test_conclusion_is_success_when_the_gate_passes() -> None:
+    out = render("success", "skipped", "skipped", "skipped", "skipped")
+    assert out["passed"] == "true"
+    assert out["conclusion"] == "success"
+
+
+def test_conclusion_is_failure_when_the_gate_fails() -> None:
+    out = render("success", "success", "success", "success", "failure")
+    assert out["passed"] == "false"
+    assert out["conclusion"] == "failure"
+
+
+def test_conclusion_tracks_passed_across_every_scenario_in_this_module() -> None:
+    """The two outputs are one verdict; nothing may make them disagree.
+
+    A future edit that adds a rule to `passed` but forgets `conclusion` would
+    reopen exactly the gap this change closed — the SDK-side check reporting
+    something other than what the gate decided.
+    """
+    scenarios = [
+        (
+            "success",
+            "success",
+            "success",
+            "success",
+            "success",
+            "success",
+            "success",
+            "success",
+        ),
+        (
+            "failure",
+            "success",
+            "success",
+            "skipped",
+            "skipped",
+            "skipped",
+            "skipped",
+            "skipped",
+        ),
+        (
+            "success",
+            "skipped",
+            "failure",
+            "skipped",
+            "skipped",
+            "skipped",
+            "skipped",
+            "skipped",
+        ),
+        (
+            "success",
+            "skipped",
+            "skipped",
+            "skipped",
+            "skipped",
+            "failure",
+            "skipped",
+            "skipped",
+        ),
+        (
+            "success",
+            "success",
+            "success",
+            "failure",
+            "skipped",
+            "success",
+            "skipped",
+            "skipped",
+        ),
+        (
+            "success",
+            "success",
+            "success",
+            "success",
+            "skipped",
+            "success",
+            "failure",
+            "skipped",
+        ),
+        (
+            "success",
+            "success",
+            "success",
+            "success",
+            "skipped",
+            "success",
+            "success",
+            "failure",
+        ),
+        (
+            "success",
+            "success",
+            "success",
+            "success",
+            "skipped",
+            "success",
+            "success",
+            "success",
+        ),
+        (
+            "success",
+            "success",
+            "success",
+            "success",
+            "cancelled",
+            "success",
+            "success",
+            "success",
+        ),
+    ]
+    for scenario in scenarios:
+        out = render(*scenario)
+        expected = "success" if out["passed"] == "true" else "failure"
+        assert out["conclusion"] == expected, f"disagreed on {scenario}"
+
+
+def test_the_real_failure_this_change_was_written_for() -> None:
+    """End to end, in the shape it actually occurred.
+
+    application-sdk#3074 dispatched e2e to atlan-openapi-app. Unit, integration
+    and discovery were green; the arm64 leg of the image build failed on a
+    single-arch base; merge and the matrix skipped behind it. The Tests Gate
+    failed — and the callback, judging a smaller input set, completed the
+    SDK-side check run as SUCCESS. Both must now read failure.
+    """
+    out = render(
+        unit="success",
+        integration="success",
+        detect_integration="success",
+        discover_e2e="success",
+        e2e="skipped",
+        detect_merge_queue="skipped",
+        build_e2e_image="failure",
+        merge_e2e_image="skipped",
+    )
+    assert out["passed"] == "false"
+    assert out["conclusion"] == "failure", (
+        "this is the bug: the check run mirrored onto the dispatching SDK PR "
+        "must report the connector run's failure"
+    )
+    assert out["e2e-status"] == "❌ e2e image build failed"

--- a/.github/scripts/verify_connector_gate_upstream.py
+++ b/.github/scripts/verify_connector_gate_upstream.py
@@ -39,8 +39,16 @@ def evaluate(
     matrix_result: str,
     base_image_result: str,
     connector_result: str,
+    merge_base_image_result: str,
 ) -> tuple[str | None, bool]:
-    """Returns (error_message, dispatched). error_message is None on success."""
+    """Returns (error_message, dispatched). error_message is None on success.
+
+    ``merge_base_image_result`` is the manifest-merge job that combines the
+    per-arch base builds. It is checked separately because a failed arch leg
+    leaves the merge *skipped* rather than failed, and skipped is the benign
+    value for both — so neither result alone distinguishes "no base image was
+    requested" from "the base image never got built".
+    """
     if changes_result != "success":
         return (
             f"Detect Changes did not succeed ({changes_result}) — failing the gate closed.",
@@ -56,6 +64,21 @@ def evaluate(
             f"Build SDK base image did not succeed ({base_image_result}) — failing the gate closed.",
             False,
         )
+    if merge_base_image_result not in OK_BASE_IMAGE_RESULTS:
+        return (
+            f"Merge SDK base image manifest did not succeed ({merge_base_image_result}) "
+            "— failing the gate closed.",
+            False,
+        )
+    # The pair that neither check above catches on its own: the arch legs
+    # succeeded, so the merge should have run, but it did not. The connectors
+    # would have been dispatched against a manifest tag that was never created.
+    if base_image_result == "success" and merge_base_image_result == "skipped":
+        return (
+            "Build SDK base image succeeded but the manifest merge was skipped — "
+            "the PR base image tag was never created; failing the gate closed.",
+            False,
+        )
     if connector_result not in OK_CONNECTOR_RESULTS:
         return (
             f"Connector Tests dispatch did not succeed ({connector_result}) — failing the gate.",
@@ -69,6 +92,10 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--changes-result", required=True)
     parser.add_argument("--matrix-result", required=True)
     parser.add_argument("--base-image-result", required=True)
+    # Required, not defaulted: this gate is fail-closed, and a default of
+    # "skipped" would make a forgotten flag look like the legitimate merge_group
+    # path rather than an omission.
+    parser.add_argument("--merge-base-image-result", required=True)
     parser.add_argument("--connector-result", required=True)
     args = parser.parse_args(argv)
 
@@ -77,6 +104,7 @@ def main(argv: list[str] | None = None) -> int:
         args.matrix_result,
         args.base_image_result,
         args.connector_result,
+        args.merge_base_image_result,
     )
     if error:
         print(f"::error::{error}")

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -294,9 +294,21 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
-          # amd64 only — GitHub-hosted e2e runners are amd64; the connector
-          # build (sdr-e2e) is single-platform too. Keeps the rebuild fast.
-          platforms: linux/amd64
+          # BOTH arches, and it has to stay that way: the connector's e2e image
+          # build (tests-reusable's build-e2e-image) is a two-leg native matrix
+          # — amd64 for the per-leg worker on the runner, arm64 for the tenant's
+          # node — and each leg does `FROM <this image>`. A single-arch base
+          # fails the arm64 leg outright with "no match for platform in
+          # manifest" before a line of the Dockerfile runs, which is what took
+          # down the arm64 leg of every e2e-labelled SDK PR. The claim this
+          # comment used to make ("the connector build is single-platform too")
+          # went stale when that matrix landed.
+          #
+          # Matches build-image.yaml's released-base build, which has published
+          # this same Dockerfile for both arches through this same action for as
+          # long as it has existed. secure-build-push-apps scans on the runner's
+          # native arch and then builds the full platform list for the push.
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.ref.outputs.image }}
           github-token: ${{ steps.app-token.outputs.token || secrets.ORG_PAT_GITHUB }}
         env:

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -304,10 +304,23 @@ jobs:
           # comment used to make ("the connector build is single-platform too")
           # went stale when that matrix landed.
           #
-          # Matches build-image.yaml's released-base build, which has published
-          # this same Dockerfile for both arches through this same action for as
-          # long as it has existed. secure-build-push-apps scans on the runner's
-          # native arch and then builds the full platform list for the push.
+          # One job with both platforms — i.e. arm64 under QEMU — even though
+          # connector-ci-e2e.md argues hard for the native-split shape that
+          # build-e2e-image uses. That argument is about the APP image, whose
+          # build is dominated by `uv sync` compiling Python deps; emulating
+          # that is the measured 5-10x. THIS Dockerfile has no compile step at
+          # all: it is `FROM` a golden image plus addgroup / mkdir / apk del /
+          # chmod / COPY. Emulation costs almost nothing when there is nothing
+          # to emulate — build-image.yaml builds this same file for both arches
+          # this same way in 1m55s-3m34s, against 1m13s for the amd64-only PR
+          # base job it replaces.
+          #
+          # Splitting it natively would also mean fixing secure-build-push-apps
+          # first: its scan step hardcodes `platforms: linux/amd64` under a
+          # comment claiming it builds "the runner's native platform", so on an
+          # ubuntu-24.04-arm runner the split would quietly move the emulation
+          # into the Trivy scan rather than remove it. Not worth it for ~90s on
+          # a label-gated path; revisit if this Dockerfile ever grows a build.
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.ref.outputs.image }}
           github-token: ${{ steps.app-token.outputs.token || secrets.ORG_PAT_GITHUB }}

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -51,6 +51,16 @@ jobs:
             container:
               - 'Dockerfile'
               - 'entrypoint.sh'
+              # The action that BUILDS and SCANS that Dockerfile, so a change to
+              # how the image is produced re-runs the paths that produce it —
+              # the container Trivy scan and the PR base-image build. Same
+              # reasoning as the self-referential `ci:` entry below, and as
+              # `sdk:` listing the test-harness action dirs: without it, a change
+              # to the build/scan machinery merges without either ever running
+              # against it. That is not hypothetical — the per-arch split of
+              # build-sdk-base-image and the fix to this action's hardcoded scan
+              # platform both landed on a PR where these jobs skipped.
+              - '.github/actions/secure-build-push-apps/**'
             sdk:
               - 'application_sdk/**'
               - 'tests/**'

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -251,10 +251,34 @@ jobs:
       (github.event.action != 'labeled' || github.event.label.name == 'e2e') &&
       github.event.pull_request.head.repo.fork != true &&
       github.event.pull_request.user.login != 'dependabot[bot]'
-    runs-on: ubuntu-latest
+    # One architecture per job, each on a runner native to it — the same shape
+    # build-e2e-image uses for the app image, and for the same reason: every leg
+    # of that matrix does `FROM` this image, so this must serve both arches, and
+    # emulating either half is a cost paid on every e2e-labelled PR. See
+    # docs/standards/connector-ci-e2e.md.
+    strategy:
+      # Knowing whether ONE arch or BOTH failed is the diagnosis when a base
+      # build breaks on an architecture rather than in general.
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            platform: linux/amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            platform: linux/arm64
+            # NOT ubuntu-latest — that would build arm64 under QEMU and still
+            # succeed, just slower, which is a regression that looks like
+            # nothing in review. test_build_app_image_action pins the pairing.
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
     outputs:
-      image: ${{ steps.ref.outputs.image }}
+      # The tag WITHOUT the per-arch suffix — what merge-sdk-base-image combines
+      # into and what the connector actually builds FROM. Matrix job outputs are
+      # last-writer-wins, which is safe here only because every leg writes the
+      # same string; the per-arch refs are deliberately not surfaced.
+      image-base: ${{ steps.ref.outputs.image }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Set up Buildx
@@ -294,39 +318,89 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
-          # BOTH arches, and it has to stay that way: the connector's e2e image
-          # build (tests-reusable's build-e2e-image) is a two-leg native matrix
+          # This leg's architecture only; merge-sdk-base-image combines the two.
+          # The base MUST end up serving both: the connector's e2e image build
+          # (tests-reusable's build-e2e-image) is itself a two-leg native matrix
           # — amd64 for the per-leg worker on the runner, arm64 for the tenant's
           # node — and each leg does `FROM <this image>`. A single-arch base
           # fails the arm64 leg outright with "no match for platform in
           # manifest" before a line of the Dockerfile runs, which is what took
-          # down the arm64 leg of every e2e-labelled SDK PR. The claim this
-          # comment used to make ("the connector build is single-platform too")
-          # went stale when that matrix landed.
-          #
-          # One job with both platforms — i.e. arm64 under QEMU — even though
-          # connector-ci-e2e.md argues hard for the native-split shape that
-          # build-e2e-image uses. That argument is about the APP image, whose
-          # build is dominated by `uv sync` compiling Python deps; emulating
-          # that is the measured 5-10x. THIS Dockerfile has no compile step at
-          # all: it is `FROM` a golden image plus addgroup / mkdir / apk del /
-          # chmod / COPY. Emulation costs almost nothing when there is nothing
-          # to emulate — build-image.yaml builds this same file for both arches
-          # this same way in 1m55s-3m34s, against 1m13s for the amd64-only PR
-          # base job it replaces.
-          #
-          # Splitting it natively would also mean fixing secure-build-push-apps
-          # first: its scan step hardcodes `platforms: linux/amd64` under a
-          # comment claiming it builds "the runner's native platform", so on an
-          # ubuntu-24.04-arm runner the split would quietly move the emulation
-          # into the Trivy scan rather than remove it. Not worth it for ~90s on
-          # a label-gated path; revisit if this Dockerfile ever grows a build.
-          platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.ref.outputs.image }}
+          # down the arm64 leg of every e2e-labelled SDK PR. The claim the
+          # comment here used to make ("the connector build is single-platform
+          # too") went stale when that matrix landed.
+          platforms: ${{ matrix.platform }}
+          tags: ${{ steps.ref.outputs.image }}-${{ matrix.arch }}
+          # Per-arch cache scope, and it is load-bearing. The action defaults to
+          # an unscoped `type=gha`, which both legs would then share: concurrent
+          # builds overwrite each other's cache manifest, after which every later
+          # run finds the other architecture's and misses. Nothing breaks; both
+          # legs just go cold forever. Same trap tag-suffix closes for the app
+          # image build.
+          cache-from: type=gha,scope=sdk-base-${{ matrix.arch }}
+          cache-to: type=gha,mode=min,scope=sdk-base-${{ matrix.arch }}
           github-token: ${{ steps.app-token.outputs.token || secrets.ORG_PAT_GITHUB }}
         env:
           DOCKER_CLIENT_TIMEOUT: 600
           COMPOSE_HTTP_TIMEOUT: 600
+
+  # Combine the two per-arch base images into the manifest list the connector
+  # builds FROM. `imagetools create` is a registry-side operation on digests —
+  # no build context, no pull, a handful of seconds — which is what makes the
+  # native split nearly free next to emulating one half.
+  merge-sdk-base-image:
+    name: Merge SDK base image manifest
+    needs: build-sdk-base-image
+    # No label term needed: this inherits build-sdk-base-image's skip, and the
+    # FND-48 gate lives on that job. A failed arch leg leaves this SKIPPED, not
+    # failed, which is why every consumer below gates on BOTH results.
+    if: needs.build-sdk-base-image.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      image: ${{ needs.build-sdk-base-image.outputs.image-base }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Log in to Atlan Harbor Registry
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: registry.atlan.com
+          username: ${{ secrets.HARBOR_USERNAME }}
+          password: ${{ secrets.HARBOR_PASSWORD }}
+      # Buildx for `imagetools`, which is a buildx subcommand.
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+      - name: Create the multi-arch manifest
+        env:
+          IMAGE: ${{ needs.build-sdk-base-image.outputs.image-base }}
+        run: |
+          set -euo pipefail
+          docker buildx imagetools create --tag "$IMAGE" \
+            "${IMAGE}-amd64" "${IMAGE}-arm64"
+
+      # The assert that matters: this is the reference the connector's Dockerfile
+      # resolves. A leg that quietly built the wrong architecture produces an
+      # index with two of the same, and the failure would surface a repo away as
+      # "no match for platform in manifest" — the error this whole change exists
+      # to stop shipping.
+      #
+      # Retried, for the reason merge-e2e-image's copy is: `imagetools create`
+      # writes the manifest list ONLY in the registry, so reading it back a step
+      # later is exactly the read-after-write that returned `manifest unknown`
+      # 0.7s after a push reported success. The retry wraps the inspect, not the
+      # assertion over its output, so a genuinely single-arch manifest still
+      # fails once rather than three times.
+      - name: Assert the manifest serves both architectures
+        env:
+          IMAGE: ${{ needs.build-sdk-base-image.outputs.image-base }}
+        run: |
+          set -euo pipefail
+          RAW=$(.github/scripts/with-retry.sh \
+            docker buildx imagetools inspect --raw "$IMAGE")
+          printf '%s' "$RAW" \
+            | python3 .github/scripts/assert_image_platforms.py \
+                --expected linux/amd64,linux/arm64
 
   # Connector tests: dispatches tests.yaml to each connector repo.
   # Triggers:
@@ -342,16 +416,26 @@ jobs:
   #     the connector is rebuilt on top of the SDK PR's runtime image.
   connector-tests:
     name: Connector E2E dispatch (${{ matrix.repo_name }})
-    needs: [changes, matrix-builder, build-sdk-base-image]
+    needs: [changes, matrix-builder, build-sdk-base-image, merge-sdk-base-image]
     # always() so a *skipped* build-sdk-base-image (merge_group path) does
     # not auto-skip this job. The explicit result clause still BLOCKS this
     # job when the base build genuinely fails on the e2e path — a base that
     # won't build is the signal, not something to mask by silently falling
     # back to the released base.
+    #
+    # BOTH base-image jobs are named, and that is not belt-and-braces: a failed
+    # arch leg leaves merge-sdk-base-image SKIPPED rather than failed (its `if`
+    # is simply not satisfied), and 'skipped' is the benign value in these
+    # clauses. Gating on the merge alone would dispatch the connectors with
+    # base_image_ref pointing at a manifest tag that was never created — every
+    # connector build then failing on a missing image, a repo away from the
+    # cause. Gating on the build alone would miss a merge that failed on its
+    # own. This is the same trap tests-reusable's e2e job documents.
     if: |
       always() &&
       needs.matrix-builder.result == 'success' &&
-      (needs.build-sdk-base-image.result == 'success' || needs.build-sdk-base-image.result == 'skipped') && (
+      (needs.build-sdk-base-image.result == 'success' || needs.build-sdk-base-image.result == 'skipped') &&
+      (needs.merge-sdk-base-image.result == 'success' || needs.merge-sdk-base-image.result == 'skipped') && (
         (
           (needs.changes.outputs.sdk == 'true' || needs.changes.outputs.container == 'true' || needs.changes.outputs.ci == 'true') &&
           github.event_name == 'merge_group'
@@ -421,7 +505,7 @@ jobs:
           # this SDK PR — tests-reusable keys its concurrency on github.ref and
           # its e2e legs are cancel-in-progress:false, so nothing depends on it.
           # Set to the same SHA as check-sha below so the two line up.
-          workflow-inputs: ${{ github.event_name == 'merge_group' && format('{{"application_sdk_ref":"{0}","distinct_id":"{1}"}}', github.sha, github.sha) || format('{{"application_sdk_ref":"{0}","run_e2e":"true","base_image_ref":"{1}","distinct_id":"{2}"}}', github.event.pull_request.head.sha, needs.build-sdk-base-image.outputs.image, github.event.pull_request.head.sha) }}
+          workflow-inputs: ${{ github.event_name == 'merge_group' && format('{{"application_sdk_ref":"{0}","distinct_id":"{1}"}}', github.sha, github.sha) || format('{{"application_sdk_ref":"{0}","run_e2e":"true","base_image_ref":"{1}","distinct_id":"{2}"}}', github.event.pull_request.head.sha, needs.merge-sdk-base-image.outputs.image, github.event.pull_request.head.sha) }}
           wait-mode: callback
           check-run-name: "Connector E2E run / ${{ matrix.repo_name }}"
           check-sha: ${{ github.event_name == 'merge_group' && github.sha || github.event.pull_request.head.sha }}
@@ -519,7 +603,14 @@ jobs:
   # treating a skipped connector-tests as the genuine docs-only skip.
   connector-gate:
     name: Connector Tests Gate
-    needs: [changes, matrix-builder, build-sdk-base-image, connector-tests]
+    needs:
+      [
+        changes,
+        matrix-builder,
+        build-sdk-base-image,
+        merge-sdk-base-image,
+        connector-tests,
+      ]
     if: always()
     runs-on: ubuntu-latest
     permissions:
@@ -540,12 +631,14 @@ jobs:
           CHANGES_RESULT: ${{ needs.changes.result }}
           MATRIX_RESULT: ${{ needs.matrix-builder.result }}
           BASE_IMAGE_RESULT: ${{ needs.build-sdk-base-image.result }}
+          MERGE_BASE_IMAGE_RESULT: ${{ needs.merge-sdk-base-image.result }}
           CONNECTOR_RESULT: ${{ needs.connector-tests.result }}
         run: |
           python3 .github/scripts/verify_connector_gate_upstream.py \
             --changes-result "$CHANGES_RESULT" \
             --matrix-result "$MATRIX_RESULT" \
             --base-image-result "$BASE_IMAGE_RESULT" \
+            --merge-base-image-result "$MERGE_BASE_IMAGE_RESULT" \
             --connector-result "$CONNECTOR_RESULT"
 
       # Rolls up every 'Connector E2E run / <repo>' check run in ONE endpoint

--- a/.github/workflows/tests-reusable.yaml
+++ b/.github/workflows/tests-reusable.yaml
@@ -1528,7 +1528,25 @@ jobs:
   # empty on the connector's own same-repo pull_request/push runs.
   report-to-sdk:
     name: Report to application-sdk
-    needs: [unit, detect-integration, integration, e2e]
+    # The SAME set the Tests Gate aggregates, because this job now reports the
+    # SAME verdict: the mirrored `Connector E2E run / <app>` check on the
+    # dispatching SDK PR must say what this run's gate says. It previously
+    # needed a strict subset (no detect-merge-queue, no discover-e2e, none of
+    # the install path) and re-derived its own conclusion from it, which is
+    # exactly how a connector run with a red Tests Gate reported green on the
+    # SDK side.
+    needs:
+      [
+        unit,
+        detect-merge-queue,
+        detect-integration,
+        integration,
+        discover-e2e,
+        build-e2e-image,
+        merge-e2e-image,
+        prepare-tenant,
+        e2e,
+      ]
     if: |
       always() &&
       github.event_name == 'workflow_dispatch' &&
@@ -1620,7 +1638,32 @@ jobs:
           name: sdr-integration-tests-${{ inputs.app-name }}-results
           path: connector-results
 
-      - name: Determine conclusion + build summary
+      # THE verdict. Same action, same inputs as the Tests Gate job below, so
+      # the mirrored check on the dispatching SDK PR and this run's required
+      # check are one decision evaluated twice rather than two decisions that
+      # can disagree. Pinned at @main (not the dispatching SDK ref) on purpose:
+      # the action and its driver are checked out together, so unlike the
+      # callback scripts below there is no ref-skew to guard against.
+      - name: Evaluate Tests Gate (the conclusion this callback reports)
+        id: gate
+        uses: atlanhq/application-sdk/.github/actions/verify-test-gate@main
+        with:
+          unit-result: ${{ needs.unit.result }}
+          integration-result: ${{ needs.integration.result }}
+          detect-integration-result: ${{ needs.detect-integration.result }}
+          detect-merge-queue-result: ${{ needs.detect-merge-queue.result }}
+          discover-e2e-result: ${{ needs.discover-e2e.result }}
+          build-e2e-image-result: ${{ needs.build-e2e-image.result }}
+          merge-e2e-image-result: ${{ needs.merge-e2e-image.result }}
+          prepare-tenant-result: ${{ needs.prepare-tenant.result }}
+          e2e-result: ${{ needs.e2e.result }}
+
+      # Body only — the `conclusion` this step still emits is ignored (see the
+      # completion step). Its CLI is deliberately left untouched: this script is
+      # checked out from the DISPATCHING SDK ref, which can be older than the
+      # workflow (always @main), so a new flag here would make every in-flight
+      # SDK PR's callback die on `unrecognized arguments`.
+      - name: Build summary
         id: report
         env:
           UNIT_RESULT: ${{ needs.unit.result }}
@@ -1638,6 +1681,26 @@ jobs:
             --unit-summary "$UNIT_SUMMARY" \
             --integration-summary "$INTEGRATION_SUMMARY"
 
+      # The body above is built from the four results that script has always
+      # taken, so on the paths it cannot see (a failed image build, a skipped
+      # matrix) it would render a benign "**e2e:** skipped" under a failure
+      # conclusion. Append the gate's own rendered verdict so the check run a
+      # reviewer opens on the SDK PR states the cause. Straight-line appends —
+      # no branching in the shell, per docs/standards/ci.md — and it works for
+      # both the artifact-rendered report and the fallback body.
+      - name: Append the gate verdict to the check-run body
+        env:
+          SUMMARY_FILE: ${{ steps.report.outputs.summary_file }}
+          OVERALL_STATUS: ${{ steps.gate.outputs.overall-status }}
+          E2E_STATUS: ${{ steps.gate.outputs.e2e-status }}
+        run: |
+          set -euo pipefail
+          {
+            printf '\n---\n\n'
+            printf '**Tests Gate:** %s\n' "$OVERALL_STATUS"
+            printf '**e2e:** %s\n' "$E2E_STATUS"
+          } >> "$SUMMARY_FILE"
+
       - name: Complete the check run on application-sdk
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
@@ -1649,7 +1712,7 @@ jobs:
             --repo atlanhq/application-sdk \
             --sha "$SHA" \
             --name "Connector E2E run / ${REPO_SHORT}" \
-            --conclusion "${{ steps.report.outputs.conclusion }}" \
+            --conclusion "${{ steps.gate.outputs.conclusion }}" \
             --summary-file "${{ steps.report.outputs.summary_file }}" \
             --details-url "$RUN_URL"
 
@@ -1734,6 +1797,9 @@ jobs:
         detect-integration,
         integration,
         discover-e2e,
+        build-e2e-image,
+        merge-e2e-image,
+        prepare-tenant,
         e2e,
       ]
     if: always()
@@ -1753,7 +1819,11 @@ jobs:
       # passed. Integration skipped (PR / no suite) is a pass; unit must succeed.
       # detect-integration is gated too: a *failed* detection (not a PR skip)
       # fails the gate, so a checkout/glob flake can't silently skip integration
-      # and green the required check.
+      # and green the required check. The three install-path jobs (image build,
+      # manifest merge, tenant install) are gated for the same reason — they are
+      # exactly what the e2e matrix's own `if` requires, so a failure in any of
+      # them drops e2e to a skip. Passing them in names the cause instead of
+      # leaving the driver to infer it from the skip.
       - name: Evaluate Tests Gate
         id: gate
         if: always()
@@ -1764,6 +1834,9 @@ jobs:
           detect-integration-result: ${{ needs.detect-integration.result }}
           detect-merge-queue-result: ${{ needs.detect-merge-queue.result }}
           discover-e2e-result: ${{ needs.discover-e2e.result }}
+          build-e2e-image-result: ${{ needs.build-e2e-image.result }}
+          merge-e2e-image-result: ${{ needs.merge-e2e-image.result }}
+          prepare-tenant-result: ${{ needs.prepare-tenant.result }}
           e2e-result: ${{ needs.e2e.result }}
 
       - name: Post unified test-summary comment on PR

--- a/docs/standards/connector-ci-e2e.md
+++ b/docs/standards/connector-ci-e2e.md
@@ -380,6 +380,19 @@ Four things this shape makes load-bearing:
   `test_build_app_image_action.py` derives the required set from the matrix
   itself, so a third architecture cannot leave the base behind.
 
+  **That base is built as one multi-platform job, not a native split, and the
+  distinction matters.** The 5-10x emulation figure below is about *this* image
+  — the app image, whose build time is `uv sync` compiling Python dependencies.
+  The SDK runtime base compiles nothing: it is `FROM` a golden image plus
+  `addgroup` / `mkdir` / `apk del` / `chmod` / `COPY`. Emulation is close to free
+  when there is nothing to emulate, and it is measured — `build-image.yaml`
+  builds that same Dockerfile for both arches in one QEMU job in 1m55s-3m34s.
+  Splitting it natively would also require fixing `secure-build-push-apps`,
+  whose scan step hardcodes `platforms: linux/amd64` beneath a comment claiming
+  it uses the runner's native platform: on an `ubuntu-24.04-arm` runner that
+  moves the emulation into the Trivy scan instead of removing it. Read the rule
+  as "don't emulate a *compile*", not "never emulate".
+
 The other three fail *silently*:
 
 - **The runner/platform pairing.** `platform: linux/arm64` on an x64 runner still

--- a/docs/standards/connector-ci-e2e.md
+++ b/docs/standards/connector-ci-e2e.md
@@ -380,18 +380,24 @@ Four things this shape makes load-bearing:
   `test_build_app_image_action.py` derives the required set from the matrix
   itself, so a third architecture cannot leave the base behind.
 
-  **That base is built as one multi-platform job, not a native split, and the
-  distinction matters.** The 5-10x emulation figure below is about *this* image
-  — the app image, whose build time is `uv sync` compiling Python dependencies.
-  The SDK runtime base compiles nothing: it is `FROM` a golden image plus
-  `addgroup` / `mkdir` / `apk del` / `chmod` / `COPY`. Emulation is close to free
-  when there is nothing to emulate, and it is measured — `build-image.yaml`
-  builds that same Dockerfile for both arches in one QEMU job in 1m55s-3m34s.
-  Splitting it natively would also require fixing `secure-build-push-apps`,
-  whose scan step hardcodes `platforms: linux/amd64` beneath a comment claiming
-  it uses the runner's native platform: on an `ubuntu-24.04-arm` runner that
-  moves the emulation into the Trivy scan instead of removing it. Read the rule
-  as "don't emulate a *compile*", not "never emulate".
+  **That base uses the same native-split shape**, for the same reasons: a
+  per-arch `build-sdk-base-image` matrix on native runners, combined by
+  `merge-sdk-base-image` with `imagetools create`. Adopting it required fixing
+  `secure-build-push-apps` first — its scan step hardcoded
+  `platforms: linux/amd64` beneath a comment claiming it used the runner's
+  native platform. On an x64 runner the two agreed, so the lie was invisible;
+  on `ubuntu-24.04-arm` it builds an emulated amd64 image for Trivy and then
+  pushes a different one, so the scan stops describing the artefact it gates.
+  It now follows `runner.arch`.
+
+  **Both base-image jobs are named in every downstream gate**, and that is the
+  same trap the e2e matrix documents: a failed arch leg leaves the merge
+  *skipped* rather than failed, and skipped is the benign value. Gating on the
+  merge alone would dispatch the connectors with `base_image_ref` pointing at a
+  manifest tag that was never created — every connector build then failing on a
+  missing image, one repo from the cause. `connector-tests` gates on both, and
+  `verify_connector_gate_upstream.py` additionally rejects the
+  build-succeeded-but-merge-skipped pair outright.
 
 The other three fail *silently*:
 

--- a/docs/standards/connector-ci-e2e.md
+++ b/docs/standards/connector-ci-e2e.md
@@ -282,6 +282,20 @@ A single always-on job (`connector-tests`) on apps-sdk PRs fans out to the conne
 
 > The two are deliberately split: the dispatch job can't stay pending for the whole (8+ min) connector run without polling, so a separate `run` check holds the "is it done?" state and is closed by a push callback. Both are owned by the fleet App so the cross-repo callback can complete them and they're attributed to the fleet App's check suite (not an arbitrary `github-actions` one). The `E2E Callback Watchdog` sweeps any `run` check left pending if a connector runner dies before its callback fires.
 
+**The `run` check reports the connector's Tests Gate verdict, and nothing else.**
+`report-to-sdk` runs the same [`verify-test-gate`](../../.github/actions/verify-test-gate/action.yaml)
+action as the connector's own `Tests Gate` job, over the same job results, and
+completes the check run with its `conclusion` output. This is a contract, not an
+implementation detail: a red connector run must be red on the SDK PR that
+triggered it. It was not always so — the callback used to derive its own verdict
+in `build_callback_summary.py` from a subset of the gate's inputs (no
+`discover-e2e`, none of the install-path jobs, no "discovery found suites but the
+matrix skipped" anomaly rule), so a connector run whose `Tests Gate` failed
+because its arm64 e2e image build failed still completed the SDK-side check as
+**success**. Both halves are pinned by `test_build_callback_summary.py`: the two
+jobs must feed one action, with identical inputs, and each must `need` every job
+it judges. If you add a job to the gate, add it to both.
+
 The `tests.yaml` job in each connector runs unit + integration tests unconditionally. The full-DAG `e2e` job inside `tests.yaml` runs only when the SDK PR carries the `e2e` label — controlled via the `run_e2e` workflow input (`"true"` / `"false"`) passed by the dispatcher.
 
 Mechanism: `codex-/return-dispatch@v4` in `e2e-apps/action.yaml` fires `workflow_dispatch` on the target repo, passing `application_sdk_ref` (the SDK PR's head SHA, used by the connector to re-pin the SDK before running tests), `run_e2e` (derived from whether the SDK PR has the `e2e` label), and `distinct_id` (the dispatching SHA — see below).
@@ -352,7 +366,21 @@ emulating costs several. On a path that runs on every install-path e2e, that is 
 whole design. arm64 runners are also ~20% cheaper per minute, so it is not a
 speed-for-money trade.
 
-Three things this shape makes load-bearing, each of which fails *silently*:
+Four things this shape makes load-bearing:
+
+- **The base image's architectures.** Every leg does `FROM` the runtime base, so
+  the base must serve every architecture the matrix builds. On an e2e-labelled
+  SDK PR that base is not the released `app-runtime-base:3` but a PR-scoped one
+  built by `build-sdk-base-image` in `pull_request.yaml` — a different workflow,
+  which stayed `linux/amd64` after this matrix went two-arch. The arm64 leg then
+  died on `no match for platform in manifest` before a line of the connector
+  Dockerfile ran, and the error names the base image rather than the workflow
+  that published it. This is the one item in this list that fails *loudly* —
+  it just fails somewhere that reads like it has nothing to do with the SDK PR.
+  `test_build_app_image_action.py` derives the required set from the matrix
+  itself, so a third architecture cannot leave the base behind.
+
+The other three fail *silently*:
 
 - **The runner/platform pairing.** `platform: linux/arm64` on an x64 runner still
   succeeds — just emulated. Nothing goes red; the build is simply several times


### PR DESCRIPTION
## The problem

A label-gated connector e2e run whose `Tests Gate` **failed** could still complete the mirrored `Connector E2E run / <app>` check on the application-sdk PR that triggered it as **success** — so a failure in the triggered app was invisible on the PR responsible for it.

Seen on the release PR #3074: [`atlan-openapi-app` run 31444230587](https://github.com/atlanhq/atlan-openapi-app/actions/runs/31444230587) failed its Tests Gate, and [the mirrored check](https://github.com/atlanhq/application-sdk/pull/3074/checks?check_run_id=93634946132) on #3074 reported success.

### Root cause: two implementations of one question

| | inputs | anomaly rule |
|---|---|---|
| `verify_test_gate.py` (Tests Gate) | unit, detect-merge-queue, detect-integration, integration, discover-e2e, e2e | yes |
| `build_callback_summary.py` (SDK-side check run) | unit, detect-integration, integration, e2e | no |

The arm64 leg of `Build e2e image` failed → `merge-e2e-image` skipped → the e2e matrix skipped. The gate caught that through its "discovery found suites but the matrix was skipped" rule. The callback, which cannot see `discover-e2e` at all, read `e2e == skipped` as an optional-by-skip **pass**.

Neither implementation was wrong on its own terms. The defect was that there were two.

### Second, independent bug: the arm64 build itself

`build-sdk-base-image` published the PR-scoped `app-runtime-base` as `linux/amd64` only, while `build-e2e-image` is a two-arch native matrix and every leg does `FROM` that image. The arm64 leg died on `no match for platform in manifest` before a line of the connector Dockerfile ran. The comment justifying amd64-only ("the connector build is single-platform too") went stale when that matrix landed — so this broke **every** e2e-labelled SDK PR, not just #3074.

## The fix

**Status mirroring**
- `report-to-sdk` now completes the check run with the gate driver's `conclusion` output, over identical inputs and identical `needs` as the gate job. One decision, evaluated twice.
- The gate additionally judges the three install-path jobs the e2e matrix's own `if` gates on (image build, manifest merge, tenant install), so the annotation names the cause instead of the downstream symptom. The anomaly rule now fires only when nothing upstream explains the skip.
- The check-run body gains the gate's rendered verdict, so the summary can't say "**e2e:** skipped" under a failure conclusion.

**The base image** — built as a native two-arch split, matching `build-e2e-image`:
- per-arch matrix on `ubuntu-latest` / `ubuntu-24.04-arm`, combined by a new `merge-sdk-base-image` job with `imagetools create`, which asserts the merged index serves both arches before anything consumes it.
- **Fixes a latent bug in `secure-build-push-apps`** that the split exposed: its scan step hardcoded `platforms: linux/amd64` beneath a comment claiming it built "the runner's native platform". True on every existing (x64) caller, which is why the two never disagreed — but on an ARM runner it builds an emulated amd64 image for Trivy and then pushes a different one, so the scan stops describing the artefact it gates. Now follows `runner.arch`; byte-identical for existing callers.
- Per-arch buildx cache scopes: the action defaults to an unscoped `type=gha`, so two concurrent legs would overwrite each other's cache manifest and both go cold forever, silently.
- **Every downstream gate names both base-image jobs.** A failed arch leg leaves the merge *skipped*, not failed, and skipped is the benign value in those clauses — gating on the merge alone would dispatch connectors with `base_image_ref` pointing at a manifest tag that was never created. `verify_connector_gate_upstream.py` also rejects the build-succeeded-but-merge-skipped pair outright, and its new flag is **required** rather than defaulted so forgotten wiring can't look like the legitimate `merge_group` skip.

`docs/standards/connector-ci-e2e.md` records both contracts.

> Note on history: the middle commit (`docs(ci): record why the SDK base image builds multi-arch in one job`) argued for the single-job QEMU shape. Review feedback took it to the native split instead, and the third commit supersedes it. Left in place rather than force-pushed; it squashes away on merge.

## One judgment call worth review

**`build_callback_summary.py`'s CLI is deliberately untouched.** That script is checked out from the *dispatching SDK ref*, while the workflow always comes from `@main` — so it can be **older** than the workflow calling it. Adding a flag would kill every in-flight e2e-labelled SDK PR's callback on `unrecognized arguments`. Its `determine_conclusion` therefore survives as a back-compat shim for the reverse skew (a pre-fix `main` workflow paired with a post-fix script), documented with an explicit removal trigger: the next release after this lands on `main`.

## Verification

- 1572 CI script tests pass; pre-commit clean; conformance reports zero findings in changed files.
- Every new guard negative-controlled — reverting the `--conclusion` wiring, dropping `discover-e2e` from the callback's inputs, restoring the hardcoded scan platform, and gating on the merge job alone each fail the corresponding test.
- New tests include the failure in the exact shape it occurred (`test_the_real_failure_this_change_was_written_for`), a guard that `conclusion` and `passed` can never disagree, and native-runner/cache-scope pinning for the base legs mirroring what already exists for the app legs.
- The arch guard reads **both matrices from the YAML**, so a third architecture cannot leave the base behind.
- Confirmed the released `app-runtime-base:3` is already an amd64+arm64 index, so the golden base supports arm64.

**Not verified locally:** neither the base-image split nor the callback path can run without an `e2e`-labelled PR, and the callback specifically runs `main`'s `tests-reusable.yaml`, so its corrected wiring only goes live post-merge. Labelling this PR does exercise the new base-image split end to end.

FND-201

🤖 Generated with [Claude Code](https://claude.com/claude-code)
