### PR TITLE
feat(execution): TaskStalledError and the stall branch in the cancellation handler (FND-289)

### DIFF
--- a/application_sdk/errors/__init__.py
+++ b/application_sdk/errors/__init__.py
@@ -49,6 +49,7 @@ from application_sdk.errors.leaves import (
     RateLimitedError,
     ResourceExhaustedError,
     SourceUnavailableError,
+    TaskStalledError,
     UnimplementedError,
 )
 from application_sdk.errors.wire import FailureDetails
@@ -148,6 +149,7 @@ __all__ = [
     "PreconditionError",
     "RateLimitedError",
     "ResourceExhaustedError",
+    "TaskStalledError",
     "UnimplementedError",
     "WORKER_EVICTED_TYPE",
     # Legacy (deprecated — removed in v4.0)

--- a/application_sdk/errors/leaves.py
+++ b/application_sdk/errors/leaves.py
@@ -43,6 +43,50 @@ class AppTimeoutError(AppError):
 
 
 @dataclass(kw_only=True)
+class TaskStalledError(AppTimeoutError):
+    """An activity attempt was failed for making no observable progress (ADR-0018).
+
+    Raised by the SDK's activity wrapper, not by app code: the stall watchdog in
+    the auto-heartbeat loop cancels the attempt, and the cancellation handler
+    turns that cancel into this error. It means the attempt kept heartbeating —
+    the event loop was alive — while nothing observable advanced for longer than
+    the task's ``max_no_progress_seconds``.
+
+    A subtype of :class:`AppTimeoutError` rather than a sixteenth categorical
+    leaf: a stall *is* a TIMEOUT-category failure, so ``except AppTimeoutError``
+    catch sites and TIMEOUT-keyed consumers keep working, while the distinct
+    ``code`` and the Temporal wire type ``"TaskStalledError"`` let a stall kill
+    be counted separately from a ``StartToClose`` or heartbeat timeout. The
+    ``TIMEOUT_`` prefix on the code is the convention every leaf subclass follows
+    (P003) so the code column carries its category without a join.
+
+    ``stalled_for_seconds`` is not the inherited ``elapsed_seconds``, and both
+    can be meaningful at once: ``elapsed_seconds`` measures how long a bounded
+    wait ran before it was abandoned, while this measures the *quiet gap* inside
+    an attempt that may have been productively running for hours before it went
+    silent. A stall has no bounded wait that elapsed — that absence is the whole
+    problem the watchdog exists to detect — so ``timeout_seconds`` and
+    ``elapsed_seconds`` are left unset on this path.
+
+    **Retryable, deliberately.** The dominant cause is a transient source-side
+    hang in an app whose error handling never surfaced it, which self-heals on a
+    fresh attempt; a genuine wedge re-stalls and costs at most a few multiples of
+    ``max_no_progress_seconds``, not of the duration backstop. Non-retryable
+    would convert the self-healing majority into failed runs needing a manual
+    re-run that restarts from zero anyway (ADR-0018 → *Failing the activity*).
+    Pinned here rather than inherited so a future change to
+    :class:`AppTimeoutError`'s default cannot silently flip it.
+    """
+
+    stalled_for_seconds: float | None = None
+    last_progress_label: str | None = None
+
+    default_retryable: ClassVar[bool] = True
+    code: ClassVar[str] = "TIMEOUT_TASK_STALLED"
+    audience: ClassVar[Audience] = Audience.APP_OWNER
+
+
+@dataclass(kw_only=True)
 class RateLimitedError(AppError):
     limit_type: str | None = None
     retry_after_seconds: float | None = None

--- a/application_sdk/execution/_temporal/activities.py
+++ b/application_sdk/execution/_temporal/activities.py
@@ -14,7 +14,7 @@ import asyncio
 import dataclasses
 from collections.abc import Callable
 from datetime import timedelta
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 from uuid import uuid4
 
 from temporalio import activity
@@ -25,6 +25,10 @@ from application_sdk.constants import LOCAL_WORKFLOW_ID, TRACKED_FILE_REFS_KEY
 from application_sdk.contracts.base import Input, Output
 from application_sdk.contracts.types import FileReference
 from application_sdk.observability.logger_adaptor import get_logger
+
+if TYPE_CHECKING:
+    from application_sdk.errors.base import AppError
+    from application_sdk.execution.errors import ApplicationError
 
 logger = get_logger(__name__)
 
@@ -70,6 +74,62 @@ def _sever_cause_chain(exc: BaseException) -> None:
             current.__context__ = None
             break
         current = nxt
+
+
+def _to_application_error(e: AppError) -> ApplicationError:
+    """Translate a typed :class:`AppError` into the ``ApplicationError`` we raise.
+
+    Shared by every site in this module that fails an activity with a typed
+    error — the stall branch of the cancellation handler and the general
+    ``AppError`` branch — because all three things it does are easy to get
+    subtly different in a second copy, and each one silently degrades a failure
+    that a human has to read later:
+
+    - the ``FailureDetails`` guard, so non-serialisable evidence costs the
+      structured details rather than replacing the real error with a secondary
+      one;
+    - ``_sever_cause_chain``, so Temporal's failure serializer can always
+      complete (BLDX-1512);
+    - ``non_retryable=not e.effective_retryable``, so the error's own retry
+      policy reaches Temporal instead of the default.
+
+    Args:
+        e: The typed error to translate. Mutated by the cause-chain severing,
+            which is safe because the caller raises the returned
+            ``ApplicationError`` immediately.
+
+    Returns:
+        The ``ApplicationError`` to raise, with the error's class name as its
+        wire ``type``. Callers must still ``raise ... from`` the original
+        exception so the traceback keeps its chain.
+    """
+    from application_sdk.execution.errors import (  # noqa: PLC0415 — circular: execution/__init__.py loads sibling modules + app.base imports execution
+        ApplicationError,
+    )
+
+    # Guard FailureDetails construction: evidence fields may contain
+    # non-serialisable values; fall back to details-free ApplicationError
+    # rather than letting a secondary error mask the original.
+    try:
+        details: tuple[Any, ...] = (e.to_failure_details(),)
+    except Exception:
+        logger.warning(
+            "Failed to build FailureDetails for %s; raising without structured details",
+            type(e).__name__,
+            exc_info=True,
+        )
+        details = ()
+
+    # Sever deep / cyclic __cause__ / __context__ chains before Temporal's
+    # failure serializer walks them (BLDX-1512).
+    _sever_cause_chain(e)
+
+    return ApplicationError(
+        str(e),
+        *details,
+        type=type(e).__name__,
+        non_retryable=not e.effective_retryable,
+    )
 
 
 @dataclasses.dataclass
@@ -213,18 +273,51 @@ def create_activity_from_task(
         stop_event = asyncio.Event()
         heartbeat_task = None
 
-        with bind_progress_tracker(ProgressTracker()):
+        with bind_progress_tracker(ProgressTracker()) as tracker:
             try:
                 if (
                     context.heartbeat_timeout_seconds is not None
                     and context.auto_heartbeat_seconds is not None
                 ):
+                    # Captured here, in the attempt's own task. The handler below
+                    # runs inside the heartbeat task, where
+                    # `asyncio.current_task()` would be the watchdog itself — it
+                    # would cancel the thing doing the watching and leave the
+                    # wedged attempt running.
+                    activity_task = asyncio.current_task()
+
+                    def on_stall(
+                        stalled_for_seconds: float, last_progress_label: str
+                    ) -> None:
+                        """Fail this attempt: record the verdict, then cancel it.
+
+                        Recording before cancelling is what makes the two
+                        orderings equivalent: the cancellation lands at the
+                        attempt's next ``await``, which is never earlier than the
+                        return from this call, so the observation is always
+                        already there when the handler below reads it.
+                        """
+                        tracker.flag_stalled(
+                            stalled_for_seconds=stalled_for_seconds,
+                            last_progress_label=last_progress_label,
+                        )
+                        if activity_task is not None:
+                            activity_task.cancel()
+
                     heartbeat_task = asyncio.create_task(
                         auto_heartbeat_loop(
                             interval_seconds=context.auto_heartbeat_seconds,
                             heartbeat_fn=heartbeat_controller.heartbeat_keepalive,
                             stop_event=stop_event,
                             task_name=context.task_name,
+                            # `watchdog_mode` and `max_no_progress_seconds` are
+                            # deliberately absent: their defaults leave the
+                            # watchdog inert, and the per-task flag and budget
+                            # that turn it on are FND-296's. Injecting the
+                            # handler now means enabling the watchdog is a config
+                            # change rather than a second seam.
+                            progress=tracker,
+                            on_stall=on_stall,
                         )
                     )
 
@@ -281,14 +374,17 @@ def create_activity_from_task(
             except asyncio.CancelledError as e:
                 # In Python 3.8+, ``asyncio.CancelledError`` extends ``BaseException``,
                 # so it bypasses the ``except Exception`` block below. We must catch
-                # it explicitly to attribute pod-termination cancels to
-                # ``ApplicationError(type=WORKER_EVICTED_TYPE)`` and let other cancels propagate as today.
+                # it explicitly to attribute the two cancels the SDK gives a
+                # meaning — a stall kill to
+                # ``ApplicationError(type="TaskStalledError")`` and a pod
+                # termination to ``ApplicationError(type=WORKER_EVICTED_TYPE)`` —
+                # and let every other cancel propagate as today.
                 #
                 # NOTE: converting ``CancelledError`` to a regular exception
                 # technically violates asyncio's cancellation protocol — the
                 # task ends in done-with-exception state instead of cancelled,
                 # so callers keying on ``Task.cancelled()`` would observe False.
-                # In practice this only fires during graceful worker shutdown,
+                # In practice it only fires on those two attributed cancels,
                 # where the only consumer is Temporal's activity wrapper (which
                 # records the failure on the wire as ``ApplicationError`` — the
                 # exact behaviour we want so the workflow-side eviction loop can
@@ -296,6 +392,49 @@ def create_activity_from_task(
                 # heartbeat cleanup. If we ever surface this swap to a plain
                 # asyncio caller, we'd need to relocate it to a Temporal
                 # interceptor instead.
+
+                # The stall check comes FIRST, ahead of the shutdown check, and
+                # the order is load-bearing rather than stylistic: a stall and a
+                # SIGTERM can coincide, and if eviction won that race, a wedged
+                # attempt would be mislabelled `WorkerEvicted` and re-dispatched
+                # by the workflow-side eviction-retry loop *outside* the normal
+                # retry budget — the exact amplification ADR-0018 exists to
+                # remove. Attributed to the stall, it spends the task's own retry
+                # budget like any other failure.
+                stall = tracker.stall
+                if stall is not None:
+                    from application_sdk.errors.leaves import (  # noqa: PLC0415 — circular: execution/__init__.py loads sibling modules + errors imports observability transitively
+                        TaskStalledError,
+                    )
+
+                    last_label = stall.last_progress_label or "<none>"
+                    _sever_cause_chain(e)
+                    raise _to_application_error(
+                        TaskStalledError(
+                            message=(
+                                f"Task '{context.task_name}' made no observable "
+                                f"progress for {stall.stalled_for_seconds:.0f}s; "
+                                f"last signal was '{last_label}'"
+                            ),
+                            operation=context.task_name,
+                            stalled_for_seconds=stall.stalled_for_seconds,
+                            # Left unset rather than "" when the attempt never
+                            # reported one: absent reads as absent on the wire,
+                            # and "the attempt never made a single observable
+                            # signal" is a materially different finding from "it
+                            # went quiet after this one".
+                            last_progress_label=stall.last_progress_label or None,
+                            app_name=context.app_name,
+                            run_id=run_id,
+                            suggested_action=(
+                                "Declare an allowance for the call that "
+                                "legitimately runs quiet for this long; otherwise "
+                                "look for a retry loop that never exits, or a "
+                                "source connection that hung without erroring"
+                            ),
+                        )
+                    ) from e
+
                 from application_sdk.execution.shutdown import (  # noqa: PLC0415 — circular: execution/__init__.py loads sibling modules + app.base imports execution
                     is_worker_shutting_down,
                 )
@@ -323,33 +462,7 @@ def create_activity_from_task(
                 )
 
                 if isinstance(e, _AppError):
-                    from application_sdk.execution.errors import (  # noqa: PLC0415 — circular
-                        ApplicationError,
-                    )
-
-                    # Guard FailureDetails construction: evidence fields may contain
-                    # non-serialisable values; fall back to details-free ApplicationError
-                    # rather than letting a secondary error mask the original.
-                    try:
-                        details: tuple[Any, ...] = (e.to_failure_details(),)
-                    except Exception:
-                        logger.warning(
-                            "Failed to build FailureDetails for %s; raising without structured details",
-                            type(e).__name__,
-                            exc_info=True,
-                        )
-                        details = ()
-
-                    # Sever deep / cyclic __cause__ / __context__ chains before
-                    # Temporal's failure serializer walks them (BLDX-1512).
-                    _sever_cause_chain(e)
-
-                    raise ApplicationError(
-                        str(e),
-                        *details,
-                        type=type(e).__name__,
-                        non_retryable=not e.effective_retryable,
-                    ) from e
+                    raise _to_application_error(e) from e
                 raise
 
             finally:

--- a/application_sdk/execution/progress.py
+++ b/application_sdk/execution/progress.py
@@ -42,6 +42,12 @@ an activity. The framework hooks (FND-288), the ``run_in_thread`` auto-holds
 (FND-290) and the warn-mode telemetry that consumes :class:`ClosedHold`
 (FND-292) are separate pieces built on this one; :func:`holding_progress`
 (FND-291) lives here, next to the tracker whose holds it opens.
+
+In enforce mode the watchdog's verdict comes back through
+:meth:`ProgressTracker.flag_stalled`, and that :class:`StallObservation` is what
+tells ``activities.py`` that a landing ``asyncio.CancelledError`` is a stall kill
+rather than a worker eviction — the two are otherwise indistinguishable at the
+handler that sees them.
 """
 
 from __future__ import annotations
@@ -128,6 +134,29 @@ class ClosedHold:
 
 
 @dataclass(frozen=True)
+class StallObservation:
+    """The no-progress gap the watchdog acted on, frozen at the moment it acted.
+
+    Written by the activity layer's ``on_stall`` handler and read by the
+    cancellation handler that turns the resulting ``CancelledError`` into a
+    typed ``TaskStalledError`` (ADR-0018 → *Failing the activity*). Frozen at
+    detection time rather than re-derived at the raise site because by then the
+    numbers have moved: :meth:`ProgressTracker.stalled_for` keeps growing while
+    the cancellation travels to the attempt's next ``await``, and any progress
+    signal in flight would re-arm it entirely.
+
+    Attributes:
+        stalled_for_seconds: Seconds without an observable progress signal, as
+            observed by the watchdog tick that decided to fail the attempt.
+        last_progress_label: The last progress label seen, ``""`` if the attempt
+            never reported one.
+    """
+
+    stalled_for_seconds: float
+    last_progress_label: str
+
+
+@dataclass(frozen=True)
 class _Hold:
     """An in-flight vouch. ``allowance_seconds=None`` means unbounded."""
 
@@ -183,6 +212,7 @@ class ProgressTracker:
         self._last_label: str = ""
         self._last_at: float = clock()
         self._holds: dict[int, _Hold] = {}
+        self._stall: StallObservation | None = None
         # Mutations are not confined to the event loop: contextvars propagate
         # into `run_in_thread`, so framework hooks and `context.heartbeat()`
         # inside an offloaded blocking call reach this object from a worker
@@ -357,6 +387,48 @@ class ProgressTracker:
                     since = max(since, deadline)
         return max(0.0, now - since)
 
+    @property
+    def stall(self) -> StallObservation | None:
+        """The gap the watchdog failed this attempt for, ``None`` if it has not.
+
+        The one thing that tells the activity's ``except CancelledError`` handler
+        *whose* cancellation it is holding: a stall kill and a worker eviction
+        arrive at the same handler as the same exception type, and only this
+        distinguishes them (ADR-0018 → *Failing the activity*). Read it before
+        the shutdown check — a stall and a SIGTERM can coincide, and attributing
+        such a cancel to eviction would re-dispatch a wedged attempt outside the
+        normal retry budget.
+        """
+        with self._lock:
+            return self._stall
+
+    def flag_stalled(
+        self, stalled_for_seconds: float, last_progress_label: str
+    ) -> None:
+        """Record that the watchdog has judged this attempt stalled.
+
+        Called by the activity layer's ``on_stall`` handler immediately before it
+        cancels the attempt, so the observation is already here when the
+        cancellation lands. Not progress, and deliberately not a mutation of the
+        stall clock: this records a verdict, it does not change what was
+        observed.
+
+        First flag wins. A second call cannot happen through the watchdog (the
+        loop returns as soon as it enforces), and if it ever did, the
+        observation that decided to cancel the attempt is the one worth naming in
+        the failure.
+
+        Args:
+            stalled_for_seconds: The gap the watchdog observed.
+            last_progress_label: The last progress label it saw, ``""`` if none.
+        """
+        with self._lock:
+            if self._stall is None:
+                self._stall = StallObservation(
+                    stalled_for_seconds=stalled_for_seconds,
+                    last_progress_label=last_progress_label,
+                )
+
     def _notify_hold_closed(self, closed: ClosedHold) -> None:
         observer = self._on_hold_closed
         if observer is None:
@@ -433,6 +505,22 @@ class _InertProgressTracker(ProgressTracker):
     def stalled_for(self) -> float:
         """Always ``0.0`` — nothing is watching, so nothing is stalled."""
         return 0.0
+
+    @property
+    def stall(self) -> StallObservation | None:
+        """Always ``None`` — no watchdog observes this context."""
+        return None
+
+    def flag_stalled(
+        self, stalled_for_seconds: float, last_progress_label: str
+    ) -> None:
+        """Record nothing.
+
+        Overridden for the same reason the other mutators are: this instance is a
+        process-wide singleton, so a verdict recorded on it would outlive its
+        caller and make every later cancellation anywhere in the process read as
+        a stall kill.
+        """
 
 
 _INERT_TRACKER = _InertProgressTracker()

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -1,8 +1,8 @@
 <!--
 generated-by:  capability-manifest skill (.claude/skills/capability-manifest)
 sdk-version:   3.27.2
-source-sha:    9ecd435db35594f3554a9df3be34c153ff594636
-source-date:   2026-08-12T17:02:59+01:00
+source-sha:    aaaed3a54415a5dba8626bd74796c586cfa1c168
+source-date:   2026-08-13T03:04:30+01:00
 do-not-edit:   re-run the skill instead of hand-editing
 -->
 
@@ -23,7 +23,7 @@ do-not-edit:   re-run the skill instead of hand-editing
 | `application_sdk.common` | Shared utilities — SQL filters, concurrency helpers, TaskStatistics, DataframeType | 11 |
 | `application_sdk.contracts` | Typed Pydantic Input/Output base classes, payload safety, storage and type helpers | 28 |
 | `application_sdk.credentials` | Credential resolvers (Atlan, OAuth, Git, agent), registry, vault spec | 41 |
-| `application_sdk.errors` | Structured error codes — ErrorCode dataclass and cross-component constants (APP_ERROR, HANDLER_ERROR, CONTRACT_VALIDATION, etc.) | 58 |
+| `application_sdk.errors` | Structured error codes — ErrorCode dataclass and cross-component constants (APP_ERROR, HANDLER_ERROR, CONTRACT_VALIDATION, etc.) | 59 |
 | `application_sdk.execution` | Task/workflow execution — retry, heartbeat, sandbox, AppWorker, Temporal client | 20 |
 | `application_sdk.handler` | HTTP handler framework — Handler ABC, DefaultHandler, preflight, auth, service factory | 22 |
 | `application_sdk.infrastructure` | Protocol-based infrastructure (StateStore, SecretStore, PubSub, Bindings, CapacityPool) | 37 |
@@ -1043,6 +1043,13 @@ Structured error codes — ErrorCode dataclass and cross-component constants (AP
 - **Import:** `from application_sdk.errors import SourceUnavailableError`
 - **Signature:** `class SourceUnavailableError(*, ...)`
 - **Summary:** Customer-controlled source system is temporarily unreachable.
+- **Defined in:** `application_sdk/errors/leaves.py`
+
+#### `TaskStalledError`
+
+- **Import:** `from application_sdk.errors import TaskStalledError`
+- **Signature:** `class TaskStalledError(*, ...)`
+- **Summary:** An activity attempt was failed for making no observable progress (ADR-0018).
 - **Defined in:** `application_sdk/errors/leaves.py`
 
 #### `UnimplementedError`

--- a/docs/concepts/common.md
+++ b/docs/concepts/common.md
@@ -57,6 +57,7 @@ AppError  (base — application_sdk.errors)
 │   ├── SourceUnavailableError   SOURCE_UNAVAILABLE        retryable=True   audience=USER
 │   ├── ResourceExhaustedError RESOURCE_EXHAUSTED         retryable=True   audience=PLATFORM
 │   ├── AppTimeoutError        TIMEOUT                    retryable=True   audience=APP_OWNER
+│   │   └── TaskStalledError   TIMEOUT (TIMEOUT_TASK_STALLED)  retryable=True   audience=APP_OWNER
 │   ├── CancelledError         CANCELLED                  retryable=False  audience=APP_OWNER
 │   ├── DataIntegrityError     DATA_INTEGRITY             retryable=False  audience=APP_OWNER
 │   ├── InternalError          INTERNAL                   retryable=False  audience=APP_OWNER
@@ -99,6 +100,18 @@ config fetches tomorrow) just by catching this one marker, with no new per-domai
 `SecretStoreUnavailableError` above is the first concrete example: it multiply-inherits
 `SecretStoreError` (so `except SecretStoreError:` still catches it) and `ColdStartRaceError`
 (so the retry helper does too).
+
+### TaskStalledError — raised by the SDK, never by an app
+
+`TaskStalledError(AppTimeoutError)` is the failure the stall watchdog produces when an activity
+attempt keeps heartbeating but nothing observable advances for longer than the task's
+no-progress budget (ADR-0018). It carries `stalled_for_seconds` and `last_progress_label`, so
+the failure names *where* the attempt went quiet rather than only that it did, and it is
+**retryable**: the dominant cause is a transient source-side hang that self-heals on a fresh
+attempt. A subtype rather than a sixteenth leaf, so `except AppTimeoutError:` still catches it
+while the distinct `TIMEOUT_TASK_STALLED` code and the `TaskStalledError` Temporal wire type keep stall
+kills countable apart from `StartToClose` and heartbeat timeouts. App code should not raise it —
+raise the leaf that describes what the source actually did.
 
 ### Raise by failure shape
 

--- a/tests/unit/errors/test_categorical.py
+++ b/tests/unit/errors/test_categorical.py
@@ -18,6 +18,7 @@ from application_sdk.errors.leaves import (
     RateLimitedError,
     ResourceExhaustedError,
     SourceUnavailableError,
+    TaskStalledError,
     UnimplementedError,
 )
 
@@ -213,6 +214,92 @@ def test_leaf_audience_in_failure_details(
 ) -> None:
     fd = cls(message="test").to_failure_details()
     assert fd.audience is expected_audience
+
+
+class TestTaskStalledError:
+    """The stall subtype of the TIMEOUT leaf (ADR-0018).
+
+    Not in ``_LEAVES``: that table is one entry per ``FailureCategory``, and a
+    stall shares TIMEOUT with :class:`AppTimeoutError` by design rather than
+    claiming a sixteenth category.
+    """
+
+    def test_is_an_app_timeout_error(self) -> None:
+        # `except AppTimeoutError:` in an app must keep catching a stall kill —
+        # that is the whole reason this is a subtype and not a new leaf.
+        assert issubclass(TaskStalledError, AppTimeoutError)
+        assert isinstance(TaskStalledError(message="stalled"), AppTimeoutError)
+
+    def test_metadata(self) -> None:
+        assert TaskStalledError.category is FailureCategory.TIMEOUT
+        assert TaskStalledError.code == "TIMEOUT_TASK_STALLED"
+        assert TaskStalledError.audience is Audience.APP_OWNER
+        assert (
+            TaskStalledError(message="stalled").qualified_code
+            == "TIMEOUT.TIMEOUT_TASK_STALLED"
+        )
+
+    def test_is_retryable_by_default(self) -> None:
+        """The deliberate half of the ADR-0018 argument, pinned.
+
+        The dominant cause of a stall is a transient source-side hang that
+        self-heals; flipping this to non-retryable would convert that majority
+        into failed runs needing a manual re-run from zero.
+        """
+        assert TaskStalledError.default_retryable is True
+        assert TaskStalledError(message="stalled").effective_retryable is True
+
+    def test_distinguishable_from_a_plain_timeout_on_the_wire(self) -> None:
+        """Same category, different code — so a stall kill is countable on its own.
+
+        Rolling a stall into ``TIMEOUT.TIMEOUT`` would make the M2 warn data
+        unreadable: the fleet-wide numbers could not separate stall kills from
+        StartToClose and heartbeat timeouts.
+        """
+        stalled = TaskStalledError(message="stalled").to_failure_details()
+        plain = AppTimeoutError(message="timed out").to_failure_details()
+
+        assert stalled.category is plain.category
+        assert stalled.code != plain.code
+
+    def test_evidence_carries_the_gap_and_the_label(self) -> None:
+        fd = TaskStalledError(
+            message="stalled",
+            operation="fetch_tables",
+            stalled_for_seconds=915.0,
+            last_progress_label="writer.flush_buffer",
+        ).to_failure_details()
+
+        assert fd.evidence["stalled_for_seconds"] == 915.0
+        assert fd.evidence["last_progress_label"] == "writer.flush_buffer"
+        assert fd.evidence["operation"] == "fetch_tables"
+        assert fd.retryable is True
+        assert fd.audience is Audience.APP_OWNER
+
+    def test_the_inherited_bounded_wait_fields_stay_unset(self) -> None:
+        """A stall has no bounded wait that elapsed — that absence is the point.
+
+        Populating ``timeout_seconds`` / ``elapsed_seconds`` with the stall gap
+        would claim a limit was configured and hit, when what happened is that
+        nothing bounded the quiet at all.
+        """
+        fd = TaskStalledError(
+            message="stalled", stalled_for_seconds=915.0
+        ).to_failure_details()
+
+        assert fd.evidence["timeout_seconds"] is None
+        assert fd.evidence["elapsed_seconds"] is None
+
+    def test_context_fields_survive_to_the_envelope(self) -> None:
+        fd = TaskStalledError(
+            message="stalled",
+            app_name="_app",
+            run_id="run-1",
+            suggested_action="declare an allowance",
+        ).to_failure_details()
+
+        assert (fd.app_name, fd.run_id) == ("_app", "run-1")
+        assert fd.suggested_action == "declare an allowance"
 
 
 def test_internal_error_classification_pending_default() -> None:

--- a/tests/unit/execution/test_activities.py
+++ b/tests/unit/execution/test_activities.py
@@ -638,7 +638,9 @@ class TestActivityFnExecution:
         )
 
         # Patch auto_heartbeat_loop so it returns immediately when stop_event set.
-        async def fake_loop(*, interval_seconds, heartbeat_fn, stop_event, task_name):
+        async def fake_loop(
+            *, interval_seconds, heartbeat_fn, stop_event, task_name, **_watchdog
+        ):
             await stop_event.wait()
 
         with (

--- a/tests/unit/execution/test_progress.py
+++ b/tests/unit/execution/test_progress.py
@@ -415,6 +415,94 @@ class TestClosedHoldObservations:
 
 
 # ---------------------------------------------------------------------------
+# The stall verdict (what tells the cancellation handler whose cancel it is)
+# ---------------------------------------------------------------------------
+
+
+class TestStallVerdict:
+    def test_no_verdict_until_the_watchdog_records_one(self) -> None:
+        clock = FakeClock()
+        tracker = _tracker(clock)
+
+        clock.advance(9000.0)
+
+        # Quiet for hours is not a verdict: only the watchdog decides, and only
+        # in enforce mode. A tracker that answered "stalled" on elapsed time
+        # alone would make warn mode fail activities.
+        assert tracker.stalled_for() == 9000.0
+        assert tracker.stall is None
+
+    def test_verdict_carries_the_observed_gap_and_label(self) -> None:
+        clock = FakeClock()
+        tracker = _tracker(clock)
+
+        tracker.flag_stalled(
+            stalled_for_seconds=915.0, last_progress_label="writer.flush_buffer"
+        )
+
+        stall = tracker.stall
+        assert stall is not None
+        assert stall.stalled_for_seconds == 915.0
+        assert stall.last_progress_label == "writer.flush_buffer"
+
+    def test_verdict_is_frozen_against_later_progress(self) -> None:
+        """The numbers must not move between the verdict and the raise site.
+
+        The cancellation travels to the attempt's next ``await``, and anything
+        still in flight can mark progress on the way — which would re-arm
+        ``stalled_for()`` and relabel ``last_label``, leaving the failure to
+        report a gap of nothing after a signal that arrived post-mortem.
+        """
+        clock = FakeClock()
+        tracker = _tracker(clock)
+        clock.advance(900.0)
+        tracker.flag_stalled(stalled_for_seconds=900.0, last_progress_label="extract")
+
+        clock.advance(5.0)
+        tracker.mark_progress("storage.upload_part")
+
+        stall = tracker.stall
+        assert stall is not None
+        assert stall.stalled_for_seconds == 900.0
+        assert stall.last_progress_label == "extract"
+        assert tracker.last_label == "storage.upload_part"
+
+    def test_flagging_is_not_progress(self) -> None:
+        clock = FakeClock()
+        tracker = _tracker(clock)
+        clock.advance(600.0)
+
+        tracker.flag_stalled(stalled_for_seconds=600.0, last_progress_label="")
+
+        # Recording the verdict must not touch the clock it is a verdict about.
+        assert tracker.stalled_for() == 600.0
+
+    def test_first_verdict_wins(self) -> None:
+        clock = FakeClock()
+        tracker = _tracker(clock)
+
+        tracker.flag_stalled(stalled_for_seconds=900.0, last_progress_label="extract")
+        tracker.flag_stalled(stalled_for_seconds=1800.0, last_progress_label="later")
+
+        stall = tracker.stall
+        assert stall is not None
+        assert (stall.stalled_for_seconds, stall.last_progress_label) == (
+            900.0,
+            "extract",
+        )
+
+    def test_an_unlabelled_attempt_records_an_empty_label(self) -> None:
+        clock = FakeClock()
+        tracker = _tracker(clock)
+
+        tracker.flag_stalled(stalled_for_seconds=60.0, last_progress_label="")
+
+        stall = tracker.stall
+        assert stall is not None
+        assert stall.last_progress_label == ""
+
+
+# ---------------------------------------------------------------------------
 # Clock injection
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/execution/test_progress_context.py
+++ b/tests/unit/execution/test_progress_context.py
@@ -168,6 +168,19 @@ class TestNoTrackerBound:
 
         assert warning.call_count == 0
 
+    def test_a_stall_verdict_cannot_stick_to_the_inert_singleton(self) -> None:
+        """The one no-op whose absence would leak across every later attempt.
+
+        The inert tracker is process-wide, so a verdict recorded on it would
+        outlive its caller and make every subsequent cancellation anywhere in the
+        process — a real worker eviction included — read as a stall kill.
+        """
+        current_progress_tracker().flag_stalled(
+            stalled_for_seconds=900.0, last_progress_label="writer.flush_buffer"
+        )
+
+        assert current_progress_tracker().stall is None
+
 
 class TestBinding:
     def test_the_block_yields_and_binds_the_same_tracker(self) -> None:
@@ -322,6 +335,7 @@ class TestActivityBinding:
             heartbeat_fn: Callable[[], None],
             stop_event: asyncio.Event,
             task_name: str,
+            **_watchdog: object,
         ) -> None:
             await stop_event.wait()
 
@@ -445,6 +459,7 @@ class TestActivityBinding:
             heartbeat_fn: Callable[[], None],
             stop_event: asyncio.Event,
             task_name: str,
+            **_watchdog: object,
         ) -> None:
             await stop_event.wait()
             raise asyncio.CancelledError

--- a/tests/unit/execution/test_stall_failure.py
+++ b/tests/unit/execution/test_stall_failure.py
@@ -1,0 +1,502 @@
+"""How a stall becomes a typed, diagnosable failure (FND-289, ADR-0018).
+
+Three things are proven here, because each is a way this path could look wired
+and still be wrong in production:
+
+1. **The attribution.** A stall kill and a worker eviction arrive at the same
+   ``except asyncio.CancelledError`` handler as the same exception type. Only the
+   tracker's verdict separates them, and the failure a human reads afterwards
+   has to name the gap and the last progress signal — a bare ``CancelledError``
+   names neither.
+2. **The order of the two checks.** A stall and a SIGTERM can coincide. If
+   eviction won that race the attempt would be re-dispatched by the
+   workflow-side eviction-retry loop *outside* the normal retry budget, so the
+   matrix of (stall, shutting down) is pinned in all four corners.
+3. **What is wired, and what deliberately is not.** The handler is injected now;
+   the mode and the budget that make the watchdog act are FND-296's, so on this
+   branch the watchdog is inert and the behaviour change is zero. A test asserts
+   that absence rather than trusting it.
+
+The end-to-end test drives the *real* watchdog inside the *real* activity body,
+with only the enforce config injected — no patched clock (an asyncio loop shares
+``time.monotonic``), just a 10 ms tick against a 50 ms budget.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from typing import Any, cast
+from unittest import mock
+
+import pytest
+
+from application_sdk.app.base import App
+from application_sdk.app.registry import AppRegistry, TaskRegistry
+from application_sdk.app.task import task
+from application_sdk.contracts.base import Input, Output
+from application_sdk.errors.leaves import WORKER_EVICTED_TYPE, TaskStalledError
+from application_sdk.errors.wire import FailureDetails
+from application_sdk.execution import shutdown as shutdown_module
+from application_sdk.execution._temporal import activities as activities_module
+from application_sdk.execution._temporal.activities import (
+    TaskContext,
+    create_activity_from_task,
+)
+from application_sdk.execution.errors import ApplicationError
+from application_sdk.execution.heartbeat import (
+    auto_heartbeat_loop as _real_auto_heartbeat_loop,
+)
+from application_sdk.execution.progress import (
+    ProgressTracker,
+    ProgressWatchdogMode,
+    current_progress_tracker,
+)
+
+_HEARTBEAT_LOOP = "application_sdk.execution.heartbeat.auto_heartbeat_loop"
+
+
+class _StallIn(Input, allow_unbounded_fields=True):
+    name: str = "x"
+
+
+class _StallOut(Output, allow_unbounded_fields=True):
+    msg: str = ""
+
+
+ActivityFn = Callable[[TaskContext, _StallIn], Awaitable[_StallOut]]
+
+
+def _activity_for(app_name: str, task_name: str) -> ActivityFn:
+    tasks = TaskRegistry.get_instance().get_tasks_for_app(app_name)
+    return cast(
+        "ActivityFn",
+        create_activity_from_task(next(t for t in tasks if t.name == task_name)),
+    )
+
+
+def _task_context(
+    app_name: str, task_name: str, *, heartbeating: bool = True
+) -> TaskContext:
+    return TaskContext(
+        app_name=app_name,
+        task_name=task_name,
+        run_id="run-1",
+        heartbeat_timeout_seconds=60 if heartbeating else None,
+        auto_heartbeat_seconds=10 if heartbeating else None,
+    )
+
+
+def _enforcing_watchdog(
+    *, budget_seconds: float = 0.05, tick_seconds: float = 0.01
+) -> Callable[..., Awaitable[None]]:
+    """The real auto-heartbeat loop, with the config FND-296 will supply.
+
+    Everything under test stays real — the tick, the gap arithmetic, the
+    ``on_stall`` call, the loop returning immediately after enforcing. Only
+    ``watchdog_mode`` and ``max_no_progress_seconds`` are injected, since
+    ``activities.py`` has nothing to read them from yet.
+    """
+
+    async def loop(**kwargs: Any) -> None:
+        kwargs["interval_seconds"] = tick_seconds
+        await _real_auto_heartbeat_loop(
+            **kwargs,
+            max_no_progress_seconds=budget_seconds,
+            watchdog_mode=ProgressWatchdogMode.ENFORCE,
+        )
+
+    return loop
+
+
+def _watchdog_reporting(
+    stalled_for: float, last_label: str
+) -> Callable[..., Awaitable[None]]:
+    """A watchdog stand-in that reports one stall, then returns as the real one does.
+
+    Used where the *values* in the failure matter: the real loop can only produce
+    whatever gap wall-clock happens to give it, and a failure message is worth
+    asserting exactly.
+    """
+
+    async def loop(*, on_stall: Callable[[float, str], None], **_kwargs: Any) -> None:
+        on_stall(stalled_for, last_label)
+
+    return loop
+
+
+async def _idle_watchdog(*, stop_event: asyncio.Event, **_kwargs: Any) -> None:
+    """A watchdog stand-in that observes nothing — no stall, ever."""
+    await stop_event.wait()
+
+
+def _quiet_activity() -> ActivityFn:
+    """An attempt that goes quiet: no progress signal, and it never returns.
+
+    Defined per call rather than at module scope because registration happens at
+    class-definition time and the registries are reset between tests.
+    """
+
+    class _QuietApp(App):
+        @task(timeout_seconds=600)
+        async def quiet(self, input: _StallIn) -> _StallOut:
+            await asyncio.sleep(3600)
+            return _StallOut(msg="never")
+
+        async def run(self, input: _StallIn) -> _StallOut:
+            return await self.quiet(input)
+
+    return _activity_for("_quiet-app", "quiet")
+
+
+def _self_cancelling_activity() -> ActivityFn:
+    """An attempt cancelled by something that is neither the watchdog nor a SIGTERM."""
+
+    class _SelfCancellingApp(App):
+        @task(timeout_seconds=600)
+        async def boom(self, input: _StallIn) -> _StallOut:
+            raise asyncio.CancelledError
+
+        async def run(self, input: _StallIn) -> _StallOut:
+            return await self.boom(input)
+
+    return _activity_for("_self-cancelling-app", "boom")
+
+
+@pytest.fixture(autouse=True)
+def _clean_worker_state() -> Any:
+    AppRegistry.reset()
+    TaskRegistry.reset()
+    shutdown_module.reset_worker_shutting_down()
+    yield
+    AppRegistry.reset()
+    TaskRegistry.reset()
+    shutdown_module.reset_worker_shutting_down()
+
+
+@pytest.fixture(autouse=True)
+def _no_infrastructure() -> Any:
+    with (
+        mock.patch.object(
+            activities_module.activity,
+            "info",
+            return_value=mock.MagicMock(workflow_id="wf-stall"),
+        ),
+        mock.patch(
+            "application_sdk.infrastructure.context.get_infrastructure",
+            return_value=None,
+        ),
+    ):
+        yield
+
+
+def _details_of(error: ApplicationError) -> FailureDetails:
+    assert error.details, "the failure carried no structured details"
+    details = error.details[0]
+    assert isinstance(details, FailureDetails)
+    return details
+
+
+class TestStallKill:
+    async def test_a_stalled_attempt_fails_with_task_stalled_error(self) -> None:
+        """End to end: real watchdog, real activity body, real cancellation handler."""
+        activity_fn = _quiet_activity()
+
+        with (
+            mock.patch(_HEARTBEAT_LOOP, new=_enforcing_watchdog()),
+            pytest.raises(ApplicationError) as exc_info,
+        ):
+            await activity_fn(_task_context("_quiet-app", "quiet"), _StallIn())
+
+        error = exc_info.value
+        # The wire type is what Temporal serialises and what a retry policy or a
+        # timeout-subtype classifier can key on — the Python class does not cross
+        # the activity boundary.
+        assert error.type == "TaskStalledError"
+        details = _details_of(error)
+        assert details.code == "TIMEOUT_TASK_STALLED"
+        assert details.evidence["stalled_for_seconds"] >= 0.05
+        assert details.evidence["operation"] == "quiet"
+        assert details.app_name == "_quiet-app"
+        assert details.run_id == "run-1"
+
+    async def test_a_stall_kill_is_retryable_at_the_temporal_layer(self) -> None:
+        """The deliberate half of the ADR-0018 argument, at the boundary that acts on it.
+
+        ``non_retryable=True`` here would convert the self-healing majority — a
+        transient source hang the app never surfaced — into failed runs needing a
+        manual re-run that restarts from zero anyway.
+        """
+        activity_fn = _quiet_activity()
+
+        with (
+            mock.patch(_HEARTBEAT_LOOP, new=_enforcing_watchdog()),
+            pytest.raises(ApplicationError) as exc_info,
+        ):
+            await activity_fn(_task_context("_quiet-app", "quiet"), _StallIn())
+
+        assert exc_info.value.non_retryable is False
+        assert _details_of(exc_info.value).retryable is True
+
+    async def test_the_failure_names_the_gap_and_the_last_signal(self) -> None:
+        activity_fn = _quiet_activity()
+
+        with (
+            mock.patch(
+                _HEARTBEAT_LOOP,
+                new=_watchdog_reporting(915.0, "writer.flush_buffer"),
+            ),
+            pytest.raises(ApplicationError) as exc_info,
+        ):
+            await activity_fn(_task_context("_quiet-app", "quiet"), _StallIn())
+
+        assert exc_info.value.message == (
+            "Task 'quiet' made no observable progress for 915s; "
+            "last signal was 'writer.flush_buffer'"
+        )
+        evidence = _details_of(exc_info.value).evidence
+        assert evidence["stalled_for_seconds"] == 915.0
+        assert evidence["last_progress_label"] == "writer.flush_buffer"
+
+    async def test_an_attempt_that_never_reported_progress_says_so(self) -> None:
+        """ "Nothing was ever observed" is a different finding from "it went quiet after X".
+
+        It is the shape that means the task has no instrumentation on its path at
+        all, which is the work-list entry an app owner acts on — so the failure
+        must not disguise it as an unnamed signal.
+        """
+        activity_fn = _quiet_activity()
+
+        with (
+            mock.patch(_HEARTBEAT_LOOP, new=_watchdog_reporting(60.0, "")),
+            pytest.raises(ApplicationError) as exc_info,
+        ):
+            await activity_fn(_task_context("_quiet-app", "quiet"), _StallIn())
+
+        assert "last signal was '<none>'" in exc_info.value.message
+        assert _details_of(exc_info.value).evidence["last_progress_label"] is None
+
+    async def test_the_handler_cancels_the_attempt_not_the_watchdog(self) -> None:
+        """The handler runs inside the heartbeat task, so it cannot ask for "this" task.
+
+        Reading ``asyncio.current_task()`` from inside ``on_stall`` would cancel
+        the watchdog and leave the wedged attempt running — which fails as a
+        never-returning activity rather than as a stall, i.e. exactly the failure
+        mode this issue exists to end. If the wrong task were cancelled the
+        stand-in below would die before it recorded that it had finished.
+        """
+        activity_fn = _quiet_activity()
+        watchdog_finished: list[bool] = []
+
+        async def loop(
+            *, on_stall: Callable[[float, str], None], **_kwargs: Any
+        ) -> None:
+            on_stall(900.0, "extract.page")
+            # The real loop returns straight after enforcing; reaching this line
+            # proves the cancellation did not land here.
+            watchdog_finished.append(True)
+
+        with (
+            mock.patch(_HEARTBEAT_LOOP, new=loop),
+            pytest.raises(ApplicationError) as exc_info,
+        ):
+            await activity_fn(_task_context("_quiet-app", "quiet"), _StallIn())
+
+        assert exc_info.value.type == "TaskStalledError"
+        assert watchdog_finished == [True]
+
+    async def test_the_attempt_tracker_is_unbound_after_a_stall_kill(self) -> None:
+        """The ``finally`` still runs on the path that swaps the exception type."""
+        activity_fn = _quiet_activity()
+        before = current_progress_tracker()
+
+        with (
+            mock.patch(_HEARTBEAT_LOOP, new=_watchdog_reporting(900.0, "extract.page")),
+            pytest.raises(ApplicationError),
+        ):
+            await activity_fn(_task_context("_quiet-app", "quiet"), _StallIn())
+
+        assert current_progress_tracker() is before
+
+    async def test_an_unbuildable_envelope_still_fails_as_a_stall(self) -> None:
+        """The shared translation's guard covers this branch too.
+
+        A secondary failure while building the details must cost the structured
+        evidence, not replace the stall with a serialisation error — the same
+        contract the ordinary ``AppError`` branch has, which is the point of both
+        branches calling one helper.
+        """
+        activity_fn = _quiet_activity()
+
+        with (
+            mock.patch(_HEARTBEAT_LOOP, new=_watchdog_reporting(900.0, "extract.page")),
+            mock.patch.object(
+                TaskStalledError,
+                "to_failure_details",
+                side_effect=RuntimeError("evidence not serialisable"),
+            ),
+            mock.patch.object(activities_module.logger, "warning") as warning,
+            pytest.raises(ApplicationError) as exc_info,
+        ):
+            await activity_fn(_task_context("_quiet-app", "quiet"), _StallIn())
+
+        assert exc_info.value.type == "TaskStalledError"
+        assert exc_info.value.details == ()
+        assert warning.call_count == 1
+
+
+class TestFlagCheckOrder:
+    """The (stall, shutting down) matrix, in all four corners."""
+
+    async def test_a_stall_during_shutdown_is_attributed_to_the_stall(self) -> None:
+        """Stall wins, so the attempt is not re-dispatched outside its retry budget.
+
+        ``WorkerEvicted`` is non-retryable at the Temporal layer *and* re-run by
+        the workflow-side eviction loop, which does not count against the task's
+        retry budget. A wedged attempt attributed there would be re-dispatched
+        past the point where retries were supposed to stop.
+        """
+        activity_fn = _quiet_activity()
+        shutdown_module.mark_worker_shutting_down()
+
+        with (
+            mock.patch(_HEARTBEAT_LOOP, new=_watchdog_reporting(900.0, "extract.page")),
+            pytest.raises(ApplicationError) as exc_info,
+        ):
+            await activity_fn(_task_context("_quiet-app", "quiet"), _StallIn())
+
+        assert exc_info.value.type == "TaskStalledError"
+        assert exc_info.value.non_retryable is False
+
+    async def test_shutdown_without_a_stall_is_still_worker_evicted(self) -> None:
+        """The new branch must not annex the eviction path it sits in front of."""
+        activity_fn = _self_cancelling_activity()
+        shutdown_module.mark_worker_shutting_down()
+
+        with (
+            mock.patch(_HEARTBEAT_LOOP, new=_idle_watchdog),
+            pytest.raises(ApplicationError) as exc_info,
+        ):
+            await activity_fn(_task_context("_self-cancelling-app", "boom"), _StallIn())
+
+        assert exc_info.value.type == WORKER_EVICTED_TYPE
+        assert exc_info.value.non_retryable is True
+
+    async def test_an_unattributed_cancel_still_propagates(self) -> None:
+        activity_fn = _self_cancelling_activity()
+
+        with (
+            mock.patch(_HEARTBEAT_LOOP, new=_idle_watchdog),
+            pytest.raises(asyncio.CancelledError),
+        ):
+            await activity_fn(_task_context("_self-cancelling-app", "boom"), _StallIn())
+
+    async def test_a_healthy_attempt_is_untouched(self) -> None:
+        class _FineApp(App):
+            @task(timeout_seconds=600)
+            async def fine(self, input: _StallIn) -> _StallOut:
+                current_progress_tracker().mark_progress("extract.page")
+                return _StallOut(msg="ok")
+
+            async def run(self, input: _StallIn) -> _StallOut:
+                return await self.fine(input)
+
+        _FineApp()
+        activity_fn = _activity_for("_fine-app", "fine")
+
+        with mock.patch(_HEARTBEAT_LOOP, new=_enforcing_watchdog()):
+            result = await activity_fn(_task_context("_fine-app", "fine"), _StallIn())
+
+        assert result.msg == "ok"
+
+
+class TestWatchdogWiring:
+    async def test_the_watchdog_is_handed_the_attempts_tracker_and_a_handler(
+        self,
+    ) -> None:
+        seen: dict[str, Any] = {}
+        from_body: list[ProgressTracker] = []
+
+        class _WiredApp(App):
+            @task(timeout_seconds=600)
+            async def wired(self, input: _StallIn) -> _StallOut:
+                from_body.append(current_progress_tracker())
+                return _StallOut(msg="ok")
+
+            async def run(self, input: _StallIn) -> _StallOut:
+                return await self.wired(input)
+
+        async def loop(*, stop_event: asyncio.Event, **kwargs: Any) -> None:
+            seen.update(kwargs)
+            await stop_event.wait()
+
+        _WiredApp()
+        activity_fn = _activity_for("_wired-app", "wired")
+
+        with mock.patch(_HEARTBEAT_LOOP, new=loop):
+            await activity_fn(_task_context("_wired-app", "wired"), _StallIn())
+
+        # The same object the framework hooks report into — a watchdog watching a
+        # second tracker would observe silence while work advanced.
+        assert seen["progress"] is from_body[0]
+        assert callable(seen["on_stall"])
+
+    async def test_the_watchdog_config_is_left_to_the_flag(self) -> None:
+        """No mode and no budget, so the watchdog is inert on this branch.
+
+        This is what makes the claim "zero behaviour change" checkable rather
+        than argued: the handler is injected, and turning the watchdog on is a
+        config change (FND-296), not another seam.
+        """
+        seen: dict[str, Any] = {}
+
+        class _InertApp(App):
+            @task(timeout_seconds=600)
+            async def inert(self, input: _StallIn) -> _StallOut:
+                return _StallOut(msg="ok")
+
+            async def run(self, input: _StallIn) -> _StallOut:
+                return await self.inert(input)
+
+        async def loop(*, stop_event: asyncio.Event, **kwargs: Any) -> None:
+            seen.update(kwargs)
+            await stop_event.wait()
+
+        _InertApp()
+        activity_fn = _activity_for("_inert-app", "inert")
+
+        with mock.patch(_HEARTBEAT_LOOP, new=loop):
+            await activity_fn(_task_context("_inert-app", "inert"), _StallIn())
+
+        assert "watchdog_mode" not in seen
+        assert "max_no_progress_seconds" not in seen
+
+    async def test_no_heartbeat_loop_means_no_watchdog(self) -> None:
+        """A task with heartbeating disabled runs no loop, so nothing can stall it.
+
+        Recorded rather than asserted as desirable: the tracker is bound for such
+        a task, but the watchdog lives in the auto-heartbeat loop, so today the
+        duration backstop is that task's only bound.
+        """
+        loop_calls: list[dict[str, Any]] = []
+
+        class _NoBeatApp(App):
+            @task(timeout_seconds=600)
+            async def nobeat(self, input: _StallIn) -> _StallOut:
+                return _StallOut(msg="ok")
+
+            async def run(self, input: _StallIn) -> _StallOut:
+                return await self.nobeat(input)
+
+        async def loop(**kwargs: Any) -> None:
+            loop_calls.append(kwargs)
+
+        activity_fn = _activity_for("_no-beat-app", "nobeat")
+
+        with mock.patch(_HEARTBEAT_LOOP, new=loop):
+            result = await activity_fn(
+                _task_context("_no-beat-app", "nobeat", heartbeating=False), _StallIn()
+            )
+
+        assert result.msg == "ok"
+        assert loop_calls == []


### PR DESCRIPTION
> **No longer stacked.** Everything below this one has merged (#3145, #3147, #3148, #3150, #3158, plus FND-291's `holding_progress`), so this is rebased onto `main` and the full check matrix runs for real. Rebasing adapted two things to what landed: the tracker is bound through main's `bind_progress_tracker()` block rather than a `set`/`reset` pair, and the `on_stall` closure reads that block's `as tracker`.

Implements [FND-289](https://linear.app/atlan-epd/issue/FND-289/taskstallederror-and-the-stall-branch-in-the-cancellation-handler) — the failure end of [ADR-0018](https://github.com/atlanhq/application-sdk/blob/main/docs/adr/0018-progress-aware-heartbeat.md) → *Failing the activity, and what the failure looks like*.

#3147 built the detector, #3148 made the tracker reachable, #3150 fed it, #3158 vouched for blocking work. None of them can *fail* anything: `on_stall` is an injected handler with nobody injecting it. This PR is that handler, plus the typed failure it produces.

The problem it solves is that a stall kill and a worker eviction arrive at the same `except asyncio.CancelledError` handler as the same exception type. Without something to tell them apart, a stalled attempt either dies as a bare `CancelledError` — naming neither the gap nor where the attempt went quiet — or gets attributed to eviction and **re-dispatched by the workflow-side eviction-retry loop outside its retry budget**, which is the amplification ADR-0018 exists to remove.

## What this adds

**`ProgressTracker.flag_stalled()` → `StallObservation`** (`execution/progress.py`). The watchdog's verdict, frozen at the tick that decided to act: the gap it observed and the last label it saw. Not progress, and not a mutation of the stall clock.

**`TaskStalledError`** (`errors/leaves.py`), carrying `stalled_for_seconds` and `last_progress_label` as **dataclass fields** — so they reach `FailureDetails.evidence` and redaction stays at the wire layer rather than being achieved by withholding context from the failure.

**The handler and the branch** (`_temporal/activities.py`). `on_stall` flags the tracker and cancels the attempt's task; the cancellation lands at the attempt's next `await` and hits a new branch **ahead of** the `is_worker_shutting_down()` check, which raises the typed error through the shared translation helper.

## Decisions a reviewer should look at

**1. The verdict lives on the tracker, not in a closure local.** A `nonlocal` in `activity_fn` would work — same per-attempt isolation, smaller API. The tracker wins because it already owns both quantities the failure needs (`stalled_for()`, `last_label`) and is the object every other piece of this design reads; a second per-attempt state holder next to it is the thing that goes stale. The cost is one override on `_InertProgressTracker`, which matters more than it looks: that instance is a **process-wide singleton**, so a verdict stuck to it would outlive its caller and make every later cancellation anywhere in the process — a real worker eviction included — read as a stall kill. Tested (`test_a_stall_verdict_cannot_stick_to_the_inert_singleton`).

**2. The observation is frozen at detection, not re-derived at the raise site.** By the time the cancellation reaches the attempt's next `await`, `stalled_for()` has grown, and any signal still in flight re-arms it entirely and relabels `last_label` — so a re-derived failure could report a small gap after a signal that arrived post-mortem. `test_verdict_is_frozen_against_later_progress` pins it.

**3. `TaskStalledError` subclasses `AppTimeoutError` rather than being a sixteenth categorical leaf.** A stall *is* a TIMEOUT-category failure, so `except AppTimeoutError:` catch sites and TIMEOUT-keyed consumers keep working, and `leaves.py` keeps its one-leaf-per-`FailureCategory` shape — the same relationship `ColdStartRaceError` has to `DependencyUnavailableError`. The distinct code and the Temporal wire type `"TaskStalledError"` are what keep stall kills countable apart from `StartToClose` and heartbeat timeouts, which is the whole point of CNCT-10's classification work.

The code is `TIMEOUT_TASK_STALLED`, not `TASK_STALLED` — conformance rule **P003** requires a leaf subclass's code to carry its parent's category prefix, and caught it on the first run.

**4. The two inherited bounded-wait fields stay unset.** `AppTimeoutError` brings `timeout_seconds` and `elapsed_seconds`; a stall has no bounded wait that elapsed, and that absence *is* the finding. `stalled_for_seconds` is a genuinely different quantity: the quiet gap inside an attempt that may have been productively running for hours before it went silent. Filling `elapsed_seconds` with the gap would claim a limit was configured and hit.

**5. `TaskStalledError` is retryable, deliberately.** The dominant cause is a transient source-side hang in an app whose error handling never surfaced it, which self-heals on a fresh attempt; a genuine wedge re-stalls and costs at most a few multiples of `max_no_progress_seconds`, not of the 24h backstop. Non-retryable would convert the self-healing majority into failed runs needing a manual re-run that restarts from zero anyway. Pinned on the class rather than inherited, so a future change to `AppTimeoutError`'s default cannot silently flip it.

**6. Flag-check order is load-bearing, and all four corners are tested.** A stall and a SIGTERM can coincide:

| stalled | shutting down | outcome |
| --- | --- | --- |
| ✓ | ✓ | `TaskStalledError` — spends the task's own retry budget |
| ✓ | ✗ | `TaskStalledError` |
| ✗ | ✓ | `WorkerEvicted`, unchanged |
| ✗ | ✗ | `CancelledError` propagates, unchanged |

The top row is the one the order buys: `WorkerEvicted` is non-retryable at the Temporal layer *and* re-run by the eviction loop, which does not count against the task's retries.

**7. `asyncio.current_task()` is captured in the attempt's frame, not read inside `on_stall`.** The handler runs in the heartbeat task, so reading it there would cancel the watchdog and leave the wedged attempt running — a failure that looks like a hung activity rather than a stall, i.e. exactly what this issue exists to end. `test_the_handler_cancels_the_attempt_not_the_watchdog` fails if that moves.

**8. The `AppError → ApplicationError(*FailureDetails)` translation is factored into one helper, not duplicated.** Three things travel with it — the non-serialisable-evidence guard, `_sever_cause_chain` (BLDX-1512) and `non_retryable=not e.effective_retryable` — and each degrades a failure silently if a second copy drifts. `test_an_unbuildable_envelope_still_fails_as_a_stall` exercises the guard through the *new* branch, so the sharing is asserted rather than assumed.

**9. `last_progress_label` is `None`, not `""`, when the attempt never reported one.** "Nothing was ever observed" is the shape that means a task has no instrumentation on its path at all — a different work-list entry from "it went quiet after this one" — so it must not arrive on the wire disguised as an unnamed signal. The message says `<none>`, matching the watchdog's own log line.

## Scope: the watchdog is still inert

`progress` and `on_stall` are now passed to `auto_heartbeat_loop`; `watchdog_mode` and `max_no_progress_seconds` are **not**. Their defaults leave the watchdog off, so on this branch nothing can stall and the behaviour change is zero — the per-task flag and budget are FND-296's. Injecting the handler now is what makes enabling the watchdog a config change rather than a second seam. `test_the_watchdog_config_is_left_to_the_flag` asserts the absence rather than trusting it.

Two things I noticed and deliberately did not fix here:

- **A task with `heartbeat_timeout_seconds=None` gets a tracker but no watchdog.** The watchdog lives in the auto-heartbeat loop, and that loop is not started for such a task — so `progress.py`'s comment that the tracker is created unconditionally *because* the watchdog bounds a wedged attempt on a heartbeat-disabled task is, today, aspirational. Whether to run the loop for watchdog purposes alone belongs with the flag (FND-296).
- **`Task.uncancel()` is not called** when the cancellation is converted to an exception. That is pre-existing on the eviction path and correct for both consumers we have (Temporal's activity wrapper, and the `finally`'s `asyncio.wait_for`, whose cancellation accounting is relative to entry) — but the stall path makes self-cancellation a routine event rather than a shutdown-only one, so it is worth a look before enforce ships.

## Tests

**28 new**, across four files:

- `tests/unit/execution/test_stall_failure.py` — **14**. The headline one drives the **real** watchdog inside the **real** activity body with only the enforce config injected (10 ms tick, 50 ms budget, no patched clock — an asyncio loop shares `time.monotonic`), and asserts the failure that comes out. Then: retryability at the Temporal boundary, the exact message and evidence, the never-reported-progress shape, the cancel landing on the attempt and not the watchdog, the tracker unbinding on the new path, the details guard, all four corners of the flag matrix, a healthy attempt left untouched, and the three wiring assertions.
- `tests/unit/execution/test_progress.py` — **6** on the verdict: no verdict from elapsed time alone, the frozen pair, flagging is not progress, first-flag-wins, the empty label.
- `tests/unit/errors/test_categorical.py` — **7** on the error class: the subtype relationship, metadata, retryability, same-category-different-code, evidence, the unset inherited fields, context fields.
- `tests/unit/execution/test_progress_context.py` — **1**: the inert singleton refuses a verdict.

Sibling test doubles for `auto_heartbeat_loop` gained a `**kwargs` sink, now that the loop is called with the watchdog arguments.

Verification:

- `uv run pytest tests/unit` — **6835 passed, 9 skipped** (post-rebase, on `main`)
- `uv run pre-commit run --files <all 11 changed files>` — ruff, ruff-format, isort, pyright clean
- Full conformance suite, diffed against the same run on `main` by `(rule, file, message)` — **0 new findings, 0 resolved** (492 both sides), `exitCode: 0`. The pre-rebase run was `exitCode: 1` on P003; the diff is what caught it.
- Import-cycle check: `activities`, `progress` and `errors` each imported first in a fresh interpreter

A third sibling test double — `cancelling_loop`, added by FND-291 after this branch was cut — gained the same `**kwargs` sink during the rebase, since the loop is now called with the watchdog arguments.
