### PR TITLE
fix(incremental): strip the source prefix when downloading state trees (FND-340)

### DIFF
--- a/application_sdk/common/incremental/column_extraction/analysis.py
+++ b/application_sdk/common/incremental/column_extraction/analysis.py
@@ -20,7 +20,8 @@ def get_transformed_dir(workflow_args: dict[str, Any]) -> Path:
     """Return current run's transformed directory.
 
     Caller must ensure files are downloaded from S3 before calling this.
-    Files are at output_path/transformed after ObjectStore.download_prefix().
+    Files are at output_path/transformed after
+    ``download_prefix(..., strip_prefix=True)``.
 
     Args:
         workflow_args: Dictionary containing workflow configuration with output_path.

--- a/application_sdk/common/incremental/helpers.py
+++ b/application_sdk/common/incremental/helpers.py
@@ -230,11 +230,14 @@ async def download_s3_prefix_with_structure(
 ) -> None:
     """Download files under *s3_prefix* into *local_destination*, prefix stripped.
 
-    Thin wrapper over :func:`~application_sdk.storage.batch.download_prefix`
+    Supported alias for :func:`~application_sdk.storage.batch.download_prefix`
     with ``strip_prefix=True``: ``<s3_prefix>/table/chunk-0.json`` lands at
-    ``<local_destination>/table/chunk-0.json``. Retained because app code
-    outside the SDK imports it; new SDK call sites use ``download_prefix``
-    directly so the incremental path has one download implementation and one
+    ``<local_destination>/table/chunk-0.json``.
+
+    This is a **supported** compatibility alias, not a deprecated one — it is
+    retained indefinitely because app code outside the SDK imports it, and there
+    is no removal target. New SDK call sites should prefer ``download_prefix``
+    directly so the incremental path keeps one download implementation and one
     path policy (FND-340).
 
     Args:

--- a/application_sdk/common/incremental/helpers.py
+++ b/application_sdk/common/incremental/helpers.py
@@ -8,7 +8,6 @@ This module contains helper functions for:
 
 from __future__ import annotations
 
-import asyncio
 import os
 import re
 import shutil
@@ -24,8 +23,8 @@ from application_sdk.constants import (
     TEMPORARY_PATH,
 )
 from application_sdk.observability.logger_adaptor import get_logger
-from application_sdk.storage.batch import list_keys_with_meta
-from application_sdk.storage.ops import download_file, download_file_chunked
+from application_sdk.storage.batch import download_prefix
+from application_sdk.storage.ops import download_file
 
 logger = get_logger(__name__)
 
@@ -229,51 +228,31 @@ async def download_s3_prefix_with_structure(
     local_destination: Path,
     max_concurrency: int = MAX_CONCURRENT_STORAGE_TRANSFERS,
 ) -> None:
-    """Download files from S3 preserving relative directory structure.
+    """Download files under *s3_prefix* into *local_destination*, prefix stripped.
 
-    This helper handles path stripping correctly to maintain the expected
-    directory structure locally.
+    Thin wrapper over :func:`~application_sdk.storage.batch.download_prefix`
+    with ``strip_prefix=True``: ``<s3_prefix>/table/chunk-0.json`` lands at
+    ``<local_destination>/table/chunk-0.json``. Retained because app code
+    outside the SDK imports it; new SDK call sites use ``download_prefix``
+    directly so the incremental path has one download implementation and one
+    path policy (FND-340).
 
     Args:
-        s3_prefix: S3 prefix path to download from
-        local_destination: Local directory to download files into
-        max_concurrency: Maximum number of concurrent downloads (default: MAX_CONCURRENT_STORAGE_TRANSFERS).
+        s3_prefix: Object-store prefix to download from.
+        local_destination: Local directory to download files into.
+        max_concurrency: Maximum number of concurrent downloads
+            (default: ``MAX_CONCURRENT_STORAGE_TRANSFERS``).
 
     Raises:
-        Exception: If listing or downloading fails
+        StorageError: If listing or downloading fails.
+        StorageIntegrityError: If an object does not match its sidecar digest.
     """
-    # List files under the prefix from Object Store. Sizes + etags from the
-    # listing let large files fetch via bounded, version-pinned range GETs
-    # without a per-file HEAD (BLDX-1513 / BLDX-1523).
-    items = await list_keys_with_meta(
+    await download_prefix(
         prefix=s3_prefix,
+        local_dir=local_destination,
+        strip_prefix=True,
+        max_concurrency=max_concurrency,
     )
-
-    # Normalize source prefix for path stripping
-    source_prefix = s3_prefix.rstrip("/")
-
-    sem = asyncio.Semaphore(max_concurrency)
-
-    async def _download_one(file_path: str, size: int, etag: str | None) -> None:
-        # Strip source prefix to get relative path
-        if file_path.startswith(source_prefix):
-            relative_path = file_path[len(source_prefix) :].lstrip("/")
-        else:
-            relative_path = file_path
-
-        local_file_path = local_destination.joinpath(relative_path)
-        local_file_path.parent.mkdir(parents=True, exist_ok=True)
-
-        async with sem:
-            await download_file_chunked(
-                key=file_path,
-                local_path=str(local_file_path),
-                file_size=size,
-                etag=etag,
-            )
-
-    # Download all files concurrently with bounded parallelism
-    await asyncio.gather(*[_download_one(fp, size, etag) for fp, size, etag in items])
 
 
 # =============================================================================

--- a/application_sdk/common/incremental/state/state_reader.py
+++ b/application_sdk/common/incremental/state/state_reader.py
@@ -79,9 +79,13 @@ async def download_current_state(
     json_count = 0
 
     try:
+        # strip_prefix: current_state_dir already *is* the current-state
+        # directory, so the store prefix must not be repeated inside it —
+        # readers key off <current_state_dir>/table etc. (FND-340).
         await download_prefix(
             prefix=current_state_s3_prefix,
             local_dir=str(current_state_dir),
+            strip_prefix=True,
         )
 
         json_count = count_json_files_recursive(current_state_dir)

--- a/application_sdk/common/incremental/state/state_writer.py
+++ b/application_sdk/common/incremental/state/state_writer.py
@@ -34,7 +34,6 @@ from pathlib import Path
 from application_sdk.common.incremental.helpers import (
     copy_directory_parallel,
     count_json_files_recursive,
-    download_s3_prefix_with_structure,
     get_persistent_artifacts_path,
     get_persistent_s3_prefix,
 )
@@ -113,9 +112,13 @@ async def download_transformed_data(output_path: str) -> Path:
     transformed_dir = Path(transformed_local_path)
     transformed_dir.mkdir(parents=True, exist_ok=True)
 
+    # strip_prefix: transformed_dir already *is* the run's transformed directory,
+    # so the store prefix must not be repeated inside it — downstream readers
+    # (table_scope, column extraction) key off <transformed_dir>/table (FND-340).
     await download_prefix(
         prefix=transformed_s3_prefix,
         local_dir=str(transformed_dir),
+        strip_prefix=True,
     )
 
     return transformed_dir
@@ -171,9 +174,10 @@ async def prepare_previous_state(
     # Download previous state from S3 to temporary location
     logger.info("Downloading previous state from S3: %s", current_state_s3_prefix)
     try:
-        await download_s3_prefix_with_structure(
-            s3_prefix=current_state_s3_prefix,
-            local_destination=previous_state_temp_dir,
+        await download_prefix(
+            prefix=current_state_s3_prefix,
+            local_dir=previous_state_temp_dir,
+            strip_prefix=True,
         )
         logger.info(
             "Previous state downloaded to temporary location: %s",

--- a/application_sdk/storage/batch.py
+++ b/application_sdk/storage/batch.py
@@ -367,8 +367,14 @@ def _local_relative_key(key: str, strip: str) -> str:
     With *strip* empty the key is used whole (full-store-path layout). Otherwise
     *strip* — the normalised listing prefix, without its trailing ``/`` — is
     removed, so the tree *under* the prefix is what lands locally.
+
+    The strip is boundary-aware: only a key that *is* the prefix or sits under
+    it (``<strip>/...``) is stripped. A bare ``startswith`` match would also
+    mis-strip a sibling key sharing a string prefix (``a/b2/x`` under strip
+    ``a/b`` → ``2/x``) — reachable when the caller passes ``normalize=False``
+    with a slash-less prefix, where the listing itself is not boundary-safe.
     """
-    if not strip or not key.startswith(strip):
+    if not strip or not (key == strip or key.startswith(strip + "/")):
         return key
     relative = key[len(strip) :].lstrip("/")
     # A key that *is* the prefix (only reachable with normalize=False and a

--- a/application_sdk/storage/batch.py
+++ b/application_sdk/storage/batch.py
@@ -361,6 +361,22 @@ async def delete_prefix(
     return len(paths)
 
 
+def _local_relative_key(key: str, strip: str) -> str:
+    """Return the path *key* should occupy under a download destination.
+
+    With *strip* empty the key is used whole (full-store-path layout). Otherwise
+    *strip* — the normalised listing prefix, without its trailing ``/`` — is
+    removed, so the tree *under* the prefix is what lands locally.
+    """
+    if not strip or not key.startswith(strip):
+        return key
+    relative = key[len(strip) :].lstrip("/")
+    # A key that *is* the prefix (only reachable with normalize=False and a
+    # slash-less prefix) leaves nothing to join, which would target the
+    # destination directory itself — keep its basename so a file is written.
+    return relative or PurePosixPath(key).name
+
+
 async def download_prefix(
     prefix: str,
     local_dir: str | Path,
@@ -368,12 +384,28 @@ async def download_prefix(
     *,
     suffix: str = "",
     normalize: bool = True,
+    strip_prefix: bool = False,
     max_concurrency: int = 4,
 ) -> list[str]:
     """Download all objects under *prefix* to a local directory.
 
-    Each key's full store path is preserved under *local_dir*
-    (e.g. key ``artifacts/run/file.json`` → ``local_dir/artifacts/run/file.json``).
+    *strip_prefix* selects between the two layouts:
+
+    * ``False`` (default) — each key's full store path is preserved under
+      *local_dir* (key ``artifacts/run/file.json`` →
+      ``local_dir/artifacts/run/file.json``).
+    * ``True`` — *prefix* is stripped, so the tree beneath it is reproduced
+      directly in *local_dir* (key ``artifacts/run/file.json`` under prefix
+      ``artifacts/run`` → ``local_dir/file.json``).
+
+    Pass ``strip_prefix=True`` whenever *local_dir* already names the same
+    directory as *prefix* — otherwise the prefix appears twice in the result
+    (``<out>/transformed/artifacts/.../transformed/table/``) and any reader that
+    looks for a fixed subpath such as ``<out>/transformed/table`` finds nothing
+    (FND-340). It is the exact inverse of
+    :func:`upload_prefix` ``(local_dir, prefix)``, which writes each file's path
+    *relative to* ``local_dir`` under ``prefix``.
+
     Downloads run concurrently (up to *max_concurrency* at a time).
 
     ``{key}.sha256`` sidecars are not mirrored to disk: they are SDK
@@ -388,6 +420,9 @@ async def download_prefix(
         store: Source store, or ``None`` to use the infrastructure store.
         suffix: Optional extension filter (e.g. ``".parquet"``).
         normalize: When ``True`` (default), normalise *prefix* before use.
+        strip_prefix: When ``True``, drop *prefix* from each key so only the
+            tree below it is written under *local_dir*.  Defaults to ``False``
+            (full store path preserved).
         max_concurrency: Maximum parallel downloads (default 4).
 
     Returns:
@@ -405,8 +440,18 @@ async def download_prefix(
         lsuffix = suffix.lower()
         objects = [o for o in objects if o.key.lower().endswith(lsuffix)]
     local = Path(local_dir)
+    # Strip against the *normalised* listing prefix rather than the caller's raw
+    # argument: normalisation is what the listing matched on, so a v2-style
+    # "./local/tmp/artifacts/..." prefix strips exactly like its "artifacts/..."
+    # key form.
+    strip = (
+        _normalize_listing_prefix(prefix, normalize).rstrip("/") if strip_prefix else ""
+    )
     # Reject keys whose resolved path escapes local_dir (e.g. via ".." segments).
-    destinations = [str(_safe_join_under(local, obj.key)) for obj in objects]
+    destinations = [
+        str(_safe_join_under(local, _local_relative_key(obj.key, strip)))
+        for obj in objects
+    ]
 
     sem = asyncio.Semaphore(max_concurrency)
 
@@ -452,7 +497,9 @@ async def upload_prefix(
     Note:
         Param order is ``(local_dir, prefix)`` — source first, destination second.
         This is the inverse of :func:`download_prefix` ``(prefix, local_dir)`` which
-        also follows source-first convention.
+        also follows source-first convention. The *layout* round-trips only with
+        ``download_prefix(..., strip_prefix=True)``; the default download keeps
+        each key's full store path, which nests the prefix under *local_dir*.
 
     Args:
         local_dir: Local directory to upload from.

--- a/application_sdk/templates/incremental_sql_metadata_extractor.py
+++ b/application_sdk/templates/incremental_sql_metadata_extractor.py
@@ -452,7 +452,6 @@ class IncrementalSqlMetadataExtractor(SqlMetadataExtractor):
             get_tables_needing_column_extraction,
         )
         from application_sdk.common.incremental.helpers import (  # noqa: PLC0415 — circular: package __init__ loads sibling modules
-            download_s3_prefix_with_structure,
             get_persistent_artifacts_path,
         )
         from application_sdk.execution import (  # noqa: PLC0415 — circular: package __init__ loads sibling modules
@@ -477,9 +476,13 @@ class IncrementalSqlMetadataExtractor(SqlMetadataExtractor):
         transformed_dir.mkdir(parents=True, exist_ok=True)
 
         logger.info("Downloading transformed files from S3: %s", transformed_s3_prefix)
+        # strip_prefix: transformed_dir already *is* the run's transformed
+        # directory; without stripping the store prefix reappears inside it and
+        # the <transformed_dir>/table lookup below finds nothing (FND-340).
         await download_prefix(
             prefix=transformed_s3_prefix,
             local_dir=str(transformed_dir),
+            strip_prefix=True,
         )
 
         batch_size = input.column_batch_size
@@ -504,9 +507,10 @@ class IncrementalSqlMetadataExtractor(SqlMetadataExtractor):
                     input.current_state_s3_prefix,
                 )
                 try:
-                    await download_s3_prefix_with_structure(
-                        s3_prefix=input.current_state_s3_prefix,
-                        local_destination=previous_current_state_dir,
+                    await download_prefix(
+                        prefix=input.current_state_s3_prefix,
+                        local_dir=previous_current_state_dir,
+                        strip_prefix=True,
                     )
                     logger.info(
                         "Current-state downloaded: %s", previous_current_state_dir

--- a/docs/concepts/storage.md
+++ b/docs/concepts/storage.md
@@ -78,6 +78,28 @@ found = await exists("artifacts/my-app/output.json")
 keys = await list_keys("artifacts/my-app/")  # returns list[str]
 ```
 
+### Prefix downloads
+
+`download_prefix` writes one of two layouts, and picking the wrong one is
+silent — the bytes arrive, just not where the reader looks:
+
+```python
+from application_sdk.storage import download_prefix
+
+# Default: the full store path is preserved under local_dir.
+# key "artifacts/run/transformed/table/a.json" → "<out>/artifacts/run/transformed/table/a.json"
+await download_prefix("artifacts/run/transformed", "<out>")
+
+# strip_prefix=True: only the tree *under* the prefix lands in local_dir.
+# key "artifacts/run/transformed/table/a.json" → "<out>/table/a.json"
+await download_prefix("artifacts/run/transformed", "<out>", strip_prefix=True)
+```
+
+Use `strip_prefix=True` whenever `local_dir` already names the same directory as
+the prefix (the usual shape when recovering a run's `transformed/` or
+`current-state/` tree), otherwise the prefix appears twice and a reader keyed on
+a fixed subpath such as `<out>/table` finds nothing.
+
 ---
 
 ## FileReference

--- a/tests/integration/test_incremental_pipeline.py
+++ b/tests/integration/test_incremental_pipeline.py
@@ -434,3 +434,69 @@ async def test_incremental_diff_with_s3_roundtrip(tmp_path, store, infra):
     # Verify delete records survived roundtrip
     delete_table_files = list(download_dir.rglob("delete/table/*.json"))
     assert len(delete_table_files) == 1
+
+
+# ---------------------------------------------------------------------------
+# Test: transformed-tree recovery from the object store
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_transformed_recovery_from_store_feeds_current_state(
+    tmp_path, monkeypatch, store, infra
+):
+    """A pod that lost its local ``transformed/`` tree recovers a *usable* one.
+
+    This is the FND-340 / CONNECT-817 path: when an activity is rescheduled
+    mid-run (container restart), ``write_current_state`` re-downloads the run's
+    transformed output from the object store. The non-stripping download landed
+    it at ``transformed/artifacts/.../transformed/table/``, so
+    ``get_current_table_scope`` found no ``transformed/table`` and the snapshot
+    died with "No tables found in transformed output".
+    """
+    from application_sdk.common.incremental.state.state_writer import (
+        create_current_state_snapshot,
+        download_transformed_data,
+    )
+    from application_sdk.execution._temporal import activity_utils
+
+    staging = tmp_path / "staging"
+    monkeypatch.setattr(activity_utils, "TEMPORARY_PATH", str(staging))
+    output_path = staging / "artifacts/apps/oracle/workflows/wf-1/run-1"
+    run_prefix = "artifacts/apps/oracle/workflows/wf-1/run-1/transformed"
+
+    # The transform step's output, present in the object store only — this pod
+    # never wrote it locally.
+    remote_source = tmp_path / "remote-source"
+    _write_jsonl(
+        remote_source / "table" / "chunk-0.json",
+        [_table_entity("db/s/t1", "CREATED"), _table_entity("db/s/t2", "NO CHANGE")],
+    )
+    _write_jsonl(
+        remote_source / "column" / "chunk-0.json",
+        [_column_entity("db/s/t1/c1", "db/s/t1")],
+    )
+    _write_jsonl(remote_source / "schema" / "chunk-0.json", [_schema_entity("db/s")])
+    await upload_prefix(local_dir=remote_source, prefix=run_prefix, store=store)
+
+    transformed_dir = await download_transformed_data(str(output_path))
+
+    # Layout: entity directories directly under transformed/, prefix not repeated.
+    assert transformed_dir == output_path / "transformed"
+    assert _count_jsonl(transformed_dir / "table") == 2
+    assert not (transformed_dir / "artifacts").exists()
+
+    # And the layout is usable: real DuckDB scope + snapshot, the step that
+    # raised FileNotFoundError before the fix.
+    result = await create_current_state_snapshot(
+        connection_qualified_name="default/oracle/123",
+        transformed_dir=transformed_dir,
+        previous_state_dir=None,
+        current_state_dir=tmp_path / "current-state",
+        s3_prefix="persistent-artifacts/apps/oracle/connection/123",
+        run_id="run-1",
+        application_name="oracle",
+    )
+
+    assert result.total_files > 0
+    assert (result.current_state_dir / "table" / "chunk-0.json").exists()

--- a/tests/unit/common/incremental/conftest.py
+++ b/tests/unit/common/incremental/conftest.py
@@ -1,0 +1,30 @@
+"""Shared fixtures for incremental-extraction unit tests."""
+
+from collections.abc import Iterator
+
+import pytest
+from obstore.store import MemoryStore
+
+from application_sdk.infrastructure.context import (
+    InfrastructureContext,
+    clear_infrastructure,
+    set_infrastructure,
+)
+from application_sdk.storage.factory import create_memory_store
+
+
+@pytest.fixture
+def memory_store() -> Iterator[MemoryStore]:
+    """An in-memory object store bound as the infrastructure store.
+
+    Lets the incremental download/upload helpers — which resolve their store
+    from the infrastructure context — run against real storage, so a test can
+    assert the resulting on-disk *layout* instead of mocking the transfer away
+    (FND-340).
+    """
+    store = create_memory_store()
+    set_infrastructure(InfrastructureContext(storage=store))
+    try:
+        yield store
+    finally:
+        clear_infrastructure()

--- a/tests/unit/common/incremental/test_helpers.py
+++ b/tests/unit/common/incremental/test_helpers.py
@@ -9,7 +9,6 @@ Tests cover public functions with real business logic:
 - copy_directory_parallel: Parallel file copy operations
 """
 
-import asyncio
 import tempfile
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
@@ -30,6 +29,7 @@ from application_sdk.common.incremental.incremental_errors import (
     ConnectionQualifiedNameFormatError,
     ConnectionQualifiedNameMissingError,
 )
+from application_sdk.storage.ops import _put
 
 # ---------------------------------------------------------------------------
 # extract_epoch_id_from_qualified_name
@@ -263,121 +263,59 @@ class TestCopyDirectoryParallel:
 
 
 class TestDownloadS3PrefixWithStructure:
-    """Tests for parallel S3 prefix download with structure preservation."""
+    """Tests for the prefix-stripping download wrapper.
 
-    async def test_downloads_all_listed_files_to_correct_paths(self):
-        """All listed files are downloaded to correct local paths preserving structure."""
-        with tempfile.TemporaryDirectory() as temp_dir:
-            local_dest = Path(temp_dir) / "output"
-            s3_prefix = "bucket/tenant/data/"
-            items = [
-                ("bucket/tenant/data/subdir/file1.json", 11, '"etag-1"'),
-                ("bucket/tenant/data/file2.json", 22, '"etag-2"'),
-            ]
+    Exercised against a real (in-memory) object store rather than a mocked
+    download: the whole point of this helper is *where the bytes land*, which a
+    mock asserting "was awaited" cannot see (FND-340).
+    """
 
-            mock_download = AsyncMock()
-            mock_list = AsyncMock(return_value=items)
+    async def test_strips_prefix_so_tree_lands_directly_in_destination(
+        self, memory_store, tmp_path
+    ) -> None:
+        """``<prefix>/table/x.json`` → ``<dest>/table/x.json``, prefix not repeated."""
+        prefix = "persistent-artifacts/apps/app/connection/1/current-state"
+        await _put(
+            f"{prefix}/table/chunk-0.json", b'{"a": 1}', memory_store, normalize=False
+        )
+        await _put(
+            f"{prefix}/column/chunk-0.json", b'{"b": 2}', memory_store, normalize=False
+        )
 
-            with (
-                patch(
-                    "application_sdk.common.incremental.helpers.list_keys_with_meta",
-                    mock_list,
-                ),
-                patch(
-                    "application_sdk.common.incremental.helpers.download_file_chunked",
-                    mock_download,
-                ),
-            ):
-                await download_s3_prefix_with_structure(s3_prefix, local_dest)
+        dest = tmp_path / "current-state"
+        await download_s3_prefix_with_structure(prefix, dest)
 
-            mock_list.assert_awaited_once_with(prefix=s3_prefix)
-            assert mock_download.await_count == 2
-            # Size + etag from the listing are threaded through so large files
-            # chunk without a per-file HEAD and range GETs stay version-pinned.
-            mock_download.assert_any_await(
-                key="bucket/tenant/data/subdir/file1.json",
-                local_path=str(local_dest / "subdir" / "file1.json"),
-                file_size=11,
-                etag='"etag-1"',
-            )
-            mock_download.assert_any_await(
-                key="bucket/tenant/data/file2.json",
-                local_path=str(local_dest / "file2.json"),
-                file_size=22,
-                etag='"etag-2"',
-            )
+        assert (dest / "table" / "chunk-0.json").read_bytes() == b'{"a": 1}'
+        assert (dest / "column" / "chunk-0.json").read_bytes() == b'{"b": 2}'
+        # No second copy of the store prefix underneath the destination.
+        assert not (dest / "persistent-artifacts").exists()
 
-    async def test_concurrency_bounded_by_semaphore(self):
-        """No more than MAX_CONCURRENT_STORAGE_TRANSFERS (4) concurrent downloads run at once."""
+    async def test_empty_prefix_downloads_nothing(self, memory_store, tmp_path) -> None:
+        """A prefix with no objects leaves the destination empty (no error)."""
+        dest = tmp_path / "out"
+        await download_s3_prefix_with_structure("nothing/here", dest)
 
-        max_concurrent = 0
-        current_concurrent = 0
-        lock = asyncio.Lock()
+        assert not dest.exists() or not any(dest.rglob("*"))
 
-        async def _tracking_download(**kwargs):
-            nonlocal max_concurrent, current_concurrent
-            async with lock:
-                current_concurrent += 1
-                max_concurrent = max(max_concurrent, current_concurrent)
-            await asyncio.sleep(0.01)
-            async with lock:
-                current_concurrent -= 1
+    async def test_forwards_concurrency_bound_to_download_prefix(
+        self, tmp_path
+    ) -> None:
+        """The caller's concurrency bound reaches the underlying primitive.
 
-        items = [(f"prefix/file{i}.json", 10, None) for i in range(50)]
-
-        with (
-            tempfile.TemporaryDirectory() as temp_dir,
-            patch(
-                "application_sdk.common.incremental.helpers.list_keys_with_meta",
-                AsyncMock(return_value=items),
-            ),
-            patch(
-                "application_sdk.common.incremental.helpers.download_file_chunked",
-                side_effect=_tracking_download,
-            ),
-        ):
-            await download_s3_prefix_with_structure("prefix/", Path(temp_dir))
-
-        assert max_concurrent <= 4
-
-    async def test_empty_file_list(self):
-        """No downloads when prefix has no files."""
+        Bounding itself is ``download_prefix``'s contract (and its tests); what
+        this wrapper owns is passing the value through along with
+        ``strip_prefix=True``.
+        """
         mock_download = AsyncMock()
-        with (
-            patch(
-                "application_sdk.common.incremental.helpers.list_keys_with_meta",
-                AsyncMock(return_value=[]),
-            ),
-            patch(
-                "application_sdk.common.incremental.helpers.download_file_chunked",
-                mock_download,
-            ),
+        with patch(
+            "application_sdk.common.incremental.helpers.download_prefix",
+            mock_download,
         ):
-            await download_s3_prefix_with_structure("prefix/", Path("/tmp/out"))
+            await download_s3_prefix_with_structure("p/", tmp_path, max_concurrency=7)
 
-        mock_download.assert_not_awaited()
-
-    async def test_path_without_prefix_used_as_is(self):
-        """Files not starting with the prefix are used as relative path directly."""
-        with tempfile.TemporaryDirectory() as temp_dir:
-            local_dest = Path(temp_dir) / "output"
-            mock_download = AsyncMock()
-
-            with (
-                patch(
-                    "application_sdk.common.incremental.helpers.list_keys_with_meta",
-                    AsyncMock(return_value=[("other/path/file.json", 5, None)]),
-                ),
-                patch(
-                    "application_sdk.common.incremental.helpers.download_file_chunked",
-                    mock_download,
-                ),
-            ):
-                await download_s3_prefix_with_structure("prefix/", local_dest)
-
-            mock_download.assert_awaited_once_with(
-                key="other/path/file.json",
-                local_path=str(local_dest / "other" / "path" / "file.json"),
-                file_size=5,
-                etag=None,
-            )
+        mock_download.assert_awaited_once_with(
+            prefix="p/",
+            local_dir=tmp_path,
+            strip_prefix=True,
+            max_concurrency=7,
+        )

--- a/tests/unit/common/incremental/test_state_reader.py
+++ b/tests/unit/common/incremental/test_state_reader.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
 from application_sdk.common.incremental.state.state_reader import download_current_state
+from application_sdk.storage.ops import _put
 
 
 class TestDownloadCurrentState:
@@ -73,6 +74,39 @@ class TestDownloadCurrentState:
 
         assert exists is True
         assert json_count == 2
+
+    async def test_state_lands_unnested_under_current_state_dir(
+        self, memory_store, tmp_path, monkeypatch
+    ) -> None:
+        """Downloaded state must land at ``<current-state>/<entity>/``.
+
+        Real store instead of a mocked download, because the regression this
+        guards (FND-340) was purely about *where* the bytes landed: the JSON
+        count is taken with ``rglob``, so a nested tree still reported
+        ``current_state_available=True`` while no keyed reader could use it.
+        """
+        from application_sdk.common.incremental import helpers
+
+        monkeypatch.setattr(helpers, "TEMPORARY_PATH", str(tmp_path))
+        prefix = "persistent-artifacts/apps/oracle/connection/123/current-state"
+        await _put(
+            f"{prefix}/table/chunk-0.json", b'{"t": 1}', memory_store, normalize=False
+        )
+        await _put(
+            f"{prefix}/column/chunk-0.json", b'{"c": 1}', memory_store, normalize=False
+        )
+
+        state_dir, s3_prefix, exists, json_count = await download_current_state(
+            connection_qualified_name="default/oracle/123",
+            application_name="oracle",
+        )
+
+        assert s3_prefix == prefix
+        assert exists is True
+        assert json_count == 2
+        assert (state_dir / "table" / "chunk-0.json").read_bytes() == b'{"t": 1}'
+        assert (state_dir / "column" / "chunk-0.json").read_bytes() == b'{"c": 1}'
+        assert not (state_dir / "persistent-artifacts").exists()
 
     async def test_empty_download_returns_not_exists(self):
         """Download that results in zero JSON files returns exists=False."""

--- a/tests/unit/common/incremental/test_state_writer.py
+++ b/tests/unit/common/incremental/test_state_writer.py
@@ -31,6 +31,7 @@ from application_sdk.common.incremental.state.state_writer import (
     upload_current_state,
 )
 from application_sdk.common.incremental.state.table_scope import add_table_to_scope
+from application_sdk.storage.ops import _put
 
 # ---------------------------------------------------------------------------
 # copy_non_column_entities
@@ -191,7 +192,7 @@ class TestPreparePreviousState:
 
             with patch(
                 "application_sdk.common.incremental.state.state_writer."
-                "download_s3_prefix_with_structure",
+                "download_prefix",
                 new_callable=AsyncMock,
             ):
                 result = await prepare_previous_state(
@@ -213,7 +214,7 @@ class TestPreparePreviousState:
 
             with patch(
                 "application_sdk.common.incremental.state.state_writer."
-                "download_s3_prefix_with_structure",
+                "download_prefix",
                 new_callable=AsyncMock,
                 side_effect=Exception("S3 failure"),
             ):
@@ -232,6 +233,34 @@ class TestPreparePreviousState:
             expected_temp = state_dir.parent / f"{state_dir.name}.previous"
             assert not expected_temp.exists()
 
+    async def test_previous_state_lands_unnested_in_temp_dir(
+        self, memory_store, tmp_path
+    ) -> None:
+        """Previous state must land at ``<temp>/<entity>/`` for the diff reader.
+
+        Real store, real bytes: create_incremental_diff globs
+        ``<previous_state_dir>/table/*.json``, so a prefix repeated inside the
+        temp dir silently reports "no previous tables" (FND-340).
+        """
+        prefix = "persistent-artifacts/apps/oracle/connection/123/current-state"
+        await _put(
+            f"{prefix}/table/chunk-0.json", b'{"t": 1}', memory_store, normalize=False
+        )
+
+        state_dir = tmp_path / "current-state"
+        state_dir.mkdir()
+
+        previous = await prepare_previous_state(
+            connection_qualified_name="default/oracle/123",
+            current_state_available=True,
+            current_state_dir=state_dir,
+            application_name="oracle",
+        )
+
+        assert previous is not None
+        assert (previous / "table" / "chunk-0.json").read_bytes() == b'{"t": 1}'
+        assert not (previous / "persistent-artifacts").exists()
+
     async def test_stale_temp_removal_offloaded_to_thread(self):
         """The leftover-temp rmtree must not run inline on the event loop.
 
@@ -249,7 +278,7 @@ class TestPreparePreviousState:
             with (
                 patch(
                     "application_sdk.common.incremental.state.state_writer."
-                    "download_s3_prefix_with_structure",
+                    "download_prefix",
                     new_callable=AsyncMock,
                 ),
                 patch(
@@ -307,6 +336,40 @@ class TestDownloadTransformedData:
 
             assert result == Path(temp_dir) / "transformed"
             mock_store.assert_awaited_once()
+
+    async def test_lands_files_where_transformed_readers_look(
+        self, memory_store, tmp_path, monkeypatch
+    ) -> None:
+        """Downloaded bytes must land at ``<output_path>/transformed/<entity>/``.
+
+        Run against a real store rather than a mocked download: the regression
+        this guards (FND-340) was a *layout* bug, invisible to a mock asserting
+        only that the download was awaited. The nested layout it produced —
+        ``transformed/artifacts/.../transformed/table/`` — made
+        ``get_current_table_scope`` return None and ``write_current_state``
+        raise "No tables found in transformed output".
+        """
+        from application_sdk.execution._temporal import activity_utils
+
+        staging = tmp_path / "staging"
+        monkeypatch.setattr(activity_utils, "TEMPORARY_PATH", str(staging))
+        output_path = staging / "artifacts/apps/oracle/workflows/wf-1/run-1"
+
+        prefix = "artifacts/apps/oracle/workflows/wf-1/run-1/transformed"
+        await _put(
+            f"{prefix}/table/chunk-0.json", b'{"t": 1}', memory_store, normalize=False
+        )
+        await _put(
+            f"{prefix}/column/chunk-0.json", b'{"c": 1}', memory_store, normalize=False
+        )
+
+        transformed_dir = await download_transformed_data(str(output_path))
+
+        assert transformed_dir == output_path / "transformed"
+        assert (transformed_dir / "table" / "chunk-0.json").read_bytes() == b'{"t": 1}'
+        assert (transformed_dir / "column" / "chunk-0.json").read_bytes() == b'{"c": 1}'
+        # The nested-layout signature must not reappear.
+        assert not (transformed_dir / "artifacts").exists()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/storage/test_batch.py
+++ b/tests/unit/storage/test_batch.py
@@ -148,6 +148,74 @@ class TestDownloadPrefix:
         assert (tmp_path / "dl" / "sub" / "a.txt").read_bytes() == b"alpha"
         assert (tmp_path / "dl" / "b.txt").read_bytes() == b"beta"
 
+    async def test_strip_prefix_reproduces_only_the_tree_under_prefix(
+        self, store, tmp_path
+    ) -> None:
+        """strip_prefix=True drops the prefix instead of repeating it locally."""
+        await _put("run/transformed/table/a.json", b"alpha", store, normalize=False)
+        await _put("run/transformed/column/b.json", b"beta", store, normalize=False)
+
+        dests = await download_prefix(
+            "run/transformed",
+            tmp_path,
+            store,
+            normalize=False,
+            strip_prefix=True,
+        )
+
+        assert len(dests) == 2
+        assert (tmp_path / "table" / "a.json").read_bytes() == b"alpha"
+        assert (tmp_path / "column" / "b.json").read_bytes() == b"beta"
+        # The defining property: no second copy of the prefix under local_dir.
+        assert not (tmp_path / "run").exists()
+
+    async def test_strip_prefix_handles_trailing_slash(self, store, tmp_path) -> None:
+        """A slash-terminated prefix strips identically (no leading-slash join)."""
+        await _put("run/transformed/table/a.json", b"alpha", store, normalize=False)
+
+        await download_prefix(
+            "run/transformed/", tmp_path, store, normalize=False, strip_prefix=True
+        )
+
+        assert (tmp_path / "table" / "a.json").read_bytes() == b"alpha"
+
+    async def test_strip_prefix_strips_the_normalised_prefix(
+        self, store, tmp_path, monkeypatch
+    ) -> None:
+        """A v2-style staging path strips as its normalised ``artifacts/...`` key.
+
+        Stripping the caller's raw argument would miss — the listing matched the
+        normalised form — and every file would land under a full copy of the key
+        path instead.
+        """
+        from application_sdk import constants
+
+        monkeypatch.setattr(constants, "TEMPORARY_PATH", str(tmp_path / "staging"))
+        await _put(
+            "artifacts/run/transformed/table/a.json", b"a", store, normalize=False
+        )
+
+        dest = tmp_path / "out"
+        await download_prefix(
+            f"{tmp_path}/staging/artifacts/run/transformed",
+            dest,
+            store,
+            strip_prefix=True,
+        )
+
+        assert (dest / "table" / "a.json").read_bytes() == b"a"
+        assert not (dest / "artifacts").exists()
+
+    async def test_default_keeps_full_store_path(self, store, tmp_path) -> None:
+        """Without strip_prefix the full key layout is preserved (unchanged default)."""
+        await _put("run/transformed/table/a.json", b"alpha", store, normalize=False)
+
+        await download_prefix("run/transformed", tmp_path, store, normalize=False)
+
+        assert (
+            tmp_path / "run" / "transformed" / "table" / "a.json"
+        ).read_bytes() == b"alpha"
+
     async def test_suffix_filter_restricts_download(self, store, tmp_path) -> None:
         await _put("d/x.parquet", b"p", store, normalize=False)
         await _put("d/x.json", b"j", store, normalize=False)

--- a/tests/unit/storage/test_batch.py
+++ b/tests/unit/storage/test_batch.py
@@ -216,6 +216,21 @@ class TestDownloadPrefix:
             tmp_path / "run" / "transformed" / "table" / "a.json"
         ).read_bytes() == b"alpha"
 
+    async def test_strip_prefix_does_not_misstrip_sibling_keys(self) -> None:
+        """The strip matches on a path boundary, never a bare string prefix.
+
+        A sibling key sharing a string prefix (``a/b2/x`` under strip ``a/b``)
+        must be preserved whole, not mis-stripped to ``2/x``. The store listing
+        is itself boundary-aware (obstore returns only keys under ``a/b/``), so
+        this exercises ``_local_relative_key`` directly to pin the defensive
+        contract independent of any backend's listing semantics.
+        """
+        from application_sdk.storage.batch import _local_relative_key
+
+        assert _local_relative_key("a/b/file.json", "a/b") == "file.json"
+        assert _local_relative_key("a/b2/file.json", "a/b") == "a/b2/file.json"
+        assert _local_relative_key("a/b", "a/b") == "b"
+
     async def test_suffix_filter_restricts_download(self, store, tmp_path) -> None:
         await _put("d/x.parquet", b"p", store, normalize=False)
         await _put("d/x.json", b"j", store, normalize=False)

--- a/tests/unit/templates/test_incremental_sql_metadata_extractor.py
+++ b/tests/unit/templates/test_incremental_sql_metadata_extractor.py
@@ -702,6 +702,16 @@ class TestPrepareColumnExtractionQueriesInlineImports:
         artifacts_dir = tmp_path / "persistent"
         artifacts_dir.mkdir()
 
+        # Both downloads go through download_prefix now, so fail only the
+        # current-state one and let the transformed download succeed.
+        state_downloads = 0
+
+        async def _download(*, prefix: str, **kwargs) -> None:
+            nonlocal state_downloads
+            if prefix == "s3://state":
+                state_downloads += 1
+                raise RuntimeError("S3 failure")
+
         with (
             patch(
                 "application_sdk.execution.get_object_store_prefix",
@@ -709,16 +719,12 @@ class TestPrepareColumnExtractionQueriesInlineImports:
             ),
             patch(
                 "application_sdk.storage.batch.download_prefix",
-                new=AsyncMock(return_value=None),
+                new=AsyncMock(side_effect=_download),
             ),
             patch(
                 "application_sdk.common.incremental.helpers.get_persistent_artifacts_path",
                 return_value=artifacts_dir,
             ),
-            patch(
-                "application_sdk.common.incremental.helpers.download_s3_prefix_with_structure",
-                new=AsyncMock(side_effect=RuntimeError("S3 failure")),
-            ) as mock_dl_state,
             patch(
                 "application_sdk.common.incremental.column_extraction.get_backfill_tables",
                 return_value=set(),
@@ -740,7 +746,7 @@ class TestPrepareColumnExtractionQueriesInlineImports:
             )
         # Failure was swallowed; flow continued with no batches
         assert out.total_batches == 0
-        mock_dl_state.assert_awaited_once()
+        assert state_downloads == 1
 
 
 class TestWriteCurrentStateInlineImports:


### PR DESCRIPTION
## What

The incremental path recovered its `transformed/` and `current-state/` trees with `download_prefix`, whose documented contract is that each key's **full store path** is preserved under `local_dir`. Three call sites passed a `local_dir` that already named the same directory, so a run that re-downloaded its tree got

```
<output_path>/transformed/artifacts/apps/.../transformed/table/chunk-0.json
```

instead of `<output_path>/transformed/table/chunk-0.json`. Every reader keyed on the fixed subpath then found nothing:

1. `get_current_table_scope` returns `None` → `write_current_state` raises `FileNotFoundError: No tables found in transformed output` (the CONNECT-817 signature).
2. Phase 3 raises `Transformed table directory not found` from `column_extraction/analysis.py`.
3. `state_reader` still reported `current_state_available=True`, because it counts JSON files with `rglob` — a tree no keyed reader could actually use.

Only reachable when the activity runs on a pod that doesn't already have the files locally (container restart / reschedule mid-run), which is why it correlates with long-running large connections rather than every run. Not a regression: the call sites are identical back to `v3.0.0`. The pre-obstore implementation stripped correctly; the rewrite dropped that and the call sites were never updated.

## How

`download_prefix` gains an explicit `strip_prefix: bool = False` mode, and the incremental path is collapsed onto it — the alternative in the issue was to route everything through `download_s3_prefix_with_structure`, which stripped correctly but carried its own listing/download loop with **no** sidecar exclusion, no `{key}.sha256` verification and no path-traversal guard. Rather than keep the poorer implementation, that helper is now a thin wrapper over `download_prefix(..., strip_prefix=True)`; it stays importable because app code outside the SDK imports it. One implementation, one path policy, no divergent readers of the same tree.

Call sites, all now `strip_prefix=True`:

| Call site | Was |
| -- | -- |
| `state_writer.download_transformed_data` | non-stripping — **bug** |
| `state_reader.download_current_state` | non-stripping — **bug** |
| `incremental_sql_metadata_extractor.prepare_column_extraction_queries` | non-stripping — **bug** |
| `state_writer.prepare_previous_state` | stripping via the helper |
| the extractor's backfill-comparison download | stripping via the helper |

One detail worth review attention: the strip is computed against the **normalised** listing prefix, not the caller's raw argument. Stripping the raw string — what the old helper did — silently falls through to the full key for a v2-style `./local/tmp/...` prefix, since the listing matched the normalised `artifacts/...` form. `test_strip_prefix_strips_the_normalised_prefix` pins that.

## Testing

The old behaviour survived because the only coverage mocked `download_prefix` out and asserted it was awaited — a mock cannot see a layout bug. Every new test runs against a real store:

- `tests/unit/storage/test_batch.py` — strip vs. default layout, trailing-slash prefix, normalised-prefix stripping.
- `tests/unit/common/incremental/{test_state_writer,test_state_reader,test_helpers}.py` — per-call-site layout assertions (`<dir>/table/chunk-0.json` present, prefix not repeated). New `conftest.py` fixture binds a MemoryStore as the infrastructure store.
- `tests/integration/test_incremental_pipeline.py::test_transformed_recovery_from_store_feeds_current_state` — uploads a transformed tree, recovers it on a "fresh pod", then drives `create_current_state_snapshot` over it with real DuckDB. The CONNECT-817 signature end to end.

Both new regression tests were confirmed to fail on the pre-fix code (reverting `strip_prefix=True` gives `assert _count_jsonl(transformed_dir / "table") == 2` → `0 == 2`).

Local: 6881 unit passed, 33 integration (incremental + storage) passed, pre-commit clean including pyright, `conformance detect` shows no new findings on the touched files.

## Security-relevant notes

`download_s3_prefix_with_structure` now inherits three protections it did not have: SHA-256 sidecar verification on every downloaded object, the `_safe_join_under` guard rejecting keys whose resolved path escapes the destination, and exclusion of `.sha256` sidecars from the on-disk tree. No behaviour is weakened; the default `download_prefix` layout is unchanged, so `strip_prefix` is purely opt-in.

## Follow-up

Once this ships, `atlan-oracle-app` can drop `_rehydrate_transformed_if_missing` and the duplicate download it guards — its workaround currently rehydrates the tree correctly and then the SDK parent re-downloads the whole thing into the nested path anyway, so a large connection pays for the bytes twice. Not yet communicated to that team.

This does not settle the open question on CONNECT-817 about the six Aug 9–11 runs; that needs the run's image tag / Temporal BuildId and a listing of the run's `transformed/table/` prefix, and is tracked there.

Fixes FND-340.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
