### PR TITLE
feat(conformance): lane-model fleet preset + per-PR delivered-deps in the fleet scanner

### DIFF
--- a/packages/conformance/conformance/renovate/classify.py
+++ b/packages/conformance/conformance/renovate/classify.py
@@ -157,14 +157,15 @@ def derive_update_type(pr: RenovatePR) -> UpdateType:
 _BODY_TABLE_NAME_RE = re.compile(
     r"^\|\s*(?:\[(?P<linked>[^\]]+)\]|(?P<bare>[^|\[\]]+?))\s*(?:\(|\|)"
 )
-_BODY_TABLE_CHANGE_RE = re.compile(r"`(?P<from>[^`]+)`\s*->\s*`(?P<to>[^`]+)`")
+_BODY_TABLE_CHANGE_RE = re.compile(r"`(?P<from>[^`]+)`\s*(?:->|→)\s*`(?P<to>[^`]+)`")
 
 # Title fallback: "chore(deps): update dependency atlan-application-sdk to v3.27.0",
-# "chore(deps): update app-contract-toolkit to v0.18.1". Grouped titles without a
-# trailing version ("update non-critical python dependencies") deliberately don't
-# match — there is no version to report.
+# "chore(deps): update app-contract-toolkit to v0.18.1",
+# "chore(deps): update anthropics/claude-code-action action to v1.0.190". Grouped
+# titles without a trailing version ("update non-critical python dependencies")
+# deliberately don't match — there is no version to report.
 _TITLE_DEP_RE = re.compile(
-    r"update (?:dependency )?(?P<name>[A-Za-z0-9._/@-]+) to v?(?P<to>\d[\w.+-]*)",
+    r"update (?:dependency )?(?P<name>[A-Za-z0-9._/@-]+)(?: action)? to v?(?P<to>\d[\w.+-]*)",
     re.IGNORECASE,
 )
 

--- a/packages/conformance/conformance/renovate/classify.py
+++ b/packages/conformance/conformance/renovate/classify.py
@@ -28,6 +28,7 @@ from conformance.renovate.models import (
     BlockingReason,
     Category,
     ChecksState,
+    PRDep,
     RenovatePR,
     UpdateType,
 )
@@ -38,6 +39,7 @@ _LABEL_CATEGORY_MAP: dict[str, Category] = {
     "update:github-actions": Category.GITHUB_ACTIONS,
     "contract-toolkit-update": Category.CONTRACT_TOOLKIT,
     "conformance-package-update": Category.CONFORMANCE_PACKAGE,
+    "sdk-package-update": Category.SDK_PACKAGE,
 }
 _LABEL_UPDATE_TYPE_MAP: dict[str, UpdateType] = {
     "update:major": UpdateType.MAJOR,
@@ -46,6 +48,11 @@ _LABEL_UPDATE_TYPE_MAP: dict[str, UpdateType] = {
     "update:digest": UpdateType.DIGEST,
     "update:pin": UpdateType.PIN,
 }
+
+# The runtime SDK package — matched in branch slugs (renovate/atlan-application-sdk-3.x)
+# and titles ("update dependency atlan-application-sdk to v3.27.0"). The negative
+# lookahead keeps atlan-application-sdk-conformance from matching.
+_SDK_PACKAGE_RE = re.compile(r"atlan-application-sdk(?!-conformance)")
 
 # Allowed file patterns for the auto-approve gate (mirrors renovate-auto-approve-reusable.yml).
 _DEP_FILE_RE = re.compile(
@@ -96,8 +103,14 @@ def categorize(pr: RenovatePR) -> Category:
         "conformance-package" in branch
         or "application-sdk-conformance" in branch
         or "conformance package" in title
+        or "application-sdk-conformance" in title
     ):
         return Category.CONFORMANCE_PACKAGE
+    # SDK check must come AFTER conformance: "atlan-application-sdk" is a
+    # prefix of "atlan-application-sdk-conformance", so the negative lookahead
+    # alone isn't enough for grouped-branch slugs that drop the suffix.
+    if _SDK_PACKAGE_RE.search(branch) or _SDK_PACKAGE_RE.search(title):
+        return Category.SDK_PACKAGE
 
     return Category.PYTHON_DEP
 
@@ -136,6 +149,79 @@ def derive_update_type(pr: RenovatePR) -> UpdateType:
     return update_type_from_body(pr.body)
 
 
+# Renovate PR body version-table row: first cell is the package (usually a
+# markdown link, sometimes bare text), and the Change cell renders the version
+# move as `old` -> `new`. Cell-internal parentheses (changelog links, "(source)")
+# and extra columns vary by manager, so match loosely: name from the first cell,
+# then the first backtick-quoted arrow pair anywhere on the same row.
+_BODY_TABLE_NAME_RE = re.compile(
+    r"^\|\s*(?:\[(?P<linked>[^\]]+)\]|(?P<bare>[^|\[\]]+?))\s*(?:\(|\|)"
+)
+_BODY_TABLE_CHANGE_RE = re.compile(r"`(?P<from>[^`]+)`\s*->\s*`(?P<to>[^`]+)`")
+
+# Title fallback: "chore(deps): update dependency atlan-application-sdk to v3.27.0",
+# "chore(deps): update app-contract-toolkit to v0.18.1". Grouped titles without a
+# trailing version ("update non-critical python dependencies") deliberately don't
+# match — there is no version to report.
+_TITLE_DEP_RE = re.compile(
+    r"update (?:dependency )?(?P<name>[A-Za-z0-9._/@-]+) to v?(?P<to>\d[\w.+-]*)",
+    re.IGNORECASE,
+)
+
+
+def extract_deps(pr: RenovatePR) -> tuple[PRDep, ...]:
+    """Which packages this PR delivers, as (name, from, to) triples.
+
+    Body version-table first (authoritative — grouped PRs list every package
+    there and their titles carry no version), title parse as fallback for
+    bodies that are empty or unrecognisable. Lock-file-maintenance PRs have no
+    table and yield () — they deliver in-range bumps invisibly, which is
+    exactly why downstream freshness tooling needs the explicit deps on every
+    other category.
+    """
+    deps: list[PRDep] = []
+    seen: set[tuple[str, str]] = set()
+    for line in pr.body.splitlines():
+        name_m = _BODY_TABLE_NAME_RE.match(line.strip())
+        if not name_m:
+            continue
+        name = (name_m.group("linked") or name_m.group("bare") or "").strip()
+        # Skip the header row and separator rows.
+        if (
+            not name
+            or name.lower() in {"package", "dependency", "update"}
+            or set(name) <= {"-", ":"}
+        ):
+            continue
+        change_m = _BODY_TABLE_CHANGE_RE.search(line)
+        if not change_m:
+            continue
+        key = (name, change_m.group("to").strip())
+        if key in seen:
+            continue
+        seen.add(key)
+        deps.append(
+            PRDep(
+                name=name,
+                from_version=change_m.group("from").strip(),
+                to_version=change_m.group("to").strip(),
+            )
+        )
+    if deps:
+        return tuple(deps)
+
+    title_m = _TITLE_DEP_RE.search(pr.title)
+    if title_m:
+        return (
+            PRDep(
+                name=title_m.group("name"),
+                from_version="",
+                to_version=title_m.group("to"),
+            ),
+        )
+    return ()
+
+
 def auto_merge_expected(category: Category, update_type: UpdateType) -> bool:
     """
     Mirror renovate-config/default.json auto-merge policy.
@@ -143,6 +229,7 @@ def auto_merge_expected(category: Category, update_type: UpdateType) -> bool:
     lock-maintenance → always auto (uv.lock refresh, in-range)
     github-actions   → always auto (incl. major; validated by CI gate)
     contract-toolkit → auto for minor/patch; human for major
+    sdk-package      → always human (runtime SDK bumps are a deliberate merge)
     python-dep       → always human (edits pyproject.toml constraint → out-of-range)
     """
     if category == Category.LOCK_MAINTENANCE:
@@ -256,4 +343,5 @@ def classify(pr: RenovatePR) -> RenovatePR:
         auto_merge_expected=ame,
         blocking_reason=br,
         age_days=age,
+        deps=extract_deps(pr),
     )

--- a/packages/conformance/conformance/renovate/models.py
+++ b/packages/conformance/conformance/renovate/models.py
@@ -15,6 +15,7 @@ class Category(str, Enum):
     GITHUB_ACTIONS = "github-actions"
     CONTRACT_TOOLKIT = "contract-toolkit"
     CONFORMANCE_PACKAGE = "conformance-package"
+    SDK_PACKAGE = "sdk-package"
     PYTHON_DEP = "python-dep"
     UNKNOWN = "unknown"
 
@@ -70,6 +71,22 @@ class ChecksState(str, Enum):
 
 
 @dataclass(frozen=True)
+class PRDep:
+    """One dependency a Renovate PR delivers: package name + version change.
+
+    Parsed from the PR body's version table (primary) or the PR title
+    (fallback) — see ``classify.extract_deps``. Versions are kept verbatim as
+    Renovate rendered them (a constraint change may read ``>=3.20,<4``, a
+    lockfile bump ``3.26.1``); consumers that need semver should parse
+    defensively. ``from_version`` may be empty when only the target version is
+    known (title-only parse)."""
+
+    name: str
+    from_version: str
+    to_version: str
+
+
+@dataclass(frozen=True)
 class RenovatePR:
     """Normalised representation of a single Renovate PR."""
 
@@ -96,6 +113,11 @@ class RenovatePR:
     auto_merge_expected: bool = False
     blocking_reason: BlockingReason = BlockingReason.UNKNOWN
     age_days: int = 0
+    # populated by classify() from the PR body/title — which packages this PR
+    # delivers, so downstream dashboards can join "repo is behind on tool X" to
+    # the exact PR that fixes it. Empty for lock-file-maintenance PRs (they
+    # carry no version table) and unparseable bodies.
+    deps: tuple[PRDep, ...] = ()
 
 
 @dataclass

--- a/packages/conformance/conformance/renovate/scan.py
+++ b/packages/conformance/conformance/renovate/scan.py
@@ -210,6 +210,13 @@ def _pr_to_dict(pr: RenovatePR) -> dict:
         "ageDays": pr.age_days,
         "createdAt": pr.created_at.isoformat(),
         "updatedAt": pr.updated_at.isoformat(),
+        # Which packages this PR delivers (parsed from body table / title) —
+        # lets the fleet-freshness dashboard join "repo behind on tool X" to
+        # the exact PR that fixes it. Empty for lock-maintenance PRs.
+        "deps": [
+            {"name": d.name, "from": d.from_version, "to": d.to_version}
+            for d in pr.deps
+        ],
     }
 
 

--- a/packages/conformance/tests/test_renovate_classify.py
+++ b/packages/conformance/tests/test_renovate_classify.py
@@ -608,3 +608,35 @@ def test_extract_deps_grouped_title_without_version_yields_empty() -> None:
         make_pr(body="", title="chore(deps): update non-critical python dependencies")
     )
     assert pr.deps == ()
+
+
+# Live Renovate bodies render the Change column with a Unicode arrow — captured
+# from PR #3117 on this repo (an `update … action to …` github-actions PR). The
+# parser must match what Renovate actually emits, not an idealized ASCII table.
+_LIVE_BODY_TABLE_UNICODE_ARROW = """\
+This PR contains the following updates:
+
+| Package | Type | Update | Change |
+|---|---|---|---|
+| [atlanhq/application-sdk](https://redirect.github.com/atlanhq/application-sdk) | action | patch | `v3.27.0` → `v3.27.1` |
+"""
+
+
+def test_extract_deps_from_live_body_table_unicode_arrow() -> None:
+    pr = classify(make_pr(body=_LIVE_BODY_TABLE_UNICODE_ARROW))
+    assert [(d.name, d.from_version, d.to_version) for d in pr.deps] == [
+        ("atlanhq/application-sdk", "v3.27.0", "v3.27.1")
+    ]
+
+
+def test_extract_deps_title_fallback_action_form() -> None:
+    # Live title of PR #3112: github-actions bumps say "update X action to vY".
+    pr = classify(
+        make_pr(
+            body="no table here",
+            title="chore(deps): update anthropics/claude-code-action action to v1.0.190",
+        )
+    )
+    assert [(d.name, d.from_version, d.to_version) for d in pr.deps] == [
+        ("anthropics/claude-code-action", "", "1.0.190")
+    ]

--- a/packages/conformance/tests/test_renovate_classify.py
+++ b/packages/conformance/tests/test_renovate_classify.py
@@ -483,3 +483,128 @@ def test_parse_checks_state_failing_checkrun_not_classified_green() -> None:
 
 def test_parse_checks_state_empty_rollup() -> None:
     assert _parse_checks_state([]) is ChecksState.UNKNOWN
+
+
+# ── Category: sdk-package ────────────────────────────────────────────────────
+
+
+def test_category_sdk_package_via_label() -> None:
+    pr = classify(make_pr(labels=["sdk-package-update"]))
+    assert pr.category is Category.SDK_PACKAGE
+
+
+def test_category_sdk_package_fallback_branch() -> None:
+    pr = classify(make_pr(labels=[], branch="renovate/atlan-application-sdk-3.x"))
+    assert pr.category is Category.SDK_PACKAGE
+
+
+def test_category_sdk_package_fallback_title() -> None:
+    pr = classify(
+        make_pr(
+            labels=[],
+            branch="renovate/some-branch",
+            title="chore(deps): update dependency atlan-application-sdk to v3.27.0",
+        )
+    )
+    assert pr.category is Category.SDK_PACKAGE
+
+
+def test_category_sdk_does_not_steal_conformance() -> None:
+    # "atlan-application-sdk" is a prefix of the conformance package name, so
+    # the conformance check must win for both branch and title variants.
+    pr = classify(
+        make_pr(labels=[], branch="renovate/atlan-application-sdk-conformance-0.x")
+    )
+    assert pr.category is Category.CONFORMANCE_PACKAGE
+    pr = classify(
+        make_pr(
+            labels=[],
+            branch="renovate/some-branch",
+            title="Update dependency atlan-application-sdk-conformance to v0.14.0",
+        )
+    )
+    assert pr.category is Category.CONFORMANCE_PACKAGE
+
+
+def test_auto_merge_expected_sdk_package() -> None:
+    # Runtime SDK bumps are a deliberate human merge regardless of update type.
+    pr = classify(make_pr(labels=["sdk-package-update", "update:patch"]))
+    assert pr.auto_merge_expected is False
+    assert pr.blocking_reason is BlockingReason.AWAITING_HUMAN_REVIEW
+
+
+# ── extract_deps: PR → delivered packages ────────────────────────────────────
+
+
+_SDK_BODY_TABLE = """\
+This PR contains the following updates:
+
+| Package | Change | Age | Adoption | Passing | Confidence |
+|---|---|---|---|---|---|
+| [atlan-application-sdk](https://redirect.github.com/atlanhq/application-sdk) ([changelog](https://example)) | `3.26.0` -> `3.27.0` | ok | ok | ok | ok |
+"""
+
+_GROUP_BODY_TABLE = """\
+| Package | Change |
+|---|---|
+| [requests](https://example) | `2.31.0` -> `2.32.1` |
+| pydantic | `2.7.0` -> `2.8.0` |
+"""
+
+
+def test_extract_deps_from_body_table_linked() -> None:
+    pr = classify(make_pr(body=_SDK_BODY_TABLE))
+    assert [(d.name, d.from_version, d.to_version) for d in pr.deps] == [
+        ("atlan-application-sdk", "3.26.0", "3.27.0")
+    ]
+
+
+def test_extract_deps_from_body_table_grouped_multiple_rows() -> None:
+    # Grouped PRs: every package row is captured; header/separator rows are not.
+    pr = classify(make_pr(body=_GROUP_BODY_TABLE))
+    assert [(d.name, d.to_version) for d in pr.deps] == [
+        ("requests", "2.32.1"),
+        ("pydantic", "2.8.0"),
+    ]
+
+
+def test_extract_deps_title_fallback_when_no_table() -> None:
+    pr = classify(
+        make_pr(
+            body="no table here",
+            title="chore(deps): update dependency atlan-application-sdk to v3.27.0",
+        )
+    )
+    assert [(d.name, d.from_version, d.to_version) for d in pr.deps] == [
+        ("atlan-application-sdk", "", "3.27.0")
+    ]
+
+
+def test_extract_deps_custom_manager_title() -> None:
+    # The contract-toolkit custom manager drops the "dependency" word.
+    pr = classify(
+        make_pr(body="", title="chore(deps): update app-contract-toolkit to v0.18.1")
+    )
+    assert [(d.name, d.to_version) for d in pr.deps] == [
+        ("app-contract-toolkit", "0.18.1")
+    ]
+
+
+def test_extract_deps_lock_maintenance_empty() -> None:
+    # Lock refresh PRs carry no version table and no versioned title.
+    pr = classify(
+        make_pr(
+            labels=["update:lock-maintenance"],
+            title="Lock file maintenance",
+            branch="renovate/lock-file-maintenance",
+            body="This PR refreshes the lock file.",
+        )
+    )
+    assert pr.deps == ()
+
+
+def test_extract_deps_grouped_title_without_version_yields_empty() -> None:
+    pr = classify(
+        make_pr(body="", title="chore(deps): update non-critical python dependencies")
+    )
+    assert pr.deps == ()

--- a/renovate-config/default.json
+++ b/renovate-config/default.json
@@ -12,7 +12,7 @@
   ],
   "rebaseWhen": "behind-base-branch",
   "prHourlyLimit": 0,
-  "prConcurrentLimit": 5,
+  "prConcurrentLimit": 8,
   "labels": [
     "dependencies"
   ],
@@ -28,7 +28,7 @@
     "github-actions[bot]@users.noreply.github.com"
   ],
   "lockFileMaintenance": {
-    "description": "Python in-range deps: refresh uv.lock without touching pyproject.toml; auto-merge on green.",
+    "description": "Python in-range deps: refresh uv.lock without touching pyproject.toml; auto-merge on green. prPriority 5: the lock-refresh lane is created ahead of the non-critical crowd but after the SDK / conformance / toolkit lanes (see the lane-model packageRules below).",
     "enabled": true,
     "schedule": [
       "at any time"
@@ -36,6 +36,7 @@
     "automerge": true,
     "automergeType": "pr",
     "platformAutomerge": true,
+    "prPriority": 5,
     "addLabels": [
       "update:lock-maintenance"
     ]
@@ -52,6 +53,17 @@
       "enabled": false
     },
     {
+      "description": "SDK lane: give atlan-application-sdk bumps their own uv.lock-only PR (rangeStrategy update-lockfile, mirroring the conformance-package rule) instead of riding the batched lockFileMaintenance refresh \u2014 a stale lock-refresh branch that is not behind main never re-resolves, so it can sit pinned one SDK release behind indefinitely. prPriority 10: when prConcurrentLimit is contended, the SDK PR is created before every other dependency PR (Renovate cannot exempt a package from the limit; priority ordering + the bounded lanes below are the substitute). Deliberately NOT auto-merged \u2014 runtime SDK bumps stay human-reviewed, matching the python-dep policy. The sdk-package-update label is the fleet scanner's classification signal.",
+      "matchPackageNames": [
+        "atlan-application-sdk"
+      ],
+      "rangeStrategy": "update-lockfile",
+      "prPriority": 10,
+      "addLabels": [
+        "sdk-package-update"
+      ]
+    },
+    {
       "description": "app-contract-toolkit (Pkl): minor+patch in one PR; auto-merge on green. Matched by the regex customManager below. postUpgradeTasks re-resolves contract/PklProject.deps.json and regenerates app/generated/** (+ atlan.yaml/app.yaml) in-branch via the shared renovate-pkl-sync driver, so the bump lands as a self-contained PR with no follow-up glue workflow. Runs ONLY under self-hosted Renovate: postUpgradeTasks commands are gated by the allowedCommands admin allowlist (set in application-sdk's central renovate workflow), so this block is an inert no-op under the Mend-hosted app. The driver is installed as a bare PATH command by that workflow (Renovate does NOT shell-expand the command, so it must not contain ${VARS}); --no-commit leaves the fileFilters commit to Renovate.",
       "matchManagers": [
         "custom.regex"
@@ -64,6 +76,7 @@
       "automerge": true,
       "automergeType": "pr",
       "platformAutomerge": true,
+      "prPriority": 9,
       "addLabels": [
         "contract-toolkit-update"
       ],
@@ -97,6 +110,7 @@
       ],
       "rangeStrategy": "update-lockfile",
       "groupName": "conformance package",
+      "prPriority": 9,
       "addLabels": [
         "conformance-package-update"
       ]
@@ -113,6 +127,38 @@
       "automerge": true,
       "automergeType": "pr",
       "platformAutomerge": true
+    },
+    {
+      "description": "Lane model: group every OTHER PyPI dependency's non-major updates into ONE rolling PR. With bounded lanes — SDK (1) + conformance (1) + contract-toolkit (1) + lock maintenance (1) + this group (1) + github-actions (1) — the crowd occupies a single prConcurrentLimit slot and can never starve the critical lanes, which soft-mode repos previously hit: 5 human-review dep PRs squatting every slot meant an SDK bump PR was simply never created. Excludes the packages with dedicated lanes above.",
+      "matchDatasources": [
+        "pypi"
+      ],
+      "matchPackageNames": [
+        "!atlan-application-sdk",
+        "!atlan-application-sdk-conformance"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "pin",
+        "digest"
+      ],
+      "groupName": "non-critical python dependencies",
+      "prPriority": 0
+    },
+    {
+      "description": "Lane model: majors of non-critical PyPI deps stay individual PRs (a red major must not block the grouped non-major lane) but carry the lowest priority, so they are created last whenever prConcurrentLimit is contended.",
+      "matchDatasources": [
+        "pypi"
+      ],
+      "matchPackageNames": [
+        "!atlan-application-sdk",
+        "!atlan-application-sdk-conformance"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "prPriority": -1
     },
     {
       "description": "GitHub Actions: group all update types (including major) in one PR; auto-merge on green. Major action bumps are safe to auto-merge because the auto-approval workflow gates on green CI, which validates behaviour. Unlike Python deps, action majors are frequent and low-risk compared to library API changes.",


### PR DESCRIPTION
## Why

Two systemic gaps in the fleet Renovate setup:

1. **PR-slot starvation.** `prConcurrentLimit: 5` means a repo with 5 open dependency PRs (common on soft-mode repos where every PR awaits human review) never gets an SDK / conformance / toolkit bump PR at all. Renovate cannot exempt a package from the limit — only `prPriority` is allowed inside `packageRules` — so the fix has to be structural.
2. **Frozen resolutions.** In-range SDK bumps ride the batched lock-file-maintenance PR, whose branch is typically *not behind main* and therefore never rebased — it can sit pinned one release behind indefinitely (recent trino example).

## What

### Lane model (`renovate-config/default.json`)
Bounded lanes so the critical bumps always have a slot:

| Lane | Change |
|---|---|
| `atlan-application-sdk` | dedicated uv.lock-only PR (`rangeStrategy: update-lockfile`, mirroring the conformance-package rule), `prPriority: 10`, new `sdk-package-update` label. **Stays human-reviewed** (no automerge change). |
| conformance package | `prPriority: 9` |
| app-contract-toolkit | `prPriority: 9` |
| lock-file maintenance | `prPriority: 5` |
| every other PyPI dep (non-major) | grouped into ONE rolling "non-critical python dependencies" PR, `prPriority: 0` |
| other PyPI majors | stay individual (a red major must not block the group), `prPriority: -1` — created last |
| `prConcurrentLimit` | 5 → 8 headroom |

Config validated against the current Renovate JSON schema.

### Fleet scanner: per-PR delivered deps
The freshness dashboard needs to join *"repo behind on tool X"* → *"the exact PR that fixes it"*. Mirror PRs only carried title/branch, and grouped titles have no version. The scanner now emits:
- `deps: [{name, from, to}]` per PR — parsed from the body version table (authoritative for grouped PRs) with a title fallback; lock-maintenance PRs correctly yield `[]`.
- a dedicated `sdk-package` category driven by the new label (title/branch fallback with a negative-lookahead so it never steals `…-sdk-conformance` PRs), `auto_merge_expected=False`.
- fixes the conformance title fallback missing the bare package name.

## Testing
- `pytest packages/conformance/tests/` — 2496 passed (13 new classifier/deps cases).
- `jsonschema` validation of the edited preset against `docs.renovatebot.com/renovate-schema.json`.
- pre-commit (ruff, pyright, isort) clean.

## Companion PR
- atlanhq/connector-pulse#828 — consumes `deps` for the dashboard fix-PR join and adds the daily nudge workflow.

## Rollout notes
- Existing open per-dep PRs are unaffected; grouping applies to newly created branches. Repos' soft-mode overrides (`automerge: false`) still apply on top of the preset.
- The nudge workflow's dispatch arm needs `actions: write` on the `atlan-app-fleet` App to trigger `renovate.yaml` cross-repo — worth verifying after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)