### PR TITLE
feat(execution): auto-hold every blocking offload so the watchdog never false-kills (FND-290)

### DIFF
--- a/application_sdk/app/base.py
+++ b/application_sdk/app/base.py
@@ -931,7 +931,14 @@ class App(ABC):
     ) -> Any:
         """Run a blocking function in a thread pool.
 
-        Only available in @task methods.
+        Only available in @task methods. The offload is automatically wrapped in
+        an unbounded progress hold (ADR-0018), so a legitimately long blocking
+        call is never read as a stall. To bound it instead, wrap the offload in
+        :meth:`holding_progress` with the allowance you would give this one
+        call::
+
+            async with self.holding_progress("full table scan", timeout=7200):
+                rows = await self.run_in_thread(cursor.execute, sql)
 
         Args:
             func: Blocking function to run.

--- a/application_sdk/app/context.py
+++ b/application_sdk/app/context.py
@@ -575,6 +575,20 @@ class TaskExecutionContext:
         ContextVars (ObjectStore, logger context, correlation ID, infrastructure
         handles) are propagated to the worker thread automatically.
 
+        The offload is automatically wrapped in an unbounded progress hold
+        (ADR-0018), so however long the blocking call takes, the stall watchdog
+        never accuses it of stalling. Nothing to do at the call site, and a
+        legitimately long blocking call behaves exactly as it did before the
+        watchdog existed. To bound it instead, wrap the offload in
+        :meth:`holding_progress` with the allowance you would actually let this
+        one call have — a wedged call is then caught at ``timeout`` plus the
+        no-progress budget rather than at the duration backstop::
+
+            async with self.task_context.holding_progress(
+                "full table scan", timeout=7200
+            ):
+                rows = await self.task_context.run_in_thread(cursor.execute, sql)
+
         **CRITICAL: your blocking code MUST have its own timeout.** Python
         threads cannot be forcibly killed; a hang here hangs the thread
         forever.

--- a/application_sdk/execution/heartbeat.py
+++ b/application_sdk/execution/heartbeat.py
@@ -17,6 +17,7 @@ can never break the caller.
 
 import asyncio
 import concurrent.futures
+import contextlib
 import contextvars
 import functools
 import math
@@ -25,7 +26,7 @@ import os
 import re
 import threading
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from concurrent.futures.process import BrokenProcessPool
 from typing import Any, Protocol, TypeVar
 
@@ -33,6 +34,7 @@ from application_sdk.execution.progress import (
     ProgressTracker,
     ProgressWatchdogMode,
     current_progress_tracker,
+    declared_hold_active,
 )
 from application_sdk.observability import (
     resource_sampler as _resource_sampler,  # module alias kept so tests can patch _resource_sampler.sample()
@@ -536,6 +538,60 @@ def _is_usable_callable_name(name: str) -> bool:
     )
 
 
+@contextlib.contextmanager
+def _auto_hold(label: str, timeout: float | None) -> Iterator[None]:
+    """Vouch for an offload — unless a human already vouched for it.
+
+    The automatic half of ADR-0018's mechanism 2, shared by both offload seams so
+    the precedence rule below cannot be right at one and wrong at the other.
+
+    **An explicit allowance wins.** Inside a ``holding_progress`` block the auto-
+    hold stands down entirely and the declared hold governs. It has to: the
+    tracker's hold set is a union — ``held()`` and ``stalled_for()`` say
+    "vouched" while *any* hold is unlapsed — so an unbounded auto-hold nested
+    inside a bounded declared one keeps vouching after the declared allowance
+    lapses. The author asked for a wedged call to be caught at
+    ``timeout + budget``; adding a hold they did not ask for would silently hand
+    the site back to the duration backstop, which is the exact outcome
+    ``holding_progress`` exists to prevent. Standing down is also the honest
+    reading: the operation *is* already vouched for, by someone who knows the
+    number.
+
+    That leaves exactly one hold around the offload rather than two, so the
+    warn-mode work-list ranks the site an author can act on — the declared one —
+    instead of double-counting the same wall-clock under a second label.
+
+    The suppression is context-scoped (:func:`declared_hold_active`), never
+    tracker-scoped: a concurrent offload in a task that never entered the block
+    still gets its own hold. Suppressing on "some hold is open somewhere on this
+    tracker" would leave real blocking work unvouched and re-introduce the
+    false-kill this mechanism exists to remove.
+
+    Args:
+        label: Hold label — a site, never a value.
+        timeout: Allowance for the hold, or ``None`` for an unbounded one.
+
+    Yields:
+        Nothing; the caller runs its offload inside the block.
+    """
+    if declared_hold_active():
+        yield
+        return
+    # The tracker is read once and both calls go to that same object. Re-reading
+    # for the release would pick up whatever tracker the context has by then,
+    # which for a hold spanning a context change releases the wrong deadline.
+    tracker = current_progress_tracker()
+    hold = tracker.enter_hold(label, timeout)
+    try:
+        yield
+    finally:
+        # `finally`, not the success path: an offload that raises, and an
+        # activity cancelled mid-offload, must still release *their own* token.
+        # A leaked unbounded hold vouches for the rest of the attempt, which
+        # turns one exception into a watchdog that never fires again.
+        tracker.exit_hold(hold)
+
+
 async def run_in_thread(func: Callable[..., T], *args: Any, **kwargs: Any) -> T:
     """Last-resort escape hatch: run a blocking function in a thread pool.
 
@@ -600,7 +656,9 @@ async def run_in_thread(func: Callable[..., T], *args: Any, **kwargs: Any) -> T:
       ``holding_progress(label, timeout=...)``
       (:func:`application_sdk.execution.progress.holding_progress`) and a wedged
       call is caught at ``timeout`` + the no-progress budget instead of at the
-      backstop.
+      backstop. Inside such a block the automatic hold **stands down** and your
+      declared allowance governs; the SDK never adds a vouch that would outlive
+      the one you asked for.
 
     **CRITICAL: your blocking code MUST have its own timeout.**
     Python threads cannot be forcibly killed. If the wrapped call hangs
@@ -635,30 +693,11 @@ async def run_in_thread(func: Callable[..., T], *args: Any, **kwargs: Any) -> T:
     # inactive for the call's duration, the duration backstop owns it, and warn
     # mode reports every closed hold with its observed duration. That residual
     # is accepted and surfaced, not closed.
-    #
-    # The hold starts before the executor dispatch on purpose, so it also covers
-    # time spent queued behind a saturated `sdk-blocking-` pool: that is quiet
-    # time the attempt can do nothing about, and killing it is exactly the
-    # false-kill this hold exists to prevent.
-    #
-    # The tracker is read once and both calls go to that same object. Re-reading
-    # for the release would pick up whatever tracker the context has by then,
-    # which for a hold spanning a context change releases the wrong deadline.
-    tracker = current_progress_tracker()
-    hold = tracker.enter_hold(
-        _THREAD_HOLD_PREFIX + _offloaded_callable_name(func), None
-    )
-    try:
+    with _auto_hold(_THREAD_HOLD_PREFIX + _offloaded_callable_name(func), None):
         return await loop.run_in_executor(
             _BLOCKING_EXECUTOR,
             functools.partial(ctx.run, functools.partial(func, *args, **kwargs)),
         )
-    finally:
-        # `finally`, not the success path: an offload that raises, and an
-        # activity cancelled mid-offload, must still release *their own* token.
-        # A leaked unbounded hold vouches for the rest of the attempt, which
-        # turns one exception into a watchdog that never fires again.
-        tracker.exit_hold(hold)
 
 
 # Executor for work that must not be able to take the worker down with it.
@@ -809,11 +848,13 @@ async def run_fault_isolated(
     # it failed. What ADR-0018 rejects is deriving a bound from the *callee's*
     # per-operation kwargs, which is a different number. `timeout=None` still
     # means an unbounded hold, matching `None`'s "wait forever" here.
-    tracker = current_progress_tracker()
-    hold = tracker.enter_hold(
-        _ISOLATED_HOLD_PREFIX + _offloaded_callable_name(func), timeout
-    )
-    try:
+    #
+    # Inside a `holding_progress` block this stands down like `run_in_thread`'s
+    # does — see `_auto_hold`. Harmless even when this call's own `timeout` is
+    # tighter than the declared allowance: `timeout` is enforced here by killing
+    # the child, so the call returns at its deadline whether or not a hold is
+    # watching.
+    with _auto_hold(_ISOLATED_HOLD_PREFIX + _offloaded_callable_name(func), timeout):
         future = loop.run_in_executor(
             _get_process_executor(workers), functools.partial(func, *args, **kwargs)
         )
@@ -849,11 +890,6 @@ async def run_fault_isolated(
             raise BrokenProcessPool(
                 "process pool was discarded while this call was queued"
             ) from None
-    finally:
-        # Every exit releases this call's own token: a crashed child, a timeout,
-        # a foreign pool discard, a real cancellation. A leaked hold would vouch
-        # for the rest of the attempt.
-        tracker.exit_hold(hold)
 
 
 async def run_best_effort(

--- a/application_sdk/execution/heartbeat.py
+++ b/application_sdk/execution/heartbeat.py
@@ -28,7 +28,11 @@ from collections.abc import Callable
 from concurrent.futures.process import BrokenProcessPool
 from typing import Any, Protocol, TypeVar
 
-from application_sdk.execution.progress import ProgressTracker, ProgressWatchdogMode
+from application_sdk.execution.progress import (
+    ProgressTracker,
+    ProgressWatchdogMode,
+    current_progress_tracker,
+)
 from application_sdk.observability import (
     resource_sampler as _resource_sampler,  # module alias kept so tests can patch _resource_sampler.sample()
 )
@@ -458,6 +462,43 @@ async def auto_heartbeat_loop(
             return
 
 
+#: Label prefixes for the auto-holds on the two offload seams (ADR-0018 →
+#: *Feeding the tracker*, mechanism 2). The offloaded callable's own name is
+#: appended, so warn mode ranks *sites* — "run_in_thread.Cursor.execute, p99
+#: 40min, unbounded" is a work-list entry — instead of collapsing every blocking
+#: call in an app into one bucket. Naming the seam is part of the signal: it
+#: tells an operator which primitive to wrap in ``holding_progress()``.
+_THREAD_HOLD_PREFIX = "run_in_thread."
+_ISOLATED_HOLD_PREFIX = "run_fault_isolated."
+
+
+def _offloaded_callable_name(func: Callable[..., Any]) -> str:
+    """Name the offloaded callable, for its auto-hold label.
+
+    Reads the callable's own ``__qualname__`` rather than inspecting the caller's
+    frame. All three ``run_in_thread`` entry points funnel into one
+    implementation, so a frame walk would name an SDK wrapper on two of the
+    three; and the callee is the half of the site an operator can act on anyway.
+
+    Only ever a code identifier — never an argument — so no query, path,
+    credential or customer value can reach a hold label.
+
+    Each fallback exists because something real lacks a usable ``__qualname__``:
+    ``functools.partial`` carries no name of its own (the wrapped callable
+    does), a callable *instance* has one only on its class, and a ``Mock``
+    fabricates a child mock for whatever attribute is asked of it, which would
+    otherwise put a repr into a label.
+    """
+    target: Any = func
+    while isinstance(target, functools.partial):
+        target = target.func
+    for attribute in ("__qualname__", "__name__"):
+        name = getattr(target, attribute, None)
+        if isinstance(name, str) and name:
+            return name
+    return type(target).__name__
+
+
 async def run_in_thread(func: Callable[..., T], *args: Any, **kwargs: Any) -> T:
     """Last-resort escape hatch: run a blocking function in a thread pool.
 
@@ -510,6 +551,19 @@ async def run_in_thread(func: Callable[..., T], *args: Any, **kwargs: Any) -> T:
       isolated from the caller (copy semantics).
     - Threads run on a dedicated ``sdk-blocking-*`` pool, separate from
       Temporal's activity pool, to avoid deadlocking the worker.
+    - The offload is automatically wrapped in an **unbounded** progress hold
+      (ADR-0018), so the stall watchdog never accuses a legitimately long
+      blocking call of stalling. Nothing to do at the call site, and nothing
+      about a long blocking call behaves differently than it did before the
+      watchdog existed. The SDK does not invent a duration for somebody else's
+      blocking call, so the watchdog is inactive for the call's whole duration
+      and the activity's duration bound is the only thing still holding it.
+      If you can say how long you would let this one call run before you would
+      rather it failed, declare it — wrap the offload in
+      ``holding_progress(label, timeout=...)``
+      (:func:`application_sdk.execution.progress.holding_progress`) and a wedged
+      call is caught at ``timeout`` + the no-progress budget instead of at the
+      backstop.
 
     **CRITICAL: your blocking code MUST have its own timeout.**
     Python threads cannot be forcibly killed. If the wrapped call hangs
@@ -530,10 +584,44 @@ async def run_in_thread(func: Callable[..., T], *args: Any, **kwargs: Any) -> T:
     """
     ctx = contextvars.copy_context()
     loop = asyncio.get_running_loop()
-    return await loop.run_in_executor(
-        _BLOCKING_EXECUTOR,
-        functools.partial(ctx.run, functools.partial(func, *args, **kwargs)),
+    # Auto-hold, unbounded (ADR-0018 → *Feeding the tracker*, mechanism 2).
+    # `run_in_thread` is a mandatory seam, so this is the one place the SDK can
+    # vouch for blocking work for free — and it must vouch without inventing a
+    # duration. `func`'s own `timeout=` kwarg is not one: it is per-operation (a
+    # `requests` read timeout bounds the gap between socket reads, a
+    # `statement_timeout` bounds one statement of many), so a bound derived from
+    # it is systematically *smaller* than the call's legitimate duration, and
+    # the dominant shape — `run_in_thread(cursor.execute, sql)` — carries no
+    # timeout at all. Any fallback tight enough to be useful would be tighter
+    # than today's `start_to_close`, i.e. the upgrade would make legitimate long
+    # blocking work fail sooner than before. So: unbounded, the watchdog is
+    # inactive for the call's duration, the duration backstop owns it, and warn
+    # mode reports every closed hold with its observed duration. That residual
+    # is accepted and surfaced, not closed.
+    #
+    # The hold starts before the executor dispatch on purpose, so it also covers
+    # time spent queued behind a saturated `sdk-blocking-` pool: that is quiet
+    # time the attempt can do nothing about, and killing it is exactly the
+    # false-kill this hold exists to prevent.
+    #
+    # The tracker is read once and both calls go to that same object. Re-reading
+    # for the release would pick up whatever tracker the context has by then,
+    # which for a hold spanning a context change releases the wrong deadline.
+    tracker = current_progress_tracker()
+    hold = tracker.enter_hold(
+        _THREAD_HOLD_PREFIX + _offloaded_callable_name(func), None
     )
+    try:
+        return await loop.run_in_executor(
+            _BLOCKING_EXECUTOR,
+            functools.partial(ctx.run, functools.partial(func, *args, **kwargs)),
+        )
+    finally:
+        # `finally`, not the success path: an offload that raises, and an
+        # activity cancelled mid-offload, must still release *their own* token.
+        # A leaked unbounded hold vouches for the rest of the attempt, which
+        # turns one exception into a watchdog that never fires again.
+        tracker.exit_hold(hold)
 
 
 # Executor for work that must not be able to take the worker down with it.
@@ -639,6 +727,13 @@ async def run_fault_isolated(
     - The child imports ``func``'s module on first use (one-time cost,
       amortized by the pooled worker).
 
+    Like :func:`run_in_thread`, the call is automatically wrapped in a progress
+    hold (ADR-0018) so an isolated call — which emits nothing at all until the
+    child returns — is never read as a stall. Here the hold is *bounded* by
+    ``timeout`` when one is given, because that number is already a wall-clock
+    kill enforced below; ``timeout=None`` gives an unbounded hold, matching its
+    "wait forever" semantics.
+
     Args:
         func: Module-level function to run in the child.
         timeout: Seconds to wait before killing the child and raising
@@ -663,37 +758,65 @@ async def run_fault_isolated(
     if workers < 1:
         raise ValueError(f"max_workers must be >= 1, got {workers}")
     loop = asyncio.get_running_loop()
-    future = loop.run_in_executor(
-        _get_process_executor(workers), functools.partial(func, *args, **kwargs)
+    # Auto-hold, bounded by this call's own `timeout` (ADR-0018 → *Feeding the
+    # tracker*, mechanism 2 — the same treatment as `run_in_thread`, since this
+    # is the SDK's other offload seam and an isolated call emits nothing at all
+    # until the child returns; the SDK's own default `timeout` for the upload
+    # validation scan is 600s, well past any plausible no-progress budget).
+    #
+    # Bounded rather than unbounded because unlike `run_in_thread` there is a
+    # real wall-clock number here and it belongs to *this* function, not to
+    # `func`: the block below enforces `timeout` by killing the child and raising
+    # `TimeoutError`, so it means precisely what `enter_hold`'s allowance means —
+    # how long the caller would let this one operation run before it would rather
+    # it failed. What ADR-0018 rejects is deriving a bound from the *callee's*
+    # per-operation kwargs, which is a different number. `timeout=None` still
+    # means an unbounded hold, matching `None`'s "wait forever" here.
+    tracker = current_progress_tracker()
+    hold = tracker.enter_hold(
+        _ISOLATED_HOLD_PREFIX + _offloaded_callable_name(func), timeout
     )
-    if timeout is not None:
-        # Not asyncio.wait_for: on timeout it cancels the future and then waits
-        # for the cancellation to land — but a running executor call cannot be
-        # cancelled, so wait_for would hang exactly when the child hangs.
-        # asyncio.wait just stops waiting; we then kill the child ourselves.
-        done, _ = await asyncio.wait({future}, timeout=timeout)
-        if not done:
-            _discard_process_executor(workers)
-            # The kill resolves the abandoned future with BrokenProcessPool;
-            # consume it so asyncio never logs "exception was never retrieved".
-            future.add_done_callback(lambda f: None if f.cancelled() else f.exception())
-            raise TimeoutError(f"run_fault_isolated timed out after {timeout}s")
     try:
-        return await future
-    except BrokenProcessPool:
-        _discard_process_executor(workers)
-        raise
-    except asyncio.CancelledError:
-        task = asyncio.current_task()
-        if task is not None and task.cancelling():
-            raise  # real cancellation of the caller — must propagate
-        # Foreign cancellation: a concurrent caller's timeout discarded the
-        # shared pool while this call was still queued. From this caller's
-        # perspective that is exactly a broken pool — surface it as the
-        # catchable exception the contract promises, never CancelledError.
-        raise BrokenProcessPool(
-            "process pool was discarded while this call was queued"
-        ) from None
+        future = loop.run_in_executor(
+            _get_process_executor(workers), functools.partial(func, *args, **kwargs)
+        )
+        if timeout is not None:
+            # Not asyncio.wait_for: on timeout it cancels the future and then
+            # waits for the cancellation to land — but a running executor call
+            # cannot be cancelled, so wait_for would hang exactly when the child
+            # hangs. asyncio.wait just stops waiting; we then kill the child
+            # ourselves.
+            done, _ = await asyncio.wait({future}, timeout=timeout)
+            if not done:
+                _discard_process_executor(workers)
+                # The kill resolves the abandoned future with BrokenProcessPool;
+                # consume it so asyncio never logs "exception was never
+                # retrieved".
+                future.add_done_callback(
+                    lambda f: None if f.cancelled() else f.exception()
+                )
+                raise TimeoutError(f"run_fault_isolated timed out after {timeout}s")
+        try:
+            return await future
+        except BrokenProcessPool:
+            _discard_process_executor(workers)
+            raise
+        except asyncio.CancelledError:
+            task = asyncio.current_task()
+            if task is not None and task.cancelling():
+                raise  # real cancellation of the caller — must propagate
+            # Foreign cancellation: a concurrent caller's timeout discarded the
+            # shared pool while this call was still queued. From this caller's
+            # perspective that is exactly a broken pool — surface it as the
+            # catchable exception the contract promises, never CancelledError.
+            raise BrokenProcessPool(
+                "process pool was discarded while this call was queued"
+            ) from None
+    finally:
+        # Every exit releases this call's own token: a crashed child, a timeout,
+        # a foreign pool discard, a real cancellation. A leaked hold would vouch
+        # for the rest of the attempt.
+        tracker.exit_hold(hold)
 
 
 async def run_best_effort(

--- a/application_sdk/execution/heartbeat.py
+++ b/application_sdk/execution/heartbeat.py
@@ -22,6 +22,7 @@ import functools
 import math
 import multiprocessing
 import os
+import re
 import threading
 import time
 from collections.abc import Callable
@@ -471,6 +472,22 @@ async def auto_heartbeat_loop(
 _THREAD_HOLD_PREFIX = "run_in_thread."
 _ISOLATED_HOLD_PREFIX = "run_fault_isolated."
 
+#: What a dotted Python qualname can contain, and nothing else: identifier
+#: characters, the dots joining them, and the angle brackets CPython puts around
+#: ``<lambda>`` and ``<locals>``. A name carrying anything outside this — a
+#: space, a quote, a path separator, a newline — is not a code identifier, so it
+#: is not something this label may repeat.
+_CALLABLE_NAME_PATTERN = re.compile(r"^[A-Za-z0-9_.<>]+$")
+
+#: Longest callable name kept in a label. Real qualnames are short; the deepest
+#: shape in the SDK's own tests (a lambda nested in a test method) is under 90.
+_MAX_CALLABLE_NAME_LENGTH = 120
+
+#: Stand-in for a callable whose name is unusable. A stable constant, so a name
+#: this function refuses adds exactly one series to a metric rather than one per
+#: distinct value.
+_UNNAMEABLE_CALLABLE = "<callable>"
+
 
 def _offloaded_callable_name(func: Callable[..., Any]) -> str:
     """Name the offloaded callable, for its auto-hold label.
@@ -488,15 +505,35 @@ def _offloaded_callable_name(func: Callable[..., Any]) -> str:
     does), a callable *instance* has one only on its class, and a ``Mock``
     fabricates a child mock for whatever attribute is asked of it, which would
     otherwise put a repr into a label.
+
+    The name is then checked against what a qualname can actually look like, and
+    replaced with :data:`_UNNAMEABLE_CALLABLE` if it is not. ``__qualname__`` is
+    an ordinary writable attribute, so "it comes from code" is a convention
+    rather than a guarantee — a decorator, a factory or a dynamically-built
+    class can set it to anything, including a per-call value. That matters here
+    and not at a normal call site: this string lands in the stall log and in the
+    ``last_label`` *metric attribute*, where a per-call value is unbounded
+    series cardinality and a long one is dead weight on every stall report. This
+    is defence in depth, not a live threat — but the guarantee this function
+    advertises is cheap to actually enforce.
     """
     target: Any = func
     while isinstance(target, functools.partial):
         target = target.func
     for attribute in ("__qualname__", "__name__"):
         name = getattr(target, attribute, None)
-        if isinstance(name, str) and name:
+        if isinstance(name, str) and _is_usable_callable_name(name):
             return name
-    return type(target).__name__
+    fallback = type(target).__name__
+    return fallback if _is_usable_callable_name(fallback) else _UNNAMEABLE_CALLABLE
+
+
+def _is_usable_callable_name(name: str) -> bool:
+    """Whether ``name`` is short enough and shaped like a dotted qualname."""
+    return (
+        0 < len(name) <= _MAX_CALLABLE_NAME_LENGTH
+        and _CALLABLE_NAME_PATTERN.match(name) is not None
+    )
 
 
 async def run_in_thread(func: Callable[..., T], *args: Any, **kwargs: Any) -> T:

--- a/application_sdk/execution/progress.py
+++ b/application_sdk/execution/progress.py
@@ -298,6 +298,26 @@ class ProgressTracker:
             )
         )
 
+    def has_open_hold(self, token: int) -> bool:
+        """Whether ``token`` names a hold that has not been released yet.
+
+        Deliberately *not* :meth:`held`: this asks whether one specific hold is
+        still open, not whether anything is still vouching. A bounded hold whose
+        allowance has lapsed answers ``True`` here and stops counting in
+        :meth:`held` — which is what the automatic holds need, since a lapsed
+        declared hold must keep them suppressed (re-arming an unbounded auto-hold
+        at the moment an allowance lapses would defeat the allowance) while the
+        watchdog is free to resume.
+
+        Args:
+            token: A token from :meth:`enter_hold`.
+
+        Returns:
+            ``True`` while that hold is open on *this* tracker.
+        """
+        with self._lock:
+            return token in self._holds
+
     def held(self) -> bool:
         """Whether any hold is currently vouching for the attempt.
 
@@ -397,6 +417,15 @@ class _InertProgressTracker(ProgressTracker):
     def exit_hold(self, token: int) -> None:
         """Release nothing, and stay quiet: there was no hold to release."""
 
+    def has_open_hold(self, token: int) -> bool:
+        """Always ``False`` — an inert tracker never opened one.
+
+        Overridden rather than inherited for the same reason the mutators are:
+        this instance is a process-wide singleton, and the inherited reader would
+        take its shared lock on every offload made outside an activity.
+        """
+        return False
+
     def held(self) -> bool:
         """Always ``False`` — an inert tracker vouches for nothing."""
         return False
@@ -412,18 +441,28 @@ _progress_tracker: ContextVar[ProgressTracker | None] = ContextVar(
     "progress_tracker", default=None
 )
 
-#: Whether a :func:`holding_progress` block covers the current context.
-#: Set for the block's dynamic extent, which is what makes it answer *"is this
-#: work already covered by an allowance a human declared?"* rather than the
-#: tracker-wide *"is anything vouching?"* that :meth:`ProgressTracker.held`
-#: answers. The distinction matters because the tracker's hold set is flat: it
-#: cannot tell an enclosing hold from a concurrent one, and only the enclosing
-#: relationship should suppress anything.
-_declared_hold: ContextVar[bool] = ContextVar("declared_hold", default=False)
+#: The declared hold covering the current context, as ``(tracker, token)``.
+#: Set by :func:`holding_progress` for its block's dynamic extent, which is what
+#: makes it answer *"is this work already covered by an allowance a human
+#: declared?"* rather than the tracker-wide *"is anything vouching?"* that
+#: :meth:`ProgressTracker.held` answers. The distinction matters because the
+#: tracker's hold set is flat: it cannot tell an enclosing hold from a concurrent
+#: one, and only the enclosing relationship should suppress anything.
+#:
+#: A *reference to the hold* rather than a boolean, because a boolean can outlive
+#: what it describes. ``asyncio.create_task`` copies the creating context
+#: (PEP 567), so a task spawned inside the block carries the mark into a lifetime
+#: the parent's ``reset`` can never reach — and a *detached* one, still running
+#: after the block exits, would then suppress its own auto-hold with no declared
+#: hold left to cover it. Naming the hold makes the mark falsifiable: the token
+#: is either still open on that tracker or it is not.
+_declared_hold: ContextVar[tuple["ProgressTracker", int] | None] = ContextVar(
+    "declared_hold", default=None
+)
 
 
 def declared_hold_active() -> bool:
-    """Whether an explicit declared allowance already covers this context.
+    """Whether an explicit declared allowance is *still* covering this context.
 
     Read by the automatic holds (FND-290) so they can stand down inside a
     :func:`holding_progress` block. An author who declares an allowance is
@@ -433,12 +472,30 @@ def declared_hold_active() -> bool:
     an unbounded hold never lapses — which would hand a site its author had
     bounded back to the duration backstop.
 
+    Both halves of the check earn their place:
+
+    - **The hold is still open** (:meth:`ProgressTracker.has_open_hold`), not
+      merely marked. A task spawned inside the block inherits a *copy* of the
+      context, so the mark survives in that task after the block exits and
+      releases the hold. Trusting the mark alone would let such a task stand
+      down with nothing vouching for it at all — no declared hold, and no
+      auto-hold either — which is a worse hole than the one this suppression
+      closes. Once the declared hold is released, that task's next offload is
+      auto-held again like any other.
+    - **It is open on the tracker bound right now.** A hold belonging to a
+      different attempt cannot govern this one, so a rebind in between must not
+      suppress anything.
+
     Context-scoped rather than tracker-scoped on purpose. A concurrent task that
     never entered the block does not observe the mark, so its own offload is
     still auto-held; suppressing that one would leave real blocking work
     unvouched, which is the false-kill this whole mechanism exists to prevent.
     """
-    return _declared_hold.get()
+    declared = _declared_hold.get()
+    if declared is None:
+        return False
+    tracker, token = declared
+    return tracker is current_progress_tracker() and tracker.has_open_hold(token)
 
 
 def current_progress_tracker() -> ProgressTracker:
@@ -597,9 +654,13 @@ async def holding_progress(label: str, *, timeout: float | None) -> AsyncIterato
     # spanning a context change releases the wrong deadline.
     tracker = current_progress_tracker()
     token = tracker.enter_hold(label, timeout)
-    declared = _declared_hold.set(True)
+    declared = _declared_hold.set((tracker, token))
     try:
         yield
     finally:
+        # Reset first, then release. Both orders are correct for this context —
+        # the mark names this token either way — but releasing last keeps the
+        # window in which the mark points at a live hold as small as possible for
+        # any task still reading a *copy* of this context.
         _declared_hold.reset(declared)
         tracker.exit_hold(token)

--- a/application_sdk/execution/progress.py
+++ b/application_sdk/execution/progress.py
@@ -412,6 +412,34 @@ _progress_tracker: ContextVar[ProgressTracker | None] = ContextVar(
     "progress_tracker", default=None
 )
 
+#: Whether a :func:`holding_progress` block covers the current context.
+#: Set for the block's dynamic extent, which is what makes it answer *"is this
+#: work already covered by an allowance a human declared?"* rather than the
+#: tracker-wide *"is anything vouching?"* that :meth:`ProgressTracker.held`
+#: answers. The distinction matters because the tracker's hold set is flat: it
+#: cannot tell an enclosing hold from a concurrent one, and only the enclosing
+#: relationship should suppress anything.
+_declared_hold: ContextVar[bool] = ContextVar("declared_hold", default=False)
+
+
+def declared_hold_active() -> bool:
+    """Whether an explicit declared allowance already covers this context.
+
+    Read by the automatic holds (FND-290) so they can stand down inside a
+    :func:`holding_progress` block. An author who declares an allowance is
+    making a statement the SDK must not quietly outvote: an unbounded auto-hold
+    added *inside* a bounded one keeps vouching after the declared allowance
+    lapses — ``held()`` and ``stalled_for()`` treat the hold set as a union, and
+    an unbounded hold never lapses — which would hand a site its author had
+    bounded back to the duration backstop.
+
+    Context-scoped rather than tracker-scoped on purpose. A concurrent task that
+    never entered the block does not observe the mark, so its own offload is
+    still auto-held; suppressing that one would leave real blocking work
+    unvouched, which is the false-kill this whole mechanism exists to prevent.
+    """
+    return _declared_hold.get()
+
 
 def current_progress_tracker() -> ProgressTracker:
     """Get the :class:`ProgressTracker` for the current activity attempt.
@@ -510,6 +538,13 @@ async def holding_progress(label: str, *, timeout: float | None) -> AsyncIterato
     effective kill time for a wedged call is ``timeout + budget`` rather than the
     duration backstop's 24h.
 
+    **The allowance you declare governs everything inside the block**, including
+    the automatic holds ``run_in_thread`` and ``run_fault_isolated`` would
+    otherwise add (FND-290): those stand down here, so the blocking example below
+    lapses at ``timeout`` like the async one rather than inheriting an unbounded
+    auto-hold that would outlive it. That is why the two examples have the same
+    kill time despite one of them offloading.
+
     **Expect to need this in almost every connector.** Blocking calls are
     auto-held because ``run_in_thread`` is a mandatory seam, but async source
     calls have no equivalent SDK-owned seam — a connector talks to its source
@@ -562,7 +597,9 @@ async def holding_progress(label: str, *, timeout: float | None) -> AsyncIterato
     # spanning a context change releases the wrong deadline.
     tracker = current_progress_tracker()
     token = tracker.enter_hold(label, timeout)
+    declared = _declared_hold.set(True)
     try:
         yield
     finally:
+        _declared_hold.reset(declared)
         tracker.exit_hold(token)

--- a/docs/adr/0018-progress-aware-heartbeat.md
+++ b/docs/adr/0018-progress-aware-heartbeat.md
@@ -471,6 +471,36 @@ Detection latency is `max_no_progress_seconds` plus at most one loop tick (10s).
    duration of the call and the 24h backstop is the only bound — a real, documented
    residual. Warn mode surfaces each one with its observed duration, and the
    conformance rule keeps them visible afterwards.
+
+   As landed (FND-290), the hold wraps the *single* implementation all three
+   public entry points funnel into — the module-level `run_in_thread`, the
+   `TaskExecutionContext` wrapper and `App.run_in_thread` — so a blocking call
+   gets exactly one hold no matter which one an app reaches for. It starts before
+   the executor dispatch, so it also covers time queued behind a saturated
+   `sdk-blocking-` pool, and it is released in a `finally`: an offload that
+   raises, and an activity cancelled mid-offload, must release their *own* token,
+   because a leaked unbounded hold vouches for the rest of the attempt and
+   silences the watchdog for good. Holds are keyed by token, so concurrent
+   offloads under one `asyncio.gather`, and an auto-hold nested inside an
+   author's declared `holding_progress`, never release each other.
+
+   The label is `run_in_thread.<callable qualname>` — the offloaded callable's
+   own name, never an argument, so warn mode ranks *sites*
+   (`run_in_thread.Cursor.execute`, p99 40min, unbounded) instead of collapsing
+   an app's blocking work into one bucket, and no query, path or credential can
+   reach a log or metric label through this route.
+
+   `run_fault_isolated` — the SDK's other offload seam, and `run_best_effort`'s
+   mechanism — is held on the same grounds: an isolated call emits nothing at all
+   until the child returns, and the SDK's own default allowance for the upload
+   validation scan is 600s, well past any plausible no-progress budget. Its hold
+   is **bounded by its own `timeout`** where `run_in_thread`'s is unbounded, and
+   that is not the derived bound rejected above: what is rejected is inferring an
+   allowance from the *callee's* per-operation kwargs, whereas
+   `run_fault_isolated(timeout=...)` is this function's own parameter, enforced
+   here as a wall-clock kill of the child — which is exactly what an allowance
+   means. `timeout=None` still yields an unbounded hold, matching its "wait
+   forever" semantics.
 3. **Manual `context.heartbeat(...)` or `holding_progress(...)` (explicit, app
    action).** The residual: a custom async loop, or an opaque single `await`
    against the connector's own source client (see the asymmetry below — this is

--- a/docs/concepts/apps.md
+++ b/docs/concepts/apps.md
@@ -218,7 +218,13 @@ async with self.holding_progress("full table scan", timeout=7200):
     rows = await self.run_in_thread(cursor.execute, sql)
 ```
 
-For opaque *async* calls (the connector's own async client) there is no SDK-owned seam to auto-hold, so wrap those in `holding_progress` directly. See [ADR-0018](../adr/0018-progress-aware-heartbeat.md) for the design.
+`timeout` is **not** a prediction of how long the call takes. Err generous: too generous only delays detection toward the backstop, while too tight kills a healthy run — and because stall kills retry, a too-tight allowance burns the same wasted work up to three times.
+
+**Inside a `holding_progress` block the automatic holds stand down**, so the allowance you declared is what governs. The example above lapses at 7200s rather than inheriting an unbounded auto-hold that would outlive it — the SDK never adds a vouch that outlives the one you asked for. (An offload running concurrently in a task that never entered the block is still auto-held.)
+
+For opaque *async* calls (the connector's own async client) there is no SDK-owned seam to auto-hold, so wrap those in `holding_progress` directly. Expect to need it: interleaved streaming reads (fetch a page, write a batch, repeat) are already covered by the SDK's own writer and transfer loops, but almost every connector makes at least one genuinely opaque single call — one large metadata query, one slow list/export that returns everything at once.
+
+See [ADR-0018](../adr/0018-progress-aware-heartbeat.md) for the design.
 
 ## Lifecycle Hooks
 

--- a/docs/concepts/apps.md
+++ b/docs/concepts/apps.md
@@ -198,6 +198,28 @@ class MyIncrementalExtractor(IncrementalSqlMetadataExtractor):
 
 Base class for all metadata-extraction Apps. Provides upload, cleanup, and lifecycle plumbing without committing to a SQL-specific task layout. `SqlMetadataExtractor` extends this with SQL-specific defaults and task structure.
 
+## Offloading Blocking Work (`run_in_thread` and auto-holds)
+
+Connector code runs on Temporal's asyncio event loop, so a blocking call (a sync database driver, a filesystem read, a vendor SDK without async support) must not run on the loop itself. Offload it with `run_in_thread` — reachable as `self.run_in_thread(...)`, `self.task_context.run_in_thread(...)`, or the module-level `application_sdk.execution.heartbeat.run_in_thread`:
+
+```python
+rows = await self.run_in_thread(cursor.execute, sql)
+```
+
+Every offload is automatically wrapped in a **progress hold** (ADR-0018), so the stall watchdog never reads a legitimately long blocking call as a stall and false-kills it. There is nothing to do at the call site — a long blocking call behaves exactly as it did before the watchdog existed:
+
+- `run_in_thread` holds are **unbounded**. The SDK does not invent a duration for somebody else's blocking call, so the watchdog is inactive for the call's whole duration and the activity's duration bound is the only thing still holding it.
+- `run_fault_isolated` holds are **bounded by that call's own `timeout`** (the wall-clock kill it already enforces), and unbounded when `timeout=None`, matching its "wait forever" semantics.
+
+To give a blocking call a real bound instead of the unbounded default, wrap the offload in `holding_progress(label, timeout=...)` — declaring how long you would let this one call run before you would rather it failed. A wedged call is then caught at `timeout` plus the no-progress budget rather than at the duration backstop:
+
+```python
+async with self.holding_progress("full table scan", timeout=7200):
+    rows = await self.run_in_thread(cursor.execute, sql)
+```
+
+For opaque *async* calls (the connector's own async client) there is no SDK-owned seam to auto-hold, so wrap those in `holding_progress` directly. See [ADR-0018](../adr/0018-progress-aware-heartbeat.md) for the design.
+
 ## Lifecycle Hooks
 
 ### on_complete

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,12 +1,17 @@
 """Unit test configuration and autouse fixtures."""
 
-from collections.abc import Iterator
+import time
+from collections.abc import Callable, Iterator
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from loguru import logger as _loguru_logger
 
-from application_sdk.execution.progress import ProgressTracker, bind_progress_tracker
+from application_sdk.execution.progress import (
+    ClosedHold,
+    ProgressTracker,
+    bind_progress_tracker,
+)
 
 # Re-export shared registry fixtures so all unit tests can use them without
 # explicit per-file imports (pytest discovers fixtures via conftest chain).
@@ -17,17 +22,23 @@ from application_sdk.testing.fixtures import (  # noqa: F401
 
 
 class RecordingProgressTracker(ProgressTracker):
-    """A real :class:`ProgressTracker` that also keeps every label it was given.
+    """A real :class:`ProgressTracker` that also keeps a history of its signals.
 
     ``ProgressTracker`` only retains the *most recent* label, which is all the
     stall watchdog needs but not enough to assert that a framework hook fires
     once per unit of work rather than once per record (ADR-0018's hard
     constraint). Subclassing keeps the real stall/hold behaviour intact — no
-    stub — while adding the ordered label history a hook test needs.
+    stub — while adding the ordered histories a hook or auto-hold test needs.
+
+    :attr:`labels` records ``mark_progress`` calls; :attr:`holds` records every
+    hold as it closes, which is a separate list because a closed hold is *not* a
+    ``mark_progress`` call — ``exit_hold`` re-arms the stall clock directly, so a
+    hold would otherwise leave no trace in either history.
     """
 
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, clock: Callable[[], float] = time.monotonic) -> None:
+        self.holds: list[ClosedHold] = []
+        super().__init__(clock=clock, on_hold_closed=self.holds.append)
         self.labels: list[str] = []
 
     def mark_progress(self, label: str = "") -> None:
@@ -37,6 +48,10 @@ class RecordingProgressTracker(ProgressTracker):
     def count(self, label: str) -> int:
         """How many times *label* was recorded."""
         return self.labels.count(label)
+
+    def holds_for(self, label: str) -> list[ClosedHold]:
+        """Every closed hold recorded under *label*, in the order they closed."""
+        return [hold for hold in self.holds if hold.label == label]
 
 
 @pytest.fixture

--- a/tests/unit/execution/test_offload_holds.py
+++ b/tests/unit/execution/test_offload_holds.py
@@ -1,0 +1,609 @@
+"""Unit tests for the ``run_in_thread`` / ``run_fault_isolated`` auto-holds (FND-290).
+
+ADR-0018 → *Feeding the tracker*, mechanism 2. The one thing these tests exist to
+prove is a **negative**: turning the stall watchdog on must not make a
+legitimately long blocking call fail where it used to succeed. So the assertions
+are about the hold being *unbounded*, being active for the call's whole duration,
+and — the way this would actually break in production — being released by
+whichever offload owns it and no other.
+
+Two properties get counted rather than merely observed, because presence alone
+would pass while the mechanism was wrong:
+
+- **Exactly one hold per offload.** Three public entry points funnel into one
+  implementation, so a hold added per entry point instead of per offload would
+  still show "a hold is active" while double-counting every call the wrapper
+  makes.
+- **Nothing in a label but code.** A hold label reaches the stall log, the metric
+  and the warn-mode report, so an argument leaking into one is a data leak, not a
+  cosmetic bug.
+
+The fake clock is injected into the tracker, never patched globally: an asyncio
+loop shares ``time.monotonic``, and patching it makes the loop itself misbehave.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from concurrent.futures.process import BrokenProcessPool
+from dataclasses import dataclass
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from application_sdk.app.context import AppContext, TaskExecutionContext
+from application_sdk.execution.heartbeat import (
+    NoopHeartbeatController,
+    _check_for_stall,
+    run_best_effort,
+    run_fault_isolated,
+    run_in_thread,
+)
+from application_sdk.execution.progress import (
+    ProgressWatchdogMode,
+    bind_progress_tracker,
+    current_progress_tracker,
+    holding_progress,
+)
+from tests.unit.conftest import RecordingProgressTracker
+
+THREAD_PREFIX = "run_in_thread."
+ISOLATED_PREFIX = "run_fault_isolated."
+
+
+@dataclass
+class _FakeClock:
+    """A monotonic clock the test advances explicitly."""
+
+    now: float = 1000.0
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+@pytest.fixture
+def tracker() -> Any:
+    """Bind a recording tracker for the test, as ``activities.py`` would."""
+    recording = RecordingProgressTracker()
+    with bind_progress_tracker(recording):
+        yield recording
+
+
+# Module-level so the spawn child can pickle them by reference (it re-imports
+# this module), which rules out closures and mocks for the isolated tests.
+
+
+def _echo(value: str) -> str:
+    return f"echo:{value}"
+
+
+def _sleep_forever() -> None:
+    time.sleep(3600)
+
+
+def _raise_value_error() -> None:
+    raise ValueError("boom")
+
+
+class _Cursor:
+    """Stands in for the shape the ADR calls dominant: ``cursor.execute(sql)``."""
+
+    def execute(self, sql: str) -> str:
+        return f"rows for {sql}"
+
+
+class _Callable:
+    """A callable *instance*: its name lives on the class, not the object."""
+
+    def __call__(self) -> str:
+        return "called"
+
+
+# ---------------------------------------------------------------------------
+# The offload is vouched for, through every entry point
+# ---------------------------------------------------------------------------
+
+
+class TestTheOffloadIsVouchedFor:
+    @pytest.mark.asyncio
+    async def test_the_hold_is_active_for_the_whole_call(
+        self, tracker: RecordingProgressTracker
+    ) -> None:
+        """Read from inside the blocking call: the vouch is live *while* it runs.
+
+        Asserting only on the closed hold afterwards would pass even if the hold
+        were entered and released back to back around the offload.
+        """
+
+        def _blocking() -> tuple[bool, float]:
+            return tracker.held(), tracker.stalled_for()
+
+        held_during, stalled_during = await run_in_thread(_blocking)
+
+        assert held_during is True
+        assert stalled_during == 0.0
+        assert tracker.held() is False, "the hold must not outlive the offload"
+
+    @pytest.mark.asyncio
+    async def test_the_context_wrapper_reaches_the_same_hold(
+        self, tracker: RecordingProgressTracker
+    ) -> None:
+        """``TaskExecutionContext.run_in_thread`` — the entry point apps use."""
+        context = TaskExecutionContext(
+            app_context=AppContext(app_name="_hold-app", app_version="0.0.0"),
+            task_name="extract",
+            heartbeat_controller=NoopHeartbeatController(),
+        )
+
+        def _blocking() -> bool:
+            return tracker.held()
+
+        assert await context.run_in_thread(_blocking) is True
+        assert len(tracker.holds) == 1
+        assert tracker.holds[0].label.startswith(THREAD_PREFIX)
+
+    @pytest.mark.asyncio
+    async def test_one_hold_per_offload_not_per_entry_point(
+        self, tracker: RecordingProgressTracker
+    ) -> None:
+        """A count, because every layering mistake here still looks vouched-for.
+
+        The module-level function, the ``TaskExecutionContext`` wrapper and
+        ``App.run_in_thread`` are three public entry points over *one*
+        implementation. Holding at each layer instead of at the offload would
+        report two or three holds for a single blocking call — and would inflate
+        the warn-mode duration ranking with holds nobody can act on.
+        """
+        context = TaskExecutionContext(
+            app_context=AppContext(app_name="_hold-app", app_version="0.0.0"),
+            task_name="extract",
+            heartbeat_controller=NoopHeartbeatController(),
+        )
+
+        await run_in_thread(_echo, "a")
+        await context.run_in_thread(_echo, "b")
+
+        assert len(tracker.holds) == 2
+
+    @pytest.mark.asyncio
+    async def test_a_completed_offload_counts_as_progress(
+        self, tracker: RecordingProgressTracker
+    ) -> None:
+        """A loop of short offloads keeps the attempt alive on its own.
+
+        ``exit_hold`` re-arms the stall clock under the hold's label, so a task
+        whose only observable work is a sequence of blocking calls needs no
+        framework hook and no manual heartbeat to stay out of the watchdog.
+        """
+        for _ in range(3):
+            await run_in_thread(_echo, "chunk")
+
+        assert tracker.last_label == f"{THREAD_PREFIX}_echo"
+        assert tracker.stalled_for() < 1.0
+
+
+# ---------------------------------------------------------------------------
+# Unbounded: the upgrade must never false-kill
+# ---------------------------------------------------------------------------
+
+
+class TestTheHoldIsUnbounded:
+    @pytest.mark.asyncio
+    async def test_no_allowance_is_invented(
+        self, tracker: RecordingProgressTracker
+    ) -> None:
+        """The SDK declares nothing on the author's behalf.
+
+        Deriving a bound from the call's own ``timeout=`` kwarg was rejected in
+        review — it is per-operation, so it is systematically smaller than the
+        call's legitimate duration. Passing one here must change nothing.
+        """
+        await run_in_thread(_echo, "value")
+        await run_in_thread(lambda timeout: timeout, timeout=30)
+
+        assert [hold.allowance_seconds for hold in tracker.holds] == [None, None]
+        assert [hold.bounded for hold in tracker.holds] == [False, False]
+
+    @pytest.mark.asyncio
+    async def test_a_six_hour_blocking_call_is_not_a_stall(self) -> None:
+        """The whole point of the issue, asserted through the watchdog itself.
+
+        Six hours pass inside one blocking call — longer than the largest
+        ``start_to_close`` weight class in the fleet — against a 60s budget in
+        ``ENFORCE``. The watchdog must not fire, so upgrading a task that makes
+        one long blocking call cannot fail where it used to succeed.
+        """
+        clock = _FakeClock()
+        recording = RecordingProgressTracker(clock=clock)
+        on_stall = MagicMock()
+
+        def _six_hours_of_blocking_work() -> None:
+            clock.advance(6 * 60 * 60)
+
+        with bind_progress_tracker(recording):
+            await run_in_thread(_six_hours_of_blocking_work)
+            # Checked after the call as well: a hold that stopped vouching the
+            # moment it closed would leave the six quiet hours it covered on the
+            # clock, and the very next tick would kill the attempt.
+            fired = _check_for_stall(
+                progress=recording,
+                budget_seconds=60.0,
+                mode=ProgressWatchdogMode.ENFORCE,
+                task_name="extract",
+                on_stall=on_stall,
+            )
+
+        assert fired is False
+        on_stall.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_the_watchdog_is_inactive_mid_call_by_design(self) -> None:
+        """The accepted residual, pinned so it is a decision and not a surprise.
+
+        An unbounded hold means the stall watchdog cannot fire *at all* while the
+        call runs, however long it runs — the duration backstop is the only bound
+        left. If this ever starts failing, someone has narrowed the residual, and
+        ADR-0018 plus the warn-mode report need to be re-read before it lands.
+        """
+        clock = _FakeClock()
+        recording = RecordingProgressTracker(clock=clock)
+        on_stall = MagicMock()
+
+        def _wedged_blocking_call() -> bool:
+            clock.advance(24 * 60 * 60)
+            return _check_for_stall(
+                progress=recording,
+                budget_seconds=60.0,
+                mode=ProgressWatchdogMode.ENFORCE,
+                task_name="extract",
+                on_stall=on_stall,
+            )
+
+        with bind_progress_tracker(recording):
+            fired = await run_in_thread(_wedged_blocking_call)
+
+        assert fired is False
+        on_stall.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_the_hold_reports_the_duration_it_observed(self) -> None:
+        """What makes an auto-held call visible to the warn-mode work-list.
+
+        The hold is the reason the watchdog says nothing, so without the observed
+        duration on the way out, blocking work would be invisible to the audit
+        precisely *because* it was vouched for.
+        """
+        clock = _FakeClock()
+        recording = RecordingProgressTracker(clock=clock)
+
+        with bind_progress_tracker(recording):
+            await run_in_thread(lambda: clock.advance(90.0))
+
+        assert len(recording.holds) == 1
+        closed = recording.holds[0]
+        assert closed.duration_seconds == pytest.approx(90.0)
+        assert closed.bounded is False
+        assert closed.lapsed is False, "an unbounded hold can never lapse"
+
+
+# ---------------------------------------------------------------------------
+# Release discipline: only ever this offload's own token
+# ---------------------------------------------------------------------------
+
+
+class TestTheHoldIsAlwaysReleased:
+    @pytest.mark.asyncio
+    async def test_released_when_the_blocking_call_raises(
+        self, tracker: RecordingProgressTracker
+    ) -> None:
+        """A leak here silences the watchdog for the rest of the attempt."""
+        with pytest.raises(ValueError, match="boom"):
+            await run_in_thread(_raise_value_error)
+
+        assert tracker.held() is False
+        assert len(tracker.holds) == 1
+
+    @pytest.mark.asyncio
+    async def test_released_when_the_caller_is_cancelled_mid_offload(
+        self, tracker: RecordingProgressTracker
+    ) -> None:
+        """Cancellation is the realistic leak: the thread outlives the await.
+
+        A cancelled activity that later resumes work in the same context — or a
+        cancellation swallowed by a caller — would otherwise carry an unbounded
+        hold nobody can release, and the watchdog would never fire again.
+        """
+        started = threading.Event()
+        release = threading.Event()
+
+        def _blocking() -> None:
+            started.set()
+            release.wait(timeout=5)
+
+        offload = asyncio.create_task(run_in_thread(_blocking))
+        await asyncio.to_thread(started.wait, 5)
+        offload.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await offload
+        release.set()
+
+        assert tracker.held() is False
+        assert len(tracker.holds) == 1
+
+    @pytest.mark.asyncio
+    async def test_concurrent_offloads_release_only_their_own_hold(
+        self, tracker: RecordingProgressTracker
+    ) -> None:
+        """``asyncio.gather`` over several offloads — the shape holds are keyed for.
+
+        The fast offload finishes first. If holds were stacked rather than keyed
+        by token, its release would pop the slow one's entry and the attempt
+        would stop being vouched for while the slow call is still blocking.
+        """
+        release_slow = threading.Event()
+        slow_running = threading.Event()
+
+        def _slow() -> str:
+            slow_running.set()
+            release_slow.wait(timeout=5)
+            return "slow"
+
+        def _fast() -> str:
+            return "fast"
+
+        slow = asyncio.create_task(run_in_thread(_slow))
+        await asyncio.to_thread(slow_running.wait, 5)
+
+        assert await run_in_thread(_fast) == "fast"
+        assert (
+            tracker.held() is True
+        ), "the fast offload's release must not take the slow one's hold with it"
+
+        release_slow.set()
+        assert await slow == "slow"
+        assert tracker.held() is False
+        assert len(tracker.holds) == 2
+
+    @pytest.mark.asyncio
+    async def test_an_offload_inside_a_declared_hold_leaves_it_intact(
+        self, tracker: RecordingProgressTracker
+    ) -> None:
+        """Nesting, in the shape ADR-0018's own blocking example produces.
+
+        ``holding_progress`` around ``run_in_thread`` (FND-291) means an author's
+        *declared* bounded hold with this PR's auto-hold nested inside it. The
+        inner release must not touch the outer token — that would drop a declared
+        allowance on the floor mid-call and hand the site back to the backstop,
+        turning a `timeout + budget` kill time silently back into 24h.
+
+        FND-291 already asserts the offload can *see* the enclosing hold; what is
+        asserted here is the release, which is this PR's half.
+        """
+        async with holding_progress("full table scan", timeout=7200):
+            await run_in_thread(_echo, "page")
+
+            assert (
+                tracker.held() is True
+            ), "the declared hold must survive the inner release"
+            assert [hold.label for hold in tracker.holds] == [f"{THREAD_PREFIX}_echo"]
+
+        assert tracker.held() is False
+        # Inner first, outer second — and the outer keeps the allowance its
+        # author declared rather than inheriting the auto-hold's `None`.
+        assert [hold.allowance_seconds for hold in tracker.holds] == [None, 7200]
+        assert tracker.holds[1].label == "full table scan"
+
+
+# ---------------------------------------------------------------------------
+# Labels name the site, and only ever code
+# ---------------------------------------------------------------------------
+
+
+class TestTheHoldLabel:
+    @pytest.mark.asyncio
+    async def test_it_names_the_offloaded_callable(
+        self, tracker: RecordingProgressTracker
+    ) -> None:
+        """So warn mode ranks sites instead of one ``run_in_thread`` bucket."""
+        await run_in_thread(_Cursor().execute, "SELECT 1")
+
+        assert tracker.holds[0].label == f"{THREAD_PREFIX}_Cursor.execute"
+
+    @pytest.mark.asyncio
+    async def test_no_argument_reaches_the_label(
+        self, tracker: RecordingProgressTracker
+    ) -> None:
+        """Labels are carried into logs and metrics, so this is a data-leak pin.
+
+        The arguments here are the three shapes that would matter if one ever
+        leaked: a query with a tenant-shaped literal, a filesystem path, and a
+        credential-shaped value.
+        """
+        await run_in_thread(
+            _Cursor().execute,
+            "SELECT * FROM example_tenant.orders WHERE region = 'apac'",
+        )
+        await run_in_thread(_echo, "/local/tmp/artifacts/run-1/chunk-0.parquet")
+        await run_in_thread(_echo, "not-a-real-secret-value")
+
+        labels = " ".join(hold.label for hold in tracker.holds)
+        for leak in ("example_tenant", "SELECT", "artifacts", "secret", "apac"):
+            assert leak not in labels
+
+    @pytest.mark.asyncio
+    async def test_a_partial_is_named_by_the_callable_it_wraps(
+        self, tracker: RecordingProgressTracker
+    ) -> None:
+        """``functools.partial`` carries no name of its own; the wrapped one does."""
+        import functools
+
+        await run_in_thread(functools.partial(functools.partial(_echo), "value"))
+
+        assert tracker.holds[0].label == f"{THREAD_PREFIX}_echo"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("func", "expected"),
+        [
+            (lambda: "lambda", "<lambda>"),
+            (_Callable(), "_Callable"),
+            (MagicMock(return_value=None), "MagicMock"),
+        ],
+        ids=["lambda", "callable-instance", "mock"],
+    )
+    async def test_a_nameless_callable_still_gets_a_usable_label(
+        self, tracker: RecordingProgressTracker, func: Any, expected: str
+    ) -> None:
+        """Every fallback in the naming helper, including the one that matters.
+
+        A ``Mock`` fabricates a child mock for any attribute asked of it, so
+        reading ``__qualname__`` without checking it is a string would put a
+        ``<MagicMock id=...>`` repr — a per-instance value, so unbounded metric
+        cardinality — straight into a label.
+
+        Matched on the tail, not for equality: a lambda or a nested function
+        carries its enclosing scope in ``__qualname__`` (``...<locals>.<lambda>``),
+        which is verbose but still exactly the identifier that locates the site.
+        """
+        await run_in_thread(func)
+
+        label = tracker.holds[0].label
+        assert label.startswith(THREAD_PREFIX)
+        assert label.endswith(expected)
+        assert "id=" not in label, "a repr, not an identifier, reached the label"
+
+
+# ---------------------------------------------------------------------------
+# Outside an activity: byte-for-byte the old behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestWithNoTrackerBound:
+    @pytest.mark.asyncio
+    async def test_the_offload_is_unchanged_and_silent(self, loguru_capture) -> None:
+        """Local runs, unit tests, scripts: inert, and no warning about it.
+
+        The inert tracker hands back a token no real tracker can own, and its
+        ``exit_hold`` stays quiet — so the release path must not log the
+        "no such hold" warning on every offload made outside an activity.
+        """
+        assert await run_in_thread(_echo, "hi") == "echo:hi"
+
+        assert current_progress_tracker().held() is False
+        assert current_progress_tracker().last_label == ""
+        assert not [
+            record
+            for record in loguru_capture
+            if "exit_hold" in record["message"] or "no such hold" in record["message"]
+        ]
+
+
+# ---------------------------------------------------------------------------
+# run_fault_isolated — the other offload seam, bounded by its own timeout
+# ---------------------------------------------------------------------------
+
+
+class TestTheIsolatedOffloadHold:
+    @pytest.mark.asyncio
+    async def test_a_declared_timeout_becomes_the_allowance(
+        self, tracker: RecordingProgressTracker
+    ) -> None:
+        """Not a derived bound: this ``timeout`` is enforced here as a kill.
+
+        What ADR-0018 rejects is inferring an allowance from the *callee's*
+        per-operation kwargs. ``run_fault_isolated``'s own ``timeout`` is a
+        wall-clock ceiling it enforces by killing the child, which is exactly
+        what an allowance means — so reusing it invents nothing.
+        """
+        assert await run_fault_isolated(_echo, "hi", timeout=30) == "echo:hi"
+
+        assert len(tracker.holds) == 1
+        closed = tracker.holds[0]
+        assert closed.label == f"{ISOLATED_PREFIX}_echo"
+        assert closed.allowance_seconds == 30
+        assert closed.lapsed is False
+
+    @pytest.mark.asyncio
+    async def test_no_timeout_means_an_unbounded_hold(
+        self, tracker: RecordingProgressTracker
+    ) -> None:
+        """``timeout=None`` waits forever, so the hold vouches without a bound."""
+        await run_fault_isolated(_echo, "hi")
+
+        assert tracker.holds[0].allowance_seconds is None
+
+    @pytest.mark.asyncio
+    async def test_released_when_the_timeout_kills_the_child(
+        self, tracker: RecordingProgressTracker
+    ) -> None:
+        with pytest.raises(TimeoutError):
+            await run_fault_isolated(_sleep_forever, timeout=0.5)
+
+        assert tracker.held() is False
+        assert len(tracker.holds) == 1
+
+    @pytest.mark.asyncio
+    async def test_released_when_the_child_raises(
+        self, tracker: RecordingProgressTracker
+    ) -> None:
+        with pytest.raises(ValueError, match="boom"):
+            await run_fault_isolated(_raise_value_error)
+
+        assert tracker.held() is False
+        assert len(tracker.holds) == 1
+
+    @pytest.mark.asyncio
+    async def test_a_rejected_pool_width_records_no_hold(
+        self, tracker: RecordingProgressTracker
+    ) -> None:
+        """The argument check runs before the hold, so nothing was offloaded.
+
+        Entering first would report a zero-duration hold for a call that never
+        reached a child — noise in the audit for a programming error.
+        """
+        with pytest.raises(ValueError):
+            await run_fault_isolated(_echo, "hi", max_workers=0)
+
+        assert tracker.holds == []
+        assert tracker.held() is False
+
+    @pytest.mark.asyncio
+    async def test_best_effort_delegates_one_hold(
+        self, tracker: RecordingProgressTracker
+    ) -> None:
+        """The policy layer holds through the mechanism, not on top of it."""
+        logger = MagicMock()
+
+        assert await run_best_effort(_echo, "hi", label="Echo", logger=logger) == (
+            "echo:hi"
+        )
+
+        assert len(tracker.holds) == 1
+        assert tracker.holds[0].label == f"{ISOLATED_PREFIX}_echo"
+
+    @pytest.mark.asyncio
+    async def test_a_foreign_pool_discard_still_releases(
+        self, tracker: RecordingProgressTracker
+    ) -> None:
+        """Both concurrent callers release, including the one killed by the other.
+
+        One caller's timeout discards the shared pool and breaks the other's
+        in-flight child. Two offloads went out, so two holds must come back —
+        the abandoned one is exactly the token that would leak.
+        """
+        hung, foreign = await asyncio.gather(
+            run_fault_isolated(_sleep_forever, timeout=0.5),
+            run_fault_isolated(_sleep_forever, timeout=30),
+            return_exceptions=True,
+        )
+
+        assert isinstance(hung, TimeoutError)
+        assert isinstance(foreign, BrokenProcessPool)
+        assert len(tracker.holds) == 2
+        assert tracker.held() is False

--- a/tests/unit/execution/test_offload_holds.py
+++ b/tests/unit/execution/test_offload_holds.py
@@ -525,6 +525,89 @@ class TestADeclaredAllowanceGoverns:
         ]
 
     @pytest.mark.asyncio
+    async def test_a_task_that_outlives_the_block_is_vouched_for_again(
+        self, tracker: RecordingProgressTracker
+    ) -> None:
+        """The detached-task escape: standing down must never leave *nothing*.
+
+        ``asyncio.create_task`` copies the creating context (PEP 567), so a task
+        spawned inside the block carries the suppression mark into a lifetime the
+        parent's ``reset`` cannot reach. If the mark were a plain boolean, such a
+        task offloading *after* the block exits would stand down with no declared
+        hold left to cover it — no vouch at all while the watchdog is live, which
+        is a worse hole than the one the suppression closes, and precisely the
+        false-kill this whole issue exists to prevent.
+
+        Naming the hold instead of flagging it makes the mark falsifiable, so the
+        detached task is auto-held again like any other caller.
+        """
+        block_exited = threading.Event()
+        vouched_during_offload: list[bool] = []
+
+        async def _detached() -> None:
+            await asyncio.to_thread(block_exited.wait, 5)
+            await run_in_thread(lambda: vouched_during_offload.append(tracker.held()))
+
+        async with holding_progress("full table scan", timeout=7200):
+            child = asyncio.create_task(_detached())
+            await asyncio.sleep(0)  # let it start and park
+
+        block_exited.set()
+        await child
+
+        assert vouched_during_offload == [
+            True
+        ], "an offload outliving the declared block must get its own auto-hold"
+        assert [hold.label for hold in tracker.holds] == [
+            "full table scan",
+            f"{THREAD_PREFIX}<lambda>",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_a_hold_on_another_tracker_suppresses_nothing(
+        self, tracker: RecordingProgressTracker
+    ) -> None:
+        """A declared hold can only govern the attempt it was declared on.
+
+        If the tracker is rebound between the declaration and the offload, the
+        declared hold belongs to the previous attempt — it vouches for nothing
+        here, so suppressing on it would leave this attempt's offload unvouched.
+        """
+        other = RecordingProgressTracker()
+
+        async with holding_progress("full table scan", timeout=7200):
+            with bind_progress_tracker(other):
+                await run_in_thread(_echo, "different attempt")
+
+        assert [hold.label for hold in other.holds] == [f"{THREAD_PREFIX}_echo"]
+        assert [hold.label for hold in tracker.holds] == ["full table scan"]
+
+    @pytest.mark.asyncio
+    async def test_a_lapsed_declared_hold_still_suppresses(self) -> None:
+        """Suppression tracks the token being *open*, not the hold still vouching.
+
+        Once a declared allowance lapses the watchdog is meant to resume and fire
+        one budget later. If the auto-hold re-armed at that moment it would vouch
+        unboundedly again and defeat the allowance a second time — so an offload
+        started after the lapse, while the block is still open, must stay
+        suppressed.
+        """
+        clock = _FakeClock()
+        recording = RecordingProgressTracker(clock=clock)
+
+        with bind_progress_tracker(recording):
+            async with holding_progress("full table scan", timeout=600):
+                clock.advance(900)  # the declared allowance lapses
+
+                assert recording.held() is False, "the lapsed hold stops vouching"
+                await run_in_thread(_echo, "after the lapse")
+
+                # No auto-hold was added, so the watchdog stays free to fire.
+                assert recording.held() is False
+
+        assert [hold.label for hold in recording.holds] == ["full table scan"]
+
+    @pytest.mark.asyncio
     async def test_nested_declared_blocks_restore_one_level_at_a_time(
         self, tracker: RecordingProgressTracker
     ) -> None:

--- a/tests/unit/execution/test_offload_holds.py
+++ b/tests/unit/execution/test_offload_holds.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import asyncio
 import threading
 import time
+from collections.abc import Callable
 from concurrent.futures.process import BrokenProcessPool
 from dataclasses import dataclass
 from typing import Any
@@ -52,6 +53,7 @@ from tests.unit.conftest import RecordingProgressTracker
 
 THREAD_PREFIX = "run_in_thread."
 ISOLATED_PREFIX = "run_fault_isolated."
+UNNAMEABLE = "<callable>"
 
 
 @dataclass
@@ -327,7 +329,10 @@ class TestTheHoldIsAlwaysReleased:
             release.wait(timeout=5)
 
         offload = asyncio.create_task(run_in_thread(_blocking))
-        await asyncio.to_thread(started.wait, 5)
+        # Asserted, not awaited-and-discarded: a `wait` that timed out on a
+        # contended runner would cancel before the offload owned its hold, and
+        # the test would pass without ever exercising the release it exists for.
+        assert await asyncio.to_thread(started.wait, 5), "offload never started"
         offload.cancel()
         with pytest.raises(asyncio.CancelledError):
             await offload
@@ -358,7 +363,10 @@ class TestTheHoldIsAlwaysReleased:
             return "fast"
 
         slow = asyncio.create_task(run_in_thread(_slow))
-        await asyncio.to_thread(slow_running.wait, 5)
+        # Asserted for the same reason as the cancellation test: if the slow
+        # offload never got going, "the fast release left a hold standing" would
+        # be checking nothing.
+        assert await asyncio.to_thread(slow_running.wait, 5), "slow never started"
 
         assert await run_in_thread(_fast) == "fast"
         assert (
@@ -477,6 +485,113 @@ class TestTheHoldLabel:
         assert label.startswith(THREAD_PREFIX)
         assert label.endswith(expected)
         assert "id=" not in label, "a repr, not an identifier, reached the label"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "hostile_qualname",
+        [
+            "extract for example_tenant",
+            "query('SELECT * FROM orders')",
+            "/local/tmp/artifacts/run-1/chunk-0.parquet",
+            "fetch\nrows",
+            "scan_" + "x" * 200,
+        ],
+        ids=["spaces", "quoted-value", "path", "newline", "too-long"],
+    )
+    async def test_a_name_that_is_not_an_identifier_never_reaches_the_label(
+        self, tracker: RecordingProgressTracker, hostile_qualname: str
+    ) -> None:
+        """``__qualname__`` is writable, so "it comes from code" needs enforcing.
+
+        A decorator, a factory or a dynamically-built class can set it to
+        anything, including a per-call value. Everywhere else that is harmless;
+        here the string lands in the ``last_label`` metric attribute, where a
+        per-call value is unbounded series cardinality and a 200-character one is
+        dead weight on every stall report.
+
+        Both name attributes are poisoned, so the label falls through to the
+        callable's *type* name — still a real identifier, and still useful.
+        """
+
+        def _named() -> str:
+            return "done"
+
+        _named.__qualname__ = hostile_qualname
+        _named.__name__ = hostile_qualname
+
+        await run_in_thread(_named)
+
+        label = tracker.holds[0].label
+        assert hostile_qualname not in label
+        assert label == f"{THREAD_PREFIX}function"
+
+    @pytest.mark.asyncio
+    async def test_an_unnameable_callable_collapses_to_one_constant(
+        self, tracker: RecordingProgressTracker
+    ) -> None:
+        """The bottom rung: every name a callable has is unusable.
+
+        Reached only by a callable whose *class* was also given a junk name, so
+        it is a backstop rather than a path real code takes. It matters that the
+        backstop is a single constant: one refused label must add one metric
+        series, not one per distinct junk value — otherwise refusing the name
+        would cost exactly what keeping it did.
+        """
+
+        class _Hostile:
+            def __call__(self) -> str:
+                return "done"
+
+        _Hostile.__qualname__ = "callable for example_tenant"
+        _Hostile.__name__ = "callable for example_tenant"
+
+        await run_in_thread(_Hostile())
+
+        assert tracker.holds[0].label == f"{THREAD_PREFIX}{UNNAMEABLE}"
+
+    @pytest.mark.asyncio
+    async def test_a_hostile_qualname_falls_back_to_the_plain_name(
+        self, tracker: RecordingProgressTracker
+    ) -> None:
+        """Degrade one rung at a time, not straight to the constant.
+
+        ``__qualname__`` and ``__name__`` are set independently, so a callable
+        can carry an unusable one and a perfectly good other. Naming the site is
+        the whole point of the label, so a real identifier beats the stable
+        constant whenever one is available.
+        """
+
+        def _named() -> str:
+            return "done"
+
+        _named.__qualname__ = "extract for example_tenant"
+
+        await run_in_thread(_named)
+
+        assert tracker.holds[0].label == f"{THREAD_PREFIX}_named"
+
+    @pytest.mark.asyncio
+    async def test_a_deeply_nested_qualname_is_still_kept(
+        self, tracker: RecordingProgressTracker
+    ) -> None:
+        """The length cap must not refuse names real code produces.
+
+        A lambda nested inside a test method already carries its whole enclosing
+        scope, which is the longest shape the SDK's own suite generates — if the
+        cap cannot admit that, it is set too low to be useful.
+        """
+
+        def _outer() -> Callable[[], str]:
+            def _deeply_nested_inner_helper_with_a_long_name() -> str:
+                return "done"
+
+            return _deeply_nested_inner_helper_with_a_long_name
+
+        await run_in_thread(_outer())
+
+        label = tracker.holds[0].label
+        assert label.endswith("_deeply_nested_inner_helper_with_a_long_name")
+        assert UNNAMEABLE not in label
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/execution/test_offload_holds.py
+++ b/tests/unit/execution/test_offload_holds.py
@@ -378,34 +378,170 @@ class TestTheHoldIsAlwaysReleased:
         assert tracker.held() is False
         assert len(tracker.holds) == 2
 
+
+# ---------------------------------------------------------------------------
+# A declared allowance wins: the auto-hold stands down inside holding_progress
+# ---------------------------------------------------------------------------
+
+
+class TestADeclaredAllowanceGoverns:
+    """``holding_progress`` around an offload — ADR-0018's blocking example.
+
+    The tracker's hold set is a *union*: ``held()`` and ``stalled_for()`` report
+    vouched while any hold is unlapsed, and an unbounded hold never lapses. So an
+    auto-hold nested inside a declared one would keep vouching past the declared
+    allowance and hand the site back to the 24h backstop — the exact outcome
+    ``holding_progress`` exists to prevent. The auto-hold therefore stands down
+    inside a declared block.
+    """
+
     @pytest.mark.asyncio
-    async def test_an_offload_inside_a_declared_hold_leaves_it_intact(
+    async def test_a_wedged_offload_is_still_caught_at_timeout_plus_budget(
+        self,
+    ) -> None:
+        """The promise `holding_progress`'s own docstring makes, end to end.
+
+        A blocking call wedges inside a declared 7200s allowance. Once the
+        allowance lapses the watchdog must resume *from the deadline* and fire
+        one budget later — not stay paused for the 24h backstop because the
+        offload added a vouch nobody asked for.
+        """
+        clock = _FakeClock()
+        recording = RecordingProgressTracker(clock=clock)
+        on_stall = MagicMock()
+        wedged = threading.Event()
+        entered = threading.Event()
+
+        def _wedged_blocking_call() -> None:
+            entered.set()
+            wedged.wait(timeout=10)
+
+        try:
+            with bind_progress_tracker(recording):
+                async with holding_progress("full table scan", timeout=7200):
+                    offload = asyncio.create_task(run_in_thread(_wedged_blocking_call))
+                    assert await asyncio.to_thread(entered.wait, 5), "never started"
+
+                    # The declared allowance lapses, then the budget elapses.
+                    clock.advance(7200 + 60 + 1)
+
+                    assert recording.held() is False
+                    assert recording.stalled_for() == pytest.approx(61.0)
+                    fired = _check_for_stall(
+                        progress=recording,
+                        budget_seconds=60.0,
+                        mode=ProgressWatchdogMode.ENFORCE,
+                        task_name="extract",
+                        on_stall=on_stall,
+                    )
+
+                    assert fired is True
+                    on_stall.assert_called_once()
+        finally:
+            wedged.set()
+            await offload
+
+    @pytest.mark.asyncio
+    async def test_only_the_declared_hold_is_recorded(
         self, tracker: RecordingProgressTracker
     ) -> None:
-        """Nesting, in the shape ADR-0018's own blocking example produces.
+        """One hold around the offload, not two.
 
-        ``holding_progress`` around ``run_in_thread`` (FND-291) means an author's
-        *declared* bounded hold with this PR's auto-hold nested inside it. The
-        inner release must not touch the outer token — that would drop a declared
-        allowance on the floor mid-call and hand the site back to the backstop,
-        turning a `timeout + budget` kill time silently back into 24h.
-
-        FND-291 already asserts the offload can *see* the enclosing hold; what is
-        asserted here is the release, which is this PR's half.
+        The warn-mode work-list should rank the site an author can act on — the
+        declared one — rather than double-counting the same wall-clock under a
+        second auto-generated label.
         """
         async with holding_progress("full table scan", timeout=7200):
             await run_in_thread(_echo, "page")
 
-            assert (
-                tracker.held() is True
-            ), "the declared hold must survive the inner release"
-            assert [hold.label for hold in tracker.holds] == [f"{THREAD_PREFIX}_echo"]
+            assert tracker.held() is True
 
+        assert [hold.label for hold in tracker.holds] == ["full table scan"]
+        assert [hold.allowance_seconds for hold in tracker.holds] == [7200]
         assert tracker.held() is False
-        # Inner first, outer second — and the outer keeps the allowance its
-        # author declared rather than inheriting the auto-hold's `None`.
-        assert [hold.allowance_seconds for hold in tracker.holds] == [None, 7200]
-        assert tracker.holds[1].label == "full table scan"
+
+    @pytest.mark.asyncio
+    async def test_an_isolated_call_stands_down_too(
+        self, tracker: RecordingProgressTracker
+    ) -> None:
+        """Both offload seams obey the same precedence rule.
+
+        A rule that held at one seam and not the other would be worse than no
+        rule: the same `holding_progress` block would mean different things
+        depending on which primitive the body happened to reach for.
+        """
+        async with holding_progress("validation scan", timeout=600):
+            await run_fault_isolated(_echo, "hi", timeout=30)
+
+        assert [hold.label for hold in tracker.holds] == ["validation scan"]
+
+    @pytest.mark.asyncio
+    async def test_a_concurrent_offload_outside_the_block_is_still_held(
+        self, tracker: RecordingProgressTracker
+    ) -> None:
+        """The reason this is context-scoped and not tracker-scoped.
+
+        Suppressing on "some hold is open on this tracker" would leave a
+        concurrent offload in an unrelated task unvouched for its whole duration
+        — re-introducing the false-kill the auto-hold exists to remove. Only the
+        task that entered the block sees the mark.
+        """
+        inside_running = threading.Event()
+        release_inside = threading.Event()
+
+        async def _inside_a_declared_block() -> None:
+            async with holding_progress("declared", timeout=600):
+                await run_in_thread(inside_running.set)
+                await asyncio.to_thread(release_inside.wait, 5)
+
+        declared = asyncio.create_task(_inside_a_declared_block())
+        assert await asyncio.to_thread(inside_running.wait, 5), "never started"
+
+        # This offload's task never entered the block, so it must be auto-held.
+        await run_in_thread(_echo, "elsewhere")
+
+        release_inside.set()
+        await declared
+
+        labels = [hold.label for hold in tracker.holds]
+        assert (
+            f"{THREAD_PREFIX}_echo" in labels
+        ), "an offload outside the declared block must still be vouched for"
+        assert "declared" in labels
+
+    @pytest.mark.asyncio
+    async def test_the_auto_hold_returns_once_the_block_exits(
+        self, tracker: RecordingProgressTracker
+    ) -> None:
+        """Standing down lasts exactly as long as the declared allowance does."""
+        async with holding_progress("full table scan", timeout=7200):
+            await run_in_thread(_echo, "inside")
+
+        await run_in_thread(_echo, "after")
+
+        assert [hold.label for hold in tracker.holds] == [
+            "full table scan",
+            f"{THREAD_PREFIX}_echo",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_nested_declared_blocks_restore_one_level_at_a_time(
+        self, tracker: RecordingProgressTracker
+    ) -> None:
+        """An inner block exiting must not re-arm the auto-hold under an outer one.
+
+        The mark is a ContextVar token, so leaving the inner block restores the
+        outer block's value rather than clearing it — otherwise an offload
+        between the inner and outer exits would add exactly the hold this
+        precedence rule exists to suppress.
+        """
+        async with holding_progress("outer", timeout=7200):
+            async with holding_progress("inner", timeout=600):
+                await run_in_thread(_echo, "innermost")
+
+            await run_in_thread(_echo, "between")
+
+        assert [hold.label for hold in tracker.holds] == ["inner", "outer"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/execution/test_progress_context.py
+++ b/tests/unit/execution/test_progress_context.py
@@ -46,6 +46,7 @@ from application_sdk.execution.progress import (
     bind_progress_tracker,
     current_progress_tracker,
 )
+from tests.unit.conftest import RecordingProgressTracker
 
 
 class _ProgIn(Input, allow_unbounded_fields=True):
@@ -209,7 +210,11 @@ class TestReachableFromRunInThread:
 
     @pytest.mark.asyncio
     async def test_module_level_run_in_thread(self) -> None:
-        tracker = ProgressTracker()
+        # A recording tracker, because the label history is what proves the mark
+        # landed: the offload's own auto-hold (FND-290) releases *after* the
+        # thread returns and re-arms the stall clock under its own label, so
+        # `last_label` is the hold's by the time the await completes.
+        tracker = RecordingProgressTracker()
 
         with bind_progress_tracker(tracker):
             seen = await run_in_thread(_read_tracker_deep)
@@ -218,17 +223,17 @@ class TestReachableFromRunInThread:
         # The context is copied into the thread, but the tracker object is
         # shared — so progress marked in the thread lands on the attempt's
         # tracker rather than on a private copy that dies with the thread.
-        assert tracker.last_label == "from_thread"
+        assert "from_thread" in tracker.labels
 
     @pytest.mark.asyncio
     async def test_task_execution_context_run_in_thread(self) -> None:
-        tracker = ProgressTracker()
+        tracker = RecordingProgressTracker()
 
         with bind_progress_tracker(tracker):
             seen = await _task_execution_context().run_in_thread(_read_tracker_deep)
 
         assert seen is tracker
-        assert tracker.last_label == "from_thread"
+        assert "from_thread" in tracker.labels
 
     @pytest.mark.asyncio
     async def test_reachable_from_a_nested_async_frame(self) -> None:
@@ -358,7 +363,12 @@ class TestActivityBinding:
         from_body, from_wrapper, from_module_level = seen
         assert from_wrapper is from_body
         assert from_module_level is from_body
-        assert from_body.last_label == "from_thread"
+        # The activity owns this tracker, so there is no label history to read —
+        # only the most recent signal, which is the second offload's auto-hold
+        # (FND-290) releasing under the offloaded callable's name. That is the
+        # composed shape end to end: bound by `activities.py`, reached through
+        # both entry points, and vouched for on the way back out.
+        assert from_body.last_label == "run_in_thread._read_tracker_deep"
 
     @pytest.mark.asyncio
     async def test_tracker_is_unbound_after_the_activity_returns(self) -> None:


### PR DESCRIPTION
> **Now based on `main`** — every PR ahead of this one in the ADR-0018 stack has merged (#3145 → #3147 → #3148 → #3150 → #3157), so the full CI matrix runs on this PR for real. Rebased onto `820b13c4`; one commit, no conflicts left.

Implements [FND-290](https://linear.app/atlan-epd/issue/FND-290/run-in-thread-auto-holds-unbounded-so-upgrade-never-false-kills) — [ADR-0018](https://github.com/atlanhq/application-sdk/blob/main/docs/adr/0018-progress-aware-heartbeat.md) → *Feeding the tracker*, **mechanism 2**: blocking work is vouched for automatically, at the seam ADR-0010 already makes mandatory.

This is the piece that makes the watchdog safe to turn on. #3150 covers the streaming majority with `mark_progress` hooks; #3157 gives an author the *explicit* hold for an opaque call; this one covers the case where nobody typed anything — a blocking call that emits nothing until it returns, held automatically because `run_in_thread` is a mandatory seam. The entire deliverable is a **negative**: after this, turning the watchdog on cannot fail a long blocking call that succeeds today.

With this merged, M1's mechanism work is complete: tracker, reach, framework hooks, explicit holds, automatic holds.

## What lands

| Seam | Hold | Label |
| --- | --- | --- |
| `run_in_thread` (module-level, `TaskExecutionContext.run_in_thread`, `App.run_in_thread`) | **unbounded** | `run_in_thread.<callable qualname>` |
| `run_fault_isolated` (and `run_best_effort` through it) | **bounded by its own `timeout`**, unbounded when `None` | `run_fault_isolated.<callable qualname>` |

…and inside a `holding_progress` block, **neither** — the declared allowance governs (decision 9).

No new API, no call-site change in any app, no new arguments on any function.

## Decisions a reviewer should look at

**1. One hold per offload, not per entry point.** All three public `run_in_thread` entry points funnel into one implementation (`context.py` and `base.py` are pure delegations), so the hold goes on the implementation. Holding at each layer would report two or three holds for a single blocking call and inflate the warn-mode duration ranking with holds nobody can act on. `test_one_hold_per_offload_not_per_entry_point` asserts a **count of 2** across two entry points, not presence.

**2. The hold starts before the executor dispatch.** So it also covers time queued behind a saturated `sdk-blocking-` pool. That is quiet time the attempt can do nothing about, and killing it is exactly the false-kill this issue forbids.

**3. Released in a `finally`, and that is the failure mode worth testing.** An offload that raises, and an activity cancelled mid-offload, must release *their own* token — a leaked unbounded hold vouches for the rest of the attempt, so one exception would silence the watchdog permanently. The cancellation test is the realistic one: `task.cancel()` resolves the awaiting future while the worker thread keeps running, so the `finally` is the only thing that releases.

**4. Nothing but code reaches a label.** The label is the offloaded callable's `__qualname__`, never an argument. This is a data-leak pin, not a cosmetic one — labels reach the stall log, the stall metric and the warn-mode report. `test_no_argument_reaches_the_label` offloads a query carrying a tenant-shaped literal, a filesystem path and a credential-shaped value and asserts none of it appears in any label.

Naming the *callee* rather than walking the caller's frame is deliberate: three entry points funnel into one implementation, so a frame walk would name an SDK wrapper on two of the three.

The name is then *validated*, because `__qualname__` and `__name__` are ordinary writable attributes — "it comes from code" is a convention, not a guarantee, and a decorator or dynamically-built class can set either to a per-call value. Everywhere else that is harmless; here the string is a metric attribute, where a per-call value is unbounded series cardinality. So the name must match a dotted-qualname charset and a length cap, degrading one rung at a time (`__qualname__` → `__name__` → type name) and collapsing to the single constant `<callable>` only when every rung is unusable — one refused label costs one series, not one per junk value. A `Mock`, which fabricates a child mock for any attribute asked of it, is caught by the same check.

**5. `run_fault_isolated` is scope beyond the issue's `run_in_thread`, and its hold is *bounded*.** FND-290 names `run_in_thread`. I held the other offload seam too, on ADR-0018's own rule — if one step can outlast the budget with nothing carrying its signal, it must be observable. An isolated call emits nothing at all until the child returns, and the SDK's own default for the upload-validation scan is `ATLAN_VALIDATE_ASSETS_TIMEOUT_SECONDS=600` — a 10-minute quiet window at an SDK-owned site, well past any plausible no-progress budget.

Bounded rather than unbounded because **the number exists and is real**. What ADR-0018 rejects is deriving an allowance from the *callee's* per-operation kwargs. `run_fault_isolated(timeout=...)` is that function's own parameter and is enforced there as a wall-clock kill of the child — precisely what `enter_hold`'s allowance means ("how long you would let this one operation run before you would rather it failed"). `timeout=None` still gives an unbounded hold, matching its "wait forever" semantics. It cannot lapse in practice: the call itself returns at the deadline.

**6. Why `run_in_thread` gets no bound at all.** Restating the rejected alternative, since this is the issue's core: `func`'s own `timeout=` kwarg is per-operation — a `requests` read timeout bounds the gap between socket reads, a `statement_timeout` bounds one statement of many — so a bound derived from it is systematically *smaller* than the call's legitimate duration. The dominant shape, `run_in_thread(cursor.execute, sql)`, carries no `timeout=` at all, and any fallback tight enough to be useful would be tighter than today's 2h/6h `start_to_close`, making legitimate blocking work fail *sooner* after the upgrade. A `blocking_timeout=` kwarg was never mechanically available either: `run_in_thread(func, *args, **kwargs)` forwards every kwarg to `func`, so the name would collide.

**7. The residual is pinned by a test, so narrowing it can't happen by accident.** An unbounded hold means the watchdog cannot fire *at all* while the call runs, however long — the duration backstop is the only bound left. `test_the_watchdog_is_inactive_mid_call_by_design` advances a 24h fake clock inside the blocking call and asserts `_check_for_stall` returns `False` in `ENFORCE`. If that test ever fails, somebody narrowed an accepted residual and ADR-0018 needs re-reading before it lands.

**9. An explicit allowance beats the automatic one.** `ProgressTracker`'s hold set is a *union* — `held()`/`stalled_for()` report vouched while any hold is unlapsed, and an unbounded hold never lapses. So an auto-hold nested inside `holding_progress(timeout=T)` kept vouching *past* T and handed the site back to the 24h backstop: the exact outcome `holding_progress` exists to prevent, on ADR-0018's own canonical blocking example. Caught in review; reproduced before fixing.

Both seams now stand down inside a declared block (`_auto_hold`, shared so the rule can't be right at one seam and wrong at the other). The alternative — having the auto-hold inherit the *remaining* allowance — works, but manufactures a derived duration and files it in the warn-mode report as though a human declared it, which is the derived-bound shape this ADR rejects. Standing down also leaves one hold around the offload instead of two, so the work-list ranks the site an author can act on.

The suppression is **context-scoped, never tracker-scoped**: "some hold is open on this tracker" would suppress a concurrent offload in an unrelated task and leave real blocking work unvouched, reintroducing the very false-kill this PR removes. Verified empirically that a `ContextVar` set through an async context manager is visible to the caller, nests correctly, and is invisible to a sibling task that never entered the block.

**8. No `None` checks.** `current_progress_tracker()` returns a null object; the inert `enter_hold` hands back `-1`, which a real tracker rejects with a warning rather than silently releasing someone else's hold. `test_the_offload_is_unchanged_and_silent` asserts the release path logs *nothing* outside an activity — every offload in a local run or unit test would otherwise emit a "no such hold" warning.

## Three merged FND-287 tests changed

`exit_hold` re-arms the stall clock under the hold's label (#3145's semantics), and the auto-hold releases *after* the worker thread returns — so `last_label` is now the hold's label, not whatever the thread marked. Three assertions in `test_progress_context.py` (merged in #3148) read `last_label == "from_thread"`.

Two now use `RecordingProgressTracker` and assert `"from_thread" in tracker.labels`, which proves the same thing the original assertion was a proxy for (the mark landed on the *shared* object, not a private copy that dies with the thread) and is no longer sensitive to what happens after. The third runs inside a real activity, so there is no label history to read — it now asserts `last_label == "run_in_thread._read_tracker_deep"`, which pins the composed shape end to end: bound by `activities.py`, reached through both entry points, vouched for on the way out.

## Cost

The hold is one `ContextVar.get()` plus an `enter_hold`/`exit_hold` pair, measured against the smallest thing it can ever attach to — an empty `run_in_thread` round trip (median of 7 × 200k hold pairs, 3 × 20k offloads):

| | per call | share of one empty offload |
| --- | --- | --- |
| hold pair, inert tracker | 35.7 ns | 0.11% |
| hold pair, real tracker | 914 ns | 2.9% |
| label + identifier validation | 206 ns | 0.68% |
| empty `run_in_thread` round trip | 30.5 µs | — |

End-to-end the offload goes 30.5 µs → 31.7 µs with a tracker bound. The ~900 ns is dominated by the two frozen dataclasses `ProgressTracker` constructs per hold (`_Hold`, `ClosedHold`) — #3145's shape, not something added here. Against a real blocking call (milliseconds at the very fastest; the sites this exists for run for minutes) it is unmeasurable, and no SDK-internal `run_in_thread` call site is per-record — they are per file, per push, per directory.

## Tests

39 new in `tests/unit/execution/test_offload_holds.py`, plus a `holds` history and an injectable clock on the shared `RecordingProgressTracker` in `tests/unit/conftest.py` (a closed hold is not a `mark_progress` call, so it would otherwise leave no trace in either history — FND-292 will want this too).

- **Vouched for** (4) — the hold is live *read from inside* the blocking call, not just observed afterwards; the `TaskExecutionContext` wrapper reaches the same hold; one hold per offload across two entry points; a sequence of offloads keeps the attempt alive with no hook and no manual heartbeat.
- **Unbounded** (4) — no allowance invented even when the call passes its own `timeout=`; a six-hour blocking call is not a stall through `_check_for_stall` in `ENFORCE` at a 60s budget; the mid-call residual; the observed duration reported on the way out.
- **A declared allowance governs** (6) — a wedged offload inside `holding_progress(timeout=7200)` is still caught at `timeout + budget` through `_check_for_stall` in `ENFORCE`; only the declared hold is recorded, not two; `run_fault_isolated` stands down identically; a concurrent offload in a task that never entered the block is *still* auto-held; the auto-hold returns once the block exits; nested blocks restore one level at a time.
- **Release discipline** (4) — released when the call raises, when the caller is cancelled mid-offload, when a concurrent gather's fast offload finishes while the slow one still blocks (keyed by token, so no stack-pop bug), and when the auto-hold is nested inside a real `holding_progress` block — the inner release must not drop the outer *declared* allowance, which would silently turn a `timeout + budget` kill time back into 24h.
- **Labels** (13) — names the callable; no argument reaches a label; `functools.partial`; lambda / callable instance / `Mock`; a poisoned `__qualname__` degrading to `__name__` and then to the type name; five shapes of junk name (spaces, a quoted value, a path, a newline, 200 chars) never reaching the label; the unnameable backstop collapsing to one constant; and a deeply nested real qualname *not* being refused, so the cap can't be set uselessly low.
- **Inert** (1) — unchanged and silent with no tracker bound.
- **`run_fault_isolated`** (7) — a declared timeout becomes the allowance; `None` is unbounded; released on timeout, on a child exception, and on a foreign pool discard (two offloads → two holds, the abandoned one being exactly the token that would leak); a rejected `max_workers` records no hold at all; `run_best_effort` delegates one hold rather than adding its own.

The fake clock is injected into the tracker, never patched globally — an asyncio loop shares `time.monotonic`.

Verification:

- `uv run pytest tests/unit` — **6731 passed, 9 skipped**
- `uv run pre-commit run --files <all 7 changed files>` — ruff, ruff-format, isort, pyright clean
- Full conformance suite, diffed against the same run on `main` by `(rule, file, message)` — **0 new findings, 0 resolved** (487 raw / 340 unique both sides), `exitCode: 0`
- Capability manifest regenerated: only the three metadata header fields the drift check excludes changed — no API-surface drift
- Import-cycle check: `execution.heartbeat`, `execution`, `app.context`, `app.base`, `execution.progress` each imported first in a fresh interpreter

## Scope left out

- **FND-291** (`holding_progress()`, merged in #3157) is the explicit counterpart — the author-declared allowance for an opaque *async* call, which has no mandatory seam to auto-hold. Nothing in it needed changing; this PR points the three `run_in_thread` docstrings at it as the way to trade the automatic unbounded hold for a real bound.
- **FND-292** owns the warn-mode telemetry that consumes `ClosedHold`; this PR is what gives it blocking-call observations to consume.
- **FND-300** owns the conformance rule that keeps un-held opaque sites visible.
- **FND-295** owns the user-facing docs. The API docstrings on all three `run_in_thread` entry points and on `run_fault_isolated` are updated here, since the auto-hold is behaviour of those APIs.

---

## Review follow-ups

The second commit applies all three nits from SDK review round 1:

- **[SEC] the label's identifier guarantee is now enforced, not assumed** — see decision 4 above. The review's point was exactly right: the PR tested that *arguments* can't reach a label while trusting `__qualname__` verbatim, which is the half that isn't guaranteed.
- **[TEST] ×2 — two concurrency tests awaited a `threading.Event.wait()` and discarded the result.** A coordination timeout on a contended runner would have let the cancellation and concurrent-release tests pass without exercising the release they exist for. Both now assert the wait.

Round 2 raised two Important findings, both fixed in the fourth commit:

- **[STRUCT] the nested-hold precedence defect** — decision 9 above. A real bug this PR introduced against a promise that shipped in #3157.
- **[DX] concept-doc drift** — `docs/concepts/apps.md` is what a connector author reads; the ADR is maintainer rationale. The sdk-resolve bot pushed a section for this concurrently; I rebased onto it, kept its placement, folded in the stand-down semantics it predated, and removed my duplicate.

## Rebase notes

Replayed onto `main` with `git rebase --onto origin/main <old base>`, so only the FND-290 commit is applied — the ancestors were squash-merged and would otherwise have been re-applied as non-patch-identical duplicates.

Two conflicts, both in test files, both from review changes made to #3148 after this branch was cut:

- **`set_progress_tracker` / `reset_progress_tracker` became `bind_progress_tracker`**, a context manager. Migrated the new test file's fixture and its three fake-clock tests to the block form; no production code was affected, since the auto-hold reads `current_progress_tracker()`, which is unchanged.
- **`test_progress_context.py`** had migrated the same three assertions this PR needs to change to the block form. Resolved by keeping `main`'s block form and re-applying this PR's assertion changes on top.

`main` also moved hold-token allocation to a process-wide counter; nothing here depends on token values, and the 26 tests pass unchanged against it.
