### PR TITLE
fix(handler): parse JSON-string extra when flattening credentials

### DIFF
--- a/.claude/skills/capability-manifest/SKILL.md
+++ b/.claude/skills/capability-manifest/SKILL.md
@@ -15,7 +15,7 @@ optional_triggers:
   - "what does the SDK expose"
   - "list public methods of the SDK"
 owner: connector-platform-team
-last_updated: "2026-07-14"
+last_updated: "2026-08-12"
 staleness_days: 30
 inputs:
   - mode: "create | refresh | verify (auto-detected from existing state)"

--- a/application_sdk/credentials/utils.py
+++ b/application_sdk/credentials/utils.py
@@ -22,33 +22,82 @@ logger = get_logger(__name__)
 OBJECT_STORE_PREFIX = "objectstore://"
 
 
-def parse_credentials_extra(credentials: dict[str, Any]) -> dict[str, Any]:
-    """Parse the 'extra' field from credentials, handling both string and dict inputs.
+def parse_credentials_extra(
+    credentials: dict[str, Any], *, strict: bool = True
+) -> dict[str, Any]:
+    """Decode the ``extra`` field of a credential dict.
+
+    ``extra`` is stored in two legal shapes — a nested object, or that same
+    object serialized to a JSON string — because its producers (the Atlan UI,
+    Heracles, Argo templates, agent JSON) straddle the v2/v3 credential
+    contract boundary. This is the **only** decoder for that field: every
+    consumer routes through it so that a shape one code path accepts cannot
+    be a shape another code path silently drops.
+
+    Always returns a mapping. Absent, null, and empty ``extra`` are all "no
+    extra" — handing back the raw ``None`` instead only moved the failure to
+    an ``AttributeError`` on the caller's next ``.get()``.
 
     Args:
-        credentials: Credentials dictionary containing an 'extra' field.
+        credentials: Credential dict that may carry an ``extra`` field.
+        strict: Policy for an ``extra`` that is present but unusable (not
+            decodable, or not a JSON object). ``True`` — the runtime-client
+            policy — raises: a connector cannot build a DSN without it, and
+            a typed credential error beats a downstream ``AttributeError``.
+            ``False`` — the flattening policy — returns ``{}`` instead, for
+            callers that run where no one is positioned to distinguish a
+            malformed credential from an absent one and so must never raise.
 
     Returns:
-        Parsed extra field as a dictionary.
+        The decoded ``extra`` object, or ``{}`` when it is absent (or
+        unusable and ``strict`` is ``False``).
 
     Raises:
-        CommonError: If the extra field contains invalid JSON.
+        CredentialParseError: ``strict`` is set and ``extra`` is present but
+            is neither valid JSON nor a JSON object.
     """
-    extra: str | dict[str, Any] = credentials.get("extra", {})
+    extra: Any = credentials.get("extra")
+
+    if extra is None or extra == "":
+        return {}
+
+    if isinstance(extra, dict):
+        return extra
+
+    def _reject(message: str, cause: Exception | None = None) -> dict[str, Any]:
+        if not strict:
+            # Never silent: dropping ``extra`` costs the caller every
+            # connection param stored inside it, and a lenient caller by
+            # definition has no error to surface. The log line is the only
+            # trace, so it must carry the reason — but never the value, which
+            # is credential material.
+            logger.warning(
+                "Dropping unusable credentials extra field, continuing without "
+                "it (any connection params stored inside it will be absent): %s",
+                message,
+                exc_info=cause is not None,
+            )
+            return {}
+        from application_sdk.credentials.errors import (  # noqa: PLC0415
+            CredentialParseError,
+        )
+
+        raise CredentialParseError(
+            message=message, credential_name="extra", cause=cause
+        ) from cause
 
     if isinstance(extra, str):
         try:
-            return orjson.loads(extra)
+            extra = orjson.loads(extra)
         except json.JSONDecodeError as e:
-            from application_sdk.credentials.errors import (  # noqa: PLC0415
-                CredentialParseError,
-            )
+            # conformance: ignore[E007] not swallowed — _reject raises under strict and logs a WARNING with exc_info otherwise; the rule is lexical and cannot follow into the helper
+            return _reject("Invalid JSON in credentials extra field", e)
 
-            raise CredentialParseError(
-                message="Invalid JSON in credentials extra field",
-                credential_name="extra",
-                cause=e,
-            ) from e
+    if not isinstance(extra, dict):
+        return _reject(
+            "Credentials extra field is not a JSON object "
+            f"(decoded to {type(extra).__name__})"
+        )
 
     return extra
 

--- a/application_sdk/credentials/utils.py
+++ b/application_sdk/credentials/utils.py
@@ -30,9 +30,21 @@ def parse_credentials_extra(
     ``extra`` is stored in two legal shapes — a nested object, or that same
     object serialized to a JSON string — because its producers (the Atlan UI,
     Heracles, Argo templates, agent JSON) straddle the v2/v3 credential
-    contract boundary. This is the **only** decoder for that field: every
-    consumer routes through it so that a shape one code path accepts cannot
-    be a shape another code path silently drops.
+    contract boundary. A reader that handles only one shape silently drops
+    whatever the other shape carried, so the credential-resolution and
+    gate-flattening paths share this decoder rather than shape-matching
+    locally: ``clients/sql.py`` and
+    :func:`~application_sdk.handler.contracts.flatten_credentials_to_pairs`.
+
+    It is **not** yet the only reader of ``extra`` in the SDK. These still
+    parse it independently and remain to be routed through here:
+
+    * ``storage/cloud.py`` — decodes both shapes, but with its own error type
+      and an additional ``extras`` alias key.
+    * ``credentials/agent.py`` (secret-reference collection and substitution)
+      and ``infrastructure/_dapr/credential_vault.py`` (secret substitution)
+      — ``isinstance(extra, dict)`` only, so a JSON-string ``extra`` is
+      skipped rather than decoded.
 
     Always returns a mapping. Absent, null, and empty ``extra`` are all "no
     extra" — handing back the raw ``None`` instead only moved the failure to
@@ -58,7 +70,10 @@ def parse_credentials_extra(
     """
     extra: Any = credentials.get("extra")
 
-    if extra is None or extra == "":
+    # ``isinstance`` before the emptiness test: ``extra`` is arbitrarily typed
+    # here, and a bare ``== ""`` on a container that overloads equality returns
+    # a container rather than a bool, raising on the truthiness check.
+    if extra is None or (isinstance(extra, str) and not extra):
         return {}
 
     if isinstance(extra, dict):

--- a/application_sdk/handler/contracts.py
+++ b/application_sdk/handler/contracts.py
@@ -207,9 +207,22 @@ def flatten_credentials_to_pairs(creds_dict: dict[str, Any]) -> list[dict[str, s
     Nested ``extra`` is hoisted to ``extra.<k>`` keys. Shared by the HTTP
     preflight path (heracles-normalized requests) and the injected gate's
     resolved-credential conversion so both emit identical shapes.
+
+    ``extra`` stored as a JSON string (a legal shape — every SQL client parses
+    it via ``parse_credentials_extra``) is decoded before hoisting. Dropping it
+    instead starved gate-side handlers of connection params the runtime client
+    could see (e.g. Oracle host/port/sid living inside ``extra``), turning
+    every preflight into an instant false block. A string that does not decode
+    to a dict keeps the legacy behavior (skipped) — the runtime client would
+    reject it anyway, and flattening must not fail where it previously didn't.
     """
     pairs: list[dict[str, str]] = []
     extra = creds_dict.get("extra")
+    if isinstance(extra, str):
+        try:
+            extra = json.loads(extra)
+        except json.JSONDecodeError:
+            extra = None
     for key, value in creds_dict.items():
         if key == "extra" or value is None:
             continue

--- a/application_sdk/handler/contracts.py
+++ b/application_sdk/handler/contracts.py
@@ -23,6 +23,7 @@ from pydantic.alias_generators import to_camel
 
 from application_sdk.contracts.base import SerializableEnum
 from application_sdk.credentials.spec import AgentCredentialSpec
+from application_sdk.credentials.utils import parse_credentials_extra
 from application_sdk.errors.base import AppError
 from application_sdk.errors.wire import FailureDetails
 
@@ -208,31 +209,30 @@ def flatten_credentials_to_pairs(creds_dict: dict[str, Any]) -> list[dict[str, s
     preflight path (heracles-normalized requests) and the injected gate's
     resolved-credential conversion so both emit identical shapes.
 
-    ``extra`` stored as a JSON string (a legal shape — every SQL client parses
-    it via ``parse_credentials_extra``) is decoded before hoisting. Dropping it
-    instead starved gate-side handlers of connection params the runtime client
-    could see (e.g. Oracle host/port/sid living inside ``extra``), turning
-    every preflight into an instant false block. A string that does not decode
-    to a dict keeps the legacy behavior (skipped) — the runtime client would
-    reject it anyway, and flattening must not fail where it previously didn't.
+    These pairs are the only credential view a gate-side handler ever sees, so
+    ``extra`` is decoded through :func:`parse_credentials_extra` — the same
+    decoder the runtime clients use — rather than shape-matched here. Anything
+    the runtime client can resolve out of ``extra`` must therefore also be
+    reachable in this view; a second, narrower reader is how the two views
+    drift apart and the gate starts blocking on params the extraction path
+    would have found.
+
+    ``strict=False``: flattening runs on the HTTP request path and inside the
+    injected gate, neither of which has a caller positioned to act on a parse
+    failure. An unusable ``extra`` is dropped here and the runtime client
+    raises the typed error on its own path.
     """
     pairs: list[dict[str, str]] = []
-    extra = creds_dict.get("extra")
-    if isinstance(extra, str):
-        try:
-            extra = json.loads(extra)
-        except json.JSONDecodeError:
-            extra = None
+    extra = parse_credentials_extra(creds_dict, strict=False)
     for key, value in creds_dict.items():
         if key == "extra" or value is None:
             continue
         pairs.append({"key": key, "value": _serialize_credential_value(value)})
-    if isinstance(extra, dict):
-        for key, value in extra.items():
-            if value is not None:
-                pairs.append(
-                    {"key": f"extra.{key}", "value": _serialize_credential_value(value)}
-                )
+    for key, value in extra.items():
+        if value is not None:
+            pairs.append(
+                {"key": f"extra.{key}", "value": _serialize_credential_value(value)}
+            )
     return pairs
 
 

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -1,8 +1,8 @@
 <!--
 generated-by:  capability-manifest skill (.claude/skills/capability-manifest)
 sdk-version:   3.27.1
-source-sha:    b6e756091f012a5e5e7db9309f99e5e9655c931b
-source-date:   2026-08-11T10:10:51+00:00
+source-sha:    bf6096e844bdd66ebcdfcc592b709cee5768f7c1
+source-date:   2026-08-12T00:40:27+01:00
 do-not-edit:   re-run the skill instead of hand-editing
 -->
 
@@ -881,8 +881,8 @@ Credential resolvers (Atlan, OAuth, Git, agent), registry, vault spec
 #### `parse_credentials_extra`
 
 - **Import:** `from application_sdk.credentials import parse_credentials_extra`
-- **Signature:** `parse_credentials_extra(credentials: dict[str, Any])`
-- **Summary:** Parse the 'extra' field from credentials, handling both string and dict inputs.
+- **Signature:** `parse_credentials_extra(credentials: dict[str, Any], *, strict: bool = True)`
+- **Summary:** Decode the ``extra`` field of a credential dict.
 - **Defined in:** `application_sdk/credentials/utils.py`
 
 #### `register_credential_type`

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -1,8 +1,8 @@
 <!--
 generated-by:  capability-manifest skill (.claude/skills/capability-manifest)
 sdk-version:   3.27.1
-source-sha:    bf6096e844bdd66ebcdfcc592b709cee5768f7c1
-source-date:   2026-08-12T00:40:27+01:00
+source-sha:    77acd050ebe24f1d840dd487b05ba10dd7ec2df3
+source-date:   2026-08-12T01:12:24+01:00
 do-not-edit:   re-run the skill instead of hand-editing
 -->
 

--- a/tests/unit/credentials/test_utils.py
+++ b/tests/unit/credentials/test_utils.py
@@ -2,7 +2,146 @@ import base64
 import os
 from unittest.mock import AsyncMock, patch
 
-from application_sdk.credentials.utils import resolve_credential_file
+import pytest
+
+from application_sdk.credentials.errors import CredentialParseError
+from application_sdk.credentials.utils import (
+    parse_credentials_extra,
+    resolve_credential_file,
+)
+
+
+class TestParseCredentialsExtra:
+    """The single decoder for the credential ``extra`` field.
+
+    ``extra`` arrives in two legal shapes — a nested object, or that object
+    serialized to a JSON string — because its producers straddle the v2/v3
+    contract boundary. Every consumer routes through this function precisely
+    so a shape one caller accepts cannot be a shape another caller drops.
+
+    Two policies, one decoder. ``strict=True`` (runtime clients) fails loudly:
+    a connector cannot build a DSN from an unusable ``extra``, and a typed
+    error beats an ``AttributeError`` three frames later. ``strict=False``
+    (the flattener) returns ``{}``: it runs where no caller can distinguish
+    a malformed credential from an absent one, so it must not raise.
+    """
+
+    # -- shapes accepted identically in both modes --------------------------
+
+    @pytest.mark.parametrize("strict", [True, False])
+    def test_dict_extra_returned_as_is(self, strict):
+        extra = {"host": "h", "port": 1521}
+        assert parse_credentials_extra({"extra": extra}, strict=strict) == extra
+
+    @pytest.mark.parametrize("strict", [True, False])
+    def test_json_string_extra_decoded(self, strict):
+        assert parse_credentials_extra(
+            {"extra": '{"host": "h", "port": 1521}'}, strict=strict
+        ) == {"host": "h", "port": 1521}
+
+    @pytest.mark.parametrize("strict", [True, False])
+    def test_both_shapes_decode_identically(self, strict):
+        """The parity that the whole two-shape tolerance exists to provide."""
+        as_dict = parse_credentials_extra(
+            {"extra": {"host": "h", "sid": "DB1"}}, strict=strict
+        )
+        as_string = parse_credentials_extra(
+            {"extra": '{"host": "h", "sid": "DB1"}'}, strict=strict
+        )
+        assert as_string == as_dict
+
+    @pytest.mark.parametrize("strict", [True, False])
+    def test_absent_extra_is_empty_dict(self, strict):
+        assert parse_credentials_extra({"username": "u"}, strict=strict) == {}
+
+    @pytest.mark.parametrize("strict", [True, False])
+    def test_null_extra_is_empty_dict(self, strict):
+        """An explicit JSON null is 'no extra', not a value to hand back.
+
+        Returning ``None`` here handed every caller an ``AttributeError`` on
+        the next ``.get()``.
+        """
+        assert parse_credentials_extra({"extra": None}, strict=strict) == {}
+
+    @pytest.mark.parametrize("strict", [True, False])
+    def test_empty_string_extra_is_empty_dict(self, strict):
+        assert parse_credentials_extra({"extra": ""}, strict=strict) == {}
+
+    # -- where the two policies diverge -------------------------------------
+
+    def test_strict_raises_on_undecodable_string(self):
+        with pytest.raises(CredentialParseError) as exc_info:
+            parse_credentials_extra({"extra": "{not-json"})
+        assert exc_info.value.credential_name == "extra"
+
+    def test_lenient_returns_empty_on_undecodable_string(self):
+        assert parse_credentials_extra({"extra": "{not-json"}, strict=False) == {}
+
+    def test_strict_raises_on_non_object_json(self):
+        """A JSON array decodes cleanly but is not an object.
+
+        The declared return type is ``dict``; handing back a list produced an
+        ``AttributeError`` in the caller instead of a typed credential error.
+        """
+        with pytest.raises(CredentialParseError):
+            parse_credentials_extra({"extra": '["a", "b"]'})
+
+    def test_lenient_returns_empty_on_non_object_json(self):
+        assert parse_credentials_extra({"extra": '["a", "b"]'}, strict=False) == {}
+
+    def test_strict_raises_on_non_mapping_value(self):
+        with pytest.raises(CredentialParseError):
+            parse_credentials_extra({"extra": 7})
+
+    def test_lenient_returns_empty_on_non_mapping_value(self):
+        assert parse_credentials_extra({"extra": 7}, strict=False) == {}
+
+    def test_strict_is_the_default(self):
+        """Callers that omit the flag get the loud policy."""
+        with pytest.raises(CredentialParseError):
+            parse_credentials_extra({"extra": "{not-json"})
+
+    # -- the lenient path must never be silent ------------------------------
+
+    @pytest.mark.parametrize(
+        "extra",
+        ["{not-json", '["a", "b"]', 7],
+        ids=["undecodable", "json_array", "non_mapping"],
+    )
+    def test_lenient_drop_is_logged(self, extra):
+        """A swallowed `extra` leaves a trace or the next defect is invisible.
+
+        Silence is what let a dropped `extra` reach production: the credential
+        looked complete, the connectivity check just failed. The lenient caller
+        has no exception to surface, so this log line is the only signal.
+        """
+        with patch("application_sdk.credentials.utils.logger") as mock_logger:
+            assert parse_credentials_extra({"extra": extra}, strict=False) == {}
+
+        mock_logger.warning.assert_called_once()
+        message = mock_logger.warning.call_args.args[0]
+        assert "extra" in message
+
+    def test_lenient_drop_log_excludes_credential_material(self):
+        """The reason is loggable; the value never is."""
+        secret = "s3cr3t-token-value"
+        with patch("application_sdk.credentials.utils.logger") as mock_logger:
+            parse_credentials_extra(
+                {"extra": f'{{"token": "{secret}", BROKEN'}, strict=False
+            )
+
+        rendered = " ".join(str(a) for a in mock_logger.warning.call_args.args)
+        assert secret not in rendered
+
+    def test_usable_extra_logs_nothing(self):
+        """No warning on the happy path — this runs on every credential load."""
+        with patch("application_sdk.credentials.utils.logger") as mock_logger:
+            parse_credentials_extra({"extra": '{"host": "h"}'}, strict=False)
+            parse_credentials_extra({"extra": {"host": "h"}}, strict=False)
+            parse_credentials_extra({}, strict=False)
+            parse_credentials_extra({"extra": None}, strict=False)
+
+        mock_logger.warning.assert_not_called()
 
 
 class TestResolveCredentialFile:

--- a/tests/unit/handler/test_contracts.py
+++ b/tests/unit/handler/test_contracts.py
@@ -44,9 +44,15 @@ class TestFlattenCredentialsToPairs:
     """`flatten_credentials_to_pairs` / `HandlerCredential.list_from_raw`.
 
     The flattened pairs are the only credential view a gate-side handler ever
-    sees, so `extra` must survive in both of its legal shapes (dict and JSON
-    string) — a dropped `extra` starves the handler of connection params the
-    runtime client would resolve (the Oracle miner false-block defect).
+    sees. `extra` is stored in two legal shapes (nested object, or that object
+    serialized to a JSON string), so both must flatten identically — a dropped
+    `extra` hands the handler fewer connection params than the runtime client
+    resolves from the same credential.
+
+    Flattening must never raise: it runs on the HTTP request path and inside
+    the injected gate, neither of which has a caller positioned to distinguish
+    "malformed credential" from "no credential". Unusable `extra` is dropped
+    and the runtime client raises the typed error on its own path.
     """
 
     def test_top_level_keys_flatten(self):
@@ -64,12 +70,12 @@ class TestFlattenCredentialsToPairs:
     def test_string_extra_parsed_and_hoisted(self):
         """JSON-string `extra` must flatten identically to dict `extra`."""
         as_dict = flatten_credentials_to_pairs(
-            {"username": "u", "extra": {"host": "h", "port": 1521, "sid": "ORCL"}}
+            {"username": "u", "extra": {"host": "h", "port": 1521, "sid": "DB1"}}
         )
         as_string = flatten_credentials_to_pairs(
             {
                 "username": "u",
-                "extra": '{"host": "h", "port": 1521, "sid": "ORCL"}',
+                "extra": '{"host": "h", "port": 1521, "sid": "DB1"}',
             }
         )
         assert as_string == as_dict
@@ -79,13 +85,22 @@ class TestFlattenCredentialsToPairs:
         pairs = flatten_credentials_to_pairs({"extra": '{"filter": {"db": ["s"]}}'})
         assert pairs == [{"key": "extra.filter", "value": '{"db": ["s"]}'}]
 
-    def test_invalid_json_string_extra_skipped(self):
-        """Undecodable string keeps the legacy drop — flattening never raises."""
+    def test_invalid_json_string_extra_dropped(self):
+        """Undecodable string is dropped — flattening never raises."""
         pairs = flatten_credentials_to_pairs({"username": "u", "extra": "{not-json"})
         assert pairs == [{"key": "username", "value": "u"}]
 
-    def test_non_dict_json_string_extra_skipped(self):
+    def test_non_object_json_string_extra_dropped(self):
         pairs = flatten_credentials_to_pairs({"username": "u", "extra": '["a", "b"]'})
+        assert pairs == [{"key": "username", "value": "u"}]
+
+    def test_non_mapping_extra_dropped(self):
+        """A non-str, non-dict `extra` has no keys to hoist and must not raise."""
+        pairs = flatten_credentials_to_pairs({"username": "u", "extra": 7})
+        assert pairs == [{"key": "username", "value": "u"}]
+
+    def test_null_extra_dropped(self):
+        pairs = flatten_credentials_to_pairs({"username": "u", "extra": None})
         assert pairs == [{"key": "username", "value": "u"}]
 
     def test_none_values_skipped(self):

--- a/tests/unit/handler/test_contracts.py
+++ b/tests/unit/handler/test_contracts.py
@@ -24,6 +24,7 @@ from application_sdk.handler.contracts import (
     PreflightStatus,
     SqlMetadataObject,
     SqlMetadataOutput,
+    flatten_credentials_to_pairs,
 )
 
 
@@ -37,6 +38,70 @@ class TestHandlerCredential:
         cred = HandlerCredential(key="token", value="abc123")
         assert cred.key == "token"
         assert cred.value == "abc123"
+
+
+class TestFlattenCredentialsToPairs:
+    """`flatten_credentials_to_pairs` / `HandlerCredential.list_from_raw`.
+
+    The flattened pairs are the only credential view a gate-side handler ever
+    sees, so `extra` must survive in both of its legal shapes (dict and JSON
+    string) — a dropped `extra` starves the handler of connection params the
+    runtime client would resolve (the Oracle miner false-block defect).
+    """
+
+    def test_top_level_keys_flatten(self):
+        pairs = flatten_credentials_to_pairs({"username": "u", "port": 1521})
+        assert {"key": "username", "value": "u"} in pairs
+        assert {"key": "port", "value": "1521"} in pairs
+
+    def test_dict_extra_hoisted(self):
+        pairs = flatten_credentials_to_pairs(
+            {"username": "u", "extra": {"host": "h", "protocol": "TCP"}}
+        )
+        assert {"key": "extra.host", "value": "h"} in pairs
+        assert {"key": "extra.protocol", "value": "TCP"} in pairs
+
+    def test_string_extra_parsed_and_hoisted(self):
+        """JSON-string `extra` must flatten identically to dict `extra`."""
+        as_dict = flatten_credentials_to_pairs(
+            {"username": "u", "extra": {"host": "h", "port": 1521, "sid": "ORCL"}}
+        )
+        as_string = flatten_credentials_to_pairs(
+            {
+                "username": "u",
+                "extra": '{"host": "h", "port": 1521, "sid": "ORCL"}',
+            }
+        )
+        assert as_string == as_dict
+        assert {"key": "extra.host", "value": "h"} in as_string
+
+    def test_string_extra_nested_values_serialized(self):
+        pairs = flatten_credentials_to_pairs({"extra": '{"filter": {"db": ["s"]}}'})
+        assert pairs == [{"key": "extra.filter", "value": '{"db": ["s"]}'}]
+
+    def test_invalid_json_string_extra_skipped(self):
+        """Undecodable string keeps the legacy drop — flattening never raises."""
+        pairs = flatten_credentials_to_pairs({"username": "u", "extra": "{not-json"})
+        assert pairs == [{"key": "username", "value": "u"}]
+
+    def test_non_dict_json_string_extra_skipped(self):
+        pairs = flatten_credentials_to_pairs({"username": "u", "extra": '["a", "b"]'})
+        assert pairs == [{"key": "username", "value": "u"}]
+
+    def test_none_values_skipped(self):
+        pairs = flatten_credentials_to_pairs(
+            {"username": "u", "password": None, "extra": '{"host": "h", "sid": null}'}
+        )
+        assert pairs == [
+            {"key": "username", "value": "u"},
+            {"key": "extra.host", "value": "h"},
+        ]
+
+    def test_list_from_raw_round_trips_string_extra(self):
+        creds = HandlerCredential.list_from_raw(
+            {"username": "u", "extra": '{"host": "h"}'}
+        )
+        assert HandlerCredential(key="extra.host", value="h") in creds
 
 
 class TestAuthStatus:

--- a/tests/unit/handler/test_credential_view_parity.py
+++ b/tests/unit/handler/test_credential_view_parity.py
@@ -1,0 +1,145 @@
+"""Parity between the two views of a single credential.
+
+One resolved credential is read through two different lenses:
+
+* the **runtime view** — `AsyncBaseSQLClient.get_sqlalchemy_connection_string`,
+  which resolves each required param top-level-first, then from `extra`
+  (`credentials.get(p) or extra.get(p)`);
+* the **gate view** — `flatten_credentials_to_pairs`, the flat
+  `[{key, value}]` list that is the *only* credential a handler sees on the
+  HTTP preflight path and inside the injected preflight gate.
+
+The invariant: anything the runtime lens can resolve, the gate lens must
+expose. Break it and the gate fails a connectivity check against params the
+extraction path would have found — a false block, reported as a real one.
+
+These tests are deliberately written against `DB_CONFIG.required` rather than
+against a fixed key list, so they hold for any connector layout.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from application_sdk.clients.models import DatabaseConfig
+from application_sdk.clients.sql import AsyncBaseSQLClient
+from application_sdk.handler.contracts import flatten_credentials_to_pairs
+
+
+class _TopLevelParamClient(AsyncBaseSQLClient):
+    """Every required param lives at the top level of the credential.
+
+    This is the common connector layout, and it is *immune* to a dropped
+    `extra` — which is exactly why the defect below survived in production
+    while the widely-exercised connectors stayed green.
+    """
+
+    DB_CONFIG = DatabaseConfig(
+        template="fake://{username}:{password}@{host}:{port}",
+        required=["username", "password", "host", "port"],
+    )
+
+
+class _ExtraParamClient(AsyncBaseSQLClient):
+    """Required params straddle the top level and `extra`.
+
+    `sid` has no top-level home in the credential shape, so it can only be
+    resolved out of `extra`. Drop `extra` and the DSN cannot be built at all.
+    """
+
+    DB_CONFIG = DatabaseConfig(
+        template="fake://{username}:{password}@{host}:{port}/{sid}",
+        required=["username", "password", "host", "port", "sid"],
+    )
+
+
+def _gate_view(creds: dict[str, Any]) -> set[str]:
+    """The set of credential keys a gate-side handler can actually read."""
+    return {pair["key"] for pair in flatten_credentials_to_pairs(creds)}
+
+
+def _assert_views_agree(
+    client_cls: type[AsyncBaseSQLClient], creds: dict[str, Any]
+) -> None:
+    required = client_cls.DB_CONFIG.required if client_cls.DB_CONFIG else []
+
+    # Runtime lens: raises MissingSqlParamError if any required param is
+    # unresolvable, so reaching the assertions proves the credential is
+    # complete as far as the extraction path is concerned.
+    client_cls(credentials=creds).get_sqlalchemy_connection_string()
+
+    keys = _gate_view(creds)
+    for param in required:
+        assert param in keys or f"extra.{param}" in keys, (
+            f"runtime client resolves {param!r} from this credential but the "
+            f"gate view does not expose it (as {param!r} or 'extra.{param}'); "
+            f"gate view = {sorted(keys)}"
+        )
+
+
+@pytest.fixture(params=["dict", "json_string"])
+def extra_shape(request: pytest.FixtureRequest):
+    """Both legal storage shapes of `extra`, applied to the same object."""
+
+    def apply(extra: dict[str, Any]) -> Any:
+        return extra if request.param == "dict" else json.dumps(extra)
+
+    return apply
+
+
+class TestRuntimeAndGateViewsAgree:
+    def test_top_level_layout(self, extra_shape):
+        """The immune layout — passes with or without `extra` surviving."""
+        _assert_views_agree(
+            _TopLevelParamClient,
+            {
+                "username": "u",
+                "password": "p",
+                "host": "h",
+                "port": 1521,
+                "extra": extra_shape({"database": "db"}),
+            },
+        )
+
+    def test_params_inside_extra(self, extra_shape):
+        """The layout that exposed the defect: `sid` only exists in `extra`."""
+        _assert_views_agree(
+            _ExtraParamClient,
+            {
+                "username": "u",
+                "password": "p",
+                "extra": extra_shape({"host": "h", "port": 1521, "sid": "DB1"}),
+            },
+        )
+
+    def test_params_split_across_both(self, extra_shape):
+        _assert_views_agree(
+            _ExtraParamClient,
+            {
+                "username": "u",
+                "password": "p",
+                "host": "h",
+                "extra": extra_shape({"port": 1521, "sid": "DB1"}),
+            },
+        )
+
+
+class TestGateViewNeverRaises:
+    """The gate view is built where no caller can act on a parse failure.
+
+    A credential the runtime client will reject must still flatten — the
+    typed error belongs on the runtime path, not on the flattening path.
+    """
+
+    @pytest.mark.parametrize(
+        "extra",
+        ["{not-json", '["a", "b"]', "", 7, None],
+        ids=["undecodable", "json_array", "empty_string", "non_mapping", "null"],
+    )
+    def test_unusable_extra_flattens_to_top_level_only(self, extra: Any):
+        assert flatten_credentials_to_pairs({"username": "u", "extra": extra}) == [
+            {"key": "username", "value": "u"}
+        ]

--- a/tests/unit/handler/test_credential_view_parity.py
+++ b/tests/unit/handler/test_credential_view_parity.py
@@ -126,6 +126,36 @@ class TestRuntimeAndGateViewsAgree:
             },
         )
 
+    def test_gate_values_match_runtime_resolved_values(self, extra_shape):
+        """Key presence is the contract; this locks the values down too.
+
+        Both views serialize from the same `creds_dict`, so agreement here is
+        structural rather than coincidental — but nothing enforced it, and a
+        future change to `_serialize_credential_value` could hand the gate a
+        differently-rendered `port` than the DSN gets.
+        """
+        creds = {
+            "username": "u",
+            "password": "p",
+            "host": "h",
+            "extra": extra_shape({"port": 1521, "sid": "DB1"}),
+        }
+        extra = (
+            json.loads(creds["extra"])
+            if isinstance(creds["extra"], str)
+            else creds["extra"]
+        )
+        pairs = {p["key"]: p["value"] for p in flatten_credentials_to_pairs(creds)}
+
+        for param in _ExtraParamClient.DB_CONFIG.required:
+            # The runtime lens: top level first, then `extra` (clients/sql.py).
+            runtime_value = creds.get(param) or extra.get(param)
+            gate_value = pairs.get(param, pairs.get(f"extra.{param}"))
+            assert gate_value == str(runtime_value), (
+                f"{param!r}: runtime resolves {runtime_value!r} but the gate "
+                f"view carries {gate_value!r}"
+            )
+
 
 class TestGateViewNeverRaises:
     """The gate view is built where no caller can act on a parse failure.


### PR DESCRIPTION
## Problem

`flatten_credentials_to_pairs` (`application_sdk/handler/contracts.py`) builds the flat `[{key, value}]` list that is the **only** credential view a gate-side handler ever sees — `HandlerCredential.list_from_raw` feeds both the injected preflight gate and the HTTP preflight path.

It hoisted `extra` into `extra.<k>` pairs only when `extra` was already a `dict`. `extra` is also legally stored as a JSON string, and that shape was dropped **silently** — no log, no error, just a credential that looks complete while missing everything stored inside `extra`.

For a connector whose connection params live in `extra`:

- the gate-side handler receives `host=None, port=None, sid=None`
- its connectivity check fails locally in milliseconds, without ever reaching the source
- the gate records a `would_block` verdict, while the extraction path — which decodes string `extra` correctly — connects to that same source a moment later

That is a false block: the gate reporting a credential problem that does not exist.

## Why this surfaced now and not months ago

Worth stating plainly, because "surely this could never have worked" is the natural reaction.

**The broken reader is new.** `flatten_credentials_to_pairs` was introduced with the injected preflight gate; before that, nothing converted a resolved credential into flat pairs. The extraction path has always decoded `extra` through `parse_credentials_extra`, which handles both shapes. So the credential contract was never misaligned — the gate added a *second, narrower* reader of the same field, and only that one dropped a legal shape.

**The gate is soft by default.** A false verdict records `would_block` and the run proceeds. Nothing fails, so the only symptom is gate telemetry — which is how this was found: a false-blocks signal from connector health monitoring, where every gate run in the observation window failed connectivity in under 100 ms (a real probe takes seconds), and worker logs show the gate failing on `host=None, port=None, sid=None` with the extraction loading the same credential successfully immediately after.

**Most connectors are structurally immune.** The runtime client resolves each required param top-level-first, then from `extra` (`clients/sql.py`: `self.credentials.get(param) or extra.get(param)`). A connector whose required params all sit at the top level loses nothing when `extra` is dropped, whatever shape it was stored in — only optional params go missing, and the probe still connects. Only a connector with a required param that exists *solely* inside `extra` — an Oracle `sid`, for instance — loses the ability to connect at all. That is why the widely-exercised connectors stayed green, and it is now pinned by a test instead of left as folklore.

One claim from the first draft of this description, corrected: "the shape every SQL client's runtime path handles" is true, but it is not evidence that producers emit that shape — it only shows the runtime never had to care. The actual evidence is the observation itself. Extraction succeeded on a credential where flattening produced nothing, and that is only possible if the stored `extra` was a string; a dict would have flattened fine.

## Fix

Adding a second `isinstance(extra, str)` decode next to the first would fix the symptom while preserving the structure that caused it — two readers of one field with different tolerance. Instead, `parse_credentials_extra` becomes the single decoder, and the caller picks a policy:

- **`strict=True`** (default — runtime clients): an unusable `extra` raises `CredentialParseError`. A connector cannot build a DSN without it, and a typed credential error beats an `AttributeError` three frames later.
- **`strict=False`** (the flattener): an unusable `extra` is dropped and logged at WARNING. Flattening runs on the HTTP request path and inside the gate, neither of which has a caller positioned to act on a parse failure, so it must not raise.

`flatten_credentials_to_pairs` calls that decoder instead of shape-matching locally.

The lenient path is never silent. Silence is what let this reach production — the credential looked complete and the connectivity check simply failed. A dropped `extra` now logs the reason, never the value.

Two behaviours tightened as a consequence, both narrowing a crash into a typed error:

- `extra: null` and `extra: ""` return `{}` instead of the raw value. Previously `None` was handed straight back and the caller's next `.get()` raised `AttributeError`.
- A JSON value decoding to a non-object (e.g. an array) raises `CredentialParseError` under `strict`, rather than being returned as a `list` in violation of the declared `dict` return type.

## Tests

Red before the change, green after. Three groups.

**`TestParseCredentialsExtra`** — the decoder itself, which had no test coverage at all. Both shapes decode identically in both modes; absent / null / empty all yield `{}`; the two policies diverge only on a present-but-unusable value; the lenient drop is logged, the log excludes credential material, and the happy path logs nothing.

**`TestFlattenCredentialsToPairs`** — dict/string parity, nested-value serialization, and every unusable `extra` shape dropped without raising.

**`tests/unit/handler/test_credential_view_parity.py`** — the invariant that actually broke, which nothing was guarding: *anything the runtime client can resolve from a credential, the gate view must expose.* Written against `DB_CONFIG.required` rather than a fixed key list, so it holds for any connector layout, and parametrized over both `extra` shapes. It also encodes the immunity described above — `test_top_level_layout[json_string]` passes even against the unfixed code, while `test_params_inside_extra[json_string]` fails. The difference between the connectors that were fine and the one that was not, as an executable statement rather than a paragraph.

## Verification

- `tests/unit`: 6477 passed, 9 skipped
- pre-commit (ruff, ruff-format, isort, pyright): clean
- conformance: no new unsuppressed findings; clears two that the first version of this fix introduced (E009 on its `except: extra = None`, plus an O001)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
