### PR TITLE
fix(storage): atomic artifact writes + typed disk-full error (FND-318)

### DIFF
--- a/application_sdk/common/_listing.py
+++ b/application_sdk/common/_listing.py
@@ -1,4 +1,4 @@
-"""Race-safe directory listing.
+"""Race-safe directory listing, and what a listing is allowed to yield.
 
 Wraps ``os.scandir`` with a metadata-flush barrier so directories
 written immediately before the listing return their full contents:
@@ -10,6 +10,16 @@ written immediately before the listing return their full contents:
   finished write. ``F_FULLFSYNC`` on the directory FD forces the
   commit before the listing reads it. On Linux ``os.fsync`` covers
   the equivalent NFS / FUSE case. On Windows the barrier is a no-op.
+
+This module also owns :data:`INTERNAL_DIRNAMES` — the directory names
+the SDK uses for its own working files, which must never surface as
+artifacts. It lives here rather than beside the writer that creates
+them because *excluding* them is a property of every tree walk, and
+there is more than one walker: ``safe_list_directory`` below and
+``storage.batch.upload_prefix``. Both consult this one definition, so
+"invisible to a listing" and "invisible to a prefix upload" cannot
+drift apart. Keeping the vocabulary in this stdlib-only module also
+means neither walker takes on a new import to honour it.
 """
 
 from __future__ import annotations
@@ -22,6 +32,47 @@ from pathlib import Path
 # Darwin-only fcntl op: flush kernel buffer + drive cache. Value from
 # <sys/fcntl.h>; not exported by Python's fcntl module.
 _DARWIN_F_FULLFSYNC = 51
+
+#: Directory an atomic write stages its partial file in, sited as a
+#: sibling of the artifact rather than as a suffix beside it — a
+#: ``foo.json.tmp`` next to ``foo.json`` is picked up by every walk of
+#: the artifact directory, which is the leak this name exists to avoid.
+#: Written by :mod:`application_sdk.common.atomic` (FND-318).
+PARTIAL_DIRNAME = ".sdk-partial"
+
+#: Directory a ``Writer`` stages its whole output in until ``close()``
+#: publishes it, sited as a sibling of the output directory (FND-317).
+#: A sibling is out of reach of a walk of the *output* directory, but
+#: not of a walk of the run root a level up — which is what a prefix
+#: upload of a whole run does — so it belongs in the set below.
+#: Re-exported as ``_STAGING_ROOT_DIRNAME`` by ``storage.formats``,
+#: which owns the staging behaviour; defined here so the exclusion
+#: stays a single fact and this module keeps its stdlib-only imports.
+WRITER_STAGING_DIRNAME = ".sdk-writer-staging"
+
+#: Every directory name that holds SDK working files rather than
+#: artifacts. An explicit set rather than a ``.sdk-`` prefix rule: a
+#: denylist that silently swallowed a customer directory because its
+#: name matched a convention would be a data-loss bug, and the set is
+#: short enough that adding to it is a one-line change. Add here when
+#: introducing a new SDK-internal working directory — every walker
+#: picks it up with no further edit.
+INTERNAL_DIRNAMES: frozenset[str] = frozenset({PARTIAL_DIRNAME, WRITER_STAGING_DIRNAME})
+
+
+def is_internal_dirname(name: str) -> bool:
+    """Return ``True`` when *name* is an SDK working directory, not an artifact."""
+    return name in INTERNAL_DIRNAMES
+
+
+def prune_internal_dirs(dirnames: list[str]) -> None:
+    """Drop SDK working directories from ``os.walk``'s ``dirnames``, in place.
+
+    ``os.walk`` re-reads ``dirnames`` after yielding to decide where to
+    descend, so mutating it in place — rather than filtering the copy —
+    is what actually stops the descent.
+    """
+    dirnames[:] = [name for name in dirnames if not is_internal_dirname(name)]
 
 
 def _flush_directory_metadata(path: Path) -> None:
@@ -69,6 +120,11 @@ def _scandir_recursive(path: Path) -> Iterator[Path]:
     Symlinks are not followed: prevents loops on cyclic structures
     and excludes symlink-to-file entries (a behaviour change vs
     ``Path.rglob`` — see ``safe_list_directory``).
+
+    :data:`INTERNAL_DIRNAMES` are not descended into. The test is on
+    the entry name during descent, never on ``path`` itself, so a
+    caller that deliberately points the walk *at* one of these
+    directories still gets its contents.
     """
     stack: list[Path] = [path]
     while stack:
@@ -76,6 +132,8 @@ def _scandir_recursive(path: Path) -> Iterator[Path]:
         with os.scandir(current) as it:
             for entry in it:
                 if entry.is_dir(follow_symlinks=False):
+                    if is_internal_dirname(entry.name):
+                        continue
                     stack.append(Path(entry.path))
                 elif entry.is_file(follow_symlinks=False):
                     yield Path(entry.path)
@@ -104,6 +162,10 @@ def safe_list_directory(path: Path) -> list[Path]:
     NOT included (``follow_symlinks=False`` on every check). New
     callers needing symlink-following should add an opt-in parameter
     rather than changing the default.
+
+    Directories named in :data:`INTERNAL_DIRNAMES` are skipped — an
+    in-flight atomic write must not surface as an artifact in a
+    ``FileReference`` directory or anywhere else this listing feeds.
     """
     _flush_directory_metadata(path)
     return list(_scandir_recursive(path))

--- a/application_sdk/common/atomic.py
+++ b/application_sdk/common/atomic.py
@@ -1,0 +1,463 @@
+"""Atomic artifact writes, and the typed failure when the disk is full (FND-318).
+
+Why this module exists
+----------------------
+A write that fails part-way through leaves a truncated file **at the
+artifact's real name**. Nothing downstream can tell that file from a correct
+one: it is where it is supposed to be, so it is carried forward, uploaded, and
+integrity-checked against its own truncated bytes (see
+:mod:`application_sdk.storage.integrity` — the transfer layer faithfully
+records exactly the bytes that moved, because exactly the intended bytes *did*
+move). The failure surfaces much later, in a *consuming* app's parser, at a
+byte offset that is identical on every retry.
+
+The SDK already knew the fix and applied it only to its own bookkeeping — the
+resume checkpoint in :mod:`application_sdk.storage.chunked` and the local
+secrets file in :mod:`application_sdk.handler.service` are both written
+temp → fsync → ``os.replace``. Every artifact an *app* produced was written
+direct-to-final-name. This module inverts that back: the SDK owns the writers
+apps actually use, so an app should have to go out of its way (a raw ``open()``)
+to produce a partial artifact, not go out of its way to avoid one.
+
+The guarantee
+-------------
+A partial artifact becomes **unnameable**. The final path either does not exist
+or holds a complete file — there is no observable state in between, because the
+bytes are written somewhere else entirely and the final path only ever comes
+into existence via ``os.replace``, which is atomic on POSIX and on Windows.
+
+Three parts make that hold:
+
+* **The staging file is in a sibling directory, not a suffix.** A
+  ``foo.json.tmp`` sitting next to ``foo.json`` is picked up by every walk of
+  the artifact directory — a prefix upload would ship it, a directory
+  ``FileReference`` would adopt it. Staging goes in
+  :data:`~application_sdk.common._listing.PARTIAL_DIRNAME`, a directory both
+  the SDK's tree walkers know to skip, and the *same parent* as the artifact so
+  the publish is a same-filesystem rename rather than a copy.
+* **fsync happens before the replace, inside the guard.** This is not about
+  durability across node loss — the failure this targets is a step failure, and
+  the page cache survives that (the argument
+  ``storage.chunked._save_transfer_state`` already makes). It is about *when
+  ENOSPC is reported*: on a delayed-allocation filesystem the ``write`` calls
+  can all succeed and the error only materialise at flush. Without an fsync
+  before the rename, a short write can be published as a complete artifact and
+  no error is raised anywhere — precisely the incident.
+* **The staging file is removed on every exit path.** Failure leaves nothing
+  behind, and in particular nothing holding the blocks that the retry needs.
+
+What it does not cover
+----------------------
+An app that opens its own file handle bypasses all of this, and so does any SDK
+writer that *appends* to an artifact across calls — you cannot atomically
+append without rewriting the whole file, and
+:meth:`~application_sdk.storage.formats.json.JsonFileWriter._write_chunk` does
+exactly that. Those paths still get :func:`disk_full_guard`, so an ``ENOSPC``
+there is typed and attributed even though the file is not atomic.
+"""
+
+from __future__ import annotations
+
+import errno
+import os
+import shutil
+import uuid
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from typing import IO, Any, NoReturn
+
+from application_sdk.common._listing import PARTIAL_DIRNAME
+from application_sdk.common.path import convert_to_extended_path
+
+__all__ = [
+    "PARTIAL_DIRNAME",
+    "atomic_copy",
+    "atomic_path",
+    "atomic_write",
+    "disk_full_guard",
+    "ensure_free_space",
+]
+
+#: ``errno`` values that mean "this filesystem has no room for your write".
+#: ``EDQUOT`` is the same event seen from a quota rather than from free blocks,
+#: and it needs the same response from whoever is on call, so both map to one
+#: type rather than making every caller learn the distinction. Resolved via
+#: ``getattr`` because ``EDQUOT`` is absent on some platforms.
+_DISK_FULL_ERRNOS: frozenset[int] = frozenset(
+    value
+    for value in (getattr(errno, name, None) for name in ("ENOSPC", "EDQUOT"))
+    if value is not None
+)
+
+
+def _format_bytes(count: int) -> str:
+    """Render a byte count the way an operator sizing a volume would read it."""
+    if count < 1024:
+        return f"{count} B"
+    size = float(count)
+    for unit in ("KiB", "MiB", "GiB"):
+        size /= 1024.0
+        if size < 1024.0:
+            return f"{size:.1f} {unit}"
+    return f"{size / 1024.0:.1f} TiB"
+
+
+def _nearest_existing_dir(path: Path) -> Path | None:
+    """Return the closest ancestor of *path* that exists, for a free-space probe.
+
+    ``shutil.disk_usage`` needs a path that exists; the directory a write is
+    about to create does not yet. Walking up finds the mount point the write
+    will land on, which is what the probe is actually asking about.
+    """
+    for candidate in (path, *path.parents):
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def _free_bytes(path: Path) -> int | None:
+    """Free bytes on the filesystem holding *path*, or ``None`` if unprobeable."""
+    probe = _nearest_existing_dir(path)
+    if probe is None:
+        return None
+    try:
+        return shutil.disk_usage(probe).free
+    except OSError:
+        return None  # conformance: ignore[E007] an unprobeable filesystem costs only the free-bytes number on an error already being raised; a log here would fire per failure with nothing actionable in it
+
+
+def _is_disk_full(exc: OSError) -> bool:
+    """Return ``True`` when *exc* is the filesystem saying it has no room."""
+    return exc.errno in _DISK_FULL_ERRNOS
+
+
+def _raise_disk_full(
+    exc: OSError,
+    *,
+    path: Path,
+    operation: str,
+    required_bytes: int | None = None,
+) -> NoReturn:
+    """Re-raise a disk-full ``OSError`` as the typed error, chained to its cause."""
+    from application_sdk.errors import DiskFullError  # noqa: PLC0415
+
+    free = _free_bytes(path)
+    detail = f"{operation} of '{path}' failed: no space left on device"
+    if free is not None:
+        detail += f" ({_format_bytes(free)} free)"
+    if required_bytes is not None:
+        detail += f"; the write needs about {_format_bytes(required_bytes)}"
+    raise DiskFullError(
+        message=detail,
+        path=str(path),
+        operation=operation,
+        required_bytes=required_bytes,
+        free_bytes=free,
+        limit=None if free is None else f"{free} bytes free",
+        observed=None if required_bytes is None else f"{required_bytes} bytes needed",
+        cause=exc,
+    ) from exc
+
+
+@contextmanager
+def disk_full_guard(
+    path: str | Path,
+    *,
+    operation: str,
+    required_bytes: int | None = None,
+) -> Iterator[None]:
+    """Map a disk-full ``OSError`` raised inside the block to ``DiskFullError``.
+
+    Every other ``OSError`` propagates untouched — this classifies one specific
+    failure, it does not become a general I/O error wrapper.
+
+    Use it directly only on writes that :func:`atomic_write` cannot cover (an
+    append, a third-party writer holding its own handle for the whole run). The
+    atomic helpers already apply it.
+
+    Args:
+        path: Artifact being written. Names the failure and locates the
+            free-space probe.
+        operation: Short phrase naming the step, used verbatim in the message
+            and carried as evidence — "carry-forward copy", "marker write".
+        required_bytes: Size the write needs, when the caller knows it. Turns
+            the message from "no room" into "needs N, has M".
+    """
+    try:
+        yield
+    except OSError as exc:
+        if not _is_disk_full(exc):
+            raise
+        _raise_disk_full(
+            exc,
+            path=Path(path),
+            operation=operation,
+            required_bytes=required_bytes,
+        )
+
+
+def ensure_free_space(
+    path: str | Path,
+    required_bytes: int,
+    *,
+    operation: str,
+) -> None:
+    """Fail before a large write that the filesystem plainly cannot hold.
+
+    Turns "silently corrupt, forty minutes in" into "needs ~N GiB, has M, in
+    five seconds". The comparison is strict — free space is not padded with an
+    invented safety margin, because the SDK has no basis for picking one. That
+    makes this a check for the *plainly impossible* write, not the marginal
+    one; a write that clears this bar and still runs out is caught by
+    :func:`disk_full_guard` and reported identically.
+
+    A filesystem that cannot be probed at all is not treated as a failure: the
+    write proceeds and its own error remains the signal.
+
+    Args:
+        path: Where the write will land.
+        required_bytes: Bytes the write needs. Non-positive is a no-op.
+        operation: Short phrase naming the step, for the message and evidence.
+
+    Raises:
+        DiskFullError: If the filesystem has less free space than *required_bytes*.
+    """
+    if required_bytes <= 0:
+        return
+    free = _free_bytes(Path(path))
+    if free is None or free >= required_bytes:
+        return
+
+    from application_sdk.errors import DiskFullError  # noqa: PLC0415
+
+    raise DiskFullError(
+        message=(
+            f"{operation} of '{path}' needs about {_format_bytes(required_bytes)} "
+            f"but only {_format_bytes(free)} is free on that filesystem. Failing "
+            f"before the write rather than part-way through it."
+        ),
+        path=str(path),
+        operation=operation,
+        required_bytes=required_bytes,
+        free_bytes=free,
+        limit=f"{free} bytes free",
+        observed=f"{required_bytes} bytes needed",
+    )
+
+
+def _fsync_path(path: Path) -> None:
+    """Flush *path* to the filesystem so a short write cannot pass as complete.
+
+    Opened ``O_RDWR`` rather than ``O_RDONLY``: fsync on a read-only descriptor
+    is fine on POSIX but not portable to Windows, and the file is ours — it was
+    created moments ago inside the staging directory.
+    """
+    fd = os.open(
+        convert_to_extended_path(path),
+        os.O_RDWR | getattr(os, "O_BINARY", 0),
+    )
+    try:
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+
+
+def _discard(path: Path) -> None:
+    """Remove a staging file, best-effort.
+
+    Called on the failure path, where the write has already raised and that
+    error is the one worth surfacing. A leftover staging file is inert — it is
+    in a directory no listing descends into — so failing the run a second time
+    over the cleanup would trade a real signal for a cosmetic one.
+    """
+    try:
+        os.unlink(convert_to_extended_path(path))
+    # conformance: ignore[E002] best-effort cleanup on a path that is already failing; a leftover staging file is inert and never published
+    except OSError:
+        pass
+
+
+@contextmanager
+def atomic_path(
+    path: str | Path,
+    *,
+    operation: str,
+    required_bytes: int | None = None,
+) -> Iterator[Path]:
+    """Yield a staging path to write, and publish it onto *path* on clean exit.
+
+    For writers that insist on owning the file themselves —
+    ``pyarrow.parquet.write_table``, ``shutil.copy2``, anything taking a
+    filename rather than a handle. Write to the yielded path; on a clean exit
+    it is fsync'd and renamed onto *path* in one atomic step. On any exception
+    it is removed and *path* is left exactly as it was.
+
+    Use :func:`atomic_write` instead when you are writing bytes yourself.
+
+    Args:
+        path: Final artifact path. Its parent directory is created.
+        operation: Short phrase naming the step, for the failure message.
+        required_bytes: Size the write needs, when known — checked up front by
+            :func:`ensure_free_space`.
+
+    Yields:
+        The staging path to write to.
+
+    Raises:
+        DiskFullError: If the filesystem is out of space, before or during
+            the write.
+        FileNotFoundError: If the block exits cleanly without writing anything
+            to the staging path.
+    """
+    final = Path(path)
+    # A child of the artifact's own directory: same filesystem, so publishing
+    # is a rename and not a copy. Created, never removed — an empty staging
+    # directory is invisible to every listing anyway, and removing it would
+    # race a concurrent writer that has already created its own staging file
+    # in there.
+    staging_dir = final.parent / PARTIAL_DIRNAME
+    os.makedirs(convert_to_extended_path(staging_dir), exist_ok=True)
+    # uuid4 rather than a counter or the pid: two writers racing on the same
+    # artifact name — a cancelled attempt's orphaned thread and its retry —
+    # must not resolve the same staging path, and neither may see the other.
+    staging = staging_dir / f"{final.name}.{uuid.uuid4().hex}"
+
+    if required_bytes is not None:
+        ensure_free_space(staging_dir, required_bytes, operation=operation)
+
+    published = False
+    try:
+        with disk_full_guard(final, operation=operation, required_bytes=required_bytes):
+            yield staging
+            if not os.path.exists(convert_to_extended_path(staging)):
+                raise FileNotFoundError(
+                    errno.ENOENT,
+                    f"{operation} of '{final}' wrote nothing to its staging path",
+                    str(staging),
+                )
+            _fsync_path(staging)
+            os.replace(
+                convert_to_extended_path(staging), convert_to_extended_path(final)
+            )
+            published = True
+    finally:
+        if not published:
+            _discard(staging)
+
+
+@contextmanager
+def atomic_write(
+    path: str | Path,
+    *,
+    operation: str,
+    mode: str = "wb",
+    encoding: str | None = None,
+    required_bytes: int | None = None,
+    **open_kwargs: Any,
+) -> Iterator[IO[Any]]:
+    """Yield an open handle whose contents land at *path* only if the block succeeds.
+
+    The canonical SDK artifact write. Everything :func:`atomic_path` guarantees,
+    with the handle opened and flushed for you.
+
+    ``mode`` must be a creating mode (``"wb"``, ``"w"``, ``"xb"``, …). Append
+    modes are rejected: the staging file starts empty, so ``"ab"`` here would
+    silently drop everything already in the artifact rather than appending to
+    it. A genuine append cannot be made atomic without rewriting the whole file
+    — wrap it in :func:`disk_full_guard` instead and accept that it is not.
+
+    Args:
+        path: Final artifact path. Its parent directory is created.
+        operation: Short phrase naming the step, for the failure message.
+        mode: Any creating mode ``open`` accepts.
+        encoding: Text encoding, for text modes.
+        required_bytes: Size the write needs, when known.
+        **open_kwargs: Forwarded to ``open``.
+
+    Yields:
+        The open handle to write to.
+
+    Raises:
+        DiskFullError: If the filesystem is out of space, before or during
+            the write.
+        AtomicWriteModeError: If *mode* is an append mode or is not a writing
+            mode.
+    """
+    from application_sdk.common.errors import AtomicWriteModeError  # noqa: PLC0415
+
+    if "a" in mode or "+" in mode:
+        raise AtomicWriteModeError(
+            message=(
+                f"atomic_write does not support mode {mode!r}: the staging file "
+                f"starts empty, so appending to it would discard the existing "
+                f"artifact rather than extend it. Use disk_full_guard around the "
+                f"append instead."
+            ),
+            constraint="a creating mode: w, wb, x, xb",
+            value_summary=mode,
+        )
+    if not any(flag in mode for flag in ("w", "x")):
+        raise AtomicWriteModeError(
+            message=f"atomic_write needs a writing mode, got {mode!r}",
+            constraint="a creating mode: w, wb, x, xb",
+            value_summary=mode,
+        )
+
+    with atomic_path(
+        path, operation=operation, required_bytes=required_bytes
+    ) as staging:
+        with open(
+            convert_to_extended_path(staging),
+            mode=mode,
+            encoding=encoding,
+            **open_kwargs,
+        ) as handle:
+            yield handle
+            # Inside the handle's context and inside atomic_path's guard, so a
+            # buffer that only fails to reach the filesystem here — the usual
+            # shape of ENOSPC on a buffered write — still fails the write
+            # rather than closing quietly and publishing a short file.
+            handle.flush()
+            os.fsync(handle.fileno())
+
+
+def atomic_copy(
+    src: str | Path,
+    dst: str | Path,
+    *,
+    operation: str = "file copy",
+) -> None:
+    """Copy *src* to *dst* so that *dst* never exists in a partial state.
+
+    ``shutil.copy2`` writes straight to its destination filename, so a copy
+    interrupted by a full disk leaves a truncated file at the artifact's real
+    name — the write that produced the incident behind FND-318. This stages the
+    copy and publishes it with a rename instead.
+
+    Metadata is preserved, as ``copy2`` does.
+
+    Args:
+        src: File to copy.
+        dst: Destination path (a filename, not a directory).
+        operation: Short phrase naming the step, for the failure message.
+
+    Raises:
+        DiskFullError: If the filesystem is out of space, before or during
+            the copy.
+    """
+    source = Path(src)
+    # Probed rather than assumed: this is the one write whose size is known
+    # before it starts, which is what lets the failure say "needs N, has M".
+    try:
+        required = source.stat().st_size
+    # conformance: ignore[E009] an unstat-able source fails in copy2 below with its own error; skipping the preflight only forgoes the better message
+    except OSError:
+        required = 0
+
+    with atomic_path(
+        dst, operation=operation, required_bytes=required or None
+    ) as staging:
+        shutil.copy2(
+            convert_to_extended_path(source), convert_to_extended_path(staging)
+        )

--- a/application_sdk/common/atomic.py
+++ b/application_sdk/common/atomic.py
@@ -317,7 +317,11 @@ def atomic_path(
     # race a concurrent writer that has already created its own staging file
     # in there.
     staging_dir = final.parent / PARTIAL_DIRNAME
-    os.makedirs(convert_to_extended_path(staging_dir), exist_ok=True)
+    # Inside the guard: creating the staging directory is itself a write, and
+    # on a full filesystem it fails with the same ENOSPC the write would have
+    # — so it is classified identically rather than escaping as a raw OSError.
+    with disk_full_guard(final, operation=operation, required_bytes=required_bytes):
+        os.makedirs(convert_to_extended_path(staging_dir), exist_ok=True)
     # uuid4 rather than a counter or the pid: two writers racing on the same
     # artifact name — a cancelled attempt's orphaned thread and its retry —
     # must not resolve the same staging path, and neither may see the other.
@@ -361,16 +365,20 @@ def atomic_write(
     The canonical SDK artifact write. Everything :func:`atomic_path` guarantees,
     with the handle opened and flushed for you.
 
-    ``mode`` must be a creating mode (``"wb"``, ``"w"``, ``"xb"``, …). Append
-    modes are rejected: the staging file starts empty, so ``"ab"`` here would
-    silently drop everything already in the artifact rather than appending to
-    it. A genuine append cannot be made atomic without rewriting the whole file
-    — wrap it in :func:`disk_full_guard` instead and accept that it is not.
+    ``mode`` must be a ``"w"`` mode. Append modes are rejected: the staging
+    file starts empty, so ``"ab"`` here would silently drop everything already
+    in the artifact rather than appending to it. Exclusive-create (``"x"``)
+    modes are rejected too: publication is ``os.replace``, which overwrites, so
+    the exclusivity would not survive the rename and an existing artifact would
+    be clobbered by a mode claiming to refuse exactly that. The contract is
+    last-writer-wins. A genuine append cannot be made atomic without rewriting
+    the whole file — wrap it in :func:`disk_full_guard` instead and accept that
+    it is not.
 
     Args:
         path: Final artifact path. Its parent directory is created.
         operation: Short phrase naming the step, for the failure message.
-        mode: Any creating mode ``open`` accepts.
+        mode: Any writing mode ``open`` accepts (``"w"``, ``"wb"``).
         encoding: Text encoding, for text modes.
         required_bytes: Size the write needs, when known.
         **open_kwargs: Forwarded to ``open``.
@@ -381,8 +389,8 @@ def atomic_write(
     Raises:
         DiskFullError: If the filesystem is out of space, before or during
             the write.
-        AtomicWriteModeError: If *mode* is an append mode or is not a writing
-            mode.
+        AtomicWriteModeError: If *mode* is an append mode, an exclusive-create
+            mode, or not a writing mode.
     """
     from application_sdk.common.errors import AtomicWriteModeError  # noqa: PLC0415
 
@@ -397,10 +405,22 @@ def atomic_write(
             constraint="a creating mode: w, wb, x, xb",
             value_summary=mode,
         )
-    if not any(flag in mode for flag in ("w", "x")):
+    if "x" in mode:
+        raise AtomicWriteModeError(
+            message=(
+                f"atomic_write does not support mode {mode!r}: publication is "
+                f"os.replace, which overwrites, so exclusive-create semantics "
+                f"cannot survive the rename — an 'x' mode here would clobber an "
+                f"existing artifact while claiming not to. The contract is "
+                f"last-writer-wins; use a creating 'w' mode."
+            ),
+            constraint="a creating mode: w, wb",
+            value_summary=mode,
+        )
+    if "w" not in mode:
         raise AtomicWriteModeError(
             message=f"atomic_write needs a writing mode, got {mode!r}",
-            constraint="a creating mode: w, wb, x, xb",
+            constraint="a creating mode: w, wb",
             value_summary=mode,
         )
 

--- a/application_sdk/common/atomic.py
+++ b/application_sdk/common/atomic.py
@@ -402,7 +402,7 @@ def atomic_write(
                 f"artifact rather than extend it. Use disk_full_guard around the "
                 f"append instead."
             ),
-            constraint="a creating mode: w, wb, x, xb",
+            constraint="a creating mode: w, wb",
             value_summary=mode,
         )
     if "x" in mode:

--- a/application_sdk/common/errors.py
+++ b/application_sdk/common/errors.py
@@ -49,6 +49,21 @@ class PathEmptyError(InvalidInputError):
 
 
 @dataclass(kw_only=True)
+class AtomicWriteModeError(InvalidInputError):
+    """``atomic_write`` was given a mode it cannot honour.
+
+    An append mode is the case worth naming: the staging file starts empty, so
+    appending to it would discard the existing artifact rather than extend it —
+    silently, and only for callers who happen to append. Raised eagerly so that
+    mistake is a startup-shaped failure rather than a data-loss one.
+    """
+
+    code: ClassVar[str] = "INVALID_INPUT_ATOMIC_WRITE_MODE"
+    message: str = "Unsupported mode for an atomic write"
+    field: str | None = "mode"
+
+
+@dataclass(kw_only=True)
 class FileConverterNotFoundError(UnimplementedError):
     """No converter registered for the given file type."""
 

--- a/application_sdk/common/incremental/helpers.py
+++ b/application_sdk/common/incremental/helpers.py
@@ -11,11 +11,11 @@ from __future__ import annotations
 import asyncio
 import os
 import re
-import shutil
 from concurrent.futures import ThreadPoolExecutor
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
+from application_sdk.common.atomic import atomic_copy, ensure_free_space
 from application_sdk.constants import (
     APPLICATION_NAME,
     MARKER_TIMESTAMP_FORMAT,
@@ -313,9 +313,12 @@ def copy_directory_parallel(
         Number of files copied
 
     Raises:
+        DiskFullError: If the destination filesystem cannot hold the copy —
+            either because it plainly has less room than the whole batch needs,
+            or because it ran out part-way through.
         FileNotFoundError: If a source file disappears during copy
         PermissionError: If lacking permissions to read src or write dest
-        OSError: For disk space issues or other I/O errors
+        OSError: For other I/O errors
     """
     if not src_dir.exists():
         return 0
@@ -326,9 +329,36 @@ def copy_directory_parallel(
 
     dest_dir.mkdir(parents=True, exist_ok=True)
 
+    # This is the carry-forward copy behind FND-318. It ran out of space
+    # part-way through and `shutil.copy2` left a truncated file at the
+    # artifact's real name; the run then carried it forward and uploaded it,
+    # and a publish forty minutes later failed in DuckDB at the same byte
+    # offset on every retry. Two changes close that: the batch's total size is
+    # checked before the first byte moves, so a plainly-undersized volume fails
+    # in seconds with a number an operator can act on; and each file is staged
+    # and renamed, so a failure part-way through leaves no file at all rather
+    # than a partial one.
+    total_bytes = 0
+    for src_file in files:
+        try:
+            total_bytes += src_file.stat().st_size
+        except OSError:
+            # Only the estimate is affected — this file is still copied below,
+            # and that copy raises its own error if the file is really gone.
+            # DEBUG because a file disappearing between the glob and the stat
+            # is a benign race, not a condition anyone acts on.
+            logger.debug(
+                "Could not size %s for the carry-forward space check; the "
+                "estimate will be low by that file",
+                src_file,
+                exc_info=True,
+            )
+            continue
+    ensure_free_space(dest_dir, total_bytes, operation="carry-forward copy")
+
     def copy_single_file(src_file: Path) -> None:
-        """Copy a single file to dest_dir. Raises on failure."""
-        shutil.copy2(src_file, dest_dir / src_file.name)
+        """Copy a single file to dest_dir, atomically. Raises on failure."""
+        atomic_copy(src_file, dest_dir / src_file.name, operation="carry-forward copy")
 
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
         list(executor.map(copy_single_file, files))

--- a/application_sdk/common/incremental/helpers.py
+++ b/application_sdk/common/incremental/helpers.py
@@ -15,7 +15,11 @@ from concurrent.futures import ThreadPoolExecutor
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
-from application_sdk.common.atomic import atomic_copy, ensure_free_space
+from application_sdk.common.atomic import (
+    atomic_copy,
+    disk_full_guard,
+    ensure_free_space,
+)
 from application_sdk.constants import (
     APPLICATION_NAME,
     MARKER_TIMESTAMP_FORMAT,
@@ -327,7 +331,11 @@ def copy_directory_parallel(
     if not files:
         return 0
 
-    dest_dir.mkdir(parents=True, exist_ok=True)
+    # Inside the guard: creating the destination is itself a write, and on a
+    # full filesystem it fails with the same ENOSPC/EDQUOT the copies below
+    # would have — the docstring promises DiskFullError for exactly this.
+    with disk_full_guard(dest_dir, operation="carry-forward copy"):
+        dest_dir.mkdir(parents=True, exist_ok=True)
 
     # This is the carry-forward copy behind FND-318. It ran out of space
     # part-way through and `shutil.copy2` left a truncated file at the

--- a/application_sdk/common/incremental/marker.py
+++ b/application_sdk/common/incremental/marker.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from typing import Any
 
+from application_sdk.common.atomic import atomic_write
 from application_sdk.common.incremental.helpers import (
     download_marker_from_s3,
     get_persistent_artifacts_path,
@@ -184,6 +185,9 @@ async def persist_marker_to_storage(
         - s3_key: S3 key where marker was uploaded
 
     Raises:
+        DiskFullError: If the local marker write runs out of disk. No marker
+            file is left behind — the next run reads the previous marker and
+            re-extracts rather than skipping the window this one covered.
         Exception: If upload to S3 fails
 
     Example:
@@ -202,9 +206,14 @@ async def persist_marker_to_storage(
     # Ensure local directory exists
     local_marker_path.parent.mkdir(parents=True, exist_ok=True)
 
-    # Write marker to local file
+    # Write marker to local file. Atomic because a truncated marker is its own
+    # incident: it is the timestamp the *next* run starts from, it is uploaded
+    # and retained, and a half-written one is still a parseable-looking string
+    # — so the damage is a silently wrong extraction window rather than a
+    # failure anyone sees (FND-318).
     logger.info("Writing marker to local file: %s", local_marker_path)
-    local_marker_path.write_text(marker_value, encoding="utf-8")
+    with atomic_write(local_marker_path, operation="marker write") as marker_file:
+        marker_file.write(marker_value.encode("utf-8"))
 
     # Upload marker to S3
     logger.info("Uploading marker to S3: %s", marker_s3_key)

--- a/application_sdk/common/incremental/marker.py
+++ b/application_sdk/common/incremental/marker.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from typing import Any
 
-from application_sdk.common.atomic import atomic_write
+from application_sdk.common.atomic import atomic_write, disk_full_guard
 from application_sdk.common.incremental.helpers import (
     download_marker_from_s3,
     get_persistent_artifacts_path,
@@ -203,8 +203,12 @@ async def persist_marker_to_storage(
         connection_qualified_name, "marker.txt", application_name
     )
 
-    # Ensure local directory exists
-    local_marker_path.parent.mkdir(parents=True, exist_ok=True)
+    # Ensure local directory exists. Inside the guard: the mkdir is itself a
+    # write, and on a full filesystem it fails with the same ENOSPC the marker
+    # write below would have — classified identically rather than escaping the
+    # typed handling the atomic_write provides.
+    with disk_full_guard(local_marker_path, operation="marker write"):
+        local_marker_path.parent.mkdir(parents=True, exist_ok=True)
 
     # Write marker to local file. Atomic because a truncated marker is its own
     # incident: it is the timestamp the *next* run starts from, it is uploaded

--- a/application_sdk/common/incremental/state/incremental_diff.py
+++ b/application_sdk/common/incremental/state/incremental_diff.py
@@ -36,6 +36,7 @@ from typing import Any, Callable, Dict, List, Optional, Set
 
 import orjson
 
+from application_sdk.common.atomic import atomic_write
 from application_sdk.common.incremental.helpers import (
     copy_directory_parallel,
     count_json_files_recursive,
@@ -568,10 +569,12 @@ def _write_metadata(
         "total_files": result.total_files,
     }
 
+    # Atomic: a truncated metadata.json is not a file Argo fails on, it is a
+    # file Argo *routes on* — a half-written counts block is what turns a
+    # stream publish into a skipped one (FND-318).
     metadata_path = incremental_diff_dir.joinpath("metadata.json")
-    metadata_path.write_text(
-        orjson.dumps(metadata, option=orjson.OPT_INDENT_2).decode(), encoding="utf-8"
-    )
+    with atomic_write(metadata_path, operation="diff metadata write") as metadata_file:
+        metadata_file.write(orjson.dumps(metadata, option=orjson.OPT_INDENT_2))
     logger.info("Wrote metadata.json: %s", metadata_path)
 
 

--- a/application_sdk/errors/__init__.py
+++ b/application_sdk/errors/__init__.py
@@ -13,7 +13,7 @@ Canonical API (v3.x+)::
         InvalidInputError, PreconditionError,
         RateLimitedError, UnimplementedError,
         DependencyUnavailableError, SourceUnavailableError,
-        ResourceExhaustedError,
+        ResourceExhaustedError, DiskFullError,
         DataIntegrityError, CancelledError, InternalError,
     )
 
@@ -43,6 +43,7 @@ from application_sdk.errors.leaves import (
     DaprSidecarUnreachableError,
     DataIntegrityError,
     DependencyUnavailableError,
+    DiskFullError,
     InternalError,
     InvalidInputError,
     NotFoundError,
@@ -144,6 +145,7 @@ __all__ = [
     "DaprSidecarUnreachableError",
     "DataIntegrityError",
     "DependencyUnavailableError",
+    "DiskFullError",
     "SourceUnavailableError",
     "InternalError",
     "InvalidInputError",

--- a/application_sdk/errors/leaves.py
+++ b/application_sdk/errors/leaves.py
@@ -337,6 +337,54 @@ class ResourceExhaustedError(AppError):
 
 
 @dataclass(kw_only=True)
+class DiskFullError(ResourceExhaustedError):
+    """A local write failed because the filesystem had no room for it (FND-318).
+
+    Raised by the SDK's write boundary (:mod:`application_sdk.common.atomic`)
+    for ``ENOSPC`` and ``EDQUOT`` — either the volume is out of blocks or the
+    writing identity is over its quota. Both mean the same thing to whoever has
+    to act, which is why they share one type.
+
+    A bare ``OSError`` is the failure this replaces. It carries no category, so
+    it lands in whatever broad ``except`` happens to be in the call stack and
+    the run reports some downstream symptom instead — in the incident that
+    motivated this, a truncated JSON artifact that failed in a *consuming*
+    app's parser forty minutes later. A typed error is classified, attributable
+    to the writing step, and alertable.
+
+    **This error is also the operator's signal that the deployment needs more
+    ephemeral storage.** Requests and limits are deployment configuration and
+    are deliberately not requested from either the SDK or the app — neither can
+    know the number. Naming the path, what the write needed, and what was free
+    tells the operator which deployment to raise and by roughly how much,
+    without either codebase guessing.
+
+    **Retryable, inherited deliberately.** Disk pressure is often not ours: a
+    co-tenant's scratch space frees, or a fresh attempt starts on a node that
+    has room. A genuinely undersized deployment re-fails at
+    :func:`~application_sdk.common.atomic.ensure_free_space` in seconds rather
+    than part-way through a long write, so the retries are cheap and each one
+    re-emits the same operator signal.
+    """
+
+    path: str | None = None
+    operation: str | None = None
+    required_bytes: int | None = None
+    free_bytes: int | None = None
+
+    code: ClassVar[str] = "RESOURCE_EXHAUSTED_DISK_FULL"
+    resource: str | None = "disk"
+    # Defaulted on the class rather than passed at each raise site: the
+    # remediation is the same wherever this is raised from, and a raise site
+    # that forgot it would ship the one failure whose whole purpose is telling
+    # an operator what to change with no instruction attached.
+    suggested_action: str | None = (
+        "Raise the ephemeral-storage request/limit on this deployment, or "
+        "reduce the volume this step stages on local disk."
+    )
+
+
+@dataclass(kw_only=True)
 class DataIntegrityError(AppError):
     expectation: str | None = None
     observed: str | None = None

--- a/application_sdk/storage/batch.py
+++ b/application_sdk/storage/batch.py
@@ -29,6 +29,7 @@ import obstore
 # and writes them. Re-exported here (``batch.SIDECAR_SUFFIX`` /
 # ``batch.is_sidecar_key``) because the listing filters are the historical
 # import site and ``application_sdk.storage`` re-exports both from batch.
+from application_sdk.common._listing import prune_internal_dirs
 from application_sdk.storage.integrity import (
     SIDECAR_SUFFIX as SIDECAR_SUFFIX,  # re-export
 )
@@ -447,7 +448,10 @@ async def upload_prefix(
     """Upload all files under *local_dir* to the store under *prefix*.
 
     Each file's relative path is preserved under *prefix*.
-    Symlinks are skipped to prevent path-traversal.
+    Symlinks are skipped to prevent path-traversal, and SDK working
+    directories (:data:`~application_sdk.common._listing.INTERNAL_DIRNAMES`) are
+    not descended into — an artifact still being staged by an atomic write must
+    not be uploaded as though it were finished (FND-318).
 
     Note:
         Param order is ``(local_dir, prefix)`` — source first, destination second.
@@ -473,7 +477,8 @@ async def upload_prefix(
 
     def _collect_files() -> list[tuple[str, Path]]:
         collected: list[tuple[str, Path]] = []
-        for root, _dirs, filenames in os.walk(local, followlinks=False):
+        for root, dirs, filenames in os.walk(local, followlinks=False):
+            prune_internal_dirs(dirs)
             for fname in filenames:
                 file_path = Path(root) / fname
                 if file_path.is_symlink():

--- a/application_sdk/storage/formats/__init__.py
+++ b/application_sdk/storage/formats/__init__.py
@@ -19,7 +19,7 @@ from typing import TYPE_CHECKING, Any, Union, cast
 import orjson
 
 from application_sdk.common._listing import WRITER_STAGING_DIRNAME, prune_internal_dirs
-from application_sdk.common.atomic import atomic_write
+from application_sdk.common.atomic import atomic_copy, atomic_write, disk_full_guard
 from application_sdk.common.models import TaskStatistics
 from application_sdk.common.types import DataframeType
 from application_sdk.contracts.types import FileReference
@@ -432,8 +432,15 @@ class Writer(ABC):
                         raise
                     # Staging is a sibling of the output directory, so this only
                     # happens when the output directory is itself a mount point.
-                    # Copy rather than fail.
-                    shutil.move(source, destination)
+                    # Copy rather than fail — but never straight to the final
+                    # name: a copy interrupted there leaves a truncated file at
+                    # the artifact's real path, the exact incident class this
+                    # staging exists to kill. atomic_copy stages the copy next
+                    # to the destination and publishes it with a rename, so the
+                    # final name only ever appears complete; the source unlink
+                    # after a successful copy completes the move.
+                    atomic_copy(source, destination, operation="writer publish")
+                    os.unlink(source)
                     copied += 1
 
         if copied:
@@ -966,7 +973,12 @@ class Writer(ABC):
 
             # Write the statistics to a json file inside a dedicated statistics/ folder
             statistics_dir = os.path.join(self._write_root, "statistics")
-            os.makedirs(statistics_dir, exist_ok=True)
+            # Inside the guard: creating the directory is itself a write, and
+            # on a full filesystem it fails with the same ENOSPC the sidecar
+            # write would have — classified identically rather than escaping as
+            # a raw OSError that FormatStatisticsWriteError would wrap untyped.
+            with disk_full_guard(statistics_dir, operation="writer statistics write"):
+                os.makedirs(statistics_dir, exist_ok=True)
             output_file_name = os.path.join(statistics_dir, "statistics.json.ignore")
             # If chunk_start is provided, include it in the statistics filename
             try:

--- a/application_sdk/storage/formats/__init__.py
+++ b/application_sdk/storage/formats/__init__.py
@@ -18,6 +18,8 @@ from typing import TYPE_CHECKING, Any, Union, cast
 
 import orjson
 
+from application_sdk.common._listing import WRITER_STAGING_DIRNAME, prune_internal_dirs
+from application_sdk.common.atomic import atomic_write
 from application_sdk.common.models import TaskStatistics
 from application_sdk.common.types import DataframeType
 from application_sdk.contracts.types import FileReference
@@ -61,7 +63,14 @@ logger = get_logger(__name__)
 #: Directory holding every writer's private staging tree. Created as a *sibling*
 #: of the writer's output directory, never inside it — see
 #: :meth:`Writer._ensure_staging_root`.
-_STAGING_ROOT_DIRNAME = ".sdk-writer-staging"
+#:
+#: The name itself lives in ``common._listing`` alongside every other
+#: SDK-working-directory name, because being a sibling only puts this tree out
+#: of reach of a walk of the *output* directory — a prefix upload of the run
+#: root walks a level higher and would ship a cancelled attempt's staging tree
+#: as run output. One definition, so the walkers and this module cannot
+#: disagree about what is an artifact (FND-318).
+_STAGING_ROOT_DIRNAME = WRITER_STAGING_DIRNAME
 
 #: Subdirectory of a writer's staging root holding files bound for the output
 #: directory. Its layout mirrors the output directory exactly, so publishing is
@@ -394,13 +403,21 @@ class Writer(ABC):
         never leave a half-published attempt for the next one to adopt. The
         cost is a burst of same-filesystem renames — metadata operations, no
         bytes moved — at the end of a writer's life.
+
+        SDK working directories under the staged tree are not descended into.
+        The writers below stage each individual file too (FND-318), so
+        ``.sdk-partial`` sits inside this tree by construction — publishing it
+        would recreate the directory in the output and, if an atomic write had
+        failed, hand a partial file the very name this staging exists to
+        withhold.
         """
         if self._staging_root is None or self._staging_published:
             return
 
         staged_output = os.path.join(self._staging_root, _STAGED_OUTPUT_DIRNAME)
         copied = 0
-        for directory, _subdirectories, file_names in os.walk(staged_output):
+        for directory, subdirectories, file_names in os.walk(staged_output):
+            prune_internal_dirs(subdirectories)
             destination_dir = os.path.normpath(
                 os.path.join(self.path, os.path.relpath(directory, staged_output))
             )
@@ -964,8 +981,14 @@ class Writer(ABC):
                     exc_info=True,
                 )
 
-            # Write the statistics dictionary to the JSON file
-            with open(output_file_name, "wb") as f:
+            # Write the statistics dictionary to the JSON file. Atomic: the
+            # sidecar is the record of how many rows the chunks hold, so a
+            # truncated one does not fail loudly — it is read as a smaller,
+            # plausible count, and the shortfall is attributed to extraction
+            # rather than to the write (FND-318).
+            with atomic_write(
+                output_file_name, operation="writer statistics write"
+            ) as f:
                 f.write(orjson.dumps(statistics))
 
             # Push the file to the object store (key = local path for consistency).

--- a/application_sdk/storage/formats/json.py
+++ b/application_sdk/storage/formats/json.py
@@ -427,12 +427,13 @@ class JsonFileWriter(Writer):
         Not an atomic write, unlike the SDK's other artifact writers (FND-318):
         successive calls *append* to the same chunk file, and an append cannot
         be staged-and-renamed without rewriting everything already in the file
-        on every call. What it does get is :func:`disk_full_guard`, so running
-        out of disk here is a typed ``DiskFullError`` naming this file and this
-        step rather than a bare ``OSError`` that some broad ``except`` upstream
-        swallows. A chunk left short by that failure is still short — the run
-        fails, and the residue is bounded by the writer's staging (FND-317)
-        rather than by this method.
+        on every call. What it does get is :func:`disk_full_guard` around a
+        flushed and fsync'd write, so running out of disk here is a typed
+        ``DiskFullError`` naming this file and this step rather than a bare
+        ``OSError`` that some broad ``except`` upstream swallows — or, on a
+        delayed-allocation filesystem, no error at all. A chunk left short by
+        that failure is still short — the run fails, and the residue is bounded
+        by the writer's staging (FND-317) rather than by this method.
         """
 
         def _default_serializer(obj: object) -> str:
@@ -453,6 +454,14 @@ class JsonFileWriter(Writer):
                                 option=orjson.OPT_APPEND_NEWLINE,
                             )
                         )
+                    # Flush and fsync inside the guard, as the atomic writers
+                    # do (FND-318): on a delayed-allocation filesystem the
+                    # write() calls only dirty page cache, so without this the
+                    # ENOSPC surfaces later — or never — and a short chunk
+                    # passes as complete. This does not make the append atomic;
+                    # it makes its failure typed and attributed here.
+                    f.flush()
+                    os.fsync(f.fileno())
 
         # Offloaded as one hop: `to_dict` materialises the whole chunk and the
         # write loop is one blocking syscall per record. Neither yields, so

--- a/application_sdk/storage/formats/json.py
+++ b/application_sdk/storage/formats/json.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any
 
 import orjson
 
+from application_sdk.common.atomic import disk_full_guard
 from application_sdk.common.file_ops import SafeFileOps
 from application_sdk.common.types import DataframeType
 from application_sdk.constants import DAPR_MAX_GRPC_MESSAGE_LENGTH
@@ -421,7 +422,18 @@ class JsonFileWriter(Writer):
             self.chunk_count = self.chunk_start + self.chunk_count
 
     async def _write_chunk(self, chunk: "pd.DataFrame", file_name: str):
-        """Write a chunk to a JSON file using orjson."""
+        """Write a chunk to a JSON file using orjson.
+
+        Not an atomic write, unlike the SDK's other artifact writers (FND-318):
+        successive calls *append* to the same chunk file, and an append cannot
+        be staged-and-renamed without rewriting everything already in the file
+        on every call. What it does get is :func:`disk_full_guard`, so running
+        out of disk here is a typed ``DiskFullError`` naming this file and this
+        step rather than a bare ``OSError`` that some broad ``except`` upstream
+        swallows. A chunk left short by that failure is still short — the run
+        fails, and the residue is bounded by the writer's staging (FND-317)
+        rather than by this method.
+        """
 
         def _default_serializer(obj: object) -> str:
             # pandas.Timestamp and similar datetime-like objects are not
@@ -431,15 +443,16 @@ class JsonFileWriter(Writer):
         mode = "ab+" if SafeFileOps.exists(file_name) else "wb"
 
         def _serialize_and_write() -> None:
-            with SafeFileOps.open(file_name, mode=mode) as f:
-                for record in chunk.to_dict(orient="records"):
-                    f.write(
-                        orjson.dumps(
-                            record,
-                            default=_default_serializer,
-                            option=orjson.OPT_APPEND_NEWLINE,
+            with disk_full_guard(file_name, operation="json chunk write"):
+                with SafeFileOps.open(file_name, mode=mode) as f:
+                    for record in chunk.to_dict(orient="records"):
+                        f.write(
+                            orjson.dumps(
+                                record,
+                                default=_default_serializer,
+                                option=orjson.OPT_APPEND_NEWLINE,
+                            )
                         )
-                    )
 
         # Offloaded as one hop: `to_dict` materialises the whole chunk and the
         # write loop is one blocking syscall per record. Neither yields, so

--- a/application_sdk/storage/formats/parquet.py
+++ b/application_sdk/storage/formats/parquet.py
@@ -6,6 +6,7 @@ import warnings
 from collections.abc import AsyncGenerator, AsyncIterator, Generator, Iterator
 from typing import TYPE_CHECKING, cast
 
+from application_sdk.common.atomic import atomic_path
 from application_sdk.common.file_ops import SafeFileOps
 from application_sdk.constants import DAPR_MAX_GRPC_MESSAGE_LENGTH
 from application_sdk.contracts.types import FileReference
@@ -1083,11 +1084,25 @@ class ParquetFileWriter(Writer):
                     len(table), 16_000_000 // max(1, table.nbytes // max(1, len(table)))
                 ),
             )
-            pq.write_table(
-                table,
+            # Staged and renamed rather than written in place (FND-318).
+            # `pq.write_table` always overwrites its target, so this chunk is a
+            # whole-file write and can be made atomic without changing what
+            # lands: a chunk that runs out of disk leaves no file at
+            # `file_name` at all, rather than a parquet footer-less prefix that
+            # every downstream reader fails on identically. `table.nbytes` is
+            # the pre-compression size, so it over-estimates what snappy will
+            # actually need — deliberately, since the preflight is only meant
+            # to catch the plainly impossible write.
+            with atomic_path(
                 file_name,
-                compression="snappy",
-                row_group_size=row_group_size,
-            )
+                operation="parquet chunk write",
+                required_bytes=table.nbytes or None,
+            ) as staging:
+                pq.write_table(
+                    table,
+                    str(staging),
+                    compression="snappy",
+                    row_group_size=row_group_size,
+                )
 
         await run_in_thread(_convert_and_write)

--- a/application_sdk/storage/integrity.py
+++ b/application_sdk/storage/integrity.py
@@ -52,10 +52,17 @@ disk and *then* handed it to ``upload_file`` gets a sidecar recording the
 truncated content as the expected digest, and every downstream check passes: as
 far as the transfer layer can tell, exactly the intended bytes moved.
 
-Closing that half needs the producer to fail hard on its own write errors and
-delete partial output rather than upload it — the producer-side half of FND-306,
-tracked against the connector apps. What the machinery here does buy against a
-mid-write producer failure is narrower and still worth having:
+Closing that half needs the producer to never leave partial output at an
+artifact's real name in the first place, which is
+:mod:`application_sdk.common.atomic` (FND-318): every SDK writer stages its
+bytes elsewhere and renames them into place, so a write that fails leaves the
+final path either absent or holding the previous complete artifact — there is
+nothing partial for this module to faithfully record. That is the producer-side
+half, and it belongs in the SDK for the same reason this module does: the SDK
+owns the writers apps actually use.
+
+What the machinery here buys *on top of* that is narrower and still worth
+having:
 
 * a file truncated *while the upload is reading it* is caught (local-shrink);
 * any corruption after a good upload — a rewrite, a partial restore, a

--- a/application_sdk/storage/reference.py
+++ b/application_sdk/storage/reference.py
@@ -47,6 +47,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from application_sdk.common._listing import safe_list_directory
+from application_sdk.common.atomic import atomic_write
 from application_sdk.contracts.types import FileReference
 from application_sdk.execution.heartbeat import run_in_thread
 
@@ -95,9 +96,20 @@ def _make_storage_prefix(ref: FileReference, *, output_path: str | None = None) 
 
 
 def _write_local_sidecar(local_path: str, sha256: str) -> None:
-    """Write a local ``.sha256`` sidecar next to *local_path*."""
+    """Write a local ``.sha256`` sidecar next to *local_path*.
+
+    Atomic even though the write is best-effort, and *because* it is: a
+    truncated digest is not a missing sidecar, it is a wrong one. A later
+    ``materialize`` would compare a good local file against a partial digest,
+    conclude the file is stale, and re-download it every time — a silent,
+    permanent tax rather than the visible failure a missing sidecar produces
+    (FND-318).
+    """
     try:
-        Path(local_path + ".sha256").write_text(sha256)
+        with atomic_write(
+            local_path + ".sha256", operation="local sidecar write"
+        ) as sidecar:
+            sidecar.write(sha256.encode())
     except Exception:
         logger.warning(
             "Sidecar write failed (best-effort, continuing without)", exc_info=True

--- a/docs/agents/coding-standards.md
+++ b/docs/agents/coding-standards.md
@@ -150,6 +150,40 @@ result = requests.get(url)
 result = await self.run_in_thread(requests.get, url)
 ```
 
+## Writing Files
+
+Never write an artifact directly to its final name. Use `application_sdk.common.atomic`:
+
+```python
+from application_sdk.common.atomic import atomic_write
+
+# Wrong — a write that dies part-way leaves a truncated file at the real name.
+# Nothing downstream can tell it from a correct one, so it gets carried forward
+# and uploaded, and the failure surfaces in a consuming app's parser instead.
+Path(out).write_text(payload)
+
+# Right — the final path either does not exist or holds a complete file.
+with atomic_write(out, operation="entity export") as handle:
+    handle.write(payload.encode())
+```
+
+`operation` is a short phrase naming the step; it goes into the failure message and
+its evidence. Two companions:
+
+- `atomic_path(path, operation=...)` for writers that take a filename rather than a
+  handle (`pq.write_table`, `shutil.copy2`), and `atomic_copy(src, dst)` for copies.
+- `disk_full_guard(path, operation=...)` for a write that genuinely cannot be atomic
+  — an append across calls. It types the failure without the atomicity.
+
+A full disk raises `DiskFullError` naming the path and the shortfall, which is the
+signal an operator reads to raise a deployment's ephemeral storage. Pass
+`required_bytes=` when the size is known up front and the check happens before the
+first byte moves. See `docs/concepts/storage.md` → *Atomic artifact writes*.
+
+Every SDK writer already goes through this, so a `Writer`, `FileReference`, or the
+incremental helpers need nothing from you. This rule is for code that opens a file
+itself.
+
 ## Long-Running Tasks: Progress and Stalls
 
 A task that goes quiet for longer than `max_no_progress_seconds` (900s) is reported as a

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -1,8 +1,8 @@
 <!--
 generated-by:  capability-manifest skill (.claude/skills/capability-manifest)
 sdk-version:   3.27.2
-source-sha:    8e86c09581efadf31c6f728f3948c990bdd4055a
-source-date:   2026-08-13T11:24:18+01:00
+source-sha:    361a973002eda45ffab9409782f66a570d5b4cfb
+source-date:   2026-08-13T12:56:26+00:00
 do-not-edit:   re-run the skill instead of hand-editing
 -->
 
@@ -23,10 +23,10 @@ do-not-edit:   re-run the skill instead of hand-editing
 | `application_sdk.common` | Shared utilities — SQL filters, concurrency helpers, TaskStatistics, DataframeType | 11 |
 | `application_sdk.contracts` | Typed Pydantic Input/Output base classes, payload safety, storage and type helpers | 28 |
 | `application_sdk.credentials` | Credential resolvers (Atlan, OAuth, Git, agent), registry, vault spec | 41 |
-| `application_sdk.errors` | Structured error codes — ErrorCode dataclass and cross-component constants (APP_ERROR, HANDLER_ERROR, CONTRACT_VALIDATION, etc.) | 60 |
+| `application_sdk.errors` | Structured error codes — ErrorCode dataclass and cross-component constants (APP_ERROR, HANDLER_ERROR, CONTRACT_VALIDATION, etc.) | 61 |
 | `application_sdk.execution` | Task/workflow execution — retry, heartbeat, sandbox, AppWorker, Temporal client | 20 |
 | `application_sdk.handler` | HTTP handler framework — Handler ABC, DefaultHandler, preflight, auth, service factory | 22 |
-| `application_sdk.infrastructure` | Protocol-based infrastructure (StateStore, SecretStore, PubSub, Bindings, CapacityPool) | 37 |
+| `application_sdk.infrastructure` | Protocol-based infrastructure (StateStore, SecretStore, PubSub, Bindings, CapacityPool) | 38 |
 | `application_sdk.main` | Dev entry point — run_dev_combined() and AppConfig for local execution and container startup | 2 |
 | `application_sdk.observability` | Logging context — ExecutionContext, CorrelationContext, request/correlation helpers | 11 |
 | `application_sdk.outputs` | Output collectors and record models for Automation Engine | 4 |
@@ -961,6 +961,13 @@ Structured error codes — ErrorCode dataclass and cross-component constants (AP
 - **Summary:** Marker for a :class:`DependencyUnavailableError` that specifically means
 - **Defined in:** `application_sdk/errors/leaves.py`
 
+#### `DaprSidecarUnreachableError`
+
+- **Import:** `from application_sdk.errors import DaprSidecarUnreachableError`
+- **Signature:** `class DaprSidecarUnreachableError(*, ...)`
+- **Summary:** Terminal form of a cold-start race: the Dapr sidecar never became
+- **Defined in:** `application_sdk/errors/leaves.py`
+
 #### `DataIntegrityError`
 
 - **Import:** `from application_sdk.errors import DataIntegrityError`
@@ -1811,6 +1818,13 @@ Protocol-based infrastructure (StateStore, SecretStore, PubSub, Bindings, Capaci
 - **Import:** `from application_sdk.infrastructure import SecretStoreUnavailableError`
 - **Signature:** `class SecretStoreUnavailableError(secret_name: str, *, cause: Exception | None = None)`
 - **Summary:** The secret store / Dapr sidecar was *unreachable* — a transport failure
+- **Defined in:** `application_sdk/infrastructure/secrets.py`
+
+#### `SecretStoreUnreachableError`
+
+- **Import:** `from application_sdk.infrastructure import SecretStoreUnreachableError`
+- **Signature:** `class SecretStoreUnreachableError(secret_name: str, ...)`
+- **Summary:** Terminal counterpart of :class:`SecretStoreUnavailableError`: the secret
 - **Defined in:** `application_sdk/infrastructure/secrets.py`
 
 #### `StateStore`

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -1,8 +1,8 @@
 <!--
 generated-by:  capability-manifest skill (.claude/skills/capability-manifest)
 sdk-version:   3.27.2
-source-sha:    361a973002eda45ffab9409782f66a570d5b4cfb
-source-date:   2026-08-13T12:56:26+00:00
+source-sha:    eca64286e05f3c2f2cdb0e4fc4addbccd7cdabd1
+source-date:   2026-08-13T13:08:47+00:00
 do-not-edit:   re-run the skill instead of hand-editing
 -->
 

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -1,8 +1,8 @@
 <!--
 generated-by:  capability-manifest skill (.claude/skills/capability-manifest)
 sdk-version:   3.27.2
-source-sha:    d17c44d109b54a9bed98a6170cb41de1df3c0987
-source-date:   2026-08-13T10:58:48+05:30
+source-sha:    8e86c09581efadf31c6f728f3948c990bdd4055a
+source-date:   2026-08-13T11:24:18+01:00
 do-not-edit:   re-run the skill instead of hand-editing
 -->
 
@@ -26,7 +26,7 @@ do-not-edit:   re-run the skill instead of hand-editing
 | `application_sdk.errors` | Structured error codes — ErrorCode dataclass and cross-component constants (APP_ERROR, HANDLER_ERROR, CONTRACT_VALIDATION, etc.) | 60 |
 | `application_sdk.execution` | Task/workflow execution — retry, heartbeat, sandbox, AppWorker, Temporal client | 20 |
 | `application_sdk.handler` | HTTP handler framework — Handler ABC, DefaultHandler, preflight, auth, service factory | 22 |
-| `application_sdk.infrastructure` | Protocol-based infrastructure (StateStore, SecretStore, PubSub, Bindings, CapacityPool) | 38 |
+| `application_sdk.infrastructure` | Protocol-based infrastructure (StateStore, SecretStore, PubSub, Bindings, CapacityPool) | 37 |
 | `application_sdk.main` | Dev entry point — run_dev_combined() and AppConfig for local execution and container startup | 2 |
 | `application_sdk.observability` | Logging context — ExecutionContext, CorrelationContext, request/correlation helpers | 11 |
 | `application_sdk.outputs` | Output collectors and record models for Automation Engine | 4 |
@@ -961,13 +961,6 @@ Structured error codes — ErrorCode dataclass and cross-component constants (AP
 - **Summary:** Marker for a :class:`DependencyUnavailableError` that specifically means
 - **Defined in:** `application_sdk/errors/leaves.py`
 
-#### `DaprSidecarUnreachableError`
-
-- **Import:** `from application_sdk.errors import DaprSidecarUnreachableError`
-- **Signature:** `class DaprSidecarUnreachableError(*, ...)`
-- **Summary:** Terminal form of a cold-start race: the Dapr sidecar never became
-- **Defined in:** `application_sdk/errors/leaves.py`
-
 #### `DataIntegrityError`
 
 - **Import:** `from application_sdk.errors import DataIntegrityError`
@@ -1818,13 +1811,6 @@ Protocol-based infrastructure (StateStore, SecretStore, PubSub, Bindings, Capaci
 - **Import:** `from application_sdk.infrastructure import SecretStoreUnavailableError`
 - **Signature:** `class SecretStoreUnavailableError(secret_name: str, *, cause: Exception | None = None)`
 - **Summary:** The secret store / Dapr sidecar was *unreachable* — a transport failure
-- **Defined in:** `application_sdk/infrastructure/secrets.py`
-
-#### `SecretStoreUnreachableError`
-
-- **Import:** `from application_sdk.infrastructure import SecretStoreUnreachableError`
-- **Signature:** `class SecretStoreUnreachableError(secret_name: str, ...)`
-- **Summary:** Terminal counterpart of :class:`SecretStoreUnavailableError`: the secret
 - **Defined in:** `application_sdk/infrastructure/secrets.py`
 
 #### `StateStore`

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -982,6 +982,13 @@ Structured error codes — ErrorCode dataclass and cross-component constants (AP
 - **Summary:** Required Atlan-internal platform service is temporarily down or degraded.
 - **Defined in:** `application_sdk/errors/leaves.py`
 
+#### `DiskFullError`
+
+- **Import:** `from application_sdk.errors import DiskFullError`
+- **Signature:** `class DiskFullError(*, ...)`
+- **Summary:** A local write failed because the filesystem had no room for it (FND-318).
+- **Defined in:** `application_sdk/errors/leaves.py`
+
 #### `ErrorCode`
 
 - **Import:** `from application_sdk.errors import ErrorCode`

--- a/docs/concepts/common.md
+++ b/docs/concepts/common.md
@@ -56,6 +56,7 @@ AppError  (base — application_sdk.errors)
 │   ├── DependencyUnavailableError  DEPENDENCY_UNAVAILABLE retryable=True  audience=PLATFORM
 │   ├── SourceUnavailableError   SOURCE_UNAVAILABLE        retryable=True   audience=USER
 │   ├── ResourceExhaustedError RESOURCE_EXHAUSTED         retryable=True   audience=PLATFORM
+│   │   └── DiskFullError      RESOURCE_EXHAUSTED (RESOURCE_EXHAUSTED_DISK_FULL)  retryable=True   audience=PLATFORM
 │   ├── AppTimeoutError        TIMEOUT                    retryable=True   audience=APP_OWNER
 │   │   └── TaskStalledError   TIMEOUT (TIMEOUT_TASK_STALLED)  retryable=True   audience=APP_OWNER
 │   ├── CancelledError         CANCELLED                  retryable=False  audience=APP_OWNER

--- a/docs/concepts/storage.md
+++ b/docs/concepts/storage.md
@@ -243,13 +243,62 @@ disk and *then* uploaded it gets a sidecar recording the truncated content as
 the expected digest, and every downstream check passes — exactly the intended
 bytes moved, as far as the transfer layer can tell.
 
-Closing that half is the producer's job: fail hard on write errors, and delete
-partial output rather than upload it. That is tracked against the connector
-apps. What the transfer layer buys against a mid-write producer failure is
-narrower, and still worth having: a file truncated *while the upload reads it*
-is caught; any corruption after a good upload is caught on the next download
-rather than surfacing as a parser error; and the failure is attributed to the
-artifact and its producing key instead of to whichever consumer opened it.
+Closing that half is [atomic artifact writes](#atomic-artifact-writes) below.
+What the transfer layer buys on top of it is narrower, and still worth having:
+a file truncated *while the upload reads it* is caught; any corruption after a
+good upload is caught on the next download rather than surfacing as a parser
+error; and the failure is attributed to the artifact and its producing key
+instead of to whichever consumer opened it.
+
+---
+
+## Atomic artifact writes
+
+Every SDK writer that produces an app artifact writes it **atomically**: the
+bytes go to a staging file, are flushed to the filesystem, and are renamed onto
+the artifact's path in one step. The artifact's final path therefore either does
+not exist or holds a complete file. A partial artifact is *unnameable*.
+
+That matters because a truncated file at an artifact's real name is
+indistinguishable from a correct one. It gets carried forward, uploaded, and
+integrity-checked against its own truncated bytes, and the failure surfaces much
+later inside a consuming app's parser — at a byte offset that is identical on
+every retry, which is what makes it look like a consumer bug.
+
+Covered writers: the incremental carry-forward state copy, the incremental
+marker, incremental diff metadata, writer chunk output and its statistics
+sidecar, and the local `.sha256` sidecar. `JsonFileWriter` chunks are the one
+exception — successive calls append to the same file, and an append cannot be
+staged and renamed without rewriting it — so those get the typed error below
+without the atomicity.
+
+Staging lives in a `.sdk-partial/` directory beside the artifact rather than as
+a `.tmp` suffix next to it, so it is never picked up by a directory listing, a
+directory `FileReference`, or a prefix upload. `safe_list_directory` and
+`upload_prefix` read one shared definition of what to skip.
+
+An app that opens its own file handle bypasses all of this. The guarantee covers
+the writers the SDK owns, which is where app artifacts actually come from.
+
+### Running out of disk
+
+A write that fails for lack of space raises `DiskFullError` — a
+`ResourceExhaustedError` leaf naming the path, the step, the bytes needed, and
+the bytes free. A bare `OSError` is what this replaces: it carries no category,
+so it lands in whatever broad `except` is in the call stack and the run reports
+some unrelated downstream symptom instead.
+
+**This error is the signal that a deployment needs more ephemeral storage.**
+Requests and limits are deployment configuration and are deliberately not
+requested from the SDK or from app code — neither can know the number. The error
+tells the operator which deployment to raise and roughly by how much.
+
+Before a large write whose size is known up front, the SDK checks free space
+first, so a plainly undersized volume fails in seconds with `needs ~N GiB, has
+M` rather than corrupting output forty minutes in. The check is strict — free
+space is not padded with an invented margin — so it catches the impossible write,
+not the marginal one; a marginal write that still runs out is caught during the
+write and reported identically.
 
 ---
 

--- a/docs/standards/exceptions.md
+++ b/docs/standards/exceptions.md
@@ -231,6 +231,11 @@ When reviewing code, check for:
       PreconditionError, RateLimitedError, AppTimeoutError,
       ResourceExhaustedError, DataIntegrityError, InternalError,
       UnimplementedError, AppPermissionDeniedError, CancelledError,
+      # Specialized subtypes of the leaves above, e.g. DiskFullError
+      # (ResourceExhaustedError; a local write hit ENOSPC/EDQUOT) and
+      # TaskStalledError (AppTimeoutError) — raise the subtype when it
+      # describes the failure precisely.
+      DiskFullError,
   )
 
   # DependencyUnavailableError — retryable=True, audience=PLATFORM

--- a/tests/unit/common/test_atomic.py
+++ b/tests/unit/common/test_atomic.py
@@ -1,0 +1,391 @@
+"""FND-318: a partial artifact must never be reachable at its final name.
+
+The bug these cover is not "a write failed" — writes fail all the time and the
+run notices. It is a write that fails and *leaves the wreckage where a correct
+artifact goes*: a truncated file at the artifact's real name is carried
+forward, uploaded, and integrity-checked against its own truncated bytes, and
+the failure only surfaces much later in a consuming app's parser.
+
+So every test here asserts the same two things about an induced ``ENOSPC``:
+nothing is left at the final path, and the failure arrives typed. They are run
+through the real call paths — ``copy_directory_parallel``,
+``persist_marker_to_storage``, the writers — rather than against the helper
+alone, because the helper being correct is not the claim; the claim is that the
+paths apps actually use go through it.
+
+``ENOSPC`` is induced at ``os.fsync`` for the atomic writers. That is not a
+convenience: on a delayed-allocation filesystem it is *where a real ENOSPC
+arrives*, since the ``write`` calls only dirty page cache. It is also the point
+that makes the whole thing work — without an fsync before the rename, a short
+write publishes silently and nothing raises anywhere.
+"""
+
+from __future__ import annotations
+
+import errno
+import os
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from application_sdk.common._listing import safe_list_directory
+from application_sdk.common.atomic import (
+    PARTIAL_DIRNAME,
+    atomic_copy,
+    atomic_path,
+    atomic_write,
+    disk_full_guard,
+    ensure_free_space,
+)
+from application_sdk.errors import DiskFullError, ResourceExhaustedError
+
+
+def _enospc(*_args: Any, **_kwargs: Any) -> Any:
+    """Stand-in for a filesystem with no room left."""
+    raise OSError(errno.ENOSPC, "No space left on device")
+
+
+class _Usage:
+    """Minimal stand-in for ``shutil.disk_usage``'s named tuple."""
+
+    def __init__(self, *, free: int) -> None:
+        self.total = free * 2
+        self.used = free
+        self.free = free
+
+
+def _names(directory: Path) -> set[str]:
+    """Every entry directly under *directory*, staging directory included.
+
+    Deliberately ``os.listdir`` rather than ``safe_list_directory``: these
+    assertions are about what is *really* on disk, and the listing helper is
+    one of the things under test.
+    """
+    return set(os.listdir(directory))
+
+
+def _staged_files(directory: Path) -> list[Path]:
+    """Files left behind in *directory*'s staging tree."""
+    staging = directory / PARTIAL_DIRNAME
+    return list(staging.iterdir()) if staging.exists() else []
+
+
+# ---------------------------------------------------------------------------
+# The guarantee, at the helper
+# ---------------------------------------------------------------------------
+
+
+class TestAtomicWrite:
+    def test_the_final_path_does_not_exist_until_the_write_completes(
+        self, tmp_path: Path
+    ) -> None:
+        artifact = tmp_path / "artifact.json"
+
+        with atomic_write(artifact, operation="test write") as handle:
+            handle.write(b'{"partial')
+            assert (
+                not artifact.exists()
+            ), "the artifact was nameable while it was still being written"
+
+        assert artifact.read_bytes() == b'{"partial'
+
+    def test_enospc_leaves_no_file_at_the_final_path(self, tmp_path: Path) -> None:
+        artifact = tmp_path / "artifact.json"
+
+        with patch("os.fsync", _enospc):
+            with pytest.raises(DiskFullError):
+                with atomic_write(artifact, operation="test write") as handle:
+                    handle.write(b"x" * 184)
+
+        assert not artifact.exists()
+        assert _staged_files(tmp_path) == [], "a staging file survived the failure"
+
+    def test_enospc_does_not_disturb_an_artifact_already_in_place(
+        self, tmp_path: Path
+    ) -> None:
+        """The rename is the only thing that ever touches the final path.
+
+        A direct-to-final write truncates the previous artifact the moment it
+        opens the file, so a failed re-write destroys a good file that was
+        already there. Staging means the worst case is the run failing with the
+        old artifact intact.
+        """
+        artifact = tmp_path / "artifact.json"
+        artifact.write_bytes(b'{"complete": true}')
+
+        with patch("os.fsync", _enospc):
+            with pytest.raises(DiskFullError):
+                with atomic_write(artifact, operation="test write") as handle:
+                    handle.write(b'{"replacement')
+
+        assert artifact.read_bytes() == b'{"complete": true}'
+
+    def test_an_unrelated_oserror_is_not_reclassified(self, tmp_path: Path) -> None:
+        """Only ENOSPC/EDQUOT become DiskFullError; this is a classifier, not a wrapper."""
+        artifact = tmp_path / "artifact.json"
+
+        def _eacces(*_args: Any, **_kwargs: Any) -> Any:
+            raise OSError(errno.EACCES, "Permission denied")
+
+        with patch("os.fsync", _eacces):
+            with pytest.raises(OSError) as caught:
+                with atomic_write(artifact, operation="test write") as handle:
+                    handle.write(b"x")
+
+        assert not isinstance(caught.value, DiskFullError)
+        assert caught.value.errno == errno.EACCES
+        assert not artifact.exists()
+
+    def test_a_failure_in_the_caller_publishes_nothing(self, tmp_path: Path) -> None:
+        """Any exception, not just a disk one, leaves the final path untouched."""
+        artifact = tmp_path / "artifact.json"
+
+        with pytest.raises(ValueError):
+            with atomic_write(artifact, operation="test write") as handle:
+                handle.write(b"half a record")
+                raise ValueError("serialisation blew up")
+
+        assert not artifact.exists()
+        assert _staged_files(tmp_path) == []
+
+    def test_append_modes_are_rejected(self, tmp_path: Path) -> None:
+        """An append through here would silently discard the existing artifact."""
+        from application_sdk.common.errors import AtomicWriteModeError  # noqa: PLC0415
+
+        with pytest.raises(AtomicWriteModeError, match="does not support mode"):
+            with atomic_write(tmp_path / "a.json", operation="t", mode="ab"):
+                pass
+
+    def test_a_non_writing_mode_is_rejected(self, tmp_path: Path) -> None:
+        from application_sdk.common.errors import AtomicWriteModeError  # noqa: PLC0415
+
+        with pytest.raises(AtomicWriteModeError, match="needs a writing mode"):
+            with atomic_write(tmp_path / "a.json", operation="t", mode="rb"):
+                pass
+
+    def test_text_mode_round_trips(self, tmp_path: Path) -> None:
+        artifact = tmp_path / "marker.txt"
+
+        with atomic_write(
+            artifact, operation="test write", mode="w", encoding="utf-8"
+        ) as handle:
+            handle.write("2026-08-13T00:00:00Z")
+
+        assert artifact.read_text(encoding="utf-8") == "2026-08-13T00:00:00Z"
+
+    def test_concurrent_writers_of_the_same_artifact_do_not_share_a_staging_path(
+        self, tmp_path: Path
+    ) -> None:
+        """A cancelled attempt's orphan and its retry must not collide."""
+        artifact = tmp_path / "chunk-0.parquet"
+        seen: list[Path] = []
+
+        for _ in range(2):
+            with atomic_path(artifact, operation="test write") as staging:
+                seen.append(staging)
+                staging.write_bytes(b"data")
+
+        assert seen[0] != seen[1]
+        assert all(path.parent.name == PARTIAL_DIRNAME for path in seen)
+
+    def test_a_block_that_writes_nothing_is_an_error_not_a_silent_success(
+        self, tmp_path: Path
+    ) -> None:
+        artifact = tmp_path / "artifact.parquet"
+
+        with pytest.raises(FileNotFoundError):
+            with atomic_path(artifact, operation="test write"):
+                pass
+
+        assert not artifact.exists()
+
+
+class TestAtomicCopy:
+    def test_a_copy_that_runs_out_of_space_leaves_nothing_behind(
+        self, tmp_path: Path
+    ) -> None:
+        source = tmp_path / "src.json"
+        source.write_bytes(b'{"rows": 4000}')
+        destination = tmp_path / "dest" / "src.json"
+        destination.parent.mkdir()
+
+        with patch("application_sdk.common.atomic.shutil.copy2", _enospc):
+            with pytest.raises(DiskFullError):
+                atomic_copy(source, destination, operation="test copy")
+
+        assert not destination.exists()
+        assert _staged_files(destination.parent) == []
+
+    def test_a_successful_copy_publishes_the_whole_file(self, tmp_path: Path) -> None:
+        source = tmp_path / "src.json"
+        source.write_bytes(b'{"rows": 4000}')
+        destination = tmp_path / "dest" / "src.json"
+        destination.parent.mkdir()
+
+        atomic_copy(source, destination, operation="test copy")
+
+        assert destination.read_bytes() == source.read_bytes()
+
+
+# ---------------------------------------------------------------------------
+# The typed failure
+# ---------------------------------------------------------------------------
+
+
+class TestDiskFullError:
+    def test_it_names_the_path_and_the_step(self, tmp_path: Path) -> None:
+        artifact = tmp_path / "column-ancestral-201.json"
+
+        with patch("os.fsync", _enospc):
+            with pytest.raises(DiskFullError) as caught:
+                with atomic_write(artifact, operation="carry-forward copy") as handle:
+                    handle.write(b"x")
+
+        error = caught.value
+        assert error.path == str(artifact)
+        assert error.operation == "carry-forward copy"
+        assert error.free_bytes is not None
+        assert "carry-forward copy" in str(error)
+        assert str(artifact) in str(error)
+
+    def test_it_is_a_resource_exhausted_leaf(self) -> None:
+        """So RESOURCE_EXHAUSTED consumers route it without knowing the subtype."""
+        error = DiskFullError(message="out of room")
+        assert isinstance(error, ResourceExhaustedError)
+        assert error.qualified_code == "RESOURCE_EXHAUSTED.RESOURCE_EXHAUSTED_DISK_FULL"
+        assert error.effective_retryable is True
+
+    def test_the_wire_envelope_carries_the_operator_signal(self) -> None:
+        """It is the only thing that tells an operator to raise ephemeral storage."""
+        error = DiskFullError(
+            message="out of room",
+            path="/local/tmp/x.json",
+            operation="carry-forward copy",
+            required_bytes=4096,
+            free_bytes=10,
+        )
+        details = error.to_failure_details()
+
+        assert details.evidence["path"] == "/local/tmp/x.json"
+        assert details.evidence["required_bytes"] == 4096
+        assert details.evidence["free_bytes"] == 10
+        assert details.audience.value == "PLATFORM"
+        assert details.suggested_action is not None
+        assert "ephemeral-storage" in details.suggested_action
+
+    def test_edquot_is_the_same_failure(self, tmp_path: Path) -> None:
+        """A quota ceiling needs the same response as an empty volume."""
+        quota_errno = getattr(errno, "EDQUOT", None)
+        if quota_errno is None:
+            pytest.skip("EDQUOT is not defined on this platform")
+
+        def _over_quota(*_args: Any, **_kwargs: Any) -> Any:
+            raise OSError(quota_errno, "Disc quota exceeded")
+
+        with patch("os.fsync", _over_quota):
+            with pytest.raises(DiskFullError):
+                with atomic_write(tmp_path / "a.json", operation="t") as handle:
+                    handle.write(b"x")
+
+
+class TestDiskFullGuard:
+    def test_it_types_a_write_it_cannot_make_atomic(self, tmp_path: Path) -> None:
+        with pytest.raises(DiskFullError) as caught:
+            with disk_full_guard(
+                tmp_path / "chunk-0.json", operation="json chunk write"
+            ):
+                _enospc()
+
+        assert caught.value.operation == "json chunk write"
+
+    def test_it_passes_every_other_oserror_through(self, tmp_path: Path) -> None:
+        with pytest.raises(FileNotFoundError):
+            with disk_full_guard(tmp_path / "x", operation="t"):
+                raise FileNotFoundError(errno.ENOENT, "nope")
+
+
+class TestEnsureFreeSpace:
+    def test_a_plainly_impossible_write_fails_before_it_starts(
+        self, tmp_path: Path
+    ) -> None:
+        with patch(
+            "application_sdk.common.atomic.shutil.disk_usage",
+            return_value=_Usage(free=1024),
+        ):
+            with pytest.raises(DiskFullError) as caught:
+                ensure_free_space(tmp_path, 8 * 1024**3, operation="carry-forward copy")
+
+        error = caught.value
+        assert error.required_bytes == 8 * 1024**3
+        assert error.free_bytes == 1024
+        assert "8.0 GiB" in str(error)
+        assert "1.0 KiB" in str(error)
+
+    def test_a_write_that_fits_is_not_blocked(self, tmp_path: Path) -> None:
+        ensure_free_space(tmp_path, 16, operation="t")  # should not raise
+
+    def test_zero_is_a_no_op(self, tmp_path: Path) -> None:
+        ensure_free_space(tmp_path, 0, operation="t")  # should not raise
+
+    def test_an_unprobeable_filesystem_does_not_block_the_write(
+        self, tmp_path: Path
+    ) -> None:
+        """The write's own failure stays the signal; the probe is an optimisation."""
+        with patch("application_sdk.common.atomic.shutil.disk_usage", _enospc):
+            ensure_free_space(tmp_path, 8 * 1024**3, operation="t")  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# Staging must be invisible to everything that enumerates artifacts
+# ---------------------------------------------------------------------------
+
+
+class TestStagingIsInvisible:
+    def test_a_directory_listing_does_not_see_an_in_flight_write(
+        self, tmp_path: Path
+    ) -> None:
+        (tmp_path / "done.json").write_bytes(b"{}")
+
+        with atomic_write(tmp_path / "in-flight.json", operation="t") as handle:
+            handle.write(b"{")
+            listed = safe_list_directory(tmp_path)
+
+        assert [path.name for path in listed] == ["done.json"]
+
+    def test_a_listing_still_works_when_pointed_at_the_staging_directory(
+        self, tmp_path: Path
+    ) -> None:
+        """The exclusion is on descent, so an explicit target is not swallowed."""
+        with atomic_write(tmp_path / "a.json", operation="t") as handle:
+            handle.write(b"{")
+            staged = safe_list_directory(tmp_path / PARTIAL_DIRNAME)
+
+        assert len(staged) == 1
+
+    async def test_a_prefix_upload_does_not_ship_an_in_flight_write(
+        self, tmp_path: Path
+    ) -> None:
+        from application_sdk.storage.batch import upload_prefix  # noqa: PLC0415
+        from application_sdk.storage.factory import create_memory_store  # noqa: PLC0415
+
+        (tmp_path / "done.json").write_bytes(b"{}")
+        store = create_memory_store()
+
+        with atomic_write(tmp_path / "in-flight.json", operation="t") as handle:
+            handle.write(b"{")
+            keys = await upload_prefix(tmp_path, "out", store, normalize=False)
+
+        assert keys == ["out/done.json"]
+
+    def test_the_staging_directory_is_left_behind_but_empty(
+        self, tmp_path: Path
+    ) -> None:
+        """Removing it would race a concurrent writer; leaving it costs nothing."""
+        with atomic_write(tmp_path / "a.json", operation="t") as handle:
+            handle.write(b"{}")
+
+        assert _names(tmp_path) == {"a.json", PARTIAL_DIRNAME}
+        assert _staged_files(tmp_path) == []
+        assert safe_list_directory(tmp_path) == [tmp_path / "a.json"]

--- a/tests/unit/common/test_atomic.py
+++ b/tests/unit/common/test_atomic.py
@@ -158,6 +158,15 @@ class TestAtomicWrite:
             with atomic_write(tmp_path / "a.json", operation="t", mode="ab"):
                 pass
 
+    def test_exclusive_create_modes_are_rejected(self, tmp_path: Path) -> None:
+        """Publication is os.replace, which overwrites, so "x" would lie about
+        refusing to clobber — the honest contract is last-writer-wins."""
+        from application_sdk.common.errors import AtomicWriteModeError  # noqa: PLC0415
+
+        with pytest.raises(AtomicWriteModeError, match="does not support mode"):
+            with atomic_write(tmp_path / "a.json", operation="t", mode="xb"):
+                pass
+
     def test_a_non_writing_mode_is_rejected(self, tmp_path: Path) -> None:
         from application_sdk.common.errors import AtomicWriteModeError  # noqa: PLC0415
 
@@ -199,6 +208,21 @@ class TestAtomicWrite:
             with atomic_path(artifact, operation="test write"):
                 pass
 
+        assert not artifact.exists()
+
+    def test_a_staging_directory_that_cannot_be_created_fails_typed(
+        self, tmp_path: Path
+    ) -> None:
+        """Creating .sdk-partial is itself a write; on a full filesystem its
+        ENOSPC must arrive as DiskFullError, not escape as a bare OSError."""
+        artifact = tmp_path / "artifact.json"
+
+        with patch("application_sdk.common.atomic.os.makedirs", _enospc):
+            with pytest.raises(DiskFullError) as caught:
+                with atomic_write(artifact, operation="test write") as handle:
+                    handle.write(b"x")
+
+        assert caught.value.operation == "test write"
         assert not artifact.exists()
 
 

--- a/tests/unit/common/test_atomic_write_sites.py
+++ b/tests/unit/common/test_atomic_write_sites.py
@@ -1,0 +1,489 @@
+"""FND-318 acceptance, one test per SDK writer that produces an app artifact.
+
+The previous module tests the helper. These test the claim that actually
+matters — that the paths apps use go *through* it — by driving each real
+function with the disk out from under it and asserting the same two properties
+every time: nothing at the artifact's final path, and a typed ``DiskFullError``
+rather than a bare ``OSError`` for a broad ``except`` to swallow.
+
+The list is the inventory FND-318 was filed against:
+
+============================================  ==========================
+writer                                        artifact
+============================================  ==========================
+``copy_directory_parallel``                   carry-forward state copy
+``persist_marker_to_storage``                 the incremental marker
+``_write_metadata``                           diff metadata for Argo
+``Writer._write_statistics``                  the statistics sidecar
+``ParquetFileWriter._write_chunk``            a parquet chunk
+``_write_local_sidecar``                      the local ``.sha256``
+``JsonFileWriter._write_chunk``               a JSON chunk (typed only)
+============================================  ==========================
+
+The JSON chunk is the one exception, and deliberately so: successive calls
+append to the same file, and an append cannot be staged and renamed without
+rewriting everything already in it. It gets the typed error and nothing more,
+which its test asserts explicitly rather than leaving as an omission.
+"""
+
+from __future__ import annotations
+
+import errno
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pandas as pd
+import pytest
+
+from application_sdk.common.atomic import PARTIAL_DIRNAME
+from application_sdk.common.incremental.helpers import copy_directory_parallel
+from application_sdk.errors import DiskFullError
+
+
+def _enospc(*_args: Any, **_kwargs: Any) -> Any:
+    raise OSError(errno.ENOSPC, "No space left on device")
+
+
+class _Usage:
+    def __init__(self, *, free: int) -> None:
+        self.total = free * 2
+        self.used = free
+        self.free = free
+
+
+def _artifacts(directory: Path) -> list[str]:
+    """Names directly under *directory*, excluding the staging tree."""
+    if not directory.exists():
+        return []
+    return sorted(p.name for p in directory.iterdir() if p.name != PARTIAL_DIRNAME)
+
+
+# ---------------------------------------------------------------------------
+# The incident site: the carry-forward copy
+# ---------------------------------------------------------------------------
+
+
+class TestCarryForwardCopy:
+    """``copy_directory_parallel`` — where the 184-byte column file came from."""
+
+    def test_a_copy_that_runs_out_of_space_names_no_partial_file(
+        self, tmp_path: Path
+    ) -> None:
+        source = tmp_path / "column"
+        source.mkdir()
+        (source / "column-ancestral-201.json").write_bytes(b'{"rows": []}' * 100)
+        destination = tmp_path / "current-state" / "column"
+
+        def _truncating_copy2(src: Any, dst: Any, **_kwargs: Any) -> Any:
+            # What `shutil.copy2` actually does on a full disk: it copies until
+            # the filesystem stops it, *then* raises. Both halves matter — a
+            # stub that raises without writing would pass against the very
+            # behaviour this test exists to rule out.
+            Path(dst).write_bytes(Path(src).read_bytes()[:184])
+            _enospc()
+
+        with patch("application_sdk.common.atomic.shutil.copy2", _truncating_copy2):
+            with pytest.raises(DiskFullError) as caught:
+                copy_directory_parallel(source, destination)
+
+        assert caught.value.operation == "carry-forward copy"
+        assert (
+            _artifacts(destination) == []
+        ), "a truncated file was left where a carried-forward artifact goes"
+
+    def test_a_plainly_undersized_volume_fails_before_any_byte_moves(
+        self, tmp_path: Path
+    ) -> None:
+        """The five-second failure, instead of silent corruption forty minutes in."""
+        source = tmp_path / "column"
+        source.mkdir()
+        for index in range(3):
+            (source / f"column-{index}.json").write_bytes(b"x" * 4096)
+        destination = tmp_path / "current-state" / "column"
+
+        copied: list[Any] = []
+
+        def _record(*args: Any, **kwargs: Any) -> Any:
+            copied.append(args)
+
+        with patch(
+            "application_sdk.common.atomic.shutil.disk_usage",
+            return_value=_Usage(free=512),
+        ):
+            with patch("application_sdk.common.atomic.shutil.copy2", _record):
+                with pytest.raises(DiskFullError) as caught:
+                    copy_directory_parallel(source, destination)
+
+        assert copied == [], "the preflight let the copy start anyway"
+        assert caught.value.required_bytes == 3 * 4096
+        assert caught.value.free_bytes == 512
+
+    def test_a_healthy_copy_is_unchanged(self, tmp_path: Path) -> None:
+        source = tmp_path / "column"
+        source.mkdir()
+        (source / "a.json").write_bytes(b'{"a": 1}')
+        (source / "b.json").write_bytes(b'{"b": 2}')
+        destination = tmp_path / "current-state" / "column"
+
+        assert copy_directory_parallel(source, destination) == 2
+        assert _artifacts(destination) == ["a.json", "b.json"]
+        assert (destination / "a.json").read_bytes() == b'{"a": 1}'
+
+
+# ---------------------------------------------------------------------------
+# The incremental marker
+# ---------------------------------------------------------------------------
+
+
+class TestMarkerWrite:
+    async def test_a_marker_that_runs_out_of_space_is_not_written_at_all(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A half-written marker still parses — it is just the wrong window."""
+        from application_sdk.common.incremental import helpers, marker  # noqa: PLC0415
+
+        monkeypatch.setattr(helpers, "TEMPORARY_PATH", str(tmp_path))
+        upload = AsyncMock()
+        monkeypatch.setattr(marker, "upload_file", upload)
+
+        marker_path = helpers.get_persistent_artifacts_path(
+            "default/oracle/1696528289", "marker.txt", "oracle"
+        )
+
+        with patch("os.fsync", _enospc):
+            with pytest.raises(DiskFullError) as caught:
+                await marker.persist_marker_to_storage(
+                    connection_qualified_name="default/oracle/1696528289",
+                    marker_value="2026-08-13T00:00:00Z",
+                    application_name="oracle",
+                )
+
+        assert caught.value.operation == "marker write"
+        assert not marker_path.exists()
+        upload.assert_not_awaited()
+
+    async def test_a_healthy_marker_write_is_unchanged(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from application_sdk.common.incremental import helpers, marker  # noqa: PLC0415
+
+        monkeypatch.setattr(helpers, "TEMPORARY_PATH", str(tmp_path))
+        monkeypatch.setattr(marker, "upload_file", AsyncMock())
+
+        result = await marker.persist_marker_to_storage(
+            connection_qualified_name="default/oracle/1696528289",
+            marker_value="2026-08-13T00:00:00Z",
+            application_name="oracle",
+        )
+
+        assert result["marker_written"] is True
+        assert Path(result["local_path"]).read_text(encoding="utf-8") == (
+            "2026-08-13T00:00:00Z"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Diff metadata — the file Argo routes on
+# ---------------------------------------------------------------------------
+
+
+class TestDiffMetadataWrite:
+    def test_a_truncated_routing_file_is_never_named(self, tmp_path: Path) -> None:
+        from application_sdk.common.incremental.models import (  # noqa: PLC0415
+            IncrementalDiffResult,
+        )
+        from application_sdk.common.incremental.state.incremental_diff import (  # noqa: PLC0415
+            _write_metadata,
+        )
+
+        result = IncrementalDiffResult(is_incremental=True)
+
+        with patch("os.fsync", _enospc):
+            with pytest.raises(DiskFullError) as caught:
+                _write_metadata(tmp_path, result)
+
+        assert caught.value.operation == "diff metadata write"
+        assert _artifacts(tmp_path) == []
+
+    def test_a_healthy_metadata_write_is_unchanged(self, tmp_path: Path) -> None:
+        import orjson  # noqa: PLC0415
+
+        from application_sdk.common.incremental.models import (  # noqa: PLC0415
+            IncrementalDiffResult,
+        )
+        from application_sdk.common.incremental.state.incremental_diff import (  # noqa: PLC0415
+            _write_metadata,
+        )
+
+        _write_metadata(tmp_path, IncrementalDiffResult(is_incremental=True))
+
+        written = orjson.loads((tmp_path / "metadata.json").read_bytes())
+        assert written["is_incremental"] is True
+
+
+# ---------------------------------------------------------------------------
+# Writer output
+# ---------------------------------------------------------------------------
+
+
+class TestWriterStatistics:
+    async def test_a_statistics_sidecar_that_runs_out_of_space_is_not_named(
+        self, tmp_path: Path
+    ) -> None:
+        """A truncated sidecar reads as a smaller, plausible row count."""
+        from application_sdk.storage.formats.format_errors import (  # noqa: PLC0415
+            FormatStatisticsWriteError,
+        )
+        from application_sdk.storage.formats.json import JsonFileWriter  # noqa: PLC0415
+
+        writer = JsonFileWriter(path=str(tmp_path / "out"))
+        writer.total_record_count = 4000
+
+        with patch("os.fsync", _enospc):
+            with pytest.raises(FormatStatisticsWriteError) as caught:
+                await writer._write_statistics()
+
+        # The writer wraps everything it raises; the disk-full cause has to
+        # survive that wrap or the failure is unattributable.
+        assert isinstance(caught.value.cause, DiskFullError)
+        assert _artifacts(tmp_path / "out" / "statistics") == []
+
+
+class TestParquetChunkWrite:
+    async def test_a_chunk_that_runs_out_of_space_leaves_no_parquet_behind(
+        self, tmp_path: Path
+    ) -> None:
+        """The truncated-parquet case: no footer, and every reader fails alike."""
+        from application_sdk.storage.formats.parquet import (  # noqa: PLC0415
+            ParquetFileWriter,
+        )
+
+        output = tmp_path / "out"
+        output.mkdir()
+        writer = ParquetFileWriter(path=str(output))
+        chunk = pd.DataFrame({"id": [1, 2, 3], "value": ["a", "b", "c"]})
+        target = output / "chunk-0-part0.parquet"
+
+        with patch("os.fsync", _enospc):
+            with pytest.raises(DiskFullError) as caught:
+                await writer._write_chunk(chunk, str(target))
+
+        assert caught.value.operation == "parquet chunk write"
+        assert not target.exists()
+        assert _artifacts(output) == []
+
+    async def test_a_healthy_chunk_write_publishes_under_its_own_name(
+        self, tmp_path: Path
+    ) -> None:
+        from application_sdk.storage.formats.parquet import (  # noqa: PLC0415
+            ParquetFileWriter,
+        )
+
+        output = tmp_path / "out"
+        output.mkdir()
+        writer = ParquetFileWriter(path=str(output))
+        chunk = pd.DataFrame({"id": [1, 2, 3], "value": ["a", "b", "c"]})
+        target = output / "chunk-0-part0.parquet"
+
+        await writer._write_chunk(chunk, str(target))
+
+        assert _artifacts(output) == ["chunk-0-part0.parquet"]
+        assert pd.read_parquet(target)["id"].tolist() == [1, 2, 3]
+
+
+class TestJsonChunkWrite:
+    async def test_it_is_typed_even_though_it_cannot_be_atomic(
+        self, tmp_path: Path
+    ) -> None:
+        """Stated as a test rather than left as a silent gap.
+
+        The append protocol rules out staging, so the file *can* be left short.
+        What must not happen is the failure arriving as a bare ``OSError`` with
+        nothing naming the file or the step.
+        """
+        from application_sdk.storage.formats.json import JsonFileWriter  # noqa: PLC0415
+
+        writer = JsonFileWriter(path=str(tmp_path / "out"))
+        chunk = pd.DataFrame({"id": [1], "value": ["a"]})
+        target = tmp_path / "out" / "chunk-0-part0.json"
+
+        class _FullHandle:
+            def write(self, _data: bytes) -> int:
+                raise OSError(errno.ENOSPC, "No space left on device")
+
+            def close(self) -> None:
+                pass
+
+        with patch(
+            "application_sdk.storage.formats.json.SafeFileOps.open"
+        ) as mock_open:
+            mock_open.return_value.__enter__ = lambda _self: _FullHandle()
+            mock_open.return_value.__exit__ = lambda *_args: None
+            with pytest.raises(DiskFullError) as caught:
+                await writer._write_chunk(chunk, str(target))
+
+        assert caught.value.operation == "json chunk write"
+        assert caught.value.path == str(target)
+
+
+class TestLocalSidecarWrite:
+    def test_a_sidecar_that_runs_out_of_space_is_absent_rather_than_wrong(
+        self, tmp_path: Path
+    ) -> None:
+        """A truncated digest is worse than none: it re-downloads a good file forever."""
+        from application_sdk.storage.reference import (  # noqa: PLC0415
+            _write_local_sidecar,
+        )
+
+        artifact = tmp_path / "data.parquet"
+        artifact.write_bytes(b"parquet")
+
+        with patch("os.fsync", _enospc):
+            # Best-effort by contract: the caller continues without a sidecar.
+            _write_local_sidecar(str(artifact), "a" * 64)
+
+        assert _artifacts(tmp_path) == ["data.parquet"]
+
+    def test_a_healthy_sidecar_write_is_unchanged(self, tmp_path: Path) -> None:
+        from application_sdk.storage.reference import (  # noqa: PLC0415
+            _write_local_sidecar,
+        )
+
+        artifact = tmp_path / "data.parquet"
+        artifact.write_bytes(b"parquet")
+
+        _write_local_sidecar(str(artifact), "a" * 64)
+
+        assert (tmp_path / "data.parquet.sha256").read_text() == "a" * 64
+
+
+# ---------------------------------------------------------------------------
+# Nothing an SDK writer stages may reach the object store
+# ---------------------------------------------------------------------------
+
+
+class TestStagingNeverUploads:
+    async def test_a_prefix_upload_of_a_run_directory_skips_staging_trees(
+        self, tmp_path: Path
+    ) -> None:
+        """Staging is nested a level down, as it is under a real output root."""
+        from application_sdk.storage.batch import upload_prefix  # noqa: PLC0415
+        from application_sdk.storage.factory import create_memory_store  # noqa: PLC0415
+
+        entity_dir = tmp_path / "column"
+        staging = entity_dir / PARTIAL_DIRNAME
+        staging.mkdir(parents=True)
+        (entity_dir / "column-0.json").write_bytes(b"{}")
+        (staging / "column-1.json.deadbeef").write_bytes(b'{"trunca')
+
+        keys = await upload_prefix(
+            tmp_path, "run", create_memory_store(), normalize=False
+        )
+
+        assert keys == ["run/column/column-0.json"]
+
+    async def test_a_prefix_upload_of_a_run_root_skips_a_writer_staging_tree(
+        self, tmp_path: Path
+    ) -> None:
+        """FND-317 sites the writer's staging tree as a *sibling* of its output.
+
+        That puts it out of reach of a walk of the output directory, but a
+        prefix upload of the run root walks a level higher — so without the
+        shared exclusion a cancelled attempt's staged chunks ship as run output.
+        """
+        from application_sdk.storage.batch import upload_prefix  # noqa: PLC0415
+        from application_sdk.storage.factory import create_memory_store  # noqa: PLC0415
+        from application_sdk.storage.formats import (  # noqa: PLC0415
+            _STAGING_ROOT_DIRNAME,
+        )
+
+        output = tmp_path / "output"
+        output.mkdir()
+        (output / "chunk-0-part0.parquet").write_bytes(b"published")
+        orphaned = tmp_path / _STAGING_ROOT_DIRNAME / "deadbeef" / "output"
+        orphaned.mkdir(parents=True)
+        (orphaned / "chunk-0-part0.parquet").write_bytes(b"a cancelled attempt")
+
+        keys = await upload_prefix(
+            tmp_path, "run", create_memory_store(), normalize=False
+        )
+
+        assert keys == ["run/output/chunk-0-part0.parquet"]
+
+    async def test_a_published_writer_directory_holds_no_staging_directory(
+        self, tmp_path: Path
+    ) -> None:
+        """The two staging layers must not publish each other.
+
+        A writer stages its whole output and publishes at ``close()``
+        (FND-317); each file inside that tree is *also* staged individually
+        (FND-318), so ``.sdk-partial`` sits inside the tree the publish walks.
+        Publishing it would recreate the directory in the output — and, if an
+        atomic write had failed, hand a partial file the exact name the staging
+        exists to withhold.
+        """
+        from application_sdk.storage.formats.parquet import (  # noqa: PLC0415
+            ParquetFileWriter,
+        )
+
+        output = tmp_path / "out"
+        # defer_uploads keeps the object store out of this: the question is what
+        # ends up on local disk under the writer's output directory.
+        writer = ParquetFileWriter(
+            path=str(output), typename="test_type", defer_uploads=True
+        )
+        await writer.write(pd.DataFrame({"id": [1, 2], "value": ["a", "b"]}))
+        await writer.close()
+
+        published = sorted(
+            str(p.relative_to(writer.path)) for p in Path(writer.path).rglob("*")
+        )
+        assert PARTIAL_DIRNAME not in published
+        assert all(not name.startswith(".sdk-") for name in published), published
+        assert "chunk-0-part0.parquet" in published
+
+    def test_the_exclusion_has_exactly_one_definition(self) -> None:
+        """Every walker reads the same set, so they cannot drift apart."""
+        from application_sdk.common import _listing  # noqa: PLC0415
+        from application_sdk.storage import batch, formats  # noqa: PLC0415
+
+        assert batch.prune_internal_dirs is _listing.prune_internal_dirs
+        assert formats.prune_internal_dirs is _listing.prune_internal_dirs
+        # The writer's staging tree is the same fact, not a second one: FND-317
+        # names it and this module excludes it, from one definition.
+        assert formats._STAGING_ROOT_DIRNAME is _listing.WRITER_STAGING_DIRNAME
+        assert _listing.INTERNAL_DIRNAMES == {
+            PARTIAL_DIRNAME,
+            _listing.WRITER_STAGING_DIRNAME,
+        }
+
+
+def test_no_sdk_writer_reintroduces_a_direct_to_final_write() -> None:
+    """The write sites FND-318 converted must stay converted.
+
+    A line-level guard rather than a behavioural one, and that is the point: a
+    future edit that reaches for ``write_text``/``copy2`` at one of these sites
+    reintroduces exactly the bug, and it does so silently — every existing test
+    keeps passing, because a direct write is only wrong when it fails.
+    """
+    banned = {
+        "application_sdk/common/incremental/marker.py": ("write_text(",),
+        "application_sdk/common/incremental/state/incremental_diff.py": (
+            "metadata_path.write_text(",
+        ),
+        "application_sdk/common/incremental/helpers.py": ("shutil.copy2(",),
+        "application_sdk/storage/reference.py": ('+ ".sha256").write_text(',),
+    }
+    root = Path(__file__).resolve().parents[3]
+
+    offenders = [
+        f"{relative}: {pattern}"
+        for relative, patterns in banned.items()
+        for pattern in patterns
+        if pattern in (root / relative).read_text()
+    ]
+    assert offenders == [], (
+        "direct-to-final artifact write reintroduced; use "
+        "application_sdk.common.atomic instead: " + ", ".join(offenders)
+    )

--- a/tests/unit/common/test_atomic_write_sites.py
+++ b/tests/unit/common/test_atomic_write_sites.py
@@ -474,6 +474,16 @@ def test_no_sdk_writer_reintroduces_a_direct_to_final_write() -> None:
         ),
         "application_sdk/common/incremental/helpers.py": ("shutil.copy2(",),
         "application_sdk/storage/reference.py": ('+ ".sha256").write_text(',),
+        # _write_statistics in formats/__init__.py wrote the statistics sidecar
+        # with a bare open() at method-body indent; the pattern carries that
+        # indent so a top-level helper elsewhere does not trip it.
+        "application_sdk/storage/formats/__init__.py": ("\n            with open(",),
+        # _write_chunk in formats/parquet.py passed the final path straight to
+        # pq.write_table; the converted form writes to the atomic_path staging
+        # path instead, so the banned form is write_table on `file_name`.
+        "application_sdk/storage/formats/parquet.py": (
+            "pq.write_table(\n                table,\n                file_name,",
+        ),
     }
     root = Path(__file__).resolve().parents[3]
 

--- a/tests/unit/storage/formats/test_offload_cancellation.py
+++ b/tests/unit/storage/formats/test_offload_cancellation.py
@@ -35,6 +35,7 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
 
+from application_sdk.common.atomic import PARTIAL_DIRNAME
 from application_sdk.common.file_ops import SafeFileOps
 from application_sdk.common.types import DataframeType
 from application_sdk.storage.formats import _STAGING_ROOT_DIRNAME
@@ -64,6 +65,19 @@ WORKER_THREAD_PREFIX = "sdk-blocking-"
 #: Captured before any patching so :class:`GatedParquetFile` can delegate to the
 #: real reader while ``pq.ParquetFile`` itself is patched out.
 REAL_PARQUET_FILE = pq.ParquetFile
+
+
+def _published_path(where: object) -> str:
+    """Map a path handed to ``pq.write_table`` to the artifact it publishes to.
+
+    Writers stage each chunk as ``<dir>/.sdk-partial/<name>.<token>`` and rename
+    it onto ``<dir>/<name>`` once the write succeeds (FND-318). A path that is
+    not staged is returned unchanged.
+    """
+    staged = Path(str(where))
+    if staged.parent.name != PARTIAL_DIRNAME:
+        return str(staged)
+    return str(staged.parent.parent / staged.name.rsplit(".", 1)[0])
 
 
 async def wait_until(predicate) -> bool:
@@ -425,14 +439,19 @@ class TestWriterAttemptIsolation:
 
         def gated_write_table(table, where, **kwargs):
             # Gate only the orphan's own write; the retry must run at full speed
-            # so it provably reaches consolidation first.
-            gated = str(where) == orphan_chunk and not write_started.is_set()
+            # so it provably reaches consolidation first. Compared on the
+            # published path because the writer hands `pq.write_table` a staged
+            # one (FND-318) — the chunk this test is about is still `chunk-0`,
+            # it just does not carry that name until the write succeeds.
+            gated = (
+                _published_path(where) == orphan_chunk and not write_started.is_set()
+            )
             if gated:
                 write_started.set()
                 may_write.wait(timeout=BLOCK_TIMEOUT_SECONDS)
             result = real_write_table(table, where, **kwargs)
             if gated:
-                orphan_writes_done.append(str(where))
+                orphan_writes_done.append(_published_path(where))
             return result
 
         with patch.object(pq, "write_table", side_effect=gated_write_table):
@@ -457,9 +476,12 @@ class TestWriterAttemptIsolation:
             # Wait for the orphan's write to *land*, not merely for the path to
             # exist: on a shared directory the file is already there, written by
             # the retry, and the whole failure is the orphan replacing it
-            # afterwards.
+            # afterwards. Both halves are required — `orphan_writes_done` proves
+            # it was the orphan's own write that ran, and the path check proves
+            # the staged chunk was published (FND-318 publishes after the write
+            # returns, so the two are not simultaneous).
             assert await wait_until(
-                lambda: bool(orphan_writes_done)
+                lambda: bool(orphan_writes_done) and os.path.exists(orphan_chunk)
             ), "the orphaned worker never landed its chunk"
 
             await retry._consolidate_current_folder()
@@ -532,13 +554,18 @@ class TestWriterOutputIsolation:
         orphan_chunk = os.path.join(orphan._write_root, "chunk-0-part0.parquet")
 
         def gated_write_table(table, where, **kwargs):
-            gated = str(where) == orphan_chunk and not write_started.is_set()
+            # Compared on the published path: each chunk is also staged
+            # individually inside the writer's staging tree (FND-318), so the
+            # path pq.write_table is handed is not the one this test names.
+            gated = (
+                _published_path(where) == orphan_chunk and not write_started.is_set()
+            )
             if gated:
                 write_started.set()
                 may_write.wait(timeout=BLOCK_TIMEOUT_SECONDS)
             result = real_write_table(table, where, **kwargs)
             if gated:
-                orphan_writes_done.append(str(where))
+                orphan_writes_done.append(_published_path(where))
             return result
 
         with patch.object(pq, "write_table", side_effect=gated_write_table):
@@ -562,8 +589,12 @@ class TestWriterOutputIsolation:
                 # is never left parked on the gate.
                 may_write.set()
 
+            # Both halves: `orphan_writes_done` proves the orphan's own write
+            # ran, and the path check proves its staged chunk was published
+            # into the orphan's tree — the two are not simultaneous, since
+            # FND-318 renames after the write returns.
             assert await wait_until(
-                lambda: bool(orphan_writes_done)
+                lambda: bool(orphan_writes_done) and os.path.exists(orphan_chunk)
             ), "the orphaned worker never landed its chunk"
 
         assert files_under(retry.path) == [

--- a/tests/unit/storage/formats/test_offload_cancellation.py
+++ b/tests/unit/storage/formats/test_offload_cancellation.py
@@ -796,3 +796,66 @@ class TestWriterOutputIsolation:
         assert published["value"].tolist() == [
             "retry"
         ], "the orphaned writer's rows were appended to the retry's chunk"
+
+    async def test_a_cross_filesystem_publish_never_writes_directly_to_the_final_name(
+        self, tmp_path: Path
+    ) -> None:
+        """The EXDEV fallback is staged, not direct-to-final (FND-318 review).
+
+        When the output directory is itself a mount point, staging and output
+        sit on different filesystems, ``os.replace`` raises ``EXDEV``, and the
+        publish must fall back to a copy. That copy used to be ``shutil.move``
+        straight onto the artifact's real name — an interruption or ``ENOSPC``
+        mid-copy left a truncated file at the very path staging exists to keep
+        clean. The fallback now routes through ``atomic_copy`` (stage next to
+        the destination, fsync, rename) and unlinks the source itself, so the
+        final name only ever appears complete even on that layout.
+        """
+        import errno as errno_module
+
+        writer = make_output_writer(tmp_path)
+        await writer.write(pd.DataFrame({"id": [1, 2, 3], "value": ["a", "b", "c"]}))
+
+        real_replace = os.replace
+        moved: list[tuple[str, str]] = []
+
+        # Refuse only renames that land in the output directory — staging tree
+        # → ``writer.path`` — with EXDEV, as a mount-point output directory
+        # would. Renames that stay inside the staging tree (atomic_write's own
+        # publish of the statistics sidecar) or stage next to their
+        # destination inside the output directory (atomic_copy's publish) are
+        # same-filesystem by construction and must pass through, or the fake
+        # would simulate a filesystem that cannot rename within one directory
+        # — a different failure entirely.
+        output_dir = os.path.normpath(writer.path)
+
+        def refuse_cross_filesystem_rename(src, dst, **kwargs):
+            if str(dst).startswith(
+                output_dir + os.sep
+            ) and _STAGING_ROOT_DIRNAME in str(src):
+                raise OSError(errno_module.EXDEV, "Invalid cross-device link")
+            return real_replace(src, dst, **kwargs)
+
+        def no_direct_move(src, dst, **kwargs):
+            moved.append((str(src), str(dst)))
+            return real_replace(src, dst, **kwargs)
+
+        with (
+            patch.object(os, "replace", side_effect=refuse_cross_filesystem_rename),
+            patch("shutil.move", side_effect=no_direct_move),
+        ):
+            await writer.close()
+
+        assert moved == [], (
+            "the cross-filesystem fallback published with shutil.move "
+            f"direct-to-final: {moved}"
+        )
+        # The staged copy still landed the chunk under its real name.
+        assert "chunk-0-part0.parquet" in files_under(writer.path)
+        assert set(
+            pd.read_parquet(os.path.join(writer.path, "chunk-0-part0.parquet"))["value"]
+        ) == {
+            "a",
+            "b",
+            "c",
+        }

--- a/tests/unit/storage/formats/writers/test_json_writer.py
+++ b/tests/unit/storage/formats/writers/test_json_writer.py
@@ -194,3 +194,30 @@ async def test_write_chunk_handles_pandas_timestamp(tmp_path: Path) -> None:
         record = orjson.loads(f.read().strip())
     assert record["name"] == "a"
     assert "2024-01-01" in record["ts"]
+
+
+@pytest.mark.asyncio
+async def test_write_chunk_surfaces_a_delayed_allocation_enospc_typed(
+    tmp_path: Path,
+) -> None:
+    """The append cannot be staged, but it is flushed and fsync'd inside the
+    guard (FND-318): on a delayed-allocation filesystem the write() calls only
+    dirty page cache, so without the fsync the ENOSPC surfaces later — or
+    never — and a short chunk passes as complete."""
+    import errno
+
+    from application_sdk.errors import DiskFullError
+
+    writer = JsonFileWriter(path=str(tmp_path / "out"))
+    df = pd.DataFrame({"id": [1, 2]})
+    out_file = str(tmp_path / "out" / "chunk.json")
+
+    def _enospc(*_args: Any, **_kwargs: Any) -> None:
+        raise OSError(errno.ENOSPC, "No space left on device")
+
+    with patch("os.fsync", _enospc):
+        with pytest.raises(DiskFullError) as caught:
+            await writer._write_chunk(df, out_file)
+
+    assert caught.value.operation == "json chunk write"
+    assert caught.value.path == out_file

--- a/tests/unit/storage/formats/writers/test_parquet_writer.py
+++ b/tests/unit/storage/formats/writers/test_parquet_writer.py
@@ -14,6 +14,7 @@ import pyarrow.parquet as pq
 import pytest
 
 from application_sdk import constants
+from application_sdk.common.atomic import PARTIAL_DIRNAME
 from application_sdk.common.file_ops import SafeFileOps
 from application_sdk.infrastructure.context import (
     InfrastructureContext,
@@ -26,6 +27,35 @@ from application_sdk.storage.factory import create_memory_store
 from application_sdk.storage.formats.parquet import ParquetFileReader, ParquetFileWriter
 from application_sdk.storage.formats.utils import path_gen
 from application_sdk.storage.reference import persist_file_reference
+
+
+def _published_name(where: object) -> str:
+    """Filename a path handed to ``pq.write_table`` publishes under.
+
+    Each chunk is written to ``<dir>/.sdk-partial/<name>.<token>`` and renamed
+    onto ``<dir>/<name>`` once the write succeeds (FND-318), so the staged
+    filename carries a token the published one does not.
+    """
+    staged = Path(str(where))
+    if staged.parent.name != PARTIAL_DIRNAME:
+        return staged.name
+    return staged.name.rsplit(".", 1)[0]
+
+
+def _stub_write_table(table: pa.Table, where: object, **kwargs: object) -> None:
+    """Stand in for ``pq.write_table`` while still producing a file.
+
+    A bare ``MagicMock`` writes nothing, and the writer stages each chunk and
+    renames it into place (FND-318) — so a stub that produces no file makes the
+    writer report, correctly, that the chunk was never written. Touching the
+    path keeps these tests about *which* path the writer resolves without
+    paying for real parquet encoding.
+
+    ``where`` is a buffer rather than a path on the writer's size-estimation
+    call; there is nothing to create in that case.
+    """
+    if isinstance(where, (str, os.PathLike)):
+        Path(where).write_bytes(b"")
 
 
 @pytest.fixture
@@ -295,7 +325,9 @@ class TestParquetFileWriterWriteDataframe:
         self, base_output_path: str, sample_dataframe: pd.DataFrame
     ):
         """Test successful DataFrame writing."""
-        with patch("pyarrow.parquet.write_table") as mock_write_table:
+        with patch(
+            "pyarrow.parquet.write_table", side_effect=_stub_write_table
+        ) as mock_write_table:
             parquet_output = ParquetFileWriter(
                 path=os.path.join(base_output_path, "test"),
                 use_consolidation=False,
@@ -311,7 +343,9 @@ class TestParquetFileWriterWriteDataframe:
         self, base_output_path: str, sample_dataframe: pd.DataFrame
     ):
         """Test DataFrame writing with custom path generation."""
-        with patch("pyarrow.parquet.write_table") as mock_write_table:
+        with patch(
+            "pyarrow.parquet.write_table", side_effect=_stub_write_table
+        ) as mock_write_table:
             parquet_output = ParquetFileWriter(
                 path=base_output_path,
                 start_marker="test_start",
@@ -323,7 +357,13 @@ class TestParquetFileWriterWriteDataframe:
             mock_write_table.assert_called()
             call_args = mock_write_table.call_args
             file_path = call_args[0][1]  # Second positional arg is the file path
-            assert "chunk-" in str(file_path) and ".parquet" in str(file_path)
+            # Mapped back through the per-file staging directory before the
+            # name is read: the chunk is written to
+            # `<dir>/.sdk-partial/<name>.<token>` and renamed onto `<dir>/<name>`
+            # once the write succeeds (FND-318). The generated name is what this
+            # test is about, and it is unchanged.
+            assert "chunk-" in _published_name(file_path)
+            assert _published_name(file_path).endswith(".parquet")
 
     @pytest.mark.asyncio
     async def test_write_error_handling(


### PR DESCRIPTION
Closes [FND-318](https://linear.app/atlan-epd/issue/FND-318/atomic-artifact-writes-typed-disk-full-error-in-the-sdk-so-a-partial). The producer half of [FND-306](https://linear.app/atlan-epd/issue/FND-306), whose SDK work (#3171) validates every transfer and still cannot fix the reported incidents.

## The bug

A write that fails part-way leaves a truncated file **at the artifact's real name**. Nothing downstream can tell it from a correct one, so it is carried forward, uploaded, and integrity-checked against its own truncated bytes. The failure surfaces much later inside a *consuming* app's parser, at a byte offset identical on every retry — which is exactly what makes it read as a consumer bug.

FND-306 could not close this. The sidecar attests to the bytes the SDK read at upload time, not to the artifact being complete: exactly the intended bytes moved, so every check passes.

The SDK already knew the `temp → fsync → os.replace` idiom and applied it to **its own bookkeeping only** — the resume checkpoint (`storage/chunked.py`) and the local secrets file (`handler/service.py`). Every artifact an *app* produced was written direct-to-final-name. This inverts that back: an app should have to go out of its way (a raw `open()`) to produce a partial artifact, not go out of its way to avoid one.

## The helper

`application_sdk/common/atomic.py` — `atomic_write` (you own the bytes), `atomic_path` (a third-party writer owns the file: `pq.write_table`, `shutil.copy2`), `atomic_copy`, plus `disk_full_guard` and `ensure_free_space`.

Three properties carry it:

- **Staging is a sibling directory, not a suffix.** A `foo.json.tmp` next to `foo.json` is picked up by every walk of the artifact directory — a prefix upload ships it, a directory `FileReference` adopts it. Staging goes in `.sdk-partial/`, a *child of the artifact's own directory* so the publish is a same-filesystem rename rather than a copy.
- **fsync before the replace, inside the guard.** Not for durability across node loss — the page cache survives a step failure, which is the argument `_save_transfer_state` already makes. It is about *when ENOSPC is reported*: on a delayed-allocation filesystem the `write` calls only dirty page cache, and without an fsync before the rename a short write is published as a complete artifact with nothing raised anywhere. That is precisely the incident.
- **The staging file is removed on every exit path**, including the one holding the blocks the retry needs.

## The typed error

`DiskFullError`, a `ResourceExhaustedError` leaf (`RESOURCE_EXHAUSTED_DISK_FULL`, retryable, PLATFORM), covering `ENOSPC` and `EDQUOT` — one type, because a quota ceiling and an empty volume need the same response from whoever is on call.

It names the path, the step, the bytes needed and the bytes free. **This error is the operator's signal that a deployment needs more ephemeral storage** — which is why the remediation is defaulted on the class rather than passed at each raise site: the one failure whose entire purpose is telling an operator what to change must never ship without the instruction attached. Requests/limits stay deployment configuration; neither the SDK nor the app guesses a number it cannot know.

`ensure_free_space` fails a plainly undersized volume in seconds with `needs ~N GiB, has M`. Strict comparison, no invented safety margin — it catches the impossible write, not the marginal one, and a marginal write that still runs out is caught during the write and reported identically.

## Converted writers

| site | artifact |
|---|---|
| `incremental/helpers.py` `copy_single_file` | carry-forward state copy — **the incident site**, plus a whole-batch space preflight |
| `incremental/marker.py` | the incremental marker |
| `incremental/state/incremental_diff.py` | diff metadata (Argo routes on it) |
| `storage/formats/__init__.py` | the writer statistics sidecar |
| `storage/formats/parquet.py` | parquet chunk output |
| `storage/reference.py` | the local `.sha256` sidecar |

`safe_list_directory` and `upload_prefix` now read **one** shared exclusion set (`_listing.INTERNAL_DIRNAMES`), so "invisible to a listing" and "invisible to a prefix upload" cannot drift apart. It lives in the stdlib-only `_listing` module so neither walker takes on an import to honour it.

## The stated exception

`JsonFileWriter._write_chunk` is **not** atomic, deliberately: successive calls append to the same chunk file, and an append cannot be staged and renamed without rewriting everything already in it on every call. It gets `disk_full_guard` — so an ENOSPC there is typed and attributed — and `test_it_is_typed_even_though_it_cannot_be_atomic` asserts exactly that, rather than leaving the gap silent.

The issue's own residual stands too: an app that opens its own file handle bypasses all of this. `docs/agents/coding-standards.md` gains a *Writing Files* section for that case.

## Tests

41 new tests across two modules — one for the helper, one that drives each **real** call path (`copy_directory_parallel`, `persist_marker_to_storage`, `_write_metadata`, the writers) with the disk pulled out from under it. Every one was verified to fail against direct-to-final behaviour, with the symptom it describes:

| test | pre-fix failure |
|---|---|
| final path absent until the write completes | `the artifact was nameable while it was still being written` |
| ENOSPC leaves no file at the final path | the truncated file is there |
| ENOSPC does not disturb an artifact already in place | the previous good artifact is destroyed |
| carry-forward copy names no partial file | `['column-ancestral-201.json'] != []` |
| marker / diff metadata / statistics / parquet chunk | the partial artifact is at its real name |
| listing and prefix upload skip an in-flight write | the staging file is listed / uploaded |

The falsification for the copy test matters: its stub writes 184 bytes *then* raises, because a stub that raised without writing would pass against the very behaviour the test exists to rule out.

Also a line-level guard (`test_no_sdk_writer_reintroduces_a_direct_to_final_write`) — a future edit reaching for `write_text`/`copy2` at a converted site reintroduces the bug *silently*, since a direct write is only wrong when it fails.

Two existing test files updated: `test_parquet_writer.py`'s `pq.write_table` mock now produces a file (a mock that writes nothing makes the writer correctly report that the chunk was never written), and `test_offload_cancellation.py` gates on the published path rather than the staged one.

## Gates

Full unit suite green (6896 passed, 9 skipped). `pre-commit run --all-files` clean. Conformance clean — no new findings in any changed file.

## Reviewer notes

- **Rebased onto #3182 (FND-317)**, which landed first. The two layers compose: a writer stages its *whole output* and publishes at `close()` (FND-317), and each file inside that tree is *also* staged individually (this PR). They are complementary rather than redundant — `__aexit__` calls `close()` even on the failure path, so without this a truncated staged chunk would still be published under its real name.

  The rebase surfaced two semantic conflicts beyond the textual one, both fixed here:

  - **`_publish_staged_files` walked the staged tree with a raw `os.walk`.** `.sdk-partial` now sits *inside* that tree by construction, so the publish would have recreated it in the output directory — and, had an atomic write failed, handed a partial file the exact name the staging exists to withhold. It now prunes internal directories through the same shared predicate.
  - **`.sdk-writer-staging` was not in the exclusion set.** Being a *sibling* of the output directory puts it out of reach of a walk of that directory, but a prefix upload of the run root walks a level higher — so a cancelled attempt's staged chunks would ship as run output. The name now lives in `common/_listing.py` alongside `.sdk-partial` and `storage.formats` imports it, so the two modules cannot disagree about what an artifact is.

  Three new tests cover the interaction, each verified to fail without its fix.
- `storage/integrity.py` and `docs/concepts/storage.md` both said the producer-side half was "tracked against the connector apps". That was the wrong call, per the issue; both are corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

