### PR TITLE
ci(tests): report a cancelled connector run as cancelled, not failed

### DIFF
--- a/.github/actions/verify-test-gate/action.yaml
+++ b/.github/actions/verify-test-gate/action.yaml
@@ -71,8 +71,16 @@ outputs:
   conclusion:
     description: |
       The same verdict as `passed`, spelled as a GitHub Checks API conclusion
-      ("success" / "failure"). Lets the cross-repo callback complete the SDK-side
-      check run from this action directly, instead of re-deriving the verdict.
+      ("success" / "failure" / "cancelled"). Lets the cross-repo callback
+      complete the SDK-side check run from this action directly, instead of
+      re-deriving the verdict.
+
+      "cancelled" is emitted for a BLOCKED gate whose only non-passing results
+      are cancellations — a manual cancel, a superseded commit, or a
+      concurrency-group eviction. `passed` is still "false" there (an un-run
+      test must never green a merge), but reporting it as "failure" tells a
+      reviewer on the dispatching SDK PR that their change broke the connector,
+      which sends them into the wrong diff (FND-218).
     value: ${{ steps.gate.outputs.conclusion }}
   unit-status:
     description: Human-readable status for the unit row.

--- a/.github/actions/verify-test-gate/verify_test_gate.py
+++ b/.github/actions/verify-test-gate/verify_test_gate.py
@@ -74,6 +74,22 @@ import sys
 # "e2e not requested" and "discovery skipped"; anything else fails the gate.
 _OK_OPTIONAL = ("success", "skipped")
 
+# A job that never ran to a verdict. GitHub reports this for a manual cancel,
+# for a run superseded via cancel-in-progress — and for a concurrency-group
+# EVICTION, which is the one worth spelling out: GitHub keeps only ONE pending
+# run per group, so a third arrival cancels the queued one before it is ever
+# given a runner (no log output at all). None of these are test failures, and
+# the fix for all of them is "re-run", not "triage the diff". The gate still
+# BLOCKS — an un-run test cannot green a merge — but it must not report the
+# result as though the code was found wanting. See FND-218.
+_CANCELLED = "cancelled"
+
+_CANCELLED_GUIDANCE = (
+    "no test reported a verdict: the job(s) above were cancelled, not failed "
+    "(manual cancel, superseded commit, or a concurrency-group eviction). "
+    "Re-run rather than triage the diff."
+)
+
 
 def _install_path(
     build_e2e_image: str, merge_e2e_image: str, prepare_tenant: str
@@ -177,11 +193,56 @@ def evaluate(
     return errors
 
 
+def cancelled_only(
+    unit: str,
+    integration: str,
+    detect_integration: str,
+    discover_e2e: str,
+    e2e: str,
+    detect_merge_queue: str = "skipped",
+    build_e2e_image: str = "skipped",
+    merge_e2e_image: str = "skipped",
+    prepare_tenant: str = "skipped",
+) -> bool:
+    """True when at least one job was cancelled and nothing actually failed.
+
+    Deliberately requires a cancellation to be *present* rather than merely an
+    absence of failures. The "discovery succeeded but the matrix was skipped"
+    anomaly produces an error while every result sits in ``_OK_OPTIONAL``;
+    treating that as a cancellation would hide a real misconfiguration behind a
+    "just re-run" verdict — the opposite of what this distinction is for.
+    """
+    non_ok = [
+        result
+        for result in (
+            unit,
+            integration,
+            detect_integration,
+            discover_e2e,
+            e2e,
+            detect_merge_queue,
+            build_e2e_image,
+            merge_e2e_image,
+            prepare_tenant,
+        )
+        if result not in _OK_OPTIONAL
+    ]
+    return bool(non_ok) and all(result == _CANCELLED for result in non_ok)
+
+
+# Row text for a job that was cancelled. Distinct glyph from ❌ on purpose: the
+# summary table is the first thing read, and "failed" there sends a reviewer
+# into a diff that is not the problem.
+_CANCELLED_ROW = "🚫 Cancelled — not run"
+
+
 def _unit_status(unit: str) -> str:
     if unit == "success":
         return "✅ Passed"
     if unit == "skipped":
         return "⊘ Skipped"
+    if unit == _CANCELLED:
+        return _CANCELLED_ROW
     return "❌ Failed"
 
 
@@ -191,12 +252,18 @@ def _integration_status(
     # A detection failure drops integration to a skip; surface that as a failure
     # rather than the benign "skipped" string, so the display never claims the
     # tier was cleanly skipped when detection actually broke.
+    if detect_merge_queue == _CANCELLED:
+        return "🚫 Merge-queue detection cancelled — not run"
     if detect_merge_queue not in _OK_OPTIONAL:
         return "❌ Merge-queue detection failed"
+    if detect_integration == _CANCELLED:
+        return "🚫 Integration-suite detection cancelled — not run"
     if detect_integration not in _OK_OPTIONAL:
         return "❌ Integration-suite detection failed"
     if integration == "success":
         return "✅ Passed"
+    if integration == _CANCELLED:
+        return _CANCELLED_ROW
     if integration == "skipped":
         # Two distinct reasons, and the difference matters to a reader deciding
         # whether their change was actually exercised: a queue will run the tier
@@ -214,6 +281,8 @@ def _e2e_status(
 ) -> str:
     if discover_e2e == "skipped":
         return "⊘ Skipped — add `e2e` label to trigger"
+    if discover_e2e == _CANCELLED:
+        return "🚫 e2e discovery cancelled — not run"
     if discover_e2e == "failure":
         return "❌ No suites discovered (e2e was requested)"
     # Ahead of the success/skip checks: an install-path failure is WHY the matrix
@@ -223,6 +292,8 @@ def _e2e_status(
     for _annotation, row, result in _install_path(
         build_e2e_image, merge_e2e_image, prepare_tenant
     ):
+        if result == _CANCELLED:
+            return f"🚫 {row} cancelled — not run"
         if result not in _OK_OPTIONAL:
             return f"❌ {row} failed"
     if e2e == "success":
@@ -231,6 +302,8 @@ def _e2e_status(
         return "❌ Matrix skipped despite discovered suites"
     if e2e == "skipped":
         return "⊘ Skipped"
+    if e2e == _CANCELLED:
+        return _CANCELLED_ROW
     return "❌ Failed"
 
 
@@ -252,6 +325,16 @@ def render(
     straight into ``complete_check_run.py --conclusion`` — mapping true/false to
     success/failure in workflow YAML would put the decision back outside the one
     tested authority, which is the drift this driver exists to prevent.
+
+    A blocked gate is spelled ``cancelled`` rather than ``failure`` when nothing
+    actually failed and the blocking results are all cancellations. ``passed``
+    is "false" either way — the gate must never green an un-run test — but the
+    two are NOT interchangeable to a reader: a mirrored ``failure`` on the
+    dispatching SDK PR reads as "your change broke the connector" and sends
+    someone into the wrong diff, which is precisely what happened in FND-218.
+    ``cancelled`` is a valid Checks API conclusion and has been in
+    ``complete_check_run.py``'s accepted set since that script was introduced,
+    so this is safe for the oldest dispatching SDK ref that can still call back.
     """
     errors = evaluate(
         unit,
@@ -264,9 +347,26 @@ def render(
         merge_e2e_image,
         prepare_tenant,
     )
+    blocked_by_cancellation = errors and cancelled_only(
+        unit,
+        integration,
+        detect_integration,
+        discover_e2e,
+        e2e,
+        detect_merge_queue,
+        build_e2e_image,
+        merge_e2e_image,
+        prepare_tenant,
+    )
     return {
         "passed": "true" if not errors else "false",
-        "conclusion": "success" if not errors else "failure",
+        "conclusion": (
+            "success"
+            if not errors
+            else _CANCELLED
+            if blocked_by_cancellation
+            else "failure"
+        ),
         "unit-status": _unit_status(unit),
         "integration-status": _integration_status(
             integration, detect_integration, detect_merge_queue
@@ -274,7 +374,13 @@ def render(
         "e2e-status": _e2e_status(
             discover_e2e, e2e, build_e2e_image, merge_e2e_image, prepare_tenant
         ),
-        "overall-status": "✅ All passed" if not errors else "❌ Some failed",
+        "overall-status": (
+            "✅ All passed"
+            if not errors
+            else "🚫 Cancelled — no verdict, re-run"
+            if blocked_by_cancellation
+            else "❌ Some failed"
+        ),
     }
 
 
@@ -331,6 +437,21 @@ def main(argv: list[str] | None = None) -> int:
         args.prepare_tenant,
     ):
         print(f"::error::{reason}", file=sys.stderr)
+
+    # Follows the per-job reasons so the annotation list reads cause-then-verdict:
+    # which jobs did not report, then what that means for whoever is looking.
+    if cancelled_only(
+        args.unit,
+        args.integration,
+        args.detect_integration,
+        args.discover_e2e,
+        args.e2e,
+        args.detect_merge_queue,
+        args.build_e2e_image,
+        args.merge_e2e_image,
+        args.prepare_tenant,
+    ):
+        print(f"::error::{_CANCELLED_GUIDANCE}", file=sys.stderr)
 
     for key, value in render(
         args.unit,

--- a/.github/actions/verify-test-gate/verify_test_gate.py
+++ b/.github/actions/verify-test-gate/verify_test_gate.py
@@ -210,8 +210,27 @@ def cancelled_only(
     absence of failures. The "discovery succeeded but the matrix was skipped"
     anomaly produces an error while every result sits in ``_OK_OPTIONAL``;
     treating that as a cancellation would hide a real misconfiguration behind a
-    "just re-run" verdict — the opposite of what this distinction is for.
+    "just re-run" verdict — the opposite of what this distinction is for. The
+    anomaly is raised by ``evaluate`` independently of the raw job results, so a
+    cancellation elsewhere does not make it disappear: it must be excluded
+    explicitly, or a simultaneous cancellation would mask it.
     """
+    # The matrix-skipped anomaly fires on raw results that all sit in
+    # _OK_OPTIONAL, so it is invisible to the non_ok filter below. It is the one
+    # gate error that is never cancellation-attributable, so its presence means
+    # the block is not a pure cancellation — spell it "failure" and surface the
+    # misconfiguration, never "just re-run".
+    if (
+        discover_e2e == "success"
+        and e2e == "skipped"
+        and all(
+            result in _OK_OPTIONAL
+            for _annotation, _row, result in _install_path(
+                build_e2e_image, merge_e2e_image, prepare_tenant
+            )
+        )
+    ):
+        return False
     non_ok = [
         result
         for result in (

--- a/.github/scripts/poll_check_runs_gate.py
+++ b/.github/scripts/poll_check_runs_gate.py
@@ -223,12 +223,30 @@ def wait_for_checks(
         return False
 
     failed = [
-        n
+        (n, latest[n].get("conclusion"))
         for n in expected_names
         if latest[n].get("conclusion") not in PASSING_CONCLUSIONS
     ]
     if failed:
-        print(f"::error::check runs did not pass: {failed}")
+        # Name the CONCLUSION, not just the check. This used to print bare names,
+        # which made a connector whose tests genuinely failed indistinguishable
+        # from one that never ran — and the second case has a completely
+        # different response (re-run, don't read the diff).
+        print(
+            "::error::check runs did not pass: "
+            + ", ".join(f"{name} ({conclusion})" for name, conclusion in failed)
+        )
+        cancelled = [name for name, conclusion in failed if conclusion == "cancelled"]
+        if cancelled:
+            print(
+                "::error::cancelled, not failed: "
+                + ", ".join(cancelled)
+                + " — no test reported a verdict. Usually a concurrency-group "
+                "eviction in the connector repo (GitHub keeps only ONE pending "
+                "run per group, so a third arrival cancels the queued one before "
+                "it gets a runner), or a manual cancel. Re-run rather than "
+                "triage the diff. See FND-218."
+            )
         return False
 
     print(f"All {len(expected_names)} connector check run(s) passed.")

--- a/.github/scripts/tests/test_poll_check_runs_gate.py
+++ b/.github/scripts/tests/test_poll_check_runs_gate.py
@@ -302,6 +302,57 @@ def test_wait_for_checks_fails_on_bad_conclusion(monkeypatch):
     assert ok is False
 
 
+# --- the gate log must distinguish "never ran" from "failed" (FND-218) ------
+
+
+def test_the_failure_annotation_names_each_conclusion(monkeypatch, capsys):
+    # Bare names made a connector whose tests genuinely failed
+    # indistinguishable from one that was evicted before it got a runner —
+    # and those have opposite responses (read the diff vs. re-run).
+    def fake_run(cmd, **kwargs):
+        runs = [
+            {"name": NAMES[0], "status": "completed", "conclusion": "failure"},
+            {"name": NAMES[1], "status": "completed", "conclusion": "timed_out"},
+        ]
+        return _http_response(200, '"v1"', _check_runs_body(runs))
+
+    monkeypatch.setattr(mod, "run", fake_run)
+    assert mod.wait_for_checks(REPO, SHA, NAMES, sleep=lambda s: None) is False
+    out = capsys.readouterr().out
+    assert f"{NAMES[0]} (failure)" in out
+    assert f"{NAMES[1]} (timed_out)" in out
+
+
+def test_a_cancelled_check_gets_the_eviction_explanation(monkeypatch, capsys):
+    def fake_run(cmd, **kwargs):
+        runs = [
+            {"name": NAMES[0], "status": "completed", "conclusion": "cancelled"},
+            {"name": NAMES[1], "status": "completed", "conclusion": "success"},
+        ]
+        return _http_response(200, '"v1"', _check_runs_body(runs))
+
+    monkeypatch.setattr(mod, "run", fake_run)
+    # Still blocks: an un-run connector test cannot green the merge.
+    assert mod.wait_for_checks(REPO, SHA, NAMES, sleep=lambda s: None) is False
+    out = capsys.readouterr().out
+    assert "cancelled, not failed" in out
+    assert NAMES[0] in out
+    assert "Re-run rather than triage the diff." in out
+
+
+def test_no_eviction_explanation_when_nothing_was_cancelled(monkeypatch, capsys):
+    def fake_run(cmd, **kwargs):
+        runs = [
+            {"name": NAMES[0], "status": "completed", "conclusion": "failure"},
+            {"name": NAMES[1], "status": "completed", "conclusion": "success"},
+        ]
+        return _http_response(200, '"v1"', _check_runs_body(runs))
+
+    monkeypatch.setattr(mod, "run", fake_run)
+    assert mod.wait_for_checks(REPO, SHA, NAMES, sleep=lambda s: None) is False
+    assert "cancelled, not failed" not in capsys.readouterr().out
+
+
 def test_wait_for_checks_times_out_when_never_complete(monkeypatch):
     def fake_run(cmd, **kwargs):
         runs = [{"name": NAMES[0], "status": "in_progress"}]

--- a/.github/scripts/tests/test_verify_test_gate.py
+++ b/.github/scripts/tests/test_verify_test_gate.py
@@ -860,6 +860,27 @@ def test_cancelled_only_is_false_when_the_gate_passes() -> None:
     assert not cancelled_only("success", "success", "success", "success", "success")
 
 
+def test_a_cancellation_does_not_mask_the_matrix_skipped_anomaly() -> None:
+    # The anomaly error is raised by evaluate() independently of the raw job
+    # results, so a cancellation elsewhere does not make it go away. cancelled_only
+    # used to inspect raw results alone: a cancelled detection job coinciding with
+    # the anomaly (discovery green, matrix skipped, install path clean) returned
+    # True, and the gate spelled a genuine misconfiguration "just re-run".
+    assert not cancelled_only(
+        "success", "success", "success", "success", "skipped", "cancelled"
+    )
+    out = render("success", "success", "success", "success", "skipped", "cancelled")
+    assert out["passed"] == "false"
+    assert out["conclusion"] == "failure", (
+        "the anomaly is not cancellation-attributable, so its presence must "
+        "spell failure and surface the misconfiguration — never a benign re-run"
+    )
+    errors = evaluate(
+        "success", "success", "success", "success", "skipped", "cancelled"
+    )
+    assert any("matrix was skipped" in e for e in errors)
+
+
 def test_main_annotates_the_cancellation_guidance(capsys) -> None:
     rc = main(
         [

--- a/.github/scripts/tests/test_verify_test_gate.py
+++ b/.github/scripts/tests/test_verify_test_gate.py
@@ -18,7 +18,7 @@ sys.path.insert(
     0, str(Path(__file__).parent.parent.parent / "actions" / "verify-test-gate")
 )
 
-from verify_test_gate import evaluate, main, render  # noqa: E402
+from verify_test_gate import cancelled_only, evaluate, main, render  # noqa: E402
 
 # --- passing states --------------------------------------------------------
 
@@ -704,8 +704,18 @@ def test_conclusion_tracks_passed_across_every_scenario_in_this_module() -> None
     ]
     for scenario in scenarios:
         out = render(*scenario)
-        expected = "success" if out["passed"] == "true" else "failure"
-        assert out["conclusion"] == expected, f"disagreed on {scenario}"
+        # A blocked gate spells itself "cancelled" rather than "failure" when
+        # nothing actually failed (see the cancellation tests below) — so the
+        # invariant is that `conclusion` agrees with `passed` about PASS/BLOCK,
+        # not that BLOCK has exactly one spelling.
+        if out["passed"] == "true":
+            assert out["conclusion"] == "success", f"disagreed on {scenario}"
+        else:
+            assert out["conclusion"] in (
+                "failure",
+                "cancelled",
+            ), f"disagreed on {scenario}"
+            assert out["conclusion"] != "success", f"disagreed on {scenario}"
 
 
 def test_the_real_failure_this_change_was_written_for() -> None:
@@ -733,3 +743,164 @@ def test_the_real_failure_this_change_was_written_for() -> None:
         "must report the connector run's failure"
     )
     assert out["e2e-status"] == "❌ e2e image build failed"
+
+
+# --- cancellation is not failure (FND-218) ---------------------------------
+#
+# GitHub keeps at most ONE pending run per concurrency group, so a third
+# arrival cancels the queued one before it is ever given a runner. The gate
+# must still BLOCK (an un-run test cannot green a merge) but must not spell
+# that block "failure" — a mirrored failure on the dispatching SDK PR reads as
+# "your change broke the connector" and sends a reviewer into the wrong diff.
+
+
+def test_cancelled_integration_blocks_but_reports_cancelled() -> None:
+    out = render("success", "cancelled", "success", "skipped", "skipped")
+    assert out["passed"] == "false", "an un-run test must never green the gate"
+    assert out["conclusion"] == "cancelled"
+    assert out["overall-status"] == "🚫 Cancelled — no verdict, re-run"
+    assert out["integration-status"] == "🚫 Cancelled — not run"
+
+
+def test_cancelled_unit_reports_cancelled() -> None:
+    out = render("cancelled", "skipped", "skipped", "skipped", "skipped")
+    assert out["passed"] == "false"
+    assert out["conclusion"] == "cancelled"
+    assert out["unit-status"] == "🚫 Cancelled — not run"
+
+
+def test_cancelled_e2e_leg_reports_cancelled() -> None:
+    out = render("success", "success", "success", "success", "cancelled")
+    assert out["passed"] == "false"
+    assert out["conclusion"] == "cancelled"
+    assert out["e2e-status"] == "🚫 Cancelled — not run"
+
+
+def test_a_real_failure_alongside_a_cancellation_is_still_failure() -> None:
+    # The discriminator is "did anything actually fail", not "was anything
+    # cancelled". A cancelled sibling must not launder a genuine failure into
+    # a benign "just re-run" verdict.
+    out = render("success", "failure", "success", "success", "cancelled")
+    assert out["passed"] == "false"
+    assert out["conclusion"] == "failure"
+
+
+@pytest.mark.parametrize(
+    "kwargs,row",
+    [
+        ({"build_e2e_image": "cancelled"}, "🚫 e2e image build cancelled — not run"),
+        (
+            {"merge_e2e_image": "cancelled"},
+            "🚫 e2e image manifest merge cancelled — not run",
+        ),
+        ({"prepare_tenant": "cancelled"}, "🚫 Tenant install cancelled — not run"),
+    ],
+)
+def test_cancelled_install_path_jobs_report_cancelled(kwargs, row) -> None:
+    out = render(
+        unit="success",
+        integration="success",
+        detect_integration="success",
+        discover_e2e="success",
+        e2e="skipped",
+        **kwargs,
+    )
+    assert out["passed"] == "false"
+    assert out["conclusion"] == "cancelled"
+    assert out["e2e-status"] == row
+
+
+@pytest.mark.parametrize(
+    "kwargs,row",
+    [
+        (
+            {"detect_merge_queue": "cancelled"},
+            "🚫 Merge-queue detection cancelled — not run",
+        ),
+        (
+            {"detect_integration": "cancelled"},
+            "🚫 Integration-suite detection cancelled — not run",
+        ),
+    ],
+)
+def test_cancelled_detection_jobs_report_cancelled(kwargs, row) -> None:
+    defaults = {
+        "unit": "success",
+        "integration": "skipped",
+        "detect_integration": "success",
+        "discover_e2e": "skipped",
+        "e2e": "skipped",
+    }
+    out = render(**{**defaults, **kwargs})
+    assert out["passed"] == "false"
+    assert out["conclusion"] == "cancelled"
+    assert out["integration-status"] == row
+
+
+def test_cancelled_discovery_reports_cancelled() -> None:
+    out = render("success", "success", "success", "cancelled", "skipped")
+    assert out["passed"] == "false"
+    assert out["conclusion"] == "cancelled"
+    assert out["e2e-status"] == "🚫 e2e discovery cancelled — not run"
+
+
+def test_the_matrix_skipped_anomaly_is_not_laundered_as_a_cancellation() -> None:
+    # This anomaly errors while every result sits in the OK set, so a naive
+    # "no failures ⇒ cancelled" rule would report it as "just re-run" and hide
+    # a genuine misconfiguration. cancelled_only requires an actual
+    # cancellation to be present.
+    assert not cancelled_only("success", "success", "success", "success", "skipped")
+    out = render("success", "success", "success", "success", "skipped")
+    assert out["passed"] == "false"
+    assert out["conclusion"] == "failure"
+
+
+def test_cancelled_only_is_false_when_the_gate_passes() -> None:
+    # No cancellation present, nothing blocking — there is nothing to explain.
+    assert not cancelled_only("success", "success", "success", "success", "success")
+
+
+def test_main_annotates_the_cancellation_guidance(capsys) -> None:
+    rc = main(
+        [
+            "--unit",
+            "success",
+            "--integration",
+            "cancelled",
+            "--detect-integration",
+            "success",
+            "--discover-e2e",
+            "skipped",
+            "--e2e",
+            "skipped",
+        ]
+    )
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "conclusion=cancelled" in captured.out
+    assert "passed=false" in captured.out
+    # The per-job reason still fires; the guidance is additive, and follows it
+    # so the annotation list reads cause-then-verdict.
+    assert "integration tests did not succeed (result=cancelled)" in captured.err
+    assert "were cancelled, not failed" in captured.err
+    assert "Re-run rather than triage the diff." in captured.err
+
+
+def test_main_does_not_annotate_the_guidance_on_a_real_failure(capsys) -> None:
+    main(
+        [
+            "--unit",
+            "success",
+            "--integration",
+            "failure",
+            "--detect-integration",
+            "success",
+            "--discover-e2e",
+            "skipped",
+            "--e2e",
+            "skipped",
+        ]
+    )
+    captured = capsys.readouterr()
+    assert "conclusion=failure" in captured.out
+    assert "Re-run rather than triage" not in captured.err


### PR DESCRIPTION
First item of FND-250. Follows #3124, which fixed the merge-queue half of that problem.

## Why

GitHub holds at most **one pending run per concurrency group**, so a third arrival cancels the queued one before it is ever given a runner — no log output at all. When that happened to a connector run, the callback mirrored `failure` onto the dispatching application-sdk PR, which reads as *"your change broke the connector"*.

That misdiagnosis is what made FND-218 expensive. The eviction was cheap to fix once it was visible; the cost was in the looking, because nothing anywhere said "this test did not run". The SDK-side gate log said only:

```
::error::check runs did not pass: ['Connector E2E run / atlan-openapi-app', 'Connector E2E run / atlan-mysql-app']
```

Names, no conclusions — an eviction and a genuine test failure are indistinguishable from that line.

## What changes

**`verify-test-gate`** emits `conclusion: cancelled` when the gate is blocked and every non-passing result is a cancellation (manual cancel, superseded commit, or a concurrency eviction).

- `passed` stays `false`. An un-run test must never green a merge — this changes how a block is *reported*, never whether it blocks.
- Summary rows and the overall status get a distinct glyph (`🚫 Cancelled — not run`) instead of `❌ Failed`, per job: unit, integration, both detection jobs, discovery, all three install-path jobs, and the e2e matrix.
- The driver annotates `no test reported a verdict … Re-run rather than triage the diff.`
- A genuine failure alongside a cancellation is still `failure`, so a cancelled sibling cannot launder a real one. The discriminator is "did anything actually fail", not "was anything cancelled".
- The "discovery succeeded but the matrix was skipped" anomaly errors while every result sits in the OK set, so `cancelled_only` requires a cancellation to be *present* — otherwise that misconfiguration would be relabelled "just re-run". Covered by a test.

**`poll_check_runs_gate.py`** names each failing check with its conclusion, and adds an explicit second annotation for cancellations pointing at the eviction mechanism.

## Compatibility

`cancelled` is a valid Checks API conclusion, and it has been in `complete_check_run.py`'s `--conclusion` choices since that script was introduced (verified against its first revision) — so the new value is safe for the oldest dispatching SDK ref that can still call back. `verify-test-gate` is consumed cross-repo at `@main`; only the *value domain* of an existing output widens, no input or CLI changes, so no caller needs updating.

## Tests

`.github/scripts/tests/` — 1593 passed. 17 new cases covering every row string, the failure-alongside-cancellation discriminator, the anomaly guard, both annotation paths, and the gate log's conclusion naming.

One existing assertion changed: `test_conclusion_tracks_passed_across_every_scenario_in_this_module` hard-coded `failure` as the only spelling of a block. It now asserts `conclusion` agrees with `passed` about pass/block, which is the invariant that test exists to protect.

## Not fixed here

This makes the remaining hazard legible; it does not remove it. The e2e path's tenant-scoped groups still have one pending slot, and a third concurrent `e2e`-labelled PR will still evict the waiting run — it will now just say so. Replacing them with a real `(app, cloud)` lease is the rest of FND-250, and needs a design decision rather than a config change.

Refs: FND-250
