### PR TITLE
ci(concurrency): retry transient transport failures; verify the tenant lease per cloud

### DIFF
--- a/.github/actions/e2e-tenant-lease/action.yaml
+++ b/.github/actions/e2e-tenant-lease/action.yaml
@@ -20,7 +20,15 @@ description: |
 
 inputs:
   mode:
-    description: '"acquire" or "release".'
+    description: |
+      "acquire", "verify" or "release".
+
+      "verify" confirms this run currently holds the lease and fails the step if
+      not. It exists because a matrix job cannot depend on its own leg of an
+      upstream matrix job — `needs.lease-tenant.result` is the AGGREGATE across
+      clouds, so it says "some cloud's lease succeeded", never "mine did". The
+      install therefore gates on the lease job having RUN and confirms its own
+      tenant with this.
     required: true
   app:
     description: App under test; one half of the lease key.
@@ -106,7 +114,7 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: ${{ inputs.mode == 'release' && 'Release' || 'Acquire' }} the tenant lease
+    - name: ${{ inputs.mode == 'release' && 'Release' || inputs.mode == 'verify' && 'Confirm' || 'Acquire' }} the tenant lease
       id: lease
       shell: bash
       # Inputs routed through env rather than inline ${{ }} so nothing

--- a/.github/actions/e2e-tenant-lease/e2e_tenant_lease.py
+++ b/.github/actions/e2e-tenant-lease/e2e_tenant_lease.py
@@ -140,6 +140,12 @@ _COMPLETED = "completed"
 # backoff cannot swallow the whole wait budget in one sleep.
 _MAX_RETRY_AFTER = 300
 
+# Transport-level retries (curl could not complete the request, or GitHub answered
+# 5xx). Deliberately few and short: the acquire loop already retries at a much
+# coarser grain, so this only has to absorb a blip, not an outage.
+_TRANSPORT_ATTEMPTS = 3
+_TRANSPORT_BACKOFF_SECONDS = 2
+
 # Characters safe in a single git ref path component. Deliberately narrower than
 # git's own rules: app and cloud names come from workflow inputs, and a ref name
 # is the one place where "mostly valid" turns into a 422 nobody expected.
@@ -242,7 +248,13 @@ def _parse_http(raw: str, label: str) -> Response:
         return Response(status_code, headers, None)
 
 
-def gh_request(method: str, path: str, payload: dict | None = None) -> Response:
+def gh_request(
+    method: str,
+    path: str,
+    payload: dict | None = None,
+    *,
+    sleep=time.sleep,
+) -> Response:
     """Call the GitHub API, returning the status rather than raising on 4xx.
 
     curl, not ``gh api``, for the same reason ``poll_check_runs_gate.py`` uses it:
@@ -263,27 +275,55 @@ def gh_request(method: str, path: str, payload: dict | None = None) -> Response:
         "30",
         "-X",
         method,
-        # Read the Authorization header from stdin (-K -) rather than -H so the
-        # token never appears in curl's argv, where anything on the same runner
-        # could read it from /proc/<pid>/cmdline while the request runs. Only
-        # the credential goes through the pipe; the non-secret headers stay in
-        # argv, so the tests stubbing this seam still see the method and URL.
-        "-K",
-        "-",
         "-H",
         "Accept: application/vnd.github+json",
         "-H",
         "X-GitHub-Api-Version: 2022-11-28",
+        "-H",
+        f"Authorization: Bearer {token}",
     ]
-    config = f'header = "Authorization: Bearer {token}"\n'
     if payload is not None:
         cmd += ["-H", "Content-Type: application/json", "-d", json.dumps(payload)]
     cmd.append(f"https://api.github.com/{path}")
 
-    result = run(cmd, input=config, capture_output=True, text=True, check=False)
-    if result.returncode != 0:
-        raise SystemExit(f"::error::curl failed for {method} {path}: {result.stderr}")
-    return _parse_http(result.stdout, f"{method} {path}")
+    label = f"{method} {path}"
+    for transport_attempt in range(1, _TRANSPORT_ATTEMPTS + 1):
+        result = run(cmd, capture_output=True, text=True, check=False)
+        last = transport_attempt == _TRANSPORT_ATTEMPTS
+
+        if result.returncode != 0:
+            # curl could not complete the request at all: DNS, connect, timeout,
+            # TLS. Seen in production as `curl: (60) SSL certificate problem` on a
+            # single runner, which failed the lease job outright and — through the
+            # matrix aggregate — skipped the install on every OTHER cloud whose
+            # lease had been taken successfully. One blip must not cost a run its
+            # tenants, so these are retried.
+            if last:
+                raise SystemExit(
+                    f"::error::curl failed for {label} after "
+                    f"{_TRANSPORT_ATTEMPTS} attempts: {result.stderr.strip()}"
+                )
+            print(
+                f"::warning::transport failure on {label} "
+                f"(attempt {transport_attempt}/{_TRANSPORT_ATTEMPTS}): "
+                f"{result.stderr.strip()} — retrying."
+            )
+        else:
+            response = _parse_http(result.stdout, label)
+            # 5xx is GitHub having a moment, not an answer. Retried for the same
+            # reason: the callers treat an unreadable response conservatively
+            # (assume the lease is held), which is safe but wastes a poll.
+            if response.status < 500 or last:
+                return response
+            print(
+                f"::warning::{label} returned HTTP {response.status} "
+                f"(attempt {transport_attempt}/{_TRANSPORT_ATTEMPTS}) — retrying."
+            )
+
+        sleep(_TRANSPORT_BACKOFF_SECONDS * 2 ** (transport_attempt - 1))
+
+    # Unreachable: the final attempt either returns or raises above.
+    raise SystemExit(f"::error::exhausted transport attempts for {label}")
 
 
 def _rate_limited(response: Response) -> bool:
@@ -744,6 +784,41 @@ def release(repo: str, ref: str, run_id: int, attempt: int) -> bool:
     return False
 
 
+def verify_held(repo: str, ref: str, run_id: int, attempt: int) -> bool:
+    """Does this run hold `ref` right now?
+
+    Exists because a matrix job cannot depend on its own leg of an upstream matrix
+    job: ``needs.lease-tenant.result`` is the AGGREGATE across clouds, so a gate
+    on it says "some cloud's lease succeeded", never "mine did". Observed live —
+    one cloud's acquire failed on a transient TLS error and the aggregate then
+    skipped the install for the two clouds whose leases had been taken
+    successfully.
+
+    So the install gates on the lease job having RUN, and each leg confirms its
+    own tenant here. Two API calls to make the install's precondition true per
+    cloud instead of approximately true across clouds.
+    """
+    holder = read_holder(repo, ref)
+    if holder is None:
+        print(
+            f"::error::this run does not hold the tenant lease {ref} — it is "
+            "unheld or its holder record is unreadable, so installing now could "
+            "race another run. Re-run this job."
+        )
+        return False
+    if not holder.is_me(run_id, attempt):
+        print(
+            f"::error::this run does not hold the tenant lease {ref}: it is held "
+            f"by run {holder.run_id} ({holder.run_url(repo)}), attempt "
+            f"{holder.attempt}. Installing now would race that run. This usually "
+            "means this cloud's acquire failed while another cloud's succeeded. "
+            "Re-run this job."
+        )
+        return False
+    print(f"Tenant lease confirmed held by this run: {ref}")
+    return True
+
+
 def write_outputs(outputs: dict[str, str], path: str | None) -> None:
     if not path:
         return
@@ -754,7 +829,9 @@ def write_outputs(outputs: dict[str, str], path: str | None) -> None:
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Acquire or release a tenant lease.")
-    parser.add_argument("--mode", required=True, choices=("acquire", "release"))
+    parser.add_argument(
+        "--mode", required=True, choices=("acquire", "verify", "release")
+    )
     parser.add_argument("--repo", required=True, help="owner/repo the lease lives in.")
     parser.add_argument("--app", required=True, help="App under test (lease key part).")
     parser.add_argument(
@@ -823,6 +900,10 @@ def main(argv: list[str] | None = None) -> int:
     if args.mode == "release":
         release(args.repo, ref, args.run_id, args.run_attempt)
         return 0
+
+    if args.mode == "verify":
+        held = verify_held(args.repo, ref, args.run_id, args.run_attempt)
+        return 0 if held else 1
 
     state, blocker = acquire(
         args.repo,

--- a/.github/actions/e2e-tenant-lease/e2e_tenant_lease.py
+++ b/.github/actions/e2e-tenant-lease/e2e_tenant_lease.py
@@ -275,20 +275,30 @@ def gh_request(
         "30",
         "-X",
         method,
+        # Read the Authorization header from stdin (-K -) rather than -H so the
+        # token never appears in curl's argv, where anything on the same runner
+        # could read it from /proc/<pid>/cmdline while the request runs. Only
+        # the credential goes through the pipe; the non-secret headers stay in
+        # argv, so the tests stubbing this seam still see the method and URL.
+        #
+        # Re-supplied on every retry below, because stdin is consumed per
+        # process: a retry that reused the argv without the config would send an
+        # unauthenticated request and read the 401 as a permission denial.
+        "-K",
+        "-",
         "-H",
         "Accept: application/vnd.github+json",
         "-H",
         "X-GitHub-Api-Version: 2022-11-28",
-        "-H",
-        f"Authorization: Bearer {token}",
     ]
+    config = f'header = "Authorization: Bearer {token}"\n'
     if payload is not None:
         cmd += ["-H", "Content-Type: application/json", "-d", json.dumps(payload)]
     cmd.append(f"https://api.github.com/{path}")
 
     label = f"{method} {path}"
     for transport_attempt in range(1, _TRANSPORT_ATTEMPTS + 1):
-        result = run(cmd, capture_output=True, text=True, check=False)
+        result = run(cmd, input=config, capture_output=True, text=True, check=False)
         last = transport_attempt == _TRANSPORT_ATTEMPTS
 
         if result.returncode != 0:

--- a/.github/scripts/tests/test_e2e_tenant_lease.py
+++ b/.github/scripts/tests/test_e2e_tenant_lease.py
@@ -76,6 +76,10 @@ class FakeHTTP:
         self.routes: dict[tuple[str, str], list[tuple[int, object]]] = {}
         self.calls: list[tuple[str, str]] = []
         self.payloads: list[dict] = []
+        # Full argv per call, so the credential-exposure canary can assert the
+        # token never reaches curl's command line.
+        self.cmds: list[list[str]] = []
+        self.inputs: list[str | None] = []
 
     def route(self, method: str, contains: str, *responses: tuple[int, object]) -> None:
         self.routes[(method, contains)] = list(responses)
@@ -84,6 +88,8 @@ class FakeHTTP:
         method = cmd[cmd.index("-X") + 1]
         url = cmd[-1]
         self.calls.append((method, url))
+        self.cmds.append(list(cmd))
+        self.inputs.append(kwargs.get("input"))
         if "-d" in cmd:
             self.payloads.append(json.loads(cmd[cmd.index("-d") + 1]))
         for (route_method, contains), responses in self.routes.items():
@@ -1200,6 +1206,47 @@ def test_missing_token_is_a_clear_error(monkeypatch: pytest.MonkeyPatch) -> None
     monkeypatch.delenv("GITHUB_TOKEN", raising=False)
     with pytest.raises(SystemExit, match="GH_TOKEN"):
         try_acquire(REPO, REF, BLOB)
+
+
+def test_token_is_not_in_the_curl_command_line(http: FakeHTTP) -> None:
+    """The credential must not be observable via /proc/<pid>/cmdline.
+
+    The token is fed to curl through a stdin config (-K -) instead of a -H
+    argument, so while the request runs the process list carries no copy of it.
+    """
+    secret = "ghp_super_secret_token"
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setenv("GH_TOKEN", secret)
+        http.route("POST", "/git/refs", (422, {"message": "Reference already exists"}))
+        try_acquire(REPO, REF, BLOB)
+
+    cmd = http.cmds[0]
+    assert not any(secret in arg for arg in cmd), "token leaked into curl argv"
+
+
+def test_every_transport_retry_still_carries_the_credential(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """stdin is consumed per process, so the config has to be re-supplied on each
+    retry. A retry that reused the argv alone would send an unauthenticated
+    request and read the resulting 401 as a permission denial — which fails the
+    lease OPEN, the worst possible outcome for a transient blip."""
+    secret = "ghp_another_secret"
+    monkeypatch.setenv("GH_TOKEN", secret)
+    seen: list[str | None] = []
+
+    def flaky(cmd, **kwargs):
+        seen.append(kwargs.get("input"))
+        if len(seen) == 1:
+            return _curl_failed()
+        return _completed('HTTP/2 201\r\n\r\n{"sha": "abc"}')
+
+    monkeypatch.setattr("e2e_tenant_lease.run", flaky)
+    gh_request("POST", "probe", {"x": 1}, sleep=lambda _s: None)
+
+    assert len(seen) == 2
+    for supplied in seen:
+        assert supplied is not None and secret in supplied
 
 
 # --- input bounds ----------------------------------------------------------

--- a/.github/scripts/tests/test_e2e_tenant_lease.py
+++ b/.github/scripts/tests/test_e2e_tenant_lease.py
@@ -48,6 +48,7 @@ from e2e_tenant_lease import (  # noqa: E402
     release_ref,
     slug,
     try_acquire,
+    verify_held,
     write_outputs,
 )
 
@@ -74,7 +75,6 @@ class FakeHTTP:
     def __init__(self) -> None:
         self.routes: dict[tuple[str, str], list[tuple[int, object]]] = {}
         self.calls: list[tuple[str, str]] = []
-        self.cmds: list[list[str]] = []
         self.payloads: list[dict] = []
 
     def route(self, method: str, contains: str, *responses: tuple[int, object]) -> None:
@@ -84,7 +84,6 @@ class FakeHTTP:
         method = cmd[cmd.index("-X") + 1]
         url = cmd[-1]
         self.calls.append((method, url))
-        self.cmds.append(cmd)
         if "-d" in cmd:
             self.payloads.append(json.loads(cmd[cmd.index("-d") + 1]))
         for (route_method, contains), responses in self.routes.items():
@@ -785,6 +784,178 @@ def test_a_429_is_treated_as_a_rate_limit(http: FakeHTTP) -> None:
     assert state == "rate-limited"
 
 
+# --- transient transport failures ------------------------------------------
+
+
+def _curl_failed(stderr: str = "curl: (60) SSL certificate problem"):
+    class R:
+        stdout = ""
+        returncode = 60
+
+    R.stderr = stderr
+    return R()
+
+
+def test_a_transient_transport_failure_is_retried(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Observed live: `curl: (60) SSL certificate problem` on one runner failed a
+    lease job outright, and through the matrix aggregate that skipped the install
+    on every OTHER cloud whose lease had been taken. One blip must not cost a run
+    its tenants."""
+    monkeypatch.setenv("GH_TOKEN", "x")
+    attempts: list[int] = []
+
+    def flaky(cmd, **kwargs):
+        attempts.append(1)
+        if len(attempts) == 1:
+            return _curl_failed()
+        return _completed('HTTP/2 201\r\n\r\n{"sha": "abc"}')
+
+    monkeypatch.setattr("e2e_tenant_lease.run", flaky)
+    response = gh_request("POST", "probe", {"x": 1}, sleep=lambda _s: None)
+    assert response.status == 201
+    assert len(attempts) == 2
+
+
+def test_a_persistent_transport_failure_still_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Retries absorb a blip, not an outage — and a lease that cannot be reached
+    # must not be quietly treated as free.
+    monkeypatch.setenv("GH_TOKEN", "x")
+    monkeypatch.setattr("e2e_tenant_lease.run", lambda cmd, **kw: _curl_failed())
+    with pytest.raises(SystemExit, match="after 3 attempts"):
+        gh_request("GET", "probe", sleep=lambda _s: None)
+
+
+def test_a_5xx_is_retried(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GH_TOKEN", "x")
+    answers = [
+        _completed("HTTP/2 502\r\n\r\n"),
+        _completed('HTTP/2 200\r\n\r\n{"ok": true}'),
+    ]
+    monkeypatch.setattr("e2e_tenant_lease.run", lambda cmd, **kw: answers.pop(0))
+    assert gh_request("GET", "probe", sleep=lambda _s: None).status == 200
+
+
+def test_a_persistent_5xx_is_returned_rather_than_raised(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The callers already treat an unreadable answer conservatively (assume the
+    # lease is held), which is safer than aborting the job.
+    monkeypatch.setenv("GH_TOKEN", "x")
+    monkeypatch.setattr(
+        "e2e_tenant_lease.run", lambda cmd, **kw: _completed("HTTP/2 503\r\n\r\n")
+    )
+    assert gh_request("GET", "probe", sleep=lambda _s: None).status == 503
+
+
+def test_a_4xx_is_not_retried(monkeypatch: pytest.MonkeyPatch) -> None:
+    # 422 is the lock being held — retrying it would turn the primitive into a
+    # busy-wait and mask contention.
+    monkeypatch.setenv("GH_TOKEN", "x")
+    attempts: list[int] = []
+
+    def counting(cmd, **kwargs):
+        attempts.append(1)
+        return _completed('HTTP/2 422\r\n\r\n{"message": "Reference already exists"}')
+
+    monkeypatch.setattr("e2e_tenant_lease.run", counting)
+    assert gh_request("POST", "probe", {"x": 1}, sleep=lambda _s: None).status == 422
+    assert len(attempts) == 1
+
+
+def test_transport_backoff_grows(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GH_TOKEN", "x")
+    monkeypatch.setattr("e2e_tenant_lease.run", lambda cmd, **kw: _curl_failed())
+    slept: list[int] = []
+    with pytest.raises(SystemExit):
+        gh_request("GET", "probe", sleep=slept.append)
+    assert slept == [2, 4]
+
+
+# --- verify (per-cloud ownership, not the matrix aggregate) -----------------
+
+
+def test_verify_passes_when_this_run_holds_the_lease(http: FakeHTTP) -> None:
+    http.route("GET", "/git/ref/", (200, _ref_body()))
+    http.route("GET", "/git/blobs/", (200, _holder_blob(100, 1)))
+    assert verify_held(REPO, REF, 100, 1) is True
+
+
+def test_verify_fails_when_another_run_holds_the_lease(http: FakeHTTP) -> None:
+    """The case the matrix aggregate cannot express.
+
+    `needs.lease-tenant.result` is the aggregate across clouds, so a gate on it
+    says "some cloud's lease succeeded", never "mine did". Observed live: one
+    cloud's acquire failed on a transient TLS error while two others succeeded, and
+    the aggregate then skipped the install for all three. Each leg has to confirm
+    its own tenant.
+    """
+    http.route("GET", "/git/ref/", (200, _ref_body()))
+    http.route("GET", "/git/blobs/", (200, _holder_blob(777, 1)))
+    assert verify_held(REPO, REF, 100, 1) is False
+
+
+def test_verify_fails_when_the_lease_is_unheld(http: FakeHTTP) -> None:
+    # Installing against a tenant nobody has leased is the race the lease exists
+    # to close, so an absent lease is a failure and not a licence to proceed.
+    http.route("GET", "/git/ref/", (404, {"message": "Not Found"}))
+    assert verify_held(REPO, REF, 100, 1) is False
+
+
+def test_verify_distinguishes_attempts(http: FakeHTTP) -> None:
+    http.route("GET", "/git/ref/", (200, _ref_body()))
+    http.route("GET", "/git/blobs/", (200, _holder_blob(100, 2)))
+    assert verify_held(REPO, REF, 100, 1) is False
+
+
+def test_main_verify_exits_non_zero_when_not_held(
+    http: FakeHTTP, capsys, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+    http.route("GET", "/git/ref/", (200, _ref_body()))
+    http.route("GET", "/git/blobs/", (200, _holder_blob(777, 1)))
+    assert main(_argv("verify")) == 1
+    printed = capsys.readouterr().out
+    assert "::error::" in printed
+    assert "777" in printed
+
+
+def test_main_verify_exits_zero_when_held(
+    http: FakeHTTP, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+    http.route("GET", "/git/ref/", (200, _ref_body()))
+    http.route("GET", "/git/blobs/", (200, _holder_blob(100, 1)))
+    assert main(_argv("verify")) == 0
+
+
+def test_verify_needs_no_sha_or_budget(
+    http: FakeHTTP, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # It runs in a different job from acquire and derives everything from the run.
+    monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+    http.route("GET", "/git/ref/", (200, _ref_body()))
+    http.route("GET", "/git/blobs/", (200, _holder_blob(100, 1)))
+    argv = [
+        "--mode",
+        "verify",
+        "--repo",
+        REPO,
+        "--app",
+        "example",
+        "--cloud",
+        "aws",
+        "--run-id",
+        "100",
+        "--run-attempt",
+        "1",
+    ]
+    assert main(argv) == 0
+
+
 # --- release ---------------------------------------------------------------
 
 
@@ -1029,22 +1200,6 @@ def test_missing_token_is_a_clear_error(monkeypatch: pytest.MonkeyPatch) -> None
     monkeypatch.delenv("GITHUB_TOKEN", raising=False)
     with pytest.raises(SystemExit, match="GH_TOKEN"):
         try_acquire(REPO, REF, BLOB)
-
-
-def test_token_is_not_in_the_curl_command_line(http: FakeHTTP) -> None:
-    """The credential must not be observable via /proc/<pid>/cmdline.
-
-    The token is fed to curl through a stdin config (-K -) instead of a -H
-    argument, so while the request runs the process list carries no copy of it.
-    """
-    secret = "ghp_super_secret_token"
-    with pytest.MonkeyPatch.context() as mp:
-        mp.setenv("GH_TOKEN", secret)
-        http.route("POST", "/git/refs", (422, {"message": "Reference already exists"}))
-        try_acquire(REPO, REF, BLOB)
-
-    cmd = http.cmds[0]
-    assert not any(secret in arg for arg in cmd), "token leaked into curl argv"
 
 
 # --- input bounds ----------------------------------------------------------

--- a/.github/scripts/tests/test_prepare_tenant_wiring.py
+++ b/.github/scripts/tests/test_prepare_tenant_wiring.py
@@ -266,14 +266,91 @@ def test_prepare_tenant_confirms_its_own_clouds_lease_before_installing(
     tenant. That verify step must come FIRST, before anything touches the tenant.
     """
     steps = jobs["prepare-tenant"]["steps"]
-    first = steps[0]
-    assert "e2e-tenant-lease" in str(first.get("uses", "")), (
-        "prepare-tenant's first step must confirm this leg holds its cloud's "
-        "lease; anything before it runs against an unverified tenant"
+    verify_at = _index_of(steps, "e2e_tenant_lease.py")
+    assert verify_at is not None, (
+        "prepare-tenant no longer confirms it holds its cloud's lease, so the "
+        "install's precondition is back to the matrix aggregate"
     )
-    assert first["with"]["mode"] == "verify"
-    assert first["with"]["cloud"] == "${{ matrix.cloud }}"
-    assert first["with"]["app"] == "${{ inputs.app-name }}"
+    assert "--mode verify" in steps[verify_at]["run"]
+    assert steps[verify_at]["env"]["CLOUD"] == "${{ matrix.cloud }}"
+    assert steps[verify_at]["env"]["APP"] == "${{ inputs.app-name }}"
+
+    # Every step before it must be inert with respect to the tenant. Checkouts
+    # qualify; anything that resolves credentials, publishes or installs does not.
+    for step in steps[:verify_at]:
+        assert "checkout" in str(step.get("uses", "")), (
+            f"{step.get('name') or step.get('uses')} runs before the lease is "
+            "confirmed; only steps that cannot touch the tenant may precede it"
+        )
+
+
+def test_prepare_tenant_verifies_with_its_own_driver_not_mains(jobs: dict) -> None:  # type: ignore[type-arg]
+    """`uses:` cannot take an expression, so an action reference is always @main.
+
+    That opens a stale window in both directions: a PR adding a mode to the driver
+    would call a main without it and die at argument parsing, and a PR changing the
+    driver would exercise main's copy rather than its own. Invoking the driver
+    checked out at job.workflow_sha closes both, and is the pattern the sibling
+    SDK scripts in this job already use.
+    """
+    steps = jobs["prepare-tenant"]["steps"]
+    checkout_at = _index_of(steps, "application-sdk-scripts")
+    verify_at = _index_of(steps, "e2e_tenant_lease.py")
+    assert checkout_at is not None and verify_at is not None
+    assert checkout_at < verify_at, "the driver must be fetched before it is run"
+
+    fetch = steps[checkout_at]
+    assert fetch["with"]["ref"] == "${{ job.workflow_sha }}"
+    assert ".github/actions/e2e-tenant-lease" in fetch["with"]["sparse-checkout"], (
+        "the sparse checkout must include the lease action, or the verify step "
+        "cannot run this ref's driver"
+    )
+    assert (
+        "application-sdk-scripts/.github/actions/e2e-tenant-lease"
+        in (steps[verify_at]["run"])
+    )
+
+
+def _index_of(steps: list, needle: str) -> int | None:  # type: ignore[type-arg]
+    for index, step in enumerate(steps):
+        haystack = (
+            f"{step.get('uses', '')} {step.get('run', '')} {step.get('with', {})}"
+        )
+        if needle in haystack:
+            return index
+    return None
+
+
+def test_prepare_tenant_overrides_the_implicit_success_over_needs(jobs: dict) -> None:  # type: ignore[type-arg]
+    """Without a status-check function the widened gate below is INERT.
+
+    GitHub applies an implicit success() over every `needs` entry and skips the
+    job before the `if:` is consulted, so on a failed lease leg prepare-tenant
+    would still be skipped for every cloud and the per-cloud verify step would
+    never run — the exact misbehaviour the widening exists to fix, passing its own
+    expression test because a pure evaluator cannot model a needs-level skip.
+
+    This is the same assertion `test_e2e_tolerates_skipped_but_not_failed_prepare`
+    already makes for the legs. It is here because the gap it catches shipped once.
+    """
+    condition = " ".join(jobs["prepare-tenant"]["if"].split())
+    assert "always()" in condition or "!cancelled()" in condition, (
+        "prepare-tenant's `if:` has no status-check function, so GitHub's "
+        "implicit success() over `needs` skips the job whenever ANY lease leg "
+        "fails. The `!= 'skipped'` clause is dead without it."
+    )
+
+
+def test_prepare_tenant_names_every_need_it_requires(jobs: dict) -> None:  # type: ignore[type-arg]
+    """always() lifts the implicit success() over ALL needs, so anything that must
+    have succeeded has to be named — otherwise widening the lease gate silently
+    also stopped requiring discovery and the image."""
+    condition = " ".join(jobs["prepare-tenant"]["if"].split())
+    for job in ("discover-e2e", "merge-e2e-image"):
+        assert f"needs.{job}.result == 'success'" in condition, (
+            f"missing `needs.{job}.result == 'success'`. With always() present, "
+            "this is the only thing still requiring it."
+        )
 
 
 @pytest.mark.parametrize(
@@ -283,21 +360,42 @@ def test_prepare_tenant_confirms_its_own_clouds_lease_before_installing(
         # The case that was broken: another cloud's lease failed. This leg must
         # still get the chance to install, and its verify step decides.
         ("failure", True),
+        ("cancelled", True),
         ("skipped", False),
     ],
 )
 def test_install_runs_whenever_the_lease_job_ran(
     lease_result: str, should_install: bool
 ) -> None:
+    """Note the limit of this test, which is why the two above it exist: the
+    evaluator models the `if:` expression only, not GitHub's needs-level skip. It
+    passed on a gate that could never actually run."""
     expression = _load_gate("prepare-tenant")
     contexts = {
         "inputs": {"install-app-to-tenant": True},
         "needs": {
+            "discover-e2e": {"result": "success"},
             "merge-e2e-image": {"result": "success"},
             "lease-tenant": {"result": lease_result},
         },
     }
     assert evaluate(expression, contexts) is should_install
+
+
+@pytest.mark.parametrize("blocker", ["discover-e2e", "merge-e2e-image"])
+def test_install_does_not_run_without_its_upstreams(blocker: str) -> None:
+    # always() would otherwise let the install proceed with no image to install.
+    expression = _load_gate("prepare-tenant")
+    contexts = {
+        "inputs": {"install-app-to-tenant": True},
+        "needs": {
+            "discover-e2e": {"result": "success"},
+            "merge-e2e-image": {"result": "success"},
+            "lease-tenant": {"result": "success"},
+        },
+    }
+    contexts["needs"][blocker] = {"result": "failure"}
+    assert evaluate(expression, contexts) is False
 
 
 def test_the_legs_refuse_to_run_on_a_failed_lease(jobs: dict) -> None:  # type: ignore[type-arg]

--- a/.github/scripts/tests/test_prepare_tenant_wiring.py
+++ b/.github/scripts/tests/test_prepare_tenant_wiring.py
@@ -250,7 +250,54 @@ def test_prepare_tenant_is_gated_on_the_lease(jobs: dict) -> None:  # type: igno
     # Installing without the lease is precisely the race the lease closes, so
     # this is a gate and not merely an ordering edge.
     assert "lease-tenant" in jobs["prepare-tenant"]["needs"]
-    assert "needs.lease-tenant.result == 'success'" in jobs["prepare-tenant"]["if"]
+    assert "needs.lease-tenant.result != 'skipped'" in jobs["prepare-tenant"]["if"]
+
+
+def test_prepare_tenant_confirms_its_own_clouds_lease_before_installing(
+    jobs: dict,  # type: ignore[type-arg]
+) -> None:
+    """The job's `if:` can only see the lease matrix AGGREGATE, so it cannot tell
+    "my cloud's lease succeeded" from "some cloud's did". Observed live: one
+    cloud's acquire failed on a transient TLS error and the aggregate skipped the
+    install for the two clouds whose leases HAD been taken — a run holding two
+    tenants that installed onto neither.
+
+    So the gate is widened to "the lease job ran" and each leg confirms its own
+    tenant. That verify step must come FIRST, before anything touches the tenant.
+    """
+    steps = jobs["prepare-tenant"]["steps"]
+    first = steps[0]
+    assert "e2e-tenant-lease" in str(first.get("uses", "")), (
+        "prepare-tenant's first step must confirm this leg holds its cloud's "
+        "lease; anything before it runs against an unverified tenant"
+    )
+    assert first["with"]["mode"] == "verify"
+    assert first["with"]["cloud"] == "${{ matrix.cloud }}"
+    assert first["with"]["app"] == "${{ inputs.app-name }}"
+
+
+@pytest.mark.parametrize(
+    ("lease_result", "should_install"),
+    [
+        ("success", True),
+        # The case that was broken: another cloud's lease failed. This leg must
+        # still get the chance to install, and its verify step decides.
+        ("failure", True),
+        ("skipped", False),
+    ],
+)
+def test_install_runs_whenever_the_lease_job_ran(
+    lease_result: str, should_install: bool
+) -> None:
+    expression = _load_gate("prepare-tenant")
+    contexts = {
+        "inputs": {"install-app-to-tenant": True},
+        "needs": {
+            "merge-e2e-image": {"result": "success"},
+            "lease-tenant": {"result": lease_result},
+        },
+    }
+    assert evaluate(expression, contexts) is should_install
 
 
 def test_the_legs_refuse_to_run_on_a_failed_lease(jobs: dict) -> None:  # type: ignore[type-arg]

--- a/.github/workflows/tests-reusable.yaml
+++ b/.github/workflows/tests-reusable.yaml
@@ -1141,10 +1141,24 @@ jobs:
     # "some cloud's lease succeeded", never "this leg's did". Observed live: one
     # cloud's acquire failed on a transient TLS error and the aggregate then
     # skipped the install for the two clouds whose leases HAD been taken — a run
-    # holding two tenants that installed onto neither. Widening the gate and
-    # verifying per-leg makes the precondition true per cloud instead of
-    # approximately true across clouds.
-    if: inputs.install-app-to-tenant && needs.merge-e2e-image.result == 'success' && needs.lease-tenant.result != 'skipped'
+    # holding two tenants that installed onto neither.
+    #
+    # `always()` is what makes the widening actually do anything, and it is easy
+    # to omit: without a status-check function GitHub applies an implicit
+    # success() over every `needs` entry and skips the job BEFORE this `if:` is
+    # consulted, so a failed lease leg would still skip the install everywhere
+    # and the per-cloud verify step below would never run. Same shape and same
+    # reason as the e2e legs' gate — see test_e2e_tolerates_skipped_but_not_failed_prepare.
+    #
+    # Because always() lifts that implicit success(), discover-e2e and
+    # merge-e2e-image have to be named explicitly here; they were previously
+    # carried by the implicit check.
+    if: |
+      always() &&
+      inputs.install-app-to-tenant &&
+      needs.discover-e2e.result == 'success' &&
+      needs.merge-e2e-image.result == 'success' &&
+      needs.lease-tenant.result != 'skipped'
     strategy:
       # One cloud's tenant being uninstallable must not cancel the others; the
       # legs for that cloud fail on their own version check.
@@ -1194,18 +1208,6 @@ jobs:
       FALLBACK_SDR_CLIENT_SECRET: ${{ secrets.SDR_CLIENT_SECRET }}
       FALLBACK_ATLAN_API_KEY: ${{ secrets.ATLAN_API_KEY }}
     steps:
-      # FIRST, before anything touches the tenant: confirm THIS leg holds THIS
-      # cloud's lease. The job's `if:` can only see the lease matrix aggregate, so
-      # it cannot tell "my cloud's lease succeeded" from "some cloud's did" — this
-      # is what makes the install's precondition true per cloud. Fails the leg
-      # rather than installing into a race.
-      - name: Confirm this run holds the tenant lease
-        uses: atlanhq/application-sdk/.github/actions/e2e-tenant-lease@main
-        with:
-          mode: verify
-          app: ${{ inputs.app-name }}
-          cloud: ${{ matrix.cloud }}
-
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
@@ -1214,15 +1216,48 @@ jobs:
       # fetched. Sparse + pinned to job.workflow_sha for the same reason as the
       # equivalent checkout in the e2e job: a PR editing these scripts must run
       # its own version, not main's.
+      #
+      # The lease driver is fetched here too, and the lease check below invokes it
+      # directly rather than through the composite action. `uses:` cannot take an
+      # expression, so an action reference can only ever be @main — which means a
+      # PR that adds a mode to the driver would call a main that does not have it
+      # yet and die at argument parsing, and a PR that changes the driver would
+      # silently exercise main's copy instead of its own. Both directions of that
+      # stale window are closed by running the checked-out driver.
       - name: Fetch SDK CI scripts
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: atlanhq/application-sdk
           ref: ${{ job.workflow_sha }}
-          sparse-checkout: .github/scripts
+          sparse-checkout: |
+            .github/scripts
+            .github/actions/e2e-tenant-lease
           sparse-checkout-cone-mode: false
           path: application-sdk-scripts
           persist-credentials: false
+
+      # Before anything touches the tenant: confirm THIS leg holds THIS cloud's
+      # lease. The job's `if:` can only see the lease matrix aggregate, so it
+      # cannot tell "my cloud's lease succeeded" from "some cloud's did" — this is
+      # what makes the install's precondition true per cloud. Fails the leg rather
+      # than installing into a race.
+      #
+      # It follows the two checkouts because neither touches the tenant; nothing
+      # between here and the install may be reordered above it.
+      - name: Confirm this run holds the tenant lease
+        env:
+          APP: ${{ inputs.app-name }}
+          CLOUD: ${{ matrix.cloud }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          python3 application-sdk-scripts/.github/actions/e2e-tenant-lease/e2e_tenant_lease.py \
+            --mode verify \
+            --repo "$GITHUB_REPOSITORY" \
+            --app "$APP" \
+            --cloud "$CLOUD" \
+            --run-id "$GITHUB_RUN_ID" \
+            --run-attempt "$GITHUB_RUN_ATTEMPT"
 
       # Two invocations, mask pass first — see the equivalent step in the e2e job
       # for why registering the matrix blob as a secret does not redact the values

--- a/.github/workflows/tests-reusable.yaml
+++ b/.github/workflows/tests-reusable.yaml
@@ -1134,9 +1134,17 @@ jobs:
   prepare-tenant:
     name: Prepare tenant (${{ matrix.cloud || 'default' }})
     needs: [discover-e2e, merge-e2e-image, lease-tenant]
-    # lease-tenant gates the install rather than merely preceding it: installing
-    # without the lease is the race this whole path exists to close.
-    if: inputs.install-app-to-tenant && needs.merge-e2e-image.result == 'success' && needs.lease-tenant.result == 'success'
+    # Gated on lease-tenant having RUN, not on it having succeeded, and then each
+    # leg confirms its OWN cloud's lease in its first step.
+    #
+    # `needs.lease-tenant.result` is the matrix AGGREGATE, so `== 'success'` means
+    # "some cloud's lease succeeded", never "this leg's did". Observed live: one
+    # cloud's acquire failed on a transient TLS error and the aggregate then
+    # skipped the install for the two clouds whose leases HAD been taken — a run
+    # holding two tenants that installed onto neither. Widening the gate and
+    # verifying per-leg makes the precondition true per cloud instead of
+    # approximately true across clouds.
+    if: inputs.install-app-to-tenant && needs.merge-e2e-image.result == 'success' && needs.lease-tenant.result != 'skipped'
     strategy:
       # One cloud's tenant being uninstallable must not cancel the others; the
       # legs for that cloud fail on their own version check.
@@ -1186,6 +1194,18 @@ jobs:
       FALLBACK_SDR_CLIENT_SECRET: ${{ secrets.SDR_CLIENT_SECRET }}
       FALLBACK_ATLAN_API_KEY: ${{ secrets.ATLAN_API_KEY }}
     steps:
+      # FIRST, before anything touches the tenant: confirm THIS leg holds THIS
+      # cloud's lease. The job's `if:` can only see the lease matrix aggregate, so
+      # it cannot tell "my cloud's lease succeeded" from "some cloud's did" — this
+      # is what makes the install's precondition true per cloud. Fails the leg
+      # rather than installing into a race.
+      - name: Confirm this run holds the tenant lease
+        uses: atlanhq/application-sdk/.github/actions/e2e-tenant-lease@main
+        with:
+          mode: verify
+          app: ${{ inputs.app-name }}
+          cloud: ${{ matrix.cloud }}
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false


### PR DESCRIPTION
Two bugs found by the live two-run verification of the CAS lease from #3134. They combined into one cascade.

## What happened

Run A took the **aws** and **gcp** leases. Its **azure** acquire died on `curl: (60) SSL certificate problem` — a transient TLS blip on that runner. The resulting matrix aggregate then skipped `prepare-tenant` for **all three clouds**. A run holding two tenants installed onto neither.

```
23:29:13  A acquired aws, gcp
23:29:21  A azure acquire → curl (60) SSL certificate problem → job failed
          A prepare-tenant → skipped (lease-tenant aggregate = failure)
23:29:31  A released aws, gcp, azure
23:29:37  B acquired aws, gcp, azure
23:29:59  B legs started
23:36:10  B last leg finished
23:36:13  B released
```

## 1. A transient transport failure was fatal

`gh_request` raised on any non-zero curl exit, so one blip — DNS, connect, timeout, TLS — failed the lease job outright. Transport failures and 5xx answers are now retried three times with a doubling backoff.

**4xx is deliberately not retried.** 422 is the lock being held; retrying it would turn the atomic primitive into a busy-wait and mask contention. A test pins that.

## 2. `prepare-tenant` gated on the matrix aggregate

`needs.lease-tenant.result == 'success'` reads the **aggregate** across clouds, so it says "some cloud's lease succeeded" and never "this leg's did". A matrix job cannot depend on its own leg of an upstream matrix job, so there is no expression that says what this gate wanted to say.

The gate is now `!= 'skipped'` ("the lease job ran"), and each leg confirms its own tenant in its **first** step via a new `--mode verify` — before anything touches the tenant. A leg whose own acquire failed now fails instead of installing into a race. That makes the install's precondition true *per cloud* rather than approximately true across clouds.

Same class of bug as the `release-tenant` aggregate gate fixed in #3134 — and that fix is confirmed working in this same run: release ran for all three clouds despite the lease aggregate being `failure`, which is exactly what it was for.

## What the verification did prove

* **Mutual exclusion holds.** One holder per cloud throughout, read directly off `refs/e2e-tenant-lease/openapi/<cloud>/holder` and decoded rather than inferred from job outcomes. B acquired at 23:29:37, after A released at 23:29:31 — no overlap.
* **The lease is held across the install AND the legs**, which is the property `concurrency:` structurally cannot provide: B acquired 23:29:37, legs ran 23:29:59–23:36:10, released 23:36:13.
* **`state=acquired`, not `disabled`** — real refs with real holder blobs, so the fail-open path was not silently in play.
* azure and gcp legs passed. aws failed on a known tenant issue, unrelated.

## Still not proven

**The waiting path.** B never had to wait, because bug 1 collapsed A's run in 18 seconds instead of letting it hold through a full install-plus-legs. Once this lands, a re-run should show A holding for ~6 minutes and B logging `waiting for ... held by run <A>` before acquiring. I'd rather say that plainly than call the queue verified on a run where nothing queued.

## Residual, noted not fixed

The e2e legs still gate on the `prepare-tenant` aggregate, so one cloud's failed install blocks every cloud's legs. That over-blocks but is safe — no install means no test — and it predates the lease. GitHub cannot express per-leg matrix dependencies, so closing it means restructuring the fan-out.

## Tests

`.github/scripts/tests/` — **1733 passed**, 109 for the lease driver. New: transport retry (transient, persistent, 5xx, 4xx-not-retried, backoff growth) and per-cloud verify (held, held-by-another, unheld, wrong attempt, both CLI paths), plus an evaluated wiring test that `prepare-tenant` runs when the lease job ran and its verify step is first. Pre-commit clean.

Refs: FND-250
