### PR TITLE
fix(contract-toolkit): gate single-parent dependsOn on parent success (FND-261)

### DIFF
--- a/application_sdk/testing/e2e/payload.py
+++ b/application_sdk/testing/e2e/payload.py
@@ -258,7 +258,7 @@ def build_seed_dag(
                     "output_prefix": "$.extract.outputs.view_lineage_output_prefix",
                 },
             },
-            "depends_on": {"node_id": "extract"},
+            "depends_on": {"node_id": "extract", "tag": "success"},
         },
         "publish": {
             "node_type": "workflow",
@@ -276,7 +276,7 @@ def build_seed_dag(
                     "current_state_prefix": "$.extract.outputs.current_state_prefix",
                 },
             },
-            "depends_on": {"node_id": "extract"},
+            "depends_on": {"node_id": "extract", "tag": "success"},
         },
         "lineage-app": {
             "node_type": "workflow",

--- a/application_sdk/testing/full_dag/payload.py
+++ b/application_sdk/testing/full_dag/payload.py
@@ -253,7 +253,7 @@ def build_seed_dag(
                     "output_prefix": "$.extract.outputs.view_lineage_output_prefix",
                 },
             },
-            "depends_on": {"node_id": "extract"},
+            "depends_on": {"node_id": "extract", "tag": "success"},
         },
         "publish": {
             "node_type": "workflow",
@@ -283,7 +283,7 @@ def build_seed_dag(
                     "current_state_prefix": "$.extract.outputs.current_state_prefix",
                 },
             },
-            "depends_on": {"node_id": "extract"},
+            "depends_on": {"node_id": "extract", "tag": "success"},
         },
         "lineage-app": {
             "node_type": "workflow",

--- a/contract-toolkit/docs/reference.md
+++ b/contract-toolkit/docs/reference.md
@@ -1585,16 +1585,19 @@ time instead of at AE parse time.
 
 `dependsOn` emits two shapes based on list length:
 
-- 1 entry → `"depends_on": {"node_id": "..."}` (fires on the parent's SUCCESS *or* FAILURE)
+- 1 entry → `"depends_on": {"node_id": "...", "tag": "success"}`
+  (node is scheduled only when the parent reaches SUCCESS)
 - 2+ entries → `"depends_on": {"and_conditions": [{"node_id": "...", "tag": "success"}, ...]}`
   (strict AND-fan-in: node is scheduled only when every listed parent reaches SUCCESS)
 
-The `tag: "success"` in the multi-parent shape is honored by AE's condition evaluator
-(`automation_engine/workflows/graph.py`), which gates on
-`WorkflowRunNodeStatus.SUCCESS`. Because single-parent emission omits `tag`, adding a
-second entry to an existing `dependsOn` is not a pure additive change — it switches the
-node from "fire on any completion" to "fire only on all-success". Call this out in the
-app PR that introduces the second entry. See `examples/fanin/` for a minimal example.
+Both shapes carry `tag: "success"`. AE's condition evaluator
+(`automation_engine/workflows/graph.py`) honors it by gating on
+`WorkflowRunNodeStatus.SUCCESS`, so a failed or skipped parent leaves the dependent
+node Skipped rather than scheduling it. Adding an entry to an existing `dependsOn` is
+therefore purely additive: it widens the set of parents that must succeed without
+changing the gate itself. A node that genuinely must run regardless of its parent's
+outcome needs `dependsOnCondition` with an explicit tag (or the run-level
+`workflow_complete` tag) instead. See `examples/fanin/` for a minimal example.
 
 Pkl listing amendment matters for pre-built nodes. Nodes such as `PublishNode`,
 `QueryIntelligenceNode`, and `LineageNode` define defaults like
@@ -2791,7 +2794,7 @@ behavior.
           "connection_entity": "{{connection}}"
         }
       },
-      "depends_on": { "node_id": "extract" }
+      "depends_on": { "node_id": "extract", "tag": "success" }
     }
   }
 }

--- a/contract-toolkit/docs/reference.md
+++ b/contract-toolkit/docs/reference.md
@@ -1595,9 +1595,45 @@ Both shapes carry `tag: "success"`. AE's condition evaluator
 `WorkflowRunNodeStatus.SUCCESS`, so a failed or skipped parent leaves the dependent
 node Skipped rather than scheduling it. Adding an entry to an existing `dependsOn` is
 therefore purely additive: it widens the set of parents that must succeed without
-changing the gate itself. A node that genuinely must run regardless of its parent's
-outcome needs `dependsOnCondition` with an explicit tag (or the run-level
-`workflow_complete` tag) instead. See `examples/fanin/` for a minimal example.
+changing the gate itself. See `examples/fanin/` for a minimal example.
+
+**Opting out of the success gate (ordering-only dependencies).** `dependsOn` is
+deliberately fail-fast, because that is what almost every connector pipeline wants. When
+a node must run purely for *sequencing* — after the parent settles, whatever its outcome
+— omit the tag and spell the dependency out with `dependsOnCondition`:
+
+```pkl
+// Single parent, ordering only → "depends_on": {"node_id": "extract"}
+dependsOnCondition = new DependencyCondition { nodeId = "extract" }
+
+// Several parents, ordering only
+dependsOnCondition = new DependencyCondition {
+  andConditions {
+    new DependencyCondition { nodeId = "extract" }
+    new DependencyCondition { nodeId = "publish" }
+  }
+}
+
+// Mixed: extract must succeed, publish only has to settle
+dependsOnCondition = new DependencyCondition {
+  andConditions {
+    new DependencyCondition { nodeId = "extract"; tag = "success" }
+    new DependencyCondition { nodeId = "publish" }
+  }
+}
+```
+
+An untagged node condition is ready once that parent's status is SUCCESS *or* FAILURE —
+the pre-fix `dependsOn` behavior, now opt-in per dependency instead of implicit. Two
+caveats:
+
+- It is failure-tolerant but **not** skip-tolerant. A *skipped* parent has neither status,
+  so the dependent node is skipped too and skips cascade down the branch. For a node that
+  must run even when upstream never executed, use the run-level `workflow_complete` tag
+  (see `NotificationNode`) rather than an untagged node condition.
+- On pre-built nodes that ship a default `dependsOn` (`PublishNode`,
+  `QueryIntelligenceNode`, `LineageNode`), set `dependsOn = null` first — the two
+  properties are mutually exclusive and `pkl eval` rejects setting both.
 
 Pkl listing amendment matters for pre-built nodes. Nodes such as `PublishNode`,
 `QueryIntelligenceNode`, and `LineageNode` define defaults like

--- a/contract-toolkit/examples/bundle/app/generated/crawler/manifest.json
+++ b/contract-toolkit/examples/bundle/app/generated/crawler/manifest.json
@@ -49,7 +49,8 @@
         }
       },
       "depends_on": {
-        "node_id": "extract"
+        "node_id": "extract",
+        "tag": "success"
       },
       "error_handling": {
         "start_to_close_timeout_seconds": 259200

--- a/contract-toolkit/examples/fanin/app.pkl
+++ b/contract-toolkit/examples/fanin/app.pkl
@@ -1,20 +1,24 @@
 /// Minimal example demonstrating DAG dependencies.
 ///
-/// With 2+ entries in `dependsOn`, the renderer emits AE's fan-in shape:
+/// `dependsOn` is fail-fast at every list length — every entry it emits carries
+/// `tag: "success"`, so a node is scheduled only once its parent(s) SUCCEED:
 ///
-///     "depends_on": {
+///     dependsOn { "extract" }      → {"node_id": "extract", "tag": "success"}
+///
+///     dependsOn { "left"; "right" } → {
 ///       "and_conditions": [
 ///         {"node_id": "left",  "tag": "success"},
 ///         {"node_id": "right", "tag": "success"}
 ///       ]
 ///     }
 ///
-/// `tag: "success"` gates `join` on BOTH parents reaching SUCCESS.
+/// To opt out and depend on a parent purely for *ordering* — run once it settles,
+/// whatever the outcome — omit the tag via `dependsOnCondition` (see `audit` and
+/// `mixed-gate` below). An untagged node condition is satisfied by SUCCESS or
+/// FAILURE, but not by a SKIPPED parent.
 ///
 /// For tags, OR conditions, or nested conditions, use the explicit
 /// `dependsOnCondition` API instead of overloading `dependsOn`.
-///
-/// See also: `trino/app.pkl` for the single-parent `dependsOn` pattern.
 amends "../../src/App.pkl"
 
 import "../../src/Connectors.pkl"
@@ -86,6 +90,28 @@ extraNodes {
           nodeId = "right"
           tag = "failure"
         }
+      }
+    }
+  }
+  // Ordering-only opt-out: `dependsOn { "join" }` would gate this on `join`
+  // succeeding. An untagged `dependsOnCondition` keeps the sequencing without
+  // the success gate, so the audit still runs when `join` fails.
+  ["audit"] = new DAGNode {
+    displayName = "Audit After Join Settles"
+    workflowType = "AuditWorkflow"
+    args {}
+    dependsOnCondition = new DependencyCondition { nodeId = "join" }
+  }
+  // Per-parent gating, which the `dependsOn` shorthand cannot express: `left`
+  // must succeed, `right` only has to reach a terminal state.
+  ["mixed-gate"] = new DAGNode {
+    displayName = "Left Must Succeed, Right Must Settle"
+    workflowType = "MixedGateWorkflow"
+    args {}
+    dependsOnCondition = new DependencyCondition {
+      andConditions {
+        new DependencyCondition { nodeId = "left"; tag = "success" }
+        new DependencyCondition { nodeId = "right" }
       }
     }
   }

--- a/contract-toolkit/examples/fanin/app/generated/manifest.json
+++ b/contract-toolkit/examples/fanin/app/generated/manifest.json
@@ -148,6 +148,52 @@
       "error_handling": {
         "start_to_close_timeout_seconds": 86400
       }
+    },
+    "audit": {
+      "activity_name": "execute_workflow",
+      "activity_display_name": "Audit After Join Settles",
+      "app_name": "automation-engine",
+      "inputs": {
+        "workflow_type": "AuditWorkflow",
+        "app_name": "automation-engine",
+        "task_queue": "atlan-automation-engine-{deployment_name}",
+        "args": {
+          "app_name": "automation-engine"
+        }
+      },
+      "depends_on": {
+        "node_id": "join"
+      },
+      "error_handling": {
+        "start_to_close_timeout_seconds": 86400
+      }
+    },
+    "mixed-gate": {
+      "activity_name": "execute_workflow",
+      "activity_display_name": "Left Must Succeed, Right Must Settle",
+      "app_name": "automation-engine",
+      "inputs": {
+        "workflow_type": "MixedGateWorkflow",
+        "app_name": "automation-engine",
+        "task_queue": "atlan-automation-engine-{deployment_name}",
+        "args": {
+          "app_name": "automation-engine"
+        }
+      },
+      "depends_on": {
+        "and_conditions": [
+          {
+            "node_id": "left",
+            "tag": "success"
+          },
+          {
+            "node_id": "right"
+          }
+        ]
+      },
+      "error_handling": {
+        "start_to_close_timeout_seconds": 86400
+      }
     }
   }
 }

--- a/contract-toolkit/examples/fanin/app/generated/manifest.json
+++ b/contract-toolkit/examples/fanin/app/generated/manifest.json
@@ -46,7 +46,8 @@
         }
       },
       "depends_on": {
-        "node_id": "extract"
+        "node_id": "extract",
+        "tag": "success"
       },
       "error_handling": {
         "start_to_close_timeout_seconds": 259200
@@ -65,7 +66,8 @@
         }
       },
       "depends_on": {
-        "node_id": "extract"
+        "node_id": "extract",
+        "tag": "success"
       },
       "error_handling": {
         "start_to_close_timeout_seconds": 86400
@@ -84,7 +86,8 @@
         }
       },
       "depends_on": {
-        "node_id": "extract"
+        "node_id": "extract",
+        "tag": "success"
       },
       "error_handling": {
         "start_to_close_timeout_seconds": 86400

--- a/contract-toolkit/examples/full/app/generated/manifest.json
+++ b/contract-toolkit/examples/full/app/generated/manifest.json
@@ -58,7 +58,8 @@
         }
       },
       "depends_on": {
-        "node_id": "extract"
+        "node_id": "extract",
+        "tag": "success"
       },
       "error_handling": {
         "start_to_close_timeout_seconds": 86400
@@ -88,7 +89,8 @@
         }
       },
       "depends_on": {
-        "node_id": "extract"
+        "node_id": "extract",
+        "tag": "success"
       },
       "error_handling": {
         "start_to_close_timeout_seconds": 14400
@@ -108,7 +110,8 @@
         }
       },
       "depends_on": {
-        "node_id": "publish"
+        "node_id": "publish",
+        "tag": "success"
       },
       "error_handling": {
         "start_to_close_timeout_seconds": 86400

--- a/contract-toolkit/examples/publish-controls/app/generated/manifest.json
+++ b/contract-toolkit/examples/publish-controls/app/generated/manifest.json
@@ -49,7 +49,8 @@
         }
       },
       "depends_on": {
-        "node_id": "extract"
+        "node_id": "extract",
+        "tag": "success"
       },
       "error_handling": {
         "start_to_close_timeout_seconds": 14400

--- a/contract-toolkit/src/App.pkl
+++ b/contract-toolkit/src/App.pkl
@@ -699,6 +699,10 @@ open class DAGNode {
   taskQueue: String?
   args: Mapping<String, Any>
 
+  /// Upstream dependencies for this node. Gates on the parent(s) reaching
+  /// SUCCESS — a failed or skipped parent does not schedule this node.
+  /// Use `dependsOnCondition` instead if a node genuinely needs to run
+  /// regardless of the parent's outcome (e.g. a cleanup/notify step).
   dependsOn: Listing<String>?
 
   dependsOnCondition: DependencyCondition?
@@ -2414,9 +2418,13 @@ local function renderNode(node: DAGNode): Mapping<String, Any> =
     ["task_queue"] = node.taskQueue ?? "atlan-\(node.appName)-{deployment_name}"
     ["args"] = renderNodeArgs(node)
   }
+  // Single parent → depends_on: {node_id, tag: "success"}. Multi-parent →
+  // depends_on: {and_conditions: [...]}. Both forms gate on the parent(s)
+  // succeeding — a failed/skipped parent must not schedule this node.
   when (node.dependsOn != null && node.dependsOn.length == 1) {
     ["depends_on"] = new Mapping {
       ["node_id"] = node.dependsOn.first
+      ["tag"] = "success"
     }
   }
   when (node.dependsOn != null && node.dependsOn.length > 1) {

--- a/contract-toolkit/src/NativeApp.pkl
+++ b/contract-toolkit/src/NativeApp.pkl
@@ -870,10 +870,11 @@ open class DAGNode {
   taskQueue: String?
   args: Mapping<String, Any>
 
-  /// Upstream dependencies for this node. Emission shape is chosen
-  /// automatically based on list length:
+  /// Upstream dependencies for this node. Both forms gate on the parent(s)
+  /// reaching SUCCESS — a failed or skipped parent does not schedule this
+  /// node. Emission shape is chosen automatically based on list length:
   ///
-  ///   `dependsOn { "a" }`  → `"depends_on": {"node_id": "a"}`
+  ///   `dependsOn { "a" }`  → `"depends_on": {"node_id": "a", "tag": "success"}`
   ///
   ///   `dependsOn { "a"; "b" }` → ```
   ///     "depends_on": {
@@ -885,7 +886,9 @@ open class DAGNode {
   ///   ```
   ///
   /// The 2+ entry form maps to AE's `and_conditions` fan-in: the node is
-  /// scheduled only after ALL listed parents succeed.
+  /// scheduled only after ALL listed parents succeed. Use
+  /// `dependsOnCondition` instead if a node genuinely needs to run
+  /// regardless of the parent's outcome (e.g. a cleanup/notify step).
   dependsOn: Listing<String>?
 
   /// Explicit AE dependency condition for tags, OR, or nested logic. Mutually
@@ -2640,10 +2643,13 @@ local function renderNode(node: DAGNode): Mapping<String, Any> =
     ["task_queue"] = node.taskQueue ?? "atlan-\(node.appName)-{deployment_name}"
     ["args"] = renderNodeArgs(node)
   }
-  // Single parent → depends_on: {node_id}. Multi-parent → depends_on: {and_conditions: [...]}.
+  // Single parent → depends_on: {node_id, tag: "success"}. Multi-parent →
+  // depends_on: {and_conditions: [...]}. Both forms gate on the parent(s)
+  // succeeding — a failed/skipped parent must not schedule this node.
   when (node.dependsOn != null && node.dependsOn.length == 1) {
     ["depends_on"] = new Mapping {
       ["node_id"] = node.dependsOn.first
+      ["tag"] = "success"
     }
   }
   when (node.dependsOn != null && node.dependsOn.length > 1) {

--- a/contract-toolkit/tests/dag_success_gate_test.pkl
+++ b/contract-toolkit/tests/dag_success_gate_test.pkl
@@ -71,4 +71,28 @@ facts {
       }
     }
   }
+
+  // ---- Ordering-only opt-out stays available -----------------------------
+  //
+  // Gating `dependsOn` on success is the right default, but sequencing a node
+  // after a parent *without* the gate must stay expressible. AE's evaluator
+  // (`graph.py`) treats an untagged node condition as ready once the parent's
+  // status is SUCCESS or FAILURE, so `renderDependencyCondition` must keep
+  // omitting `tag` when the author omits it — otherwise the success gate
+  // becomes mandatory and cleanup/audit nodes lose their escape hatch.
+
+  ["App.pkl: untagged dependsOnCondition renders no tag (ordering-only opt-out)"] {
+    faninDag["audit"]["depends_on"] == new Mapping {
+      ["node_id"] = "join"
+    }
+  }
+
+  ["App.pkl: and_conditions preserve per-parent tagging (one gated, one ordering-only)"] {
+    faninDag["mixed-gate"]["depends_on"] == new Mapping {
+      ["and_conditions"] = new Listing {
+        new Mapping { ["node_id"] = "left"; ["tag"] = "success" }
+        new Mapping { ["node_id"] = "right" }
+      }
+    }
+  }
 }

--- a/contract-toolkit/tests/dag_success_gate_test.pkl
+++ b/contract-toolkit/tests/dag_success_gate_test.pkl
@@ -1,0 +1,74 @@
+/// Regression test (FND-261): a single-parent `dependsOn` must gate on the
+/// parent reaching SUCCESS, matching the multi-parent `and_conditions` form.
+///
+/// Background: `renderNode()` used to emit a bare `{"node_id": "<parent>"}`
+/// for the common single-parent case (no `tag`), which AE schedules once the
+/// parent reaches ANY terminal state — including FAILED. That let downstream
+/// nodes (e.g. `publish`, `promote-incremental-marker`) run after their
+/// upstream `extract` node failed, producing confusing secondary failures
+/// (jsonpath lookups against outputs the failed extract never wrote) instead
+/// of being skipped like a properly gated sibling branch. Only the 2+-parent
+/// `and_conditions` path added `tag: "success"` per condition; the fix makes
+/// the single-parent shorthand match it.
+amends "pkl:test"
+
+import "pkl:json"
+import "fixtures/default_pipeline.pkl" as defaultPipelineApp
+import "fixtures/native_app_pipeline.pkl" as nativeAppPipelineApp
+import "../examples/fanin/app.pkl" as faninExampleApp
+
+// App.pkl: default (undeclared) pipeline — publish depends solely on extract.
+local appDag = new json.Parser { useMapping = true }.parse(
+  defaultPipelineApp.output.files["app/generated/manifest.json"].text
+)["dag"]
+
+// NativeApp.pkl: same single-parent shape via the legacy native template.
+local nativeAppDag = new json.Parser { useMapping = true }.parse(
+  nativeAppPipelineApp.output.files["manifest.json"].text
+)["dag"]
+
+// Multi-parent fan-in example — regression guard that the 2+-parent path is untouched.
+local faninDag = new json.Parser { useMapping = true }.parse(
+  faninExampleApp.output.files["app/generated/manifest.json"].text
+)["dag"]
+
+facts {
+  // ---- App.pkl -----------------------------------------------------------
+
+  ["App.pkl: default publish node's single-parent depends_on gates on success"] {
+    appDag["publish"]["depends_on"] == new Mapping {
+      ["node_id"] = "extract"
+      ["tag"] = "success"
+    }
+  }
+
+  // ---- NativeApp.pkl -------------------------------------------------------
+
+  ["NativeApp.pkl: default publish node's single-parent depends_on gates on success"] {
+    nativeAppDag["publish"]["depends_on"] == new Mapping {
+      ["node_id"] = "extract"
+      ["tag"] = "success"
+    }
+  }
+
+  // ---- Multi-parent shape is unaffected (regression guard) ---------------
+
+  ["App.pkl: single-parent extraNodes ('left'/'right') gate on extract succeeding"] {
+    faninDag["left"]["depends_on"] == new Mapping {
+      ["node_id"] = "extract"
+      ["tag"] = "success"
+    } && faninDag["right"]["depends_on"] == new Mapping {
+      ["node_id"] = "extract"
+      ["tag"] = "success"
+    }
+  }
+
+  ["App.pkl: multi-parent dependsOn still renders and_conditions with tag=success per entry"] {
+    faninDag["join"]["depends_on"] == new Mapping {
+      ["and_conditions"] = new Listing {
+        new Mapping { ["node_id"] = "left"; ["tag"] = "success" }
+        new Mapping { ["node_id"] = "right"; ["tag"] = "success" }
+      }
+    }
+  }
+}

--- a/docs/guides/multi-app-coordination.md
+++ b/docs/guides/multi-app-coordination.md
@@ -57,7 +57,7 @@ A two-phase manifest looks like:
           "output_path": "$.extract.outputs.output_path"
         }
       },
-      "depends_on": { "node_id": "extract" }
+      "depends_on": { "node_id": "extract", "tag": "success" }
     }
   }
 }


### PR DESCRIPTION
## Summary
- `renderNode()` in `contract-toolkit` (duplicated in both `App.pkl` and `NativeApp.pkl`) emitted `"depends_on": {"node_id": "<parent>"}` for the common single-parent case with **no success tag**, while the 2+-parent `and_conditions` path added `"tag": "success"` per condition.
- AE schedules an untagged `node_id` dependency once the parent reaches **any** terminal state, not just success. So any node with exactly one upstream dependency (`PublishNode`, `promote-incremental-marker`, single-parent `extraNodes`, etc. — the common case) ran even after its parent failed, instead of being skipped.
- Observed live on a Databricks connector run: `Extract Databricks Metadata` failed, but `Publish to Atlas` and `Promote Incremental Marker` still ran and failed again on missing jsonpath outputs (`$.extract.outputs...` never existed). The sibling lineage branch, which happens to have 2+ parents and already carries `tag: "success"`, correctly showed **Skipped**.

## Fix
- Add `["tag"] = "success"` to the single-parent branch of `renderNode()` in both `App.pkl` and `NativeApp.pkl`, matching the multi-parent branch.
- Updated the `DAGNode.dependsOn` doc comments in both files to reflect the corrected emitted shape and note `dependsOnCondition` as the escape hatch for nodes that genuinely need to run regardless of parent outcome.
- Regenerated all example manifests (`scripts/regenerate-all.sh`); only examples with a single-parent `dependsOn` edge changed (`bundle`, `fanin`, `full`, `publish-controls`).
- Added `tests/dag_success_gate_test.pkl` asserting the single-parent shape now carries `tag: "success"` (via `App.pkl`'s default pipeline, `NativeApp.pkl`'s native fixture, and the `fanin` example's single-parent extraNodes), plus a regression guard that the existing multi-parent `and_conditions` shape is untouched.

## Blast-radius check: does any app rely on the old (buggy) "run regardless of outcome" behavior?

Grepped every locally available connector app's `contract/*.pkl` for custom `dependsOn` usage across 30 repos (athena, mssql, mysql, oracle, postgres, saphana, sigma, tableau, teradata, etc.). Findings:

- Every single-parent `dependsOn` edge found (`extract→publish`, `publish→lineage-app`, `lineage-app→lineage-publish`, `qi→process`, etc.) is a strict success chain — the downstream node's args are jsonpath refs into the parent's outputs (e.g. `$.extract.outputs.connection_qualified_name`). If the parent failed, those outputs never existed, so pre-fix the child ran anyway and failed a second time with a confusing `jsonpath did not match` error instead of being skipped — the exact Databricks symptom above. Post-fix it's just skipped, with the same run-level outcome (still FAILED, since extract failed) but without the noisy secondary failure.
- **`atlan-mysql-app/contract/app.pkl` already hand-rolls a workaround for this exact bug**, independent confirmation that "gate on success" is the behavior everyone actually wants:
  ```pkl
  ["lineage-publish"] = new LineagePublishNode {
    dependsOn = null
    dependsOnCondition = new DependencyCondition {
      nodeId = "lineage-app"
      tag = "success"
    }
  }
  ```
  The app author bypassed the `dependsOn` shorthand entirely because it didn't gate on success for a single parent. After this fix, that workaround is redundant but stays valid/harmless.
- `NotificationNode` (the one legitimate "should fire even after failure" case) never used the buggy `dependsOn` shorthand — it uses `dependsOnCondition = new DependencyCondition { tag = "workflow_complete" }`, a custom AE tag unrelated to `dependsOn`. Untouched by this change.

**Non-correctness note for downstream consumers:** once connectors bump to a version with this fix, runs like the Databricks one above will show `Publish to Atlas` / `Promote Incremental Marker` as **Skipped** instead of **FAILED**. Any downstream tooling that counts per-node/per-activity `FAILED` rows (e.g. failure dashboards bucketing by activity) rather than de-duplicating to one failure per run will see fewer duplicate failure rows for affected connectors after rollout — a change in the data, not a bug, but worth flagging so a metric shift isn't misread.

**Recommendation:** land this, then canary on one or two connectors (bump SDK, re-`pkl eval`, watch a few real runs) before bumping org-wide across all ~40+ connector repos, since it changes DAG scheduling behavior everywhere at once.

## Linear
FND-261

## Test plan
- [x] `pkl test tests/*.pkl` — 295/295 passed
- [x] `scripts/check-invariants.sh` — all invariant checks passed
- [x] Regenerated example manifests diff reviewed — only single-parent `depends_on` edges gained `tag: "success"`; multi-parent shapes unchanged
- [x] Scanned 30 local connector app contracts for reliance on the old behavior — none found; one (`atlan-mysql-app`) already worked around it
- [ ] Downstream connector apps (e.g. `atlan-databricks-app`) should re-`pkl eval` their contracts once this SDK version is bumped, to confirm the generated `publish`/`promote-incremental-marker` nodes now correctly show **Skipped** (not re-run) after an upstream extract failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)