### PR TITLE
ci(trivy): decouple scan reporting from enforcement so a comment blip can't eject a PR

### DIFF
--- a/.github/actions/trivy/action.yaml
+++ b/.github/actions/trivy/action.yaml
@@ -102,33 +102,39 @@ runs:
     # entries, where the comment would land on an already-approved PR that is
     # seconds from merging.
     #
-    # The two comment steps are `continue-on-error` because this job is a
+    # Every reporting step is `continue-on-error` because this job is a
     # required status check: a transient GitHub API or TLS error while posting
     # a decorative comment used to fail the check outright, which ejects the
     # entry from the merge queue and throws away every other check in it
-    # (FND-256). Reporting must never be able to do that; enforcement below is
-    # what is allowed to fail the job.
+    # (FND-256). The preparation steps have the same failure shape one step
+    # earlier — a `pip install` blip or a malformed JSON render must not eject
+    # the PR either. Reporting must never be able to do that; enforcement below
+    # is what is allowed to fail the job.
 
     - name: Set up Python
       if: inputs.add-report-comment-to-pr == 'true' && github.event_name == 'pull_request'
+      continue-on-error: true
       uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
       with:
         python-version: '3.14'
 
     - name: Install Dependencies
       if: inputs.add-report-comment-to-pr == 'true' && github.event_name == 'pull_request'
+      continue-on-error: true
       shell: bash
       run: |
         pip install mdutils
 
     - name: Convert Vulnerability Scan Results to Markdown
       if: inputs.add-report-comment-to-pr == 'true' && github.event_name == 'pull_request'
+      continue-on-error: true
       shell: bash
       run: |
         python .github/scripts/trivy-to-markdown.py trivy-vuln-results.json trivy-vuln-results.md Vulnerability
 
     - name: Convert Secret Scan Results to Markdown
       if: inputs.add-report-comment-to-pr == 'true' && github.event_name == 'pull_request'
+      continue-on-error: true
       shell: bash
       run: |
         python .github/scripts/trivy-to-markdown.py trivy-secret-results.json trivy-secret-results.md Secret

--- a/.github/actions/trivy/action.yaml
+++ b/.github/actions/trivy/action.yaml
@@ -7,7 +7,21 @@ description: |
 
 inputs:
   add-report-comment-to-pr:
-    description: Whether to add a comment to the PR with the Trivy scan results
+    description: |
+      Whether to post the scan reports as PR comments. Reporting only — it has
+      no bearing on whether findings gate the check; that is `fail-on-findings`.
+      Comments are additionally skipped on any event other than `pull_request`,
+      because a `merge_group` entry has no PR of its own worth annotating.
+    required: false
+    default: 'true'
+
+  fail-on-findings:
+    description: |
+      Whether to fail the job on HIGH/CRITICAL vulnerabilities that have a fix
+      available, or on any detected secret. This is the enforcement switch, and
+      it is deliberately separate from the reporting one above: the two shared a
+      single input until FND-256, so turning comments off would have silently
+      turned the security gate off with them.
     required: false
     default: 'true'
 
@@ -81,46 +95,68 @@ runs:
         sarif_file: 'trivy-secret-results.sarif'
         category: 'trivy-secret'
 
+    # ── Reporting ────────────────────────────────────────────────────────────
+    # Everything from here to the enforcement block exists only to render the
+    # JSON reports into PR comments, so all of it carries the same gate. The
+    # `pull_request` half of that gate keeps the work out of `merge_group`
+    # entries, where the comment would land on an already-approved PR that is
+    # seconds from merging.
+    #
+    # The two comment steps are `continue-on-error` because this job is a
+    # required status check: a transient GitHub API or TLS error while posting
+    # a decorative comment used to fail the check outright, which ejects the
+    # entry from the merge queue and throws away every other check in it
+    # (FND-256). Reporting must never be able to do that; enforcement below is
+    # what is allowed to fail the job.
+
     - name: Set up Python
-      if: inputs.add-report-comment-to-pr == 'true'
+      if: inputs.add-report-comment-to-pr == 'true' && github.event_name == 'pull_request'
       uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
       with:
         python-version: '3.14'
 
     - name: Install Dependencies
-      if: inputs.add-report-comment-to-pr == 'true'
+      if: inputs.add-report-comment-to-pr == 'true' && github.event_name == 'pull_request'
       shell: bash
       run: |
         pip install mdutils
 
     - name: Convert Vulnerability Scan Results to Markdown
-      if: inputs.add-report-comment-to-pr == 'true'
+      if: inputs.add-report-comment-to-pr == 'true' && github.event_name == 'pull_request'
       shell: bash
       run: |
         python .github/scripts/trivy-to-markdown.py trivy-vuln-results.json trivy-vuln-results.md Vulnerability
 
     - name: Convert Secret Scan Results to Markdown
-      if: inputs.add-report-comment-to-pr == 'true'
+      if: inputs.add-report-comment-to-pr == 'true' && github.event_name == 'pull_request'
       shell: bash
       run: |
         python .github/scripts/trivy-to-markdown.py trivy-secret-results.json trivy-secret-results.md Secret
 
     - name: Comment on PR with Vulnerability Scan Results
-      if: inputs.add-report-comment-to-pr == 'true'
+      if: inputs.add-report-comment-to-pr == 'true' && github.event_name == 'pull_request'
+      continue-on-error: true
       uses: mshick/add-pr-comment@ec328af66588ab8f77cdeb2c264f14aba45bbf59 # v3
       with:
         message-id: trivy-vuln
         message-path: trivy-vuln-results.md
 
     - name: Comment on PR with Secret Scan Results
-      if: inputs.add-report-comment-to-pr == 'true'
+      if: inputs.add-report-comment-to-pr == 'true' && github.event_name == 'pull_request'
+      continue-on-error: true
       uses: mshick/add-pr-comment@ec328af66588ab8f77cdeb2c264f14aba45bbf59 # v3
       with:
         message-id: trivy-secret
         message-path: trivy-secret-results.md
 
+    # ── Enforcement ──────────────────────────────────────────────────────────
+    # The only steps permitted to fail this job, and the reason it is a required
+    # check. Gated on `fail-on-findings`, never on the reporting switch, and
+    # never on the event name: a `merge_group` entry gets exactly the same gate
+    # as the PR did.
+
     - name: Fail on High/Critical Vulnerabilities (with fix available)
-      if: inputs.add-report-comment-to-pr == 'true'
+      if: inputs.fail-on-findings == 'true'
       uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
       with:
         scan-type: 'fs'
@@ -134,7 +170,7 @@ runs:
         TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db:1
 
     - name: Fail on Any Secrets Found
-      if: inputs.add-report-comment-to-pr == 'true'
+      if: inputs.fail-on-findings == 'true'
       uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
       with:
         scan-type: 'fs'

--- a/.github/scripts/tests/test_trivy_action_gates.py
+++ b/.github/scripts/tests/test_trivy_action_gates.py
@@ -1,0 +1,219 @@
+"""Guards for the reporting/enforcement split in .github/actions/trivy (FND-256).
+
+`Trivy Code Scan` is a required status check, and the composite action behind it
+does two unrelated things: it *reports* findings (markdown render → PR comment)
+and it *enforces* them (a second scan with `exit-code: 1`). Both used to hang off
+a single `add-report-comment-to-pr` input, which produced two distinct failures:
+
+1. A transient GitHub API/TLS error while posting a decorative comment failed the
+   required check, which ejects the entry from the merge queue and discards every
+   other check in it. That is what happened to #3105.
+2. The obvious fix — turn commenting off outside `pull_request` — would also have
+   turned off the vulnerability and secret gates, silently. Nothing would have
+   gone red; the check would simply have stopped checking.
+
+So the contract this file pins is a separation, not a behaviour: reporting may be
+skipped and may fail harmlessly, enforcement may do neither. Both halves are
+GitHub-evaluated `if:` expressions and `continue-on-error` flags that no runner
+is available to exercise here, so each gate is lifted verbatim out of the YAML
+and evaluated against synthetic contexts — the same approach as
+test_label_trigger_gates.py, and for the same reason: a presence check proves a
+term is there, not that it is wired in at the right precedence.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _gha_expr import evaluate  # noqa: E402
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_ACTION = _REPO_ROOT / ".github/actions/trivy/action.yaml"
+_CALLER = _REPO_ROOT / ".github/workflows/pull_request.yaml"
+
+#: Steps that exist only to produce the PR comment. Skippable, and harmless if
+#: they fail.
+_REPORTING_STEPS = (
+    "Set up Python",
+    "Install Dependencies",
+    "Convert Vulnerability Scan Results to Markdown",
+    "Convert Secret Scan Results to Markdown",
+    "Comment on PR with Vulnerability Scan Results",
+    "Comment on PR with Secret Scan Results",
+)
+
+#: The steps that actually gate the check. Neither skippable by event nor
+#: allowed to swallow its own failure.
+_ENFORCEMENT_STEPS = (
+    "Fail on High/Critical Vulnerabilities (with fix available)",
+    "Fail on Any Secrets Found",
+)
+
+#: The two steps whose failure must not fail the job.
+_NON_FATAL_STEPS = (
+    "Comment on PR with Vulnerability Scan Results",
+    "Comment on PR with Secret Scan Results",
+)
+
+#: Events that reach the trivy job. `merge_group` is the one that motivated
+#: FND-256; `pull_request` is where the comment is actually wanted.
+_EVENTS = ("pull_request", "merge_group")
+
+
+def _action() -> dict[str, Any]:
+    return yaml.safe_load(_ACTION.read_text(encoding="utf-8"))
+
+
+def _steps() -> list[dict[str, Any]]:
+    return _action()["runs"]["steps"]
+
+
+def _step(name: str) -> dict[str, Any]:
+    for step in _steps():
+        if step.get("name") == name:
+            return step
+    raise AssertionError(f"{_ACTION.name} has no step named {name!r}")
+
+
+def _gate(name: str) -> str:
+    gate = _step(name).get("if")
+    assert gate, f"step {name!r} lost its `if:` gate"
+    return str(gate)
+
+
+def _contexts(*, event: str, comment: str, fail: str) -> dict[str, Any]:
+    return {
+        "github": {"event_name": event},
+        "inputs": {
+            "add-report-comment-to-pr": comment,
+            "fail-on-findings": fail,
+        },
+    }
+
+
+# ── Reporting is skipped outside pull_request ────────────────────────────────
+
+
+@pytest.mark.parametrize("name", _REPORTING_STEPS)
+@pytest.mark.parametrize(
+    "event, comment, expected",
+    [
+        ("pull_request", "true", True),
+        ("pull_request", "false", False),
+        ("merge_group", "true", False),
+        ("merge_group", "false", False),
+    ],
+)
+def test_reporting_runs_only_on_pull_request_when_enabled(
+    name: str, event: str, comment: str, expected: bool
+) -> None:
+    # `fail` is varied separately below; reporting must not consult it at all,
+    # which the invariance test pins. Here it is held at the default.
+    gate = _gate(name)
+    assert (
+        evaluate(gate, _contexts(event=event, comment=comment, fail="true")) is expected
+    )
+
+
+@pytest.mark.parametrize("name", _REPORTING_STEPS)
+def test_reporting_gate_ignores_the_enforcement_switch(name: str) -> None:
+    """Turning enforcement off must not silently stop the reports too."""
+    gate = _gate(name)
+    with_enforcement = evaluate(
+        gate, _contexts(event="pull_request", comment="true", fail="true")
+    )
+    without_enforcement = evaluate(
+        gate, _contexts(event="pull_request", comment="true", fail="false")
+    )
+    assert with_enforcement is without_enforcement is True
+
+
+# ── Enforcement is not skippable ─────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("name", _ENFORCEMENT_STEPS)
+@pytest.mark.parametrize("event", _EVENTS)
+@pytest.mark.parametrize("comment", ("true", "false"))
+def test_enforcement_runs_on_every_event_regardless_of_reporting(
+    name: str, event: str, comment: str
+) -> None:
+    """The regression that would make the required check stop checking.
+
+    A `merge_group` entry must get the same gate the PR got, and the reporting
+    switch must not be able to reach it — this is the exact coupling FND-256
+    removed.
+    """
+    gate = _gate(name)
+    assert evaluate(gate, _contexts(event=event, comment=comment, fail="true")) is True
+
+
+@pytest.mark.parametrize("name", _ENFORCEMENT_STEPS)
+@pytest.mark.parametrize("event", _EVENTS)
+def test_enforcement_is_switched_by_its_own_input(name: str, event: str) -> None:
+    gate = _gate(name)
+    assert evaluate(gate, _contexts(event=event, comment="true", fail="false")) is False
+
+
+@pytest.mark.parametrize("name", _ENFORCEMENT_STEPS)
+def test_enforcement_gate_never_mentions_the_reporting_input(name: str) -> None:
+    """Belt to the invariance test's braces.
+
+    Evaluation proves the coupling is gone for the payloads tried; the textual
+    check proves nobody reintroduced the input in a term those payloads happen
+    not to distinguish (`|| inputs.add-report-comment-to-pr == 'maybe'`).
+    """
+    assert "add-report-comment-to-pr" not in _gate(name)
+
+
+# ── Failure containment ──────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("name", _NON_FATAL_STEPS)
+def test_comment_steps_cannot_fail_the_required_check(name: str) -> None:
+    step = _step(name)
+    assert step.get("continue-on-error") is True, (
+        f"{name!r} must be continue-on-error: a transient API error while "
+        "posting a comment would otherwise eject the PR from the merge queue"
+    )
+
+
+@pytest.mark.parametrize("name", _ENFORCEMENT_STEPS)
+def test_enforcement_steps_are_allowed_to_fail_the_job(name: str) -> None:
+    step = _step(name)
+    assert "continue-on-error" not in step, (
+        f"{name!r} is the check's teeth; continue-on-error would make the "
+        "required status check report success on real findings"
+    )
+
+
+# ── Inputs fail closed ───────────────────────────────────────────────────────
+
+
+def test_enforcement_input_exists_and_defaults_to_on() -> None:
+    inputs = _action()["inputs"]
+    assert "fail-on-findings" in inputs, (
+        "enforcement must have its own input; sharing one with reporting is the "
+        "bug FND-256 fixed"
+    )
+    assert (
+        inputs["fail-on-findings"]["default"] == "true"
+    ), "a caller that omits the input must still get the security gate"
+
+
+def test_caller_passes_both_switches_explicitly() -> None:
+    """The one caller states both, so editing one is visibly not editing both."""
+    workflow = yaml.safe_load(_CALLER.read_text(encoding="utf-8"))
+    steps = workflow["jobs"]["trivy"]["steps"]
+    invocations = [s for s in steps if s.get("uses") == "./.github/actions/trivy"]
+    assert len(invocations) == 1, "expected exactly one trivy action invocation"
+
+    passed = invocations[0].get("with") or {}
+    assert passed.get("fail-on-findings") == "true"
+    assert passed.get("add-report-comment-to-pr") == "true"

--- a/.github/scripts/tests/test_trivy_action_gates.py
+++ b/.github/scripts/tests/test_trivy_action_gates.py
@@ -13,10 +13,11 @@ a single `add-report-comment-to-pr` input, which produced two distinct failures:
    gone red; the check would simply have stopped checking.
 
 So the contract this file pins is a separation, not a behaviour: reporting may be
-skipped and may fail harmlessly, enforcement may do neither. Both halves are
-GitHub-evaluated `if:` expressions and `continue-on-error` flags that no runner
-is available to exercise here, so each gate is lifted verbatim out of the YAML
-and evaluated against synthetic contexts — the same approach as
+skipped and may fail harmlessly — every reporting step, from Python setup to the
+comment post, is `continue-on-error` — while enforcement may do neither. Both
+halves are GitHub-evaluated `if:` expressions and `continue-on-error` flags that
+no runner is available to exercise here, so each gate is lifted verbatim out of
+the YAML and evaluated against synthetic contexts — the same approach as
 test_label_trigger_gates.py, and for the same reason: a presence check proves a
 term is there, not that it is wired in at the right precedence.
 """
@@ -56,11 +57,11 @@ _ENFORCEMENT_STEPS = (
     "Fail on Any Secrets Found",
 )
 
-#: The two steps whose failure must not fail the job.
-_NON_FATAL_STEPS = (
-    "Comment on PR with Vulnerability Scan Results",
-    "Comment on PR with Secret Scan Results",
-)
+#: The steps whose failure must not fail the job: all of reporting. The comment
+#: posts are the FND-256 case; the four preparation steps share the failure
+#: shape one step earlier (a `pip install` blip would eject the PR before the
+#: enforcement scans even run), so the invariant pins them too.
+_NON_FATAL_STEPS = _REPORTING_STEPS
 
 #: Events that reach the trivy job. `merge_group` is the one that motivated
 #: FND-256; `pull_request` is where the comment is actually wanted.
@@ -176,11 +177,12 @@ def test_enforcement_gate_never_mentions_the_reporting_input(name: str) -> None:
 
 
 @pytest.mark.parametrize("name", _NON_FATAL_STEPS)
-def test_comment_steps_cannot_fail_the_required_check(name: str) -> None:
+def test_reporting_steps_cannot_fail_the_required_check(name: str) -> None:
     step = _step(name)
     assert step.get("continue-on-error") is True, (
-        f"{name!r} must be continue-on-error: a transient API error while "
-        "posting a comment would otherwise eject the PR from the merge queue"
+        f"{name!r} must be continue-on-error: a transient failure anywhere in "
+        "reporting — a comment post, a pip install, a markdown render — would "
+        "otherwise eject the PR from the merge queue"
     )
 
 

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -165,7 +165,12 @@ jobs:
       - uses: "./.github/actions/trivy"
         if: needs.changes.outputs.scan == 'true'
         with:
+          # Reporting and enforcement are separate switches on purpose — see the
+          # action's input docs. Both are passed explicitly so that a future edit
+          # to one is visibly not an edit to the other. The action itself skips
+          # the comments on merge_group; enforcement runs on every event.
           add-report-comment-to-pr: "true"
+          fail-on-findings: "true"
 
   trivy-container:
     name: Trivy Container Scan


### PR DESCRIPTION
## What happened

#3105 was ejected from the merge queue at `01:30:01Z`. The required **`Trivy Code Scan`** check failed in its `merge_group` run ([31553683389 → PR Checks 31553711412](https://github.com/atlanhq/application-sdk/actions/runs/31553711412)), in the last cosmetic step of the composite action:

```
##[start-action display=Comment on PR with Vulnerability Scan Results;id=__self.__mshick_add-pr-comment]
##[error]self-signed certificate; if the root CA is installed locally, try running Node.js with --use-system-ca
##[end-action ... outcome=failure ... duration_ms=242]
```

A transient Node TLS error from `mshick/add-pr-comment`, 242 ms in. **Transient, not structural to `merge_group`**: 42 minutes earlier the same step ran and succeeded (524 ms) in the entry for pr-3137.

Nothing else in the entry was unhappy — `SDR K8s E2E (LM)` succeeded (dispatched run 602 s), as did all three connector E2E dispatches, the Connector Tests Gate, and every SDK Gate / conformance leg. In particular this was **not** the recent `(app, cloud)` tenant-lease work (#3131 / #3134 / #3138): since #3131 landed, #3105 is the only `merge_group` failure and it is not lease-related. The three earlier `merge_group` failures (pr-3108, pr-2894, pr-3127) were all `SDR K8s E2E (LM)` — the ref-keyed-concurrency problem FND-218 and the lease work fixed.

## Why it needed more than a one-line `if:`

The action does two unrelated jobs — it *reports* findings (markdown render → PR comment) and it *enforces* them (a second scan with `exit-code: 1`) — and both hung off a single `add-report-comment-to-pr` input. So the obvious fix, gating comments to `pull_request`, would have taken `Fail on High/Critical Vulnerabilities (with fix available)` and `Fail on Any Secrets Found` down with them. Nothing would have gone red; the required check would simply have stopped checking. Only one caller exists and it passes `"true"`, so nothing was unenforced in practice — but the coupling had to go first.

## The change

| | before | after |
|---|---|---|
| comment steps | `add-report-comment-to-pr == 'true'`, fatal on error | `… && github.event_name == 'pull_request'`, `continue-on-error: true` |
| markdown render + Python setup | `add-report-comment-to-pr == 'true'` | same gate as the comments (they only feed them) |
| the two `Fail on …` steps | **`add-report-comment-to-pr == 'true'`** | `fail-on-findings == 'true'` — new input, default `'true'` |

Reporting may now be skipped and may fail harmlessly; enforcement may do neither, and runs identically on `pull_request` and `merge_group`. This is the shape the sibling `trivy-container` action already has (`fail-on-vulns` for enforcement, `continue-on-error` on decoration), so the two are now consistent.

`fail-on-findings` defaults to `'true'` so a caller that omits it still gets the gate — fail-closed. The one in-repo caller passes both switches explicitly, so a future edit to one is visibly not an edit to the other.

## Testing

`.github/scripts/tests/test_trivy_action_gates.py` (50 cases) lifts each gate verbatim out of the YAML and evaluates it against synthetic contexts via `_gha_expr`, per the `docs/standards/ci.md` convention for gates that no runner can exercise locally. It pins: reporting runs only on `pull_request` and only when enabled; enforcement runs on every event regardless of the reporting switch, and never textually mentions it; the comment steps carry `continue-on-error` and the enforcing steps do not; the new input exists and defaults on.

Mutation-checked — reinstating either half of the old coupling (the shared input, or a dropped `continue-on-error`) turns six of those tests red.

Full `.github/scripts/tests` suite: 1791 passed. Pre-commit clean on all three files.

## Blast radius

One downstream repo in the org pins this action at `@main`. It passes `add-report-comment-to-pr: "true"` and already wraps the whole step in `continue-on-error`, so its enforcement behaviour is unchanged (new input defaults on) and it simply stops doing comment work on its `push` and `schedule` triggers, where the comment had nowhere to go. No shim needed: the existing input keeps its name, default, and meaning for reporting.

## Deliberately out of scope

- **The `upload-sarif` steps are left fatal.** They are the path by which findings reach the Security tab, so making them non-fatal trades a queue-cycle risk for a silent reporting gap. Different call, worth making separately if it ever actually fires.
- **A dequeued entry does not cancel its dispatched downstream run.** In the #3105 entry, `SDR K8s E2E (LM)` kept running until `01:38:59Z` — ~9 minutes after the entry was ejected at `01:30:01Z` — so the dispatched run went on holding the tenant lease for a dead entry. Noted as a follow-up on FND-256 rather than fixed here.

Closes FND-256.
