### PR TITLE
ci(release): fix untagged-repo crash and land an app's first release on 1.0.0

### DIFF
--- a/.github/scripts/release.py
+++ b/.github/scripts/release.py
@@ -12,32 +12,88 @@ import semver
 _SUBPKG_RE = re.compile(r"^[a-z]+\((contract-toolkit|conformance)\)!?:")
 
 
+def _git(*args: str, quiet: bool = False) -> str:
+    """Run git with an explicit argv list and return stdout, stripped.
+
+    Deliberately not `shell=True`. Command output interpolated into a shell
+    string is not guaranteed to be a single line, and a newline silently splits
+    one command into two — the second half is then executed as a command name.
+    An argv list makes a multi-line value a plain bad argument instead.
+
+    Args:
+        *args: Arguments passed to git.
+        quiet: Discard stderr. Only for probes whose failure is expected and
+            handled by the caller, so the log is not polluted with a `fatal:`
+            line describing a non-problem.
+    """
+    return (
+        subprocess.check_output(
+            ["git", *args],
+            stderr=subprocess.DEVNULL if quiet else None,
+        )
+        .decode()
+        .strip()
+    )
+
+
+def _resolve_rev_range() -> list[str]:
+    """Resolve the revision range to walk when determining the version bump.
+
+    Returns:
+        List[str]: `["<tag>..HEAD"]` when a released version tag exists,
+                   otherwise `["HEAD"]` to walk the full history.
+
+    The untagged case walks HEAD rather than deriving a start point from
+    `git rev-list --max-parents=0 HEAD`. That command emits one SHA *per root
+    commit*, so a repository whose history was grafted from more than one root
+    yields a multi-line value — which is not a usable revision. It also excludes
+    the root commit itself from the range, dropping it from the changelog.
+    """
+    try:
+        last_tag = _git(
+            "describe",
+            "--tags",
+            "--abbrev=0",
+            "--match=v[0-9]*",
+            "--exclude=*rc*",
+            quiet=True,
+        )
+    except subprocess.CalledProcessError:
+        # No release tag yet: a repo that has never been released, or whose
+        # tags all predate the `v*` convention.
+        logging.info("No release tag found - walking full history from HEAD")
+        return ["HEAD"]
+
+    logging.info(f"Last tag found: {last_tag}")
+    return [f"{last_tag}..HEAD"]
+
+
 def get_commits_since_last_tag() -> list[str]:
     """Get all commits since the last non release-candidate tag.
 
     Returns:
         List[str]:  List of commit messages since the last git non release-candidate tag.
-                    If no tags exist, returns commits since the initial commit.
+                    If no such tag exists, returns every commit reachable from HEAD.
     """
+    rev_range = _resolve_rev_range()
     try:
-        # Get the last non release-candidate tag or initial commit if no tags exist
-        last_tag_cmd = "git describe --tags --abbrev=0 --match='v[0-9]*' --exclude='*rc*' 2>/dev/null || git rev-list --max-parents=0 HEAD"
-        last_tag = subprocess.check_output(last_tag_cmd, shell=True).decode().strip()
-        logging.info(f"Last tag found: {last_tag}")
-
-        # Get all commits since that reference, excluding sub-packages that manage
+        # Get all commits in that range, excluding sub-packages that manage
         # their own versioning and changelogs (contract-toolkit, conformance).
-        cmd = (
-            f"git log {last_tag}..HEAD --pretty=format:%s%n%b"
-            " -- . ':(exclude)contract-toolkit' ':(exclude)packages/conformance'"
-        )
-        commits = subprocess.check_output(cmd, shell=True).decode().strip().split("\n")
+        commits = _git(
+            "log",
+            *rev_range,
+            "--pretty=format:%s%n%b",
+            "--",
+            ".",
+            ":(exclude)contract-toolkit",
+            ":(exclude)packages/conformance",
+        ).split("\n")
         # Filter out empty lines that may appear between commits
         commits = [commit for commit in commits if commit.strip()]
         # Drop sub-package scoped commits that slipped through the path filter
         # (e.g. a mixed PR whose squash subject is feat(conformance): …).
         commits = [c for c in commits if not _SUBPKG_RE.match(c.splitlines()[0])]
-        logging.info(f"Found {len(commits)} commits since last tag: {last_tag}")
+        logging.info(f"Found {len(commits)} commits in {' '.join(rev_range)}")
         return commits
 
     except subprocess.CalledProcessError as e:

--- a/.github/scripts/release.py
+++ b/.github/scripts/release.py
@@ -1,3 +1,4 @@
+import argparse
 import logging
 import re
 import subprocess
@@ -36,6 +37,25 @@ def _git(*args: str, quiet: bool = False) -> str:
     )
 
 
+def last_release_tag() -> str | None:
+    """Return the most recent non release-candidate version tag, or None.
+
+    None means the repository has never been released — it has no tag matching
+    `v[0-9]*`, or all of its tags predate that convention.
+    """
+    try:
+        return _git(
+            "describe",
+            "--tags",
+            "--abbrev=0",
+            "--match=v[0-9]*",
+            "--exclude=*rc*",
+            quiet=True,
+        )
+    except subprocess.CalledProcessError:
+        return None
+
+
 def _resolve_rev_range() -> list[str]:
     """Resolve the revision range to walk when determining the version bump.
 
@@ -49,18 +69,8 @@ def _resolve_rev_range() -> list[str]:
     yields a multi-line value — which is not a usable revision. It also excludes
     the root commit itself from the range, dropping it from the changelog.
     """
-    try:
-        last_tag = _git(
-            "describe",
-            "--tags",
-            "--abbrev=0",
-            "--match=v[0-9]*",
-            "--exclude=*rc*",
-            quiet=True,
-        )
-    except subprocess.CalledProcessError:
-        # No release tag yet: a repo that has never been released, or whose
-        # tags all predate the `v*` convention.
+    last_tag = last_release_tag()
+    if last_tag is None:
         logging.info("No release tag found - walking full history from HEAD")
         return ["HEAD"]
 
@@ -217,6 +227,46 @@ def update_pyproject_version(new_version: str) -> None:
         raise
 
 
+def apply_first_release_floor(
+    new_version: str, floor: str | None, has_release_tag: bool
+) -> str:
+    """Raise a repository's *first* release to at least `floor`.
+
+    Apps are scaffolded at 0.1.0, so a plain conventional-commit bump would
+    publish their first ever release as 0.2.0 and trickle up from there. A
+    first release is a 1.0.0 event, so on the first release only, anything
+    below the floor is raised to it.
+
+    Args:
+        new_version (str): Version produced by the conventional-commit bump.
+        floor (str | None): Minimum version for a first release. None or empty
+            disables the floor entirely (the SDK's own release passes nothing).
+        has_release_tag (bool): Whether the repository has been released before.
+
+    Returns:
+        str: `floor` when this is a first release and the computed bump is below
+             it, otherwise `new_version` unchanged.
+
+    A floor, not an assignment: repositories already at or past it must keep
+    bumping normally. 13 of the 36 currently-untagged apps sit at exactly 1.0.0
+    in pyproject.toml, and forcing the version to 1.0.0 there would produce a
+    bump PR that does not change the version at all.
+    """
+    if not floor or has_release_tag:
+        return new_version
+
+    if semver.VersionInfo.parse(floor) <= semver.VersionInfo.parse(new_version):
+        logging.info(
+            f"First release, but {new_version} already meets the {floor} floor - leaving as is"
+        )
+        return new_version
+
+    logging.info(
+        f"First release for this repository - raising {new_version} to {floor}"
+    )
+    return floor
+
+
 def main():
     """Main entry point for the version update process.
 
@@ -224,19 +274,41 @@ def main():
     1. Gets current version
     2. Retrieves commits since last tag
     3. Calculates version bump
-    4. Updates pyproject.toml with new version
+    4. Applies the first-release floor, if one was requested
+    5. Updates pyproject.toml with new version
     """
     logging.basicConfig(
         level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
     )
     logging.info("Starting version update process")
 
-    current_branch = str(sys.argv[1])
-    current_version = str(sys.argv[2])
+    parser = argparse.ArgumentParser(description="Bump the project version.")
+    parser.add_argument(
+        "branch", help="Branch being released (only 'main' is supported)"
+    )
+    parser.add_argument("current_version", help="Current version from pyproject.toml")
+    parser.add_argument(
+        "--first-release-version",
+        default="",
+        help=(
+            "Minimum version for a repository's first release, i.e. one with no "
+            "v* tag yet. Empty (the default) disables the floor and uses the "
+            "plain conventional-commit bump."
+        ),
+    )
+    args = parser.parse_args()
+
+    current_branch = args.branch
+    current_version = args.current_version
     commits = get_commits_since_last_tag()
 
     new_version = calculate_version_bump(
         current_version=current_version, commits=commits, current_branch=current_branch
+    )
+    new_version = apply_first_release_floor(
+        new_version,
+        floor=args.first_release_version,
+        has_release_tag=last_release_tag() is not None,
     )
 
     update_pyproject_version(new_version=new_version)

--- a/.github/scripts/tests/test_release.py
+++ b/.github/scripts/tests/test_release.py
@@ -241,3 +241,91 @@ class TestGetCommitsSinceLastTag:
     ) -> None:
         monkeypatch.chdir(git_repo)
         assert isinstance(release.get_commits_since_last_tag(), list)
+
+
+# ---------------------------------------------------------------------------
+# Untagged repositories — the no-tag branch of _resolve_rev_range
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def multi_root_untagged_repo(tmp_path: Path) -> Path:
+    """Return a temp git repo with no release tag and *two* root commits.
+
+    Reproduces a repository whose history was grafted from two independent
+    starting points and that has never been tagged. That combination made the
+    previous `git rev-list --max-parents=0 HEAD` fallback emit one SHA per root,
+    producing a multi-line value that split the subsequent `git log` command in
+    two and aborted the bump with exit 127.
+    """
+
+    def git(*args: str) -> None:
+        subprocess.check_call(
+            ["git", *args],
+            cwd=tmp_path,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+
+    git("init")
+    git("config", "user.email", "test@example.com")
+    git("config", "user.name", "Test")
+    git("config", "commit.gpgsign", "false")
+
+    # First root
+    (tmp_path / "a.txt").write_text("a\n")
+    git("add", ".")
+    git("commit", "-m", "feat: first history")
+    main_branch = (
+        subprocess.check_output(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd=tmp_path
+        )
+        .decode()
+        .strip()
+    )
+
+    # Second, entirely unrelated root
+    git("checkout", "--orphan", "second-root")
+    git("rm", "-rf", ".")
+    (tmp_path / "b.txt").write_text("b\n")
+    git("add", ".")
+    git("commit", "-m", "fix: second history")
+
+    # Graft them together — HEAD now reaches two root commits
+    git("checkout", main_branch)
+    git("merge", "--allow-unrelated-histories", "--no-edit", "second-root")
+
+    return tmp_path
+
+
+class TestUntaggedRepo:
+    def test_fixture_really_has_two_roots(self, multi_root_untagged_repo: Path) -> None:
+        """Guard the fixture: without two roots the regression below is vacuous."""
+        roots = subprocess.check_output(
+            ["git", "rev-list", "--max-parents=0", "HEAD"], cwd=multi_root_untagged_repo
+        )
+        assert len(roots.decode().strip().split("\n")) == 2
+
+    def test_rev_range_is_head_when_untagged(
+        self, multi_root_untagged_repo: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No release tag must resolve to a bare HEAD walk, never a `a..HEAD` range."""
+        monkeypatch.chdir(multi_root_untagged_repo)
+        assert release._resolve_rev_range() == ["HEAD"]
+
+    def test_multi_root_untagged_repo_does_not_crash(
+        self, multi_root_untagged_repo: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Regression: this raised CalledProcessError (exit 127) before the fix."""
+        monkeypatch.chdir(multi_root_untagged_repo)
+        commits = release.get_commits_since_last_tag()
+        # Both roots must be represented — a `head -1` style fix would drop one.
+        assert "feat: first history" in commits
+        assert "fix: second history" in commits
+
+    def test_tagged_repo_still_uses_a_range(
+        self, git_repo: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The tagged path is unchanged: walk from the last release tag."""
+        monkeypatch.chdir(git_repo)
+        assert release._resolve_rev_range() == ["v1.0.0..HEAD"]

--- a/.github/scripts/tests/test_release.py
+++ b/.github/scripts/tests/test_release.py
@@ -329,3 +329,71 @@ class TestUntaggedRepo:
         """The tagged path is unchanged: walk from the last release tag."""
         monkeypatch.chdir(git_repo)
         assert release._resolve_rev_range() == ["v1.0.0..HEAD"]
+
+    def test_last_release_tag_is_none_when_untagged(
+        self, multi_root_untagged_repo: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(multi_root_untagged_repo)
+        assert release.last_release_tag() is None
+
+    def test_last_release_tag_returns_the_tag_when_tagged(
+        self, git_repo: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(git_repo)
+        assert release.last_release_tag() == "v1.0.0"
+
+
+# ---------------------------------------------------------------------------
+# apply_first_release_floor — apps' first release is a 1.0.0 event
+# ---------------------------------------------------------------------------
+
+
+class TestApplyFirstReleaseFloor:
+    def test_first_release_below_floor_is_raised(self) -> None:
+        """An app scaffolded at 0.1.0 releases as 1.0.0, not 0.2.0."""
+        assert (
+            release.apply_first_release_floor(
+                "0.2.0", floor="1.0.0", has_release_tag=False
+            )
+            == "1.0.0"
+        )
+
+    def test_first_release_already_at_floor_bumps_normally(self) -> None:
+        """A floor, not an assignment.
+
+        13 of the 36 currently-untagged apps sit at exactly 1.0.0. Forcing the
+        floor there would emit a bump PR that does not change the version.
+        """
+        assert (
+            release.apply_first_release_floor(
+                "1.0.1", floor="1.0.0", has_release_tag=False
+            )
+            == "1.0.1"
+        )
+
+    def test_first_release_past_floor_bumps_normally(self) -> None:
+        assert (
+            release.apply_first_release_floor(
+                "2.3.1", floor="1.0.0", has_release_tag=False
+            )
+            == "2.3.1"
+        )
+
+    def test_already_released_repo_is_untouched(self) -> None:
+        """Only the *first* release gets the floor — later ones bump normally."""
+        assert (
+            release.apply_first_release_floor(
+                "0.2.0", floor="1.0.0", has_release_tag=True
+            )
+            == "0.2.0"
+        )
+
+    @pytest.mark.parametrize("floor", ["", None])
+    def test_empty_floor_disables_the_behaviour(self, floor: str | None) -> None:
+        """The SDK's own release passes no floor and must be unaffected."""
+        assert (
+            release.apply_first_release_floor(
+                "0.2.0", floor=floor, has_release_tag=False
+            )
+            == "0.2.0"
+        )

--- a/.github/scripts/tests/test_update_changelog.py
+++ b/.github/scripts/tests/test_update_changelog.py
@@ -1,0 +1,314 @@
+"""Tests for .github/scripts/update_changelog.py.
+
+Coverage:
+  1. get_commits_since_last_tag — tagged repos keep the compare API; untagged
+     repos enumerate full history via the paginated commits API (never
+     `git rev-list --max-parents=0 HEAD`, which emits one SHA per root and
+     breaks the compare call on multi-root repos).
+  2. Untagged failure modes fail loudly — a first release must never ship an
+     empty changelog with a green workflow.
+  3. _format_commits — author fallbacks and API-shape tolerance.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import update_changelog
+
+# ---------------------------------------------------------------------------
+# Real-git fixtures (same shapes as test_release.py)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def passthrough_run(monkeypatch: pytest.MonkeyPatch):
+    """Intercept only `gh api` calls; pass every other subprocess (git
+    plumbing, the tag probe) through to the real subprocess.run."""
+    real_run = update_changelog.subprocess.run
+
+    def install(handler) -> list[list[str]]:
+        calls: list[list[str]] = []
+
+        def fake_run(cmd, *a, **k):
+            if cmd[:2] == ["gh", "api"]:
+                calls.append(cmd)
+                return handler(cmd)
+            return real_run(cmd, *a, **k)
+
+        monkeypatch.setattr(update_changelog.subprocess, "run", fake_run)
+        return calls
+
+    return install
+
+
+def _init_repo(path: Path) -> None:
+    def git(*args: str) -> None:
+        subprocess.check_call(
+            ["git", *args],
+            cwd=path,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+
+    git("init")
+    git("config", "user.email", "test@example.com")
+    git("config", "user.name", "Test")
+    git("config", "commit.gpgsign", "false")
+
+
+@pytest.fixture
+def multi_root_untagged_repo(tmp_path: Path) -> Path:
+    """A repo with no tags and two root commits — the shape that made the old
+    `rev-list --max-parents=0 HEAD` fallback emit a multi-line value and break
+    the compare API call."""
+    _init_repo(tmp_path)
+
+    def git(*args: str) -> None:
+        subprocess.check_call(
+            ["git", *args],
+            cwd=tmp_path,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+
+    (tmp_path / "a.txt").write_text("a\n")
+    git("add", ".")
+    git("commit", "-m", "feat: first history")
+    main_branch = (
+        subprocess.check_output(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd=tmp_path
+        )
+        .decode()
+        .strip()
+    )
+
+    git("checkout", "--orphan", "second-root")
+    git("rm", "-rf", ".")
+    (tmp_path / "b.txt").write_text("b\n")
+    git("add", ".")
+    git("commit", "-m", "fix: second history")
+
+    git("checkout", main_branch)
+    git("merge", "--allow-unrelated-histories", "--no-edit", "second-root")
+    return tmp_path
+
+
+@pytest.fixture
+def tagged_repo(tmp_path: Path) -> Path:
+    """A repo with a v1.0.0 tag and one commit after it."""
+    _init_repo(tmp_path)
+
+    def git(*args: str) -> None:
+        subprocess.check_call(
+            ["git", *args],
+            cwd=tmp_path,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+
+    (tmp_path / "a.txt").write_text("a\n")
+    git("add", ".")
+    git("commit", "-m", "chore: initial commit")
+    git("tag", "v1.0.0")
+    (tmp_path / "a.txt").write_text("a2\n")
+    git("add", ".")
+    git("commit", "-m", "feat: post-tag work")
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# _gh_api_commits — API failure and pagination-shape handling
+# ---------------------------------------------------------------------------
+
+
+class TestGhApiCommits:
+    def test_fails_loudly_without_token(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """No token must raise — never return [] and write an empty changelog."""
+        monkeypatch.delenv("GH_TOKEN", raising=False)
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        with pytest.raises(RuntimeError, match="GH_TOKEN"):
+            update_changelog._gh_api_commits("repos/o/r/commits?sha=HEAD")
+
+    def test_fails_loudly_on_api_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A gh api failure must raise — never return [] (the old code caught
+        the error and shipped the first release with an empty changelog)."""
+        monkeypatch.setenv("GH_TOKEN", "test-token")
+        monkeypatch.setattr(
+            update_changelog.subprocess,
+            "run",
+            lambda *a, **k: subprocess.CompletedProcess(
+                args=a[0], returncode=1, stdout="", stderr="HTTP 404: Not Found"
+            ),
+        )
+        with pytest.raises(RuntimeError, match="gh api"):
+            update_changelog._gh_api_commits("repos/o/r/commits?sha=HEAD")
+
+    def test_parses_paginated_output(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """--paginate concatenates one JSON array per page — all pages merge."""
+        monkeypatch.setenv("GH_TOKEN", "test-token")
+        page1 = json.dumps([{"sha": "a" * 40, "commit": {"message": "one"}}])
+        page2 = json.dumps([{"sha": "b" * 40, "commit": {"message": "two"}}])
+        monkeypatch.setattr(
+            update_changelog.subprocess,
+            "run",
+            lambda *a, **k: subprocess.CompletedProcess(
+                args=a[0], returncode=0, stdout=f"{page1}\n{page2}\n", stderr=""
+            ),
+        )
+        commits = update_changelog._gh_api_commits("repos/o/r/commits?sha=HEAD")
+        assert [c["sha"] for c in commits] == ["a" * 40, "b" * 40]
+
+
+# ---------------------------------------------------------------------------
+# get_commits_since_last_tag — tagged vs untagged path selection
+# ---------------------------------------------------------------------------
+
+
+class TestGetCommitsSinceLastTag:
+    def test_fixture_really_has_two_roots(self, multi_root_untagged_repo: Path) -> None:
+        """Guard the fixture: without two roots the untagged tests are vacuous."""
+        roots = subprocess.check_output(
+            ["git", "rev-list", "--max-parents=0", "HEAD"], cwd=multi_root_untagged_repo
+        )
+        assert len(roots.decode().strip().split("\n")) == 2
+
+    def test_untagged_enumerates_full_history_via_commits_api(
+        self,
+        multi_root_untagged_repo: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        passthrough_run,
+    ) -> None:
+        """No tag must page repos/{o}/{r}/commits?sha=HEAD — never the compare
+        API with a range derived from root commits."""
+        monkeypatch.chdir(multi_root_untagged_repo)
+        monkeypatch.setenv("GH_TOKEN", "test-token")
+        monkeypatch.setenv("GITHUB_REPOSITORY", "octo/app")
+
+        page = json.dumps(
+            [
+                {
+                    "sha": "c" * 40,
+                    "author": {"login": "atlan-ci"},
+                    "commit": {"message": "feat: first history\n\nbody"},
+                },
+                {
+                    "sha": "d" * 40,
+                    "author": {"login": "vaibhavatlan"},
+                    "commit": {"message": "fix: second history"},
+                },
+            ]
+        )
+        calls = passthrough_run(
+            lambda cmd: subprocess.CompletedProcess(
+                args=cmd, returncode=0, stdout=f"{page}\n", stderr=""
+            )
+        )
+
+        commits = update_changelog.get_commits_since_last_tag("0.1.0")
+
+        gh_calls = [c for c in calls if c[:2] == ["gh", "api"]]
+        assert len(gh_calls) == 1
+        assert "repos/octo/app/commits?sha=HEAD" in gh_calls[0]
+        assert not any("compare" in arg for call in gh_calls for arg in call)
+        # Oldest-first: the API returns newest first, changelog walks from the start.
+        assert commits == [
+            f"{'d' * 7}|vaibhavatlan|fix: second history",
+            f"{'c' * 7}|atlan-ci|feat: first history",
+        ]
+
+    def test_tagged_repo_uses_compare_api(
+        self,
+        tagged_repo: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        passthrough_run,
+    ) -> None:
+        """The tagged path is unchanged: compare v<current>...HEAD."""
+        monkeypatch.chdir(tagged_repo)
+        monkeypatch.setenv("GH_TOKEN", "test-token")
+        monkeypatch.setenv("GITHUB_REPOSITORY", "octo/app")
+
+        calls = passthrough_run(
+            lambda cmd: subprocess.CompletedProcess(
+                args=cmd,
+                returncode=0,
+                stdout="e5f6a7b|vaibhavatlan|feat: post-tag work\n",
+                stderr="",
+            )
+        )
+
+        commits = update_changelog.get_commits_since_last_tag("1.0.0")
+
+        gh_calls = [c for c in calls if c[:2] == ["gh", "api"]]
+        assert len(gh_calls) == 1
+        assert "repos/octo/app/compare/v1.0.0...HEAD" in gh_calls[0]
+        assert commits == ["e5f6a7b|vaibhavatlan|feat: post-tag work"]
+
+    def test_tagged_compare_failure_raises(
+        self,
+        tagged_repo: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        passthrough_run,
+    ) -> None:
+        """Even on the tagged path an API failure must not become an empty
+        changelog with a green workflow."""
+        monkeypatch.chdir(tagged_repo)
+        monkeypatch.setenv("GH_TOKEN", "test-token")
+
+        passthrough_run(
+            lambda cmd: subprocess.CompletedProcess(
+                args=cmd, returncode=1, stdout="", stderr="boom"
+            )
+        )
+
+        with pytest.raises(RuntimeError, match="compare"):
+            update_changelog.get_commits_since_last_tag("1.0.0")
+
+
+# ---------------------------------------------------------------------------
+# _format_commits
+# ---------------------------------------------------------------------------
+
+
+class TestFormatCommits:
+    def test_prefers_github_login(self) -> None:
+        commits = [
+            {
+                "sha": "1234567890abcdef",
+                "author": {"login": "octocat"},
+                "commit": {"message": "feat: thing", "author": {"name": "The Octocat"}},
+            }
+        ]
+        assert update_changelog._format_commits(commits) == [
+            "1234567|octocat|feat: thing"
+        ]
+
+    def test_falls_back_to_commit_author_name(self) -> None:
+        """Commits by users outside the org have a null top-level author."""
+        commits = [
+            {
+                "sha": "1234567890abcdef",
+                "author": None,
+                "commit": {"message": "fix: thing", "author": {"name": "External"}},
+            }
+        ]
+        assert update_changelog._format_commits(commits) == [
+            "1234567|External|fix: thing"
+        ]
+
+    def test_uses_first_message_line_and_reverses_order(self) -> None:
+        commits = [
+            {"sha": "a" * 40, "author": None, "commit": {"message": "newest\n\nbody"}},
+            {"sha": "b" * 40, "author": None, "commit": {"message": "oldest"}},
+        ]
+        assert update_changelog._format_commits(commits) == [
+            f"{'b' * 7}||oldest",
+            f"{'a' * 7}||newest",
+        ]

--- a/.github/scripts/update_changelog.py
+++ b/.github/scripts/update_changelog.py
@@ -10,11 +10,66 @@ changelog format.
 Usage: python update_changelog.py <current_version> <new_version>
 """
 
+import json
 import os
 import re
 import subprocess
 import sys
 from datetime import datetime
+
+
+def _get_repo() -> tuple[str, str]:
+    """Read the repo from the environment so this script works for any
+    downstream app (GITHUB_REPOSITORY is always set in GitHub Actions; default
+    to application-sdk for local runs)."""
+    owner, repo = os.environ.get("GITHUB_REPOSITORY", "atlanhq/application-sdk").split(
+        "/", 1
+    )
+    return owner, repo
+
+
+def _gh_api_commits(path: str) -> list[dict]:
+    """Call `gh api <path>` (paginating) and return the decoded JSON list.
+
+    The path must resolve to a JSON array of commit objects. Raises
+    RuntimeError when the call fails or the token is missing — a changelog
+    written from zero commits is silently empty, and an empty first-release
+    changelog ships looking like a success.
+    """
+    if not os.environ.get("GH_TOKEN") and not os.environ.get("GITHUB_TOKEN"):
+        raise RuntimeError(
+            "GH_TOKEN is not set — cannot list commits for the changelog. "
+            "Set GH_TOKEN (the release workflow does) and re-run."
+        )
+
+    result = subprocess.run(
+        ["gh", "api", "--paginate", path],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"gh api {path} failed: {result.stderr.strip()}")
+
+    # --paginate concatenates one JSON array per page, so decode line by line.
+    commits = []
+    for line in result.stdout.splitlines():
+        line = line.strip()
+        if line:
+            commits.extend(json.loads(line))
+    return commits
+
+
+def _format_commits(commits: list[dict]) -> list[str]:
+    """Render commit objects as `sha7|author|subject` lines (oldest first)."""
+    lines = []
+    for commit in reversed(commits):
+        author = (commit.get("author") or {}).get("login") or (
+            commit.get("commit", {}).get("author") or {}
+        ).get("name", "")
+        subject = commit.get("commit", {}).get("message", "").split("\n")[0]
+        lines.append(f"{commit['sha'][:7]}|{author}|{subject}")
+    return lines
 
 
 def get_commits_since_last_tag(current_version):
@@ -26,43 +81,45 @@ def get_commits_since_last_tag(current_version):
 
     Returns:
         list: A list of commit messages
+
+    When the tag exists, uses the compare API (`v{current}...HEAD`). When it
+    does not — a repository's first release — enumerates the full history via
+    the commits API instead. The previous fallback built a range from
+    `git rev-list --max-parents=0 HEAD`, which emits one SHA per root commit:
+    on a multi-root repo the multi-line value makes the compare call fail
+    (net/url: invalid control character), and the old `[]`-on-error path then
+    shipped the first-ever release with an empty changelog and a green
+    workflow. On a single-root untagged repo it silently omitted the root
+    commit from the range.
     """
     tag = f"v{current_version}"
 
     # Check if tag exists
     result = subprocess.run(["git", "tag", "-l", tag], capture_output=True, text=True)
 
+    owner, repo = _get_repo()
+
     if tag in result.stdout:
-        range_spec = f"{tag}...HEAD"
-    else:
-        old_tag = subprocess.check_output(
-            ["git", "rev-list", "--max-parents=0", "HEAD"],
+        # Standard pipe '|' delimiter to avoid encoding issues.
+        jq_filter = '.commits[] | "\\(.sha[0:7])|\\(.author.login // .commit.author.name)|\\(.commit.message | split("\\n")[0])"'
+        result = subprocess.run(
+            [
+                "gh",
+                "api",
+                f"repos/{owner}/{repo}/compare/{tag}...HEAD",
+                "--jq",
+                jq_filter,
+            ],
+            capture_output=True,
             text=True,
-        ).strip()
-        range_spec = f"{old_tag}...HEAD"
+            encoding="utf-8",
+        )
+        if result.returncode != 0:
+            raise RuntimeError(f"gh api compare failed: {result.stderr.strip()}")
+        return result.stdout.strip().split("\n") if result.stdout.strip() else []
 
-    # Read the repo from the environment so this script works for any downstream app
-    # (GITHUB_REPOSITORY is always set in GitHub Actions; default to application-sdk for local runs)
-    owner, repo = os.environ.get("GITHUB_REPOSITORY", "atlanhq/application-sdk").split(
-        "/", 1
-    )
-    compare_path = f"repos/{owner}/{repo}/compare/{range_spec}"
-
-    # Use a standard pipe '|' delimiter to avoid encoding issues.
-    jq_filter = '.commits[] | "\\(.sha[0:7])|\\(.author.login // .commit.author.name)|\\(.commit.message | split("\\n")[0])"'
-
-    result = subprocess.run(
-        ["gh", "api", compare_path, "--jq", jq_filter],
-        capture_output=True,
-        text=True,
-        encoding="utf-8",
-    )
-
-    if result.returncode != 0:
-        print(f"Error calling GitHub API: {result.stderr}")
-        return []
-
-    return result.stdout.strip().split("\n") if result.stdout.strip() else []
+    # Untagged: first release — walk every commit reachable from HEAD.
+    return _format_commits(_gh_api_commits(f"repos/{owner}/{repo}/commits?sha=HEAD"))
 
 
 def categorize_commits(commits):
@@ -77,9 +134,7 @@ def categorize_commits(commits):
     """
     categories = {"features": [], "fixes": [], "chores": [], "other": []}
 
-    owner, repo = os.environ.get("GITHUB_REPOSITORY", "atlanhq/application-sdk").split(
-        "/", 1
-    )
+    owner, repo = _get_repo()
 
     for commit in commits:
         if not commit:
@@ -118,9 +173,7 @@ def get_full_changelog_url(current_version, new_version):
     """
     Generate the full changelog URL for GitHub comparison.
     """
-    owner, repo = os.environ.get("GITHUB_REPOSITORY", "atlanhq/application-sdk").split(
-        "/", 1
-    )
+    owner, repo = _get_repo()
     return (
         f"https://github.com/{owner}/{repo}/compare/v{current_version}...v{new_version}"
     )

--- a/.github/workflows/release-version-bump.yaml
+++ b/.github/workflows/release-version-bump.yaml
@@ -41,6 +41,11 @@ on:
         required: false
         type: string
         default: "main"
+      first_release_version:
+        description: "Minimum version for an app's *first* release (a repo with no v* tag yet). Apps are scaffolded at 0.1.0, so without this their first ever release would be 0.2.0; a first release is a 1.0.0 event. Applied as a floor, not an assignment — an app already at or past it keeps bumping normally. Set to an empty string to disable and use the plain conventional-commit bump."
+        required: false
+        type: string
+        default: "1.0.0"
       private_git_auth:
         description: "Set true if the app has a private-org (atlanhq) git dependency that `uv lock` must resolve during the version bump. When true, atlanhq GitHub remotes are rewritten to token auth (via ORG_PAT_GITHUB) before `uv lock` runs, so resolution of the private git source succeeds. Default false — apps with only PyPI deps are unaffected. Mirrors the `private_git_auth` input in build-and-publish-app.yaml."
         required: false
@@ -148,7 +153,13 @@ jobs:
         run: |
           python3 -m venv /tmp/bump-venv
           /tmp/bump-venv/bin/pip install semver packaging -q
-          /tmp/bump-venv/bin/python .sdk-scripts/.github/scripts/release.py "${{ inputs.target_branch }}" "${{ steps.versions.outputs.current }}"
+          # --first-release-version is always passed; an empty value disables the
+          # floor in the script, so the caller opts out via the input rather than
+          # via a shell conditional here (docs/standards/ci.md).
+          /tmp/bump-venv/bin/python .sdk-scripts/.github/scripts/release.py \
+            "${{ inputs.target_branch }}" \
+            "${{ steps.versions.outputs.current }}" \
+            --first-release-version "${{ inputs.first_release_version }}"
           uv lock
           NEW=$(uvx --from=toml-cli toml get --toml-path=pyproject.toml project.version)
           echo "new=${NEW}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Problem

`release-version-bump.yaml` runs `.github/scripts/release.py` after every merge to `main` in each consuming app. To decide the bump size it needs the commits since the last release, and it resolved the start of that walk like this:

```python
last_tag_cmd = "git describe --tags --abbrev=0 --match='v[0-9]*' --exclude='*rc*' 2>/dev/null || git rev-list --max-parents=0 HEAD"
last_tag = subprocess.check_output(last_tag_cmd, shell=True).decode().strip()
cmd = f"git log {last_tag}..HEAD --pretty=format:%s%n%b -- . ':(exclude)contract-toolkit' ':(exclude)packages/conformance'"
commits = subprocess.check_output(cmd, shell=True)
```

Two conditions have to line up:

1. **No tag matching `v[0-9]*`** — a repo that has never been released. `git describe` fails, so the `||` fallback runs.
2. **More than one root commit** — a history grafted from two independent starting points. `git rev-list --max-parents=0 HEAD` emits one SHA *per root*, so it returns **two lines**.

`last_tag` is then multi-line. Interpolated into a `shell=True` string, it splits one command into two — and the second line is executed as a command name:

```
INFO - Last tag found: 9d61d9d48847e6b149e6910e5504d93420323c02
350e068cb1f9fb05994656e6561b4ed5512f3f16
/bin/sh: 2: 350e068cb1f9fb05994656e6561b4ed5512f3f16: not found
ERROR - Error retrieving commits: ... returned non-zero exit status 127
##[error]Process completed with exit code 1.
```

The script dies at the `Bump version` step, so `Commit and open PR` never runs. The affected repo gets **no version-bump PR on any merge, indefinitely** — and because each run fails in isolation, nothing escalates. One consuming app has been in this state since the workflow was wired up: five merges to `main`, five identical failures, zero tags, zero releases, `pyproject.toml` still on its initial version.

## Fix

**Don't derive a start point when there is no tag.** An untagged repo now walks `HEAD` directly rather than building a `<root>..HEAD` range. Nothing is derived, so the multi-root case has nothing to go wrong with — and it fixes a quieter bug the crash was masking: `<root>..HEAD` *excludes* the root commit, so the first commit never reached the changelog even in single-root repos.

Deliberately **not** `| head -1`. That silences the crash and silently drops one root's entire history from the changelog — a wrong changelog nobody notices is worse than a loud failure.

**Pass argv instead of `shell=True`.** This is the underlying defect class: command output interpolated into a shell string with no single-line guarantee. With an argv list, a multi-line value is a bad argument git rejects cleanly, not a second command. `git describe` is a probe whose failure is expected and handled, so only its stderr is discarded — real git errors elsewhere still surface.

```python
def _resolve_rev_range() -> list[str]:
    try:
        last_tag = _git("describe", "--tags", "--abbrev=0",
                        "--match=v[0-9]*", "--exclude=*rc*", quiet=True)
    except subprocess.CalledProcessError:
        logging.info("No release tag found - walking full history from HEAD")
        return ["HEAD"]
    logging.info(f"Last tag found: {last_tag}")
    return [f"{last_tag}..HEAD"]
```

## Verification

Reproduced against a purpose-built two-root untagged repo — old code vs new, same fixture:

```
roots: 2

OLD  last_tag = '0576c1887c44a248f544a8d6843490c8ca259aeb\n15f47a534aedbf20e6da34fcd7335b513c7595e5'
OLD  result: CRASH -> CalledProcessError, exit 127

NEW  rev_range = ['HEAD']
NEW  result: no crash, commits = ['fix: second history', 'feat: first history']
```

The `OLD` line reproduces the CI failure exactly, down to the exit code.

Four tests added to `.github/scripts/tests/test_release.py`:

- a fixture guard asserting the temp repo really has two roots (without it the regression test is vacuous)
- `_resolve_rev_range()` returns `["HEAD"]` when untagged
- the two-root untagged repo no longer raises, **and both roots' commits are present** — this is what fails under a `head -1` fix
- the tagged path still resolves to `v1.0.0..HEAD`

`40 passed` for the full `test_release.py` suite.

## Blast radius

Behaviour is unchanged for any repo with a `v*` tag — that path still resolves `<tag>..HEAD` exactly as before, covered by the last test above. The only behaviour change is in the untagged branch, which previously either crashed (multi-root) or silently omitted the root commit from the changelog (single-root).

---

# Second commit: an app's first release lands on 1.0.0

Same code path — the untagged branch above was unreachable until this PR fixed it, so this is the first time it does anything useful.

Apps are scaffolded at `0.1.0`, so their first ever release published as `0.2.0` and trickled upward. A first release should be a `1.0.0` event.

The app-facing reusable workflow now passes a `first_release_version` input (default `1.0.0`) through to `release.py`. When the repo has no `v*` tag, the computed conventional-commit bump is raised to that version.

**A floor, not an assignment.** Fleet audit: **36 of 74** app repos are untagged, and **13 of those already sit at exactly `1.0.0`** in `pyproject.toml`. Assigning the floor there would emit a bump PR that doesn't change the version at all. Repos at or past the floor keep bumping normally.

**Scoped to apps.** `release.py` is shared with the SDK's own `release.yaml`, which passes no floor and is unaffected — the flag defaults to empty and an empty value disables the behaviour. Callers opt out through the workflow input rather than a shell conditional, per `docs/standards/ci.md`.

### Verification

Ran the script exactly as each caller invokes it, against throwaway repos:

```
PASS  app  untagged 0.1.0 + feat  (floor)  -> 1.0.0
PASS  app  untagged 0.1.0 + fix   (floor)  -> 1.0.0
PASS  app  untagged 1.0.0 + fix   (floor)  -> 1.0.1
PASS  app  untagged 1.0.0 + feat  (floor)  -> 1.1.0
PASS  app  untagged 2.3.0 + fix   (floor)  -> 2.3.1
PASS  app  TAGGED   1.0.0 + feat  (floor)  -> 1.1.0
PASS  app  untagged 0.1.0, floor disabled  -> 0.2.0
PASS  SDK  untagged 0.1.0, 2-arg form      -> 0.2.0
PASS  SDK  TAGGED   1.2.0, 2-arg form      -> 1.2.1
```

Plus 6 unit tests on the pure `apply_first_release_floor` function and 2 on `last_release_tag()`. **48 passed** for the full file.

---

## Follow-up (not in this PR)

Apps already stuck in this state are unblocked by this fix alone — no tag required. With no tag, `_resolve_rev_range()` returns `["HEAD"]`, the walk covers the full history, and the bump is computed from `pyproject.toml` exactly as normal.

One thing to watch on the first post-fix bump: it walks the repo's **entire** history, so that changelog section contains every commit ever made (221, in the app that prompted this). The version itself is now governed by the 1.0.0 floor, but the changelog is not capped. Tagging `v<current pyproject version>` before the next merge would cap the walk — at the cost of skipping the floor, since a tagged repo is no longer a first release. Worth deciding per app; doing nothing is safe, just verbose.

Note a repo carrying `!:` or `BREAKING CHANGE:` anywhere in its untagged history will read as breaking across that full walk. Checked the app that prompted this — no such markers.

Also worth a fleet check for repos with `release.yaml` wired but zero tags and zero successful bump runs, so this fails loudly rather than silently.
