### PR TITLE
fix(errors): redact dict/JSON-form secrets in redact_secrets (ReDoS-safe)

### DIFF
--- a/application_sdk/errors/base.py
+++ b/application_sdk/errors/base.py
@@ -29,6 +29,17 @@ _TRACEBACK_MAX_LEN = 8000
 # trailing `@` in a no-space query string — the safe failure direction for a
 # secret redactor.
 _URL_USERINFO_RE = re.compile(r"([a-z][a-z0-9+.-]*://)(?:[^@\s]+@)+", re.IGNORECASE)
+# Shared alternation of secret-bearing key tokens, matched case-insensitively
+# as a substring — so ``client_secret`` is caught via ``secret``. Reused by
+# both the ``key=value`` form and the ``'key': 'value'`` mapping-repr form so
+# the two stay in sync. ``client_id`` is intentionally absent: it is a public
+# identifier, not a credential, and dropping it removes "which client failed"
+# from auth errors (same rationale as ``uid`` below).
+_SECRET_KEY_ALTERNATION = (
+    r"(?:api_key|access_token|auth_token|password|passwd|pwd|secret"
+    r"|credential|private_key)"
+)
+
 # Matches secret query params: api_key=value → api_key=***
 # ``pwd`` covers ODBC/DSN keyword syntax (``UID=sa;PWD=…``), which no other
 # keyword here matches — ODBC connectors do not use ``password=``.
@@ -46,16 +57,44 @@ _URL_USERINFO_RE = re.compile(r"([a-z][a-z0-9+.-]*://)(?:[^@\s]+@)+", re.IGNOREC
 # the tail of ``run_guid=`` and ``correlation_uuid=`` — redacting the exact
 # correlation IDs an on-call needs.
 _SECRET_PARAM_RE = re.compile(
-    r"(?i)((?:api_key|access_token|auth_token|password|passwd|pwd|secret|credential|private_key)=)(?:\{[^}]*\}|[^\s&,;#]+)",
+    rf"(?i)({_SECRET_KEY_ALTERNATION}=)(?:\{{[^}}]*\}}|[^\s&,;#]+)",
+)
+
+# Matches secrets in mapping / JSON repr form, so a credentials dict rendered
+# into a message or traceback is scrubbed too — this is the shape that leaked
+# in AUT-1113 (a token payload printed by loguru diagnose):
+#   {'client_secret': 'xyz'}  → {'client_secret': '***'}
+#   {"api_key": "xyz"}        → {"api_key": "***"}
+# The key is a quoted string containing a sensitive token; the value is the
+# following quoted string of the SAME quote char (``\3`` backref). The value
+# body ``(?:\\.|[^\\])*?`` handles escaped quotes (``\'``) so a value that
+# embeds a quote — which Python ``repr`` emits as ``'a\'b'`` for a secret
+# containing one — does not end the match early and leak its tail. The two
+# branches are disjoint on their first character (``\\.`` always starts with a
+# backslash, ``[^\\]`` never does), so there is exactly one way to consume any
+# prefix — no partitions to explore, so no catastrophic backtracking on a long
+# backslash run in an unterminated value (``redact_secrets`` runs on
+# semi-untrusted driver-error text on the logging path). Lazy ``*?`` keeps the
+# match ending at the first delimiter, avoiding greedy over-redaction across
+# sibling keys. Best-effort: only quoted str values are matched (``b'...'`` /
+# unquoted are not). ``client_id`` is not matched (see the alternation note
+# above), so "which client" stays visible.
+_SECRET_MAPPING_RE = re.compile(
+    rf"(?i)((['\"])[\w.\- ]*{_SECRET_KEY_ALTERNATION}[\w.\- ]*\2\s*:\s*)"
+    rf"(['\"])(?:\\.|[^\\])*?\3",
 )
 
 
 def redact_secrets(text: str) -> str:
-    """Redact URL userinfo and known secret query-params from a string.
+    """Redact URL userinfo and known secrets from a string.
+
+    Handles three shapes: URL userinfo (``scheme://user:pass@``), ``key=value``
+    query/connection-string params, and ``'key': 'value'`` mapping/JSON repr.
 
     Use this when logging strings that may embed credentials but are not a
     single cause exception — e.g. a formatted traceback whose frames are worth
-    keeping but whose driver messages embed connection-string passwords.
+    keeping but whose driver messages embed connection-string passwords, or a
+    message that rendered a credentials dict.
 
     ``text`` must be a ``str`` — callers holding an exception or other object
     should stringify first (the sibling :func:`sanitize_cause_repr` does this
@@ -63,6 +102,7 @@ def redact_secrets(text: str) -> str:
     """
     text = _URL_USERINFO_RE.sub(r"\1***@", text)
     text = _SECRET_PARAM_RE.sub(r"\1***", text)
+    text = _SECRET_MAPPING_RE.sub(r"\1\3***\3", text)
     return text
 
 

--- a/tests/unit/errors/test_base.py
+++ b/tests/unit/errors/test_base.py
@@ -211,6 +211,69 @@ def test_redact_secrets_userinfo_and_params() -> None:
     assert "abc123" not in out and "hunter2" not in out
 
 
+def test_redact_secrets_masks_client_secret_in_dict_repr() -> None:
+    """AUT-1113: a credentials dict rendered into a string (e.g. loguru diagnose
+    of a token payload) must have its secret value masked, key and shape kept."""
+    from application_sdk.errors import redact_secrets
+
+    payload = (
+        "{'client_id': 'atlan-argo', 'client_secret': 'sYnth3ticSecret', "
+        "'grant_type': 'client_credentials'}"
+    )
+    out = redact_secrets(payload)
+    assert "sYnth3ticSecret" not in out
+    assert "'client_secret': '***'" in out
+    # client_id is a public identifier — it stays visible for debugging.
+    assert "atlan-argo" in out
+
+
+def test_redact_secrets_masks_json_form_secrets() -> None:
+    from application_sdk.errors import redact_secrets
+
+    out = redact_secrets('{"api_key": "abc123", "user": "sa"}')
+    assert "abc123" not in out
+    assert '"api_key": "***"' in out
+    assert "sa" in out
+
+
+def test_redact_secrets_masks_secret_value_with_embedded_quote() -> None:
+    """A secret value containing a quote (which ``repr`` escapes) must be fully
+    masked — the escaped quote must not end the match early and leak the tail."""
+    from application_sdk.errors import redact_secrets
+
+    # repr({"password": "a'b\"c-SECRET"}) -> {'password': 'a\'b"c-SECRET'}
+    rendered = repr({"password": "a'b\"c-SECRET"})
+    out = redact_secrets(rendered)
+    assert "SECRET" not in out
+    assert "a'b" not in out  # no tail after the escaped quote leaks
+    assert "'password': '***'" in out
+
+
+def test_redact_secrets_is_linear_on_backslash_runs() -> None:
+    """Regression: ``_SECRET_MAPPING_RE`` must not backtrack exponentially on an
+    unterminated quoted value with a long backslash run. ``redact_secrets`` runs
+    on semi-untrusted driver-error text on the logging path, so a hang here
+    takes the log call with it. A regressed (ambiguous) pattern would blow past
+    the subprocess timeout and be killed; the fixed pattern returns instantly.
+
+    Run in a subprocess because a catastrophic-backtracking ``re`` match is a
+    C-level loop that Python signals cannot interrupt — only killing the process
+    reliably bounds it.
+    """
+    import subprocess
+    import sys
+
+    # Child builds `{'password': '` + 64 backslashes (unterminated). chr(92) is
+    # a backslash — avoids escaping the run through two string layers.
+    code = (
+        "from application_sdk.errors import redact_secrets; "
+        "redact_secrets(\"{'password': '\" + chr(92) * 64)"
+    )
+    # ~phi**64 for an ambiguous pattern (astronomically slow); the fixed one is
+    # sub-millisecond. 10s is a wide margin that still fails a real regression.
+    subprocess.run([sys.executable, "-c", code], timeout=10, check=True)
+
+
 def test_redact_secrets_consumes_at_in_password() -> None:
     """A raw `@` inside the password must not leave the tail exposed."""
     from application_sdk.errors import redact_secrets


### PR DESCRIPTION
> **Scope reduced.** This PR started as a diagnose-scrubbing monkeypatch (keep `diagnose` on, mask known secret shapes). That approach is **superseded by #3268**, which turns `diagnose` off by default — the allowlist-shaped fix the review concluded was right. What remains here is the one piece that's useful regardless of `diagnose`: the string-level `redact_secrets` improvement. The monkeypatch, sink wiring, primitives (`sensitive`/`Secret`/`RedactingMapping`), and the two env vars have been dropped.

## What this does

`redact_secrets()` handled URL userinfo and `key=value` params, but not the **`'key': 'value'` dict/JSON shape** — the form a credentials dict takes when it's rendered into a message or a formatted traceback (`safe_traceback`, `sanitize_cause_repr`). Adds `_SECRET_MAPPING_RE` so:

```
{'client_secret': 'xyz'}  → {'client_secret': '***'}
{"api_key": "xyz"}        → {"api_key": "***"}
```

- The sensitive-key alternation is hoisted into a shared `_SECRET_KEY_ALTERNATION`, used by both the `=` and `:` patterns, so they can't drift.
- The value body is `(?:\\.|[^\\])*?` — **disjoint branches** (backslash vs. not) + **lazy** — so it handles escaped quotes (`'a\'b'`) **without catastrophic backtracking**. `redact_secrets` runs on semi-untrusted driver-error text on the logging path, so a hang would take the log call with it. (This corrects a ReDoS in an earlier revision of this PR; the fix is @cmgrote's suggested construction.)
- `client_id` is deliberately not matched — public identifier, kept for debugging.

## Tests

- Mapping/JSON-form masking (both quote styles), embedded-quote value, and a **ReDoS regression** that pins linear behaviour under a subprocess timeout (an ambiguous pattern would be killed; the fixed one returns instantly).
- All `errors/base` tests pass; ruff + ruff-format + pyright clean.

Refs: #3268 (supersedes the diagnose approach).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012KVtq9FTe9asyd6HJMKvx5