### PR TITLE
feat(execution): stall watchdog in the auto-heartbeat loop (FND-286)

### DIFF
--- a/application_sdk/execution/heartbeat.py
+++ b/application_sdk/execution/heartbeat.py
@@ -19,6 +19,7 @@ import asyncio
 import concurrent.futures
 import contextvars
 import functools
+import math
 import multiprocessing
 import os
 import threading
@@ -332,14 +333,20 @@ async def auto_heartbeat_loop(
         if progress is not None and watchdog_mode is not ProgressWatchdogMode.OFF
         else None
     )
-    if watchdog_budget is not None and watchdog_budget <= 0:
+    if watchdog_budget is not None and (
+        not math.isfinite(watchdog_budget) or watchdog_budget <= 0
+    ):
         # Refuse rather than obey. A budget of zero makes every attempt stall on
         # its first tick, so honouring it in enforce mode would turn one bad
-        # config value into a fleet-wide kill switch.
+        # config value into a fleet-wide kill switch. NaN slips past the
+        # `<= 0` check (comparisons against NaN are always False) and would
+        # enforce on the first tick, while +inf would silently never enforce —
+        # so only a finite positive allowance counts as a real budget.
         logger.warning(
-            "Stall watchdog for task '%s' was given a non-positive no-progress "
-            "budget (%.0fs); disabling the watchdog — set max_no_progress_seconds "
-            "to a real allowance, or the mode to 'off' to disable it deliberately",
+            "Stall watchdog for task '%s' was given a non-positive or "
+            "non-finite no-progress budget (%ss); disabling the watchdog — set "
+            "max_no_progress_seconds to a finite positive allowance, or the "
+            "mode to 'off' to disable it deliberately",
             task_name,
             watchdog_budget,
         )

--- a/application_sdk/execution/heartbeat.py
+++ b/application_sdk/execution/heartbeat.py
@@ -27,6 +27,7 @@ from collections.abc import Callable
 from concurrent.futures.process import BrokenProcessPool
 from typing import Any, Protocol, TypeVar
 
+from application_sdk.execution.progress import ProgressTracker, ProgressWatchdogMode
 from application_sdk.observability import (
     resource_sampler as _resource_sampler,  # module alias kept so tests can patch _resource_sampler.sample()
 )
@@ -39,6 +40,14 @@ _MEMORY_WARN_THRESHOLD = 0.80
 _MEMORY_WARN_HYSTERESIS = (
     0.05  # re-arm only once ratio drops below threshold - hysteresis
 )
+
+#: Meter for signals this module owns. Deliberately not the Temporal meter: the
+#: stall watchdog has no Temporal dependency, so it also reports from local runs.
+_METER_NAME = "application_sdk.execution"
+
+#: Lazily created singletons — one instrument per process, built on first use so
+#: nothing is bound before ``run_main()`` configures the ``MeterProvider``.
+_INSTRUMENTS: dict[str, Any] = {}
 
 # Dedicated executor for blocking operations dispatched via run_in_thread().
 #
@@ -133,11 +142,153 @@ class NoopHeartbeatController:
         return self._details
 
 
+def _no_progress_gap_histogram() -> Any:
+    """Gap-duration histogram, created on first stall observation.
+
+    A histogram rather than a counter because the fleet-wide *distribution* of
+    no-progress gaps is what sizes ``max_no_progress_seconds`` before anything
+    enforces (ADR-0018 → *Decisions taken*).
+    """
+    if "no_progress_gap" not in _INSTRUMENTS:
+        from opentelemetry import (  # noqa: PLC0415 — cold path: only reached on a stall observation
+            metrics as _otel_metrics,
+        )
+
+        _INSTRUMENTS["no_progress_gap"] = _otel_metrics.get_meter(
+            _METER_NAME
+        ).create_histogram(
+            "task.no_progress_gap",
+            unit="s",
+            description=(
+                "Seconds a task attempt went without an observable progress "
+                "signal, recorded once per gap that exceeded "
+                "max_no_progress_seconds. Partitioned by task, the last "
+                "progress label seen, and the watchdog mode — so warn-mode "
+                "observations and enforced kills aggregate separately."
+            ),
+        )
+    return _INSTRUMENTS["no_progress_gap"]
+
+
+def _record_no_progress_gap(
+    task_name: str, stalled_for: float, last_label: str, mode: ProgressWatchdogMode
+) -> None:
+    """Record one no-progress gap. Never raises.
+
+    The metric is emitted in *both* warn and enforce mode: in warn mode it is
+    the whole point (nothing else reports the gap), and in enforce mode it is
+    what makes the kill rate measurable.
+    """
+    try:
+        _no_progress_gap_histogram().record(
+            stalled_for,
+            {
+                "task.name": task_name,
+                # A progress label identifies a call site, never a value — see
+                # ProgressTracker.enter_hold — so this stays bounded.
+                "progress.last_label": last_label,
+                "watchdog.mode": mode.value,
+            },
+        )
+    # Best-effort observability: a metric-backend problem must never fail the
+    # activity the watchdog is only observing.
+    except Exception:
+        logger.warning(
+            "Failed to record the no-progress gap metric for task '%s' (%.0fs gap); "
+            "the stall is still logged but will be missing from the fleet-wide "
+            "gap distribution",
+            task_name,
+            stalled_for,
+            exc_info=True,
+        )
+
+
+def _check_for_stall(
+    progress: ProgressTracker,
+    budget_seconds: float,
+    mode: ProgressWatchdogMode,
+    task_name: str,
+    on_stall: Callable[[float, str], None] | None,
+) -> bool:
+    """Report a no-progress gap if one is open. Returns True to stop the loop.
+
+    Called once per heartbeat tick, so detection latency is ``budget_seconds``
+    plus at most one tick.
+
+    Args:
+        progress: The attempt's tracker. ``stalled_for()`` already accounts for
+            holds, so a vouched-for operation reads as no gap at all.
+        budget_seconds: ``max_no_progress_seconds`` for this task.
+        mode: ``WARN`` reports; ``ENFORCE`` reports and fails the activity.
+        task_name: Task name, for the log and the metric.
+        on_stall: Injected by the activity layer to fail the attempt — the
+            watchdog itself stays free of activity/Temporal semantics. Only
+            called in ``ENFORCE``.
+
+    Returns:
+        ``True`` when the caller must return immediately: the watchdog *is*
+        ``heartbeat_task``, and the activity's ``finally`` sets ``stop_event``
+        and awaits it with a 1s bound, so it must not keep looping after
+        deciding to fail the attempt.
+    """
+    stalled = progress.stalled_for()
+    if stalled < budget_seconds:
+        return False
+
+    last_label = progress.last_label
+    _record_no_progress_gap(task_name, stalled, last_label, mode)
+
+    if mode is not ProgressWatchdogMode.ENFORCE or on_stall is None:
+        # INFO, never WARNING: under a fleet-wide default this is an expected
+        # observation, and emitting it at WARNING would manufacture exactly the
+        # alert noise ADR-0018 exists to reduce. Dashboards read the metric.
+        logger.info(
+            "Task '%s' made no observable progress for %.0fs (budget %.0fs); last "
+            "signal was '%s' — not failing (warn mode)",
+            task_name,
+            stalled,
+            budget_seconds,
+            last_label or "<none>",
+        )
+        # Re-arm so each gap is reported once rather than every tick. The empty
+        # label deliberately leaves last_label alone: the signal just reported
+        # is still the most useful thing to name in the next report.
+        progress.mark_progress()
+        return False
+
+    logger.warning(
+        "Task '%s' made no observable progress for %.0fs (budget %.0fs); last "
+        "signal was '%s' — failing the activity",
+        task_name,
+        stalled,
+        budget_seconds,
+        last_label or "<none>",
+    )
+    try:
+        on_stall(stalled, last_label)
+    # The watchdog must not keep beating for an attempt it has already decided
+    # to fail; the failure is handled by stopping the loop below.
+    except Exception:
+        logger.warning(
+            "Stall handler for task '%s' raised, so the attempt was not failed "
+            "in-process; stopping the heartbeat loop so Temporal's "
+            "heartbeat_timeout reclaims it instead",
+            task_name,
+            exc_info=True,
+        )
+    return True
+
+
 async def auto_heartbeat_loop(
     interval_seconds: float,
     heartbeat_fn: Callable[[], None],
     stop_event: asyncio.Event,
     task_name: str,
+    *,
+    progress: ProgressTracker | None = None,
+    max_no_progress_seconds: float | None = None,
+    watchdog_mode: ProgressWatchdogMode = ProgressWatchdogMode.OFF,
+    on_stall: Callable[[float, str], None] | None = None,
 ) -> None:
     """Background task that sends heartbeats at regular intervals.
 
@@ -148,15 +299,67 @@ async def auto_heartbeat_loop(
     They WILL FAIL for blocking I/O, CPU-bound computation, or long-running
     C extensions. Use run_in_thread() to wrap blocking operations.
 
+    When a ``progress`` tracker and a budget are supplied, the same loop also
+    runs the ADR-0018 **stall watchdog**. The beat itself stays
+    **unconditional** — it is the crash detector (OOM, SIGKILL, node loss,
+    partition, starved loop) and ``heartbeat_timeout`` keeps its meaning and its
+    60s default. The watchdog is a second, independent question asked on the
+    same tick: *has this attempt done anything observable lately?*
+
     Args:
         interval_seconds: How often to send heartbeats.
         heartbeat_fn: Function to call for each heartbeat.
         stop_event: Event to signal loop termination.
         task_name: Name of the task (for warning messages).
+        progress: The attempt's :class:`ProgressTracker`. ``None`` leaves the
+            watchdog inert.
+        max_no_progress_seconds: How long this task may go without an
+            observable progress signal. ``None`` leaves the watchdog inert.
+        watchdog_mode: ``OFF`` (inert), ``WARN`` (report only) or ``ENFORCE``
+            (report, then fail the attempt via ``on_stall``).
+        on_stall: Called as ``on_stall(stalled_for, last_label)`` when a stall
+            is enforced. Injected by the activity layer — the same way
+            ``heartbeat_fn`` already is — so this module stays free of
+            activity/Temporal semantics and the watchdog is unit-testable
+            without a worker.
     """
     warning_threshold = interval_seconds * 0.5
     _limit_bytes = parse_pod_memory_limit(os.environ.get("K8S_POD_MEMORY_LIMIT", ""))
     _memory_warn_active = False
+
+    watchdog_budget: float | None = (
+        max_no_progress_seconds
+        if progress is not None and watchdog_mode is not ProgressWatchdogMode.OFF
+        else None
+    )
+    if watchdog_budget is not None and watchdog_budget <= 0:
+        # Refuse rather than obey. A budget of zero makes every attempt stall on
+        # its first tick, so honouring it in enforce mode would turn one bad
+        # config value into a fleet-wide kill switch.
+        logger.warning(
+            "Stall watchdog for task '%s' was given a non-positive no-progress "
+            "budget (%.0fs); disabling the watchdog — set max_no_progress_seconds "
+            "to a real allowance, or the mode to 'off' to disable it deliberately",
+            task_name,
+            watchdog_budget,
+        )
+        watchdog_budget = None
+    if (
+        watchdog_budget is not None
+        and watchdog_mode is ProgressWatchdogMode.ENFORCE
+        and on_stall is None
+    ):
+        # A wiring bug, not a config choice. Downgrade rather than raise: the
+        # watchdog must never itself be the thing that fails an activity, and
+        # reporting is strictly better than going silent. Downgraded here rather
+        # than at the call site so the metric's mode attribute describes what
+        # the watchdog actually did.
+        logger.warning(
+            "Stall watchdog for task '%s' was asked to enforce but no on_stall "
+            "handler was injected; reporting gaps without failing the attempt",
+            task_name,
+        )
+        watchdog_mode = ProgressWatchdogMode.WARN
 
     while not stop_event.is_set():
         loop_start = time.monotonic()
@@ -229,6 +432,23 @@ async def auto_heartbeat_loop(
                     e,
                     exc_info=True,
                 )
+
+        # The stall watchdog runs last in the tick: the beat is the crash
+        # detector and goes out first, and an enforced stall returns from here,
+        # so putting it after the memory sample means the tick that kills a
+        # wedged attempt still carries that attempt's last memory observation.
+        if (
+            progress is not None
+            and watchdog_budget is not None
+            and _check_for_stall(
+                progress=progress,
+                budget_seconds=watchdog_budget,
+                mode=watchdog_mode,
+                task_name=task_name,
+                on_stall=on_stall,
+            )
+        ):
+            return
 
 
 async def run_in_thread(func: Callable[..., T], *args: Any, **kwargs: Any) -> T:

--- a/application_sdk/execution/progress.py
+++ b/application_sdk/execution/progress.py
@@ -24,10 +24,12 @@ Two signals feed it (see ADR-0018 → *Feeding the tracker*):
   at the one call site that knows, or declares nothing and gets an unbounded
   hold that the duration backstop owns.
 
-The watchdog itself (FND-286), the ContextVar plumbing that makes the tracker
-reachable from app code (FND-287), the framework hooks (FND-288) and the
-warn-mode telemetry that consumes :class:`ClosedHold` (FND-292) are separate
-pieces built on this one.
+The watchdog that consumes the tracker lives in
+:func:`~application_sdk.execution.heartbeat.auto_heartbeat_loop` and runs in one
+of the three :class:`ProgressWatchdogMode` states. The ContextVar plumbing that
+makes the tracker reachable from app code (FND-287), the framework hooks
+(FND-288) and the warn-mode telemetry that consumes :class:`ClosedHold`
+(FND-292) are separate pieces built on this one.
 """
 
 from __future__ import annotations
@@ -37,9 +39,37 @@ import time
 from collections.abc import Callable
 from dataclasses import dataclass
 
+from application_sdk.contracts.base import SerializableEnum
 from application_sdk.observability.logger_adaptor import get_logger
 
 logger = get_logger(__name__)
+
+
+class ProgressWatchdogMode(SerializableEnum):
+    """How the stall watchdog reacts to a no-progress gap (ADR-0018).
+
+    Three states, not two, because the watchdog is also the audit tool that
+    tells an app *where* it needs holds — a job that only works if it can
+    observe without being able to fail anything.
+
+    ``SerializableEnum`` (a ``StrEnum``) rather than a plain ``Enum``: the mode
+    ends up on the task's Temporal payload alongside
+    ``heartbeat_timeout_seconds``, and it is used directly as a metric
+    attribute value.
+    """
+
+    OFF = "off"
+    """Inert. Nothing is observed and nothing is reported — byte-identical to
+    pre-ADR-0018 behaviour. A kill-switch, not the normal state."""
+
+    WARN = "warn"
+    """Report every gap as a metric and an INFO log; never fail an activity.
+    The fleet-wide default, and the audit tool that produces each app's
+    work-list."""
+
+    ENFORCE = "enforce"
+    """Report the gap, then fail the activity through the injected
+    ``on_stall`` handler."""
 
 
 @dataclass(frozen=True)

--- a/tests/unit/execution/test_heartbeat.py
+++ b/tests/unit/execution/test_heartbeat.py
@@ -11,6 +11,9 @@ from __future__ import annotations
 import asyncio
 import sys
 import types
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -21,6 +24,7 @@ from application_sdk.execution.heartbeat import (
     auto_heartbeat_loop,
     run_in_thread,
 )
+from application_sdk.execution.progress import ProgressTracker, ProgressWatchdogMode
 
 # ---------------------------------------------------------------------------
 # NoopHeartbeatController
@@ -441,3 +445,522 @@ class TestRunInThread:
         with patch.object(hb_mod.asyncio, "get_running_loop", return_value=fake_loop):
             with pytest.raises(ValueError):
                 await run_in_thread(bad)
+
+
+# ---------------------------------------------------------------------------
+# Stall watchdog (ADR-0018 / FND-286)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class WatchdogClock:
+    """A monotonic clock the test advances explicitly.
+
+    The tracker takes its clock by injection precisely so tests never patch
+    ``time.monotonic``: the asyncio loop driving ``auto_heartbeat_loop`` shares
+    that global, so patching it makes the loop itself misbehave.
+    """
+
+    now: float = 1000.0
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+@dataclass
+class StallRecorder:
+    """Captures the (stalled_for, last_label) pairs on_stall is called with."""
+
+    calls: list[tuple[float, str]] = field(default_factory=list)
+    raises: bool = False
+
+    def __call__(self, stalled_for: float, last_label: str) -> None:
+        self.calls.append((stalled_for, last_label))
+        if self.raises:
+            raise RuntimeError("cancelling the activity task failed")
+
+
+@dataclass
+class LoopRun:
+    """What one driven run of the loop observed."""
+
+    beats: int
+    stall_infos: list[Any]
+    stall_warnings: list[Any]
+    recorded: list[Any]
+
+
+async def _drive(
+    *,
+    tracker: ProgressTracker | None,
+    clock: WatchdogClock,
+    mode: ProgressWatchdogMode = ProgressWatchdogMode.OFF,
+    budget: float | None = None,
+    on_stall: Callable[[float, str], None] | None = None,
+    step: float = 1.0,
+    ticks: int = 1,
+    per_tick: Callable[[int], None] | None = None,
+    record_raises: bool = False,
+) -> LoopRun:
+    """Run ``auto_heartbeat_loop`` for at most ``ticks`` ticks.
+
+    Each tick advances ``clock`` by ``step`` *before* the watchdog runs, so at
+    tick ``n`` the watchdog sees a gap of ``n * step`` unless something marked
+    progress. The real loop interval stays sub-millisecond — the fake clock,
+    not wall time, is what the watchdog reads.
+    """
+    from application_sdk.execution import heartbeat as hb_mod
+
+    stop = asyncio.Event()
+    beats: list[int] = []
+    histogram = MagicMock()
+    if record_raises:
+        histogram.record.side_effect = RuntimeError("metric backend down")
+
+    def hb_fn() -> None:
+        beats.append(1)
+        clock.advance(step)
+        if per_tick is not None:
+            per_tick(len(beats))
+        if len(beats) >= ticks:
+            stop.set()
+
+    with (
+        patch.object(hb_mod, "logger") as mock_logger,
+        patch.object(hb_mod, "_no_progress_gap_histogram", return_value=histogram),
+    ):
+        await auto_heartbeat_loop(
+            interval_seconds=0.001,
+            heartbeat_fn=hb_fn,
+            stop_event=stop,
+            task_name="extract",
+            progress=tracker,
+            max_no_progress_seconds=budget,
+            watchdog_mode=mode,
+            on_stall=on_stall,
+        )
+
+    return LoopRun(
+        beats=len(beats),
+        stall_infos=[
+            c
+            for c in mock_logger.info.call_args_list
+            if "no observable progress" in str(c)
+        ],
+        stall_warnings=[
+            c
+            for c in mock_logger.warning.call_args_list
+            if any(
+                marker in str(c)
+                for marker in ("progress", "Stall watchdog", "Stall handler")
+            )
+        ],
+        recorded=list(histogram.record.call_args_list),
+    )
+
+
+class TestStallWatchdogInert:
+    """Purely additive: with nothing injected, the loop behaves exactly as before."""
+
+    @pytest.mark.asyncio
+    async def test_no_tracker_means_no_watchdog(self) -> None:
+        run = await _drive(tracker=None, clock=WatchdogClock(), budget=1.0, ticks=3)
+
+        assert run.beats == 3
+        assert not run.stall_infos and not run.stall_warnings and not run.recorded
+
+    @pytest.mark.asyncio
+    async def test_off_mode_observes_nothing(self) -> None:
+        clock = WatchdogClock()
+        run = await _drive(
+            tracker=ProgressTracker(clock=clock),
+            clock=clock,
+            mode=ProgressWatchdogMode.OFF,
+            budget=1.0,
+            step=100.0,
+            ticks=3,
+        )
+
+        assert run.beats == 3
+        assert not run.stall_infos and not run.stall_warnings and not run.recorded
+
+    @pytest.mark.asyncio
+    async def test_no_budget_means_no_watchdog(self) -> None:
+        clock = WatchdogClock()
+        run = await _drive(
+            tracker=ProgressTracker(clock=clock),
+            clock=clock,
+            mode=ProgressWatchdogMode.ENFORCE,
+            budget=None,
+            step=100.0,
+            ticks=3,
+        )
+
+        assert run.beats == 3
+        assert not run.stall_infos and not run.stall_warnings and not run.recorded
+
+
+class TestStallWatchdogEnforce:
+    @pytest.mark.asyncio
+    async def test_gap_at_the_budget_fails_the_activity_and_stops_the_loop(
+        self,
+    ) -> None:
+        clock = WatchdogClock()
+        tracker = ProgressTracker(clock=clock)
+        tracker.mark_progress("write_batch")
+        stalls = StallRecorder()
+
+        run = await _drive(
+            tracker=tracker,
+            clock=clock,
+            mode=ProgressWatchdogMode.ENFORCE,
+            budget=5.0,
+            on_stall=stalls,
+            step=2.0,
+            ticks=20,
+        )
+
+        # Gap reaches the budget on tick 3 (2s per tick); the watchdog *is*
+        # heartbeat_task, so it returns there rather than beating 17 more times.
+        assert stalls.calls == [(6.0, "write_batch")]
+        assert run.beats == 3
+
+    @pytest.mark.asyncio
+    async def test_stall_is_reported_at_warning_and_names_the_last_signal(self) -> None:
+        clock = WatchdogClock()
+        tracker = ProgressTracker(clock=clock)
+        tracker.mark_progress("fetch_page")
+
+        run = await _drive(
+            tracker=tracker,
+            clock=clock,
+            mode=ProgressWatchdogMode.ENFORCE,
+            budget=5.0,
+            on_stall=StallRecorder(),
+            step=5.0,
+            ticks=5,
+        )
+
+        assert len(run.stall_warnings) == 1
+        assert not run.stall_infos
+        assert "failing the activity" in run.stall_warnings[0].args[0]
+        assert run.stall_warnings[0].args[1:] == ("extract", 5.0, 5.0, "fetch_page")
+
+    @pytest.mark.asyncio
+    async def test_detection_latency_is_budget_plus_at_most_one_tick(self) -> None:
+        """The tick that first sees ``stalled >= budget`` is the tick that fires."""
+        clock = WatchdogClock()
+        tracker = ProgressTracker(clock=clock)
+        stalls = StallRecorder()
+
+        run = await _drive(
+            tracker=tracker,
+            clock=clock,
+            mode=ProgressWatchdogMode.ENFORCE,
+            budget=10.0,
+            on_stall=stalls,
+            step=3.0,
+            ticks=20,
+        )
+
+        # Gaps go 3, 6, 9, 12 — the first tick at or past the budget is the 4th,
+        # i.e. one tick's worth of overshoot and no more.
+        assert run.beats == 4
+        assert stalls.calls == [(12.0, "")]
+
+    @pytest.mark.asyncio
+    async def test_progress_each_tick_never_stalls(self) -> None:
+        clock = WatchdogClock()
+        tracker = ProgressTracker(clock=clock)
+        stalls = StallRecorder()
+
+        run = await _drive(
+            tracker=tracker,
+            clock=clock,
+            mode=ProgressWatchdogMode.ENFORCE,
+            budget=5.0,
+            on_stall=stalls,
+            step=4.0,
+            ticks=10,
+            per_tick=lambda _n: tracker.mark_progress("write_batch"),
+        )
+
+        assert not stalls.calls
+        assert run.beats == 10
+
+    @pytest.mark.asyncio
+    async def test_unbounded_hold_suppresses_the_stall(self) -> None:
+        """A vouched-for opaque call is never accused of stalling."""
+        clock = WatchdogClock()
+        tracker = ProgressTracker(clock=clock)
+        tracker.enter_hold("full table scan", timeout=None)
+        stalls = StallRecorder()
+
+        run = await _drive(
+            tracker=tracker,
+            clock=clock,
+            mode=ProgressWatchdogMode.ENFORCE,
+            budget=5.0,
+            on_stall=stalls,
+            step=50.0,
+            ticks=6,
+        )
+
+        assert not stalls.calls
+        assert run.beats == 6
+
+    @pytest.mark.asyncio
+    async def test_lapsed_bounded_hold_fires_at_allowance_plus_budget(self) -> None:
+        """Kill time for a wedged held call is ``allowance + budget``."""
+        clock = WatchdogClock()
+        tracker = ProgressTracker(clock=clock)
+        tracker.enter_hold("snapshot metadata query", timeout=10.0)
+        stalls = StallRecorder()
+
+        run = await _drive(
+            tracker=tracker,
+            clock=clock,
+            mode=ProgressWatchdogMode.ENFORCE,
+            budget=5.0,
+            on_stall=stalls,
+            step=1.0,
+            ticks=40,
+        )
+
+        # The allowance vouches to t+10; the stall clock then runs from the
+        # deadline, so the gap first reaches 5s at t+15.
+        assert run.beats == 15
+        assert stalls.calls == [(5.0, "")]
+
+    @pytest.mark.asyncio
+    async def test_beat_stays_unconditional_while_stalled(self) -> None:
+        """The keepalive is the crash detector; a stall must not gate it."""
+        clock = WatchdogClock()
+        tracker = ProgressTracker(clock=clock)
+
+        run = await _drive(
+            tracker=tracker,
+            clock=clock,
+            mode=ProgressWatchdogMode.WARN,
+            budget=1.0,
+            step=100.0,
+            ticks=5,
+        )
+
+        assert run.beats == 5
+
+    @pytest.mark.asyncio
+    async def test_on_stall_failure_stops_the_loop_anyway(self) -> None:
+        """If the handler can't fail the attempt, stop beating and let
+        Temporal's heartbeat_timeout reclaim it — never keep beating for an
+        attempt already judged wedged."""
+        clock = WatchdogClock()
+        tracker = ProgressTracker(clock=clock)
+        stalls = StallRecorder(raises=True)
+
+        run = await _drive(
+            tracker=tracker,
+            clock=clock,
+            mode=ProgressWatchdogMode.ENFORCE,
+            budget=5.0,
+            on_stall=stalls,
+            step=5.0,
+            ticks=20,
+        )
+
+        assert len(stalls.calls) == 1
+        assert run.beats == 1
+        assert any("Stall handler" in str(c) for c in run.stall_warnings)
+
+
+class TestStallWatchdogWarn:
+    @pytest.mark.asyncio
+    async def test_warn_reports_each_gap_once_and_never_fails(self) -> None:
+        clock = WatchdogClock()
+        tracker = ProgressTracker(clock=clock)
+        tracker.mark_progress("write_batch")
+        stalls = StallRecorder()
+
+        run = await _drive(
+            tracker=tracker,
+            clock=clock,
+            mode=ProgressWatchdogMode.WARN,
+            budget=5.0,
+            on_stall=stalls,
+            step=2.0,
+            ticks=12,
+        )
+
+        # Gaps of 6s open at ticks 3, 6, 9 and 12 — reported once each, not on
+        # every one of the 12 ticks, because reporting re-arms the stall clock.
+        assert len(run.stall_infos) == 4
+        assert not stalls.calls
+        assert run.beats == 12
+
+    @pytest.mark.asyncio
+    async def test_warn_never_logs_at_warning(self) -> None:
+        """A fleet-wide default that logged at WARNING would manufacture exactly
+        the alert noise ADR-0018 exists to reduce."""
+        clock = WatchdogClock()
+        tracker = ProgressTracker(clock=clock)
+
+        run = await _drive(
+            tracker=tracker,
+            clock=clock,
+            mode=ProgressWatchdogMode.WARN,
+            budget=5.0,
+            step=10.0,
+            ticks=4,
+        )
+
+        assert run.stall_infos
+        assert not run.stall_warnings
+
+    @pytest.mark.asyncio
+    async def test_re_arm_keeps_the_label_it_just_reported(self) -> None:
+        clock = WatchdogClock()
+        tracker = ProgressTracker(clock=clock)
+        tracker.mark_progress("fetch_page")
+
+        run = await _drive(
+            tracker=tracker,
+            clock=clock,
+            mode=ProgressWatchdogMode.WARN,
+            budget=5.0,
+            step=10.0,
+            ticks=3,
+        )
+
+        assert len(run.stall_infos) == 3
+        for call in run.stall_infos:
+            assert call.args[-1] == "fetch_page"
+        assert tracker.last_label == "fetch_page"
+
+    @pytest.mark.asyncio
+    async def test_unlabelled_gap_reads_as_none(self) -> None:
+        clock = WatchdogClock()
+        tracker = ProgressTracker(clock=clock)
+
+        run = await _drive(
+            tracker=tracker,
+            clock=clock,
+            mode=ProgressWatchdogMode.WARN,
+            budget=5.0,
+            step=10.0,
+            ticks=1,
+        )
+
+        assert run.stall_infos[0].args[-1] == "<none>"
+
+
+class TestStallWatchdogMetric:
+    @pytest.mark.asyncio
+    async def test_gap_is_recorded_with_task_label_and_mode(self) -> None:
+        clock = WatchdogClock()
+        tracker = ProgressTracker(clock=clock)
+        tracker.mark_progress("write_batch")
+
+        run = await _drive(
+            tracker=tracker,
+            clock=clock,
+            mode=ProgressWatchdogMode.WARN,
+            budget=5.0,
+            step=6.0,
+            ticks=1,
+        )
+
+        assert len(run.recorded) == 1
+        value, attributes = run.recorded[0].args
+        assert value == 6.0
+        assert attributes == {
+            "task.name": "extract",
+            "progress.last_label": "write_batch",
+            "watchdog.mode": "warn",
+        }
+
+    @pytest.mark.asyncio
+    async def test_enforced_gap_is_recorded_too(self) -> None:
+        clock = WatchdogClock()
+        tracker = ProgressTracker(clock=clock)
+
+        run = await _drive(
+            tracker=tracker,
+            clock=clock,
+            mode=ProgressWatchdogMode.ENFORCE,
+            budget=5.0,
+            on_stall=StallRecorder(),
+            step=5.0,
+            ticks=1,
+        )
+
+        assert len(run.recorded) == 1
+        assert run.recorded[0].args[1]["watchdog.mode"] == "enforce"
+
+    @pytest.mark.asyncio
+    async def test_metric_failure_never_breaks_the_watchdog(self) -> None:
+        clock = WatchdogClock()
+        tracker = ProgressTracker(clock=clock)
+        stalls = StallRecorder()
+
+        run = await _drive(
+            tracker=tracker,
+            clock=clock,
+            mode=ProgressWatchdogMode.ENFORCE,
+            budget=5.0,
+            on_stall=stalls,
+            step=5.0,
+            ticks=10,
+            record_raises=True,
+        )
+
+        assert stalls.calls == [(5.0, "")]
+        assert any("gap metric" in str(c) for c in run.stall_warnings)
+
+
+class TestStallWatchdogWiring:
+    @pytest.mark.asyncio
+    async def test_enforce_without_a_handler_downgrades_to_warn(self) -> None:
+        """A wiring bug must not silence the watchdog, and must not let it
+        pretend it enforced."""
+        clock = WatchdogClock()
+        tracker = ProgressTracker(clock=clock)
+
+        run = await _drive(
+            tracker=tracker,
+            clock=clock,
+            mode=ProgressWatchdogMode.ENFORCE,
+            budget=5.0,
+            on_stall=None,
+            step=10.0,
+            ticks=3,
+        )
+
+        assert any("no on_stall handler" in str(c) for c in run.stall_warnings)
+        assert len(run.stall_infos) == 3
+        assert run.beats == 3
+        assert all(c.args[1]["watchdog.mode"] == "warn" for c in run.recorded)
+
+    @pytest.mark.asyncio
+    async def test_non_positive_budget_disables_the_watchdog(self) -> None:
+        """One bad config value must not become a fleet-wide kill switch."""
+        clock = WatchdogClock()
+        tracker = ProgressTracker(clock=clock)
+        stalls = StallRecorder()
+
+        run = await _drive(
+            tracker=tracker,
+            clock=clock,
+            mode=ProgressWatchdogMode.ENFORCE,
+            budget=0.0,
+            on_stall=stalls,
+            step=10.0,
+            ticks=3,
+        )
+
+        assert any("non-positive" in str(c) for c in run.stall_warnings)
+        assert not stalls.calls
+        assert not run.stall_infos and not run.recorded
+        assert run.beats == 3

--- a/tests/unit/execution/test_heartbeat.py
+++ b/tests/unit/execution/test_heartbeat.py
@@ -964,3 +964,53 @@ class TestStallWatchdogWiring:
         assert not stalls.calls
         assert not run.stall_infos and not run.recorded
         assert run.beats == 3
+
+    @pytest.mark.asyncio
+    async def test_negative_budget_disables_the_watchdog(self) -> None:
+        """A negative allowance vouches for nothing: the guard must refuse it
+        the same way it refuses zero."""
+        clock = WatchdogClock()
+        tracker = ProgressTracker(clock=clock)
+        stalls = StallRecorder()
+
+        run = await _drive(
+            tracker=tracker,
+            clock=clock,
+            mode=ProgressWatchdogMode.ENFORCE,
+            budget=-5.0,
+            on_stall=stalls,
+            step=10.0,
+            ticks=3,
+        )
+
+        assert any("non-positive" in str(c) for c in run.stall_warnings)
+        assert not stalls.calls
+        assert not run.stall_infos and not run.recorded
+        assert run.beats == 3
+
+    @pytest.mark.asyncio
+    async def test_non_finite_budget_disables_the_watchdog(self) -> None:
+        """NaN slips past a `<= 0` check (every comparison against NaN is
+        False) and +inf would silently never enforce — both must disable the
+        watchdog like any other invalid budget."""
+        for bad_budget in (float("nan"), float("inf")):
+            clock = WatchdogClock()
+            tracker = ProgressTracker(clock=clock)
+            stalls = StallRecorder()
+
+            run = await _drive(
+                tracker=tracker,
+                clock=clock,
+                mode=ProgressWatchdogMode.ENFORCE,
+                budget=bad_budget,
+                on_stall=stalls,
+                step=10.0,
+                ticks=3,
+            )
+
+            assert any(
+                "non-positive" in str(c) for c in run.stall_warnings
+            ), f"budget={bad_budget} did not trip the guard"
+            assert not stalls.calls, f"budget={bad_budget} enforced a stall"
+            assert not run.stall_infos and not run.recorded
+            assert run.beats == 3


### PR DESCRIPTION
> **Stacked on #3145** (FND-283, `chrishehim/fnd-283`) — review that one first; this PR's diff is only the two files below plus the enum. Retarget to `main` once #3145 merges.

Implements [FND-286](https://linear.app/atlan-epd/issue/FND-286/stall-watchdog-inside-the-auto-heartbeat-loop-max-no-progress-seconds) — the ADR-0018 detector itself, added to `auto_heartbeat_loop` in `execution/heartbeat.py`. It consumes the `ProgressTracker` from #3145 and answers, once per tick, *has this attempt done anything observable lately?*

## What this adds

**`ProgressWatchdogMode`** (`execution/progress.py`) — `off` / `warn` / `enforce`. Three states, not two, because the watchdog is also the audit tool that tells an app where it needs holds — a job that only works if it can observe without being able to fail anything. A `SerializableEnum` (`StrEnum`) rather than a plain `Enum`: the mode ends up on the task's Temporal payload alongside `heartbeat_timeout_seconds`, and it is used directly as a metric attribute value.

**The watchdog in the loop** — four new keyword-only params on `auto_heartbeat_loop` (`progress`, `max_no_progress_seconds`, `watchdog_mode`, `on_stall`), all defaulting to inert. The existing beat, event-loop-block warning and memory sampling are byte-for-byte unchanged:

- `hb.heartbeat_keepalive()` stays **unconditional**. It is the crash detector (OOM, SIGKILL, node loss, partition, starved loop), `heartbeat_timeout` keeps its 60s default and its current meaning, and a stall never gates it (tested). Making the beat conditional on progress is Option 5 in the ADR and was rejected.
- Every gap at or past the budget is **always** recorded as a metric, in both modes: `task.no_progress_gap` (histogram, seconds) with `task.name`, `progress.last_label` and `watchdog.mode`. A histogram because the fleet-wide *distribution* is what sizes `max_no_progress_seconds` (M3); `watchdog.mode` because warn observations and enforced kills must aggregate separately.
- **enforce**: log at WARNING, call `on_stall(stalled_for, last_label)`, `return` immediately — the watchdog *is* `heartbeat_task`, and the activity's `finally` sets `stop_event` and awaits it with a 1s bound.
- **warn**: log at **INFO** — never WARNING — then `mark_progress()` with an empty label to re-arm, so each gap is reported once rather than every tick, and the label just reported survives into the next report.
- `on_stall` is **injected**, the same way `heartbeat_fn` already is, so `heartbeat.py` stays free of activity/Temporal semantics and the watchdog is unit-testable without a worker.

## Scope: no `activities.py` wiring yet

The ADR says `on_stall` is injected by `activities.py`, and it will be — but that injection needs `TaskStalledError` and the stall branch in the cancellation handler (FND-289), the ContextVar that makes the tracker reachable (FND-287), and the `progress_watchdog` flag on `TaskMetadata` (FND-296). None exist yet, so wiring here would be a half-connected seam. This PR ships the detector alone, fully tested, exactly as #3145 shipped the tracker alone. **On this branch nothing constructs a tracker, so the watchdog is unreachable in production — the behaviour change is zero.**

## Decisions a reviewer should look at

**1. The watchdog runs last in the tick, after memory sampling.** The ADR sketch shows it after the beat, but the sketch also shows memory sampling before the beat, which is not what the real loop does — so "last in the tick" is what the sketch means. Concretely: the beat is the crash detector and must go out first, and an enforced stall returns from the watchdog, so running it last means the tick that kills a wedged attempt still carries that attempt's last memory observation — "wedged *and* at 95% of its limit" is exactly what an operator wants on that line.

**2. `enforce` with no `on_stall` downgrades to warn rather than raising or going silent.** That combination is a wiring bug, not a config choice. Raising would make the watchdog the thing that fails an activity — the one thing it must never be — and silently skipping would lose the gap entirely. The downgrade happens once at loop entry rather than per-check, so the metric's `watchdog.mode` attribute describes what the watchdog *actually did* instead of claiming an enforcement that never happened.

**3. A non-positive budget disables the watchdog, with a WARNING.** A budget of zero makes every attempt stall on its first tick, so honouring it in enforce mode would turn one bad config value into a fleet-wide kill switch. Refuse rather than obey — the same posture as the tracker's handling of a negative hold allowance in #3145.

**4. If `on_stall` itself raises, the loop stops anyway.** The attempt was not failed in-process, so the alternative is to keep beating for an attempt already judged wedged — the exact status quo this ADR exists to end. Stopping the loop stops the beat, which hands the attempt to Temporal's `heartbeat_timeout` (60s): a bounded, well-understood reclaim rather than an unbounded limp. Logged at WARNING with the traceback, since it means the stall plumbing is broken.

**5. Metric emission is best-effort and never raises.** A metric-backend problem must not fail the activity the watchdog is only observing; the stall is still logged and enforced, and the WARNING says the observation will be missing from the fleet distribution.

**6. No `conformance: ignore[E004]` markers on the new `except Exception` blocks.** Both log at WARNING with `exc_info=True`, which E004 already accepts — verified empirically by stripping the markers and re-running detect. An inert suppression reads as "this code violates a rule" and would hide a future genuine violation at that site. (#3145's equivalent marker in `progress.py` is likewise inert; left alone here rather than reaching into that PR's file.)

## Tests

`tests/unit/execution/test_heartbeat.py` — 20 new tests, no worker, no patched global clock (a typed `WatchdogClock` the test advances from inside the heartbeat fn, so the loop's own `time.monotonic` is untouched). Covers: inert in all three "not configured" shapes; the gap firing at the budget and stopping the loop; detection latency of budget + at most one tick; progress re-arming the clock; an unbounded hold suppressing the stall; a lapsed bounded hold firing at `allowance + budget`; the beat staying unconditional while stalled; `on_stall` raising; warn reporting once per gap across 12 ticks and never at WARNING; the re-armed label surviving; `<none>` for an unlabelled gap; metric value and all three dimensions in both modes; a failing metric backend; the enforce-without-handler downgrade; and the non-positive budget guard.

- `uv run pytest tests/unit` — 6599 passed, 9 skipped
- `uv run pre-commit run --files ...` — ruff, ruff-format, isort, pyright clean
- Full conformance suite — no new findings in the changed files (the four unsuppressed hits in `heartbeat.py` are pre-existing and untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
