### PR TITLE
feat(execution): holding_progress() — one context manager for opaque calls (FND-291)

### DIFF
--- a/application_sdk/app/base.py
+++ b/application_sdk/app/base.py
@@ -11,6 +11,7 @@ import threading
 import warnings
 from abc import ABC
 from collections.abc import Callable
+from contextlib import AbstractAsyncContextManager
 from dataclasses import replace
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -948,6 +949,39 @@ class App(ABC):
                 "run_in_thread() can only be called inside @task methods."
             )
         return await self._task_context.run_in_thread(func, *args, **kwargs)
+
+    def holding_progress(
+        self, label: str, *, timeout: float | None
+    ) -> AbstractAsyncContextManager[None]:
+        """Vouch for one opaque operation for as long as you would let it run.
+
+        Pauses the stall watchdog (ADR-0018) for a call the SDK cannot see into,
+        and records the completed call as progress on exit::
+
+            async with self.holding_progress("snapshot metadata query", timeout=1800):
+                rows = await long_single_query(...)
+
+        Only available in @task methods — outside one there is no attempt to
+        vouch for, so a hold there would claim coverage it cannot provide.
+
+        Args:
+            label: The call site being vouched for. Must identify a *site*,
+                never a query, key, credential or customer value.
+            timeout: How long you would let this one operation run before you
+                would rather it failed — not a prediction of its duration.
+                Keyword-only and required; ``None`` declares an unbounded hold.
+
+        Returns:
+            An async context manager. Use it with ``async with``.
+
+        Raises:
+            AppContextError: If called outside a @task method.
+        """
+        if self._task_context is None:
+            raise AppContextError(
+                "holding_progress() can only be called inside @task methods."
+            )
+        return self._task_context.holding_progress(label, timeout=timeout)
 
     # =========================================================================
     # State accessors

--- a/application_sdk/app/context.py
+++ b/application_sdk/app/context.py
@@ -2,6 +2,7 @@
 """Execution context for Apps."""
 
 from collections.abc import Callable
+from contextlib import AbstractAsyncContextManager
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, TypeVar
@@ -435,6 +436,8 @@ class TaskExecutionContext:
     - heartbeat(): Send manual heartbeats with progress details
     - get_last_heartbeat_details(): Get last heartbeat for resume on retry
     - run_in_thread(): Run blocking operations without breaking heartbeats
+    - holding_progress(): Vouch for one opaque call the SDK cannot see into,
+      so the stall watchdog does not read it as a stall
 
     This context is only available inside @task methods, not in run().
     Access via self.task_context in your task methods.
@@ -600,3 +603,55 @@ class TaskExecutionContext:
         )
 
         return await run_in_thread(func, *args, **kwargs)
+
+    def holding_progress(
+        self, label: str, *, timeout: float | None
+    ) -> AbstractAsyncContextManager[None]:
+        """Vouch for one opaque operation for as long as you would let it run.
+
+        Pauses the ADR-0018 stall watchdog for the duration of a call the SDK
+        cannot see into, and records the completed call as progress on exit.
+        Covers both shapes of opaque work — an ``await`` against your own async
+        client, and a blocking call offloaded through :meth:`run_in_thread`::
+
+            # async: your own client, which the SDK cannot see into
+            async with self.task_context.holding_progress(
+                "snapshot metadata query", timeout=1800
+            ):
+                rows = await long_single_query(...)
+
+            # blocking: the same wrapper around the offload
+            async with self.task_context.holding_progress(
+                "full table scan", timeout=7200
+            ):
+                rows = await self.task_context.run_in_thread(cursor.execute, sql)
+
+        Expect to need this in almost every connector: streaming reads that
+        interleave fetch and write are already covered by the write side, but a
+        genuinely opaque *single* call — one large metadata query, one slow
+        list/export — emits nothing until it completes and would otherwise read
+        as a stall.
+
+        Args:
+            label: The call site being vouched for. Must identify a *site* —
+                never interpolate a query, a key, a credential or a customer
+                value into it.
+            timeout: How long you would let this one operation run before you
+                would rather it failed — **not** a prediction of how long it
+                takes. Keyword-only and required: the SDK never defaults this
+                number. ``timeout=None`` declares an unbounded hold, leaving the
+                duration backstop as the only bound. Err generous — too tight
+                kills a healthy run, and stall kills retry.
+
+        Returns:
+            An async context manager. Use it with ``async with``.
+
+        See Also:
+            ``docs/adr/0018-progress-aware-heartbeat.md`` → *Holds* and
+            *Choosing the allowance*.
+        """
+        from application_sdk.execution.progress import (  # noqa: PLC0415 — circular: execution/__init__.py loads _temporal which imports app.base
+            holding_progress,
+        )
+
+        return holding_progress(label, timeout=timeout)

--- a/application_sdk/execution/progress.py
+++ b/application_sdk/execution/progress.py
@@ -22,7 +22,9 @@ Two signals feed it (see ADR-0018 → *Feeding the tracker*):
   query, one slow API call, a blocking call offloaded through
   ``run_in_thread``). The SDK never invents the allowance; a human declares it
   at the one call site that knows, or declares nothing and gets an unbounded
-  hold that the duration backstop owns.
+  hold that the duration backstop owns. App code does not pair these two calls
+  by hand — :func:`holding_progress` is the public front door, and it is the
+  one piece of ADR-0018 an app author is expected to type.
 
 Both signals are produced deep inside code that has no reference to the
 tracker — the SDK's transfer loops, a blocking call offloaded through
@@ -37,9 +39,9 @@ The watchdog that consumes the tracker lives in
 of the three :class:`ProgressWatchdogMode` states. It is handed the tracker by
 injection rather than reading the ContextVar, so it stays unit-testable without
 an activity. The framework hooks (FND-288), the ``run_in_thread`` auto-holds
-(FND-290), the public ``holding_progress()`` context manager (FND-291) and the
-warn-mode telemetry that consumes :class:`ClosedHold` (FND-292) are separate
-pieces built on this one.
+(FND-290) and the warn-mode telemetry that consumes :class:`ClosedHold`
+(FND-292) are separate pieces built on this one; :func:`holding_progress`
+(FND-291) lives here, next to the tracker whose holds it opens.
 """
 
 from __future__ import annotations
@@ -47,8 +49,8 @@ from __future__ import annotations
 import itertools
 import threading
 import time
-from collections.abc import Callable, Iterator
-from contextlib import contextmanager
+from collections.abc import AsyncIterator, Callable, Iterator
+from contextlib import asynccontextmanager, contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass
 
@@ -475,3 +477,92 @@ def bind_progress_tracker(tracker: ProgressTracker) -> Iterator[ProgressTracker]
         yield tracker
     finally:
         _progress_tracker.reset(token)
+
+
+@asynccontextmanager
+async def holding_progress(label: str, *, timeout: float | None) -> AsyncIterator[None]:
+    """Vouch for one opaque operation for as long as you would let it run.
+
+    The explicit half of ADR-0018, and the only part of it an app author types.
+    One context manager covers both shapes of opaque work — an ``await`` against
+    the connector's own async client, and a blocking call offloaded through
+    ``run_in_thread``:
+
+    .. code-block:: python
+
+        # async: the connector's own client, which the SDK cannot see into
+        async with holding_progress("snapshot metadata query", timeout=1800):
+            rows = await long_single_query(...)
+
+        # blocking: the same wrapper around the offload
+        async with holding_progress("full table scan", timeout=7200):
+            rows = await run_in_thread(cursor.execute, sql)
+
+    Inside an ``App`` subclass, reach it as ``self.holding_progress(...)`` or
+    ``self.task_context.holding_progress(...)`` — the same two receivers as
+    ``run_in_thread``. Import this function directly for app code that sits
+    outside the app class.
+
+    Inside the block the stall watchdog is paused for this attempt; on exit the
+    completed operation is recorded as progress under ``label``. Past the
+    declared allowance the hold **lapses**: the watchdog resumes from the
+    deadline and the stall fires ``max_no_progress_seconds`` later, so the
+    effective kill time for a wedged call is ``timeout + budget`` rather than the
+    duration backstop's 24h.
+
+    **Expect to need this in almost every connector.** Blocking calls are
+    auto-held because ``run_in_thread`` is a mandatory seam, but async source
+    calls have no equivalent SDK-owned seam — a connector talks to its source
+    with its *own* async client (async SQLAlchemy, ``httpx.AsyncClient``, a
+    vendor SDK), and the SDK's internal SQL/HTTP clients are not on that path.
+    Interleaved streaming reads (fetch a page, write a batch, repeat) are
+    already covered by the write side and need no hold; the residual this exists
+    for is the genuinely opaque *single* call — one large metadata query, one
+    slow list/export that returns everything at once. That is a standard part of
+    writing a long-running async task, not a rare escape hatch.
+
+    Args:
+        label: The call site being vouched for, e.g.
+            ``"snapshot metadata query"``. Named in the stall log and in the
+            warn-mode hold report, so it must identify a *site* — never
+            interpolate a query, a key, a credential or a customer value into
+            it.
+        timeout: How long you would let this one operation run before you would
+            rather it failed — **not** a prediction of how long it takes. That
+            question is answerable here because it is a property of one
+            operation against one resource, rather than of a tenant's data
+            volume. Keyword-only and required: the SDK never derives or defaults
+            this number, so declaring nothing is spelled ``timeout=None``, which
+            makes the hold unbounded and hands the whole bound to the duration
+            backstop — an accepted residual, and one warn mode reports rather
+            than hides.
+
+            Err generous. The error is asymmetric: too generous only delays
+            detection toward the backstop, while too tight kills a healthy run —
+            and because stall kills retry, a too-tight allowance burns the same
+            wasted work up to three times. Use warn mode's observed p99 for the
+            site plus headroom rather than a number invented at the desk.
+
+    Yields:
+        ``None`` — the block's value is the vouch, not an object.
+
+    Note:
+        Outside an activity (a local run, a unit test, a script) this is inert:
+        there is no attempt to vouch for, so the hold is recorded nowhere and
+        nothing observes it.
+
+        The hold is released in a ``finally``, so an exception or a cancellation
+        inside the block releases it rather than leaving the watchdog paused for
+        the rest of the attempt. Holds are keyed by token rather than stacked, so
+        nesting and concurrent blocks — ``asyncio.gather`` over several opaque
+        calls — cannot release each other's deadlines.
+    """
+    # Read the tracker once and release on the same object. Re-reading at exit
+    # would pick up whatever the context has bound by then, which for a hold
+    # spanning a context change releases the wrong deadline.
+    tracker = current_progress_tracker()
+    token = tracker.enter_hold(label, timeout)
+    try:
+        yield
+    finally:
+        tracker.exit_hold(token)

--- a/docs/adr/0018-progress-aware-heartbeat.md
+++ b/docs/adr/0018-progress-aware-heartbeat.md
@@ -489,13 +489,22 @@ One mechanism covers both blocking and async opaque work:
 
 ```python
 # async: the connector's own client
-async with self.context.holding_progress("snapshot metadata query", timeout=1800):
+async with self.holding_progress("snapshot metadata query", timeout=1800):
     rows = await long_single_query(...)
 
 # blocking: the same wrapper around the offload
-async with self.context.holding_progress("full table scan", timeout=7200):
-    rows = await self.context.run_in_thread(cursor.execute, sql)
+async with self.holding_progress("full table scan", timeout=7200):
+    rows = await self.run_in_thread(cursor.execute, sql)
 ```
+
+It lives on `TaskExecutionContext` next to `run_in_thread`, with the same
+`App`-level shorthand (`self.holding_progress(...)` /
+`self.task_context.holding_progress(...)`), and as a module-level
+`application_sdk.execution.progress.holding_progress` for app code that sits
+outside the app class. `timeout` is keyword-only and **required**: declaring
+nothing is spelled `timeout=None`, so an unbounded hold is a statement in the
+source rather than an omission, and no default can quietly reintroduce a
+derived duration.
 
 An earlier draft of this ADR proposed *deriving* the hold's bound from the
 `timeout=` kwarg the call already carries, on the theory that ADR-0010 already

--- a/tests/unit/execution/test_holding_progress.py
+++ b/tests/unit/execution/test_holding_progress.py
@@ -1,0 +1,459 @@
+"""Unit tests for ``holding_progress()`` (FND-291).
+
+The context manager is four lines, so the risk is not in the code — it is in the
+semantics it has to preserve under every exit path. Five things are proven here,
+each a way a hold can be plausibly wrong and still look fine:
+
+1. **The vouch works and then stops.** Inside the block the watchdog reads no
+   gap even past the budget; on exit the completed call is recorded as progress.
+2. **The lapse resumes from the deadline, not from the last signal before the
+   hold.** That is what makes the effective kill time for a wedged held call
+   ``timeout + budget`` (ADR-0018 → *Holds*). Resuming from the earlier signal
+   would fire the stall the instant the allowance lapsed; resuming from "now"
+   would forgive the allowance twice.
+3. **Every exit path releases.** Return, exception and cancellation. A leaked
+   hold does not fail loudly — it silently pauses the watchdog for the rest of
+   the attempt, which is the exact failure the watchdog exists to catch.
+4. **Concurrent and nested blocks cannot release each other.** Holds are keyed
+   by token rather than stacked, and ``asyncio.gather`` over several opaque
+   calls is the shape that would break a stack.
+5. **The SDK never derives or defaults the allowance.** Pinned against the
+   signature, because a default added later would silently reintroduce the
+   guessed duration knob ADR-0018 exists to abolish.
+
+Clocks are injected, never patched: an asyncio loop shares ``time.monotonic``,
+so patching it globally makes the loop itself misbehave.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from collections.abc import Iterator
+
+import pytest
+
+from application_sdk.app.base import App, AppContextError
+from application_sdk.app.context import AppContext, TaskExecutionContext
+from application_sdk.contracts.base import Input, Output
+from application_sdk.execution.heartbeat import NoopHeartbeatController
+from application_sdk.execution.progress import (
+    ClosedHold,
+    ProgressTracker,
+    bind_progress_tracker,
+    current_progress_tracker,
+    holding_progress,
+)
+
+BUDGET = 300.0
+"""A stand-in for ``max_no_progress_seconds``. Only used in comparisons."""
+
+
+class _Clock:
+    """A monotonic clock the test advances by hand."""
+
+    def __init__(self) -> None:
+        self.now = 1000.0
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+@pytest.fixture
+def clock() -> _Clock:
+    return _Clock()
+
+
+@pytest.fixture
+def closed() -> list[ClosedHold]:
+    """Every hold this test closes, in order — the FND-292 audit seam."""
+    return []
+
+
+@pytest.fixture
+def tracker(clock: _Clock, closed: list[ClosedHold]) -> Iterator[ProgressTracker]:
+    """A real tracker bound as the current attempt's, as ``activities.py`` does."""
+    instance = ProgressTracker(clock=clock, on_hold_closed=closed.append)
+    with bind_progress_tracker(instance):
+        yield instance
+
+
+class TestTheVouch:
+    """Inside the block there is no gap; outside it the call counts as progress."""
+
+    @pytest.mark.asyncio
+    async def test_a_bounded_hold_suppresses_a_gap_past_the_budget(
+        self, tracker: ProgressTracker, clock: _Clock
+    ) -> None:
+        async with holding_progress("snapshot metadata query", timeout=1800):
+            clock.advance(BUDGET * 3)
+
+            assert tracker.held() is True
+            assert tracker.stalled_for() == 0.0
+
+    @pytest.mark.asyncio
+    async def test_exiting_records_the_call_as_progress(
+        self, tracker: ProgressTracker, clock: _Clock
+    ) -> None:
+        """A completed opaque call *is* forward progress, under its own label.
+
+        Without this the attempt would leave the block already at the gap it
+        spent inside it, and stall on the very next tick.
+        """
+        async with holding_progress("snapshot metadata query", timeout=1800):
+            clock.advance(1500.0)
+
+        assert tracker.held() is False
+        assert tracker.stalled_for() == 0.0
+        assert tracker.last_label == "snapshot metadata query"
+
+    @pytest.mark.asyncio
+    async def test_the_gap_resumes_from_the_exit(
+        self, tracker: ProgressTracker, clock: _Clock
+    ) -> None:
+        async with holding_progress("snapshot metadata query", timeout=1800):
+            clock.advance(1500.0)
+        clock.advance(60.0)
+
+        assert tracker.stalled_for() == pytest.approx(60.0)
+
+    @pytest.mark.asyncio
+    async def test_an_unbounded_hold_vouches_indefinitely(
+        self, tracker: ProgressTracker, clock: _Clock
+    ) -> None:
+        """``timeout=None`` is the declared residual: the backstop is the bound."""
+        async with holding_progress("vendor export", timeout=None):
+            clock.advance(86_400.0)
+
+            assert tracker.held() is True
+            assert tracker.stalled_for() == 0.0
+
+    @pytest.mark.asyncio
+    async def test_the_observed_hold_is_reported_once(
+        self, tracker: ProgressTracker, clock: _Clock, closed: list[ClosedHold]
+    ) -> None:
+        """What warn mode ranks sites on (FND-292)."""
+        async with holding_progress("snapshot metadata query", timeout=1800):
+            clock.advance(400.0)
+
+        assert closed == [
+            ClosedHold(
+                label="snapshot metadata query",
+                duration_seconds=400.0,
+                allowance_seconds=1800.0,
+            )
+        ]
+        assert closed[0].bounded is True
+        assert closed[0].lapsed is False
+
+
+class TestTheLapse:
+    """Past the allowance the hold stops vouching and the watchdog resumes."""
+
+    @pytest.mark.asyncio
+    async def test_the_hold_stops_vouching_at_its_deadline(
+        self, tracker: ProgressTracker, clock: _Clock
+    ) -> None:
+        async with holding_progress("snapshot metadata query", timeout=1800):
+            clock.advance(1799.0)
+            assert tracker.held() is True
+
+            clock.advance(2.0)
+            assert tracker.held() is False
+
+    @pytest.mark.asyncio
+    async def test_the_gap_resumes_from_the_deadline_not_the_entry(
+        self, tracker: ProgressTracker, clock: _Clock
+    ) -> None:
+        """The kill time for a wedged held call is ``timeout + budget``.
+
+        The allowance vouched for everything up to the deadline, so the earliest
+        instant the attempt can be accused of stalling is the deadline itself —
+        not the last progress signal before the hold, which would fire the stall
+        the moment the allowance lapsed.
+        """
+        async with holding_progress("snapshot metadata query", timeout=1800):
+            clock.advance(1800.0 + BUDGET - 1.0)
+            assert tracker.stalled_for() < BUDGET
+
+            clock.advance(2.0)
+            assert tracker.stalled_for() >= BUDGET
+
+    @pytest.mark.asyncio
+    async def test_a_lapsed_hold_is_reported_as_lapsed(
+        self, tracker: ProgressTracker, clock: _Clock, closed: list[ClosedHold]
+    ) -> None:
+        """A too-tight allowance is visible in the audit, not only in a kill."""
+        async with holding_progress("snapshot metadata query", timeout=1800):
+            clock.advance(2000.0)
+
+        assert closed[0].lapsed is True
+        assert closed[0].duration_seconds == pytest.approx(2000.0)
+
+    @pytest.mark.asyncio
+    async def test_a_negative_allowance_vouches_for_nothing(
+        self, tracker: ProgressTracker, clock: _Clock
+    ) -> None:
+        """A programming error must not forgive the quiet that preceded it.
+
+        ``enter_hold`` logs and treats it as already exhausted; the block still
+        runs and still releases, because a bad number is not a reason to change
+        what the app's code does.
+        """
+        clock.advance(BUDGET + 1.0)
+
+        async with holding_progress("snapshot metadata query", timeout=-1.0):
+            assert tracker.held() is False
+            assert tracker.stalled_for() >= BUDGET
+
+
+class TestEveryExitPathReleases:
+    """A leaked hold pauses the watchdog for the rest of the attempt, silently."""
+
+    @pytest.mark.asyncio
+    async def test_an_exception_releases_the_hold_and_propagates(
+        self, tracker: ProgressTracker
+    ) -> None:
+        with pytest.raises(ValueError, match="source refused"):
+            async with holding_progress("snapshot metadata query", timeout=1800):
+                raise ValueError("source refused")
+
+        assert tracker.held() is False
+
+    @pytest.mark.asyncio
+    async def test_a_cancellation_releases_the_hold(
+        self, tracker: ProgressTracker
+    ) -> None:
+        """The shape a Temporal activity cancellation actually takes."""
+        inside = asyncio.Event()
+
+        async def _held_forever() -> None:
+            async with holding_progress("snapshot metadata query", timeout=1800):
+                inside.set()
+                await asyncio.Event().wait()
+
+        running = asyncio.create_task(_held_forever())
+        await inside.wait()
+        assert tracker.held() is True
+
+        running.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await running
+
+        assert tracker.held() is False
+
+    @pytest.mark.asyncio
+    async def test_a_hold_still_reports_when_the_body_raises(
+        self, tracker: ProgressTracker, clock: _Clock, closed: list[ClosedHold]
+    ) -> None:
+        """A site that fails is a site the work-list needs most."""
+        with pytest.raises(ValueError):
+            async with holding_progress("snapshot metadata query", timeout=1800):
+                clock.advance(120.0)
+                raise ValueError("source refused")
+
+        assert [(c.label, c.duration_seconds) for c in closed] == [
+            ("snapshot metadata query", 120.0)
+        ]
+
+    @pytest.mark.asyncio
+    async def test_an_unentered_context_manager_opens_no_hold(
+        self, tracker: ProgressTracker
+    ) -> None:
+        """Building the manager without ``async with`` must not leak a hold.
+
+        The hold opens in ``__aenter__``, so a manager that is constructed and
+        dropped — a refactor that loses the ``async with`` — vouches for
+        nothing rather than vouching forever.
+        """
+        holding_progress("snapshot metadata query", timeout=1800)
+
+        assert tracker.held() is False
+
+
+class TestConcurrentAndNested:
+    """Holds are keyed by token, so no block can release another's deadline."""
+
+    @pytest.mark.asyncio
+    async def test_gathered_holds_release_only_their_own(
+        self, tracker: ProgressTracker, clock: _Clock
+    ) -> None:
+        both_inside = asyncio.Barrier(2)
+        first_released = asyncio.Event()
+
+        async def _fast() -> None:
+            async with holding_progress("small list call", timeout=60):
+                await both_inside.wait()
+            first_released.set()
+
+        async def _slow() -> None:
+            async with holding_progress("full table scan", timeout=7200):
+                await both_inside.wait()
+                await first_released.wait()
+                # The fast block has exited. A stack-based implementation would
+                # have popped this hold instead of its own.
+                clock.advance(BUDGET * 2)
+                assert tracker.held() is True
+                assert tracker.stalled_for() == 0.0
+
+        await asyncio.gather(_fast(), _slow())
+
+        assert tracker.held() is False
+
+    @pytest.mark.asyncio
+    async def test_nesting_leaves_the_outer_hold_vouching(
+        self, tracker: ProgressTracker, clock: _Clock
+    ) -> None:
+        async with holding_progress("full table scan", timeout=7200):
+            async with holding_progress("row count probe", timeout=60):
+                pass
+
+            clock.advance(BUDGET * 2)
+            assert tracker.held() is True
+            assert tracker.stalled_for() == 0.0
+
+    @pytest.mark.asyncio
+    async def test_each_gathered_hold_is_reported_separately(
+        self, tracker: ProgressTracker, closed: list[ClosedHold]
+    ) -> None:
+        async def _hold(label: str) -> None:
+            async with holding_progress(label, timeout=60):
+                await asyncio.sleep(0)
+
+        await asyncio.gather(_hold("call-a"), _hold("call-b"), _hold("call-c"))
+
+        assert sorted(c.label for c in closed) == ["call-a", "call-b", "call-c"]
+
+
+class TestTheAllowanceIsNeverDefaulted:
+    """FND-291's acceptance criterion, pinned where a refactor would break it."""
+
+    def test_timeout_is_required_and_keyword_only(self) -> None:
+        parameter = inspect.signature(holding_progress).parameters["timeout"]
+
+        assert parameter.default is inspect.Parameter.empty
+        assert parameter.kind is inspect.Parameter.KEYWORD_ONLY
+
+    @pytest.mark.parametrize(
+        "delegate",
+        [TaskExecutionContext.holding_progress, App.holding_progress],
+        ids=["task-context", "app"],
+    )
+    def test_the_delegates_do_not_default_it_either(self, delegate: object) -> None:
+        parameter = inspect.signature(delegate).parameters["timeout"]  # type: ignore[arg-type]
+
+        assert parameter.default is inspect.Parameter.empty
+        assert parameter.kind is inspect.Parameter.KEYWORD_ONLY
+
+    def test_omitting_the_allowance_is_a_type_error(self) -> None:
+        with pytest.raises(TypeError, match="timeout"):
+            holding_progress("snapshot metadata query")  # type: ignore[call-arg]
+
+
+class TestOutsideAnActivity:
+    """Local runs, unit tests and scripts behave as they did before ADR-0018."""
+
+    @pytest.mark.asyncio
+    async def test_the_block_is_inert_with_no_tracker_bound(self) -> None:
+        async with holding_progress("snapshot metadata query", timeout=1800):
+            assert current_progress_tracker().held() is False
+
+        assert current_progress_tracker().stalled_for() == 0.0
+        assert current_progress_tracker().last_label == ""
+
+    @pytest.mark.asyncio
+    async def test_an_inert_block_swallows_nothing(self) -> None:
+        with pytest.raises(ValueError, match="source refused"):
+            async with holding_progress("snapshot metadata query", timeout=1800):
+                raise ValueError("source refused")
+
+
+class _HoldIn(Input, allow_unbounded_fields=True):
+    name: str = "default"
+
+
+class _HoldOut(Output, allow_unbounded_fields=True):
+    held_for: float = 0.0
+
+
+def _task_execution_context() -> TaskExecutionContext:
+    """A ``TaskExecutionContext`` with no Temporal behind it."""
+    return TaskExecutionContext(
+        app_context=AppContext(app_name="_hold-app", app_version="0.0.0"),
+        task_name="scan",
+        heartbeat_controller=NoopHeartbeatController(),
+    )
+
+
+class _HoldApp(App):
+    """The minimum an ``App`` needs to exist; the delegate is what's under test."""
+
+    async def run(self, input: _HoldIn) -> _HoldOut:
+        return _HoldOut()
+
+
+class TestTheDelegates:
+    """The two receivers app authors actually type."""
+
+    @pytest.mark.asyncio
+    async def test_the_task_context_holds_on_the_attempts_tracker(
+        self, tracker: ProgressTracker, clock: _Clock
+    ) -> None:
+        async with _task_execution_context().holding_progress(
+            "full table scan", timeout=7200
+        ):
+            clock.advance(BUDGET * 2)
+
+            assert tracker.held() is True
+            assert tracker.stalled_for() == 0.0
+
+        assert tracker.last_label == "full table scan"
+
+    @pytest.mark.asyncio
+    async def test_the_app_delegate_reaches_the_same_hold(
+        self, tracker: ProgressTracker, clock: _Clock
+    ) -> None:
+        """``self.holding_progress(...)``, alongside ``self.run_in_thread(...)``."""
+        app = _HoldApp()
+        app._task_context = _task_execution_context()
+
+        async with app.holding_progress("full table scan", timeout=7200):
+            clock.advance(BUDGET * 2)
+
+            assert current_progress_tracker() is tracker
+            assert tracker.stalled_for() == 0.0
+
+        assert tracker.last_label == "full table scan"
+
+    def test_the_app_delegate_refuses_outside_a_task(self) -> None:
+        """A hold in ``run()`` would claim coverage no watchdog provides."""
+        with pytest.raises(AppContextError, match="inside @task methods"):
+            _HoldApp().holding_progress("full table scan", timeout=7200)
+
+
+class TestTheAdrsBlockingExample:
+    """``holding_progress`` around ``run_in_thread`` — the ADR's second example."""
+
+    @pytest.mark.asyncio
+    async def test_the_hold_spans_the_offload(
+        self, tracker: ProgressTracker, clock: _Clock
+    ) -> None:
+        def _blocking_scan() -> str:
+            # Read from inside the worker thread: the hold was opened on the
+            # loop, so this proves the offload sees the same vouched attempt
+            # rather than a private copy that dies with the thread.
+            assert current_progress_tracker() is tracker
+            assert tracker.held() is True
+            return "scanned"
+
+        context = _task_execution_context()
+
+        async with context.holding_progress("full table scan", timeout=7200):
+            clock.advance(BUDGET * 2)
+            assert await context.run_in_thread(_blocking_scan) == "scanned"
+
+        assert tracker.held() is False
+        assert tracker.last_label == "full table scan"


### PR DESCRIPTION
> **No longer stacked.** #3145 (FND-283) → #3147 (FND-286) → #3148 (FND-287) → #3150 (FND-288) have all merged, so this is now a single commit on `main` and the full check matrix runs. Re-applied onto current `main` rather than rebased: the stack was squash-merged, so replaying my branch's ancestors would have conflicted against their own already-merged squashes.

Implements [FND-291](https://linear.app/atlan-epd/issue/FND-291/holding-progress-one-context-manager-for-opaque-calls-allowance) — the explicit half of [ADR-0018](https://github.com/atlanhq/application-sdk/blob/main/docs/adr/0018-progress-aware-heartbeat.md) (→ *Holds* and *Choosing the allowance*), and the only part of it an app author types.

Everything already merged is invisible to apps: #3145 is the tracker, #3148 makes it reachable, #3150 hooks the framework's own loops. This PR is the one new public API — an async context manager that vouches for a call the SDK cannot see into, for an allowance **a human declares** at the one call site that knows it.

```python
# async: the connector's own client
async with self.holding_progress("snapshot metadata query", timeout=1800):
    rows = await long_single_query(...)

# blocking: the same wrapper around the offload
async with self.holding_progress("full table scan", timeout=7200):
    rows = await self.run_in_thread(cursor.execute, sql)
```

Inside the block the stall watchdog reads no gap. On exit the completed call is recorded as progress under its label. Past the allowance the hold **lapses**: the watchdog resumes *from the deadline*, and the stall fires `max_no_progress_seconds` later — so effective kill time for a wedged call is `timeout + budget` rather than the 24h backstop.

## Decisions a reviewer should look at

**1. `timeout` is keyword-only and *required*, and there is a test pinning that.** FND-291's acceptance criterion is "the SDK never derives or defaults the number", and a default value *is* the SDK defaulting the number. So declaring nothing is spelled `timeout=None` rather than omitted: an unbounded hold becomes a statement in the source instead of an absence, which is what lets warn mode's work-list distinguish "deliberate residual" from "forgot the kwarg". `test_timeout_is_required_and_keyword_only` and `test_the_delegates_do_not_default_it_either` assert it against `inspect.signature`, because a default added in a later refactor would silently reintroduce the guessed-duration knob ADR-0018 exists to abolish and nothing else would catch it.

**2. Three receivers, mirroring `run_in_thread` exactly.** The module-level `application_sdk.execution.progress.holding_progress` for app code outside the app class, `TaskExecutionContext.holding_progress` (the issue's stated scope), and the `App` shorthand `self.holding_progress(...)`. `run_in_thread` already exists at all three, and the ADR's own example pairs the two at the same receiver — a hold that only existed on `task_context` while the offload it wraps is reachable as `self.run_in_thread` would make the canonical two-line example mix receivers.

**3. The ADR's `self.context.holding_progress(...)` is corrected, not implemented.** `self.context` is `AppContext`, which has no `run_in_thread`, no `heartbeat`, and now deliberately no `holding_progress`: it is the context available in `run()` too, where there is no attempt and no watchdog, so a hold there would claim coverage it cannot provide. The ADR examples now read `self.holding_progress` / `self.run_in_thread`, which is what the code actually offers.

**4. The `App` delegate raises outside a `@task` method.** Same as `heartbeat()`, `get_last_heartbeat_details()` and `run_in_thread()`. Being inert instead would be defensible — the inert tracker already makes the hold harmless — but silence there tells an author their hold is working when it is vouching for nothing.

**5. The tracker is read once, and released on the same object.** `current_progress_tracker()`'s docstring warns that a caller pairing enter/exit must not call it twice; re-reading at exit picks up whatever the context has bound by then, which for a hold spanning a context change releases the wrong deadline. One local, released in a `finally`.

**6. No entry-side `mark_progress`.** Entering a hold is not work completing. `exit_hold` already marks progress under the hold's label (FND-283), which is why leaving the block does not immediately stall on the gap it just spent inside.

**7. `@asynccontextmanager`, not a hand-written `__aenter__`/`__aexit__` class.** The hold opens in `__aenter__`, so a manager that is constructed and dropped — a refactor that loses the `async with` — vouches for nothing rather than vouching forever. `test_an_unentered_context_manager_opens_no_hold` pins that. A class entering in `__init__` would have the opposite failure. This is also the shape #3148's review settled on for `bind_progress_tracker`: a block with no token for a caller to mislay, so the pairing is not something a call site can get wrong.

**8. Lazy import in `app/context.py`, top-level in `progress.py`.** `application_sdk.execution`'s package `__init__` reaches back into `app.base`, so a top-level `from application_sdk.execution.progress import holding_progress` in `app/context.py` is a hard `ImportError` — the same constraint the adjacent `run_in_thread` import already carries, and verified here in a fresh interpreter rather than assumed.

## What the tests actually prove

26 tests in `tests/unit/execution/test_holding_progress.py`. The context manager is four lines, so the risk is not in the code — it is in the semantics under every exit path. Clocks are injected, never patched: an asyncio loop shares `time.monotonic`.

- **The vouch works and then stops** — no gap past 3× the budget while held; on exit `last_label` is the hold's label and `stalled_for()` resumes from the *exit*, not from before the block.
- **The lapse resumes from the deadline, not from the entry** — `test_the_gap_resumes_from_the_deadline_not_the_entry` asserts the gap is still under budget at `timeout + budget - 1s` and over it 2s later. That is the `timeout + budget` kill time. Resuming from the last signal before the hold would fire the stall the instant the allowance lapsed; resuming from "now" would forgive the allowance twice.
- **Every exit path releases** — return, `ValueError`, and a real `task.cancel()` on a coroutine parked inside the block. A leaked hold does not fail loudly; it silently pauses the watchdog for the rest of the attempt, which is the exact failure the watchdog exists to catch. A hold whose body raised is still reported to `on_hold_closed` — a site that fails is the site the work-list needs most.
- **Concurrent and nested blocks cannot release each other** — `asyncio.gather` with a barrier so both are inside at once, then the fast block exits and the slow one asserts it is still vouching past 2× the budget. A stack-based implementation passes every other test in this file and fails this one.
- **`timeout=None`** vouches across 24h; **`timeout=-1`** vouches for nothing and does not forgive the quiet that preceded it.
- **Outside an activity it is inert and swallows nothing** — local runs, unit tests and scripts behave as they did before ADR-0018.
- **The ADR's blocking example composes** — `holding_progress` around `run_in_thread`, with the hold read from *inside* the worker thread to prove the offload sees the same vouched attempt rather than a private copy.

## Scope left out

- **FND-290** (`run_in_thread` auto-holds) is the *other* path to a hold and is not in this PR. It uses the same `enter_hold`/`exit_hold` pair; nothing here needs to change for it.
- **FND-292** owns the warn-mode telemetry that consumes `ClosedHold`. This PR only checks the observations arrive correctly shaped.
- **FND-295** owns the user-facing docs, including the "expected in nearly every connector" framing for app authors. The framing is in the docstrings here so it is at the call site, but the guide is that issue's.

## Verification

Re-run in full after re-applying onto current `main` (which carries #3148's review change from `set_progress_tracker`/`reset_progress_tracker` to the `bind_progress_tracker` block — the test fixture here uses the new form):

- `uv run pytest tests/unit` — **6692 passed, 9 skipped**
- `uv run pre-commit run --files <all 5 changed files>` — ruff, ruff-format, isort, pyright clean
- Full conformance suite, diffed against the same run on `main` by `(rule, file, message)` — **0 new findings, 0 resolved** (487 both sides), `exitCode: 0`
- Import-cycle check: `application_sdk.app.context` and `application_sdk.execution.progress` each imported first in a fresh interpreter, plus a live `async with` through the lazy import path

Local runs are Python 3.11 / macOS; the check matrix on this PR now covers the rest.
