### PR TITLE
fix(handler): stop credential config writes from destroying the record

### DIFF
--- a/application_sdk/constants.py
+++ b/application_sdk/constants.py
@@ -129,6 +129,21 @@ PREFLIGHT_GATE_MODE_ENV = "ATLAN_PREFLIGHT_GATE_MODE"
 # In Docker (WORKDIR=/app, app code at /app/app/) this resolves to /app/app/generated.
 CONTRACT_GENERATED_DIR = os.environ.get("ATLAN_CONTRACT_GENERATED_DIR", "app/generated")
 
+# Enforcement mode for the credential config.json write guard, which refuses to
+# let POST /workflows/v1/config/{guid}?type=credentials drop a required,
+# non-secret field the stored record already carries (authType, host, port).
+# See application_sdk.handler.credential_config.
+#
+#   "repair" (default) — restore the dropped fields from the stored record, log
+#       a warning, return 200. Chosen as the default because it preserves the
+#       record without changing any caller's success/failure contract: a client
+#       that treats a 4xx here as fatal cannot be broken by it.
+#   "reject"           — return 422 naming the dropped fields. Prevents the bad
+#       write and surfaces the offending caller, but a client that treats the
+#       failure as fatal will fail the enclosing operation.
+#   "off"              — legacy behaviour, blind overwrite.
+CREDENTIAL_CONFIG_GUARD = os.getenv("ATLAN_CREDENTIAL_CONFIG_GUARD", "repair").lower()
+
 # Cleanup Paths (custom paths for cleanup operations, supports multiple paths separated by comma)
 # If empty, cleanup activities will default to workflow-specific paths at runtime
 CLEANUP_BASE_PATHS = [

--- a/application_sdk/handler/credential_config.py
+++ b/application_sdk/handler/credential_config.py
@@ -1,0 +1,369 @@
+"""Non-destructive guard for the materialised credential ``config.json``.
+
+``POST /workflows/v1/config/{guid}?type=credentials`` is a blind, whole-object
+PUT: the body is never schema-checked (only the path params are) and
+:func:`~application_sdk.storage.ops.put_json` overwrites unconditionally. A
+request that carries a GUID but an empty body therefore replaces a complete
+credential record with ``{"credentialSource": "direct"}``.
+
+That loses exactly the fields with no redundant copy. A credential is assembled
+at run time from two stores:
+
+* **Vault** — ``username`` / ``password`` / ``extra``. Survives, because
+  :meth:`DaprCredentialVault.get_credentials` merges the secret half *over* the
+  object-store half with ``dict.update`` (add-only).
+* **Object store** (this file) — ``authType`` / ``host`` / ``port`` /
+  ``connectorType`` / ``name`` / ``connectorConfigName``. Gone for good.
+
+So the fields that *select* the auth branch and the API endpoint are the ones
+with no backup, while everything the branch then consumes is stored twice. This
+module closes that inversion at the write, using the schema the app already
+ships.
+
+Where the schema comes from
+---------------------------
+Each connector generates a credential configmap from its ``credentials.pkl``
+contract into ``CONTRACT_GENERATED_DIR`` — e.g.
+``app/generated/crawler/atlan-connectors-bigquery.json``. The handler service
+already reads these files to serve ``/workflows/v1/configmap/{id}``, so the
+schema is on the same disk in the same process as the write endpoint. This
+module reads the ``config`` block of the file named by the record's
+``connectorConfigName``.
+
+The dialect is **not** JSON Schema
+----------------------------------
+It is the Atlan form-toolkit dialect, and three differences matter:
+
+* ``"type": "conditional"`` is not a JSON Schema type. BigQuery declares
+  ``host``/``port`` conditional on ``extra.connect_type == "private"``;
+  Snowflake and Databricks declare them unconditionally required.
+* ``"required": true`` sits *inside* a property, not as an array on the parent.
+* ``anyOf`` addresses **dotted paths** — ``{"properties": {"extra.connect_type":
+  {"const": "private"}}, "required": ["host"]}``. Under real JSON Schema
+  semantics that branch never binds (the sibling ``auth-type`` branch already
+  passes, and no property is literally named ``extra.connect_type``), so a
+  stock ``jsonschema.validate`` would report PASS on precisely the body this
+  module exists to catch.
+
+Hence a small dialect-aware evaluator rather than a JSON Schema library.
+
+What is deliberately *not* checked
+---------------------------------
+Secret-bearing fields, because Heracles strips them before this endpoint ever
+sees them — demanding them would reject every legitimate write:
+
+* the per-auth-type branch objects named by ``anyOf`` (``basic``, ``gcp-wif``,
+  ``keypair``, ``aws_service``, …). These *are* the secret containers:
+  BigQuery's ``basic`` holds ``username`` + ``password``; its ``gcp-wif`` holds
+  ``atlan_oauth_secret``.
+* top-level ``username`` / ``password``.
+* any ``extra`` key whose name matches :data:`_SECRET_NAME_RE` — the same
+  ``secret`` / ``private_key`` / ``passphrase`` / ``password`` family Heracles
+  redacts from its ``extra`` copy.
+
+Enum values are not policed either. The schema enumerates form values
+(``basic``, ``gcp-wif``) while stored records legitimately carry the runtime
+alias (``service_account``), so an enum check would reject working credentials.
+Presence is the only thing asserted.
+
+The check is a *transition* check
+--------------------------------
+Nothing here decides whether a credential is valid in the abstract — only
+whether this write **drops a required field the stored record already had**.
+That keeps three legitimate flows untouched:
+
+* a first-ever create (no stored object ⇒ nothing can be dropped),
+* a value change (``authType`` basic → gcp-wif),
+* dropping a field that is no longer required — switching BigQuery from
+  Private Network Link back to public sends ``extra.connect_type: "public"``
+  and omits ``host``, and because the requirement is evaluated *conditionally*
+  against the incoming body, ``host`` is correctly not demanded.
+
+See ``ATLAN_CREDENTIAL_CONFIG_GUARD`` in :mod:`application_sdk.constants` for
+the enforcement modes.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+from application_sdk.observability.logger_adaptor import get_logger
+
+logger = get_logger(__name__)
+
+__all__ = [
+    "GUARD_MODE_OFF",
+    "GUARD_MODE_REJECT",
+    "GUARD_MODE_REPAIR",
+    "dropped_required_fields",
+    "load_credential_schema",
+    "repair_dropped_fields",
+]
+
+GUARD_MODE_REPAIR = "repair"
+GUARD_MODE_REJECT = "reject"
+GUARD_MODE_OFF = "off"
+
+#: ``extra`` keys Heracles redacts from the object-store copy. Mirrors
+#: ``stripSensitiveCredentialFields`` — a field matching this never reaches the
+#: endpoint, so it must never be required.
+_SECRET_NAME_RE = re.compile(
+    r"secret|password|passphrase|private[_-]?key|token", re.IGNORECASE
+)
+
+#: Top-level credential fields that live only in Vault.
+_VAULT_ONLY_FIELDS = frozenset({"username", "password"})
+
+
+def load_credential_schema(
+    record: dict[str, Any],
+    existing: dict[str, Any] | None,
+    generated_dir: Path,
+) -> dict[str, Any] | None:
+    """Return the ``config`` block of the record's credential configmap.
+
+    The schema is located by ``connectorConfigName``, read from the incoming
+    body first and the stored record second — the stub body that motivates this
+    module carries no ``connectorConfigName``, so the stored copy is what
+    identifies it.
+
+    Returns ``None`` whenever the schema cannot be identified or read, which
+    makes the guard a no-op. An app that ships no credential configmap, or a
+    record predating the contract, must not be blocked from saving.
+    """
+    name = (record.get("connectorConfigName") or "") or (
+        (existing or {}).get("connectorConfigName") or ""
+    )
+    if not isinstance(name, str) or not name.strip():
+        return None
+    name = name.strip()
+
+    if not generated_dir.exists():
+        return None
+
+    for json_file in generated_dir.rglob("*.json"):
+        if json_file.stem != name:
+            continue
+        try:
+            import orjson  # noqa: PLC0415 — cold path: only on a credential write
+
+            payload = orjson.loads(json_file.read_bytes())
+        except Exception:
+            logger.warning(
+                "Credential configmap %s is unreadable; skipping the config guard",
+                name,
+                exc_info=True,
+            )
+            return None
+        config = payload.get("config")
+        return config if isinstance(config, dict) else None
+    return None
+
+
+def _auth_branch_names(schema: dict[str, Any]) -> set[str]:
+    """Object names that hold per-auth-type secrets, taken from ``anyOf``.
+
+    A branch is ``{"properties": {"auth-type": {"const": X}}, "required": [Y]}``
+    — ``Y`` is the object carrying that auth type's fields. Those objects never
+    survive Heracles' strip, so they are excluded from the required set. Derived
+    from the schema rather than hardcoded, so a connector adding an auth type
+    needs no change here.
+    """
+    names: set[str] = set()
+    for branch in schema.get("anyOf") or []:
+        if not isinstance(branch, dict):
+            continue
+        props = branch.get("properties")
+        if not isinstance(props, dict):
+            continue
+        if not any(_property_aliases(key) & {"auth-type"} for key in props):
+            continue
+        for required in branch.get("required") or []:
+            if isinstance(required, str):
+                names.add(required)
+    return names
+
+
+def _property_aliases(name: str) -> set[str]:
+    """Spellings of a schema property name that a stored record may use.
+
+    The contract declares kebab-case (``auth-type``) while stored records carry
+    camelCase (``authType``); some producers send snake_case. All three are the
+    same field.
+    """
+    kebab = name.replace("_", "-")
+    snake = name.replace("-", "_")
+    head, *rest = snake.split("_")
+    camel = head + "".join(part[:1].upper() + part[1:] for part in rest)
+    return {name, kebab, snake, camel}
+
+
+def _resolve_alias(segment: str, mapping: Any) -> str | None:
+    """The spelling of ``segment`` that ``mapping`` actually uses, if any."""
+    if not isinstance(mapping, dict):
+        return None
+    for alias in _property_aliases(segment):
+        if alias in mapping:
+            return alias
+    return None
+
+
+def _lookup(record: dict[str, Any], dotted: str) -> Any:
+    """Read a possibly-dotted path, trying every alias at each segment."""
+    current: Any = record
+    for segment in dotted.split("."):
+        alias = _resolve_alias(segment, current)
+        if alias is None:
+            return None
+        current = current[alias]
+    return current
+
+
+def _is_present(record: dict[str, Any], dotted: str) -> bool:
+    """True when the path resolves to a non-blank value.
+
+    A key present with ``None`` or ``""`` counts as absent: an empty
+    ``authType`` selects no auth branch and an empty ``host`` resolves to the
+    public endpoint, so both are losses in every way that matters.
+    """
+    value = _lookup(record, dotted)
+    if value is None:
+        return False
+    if isinstance(value, str) and not value.strip():
+        return False
+    return True
+
+
+def _required_fields(schema: dict[str, Any], record: dict[str, Any]) -> list[str]:
+    """Non-secret fields the schema requires *for this record*.
+
+    ``record`` decides the conditional requirements, so it should be the
+    effective post-write shape (stored merged with incoming).
+    """
+    properties = schema.get("properties")
+    if not isinstance(properties, dict):
+        return []
+
+    excluded = _auth_branch_names(schema) | _VAULT_ONLY_FIELDS
+    required: list[str] = []
+
+    for name, spec in properties.items():
+        if name in excluded or not isinstance(spec, dict):
+            continue
+        if _SECRET_NAME_RE.search(name):
+            continue
+
+        if spec.get("required") is True:
+            required.append(name)
+
+        # A conditional field is required only when its condition holds — this
+        # is what lets a private → public switch legitimately drop ``host``.
+        if spec.get("type") == "conditional":
+            for condition in spec.get("conditions") or []:
+                if not isinstance(condition, dict) or not condition.get("required"):
+                    continue
+                target = condition.get("property")
+                if not isinstance(target, str):
+                    continue
+                if _lookup(record, target) == condition.get("value"):
+                    required.append(name)
+                    break
+
+        # One level of nesting covers `extra`, the only nested object in the
+        # credential contracts. Secret-named children are skipped: Heracles
+        # redacts them from this copy.
+        if spec.get("type") == "object":
+            children = spec.get("properties")
+            if not isinstance(children, dict):
+                continue
+            for child, child_spec in children.items():
+                if not isinstance(child_spec, dict):
+                    continue
+                if child_spec.get("required") is not True:
+                    continue
+                if _SECRET_NAME_RE.search(child) or child in _VAULT_ONLY_FIELDS:
+                    continue
+                required.append(f"{name}.{child}")
+
+    return required
+
+
+def dropped_required_fields(
+    incoming: dict[str, Any],
+    existing: dict[str, Any] | None,
+    schema: dict[str, Any] | None,
+) -> list[str]:
+    """Required, non-secret fields the stored record has and the write loses.
+
+    Empty when there is no schema, no stored record, or the write preserves
+    everything required — the guard only ever fires on a genuine regression of
+    the stored object.
+    """
+    if not schema or not existing:
+        return []
+
+    effective = {**existing, **incoming}
+    return [
+        field
+        for field in _required_fields(schema, effective)
+        if _is_present(existing, field) and not _is_present(incoming, field)
+    ]
+
+
+def _assign(
+    record: dict[str, Any],
+    dotted: str,
+    value: Any,
+    reference: dict[str, Any] | None = None,
+) -> None:
+    """Set a possibly-dotted path using the spelling already in use.
+
+    Alias preference is: whatever ``record`` already uses, else whatever
+    ``reference`` (the stored record) uses, else the schema's own spelling.
+
+    The middle case carries the weight. A stub body has no spelling of its own,
+    and the contract declares kebab-case (``auth-type``) while stored records and
+    every runtime reader use camelCase (``authType``) — so defaulting to the
+    schema name would "restore" a field nothing reads, leaving the credential
+    just as broken but now silently.
+    """
+    segments = dotted.split(".")
+    current = record
+    ref: Any = reference or {}
+    for segment in segments[:-1]:
+        key = (
+            _resolve_alias(segment, current) or _resolve_alias(segment, ref) or segment
+        )
+        nested = current.get(key)
+        if not isinstance(nested, dict):
+            nested = {}
+            current[key] = nested
+        current = nested
+        ref_alias = _resolve_alias(segment, ref)
+        ref = ref[ref_alias] if ref_alias is not None else {}
+    leaf = segments[-1]
+    key = _resolve_alias(leaf, current) or _resolve_alias(leaf, ref) or leaf
+    current[key] = value
+
+
+def repair_dropped_fields(
+    incoming: dict[str, Any],
+    existing: dict[str, Any],
+    fields: list[str],
+) -> dict[str, Any]:
+    """Backfill only ``fields`` from ``existing`` onto a copy of ``incoming``.
+
+    Deliberately not a full merge: a blind ``{**existing, **incoming}`` would
+    also resurrect fields the caller meant to remove — a stale private-link
+    ``host`` outliving a switch back to the public endpoint, for instance.
+    Restoring exactly the required fields that went missing keeps every
+    intentional edit intact.
+    """
+    import copy  # noqa: PLC0415 — cold path: only on a detected drop
+
+    repaired = copy.deepcopy(incoming)
+    for field in fields:
+        _assign(repaired, field, _lookup(existing, field), reference=existing)
+    return repaired

--- a/application_sdk/handler/service.py
+++ b/application_sdk/handler/service.py
@@ -1091,6 +1091,80 @@ async def _config_save_to_objectstore(
     return True
 
 
+async def _guard_credential_config(
+    config_id: str, body: dict[str, Any]
+) -> dict[str, Any]:
+    """Stop a credential write from dropping fields that have no Vault copy.
+
+    ``authType``, ``host`` and ``port`` live only in this object, so a body that
+    omits them destroys them — see
+    :mod:`application_sdk.handler.credential_config` for the full asymmetry and
+    why the check is schema-driven rather than a blind merge.
+
+    Returns the body to persist: unchanged when the write preserves everything
+    required, repaired when ``ATLAN_CREDENTIAL_CONFIG_GUARD=repair`` (default),
+    and raises ``HTTPException(422)`` under ``reject``. Any internal failure
+    degrades to the unmodified body — a guard defect must not make credentials
+    unsavable.
+    """
+    from application_sdk.constants import (  # noqa: PLC0415 — cold path: only on a credential write
+        CREDENTIAL_CONFIG_GUARD,
+    )
+    from application_sdk.handler import (  # noqa: PLC0415 — circular: handler/__init__.py imports this module
+        credential_config,
+    )
+
+    if CREDENTIAL_CONFIG_GUARD == credential_config.GUARD_MODE_OFF:
+        return body
+
+    try:
+        existing = await _config_load_from_objectstore(
+            config_id, config_type="credentials"
+        )
+        schema = credential_config.load_credential_schema(
+            body, existing, CONTRACT_GENERATED_DIR
+        )
+        dropped = credential_config.dropped_required_fields(body, existing, schema)
+    except Exception:
+        logger.warning(
+            "Credential config guard failed for %s; saving the body unmodified",
+            config_id,
+            exc_info=True,
+        )
+        return body
+
+    if not dropped:
+        return body
+
+    # Field NAMES only — never a value. This object holds credential material.
+    if CREDENTIAL_CONFIG_GUARD == credential_config.GUARD_MODE_REJECT:
+        logger.error(
+            "Rejected credential config write for %s: would drop required "
+            "field(s) %s present in the stored record",
+            config_id,
+            ", ".join(dropped),
+        )
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"Credential config write would drop required field(s) "
+                f"{', '.join(dropped)} present in the stored record for "
+                f"{config_id}. Send the complete credential body, or omit the "
+                f"credential from this request to leave the stored record "
+                f"untouched."
+            ),
+        )
+
+    logger.warning(
+        "Repaired credential config write for %s: restored required field(s) %s "
+        "that the incoming body dropped. The caller sent an incomplete "
+        "credential body — this is a client defect, not a stored-record defect.",
+        config_id,
+        ", ".join(dropped),
+    )
+    return credential_config.repair_dropped_fields(body, existing or {}, dropped)
+
+
 async def _provision_local_vault(guid: str, body: dict[str, Any]) -> JSONResponse:
     """Split credentials into sensitive/non-sensitive and persist locally.
 
@@ -1650,6 +1724,9 @@ def _register_workflow_routes(
                 DeprecationWarning,
                 stacklevel=2,
             )
+
+        if type == "credentials" and isinstance(body, dict):
+            body = await _guard_credential_config(config_id, body)
 
         saved = await _config_save_to_objectstore(config_id, body, config_type=type)
 

--- a/tests/unit/handler/test_credential_config.py
+++ b/tests/unit/handler/test_credential_config.py
@@ -1,0 +1,480 @@
+"""Tests for the credential ``config.json`` write guard.
+
+The failure being prevented: a ``POST /workflows/v1/config/{guid}?type=credentials``
+carrying a GUID but an effectively-empty body replaces a complete credential
+record with ``{"credentialSource": "direct"}``. That destroys ``authType`` /
+``host`` / ``port``, which have no copy in Vault, while everything the auth
+branch consumes (``password``, ``extra``) survives — so the corruption is
+invisible for service-account connections (the app's ``.get()`` default lands on
+the right branch by accident) and fatal for Workload Identity Federation.
+
+The schemas below are trimmed from real generated credential configmaps
+(``app/generated/*/atlan-connectors-*.json``) and keep the three shapes that
+matter:
+
+* **BigQuery** — ``host``/``port`` are ``type: "conditional"``, required only
+  when ``extra.connect_type == "private"``; ``extra.connect_type`` is required;
+  auth branches are ``basic`` / ``gcp-wif``.
+* **Snowflake** — ``host``/``port`` unconditionally required, five auth
+  branches. Proves the guard needs no per-connector code.
+* **Databricks** — same unconditional shape, three auth branches.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import orjson
+import pytest
+
+from application_sdk.handler.credential_config import (
+    dropped_required_fields,
+    load_credential_schema,
+    repair_dropped_fields,
+)
+
+# ---------------------------------------------------------------------------
+# Schemas (trimmed from the real generated configmaps)
+# ---------------------------------------------------------------------------
+
+_BIGQUERY_SCHEMA: dict[str, Any] = {
+    "properties": {
+        "name": {"type": "string", "required": False},
+        "connector": {"type": "string", "required": False},
+        "connectorType": {"type": "string", "required": False},
+        "extra": {
+            "type": "object",
+            "properties": {
+                "connect_type": {
+                    "type": "string",
+                    "required": True,
+                    "enum": ["public", "private"],
+                    "default": "public",
+                }
+            },
+        },
+        "host": {
+            "type": "conditional",
+            "required": False,
+            "default": "https://bigquery.googleapis.com",
+            "conditions": [
+                {
+                    "property": "extra.connect_type",
+                    "value": "private",
+                    "required": True,
+                }
+            ],
+        },
+        "port": {
+            "type": "conditional",
+            "required": False,
+            "default": 443,
+            "conditions": [
+                {
+                    "property": "extra.connect_type",
+                    "value": "private",
+                    "required": False,
+                }
+            ],
+        },
+        "auth-type": {
+            "type": "string",
+            "enum": ["basic", "gcp-wif"],
+            "default": "basic",
+            "required": True,
+        },
+        # The secret containers. `basic` holds username + password; `gcp-wif`
+        # holds atlan_oauth_secret. Heracles strips both before this endpoint.
+        "basic": {
+            "type": "object",
+            "properties": {
+                "username": {"type": "string", "required": True},
+                "password": {"type": "string", "required": True},
+                "extra": {"type": "object"},
+            },
+        },
+        "gcp-wif": {"type": "object", "properties": {"extra": {"type": "object"}}},
+    },
+    "anyOf": [
+        {"properties": {"auth-type": {"const": "basic"}}, "required": ["basic"]},
+        {"properties": {"auth-type": {"const": "gcp-wif"}}, "required": ["gcp-wif"]},
+        {
+            "properties": {"extra.connect_type": {"const": "private"}},
+            "required": ["host"],
+        },
+    ],
+}
+
+_SNOWFLAKE_SCHEMA: dict[str, Any] = {
+    "properties": {
+        "name": {"type": "string", "required": False},
+        "host": {"type": "string", "required": True},
+        "port": {"type": "number", "required": True},
+        "auth-type": {"type": "string", "required": True},
+        "basic": {"type": "object", "properties": {"password": {"required": True}}},
+        "keypair": {"type": "object"},
+        "okta": {"type": "object"},
+        "custom_oauth": {"type": "object"},
+        "entra_id": {"type": "object"},
+    },
+    "anyOf": [
+        {"properties": {"auth-type": {"const": "basic"}}, "required": ["basic"]},
+        {"properties": {"auth-type": {"const": "keypair"}}, "required": ["keypair"]},
+        {"properties": {"auth-type": {"const": "okta"}}, "required": ["okta"]},
+        {"properties": {"auth-type": {"const": "entra_id"}}, "required": ["entra_id"]},
+        {
+            "properties": {"auth-type": {"const": "custom_oauth"}},
+            "required": ["custom_oauth"],
+        },
+    ],
+}
+
+_DATABRICKS_SCHEMA: dict[str, Any] = {
+    "properties": {
+        "host": {"type": "string", "required": True},
+        "port": {"type": "number", "required": True},
+        "auth-type": {"type": "string", "required": True},
+        "basic": {"type": "object"},
+        "aws_service": {"type": "object"},
+        "azure_service": {"type": "object"},
+    },
+    "anyOf": [
+        {"properties": {"auth-type": {"const": "basic"}}, "required": ["basic"]},
+        {
+            "properties": {"auth-type": {"const": "aws_service"}},
+            "required": ["aws_service"],
+        },
+        {
+            "properties": {"auth-type": {"const": "azure_service"}},
+            "required": ["azure_service"],
+        },
+    ],
+}
+
+# ---------------------------------------------------------------------------
+# Stored records, as they exist in the object store post-strip
+# ---------------------------------------------------------------------------
+
+#: A healthy BigQuery WIF record on a public endpoint. Note `authType` camelCase
+#: while the schema declares `auth-type`, and the runtime alias `gcp-wif`.
+_BQ_WIF_PUBLIC = {
+    "name": "bq-wif",
+    "connectorConfigName": "atlan-connectors-bigquery",
+    "connectorType": "bigquery",
+    "authType": "gcp-wif",
+    "host": "https://bigquery.googleapis.com",
+    "port": 443,
+    "extra": {"connect_type": "public", "project_id": "example-project"},
+    "credentialSource": "direct",
+}
+
+#: A healthy BigQuery service-account record behind Private Service Connect.
+_BQ_SA_PRIVATE = {
+    "name": "bq-psc",
+    "connectorConfigName": "atlan-connectors-bigquery",
+    "authType": "service_account",  # runtime alias, absent from the schema enum
+    "host": "https://bigquery-private.p.googleapis.com",
+    "port": 443,
+    "extra": {"connect_type": "private", "project_id": "example-project"},
+    "credentialSource": "direct",
+}
+
+#: The corruption signature — what a GUID-only request writes today.
+_STUB_BODY = {"credentialSource": "direct"}
+
+
+class TestDroppedRequiredFields:
+    """The transition check itself."""
+
+    def test_stub_body_over_wif_record_is_caught(self) -> None:
+        """CONNECT-843: the body that silently broke IKEA's miner."""
+        dropped = dropped_required_fields(_STUB_BODY, _BQ_WIF_PUBLIC, _BIGQUERY_SCHEMA)
+        assert "auth-type" in dropped
+
+    def test_stub_body_over_private_record_also_loses_host(self) -> None:
+        """A private connection additionally loses the endpoint.
+
+        This is the worse half: an empty ``host`` resolves to ``None`` in
+        ``resolve_bigquery_base``, so the client silently falls back to the
+        public endpoint instead of failing.
+        """
+        dropped = dropped_required_fields(_STUB_BODY, _BQ_SA_PRIVATE, _BIGQUERY_SCHEMA)
+        assert "auth-type" in dropped
+        assert "host" in dropped
+
+    def test_public_record_does_not_require_host(self) -> None:
+        """``host`` is conditional — a public connection never demands it."""
+        existing = {**_BQ_WIF_PUBLIC}
+        existing.pop("host")
+        dropped = dropped_required_fields(_STUB_BODY, existing, _BIGQUERY_SCHEMA)
+        assert "host" not in dropped
+
+    def test_private_to_public_switch_may_drop_host(self) -> None:
+        """The regression a blind merge would cause.
+
+        Switching back to the public endpoint legitimately omits ``host``. A
+        ``{**existing, **body}`` merge would resurrect the stale private host and
+        keep routing at a Private Service Connect endpoint the customer just
+        turned off. Because the requirement is evaluated conditionally against
+        the *incoming* body, nothing is flagged.
+        """
+        body = {
+            "name": "bq-psc",
+            "connectorConfigName": "atlan-connectors-bigquery",
+            "authType": "service_account",
+            "port": 443,
+            "extra": {"connect_type": "public", "project_id": "example-project"},
+        }
+        assert dropped_required_fields(body, _BQ_SA_PRIVATE, _BIGQUERY_SCHEMA) == []
+
+    def test_public_to_private_switch_without_host_is_caught(self) -> None:
+        """Turning private on without a host is invalid in the other direction."""
+        body = {
+            "connectorConfigName": "atlan-connectors-bigquery",
+            "authType": "service_account",
+            "extra": {"connect_type": "private"},
+        }
+        assert "host" in dropped_required_fields(body, _BQ_SA_PRIVATE, _BIGQUERY_SCHEMA)
+
+    def test_first_ever_create_is_never_blocked(self) -> None:
+        """No stored object ⇒ nothing can be dropped."""
+        assert dropped_required_fields(_STUB_BODY, None, _BIGQUERY_SCHEMA) == []
+        assert dropped_required_fields(_STUB_BODY, {}, _BIGQUERY_SCHEMA) == []
+
+    def test_no_schema_is_a_no_op(self) -> None:
+        """An app without a generated credential configmap is unaffected."""
+        assert dropped_required_fields(_STUB_BODY, _BQ_WIF_PUBLIC, None) == []
+
+    def test_complete_body_passes_untouched(self) -> None:
+        assert (
+            dropped_required_fields(_BQ_WIF_PUBLIC, _BQ_WIF_PUBLIC, _BIGQUERY_SCHEMA)
+            == []
+        )
+
+    def test_auth_type_value_change_is_allowed(self) -> None:
+        """Changing the auth type is an edit, not a loss."""
+        body = {**_BQ_WIF_PUBLIC, "authType": "basic"}
+        assert dropped_required_fields(body, _BQ_WIF_PUBLIC, _BIGQUERY_SCHEMA) == []
+
+    def test_blank_value_counts_as_dropped(self) -> None:
+        """``authType: ""`` selects no auth branch, so it is a loss."""
+        body = {**_BQ_WIF_PUBLIC, "authType": ""}
+        assert "auth-type" in dropped_required_fields(
+            body, _BQ_WIF_PUBLIC, _BIGQUERY_SCHEMA
+        )
+
+    def test_null_host_on_private_counts_as_dropped(self) -> None:
+        body = {**_BQ_SA_PRIVATE, "host": None}
+        assert "host" in dropped_required_fields(body, _BQ_SA_PRIVATE, _BIGQUERY_SCHEMA)
+
+    def test_kebab_case_record_matches_kebab_schema(self) -> None:
+        """A producer sending ``auth-type`` verbatim is understood too."""
+        existing = {k: v for k, v in _BQ_WIF_PUBLIC.items() if k != "authType"}
+        existing["auth-type"] = "gcp-wif"
+        assert "auth-type" in dropped_required_fields(
+            _STUB_BODY, existing, _BIGQUERY_SCHEMA
+        )
+
+    def test_nested_extra_requirement_is_checked(self) -> None:
+        """``extra.connect_type`` is required and lives in the redacted copy."""
+        assert "extra.connect_type" in dropped_required_fields(
+            _STUB_BODY, _BQ_WIF_PUBLIC, _BIGQUERY_SCHEMA
+        )
+
+
+class TestSecretsAreNeverRequired:
+    """ "Only skipping secrets/password" — the exclusion rules."""
+
+    def test_auth_branch_objects_are_not_required(self) -> None:
+        """``basic`` / ``gcp-wif`` hold the secrets and never reach this endpoint.
+
+        Demanding them would reject every legitimate write, since Heracles strips
+        them by design.
+        """
+        dropped = dropped_required_fields(_STUB_BODY, _BQ_WIF_PUBLIC, _BIGQUERY_SCHEMA)
+        assert "basic" not in dropped
+        assert "gcp-wif" not in dropped
+
+    def test_username_and_password_are_not_required(self) -> None:
+        existing = {**_BQ_SA_PRIVATE, "username": "sa@example.iam.gserviceaccount.com"}
+        dropped = dropped_required_fields(_STUB_BODY, existing, _BIGQUERY_SCHEMA)
+        assert "username" not in dropped
+        assert "password" not in dropped
+
+    @pytest.mark.parametrize(
+        "secret_field",
+        [
+            "atlan_oauth_secret",
+            "client_secret",
+            "private_key",
+            "private-key",
+            "passphrase",
+            "some_password",
+            "access_token",
+        ],
+    )
+    def test_secret_named_extra_children_are_not_required(
+        self, secret_field: str
+    ) -> None:
+        """Mirrors Heracles' ``extra`` redaction list."""
+        schema = {
+            "properties": {
+                "extra": {
+                    "type": "object",
+                    "properties": {secret_field: {"required": True}},
+                }
+            }
+        }
+        existing = {
+            "connectorConfigName": "x",
+            "extra": {secret_field: "redacted-in-store"},
+        }
+        assert dropped_required_fields(_STUB_BODY, existing, schema) == []
+
+
+class TestGeneralisesAcrossConnectors:
+    """One SDK change, every connector — no per-connector branching."""
+
+    def test_snowflake_stub_body_loses_host_port_and_auth_type(self) -> None:
+        existing = {
+            "connectorConfigName": "atlan-connectors-snowflake",
+            "authType": "basic",
+            "host": "acme.snowflakecomputing.com",
+            "port": 443,
+        }
+        dropped = dropped_required_fields(_STUB_BODY, existing, _SNOWFLAKE_SCHEMA)
+        assert set(dropped) == {"host", "port", "auth-type"}
+
+    def test_databricks_stub_body_loses_host_port_and_auth_type(self) -> None:
+        existing = {
+            "connectorConfigName": "atlan-connectors-databricks",
+            "authType": "aws_service",
+            "host": "dbc-example.cloud.databricks.com",
+            "port": 443,
+        }
+        dropped = dropped_required_fields(_STUB_BODY, existing, _DATABRICKS_SCHEMA)
+        assert set(dropped) == {"host", "port", "auth-type"}
+
+    def test_snowflake_auth_branches_are_all_excluded(self) -> None:
+        """Five auth types, all secret containers, none required."""
+        existing = {
+            "connectorConfigName": "atlan-connectors-snowflake",
+            "authType": "keypair",
+            "host": "acme.snowflakecomputing.com",
+            "port": 443,
+            "keypair": {"password": "x"},
+        }
+        dropped = dropped_required_fields(_STUB_BODY, existing, _SNOWFLAKE_SCHEMA)
+        for branch in ("basic", "keypair", "okta", "custom_oauth", "entra_id"):
+            assert branch not in dropped
+
+
+class TestRepairDroppedFields:
+    """Repair restores exactly what went missing — not a blind merge."""
+
+    def test_restores_dropped_fields_only(self) -> None:
+        dropped = dropped_required_fields(_STUB_BODY, _BQ_SA_PRIVATE, _BIGQUERY_SCHEMA)
+        repaired = repair_dropped_fields(_STUB_BODY, _BQ_SA_PRIVATE, dropped)
+
+        assert repaired["authType"] == "service_account"
+        assert repaired["host"] == "https://bigquery-private.p.googleapis.com"
+        assert repaired["extra"]["connect_type"] == "private"
+        # Not resurrected: `name` is not required, so it stays dropped.
+        assert "name" not in repaired
+
+    def test_repaired_body_passes_a_second_pass(self) -> None:
+        """Idempotence: re-running the guard on the repaired body finds nothing."""
+        dropped = dropped_required_fields(_STUB_BODY, _BQ_SA_PRIVATE, _BIGQUERY_SCHEMA)
+        repaired = repair_dropped_fields(_STUB_BODY, _BQ_SA_PRIVATE, dropped)
+        assert dropped_required_fields(repaired, _BQ_SA_PRIVATE, _BIGQUERY_SCHEMA) == []
+
+    def test_does_not_mutate_the_incoming_body(self) -> None:
+        body = {"credentialSource": "direct"}
+        repair_dropped_fields(body, _BQ_SA_PRIVATE, ["host", "auth-type"])
+        assert body == {"credentialSource": "direct"}
+
+    def test_preserves_the_incoming_camel_spelling(self) -> None:
+        """A body that already uses ``authType`` keeps it, gaining no duplicate."""
+        body = {"authType": "", "credentialSource": "direct"}
+        repaired = repair_dropped_fields(body, _BQ_WIF_PUBLIC, ["auth-type"])
+        assert repaired["authType"] == "gcp-wif"
+        assert "auth-type" not in repaired
+
+
+class TestLoadCredentialSchema:
+    """Schema discovery via ``connectorConfigName``."""
+
+    @staticmethod
+    def _write(tmp_path: Path, stem: str, payload: dict[str, Any]) -> Path:
+        generated = tmp_path / "generated" / "crawler"
+        generated.mkdir(parents=True, exist_ok=True)
+        (generated / f"{stem}.json").write_bytes(orjson.dumps(payload))
+        return tmp_path / "generated"
+
+    def test_found_via_incoming_body(self, tmp_path: Path) -> None:
+        root = self._write(
+            tmp_path, "atlan-connectors-bigquery", {"config": _BIGQUERY_SCHEMA}
+        )
+        schema = load_credential_schema(
+            {"connectorConfigName": "atlan-connectors-bigquery"}, None, root
+        )
+        assert schema is not None
+        assert "auth-type" in schema["properties"]
+
+    def test_found_via_stored_record_when_body_is_a_stub(self, tmp_path: Path) -> None:
+        """The stub body names no connector — the stored copy must identify it.
+
+        Without this fallback the guard could never fire on the exact body it
+        exists to catch.
+        """
+        root = self._write(
+            tmp_path, "atlan-connectors-bigquery", {"config": _BIGQUERY_SCHEMA}
+        )
+        schema = load_credential_schema(_STUB_BODY, _BQ_WIF_PUBLIC, root)
+        assert schema is not None
+
+    def test_missing_connector_config_name_yields_none(self, tmp_path: Path) -> None:
+        root = self._write(tmp_path, "atlan-connectors-bigquery", {"config": {}})
+        assert load_credential_schema(_STUB_BODY, {}, root) is None
+
+    def test_unknown_connector_config_name_yields_none(self, tmp_path: Path) -> None:
+        root = self._write(
+            tmp_path, "atlan-connectors-bigquery", {"config": _BIGQUERY_SCHEMA}
+        )
+        assert (
+            load_credential_schema({"connectorConfigName": "nope"}, None, root) is None
+        )
+
+    def test_missing_generated_dir_yields_none(self, tmp_path: Path) -> None:
+        assert (
+            load_credential_schema(
+                {"connectorConfigName": "atlan-connectors-bigquery"},
+                None,
+                tmp_path / "absent",
+            )
+            is None
+        )
+
+    def test_unreadable_configmap_degrades_to_none(self, tmp_path: Path) -> None:
+        """A malformed configmap must not make credentials unsavable."""
+        generated = tmp_path / "generated" / "crawler"
+        generated.mkdir(parents=True)
+        (generated / "atlan-connectors-bigquery.json").write_bytes(b"{not json")
+        assert (
+            load_credential_schema(
+                {"connectorConfigName": "atlan-connectors-bigquery"},
+                None,
+                tmp_path / "generated",
+            )
+            is None
+        )
+
+    def test_configmap_without_config_block_yields_none(self, tmp_path: Path) -> None:
+        root = self._write(tmp_path, "atlan-connectors-bigquery", {"icon": "x"})
+        assert (
+            load_credential_schema(
+                {"connectorConfigName": "atlan-connectors-bigquery"}, None, root
+            )
+            is None
+        )

--- a/tests/unit/handler/test_service.py
+++ b/tests/unit/handler/test_service.py
@@ -5760,6 +5760,262 @@ class TestConfigEndpointPersistence:
         assert response.json()["data"] == {"hello": "world"}
 
 
+class TestCredentialConfigGuard:
+    """POST /workflows/v1/config/{id}?type=credentials must not destroy a record.
+
+    A request carrying a GUID but an effectively-empty body used to overwrite a
+    complete credential with ``{"credentialSource": "direct"}``, destroying
+    ``authType`` / ``host`` / ``port`` — the three fields with no Vault copy.
+    Unit coverage of the rules lives in ``test_credential_config.py``; these
+    tests pin the endpoint's behaviour in each mode.
+    """
+
+    _SCHEMA = {
+        "config": {
+            "properties": {
+                "auth-type": {"type": "string", "required": True},
+                "host": {"type": "string", "required": True},
+                "basic": {
+                    "type": "object",
+                    "properties": {"password": {"required": True}},
+                },
+            },
+            "anyOf": [
+                {
+                    "properties": {"auth-type": {"const": "basic"}},
+                    "required": ["basic"],
+                }
+            ],
+        }
+    }
+
+    _STORED = {
+        "connectorConfigName": "atlan-connectors-example",
+        "authType": "gcp-wif",
+        "host": "https://example-private.p.googleapis.com",
+        "credentialSource": "direct",
+    }
+
+    def _client(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:
+        import orjson
+
+        generated = tmp_path / "generated"
+        generated.mkdir(parents=True, exist_ok=True)
+        (generated / "atlan-connectors-example.json").write_bytes(
+            orjson.dumps(self._SCHEMA)
+        )
+        monkeypatch.setattr(
+            "application_sdk.handler.service.CONTRACT_GENERATED_DIR", generated
+        )
+        from unittest.mock import MagicMock
+
+        app = create_app_handler_service(
+            _TestHandler(), app_name="cred-guard", storage=MagicMock()
+        )
+        return TestClient(app)
+
+    @staticmethod
+    def _stored_download(stored: dict[str, object] | None):
+        """A ``download_file`` stand-in serving ``stored`` (or a missing key)."""
+        import orjson
+
+        async def fake_download(key, dest, store):
+            if stored is None:
+                raise FileNotFoundError(key)
+            Path(dest).write_bytes(orjson.dumps(stored))
+
+        return fake_download
+
+    def _post(
+        self,
+        client: TestClient,
+        body: dict[str, object],
+        stored: dict[str, object] | None,
+    ):
+        from unittest.mock import AsyncMock, patch
+
+        with (
+            patch(
+                "application_sdk.storage.ops.download_file",
+                new=AsyncMock(side_effect=self._stored_download(stored)),
+            ),
+            patch(
+                "application_sdk.storage.ops.put_json", new=AsyncMock(return_value=None)
+            ) as mock_put,
+        ):
+            response = client.post(
+                "/workflows/v1/config/guid-123",
+                params={"type": "credentials"},
+                json=body,
+            )
+        return response, mock_put
+
+    def test_repair_mode_restores_the_dropped_fields(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Default mode: 200, and the persisted object keeps authType + host.
+
+        Returning 200 is deliberate — it cannot break a caller that treats a 4xx
+        from this endpoint as fatal, whatever that caller's error handling does.
+        """
+        monkeypatch.setattr(
+            "application_sdk.constants.CREDENTIAL_CONFIG_GUARD", "repair"
+        )
+        client = self._client(tmp_path, monkeypatch)
+        response, mock_put = self._post(
+            client, {"credentialSource": "direct"}, self._STORED
+        )
+
+        assert response.status_code == 200
+        persisted = mock_put.await_args.args[1]
+        assert persisted["authType"] == "gcp-wif"
+        assert persisted["host"] == "https://example-private.p.googleapis.com"
+
+    def test_reject_mode_returns_422_and_writes_nothing(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "application_sdk.constants.CREDENTIAL_CONFIG_GUARD", "reject"
+        )
+        client = self._client(tmp_path, monkeypatch)
+        response, mock_put = self._post(
+            client, {"credentialSource": "direct"}, self._STORED
+        )
+
+        assert response.status_code == 422
+        detail = response.json()["detail"]
+        assert "auth-type" in detail and "host" in detail
+        mock_put.assert_not_awaited()
+
+    def test_reject_detail_never_leaks_a_credential_value(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The 4xx names fields, never values — this object holds credentials."""
+        monkeypatch.setattr(
+            "application_sdk.constants.CREDENTIAL_CONFIG_GUARD", "reject"
+        )
+        client = self._client(tmp_path, monkeypatch)
+        stored = {**self._STORED, "password": "super-secret-key-material"}
+        response, _ = self._post(client, {"credentialSource": "direct"}, stored)
+
+        assert response.status_code == 422
+        assert "super-secret-key-material" not in response.text
+        assert "https://example-private.p.googleapis.com" not in response.text
+
+    def test_off_mode_preserves_legacy_overwrite(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr("application_sdk.constants.CREDENTIAL_CONFIG_GUARD", "off")
+        client = self._client(tmp_path, monkeypatch)
+        response, mock_put = self._post(
+            client, {"credentialSource": "direct"}, self._STORED
+        )
+
+        assert response.status_code == 200
+        assert mock_put.await_args.args[1] == {"credentialSource": "direct"}
+
+    def test_complete_body_is_persisted_verbatim(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A well-formed write is untouched — the guard is not a merge."""
+        monkeypatch.setattr(
+            "application_sdk.constants.CREDENTIAL_CONFIG_GUARD", "repair"
+        )
+        client = self._client(tmp_path, monkeypatch)
+        body = {
+            "connectorConfigName": "atlan-connectors-example",
+            "authType": "basic",
+            "host": "https://example.googleapis.com",
+        }
+        response, mock_put = self._post(client, body, self._STORED)
+
+        assert response.status_code == 200
+        assert mock_put.await_args.args[1] == body
+
+    def test_first_ever_create_is_not_blocked(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No stored object ⇒ nothing to drop ⇒ the write proceeds."""
+        monkeypatch.setattr(
+            "application_sdk.constants.CREDENTIAL_CONFIG_GUARD", "reject"
+        )
+        client = self._client(tmp_path, monkeypatch)
+        body = {"connectorConfigName": "atlan-connectors-example"}
+        response, mock_put = self._post(client, body, None)
+
+        assert response.status_code == 200
+        assert mock_put.await_args.args[1] == body
+
+    def test_workflow_type_config_is_untouched(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The guard is scoped to credentials; other config types are unchanged."""
+        from unittest.mock import AsyncMock, patch
+
+        monkeypatch.setattr(
+            "application_sdk.constants.CREDENTIAL_CONFIG_GUARD", "reject"
+        )
+        client = self._client(tmp_path, monkeypatch)
+        with patch(
+            "application_sdk.storage.ops.put_json", new=AsyncMock(return_value=None)
+        ) as mock_put:
+            response = client.post(
+                "/workflows/v1/config/guid-123",
+                params={"type": "someothertype"},
+                json={"anything": "goes"},
+            )
+        assert response.status_code == 200
+        assert mock_put.await_args.args[1] == {"anything": "goes"}
+
+    def test_guard_failure_degrades_to_saving_the_body(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A guard defect must never make credentials unsavable."""
+        from unittest.mock import AsyncMock, patch
+
+        monkeypatch.setattr(
+            "application_sdk.constants.CREDENTIAL_CONFIG_GUARD", "reject"
+        )
+        client = self._client(tmp_path, monkeypatch)
+        with (
+            patch(
+                "application_sdk.handler.service._config_load_from_objectstore",
+                new=AsyncMock(side_effect=RuntimeError("boom")),
+            ),
+            patch(
+                "application_sdk.storage.ops.put_json", new=AsyncMock(return_value=None)
+            ) as mock_put,
+        ):
+            response = client.post(
+                "/workflows/v1/config/guid-123",
+                params={"type": "credentials"},
+                json={"credentialSource": "direct"},
+            )
+        assert response.status_code == 200
+        assert mock_put.await_args.args[1] == {"credentialSource": "direct"}
+
+    def test_non_dict_body_is_not_guarded(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A JSON array body must not crash the guard."""
+        from unittest.mock import AsyncMock, patch
+
+        monkeypatch.setattr(
+            "application_sdk.constants.CREDENTIAL_CONFIG_GUARD", "reject"
+        )
+        client = self._client(tmp_path, monkeypatch)
+        with patch(
+            "application_sdk.storage.ops.put_json", new=AsyncMock(return_value=None)
+        ) as mock_put:
+            response = client.post(
+                "/workflows/v1/config/guid-123",
+                params={"type": "credentials"},
+                json=["not", "a", "dict"],
+            )
+        assert response.status_code == 200
+        assert mock_put.await_args.args[1] == ["not", "a", "dict"]
+
+
 def _install_fake_app_module(
     monkeypatch: pytest.MonkeyPatch, entrypoint: str, leaf: str, **attrs: object
 ) -> None:


### PR DESCRIPTION
## The defect

`POST /workflows/v1/config/{guid}?type=credentials` is a blind whole-object PUT. The body is never schema-checked — only the path params are (`_CONFIG_KEY_PATTERN`) — and `put_json` overwrites unconditionally with no read-modify-write, no If-Match, no versioning. A request that carries a GUID but an effectively-empty body replaces a complete credential record with `{"credentialSource": "direct"}`.

That destroys exactly the fields with no redundant copy. `DaprCredentialVault.get_credentials` merges the Vault half **over** the object-store half with `dict.update`, so the merge can only ADD keys:

| Field | Object store | Vault | Survives an overwrite? |
|---|---|---|---|
| `username` / `password` / `extra` | stripped / redacted | ✅ | **yes** — Vault copy wins the merge |
| `authType` | ✅ only home | ❌ | **no** |
| `host` / `port` | ✅ only home | ❌ | **no** |

The fields that *select* the auth branch and the API endpoint are stored once; everything the branch then consumes is stored twice.

Observed symptoms of that inversion:

- a **service-account** connection keeps working — the connector's `.get("authType", …, "service_account")` default lands on the right branch by accident, so the corruption is invisible;
- a **WIF** connection fails with `service account credentials missing service_account_info or password` while the stack trace visibly contains a full WIF credential;
- a **private-link** connection silently falls back to the **public endpoint**, because an empty `host` resolves to no `client_options` — then 403s on VPC-SC and reads as a perimeter/IAM problem.

## The approach

A **transition check, not a validity check.** Nothing here decides whether a credential is valid in the abstract — only whether *this write drops a required, non-secret field the stored record already carries*. That keeps every legitimate flow untouched:

- a first-ever create (no stored object ⇒ nothing can be dropped);
- a value change (`authType` basic → gcp-wif);
- a **private → public switch that legitimately omits `host`** — the requirement is evaluated conditionally against the incoming body, which is precisely what a blind `{**existing, **body}` merge would get wrong by resurrecting a stale Private Service Connect host the customer just turned off.

Required fields come from the app's **own generated credential configmap** (`credentials.pkl` → `app/generated/*/atlan-connectors-*.json`) — which this service already reads to serve `/workflows/v1/configmap/{id}`, so the schema is on the same disk in the same process as the write.

### Secrets are exempt, derived from the schema rather than hardcoded

Heracles strips secret-bearing fields before this endpoint ever sees them, so demanding them would reject every legitimate write. Excluded:

- the per-auth-type branch objects named by `anyOf` — `basic`, `gcp-wif`, `keypair`, `aws_service`, … — which **are** the secret containers (BigQuery's `basic` holds `username` + `password`; its `gcp-wif` holds `atlan_oauth_secret`). Derived from the schema, so a connector adding an auth type needs no change here;
- top-level `username` / `password`;
- any `extra` key matching the `secret` / `password` / `passphrase` / `private_key` / `token` family Heracles redacts.

Enum values are **not** policed: the schema enumerates form values (`basic`, `gcp-wif`) while stored records legitimately carry runtime aliases (`service_account`), so an enum check would reject working credentials. Presence is the only thing asserted.

### Why not a JSON Schema library

The generated dialect is the Atlan form-toolkit dialect, not JSON Schema:

- `"type": "conditional"` is not a JSON Schema type — BigQuery declares `host`/`port` conditional on `extra.connect_type == "private"`, while Snowflake and Databricks declare them unconditionally required;
- `"required": true` sits *inside* a property, not as an array on the parent;
- `anyOf` addresses **dotted paths** — `{"properties": {"extra.connect_type": {"const": "private"}}, "required": ["host"]}`. No instance has a literal `extra.connect_type` key, and the sibling `auth-type` branch passes first, so that branch never binds. **A stock `jsonschema.validate` reports PASS on exactly the body this PR exists to catch.**

Hence a small dialect-aware evaluator (~120 lines of logic).

## Modes — `ATLAN_CREDENTIAL_CONFIG_GUARD`

| Mode | Behaviour |
|---|---|
| **`repair`** (default) | restore the dropped fields from the stored record, log a warning, return **200** |
| `reject` | return **422** naming the dropped fields; nothing is written |
| `off` | previous behaviour, blind overwrite |

Any internal guard failure degrades to saving the body unmodified — a guard defect must never make credentials unsavable. Logs and the 422 detail carry **field names only, never values**; there's a test pinning that.

## ⚠️ Blocking pre-merge item — the default mode needs one check

`repair` is the default deliberately, and reviewers should confirm or overturn it.

The 422 that `reject` returns fires on exactly the body the buggy caller sends today. So the question is **how Heracles handles an `UpsertCredentialConfig` failure**:

- if **best-effort** (log + continue) → `reject` is safe and strictly better: the bad write is refused, the record survives, workflow creation still succeeds;
- if **fatal** → `reject` breaks workflow creation for every reused-credential call, across every connector, and surfaces to pyatlan as an `AtlanError`.

`repair` returns 200 in both worlds and preserves the record in both worlds, so it cannot break a caller whatever its error handling does. To settle it:

```bash
grep -rn "UpsertCredentialConfig" --include="*.go" .   # then: is the error returned, or logged and dropped?
```

If it's best-effort, flip the default to `reject` — it also surfaces the offending caller instead of silently absorbing it.

## Scope

This stops **new** corruption. It does not repair already-stubbed records — that needs a re-save of the credential, or an ops sweep. It's also independent of the client-side fixes (routing a reused GUID onto `connection.attributes.defaultCredentialGuid`) and of the Heracles-side guard on the two create paths; this is the defence-in-depth layer that holds regardless of which client shape arrives.

## Testing

- **36** new unit tests in `tests/unit/handler/test_credential_config.py`
- **9** new endpoint tests in `test_service.py` covering all three modes, the secret-leak assertion, first-ever create, non-credential config types, non-dict bodies, and guard-failure degradation
- `tests/unit/handler/` + `test_constants.py`: **500 passed**
- full unit suite: **6804 passed, 9 failed** — all 9 are `ModuleNotFoundError` for `redis` / `fastmcp` (optional extras absent from the local venv); verified identical on base with the change stashed
- `ruff`, `ruff-format`, `isort`, `pyright` pass
- Validated against the **real** generated schemas for BigQuery (conditional `host`/`port`, 2 auth branches), Snowflake (unconditional, 5 branches) and Databricks (3) — the check needs no per-connector code

🤖 Generated with [Claude Code](https://claude.com/claude-code)
