### PR TITLE
feat(execution): framework mark_progress() hooks on the writer, emission and transfer loops (FND-288)

### DIFF
--- a/application_sdk/storage/chunked.py
+++ b/application_sdk/storage/chunked.py
@@ -175,6 +175,13 @@ async def _fetch_chunk(
     progress_interval: float,
 ) -> None:
     """Fetch one range and write it at its fixed offset; checkpoint + heartbeat."""
+    # Lazy, and it cannot be hoisted to module scope: application_sdk.execution's
+    # package __init__ reaches back into storage.ops, which imports this module.
+    # A sys.modules lookup per chunk is nothing against a multi-MiB range GET.
+    from application_sdk.execution.progress import (  # noqa: PLC0415 — circular: see comment above
+        current_progress_tracker,
+    )
+
     length = min(chunk_size_bytes, size - offset)
     async with sem:
         if etag is not None:
@@ -209,6 +216,9 @@ async def _fetch_chunk(
             )
         progress.completed_bytes += len(raw)
         progress.fetched_bytes += len(raw)
+        # One range GET landed at its offset — the unit of work for this path
+        # (ADR-0018).
+        current_progress_tracker().mark_progress("storage.download_range")
         if progress_interval > 0:
             now = time.monotonic()
             if now - progress.last_progress >= progress_interval:

--- a/application_sdk/storage/cloud.py
+++ b/application_sdk/storage/cloud.py
@@ -381,6 +381,13 @@ class CloudStore:
             Number of bytes uploaded.
         """
         path = Path(local_path)
+        # Hoisted out of the part loop; lazy for the same reason as the logger
+        # above — application_sdk.execution's package __init__ reaches back into
+        # storage.ops, which this module imports at top level.
+        from application_sdk.execution.progress import (  # noqa: PLC0415 — circular: see comment above
+            current_progress_tracker,
+        )
+
         try:
             size = path.stat().st_size
             chunk = _compute_part_size(size, 8 * 1024 * 1024)
@@ -393,6 +400,13 @@ class CloudStore:
                         if not buf:
                             break
                         await writer.write(buf)
+                        # One part on its way to the external store. The
+                        # download side needs no hook here: _download_single
+                        # routes through download_file_chunked, which marks per
+                        # range GET.
+                        current_progress_tracker().mark_progress(
+                            "cloudstore.upload_part"
+                        )
         except StorageError:
             raise
         # conformance: ignore[E004] re-raise only; checks azure container-not-found then wraps in StorageConfigError/StorageError

--- a/application_sdk/storage/file_ref_sync.py
+++ b/application_sdk/storage/file_ref_sync.py
@@ -42,6 +42,7 @@ from typing import TYPE_CHECKING, Any
 from pydantic import BaseModel
 
 from application_sdk.contracts.types import FileReference, Lazy
+from application_sdk.execution.progress import current_progress_tracker
 from application_sdk.observability.logger_adaptor import get_logger
 
 if TYPE_CHECKING:
@@ -242,6 +243,12 @@ async def _replace_refs(
     ) -> tuple[str, FileReference]:
         async with sem:
             result = await factory()
+        # One ref persisted or materialised is one unit of work (ADR-0018).
+        # The per-file and per-part marks inside transfer/ops already keep a
+        # single large ref visible; this coarser mark exists for the label,
+        # which tells an operator the interceptor was moving typed I/O rather
+        # than the app being mid-transfer on one file.
+        current_progress_tracker().mark_progress(f"file_ref.{mode}")
         return key, result
 
     pairs = await asyncio.gather(*[_run(k, f) for k, f in _factories.items()])

--- a/application_sdk/storage/formats/__init__.py
+++ b/application_sdk/storage/formats/__init__.py
@@ -20,6 +20,7 @@ from application_sdk.common.models import TaskStatistics
 from application_sdk.common.types import DataframeType
 from application_sdk.contracts.types import FileReference
 from application_sdk.execution.heartbeat import run_in_thread
+from application_sdk.execution.progress import current_progress_tracker
 from application_sdk.observability.logger_adaptor import get_logger
 from application_sdk.observability.metrics_adaptor import MetricType
 from application_sdk.storage.formats.utils import (
@@ -689,6 +690,14 @@ class Writer(ABC):
 
                 self.current_buffer_size = 0
 
+                # One buffer chunk on disk is one observable unit of work
+                # (ADR-0018). This is the single chunk boundary every writer
+                # subclass shares — JsonFileWriter and the non-consolidating
+                # ParquetFileWriter path both reach it — so a long
+                # `write_batches` stream stays visible to the stall watchdog
+                # without any per-record cost.
+                current_progress_tracker().mark_progress("writer.flush_buffer")
+
                 # Record chunk metrics
                 self.metrics.record_metric(
                     name="chunks_written",
@@ -768,6 +777,13 @@ class Writer(ABC):
             # to a no-op so the statistics sidecar travels via close()'s
             # returned FileReference instead of inline.
             await self._upload_file(output_file_name)
+
+            # The statistics sidecar is the last thing a writer emits, and
+            # `close()` runs `_finalize()` (parquet consolidation, remaining
+            # uploads) immediately before it. Marking here means the quiet
+            # window the watchdog measures starts from the end of the writer's
+            # work rather than from its last buffer chunk.
+            current_progress_tracker().mark_progress("writer.statistics")
 
             return statistics
         # conformance: ignore[E004] re-raises as typed FormatStatisticsWriteError; no information is discarded

--- a/application_sdk/storage/formats/parquet.py
+++ b/application_sdk/storage/formats/parquet.py
@@ -10,6 +10,7 @@ from application_sdk.constants import DAPR_MAX_GRPC_MESSAGE_LENGTH
 from application_sdk.contracts.types import FileReference
 from application_sdk.errors import AppError
 from application_sdk.execution.heartbeat import run_in_thread
+from application_sdk.execution.progress import current_progress_tracker
 from application_sdk.observability.logger_adaptor import get_logger
 from application_sdk.observability.metrics_adaptor import MetricType, get_metrics
 from application_sdk.storage.batch import delete_prefix as _delete_prefix
@@ -732,6 +733,11 @@ class ParquetFileWriter(Writer):
         # Write chunk using existing write_chunk method
         await self._write_chunk(chunk, chunk_file_path)
 
+        # The consolidation path never reaches Writer._flush_buffer, so it
+        # needs its own chunk boundary: accumulation can run for the whole
+        # `write_batches` stream before the first consolidation happens.
+        current_progress_tracker().mark_progress("writer.accumulate_chunk")
+
     async def _consolidate_current_folder(self):
         """Consolidate current temp folder using pyarrow."""
         if self.current_folder_records == 0 or self.current_temp_folder_path is None:
@@ -774,6 +780,13 @@ class ParquetFileWriter(Writer):
                 if not self.defer_uploads:
                     await _upload_file(consolidated_file_path, consolidated_file_path)
                 partitions += 1
+
+                # One consolidated file written (and uploaded) is one unit.
+                # Marking inside the loop rather than after it matters: a
+                # folder at the consolidation threshold can produce many files,
+                # and a slow store would otherwise make the whole consolidation
+                # one quiet window.
+                current_progress_tracker().mark_progress("writer.consolidate_chunk")
 
             # Update statistics
             self.chunk_count += 1

--- a/application_sdk/storage/ops.py
+++ b/application_sdk/storage/ops.py
@@ -565,6 +565,12 @@ async def upload_file(
         STORAGE_PROGRESS_LOG_INTERVAL_SECONDS as _progress_interval,
     )
 
+    # Hoisted out of the part loop so the lazy import is paid once per upload
+    # rather than once per part.
+    from application_sdk.execution.progress import (  # noqa: PLC0415 — circular: application_sdk.execution's package __init__ reaches back into storage.ops
+        current_progress_tracker,
+    )
+
     last_progress = started
     bytes_sent = 0
     try:
@@ -584,6 +590,15 @@ async def upload_file(
                         h.update(chunk)
                     await writer.write(chunk)
                     bytes_sent += len(chunk)
+                    # One multipart part on its way to the store is one
+                    # observable unit (ADR-0018). Marking per part rather than
+                    # per file is what keeps a single multi-GB upload — the
+                    # common shape for a large connector's parquet output —
+                    # from looking like one long quiet window to the stall
+                    # watchdog. Unconditional, unlike the progress *log* below:
+                    # a mark is two stores under an uncontended lock, so it
+                    # needs no interval gate.
+                    current_progress_tracker().mark_progress("storage.upload_part")
                     if _progress_interval > 0:
                         now = time.monotonic()
                         if now - last_progress >= _progress_interval:
@@ -743,6 +758,12 @@ async def download_file(
             STORAGE_PROGRESS_LOG_INTERVAL_SECONDS as _progress_interval,
         )
 
+        # Hoisted out of the stream loop so the lazy import is paid once per
+        # download rather than once per chunk.
+        from application_sdk.execution.progress import (  # noqa: PLC0415 — circular: application_sdk.execution's package __init__ reaches back into storage.ops
+            current_progress_tracker,
+        )
+
         last_progress = started
         with os.fdopen(fd, "wb") as fh:
             async for chunk in result.stream(min_chunk_size=min_chunk_size):
@@ -751,6 +772,9 @@ async def download_file(
                 bytes_written += len(raw)
                 if h is not None:
                     h.update(raw)
+                # One streamed chunk landed on disk — see the matching mark in
+                # upload_file for why this is per chunk and ungated.
+                current_progress_tracker().mark_progress("storage.download_chunk")
                 if _progress_interval > 0:
                     now = time.monotonic()
                     if now - last_progress >= _progress_interval:

--- a/application_sdk/storage/rolling.py
+++ b/application_sdk/storage/rolling.py
@@ -76,6 +76,7 @@ from typing import Any, Generic, TypeVar
 
 from application_sdk.common.file_ops import SafeFileOps
 from application_sdk.contracts.types import FileReference
+from application_sdk.execution.progress import current_progress_tracker
 from application_sdk.observability.logger_adaptor import get_logger
 from application_sdk.storage.rolling_errors import (
     InvalidRollingFileWriterError,
@@ -532,6 +533,15 @@ class RollingFileWriter(Generic[T]):
                 exc_info=True,
             )
             raise
+
+        # One rolled chunk on disk is one observable unit (ADR-0018). This class
+        # is not a `Writer` subclass, so it does not inherit
+        # `Writer._flush_buffer`'s hook — and since it is the *recommended*
+        # replacement for the v4.0-deprecated writers, leaving it unhooked would
+        # mean the migration target had less stall coverage than what it
+        # replaces. Marked before `on_chunk_complete` so a slow callback is
+        # measured as the quiet window it is.
+        current_progress_tracker().mark_progress("writer.rolling_flush")
 
         completed_index = self._chunk_index
         self._chunk_index += 1

--- a/application_sdk/storage/transfer.py
+++ b/application_sdk/storage/transfer.py
@@ -44,6 +44,7 @@ from application_sdk.common._listing import safe_list_directory
 from application_sdk.constants import MAX_CONCURRENT_STORAGE_TRANSFERS
 from application_sdk.contracts.types import FileReference, StorageTier
 from application_sdk.execution.heartbeat import run_in_thread
+from application_sdk.execution.progress import current_progress_tracker
 from application_sdk.observability.logger_adaptor import get_logger
 
 # Sidecar suffix / predicate and the batch key listers are owned by
@@ -132,12 +133,21 @@ async def _upload_one(
         local_digest = await _sha256_file_async(local_file)
         remote_digest = await _get_remote_sha256(store, store_key)
         if remote_digest == local_digest:
+            # A skip is still one file resolved. Directory uploads that skip
+            # thousands of hash-matching files on an idempotent retry are doing
+            # real work (a digest and a sidecar GET each) and must not read as
+            # a stall.
+            current_progress_tracker().mark_progress("storage.upload_file")
             return False, "skipped:hash_match"
         sha256 = await upload_file(store_key, local_file, store, normalize=False)
     else:
         sha256 = await upload_file(store_key, local_file, store, normalize=False)
 
     await _put_remote_sha256(store, store_key, sha256)
+    # Per-file boundary, on top of the per-part marks inside upload_file: this
+    # is the label an operator wants in a stall message, since it says the
+    # attempt was moving whole files rather than stuck mid-transfer on one.
+    current_progress_tracker().mark_progress("storage.upload_file")
     return True, "uploaded"
 
 
@@ -185,6 +195,9 @@ async def _upload_from_store(
     if await _cross_store_sha256_match(
         source_store, source_key, target_store, target_key
     ):
+        # Two sidecar GETs per key: a fallback reconcile over a large prefix
+        # that skips everything is still forward progress.
+        current_progress_tracker().mark_progress("storage.copy_file")
         return False, "skipped:hash_match"
 
     fd, tmp_path_str = tempfile.mkstemp()
@@ -201,6 +214,7 @@ async def _upload_from_store(
         )
         sha256 = await upload_file(target_key, tmp, target_store, normalize=False)
         await _put_remote_sha256(target_store, target_key, sha256)
+        current_progress_tracker().mark_progress("storage.copy_file")
         return True, "uploaded"
     finally:
         tmp.unlink(missing_ok=True)
@@ -236,6 +250,9 @@ async def _download_one(
         if remote_digest is not None:
             local_digest = await _sha256_file_async(local_file)
             if local_digest == remote_digest:
+                # See _upload_one: a hash-match skip is one file resolved, and
+                # the prefix download loop below runs these sequentially.
+                current_progress_tracker().mark_progress("storage.download_file")
                 return False, "skipped:hash_match"
 
     local_file.parent.mkdir(parents=True, exist_ok=True)
@@ -248,6 +265,7 @@ async def _download_one(
         etag=etag,
         resume=resume,
     )
+    current_progress_tracker().mark_progress("storage.download_file")
     return True, "downloaded"
 
 

--- a/application_sdk/templates/sql_app.py
+++ b/application_sdk/templates/sql_app.py
@@ -114,6 +114,7 @@ from application_sdk.errors.leaves import (
 from application_sdk.errors.wire import secret_named_evidence_keys
 from application_sdk.execution import build_output_path, get_object_store_prefix
 from application_sdk.execution.heartbeat import run_in_thread
+from application_sdk.execution.progress import current_progress_tracker
 from application_sdk.infrastructure.context import get_infrastructure
 from application_sdk.observability.logger_adaptor import get_logger
 from application_sdk.templates.contracts.sql_metadata import (
@@ -1560,6 +1561,18 @@ class SqlApp(App):
                     payload = await run_in_thread(_serialize_batch, batch)
                     f.write(payload)
                     count += len(batch)
+                    # One fetched page serialised and written is one observable
+                    # unit (ADR-0018). Marked here rather than per record: one
+                    # page is already the unit, and a mark per record would be a
+                    # hot-path cost for no extra signal.
+                    #
+                    # This is the whole reason the read side needs no hold — the
+                    # fetch → serialise → write cycle marks on every page, so
+                    # only a *single* cycle slower than max_no_progress_seconds
+                    # needs an explicit hold from the app. (FND-290's auto-hold
+                    # around the `run_in_thread` above already covers the
+                    # serialise leg of that cycle.)
+                    current_progress_tracker().mark_progress("extract.page")
         finally:
             await client.close()
 
@@ -1698,6 +1711,16 @@ class SqlApp(App):
         # whole transform, which stops the auto-heartbeat and gets a healthy
         # activity killed on heartbeat_timeout. Every SQL connector inherits
         # this method, so the fix applies fleet-wide (ADR-0010).
+        #
+        # No framework progress hook inside `_map_records`, deliberately
+        # (ADR-0018). The loop is line-by-line with no batch boundary to mark
+        # at, and the never-per-record rule forbids the only boundary it has.
+        # It does not need one: the whole map is a single `run_in_thread` hop,
+        # which FND-290 wraps in an unbounded auto-hold — so the stall watchdog
+        # is vouched for across the entire transform by mechanism 2 rather than
+        # mechanism 1. That leaves the 24h backstop as its only bound, which is
+        # the ADR's accepted residual for opaque offloaded work and is exactly
+        # what warn mode is meant to surface with an observed duration.
         count = await run_in_thread(_map_records)
 
         logger.info("Transformed %s: %d records", entity_type, count)

--- a/application_sdk/templates/sql_metadata_extractor.py
+++ b/application_sdk/templates/sql_metadata_extractor.py
@@ -39,6 +39,7 @@ from application_sdk.common.sql_filters import (
 from application_sdk.contracts.storage import UploadInput
 from application_sdk.contracts.types import StorageTier
 from application_sdk.credentials import CredentialResolver, legacy_credential_ref
+from application_sdk.execution.progress import current_progress_tracker
 from application_sdk.infrastructure.context import get_infrastructure
 from application_sdk.observability.logger_adaptor import get_logger
 from application_sdk.templates._template_errors import (
@@ -268,6 +269,13 @@ class SqlMetadataExtractor(BaseMetadataExtractor):
     # ------------------------------------------------------------------
     # Fetch tasks — default implementations using SQL class attributes
     # ------------------------------------------------------------------
+    #
+    # Each page loop below marks progress at the page boundary
+    # (ADR-0018 → *Feeding the tracker*, mechanism 1). Unlike the extract →
+    # write shape, these four fetch nothing to a writer — they accumulate names
+    # (or a count) in memory and return — so there is no write side to carry
+    # the signal for them, and a wide catalog can page for a long time. The
+    # mark goes outside the per-row loop: one page is already the unit.
 
     @task(timeout_seconds=1800)
     async def fetch_databases(self, input: FetchDatabasesInput) -> FetchDatabasesOutput:
@@ -296,6 +304,7 @@ class SqlMetadataExtractor(BaseMetadataExtractor):
                     val = row.get(key)
                     if val:
                         databases.append(str(val))
+                current_progress_tracker().mark_progress("fetch_databases.page")
             return FetchDatabasesOutput(
                 databases=databases,
                 chunk_count=1,
@@ -328,6 +337,7 @@ class SqlMetadataExtractor(BaseMetadataExtractor):
                     val = row.get(key)
                     if val:
                         schemas.append(str(val))
+                current_progress_tracker().mark_progress("fetch_schemas.page")
             return FetchSchemasOutput(
                 schemas=schemas,
                 chunk_count=1,
@@ -360,6 +370,7 @@ class SqlMetadataExtractor(BaseMetadataExtractor):
                     val = row.get(key)
                     if val:
                         tables.append(str(val))
+                current_progress_tracker().mark_progress("fetch_tables.page")
             return FetchTablesOutput(
                 tables=tables,
                 chunk_count=1,
@@ -390,6 +401,7 @@ class SqlMetadataExtractor(BaseMetadataExtractor):
             total = 0
             async for batch in client.run_query(sql):
                 total += len(batch)
+                current_progress_tracker().mark_progress("fetch_columns.page")
             return FetchColumnsOutput(chunk_count=1, total_record_count=total)
         finally:
             await client.close()

--- a/docs/adr/0018-progress-aware-heartbeat.md
+++ b/docs/adr/0018-progress-aware-heartbeat.md
@@ -413,11 +413,57 @@ Detection latency is `max_no_progress_seconds` plus at most one loop tick (10s).
 ### Feeding the tracker (three mechanisms, most-automatic first)
 
 1. **Framework hooks (automatic, no app action).** Call `mark_progress()` wherever
-   the SDK already loops over units of work: the batched output writers, the
-   record/statistics emission path, and the `ObjectStore` transfer loops
-   (`storage/transfer.py`, `storage/chunked.py`, `storage/file_ref_sync.py`). This
-   covers the streaming majority — the bulk of connector runtime — with no code
-   change in the app.
+   the SDK already loops over units of work. This covers the streaming majority —
+   the bulk of connector runtime — with no code change in the app. Each hook
+   reaches the attempt's tracker through `current_progress_tracker()` (FND-287),
+   which outside an activity returns the inert tracker — so every hook below is a
+   no-op until `activities.py` binds one. As landed (FND-288), the hooked set is:
+
+   | Where | Unit | Label |
+   | --- | --- | --- |
+   | `storage/formats/__init__.py` — `Writer._flush_buffer` | one buffer chunk written | `writer.flush_buffer` |
+   | `storage/formats/__init__.py` — `Writer._write_statistics` | statistics sidecar emitted at `close()` | `writer.statistics` |
+   | `storage/formats/parquet.py` — `_write_chunk_to_temp_folder` | one accumulated chunk | `writer.accumulate_chunk` |
+   | `storage/formats/parquet.py` — `_consolidate_current_folder` | one consolidated file | `writer.consolidate_chunk` |
+   | `storage/rolling.py` — `RollingFileWriter._flush_locked` | one rolled chunk | `writer.rolling_flush` |
+   | `storage/ops.py` — `upload_file` / `download_file` | one multipart part / streamed chunk | `storage.upload_part`, `storage.download_chunk` |
+   | `storage/chunked.py` — `_fetch_chunk` | one range GET at its offset | `storage.download_range` |
+   | `storage/transfer.py` — `_upload_one` / `_upload_from_store` / `_download_one` | one file transferred *or* skipped on a hash match | `storage.upload_file`, `storage.copy_file`, `storage.download_file` |
+   | `storage/cloud.py` — `CloudStore.upload` | one part to an external store | `cloudstore.upload_part` |
+   | `storage/file_ref_sync.py` — `_replace_refs` | one `FileReference` persisted / materialised | `file_ref.persist`, `file_ref.materialize` |
+   | `templates/sql_app.py` — `_extract_entity` | one fetched page written to raw JSONL | `extract.page` |
+   | `templates/sql_metadata_extractor.py` — `fetch_databases` / `fetch_schemas` / `fetch_tables` / `fetch_columns` | one fetched page | `fetch_*.page` |
+
+   Two grains on purpose: **per part/chunk** inside the byte loops, so a single
+   multi-GB object is never one long quiet window, and **per file** at the
+   orchestration boundaries, so `last_label` tells an operator *which* loop went
+   quiet rather than only that bytes were moving. A hash-match skip counts as
+   progress — an idempotent retry over a large prefix pays a digest and a sidecar
+   GET per file, and reading that as silence would manufacture a stall.
+
+   `storage/ops.py`, `storage/rolling.py`, `storage/cloud.py` and the template page
+   loops are additions to this ADR's original three-file sketch, each because a
+   single step there can outlast the budget with nothing else to carry its signal:
+   `ops` owns the actual byte loops the other modules delegate to;
+   `RollingFileWriter` is the *recommended* replacement for the v4.0-deprecated
+   writers and is not a `Writer` subclass, so it inherits no hook; and the
+   `fetch_*` page loops accumulate in memory rather than streaming to a writer, so
+   there is no write side to cover for them.
+
+   **Where mechanism 1 stops and mechanism 2 starts.** A hook only helps a loop
+   that yields *and* has a boundary worth marking. `SqlApp._transform_entity` has
+   neither: rollout step 1 (FND-282) offloaded its whole record map into a single
+   `run_in_thread` hop, and the loop inside is line-by-line with no batch
+   boundary — the only boundary available is the per-record one this rule
+   forbids. It needs no hook, because the auto-hold below vouches for the entire
+   offloaded call. Coverage there is mechanism 2, and the residual is the 24h
+   backstop that warn mode is meant to surface.
+
+   The general rule: **a synchronous loop that holds the event loop cannot be
+   fixed with a mark** — the watchdog coroutine cannot tick to read one. That is
+   loop starvation, `heartbeat_timeout`'s job, and an ADR-0010 offload is the
+   fix. Offload first, then decide whether the offloaded call wants a hook
+   (a yielding batch loop) or a hold (one opaque hop).
 2. **`run_in_thread` auto-holds (automatic for blocking work).** Anything offloaded
    through `run_in_thread` is wrapped in an **unbounded** hold by the SDK, so a
    legitimate long blocking call is never false-killed and behaviour on upgrade is

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,9 +1,12 @@
 """Unit test configuration and autouse fixtures."""
 
+from collections.abc import Iterator
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from loguru import logger as _loguru_logger
+
+from application_sdk.execution.progress import ProgressTracker, bind_progress_tracker
 
 # Re-export shared registry fixtures so all unit tests can use them without
 # explicit per-file imports (pytest discovers fixtures via conftest chain).
@@ -11,6 +14,45 @@ from application_sdk.testing.fixtures import (  # noqa: F401
     clean_app_registry,
     clean_task_registry,
 )
+
+
+class RecordingProgressTracker(ProgressTracker):
+    """A real :class:`ProgressTracker` that also keeps every label it was given.
+
+    ``ProgressTracker`` only retains the *most recent* label, which is all the
+    stall watchdog needs but not enough to assert that a framework hook fires
+    once per unit of work rather than once per record (ADR-0018's hard
+    constraint). Subclassing keeps the real stall/hold behaviour intact — no
+    stub — while adding the ordered label history a hook test needs.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.labels: list[str] = []
+
+    def mark_progress(self, label: str = "") -> None:
+        self.labels.append(label)
+        super().mark_progress(label)
+
+    def count(self, label: str) -> int:
+        """How many times *label* was recorded."""
+        return self.labels.count(label)
+
+
+@pytest.fixture
+def progress_marks() -> Iterator[RecordingProgressTracker]:
+    """Bind a recording tracker for the test, and hand it back.
+
+    Framework hooks read the current attempt's tracker via
+    :func:`~application_sdk.execution.progress.current_progress_tracker`, which
+    outside an activity returns the inert tracker that discards every signal —
+    so binding a real one here is what turns the hooks on for a test. Stands in
+    for the per-attempt bind ``activities.py`` does in production, via the same
+    ``bind_progress_tracker`` block, so a test can never leave a binding behind.
+    """
+    tracker = RecordingProgressTracker()
+    with bind_progress_tracker(tracker):
+        yield tracker
 
 
 @pytest.fixture

--- a/tests/unit/storage/formats/test_writer_progress_hooks.py
+++ b/tests/unit/storage/formats/test_writer_progress_hooks.py
@@ -1,0 +1,261 @@
+"""Framework ``mark_progress()`` hooks on the batched output writers (FND-288).
+
+ADR-0018's hard constraint for these hooks is *batch and chunk boundaries,
+never per record* — so every test here asserts a **count**, not just presence.
+A hook that fired per record would still make the presence assertions pass.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
+from application_sdk.storage.formats.json import JsonFileWriter
+from application_sdk.storage.formats.parquet import ParquetFileWriter
+from application_sdk.storage.rolling import CountPolicy, RollingFileWriter
+from tests.unit.conftest import RecordingProgressTracker
+
+_ROWS = 1000
+_BUFFER = 100
+
+
+def _frame(rows: int = _ROWS) -> pd.DataFrame:
+    return pd.DataFrame({"id": range(rows), "name": [f"n{i}" for i in range(rows)]})
+
+
+# ---------------------------------------------------------------------------
+# Writer._flush_buffer — the boundary every writer subclass shares
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_flush_buffer_marks_once_per_chunk_never_per_record(
+    tmp_path: Path, progress_marks: RecordingProgressTracker
+) -> None:
+    writer = ParquetFileWriter(
+        path=str(tmp_path / "out"), buffer_size=_BUFFER, defer_uploads=True
+    )
+    await writer.write(_frame())
+
+    assert progress_marks.count("writer.flush_buffer") == _ROWS // _BUFFER
+    # The whole point of the constraint: the row count must not leak into the
+    # mark count.
+    assert len(progress_marks.labels) < _ROWS
+
+
+@pytest.mark.asyncio
+async def test_json_writer_inherits_the_same_flush_hook(
+    tmp_path: Path, progress_marks: RecordingProgressTracker
+) -> None:
+    """JsonFileWriter overrides only ``_write_chunk``, so it gets the hook free."""
+    with patch("application_sdk.storage.formats._upload_file"):
+        writer = JsonFileWriter(path=str(tmp_path / "json"), buffer_size=_BUFFER)
+        await writer.write(_frame())
+
+    assert progress_marks.count("writer.flush_buffer") == _ROWS // _BUFFER
+
+
+@pytest.mark.asyncio
+async def test_an_empty_write_marks_nothing(
+    tmp_path: Path, progress_marks: RecordingProgressTracker
+) -> None:
+    """No unit of work completed means no progress signal.
+
+    A mark on a no-op write would forgive real quiet time — an activity looping
+    over empty frames is exactly the wedged-but-looping shape the watchdog
+    exists to catch.
+    """
+    writer = ParquetFileWriter(path=str(tmp_path / "empty"), defer_uploads=True)
+    await writer.write(pd.DataFrame())
+
+    assert progress_marks.labels == []
+
+
+@pytest.mark.asyncio
+async def test_batched_write_marks_every_batch(
+    tmp_path: Path, progress_marks: RecordingProgressTracker
+) -> None:
+    """``write_batches`` streams; each batch's chunks must each be marked."""
+
+    def batches():
+        for _ in range(4):
+            yield _frame(_BUFFER)
+
+    writer = ParquetFileWriter(
+        path=str(tmp_path / "batched"), buffer_size=_BUFFER, defer_uploads=True
+    )
+    await writer.write_batches(batches())
+
+    assert progress_marks.count("writer.flush_buffer") == 4
+
+
+# ---------------------------------------------------------------------------
+# close() → the statistics emission
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_close_marks_the_statistics_emission_once(
+    tmp_path: Path, progress_marks: RecordingProgressTracker
+) -> None:
+    writer = ParquetFileWriter(
+        path=str(tmp_path / "stats"), buffer_size=_BUFFER, defer_uploads=True
+    )
+    await writer.write(_frame(_BUFFER))
+    await writer.close()
+
+    assert progress_marks.count("writer.statistics") == 1
+    # It is the *last* thing the writer emits, so it must be the label an
+    # operator sees if the attempt goes quiet right after a writer finished.
+    assert progress_marks.labels[-1] == "writer.statistics"
+
+
+@pytest.mark.asyncio
+async def test_a_second_close_marks_nothing_more(
+    tmp_path: Path, progress_marks: RecordingProgressTracker
+) -> None:
+    """close() is idempotent; its cached-result path does no work to report."""
+    writer = ParquetFileWriter(
+        path=str(tmp_path / "twice"), buffer_size=_BUFFER, defer_uploads=True
+    )
+    await writer.write(_frame(_BUFFER))
+    await writer.close()
+    await writer.close()
+
+    assert progress_marks.count("writer.statistics") == 1
+
+
+# ---------------------------------------------------------------------------
+# The parquet consolidation path, which never reaches _flush_buffer
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_consolidation_path_marks_accumulation_and_consolidation(
+    tmp_path: Path, progress_marks: RecordingProgressTracker
+) -> None:
+    def batches():
+        for _ in range(4):
+            yield _frame(_BUFFER)
+
+    writer = ParquetFileWriter(
+        path=str(tmp_path / "consolidated"),
+        buffer_size=_BUFFER,
+        use_consolidation=True,
+        defer_uploads=True,
+    )
+    writer.consolidation_threshold = 2 * _BUFFER
+    await writer.write_batches(batches())
+
+    # Four accumulated chunks, and four consolidated files (two folders hit the
+    # 200-record threshold; each consolidates into 200/buffer_size = 2 files).
+    # The consolidation path bypasses _flush_buffer entirely, so without its own
+    # hooks this whole stream would be one quiet window.
+    assert progress_marks.count("writer.accumulate_chunk") == 4
+    assert progress_marks.count("writer.consolidate_chunk") == 4
+    assert progress_marks.count("writer.flush_buffer") == 0
+
+
+# ---------------------------------------------------------------------------
+# RollingFileWriter — the recommended replacement, and not a Writer subclass
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rolling_writer_marks_once_per_rolled_chunk(
+    tmp_path: Path, progress_marks: RecordingProgressTracker
+) -> None:
+    flushed: list[str] = []
+
+    def flush_fn(batches: list[pd.DataFrame], path: str) -> None:
+        pd.concat(batches, ignore_index=True).to_json(path, orient="records")
+        flushed.append(path)
+
+    async with RollingFileWriter[pd.DataFrame](
+        base_path=str(tmp_path),
+        extension=".json",
+        flush_fn=flush_fn,
+        rollover_policy=CountPolicy(max_records=_BUFFER),
+    ) as writer:
+        for _ in range(3):
+            await writer.append(_frame(_BUFFER))
+
+    assert progress_marks.count("writer.rolling_flush") == len(flushed)
+    assert progress_marks.count("writer.rolling_flush") == 3
+
+
+@pytest.mark.asyncio
+async def test_rolling_writer_marks_before_the_completion_callback(
+    tmp_path: Path, progress_marks: RecordingProgressTracker
+) -> None:
+    """A slow ``on_chunk_complete`` must be measured, not excused.
+
+    The mark lands before the callback runs, so time spent inside a caller's
+    callback counts toward the no-progress window rather than being credited to
+    the chunk that preceded it.
+    """
+    seen_at_callback: list[int] = []
+
+    def flush_fn(batches: list[pd.DataFrame], path: str) -> None:
+        pd.concat(batches, ignore_index=True).to_json(path, orient="records")
+
+    def on_chunk_complete(index: int, path: str) -> None:
+        seen_at_callback.append(progress_marks.count("writer.rolling_flush"))
+
+    async with RollingFileWriter[pd.DataFrame](
+        base_path=str(tmp_path),
+        extension=".json",
+        flush_fn=flush_fn,
+        rollover_policy=CountPolicy(max_records=_BUFFER),
+        on_chunk_complete=on_chunk_complete,
+    ) as writer:
+        await writer.append(_frame(_BUFFER))
+
+    assert seen_at_callback == [1]
+
+
+@pytest.mark.asyncio
+async def test_a_failed_flush_marks_nothing(
+    tmp_path: Path, progress_marks: RecordingProgressTracker
+) -> None:
+    def flush_fn(batches: list[pd.DataFrame], path: str) -> None:
+        raise OSError("disk full")
+
+    writer = RollingFileWriter[pd.DataFrame](
+        base_path=str(tmp_path),
+        extension=".json",
+        flush_fn=flush_fn,
+        rollover_policy=CountPolicy(max_records=_BUFFER),
+    )
+    with pytest.raises(OSError, match="disk full"):
+        await writer.append(_frame(_BUFFER))
+
+    assert progress_marks.labels == []
+
+
+# ---------------------------------------------------------------------------
+# Inertness — the hooks must be invisible until a tracker is bound
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_writers_behave_identically_with_no_tracker_bound(
+    tmp_path: Path,
+) -> None:
+    """No ``progress_marks`` fixture here: no tracker is bound, on purpose.
+
+    Outside an activity ``current_progress_tracker()`` hands back the inert
+    tracker, so every hook discards its signal and behaviour is unchanged.
+    """
+    writer = ParquetFileWriter(
+        path=str(tmp_path / "inert"), buffer_size=_BUFFER, defer_uploads=True
+    )
+    await writer.write(_frame())
+    result = await writer.close()
+
+    assert result.total_record_count == _ROWS
+    assert os.path.isdir(str(tmp_path / "inert"))

--- a/tests/unit/storage/test_progress_hooks.py
+++ b/tests/unit/storage/test_progress_hooks.py
@@ -1,0 +1,283 @@
+"""Framework ``mark_progress()`` hooks on the ObjectStore transfer loops (FND-288).
+
+Two grains are hooked, on purpose (ADR-0018):
+
+* **per part / per chunk** inside ``ops.upload_file``, ``ops.download_file``,
+  ``chunked._fetch_chunk`` and ``cloud.CloudStore.upload`` — so that a single
+  multi-GB object cannot be one long quiet window;
+* **per file** inside ``transfer._upload_one`` / ``_upload_from_store`` /
+  ``_download_one`` and ``file_ref_sync._replace_refs`` — so the label an
+  operator reads in a stall message says *which* loop went quiet.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from application_sdk.contracts.types import FileReference, StorageTier
+from application_sdk.storage.chunked import download_file_chunked
+from application_sdk.storage.cloud import CloudStore
+from application_sdk.storage.factory import create_memory_store
+from application_sdk.storage.file_ref_sync import (
+    materialize_file_refs,
+    persist_file_refs,
+)
+from application_sdk.storage.ops import download_file, upload_file
+from application_sdk.storage.transfer import download, upload
+from tests.unit.conftest import RecordingProgressTracker
+
+_PART = 1024
+
+
+@pytest.fixture
+def store():
+    return create_memory_store()
+
+
+def _local_file(tmp_path: Path, name: str, parts: int = 4) -> Path:
+    path = tmp_path / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"x" * (_PART * parts))
+    return path
+
+
+# ---------------------------------------------------------------------------
+# ops.upload_file / ops.download_file — the byte loops
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_upload_marks_once_per_part(
+    tmp_path: Path, store, progress_marks: RecordingProgressTracker
+) -> None:
+    """A large single file must emit a signal per part, not one at the end."""
+    src = _local_file(tmp_path, "big.bin", parts=4)
+
+    await upload_file("k/big.bin", src, store, chunk_size=_PART, normalize=False)
+
+    assert progress_marks.count("storage.upload_part") == 4
+
+
+@pytest.mark.asyncio
+async def test_a_zero_byte_upload_marks_nothing(
+    tmp_path: Path, store, progress_marks: RecordingProgressTracker
+) -> None:
+    """No parts written means no part-level progress to report."""
+    empty = tmp_path / "empty.bin"
+    empty.write_bytes(b"")
+
+    await upload_file("k/empty.bin", empty, store, normalize=False)
+
+    assert progress_marks.count("storage.upload_part") == 0
+
+
+@pytest.mark.asyncio
+async def test_download_marks_per_streamed_chunk(
+    tmp_path: Path, store, progress_marks: RecordingProgressTracker
+) -> None:
+    src = _local_file(tmp_path, "src.bin", parts=4)
+    await upload_file("k/src.bin", src, store, normalize=False)
+    progress_marks.labels.clear()
+
+    await download_file("k/src.bin", tmp_path / "out.bin", store, normalize=False)
+
+    assert progress_marks.count("storage.download_chunk") >= 1
+    assert (tmp_path / "out.bin").read_bytes() == src.read_bytes()
+
+
+# ---------------------------------------------------------------------------
+# chunked._fetch_chunk — the parallel range-GET path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_chunked_download_marks_once_per_range_get(
+    tmp_path: Path, store, progress_marks: RecordingProgressTracker
+) -> None:
+    src = _local_file(tmp_path, "ranged.bin", parts=4)
+    await upload_file("k/ranged.bin", src, store, normalize=False)
+    progress_marks.labels.clear()
+
+    await download_file_chunked(
+        "k/ranged.bin",
+        tmp_path / "ranged-out.bin",
+        store,
+        chunk_size_bytes=_PART,
+        normalize=False,
+        resume=False,
+    )
+
+    assert progress_marks.count("storage.download_range") == 4
+    assert (tmp_path / "ranged-out.bin").read_bytes() == src.read_bytes()
+
+
+# ---------------------------------------------------------------------------
+# transfer — the per-file boundaries, including skips
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_directory_upload_marks_once_per_file(
+    tmp_path: Path, store, progress_marks: RecordingProgressTracker
+) -> None:
+    src_dir = tmp_path / "dir"
+    for i in range(3):
+        _local_file(src_dir, f"f{i}.bin", parts=1)
+
+    await upload(str(src_dir), storage_path="prefix/dir/", store=store)
+
+    assert progress_marks.count("storage.upload_file") == 3
+
+
+@pytest.mark.asyncio
+async def test_a_hash_match_skip_still_counts_as_progress(
+    tmp_path: Path, store, progress_marks: RecordingProgressTracker
+) -> None:
+    """An idempotent retry that skips every file is doing real work.
+
+    Each skip costs a local digest plus a sidecar GET. Treating a long run of
+    skips as silence would make a retry over a large prefix look like a stall.
+    """
+    src_dir = tmp_path / "dir"
+    for i in range(3):
+        _local_file(src_dir, f"f{i}.bin", parts=1)
+
+    await upload(str(src_dir), storage_path="prefix/dir/", store=store)
+    progress_marks.labels.clear()
+
+    result = await upload(
+        str(src_dir), storage_path="prefix/dir/", skip_if_exists=True, store=store
+    )
+
+    assert result.synced is False
+    assert progress_marks.count("storage.upload_file") == 3
+    assert progress_marks.count("storage.upload_part") == 0
+
+
+@pytest.mark.asyncio
+async def test_prefix_download_marks_once_per_file(
+    tmp_path: Path, store, progress_marks: RecordingProgressTracker
+) -> None:
+    src_dir = tmp_path / "dir"
+    for i in range(3):
+        _local_file(src_dir, f"f{i}.bin", parts=1)
+    await upload(str(src_dir), storage_path="prefix/dir/", store=store)
+    progress_marks.labels.clear()
+
+    await download("prefix/dir/", str(tmp_path / "out"), store=store)
+
+    assert progress_marks.count("storage.download_file") == 3
+
+
+@pytest.mark.asyncio
+async def test_cross_store_copy_marks_per_file(
+    tmp_path: Path, progress_marks: RecordingProgressTracker
+) -> None:
+    """The SDR deployment-store fallback streams from one store to another."""
+    source_store = create_memory_store()
+    target_store = create_memory_store()
+    src_dir = tmp_path / "dir"
+    for i in range(2):
+        _local_file(src_dir, f"f{i}.bin", parts=1)
+    await upload(str(src_dir), storage_path="src/dir/", store=source_store)
+    progress_marks.labels.clear()
+
+    # local_path absent on this "pod" → the fallback branch streams from source.
+    await upload(
+        str(tmp_path / "missing"),
+        storage_path="dst/dir/",
+        store=target_store,
+        _source_ref=FileReference(storage_path="src/dir/"),
+        _source_store=source_store,
+    )
+
+    assert progress_marks.count("storage.copy_file") == 2
+
+
+# ---------------------------------------------------------------------------
+# file_ref_sync — the interceptor's typed-I/O boundary
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_persist_marks_once_per_reference(
+    tmp_path: Path, store, progress_marks: RecordingProgressTracker
+) -> None:
+    refs = [
+        FileReference.from_local(str(_local_file(tmp_path, f"r{i}.bin", parts=1)))
+        for i in range(3)
+    ]
+
+    await persist_file_refs(store, refs, output_path="artifacts/run")
+
+    assert progress_marks.count("file_ref.persist") == 3
+
+
+@pytest.mark.asyncio
+async def test_materialize_marks_once_per_reference(
+    tmp_path: Path, store, progress_marks: RecordingProgressTracker
+) -> None:
+    refs = [
+        FileReference.from_local(
+            str(_local_file(tmp_path, f"m{i}.bin", parts=1)), tier=StorageTier.RETAINED
+        )
+        for i in range(2)
+    ]
+    persisted = await persist_file_refs(store, refs, output_path="artifacts/run")
+    # FileReference is immutable, so drop local_path via model_copy to force a
+    # real download rather than a local-sidecar short-circuit.
+    remote_only = [ref.model_copy(update={"local_path": None}) for ref in persisted]
+    progress_marks.labels.clear()
+
+    await materialize_file_refs(store, remote_only)
+
+    assert progress_marks.count("file_ref.materialize") == 2
+
+
+# ---------------------------------------------------------------------------
+# CloudStore — external / customer-owned buckets
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cloudstore_upload_marks_once_per_part(
+    tmp_path: Path, progress_marks: RecordingProgressTracker
+) -> None:
+    cloud = CloudStore(create_memory_store())
+    src = _local_file(tmp_path, "export.bin", parts=4)
+
+    await cloud.upload(src, "exports/export.bin")
+
+    # CloudStore fixes its own 8 MiB target part size, so a small file is one
+    # part — the assertion that matters is that the loop marks at all, since a
+    # GB-class export to a customer bucket is the failure shape this covers.
+    assert progress_marks.count("cloudstore.upload_part") >= 1
+
+
+# ---------------------------------------------------------------------------
+# Inertness
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_transfers_behave_identically_with_no_tracker_bound(
+    tmp_path: Path, store
+) -> None:
+    """No ``progress_marks`` fixture here: no tracker is bound, on purpose.
+
+    Outside an activity ``current_progress_tracker()`` hands back the inert
+    tracker, so every hook discards its signal and behaviour is unchanged.
+    """
+    src = _local_file(tmp_path, "inert.bin", parts=2)
+
+    digest = await upload_file(
+        "k/inert.bin", src, store, chunk_size=_PART, normalize=False
+    )
+    await download_file(
+        "k/inert.bin", tmp_path / "inert-out.bin", store, normalize=False
+    )
+
+    assert digest is not None
+    assert (tmp_path / "inert-out.bin").read_bytes() == src.read_bytes()

--- a/tests/unit/templates/test_progress_hooks.py
+++ b/tests/unit/templates/test_progress_hooks.py
@@ -1,0 +1,235 @@
+"""Framework ``mark_progress()`` hooks on the record emission path (FND-288).
+
+Covers the two shapes in the SQL templates (ADR-0018 → *Feeding the tracker*):
+
+* ``SqlApp._extract_entity`` — fetch a page, write a batch, repeat. Marking at
+  the page boundary is what makes the read loop need no hold: only a *single*
+  fetch+write cycle slower than ``max_no_progress_seconds`` needs one.
+* ``SqlMetadataExtractor.fetch_*`` — page loops with no write side at all, so
+  nothing else would carry the signal for them.
+
+Also pins the deliberate *absence* of a hook in ``_transform_entity``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, ClassVar
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from application_sdk.templates.contracts.sql_metadata import (
+    ExtractionTaskInput,
+    FetchColumnsInput,
+    FetchDatabasesInput,
+    FetchSchemasInput,
+    FetchTablesInput,
+    TransformInput,
+)
+from application_sdk.templates.sql_app import SqlApp
+from application_sdk.templates.sql_metadata_extractor import SqlMetadataExtractor
+from tests.unit.conftest import RecordingProgressTracker
+
+
+class _PagedSQLClient:
+    """Yields a fixed list of pages from ``run_query``, one page per iteration."""
+
+    def __init__(self, pages: list[list[dict[str, Any]]] | None = None) -> None:
+        self._pages = pages or []
+        self.closed = False
+        self.last_query: str | None = None
+
+    async def load(self, credentials: Any = None) -> None:
+        pass
+
+    async def run_query(self, query: str, batch_size: int = 100000):
+        self.last_query = query
+        for page in self._pages:
+            yield page
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+def _task_input(output_path: str, **kwargs: Any) -> TransformInput:
+    defaults: dict[str, Any] = {
+        "workflow_id": "test-wf",
+        "output_path": output_path,
+        "output_prefix": "/tmp",
+        "exclude_filter": "",
+        "include_filter": "",
+        "temp_table_regex": "",
+    }
+    defaults.update(kwargs)
+    return TransformInput(**defaults)
+
+
+class _App(SqlApp):
+    sql_client_class: ClassVar = _PagedSQLClient  # type: ignore[assignment]
+    _app_registered: ClassVar[bool] = True
+    fetch_database_sql: ClassVar[str] = "SELECT database_name FROM databases"
+
+    def map_database(self, record: dict[str, Any], connection_qn: str) -> dict:
+        return {"typeName": "Database", "qualifiedName": connection_qn}
+
+
+# ---------------------------------------------------------------------------
+# extract_* — page boundary
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_extract_marks_once_per_page_never_per_record(
+    tmp_path: Path, progress_marks: RecordingProgressTracker
+) -> None:
+    pages = [[{"database_name": f"db{i}-{j}"} for j in range(50)] for i in range(4)]
+    client = _PagedSQLClient(pages=pages)
+    app = _App()
+
+    with patch.object(app, "_init_sql_client", AsyncMock(return_value=client)):
+        result = await app.extract_databases(_task_input(str(tmp_path)))
+
+    assert result.total_record_count == 200
+    assert progress_marks.count("extract.page") == 4
+    # The constraint made explicit: 200 records, 4 marks.
+    assert len(progress_marks.labels) == 4
+
+
+@pytest.mark.asyncio
+async def test_an_extract_that_yields_no_pages_marks_nothing(
+    tmp_path: Path, progress_marks: RecordingProgressTracker
+) -> None:
+    client = _PagedSQLClient(pages=[])
+    app = _App()
+
+    with patch.object(app, "_init_sql_client", AsyncMock(return_value=client)):
+        await app.extract_databases(_task_input(str(tmp_path)))
+
+    assert progress_marks.labels == []
+
+
+@pytest.mark.asyncio
+async def test_transform_deliberately_records_no_progress(
+    tmp_path: Path, progress_marks: RecordingProgressTracker
+) -> None:
+    """``_transform_entity`` is covered by a hold, not by a framework hook.
+
+    FND-282 offloaded the whole record map to a single ``run_in_thread`` hop, so
+    it is FND-290's unbounded auto-hold that vouches for it — mechanism 2, not
+    mechanism 1. There is also no boundary to hook: the loop is line-by-line,
+    and marking per record is the one thing ADR-0018 forbids outright.
+
+    Pinned as a test because the tempting change here is wrong in both
+    directions — adding a per-record mark violates the hard constraint, and
+    adding one *outside* the offloaded callable would mark once for a transform
+    that can run for hours.
+    """
+    raw_dir = tmp_path / "raw" / "database"
+    raw_dir.mkdir(parents=True)
+    (raw_dir / "records.json").write_text(
+        "\n".join(json.dumps({"database_name": f"db{i}"}) for i in range(20)) + "\n"
+    )
+    app = _App()
+
+    result = await app.transform_databases(_task_input(str(tmp_path)))
+
+    assert result.total_record_count == 20
+    assert progress_marks.labels == []
+
+
+# ---------------------------------------------------------------------------
+# fetch_* — page loops with no write side
+# ---------------------------------------------------------------------------
+
+
+def _extractor(client: _PagedSQLClient, **attrs: str) -> SqlMetadataExtractor:
+    class _E(SqlMetadataExtractor):
+        _app_registered = True
+        sql_client_class = _PagedSQLClient  # type: ignore[assignment]
+
+    for name, value in attrs.items():
+        setattr(_E, name, value)
+
+    extractor = _E.__new__(_E)
+
+    async def _fake_load(_input: ExtractionTaskInput) -> _PagedSQLClient:
+        return client
+
+    extractor._load_sql_client = _fake_load  # type: ignore[method-assign]
+    return extractor
+
+
+@pytest.mark.parametrize(
+    ("attr", "sql", "row_key", "method", "input_cls", "label"),
+    [
+        (
+            "fetch_database_sql",
+            "SELECT db FROM meta",
+            "database_name",
+            "fetch_databases",
+            FetchDatabasesInput,
+            "fetch_databases.page",
+        ),
+        (
+            "fetch_schema_sql",
+            "SELECT s FROM meta",
+            "schema_name",
+            "fetch_schemas",
+            FetchSchemasInput,
+            "fetch_schemas.page",
+        ),
+        (
+            "fetch_table_sql",
+            "SELECT t FROM meta",
+            "table_name",
+            "fetch_tables",
+            FetchTablesInput,
+            "fetch_tables.page",
+        ),
+        (
+            "fetch_column_sql",
+            "SELECT c FROM meta",
+            "column_name",
+            "fetch_columns",
+            FetchColumnsInput,
+            "fetch_columns.page",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_each_fetch_task_marks_once_per_page(
+    attr: str,
+    sql: str,
+    row_key: str,
+    method: str,
+    input_cls: type,
+    label: str,
+    progress_marks: RecordingProgressTracker,
+) -> None:
+    pages = [[{row_key: f"v{i}-{j}"} for j in range(10)] for i in range(3)]
+    client = _PagedSQLClient(pages=pages)
+    extractor = _extractor(client, **{attr: sql})
+
+    await getattr(extractor, method)(input_cls())
+
+    assert progress_marks.count(label) == 3
+    assert len(progress_marks.labels) == 3
+
+
+@pytest.mark.asyncio
+async def test_fetch_tasks_are_inert_without_a_bound_tracker() -> None:
+    """No ``progress_marks`` fixture here: no tracker is bound, on purpose.
+
+    Outside an activity ``current_progress_tracker()`` hands back the inert
+    tracker, so every hook discards its signal and behaviour is unchanged.
+    """
+    pages = [[{"database_name": "db1"}]]
+    client = _PagedSQLClient(pages=pages)
+    extractor = _extractor(client, fetch_database_sql="SELECT db FROM meta")
+
+    out = await extractor.fetch_databases(FetchDatabasesInput())
+
+    assert out.databases == ["db1"]
+    assert client.closed is True


### PR DESCRIPTION
> No longer stacked — #3145 (FND-283), #3147 (FND-286), #3148 (FND-287) and #3146 (FND-282) have all merged, so this targets `main` directly and the full CI matrix applies. Rebased onto FND-282, which changed decision 3 below.

Implements [FND-288](https://linear.app/atlan-epd/issue/FND-288/framework-mark-progress-hooks-on-the-writer-emission-and-transfer) — **rollout step 2** of [ADR-0018](https://github.com/atlanhq/application-sdk/blob/main/docs/adr/0018-progress-aware-heartbeat.md): get the streaming majority of connector runtime emitting progress *before* anything observes it, with no code change in any app.

This PR is hooks only. It adds no new API and does not touch `execution/progress.py` — every hook reads the attempt's tracker through **#3148's `current_progress_tracker()`**, which outside an activity returns the inert tracker. So the hooks are live wherever `activities.py` binds a tracker (#3148) and inert everywhere else; the watchdog that acts on the signal is #3147, in `warn` mode.

## The hooks

| Where | Unit | Label |
| --- | --- | --- |
| `Writer._flush_buffer` | one buffer chunk written | `writer.flush_buffer` |
| `Writer._write_statistics` | statistics sidecar at `close()` | `writer.statistics` |
| `ParquetFileWriter._write_chunk_to_temp_folder` | one accumulated chunk | `writer.accumulate_chunk` |
| `ParquetFileWriter._consolidate_current_folder` | one consolidated file | `writer.consolidate_chunk` |
| `RollingFileWriter._flush_locked` | one rolled chunk | `writer.rolling_flush` |
| `ops.upload_file` / `ops.download_file` | one multipart part / streamed chunk | `storage.upload_part`, `storage.download_chunk` |
| `chunked._fetch_chunk` | one range GET at its offset | `storage.download_range` |
| `transfer._upload_one` / `_upload_from_store` / `_download_one` | one file transferred **or** skipped on a hash match | `storage.upload_file`, `storage.copy_file`, `storage.download_file` |
| `CloudStore.upload` | one part to an external store | `cloudstore.upload_part` |
| `file_ref_sync._replace_refs` | one `FileReference` persisted / materialised | `file_ref.persist`, `file_ref.materialize` |
| `SqlApp._extract_entity` | one fetched page serialised + written to raw JSONL | `extract.page` |
| `SqlMetadataExtractor.fetch_databases` / `fetch_schemas` / `fetch_tables` / `fetch_columns` | one fetched page | `fetch_*.page` |

## Decisions a reviewer should look at

**1. Uploads are hooked at *two* grains, deliberately.** Per part inside `ops.upload_file`, and per file in `transfer`. The fine grain is load-bearing: a single multi-GB parquet upload goes through `ops.upload_file`'s `while True: read → await writer.write(chunk)` loop, and without a per-part mark that whole upload is one quiet window regardless of how many files the directory had. The coarse grain is for the *label* — `storage.upload_file` in a stall message tells an operator the attempt was moving whole files, `storage.upload_part` tells them it was stuck mid-transfer on one. Both are cheap; only the pair distinguishes the two failures.

**2. A hash-match skip counts as progress.** `_upload_one` / `_download_one` / `_upload_from_store` mark on the skip path too. An idempotent retry over a large prefix pays a local digest plus a sidecar GET per file and transfers nothing; reading that as silence would manufacture a stall out of the SDK's own dedup working correctly. Tested (`test_a_hash_match_skip_still_counts_as_progress` asserts three file marks and zero part marks).

**3. `SqlApp._transform_entity` is covered by a hold, not a hook — and there is a test pinning that.** FND-282 (#3146, rollout step 1) landed while this PR was open and offloaded the whole record map into a single `run_in_thread` hop. So it needs no framework hook for two reasons that both survive: the loop inside is line-by-line with **no batch boundary to mark at** — the only boundary available is the per-record one ADR-0018 forbids outright — and the single offloaded hop is what FND-290's unbounded auto-hold vouches for. Coverage there is mechanism 2, and the residual is the 24h backstop that warn mode exists to surface. The test is pinned because the tempting change is wrong in *both* directions: a per-record mark violates the hard constraint, and a mark outside the offloaded callable would fire once for a transform that can run for hours.

The ADR's mechanism-1 note is rewritten to match, and generalised: **a synchronous loop that holds the event loop cannot be fixed with a mark** (the watchdog coroutine cannot tick to read one) — offload first, then decide whether the result wants a hook (a yielding batch loop) or a hold (one opaque hop).

**4. Four files beyond the issue's enumerated list.** FND-288 names the writers, the emission path, and `storage/{transfer,chunked,file_ref_sync}.py`. I also hooked `storage/ops.py`, `storage/rolling.py`, `storage/cloud.py` and the template page loops, each because ADR-0018's own rule ("if any one step can run longer than the budget without emitting a signal, that step must be made observable") applies and nothing else would carry the signal:

- **`ops.py`** owns the actual byte loops the three named modules delegate to. Hooking only the callers leaves the single-large-file case uncovered — see decision 1.
- **`rolling.py`** — `RollingFileWriter` is the **recommended replacement** for the v4.0-deprecated `ParquetFileWriter`/`JsonFileWriter`, and it is not a `Writer` subclass, so it inherits no hook. Leaving it out would give the migration target *less* stall coverage than the thing it replaces.
- **`cloud.py`** — `CloudStore.upload` is the same part loop against a customer-owned bucket. Its download side needed nothing: `_download_single` routes through `download_file_chunked`, already hooked.
- **the `fetch_*` page loops** — these four accumulate names (or a count) in memory and return, so unlike extract → write there is no write side to carry the signal, and a wide catalog can page for a long time.

**5. Lazy imports in `ops.py` / `chunked.py` / `cloud.py`, top-level everywhere else.** `application_sdk.execution`'s package `__init__` reaches back into `storage.ops` (via `app.base → contracts → credentials → common.utils`), so a top-level `from application_sdk.execution.progress import current_progress_tracker` in those three modules is a hard `ImportError` — verified, not assumed. Hoisted above the loop in `upload_file` / `download_file` / `CloudStore.upload` so the `sys.modules` lookup is paid once per transfer; `_fetch_chunk` pays it per chunk, which is nothing against a multi-MiB range GET. `transfer.py`, `formats/`, `rolling.py` and the templates already import from `application_sdk.execution` at top level, so they use a plain import.

**6. Marks land *after* the unit, never before.** Marking on entry would report work that has not happened, and a wedge inside the very first unit would read as progress. `RollingFileWriter` marks before its `on_chunk_complete` callback for the same reason — a slow caller callback must be measured as the quiet window it is, not credited to the chunk that preceded it (`test_rolling_writer_marks_before_the_completion_callback`).

**7. Labels are sites, never values.** No key, query, path, credential or customer value is interpolated into a label. The one computed label is `file_ref.{mode}` where `mode` is the literal `"persist"` / `"materialize"`.

**8. No None checks at any hook site**, because #3148's accessor returns a null object rather than `None`. That is the whole reason it was built that way, and this PR is its first bulk consumer: 20 call sites, zero guards.

## The hard constraint: never per record

Every hook test asserts a **count**, not presence — a hook that fired per record would pass a presence assertion:

- 1,000 rows at `buffer_size=100` → exactly **10** `writer.flush_buffer` marks.
- 4 pages × 50 records → exactly **4** `extract.page` marks, `len(labels) == 4`.
- 3 pages × 10 rows per `fetch_*` → exactly **3** marks.

Empty/failed units mark nothing: an empty `write()`, an extract that yields no pages, a flush that raises, and a zero-byte upload all record zero — a mark on a no-op would forgive real quiet time, which is exactly the wedged-but-looping shape the watchdog exists to catch.

## Benchmark — no measurable regression

400,000 rows in 40 batches at `buffer_size=1000` through `ParquetFileWriter.write_batches` (401 writer marks per run), 9 interleaved repeats with the configuration order rotated each iteration so no config gets a systematically warm slot:

| Config | median | min |
| --- | --- | --- |
| hooks patched out (baseline) | 5710 ms | 5252 ms |
| hooks present, inert tracker | 5476 ms | 5281 ms |
| hooks present, real tracker bound | 5663 ms | 5357 ms |

The end-to-end spread (±10% run to run) swamps the effect — this run the *inert* median came out 4% **below** the hooks-removed baseline, which is noise, not a speedup. The authoritative number is the derived bound from the measured per-call cost:

| | per call | 401 marks | share of a 5.7 s write |
| --- | --- | --- | --- |
| inert tracker | 38.8 ns | 0.02 ms | **0.0003%** |
| real tracker | 154.7 ns | 0.06 ms | **0.0011%** |

(A bare `lambda label='': None` call is 14.0 ns. The inert path is `ContextVar.get()` + a branch + an attribute lookup + an empty method call, hence ~2.8× a bare call and still under 40 ns.)

## Scope left out

- **CNCT-10** (timeout-subtype classification) is a *release-coordination* prerequisite for step 2, not code in this PR — a separate issue on a different team's surface. It must land in the same release as this so stall kills are distinguishable from starvation kills in the fleet-wide numbers; without it the M2 warn data cannot be read.
- **FND-295** owns the user-facing docs.

## Tests

31 new tests across three files, plus a `progress_marks` fixture in `tests/unit/conftest.py` — a `RecordingProgressTracker` subclass bound via #3148's `bind_progress_tracker` block (real stall/hold behaviour, with the ordered label history a count assertion needs).

- `tests/unit/storage/formats/test_writer_progress_hooks.py` — 11: per-chunk counts for parquet and json, empty write, batched write, statistics once (and once on double `close()`), the consolidation path's own two boundaries, `RollingFileWriter` per rolled chunk and its callback ordering, a failed flush, and inertness with no tracker bound.
- `tests/unit/storage/test_progress_hooks.py` — 12: per-part upload, zero-byte upload, streamed download, per-range-GET chunked download, per-file directory upload/download, hash-match skips, the SDR cross-store fallback, persist/materialise per ref, `CloudStore` upload, and inertness.
- `tests/unit/templates/test_progress_hooks.py` — 8: per-page extract (200 records → 4 marks), no pages, the deliberate `_transform_entity` absence, all four `fetch_*` parametrised, and inertness.

No seam tests here — #3148's `test_progress_context.py` already covers binding, reset-on-raise, the inert tracker, reach from both `run_in_thread` entry points, and per-activity isolation.

Verification:

- `uv run pytest tests/unit` — **6666 passed, 9 skipped**
- `uv run pre-commit run --files <all 15 changed files>` — ruff, ruff-format, isort, pyright clean
- Full conformance suite, diffed against the same run on `origin/main` by `(rule, file, message)` — **0 new findings, 0 resolved** (487 both sides), `exitCode: 0`
- Import-cycle check: every touched module imported first in a fresh interpreter

