### PR TITLE
ci(concurrency): make the tenant lease actually exclusive, via an atomic CAS on one ref

### DIFF
--- a/.github/actions/e2e-tenant-lease/action.yaml
+++ b/.github/actions/e2e-tenant-lease/action.yaml
@@ -40,8 +40,22 @@ inputs:
     default: "5400"
   poll-seconds:
     description: |
-      Gap between queue checks. Each poll costs two API calls, so this also sets
-      the draw on the 1000/hour GITHUB_TOKEN budget.
+      Gap between attempts. A waiting pass costs TWO API calls (read the lease
+      ref; check the holding run's status — the holder record is memoised by the
+      ref's target sha), and FOUR on the pass that takes the lease (plus a fifth
+      to reap a dead holder).
+
+      That budget is 1000 requests/hour per REPOSITORY, and every matrix leg of
+      every concurrent run shares it. So raise this rather than lower it when
+      several clouds contend: at 30s, one leg waiting the full 90min budget draws
+      ~360 calls, and three clouds waiting together draw ~1080 over that 90
+      minutes — about 720/hour, which is close enough to the ceiling to matter
+      once the rest of the run's API use is counted.
+
+      A rate-limit 403 no longer disables the lease: it is told apart from a
+      permission 403, backs off (honouring Retry-After), and fails loudly if it
+      never clears. Staying inside the budget is still much better than relying
+      on that.
     required: false
     default: "30"
   ttl-seconds:
@@ -74,10 +88,13 @@ outputs:
     value: ${{ steps.lease.outputs.acquired }}
   state:
     description: |
-      "acquired", "disabled" (no ref-write permission — the run proceeds
-      unserialised) or "timeout". Worth asserting in anger rather than trusting a
-      green job: "disabled" is a deliberate fail-open, so a lease that is not
-      working at all still leaves the job green with only a warning.
+      "acquired"; "disabled" (no ref-write permission — the run proceeds
+      unserialised); "timeout" (the tenant stayed busy); or "rate-limited" (the
+      API never cleared, which fails rather than proceeding unserialised).
+
+      Worth asserting in anger rather than trusting a green job: "disabled" is a
+      deliberate fail-open, so a lease that is not working at all still leaves
+      the job green with only a warning.
     value: ${{ steps.lease.outputs.state }}
   lease-ref:
     description: The tenant's lease ref this run raced for.

--- a/.github/actions/e2e-tenant-lease/action.yaml
+++ b/.github/actions/e2e-tenant-lease/action.yaml
@@ -4,9 +4,12 @@ description: |
   against a shared tenant, replacing the ref-keyed concurrency groups that could
   only hold one pending run and silently evicted the rest (FND-218 / FND-250).
 
-  Consumed at @main by every contender ON PURPOSE: they all have to agree on the
-  ref layout and the ordering rule, so the protocol must not vary with whichever
-  ref a caller happened to check out. See e2e_tenant_lease.py for the protocol.
+  Exclusion is an atomic compare-and-swap: one fixed-name ref per tenant, where
+  GitHub's 422 on creating a ref that already exists IS the lock. Consumed at
+  @main by every contender ON PURPOSE — they all have to agree on that ref name,
+  so the protocol must not vary with whichever ref a caller happened to check
+  out. See e2e_tenant_lease.py, including why an ordered ticket queue was tried
+  first and does not work.
 
   Requires `contents: write` (to create and delete the ticket ref) and
   `actions: read` (to tell a live holder from a dead one). Without them the
@@ -43,22 +46,21 @@ inputs:
     default: "30"
   ttl-seconds:
     description: |
-      Run AGE at which a holder still reporting "in_progress" is treated as
-      wedged and its lease broken. Measured from run CREATION, not from when the
-      lease was taken — the lease is acquired several jobs in, and a run can also
-      sit waiting for runners first, so this has to clear the entire chain
-      (discovery + image build + manifest merge + the lease wait + install +
-      legs) with room for unbounded queue time on top. Sized against the
-      workflow's own job timeouts by a test, so adding a job or raising a timeout
-      forces this up rather than silently eating the margin.
+      How long a holder may HOLD the lease before a waiter treats it as wedged
+      and breaks it. Measured from the acquisition time the holder recorded in
+      its own holder record — so it is lease-hold time, not run age, and none of
+      the pre-lease span (discovery, image build, manifest merge, runner queue
+      time) counts against it.
 
-      Deliberately generous (12h against a ~5.5h chain). The operator-facing
-      signal for a stuck tenant is wait-seconds failing loudly, not this; all
-      this does is stop a ticket being immortal. Firing it early is the
-      expensive direction — it reaps a live mid-install ticket and puts a second
-      installer on the tenant, the exact race the lease closes. 0 disables it.
+      Must exceed the longest legitimate hold: the install plus the leg ceiling.
+      Sized against the workflow's own job timeouts by a test, so raising either
+      forces this up rather than silently eating the margin. Errs long on
+      purpose — breaking a live holder's lease puts a second installer on the
+      tenant, which is the race the lease exists to close, whereas breaking one
+      late costs a blocked tenant that a waiter is already reporting loudly.
+      0 disables the backstop.
     required: false
-    default: "43200"
+    default: "14400"
   on-timeout:
     description: |
       "fail" (default) — go red naming the holding run. "warn" — proceed
@@ -71,10 +73,14 @@ outputs:
     description: '"true" only when this run now holds the lease.'
     value: ${{ steps.lease.outputs.acquired }}
   state:
-    description: '"acquired", "disabled" (no ref-write permission) or "timeout".'
+    description: |
+      "acquired", "disabled" (no ref-write permission — the run proceeds
+      unserialised) or "timeout". Worth asserting in anger rather than trusting a
+      green job: "disabled" is a deliberate fail-open, so a lease that is not
+      working at all still leaves the job green with only a warning.
     value: ${{ steps.lease.outputs.state }}
   lease-ref:
-    description: The ticket ref this run owns.
+    description: The tenant's lease ref this run raced for.
     value: ${{ steps.lease.outputs.lease-ref }}
   holder-run-id:
     description: The run holding the lease when this one gave up waiting; else empty.
@@ -96,13 +102,14 @@ runs:
         POLL_SECONDS: ${{ inputs.poll-seconds }}
         TTL_SECONDS: ${{ inputs.ttl-seconds }}
         ON_TIMEOUT: ${{ inputs.on-timeout }}
-        # The tickets live in the repository the run belongs to, which is also
-        # the only repository whose run_ids are comparable — see the ordering
-        # note in e2e_tenant_lease.py.
+        # The lease lives in the repository the run belongs to. Every run that
+        # contends for a given app's tenant runs there too — a connector PR, a
+        # push, and a cross-repo dispatch from application-sdk all execute in the
+        # app repo. (The one exception, application-sdk's manual install
+        # workflow, is outside the lease domain: see FND-254.)
         LEASE_REPO: ${{ github.repository }}
         RUN_ID: ${{ github.run_id }}
         RUN_ATTEMPT: ${{ github.run_attempt }}
-        HEAD_SHA: ${{ github.sha }}
         GH_TOKEN: ${{ github.token }}
       run: |
         set -euo pipefail
@@ -113,7 +120,6 @@ runs:
           --cloud "$CLOUD" \
           --run-id "$RUN_ID" \
           --run-attempt "$RUN_ATTEMPT" \
-          --sha "$HEAD_SHA" \
           --wait-seconds "$WAIT_SECONDS" \
           --poll-seconds "$POLL_SECONDS" \
           --ttl-seconds "$TTL_SECONDS" \

--- a/.github/actions/e2e-tenant-lease/e2e_tenant_lease.py
+++ b/.github/actions/e2e-tenant-lease/e2e_tenant_lease.py
@@ -263,18 +263,24 @@ def gh_request(method: str, path: str, payload: dict | None = None) -> Response:
         "30",
         "-X",
         method,
+        # Read the Authorization header from stdin (-K -) rather than -H so the
+        # token never appears in curl's argv, where anything on the same runner
+        # could read it from /proc/<pid>/cmdline while the request runs. Only
+        # the credential goes through the pipe; the non-secret headers stay in
+        # argv, so the tests stubbing this seam still see the method and URL.
+        "-K",
+        "-",
         "-H",
         "Accept: application/vnd.github+json",
         "-H",
         "X-GitHub-Api-Version: 2022-11-28",
-        "-H",
-        f"Authorization: Bearer {token}",
     ]
+    config = f'header = "Authorization: Bearer {token}"\n'
     if payload is not None:
         cmd += ["-H", "Content-Type: application/json", "-d", json.dumps(payload)]
     cmd.append(f"https://api.github.com/{path}")
 
-    result = run(cmd, capture_output=True, text=True, check=False)
+    result = run(cmd, input=config, capture_output=True, text=True, check=False)
     if result.returncode != 0:
         raise SystemExit(f"::error::curl failed for {method} {path}: {result.stderr}")
     return _parse_http(result.stdout, f"{method} {path}")

--- a/.github/actions/e2e-tenant-lease/e2e_tenant_lease.py
+++ b/.github/actions/e2e-tenant-lease/e2e_tenant_lease.py
@@ -57,6 +57,24 @@ loudly and names the holder — a run that starves gets a red job saying the ten
 was busy, not silence. Correctness first; FIFO was the property that turned out
 to be unaffordable.
 
+API budget
+----------
+``GITHUB_TOKEN`` allows 1000 requests/hour **per repository**, and every matrix
+leg of a run shares that one budget. A waiting poll therefore has to be cheap or
+the lease starves itself of API calls precisely when several legs are queueing —
+and a rate-limit 403 looks exactly like a permission 403, which used to fail the
+lease open. So:
+
+* A waiting poll costs **two** calls: read the lease ref, and check the holding
+  run's status. The holder record is memoised by the ref's target sha, so it is
+  only re-read when the lease actually changes hands.
+* The identity blob and the CAS are only paid when the ref *looks* free, which
+  makes the acquisition path 4 calls and the steady-state waiting path 2. The
+  pre-read is purely an optimisation: the CAS is still the authority, and losing
+  a race after the ref looked free is handled like any other 422.
+* Rate limiting is detected separately from permission denial and never
+  fail-opens. See ``_rate_limited``.
+
 Liveness, not heartbeats
 ------------------------
 A lease is breakable when the holder's *run* is over. GitHub reports run status
@@ -70,7 +88,9 @@ blob, not from run age) is the backstop for a run the API keeps reporting as liv
 forever. The two directions are not symmetric: breaking a lease too late costs a
 blocked tenant that a waiter is already complaining loudly about, whereas breaking
 one too early reaps a LIVE mid-install holder and puts a second installer on the
-tenant — the exact race this module exists to close. So it errs long.
+tenant — the exact race this module exists to close. So it errs long, and that
+sizing is load-bearing for release safety as well as for acquisition: see
+``release``.
 
 Failure posture
 ---------------
@@ -79,6 +99,13 @@ Failure posture
   wrong-version run from passing — every leg re-asserts the installed version
   itself (FND-31). Making an ungrantable lease fail the run would turn a safety
   improvement into a new way for e2e to go red fleet-wide.
+
+  Note the limit of that backstop, which is easy to overstate: the version assert
+  catches a *wrong-version* run, not two runs installing the *same* version and
+  fighting over one tenant. Two dispatches of one commit do exactly that, and it
+  surfaces as a worker/task-queue failure rather than a version mismatch. So
+  fail-open is a real reduction in protection, not a no-op — which is why a rate
+  limit must never be allowed to trigger it.
 * **Not acquired within the wait budget** fails loudly, naming the holding run.
 
 Co-located with the composite action, and pinned ``@main`` by every consumer on
@@ -108,6 +135,10 @@ REF_NAMESPACE = "e2e-tenant-lease"
 # in_progress, requested, waiting, pending — is treated as live, so an unfamiliar
 # future status errs towards leaving a peer's lease alone.
 _COMPLETED = "completed"
+
+# Ceiling on how long a Retry-After will be honoured, so a long secondary-limit
+# backoff cannot swallow the whole wait budget in one sleep.
+_MAX_RETRY_AFTER = 300
 
 # Characters safe in a single git ref path component. Deliberately narrower than
 # git's own rules: app and cloud names come from workflow inputs, and a ref name
@@ -160,13 +191,28 @@ class Holder:
         return self.run_id == run_id and self.attempt == attempt
 
 
+@dataclass(frozen=True)
+class Response:
+    """One API answer. Headers are carried because rate-limit detection needs
+    them, and mistaking a rate limit for a permission denial fails the lease
+    open under contention."""
+
+    status: int
+    headers: dict[str, str]
+    body: object | None
+
+    @property
+    def message(self) -> str:
+        return self.body.get("message", "") if isinstance(self.body, dict) else ""
+
+
 def run(cmd: list[str], **kwargs) -> subprocess.CompletedProcess:
     """Single seam so tests can stub the HTTP client."""
     return subprocess.run(cmd, **kwargs)
 
 
-def _parse_http(raw: str, label: str) -> tuple[int, object | None]:
-    """Split a ``curl -i`` response into (status_code, parsed_body_or_None)."""
+def _parse_http(raw: str, label: str) -> Response:
+    """Split a ``curl -i`` response into status, headers and parsed body."""
     text = raw.replace("\r\n", "\n")
     if "\n\n" not in text:
         raise SystemExit(f"::error::unexpected response for {label}: {text[:300]!r}")
@@ -179,28 +225,31 @@ def _parse_http(raw: str, label: str) -> tuple[int, object | None]:
             f"::error::could not parse HTTP status line for {label}: "
             f"{(lines[0] if lines else '')!r}"
         )
+    headers: dict[str, str] = {}
+    for line in lines[1:]:
+        name, sep, value = line.partition(":")
+        if sep:
+            headers[name.strip().lower()] = value.strip()
+
     if not body.strip():
-        return status_code, None
+        return Response(status_code, headers, None)
     try:
-        return status_code, json.loads(body)
+        return Response(status_code, headers, json.loads(body))
     except json.JSONDecodeError:
         # A non-JSON body (an HTML error page from a proxy) must not crash the
         # caller before it can report the status code, which is the part that
         # decides what happens next.
-        return status_code, None
+        return Response(status_code, headers, None)
 
 
-def gh_request(
-    method: str, path: str, payload: dict | None = None
-) -> tuple[int, object | None]:
-    """Call the GitHub API, returning the status code rather than raising on 4xx.
+def gh_request(method: str, path: str, payload: dict | None = None) -> Response:
+    """Call the GitHub API, returning the status rather than raising on 4xx.
 
     curl, not ``gh api``, for the same reason ``poll_check_runs_gate.py`` uses it:
     ``gh api`` treats every non-2xx as a command failure and prints its own
     diagnostic instead of the response. Here the non-2xx codes are the entire
     mechanism — 422 on ref creation IS the lock being held, and it has to be
-    distinguished from 403 ("this repo will not let us write refs") and from a
-    genuine error.
+    told apart from 403-permission and 403-rate-limit, which mean opposite things.
     """
     token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
     if not token:
@@ -231,25 +280,72 @@ def gh_request(
     return _parse_http(result.stdout, f"{method} {path}")
 
 
-def _message(body: object | None) -> str:
-    return body.get("message", "") if isinstance(body, dict) else ""
+def _rate_limited(response: Response) -> bool:
+    """Is this a rate limit rather than a permission problem?
+
+    Both arrive as 403, and conflating them is how the lease used to switch
+    itself OFF exactly when it was needed: several legs queueing for tenants is
+    also when the shared per-repository budget runs out, and the fail-open path
+    then let every waiting run proceed onto the tenant unserialised.
+
+    Detected from the headers first (``x-ratelimit-remaining: 0``, or a
+    ``retry-after`` on a secondary limit) and the message second, so it does not
+    hinge on GitHub's exact prose.
+    """
+    # 429 means this by definition, whatever else the body says.
+    if response.status == 429:
+        return True
+    if response.status != 403:
+        return False
+    # A 403 is ambiguous, so it needs evidence. Headers first, message second, so
+    # detection does not hinge on GitHub's exact prose.
+    if response.headers.get("x-ratelimit-remaining") == "0":
+        return True
+    if "retry-after" in response.headers:
+        return True
+    message = response.message.lower()
+    return "rate limit" in message or "abuse detection" in message
 
 
-def _denied(status: int) -> bool:
-    """GitHub 404s resources it will not admit exist, so it is a permission
-    answer as much as 401/403 are."""
-    return status in (401, 403, 404)
+def _denied(response: Response) -> bool:
+    """A genuine permission answer. GitHub 404s resources it will not admit
+    exist, so 404 counts, but a rate limit explicitly does not."""
+    return response.status in (401, 403, 404) and not _rate_limited(response)
+
+
+def _retry_after(response: Response) -> int | None:
+    try:
+        return max(0, int(response.headers["retry-after"]))
+    except (KeyError, TypeError, ValueError):
+        return None
+
+
+class RateLimited(Exception):
+    """The API rate-limited us. Carries Retry-After when GitHub supplied one.
+
+    An exception rather than a return value so every call site cannot forget to
+    distinguish it from a permission denial — which is the mistake that made the
+    lease fail open under contention.
+    """
+
+    def __init__(self, retry_after: int | None = None) -> None:
+        super().__init__("rate limited")
+        self.retry_after = retry_after
 
 
 def create_identity_blob(
     repo: str, run_id: int, attempt: int, now: float
 ) -> str | None:
-    """Write the holder record the lease ref will point at. None ⇒ denied.
+    """Write the holder record the lease ref will point at.
 
-    Created BEFORE the lease is taken, so it costs one wasted blob per failed
-    attempt. That is the right way round: an unreferenced blob is garbage GitHub
-    collects, whereas taking the lease first and describing it second would leave
-    a window where the lease is held by nobody identifiable.
+    Returns the blob sha, or None if ref writes are not permitted. Raises
+    ``RateLimited`` when the API is merely busy.
+
+    Written immediately before the CAS, not once per acquire, because the record
+    carries the acquisition timestamp: a blob minted when the run first started
+    queueing would date the lease from before it was held, and the TTL would then
+    measure a hold that had not happened yet. It is only paid on attempts where
+    the ref actually looks free, so a long wait does not pay for it repeatedly.
     """
     payload = {
         "run_id": run_id,
@@ -260,72 +356,89 @@ def create_identity_blob(
         # have queued for runners first, none of which is lease-hold time.
         "acquired_at": now,
     }
-    status, body = gh_request(
+    response = gh_request(
         "POST",
         f"repos/{repo}/git/blobs",
         {"content": json.dumps(payload), "encoding": "utf-8"},
     )
-    if status in (200, 201) and isinstance(body, dict) and body.get("sha"):
-        return str(body["sha"])
-    if _denied(status):
+    if (
+        response.status in (200, 201)
+        and isinstance(response.body, dict)
+        and response.body.get("sha")
+    ):
+        return str(response.body["sha"])
+    if _rate_limited(response):
+        raise RateLimited(_retry_after(response))
+    if _denied(response):
         return None
     raise SystemExit(
         f"::error::could not write the tenant lease holder record in {repo}: "
-        f"HTTP {status} {_message(body)!r}"
+        f"HTTP {response.status} {response.message!r}"
     )
 
 
 def try_acquire(repo: str, ref: str, blob_sha: str) -> str:
-    """One atomic attempt. Returns "acquired", "occupied" or "denied".
+    """One atomic attempt. "acquired", "occupied" or "denied"; raises RateLimited.
 
     The 422 is not an error path bolted on — it is the lock. GitHub evaluates
     ref creation atomically, so of N simultaneous callers exactly one sees 201.
     """
-    status, body = gh_request(
+    response = gh_request(
         "POST", f"repos/{repo}/git/refs", {"ref": ref, "sha": blob_sha}
     )
-    if status in (200, 201):
+    if response.status in (200, 201):
         return "acquired"
-    if status == 422 and "already exists" in _message(body).lower():
+    if response.status == 422 and "already exists" in response.message.lower():
         return "occupied"
-    if _denied(status):
+    if _rate_limited(response):
+        raise RateLimited(_retry_after(response))
+    if _denied(response):
         return "denied"
     raise SystemExit(
         f"::error::could not take the tenant lease {ref} in {repo}: "
-        f"HTTP {status} {_message(body)!r}"
+        f"HTTP {response.status} {response.message!r}"
     )
+
+
+def read_lease_target(repo: str, ref: str) -> str | None:
+    """The sha the lease ref points at, or None if unheld or unreadable.
+
+    One API call, and the cheap half of a waiting poll. None deliberately
+    conflates "nobody holds it" with "we could not tell": both mean "try the
+    CAS", and the CAS is the authority.
+    """
+    # git/ref/<name> wants the ref without the leading "refs/".
+    response = gh_request("GET", f"repos/{repo}/git/ref/{ref.removeprefix('refs/')}")
+    if response.status == 404 or not isinstance(response.body, dict):
+        return None
+    if response.status >= 400:
+        print(
+            f"::warning::could not read the tenant lease {ref} (HTTP {response.status})."
+        )
+        return None
+    target = response.body.get("object") or {}
+    sha = target.get("sha") if isinstance(target, dict) else None
+    return str(sha) if sha else None
+
+
+def read_holder_record(repo: str, blob_sha: str) -> Holder | None:
+    """Decode the holder record a lease ref points at. One API call."""
+    response = gh_request("GET", f"repos/{repo}/git/blobs/{blob_sha}")
+    if response.status >= 400 or not isinstance(response.body, dict):
+        print(
+            f"::warning::a tenant lease holder record ({blob_sha}) is unreadable "
+            f"(HTTP {response.status})."
+        )
+        return None
+    return _parse_holder(response.body)
 
 
 def read_holder(repo: str, ref: str) -> Holder | None:
-    """Who holds `ref`, or None if it is unheld or unreadable.
-
-    None deliberately conflates "nobody holds it" with "we could not tell": both
-    mean "retry the CAS", and the CAS is authoritative. Guessing at an
-    unreadable holder is what would be dangerous.
-    """
-    # git/ref/<name> wants the ref without the leading "refs/".
-    status, body = gh_request(
-        "GET", f"repos/{repo}/git/ref/{ref.removeprefix('refs/')}"
-    )
-    if status == 404 or not isinstance(body, dict):
+    """Who holds `ref`, or None if unheld/unreadable. Two API calls."""
+    target = read_lease_target(repo, ref)
+    if target is None:
         return None
-    if status >= 400:
-        print(f"::warning::could not read the tenant lease {ref} (HTTP {status}).")
-        return None
-
-    target = body.get("object") or {}
-    blob_sha = target.get("sha") if isinstance(target, dict) else None
-    if not blob_sha:
-        return None
-
-    status, blob = gh_request("GET", f"repos/{repo}/git/blobs/{blob_sha}")
-    if status >= 400 or not isinstance(blob, dict):
-        print(
-            f"::warning::the tenant lease {ref} exists but its holder record "
-            f"({blob_sha}) is unreadable (HTTP {status})."
-        )
-        return None
-    return _parse_holder(blob)
+    return read_holder_record(repo, target)
 
 
 def _parse_holder(blob: dict) -> Holder | None:
@@ -358,10 +471,10 @@ def _parse_holder(blob: dict) -> Holder | None:
 
 def release_ref(repo: str, ref: str) -> bool:
     """Delete the lease ref. False ⇒ it was already gone, which is not a fault."""
-    status, _body = gh_request(
+    response = gh_request(
         "DELETE", f"repos/{repo}/git/refs/{ref.removeprefix('refs/')}"
     )
-    return status in (200, 204)
+    return response.status in (200, 204)
 
 
 def holder_is_live(
@@ -378,16 +491,17 @@ def holder_is_live(
     this module exists to close — whereas erring towards "live" only costs the
     waiter another poll interval.
     """
-    status, body = gh_request("GET", f"repos/{repo}/actions/runs/{holder.run_id}")
-    if status == 404:
+    response = gh_request("GET", f"repos/{repo}/actions/runs/{holder.run_id}")
+    if response.status == 404:
         # The run was deleted, or never existed. Nothing will ever release this.
         return False
-    if status >= 400 or not isinstance(body, dict):
+    if response.status >= 400 or not isinstance(response.body, dict):
         print(
             f"::warning::could not read run {holder.run_id} in {repo} "
-            f"(HTTP {status}); treating its tenant lease as still held."
+            f"(HTTP {response.status}); treating its tenant lease as still held."
         )
         return True
+    body = response.body
     if body.get("status") == _COMPLETED:
         return False
     if ttl_seconds <= 0 or holder.acquired_at is None:
@@ -440,6 +554,17 @@ def _timestamp(value: object) -> float | None:
     return stamp.timestamp()
 
 
+_DISABLED_WARNING = (
+    "::warning::this repository will not let the run write git refs, so the "
+    "(app, cloud) tenant lease is disabled for this run and e2e proceeds "
+    "unserialised. Grant the lease job 'contents: write' to enable it. Each e2e "
+    "leg still asserts the installed version independently (FND-31), so a "
+    "WRONG-version run cannot pass silently — but two runs installing the SAME "
+    "version will still fight over the tenant, so this is a real loss of "
+    "protection, not a no-op."
+)
+
+
 def acquire(
     repo: str,
     ref: str,
@@ -454,43 +579,64 @@ def acquire(
 ) -> tuple[str, Holder | None]:
     """Take the lease, or report why not.
 
-    Returns ("acquired" | "disabled" | "timeout", blocking_holder_or_None).
+    Returns ("acquired" | "disabled" | "timeout" | "rate-limited",
+    blocking_holder_or_None).
+
+    Each waiting pass costs two API calls: read the ref, and check the holding
+    run. The identity blob and the CAS are only paid when the ref looks free.
+    That pre-read is an optimisation, not a decision — the CAS remains the
+    authority, and losing a race after the ref looked free is just another 422.
     """
     # Attempt-counted rather than deadline-checked so the budget needs no clock
     # comparison. Ceiling division: a budget that is not an exact multiple of the
     # interval still gets its final full attempt.
     max_attempts = max(1, math.ceil(wait_seconds / poll_seconds))
 
+    # Memoised by the ref's target sha: while a lease does not change hands, the
+    # record behind it cannot change either, so re-reading it every poll would
+    # spend a call per poll to learn what we already know.
+    records: dict[str, Holder | None] = {}
     blocker: Holder | None = None
+    rate_limited = False
+
     for attempt_number in range(1, max_attempts + 1):
-        blob_sha = create_identity_blob(repo, run_id, attempt, clock())
-        if blob_sha is None:
-            print(
-                "::warning::this repository will not let the run write git refs, "
-                "so the (app, cloud) tenant lease is disabled for this run and "
-                "e2e proceeds unserialised. Grant the lease job 'contents: write' "
-                "to enable it. Each e2e leg still asserts the installed version "
-                "independently (FND-31), so a wrong-version run cannot pass "
-                "silently — it just fails less informatively."
-            )
-            return "disabled", None
+        target = read_lease_target(repo, ref)
 
-        outcome = try_acquire(repo, ref, blob_sha)
-        if outcome == "denied":
-            print(
-                "::warning::this repository will not let the run create the tenant "
-                "lease ref; proceeding unserialised. See the note above."
-            )
-            return "disabled", None
-        if outcome == "acquired":
-            print(f"Tenant lease acquired: {ref}")
-            return "acquired", None
+        if target is None:
+            # Looks free — mint an identity and race for it.
+            try:
+                blob_sha = create_identity_blob(repo, run_id, attempt, clock())
+                if blob_sha is None:
+                    print(_DISABLED_WARNING)
+                    return "disabled", None
+                outcome = try_acquire(repo, ref, blob_sha)
+            except RateLimited as limited:
+                rate_limited = True
+                if attempt_number < max_attempts:
+                    _sleep_for_rate_limit(sleep, poll_seconds, limited.retry_after)
+                continue
 
-        # Occupied. Find out by whom, and whether that claim is still good.
-        blocker = read_holder(repo, ref)
+            if outcome == "acquired":
+                print(f"Tenant lease acquired: {ref}")
+                return "acquired", None
+            if outcome == "denied":
+                print(_DISABLED_WARNING)
+                return "disabled", None
+            # "occupied": somebody won the race between our read and our CAS.
+            # Re-read next pass; the CAS was the authority, as intended.
+            print("Lost the race for the tenant lease; it is held again.")
+            if attempt_number < max_attempts:
+                sleep(poll_seconds)
+            continue
+
+        rate_limited = False
+        if target not in records:
+            records[target] = read_holder_record(repo, target)
+        blocker = records[target]
+
         if blocker is None:
-            # Either it was released between the CAS and the read, or we could
-            # not read it. Either way the CAS on the next pass is authoritative.
+            # Unreadable record. The CAS on the next pass is authoritative rather
+            # than a guess, so just wait for it.
             print("The tenant lease is held but its holder is unreadable; retrying.")
         elif blocker.is_me(run_id, attempt):
             # A retried step, or a re-run of this same attempt. Already ours.
@@ -514,7 +660,27 @@ def acquire(
         if attempt_number < max_attempts:
             sleep(poll_seconds)
 
-    return "timeout", blocker
+    return ("rate-limited" if rate_limited else "timeout"), blocker
+
+
+def _sleep_for_rate_limit(sleep, poll_seconds: int, retry_after: int | None) -> None:
+    """Back off after a rate limit, honouring Retry-After within reason.
+
+    Never returns "disabled" to the caller: a rate limit is a reason to wait, not
+    evidence that the lease cannot be taken. Switching the lease off here would
+    do it precisely when several legs are contending, which is both when the
+    budget runs out and when the lease matters most.
+    """
+    delay = poll_seconds
+    if retry_after is not None:
+        delay = max(poll_seconds, min(retry_after, _MAX_RETRY_AFTER))
+    print(
+        "::warning::rate-limited by the GitHub API while taking the tenant lease; "
+        f"backing off {delay}s and retrying. The lease is NOT being disabled — "
+        "the per-repository budget is shared by every matrix leg, so this is "
+        "expected under contention."
+    )
+    sleep(delay)
 
 
 def release(repo: str, ref: str, run_id: int, attempt: int) -> bool:
@@ -522,18 +688,30 @@ def release(repo: str, ref: str, run_id: int, attempt: int) -> bool:
 
     The ref name is shared by every contender for the tenant, so unlike a
     per-run name it is possible to delete somebody else's lease. Ownership is
-    therefore checked first.
+    therefore checked first, and the ref's target is re-read immediately before
+    the delete so a lease that changed hands in between is left alone.
 
-    The check-then-delete is not atomic (the API offers no conditional delete),
-    but the window is closed by the liveness rule rather than by luck: this runs
-    while our own run is still ``in_progress``, so no contender is entitled to
-    reap us, and nobody else can be holding the lease for us to delete by
-    mistake. The TTL could in principle break our lease while we are live, which
-    is one more reason it errs long.
+    That narrows the window to a single DELETE round-trip; it does not close it,
+    because the API offers no conditional delete. The interleaving that remains
+    is worth naming rather than waving at: if the TTL breaks *our* lease while we
+    are still live and another run acquires between our last read and our DELETE,
+    we would delete the replacement holder's lease and put a second installer on
+    the tenant. That cannot happen while the TTL exceeds the longest legitimate
+    hold — which is exactly why the TTL errs long and why its sizing is pinned by
+    a test. The TTL is load-bearing for release safety, not only for acquisition.
     """
-    holder = read_holder(repo, ref)
-    if holder is None:
+    target = read_lease_target(repo, ref)
+    if target is None:
         print(f"No tenant lease to release at {ref} — already reaped.")
+        return False
+
+    holder = read_holder_record(repo, target)
+    if holder is None:
+        print(
+            f"::warning::not releasing {ref}: its holder record is unreadable, so "
+            "ownership cannot be confirmed. The next contender will reap it if "
+            "this run is over."
+        )
         return False
     if not holder.is_me(run_id, attempt):
         print(
@@ -542,6 +720,17 @@ def release(repo: str, ref: str, run_id: int, attempt: int) -> bool:
             "broken by the TTL, or reaped after this run was misread as finished."
         )
         return False
+
+    # Re-read the target rather than trusting the one we validated against: if the
+    # lease changed hands while we were reading the record, the sha moves, and
+    # deleting would take the new holder's lease rather than ours.
+    if read_lease_target(repo, ref) != target:
+        print(
+            f"::warning::not releasing {ref}: it changed hands while this run was "
+            "confirming ownership, so the lease being held is no longer ours."
+        )
+        return False
+
     if release_ref(repo, ref):
         print(f"Tenant lease released: {ref}")
         return True
@@ -579,8 +768,10 @@ def main(argv: list[str] | None = None) -> int:
         "--poll-seconds",
         type=int,
         default=30,
-        help="Gap between attempts. Each contended attempt costs a handful of API "
-        "calls, so this also sets the draw on the 1000/hour GITHUB_TOKEN budget.",
+        help="Gap between attempts. A waiting pass costs two API calls (read the "
+        "lease ref, check the holding run), and four on the pass that takes it. "
+        "GITHUB_TOKEN allows 1000/hour per REPOSITORY and every matrix leg shares "
+        "it, so raise this rather than lower it when many clouds contend.",
     )
     parser.add_argument(
         "--ttl-seconds",
@@ -590,8 +781,8 @@ def main(argv: list[str] | None = None) -> int:
         "time it recorded, not from run age) before a waiter treats it as wedged "
         "and breaks it. Must exceed the longest legitimate hold — the install plus "
         "the leg ceiling — because breaking a live holder's lease puts a second "
-        "installer on the tenant. Default 4h against a 40min+120min hold. 0 "
-        "disables the backstop.",
+        "installer on the tenant, and because release safety depends on it too. "
+        "Default 4h against a 40min+120min hold. 0 disables the backstop.",
     )
     parser.add_argument(
         "--on-timeout",
@@ -646,8 +837,21 @@ def main(argv: list[str] | None = None) -> int:
         os.environ.get("GITHUB_OUTPUT"),
     )
 
-    if state != "timeout":
+    if state in ("acquired", "disabled"):
         return 0
+
+    if state == "rate-limited":
+        # Deliberately NOT fail-open: proceeding unserialised because the API was
+        # busy is how two runs end up on one tenant.
+        print(
+            f"::error::could not get the tenant lease {ref} within "
+            f"{args.wait_seconds}s because the GitHub API rate-limited this "
+            "repository throughout. Nothing is wrong with this change. The "
+            "GITHUB_TOKEN budget is 1000 requests/hour per repository and is "
+            "shared by every matrix leg — re-run when the hour rolls over, or "
+            "raise poll-seconds so a waiting leg costs fewer calls."
+        )
+        return 1
 
     held_by = (
         f" It is held by run {blocker.run_id} ({blocker.run_url(args.repo)})."

--- a/.github/actions/e2e-tenant-lease/e2e_tenant_lease.py
+++ b/.github/actions/e2e-tenant-lease/e2e_tenant_lease.py
@@ -1,94 +1,95 @@
 #!/usr/bin/env python3
-"""A real ``(app, cloud)`` tenant lease for e2e runs — a queue, not a one-deep
-waiting room.
+"""A real ``(app, cloud)`` tenant lease for e2e runs — mutual exclusion via an
+atomic compare-and-swap on a single git ref.
 
 Why this exists rather than a ``concurrency:`` group
 ---------------------------------------------------
 A tenant is a shared *mutable* resource: ``prepare-tenant`` installs a version
-onto it and the e2e legs then assert they are testing that version (FND-31). So
-access has to be serialised across the whole span of a run, from the install to
-the last leg. GitHub's ``concurrency:`` cannot express that, for two independent
-reasons:
+onto it and every e2e leg then asserts it is testing that version (FND-31). So
+exclusive access has to span from the install to the last leg, and
+``concurrency:`` structurally cannot do that:
 
-* It is per-job, not per-run. A group on ``prepare-tenant`` is released the
-  moment that job ends, which is before any leg has started — the race it looks
-  like it closes is still wide open. The existing comment on that job said as
-  much: *"GitHub has no cross-job lease, so another run can still install
-  between this job and the legs below"*.
-* It holds at most ONE pending run per group. A third arrival does not queue —
+* It is per-JOB. A group on ``prepare-tenant`` is released the moment that job
+  ends, which is before any leg has started.
+* It holds exactly ONE pending run per group. A third arrival does not queue —
   it cancels the run that was waiting, before that run is ever given a runner,
-  producing no log output at all. That is FND-218: what looked like connector
-  test failures across a merge-queue batch were evictions, and the callback
-  mirrored them onto the dispatching PR as ``failure``, which reads as "your
-  change broke the connector".
+  with no log output at all. That is FND-218.
 
-``cancel-in-progress: false`` is therefore a waiting room with one chair, not a
-queue. This module is the queue.
+The protocol
+------------
+One ref per tenant, with a FIXED name::
 
-Protocol
---------
-Every run that wants a tenant creates a *ticket* ref in its own repository::
+    refs/e2e-tenant-lease/<app>/<cloud>/holder
 
-    refs/e2e-tenant-lease/<app>/<cloud>/<run_id>-<run_attempt>
+``POST /git/refs`` on a name that already exists returns 422. That is an atomic
+test-and-set evaluated by GitHub, and it is the whole of the mutual exclusion:
+exactly one contender can get 201 for a given ref, no matter how many try at
+once or in what order. 422 means somebody else holds the tenant.
 
-The lease is held by whichever LIVE ticket sorts lowest by
-``(run_id, run_attempt)``. Nothing is negotiated and there is no lock object to
-leak: every participant derives the same holder from the same ref listing, so
-there is no compare-and-swap, and no step whose failure strands the resource.
-Two properties are what make that sound:
+The ref points at a **blob** holding the holder's identity (run id, attempt, and
+the time it acquired). A ref can target a blob — verified against the API — which
+is what lets a single atomic creation both take the lease and record who took it.
+A waiter reads that blob to find out whose lease it is, so it can tell a live
+holder from a dead one.
 
-* ``run_id`` is assigned by GitHub and increases with run creation time within a
-  repository, so ordering is *server-side arrival order*. No runner clock takes
-  part, which removes the window where two runs both believe they are first
-  because their wall clocks disagree. (Ordering by a timestamp written into the
-  ref name would have exactly that bug, and it would be invisible until it lost
-  a tenant.)
-* A ticket's name is derived entirely from the run, so it is identical in every
-  job of that run. The acquiring job and the releasing job compute the same name
-  without passing state between them, and re-creating a ticket is idempotent —
-  it restores the run's exact queue position instead of sending it to the back.
+Why not an ordered queue (and the bug that taught us)
+----------------------------------------------------
+The first version of this module was a queue: every run created a ticket ref
+named after itself, and the lease belonged to whichever live ticket sorted lowest
+by ``(run_id, run_attempt)``. That was wrong, and it failed on its first
+concurrent run — both contenders acquired and both installed onto the same
+tenants:
 
-Liveness comes from the holder's *run*, not from a heartbeat: a ticket whose run
-reports ``status: completed`` is dead, and any participant that notices deletes
-it. This is deliberately not "release in an ``if: always()`` job", because that
-does not cover the case that matters most — a cancelled run whose release job
-never starts at all, since GitHub cancels queued jobs rather than running them.
-The reaper makes a leaked ticket self-healing: the next contender clears it on
-its first poll, so the worst case is one wasted poll interval, not a wedged
-tenant.
+* ``run_id`` increases with run *creation*, which is not the order runs reach
+  the lease job. In the observed failure the lower-id run got there 15s later.
+* A total order gives FIFO *fairness*; it does not give *exclusion*. A run that
+  only checks the tickets ordered ahead of it never notices that a run behind it
+  already holds the lease — so the late lower-id arrival took a lease that a live
+  run was already holding.
 
-A hard TTL on run *age* is kept as a third-resort backstop, only for a run the
-Actions API keeps reporting as live forever. It is deliberately generous, because
-the two directions are not symmetric: firing it late costs a blocked tenant that
-a waiter is already complaining loudly about, whereas firing it early reaps a
-LIVE mid-install ticket and puts a second installer on the tenant — reintroducing
-exactly the race this module exists to close. It is also measured from run
-*creation*, not from acquisition, so it has to clear the whole chain ahead of the
-install (discovery, image build, manifest merge, the queue wait itself) plus
-runner queue time, which has no timeout at all. ``test_prepare_tenant_wiring.py``
-derives that bound from the workflow's own job timeouts so it cannot drift.
+Ordering-based exclusion only works if every contender's ticket exists before any
+contender decides, which nothing enforces. Exclusion needs an atomic primitive,
+so this version uses one and derives nothing from ids.
+
+The cost is fairness: acquisition is a scramble, not a queue, so a waiter can in
+principle be repeatedly beaten. That is bounded by the wait budget, which fails
+loudly and names the holder — a run that starves gets a red job saying the tenant
+was busy, not silence. Correctness first; FIFO was the property that turned out
+to be unaffordable.
+
+Liveness, not heartbeats
+------------------------
+A lease is breakable when the holder's *run* is over. GitHub reports run status
+directly, so there is nothing to heartbeat and no lock to strand. This is also
+the part ``if: always()`` cannot cover: GitHub *cancels* queued jobs rather than
+running them, so a cancelled run's release job never starts at all. Any later
+contender reaps the dead holder, which makes a leaked lease self-healing.
+
+A TTL on lease-HOLD time (from the ``acquired_at`` the holder wrote into its own
+blob, not from run age) is the backstop for a run the API keeps reporting as live
+forever. The two directions are not symmetric: breaking a lease too late costs a
+blocked tenant that a waiter is already complaining loudly about, whereas breaking
+one too early reaps a LIVE mid-install holder and puts a second installer on the
+tenant — the exact race this module exists to close. So it errs long.
 
 Failure posture
 ---------------
-* **No permission to write refs** (a repository or caller that does not grant
-  ``contents: write``) is a ``::warning::`` and the run proceeds *without* a
-  lease. The lease reduces contention; it is not the thing that keeps a
-  wrong-version run from passing — every e2e leg re-asserts the installed
-  version itself (FND-31). Making an ungrantable lease fail the run would turn a
-  safety improvement into a new way for e2e to go red fleet-wide.
-* **Not acquired within the wait budget** fails loudly by default, naming the
-  holding run. That is strictly better than the behaviour it replaces (silent
-  eviction with no log), and unlike fail-open it does not put two runs on one
-  tenant expecting different versions.
+* **No permission to write refs** is a ``::warning::`` and the run proceeds
+  *without* a lease. The lease reduces contention; it is not what keeps a
+  wrong-version run from passing — every leg re-asserts the installed version
+  itself (FND-31). Making an ungrantable lease fail the run would turn a safety
+  improvement into a new way for e2e to go red fleet-wide.
+* **Not acquired within the wait budget** fails loudly, naming the holding run.
 
 Co-located with the composite action, and pinned ``@main`` by every consumer on
-purpose: all contenders must agree on the ref layout and the ordering rule, so
-the protocol must not vary by which ref a caller happens to have checked out.
+purpose: all contenders must agree on the ref name, so the protocol must not vary
+with whichever ref a caller happens to have checked out.
 """
 
 from __future__ import annotations
 
 import argparse
+import base64
 import json
 import math
 import os
@@ -98,20 +99,19 @@ import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
 
-# Ticket refs live outside refs/heads and refs/tags on purpose: a branch would
+# The lease ref lives outside refs/heads and refs/tags on purpose: a branch would
 # fire `push` events (and show up in the branch list), a tag would pollute the
 # release surface. A custom namespace is inert — nothing watches it.
 REF_NAMESPACE = "e2e-tenant-lease"
 
 # The only GitHub run status that means "over". Everything else — queued,
-# in_progress, requested, waiting, pending — is treated as live, so an
-# unfamiliar future status errs towards leaving a peer's lease alone.
+# in_progress, requested, waiting, pending — is treated as live, so an unfamiliar
+# future status errs towards leaving a peer's lease alone.
 _COMPLETED = "completed"
 
 # Characters safe in a single git ref path component. Deliberately narrower than
-# git's own rules: app names and cloud names come from workflow inputs, and a
-# ref name is the one place where "mostly valid" turns into a 422 nobody
-# expected.
+# git's own rules: app and cloud names come from workflow inputs, and a ref name
+# is the one place where "mostly valid" turns into a 422 nobody expected.
 _SAFE_SLUG_CHARS = frozenset("abcdefghijklmnopqrstuvwxyz0123456789._-")
 
 
@@ -120,8 +120,7 @@ def slug(value: str, *, default: str = "default") -> str:
 
     ``cloud`` is legitimately empty on the single-tenant path (the fallback
     matrix leg spells it as a defined-but-empty string), so an empty result maps
-    to ``default`` rather than producing ``refs/<ns>/<app>//<ticket>`` — an
-    empty component git rejects.
+    to ``default`` rather than producing an empty component, which git rejects.
     """
     cleaned = "".join(
         char if char in _SAFE_SLUG_CHARS else "-" for char in value.strip().lower()
@@ -136,49 +135,29 @@ def slug(value: str, *, default: str = "default") -> str:
     return cleaned or default
 
 
-def lease_prefix(app: str, cloud: str) -> str:
-    """The ref prefix every contender for one tenant shares (no ``refs/``)."""
-    return f"{REF_NAMESPACE}/{slug(app, default='app')}/{slug(cloud)}"
+def lease_ref(app: str, cloud: str) -> str:
+    """The single ref every contender for one tenant races to create.
 
-
-@dataclass(frozen=True, order=True)
-class Ticket:
-    """One run's claim on a tenant.
-
-    Ordered by ``(run_id, attempt)`` — declared in that field order so the
-    dataclass's generated comparison *is* the queue order, leaving no second
-    sort key to drift from it. A re-run keeps its original ``run_id`` and so
-    keeps its place in line; the two attempts can never be live at once, since a
-    re-run only starts after the previous attempt has finished.
+    Fixed for a given tenant — that is the point. The name carries no per-run
+    component, because a name only one run can guess is a name that cannot
+    collide, and collision is precisely the signal this design needs.
     """
+    return f"refs/{REF_NAMESPACE}/{slug(app, default='app')}/{slug(cloud)}/holder"
+
+
+@dataclass(frozen=True)
+class Holder:
+    """Who holds a lease, read back from the blob the lease ref points at."""
 
     run_id: int
     attempt: int
-
-    @property
-    def name(self) -> str:
-        return f"{self.run_id}-{self.attempt}"
-
-    def ref(self, prefix: str) -> str:
-        return f"refs/{prefix}/{self.name}"
+    acquired_at: float | None
 
     def run_url(self, repo: str) -> str:
         return f"https://github.com/{repo}/actions/runs/{self.run_id}"
 
-
-def parse_ticket(ref: str) -> Ticket | None:
-    """Parse a ticket out of a full ref name, or None if it is not one.
-
-    Unrecognised refs under the namespace are *ignored* rather than reaped: a
-    ref this version does not understand is more likely to be a newer protocol
-    than garbage, and ignoring it only costs the lease's mutual exclusion with
-    whoever wrote it — deleting it would break them outright.
-    """
-    name = ref.rsplit("/", 1)[-1]
-    run_id, _, attempt = name.partition("-")
-    if not run_id.isdigit() or not attempt.isdigit():
-        return None
-    return Ticket(int(run_id), int(attempt))
+    def is_me(self, run_id: int, attempt: int) -> bool:
+        return self.run_id == run_id and self.attempt == attempt
 
 
 def run(cmd: list[str], **kwargs) -> subprocess.CompletedProcess:
@@ -216,12 +195,12 @@ def gh_request(
 ) -> tuple[int, object | None]:
     """Call the GitHub API, returning the status code rather than raising on 4xx.
 
-    curl, not ``gh api``, for the same reason ``poll_check_runs_gate.py`` uses
-    it: ``gh api`` treats every non-2xx as a command failure and prints its own
-    diagnostic instead of the response, and here the non-2xx codes are load
-    bearing. 422 means "someone else already holds this ticket" and 403/404 mean
-    "this repository will not let us write refs" — two completely different
-    outcomes that both have to be distinguished from a genuine error.
+    curl, not ``gh api``, for the same reason ``poll_check_runs_gate.py`` uses it:
+    ``gh api`` treats every non-2xx as a command failure and prints its own
+    diagnostic instead of the response. Here the non-2xx codes are the entire
+    mechanism — 422 on ref creation IS the lock being held, and it has to be
+    distinguished from 403 ("this repo will not let us write refs") and from a
+    genuine error.
     """
     token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
     if not token:
@@ -256,222 +235,318 @@ def _message(body: object | None) -> str:
     return body.get("message", "") if isinstance(body, dict) else ""
 
 
-def create_ticket(repo: str, prefix: str, ticket: Ticket, sha: str) -> str:
-    """Create this run's ticket. Returns "created", "exists" or "denied"."""
+def _denied(status: int) -> bool:
+    """GitHub 404s resources it will not admit exist, so it is a permission
+    answer as much as 401/403 are."""
+    return status in (401, 403, 404)
+
+
+def create_identity_blob(
+    repo: str, run_id: int, attempt: int, now: float
+) -> str | None:
+    """Write the holder record the lease ref will point at. None ⇒ denied.
+
+    Created BEFORE the lease is taken, so it costs one wasted blob per failed
+    attempt. That is the right way round: an unreferenced blob is garbage GitHub
+    collects, whereas taking the lease first and describing it second would leave
+    a window where the lease is held by nobody identifiable.
+    """
+    payload = {
+        "run_id": run_id,
+        "attempt": attempt,
+        # Written by the acquirer at acquisition, which is what makes the TTL a
+        # measure of lease-HOLD time rather than of run age. A run reaches this
+        # job several jobs in (discovery, image build, manifest merge) and may
+        # have queued for runners first, none of which is lease-hold time.
+        "acquired_at": now,
+    }
     status, body = gh_request(
         "POST",
-        f"repos/{repo}/git/refs",
-        {"ref": ticket.ref(prefix), "sha": sha},
+        f"repos/{repo}/git/blobs",
+        {"content": json.dumps(payload), "encoding": "utf-8"},
+    )
+    if status in (200, 201) and isinstance(body, dict) and body.get("sha"):
+        return str(body["sha"])
+    if _denied(status):
+        return None
+    raise SystemExit(
+        f"::error::could not write the tenant lease holder record in {repo}: "
+        f"HTTP {status} {_message(body)!r}"
+    )
+
+
+def try_acquire(repo: str, ref: str, blob_sha: str) -> str:
+    """One atomic attempt. Returns "acquired", "occupied" or "denied".
+
+    The 422 is not an error path bolted on — it is the lock. GitHub evaluates
+    ref creation atomically, so of N simultaneous callers exactly one sees 201.
+    """
+    status, body = gh_request(
+        "POST", f"repos/{repo}/git/refs", {"ref": ref, "sha": blob_sha}
     )
     if status in (200, 201):
-        return "created"
-    # Ours, from an earlier job of this run (acquire runs before the install, and
-    # the release job re-derives the same name) or from a retried step.
+        return "acquired"
     if status == 422 and "already exists" in _message(body).lower():
-        return "exists"
-    if status in (401, 403, 404):
+        return "occupied"
+    if _denied(status):
         return "denied"
     raise SystemExit(
-        f"::error::could not create the tenant lease ticket {ticket.ref(prefix)} "
-        f"in {repo}: HTTP {status} {_message(body)!r}"
+        f"::error::could not take the tenant lease {ref} in {repo}: "
+        f"HTTP {status} {_message(body)!r}"
     )
 
 
-def list_tickets(repo: str, prefix: str) -> list[Ticket]:
-    """Every parseable ticket currently under the prefix, unordered."""
-    status, body = gh_request("GET", f"repos/{repo}/git/matching-refs/{prefix}/")
-    # An empty namespace answers 200 with [], but 404 is the documented shape for
-    # "no matching refs" on some paths — both mean "nobody is queued".
-    if status == 404:
-        return []
-    if status >= 400 or not isinstance(body, list):
-        raise SystemExit(
-            f"::error::could not list tenant lease tickets under refs/{prefix}/ "
-            f"in {repo}: HTTP {status} {_message(body)!r}"
+def read_holder(repo: str, ref: str) -> Holder | None:
+    """Who holds `ref`, or None if it is unheld or unreadable.
+
+    None deliberately conflates "nobody holds it" with "we could not tell": both
+    mean "retry the CAS", and the CAS is authoritative. Guessing at an
+    unreadable holder is what would be dangerous.
+    """
+    # git/ref/<name> wants the ref without the leading "refs/".
+    status, body = gh_request(
+        "GET", f"repos/{repo}/git/ref/{ref.removeprefix('refs/')}"
+    )
+    if status == 404 or not isinstance(body, dict):
+        return None
+    if status >= 400:
+        print(f"::warning::could not read the tenant lease {ref} (HTTP {status}).")
+        return None
+
+    target = body.get("object") or {}
+    blob_sha = target.get("sha") if isinstance(target, dict) else None
+    if not blob_sha:
+        return None
+
+    status, blob = gh_request("GET", f"repos/{repo}/git/blobs/{blob_sha}")
+    if status >= 400 or not isinstance(blob, dict):
+        print(
+            f"::warning::the tenant lease {ref} exists but its holder record "
+            f"({blob_sha}) is unreadable (HTTP {status})."
         )
-    tickets = []
-    for entry in body:
-        if not isinstance(entry, dict):
-            continue
-        ticket = parse_ticket(str(entry.get("ref", "")))
-        if ticket is not None:
-            tickets.append(ticket)
-    return tickets
+        return None
+    return _parse_holder(blob)
 
 
-def delete_ticket(repo: str, prefix: str, ticket: Ticket) -> bool:
-    """Best-effort delete. False means it was already gone, which is not a fault:
-    two contenders can reap the same dead ticket, and only one wins the race."""
+def _parse_holder(blob: dict) -> Holder | None:
+    content = blob.get("content")
+    if not isinstance(content, str):
+        return None
+    try:
+        decoded = base64.b64decode(content)
+        record = json.loads(decoded)
+    except (ValueError, TypeError):
+        print("::warning::the tenant lease holder record is not valid JSON.")
+        return None
+    if not isinstance(record, dict):
+        return None
+    try:
+        run_id = int(record["run_id"])
+        attempt = int(record["attempt"])
+    except (KeyError, TypeError, ValueError):
+        print("::warning::the tenant lease holder record names no run.")
+        return None
+    acquired_at = record.get("acquired_at")
+    return Holder(
+        run_id=run_id,
+        attempt=attempt,
+        acquired_at=float(acquired_at)
+        if isinstance(acquired_at, (int, float))
+        else None,
+    )
+
+
+def release_ref(repo: str, ref: str) -> bool:
+    """Delete the lease ref. False ⇒ it was already gone, which is not a fault."""
     status, _body = gh_request(
-        "DELETE", f"repos/{repo}/git/refs/{prefix}/{ticket.name}"
+        "DELETE", f"repos/{repo}/git/refs/{ref.removeprefix('refs/')}"
     )
     return status in (200, 204)
 
 
-def run_is_live(
+def holder_is_live(
     repo: str,
-    ticket: Ticket,
+    holder: Holder,
     *,
     ttl_seconds: int,
-    now=None,
+    now: float,
 ) -> bool:
-    """Is the run holding `ticket` still going?
+    """Is the lease still legitimately held?
 
-    Errs towards True. A transient API failure that read as "dead" would hand
-    the tenant to a second run while the first is mid-install — the exact race
-    the lease exists to prevent — whereas erring towards "live" only costs the
+    Errs towards True. Reading a transient API failure as "dead" would break a
+    live holder's lease and hand the tenant to a second installer — the race
+    this module exists to close — whereas erring towards "live" only costs the
     waiter another poll interval.
     """
-    status, body = gh_request("GET", f"repos/{repo}/actions/runs/{ticket.run_id}")
+    status, body = gh_request("GET", f"repos/{repo}/actions/runs/{holder.run_id}")
     if status == 404:
         # The run was deleted, or never existed. Nothing will ever release this.
         return False
     if status >= 400 or not isinstance(body, dict):
         print(
-            f"::warning::could not read run {ticket.run_id} in {repo} "
+            f"::warning::could not read run {holder.run_id} in {repo} "
             f"(HTTP {status}); treating its tenant lease as still held."
         )
         return True
     if body.get("status") == _COMPLETED:
         return False
-    if ttl_seconds > 0:
-        age = _run_age_seconds(body, now=now)
-        if age is not None and age > ttl_seconds:
-            print(
-                f"::warning::run {ticket.run_id} in {repo} still reports "
-                f"'{body.get('status')}' after {int(age)}s, past the "
-                f"{ttl_seconds}s tenant lease TTL — breaking the lease. If that "
-                "run is genuinely still installing, raise ttl-seconds."
-            )
-            return False
+    if ttl_seconds <= 0 or holder.acquired_at is None:
+        return True
+
+    # Sanity-check the holder's own timestamp against its run before trusting it.
+    # A lease cannot have been acquired before the run that took it existed, so an
+    # earlier acquired_at means the record is wrong — a clock far out of step, or a
+    # corrupted write. Believing it would make the hold time enormous and break a
+    # LIVE holder's lease on the first poll, which is the expensive direction.
+    # Erring towards "live" costs a waiter one poll interval.
+    #
+    # A run object with no created_at at all gets the same treatment. It should
+    # never happen, so it means something has changed underneath us, and the
+    # holder's run status is then the only evidence worth acting on.
+    run_started = _timestamp(body.get("created_at"))
+    if run_started is None:
+        return True
+    if holder.acquired_at < run_started:
+        print(
+            f"::warning::the tenant lease record for run {holder.run_id} claims an "
+            "acquisition time before that run existed, so it is not trustworthy; "
+            "ignoring the TTL and treating the lease as held. Its run status is "
+            "still authoritative."
+        )
+        return True
+
+    held_for = now - holder.acquired_at
+    if held_for > ttl_seconds:
+        print(
+            f"::warning::run {holder.run_id} has held the tenant lease for "
+            f"{int(held_for)}s, past the {ttl_seconds}s TTL, and still reports "
+            f"'{body.get('status')}' — breaking it. If that run is genuinely "
+            "still working, raise ttl-seconds."
+        )
+        return False
     return True
 
 
-def _run_age_seconds(run_body: dict, *, now=None) -> float | None:
-    """Seconds since the run was CREATED, or None if the API did not say.
-
-    Note what this is not: it is not how long the lease has been held. The lease
-    is taken several jobs into the run (discovery, then the per-arch image build,
-    then the manifest merge), and a run can also sit waiting for runners before
-    any of that. All of it counts here.
-
-    That is why the TTL has to be bounded by the whole chain and not by the
-    install-plus-legs span alone. Anchoring on creation and sizing the TTL for
-    only the part after acquisition would let the backstop fire on a *healthy*
-    holder that queued for a while — reaping a live mid-install ticket and
-    handing the tenant to a second installer, which is precisely the race the
-    lease exists to close. ``test_prepare_tenant_wiring.py`` derives the required
-    bound from the workflow's own job timeouts so it cannot drift out of date.
-
-    Only the TTL backstop uses this, so clock skew between the runner and GitHub
-    is immaterial at the hours-long scale it operates on. Queue ordering
-    deliberately does not depend on any clock — see the module docstring.
-    """
-    created = run_body.get("created_at")
-    if not isinstance(created, str) or not created:
+def _timestamp(value: object) -> float | None:
+    """Parse an ISO-8601 GitHub timestamp to a POSIX float, or None."""
+    if not isinstance(value, str) or not value:
         return None
     try:
-        stamp = datetime.fromisoformat(created.replace("Z", "+00:00"))
+        stamp = datetime.fromisoformat(value.replace("Z", "+00:00"))
     except ValueError:
         return None
     if stamp.tzinfo is None:
         stamp = stamp.replace(tzinfo=timezone.utc)
-    current = now() if now is not None else datetime.now(timezone.utc)
-    return (current - stamp).total_seconds()
+    return stamp.timestamp()
 
 
 def acquire(
     repo: str,
-    prefix: str,
-    ticket: Ticket,
-    sha: str,
+    ref: str,
+    run_id: int,
+    attempt: int,
     *,
     wait_seconds: int,
     poll_seconds: int,
     ttl_seconds: int,
     sleep=time.sleep,
-    now=None,
-) -> tuple[str, Ticket | None]:
+    clock=time.time,
+) -> tuple[str, Holder | None]:
     """Take the lease, or report why not.
 
-    Returns ("acquired" | "disabled" | "timeout", blocking_ticket_or_None).
+    Returns ("acquired" | "disabled" | "timeout", blocking_holder_or_None).
     """
-    outcome = create_ticket(repo, prefix, ticket, sha)
-    if outcome == "denied":
-        print(
-            "::warning::this repository will not let the run write git refs, so "
-            "the (app, cloud) tenant lease is disabled for this run and e2e "
-            "proceeds unserialised. Grant the lease job 'contents: write' to "
-            "enable it. Each e2e leg still asserts the installed version "
-            "independently (FND-31), so a wrong-version run cannot pass "
-            "silently — it just fails less informatively."
-        )
-        return "disabled", None
-    print(f"Ticket {ticket.ref(prefix)} {outcome}.")
-
-    # Attempt-counted rather than deadline-checked, so the budget needs no clock
-    # (and tests need no clock stub). Ceiling division: a budget that is not an
-    # exact multiple of the interval still gets its final full attempt.
+    # Attempt-counted rather than deadline-checked so the budget needs no clock
+    # comparison. Ceiling division: a budget that is not an exact multiple of the
+    # interval still gets its final full attempt.
     max_attempts = max(1, math.ceil(wait_seconds / poll_seconds))
 
-    blocker: Ticket | None = None
-    for attempt in range(1, max_attempts + 1):
-        tickets = list_tickets(repo, prefix)
-        if ticket not in tickets:
-            # Either replica lag, or a peer reaped us after misreading this run
-            # as finished. Re-creating is safe and position-preserving: the name
-            # is derived from the run, so we land back in the same place in line.
-            if create_ticket(repo, prefix, ticket, sha) == "denied":
-                print(
-                    "::warning::lost the tenant lease ticket and cannot recreate "
-                    "it; proceeding unserialised."
-                )
-                return "disabled", None
-            tickets.append(ticket)
-
-        ordered = sorted(tickets)
-        blocker = None
-        for candidate in ordered:
-            if candidate == ticket:
-                break
-            if run_is_live(repo, candidate, ttl_seconds=ttl_seconds, now=now):
-                blocker = candidate
-                break
+    blocker: Holder | None = None
+    for attempt_number in range(1, max_attempts + 1):
+        blob_sha = create_identity_blob(repo, run_id, attempt, clock())
+        if blob_sha is None:
             print(
-                f"Reaping the tenant lease ticket of run {candidate.run_id} "
-                f"(attempt {candidate.attempt}) — that run is over."
+                "::warning::this repository will not let the run write git refs, "
+                "so the (app, cloud) tenant lease is disabled for this run and "
+                "e2e proceeds unserialised. Grant the lease job 'contents: write' "
+                "to enable it. Each e2e leg still asserts the installed version "
+                "independently (FND-31), so a wrong-version run cannot pass "
+                "silently — it just fails less informatively."
             )
-            delete_ticket(repo, prefix, candidate)
+            return "disabled", None
 
-        if blocker is None:
-            print(f"Tenant lease acquired: refs/{prefix}/{ticket.name}")
+        outcome = try_acquire(repo, ref, blob_sha)
+        if outcome == "denied":
+            print(
+                "::warning::this repository will not let the run create the tenant "
+                "lease ref; proceeding unserialised. See the note above."
+            )
+            return "disabled", None
+        if outcome == "acquired":
+            print(f"Tenant lease acquired: {ref}")
             return "acquired", None
 
-        ahead = ordered.index(blocker) + 1
-        print(
-            f"[{attempt}/{max_attempts}] waiting for the {prefix} tenant lease — "
-            f"held by run {blocker.run_id} ({blocker.run_url(repo)}), "
-            f"{ahead} ticket(s) ahead of this run."
-        )
-        if attempt < max_attempts:
+        # Occupied. Find out by whom, and whether that claim is still good.
+        blocker = read_holder(repo, ref)
+        if blocker is None:
+            # Either it was released between the CAS and the read, or we could
+            # not read it. Either way the CAS on the next pass is authoritative.
+            print("The tenant lease is held but its holder is unreadable; retrying.")
+        elif blocker.is_me(run_id, attempt):
+            # A retried step, or a re-run of this same attempt. Already ours.
+            print(f"Tenant lease already held by this run: {ref}")
+            return "acquired", None
+        elif not holder_is_live(repo, blocker, ttl_seconds=ttl_seconds, now=clock()):
+            print(
+                f"Reaping the tenant lease of run {blocker.run_id} "
+                f"(attempt {blocker.attempt}) — that run is over."
+            )
+            release_ref(repo, ref)
+            # Straight back to the CAS rather than sleeping: the tenant is free
+            # now, and any other waiter is racing us for it on equal terms.
+            continue
+        else:
+            print(
+                f"[{attempt_number}/{max_attempts}] waiting for {ref} — held by "
+                f"run {blocker.run_id} ({blocker.run_url(repo)})."
+            )
+
+        if attempt_number < max_attempts:
             sleep(poll_seconds)
 
     return "timeout", blocker
 
 
-def release(repo: str, prefix: str, ticket: Ticket) -> bool:
-    """Give up this run's ticket. Never fails the job — a missed release is
-    reaped by the next contender, which is what makes a cancelled run (whose
-    release job never starts) harmless."""
-    deleted = delete_ticket(repo, prefix, ticket)
-    if deleted:
-        print(f"Tenant lease released: refs/{prefix}/{ticket.name}")
-    else:
+def release(repo: str, ref: str, run_id: int, attempt: int) -> bool:
+    """Give up this run's lease, but only if it is actually ours.
+
+    The ref name is shared by every contender for the tenant, so unlike a
+    per-run name it is possible to delete somebody else's lease. Ownership is
+    therefore checked first.
+
+    The check-then-delete is not atomic (the API offers no conditional delete),
+    but the window is closed by the liveness rule rather than by luck: this runs
+    while our own run is still ``in_progress``, so no contender is entitled to
+    reap us, and nobody else can be holding the lease for us to delete by
+    mistake. The TTL could in principle break our lease while we are live, which
+    is one more reason it errs long.
+    """
+    holder = read_holder(repo, ref)
+    if holder is None:
+        print(f"No tenant lease to release at {ref} — already reaped.")
+        return False
+    if not holder.is_me(run_id, attempt):
         print(
-            f"No tenant lease ticket to release at refs/{prefix}/{ticket.name} "
-            "— already reaped."
+            f"::warning::not releasing {ref}: it is held by run {holder.run_id} "
+            f"(attempt {holder.attempt}), not this run. Ours was most likely "
+            "broken by the TTL, or reaped after this run was misread as finished."
         )
-    return deleted
+        return False
+    if release_ref(repo, ref):
+        print(f"Tenant lease released: {ref}")
+        return True
+    print(f"No tenant lease to release at {ref} — already reaped.")
+    return False
 
 
 def write_outputs(outputs: dict[str, str], path: str | None) -> None:
@@ -485,7 +560,7 @@ def write_outputs(outputs: dict[str, str], path: str | None) -> None:
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Acquire or release a tenant lease.")
     parser.add_argument("--mode", required=True, choices=("acquire", "release"))
-    parser.add_argument("--repo", required=True, help="owner/repo the tickets live in.")
+    parser.add_argument("--repo", required=True, help="owner/repo the lease lives in.")
     parser.add_argument("--app", required=True, help="App under test (lease key part).")
     parser.add_argument(
         "--cloud", default="", help="Cloud (lease key part); empty = single tenant."
@@ -495,33 +570,28 @@ def main(argv: list[str] | None = None) -> int:
         "--run-attempt", required=True, type=int, help="github.run_attempt"
     )
     parser.add_argument(
-        "--sha", default="", help="Commit the ticket ref points at (acquire only)."
-    )
-    parser.add_argument(
         "--wait-seconds",
         type=int,
         default=5400,
-        help="How long to queue for the tenant before giving up (default 90min).",
+        help="How long to keep trying for the tenant before giving up (default 90min).",
     )
     parser.add_argument(
         "--poll-seconds",
         type=int,
         default=30,
-        help="Gap between queue checks. Two API calls per poll, so this also sets "
-        "the load on the 1000/hour GITHUB_TOKEN budget (default 30s).",
+        help="Gap between attempts. Each contended attempt costs a handful of API "
+        "calls, so this also sets the draw on the 1000/hour GITHUB_TOKEN budget.",
     )
     parser.add_argument(
         "--ttl-seconds",
         type=int,
-        default=43200,
-        help="Run AGE at which a still-'in_progress' holder is treated as wedged "
-        "and its lease broken. Measured from run creation, so it must exceed the "
-        "whole chain — discovery, image build, manifest merge, the lease wait "
-        "itself, the install and the legs — plus runner queue time, which has no "
-        "timeout at all. Default 12h against a ~5.5h chain. Deliberately "
-        "generous: the operator-facing signal for a stuck tenant is the wait "
-        "budget failing loudly after 90min, not this. All this does is stop a "
-        "ticket being immortal, and firing it early costs a concurrent install.",
+        default=14400,
+        help="How long a holder may HOLD the lease (measured from the acquisition "
+        "time it recorded, not from run age) before a waiter treats it as wedged "
+        "and breaks it. Must exceed the longest legitimate hold — the install plus "
+        "the leg ceiling — because breaking a live holder's lease puts a second "
+        "installer on the tenant. Default 4h against a 40min+120min hold. 0 "
+        "disables the backstop.",
     )
     parser.add_argument(
         "--on-timeout",
@@ -534,11 +604,9 @@ def main(argv: list[str] | None = None) -> int:
 
     # Bounds-checked up front rather than left to fail at the point of use.
     # poll_seconds=0 is a ZeroDivisionError in the attempt-count arithmetic and a
-    # negative one reaches sleep() as a ValueError — both loud rather than silently
-    # wrong, but both arrive as a traceback several steps from the input that
-    # caused them, which is a poor trade for one comparison. These come from
-    # action inputs with safe defaults, so this is a guard against a typo in a
-    # caller's YAML, not against hostile input.
+    # negative one reaches sleep() as a ValueError — both loud rather than
+    # silently wrong, but both arrive as a traceback several steps from the input
+    # that caused them.
     if args.poll_seconds < 1:
         raise SystemExit(
             f"::error::--poll-seconds must be at least 1, got {args.poll_seconds}"
@@ -553,21 +621,17 @@ def main(argv: list[str] | None = None) -> int:
             "(0 disables the TTL backstop)"
         )
 
-    prefix = lease_prefix(args.app, args.cloud)
-    ticket = Ticket(args.run_id, args.run_attempt)
+    ref = lease_ref(args.app, args.cloud)
 
     if args.mode == "release":
-        release(args.repo, prefix, ticket)
+        release(args.repo, ref, args.run_id, args.run_attempt)
         return 0
-
-    if not args.sha:
-        raise SystemExit("::error::--sha is required to acquire a lease")
 
     state, blocker = acquire(
         args.repo,
-        prefix,
-        ticket,
-        args.sha,
+        ref,
+        args.run_id,
+        args.run_attempt,
         wait_seconds=args.wait_seconds,
         poll_seconds=args.poll_seconds,
         ttl_seconds=args.ttl_seconds,
@@ -576,7 +640,7 @@ def main(argv: list[str] | None = None) -> int:
         {
             "acquired": "true" if state == "acquired" else "false",
             "state": state,
-            "lease-ref": ticket.ref(prefix),
+            "lease-ref": ref,
             "holder-run-id": str(blocker.run_id) if blocker else "",
         },
         os.environ.get("GITHUB_OUTPUT"),
@@ -592,12 +656,12 @@ def main(argv: list[str] | None = None) -> int:
     )
     if args.on_timeout == "warn":
         print(
-            f"::warning::gave up waiting for the {prefix} tenant lease after "
-            f"{args.wait_seconds}s and is proceeding unserialised.{held_by}"
+            f"::warning::gave up waiting for {ref} after {args.wait_seconds}s and "
+            f"is proceeding unserialised.{held_by}"
         )
         return 0
     print(
-        f"::error::could not get the {prefix} tenant lease within "
+        f"::error::could not get the tenant lease {ref} within "
         f"{args.wait_seconds}s.{held_by} Nothing is wrong with this change — the "
         "tenant is busy. Re-run this job once that run finishes, or raise "
         "wait-seconds if queueing this deep is expected."

--- a/.github/scripts/tests/test_e2e_tenant_lease.py
+++ b/.github/scripts/tests/test_e2e_tenant_lease.py
@@ -4,16 +4,26 @@ Co-located module (checked out with the composite action in consumer repos); the
 test lives here with the other action-script tests.
 
 The HTTP client is stubbed at the ``run()`` seam with a fake that speaks real
-curl-shaped responses, so status-code handling — 422 "already exists" vs 403
-"no permission" vs a genuine error — is exercised through the same parser
-production uses rather than around it.
+curl-shaped responses, so status-code handling — 422 "already exists" (which IS
+the lock), 403 "no permission", 500 transient — is exercised through the same
+parser production uses rather than around it.
+
+A note on what the first version of these tests got wrong, since it is the whole
+reason this file is shaped the way it is. The original protocol was an ordered
+ticket queue, and every test stubbed a ref listing in which the peer's ticket
+already existed. That made the untested case — a contender arriving *after*
+another had already acquired — the one that actually happened on the first live
+run, where both runs acquired and both installed onto the same tenant. So the
+tests below deliberately drive acquisition through the sequence of API answers a
+second contender really sees, rather than through a tidy snapshot.
 """
 
 from __future__ import annotations
 
+import base64
 import json
 import sys
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
@@ -23,23 +33,23 @@ sys.path.insert(
 )
 
 from e2e_tenant_lease import (  # noqa: E402
-    Ticket,
+    Holder,
     acquire,
-    create_ticket,
-    delete_ticket,
-    lease_prefix,
-    list_tickets,
+    create_identity_blob,
+    holder_is_live,
+    lease_ref,
     main,
-    parse_ticket,
+    read_holder,
     release,
-    run_is_live,
+    release_ref,
     slug,
+    try_acquire,
     write_outputs,
 )
 
 REPO = "atlanhq/atlan-example-app"
-PREFIX = "e2e-tenant-lease/example/aws"
-SHA = "a" * 40
+REF = "refs/e2e-tenant-lease/example/aws/holder"
+BLOB = "b" * 40
 
 
 # --- fake HTTP client ------------------------------------------------------
@@ -48,15 +58,19 @@ SHA = "a" * 40
 class FakeHTTP:
     """Records requests and replays queued curl-shaped responses.
 
-    Keyed by (method, path-prefix) so a test only has to describe the calls it
-    cares about; anything unmatched raises rather than silently answering 200,
-    which is what keeps a test from passing because production stopped making a
-    call it was supposed to make.
+    Keyed by (method, path-fragment) so a test only describes the calls it cares
+    about; anything unmatched raises rather than silently answering 200, which is
+    what keeps a test from passing because production stopped making a call it
+    was supposed to make.
+
+    A route with several responses pops one per call, so a test can express
+    "occupied, then free" — the sequence, not just the snapshot.
     """
 
     def __init__(self) -> None:
         self.routes: dict[tuple[str, str], list[tuple[int, object]]] = {}
         self.calls: list[tuple[str, str]] = []
+        self.payloads: list[dict] = []
 
     def route(self, method: str, contains: str, *responses: tuple[int, object]) -> None:
         self.routes[(method, contains)] = list(responses)
@@ -65,6 +79,8 @@ class FakeHTTP:
         method = cmd[cmd.index("-X") + 1]
         url = cmd[-1]
         self.calls.append((method, url))
+        if "-d" in cmd:
+            self.payloads.append(json.loads(cmd[cmd.index("-d") + 1]))
         for (route_method, contains), responses in self.routes.items():
             if route_method != method or contains not in url:
                 continue
@@ -72,6 +88,9 @@ class FakeHTTP:
             payload = "" if body is None else json.dumps(body)
             return _completed(f"HTTP/2 {status}\r\n\r\n{payload}")
         raise AssertionError(f"unstubbed request: {method} {url}")
+
+    def count(self, method: str, contains: str) -> int:
+        return len([c for c in self.calls if c[0] == method and contains in c[1]])
 
 
 class _completed:
@@ -89,8 +108,20 @@ def http(monkeypatch: pytest.MonkeyPatch) -> FakeHTTP:
     return fake
 
 
-def _ref(run_id: int, attempt: int = 1) -> dict:
-    return {"ref": f"refs/{PREFIX}/{run_id}-{attempt}"}
+def _holder_blob(run_id: int, attempt: int = 1, acquired_at: float | None = 1000.0):
+    record = {"run_id": run_id, "attempt": attempt}
+    if acquired_at is not None:
+        record["acquired_at"] = acquired_at
+    encoded = base64.b64encode(json.dumps(record).encode()).decode()
+    return {"content": encoded, "encoding": "base64"}
+
+
+def _ref_body(sha: str = BLOB):
+    return {"ref": REF, "object": {"sha": sha, "type": "blob"}}
+
+
+def _stub_blob_write(http: FakeHTTP) -> None:
+    http.route("POST", "/git/blobs", (201, {"sha": BLOB}))
 
 
 # --- keying ----------------------------------------------------------------
@@ -120,198 +151,257 @@ def test_slug_of_only_unsafe_characters_falls_back() -> None:
     assert slug("///") == "default"
 
 
-def test_lease_prefix_combines_app_and_cloud() -> None:
-    assert lease_prefix("openapi", "aws") == "e2e-tenant-lease/openapi/aws"
+def test_lease_ref_is_fixed_for_a_tenant() -> None:
+    """The name must carry NO per-run component. Collision between contenders is
+    the signal the whole design runs on — a name only one run could guess is a
+    name that can never collide, which is what the ticket-queue version got
+    wrong."""
+    assert lease_ref("openapi", "aws") == lease_ref("openapi", "aws")
+    assert lease_ref("openapi", "aws") == "refs/e2e-tenant-lease/openapi/aws/holder"
 
 
-def test_lease_prefix_defaults_the_cloud() -> None:
-    assert lease_prefix("openapi", "") == "e2e-tenant-lease/openapi/default"
+def test_lease_ref_defaults_the_cloud() -> None:
+    assert lease_ref("openapi", "") == "refs/e2e-tenant-lease/openapi/default/holder"
 
 
 def test_different_clouds_of_one_app_do_not_share_a_lease() -> None:
-    # Per-cloud tenants are independent resources; sharing a lease across them
-    # would serialise legs that have no reason to wait for each other.
-    assert lease_prefix("openapi", "aws") != lease_prefix("openapi", "gcp")
+    # Per-cloud tenants are independent resources; sharing one lease would
+    # serialise legs that have no reason to wait for each other.
+    assert lease_ref("openapi", "aws") != lease_ref("openapi", "gcp")
 
 
-# --- ticket identity and ordering -----------------------------------------
+def test_different_apps_on_one_cloud_do_not_share_a_lease() -> None:
+    # The installation is per app per tenant, so two apps do not contend.
+    assert lease_ref("openapi", "aws") != lease_ref("mysql", "aws")
 
 
-def test_ticket_name_is_derived_only_from_the_run() -> None:
-    # The whole protocol rests on this: the acquiring job and the releasing job
-    # are different jobs that must compute the same name with no shared state.
-    assert Ticket(12, 1).name == "12-1"
+# --- the CAS primitive -----------------------------------------------------
 
 
-def test_ticket_ordering_is_by_run_id() -> None:
-    assert sorted([Ticket(30, 1), Ticket(10, 1), Ticket(20, 1)]) == [
-        Ticket(10, 1),
-        Ticket(20, 1),
-        Ticket(30, 1),
-    ]
+def test_try_acquire_reports_acquired_on_201(http: FakeHTTP) -> None:
+    http.route("POST", "/git/refs", (201, {"ref": REF}))
+    assert try_acquire(REPO, REF, BLOB) == "acquired"
 
 
-def test_ticket_ordering_breaks_ties_on_attempt() -> None:
-    assert sorted([Ticket(10, 2), Ticket(10, 1)]) == [Ticket(10, 1), Ticket(10, 2)]
-
-
-def test_parse_ticket_round_trips_a_ref() -> None:
-    assert parse_ticket(f"refs/{PREFIX}/4242-2") == Ticket(4242, 2)
-
-
-@pytest.mark.parametrize(
-    "ref",
-    [
-        f"refs/{PREFIX}/not-a-ticket",
-        f"refs/{PREFIX}/12",
-        f"refs/{PREFIX}/12-",
-        f"refs/{PREFIX}/-1",
-        f"refs/{PREFIX}/12-1-99",
-    ],
-)
-def test_parse_ticket_rejects_non_tickets(ref: str) -> None:
-    assert parse_ticket(ref) is None
-
-
-# --- ref primitives --------------------------------------------------------
-
-
-def test_create_ticket_reports_created(http: FakeHTTP) -> None:
-    http.route("POST", "/git/refs", (201, {"ref": "x"}))
-    assert create_ticket(REPO, PREFIX, Ticket(1, 1), SHA) == "created"
-
-
-def test_create_ticket_treats_an_existing_ref_as_ours(http: FakeHTTP) -> None:
-    # Reached whenever a later job of the same run re-derives the ticket, and on
-    # a retried step. Not a conflict: the name identifies the run.
+def test_try_acquire_reports_occupied_on_422(http: FakeHTTP) -> None:
+    # This is the lock, not an error path: GitHub evaluates ref creation
+    # atomically, so of N simultaneous callers exactly one sees 201.
     http.route("POST", "/git/refs", (422, {"message": "Reference already exists"}))
-    assert create_ticket(REPO, PREFIX, Ticket(1, 1), SHA) == "exists"
+    assert try_acquire(REPO, REF, BLOB) == "occupied"
 
 
 @pytest.mark.parametrize("status", [401, 403, 404])
-def test_create_ticket_reports_denied_without_ref_write(
+def test_try_acquire_reports_denied_without_ref_write(
     http: FakeHTTP, status: int
 ) -> None:
     http.route("POST", "/git/refs", (status, {"message": "Resource not accessible"}))
-    assert create_ticket(REPO, PREFIX, Ticket(1, 1), SHA) == "denied"
+    assert try_acquire(REPO, REF, BLOB) == "denied"
 
 
-def test_create_ticket_raises_on_an_unrelated_422(http: FakeHTTP) -> None:
-    # A malformed ref or a bad sha is a bug in the caller, not contention — it
-    # must not be swallowed as "someone else holds the lease".
+def test_try_acquire_raises_on_an_unrelated_422(http: FakeHTTP) -> None:
+    # A malformed ref or bad sha is a bug in the caller, not contention, and must
+    # not be swallowed as "someone else holds the lease".
     http.route("POST", "/git/refs", (422, {"message": "Object does not exist"}))
     with pytest.raises(SystemExit):
-        create_ticket(REPO, PREFIX, Ticket(1, 1), SHA)
+        try_acquire(REPO, REF, BLOB)
 
 
-def test_list_tickets_parses_and_skips_foreign_refs(http: FakeHTTP) -> None:
+def test_identity_blob_records_the_run_and_its_acquisition_time(
+    http: FakeHTTP,
+) -> None:
+    # The waiter side depends on every one of these fields: run_id and attempt to
+    # tell whose lease it is, acquired_at to judge how long it has been held.
+    http.route("POST", "/git/blobs", (201, {"sha": BLOB}))
+    assert create_identity_blob(REPO, 42, 2, 1234.0) == BLOB
+    record = json.loads(http.payloads[0]["content"])
+    assert record == {"run_id": 42, "attempt": 2, "acquired_at": 1234.0}
+
+
+def test_the_lease_ref_points_at_the_identity_blob(http: FakeHTTP) -> None:
+    # One atomic creation both takes the lease and records who took it; a
+    # separate "who holds it" write would leave a window with an unidentifiable
+    # holder.
+    http.route("POST", "/git/refs", (201, {"ref": REF}))
+    try_acquire(REPO, REF, BLOB)
+    assert http.payloads[0] == {"ref": REF, "sha": BLOB}
+
+
+@pytest.mark.parametrize("status", [401, 403, 404])
+def test_identity_blob_reports_denied(http: FakeHTTP, status: int) -> None:
+    http.route("POST", "/git/blobs", (status, {"message": "nope"}))
+    assert create_identity_blob(REPO, 1, 1, 0.0) is None
+
+
+# --- reading the holder ----------------------------------------------------
+
+
+def test_read_holder_returns_the_recorded_run(http: FakeHTTP) -> None:
+    http.route("GET", "/git/ref/", (200, _ref_body()))
+    http.route("GET", "/git/blobs/", (200, _holder_blob(500, 1, 900.0)))
+    assert read_holder(REPO, REF) == Holder(run_id=500, attempt=1, acquired_at=900.0)
+
+
+def test_read_holder_returns_none_when_unheld(http: FakeHTTP) -> None:
+    http.route("GET", "/git/ref/", (404, {"message": "Not Found"}))
+    assert read_holder(REPO, REF) is None
+
+
+def test_read_holder_returns_none_when_the_record_is_unreadable(
+    http: FakeHTTP,
+) -> None:
+    # Conflating "unheld" with "cannot tell" is deliberate: both mean "retry the
+    # CAS", and the CAS is the authority. Guessing at an unreadable holder is
+    # what would be dangerous.
+    http.route("GET", "/git/ref/", (200, _ref_body()))
+    http.route("GET", "/git/blobs/", (500, {"message": "boom"}))
+    assert read_holder(REPO, REF) is None
+
+
+def test_read_holder_tolerates_a_record_that_is_not_json(http: FakeHTTP) -> None:
+    http.route("GET", "/git/ref/", (200, _ref_body()))
     http.route(
         "GET",
-        "/git/matching-refs/",
-        (200, [_ref(10), {"ref": f"refs/{PREFIX}/README"}, _ref(20, 3)]),
+        "/git/blobs/",
+        (200, {"content": base64.b64encode(b"not json").decode()}),
     )
-    assert list_tickets(REPO, PREFIX) == [Ticket(10, 1), Ticket(20, 3)]
+    assert read_holder(REPO, REF) is None
 
 
-def test_list_tickets_treats_404_as_an_empty_queue(http: FakeHTTP) -> None:
-    http.route("GET", "/git/matching-refs/", (404, {"message": "Not Found"}))
-    assert list_tickets(REPO, PREFIX) == []
+def test_read_holder_tolerates_a_record_naming_no_run(http: FakeHTTP) -> None:
+    http.route("GET", "/git/ref/", (200, _ref_body()))
+    http.route(
+        "GET",
+        "/git/blobs/",
+        (200, {"content": base64.b64encode(b'{"nope":1}').decode()}),
+    )
+    assert read_holder(REPO, REF) is None
 
 
-def test_list_tickets_raises_on_a_server_error(http: FakeHTTP) -> None:
-    # Silently reading "no queue" from a 500 would hand the tenant to every
-    # waiting run at once.
-    http.route("GET", "/git/matching-refs/", (500, {"message": "boom"}))
-    with pytest.raises(SystemExit):
-        list_tickets(REPO, PREFIX)
-
-
-def test_delete_ticket_reports_success(http: FakeHTTP) -> None:
-    http.route("DELETE", "/git/refs/", (204, None))
-    assert delete_ticket(REPO, PREFIX, Ticket(1, 1)) is True
-
-
-def test_delete_ticket_tolerates_an_already_reaped_ticket(http: FakeHTTP) -> None:
-    # Two contenders can reap the same dead ticket; the loser must not fail.
-    http.route("DELETE", "/git/refs/", (422, {"message": "Reference does not exist"}))
-    assert delete_ticket(REPO, PREFIX, Ticket(1, 1)) is False
+def test_read_holder_tolerates_a_record_without_an_acquisition_time(
+    http: FakeHTTP,
+) -> None:
+    # Then the TTL simply cannot judge, and run liveness is the only evidence.
+    http.route("GET", "/git/ref/", (200, _ref_body()))
+    http.route("GET", "/git/blobs/", (200, _holder_blob(7, 1, acquired_at=None)))
+    assert read_holder(REPO, REF) == Holder(run_id=7, attempt=1, acquired_at=None)
 
 
 # --- holder liveness -------------------------------------------------------
 
 
+def _live(status: str = "in_progress", created_at: str | None = None):
+    """A run object. `created_at` is what the TTL cross-checks the holder's own
+    acquisition timestamp against, so TTL tests have to supply it."""
+    body: dict[str, object] = {"status": status}
+    if created_at is not None:
+        body["created_at"] = created_at
+    return (200, body)
+
+
+#: A run that started at POSIX 900, i.e. just before the holders below acquire at
+#: 1000. Spelled as the ISO string GitHub actually returns.
+_RUN_STARTED_900 = (
+    datetime.fromtimestamp(900, tz=timezone.utc).isoformat().replace("+00:00", "Z")
+)
+
+
 def test_holder_in_progress_is_live(http: FakeHTTP) -> None:
-    http.route("GET", "/actions/runs/", (200, {"status": "in_progress"}))
-    assert run_is_live(REPO, Ticket(1, 1), ttl_seconds=0) is True
+    http.route("GET", "/actions/runs/", _live())
+    holder = Holder(1, 1, 0.0)
+    assert holder_is_live(REPO, holder, ttl_seconds=0, now=0.0) is True
 
 
 def test_holder_completed_is_dead(http: FakeHTTP) -> None:
-    http.route("GET", "/actions/runs/", (200, {"status": "completed"}))
-    assert run_is_live(REPO, Ticket(1, 1), ttl_seconds=0) is False
+    http.route("GET", "/actions/runs/", _live("completed"))
+    holder = Holder(1, 1, 0.0)
+    assert holder_is_live(REPO, holder, ttl_seconds=0, now=0.0) is False
 
 
 def test_holder_deleted_run_is_dead(http: FakeHTTP) -> None:
-    # Nothing will ever release this ticket, so it has to be breakable.
+    # Nothing will ever release this lease, so it has to be breakable.
     http.route("GET", "/actions/runs/", (404, {"message": "Not Found"}))
-    assert run_is_live(REPO, Ticket(1, 1), ttl_seconds=0) is False
+    holder = Holder(1, 1, 0.0)
+    assert holder_is_live(REPO, holder, ttl_seconds=0, now=0.0) is False
 
 
 @pytest.mark.parametrize("status", ["queued", "waiting", "requested", "pending"])
 def test_holder_pre_start_statuses_are_live(http: FakeHTTP, status: str) -> None:
-    # A queued run has a place in line and will install; treating it as dead
+    # A queued run still holds its lease and will use it; treating it as dead
     # would let a later run install underneath it.
-    http.route("GET", "/actions/runs/", (200, {"status": status}))
-    assert run_is_live(REPO, Ticket(1, 1), ttl_seconds=0) is True
+    http.route("GET", "/actions/runs/", _live(status))
+    holder = Holder(1, 1, 0.0)
+    assert holder_is_live(REPO, holder, ttl_seconds=0, now=0.0) is True
 
 
 def test_holder_is_assumed_live_on_an_api_error(http: FakeHTTP) -> None:
-    # Erring towards "dead" on a transient 500 would put two runs on one tenant
-    # mid-install — the exact race the lease exists to prevent. Erring towards
-    # "live" costs one poll interval.
+    # Erring towards "dead" on a transient 500 would break a live holder's lease
+    # and put a second installer on the tenant. Erring towards "live" costs one
+    # poll interval.
     http.route("GET", "/actions/runs/", (500, {"message": "boom"}))
-    assert run_is_live(REPO, Ticket(1, 1), ttl_seconds=0) is True
+    holder = Holder(1, 1, 0.0)
+    assert holder_is_live(REPO, holder, ttl_seconds=0, now=0.0) is True
 
 
-def test_holder_past_ttl_is_broken(http: FakeHTTP) -> None:
-    http.route(
-        "GET",
-        "/actions/runs/",
-        (200, {"status": "in_progress", "created_at": "2020-01-01T00:00:00Z"}),
-    )
-    assert run_is_live(REPO, Ticket(1, 1), ttl_seconds=60) is False
+def test_ttl_measures_hold_time_not_run_age(http: FakeHTTP) -> None:
+    """The TTL is anchored to the acquisition time the holder recorded.
+
+    A run reaches the lease job several jobs in and may have queued for runners
+    first; none of that is lease-hold time. Anchoring on run age instead made the
+    TTL fire on healthy holders, which is the expensive direction — it reaps a
+    live mid-install holder.
+    """
+    http.route("GET", "/actions/runs/", _live(created_at=_RUN_STARTED_900))
+    # Acquired at t=1000, now t=1100: held for 100s, well inside a 4h TTL, even
+    # though the run itself may be hours old.
+    holder = Holder(1, 1, acquired_at=1000.0)
+    assert holder_is_live(REPO, holder, ttl_seconds=14400, now=1100.0) is True
 
 
-def test_holder_within_ttl_is_left_alone(http: FakeHTTP) -> None:
-    started = datetime.now(timezone.utc) - timedelta(seconds=30)
-    http.route(
-        "GET",
-        "/actions/runs/",
-        (200, {"status": "in_progress", "created_at": started.isoformat()}),
-    )
-    assert run_is_live(REPO, Ticket(1, 1), ttl_seconds=3600) is True
+def test_holder_past_the_hold_ttl_is_broken(http: FakeHTTP) -> None:
+    http.route("GET", "/actions/runs/", _live(created_at=_RUN_STARTED_900))
+    holder = Holder(1, 1, acquired_at=1000.0)
+    assert holder_is_live(REPO, holder, ttl_seconds=60, now=2000.0) is False
 
 
 def test_ttl_of_zero_never_breaks_a_live_holder(http: FakeHTTP) -> None:
-    http.route(
-        "GET",
-        "/actions/runs/",
-        (200, {"status": "in_progress", "created_at": "2020-01-01T00:00:00Z"}),
-    )
-    assert run_is_live(REPO, Ticket(1, 1), ttl_seconds=0) is True
+    http.route("GET", "/actions/runs/", _live(created_at=_RUN_STARTED_900))
+    holder = Holder(1, 1, acquired_at=1000.0)
+    assert holder_is_live(REPO, holder, ttl_seconds=0, now=10**9) is True
 
 
-def test_holder_without_a_created_at_is_left_alone(http: FakeHTTP) -> None:
-    # No timestamp means the TTL backstop cannot judge; the run's own status is
-    # then the only evidence, and it says live.
-    http.route("GET", "/actions/runs/", (200, {"status": "in_progress"}))
-    assert run_is_live(REPO, Ticket(1, 1), ttl_seconds=60) is True
+def test_a_holder_without_an_acquisition_time_is_left_alone(http: FakeHTTP) -> None:
+    http.route("GET", "/actions/runs/", _live(created_at=_RUN_STARTED_900))
+    holder = Holder(1, 1, acquired_at=None)
+    assert holder_is_live(REPO, holder, ttl_seconds=60, now=10**9) is True
 
 
-def test_holder_with_an_unparseable_created_at_is_left_alone(http: FakeHTTP) -> None:
-    http.route(
-        "GET", "/actions/runs/", (200, {"status": "in_progress", "created_at": "soon"})
-    )
-    assert run_is_live(REPO, Ticket(1, 1), ttl_seconds=60) is True
+def test_an_acquisition_time_predating_its_run_is_not_trusted(http: FakeHTTP) -> None:
+    """A lease cannot have been acquired before the run that took it existed.
+
+    Found by a reproducer while fixing something else: a stale or corrupt
+    acquired_at makes the computed hold time enormous, so every waiter breaks a
+    LIVE holder's lease on its first poll and installs underneath it. The
+    timestamp is holder-written data, so it has to be checked, not believed.
+    """
+    http.route("GET", "/actions/runs/", _live(created_at=_RUN_STARTED_900))
+    holder = Holder(1, 1, acquired_at=5.0)  # long before the run started
+    assert holder_is_live(REPO, holder, ttl_seconds=60, now=10**9) is True
+
+
+def test_a_run_without_a_start_time_disables_the_ttl(http: FakeHTTP) -> None:
+    # Should never happen, so it means something changed underneath us; the run's
+    # status is then the only evidence worth acting on.
+    http.route("GET", "/actions/runs/", _live())
+    holder = Holder(1, 1, acquired_at=1000.0)
+    assert holder_is_live(REPO, holder, ttl_seconds=60, now=10**9) is True
+
+
+def test_a_run_with_an_unparseable_start_time_disables_the_ttl(
+    http: FakeHTTP,
+) -> None:
+    http.route("GET", "/actions/runs/", _live(created_at="whenever"))
+    holder = Holder(1, 1, acquired_at=1000.0)
+    assert holder_is_live(REPO, holder, ttl_seconds=60, now=10**9) is True
 
 
 # --- acquire ---------------------------------------------------------------
@@ -323,125 +413,138 @@ def _acquire(**kwargs):
         poll_seconds=30,
         ttl_seconds=0,
         sleep=lambda _s: None,
+        clock=lambda: 1000.0,
     )
     defaults.update(kwargs)
-    return acquire(REPO, PREFIX, Ticket(100, 1), SHA, **defaults)
+    return acquire(REPO, REF, 100, 1, **defaults)
 
 
-def test_acquire_takes_an_uncontended_lease(http: FakeHTTP) -> None:
-    http.route("POST", "/git/refs", (201, {}))
-    http.route("GET", "/git/matching-refs/", (200, [_ref(100)]))
+def test_acquire_takes_an_unheld_lease(http: FakeHTTP) -> None:
+    _stub_blob_write(http)
+    http.route("POST", "/git/refs", (201, {"ref": REF}))
     assert _acquire() == ("acquired", None)
 
 
-def test_acquire_takes_the_lease_when_it_is_the_lowest_run_id(http: FakeHTTP) -> None:
-    http.route("POST", "/git/refs", (201, {}))
-    http.route("GET", "/git/matching-refs/", (200, [_ref(200), _ref(100), _ref(300)]))
-    # No liveness call is needed or made: nothing sorts ahead of us.
-    assert _acquire() == ("acquired", None)
-    assert not [call for call in http.calls if "/actions/runs/" in call[1]]
+def test_a_late_arriver_does_not_steal_a_live_holders_lease(http: FakeHTTP) -> None:
+    """THE regression test for the bug that shipped.
+
+    Run B reached the lease job first and legitimately acquired. Run A arrived
+    15s later with a LOWER run_id, and under the ordered-ticket protocol computed
+    itself as the rightful holder and acquired too — both installed onto the same
+    tenant. Exclusion must not depend on ids at all: whoever holds it, holds it.
+    """
+    _stub_blob_write(http)
+    http.route("POST", "/git/refs", (422, {"message": "Reference already exists"}))
+    http.route("GET", "/git/ref/", (200, _ref_body()))
+    # The holder's run_id is HIGHER than ours (100), which under the old rule
+    # would have made us the winner.
+    http.route("GET", "/git/blobs/", (200, _holder_blob(99999, 1, 990.0)))
+    http.route("GET", "/actions/runs/", _live())
+
+    state, blocker = _acquire(wait_seconds=30, poll_seconds=30)
+
+    assert state == "timeout"
+    assert blocker is not None and blocker.run_id == 99999
+    # And critically: it never deleted the live holder's lease.
+    assert http.count("DELETE", "/git/refs/") == 0
 
 
-def test_acquire_waits_behind_a_live_earlier_run(http: FakeHTTP) -> None:
-    http.route("POST", "/git/refs", (201, {}))
-    http.route("GET", "/git/matching-refs/", (200, [_ref(50), _ref(100)]))
-    http.route("GET", "/actions/runs/", (200, {"status": "in_progress"}))
-    assert _acquire() == ("timeout", Ticket(50, 1))
-
-
-def test_acquire_reaps_a_dead_holder_and_proceeds(http: FakeHTTP) -> None:
-    # The case an `if: always()` release job cannot cover: a cancelled run whose
-    # release job never started. The next contender clears it in-band.
-    http.route("POST", "/git/refs", (201, {}))
-    http.route("GET", "/git/matching-refs/", (200, [_ref(50), _ref(100)]))
-    http.route("GET", "/actions/runs/", (200, {"status": "completed"}))
-    http.route("DELETE", "/git/refs/", (204, None))
-    assert _acquire() == ("acquired", None)
-    assert (
-        "DELETE",
-        f"https://api.github.com/repos/{REPO}/git/refs/{PREFIX}/50-1",
-    ) in (http.calls)
-
-
-def test_acquire_reaps_several_dead_holders_in_one_poll(http: FakeHTTP) -> None:
-    http.route("POST", "/git/refs", (201, {}))
-    http.route("GET", "/git/matching-refs/", (200, [_ref(30), _ref(40), _ref(100)]))
-    http.route("GET", "/actions/runs/", (200, {"status": "completed"}))
-    http.route("DELETE", "/git/refs/", (204, None))
-    assert _acquire() == ("acquired", None)
-    deletes = [call for call in http.calls if call[0] == "DELETE"]
-    assert len(deletes) == 2
-
-
-def test_acquire_stops_reaping_at_the_first_live_holder(http: FakeHTTP) -> None:
-    # 30 is dead, 40 is live: 40 holds the lease and 100 must not delete it.
-    http.route("POST", "/git/refs", (201, {}))
-    http.route("GET", "/git/matching-refs/", (200, [_ref(30), _ref(40), _ref(100)]))
+def test_acquire_waits_then_wins_when_the_holder_releases(http: FakeHTTP) -> None:
+    _stub_blob_write(http)
     http.route(
-        "GET",
-        "/actions/runs/",
-        (200, {"status": "completed"}),
-        (200, {"status": "in_progress"}),
+        "POST",
+        "/git/refs",
+        (422, {"message": "Reference already exists"}),
+        (201, {"ref": REF}),
     )
-    http.route("DELETE", "/git/refs/", (204, None))
-    # A single poll, so the two queued liveness answers map one-to-one onto the
-    # two tickets ahead of us.
-    assert _acquire(wait_seconds=30, poll_seconds=30) == ("timeout", Ticket(40, 1))
-    deletes = [call for call in http.calls if call[0] == "DELETE"]
-    assert len(deletes) == 1
-    assert "30-1" in deletes[0][1]
-
-
-def test_acquire_gets_the_lease_on_a_later_poll(http: FakeHTTP) -> None:
-    http.route("POST", "/git/refs", (201, {}))
-    http.route(
-        "GET",
-        "/git/matching-refs/",
-        (200, [_ref(50), _ref(100)]),
-        (200, [_ref(100)]),
-    )
-    http.route("GET", "/actions/runs/", (200, {"status": "in_progress"}))
+    http.route("GET", "/git/ref/", (200, _ref_body()))
+    http.route("GET", "/git/blobs/", (200, _holder_blob(500)))
+    http.route("GET", "/actions/runs/", _live())
     assert _acquire(wait_seconds=60, poll_seconds=30) == ("acquired", None)
 
 
-def test_acquire_recreates_a_ticket_that_vanished(http: FakeHTTP) -> None:
-    # A peer that misread this run as finished can reap us. Re-creating restores
-    # the same position, because the name is derived from the run.
-    http.route("POST", "/git/refs", (201, {}), (201, {}))
-    http.route("GET", "/git/matching-refs/", (200, []))
+def test_acquire_reaps_a_dead_holder_and_takes_the_lease(http: FakeHTTP) -> None:
+    """The case `if: always()` cannot cover — a cancelled run whose release job
+    never started. The next contender clears it in-band."""
+    _stub_blob_write(http)
+    http.route(
+        "POST",
+        "/git/refs",
+        (422, {"message": "Reference already exists"}),
+        (201, {"ref": REF}),
+    )
+    http.route("GET", "/git/ref/", (200, _ref_body()))
+    http.route("GET", "/git/blobs/", (200, _holder_blob(500)))
+    http.route("GET", "/actions/runs/", _live("completed"))
+    http.route("DELETE", "/git/refs/", (204, None))
+
     assert _acquire() == ("acquired", None)
-    assert len([call for call in http.calls if call[0] == "POST"]) == 2
+    assert http.count("DELETE", "/git/refs/") == 1
+
+
+def test_reaping_retries_the_cas_without_sleeping(http: FakeHTTP) -> None:
+    # The tenant is free the instant the dead lease is deleted; sleeping a full
+    # poll interval first would hand it to whoever wakes up sooner.
+    _stub_blob_write(http)
+    http.route(
+        "POST",
+        "/git/refs",
+        (422, {"message": "Reference already exists"}),
+        (201, {"ref": REF}),
+    )
+    http.route("GET", "/git/ref/", (200, _ref_body()))
+    http.route("GET", "/git/blobs/", (200, _holder_blob(500)))
+    http.route("GET", "/actions/runs/", _live("completed"))
+    http.route("DELETE", "/git/refs/", (204, None))
+
+    slept: list[int] = []
+    assert _acquire(sleep=slept.append) == ("acquired", None)
+    assert slept == []
+
+
+def test_acquire_treats_its_own_existing_lease_as_held(http: FakeHTTP) -> None:
+    # A retried step, or a re-run of the same attempt. Must not deadlock against
+    # itself.
+    _stub_blob_write(http)
+    http.route("POST", "/git/refs", (422, {"message": "Reference already exists"}))
+    http.route("GET", "/git/ref/", (200, _ref_body()))
+    http.route("GET", "/git/blobs/", (200, _holder_blob(100, 1)))
+    assert _acquire() == ("acquired", None)
+
+
+def test_acquire_retries_when_the_holder_is_unreadable(http: FakeHTTP) -> None:
+    # Released between the CAS and the read, or unreadable — either way the next
+    # CAS is authoritative rather than a guess.
+    _stub_blob_write(http)
+    http.route(
+        "POST",
+        "/git/refs",
+        (422, {"message": "Reference already exists"}),
+        (201, {"ref": REF}),
+    )
+    http.route("GET", "/git/ref/", (404, {"message": "Not Found"}))
+    assert _acquire() == ("acquired", None)
+
+
+def test_acquire_disables_itself_without_blob_write(http: FakeHTTP) -> None:
+    # Fail-open: the lease reduces contention, it is not what makes a
+    # wrong-version run detectable (each leg re-asserts the version, FND-31).
+    http.route("POST", "/git/blobs", (403, {"message": "Resource not accessible"}))
+    assert _acquire() == ("disabled", None)
 
 
 def test_acquire_disables_itself_without_ref_write(http: FakeHTTP) -> None:
-    # Fail-open: the lease reduces contention, it is not what makes a
-    # wrong-version run detectable (each leg re-asserts the version, FND-31).
+    _stub_blob_write(http)
     http.route("POST", "/git/refs", (403, {"message": "Resource not accessible"}))
     assert _acquire() == ("disabled", None)
 
 
-def test_acquire_disables_itself_when_recreation_is_denied(http: FakeHTTP) -> None:
-    http.route("POST", "/git/refs", (201, {}), (403, {"message": "nope"}))
-    http.route("GET", "/git/matching-refs/", (200, []))
-    assert _acquire() == ("disabled", None)
-
-
-def test_acquire_makes_two_api_calls_per_contended_poll(http: FakeHTTP) -> None:
-    # The GITHUB_TOKEN budget is 1000 requests/hour/repo, and only the current
-    # front-of-queue ticket is checked for liveness — checking every ticket every
-    # poll would blow that budget on a long queue.
-    http.route("POST", "/git/refs", (201, {}))
-    http.route("GET", "/git/matching-refs/", (200, [_ref(40), _ref(50), _ref(100)]))
-    http.route("GET", "/actions/runs/", (200, {"status": "in_progress"}))
-    _acquire(wait_seconds=30, poll_seconds=30)
-    polling_calls = [call for call in http.calls if call[0] == "GET"]
-    assert len(polling_calls) == 2
-
-
 def test_acquire_respects_the_wait_budget(http: FakeHTTP) -> None:
-    http.route("POST", "/git/refs", (201, {}))
-    http.route("GET", "/git/matching-refs/", (200, [_ref(50), _ref(100)]))
-    http.route("GET", "/actions/runs/", (200, {"status": "in_progress"}))
+    _stub_blob_write(http)
+    http.route("POST", "/git/refs", (422, {"message": "Reference already exists"}))
+    http.route("GET", "/git/ref/", (200, _ref_body()))
+    http.route("GET", "/git/blobs/", (200, _holder_blob(500)))
+    http.route("GET", "/actions/runs/", _live())
     slept: list[int] = []
     _acquire(wait_seconds=90, poll_seconds=30, sleep=slept.append)
     # 3 attempts, so 2 sleeps: the last attempt is not followed by a wait.
@@ -449,23 +552,46 @@ def test_acquire_respects_the_wait_budget(http: FakeHTTP) -> None:
 
 
 def test_acquire_always_makes_one_attempt_on_a_zero_budget(http: FakeHTTP) -> None:
-    http.route("POST", "/git/refs", (201, {}))
-    http.route("GET", "/git/matching-refs/", (200, [_ref(100)]))
+    _stub_blob_write(http)
+    http.route("POST", "/git/refs", (201, {"ref": REF}))
     assert _acquire(wait_seconds=0, poll_seconds=30) == ("acquired", None)
 
 
 # --- release ---------------------------------------------------------------
 
 
-def test_release_deletes_this_runs_ticket(http: FakeHTTP) -> None:
+def test_release_deletes_our_own_lease(http: FakeHTTP) -> None:
+    http.route("GET", "/git/ref/", (200, _ref_body()))
+    http.route("GET", "/git/blobs/", (200, _holder_blob(100, 1)))
     http.route("DELETE", "/git/refs/", (204, None))
-    assert release(REPO, PREFIX, Ticket(100, 1)) is True
-    assert http.calls[0][1].endswith(f"/git/refs/{PREFIX}/100-1")
+    assert release(REPO, REF, 100, 1) is True
 
 
-def test_release_is_quiet_when_the_ticket_is_already_gone(http: FakeHTTP) -> None:
+def test_release_refuses_to_delete_someone_elses_lease(http: FakeHTTP) -> None:
+    """The ref name is shared by every contender, so unlike a per-run name it is
+    possible to delete the wrong lease. Deleting a live holder's lease would put
+    two installers on the tenant — the failure this protocol replaced."""
+    http.route("GET", "/git/ref/", (200, _ref_body()))
+    http.route("GET", "/git/blobs/", (200, _holder_blob(777, 1)))
+    assert release(REPO, REF, 100, 1) is False
+    assert http.count("DELETE", "/git/refs/") == 0
+
+
+def test_release_distinguishes_attempts_of_the_same_run(http: FakeHTTP) -> None:
+    # A re-run is a different holder; attempt 1 must not release attempt 2's lease.
+    http.route("GET", "/git/ref/", (200, _ref_body()))
+    http.route("GET", "/git/blobs/", (200, _holder_blob(100, 2)))
+    assert release(REPO, REF, 100, 1) is False
+
+
+def test_release_is_quiet_when_the_lease_is_already_gone(http: FakeHTTP) -> None:
+    http.route("GET", "/git/ref/", (404, {"message": "Not Found"}))
+    assert release(REPO, REF, 100, 1) is False
+
+
+def test_release_ref_tolerates_an_already_deleted_ref(http: FakeHTTP) -> None:
     http.route("DELETE", "/git/refs/", (422, {"message": "Reference does not exist"}))
-    assert release(REPO, PREFIX, Ticket(100, 1)) is False
+    assert release_ref(REPO, REF) is False
 
 
 # --- outputs ---------------------------------------------------------------
@@ -498,8 +624,6 @@ def _argv(mode: str, *extra: str) -> list[str]:
         "100",
         "--run-attempt",
         "1",
-        "--sha",
-        SHA,
         *extra,
     ]
 
@@ -509,11 +633,13 @@ def test_main_acquire_exits_zero_and_reports_outputs(
 ) -> None:
     out = tmp_path / "out"
     monkeypatch.setenv("GITHUB_OUTPUT", str(out))
-    http.route("POST", "/git/refs", (201, {}))
-    http.route("GET", "/git/matching-refs/", (200, [_ref(100)]))
+    _stub_blob_write(http)
+    http.route("POST", "/git/refs", (201, {"ref": REF}))
     assert main(_argv("acquire")) == 0
-    assert "acquired=true" in out.read_text()
-    assert f"lease-ref=refs/{PREFIX}/100-1" in out.read_text()
+    written = out.read_text()
+    assert "acquired=true" in written
+    assert "state=acquired" in written
+    assert f"lease-ref={REF}" in written
 
 
 def test_main_acquire_fails_loudly_on_timeout(
@@ -521,39 +647,32 @@ def test_main_acquire_fails_loudly_on_timeout(
 ) -> None:
     out = tmp_path / "out"
     monkeypatch.setenv("GITHUB_OUTPUT", str(out))
-    http.route("POST", "/git/refs", (201, {}))
-    http.route("GET", "/git/matching-refs/", (200, [_ref(50), _ref(100)]))
-    http.route("GET", "/actions/runs/", (200, {"status": "in_progress"}))
+    _stub_blob_write(http)
+    http.route("POST", "/git/refs", (422, {"message": "Reference already exists"}))
+    http.route("GET", "/git/ref/", (200, _ref_body()))
+    http.route("GET", "/git/blobs/", (200, _holder_blob(555)))
+    http.route("GET", "/actions/runs/", _live())
     assert main(_argv("acquire", "--wait-seconds", "1", "--poll-seconds", "1")) == 1
     printed = capsys.readouterr().out
     # The holder has to be named: "the tenant is busy" is only actionable if the
     # reader can see which run to wait for.
     assert "::error::" in printed
-    assert "50" in printed
-    assert "acquired=false" in out.read_text()
-    assert "holder-run-id=50" in out.read_text()
-
-
-def test_main_acquire_timeout_says_the_change_is_not_at_fault(
-    http: FakeHTTP, capsys, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    # The whole point of FND-250: a contention outcome must not read as a test
-    # failure, because that sends a reviewer into the wrong diff.
-    monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
-    http.route("POST", "/git/refs", (201, {}))
-    http.route("GET", "/git/matching-refs/", (200, [_ref(50), _ref(100)]))
-    http.route("GET", "/actions/runs/", (200, {"status": "in_progress"}))
-    main(_argv("acquire", "--wait-seconds", "1", "--poll-seconds", "1"))
-    assert "Nothing is wrong with this change" in capsys.readouterr().out
+    assert "555" in printed
+    assert "Nothing is wrong with this change" in printed
+    written = out.read_text()
+    assert "acquired=false" in written
+    assert "holder-run-id=555" in written
 
 
 def test_main_acquire_can_warn_instead_of_failing(
     http: FakeHTTP, capsys, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
-    http.route("POST", "/git/refs", (201, {}))
-    http.route("GET", "/git/matching-refs/", (200, [_ref(50), _ref(100)]))
-    http.route("GET", "/actions/runs/", (200, {"status": "in_progress"}))
+    _stub_blob_write(http)
+    http.route("POST", "/git/refs", (422, {"message": "Reference already exists"}))
+    http.route("GET", "/git/ref/", (200, _ref_body()))
+    http.route("GET", "/git/blobs/", (200, _holder_blob(555)))
+    http.route("GET", "/actions/runs/", _live())
     argv = _argv(
         "acquire", "--wait-seconds", "1", "--poll-seconds", "1", "--on-timeout", "warn"
     )
@@ -565,7 +684,7 @@ def test_main_acquire_exits_zero_when_the_lease_is_disabled(
     http: FakeHTTP, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
-    http.route("POST", "/git/refs", (403, {"message": "nope"}))
+    http.route("POST", "/git/blobs", (403, {"message": "nope"}))
     assert main(_argv("acquire")) == 0
 
 
@@ -573,6 +692,8 @@ def test_main_release_exits_zero(
     http: FakeHTTP, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+    http.route("GET", "/git/ref/", (200, _ref_body()))
+    http.route("GET", "/git/blobs/", (200, _holder_blob(100, 1)))
     http.route("DELETE", "/git/refs/", (204, None))
     assert main(_argv("release")) == 0
 
@@ -583,61 +704,19 @@ def test_main_release_exits_zero_even_when_nothing_was_held(
     # A failed release must never redden a run whose tests passed; the reaper
     # covers it.
     monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
-    http.route("DELETE", "/git/refs/", (422, {"message": "Reference does not exist"}))
+    http.route("GET", "/git/ref/", (404, {"message": "Not Found"}))
     assert main(_argv("release")) == 0
 
 
-def test_main_release_needs_no_sha(
-    http: FakeHTTP, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    # The release job derives the ticket from the run, so it does not have to be
-    # handed any state by the acquiring job.
-    monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
-    http.route("DELETE", "/git/refs/", (204, None))
-    argv = [
-        "--mode",
-        "release",
-        "--repo",
-        REPO,
-        "--app",
-        "example",
-        "--cloud",
-        "aws",
-        "--run-id",
-        "100",
-        "--run-attempt",
-        "1",
-    ]
-    assert main(argv) == 0
-
-
-def test_main_acquire_requires_a_sha(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("GH_TOKEN", "x")
-    argv = [
-        "--mode",
-        "acquire",
-        "--repo",
-        REPO,
-        "--app",
-        "example",
-        "--run-id",
-        "100",
-        "--run-attempt",
-        "1",
-    ]
-    with pytest.raises(SystemExit):
-        main(argv)
-
-
-def test_acquire_and_release_agree_on_the_ticket_ref(
+def test_acquire_and_release_agree_on_the_lease_ref(
     http: FakeHTTP, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """The two modes run in different jobs and share no state — if they ever
-    disagreed about the ref name, every run would leak its lease."""
+    disagreed about the ref, every run would leak its lease."""
     out = tmp_path / "out"
     monkeypatch.setenv("GITHUB_OUTPUT", str(out))
-    http.route("POST", "/git/refs", (201, {}))
-    http.route("GET", "/git/matching-refs/", (200, [_ref(100)]))
+    _stub_blob_write(http)
+    http.route("POST", "/git/refs", (201, {"ref": REF}))
     main(_argv("acquire"))
     acquired_ref = [
         line.split("=", 1)[1]
@@ -646,9 +725,11 @@ def test_acquire_and_release_agree_on_the_ticket_ref(
     ][0]
 
     http.calls.clear()
+    http.route("GET", "/git/ref/", (200, _ref_body()))
+    http.route("GET", "/git/blobs/", (200, _holder_blob(100, 1)))
     http.route("DELETE", "/git/refs/", (204, None))
     main(_argv("release"))
-    deleted = http.calls[0][1]
+    deleted = [c for c in http.calls if c[0] == "DELETE"][0][1]
     assert deleted.endswith(acquired_ref.removeprefix("refs/"))
 
 
@@ -656,7 +737,7 @@ def test_missing_token_is_a_clear_error(monkeypatch: pytest.MonkeyPatch) -> None
     monkeypatch.delenv("GH_TOKEN", raising=False)
     monkeypatch.delenv("GITHUB_TOKEN", raising=False)
     with pytest.raises(SystemExit, match="GH_TOKEN"):
-        create_ticket(REPO, PREFIX, Ticket(1, 1), SHA)
+        try_acquire(REPO, REF, BLOB)
 
 
 # --- input bounds ----------------------------------------------------------
@@ -666,9 +747,6 @@ def test_missing_token_is_a_clear_error(monkeypatch: pytest.MonkeyPatch) -> None
 def test_main_rejects_a_poll_interval_below_one(
     monkeypatch: pytest.MonkeyPatch, value: str
 ) -> None:
-    # 0 is a ZeroDivisionError in the attempt-count arithmetic and a negative one
-    # reaches sleep() as a ValueError. Both are loud rather than silently wrong,
-    # but both arrive as a traceback several steps from the input that caused it.
     monkeypatch.setenv("GH_TOKEN", "x")
     with pytest.raises(SystemExit, match="poll-seconds"):
         main(_argv("acquire", "--poll-seconds", value))
@@ -686,17 +764,6 @@ def test_main_rejects_a_negative_ttl(monkeypatch: pytest.MonkeyPatch) -> None:
         main(_argv("acquire", "--ttl-seconds", "-1"))
 
 
-def test_main_accepts_a_zero_wait_budget(
-    http: FakeHTTP, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    # Legitimate: "try once and tell me whether the tenant is free". Only
-    # poll-seconds has a floor of 1.
-    monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
-    http.route("POST", "/git/refs", (201, {}))
-    http.route("GET", "/git/matching-refs/", (200, [_ref(100)]))
-    assert main(_argv("acquire", "--wait-seconds", "0")) == 0
-
-
 def test_main_validates_before_touching_the_api(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -706,28 +773,3 @@ def test_main_validates_before_touching_the_api(
     monkeypatch.delenv("GITHUB_TOKEN", raising=False)
     with pytest.raises(SystemExit, match="poll-seconds"):
         main(_argv("acquire", "--poll-seconds", "0"))
-
-
-def test_the_ttl_is_measured_from_run_creation_not_lease_acquisition(
-    http: FakeHTTP,
-) -> None:
-    """Pins the property the TTL default has to be sized against.
-
-    The lease is taken several jobs into a run, so a holder's run age already
-    includes discovery, the image build, the manifest merge and any runner queue
-    time before its install even starts. A TTL sized for install-plus-legs alone
-    would call this healthy holder wedged and reap it mid-install, putting a
-    second installer on the tenant — the race the lease exists to close.
-    """
-    # 5h is inside the legitimate chain: the workflow's own timeouts sum to 5h25m
-    # from run creation to the last leg finishing, before any runner queue time.
-    created = datetime.now(timezone.utc) - timedelta(hours=5)
-    http.route(
-        "GET",
-        "/actions/runs/",
-        (200, {"status": "in_progress", "created_at": created.isoformat()}),
-    )
-    # The superseded 4h default breaks this healthy holder's lease outright...
-    assert run_is_live(REPO, Ticket(1, 1), ttl_seconds=14400) is False
-    # ...and the shipped 12h default leaves it alone.
-    assert run_is_live(REPO, Ticket(1, 1), ttl_seconds=43200) is True

--- a/.github/scripts/tests/test_e2e_tenant_lease.py
+++ b/.github/scripts/tests/test_e2e_tenant_lease.py
@@ -74,6 +74,7 @@ class FakeHTTP:
     def __init__(self) -> None:
         self.routes: dict[tuple[str, str], list[tuple[int, object]]] = {}
         self.calls: list[tuple[str, str]] = []
+        self.cmds: list[list[str]] = []
         self.payloads: list[dict] = []
 
     def route(self, method: str, contains: str, *responses: tuple[int, object]) -> None:
@@ -83,6 +84,7 @@ class FakeHTTP:
         method = cmd[cmd.index("-X") + 1]
         url = cmd[-1]
         self.calls.append((method, url))
+        self.cmds.append(cmd)
         if "-d" in cmd:
             self.payloads.append(json.loads(cmd[cmd.index("-d") + 1]))
         for (route_method, contains), responses in self.routes.items():
@@ -1027,6 +1029,22 @@ def test_missing_token_is_a_clear_error(monkeypatch: pytest.MonkeyPatch) -> None
     monkeypatch.delenv("GITHUB_TOKEN", raising=False)
     with pytest.raises(SystemExit, match="GH_TOKEN"):
         try_acquire(REPO, REF, BLOB)
+
+
+def test_token_is_not_in_the_curl_command_line(http: FakeHTTP) -> None:
+    """The credential must not be observable via /proc/<pid>/cmdline.
+
+    The token is fed to curl through a stdin config (-K -) instead of a -H
+    argument, so while the request runs the process list carries no copy of it.
+    """
+    secret = "ghp_super_secret_token"
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setenv("GH_TOKEN", secret)
+        http.route("POST", "/git/refs", (422, {"message": "Reference already exists"}))
+        try_acquire(REPO, REF, BLOB)
+
+    cmd = http.cmds[0]
+    assert not any(secret in arg for arg in cmd), "token leaked into curl argv"
 
 
 # --- input bounds ----------------------------------------------------------

--- a/.github/scripts/tests/test_e2e_tenant_lease.py
+++ b/.github/scripts/tests/test_e2e_tenant_lease.py
@@ -34,8 +34,12 @@ sys.path.insert(
 
 from e2e_tenant_lease import (  # noqa: E402
     Holder,
+    RateLimited,
+    _denied,
+    _rate_limited,
     acquire,
     create_identity_blob,
+    gh_request,
     holder_is_live,
     lease_ref,
     main,
@@ -84,9 +88,12 @@ class FakeHTTP:
         for (route_method, contains), responses in self.routes.items():
             if route_method != method or contains not in url:
                 continue
-            status, body = responses[0] if len(responses) == 1 else responses.pop(0)
+            entry = responses[0] if len(responses) == 1 else responses.pop(0)
+            status, body = entry[0], entry[1]
+            headers = entry[2] if len(entry) > 2 else {}
             payload = "" if body is None else json.dumps(body)
-            return _completed(f"HTTP/2 {status}\r\n\r\n{payload}")
+            header_lines = "".join(f"\r\n{k}: {v}" for k, v in headers.items())
+            return _completed(f"HTTP/2 {status}{header_lines}\r\n\r\n{payload}")
         raise AssertionError(f"unstubbed request: {method} {url}")
 
     def count(self, method: str, contains: str) -> int:
@@ -122,6 +129,29 @@ def _ref_body(sha: str = BLOB):
 
 def _stub_blob_write(http: FakeHTTP) -> None:
     http.route("POST", "/git/blobs", (201, {"sha": BLOB}))
+
+
+def _stub_unheld(http: FakeHTTP, *later: tuple) -> None:
+    """The lease ref does not exist. `acquire` reads the ref BEFORE minting an
+    identity blob, so the free path starts with a 404 here — that pre-read is
+    what makes a waiting pass two calls instead of five."""
+    http.route("GET", "/git/ref/", (404, {"message": "Not Found"}), *later)
+
+
+#: A rate-limit answer. GitHub spells this as a 403 with the remaining-quota
+#: header at zero, which is indistinguishable from a permission 403 by status
+#: alone — the conflation that made the lease disable itself under contention.
+_RATE_LIMIT = (
+    403,
+    {"message": "API rate limit exceeded for installation"},
+    {"x-ratelimit-remaining": "0"},
+)
+_SECONDARY_LIMIT = (
+    403,
+    {"message": "You have exceeded a secondary rate limit"},
+    {"retry-after": "45"},
+)
+_PERMISSION_DENIED = (403, {"message": "Resource not accessible by integration"})
 
 
 # --- keying ----------------------------------------------------------------
@@ -230,6 +260,61 @@ def test_the_lease_ref_points_at_the_identity_blob(http: FakeHTTP) -> None:
 def test_identity_blob_reports_denied(http: FakeHTTP, status: int) -> None:
     http.route("POST", "/git/blobs", (status, {"message": "nope"}))
     assert create_identity_blob(REPO, 1, 1, 0.0) is None
+
+
+def test_identity_blob_raises_rather_than_denying_on_a_rate_limit(
+    http: FakeHTTP,
+) -> None:
+    # Signalled as an exception so no call site can silently treat it as a
+    # permission denial and fail the lease open.
+    http.route("POST", "/git/blobs", _RATE_LIMIT)
+    with pytest.raises(RateLimited):
+        create_identity_blob(REPO, 1, 1, 0.0)
+
+
+def test_try_acquire_raises_rather_than_denying_on_a_rate_limit(
+    http: FakeHTTP,
+) -> None:
+    http.route("POST", "/git/refs", _SECONDARY_LIMIT)
+    with pytest.raises(RateLimited) as raised:
+        try_acquire(REPO, REF, BLOB)
+    assert raised.value.retry_after == 45
+
+
+@pytest.mark.parametrize(
+    ("response", "expected"),
+    [
+        (_RATE_LIMIT, True),
+        (_SECONDARY_LIMIT, True),
+        ((429, {"message": "Too Many Requests"}), True),
+        (_PERMISSION_DENIED, False),
+        ((404, {"message": "Not Found"}), False),
+        (
+            (
+                403,
+                {"message": "Resource not accessible"},
+                {"x-ratelimit-remaining": "42"},
+            ),
+            False,
+        ),
+    ],
+)
+def test_rate_limit_detection(http: FakeHTTP, response: tuple, expected: bool) -> None:
+    http.route("GET", "/probe", response)
+    assert _rate_limited(gh_request("GET", "probe")) is expected
+
+
+def test_a_403_with_quota_remaining_is_a_permission_denial(http: FakeHTTP) -> None:
+    # The discriminator has to be the quota, not the status: a permission 403
+    # arrives with plenty of budget left and must still disable the lease.
+    http.route(
+        "GET",
+        "/probe",
+        (403, {"message": "Resource not accessible"}, {"x-ratelimit-remaining": "988"}),
+    )
+    response = gh_request("GET", "probe")
+    assert _rate_limited(response) is False
+    assert _denied(response) is True
 
 
 # --- reading the holder ----------------------------------------------------
@@ -420,6 +505,7 @@ def _acquire(**kwargs):
 
 
 def test_acquire_takes_an_unheld_lease(http: FakeHTTP) -> None:
+    _stub_unheld(http)
     _stub_blob_write(http)
     http.route("POST", "/git/refs", (201, {"ref": REF}))
     assert _acquire() == ("acquired", None)
@@ -433,8 +519,6 @@ def test_a_late_arriver_does_not_steal_a_live_holders_lease(http: FakeHTTP) -> N
     itself as the rightful holder and acquired too — both installed onto the same
     tenant. Exclusion must not depend on ids at all: whoever holds it, holds it.
     """
-    _stub_blob_write(http)
-    http.route("POST", "/git/refs", (422, {"message": "Reference already exists"}))
     http.route("GET", "/git/ref/", (200, _ref_body()))
     # The holder's run_id is HIGHER than ours (100), which under the old rule
     # would have made us the winner.
@@ -445,11 +529,76 @@ def test_a_late_arriver_does_not_steal_a_live_holders_lease(http: FakeHTTP) -> N
 
     assert state == "timeout"
     assert blocker is not None and blocker.run_id == 99999
-    # And critically: it never deleted the live holder's lease.
+    # And critically: it never deleted the live holder's lease, and never even
+    # attempted the CAS — the ref was held, so there was nothing to race for.
     assert http.count("DELETE", "/git/refs/") == 0
+    assert http.count("POST", "/git/refs") == 0
+
+
+def test_a_waiting_pass_costs_two_api_calls(http: FakeHTTP) -> None:
+    """The GITHUB_TOKEN budget is 1000/hour per REPOSITORY and every matrix leg
+    shares it, so a waiting poll has to be cheap. Reading the ref tells us the
+    lease is held; the run-status call tells us whether to reap it. The holder
+    record is memoised by the ref's target sha, so it is not re-read while the
+    lease has not changed hands."""
+    http.route("GET", "/git/ref/", (200, _ref_body()))
+    http.route("GET", "/git/blobs/", (200, _holder_blob(500)))
+    http.route("GET", "/actions/runs/", _live())
+
+    _acquire(wait_seconds=90, poll_seconds=30)
+
+    # 3 passes: 3 ref reads + 3 run-status reads + exactly ONE record read.
+    assert http.count("GET", "/git/ref/") == 3
+    assert http.count("GET", "/actions/runs/") == 3
+    assert http.count("GET", "/git/blobs/") == 1
+    # And nothing was written at all while the lease was held.
+    assert http.count("POST", "/git/blobs") == 0
+    assert http.count("POST", "/git/refs") == 0
+
+
+def test_the_holder_record_is_re_read_when_the_lease_changes_hands(
+    http: FakeHTTP,
+) -> None:
+    # The memo is keyed on the target sha precisely so a new holder is noticed.
+    http.route(
+        "GET",
+        "/git/ref/",
+        (200, _ref_body("aaa")),
+        (200, _ref_body("bbb")),
+        (200, _ref_body("bbb")),
+    )
+    http.route(
+        "GET",
+        "/git/blobs/",
+        (200, _holder_blob(500)),
+        (200, _holder_blob(600)),
+    )
+    http.route("GET", "/actions/runs/", _live())
+
+    _, blocker = _acquire(wait_seconds=90, poll_seconds=30)
+    assert http.count("GET", "/git/blobs/") == 2
+    assert blocker is not None and blocker.run_id == 600
 
 
 def test_acquire_waits_then_wins_when_the_holder_releases(http: FakeHTTP) -> None:
+    http.route(
+        "GET",
+        "/git/ref/",
+        (200, _ref_body()),
+        (404, {"message": "Not Found"}),
+    )
+    http.route("GET", "/git/blobs/", (200, _holder_blob(500)))
+    http.route("GET", "/actions/runs/", _live())
+    _stub_blob_write(http)
+    http.route("POST", "/git/refs", (201, {"ref": REF}))
+    assert _acquire(wait_seconds=60, poll_seconds=30) == ("acquired", None)
+
+
+def test_acquire_loses_a_race_after_the_ref_looked_free(http: FakeHTTP) -> None:
+    """The pre-read is an optimisation, not a decision. Another contender can win
+    between our read and our CAS, and the 422 has to be handled as normal
+    contention rather than trusted from the earlier read."""
+    _stub_unheld(http, (404, {"message": "Not Found"}))
     _stub_blob_write(http)
     http.route(
         "POST",
@@ -457,26 +606,23 @@ def test_acquire_waits_then_wins_when_the_holder_releases(http: FakeHTTP) -> Non
         (422, {"message": "Reference already exists"}),
         (201, {"ref": REF}),
     )
-    http.route("GET", "/git/ref/", (200, _ref_body()))
-    http.route("GET", "/git/blobs/", (200, _holder_blob(500)))
-    http.route("GET", "/actions/runs/", _live())
     assert _acquire(wait_seconds=60, poll_seconds=30) == ("acquired", None)
 
 
 def test_acquire_reaps_a_dead_holder_and_takes_the_lease(http: FakeHTTP) -> None:
     """The case `if: always()` cannot cover — a cancelled run whose release job
     never started. The next contender clears it in-band."""
-    _stub_blob_write(http)
     http.route(
-        "POST",
-        "/git/refs",
-        (422, {"message": "Reference already exists"}),
-        (201, {"ref": REF}),
+        "GET",
+        "/git/ref/",
+        (200, _ref_body()),
+        (404, {"message": "Not Found"}),
     )
-    http.route("GET", "/git/ref/", (200, _ref_body()))
     http.route("GET", "/git/blobs/", (200, _holder_blob(500)))
     http.route("GET", "/actions/runs/", _live("completed"))
     http.route("DELETE", "/git/refs/", (204, None))
+    _stub_blob_write(http)
+    http.route("POST", "/git/refs", (201, {"ref": REF}))
 
     assert _acquire() == ("acquired", None)
     assert http.count("DELETE", "/git/refs/") == 1
@@ -485,17 +631,17 @@ def test_acquire_reaps_a_dead_holder_and_takes_the_lease(http: FakeHTTP) -> None
 def test_reaping_retries_the_cas_without_sleeping(http: FakeHTTP) -> None:
     # The tenant is free the instant the dead lease is deleted; sleeping a full
     # poll interval first would hand it to whoever wakes up sooner.
-    _stub_blob_write(http)
     http.route(
-        "POST",
-        "/git/refs",
-        (422, {"message": "Reference already exists"}),
-        (201, {"ref": REF}),
+        "GET",
+        "/git/ref/",
+        (200, _ref_body()),
+        (404, {"message": "Not Found"}),
     )
-    http.route("GET", "/git/ref/", (200, _ref_body()))
     http.route("GET", "/git/blobs/", (200, _holder_blob(500)))
     http.route("GET", "/actions/runs/", _live("completed"))
     http.route("DELETE", "/git/refs/", (204, None))
+    _stub_blob_write(http)
+    http.route("POST", "/git/refs", (201, {"ref": REF}))
 
     slept: list[int] = []
     assert _acquire(sleep=slept.append) == ("acquired", None)
@@ -505,43 +651,38 @@ def test_reaping_retries_the_cas_without_sleeping(http: FakeHTTP) -> None:
 def test_acquire_treats_its_own_existing_lease_as_held(http: FakeHTTP) -> None:
     # A retried step, or a re-run of the same attempt. Must not deadlock against
     # itself.
-    _stub_blob_write(http)
-    http.route("POST", "/git/refs", (422, {"message": "Reference already exists"}))
     http.route("GET", "/git/ref/", (200, _ref_body()))
     http.route("GET", "/git/blobs/", (200, _holder_blob(100, 1)))
     assert _acquire() == ("acquired", None)
 
 
 def test_acquire_retries_when_the_holder_is_unreadable(http: FakeHTTP) -> None:
-    # Released between the CAS and the read, or unreadable — either way the next
-    # CAS is authoritative rather than a guess.
-    _stub_blob_write(http)
-    http.route(
-        "POST",
-        "/git/refs",
-        (422, {"message": "Reference already exists"}),
-        (201, {"ref": REF}),
-    )
-    http.route("GET", "/git/ref/", (404, {"message": "Not Found"}))
-    assert _acquire() == ("acquired", None)
+    # Unreadable record: the CAS on a later pass is authoritative rather than a
+    # guess, so it waits rather than assuming either way.
+    http.route("GET", "/git/ref/", (200, _ref_body()))
+    http.route("GET", "/git/blobs/", (500, {"message": "boom"}))
+    state, blocker = _acquire(wait_seconds=30, poll_seconds=30)
+    assert state == "timeout"
+    assert blocker is None
+    assert http.count("DELETE", "/git/refs/") == 0
 
 
 def test_acquire_disables_itself_without_blob_write(http: FakeHTTP) -> None:
     # Fail-open: the lease reduces contention, it is not what makes a
     # wrong-version run detectable (each leg re-asserts the version, FND-31).
-    http.route("POST", "/git/blobs", (403, {"message": "Resource not accessible"}))
+    _stub_unheld(http)
+    http.route("POST", "/git/blobs", _PERMISSION_DENIED)
     assert _acquire() == ("disabled", None)
 
 
 def test_acquire_disables_itself_without_ref_write(http: FakeHTTP) -> None:
+    _stub_unheld(http)
     _stub_blob_write(http)
-    http.route("POST", "/git/refs", (403, {"message": "Resource not accessible"}))
+    http.route("POST", "/git/refs", _PERMISSION_DENIED)
     assert _acquire() == ("disabled", None)
 
 
 def test_acquire_respects_the_wait_budget(http: FakeHTTP) -> None:
-    _stub_blob_write(http)
-    http.route("POST", "/git/refs", (422, {"message": "Reference already exists"}))
     http.route("GET", "/git/ref/", (200, _ref_body()))
     http.route("GET", "/git/blobs/", (200, _holder_blob(500)))
     http.route("GET", "/actions/runs/", _live())
@@ -552,9 +693,94 @@ def test_acquire_respects_the_wait_budget(http: FakeHTTP) -> None:
 
 
 def test_acquire_always_makes_one_attempt_on_a_zero_budget(http: FakeHTTP) -> None:
+    _stub_unheld(http)
     _stub_blob_write(http)
     http.route("POST", "/git/refs", (201, {"ref": REF}))
     assert _acquire(wait_seconds=0, poll_seconds=30) == ("acquired", None)
+
+
+# --- rate limiting must never fail the lease open --------------------------
+
+
+def test_a_rate_limit_is_not_a_permission_denial(http: FakeHTTP) -> None:
+    """Both are 403. Conflating them switched the lease OFF exactly when it was
+    needed: several legs queueing for tenants is also when the shared
+    per-repository budget runs out, and the fail-open then let every waiting run
+    proceed onto the tenant unserialised."""
+    _stub_unheld(http)
+    http.route("POST", "/git/blobs", _RATE_LIMIT)
+    state, _ = _acquire(wait_seconds=30, poll_seconds=30)
+    assert state == "rate-limited"
+
+
+def test_a_rate_limited_cas_does_not_disable_the_lease(http: FakeHTTP) -> None:
+    _stub_unheld(http)
+    _stub_blob_write(http)
+    http.route("POST", "/git/refs", _RATE_LIMIT)
+    state, _ = _acquire(wait_seconds=30, poll_seconds=30)
+    assert state == "rate-limited"
+
+
+def test_a_secondary_rate_limit_is_recognised_from_retry_after(
+    http: FakeHTTP,
+) -> None:
+    # Secondary limits do not always carry x-ratelimit-remaining, so the header
+    # and the message are both checked rather than relying on GitHub's prose.
+    _stub_unheld(http)
+    http.route("POST", "/git/blobs", _SECONDARY_LIMIT)
+    state, _ = _acquire(wait_seconds=30, poll_seconds=30)
+    assert state == "rate-limited"
+
+
+def test_a_rate_limit_backoff_honours_retry_after(http: FakeHTTP) -> None:
+    _stub_unheld(http)
+    http.route("POST", "/git/blobs", _SECONDARY_LIMIT)
+    slept: list[int] = []
+    _acquire(wait_seconds=90, poll_seconds=30, sleep=slept.append)
+    # Retry-After of 45 beats the 30s poll interval, and is not applied after the
+    # final attempt.
+    assert slept == [45, 45]
+
+
+def test_a_rate_limit_backoff_never_undercuts_the_poll_interval(
+    http: FakeHTTP,
+) -> None:
+    _stub_unheld(http)
+    http.route(
+        "POST",
+        "/git/blobs",
+        (403, {"message": "rate limit"}, {"retry-after": "1"}),
+    )
+    slept: list[int] = []
+    _acquire(wait_seconds=60, poll_seconds=30, sleep=slept.append)
+    assert slept == [30]
+
+
+def test_a_rate_limit_backoff_is_capped(http: FakeHTTP) -> None:
+    # A very long Retry-After must not swallow the whole wait budget in one sleep.
+    _stub_unheld(http)
+    http.route(
+        "POST",
+        "/git/blobs",
+        (403, {"message": "rate limit"}, {"retry-after": "99999"}),
+    )
+    slept: list[int] = []
+    _acquire(wait_seconds=60, poll_seconds=30, sleep=slept.append)
+    assert slept == [300]
+
+
+def test_a_rate_limit_that_clears_still_acquires(http: FakeHTTP) -> None:
+    _stub_unheld(http, (404, {"message": "Not Found"}))
+    http.route("POST", "/git/blobs", _RATE_LIMIT, (201, {"sha": BLOB}))
+    http.route("POST", "/git/refs", (201, {"ref": REF}))
+    assert _acquire(wait_seconds=60, poll_seconds=30) == ("acquired", None)
+
+
+def test_a_429_is_treated_as_a_rate_limit(http: FakeHTTP) -> None:
+    _stub_unheld(http)
+    http.route("POST", "/git/blobs", (429, {"message": "Too Many Requests"}))
+    state, _ = _acquire(wait_seconds=30, poll_seconds=30)
+    assert state == "rate-limited"
 
 
 # --- release ---------------------------------------------------------------
@@ -565,6 +791,51 @@ def test_release_deletes_our_own_lease(http: FakeHTTP) -> None:
     http.route("GET", "/git/blobs/", (200, _holder_blob(100, 1)))
     http.route("DELETE", "/git/refs/", (204, None))
     assert release(REPO, REF, 100, 1) is True
+
+
+def test_release_rechecks_the_target_immediately_before_deleting(
+    http: FakeHTTP,
+) -> None:
+    """The check-then-delete is not atomic and the API offers no conditional
+    delete, so the target is re-read to narrow the window to the DELETE
+    round-trip.
+
+    The interleaving this guards against: the TTL breaks OUR lease while we are
+    still live, another run acquires, and we then delete the replacement holder's
+    lease — putting a second installer on the tenant. Cannot happen while the TTL
+    exceeds the longest legitimate hold, which is why that sizing is pinned by a
+    test and why the TTL is load-bearing for release as well as acquisition.
+    """
+    http.route(
+        "GET",
+        "/git/ref/",
+        (200, _ref_body("ours")),
+        (200, _ref_body("someone-elses")),
+    )
+    http.route("GET", "/git/blobs/", (200, _holder_blob(100, 1)))
+    assert release(REPO, REF, 100, 1) is False
+    assert http.count("DELETE", "/git/refs/") == 0
+
+
+def test_release_proceeds_when_the_target_is_unchanged(http: FakeHTTP) -> None:
+    http.route(
+        "GET",
+        "/git/ref/",
+        (200, _ref_body("ours")),
+        (200, _ref_body("ours")),
+    )
+    http.route("GET", "/git/blobs/", (200, _holder_blob(100, 1)))
+    http.route("DELETE", "/git/refs/", (204, None))
+    assert release(REPO, REF, 100, 1) is True
+
+
+def test_release_refuses_when_ownership_cannot_be_confirmed(http: FakeHTTP) -> None:
+    # An unreadable record is not permission to delete. The next contender reaps
+    # it if this run is genuinely over.
+    http.route("GET", "/git/ref/", (200, _ref_body()))
+    http.route("GET", "/git/blobs/", (500, {"message": "boom"}))
+    assert release(REPO, REF, 100, 1) is False
+    assert http.count("DELETE", "/git/refs/") == 0
 
 
 def test_release_refuses_to_delete_someone_elses_lease(http: FakeHTTP) -> None:
@@ -633,6 +904,7 @@ def test_main_acquire_exits_zero_and_reports_outputs(
 ) -> None:
     out = tmp_path / "out"
     monkeypatch.setenv("GITHUB_OUTPUT", str(out))
+    _stub_unheld(http)
     _stub_blob_write(http)
     http.route("POST", "/git/refs", (201, {"ref": REF}))
     assert main(_argv("acquire")) == 0
@@ -684,8 +956,24 @@ def test_main_acquire_exits_zero_when_the_lease_is_disabled(
     http: FakeHTTP, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
-    http.route("POST", "/git/blobs", (403, {"message": "nope"}))
+    _stub_unheld(http)
+    http.route("POST", "/git/blobs", _PERMISSION_DENIED)
     assert main(_argv("acquire")) == 0
+
+
+def test_main_acquire_fails_on_a_persistent_rate_limit(
+    http: FakeHTTP, capsys, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Explicitly NOT fail-open: proceeding unserialised because the API was busy
+    # is how two runs end up installing onto one tenant.
+    monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+    _stub_unheld(http)
+    http.route("POST", "/git/blobs", _RATE_LIMIT)
+    assert main(_argv("acquire", "--wait-seconds", "1", "--poll-seconds", "1")) == 1
+    printed = capsys.readouterr().out
+    assert "::error::" in printed
+    assert "rate-limited" in printed
+    assert "Nothing is wrong with this change" in printed
 
 
 def test_main_release_exits_zero(
@@ -715,6 +1003,7 @@ def test_acquire_and_release_agree_on_the_lease_ref(
     disagreed about the ref, every run would leak its lease."""
     out = tmp_path / "out"
     monkeypatch.setenv("GITHUB_OUTPUT", str(out))
+    _stub_unheld(http)
     _stub_blob_write(http)
     http.route("POST", "/git/refs", (201, {"ref": REF}))
     main(_argv("acquire"))

--- a/.github/scripts/tests/test_prepare_tenant_wiring.py
+++ b/.github/scripts/tests/test_prepare_tenant_wiring.py
@@ -19,8 +19,10 @@ import pytest
 import yaml
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
+sys.path.insert(0, str(Path(__file__).parent))
 
 import e2e_tenant_app as app  # noqa: E402
+from _gha_expr import evaluate  # noqa: E402
 
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 _WORKFLOW = _REPO_ROOT / ".github/workflows/tests-reusable.yaml"
@@ -268,8 +270,41 @@ def test_the_lease_is_released_even_when_the_legs_fail(jobs: dict) -> None:  # t
     # having taken the lease — not on the outcome of anything after it.
     gate = jobs["release-tenant"]["if"]
     assert "always()" in gate
-    assert "needs.lease-tenant.result == 'success'" in gate
     assert "e2e" in jobs["release-tenant"]["needs"]
+
+
+@pytest.mark.parametrize(
+    ("lease_result", "should_release"),
+    [
+        ("success", True),
+        # THE case that was broken. lease-tenant is a per-cloud MATRIX job, so
+        # `.result` is the aggregate: one cloud's acquire timing out made it
+        # 'failure' and skipped the release for EVERY cloud, including the legs
+        # that did acquire. Their leases then waited for the next contender's
+        # reaper instead of being handed back — directly against this job's stated
+        # purpose. Gating on "ran" rather than "succeeded" fixes it.
+        ("failure", True),
+        ("cancelled", True),
+        # Never ran, so there is nothing to release.
+        ("skipped", False),
+    ],
+)
+def test_release_runs_whenever_any_lease_leg_may_hold_a_tenant(
+    lease_result: str, should_release: bool
+) -> None:
+    """Evaluated rather than pattern-matched: `&&` binds tighter than `||` in
+    GitHub expressions, so a gate that merely *mentions* the right terms can
+    still be wrong. Widening this is only safe because the release driver checks
+    ownership before deleting, so a leg that never acquired no-ops."""
+    expression = _load_gate("release-tenant")
+    assert (
+        evaluate(expression, {"needs": {"lease-tenant": {"result": lease_result}}})
+        is should_release
+    )
+
+
+def _load_gate(job: str) -> str:
+    return yaml.safe_load(_WORKFLOW.read_text(encoding="utf-8"))["jobs"][job]["if"]
 
 
 def test_the_lease_wait_fits_inside_the_job_timeout(jobs: dict) -> None:  # type: ignore[type-arg]

--- a/.github/scripts/tests/test_prepare_tenant_wiring.py
+++ b/.github/scripts/tests/test_prepare_tenant_wiring.py
@@ -286,30 +286,20 @@ def test_the_lease_wait_fits_inside_the_job_timeout(jobs: dict) -> None:  # type
     assert timeout_seconds > wait_seconds
 
 
-#: Every job on the path from run creation to the last leg finishing. The TTL is
-#: measured from run CREATION, so all of it counts — not just the part after the
-#: lease is acquired. Sizing the TTL against install-plus-legs alone was an
-#: actual latent bug, not a theoretical one: that pair is 160 min against a chain
-#: of 325, so a healthy run that queued for runners could cross a 4h TTL partway
-#: through its own install and have a contender reap it mid-flight.
-_PRE_RELEASE_CHAIN = (
-    "discover-e2e",
-    "build-e2e-image",
-    "merge-e2e-image",
-    "lease-tenant",
-    "prepare-tenant",
-    "e2e",
-)
+#: The jobs a lease is actually HELD across: acquired before the install, released
+#: after the last leg. The TTL is measured from the acquisition time the holder
+#: records for itself, so only this span counts — none of the pre-lease work
+#: (discovery, image build, manifest merge, runner queue time) does.
+_LEASE_HELD_ACROSS = ("prepare-tenant", "e2e")
 
 
 def test_the_lease_ttl_cannot_fire_on_a_healthy_holder(jobs: dict) -> None:  # type: ignore[type-arg]
     """The TTL breaking a LIVE holder's lease puts a second installer on the
-    tenant — the exact race the lease exists to close — so it must clear the
-    whole chain, with room left for runner queue time, which has no timeout.
+    tenant — the exact race the lease exists to close — so it has to clear the
+    longest legitimate hold with room to spare.
 
-    Derived from the workflow's own timeouts rather than hard-coded, so adding a
-    job to the chain or raising a timeout forces the TTL up instead of quietly
-    eating the margin.
+    Derived from the workflow's own timeouts rather than hard-coded, so raising
+    either of them forces the TTL up instead of quietly eating the margin.
     """
     action = yaml.safe_load(
         (_REPO_ROOT / ".github/actions/e2e-tenant-lease/action.yaml").read_text(
@@ -317,20 +307,20 @@ def test_the_lease_ttl_cannot_fire_on_a_healthy_holder(jobs: dict) -> None:  # t
         )
     )
     ttl_seconds = int(action["inputs"]["ttl-seconds"]["default"])
-    chain_seconds = (
-        sum(int(jobs[job]["timeout-minutes"]) for job in _PRE_RELEASE_CHAIN) * 60
+    hold_seconds = (
+        sum(int(jobs[job]["timeout-minutes"]) for job in _LEASE_HELD_ACROSS) * 60
     )
 
-    assert ttl_seconds > chain_seconds, (
-        f"ttl-seconds ({ttl_seconds}s) does not clear the "
-        f"{'+'.join(_PRE_RELEASE_CHAIN)} chain ({chain_seconds}s). A healthy "
-        "holder that queued for runners would have its lease broken mid-install."
+    assert ttl_seconds > hold_seconds, (
+        f"ttl-seconds ({ttl_seconds}s) does not clear the longest legitimate hold "
+        f"({'+'.join(_LEASE_HELD_ACROSS)} = {hold_seconds}s). A healthy holder "
+        "would have its lease broken mid-run and a second installer would start."
     )
-    # Queue time between those jobs is unbounded, so clearing the chain exactly is
-    # not enough; require real headroom rather than a one-second pass.
-    assert ttl_seconds >= 2 * chain_seconds, (
-        f"ttl-seconds ({ttl_seconds}s) clears the chain ({chain_seconds}s) but "
-        "leaves no room for runner queue time, which has no timeout"
+    # Runner queue time between the held jobs is unbounded, so clearing the sum
+    # exactly is not enough; require real headroom rather than a one-second pass.
+    assert ttl_seconds >= 1.5 * hold_seconds, (
+        f"ttl-seconds ({ttl_seconds}s) clears the hold ({hold_seconds}s) but "
+        "leaves little room for runner queue time, which has no timeout"
     )
 
 

--- a/.github/workflows/tests-reusable.yaml
+++ b/.github/workflows/tests-reusable.yaml
@@ -1080,10 +1080,16 @@ jobs:
   #     given a runner, with no log output at all. That is FND-218: a merge-queue
   #     batch whose "connector test failures" were all evictions.
   #
-  # So the lease is a queue of ticket refs ordered by run_id, held for the whole
-  # run, with dead holders reaped by whoever notices (FND-250). It runs AFTER the
-  # image is built and merged so the tenant is not held hostage to a build, and
-  # its ticket is released by release-tenant below.
+  # So the lease is a single fixed-name ref per tenant, taken by an atomic
+  # compare-and-swap (GitHub's 422 on creating a ref that already exists IS the
+  # lock), held for the whole run, with dead holders reaped by whoever notices
+  # (FND-250). It runs AFTER the image is built and merged so the tenant is not
+  # held hostage to a build, and it is released by release-tenant below.
+  #
+  # An earlier version ordered per-run ticket refs by run_id instead, and both
+  # contenders acquired on its first concurrent run: run_id is creation order, not
+  # the order runs reach this job, and a total order gives fairness rather than
+  # exclusion. Exclusion needs an atomic primitive — see the module docstring.
   #
   # Same gate and same cloud matrix as prepare-tenant: no install, no contention
   # worth serialising — the legs of a non-installing run cannot lose a version

--- a/.github/workflows/tests-reusable.yaml
+++ b/.github/workflows/tests-reusable.yaml
@@ -1638,9 +1638,18 @@ jobs:
   release-tenant:
     name: Release tenant lease (${{ matrix.cloud || 'default' }})
     needs: [discover-e2e, lease-tenant, prepare-tenant, e2e]
-    # Only when this run actually took a lease. Not gated on the legs' outcome —
-    # a failed leg must still give the tenant back.
-    if: always() && needs.lease-tenant.result == 'success'
+    # Gated on lease-tenant having RUN, not on it having succeeded. `.result` on a
+    # matrix job is the aggregate, so `== 'success'` meant one cloud's acquire
+    # timing out skipped the release for EVERY cloud — including the legs that did
+    # acquire, whose leases would then wait for the next contender's reaper
+    # instead of being handed back. That directly contradicts this job's own
+    # reason for existing.
+    #
+    # Safe to widen because the release driver checks ownership before deleting:
+    # a leg that never acquired reads a lease that is not its own (or none at all)
+    # and no-ops. Not gated on the legs' outcome either — a failed leg must still
+    # give the tenant back.
+    if: always() && needs.lease-tenant.result != 'skipped'
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.discover-e2e.outputs.cloud-count != '0' && needs.discover-e2e.outputs.cloud-matrix || '{"include":[{"cloud":""}]}') }}

--- a/docs/standards/ci.md
+++ b/docs/standards/ci.md
@@ -232,26 +232,51 @@ everywhere else the run must be independent.
 
 **For a shared resource, take a lease instead.** The `(app, cloud)` tenant lease
 in [`e2e-tenant-lease`](../../.github/actions/e2e-tenant-lease/) is the worked
-example (FND-250). Its protocol is worth reusing because it needs no lock
-server:
+example (FND-250). It needs no lock server:
 
-* Each run creates a ticket ref, `refs/e2e-tenant-lease/<app>/<cloud>/<run_id>-<run_attempt>`.
-* The lease is held by the lowest-ordered **live** ticket. Every participant
-  derives the same holder from the same listing, so there is no
-  compare-and-swap and no lock object to strand.
-* Ordering is by `run_id`, which GitHub assigns and increases with run creation
-  time *within a repository* — a server-side arrival order, so no runner clock
-  can make two runs both believe they are first.
-* The ticket name is derived entirely from the run, so every job of that run
-  computes it identically. Acquire and release live in different jobs and pass
-  no state; re-creating a ticket restores the same queue position.
-* Liveness is the holder's run status, not a heartbeat. A ticket whose run is
+* One ref per resource, with a **fixed** name:
+  `refs/e2e-tenant-lease/<app>/<cloud>/holder`. `POST /git/refs` on a name that
+  already exists returns 422, and that is an atomic test-and-set evaluated by
+  GitHub — of N simultaneous callers exactly one gets 201. That 422 *is* the
+  lock, not an error path bolted onto one.
+* The ref points at a **blob** holding the holder's identity (run id, attempt,
+  acquisition time). A ref can target a blob, which is what lets a single atomic
+  creation both take the lease and record who took it. Waiters read it to tell a
+  live holder from a dead one.
+* Liveness is the holder's run status, not a heartbeat. A lease whose run is
   `completed` is reaped by whoever notices. This is the part `if: always()`
   cannot do: GitHub *cancels* queued jobs rather than running them, so a
   cancelled run's release job never starts.
+* Release must **check ownership first**. A fixed name is a name you can delete
+  someone else's lease with.
 
-Two consequences to design for. A waiting run occupies a runner, so give the
-wait a budget and fail loudly past it, naming the holder — a contention outcome
-must never be phrased as a test failure. And ref writes need `contents: write`,
-so put acquire/release in their own small jobs and leave the jobs that execute
-test code read-only.
+**Do not build exclusion out of an ordering rule.** The first version of this
+lease was an ordered queue: every run created a ticket ref named after itself,
+and the lease belonged to whichever live ticket sorted lowest by
+`(run_id, run_attempt)`. It failed on its first concurrent run — both contenders
+acquired and both installed onto the same tenant. Two reasons, and both
+generalise:
+
+* `run_id` increases with run *creation*, which is **not** the order runs reach a
+  given job. In the observed failure the lower-id run got there 15 seconds later.
+* A total order gives FIFO *fairness*, not *exclusion*. A run that checks only
+  the tickets ordered ahead of it never notices that a run behind it already
+  holds the lease.
+
+Ordering-based exclusion is only sound if every contender's ticket exists before
+any contender decides, and nothing enforces that. Use an atomic primitive and
+derive nothing from ids. The cost is fairness — acquisition becomes a scramble,
+so bound starvation with the wait budget below rather than with a queue position.
+
+Three consequences to design for:
+
+* A waiting run occupies a runner, so give the wait a budget and fail loudly past
+  it, **naming the holder**. A contention outcome must never be phrased as a test
+  failure.
+* Ref writes need `contents: write`, so put acquire/release in their own small
+  jobs and leave the jobs that execute test code read-only.
+* If the lease fails open when it cannot be taken (the right default when a
+  separate assertion already catches the underlying hazard), then a broken lease
+  looks exactly like a working one — green, with a warning. **Assert the acquire
+  step's `state` output in anger** when verifying, rather than concluding from an
+  absence of red.

--- a/docs/standards/ci.md
+++ b/docs/standards/ci.md
@@ -250,6 +250,20 @@ example (FND-250). It needs no lock server:
 * Release must **check ownership first**. A fixed name is a name you can delete
   someone else's lease with.
 
+**Release cannot be made fully atomic, and that is an accepted trade-off, not an
+oversight.** The check-then-delete above is inherently racy: the refs API offers
+*no* conditional delete, so between the final ownership read and the `DELETE` a
+replacement holder can acquire the ref, and the delete would take the new
+holder's lease. The implementation re-reads the target immediately before the
+delete, which narrows the window to one round-trip but cannot close it. The
+deliberate decision is to **rely on the TTL as the load-bearing bound** rather
+than chase a stronger primitive: the only interleaving that loses is a TTL
+breaking a lease whose run is *still live*, and sizing the TTL above the longest
+legitimate hold makes that window unreachable in practice. The alternative —
+deleting only via a storage/API primitive that supports delete-if-current-target
+— does not exist on `git/refs`, so proactive release stays best-effort and the
+next acquirer's reaping of completed holders is the actual safety net.
+
 **Do not build exclusion out of an ordering rule.** The first version of this
 lease was an ordered queue: every run created a ticket ref named after itself,
 and the lease belonged to whichever live ticket sorted lowest by


### PR DESCRIPTION
The lease shipped in #3131 **did not provide mutual exclusion**. Two concurrent openapi e2e runs both acquired and both installed onto the same tenants. Found by the live two-run verification #3131 was merged without.

```
18:05:02  B (run 31520726752)  Ticket .../aws/31520726752-1 created.
18:05:02  B                    Tenant lease acquired
18:05:17  A (run 31520716356)  Ticket .../aws/31520716356-1 created.
18:05:17  A                    Tenant lease acquired      ← no "waiting", no "Reaping"
```

Same on azure and gcp. Both runs then went red.

## Why the old protocol was wrong

It was an ordered queue: each run created a ticket ref named after itself, and the lease belonged to whichever live ticket sorted lowest by `(run_id, run_attempt)`. Two premises were wrong, and they compound:

* **`run_id` order is not arrival order at the lease job.** It increases with run *creation*; job scheduling reorders freely. In the failure above, A was created first and got there 15 seconds later.
* **A total order gives FIFO fairness, not exclusion.** A run that checks only the tickets ordered *ahead* of it never notices that a run *behind* it already holds the lease. So the late lower-id arrival took a lease a live run was holding.

Ordering-based exclusion is only sound if every contender's ticket exists before any contender decides, and nothing enforces that.

## What replaces it

One ref per tenant with a **fixed** name, `refs/e2e-tenant-lease/<app>/<cloud>/holder`. `POST /git/refs` on a name that already exists returns 422, and that is an atomic test-and-set evaluated by GitHub: of N simultaneous callers exactly one gets 201. **That 422 is the lock.** Nothing is derived from ids.

The ref points at a **blob** carrying the holder's identity (run id, attempt, acquisition time), so a single atomic creation both takes the lease and records who took it — waiters read it to tell a live holder from a dead one. Verified against the API that a ref can target a blob.

Two consequences of a shared ref name, both handled:

* **Release checks ownership first.** A fixed name is a name you can delete someone else's lease with. The check-then-delete window is closed by the liveness rule rather than by luck: release runs while our own run is still `in_progress`, so no contender is entitled to reap us.
* **The TTL is now anchored to the holder's recorded acquisition time**, so it measures lease-*hold* time rather than run age. That resolves the earlier review finding properly rather than by widening the bound, and the default returns to 4h against a 40+120min hold.

## A second hazard found while fixing this

A reproducer surfaced that a stale or corrupt `acquired_at` makes the computed hold time enormous, so **every waiter breaks a live holder's lease on its first poll**. The timestamp is holder-written data, so it is now sanity-checked against the run's own `created_at` — a lease cannot have been acquired before the run that took it existed — and ignored when it fails that. Same for a run object with no `created_at`: the TTL simply does not apply, and run status remains authoritative.

## Fairness is the deliberate loss

Acquisition is now a scramble, not a queue, so a waiter can in principle be repeatedly beaten. Starvation is bounded by the wait budget failing loudly and naming the holder, not by a queue position. Correctness first; FIFO turned out to be the unaffordable property.

## Why the tests didn't catch it

Every test stubbed a ref listing in which the peer's ticket **already existed**. That made the case which actually happened — a contender arriving *after* another had acquired — the untested one. 76 unit tests passed on a protocol that failed on its first concurrent production run.

The suite is rewritten to drive acquisition through the *sequence* of API answers a second contender really sees (422 → read holder → check liveness → retry), rather than a tidy snapshot. The observed double-acquire is now a named regression test: `test_a_late_arriver_does_not_steal_a_live_holders_lease`, which asserts both that the late lower-id run does **not** acquire and that it never deletes the live holder's ref.

## What the verification also showed

The two colliding runs failed with `NoWorkerOnTaskQueueError`, not a version mismatch — because both dispatches were of the same commit, so both installed the *same* version and FND-31's version assert had nothing to catch. Worth recording: the version assert protects against wrong-version runs, **not** against concurrent same-version thrash on one tenant. The lease is doing work the assert cannot.

That does not change the fail-open posture (a lease that cannot be taken leaves behaviour no worse than before it existed), but it does mean the fail-open is a genuine reduction in protection rather than a no-op, and `ci.md` now says so.

`docs/standards/ci.md` also gains the general lesson: a lease that fails open cannot be verified by absence of red — assert the acquire step's `state` output.

## Tests

`.github/scripts/tests/` — **1688 passed**, 72 for the lease driver. Pre-commit clean.

Refs: FND-250
