### PR TITLE
ci(e2e): fail the install path at discovery when no tenant matrix is shared (FND-203)

### DIFF
--- a/.github/scripts/tests/test_prepare_tenant_wiring.py
+++ b/.github/scripts/tests/test_prepare_tenant_wiring.py
@@ -22,7 +22,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 sys.path.insert(0, str(Path(__file__).parent))
 
 import e2e_tenant_app as app  # noqa: E402
-from _gha_expr import evaluate  # noqa: E402
+from _gha_expr import evaluate, evaluate_operand  # noqa: E402
 
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 _WORKFLOW = _REPO_ROOT / ".github/workflows/tests-reusable.yaml"
@@ -699,6 +699,144 @@ def test_a_missing_tenant_id_is_rejected_before_anything_is_published(
             f"the tenant-ID gate must run before {later!r} — the whole point is "
             "rejecting the misconfiguration before any work or any publish"
         )
+
+
+# ── Two checks, at two altitudes, neither redundant (FND-203) ────────────────
+# The install path has one precondition ("a tenant_id can be resolved") that is
+# knowable in two halves at two different times, so it is checked twice. Nothing
+# in the workflow says that, and each check looks redundant next to the other —
+# which is exactly how one of them gets deleted.
+
+#: In discover-e2e, the first job on the e2e path. Catches "no tenant matrix
+#: shared with this repo at all", the openapi case: knowable from a secret's
+#: presence, so it costs seconds.
+_EARLY_CHECK = "Require the tenant matrix on the install path"
+
+#: In prepare-tenant, after tenant resolution. Catches "matrix present, this
+#: cloud's entry has no `tenant_id`" — invisible to the early check, which only
+#: ever sees whether the secret exists.
+_LATE_CHECK = "Require a tenant ID before publishing anything"
+
+
+def _named_step(jobs: dict, job: str, name: str) -> dict:  # type: ignore[type-arg]
+    matches = [s for s in jobs[job]["steps"] if str(s.get("name", "")) == name]
+    assert (
+        len(matches) == 1
+    ), f"expected exactly one {name!r} step in {job}, found {len(matches)}"
+    return matches[0]
+
+
+def test_both_install_preconditions_are_checked(jobs: dict) -> None:  # type: ignore[type-arg]
+    """Neither check subsumes the other, so removing either is a regression.
+
+    ``HAS_TENANT_MATRIX`` proves the secret *exists*; it says nothing about
+    whether the cloud's entry inside it carries a ``tenant_id``. So the early
+    check cannot cover the late one's case. And the late check cannot cover the
+    early one's cheaply: it runs after two per-arch image builds and a manifest
+    merge, which is the ~4 minutes of runner time FND-203 is about.
+
+    Dropping the early one restores the waste. Dropping the late one lets a run
+    with a matrix but no ``tenant_id`` for its cloud reach the publish and fail
+    inside the driver on an empty ``--tenant``, several steps past the cause.
+    """
+    _named_step(jobs, "discover-e2e", _EARLY_CHECK)
+    _named_step(jobs, "prepare-tenant", _LATE_CHECK)
+
+
+def test_the_install_path_precondition_is_checked_at_discovery(jobs: dict) -> None:  # type: ignore[type-arg]
+    step = _named_step(jobs, "discover-e2e", _EARLY_CHECK)
+    condition = " ".join(str(step["if"]).split())
+
+    assert "inputs.install-app-to-tenant" in condition, (
+        "the early check must fire only on the install path — a caller that never "
+        "installs is entitled to the single-tenant fallback, which is what the "
+        "'Warn that the cross-CSP matrix is unavailable' step covers instead"
+    )
+    assert "env.HAS_TENANT_MATRIX == ''" in condition, (
+        "the early check must key on the tenant-matrix signal; a step `if:` cannot "
+        "read the `secrets` context directly, which is why the job carries it as env"
+    )
+    assert "exit 1" in step["run"], (
+        "the early check must FAIL the run. A warning would let it go on to spend "
+        "two image builds discovering the same thing in prepare-tenant."
+    )
+
+
+def test_the_early_check_precedes_every_step_that_costs_anything(jobs: dict) -> None:  # type: ignore[type-arg]
+    """Placement is the entire value: a correct check in the wrong place saves
+    nothing. It must precede the checkout and both discovery invocations, so the
+    job fails in seconds rather than after the tree is fetched and globbed."""
+    steps = jobs["discover-e2e"]["steps"]
+    labels = [str(step.get("name") or step.get("uses", "")) for step in steps]
+    position = labels.index(_EARLY_CHECK)
+
+    first_uses = next(
+        index for index, step in enumerate(steps) if step.get("uses") is not None
+    )
+    assert position < first_uses, (
+        f"the early check runs after {labels[first_uses]!r}; it needs no checkout "
+        "and no action, so nothing may precede it except the distinct-id breadcrumb"
+    )
+    for later in ("Discover suites", "Discover clouds"):
+        assert position < labels.index(later)
+
+
+@pytest.mark.parametrize(
+    "secret,expected",
+    [
+        ("", ""),
+        ('{"aws":{"tenant":"t","tenant_id":"i"}}', "true"),
+    ],
+)
+def test_the_early_checks_signal_is_empty_exactly_when_the_secret_is(
+    jobs: dict,  # type: ignore[type-arg]
+    secret: str,
+    expected: str,
+) -> None:
+    """The signal must resolve to '' — not 'false' — when the secret is absent.
+
+    The check reads ``env.HAS_TENANT_MATRIX == ''``, so a plausible-looking
+    simplification of the expression to a bare ``secrets.X != ''`` would render
+    the signal ``'false'``, never match, and disable the check silently. That is
+    the failure mode worth a test: the loud direction (losing the job-level env
+    entirely, making the comparison always true) fails every install-path run on
+    its first use.
+    """
+    env = jobs["discover-e2e"].get("env") or {}
+    assert "HAS_TENANT_MATRIX" in env, (
+        "discover-e2e no longer carries HAS_TENANT_MATRIX at JOB level, so the "
+        "early check's `if:` cannot see it — a step condition cannot read `secrets`"
+    )
+    resolved = evaluate_operand(
+        env["HAS_TENANT_MATRIX"], {"secrets": {"E2E_TENANT_MATRIX_JSON": secret}}
+    )
+    assert resolved == expected
+
+
+@pytest.mark.parametrize(
+    "discovery,builds",
+    [("failure", False), ("success", True)],
+)
+def test_a_failed_discovery_skips_the_image_builds(
+    jobs: dict,  # type: ignore[type-arg]
+    discovery: str,
+    builds: bool,
+) -> None:
+    """What converts the early failure into an actual saving.
+
+    Failing discover-e2e only avoids the two builds because build-e2e-image gates
+    on discover-e2e having SUCCEEDED. Widen that to `always()` or to
+    `result != 'skipped'` — both of which read as harmless robustness — and the
+    builds run anyway, at which point the early check saves nothing at all.
+    """
+    ran = evaluate(
+        jobs["build-e2e-image"]["if"],
+        {
+            "inputs": {"install-app-to-tenant": True},
+            "needs": {"discover-e2e": {"result": discovery, "outputs": {"count": "2"}}},
+        },
+    )
+    assert ran is builds
 
 
 def test_job_timeout_stays_above_the_scripts_own_waits(jobs: dict) -> None:  # type: ignore[type-arg]

--- a/.github/scripts/tests/test_prepare_tenant_wiring.py
+++ b/.github/scripts/tests/test_prepare_tenant_wiring.py
@@ -717,6 +717,12 @@ _EARLY_CHECK = "Require the tenant matrix on the install path"
 #: ever sees whether the secret exists.
 _LATE_CHECK = "Require a tenant ID before publishing anything"
 
+#: The distinct-id breadcrumb, the one step allowed to precede the early check.
+#: It is a free ``echo`` — the workflow header comment names it as the only thing
+#: ahead of the gate, so a costly ``run:`` inserted before the check must trip the
+#: placement test rather than slip past a narrower first-``uses:`` comparison.
+_DISTINCT_ID_BREADCRUMB = "distinct-id ${{ inputs.distinct-id }}"
+
 
 def _named_step(jobs: dict, job: str, name: str) -> dict:  # type: ignore[type-arg]
     matches = [s for s in jobs[job]["steps"] if str(s.get("name", "")) == name]
@@ -762,10 +768,39 @@ def test_the_install_path_precondition_is_checked_at_discovery(jobs: dict) -> No
     )
 
 
+@pytest.mark.parametrize("install", [True, False])
+@pytest.mark.parametrize("signal", ["", "true"])
+def test_the_early_check_fires_only_on_the_install_path_without_a_matrix(
+    jobs: dict,  # type: ignore[type-arg]
+    install: bool,
+    signal: str,
+) -> None:
+    """The full condition, evaluated — substring asserts cannot see a broken gate.
+
+    Matching on the two operand substrings stays green under an edit that keeps
+    both while wrecking the logic (an appended ``|| true``, regrouped operators).
+    Evaluating the whole expression across the install × signal truth table pins
+    what the gate actually does: fire only when installing with no matrix.
+    """
+    step = _named_step(jobs, "discover-e2e", _EARLY_CHECK)
+    fires = evaluate(
+        step["if"],
+        {
+            "inputs": {"install-app-to-tenant": install},
+            "env": {"HAS_TENANT_MATRIX": signal},
+        },
+    )
+    assert fires is (install and signal == "")
+
+
 def test_the_early_check_precedes_every_step_that_costs_anything(jobs: dict) -> None:  # type: ignore[type-arg]
     """Placement is the entire value: a correct check in the wrong place saves
     nothing. It must precede the checkout and both discovery invocations, so the
-    job fails in seconds rather than after the tree is fetched and globbed."""
+    job fails in seconds rather than after the tree is fetched and globbed.
+
+    Measuring only against the first ``uses:`` step would miss a costly ``run:``
+    step inserted ahead of the check, so everything before it must be the named
+    distinct-id breadcrumb — the one free ``echo`` the workflow header allows."""
     steps = jobs["discover-e2e"]["steps"]
     labels = [str(step.get("name") or step.get("uses", "")) for step in steps]
     position = labels.index(_EARLY_CHECK)
@@ -777,6 +812,16 @@ def test_the_early_check_precedes_every_step_that_costs_anything(jobs: dict) -> 
         f"the early check runs after {labels[first_uses]!r}; it needs no checkout "
         "and no action, so nothing may precede it except the distinct-id breadcrumb"
     )
+
+    preceding = steps[:position]
+    assert [str(step.get("name", "")) for step in preceding] == [
+        _DISTINCT_ID_BREADCRUMB
+    ], (
+        "a step that is not the distinct-id breadcrumb runs before the early "
+        "check; anything with a `uses:` or a costly `run:` ahead of it delays the "
+        "failure past the point where it saves the two image builds"
+    )
+
     for later in ("Discover suites", "Discover clouds"):
         assert position < labels.index(later)
 

--- a/.github/workflows/tests-reusable.yaml
+++ b/.github/workflows/tests-reusable.yaml
@@ -817,6 +817,43 @@ jobs:
         shell: bash
         run: echo "Dispatched with distinct-id=${{ inputs.distinct-id }}"
 
+      # ── The install path's precondition, checked before it costs anything ───
+      # A caller on `install-app-to-tenant: true` without the tenant matrix shared
+      # with its repo can NEVER install. The fallback works exactly as designed —
+      # it is just not a fallback for installing: no matrix secret resolves
+      # `clouds` to `none`, prepare-tenant takes its single-tenant leg, and that
+      # leg supplies SDR_TEST_TENANT plus creds and an API key and no `tenant_id`.
+      # Installing needs one, because GM scopes a release via `allowed_tenants`
+      # matched exactly against the tenant's vcluster instance name. So the
+      # fallback is sufficient to RUN legs against a tenant and structurally
+      # insufficient to INSTALL onto one.
+      #
+      # Without this step the run learns that in prepare-tenant — after two
+      # per-arch image builds and a manifest merge have already run, ~4 minutes of
+      # GitHub-hosted ARM and x64 runner time, every time. The precondition is
+      # knowable here, in the first job on the e2e path, in seconds. FND-203.
+      #
+      # An ADDITION, not a move: `HAS_TENANT_MATRIX` proves the secret EXISTS, not
+      # that the relevant cloud's entry carries a `tenant_id`. This catches "no
+      # secret at all"; prepare-tenant's "Require a tenant ID before publishing
+      # anything" remains the backstop for "secret present, `tenant_id` missing for
+      # this cloud", which nothing here can see. Deleting either would look
+      # redundant to a future reader, so both are pinned by
+      # test_prepare_tenant_wiring.py.
+      #
+      # Failing rather than degrading, for the reason the late check already
+      # argues: Heracles re-fetches the manifest from the tenant-deployed pod at AE
+      # submit, so skipping the install and running the legs anyway would test the
+      # version already on the tenant while reporting on the PR's — the exact bug
+      # `install-app-to-tenant` exists to remove.
+      - name: Require the tenant matrix on the install path
+        if: inputs.install-app-to-tenant && env.HAS_TENANT_MATRIX == ''
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "::error::install-app-to-tenant is on but E2E_TENANT_MATRIX_JSON is not available to this repository, so no tenant ID can be resolved and a release cannot be scoped to any tenant. GM matches allowed_tenants EXACTLY against the tenant's vcluster instance name (e.g. 'markeznp37') — not its hostname — and the legacy single-tenant fallback (SDR_TEST_TENANT) has no matrix entry to carry that value, so there is nothing to fall back to. Either share E2E_TENANT_MATRIX_JSON with this repository, with a 'tenant_id' field on each cloud's entry (see docs/standards/connector-ci-e2e.md), or leave install-app-to-tenant off and use the E2E Tenant Install workflow, whose tenant_id input covers the one-off case. Failing at discovery rather than at prepare-tenant so this costs seconds instead of two image builds."
+          exit 1
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false

--- a/docs/standards/connector-ci-e2e.md
+++ b/docs/standards/connector-ci-e2e.md
@@ -225,14 +225,6 @@ A timeout is never downgraded this way — an accepted-but-unreconciled deploy i
 nobody else's fault, and it is the silent wrong-version failure this whole
 mechanism exists to remove.
 
-`prepare-tenant` therefore **fails** on an unresolved `tenant_id`, immediately
-after tenant resolution and before it publishes anything — it does not skip the
-install. Skipping would leave the job green having done nothing, the tenant on
-whatever version it was already running, and every leg reding on its own version
-check instead: one confusing failure per leg in place of one clear failure. Since
-`install-app-to-tenant` is opt-in, a caller that has opted in without a
-`tenant_id` is misconfigured rather than on a supported path.
-
 Each entry may also carry `"deployment_name"` when that tenant's system apps
 (publish / quality / lineage) are not registered under `production`. It reaches
 the harness as `E2E_TENANT_DEPLOYMENT_NAME`, which
@@ -270,6 +262,44 @@ key is the org-wide one.
 When the secret is not available to a repo, `clouds` is forced to `none` and the
 `Discover e2e suites` job emits a `::warning::` saying so — a run that asked for
 three clouds and got one must not look identical to one that got three.
+
+### Requiring a tenant ID on the install path
+
+That degradation is honest for a repo that only *runs legs against* a tenant, and
+insufficient for one that *installs onto* one. The single-tenant fallback supplies
+`SDR_TEST_TENANT` plus credentials and an API key, and no `tenant_id` — there is no
+matrix entry to carry one. So on `install-app-to-tenant: true` the missing secret
+is fatal, not a warning.
+
+Failing rather than skipping the install, deliberately. Skipping would leave
+`prepare-tenant` green having done nothing, the tenant on whatever version it was
+already running, and every leg reding on its own version check instead: one
+confusing failure per leg in place of one clear failure. Heracles re-fetches the
+manifest from the tenant-deployed pod at AE submit, so running the legs against an
+install that did not happen tests the version already on the tenant while
+reporting on the PR's — the exact bug `install-app-to-tenant` exists to remove.
+And since `install-app-to-tenant` is opt-in, a caller that has opted in without a
+`tenant_id` is misconfigured rather than on a supported path.
+
+**The same precondition, checked twice.** "A `tenant_id` can be resolved" is
+knowable in two halves at two different times, so it is checked at both (FND-203):
+
+| Where | Sees | Catches | Costs |
+| --- | --- | --- | --- |
+| `discover-e2e` → *Require the tenant matrix on the install path* | whether `E2E_TENANT_MATRIX_JSON` exists at all | `install-app-to-tenant: true` on a repo the secret was never shared with | seconds |
+| `prepare-tenant` → *Require a tenant ID before publishing anything* | the resolved `E2E_TENANT_ID` for **this** cloud | matrix present, this cloud's entry missing `tenant_id` | after two per-arch image builds and the manifest merge |
+
+The early check exists because the late one is expensive to reach: the install
+path builds `linux/amd64` and `linux/arm64` on separate native runners and merges
+the manifest before `prepare-tenant` runs, so a repo that could never install
+burned ~4 minutes of GitHub-hosted runner time per attempt to discover that.
+
+Neither check subsumes the other. The secret's *presence* says nothing about
+whether the entry inside it carries a `tenant_id`, so the early check cannot cover
+the late one's case; and the late check is the one that runs too late to be cheap.
+Both are pinned by `test_prepare_tenant_wiring.py`
+(`test_both_install_preconditions_are_checked`), because side by side each looks
+redundant — which is how one of them gets deleted.
 
 ## Cross-repo dispatch
 


### PR DESCRIPTION
Closes FND-203.

## Problem

A connector on `install-app-to-tenant: true` whose repo was never granted `E2E_TENANT_MATRIX_JSON` can never install — but the run only finds that out in `prepare-tenant`, after two per-arch image builds and a manifest merge have already run. That is ~4 minutes of GitHub-hosted ARM and x64 runner time, spent to discover a precondition that was knowable before the checkout.

The fallback works exactly as designed; it is just not a fallback for *installing*. No matrix secret resolves `clouds` to `none`, `prepare-tenant` takes its single-tenant leg, and that leg supplies a tenant, credentials and an API key — and no `tenant_id`. Installing needs one, because GM scopes a release via `allowed_tenants` matched **exactly** against the tenant's vcluster instance name. So the fallback is sufficient to *run legs against* a tenant and structurally insufficient to *install onto* one.

## Change

A fail-fast step in `discover-e2e`, the first job on the e2e path, placed ahead of the checkout so nothing precedes it but the `distinct-id` breadcrumb:

```yaml
- name: Require the tenant matrix on the install path
  if: inputs.install-app-to-tenant && env.HAS_TENANT_MATRIX == ''
```

It reuses the signal the job already carries at job level (a step `if:` cannot read `secrets` directly) and prints the same remedy `prepare-tenant` does today: share the secret with a per-cloud `tenant_id`, or leave `install-app-to-tenant` off and use the E2E Tenant Install workflow for one-offs.

### An addition, not a move

`HAS_TENANT_MATRIX` proves the secret **exists**, not that the relevant cloud's entry carries a `tenant_id`. So this catches "no secret at all"; `prepare-tenant`'s *Require a tenant ID before publishing anything* stays as the backstop for "secret present, `tenant_id` missing for this cloud", which nothing at discovery time can see.

| Where | Sees | Catches | Costs |
| --- | --- | --- | --- |
| `discover-e2e` (new) | whether the secret exists at all | `install-app-to-tenant: true` on a repo it was never shared with | seconds |
| `prepare-tenant` (unchanged) | the resolved `E2E_TENANT_ID` for **this** cloud | matrix present, this cloud's entry missing `tenant_id` | after two builds + the merge |

### Still failing closed

Unchanged, and deliberately so: Heracles re-fetches the manifest from the tenant-deployed pod at AE submit, so skipping the install and running the legs anyway would test the version already on the tenant while reporting on the PR's — the exact bug `install-app-to-tenant` exists to remove.

## Tests

`.github/scripts/tests/test_prepare_tenant_wiring.py` gains five guards. `test_both_install_preconditions_are_checked` is the one the ticket asked for — side by side each check looks redundant, which is how one gets deleted. Two more cover the ways the saving evaporates while the checks still *look* right:

- **The signal's shape.** The check reads `env.HAS_TENANT_MATRIX == ''`. "Simplifying" the job env to a bare `secrets.X != ''` renders the signal `'false'`, which never matches — silently disabling the check. Pinned by evaluating the real expression through `_gha_expr` and asserting `''` / `'true'`. (The opposite mutation, losing the job-level env, is loud: it fails every install-path run on first use.)
- **`build-e2e-image`'s gate.** Failing discovery only avoids the two builds because that job gates on `needs.discover-e2e.result == 'success'`. Widening it to `always()` or `!= 'skipped'` reads as harmless robustness and makes this whole PR worthless, so that `if:` is evaluated for both discovery results.

Plus step placement (before anything that costs runner time) and the new step's own gate and `exit 1`.

All five mutation-checked: dropping the `install-app-to-tenant` term, moving the step below the checkout, flattening the signal expression, and removing either check each fail a named test.

`.github/scripts/tests/` green — 1824 passed. Pre-commit clean.

## Docs

`docs/standards/connector-ci-e2e.md` gains a `### Requiring a tenant ID on the install path` subsection with the table above and the reason neither check subsumes the other. The pre-existing "`prepare-tenant` fails on an unresolved `tenant_id`" paragraph moved into it — it was stranded under the *When the FAILED verdict is about somebody else's pod* heading, which is not what it is about.

## Out of scope

Both explicitly deferred in the ticket: `atlan-openapi-app`'s own configuration (share the secret vs. drop the input), and the fail-vs-degrade question — this PR changes only *when* the failure happens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
