### PR TITLE
ci(tests): stop merge-queue entries cancelling each other's connector runs

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -415,13 +415,21 @@ jobs:
   # Connector tests: dispatches tests.yaml to each connector repo.
   # Triggers:
   #   merge_group — always runs on code-changing merge queue entries (the
-  #     primary gate). Each entry has a unique SHA so runs are parallel.
+  #     primary gate). Each entry has a unique SHA, but note the SDK's SHA is
+  #     NOT what scopes the connector-side concurrency groups: on the dispatch
+  #     path github.ref over there is the connector's own refs/heads/main. The
+  #     unit/integration groups in tests-reusable are therefore run-unique off
+  #     the PR path — see the long note on that job. Don't reintroduce a
+  #     ref-keyed group for anything a merge-queue batch can reach.
   #     build-sdk-base-image is skipped here, so base_image_ref is omitted
   #     and connectors build FROM the released base.
   #   pull_request + 'e2e' label — opt-in during PR development; also used
   #     to release-gate the release PR before merging. The connector-side
-  #     e2e job serialises itself via its own concurrency group, so
-  #     simultaneous e2e-labelled PRs queue safely on the connector side.
+  #     e2e job serialises itself via its own concurrency group — but that
+  #     serialisation is one-deep, not a queue: GitHub holds a single pending
+  #     run per group, so a THIRD simultaneous e2e-labelled PR evicts the
+  #     waiting one as `cancelled`. Keep concurrent e2e-labelled PRs to two
+  #     until that path has a real lease (see FND-218).
   #     On this path base_image_ref is the freshly-built PR base image, so
   #     the connector is rebuilt on top of the SDK PR's runtime image.
   connector-tests:
@@ -512,8 +520,9 @@ jobs:
           # distinct_id is passed explicitly: return-dispatch v4 no longer
           # injects it (see the e2e-apps workflow-inputs description). Here it
           # is only a human breadcrumb correlating the connector run back to
-          # this SDK PR — tests-reusable keys its concurrency on github.ref and
-          # its e2e legs are cancel-in-progress:false, so nothing depends on it.
+          # this SDK PR — tests-reusable's unit/integration groups are run-unique
+          # off the PR path and its e2e legs are cancel-in-progress:false, so
+          # nothing depends on it.
           # Set to the same SHA as check-sha below so the two line up.
           workflow-inputs: ${{ github.event_name == 'merge_group' && format('{{"application_sdk_ref":"{0}","distinct_id":"{1}"}}', github.sha, github.sha) || format('{{"application_sdk_ref":"{0}","run_e2e":"true","base_image_ref":"{1}","distinct_id":"{2}"}}', github.event.pull_request.head.sha, needs.merge-sdk-base-image.outputs.image, github.event.pull_request.head.sha) }}
           wait-mode: callback

--- a/.github/workflows/tests-reusable.yaml
+++ b/.github/workflows/tests-reusable.yaml
@@ -406,7 +406,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     concurrency:
-      group: tests-unit-${{ github.ref }}
+      # See the integration job below for why the group is run-unique off the
+      # PR path. Same hazard, same fix — this job was cancelled alongside it.
+      group: tests-unit-${{ startsWith(github.ref, 'refs/pull/') && github.ref || github.run_id }}
       cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
     permissions:
       pull-requests: write  # connector-unit-tests comments the coverage delta
@@ -616,7 +618,26 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: ${{ inputs.timeout-minutes }}
     concurrency:
-      group: tests-integration-${{ github.ref }}
+      # On a PR ref the group is deliberately SHARED across the PR's commits —
+      # that is what makes cancel-in-progress supersede the previous run.
+      #
+      # Off the PR path there is nothing to serialise: this job is self-contained
+      # (testcontainers / services-script on its own runner, no tenant, no shared
+      # external resource). A shared group there is not merely useless, it is
+      # actively harmful, because GitHub keeps only ONE pending run per group —
+      # a third arrival evicts the queued one with conclusion `cancelled`.
+      #
+      # That is precisely what a cross-repo dispatch delivers: on the
+      # workflow_dispatch path github.ref is the CONNECTOR's ref (always
+      # refs/heads/main), never the application-sdk commit under test, so N
+      # concurrent SDK runs all landed in one group. application-sdk's merge queue
+      # builds several entries speculatively at once and each dispatches into every
+      # connector, so a batch of queued PRs reliably evicted each other's runs —
+      # Tests Gate then failed, report-to-sdk reported failure on the SDK SHA, and
+      # the merge-queue entry was ejected with no test having actually run.
+      #
+      # Keying on run_id off the PR path gives every run its own group.
+      group: tests-integration-${{ startsWith(github.ref, 'refs/pull/') && github.ref || github.run_id }}
       cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
     permissions:
       pull-requests: write


### PR DESCRIPTION
## Problem

Batching several PRs into the merge queue reliably ejected them. The runs looked like integration-test failures; nothing had actually failed.

Two GitHub Actions facts combine badly:

1. **On a cross-repo `workflow_dispatch`, `github.ref` is the *callee* repo's ref** — for a connector dispatch that is always `refs/heads/main`, never the application-sdk commit under test. The `unit` and `integration` jobs in `tests-reusable.yaml` keyed concurrency on `github.ref`, so every concurrent SDK dispatch landed in one group (`tests-integration-refs/heads/main`).
2. **`cancel-in-progress: false` is not a queue.** GitHub holds exactly *one* pending run per concurrency group; a third arrival evicts the waiting one with `conclusion: cancelled`.

The merge queue builds several entries speculatively at once, and each `merge_group` run dispatches into every connector repo — so ~3 dispatches per connector arrive within ~20s and cancel each other. The cancelled job fails the connector's `Tests Gate`, `Report to application-sdk` posts `failure` on the SDK SHA, the SDK's `Connector Tests Gate` fails, and the merge-queue entry is ejected.

## Evidence

Three entries were live at 01:55 on 2026-08-11 (`pr-2894-653ae887`, `pr-3008-7ef17f72`, `pr-3114-81a784f3`). atlan-openapi-app `Tests` runs:

| created | event | conclusion |
|---|---|---|
| 01:55:44 | workflow_dispatch | success |
| 01:55:45 | workflow_dispatch | **cancelled** |
| 01:55:55 | workflow_dispatch | success |
| 01:58:42 | workflow_dispatch | **cancelled** |
| 01:58:45 | workflow_dispatch | success |

- The cancelled `tests / Integration` job lived **4 seconds** (01:58:51 → 01:58:55) and has **no log blob** (`404 BlobNotFound`) — it never got a runner, the eviction signature.
- SDK gate log: `check runs did not pass: ['Connector E2E run / atlan-openapi-app', 'Connector E2E run / atlan-mysql-app']`.
- Every connector run behind both ejections was `conclusion: cancelled`, never a test `failure`: 2894's entry had mysql + metabase cancelled; 3008's entry had openapi + mysql cancelled.
- The single-entry batch that followed (`pr-3114-653ae887`, 02:03:28) passed clean.

Net effect: batching more than two PRs was self-inflicting a ~2-in-3 ejection rate.

## Change

Key the `unit` and `integration` groups on `github.run_id` off the PR path, preserving the PR-ref sharing that `cancel-in-progress` depends on:

```yaml
group: tests-integration-${{ startsWith(github.ref, 'refs/pull/') && github.ref || github.run_id }}
cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
```

These jobs are self-contained — testcontainers / `services-script` on their own runner, no tenant, no shared external resource — so serialising them off the PR path bought nothing and cost eviction. PR-ref behaviour is unchanged: a new push still supersedes the previous run.

Also corrects three comments in `pull_request.yaml` that asserted the premise this disproves ("each entry has a unique SHA so runs are parallel", "simultaneous e2e-labelled PRs queue safely on the connector side").

## Rollout

Connectors pin `tests-reusable.yaml@main`, so this takes effect fleet-wide on merge with **no per-repo change**.

## Deliberately not fixed here

The tenant-scoped groups carry the same one-pending-slot hazard, but serialisation there is load-bearing so `run_id` is not a valid fix:

- `tests-reusable.yaml` e2e legs — `tests-e2e-${{ github.ref }}-${{ matrix.name }}`
- `tests-reusable.yaml` prepare-tenant — `e2e-prepare-tenant-<app>-<cloud>`
- `e2e-full-reusable.yaml` — `e2e-full-<workflow>-<ref>-<cloud>`

Merge-queue entries don't reach these (`run_e2e` is unset on the `merge_group` path, so the legs skip), so they did not contribute to these ejections. But a **third** concurrent `e2e`-labelled PR will evict the waiting run the same way. Closing that needs a real lease rather than a concurrency group. Interim guidance is now in the workflow comment: keep concurrent `e2e`-labelled PRs to two.

Refs: FND-218
