### PR TITLE
fix(storage): close the two cancellation races in the offloaded parquet paths (FND-315)

### DIFF
--- a/application_sdk/execution/heartbeat.py
+++ b/application_sdk/execution/heartbeat.py
@@ -7,12 +7,13 @@ Two modes of heartbeating are supported:
 2. Manual (developer-controlled): developer calls heartbeat() with progress info
    for resume-on-retry support.
 
-This module is also the SDK's offload seam, with three sanctioned primitives:
+This module is also the SDK's offload seam, with four sanctioned primitives:
 ``run_in_thread`` offloads blocking calls so they don't starve the heartbeat
-loop (ADR-0010); ``run_fault_isolated`` runs work in a child process so a native
-fault can't kill the worker; and ``run_best_effort`` is the policy layer over it
-for non-essential work — it isolates *and* swallows failures so best-effort work
-can never break the caller.
+loop (ADR-0010); ``submit_in_thread`` is its detached variant for cleanup that
+cancellation must not be able to skip; ``run_fault_isolated`` runs work in a
+child process so a native fault can't kill the worker; and ``run_best_effort``
+is the policy layer over it for non-essential work — it isolates *and* swallows
+failures so best-effort work can never break the caller.
 """
 
 import asyncio
@@ -534,6 +535,74 @@ async def run_in_thread(func: Callable[..., T], *args: Any, **kwargs: Any) -> T:
         _BLOCKING_EXECUTOR,
         functools.partial(ctx.run, functools.partial(func, *args, **kwargs)),
     )
+
+
+def submit_in_thread(
+    func: Callable[..., Any], *args: Any, **kwargs: Any
+) -> "concurrent.futures.Future[Any]":
+    """Run a blocking *cleanup* call on the offload pool without awaiting it.
+
+    ``run_in_thread`` is the primitive to reach for. This is its narrow
+    companion for one specific problem: **cleanup that cancellation must not be
+    able to skip.** An ``await`` inside a ``finally`` is itself a cancellation
+    point, so a cancelled coroutine can be cut off before its own cleanup runs
+    and leak whatever it was holding. Submitting instead of awaiting takes the
+    event loop out of the path entirely: the call is handed to the pool and runs
+    to completion whether or not the caller survives — and, because it is not on
+    the loop, it may block on a lock held by an orphaned worker thread.
+
+    Nothing awaits the result, so a failure has nowhere to surface. It is logged
+    here rather than being swallowed by an unretrieved future.
+
+    Use only for short, self-contained cleanup — closing a handle, releasing a
+    lock — whose result no caller needs. Anything a caller must observe, or must
+    know has finished before the next step, belongs in ``run_in_thread``.
+
+    Args:
+        func: Blocking cleanup callable.
+        *args: Positional arguments for ``func``.
+        **kwargs: Keyword arguments for ``func``.
+
+    Returns:
+        The pool future, for callers (in practice, tests) that want to wait on
+        it. A cancelled future means the pool was already shut down and the call
+        never ran. Ignoring the return value is the normal case.
+    """
+    ctx = contextvars.copy_context()
+    try:
+        future = _BLOCKING_EXECUTOR.submit(
+            ctx.run, functools.partial(func, *args, **kwargs)
+        )
+    except RuntimeError:
+        # The pool refuses work only once it has been shut down, which happens
+        # at interpreter exit. Nothing is left running to clean up after, and the
+        # OS reclaims whatever the process was holding — so this is ordinary
+        # shutdown ordering rather than a failure, and a caller unwinding in a
+        # ``finally`` must not have an exception raised at it here.
+        logger.debug(
+            "Offload pool is shut down; skipped detached cleanup call to %r",
+            getattr(func, "__qualname__", func),
+            exc_info=True,
+        )
+        skipped: concurrent.futures.Future[Any] = concurrent.futures.Future()
+        skipped.cancel()
+        return skipped
+    future.add_done_callback(_report_detached_failure)
+    return future
+
+
+def _report_detached_failure(future: "concurrent.futures.Future[Any]") -> None:
+    """Log a detached cleanup failure, since no caller will ever await it."""
+    if future.cancelled():
+        return
+    error = future.exception()
+    if error is not None:
+        logger.warning(
+            "Detached cleanup call failed: %s: %s",
+            type(error).__name__,
+            error,
+            exc_info=error,
+        )
 
 
 # Executor for work that must not be able to take the worker down with it.

--- a/application_sdk/storage/formats/parquet.py
+++ b/application_sdk/storage/formats/parquet.py
@@ -1,15 +1,16 @@
 import inspect
 import os
+import threading
 import uuid
 import warnings
-from collections.abc import AsyncGenerator, AsyncIterator, Generator
+from collections.abc import AsyncGenerator, AsyncIterator, Generator, Iterator
 from typing import TYPE_CHECKING, cast
 
 from application_sdk.common.file_ops import SafeFileOps
 from application_sdk.constants import DAPR_MAX_GRPC_MESSAGE_LENGTH
 from application_sdk.contracts.types import FileReference
 from application_sdk.errors import AppError
-from application_sdk.execution.heartbeat import run_in_thread
+from application_sdk.execution.heartbeat import run_in_thread, submit_in_thread
 from application_sdk.execution.progress import current_progress_tracker
 from application_sdk.observability.logger_adaptor import get_logger
 from application_sdk.observability.metrics_adaptor import MetricType, get_metrics
@@ -30,6 +31,78 @@ logger = get_logger(__name__)
 if TYPE_CHECKING:
     import pandas as pd
     import pyarrow as pa
+    import pyarrow.parquet as pq
+
+#: Directory under a writer's output path holding accumulation chunks until they
+#: are consolidated. Each writer owns a token-named subdirectory of it — see
+#: :meth:`ParquetFileWriter._get_temp_base_path`.
+_TEMP_ACCUMULATION_DIRNAME = "temp_accumulation"
+
+
+class _ThreadConfinedParquetReader:
+    """Owns one ``ParquetFile`` handle, touched only from worker threads.
+
+    :meth:`ParquetFileReader._get_batched_dataframe` offloads every decode step
+    to a worker thread and ``await``\\ s it, so every step is a cancellation
+    point — and a worker thread cannot be killed (ADR-0010). Closing the handle
+    from the event loop therefore raced an orphaned worker still inside
+    ``next(batches)``, closing a handle pyarrow was decoding from (FND-315).
+
+    Two rules remove that race:
+
+    * The handle is opened, decoded from and closed **only** under
+      :attr:`_lock`, so a close issued while a decode is in flight waits for it
+      instead of landing underneath it. The lock is held for a whole decode, so
+      it must never be acquired from the event loop.
+    * The event loop never *awaits* the close — see
+      :func:`~application_sdk.execution.heartbeat.submit_in_thread`. That is
+      what keeps the original reason the close was never offloaded intact: an
+      ``await`` in a ``finally`` can itself be cancelled, leaking the handle.
+    """
+
+    def __init__(self, file_path: str, chunk_size: int) -> None:
+        self._file_path = file_path
+        self._chunk_size = chunk_size
+        self._lock = threading.Lock()
+        self._parquet_file: "pq.ParquetFile | None" = None
+        self._batches: "Iterator[pa.RecordBatch] | None" = None
+        self._closed = False
+
+    def next_frame(self) -> "pd.DataFrame | None":
+        """Open the file on first call, then decode one batch. Worker threads only.
+
+        Returns ``None`` when the file is exhausted, or when the handle is
+        already closed — a step can still be queued behind the close a cancelled
+        caller submitted.
+        """
+        import pyarrow.parquet as pq  # noqa: PLC0415 — optional dep: pyarrow.parquet
+
+        with self._lock:
+            if self._closed:
+                return None
+            if self._batches is None:
+                self._parquet_file = pq.ParquetFile(self._file_path)
+                self._batches = self._parquet_file.iter_batches(
+                    batch_size=self._chunk_size
+                )
+            batch = next(self._batches, None)
+            return None if batch is None else batch.to_pandas()
+
+    def close(self) -> None:
+        """Close the handle once no decode is in flight. Worker threads only.
+
+        Idempotent, and blocking: it waits on :attr:`_lock` for however long the
+        in-flight decode takes.
+        """
+        with self._lock:
+            self._closed = True
+            parquet_file, self._parquet_file, self._batches = (
+                self._parquet_file,
+                None,
+                None,
+            )
+            if parquet_file is not None:
+                parquet_file.close()
 
 
 def _normalize_all_null_string_columns(table: "pa.Table") -> "pa.Table":
@@ -353,8 +426,6 @@ class ParquetFileReader(Reader):
         - Only reads files in the specified directory
         """
         try:
-            import pyarrow.parquet as pq  # noqa: PLC0415 — optional dep: pyarrow.parquet
-
             # Ensure files are available (local or downloaded)
             parquet_files = await _download_files(
                 self.path, PARQUET_FILE_EXTENSION, self.file_names
@@ -371,26 +442,24 @@ class ParquetFileReader(Reader):
                 # Both are blocking, and at batch_size=100k the per-batch cost
                 # is far past the heartbeat interval — offload each step so the
                 # loop stays free to beat between batches (ADR-0010).
-                pf = await run_in_thread(pq.ParquetFile, parquet_file)
+                #
+                # The handle lives in the worker rather than in this frame:
+                # every ``await`` below is a cancellation point, and a worker
+                # thread cannot be killed, so a close issued from here could
+                # land while an orphan was still decoding (FND-315).
+                reader = _ThreadConfinedParquetReader(parquet_file, chunk_size)
                 try:
-                    batches = pf.iter_batches(batch_size=chunk_size)
-
-                    def _next_frame() -> "pd.DataFrame | None":
-                        batch = next(batches, None)  # noqa: B023 — consumed within this iteration
-                        return None if batch is None else batch.to_pandas()
-
                     while True:
-                        frame = await run_in_thread(_next_frame)
+                        frame = await run_in_thread(reader.next_frame)
                         if frame is None:
                             break
                         yield frame
                 finally:
-                    # Closed inline, not via run_in_thread: an ``await`` in a
-                    # finally can itself be cancelled, which would leak the
-                    # handle on activity cancellation or generator close.
-                    # Closing a parquet reader is one cheap syscall, so there
-                    # is nothing here worth offloading.
-                    pf.close()
+                    # Submitted, not awaited: an ``await`` in a ``finally`` is
+                    # itself cancellable and would leak the handle, and the
+                    # close must be free to wait out an in-flight decode
+                    # without blocking the event loop for its duration.
+                    submit_in_thread(reader.close)
         # See _get_dataframe: preserve an already-typed AppError.
         except AppError:
             raise
@@ -539,6 +608,24 @@ class ParquetFileWriter(Writer):
         self.temp_folders_created: list[int] = []  # Track temp folders for cleanup
         self.current_temp_folder_path: str | None = None  # Current temp folder path
 
+        # Token scoping the accumulation tree to this writer instance.
+        #
+        # Cancelling an activity leaves the orphaned `_convert_and_write` worker
+        # alive (a thread cannot be killed, ADR-0010) and still writing
+        # `chunk-{n}` files. Every part of the old path was attempt-independent
+        # — `temp_accumulation/folder-{i}`, with `temp_folder_index` reset to 0
+        # both here and in `_cleanup_temp_folders` — so a retry landed on the
+        # exact directory that orphan was writing into: its file count shifted
+        # the retry's `chunk-{n}` numbering (mixing the orphan's partial output
+        # into a consolidation, or skipping the retry's own), and the retry's
+        # cleanup could rmtree a live directory (FND-315).
+        #
+        # Per writer instance rather than per activity attempt: strictly
+        # stronger (two writers within one attempt are covered too) and it
+        # needs no activity context in `storage/`, which would deepen the
+        # layering debt tracked in FND-316.
+        self._temp_run_id = uuid.uuid4().hex[:8]
+
         if self.chunk_start:
             self.chunk_count = self.chunk_start + self.chunk_count
 
@@ -658,10 +745,17 @@ class ParquetFileWriter(Writer):
 
     # Consolidation helper methods
 
+    def _get_temp_base_path(self) -> str:
+        """Root of this writer's accumulation tree.
+
+        Token-scoped, so no two writers — and therefore no two activity attempts
+        — can ever share an accumulation directory. See ``_temp_run_id``.
+        """
+        return os.path.join(self.path, _TEMP_ACCUMULATION_DIRNAME, self._temp_run_id)
+
     def _get_temp_folder_path(self, folder_index: int) -> str:
         """Generate temp folder path consistent with existing structure."""
-        temp_base_path = os.path.join(self.path, "temp_accumulation")
-        return os.path.join(temp_base_path, f"folder-{folder_index}")
+        return os.path.join(self._get_temp_base_path(), f"folder-{folder_index}")
 
     def _get_consolidated_file_path(self, folder_index: int, chunk_part: int) -> str:
         """Generate final consolidated file path using existing path_gen logic."""
@@ -818,7 +912,12 @@ class ParquetFileWriter(Writer):
             raise
 
     async def _cleanup_temp_folders(self):
-        """Clean up all temp folders after consolidation."""
+        """Clean up this writer's temp folders after consolidation.
+
+        Only ever removes paths under this writer's own token-scoped tree, so it
+        cannot delete a directory an orphaned worker from a cancelled attempt is
+        still writing into (FND-315).
+        """
         try:
             # Add current folder to cleanup list if it exists
             if self.current_temp_folder_path is not None:
@@ -827,20 +926,48 @@ class ParquetFileWriter(Writer):
             # Clean up all temp folders
             for folder_index in self.temp_folders_created:
                 temp_folder = self._get_temp_folder_path(folder_index)
-                if SafeFileOps.exists(temp_folder):
+                if not SafeFileOps.exists(temp_folder):
+                    continue
+                try:
                     # Offloaded: an accumulation folder holds a run's worth of
                     # parquet chunks, and rmtree on the event loop stalls every
                     # other coroutine — including the auto-heartbeat.
-                    await run_in_thread(
-                        SafeFileOps.rmtree, temp_folder, ignore_errors=True
+                    await run_in_thread(SafeFileOps.rmtree, temp_folder)
+                except OSError:
+                    # No `ignore_errors=True` any more. It was load-bearing only
+                    # while attempts shared this tree, where a vanished
+                    # directory meant a sibling attempt had deleted it — the
+                    # very failure it hid (FND-315). Within a writer-scoped
+                    # tree a failure here is a real one (full disk, permission
+                    # change, a file still held open) and worth reporting.
+                    logger.warning(
+                        "Failed to remove parquet accumulation folder %s; "
+                        "it will be left on local disk",
+                        temp_folder,
+                        exc_info=True,
                     )
 
-            # Clean up base temp directory if it exists and is empty
-            temp_base_path = os.path.join(self.path, "temp_accumulation")
-            if SafeFileOps.exists(temp_base_path) and not SafeFileOps.listdir(
-                temp_base_path
+            # Clean up this writer's temp root, then the shared parent, each only
+            # when empty — a sibling writer's tree is never removed here.
+            for directory in (
+                self._get_temp_base_path(),
+                os.path.join(self.path, _TEMP_ACCUMULATION_DIRNAME),
             ):
-                SafeFileOps.rmdir(temp_base_path)
+                if SafeFileOps.exists(directory) and not SafeFileOps.listdir(directory):
+                    try:
+                        SafeFileOps.rmdir(directory)
+                    except OSError:
+                        # A concurrent writer can claim its own token directory
+                        # between the emptiness check and the rmdir, which is
+                        # exactly the outcome the check wanted. Debug, not
+                        # warning: an empty directory left behind costs nothing,
+                        # and the next writer to finish removes it.
+                        logger.debug(
+                            "Left %s in place; another writer claimed it between "
+                            "the emptiness check and removal",
+                            directory,
+                            exc_info=True,
+                        )
 
             # Reset state
             self.temp_folders_created.clear()

--- a/tests/unit/execution/test_heartbeat.py
+++ b/tests/unit/execution/test_heartbeat.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import concurrent.futures
+import functools
 import sys
 import types
 from collections.abc import Callable
@@ -499,6 +500,41 @@ class TestSubmitInThread:
         assert isinstance(future.exception(), OSError)
         warning.assert_called_once()
         assert "handle already gone" in str(warning.call_args)
+
+    def test_submission_is_detached_the_callable_does_not_run_inline(self) -> None:
+        """The contract InlineExecutor cannot see: submit returns *before* running.
+
+        ``InlineExecutor`` runs the callable synchronously inside ``submit``, so
+        a regression that ran cleanup inline would still pass every other test
+        here. A pool that holds the callable pending makes the detached contract
+        observable: submission returns with the callable not yet run, and the
+        failure-callback path fires when the recorded callable is later driven.
+        """
+        from application_sdk.execution import heartbeat as hb_mod
+
+        submitted: list[Callable[[], Any]] = []
+
+        class PendingExecutor:
+            """A pool that records the callable and returns an unfinished future."""
+
+            def submit(
+                self, fn: Callable[..., Any], *args: Any, **kwargs: Any
+            ) -> concurrent.futures.Future[Any]:
+                submitted.append(functools.partial(fn, *args, **kwargs))
+                return concurrent.futures.Future()
+
+        calls: list[str] = []
+        with patch.object(hb_mod, "_BLOCKING_EXECUTOR", PendingExecutor()):
+            future = hb_mod.submit_in_thread(lambda: calls.append("ran"))
+
+        assert calls == [], "submit_in_thread ran the cleanup inline"
+        assert submitted and not future.done()
+
+        # Drive the recorded callable's future to failure; the done-callback logs it.
+        with patch.object(hb_mod.logger, "warning") as warning:
+            future.set_exception(OSError("drive failure"))
+        warning.assert_called_once()
+        assert "drive failure" in str(warning.call_args)
 
     def test_a_shut_down_pool_does_not_raise_at_the_unwinding_caller(self) -> None:
         """Callers submit from a ``finally``; interpreter exit must not raise there."""

--- a/tests/unit/execution/test_heartbeat.py
+++ b/tests/unit/execution/test_heartbeat.py
@@ -9,6 +9,7 @@ pre-set events to avoid hangs.
 from __future__ import annotations
 
 import asyncio
+import concurrent.futures
 import sys
 import types
 from collections.abc import Callable
@@ -445,6 +446,87 @@ class TestRunInThread:
         with patch.object(hb_mod.asyncio, "get_running_loop", return_value=fake_loop):
             with pytest.raises(ValueError):
                 await run_in_thread(bad)
+
+
+# ---------------------------------------------------------------------------
+# submit_in_thread — detached cleanup, also no real threads
+# ---------------------------------------------------------------------------
+
+
+class InlineExecutor:
+    """Stand-in for the SDK pool that runs submitted work on the calling thread."""
+
+    def __init__(self) -> None:
+        self.submissions: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+
+    def submit(self, fn, *args, **kwargs):
+        self.submissions.append((args, kwargs))
+        future: concurrent.futures.Future[Any] = concurrent.futures.Future()
+        future.set_running_or_notify_cancel()
+        try:
+            future.set_result(fn(*args, **kwargs))
+        except BaseException as exc:  # noqa: BLE001 — mirrors executor semantics
+            future.set_exception(exc)
+        return future
+
+
+class TestSubmitInThread:
+    def test_submits_to_the_sdk_pool_with_args_propagated(self) -> None:
+        """Detached dispatch goes to the SDK-owned pool, not the default executor."""
+        from application_sdk.execution import heartbeat as hb_mod
+
+        executor = InlineExecutor()
+        calls: list[tuple[int, int]] = []
+
+        with patch.object(hb_mod, "_BLOCKING_EXECUTOR", executor):
+            future = hb_mod.submit_in_thread(lambda a, b: calls.append((a, b)), 1, b=2)
+
+        assert calls == [(1, 2)]
+        assert future.done() and future.exception() is None
+        assert len(executor.submissions) == 1
+
+    def test_a_failure_is_reported_rather_than_swallowed(self) -> None:
+        """Nothing awaits the future, so the failure has to surface in the log."""
+        from application_sdk.execution import heartbeat as hb_mod
+
+        def boom() -> None:
+            raise OSError("handle already gone")
+
+        with patch.object(hb_mod, "_BLOCKING_EXECUTOR", InlineExecutor()):
+            with patch.object(hb_mod.logger, "warning") as warning:
+                future = hb_mod.submit_in_thread(boom)
+
+        assert isinstance(future.exception(), OSError)
+        warning.assert_called_once()
+        assert "handle already gone" in str(warning.call_args)
+
+    def test_a_shut_down_pool_does_not_raise_at_the_unwinding_caller(self) -> None:
+        """Callers submit from a ``finally``; interpreter exit must not raise there."""
+        from application_sdk.execution import heartbeat as hb_mod
+
+        shut_down = MagicMock()
+        shut_down.submit.side_effect = RuntimeError(
+            "cannot schedule new futures after shutdown"
+        )
+
+        with patch.object(hb_mod, "_BLOCKING_EXECUTOR", shut_down):
+            with patch.object(hb_mod.logger, "warning") as warning:
+                future = hb_mod.submit_in_thread(lambda: None)
+
+        assert future.cancelled(), "a skipped cleanup call must report as cancelled"
+        warning.assert_not_called()
+
+    def test_a_cancelled_submission_is_not_reported_as_a_failure(self) -> None:
+        """A future cancelled before it ran never failed, so it must stay quiet."""
+        from application_sdk.execution import heartbeat as hb_mod
+
+        cancelled: concurrent.futures.Future[Any] = concurrent.futures.Future()
+        cancelled.cancel()
+
+        with patch.object(hb_mod.logger, "warning") as warning:
+            hb_mod._report_detached_failure(cancelled)
+
+        warning.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/storage/formats/test_offload_cancellation.py
+++ b/tests/unit/storage/formats/test_offload_cancellation.py
@@ -43,7 +43,10 @@ pytestmark = pytest.mark.asyncio
 # hang fails the test rather than the job.
 BLOCK_TIMEOUT_SECONDS = 10.0
 POLL_SECONDS = 0.01
-POLL_ATTEMPTS = 500
+# The readiness poll must outlast BLOCK_TIMEOUT_SECONDS: a gated worker parks for
+# up to that long, so a shorter budget can fail the readiness assert while the
+# worker is still legitimately waiting on its own gate.
+POLL_ATTEMPTS = 1200  # 12 s > BLOCK_TIMEOUT_SECONDS
 
 WORKER_THREAD_PREFIX = "sdk-blocking-"
 
@@ -198,21 +201,23 @@ class TestReaderCancellation:
                 pass
 
         task = asyncio.create_task(consume())
-        assert await wait_until(gated.batch_started.is_set), "decode never started"
+        try:
+            assert await wait_until(gated.batch_started.is_set), "decode never started"
 
-        task.cancel()
-        with pytest.raises(asyncio.CancelledError):
-            await task
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
 
-        # The worker is provably still inside the decode here — nothing has
-        # released `may_finish`. Any close recorded at this point is the race.
-        assert gated.closes == [], (
-            "the handle was closed while a worker thread was still decoding "
-            f"from it: {gated.closes}"
-        )
-
-        # Let the orphan unwind rather than leaving it parked on the gate.
-        gated.may_finish.set()
+            # The worker is provably still inside the decode here — nothing has
+            # released `may_finish`. Any close recorded at this point is the race.
+            assert gated.closes == [], (
+                "the handle was closed while a worker thread was still decoding "
+                f"from it: {gated.closes}"
+            )
+        finally:
+            # Let the orphan unwind rather than leaving it parked on the gate,
+            # even if a readiness assertion failed above.
+            gated.may_finish.set()
 
     async def test_the_close_waits_for_the_orphaned_decode_then_runs(
         self, tmp_path: Path
@@ -230,12 +235,13 @@ class TestReaderCancellation:
                 pass
 
         task = asyncio.create_task(consume())
-        assert await wait_until(gated.batch_started.is_set), "decode never started"
-        task.cancel()
-        with pytest.raises(asyncio.CancelledError):
-            await task
-
-        gated.may_finish.set()
+        try:
+            assert await wait_until(gated.batch_started.is_set), "decode never started"
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+        finally:
+            gated.may_finish.set()
         assert await wait_until(
             lambda: bool(gated.closes)
         ), "the handle the orphaned worker was left holding was never closed"
@@ -408,23 +414,27 @@ class TestWriterAttemptIsolation:
 
         with patch.object(pq, "write_table", side_effect=gated_write_table):
             task = asyncio.create_task(orphan._accumulate_dataframe(orphan_rows))
-            assert await wait_until(
-                write_started.is_set
-            ), "orphan never started writing"
+            try:
+                assert await wait_until(
+                    write_started.is_set
+                ), "orphan never started writing"
 
-            task.cancel()
-            with pytest.raises(asyncio.CancelledError):
-                await task
+                task.cancel()
+                with pytest.raises(asyncio.CancelledError):
+                    await task
 
-            # The retry runs while the orphan's worker is still parked inside
-            # pq.write_table, holding a chunk path it resolved before cancel.
-            await retry._accumulate_dataframe(retry_rows)
+                # The retry runs while the orphan's worker is still parked inside
+                # pq.write_table, holding a chunk path it resolved before cancel.
+                await retry._accumulate_dataframe(retry_rows)
+            finally:
+                # Release the orphan even on a failed readiness assert, so its
+                # worker is never left parked on the gate.
+                may_write.set()
 
-            # Release the orphan and wait for its write to *land*, not merely for
-            # the path to exist: on a shared directory the file is already there,
-            # written by the retry, and the whole failure is the orphan replacing
-            # it afterwards.
-            may_write.set()
+            # Wait for the orphan's write to *land*, not merely for the path to
+            # exist: on a shared directory the file is already there, written by
+            # the retry, and the whole failure is the orphan replacing it
+            # afterwards.
             assert await wait_until(
                 lambda: bool(orphan_writes_done)
             ), "the orphaned worker never landed its chunk"

--- a/tests/unit/storage/formats/test_offload_cancellation.py
+++ b/tests/unit/storage/formats/test_offload_cancellation.py
@@ -1,0 +1,442 @@
+"""Regression tests for FND-315: cancellation must not race an orphaned worker.
+
+ADR-0010 moved the parquet reader's decode and the writer's convert-and-write
+into worker threads. A thread cannot be killed, so cancelling the activity
+unwinds the event loop while the worker is still touching the resource it was
+handed — and the lifecycle around both offloads was never re-examined against
+that.
+
+Every test here cancels *mid-offload*, with the blocking primitive held open so
+the orphan is provably still running when the loop unwinds. That is the part
+worth being strict about: a happy-path test passes against the broken code, so
+without cancellation coverage neither fix is verifiable.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+from application_sdk.common.types import DataframeType
+from application_sdk.storage.formats.parquet import (
+    ParquetFileReader,
+    ParquetFileWriter,
+    _ThreadConfinedParquetReader,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+pytestmark = pytest.mark.asyncio
+
+# Generous enough that a loaded CI box never trips it, short enough that a real
+# hang fails the test rather than the job.
+BLOCK_TIMEOUT_SECONDS = 10.0
+POLL_SECONDS = 0.01
+POLL_ATTEMPTS = 500
+
+WORKER_THREAD_PREFIX = "sdk-blocking-"
+
+#: Captured before any patching so :class:`GatedParquetFile` can delegate to the
+#: real reader while ``pq.ParquetFile`` itself is patched out.
+REAL_PARQUET_FILE = pq.ParquetFile
+
+
+async def wait_until(predicate) -> bool:
+    """Poll *predicate* from the event loop until it holds, or give up."""
+    for _ in range(POLL_ATTEMPTS):
+        if predicate():
+            return True
+        await asyncio.sleep(POLL_SECONDS)
+    return False
+
+
+def write_parquet(path: Path, rows: int) -> str:
+    """Write a small single-file parquet fixture and return its path."""
+    table = pa.table({"id": list(range(rows)), "value": [f"v{i}" for i in range(rows)]})
+    pq.write_table(table, str(path))
+    return str(path)
+
+
+@dataclass(frozen=True)
+class CloseRecord:
+    """One observed ``ParquetFile.close()``."""
+
+    #: Was a decode in flight on the handle at the moment it was closed?
+    decoding_in_flight: bool
+    #: Which thread issued the close.
+    thread_name: str
+
+
+class GatedParquetFile:
+    """A ``ParquetFile`` whose batch iterator can be held inside ``next()``.
+
+    Holding the iterator open is what makes the race observable: while
+    ``decoding`` is true there is a live worker inside pyarrow, and any close
+    that lands is a close racing a decode.
+    """
+
+    def __init__(
+        self,
+        file_path: str,
+        *,
+        batch_started: threading.Event,
+        may_finish: threading.Event,
+        closes: list[CloseRecord],
+    ) -> None:
+        self._real = REAL_PARQUET_FILE(file_path)
+        self._batch_started = batch_started
+        self._may_finish = may_finish
+        self._closes = closes
+        self.decoding = False
+
+    def iter_batches(self, batch_size: int) -> Iterator[pa.RecordBatch]:
+        for batch in self._real.iter_batches(batch_size=batch_size):
+            self.decoding = True
+            self._batch_started.set()
+            self._may_finish.wait(timeout=BLOCK_TIMEOUT_SECONDS)
+            self.decoding = False
+            yield batch
+
+    def close(self) -> None:
+        self._closes.append(
+            CloseRecord(
+                decoding_in_flight=self.decoding,
+                thread_name=threading.current_thread().name,
+            )
+        )
+        self._real.close()
+
+
+@dataclass
+class GatedRead:
+    """A ``ParquetFileReader`` wired to a :class:`GatedParquetFile`."""
+
+    reader: ParquetFileReader
+    batch_started: threading.Event
+    may_finish: threading.Event
+    closes: list[CloseRecord]
+
+
+def gated_reader(tmp_path: Path, *, rows: int = 12, chunk_size: int = 4) -> GatedRead:
+    """Build a reader whose every batch is gated by a released-on-demand event."""
+    parquet_file = write_parquet(tmp_path / "data.parquet", rows)
+    batch_started = threading.Event()
+    may_finish = threading.Event()
+    closes: list[CloseRecord] = []
+
+    def open_gated(file_path: str) -> GatedParquetFile:
+        return GatedParquetFile(
+            file_path,
+            batch_started=batch_started,
+            may_finish=may_finish,
+            closes=closes,
+        )
+
+    async def only_the_fixture(path, file_extension, file_names=None):
+        return [parquet_file]
+
+    # Applied for the whole test: the reader opens the handle inside the worker
+    # thread, so the patch has to still be in place well after this call.
+    patcher_download = patch(
+        "application_sdk.storage.formats.parquet._download_files",
+        side_effect=only_the_fixture,
+    )
+    patcher_open = patch.object(pq, "ParquetFile", side_effect=open_gated)
+    patcher_download.start()
+    patcher_open.start()
+
+    return GatedRead(
+        reader=ParquetFileReader(
+            path=str(tmp_path),
+            chunk_size=chunk_size,
+            dataframe_type=DataframeType.pandas,
+        ),
+        batch_started=batch_started,
+        may_finish=may_finish,
+        closes=closes,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _stop_patches():
+    yield
+    patch.stopall()
+
+
+class TestReaderCancellation:
+    """``ParquetFileReader._get_batched_dataframe`` — close vs. a live worker."""
+
+    async def test_cancelling_mid_decode_does_not_close_under_the_worker(
+        self, tmp_path: Path
+    ) -> None:
+        """The headline race.
+
+        Before FND-315 the generator's ``finally`` called ``pf.close()`` inline,
+        so a cancellation landing at the offload ``await`` closed the handle
+        while the orphaned worker was still inside ``next(batches)``, decoding
+        from it.
+
+        That the cancellation is *observed* here — with the decode still parked
+        — is also the assertion that the new close never blocks the event loop:
+        it waits for the decode on a worker thread, not on the loop.
+        """
+        gated = gated_reader(tmp_path)
+
+        async def consume() -> None:
+            async for _ in gated.reader.read_batches():
+                pass
+
+        task = asyncio.create_task(consume())
+        assert await wait_until(gated.batch_started.is_set), "decode never started"
+
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        # The worker is provably still inside the decode here — nothing has
+        # released `may_finish`. Any close recorded at this point is the race.
+        assert gated.closes == [], (
+            "the handle was closed while a worker thread was still decoding "
+            f"from it: {gated.closes}"
+        )
+
+        # Let the orphan unwind rather than leaving it parked on the gate.
+        gated.may_finish.set()
+
+    async def test_the_close_waits_for_the_orphaned_decode_then_runs(
+        self, tmp_path: Path
+    ) -> None:
+        """Not closing during the race must not mean never closing.
+
+        The close is submitted to the offload pool from the ``finally``, where it
+        blocks on the reader's mutex until the orphan leaves the decode — so it
+        happens exactly once, off the event loop, with nothing in flight.
+        """
+        gated = gated_reader(tmp_path)
+
+        async def consume() -> None:
+            async for _ in gated.reader.read_batches():
+                pass
+
+        task = asyncio.create_task(consume())
+        assert await wait_until(gated.batch_started.is_set), "decode never started"
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        gated.may_finish.set()
+        assert await wait_until(
+            lambda: bool(gated.closes)
+        ), "the handle the orphaned worker was left holding was never closed"
+
+        assert len(gated.closes) == 1, f"closed more than once: {gated.closes}"
+        assert gated.closes[0].decoding_in_flight is False
+        assert gated.closes[0].thread_name.startswith(
+            WORKER_THREAD_PREFIX
+        ), "the close must run on a worker thread, never on the event loop"
+
+    async def test_draining_a_file_closes_it_on_a_worker(self, tmp_path: Path) -> None:
+        """The happy path still closes deterministically, and still off-loop."""
+        gated = gated_reader(tmp_path, rows=12, chunk_size=4)
+        gated.may_finish.set()
+
+        frames = [frame async for frame in gated.reader.read_batches()]
+
+        assert sum(len(frame) for frame in frames) == 12
+        assert await wait_until(lambda: bool(gated.closes)), "the handle was not closed"
+        assert len(gated.closes) == 1, f"expected exactly one close: {gated.closes}"
+        assert gated.closes[0].decoding_in_flight is False
+        assert gated.closes[0].thread_name.startswith(WORKER_THREAD_PREFIX)
+
+    async def test_closing_the_generator_early_closes_the_handle(
+        self, tmp_path: Path
+    ) -> None:
+        """A consumer that stops early still gets exactly one close."""
+        gated = gated_reader(tmp_path, rows=12, chunk_size=4)
+        gated.may_finish.set()
+
+        batches = gated.reader.read_batches()
+        first = await batches.__anext__()
+        assert len(first) == 4
+        assert gated.closes == [], "closed while frames were still being served"
+
+        await batches.aclose()
+
+        assert await wait_until(lambda: bool(gated.closes)), "the handle was not closed"
+        assert len(gated.closes) == 1, f"expected exactly one close: {gated.closes}"
+        assert gated.closes[0].decoding_in_flight is False
+
+    async def test_a_step_queued_behind_the_close_opens_nothing(
+        self, tmp_path: Path
+    ) -> None:
+        """The other half of the ordering guarantee.
+
+        A cancelled caller submits its close while a decode step may still be
+        *queued* rather than running. If that step then opened the file it would
+        leak a handle nobody is left to close, so a closed reader must decline to
+        open one.
+        """
+        parquet_file = write_parquet(tmp_path / "data.parquet", 4)
+        reader = _ThreadConfinedParquetReader(parquet_file, chunk_size=2)
+
+        reader.close()
+
+        with patch.object(pq, "ParquetFile") as never_opened:
+            assert reader.next_frame() is None
+        never_opened.assert_not_called()
+
+
+def consolidated_frame(writer: ParquetFileWriter) -> pd.DataFrame:
+    """Read back everything the writer consolidated into its output directory."""
+    files = sorted(
+        os.path.join(writer.path, name)
+        for name in os.listdir(writer.path)
+        if name.endswith(".parquet")
+    )
+    assert files, "the writer produced no consolidated output"
+    return pd.concat([pd.read_parquet(f) for f in files], ignore_index=True)
+
+
+def make_writer(path: Path) -> ParquetFileWriter:
+    """Build a consolidating writer that shares its output path with its peers.
+
+    ``typename`` is what a real activity passes, and it is what makes two
+    attempts land on the same output directory: the anonymous ``defer_uploads``
+    path would give each writer its own ``_parquet_*`` subdirectory and hide the
+    race this module is about.
+    """
+    return ParquetFileWriter(
+        path=str(path),
+        typename="test_type",
+        chunk_size=500,
+        buffer_size=100,
+        use_consolidation=True,
+        defer_uploads=True,
+    )
+
+
+class TestWriterAttemptIsolation:
+    """``ParquetFileWriter`` consolidation temp folders — one tree per attempt."""
+
+    async def test_two_writers_never_share_an_accumulation_directory(
+        self, tmp_path: Path
+    ) -> None:
+        """The property the fix rests on, asserted directly.
+
+        ``temp_folder_index`` restarts at 0 for every writer, so before FND-315
+        two attempts against the same output path resolved to the identical
+        directory.
+        """
+        first, second = make_writer(tmp_path), make_writer(tmp_path)
+
+        assert first._get_temp_folder_path(0) != second._get_temp_folder_path(0)
+        assert first._get_temp_base_path() != second._get_temp_base_path()
+        # Still one shared parent, so cleanup and inspection stay predictable.
+        assert os.path.dirname(first._get_temp_base_path()) == os.path.dirname(
+            second._get_temp_base_path()
+        )
+
+    async def test_cleanup_cannot_delete_another_attempts_live_directory(
+        self, tmp_path: Path
+    ) -> None:
+        """``_cleanup_temp_folders`` only ever removes its own writer's tree.
+
+        The old cleanup did ``rmtree(..., ignore_errors=True)`` on a shared path,
+        so a retry could delete the directory an orphaned writer was mid-write
+        into and report nothing.
+        """
+        orphan, retry = make_writer(tmp_path), make_writer(tmp_path)
+        orphan._start_new_temp_folder()
+        assert orphan.current_temp_folder_path is not None
+        live_file = os.path.join(orphan.current_temp_folder_path, "chunk-0.parquet")
+        Path(live_file).write_bytes(b"in flight")
+
+        retry._start_new_temp_folder()
+        await retry._cleanup_temp_folders()
+
+        assert os.path.exists(
+            live_file
+        ), "a retry's cleanup deleted a directory another attempt was writing into"
+        assert not os.path.exists(retry._get_temp_base_path())
+
+    async def test_an_orphaned_writer_cannot_corrupt_the_retrys_consolidation(
+        self, tmp_path: Path
+    ) -> None:
+        """The full race, cancelled mid-offload.
+
+        The orphan and the retry both resolve their first chunk file *before*
+        either writes, so on a shared directory both name it ``chunk-0`` and the
+        orphan's late write silently replaces the retry's — wrong data, no error.
+        Here each writes into its own tree, so the retry consolidates exactly its
+        own rows.
+        """
+        orphan, retry = make_writer(tmp_path), make_writer(tmp_path)
+
+        orphan_rows = pd.DataFrame({"id": [100, 101], "value": ["orphan", "orphan"]})
+        retry_rows = pd.DataFrame({"id": [0, 1], "value": ["retry", "retry"]})
+
+        write_started = threading.Event()
+        may_write = threading.Event()
+        orphan_writes_done: list[str] = []
+        real_write_table = pq.write_table
+        # Resolved before either writer runs, so it is the path the orphan is
+        # gated on — and, before the fix, the path the retry writes too.
+        orphan_chunk = os.path.join(orphan._get_temp_folder_path(0), "chunk-0.parquet")
+
+        def gated_write_table(table, where, **kwargs):
+            # Gate only the orphan's own write; the retry must run at full speed
+            # so it provably reaches consolidation first.
+            gated = str(where) == orphan_chunk and not write_started.is_set()
+            if gated:
+                write_started.set()
+                may_write.wait(timeout=BLOCK_TIMEOUT_SECONDS)
+            result = real_write_table(table, where, **kwargs)
+            if gated:
+                orphan_writes_done.append(str(where))
+            return result
+
+        with patch.object(pq, "write_table", side_effect=gated_write_table):
+            task = asyncio.create_task(orphan._accumulate_dataframe(orphan_rows))
+            assert await wait_until(
+                write_started.is_set
+            ), "orphan never started writing"
+
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+            # The retry runs while the orphan's worker is still parked inside
+            # pq.write_table, holding a chunk path it resolved before cancel.
+            await retry._accumulate_dataframe(retry_rows)
+
+            # Release the orphan and wait for its write to *land*, not merely for
+            # the path to exist: on a shared directory the file is already there,
+            # written by the retry, and the whole failure is the orphan replacing
+            # it afterwards.
+            may_write.set()
+            assert await wait_until(
+                lambda: bool(orphan_writes_done)
+            ), "the orphaned worker never landed its chunk"
+
+            await retry._consolidate_current_folder()
+
+        written = consolidated_frame(retry)
+        assert sorted(written["id"].tolist()) == [0, 1]
+        assert set(written["value"]) == {
+            "retry"
+        }, "the orphaned writer's rows reached the retry's consolidated output"
+
+        # And the orphan's own write landed in its own tree rather than being
+        # deleted or redirected.
+        assert set(pd.read_parquet(orphan_chunk)["value"]) == {"orphan"}

--- a/tests/unit/storage/formats/writers/test_parquet_writer.py
+++ b/tests/unit/storage/formats/writers/test_parquet_writer.py
@@ -671,13 +671,16 @@ class TestParquetFileWriterConsolidation:
             typename="test_type",
         )
 
-        # Test temp folder path generation
+        # Test temp folder path generation. The writer's own token sits between
+        # the shared "temp_accumulation" root and the folder, so no two writers
+        # can share an accumulation directory (FND-315).
         temp_path = parquet_output._get_temp_folder_path(0)
         expected_path = os.path.join(
             base_output_path,
             "test_suffix",
             "test_type",
             "temp_accumulation",
+            parquet_output._temp_run_id,
             "folder-0",
         )
         assert temp_path == expected_path


### PR DESCRIPTION
Replaces #3178, which was stacked on `chrishehim/fnd-289` and carried a dozen unrelated sibling commits. This is the same issue implemented from scratch on latest `main`: one commit, five files.

Fixes [FND-315](https://linear.app/atlan-epd/issue/FND-315/cancellation-races-in-the-offloaded-parquet-reader-and-writer).

## The shared root cause

ADR-0010 moved the parquet reader's decode and the writer's convert-and-write onto worker threads. A thread cannot be killed, so cancelling an activity unwinds the event loop while an orphaned worker is still touching the resource it was handed — and neither surrounding lifecycle was re-examined against cancellation.

## 1. Reader — `pf.close()` raced an in-flight worker

`_get_batched_dataframe` held the `ParquetFile` in the coroutine frame and closed it in a `finally`. A cancellation landing at the offload `await` unwound into that `finally` and closed the handle while the orphan was still inside `next(batches)`, decoding from it.

The handle now lives in `_ThreadConfinedParquetReader`, which opens, decodes from and closes it **only under a mutex**. A close issued during a decode waits for the decode instead of landing underneath it.

The close is *submitted* rather than awaited. An `await` in a `finally` is itself a cancellation point and would leak the handle — which is exactly why the old close was inline on the loop — and the close also has to be free to wait out an in-flight decode without blocking the loop for its duration. That reasoning from the original comment survives; the gap it never covered was close-vs-live-worker.

## 2. Writer — an orphan shared a temp directory with the retry

The consolidation temp path was fully attempt-independent: `temp_accumulation/folder-{i}`, with `temp_folder_index` reset to `0` in both `__init__` and `_cleanup_temp_folders`. A retry therefore landed on the exact directory an orphaned `_convert_and_write` was still writing `chunk-{n}` files into:

- **Silently shifted chunk numbering** — `_write_chunk_to_temp_folder` names the next file from `len(existing_files)`, so an orphan adding files made the retry's consolidation pick up the orphan's partial output, or skip its own. Wrong data, no error.
- **Cleanup deleting a live directory** — `rmtree(..., ignore_errors=True)` on a shared path could remove the directory mid-write and report nothing.

The tree is now scoped by a per-writer token and cleanup only ever removes its own. Per *writer instance* rather than per activity attempt: strictly stronger (two writers inside one attempt are covered too), and it needs no activity context in `storage/`, which would deepen the layering debt tracked in FND-316.

That also retires `ignore_errors=True`. It was load-bearing only while attempts shared the tree, where a vanished directory meant a sibling had deleted it — the very failure it hid. Within a writer-scoped tree a failure there is a real one (full disk, permission change, a file still held open), and is now reported.

## New primitive: `submit_in_thread`

The one addition beyond the issue's scope, in `execution/heartbeat.py` alongside `run_in_thread`: a detached variant for **cleanup that cancellation must not be able to skip**. It takes the event loop out of the path entirely, so the call runs whether or not the caller survives, and may block on a lock held by an orphan.

It is what keeps the parquet side a plain mutex instead of a bespoke non-blocking handoff protocol. Because nothing awaits the result, it logs failures rather than letting an unretrieved future swallow them, and it returns a cancelled future rather than raising at an unwinding caller once the pool is shut down at interpreter exit.

## Verification

The bar the issue set: a happy-path test passes against the broken code, so cancellation coverage is the only thing that makes either fix verifiable.

- `tests/unit/storage/formats/test_offload_cancellation.py` — 8 tests, each cancelling **mid-offload** with the blocking primitive held open, so the orphan is provably still running when the loop unwinds.
- 4 more for `submit_in_thread` in `tests/unit/execution/test_heartbeat.py`.
- **Checked against pre-fix `main`**: the reader race test and the writer corruption test both fail there.
- Full unit suite 6763 passed / 9 skipped; pre-commit (ruff, isort, pyright) clean; conformance gate passes with no new findings in the touched files.

## Out of scope

The **output** directory and its `chunk-{n}-part{m}` filenames are just as attempt-independent as the temp tree was, but those names are a contract downstream consumers read, so the same trick would be a breaking change. Tracked separately as [FND-317](https://linear.app/atlan-epd/issue/FND-317/an-orphaned-writer-and-its-retry-share-the-output-directory-and-its), which can build on this PR's gated-`pq.write_table` harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
