### PR TITLE
chore(ci): remove the callback's deprecated conclusion shim

### DIFF
--- a/.github/scripts/build_callback_summary.py
+++ b/.github/scripts/build_callback_summary.py
@@ -10,24 +10,21 @@ Prefers the e2e leg's already-rendered report (asset/lineage tables etc.,
 written by sdr-e2e's PR-comment step) over a plain fallback, which only
 applies when e2e was skipped or its artifact never materialised.
 
-`determine_conclusion` is NO LONGER the callback's verdict. It decided the
-conclusion from a strict subset of the Tests Gate's inputs — no discover-e2e,
-no image-build legs, no "discovery found suites but the matrix skipped" anomaly
-rule — so a connector run whose Tests Gate was red reported success on the
-dispatching SDK PR, which is the whole reason a triggered app's failure could go
-unnoticed there. The gate driver
-(.github/actions/verify-test-gate/verify_test_gate.py) is now the single
-authority for both, and report-to-sdk reads its `conclusion` output instead.
+BODY ONLY — this script does not decide anything. It used to also emit the
+callback's `conclusion`, computed from a strict subset of the Tests Gate's
+inputs (no discover-e2e, no image-build legs, no "discovery found suites but
+the matrix skipped" anomaly rule), which is exactly how a connector run whose
+Tests Gate was red completed the mirrored check on the dispatching SDK PR as
+green. The gate driver
+(.github/actions/verify-test-gate/verify_test_gate.py) is the single authority
+for that verdict; report-to-sdk feeds its `conclusion` output straight to
+complete_check_run.py.
 
-It survives here only as a transitional shim: this script is checked out from
-the DISPATCHING SDK ref while the workflow always comes from `main`, so a
-pre-fix `main` workflow can still be pairing itself with a post-fix copy of this
-script and reading `conclusion=` out of $GITHUB_OUTPUT. Delete it — along with
-the `conclusion=` output line and its tests — in the next release after this
-lands on `main`, once no `main` workflow reads it.
+Do not reintroduce a verdict here. Two implementations of "did the connector
+tests pass" is the defect, not the inputs either one happened to read — see
+test_the_callback_reports_the_gates_verdict_not_its_own.
 
-Writes conclusion=<success|failure> (deprecated, see above) and
-summary_file=<path> to $GITHUB_OUTPUT.
+Writes summary_file=<path> to $GITHUB_OUTPUT.
 """
 
 from __future__ import annotations
@@ -36,38 +33,11 @@ import argparse
 import os
 import sys
 
-PASSING_E2E_RESULTS = {"success", "skipped"}
-# Integration is skipped on PRs and when a connector has no integration suite,
-# so "skipped" is a pass for it (mirrors the e2e optional-by-skip treatment).
-PASSING_INTEGRATION_RESULTS = {"success", "skipped"}
 # The suite-detection job gates the integration `if`. A *failure* there drops
-# integration to a skip, which PASSING_INTEGRATION_RESULTS would read as a pass
-# — so a failed detection must be its own failure signal here, exactly as the
-# Tests Gate treats it. skipped (pull_request) and success are passes.
+# integration to a skip, so the rendered line must name the detection failure
+# rather than report a clean "skipped" for a tier that was actually dropped.
+# skipped (pull_request) and success are the benign values.
 PASSING_DETECT_INTEGRATION_RESULTS = {"success", "skipped"}
-
-
-def determine_conclusion(
-    unit_result: str,
-    integration_result: str,
-    detect_integration_result: str,
-    e2e_result: str,
-) -> str:
-    """DEPRECATED — the Tests Gate driver decides the callback's conclusion.
-
-    Kept only so a pre-fix `main` workflow paired with a post-fix copy of this
-    script still gets a `conclusion=` output. See the module docstring for the
-    removal trigger. Do not add inputs here: fix the gate driver instead, or the
-    two verdicts start diverging again.
-    """
-    if (
-        unit_result == "success"
-        and detect_integration_result in PASSING_DETECT_INTEGRATION_RESULTS
-        and integration_result in PASSING_INTEGRATION_RESULTS
-        and e2e_result in PASSING_E2E_RESULTS
-    ):
-        return "success"
-    return "failure"
 
 
 def build_fallback_summary(
@@ -139,12 +109,6 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--fallback-path", default="fallback-summary.md")
     args = parser.parse_args(argv)
 
-    conclusion = determine_conclusion(
-        args.unit_result,
-        args.integration_result,
-        args.detect_integration_result,
-        args.e2e_result,
-    )
     summary_file = resolve_summary_file(
         args.artifact_summary_path,
         args.fallback_path,
@@ -156,14 +120,13 @@ def main(argv: list[str] | None = None) -> int:
         args.integration_summary,
     )
 
-    lines = [f"conclusion={conclusion}", f"summary_file={summary_file}"]
+    line = f"summary_file={summary_file}"
     github_output = os.environ.get("GITHUB_OUTPUT", "")
     if github_output:
         with open(github_output, "a") as fh:
-            fh.write("\n".join(lines) + "\n")
+            fh.write(line + "\n")
     else:
-        for line in lines:
-            print(line)
+        print(line)
     return 0
 
 

--- a/.github/scripts/tests/test_build_callback_summary.py
+++ b/.github/scripts/tests/test_build_callback_summary.py
@@ -1,7 +1,7 @@
 """Tests for .github/scripts/build_callback_summary.py.
 
-Signature: determine_conclusion / build_fallback_summary / resolve_summary_file
-take (unit, integration, detect_integration, e2e, ...).
+Signature: build_fallback_summary / resolve_summary_file take
+(unit, integration, detect_integration, e2e, ...).
 
 Also guards the WIRING of the report-to-sdk job that runs this script, because
 the bug this file's script was at the centre of was not a bug in any function
@@ -27,73 +27,18 @@ _REPO_ROOT = Path(__file__).resolve().parents[3]
 _REUSABLE = _REPO_ROOT / ".github" / "workflows" / "tests-reusable.yaml"
 
 
-def test_determine_conclusion_all_success():
-    assert (
-        mod.determine_conclusion("success", "success", "success", "success")
-        == "success"
-    )
+def test_the_script_emits_no_verdict():
+    """The removal, stated as a property rather than an absence.
 
-
-def test_determine_conclusion_integration_skipped_is_success():
-    # Integration skipped (PR / no suite) is a pass; on a PR detect-integration
-    # is skipped too — also a pass.
-    assert (
-        mod.determine_conclusion("success", "skipped", "skipped", "success")
-        == "success"
-    )
-
-
-def test_determine_conclusion_integration_skipped_no_suite_is_success():
-    # Non-PR, no integration suite: detect-integration succeeds, integration
-    # skips cleanly — a pass.
-    assert (
-        mod.determine_conclusion("success", "skipped", "success", "success")
-        == "success"
-    )
-
-
-def test_determine_conclusion_e2e_skipped_is_success():
-    assert (
-        mod.determine_conclusion("success", "success", "success", "skipped")
-        == "success"
-    )
-
-
-def test_determine_conclusion_unit_failed():
-    assert (
-        mod.determine_conclusion("failure", "success", "success", "success")
-        == "failure"
-    )
-
-
-def test_determine_conclusion_integration_failed():
-    assert (
-        mod.determine_conclusion("success", "failure", "success", "success")
-        == "failure"
-    )
-
-
-def test_determine_conclusion_detect_integration_failed():
-    # A detection failure drops integration to a skip; the callback must still
-    # report failure rather than a silent success.
-    assert (
-        mod.determine_conclusion("success", "skipped", "failure", "success")
-        == "failure"
-    )
-
-
-def test_determine_conclusion_e2e_failed():
-    assert (
-        mod.determine_conclusion("success", "success", "success", "failure")
-        == "failure"
-    )
-
-
-def test_determine_conclusion_unit_cancelled():
-    assert (
-        mod.determine_conclusion("cancelled", "skipped", "skipped", "skipped")
-        == "failure"
-    )
+    `determine_conclusion` was this script's own answer to "did the connector
+    tests pass", computed from four job results while the Tests Gate used nine
+    plus an anomaly rule — the divergence that let a red connector run report
+    green on the dispatching SDK PR. It outlived the fix only as a shim for
+    workflow/script ref skew, and every fleet caller now pins the reusable at
+    @main, so nothing reads it. A reintroduced verdict here is the bug class
+    returning, not a new feature.
+    """
+    assert not hasattr(mod, "determine_conclusion")
 
 
 def test_resolve_summary_file_prefers_artifact(tmp_path):
@@ -175,12 +120,19 @@ def test_main_writes_github_output(tmp_path, monkeypatch):
 
     assert rc == 0
     content = output_file.read_text()
-    assert "conclusion=success" in content
     assert f"summary_file={artifact}" in content
+    assert "conclusion=" not in content, (
+        "the callback's verdict comes from the Tests Gate driver; an output "
+        "named `conclusion` here is a second one waiting to be wired up"
+    )
 
 
-def test_main_detect_integration_failure_reports_failure(tmp_path, monkeypatch, capsys):
+def test_main_renders_detect_integration_failure_in_the_body(tmp_path, monkeypatch):
+    # A detection failure drops integration to a skip. main() must render that
+    # as the detection failure it was, not as a clean skip — the body is now
+    # this script's only product, so this is the wiring that matters.
     monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+    fallback = tmp_path / "fallback.md"
 
     rc = mod.main(
         [
@@ -195,13 +147,12 @@ def test_main_detect_integration_failure_reports_failure(tmp_path, monkeypatch, 
             "--artifact-summary-path",
             str(tmp_path / "missing.md"),
             "--fallback-path",
-            str(tmp_path / "fallback.md"),
+            str(fallback),
         ]
     )
 
     assert rc == 0
-    out = capsys.readouterr().out
-    assert "conclusion=failure" in out
+    assert "suite detection failure" in fallback.read_text()
 
 
 def test_main_prints_when_no_github_output(tmp_path, monkeypatch, capsys):
@@ -226,8 +177,8 @@ def test_main_prints_when_no_github_output(tmp_path, monkeypatch, capsys):
 
     assert rc == 0
     out = capsys.readouterr().out
-    assert "conclusion=failure" in out
     assert "summary_file=" in out
+    assert "conclusion=" not in out
 
 
 # --- report-to-sdk wiring --------------------------------------------------
@@ -277,8 +228,9 @@ def test_the_callback_reports_the_gates_verdict_not_its_own(reusable) -> None:
         "'did the connector tests pass', and the two will drift."
     )
     assert "steps.report.outputs.conclusion" not in complete["run"], (
-        "build_callback_summary.py's conclusion is a deprecated back-compat "
-        "shim, not the verdict — see that script's module docstring."
+        "build_callback_summary.py emits no conclusion — it builds the body "
+        "only. Reading one back from it means someone reintroduced the second "
+        "verdict; see that script's module docstring."
     )
 
 

--- a/.github/workflows/tests-reusable.yaml
+++ b/.github/workflows/tests-reusable.yaml
@@ -1679,11 +1679,11 @@ jobs:
           prepare-tenant-result: ${{ needs.prepare-tenant.result }}
           e2e-result: ${{ needs.e2e.result }}
 
-      # Body only — the `conclusion` this step still emits is ignored (see the
-      # completion step). Its CLI is deliberately left untouched: this script is
-      # checked out from the DISPATCHING SDK ref, which can be older than the
-      # workflow (always @main), so a new flag here would make every in-flight
-      # SDK PR's callback die on `unrecognized arguments`.
+      # Body only — this step emits no verdict; the completion step below takes
+      # the gate's. Its CLI stays frozen: this script is checked out from the
+      # DISPATCHING SDK ref, which can be older than the workflow (always
+      # @main), so a new flag here would make every in-flight SDK PR's callback
+      # die on `unrecognized arguments`.
       - name: Build summary
         id: report
         env:

--- a/docs/standards/connector-ci-e2e.md
+++ b/docs/standards/connector-ci-e2e.md
@@ -292,9 +292,11 @@ in `build_callback_summary.py` from a subset of the gate's inputs (no
 `discover-e2e`, none of the install-path jobs, no "discovery found suites but the
 matrix skipped" anomaly rule), so a connector run whose `Tests Gate` failed
 because its arm64 e2e image build failed still completed the SDK-side check as
-**success**. Both halves are pinned by `test_build_callback_summary.py`: the two
-jobs must feed one action, with identical inputs, and each must `need` every job
-it judges. If you add a job to the gate, add it to both.
+**success**. That second verdict is gone — `build_callback_summary.py` builds the
+check-run body and emits no `conclusion` at all. Every half is pinned by
+`test_build_callback_summary.py`: the script must expose no verdict, the two jobs
+must feed one action with identical inputs, and each must `need` every job it
+judges. If you add a job to the gate, add it to both.
 
 The `tests.yaml` job in each connector runs unit + integration tests unconditionally. The full-DAG `e2e` job inside `tests.yaml` runs only when the SDK PR carries the `e2e` label — controlled via the `run_e2e` workflow input (`"true"` / `"false"`) passed by the dispatcher.
 


### PR DESCRIPTION
Cleanup that #3111 (FND-201) deliberately deferred, now that its removal trigger has fired.

## What was left behind, and why

`build_callback_summary.py`'s `determine_conclusion` was the cross-repo callback's own answer to "did the connector tests pass" — four job results, no `discover-e2e`, no install-path legs, no anomaly rule, while the Tests Gate judged nine plus the rule. That divergence is what let a connector run with a red `Tests Gate` complete the mirrored `Connector E2E run / <app>` check on the dispatching SDK PR as **green**.

#3111 made the gate driver the single authority and stopped reading this function, but did not delete it. `report-to-sdk` checks the *script* out from the dispatching SDK ref while the *workflow* always comes from `@main`, so the two halves can be different vintages in either direction — and a pre-fix `main` workflow paired with a post-fix script would have read a `conclusion=` that no longer existed. The shim carried an explicit trigger:

> Delete it — along with the `conclusion=` output line and its tests — in the next release after this lands on `main`, once no `main` workflow reads it.

## Why it is safe now

- `main`'s `tests-reusable.yaml` completes the check run with `steps.gate.outputs.conclusion` and reads nothing from this script's output.
- **v3.27.1** contains #3111, satisfying the stated trigger.
- Swept the fleet: every consumer pins `atlanhq/application-sdk/.github/workflows/tests-reusable.yaml@main`. No repo pins a tag or SHA, and conformance rule `tests.py` plus the bootstrap template both emit `@main`, so a stale-workflow pairing cannot be introduced without failing conformance first.

## What changes

- `determine_conclusion` deleted, along with the `conclusion=` line written to `$GITHUB_OUTPUT` and the two constants only it used.
- **`PASSING_DETECT_INTEGRATION_RESULTS` stays.** `build_fallback_summary` still needs it to render a tier dropped by a failed detection as that failure rather than a clean `skipped`.
- The `--*-result` CLI is untouched. All four still feed the body, and the frozen-CLI reasoning that applied to adding flags applies equally to removing them.
- Module docstring rewritten from "here is a deprecated shim" to "this script decides nothing", with a pointer to the guard.
- Stale comment in `tests-reusable.yaml`'s Build summary step corrected; `docs/standards/connector-ci-e2e.md` records that the second verdict is gone rather than merely unused.

## Tests

`.github/scripts/tests` — **1586 passed** (1594 − 9 removed + 1 added).

The nine `determine_conclusion` cases are replaced by one guard, `test_the_script_emits_no_verdict`, plus `conclusion=` absence assertions on both `main()` output paths. Stating it as a property rather than an absence is the point: the failure mode being defended against is someone reintroducing a verdict here, not the old function's arithmetic.

Negative-controlled — restoring a `determine_conclusion` stub fails the guard:

```
E   AssertionError: assert not True
```

`test_main_detect_integration_failure_reports_failure` asserted on the removed output, so it is repurposed to `test_main_renders_detect_integration_failure_in_the_body`, asserting the rendered fallback names the detection failure. The body is now the script's only product, so that is the wiring worth pinning.

Pre-commit clean (ruff, ruff-format, isort, pyright).

## Context

FND-201's mirroring fix was verified end-to-end before this cleanup: a forced negative run reproduced the incident's job vector (discovery green, image build failed, merge/matrix skipped) and the mirrored check came back **failure** with `❌ e2e image build failed`, where pre-fix it reported success. Evidence: https://github.com/atlanhq/atlan-openapi-app/actions/runs/31514420995

Refs: FND-201
