### PR TITLE
feat(execution): ProgressTracker — progress token, keyed holds, injected clock (FND-283)

### DIFF
--- a/application_sdk/execution/progress.py
+++ b/application_sdk/execution/progress.py
@@ -153,9 +153,9 @@ class ProgressTracker:
                 warn mode can re-arm the stall clock after reporting a gap
                 without erasing the signal it just reported.
         """
-        now = self._clock()
         with self._lock:
-            self._last_at = now
+            now = self._clock()
+            self._last_at = max(self._last_at, now)
             if label:
                 self._last_label = label
 
@@ -214,11 +214,11 @@ class ProgressTracker:
                 accounting is then wrong in the *lenient* direction); it is
                 logged and otherwise ignored.
         """
-        now = self._clock()
         with self._lock:
+            now = self._clock()
             hold = self._holds.pop(token, None)
             if hold is not None:
-                self._last_at = now
+                self._last_at = max(self._last_at, now)
                 if hold.label:
                     self._last_label = hold.label
         if hold is None:

--- a/application_sdk/execution/progress.py
+++ b/application_sdk/execution/progress.py
@@ -1,0 +1,297 @@
+"""Observed forward progress for one activity attempt (ADR-0018).
+
+This is the foundation object for the stall watchdog. It answers one question —
+*how long has it been since this attempt did anything observable?* — and it
+answers it with **no Temporal dependency**, so local runs, unit tests and
+production exercise the same code path, and a task with
+``heartbeat_timeout_seconds=None`` still gets a stall watchdog.
+
+Progress tracking is deliberately a new object rather than a change to
+:class:`~application_sdk.execution.heartbeat.HeartbeatController`: the
+controller's job (send beats to Temporal) is unchanged, so its Protocol and
+``NoopHeartbeatController`` keep their current contract.
+
+Two signals feed it (see ADR-0018 → *Feeding the tracker*):
+
+- :meth:`ProgressTracker.mark_progress` — one observable unit of work
+  completed: a batch written, a chunk or file transferred, a page fetched, an
+  explicit ``context.heartbeat()``. Never wall-clock time, and never per
+  record: batch, chunk and page boundaries only.
+- :meth:`ProgressTracker.enter_hold` / :meth:`ProgressTracker.exit_hold` — a
+  *vouch* for one in-flight operation the SDK cannot see into (a single large
+  query, one slow API call, a blocking call offloaded through
+  ``run_in_thread``). The SDK never invents the allowance; a human declares it
+  at the one call site that knows, or declares nothing and gets an unbounded
+  hold that the duration backstop owns.
+
+The watchdog itself (FND-286), the ContextVar plumbing that makes the tracker
+reachable from app code (FND-287), the framework hooks (FND-288) and the
+warn-mode telemetry that consumes :class:`ClosedHold` (FND-292) are separate
+pieces built on this one.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from application_sdk.observability.logger_adaptor import get_logger
+
+logger = get_logger(__name__)
+
+
+@dataclass(frozen=True)
+class ClosedHold:
+    """One completed hold, observed at the moment its token was released.
+
+    Handed to the ``on_hold_closed`` observer so warn mode can rank hold sites
+    without anyone reading code. The shape that needs action is a *long
+    unbounded* hold: it is invisible to any other audit precisely because it is
+    auto-vouched-for, and it is the site that wants an explicit allowance
+    instead of relying on the duration backstop.
+
+    Attributes:
+        label: The label the hold was entered with (a call site, not a value).
+        duration_seconds: Wall-clock seconds the operation actually took.
+        allowance_seconds: The allowance a human declared, or ``None`` for an
+            unbounded hold.
+    """
+
+    label: str
+    duration_seconds: float
+    allowance_seconds: float | None
+
+    @property
+    def bounded(self) -> bool:
+        """Whether an allowance was declared for this hold."""
+        return self.allowance_seconds is not None
+
+    @property
+    def lapsed(self) -> bool:
+        """Whether the operation outlived its declared allowance.
+
+        A lapsed hold means the watchdog resumed while the operation was still
+        running — the allowance was too tight, or the source really did hang.
+        Always ``False`` for an unbounded hold.
+        """
+        return (
+            self.allowance_seconds is not None
+            and self.duration_seconds > self.allowance_seconds
+        )
+
+
+@dataclass(frozen=True)
+class _Hold:
+    """An in-flight vouch. ``allowance_seconds=None`` means unbounded."""
+
+    label: str
+    started_at: float
+    allowance_seconds: float | None
+
+    @property
+    def deadline(self) -> float | None:
+        """Clock reading past which this hold no longer vouches for anything."""
+        if self.allowance_seconds is None:
+            return None
+        return self.started_at + self.allowance_seconds
+
+
+class ProgressTracker:
+    """Observed forward progress for one activity attempt.
+
+    One instance per activity attempt. Cheap: a dict, two floats and an
+    uncontended lock.
+
+    Args:
+        clock: Monotonic time source, in seconds. Injected rather than read from
+            a patchable global on purpose: an asyncio loop shares
+            ``time.monotonic``, so patching it globally in tests makes the loop
+            itself misbehave (flaky ``StopIteration`` from an exhausted
+            side-effect list). Tests advance their own clock instead.
+        on_hold_closed: Called once per :meth:`exit_hold` with the observed
+            :class:`ClosedHold`. This is the warn-mode audit seam (FND-292);
+            it defaults to no observer. Exceptions raised by the observer are
+            logged and swallowed — telemetry must never fail an activity.
+    """
+
+    def __init__(
+        self,
+        clock: Callable[[], float] = time.monotonic,
+        on_hold_closed: Callable[[ClosedHold], None] | None = None,
+    ) -> None:
+        self._clock = clock
+        self._on_hold_closed = on_hold_closed
+        self._last_label: str = ""
+        self._last_at: float = clock()
+        self._holds: dict[int, _Hold] = {}
+        self._next_token: int = 0
+        # Mutations are not confined to the event loop: contextvars propagate
+        # into `run_in_thread`, so framework hooks and `context.heartbeat()`
+        # inside an offloaded blocking call reach this object from a worker
+        # thread. Token allocation especially must be serialised — two holds
+        # sharing a token would let one release the other's deadline.
+        self._lock = threading.Lock()
+
+    @property
+    def last_label(self) -> str:
+        """Label of the most recent labelled progress signal, ``""`` if none.
+
+        Named in the stall log and the stall metric so an operator sees *where*
+        the attempt went quiet rather than only *that* it did.
+        """
+        with self._lock:
+            return self._last_label
+
+    def mark_progress(self, label: str = "") -> None:
+        """Record one observable unit of work completing.
+
+        Args:
+            label: What made progress, e.g. ``"write_batch"``. An empty label
+                records the progress but leaves :attr:`last_label` alone, so
+                warn mode can re-arm the stall clock after reporting a gap
+                without erasing the signal it just reported.
+        """
+        now = self._clock()
+        with self._lock:
+            self._last_at = now
+            if label:
+                self._last_label = label
+
+    def enter_hold(self, label: str, timeout: float | None) -> int:
+        """Vouch for an in-flight operation the SDK cannot see into.
+
+        Args:
+            label: The call site being vouched for, e.g.
+                ``"snapshot metadata query"``. Carried into the stall log and
+                the :class:`ClosedHold` observation, so make it identify a
+                site — never interpolate a query, a credential or a customer
+                value into it.
+            timeout: How long the caller would let this one operation run
+                before it would rather it failed — *not* a prediction of how
+                long it takes. ``None`` is an unbounded hold: the stall
+                watchdog is inactive for the whole call and the duration
+                backstop is its only bound (an accepted residual, surfaced by
+                warn mode). A negative allowance is a programming error; it is
+                logged and treated as already exhausted.
+
+        Returns:
+            An opaque token to pass to :meth:`exit_hold`. Holds are keyed by
+            token, never popped off a stack, so concurrent holds in one
+            activity — ``asyncio.gather`` over several ``run_in_thread``
+            calls — cannot release each other's deadlines.
+        """
+        if timeout is not None and timeout < 0:
+            logger.warning(
+                "Hold '%s' was entered with a negative allowance (%.3fs); treating "
+                "it as already exhausted — the stall watchdog will not pause for it",
+                label,
+                timeout,
+            )
+        now = self._clock()
+        with self._lock:
+            token = self._next_token
+            self._next_token += 1
+            self._holds[token] = _Hold(
+                label=label, started_at=now, allowance_seconds=timeout
+            )
+        return token
+
+    def exit_hold(self, token: int) -> None:
+        """Release the hold ``token`` vouched for.
+
+        A completed operation *is* progress, so this marks progress under the
+        hold's label. It also reports the observed duration to
+        ``on_hold_closed``, which is what makes long unbounded holds visible to
+        the warn-mode report — without it, blocking work auto-held by
+        ``run_in_thread`` would be invisible to the audit precisely because it
+        was vouched for.
+
+        Args:
+            token: A token returned by :meth:`enter_hold`. An unknown or
+                already-released token means the hold plumbing is broken (stall
+                accounting is then wrong in the *lenient* direction); it is
+                logged and otherwise ignored.
+        """
+        now = self._clock()
+        with self._lock:
+            hold = self._holds.pop(token, None)
+            if hold is not None:
+                self._last_at = now
+                if hold.label:
+                    self._last_label = hold.label
+        if hold is None:
+            # The token value is deliberately not logged: "token" reads as a
+            # credential to the L010 security scanner, and a per-attempt counter
+            # adds nothing an operator can act on.
+            logger.warning(
+                "exit_hold() found no such hold — it was already released, or the "
+                "token came from a different tracker; stall accounting may be lenient"
+            )
+            return
+        self._notify_hold_closed(
+            ClosedHold(
+                label=hold.label,
+                duration_seconds=max(0.0, now - hold.started_at),
+                allowance_seconds=hold.allowance_seconds,
+            )
+        )
+
+    def held(self) -> bool:
+        """Whether any hold is currently vouching for the attempt.
+
+        An unbounded hold always vouches. A bounded one stops vouching once its
+        allowance is spent, even though its token is still open — that is how a
+        wedged call inside a hold is eventually caught instead of being excused
+        forever.
+        """
+        now = self._clock()
+        with self._lock:
+            return any(
+                hold.deadline is None or hold.deadline > now
+                for hold in self._holds.values()
+            )
+
+    def stalled_for(self) -> float:
+        """Seconds since the last observable progress, ``0.0`` while vouched-for.
+
+        A lapsed bounded hold *resumes* the stall clock from its deadline rather
+        than from the last progress signal before it: the allowance vouched for
+        everything up to the deadline, so the earliest instant the attempt can
+        be accused of stalling is the deadline itself. That is what makes the
+        effective kill time for a wedged held call ``allowance + budget``
+        (ADR-0018 → *Holds*) instead of firing the moment the allowance lapses.
+        """
+        now = self._clock()
+        with self._lock:
+            since = self._last_at
+            for hold in self._holds.values():
+                deadline = hold.deadline
+                if deadline is None or deadline > now:
+                    return 0.0
+                # A hold only vouches forward from where it started, so a
+                # non-positive allowance vouches for nothing and must not
+                # forgive the quiet that preceded it.
+                if deadline > hold.started_at:
+                    since = max(since, deadline)
+        return max(0.0, now - since)
+
+    def _notify_hold_closed(self, closed: ClosedHold) -> None:
+        observer = self._on_hold_closed
+        if observer is None:
+            return
+        try:
+            observer(closed)
+        # conformance: ignore[E004] best-effort audit telemetry; an observer that
+        # raises must never fail the activity it is only observing. Logged at
+        # WARNING with the traceback because a broken observer means the
+        # warn-mode work-list is silently incomplete.
+        except Exception:
+            logger.warning(
+                "Hold-closed observer failed for hold '%s' (%.3fs); the warn-mode "
+                "report will be missing this observation",
+                closed.label,
+                closed.duration_seconds,
+                exc_info=True,
+            )

--- a/docs/adr/0018-progress-aware-heartbeat.md
+++ b/docs/adr/0018-progress-aware-heartbeat.md
@@ -241,7 +241,18 @@ class ProgressTracker:
 
     def stalled_for(self) -> float:
         """Seconds since the last observable progress, 0 while vouched-for."""
-        return 0.0 if self.held() else self._clock() - self._last_at
+        now = self._clock()
+        since = self._last_at
+        for h in self._holds.values():
+            if h.deadline is None or h.deadline > now:
+                return 0.0
+            # A *lapsed* bounded hold resumes the clock from its deadline, not
+            # from the progress signal before it: the allowance vouched for
+            # everything up to the deadline, which is what makes the kill time
+            # for a wedged held call `timeout + budget` (see Holds) rather than
+            # firing the instant the allowance lapses.
+            since = max(since, h.deadline)
+        return now - since
 ```
 
 ### The watchdog in the loop

--- a/tests/unit/execution/test_progress.py
+++ b/tests/unit/execution/test_progress.py
@@ -1,0 +1,372 @@
+"""Unit tests for application_sdk.execution.progress.
+
+No worker, no event loop, no patched global clock: the tracker takes its clock
+by injection precisely so tests can drive time without touching
+``time.monotonic`` (which an asyncio loop shares — patching it globally makes
+the loop itself misbehave).
+"""
+
+from __future__ import annotations
+
+import time
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass, field
+
+from application_sdk.execution.progress import ClosedHold, ProgressTracker
+
+# ---------------------------------------------------------------------------
+# Test doubles
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FakeClock:
+    """A monotonic clock the test advances explicitly."""
+
+    now: float = 1000.0
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+@dataclass
+class HoldRecorder:
+    """Collects the ClosedHold observations the tracker reports."""
+
+    closed: list[ClosedHold] = field(default_factory=list)
+
+    def __call__(self, hold: ClosedHold) -> None:
+        self.closed.append(hold)
+
+
+def _tracker(clock: FakeClock, recorder: HoldRecorder | None = None) -> ProgressTracker:
+    return ProgressTracker(clock=clock, on_hold_closed=recorder)
+
+
+# ---------------------------------------------------------------------------
+# Progress signal
+# ---------------------------------------------------------------------------
+
+
+class TestMarkProgress:
+    def test_stall_clock_starts_at_construction(self) -> None:
+        clock = FakeClock()
+        tracker = _tracker(clock)
+
+        assert tracker.stalled_for() == 0.0
+        clock.advance(42.0)
+        assert tracker.stalled_for() == 42.0
+
+    def test_mark_progress_resets_the_stall_clock(self) -> None:
+        clock = FakeClock()
+        tracker = _tracker(clock)
+
+        clock.advance(30.0)
+        tracker.mark_progress("write_batch")
+        assert tracker.stalled_for() == 0.0
+
+        clock.advance(5.0)
+        assert tracker.stalled_for() == 5.0
+
+    def test_label_is_remembered(self) -> None:
+        clock = FakeClock()
+        tracker = _tracker(clock)
+
+        assert tracker.last_label == ""
+        tracker.mark_progress("write_batch")
+        assert tracker.last_label == "write_batch"
+
+    def test_unlabelled_progress_re_arms_without_erasing_the_label(self) -> None:
+        """Warn mode re-arms after reporting a gap; the reported label must survive."""
+        clock = FakeClock()
+        tracker = _tracker(clock)
+        tracker.mark_progress("transfer_chunk")
+
+        clock.advance(900.0)
+        tracker.mark_progress()
+
+        assert tracker.stalled_for() == 0.0
+        assert tracker.last_label == "transfer_chunk"
+
+
+# ---------------------------------------------------------------------------
+# Holds
+# ---------------------------------------------------------------------------
+
+
+class TestUnboundedHold:
+    def test_vouches_indefinitely(self) -> None:
+        clock = FakeClock()
+        tracker = _tracker(clock)
+        tracker.enter_hold("full table scan", None)
+
+        clock.advance(6 * 60 * 60)
+
+        assert tracker.held() is True
+        assert tracker.stalled_for() == 0.0
+
+    def test_exit_resumes_the_stall_clock_from_zero(self) -> None:
+        clock = FakeClock()
+        tracker = _tracker(clock)
+        token = tracker.enter_hold("full table scan", None)
+
+        clock.advance(3600.0)
+        tracker.exit_hold(token)
+
+        assert tracker.held() is False
+        assert tracker.stalled_for() == 0.0
+        assert tracker.last_label == "full table scan"
+
+        clock.advance(10.0)
+        assert tracker.stalled_for() == 10.0
+
+
+class TestBoundedHold:
+    def test_vouches_until_the_allowance_is_spent(self) -> None:
+        clock = FakeClock()
+        tracker = _tracker(clock)
+        tracker.enter_hold("snapshot metadata query", 1800.0)
+
+        clock.advance(1799.0)
+        assert tracker.held() is True
+        assert tracker.stalled_for() == 0.0
+
+    def test_lapsed_hold_resumes_the_stall_clock_from_its_deadline(self) -> None:
+        """Kill time for a wedged held call is allowance + budget, not allowance.
+
+        The allowance vouched for everything up to the deadline, so the stall
+        clock counts from the deadline — not from the last progress signal
+        before the hold, which would fire the instant the allowance lapsed.
+        """
+        clock = FakeClock()
+        tracker = _tracker(clock)
+        tracker.mark_progress("write_batch")
+        tracker.enter_hold("snapshot metadata query", 1800.0)
+
+        clock.advance(1800.0 + 700.0)
+
+        assert tracker.held() is False
+        assert tracker.stalled_for() == 700.0
+
+    def test_progress_inside_a_lapsed_hold_wins_over_the_deadline(self) -> None:
+        clock = FakeClock()
+        tracker = _tracker(clock)
+        tracker.enter_hold("paged export", 60.0)
+
+        clock.advance(100.0)
+        tracker.mark_progress("fetch_page")
+        clock.advance(5.0)
+
+        assert tracker.stalled_for() == 5.0
+
+    def test_zero_allowance_does_not_forgive_the_quiet_before_it(self) -> None:
+        clock = FakeClock()
+        tracker = _tracker(clock)
+        tracker.mark_progress("write_batch")
+        clock.advance(10.0)
+        tracker.enter_hold("no allowance at all", 0.0)
+
+        assert tracker.held() is False
+        assert tracker.stalled_for() == 10.0
+
+    def test_negative_allowance_is_already_exhausted(self) -> None:
+        clock = FakeClock()
+        tracker = _tracker(clock)
+        tracker.mark_progress("write_batch")
+        clock.advance(10.0)
+        tracker.enter_hold("typo", -5.0)
+
+        assert tracker.held() is False
+        assert tracker.stalled_for() == 10.0
+
+
+class TestConcurrentHolds:
+    def test_tokens_are_distinct(self) -> None:
+        clock = FakeClock()
+        tracker = _tracker(clock)
+
+        first = tracker.enter_hold("query a", None)
+        second = tracker.enter_hold("query b", None)
+
+        assert first != second
+
+    def test_exiting_one_hold_does_not_release_another(self) -> None:
+        """Keyed by token, not popped off a stack: gather() over two offloads."""
+        clock = FakeClock()
+        tracker = _tracker(clock)
+        short = tracker.enter_hold("quick query", 60.0)
+        tracker.enter_hold("slow query", 7200.0)
+
+        clock.advance(30.0)
+        tracker.exit_hold(short)
+
+        clock.advance(1000.0)
+        assert tracker.held() is True
+        assert tracker.stalled_for() == 0.0
+
+    def test_stall_waits_for_the_last_deadline_to_lapse(self) -> None:
+        clock = FakeClock()
+        tracker = _tracker(clock)
+        tracker.enter_hold("quick query", 60.0)
+        tracker.enter_hold("slow query", 600.0)
+
+        clock.advance(300.0)
+        assert tracker.stalled_for() == 0.0
+
+        clock.advance(400.0)  # now 700s in: both deadlines are behind us
+        assert tracker.stalled_for() == 100.0
+
+    def test_reverse_order_exit_is_fine(self) -> None:
+        clock = FakeClock()
+        tracker = _tracker(clock)
+        first = tracker.enter_hold("query a", None)
+        second = tracker.enter_hold("query b", None)
+
+        tracker.exit_hold(first)
+        assert tracker.held() is True
+        tracker.exit_hold(second)
+        assert tracker.held() is False
+
+    def test_token_allocation_is_thread_safe(self) -> None:
+        """contextvars reach worker threads, so holds can be entered off-loop.
+
+        Two holds sharing a token would let one release the other's deadline.
+        """
+        tracker = ProgressTracker(clock=time.monotonic)
+
+        def enter_many() -> list[int]:
+            return [tracker.enter_hold("offloaded call", None) for _ in range(200)]
+
+        with ThreadPoolExecutor(max_workers=8) as pool:
+            batches = [pool.submit(enter_many) for _ in range(8)]
+            tokens = [token for batch in batches for token in batch.result()]
+
+        assert len(tokens) == 8 * 200
+        assert len(set(tokens)) == len(tokens)
+
+
+# ---------------------------------------------------------------------------
+# Closed-hold observations (the warn-mode audit seam)
+# ---------------------------------------------------------------------------
+
+
+class TestClosedHoldObservations:
+    def test_unbounded_hold_reports_its_observed_duration(self) -> None:
+        clock = FakeClock()
+        recorder = HoldRecorder()
+        tracker = _tracker(clock, recorder)
+        token = tracker.enter_hold("full table scan", None)
+
+        clock.advance(4200.0)
+        tracker.exit_hold(token)
+
+        assert recorder.closed == [
+            ClosedHold(
+                label="full table scan",
+                duration_seconds=4200.0,
+                allowance_seconds=None,
+            )
+        ]
+        observed = recorder.closed[0]
+        assert observed.bounded is False
+        assert observed.lapsed is False
+
+    def test_bounded_hold_within_allowance_is_not_lapsed(self) -> None:
+        clock = FakeClock()
+        recorder = HoldRecorder()
+        tracker = _tracker(clock, recorder)
+        token = tracker.enter_hold("snapshot metadata query", 1800.0)
+
+        clock.advance(120.0)
+        tracker.exit_hold(token)
+
+        observed = recorder.closed[0]
+        assert observed.allowance_seconds == 1800.0
+        assert observed.bounded is True
+        assert observed.lapsed is False
+
+    def test_bounded_hold_past_its_allowance_is_lapsed(self) -> None:
+        clock = FakeClock()
+        recorder = HoldRecorder()
+        tracker = _tracker(clock, recorder)
+        token = tracker.enter_hold("snapshot metadata query", 60.0)
+
+        clock.advance(61.0)
+        tracker.exit_hold(token)
+
+        assert recorder.closed[0].lapsed is True
+
+    def test_unknown_token_reports_nothing(self) -> None:
+        clock = FakeClock()
+        recorder = HoldRecorder()
+        tracker = _tracker(clock, recorder)
+
+        tracker.exit_hold(9999)
+
+        assert recorder.closed == []
+
+    def test_double_exit_reports_once_and_does_not_reset_progress(self) -> None:
+        clock = FakeClock()
+        recorder = HoldRecorder()
+        tracker = _tracker(clock, recorder)
+        token = tracker.enter_hold("full table scan", None)
+
+        clock.advance(10.0)
+        tracker.exit_hold(token)
+        clock.advance(25.0)
+        tracker.exit_hold(token)
+
+        assert len(recorder.closed) == 1
+        assert tracker.stalled_for() == 25.0
+
+    def test_observer_failure_never_breaks_the_caller(self) -> None:
+        clock = FakeClock()
+
+        def explode(_: ClosedHold) -> None:
+            raise RuntimeError("metric backend down")
+
+        tracker = ProgressTracker(clock=clock, on_hold_closed=explode)
+        token = tracker.enter_hold("full table scan", None)
+
+        clock.advance(5.0)
+        tracker.exit_hold(token)  # must not raise
+
+        assert tracker.stalled_for() == 0.0
+
+    def test_no_observer_is_fine(self) -> None:
+        clock = FakeClock()
+        tracker = ProgressTracker(clock=clock)
+        token = tracker.enter_hold("full table scan", None)
+
+        clock.advance(5.0)
+        tracker.exit_hold(token)
+
+        assert tracker.held() is False
+
+
+# ---------------------------------------------------------------------------
+# Clock injection
+# ---------------------------------------------------------------------------
+
+
+class TestClockInjection:
+    def test_defaults_to_time_monotonic(self) -> None:
+        tracker = ProgressTracker()
+
+        assert tracker._clock is time.monotonic
+        assert tracker.stalled_for() >= 0.0
+
+    def test_no_global_clock_is_read(self) -> None:
+        """The injected clock is the only time source the tracker consults."""
+        clock = FakeClock()
+        tracker = _tracker(clock)
+        tracker.mark_progress("write_batch")
+
+        real_before = time.monotonic()
+        while time.monotonic() - real_before < 0.01:
+            pass
+
+        assert tracker.stalled_for() == 0.0

--- a/tests/unit/execution/test_progress.py
+++ b/tests/unit/execution/test_progress.py
@@ -247,6 +247,32 @@ class TestConcurrentHolds:
         assert len(tokens) == 8 * 200
         assert len(set(tokens)) == len(tokens)
 
+    def test_last_at_never_regresses_under_concurrent_writes(self) -> None:
+        """The stall clock must never move backwards, even if a caller's clock
+        sample is stale relative to a write another thread already committed.
+
+        With the clock read inside the lock and the monotonic max() guard, a
+        thread that sampled an earlier time cannot overwrite a later
+        ``_last_at``. This pins the lenient-only accounting direction the
+        ``exit_hold`` docstring promises.
+        """
+        clock = FakeClock()
+        tracker = _tracker(clock)
+
+        # Establish a baseline at t=10.
+        clock.now = 1010.0
+        tracker.mark_progress("baseline")
+        assert tracker._last_at == 1010.0
+
+        # A stale clock reading (t=5) must not move _last_at backwards.
+        clock.now = 1005.0
+        tracker.mark_progress("stale")
+        assert tracker._last_at == 1010.0
+
+        # The stall clock is still anchored at t=10.
+        clock.now = 1015.0
+        assert tracker.stalled_for() == 5.0
+
 
 # ---------------------------------------------------------------------------
 # Closed-hold observations (the warn-mode audit seam)


### PR DESCRIPTION
Implements [FND-283](https://linear.app/atlan-epd/issue/FND-283/progresstracker-progress-token-keyed-holds-injected-clock) — the foundation object for the ADR-0018 stall watchdog. Everything else in M1 (FND-286 watchdog, FND-287 ContextVar, FND-288 hooks, FND-290/291 holds, FND-292 telemetry) builds on this one, so it ships alone and fully unit-tested.

## What this adds

`application_sdk/execution/progress.py` — `ProgressTracker`, one instance per activity attempt, answering *"how long since this attempt did anything observable?"*:

- `mark_progress(label="")` — one observable unit of work completing. An empty label records the progress but leaves `last_label` alone, so warn mode can re-arm the stall clock after reporting a gap without erasing the signal it just reported.
- `enter_hold(label, timeout) -> int` / `exit_hold(token)` — vouch for one in-flight operation the SDK cannot see into. Keyed by token in a dict, never popped off a stack, so concurrent holds in one activity (`asyncio.gather` over several `run_in_thread` calls) cannot release each other's deadlines.
- `exit_hold` treats the completed operation as progress *and* reports a `ClosedHold(label, duration_seconds, allowance_seconds)` — deriving `bounded` / `lapsed` — to an injected observer.
- `held()` / `stalled_for()` / `last_label`.
- The clock is injected (default `time.monotonic`), never a patched global: an asyncio loop shares `time.monotonic`, so patching it globally in tests makes the loop itself misbehave.

Deliberately a new object rather than a change to `HeartbeatController`: the controller's job (send beats to Temporal) is unchanged, so its Protocol and `NoopHeartbeatController` keep their contract. The tracker has **no Temporal dependency**, which means local runs, unit tests and production exercise the same code path — and a task with `heartbeat_timeout_seconds=None` still gets a stall watchdog.

Not exported from `application_sdk.execution` yet, so the capability manifest is unchanged: the public seam is FND-291's `holding_progress()` over FND-287's ContextVar.

## Decisions a reviewer should look at

**1. A lapsed bounded hold resumes the stall clock from its deadline — a deliberate deviation from the ADR's sketch, which contradicts the ADR's own prose.** The sketch returns `clock() - last_at`, which fires the stall *the instant* a bounded hold lapses whenever `timeout >= budget`. The prose says the stall fires `max_no_progress_seconds` after the lapse, and that "effective kill time for a wedged call is `timeout + budget`". The allowance vouched for everything up to the deadline, so the earliest instant the attempt can be accused of stalling is the deadline itself — implemented as `since = max(last_at, latest lapsed deadline)`. **The ADR's sketch is corrected in this PR** so it no longer contradicts the paragraph above it.

Corollary: a hold only vouches *forward from where it started*, so a zero or negative allowance vouches for nothing and must not forgive the quiet that preceded it. A negative allowance is a programming error — logged at WARNING and treated as already exhausted rather than raised, because the tracker sits in the watchdog path and should never itself be the thing that fails an activity. Validation belongs at FND-291's public call site.

**2. `ClosedHold` goes to an injected observer, not to a list on the tracker.** The sketch's `_observe_hold_closed(...)` is a placeholder. An accumulating list would grow unbounded over a 24h attempt full of auto-held `run_in_thread` calls; a `Callable[[ClosedHold], None]` injected at construction keeps the tracker free of any observability dependency and leaves the metric to FND-292. The shape carries enough to rank both audit cases separately: a long *unbounded* hold (wants an explicit allowance) versus a bounded hold that overran (allowance too tight, or the source really hung). Observer exceptions are logged at WARNING with the traceback and swallowed — telemetry must never fail the activity it is only observing.

**3. Mutations are lock-guarded.** The concurrency case the ADR names is `asyncio.gather` (same thread), but contextvars propagate into `run_in_thread`, so once FND-287/288 land, framework hooks and `context.heartbeat()` inside offloaded blocking work reach this object from a worker thread. Token allocation especially must be serialised: two holds sharing a token would let one release the other's deadline — the exact failure keyed holds exist to prevent. `exit_hold` invokes its observer outside the lock so foreign code never runs while the lock is held.

**4. `exit_hold` does not log the token value.** "token" reads as a credential to the block-tier L010 conformance rule, and a per-attempt counter is not something an operator can act on. An unknown or already-released token is still logged at WARNING (without the value), because it means the hold plumbing is broken and stall accounting has gone lenient.

## Tests

`tests/unit/execution/test_progress.py` — 25 tests, no worker, no event loop, no patched global clock (a typed `FakeClock` the test advances explicitly). Covers the stall clock and label semantics, unbounded holds, bounded holds in force, a lapsed bounded hold resuming the clock from its deadline, progress inside a lapsed hold, zero/negative allowances, concurrent holds released out of order, closed-hold observations for all three shapes, unknown/double token release, a failing observer, and token uniqueness under threads.

- `uv run pytest tests/unit/execution` — 500 passed
- `uv run pre-commit run --files ...` — ruff, ruff-format, isort, pyright clean
- Full conformance suite — zero findings in the new files
