### PR TITLE
fix(sdk): route the remaining event-loop starvation sites through run_in_thread (FND-282)

### DIFF
--- a/application_sdk/common/incremental/state/state_writer.py
+++ b/application_sdk/common/incremental/state/state_writer.py
@@ -408,7 +408,19 @@ async def create_current_state_snapshot(
 
         try:
             # Step 1: Get table scope (qualified names and incremental states)
-            table_scope = get_current_table_scope(transformed_dir, conn=conn)
+            #
+            # Every sync step in this block is offloaded for the same reason:
+            # each one is a DuckDB scan over the run's transformed output or a
+            # blocking parallel directory copy, none of them yield, and their
+            # cost scales with the source. Inline they hold the event loop —
+            # and this activity's auto-heartbeat — for the whole snapshot, so a
+            # healthy large-connection run gets killed on heartbeat_timeout
+            # (ADR-0010). The DuckDB connection is `threads=1` and file-backed
+            # and each hop is awaited before the next starts, so it is only
+            # ever touched by one thread at a time.
+            table_scope = await run_in_thread(
+                get_current_table_scope, transformed_dir, conn=conn
+            )
             if not table_scope or get_scope_length(table_scope) == 0:
                 raise FileNotFoundError(
                     f"No tables found in transformed output: {transformed_dir}. "
@@ -426,14 +438,16 @@ async def create_current_state_snapshot(
             await run_in_thread(prepare_current_state_directory, current_state_dir)
 
             # Step 3: Copy non-column entities (tables, schemas, databases)
-            copy_non_column_entities(
+            await run_in_thread(
+                copy_non_column_entities,
                 transformed_dir=transformed_dir,
                 current_state_dir=current_state_dir,
                 copy_workers=copy_workers,
             )
 
             # Step 4: Copy columns from transformed (lightweight — no ancestral merge)
-            column_count = _copy_columns_from_transformed(
+            column_count = await run_in_thread(
+                _copy_columns_from_transformed,
                 transformed_dir=transformed_dir,
                 current_state_dir=current_state_dir,
                 copy_workers=copy_workers,
@@ -441,14 +455,18 @@ async def create_current_state_snapshot(
 
             # Track which tables have extracted columns
             tables_with_columns = (
-                get_table_qns_from_columns(
-                    current_state_dir.joinpath(EntityType.COLUMN.value), conn=conn
+                await run_in_thread(
+                    get_table_qns_from_columns,
+                    current_state_dir.joinpath(EntityType.COLUMN.value),
+                    conn=conn,
                 )
                 or set()
             )
             table_scope.tables_with_extracted_columns = tables_with_columns
 
-            total_files = count_json_files_recursive(current_state_dir)
+            total_files = await run_in_thread(
+                count_json_files_recursive, current_state_dir
+            )
 
             logger.info(
                 "Current-state snapshot complete (lightweight): tables=%d columns_copied=%d "
@@ -475,7 +493,8 @@ async def create_current_state_snapshot(
                 if incremental_diff_dir.exists():
                     await run_in_thread(shutil.rmtree, incremental_diff_dir)
 
-                diff_result = create_incremental_diff(
+                diff_result = await run_in_thread(
+                    create_incremental_diff,
                     transformed_dir=transformed_dir,
                     incremental_diff_dir=incremental_diff_dir,
                     table_scope=table_scope,

--- a/application_sdk/storage/batch.py
+++ b/application_sdk/storage/batch.py
@@ -418,17 +418,30 @@ async def upload_prefix(
     if normalize and prefix:
         prefix = normalize_key(prefix)
 
-    files: list[tuple[str, Path]] = []
-    for root, _dirs, filenames in os.walk(local, followlinks=False):
-        for fname in filenames:
-            file_path = Path(root) / fname
-            if file_path.is_symlink():
-                continue
-            rel = file_path.relative_to(local)
-            # Use PurePosixPath to ensure forward slashes in S3 keys (Windows uses backslash)
-            rel_posix = PurePosixPath(*rel.parts)
-            key = f"{prefix}/{rel_posix}" if prefix else str(rel_posix)
-            files.append((key, file_path))
+    def _collect_files() -> list[tuple[str, Path]]:
+        collected: list[tuple[str, Path]] = []
+        for root, _dirs, filenames in os.walk(local, followlinks=False):
+            for fname in filenames:
+                file_path = Path(root) / fname
+                if file_path.is_symlink():
+                    continue
+                rel = file_path.relative_to(local)
+                # Use PurePosixPath to ensure forward slashes in S3 keys (Windows uses backslash)
+                rel_posix = PurePosixPath(*rel.parts)
+                key = f"{prefix}/{rel_posix}" if prefix else str(rel_posix)
+                collected.append((key, file_path))
+        return collected
+
+    # Offloaded: the walk is one stat per entry over a whole run's output
+    # directory, which on a large extraction is thousands of syscalls with no
+    # await between them. Inline it holds the event loop — and the enclosing
+    # activity's auto-heartbeat — for the entire traversal (ADR-0010).
+    # Imported lazily: `application_sdk.execution` pulls in the Temporal
+    # activity utils, which import back into `contracts`/`storage`; at module
+    # scope here that closes a circular import.
+    from application_sdk.execution.heartbeat import run_in_thread  # noqa: PLC0415
+
+    files: list[tuple[str, Path]] = await run_in_thread(_collect_files)
 
     sem = asyncio.Semaphore(max_concurrency)
     uploaded: list[str] = []

--- a/application_sdk/storage/batch.py
+++ b/application_sdk/storage/batch.py
@@ -436,9 +436,18 @@ async def upload_prefix(
     # directory, which on a large extraction is thousands of syscalls with no
     # await between them. Inline it holds the event loop — and the enclosing
     # activity's auto-heartbeat — for the entire traversal (ADR-0010).
-    # Imported lazily: `application_sdk.execution` pulls in the Temporal
-    # activity utils, which import back into `contracts`/`storage`; at module
-    # scope here that closes a circular import.
+    # Imported lazily, and it has to be. This module is in the chain
+    # `storage/__init__` loads eagerly, and that chain is itself entered from
+    # `contracts.base` (contracts.types -> credentials -> common.utils ->
+    # storage). At module scope, importing `application_sdk.execution.heartbeat`
+    # runs `execution/__init__`, which pulls in the Temporal activity utils ->
+    # `application_sdk.app` -> back to `contracts.base` while it is still
+    # initialising, and that raises ImportError. The cycle runs through
+    # `execution/__init__`; there is no direct storage -> execution edge.
+    #
+    # This is also why `transfer.py`, `reference.py` and `formats/*` import
+    # `run_in_thread` at module scope without trouble — they are not in
+    # `storage/__init__`'s eager chain. Only batch/chunked/cloud/rolling are.
     from application_sdk.execution.heartbeat import run_in_thread  # noqa: PLC0415
 
     files: list[tuple[str, Path]] = await run_in_thread(_collect_files)

--- a/application_sdk/storage/chunked.py
+++ b/application_sdk/storage/chunked.py
@@ -597,8 +597,14 @@ async def download_file_chunked(
             # event loop — and the enclosing activity's auto-heartbeat — for
             # the full read+hash. Same treatment as
             # ``storage.reference._sha256_hex_file_async`` (ADR-0010, P031).
-            # Imported lazily: `application_sdk.execution` imports back into
-            # `storage`, so a module-scope import closes a circular import.
+            # Imported lazily, and it has to be: this module is in
+            # `storage/__init__`'s eager chain, so importing
+            # `application_sdk.execution.heartbeat` at module scope runs
+            # `execution/__init__` -> Temporal activity utils ->
+            # `application_sdk.app` -> back to a still-initialising
+            # `contracts.base`, raising ImportError. The cycle is via
+            # `execution/__init__`, not a direct storage -> execution edge.
+            # See `storage/batch.py` for the full chain.
             from application_sdk.execution.heartbeat import (  # noqa: PLC0415
                 run_in_thread,
             )

--- a/application_sdk/storage/chunked.py
+++ b/application_sdk/storage/chunked.py
@@ -585,8 +585,22 @@ async def download_file_chunked(
             if not compute_hash:
                 return None
 
-            h = hashlib.sha256()
-            with path.open("rb") as fh:
-                for chunk in iter(lambda: fh.read(1 << 20), b""):
-                    h.update(chunk)
-            return h.hexdigest()
+            def _digest() -> str:
+                h = hashlib.sha256()
+                with path.open("rb") as fh:
+                    for chunk in iter(lambda: fh.read(1 << 20), b""):
+                        h.update(chunk)
+                return h.hexdigest()
+
+            # Offloaded: this re-reads and digests the whole downloaded file
+            # with no await in between, so on a multi-GB download it holds the
+            # event loop — and the enclosing activity's auto-heartbeat — for
+            # the full read+hash. Same treatment as
+            # ``storage.reference._sha256_hex_file_async`` (ADR-0010, P031).
+            # Imported lazily: `application_sdk.execution` imports back into
+            # `storage`, so a module-scope import closes a circular import.
+            from application_sdk.execution.heartbeat import (  # noqa: PLC0415
+                run_in_thread,
+            )
+
+            return await run_in_thread(_digest)

--- a/application_sdk/storage/cloud.py
+++ b/application_sdk/storage/cloud.py
@@ -444,15 +444,28 @@ class CloudStore:
             List of uploaded object keys.
         """
         local = Path(local_dir)
-        files: list[tuple[str, Path]] = []
-        for root, _dirs, filenames in os.walk(local, followlinks=False):
-            for fname in filenames:
-                file_path = Path(root) / fname
-                if file_path.is_symlink():
-                    continue
-                rel = file_path.relative_to(local)
-                key = f"{prefix}/{rel}" if prefix else str(rel)
-                files.append((key, file_path))
+
+        def _collect_files() -> list[tuple[str, Path]]:
+            collected: list[tuple[str, Path]] = []
+            for root, _dirs, filenames in os.walk(local, followlinks=False):
+                for fname in filenames:
+                    file_path = Path(root) / fname
+                    if file_path.is_symlink():
+                        continue
+                    rel = file_path.relative_to(local)
+                    key = f"{prefix}/{rel}" if prefix else str(rel)
+                    collected.append((key, file_path))
+            return collected
+
+        # Offloaded: the walk is one stat per entry over the whole directory,
+        # thousands of syscalls with no await between them on a large upload.
+        # Inline it holds the event loop — and the enclosing activity's
+        # auto-heartbeat — for the entire traversal (ADR-0010).
+        # Imported lazily: `application_sdk.execution` imports back into
+        # `storage`, so a module-scope import closes a circular import.
+        from application_sdk.execution.heartbeat import run_in_thread  # noqa: PLC0415
+
+        files: list[tuple[str, Path]] = await run_in_thread(_collect_files)
 
         sem = asyncio.Semaphore(max_concurrency)
 

--- a/application_sdk/storage/cloud.py
+++ b/application_sdk/storage/cloud.py
@@ -461,8 +461,14 @@ class CloudStore:
         # thousands of syscalls with no await between them on a large upload.
         # Inline it holds the event loop — and the enclosing activity's
         # auto-heartbeat — for the entire traversal (ADR-0010).
-        # Imported lazily: `application_sdk.execution` imports back into
-        # `storage`, so a module-scope import closes a circular import.
+        # Imported lazily, and it has to be: this module is in
+        # `storage/__init__`'s eager chain, so importing
+        # `application_sdk.execution.heartbeat` at module scope runs
+        # `execution/__init__` -> Temporal activity utils ->
+        # `application_sdk.app` -> back to a still-initialising
+        # `contracts.base`, raising ImportError. The cycle is via
+        # `execution/__init__`, not a direct storage -> execution edge.
+        # See `storage/batch.py` for the full chain.
         from application_sdk.execution.heartbeat import run_in_thread  # noqa: PLC0415
 
         files: list[tuple[str, Path]] = await run_in_thread(_collect_files)

--- a/application_sdk/storage/formats/json.py
+++ b/application_sdk/storage/formats/json.py
@@ -1,6 +1,6 @@
 import os
 import warnings
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Generator
 from typing import TYPE_CHECKING, Any
 
 import orjson
@@ -9,6 +9,7 @@ from application_sdk.common.file_ops import SafeFileOps
 from application_sdk.common.types import DataframeType
 from application_sdk.constants import DAPR_MAX_GRPC_MESSAGE_LENGTH
 from application_sdk.errors import AppError
+from application_sdk.execution.heartbeat import run_in_thread
 from application_sdk.observability.logger_adaptor import get_logger
 from application_sdk.observability.metrics_adaptor import get_metrics
 from application_sdk.storage.formats.utils import (
@@ -200,21 +201,40 @@ class JsonFileReader(Reader):
             logger.info("Reading %d JSON files in batches", len(json_files))
 
             chunk_size = self.chunk_size or 100000
-            batch: list[dict] = []
+
             # Files must be JSONL (one JSON object per line). Multi-line JSON
             # arrays are not supported and will raise orjson.JSONDecodeError.
-            for json_file in json_files:
-                with open(json_file, "rb") as f:
-                    for line in f:
-                        line = line.strip()
-                        if not line:
-                            continue
-                        batch.append(orjson.loads(line))
-                        if len(batch) >= chunk_size:
-                            yield pd.DataFrame(batch)
-                            batch = []
-            if batch:
-                yield pd.DataFrame(batch)
+            def _iter_batches() -> Generator[list[dict], None, None]:
+                batch: list[dict] = []
+                for json_file in json_files:
+                    with open(json_file, "rb") as f:
+                        for line in f:
+                            line = line.strip()
+                            if not line:
+                                continue
+                            batch.append(orjson.loads(line))
+                            if len(batch) >= chunk_size:
+                                yield batch
+                                batch = []
+                if batch:
+                    yield batch
+
+            batches = _iter_batches()
+
+            def _next_frame() -> "pd.DataFrame | None":
+                records = next(batches, None)
+                return None if records is None else pd.DataFrame(records)
+
+            # Offloaded per batch: filling one batch is a tight loop of blocking
+            # reads and orjson parses that does not yield until chunk_size
+            # records are in hand — at the 100k default that is well past the
+            # heartbeat interval, so inline it starves the auto-heartbeat and
+            # gets a healthy activity killed (ADR-0010).
+            while True:
+                frame = await run_in_thread(_next_frame)
+                if frame is None:
+                    break
+                yield frame
         # An already-typed AppError carries its own category/audience/evidence
         # (e.g. ObjectStoreReadError -> DEPENDENCY_UNAVAILABLE + the searched
         # prefix). Re-wrapping it as FormatReadError would downgrade that to
@@ -247,14 +267,21 @@ class JsonFileReader(Reader):
             # All records are accumulated in memory before building the
             # DataFrame. Suitable only for small datasets (≲ a few hundred MB).
             # For large inputs, use read_batches() to stay bounded.
-            all_records: list[dict] = []
-            for json_file in json_files:
-                with open(json_file, "rb") as f:
-                    for line in f:
-                        line = line.strip()
-                        if line:
-                            all_records.append(orjson.loads(line))
-            return pd.DataFrame(all_records)
+            def _read_all() -> "pd.DataFrame":
+                all_records: list[dict] = []
+                for json_file in json_files:
+                    with open(json_file, "rb") as f:
+                        for line in f:
+                            line = line.strip()
+                            if line:
+                                all_records.append(orjson.loads(line))
+                return pd.DataFrame(all_records)
+
+            # Offloaded as one hop: this reads and parses every record in the
+            # prefix before it returns, with no await in between. Inline it
+            # holds the event loop — and the auto-heartbeat — for that whole
+            # span (ADR-0010).
+            return await run_in_thread(_read_all)
         # See _get_batched_dataframe: preserve an already-typed AppError.
         except AppError:
             raise
@@ -402,15 +429,23 @@ class JsonFileWriter(Writer):
             return str(obj)
 
         mode = "ab+" if SafeFileOps.exists(file_name) else "wb"
-        with SafeFileOps.open(file_name, mode=mode) as f:
-            for record in chunk.to_dict(orient="records"):
-                f.write(
-                    orjson.dumps(
-                        record,
-                        default=_default_serializer,
-                        option=orjson.OPT_APPEND_NEWLINE,
+
+        def _serialize_and_write() -> None:
+            with SafeFileOps.open(file_name, mode=mode) as f:
+                for record in chunk.to_dict(orient="records"):
+                    f.write(
+                        orjson.dumps(
+                            record,
+                            default=_default_serializer,
+                            option=orjson.OPT_APPEND_NEWLINE,
+                        )
                     )
-                )
+
+        # Offloaded as one hop: `to_dict` materialises the whole chunk and the
+        # write loop is one blocking syscall per record. Neither yields, so
+        # inline this stalls the event loop — including the auto-heartbeat —
+        # for the chunk's full write duration (ADR-0010).
+        await run_in_thread(_serialize_and_write)
 
     async def _finalize(self) -> None:
         """Finalize the JSON writer before closing.

--- a/application_sdk/storage/formats/parquet.py
+++ b/application_sdk/storage/formats/parquet.py
@@ -384,7 +384,12 @@ class ParquetFileReader(Reader):
                             break
                         yield frame
                 finally:
-                    await run_in_thread(pf.close)
+                    # Closed inline, not via run_in_thread: an ``await`` in a
+                    # finally can itself be cancelled, which would leak the
+                    # handle on activity cancellation or generator close.
+                    # Closing a parquet reader is one cheap syscall, so there
+                    # is nothing here worth offloading.
+                    pf.close()
         # See _get_dataframe: preserve an already-typed AppError.
         except AppError:
             raise

--- a/application_sdk/storage/formats/parquet.py
+++ b/application_sdk/storage/formats/parquet.py
@@ -274,17 +274,25 @@ class ParquetFileReader(Reader):
             self._downloaded_files.extend(parquet_files)
             logger.info("Reading %d parquet files", len(parquet_files))
 
-            tables = [pq.read_table(f) for f in parquet_files]
-            if not tables:
+            def _read_and_combine() -> "pd.DataFrame":
                 import pandas as pd  # noqa: PLC0415 — optional dep: pandas
 
-                return pd.DataFrame()
-            # Normalize legacy all-null large_string shards (pre-CNCT-80
-            # writes) so permissive promotion can merge them against a
-            # sibling shard's concrete numeric type.
-            tables = [_normalize_all_null_string_columns(t) for t in tables]
-            combined = pa.concat_tables(tables, promote_options="permissive")
-            return combined.to_pandas()
+                tables = [pq.read_table(f) for f in parquet_files]
+                if not tables:
+                    return pd.DataFrame()
+                # Normalize legacy all-null large_string shards (pre-CNCT-80
+                # writes) so permissive promotion can merge them against a
+                # sibling shard's concrete numeric type.
+                tables = [_normalize_all_null_string_columns(t) for t in tables]
+                combined = pa.concat_tables(tables, promote_options="permissive")
+                return combined.to_pandas()
+
+            # Offloaded as one hop: reading every shard, promoting schemas and
+            # materialising a single pandas frame is blocking disk I/O plus
+            # CPU-bound Arrow work whose cost scales with the prefix. Inline it
+            # holds the event loop for that whole span, which starves the
+            # auto-heartbeat and gets a healthy activity killed (ADR-0010).
+            return await run_in_thread(_read_and_combine)
         # An already-typed AppError carries its own category/audience/evidence
         # (e.g. ObjectStoreReadError -> DEPENDENCY_UNAVAILABLE + the searched
         # prefix). Re-wrapping it as FormatReadError would downgrade that to
@@ -357,12 +365,26 @@ class ParquetFileReader(Reader):
             chunk_size = self.chunk_size or 100000
 
             for parquet_file in parquet_files:
-                pf = pq.ParquetFile(parquet_file)
+                # Opening reads the file footer; advancing the iterator reads
+                # and decodes a whole row group and converts it to pandas.
+                # Both are blocking, and at batch_size=100k the per-batch cost
+                # is far past the heartbeat interval — offload each step so the
+                # loop stays free to beat between batches (ADR-0010).
+                pf = await run_in_thread(pq.ParquetFile, parquet_file)
                 try:
-                    for batch in pf.iter_batches(batch_size=chunk_size):
-                        yield batch.to_pandas()
+                    batches = pf.iter_batches(batch_size=chunk_size)
+
+                    def _next_frame() -> "pd.DataFrame | None":
+                        batch = next(batches, None)  # noqa: B023 — consumed within this iteration
+                        return None if batch is None else batch.to_pandas()
+
+                    while True:
+                        frame = await run_in_thread(_next_frame)
+                        if frame is None:
+                            break
+                        yield frame
                 finally:
-                    pf.close()
+                    await run_in_thread(pf.close)
         # See _get_dataframe: preserve an already-typed AppError.
         except AppError:
             raise
@@ -722,9 +744,16 @@ class ParquetFileWriter(Writer):
             if not temp_files:
                 return
 
-            combined_df = pd.concat(
-                [pd.read_parquet(f) for f in temp_files], ignore_index=True
-            )
+            # Offloaded: a consolidation folder holds a full buffer's worth of
+            # chunks, so reading them all back and concatenating is seconds of
+            # blocking disk I/O plus CPU. Inline it starves the auto-heartbeat
+            # for that span (ADR-0010).
+            def _read_and_concat() -> "pd.DataFrame":
+                return pd.concat(
+                    [pd.read_parquet(f) for f in temp_files], ignore_index=True
+                )
+
+            combined_df = await run_in_thread(_read_and_concat)
 
             # Write consolidated chunks respecting max_file_size_bytes
             partitions = 0
@@ -886,17 +915,23 @@ class ParquetFileWriter(Writer):
         import pyarrow as pa  # noqa: PLC0415 — optional dep: pyarrow
         import pyarrow.parquet as pq  # noqa: PLC0415 — optional dep: pyarrow.parquet
 
-        table = pa.Table.from_pandas(chunk, preserve_index=False)
-        row_group_size = max(
-            1, min(len(table), 16_000_000 // max(1, table.nbytes // max(1, len(table))))
-        )
-        # Offloaded: pq.write_table() is blocking disk I/O; running it
-        # inline stalls the event loop — including the auto-heartbeat —
-        # for the write's full duration on large chunks.
-        await run_in_thread(
-            pq.write_table,
-            table,
-            file_name,
-            compression="snappy",
-            row_group_size=row_group_size,
-        )
+        # Offloaded as one hop: `Table.from_pandas` is CPU-bound conversion over
+        # the whole chunk and `pq.write_table` is blocking disk I/O. Either one
+        # inline stalls the event loop — including the auto-heartbeat — for its
+        # full duration on large chunks (ADR-0010).
+        def _convert_and_write() -> None:
+            table = pa.Table.from_pandas(chunk, preserve_index=False)
+            row_group_size = max(
+                1,
+                min(
+                    len(table), 16_000_000 // max(1, table.nbytes // max(1, len(table)))
+                ),
+            )
+            pq.write_table(
+                table,
+                file_name,
+                compression="snappy",
+                row_group_size=row_group_size,
+            )
+
+        await run_in_thread(_convert_and_write)

--- a/application_sdk/storage/rolling.py
+++ b/application_sdk/storage/rolling.py
@@ -128,8 +128,13 @@ async def _call_maybe_blocking(fn: Callable[..., Any], *args: Any) -> Any:
     """
     if inspect.iscoroutinefunction(fn):
         return await fn(*args)
-    # Imported lazily: `application_sdk.execution` imports back into
-    # `storage`, so a module-scope import closes a circular import.
+    # Imported lazily, and it has to be: this module is in
+    # `storage/__init__`'s eager chain, so importing
+    # `application_sdk.execution.heartbeat` at module scope runs
+    # `execution/__init__` -> Temporal activity utils -> `application_sdk.app`
+    # -> back to a still-initialising `contracts.base`, raising ImportError.
+    # The cycle is via `execution/__init__`, not a direct storage -> execution
+    # edge. See `storage/batch.py` for the full chain.
     from application_sdk.execution.heartbeat import run_in_thread  # noqa: PLC0415
 
     return await run_in_thread(fn, *args)

--- a/application_sdk/storage/rolling.py
+++ b/application_sdk/storage/rolling.py
@@ -106,6 +106,35 @@ def _monotonic() -> float:
     return time.monotonic()
 
 
+async def _call_maybe_blocking(fn: Callable[..., Any], *args: Any) -> Any:
+    """Invoke a caller-supplied callback without risking the event loop.
+
+    ``flush_fn`` and ``on_chunk_complete`` may be either async or plain
+    functions. An ``async def`` yields at its own await points, so it is called
+    directly. A plain function does not yield at all — and the documented
+    parquet example (``pd.concat(...).to_parquet(path)``) is seconds of
+    CPU-bound conversion and blocking disk I/O per chunk. Calling that inline
+    holds the event loop for the whole flush, which stops the enclosing
+    activity's auto-heartbeat and gets a healthy activity killed. So a plain
+    function is dispatched to the SDK's blocking pool instead (ADR-0010).
+
+    ``run_in_thread`` copies the current ``contextvars`` context into the
+    worker thread, so a synchronous ``on_chunk_complete`` that calls
+    ``activity.heartbeat()`` still finds its activity context.
+
+    A plain function that *returns* an awaitable keeps working: the awaitable
+    is produced in the thread and returned unawaited for the caller to await
+    back on the loop.
+    """
+    if inspect.iscoroutinefunction(fn):
+        return await fn(*args)
+    # Imported lazily: `application_sdk.execution` imports back into
+    # `storage`, so a module-scope import closes a circular import.
+    from application_sdk.execution.heartbeat import run_in_thread  # noqa: PLC0415
+
+    return await run_in_thread(fn, *args)
+
+
 FlushFn = Callable[[list[T], str], Awaitable[None] | None]
 ChunkCompleteFn = Callable[[int, str], Awaitable[None] | None]
 SizeEstimatorFn = Callable[[Any], int]
@@ -483,7 +512,7 @@ class RollingFileWriter(Generic[T]):
             self.output_dir, f"chunk-{self._chunk_index}{self.extension}"
         )
         try:
-            result = self.flush_fn(self._buffer, chunk_path)
+            result = await _call_maybe_blocking(self.flush_fn, self._buffer, chunk_path)
             if inspect.isawaitable(result):
                 await result
         except Exception:
@@ -509,7 +538,9 @@ class RollingFileWriter(Generic[T]):
 
         if self.on_chunk_complete is not None:
             try:
-                cb_result = self.on_chunk_complete(completed_index, chunk_path)
+                cb_result = await _call_maybe_blocking(
+                    self.on_chunk_complete, completed_index, chunk_path
+                )
                 if inspect.isawaitable(cb_result):
                     await cb_result
             except Exception:

--- a/application_sdk/templates/incremental_sql_metadata_extractor.py
+++ b/application_sdk/templates/incremental_sql_metadata_extractor.py
@@ -524,14 +524,28 @@ class IncrementalSqlMetadataExtractor(SqlMetadataExtractor):
                 )
 
         # Step 3: Find backfill tables using DuckDB
+        #
+        # Offloaded: both DuckDB steps scan every transformed table JSON for
+        # the connection and run SQL over it — seconds to minutes on a large
+        # source, with no await inside. Inline they hold the event loop for
+        # that whole span, which stops this activity's auto-heartbeat and gets
+        # it killed on heartbeat_timeout while it is making progress
+        # (ADR-0010).
         logger.info("Analyzing table state to identify backfill candidates...")
-        backfill_qns = get_backfill_tables(transformed_dir, previous_current_state_dir)
+        backfill_qns = await run_in_thread(
+            get_backfill_tables, transformed_dir, previous_current_state_dir
+        )
         backfill_count_for_log = len(backfill_qns) if backfill_qns else 0
         logger.info("Found %d tables needing backfill", backfill_count_for_log)
 
         # Step 4: Get tables needing column extraction using DuckDB
-        filtered_rows, changed_count, backfill_count, _no_change_count = (
-            get_tables_needing_column_extraction(transformed_dir, backfill_qns)
+        (
+            filtered_rows,
+            changed_count,
+            backfill_count,
+            _no_change_count,
+        ) = await run_in_thread(
+            get_tables_needing_column_extraction, transformed_dir, backfill_qns
         )
 
         total_tables = changed_count + backfill_count
@@ -552,25 +566,31 @@ class IncrementalSqlMetadataExtractor(SqlMetadataExtractor):
         )
         batches_dir.mkdir(parents=True, exist_ok=True)
 
-        batch_idx = 0
-        total_tables_batched = 0
-        current_batch: list[str] = []
+        def _write_batches() -> tuple[int, int]:
+            written_batches = 0
+            batched = 0
+            current_batch: list[str] = []
 
-        for row in filtered_rows:
-            current_batch.append(row["table_id"])
+            for row in filtered_rows:
+                current_batch.append(row["table_id"])
 
-            if len(current_batch) >= batch_size:
-                batch_file = batches_dir / f"batch-{batch_idx}.json"
+                if len(current_batch) >= batch_size:
+                    batch_file = batches_dir / f"batch-{written_batches}.json"
+                    batch_file.write_bytes(orjson.dumps(current_batch))
+                    written_batches += 1
+                    batched += len(current_batch)
+                    current_batch = []
+
+            if current_batch:
+                batch_file = batches_dir / f"batch-{written_batches}.json"
                 batch_file.write_bytes(orjson.dumps(current_batch))
-                batch_idx += 1
-                total_tables_batched += len(current_batch)
-                current_batch = []
+                written_batches += 1
+                batched += len(current_batch)
+            return written_batches, batched
 
-        if current_batch:
-            batch_file = batches_dir / f"batch-{batch_idx}.json"
-            batch_file.write_bytes(orjson.dumps(current_batch))
-            batch_idx += 1
-            total_tables_batched += len(current_batch)
+        # Offloaded: one pass over every table needing extraction, writing a
+        # file per batch, with no await in the loop (ADR-0010).
+        batch_idx, total_tables_batched = await run_in_thread(_write_batches)
 
         logger.info(
             "Created %d batch files for %d tables at %s",

--- a/application_sdk/templates/sql_app.py
+++ b/application_sdk/templates/sql_app.py
@@ -113,6 +113,7 @@ from application_sdk.errors.leaves import (
 )
 from application_sdk.errors.wire import secret_named_evidence_keys
 from application_sdk.execution import build_output_path, get_object_store_prefix
+from application_sdk.execution.heartbeat import run_in_thread
 from application_sdk.infrastructure.context import get_infrastructure
 from application_sdk.observability.logger_adaptor import get_logger
 from application_sdk.templates.contracts.sql_metadata import (
@@ -1528,14 +1529,22 @@ class SqlApp(App):
         count = 0
         try:
             sql = self._prepare_sql(sql_template.strip(), input)
+
+            def _write_batch(f: Any, batch: list[dict[str, Any]]) -> int:
+                for record in batch:
+                    f.write(orjson.dumps(record, default=_orjson_default))
+                    f.write(b"\n")
+                return len(batch)
+
             with open(output_file, "wb") as f:
                 async for batch in client.run_query(
                     sql, batch_size=_EXTRACT_BATCH_SIZE
                 ):
-                    for record in batch:
-                        f.write(orjson.dumps(record, default=_orjson_default))
-                        f.write(b"\n")
-                        count += 1
+                    # Offloaded: serialising and writing a batch is 10k
+                    # orjson.dumps calls plus 20k blocking writes with no
+                    # await between them, so on wide rows a single batch can
+                    # outlast the heartbeat interval (ADR-0010).
+                    count += await run_in_thread(_write_batch, f, batch)
         finally:
             await client.close()
 
@@ -1640,30 +1649,41 @@ class SqlApp(App):
         output_dir.mkdir(parents=True, exist_ok=True)
         output_file = output_dir / "entities.json"
 
-        count = 0
-        with open(raw_file, "rb") as r, open(output_file, "wb") as w:
-            for line in r:
-                line = line.strip()
-                if not line:
-                    continue
-                record = orjson.loads(line)
-                asset = mapper_fn(record, connection_qn)
-                # Inject connectionName if the mapper returned a dict
-                if isinstance(asset, dict) and connection_name:
-                    asset.setdefault("attributes", {}).setdefault(
-                        "connectionName", connection_name
-                    )
-                if hasattr(asset, "to_nested_dict"):
-                    payload = asset.to_nested_dict()
-                elif hasattr(asset, "model_dump"):
-                    payload = asset.model_dump()
-                elif isinstance(asset, dict):
-                    payload = asset
-                else:
-                    payload = record
-                w.write(orjson.dumps(payload, default=_orjson_default))
-                w.write(b"\n")
-                count += 1
+        def _map_records() -> int:
+            written = 0
+            with open(raw_file, "rb") as r, open(output_file, "wb") as w:
+                for line in r:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    record = orjson.loads(line)
+                    asset = mapper_fn(record, connection_qn)
+                    # Inject connectionName if the mapper returned a dict
+                    if isinstance(asset, dict) and connection_name:
+                        asset.setdefault("attributes", {}).setdefault(
+                            "connectionName", connection_name
+                        )
+                    if hasattr(asset, "to_nested_dict"):
+                        payload = asset.to_nested_dict()
+                    elif hasattr(asset, "model_dump"):
+                        payload = asset.model_dump()
+                    elif isinstance(asset, dict):
+                        payload = asset
+                    else:
+                        payload = record
+                    w.write(orjson.dumps(payload, default=_orjson_default))
+                    w.write(b"\n")
+                    written += 1
+            return written
+
+        # Offloaded as one hop: this maps every raw record for the entity —
+        # JSON parse, the connector's mapper_fn (which builds pyatlan asset
+        # objects), serialise, write — with no await anywhere in the loop.
+        # A large table's records.json therefore holds the event loop for the
+        # whole transform, which stops the auto-heartbeat and gets a healthy
+        # activity killed on heartbeat_timeout. Every SQL connector inherits
+        # this method, so the fix applies fleet-wide (ADR-0010).
+        count = await run_in_thread(_map_records)
 
         logger.info("Transformed %s: %d records", entity_type, count)
         # Emit a FileReference to entities.json so the activity

--- a/application_sdk/templates/sql_app.py
+++ b/application_sdk/templates/sql_app.py
@@ -1530,21 +1530,36 @@ class SqlApp(App):
         try:
             sql = self._prepare_sql(sql_template.strip(), input)
 
-            def _write_batch(f: Any, batch: list[dict[str, Any]]) -> int:
-                for record in batch:
-                    f.write(orjson.dumps(record, default=_orjson_default))
-                    f.write(b"\n")
-                return len(batch)
+            def _serialize_batch(batch: list[dict[str, Any]]) -> bytes:
+                return b"".join(
+                    orjson.dumps(
+                        record,
+                        default=_orjson_default,
+                        option=orjson.OPT_APPEND_NEWLINE,
+                    )
+                    for record in batch
+                )
 
             with open(output_file, "wb") as f:
                 async for batch in client.run_query(
                     sql, batch_size=_EXTRACT_BATCH_SIZE
                 ):
-                    # Offloaded: serialising and writing a batch is 10k
-                    # orjson.dumps calls plus 20k blocking writes with no
-                    # await between them, so on wide rows a single batch can
-                    # outlast the heartbeat interval (ADR-0010).
-                    count += await run_in_thread(_write_batch, f, batch)
+                    # Only the serialisation is offloaded — 10k orjson.dumps
+                    # calls per batch is the part that outlasts the heartbeat
+                    # interval on wide rows (ADR-0010). The write stays on the
+                    # loop as one buffered call, which costs microseconds.
+                    #
+                    # Deliberately NOT passing `f` into the thread: if the
+                    # activity is cancelled at this await, the `with` block
+                    # unwinds and closes the handle while a worker thread is
+                    # still writing to it — and per ADR-0010 that thread cannot
+                    # be killed, so it would write on into a closed (or
+                    # retry-reopened) file. Serialise off-loop, write on-loop:
+                    # the handle never crosses the thread boundary, so the
+                    # single-handle streaming loop stays cancellation-safe.
+                    payload = await run_in_thread(_serialize_batch, batch)
+                    f.write(payload)
+                    count += len(batch)
         finally:
             await client.close()
 

--- a/tests/unit/storage/formats/writers/test_parquet_writer.py
+++ b/tests/unit/storage/formats/writers/test_parquet_writer.py
@@ -1,6 +1,9 @@
+import asyncio
 import contextlib
 import os
 import shutil
+import threading
+import time
 from collections.abc import Generator
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -1211,24 +1214,55 @@ class TestWriteChunkNullColumns:
         assert combined.column("extra").to_pylist() == [None, None, 10, 18]
 
     async def test_write_chunk_offloaded_to_thread(self, tmp_path) -> None:
-        """pq.write_table() must not run inline on the event loop.
+        """Chunk conversion and the disk write must not run on the event loop.
 
-        A large chunk's disk write can take long enough to stall every other
-        coroutine — including the enclosing @task's auto-heartbeat — for the
-        write's full duration.
+        A large chunk's Arrow conversion plus disk write can take long enough
+        to stall every other coroutine — including the enclosing @task's
+        auto-heartbeat — for the operation's full duration (ADR-0010).
+
+        Asserts the thread the work actually lands on rather than which
+        callable was handed to run_in_thread, so the guarantee survives the
+        blocking section being regrouped.
         """
         df = pd.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
         file_name = str(tmp_path / "offloaded.parquet")
         writer = ParquetFileWriter(str(tmp_path / "output"))
 
-        with patch(
-            "application_sdk.storage.formats.parquet.run_in_thread",
-            new_callable=AsyncMock,
-            side_effect=lambda func, *a, **kw: func(*a, **kw),
-        ) as mock_offload:
-            await writer._write_chunk(df, file_name)
+        loop_thread = threading.current_thread().name
+        write_thread: list[str] = []
+        real_write_table = pq.write_table
 
-        assert mock_offload.await_args_list, "pq.write_table was not offloaded"
-        assert mock_offload.await_args_list[0].args[0] is pq.write_table
+        def _slow_write_table(*args, **kwargs):
+            write_thread.append(threading.current_thread().name)
+            # Stand in for a large chunk's write cost, so a regression that
+            # puts this back on the loop actually stalls the ticker below.
+            time.sleep(0.3)
+            return real_write_table(*args, **kwargs)
+
+        ticks = 0
+
+        async def _ticker() -> None:
+            nonlocal ticks
+            while True:
+                await asyncio.sleep(0.01)
+                ticks += 1
+
+        with patch("pyarrow.parquet.write_table", side_effect=_slow_write_table):
+            ticker = asyncio.create_task(_ticker())
+            try:
+                await writer._write_chunk(df, file_name)
+            finally:
+                ticker.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await ticker
+
+        assert write_thread, "pq.write_table was never called"
+        assert write_thread[0] != loop_thread, "the write ran on the event loop"
+        assert write_thread[0].startswith(
+            "sdk-blocking-"
+        ), f"the write ran on {write_thread[0]}, not the SDK blocking pool"
+        # The loop kept running coroutines for the whole write — which is what
+        # lets the enclosing @task's auto-heartbeat keep beating.
+        assert ticks >= 5, f"event loop stalled during the write ({ticks} ticks)"
         table = pq.read_table(file_name)
         assert table.num_rows == 3

--- a/tests/unit/storage/test_event_loop_responsiveness.py
+++ b/tests/unit/storage/test_event_loop_responsiveness.py
@@ -138,6 +138,7 @@ class TestJsonReaderResponsiveness:
         frames, ticks = await count_ticks_during(_drain)
 
         assert [len(f) for f in frames] == [10, 10]
+        assert calls["n"] == 20, "the patched orjson.loads path never ran"
         assert_stayed_responsive(ticks, "JsonFileReader._get_batched_dataframe")
 
     async def test_whole_file_read_does_not_block_the_loop(
@@ -162,6 +163,7 @@ class TestJsonReaderResponsiveness:
         frame, ticks = await count_ticks_during(reader._get_dataframe)
 
         assert len(frame) == 5
+        assert slowed["done"], "the read path never ran"
         assert_stayed_responsive(ticks, "JsonFileReader._get_dataframe")
 
 

--- a/tests/unit/storage/test_event_loop_responsiveness.py
+++ b/tests/unit/storage/test_event_loop_responsiveness.py
@@ -1,0 +1,302 @@
+"""Regression tests for FND-282: the write/read hot paths must not starve the loop.
+
+Heartbeat timeouts across the fleet are dominated by event-loop starvation
+rather than by timeout semantics (ADR-0018, *Problem 2*): blocking work holds
+the loop, the auto-heartbeat coroutine never gets to run, and Temporal kills an
+activity that was making progress the whole time.
+
+Each test here drives a hot path while a ticker coroutine counts how often the
+loop got to run something else. The blocking primitive underneath is slowed
+down so a regression that puts it back on the loop stalls the ticker and fails
+the assertion. This asserts the property ADR-0010 actually cares about — the
+loop stays free to beat — rather than which callable was handed to
+``run_in_thread``, so it survives the blocking sections being regrouped.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import time
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+from typing import Any, TypeVar
+
+import orjson
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+from application_sdk.storage.formats.json import JsonFileReader, JsonFileWriter
+from application_sdk.storage.formats.parquet import ParquetFileReader
+from application_sdk.storage.rolling import RollingFileWriter
+
+pytestmark = pytest.mark.asyncio
+
+T = TypeVar("T")
+
+# How long the patched blocking primitive pretends to take. Long enough that a
+# regression is unambiguous, short enough to keep the suite fast.
+BLOCK_SECONDS = 0.3
+TICK_SECONDS = 0.01
+# A responsive loop gets ~30 ticks per blocking call; a blocked one gets 0.
+# 5 leaves generous headroom for a loaded CI box.
+MIN_TICKS = 5
+
+
+async def count_ticks_during(work: Callable[[], Awaitable[T]]) -> tuple[T, int]:
+    """Run *work*, returning its result and how many times the loop ticked."""
+    ticks = 0
+
+    async def _ticker() -> None:
+        nonlocal ticks
+        while True:
+            await asyncio.sleep(TICK_SECONDS)
+            ticks += 1
+
+    ticker = asyncio.create_task(_ticker())
+    try:
+        result = await work()
+    finally:
+        ticker.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await ticker
+    return result, ticks
+
+
+def assert_stayed_responsive(ticks: int, what: str) -> None:
+    assert ticks >= MIN_TICKS, (
+        f"{what} stalled the event loop ({ticks} ticks) — a starved loop cannot "
+        "run the auto-heartbeat, which is what gets healthy activities killed"
+    )
+
+
+def write_jsonl(path: Path, rows: int) -> Path:
+    with path.open("wb") as f:
+        for i in range(rows):
+            f.write(orjson.dumps({"id": i, "name": f"row-{i}"}))
+            f.write(b"\n")
+    return path
+
+
+class TestJsonWriterResponsiveness:
+    async def test_write_chunk_does_not_block_the_loop(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        writer = JsonFileWriter(str(tmp_path / "out"))
+        chunk = pd.DataFrame({"id": [1, 2, 3], "name": ["a", "b", "c"]})
+        file_name = str(tmp_path / "out" / "chunk.json")
+
+        real_dumps = orjson.dumps
+        slowed = {"done": False}
+
+        def _slow_dumps(*args: Any, **kwargs: Any) -> bytes:
+            # Charge the cost once, standing in for a full-size chunk.
+            if not slowed["done"]:
+                slowed["done"] = True
+                time.sleep(BLOCK_SECONDS)
+            return real_dumps(*args, **kwargs)
+
+        monkeypatch.setattr(
+            "application_sdk.storage.formats.json.orjson.dumps", _slow_dumps
+        )
+
+        _, ticks = await count_ticks_during(
+            lambda: writer._write_chunk(chunk, file_name)
+        )
+
+        assert slowed["done"], "the serialise path never ran"
+        assert_stayed_responsive(ticks, "JsonFileWriter._write_chunk")
+        assert Path(file_name).read_bytes().count(b"\n") == 3
+
+
+class TestJsonReaderResponsiveness:
+    async def test_batched_read_does_not_block_the_loop(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        write_jsonl(tmp_path / "records.json", rows=20)
+        reader = JsonFileReader(str(tmp_path), chunk_size=10)
+
+        real_loads = orjson.loads
+        calls = {"n": 0}
+
+        def _slow_loads(*args: Any, **kwargs: Any) -> Any:
+            # Charge the cost on the first record of each batch.
+            if calls["n"] % 10 == 0:
+                time.sleep(BLOCK_SECONDS / 2)
+            calls["n"] += 1
+            return real_loads(*args, **kwargs)
+
+        monkeypatch.setattr(
+            "application_sdk.storage.formats.json.orjson.loads", _slow_loads
+        )
+
+        async def _drain() -> list[pd.DataFrame]:
+            return [frame async for frame in reader._get_batched_dataframe()]
+
+        frames, ticks = await count_ticks_during(_drain)
+
+        assert [len(f) for f in frames] == [10, 10]
+        assert_stayed_responsive(ticks, "JsonFileReader._get_batched_dataframe")
+
+    async def test_whole_file_read_does_not_block_the_loop(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        write_jsonl(tmp_path / "records.json", rows=5)
+        reader = JsonFileReader(str(tmp_path))
+
+        real_loads = orjson.loads
+        slowed = {"done": False}
+
+        def _slow_loads(*args: Any, **kwargs: Any) -> Any:
+            if not slowed["done"]:
+                slowed["done"] = True
+                time.sleep(BLOCK_SECONDS)
+            return real_loads(*args, **kwargs)
+
+        monkeypatch.setattr(
+            "application_sdk.storage.formats.json.orjson.loads", _slow_loads
+        )
+
+        frame, ticks = await count_ticks_during(reader._get_dataframe)
+
+        assert len(frame) == 5
+        assert_stayed_responsive(ticks, "JsonFileReader._get_dataframe")
+
+
+class TestParquetReaderResponsiveness:
+    async def test_whole_prefix_read_does_not_block_the_loop(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        table = pa.Table.from_pandas(
+            pd.DataFrame({"id": [1, 2, 3]}), preserve_index=False
+        )
+        pq.write_table(table, str(tmp_path / "chunk-0.parquet"))
+        reader = ParquetFileReader(str(tmp_path))
+
+        real_read_table = pq.read_table
+        slowed = {"done": False}
+
+        def _slow_read_table(*args: Any, **kwargs: Any) -> pa.Table:
+            if not slowed["done"]:
+                slowed["done"] = True
+                time.sleep(BLOCK_SECONDS)
+            return real_read_table(*args, **kwargs)
+
+        monkeypatch.setattr("pyarrow.parquet.read_table", _slow_read_table)
+
+        frame, ticks = await count_ticks_during(reader._get_dataframe)
+
+        assert slowed["done"], "the read path never ran"
+        assert len(frame) == 3
+        assert_stayed_responsive(ticks, "ParquetFileReader._get_dataframe")
+
+    async def test_batched_read_does_not_block_the_loop(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        table = pa.Table.from_pandas(
+            pd.DataFrame({"id": list(range(20))}), preserve_index=False
+        )
+        pq.write_table(table, str(tmp_path / "chunk-0.parquet"), row_group_size=5)
+        reader = ParquetFileReader(str(tmp_path), chunk_size=5)
+
+        real_parquet_file = pq.ParquetFile
+        slowed = {"done": False}
+
+        def _slow_parquet_file(*args: Any, **kwargs: Any) -> Any:
+            if not slowed["done"]:
+                slowed["done"] = True
+                time.sleep(BLOCK_SECONDS)
+            return real_parquet_file(*args, **kwargs)
+
+        monkeypatch.setattr("pyarrow.parquet.ParquetFile", _slow_parquet_file)
+
+        async def _drain() -> list[pd.DataFrame]:
+            return [frame async for frame in reader._get_batched_dataframe()]
+
+        frames, ticks = await count_ticks_during(_drain)
+
+        assert slowed["done"], "the read path never ran"
+        assert sum(len(f) for f in frames) == 20
+        assert_stayed_responsive(ticks, "ParquetFileReader._get_batched_dataframe")
+
+
+class TestRollingWriterResponsiveness:
+    """The recommended (non-deprecated) writer runs a caller-supplied flush_fn.
+
+    Its own documented parquet example is a plain function doing
+    ``pd.concat(...).to_parquet(...)``, so if the writer calls a sync flush_fn
+    inline, every connector following the docs blocks the loop on every chunk.
+    """
+
+    async def test_sync_flush_fn_runs_off_the_loop(self, tmp_path: Path) -> None:
+        flushed: list[tuple[int, str]] = []
+
+        def _blocking_flush(batches: list[pd.DataFrame], path: str) -> None:
+            time.sleep(BLOCK_SECONDS)
+            pd.concat(batches, ignore_index=True).to_parquet(path)
+            flushed.append((len(batches), path))
+
+        async def _run() -> None:
+            async with RollingFileWriter[pd.DataFrame](
+                base_path=str(tmp_path / "rolling"),
+                extension=".parquet",
+                flush_fn=_blocking_flush,
+            ) as writer:
+                await writer.append(pd.DataFrame({"id": [1, 2]}))
+                await writer.flush()
+
+        _, ticks = await count_ticks_during(_run)
+
+        assert len(flushed) == 1, "flush_fn did not run"
+        assert_stayed_responsive(ticks, "RollingFileWriter sync flush_fn")
+
+    async def test_async_flush_fn_is_still_awaited_directly(
+        self, tmp_path: Path
+    ) -> None:
+        """An async flush_fn yields on its own; it must not be sent to a thread."""
+        seen: list[str] = []
+
+        async def _async_flush(batches: list[pd.DataFrame], path: str) -> None:
+            await asyncio.sleep(0)
+            pd.concat(batches, ignore_index=True).to_parquet(path)
+            seen.append(path)
+
+        async with RollingFileWriter[pd.DataFrame](
+            base_path=str(tmp_path / "rolling-async"),
+            extension=".parquet",
+            flush_fn=_async_flush,
+        ) as writer:
+            await writer.append(pd.DataFrame({"id": [1, 2]}))
+            await writer.flush()
+
+        assert len(seen) == 1
+        assert Path(seen[0]).exists()
+
+    async def test_sync_on_chunk_complete_runs_off_the_loop(
+        self, tmp_path: Path
+    ) -> None:
+        completed: list[int] = []
+
+        def _flush(batches: list[pd.DataFrame], path: str) -> None:
+            pd.concat(batches, ignore_index=True).to_parquet(path)
+
+        def _blocking_callback(index: int, path: str) -> None:
+            time.sleep(BLOCK_SECONDS)
+            completed.append(index)
+
+        async def _run() -> None:
+            async with RollingFileWriter[pd.DataFrame](
+                base_path=str(tmp_path / "rolling-cb"),
+                extension=".parquet",
+                flush_fn=_flush,
+                on_chunk_complete=_blocking_callback,
+            ) as writer:
+                await writer.append(pd.DataFrame({"id": [1, 2]}))
+                await writer.flush()
+
+        _, ticks = await count_ticks_during(_run)
+
+        assert completed == [0]
+        assert_stayed_responsive(ticks, "RollingFileWriter sync on_chunk_complete")

--- a/tests/unit/templates/test_sql_app_event_loop.py
+++ b/tests/unit/templates/test_sql_app_event_loop.py
@@ -1,0 +1,204 @@
+"""FND-282: the SqlApp extract/transform bodies must not starve the event loop.
+
+``SqlApp`` is the base class every SQL connector inherits, so a blocking loop
+in ``_extract_entity`` / ``_transform_entity`` is a fleet-wide starvation site:
+the auto-heartbeat coroutine cannot run, and Temporal kills an activity that
+was making progress throughout (ADR-0010, ADR-0018 *Problem 2*).
+
+``_transform_entity`` is the sharper case — it maps every raw record for the
+entity (JSON parse, the connector's ``map_*`` function, serialise, write) with
+no await anywhere in the loop, so its hold scales with the source table.
+
+Both tests drive the real method while a ticker coroutine counts how often the
+loop got to run something else, so they assert the property that matters rather
+than which callable was handed to ``run_in_thread``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import time
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+from typing import Any, ClassVar, TypeVar
+
+import orjson
+import pytest
+
+from application_sdk.clients.sql import BaseSQLClient
+from application_sdk.templates.contracts.sql_metadata import (
+    ExtractionTaskInput,
+    TransformInput,
+)
+from application_sdk.templates.sql_app import SqlApp
+
+pytestmark = pytest.mark.asyncio
+
+T = TypeVar("T")
+
+BLOCK_SECONDS = 0.3
+TICK_SECONDS = 0.01
+MIN_TICKS = 5
+
+
+class _FakeSqlClient(BaseSQLClient):
+    """In-process SQL client yielding one fixed batch — no network, no driver."""
+
+    _ROWS: ClassVar[list[dict[str, Any]]] = [
+        {"database_name": "prod"},
+        {"database_name": "stage"},
+    ]
+
+    def __init__(self) -> None:
+        pass  # skip BaseSQLClient.__init__ — no DB_CONFIG needed for the fake
+
+    async def load(self, credentials: dict[str, Any] | None = None) -> None:
+        return None
+
+    async def close(self) -> None:
+        return None
+
+    async def run_query(self, query: str, batch_size: int = 100_000):
+        yield self._ROWS
+
+
+class _SlowMapperApp(SqlApp):
+    """SqlApp whose mapper is expensive, standing in for a real pyatlan mapper."""
+
+    sql_client_class: ClassVar[type[BaseSQLClient] | None] = _FakeSqlClient
+    _app_registered: ClassVar[bool] = True
+
+    fetch_database_sql: ClassVar[str] = "SELECT 1"
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.mapped = 0
+
+    def map_database(
+        self, record: dict[str, Any], connection_qn: str
+    ) -> dict[str, Any]:
+        # Charge the cost once — a real mapper's per-record cost times a large
+        # table is what produces the multi-second holds seen in production.
+        if self.mapped == 0:
+            time.sleep(BLOCK_SECONDS)
+        self.mapped += 1
+        return {
+            "typeName": "Database",
+            "attributes": {
+                "name": record["database_name"],
+                "qualifiedName": f"{connection_qn}/{record['database_name']}",
+            },
+        }
+
+
+async def count_ticks_during(work: Callable[[], Awaitable[T]]) -> tuple[T, int]:
+    """Run *work*, returning its result and how many times the loop ticked."""
+    ticks = 0
+
+    async def _ticker() -> None:
+        nonlocal ticks
+        while True:
+            await asyncio.sleep(TICK_SECONDS)
+            ticks += 1
+
+    ticker = asyncio.create_task(_ticker())
+    try:
+        result = await work()
+    finally:
+        ticker.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await ticker
+    return result, ticks
+
+
+def _extract_input(tmp_path: Path) -> ExtractionTaskInput:
+    return ExtractionTaskInput(
+        workflow_id="wf-test",
+        output_path=str(tmp_path),
+        output_prefix=str(tmp_path),
+        exclude_filter="",
+        include_filter="",
+        temp_table_regex="",
+    )
+
+
+def _transform_input(tmp_path: Path) -> TransformInput:
+    return TransformInput(
+        workflow_id="wf-test",
+        output_path=str(tmp_path),
+        output_prefix=str(tmp_path),
+        exclude_filter="",
+        include_filter="",
+        temp_table_regex="",
+        raw_file=None,
+    )
+
+
+@pytest.fixture
+def app(monkeypatch: pytest.MonkeyPatch) -> _SlowMapperApp:
+    instance = _SlowMapperApp()
+
+    async def _fake_init(self: Any, _input: Any) -> BaseSQLClient:
+        return _FakeSqlClient()
+
+    monkeypatch.setattr(SqlApp, "_init_sql_client", _fake_init)
+    return instance
+
+
+async def test_transform_entity_does_not_block_the_loop(
+    app: _SlowMapperApp, tmp_path: Path
+) -> None:
+    raw_dir = tmp_path / "raw" / "database"
+    raw_dir.mkdir(parents=True)
+    with (raw_dir / "records.json").open("wb") as f:
+        for name in ("prod", "stage"):
+            f.write(orjson.dumps({"database_name": name}))
+            f.write(b"\n")
+
+    result, ticks = await count_ticks_during(
+        lambda: app._transform_entity(
+            entity_type="database",
+            mapper_fn=app.map_database,
+            input=_transform_input(tmp_path),
+        )
+    )
+
+    assert result.total_record_count == 2
+    assert app.mapped == 2, "the mapper never ran"
+    assert ticks >= MIN_TICKS, (
+        f"_transform_entity stalled the event loop ({ticks} ticks) — a starved "
+        "loop cannot run the auto-heartbeat, which is what gets healthy "
+        "activities killed on heartbeat_timeout"
+    )
+
+
+async def test_extract_entity_does_not_block_the_loop(
+    app: _SlowMapperApp, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    real_dumps = orjson.dumps
+    slowed = {"done": False}
+
+    def _slow_dumps(*args: Any, **kwargs: Any) -> bytes:
+        # Charge the cost once, standing in for a full 10k-row batch.
+        if not slowed["done"]:
+            slowed["done"] = True
+            time.sleep(BLOCK_SECONDS)
+        return real_dumps(*args, **kwargs)
+
+    monkeypatch.setattr("application_sdk.templates.sql_app.orjson.dumps", _slow_dumps)
+
+    result, ticks = await count_ticks_during(
+        lambda: app._extract_entity(
+            entity_type="database",
+            sql_template=_SlowMapperApp.fetch_database_sql,
+            input=_extract_input(tmp_path),
+        )
+    )
+
+    assert result.total_record_count == 2
+    assert slowed["done"], "the serialise path never ran"
+    assert ticks >= MIN_TICKS, (
+        f"_extract_entity stalled the event loop ({ticks} ticks) — a starved "
+        "loop cannot run the auto-heartbeat"
+    )

--- a/tests/unit/templates/test_sql_app_event_loop.py
+++ b/tests/unit/templates/test_sql_app_event_loop.py
@@ -27,6 +27,7 @@ import orjson
 import pytest
 
 from application_sdk.clients.sql import BaseSQLClient
+from application_sdk.templates import sql_app as sql_app_module
 from application_sdk.templates.contracts.sql_metadata import (
     ExtractionTaskInput,
     TransformInput,
@@ -202,3 +203,44 @@ async def test_extract_entity_does_not_block_the_loop(
         f"_extract_entity stalled the event loop ({ticks} ticks) — a starved "
         "loop cannot run the auto-heartbeat"
     )
+
+
+async def test_extract_entity_never_hands_the_file_handle_to_a_thread(
+    app: _SlowMapperApp, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Only serialisation may be offloaded — never the open output handle.
+
+    If the handle crossed into the blocking pool, a cancellation at that await
+    would unwind the enclosing ``with`` and close the file while a worker thread
+    was still writing to it. Per ADR-0010 that thread cannot be killed, so it
+    would write on into a closed — or retry-reopened — file.
+
+    Asserts the invariant directly: nothing passed to ``run_in_thread`` is a
+    file object, and the bytes still land on disk.
+    """
+    offloaded_args: list[Any] = []
+    real_run_in_thread = sql_app_module.run_in_thread
+
+    async def _recording_run_in_thread(func: Any, *args: Any, **kwargs: Any) -> Any:
+        offloaded_args.extend(args)
+        offloaded_args.extend(kwargs.values())
+        return await real_run_in_thread(func, *args, **kwargs)
+
+    monkeypatch.setattr(sql_app_module, "run_in_thread", _recording_run_in_thread)
+
+    result = await app._extract_entity(
+        entity_type="database",
+        sql_template=_SlowMapperApp.fetch_database_sql,
+        input=_extract_input(tmp_path),
+    )
+
+    assert offloaded_args, "nothing was offloaded"
+    for arg in offloaded_args:
+        assert not hasattr(arg, "write"), (
+            f"a file-like object ({arg!r}) was handed to run_in_thread — a "
+            "cancellation there would close the handle under a live writer"
+        )
+
+    assert result.total_record_count == 2
+    written = (tmp_path / "raw" / "database" / "records.json").read_bytes()
+    assert written.count(b"\n") == 2


### PR DESCRIPTION
Rollout **step 1** of [ADR-0018](https://github.com/atlanhq/application-sdk/blob/main/docs/adr/0018-progress-aware-heartbeat.md) — fixes the ADR-0010 adoption gaps before a second heartbeat mechanism lands on top of them. Linear: [FND-282](https://linear.app/atlan-epd/issue/FND-282/fix-the-event-loop-starvation-sites-adr-0010-audit-before-adding-the).

`activity Heartbeat timeout` is today's dominant production alert, and those failures are overwhelmingly **event-loop starvation**, not a timeout-semantics problem: blocking work holds the loop, the auto-heartbeat coroutine never gets to run, and Temporal kills an activity that was making progress the whole time.

## How the sites were found

Primary source, as the issue specifies, is the auto-heartbeat loop's own warning:

> `Event loop blocked for %.1fs during task %s, auto-heartbeating may be unreliable.`

A 7-day fleet scan of `otel_logs.service_logs` over `ServiceName LIKE 'atlan-%-app'` returns exactly one emitter today — see *Follow-up* below.

A static AST audit of `application_sdk/` ran alongside it rather than instead of it, because **the warning only fires when the block is _shorter_ than the heartbeat timeout**. A block long enough to kill the activity produces a heartbeat timeout, not a warning. The log is a floor on the problem, not a census.

## What was blocking

ADR-0010 had been adopted **partially**: `run_in_thread` was already in place on ~15 sites, but the equivalent work one frame away was still inline.

| Site | What was on the loop |
|---|---|
| `storage/rolling.py` `_flush_locked` | The recommended non-deprecated writer called a **synchronous `flush_fn` inline**. Its own documented example is `pd.concat(...).to_parquet(path)` — so every connector following the docs blocked the loop on every chunk. Same for `on_chunk_complete`. |
| `templates/sql_app.py` `_transform_entity` | Maps **every** raw record for an entity — parse → connector `map_*` (builds pyatlan assets) → serialise → write — with no `await` anywhere in the loop. Base class for every SQL connector. |
| `templates/sql_app.py` `_extract_entity` | 10k `orjson.dumps` + 20k writes per batch, no await between. |
| `common/incremental/state/state_writer.py` | `create_current_state_snapshot` ran two DuckDB scans, two blocking parallel directory copies, a recursive file count and `create_incremental_diff` inline. It already offloaded `rmtree` and `prepare_current_state_directory` — the expensive neighbours were missed. |
| `templates/incremental_sql_metadata_extractor.py` | `get_backfill_tables` + `get_tables_needing_column_extraction` (synchronous DuckDB over the run's transformed output), plus the batch-file write loop. |
| `storage/formats/parquet.py` | Whole-prefix `read_table` + `concat_tables` + `to_pandas`; per-row-group `iter_batches`/`to_pandas`; consolidation `read_parquet`; `Table.from_pandas` (only `write_table` had been offloaded). |
| `storage/formats/json.py` | Per-chunk read+parse loop (100k default), whole-prefix read, chunk write loop. |
| `storage/batch.py`, `storage/cloud.py` | `os.walk` + per-entry `is_symlink()` over a whole run's output directory. |
| `storage/chunked.py` | Post-download whole-file sha256 — `transfer.py` and `reference.py` already offloaded the identical helper. |

Async `flush_fn` / `on_chunk_complete` callbacks still run directly on the loop, since they yield at their own await points. `run_in_thread` copies the `contextvars` context, so a synchronous `on_chunk_complete` calling `activity.heartbeat()` still finds its activity context.

## Deliberately not changed

- **`storage/formats/__init__.py:487` — `gc.collect()` per chunk in the base writer loop.** A full gen-2 GC on a large worker heap is a real multi-hundred-ms loop stall, but `run_in_thread` **cannot** fix it: GC stops the world regardless of calling thread. Flagged rather than touched — removing it risks a memory regression and it needs its own decision.
- `handler/service.py` FastAPI routes — different loop, not a heartbeat-timeout path.
- Observability flush/cleanup — bounded, with awaits interleaved.
- Marker / credential / statistics files — O(1).

## Testing

New tests assert **loop responsiveness**, not which callable reached `run_in_thread`, so the guarantee survives the blocking sections being regrouped: a ticker coroutine counts loop turns while the real method runs against a slowed blocking primitive. Each was confirmed to fail on revert — **0 ticks vs ~30**.

- `tests/unit/storage/test_event_loop_responsiveness.py` (8 tests)
- `tests/unit/templates/test_sql_app_event_loop.py` (2 tests)
- `test_parquet_writer.py::test_write_chunk_offloaded_to_thread` rewritten off callable-identity onto the thread + responsiveness assertion.

6563 unit tests pass; pre-commit clean (ruff, ruff-format, isort, pyright); conformance introduces no new findings.

## Implementation note

`storage/{batch,chunked,cloud,rolling}.py` import `run_in_thread` **lazily**. `application_sdk.execution` imports back into `contracts`/`storage`, so a module-scope import closes a circular import. `app/base.py` already uses this pattern.

## Follow-up (not in this PR)

The one app the fleet signal actually names is **`atlanhq/atlan-local-marketplace-app`** — a separate repo, untouched here. Its `deployment_orchestrator` tasks (`discover_workflow_tasks`, `trigger_cd`, `fetch_manifests_for_targets`, `call_mdlh_admin_api`, `upgrade_one_workflow`) are the current top emitter, with holds up to 62s. Its `AEClient` is properly async (httpx) and `commons/kubectl.py` already ships async wrappers, so the blocking is most likely CPU-bound manifest diffing in `manifest_upgrade.py` and/or sync `subprocess.run` paths reached from async callers.

That bears on FND-282's "done when": the drop in starvation-attributable heartbeat alerts can only be read after **both** this and the marketplace app have shipped, since that app dominates the signal today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
