### PR TITLE
feat(conformance): add K014 requiring an explicit release_model in atlan.yaml

### DIFF
--- a/packages/conformance/conformance/docs/rules/contract-toolkit.md
+++ b/packages/conformance/conformance/docs/rules/contract-toolkit.md
@@ -5,7 +5,7 @@
 
 # Contract-Toolkit Conformance Rules (K-series)
 
-**13 rules** · Checker: `suite.checks.legacy_contract` (K001–K002, pkl-source regex, scans ``contract/**/*.pkl``), `suite.checks.generated_freshness` (K003–K005, scans ``contract/PklProject``, ``contract/PklProject.deps.json``, ``atlan.yaml``, ``app.yaml``, and ``app/generated/**``), `suite.checks.manifest_contract` (K006, cross-references ``app/generated/**/manifest.json`` against Python ``Output`` contracts)
+**14 rules** · Checker: `suite.checks.legacy_contract` (K001–K002, pkl-source regex, scans ``contract/**/*.pkl``), `suite.checks.generated_freshness` (K003–K005, scans ``contract/PklProject``, ``contract/PklProject.deps.json``, ``atlan.yaml``, ``app.yaml``, and ``app/generated/**``), `suite.checks.manifest_contract` (K006, cross-references ``app/generated/**/manifest.json`` against Python ``Output`` contracts)
 
 Suppress a finding on the violating line or the line directly above it:
 
@@ -28,6 +28,7 @@ Suppress a finding on the violating line or the line directly above it:
 | [K011](#k011) | `AppIdMissingFromContract` | `block` | `app` | `contract-toolkit` | — | 0.14.0 |
 | [K012](#k012) | `GeneratePoeTaskMissing` | `block` | `app` | `contract-toolkit` | — | 0.14.0 |
 | [K013](#k013) | `ManifestNodeAppNameMisattributed` | `warn` | `app` | `contract-toolkit` | — | 0.18.0 |
+| [K014](#k014) | `ReleaseModelUndeclared` | `warn` | `app` | `contract-toolkit` | — | 0.18.0 |
 
 ---
 
@@ -582,5 +583,68 @@ would move where the node runs.
 **No suppression is available.** The finding is anchored on a generated `.json`
 artifact, which has no comment syntax to carry a directive -- as with K009, the only
 resolution is to fix the contract and regenerate. Never hand-edit `manifest.json`.
+
+---
+
+## K014 — `ReleaseModelUndeclared` {#k014}
+
+**Tier:** `warn` · **Scope:** `app` · **Category:** `contract-toolkit` · **Autofixable:** — · **Since:** 0.18.0
+
+> atlan.yaml declares no top-level release_model, so the app silently inherits the 'cd' default and auto-publishes on merge
+
+**Rationale:** release_model decides whether merging to main publishes the app to every tenant. The
+publish step reads it out of the committed atlan.yaml and defaults a missing key to 'cd'
+(.github/scripts/parse_atlan_yaml.py), so an app that never declares it auto-publishes
+to channel='all' on every merge -- not because anyone chose continuous delivery, but
+because the key was absent. That default is silent by construction: the app builds,
+tests and publishes successfully, so no gate has any reason to speak up, and the release
+model an app is actually running is invisible in review. A fleet sweep found 36 of 75
+connectors in exactly that state, none of them deliberately. This rule does not prefer
+either model -- 'cd' is a legitimate choice -- it only requires that the choice be
+written down, so it is reviewable and cannot be inherited by accident.
+
+The committed `atlan.yaml` has no usable top-level `release_model:` key, or declares a
+value outside the allowed set.
+
+`release_model` selects how the app reaches tenants:
+
+    cd      every merge to main publishes to channel='all'     semver  merges build
+only; a GitHub Release publishes to all
+
+A missing key is read as `cd` (`.github/scripts/parse_atlan_yaml.py`), so omitting it
+opts the app into fleet-wide publish-on-merge by default. Nothing else reports this: the
+omission breaks no build and fails no test, and the effective model never appears in a
+diff.
+
+**This rule takes no side between `cd` and `semver`.** It fires only on an *undeclared*
+or *invalid* value. Declaring `release_model: cd` explicitly satisfies it.
+
+`versioned` is a deprecated alias for `semver`, normalised on read; it is reported so it
+can be migrated.
+
+**Fix -- where the key goes depends on whether the contract emits atlan.yaml.**
+Determine that by running `pkl eval -m <out> contract/app.pkl` and checking whether
+`atlan.yaml` appears in the output. Do not infer it from the presence of
+`contract/app.pkl` or from which template the contract `amends` -- both are unreliable,
+and a `NativeApp.pkl` contract can still emit `atlan.yaml` through its own
+`additionalOutputFiles` block.
+
+*The contract emits it* -- declare it at the source, in the pkl `metadata` mapping,
+whose entries are emitted as top-level `atlan.yaml` keys (the same untyped hatch K011
+prescribes for `app_id`), then regenerate:
+
+    metadata {       ["release_model"] = "semver"     }
+
+If the contract instead builds `atlan.yaml` itself via an inline
+`additionalOutputFiles["atlan.yaml"]` mapping, add the key to that mapping. Either way,
+never hand-edit a generated `atlan.yaml` -- K005 guards its provenance banner and the
+next toolkit bump reverts the edit.
+
+*The contract does not emit it* -- `atlan.yaml` is hand-owned; add `release_model:` to
+it directly.
+
+**Suppress** with `# conformance: ignore[K014] <reason>` on the first line of
+`atlan.yaml` (or the line above the key). A suppression is rarely the right answer:
+declaring the value is one line and is the entire point of the rule.
 
 ---

--- a/packages/conformance/conformance/programs/areas/contract-toolkit.prose.md
+++ b/packages/conformance/conformance/programs/areas/contract-toolkit.prose.md
@@ -42,7 +42,7 @@ All K-series rules are WARN-tier **except K009, K011, and K012 (BLOCK)**.  So in
 placeholder), K011 (missing `app_id`), or K012 (missing `generate` poe task)
 finding is present — those are FAILING results that fail the gate and must be
 remediated in default mode.  In **strict** mode the fingerprint-set also includes the
-unsuppressed WARNING results (K003/K004/K005/K007/K008/K010), which is where the
+unsuppressed WARNING results (K003/K004/K005/K007/K008/K010/K014), which is where the
 rest of K-series remediation runs.
 
 The active scope decides which rules can appear: K001–K014 are all `scope=APP`,

--- a/packages/conformance/conformance/programs/areas/contract-toolkit.prose.md
+++ b/packages/conformance/conformance/programs/areas/contract-toolkit.prose.md
@@ -20,7 +20,10 @@ description: >
   and regenerating — all verified by the pkl-eval gate.  K013 (a DAG node running a
   toolkit-owned workflow but still attributed to automation-engine) is fixed in
   contract/app.pkl -- by switching to the built-in node class or setting appName
-  explicitly -- and verified by the pkl-eval gate.  K009, K011, and K012 are
+  explicitly -- and verified by the pkl-eval gate.  K014 (atlan.yaml declares no
+  release_model, so the app inherits the publish-on-merge default) is fixed either
+  in the contract or in a hand-owned atlan.yaml, decided by whether the contract
+  actually emits that file.  K009, K011, and K012 are
   BLOCK-tier (they fail the gate in default mode); the rest of the K-series is WARN.
 ---
 
@@ -42,7 +45,7 @@ remediated in default mode.  In **strict** mode the fingerprint-set also include
 unsuppressed WARNING results (K003/K004/K005/K007/K008/K010), which is where the
 rest of K-series remediation runs.
 
-The active scope decides which rules can appear: K001–K013 are all `scope=APP`,
+The active scope decides which rules can appear: K001–K014 are all `scope=APP`,
 so they surface only on consumer app repos.  The runner auto-detects scope, so
 the SDK repo sees 0 findings.
 
@@ -98,7 +101,9 @@ K007–K011, K013), the `pkl-eval` gate runs `pkl eval` to verify the contract c
 and regenerated cleanly.  **K006 and K012 are the exceptions**: K006's fix is a
 plain Python edit and K012's is a `pyproject.toml` edit (both see below), neither
 involving `.pkl` or generated artifacts, so both are verified by the standard
-test-suite gate instead of `pkl-eval`.
+test-suite gate instead of `pkl-eval`.  **K014 is either**, decided per repo: the
+contract route regenerates and is verified by `pkl-eval`; the hand-owned-atlan.yaml
+route touches no `.pkl` and is verified by the test-suite gate.
 
 The freshness rules (K003/K004/K005) are remediated by running a pkl command
 (`pkl project resolve` and/or `pkl eval -m . contract/app.pkl`), so they are
@@ -494,12 +499,78 @@ note to regenerate locally; never hand-edit `manifest.json`.
 
 ---
 
+**K014 ReleaseModelUndeclared** — `atlan.yaml` declares no top-level
+`release_model`, or declares an invalid/deprecated value.  A missing key is read
+as `cd`, so the app auto-publishes to `channel='all'` on every merge without
+anyone having chosen that.  **WARN-tier** (strict mode only).
+`classification = "judgment"` — the *value* is a release-policy decision owned by
+the app team, not derivable from the repo.
+
+**The rule takes no side between `cd` and `semver`.**  Never silently pick
+`semver` for an app that has not asked for it: switching an app to `semver` stops
+merges publishing to tenants, so an app whose team is not yet cutting GitHub
+Releases would silently lose its delivery path.  An invalid value is mechanical
+(correct it to the intended model); a *missing* value needs the owner's intent, so
+prefer residue with the question unless the intent is already recorded in the repo
+(e.g. a release policy doc, or the contract already declaring it — see step 1).
+
+*Procedure:*
+
+1. **Check the contract first.**  If `contract/app.pkl` already declares
+   `["release_model"]` and only the committed `atlan.yaml` lacks the rendered key,
+   the intent is settled: regenerate (step 3) and stop.  This is a pure staleness
+   fix with no policy decision.
+2. **Determine where the key belongs — by observation, not inference.**  Run
+   `pkl eval -m <tmpdir> contract/app.pkl` and check whether `atlan.yaml` appears
+   in the output.
+
+   **Do not** infer this from the presence of `contract/app.pkl`, nor from which
+   template the contract `amends`.  Both are unreliable: most contracts do *not*
+   emit `atlan.yaml`, and a `NativeApp.pkl` contract can still emit one through
+   its own `additionalOutputFiles` block.  Getting this backwards is itself the
+   bug — putting the key in a generated `atlan.yaml` means the next toolkit bump
+   silently reverts it.
+
+   - **The eval emits `atlan.yaml`** → the file is generated.  Declare the key in
+     the pkl `metadata` mapping (the same untyped hatch K011 uses for `app_id`):
+
+     ```
+     metadata {
+       ["release_model"] = "semver"
+     }
+     ```
+
+     If the contract instead builds `atlan.yaml` itself via an inline
+     `additionalOutputFiles["atlan.yaml"]` mapping, add the key inside *that*
+     mapping — a top-level `metadata` block will not reach it.  **requires `pkl`.**
+   - **The eval does not emit `atlan.yaml`** → the file is hand-owned.  Add
+     `release_model:` to it directly, near `build_tag:`.  Does **not** require
+     `pkl`, and no regeneration step applies.
+3. If the contract route was taken, regenerate with `pkl eval -m . contract/app.pkl`
+   (or `uv run poe generate`) and set `touched_files` the K003-step-4 way so a gate
+   rejection reverts every regenerated artifact.  **Never hand-edit a generated
+   `atlan.yaml`** — K005 guards its provenance banner.
+4. **Abort to residue if the committed `atlan.yaml` is already drifted** from a
+   fresh eval beyond the one key being added.  Regenerating a drifted file sweeps
+   unrelated reversions into a fix labelled "declare release_model" — the same
+   failure class K005 and the freshness rules exist to prevent.  Report the drift
+   instead; it needs an owner decision per field.
+5. Suppression (strict mode): `# conformance: ignore[K014] <reason>` on the first
+   line of `atlan.yaml` or the line above the key.  Rarely right — declaring the
+   value is one line.  Route to residue.
+
+If `pkl` is unavailable, the emission test in step 2 cannot be run; route to
+residue rather than guessing which file to edit.
+
+---
+
 **Suppress outcome (strict mode only, WARNING-tier findings)**: the model may
 propose an inline suppression comment — `// conformance: ignore[Kxxx]
 <8–40 word justification>` for the `.pkl`-source / `PklProject`-anchored rules
 (K001–K005, K007, K008, K010; `//` comments) or `# conformance: ignore[Kxxx]
 <8–40 word justification>` for the artifact/Python-anchored rules (K006 Python,
-K009 text artifact; `#` comments) — on the violating line or the comment-only
+K009 text artifact, K014 `atlan.yaml`; `#` comments) — on the violating line or
+the comment-only
 line directly above it when a legitimate exception exists (e.g. a K001 finding on
 a contract intentionally kept at the legacy module during a phased migration with
 a tracked follow-on ticket).  Route every suppression to residue for human audit.

--- a/packages/conformance/conformance/programs/functions/remediate-finding.prose.md
+++ b/packages/conformance/conformance/programs/functions/remediate-finding.prose.md
@@ -59,6 +59,16 @@ wider than `contract/*.pkl` — `pkl project resolve`/`pkl eval` also write
 `app/generated/`, `atlan.yaml`, or `app.yaml`; see `areas/contract-toolkit.prose.md`
 for how `touched_files` accounts for that full set.
 
+**K014 is the one K-series rule that may write `atlan.yaml` directly** — and only
+after establishing, by running `pkl eval -m <tmpdir> contract/app.pkl` and
+inspecting the output, that the contract does **not** emit `atlan.yaml`.  When the
+contract does emit it, the file is a generated artifact and the general
+never-hand-edit-a-generated-artifact rule applies unchanged: the edit goes in the
+contract and `atlan.yaml` is rewritten by regeneration, not by this function.  See
+`areas/contract-toolkit.prose.md`'s K014 procedure — the emission test is
+mandatory, because neither the presence of `contract/app.pkl` nor the contract's
+`amends` line reliably predicts the answer.
+
 For C002 findings (and C003's absent-`.gitignore` case) only, invoking
 `atlan-application-sdk-conformance bootstrap` is also permitted, despite it
 writing under `.github/` and `.gitignore`. This is not a carve-out of the

--- a/packages/conformance/conformance/suite/checks/release_contract.py
+++ b/packages/conformance/conformance/suite/checks/release_contract.py
@@ -1,4 +1,4 @@
-"""K011/K012 release-readiness guards — app_id in atlan.yaml + generate poe task.
+"""K011/K012/K014 release-readiness guards — atlan.yaml keys + generate poe task.
 
 K011 ``AppIdMissingFromContract``: the generated ``atlan.yaml`` must carry a
 top-level ``app_id`` (the Global Marketplace identity the publish step POSTs to
@@ -9,7 +9,13 @@ K012 ``GeneratePoeTaskMissing``: ``pyproject.toml`` must define a ``generate``
 poe task (the SDK Certify step runs ``uv run poe generate`` and hard-fails
 without it, aborting the publish with ``Unrecognized task 'generate'``).
 
-Both are APP-scoped and gated on the presence of a ``contract/`` directory —
+K014 ``ReleaseModelUndeclared``: ``atlan.yaml`` must declare a top-level
+``release_model`` with an allowed value. A missing key is read as ``cd``, so
+omitting it silently opts the app into publish-to-all-tenants on every merge.
+The rule takes no side between ``cd`` and ``semver`` — it only requires the
+choice to be written down.
+
+All three are APP-scoped and gated on the presence of a ``contract/`` directory —
 the same "is this a pkl-contract-driven app repo?" signal the sibling K checks
 (``legacy_contract``, ``generated_freshness``) use. The SDK repo has no
 ``contract/`` dir, so the check no-ops there (and the runner's scope filter
@@ -57,6 +63,19 @@ _EMPTY_APP_ID_VALUES = frozenset({'""', "''", "null", "Null", "NULL", "~"})
 # meaningful line; absence just falls back to line 1.
 _POE_TASKS_HEADER_RE = re.compile(r"^[ \t]*\[tool\.poe\.tasks\]", re.MULTILINE)
 
+# Top-level ``release_model:`` key in atlan.yaml, anchored in column 0 for the
+# same reason as ``_APP_ID_RE``: only a manifest-level key is what the publish
+# step reads. A nested ``release_model:`` under some other mapping must not
+# satisfy the rule — an indentation-blind match reports an app as compliant
+# when the publish step still sees nothing.
+_RELEASE_MODEL_RE = re.compile(r"^release_model:[ \t]*(.*)$", re.MULTILINE)
+
+# Values the publish step accepts (``parse_atlan_yaml.py``). ``versioned`` is a
+# deprecated alias normalised to ``semver`` on read — still honoured, so it is
+# reported for migration rather than treated as broken.
+_VALID_RELEASE_MODELS = frozenset({"cd", "semver", "versioned"})
+_DEPRECATED_RELEASE_MODELS = frozenset({"versioned"})
+
 
 def discover(root: Path) -> list[Path]:
     """Return ``[root]`` for a pkl-contract-driven app repo, else ``[]``.
@@ -91,8 +110,55 @@ def _app_id_missing(text: str) -> bool:
     return not value or value in _EMPTY_APP_ID_VALUES
 
 
+def _release_model_problem(text: str) -> str | None:
+    """Describe why atlan.yaml's ``release_model`` is unusable, else ``None``.
+
+    Returns a sentence completing "atlan.yaml ..." so the caller can build one
+    message. Three failure shapes, all of which leave the app on a release model
+    nobody chose or one the publish step rejects:
+
+    * key absent, or present with no value — read as the ``cd`` default
+      (``parse_atlan_yaml.py``), i.e. publish-to-all-tenants on every merge
+    * value outside the allowed set — the publish step errors out
+    * ``versioned`` — a deprecated alias for ``semver``; honoured, but worth
+      migrating before the alias is dropped
+
+    An explicit ``cd`` is accepted: the rule requires a declared choice, not a
+    particular one.
+    """
+    match = _RELEASE_MODEL_RE.search(text)
+    if match is None:
+        return (
+            "declares no top-level 'release_model'. A missing key is read as "
+            "'cd', so every merge to main publishes this app to channel='all'"
+        )
+
+    # Strip an inline comment before evaluating: `semver  # why` is a valid
+    # declaration, and the comment is not part of the value.
+    value = match.group(1).split("#", 1)[0].strip().strip("\"'")
+    if not value or value in {"null", "Null", "NULL", "~"}:
+        return (
+            "declares 'release_model' with no value, which is read as the 'cd' "
+            "default, so every merge to main publishes to channel='all'"
+        )
+    if value not in _VALID_RELEASE_MODELS:
+        # Advertise only the non-deprecated values — pointing a fix at
+        # ``versioned`` would trade one finding for another.
+        allowed = ", ".join(sorted(_VALID_RELEASE_MODELS - _DEPRECATED_RELEASE_MODELS))
+        return (
+            f"declares release_model '{value}', which the publish step rejects. "
+            f"Allowed values: {allowed}"
+        )
+    if value in _DEPRECATED_RELEASE_MODELS:
+        return (
+            f"declares release_model '{value}', a deprecated alias for 'semver' "
+            "that is normalised on read. Declare 'semver' directly"
+        )
+    return None
+
+
 def scan_all(paths: list[Path], root: Path) -> list[Finding]:
-    """Emit K011 (missing app_id) and K012 (missing generate poe task).
+    """Emit K011 (app_id), K014 (release_model) and K012 (generate poe task).
 
     No-ops when ``discover`` returned nothing (not a contract-driven app repo).
     """
@@ -125,6 +191,29 @@ def scan_all(paths: list[Path], root: Path) -> list[Finding]:
                     ),
                     # atlan.yaml uses '#' comments, so the shared TOML/# directive
                     # scanner applies unchanged.
+                    suppressions=parse_toml_suppressions(text),
+                )
+            )
+
+        # K014 — release_model declared, with an allowed value.
+        #
+        # Gated on the same "atlan.yaml exists" condition as K011: a contract
+        # repo with no atlan.yaml has a missing generated output (K004's
+        # concern), not an undeclared release model.
+        problem = _release_model_problem(text)
+        if problem is not None:
+            findings.append(
+                make_toml_finding(
+                    rule_id="K014",
+                    file="atlan.yaml",
+                    line=_line_of(text, _RELEASE_MODEL_RE),
+                    column=1,
+                    message=(
+                        f"atlan.yaml {problem}. Declare the intended model "
+                        "explicitly ('cd' or 'semver'): in the pkl metadata "
+                        "block and regenerate if the contract emits atlan.yaml, "
+                        "otherwise directly in atlan.yaml."
+                    ),
                     suppressions=parse_toml_suppressions(text),
                 )
             )
@@ -168,7 +257,7 @@ def scan_all(paths: list[Path], root: Path) -> list[Finding]:
 
 
 def scan_path(path: Path, root: Path) -> list[Finding]:  # noqa: ARG001
-    """No-op: K011/K012 are cross-artifact; use :func:`scan_all`."""
+    """No-op: K011/K012/K014 are cross-artifact; use :func:`scan_all`."""
     return []
 
 
@@ -176,7 +265,8 @@ main = make_cli_main(
     scan_all=scan_all,
     discover=discover,
     description=(
-        "K011/K012 release-readiness: atlan.yaml app_id + generate poe task presence."
+        "K011/K012/K014 release-readiness: atlan.yaml app_id + release_model, "
+        "generate poe task presence."
     ),
 )
 

--- a/packages/conformance/conformance/suite/checks/release_contract.py
+++ b/packages/conformance/conformance/suite/checks/release_contract.py
@@ -117,14 +117,23 @@ def _release_model_problem(text: str) -> str | None:
     message. Three failure shapes, all of which leave the app on a release model
     nobody chose or one the publish step rejects:
 
-    * key absent, or present with no value — read as the ``cd`` default
-      (``parse_atlan_yaml.py``), i.e. publish-to-all-tenants on every merge
+    * key absent — read as the ``cd`` default (``parse_atlan_yaml.py``), i.e.
+      publish-to-all-tenants on every merge
+    * key present with no value (bare ``release_model:`` or a YAML null) — the
+      key exists, so ``d.get("release_model", "cd")`` returns ``None`` and the
+      publish step *rejects* it (``None not in _ALLOWED_RELEASE_MODELS``)
     * value outside the allowed set — the publish step errors out
     * ``versioned`` — a deprecated alias for ``semver``; honoured, but worth
       migrating before the alias is dropped
 
     An explicit ``cd`` is accepted: the rule requires a declared choice, not a
     particular one.
+
+    ``_RELEASE_MODEL_RE.search`` takes the *first* top-level ``release_model:``,
+    while ``yaml.safe_load`` keeps the *last* of a duplicated key — a duplicated
+    key can pass conformance while the publish step reads the later value. That
+    is pathological (a duplicate top-level key is its own bug), so the first
+    match is treated as the declared value.
     """
     match = _RELEASE_MODEL_RE.search(text)
     if match is None:
@@ -138,8 +147,9 @@ def _release_model_problem(text: str) -> str | None:
     value = match.group(1).split("#", 1)[0].strip().strip("\"'")
     if not value or value in {"null", "Null", "NULL", "~"}:
         return (
-            "declares 'release_model' with no value, which is read as the 'cd' "
-            "default, so every merge to main publishes to channel='all'"
+            "declares 'release_model' with no value. The key exists, so the "
+            "publish step reads it as None and rejects it (None is not an "
+            "allowed value) — give it an explicit model"
         )
     if value not in _VALID_RELEASE_MODELS:
         # Advertise only the non-deprecated values — pointing a fix at

--- a/packages/conformance/conformance/suite/rules/contract_toolkit.py
+++ b/packages/conformance/conformance/suite/rules/contract_toolkit.py
@@ -930,4 +930,94 @@ RULES: tuple[RuleDefinition, ...] = (
             "packages/conformance/conformance/docs/rules/contract-toolkit.md#k013"
         ),
     ),
+    RuleDefinition(
+        id="K014",
+        scope=RuleScope.APP,
+        name="ReleaseModelUndeclared",
+        tier=EnforcementTier.WARN,
+        mechanism=RuleMechanism.STATIC,
+        category="contract-toolkit",
+        autofixable=False,
+        since="0.18.0",
+        orthogonal_gate="pkl-eval",
+        rationale=(
+            "release_model decides whether merging to main publishes the app to "
+            "every tenant. The publish step reads it out of the committed "
+            "atlan.yaml and defaults a missing key to 'cd' "
+            "(.github/scripts/parse_atlan_yaml.py), so an app that never "
+            "declares it auto-publishes to channel='all' on every merge -- not "
+            "because anyone chose continuous delivery, but because the key was "
+            "absent. That default is silent by construction: the app builds, "
+            "tests and publishes successfully, so no gate has any reason to "
+            "speak up, and the release model an app is actually running is "
+            "invisible in review. A fleet sweep found 36 of 75 connectors in "
+            "exactly that state, none of them deliberately. This rule does not "
+            "prefer either model -- 'cd' is a legitimate choice -- it only "
+            "requires that the choice be written down, so it is reviewable and "
+            "cannot be inherited by accident."
+        ),
+        short_description=(
+            "atlan.yaml declares no top-level release_model, so the app "
+            "silently inherits the 'cd' default and auto-publishes on merge"
+        ),
+        full_description=(
+            "The committed ``atlan.yaml`` has no usable top-level "
+            "``release_model:`` key, or declares a value outside the allowed "
+            "set.\n"
+            "\n"
+            "``release_model`` selects how the app reaches tenants:\n"
+            "\n"
+            "    cd      every merge to main publishes to channel='all'\n"
+            "    semver  merges build only; a GitHub Release publishes to all\n"
+            "\n"
+            "A missing key is read as ``cd`` "
+            "(``.github/scripts/parse_atlan_yaml.py``), so omitting it opts the "
+            "app into fleet-wide publish-on-merge by default. Nothing else "
+            "reports this: the omission breaks no build and fails no test, and "
+            "the effective model never appears in a diff.\n"
+            "\n"
+            "**This rule takes no side between ``cd`` and ``semver``.** It fires "
+            "only on an *undeclared* or *invalid* value. Declaring "
+            "``release_model: cd`` explicitly satisfies it.\n"
+            "\n"
+            "``versioned`` is a deprecated alias for ``semver``, normalised on "
+            "read; it is reported so it can be migrated.\n"
+            "\n"
+            "**Fix -- where the key goes depends on whether the contract emits "
+            "atlan.yaml.** Determine that by running ``pkl eval -m <out> "
+            "contract/app.pkl`` and checking whether ``atlan.yaml`` appears in "
+            "the output. Do not infer it from the presence of "
+            "``contract/app.pkl`` or from which template the contract "
+            "``amends`` -- both are unreliable, and a ``NativeApp.pkl`` contract "
+            "can still emit ``atlan.yaml`` through its own "
+            "``additionalOutputFiles`` block.\n"
+            "\n"
+            "*The contract emits it* -- declare it at the source, in the pkl "
+            "``metadata`` mapping, whose entries are emitted as top-level "
+            "``atlan.yaml`` keys (the same untyped hatch K011 prescribes for "
+            "``app_id``), then regenerate:\n"
+            "\n"
+            "    metadata {\n"
+            '      ["release_model"] = "semver"\n'
+            "    }\n"
+            "\n"
+            "If the contract instead builds ``atlan.yaml`` itself via an inline "
+            '``additionalOutputFiles["atlan.yaml"]`` mapping, add the key to '
+            "that mapping. Either way, never hand-edit a generated "
+            "``atlan.yaml`` -- K005 guards its provenance banner and the next "
+            "toolkit bump reverts the edit.\n"
+            "\n"
+            "*The contract does not emit it* -- ``atlan.yaml`` is hand-owned; "
+            "add ``release_model:`` to it directly.\n"
+            "\n"
+            "**Suppress** with ``# conformance: ignore[K014] <reason>`` on the "
+            "first line of ``atlan.yaml`` (or the line above the key). A "
+            "suppression is rarely the right answer: declaring the value is one "
+            "line and is the entire point of the rule.\n"
+        ),
+        help_uri=(
+            "https://github.com/atlanhq/application-sdk/blob/main/"
+            "packages/conformance/conformance/docs/rules/contract-toolkit.md#k014"
+        ),
+    ),
 )

--- a/packages/conformance/tests/test_catalog.py
+++ b/packages/conformance/tests/test_catalog.py
@@ -180,6 +180,8 @@ def test_catalog_app_scoped_rules_are_the_expected_set() -> None:
     # pyproject generate poe task only exist on a consumer app that publishes to
     # the marketplace; the SDK has no contract/ dir, no atlan.yaml, and no
     # marketplace publish, so neither rule applies to it (CONNECT release-pipeline).
+    # K014: same release-readiness family — release_model selects how the app
+    # reaches tenants, and only a consumer app has an atlan.yaml declaring it.
     # E020: HTTP-failure-to-empty-return — the harm (publishing a partial crawl as
     # complete) is a connector extract/publish concern; the SDK's matching sites are
     # legitimate best-effort infra (health/metric scrapes), not crawlers (BLDX-1503).
@@ -227,6 +229,7 @@ def test_catalog_app_scoped_rules_are_the_expected_set() -> None:
         "K011",
         "K012",
         "K013",
+        "K014",
         "P004",
         "P005",
         "P008",
@@ -529,6 +532,7 @@ def test_catalog_k_series_present() -> None:
         "K011",
         "K012",
         "K013",
+        "K014",
     }
     missing = expected - k_ids
     assert not missing, f"Missing K-series rules: {missing}"

--- a/packages/conformance/tests/test_release_contract.py
+++ b/packages/conformance/tests/test_release_contract.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
 from conformance.suite.checks.release_contract import discover, scan_all
 from conformance.suite.rules import get_rule
 from conformance.suite.schema.disposition import EnforcementTier, RuleScope
@@ -238,3 +239,110 @@ def test_clean_setup_produces_no_findings(tmp_path: Path) -> None:
         tmp_path, atlan=_ATLAN_WITH_APP_ID, pyproject=_PYPROJECT_WITH_GENERATE
     )
     assert _ids(findings) == []
+
+
+# ---------------------------------------------------------------------------
+# K014 — release_model must be a declared, valid choice
+# ---------------------------------------------------------------------------
+
+
+def test_k014_rule_metadata() -> None:
+    rule = get_rule("K014")
+    assert rule.name == "ReleaseModelUndeclared"
+    assert rule.tier is EnforcementTier.WARN
+    assert rule.scope is RuleScope.APP
+    assert rule.category == "contract-toolkit"
+
+
+def test_k014_fires_when_release_model_absent(tmp_path: Path) -> None:
+    """The fleet-wide default case: no key at all, so the app inherits 'cd'."""
+    findings = _app_repo(tmp_path, atlan="name: openapi\napp_id: abc\n")
+    assert "K014" in _ids(findings)
+
+
+def test_k014_silent_on_explicit_semver(tmp_path: Path) -> None:
+    findings = _app_repo(tmp_path, atlan=_ATLAN_WITH_APP_ID)
+    assert "K014" not in _ids(findings)
+
+
+def test_k014_silent_on_explicit_cd(tmp_path: Path) -> None:
+    """The rule wants a *declared* choice, not a particular one."""
+    findings = _app_repo(
+        tmp_path, atlan="name: openapi\napp_id: abc\nrelease_model: cd\n"
+    )
+    assert "K014" not in _ids(findings)
+
+
+def test_k014_fires_on_bare_key(tmp_path: Path) -> None:
+    findings = _app_repo(tmp_path, atlan="name: openapi\napp_id: abc\nrelease_model:\n")
+    assert "K014" in _ids(findings)
+
+
+@pytest.mark.parametrize("null", ["null", "Null", "NULL", "~", '""', "''"])
+def test_k014_fires_on_null_value(tmp_path: Path, null: str) -> None:
+    findings = _app_repo(
+        tmp_path, atlan=f"name: openapi\napp_id: abc\nrelease_model: {null}\n"
+    )
+    assert "K014" in _ids(findings)
+
+
+def test_k014_fires_on_invalid_value(tmp_path: Path) -> None:
+    findings = _app_repo(
+        tmp_path, atlan="name: openapi\napp_id: abc\nrelease_model: rolling\n"
+    )
+    k014 = [f for f in findings if f.rule_id == "K014"]
+    assert k014
+    # The fix hint must not advertise the deprecated alias.
+    assert "versioned" not in k014[0].message
+
+
+def test_k014_fires_on_deprecated_versioned_alias(tmp_path: Path) -> None:
+    findings = _app_repo(
+        tmp_path, atlan="name: openapi\napp_id: abc\nrelease_model: versioned\n"
+    )
+    k014 = [f for f in findings if f.rule_id == "K014"]
+    assert k014
+    assert "deprecated" in k014[0].message
+
+
+def test_k014_accepts_quoted_and_commented_value(tmp_path: Path) -> None:
+    findings = _app_repo(
+        tmp_path,
+        atlan='name: openapi\napp_id: abc\nrelease_model: "semver"  # deliberate\n',
+    )
+    assert "K014" not in _ids(findings)
+
+
+def test_k014_nested_release_model_does_not_satisfy(tmp_path: Path) -> None:
+    """An indented key is not the manifest-level value the publish step reads.
+
+    An indentation-blind match would report this app as compliant while the
+    publish step still falls back to 'cd'.
+    """
+    findings = _app_repo(
+        tmp_path,
+        atlan="name: openapi\napp_id: abc\ndeploy:\n  release_model: semver\n",
+    )
+    assert "K014" in _ids(findings)
+
+
+def test_k014_anchored_in_atlan_yaml(tmp_path: Path) -> None:
+    findings = _app_repo(tmp_path, atlan="name: openapi\napp_id: abc\n")
+    k014 = [f for f in findings if f.rule_id == "K014"]
+    assert k014
+    assert k014[0].file == "atlan.yaml"
+
+
+def test_k014_silent_when_no_atlan_yaml(tmp_path: Path) -> None:
+    """A missing atlan.yaml is K004's regeneration concern, not this rule's."""
+    findings = _app_repo(tmp_path, atlan=None)
+    assert "K014" not in _ids(findings)
+
+
+def test_k014_suppressed_by_directive(tmp_path: Path) -> None:
+    body = "# conformance: ignore[K014] not published\nname: openapi\napp_id: abc\n"
+    findings = _app_repo(tmp_path, atlan=body)
+    k014 = [f for f in findings if f.rule_id == "K014"]
+    assert k014
+    assert k014[0].suppressed is True
+    assert "K014" not in _ids(findings)


### PR DESCRIPTION
## What

Adds conformance rule **K014 `ReleaseModelUndeclared`** — APP scope, WARN tier — asserting
that an app's `atlan.yaml` declares a top-level `release_model` with an allowed value.
Ships with its remediation prescription, per the detection+remediation-together rule.

## Why

A missing `release_model` is read as `cd` by the publish step
(`.github/scripts/parse_atlan_yaml.py:223`), so an app that never declares it
**auto-publishes to `channel='all'` on every merge** — not because anyone chose
continuous delivery, but because the key was absent.

The omission is silent by construction: it breaks no build, fails no test, and the
effective release model never appears in a diff, so no gate had any reason to speak up.
A fleet sweep (FND-212) found **36 of 75 connectors** in exactly that state, none of them
deliberately.

Of the three related failure modes, the other two were already caught weakly — a
contract↔yaml mismatch in either direction surfaces via the generated-freshness gate, but
only as generic advisory drift, which is why `cosmosnosql` and `mode` sat undetected with
the key declared in their contract but missing from the committed yaml. **Absence had no
detection at all.**

## What it does — and deliberately does not

Fires on: key absent · bare key · empty/null value · value outside `cd`/`semver`/`versioned`
· the deprecated `versioned` alias.

**It takes no side between `cd` and `semver`.** Absence defaults to `cd`, which is a
*legitimate* value — the defect is implicitness, not invalidity. Requiring an explicit
declaration makes the choice reviewable without imposing release policy on the owning team;
`release_model: cd` satisfies the rule. Mandating `semver` would be an above-the-bar
mandate (P-series territory) and would immediately flag apps deliberately on `cd`.

WARN tier per the new-rule discipline. Once the FND-212 PRs merge, all 75 connectors
declare it explicitly, so this rule fires **zero** times fleet-wide.

## The remediation half — the routing rule is the substance

The prescription encodes where the key belongs, because getting that backwards *is* the bug
(FND-151, FND-158):

1. Establish whether the contract emits `atlan.yaml` by **running `pkl eval -m` and
   inspecting the output** — never by inferring from the presence of `contract/app.pkl` or
   from the contract's `amends` line. Only 28 of 75 contracts actually emit it, and
   `atlan-presto-app` amends `NativeApp.pkl` yet does emit one.
2. **Emits it** → declare in the pkl `metadata` mapping (the same untyped hatch K011 uses
   for `app_id`) and regenerate. If the contract builds `atlan.yaml` itself via an inline
   `additionalOutputFiles["atlan.yaml"]` mapping, the key goes in *that* mapping.
3. **Does not emit it** → `atlan.yaml` is hand-owned; edit it directly.
4. **Abort to residue if the committed `atlan.yaml` is already drifted** beyond the one
   key — regenerating a drifted file sweeps unrelated reversions into a fix labelled
   "declare release_model".

K014 is consequently **the one K-series rule permitted to write `atlan.yaml` directly**, and
only after that emission test says the file is hand-owned. The write-scope note in
`remediate-finding.prose.md` states this explicitly rather than leaving it inherited.

## No CI change needed

The K-series matrix leg already exists and already watches
`{contract/**,atlan.yaml,app.yaml,app/generated/**}`, so the rule runs fleet-wide with no
workflow edit. Scope is auto-detected, so it no-ops on the SDK.

## Verification

- Full package suite: **2173 passed, 1 xfailed**.
- Repo-root `pre-commit run --all-files` green (the pinned-ruff reflow is committed; it
  touched only lines added here).
- Docs regenerated via `gen-rule-docs`, not hand-edited.
- **End-to-end against real repos, not fixtures:**
  - fires on `atlan-adls-app@main` (no `release_model`) — one K014 WARN;
  - silent on the same repo's `release_model: semver` branch;
  - silent on this repo (APP scope correctly excludes the SDK).

## Known coverage limit (not fixed here)

`discover()` keys off a top-level `contract/` directory, so K011/K012/K014 all no-op on
non-standard layouts — `atlan-gcs-app` (`app/contract/`) and apps with no pkl contract.
That covers ~67 of the 75 connectors. Widening `discover()` would change K011/K012
behaviour fleet-wide and belongs in its own change.

## Follow-ups

Graduate to BLOCK once fleet WARN counts are confirmed at zero. A typed `releaseModel`
field on the contract toolkit would remove the untyped-`metadata` workaround for all
contract-driven apps.

Refs FND-216. Regression guard for FND-212.
