### PR TITLE
fix(app): serialize upload's asset-validation scan to one worker

### DIFF
--- a/application_sdk/app/base.py
+++ b/application_sdk/app/base.py
@@ -239,12 +239,28 @@ async def _warn_on_invalid_transformed_assets(local_path: str, app_name: str) ->
     # Best-effort: run_best_effort isolates the scan in a child process and, on
     # any native crash / timeout / error, logs a warning and returns None — the
     # upload is never blocked, failed, or crashed by the validation scaffold.
+    #
+    # max_workers=1: serialize this across concurrent uploads on the same worker
+    # process rather than letting the default width (min(4, cpu_count)) spawn up
+    # to 4 parallel children. Each child re-imports the pyatlan/msgspec decode
+    # stack, which is the dominant memory cost here (measured ~250-300MB RSS per
+    # child from a 274-column real-world sample). On a pod handling several
+    # concurrent connector workflows — the normal case for a tenant with multiple
+    # connections on the same cron schedule — parallel children compound and can
+    # push a modestly-sized pod (e.g. 750Mi limit) into OOMKill. This is
+    # best-effort, warn-only validation off the workflow-critical path, so the
+    # added queueing latency under concurrency is an acceptable trade for
+    # bounded worst-case memory (measured ~45% lower peak RSS under 3 concurrent
+    # callers: 746MB -> 407MB for this same sample) — found investigating a
+    # production `App.upload()` heartbeat-timeout that traced to the worker
+    # pod being OOMKilled under this exact concurrent-upload pattern.
     report = await run_best_effort(
         validate_transformed_dir,
         str(target),
         label="Transformed-asset validation",
         logger=_task_logger,
         timeout=VALIDATE_ASSETS_TIMEOUT_SECONDS,
+        max_workers=1,
     )
 
     if report is None:

--- a/tests/unit/app/test_upload_asset_validation.py
+++ b/tests/unit/app/test_upload_asset_validation.py
@@ -26,7 +26,7 @@ import importlib.util
 import json
 import time
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from pyatlan_v9.model.assets import Column, Database, Schema, Table
@@ -338,6 +338,27 @@ class TestWarnOnInvalidTransformedAssets:
             logger.warning.assert_called_once()
             assert "timed out" in logger.warning.call_args.args[0]
             logger.info.assert_not_called()
+
+    async def test_scan_is_serialized_to_one_worker(self, tmp_path: Path) -> None:
+        # Regression guard: the scan must pin max_workers=1 on its
+        # run_best_effort call. Each child re-imports the pyatlan/msgspec decode
+        # stack, so letting the default width (min(4, cpu_count)) fan out lets N
+        # concurrent uploads on the same pod spawn N children in parallel — the
+        # dominant memory cost observed pushing a modestly-sized worker pod
+        # (e.g. 750Mi) into OOMKill under concurrent load. Serializing behind one
+        # child bounds worst-case memory; this is best-effort/warn-only work off
+        # the workflow-critical path, so the added queueing latency is an
+        # acceptable trade. Asserted directly on the call args (rather than
+        # behaviorally, e.g. via timing) to avoid flakiness.
+        _valid_hierarchy(tmp_path)
+        with patch.object(base_module, "_task_logger"):
+            with patch(
+                "application_sdk.execution.heartbeat.run_best_effort",
+                AsyncMock(return_value=None),
+            ) as mock_run_best_effort:
+                await _warn_on_invalid_transformed_assets(str(tmp_path), APP)
+            mock_run_best_effort.assert_called_once()
+            assert mock_run_best_effort.call_args.kwargs.get("max_workers") == 1
 
     async def test_concurrent_uploads_both_survive_timeouts(
         self, tmp_path: Path


### PR DESCRIPTION
## Context

Investigated a production `App.upload()` heartbeat-timeout (3 attempts, each dying silently ~60s in with zero log output after `activity.started`) that at first looked like an event-loop-block bug. Downloaded the real artifacts for the failing run and reproduced against the exact deployed SDK version — both suspect calls (`_warn_on_invalid_transformed_assets` and the real object-store upload) completed in a few seconds each in isolation. The actual cause, confirmed via the worker pod's own Kubernetes metrics: the pod was **OOMKilled** repeatedly during the window (`kube_pod_container_status_last_terminated_reason=OOMKilled`, restart count 0→3 in under 4 minutes) and separately evicted by the VPA Updater mid-attempt. Every upload attempt's process was killed before it could send a single heartbeat, so Temporal just waited out the full configured timeout each time — that's the "silent hang," and it isn't a hang at all.

## Root cause

`App.upload()`'s warn-only asset-validation hook (`_warn_on_invalid_transformed_assets`, BLDX-1555) isolates its pyatlan_v9/msgspec scan in a spawned child process via `run_best_effort` → `run_fault_isolated` → `ProcessPoolExecutor(spawn)`, so a native decode crash can't take the worker down (CNCT-85). The pool defaults to `max_workers=min(4, cpu_count)` — up to 4 children can run **in parallel**.

Each child re-imports the full pyatlan_v9/msgspec decode stack, which is the dominant memory cost — not the data volume being validated (the failing run was tiny: 45 tables / 274 columns). The affected tenant runs several MySQL connections on the same cron schedule sharing one worker deployment, so concurrent uploads each submit to the same shared pool and multiple children spawn in parallel on the same pod at once.

Reproduced locally against the real transformed-asset data from the failing run, on the exact deployed SDK version, Python 3.13:

| Scenario (3 concurrent validations, real data) | Peak RSS |
|---|---|
| Unpatched (default width, up to 4 parallel children) | **746 MB** |
| Patched (`max_workers=1`, serialized) | **391–407 MB** |

746MB is right at the affected tenant's 750Mi pod memory limit — and that number doesn't include the rest of the worker process's own baseline footprint (event loop, Temporal SDK, obstore, other in-flight workflow state), which stacks on top of it in production.

## Fix

Pin `max_workers=1` on this one `run_best_effort(...)` call site, serializing the scan across concurrent uploads on the same worker process instead of letting it fan out to 4-wide. This is best-effort, warn-only validation off the workflow-critical path — the added queueing latency under concurrency is an acceptable trade for bounded worst-case memory (~45% lower peak RSS in the measurement above).

This is a shared-infra fix (`App.upload()` is used by every connector app), not connector-specific.

## A note on `test_concurrent_real_decodes_all_succeed_and_worker_survives`

That existing test (added for the msgspec 0.20.0 concurrent-decode segfault, CNCT-85) explicitly fans out 8 concurrent validations and asserts they run "genuinely in PARALLEL across child processes" as its regression coverage. Serializing here changes that test's actual execution shape (still passes — the assertions are behavioral, not timing-based — but it's no longer exercising true parallelism). I checked whether this reopens the segfault risk: `msgspec` is now pinned at **0.21.1**, which per that test's own comment already made same-process concurrent decode safe *regardless of pool width or process topology*. So serializing here does not reintroduce the original bug this test guards against.

## Tests

- Added `test_scan_is_serialized_to_one_worker` — asserts `max_workers=1` directly on the `run_best_effort` call args (avoids timing-based flakiness).
- `uv sync --all-extras --all-groups && uv run pytest tests/unit/` → **6388 passed, 0 failed, 9 skipped** (pre-existing skips).
- `ruff check` / `ruff format --check` / `isort --profile black --check-only` clean on both changed files (pinned versions from `.pre-commit-config.yaml`: ruff 0.6.4, isort 5.13.2).

## Scope

No refactoring, no unrelated cleanup — one kwarg + a comment explaining why, plus one new test. Net diff: `application_sdk/app/base.py` (+16), `tests/unit/app/test_upload_asset_validation.py` (+22).

## Downstream impact — please read

Downstream apps pin their own `atlan-application-sdk` version and will **not** pick this up until they bump their dependency after release. This PR does not touch any downstream app.

This reduces the *chance* of OOM under concurrency but doesn't eliminate it on its own — a pod that's already this tight on memory for its real concurrent load may still need a bump; that's a per-tenant infra/Helm decision, out of scope here.

## Review

This touches shared infrastructure (`App.upload()`) used across the connector fleet — please route to a maintainer/SDK-team review rather than a fast-path merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)