### PR TITLE
feat(contract-toolkit): emit ui.isDelimitedBySemicolons from AdvancedJDBCUrlGroup

### DIFF
--- a/contract-toolkit/README.md
+++ b/contract-toolkit/README.md
@@ -141,7 +141,15 @@ selected upload widget plus `ui.accept`, `ui.fileMetadata`, and opt-in
 the generated default is still emitted, so no form input is required.
 For `credentialUrlGroup` forms, the visible auth panes live inside
 `jdbcUrl.properties`; root-level auth panes are hidden merge targets for agent
-credential overrides.
+credential overrides. For sources whose JDBC URL separates its parameters with
+`;` rather than the `?a=&b=` query-string form (Hive, for example, connects
+with `jdbc:hive2://host:port/db;k=v;k2=v2`), set
+`isDelimitedBySemicolons = true` on the `credentialUrlGroup`. The generated
+config then emits `ui.isDelimitedBySemicolons` on the base `jdbcUrl.ui` block
+and every per-mode/per-auth condition, and the frontend's
+`AdvancedJDBCUrlGroup.vue` rewrites the separators before parsing the URL. The
+flag is opt-in, defaults to `false`, and is omitted (not emitted as `false`)
+when unset, so existing generated output is unchanged.
 
 ### Manifest (`app/generated/manifest.json`)
 

--- a/contract-toolkit/docs/reference.md
+++ b/contract-toolkit/docs/reference.md
@@ -1172,6 +1172,7 @@ class AdvancedJDBCUrlGroup {
   urlAddonBefore: String                     // Prefix on the URL text input
   connectByDefault: "host"|"url" = "host"    // Initial radio value
   urlLabel: String = "SQLAlchemy Connection URL"
+  isDelimitedBySemicolons: Boolean = false   // For `;`-delimited JDBC URLs (e.g. Hive `jdbc:hive2://host:port/db;k=v`); emits `ui.isDelimitedBySemicolons` on the base block + every condition. Omitted (not `false`) when unset.
   urlHelp: String?
   urlPlaceholder: String?
   hostField: FieldSpec                       // Shared host row (FieldSpec re-used across auth-types)

--- a/contract-toolkit/src/App.pkl
+++ b/contract-toolkit/src/App.pkl
@@ -613,6 +613,16 @@ class AdvancedJDBCUrlGroup {
 
   urlLabel: String = "SQLAlchemy Connection URL"
 
+  /// Set for sources whose JDBC URL separates its parameters with `;` rather
+  /// than the `?a=&b=` query-string form — Hive, for example, connects with
+  /// `jdbc:hive2://host:port/db;k=v;k2=v2`.
+  ///
+  /// Renders as `ui.isDelimitedBySemicolons`, which the frontend's
+  /// `AdvancedJDBCUrlGroup.vue` reads to rewrite the separators before parsing
+  /// the URL. Without it a semicolon-delimited URL entered in URL mode does not
+  /// parse, and the host/port/database fields it feeds stay empty.
+  isDelimitedBySemicolons: Boolean = false
+
   urlHelp: String?
 
   urlPlaceholder: String?
@@ -1803,6 +1813,9 @@ local function renderJdbcBranch(
     ["protocol"] = group.protocol
     ["connectByPropertyId"] = "\(nsFor(mode)).connectBy"
     ["urlPartPropertyIdMapping"] = renderUrlPartMapping(jdbcOpt.urlPartMapping, nsFor(mode))
+    when (group.isDelimitedBySemicolons) {
+      ["isDelimitedBySemicolons"] = true
+    }
   }
 }
 
@@ -1944,6 +1957,9 @@ local function renderJdbcUrlField(
     ["connectByPropertyId"] = "credential-guid.connectBy"
     ["protocol"] = group.protocol
     ["urlPartPropertyIdMapping"] = new Mapping {}
+    when (group.isDelimitedBySemicolons) {
+      ["isDelimitedBySemicolons"] = true
+    }
   }
   ["anyOf"] = new Listing {
     for (authKey, _ in options) {

--- a/contract-toolkit/src/NativeApp.pkl
+++ b/contract-toolkit/src/NativeApp.pkl
@@ -645,6 +645,15 @@ class AdvancedJDBCUrlGroup {
   /// Label on the URL text input row.
   urlLabel: String = "SQLAlchemy Connection URL"
 
+  /// Set for sources whose JDBC URL separates its parameters with `;` rather
+  /// than the `?a=&b=` query-string form — Hive, for example, connects with
+  /// `jdbc:hive2://host:port/db;k=v;k2=v2`. Emitted as
+  /// `ui.isDelimitedBySemicolons` in both the base `jdbcUrl.ui` block and every
+  /// per-mode/per-auth condition; the frontend's `AdvancedJDBCUrlGroup.vue`
+  /// reads it to rewrite the separators before parsing the URL. Omitted when
+  /// `false` (the default), so existing generated output is unchanged.
+  isDelimitedBySemicolons: Boolean = false
+
   /// Help text on the URL text input row.
   urlHelp: String?
 
@@ -2019,6 +2028,9 @@ local function renderJdbcBranch(
     ["protocol"] = group.protocol
     ["connectByPropertyId"] = "\(nsFor(mode)).connectBy"
     ["urlPartPropertyIdMapping"] = renderUrlPartMapping(jdbcOpt.urlPartMapping, nsFor(mode))
+    when (group.isDelimitedBySemicolons) {
+      ["isDelimitedBySemicolons"] = true
+    }
   }
 }
 
@@ -2182,6 +2194,9 @@ local function renderJdbcUrlField(
     ["connectByPropertyId"] = "credential-guid.connectBy"
     ["protocol"] = group.protocol
     ["urlPartPropertyIdMapping"] = new Mapping {}
+    when (group.isDelimitedBySemicolons) {
+      ["isDelimitedBySemicolons"] = true
+    }
   }
   ["anyOf"] = new Listing {
     for (authKey, _ in options) {

--- a/contract-toolkit/tests/jdbc_auth_pane_test.pkl
+++ b/contract-toolkit/tests/jdbc_auth_pane_test.pkl
@@ -202,8 +202,35 @@ local nativeSingleAuthJdbcApp = (NativeApp) {
   }
 }
 
+/// Semicolon-delimited JDBC URL (Hive: `jdbc:hive2://host:port/db;k=v;k2=v2`).
+/// The flag has to reach every rendered `jdbcUrl` ui block — the per-mode
+/// conditions as well as the base — or the frontend parses the URL with the
+/// wrong separator and leaves the host/port/database fields empty.
+local semicolonJdbcApp = (jdbcApp) {
+  name = "jdbc-semicolon-test"
+  credentialUrlGroup = (jdbcApp.credentialUrlGroup!!) {
+    isDelimitedBySemicolons = true
+  }
+  uiConfig = new App.UIConfig {
+    tasks {
+      ["Credential"] {
+        inputs {
+          ["credential-guid"] = new App.CredentialInput {
+            credType = "atlan-connectors-jdbc-semicolon-test"
+          }
+        }
+      }
+    }
+  }
+}
+
 local credentialJson: String = jdbcApp.output.files["app/generated/atlan-connectors-jdbc-auth-test.json"].text
 local credential = new json.Parser { useMapping = true }.parse(credentialJson)
+
+local semicolonJson: String =
+  semicolonJdbcApp.output.files["app/generated/atlan-connectors-jdbc-semicolon-test.json"].text
+local semicolonProperties =
+  new json.Parser { useMapping = true }.parse(semicolonJson)["config"]["properties"]
 
 local singleAuthCredentialJson: String =
   singleAuthJdbcApp.output.files["app/generated/atlan-connectors-jdbc-single-auth-test.json"].text
@@ -248,5 +275,16 @@ facts {
     nativeSingleAuthProperties["basic"]["ui"]["hidden"] == true
     nativeSingleAuthProperties["jdbcUrl"]["properties"]["basic"]["ui"]["hidden"] == false
     nativeSingleAuthProperties["jdbcUrl"]["properties"]["auth-type"]["ui"]["hidden"] == true
+  }
+
+  ["isDelimitedBySemicolons reaches the base jdbcUrl ui and every condition"] {
+    semicolonProperties["jdbcUrl"]["ui"]["isDelimitedBySemicolons"] == true
+    semicolonProperties["jdbcUrl"]["conditions"]
+      .every((c) -> c["ui"]["isDelimitedBySemicolons"] == true)
+  }
+
+  ["isDelimitedBySemicolons is omitted, not emitted false, when unset"] {
+    !semicolonJson.contains("\"isDelimitedBySemicolons\": false")
+    !credentialJson.contains("isDelimitedBySemicolons")
   }
 }


### PR DESCRIPTION
### Changelog
- Add `isDelimitedBySemicolons: Boolean = false` to `AdvancedJDBCUrlGroup`.
- Emit it as `ui.isDelimitedBySemicolons` from both renderer sites — the base `jdbcUrl` ui block (`renderJdbcUrlField`) and each per-mode condition (`renderJdbcBranch`).
- Extend `jdbc_auth_pane_test.pkl` with a semicolon app: the flag reaches the base ui and every condition, and is omitted entirely (not emitted as `false`) when unset.

### Additional context (e.g. screenshots, logs, links)
TL;DR: the frontend already supports semicolon-delimited JDBC URLs, but the toolkit has no way to turn it on, so Hive hand-maintains its whole connector config to inject one boolean.

`atlan-frontend` reads this flag today:

- `src/types/workflow/property.ts:320` — `isDelimitedBySemicolons?: boolean` on `JDBCUrlGroupProperty`, the type shared by both JDBC widgets.
- `src/workflowsv2/components/dynamicForm2/widget/AdvancedJDBCUrlGroup.vue:67,143,257` — rewrites `;` to `?`/`&` before `new ConnectionString(...)` parses the URL.
- `.../widget/__tests__/AdvancedJDBCUrlGroup.spec.ts:154,215` — covers both parsing and generating semicolon URLs.

So `AdvancedJDBCUrlGroup` (what the toolkit emits) already handles this correctly. The only missing piece was a contract field to set it. Without the flag, a URL like `jdbc:hive2://host:port/db;k=v;k2=v2` entered in URL mode fails to parse, and the host/port/database fields it feeds stay empty.

This is why `atlan-hive-app` overwrites its generated `atlan-connectors-hive.json` wholesale from a hand-maintained copy (`docs/scripts/patch_connector_config.py`) — the app's `freshness` check is permanently red as a result. With this field, hive sets `isDelimitedBySemicolons = true` on its `credentialUrlGroup` and drops the overlay.

Additive and default-off: `when (group.isDelimitedBySemicolons)` means no existing caller's output changes by a single byte. Full toolkit suite passes — 291 tests, 699 asserts.
