### PR TITLE
fix(storage): treat a key that vanishes mid-delete as benign in delete_prefix (FND-341)

### DIFF
--- a/application_sdk/storage/batch.py
+++ b/application_sdk/storage/batch.py
@@ -38,6 +38,7 @@ from application_sdk.storage.integrity import (
 )
 from application_sdk.storage.integrity import is_sidecar_key, sidecar_key
 from application_sdk.storage.ops import (
+    _is_local_dir_collision,
     _is_not_found,
     _list_items,
     _normalize_listing_prefix,
@@ -344,7 +345,11 @@ async def delete_prefix(
             paths.append(root_marker)
         # conformance: ignore[E004] probe for directory marker existence; not-found is expected and swallowed intentionally
         except Exception as exc:
-            if not _is_not_found(exc):
+            # A local store maps the bare marker key onto the directory the
+            # prefix holds, and its stat does not surface as "not found" (on
+            # Windows it is a GenericError "Access is denied") — that is a
+            # directory collision (no marker object), not a permission error.
+            if not (_is_not_found(exc) or _is_local_dir_collision(exc)):
                 from application_sdk.storage.errors import (  # noqa: PLC0415 — circular: storage/__init__.py loads sibling modules
                     StorageError,
                 )
@@ -414,6 +419,9 @@ async def _delete_paths_individually(
 
     Raises:
         StorageError: If a delete fails for any reason other than not-found.
+            The first failure also cancels the remaining per-key deletes and
+            *waits* for that cancellation to finish before propagating, so no
+            sibling delete outlives the raised error.
     """
     import asyncio  # noqa: PLC0415 — stdlib asyncio; lazy use only
 
@@ -423,10 +431,27 @@ async def _delete_paths_individually(
         async with sem:
             return await _delete_object(path, store, normalize=False)
 
-    # gather() with the default return_exceptions=False keeps genuine failures
-    # fatal: the first StorageError from ops.delete propagates to the caller.
-    deleted: list[bool] = await asyncio.gather(*[_delete_one(p) for p in paths])
-    return sum(deleted)
+    # A TaskGroup (vs gather) gives structured cancel-and-await semantics: on
+    # the first StorageError the group cancels the remaining per-key tasks and
+    # does not return until they have actually finished unwinding, so no delete
+    # is left in flight to complete after the caller has seen the failure.  The
+    # group wraps the failure in an ExceptionGroup; unwrap the StorageError so
+    # the caller sees the original contract (a bare StorageError), not a group.
+    from application_sdk.storage.errors import (  # noqa: PLC0415 — circular: storage/__init__.py loads sibling modules
+        StorageError,
+    )
+
+    try:
+        async with asyncio.TaskGroup() as tg:
+            tasks = [tg.create_task(_delete_one(p)) for p in paths]
+    except BaseExceptionGroup as group:
+        storage_error = next(
+            (e for e in group.exceptions if isinstance(e, StorageError)), None
+        )
+        if storage_error is not None:
+            raise storage_error from group
+        raise
+    return sum(t.result() for t in tasks)
 
 
 def _local_relative_key(key: str, strip: str) -> str:

--- a/application_sdk/storage/batch.py
+++ b/application_sdk/storage/batch.py
@@ -26,12 +26,13 @@ from typing import TYPE_CHECKING
 import obstore
 
 from application_sdk._runtime.offload import run_in_thread
+from application_sdk.common._listing import prune_internal_dirs
+from application_sdk.observability.logger_adaptor import get_logger
 
 # Sidecar naming is owned by ``storage.integrity`` — the module that also reads
 # and writes them. Re-exported here (``batch.SIDECAR_SUFFIX`` /
 # ``batch.is_sidecar_key``) because the listing filters are the historical
 # import site and ``application_sdk.storage`` re-exports both from batch.
-from application_sdk.common._listing import prune_internal_dirs
 from application_sdk.storage.integrity import (
     SIDECAR_SUFFIX as SIDECAR_SUFFIX,  # re-export
 )
@@ -42,6 +43,9 @@ from application_sdk.storage.ops import (
     _normalize_listing_prefix,
     _resolve_store,
     _safe_join_under,
+)
+from application_sdk.storage.ops import delete as _delete_object
+from application_sdk.storage.ops import (
     download_file_chunked,
     normalize_key,
     upload_file,
@@ -51,6 +55,8 @@ if TYPE_CHECKING:
     from obstore.store import ObjectStore
 
     from application_sdk.storage.ops import BoundStore
+
+logger = get_logger(__name__)
 
 
 async def list_keys(
@@ -279,11 +285,11 @@ async def delete_prefix(
 
     Uses the store's native bulk-delete API where available (S3 batches up to
     1 000 keys per request; Azure up to 256; GCS issues 10 parallel individual
-    DELETE requests).  A not-found error on GCS or Azure after a fresh listing
-    indicates concurrent modification of the same prefix and is surfaced as a
-    ``StorageError`` rather than silently retried — such a failure almost
-    certainly signals an unexpected interaction between two apps sharing the
-    same prefix, which is a bug worth making explicit.
+    DELETE requests).  A not-found error after the fresh listing means a key
+    vanished between the two calls — the desired end state for that key is
+    reached either way, so it is benign: it is logged as a warning (it can
+    indicate two apps sharing the prefix) and the delete falls back to an
+    idempotent per-key pass (FND-341).  Every other error is fatal.
 
     Args:
         prefix: Key prefix — all objects under this prefix are deleted.
@@ -293,10 +299,12 @@ async def delete_prefix(
         normalize: When ``True`` (default), normalise *prefix* before use.
 
     Returns:
-        Number of objects deleted.
+        Number of objects deleted.  Keys that vanished concurrently are not
+        counted — only objects this call actually removed.
 
     Raises:
-        StorageError: If the listing or any deletion fails.
+        StorageError: If the listing fails, or if a deletion fails for any
+            reason other than the key already being gone.
         ObjectStoreNotProvidedError: If *store* is ``None`` and no infrastructure store is set.
     """
     resolved = _resolve_store(store)
@@ -351,17 +359,74 @@ async def delete_prefix(
 
     try:
         await obstore.delete_async(resolved, paths)
-    # conformance: ignore[E004] always re-raises as StorageError; no logging needed at this layer
+    # conformance: ignore[E004] not-found is the benign list/delete race handled below (logged + retried per key); every other error re-raises as StorageError
     except Exception as exc:
-        from application_sdk.storage.errors import (  # noqa: PLC0415 — circular: storage/__init__.py loads sibling modules
-            StorageError,
-        )
+        if not _is_not_found(exc):
+            from application_sdk.storage.errors import (  # noqa: PLC0415 — circular: storage/__init__.py loads sibling modules
+                StorageError,
+            )
 
-        raise StorageError(
-            f"Failed to delete {len(paths)} objects with prefix '{prefix}'", cause=exc
-        ) from exc
+            raise StorageError(
+                f"Failed to delete {len(paths)} objects with prefix '{prefix}'",
+                cause=exc,
+            ) from exc
+
+        # A key vanished between the listing and the bulk delete (GCS and Azure
+        # report a per-key not-found; S3 and MemoryStore treat it as success).
+        # The end state this call wants — the object gone — is already true for
+        # that key, so failing the caller over it turns a benign race into a
+        # workflow failure (FND-341).  It *can* mean two apps are writing the
+        # same prefix, which is worth seeing, so say so at WARNING instead.
+        logger.warning(
+            "Object under prefix '%s' vanished between listing and bulk delete; "
+            "retrying %d key(s) individually. This is benign on its own, but can "
+            "indicate two apps writing the same prefix. Store error: %s",
+            prefix,
+            len(paths),
+            exc,
+            exc_info=True,
+        )
+        # obstore's bulk delete is all-or-nothing to the caller: it names at most
+        # one key and stops at the first per-key failure, so neither which keys
+        # are gone nor which are still there is knowable from here.  Re-run the
+        # deletes one key at a time — ``ops.delete`` is idempotent (``False`` on
+        # not-found) and still fatal on real errors — so the prefix ends up empty
+        # and the count reflects only what this call removed.
+        return await _delete_paths_individually(resolved, paths)
 
     return len(paths)
+
+
+async def _delete_paths_individually(
+    store: ObjectStore,
+    paths: list[str],
+    *,
+    max_concurrency: int = 10,
+) -> int:
+    """Delete *paths* one key at a time, skipping keys that are already gone.
+
+    Fallback path for the benign list/delete race in :func:`delete_prefix`; the
+    default concurrency matches obstore's own fan-out for stores without a
+    native bulk delete.
+
+    Returns:
+        Number of keys that existed and were deleted.
+
+    Raises:
+        StorageError: If a delete fails for any reason other than not-found.
+    """
+    import asyncio  # noqa: PLC0415 — stdlib asyncio; lazy use only
+
+    sem = asyncio.Semaphore(max_concurrency)
+
+    async def _delete_one(path: str) -> bool:
+        async with sem:
+            return await _delete_object(path, store, normalize=False)
+
+    # gather() with the default return_exceptions=False keeps genuine failures
+    # fatal: the first StorageError from ops.delete propagates to the caller.
+    deleted: list[bool] = await asyncio.gather(*[_delete_one(p) for p in paths])
+    return sum(deleted)
 
 
 def _local_relative_key(key: str, strip: str) -> str:

--- a/application_sdk/storage/batch.py
+++ b/application_sdk/storage/batch.py
@@ -349,7 +349,12 @@ async def delete_prefix(
             # prefix holds, and its stat does not surface as "not found" (on
             # Windows it is a GenericError "Access is denied") — that is a
             # directory collision (no marker object), not a permission error.
-            if not (_is_not_found(exc) or _is_local_dir_collision(exc)):
+            # The store and key are threaded in so the relaxation is decided by
+            # what the key actually resolves to, not by the message wording.
+            if not (
+                _is_not_found(exc)
+                or _is_local_dir_collision(exc, resolved, root_marker)
+            ):
                 from application_sdk.storage.errors import (  # noqa: PLC0415 — circular: storage/__init__.py loads sibling modules
                     StorageError,
                 )
@@ -445,11 +450,14 @@ async def _delete_paths_individually(
         async with asyncio.TaskGroup() as tg:
             tasks = [tg.create_task(_delete_one(p)) for p in paths]
     except BaseExceptionGroup as group:
-        storage_error = next(
-            (e for e in group.exceptions if isinstance(e, StorageError)), None
-        )
-        if storage_error is not None:
-            raise storage_error from group
+        # Unwrap only a group that is *entirely* StorageError. Picking the first
+        # StorageError out of a mixed group would demote every other leaf to
+        # ``__cause__`` — reachable in a traceback, invisible to an
+        # ``except`` clause. ops.delete wraps every per-key failure, so the
+        # homogeneous case is the only one that happens in practice; a foreign
+        # leaf means something unforeseen and is better surfaced as the group.
+        if all(isinstance(leaf, StorageError) for leaf in group.exceptions):
+            raise group.exceptions[0] from group
         raise
     return sum(t.result() for t in tasks)
 

--- a/application_sdk/storage/ops.py
+++ b/application_sdk/storage/ops.py
@@ -313,13 +313,6 @@ def _is_not_found(exc: BaseException) -> bool:
     * Substring fallback (``"not found"``, ``"404"``, …) for generic obstore
       errors that surface only as ``GenericError`` with the underlying HTTP
       status in the message.
-    * ``"access is denied"`` / ``"is a directory"`` — how a *local* store
-      reports a key that resolves to a directory rather than an object (the
-      Windows ``LocalStore`` raises ``GenericError`` "Access is denied" on a
-      directory stat, where POSIX surfaces ``FileNotFoundError``).  A key that
-      collides with a directory cannot exist as a retrievable object, so every
-      caller contract here — "False / None / skip when the object is not
-      there" — is served by treating it as missing.
 
     Class-based detection runs first so we don't misclassify a generic
     ``GenericError("HTTP 503: 404 not in title")`` style flake.
@@ -335,8 +328,33 @@ def _is_not_found(exc: BaseException) -> bool:
         or "does not exist" in msg
         or "404" in msg
         or "key not found" in msg
-        or "access is denied" in msg
-        or "is a directory" in msg
+    )
+
+
+def _is_local_dir_collision(exc: BaseException) -> bool:
+    """Return True when a *local* store reports a key that resolves to a directory.
+
+    A :class:`~obstore.store.LocalStore` maps an object key onto a filesystem
+    path, so a probe of a key that names a directory (e.g. the bare root marker
+    ``"t"`` when ``t/`` holds children) does not surface as "not found": on
+    Windows the ``LocalStore`` raises ``GenericError("… Unable to open file …:
+    Access is denied. (os error 5)")`` on the directory stat, and on any
+    platform a failed open can surface as "… Is a directory".  A key that
+    resolves to a directory can never exist as an object, so this is a
+    directory-collision — not a permission or I/O failure — and every caller
+    contract here ("False / None / skip when the object is not there") is
+    served by treating it as missing.
+
+    The match is deliberately conjunctive (an "unable to open file" prefix
+    *and* the directory-stat suffix) so a plain ``ERROR_ACCESS_DENIED`` or a
+    cloud 403 containing "access is denied" is **not** reclassified as
+    not-found — permission failures stay fatal (see the ``StorageError``
+    contract on :func:`delete` / :func:`exists` and ``StoragePermissionError``
+    in ``storage.preflight``).
+    """
+    msg = str(exc).lower()
+    return "unable to open file" in msg and (
+        "access is denied" in msg or "is a directory" in msg
     )
 
 

--- a/application_sdk/storage/ops.py
+++ b/application_sdk/storage/ops.py
@@ -313,6 +313,13 @@ def _is_not_found(exc: BaseException) -> bool:
     * Substring fallback (``"not found"``, ``"404"``, …) for generic obstore
       errors that surface only as ``GenericError`` with the underlying HTTP
       status in the message.
+    * ``"access is denied"`` / ``"is a directory"`` — how a *local* store
+      reports a key that resolves to a directory rather than an object (the
+      Windows ``LocalStore`` raises ``GenericError`` "Access is denied" on a
+      directory stat, where POSIX surfaces ``FileNotFoundError``).  A key that
+      collides with a directory cannot exist as a retrievable object, so every
+      caller contract here — "False / None / skip when the object is not
+      there" — is served by treating it as missing.
 
     Class-based detection runs first so we don't misclassify a generic
     ``GenericError("HTTP 503: 404 not in title")`` style flake.
@@ -328,6 +335,8 @@ def _is_not_found(exc: BaseException) -> bool:
         or "does not exist" in msg
         or "404" in msg
         or "key not found" in msg
+        or "access is denied" in msg
+        or "is a directory" in msg
     )
 
 

--- a/application_sdk/storage/ops.py
+++ b/application_sdk/storage/ops.py
@@ -331,27 +331,49 @@ def _is_not_found(exc: BaseException) -> bool:
     )
 
 
-def _is_local_dir_collision(exc: BaseException) -> bool:
-    """Return True when a *local* store reports a key that resolves to a directory.
+def _is_local_dir_collision(exc: BaseException, store: ObjectStore, key: str) -> bool:
+    """Return True when *key* names a directory in a local store, not an object.
 
     A :class:`~obstore.store.LocalStore` maps an object key onto a filesystem
     path, so a probe of a key that names a directory (e.g. the bare root marker
     ``"t"`` when ``t/`` holds children) does not surface as "not found": on
-    Windows the ``LocalStore`` raises ``GenericError("… Unable to open file …:
-    Access is denied. (os error 5)")`` on the directory stat, and on any
-    platform a failed open can surface as "… Is a directory".  A key that
-    resolves to a directory can never exist as an object, so this is a
-    directory-collision — not a permission or I/O failure — and every caller
-    contract here ("False / None / skip when the object is not there") is
+    Windows the stat raises ``GenericError("… Unable to open file …: Access is
+    denied. (os error 5)")``, and a failed open can surface as "… Is a
+    directory".  A key that resolves to a directory can never also exist as an
+    object, so this is a directory collision — not a permission or I/O failure
+    — and the caller contract here ("skip when the object is not there") is
     served by treating it as missing.
 
-    The match is deliberately conjunctive (an "unable to open file" prefix
-    *and* the directory-stat suffix) so a plain ``ERROR_ACCESS_DENIED`` or a
-    cloud 403 containing "access is denied" is **not** reclassified as
-    not-found — permission failures stay fatal (see the ``StorageError``
-    contract on :func:`delete` / :func:`exists` and ``StoragePermissionError``
-    in ``storage.preflight``).
+    Deliberately not a message match on its own; message text alone would
+    reclassify a genuine failure that happens to be worded the same way (a
+    non-local backend, or a local *file* that is unreadable).  Three gates, in
+    order of authority:
+
+    1. Not a ``LocalStore`` → never a directory collision.  Cloud backends have
+       no directories; a 403 wording similar to Windows' stays fatal.
+    2. A ``LocalStore`` with a prefix (what :func:`storage.factory.create_local_store`
+       builds) → resolve the key and ask the filesystem.  ``is_dir()`` is the
+       authoritative answer and needs no message parsing: it is ``False`` for an
+       unreadable *file*, so a real permission failure still raises.
+    3. A rootless ``LocalStore`` (keys are not resolvable to a path here) → fall
+       back to the conjunctive message shape: an "unable to open file" prefix
+       *and* a directory-stat suffix.  A plain ``ERROR_ACCESS_DENIED`` or a
+       cloud 403 containing "access is denied" does not match.
+
+    Permission failures must stay fatal in every case — see the ``StorageError``
+    contract on :func:`delete` / :func:`exists`, and ``StoragePermissionError``
+    in ``storage.preflight``.
     """
+    from obstore.store import LocalStore  # noqa: PLC0415 — defensive: keep inline
+
+    if not isinstance(store, LocalStore):
+        return False
+
+    root = store.prefix
+    if root is not None:
+        # PurePosixPath: obstore keys are always '/'-separated, whatever the OS.
+        return Path(root, *PurePosixPath(key).parts).is_dir()
+
     msg = str(exc).lower()
     return "unable to open file" in msg and (
         "access is denied" in msg or "is a directory" in msg

--- a/docs/concepts/storage.md
+++ b/docs/concepts/storage.md
@@ -78,6 +78,13 @@ found = await exists("artifacts/my-app/output.json")
 keys = await list_keys("artifacts/my-app/")  # returns list[str]
 ```
 
+`delete_prefix(prefix)` removes every object under a prefix and returns the
+number of objects this call actually removed. A key that vanishes between the
+listing and the delete — a concurrent writer removed it first — is benign (the
+desired end state is already true for it): it is logged as a warning naming the
+prefix and excluded from the returned count rather than failing the caller.
+Every other deletion error still raises `StorageError`.
+
 ### Prefix downloads
 
 `download_prefix` writes one of two layouts, and picking the wrong one is

--- a/tests/unit/storage/test_batch.py
+++ b/tests/unit/storage/test_batch.py
@@ -164,8 +164,9 @@ class TestDeletePrefix:
         report a missing key (local, GCS, Azure) can show the exclusion — S3 and
         MemoryStore treat deleting a gone key as success, so ``ops.delete``
         legitimately counts it.  The head probe is pinned to the Windows
-        directory-stat response (see below) so the test fails on every OS if
-        ``_is_not_found`` stops recognising it.
+        LocalStore directory-stat response (see below) so the test fails on
+        every OS if the root-marker probe stops recognising a directory
+        collision as "no marker".
         """
         store = create_local_store(tmp_path / "store")
         await _put("t/gone.txt", b"1", store, normalize=False)
@@ -186,10 +187,11 @@ class TestDeletePrefix:
 
         # The root-marker probe for "t/" is the bare key "t", which the local
         # store maps onto the *directory* holding the two keys.  POSIX reports
-        # that stat as not-found, but the Windows LocalStore raises
-        # GenericError("Access is denied") — a directory can never be an
-        # object, so the probe must read it as "no marker" on every OS.
-        # Pin that response so this regression is exercised everywhere.
+        # that stat as not-found, but the Windows LocalStore raises a
+        # GenericError "Unable to open file …: Access is denied" — a directory
+        # can never be an object, so the probe must read it as "no marker" on
+        # every OS.  Pin that exact response so this regression is exercised
+        # everywhere.
         real_head_async = obstore.head_async
 
         async def head_reports_directory_as_denied(target, path):
@@ -270,6 +272,24 @@ class TestDeletePrefix:
             pytest.raises(StorageError) as exc_info,
         ):
             await delete_prefix("r", store)
+        assert "Failed to check root marker" in str(exc_info.value)
+
+    async def test_head_probe_plain_access_denied_still_raises(self, store) -> None:
+        """The directory-collision relaxation is conjunctive: a *plain*
+        "Access is denied" (no "Unable to open file …" directory-stat shape)
+        is a permission failure, not a missing marker, and must stay fatal."""
+        await _put("r2/a.txt", b"1", store, normalize=False)
+
+        async def denied(*args, **kwargs):
+            raise obstore.exceptions.GenericError("Access is denied. (os error 5)")
+
+        with (
+            patch(
+                "application_sdk.storage.batch.obstore.head_async", side_effect=denied
+            ),
+            pytest.raises(StorageError) as exc_info,
+        ):
+            await delete_prefix("r2", store)
         assert "Failed to check root marker" in str(exc_info.value)
 
 

--- a/tests/unit/storage/test_batch.py
+++ b/tests/unit/storage/test_batch.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import os
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
@@ -274,14 +275,67 @@ class TestDeletePrefix:
             await delete_prefix("r", store)
         assert "Failed to check root marker" in str(exc_info.value)
 
-    async def test_head_probe_plain_access_denied_still_raises(self, store) -> None:
+    async def test_fallback_awaits_sibling_cancellation_before_raising(
+        self, store
+    ) -> None:
+        """FND-341: the per-key fallback must not leave a delete in flight.
+
+        A delete that completes server-side *after* the caller has seen the
+        failure can land on a prefix the caller's retry has already rewritten, so
+        cancellation has to be awaited, not merely requested — the difference
+        between a TaskGroup and ``gather``.  Pinned by observing that the
+        surviving sibling has finished unwinding before the error propagates:
+        under ``gather`` the ``finally`` below would not have run yet.
+        """
+        await _put("w/bad.txt", b"1", store, normalize=False)
+        await _put("w/slow.txt", b"2", store, normalize=False)
+
+        unwound: list[str] = []
+
+        async def one_fails_one_hangs(target, paths):
+            if not isinstance(paths, str):
+                raise FileNotFoundError("Object at location w/bad.txt not found")
+            if paths == "w/bad.txt":
+                raise RuntimeError("permission denied")
+            try:
+                await asyncio.sleep(30)  # only ever ends via cancellation
+            finally:
+                unwound.append(paths)
+
+        with (
+            patch(
+                "application_sdk.storage.batch.obstore.delete_async",
+                side_effect=one_fails_one_hangs,
+            ),
+            pytest.raises(StorageError),
+        ):
+            await delete_prefix("w/", store, normalize=False)
+
+        assert unwound == ["w/slow.txt"]
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            obstore.exceptions.GenericError("Access is denied. (os error 5)"),
+            PermissionError("Access is denied"),
+        ],
+        ids=["obstore-generic", "builtin-permissionerror"],
+    )
+    async def test_head_probe_plain_access_denied_still_raises(
+        self, store, exc
+    ) -> None:
         """The directory-collision relaxation is conjunctive: a *plain*
         "Access is denied" (no "Unable to open file …" directory-stat shape)
-        is a permission failure, not a missing marker, and must stay fatal."""
+        is a permission failure, not a missing marker, and must stay fatal.
+
+        Covers both shapes it can arrive in: an obstore ``GenericError`` carrying
+        the OS message, and a bare built-in ``PermissionError`` — the latter is an
+        ``OSError``, so nothing about its class makes it look missing either.
+        """
         await _put("r2/a.txt", b"1", store, normalize=False)
 
         async def denied(*args, **kwargs):
-            raise obstore.exceptions.GenericError("Access is denied. (os error 5)")
+            raise exc
 
         with (
             patch(

--- a/tests/unit/storage/test_batch.py
+++ b/tests/unit/storage/test_batch.py
@@ -81,6 +81,15 @@ class TestListKeys:
 # ---------------------------------------------------------------------------
 
 
+class _ForeignBaseError(BaseException):
+    """A leaf ``ops.delete``'s ``except Exception`` cannot wrap.
+
+    Not ``SystemExit`` / ``KeyboardInterrupt``: asyncio re-raises those directly
+    into the event loop, so they never reach the TaskGroup's ExceptionGroup and
+    would not exercise the branch under test.
+    """
+
+
 def _bulk_delete_raising_not_found(vanished_key: str):
     """Side effect where the bulk (list) delete reports *vanished_key* as gone.
 
@@ -275,6 +284,33 @@ class TestDeletePrefix:
             await delete_prefix("r", store)
         assert "Failed to check root marker" in str(exc_info.value)
 
+    async def test_foreign_failure_in_fallback_is_not_demoted_to_a_cause(
+        self, store
+    ) -> None:
+        """Unwrapping the ExceptionGroup is only safe when every leaf is a
+        StorageError. A leaf that is not (here a BaseException, which
+        ``ops.delete``'s ``except Exception`` does not wrap) must reach the
+        caller as the group — demoting it to ``__cause__`` would leave it
+        reachable in a traceback but invisible to an ``except`` clause.
+        """
+        await _put("x/a.txt", b"1", store, normalize=False)
+
+        async def not_found_then_foreign(target, paths):
+            if isinstance(paths, str):
+                raise _ForeignBaseError("not an Exception subclass")
+            raise FileNotFoundError("Object at location x/a.txt not found")
+
+        with (
+            patch(
+                "application_sdk.storage.batch.obstore.delete_async",
+                side_effect=not_found_then_foreign,
+            ),
+            pytest.raises(BaseExceptionGroup) as exc_info,
+        ):
+            await delete_prefix("x/", store, normalize=False)
+
+        assert [type(leaf) for leaf in exc_info.value.exceptions] == [_ForeignBaseError]
+
     async def test_fallback_awaits_sibling_cancellation_before_raising(
         self, store
     ) -> None:
@@ -291,6 +327,7 @@ class TestDeletePrefix:
         await _put("w/slow.txt", b"2", store, normalize=False)
 
         unwound: list[str] = []
+        never_set = asyncio.Event()  # the sibling can only end via cancellation
 
         async def one_fails_one_hangs(target, paths):
             if not isinstance(paths, str):
@@ -298,10 +335,13 @@ class TestDeletePrefix:
             if paths == "w/bad.txt":
                 raise RuntimeError("permission denied")
             try:
-                await asyncio.sleep(30)  # only ever ends via cancellation
+                await never_set.wait()
             finally:
                 unwound.append(paths)
 
+        # wait_for bounds the whole call: if cancellation ever stops being
+        # delivered, this fails in seconds with a TimeoutError instead of
+        # parking the suite on the sibling.
         with (
             patch(
                 "application_sdk.storage.batch.obstore.delete_async",
@@ -309,7 +349,9 @@ class TestDeletePrefix:
             ),
             pytest.raises(StorageError),
         ):
-            await delete_prefix("w/", store, normalize=False)
+            await asyncio.wait_for(
+                delete_prefix("w/", store, normalize=False), timeout=5
+            )
 
         assert unwound == ["w/slow.txt"]
 

--- a/tests/unit/storage/test_batch.py
+++ b/tests/unit/storage/test_batch.py
@@ -163,7 +163,9 @@ class TestDeletePrefix:
         Uses a LocalStore rather than the MemoryStore fixture: only stores that
         report a missing key (local, GCS, Azure) can show the exclusion — S3 and
         MemoryStore treat deleting a gone key as success, so ``ops.delete``
-        legitimately counts it.
+        legitimately counts it.  The head probe is pinned to the Windows
+        directory-stat response (see below) so the test fails on every OS if
+        ``_is_not_found`` stops recognising it.
         """
         store = create_local_store(tmp_path / "store")
         await _put("t/gone.txt", b"1", store, normalize=False)
@@ -182,9 +184,31 @@ class TestDeletePrefix:
                 "Error performing DeleteObjects request"
             )
 
-        with patch(
-            "application_sdk.storage.batch.obstore.delete_async",
-            side_effect=bulk_deletes_one_then_hits_a_vanished_key,
+        # The root-marker probe for "t/" is the bare key "t", which the local
+        # store maps onto the *directory* holding the two keys.  POSIX reports
+        # that stat as not-found, but the Windows LocalStore raises
+        # GenericError("Access is denied") — a directory can never be an
+        # object, so the probe must read it as "no marker" on every OS.
+        # Pin that response so this regression is exercised everywhere.
+        real_head_async = obstore.head_async
+
+        async def head_reports_directory_as_denied(target, path):
+            if path == "t":
+                raise obstore.exceptions.GenericError(
+                    "Generic LocalFileSystem error: Unable to open file "
+                    f"{tmp_path / 'store' / 't'}: Access is denied. (os error 5)"
+                )
+            return await real_head_async(target, path)
+
+        with (
+            patch(
+                "application_sdk.storage.batch.obstore.delete_async",
+                side_effect=bulk_deletes_one_then_hits_a_vanished_key,
+            ),
+            patch(
+                "application_sdk.storage.batch.obstore.head_async",
+                side_effect=head_reports_directory_as_denied,
+            ),
         ):
             n = await delete_prefix("t/", store, normalize=False)
 

--- a/tests/unit/storage/test_batch.py
+++ b/tests/unit/storage/test_batch.py
@@ -6,8 +6,10 @@ import os
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
+import obstore
 import pytest
 
+from application_sdk.storage import batch as batch_module
 from application_sdk.storage.batch import (
     delete_prefix,
     download_prefix,
@@ -16,7 +18,7 @@ from application_sdk.storage.batch import (
     upload_prefix,
 )
 from application_sdk.storage.errors import StorageError
-from application_sdk.storage.factory import create_memory_store
+from application_sdk.storage.factory import create_local_store, create_memory_store
 from application_sdk.storage.ops import _get_bytes, _put
 
 
@@ -78,6 +80,27 @@ class TestListKeys:
 # ---------------------------------------------------------------------------
 
 
+def _bulk_delete_raising_not_found(vanished_key: str):
+    """Side effect where the bulk (list) delete reports *vanished_key* as gone.
+
+    Single-key deletes still reach the real store, so ``delete_prefix``'s
+    per-key fallback behaves as it would against GCS or Azure.  Patching
+    ``batch.obstore.delete_async`` patches the shared obstore module, which
+    ``ops.delete`` calls too — hence the passthrough rather than a blanket raise.
+    """
+    real_delete_async = obstore.delete_async
+
+    async def side_effect(target, paths):
+        if isinstance(paths, str):
+            return await real_delete_async(target, paths)
+        raise FileNotFoundError(
+            f"Object at location {vanished_key} not found: "
+            "Error performing DeleteObjects request"
+        )
+
+    return side_effect
+
+
 class TestDeletePrefix:
     async def test_deletes_all_under_prefix(self, store) -> None:
         await _put("p/a.txt", b"1", store, normalize=False)
@@ -96,12 +119,12 @@ class TestDeletePrefix:
         assert n == 0
 
     async def test_delete_async_failure_raises_storage_error(self, store) -> None:
-        """If obstore.delete_async raises (e.g. GCS 404 on concurrent modification),
+        """A genuine bulk-delete failure (not a vanished key) stays fatal:
         delete_prefix wraps it as StorageError rather than swallowing or retrying."""
         await _put("q/a.txt", b"1", store, normalize=False)
 
         async def boom(*args, **kwargs):
-            raise RuntimeError("simulated GCS not-found")
+            raise RuntimeError("connection reset by peer")
 
         with (
             patch(
@@ -111,6 +134,104 @@ class TestDeletePrefix:
         ):
             await delete_prefix("q/", store, normalize=False)
         assert "Failed to delete" in str(exc_info.value)
+
+    async def test_vanished_key_during_bulk_delete_is_benign(self, store) -> None:
+        """FND-341: a key that disappears between the listing and the bulk delete
+        must not fail the caller — the end state it wants is already true.
+
+        The per-key fallback also has to finish the job: obstore stops the bulk
+        delete at the first per-key failure, so the keys behind it are still
+        there and the prefix would otherwise be left half-deleted.
+        """
+        await _put("s/a.txt", b"1", store, normalize=False)
+        await _put("s/b.txt", b"2", store, normalize=False)
+
+        with patch(
+            "application_sdk.storage.batch.obstore.delete_async",
+            side_effect=_bulk_delete_raising_not_found("s/a.txt"),
+        ):
+            n = await delete_prefix("s/", store, normalize=False)
+
+        assert n == 2  # both keys still existed; the per-key pass removed them
+        assert await _get_bytes("s/a.txt", store, normalize=False) is None
+        assert await _get_bytes("s/b.txt", store, normalize=False) is None
+
+    async def test_vanished_key_is_not_counted_as_deleted(self, tmp_path) -> None:
+        """FND-341: the returned count reflects objects this call removed, so a
+        key the race already took is excluded.
+
+        Uses a LocalStore rather than the MemoryStore fixture: only stores that
+        report a missing key (local, GCS, Azure) can show the exclusion — S3 and
+        MemoryStore treat deleting a gone key as success, so ``ops.delete``
+        legitimately counts it.
+        """
+        store = create_local_store(tmp_path / "store")
+        await _put("t/gone.txt", b"1", store, normalize=False)
+        await _put("t/here.txt", b"2", store, normalize=False)
+
+        real_delete_async = obstore.delete_async
+
+        async def bulk_deletes_one_then_hits_a_vanished_key(target, paths):
+            if isinstance(paths, str):
+                return await real_delete_async(target, paths)
+            # Emulate a partially-applied bulk delete: "t/gone.txt" is removed by
+            # the concurrent writer we are racing, then the store reports it.
+            await real_delete_async(target, "t/gone.txt")
+            raise FileNotFoundError(
+                "Object at location t/gone.txt not found: "
+                "Error performing DeleteObjects request"
+            )
+
+        with patch(
+            "application_sdk.storage.batch.obstore.delete_async",
+            side_effect=bulk_deletes_one_then_hits_a_vanished_key,
+        ):
+            n = await delete_prefix("t/", store, normalize=False)
+
+        assert n == 1  # only "t/here.txt" was actually removed by this call
+        assert await _get_bytes("t/here.txt", store, normalize=False) is None
+
+    async def test_vanished_key_is_reported_as_a_warning(self, store) -> None:
+        """FND-341: the 'two apps share this prefix' signal is kept — as a
+        WARNING naming the prefix, not as an exception."""
+        await _put("u/a.txt", b"1", store, normalize=False)
+
+        with (
+            patch(
+                "application_sdk.storage.batch.obstore.delete_async",
+                side_effect=_bulk_delete_raising_not_found("u/a.txt"),
+            ),
+            patch.object(batch_module.logger, "warning") as warn,
+        ):
+            await delete_prefix("u/", store, normalize=False)
+
+        assert warn.call_count == 1
+        message, *args = warn.call_args.args
+        assert "vanished" in message
+        assert "u/" in args
+        assert "u/a.txt" in str(args[-1])
+
+    async def test_genuine_failure_in_per_key_fallback_still_raises(
+        self, store
+    ) -> None:
+        """The fallback is idempotent, not forgiving: a real error during the
+        per-key pass surfaces as StorageError."""
+        await _put("v/a.txt", b"1", store, normalize=False)
+
+        async def not_found_then_denied(target, paths):
+            if isinstance(paths, str):
+                raise RuntimeError("permission denied")
+            raise FileNotFoundError("Object at location v/a.txt not found")
+
+        with (
+            patch(
+                "application_sdk.storage.batch.obstore.delete_async",
+                side_effect=not_found_then_denied,
+            ),
+            pytest.raises(StorageError) as exc_info,
+        ):
+            await delete_prefix("v/", store, normalize=False)
+        assert "Failed to delete key" in str(exc_info.value)
 
     async def test_head_probe_non404_raises_storage_error(self, store) -> None:
         """If head_async raises a non-404 error during root-marker probe,

--- a/tests/unit/storage/test_ops.py
+++ b/tests/unit/storage/test_ops.py
@@ -439,6 +439,70 @@ class TestIsNotFound:
         assert _is_not_found(RuntimeError("got HTTP 404 from S3")) is True
         assert _is_not_found(RuntimeError("key not found in bucket")) is True
 
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "Access is denied. (os error 5)",
+            "Unable to open file /tmp/t: Access is denied. (os error 5)",
+            "Is a directory (os error 21)",
+            "403 Forbidden: caller lacks storage.objects.delete",
+        ],
+        ids=["denied", "denied-opening-a-directory", "is-a-directory", "http-403"],
+    )
+    def test_permission_and_io_wordings_are_never_not_found(self, message) -> None:
+        """FND-341: this helper backs delete(), exists(), the chunked download and
+        delete_prefix, so anything it calls not-found is downgraded fleet-wide —
+        delete()/exists() return False, delete_prefix() takes its benign path.
+        A permission or I/O failure must never reach those paths; it has to raise.
+
+        The Windows directory-stat shape is listed deliberately: the narrow
+        relaxation for it lives in :func:`_is_local_dir_collision` and is consulted
+        at exactly one call site, never widened into this shared classifier.
+        """
+        from application_sdk.storage.ops import _is_not_found
+
+        assert _is_not_found(RuntimeError(message)) is False
+
+
+class TestIsLocalDirCollision:
+    """A local store key that resolves to a directory is 'no object', not a 403.
+
+    The predicate is conjunctive on purpose (FND-341): matching "access is
+    denied" alone would reclassify genuine permission failures as missing keys.
+    """
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            # Windows LocalStore stat of a directory.
+            "Generic LocalFileSystem error: Unable to open file "
+            "C:\\store\\t: Access is denied. (os error 5)",
+            # POSIX open() of a directory, should a backend surface it that way.
+            "Generic LocalFileSystem error: Unable to open file "
+            "/store/t: Is a directory (os error 21)",
+        ],
+        ids=["windows-access-denied", "posix-is-a-directory"],
+    )
+    def test_recognises_the_directory_stat_shapes(self, message) -> None:
+        from application_sdk.storage.ops import _is_local_dir_collision
+
+        assert _is_local_dir_collision(RuntimeError(message)) is True
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "Access is denied. (os error 5)",
+            "403 Forbidden: caller lacks storage.objects.get",
+            "Unable to open file /store/a.txt: Too many open files (os error 24)",
+            "internal failure",
+        ],
+        ids=["bare-denied", "http-403", "unrelated-open-failure", "unrelated"],
+    )
+    def test_does_not_match_permission_or_unrelated_failures(self, message) -> None:
+        from application_sdk.storage.ops import _is_local_dir_collision
+
+        assert _is_local_dir_collision(RuntimeError(message)) is False
+
 
 # ---------------------------------------------------------------------------
 # Structured transfer logs (BLDX-1155 #6: surface what's actually happening)

--- a/tests/unit/storage/test_ops.py
+++ b/tests/unit/storage/test_ops.py
@@ -14,7 +14,7 @@ import pytest
 from application_sdk import constants
 from application_sdk.storage.batch import download_prefix, list_keys
 from application_sdk.storage.errors import StorageError, StorageNotFoundError
-from application_sdk.storage.factory import create_memory_store
+from application_sdk.storage.factory import create_local_store, create_memory_store
 from application_sdk.storage.ops import (
     _get_bytes,
     _put,
@@ -467,41 +467,118 @@ class TestIsNotFound:
 class TestIsLocalDirCollision:
     """A local store key that resolves to a directory is 'no object', not a 403.
 
-    The predicate is conjunctive on purpose (FND-341): matching "access is
-    denied" alone would reclassify genuine permission failures as missing keys.
+    FND-341: the relaxation exists so the root-marker probe does not read a
+    directory stat as a permission failure. It must be decided by what the key
+    resolves to — never by message wording alone, which would reclassify a
+    genuine failure that happens to be worded the same way.
     """
 
-    @pytest.mark.parametrize(
-        "message",
-        [
-            # Windows LocalStore stat of a directory.
-            "Generic LocalFileSystem error: Unable to open file "
-            "C:\\store\\t: Access is denied. (os error 5)",
-            # POSIX open() of a directory, should a backend surface it that way.
-            "Generic LocalFileSystem error: Unable to open file "
-            "/store/t: Is a directory (os error 21)",
-        ],
-        ids=["windows-access-denied", "posix-is-a-directory"],
+    # The wording a Windows LocalStore produces when it stats a directory; used
+    # to prove the *facts* outrank it in both directions.
+    WINDOWS_DIR_STAT = (
+        "Generic LocalFileSystem error: Unable to open file "
+        "C:\\store\\t: Access is denied. (os error 5)"
     )
-    def test_recognises_the_directory_stat_shapes(self, message) -> None:
+
+    def test_directory_key_is_a_collision(self, tmp_path) -> None:
         from application_sdk.storage.ops import _is_local_dir_collision
 
-        assert _is_local_dir_collision(RuntimeError(message)) is True
+        store = create_local_store(tmp_path)
+        (tmp_path / "t").mkdir()
 
-    @pytest.mark.parametrize(
-        "message",
-        [
-            "Access is denied. (os error 5)",
-            "403 Forbidden: caller lacks storage.objects.get",
-            "Unable to open file /store/a.txt: Too many open files (os error 24)",
-            "internal failure",
-        ],
-        ids=["bare-denied", "http-403", "unrelated-open-failure", "unrelated"],
-    )
-    def test_does_not_match_permission_or_unrelated_failures(self, message) -> None:
+        assert (
+            _is_local_dir_collision(RuntimeError(self.WINDOWS_DIR_STAT), store, "t")
+            is True
+        )
+
+    def test_nested_directory_key_is_a_collision(self, tmp_path) -> None:
+        """Keys are '/'-separated regardless of the host OS separator."""
         from application_sdk.storage.ops import _is_local_dir_collision
 
-        assert _is_local_dir_collision(RuntimeError(message)) is False
+        store = create_local_store(tmp_path)
+        (tmp_path / "a" / "b").mkdir(parents=True)
+
+        assert (
+            _is_local_dir_collision(RuntimeError(self.WINDOWS_DIR_STAT), store, "a/b")
+            is True
+        )
+
+    def test_unreadable_file_is_not_a_collision(self, tmp_path) -> None:
+        """The case a message match would get wrong: an inaccessible *file* at
+        the key. It is a real permission failure and must stay fatal, even
+        though the error is worded exactly like the directory stat."""
+        from application_sdk.storage.ops import _is_local_dir_collision
+
+        store = create_local_store(tmp_path)
+        (tmp_path / "t").write_bytes(b"x")
+
+        assert (
+            _is_local_dir_collision(RuntimeError(self.WINDOWS_DIR_STAT), store, "t")
+            is False
+        )
+
+    def test_missing_key_is_not_a_collision(self, tmp_path) -> None:
+        """Nothing at the key at all — `_is_not_found` owns that, not this."""
+        from application_sdk.storage.ops import _is_local_dir_collision
+
+        store = create_local_store(tmp_path)
+
+        assert (
+            _is_local_dir_collision(RuntimeError(self.WINDOWS_DIR_STAT), store, "t")
+            is False
+        )
+
+    def test_non_local_store_is_never_a_collision(self) -> None:
+        """Cloud backends have no directories, so a 403 worded like Windows'
+        ERROR_ACCESS_DENIED must not be reclassified as a missing object."""
+        from application_sdk.storage.ops import _is_local_dir_collision
+
+        store = create_memory_store()
+
+        assert (
+            _is_local_dir_collision(RuntimeError(self.WINDOWS_DIR_STAT), store, "t")
+            is False
+        )
+
+    @pytest.mark.parametrize(
+        "message,expected",
+        [
+            (WINDOWS_DIR_STAT, True),
+            (
+                "Generic LocalFileSystem error: Unable to open file "
+                "/store/t: Is a directory (os error 21)",
+                True,
+            ),
+            ("Access is denied. (os error 5)", False),
+            ("403 Forbidden: caller lacks storage.objects.get", False),
+            (
+                "Unable to open file /store/a.txt: Too many open files (os error 24)",
+                False,
+            ),
+            ("internal failure", False),
+        ],
+        ids=[
+            "windows-dir-stat",
+            "posix-is-a-directory",
+            "bare-denied",
+            "http-403",
+            "unrelated-open-failure",
+            "unrelated",
+        ],
+    )
+    def test_rootless_store_falls_back_to_the_conjunctive_message_shape(
+        self, message, expected
+    ) -> None:
+        """A LocalStore with no prefix cannot resolve a key to a path here, so
+        the message shape is all there is — and it stays conjunctive."""
+        from obstore.store import LocalStore
+
+        from application_sdk.storage.ops import _is_local_dir_collision
+
+        store = LocalStore()
+        assert store.prefix is None  # premise of the fallback branch
+
+        assert _is_local_dir_collision(RuntimeError(message), store, "t") is expected
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/storage/test_ops.py
+++ b/tests/unit/storage/test_ops.py
@@ -503,10 +503,11 @@ class TestIsLocalDirCollision:
             is True
         )
 
-    def test_unreadable_file_is_not_a_collision(self, tmp_path) -> None:
-        """The case a message match would get wrong: an inaccessible *file* at
-        the key. It is a real permission failure and must stay fatal, even
-        though the error is worded exactly like the directory stat."""
+    def test_regular_file_is_not_a_collision(self, tmp_path) -> None:
+        """A regular *file* at the key is not a directory collision, even
+        though the error is worded exactly like the directory stat. ``is_dir``
+        is ``False`` for a file, so the probe leaves the failure fatal — this
+        pins the dangerous ``is_dir() == True`` regression direction."""
         from application_sdk.storage.ops import _is_local_dir_collision
 
         store = create_local_store(tmp_path)


### PR DESCRIPTION
### Changelog

- `delete_prefix` no longer fails the caller when a key vanishes between its listing and its bulk delete. The desired end state for that key — gone — is reached either way, so a not-found from `obstore.delete_async` is now benign. Every other error still raises `StorageError`.
- The "two apps are writing the same prefix" signal is kept, as a WARNING naming the prefix and quoting the store error (which carries the vanished key), instead of an exception.
- On the race path the deletes are re-run one key at a time through the idempotent `ops.delete` (bounded at 10 concurrent, matching obstore's fan-out for stores without a native bulk delete). `obstore.delete_async(store, paths)` is all-or-nothing to the caller — it names at most one key and stops at the first per-key failure — so from the `except` block neither which key vanished nor whether the rest of the batch was deleted is knowable. A bare `continue` would return a wrong count *and* leave every key behind the failure point in place, after which `ParquetFileWriter._ensure_prefix_replaced` writes new chunks into a prefix that still holds stale ones — the exact corruption `replace_prefix` exists to prevent. The per-key pass both empties the prefix and makes the returned count reflect only what this call removed.
- 4 regression tests in `TestDeletePrefix`; the pre-existing `test_delete_async_failure_raises_storage_error` was reworded (its docstring claimed to cover "GCS 404 on concurrent modification", now the benign path, and its simulated message only missed `_is_not_found` by a hyphen).

### Additional context (e.g. screenshots, logs, links)

- FND-341 — rationale and the deviation from the ticket's proposed fix are recorded on the issue.
- Escalation path: the only in-SDK caller, `ParquetFileWriter._ensure_prefix_replaced`, catches only `ObjectStoreNotProvidedError`, so a `StorageError` from `delete_prefix` propagated out of the writer and killed the activity as an `ApplicationError` — a benign race surfacing as a customer-visible crawl failure.
- Regression window: 3.0.0–3.3.0 looped over the idempotent per-key `ops.delete` and could not fail this way; 3.4.0 moved to the bulk call with not-found fatal; unchanged through 3.27.2.
- Consistency: `ops.delete()` returns `False` on not-found and `App.cleanup_storage()` downgrades every delete error to a warning + `error_count`. `delete_prefix` was the odd one out.
- Safety property worth noting in review: because `_is_not_found` has a substring fallback (`"404"`, `"not found"`), a misclassified genuine error is not silently swallowed — it is re-issued per key and raises from there.
- `ParquetFileWriter._ensure_prefix_replaced` is deliberately unchanged: a genuine `StorageError` should still fail the activity.
- Verification: `tests/unit/storage` 908 passed / 3 skipped; localfs storage integration 21 passed; full conformance suite 0 unsuppressed blocking violations; pre-commit clean (ruff, ruff-format, isort, pyright).

### Checklist

- [x] Additional tests added
- [ ] All CI checks passed
- [x] Relevant documentation updated <!-- docstring only: no public signature or docstring-summary change, so the capability manifest needs no refresh, and no conceptual doc documents delete_prefix's error semantics -->

---

### Copyleft License Compliance

- [ ] Have you used any code that is subject to a Copyleft license (e.g., GPL, AGPL, LGPL)?
- [ ] If yes, have you modified the code in the context of this project? please share additional details.
