### PR TITLE
feat(execution): warn-mode telemetry — the two shapes and the per-app work-list (FND-292)

### DIFF
--- a/application_sdk/execution/_temporal/activities.py
+++ b/application_sdk/execution/_temporal/activities.py
@@ -207,6 +207,9 @@ def create_activity_from_task(
             ProgressTracker,
             bind_progress_tracker,
         )
+        from application_sdk.execution.progress_telemetry import (  # noqa: PLC0415 — circular: execution/__init__.py loads sibling modules + app.base imports execution
+            closed_hold_observer,
+        )
 
         app_registry = AppRegistry.get_instance()
         app_metadata = app_registry.get(context.app_name)
@@ -270,10 +273,20 @@ def create_activity_from_task(
         # leave a dead attempt's tracker bound to this context — not a raise
         # from `create_task` while the loop is closing, and not a
         # `CancelledError` (a `BaseException`) landing in the cleanup below.
+        #
+        # The hold observer is the second half of the warn-mode report: every
+        # hold this attempt releases is measured, so long *unbounded* holds —
+        # invisible to any code audit precisely because they are
+        # auto-vouched-for — show up on the app's work-list alongside the
+        # no-progress gaps the watchdog reports. Attached here rather than left
+        # to the watchdog's own wiring because a hold is worth observing on any
+        # task, including one with heartbeating disabled.
         stop_event = asyncio.Event()
         heartbeat_task = None
 
-        with bind_progress_tracker(ProgressTracker()) as tracker:
+        with bind_progress_tracker(
+            ProgressTracker(on_hold_closed=closed_hold_observer(context.task_name))
+        ) as tracker:
             try:
                 if (
                     context.heartbeat_timeout_seconds is not None

--- a/application_sdk/execution/heartbeat.py
+++ b/application_sdk/execution/heartbeat.py
@@ -37,6 +37,7 @@ from application_sdk.execution.progress import (
     current_progress_tracker,
     declared_hold_active,
 )
+from application_sdk.execution.progress_telemetry import record_no_progress_gap
 from application_sdk.observability import (
     resource_sampler as _resource_sampler,  # module alias kept so tests can patch _resource_sampler.sample()
 )
@@ -49,14 +50,6 @@ _MEMORY_WARN_THRESHOLD = 0.80
 _MEMORY_WARN_HYSTERESIS = (
     0.05  # re-arm only once ratio drops below threshold - hysteresis
 )
-
-#: Meter for signals this module owns. Deliberately not the Temporal meter: the
-#: stall watchdog has no Temporal dependency, so it also reports from local runs.
-_METER_NAME = "application_sdk.execution"
-
-#: Lazily created singletons — one instrument per process, built on first use so
-#: nothing is bound before ``run_main()`` configures the ``MeterProvider``.
-_INSTRUMENTS: dict[str, Any] = {}
 
 # Dedicated executor for blocking operations dispatched via run_in_thread().
 #
@@ -151,67 +144,6 @@ class NoopHeartbeatController:
         return self._details
 
 
-def _no_progress_gap_histogram() -> Any:
-    """Gap-duration histogram, created on first stall observation.
-
-    A histogram rather than a counter because the fleet-wide *distribution* of
-    no-progress gaps is what sizes ``max_no_progress_seconds`` before anything
-    enforces (ADR-0018 → *Decisions taken*).
-    """
-    if "no_progress_gap" not in _INSTRUMENTS:
-        from opentelemetry import (  # noqa: PLC0415 — cold path: only reached on a stall observation
-            metrics as _otel_metrics,
-        )
-
-        _INSTRUMENTS["no_progress_gap"] = _otel_metrics.get_meter(
-            _METER_NAME
-        ).create_histogram(
-            "task.no_progress_gap",
-            unit="s",
-            description=(
-                "Seconds a task attempt went without an observable progress "
-                "signal, recorded once per gap that exceeded "
-                "max_no_progress_seconds. Partitioned by task, the last "
-                "progress label seen, and the watchdog mode — so warn-mode "
-                "observations and enforced kills aggregate separately."
-            ),
-        )
-    return _INSTRUMENTS["no_progress_gap"]
-
-
-def _record_no_progress_gap(
-    task_name: str, stalled_for: float, last_label: str, mode: ProgressWatchdogMode
-) -> None:
-    """Record one no-progress gap. Never raises.
-
-    The metric is emitted in *both* warn and enforce mode: in warn mode it is
-    the whole point (nothing else reports the gap), and in enforce mode it is
-    what makes the kill rate measurable.
-    """
-    try:
-        _no_progress_gap_histogram().record(
-            stalled_for,
-            {
-                "task.name": task_name,
-                # A progress label identifies a call site, never a value — see
-                # ProgressTracker.enter_hold — so this stays bounded.
-                "progress.last_label": last_label,
-                "watchdog.mode": mode.value,
-            },
-        )
-    # Best-effort observability: a metric-backend problem must never fail the
-    # activity the watchdog is only observing.
-    except Exception:
-        logger.warning(
-            "Failed to record the no-progress gap metric for task '%s' (%.0fs gap); "
-            "the stall is still logged but will be missing from the fleet-wide "
-            "gap distribution",
-            task_name,
-            stalled_for,
-            exc_info=True,
-        )
-
-
 def _check_for_stall(
     progress: ProgressTracker,
     budget_seconds: float,
@@ -245,7 +177,7 @@ def _check_for_stall(
         return False
 
     last_label = progress.last_label
-    _record_no_progress_gap(task_name, stalled, last_label, mode)
+    record_no_progress_gap(task_name, stalled, last_label, mode)
 
     if mode is not ProgressWatchdogMode.ENFORCE or on_stall is None:
         # INFO, never WARNING: under a fleet-wide default this is an expected

--- a/application_sdk/execution/progress.py
+++ b/application_sdk/execution/progress.py
@@ -65,6 +65,18 @@ from application_sdk.observability.logger_adaptor import get_logger
 
 logger = get_logger(__name__)
 
+#: How long a task may go without an observable progress signal, in seconds
+#: (ADR-0018 → *Decisions taken*). Roughly app-independent: it answers "how long
+#: may this attempt be silent?", not "how much data does this tenant have?".
+#:
+#: One number with two uses, deliberately not two numbers. The stall watchdog
+#: takes it as ``max_no_progress_seconds`` (the per-task flag that carries it is
+#: FND-296's), and the warn-mode hold report takes it as the floor above which a
+#: hold is worth naming in the log — a hold longer than the budget is exactly a
+#: hold that *would* have tripped the watchdog had it not been vouched for,
+#: which is the work-list criterion.
+DEFAULT_MAX_NO_PROGRESS_SECONDS = 900.0
+
 
 class ProgressWatchdogMode(SerializableEnum):
     """How the stall watchdog reacts to a no-progress gap (ADR-0018).

--- a/application_sdk/execution/progress_telemetry.py
+++ b/application_sdk/execution/progress_telemetry.py
@@ -1,0 +1,264 @@
+"""Warn-mode telemetry for the stall watchdog (ADR-0018).
+
+The obvious question from any app author is *"how do I find every place in my
+codebase that needs a hold, and what allowance do I put on each one?"*
+Answering it with "audit your code" would reintroduce ADR-0018's own problem one
+level down: a per-site number, guessed up front, by hand. The watchdog already
+observes exactly what that audit would look for, so it reports instead, and the
+whole-codebase audit collapses into reading a report.
+
+Two shapes are emitted, and they are the two things that need action:
+
+1. **No-progress gaps with no hold in force** —
+   :func:`record_no_progress_gap`. The sites that need a progress hook or a
+   hold.
+2. **Long holds, and long *unbounded* holds above all** —
+   :func:`record_closed_hold`, fed by every
+   :meth:`~application_sdk.execution.progress.ProgressTracker.exit_hold`.
+   The sites that want an explicit allowance rather than the duration backstop.
+   Without this shape a blocking call offloaded through ``run_in_thread`` is
+   invisible to the audit *precisely because it is auto-vouched-for*.
+
+Both shapes are a metric plus an **INFO** log — never WARNING. Warn mode is a
+fleet-wide default, so a stall observation under it is an expected observation
+rather than an actionable failure, and emitting it at WARNING would manufacture
+exactly the alert noise ADR-0018 exists to reduce. Dashboards and the per-app
+work-list read the metric; the log is the same finding for whoever happens to be
+reading one app's logs. The only WARNING here is a telemetry failure, which is a
+statement about the report being incomplete, not about the app.
+
+Ranking per app needs no attribute on these instruments: ``app.name`` is inlined
+onto every series from the OTel Resource (see
+``observability/_prometheus_enrichment.py``), and the rest of the app identity
+(version, release channel, k8s topology) is reachable through ``target_info``.
+So these instruments carry only what distinguishes *sites within* an app, which
+is what keeps them rankable per app and aggregatable fleet-wide at once.
+"""
+
+from __future__ import annotations
+
+import functools
+from collections.abc import Callable
+from typing import Any
+
+from application_sdk.execution.progress import (
+    DEFAULT_MAX_NO_PROGRESS_SECONDS,
+    ClosedHold,
+    ProgressWatchdogMode,
+)
+from application_sdk.observability.logger_adaptor import get_logger
+
+logger = get_logger(__name__)
+
+#: Meter for the signals this module owns. Deliberately not the Temporal meter:
+#: neither the tracker nor the watchdog has a Temporal dependency, so both also
+#: report from local runs.
+_METER_NAME = "application_sdk.execution"
+
+#: Lazily created singletons — one instrument per process, built on first use so
+#: nothing is bound before ``run_main()`` configures the ``MeterProvider``.
+_INSTRUMENTS: dict[str, Any] = {}
+
+
+def _no_progress_gap_histogram() -> Any:
+    """Gap-duration histogram, created on first stall observation.
+
+    A histogram rather than a counter because the fleet-wide *distribution* of
+    no-progress gaps is what sizes ``max_no_progress_seconds`` before anything
+    enforces (ADR-0018 → *Decisions taken*).
+    """
+    if "no_progress_gap" not in _INSTRUMENTS:
+        from opentelemetry import (  # noqa: PLC0415 — cold path: only reached on a stall observation
+            metrics as _otel_metrics,
+        )
+
+        _INSTRUMENTS["no_progress_gap"] = _otel_metrics.get_meter(
+            _METER_NAME
+        ).create_histogram(
+            "task.no_progress_gap",
+            unit="s",
+            description=(
+                "Seconds a task attempt went without an observable progress "
+                "signal, recorded once per gap that exceeded "
+                "max_no_progress_seconds. Partitioned by task, the last "
+                "progress label seen, and the watchdog mode — so warn-mode "
+                "observations and enforced kills aggregate separately."
+            ),
+        )
+    return _INSTRUMENTS["no_progress_gap"]
+
+
+def _hold_duration_histogram() -> Any:
+    """Hold-duration histogram, created on the first hold this process closes.
+
+    Every closed hold is recorded, not only the long ones: choosing an allowance
+    for a site means reading that site's observed distribution (ADR-0018 asks
+    for its p99 plus headroom), and a metric that only fired above a threshold
+    could not answer that question.
+    """
+    if "hold_duration" not in _INSTRUMENTS:
+        from opentelemetry import (  # noqa: PLC0415 — cold path: only reached once a hold closes
+            metrics as _otel_metrics,
+        )
+
+        _INSTRUMENTS["hold_duration"] = _otel_metrics.get_meter(
+            _METER_NAME
+        ).create_histogram(
+            "task.hold_duration",
+            unit="s",
+            description=(
+                "Seconds an operation held the stall watchdog, recorded once "
+                "per hold released. Partitioned by task, the hold's label, "
+                "whether an allowance was declared, and whether the operation "
+                "outlived it — so the long *unbounded* holds (the sites that "
+                "want an explicit allowance) and the lapsed ones (the "
+                "allowances that are too tight) rank separately, and each "
+                "site's own distribution is what sizes its allowance."
+            ),
+        )
+    return _INSTRUMENTS["hold_duration"]
+
+
+def record_no_progress_gap(
+    task_name: str, stalled_for: float, last_label: str, mode: ProgressWatchdogMode
+) -> None:
+    """Record one no-progress gap. Never raises.
+
+    The metric is emitted in *both* warn and enforce mode: in warn mode it is
+    the whole point (nothing else reports the gap), and in enforce mode it is
+    what makes the kill rate measurable.
+    """
+    try:
+        _no_progress_gap_histogram().record(
+            stalled_for,
+            {
+                "task.name": task_name,
+                # A progress label identifies a call site, never a value — see
+                # ProgressTracker.enter_hold — so this stays bounded.
+                "progress.last_label": last_label,
+                "watchdog.mode": mode.value,
+            },
+        )
+    # Best-effort observability: a metric-backend problem must never fail the
+    # activity the watchdog is only observing.
+    except Exception:
+        logger.warning(
+            "Failed to record the no-progress gap metric for task '%s' (%.0fs gap); "
+            "the stall is still logged but will be missing from the fleet-wide "
+            "gap distribution",
+            task_name,
+            stalled_for,
+            exc_info=True,
+        )
+
+
+def record_closed_hold(
+    closed: ClosedHold,
+    *,
+    task_name: str,
+    budget_seconds: float = DEFAULT_MAX_NO_PROGRESS_SECONDS,
+) -> None:
+    """Record one released hold — the second warn-mode shape. Never raises.
+
+    Every hold reaches the metric, so each site's own duration distribution is
+    available to size its allowance from. Only a *notable* hold reaches the log,
+    because once ``run_in_thread`` auto-holds every blocking offload a line per
+    hold would be a line per blocking call — noise that would bury the two
+    findings worth acting on:
+
+    - an **unbounded** hold that ran longer than the no-progress budget. It
+      would have tripped the watchdog had it not been auto-vouched-for, so it is
+      on the work-list: declaring an allowance bounds a wedge there at
+      ``allowance + budget`` instead of leaving it to the duration backstop.
+    - a hold that **lapsed** — the human's own declared allowance was outlived,
+      so the watchdog resumed while the operation was still running. Notable at
+      any duration precisely because nobody had to invent the threshold; too
+      tight an allowance is what turns a healthy slow call into a false kill
+      once anything enforces.
+
+    A long *bounded* hold that stayed inside its allowance is neither: somebody
+    already looked at that site and sized it.
+
+    Args:
+        closed: The observation handed over by ``exit_hold``.
+        task_name: Task the hold was taken in, for the log and the metric.
+        budget_seconds: The task's ``max_no_progress_seconds``. Used only as the
+            floor for the unbounded-hold log line — the metric records
+            everything either way.
+    """
+    _record_hold_duration(closed, task_name)
+
+    if closed.lapsed:
+        logger.info(
+            "Task '%s' held the stall watchdog at '%s' for %.0fs, outliving the "
+            "%.0fs allowance declared for it; the watchdog resumed while the "
+            "operation was still running — raise the allowance if this site is "
+            "healthy, since too tight an allowance is what turns a slow call "
+            "into a failed attempt once the watchdog enforces",
+            task_name,
+            closed.label or "<unlabelled>",
+            closed.duration_seconds,
+            # Never None here: `lapsed` is False for an unbounded hold.
+            closed.allowance_seconds,
+        )
+        return
+
+    if not closed.bounded and closed.duration_seconds >= budget_seconds:
+        logger.info(
+            "Task '%s' held the stall watchdog at '%s' for %.0fs with no declared "
+            "allowance (no-progress budget %.0fs); this site is on the work-list "
+            "— wrap it in holding_progress(timeout=...) so a wedge here is caught "
+            "at allowance + budget rather than left to the duration backstop",
+            task_name,
+            closed.label or "<unlabelled>",
+            closed.duration_seconds,
+            budget_seconds,
+        )
+
+
+def closed_hold_observer(
+    task_name: str, *, budget_seconds: float = DEFAULT_MAX_NO_PROGRESS_SECONDS
+) -> Callable[[ClosedHold], None]:
+    """Build the ``on_hold_closed`` observer for one attempt's tracker.
+
+    Args:
+        task_name: Task this tracker belongs to.
+        budget_seconds: The task's ``max_no_progress_seconds``; see
+            :func:`record_closed_hold`.
+
+    Returns:
+        A callable taking one :class:`ClosedHold`, to hand to
+        :class:`~application_sdk.execution.progress.ProgressTracker`. It never
+        raises, and the tracker guards it a second time — telemetry must never
+        fail the activity it is only observing.
+    """
+    return functools.partial(
+        record_closed_hold, task_name=task_name, budget_seconds=budget_seconds
+    )
+
+
+def _record_hold_duration(closed: ClosedHold, task_name: str) -> None:
+    try:
+        _hold_duration_histogram().record(
+            closed.duration_seconds,
+            {
+                "task.name": task_name,
+                # A hold label identifies a call site, never a value — see
+                # ProgressTracker.enter_hold — so this stays bounded.
+                "hold.label": closed.label,
+                # The shape that needs action. Kept as a dimension rather than
+                # split into two instruments so one query ranks both.
+                "hold.bounded": str(closed.bounded).lower(),
+                "hold.lapsed": str(closed.lapsed).lower(),
+            },
+        )
+    # Best-effort observability, exactly as for the gap metric above.
+    except Exception:
+        logger.warning(
+            "Failed to record the hold duration metric for task '%s' (hold '%s', "
+            "%.0fs); the per-app hold work-list will be missing this observation",
+            task_name,
+            closed.label or "<unlabelled>",
+            closed.duration_seconds,
+            exc_info=True,
+        )

--- a/tests/unit/execution/test_heartbeat.py
+++ b/tests/unit/execution/test_heartbeat.py
@@ -631,6 +631,7 @@ async def _drive(
     not wall time, is what the watchdog reads.
     """
     from application_sdk.execution import heartbeat as hb_mod
+    from application_sdk.execution import progress_telemetry as pt_mod
 
     stop = asyncio.Event()
     beats: list[int] = []
@@ -646,9 +647,12 @@ async def _drive(
         if len(beats) >= ticks:
             stop.set()
 
+    # Two loggers: the watchdog's decisions are logged from the loop, the metric
+    # is recorded (and its failures reported) from the telemetry module.
     with (
         patch.object(hb_mod, "logger") as mock_logger,
-        patch.object(hb_mod, "_no_progress_gap_histogram", return_value=histogram),
+        patch.object(pt_mod, "logger") as mock_metric_logger,
+        patch.object(pt_mod, "_no_progress_gap_histogram", return_value=histogram),
     ):
         await auto_heartbeat_loop(
             interval_seconds=0.001,
@@ -670,7 +674,10 @@ async def _drive(
         ],
         stall_warnings=[
             c
-            for c in mock_logger.warning.call_args_list
+            for c in (
+                *mock_logger.warning.call_args_list,
+                *mock_metric_logger.warning.call_args_list,
+            )
             if any(
                 marker in str(c)
                 for marker in ("progress", "Stall watchdog", "Stall handler")

--- a/tests/unit/execution/test_progress_telemetry.py
+++ b/tests/unit/execution/test_progress_telemetry.py
@@ -1,0 +1,276 @@
+"""Unit tests for application_sdk.execution.progress_telemetry.
+
+The second warn-mode shape: what a released hold reports, and which of those
+reports is worth a log line. The first shape (no-progress gaps) is exercised
+through the watchdog loop in ``test_heartbeat.py``, which is where it is
+produced.
+
+Assertions run against the observer as the tracker actually calls it — through
+``exit_hold`` — rather than against the record function alone, so the wiring is
+covered too.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from application_sdk.execution import progress_telemetry as pt_mod
+from application_sdk.execution.progress import (
+    DEFAULT_MAX_NO_PROGRESS_SECONDS,
+    ClosedHold,
+    ProgressTracker,
+)
+from application_sdk.execution.progress_telemetry import (
+    closed_hold_observer,
+    record_closed_hold,
+)
+
+# ---------------------------------------------------------------------------
+# Test doubles
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FakeClock:
+    """A monotonic clock the test advances explicitly.
+
+    Injected rather than patched: an asyncio loop shares ``time.monotonic``, so
+    patching it globally makes the loop itself misbehave.
+    """
+
+    now: float = 1000.0
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+@dataclass
+class Observed:
+    """What one hold's release reported."""
+
+    recorded: list[Any] = field(default_factory=list)
+    infos: list[Any] = field(default_factory=list)
+    warnings: list[Any] = field(default_factory=list)
+
+    @property
+    def attributes(self) -> dict[str, str]:
+        """Attributes of the single recorded observation."""
+        assert len(self.recorded) == 1
+        return self.recorded[0].args[1]
+
+    @property
+    def duration(self) -> float:
+        assert len(self.recorded) == 1
+        return self.recorded[0].args[0]
+
+
+def _release(
+    *,
+    took: float,
+    allowance: float | None,
+    label: str = "full table scan",
+    task_name: str = "extract",
+    budget: float = DEFAULT_MAX_NO_PROGRESS_SECONDS,
+    record_raises: bool = False,
+) -> Observed:
+    """Open a hold on a real tracker, let ``took`` seconds pass, release it."""
+    clock = FakeClock()
+    histogram = MagicMock()
+    if record_raises:
+        histogram.record.side_effect = RuntimeError("metric backend down")
+
+    tracker = ProgressTracker(
+        clock=clock,
+        on_hold_closed=closed_hold_observer(task_name, budget_seconds=budget),
+    )
+    token = tracker.enter_hold(label, allowance)
+    clock.advance(took)
+
+    with (
+        patch.object(pt_mod, "logger") as mock_logger,
+        patch.object(pt_mod, "_hold_duration_histogram", return_value=histogram),
+    ):
+        tracker.exit_hold(token)
+
+    return Observed(
+        recorded=list(histogram.record.call_args_list),
+        infos=list(mock_logger.info.call_args_list),
+        warnings=list(mock_logger.warning.call_args_list),
+    )
+
+
+# ---------------------------------------------------------------------------
+# The metric: every hold, so each site has a distribution to size from
+# ---------------------------------------------------------------------------
+
+
+class TestHoldMetric:
+    def test_an_unbounded_hold_is_recorded_as_unbounded(self) -> None:
+        observed = _release(took=42.0, allowance=None)
+
+        assert observed.duration == 42.0
+        assert observed.attributes == {
+            "task.name": "extract",
+            "hold.label": "full table scan",
+            "hold.bounded": "false",
+            "hold.lapsed": "false",
+        }
+
+    def test_a_hold_inside_its_allowance_is_bounded_and_not_lapsed(self) -> None:
+        observed = _release(took=30.0, allowance=60.0)
+
+        assert observed.attributes["hold.bounded"] == "true"
+        assert observed.attributes["hold.lapsed"] == "false"
+
+    def test_a_hold_past_its_allowance_is_lapsed(self) -> None:
+        observed = _release(took=90.0, allowance=60.0)
+
+        assert observed.attributes["hold.bounded"] == "true"
+        assert observed.attributes["hold.lapsed"] == "true"
+
+    def test_short_holds_are_recorded_too(self) -> None:
+        """The metric is not thresholded: choosing an allowance for a site means
+        reading that site's whole distribution, not only its tail."""
+        observed = _release(took=0.25, allowance=None)
+
+        assert observed.duration == 0.25
+        assert not observed.infos
+
+    def test_the_task_name_comes_from_the_observer(self) -> None:
+        observed = _release(took=1.0, allowance=None, task_name="fetch_databases")
+
+        assert observed.attributes["task.name"] == "fetch_databases"
+
+
+# ---------------------------------------------------------------------------
+# The log: only the findings that are on the work-list
+# ---------------------------------------------------------------------------
+
+
+class TestWorkListLog:
+    def test_a_long_unbounded_hold_is_reported(self) -> None:
+        observed = _release(took=1200.0, allowance=None, budget=900.0)
+
+        assert len(observed.infos) == 1
+        message = str(observed.infos[0])
+        assert "holding_progress" in message
+        assert "no declared allowance" in message
+
+    def test_an_unbounded_hold_at_the_budget_is_reported(self) -> None:
+        """The boundary is inclusive: a hold that reached the budget is exactly
+        one that would have tripped the watchdog had it not been vouched for."""
+        observed = _release(took=900.0, allowance=None, budget=900.0)
+
+        assert len(observed.infos) == 1
+
+    def test_a_short_unbounded_hold_is_not_reported(self) -> None:
+        observed = _release(took=899.0, allowance=None, budget=900.0)
+
+        assert not observed.infos
+
+    def test_a_lapsed_hold_is_reported_however_short(self) -> None:
+        """No SDK-invented threshold is involved: the human declared the number
+        and the operation outlived it."""
+        observed = _release(took=2.0, allowance=1.0, budget=900.0)
+
+        assert len(observed.infos) == 1
+        assert "outliving" in str(observed.infos[0])
+
+    def test_a_long_bounded_hold_inside_its_allowance_is_not_reported(self) -> None:
+        """Somebody already looked at this site and sized it — it is not work."""
+        observed = _release(took=5000.0, allowance=7200.0, budget=900.0)
+
+        assert not observed.infos
+
+    def test_findings_are_never_logged_at_warning(self) -> None:
+        """Warn mode is a fleet-wide default, so a finding is an expected
+        observation rather than an actionable failure (ADR-0018)."""
+        for took, allowance in ((1200.0, None), (2.0, 1.0)):
+            observed = _release(took=took, allowance=allowance, budget=900.0)
+
+            assert observed.infos and not observed.warnings
+
+    def test_an_unlabelled_hold_still_reads(self) -> None:
+        observed = _release(took=1200.0, allowance=None, budget=900.0, label="")
+
+        assert "<unlabelled>" in str(observed.infos[0])
+        assert observed.attributes["hold.label"] == ""
+
+
+# ---------------------------------------------------------------------------
+# Telemetry must never fail the activity it is only observing
+# ---------------------------------------------------------------------------
+
+
+class TestBestEffort:
+    def test_a_metric_failure_still_reports_the_finding(self) -> None:
+        observed = _release(
+            took=1200.0, allowance=None, budget=900.0, record_raises=True
+        )
+
+        assert len(observed.infos) == 1
+        assert any("hold duration metric" in str(c) for c in observed.warnings)
+
+    def test_a_metric_failure_never_reaches_the_caller(self) -> None:
+        """``exit_hold`` runs in the app's own ``finally`` — it must return
+        normally whatever the metric backend is doing. ``_release`` calls it
+        unguarded, so returning at all is half the assertion."""
+        observed = _release(took=1.0, allowance=None, record_raises=True)
+
+        assert len(observed.recorded) == 1  # attempted, not skipped
+        assert observed.warnings  # and reported as a gap in the report
+
+
+# ---------------------------------------------------------------------------
+# The observer itself
+# ---------------------------------------------------------------------------
+
+
+class TestObserver:
+    def test_the_default_budget_is_the_no_progress_budget(self) -> None:
+        """One number with two uses, not two numbers that can drift apart."""
+        histogram = MagicMock()
+        with (
+            patch.object(pt_mod, "logger") as mock_logger,
+            patch.object(pt_mod, "_hold_duration_histogram", return_value=histogram),
+        ):
+            closed_hold_observer("extract")(
+                ClosedHold(
+                    label="metadata query",
+                    duration_seconds=DEFAULT_MAX_NO_PROGRESS_SECONDS,
+                    allowance_seconds=None,
+                )
+            )
+
+        assert len(mock_logger.info.call_args_list) == 1
+
+    @pytest.mark.parametrize("allowance", [None, 60.0])
+    def test_an_unreachable_meter_degrades_to_log_only(
+        self, allowance: float | None
+    ) -> None:
+        """No ``MeterProvider`` at all — both shapes of finding must still be
+        named in the log rather than disappearing with the metric."""
+        with (
+            patch.object(pt_mod, "logger") as mock_logger,
+            patch.object(
+                pt_mod, "_hold_duration_histogram", side_effect=RuntimeError("no meter")
+            ),
+        ):
+            record_closed_hold(
+                ClosedHold(
+                    label="metadata query",
+                    duration_seconds=10_000.0,
+                    allowance_seconds=allowance,
+                ),
+                task_name="extract",
+            )
+
+        assert len(mock_logger.info.call_args_list) == 1
+        assert mock_logger.warning.call_args_list


### PR DESCRIPTION
Closes FND-292. ADR-0018 → *Warn mode: the watchdog is its own audit tool*.

> **Stacked on #3160** (FND-289, `chrishehim/fnd-289`) — review only the 6 files below; merge that one first. FND-290 is already merged into the base, so `run_in_thread` and `run_fault_isolated` auto-hold every offload today, which is what makes the second shape here carry real traffic.

Warn mode is what turns the stall watchdog into its own audit tool. The obvious author question is *"how do I find every place that needs a hold, and what allowance do I put on each?"* — and answering it with "audit your code" would reintroduce ADR-0018's own problem one level down: a per-site number, guessed up front, by hand. The watchdog already observes exactly what that audit would look for, so it reports instead, and the whole-codebase audit collapses into reading a report.

## The two shapes

**1. No-progress gaps with no hold in force** — the sites that need a progress hook or a hold. Already emitted by the watchdog (FND-286); moved into the new `execution/progress_telemetry.py` so both shapes share one meter, one instrument cache and one home for FND-293's alert to build on. `heartbeat.py` keeps the loop logic and loses ~70 lines of metric plumbing its own docstring (beats + the offload seam) never claimed.

**2. Long holds, and long *unbounded* holds above all** — the sites that want an explicit allowance rather than the duration backstop. New, fed by every `exit_hold` through the `ClosedHold` seam FND-283 left open and wired onto the attempt's tracker in `activities.py`. Without this shape a blocking call offloaded through `run_in_thread` is invisible to the audit *precisely because it is auto-vouched-for*.

| | metric | log |
| --- | --- | --- |
| `task.no_progress_gap` | once per gap that exceeded the budget | INFO |
| `task.hold_duration` | **every** hold released | INFO only when on the work-list |

Every closed hold reaches the metric because choosing an allowance for a site means reading that site's whole distribution — ADR-0018 asks for its p99 plus headroom — and a metric that only fired above a threshold could not answer that. Only a hold that is *on the work-list* reaches the log, because with FND-290's auto-holds in the base a line per hold would be a line per blocking call:

- an **unbounded** hold that outran the no-progress budget — it would have tripped the watchdog had it not been auto-vouched-for, so declaring an allowance bounds a wedge there at `allowance + budget` instead of leaving it to the backstop;
- a hold that **lapsed** — the human's own declared allowance was outlived, so the watchdog resumed while the operation was still running. Notable at any duration precisely because nobody had to invent the threshold; too tight an allowance is what turns a healthy slow call into a false kill once anything enforces.

A long *bounded* hold inside its allowance is neither — somebody already looked at that site and sized it.

`hold.label` is safe as a metric dimension: FND-290's `_offloaded_callable_name` already reduces an auto-hold's label to a checked code identifier with a single stand-in for anything unusable, and a declared hold's label is a human-typed call-site name.

## Constraints held

- **Never WARNING.** Warn mode is a fleet-wide default, so a stall observation under it is an expected observation rather than an actionable failure; WARNING would manufacture exactly the alert noise ADR-0018 exists to reduce. The only WARNING in the module is a telemetry failure — a statement about the report being incomplete, not about the app.
- **Reported once.** Gaps re-arm after reporting (unchanged from FND-286); a hold reports once, when it closes.
- **Rankable per app, aggregatable fleet-wide.** No app attribute is needed: `app.name` is inlined onto every series from the OTel Resource and the rest of the app identity is reachable through `target_info`, so the instruments carry only what distinguishes sites *within* an app.
- **Never fails an activity.** Each record is guarded locally, and `ProgressTracker` guards the observer a second time. The observer also runs outside the tracker's lock.

## `DEFAULT_MAX_NO_PROGRESS_SECONDS`

One number with two uses rather than two numbers that can drift apart: the hold report's log floor now, and `max_no_progress_seconds` when FND-296 adds the per-task `progress_watchdog` flag. 900s is ADR-0018's stated starting value.

## Not in scope

The per-task flag and the warn-by-default wiring are FND-296; the alert on the stall metric is FND-293; the author-facing docs are FND-295.

## Testing

- New `tests/unit/execution/test_progress_telemetry.py` (17 tests) drives the observer through a real `ProgressTracker.exit_hold`, so the wiring is covered along with the policy: metric attributes for each hold shape, the log's boundary cases in both directions, findings never at WARNING, and degrade-to-log-only when no `MeterProvider` is reachable.
- `tests/unit/execution/test_heartbeat.py` updated for the moved shape-1 helpers; the metric assertions still run through the watchdog loop.
- Full unit suite green on the rebased branch (6853 passed), pre-commit clean, conformance clean on every changed file.
