### PR TITLE
fix(conformance): authenticate private atlanhq git deps in the pre-commit template

### DIFF
--- a/packages/conformance/conformance/bootstrap/templates/checks.yml
+++ b/packages/conformance/conformance/bootstrap/templates/checks.yml
@@ -27,5 +27,14 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y << system_deps >>
-<% endif %>      - uses: atlanhq/application-sdk/.github/actions/setup-deps@main
+<% endif %>      # setup-deps below runs `uv sync`, which for an app with a private-org
+      # (atlanhq) git dependency has to clone that OTHER repo — and the checkout
+      # above carries no auth for it, so the sync dies on
+      # `Permission denied (publickey)` and pre-commit never runs at all.
+      # The action no-ops when ORG_PAT_GITHUB is absent, so apps with only PyPI
+      # dependencies are unaffected and nothing has to be configured per-app.
+      - uses: atlanhq/application-sdk/.github/actions/private-git-auth@main
+        with:
+          token: ${{ secrets.ORG_PAT_GITHUB }}
+      - uses: atlanhq/application-sdk/.github/actions/setup-deps@main
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1

--- a/packages/conformance/tests/test_bootstrap.py
+++ b/packages/conformance/tests/test_bootstrap.py
@@ -1189,9 +1189,12 @@ def test_checks_yml_without_deps_is_byte_identical_to_no_step_render() -> None:
     drift in every already-bootstrapped repo (none of which passes this flag)."""
     rendered = render("checks.yml")
     assert "apt-get" not in rendered
-    # The checkout step is followed immediately by setup-deps, with nothing
-    # (not even an empty line) where the conditional block sat.
-    assert "# v7.0.1\n      - uses: atlanhq" in rendered
+    # The checkout step is followed immediately by the next step's leading
+    # comment, with nothing (not even an empty line) where the conditional
+    # block sat. Asserted on the first line that follows checkout whatever that
+    # step happens to be, so this keeps testing the whitespace contract rather
+    # than pinning which step comes next.
+    assert "# v7.0.1\n      # setup-deps below runs" in rendered
 
 
 def test_checks_yml_renders_system_deps_step() -> None:


### PR DESCRIPTION
Split out of #3151 — that PR is CI-only (`ci:`), this one touches conformance core and so must be titled `fix(conformance):`. The title convention allows exactly one category per PR, so they cannot ride together.

**Merge #3151 first.** This template references `atlanhq/application-sdk/.github/actions/private-git-auth@main`, which #3151 creates.

Closes part of FND-304.

## Problem

The bootstrap `checks.yml` template runs `setup-deps` (which is `uv sync`) with no auth for other atlanhq repos. An app with a private-org git dependency therefore cannot install its dependencies, and pre-commit never runs at all.

This is live, not theoretical — `atlan-snowflake-app` → *Pre-commit Checks* is failing on every run right now, all three `setup-deps` retries dying:

```
× Failed to download and build `query-redaction @
  git+ssh://git@github.com/atlanhq/atlan-query-intelligence-app.git@6d0c6fc…`
      git@github.com: Permission denied (publickey).
  hint: `query-redaction` was included because `atlan-snowflake-app` (v0.1.0) depends on `query-redaction`
```

`atlan-bigquery-app` hit the identical wall and hand-rolled a six-line `git config url.insteadOf` block into its own `checks.yml`, commented *"setup-deps runs uv sync with no auth, so rewrite atlanhq remotes to a token URL first"*. Snowflake has the pristine template and is simply broken.

## Fix

Call the shared `private-git-auth` action ahead of `setup-deps`. Because `checks.yml` is a **workflow** (not a composite action), `secrets.ORG_PAT_GITHUB` resolves directly there — no input, no per-app wiring, nothing to opt into. The action no-ops without a token, so apps with only PyPI dependencies are unaffected.

### Why not fix `setup-deps` itself

That would have been tidier — one change covering every consumer. But composite actions cannot read the `secrets` context, so `setup-deps` would need a `git-token` input that every caller has to pass, which is exactly the per-app opt-in #3151 removes. Doing it one level up, in the workflow template, keeps it automatic.

### Scope

`run-conformance-detect-action.yaml` is the only other template that runs `uv sync`, and it is already covered — `conformance-reusable.yaml` authenticates at job level before invoking it. No other bootstrap template installs dependencies.

## Test change

The byte-identity test guarding the un-taken `<% if system_deps %>` block moves its assertion to the new first-line-after-checkout. It keeps testing the real contract — no stray blank line where the conditional sat, which would surface as C002 drift in every bootstrapped repo — rather than pinning which step comes next.

`251 passed` across `test_bootstrap.py`, `test_bootstrap_drift.py`, `test_bootstrap_extract.py`.

## Follow-up this does not cover

The template governs newly bootstrapped and re-synced repos, and C002 tracks drift at WARN so it never blocks. The two repos with a private dep today still need a direct PR to their own `checks.yml`:

- `atlan-snowflake-app` — currently red; add the step.
- `atlan-bigquery-app` — currently green via its hand-rolled block; swap it for the shared action.
