### PR TITLE
ci(e2e): replace ref-keyed concurrency groups with an (app, cloud) tenant lease

### DIFF
--- a/.github/actions/e2e-tenant-lease/action.yaml
+++ b/.github/actions/e2e-tenant-lease/action.yaml
@@ -43,12 +43,22 @@ inputs:
     default: "30"
   ttl-seconds:
     description: |
-      Age at which a holder still reporting "in_progress" is treated as wedged
-      and its lease broken. Must stay above the longest legitimate run (a 40min
-      install plus a 120min leg ceiling), or a slow-but-healthy run loses its
-      tenant mid-flight.
+      Run AGE at which a holder still reporting "in_progress" is treated as
+      wedged and its lease broken. Measured from run CREATION, not from when the
+      lease was taken — the lease is acquired several jobs in, and a run can also
+      sit waiting for runners first, so this has to clear the entire chain
+      (discovery + image build + manifest merge + the lease wait + install +
+      legs) with room for unbounded queue time on top. Sized against the
+      workflow's own job timeouts by a test, so adding a job or raising a timeout
+      forces this up rather than silently eating the margin.
+
+      Deliberately generous (12h against a ~5.5h chain). The operator-facing
+      signal for a stuck tenant is wait-seconds failing loudly, not this; all
+      this does is stop a ticket being immortal. Firing it early is the
+      expensive direction — it reaps a live mid-install ticket and puts a second
+      installer on the tenant, the exact race the lease closes. 0 disables it.
     required: false
-    default: "14400"
+    default: "43200"
   on-timeout:
     description: |
       "fail" (default) — go red naming the holding run. "warn" — proceed

--- a/.github/actions/e2e-tenant-lease/action.yaml
+++ b/.github/actions/e2e-tenant-lease/action.yaml
@@ -1,0 +1,110 @@
+name: E2E tenant lease
+description: |
+  Acquire or release the (app, cloud) tenant lease that serialises e2e runs
+  against a shared tenant, replacing the ref-keyed concurrency groups that could
+  only hold one pending run and silently evicted the rest (FND-218 / FND-250).
+
+  Consumed at @main by every contender ON PURPOSE: they all have to agree on the
+  ref layout and the ordering rule, so the protocol must not vary with whichever
+  ref a caller happened to check out. See e2e_tenant_lease.py for the protocol.
+
+  Requires `contents: write` (to create and delete the ticket ref) and
+  `actions: read` (to tell a live holder from a dead one). Without them the
+  action warns and disables the lease rather than failing — each e2e leg
+  re-asserts the installed version independently (FND-31), so the lease reduces
+  contention rather than being the thing that makes a wrong-version run
+  detectable.
+
+inputs:
+  mode:
+    description: '"acquire" or "release".'
+    required: true
+  app:
+    description: App under test; one half of the lease key.
+    required: true
+  cloud:
+    description: |
+      Cloud whose tenant this is; the other half of the lease key. Empty is
+      valid and means the single-tenant fallback path, keyed as "default".
+    required: false
+    default: ""
+  wait-seconds:
+    description: |
+      How long to queue for the tenant before giving up. Default 90min: long
+      enough to sit behind one full install-plus-legs run ahead in the queue,
+      short enough that a wedged tenant is reported the same working day.
+    required: false
+    default: "5400"
+  poll-seconds:
+    description: |
+      Gap between queue checks. Each poll costs two API calls, so this also sets
+      the draw on the 1000/hour GITHUB_TOKEN budget.
+    required: false
+    default: "30"
+  ttl-seconds:
+    description: |
+      Age at which a holder still reporting "in_progress" is treated as wedged
+      and its lease broken. Must stay above the longest legitimate run (a 40min
+      install plus a 120min leg ceiling), or a slow-but-healthy run loses its
+      tenant mid-flight.
+    required: false
+    default: "14400"
+  on-timeout:
+    description: |
+      "fail" (default) — go red naming the holding run. "warn" — proceed
+      unserialised.
+    required: false
+    default: fail
+
+outputs:
+  acquired:
+    description: '"true" only when this run now holds the lease.'
+    value: ${{ steps.lease.outputs.acquired }}
+  state:
+    description: '"acquired", "disabled" (no ref-write permission) or "timeout".'
+    value: ${{ steps.lease.outputs.state }}
+  lease-ref:
+    description: The ticket ref this run owns.
+    value: ${{ steps.lease.outputs.lease-ref }}
+  holder-run-id:
+    description: The run holding the lease when this one gave up waiting; else empty.
+    value: ${{ steps.lease.outputs.holder-run-id }}
+
+runs:
+  using: composite
+  steps:
+    - name: ${{ inputs.mode == 'release' && 'Release' || 'Acquire' }} the tenant lease
+      id: lease
+      shell: bash
+      # Inputs routed through env rather than inline ${{ }} so nothing
+      # interpolates into the command line (docs/standards/ci.md).
+      env:
+        MODE: ${{ inputs.mode }}
+        APP: ${{ inputs.app }}
+        CLOUD: ${{ inputs.cloud }}
+        WAIT_SECONDS: ${{ inputs.wait-seconds }}
+        POLL_SECONDS: ${{ inputs.poll-seconds }}
+        TTL_SECONDS: ${{ inputs.ttl-seconds }}
+        ON_TIMEOUT: ${{ inputs.on-timeout }}
+        # The tickets live in the repository the run belongs to, which is also
+        # the only repository whose run_ids are comparable — see the ordering
+        # note in e2e_tenant_lease.py.
+        LEASE_REPO: ${{ github.repository }}
+        RUN_ID: ${{ github.run_id }}
+        RUN_ATTEMPT: ${{ github.run_attempt }}
+        HEAD_SHA: ${{ github.sha }}
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        set -euo pipefail
+        python3 "${{ github.action_path }}/e2e_tenant_lease.py" \
+          --mode "$MODE" \
+          --repo "$LEASE_REPO" \
+          --app "$APP" \
+          --cloud "$CLOUD" \
+          --run-id "$RUN_ID" \
+          --run-attempt "$RUN_ATTEMPT" \
+          --sha "$HEAD_SHA" \
+          --wait-seconds "$WAIT_SECONDS" \
+          --poll-seconds "$POLL_SECONDS" \
+          --ttl-seconds "$TTL_SECONDS" \
+          --on-timeout "$ON_TIMEOUT"

--- a/.github/actions/e2e-tenant-lease/e2e_tenant_lease.py
+++ b/.github/actions/e2e-tenant-lease/e2e_tenant_lease.py
@@ -55,8 +55,18 @@ does not cover the case that matters most — a cancelled run whose release job
 never starts at all, since GitHub cancels queued jobs rather than running them.
 The reaper makes a leaked ticket self-healing: the next contender clears it on
 its first poll, so the worst case is one wasted poll interval, not a wedged
-tenant. A hard TTL on run *age* is kept as a second backstop for a run the
-Actions API will not report on.
+tenant.
+
+A hard TTL on run *age* is kept as a third-resort backstop, only for a run the
+Actions API keeps reporting as live forever. It is deliberately generous, because
+the two directions are not symmetric: firing it late costs a blocked tenant that
+a waiter is already complaining loudly about, whereas firing it early reaps a
+LIVE mid-install ticket and puts a second installer on the tenant — reintroducing
+exactly the race this module exists to close. It is also measured from run
+*creation*, not from acquisition, so it has to clear the whole chain ahead of the
+install (discovery, image build, manifest merge, the queue wait itself) plus
+runner queue time, which has no timeout at all. ``test_prepare_tenant_wiring.py``
+derives that bound from the workflow's own job timeouts so it cannot drift.
 
 Failure posture
 ---------------
@@ -338,10 +348,23 @@ def run_is_live(
 
 
 def _run_age_seconds(run_body: dict, *, now=None) -> float | None:
-    """Seconds since the run was created, or None if the API did not say.
+    """Seconds since the run was CREATED, or None if the API did not say.
+
+    Note what this is not: it is not how long the lease has been held. The lease
+    is taken several jobs into the run (discovery, then the per-arch image build,
+    then the manifest merge), and a run can also sit waiting for runners before
+    any of that. All of it counts here.
+
+    That is why the TTL has to be bounded by the whole chain and not by the
+    install-plus-legs span alone. Anchoring on creation and sizing the TTL for
+    only the part after acquisition would let the backstop fire on a *healthy*
+    holder that queued for a while — reaping a live mid-install ticket and
+    handing the tenant to a second installer, which is precisely the race the
+    lease exists to close. ``test_prepare_tenant_wiring.py`` derives the required
+    bound from the workflow's own job timeouts so it cannot drift out of date.
 
     Only the TTL backstop uses this, so clock skew between the runner and GitHub
-    is immaterial at the hours-long scale the TTL operates on. Queue ordering
+    is immaterial at the hours-long scale it operates on. Queue ordering
     deliberately does not depend on any clock — see the module docstring.
     """
     created = run_body.get("created_at")
@@ -490,10 +513,15 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--ttl-seconds",
         type=int,
-        default=14400,
-        help="Age at which a still-'in_progress' holder is treated as wedged and "
-        "its lease broken. Must exceed the longest legitimate run (default 4h, "
-        "against a 40min install plus a 120min leg ceiling).",
+        default=43200,
+        help="Run AGE at which a still-'in_progress' holder is treated as wedged "
+        "and its lease broken. Measured from run creation, so it must exceed the "
+        "whole chain — discovery, image build, manifest merge, the lease wait "
+        "itself, the install and the legs — plus runner queue time, which has no "
+        "timeout at all. Default 12h against a ~5.5h chain. Deliberately "
+        "generous: the operator-facing signal for a stuck tenant is the wait "
+        "budget failing loudly after 90min, not this. All this does is stop a "
+        "ticket being immortal, and firing it early costs a concurrent install.",
     )
     parser.add_argument(
         "--on-timeout",
@@ -503,6 +531,27 @@ def main(argv: list[str] | None = None) -> int:
         "unserialised.",
     )
     args = parser.parse_args(sys.argv[1:] if argv is None else argv)
+
+    # Bounds-checked up front rather than left to fail at the point of use.
+    # poll_seconds=0 is a ZeroDivisionError in the attempt-count arithmetic and a
+    # negative one reaches sleep() as a ValueError — both loud rather than silently
+    # wrong, but both arrive as a traceback several steps from the input that
+    # caused them, which is a poor trade for one comparison. These come from
+    # action inputs with safe defaults, so this is a guard against a typo in a
+    # caller's YAML, not against hostile input.
+    if args.poll_seconds < 1:
+        raise SystemExit(
+            f"::error::--poll-seconds must be at least 1, got {args.poll_seconds}"
+        )
+    if args.wait_seconds < 0:
+        raise SystemExit(
+            f"::error::--wait-seconds cannot be negative, got {args.wait_seconds}"
+        )
+    if args.ttl_seconds < 0:
+        raise SystemExit(
+            f"::error::--ttl-seconds cannot be negative, got {args.ttl_seconds} "
+            "(0 disables the TTL backstop)"
+        )
 
     prefix = lease_prefix(args.app, args.cloud)
     ticket = Ticket(args.run_id, args.run_attempt)

--- a/.github/actions/e2e-tenant-lease/e2e_tenant_lease.py
+++ b/.github/actions/e2e-tenant-lease/e2e_tenant_lease.py
@@ -1,0 +1,560 @@
+#!/usr/bin/env python3
+"""A real ``(app, cloud)`` tenant lease for e2e runs — a queue, not a one-deep
+waiting room.
+
+Why this exists rather than a ``concurrency:`` group
+---------------------------------------------------
+A tenant is a shared *mutable* resource: ``prepare-tenant`` installs a version
+onto it and the e2e legs then assert they are testing that version (FND-31). So
+access has to be serialised across the whole span of a run, from the install to
+the last leg. GitHub's ``concurrency:`` cannot express that, for two independent
+reasons:
+
+* It is per-job, not per-run. A group on ``prepare-tenant`` is released the
+  moment that job ends, which is before any leg has started — the race it looks
+  like it closes is still wide open. The existing comment on that job said as
+  much: *"GitHub has no cross-job lease, so another run can still install
+  between this job and the legs below"*.
+* It holds at most ONE pending run per group. A third arrival does not queue —
+  it cancels the run that was waiting, before that run is ever given a runner,
+  producing no log output at all. That is FND-218: what looked like connector
+  test failures across a merge-queue batch were evictions, and the callback
+  mirrored them onto the dispatching PR as ``failure``, which reads as "your
+  change broke the connector".
+
+``cancel-in-progress: false`` is therefore a waiting room with one chair, not a
+queue. This module is the queue.
+
+Protocol
+--------
+Every run that wants a tenant creates a *ticket* ref in its own repository::
+
+    refs/e2e-tenant-lease/<app>/<cloud>/<run_id>-<run_attempt>
+
+The lease is held by whichever LIVE ticket sorts lowest by
+``(run_id, run_attempt)``. Nothing is negotiated and there is no lock object to
+leak: every participant derives the same holder from the same ref listing, so
+there is no compare-and-swap, and no step whose failure strands the resource.
+Two properties are what make that sound:
+
+* ``run_id`` is assigned by GitHub and increases with run creation time within a
+  repository, so ordering is *server-side arrival order*. No runner clock takes
+  part, which removes the window where two runs both believe they are first
+  because their wall clocks disagree. (Ordering by a timestamp written into the
+  ref name would have exactly that bug, and it would be invisible until it lost
+  a tenant.)
+* A ticket's name is derived entirely from the run, so it is identical in every
+  job of that run. The acquiring job and the releasing job compute the same name
+  without passing state between them, and re-creating a ticket is idempotent —
+  it restores the run's exact queue position instead of sending it to the back.
+
+Liveness comes from the holder's *run*, not from a heartbeat: a ticket whose run
+reports ``status: completed`` is dead, and any participant that notices deletes
+it. This is deliberately not "release in an ``if: always()`` job", because that
+does not cover the case that matters most — a cancelled run whose release job
+never starts at all, since GitHub cancels queued jobs rather than running them.
+The reaper makes a leaked ticket self-healing: the next contender clears it on
+its first poll, so the worst case is one wasted poll interval, not a wedged
+tenant. A hard TTL on run *age* is kept as a second backstop for a run the
+Actions API will not report on.
+
+Failure posture
+---------------
+* **No permission to write refs** (a repository or caller that does not grant
+  ``contents: write``) is a ``::warning::`` and the run proceeds *without* a
+  lease. The lease reduces contention; it is not the thing that keeps a
+  wrong-version run from passing — every e2e leg re-asserts the installed
+  version itself (FND-31). Making an ungrantable lease fail the run would turn a
+  safety improvement into a new way for e2e to go red fleet-wide.
+* **Not acquired within the wait budget** fails loudly by default, naming the
+  holding run. That is strictly better than the behaviour it replaces (silent
+  eviction with no log), and unlike fail-open it does not put two runs on one
+  tenant expecting different versions.
+
+Co-located with the composite action, and pinned ``@main`` by every consumer on
+purpose: all contenders must agree on the ref layout and the ordering rule, so
+the protocol must not vary by which ref a caller happens to have checked out.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+# Ticket refs live outside refs/heads and refs/tags on purpose: a branch would
+# fire `push` events (and show up in the branch list), a tag would pollute the
+# release surface. A custom namespace is inert — nothing watches it.
+REF_NAMESPACE = "e2e-tenant-lease"
+
+# The only GitHub run status that means "over". Everything else — queued,
+# in_progress, requested, waiting, pending — is treated as live, so an
+# unfamiliar future status errs towards leaving a peer's lease alone.
+_COMPLETED = "completed"
+
+# Characters safe in a single git ref path component. Deliberately narrower than
+# git's own rules: app names and cloud names come from workflow inputs, and a
+# ref name is the one place where "mostly valid" turns into a 422 nobody
+# expected.
+_SAFE_SLUG_CHARS = frozenset("abcdefghijklmnopqrstuvwxyz0123456789._-")
+
+
+def slug(value: str, *, default: str = "default") -> str:
+    """Reduce a free-text key to one safe git ref path component.
+
+    ``cloud`` is legitimately empty on the single-tenant path (the fallback
+    matrix leg spells it as a defined-but-empty string), so an empty result maps
+    to ``default`` rather than producing ``refs/<ns>/<app>//<ticket>`` — an
+    empty component git rejects.
+    """
+    cleaned = "".join(
+        char if char in _SAFE_SLUG_CHARS else "-" for char in value.strip().lower()
+    )
+    # git rejects "..", a leading "-" is hostile to CLI tooling, and a component
+    # ending ".lock" is reserved.
+    while ".." in cleaned:
+        cleaned = cleaned.replace("..", "-")
+    cleaned = cleaned.strip("-._")
+    while cleaned.endswith(".lock"):
+        cleaned = cleaned[: -len(".lock")].strip("-._")
+    return cleaned or default
+
+
+def lease_prefix(app: str, cloud: str) -> str:
+    """The ref prefix every contender for one tenant shares (no ``refs/``)."""
+    return f"{REF_NAMESPACE}/{slug(app, default='app')}/{slug(cloud)}"
+
+
+@dataclass(frozen=True, order=True)
+class Ticket:
+    """One run's claim on a tenant.
+
+    Ordered by ``(run_id, attempt)`` — declared in that field order so the
+    dataclass's generated comparison *is* the queue order, leaving no second
+    sort key to drift from it. A re-run keeps its original ``run_id`` and so
+    keeps its place in line; the two attempts can never be live at once, since a
+    re-run only starts after the previous attempt has finished.
+    """
+
+    run_id: int
+    attempt: int
+
+    @property
+    def name(self) -> str:
+        return f"{self.run_id}-{self.attempt}"
+
+    def ref(self, prefix: str) -> str:
+        return f"refs/{prefix}/{self.name}"
+
+    def run_url(self, repo: str) -> str:
+        return f"https://github.com/{repo}/actions/runs/{self.run_id}"
+
+
+def parse_ticket(ref: str) -> Ticket | None:
+    """Parse a ticket out of a full ref name, or None if it is not one.
+
+    Unrecognised refs under the namespace are *ignored* rather than reaped: a
+    ref this version does not understand is more likely to be a newer protocol
+    than garbage, and ignoring it only costs the lease's mutual exclusion with
+    whoever wrote it — deleting it would break them outright.
+    """
+    name = ref.rsplit("/", 1)[-1]
+    run_id, _, attempt = name.partition("-")
+    if not run_id.isdigit() or not attempt.isdigit():
+        return None
+    return Ticket(int(run_id), int(attempt))
+
+
+def run(cmd: list[str], **kwargs) -> subprocess.CompletedProcess:
+    """Single seam so tests can stub the HTTP client."""
+    return subprocess.run(cmd, **kwargs)
+
+
+def _parse_http(raw: str, label: str) -> tuple[int, object | None]:
+    """Split a ``curl -i`` response into (status_code, parsed_body_or_None)."""
+    text = raw.replace("\r\n", "\n")
+    if "\n\n" not in text:
+        raise SystemExit(f"::error::unexpected response for {label}: {text[:300]!r}")
+    header_block, _, body = text.partition("\n\n")
+    lines = header_block.splitlines()
+    try:
+        status_code = int(lines[0].split()[1])
+    except (IndexError, ValueError):
+        raise SystemExit(
+            f"::error::could not parse HTTP status line for {label}: "
+            f"{(lines[0] if lines else '')!r}"
+        )
+    if not body.strip():
+        return status_code, None
+    try:
+        return status_code, json.loads(body)
+    except json.JSONDecodeError:
+        # A non-JSON body (an HTML error page from a proxy) must not crash the
+        # caller before it can report the status code, which is the part that
+        # decides what happens next.
+        return status_code, None
+
+
+def gh_request(
+    method: str, path: str, payload: dict | None = None
+) -> tuple[int, object | None]:
+    """Call the GitHub API, returning the status code rather than raising on 4xx.
+
+    curl, not ``gh api``, for the same reason ``poll_check_runs_gate.py`` uses
+    it: ``gh api`` treats every non-2xx as a command failure and prints its own
+    diagnostic instead of the response, and here the non-2xx codes are load
+    bearing. 422 means "someone else already holds this ticket" and 403/404 mean
+    "this repository will not let us write refs" — two completely different
+    outcomes that both have to be distinguished from a genuine error.
+    """
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    if not token:
+        raise SystemExit("::error::GH_TOKEN (or GITHUB_TOKEN) must be set")
+
+    cmd = [
+        "curl",
+        "-sS",
+        "-i",
+        "--max-time",
+        "30",
+        "-X",
+        method,
+        "-H",
+        "Accept: application/vnd.github+json",
+        "-H",
+        "X-GitHub-Api-Version: 2022-11-28",
+        "-H",
+        f"Authorization: Bearer {token}",
+    ]
+    if payload is not None:
+        cmd += ["-H", "Content-Type: application/json", "-d", json.dumps(payload)]
+    cmd.append(f"https://api.github.com/{path}")
+
+    result = run(cmd, capture_output=True, text=True, check=False)
+    if result.returncode != 0:
+        raise SystemExit(f"::error::curl failed for {method} {path}: {result.stderr}")
+    return _parse_http(result.stdout, f"{method} {path}")
+
+
+def _message(body: object | None) -> str:
+    return body.get("message", "") if isinstance(body, dict) else ""
+
+
+def create_ticket(repo: str, prefix: str, ticket: Ticket, sha: str) -> str:
+    """Create this run's ticket. Returns "created", "exists" or "denied"."""
+    status, body = gh_request(
+        "POST",
+        f"repos/{repo}/git/refs",
+        {"ref": ticket.ref(prefix), "sha": sha},
+    )
+    if status in (200, 201):
+        return "created"
+    # Ours, from an earlier job of this run (acquire runs before the install, and
+    # the release job re-derives the same name) or from a retried step.
+    if status == 422 and "already exists" in _message(body).lower():
+        return "exists"
+    if status in (401, 403, 404):
+        return "denied"
+    raise SystemExit(
+        f"::error::could not create the tenant lease ticket {ticket.ref(prefix)} "
+        f"in {repo}: HTTP {status} {_message(body)!r}"
+    )
+
+
+def list_tickets(repo: str, prefix: str) -> list[Ticket]:
+    """Every parseable ticket currently under the prefix, unordered."""
+    status, body = gh_request("GET", f"repos/{repo}/git/matching-refs/{prefix}/")
+    # An empty namespace answers 200 with [], but 404 is the documented shape for
+    # "no matching refs" on some paths — both mean "nobody is queued".
+    if status == 404:
+        return []
+    if status >= 400 or not isinstance(body, list):
+        raise SystemExit(
+            f"::error::could not list tenant lease tickets under refs/{prefix}/ "
+            f"in {repo}: HTTP {status} {_message(body)!r}"
+        )
+    tickets = []
+    for entry in body:
+        if not isinstance(entry, dict):
+            continue
+        ticket = parse_ticket(str(entry.get("ref", "")))
+        if ticket is not None:
+            tickets.append(ticket)
+    return tickets
+
+
+def delete_ticket(repo: str, prefix: str, ticket: Ticket) -> bool:
+    """Best-effort delete. False means it was already gone, which is not a fault:
+    two contenders can reap the same dead ticket, and only one wins the race."""
+    status, _body = gh_request(
+        "DELETE", f"repos/{repo}/git/refs/{prefix}/{ticket.name}"
+    )
+    return status in (200, 204)
+
+
+def run_is_live(
+    repo: str,
+    ticket: Ticket,
+    *,
+    ttl_seconds: int,
+    now=None,
+) -> bool:
+    """Is the run holding `ticket` still going?
+
+    Errs towards True. A transient API failure that read as "dead" would hand
+    the tenant to a second run while the first is mid-install — the exact race
+    the lease exists to prevent — whereas erring towards "live" only costs the
+    waiter another poll interval.
+    """
+    status, body = gh_request("GET", f"repos/{repo}/actions/runs/{ticket.run_id}")
+    if status == 404:
+        # The run was deleted, or never existed. Nothing will ever release this.
+        return False
+    if status >= 400 or not isinstance(body, dict):
+        print(
+            f"::warning::could not read run {ticket.run_id} in {repo} "
+            f"(HTTP {status}); treating its tenant lease as still held."
+        )
+        return True
+    if body.get("status") == _COMPLETED:
+        return False
+    if ttl_seconds > 0:
+        age = _run_age_seconds(body, now=now)
+        if age is not None and age > ttl_seconds:
+            print(
+                f"::warning::run {ticket.run_id} in {repo} still reports "
+                f"'{body.get('status')}' after {int(age)}s, past the "
+                f"{ttl_seconds}s tenant lease TTL — breaking the lease. If that "
+                "run is genuinely still installing, raise ttl-seconds."
+            )
+            return False
+    return True
+
+
+def _run_age_seconds(run_body: dict, *, now=None) -> float | None:
+    """Seconds since the run was created, or None if the API did not say.
+
+    Only the TTL backstop uses this, so clock skew between the runner and GitHub
+    is immaterial at the hours-long scale the TTL operates on. Queue ordering
+    deliberately does not depend on any clock — see the module docstring.
+    """
+    created = run_body.get("created_at")
+    if not isinstance(created, str) or not created:
+        return None
+    try:
+        stamp = datetime.fromisoformat(created.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if stamp.tzinfo is None:
+        stamp = stamp.replace(tzinfo=timezone.utc)
+    current = now() if now is not None else datetime.now(timezone.utc)
+    return (current - stamp).total_seconds()
+
+
+def acquire(
+    repo: str,
+    prefix: str,
+    ticket: Ticket,
+    sha: str,
+    *,
+    wait_seconds: int,
+    poll_seconds: int,
+    ttl_seconds: int,
+    sleep=time.sleep,
+    now=None,
+) -> tuple[str, Ticket | None]:
+    """Take the lease, or report why not.
+
+    Returns ("acquired" | "disabled" | "timeout", blocking_ticket_or_None).
+    """
+    outcome = create_ticket(repo, prefix, ticket, sha)
+    if outcome == "denied":
+        print(
+            "::warning::this repository will not let the run write git refs, so "
+            "the (app, cloud) tenant lease is disabled for this run and e2e "
+            "proceeds unserialised. Grant the lease job 'contents: write' to "
+            "enable it. Each e2e leg still asserts the installed version "
+            "independently (FND-31), so a wrong-version run cannot pass "
+            "silently — it just fails less informatively."
+        )
+        return "disabled", None
+    print(f"Ticket {ticket.ref(prefix)} {outcome}.")
+
+    # Attempt-counted rather than deadline-checked, so the budget needs no clock
+    # (and tests need no clock stub). Ceiling division: a budget that is not an
+    # exact multiple of the interval still gets its final full attempt.
+    max_attempts = max(1, math.ceil(wait_seconds / poll_seconds))
+
+    blocker: Ticket | None = None
+    for attempt in range(1, max_attempts + 1):
+        tickets = list_tickets(repo, prefix)
+        if ticket not in tickets:
+            # Either replica lag, or a peer reaped us after misreading this run
+            # as finished. Re-creating is safe and position-preserving: the name
+            # is derived from the run, so we land back in the same place in line.
+            if create_ticket(repo, prefix, ticket, sha) == "denied":
+                print(
+                    "::warning::lost the tenant lease ticket and cannot recreate "
+                    "it; proceeding unserialised."
+                )
+                return "disabled", None
+            tickets.append(ticket)
+
+        ordered = sorted(tickets)
+        blocker = None
+        for candidate in ordered:
+            if candidate == ticket:
+                break
+            if run_is_live(repo, candidate, ttl_seconds=ttl_seconds, now=now):
+                blocker = candidate
+                break
+            print(
+                f"Reaping the tenant lease ticket of run {candidate.run_id} "
+                f"(attempt {candidate.attempt}) — that run is over."
+            )
+            delete_ticket(repo, prefix, candidate)
+
+        if blocker is None:
+            print(f"Tenant lease acquired: refs/{prefix}/{ticket.name}")
+            return "acquired", None
+
+        ahead = ordered.index(blocker) + 1
+        print(
+            f"[{attempt}/{max_attempts}] waiting for the {prefix} tenant lease — "
+            f"held by run {blocker.run_id} ({blocker.run_url(repo)}), "
+            f"{ahead} ticket(s) ahead of this run."
+        )
+        if attempt < max_attempts:
+            sleep(poll_seconds)
+
+    return "timeout", blocker
+
+
+def release(repo: str, prefix: str, ticket: Ticket) -> bool:
+    """Give up this run's ticket. Never fails the job — a missed release is
+    reaped by the next contender, which is what makes a cancelled run (whose
+    release job never starts) harmless."""
+    deleted = delete_ticket(repo, prefix, ticket)
+    if deleted:
+        print(f"Tenant lease released: refs/{prefix}/{ticket.name}")
+    else:
+        print(
+            f"No tenant lease ticket to release at refs/{prefix}/{ticket.name} "
+            "— already reaped."
+        )
+    return deleted
+
+
+def write_outputs(outputs: dict[str, str], path: str | None) -> None:
+    if not path:
+        return
+    with open(path, "a", encoding="utf-8") as handle:
+        for key, value in outputs.items():
+            handle.write(f"{key}={value}\n")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Acquire or release a tenant lease.")
+    parser.add_argument("--mode", required=True, choices=("acquire", "release"))
+    parser.add_argument("--repo", required=True, help="owner/repo the tickets live in.")
+    parser.add_argument("--app", required=True, help="App under test (lease key part).")
+    parser.add_argument(
+        "--cloud", default="", help="Cloud (lease key part); empty = single tenant."
+    )
+    parser.add_argument("--run-id", required=True, type=int, help="github.run_id")
+    parser.add_argument(
+        "--run-attempt", required=True, type=int, help="github.run_attempt"
+    )
+    parser.add_argument(
+        "--sha", default="", help="Commit the ticket ref points at (acquire only)."
+    )
+    parser.add_argument(
+        "--wait-seconds",
+        type=int,
+        default=5400,
+        help="How long to queue for the tenant before giving up (default 90min).",
+    )
+    parser.add_argument(
+        "--poll-seconds",
+        type=int,
+        default=30,
+        help="Gap between queue checks. Two API calls per poll, so this also sets "
+        "the load on the 1000/hour GITHUB_TOKEN budget (default 30s).",
+    )
+    parser.add_argument(
+        "--ttl-seconds",
+        type=int,
+        default=14400,
+        help="Age at which a still-'in_progress' holder is treated as wedged and "
+        "its lease broken. Must exceed the longest legitimate run (default 4h, "
+        "against a 40min install plus a 120min leg ceiling).",
+    )
+    parser.add_argument(
+        "--on-timeout",
+        choices=("fail", "warn"),
+        default="fail",
+        help="fail (default): the job goes red naming the holder. warn: proceed "
+        "unserialised.",
+    )
+    args = parser.parse_args(sys.argv[1:] if argv is None else argv)
+
+    prefix = lease_prefix(args.app, args.cloud)
+    ticket = Ticket(args.run_id, args.run_attempt)
+
+    if args.mode == "release":
+        release(args.repo, prefix, ticket)
+        return 0
+
+    if not args.sha:
+        raise SystemExit("::error::--sha is required to acquire a lease")
+
+    state, blocker = acquire(
+        args.repo,
+        prefix,
+        ticket,
+        args.sha,
+        wait_seconds=args.wait_seconds,
+        poll_seconds=args.poll_seconds,
+        ttl_seconds=args.ttl_seconds,
+    )
+    write_outputs(
+        {
+            "acquired": "true" if state == "acquired" else "false",
+            "state": state,
+            "lease-ref": ticket.ref(prefix),
+            "holder-run-id": str(blocker.run_id) if blocker else "",
+        },
+        os.environ.get("GITHUB_OUTPUT"),
+    )
+
+    if state != "timeout":
+        return 0
+
+    held_by = (
+        f" It is held by run {blocker.run_id} ({blocker.run_url(args.repo)})."
+        if blocker
+        else ""
+    )
+    if args.on_timeout == "warn":
+        print(
+            f"::warning::gave up waiting for the {prefix} tenant lease after "
+            f"{args.wait_seconds}s and is proceeding unserialised.{held_by}"
+        )
+        return 0
+    print(
+        f"::error::could not get the {prefix} tenant lease within "
+        f"{args.wait_seconds}s.{held_by} Nothing is wrong with this change — the "
+        "tenant is busy. Re-run this job once that run finishes, or raise "
+        "wait-seconds if queueing this deep is expected."
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/actions/verify-test-gate/action.yaml
+++ b/.github/actions/verify-test-gate/action.yaml
@@ -53,10 +53,19 @@ inputs:
       build-e2e-image-result.
     required: false
     default: skipped
+  lease-tenant-result:
+    description: |
+      needs.lease-tenant.result (queues for the shared (app, cloud) tenant
+      before anything installs onto it). A failure here means the tenant was
+      busy, not that the change is broken, so it must be named rather than left
+      to surface as the downstream "matrix skipped" anomaly (FND-250). Same
+      reasoning and same default as build-e2e-image-result.
+    required: false
+    default: skipped
   prepare-tenant-result:
     description: |
       needs.prepare-tenant.result (installs the image under test onto each
-      cloud's tenant). The last of the three install-path jobs the e2e matrix
+      cloud's tenant). The last of the four install-path jobs the e2e matrix
       gates on. Same reasoning and same default as build-e2e-image-result.
     required: false
     default: skipped
@@ -110,6 +119,7 @@ runs:
         DISCOVER_E2E_RESULT: ${{ inputs.discover-e2e-result }}
         BUILD_E2E_IMAGE_RESULT: ${{ inputs.build-e2e-image-result }}
         MERGE_E2E_IMAGE_RESULT: ${{ inputs.merge-e2e-image-result }}
+        LEASE_TENANT_RESULT: ${{ inputs.lease-tenant-result }}
         PREPARE_TENANT_RESULT: ${{ inputs.prepare-tenant-result }}
         E2E_RESULT: ${{ inputs.e2e-result }}
       run: |
@@ -122,5 +132,6 @@ runs:
           --discover-e2e "$DISCOVER_E2E_RESULT" \
           --build-e2e-image "$BUILD_E2E_IMAGE_RESULT" \
           --merge-e2e-image "$MERGE_E2E_IMAGE_RESULT" \
+          --lease-tenant "$LEASE_TENANT_RESULT" \
           --prepare-tenant "$PREPARE_TENANT_RESULT" \
           --e2e "$E2E_RESULT" >> "$GITHUB_OUTPUT"

--- a/.github/actions/verify-test-gate/verify_test_gate.py
+++ b/.github/actions/verify-test-gate/verify_test_gate.py
@@ -32,9 +32,9 @@ Gate passes iff:
     when the connector ships no integration suite), AND
   * e2e discovery succeeded OR was skipped (skipped = e2e not requested; a
     *failed* discovery means e2e was requested but no suites were found), AND
-  * the per-arch e2e image build, the manifest merge and the tenant install
-    succeeded OR were skipped (skipped = the install path is off, or e2e was
-    not requested), AND
+  * the per-arch e2e image build, the manifest merge, the tenant lease and the
+    tenant install succeeded OR were skipped (skipped = the install path is off,
+    or e2e was not requested), AND
   * the e2e matrix succeeded OR was skipped (matrix aggregate is success only
     if every leg passed).
 
@@ -46,9 +46,9 @@ legitimate) and ``integration`` then skips cleanly, so there is no analogous
 ``detect-integration == success and integration == skipped`` check — that pair
 is the normal no-suite path.
 
-The three install-path jobs are checked for the same reason the detection jobs
-are: ``build-e2e-image``, ``merge-e2e-image`` and ``prepare-tenant`` are exactly
-the jobs the e2e matrix's own ``if`` gates on, so a failure in any of them drops
+The install-path jobs are checked for the same reason the detection jobs are:
+``build-e2e-image``, ``merge-e2e-image``, ``lease-tenant`` and ``prepare-tenant``
+are exactly the jobs the e2e matrix's own ``if`` gates on, so a failure in any of them drops
 the matrix to a skip. The anomaly rule above already refused to green that, but
 it named the symptom ("matrix skipped") rather than the cause ("the arm64 image
 build failed") — which is precisely what made the first real occurrence take a
@@ -92,7 +92,10 @@ _CANCELLED_GUIDANCE = (
 
 
 def _install_path(
-    build_e2e_image: str, merge_e2e_image: str, prepare_tenant: str
+    build_e2e_image: str,
+    merge_e2e_image: str,
+    prepare_tenant: str,
+    lease_tenant: str,
 ) -> list[tuple[str, str, str]]:
     """The jobs between discovery and the e2e matrix, in order.
 
@@ -100,6 +103,21 @@ def _install_path(
     ``evaluate`` and ``_e2e_status`` cannot disagree about which jobs belong to
     this leg, about their order, or about which one a reader is pointed at when
     several fail together.
+
+    ``lease-tenant`` sits where it runs: after the image exists and immediately
+    before the install, because it is the job that waits for the tenant to be
+    free (FND-250). Its failure mode is contention, not a broken change, so it
+    has to be named — left unnamed it would surface only as the downstream
+    "matrix skipped despite discovered suites" anomaly, which reads like a
+    workflow misconfiguration.
+
+    No parameter here has a default, deliberately: every caller must name every
+    job. A default let a call site that predated ``lease_tenant`` keep compiling
+    while silently computing the install path as though the lease had passed,
+    which relabelled a cancelled lease as ``failure``. The public functions keep
+    their trailing defaults — they are consumed cross-repo at ``@main`` and
+    cannot break callers — but this helper is module-private, so a missed
+    argument should be a TypeError.
     """
     return [
         ("the e2e image build", "e2e image build", build_e2e_image),
@@ -108,6 +126,7 @@ def _install_path(
             "e2e image manifest merge",
             merge_e2e_image,
         ),
+        ("the tenant lease", "Tenant lease", lease_tenant),
         ("the tenant install", "Tenant install", prepare_tenant),
     ]
 
@@ -122,10 +141,11 @@ def evaluate(
     build_e2e_image: str = "skipped",
     merge_e2e_image: str = "skipped",
     prepare_tenant: str = "skipped",
+    lease_tenant: str = "skipped",
 ) -> list[str]:
     """Return human-readable failure reasons (empty ⇒ the gate passes).
 
-    ``detect_merge_queue`` and the three install-path results are trailing and
+    ``detect_merge_queue`` and the four install-path results are trailing and
     default to "skipped" because this driver is consumed cross-repo via
     ``@main``: a required positional would break every caller the instant it
     merged, before their workflows could update. "skipped" is the neutral
@@ -163,7 +183,7 @@ def evaluate(
     # skip. Named directly so the annotation reports the cause rather than the
     # downstream symptom.
     for annotation, _row, result in _install_path(
-        build_e2e_image, merge_e2e_image, prepare_tenant
+        build_e2e_image, merge_e2e_image, prepare_tenant, lease_tenant
     ):
         if result not in _OK_OPTIONAL:
             errors.append(f"{annotation} did not succeed (result={result})")
@@ -183,7 +203,7 @@ def evaluate(
         and all(
             result in _OK_OPTIONAL
             for _annotation, _row, result in _install_path(
-                build_e2e_image, merge_e2e_image, prepare_tenant
+                build_e2e_image, merge_e2e_image, prepare_tenant, lease_tenant
             )
         )
     ):
@@ -203,6 +223,7 @@ def cancelled_only(
     build_e2e_image: str = "skipped",
     merge_e2e_image: str = "skipped",
     prepare_tenant: str = "skipped",
+    lease_tenant: str = "skipped",
 ) -> bool:
     """True when at least one job was cancelled and nothing actually failed.
 
@@ -226,7 +247,7 @@ def cancelled_only(
         and all(
             result in _OK_OPTIONAL
             for _annotation, _row, result in _install_path(
-                build_e2e_image, merge_e2e_image, prepare_tenant
+                build_e2e_image, merge_e2e_image, prepare_tenant, lease_tenant
             )
         )
     ):
@@ -243,6 +264,7 @@ def cancelled_only(
             build_e2e_image,
             merge_e2e_image,
             prepare_tenant,
+            lease_tenant,
         )
         if result not in _OK_OPTIONAL
     ]
@@ -297,6 +319,7 @@ def _e2e_status(
     build_e2e_image: str = "skipped",
     merge_e2e_image: str = "skipped",
     prepare_tenant: str = "skipped",
+    lease_tenant: str = "skipped",
 ) -> str:
     if discover_e2e == "skipped":
         return "⊘ Skipped — add `e2e` label to trigger"
@@ -309,11 +332,15 @@ def _e2e_status(
     # in the same order and with the same labels as the annotations, from the one
     # list, so the row and the error text always name the same job.
     for _annotation, row, result in _install_path(
-        build_e2e_image, merge_e2e_image, prepare_tenant
+        build_e2e_image, merge_e2e_image, prepare_tenant, lease_tenant
     ):
         if result == _CANCELLED:
             return f"🚫 {row} cancelled — not run"
         if result not in _OK_OPTIONAL:
+            # The lease row says why, because "failed" alone would send a reader
+            # into their own diff: the tenant was busy, not broken.
+            if row == "Tenant lease":
+                return "⏳ Tenant busy — lease not acquired, re-run"
             return f"❌ {row} failed"
     if e2e == "success":
         return "✅ Passed"
@@ -336,6 +363,7 @@ def render(
     build_e2e_image: str = "skipped",
     merge_e2e_image: str = "skipped",
     prepare_tenant: str = "skipped",
+    lease_tenant: str = "skipped",
 ) -> dict[str, str]:
     """Compute the gate's outputs: pass/fail + the display status strings.
 
@@ -365,6 +393,7 @@ def render(
         build_e2e_image,
         merge_e2e_image,
         prepare_tenant,
+        lease_tenant,
     )
     blocked_by_cancellation = errors and cancelled_only(
         unit,
@@ -376,6 +405,7 @@ def render(
         build_e2e_image,
         merge_e2e_image,
         prepare_tenant,
+        lease_tenant,
     )
     return {
         "passed": "true" if not errors else "false",
@@ -391,7 +421,12 @@ def render(
             integration, detect_integration, detect_merge_queue
         ),
         "e2e-status": _e2e_status(
-            discover_e2e, e2e, build_e2e_image, merge_e2e_image, prepare_tenant
+            discover_e2e,
+            e2e,
+            build_e2e_image,
+            merge_e2e_image,
+            prepare_tenant,
+            lease_tenant,
         ),
         "overall-status": (
             "✅ All passed"
@@ -435,6 +470,11 @@ def main(argv: list[str] | None = None) -> int:
         help="needs.merge-e2e-image.result",
     )
     parser.add_argument(
+        "--lease-tenant",
+        default="skipped",
+        help="needs.lease-tenant.result (queues for the shared tenant)",
+    )
+    parser.add_argument(
         "--prepare-tenant",
         default="skipped",
         help="needs.prepare-tenant.result",
@@ -454,6 +494,7 @@ def main(argv: list[str] | None = None) -> int:
         args.build_e2e_image,
         args.merge_e2e_image,
         args.prepare_tenant,
+        args.lease_tenant,
     ):
         print(f"::error::{reason}", file=sys.stderr)
 
@@ -469,6 +510,7 @@ def main(argv: list[str] | None = None) -> int:
         args.build_e2e_image,
         args.merge_e2e_image,
         args.prepare_tenant,
+        args.lease_tenant,
     ):
         print(f"::error::{_CANCELLED_GUIDANCE}", file=sys.stderr)
 
@@ -482,6 +524,7 @@ def main(argv: list[str] | None = None) -> int:
         args.build_e2e_image,
         args.merge_e2e_image,
         args.prepare_tenant,
+        args.lease_tenant,
     ).items():
         print(f"{key}={value}")
     return 0

--- a/.github/scripts/tests/test_e2e_tenant_lease.py
+++ b/.github/scripts/tests/test_e2e_tenant_lease.py
@@ -657,3 +657,77 @@ def test_missing_token_is_a_clear_error(monkeypatch: pytest.MonkeyPatch) -> None
     monkeypatch.delenv("GITHUB_TOKEN", raising=False)
     with pytest.raises(SystemExit, match="GH_TOKEN"):
         create_ticket(REPO, PREFIX, Ticket(1, 1), SHA)
+
+
+# --- input bounds ----------------------------------------------------------
+
+
+@pytest.mark.parametrize("value", ["0", "-1"])
+def test_main_rejects_a_poll_interval_below_one(
+    monkeypatch: pytest.MonkeyPatch, value: str
+) -> None:
+    # 0 is a ZeroDivisionError in the attempt-count arithmetic and a negative one
+    # reaches sleep() as a ValueError. Both are loud rather than silently wrong,
+    # but both arrive as a traceback several steps from the input that caused it.
+    monkeypatch.setenv("GH_TOKEN", "x")
+    with pytest.raises(SystemExit, match="poll-seconds"):
+        main(_argv("acquire", "--poll-seconds", value))
+
+
+def test_main_rejects_a_negative_wait_budget(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GH_TOKEN", "x")
+    with pytest.raises(SystemExit, match="wait-seconds"):
+        main(_argv("acquire", "--wait-seconds", "-1"))
+
+
+def test_main_rejects_a_negative_ttl(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GH_TOKEN", "x")
+    with pytest.raises(SystemExit, match="ttl-seconds"):
+        main(_argv("acquire", "--ttl-seconds", "-1"))
+
+
+def test_main_accepts_a_zero_wait_budget(
+    http: FakeHTTP, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Legitimate: "try once and tell me whether the tenant is free". Only
+    # poll-seconds has a floor of 1.
+    monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+    http.route("POST", "/git/refs", (201, {}))
+    http.route("GET", "/git/matching-refs/", (200, [_ref(100)]))
+    assert main(_argv("acquire", "--wait-seconds", "0")) == 0
+
+
+def test_main_validates_before_touching_the_api(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # With no token set, reaching the API would raise about GH_TOKEN instead — so
+    # this also pins that validation happens before any request.
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    with pytest.raises(SystemExit, match="poll-seconds"):
+        main(_argv("acquire", "--poll-seconds", "0"))
+
+
+def test_the_ttl_is_measured_from_run_creation_not_lease_acquisition(
+    http: FakeHTTP,
+) -> None:
+    """Pins the property the TTL default has to be sized against.
+
+    The lease is taken several jobs into a run, so a holder's run age already
+    includes discovery, the image build, the manifest merge and any runner queue
+    time before its install even starts. A TTL sized for install-plus-legs alone
+    would call this healthy holder wedged and reap it mid-install, putting a
+    second installer on the tenant — the race the lease exists to close.
+    """
+    # 5h is inside the legitimate chain: the workflow's own timeouts sum to 5h25m
+    # from run creation to the last leg finishing, before any runner queue time.
+    created = datetime.now(timezone.utc) - timedelta(hours=5)
+    http.route(
+        "GET",
+        "/actions/runs/",
+        (200, {"status": "in_progress", "created_at": created.isoformat()}),
+    )
+    # The superseded 4h default breaks this healthy holder's lease outright...
+    assert run_is_live(REPO, Ticket(1, 1), ttl_seconds=14400) is False
+    # ...and the shipped 12h default leaves it alone.
+    assert run_is_live(REPO, Ticket(1, 1), ttl_seconds=43200) is True

--- a/.github/scripts/tests/test_e2e_tenant_lease.py
+++ b/.github/scripts/tests/test_e2e_tenant_lease.py
@@ -1,0 +1,659 @@
+"""Tests for .github/actions/e2e-tenant-lease/e2e_tenant_lease.py.
+
+Co-located module (checked out with the composite action in consumer repos); the
+test lives here with the other action-script tests.
+
+The HTTP client is stubbed at the ``run()`` seam with a fake that speaks real
+curl-shaped responses, so status-code handling — 422 "already exists" vs 403
+"no permission" vs a genuine error — is exercised through the same parser
+production uses rather than around it.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(
+    0, str(Path(__file__).parent.parent.parent / "actions" / "e2e-tenant-lease")
+)
+
+from e2e_tenant_lease import (  # noqa: E402
+    Ticket,
+    acquire,
+    create_ticket,
+    delete_ticket,
+    lease_prefix,
+    list_tickets,
+    main,
+    parse_ticket,
+    release,
+    run_is_live,
+    slug,
+    write_outputs,
+)
+
+REPO = "atlanhq/atlan-example-app"
+PREFIX = "e2e-tenant-lease/example/aws"
+SHA = "a" * 40
+
+
+# --- fake HTTP client ------------------------------------------------------
+
+
+class FakeHTTP:
+    """Records requests and replays queued curl-shaped responses.
+
+    Keyed by (method, path-prefix) so a test only has to describe the calls it
+    cares about; anything unmatched raises rather than silently answering 200,
+    which is what keeps a test from passing because production stopped making a
+    call it was supposed to make.
+    """
+
+    def __init__(self) -> None:
+        self.routes: dict[tuple[str, str], list[tuple[int, object]]] = {}
+        self.calls: list[tuple[str, str]] = []
+
+    def route(self, method: str, contains: str, *responses: tuple[int, object]) -> None:
+        self.routes[(method, contains)] = list(responses)
+
+    def __call__(self, cmd: list[str], **kwargs):
+        method = cmd[cmd.index("-X") + 1]
+        url = cmd[-1]
+        self.calls.append((method, url))
+        for (route_method, contains), responses in self.routes.items():
+            if route_method != method or contains not in url:
+                continue
+            status, body = responses[0] if len(responses) == 1 else responses.pop(0)
+            payload = "" if body is None else json.dumps(body)
+            return _completed(f"HTTP/2 {status}\r\n\r\n{payload}")
+        raise AssertionError(f"unstubbed request: {method} {url}")
+
+
+class _completed:
+    def __init__(self, stdout: str, returncode: int = 0, stderr: str = "") -> None:
+        self.stdout = stdout
+        self.returncode = returncode
+        self.stderr = stderr
+
+
+@pytest.fixture
+def http(monkeypatch: pytest.MonkeyPatch) -> FakeHTTP:
+    monkeypatch.setenv("GH_TOKEN", "x")
+    fake = FakeHTTP()
+    monkeypatch.setattr("e2e_tenant_lease.run", fake)
+    return fake
+
+
+def _ref(run_id: int, attempt: int = 1) -> dict:
+    return {"ref": f"refs/{PREFIX}/{run_id}-{attempt}"}
+
+
+# --- keying ----------------------------------------------------------------
+
+
+def test_slug_passes_through_a_plain_name() -> None:
+    assert slug("openapi") == "openapi"
+
+
+def test_slug_lowercases_and_replaces_unsafe_characters() -> None:
+    assert slug("My App/Name") == "my-app-name"
+
+
+def test_slug_maps_empty_to_default() -> None:
+    # The single-tenant fallback leg spells cloud as a defined-but-empty string;
+    # an empty ref component is a 422, not a lease.
+    assert slug("") == "default"
+
+
+def test_slug_strips_git_hostile_shapes() -> None:
+    assert ".." not in slug("a..b")
+    assert not slug("-lead").startswith("-")
+    assert not slug("thing.lock").endswith(".lock")
+
+
+def test_slug_of_only_unsafe_characters_falls_back() -> None:
+    assert slug("///") == "default"
+
+
+def test_lease_prefix_combines_app_and_cloud() -> None:
+    assert lease_prefix("openapi", "aws") == "e2e-tenant-lease/openapi/aws"
+
+
+def test_lease_prefix_defaults_the_cloud() -> None:
+    assert lease_prefix("openapi", "") == "e2e-tenant-lease/openapi/default"
+
+
+def test_different_clouds_of_one_app_do_not_share_a_lease() -> None:
+    # Per-cloud tenants are independent resources; sharing a lease across them
+    # would serialise legs that have no reason to wait for each other.
+    assert lease_prefix("openapi", "aws") != lease_prefix("openapi", "gcp")
+
+
+# --- ticket identity and ordering -----------------------------------------
+
+
+def test_ticket_name_is_derived_only_from_the_run() -> None:
+    # The whole protocol rests on this: the acquiring job and the releasing job
+    # are different jobs that must compute the same name with no shared state.
+    assert Ticket(12, 1).name == "12-1"
+
+
+def test_ticket_ordering_is_by_run_id() -> None:
+    assert sorted([Ticket(30, 1), Ticket(10, 1), Ticket(20, 1)]) == [
+        Ticket(10, 1),
+        Ticket(20, 1),
+        Ticket(30, 1),
+    ]
+
+
+def test_ticket_ordering_breaks_ties_on_attempt() -> None:
+    assert sorted([Ticket(10, 2), Ticket(10, 1)]) == [Ticket(10, 1), Ticket(10, 2)]
+
+
+def test_parse_ticket_round_trips_a_ref() -> None:
+    assert parse_ticket(f"refs/{PREFIX}/4242-2") == Ticket(4242, 2)
+
+
+@pytest.mark.parametrize(
+    "ref",
+    [
+        f"refs/{PREFIX}/not-a-ticket",
+        f"refs/{PREFIX}/12",
+        f"refs/{PREFIX}/12-",
+        f"refs/{PREFIX}/-1",
+        f"refs/{PREFIX}/12-1-99",
+    ],
+)
+def test_parse_ticket_rejects_non_tickets(ref: str) -> None:
+    assert parse_ticket(ref) is None
+
+
+# --- ref primitives --------------------------------------------------------
+
+
+def test_create_ticket_reports_created(http: FakeHTTP) -> None:
+    http.route("POST", "/git/refs", (201, {"ref": "x"}))
+    assert create_ticket(REPO, PREFIX, Ticket(1, 1), SHA) == "created"
+
+
+def test_create_ticket_treats_an_existing_ref_as_ours(http: FakeHTTP) -> None:
+    # Reached whenever a later job of the same run re-derives the ticket, and on
+    # a retried step. Not a conflict: the name identifies the run.
+    http.route("POST", "/git/refs", (422, {"message": "Reference already exists"}))
+    assert create_ticket(REPO, PREFIX, Ticket(1, 1), SHA) == "exists"
+
+
+@pytest.mark.parametrize("status", [401, 403, 404])
+def test_create_ticket_reports_denied_without_ref_write(
+    http: FakeHTTP, status: int
+) -> None:
+    http.route("POST", "/git/refs", (status, {"message": "Resource not accessible"}))
+    assert create_ticket(REPO, PREFIX, Ticket(1, 1), SHA) == "denied"
+
+
+def test_create_ticket_raises_on_an_unrelated_422(http: FakeHTTP) -> None:
+    # A malformed ref or a bad sha is a bug in the caller, not contention — it
+    # must not be swallowed as "someone else holds the lease".
+    http.route("POST", "/git/refs", (422, {"message": "Object does not exist"}))
+    with pytest.raises(SystemExit):
+        create_ticket(REPO, PREFIX, Ticket(1, 1), SHA)
+
+
+def test_list_tickets_parses_and_skips_foreign_refs(http: FakeHTTP) -> None:
+    http.route(
+        "GET",
+        "/git/matching-refs/",
+        (200, [_ref(10), {"ref": f"refs/{PREFIX}/README"}, _ref(20, 3)]),
+    )
+    assert list_tickets(REPO, PREFIX) == [Ticket(10, 1), Ticket(20, 3)]
+
+
+def test_list_tickets_treats_404_as_an_empty_queue(http: FakeHTTP) -> None:
+    http.route("GET", "/git/matching-refs/", (404, {"message": "Not Found"}))
+    assert list_tickets(REPO, PREFIX) == []
+
+
+def test_list_tickets_raises_on_a_server_error(http: FakeHTTP) -> None:
+    # Silently reading "no queue" from a 500 would hand the tenant to every
+    # waiting run at once.
+    http.route("GET", "/git/matching-refs/", (500, {"message": "boom"}))
+    with pytest.raises(SystemExit):
+        list_tickets(REPO, PREFIX)
+
+
+def test_delete_ticket_reports_success(http: FakeHTTP) -> None:
+    http.route("DELETE", "/git/refs/", (204, None))
+    assert delete_ticket(REPO, PREFIX, Ticket(1, 1)) is True
+
+
+def test_delete_ticket_tolerates_an_already_reaped_ticket(http: FakeHTTP) -> None:
+    # Two contenders can reap the same dead ticket; the loser must not fail.
+    http.route("DELETE", "/git/refs/", (422, {"message": "Reference does not exist"}))
+    assert delete_ticket(REPO, PREFIX, Ticket(1, 1)) is False
+
+
+# --- holder liveness -------------------------------------------------------
+
+
+def test_holder_in_progress_is_live(http: FakeHTTP) -> None:
+    http.route("GET", "/actions/runs/", (200, {"status": "in_progress"}))
+    assert run_is_live(REPO, Ticket(1, 1), ttl_seconds=0) is True
+
+
+def test_holder_completed_is_dead(http: FakeHTTP) -> None:
+    http.route("GET", "/actions/runs/", (200, {"status": "completed"}))
+    assert run_is_live(REPO, Ticket(1, 1), ttl_seconds=0) is False
+
+
+def test_holder_deleted_run_is_dead(http: FakeHTTP) -> None:
+    # Nothing will ever release this ticket, so it has to be breakable.
+    http.route("GET", "/actions/runs/", (404, {"message": "Not Found"}))
+    assert run_is_live(REPO, Ticket(1, 1), ttl_seconds=0) is False
+
+
+@pytest.mark.parametrize("status", ["queued", "waiting", "requested", "pending"])
+def test_holder_pre_start_statuses_are_live(http: FakeHTTP, status: str) -> None:
+    # A queued run has a place in line and will install; treating it as dead
+    # would let a later run install underneath it.
+    http.route("GET", "/actions/runs/", (200, {"status": status}))
+    assert run_is_live(REPO, Ticket(1, 1), ttl_seconds=0) is True
+
+
+def test_holder_is_assumed_live_on_an_api_error(http: FakeHTTP) -> None:
+    # Erring towards "dead" on a transient 500 would put two runs on one tenant
+    # mid-install — the exact race the lease exists to prevent. Erring towards
+    # "live" costs one poll interval.
+    http.route("GET", "/actions/runs/", (500, {"message": "boom"}))
+    assert run_is_live(REPO, Ticket(1, 1), ttl_seconds=0) is True
+
+
+def test_holder_past_ttl_is_broken(http: FakeHTTP) -> None:
+    http.route(
+        "GET",
+        "/actions/runs/",
+        (200, {"status": "in_progress", "created_at": "2020-01-01T00:00:00Z"}),
+    )
+    assert run_is_live(REPO, Ticket(1, 1), ttl_seconds=60) is False
+
+
+def test_holder_within_ttl_is_left_alone(http: FakeHTTP) -> None:
+    started = datetime.now(timezone.utc) - timedelta(seconds=30)
+    http.route(
+        "GET",
+        "/actions/runs/",
+        (200, {"status": "in_progress", "created_at": started.isoformat()}),
+    )
+    assert run_is_live(REPO, Ticket(1, 1), ttl_seconds=3600) is True
+
+
+def test_ttl_of_zero_never_breaks_a_live_holder(http: FakeHTTP) -> None:
+    http.route(
+        "GET",
+        "/actions/runs/",
+        (200, {"status": "in_progress", "created_at": "2020-01-01T00:00:00Z"}),
+    )
+    assert run_is_live(REPO, Ticket(1, 1), ttl_seconds=0) is True
+
+
+def test_holder_without_a_created_at_is_left_alone(http: FakeHTTP) -> None:
+    # No timestamp means the TTL backstop cannot judge; the run's own status is
+    # then the only evidence, and it says live.
+    http.route("GET", "/actions/runs/", (200, {"status": "in_progress"}))
+    assert run_is_live(REPO, Ticket(1, 1), ttl_seconds=60) is True
+
+
+def test_holder_with_an_unparseable_created_at_is_left_alone(http: FakeHTTP) -> None:
+    http.route(
+        "GET", "/actions/runs/", (200, {"status": "in_progress", "created_at": "soon"})
+    )
+    assert run_is_live(REPO, Ticket(1, 1), ttl_seconds=60) is True
+
+
+# --- acquire ---------------------------------------------------------------
+
+
+def _acquire(**kwargs):
+    defaults = dict(
+        wait_seconds=60,
+        poll_seconds=30,
+        ttl_seconds=0,
+        sleep=lambda _s: None,
+    )
+    defaults.update(kwargs)
+    return acquire(REPO, PREFIX, Ticket(100, 1), SHA, **defaults)
+
+
+def test_acquire_takes_an_uncontended_lease(http: FakeHTTP) -> None:
+    http.route("POST", "/git/refs", (201, {}))
+    http.route("GET", "/git/matching-refs/", (200, [_ref(100)]))
+    assert _acquire() == ("acquired", None)
+
+
+def test_acquire_takes_the_lease_when_it_is_the_lowest_run_id(http: FakeHTTP) -> None:
+    http.route("POST", "/git/refs", (201, {}))
+    http.route("GET", "/git/matching-refs/", (200, [_ref(200), _ref(100), _ref(300)]))
+    # No liveness call is needed or made: nothing sorts ahead of us.
+    assert _acquire() == ("acquired", None)
+    assert not [call for call in http.calls if "/actions/runs/" in call[1]]
+
+
+def test_acquire_waits_behind_a_live_earlier_run(http: FakeHTTP) -> None:
+    http.route("POST", "/git/refs", (201, {}))
+    http.route("GET", "/git/matching-refs/", (200, [_ref(50), _ref(100)]))
+    http.route("GET", "/actions/runs/", (200, {"status": "in_progress"}))
+    assert _acquire() == ("timeout", Ticket(50, 1))
+
+
+def test_acquire_reaps_a_dead_holder_and_proceeds(http: FakeHTTP) -> None:
+    # The case an `if: always()` release job cannot cover: a cancelled run whose
+    # release job never started. The next contender clears it in-band.
+    http.route("POST", "/git/refs", (201, {}))
+    http.route("GET", "/git/matching-refs/", (200, [_ref(50), _ref(100)]))
+    http.route("GET", "/actions/runs/", (200, {"status": "completed"}))
+    http.route("DELETE", "/git/refs/", (204, None))
+    assert _acquire() == ("acquired", None)
+    assert (
+        "DELETE",
+        f"https://api.github.com/repos/{REPO}/git/refs/{PREFIX}/50-1",
+    ) in (http.calls)
+
+
+def test_acquire_reaps_several_dead_holders_in_one_poll(http: FakeHTTP) -> None:
+    http.route("POST", "/git/refs", (201, {}))
+    http.route("GET", "/git/matching-refs/", (200, [_ref(30), _ref(40), _ref(100)]))
+    http.route("GET", "/actions/runs/", (200, {"status": "completed"}))
+    http.route("DELETE", "/git/refs/", (204, None))
+    assert _acquire() == ("acquired", None)
+    deletes = [call for call in http.calls if call[0] == "DELETE"]
+    assert len(deletes) == 2
+
+
+def test_acquire_stops_reaping_at_the_first_live_holder(http: FakeHTTP) -> None:
+    # 30 is dead, 40 is live: 40 holds the lease and 100 must not delete it.
+    http.route("POST", "/git/refs", (201, {}))
+    http.route("GET", "/git/matching-refs/", (200, [_ref(30), _ref(40), _ref(100)]))
+    http.route(
+        "GET",
+        "/actions/runs/",
+        (200, {"status": "completed"}),
+        (200, {"status": "in_progress"}),
+    )
+    http.route("DELETE", "/git/refs/", (204, None))
+    # A single poll, so the two queued liveness answers map one-to-one onto the
+    # two tickets ahead of us.
+    assert _acquire(wait_seconds=30, poll_seconds=30) == ("timeout", Ticket(40, 1))
+    deletes = [call for call in http.calls if call[0] == "DELETE"]
+    assert len(deletes) == 1
+    assert "30-1" in deletes[0][1]
+
+
+def test_acquire_gets_the_lease_on_a_later_poll(http: FakeHTTP) -> None:
+    http.route("POST", "/git/refs", (201, {}))
+    http.route(
+        "GET",
+        "/git/matching-refs/",
+        (200, [_ref(50), _ref(100)]),
+        (200, [_ref(100)]),
+    )
+    http.route("GET", "/actions/runs/", (200, {"status": "in_progress"}))
+    assert _acquire(wait_seconds=60, poll_seconds=30) == ("acquired", None)
+
+
+def test_acquire_recreates_a_ticket_that_vanished(http: FakeHTTP) -> None:
+    # A peer that misread this run as finished can reap us. Re-creating restores
+    # the same position, because the name is derived from the run.
+    http.route("POST", "/git/refs", (201, {}), (201, {}))
+    http.route("GET", "/git/matching-refs/", (200, []))
+    assert _acquire() == ("acquired", None)
+    assert len([call for call in http.calls if call[0] == "POST"]) == 2
+
+
+def test_acquire_disables_itself_without_ref_write(http: FakeHTTP) -> None:
+    # Fail-open: the lease reduces contention, it is not what makes a
+    # wrong-version run detectable (each leg re-asserts the version, FND-31).
+    http.route("POST", "/git/refs", (403, {"message": "Resource not accessible"}))
+    assert _acquire() == ("disabled", None)
+
+
+def test_acquire_disables_itself_when_recreation_is_denied(http: FakeHTTP) -> None:
+    http.route("POST", "/git/refs", (201, {}), (403, {"message": "nope"}))
+    http.route("GET", "/git/matching-refs/", (200, []))
+    assert _acquire() == ("disabled", None)
+
+
+def test_acquire_makes_two_api_calls_per_contended_poll(http: FakeHTTP) -> None:
+    # The GITHUB_TOKEN budget is 1000 requests/hour/repo, and only the current
+    # front-of-queue ticket is checked for liveness — checking every ticket every
+    # poll would blow that budget on a long queue.
+    http.route("POST", "/git/refs", (201, {}))
+    http.route("GET", "/git/matching-refs/", (200, [_ref(40), _ref(50), _ref(100)]))
+    http.route("GET", "/actions/runs/", (200, {"status": "in_progress"}))
+    _acquire(wait_seconds=30, poll_seconds=30)
+    polling_calls = [call for call in http.calls if call[0] == "GET"]
+    assert len(polling_calls) == 2
+
+
+def test_acquire_respects_the_wait_budget(http: FakeHTTP) -> None:
+    http.route("POST", "/git/refs", (201, {}))
+    http.route("GET", "/git/matching-refs/", (200, [_ref(50), _ref(100)]))
+    http.route("GET", "/actions/runs/", (200, {"status": "in_progress"}))
+    slept: list[int] = []
+    _acquire(wait_seconds=90, poll_seconds=30, sleep=slept.append)
+    # 3 attempts, so 2 sleeps: the last attempt is not followed by a wait.
+    assert slept == [30, 30]
+
+
+def test_acquire_always_makes_one_attempt_on_a_zero_budget(http: FakeHTTP) -> None:
+    http.route("POST", "/git/refs", (201, {}))
+    http.route("GET", "/git/matching-refs/", (200, [_ref(100)]))
+    assert _acquire(wait_seconds=0, poll_seconds=30) == ("acquired", None)
+
+
+# --- release ---------------------------------------------------------------
+
+
+def test_release_deletes_this_runs_ticket(http: FakeHTTP) -> None:
+    http.route("DELETE", "/git/refs/", (204, None))
+    assert release(REPO, PREFIX, Ticket(100, 1)) is True
+    assert http.calls[0][1].endswith(f"/git/refs/{PREFIX}/100-1")
+
+
+def test_release_is_quiet_when_the_ticket_is_already_gone(http: FakeHTTP) -> None:
+    http.route("DELETE", "/git/refs/", (422, {"message": "Reference does not exist"}))
+    assert release(REPO, PREFIX, Ticket(100, 1)) is False
+
+
+# --- outputs ---------------------------------------------------------------
+
+
+def test_write_outputs_appends_key_value_pairs(tmp_path: Path) -> None:
+    target = tmp_path / "out"
+    write_outputs({"acquired": "true", "state": "acquired"}, str(target))
+    assert target.read_text() == "acquired=true\nstate=acquired\n"
+
+
+def test_write_outputs_is_a_noop_without_a_path() -> None:
+    write_outputs({"acquired": "true"}, None)
+
+
+# --- CLI -------------------------------------------------------------------
+
+
+def _argv(mode: str, *extra: str) -> list[str]:
+    return [
+        "--mode",
+        mode,
+        "--repo",
+        REPO,
+        "--app",
+        "example",
+        "--cloud",
+        "aws",
+        "--run-id",
+        "100",
+        "--run-attempt",
+        "1",
+        "--sha",
+        SHA,
+        *extra,
+    ]
+
+
+def test_main_acquire_exits_zero_and_reports_outputs(
+    http: FakeHTTP, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    out = tmp_path / "out"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(out))
+    http.route("POST", "/git/refs", (201, {}))
+    http.route("GET", "/git/matching-refs/", (200, [_ref(100)]))
+    assert main(_argv("acquire")) == 0
+    assert "acquired=true" in out.read_text()
+    assert f"lease-ref=refs/{PREFIX}/100-1" in out.read_text()
+
+
+def test_main_acquire_fails_loudly_on_timeout(
+    http: FakeHTTP, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    out = tmp_path / "out"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(out))
+    http.route("POST", "/git/refs", (201, {}))
+    http.route("GET", "/git/matching-refs/", (200, [_ref(50), _ref(100)]))
+    http.route("GET", "/actions/runs/", (200, {"status": "in_progress"}))
+    assert main(_argv("acquire", "--wait-seconds", "1", "--poll-seconds", "1")) == 1
+    printed = capsys.readouterr().out
+    # The holder has to be named: "the tenant is busy" is only actionable if the
+    # reader can see which run to wait for.
+    assert "::error::" in printed
+    assert "50" in printed
+    assert "acquired=false" in out.read_text()
+    assert "holder-run-id=50" in out.read_text()
+
+
+def test_main_acquire_timeout_says_the_change_is_not_at_fault(
+    http: FakeHTTP, capsys, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The whole point of FND-250: a contention outcome must not read as a test
+    # failure, because that sends a reviewer into the wrong diff.
+    monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+    http.route("POST", "/git/refs", (201, {}))
+    http.route("GET", "/git/matching-refs/", (200, [_ref(50), _ref(100)]))
+    http.route("GET", "/actions/runs/", (200, {"status": "in_progress"}))
+    main(_argv("acquire", "--wait-seconds", "1", "--poll-seconds", "1"))
+    assert "Nothing is wrong with this change" in capsys.readouterr().out
+
+
+def test_main_acquire_can_warn_instead_of_failing(
+    http: FakeHTTP, capsys, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+    http.route("POST", "/git/refs", (201, {}))
+    http.route("GET", "/git/matching-refs/", (200, [_ref(50), _ref(100)]))
+    http.route("GET", "/actions/runs/", (200, {"status": "in_progress"}))
+    argv = _argv(
+        "acquire", "--wait-seconds", "1", "--poll-seconds", "1", "--on-timeout", "warn"
+    )
+    assert main(argv) == 0
+    assert "::warning::" in capsys.readouterr().out
+
+
+def test_main_acquire_exits_zero_when_the_lease_is_disabled(
+    http: FakeHTTP, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+    http.route("POST", "/git/refs", (403, {"message": "nope"}))
+    assert main(_argv("acquire")) == 0
+
+
+def test_main_release_exits_zero(
+    http: FakeHTTP, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+    http.route("DELETE", "/git/refs/", (204, None))
+    assert main(_argv("release")) == 0
+
+
+def test_main_release_exits_zero_even_when_nothing_was_held(
+    http: FakeHTTP, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A failed release must never redden a run whose tests passed; the reaper
+    # covers it.
+    monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+    http.route("DELETE", "/git/refs/", (422, {"message": "Reference does not exist"}))
+    assert main(_argv("release")) == 0
+
+
+def test_main_release_needs_no_sha(
+    http: FakeHTTP, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The release job derives the ticket from the run, so it does not have to be
+    # handed any state by the acquiring job.
+    monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+    http.route("DELETE", "/git/refs/", (204, None))
+    argv = [
+        "--mode",
+        "release",
+        "--repo",
+        REPO,
+        "--app",
+        "example",
+        "--cloud",
+        "aws",
+        "--run-id",
+        "100",
+        "--run-attempt",
+        "1",
+    ]
+    assert main(argv) == 0
+
+
+def test_main_acquire_requires_a_sha(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GH_TOKEN", "x")
+    argv = [
+        "--mode",
+        "acquire",
+        "--repo",
+        REPO,
+        "--app",
+        "example",
+        "--run-id",
+        "100",
+        "--run-attempt",
+        "1",
+    ]
+    with pytest.raises(SystemExit):
+        main(argv)
+
+
+def test_acquire_and_release_agree_on_the_ticket_ref(
+    http: FakeHTTP, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The two modes run in different jobs and share no state — if they ever
+    disagreed about the ref name, every run would leak its lease."""
+    out = tmp_path / "out"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(out))
+    http.route("POST", "/git/refs", (201, {}))
+    http.route("GET", "/git/matching-refs/", (200, [_ref(100)]))
+    main(_argv("acquire"))
+    acquired_ref = [
+        line.split("=", 1)[1]
+        for line in out.read_text().splitlines()
+        if line.startswith("lease-ref=")
+    ][0]
+
+    http.calls.clear()
+    http.route("DELETE", "/git/refs/", (204, None))
+    main(_argv("release"))
+    deleted = http.calls[0][1]
+    assert deleted.endswith(acquired_ref.removeprefix("refs/"))
+
+
+def test_missing_token_is_a_clear_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    with pytest.raises(SystemExit, match="GH_TOKEN"):
+        create_ticket(REPO, PREFIX, Ticket(1, 1), SHA)

--- a/.github/scripts/tests/test_label_trigger_gates.py
+++ b/.github/scripts/tests/test_label_trigger_gates.py
@@ -338,6 +338,13 @@ def test_the_e2e_concurrency_groups_still_refuse_to_cancel_in_progress() -> None
     Automation Engine run has a cleanup path — cancelling mid-run today leaves
     tenant state behind. If this assertion is what fails, that decision is being
     made implicitly.
+
+    Tracked as FND-252, which is where a deliberate flip belongs: it carries the
+    cleanup-path prerequisite and the group-keying constraint that has to survive
+    the change (run-unique off the PR path, or a cross-repo dispatch collapses
+    every run into one group — FND-218). This guard has already caught one
+    incidental attempt, in the FND-250 lease work, where turning it on had been
+    added as a runner-time win rather than as the decision it is.
     """
     workflow = _load(_WORKFLOW_DIR / "tests-reusable.yaml")
     e2e_jobs = [

--- a/.github/scripts/tests/test_prepare_tenant_wiring.py
+++ b/.github/scripts/tests/test_prepare_tenant_wiring.py
@@ -60,7 +60,7 @@ def test_install_is_off_by_default(workflow: dict) -> None:  # type: ignore[type
     assert spec["type"] == "boolean"
 
 
-@pytest.mark.parametrize("job", ["build-e2e-image", "prepare-tenant"])
+@pytest.mark.parametrize("job", ["build-e2e-image", "lease-tenant", "prepare-tenant"])
 def test_new_jobs_are_gated_on_the_input(jobs: dict, job: str) -> None:  # type: ignore[type-arg]
     assert "inputs.install-app-to-tenant" in jobs[job]["if"], (
         f"{job} must not run when install-app-to-tenant is off — otherwise every "
@@ -166,22 +166,163 @@ def _sdr_step(jobs: dict) -> dict:  # type: ignore[type-arg]
 # ── Tenant-scoped concurrency ────────────────────────────────────────────────
 
 
-def test_prepare_tenant_serialises_per_tenant_not_per_ref(jobs: dict) -> None:  # type: ignore[type-arg]
+def test_prepare_tenant_leaves_tenant_exclusion_to_the_lease(jobs: dict) -> None:  # type: ignore[type-arg]
+    """Tenant exclusion moved from this group to the (app, cloud) lease (FND-250).
+
+    A tenant-keyed group here would now be actively harmful, not merely
+    redundant: it holds ONE pending run, so a third run whose lease has not come
+    up yet would be evicted before it ever got a runner — reintroducing FND-218
+    inside the fix for it. Run-unique is the requirement, and it is only safe
+    *because* lease-tenant serialises the tenant properly.
+    """
     concurrency = jobs["prepare-tenant"]["concurrency"]
     group = concurrency["group"]
 
-    # The installation is tenant-scoped, so the group has to identify the TENANT
-    # (app + cloud). Keying on github.ref would let two PRs install different
-    # versions to the same tenant concurrently, and the loser is silently what
-    # the tenant ends up running.
-    assert "inputs.app-name" in group and "matrix.cloud" in group
-    assert "github.ref" not in group, (
-        "keying on the ref permits concurrent installs to the same tenant from "
-        "different refs, which is the race this group exists to narrow"
+    assert "github.run_id" in group, (
+        "prepare-tenant's group must be run-unique; anything shared across runs "
+        "queues one-deep and evicts the rest (FND-218)"
     )
+    assert "inputs.app-name" not in group, (
+        "a tenant-keyed group here re-adds a one-pending-slot waiting room in "
+        "front of the lease; serialisation belongs to lease-tenant"
+    )
+    assert "github.ref" not in group
     # Cancelling mid-install abandons the deployment and leaves the tenant in
     # whatever state LM reached.
     assert concurrency["cancel-in-progress"] is False
+
+
+# ── The (app, cloud) tenant lease (FND-250) ──────────────────────────────────
+
+_LEASE_ACTION = "atlanhq/application-sdk/.github/actions/e2e-tenant-lease@main"
+
+
+def _lease_step(jobs: dict, job: str) -> dict:  # type: ignore[type-arg]
+    for step in jobs[job]["steps"]:
+        if "e2e-tenant-lease" in str(step.get("uses", "")):
+            return step
+    raise AssertionError(f"{job} no longer invokes the e2e-tenant-lease action")
+
+
+@pytest.mark.parametrize(
+    ("job", "mode"), [("lease-tenant", "acquire"), ("release-tenant", "release")]
+)
+def test_the_lease_jobs_use_the_shared_action_at_main(
+    jobs: dict,  # type: ignore[type-arg]
+    job: str,
+    mode: str,
+) -> None:
+    """Pinned @main on purpose: every contender has to agree on the ref layout
+    and the ordering rule, so the protocol must not vary by checked-out ref."""
+    step = _lease_step(jobs, job)
+    assert step["uses"] == _LEASE_ACTION
+    assert step["with"]["mode"] == mode
+
+
+@pytest.mark.parametrize("job", ["lease-tenant", "release-tenant"])
+def test_the_lease_jobs_key_on_app_and_cloud(jobs: dict, job: str) -> None:  # type: ignore[type-arg]
+    """Acquire and release must name the same tenant, or every run leaks its
+    ticket and the next contender waits for a holder that has already gone."""
+    with_ = _lease_step(jobs, job)["with"]
+    assert with_["app"] == "${{ inputs.app-name }}"
+    assert with_["cloud"] == "${{ matrix.cloud }}"
+
+
+@pytest.mark.parametrize("job", ["lease-tenant", "release-tenant"])
+def test_the_lease_jobs_can_write_refs_and_read_runs(jobs: dict, job: str) -> None:  # type: ignore[type-arg]
+    # contents: write creates and deletes the ticket; actions: read tells a live
+    # holder from a dead one. Scoped to these two jobs so the long-running legs
+    # that execute test code keep read-only contents.
+    permissions = jobs[job]["permissions"]
+    assert permissions["contents"] == "write"
+    assert permissions["actions"] == "read"
+
+
+def test_the_legs_do_not_get_ref_write(jobs: dict) -> None:  # type: ignore[type-arg]
+    # Least privilege: the lease's write capability must not leak into the job
+    # that runs connector test code.
+    assert jobs["e2e"]["permissions"]["contents"] == "read"
+
+
+def test_prepare_tenant_is_gated_on_the_lease(jobs: dict) -> None:  # type: ignore[type-arg]
+    # Installing without the lease is precisely the race the lease closes, so
+    # this is a gate and not merely an ordering edge.
+    assert "lease-tenant" in jobs["prepare-tenant"]["needs"]
+    assert "needs.lease-tenant.result == 'success'" in jobs["prepare-tenant"]["if"]
+
+
+def test_the_legs_refuse_to_run_on_a_failed_lease(jobs: dict) -> None:  # type: ignore[type-arg]
+    """A failed lease leaves prepare-tenant SKIPPED, and 'skipped' is benign in
+    the legs' gate — so without lease-tenant named here the legs would run
+    against a tenant nobody installed onto, with expected-app-version empty so
+    the version check self-skips. A silently passing wrong-version run, from the
+    machinery added to prevent them."""
+    assert "lease-tenant" in jobs["e2e"]["needs"]
+    gate = jobs["e2e"]["if"]
+    assert "needs.lease-tenant.result == 'success'" in gate
+    assert "needs.lease-tenant.result == 'skipped'" in gate
+
+
+def test_the_lease_is_released_even_when_the_legs_fail(jobs: dict) -> None:  # type: ignore[type-arg]
+    # A failed leg must still hand the tenant back, so the release is gated on
+    # having taken the lease — not on the outcome of anything after it.
+    gate = jobs["release-tenant"]["if"]
+    assert "always()" in gate
+    assert "needs.lease-tenant.result == 'success'" in gate
+    assert "e2e" in jobs["release-tenant"]["needs"]
+
+
+def test_the_lease_wait_fits_inside_the_job_timeout(jobs: dict) -> None:  # type: ignore[type-arg]
+    """If the runner's timeout fires first, a bare "job cancelled after Nm"
+    replaces the script's error — which is the one place the holding run is
+    named, and therefore the only actionable output this job produces."""
+    action = yaml.safe_load(
+        (_REPO_ROOT / ".github/actions/e2e-tenant-lease/action.yaml").read_text(
+            encoding="utf-8"
+        )
+    )
+    wait_seconds = int(action["inputs"]["wait-seconds"]["default"])
+    timeout_seconds = int(jobs["lease-tenant"]["timeout-minutes"]) * 60
+    assert timeout_seconds > wait_seconds
+
+
+def test_the_lease_ttl_exceeds_the_longest_legitimate_run() -> None:
+    """A TTL below the real ceiling breaks a slow-but-healthy holder's lease
+    mid-install, which is worse than the contention it is guarding against."""
+    action = yaml.safe_load(
+        (_REPO_ROOT / ".github/actions/e2e-tenant-lease/action.yaml").read_text(
+            encoding="utf-8"
+        )
+    )
+    ttl_seconds = int(action["inputs"]["ttl-seconds"]["default"])
+    workflow_jobs = yaml.safe_load(_WORKFLOW.read_text(encoding="utf-8"))["jobs"]
+    longest_run = (
+        int(workflow_jobs["prepare-tenant"]["timeout-minutes"])
+        + int(workflow_jobs["e2e"]["timeout-minutes"])
+    ) * 60
+    assert ttl_seconds > longest_run
+
+
+def test_the_lease_and_install_fan_out_over_the_same_clouds(jobs: dict) -> None:  # type: ignore[type-arg]
+    # A lease leg that missed a cloud the install then ran against is an
+    # unserialised install, not a visible failure.
+    assert (
+        jobs["lease-tenant"]["strategy"]["matrix"]
+        == (jobs["prepare-tenant"]["strategy"]["matrix"])
+    )
+    assert (
+        jobs["release-tenant"]["strategy"]["matrix"]
+        == (jobs["prepare-tenant"]["strategy"]["matrix"])
+    )
+
+
+def test_the_gate_is_told_about_the_lease() -> None:
+    """Otherwise a lease failure reaches the gate only as the downstream "matrix
+    skipped" anomaly, which reads as a workflow misconfiguration rather than
+    "the tenant was busy"."""
+    text = _WORKFLOW.read_text(encoding="utf-8")
+    # Both gate call sites: the required check and the cross-repo callback.
+    assert text.count("lease-tenant-result:") == 2
 
 
 # ── The two cloud fan-outs must agree ────────────────────────────────────────

--- a/.github/scripts/tests/test_prepare_tenant_wiring.py
+++ b/.github/scripts/tests/test_prepare_tenant_wiring.py
@@ -286,21 +286,66 @@ def test_the_lease_wait_fits_inside_the_job_timeout(jobs: dict) -> None:  # type
     assert timeout_seconds > wait_seconds
 
 
-def test_the_lease_ttl_exceeds_the_longest_legitimate_run() -> None:
-    """A TTL below the real ceiling breaks a slow-but-healthy holder's lease
-    mid-install, which is worse than the contention it is guarding against."""
+#: Every job on the path from run creation to the last leg finishing. The TTL is
+#: measured from run CREATION, so all of it counts — not just the part after the
+#: lease is acquired. Sizing the TTL against install-plus-legs alone was an
+#: actual latent bug, not a theoretical one: that pair is 160 min against a chain
+#: of 325, so a healthy run that queued for runners could cross a 4h TTL partway
+#: through its own install and have a contender reap it mid-flight.
+_PRE_RELEASE_CHAIN = (
+    "discover-e2e",
+    "build-e2e-image",
+    "merge-e2e-image",
+    "lease-tenant",
+    "prepare-tenant",
+    "e2e",
+)
+
+
+def test_the_lease_ttl_cannot_fire_on_a_healthy_holder(jobs: dict) -> None:  # type: ignore[type-arg]
+    """The TTL breaking a LIVE holder's lease puts a second installer on the
+    tenant — the exact race the lease exists to close — so it must clear the
+    whole chain, with room left for runner queue time, which has no timeout.
+
+    Derived from the workflow's own timeouts rather than hard-coded, so adding a
+    job to the chain or raising a timeout forces the TTL up instead of quietly
+    eating the margin.
+    """
     action = yaml.safe_load(
         (_REPO_ROOT / ".github/actions/e2e-tenant-lease/action.yaml").read_text(
             encoding="utf-8"
         )
     )
     ttl_seconds = int(action["inputs"]["ttl-seconds"]["default"])
-    workflow_jobs = yaml.safe_load(_WORKFLOW.read_text(encoding="utf-8"))["jobs"]
-    longest_run = (
-        int(workflow_jobs["prepare-tenant"]["timeout-minutes"])
-        + int(workflow_jobs["e2e"]["timeout-minutes"])
-    ) * 60
-    assert ttl_seconds > longest_run
+    chain_seconds = (
+        sum(int(jobs[job]["timeout-minutes"]) for job in _PRE_RELEASE_CHAIN) * 60
+    )
+
+    assert ttl_seconds > chain_seconds, (
+        f"ttl-seconds ({ttl_seconds}s) does not clear the "
+        f"{'+'.join(_PRE_RELEASE_CHAIN)} chain ({chain_seconds}s). A healthy "
+        "holder that queued for runners would have its lease broken mid-install."
+    )
+    # Queue time between those jobs is unbounded, so clearing the chain exactly is
+    # not enough; require real headroom rather than a one-second pass.
+    assert ttl_seconds >= 2 * chain_seconds, (
+        f"ttl-seconds ({ttl_seconds}s) clears the chain ({chain_seconds}s) but "
+        "leaves no room for runner queue time, which has no timeout"
+    )
+
+
+def test_the_lease_wait_budget_is_the_operator_facing_signal(jobs: dict) -> None:  # type: ignore[type-arg]
+    """The TTL is deliberately generous, so it must not be what tells a human the
+    tenant is stuck — the wait budget has to fail long before it, or a blocked run
+    sits silently for hours instead of reporting who holds the tenant."""
+    action = yaml.safe_load(
+        (_REPO_ROOT / ".github/actions/e2e-tenant-lease/action.yaml").read_text(
+            encoding="utf-8"
+        )
+    )
+    wait_seconds = int(action["inputs"]["wait-seconds"]["default"])
+    ttl_seconds = int(action["inputs"]["ttl-seconds"]["default"])
+    assert wait_seconds < ttl_seconds
 
 
 def test_the_lease_and_install_fan_out_over_the_same_clouds(jobs: dict) -> None:  # type: ignore[type-arg]

--- a/.github/scripts/tests/test_verify_test_gate.py
+++ b/.github/scripts/tests/test_verify_test_gate.py
@@ -925,3 +925,266 @@ def test_main_does_not_annotate_the_guidance_on_a_real_failure(capsys) -> None:
     captured = capsys.readouterr()
     assert "conclusion=failure" in captured.out
     assert "Re-run rather than triage" not in captured.err
+
+
+# --- tenant lease (FND-250) ------------------------------------------------
+
+
+def test_lease_tenant_skipped_is_a_pass() -> None:
+    # The default for every caller pinned at @main that has not wired the job,
+    # and the honest value when the install path is off.
+    assert evaluate("success", "skipped", "skipped", "skipped", "skipped") == []
+
+
+def test_lease_tenant_success_is_a_pass() -> None:
+    assert (
+        evaluate(
+            "success",
+            "success",
+            "success",
+            "success",
+            "success",
+            "success",
+            "success",
+            "success",
+            "success",
+            "success",
+        )
+        == []
+    )
+
+
+def test_lease_tenant_failure_fails_the_gate_by_name() -> None:
+    # Without this the failure surfaces only as the downstream "matrix skipped"
+    # anomaly, which reads as a workflow misconfiguration rather than "the tenant
+    # was busy".
+    errors = evaluate(
+        "success",
+        "skipped",
+        "skipped",
+        "success",
+        "skipped",
+        "skipped",
+        "success",
+        "success",
+        "skipped",
+        "failure",
+    )
+    assert any("the tenant lease did not succeed (result=failure)" in e for e in errors)
+
+
+def test_lease_tenant_failure_suppresses_the_matrix_anomaly() -> None:
+    # One cause, one annotation: the lease failing IS why the matrix skipped.
+    errors = evaluate(
+        "success",
+        "skipped",
+        "skipped",
+        "success",
+        "skipped",
+        "skipped",
+        "success",
+        "success",
+        "skipped",
+        "failure",
+    )
+    assert not any("matrix was skipped" in e for e in errors)
+
+
+def test_lease_tenant_row_says_the_tenant_was_busy() -> None:
+    # "Failed" here would send a reviewer into their own diff; the tenant was
+    # occupied, which is a re-run, not a fix.
+    row = render(
+        "success",
+        "skipped",
+        "skipped",
+        "success",
+        "skipped",
+        "skipped",
+        "success",
+        "success",
+        "skipped",
+        "failure",
+    )["e2e-status"]
+    assert row == "⏳ Tenant busy — lease not acquired, re-run"
+
+
+def test_lease_tenant_cancelled_row_reads_as_cancelled() -> None:
+    row = render(
+        "success",
+        "skipped",
+        "skipped",
+        "success",
+        "skipped",
+        "skipped",
+        "success",
+        "success",
+        "skipped",
+        "cancelled",
+    )["e2e-status"]
+    assert row == "🚫 Tenant lease cancelled — not run"
+
+
+def test_lease_tenant_cancelled_is_reported_as_cancelled_not_failure() -> None:
+    outputs = render(
+        "success",
+        "skipped",
+        "skipped",
+        "success",
+        "skipped",
+        "skipped",
+        "success",
+        "success",
+        "skipped",
+        "cancelled",
+    )
+    assert outputs["passed"] == "false"
+    assert outputs["conclusion"] == "cancelled"
+
+
+def test_lease_tenant_failure_is_reported_as_failure() -> None:
+    # A lease TIMEOUT is a genuine job failure, not a cancellation: nothing was
+    # evicted, the run waited its full budget and gave up.
+    outputs = render(
+        "success",
+        "skipped",
+        "skipped",
+        "success",
+        "skipped",
+        "skipped",
+        "success",
+        "success",
+        "skipped",
+        "failure",
+    )
+    assert outputs["passed"] == "false"
+    assert outputs["conclusion"] == "failure"
+
+
+def test_lease_tenant_row_yields_to_an_earlier_install_path_failure() -> None:
+    # Reported in pipeline order, so the row names the FIRST thing that broke —
+    # a failed image build explains the lease never running.
+    row = render(
+        "success",
+        "skipped",
+        "skipped",
+        "success",
+        "skipped",
+        "skipped",
+        "failure",
+        "skipped",
+        "skipped",
+        "skipped",
+    )["e2e-status"]
+    assert row == "❌ e2e image build failed"
+
+
+def test_lease_tenant_precedes_the_install_in_the_reported_order() -> None:
+    # Both broken: the lease is reported, because it runs first and a tenant that
+    # was never leased is why the install did not happen.
+    row = render(
+        "success",
+        "skipped",
+        "skipped",
+        "success",
+        "skipped",
+        "skipped",
+        "success",
+        "success",
+        "failure",
+        "failure",
+    )["e2e-status"]
+    assert row == "⏳ Tenant busy — lease not acquired, re-run"
+
+
+def test_main_accepts_the_lease_tenant_flag(capsys) -> None:
+    main(
+        [
+            "--unit",
+            "success",
+            "--integration",
+            "skipped",
+            "--detect-integration",
+            "skipped",
+            "--discover-e2e",
+            "success",
+            "--build-e2e-image",
+            "success",
+            "--merge-e2e-image",
+            "success",
+            "--lease-tenant",
+            "failure",
+            "--prepare-tenant",
+            "skipped",
+            "--e2e",
+            "skipped",
+        ]
+    )
+    captured = capsys.readouterr()
+    assert "passed=false" in captured.out
+    assert "the tenant lease did not succeed" in captured.err
+
+
+def test_lease_tenant_flag_defaults_to_skipped(capsys) -> None:
+    # Cross-repo compatibility: a caller pinned at @main that has not added the
+    # job yet must keep passing.
+    main(
+        [
+            "--unit",
+            "success",
+            "--integration",
+            "skipped",
+            "--detect-integration",
+            "skipped",
+            "--discover-e2e",
+            "skipped",
+            "--e2e",
+            "skipped",
+        ]
+    )
+    assert "passed=true" in capsys.readouterr().out
+
+
+def test_a_cancelled_lease_that_skipped_the_matrix_is_still_a_cancellation() -> None:
+    """Regression: the matrix-skipped anomaly guard must see the lease result.
+
+    `cancelled_only` excludes the "discovery succeeded but the matrix was
+    skipped" anomaly, because that anomaly fires on results that all sit in the
+    OK set and must never be relabelled "just re-run". But a CANCELLED lease is
+    exactly why the matrix skipped, and it is cancellation-attributable — so if
+    the guard computes the install path without the lease result, it sees three
+    OK jobs, concludes "anomaly", and reports a cancelled lease as `failure`:
+    the wrong-diff misdirection this whole area exists to remove.
+    """
+    outputs = render(
+        "success",
+        "skipped",
+        "skipped",
+        "success",
+        "skipped",
+        "skipped",
+        "success",
+        "success",
+        "skipped",
+        "cancelled",
+    )
+    assert outputs["conclusion"] == "cancelled"
+    assert outputs["passed"] == "false"
+
+
+def test_the_matrix_skipped_anomaly_still_reads_as_failure_with_a_clean_lease() -> None:
+    # The other side of the guard: nothing cancelled anywhere, so a skipped
+    # matrix is a genuine misconfiguration and must not say "re-run".
+    outputs = render(
+        "success",
+        "skipped",
+        "skipped",
+        "success",
+        "skipped",
+        "skipped",
+        "success",
+        "success",
+        "success",
+        "success",
+    )
+    assert outputs["conclusion"] == "failure"
+    assert outputs["passed"] == "false"

--- a/.github/workflows/e2e-full-reusable.yaml
+++ b/.github/workflows/e2e-full-reusable.yaml
@@ -310,7 +310,7 @@ jobs:
       #
       # cancel-in-progress stays false for the same reason as the e2e legs in
       # tests-reusable.yaml: cancelling mid-run abandons a live Automation Engine
-      # run and leaves tenant state with no cleanup path.
+      # run and leaves tenant state with no cleanup path (FND-252).
       group: e2e-full-${{ github.workflow }}-${{ github.run_id }}-${{ matrix.cloud || 'default' }}
       cancel-in-progress: false
     permissions:

--- a/.github/workflows/e2e-full-reusable.yaml
+++ b/.github/workflows/e2e-full-reusable.yaml
@@ -292,9 +292,26 @@ jobs:
       matrix: ${{ fromJson(needs.plan-clouds.outputs.count != '0' && needs.plan-clouds.outputs.matrix || '{"include":[{"cloud":""}]}') }}
     runs-on: ubuntu-latest
     timeout-minutes: ${{ inputs.timeout-minutes }}
+    # This workflow deliberately does NOT take the (app, cloud) tenant lease that
+    # tests-reusable.yaml's install path takes (FND-250). It never installs, so it
+    # cannot lose a version race: nothing it does changes what is deployed on the
+    # tenant, and no leg here asserts a version. Taking the lease would serialise
+    # it against installing runs for no safety gain, at the cost of holding a
+    # tenant for a whole full-DAG run. The residual gap — an installing run
+    # swapping the version underneath a full-DAG run in flight — predates this
+    # change and is tracked on FND-250 rather than papered over here.
     concurrency:
-      # Per-cloud group: a shared group would serialise the legs.
-      group: e2e-full-${{ github.workflow }}-${{ github.ref }}-${{ matrix.cloud || 'default' }}
+      # Per-cloud (a shared group would serialise the legs) and run-unique. It
+      # used to be keyed on github.ref, which on the dispatch path is this repo's
+      # refs/heads/main for EVERY run — so all concurrent dispatches collapsed
+      # into one group, and a group holds only one pending run: a third dispatch
+      # cancelled the queued one before it got a runner, with no log to say so
+      # (FND-218).
+      #
+      # cancel-in-progress stays false for the same reason as the e2e legs in
+      # tests-reusable.yaml: cancelling mid-run abandons a live Automation Engine
+      # run and leaves tenant state with no cleanup path.
+      group: e2e-full-${{ github.workflow }}-${{ github.run_id }}-${{ matrix.cloud || 'default' }}
       cancel-in-progress: false
     permissions:
       pull-requests: write

--- a/.github/workflows/e2e-tenant-install.yaml
+++ b/.github/workflows/e2e-tenant-install.yaml
@@ -114,6 +114,18 @@ concurrency:
   # app per tenant), so two concurrent installs would race and the loser would
   # silently be the version left running. Not cancel-in-progress — cancelling
   # mid-install leaves the tenant in whatever state LM reached.
+  #
+  # Still a group and not the (app, cloud) lease that tests-reusable's install
+  # path now takes (FND-250), because the two cannot see each other: lease
+  # tickets are refs in the repository the run belongs to, and this workflow runs
+  # in application-sdk while the runs it contends with run in the app repos.
+  # Keying the lease centrally would need a cross-repo PAT with ref-write on
+  # every app repo, which is a much larger blast radius than this hazard
+  # justifies — this is a deliberate, human-triggered install, not something CI
+  # fires concurrently. Cloud-keyed (not app-keyed) it is also stricter than the
+  # lease, serialising installs across ALL apps on a cloud. Residual gap: a
+  # manual install here can still land underneath an app repo's e2e run. Tracked
+  # on FND-250.
   group: e2e-tenant-install-${{ inputs.cloud }}
   cancel-in-progress: false
 

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -424,12 +424,13 @@ jobs:
   #     build-sdk-base-image is skipped here, so base_image_ref is omitted
   #     and connectors build FROM the released base.
   #   pull_request + 'e2e' label — opt-in during PR development; also used
-  #     to release-gate the release PR before merging. The connector-side
-  #     e2e job serialises itself via its own concurrency group — but that
-  #     serialisation is one-deep, not a queue: GitHub holds a single pending
-  #     run per group, so a THIRD simultaneous e2e-labelled PR evicts the
-  #     waiting one as `cancelled`. Keep concurrent e2e-labelled PRs to two
-  #     until that path has a real lease (see FND-218).
+  #     to release-gate the release PR before merging. Tenant access on the
+  #     connector side is serialised by the (app, cloud) lease in
+  #     tests-reusable's lease-tenant job, which is a real queue: concurrent
+  #     e2e-labelled PRs wait their turn instead of the third one being
+  #     silently evicted as `cancelled` (FND-218 / FND-250). No cap on how
+  #     many can be in flight — a run that waits longer than the lease budget
+  #     fails saying the tenant was busy, naming the run that holds it.
   #     On this path base_image_ref is the freshly-built PR base image, so
   #     the connector is rebuilt on top of the SDK PR's runtime image.
   connector-tests:

--- a/.github/workflows/tests-reusable.yaml
+++ b/.github/workflows/tests-reusable.yaml
@@ -1066,6 +1066,57 @@ jobs:
           IMAGE: ${{ needs.build-e2e-image.outputs.image-base }}
         run: echo "tag=${IMAGE##*:}" >> "$GITHUB_OUTPUT"
 
+  # ── Queue for the (app, cloud) tenant ────────────────────────────────────
+  # A tenant is a shared MUTABLE resource: prepare-tenant installs a version onto
+  # it and every leg below then asserts it is testing that version (FND-31). So
+  # exclusive access has to span from the install to the last leg — and that is
+  # something `concurrency:` structurally cannot do, for two separate reasons:
+  #
+  #   * It is per-JOB. A group on prepare-tenant is released when that job ends,
+  #     which is before any leg has started. The old comment on that job admitted
+  #     as much ("another run can still install between this job and the legs").
+  #   * It holds exactly ONE pending run per group. A third arrival does not
+  #     queue — it cancels the run that was waiting, before that run is ever
+  #     given a runner, with no log output at all. That is FND-218: a merge-queue
+  #     batch whose "connector test failures" were all evictions.
+  #
+  # So the lease is a queue of ticket refs ordered by run_id, held for the whole
+  # run, with dead holders reaped by whoever notices (FND-250). It runs AFTER the
+  # image is built and merged so the tenant is not held hostage to a build, and
+  # its ticket is released by release-tenant below.
+  #
+  # Same gate and same cloud matrix as prepare-tenant: no install, no contention
+  # worth serialising — the legs of a non-installing run cannot lose a version
+  # race because nothing changes the version under them.
+  lease-tenant:
+    name: Tenant lease (${{ matrix.cloud || 'default' }})
+    needs: [discover-e2e, merge-e2e-image]
+    if: inputs.install-app-to-tenant && needs.merge-e2e-image.result == 'success'
+    strategy:
+      # One cloud's queue being stuck must not cancel the others.
+      fail-fast: false
+      matrix: ${{ fromJson(needs.discover-e2e.outputs.cloud-count != '0' && needs.discover-e2e.outputs.cloud-matrix || '{"include":[{"cloud":""}]}') }}
+    runs-on: ubuntu-latest
+    # Above the action's own 90-minute wait budget, so a run that queues for the
+    # full budget still reaches the script's own error — which names the holding
+    # run — instead of being replaced by a bare "job cancelled after Nm".
+    timeout-minutes: 100
+    permissions:
+      # Ref writes create and delete the lease ticket. Scoped to THIS job on
+      # purpose: the long-running e2e legs below keep read-only contents, so the
+      # write capability lives only in a job that runs no test code.
+      contents: write
+      # Tell a live holder from a dead one, which is what makes a cancelled run's
+      # abandoned ticket self-healing.
+      actions: read
+    steps:
+      - name: Acquire the tenant lease
+        uses: atlanhq/application-sdk/.github/actions/e2e-tenant-lease@main
+        with:
+          mode: acquire
+          app: ${{ inputs.app-name }}
+          cloud: ${{ matrix.cloud }}
+
   # ── Install the app under test onto each cloud's tenant ──────────────────
   # One leg per CLOUD, not per suite × cloud: the installation is tenant-scoped
   # (one per app per tenant), so installing once per cloud is both sufficient and
@@ -1076,8 +1127,10 @@ jobs:
   # legs can never disagree about which clouds are in play.
   prepare-tenant:
     name: Prepare tenant (${{ matrix.cloud || 'default' }})
-    needs: [discover-e2e, merge-e2e-image]
-    if: inputs.install-app-to-tenant && needs.merge-e2e-image.result == 'success'
+    needs: [discover-e2e, merge-e2e-image, lease-tenant]
+    # lease-tenant gates the install rather than merely preceding it: installing
+    # without the lease is the race this whole path exists to close.
+    if: inputs.install-app-to-tenant && needs.merge-e2e-image.result == 'success' && needs.lease-tenant.result == 'success'
     strategy:
       # One cloud's tenant being uninstallable must not cancel the others; the
       # legs for that cloud fail on their own version check.
@@ -1105,17 +1158,17 @@ jobs:
     # was about to print — the diagnosis-hostile failure this job exists to avoid.
     timeout-minutes: 40
     concurrency:
-      # Keyed on the TENANT (app + cloud), not the ref: the installation is
-      # tenant-scoped, so two runs installing different versions concurrently
-      # would race and the loser is silently what the tenant ends up running.
-      # cancel-in-progress:false because cancelling mid-install leaves the tenant
-      # in whatever state LM reached.
+      # Run-unique, i.e. deliberately NOT a serialising group. Tenant exclusion
+      # is the lease's job now (lease-tenant above), and the lease is strictly
+      # better at it: it spans this job AND the legs, and it queues rather than
+      # evicting all but one waiter.
       #
-      # This narrows the race; it does not close it. GitHub has no cross-job
-      # lease, so another run can still install between this job and the legs
-      # below — which is exactly why each leg re-verifies the version rather than
-      # trusting this job's outcome.
-      group: e2e-prepare-tenant-${{ inputs.app-name }}-${{ matrix.cloud || 'default' }}
+      # Keying this on the tenant as well would actively hurt. Two runs that both
+      # hold no lease yet would still stack up here one-deep, and a third would
+      # be evicted with no log — reintroducing the FND-218 failure inside the fix
+      # for it. Left run-unique so this job never waits on anything except the
+      # lease it already holds.
+      group: e2e-prepare-tenant-${{ github.run_id }}-${{ matrix.cloud || 'default' }}
       cancel-in-progress: false
     permissions:
       contents: read
@@ -1307,11 +1360,20 @@ jobs:
     # version check self-skips. A silently passing wrong-version run: precisely
     # what FND-31 exists to make impossible. Adding the intermediate merge job
     # introduced that; naming both needs closes it.
-    needs: [discover-e2e, build-e2e-image, merge-e2e-image, prepare-tenant]
+    #
+    # lease-tenant is gated here for exactly the reason build-e2e-image is. A
+    # failed lease leaves prepare-tenant SKIPPED (its own `if` is not satisfied),
+    # and 'skipped' is the benign value below — so omitting it would let every leg
+    # run against a tenant nobody installed onto, with expected-app-version empty
+    # so the version check self-skips. A silently passing wrong-version run, from
+    # the job added to make wrong-version runs impossible.
+    needs:
+      [discover-e2e, build-e2e-image, merge-e2e-image, lease-tenant, prepare-tenant]
     if: |
       always() &&
       needs.discover-e2e.result == 'success' &&
       needs.discover-e2e.outputs.count != '0' &&
+      (needs.lease-tenant.result == 'success' || needs.lease-tenant.result == 'skipped') &&
       (needs.prepare-tenant.result == 'success' || needs.prepare-tenant.result == 'skipped') &&
       (needs.build-e2e-image.result == 'success' || needs.build-e2e-image.result == 'skipped') &&
       (needs.merge-e2e-image.result == 'success' || needs.merge-e2e-image.result == 'skipped')
@@ -1324,9 +1386,24 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     concurrency:
-      # Per-leg group so matrix legs run concurrently (a shared group would
-      # serialise them). cancel-in-progress:false keeps re-runs from cancelling.
-      group: tests-e2e-${{ github.ref }}-${{ matrix.name }}
+      # Run-unique, so no e2e leg ever queues behind or cancels another. It used
+      # to be keyed on github.ref, which on the cross-repo dispatch path is this
+      # repo's refs/heads/main for EVERY run — so all concurrent dispatches
+      # collapsed into one group, and a group holds only one pending run: a third
+      # dispatch cancelled the queued one before it was ever given a runner, with
+      # no log to say so (FND-218).
+      #
+      # Serialising tenant access is the lease's job now (lease-tenant), and the
+      # lease does it properly — across the install and the legs, with a queue
+      # instead of a single slot. That leaves this group with nothing to
+      # serialise, so it identifies the run and nothing else.
+      #
+      # cancel-in-progress stays false, and deliberately so: cancelling a leg
+      # mid-flight abandons a live Automation Engine run, and there is no cleanup
+      # path for the tenant state it leaves behind. Turning it on is a real
+      # decision that needs that cleanup path first — test_label_trigger_gates.py
+      # pins this so the decision cannot be taken by accident.
+      group: tests-e2e-${{ github.run_id }}-${{ matrix.name }}
       cancel-in-progress: false
     permissions:
       pull-requests: write
@@ -1540,6 +1617,38 @@ jobs:
           # Dockerfile that declares no such secret mount simply ignores it.
           git-token: ${{ secrets.ORG_PAT_GITHUB }}
 
+  # ── Hand the tenant to whoever is next in the queue ──────────────────────
+  # Prompt release, not the mechanism that makes the lease safe. GitHub cancels
+  # queued jobs rather than running them, so on a cancelled run this job never
+  # starts at all and `if: always()` does not help — which is why liveness is
+  # derived from the holder's run status instead, and any later contender reaps a
+  # ticket whose run is over. This job just means the next run waits seconds
+  # rather than one poll interval.
+  #
+  # It never fails the workflow: the driver returns 0 whether or not a ticket was
+  # there to delete, so a release hiccup cannot redden a run whose tests passed.
+  release-tenant:
+    name: Release tenant lease (${{ matrix.cloud || 'default' }})
+    needs: [discover-e2e, lease-tenant, prepare-tenant, e2e]
+    # Only when this run actually took a lease. Not gated on the legs' outcome —
+    # a failed leg must still give the tenant back.
+    if: always() && needs.lease-tenant.result == 'success'
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.discover-e2e.outputs.cloud-count != '0' && needs.discover-e2e.outputs.cloud-matrix || '{"include":[{"cloud":""}]}') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      actions: read
+    steps:
+      - name: Release the tenant lease
+        uses: atlanhq/application-sdk/.github/actions/e2e-tenant-lease@main
+        with:
+          mode: release
+          app: ${{ inputs.app-name }}
+          cloud: ${{ matrix.cloud }}
+
   # ── Callback: report the result back to the application-sdk PR/commit ────
   # that dispatched this run. application-sdk's e2e-apps composite
   # (wait-mode: callback) creates an in_progress check run on its own SHA
@@ -1565,6 +1674,7 @@ jobs:
         discover-e2e,
         build-e2e-image,
         merge-e2e-image,
+        lease-tenant,
         prepare-tenant,
         e2e,
       ]
@@ -1676,6 +1786,7 @@ jobs:
           discover-e2e-result: ${{ needs.discover-e2e.result }}
           build-e2e-image-result: ${{ needs.build-e2e-image.result }}
           merge-e2e-image-result: ${{ needs.merge-e2e-image.result }}
+          lease-tenant-result: ${{ needs.lease-tenant.result }}
           prepare-tenant-result: ${{ needs.prepare-tenant.result }}
           e2e-result: ${{ needs.e2e.result }}
 
@@ -1820,6 +1931,7 @@ jobs:
         discover-e2e,
         build-e2e-image,
         merge-e2e-image,
+        lease-tenant,
         prepare-tenant,
         e2e,
       ]
@@ -1840,11 +1952,13 @@ jobs:
       # passed. Integration skipped (PR / no suite) is a pass; unit must succeed.
       # detect-integration is gated too: a *failed* detection (not a PR skip)
       # fails the gate, so a checkout/glob flake can't silently skip integration
-      # and green the required check. The three install-path jobs (image build,
-      # manifest merge, tenant install) are gated for the same reason — they are
-      # exactly what the e2e matrix's own `if` requires, so a failure in any of
-      # them drops e2e to a skip. Passing them in names the cause instead of
-      # leaving the driver to infer it from the skip.
+      # and green the required check. The four install-path jobs (image build,
+      # manifest merge, tenant lease, tenant install) are gated for the same
+      # reason — they are exactly what the e2e matrix's own `if` requires, so a
+      # failure in any of them drops e2e to a skip. Passing them in names the
+      # cause instead of leaving the driver to infer it from the skip, which
+      # matters most for the lease: "the tenant was busy" and "your change is
+      # broken" call for opposite responses.
       - name: Evaluate Tests Gate
         id: gate
         if: always()
@@ -1857,6 +1971,7 @@ jobs:
           discover-e2e-result: ${{ needs.discover-e2e.result }}
           build-e2e-image-result: ${{ needs.build-e2e-image.result }}
           merge-e2e-image-result: ${{ needs.merge-e2e-image.result }}
+          lease-tenant-result: ${{ needs.lease-tenant.result }}
           prepare-tenant-result: ${{ needs.prepare-tenant.result }}
           e2e-result: ${{ needs.e2e.result }}
 

--- a/.github/workflows/tests-reusable.yaml
+++ b/.github/workflows/tests-reusable.yaml
@@ -1400,9 +1400,11 @@ jobs:
       #
       # cancel-in-progress stays false, and deliberately so: cancelling a leg
       # mid-flight abandons a live Automation Engine run, and there is no cleanup
-      # path for the tenant state it leaves behind. Turning it on is a real
-      # decision that needs that cleanup path first — test_label_trigger_gates.py
-      # pins this so the decision cannot be taken by accident.
+      # path for the tenant state it leaves behind. Turning it on needs that
+      # cleanup path first (FND-252) — test_label_trigger_gates.py pins this so
+      # the decision cannot be taken by accident, and it has already caught one
+      # attempt. The cost of leaving it false is a superseded commit's leg running
+      # to the 120-minute ceiling while holding the tenant lease.
       group: tests-e2e-${{ github.run_id }}-${{ matrix.name }}
       cancel-in-progress: false
     permissions:

--- a/docs/standards/ci.md
+++ b/docs/standards/ci.md
@@ -190,3 +190,68 @@ sparse-checkout it into a side path and invoke from there — the
 
 The driver runs from the consumer's working directory, so it acts on the
 consumer's files; `.sdk-scripts` only holds SDK code and must never be staged.
+
+## `concurrency:` is not a lock, and not a queue
+
+**Rule:** never use a `concurrency:` group to protect a shared external resource
+(a tenant, a fixed environment, a singleton deployment). Use it only to
+supersede or de-duplicate *runs of the same thing*.
+
+Two independent limits make it unfit as a lock:
+
+* **It is per-job.** The group is released when the job ends. Anything the job
+  set up for later jobs to use — an install, a seeded database — is unprotected
+  from the moment that job finishes.
+* **It holds ONE pending run.** `cancel-in-progress: false` reads like a queue
+  but is a waiting room with a single chair. A third arrival does not wait: it
+  *evicts* the run that was waiting, which is reported as `cancelled` having
+  never been given a runner, so there is no log blob at all (`gh api
+  .../jobs/<id>/logs` → 404). A few-second job lifetime with no logs is the
+  signature.
+
+That combination caused FND-218: batching more than two PRs into the merge queue
+self-inflicted roughly a two-in-three ejection rate, and because the connector
+callback mirrored `cancelled` as `failure`, it read on the dispatching PR as
+"your change broke the connector".
+
+**Do not key a group on `github.ref` for anything a merge queue or a cross-repo
+dispatch can reach.** On a cross-repo `workflow_dispatch`, `github.ref` is the
+*callee's* ref — always `refs/heads/main` — never the dispatching commit. So a
+ref-keyed group collapses every concurrent dispatch into one group, and the
+one-pending-slot rule then evicts all but two. Key on `github.run_id` off the PR
+path:
+
+```yaml
+concurrency:
+  group: thing-${{ startsWith(github.ref, 'refs/pull/') && github.ref || github.run_id }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+```
+
+On a real PR ref the shared group is the point (supersede the previous commit);
+everywhere else the run must be independent.
+
+**For a shared resource, take a lease instead.** The `(app, cloud)` tenant lease
+in [`e2e-tenant-lease`](../../.github/actions/e2e-tenant-lease/) is the worked
+example (FND-250). Its protocol is worth reusing because it needs no lock
+server:
+
+* Each run creates a ticket ref, `refs/e2e-tenant-lease/<app>/<cloud>/<run_id>-<run_attempt>`.
+* The lease is held by the lowest-ordered **live** ticket. Every participant
+  derives the same holder from the same listing, so there is no
+  compare-and-swap and no lock object to strand.
+* Ordering is by `run_id`, which GitHub assigns and increases with run creation
+  time *within a repository* — a server-side arrival order, so no runner clock
+  can make two runs both believe they are first.
+* The ticket name is derived entirely from the run, so every job of that run
+  computes it identically. Acquire and release live in different jobs and pass
+  no state; re-creating a ticket restores the same queue position.
+* Liveness is the holder's run status, not a heartbeat. A ticket whose run is
+  `completed` is reaped by whoever notices. This is the part `if: always()`
+  cannot do: GitHub *cancels* queued jobs rather than running them, so a
+  cancelled run's release job never starts.
+
+Two consequences to design for. A waiting run occupies a runner, so give the
+wait a budget and fail loudly past it, naming the holder — a contention outcome
+must never be phrased as a test failure. And ref writes need `contents: write`,
+so put acquire/release in their own small jobs and leave the jobs that execute
+test code read-only.


### PR DESCRIPTION
Closes the rest of FND-250. Follows #3124 (the merge-queue half) and #3130 (making an eviction legible).

## Why a lease and not a group

A tenant is a shared **mutable** resource: `prepare-tenant` installs a version and every leg then asserts it is testing that version (FND-31). `concurrency:` cannot protect that, for two independent reasons:

* **It is per-job.** A group on `prepare-tenant` is released when that job ends, which is before any leg has started. The old comment on that job admitted it: *"another run can still install between this job and the legs below"*.
* **It holds exactly ONE pending run.** A third arrival does not queue — it cancels the run that was waiting, before that run is ever given a runner, with no log blob at all. That is FND-218.

`cancel-in-progress: false` is a waiting room with one chair, not a queue.

## The protocol

Each run creates a ticket ref in its own repository:

```
refs/e2e-tenant-lease/<app>/<cloud>/<run_id>-<run_attempt>
```

The lease is held by the lowest-ordered **live** ticket. Every participant derives the same holder from the same listing, so there is no compare-and-swap and no lock object that can be stranded. Two properties carry it:

* **Ordering is by `run_id`** — assigned by GitHub, increasing with run creation time within a repository. A *server-side* arrival order, so no runner clock can make two runs both believe they are first. (Ordering on a timestamp written into the ref name would have exactly that bug, and it would stay invisible until it lost a tenant.)
* **The ticket name is derived entirely from the run**, so every job of that run computes it identically. Acquire and release are separate jobs that pass no state, and re-creating a ticket restores the same queue position rather than sending the run to the back.

**Liveness is the holder's run status, not a heartbeat.** A ticket whose run reports `completed` is reaped by whoever notices. This is the part `if: always()` cannot do — GitHub *cancels* queued jobs rather than running them, so a cancelled run's release job never starts at all. `release-tenant` only means the next run waits seconds instead of one poll interval; it is not what makes the lease safe. A hard TTL on run age is a second backstop for a run the API will not report on.

All four API primitives were verified against the real endpoint before building on them: custom-namespace ref creation (201), duplicate (422 `Reference already exists`), prefix listing via `matching-refs`, delete (204) and double-delete (422). A custom namespace rather than `refs/heads` or `refs/tags` because it is inert — a branch would fire `push` events, a tag would pollute the release surface.

## Failure posture

* **No ref-write permission** → `::warning::` and the lease disables itself; the run proceeds unserialised. The lease *reduces contention*; it is not what makes a wrong-version run detectable (every leg re-asserts the version, FND-31). An ungrantable lease must not become a new way for e2e to go red fleet-wide. Default token permissions are `write` org-wide, so this is the safety net, not the expected path.
* **Wait budget exhausted** (90 min default) → fails loudly, naming the holding run, and says *"Nothing is wrong with this change — the tenant is busy."* Strictly better than the silent eviction it replaces, and unlike fail-open it does not put two runs on one tenant expecting different versions. The gate renders it `⏳ Tenant busy — lease not acquired, re-run`.
* **API error while checking a holder** → assume live. Erring towards "dead" on a transient 500 would hand the tenant to a second run mid-install; erring towards "live" costs one poll interval.

## Gate wiring

`lease-tenant` is added to the e2e legs' `if` for exactly the reason `build-e2e-image` is: a failed lease leaves `prepare-tenant` **skipped**, and `skipped` is the benign value there — so omitting it would let every leg run against a tenant nobody installed onto, with `expected-app-version` empty so the version check self-skips. A silently passing wrong-version run, produced by the machinery added to prevent them.

It is also passed to `verify-test-gate` (both call sites: the required check and the cross-repo callback) so a lease failure is reported as its own cause instead of surfacing only as the downstream "matrix skipped despite discovered suites" anomaly, which reads as a workflow misconfiguration.

## Concurrency groups

Three groups lose their ref key. `github.ref` on a cross-repo `workflow_dispatch` is the **callee's** ref — always `refs/heads/main` — so a ref key collapsed every concurrent dispatch into one group, and the one-pending-slot rule then evicted all but two.

`cancel-in-progress` deliberately stays `false` everywhere. An existing guard in `test_label_trigger_gates.py` documents why — cancelling a leg abandons a live Automation Engine run and leaves tenant state with no cleanup path — and it **caught an attempt to flip it in this change**. FND-250 needs the group key fixed, not `cancel-in-progress`; that remains a separate decision that needs the cleanup path first.

`test_prepare_tenant_wiring.py`'s tenant-keyed-group assertion is inverted rather than deleted: a tenant-keyed group there would now be actively harmful, re-adding a one-slot waiting room in front of the lease.

## Deliberately not covered

* **`e2e-full-reusable.yaml`** gets the group fix but **not** the lease. It never installs, so it cannot lose a version race — nothing it does changes the deployed version, and no leg there asserts one. Taking the lease would serialise it against installing runs for no safety gain, at the cost of holding a tenant for a whole full-DAG run.
* **`e2e-tenant-install.yaml`** keeps its group. It runs in application-sdk while the runs it contends with run in the app repos, so the two cannot see each other's tickets. Closing that needs a cross-repo PAT with ref-write on every app repo — a much larger blast radius than a deliberate, human-triggered install justifies. Its group is also *stricter* than the lease (cloud-keyed across all apps).

Both residuals are noted in place rather than papered over.

## Security-relevant

Adds `contents: write` + `actions: read` to two new jobs. Scoped deliberately: acquire and release run no test code, and the long-running e2e legs that do keep `contents: read`. A test pins that the legs are not granted ref-write.

## One interaction with #3130 worth calling out

#3130 gained an anomaly-exclusion guard in `cancelled_only` during review: the "discovery succeeded but the matrix was skipped" anomaly fires on results that all sit in the OK set, so it has to be excluded explicitly or a simultaneous cancellation would mask a real misconfiguration.

That guard computed the install path *without* the new lease result. A **cancelled** lease is precisely why the matrix skipped, and it *is* cancellation-attributable — so the guard saw three OK jobs, concluded "anomaly", and reported a cancelled lease as `failure`. That is the exact wrong-diff misdirection #3130 exists to remove, reintroduced through a new argument. Caught by this PR's own tests on rebase.

Fixed at the call site, and `_install_path`'s parameters no longer have defaults: it is module-private, so a missed argument should be a `TypeError` rather than a silently wrong verdict. The public functions keep their trailing defaults — they are consumed cross-repo at `@main` and cannot break callers. Both directions of the guard are now pinned by tests.

## Tests

`.github/scripts/tests/` — **1692 passed**, 69 new for the lease driver plus 12 for the gate and 13 for the wiring. The HTTP client is stubbed at the `run()` seam with a fake that speaks real curl-shaped responses, so 422-already-exists / 403-no-permission / 500-transient are exercised through the same parser production uses. Covered: ordering and reaping (including "stop at the first live holder", so a dead ticket ahead of a live one does not let the lease be stolen), fail-open, ticket recreation, the two-API-calls-per-poll budget, and that acquire and release agree on the ref name — the invariant whose failure would leak every run's lease.

The `@main` pin is intentional and is asserted: every contender must agree on the ref layout and the ordering rule, so the protocol must not vary with whichever ref a caller checked out. The workflow and the action land in the same commit, and all consumers pin `@main`, so there is no window where the workflow references an action that does not exist.

Refs: FND-250
