### PR TITLE
feat(execution): reach the ProgressTracker from anywhere in the attempt (FND-287)

### DIFF
--- a/application_sdk/execution/_temporal/activities.py
+++ b/application_sdk/execution/_temporal/activities.py
@@ -143,6 +143,11 @@ def create_activity_from_task(
             TemporalHeartbeatController,
             auto_heartbeat_loop,
         )
+        from application_sdk.execution.progress import (  # noqa: PLC0415 — circular: execution/__init__.py loads sibling modules + app.base imports execution
+            ProgressTracker,
+            reset_progress_tracker,
+            set_progress_tracker,
+        )
 
         app_registry = AppRegistry.get_instance()
         app_metadata = app_registry.get(context.app_name)
@@ -193,6 +198,15 @@ def create_activity_from_task(
             heartbeat_controller=heartbeat_controller,
         )
         app_instance._task_context = task_exec_context
+
+        # One tracker per attempt, bound to the context before anything can
+        # report progress into it. Created unconditionally — deliberately not
+        # gated on heartbeat_timeout_seconds, since the stall watchdog is what
+        # bounds a wedged attempt on a task that has heartbeating disabled.
+        # The binding is what makes it reachable from the framework hooks,
+        # `run_in_thread` and `holding_progress()`, none of which is handed a
+        # reference (ADR-0018 → *Feeding the tracker*).
+        tracker_token = set_progress_tracker(ProgressTracker())
 
         stop_event = asyncio.Event()
         heartbeat_task = None
@@ -346,6 +360,11 @@ def create_activity_from_task(
                         logger.debug(
                             "Heartbeat task did not cancel cleanly", exc_info=True
                         )
+
+            # Unbind in the same context that bound it, so a caller that invokes
+            # the activity body directly (a local run, a unit test) is left with
+            # whatever tracker it had, rather than this attempt's.
+            reset_progress_tracker(tracker_token)
 
             app_instance._task_context = None
             app_instance._context = None

--- a/application_sdk/execution/_temporal/activities.py
+++ b/application_sdk/execution/_temporal/activities.py
@@ -145,8 +145,7 @@ def create_activity_from_task(
         )
         from application_sdk.execution.progress import (  # noqa: PLC0415 — circular: execution/__init__.py loads sibling modules + app.base imports execution
             ProgressTracker,
-            reset_progress_tracker,
-            set_progress_tracker,
+            bind_progress_tracker,
         )
 
         app_registry = AppRegistry.get_instance()
@@ -199,180 +198,186 @@ def create_activity_from_task(
         )
         app_instance._task_context = task_exec_context
 
-        # One tracker per attempt, bound to the context before anything can
-        # report progress into it. Created unconditionally — deliberately not
-        # gated on heartbeat_timeout_seconds, since the stall watchdog is what
-        # bounds a wedged attempt on a task that has heartbeating disabled.
-        # The binding is what makes it reachable from the framework hooks,
-        # `run_in_thread` and `holding_progress()`, none of which is handed a
-        # reference (ADR-0018 → *Feeding the tracker*).
+        # One tracker per attempt, bound for the extent of the body. Created
+        # unconditionally — deliberately not gated on heartbeat_timeout_seconds,
+        # since the stall watchdog is what bounds a wedged attempt on a task
+        # that has heartbeating disabled. The binding is what makes it reachable
+        # from the framework hooks, `run_in_thread` and `holding_progress()`,
+        # none of which is handed a reference (ADR-0018 → *Feeding the
+        # tracker*).
+        #
+        # A block rather than a set/reset pair: no path out of the body can
+        # leave a dead attempt's tracker bound to this context — not a raise
+        # from `create_task` while the loop is closing, and not a
+        # `CancelledError` (a `BaseException`) landing in the cleanup below.
         stop_event = asyncio.Event()
         heartbeat_task = None
 
-        tracker_token = set_progress_tracker(ProgressTracker())
-
-        try:
-            if (
-                context.heartbeat_timeout_seconds is not None
-                and context.auto_heartbeat_seconds is not None
-            ):
-                heartbeat_task = asyncio.create_task(
-                    auto_heartbeat_loop(
-                        interval_seconds=context.auto_heartbeat_seconds,
-                        heartbeat_fn=heartbeat_controller.heartbeat_keepalive,
-                        stop_event=stop_event,
-                        task_name=context.task_name,
-                    )
-                )
-
-            from application_sdk.storage.file_ref_sync import (  # noqa: PLC0415 — circular: execution/__init__.py loads sibling modules + app.base imports execution
-                has_refs_to_materialize,
-                has_refs_to_persist,
-                materialize_file_refs,
-                persist_file_refs,
-            )
-
-            method_name = getattr(task_metadata.func, "__name__", task_metadata.name)
-            task_method = getattr(app_instance, method_name)
-
-            # Resolve the store once for both FileReference hooks.
-            store = infra.storage if infra is not None else None
-
-            # Materialise any durable FileReferences in the input before the task runs.
-            if store is not None and has_refs_to_materialize(input_data):
-                input_data = await materialize_file_refs(store, input_data)
-
-            result = await task_method(input_data)
-
-            # Persist any ephemeral FileReferences in the output after the task completes.
-            if store is not None and has_refs_to_persist(result):
-                from application_sdk.execution._temporal.activity_utils import (  # noqa: PLC0415 — circular: execution/__init__.py loads sibling modules + app.base imports execution
-                    build_output_path,
-                )
-
-                try:
-                    output_path: str | None = build_output_path()
-                except Exception:
-                    logger.warning(
-                        "build_output_path() failed, proceeding without output path",
-                        exc_info=True,
-                    )
-                    output_path = None
-                result = await persist_file_refs(store, result, output_path=output_path)
-
-            # Track all FileReference local paths for on_complete() cleanup.
-            from application_sdk.storage.file_ref_sync import (  # noqa: PLC0415 — circular: execution/__init__.py loads sibling modules + app.base imports execution
-                _find_file_refs,
-            )
-
-            all_refs = _find_file_refs(input_data) + _find_file_refs(result)
-            if all_refs:
-                _track_file_refs(context.workflow_id, *all_refs)
-
-            return cast("Output", result)
-
-        except asyncio.CancelledError as e:
-            # In Python 3.8+, ``asyncio.CancelledError`` extends ``BaseException``,
-            # so it bypasses the ``except Exception`` block below. We must catch
-            # it explicitly to attribute pod-termination cancels to
-            # ``ApplicationError(type=WORKER_EVICTED_TYPE)`` and let other cancels propagate as today.
-            #
-            # NOTE: converting ``CancelledError`` to a regular exception
-            # technically violates asyncio's cancellation protocol — the
-            # task ends in done-with-exception state instead of cancelled,
-            # so callers keying on ``Task.cancelled()`` would observe False.
-            # In practice this only fires during graceful worker shutdown,
-            # where the only consumer is Temporal's activity wrapper (which
-            # records the failure on the wire as ``ApplicationError`` — the
-            # exact behaviour we want so the workflow-side eviction loop can
-            # re-dispatch). The activity's ``finally`` block still runs for
-            # heartbeat cleanup. If we ever surface this swap to a plain
-            # asyncio caller, we'd need to relocate it to a Temporal
-            # interceptor instead.
-            from application_sdk.execution.shutdown import (  # noqa: PLC0415 — circular: execution/__init__.py loads sibling modules + app.base imports execution
-                is_worker_shutting_down,
-            )
-
-            if is_worker_shutting_down():
-                from application_sdk.errors.leaves import (  # noqa: PLC0415 — circular: execution/__init__.py loads sibling modules + errors imports observability transitively
-                    WORKER_EVICTED_TYPE,
-                )
-                from application_sdk.execution.errors import (  # noqa: PLC0415 — circular: execution/__init__.py loads sibling modules + app.base imports execution
-                    ApplicationError,
-                )
-
-                _sever_cause_chain(e)
-                raise ApplicationError(
-                    "Activity terminated because the worker pod is shutting down",
-                    type=WORKER_EVICTED_TYPE,
-                    non_retryable=True,
-                ) from e
-            raise
-
-        # conformance: ignore[E004] exception translator: both branches re-raise; nothing is swallowed
-        except Exception as e:
-            from application_sdk.errors.base import (  # noqa: PLC0415 — circular
-                AppError as _AppError,
-            )
-
-            if isinstance(e, _AppError):
-                from application_sdk.execution.errors import (  # noqa: PLC0415 — circular
-                    ApplicationError,
-                )
-
-                # Guard FailureDetails construction: evidence fields may contain
-                # non-serialisable values; fall back to details-free ApplicationError
-                # rather than letting a secondary error mask the original.
-                try:
-                    details: tuple[Any, ...] = (e.to_failure_details(),)
-                except Exception:
-                    logger.warning(
-                        "Failed to build FailureDetails for %s; raising without structured details",
-                        type(e).__name__,
-                        exc_info=True,
-                    )
-                    details = ()
-
-                # Sever deep / cyclic __cause__ / __context__ chains before
-                # Temporal's failure serializer walks them (BLDX-1512).
-                _sever_cause_chain(e)
-
-                raise ApplicationError(
-                    str(e),
-                    *details,
-                    type=type(e).__name__,
-                    non_retryable=not e.effective_retryable,
-                ) from e
-            raise
-
-        finally:
+        with bind_progress_tracker(ProgressTracker()):
             try:
-                if heartbeat_task is not None:
-                    stop_event.set()
-                    try:
-                        await asyncio.wait_for(heartbeat_task, timeout=1.0)
-                    # conformance: ignore[E004] cleanup path cancelling heartbeat task in finally; all exceptions handled by inner cancel+log
-                    except (TimeoutError, Exception):
-                        heartbeat_task.cancel()
-                        try:
-                            await heartbeat_task
-                        # conformance: ignore[E004] heartbeat cancel cleanup in finally; debug-logged with exc_info; swallow is intentional
-                        except Exception:
-                            logger.debug(
-                                "Heartbeat task did not cancel cleanly", exc_info=True
-                            )
-            finally:
-                # Unbind in the same context that bound it, so a caller that
-                # invokes the activity body directly (a local run, a unit test)
-                # is left with whatever tracker it had, rather than this
-                # attempt's. The nested finally guarantees the reset runs even
-                # when the activity's cancellation lands during the heartbeat
-                # cleanup above (``CancelledError`` is a ``BaseException`` and
-                # would otherwise skip straight past the unbind).
-                reset_progress_tracker(tracker_token)
+                if (
+                    context.heartbeat_timeout_seconds is not None
+                    and context.auto_heartbeat_seconds is not None
+                ):
+                    heartbeat_task = asyncio.create_task(
+                        auto_heartbeat_loop(
+                            interval_seconds=context.auto_heartbeat_seconds,
+                            heartbeat_fn=heartbeat_controller.heartbeat_keepalive,
+                            stop_event=stop_event,
+                            task_name=context.task_name,
+                        )
+                    )
 
-                app_instance._task_context = None
-                app_instance._context = None
+                from application_sdk.storage.file_ref_sync import (  # noqa: PLC0415 — circular: execution/__init__.py loads sibling modules + app.base imports execution
+                    has_refs_to_materialize,
+                    has_refs_to_persist,
+                    materialize_file_refs,
+                    persist_file_refs,
+                )
+
+                method_name = getattr(
+                    task_metadata.func, "__name__", task_metadata.name
+                )
+                task_method = getattr(app_instance, method_name)
+
+                # Resolve the store once for both FileReference hooks.
+                store = infra.storage if infra is not None else None
+
+                # Materialise any durable FileReferences in the input before the task runs.
+                if store is not None and has_refs_to_materialize(input_data):
+                    input_data = await materialize_file_refs(store, input_data)
+
+                result = await task_method(input_data)
+
+                # Persist any ephemeral FileReferences in the output after the task completes.
+                if store is not None and has_refs_to_persist(result):
+                    from application_sdk.execution._temporal.activity_utils import (  # noqa: PLC0415 — circular: execution/__init__.py loads sibling modules + app.base imports execution
+                        build_output_path,
+                    )
+
+                    try:
+                        output_path: str | None = build_output_path()
+                    except Exception:
+                        logger.warning(
+                            "build_output_path() failed, proceeding without output path",
+                            exc_info=True,
+                        )
+                        output_path = None
+                    result = await persist_file_refs(
+                        store, result, output_path=output_path
+                    )
+
+                # Track all FileReference local paths for on_complete() cleanup.
+                from application_sdk.storage.file_ref_sync import (  # noqa: PLC0415 — circular: execution/__init__.py loads sibling modules + app.base imports execution
+                    _find_file_refs,
+                )
+
+                all_refs = _find_file_refs(input_data) + _find_file_refs(result)
+                if all_refs:
+                    _track_file_refs(context.workflow_id, *all_refs)
+
+                return cast("Output", result)
+
+            except asyncio.CancelledError as e:
+                # In Python 3.8+, ``asyncio.CancelledError`` extends ``BaseException``,
+                # so it bypasses the ``except Exception`` block below. We must catch
+                # it explicitly to attribute pod-termination cancels to
+                # ``ApplicationError(type=WORKER_EVICTED_TYPE)`` and let other cancels propagate as today.
+                #
+                # NOTE: converting ``CancelledError`` to a regular exception
+                # technically violates asyncio's cancellation protocol — the
+                # task ends in done-with-exception state instead of cancelled,
+                # so callers keying on ``Task.cancelled()`` would observe False.
+                # In practice this only fires during graceful worker shutdown,
+                # where the only consumer is Temporal's activity wrapper (which
+                # records the failure on the wire as ``ApplicationError`` — the
+                # exact behaviour we want so the workflow-side eviction loop can
+                # re-dispatch). The activity's ``finally`` block still runs for
+                # heartbeat cleanup. If we ever surface this swap to a plain
+                # asyncio caller, we'd need to relocate it to a Temporal
+                # interceptor instead.
+                from application_sdk.execution.shutdown import (  # noqa: PLC0415 — circular: execution/__init__.py loads sibling modules + app.base imports execution
+                    is_worker_shutting_down,
+                )
+
+                if is_worker_shutting_down():
+                    from application_sdk.errors.leaves import (  # noqa: PLC0415 — circular: execution/__init__.py loads sibling modules + errors imports observability transitively
+                        WORKER_EVICTED_TYPE,
+                    )
+                    from application_sdk.execution.errors import (  # noqa: PLC0415 — circular: execution/__init__.py loads sibling modules + app.base imports execution
+                        ApplicationError,
+                    )
+
+                    _sever_cause_chain(e)
+                    raise ApplicationError(
+                        "Activity terminated because the worker pod is shutting down",
+                        type=WORKER_EVICTED_TYPE,
+                        non_retryable=True,
+                    ) from e
+                raise
+
+            # conformance: ignore[E004] exception translator: both branches re-raise; nothing is swallowed
+            except Exception as e:
+                from application_sdk.errors.base import (  # noqa: PLC0415 — circular
+                    AppError as _AppError,
+                )
+
+                if isinstance(e, _AppError):
+                    from application_sdk.execution.errors import (  # noqa: PLC0415 — circular
+                        ApplicationError,
+                    )
+
+                    # Guard FailureDetails construction: evidence fields may contain
+                    # non-serialisable values; fall back to details-free ApplicationError
+                    # rather than letting a secondary error mask the original.
+                    try:
+                        details: tuple[Any, ...] = (e.to_failure_details(),)
+                    except Exception:
+                        logger.warning(
+                            "Failed to build FailureDetails for %s; raising without structured details",
+                            type(e).__name__,
+                            exc_info=True,
+                        )
+                        details = ()
+
+                    # Sever deep / cyclic __cause__ / __context__ chains before
+                    # Temporal's failure serializer walks them (BLDX-1512).
+                    _sever_cause_chain(e)
+
+                    raise ApplicationError(
+                        str(e),
+                        *details,
+                        type=type(e).__name__,
+                        non_retryable=not e.effective_retryable,
+                    ) from e
+                raise
+
+            finally:
+                try:
+                    if heartbeat_task is not None:
+                        stop_event.set()
+                        try:
+                            await asyncio.wait_for(heartbeat_task, timeout=1.0)
+                        # conformance: ignore[E004] cleanup path cancelling heartbeat task in finally; all exceptions handled by inner cancel+log
+                        except (TimeoutError, Exception):
+                            heartbeat_task.cancel()
+                            try:
+                                await heartbeat_task
+                            # conformance: ignore[E004] heartbeat cancel cleanup in finally; debug-logged with exc_info; swallow is intentional
+                            except Exception:
+                                logger.debug(
+                                    "Heartbeat task did not cancel cleanly",
+                                    exc_info=True,
+                                )
+                finally:
+                    # Nested so the app-instance clears survive the heartbeat
+                    # cleanup above raising — in particular a ``CancelledError``,
+                    # which is a ``BaseException`` and would otherwise skip
+                    # straight past them. (The tracker needs no such guard: its
+                    # `with` block unbinds on every exit path, cancellation
+                    # included.)
+                    app_instance._task_context = None
+                    app_instance._context = None
 
     # Set type annotations with the actual input/output types from task metadata.
     # This is critical for Temporal to properly deserialize the input dataclass.

--- a/application_sdk/execution/_temporal/activities.py
+++ b/application_sdk/execution/_temporal/activities.py
@@ -206,25 +206,25 @@ def create_activity_from_task(
         # The binding is what makes it reachable from the framework hooks,
         # `run_in_thread` and `holding_progress()`, none of which is handed a
         # reference (ADR-0018 → *Feeding the tracker*).
-        tracker_token = set_progress_tracker(ProgressTracker())
-
         stop_event = asyncio.Event()
         heartbeat_task = None
 
-        if (
-            context.heartbeat_timeout_seconds is not None
-            and context.auto_heartbeat_seconds is not None
-        ):
-            heartbeat_task = asyncio.create_task(
-                auto_heartbeat_loop(
-                    interval_seconds=context.auto_heartbeat_seconds,
-                    heartbeat_fn=heartbeat_controller.heartbeat_keepalive,
-                    stop_event=stop_event,
-                    task_name=context.task_name,
-                )
-            )
+        tracker_token = set_progress_tracker(ProgressTracker())
 
         try:
+            if (
+                context.heartbeat_timeout_seconds is not None
+                and context.auto_heartbeat_seconds is not None
+            ):
+                heartbeat_task = asyncio.create_task(
+                    auto_heartbeat_loop(
+                        interval_seconds=context.auto_heartbeat_seconds,
+                        heartbeat_fn=heartbeat_controller.heartbeat_keepalive,
+                        stop_event=stop_event,
+                        task_name=context.task_name,
+                    )
+                )
+
             from application_sdk.storage.file_ref_sync import (  # noqa: PLC0415 — circular: execution/__init__.py loads sibling modules + app.base imports execution
                 has_refs_to_materialize,
                 has_refs_to_persist,
@@ -346,28 +346,33 @@ def create_activity_from_task(
             raise
 
         finally:
-            if heartbeat_task is not None:
-                stop_event.set()
-                try:
-                    await asyncio.wait_for(heartbeat_task, timeout=1.0)
-                # conformance: ignore[E004] cleanup path cancelling heartbeat task in finally; all exceptions handled by inner cancel+log
-                except (TimeoutError, Exception):
-                    heartbeat_task.cancel()
+            try:
+                if heartbeat_task is not None:
+                    stop_event.set()
                     try:
-                        await heartbeat_task
-                    # conformance: ignore[E004] heartbeat cancel cleanup in finally; debug-logged with exc_info; swallow is intentional
-                    except Exception:
-                        logger.debug(
-                            "Heartbeat task did not cancel cleanly", exc_info=True
-                        )
+                        await asyncio.wait_for(heartbeat_task, timeout=1.0)
+                    # conformance: ignore[E004] cleanup path cancelling heartbeat task in finally; all exceptions handled by inner cancel+log
+                    except (TimeoutError, Exception):
+                        heartbeat_task.cancel()
+                        try:
+                            await heartbeat_task
+                        # conformance: ignore[E004] heartbeat cancel cleanup in finally; debug-logged with exc_info; swallow is intentional
+                        except Exception:
+                            logger.debug(
+                                "Heartbeat task did not cancel cleanly", exc_info=True
+                            )
+            finally:
+                # Unbind in the same context that bound it, so a caller that
+                # invokes the activity body directly (a local run, a unit test)
+                # is left with whatever tracker it had, rather than this
+                # attempt's. The nested finally guarantees the reset runs even
+                # when the activity's cancellation lands during the heartbeat
+                # cleanup above (``CancelledError`` is a ``BaseException`` and
+                # would otherwise skip straight past the unbind).
+                reset_progress_tracker(tracker_token)
 
-            # Unbind in the same context that bound it, so a caller that invokes
-            # the activity body directly (a local run, a unit test) is left with
-            # whatever tracker it had, rather than this attempt's.
-            reset_progress_tracker(tracker_token)
-
-            app_instance._task_context = None
-            app_instance._context = None
+                app_instance._task_context = None
+                app_instance._context = None
 
     # Set type annotations with the actual input/output types from task metadata.
     # This is critical for Temporal to properly deserialize the input dataclass.

--- a/application_sdk/execution/progress.py
+++ b/application_sdk/execution/progress.py
@@ -29,8 +29,8 @@ tracker — the SDK's transfer loops, a blocking call offloaded through
 ``run_in_thread``, an app's own ``holding_progress`` block. They reach the
 current attempt's tracker through the ContextVar in this module:
 :func:`current_progress_tracker` for consumers, and
-:func:`set_progress_tracker` / :func:`reset_progress_tracker` for
-``activities.py``, which owns one tracker per activity attempt.
+:func:`bind_progress_tracker` for ``activities.py``, which owns one tracker per
+activity attempt.
 
 The watchdog that consumes the tracker lives in
 :func:`~application_sdk.execution.heartbeat.auto_heartbeat_loop` and runs in one
@@ -46,8 +46,9 @@ from __future__ import annotations
 
 import threading
 import time
-from collections.abc import Callable
-from contextvars import ContextVar, Token
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
 from dataclasses import dataclass
 
 from application_sdk.contracts.base import SerializableEnum
@@ -425,32 +426,36 @@ def current_progress_tracker() -> ProgressTracker:
     return _INERT_TRACKER if tracker is None else tracker
 
 
-def set_progress_tracker(tracker: ProgressTracker) -> Token[ProgressTracker | None]:
-    """Bind ``tracker`` as the current attempt's tracker.
+@contextmanager
+def bind_progress_tracker(tracker: ProgressTracker) -> Iterator[ProgressTracker]:
+    """Bind ``tracker`` as the current attempt's tracker for the block's extent.
 
-    Called once per activity attempt by
-    ``application_sdk.execution._temporal.activities``, which owns the
-    tracker's lifetime. Each activity runs as its own asyncio task with its own
-    copy of the context, so concurrent activities in one worker bind their own
-    tracker and never observe each other's.
+    Entered once per activity attempt by
+    ``application_sdk.execution._temporal.activities``, which owns the tracker's
+    lifetime. Each activity runs as its own asyncio task with its own copy of
+    the context, so concurrent activities in one worker bind their own tracker
+    and never observe each other's.
+
+    A block rather than a ``set``/``reset`` pair, because a bind that outlives
+    its attempt is a silent bug of exactly the wrong shape: the next caller in
+    that context reports progress into a finished attempt's tracker, and pairing
+    an ``enter_hold`` across the boundary releases the wrong deadline. Nothing
+    here can leave a binding behind, and there is no token for a caller to
+    mislay — the pairing is not something a call site can get wrong.
+
+    Restores whatever was bound before, so a nested bind — or a test binding its
+    own tracker — leaves the caller's binding intact.
 
     Args:
         tracker: The tracker for this attempt.
 
-    Returns:
-        A token to pass to :func:`reset_progress_tracker` when the attempt ends.
+    Yields:
+        The same ``tracker``, so the owner can hold on to it for the pieces that
+        take it by injection rather than through the ContextVar (the stall
+        watchdog in ``auto_heartbeat_loop``).
     """
-    return _progress_tracker.set(tracker)
-
-
-def reset_progress_tracker(token: Token[ProgressTracker | None]) -> None:
-    """Unbind the tracker :func:`set_progress_tracker` bound.
-
-    Must be called in the same context that set it (in practice, the activity
-    body's ``finally``). Restores whatever was bound before, so a nested attempt
-    — or a test that binds its own tracker — leaves the caller's binding intact.
-
-    Args:
-        token: The token returned by :func:`set_progress_tracker`.
-    """
-    _progress_tracker.reset(token)
+    token = _progress_tracker.set(tracker)
+    try:
+        yield tracker
+    finally:
+        _progress_tracker.reset(token)

--- a/application_sdk/execution/progress.py
+++ b/application_sdk/execution/progress.py
@@ -24,12 +24,22 @@ Two signals feed it (see ADR-0018 → *Feeding the tracker*):
   at the one call site that knows, or declares nothing and gets an unbounded
   hold that the duration backstop owns.
 
+Both signals are produced deep inside code that has no reference to the
+tracker — the SDK's transfer loops, a blocking call offloaded through
+``run_in_thread``, an app's own ``holding_progress`` block. They reach the
+current attempt's tracker through the ContextVar in this module:
+:func:`current_progress_tracker` for consumers, and
+:func:`set_progress_tracker` / :func:`reset_progress_tracker` for
+``activities.py``, which owns one tracker per activity attempt.
+
 The watchdog that consumes the tracker lives in
 :func:`~application_sdk.execution.heartbeat.auto_heartbeat_loop` and runs in one
-of the three :class:`ProgressWatchdogMode` states. The ContextVar plumbing that
-makes the tracker reachable from app code (FND-287), the framework hooks
-(FND-288) and the warn-mode telemetry that consumes :class:`ClosedHold`
-(FND-292) are separate pieces built on this one.
+of the three :class:`ProgressWatchdogMode` states. It is handed the tracker by
+injection rather than reading the ContextVar, so it stays unit-testable without
+an activity. The framework hooks (FND-288), the ``run_in_thread`` auto-holds
+(FND-290), the public ``holding_progress()`` context manager (FND-291) and the
+warn-mode telemetry that consumes :class:`ClosedHold` (FND-292) are separate
+pieces built on this one.
 """
 
 from __future__ import annotations
@@ -37,6 +47,7 @@ from __future__ import annotations
 import threading
 import time
 from collections.abc import Callable
+from contextvars import ContextVar, Token
 from dataclasses import dataclass
 
 from application_sdk.contracts.base import SerializableEnum
@@ -325,3 +336,121 @@ class ProgressTracker:
                 closed.duration_seconds,
                 exc_info=True,
             )
+
+
+class _InertProgressTracker(ProgressTracker):
+    """The no-tracker case, as a well-defined no-op.
+
+    Returned by :func:`current_progress_tracker` when no activity attempt owns
+    the current context: a local run, a unit test, an HTTP handler, the SDK's
+    own transfer loops called from a script. Progress signals from those callers
+    are recorded nowhere and no watchdog observes them, so the honest answer to
+    *"is anything vouching for this?"* and *"how long has it been quiet?"* is
+    ``False`` and ``0.0`` — not the process's uptime.
+
+    Existing as a null object rather than letting the accessor return ``None``
+    is deliberate: every consumer of the tracker is a paired
+    ``enter_hold`` / ``exit_hold`` or a bare ``mark_progress`` buried in a hot
+    loop, and a ``None`` check at each of those sites is the exact thing that
+    gets half-written. It mirrors ``NoopHeartbeatController``'s role on the
+    heartbeat path.
+
+    The mutators are overridden rather than inherited because this instance is a
+    process-wide singleton: inherited ``enter_hold`` would accumulate a hold per
+    never-exited token for the life of the process, and inherited
+    ``mark_progress`` would take a shared lock on every framework-hook call made
+    outside an activity.
+    """
+
+    def mark_progress(self, label: str = "") -> None:
+        """Discard the signal — nothing is observing this context."""
+
+    def enter_hold(self, label: str, timeout: float | None) -> int:
+        """Vouch for nothing, and hand back a token no real tracker can own.
+
+        Real tokens are non-negative, so if a consumer ever pairs this
+        ``enter_hold`` with a *real* tracker's ``exit_hold`` — the ContextVar
+        having been set in between — the mismatch is logged rather than silently
+        releasing somebody else's hold.
+        """
+        return -1
+
+    def exit_hold(self, token: int) -> None:
+        """Release nothing, and stay quiet: there was no hold to release."""
+
+    def held(self) -> bool:
+        """Always ``False`` — an inert tracker vouches for nothing."""
+        return False
+
+    def stalled_for(self) -> float:
+        """Always ``0.0`` — nothing is watching, so nothing is stalled."""
+        return 0.0
+
+
+_INERT_TRACKER = _InertProgressTracker()
+
+_progress_tracker: ContextVar[ProgressTracker | None] = ContextVar(
+    "progress_tracker", default=None
+)
+
+
+def current_progress_tracker() -> ProgressTracker:
+    """Get the :class:`ProgressTracker` for the current activity attempt.
+
+    The read seam for every progress producer — the framework hooks, the
+    ``run_in_thread`` auto-hold, ``holding_progress()`` — none of which is
+    handed the tracker by its caller.
+
+    Reachable from anywhere inside the attempt, including from a worker thread:
+    ``run_in_thread`` propagates the calling context via
+    ``contextvars.copy_context()``, so blocking work offloaded through it reads
+    the same tracker as the coroutine that offloaded it. Mutations inside that
+    thread stay in the thread's copy of the context (copy semantics), but the
+    tracker *object* is shared, so progress marked from the thread lands on the
+    attempt's tracker.
+
+    Returns:
+        The current attempt's tracker, or an inert one when no attempt owns this
+        context (local runs, unit tests, non-activity callers). Never ``None``
+        and never raises, so a caller outside an activity behaves exactly as it
+        did before this plumbing existed.
+
+    Note:
+        Callers that pair ``enter_hold`` with ``exit_hold`` must hold on to the
+        object this returns and call both on it, rather than calling this twice.
+        Re-reading picks up whatever tracker the context has by then, which for
+        a hold spanning a context change would release the wrong deadline.
+    """
+    tracker = _progress_tracker.get()
+    return _INERT_TRACKER if tracker is None else tracker
+
+
+def set_progress_tracker(tracker: ProgressTracker) -> Token[ProgressTracker | None]:
+    """Bind ``tracker`` as the current attempt's tracker.
+
+    Called once per activity attempt by
+    ``application_sdk.execution._temporal.activities``, which owns the
+    tracker's lifetime. Each activity runs as its own asyncio task with its own
+    copy of the context, so concurrent activities in one worker bind their own
+    tracker and never observe each other's.
+
+    Args:
+        tracker: The tracker for this attempt.
+
+    Returns:
+        A token to pass to :func:`reset_progress_tracker` when the attempt ends.
+    """
+    return _progress_tracker.set(tracker)
+
+
+def reset_progress_tracker(token: Token[ProgressTracker | None]) -> None:
+    """Unbind the tracker :func:`set_progress_tracker` bound.
+
+    Must be called in the same context that set it (in practice, the activity
+    body's ``finally``). Restores whatever was bound before, so a nested attempt
+    — or a test that binds its own tracker — leaves the caller's binding intact.
+
+    Args:
+        token: The token returned by :func:`set_progress_tracker`.
+    """
+    _progress_tracker.reset(token)

--- a/application_sdk/execution/progress.py
+++ b/application_sdk/execution/progress.py
@@ -44,6 +44,7 @@ pieces built on this one.
 
 from __future__ import annotations
 
+import itertools
 import threading
 import time
 from collections.abc import Callable, Iterator
@@ -140,6 +141,18 @@ class _Hold:
         return self.started_at + self.allowance_seconds
 
 
+# Hold tokens are process-wide unique, not per-tracker. A per-tracker counter
+# would let two concurrently bound trackers (a nested attempt, or a test binding
+# its own tracker inside an activity) both consider token 0 valid, so a consumer
+# that paired one tracker's enter_hold with another's exit_hold would silently
+# release the wrong hold. Drawing every token from one shared counter makes a
+# token collide with only its owning tracker, so a cross-tracker exit_hold hits
+# the unknown-token warning instead. `next()` on the counter is a single
+# thread-safe step, so allocation stays correct without taking each tracker's
+# lock.
+_token_counter = itertools.count()
+
+
 class ProgressTracker:
     """Observed forward progress for one activity attempt.
 
@@ -168,7 +181,6 @@ class ProgressTracker:
         self._last_label: str = ""
         self._last_at: float = clock()
         self._holds: dict[int, _Hold] = {}
-        self._next_token: int = 0
         # Mutations are not confined to the event loop: contextvars propagate
         # into `run_in_thread`, so framework hooks and `context.heartbeat()`
         # inside an offloaded blocking call reach this object from a worker
@@ -222,7 +234,12 @@ class ProgressTracker:
             An opaque token to pass to :meth:`exit_hold`. Holds are keyed by
             token, never popped off a stack, so concurrent holds in one
             activity — ``asyncio.gather`` over several ``run_in_thread``
-            calls — cannot release each other's deadlines.
+            calls — cannot release each other's deadlines. Tokens are drawn
+            from a process-wide counter rather than a per-tracker one, so a
+            token is unique across every live tracker: a consumer that pairs
+            this ``enter_hold`` with a *different* tracker's :meth:`exit_hold`
+            (a rebind in between) hits the unknown-token warning instead of
+            silently releasing that tracker's hold.
         """
         if timeout is not None and timeout < 0:
             logger.warning(
@@ -232,9 +249,8 @@ class ProgressTracker:
                 timeout,
             )
         now = self._clock()
+        token = next(_token_counter)
         with self._lock:
-            token = self._next_token
-            self._next_token += 1
             self._holds[token] = _Hold(
                 label=label, started_at=now, allowance_seconds=timeout
             )

--- a/tests/unit/execution/test_progress.py
+++ b/tests/unit/execution/test_progress.py
@@ -247,6 +247,47 @@ class TestConcurrentHolds:
         assert len(tokens) == 8 * 200
         assert len(set(tokens)) == len(tokens)
 
+    def test_tokens_are_unique_across_live_trackers(self) -> None:
+        """Tokens come from a process-wide counter, not a per-tracker one.
+
+        Two concurrently bound trackers (a nested attempt, or a test binding its
+        own tracker inside an activity) must never both own the same token —
+        otherwise a consumer pairing one tracker's ``enter_hold`` with the
+        other's ``exit_hold`` would silently release the wrong hold.
+        """
+        clock = FakeClock()
+        first = _tracker(clock)
+        second = _tracker(clock)
+
+        first_token = first.enter_hold("query on first", None)
+        second_token = second.enter_hold("query on second", None)
+
+        assert first_token != second_token
+
+    def test_cross_tracker_exit_does_not_release_the_hold(self) -> None:
+        """A token from one tracker is unknown to another live tracker.
+
+        The cross-tracker ``exit_hold`` must hit the unknown-token path (no hold
+        closed, no progress made) and leave the real hold vouching, rather than
+        silently releasing it.
+        """
+        clock = FakeClock()
+        recorder = HoldRecorder()
+        first = _tracker(clock, recorder)
+        second = _tracker(clock, recorder)
+        token = first.enter_hold("full table scan", None)
+        second.enter_hold("slow export", None)
+
+        clock.advance(10.0)
+        second.exit_hold(token)  # token belongs to `first`, not `second`
+
+        # The cross-tracker exit was a no-op: no hold closed on either tracker…
+        assert recorder.closed == []
+        # …the real hold on `first` is still vouching (not silently released)…
+        assert first.held() is True
+        # …and `second`'s own hold is untouched.
+        assert second.held() is True
+
     def test_last_at_never_regresses_under_concurrent_writes(self) -> None:
         """The stall clock must never move backwards, even if a caller's clock
         sample is stale relative to a write another thread already committed.

--- a/tests/unit/execution/test_progress_context.py
+++ b/tests/unit/execution/test_progress_context.py
@@ -14,6 +14,10 @@ half-right and still look fine:
 3. Outside an activity the accessor is inert rather than absent: local runs,
    unit tests and non-activity callers behave exactly as they did before this
    plumbing existed.
+
+The binding itself is a block, so "bound but never unbound" is not a state a
+call site can reach — but the block still has to unbind on every path, including
+off the event loop and out of a raise, and that is pinned here.
 """
 
 from __future__ import annotations
@@ -39,9 +43,8 @@ from application_sdk.execution._temporal.activities import (
 from application_sdk.execution.heartbeat import NoopHeartbeatController, run_in_thread
 from application_sdk.execution.progress import (
     ProgressTracker,
+    bind_progress_tracker,
     current_progress_tracker,
-    reset_progress_tracker,
-    set_progress_tracker,
 )
 
 
@@ -72,6 +75,24 @@ def _task_context(app_name: str, task_name: str, *, heartbeating: bool) -> TaskC
         heartbeat_timeout_seconds=60 if heartbeating else None,
         auto_heartbeat_seconds=10 if heartbeating else None,
     )
+
+
+def _register_trivial_app() -> ActivityFn:
+    """Register an app whose task does nothing, and return its activity.
+
+    For the tests that care only about what happens *around* the task body —
+    the binding's lifetime on each exit path.
+    """
+
+    class _CleanApp(App):
+        @task(timeout_seconds=60)
+        async def greet(self, input: _ProgIn) -> _ProgOut:
+            return _ProgOut(greeting="ok")
+
+        async def run(self, input: _ProgIn) -> _ProgOut:
+            return await self.greet(input)
+
+    return _activity_for("_clean-app", "greet")
 
 
 def _task_execution_context() -> TaskExecutionContext:
@@ -148,32 +169,39 @@ class TestNoTrackerBound:
 
 
 class TestBinding:
-    def test_bound_tracker_is_returned(self) -> None:
+    def test_the_block_yields_and_binds_the_same_tracker(self) -> None:
         tracker = ProgressTracker()
-        token = set_progress_tracker(tracker)
-        try:
-            assert current_progress_tracker() is tracker
-        finally:
-            reset_progress_tracker(token)
 
-    def test_reset_restores_the_previous_binding(self) -> None:
+        with bind_progress_tracker(tracker) as bound:
+            assert bound is tracker
+            assert current_progress_tracker() is tracker
+
+    def test_exit_restores_the_previous_binding(self) -> None:
         outer = ProgressTracker()
         inner = ProgressTracker()
-        outer_token = set_progress_tracker(outer)
-        try:
-            inner_token = set_progress_tracker(inner)
-            assert current_progress_tracker() is inner
-            reset_progress_tracker(inner_token)
-            assert current_progress_tracker() is outer
-        finally:
-            reset_progress_tracker(outer_token)
 
-    def test_reset_restores_the_inert_tracker(self) -> None:
+        with bind_progress_tracker(outer):
+            with bind_progress_tracker(inner):
+                assert current_progress_tracker() is inner
+            assert current_progress_tracker() is outer
+
+    def test_exit_restores_the_inert_tracker(self) -> None:
         tracker = ProgressTracker()
-        reset_progress_tracker(set_progress_tracker(tracker))
+
+        with bind_progress_tracker(tracker):
+            pass
 
         assert current_progress_tracker() is not tracker
         assert current_progress_tracker().stalled_for() == 0.0
+
+    def test_a_raising_block_still_unbinds(self) -> None:
+        """The property the block exists for: no path leaves a binding behind."""
+        tracker = ProgressTracker()
+
+        with pytest.raises(ValueError, match="boom"), bind_progress_tracker(tracker):
+            raise ValueError("boom")
+
+        assert current_progress_tracker() is not tracker
 
 
 class TestReachableFromRunInThread:
@@ -182,11 +210,9 @@ class TestReachableFromRunInThread:
     @pytest.mark.asyncio
     async def test_module_level_run_in_thread(self) -> None:
         tracker = ProgressTracker()
-        token = set_progress_tracker(tracker)
-        try:
+
+        with bind_progress_tracker(tracker):
             seen = await run_in_thread(_read_tracker_deep)
-        finally:
-            reset_progress_tracker(token)
 
         assert seen is tracker
         # The context is copied into the thread, but the tracker object is
@@ -197,11 +223,9 @@ class TestReachableFromRunInThread:
     @pytest.mark.asyncio
     async def test_task_execution_context_run_in_thread(self) -> None:
         tracker = ProgressTracker()
-        token = set_progress_tracker(tracker)
-        try:
+
+        with bind_progress_tracker(tracker):
             seen = await _task_execution_context().run_in_thread(_read_tracker_deep)
-        finally:
-            reset_progress_tracker(token)
 
         assert seen is tracker
         assert tracker.last_label == "from_thread"
@@ -219,28 +243,28 @@ class TestReachableFromRunInThread:
             await asyncio.sleep(0)
             return current_progress_tracker()
 
-        token = set_progress_tracker(tracker)
-        try:
+        with bind_progress_tracker(tracker):
             assert await _opaque_call() is tracker
-        finally:
-            reset_progress_tracker(token)
 
     @pytest.mark.asyncio
-    async def test_rebinding_inside_the_thread_does_not_leak_back(self) -> None:
-        """Copy semantics: a rebind inside the thread stays in the thread."""
+    async def test_binding_inside_the_thread_is_confined_to_it(self) -> None:
+        """A nested bind off the event loop restores, and never reaches back."""
         outer = ProgressTracker()
         thread_local = ProgressTracker()
 
-        def _rebind() -> ProgressTracker:
-            set_progress_tracker(thread_local)
-            return current_progress_tracker()
+        def _rebind() -> tuple[ProgressTracker, ProgressTracker]:
+            with bind_progress_tracker(thread_local):
+                inside = current_progress_tracker()
+            return inside, current_progress_tracker()
 
-        token = set_progress_tracker(outer)
-        try:
-            assert await run_in_thread(_rebind) is thread_local
+        with bind_progress_tracker(outer):
+            inside, after_exit = await run_in_thread(_rebind)
+
+            assert inside is thread_local
+            # Restored within the thread's copy of the context...
+            assert after_exit is outer
+            # ...and the caller's binding was never touched.
             assert current_progress_tracker() is outer
-        finally:
-            reset_progress_tracker(token)
 
 
 class TestActivityBinding:
@@ -338,15 +362,7 @@ class TestActivityBinding:
 
     @pytest.mark.asyncio
     async def test_tracker_is_unbound_after_the_activity_returns(self) -> None:
-        class _CleanApp(App):
-            @task(timeout_seconds=60)
-            async def greet(self, input: _ProgIn) -> _ProgOut:
-                return _ProgOut(greeting="ok")
-
-            async def run(self, input: _ProgIn) -> _ProgOut:
-                return await self.greet(input)
-
-        activity_fn = _activity_for("_clean-app", "greet")
+        activity_fn = _register_trivial_app()
         before = current_progress_tracker()
 
         await activity_fn(
@@ -371,6 +387,67 @@ class TestActivityBinding:
         with pytest.raises(ValueError, match="ordinary failure"):
             await activity_fn(
                 _task_context("_boom-app", "boom", heartbeating=False),
+                _ProgIn(name="x"),
+            )
+
+        assert current_progress_tracker() is before
+
+    @pytest.mark.asyncio
+    async def test_tracker_is_unbound_when_heartbeat_setup_raises(self) -> None:
+        """A raise before the body starts must not leak the binding.
+
+        `asyncio.create_task` fails when the loop is closing — a worker being
+        torn down mid-dispatch. The dead attempt's tracker would otherwise stay
+        bound to the context the worker keeps using.
+        """
+        activity_fn = _register_trivial_app()
+        before = current_progress_tracker()
+
+        with (
+            mock.patch.object(
+                activities_module.asyncio,
+                "create_task",
+                side_effect=RuntimeError("event loop is closed"),
+            ),
+            pytest.raises(RuntimeError, match="event loop is closed"),
+        ):
+            await activity_fn(
+                _task_context("_clean-app", "greet", heartbeating=True),
+                _ProgIn(name="x"),
+            )
+
+        assert current_progress_tracker() is before
+
+    @pytest.mark.asyncio
+    async def test_tracker_is_unbound_when_cancelled_during_cleanup(self) -> None:
+        """`CancelledError` in the cleanup path must not skip the unbind.
+
+        It is a `BaseException`, so the heartbeat cleanup's `except (TimeoutError,
+        Exception)` does not catch it and it propagates straight out of the
+        activity's `finally` — past anything sequenced after the await.
+        """
+        activity_fn = _register_trivial_app()
+        before = current_progress_tracker()
+
+        async def cancelling_loop(
+            *,
+            interval_seconds: float,
+            heartbeat_fn: Callable[[], None],
+            stop_event: asyncio.Event,
+            task_name: str,
+        ) -> None:
+            await stop_event.wait()
+            raise asyncio.CancelledError
+
+        with (
+            mock.patch(
+                "application_sdk.execution.heartbeat.auto_heartbeat_loop",
+                new=cancelling_loop,
+            ),
+            pytest.raises(asyncio.CancelledError),
+        ):
+            await activity_fn(
+                _task_context("_clean-app", "greet", heartbeating=True),
                 _ProgIn(name="x"),
             )
 

--- a/tests/unit/execution/test_progress_context.py
+++ b/tests/unit/execution/test_progress_context.py
@@ -1,0 +1,411 @@
+"""Unit tests for the ProgressTracker ContextVar plumbing (FND-287).
+
+Three things are being proven here, because each is a way this plumbing could be
+half-right and still look fine:
+
+1. The current attempt's tracker is reachable from the places that actually
+   report progress — including from inside a worker thread through *both*
+   ``run_in_thread`` entry points (the module-level function and the
+   ``TaskExecutionContext`` wrapper), since both are used across the fleet and
+   covering only the wrapper would leave the auto-hold silently absent from a
+   large share of real blocking calls.
+2. Concurrent activities in one worker bind their own tracker and never observe
+   each other's.
+3. Outside an activity the accessor is inert rather than absent: local runs,
+   unit tests and non-activity callers behave exactly as they did before this
+   plumbing existed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable, Iterator
+from typing import cast
+from unittest import mock
+
+import pytest
+
+from application_sdk.app.base import App
+from application_sdk.app.context import AppContext, TaskExecutionContext
+from application_sdk.app.registry import TaskRegistry
+from application_sdk.app.task import task
+from application_sdk.contracts.base import Input, Output
+from application_sdk.execution import progress as progress_module
+from application_sdk.execution._temporal import activities as activities_module
+from application_sdk.execution._temporal.activities import (
+    TaskContext,
+    create_activity_from_task,
+)
+from application_sdk.execution.heartbeat import NoopHeartbeatController, run_in_thread
+from application_sdk.execution.progress import (
+    ProgressTracker,
+    current_progress_tracker,
+    reset_progress_tracker,
+    set_progress_tracker,
+)
+
+
+class _ProgIn(Input, allow_unbounded_fields=True):
+    name: str = "default"
+
+
+class _ProgOut(Output, allow_unbounded_fields=True):
+    greeting: str = ""
+
+
+ActivityFn = Callable[[TaskContext, _ProgIn], Awaitable[_ProgOut]]
+
+
+def _activity_for(app_name: str, task_name: str) -> ActivityFn:
+    tasks = TaskRegistry.get_instance().get_tasks_for_app(app_name)
+    activity_fn = create_activity_from_task(
+        next(t for t in tasks if t.name == task_name)
+    )
+    return cast("ActivityFn", activity_fn)
+
+
+def _task_context(app_name: str, task_name: str, *, heartbeating: bool) -> TaskContext:
+    return TaskContext(
+        app_name=app_name,
+        task_name=task_name,
+        run_id="run-1",
+        heartbeat_timeout_seconds=60 if heartbeating else None,
+        auto_heartbeat_seconds=10 if heartbeating else None,
+    )
+
+
+def _task_execution_context() -> TaskExecutionContext:
+    """A ``TaskExecutionContext`` with no Temporal behind it."""
+    return TaskExecutionContext(
+        app_context=AppContext(app_name="_prog-app", app_version="0.0.0"),
+        task_name="greet",
+        heartbeat_controller=NoopHeartbeatController(),
+    )
+
+
+def _read_tracker_deep() -> ProgressTracker:
+    """Read the tracker from a nested blocking frame, not from the entry frame.
+
+    The producers this plumbing serves (a transfer loop, an app's own blocking
+    helper) are never the function handed to ``run_in_thread`` — they sit
+    several frames below it.
+    """
+
+    def _inner() -> ProgressTracker:
+        tracker = current_progress_tracker()
+        tracker.mark_progress("from_thread")
+        return tracker
+
+    return _inner()
+
+
+class TestNoTrackerBound:
+    """Outside an activity every call is inert — never ``None``, never a raise."""
+
+    def test_accessor_returns_an_inert_tracker(self) -> None:
+        tracker = current_progress_tracker()
+
+        assert isinstance(tracker, ProgressTracker)
+        assert tracker.held() is False
+        assert tracker.stalled_for() == 0.0
+        assert tracker.last_label == ""
+
+    def test_progress_and_holds_are_no_ops(self) -> None:
+        tracker = current_progress_tracker()
+
+        tracker.mark_progress("write_batch")
+        token = tracker.enter_hold("full table scan", timeout=None)
+        tracker.exit_hold(token)
+
+        # Nothing recorded, and nothing accumulated on a process-wide singleton
+        # that would otherwise grow one hold per never-exited token.
+        assert tracker.last_label == ""
+        assert tracker.stalled_for() == 0.0
+        assert tracker.held() is False
+
+    def test_inert_token_cannot_release_a_real_tracker_hold(self) -> None:
+        """An inert token is negative, so a real tracker rejects it.
+
+        This is the failure mode of a consumer that reads the tracker twice
+        instead of holding on to it: enter outside the attempt, exit inside.
+        Releasing an unrelated real hold would silently make stall accounting
+        lenient; a warning does not.
+        """
+        inert_token = current_progress_tracker().enter_hold("opaque", timeout=None)
+        real = ProgressTracker()
+        real.enter_hold("snapshot metadata query", timeout=None)
+
+        real.exit_hold(inert_token)
+
+        assert real.held() is True
+
+    def test_exit_hold_stays_quiet(self) -> None:
+        """No hold existed, so an unpaired exit is not broken plumbing."""
+        with mock.patch.object(progress_module.logger, "warning") as warning:
+            current_progress_tracker().exit_hold(-1)
+
+        assert warning.call_count == 0
+
+
+class TestBinding:
+    def test_bound_tracker_is_returned(self) -> None:
+        tracker = ProgressTracker()
+        token = set_progress_tracker(tracker)
+        try:
+            assert current_progress_tracker() is tracker
+        finally:
+            reset_progress_tracker(token)
+
+    def test_reset_restores_the_previous_binding(self) -> None:
+        outer = ProgressTracker()
+        inner = ProgressTracker()
+        outer_token = set_progress_tracker(outer)
+        try:
+            inner_token = set_progress_tracker(inner)
+            assert current_progress_tracker() is inner
+            reset_progress_tracker(inner_token)
+            assert current_progress_tracker() is outer
+        finally:
+            reset_progress_tracker(outer_token)
+
+    def test_reset_restores_the_inert_tracker(self) -> None:
+        tracker = ProgressTracker()
+        reset_progress_tracker(set_progress_tracker(tracker))
+
+        assert current_progress_tracker() is not tracker
+        assert current_progress_tracker().stalled_for() == 0.0
+
+
+class TestReachableFromRunInThread:
+    """Both entry points must reach the tracker, not only the wrapper."""
+
+    @pytest.mark.asyncio
+    async def test_module_level_run_in_thread(self) -> None:
+        tracker = ProgressTracker()
+        token = set_progress_tracker(tracker)
+        try:
+            seen = await run_in_thread(_read_tracker_deep)
+        finally:
+            reset_progress_tracker(token)
+
+        assert seen is tracker
+        # The context is copied into the thread, but the tracker object is
+        # shared — so progress marked in the thread lands on the attempt's
+        # tracker rather than on a private copy that dies with the thread.
+        assert tracker.last_label == "from_thread"
+
+    @pytest.mark.asyncio
+    async def test_task_execution_context_run_in_thread(self) -> None:
+        tracker = ProgressTracker()
+        token = set_progress_tracker(tracker)
+        try:
+            seen = await _task_execution_context().run_in_thread(_read_tracker_deep)
+        finally:
+            reset_progress_tracker(token)
+
+        assert seen is tracker
+        assert tracker.last_label == "from_thread"
+
+    @pytest.mark.asyncio
+    async def test_reachable_from_a_nested_async_frame(self) -> None:
+        """The seam FND-291's ``holding_progress()`` will read.
+
+        It is entered from app code an arbitrary depth below the task method,
+        with no tracker in hand.
+        """
+        tracker = ProgressTracker()
+
+        async def _opaque_call() -> ProgressTracker:
+            await asyncio.sleep(0)
+            return current_progress_tracker()
+
+        token = set_progress_tracker(tracker)
+        try:
+            assert await _opaque_call() is tracker
+        finally:
+            reset_progress_tracker(token)
+
+    @pytest.mark.asyncio
+    async def test_rebinding_inside_the_thread_does_not_leak_back(self) -> None:
+        """Copy semantics: a rebind inside the thread stays in the thread."""
+        outer = ProgressTracker()
+        thread_local = ProgressTracker()
+
+        def _rebind() -> ProgressTracker:
+            set_progress_tracker(thread_local)
+            return current_progress_tracker()
+
+        token = set_progress_tracker(outer)
+        try:
+            assert await run_in_thread(_rebind) is thread_local
+            assert current_progress_tracker() is outer
+        finally:
+            reset_progress_tracker(token)
+
+
+class TestActivityBinding:
+    """The activity body owns one tracker per attempt and unbinds it after."""
+
+    @pytest.fixture(autouse=True)
+    def _no_temporal(self) -> Iterator[None]:
+        """Run the real activity body with no worker and no infrastructure."""
+        with (
+            mock.patch.object(
+                activities_module.activity,
+                "info",
+                return_value=mock.MagicMock(workflow_id="wf-prog"),
+            ),
+            mock.patch(
+                "application_sdk.infrastructure.context.get_infrastructure",
+                return_value=None,
+            ),
+        ):
+            yield
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "heartbeating", [False, True], ids=["heartbeating-off", "heartbeating-on"]
+    )
+    async def test_task_body_sees_its_attempt_tracker(self, heartbeating: bool) -> None:
+        """A task with heartbeating disabled still gets a tracker.
+
+        The stall watchdog is what bounds a wedged attempt on such a task, so
+        the binding must not be gated on the heartbeat settings.
+        """
+        seen: list[ProgressTracker] = []
+
+        class _SeeApp(App):
+            @task(timeout_seconds=60)
+            async def greet(self, input: _ProgIn) -> _ProgOut:
+                tracker = current_progress_tracker()
+                tracker.mark_progress("greeting")
+                seen.append(tracker)
+                return _ProgOut(greeting=f"hi {input.name}")
+
+            async def run(self, input: _ProgIn) -> _ProgOut:
+                return await self.greet(input)
+
+        activity_fn = _activity_for("_see-app", "greet")
+
+        async def fake_loop(
+            *,
+            interval_seconds: float,
+            heartbeat_fn: Callable[[], None],
+            stop_event: asyncio.Event,
+            task_name: str,
+        ) -> None:
+            await stop_event.wait()
+
+        with mock.patch(
+            "application_sdk.execution.heartbeat.auto_heartbeat_loop", new=fake_loop
+        ):
+            result = await activity_fn(
+                _task_context("_see-app", "greet", heartbeating=heartbeating),
+                _ProgIn(name="vee"),
+            )
+
+        assert result.greeting == "hi vee"
+        # A real tracker, not the inert one: it recorded what the task reported.
+        assert [t.last_label for t in seen] == ["greeting"]
+
+    @pytest.mark.asyncio
+    async def test_run_in_thread_inside_the_activity_reaches_the_tracker(self) -> None:
+        """The composed shape the fleet actually runs: offload inside a task."""
+        seen: list[ProgressTracker] = []
+
+        class _OffloadApp(App):
+            @task(timeout_seconds=60)
+            async def scan(self, input: _ProgIn) -> _ProgOut:
+                seen.append(current_progress_tracker())
+                seen.append(await self.task_context.run_in_thread(_read_tracker_deep))
+                seen.append(await run_in_thread(_read_tracker_deep))
+                return _ProgOut(greeting="scanned")
+
+            async def run(self, input: _ProgIn) -> _ProgOut:
+                return await self.scan(input)
+
+        activity_fn = _activity_for("_offload-app", "scan")
+
+        await activity_fn(
+            _task_context("_offload-app", "scan", heartbeating=False),
+            _ProgIn(name="x"),
+        )
+
+        from_body, from_wrapper, from_module_level = seen
+        assert from_wrapper is from_body
+        assert from_module_level is from_body
+        assert from_body.last_label == "from_thread"
+
+    @pytest.mark.asyncio
+    async def test_tracker_is_unbound_after_the_activity_returns(self) -> None:
+        class _CleanApp(App):
+            @task(timeout_seconds=60)
+            async def greet(self, input: _ProgIn) -> _ProgOut:
+                return _ProgOut(greeting="ok")
+
+            async def run(self, input: _ProgIn) -> _ProgOut:
+                return await self.greet(input)
+
+        activity_fn = _activity_for("_clean-app", "greet")
+        before = current_progress_tracker()
+
+        await activity_fn(
+            _task_context("_clean-app", "greet", heartbeating=False), _ProgIn(name="x")
+        )
+
+        assert current_progress_tracker() is before
+
+    @pytest.mark.asyncio
+    async def test_tracker_is_unbound_when_the_task_raises(self) -> None:
+        class _BoomApp(App):
+            @task(timeout_seconds=60)
+            async def boom(self, input: _ProgIn) -> _ProgOut:
+                raise ValueError("ordinary failure")
+
+            async def run(self, input: _ProgIn) -> _ProgOut:
+                return await self.boom(input)
+
+        activity_fn = _activity_for("_boom-app", "boom")
+        before = current_progress_tracker()
+
+        with pytest.raises(ValueError, match="ordinary failure"):
+            await activity_fn(
+                _task_context("_boom-app", "boom", heartbeating=False),
+                _ProgIn(name="x"),
+            )
+
+        assert current_progress_tracker() is before
+
+    @pytest.mark.asyncio
+    async def test_concurrent_activities_do_not_share_a_tracker(self) -> None:
+        """Two attempts in one worker, both inside the body at the same time."""
+        both_inside = asyncio.Barrier(2)
+        seen: dict[str, ProgressTracker] = {}
+
+        class _ConcurrentApp(App):
+            @task(timeout_seconds=60)
+            async def greet(self, input: _ProgIn) -> _ProgOut:
+                current_progress_tracker().mark_progress(input.name)
+                # Hold both attempts inside the body simultaneously, so a shared
+                # binding is observable rather than merely sequential.
+                await both_inside.wait()
+                seen[input.name] = current_progress_tracker()
+                return _ProgOut(greeting=input.name)
+
+            async def run(self, input: _ProgIn) -> _ProgOut:
+                return await self.greet(input)
+
+        activity_fn = _activity_for("_concurrent-app", "greet")
+        ctx = _task_context("_concurrent-app", "greet", heartbeating=False)
+
+        # Each attempt runs as its own asyncio task, exactly as Temporal's
+        # worker dispatches them — awaiting bare coroutines would run them in
+        # this test's own context and prove nothing.
+        await asyncio.gather(
+            asyncio.create_task(activity_fn(ctx, _ProgIn(name="alpha"))),
+            asyncio.create_task(activity_fn(ctx, _ProgIn(name="beta"))),
+        )
+
+        assert seen["alpha"] is not seen["beta"]
+        assert seen["alpha"].last_label == "alpha"
+        assert seen["beta"].last_label == "beta"


### PR DESCRIPTION
Implements [FND-287](https://linear.app/atlan-epd/issue/FND-287/reach-the-tracker-from-anywhere-in-the-activity-contextvar-plumbing) — the ContextVar that makes ADR-0018's `ProgressTracker` reachable from the code that actually produces progress signals.

**Now targets `main`** — #3145 (FND-283) and #3147 (FND-286) have both merged, so what was a stack is a plain PR.

## Why this is its own piece

Every producer the ADR names is deep inside code that holds no reference to a tracker: the SDK's batched writers and `ObjectStore` transfer loops (FND-288), a blocking call offloaded through `run_in_thread` (FND-290), an app's own opaque `await` inside `holding_progress()` (FND-291). None of them is handed one by its caller, and none of them should have to be. Everything after this in M1 reads through the seam this PR adds.

## What this adds

`application_sdk/execution/progress.py`:

- `current_progress_tracker() -> ProgressTracker` — the read seam for every producer.
- `bind_progress_tracker(tracker)` — the write side, a context manager, for `activities.py`, which owns one tracker per attempt.
- `_InertProgressTracker` + a process singleton — the no-tracker case.

`application_sdk/execution/_temporal/activities.py` — bind a fresh `ProgressTracker()` for the extent of the activity body.

## Decisions a reviewer should look at

**1. The accessor never returns `None`; the no-tracker case is a null object.** The alternative — `ProgressTracker | None` and a check at each call site — puts a branch at every one of the sites this exists to serve: paired `enter_hold`/`exit_hold` blocks and bare `mark_progress` calls buried in hot loops. That is the exact shape that gets half-written, and the failure is silent (a missing hold shows up later as a phantom stall, not as an error here). `_InertProgressTracker` answers `held() → False` and `stalled_for() → 0.0` — the honest answers when nothing is observing, as opposed to the process's uptime, which is what an inherited `stalled_for()` on a singleton would return. It mirrors `NoopHeartbeatController`'s role on the heartbeat path.

Its mutators are overridden rather than inherited for two concrete reasons, both consequences of it being a process-wide singleton: an inherited `enter_hold` would accumulate one live hold per never-exited token for the life of the process, and an inherited `mark_progress` would take a shared lock on every framework-hook call made outside an activity (local runs, HTTP handlers, the whole unit-test suite).

**2. The inert token is `-1`, so it can never release a real hold.** Real tokens are a non-negative per-attempt counter. If a consumer ever reads the tracker twice instead of holding on to it — entering outside the attempt and exiting inside — the mismatch is logged by `exit_hold` rather than silently releasing an unrelated hold and making stall accounting lenient. Pinned by a test.

**3. The ADR's trap — "must cover the module-level `run_in_thread`, not only the `TaskExecutionContext` wrapper" — is structurally absent here, and the test says so.** `TaskExecutionContext.run_in_thread` delegates straight to `heartbeat.run_in_thread`, so one ContextVar read at the module level covers both entry points, and FND-290's auto-hold only has to touch one function. That is a property of today's code rather than a guarantee, so both paths are tested independently: if the wrapper ever grows its own body, the test that proves both reach the same tracker object fails.

**4. Bound unconditionally, not gated on `heartbeat_timeout_seconds`.** A task with heartbeating disabled has nothing but `start_to_close` bounding a wedged attempt today — it is the case that most needs the stall watchdog, so gating the tracker on the heartbeat settings would exclude it. Parametrised over both heartbeat configurations.

**5. Bound before the auto-heartbeat task is created.** `asyncio.create_task` copies the context at creation, so anything the attempt spawns inherits the binding rather than racing it. Note that #3147's watchdog does *not* read the ContextVar — it takes `progress` as a parameter, injected the same way `heartbeat_fn` already is, which keeps it unit-testable without an activity. That injection is still unwired: nothing passes `progress=` into `auto_heartbeat_loop` yet, so the watchdog is dormant after both PRs land. It needs the tracker this PR creates in `activities.py`, which is why the wiring wants to sit on top of the stack (FND-289, alongside `on_stall`) rather than in either PR alone.

**6. A block, not a `set`/`reset` token pair.** `bind_progress_tracker()` is a context manager and the activity body sits inside it, so there is no token for a call site to mislay and no exit path that can leave a dead attempt's tracker bound to a context the worker keeps using — which would have the next caller reporting progress into a finished attempt, and a hold paired across the boundary releasing the wrong deadline.

An earlier revision used a token pair, on the argument that a `with` means re-indenting the whole ~150-line body for four real lines of change. That was the wrong trade, and it did not survive contact: review found two live leaks in it, both the same shape — a path that reached the end of the attempt without running the reset. A raise from `create_task` while the loop is closing (worker torn down mid-dispatch) escaped before the `try` opened; and a `CancelledError` delivered during the heartbeat-cleanup `await` is a `BaseException`, so it propagated straight out of the `finally`, past the reset sequenced after it. The block removes the shape instead of patching its two instances. Both paths now have regression tests, which the point-fix did not carry.

The nested `finally` from that fix stays: `app_instance._task_context`/`_context` are still plain assignments after an `await` in a `finally`, so they need it for the same `BaseException` reason the tracker no longer does.

**7. Nothing is exported.** `application_sdk.execution.__all__` is unchanged, so the capability manifest is unchanged; this is an SDK-internal seam. No `docs/concepts/apps.md` update either — app authors get nothing they can call until FND-290's auto-holds and FND-291's `holding_progress()`, and the design rationale already lives in ADR-0018 → *Feeding the tracker*.

## Tests

`tests/unit/execution/test_progress_context.py` — 20 tests, no worker, driving the real `activity_fn` from `create_activity_from_task`:

- **Inert outside an activity**: accessor returns a tracker (not `None`), signals are no-ops, nothing accumulates, an inert token cannot release a real tracker's hold, and an unpaired inert `exit_hold` stays quiet.
- **Binding**: the block yields the tracker it binds; exit restores the previous binding, the inert one when there was none, and does both out of a raise.
- **Reachability**: from the module-level `run_in_thread` *and* the `TaskExecutionContext` wrapper (read from a nested frame inside the thread, not the entry frame — and progress marked in the thread lands on the attempt's tracker, since only the context is copied, not the object); from a nested async frame (the seam FND-291 will read); and a nested bind inside the thread restores there without reaching back to the caller.
- **Through the activity**: the task body sees a real tracker with heartbeating on *and* off; the composed fleet shape (offload inside a task, both entry points, same object); and two attempts held inside the body simultaneously by a barrier, each dispatched as its own asyncio task the way Temporal's worker does it, see distinct trackers with their own labels.
- **Unbound on every exit path**: after the activity returns, after the task raises, after `create_task` raises during heartbeat setup, and after a `CancelledError` lands in the heartbeat cleanup.

The issue's done-when also names `holding_progress` — that leg lands with FND-291, which doesn't exist yet. What is proven here is the property it consumes: the accessor resolves to the attempt's tracker from an arbitrary depth below the task method, sync or async, including inside an offloaded thread.

Mutation-checked rather than assumed: dropping the bind fails every activity test; dropping the unbind inside the block fails all 8 tests that assert the binding's lifetime, including both new exit-path ones.

- `uv run pytest tests/unit` — 6622 passed, 9 skipped
- `uv run pre-commit run --files ...` — ruff, ruff-format, isort, pyright clean
- Full conformance suite — zero findings in the changed files (the two `E004`s on `activities.py` are pre-existing, in the heartbeat-teardown `finally`)
