### PR TITLE
ci(fix): stop sdk-review auto-approval failing on the atlan-ci rate limit

### DIFF
--- a/.github/actions/connector-integration-tests/action.yaml
+++ b/.github/actions/connector-integration-tests/action.yaml
@@ -450,8 +450,16 @@ runs:
     # dedicated `scorecard` aggregation job in tests-reusable.yaml, which
     # combines this job's integration evidence with the unit job's. This job
     # just uploads its junit + coverage.json (below) for that job to consume.
+    # `upload-artifact` classifies the artifact service's finalize 403 as
+    # non-retryable and fails on the first occurrence, even though the bytes
+    # already landed and the next attempt normally succeeds. That failed this
+    # composite, which failed the caller's Tests check, which ejected its
+    # merge-queue entry. Retry once, and never fail on it: the scorecard job
+    # downloads this with continue-on-error already.
     - name: Upload test results
+      id: upload-integration-results
       if: always()
+      continue-on-error: true
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: integration-test-results
@@ -462,6 +470,21 @@ runs:
           results/
           coverage.json
         retention-days: 14
+
+    - name: Upload test results (retry)
+      if: steps.upload-integration-results.outcome == 'failure'
+      continue-on-error: true
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      with:
+        name: integration-test-results
+        # coverage.json is written at the repo root by --cov-report=json; include
+        # it alongside results/ so the scorecard aggregation job can read the
+        # integration tier's coverage.
+        path: |
+          results/
+          coverage.json
+        retention-days: 14
+        overwrite: true
 
     - name: Cleanup
       if: always()

--- a/.github/actions/connector-unit-tests/action.yaml
+++ b/.github/actions/connector-unit-tests/action.yaml
@@ -137,8 +137,16 @@ runs:
     # Ordered BEFORE the failure is re-raised, so the evidence survives a red
     # suite. `if: always()` is kept as a belt-and-braces guard for a step above
     # that fails without going through the verdict-recording path.
+    # `upload-artifact` classifies the artifact service's finalize 403 as
+    # non-retryable and fails on the first occurrence, even though the bytes
+    # already landed and the next attempt normally succeeds. That failed this
+    # composite, which failed the caller's Tests check, which ejected its
+    # merge-queue entry. Retry once, and never fail on it: the scorecard job
+    # downloads this with continue-on-error already.
     - name: Upload coverage artifacts
+      id: upload-unit-coverage
       if: always()
+      continue-on-error: true
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: unit-test-coverage
@@ -148,6 +156,20 @@ runs:
           htmlcov/
           results/
         retention-days: 14
+
+    - name: Upload coverage artifacts (retry)
+      if: steps.upload-unit-coverage.outcome == 'failure'
+      continue-on-error: true
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      with:
+        name: unit-test-coverage
+        path: |
+          coverage.xml
+          coverage.json
+          htmlcov/
+          results/
+        retention-days: 14
+        overwrite: true
 
     # Gate on the recorded verdict: after this change the tests step always
     # succeeds (it records instead of exiting), so a bare pull_request gate

--- a/.github/actions/parity-extract/action.yaml
+++ b/.github/actions/parity-extract/action.yaml
@@ -153,8 +153,24 @@ runs:
         kill "$APP_PID" 2>/dev/null || true
         wait "$APP_PID" 2>/dev/null || true
 
-    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+    # Retry once: `upload-artifact` treats the artifact service's finalize 403
+    # as non-retryable and fails the step even though the bytes already landed,
+    # which on a gating path ejects the merge-queue entry. Still fatal if both
+    # attempts fail — a consumer in another repo depends on this artifact.
+    - name: Upload parity output
+      id: upload-parity
+      continue-on-error: true
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: ${{ inputs.artifact-name }}
         path: ./parity-output/
         retention-days: 7
+
+    - name: Upload parity output (retry)
+      if: steps.upload-parity.outcome == 'failure'
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: ${{ inputs.artifact-name }}
+        path: ./parity-output/
+        retention-days: 7
+        overwrite: true

--- a/.github/actions/sdr-e2e/action.yaml
+++ b/.github/actions/sdr-e2e/action.yaml
@@ -1356,8 +1356,14 @@ runs:
     # downloads this same artifact and posts the body verbatim on the
     # SDK PR (only the sticky marker line differs), so both PRs see
     # the same rendered report.
+    # Retry once: `upload-artifact` treats the artifact service's finalize 403
+    # as non-retryable and fails the step even though the bytes already landed,
+    # which on a gating path ejects the merge-queue entry. Still fatal if both
+    # attempts fail — a consumer in another repo depends on this artifact.
     - name: Upload test results
+      id: upload-e2e-results
       if: always()
+      continue-on-error: true
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         # artifact-suffix keeps parallel matrix legs from colliding on this
@@ -1366,6 +1372,18 @@ runs:
         name: sdr-integration-tests-${{ inputs.app-name }}${{ inputs.artifact-suffix != '' && format('-{0}', inputs.artifact-suffix) || '' }}-results
         path: results/
         retention-days: 14
+
+    - name: Upload test results (retry)
+      if: steps.upload-e2e-results.outcome == 'failure'
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      with:
+        # artifact-suffix keeps parallel matrix legs from colliding on this
+        # name (upload-artifact rejects duplicate names within a run); empty
+        # suffix preserves the historical single-artifact name.
+        name: sdr-integration-tests-${{ inputs.app-name }}${{ inputs.artifact-suffix != '' && format('-{0}', inputs.artifact-suffix) || '' }}-results
+        path: results/
+        retention-days: 14
+        overwrite: true
 
     # No explicit `createCommitStatus` step: the workflow job already
     # surfaces a check_run on the PR (e.g. `E2E Full Tests (system

--- a/.github/scripts/sdk_review_approve.py
+++ b/.github/scripts/sdk_review_approve.py
@@ -40,11 +40,42 @@ The old code sent label errors to /dev/null under `|| true`, so that failure was
 invisible. Here a delete that 404s is tolerated (the label was already absent)
 and anything else is surfaced as a ::warning::.
 
+Two callers
+-----------
+The fast path (`sdk-review-approve-on-verdict.yml`) passes the verdict comment
+in via COMMENT_BODY, straight off the `issue_comment` event, and owns the
+`sdk-review` commit status.
+
+The slow path (`sdk-review.yml`, after the mothership sandbox finishes its
+cleanup) leaves COMMENT_BODY empty; the newest summary comment is fetched
+instead. It sets EXPECTED_HEAD to the sha the review was dispatched for, does
+not write the commit status (its workflow has its own failure-path step), and
+sets REQUIRE_APPROVED_LABEL so it will not approve a verdict something has since
+invalidated.
+
+That label guard is the solo-approval safety property. `sdk-review-approved` is
+the one signal every invalidator clears: `dismiss-on-human` strips it (and
+notably does NOT touch the commit status, so the status cannot substitute),
+`downgrade-on-ci-failure` strips it, `reset-on-push` strips it. It is therefore
+read from a snapshot taken BEFORE this run reconciles labels — the shell version
+read it back after adding it, so the guard could only ever see the label it had
+just written and never fired.
+
 Environment:
     REPO                        owner/repo (e.g. atlanhq/application-sdk)
     PR_NUMBER                   pull request number
-    COMMENT_BODY                body of the triggering verdict comment
-    TRIGGERING_COMMENT_ID       id of the triggering comment
+    COMMENT_BODY                verdict comment body; when empty the newest
+                                summary comment on the PR is fetched instead
+    TRIGGERING_COMMENT_ID       id of the triggering comment; the freshness
+                                check only applies when COMMENT_BODY is set
+                                (fetching the newest makes it moot)
+    EXPECTED_HEAD               optional; when set, the PR's live head must
+                                match it as well as matching REVIEWED_HEAD
+    WRITE_STATUS                true (default) | false — own the sdk-review
+                                commit status
+    REQUIRE_APPROVED_LABEL      false (default) | true — refuse to approve
+                                unless `sdk-review-approved` was already on the
+                                PR when this run started
     GH_TOKEN                    App installation token — every call but APPROVE
     APPROVER_TOKEN              `atlan-ci` PAT — the APPROVE call only
     APPROVE_MAX_ATTEMPTS        default 3
@@ -205,14 +236,29 @@ class Client:
                 items.append(page)
         return items
 
-    def newest_summary_comment_id(self) -> int:
-        """Id of the most recent SDK review summary comment, or 0 if none."""
-        ids = [
-            comment.get("id", 0)
+    def _summary_comments(self) -> list[dict]:
+        return [
+            comment
             for comment in self._paginated(f"issues/{self.pr_number}/comments")
             if any(marker in (comment.get("body") or "") for marker in SUMMARY_MARKERS)
         ]
+
+    def newest_summary_comment_id(self) -> int:
+        """Id of the most recent SDK review summary comment, or 0 if none."""
+        ids = [comment.get("id", 0) for comment in self._summary_comments()]
         return max(ids) if ids else 0
+
+    def latest_summary_body(self) -> str:
+        """Body of the newest SDK review summary comment, or "" if none.
+
+        Ids are monotonic, so max-by-id is the newest — not merely the last in
+        page order.
+        """
+        comments = self._summary_comments()
+        if not comments:
+            return ""
+        newest = max(comments, key=lambda comment: comment.get("id", 0))
+        return newest.get("body") or ""
 
     def current_labels(self) -> set[str]:
         result = self.run(
@@ -415,9 +461,27 @@ def main(
     pr_number = os.environ.get("PR_NUMBER", "")
     body = os.environ.get("COMMENT_BODY", "")
     triggering_id = int(os.environ.get("TRIGGERING_COMMENT_ID") or 0)
+    expected_head = os.environ.get("EXPECTED_HEAD", "").strip()
+    write_status = os.environ.get("WRITE_STATUS", "true") != "false"
+    require_approved_label = os.environ.get("REQUIRE_APPROVED_LABEL", "false") == "true"
     approver_token = os.environ.get("APPROVER_TOKEN", "")
     max_attempts = int(os.environ.get("APPROVE_MAX_ATTEMPTS") or 3)
     max_wait = float(os.environ.get("APPROVE_MAX_WAIT_SECONDS") or 120)
+
+    client = Client(repo, pr_number, runner)
+
+    # Fast path hands us the event payload; slow path asks for the newest
+    # summary, which makes the freshness check below moot by construction.
+    from_event = bool(body)
+    if not from_event:
+        body = client.latest_summary_body()
+        if not body:
+            print(
+                f"::warning::No SDK review summary comment found on PR "
+                f"#{pr_number} — skipping (the sandbox may have errored before "
+                f"posting)."
+            )
+            return 0
 
     verdict = extract_verdict(body)
     if not verdict:
@@ -438,8 +502,6 @@ def main(
         )
         return 0
 
-    client = Client(repo, pr_number, runner)
-
     head_sha = client.head_sha()
     if not head_sha:
         print(f"::warning::PR #{pr_number}: HEAD unresolvable — skipping all stamps.")
@@ -454,19 +516,35 @@ def main(
         )
         return 0
 
+    # Belt-and-suspenders for the slow path: the review can take 10–30 minutes,
+    # and the sandbox could in principle have reviewed a sha other than the one
+    # its run was dispatched for.
+    if expected_head and head_sha != expected_head:
+        print(
+            f"::warning::PR #{pr_number}: head is {head_sha} but this run was "
+            f"dispatched for {expected_head} — skipping all stamps."
+        )
+        return 0
+
     # The job's concurrency group serialises runs per PR, but GitHub's queue is
     # not event-time ordered: after waiting, this run may execute after a newer
     # verdict has already been stamped. Ids are monotonic, so a larger one means
     # a newer summary exists and owns the final say.
-    newest_id = client.newest_summary_comment_id()
-    if newest_id > triggering_id:
-        print(
-            f"::notice::PR #{pr_number}: a newer SDK_REVIEW comment "
-            f"(id={newest_id}) supersedes this one (id={triggering_id}) — skipping."
-        )
-        return 0
+    if from_event:
+        newest_id = client.newest_summary_comment_id()
+        if newest_id > triggering_id:
+            print(
+                f"::notice::PR #{pr_number}: a newer SDK_REVIEW comment "
+                f"(id={newest_id}) supersedes this one (id={triggering_id}) — "
+                f"skipping."
+            )
+            return 0
 
-    to_add, to_remove = label_plan(verdict, client.current_labels())
+    # Snapshot BEFORE reconciling: `require_approved_label` asks whether the
+    # label was standing when this run started, which the post-reconcile state
+    # can no longer answer.
+    labels_before = client.current_labels()
+    to_add, to_remove = label_plan(verdict, labels_before)
     client.add_labels(to_add)
     for label in sorted(to_remove):
         client.remove_label(label)
@@ -486,8 +564,21 @@ def main(
             )
             for review_id in stale:
                 client.dismiss(review_id, message)
-        client.post_status(head_sha, state, description)
+        if write_status:
+            client.post_status(head_sha, state, description)
         print(f"Verdict '{verdict}' is not READY TO MERGE — no approval posted.")
+        return 0
+
+    # Solo-approval guard (slow path). Every invalidator — dismiss-on-human,
+    # downgrade-on-ci-failure, reset-on-push — clears this label, so its absence
+    # means something has spoken since the verdict and the approval must not be
+    # (re-)posted.
+    if require_approved_label and APPROVED_LABEL not in labels_before:
+        print(
+            f"::notice::PR #{pr_number}: `{APPROVED_LABEL}` was not present when "
+            f"this run started (a downgrade, dismissal or push likely intervened) "
+            f"— skipping approval."
+        )
         return 0
 
     # Don't double-approve: sdk-review.yml's slow path runs the same stamp after
@@ -497,7 +588,8 @@ def main(
             f"atlan-ci has already approved PR #{pr_number} with the bot "
             f"signature — skipping."
         )
-        client.post_status(head_sha, state, description)
+        if write_status:
+            client.post_status(head_sha, state, description)
         return 0
 
     if not approver_token:
@@ -514,18 +606,19 @@ def main(
         now=now,
     )
     if not approved:
-        # Leave the commit status as the dispatcher set it (pending). Going green
-        # here is what made this failure look like success on the PR.
+        # Deliberately do NOT advance the commit status. Going green here without
+        # an approving review is what made this failure look like success.
         print(
             f"::error::PR #{pr_number}: verdict is READY_TO_MERGE but the atlan-ci "
-            f"approval could not be posted. The sdk-review status is left pending so "
+            f"approval could not be posted. The sdk-review status is left as-is so "
             f"the merge gate stays blocked. Re-run this workflow, or comment "
             f"`@sdk-review`, once quota has recovered."
         )
         return 1
 
     print(f"Approved PR #{pr_number} as atlan-ci (commit_id={head_sha}).")
-    client.post_status(head_sha, state, description)
+    if write_status:
+        client.post_status(head_sha, state, description)
     return 0
 
 

--- a/.github/scripts/sdk_review_approve.py
+++ b/.github/scripts/sdk_review_approve.py
@@ -1,0 +1,533 @@
+#!/usr/bin/env python3
+"""Stamp an SDK review verdict onto a PR: labels, commit status, approval.
+
+Driven by `sdk-review-approve-on-verdict.yml` when `mothership-ai[bot]` posts a
+verdict comment. Decision logic lives here rather than inlined in the workflow,
+per docs/standards/ci.md.
+
+Two tokens, deliberately
+------------------------
+`atlan-ci` is a CODEOWNER (.github/CODEOWNERS), so the formal APPROVE review is
+the one call that must carry that identity. Everything else here — resolving
+HEAD, listing comments, reconciling labels, writing the commit status,
+dismissing stale approvals — is identity-agnostic.
+
+The previous shell implementation ran all of it on `atlan-ci`'s PAT, spending
+~15 requests per fire against a single 5,000/hr user quota shared with every
+other workflow that authenticates as `atlan-ci`. Under a burst of concurrent
+review/resolve loops that quota ran out, and the APPROVE POST — the last call in
+the sequence — took the 403. The review summary landed, the commit status went
+green, and no approval was ever posted.
+
+So: `GH_TOKEN` (a GitHub App installation token, its own quota) does everything,
+and `APPROVER_TOKEN` (the `atlan-ci` PAT) is spent on exactly one request.
+
+Ordering
+--------
+The approval is posted BEFORE the `sdk-review` commit status is set to success.
+The old order wrote the status first, so a failed approval left the PR wearing a
+green `sdk-review` check with no approving review — a state that reads as "the
+bot is done" while the merge gate is still blocked. If the approval cannot be
+posted the status is left as the dispatcher set it (pending) and the run fails
+loudly.
+
+Labels
+------
+Written through the REST labels API rather than `gh pr edit`. Labels are an
+Issues-scope resource; a fine-grained token carrying `pull_requests: write` but
+not `issues: write` can approve a review yet silently fail every label write.
+The old code sent label errors to /dev/null under `|| true`, so that failure was
+invisible. Here a delete that 404s is tolerated (the label was already absent)
+and anything else is surfaced as a ::warning::.
+
+Environment:
+    REPO                        owner/repo (e.g. atlanhq/application-sdk)
+    PR_NUMBER                   pull request number
+    COMMENT_BODY                body of the triggering verdict comment
+    TRIGGERING_COMMENT_ID       id of the triggering comment
+    GH_TOKEN                    App installation token — every call but APPROVE
+    APPROVER_TOKEN              `atlan-ci` PAT — the APPROVE call only
+    APPROVE_MAX_ATTEMPTS        default 3
+    APPROVE_MAX_WAIT_SECONDS    total sleep budget across retries, default 120
+
+Exit status:
+    0  stamped, or intentionally skipped by a guard
+    1  verdict was READY_TO_MERGE but the approval could not be posted
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import time
+from collections.abc import Callable
+
+Runner = Callable[..., subprocess.CompletedProcess]
+Sleeper = Callable[[float], None]
+
+SUMMARY_MARKERS = ("<!-- SDK_REVIEW -->", "<!-- TEST_SDK_REVIEW -->")
+
+VERDICT_RE = re.compile(r"<!--\s*VERDICT:\s*([A-Z_]+)\s*-->")
+# Fallback for legacy comments predating the structured marker: "### Verdict:
+# READY TO MERGE" in prose, which normalises to READY_TO_MERGE.
+VERDICT_PROSE_RE = re.compile(r"###\s*Verdict:\s*([A-Za-z][A-Za-z ]*)", re.IGNORECASE)
+REVIEWED_HEAD_RE = re.compile(r"<!--\s*REVIEWED_HEAD:\s*([0-9a-f]+)\s*-->")
+
+READY = "READY_TO_MERGE"
+
+APPROVED_LABEL = "sdk-review-approved"
+NEEDS_HUMAN_LABEL = "sdk-review-needs-human"
+NEEDS_REBASE_LABEL = "sdk-review-needs-rebase"
+
+# Stripped unconditionally so PRs predating the promotion out of the
+# `test-sdk-review-*` prefix don't end up wearing both.
+LEGACY_LABELS = frozenset(
+    {
+        "test-sdk-review-approved",
+        "test-sdk-review-needs-human",
+        "test-sdk-review-needs-rebase",
+    }
+)
+
+# The leading line of the approval body is a STABLE SIGNATURE used by
+# sdk-review-dismiss-on-human.yml to tell bot approvals from human ones.
+# Keep in sync with that workflow and with sdk-review.yml.
+APPROVAL_SIGNATURE = "**SDK reviewer's verdict:**"
+APPROVAL_BODY = (
+    f"{APPROVAL_SIGNATURE} READY TO MERGE.\n"
+    "\n"
+    "Full review summary is in the comment posted on this PR.\n"
+)
+
+
+def extract_verdict(body: str) -> str | None:
+    """The verdict, preferring the structured marker over the prose heading."""
+    match = VERDICT_RE.search(body)
+    if match:
+        return match.group(1)
+    prose = VERDICT_PROSE_RE.search(body)
+    if not prose:
+        return None
+    # "READY TO MERGE" -> "READY_TO_MERGE"; trailing separators dropped.
+    return "_".join(prose.group(1).upper().split()) or None
+
+
+def extract_reviewed_head(body: str) -> str | None:
+    """The sha the verdict was computed against, if the comment stamps one."""
+    match = REVIEWED_HEAD_RE.search(body)
+    return match.group(1) if match else None
+
+
+def label_plan(verdict: str, current: set[str]) -> tuple[set[str], set[str]]:
+    """Return (to_add, to_remove) for `verdict`, given the PR's current labels.
+
+    Only genuine deltas are returned, so an already-correctly-labelled PR costs
+    zero label requests.
+    """
+    if verdict == READY:
+        want, unwant = {APPROVED_LABEL}, {NEEDS_HUMAN_LABEL, NEEDS_REBASE_LABEL}
+    elif verdict == "NEEDS_HUMAN":
+        want, unwant = {NEEDS_HUMAN_LABEL}, {APPROVED_LABEL}
+    elif verdict == "NEEDS_REBASE":
+        want, unwant = {NEEDS_REBASE_LABEL}, {APPROVED_LABEL}
+    else:
+        # NEEDS_FIXES / BLOCKED / anything unrecognised: clear the two verdict
+        # labels that would otherwise imply a resolved review. `needs-rebase` is
+        # left alone — it describes the branch, not the verdict.
+        want, unwant = set(), {APPROVED_LABEL, NEEDS_HUMAN_LABEL}
+
+    unwant |= LEGACY_LABELS
+    return want - current, (unwant & current)
+
+
+def status_for(verdict: str) -> tuple[str, str]:
+    """The (state, description) to publish as the `sdk-review` commit status."""
+    if verdict == READY:
+        return "success", "Approved"
+    # NEEDS_FIXES / BLOCKED / NEEDS_HUMAN / NEEDS_REBASE / unknown all leave the
+    # merge gate visibly blocked.
+    return "failure", f"Verdict: {verdict}"
+
+
+def is_rate_limited(stderr: str) -> bool:
+    """Whether a failed `gh` invocation failed because of a rate limit."""
+    lowered = stderr.lower()
+    return "rate limit" in lowered or "secondary rate" in lowered
+
+
+class Client:
+    """Thin `gh api` wrapper. All calls use GH_TOKEN unless told otherwise."""
+
+    def __init__(self, repo: str, pr_number: str, runner: Runner = subprocess.run):
+        self.repo = repo
+        self.pr_number = pr_number
+        self._runner = runner
+
+    def run(
+        self, args: list[str], token: str | None = None
+    ) -> subprocess.CompletedProcess:
+        env = None
+        if token:
+            env = {**os.environ, "GH_TOKEN": token}
+        return self._runner(
+            ["gh", *args], capture_output=True, text=True, check=False, env=env
+        )
+
+    def head_sha(self) -> str | None:
+        result = self.run(
+            ["api", f"repos/{self.repo}/pulls/{self.pr_number}", "--jq", ".head.sha"]
+        )
+        if result.returncode != 0:
+            print(f"::warning::could not resolve PR HEAD: {result.stderr.strip()}")
+            return None
+        return result.stdout.strip() or None
+
+    def _paginated(self, path: str) -> list[dict]:
+        """Flatten a `--paginate --slurp` response into a list of objects."""
+        result = self.run(["api", f"repos/{self.repo}/{path}", "--paginate", "--slurp"])
+        if result.returncode != 0:
+            print(f"::warning::could not list {path}: {result.stderr.strip()}")
+            return []
+        try:
+            pages = json.loads(result.stdout or "[]")
+        except json.JSONDecodeError as exc:
+            print(f"::warning::could not parse {path} ({exc})")
+            return []
+        items: list[dict] = []
+        for page in pages:
+            # An un-paginated response is a bare array; --slurp adds one level.
+            # Tolerate both shapes.
+            if isinstance(page, list):
+                items.extend(item for item in page if isinstance(item, dict))
+            elif isinstance(page, dict):
+                items.append(page)
+        return items
+
+    def newest_summary_comment_id(self) -> int:
+        """Id of the most recent SDK review summary comment, or 0 if none."""
+        ids = [
+            comment.get("id", 0)
+            for comment in self._paginated(f"issues/{self.pr_number}/comments")
+            if any(marker in (comment.get("body") or "") for marker in SUMMARY_MARKERS)
+        ]
+        return max(ids) if ids else 0
+
+    def current_labels(self) -> set[str]:
+        result = self.run(
+            [
+                "api",
+                f"repos/{self.repo}/issues/{self.pr_number}",
+                "--jq",
+                ".labels[].name",
+            ]
+        )
+        if result.returncode != 0:
+            print(f"::warning::could not list labels: {result.stderr.strip()}")
+            return set()
+        return {line.strip() for line in result.stdout.splitlines() if line.strip()}
+
+    def add_labels(self, labels: set[str]) -> None:
+        if not labels:
+            return
+        args = [
+            "api",
+            f"repos/{self.repo}/issues/{self.pr_number}/labels",
+            "-X",
+            "POST",
+        ]
+        for label in sorted(labels):
+            args += ["-f", f"labels[]={label}"]
+        result = self.run(args)
+        if result.returncode != 0:
+            # Surfaced, not swallowed: a token without `issues: write` fails
+            # every label write while approvals still succeed.
+            print(
+                f"::warning::could not add labels {sorted(labels)}: "
+                f"{result.stderr.strip()}"
+            )
+        else:
+            print(f"Added labels: {sorted(labels)}")
+
+    def remove_label(self, label: str) -> None:
+        result = self.run(
+            [
+                "api",
+                f"repos/{self.repo}/issues/{self.pr_number}/labels/{label}",
+                "-X",
+                "DELETE",
+            ]
+        )
+        if result.returncode == 0:
+            print(f"Removed label: {label}")
+            return
+        if "404" in result.stderr or "Not Found" in result.stderr:
+            # Already absent — the desired end state.
+            return
+        print(f"::warning::could not remove label {label}: {result.stderr.strip()}")
+
+    def post_status(self, sha: str, state: str, description: str) -> None:
+        result = self.run(
+            [
+                "api",
+                f"repos/{self.repo}/statuses/{sha}",
+                "-X",
+                "POST",
+                "-f",
+                f"state={state}",
+                "-f",
+                "context=sdk-review",
+                "-f",
+                f"description={description}",
+            ]
+        )
+        if result.returncode != 0:
+            print(
+                f"::warning::could not set sdk-review status: {result.stderr.strip()}"
+            )
+        else:
+            print(f"Set sdk-review status: {state} ({description})")
+
+    def bot_approval_ids(self) -> list[int]:
+        """Ids of live atlan-ci approvals bearing our signature."""
+        return [
+            review.get("id")
+            for review in self._paginated(f"pulls/{self.pr_number}/reviews")
+            if review.get("state") == "APPROVED"
+            and (review.get("user") or {}).get("login") == "atlan-ci"
+            and (review.get("body") or "").startswith(APPROVAL_SIGNATURE)
+        ]
+
+    def dismiss(self, review_id: int, message: str) -> None:
+        result = self.run(
+            [
+                "api",
+                f"repos/{self.repo}/pulls/{self.pr_number}/reviews/{review_id}/dismissals",
+                "-X",
+                "PUT",
+                "-f",
+                f"message={message}",
+            ]
+        )
+        if result.returncode != 0:
+            print(
+                f"::warning::could not dismiss review {review_id}: "
+                f"{result.stderr.strip()}"
+            )
+        else:
+            print(f"Dismissed stale atlan-ci approval {review_id}.")
+
+    def rate_limit_reset(self, token: str) -> int:
+        """Epoch seconds when the approver's core quota resets, 0 if unknown."""
+        result = self.run(
+            ["api", "rate_limit", "--jq", ".resources.core.reset"], token=token
+        )
+        if result.returncode != 0:
+            return 0
+        try:
+            return int(result.stdout.strip())
+        except ValueError:
+            return 0
+
+    def approve(self, sha: str, token: str) -> subprocess.CompletedProcess:
+        # `gh pr review --approve` cannot pin commit_id, so use the raw API:
+        # pinning the review to the sha we verified means a push landing in the
+        # gap attaches the approval to the reviewed commit, not the new HEAD.
+        return self.run(
+            [
+                "api",
+                f"repos/{self.repo}/pulls/{self.pr_number}/reviews",
+                "-X",
+                "POST",
+                "-f",
+                f"commit_id={sha}",
+                "-f",
+                "event=APPROVE",
+                "-f",
+                f"body={APPROVAL_BODY}",
+            ],
+            token=token,
+        )
+
+
+def post_approval_with_retry(
+    client: Client,
+    sha: str,
+    token: str,
+    max_attempts: int,
+    max_wait: float,
+    sleeper: Sleeper = time.sleep,
+    now: Callable[[], float] = time.time,
+) -> bool:
+    """Approve as atlan-ci, retrying transients and short rate-limit waits.
+
+    A secondary rate limit clears in seconds and is worth waiting out. Primary
+    quota exhaustion can be up to an hour away: if the reset falls outside
+    `max_wait` there is nothing useful to wait for, so fail immediately with the
+    reset time named rather than burning the job timeout.
+    """
+    budget = max_wait
+    for attempt in range(1, max_attempts + 1):
+        result = client.approve(sha, token)
+        if result.returncode == 0:
+            return True
+
+        stderr = result.stderr.strip()
+        print(f"::warning::approval attempt {attempt}/{max_attempts} failed: {stderr}")
+        if attempt == max_attempts:
+            break
+
+        delay = float(attempt * 5)
+        if is_rate_limited(stderr):
+            reset = client.rate_limit_reset(token)
+            if reset:
+                wait_for = reset - now()
+                if wait_for > budget:
+                    print(
+                        f"::error::atlan-ci quota is exhausted and does not reset for "
+                        f"{wait_for:.0f}s (> {budget:.0f}s budget) — giving up rather "
+                        f"than holding the runner."
+                    )
+                    return False
+                # +2s so we wake up after the window has actually rolled over.
+                delay = max(delay, wait_for + 2)
+
+        if delay > budget:
+            print(
+                f"::error::next retry needs {delay:.0f}s but only {budget:.0f}s of "
+                f"wait budget remains — giving up."
+            )
+            return False
+        budget -= delay
+        print(f"Retrying approval in {delay:.0f}s ({budget:.0f}s budget left).")
+        sleeper(delay)
+
+    return False
+
+
+def main(
+    runner: Runner = subprocess.run,
+    sleeper: Sleeper = time.sleep,
+    now: Callable[[], float] = time.time,
+) -> int:
+    repo = os.environ.get("REPO", "")
+    pr_number = os.environ.get("PR_NUMBER", "")
+    body = os.environ.get("COMMENT_BODY", "")
+    triggering_id = int(os.environ.get("TRIGGERING_COMMENT_ID") or 0)
+    approver_token = os.environ.get("APPROVER_TOKEN", "")
+    max_attempts = int(os.environ.get("APPROVE_MAX_ATTEMPTS") or 3)
+    max_wait = float(os.environ.get("APPROVE_MAX_WAIT_SECONDS") or 120)
+
+    verdict = extract_verdict(body)
+    if not verdict:
+        print(
+            f"::warning::PR #{pr_number}: could not extract a verdict from the "
+            f"mothership-ai comment. Skipping."
+        )
+        return 0
+    print(f"Detected verdict: '{verdict}'")
+
+    # A comment with no REVIEWED_HEAD predates the stamp; its reviewed sha
+    # cannot be established, and approving blind is worse than not approving.
+    reviewed_head = extract_reviewed_head(body)
+    if not reviewed_head:
+        print(
+            f"::warning::PR #{pr_number}: verdict comment has no REVIEWED_HEAD "
+            f"marker — cannot confirm which sha was reviewed; skipping all stamps."
+        )
+        return 0
+
+    client = Client(repo, pr_number, runner)
+
+    head_sha = client.head_sha()
+    if not head_sha:
+        print(f"::warning::PR #{pr_number}: HEAD unresolvable — skipping all stamps.")
+        return 0
+
+    # The verdict was computed for reviewed_head. A push since then means the
+    # current head is unreviewed, and stamping it would bless unreviewed code.
+    if reviewed_head != head_sha:
+        print(
+            f"::warning::PR #{pr_number}: verdict was computed for {reviewed_head} "
+            f"but current head is {head_sha} — skipping all stamps."
+        )
+        return 0
+
+    # The job's concurrency group serialises runs per PR, but GitHub's queue is
+    # not event-time ordered: after waiting, this run may execute after a newer
+    # verdict has already been stamped. Ids are monotonic, so a larger one means
+    # a newer summary exists and owns the final say.
+    newest_id = client.newest_summary_comment_id()
+    if newest_id > triggering_id:
+        print(
+            f"::notice::PR #{pr_number}: a newer SDK_REVIEW comment "
+            f"(id={newest_id}) supersedes this one (id={triggering_id}) — skipping."
+        )
+        return 0
+
+    to_add, to_remove = label_plan(verdict, client.current_labels())
+    client.add_labels(to_add)
+    for label in sorted(to_remove):
+        client.remove_label(label)
+
+    state, description = status_for(verdict)
+
+    if verdict != READY:
+        # sdk-review-dismiss-on-human.yml only fires on HUMAN activity, so when a
+        # newer verdict supersedes a prior READY_TO_MERGE the stale bot approval
+        # has to be cleared here or the merge gate stays open on it.
+        stale = client.bot_approval_ids()
+        if stale:
+            message = (
+                f"Newer SDK review verdict ({verdict}) supersedes the prior bot "
+                f"approval — auto-dismissing. Re-run `@sdk-review` when ready for "
+                f"re-approval."
+            )
+            for review_id in stale:
+                client.dismiss(review_id, message)
+        client.post_status(head_sha, state, description)
+        print(f"Verdict '{verdict}' is not READY TO MERGE — no approval posted.")
+        return 0
+
+    # Don't double-approve: sdk-review.yml's slow path runs the same stamp after
+    # the SSE stream closes.
+    if client.bot_approval_ids():
+        print(
+            f"atlan-ci has already approved PR #{pr_number} with the bot "
+            f"signature — skipping."
+        )
+        client.post_status(head_sha, state, description)
+        return 0
+
+    if not approver_token:
+        print("::error::APPROVER_TOKEN is not set — cannot post a codeowner approval.")
+        return 1
+
+    approved = post_approval_with_retry(
+        client,
+        head_sha,
+        approver_token,
+        max_attempts=max_attempts,
+        max_wait=max_wait,
+        sleeper=sleeper,
+        now=now,
+    )
+    if not approved:
+        # Leave the commit status as the dispatcher set it (pending). Going green
+        # here is what made this failure look like success on the PR.
+        print(
+            f"::error::PR #{pr_number}: verdict is READY_TO_MERGE but the atlan-ci "
+            f"approval could not be posted. The sdk-review status is left pending so "
+            f"the merge gate stays blocked. Re-run this workflow, or comment "
+            f"`@sdk-review`, once quota has recovered."
+        )
+        return 1
+
+    print(f"Approved PR #{pr_number} as atlan-ci (commit_id={head_sha}).")
+    client.post_status(head_sha, state, description)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/sdk_review_approve.py
+++ b/.github/scripts/sdk_review_approve.py
@@ -100,6 +100,23 @@ Sleeper = Callable[[float], None]
 
 SUMMARY_MARKERS = ("<!-- SDK_REVIEW -->", "<!-- TEST_SDK_REVIEW -->")
 
+# The only login whose verdict comments this script may act on. The fast path's
+# job-level `if:` already pins the *triggering* comment to this author, but the
+# script also re-lists every PR comment — to find the newest summary for
+# supersede detection, and (on the slow path, COMMENT_BODY empty) to re-read the
+# verdict itself. That read path must apply the same author check, or a forged
+# `<!-- SDK_REVIEW -->` comment from anyone else would be treated as a verdict
+# and could drive the atlan-ci APPROVE.
+VERDICT_AUTHOR = "mothership-ai[bot]"
+
+
+def _is_verdict_comment(comment: dict) -> bool:
+    """A comment counts as a verdict only from the reviewer bot, with a marker."""
+    if (comment.get("user") or {}).get("login") != VERDICT_AUTHOR:
+        return False
+    return any(marker in (comment.get("body") or "") for marker in SUMMARY_MARKERS)
+
+
 VERDICT_RE = re.compile(r"<!--\s*VERDICT:\s*([A-Z_]+)\s*-->")
 # Fallback for legacy comments predating the structured marker: "### Verdict:
 # READY TO MERGE" in prose, which normalises to READY_TO_MERGE.
@@ -237,10 +254,16 @@ class Client:
         return items
 
     def _summary_comments(self) -> list[dict]:
+        """Verdict comments only: reviewer-bot-authored AND carrying a marker.
+
+        A marker alone is not proof of authorship, so a forged verdict comment
+        from any other login is filtered out here — covering both
+        `newest_summary_comment_id()` and `latest_summary_body()` at once.
+        """
         return [
             comment
             for comment in self._paginated(f"issues/{self.pr_number}/comments")
-            if any(marker in (comment.get("body") or "") for marker in SUMMARY_MARKERS)
+            if _is_verdict_comment(comment)
         ]
 
     def newest_summary_comment_id(self) -> int:

--- a/.github/scripts/sdk_review_approve.py
+++ b/.github/scripts/sdk_review_approve.py
@@ -205,6 +205,20 @@ def is_rate_limited(stderr: str) -> bool:
     return "rate limit" in lowered or "secondary rate" in lowered
 
 
+def is_secondary_rate_limit(stderr: str) -> bool:
+    """Whether the failure was a *secondary* (abuse/concurrency) throttle.
+
+    Secondary limits clear in seconds-to-a-minute and are worth waiting out on a
+    bounded delay. Primary quota exhaustion is different: it holds until the
+    hourly core window resets, which is what `rate_limit_reset()` reads — so the
+    two must not share the same wait calculation (a secondary throttle against a
+    distant core reset would otherwise fail fast instead of waiting its short
+    window).
+    """
+    lowered = stderr.lower()
+    return "secondary rate" in lowered or "abuse detection" in lowered
+
+
 class Client:
     """Thin `gh api` wrapper. All calls use GH_TOKEN unless told otherwise."""
 
@@ -297,9 +311,17 @@ class Client:
             return set()
         return {line.strip() for line in result.stdout.splitlines() if line.strip()}
 
-    def add_labels(self, labels: set[str]) -> None:
+    def add_labels(self, labels: set[str]) -> bool:
+        """Add `labels`; True on success (or nothing to do), False on failure.
+
+        The READY path keys off this: `sdk-review-downgrade-on-ci-failure.yml`
+        gates on the `sdk-review-approved` label being present, so an approval
+        posted while that label is absent would never be auto-dismissed on a
+        later CI failure. Reporting the failure lets the caller keep the
+        label/status/approval triple from durably disagreeing.
+        """
         if not labels:
-            return
+            return True
         args = [
             "api",
             f"repos/{self.repo}/issues/{self.pr_number}/labels",
@@ -316,8 +338,9 @@ class Client:
                 f"::warning::could not add labels {sorted(labels)}: "
                 f"{result.stderr.strip()}"
             )
-        else:
-            print(f"Added labels: {sorted(labels)}")
+            return False
+        print(f"Added labels: {sorted(labels)}")
+        return True
 
     def remove_label(self, label: str) -> None:
         result = self.run(
@@ -448,7 +471,12 @@ def post_approval_with_retry(
             break
 
         delay = float(attempt * 5)
-        if is_rate_limited(stderr):
+        if is_secondary_rate_limit(stderr):
+            # A secondary throttle clears in seconds-to-a-minute and has no
+            # relationship to the hourly core-quota reset `rate_limit_reset()`
+            # reads, so wait a bounded backoff rather than that unrelated reset.
+            delay = max(delay, 15.0)
+        elif is_rate_limited(stderr):
             reset = client.rate_limit_reset(token)
             if reset:
                 wait_for = reset - now()
@@ -568,11 +596,24 @@ def main(
     # can no longer answer.
     labels_before = client.current_labels()
     to_add, to_remove = label_plan(verdict, labels_before)
-    client.add_labels(to_add)
+    added_ok = client.add_labels(to_add)
     for label in sorted(to_remove):
         client.remove_label(label)
 
     state, description = status_for(verdict)
+
+    # The downgrade workflow gates on the `sdk-review-approved` label standing.
+    # Approving + greening the status while that label never landed would leave
+    # an approval no invalidator can clear on a later CI failure — so refuse to
+    # stamp and fail loudly instead, leaving the status as the dispatcher set it.
+    if verdict == READY and APPROVED_LABEL in to_add and not added_ok:
+        print(
+            f"::error::PR #{pr_number}: could not add the `{APPROVED_LABEL}` label, "
+            f"so the approval is NOT being posted and the sdk-review status is left "
+            f"pending. Without the label a later CI failure could not auto-dismiss "
+            f"the approval. Restore `issues: write` for the App token and re-run."
+        )
+        return 1
 
     if verdict != READY:
         # sdk-review-dismiss-on-human.yml only fires on HUMAN activity, so when a

--- a/.github/scripts/tests/test_artifact_upload_retry.py
+++ b/.github/scripts/tests/test_artifact_upload_retry.py
@@ -14,10 +14,25 @@ guards in this suite that assert a property of the YAML outside .github/scripts/
 (Deliberately avoids naming those sibling guards' scripts: this suite discovers
 call sites by grepping .github/ for a script's name, and a prose mention here
 would register this file as one of its callers.)
+
+What counts as a retry
+----------------------
+Structure, never the step's name. An earlier version of this guard classified any
+upload step whose name contained "(retry)" as a retry and exempted it from every
+assertion — so a *first* attempt that happened to carry that substring vanished
+from validation, and the pairing check only asked whether *some* step in the file
+had an outcome guard. Both let a genuinely unretried upload keep the guard green.
+
+Here a retry is an `actions/upload-artifact` step whose `if:` is guarded on
+`steps.<id>.outcome == 'failure'` where `<id>` is another upload step **in the
+same job or composite**, and which uploads the same artifact name and path. That
+is checked, not assumed: a companion step that guards on the right outcome but
+uploads something else, or is not an upload at all, does not satisfy the pairing.
 """
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import pytest
@@ -25,6 +40,9 @@ import yaml
 
 ROOT = Path(__file__).resolve().parents[2]
 UPLOAD_ACTION = "actions/upload-artifact"
+
+# `steps.<id>.outcome == 'failure'` — the only shape that makes a step a retry.
+OUTCOME_GUARD_RE = re.compile(r"steps\.([A-Za-z0-9_-]+)\.outcome\s*==\s*'failure'")
 
 # Uploads that do NOT need retry hardening, each with the reason it is exempt.
 # Keyed by (path suffix, artifact name) so an exemption cannot silently widen to
@@ -59,16 +77,8 @@ def _yaml_files() -> list[Path]:
     return files
 
 
-def _steps(doc: dict) -> list[dict]:
-    """Every step in a workflow's jobs or a composite action's runs block."""
-    steps: list[dict] = []
-    for job in (doc.get("jobs") or {}).values():
-        if isinstance(job, dict):
-            steps.extend(s for s in (job.get("steps") or []) if isinstance(s, dict))
-    runs = doc.get("runs") or {}
-    if isinstance(runs, dict):
-        steps.extend(s for s in (runs.get("steps") or []) if isinstance(s, dict))
-    return steps
+def _rel(path: Path) -> str:
+    return str(path.relative_to(ROOT))
 
 
 def _unparseable() -> set[str]:
@@ -81,37 +91,105 @@ def _unparseable() -> set[str]:
     return broken
 
 
-def _uploads() -> list[tuple[Path, dict, list[dict]]]:
-    found = []
+def _scopes_from_doc(rel: str, doc: dict) -> list[tuple[str, str, list[dict]]]:
+    """(file, scope, steps) per job and per composite `runs` block.
+
+    Scoping matters: `steps.<id>` only resolves within one job, so a retry in a
+    *different* job of the same file must not satisfy another job's pairing.
+    """
+    scopes: list[tuple[str, str, list[dict]]] = []
+    for job_id, job in (doc.get("jobs") or {}).items():
+        if isinstance(job, dict):
+            steps = [s for s in (job.get("steps") or []) if isinstance(s, dict)]
+            if steps:
+                scopes.append((rel, f"job {job_id}", steps))
+    runs = doc.get("runs") or {}
+    if isinstance(runs, dict):
+        steps = [s for s in (runs.get("steps") or []) if isinstance(s, dict)]
+        if steps:
+            scopes.append((rel, "composite runs", steps))
+    return scopes
+
+
+def _scopes() -> list[tuple[str, str, list[dict]]]:
+    scopes: list[tuple[str, str, list[dict]]] = []
     for path in _yaml_files():
-        if _rel(path) in UNPARSEABLE:
+        rel = _rel(path)
+        if rel in UNPARSEABLE:
             continue
         try:
             doc = yaml.safe_load(path.read_text())
         except yaml.YAMLError as exc:
             pytest.fail(
-                f"{_rel(path)} is not valid YAML ({exc.__class__.__name__}) and is "
-                f"not in UNPARSEABLE: {exc}"
+                f"{rel} is not valid YAML ({exc.__class__.__name__}) and is not "
+                f"in UNPARSEABLE: {exc}"
             )
         if not isinstance(doc, dict):
             continue
-        steps = _steps(doc)
-        for step in steps:
-            if UPLOAD_ACTION in str(step.get("uses", "")):
-                found.append((path, step, steps))
-    return found
+        scopes.extend(_scopes_from_doc(rel, doc))
+    return scopes
 
 
-def _rel(path: Path) -> str:
-    return str(path.relative_to(ROOT))
+def _is_upload(step: dict) -> bool:
+    return UPLOAD_ACTION in str(step.get("uses", ""))
+
+
+def _with(step: dict) -> dict:
+    value = step.get("with")
+    return value if isinstance(value, dict) else {}
 
 
 def _artifact_name(step: dict) -> str:
-    return str((step.get("with") or {}).get("name", ""))
+    return str(_with(step).get("name", ""))
 
 
-def _is_retry(step: dict) -> bool:
-    return "(retry)" in str(step.get("name", ""))
+def _artifact_path(step: dict) -> str:
+    """Normalised so a multi-line `path:` block compares equal across steps."""
+    raw = str(_with(step).get("path", ""))
+    return "\n".join(line.strip() for line in raw.splitlines() if line.strip())
+
+
+def _retry_target(step: dict) -> str | None:
+    """The step id this upload claims to retry, or None if it guards on nothing."""
+    match = OUTCOME_GUARD_RE.search(str(step.get("if", "")))
+    return match.group(1) if match else None
+
+
+def _classify(steps: list[dict]) -> tuple[list[dict], dict[str, list[dict]]]:
+    """Split a scope's uploads into (first_attempts, retries_by_target_id).
+
+    A retry must guard on the outcome of another *upload* step in this same
+    scope. An upload guarded on some non-upload step's outcome is treated as a
+    first attempt, so it still has to prove it has a retry of its own.
+    """
+    uploads = [s for s in steps if _is_upload(s)]
+    upload_ids = {s.get("id") for s in uploads if s.get("id")}
+
+    retries: dict[str, list[dict]] = {}
+    first_attempts: list[dict] = []
+    for step in uploads:
+        target = _retry_target(step)
+        if target and target in upload_ids:
+            retries.setdefault(target, []).append(step)
+        else:
+            first_attempts.append(step)
+    return first_attempts, retries
+
+
+def _live_first_attempts() -> list[tuple[str, str, dict, dict[str, list[dict]]]]:
+    """Every non-exempt first-attempt upload, with its scope's retry index."""
+    live = []
+    for rel, scope, steps in _scopes():
+        first_attempts, retries = _classify(steps)
+        for step in first_attempts:
+            if (rel, _artifact_name(step)) in EXEMPT:
+                continue
+            live.append((rel, scope, step, retries))
+    return live
+
+
+def _label(rel: str, scope: str, step: dict) -> str:
+    return f"{rel} [{scope}] '{step.get('name') or step.get('uses')}'"
 
 
 def test_no_new_unparseable_workflow_yaml():
@@ -129,47 +207,74 @@ def test_no_new_unparseable_workflow_yaml():
     )
 
 
-def test_the_guard_actually_finds_uploads():
-    """A scan that silently matches nothing would pass every assertion below."""
-    assert len(_uploads()) >= 10
+def test_the_guard_actually_finds_uploads_and_retries():
+    """A scan that silently matched nothing would pass every assertion below.
+
+    Asserts on both halves: if the retry-classification broke, `retries` would
+    empty out while `first_attempts` doubled, and the pairing test would then be
+    asserting over the wrong set.
+    """
+    scopes = _scopes()
+    assert len(scopes) > 50, "scope discovery collapsed"
+
+    total_first, total_retries = 0, 0
+    for _, _, steps in scopes:
+        first_attempts, retries = _classify(steps)
+        total_first += len(first_attempts)
+        total_retries += sum(len(v) for v in retries.values())
+    assert total_first >= 10, f"only {total_first} first-attempt uploads found"
+    assert total_retries >= 10, f"only {total_retries} retry uploads found"
 
 
-def test_every_gating_upload_has_a_retry_attempt():
-    missing = []
-    for path, step, steps in _uploads():
-        if _is_retry(step):
-            continue
-        key = (_rel(path), _artifact_name(step))
-        if key in EXEMPT:
-            continue
+def test_every_gating_upload_has_a_matching_retry_upload():
+    """The retry must be a real upload of the same artifact, in the same scope."""
+    problems = []
+    for rel, scope, step, retries in _live_first_attempts():
+        where = _label(rel, scope, step)
         step_id = step.get("id")
         if not step_id:
-            missing.append(
-                f"{_rel(path)}: '{step.get('name')}' has no `id` to retry on"
+            problems.append(f"{where}: no `id`, so nothing can guard a retry on it")
+            continue
+
+        companions = retries.get(step_id, [])
+        if not companions:
+            problems.append(
+                f"{where}: no `{UPLOAD_ACTION}` step in this scope is guarded on "
+                f"steps.{step_id}.outcome == 'failure'"
             )
             continue
-        guard = f"steps.{step_id}.outcome == 'failure'"
-        if not any(guard in str(other.get("if", "")) for other in steps):
-            missing.append(
-                f"{_rel(path)}: '{step.get('name')}' has no retry step guarded on {guard}"
-            )
-    assert not missing, (
-        "Artifact uploads on gating paths must be paired with a retry attempt "
-        "(see .github/actions or any conformance-*.yaml for the pattern), or "
-        "added to EXEMPT in this test with a reason:\n  " + "\n  ".join(missing)
+
+        # A companion that uploads a different artifact is not a retry of this one.
+        for companion in companions:
+            if _artifact_name(companion) != _artifact_name(step):
+                problems.append(
+                    f"{where}: its retry uploads artifact "
+                    f"'{_artifact_name(companion)}', not '{_artifact_name(step)}'"
+                )
+            if _artifact_path(companion) != _artifact_path(step):
+                problems.append(
+                    f"{where}: its retry uploads a different path "
+                    f"({_artifact_path(companion)!r} != {_artifact_path(step)!r})"
+                )
+            if companion is step:
+                problems.append(f"{where}: a step cannot be its own retry")
+
+    assert not problems, (
+        "Every artifact upload on a gating path needs a companion "
+        f"`{UPLOAD_ACTION}` step, in the same job/composite, guarded on the first "
+        "attempt's outcome and uploading the same name and path (see any "
+        "conformance-*.yaml for the pattern) — or an EXEMPT entry with a "
+        "reason:\n  " + "\n  ".join(problems)
     )
 
 
 def test_first_attempt_never_fails_the_job_before_the_retry_runs():
     """Without continue-on-error the job dies and the retry never executes."""
-    bad = []
-    for path, step, _ in _uploads():
-        if _is_retry(step):
-            continue
-        if (_rel(path), _artifact_name(step)) in EXEMPT:
-            continue
-        if step.get("continue-on-error") is not True:
-            bad.append(f"{_rel(path)}: '{step.get('name')}'")
+    bad = [
+        _label(rel, scope, step)
+        for rel, scope, step, _ in _live_first_attempts()
+        if step.get("continue-on-error") is not True
+    ]
     assert not bad, (
         "The first upload attempt must set `continue-on-error: true`, otherwise "
         "the job fails before its retry can run:\n  " + "\n  ".join(bad)
@@ -180,16 +285,111 @@ def test_retries_overwrite_so_a_partial_artifact_cannot_block_them():
     """A failed finalize can leave a same-named artifact behind; without
     overwrite the retry 409s on it and the hardening is worthless."""
     bad = []
-    for path, step, _ in _uploads():
-        if not _is_retry(step):
-            continue
-        if (step.get("with") or {}).get("overwrite") is not True:
-            bad.append(f"{_rel(path)}: '{step.get('name')}'")
+    for rel, scope, steps in _scopes():
+        _, retries = _classify(steps)
+        for companions in retries.values():
+            for companion in companions:
+                if _with(companion).get("overwrite") is not True:
+                    bad.append(_label(rel, scope, companion))
     assert not bad, "Retry attempts must set `overwrite: true`:\n  " + "\n  ".join(bad)
+
+
+def test_a_retry_is_not_identified_by_its_name():
+    """Regression: naming a step '(retry)' must not exempt it from validation.
+
+    Synthesised rather than read off disk, because the point is what the
+    classifier does with a shape the repo should never contain.
+    """
+    steps = [
+        {
+            "name": "Upload something (retry)",
+            "uses": f"{UPLOAD_ACTION}@v7",
+            "with": {"name": "thing", "path": "thing/"},
+        }
+    ]
+    first_attempts, retries = _classify(steps)
+    assert not retries, "a name substring must not make a step a retry"
+    assert len(first_attempts) == 1, (
+        "a step named '(retry)' with no outcome guard is an unretried first "
+        "attempt and must still be validated"
+    )
+
+
+def test_a_companion_guarded_on_a_non_upload_step_is_not_a_retry():
+    """Regression: the guard must require the retry to be an upload of its own."""
+    steps = [
+        {
+            "id": "build",
+            "name": "Build",
+            "run": "make",
+        },
+        {
+            "id": "upload",
+            "name": "Upload",
+            "continue-on-error": True,
+            "uses": f"{UPLOAD_ACTION}@v7",
+            "with": {"name": "thing", "path": "thing/"},
+        },
+        {
+            # Guards on the right outcome but is not an upload at all.
+            "name": "Tell someone it failed",
+            "if": "steps.upload.outcome == 'failure'",
+            "run": "echo oh no",
+        },
+    ]
+    first_attempts, retries = _classify(steps)
+    assert [s["id"] for s in first_attempts] == ["upload"]
+    assert not retries, "a non-upload step must not count as the retry"
+
+
+def test_a_retry_in_another_job_does_not_satisfy_the_pairing():
+    """`steps.<id>` only resolves within one job, so a retry in a sibling job is
+    not a retry at all — it would reference an id that does not exist there."""
+    doc = {
+        "jobs": {
+            "builder": {
+                "steps": [
+                    {
+                        "id": "upload",
+                        "name": "Upload",
+                        "continue-on-error": True,
+                        "uses": f"{UPLOAD_ACTION}@v7",
+                        "with": {"name": "thing", "path": "thing/"},
+                    }
+                ]
+            },
+            "elsewhere": {
+                "steps": [
+                    {
+                        "name": "Upload (retry)",
+                        "if": "steps.upload.outcome == 'failure'",
+                        "uses": f"{UPLOAD_ACTION}@v7",
+                        "with": {"name": "thing", "path": "thing/", "overwrite": True},
+                    }
+                ]
+            },
+        }
+    }
+    scopes = _scopes_from_doc("synthetic.yaml", doc)
+    assert len(scopes) == 2, "jobs must be separate scopes"
+
+    by_scope = {scope: _classify(steps) for _, scope, steps in scopes}
+    # The uploading job has a first attempt and no retry of its own...
+    builder_first, builder_retries = by_scope["job builder"]
+    assert [s["id"] for s in builder_first] == ["upload"]
+    assert not builder_retries
+    # ...and the sibling job's step is itself an unpaired first attempt, because
+    # the id it guards on does not exist in its scope.
+    other_first, other_retries = by_scope["job elsewhere"]
+    assert len(other_first) == 1
+    assert not other_retries
 
 
 def test_exemptions_still_point_at_real_uploads():
     """A stale exemption would silently excuse a file that no longer uploads."""
-    live = {(_rel(p), _artifact_name(s)) for p, s, _ in _uploads() if not _is_retry(s)}
+    live = set()
+    for rel, _, steps in _scopes():
+        first_attempts, _ = _classify(steps)
+        live.update((rel, _artifact_name(s)) for s in first_attempts)
     stale = sorted(set(EXEMPT) - live)
     assert not stale, f"EXEMPT entries no longer match any upload step: {stale}"

--- a/.github/scripts/tests/test_artifact_upload_retry.py
+++ b/.github/scripts/tests/test_artifact_upload_retry.py
@@ -1,0 +1,195 @@
+"""Cross-file guard: artifact uploads on gating paths must retry.
+
+`actions/upload-artifact` treats the artifact service's finalize 403 as
+non-retryable and fails the step on the first occurrence, even though the bytes
+already landed. On a gating path that fails the job, fails the aggregate gate,
+and ejects the merge-queue entry — a full CI run wasted on a flake that a second
+attempt would have absorbed.
+
+This guard reads the workflow and composite-action YAML directly rather than
+trusting a checked-in list, so a newly added upload step fails here instead of
+silently reintroducing the flake. It is the same shape as the other cross-file
+guards in this suite that assert a property of the YAML outside .github/scripts/.
+
+(Deliberately avoids naming those sibling guards' scripts: this suite discovers
+call sites by grepping .github/ for a script's name, and a prose mention here
+would register this file as one of its callers.)
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+UPLOAD_ACTION = "actions/upload-artifact"
+
+# Uploads that do NOT need retry hardening, each with the reason it is exempt.
+# Keyed by (path suffix, artifact name) so an exemption cannot silently widen to
+# other uploads added to the same file later.
+EXEMPT = {
+    (
+        "workflows/daily-security-scan.yml",
+        "security-scan-raw-results",
+    ): "scheduled scan; nothing gates on it and there is no merge queue to eject",
+    (
+        "workflows/v3-readiness-check.yaml",
+        "v3-readiness-report",
+    ): "manually dispatched report; not on a PR or merge_group path",
+}
+
+# Files that are not valid YAML today, so their steps cannot be inspected.
+# This is a quarantine list, not an allowance: the test below asserts it does not
+# grow, and each entry is a bug to fix rather than a shape to copy.
+#
+# scheduled-trivy-scan.yml: the `read -r -d '' DESCRIPTION << DESC_EOF` heredoc
+# body sits at column 0, which terminates the enclosing `run: |` block scalar, so
+# the markdown after it parses as YAML (`**Service:**` reads as an alias). GitHub
+# cannot parse it either — it lists the workflow by path instead of by `name:`
+# and every run fails. It has no upload-artifact step, so nothing is skipped
+# here by quarantining it.
+UNPARSEABLE = {"workflows/scheduled-trivy-scan.yml"}
+
+
+def _yaml_files() -> list[Path]:
+    files = sorted((ROOT / "workflows").glob("*.y*ml"))
+    files += sorted((ROOT / "actions").glob("*/action.y*ml"))
+    return files
+
+
+def _steps(doc: dict) -> list[dict]:
+    """Every step in a workflow's jobs or a composite action's runs block."""
+    steps: list[dict] = []
+    for job in (doc.get("jobs") or {}).values():
+        if isinstance(job, dict):
+            steps.extend(s for s in (job.get("steps") or []) if isinstance(s, dict))
+    runs = doc.get("runs") or {}
+    if isinstance(runs, dict):
+        steps.extend(s for s in (runs.get("steps") or []) if isinstance(s, dict))
+    return steps
+
+
+def _unparseable() -> set[str]:
+    broken = set()
+    for path in _yaml_files():
+        try:
+            yaml.safe_load(path.read_text())
+        except yaml.YAMLError:
+            broken.add(_rel(path))
+    return broken
+
+
+def _uploads() -> list[tuple[Path, dict, list[dict]]]:
+    found = []
+    for path in _yaml_files():
+        if _rel(path) in UNPARSEABLE:
+            continue
+        try:
+            doc = yaml.safe_load(path.read_text())
+        except yaml.YAMLError as exc:
+            pytest.fail(
+                f"{_rel(path)} is not valid YAML ({exc.__class__.__name__}) and is "
+                f"not in UNPARSEABLE: {exc}"
+            )
+        if not isinstance(doc, dict):
+            continue
+        steps = _steps(doc)
+        for step in steps:
+            if UPLOAD_ACTION in str(step.get("uses", "")):
+                found.append((path, step, steps))
+    return found
+
+
+def _rel(path: Path) -> str:
+    return str(path.relative_to(ROOT))
+
+
+def _artifact_name(step: dict) -> str:
+    return str((step.get("with") or {}).get("name", ""))
+
+
+def _is_retry(step: dict) -> bool:
+    return "(retry)" in str(step.get("name", ""))
+
+
+def test_no_new_unparseable_workflow_yaml():
+    """Quarantine must shrink, never grow. An unparseable workflow is invisible
+    to every guard in this suite — and GitHub cannot run it either."""
+    broken = _unparseable()
+    assert broken <= UNPARSEABLE, (
+        "New unparseable workflow/action YAML (GitHub will fail these runs and no "
+        f"guard can inspect them): {sorted(broken - UNPARSEABLE)}"
+    )
+    fixed = sorted(UNPARSEABLE - broken)
+    assert not fixed, (
+        f"{fixed} now parses — remove it from UNPARSEABLE so its steps start "
+        f"being guarded."
+    )
+
+
+def test_the_guard_actually_finds_uploads():
+    """A scan that silently matches nothing would pass every assertion below."""
+    assert len(_uploads()) >= 10
+
+
+def test_every_gating_upload_has_a_retry_attempt():
+    missing = []
+    for path, step, steps in _uploads():
+        if _is_retry(step):
+            continue
+        key = (_rel(path), _artifact_name(step))
+        if key in EXEMPT:
+            continue
+        step_id = step.get("id")
+        if not step_id:
+            missing.append(
+                f"{_rel(path)}: '{step.get('name')}' has no `id` to retry on"
+            )
+            continue
+        guard = f"steps.{step_id}.outcome == 'failure'"
+        if not any(guard in str(other.get("if", "")) for other in steps):
+            missing.append(
+                f"{_rel(path)}: '{step.get('name')}' has no retry step guarded on {guard}"
+            )
+    assert not missing, (
+        "Artifact uploads on gating paths must be paired with a retry attempt "
+        "(see .github/actions or any conformance-*.yaml for the pattern), or "
+        "added to EXEMPT in this test with a reason:\n  " + "\n  ".join(missing)
+    )
+
+
+def test_first_attempt_never_fails_the_job_before_the_retry_runs():
+    """Without continue-on-error the job dies and the retry never executes."""
+    bad = []
+    for path, step, _ in _uploads():
+        if _is_retry(step):
+            continue
+        if (_rel(path), _artifact_name(step)) in EXEMPT:
+            continue
+        if step.get("continue-on-error") is not True:
+            bad.append(f"{_rel(path)}: '{step.get('name')}'")
+    assert not bad, (
+        "The first upload attempt must set `continue-on-error: true`, otherwise "
+        "the job fails before its retry can run:\n  " + "\n  ".join(bad)
+    )
+
+
+def test_retries_overwrite_so_a_partial_artifact_cannot_block_them():
+    """A failed finalize can leave a same-named artifact behind; without
+    overwrite the retry 409s on it and the hardening is worthless."""
+    bad = []
+    for path, step, _ in _uploads():
+        if not _is_retry(step):
+            continue
+        if (step.get("with") or {}).get("overwrite") is not True:
+            bad.append(f"{_rel(path)}: '{step.get('name')}'")
+    assert not bad, "Retry attempts must set `overwrite: true`:\n  " + "\n  ".join(bad)
+
+
+def test_exemptions_still_point_at_real_uploads():
+    """A stale exemption would silently excuse a file that no longer uploads."""
+    live = {(_rel(p), _artifact_name(s)) for p, s, _ in _uploads() if not _is_retry(s)}
+    stale = sorted(set(EXEMPT) - live)
+    assert not stale, f"EXEMPT entries no longer match any upload step: {stale}"

--- a/.github/scripts/tests/test_sdk_review_approve.py
+++ b/.github/scripts/tests/test_sdk_review_approve.py
@@ -40,6 +40,15 @@ def verdict_comment(verdict: str = "READY_TO_MERGE", head: str = HEAD) -> str:
     )
 
 
+def summary_comment(
+    comment_id: int,
+    login: str = "mothership-ai[bot]",
+    body: str = "<!-- SDK_REVIEW -->",
+) -> dict:
+    """A verdict-summary list entry as the issues comments API returns it."""
+    return {"id": comment_id, "body": body, "user": {"login": login}}
+
+
 def ok(stdout: str = "") -> subprocess.CompletedProcess:
     return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
 
@@ -121,7 +130,7 @@ def base_gh(
     gh.on(is_head_lookup, ok(HEAD + "\n"))
     gh.on(
         lambda a: a[2] == f"repos/{REPO}/issues/{PR}/comments",
-        ok(json.dumps([[{"id": 5, "body": "<!-- SDK_REVIEW -->"}]])),
+        ok(json.dumps([[summary_comment(5)]])),
     )
     gh.on(
         lambda a: a[2] == f"repos/{REPO}/issues/{PR}" and "--jq" in a,
@@ -379,11 +388,51 @@ def test_newer_verdict_comment_supersedes_this_run(monkeypatch):
     gh = base_gh()
     gh.on(
         lambda a: a[2] == f"repos/{REPO}/issues/{PR}/comments",
-        ok(json.dumps([[{"id": 99, "body": "<!-- SDK_REVIEW -->"}]])),
+        ok(json.dumps([[summary_comment(99)]])),
     )
     assert run_main(gh, monkeypatch, TRIGGERING_COMMENT_ID="5") == 0
     assert gh.called(is_approve) == []
     assert gh.called(is_status) == []
+
+
+def test_forged_verdict_comment_from_another_author_does_not_supersede(monkeypatch):
+    """A non-bot comment carrying the SDK_REVIEW marker is not a verdict.
+
+    Without the author check, an attacker (or a compromised non-atlan-ci token)
+    could post a forged `<!-- SDK_REVIEW -->` comment with a high id and have it
+    treated as the newest verdict — altering the supersede decision the script
+    makes about the genuine bot verdict.
+    """
+    gh = base_gh()
+    gh.on(
+        lambda a: a[2] == f"repos/{REPO}/issues/{PR}/comments",
+        ok(json.dumps([[summary_comment(5), summary_comment(99, login="evil-doer")]])),
+    )
+    # The forged id=99 comment must be ignored, so the triggering comment (id=5)
+    # remains the newest verdict and the run proceeds to approve.
+    assert run_main(gh, monkeypatch, TRIGGERING_COMMENT_ID="5") == 0
+    assert len(gh.called(is_approve)) == 1
+
+
+def test_markerless_bot_comment_is_not_a_verdict():
+    gh = base_gh()
+    gh.on(
+        lambda a: a[2] == f"repos/{REPO}/issues/{PR}/comments",
+        ok(
+            json.dumps(
+                [
+                    [
+                        {
+                            "id": 9,
+                            "body": "no marker",
+                            "user": {"login": "mothership-ai[bot]"},
+                        }
+                    ]
+                ]
+            )
+        ),
+    )
+    assert approve.Client(REPO, PR, gh).newest_summary_comment_id() == 0
 
 
 def test_existing_bot_approval_is_not_duplicated(monkeypatch):
@@ -444,7 +493,7 @@ def slow_gh(labels: list[str] | None = None, **kwargs) -> FakeGH:
     gh = base_gh(labels=labels, **kwargs)
     gh.on(
         lambda a: a[2] == f"repos/{REPO}/issues/{PR}/comments",
-        ok(json.dumps([[{"id": 5, "body": verdict_comment()}]])),
+        ok(json.dumps([[summary_comment(5, body=verdict_comment())]])),
     )
     return gh
 
@@ -469,8 +518,8 @@ def test_slow_path_picks_the_newest_summary_not_the_last_in_page_order():
             json.dumps(
                 [
                     [
-                        {"id": 9, "body": verdict_comment("READY_TO_MERGE")},
-                        {"id": 4, "body": verdict_comment("NEEDS_FIXES")},
+                        summary_comment(9, body=verdict_comment("READY_TO_MERGE")),
+                        summary_comment(4, body=verdict_comment("NEEDS_FIXES")),
                     ]
                 ]
             )

--- a/.github/scripts/tests/test_sdk_review_approve.py
+++ b/.github/scripts/tests/test_sdk_review_approve.py
@@ -1,0 +1,439 @@
+"""Tests for the SDK review verdict stamper.
+
+The regression these pin: a READY_TO_MERGE verdict whose approval POST fails
+must NOT leave a green `sdk-review` commit status behind. That combination —
+green check, no approving review — is what made a rate-limited approval look
+like a completed review on the PR.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+SPEC = importlib.util.spec_from_file_location(
+    "sdk_review_approve", Path(__file__).resolve().parents[1] / "sdk_review_approve.py"
+)
+approve = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(approve)
+
+
+REPO = "atlanhq/application-sdk"
+PR = "7"
+HEAD = "a2f276a06384ad38ba3e2e96820a313ed3859db2"
+OTHER = "51c160b06a2a350289c7d779f4ab887503f98685"
+
+RATE_LIMIT_STDERR = "gh: API rate limit exceeded for user ID 62283865. (HTTP 403)"
+
+
+def verdict_comment(verdict: str = "READY_TO_MERGE", head: str = HEAD) -> str:
+    return (
+        "<!-- SDK_REVIEW -->\n"
+        f"<!-- VERDICT: {verdict} -->\n"
+        f"<!-- REVIEWED_HEAD: {head} -->\n"
+        "## SDK Review (mothership)\n"
+    )
+
+
+def ok(stdout: str = "") -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
+
+
+def fail(stderr: str, code: int = 1) -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(
+        args=[], returncode=code, stdout="", stderr=stderr
+    )
+
+
+class FakeGH:
+    """Records every `gh` invocation and answers from registered matchers."""
+
+    def __init__(self) -> None:
+        self.calls: list[list[str]] = []
+        self.tokens: list[str | None] = []
+        self.matchers: list[tuple] = []
+
+    def on(self, predicate, response) -> None:
+        """Register a matcher. Later registrations override earlier ones, so a
+        test can re-point a path that `base_gh()` already stubbed."""
+        self.matchers.append((predicate, response))
+
+    def __call__(self, argv, **kwargs):
+        self.calls.append(list(argv))
+        env = kwargs.get("env") or {}
+        self.tokens.append(env.get("GH_TOKEN"))
+        for predicate, response in reversed(self.matchers):
+            if predicate(argv):
+                return response() if callable(response) else response
+        return ok()
+
+    # --- assertions helpers ---
+
+    def called(self, predicate) -> list[list[str]]:
+        return [argv for argv in self.calls if predicate(argv)]
+
+
+def is_approve(argv) -> bool:
+    return (
+        argv[1] == "api"
+        and argv[2] == f"repos/{REPO}/pulls/{PR}/reviews"
+        and "POST" in argv
+    )
+
+
+def is_review_list(argv) -> bool:
+    return (
+        argv[1] == "api"
+        and argv[2] == f"repos/{REPO}/pulls/{PR}/reviews"
+        and "--paginate" in argv
+    )
+
+
+def is_status(argv) -> bool:
+    return argv[1] == "api" and argv[2].startswith(f"repos/{REPO}/statuses/")
+
+
+def is_head_lookup(argv) -> bool:
+    return argv[1] == "api" and argv[2] == f"repos/{REPO}/pulls/{PR}"
+
+
+def is_label_add(argv) -> bool:
+    return (
+        argv[1] == "api"
+        and argv[2] == f"repos/{REPO}/issues/{PR}/labels"
+        and "POST" in argv
+    )
+
+
+def is_rate_limit_probe(argv) -> bool:
+    return argv[1] == "api" and argv[2] == "rate_limit"
+
+
+def base_gh(
+    labels: list[str] | None = None, reviews: list[dict] | None = None
+) -> FakeGH:
+    gh = FakeGH()
+    gh.on(is_head_lookup, ok(HEAD + "\n"))
+    gh.on(
+        lambda a: a[2] == f"repos/{REPO}/issues/{PR}/comments",
+        ok(json.dumps([[{"id": 5, "body": "<!-- SDK_REVIEW -->"}]])),
+    )
+    gh.on(
+        lambda a: a[2] == f"repos/{REPO}/issues/{PR}" and "--jq" in a,
+        ok("\n".join(labels or [])),
+    )
+    gh.on(is_review_list, ok(json.dumps([reviews or []])))
+    return gh
+
+
+def run_main(gh: FakeGH, monkeypatch, **env) -> int:
+    defaults = {
+        "REPO": REPO,
+        "PR_NUMBER": PR,
+        "COMMENT_BODY": verdict_comment(),
+        "TRIGGERING_COMMENT_ID": "5",
+        "APPROVER_TOKEN": "pat-atlan-ci",
+        "GH_TOKEN": "app-token",
+        "APPROVE_MAX_ATTEMPTS": "3",
+        "APPROVE_MAX_WAIT_SECONDS": "120",
+    }
+    defaults.update(env)
+    for key, value in defaults.items():
+        monkeypatch.setenv(key, value)
+    slept: list[float] = []
+    code = approve.main(runner=gh, sleeper=slept.append, now=lambda: 1_000.0)
+    gh.slept = slept  # type: ignore[attr-defined]
+    return code
+
+
+# --- extract_verdict() ---------------------------------------------------
+
+
+def test_structured_marker_wins():
+    assert approve.extract_verdict(verdict_comment("NEEDS_FIXES")) == "NEEDS_FIXES"
+
+
+def test_prose_fallback_for_legacy_comments():
+    body = "## SDK Review\n\n### Verdict: READY TO MERGE\n\nsome prose"
+    assert approve.extract_verdict(body) == "READY_TO_MERGE"
+
+
+def test_prose_fallback_is_case_insensitive():
+    assert approve.extract_verdict("### verdict: needs human") == "NEEDS_HUMAN"
+
+
+def test_no_verdict_returns_none():
+    assert approve.extract_verdict("just a normal comment") is None
+
+
+def test_reviewed_head_extracted():
+    assert approve.extract_reviewed_head(verdict_comment()) == HEAD
+
+
+def test_missing_reviewed_head_returns_none():
+    assert approve.extract_reviewed_head("### Verdict: READY TO MERGE") is None
+
+
+# --- label_plan() --------------------------------------------------------
+
+
+def test_ready_adds_approved_and_clears_the_blocking_labels():
+    add, remove = approve.label_plan(
+        "READY_TO_MERGE", {"sdk-review-needs-human", "sdk-review-needs-rebase"}
+    )
+    assert add == {"sdk-review-approved"}
+    assert remove == {"sdk-review-needs-human", "sdk-review-needs-rebase"}
+
+
+def test_already_correct_labels_cost_nothing():
+    add, remove = approve.label_plan("READY_TO_MERGE", {"sdk-review-approved"})
+    assert add == set()
+    assert remove == set()
+
+
+def test_needs_human_clears_approved():
+    add, remove = approve.label_plan("NEEDS_HUMAN", {"sdk-review-approved"})
+    assert add == {"sdk-review-needs-human"}
+    assert remove == {"sdk-review-approved"}
+
+
+def test_needs_fixes_clears_verdict_labels_but_keeps_rebase():
+    add, remove = approve.label_plan(
+        "NEEDS_FIXES", {"sdk-review-approved", "sdk-review-needs-rebase"}
+    )
+    assert add == set()
+    assert remove == {"sdk-review-approved"}
+
+
+def test_legacy_labels_are_stripped_only_when_present():
+    _, remove = approve.label_plan("READY_TO_MERGE", {"test-sdk-review-approved"})
+    assert remove == {"test-sdk-review-approved"}
+    _, absent = approve.label_plan("READY_TO_MERGE", set())
+    assert absent == set()
+
+
+# --- status_for() / is_rate_limited() -----------------------------------
+
+
+@pytest.mark.parametrize(
+    "verdict,expected",
+    [
+        ("READY_TO_MERGE", "success"),
+        ("NEEDS_FIXES", "failure"),
+        ("NEEDS_HUMAN", "failure"),
+        ("BLOCKED", "failure"),
+        ("SOMETHING_NEW", "failure"),
+    ],
+)
+def test_status_state_per_verdict(verdict, expected):
+    assert approve.status_for(verdict)[0] == expected
+
+
+def test_rate_limit_detected_from_gh_stderr():
+    assert approve.is_rate_limited(RATE_LIMIT_STDERR)
+    assert approve.is_rate_limited("You have exceeded a secondary rate limit")
+    assert not approve.is_rate_limited("gh: Not Found (HTTP 404)")
+
+
+# --- post_approval_with_retry() -----------------------------------------
+
+
+def test_approval_succeeds_first_try_without_sleeping():
+    gh = base_gh()
+    client = approve.Client(REPO, PR, gh)
+    slept: list[float] = []
+    assert approve.post_approval_with_retry(
+        client, HEAD, "pat", 3, 120, sleeper=slept.append, now=lambda: 0.0
+    )
+    assert slept == []
+    assert len(gh.called(is_approve)) == 1
+
+
+def test_transient_failure_is_retried_then_succeeds():
+    gh = base_gh()
+    attempts = {"n": 0}
+
+    def flaky():
+        attempts["n"] += 1
+        return (
+            fail("gh: Internal Server Error (HTTP 500)") if attempts["n"] == 1 else ok()
+        )
+
+    gh.on(is_approve, flaky)
+    client = approve.Client(REPO, PR, gh)
+    slept: list[float] = []
+    assert approve.post_approval_with_retry(
+        client, HEAD, "pat", 3, 120, sleeper=slept.append, now=lambda: 0.0
+    )
+    assert slept == [5.0]
+
+
+def test_primary_quota_beyond_budget_fails_fast_without_sleeping():
+    """The whole point: don't hold a runner for an hour-away reset."""
+    gh = base_gh()
+    gh.on(is_approve, fail(RATE_LIMIT_STDERR, code=1))
+    gh.on(is_rate_limit_probe, ok("3600"))  # resets 3600s after now=0
+    client = approve.Client(REPO, PR, gh)
+    slept: list[float] = []
+    assert not approve.post_approval_with_retry(
+        client, HEAD, "pat", 3, 120, sleeper=slept.append, now=lambda: 0.0
+    )
+    assert slept == []
+    assert len(gh.called(is_approve)) == 1
+
+
+def test_secondary_rate_limit_inside_budget_waits_for_reset():
+    gh = base_gh()
+    attempts = {"n": 0}
+
+    def limited():
+        attempts["n"] += 1
+        return fail(RATE_LIMIT_STDERR) if attempts["n"] == 1 else ok()
+
+    gh.on(is_approve, limited)
+    gh.on(is_rate_limit_probe, ok("30"))  # 30s away, inside the 120s budget
+    client = approve.Client(REPO, PR, gh)
+    slept: list[float] = []
+    assert approve.post_approval_with_retry(
+        client, HEAD, "pat", 3, 120, sleeper=slept.append, now=lambda: 0.0
+    )
+    assert slept == [32.0]  # reset + 2s so the window has rolled over
+
+
+def test_exhausting_attempts_returns_false():
+    gh = base_gh()
+    gh.on(is_approve, fail("gh: Internal Server Error (HTTP 500)"))
+    client = approve.Client(REPO, PR, gh)
+    assert not approve.post_approval_with_retry(
+        client, HEAD, "pat", 2, 120, sleeper=lambda _: None, now=lambda: 0.0
+    )
+    assert len(gh.called(is_approve)) == 2
+
+
+# --- main(): the ordering guarantee -------------------------------------
+
+
+def test_failed_approval_leaves_status_unset(monkeypatch):
+    gh = base_gh()
+    gh.on(is_approve, fail(RATE_LIMIT_STDERR))
+    gh.on(is_rate_limit_probe, ok("999999"))
+    assert run_main(gh, monkeypatch) == 1
+    assert gh.called(is_status) == [], "a failed approval must not go green"
+
+
+def test_successful_approval_sets_status_after_approving(monkeypatch):
+    gh = base_gh()
+    assert run_main(gh, monkeypatch) == 0
+    order = [
+        "approve" if is_approve(a) else "status"
+        for a in gh.calls
+        if is_approve(a) or is_status(a)
+    ]
+    assert order == ["approve", "status"]
+
+
+def test_approve_uses_the_pat_and_everything_else_the_app_token(monkeypatch):
+    gh = base_gh()
+    assert run_main(gh, monkeypatch) == 0
+    pat_calls = [
+        argv for argv, token in zip(gh.calls, gh.tokens) if token == "pat-atlan-ci"
+    ]
+    assert len(pat_calls) == 1, "atlan-ci quota must be spent on exactly one request"
+    assert is_approve(pat_calls[0])
+
+
+def test_non_ready_verdict_sets_failure_status_and_never_approves(monkeypatch):
+    gh = base_gh()
+    assert run_main(gh, monkeypatch, COMMENT_BODY=verdict_comment("NEEDS_FIXES")) == 0
+    assert gh.called(is_approve) == []
+    (status,) = gh.called(is_status)
+    assert "state=failure" in status
+
+
+def test_superseded_ready_verdict_dismisses_the_stale_bot_approval(monkeypatch):
+    stale = {
+        "id": 42,
+        "state": "APPROVED",
+        "user": {"login": "atlan-ci"},
+        "body": approve.APPROVAL_SIGNATURE + " READY TO MERGE.",
+    }
+    gh = base_gh(reviews=[stale])
+    assert run_main(gh, monkeypatch, COMMENT_BODY=verdict_comment("NEEDS_FIXES")) == 0
+    assert gh.called(lambda a: "dismissals" in a[2])
+
+
+def test_head_moved_since_review_skips_every_stamp(monkeypatch):
+    gh = base_gh()
+    assert run_main(gh, monkeypatch, COMMENT_BODY=verdict_comment(head=OTHER)) == 0
+    assert gh.called(is_approve) == []
+    assert gh.called(is_status) == []
+    assert gh.called(is_label_add) == []
+
+
+def test_newer_verdict_comment_supersedes_this_run(monkeypatch):
+    gh = base_gh()
+    gh.on(
+        lambda a: a[2] == f"repos/{REPO}/issues/{PR}/comments",
+        ok(json.dumps([[{"id": 99, "body": "<!-- SDK_REVIEW -->"}]])),
+    )
+    assert run_main(gh, monkeypatch, TRIGGERING_COMMENT_ID="5") == 0
+    assert gh.called(is_approve) == []
+    assert gh.called(is_status) == []
+
+
+def test_existing_bot_approval_is_not_duplicated(monkeypatch):
+    existing = {
+        "id": 1,
+        "state": "APPROVED",
+        "user": {"login": "atlan-ci"},
+        "body": approve.APPROVAL_SIGNATURE + " READY TO MERGE.",
+    }
+    gh = base_gh(reviews=[existing])
+    assert run_main(gh, monkeypatch) == 0
+    assert gh.called(is_approve) == []
+    # The status still resolves — the stamp is idempotent, not skipped wholesale.
+    assert len(gh.called(is_status)) == 1
+
+
+def test_human_approval_does_not_count_as_the_bot_approval(monkeypatch):
+    human = {
+        "id": 2,
+        "state": "APPROVED",
+        "user": {"login": "cmgrote"},
+        "body": "lgtm",
+    }
+    gh = base_gh(reviews=[human])
+    assert run_main(gh, monkeypatch) == 0
+    assert len(gh.called(is_approve)) == 1
+
+
+def test_missing_approver_token_fails_loudly(monkeypatch):
+    gh = base_gh()
+    assert run_main(gh, monkeypatch, APPROVER_TOKEN="") == 1
+    assert gh.called(is_status) == []
+
+
+def test_unparseable_verdict_is_a_no_op(monkeypatch):
+    gh = base_gh()
+    assert run_main(gh, monkeypatch, COMMENT_BODY="hello") == 0
+    assert gh.calls == []
+
+
+def test_label_delete_404_is_tolerated(capsys):
+    gh = FakeGH()
+    gh.on(lambda a: "DELETE" in a, fail("gh: Not Found (HTTP 404)"))
+    approve.Client(REPO, PR, gh).remove_label("sdk-review-approved")
+    assert "::warning::" not in capsys.readouterr().out
+
+
+def test_label_write_failure_is_surfaced_not_swallowed(capsys):
+    """A token without `issues: write` must not fail silently."""
+    gh = FakeGH()
+    gh.on(is_label_add, fail("gh: Resource not accessible by integration (HTTP 403)"))
+    approve.Client(REPO, PR, gh).add_labels({"sdk-review-approved"})
+    assert "::warning::" in capsys.readouterr().out

--- a/.github/scripts/tests/test_sdk_review_approve.py
+++ b/.github/scripts/tests/test_sdk_review_approve.py
@@ -424,6 +424,122 @@ def test_unparseable_verdict_is_a_no_op(monkeypatch):
     assert gh.calls == []
 
 
+# --- slow path (sdk-review.yml) -----------------------------------------
+
+
+def slow_env(**overrides) -> dict:
+    """The slow path's configuration: fetch the summary, don't own the status."""
+    env = {
+        "COMMENT_BODY": "",
+        "EXPECTED_HEAD": HEAD,
+        "WRITE_STATUS": "false",
+        "REQUIRE_APPROVED_LABEL": "true",
+    }
+    env.update(overrides)
+    return env
+
+
+def slow_gh(labels: list[str] | None = None, **kwargs) -> FakeGH:
+    """Like base_gh, but the comment list carries a full verdict body."""
+    gh = base_gh(labels=labels, **kwargs)
+    gh.on(
+        lambda a: a[2] == f"repos/{REPO}/issues/{PR}/comments",
+        ok(json.dumps([[{"id": 5, "body": verdict_comment()}]])),
+    )
+    return gh
+
+
+def test_slow_path_reads_the_verdict_off_the_newest_comment(monkeypatch):
+    gh = slow_gh(labels=["sdk-review-approved"])
+    assert run_main(gh, monkeypatch, **slow_env()) == 0
+    assert len(gh.called(is_approve)) == 1
+
+
+def test_slow_path_does_not_write_the_commit_status(monkeypatch):
+    gh = slow_gh(labels=["sdk-review-approved"])
+    assert run_main(gh, monkeypatch, **slow_env()) == 0
+    assert gh.called(is_status) == [], "sdk-review.yml owns its own status writes"
+
+
+def test_slow_path_picks_the_newest_summary_not_the_last_in_page_order():
+    gh = FakeGH()
+    gh.on(
+        lambda a: a[2] == f"repos/{REPO}/issues/{PR}/comments",
+        ok(
+            json.dumps(
+                [
+                    [
+                        {"id": 9, "body": verdict_comment("READY_TO_MERGE")},
+                        {"id": 4, "body": verdict_comment("NEEDS_FIXES")},
+                    ]
+                ]
+            )
+        ),
+    )
+    body = approve.Client(REPO, PR, gh).latest_summary_body()
+    assert approve.extract_verdict(body) == "READY_TO_MERGE"
+
+
+def test_slow_path_skips_when_no_summary_comment_exists(monkeypatch):
+    gh = base_gh()
+    gh.on(
+        lambda a: a[2] == f"repos/{REPO}/issues/{PR}/comments",
+        ok(json.dumps([[]])),
+    )
+    assert run_main(gh, monkeypatch, **slow_env()) == 0
+    assert gh.called(is_approve) == []
+
+
+def test_slow_path_refuses_when_the_approved_label_was_already_stripped(monkeypatch):
+    """dismiss-on-human / downgrade / reset-on-push all clear the label."""
+    gh = slow_gh(labels=[])
+    assert run_main(gh, monkeypatch, **slow_env()) == 0
+    assert gh.called(is_approve) == []
+
+
+def test_label_guard_reads_the_snapshot_not_the_label_it_just_wrote(monkeypatch):
+    """The shell version added the label, then read it back and always passed.
+
+    The guard must consult the state from BEFORE this run reconciled labels, or
+    it can never fire and the slow path re-approves after a downgrade.
+    """
+    gh = slow_gh(labels=[])
+    assert run_main(gh, monkeypatch, **slow_env()) == 0
+    # It still reconciles labels (that part is unconditional)...
+    assert gh.called(is_label_add)
+    # ...but the freshly-added label must not satisfy its own guard.
+    assert gh.called(is_approve) == []
+
+
+def test_fast_path_does_not_require_the_label(monkeypatch):
+    """The fast path is the one that STAMPS the label, so it cannot demand it."""
+    gh = base_gh(labels=[])
+    assert run_main(gh, monkeypatch) == 0
+    assert len(gh.called(is_approve)) == 1
+
+
+def test_slow_path_rescues_a_fast_path_that_labelled_but_failed_to_approve(monkeypatch):
+    """Fast path wrote the label then took a 403 — the label still stands, so
+    the slow path is entitled to post the approval it could not."""
+    gh = slow_gh(labels=["sdk-review-approved"], reviews=[])
+    assert run_main(gh, monkeypatch, **slow_env()) == 0
+    assert len(gh.called(is_approve)) == 1
+
+
+def test_slow_path_head_moved_since_dispatch_skips(monkeypatch):
+    gh = slow_gh(labels=["sdk-review-approved"])
+    assert run_main(gh, monkeypatch, **slow_env(EXPECTED_HEAD=OTHER)) == 0
+    assert gh.called(is_approve) == []
+    assert gh.called(is_label_add) == []
+
+
+def test_slow_path_skips_freshness_check_since_it_fetched_the_newest(monkeypatch):
+    """TRIGGERING_COMMENT_ID is meaningless when we just read the newest."""
+    gh = slow_gh(labels=["sdk-review-approved"])
+    assert run_main(gh, monkeypatch, **slow_env(), TRIGGERING_COMMENT_ID="0") == 0
+    assert len(gh.called(is_approve)) == 1
+
+
 def test_label_delete_404_is_tolerated(capsys):
     gh = FakeGH()
     gh.on(lambda a: "DELETE" in a, fail("gh: Not Found (HTTP 404)"))

--- a/.github/scripts/tests/test_sdk_review_approve.py
+++ b/.github/scripts/tests/test_sdk_review_approve.py
@@ -314,6 +314,37 @@ def test_secondary_rate_limit_inside_budget_waits_for_reset():
     assert slept == [32.0]  # reset + 2s so the window has rolled over
 
 
+def test_secondary_rate_limit_ignores_the_distant_primary_reset():
+    """A secondary throttle must wait its short window, not the hourly core reset.
+
+    Regression: `rate_limit_reset()` reads `.resources.core.reset` — the primary
+    window. A secondary limit firing while that reset is far away must NOT be
+    failed fast against it; it should retry on a bounded delay and succeed.
+    """
+    gh = base_gh()
+    attempts = {"n": 0}
+
+    def limited():
+        attempts["n"] += 1
+        # True secondary-limit stderr, and the primary core reset is 3600s away.
+        return (
+            fail("You have exceeded a secondary rate limit. (HTTP 403)")
+            if attempts["n"] == 1
+            else ok()
+        )
+
+    gh.on(is_approve, limited)
+    gh.on(is_rate_limit_probe, ok("3600"))  # distant primary reset — irrelevant
+    client = approve.Client(REPO, PR, gh)
+    slept: list[float] = []
+    assert approve.post_approval_with_retry(
+        client, HEAD, "pat", 3, 120, sleeper=slept.append, now=lambda: 0.0
+    )
+    # Waited the bounded secondary delay (15s), NOT the 3600s primary reset.
+    assert slept == [15.0]
+    assert len(gh.called(is_approve)) == 2
+
+
 def test_exhausting_attempts_returns_false():
     gh = base_gh()
     gh.on(is_approve, fail("gh: Internal Server Error (HTTP 500)"))
@@ -333,6 +364,18 @@ def test_failed_approval_leaves_status_unset(monkeypatch):
     gh.on(is_rate_limit_probe, ok("999999"))
     assert run_main(gh, monkeypatch) == 1
     assert gh.called(is_status) == [], "a failed approval must not go green"
+
+
+def test_ready_verdict_with_failed_label_add_does_not_approve_or_go_green(monkeypatch):
+    """An approval without its `sdk-review-approved` label can never be
+    auto-dismissed on a later CI failure (the downgrade workflow gates on the
+    label) — so a failed label add must block the approval and the green status.
+    """
+    gh = base_gh()  # fast path: base_gh labels=[] → sdk-review-approved is in to_add
+    gh.on(is_label_add, fail("gh: Resource not accessible by integration (HTTP 403)"))
+    assert run_main(gh, monkeypatch) == 1
+    assert gh.called(is_approve) == [], "no approval without its label"
+    assert gh.called(is_status) == [], "status stays pending, not green"
 
 
 def test_successful_approval_sets_status_after_approving(monkeypatch):

--- a/.github/workflows/build-and-scan.yaml
+++ b/.github/workflows/build-and-scan.yaml
@@ -118,12 +118,30 @@ jobs:
           secrets: |
             git_token=${{ secrets.ORG_PAT_GITHUB }}
 
+      # `upload-artifact` classifies the artifact service's finalize 403 as
+      # non-retryable and fails on the first occurrence, even though the bytes
+      # already landed and the next attempt normally succeeds. That failed the
+      # job, which failed the aggregate gate, which ejected the merge-queue
+      # entry. So: retry once, and keep it fatal if both attempts fail —
+      # the trivy-scan job downloads this with no continue-on-error, so
+      # losing it fails that job anyway; failing here says why.
       - name: Upload image artifact
+        id: upload-image
+        continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: docker-image
           path: /tmp/image.tar
           retention-days: 7
+
+      - name: Upload image artifact (retry)
+        if: steps.upload-image.outcome == 'failure'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: docker-image
+          path: /tmp/image.tar
+          retention-days: 7
+          overwrite: true
 
   # ── Trivy scan ──────────────────────────────────────────────────────────────
   trivy-scan:
@@ -194,12 +212,30 @@ jobs:
             --output /tmp/trivy_results.json \
             "$IMAGE"
 
+      # `upload-artifact` classifies the artifact service's finalize 403 as
+      # non-retryable and fails on the first occurrence, even though the bytes
+      # already landed and the next attempt normally succeeds. That failed the
+      # job, which failed the aggregate gate, which ejected the merge-queue
+      # entry. So: retry once, and never fail the gate on it:
+      # the consumer already downloads this with continue-on-error.
       - name: Upload Trivy results
+        id: upload-trivy
+        continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: trivy-results
           path: /tmp/trivy_results.json
           retention-days: 7
+
+      - name: Upload Trivy results (retry)
+        if: steps.upload-trivy.outcome == 'failure'
+        continue-on-error: true
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: trivy-results
+          path: /tmp/trivy_results.json
+          retention-days: 7
+          overwrite: true
 
   # ── Security Gate — check Trivy results against allowlist ───────────────────
   security-gate:

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -101,13 +101,32 @@ jobs:
             echo "No SARIF output found." >> $GITHUB_STEP_SUMMARY
           fi
 
+      # `upload-artifact` classifies the artifact service's finalize 403 as
+      # non-retryable and fails on the first occurrence, even though the bytes
+      # already landed and the next attempt normally succeeds. That failed the
+      # job, which failed the aggregate gate, which ejected the merge-queue
+      # entry. So: retry once, and never fail the gate on it:
+      # results reach the Security tab via codeql-action/upload-sarif;
+      # this artifact is a debugging copy.
       - name: Upload SARIF as artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        id: upload-codeql-sarif
         if: always()
+        continue-on-error: true
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: codeql-sarif
           path: codeql-results/
           retention-days: 30
+
+      - name: Upload SARIF as artifact (retry)
+        if: steps.upload-codeql-sarif.outcome == 'failure'
+        continue-on-error: true
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: codeql-sarif
+          path: codeql-results/
+          retention-days: 30
+          overwrite: true
 
   # Code Quality Checks
   lint:

--- a/.github/workflows/conformance-ci.yaml
+++ b/.github/workflows/conformance-ci.yaml
@@ -82,12 +82,30 @@ jobs:
             --series C \
             --output ci.sarif
 
+      # `upload-artifact` classifies the artifact service's finalize 403 as
+      # non-retryable and fails on the first occurrence, even though the bytes
+      # already landed and the next attempt normally succeeds. That failed the
+      # job, which failed the aggregate gate, which ejected the merge-queue
+      # entry. So: retry once, and never fail the gate on it:
+      # the series verdict is the gate; this artifact only feeds the
+      # Security tab, whose consumer already tolerates absence.
       - name: "Upload SARIF artifact"
+        id: upload-sarif
         if: (steps.changes.outputs.relevant == 'true' || inputs.event_name == 'push') && !cancelled()
+        continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: conformance-ci-sarif
           path: ci.sarif
+
+      - name: "Upload SARIF artifact (retry)"
+        if: steps.upload-sarif.outcome == 'failure'
+        continue-on-error: true
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: conformance-ci-sarif
+          path: ci.sarif
+          overwrite: true
 
       - name: "Strip suppressed results for Security tab"
         if: ${{ inputs.upload-sarif && inputs.event_name == 'push' }}

--- a/.github/workflows/conformance-error-handling.yaml
+++ b/.github/workflows/conformance-error-handling.yaml
@@ -82,12 +82,30 @@ jobs:
             --series E \
             --output error-handling.sarif
 
+      # `upload-artifact` classifies the artifact service's finalize 403 as
+      # non-retryable and fails on the first occurrence, even though the bytes
+      # already landed and the next attempt normally succeeds. That failed the
+      # job, which failed the aggregate gate, which ejected the merge-queue
+      # entry. So: retry once, and never fail the gate on it:
+      # the series verdict is the gate; this artifact only feeds the
+      # Security tab, whose consumer already tolerates absence.
       - name: "Upload SARIF artifact"
+        id: upload-sarif
         if: (steps.changes.outputs.relevant == 'true' || inputs.event_name == 'push') && !cancelled()
+        continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: conformance-error-handling-sarif
           path: error-handling.sarif
+
+      - name: "Upload SARIF artifact (retry)"
+        if: steps.upload-sarif.outcome == 'failure'
+        continue-on-error: true
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: conformance-error-handling-sarif
+          path: error-handling.sarif
+          overwrite: true
 
       - name: "Strip suppressed results for Security tab"
         if: ${{ inputs.upload-sarif && inputs.event_name == 'push' }}

--- a/.github/workflows/conformance-logging.yaml
+++ b/.github/workflows/conformance-logging.yaml
@@ -95,12 +95,30 @@ jobs:
             --series L \
             --output logging.sarif
 
+      # `upload-artifact` classifies the artifact service's finalize 403 as
+      # non-retryable and fails on the first occurrence, even though the bytes
+      # already landed and the next attempt normally succeeds. That failed the
+      # job, which failed the aggregate gate, which ejected the merge-queue
+      # entry. So: retry once, and never fail the gate on it:
+      # the series verdict is the gate; this artifact only feeds the
+      # Security tab, whose consumer already tolerates absence.
       - name: "Upload SARIF artifact"
+        id: upload-sarif
         if: (steps.changes.outputs.relevant == 'true' || inputs.event_name == 'push') && !cancelled()
+        continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: conformance-logging-sarif
           path: logging.sarif
+
+      - name: "Upload SARIF artifact (retry)"
+        if: steps.upload-sarif.outcome == 'failure'
+        continue-on-error: true
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: conformance-logging-sarif
+          path: logging.sarif
+          overwrite: true
 
       - name: "Strip suppressed results for Security tab"
         if: ${{ inputs.upload-sarif && inputs.event_name == 'push' }}

--- a/.github/workflows/conformance-reusable.yaml
+++ b/.github/workflows/conformance-reusable.yaml
@@ -468,12 +468,31 @@ jobs:
           conformance-ref: ${{ inputs.conformance-ref }}
           needs-env: ${{ matrix.needs_env }}
 
+      # `upload-artifact` classifies the artifact service's finalize 403 as
+      # non-retryable and fails on the first occurrence, even though the bytes
+      # already landed and the next attempt normally succeeds. That failed the
+      # job, which failed the aggregate gate, which ejected the merge-queue
+      # entry. So: retry once, and never fail the gate on it:
+      # the series verdict is the gate; this artifact only feeds the
+      # Security tab, and conformance-upload-sarif.yaml already treats a
+      # missing artifact as an expected state.
       - name: "Upload SARIF artifact"
+        id: upload-sarif
         if: (steps.changes.outputs.relevant == 'true' || inputs.event_name == 'push' || inputs.force-all) && !cancelled()
+        continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: conformance-${{ matrix.slug }}-sarif
           path: ${{ matrix.slug }}.sarif
+
+      - name: "Upload SARIF artifact (retry)"
+        if: steps.upload-sarif.outcome == 'failure'
+        continue-on-error: true
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: conformance-${{ matrix.slug }}-sarif
+          path: ${{ matrix.slug }}.sarif
+          overwrite: true
 
   # ── Contract ledger append-only guard ─────────────────────────────────────
   # Verifies that no entry was deleted from the committed contract ledger and

--- a/.github/workflows/sdk-review-approve-on-verdict.yml
+++ b/.github/workflows/sdk-review-approve-on-verdict.yml
@@ -1,6 +1,6 @@
-# Post the atlan-ci approval the moment mothership-ai[bot] posts the
-# verdict comment, so the formal approval doesn't have to wait for the
-# sandbox to finish its post-verdict cleanup.
+# Stamp the SDK review verdict the moment mothership-ai[bot] posts it, so the
+# formal approval doesn't have to wait for the sandbox to finish its
+# post-verdict cleanup.
 #
 # Why this exists:
 #   `sdk-review.yml`'s "Approve PR as atlan-ci" step runs AFTER the
@@ -13,10 +13,17 @@
 #   atlan-ci approval appears.
 #
 #   `issue_comment: created` fires within seconds of the verdict comment
-#   landing. This workflow listens on that event, validates the
-#   commenter (mothership-ai[bot]) and the marker (`<!-- SDK_REVIEW -->`
-#   or the legacy `<!-- TEST_SDK_REVIEW -->`), extracts the verdict, and
-#   posts the approval directly. End-to-end: comment → approval in ~5s.
+#   landing. This workflow listens on that event and stamps directly.
+#   End-to-end: comment → approval in ~5s.
+#
+# Two tokens, deliberately:
+#   `atlan-ci` is a CODEOWNER, so the APPROVE review must carry that identity.
+#   Nothing else here does. Running the whole sequence on the `atlan-ci` PAT
+#   spent ~15 requests per fire against one 5,000/hr user quota shared with
+#   every other `atlan-ci` workflow; under a burst of concurrent review/resolve
+#   loops it ran out, and the APPROVE — last call in the sequence — took the
+#   403. So the fleet App token does everything, and ORG_PAT_GITHUB is spent
+#   on exactly one request.
 #
 # Idempotency:
 #   The approve step in `sdk-review.yml` still runs as a fallback after
@@ -24,13 +31,14 @@
 #   APPROVED review with the bot signature?" before posting, so we
 #   don't end up with two approvals on the same PR head.
 #
-# Side-effects:
+# Side-effects (all guarded, see .github/scripts/sdk_review_approve.py):
 #   labels        applied from the extracted verdict (single source of
 #                 truth, decoupled from PR-head orchestration)
 #   reviews       atlan-ci posts APPROVE only when verdict ==
 #                 READY_TO_MERGE
 #   commit-status sdk-review context flipped to success/failure based
-#                 on the verdict
+#                 on the verdict — and only AFTER the approval lands, so a
+#                 failed approval never leaves a green check behind
 
 name: SDK Review — approve on verdict comment
 
@@ -44,8 +52,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
-  statuses: write
 
 jobs:
   sdk-review-approve:
@@ -67,199 +73,40 @@ jobs:
     # may complete AFTER the later one and overwrite its label writes.
     # `cancel-in-progress: false` is required: we must not cancel the
     # newer run. GitHub queues the blocked run; by the time it starts, the
-    # freshness check below ensures it either acts on the newest comment or
-    # no-ops if a different verdict comment has since landed.
+    # freshness check in the script ensures it either acts on the newest
+    # comment or no-ops if a different verdict comment has since landed.
     concurrency:
       group: sdk-review-approve-${{ github.event.issue.number }}
       cancel-in-progress: false
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    # Headroom for APPROVE_MAX_WAIT_SECONDS of rate-limit backoff plus checkout.
+    timeout-minutes: 10
     steps:
+      - name: Checkout repo (for the stamp script)
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Mint fleet App token
+        # Carries its own rate-limit quota, independent of the `atlan-ci` user
+        # quota that ORG_PAT_GITHUB draws on. Needs `issues: write` as well as
+        # `pull_requests: write` — labels are an Issues-scope resource, and a
+        # token without it can approve a review while every label write fails.
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          app-id: ${{ secrets.FLEET_APP_ID }}
+          private-key: ${{ secrets.FLEET_APP_PRIVATE_KEY }}
+          owner: atlanhq
+          repositories: application-sdk
+
       - name: Extract verdict, apply labels, post approval
         env:
-          GH_TOKEN: ${{ secrets.ORG_PAT_GITHUB }}
+          # Everything except the APPROVE call.
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          # The APPROVE call only — atlan-ci is the CODEOWNER whose approval
+          # satisfies branch protection.
+          APPROVER_TOKEN: ${{ secrets.ORG_PAT_GITHUB }}
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.issue.number }}
           COMMENT_BODY: ${{ github.event.comment.body }}
           TRIGGERING_COMMENT_ID: ${{ github.event.comment.id }}
-        run: |
-          set -euo pipefail
-
-          # Extract the verdict. Prefer the structured marker
-          # `<!-- VERDICT: READY_TO_MERGE -->` (deterministic, formatting-
-          # invariant). Fall back to the `### Verdict:` grep for legacy
-          # comments that pre-date the structured marker.
-          #
-          # `|| true` is load-bearing here: under `set -euo pipefail`,
-          # grep returning 1 on a no-match (the structured marker isn't
-          # present yet in the verdict comment we're parsing) would kill
-          # the script BEFORE the prose-grep fallback below got a chance
-          # to run. Tolerate the no-match so we fall through cleanly.
-          VERDICT=$(printf '%s' "$COMMENT_BODY" | grep -oP '<!--\s*VERDICT:\s*\K[A-Z_]+' | head -1 || true)
-          if [ -z "$VERDICT" ]; then
-            RAW=$(printf '%s' "$COMMENT_BODY" | grep -oiP '###\s*Verdict:\s*\K[A-Z][A-Z _]+' | head -1 | tr '[:lower:]' '[:upper:]' || true)
-            VERDICT=$(printf '%s' "$RAW" | tr -s ' ' '_' | sed 's/_*$//')
-          fi
-          if [ -z "$VERDICT" ]; then
-            echo "::warning::Could not extract verdict from mothership-ai comment on PR #${PR_NUMBER}. Skipping."
-            exit 0
-          fi
-          echo "Detected verdict: '${VERDICT}'"
-
-          # Extract the sha that was actually reviewed from the structured
-          # marker `<!-- REVIEWED_HEAD: sha -->`. Uses the same idiom as
-          # VERDICT extraction above (`grep -oP '<!--\s*KEY:\s*\K...'`).
-          # A missing or empty marker means this is a legacy comment whose
-          # reviewed sha cannot be established; treat it as unverifiable
-          # rather than approving blind.
-          REVIEWED_HEAD=$(printf '%s' "$COMMENT_BODY" | grep -oP '<!--\s*REVIEWED_HEAD:\s*\K[0-9a-f]+' | head -1 || true)
-          if [ -z "$REVIEWED_HEAD" ]; then
-            echo "::warning::PR #${PR_NUMBER}: verdict comment has no REVIEWED_HEAD marker — cannot confirm which sha was reviewed; skipping all stamps."
-            exit 0
-          fi
-
-          # Resolve the PR HEAD so we can apply the commit status.
-          HEAD_SHA=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.head.sha')
-
-          # Guard: the verdict was computed for REVIEWED_HEAD. If the PR
-          # received a new push after the verdict comment was posted,
-          # REVIEWED_HEAD != HEAD_SHA. Do not stamp labels, commit status,
-          # or approval — that would bless unreviewed code.
-          if [ "$REVIEWED_HEAD" != "$HEAD_SHA" ]; then
-            echo "::warning::PR #${PR_NUMBER}: verdict was computed for ${REVIEWED_HEAD} but current head is ${HEAD_SHA} — skipping all stamps."
-            exit 0
-          fi
-
-          # S3 freshness check: verify the triggering comment is the NEWEST
-          # SDK_REVIEW summary on this PR. The concurrency group above
-          # serializes runs, but GitHub's queue is not event-time ordered —
-          # after waiting in queue, this run may execute after a NEWER
-          # verdict comment has already been processed. If so, skip to avoid
-          # overwriting a more-recent verdict's labels/status/approval.
-          #
-          # Fetch the id of the most-recent SDK_REVIEW comment using the
-          # same --paginate --slurp idiom used in sdk-review.yml. The
-          # TRIGGERING_COMMENT_ID is the event payload's comment id
-          # (integer). If a newer comment exists, its id will be larger
-          # (GitHub ids are monotonically increasing).
-          NEWEST_SDK_COMMENT_ID=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
-            --paginate --slurp 2>/dev/null \
-            | jq -r '[.[][] | select((.body | contains("<!-- SDK_REVIEW -->")) or (.body | contains("<!-- TEST_SDK_REVIEW -->")))] | last | .id // 0')
-          if [ "${NEWEST_SDK_COMMENT_ID:-0}" -gt "${TRIGGERING_COMMENT_ID:-0}" ]; then
-            echo "::notice::PR #${PR_NUMBER}: a newer SDK_REVIEW comment (id=${NEWEST_SDK_COMMENT_ID}) exists after this one (id=${TRIGGERING_COMMENT_ID}) — that run will/did process the final verdict; skipping."
-            exit 0
-          fi
-
-          # Strip the legacy `test-sdk-review-*` labels so PRs that
-          # pre-date the promotion don't end up wearing both prefixes.
-          for stale in "test-sdk-review-approved" "test-sdk-review-needs-human" "test-sdk-review-needs-rebase"; do
-            gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "$stale" 2>/dev/null || true
-          done
-
-          # Apply the canonical sdk-review-* labels based on verdict.
-          case "$VERDICT" in
-            "READY_TO_MERGE")
-              gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "sdk-review-approved" 2>/dev/null || true
-              gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "sdk-review-needs-human" 2>/dev/null || true
-              gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "sdk-review-needs-rebase" 2>/dev/null || true
-              ;;
-            "NEEDS_HUMAN")
-              gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "sdk-review-needs-human" 2>/dev/null || true
-              gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "sdk-review-approved" 2>/dev/null || true
-              ;;
-            "NEEDS_REBASE")
-              gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "sdk-review-needs-rebase" 2>/dev/null || true
-              gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "sdk-review-approved" 2>/dev/null || true
-              ;;
-            *)
-              gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "sdk-review-approved" 2>/dev/null || true
-              gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "sdk-review-needs-human" 2>/dev/null || true
-              ;;
-          esac
-
-          # Update the sdk-review commit status on the PR HEAD to
-          # reflect the verdict. The dispatch workflow sets this to
-          # pending; we resolve it here based on the actual outcome.
-          case "$VERDICT" in
-            "READY_TO_MERGE")
-              STATUS_STATE="success"; STATUS_DESC="Approved";;
-            "NEEDS_FIXES"|"BLOCKED")
-              STATUS_STATE="failure"; STATUS_DESC="Verdict: ${VERDICT}";;
-            *)
-              # NEEDS_HUMAN / NEEDS_REBASE / unknown — leave as failure
-              # so the merge gate stays visibly blocked.
-              STATUS_STATE="failure"; STATUS_DESC="Verdict: ${VERDICT}";;
-          esac
-          gh api "repos/${REPO}/statuses/${HEAD_SHA}" \
-            -X POST \
-            -f state="${STATUS_STATE}" \
-            -f context=sdk-review \
-            -f description="${STATUS_DESC}"
-
-          # Only READY_TO_MERGE gets a formal atlan-ci approval.
-          if [ "$VERDICT" != "READY_TO_MERGE" ]; then
-            echo "Verdict '${VERDICT}' is not READY TO MERGE — labels applied, no approval posted."
-            # S3: dismiss any existing bot approval. sdk-review-dismiss-on-human.yml
-            # only fires on HUMAN activity — it will not run here. When a newer
-            # verdict (e.g. NEEDS_FIXES after a second review of the same HEAD)
-            # supersedes a prior READY_TO_MERGE, the prior atlan-ci approval must be
-            # dismissed so the merge gate returns to requiring a fresh approval.
-            # Reuse the same selector used by sdk-review-dismiss-on-human.yml.
-            STALE_IDS=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews" \
-              --paginate --slurp 2>/dev/null \
-              | jq -r '[.[][] | select(.user.login == "atlan-ci" and .state == "APPROVED" and ((.body // "") | startswith("**SDK reviewer'"'"'s verdict:**")))] | .[].id' 2>/dev/null || true)
-            if [ -n "$STALE_IDS" ]; then
-              DISMISS_MSG="Newer SDK review verdict (${VERDICT}) supersedes the prior bot approval — auto-dismissing. Re-run \`@sdk-review\` when ready for re-approval."
-              for rid in $STALE_IDS; do
-                gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews/${rid}/dismissals" \
-                  -X PUT -f message="$DISMISS_MSG" 2>/dev/null || true
-                echo "Dismissed stale atlan-ci approval ${rid} (newer verdict: ${VERDICT})."
-              done
-            fi
-            exit 0
-          fi
-
-          # Idempotency guard: don't post a second atlan-ci approval if
-          # one already exists with our signature. Otherwise the slow-path
-          # approve step in sdk-review.yml would double-approve.
-          # --slurp collapses pages into one array so the count is a single
-          # number. --paginate --jq runs jq per page and concatenates numbers.
-          EXISTING=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews" \
-            --paginate --slurp 2>/dev/null \
-            | jq '[.[][] | select(.user.login == "atlan-ci" and .state == "APPROVED" and ((.body // "") | startswith("**SDK reviewer'"'"'s verdict:**")))] | length' 2>/dev/null || echo "0")
-          if [ "${EXISTING:-0}" != "0" ]; then
-            echo "atlan-ci has already approved PR #${PR_NUMBER} with the bot signature — skipping."
-            exit 0
-          fi
-
-          # NOTE: the leading line of the body is a STABLE SIGNATURE used
-          # by sdk-review-dismiss-on-human.yml to identify approvals
-          # posted by the bot. Keep this in sync with sdk-review.yml.
-          #
-          # S2: pin the review to commit_id=HEAD_SHA so GitHub associates
-          # the approval with the specific commit we verified. If a push
-          # lands between our REVIEWED_HEAD check and this POST, GitHub
-          # attaches the approval to the OLD (reviewed) commit rather than
-          # the new HEAD. Full protection against that window additionally
-          # requires `dismiss_stale_reviews_on_push` enabled on the main
-          # branch protection rule — that setting could not be verified from
-          # a non-admin token; confirm it is ON before relying on this guard.
-          # Residual TOCTOU: label writes above are PR-scoped (no sha
-          # param in the labels API). A push after label-write leaves a
-          # stale label until sdk-review-reset-on-push.yml clears it —
-          # this is the known irreducible window. Labels are display-only;
-          # branch protection gates on the review + commit status, both of
-          # which are sha-pinned.
-          # `gh pr review --approve` does not expose commit_id; use the
-          # raw API instead.
-          APPROVE_BODY=$(printf '%s\n' \
-            "**SDK reviewer's verdict:** READY TO MERGE." \
-            "" \
-            "Full review summary is in the comment posted on this PR." \
-            "")
-          gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews" \
-            -X POST \
-            -f commit_id="$HEAD_SHA" \
-            -f event=APPROVE \
-            -f body="$APPROVE_BODY"
-          echo "Approved PR #${PR_NUMBER} as atlan-ci (fast path, commit_id=${HEAD_SHA})."
+        run: python3 .github/scripts/sdk_review_approve.py

--- a/.github/workflows/sdk-review.yml
+++ b/.github/workflows/sdk-review.yml
@@ -1133,6 +1133,23 @@ jobs:
             });
             console.log(`Stamped starter comment ${commentId}: status=${finalStatus} cost=${finalCost} duration=${durationTxt} err=${errCode || '(none)'}`);
 
+      # Minted HERE rather than at the top of the job on purpose: App
+      # installation tokens expire after an hour, and this job blocks on the
+      # sandbox for up to 2h. A token minted before the review would be dead by
+      # the time we need it.
+      - name: Mint fleet App token
+        # Carries its own rate-limit quota, independent of the `atlan-ci` user
+        # quota ORG_PAT_GITHUB draws on. Needs `issues: write` as well as
+        # `pull_requests: write` — labels are an Issues-scope resource.
+        id: app-token
+        if: success() && steps.parse.outputs.pr_number != ''
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          app-id: ${{ secrets.FLEET_APP_ID }}
+          private-key: ${{ secrets.FLEET_APP_PRIVATE_KEY }}
+          owner: atlanhq
+          repositories: application-sdk
+
       # The mothership sandbox cannot approve PRs in a way that satisfies
       # the `require_code_owner_review` rule on `main`:
       # `mothership-ai[bot]` is a GitHub App, and Apps cannot be listed in
@@ -1149,190 +1166,39 @@ jobs:
       # require a fresh human approval. Identifying "the bot's approval"
       # uses a body-text signature so we never touch other atlan-ci
       # reviews.
+      #
+      # This is the SLOW path: it runs once the sandbox's SSE stream closes,
+      # 30–60s after `sdk-review-approve-on-verdict.yml` has usually already
+      # stamped. Both paths share
+      # .github/scripts/sdk_review_approve.py and both check for an existing
+      # bot-signature approval, so whichever gets there first wins and the
+      # other no-ops.
       - name: Approve PR as atlan-ci (counts as code-owner)
         if: success() && steps.parse.outputs.pr_number != ''
         env:
-          GH_TOKEN: ${{ secrets.ORG_PAT_GITHUB }}
-          PR_NUMBER: ${{ steps.parse.outputs.pr_number }}
+          # Everything except the APPROVE call. Keeping the reads, label writes
+          # and dismissals off the `atlan-ci` PAT is what stops the one call
+          # that genuinely needs that identity from being starved of quota.
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          # The APPROVE call only.
+          APPROVER_TOKEN: ${{ secrets.ORG_PAT_GITHUB }}
           REPO: ${{ github.repository }}
-          DISPATCH_HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
-        run: |
-          set -euo pipefail
-
-          # Staleness guard: a review can take 10–30 min. If a new commit
-          # landed mid-review, branch protection has already dismissed the
-          # atlan-ci approval (dismiss_stale_reviews_on_push) and
-          # sdk-review-reset-on-push.yml has cleared the labels — but if
-          # we proceed here we'd happily re-stamp labels and re-post an
-          # approval based on a verdict that described the old HEAD.
-          # Bail before we touch anything visible.
-          CURRENT_HEAD=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.head.sha')
-          if [ "$CURRENT_HEAD" != "$DISPATCH_HEAD_SHA" ]; then
-            echo "::warning::PR #${PR_NUMBER} HEAD moved from ${DISPATCH_HEAD_SHA} to ${CURRENT_HEAD} during the review. Skipping approval + labeling — a fresh @sdk-review on the new HEAD will produce a verdict that matches the actual diff."
-            exit 0
-          fi
-
-          # Re-read the just-posted summary comment to extract the verdict.
-          # The mothership orchestration (.mothership/pr-review/ORCHESTRATION.md
-          # §3e) posts a comment with the `<!-- SDK_REVIEW -->` HTML
-          # marker and a `### Verdict: <state>` line. If a prior summary
-          # exists from a re-trigger on the same PR head, the most recent
-          # comment wins.
-          #
-          # Marker tolerance: open PRs that were branched off main BEFORE
-          # the `test-sdk-review` → `sdk-review` promotion still carry the
-          # old orchestration on their head, which emits the legacy
-          # `<!-- TEST_SDK_REVIEW -->` marker. Accept either marker so the
-          # formal-approval path keeps working until those PRs rebase.
-          #
-          # The jq pattern wraps `.[] | select(...)` in `[ ... ] | last` so
-          # we get the full body of the last matching comment as a single
-          # string. A naive `.[] | select(...) | .body | tail -1` truncates
-          # the multiline body to its last line, which silently breaks the
-          # verdict grep below.
-          #
-          # --slurp collapses all pages into one array so `last` picks the
-          # genuinely most-recent matching comment. Without it, `--paginate`
-          # runs the jq filter once PER PAGE, so on a PR whose comments span
-          # multiple API pages this would emit one body per matching page
-          # (concatenated) and the verdict grep below would read the verdict
-          # from the EARLIEST matching page rather than the latest — acting
-          # on a stale verdict. `gh api` rejects `--slurp` with `--jq`, so the
-          # slurped array (array-of-pages) is piped into a standalone `jq`,
-          # which flattens with `.[][]` (same idiom as the two guards above).
-          SUMMARY=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
-            --paginate --slurp 2>/dev/null \
-            | jq -r '[.[][] | select((.body | contains("<!-- SDK_REVIEW -->")) or (.body | contains("<!-- TEST_SDK_REVIEW -->")))] | last | .body // ""')
-
-          if [ -z "$SUMMARY" ]; then
-            echo "::warning::No SDK_REVIEW summary comment found on PR #${PR_NUMBER} — skipping approval (the sandbox may have errored before posting)"
-            exit 0
-          fi
-
-          # S1 guard — REVIEWED_HEAD: belt-and-suspenders over the
-          # DISPATCH_HEAD_SHA vs CURRENT_HEAD check above (line ~1169).
-          # That check verifies the PR HEAD didn't move while the sandbox
-          # ran. This check verifies the summary comment explicitly claims
-          # to have reviewed DISPATCH_HEAD_SHA — catching the (rare but
-          # possible) case where the sandbox checked out a different commit
-          # (e.g., the REVIEWED_HEAD placeholder was not substituted, or the
-          # sandbox started from a stale snapshot). If REVIEWED_HEAD is
-          # absent the comment pre-dates the marker; treat it as unverifiable
-          # rather than approving blind, matching the fast-path behaviour.
-          REVIEWED_HEAD=$(printf '%s' "$SUMMARY" | grep -oP '<!--\s*REVIEWED_HEAD:\s*\K[0-9a-f]+' | head -1 || true)
-          if [ -z "$REVIEWED_HEAD" ]; then
-            echo "::warning::PR #${PR_NUMBER}: verdict comment has no REVIEWED_HEAD marker — cannot confirm which sha was reviewed; skipping all stamps."
-            exit 0
-          fi
-          if [ "$REVIEWED_HEAD" != "$DISPATCH_HEAD_SHA" ]; then
-            echo "::warning::PR #${PR_NUMBER}: verdict was computed for ${REVIEWED_HEAD} but this run was dispatched for ${DISPATCH_HEAD_SHA} — skipping all stamps."
-            exit 0
-          fi
-
-          # Extract the verdict. Prefer the structured marker
-          # `<!-- VERDICT: READY_TO_MERGE -->` (deterministic, formatting-
-          # invariant). Fall back to the `### Verdict:` grep for legacy
-          # comments from orchestration versions that pre-date the
-          # structured marker.
-          #
-          # `|| true` is load-bearing here: under `set -euo pipefail`,
-          # grep returning 1 on a no-match (the structured marker isn't
-          # present yet in the verdict comment we're parsing) would kill
-          # the script BEFORE the prose-grep fallback below got a chance
-          # to run. Tolerate the no-match so we fall through cleanly.
-          VERDICT=$(printf '%s' "$SUMMARY" | grep -oP '<!--\s*VERDICT:\s*\K[A-Z_]+' | head -1 || true)
-          if [ -z "$VERDICT" ]; then
-            RAW=$(printf '%s' "$SUMMARY" | grep -oiP '###\s*Verdict:\s*\K[A-Z][A-Z _]+' | head -1 | tr '[:lower:]' '[:upper:]' || true)
-            VERDICT=$(printf '%s' "$RAW" | tr -s ' ' '_' | sed 's/_*$//')
-          fi
-          echo "Detected verdict: '${VERDICT}'"
-
-          # Apply the canonical sdk-review-* labels from the GHA layer.
-          # The orchestration on a PR's head may still emit legacy
-          # `test-sdk-review-*` labels — strip those here and reapply the
-          # promoted names so labels are a single-source-of-truth read
-          # from the verdict, not from whichever orchestration the PR
-          # head happened to have.
-          for stale in "test-sdk-review-approved" "test-sdk-review-needs-human" "test-sdk-review-needs-rebase"; do
-            gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "$stale" 2>/dev/null || true
-          done
-
-          case "$VERDICT" in
-            "READY_TO_MERGE")
-              gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "sdk-review-approved" 2>/dev/null || true
-              gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "sdk-review-needs-human" 2>/dev/null || true
-              gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "sdk-review-needs-rebase" 2>/dev/null || true
-              # Idempotency guards: sdk-review-approve-on-verdict.yml posts
-              # the approval within ~5s of the verdict comment. This slow
-              # path runs 30–60s later when the sandbox finishes cleanup.
-              # By that time the fast path's approval may already be in
-              # place, OR the downgrade-on-ci-failure / dismiss-on-human
-              # workflow may have stripped the label and dismissed it. We
-              # must not re-approve in either case.
-              #
-              # The label is the canonical "this verdict still stands"
-              # signal: fast path stamps it, downgrade/dismiss strip it,
-              # reset-on-push strips it. If it's gone we treat the
-              # READY_TO_MERGE comment as stale.
-              LABEL_PRESENT=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/labels" \
-                --jq '[.[] | select(.name == "sdk-review-approved")] | length')
-              # --slurp collapses all pages into one array so the jq filter emits
-              # a SINGLE count. `gh api` rejects `--slurp` with `--jq`, so the
-              # slurped array is piped into a standalone `jq` (same idiom as the
-              # verdict-posted guard above). Without slurp, `--paginate` runs the
-              # jq per page and prints one number per page — on a PR with >30
-              # reviews that multi-line output breaks `[ ... != "0" ]`.
-              EXISTING_APPROVAL=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews" --paginate --slurp 2>/dev/null \
-                | jq '[.[][] | select(.user.login == "atlan-ci" and .state == "APPROVED" and ((.body // "") | startswith("**SDK reviewer'"'"'s verdict:**")))] | length' 2>/dev/null || echo "0")
-              if [ "$LABEL_PRESENT" = "0" ]; then
-                echo "sdk-review-approved label not present on PR #${PR_NUMBER} (downgrade or reset-on-push likely ran) — skipping approval."
-              elif [ "${EXISTING_APPROVAL:-0}" != "0" ]; then
-                echo "atlan-ci already approved PR #${PR_NUMBER} (likely from the fast path) — skipping."
-              else
-                # NOTE: the leading line of the body is a STABLE SIGNATURE used
-                # by the dismiss-on-human workflow to identify approvals posted
-                # by this flow. Keep this in sync with
-                # sdk-review-approve-on-verdict.yml.
-                #
-                # S2: pin to commit_id=DISPATCH_HEAD_SHA (which we verified ==
-                # REVIEWED_HEAD above). If a push landed between our checks and
-                # this POST, GitHub attaches the approval to the OLD (reviewed)
-                # commit rather than the new HEAD. Full protection against that
-                # window additionally requires `dismiss_stale_reviews_on_push`
-                # enabled on the main branch protection rule — that setting could
-                # not be verified from a non-admin token; confirm it is ON before
-                # relying on this guard.
-                # `gh pr review --approve` does not expose commit_id; use raw API.
-                APPROVE_BODY=$(printf '%s\n' \
-                  "**SDK reviewer's verdict:** READY TO MERGE." \
-                  "" \
-                  "Full review summary is in the comment posted on this PR." \
-                  "")
-                gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews" \
-                  -X POST \
-                  -f commit_id="$DISPATCH_HEAD_SHA" \
-                  -f event=APPROVE \
-                  -f body="$APPROVE_BODY"
-                echo "Approved PR #${PR_NUMBER} as atlan-ci (slow path fallback, commit_id=${DISPATCH_HEAD_SHA})."
-              fi
-              ;;
-            "NEEDS_HUMAN")
-              gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "sdk-review-needs-human" 2>/dev/null || true
-              gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "sdk-review-approved" 2>/dev/null || true
-              echo "Verdict NEEDS_HUMAN — labeled, no approval posted."
-              ;;
-            "NEEDS_REBASE")
-              gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "sdk-review-needs-rebase" 2>/dev/null || true
-              gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "sdk-review-approved" 2>/dev/null || true
-              echo "Verdict NEEDS_REBASE — labeled, no approval posted."
-              ;;
-            *)
-              # NEEDS_FIXES, BLOCKED, or unknown — clear approval/human labels.
-              gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "sdk-review-approved" 2>/dev/null || true
-              gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "sdk-review-needs-human" 2>/dev/null || true
-              echo "Verdict '${VERDICT}' is not READY TO MERGE — not posting an approval."
-              ;;
-          esac
+          PR_NUMBER: ${{ steps.parse.outputs.pr_number }}
+          # Empty: read the newest summary comment off the PR rather than an
+          # event payload. The sandbox posted it minutes ago.
+          COMMENT_BODY: ""
+          # Staleness guard: bail unless the PR's live head is still the sha this
+          # review was dispatched for.
+          EXPECTED_HEAD: ${{ steps.pr.outputs.head_sha }}
+          # The `Set sdk-review status to failure` step below owns this
+          # workflow's status writes; the fast path owns the success case.
+          WRITE_STATUS: "false"
+          # Solo-approval guard: refuse to approve if `sdk-review-approved` was
+          # already gone when this step started — dismiss-on-human,
+          # downgrade-on-ci-failure and reset-on-push all clear it, and any of
+          # them running means this verdict no longer stands.
+          REQUIRE_APPROVED_LABEL: "true"
+        run: python3 .github/scripts/sdk_review_approve.py
 
       - name: Set sdk-review status to failure (only on workflow failure)
         if: failure() && steps.pr.outputs.head_sha != ''

--- a/.github/workflows/tests-reusable.yaml
+++ b/.github/workflows/tests-reusable.yaml
@@ -2020,13 +2020,31 @@ jobs:
             --out results/test-readiness.json \
             || echo "::warning::test-readiness scorecard generation failed (skipped)"
 
+      # `upload-artifact` classifies the artifact service's finalize 403 as
+      # non-retryable and fails on the first occurrence, even though the bytes
+      # already landed and the next attempt normally succeeds. That failed the
+      # job, which failed the aggregate gate, which ejected the merge-queue
+      # entry. So: retry once, and never fail the gate on it:
+      # the scorecard is reporting, not a gate.
       - name: Upload scorecard
+        id: upload-scorecard
         if: hashFiles('results/test-readiness.json') != ''
+        continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: test-readiness-scorecard
           path: results/test-readiness.json
           retention-days: 14
+
+      - name: Upload scorecard (retry)
+        if: steps.upload-scorecard.outcome == 'failure'
+        continue-on-error: true
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: test-readiness-scorecard
+          path: results/test-readiness.json
+          retention-days: 14
+          overwrite: true
 
   # ── Aggregator gate (single required check for branch protection) ────────
   tests-passed:


### PR DESCRIPTION
## What broke

The `atlan-ci` auto-approval stopped landing on `READY_TO_MERGE` PRs — [#3147](https://github.com/atlanhq/application-sdk/pull/3147) is the example that surfaced it. `sdk-review-approve-on-verdict.yml` fired correctly, parsed the verdict, and then took a 403 on the last call:

```
gh: API rate limit exceeded for user ID 62283865 (HTTP 403)
```

`62283865` is `atlan-ci`. Its PAT had exhausted the 5,000 req/hr primary REST quota.

On #3147 the two calls landed two seconds apart:

| 14:15:30 | `POST /statuses/a2f276a0` → `sdk-review: success` ✅ |
| 14:15:32 | `POST /pulls/3147/reviews` → **403 rate limit** ❌ |

Leaving the PR with a green `sdk-review` check, `reviewDecision: REVIEW_REQUIRED`, zero reviews and zero labels.

Not a one-off — non-skipped runs of that workflow:

| Day | Failed / total |
|---|---|
| Aug 10 | 0 / 9 |
| Aug 11 | 3 / 39 |
| Aug 12 | **10 / 27** |

Every failure sampled back to Aug 11 is the same 403 for the same user id. The ramp tracks the burst of concurrent `sdk-review` / `sdk-resolve` loops, all authenticating as `atlan-ci`.

## Why it was fragile

`atlan-ci` is a CODEOWNER (`.github/CODEOWNERS:1`), so the APPROVE review is the *one* call that must carry that identity. Both approval paths ran all ~15 of their requests on that PAT regardless — so the call with no substitute was also the one most likely to be starved. The sibling `sdk-review-downgrade-on-ci-failure.yml` had already worked this out and mints a fleet App token *"No specific identity needed … not posting a codeowner approval"*.

## Changes

**Token split.** The fleet App token (own quota) resolves HEAD, lists comments, reconciles labels, writes the commit status, dismisses stale approvals. `ORG_PAT_GITHUB` is spent on exactly one request. `test_approve_uses_the_pat_and_everything_else_the_app_token` pins that count.

**Ordering.** The approval is posted *before* the commit status goes green. The old order is what made this failure look like success; on failure the status is left as-is and the run fails loudly. `test_failed_approval_leaves_status_unset` pins it.

**Rate-limit-aware retry.** Transients and secondary limits retry with backoff. Primary exhaustion reads the reset via `rate_limit`: inside the wait budget it sleeps, beyond it the run fails immediately naming the reset rather than holding a runner for an hour.

**Both paths, one implementation.** The slow path in `sdk-review.yml` carried its own ~185-line copy of the same logic and had the same failure mode. It now calls the same script, configured by env rather than duplicated: reads the newest summary comment instead of an event payload, pins the dispatch sha via `EXPECTED_HEAD`, and leaves the commit status to the workflow's own failure step via `WRITE_STATUS=false`. Its App token is minted immediately before the approval — installation tokens expire after an hour and that job blocks on the sandbox for up to two.

### Two latent bugs found on the way

**Labels were failing silently.** They went through `gh pr edit … 2>/dev/null || true`, so every label write on these paths failed *invisibly*. Labels are an Issues-scope resource: a token with `pull_requests: write` but not `issues: write` approves fine and labels nothing — which is why #3147 had no `sdk-review-approved` label even after a successful re-run. Now: REST labels API, 404-on-delete tolerated, anything else a `::warning::`, and a computed delta so a correctly-labelled PR costs zero requests.

**The slow path's solo-approval guard was dead.** It gates approval on `sdk-review-approved` still being present — the union invalidation signal, since `dismiss-on-human` strips the label but does **not** touch the commit status, so the status cannot substitute for it. But it read the label back *after* adding it in the same step, so it could only ever see the label it had just written. It has been inert, and the silent label failure above is the only reason that never mattered — fixing labels without fixing this would have let the slow path re-approve after a downgrade, or after a human engaged.

The guard now reads a snapshot taken before the run reconciles labels. That also makes the slow path a real fallback for the first time: when the fast path writes the label and then fails to approve, the label still stands and the slow path posts the approval it couldn't; when something has since invalidated the verdict, the label is gone and it stands down. Both directions are pinned by tests.

Logic moved into `.github/scripts/` with a pytest per `docs/standards/ci.md` — the guards, verdict mapping and retry are exactly the branching that standard exists to keep testable. Every existing guard is preserved on both paths (verdict extraction + prose fallback, REVIEWED_HEAD presence, head-match, dispatch-sha match, comment freshness, label guard, idempotency, stale-approval dismissal, sha-pinned approval).

## Verification

- `uv run --extra workflows --with pytest python -m pytest .github/scripts/tests -q` → **1873 passed** (45 new)
- `uv run pre-commit run --files …` → clean
- Both workflows re-parsed as YAML after the splice
- #3147 unblocked out-of-band by re-running the failed job once quota recovered; `atlan-ci` approval now present, pinned to `a2f276a0`

## Follow-ups

1. **Confirm the fleet App has `issues: write`.** If it doesn't, labels will now emit a visible `::warning::` instead of failing silently — which is the point — but they still won't apply until the permission is granted. This is the one thing worth checking before merge.
2. **What is actually burning the quota.** Neither `sdk-resolve.yml` nor the mothership sandbox references `ORG_PAT_GITHUB` in-repo, so I couldn't confirm from here which credential their `gh` calls run under. This PR removes ~14 of 15 requests per fire from `atlan-ci`'s budget on both paths and makes the remaining one recoverable, but if the sandbox also authenticates as `atlan-ci` that's the tap that needs turning down.
3. **A reconciler** — a scheduled sweep for PRs with a current-head `READY_TO_MERGE` verdict and no `atlan-ci` approval — would make a lost approval self-healing rather than relying on the slow-path fallback.

---

## Also in this PR: artifact uploads no longer eject merge-queue entries

Same class of problem, different mechanism. `actions/upload-artifact` classifies the artifact service's finalize 403 as **non-retryable** and fails on the first occurrence, even though the bytes already landed:

```
Uploaded bytes 92394
Finished uploading artifact content to blob storage!
Finalizing artifact upload
Error: Failed to FinalizeArtifact: Received non-retryable error:
       Failed request: (403) Forbidden: Error from intermediary with
       HTTP status code 403 "Forbidden"
```

That failed the job → `Conformance Gate` → `SDK Gate` → merge-queue ejection. A whole CI run discarded because an intermediary hiccuped on one request.

**Every artifact upload under `.github/` now makes a second attempt**, guarded on the first attempt's outcome, with `overwrite: true` (a failed finalize can leave a same-named partial that would otherwise 409 the retry).

**Where the artifact is advisory, the upload can no longer fail the job at all** — verified case by case against the actual consumer, not assumed:

| Artifact | Why it can't fail the gate |
|---|---|
| `conformance-*-sarif` (×4) | `conformance-upload-sarif.yaml` already downloads with `continue-on-error`, and only consumes artifacts from pushes to **main** — on `pull_request` / `merge_group` nothing reads them at all |
| `trivy-results`, `unit-test-coverage`, `integration-test-results` | every consumer downloads with `continue-on-error` |
| `test-readiness-scorecard`, `codeql-sarif` | reporting only; CodeQL reaches the Security tab via `codeql-action/upload-sarif` |

`docker-image`, parity output and sdr-e2e results **stay fatal** if both attempts fail — their consumers download without `continue-on-error` (sdr-e2e's lives in another repo), so a silent skip would just relocate the failure somewhere less legible.

### Inline, not a shared composite action

I built the composite first, then threw it away. All but one of these workflows is `workflow_call`, and `connector-integration-tests/action.yaml:51` already proves that a nested `uses: ./...` inside a composite resolves against the **consumer's** checkout (its `mssql-native-deps` reference is a connector-local action). Only `conformance-reusable.yaml`'s job has a working local-action precedent, and two of the jobs check nothing out at all. Repeating ~8 lines beats betting every app repo's CI on unproven resolution semantics.

### Regression guard

`test_artifact_upload_retry.py` reads the YAML directly and fails if an upload lands without a retry, without `continue-on-error` on its first attempt, or without `overwrite` on its retry. It found two upload sites this change had missed (`parity-extract`, `sdr-e2e`). Exemptions are keyed by `(file, artifact name)` with a reason and asserted to still match a real upload.

### Incidental find: a workflow that has never run

The guard also caught that **`.github/workflows/scheduled-trivy-scan.yml` is not valid YAML** — its `<< DESC_EOF` heredoc body sits at column 0, which terminates the enclosing `run: |` block scalar, so the markdown after it parses as YAML (`**Service:**` reads as an alias). GitHub can't parse it either: it lists the workflow by path instead of by `name:`, and **all 5 most recent runs failed**. Quarantined in an `UNPARSEABLE` set the guard asserts cannot grow. Left unfixed here — separate bug, no artifact upload in it, worth its own PR.
