### PR TITLE
ci(conformance): gate must honour exit-zero on a crashed leg (FND-199)

### DIFF
--- a/.github/scripts/tests/test_conformance_gate.py
+++ b/.github/scripts/tests/test_conformance_gate.py
@@ -62,7 +62,22 @@ _FAIL = "Conformance gate failed"
 #: vocabulary.  Both must fail closed rather than fall through the branch.
 _SUITE_RESULTS = ("success", "skipped", "failure", "cancelled", "", "neutral")
 
-#: (suite result, exit-zero) -> the single step that must fire.
+#: How `inputs.exit-zero` can arrive, and what it MEANS.  A `type: boolean`
+#: workflow_call input is coerced to a real boolean, so the first two are what
+#: production actually passes.  The string forms are here because a bare
+#: `inputs.exit-zero` is a cast-to-boolean and GHA treats the string 'false' as
+#: TRUTHY — so if the coercion ever stopped holding, the naive condition would
+#: read "false" as "advisory" and every hard-gate caller would silently stop
+#: enforcing while its required check went green.  That direction is much worse
+#: than the other, hence the `!= 'false'` term in the workflow and these rows.
+_EXIT_ZERO_VALUES: tuple[tuple[Any, bool], ...] = (
+    (False, False),
+    (True, True),
+    ("false", False),
+    ("true", True),
+)
+
+#: (suite result, exit-zero means advisory) -> the single step that must fire.
 _EXPECTED: dict[tuple[str, bool], str] = {
     ("success", False): _PASS_CLEAN,
     ("success", True): _PASS_CLEAN,
@@ -96,24 +111,24 @@ def gate_steps() -> dict[str, dict[str, Any]]:
     return steps
 
 
-def _contexts(suite_result: str, exit_zero: bool) -> dict[str, Any]:
+def _contexts(suite_result: str, exit_zero: Any) -> dict[str, Any]:
     return {
         "needs": {"suite": {"result": suite_result}},
         "inputs": {"exit-zero": exit_zero},
     }
 
 
-def _cases() -> Iterator[tuple[str, bool, str]]:
+def _cases() -> Iterator[tuple[str, Any, str]]:
     for suite_result in _SUITE_RESULTS:
-        for exit_zero in (False, True):
-            yield suite_result, exit_zero, _EXPECTED[(suite_result, exit_zero)]
+        for exit_zero, is_advisory in _EXIT_ZERO_VALUES:
+            yield suite_result, exit_zero, _EXPECTED[(suite_result, is_advisory)]
 
 
 @pytest.mark.parametrize(("suite_result", "exit_zero", "expected"), list(_cases()))
 def test_exactly_one_branch_fires(
     gate_steps: dict[str, dict[str, Any]],
     suite_result: str,
-    exit_zero: bool,
+    exit_zero: Any,
     expected: str,
 ) -> None:
     """Every (result × exit-zero) pair selects one branch — never zero, never two.
@@ -153,9 +168,7 @@ def test_advisory_pass_is_announced(gate_steps: dict[str, dict[str, Any]]) -> No
     assert "GITHUB_STEP_SUMMARY" in run, "advisory pass must write the run summary"
 
 
-def test_gate_still_always_runs_after_the_whole_suite(
-    gate_steps: dict[str, dict[str, Any]],  # noqa: ARG001 — module fixture loads the file
-) -> None:
+def test_gate_still_always_runs_after_the_whole_suite() -> None:
     """`if: always()` + `needs: [suite]` is what makes this a viable required check.
 
     Drop `always()` and the gate goes 'skipped' whenever a leg fails, which in a

--- a/.github/scripts/tests/test_conformance_gate.py
+++ b/.github/scripts/tests/test_conformance_gate.py
@@ -1,0 +1,167 @@
+"""The conformance required gate must decide from the suite result AND exit-zero (FND-199).
+
+The `Conformance Gate` job is the required check.  It reads the suite matrix
+job's *aggregate* result, which is 'failure' if any leg failed for any reason —
+including reasons that graded no rule at all.  The D-series leg is the only one
+that materialises the caller's environment, and its `uv sync` dies on a
+dependency with no manylinux wheel (python-ldap, mysqlclient, psycopg2 from
+source, sasl), on a private-index 401, on a network flake.  detect never runs.
+
+That made the gate asymmetric for soft-enforcement callers: with
+`exit-zero: true` a rule *violation* could never fail the gate (detect exits 0)
+while a *crash in the same series* still did.  The fix honours `exit-zero` in
+the gate as well.  It loosens no rule enforcement — under exit-zero detect
+cannot exit nonzero on findings, so a 'failure' aggregate is by construction a
+crash, never a verdict.
+
+Two properties are asserted here, and the second is the one that actually
+protects the merge queue:
+
+* The decision table itself — notably that 'cancelled' fails in BOTH modes.  A
+  cancelled run graded nothing; reporting green from it would let a merge queue
+  merge on a check that never ran.  An earlier `contains(..., 'failure')` rule
+  had exactly that hole, so it is pinned rather than assumed.
+* **Exhaustiveness.**  The branch is three sibling steps whose `if:`s must
+  partition the space: exactly one fires for every input.  Miss a case and the
+  job runs no step, succeeds, and reports a green required check having
+  evaluated nothing — the same silent-pass failure mode in a new place.  A
+  textual "is the third condition the negation of the other two" check would
+  not survive a reworded expression, so the partition is proven behaviourally
+  over the cross product instead.
+
+The conditions are lifted verbatim from the workflow and evaluated with the
+repo's GHA expression evaluator, so a change to precedence — `&&` binds tighter
+than `||`, and one paren out of place turns the exit-zero term into a no-op —
+fails here rather than in production.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any, Iterator
+
+import pytest
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _gha_expr import evaluate  # noqa: E402
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_WORKFLOW = _REPO_ROOT / ".github/workflows/conformance-reusable.yaml"
+
+#: Step names, in the order the workflow declares them.  Keyed by the outcome
+#: each step represents so the assertions below read as a decision table.
+_PASS_CLEAN = "Conformance gate passed"
+_PASS_ADVISORY = "Conformance gate passed (advisory — exit-zero)"
+_FAIL = "Conformance gate failed"
+
+#: Every value `needs.<job>.result` can take, plus two that it should not:
+#: the empty string (a job that did not run) and a value from no known
+#: vocabulary.  Both must fail closed rather than fall through the branch.
+_SUITE_RESULTS = ("success", "skipped", "failure", "cancelled", "", "neutral")
+
+#: (suite result, exit-zero) -> the single step that must fire.
+_EXPECTED: dict[tuple[str, bool], str] = {
+    ("success", False): _PASS_CLEAN,
+    ("success", True): _PASS_CLEAN,
+    ("skipped", False): _PASS_CLEAN,
+    ("skipped", True): _PASS_CLEAN,
+    # The whole point of FND-199: a crashed leg blocks a hard gate and is
+    # tolerated (loudly) under soft enforcement.
+    ("failure", False): _FAIL,
+    ("failure", True): _PASS_ADVISORY,
+    # A cancelled run graded nothing — never green, in either mode.
+    ("cancelled", False): _FAIL,
+    ("cancelled", True): _FAIL,
+    ("", False): _FAIL,
+    ("", True): _FAIL,
+    ("neutral", False): _FAIL,
+    ("neutral", True): _FAIL,
+}
+
+
+@pytest.fixture(scope="module")
+def gate_steps() -> dict[str, dict[str, Any]]:
+    """The gate job's steps, keyed by name."""
+    workflow = yaml.safe_load(_WORKFLOW.read_text(encoding="utf-8"))
+    gate = workflow["jobs"]["gate"]
+    steps = {step["name"]: step for step in gate["steps"]}
+    missing = {_PASS_CLEAN, _PASS_ADVISORY, _FAIL} - steps.keys()
+    assert not missing, (
+        f"gate job is missing step(s) {sorted(missing)} — this test identifies the "
+        f"branches by name; rename them here and in the workflow together"
+    )
+    return steps
+
+
+def _contexts(suite_result: str, exit_zero: bool) -> dict[str, Any]:
+    return {
+        "needs": {"suite": {"result": suite_result}},
+        "inputs": {"exit-zero": exit_zero},
+    }
+
+
+def _cases() -> Iterator[tuple[str, bool, str]]:
+    for suite_result in _SUITE_RESULTS:
+        for exit_zero in (False, True):
+            yield suite_result, exit_zero, _EXPECTED[(suite_result, exit_zero)]
+
+
+@pytest.mark.parametrize(("suite_result", "exit_zero", "expected"), list(_cases()))
+def test_exactly_one_branch_fires(
+    gate_steps: dict[str, dict[str, Any]],
+    suite_result: str,
+    exit_zero: bool,
+    expected: str,
+) -> None:
+    """Every (result × exit-zero) pair selects one branch — never zero, never two.
+
+    Zero is the dangerous direction: the job would succeed having run nothing
+    and report a green required check.
+    """
+    contexts = _contexts(suite_result, exit_zero)
+    fired = [
+        name for name, step in gate_steps.items() if evaluate(str(step["if"]), contexts)
+    ]
+    assert fired == [expected], (
+        f"suite result {suite_result!r} with exit-zero={exit_zero} fired {fired}, "
+        f"expected exactly [{expected!r}]"
+    )
+
+
+def test_only_the_failing_branch_exits_nonzero(
+    gate_steps: dict[str, dict[str, Any]],
+) -> None:
+    """The verdict is the exit code, not the wording of the log line."""
+    assert "exit 1" in gate_steps[_FAIL]["run"]
+    for name in (_PASS_CLEAN, _PASS_ADVISORY):
+        assert (
+            "exit 1" not in gate_steps[name]["run"]
+        ), f"{name!r} is a passing branch but its script exits nonzero"
+
+
+def test_advisory_pass_is_announced(gate_steps: dict[str, dict[str, Any]]) -> None:
+    """A green gate over a failed leg must say why, where a reader will see it.
+
+    A required check that is green is the one nobody opens, so the job log alone
+    does not count: the reason belongs in a PR annotation and the run summary.
+    """
+    run = gate_steps[_PASS_ADVISORY]["run"]
+    assert "::warning" in run, "advisory pass must raise a PR annotation"
+    assert "GITHUB_STEP_SUMMARY" in run, "advisory pass must write the run summary"
+
+
+def test_gate_still_always_runs_after_the_whole_suite(
+    gate_steps: dict[str, dict[str, Any]],  # noqa: ARG001 — module fixture loads the file
+) -> None:
+    """`if: always()` + `needs: [suite]` is what makes this a viable required check.
+
+    Drop `always()` and the gate goes 'skipped' whenever a leg fails, which in a
+    merge queue is indistinguishable from "not required yet" and blocks forever.
+    """
+    workflow = yaml.safe_load(_WORKFLOW.read_text(encoding="utf-8"))
+    gate = workflow["jobs"]["gate"]
+    assert str(gate["if"]).strip() == "always()"
+    assert gate["needs"] == ["suite"]

--- a/.github/workflows/conformance-reusable.yaml
+++ b/.github/workflows/conformance-reusable.yaml
@@ -590,8 +590,19 @@ jobs:
       # advisory.  Deliberately loud: a green required check is the one outcome
       # nobody re-reads, so the reason it is green goes in an annotation and the
       # run summary rather than in this job's log alone.
+      # `!= 'false'` is not redundant paranoia.  A bare `inputs.exit-zero` is a
+      # cast-to-boolean, and in GitHub expressions the STRING 'false' is truthy
+      # — the classic workflow footgun.  A `type: boolean` workflow_call input
+      # is coerced to a real boolean today (sdk-gate.yaml passes `force-all` as
+      # an expression and line ~398 relies on `!inputs.force-all`), so this term
+      # is inert.  It is here because the two directions are not equally bad: if
+      # that ever stops holding, without this term every HARD-gate caller
+      # silently becomes advisory and the suite stops enforcing anything, with
+      # a green check saying otherwise.  One term buys that away.
       - name: "Conformance gate passed (advisory — exit-zero)"
-        if: inputs.exit-zero && needs.suite.result == 'failure'
+        if: >-
+          inputs.exit-zero && inputs.exit-zero != 'false'
+          && needs.suite.result == 'failure'
         env:
           SUITE_RESULT: ${{ needs.suite.result }}
         run: |
@@ -611,7 +622,8 @@ jobs:
       - name: "Conformance gate failed"
         if: >-
           !(needs.suite.result == 'success' || needs.suite.result == 'skipped'
-          || (inputs.exit-zero && needs.suite.result == 'failure'))
+          || (inputs.exit-zero && inputs.exit-zero != 'false'
+              && needs.suite.result == 'failure'))
         env:
           SUITE_RESULT: ${{ needs.suite.result }}
         run: |

--- a/.github/workflows/conformance-reusable.yaml
+++ b/.github/workflows/conformance-reusable.yaml
@@ -228,9 +228,16 @@ on:
         type: boolean
       exit-zero:
         description: >
-          When true, the detect command exits 0 even when blocking violations are
-          found.  The SARIF invocation.exitCode still records the real result so
-          Security-tab tracking is unaffected; only the CI job exit code changes.
+          Declares conformance ADVISORY for this run: nothing the suite reports
+          may block the merge.  Two effects, both needed for that promise to
+          hold.  (1) The detect command exits 0 even when blocking violations are
+          found — the SARIF invocation.exitCode still records the real result so
+          Security-tab tracking is unaffected.  (2) The `Conformance Gate` job
+          tolerates a FAILED suite leg (FND-199): with exit-zero a violation can
+          no longer fail a leg, so a failed leg is by construction a crash or a
+          setup-step failure — never a rule verdict — and blocking on it would
+          enforce, at random, exactly what this input says not to enforce.  A
+          CANCELLED run still fails the gate in both modes.
           Use during soft-enforcement rollouts where violations should be observed
           but must not block merges.  Default: false (hard gate).
         required: false
@@ -521,26 +528,93 @@ jobs:
   # Always runs so it can be marked a required check without ever becoming
   # "skipped" and blocking the merge queue.  A matrix job's aggregate result is
   # 'failure' if any leg fails, so a single `needs: [suite]` covers all series.
+  # It is 'cancelled' if a run was cancelled, 'skipped' if every series
+  # self-skipped (nothing relevant changed), 'success' otherwise.
+  #
+  # ── Why the gate reads `exit-zero` too (FND-199) ──────────────────────────
+  #
+  # That aggregate is 'failure' if any leg failed for ANY reason — including
+  # reasons that evaluated no rule at all.  The D-series leg is the only one
+  # that materialises the caller's environment, and its `uv sync` dies on a
+  # dependency with no manylinux wheel (python-ldap, mysqlclient, psycopg2 from
+  # source, sasl), on a private index 401, on a network flake.  detect never
+  # runs; zero rules are graded.
+  #
+  # Reading only the aggregate made that asymmetric for soft-enforcement
+  # callers: with `exit-zero: true` a rule *violation* could never fail the gate
+  # (detect exits 0) while a *crash* still did.  So `exit-zero` — which declares
+  # conformance advisory for the run — is honoured here as well.  It loosens no
+  # rule enforcement: under exit-zero detect CANNOT exit nonzero on findings, so
+  # a 'failure' aggregate is by construction a crash or a setup-step failure.
+  # The crashed leg stays red and visible on the PR and the gate says so out
+  # loud in an annotation and the run summary; it just does not block the merge.
+  #
+  # 'cancelled' still fails in BOTH modes — a cancelled run graded nothing and
+  # must never report green into a merge queue.  Hard-gate callers
+  # (`exit-zero: false`) are unchanged: a crashed leg still fails closed,
+  # because the D series carries BLOCK-tier rules (D001, D009) that genuinely
+  # were not evaluated.  Such a caller repairs the leg — see the `apt-packages`
+  # input — rather than being handed a green gate.
+  #
+  # Three `if:`-gated straight-line steps rather than one `if [[ ... ]]`:
+  # docs/standards/ci.md bans branching shell in a workflow.  The usual remedy —
+  # move the branch into .github/scripts/ — is the wrong trade HERE, and only
+  # here.  This is a REUSABLE workflow, so `uses: ./…` and $GITHUB_ACTION_PATH
+  # resolve against the CALLER's checkout (which is why run-conformance-detect
+  # is vendored into app repos); reaching an SDK script needs the `.sdk-scripts`
+  # sparse-checkout dance, i.e. two network checkouts.  This job currently
+  # checks nothing out and therefore cannot fail for any reason except its own
+  # verdict — a property worth keeping in the one job whose red blocks every
+  # merge, and the exact class of incidental-crash-blocks-merge that FND-199 is
+  # about.  A 4-value enum does not justify importing that risk.
+  #
+  # The failing step's `if:` is the exact negation of the two passing ones, so
+  # the job cannot fall through all three and pass by accident.
+  # test_conformance_gate.py lifts all three conditions out of this file and
+  # evaluates them over every (result × exit-zero) pair, which is what makes
+  # this branch as testable as a script would have been.
   gate:
     name: "Conformance Gate"
     runs-on: ubuntu-latest
     needs: [suite]
     if: always()
     steps:
-      - name: "Evaluate conformance results"
+      - name: "Conformance gate passed"
+        if: needs.suite.result == 'success' || needs.suite.result == 'skipped'
+        env:
+          SUITE_RESULT: ${{ needs.suite.result }}
+        run: |
+          echo "Conformance gate passed (suite result: $SUITE_RESULT)."
+
+      # Reached only when a leg failed AND the caller declared conformance
+      # advisory.  Deliberately loud: a green required check is the one outcome
+      # nobody re-reads, so the reason it is green goes in an annotation and the
+      # run summary rather than in this job's log alone.
+      - name: "Conformance gate passed (advisory — exit-zero)"
+        if: inputs.exit-zero && needs.suite.result == 'failure'
         env:
           SUITE_RESULT: ${{ needs.suite.result }}
         run: |
           set -euo pipefail
-          # Fail closed on anything that is not a clean pass. The matrix job's
-          # aggregate result is 'failure' if any leg failed, 'cancelled' if a
-          # run was cancelled, 'skipped' if every series self-skipped (nothing
-          # relevant changed), 'success' otherwise. Only success|skipped pass —
-          # 'cancelled' must NOT slip through (the old contains(...,'failure')
-          # rule let it).
-          if [[ "$SUITE_RESULT" == "success" || "$SUITE_RESULT" == "skipped" ]]; then
-            echo "Conformance gate passed (suite result: $SUITE_RESULT)."
-          else
-            echo "::error::Conformance gate FAILED — suite result: $SUITE_RESULT."
-            exit 1
-          fi
+          echo "::warning title=Conformance leg failed (advisory)::A conformance leg failed, but this caller runs with exit-zero (soft enforcement), so the required gate is not blocking. Under exit-zero a rule violation cannot fail a leg — open the red 'Conformance / …' leg, it crashed before grading anything (most often the Dependencies leg's uv sync)."
+          {
+            echo "### Conformance Gate: passed (advisory)"
+            echo
+            echo "Suite result: \`$SUITE_RESULT\`, tolerated because this caller passes \`exit-zero: true\`."
+            echo
+            echo "Under \`exit-zero\` a rule violation cannot fail a leg, so a failed leg means the leg"
+            echo "itself crashed and **its rules never ran** — commonly the Dependencies leg's \`uv sync\`"
+            echo "on a dependency with no manylinux wheel. Open the red leg above; if it needs system"
+            echo "headers, pass them via the \`apt-packages\` input."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: "Conformance gate failed"
+        if: >-
+          !(needs.suite.result == 'success' || needs.suite.result == 'skipped'
+          || (inputs.exit-zero && needs.suite.result == 'failure'))
+        env:
+          SUITE_RESULT: ${{ needs.suite.result }}
+        run: |
+          set -euo pipefail
+          echo "::error::Conformance gate FAILED — suite result: $SUITE_RESULT."
+          exit 1

--- a/docs/standards/ci.md
+++ b/docs/standards/ci.md
@@ -191,6 +191,21 @@ sparse-checkout it into a side path and invoke from there — the
 The driver runs from the consumer's working directory, so it acts on the
 consumer's files; `.sdk-scripts` only holds SDK code and must never be staged.
 
+**Exception: an always-required gate job.** The pattern costs two network
+checkouts, and every one of them is a way for the job to fail for reasons that
+have nothing to do with its verdict. In a job that is a *required* check and
+runs `if: always()`, that trade is backwards: a checkout flake there blocks
+every merge in the repo. Keep such a job dependency-free and put its branch in
+sibling steps' `if:` expressions instead, with each step's `run:` straight-line
+— the conditions are still testable, by lifting them out of the YAML and
+evaluating them with
+[`_gha_expr.py`](../../.github/scripts/tests/_gha_expr.py) (worked example:
+[`test_conformance_gate.py`](../../.github/scripts/tests/test_conformance_gate.py),
+which also asserts the conditions *partition* the space, so the job can never
+fall through every branch and report green having decided nothing). FND-199 is
+the case that set this: the whole ticket was an incidental failure turning a
+required check red.
+
 ## `concurrency:` is not a lock, and not a queue
 
 **Rule:** never use a `concurrency:` group to protect a shared external resource


### PR DESCRIPTION
Closes FND-199 — https://linear.app/atlan-epd/issue/FND-199

## Problem

The `Conformance Gate` job — the required check — read only the suite matrix job's **aggregate** result. That aggregate is `failure` if any leg failed for **any** reason, including reasons that graded no rule at all. The D-series leg is the only one that materialises the caller's environment, and its `uv sync` dies on a dependency with no manylinux wheel (`python-ldap`, `mysqlclient`, `psycopg2` from source, `sasl`), on a private-index 401, on a network flake. `detect` never runs.

That was asymmetric for soft-enforcement callers: with `exit-zero: true` a rule **violation** could never fail the gate (`detect` exits 0) while a **crash in the same series** still did. `exit-zero` neutralised verdicts; nothing neutralised a crash.

## Correction to the ticket's premise

The ticket is filed as "a crash in the warn-tier D series", and that framing is wrong in a way that changes the fix. `EnforcementTier` is a property of a **rule**, resolved per finding (`suite/runner.py:_tier`) — there is no series-level or leg-level tier. The D series is **mixed**: **D001 and D009 are BLOCK**, the other eight are WARN.

So this PR deliberately does **not** add a `tier:`/`advisory:` matrix field, and does not weaken a leg. Either would invent a per-series concept the suite doesn't have, and would stop enforcing two BLOCK rules.

## Fix

The gate reads `exit-zero` alongside `needs.suite.result`. The argument that makes this safe:

> Under `exit-zero: true`, `detect` **cannot** exit nonzero on a finding. So a `failure` aggregate is by construction a crash or a setup-step failure — never a rule verdict.

Tolerating it at the gate therefore loosens **zero** rule enforcement.

| suite result | `exit-zero: false` | `exit-zero: true` |
|---|---|---|
| `success` / `skipped` | pass | pass |
| `failure` | **fail** | **pass, loudly** |
| `cancelled` | fail | **fail** |
| `''` / unknown | fail | fail |

`cancelled` still fails in *both* modes — a cancelled run graded nothing and must never report green into a merge queue (an earlier `contains(..., 'failure')` rule had exactly that hole, so it's pinned by test rather than assumed).

The advisory pass is deliberately not silent: a `::warning::` annotation plus a run-summary block stating that under `exit-zero` a failed leg means the leg *crashed before grading anything*, and pointing at `apt-packages`. The crashed leg itself stays red and visible on the PR; only the required gate stops blocking.

## Deliberate residual

A **hard-gate** caller (`exit-zero: false`) whose tree has `python-ldap` / `mysqlclient` / `psycopg2`-from-source still fails the gate when the D leg crashes. That is fail-closed and intended: D001/D009 are BLOCK-tier and genuinely were not evaluated, so a green gate would silently stop enforcing them. Those callers repair the leg via `apt-packages` (#3102). Called out explicitly because the ticket's "Generic, not hive-specific" section reads as asking for that case too — but that half would be a real loosening, whereas the exit-zero half is not.

## Why the branch is in `if:` expressions, not a script

Moving from one `if [[ ... ]]` in bash to three `if:`-gated straight-line steps also retires a standing `docs/standards/ci.md` violation (branching shell in a workflow). The standard's usual remedy — move it into `.github/scripts/` — is the wrong trade **here specifically**: this is a *reusable* workflow, so `uses: ./…` and `$GITHUB_ACTION_PATH` resolve against the **caller's** checkout (which is why `run-conformance-detect` is vendored into app repos), and reaching an SDK script needs the `.sdk-scripts` sparse-checkout — two network checkouts inside the one always-required job whose red blocks every merge. That imports precisely the incidental-crash-blocks-merge failure class this ticket is about. `ci.md` now records that as a documented exception, with this test as the worked example of keeping such a branch testable.

The failing step's `if:` is the exact negation of the two passing ones, so the job cannot fall through all three and pass by accident.

## Hardening (second commit)

`&& inputs.exit-zero != 'false'`: a bare `inputs.exit-zero` is a cast-to-boolean, and in GHA the **string** `'false'` is truthy. A `type: boolean` workflow_call input is coerced to a real boolean today (`sdk-gate.yaml` passes `force-all` as an expression and this workflow relies on `!inputs.force-all`), so the term is inert. It's there because the directions aren't equally bad: if that ever stopped holding, the naive condition reads `'false'` as *advisory* and every hard-gate caller silently stops enforcing behind a green check.

## Blast radius

The gate lives only in `conformance-reusable.yaml` — it is **not** vendored into app repos — so this takes effect for every fleet caller the moment it merges to `main`, with no per-repo bootstrap. Callers on `exit-zero: false` are unaffected.

## Verification

- `test_conformance_gate.py` (new) lifts all three conditions verbatim out of the YAML and evaluates them with the repo's GHA expression evaluator over every suite result × all four shapes the input can arrive in — asserting **exactly one branch fires**, so the job can never fall through every branch and report green having decided nothing. 27/27 pass.
- Both changes are **mutation-verified**: moving one paren (turning the exit-zero term into a no-op by precedence) fails precisely the `failure` + `exit-zero` case; deleting the `!= 'false'` term fails precisely the `failure` + string-`'false'` case.
- Full `.github/scripts/tests` suite: 1843 passed.
- `uv run pre-commit run --files ...` — ruff, ruff-format, isort, pyright clean.
- The new test also caught a real YAML error mid-change (an unquoted `: ` in a plain scalar) that GitHub would have rejected outright.

🤖 Generated with [Claude Code](https://claude.com/claude-code)