### PR TITLE
docs(execution): progress hooks, holds, allowances and the upgrade story (FND-295)

### DIFF
--- a/application_sdk/app/context.py
+++ b/application_sdk/app/context.py
@@ -477,6 +477,12 @@ class TaskExecutionContext:
         IMPORTANT: If heartbeating is disabled (heartbeat_timeout_seconds=None),
         this is a no-op.
 
+        A manual beat also **marks progress** for the stall watchdog
+        (ADR-0018), under the label ``task.heartbeat``. That is the third of the
+        three progress mechanisms, and the one an author reaches for in a custom
+        loop the SDK cannot see into — a loop that beats every iteration needs no
+        hold.
+
         Args:
             *details: Serializable progress details (e.g., index, count).
                 These are stored by Temporal and available via
@@ -489,6 +495,18 @@ class TaskExecutionContext:
                 if i % 100 == 0:
                     self.task_context.heartbeat(i, len(records))
         """
+        # Marked here rather than inside the controller for two reasons. It must
+        # count on a task with heartbeating disabled
+        # (``heartbeat_timeout_seconds=None``), where the controller is a no-op
+        # and the stall watchdog is the *only* thing bounding a wedged attempt.
+        # And it must be this call, never ``heartbeat_keepalive`` — the keepalive
+        # is unconditional, so treating it as progress would make every attempt
+        # permanently look like it was progressing.
+        from application_sdk.execution.progress import (  # noqa: PLC0415 — circular: execution/__init__.py loads _temporal which imports app.base
+            current_progress_tracker,
+        )
+
+        current_progress_tracker().mark_progress("task.heartbeat")
         self.heartbeat_controller.heartbeat(*details)
 
     def get_last_heartbeat_details(self) -> tuple[Any, ...]:

--- a/docs/agents/coding-standards.md
+++ b/docs/agents/coding-standards.md
@@ -150,6 +150,23 @@ result = requests.get(url)
 result = await self.run_in_thread(requests.get, url)
 ```
 
+## Long-Running Tasks: Progress and Stalls
+
+A task that goes quiet for longer than `max_no_progress_seconds` (900s) is reported as a
+stall — and failed, in an app that enforces. The SDK covers its own write, transfer and
+page loops, and auto-holds every `run_in_thread` offload; what it cannot see is a custom
+async loop or an opaque single `await` against the connector's own source client. Those
+need one line: `self.heartbeat(...)` in the loop, or
+`async with self.holding_progress(label, timeout=...)` around the opaque call.
+
+`timeout` is *how long you would let this one call run before you would rather it
+failed* — not a prediction of its duration. Err generous; too tight false-kills a
+healthy run, and stall kills retry.
+
+Read [Progress and Stalls](../concepts/progress-and-stalls.md) before writing a
+long-running task, and [ADR-0018](../adr/0018-progress-aware-heartbeat.md) if you need
+the design rationale.
+
 ## Large Payloads and FileReference
 
 Use `FileReference` for any data that cannot fit in Temporal's 2 MB payload limit.

--- a/docs/concepts/apps.md
+++ b/docs/concepts/apps.md
@@ -224,7 +224,10 @@ async with self.holding_progress("full table scan", timeout=7200):
 
 For opaque *async* calls (the connector's own async client) there is no SDK-owned seam to auto-hold, so wrap those in `holding_progress` directly. Expect to need it: interleaved streaming reads (fetch a page, write a batch, repeat) are already covered by the SDK's own writer and transfer loops, but almost every connector makes at least one genuinely opaque single call — one large metadata query, one slow list/export that returns everything at once.
 
-See [ADR-0018](../adr/0018-progress-aware-heartbeat.md) for the design.
+See [Progress and Stalls](progress-and-stalls.md) for the whole picture — what counts as
+progress, how to size the allowance from your own data, and how to read the report the
+watchdog produces for your app — and [ADR-0018](../adr/0018-progress-aware-heartbeat.md)
+for the design.
 
 ## Lifecycle Hooks
 

--- a/docs/concepts/monitoring.md
+++ b/docs/concepts/monitoring.md
@@ -141,6 +141,22 @@ scrape_configs:
     metrics_path: /metrics
 ```
 
+### Stall-watchdog metrics
+
+The in-process stall watchdog (ADR-0018) emits two histograms. Both are the *report* an
+app author works from, not an alert surface — the accompanying logs are INFO by design.
+See [Progress and Stalls](progress-and-stalls.md#reading-your-warn-report) for the
+queries that turn them into a per-app work-list.
+
+| Metric | Records | Labels |
+|---|---|---|
+| `task_no_progress_gap_seconds` | one entry per gap that exceeded `max_no_progress_seconds` | `task_name`, `progress_last_label`, `watchdog_mode` |
+| `task_hold_duration_seconds` | one entry per hold released — every hold, not only long ones | `task_name`, `hold_label`, `hold_bounded`, `hold_lapsed` |
+
+`watchdog_mode` is what keeps warn-mode observations and enforced kills aggregating
+separately; `hold_bounded="false"` isolates the sites still relying on the duration
+backstop.
+
 ### Recommended Alerts
 
 | Alert | Condition | Severity |
@@ -149,6 +165,13 @@ scrape_configs:
 | Worker slots exhausted | `temporal_worker_task_slots_available == 0` | Critical |
 | Elevated workflow latency | `histogram_quantile(0.99, temporal_workflow_endtoend_latency_bucket) > 300` | Warning |
 | Temporal server errors | `rate(temporal_long_request_failure_total[5m]) > 0` | Warning |
+| Stalled task attempts | `rate(task_no_progress_gap_seconds_count{watchdog_mode="warn"}[15m]) > 0` | Warning |
+
+The stall alert is **not optional while an app is in `warn`.** Warn mode cannot fail an
+activity, so an alert on this metric is what stands in for the kill: a wedged attempt is
+visible within `max_no_progress_seconds`, but it will hold its worker slot until the 24h
+backstop unless a human intervenes. Once an app runs in `enforce`, the same series
+measures its kill rate instead.
 
 ---
 

--- a/docs/concepts/progress-and-stalls.md
+++ b/docs/concepts/progress-and-stalls.md
@@ -1,0 +1,366 @@
+# Progress and Stalls
+
+A healthy-but-quiet task looks exactly like a wedged one. Both emit nothing, so any
+watchdog that kills on silence has to guess which it is holding — and the SDK's answer
+is to stop guessing: make every quiet spot *observable*, then fail only the attempts
+that go quiet with nothing to vouch for them.
+
+That is the **stall watchdog**. It runs inside your activity, alongside the
+auto-heartbeat loop, and it asks one question on every tick: *how long has it been
+since anything observable happened?* When the answer exceeds this task's
+`max_no_progress_seconds`, the gap is reported — and, in an app that enforces, the
+attempt is failed with a `TaskStalledError` naming the last signal it saw.
+
+This page is what an app author needs in order to act. [ADR-0018](../adr/0018-progress-aware-heartbeat.md)
+is the design record behind it; you should not need to read it to fix your app.
+
+!!! note "Rollout status"
+
+    The progress signals described here — the framework hooks, the automatic holds and
+    `holding_progress()` — are live now. The two settings that *act* on them,
+    `progress_watchdog` and `max_no_progress_seconds`, arrive together with the 24h
+    `start_to_close` backstop in the release that turns the watchdog on fleet-wide in
+    `warn`. Until then `timeout_seconds` keeps its 600s default and nothing observes the
+    signals. Nothing below changes when that release lands; it is written for the state
+    you will be in.
+
+---
+
+## The one rule
+
+> **If any single step can run longer than `max_no_progress_seconds` without emitting
+> a progress signal, that step must be made observable.**
+
+Observable means one of exactly three things, and the first one is free:
+
+| # | Mechanism | Who does it | Covers |
+|---|---|---|---|
+| 1 | **Framework hooks** | the SDK, automatically | streaming writes, object-store transfers, `FileReference` sync, the SQL/REST template page loops |
+| 2 | **Automatic holds** | the SDK, automatically | anything offloaded through `run_in_thread` / `run_fault_isolated` |
+| 3 | **A manual beat or a declared hold** | you, one line | a custom async loop, and any opaque single `await` against your own source client |
+
+Mechanism 3 is not a rare escape hatch. See [holding_progress()](#holding_progress-the-part-you-write)
+below — nearly every connector needs it at least once.
+
+## What counts as progress
+
+Progress is defined operationally, not by intuition:
+
+> **Progress = one observable unit of work completing** — a batch written, a chunk or
+> file transferred, a page fetched, or an explicit `self.heartbeat(...)`.
+
+It is emphatically **not** wall-clock time, and **not** event-loop liveness. Loop
+liveness is what the unconditional keepalive already proves, which is precisely why
+the keepalive cannot double as the stall detector: a task that beats every 10s while
+its source connection hangs is exactly the failure this watchdog exists to catch.
+
+By construction, **any gap between progress signals longer than the budget is a
+stall.** That is the intended behaviour, not a corner case — it is how a
+wedged-but-quiet activity gets caught. The design's job is to make sure the
+*legitimate* quiet spots are the small, known set that hooks and holds already cover.
+
+## The three knobs, and which one is which
+
+These are three different questions with three different answers. The third is new,
+and it is the one most likely to be misread.
+
+| Knob | Default | The question it answers | Do you tune it? |
+|---|---|---|---|
+| `heartbeat_timeout_seconds` | 60s | *"Is anything beating at all?"* Detects a dead process — OOM kill, SIGKILL, node loss, partition, a fully starved event loop. **Unchanged by ADR-0018.** | No |
+| `max_no_progress_seconds` | 900s | *"How long may this attempt be silent before I call it stalled?"* Detects wedged-but-alive: the loop is fine, the beats are going out, nothing is advancing. | Rarely — it is roughly app-independent |
+| `timeout_seconds` (`start_to_close`) | a 24h backstop | *"What is the absolute ceiling on one attempt?"* A last-resort bound, not a duration budget. | **No.** This is the number you used to guess; stop guessing it |
+
+Three clarifications, because each is a real misread:
+
+- **`max_no_progress_seconds` is not the beat interval.** The beat interval is
+  `auto_heartbeat_seconds` (10s), it is unconditional, and it has nothing to do with
+  the watchdog. Lowering the budget does not make your task beat more often.
+- **`max_no_progress_seconds` is not a duration budget.** A task that runs for nine
+  hours while writing a batch every thirty seconds never comes close to a 900s budget.
+  The budget measures *gaps*, not totals. If you find yourself raising it because "my
+  task takes a long time", the knob you actually want is a hold at the one call site
+  that goes quiet.
+- **`heartbeat_timeout_seconds` did not change meaning.** It still means "nothing is
+  beating", it is still 60s, and it is still the only detector for a fully blocked
+  event loop — which the in-process watchdog structurally cannot see, because a
+  starved loop never runs the watchdog either. The two cover each other's blind spot.
+
+There is a fourth setting, `progress_watchdog`, which is a mode rather than a
+duration: `off`, `warn` or `enforce`. See [Modes](#modes-off-warn-enforce).
+
+## What the SDK covers for you
+
+### Framework hooks
+
+These fire automatically. If your task's long steps run through them, you have nothing
+to do:
+
+| Where | Unit of work | Label |
+|---|---|---|
+| Streaming writers (`Writer._flush_buffer`, statistics sidecar) | one buffer chunk / the stats file | `writer.flush_buffer`, `writer.statistics` |
+| Parquet writer | one accumulated / consolidated chunk | `writer.accumulate_chunk`, `writer.consolidate_chunk` |
+| `RollingFileWriter` | one rolled chunk | `writer.rolling_flush` |
+| Object-store byte loops | one multipart part / streamed chunk / range GET | `storage.upload_part`, `storage.download_chunk`, `storage.download_range` |
+| Object-store transfers | one file transferred *or* skipped on a hash match | `storage.upload_file`, `storage.copy_file`, `storage.download_file` |
+| External `CloudStore` upload | one part | `cloudstore.upload_part` |
+| `FileReference` sync | one reference persisted / materialised | `file_ref.persist`, `file_ref.materialize` |
+| SQL / REST template page loops | one fetched page written | `extract.page`, `fetch_databases.page`, `fetch_schemas.page`, `fetch_tables.page`, `fetch_columns.page` |
+| Your own `self.heartbeat(...)` | whatever you decide | `task.heartbeat` |
+
+Hooks sit on **batch, chunk and page boundaries — never per record.** One batch is
+already the unit of observable work, and a per-record mark would be a hot-path cost for
+no extra signal.
+
+The label matters beyond bookkeeping: it is what a stall report names, so
+`last signal was 'fetch_tables.page'` tells an operator *which* loop went quiet rather
+than only that something did.
+
+### Automatic holds on offloaded work
+
+A **hold** vouches for one in-flight operation the SDK cannot see into. While a hold is
+in force the watchdog is paused, and when the hold is released the completed operation
+counts as progress.
+
+Every blocking call offloaded through `run_in_thread` is automatically wrapped in an
+**unbounded** hold, so a legitimately long blocking call is never false-killed and
+nothing at the call site changes. `run_fault_isolated` (and `run_best_effort` on top of
+it) is held too, **bounded by that call's own `timeout`** — a number it already enforces
+as a wall-clock kill of the child.
+
+"Unbounded" is a real, deliberate residual: the watchdog is inactive for the whole call
+and the 24h backstop is its only bound. That is the price of the SDK never inventing a
+duration for somebody else's blocking call — and it is the second thing your warn report
+tells you about, precisely because an auto-held call is invisible to any code audit.
+
+See [Offloading blocking work](apps.md#offloading-blocking-work-run_in_thread-and-auto-holds)
+for the call-site details.
+
+## `holding_progress()`: the part you write
+
+```python
+# async: your own client, which the SDK cannot see into
+async with self.holding_progress("snapshot metadata query", timeout=1800):
+    rows = await self._client.execute(BIG_METADATA_QUERY)
+
+# blocking: the same wrapper around the offload, to bound it
+async with self.holding_progress("full table scan", timeout=7200):
+    rows = await self.run_in_thread(cursor.execute, sql)
+```
+
+Reach it as `self.holding_progress(...)` or `self.task_context.holding_progress(...)`
+inside an `App`, or import `holding_progress` from
+`application_sdk.execution.progress` for app code outside the app class.
+
+### Expect to need it
+
+There is a genuine asymmetry between blocking and async work, and it is why this is
+routine rather than exceptional:
+
+- **Blocking source calls are already held.** `run_in_thread` is a mandatory seam —
+  every blocking call goes through it — so the SDK can hold on your behalf.
+- **Async source calls have no such seam.** Your connector talks to its source with its
+  *own* async client (an async SQLAlchemy engine, an `httpx.AsyncClient`, a vendor SDK).
+  The SDK's internal SQL and HTTP clients are for the SDK's own purposes and do not sit
+  on your connector→source path, so there is nothing for the SDK to instrument.
+
+Two things narrow the residual, but neither removes it:
+
+- **Interleaved streaming reads need no hold.** The common extraction shape — fetch a
+  page, write a batch, repeat — already marks progress on every write, so the read loop
+  is covered as long as one fetch+write cycle stays under the budget.
+- **A custom loop can beat instead.** `self.heartbeat(...)` marks progress, so a loop
+  that beats once per iteration is observable without a hold.
+
+What is left is the genuinely opaque **single** call: one large metadata query, one slow
+list or export that returns everything at once. Almost every connector makes at least
+one. For those calls a hold is **required, not advisory** — a forgotten one does not
+fail in testing, it false-kills at the tail, against the largest tenant, hours in.
+
+### What a hold actually does
+
+- Inside the block, the watchdog is paused for this attempt.
+- On exit, the completed operation is recorded as progress under `label`.
+- Past the declared allowance the hold **lapses**: the watchdog resumes *from the
+  deadline*, and the stall fires `max_no_progress_seconds` later. So a wedged held call
+  is caught at **`timeout` + budget** rather than at the 24h backstop.
+- `timeout=None` declares an **unbounded** hold — the backstop is the only bound. That
+  is a legitimate choice, and warn mode reports it rather than hiding it.
+- The allowance you declare **governs everything inside the block**, including the
+  automatic holds `run_in_thread` would otherwise add. They stand down, so the blocking
+  example above lapses at 7200s instead of inheriting an unbounded auto-hold that would
+  outlive your allowance.
+- Holds are keyed by token, so nested and concurrent blocks — an `asyncio.gather` over
+  several opaque calls — never release each other. The hold is released in a `finally`,
+  so an exception or a cancellation inside the block does not leave the watchdog paused.
+
+`label` is written into logs and metric labels, so it must identify a **site**. Never
+interpolate a query, a key, a credential or a customer value into it.
+
+## Choosing an allowance
+
+The allowance is **not a prediction of how long the operation takes.** It is:
+
+> *How long would I let this one operation run before I would rather it failed?*
+
+That question is answerable at the call site in a way "how long should this whole
+activity take?" never was, because it is a property of one operation against one
+resource rather than of a tenant's data volume.
+
+Two things make it safe to answer:
+
+**Take the number from your own data.** Every closed hold is measured, so the p99 for
+that exact site is a query away — plus headroom. A number invented at the desk is the
+thing this design exists to remove.
+
+```promql
+histogram_quantile(
+  0.99,
+  sum by (le) (
+    rate(task_hold_duration_seconds_bucket{app_name="my-app", hold_label="full table scan"}[7d])
+  )
+)
+```
+
+**Err generous, because the error is asymmetric.** Too generous only delays detection
+toward the backstop — mildly worse observability. Too tight kills a healthy run, and
+because stall kills retry, a too-tight allowance burns the same wasted work up to three
+times before the run finally fails. When unsure, round up.
+
+## Reading your warn report
+
+Warn mode observes and reports; it can never fail an activity. It emits exactly two
+shapes, and they map to the two things worth acting on.
+
+### Shape 1 — a no-progress gap with nothing vouching for it
+
+The sites that need a hook, a beat or a hold.
+
+```
+Task 'fetch_tables' made no observable progress for 1043s (budget 900s);
+last signal was 'fetch_tables.page' — not failing (warn mode)
+```
+
+```promql
+# Which tasks and which quiet spots, ranked
+topk(20,
+  sum by (task_name, progress_last_label) (
+    rate(task_no_progress_gap_seconds_count{app_name="my-app", watchdog_mode="warn"}[7d])
+  )
+)
+```
+
+`progress_last_label` is the last thing that *did* report before the silence, so it
+points at the step immediately after it. `<none>` means the attempt never reported a
+signal at all — usually a task that does all its work in one opaque call.
+
+### Shape 2 — a long hold, unbounded above all
+
+The sites that want an explicit allowance instead of the 24h backstop.
+
+```
+Task 'extract_metadata' held the stall watchdog at 'run_in_thread.Cursor.execute'
+for 2110s with no declared allowance (no-progress budget 900s); this site is on the
+work-list — wrap it in holding_progress(timeout=...) so a wedge here is caught at
+allowance + budget rather than left to the duration backstop
+```
+
+```promql
+# Long unbounded holds — the work-list, longest first
+topk(20,
+  sum by (task_name, hold_label) (
+    rate(task_hold_duration_seconds_sum{app_name="my-app", hold_bounded="false"}[7d])
+  )
+)
+```
+
+A second line appears when a hold **lapsed** — your declared allowance was outlived, so
+the watchdog resumed while the operation was still running. That is notable at any
+duration, because too tight an allowance is what turns a healthy slow call into a false
+kill once anything enforces:
+
+```promql
+sum by (task_name, hold_label) (rate(task_hold_duration_seconds_count{hold_lapsed="true"}[7d]))
+```
+
+Both shapes are a metric plus an **INFO** log — never WARNING. Under a fleet-wide
+default a warn-mode observation is an expected observation, not an actionable failure,
+and emitting it at WARNING would manufacture the alert noise this design exists to
+reduce.
+
+### Triaging the list
+
+Most of the list is *ignore it*. Work down it with this:
+
+| What you see | What to do |
+|---|---|
+| A gap on a step that is genuinely one opaque call | Wrap it in `holding_progress()` with the p99 for that site plus headroom |
+| A gap on a custom loop of your own | Add `self.heartbeat(...)` once per iteration |
+| A gap whose `last_label` is an SDK hook, on a step you know is one slow query | The query is the gap, not the hook — hold the query |
+| A long **unbounded** hold, comfortably under the backstop | Declare an allowance if you want a real bound; otherwise leave it. This is an optimisation, not a bug |
+| A long **bounded** hold that stayed inside its allowance | Nothing. Somebody already sized this site |
+| A **lapsed** hold on a site you believe is healthy | Raise the allowance — this one *will* false-kill once you enforce |
+| A gap that only ever appears on one tenant, at one step | Look at the step before you change a number. This is what a real wedge looks like |
+
+**Read the report from a large tenant.** A small tenant's fast steps hide the very gaps
+that only open at the tail — which is where the original failures came from.
+
+### Metric reference
+
+| Metric | Type | Labels |
+|---|---|---|
+| `task_no_progress_gap_seconds` | histogram | `task_name`, `progress_last_label`, `watchdog_mode` |
+| `task_hold_duration_seconds` | histogram | `task_name`, `hold_label`, `hold_bounded`, `hold_lapsed` |
+
+`app_name` is inlined onto every series, and the rest of the app identity (version,
+release channel, k8s topology) is reachable through `target_info` — see
+[Monitoring](monitoring.md#whats-in-the-metric-body).
+
+## Modes: `off`, `warn`, `enforce`
+
+| Mode | Behaviour |
+|---|---|
+| `off` | Inert. Nothing is observed, nothing is reported. A kill-switch, not a normal state |
+| `warn` | The watchdog runs and reports; it can never fail an activity. **The default** |
+| `enforce` | Reports the gap, then fails the attempt |
+
+Warn is the default fleet-wide because it cannot fail anything, which means nobody has
+to opt in and every app starts producing its own work-list on upgrade.
+
+### When a stall does fail an attempt
+
+In `enforce`, the watchdog cancels the attempt and the SDK turns that into a
+`TaskStalledError` — a subtype of `AppTimeoutError`, code `TIMEOUT_TASK_STALLED`,
+carrying `stalled_for_seconds` and `last_progress_label`. It is **retryable on
+purpose**: the dominant cause is a transient source-side hang that self-heals on a fresh
+attempt, and a genuine wedge re-stalls at a cost of a few multiples of the budget rather
+than of the backstop.
+
+Detection latency is the budget plus at most one heartbeat tick.
+
+Effective kill times:
+
+| Situation | Killed at |
+|---|---|
+| Quiet step, no hold | `max_no_progress_seconds` |
+| Wedged call inside a declared hold | `timeout` + `max_no_progress_seconds` |
+| Wedged call inside an unbounded hold (including any `run_in_thread`) | the 24h backstop |
+| Nothing beating at all (OOM, node loss, starved loop) | `heartbeat_timeout_seconds` (60s), unchanged |
+
+**Before flipping an app to `enforce`, verify against a large-tenant / tail profile —
+not a smoke test.** A small run hides the tail gaps, and because stall kills retry, an
+under-instrumented app burns the same wasted work up to three times before failing.
+
+## What if I do nothing?
+
+Nothing fails differently. See
+[Upgrading: the stall watchdog](../upgrade-guide-v3.md#step-11b-the-stall-watchdog-what-if-i-do-nothing)
+for the full answer, including which code shapes do eventually need action and which
+never will.
+
+## Related
+
+- [ADR-0018 — Progress-Aware Stall Watchdog and Duration-Backstop Timeouts](../adr/0018-progress-aware-heartbeat.md)
+- [ADR-0010 — Async-First Design and Blocking Code Pitfalls](../adr/0010-async-first-blocking-code.md)
+- [Tasks — Timeouts and auto-heartbeating](tasks.md#timeouts-and-auto-heartbeating)
+- [Apps — Offloading blocking work](apps.md#offloading-blocking-work-run_in_thread-and-auto-holds)
+- [Monitoring](monitoring.md)

--- a/docs/concepts/progress-and-stalls.md
+++ b/docs/concepts/progress-and-stalls.md
@@ -107,9 +107,9 @@ to do:
 | SQL / REST template page loops | one fetched page written | `extract.page`, `fetch_databases.page`, `fetch_schemas.page`, `fetch_tables.page`, `fetch_columns.page` |
 | Your own `self.heartbeat(...)` | whatever you decide | `task.heartbeat` |
 
-Hooks sit on **batch, chunk and page boundaries — never per record.** One batch is
-already the unit of observable work, and a per-record mark would be a hot-path cost for
-no extra signal.
+Hooks sit on **batch, chunk and page boundaries — not per record, in the current hook
+set.** One batch is already the unit of observable work, and a per-record mark would be
+a hot-path cost for no extra signal.
 
 The label matters beyond bookkeeping: it is what a stall report names, so
 `last signal was 'fetch_tables.page'` tells an operator *which* loop went quiet rather
@@ -193,8 +193,11 @@ fail in testing, it false-kills at the tail, against the largest tenant, hours i
   several opaque calls — never release each other. The hold is released in a `finally`,
   so an exception or a cancellation inside the block does not leave the watchdog paused.
 
-`label` is written into logs and metric labels, so it must identify a **site**. Never
-interpolate a query, a key, a credential or a customer value into it.
+!!! warning "High-cardinality labels"
+
+    `label` is written into logs and metric labels, so it must identify a **site**.
+    Never interpolate a query, a key, a credential or a customer value into it — a
+    per-tenant label is a metrics-backend bill, not a code bug.
 
 ## Choosing an allowance
 
@@ -353,7 +356,7 @@ under-instrumented app burns the same wasted work up to three times before faili
 ## What if I do nothing?
 
 Nothing fails differently. See
-[Upgrading: the stall watchdog](../upgrade-guide-v3.md#step-11b-the-stall-watchdog-what-if-i-do-nothing)
+[Upgrading: the stall watchdog](../upgrade-guide-v3.md#step-11b-the-stall-watchdog)
 for the full answer, including which code shapes do eventually need action and which
 never will.
 

--- a/docs/concepts/tasks.md
+++ b/docs/concepts/tasks.md
@@ -181,6 +181,28 @@ env:
 
 Explicit `@task(timeout_seconds=...)` values always take precedence over the env vars.
 
+### The three knobs
+
+Timeout-shaped settings are easy to confuse, so it is worth being explicit about which
+question each one answers:
+
+| Knob | Default | Answers | Tune it? |
+|---|---|---|---|
+| `heartbeat_timeout_seconds` | 60s | *"Is anything beating at all?"* — crash, OOM kill, node loss, a fully blocked event loop | No |
+| `max_no_progress_seconds` | 900s | *"How long may this attempt be silent before it counts as stalled?"* — wedged-but-alive | Rarely |
+| `timeout_seconds` (`start_to_close`) | 600s today; a 24h backstop once the stall watchdog ships | *"What is the absolute ceiling on one attempt?"* | No — it becomes a backstop, not a budget |
+
+`max_no_progress_seconds` and the `progress_watchdog` mode arrive with the release that
+raises `timeout_seconds` to its backstop value; the progress signals they act on are
+already live.
+
+`max_no_progress_seconds` is **not** the beat interval (that is `auto_heartbeat_seconds`,
+and it is unconditional) and **not** a duration budget — it measures the *gap* between
+progress signals, so a nine-hour task that writes a batch every thirty seconds never
+approaches it. See [Progress and Stalls](progress-and-stalls.md) for the full picture:
+what counts as progress, when you need `holding_progress()`, and how to read the report
+the watchdog produces for your app.
+
 ## Manual Heartbeats with Progress
 
 For tasks that should resume from where they left off after a retry, send typed heartbeat details:
@@ -205,6 +227,11 @@ class MyConnector(App):
             )
 ```
 
+A manual beat also **marks progress** for the stall watchdog, under the label
+`task.heartbeat` — so a custom loop that beats once per iteration is observable and
+needs no hold. It is the third of the three progress mechanisms in
+[Progress and Stalls](progress-and-stalls.md#the-one-rule).
+
 ## Infrastructure Access via self.context
 
 Inside a `@task` method, access infrastructure through `self.context`:
@@ -226,6 +253,8 @@ You do not create `DaprClient` instances or call `SecretStore` statics. Infrastr
 ## Blocking Sync Code
 
 Prefer native async libraries wherever possible. For legacy sync code that cannot be rewritten, `self.task_context.run_in_thread(fn, *args)` offloads the call to a thread pool, preventing it from stalling the event loop and blocking heartbeats. See [ADR-0010](../adr/0010-async-first-blocking-code.md) for when this is appropriate and the required internal-timeout precautions.
+
+Every offload is automatically wrapped in an unbounded progress hold, so a long blocking call is never read as a stall — see [Progress and Stalls](progress-and-stalls.md#automatic-holds-on-offloaded-work) for how to give it a real bound instead.
 
 ## FileReference: Passing Large Data Between Tasks
 

--- a/docs/standards/documentation.md
+++ b/docs/standards/documentation.md
@@ -6,6 +6,7 @@ When modifying SDK code, update corresponding conceptual documentation under `do
 *   `application_sdk/app/**` -> `docs/concepts/apps.md`
 *   `application_sdk/templates/**` -> `docs/concepts/tasks.md`
 *   `application_sdk/execution/**` -> `docs/concepts/apps.md`
+*   `application_sdk/execution/progress*.py`, `application_sdk/execution/heartbeat.py` (watchdog paths) -> `docs/concepts/progress-and-stalls.md`
 *   `application_sdk/handler/**` -> `docs/concepts/handlers.md`
 *   `application_sdk/server/**` -> `docs/concepts/server.md`
 *   `application_sdk/clients/**` -> `docs/concepts/clients.md`

--- a/docs/standards/metrics.md
+++ b/docs/standards/metrics.md
@@ -213,6 +213,11 @@ canonical bounded label set is:
 | `mode` | `record_metric` callers | `WriteMode` enum (`append`, `overwrite`, …) |
 | `type` / `format` | `record_metric` callers | Bounded enumerations of write paths |
 | `error_type` | `record_metric` callers | `type(e).__name__` |
+| `task_name` | `execution/progress_telemetry.py` | Number of registered tasks per app |
+| `progress_last_label` | same | The SDK's fixed set of progress-hook labels plus each app's own hold labels — a call site, never a value |
+| `hold_label` | same | Same set. `run_in_thread` holds are labelled by the offloaded callable's qualname, never by an argument |
+| `watchdog_mode` | same | `off`, `warn`, `enforce` |
+| `hold_bounded` / `hold_lapsed` | same | `true`, `false` |
 
 Any new label not on this list needs justification: prove it's bounded.
 
@@ -242,6 +247,8 @@ Names emitted by the consolidated SDK surface (all use OTel base units
 | `temporal_*` (Rust-core families) | various | Temporal SDK Rust core, scraped via FastAPI proxy or pushed via `TemporalCoreCollector` |
 | `temporal_core_metrics_proxy_failures_total` | counter | `handler/service.py` — bumped (with `reason` label) when the in-process Temporal-core proxy fetch from `127.0.0.1:9464` fails (timeout, non-200, etc.) so `up=1` scrapes with missing `temporal_*` series are observable from VictoriaMetrics rather than only from logs |
 | `dapr_sidecar_wait_duration_seconds` | histogram | `infrastructure/_dapr/http.py` — `wait_for_dapr_sidecar()`, label `outcome` (`ready` / `reachable_not_ready` / `timed_out`); surfaces a slow/misconfigured sidecar as a boot-time metric instead of only as a downstream liveness-probe restart loop |
+| `task_no_progress_gap_seconds` | histogram | `execution/progress_telemetry.py` — one entry per no-progress gap exceeding `max_no_progress_seconds`, labels `task_name`, `progress_last_label`, `watchdog_mode` (ADR-0018) |
+| `task_hold_duration_seconds` | histogram | same — one entry per released progress hold, labels `task_name`, `hold_label`, `hold_bounded`, `hold_lapsed`; every hold is recorded, since sizing an allowance means reading that site's own distribution |
 
 ## User-facing Metrics Shim
 

--- a/docs/upgrade-guide-v3.md
+++ b/docs/upgrade-guide-v3.md
@@ -1016,9 +1016,9 @@ async def fetch(self, input: MyInput) -> MyOutput:
 
 ---
 
-## Step 11b: The stall watchdog — "what if I do nothing?"
+## Step 11b: The stall watchdog
 
-The SDK now runs a **stall watchdog** inside every activity: it watches for observable
+What if you do nothing? The SDK now runs a **stall watchdog** inside every activity: it watches for observable
 forward progress, and reports when an attempt goes quiet for longer than
 `max_no_progress_seconds` (900s). At the same time `timeout_seconds`
 (`start_to_close`) becomes a **24h backstop** you never tune, instead of a duration you

--- a/docs/upgrade-guide-v3.md
+++ b/docs/upgrade-guide-v3.md
@@ -1016,6 +1016,70 @@ async def fetch(self, input: MyInput) -> MyOutput:
 
 ---
 
+## Step 11b: The stall watchdog — "what if I do nothing?"
+
+The SDK now runs a **stall watchdog** inside every activity: it watches for observable
+forward progress, and reports when an attempt goes quiet for longer than
+`max_no_progress_seconds` (900s). At the same time `timeout_seconds`
+(`start_to_close`) becomes a **24h backstop** you never tune, instead of a duration you
+guess.
+
+**There is no migration task here.** This step exists to tell you that, precisely.
+
+> The progress signals the watchdog reads are already live. The settings that act on
+> them — `progress_watchdog` and `max_no_progress_seconds` — arrive together with the
+> 24h backstop, in the release that turns the watchdog on fleet-wide in `warn`.
+
+### On upgrade, nothing fails differently
+
+- You land in **`warn` mode**, which cannot fail an activity. It observes and reports.
+- `heartbeat_timeout_seconds` keeps its meaning and its 60s default. Crash, OOM and
+  node-loss detection is unchanged.
+- No existing knob changes meaning, so there is no coupled default to bump.
+- The one thing that *does* change immediately is in your favour: with the backstop at
+  24h, a legitimately long run stops dying at a guessed ceiling.
+
+What you gain is a report about your own code — the sites that go quiet, and the long
+opaque calls the SDK is currently vouching for unbounded. Reading it is optional and
+can wait; the app stays correct indefinitely without it.
+
+### The added cost is telemetry
+
+Two histograms and the occasional INFO log line. Warn-mode findings are deliberately
+**never** WARNING-level — a stall observation under a fleet-wide default is an expected
+observation, not an alert.
+
+If you need even that gone, `progress_watchdog="off"` is the kill-switch. It makes the
+whole mechanism inert. It is not the normal state, and it also switches off the report
+you would otherwise use later.
+
+### Declaring holds is an eventual optimisation, not an upgrade task
+
+Wrapping opaque calls in `holding_progress()` is work you take on when you want the
+stronger guarantee — a wedge caught in minutes rather than at the backstop — at a time
+of your choosing, guided by your own warn report. It is not a precondition for taking
+the version.
+
+### Which code shapes eventually need action
+
+Relevant only if and when you flip an app to `enforce`:
+
+| Your existing code | In `warn` (today) | In `enforce` | Action |
+|---|---|---|---|
+| Streaming through SDK writers / `ObjectStore` transfers / template page loops | silent | covered — hooks mark progress | none |
+| Already calls `self.heartbeat(...)` | silent | covered — a beat marks progress | none |
+| Opaque blocking call via `run_in_thread` | reported as a long unbounded hold | covered — unbounded auto-hold; the backstop is the only bound | optional: declare an allowance to get a real bound |
+| **A custom async loop doing its own I/O** | reported as a no-progress gap | **false-killed** if any gap exceeds the budget | add a beat or a hold |
+| **An opaque single `await` against your source** (your own async client) | reported as a no-progress gap | **false-killed at the tail** | wrap in `holding_progress()` — expected in nearly every connector |
+
+The last two rows are why `enforce` is a per-app decision verified against a
+large-tenant profile, not a smoke test.
+
+See [Progress and Stalls](concepts/progress-and-stalls.md) for the three knobs, how to
+read your warn report, and how to size an allowance.
+
+---
+
 ## Step 12: App Lifecycle Hooks
 
 v3 adds structured lifecycle hooks that replace ad-hoc cleanup logic that was

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -102,6 +102,7 @@ nav:
       - State, Secrets, Pub/Sub & Bindings: concepts/state-secrets-pubsub.md
       - Entry Points: concepts/entry-points.md
       - Tasks: concepts/tasks.md
+      - Progress & Stalls: concepts/progress-and-stalls.md
       - Server: concepts/server.md
       - Clients: concepts/clients.md
       - Common: concepts/common.md

--- a/tests/unit/app/test_context.py
+++ b/tests/unit/app/test_context.py
@@ -587,7 +587,7 @@ class TestTaskExecutionContextHeartbeat:
     def test_heartbeat_marks_progress(
         self, progress_marks: RecordingProgressTracker
     ) -> None:
-        """A manual beat re-arms the stall clock (ADR-0018, mechanism 3).
+        """A manual beat marks progress for the stall watchdog (ADR-0018).
 
         The docs tell an author to beat inside a custom loop the SDK cannot see
         into *instead of* declaring a hold, so a beat that reached Temporal but

--- a/tests/unit/app/test_context.py
+++ b/tests/unit/app/test_context.py
@@ -33,6 +33,7 @@ from application_sdk.app.context import (
     _WorkflowSafeLogger,
 )
 from application_sdk.contracts.base import HeartbeatDetails
+from application_sdk.execution.heartbeat import NoopHeartbeatController
 from application_sdk.observability.context import (
     ExecutionContext,
     set_execution_context,
@@ -47,6 +48,7 @@ from application_sdk.testing.mocks import (
     MockSecretStore,
     MockStateStore,
 )
+from tests.unit.conftest import RecordingProgressTracker
 
 # ---------------------------------------------------------------------------
 # AppMetadata
@@ -581,6 +583,31 @@ class TestTaskExecutionContextHeartbeat:
         tec = self._build(hb)
         tec.heartbeat(1, 100)
         assert hb.get_heartbeat_calls() == [(1, 100)]
+
+    def test_heartbeat_marks_progress(
+        self, progress_marks: RecordingProgressTracker
+    ) -> None:
+        """A manual beat re-arms the stall clock (ADR-0018, mechanism 3).
+
+        The docs tell an author to beat inside a custom loop the SDK cannot see
+        into *instead of* declaring a hold, so a beat that reached Temporal but
+        not the tracker would leave that advice false-killing at the tail.
+        """
+        tec = self._build()
+        tec.heartbeat(1, 100)
+        assert progress_marks.labels == ["task.heartbeat"]
+
+    def test_heartbeat_marks_progress_with_heartbeating_disabled(
+        self, progress_marks: RecordingProgressTracker
+    ) -> None:
+        """...including on a task whose ``heartbeat_timeout_seconds`` is None.
+
+        There the controller is a no-op and the stall watchdog is the only thing
+        bounding a wedged attempt, so it is the case where the beat matters most.
+        """
+        tec = self._build(NoopHeartbeatController())
+        tec.heartbeat(1, 100)
+        assert progress_marks.labels == ["task.heartbeat"]
 
     def test_get_last_heartbeat_details_delegates(self) -> None:
         hb = MockHeartbeatController()


### PR DESCRIPTION
Closes [FND-295](https://linear.app/atlan-epd/issue/FND-295/docs-progress-hooks-holds-choosing-an-allowance-and-what-to-do-on).

The M2 release lands `warn` on every app in the fleet, so the report an author receives has to point somewhere. This is that somewhere. Ships with M2, not after it — it blocks FND-296.

## The new page

`docs/concepts/progress-and-stalls.md` is the single author-facing home. Everything else points at it rather than restating it, so there is one place to keep correct.

- **The one rule** — if any single step can run longer than `max_no_progress_seconds` without emitting a signal, that step must be made observable — and the three mechanisms that satisfy it, most-automatic first.
- **What counts as progress**, operationally: one observable unit of work completing. Not wall-clock, not event-loop liveness — with the reason the unconditional keepalive can't double as the stall detector.
- **The three knobs**, and both misreads called out by name: `max_no_progress_seconds` is *not* the beat interval (that's `auto_heartbeat_seconds`) and *not* a duration budget (it measures gaps, so a nine-hour task writing a batch every thirty seconds never approaches it). `heartbeat_timeout_seconds` did not change meaning.
- **`holding_progress()` as expected, not exceptional** — with the blocking/async asymmetry that makes it so: `run_in_thread` is a mandatory seam the SDK can hold for you; your source client is not, and the SDK's internal clients don't sit on that path. For an opaque single call a hold is required, not advisory — a forgotten one doesn't fail in testing, it false-kills at the tail against the largest tenant.
- **Choosing an allowance** — not a prediction of duration but *how long you would let this run before you would rather it failed*, taken from the site's own observed p99 (query included) plus headroom. Err generous: the error is asymmetric, and stall kills retry.
- **Reading your warn report** — the two shapes, the actual log lines, PromQL for each, and a triage table whose most common answer is "ignore it". Plus: read it from a large tenant, because a small one hides the tail gaps.
- **Modes, `TaskStalledError`, and the effective kill times** per situation.

## Everything else

| File | Change |
|---|---|
| `docs/concepts/tasks.md` | three-knobs table beside the existing env-var table; the manual beat as a progress signal; blocking-code pointer |
| `docs/concepts/apps.md` | the offload section now links the full picture |
| `docs/concepts/monitoring.md` | the two instruments, and the stall alert with why it is mandatory while an app is in `warn` |
| `docs/standards/metrics.md` | both metrics in the canonical inventory; five new labels justified as bounded |
| `docs/agents/coding-standards.md` | new "Long-Running Tasks: Progress and Stalls" section — the reading list for task authors |
| `docs/upgrade-guide-v3.md` | Step 11b: "what if I do nothing?" — nothing fails differently, the added cost is telemetry, `off` is the kill-switch, holds are an eventual optimisation, plus the code-shape table for whenever an app flips to `enforce` |
| `mkdocs.yml`, `docs/standards/documentation.md` | nav entry, module→doc mapping |

## Two things worth a reviewer's attention

**Sequencing against FND-296.** This lands before `progress_watchdog` and `max_no_progress_seconds` exist, so a page written purely in the present tense would document a knob nobody can set. Three short "rollout status" notes say the signals are live and the settings arrive with the backstop release; everything else is written for the post-M2 state. FND-296's PR deletes those three notes and flips `timeout_seconds`' default in one table. No env-var names are invented — only `progress_watchdog` and `max_no_progress_seconds`, both already fixed by ADR-0018.

**A gap found while writing, fixed here.** ADR-0018's mechanism 3 and `progress.py`'s own module docstring both say an explicit `context.heartbeat()` marks progress. It did not — nothing outside the SDK's framework hooks called `mark_progress`, and FND-288 didn't wire the manual beat. Advising an author to beat once per iteration in a custom loop *instead of* declaring a hold would then have been advice that false-kills at the tail. `TaskExecutionContext.heartbeat()` now marks progress under label `task.heartbeat`:

- **Above the controller, not inside it**, so it counts on a task with `heartbeat_timeout_seconds=None` — where the stall watchdog is the only thing bounding a wedged attempt, i.e. the case where it matters most.
- **Never on `heartbeat_keepalive`**, which is unconditional; treating that as progress would make every attempt look permanently alive and disable the watchdog entirely.

Two tests pin both halves.

## Verification

- `mkdocs build --strict` — no new warnings (the 21 are pre-existing on `main`), and every new cross-page anchor resolves.
- `uv run pre-commit run --files <changed>` — clean, pyright included.
- `atlan-application-sdk-conformance detect --scope sdk` — clean, no new findings.
- `pytest tests/unit/app tests/unit/execution` — 721 passed.
