### PR TITLE
feat(execution): bound the retry product, and alert on run length (FND-294)

### DIFF
--- a/application_sdk/app/base.py
+++ b/application_sdk/app/base.py
@@ -329,6 +329,27 @@ def _safe_uuid() -> UUID:
     return UUID(str(workflow.uuid4()))
 
 
+def _run_started_at_epoch() -> float:
+    """When this run started, in wall-clock seconds since the epoch.
+
+    Deterministic for replay: ``workflow.info().start_time`` comes from the
+    run's own history, so every replay of a run reads the same instant and the
+    run-length observation measures the run rather than the attempt that
+    happens to be replaying it.
+
+    Returns ``0.0`` outside a workflow context — a task invoked directly in a
+    test or a local run has no run to measure. Never raises: this value only
+    feeds an alert, so failing to read it must cost the observation and nothing
+    else.
+    """
+    try:
+        start_time = workflow.info().start_time
+    # conformance: ignore[E004] probe for Temporal workflow context; the value only feeds an observability signal, so any failure degrades to "unknown run start"
+    except Exception:
+        return 0.0  # conformance: ignore[E007] workflow-context probe; "no run to measure" is the answer, and a log line here would fire per dispatch on every local run
+    return start_time.timestamp() if start_time is not None else 0.0
+
+
 def _safe_log(level: str, message: str, **attrs: Any) -> None:
     """Log using Temporal's workflow logger.
 
@@ -2391,6 +2412,7 @@ def _wrap_instance_tasks(app_instance: Any, context_data: dict[str, Any]) -> Non
                     task_meta.auto_heartbeat_seconds,
                     task_meta.retry_policy,
                     pool=task_meta.pool,
+                    schedule_to_close_seconds=task_meta.schedule_to_close_seconds,
                 )
                 setattr(app_instance, attr_name, wrapper)
 
@@ -2408,13 +2430,14 @@ def _create_task_activity_wrapper(
     retry_policy: Any = None,
     *,
     pool: str | None = None,
+    schedule_to_close_seconds: int | None = None,
 ) -> Any:
     """Create a wrapper that executes a task as a Temporal activity.
 
     Args:
         app_name: Name of the app.
         task_name: Name of the task (simple name, no prefix).
-        timeout_seconds: Activity timeout.
+        timeout_seconds: Activity timeout for one attempt (``start_to_close``).
         retry_max_attempts: Maximum retry attempts.
         retry_max_interval_seconds: Maximum interval between retries.
         output_type: The typed output class for deserialization.
@@ -2428,6 +2451,11 @@ def _create_task_activity_wrapper(
             2. ``{ATLAN_TASK_QUEUE}-{pool}`` derived from the app's base queue
                (default — ensures different apps with the same pool name get
                different Temporal queues automatically).
+        schedule_to_close_seconds: Ceiling on the task's total time across every
+            attempt. ``None`` (the default) sends no ``schedule_to_close_timeout``
+            and leaves the retry product unbounded — ``retry_max_attempts ×
+            timeout_seconds``. Resolved against ``timeout_seconds`` by
+            :func:`~application_sdk.execution.retry.resolve_activity_time_bounds`.
 
     Returns:
         Async function that executes the task as an activity.
@@ -2443,6 +2471,17 @@ def _create_task_activity_wrapper(
     )
     from application_sdk.execution.retry import (  # noqa: PLC0415 — circular: execution/__init__.py loads _temporal which imports app.base
         _to_temporal_retry_policy,
+        resolve_activity_time_bounds,
+    )
+
+    # Resolved once, outside the wrapper: the pair is fixed for the task's
+    # lifetime, so a dispatch does no arithmetic.
+    start_to_close_seconds, total_seconds = resolve_activity_time_bounds(
+        timeout_seconds, schedule_to_close_seconds
+    )
+    start_to_close_timeout = timedelta(seconds=start_to_close_seconds)
+    schedule_to_close_timeout = (
+        timedelta(seconds=total_seconds) if total_seconds is not None else None
     )
 
     with workflow.unsafe.imports_passed_through():
@@ -2473,6 +2512,12 @@ def _create_task_activity_wrapper(
             workflow_id=context_data.get("workflow_id", LOCAL_WORKFLOW_ID),
             heartbeat_timeout_seconds=heartbeat_timeout_seconds,
             auto_heartbeat_seconds=auto_heartbeat_seconds,
+            # The workflow is the only side that knows when the *run* started —
+            # nothing in `activity.info()` carries it — and the activity needs it
+            # for the run-length SLA alert (ADR-0018 → *Bounding total time*).
+            # Sourced from history rather than a clock, so a replayed run
+            # measures its real age instead of restarting the clock.
+            run_started_at_epoch=_run_started_at_epoch(),
         )
 
         # Build heartbeat timeout if enabled
@@ -2493,11 +2538,20 @@ def _create_task_activity_wrapper(
         result: Output = await execute_activity_with_eviction_retry(
             f"{app_name}:{task_name}",
             args=[task_context, input_data],
-            start_to_close_timeout=timedelta(seconds=timeout_seconds),
+            start_to_close_timeout=start_to_close_timeout,
             heartbeat_timeout=heartbeat_timeout,
             retry_policy=temporal_retry_policy,
             result_type=output_type,
             summary=summary,
+            # Sent only when the task declares a ceiling on its retry product.
+            # Passing ``schedule_to_close_timeout=None`` would be equivalent, but
+            # omitting the key keeps the call byte-identical to before this knob
+            # existed for every task that has not opted in.
+            **(
+                {"schedule_to_close_timeout": schedule_to_close_timeout}
+                if schedule_to_close_timeout is not None
+                else {}
+            ),
             **({"task_queue": pool_queue} if pool_queue else {}),
         )
 

--- a/application_sdk/app/task.py
+++ b/application_sdk/app/task.py
@@ -26,9 +26,12 @@ from application_sdk.common._env import env_int
 from application_sdk.contracts.base import Input, Output
 from application_sdk.errors import CONTRACT_VALIDATION, ErrorCode
 from application_sdk.errors.leaves import InvalidInputError
+from application_sdk.observability.logger_adaptor import get_logger
 
 if TYPE_CHECKING:
     from application_sdk.execution.retry import RetryPolicy
+
+logger = get_logger(__name__)
 
 F = TypeVar("F", bound=Callable[..., Any])
 
@@ -40,6 +43,42 @@ _USE_DEFAULT = object()
 # Apps that need a different per-task value pass it explicitly to @task().
 _DEFAULT_HEARTBEAT_TIMEOUT_SECONDS: int = env_int("ATLAN_HEARTBEAT_TIMEOUT_SECONDS", 60)
 _DEFAULT_TIMEOUT_SECONDS: int = env_int("ATLAN_START_TO_CLOSE_TIMEOUT_SECONDS", 600)
+
+
+def _load_default_schedule_to_close_seconds() -> int | None:
+    """Read the fleet-wide total-time ceiling. ``None`` when unset or unusable.
+
+    ``0`` reads as unset, so a deployment can clear an inherited value the same
+    way it sets one. Never raises, and never lets a bad value reach a
+    decoration: a negative ceiling would make every ``@task`` in the process
+    raise at import, so a typo in one deployment manifest would stop the worker
+    booting rather than cost one config value.
+    """
+    raw = env_int("ATLAN_SCHEDULE_TO_CLOSE_TIMEOUT_SECONDS", 0)
+    if raw > 0:
+        return raw
+    if raw < 0:
+        logger.warning(
+            "Ignoring ATLAN_SCHEDULE_TO_CLOSE_TIMEOUT_SECONDS=%d: a total-time "
+            "ceiling must be positive. Leaving the retry product unbounded "
+            "(start_to_close bounds one attempt, the retry policy multiplies it)",
+            raw,
+        )
+    return None
+
+
+#: The fleet-wide ceiling on a task's *total* time across every retry (ADR-0018
+#: → *Bounding total time*). ``None`` — the SDK default — leaves the retry
+#: product unbounded, exactly as before this knob existed: ``start_to_close``
+#: bounds one attempt and the retry policy multiplies it.
+#:
+#: An env var first and a decorator argument second, on purpose. ADR-0018's
+#: accepted position is to *start* unbounded and size the ceiling from warn-mode
+#: data rather than guess it up front; making the fleet-wide decision an env var
+#: is what keeps that decision a config change instead of a redesign.
+_DEFAULT_SCHEDULE_TO_CLOSE_SECONDS: int | None = (
+    _load_default_schedule_to_close_seconds()
+)
 
 # Type alias for methods with single Input param returning Output
 TaskMethod = Callable[..., Any]
@@ -104,7 +143,22 @@ class TaskMetadata:
 
     timeout_seconds: int = _DEFAULT_TIMEOUT_SECONDS
     """Default timeout for this task. Defaults to ATLAN_START_TO_CLOSE_TIMEOUT_SECONDS
-    env var, or 600s (10 minutes) if unset."""
+    env var, or 600s (10 minutes) if unset.
+
+    Bounds ONE attempt. The retry policy multiplies it — see
+    :attr:`schedule_to_close_seconds` for the ceiling on the product."""
+
+    schedule_to_close_seconds: int | None = _DEFAULT_SCHEDULE_TO_CLOSE_SECONDS
+    """Ceiling on this task's total time across every retry, in seconds.
+
+    ``None`` leaves the retry product unbounded: ``max_attempts ×
+    timeout_seconds`` is the real worst case. Defaults to
+    ATLAN_SCHEDULE_TO_CLOSE_TIMEOUT_SECONDS, and to ``None`` when that env var is
+    unset or ``0``.
+
+    Resolved against :attr:`timeout_seconds` by
+    :func:`~application_sdk.execution.retry.resolve_activity_time_bounds`, which
+    both dispatch paths share."""
 
     pool: str | None = None
     """Logical worker-pool name for this task.
@@ -246,6 +300,7 @@ def task(
     name: str | None = None,
     description: str = "",
     timeout_seconds: int = _DEFAULT_TIMEOUT_SECONDS,
+    schedule_to_close_seconds: int | None | object = _USE_DEFAULT,
     retry_policy: "RetryPolicy | None" = None,
     retry_max_attempts: int = 3,
     retry_max_interval_seconds: int = 30,
@@ -261,6 +316,7 @@ def task(
     name: str | None = None,
     description: str = "",
     timeout_seconds: int | object = _USE_DEFAULT,
+    schedule_to_close_seconds: int | None | object = _USE_DEFAULT,
     retry_policy: "RetryPolicy | None" = None,
     retry_max_attempts: int = 3,
     retry_max_interval_seconds: int = 30,
@@ -326,9 +382,23 @@ def task(
         func: The function to decorate (when used without parentheses).
         name: Override the task name (defaults to function name).
         description: Human-readable description.
-        timeout_seconds: Activity timeout in seconds. Defaults to
-            ``ATLAN_START_TO_CLOSE_TIMEOUT_SECONDS`` env var, or 600 s (10 min)
-            if unset. Explicit values take precedence over the env var.
+        timeout_seconds: Activity timeout in seconds — the ``start_to_close``
+            budget for **one attempt**, which the retry policy then multiplies.
+            Defaults to ``ATLAN_START_TO_CLOSE_TIMEOUT_SECONDS`` env var, or
+            600 s (10 min) if unset. Explicit values take precedence over the
+            env var.
+        schedule_to_close_seconds: Ceiling on the task's **total** time across
+            every attempt, in seconds. ``None`` — the default — leaves the retry
+            product unbounded, so the real worst case is
+            ``retry_max_attempts × timeout_seconds``; see
+            :func:`~application_sdk.execution.retry.retry_product_seconds` to
+            declare exactly that product, and ``retry_max_attempts=1`` to bound
+            a backstop-class task by dropping retries instead. A ceiling below
+            ``timeout_seconds`` caps one attempt too, so declaring only a total
+            works while inheriting a generous per-attempt backstop. Defaults to
+            ``ATLAN_SCHEDULE_TO_CLOSE_TIMEOUT_SECONDS`` when that env var is set
+            to a positive value; passing ``None`` explicitly opts this task out
+            of that fleet-wide ceiling.
         retry_policy: Full retry policy. When provided, takes precedence over
             retry_max_attempts and retry_max_interval_seconds.
         retry_max_attempts: Maximum retry attempts (default 3). Ignored when
@@ -395,6 +465,18 @@ def task(
         if auto_heartbeat_seconds is _USE_DEFAULT
         else cast("int | None", auto_heartbeat_seconds)
     )
+    resolved_schedule_to_close: int | None = (
+        _DEFAULT_SCHEDULE_TO_CLOSE_SECONDS
+        if schedule_to_close_seconds is _USE_DEFAULT
+        else cast("int | None", schedule_to_close_seconds)
+    )
+    if resolved_schedule_to_close is not None and resolved_schedule_to_close <= 0:
+        raise TaskContractError(
+            f"schedule_to_close_seconds={resolved_schedule_to_close!r} must be a "
+            "positive number of seconds. Pass None to leave the retry product "
+            "unbounded (the default); a ceiling of zero would fail every attempt "
+            "before it started."
+        )
 
     def decorator(fn: F) -> F:
         task_name = name or getattr(fn, "__name__", repr(fn))
@@ -411,6 +493,7 @@ def task(
             app_name="",  # Will be set by App registration
             description=description or fn.__doc__ or "",
             timeout_seconds=resolved_timeout,
+            schedule_to_close_seconds=resolved_schedule_to_close,
             pool=pool,
             retry_policy=retry_policy,
             retry_max_attempts=retry_max_attempts,

--- a/application_sdk/constants.py
+++ b/application_sdk/constants.py
@@ -379,6 +379,12 @@ WORKFLOW_AUTH_CLIENT_SECRET_KEY = os.getenv(
 # the @task decorator. Per-task overrides still take precedence.
 #   ATLAN_HEARTBEAT_TIMEOUT_SECONDS → default heartbeat_timeout_seconds for @task
 #   ATLAN_START_TO_CLOSE_TIMEOUT_SECONDS → default timeout_seconds for @task
+#   ATLAN_SCHEDULE_TO_CLOSE_TIMEOUT_SECONDS → default schedule_to_close_seconds for
+#     @task: the ceiling on a task's total time across every retry. Unset leaves
+#     the retry product unbounded (ADR-0018 → Bounding total time).
+# The run-length SLA that alerts on an over-long run — the duration signal that
+# replaces the duration kill — is read in application_sdk/execution/run_length.py:
+#   ATLAN_RUN_LENGTH_SLA_SECONDS → RUN_LENGTH_SLA_SECONDS (default 86400, 0 disables)
 # ExecutionSettings owns the graceful shutdown timeout:
 #   - ExecutionSettings.graceful_shutdown_timeout_seconds (TEMPORAL_GRACEFUL_SHUTDOWN_TIMEOUT)
 

--- a/application_sdk/execution/__init__.py
+++ b/application_sdk/execution/__init__.py
@@ -46,7 +46,7 @@ from application_sdk.execution._temporal.converter import (
 from application_sdk.execution._temporal.worker import AppWorker, create_worker
 from application_sdk.execution.decorators import needs_lock
 from application_sdk.execution.errors import ApplicationError
-from application_sdk.execution.retry import RetryPolicy
+from application_sdk.execution.retry import RetryPolicy, retry_product_seconds
 
 __all__ = [
     "AppWorker",
@@ -69,4 +69,5 @@ __all__ = [
     "create_worker",
     "get_object_store_prefix",
     "needs_lock",
+    "retry_product_seconds",
 ]

--- a/application_sdk/execution/_temporal/activities.py
+++ b/application_sdk/execution/_temporal/activities.py
@@ -158,6 +158,33 @@ class TaskContext:
     auto_heartbeat_seconds: int | None = 20
     """Auto-heartbeat interval in seconds. Set to None for manual heartbeats only."""
 
+    run_started_at_epoch: float = 0.0
+    """When the *run* started, as wall-clock seconds since the epoch.
+
+    Set by the workflow side from ``workflow.info().start_time``, because nothing
+    in ``activity.info()`` carries it and the run-length SLA observation
+    (:mod:`application_sdk.execution.run_length`) has to measure the run rather
+    than the attempt.
+
+    ``0.0`` means unknown, and no observation is made: a task invoked outside a
+    workflow, or a run dispatched by a workflow that predates this field and is
+    still in flight across an SDK upgrade. Epoch seconds rather than a
+    ``datetime`` so the value is one float on the wire and needs no timezone
+    round-trip to be subtracted from this worker's clock."""
+
+
+def _current_workflow_type() -> str:
+    """The run's workflow type, or ``""`` outside an activity context.
+
+    Only ever used as a bounded metric attribute (one value per registered
+    workflow), so an empty string on the local path is the right answer rather
+    than a reason to raise.
+    """
+    try:
+        return activity.info().workflow_type or ""
+    except RuntimeError:  # not inside an activity context
+        return ""  # conformance: ignore[E007] activity-context probe; an empty metric attribute is the answer on the local path, not an error worth a log line
+
 
 def _track_file_refs(workflow_id: str, *refs: FileReference) -> None:
     """Add FileReference objects to the per-workflow tracking set in _app_state.
@@ -215,6 +242,9 @@ def create_activity_from_task(
         )
         from application_sdk.execution.progress_telemetry import (  # noqa: PLC0415 — circular: execution/__init__.py loads sibling modules + app.base imports execution
             closed_hold_observer,
+        )
+        from application_sdk.execution.run_length import (  # noqa: PLC0415 — circular: execution/__init__.py loads sibling modules + app.base imports execution
+            build_run_length_watch,
         )
 
         app_registry = AppRegistry.get_instance()
@@ -325,6 +355,16 @@ def create_activity_from_task(
 
                     heartbeat_task = asyncio.create_task(
                         auto_heartbeat_loop(
+                            # ADR-0018's duration *alert*: the run-length SLA
+                            # rides the same tick as the beat and the stall
+                            # watchdog. `None` whenever there is nothing to
+                            # measure — SLA disabled, or a dispatching workflow
+                            # that predates `run_started_at_epoch`.
+                            run_length=build_run_length_watch(
+                                context.run_started_at_epoch,
+                                task_name=context.task_name,
+                                workflow_type=_current_workflow_type(),
+                            ),
                             interval_seconds=context.auto_heartbeat_seconds,
                             heartbeat_fn=heartbeat_controller.heartbeat_keepalive,
                             stop_event=stop_event,
@@ -546,7 +586,9 @@ def get_activity_options(task_metadata: TaskMetadata) -> dict[str, Any]:
         task_metadata: The task metadata.
 
     Returns:
-        Dict of activity options for workflow.execute_activity().
+        Dict of activity options for workflow.execute_activity(). Carries
+        ``schedule_to_close_timeout`` only when the task declares a ceiling on
+        its retry product — omitted, as before, when it does not.
     """
     from temporalio.common import (  # noqa: PLC0415 — cold path: only used in retry policy reconstruction
         RetryPolicy as TemporalRetryPolicy,
@@ -554,6 +596,7 @@ def get_activity_options(task_metadata: TaskMetadata) -> dict[str, Any]:
 
     from application_sdk.execution.retry import (  # noqa: PLC0415 — circular: execution/__init__.py loads sibling modules + retry imports errors transitively
         _with_worker_evicted_non_retryable,
+        resolve_activity_time_bounds,
     )
 
     if task_metadata.retry_policy is not None:
@@ -576,7 +619,14 @@ def get_activity_options(task_metadata: TaskMetadata) -> dict[str, Any]:
             non_retryable_error_types=_with_worker_evicted_non_retryable([]),
         )
 
-    return {
-        "start_to_close_timeout": timedelta(seconds=task_metadata.timeout_seconds),
+    start_to_close, schedule_to_close = resolve_activity_time_bounds(
+        task_metadata.timeout_seconds, task_metadata.schedule_to_close_seconds
+    )
+
+    options: dict[str, Any] = {
+        "start_to_close_timeout": timedelta(seconds=start_to_close),
         "retry_policy": retry_policy,
     }
+    if schedule_to_close is not None:
+        options["schedule_to_close_timeout"] = timedelta(seconds=schedule_to_close)
+    return options

--- a/application_sdk/execution/heartbeat.py
+++ b/application_sdk/execution/heartbeat.py
@@ -41,6 +41,7 @@ from application_sdk._runtime.progress import (
 )
 from application_sdk.execution.progress import ProgressWatchdogMode
 from application_sdk.execution.progress_telemetry import record_no_progress_gap
+from application_sdk.execution.run_length import RunLengthWatch
 from application_sdk.observability import (
     resource_sampler as _resource_sampler,  # module alias kept so tests can patch _resource_sampler.sample()
 )
@@ -236,6 +237,7 @@ async def auto_heartbeat_loop(
     max_no_progress_seconds: float | None = None,
     watchdog_mode: ProgressWatchdogMode = ProgressWatchdogMode.OFF,
     on_stall: Callable[[float, str], None] | None = None,
+    run_length: RunLengthWatch | None = None,
 ) -> None:
     """Background task that sends heartbeats at regular intervals.
 
@@ -253,6 +255,14 @@ async def auto_heartbeat_loop(
     60s default. The watchdog is a second, independent question asked on the
     same tick: *has this attempt done anything observable lately?*
 
+    A ``run_length`` watch is a third such question, and the one the watchdog
+    cannot answer: *has the whole run been going too long?* A run that dribbles
+    progress re-arms the watchdog on every mark and stalls by no definition it
+    has, so with the duration ceiling raised to a backstop the only thing left
+    to bound it is a human — which needs an alert (ADR-0018 → *Bounding total
+    time*). It rides this tick because the tick already exists; it throttles
+    itself and reports nothing while the run is inside its SLA.
+
     Args:
         interval_seconds: How often to send heartbeats.
         heartbeat_fn: Function to call for each heartbeat.
@@ -269,6 +279,10 @@ async def auto_heartbeat_loop(
             ``heartbeat_fn`` already is — so this module stays free of
             activity/Temporal semantics and the watchdog is unit-testable
             without a worker.
+        run_length: This attempt's :class:`~application_sdk.execution.run_length.RunLengthWatch`.
+            ``None`` — the default — makes the loop byte-identical to before:
+            no run-length observation is made. Injected rather than built here
+            because only the activity layer knows when the *run* started.
     """
     warning_threshold = interval_seconds * 0.5
     _limit_bytes = parse_pod_memory_limit(os.environ.get("K8S_POD_MEMORY_LIMIT", ""))
@@ -385,6 +399,13 @@ async def auto_heartbeat_loop(
                     e,
                     exc_info=True,
                 )
+
+        # Ahead of the watchdog for the same reason the memory sample is: an
+        # enforced stall returns out of the loop, and the tick that kills a
+        # wedged attempt is exactly the tick on which "this run is also 30 hours
+        # long" is worth having recorded. `observe()` swallows its own failures.
+        if run_length is not None:
+            run_length.observe()
 
         # The stall watchdog runs last in the tick: the beat is the crash
         # detector and goes out first, and an enforced stall returns from here,

--- a/application_sdk/execution/retry.py
+++ b/application_sdk/execution/retry.py
@@ -82,6 +82,97 @@ AGGRESSIVE_RETRY = RetryPolicy(
 """Aggressive retry policy for transient failures."""
 
 
+#: Room a total-time ceiling leaves for retry backoff *between* attempts, in
+#: seconds. Mirrors the ``+ 10`` in ``preflight_gate.gate_timeouts`` — same
+#: reason: a ceiling of exactly ``attempts × attempt`` would fire during the
+#: backoff wait before the last attempt could start, which silently costs an
+#: attempt the retry policy says the task has.
+_RETRY_BACKOFF_HEADROOM_SECONDS = 10
+
+
+def retry_product_seconds(
+    timeout_seconds: int,
+    max_attempts: int,
+    *,
+    backoff_headroom_seconds: int = _RETRY_BACKOFF_HEADROOM_SECONDS,
+) -> int:
+    """The worst-case total seconds a task can consume across *every* attempt.
+
+    The arithmetic a ``start_to_close`` timeout on its own hides (ADR-0018 →
+    *Bounding total time*): a per-attempt ceiling multiplied by the retry
+    budget. A ``StartToClose`` timeout is retryable in Temporal, so a wedged
+    attempt really can spend the whole product — three attempts against a 24h
+    backstop is a 72h worst case.
+
+    Use it to declare a ``schedule_to_close_seconds`` that bounds the product at
+    exactly what the retry policy already implies, without doing the
+    multiplication by hand::
+
+        @task(
+            timeout_seconds=3600,
+            retry_max_attempts=3,
+            schedule_to_close_seconds=retry_product_seconds(3600, 3),
+        )
+
+    That is the *ceiling that changes nothing* — it makes today's worst case
+    explicit and enforced. Passing anything smaller is a real bound, and
+    :func:`resolve_activity_time_bounds` describes what it costs.
+
+    Args:
+        timeout_seconds: One attempt's ``start_to_close`` budget.
+        max_attempts: The retry policy's ``max_attempts`` (attempts, not
+            retries). Values below 1 are read as 1 — one attempt always runs.
+        backoff_headroom_seconds: Seconds added for the retry backoff waits.
+
+    Returns:
+        Total seconds across all attempts, including backoff headroom.
+    """
+    return max(1, max_attempts) * timeout_seconds + backoff_headroom_seconds
+
+
+def resolve_activity_time_bounds(
+    timeout_seconds: int, schedule_to_close_seconds: int | None
+) -> tuple[int, int | None]:
+    """Resolve one task's ``(start_to_close, schedule_to_close)`` pair.
+
+    The single reader of ``TaskMetadata.schedule_to_close_seconds``, shared by
+    both dispatch paths (``app.base._create_task_activity_wrapper`` and
+    ``activities.get_activity_options``) so the pair they hand Temporal cannot
+    diverge.
+
+    Two resolutions, and neither is a guess:
+
+    - ``None`` — the SDK's default and today's behaviour: one attempt is
+      bounded, the *product* is not. Nothing is sent for
+      ``schedule_to_close_timeout``.
+    - A ceiling **below** one attempt's timeout wins over that timeout, and
+      caps it. This is the shape an app gets by declaring only a total
+      ("this task must finish within an hour") while inheriting a generous
+      per-attempt backstop from ``ATLAN_START_TO_CLOSE_TIMEOUT_SECONDS``, and
+      honouring the tighter number is what the author asked for. Capping here
+      rather than sending an inverted pair keeps the two timeouts consistent
+      whatever the server does with an inversion, and means one attempt gets
+      the whole ceiling — a retry could not start inside it anyway.
+
+    Note the ceiling bounds one *dispatch*, which is what the retry policy
+    spends. Worker-eviction re-dispatches (``eviction_retry``) each get a fresh
+    window by design — they are bounded separately by
+    :data:`~application_sdk.constants.WORKER_EVICTION_MAX_RETRIES`, and
+    deliberately do not spend the application-error retry budget.
+
+    Args:
+        timeout_seconds: The task's per-attempt ``start_to_close`` budget.
+        schedule_to_close_seconds: The task's declared total ceiling, or
+            ``None`` to leave the product unbounded.
+
+    Returns:
+        ``(start_to_close_seconds, schedule_to_close_seconds_or_None)``.
+    """
+    if schedule_to_close_seconds is None:
+        return timeout_seconds, None
+    return min(timeout_seconds, schedule_to_close_seconds), schedule_to_close_seconds
+
+
 def _with_worker_evicted_non_retryable(non_retryable: list[str]) -> list[str]:
     """Append ``WORKER_EVICTED_TYPE`` to a non-retryable-types list, idempotently.
 

--- a/application_sdk/execution/retry.py
+++ b/application_sdk/execution/retry.py
@@ -118,6 +118,18 @@ def retry_product_seconds(
     explicit and enforced. Passing anything smaller is a real bound, and
     :func:`resolve_activity_time_bounds` describes what it costs.
 
+    What the headroom is, honestly: a fixed allowance, not a sum computed from
+    the retry policy's shape. At the default backoff (1s initial interval, 2.0
+    coefficient) it covers roughly 3–4 attempts' inter-attempt waits; a deeper
+    policy (10 attempts at those settings waits ~17 minutes across its backoff,
+    against 10s of headroom) can still fire the ceiling during a late backoff
+    wait and forfeit the attempts the policy says remain. That is deliberate:
+    the number stays policy-independent so it can be declared at decoration time,
+    and slightly-tight is the right side to err on — the ceiling's job is to
+    expose a cosmetic retry policy, not to reproduce its backoff arithmetic. If
+    a task genuinely needs every deep-policy attempt, pass a larger
+    ``backoff_headroom_seconds`` with it.
+
     Args:
         timeout_seconds: One attempt's ``start_to_close`` budget.
         max_attempts: The retry policy's ``max_attempts`` (attempts, not
@@ -125,7 +137,8 @@ def retry_product_seconds(
         backoff_headroom_seconds: Seconds added for the retry backoff waits.
 
     Returns:
-        Total seconds across all attempts, including backoff headroom.
+        Total seconds across all attempts, plus the backoff headroom described
+        above.
     """
     return max(1, max_attempts) * timeout_seconds + backoff_headroom_seconds
 

--- a/application_sdk/execution/run_length.py
+++ b/application_sdk/execution/run_length.py
@@ -1,0 +1,278 @@
+"""Run-length SLA observation — the duration *alert* (ADR-0018).
+
+Removing the duration knob removes the only wall-clock bound the system has, and
+ADR-0018 → *Bounding total time* names what replaces it. Two things are needed,
+and this module is the second:
+
+1. A ceiling on the retry product, available as a config change rather than a
+   redesign — ``@task(schedule_to_close_seconds=...)`` and
+   :func:`~application_sdk.execution.retry.resolve_activity_time_bounds`.
+2. **A duration signal for the runs no ceiling catches.** Once the AE layer
+   drops its timeouts and ``start_to_close`` is a 24h backstop, a run that
+   wedges *while dribbling small amounts of progress* is effectively unbounded:
+   every progress mark re-arms the stall watchdog, so it never fires, and the
+   run is not stalled by any definition the watchdog has. The replacement for a
+   duration kill is a duration alert, so "remove the timeouts" does not quietly
+   become "nobody notices for a week".
+
+**Why an alert and not a kill, restated where it is implemented.** The SDK
+cannot know how long a healthy run of an app takes against a tenant it has never
+seen — that is the number ADR-0018 exists to stop guessing. An *alert* threshold
+is a different kind of number from a *kill* threshold: being wrong costs a human
+one look, not a run's worth of work. That asymmetry is what makes a default
+defensible here where a default duration ceiling is not.
+
+**Where the observation comes from, and what it therefore misses.** The run's
+age is measured inside the activity attempt, on the tick the heartbeat loop
+already runs (:func:`~application_sdk.execution.heartbeat.auto_heartbeat_loop`),
+from the run start time the workflow puts on the activity's ``TaskContext``.
+That places it deliberately *outside* workflow code: a workflow-side timer would
+be a durable command in every run's history and a determinism hazard across an
+SDK upgrade, and the run shapes that matter here — a long extraction dribbling
+progress — are inside activities by construction.
+
+The cost of that choice, stated: a run is only observed while at least one of
+its activities is executing. A run idle between activities — parked on a signal,
+or waiting on a child workflow whose own activities report under *their* run's
+identity — is not observed, and neither is a task with heartbeating disabled
+(no tick to ride). If a wedge in one of those shapes ever shows up, a
+workflow-side timer is the escalation; nothing here forecloses it.
+
+The signal is a **histogram plus one WARNING log per attempt**. WARNING, unlike
+the warn-mode stall telemetry next door in ``progress_telemetry`` (INFO, because
+a warn-mode stall observation is an expected observation): a run past the length
+its own operator declared is not expected, and it is the one thing in ADR-0018's
+new world that nothing else reports.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+from application_sdk.common._env import env_int
+from application_sdk.observability.logger_adaptor import get_logger
+
+logger = get_logger(__name__)
+
+#: Meter for the signal this module owns. Shared with ``progress_telemetry``:
+#: both are execution-layer observations of one attempt, and neither has a
+#: Temporal dependency, so both also report from local runs.
+_METER_NAME = "application_sdk.execution"
+
+#: Lazily created singleton instrument, built on first use so nothing is bound
+#: before ``run_main()`` configures the ``MeterProvider``.
+_INSTRUMENTS: dict[str, Any] = {}
+
+
+#: 24 hours, as a named constant so the fallback and the documented default
+#: cannot drift apart.
+_DEFAULT_SLA_SECONDS = 86_400
+
+
+def _load_sla_seconds() -> float:
+    """Read the fleet-wide run-length SLA. ``0`` disables the observation.
+
+    24 hours by default: the same order as the ``start_to_close`` backstop
+    ADR-0018 raises the per-attempt ceiling to, so a run that has spent longer
+    than one full backstop end-to-end is the thing a human hears about. It is
+    the *alert* threshold, so an app whose healthy runs legitimately outlast it
+    sets its own value — that declaration is the point, and it costs one env var
+    rather than a code change.
+
+    Never raises: a malformed value falls back to the default (``env_int``
+    warns), and a negative one disables the observation with a complaint rather
+    than alerting on every run from its first tick.
+    """
+    raw = env_int("ATLAN_RUN_LENGTH_SLA_SECONDS", _DEFAULT_SLA_SECONDS)
+    if raw < 0:
+        logger.warning(
+            "Ignoring ATLAN_RUN_LENGTH_SLA_SECONDS=%d: a run-length SLA must be "
+            "positive, or 0 to disable the alert. Disabling it — no run-length "
+            "alert will be raised for this app",
+            raw,
+        )
+        return 0.0
+    return float(raw)
+
+
+#: How long the SLA gives a run before an alert is raised, in seconds. ``0``
+#: disables the observation entirely. Read once at import, so it is stable for
+#: the process lifetime.
+RUN_LENGTH_SLA_SECONDS: float = _load_sla_seconds()
+
+#: Shortest gap between two observations of the same run, in seconds. The
+#: heartbeat loop ticks every ``auto_heartbeat_seconds`` (10s by default), which
+#: is the right cadence for a beat and far too fine for this: an over-SLA run
+#: only needs to keep re-asserting often enough that the alert stays firing
+#: while it runs and resolves once it ends. One minute keeps the alert window in
+#: minutes rather than hours without adding a metric point per beat.
+_OBSERVE_INTERVAL_SECONDS = 60.0
+
+
+def _run_length_histogram() -> Any:
+    """Over-SLA run-age histogram, created on the first breach in this process.
+
+    A histogram of the *age*, not a counter of breaches: an operator's first
+    question about an alert is "how far over is it?", and the distribution over
+    a fleet is also what tells whoever owns the SLA whether the threshold is the
+    wrong number rather than the runs being wrong. ``_count`` is what an alert
+    rule reads.
+    """
+    if "run_length_over_sla" not in _INSTRUMENTS:
+        from opentelemetry import (  # noqa: PLC0415 — cold path: only reached once a run is over its SLA
+            metrics as _otel_metrics,
+        )
+
+        _INSTRUMENTS["run_length_over_sla"] = _otel_metrics.get_meter(
+            _METER_NAME
+        ).create_histogram(
+            "task.run_length_over_sla",
+            unit="s",
+            description=(
+                "Age of a run observed to be past its run-length SLA, recorded "
+                "once a minute per executing activity attempt for as long as it "
+                "stays over. Partitioned by the workflow type and the task that "
+                "happened to be running, so an alert on the count names both. "
+                "Never recorded for a run inside its SLA — the count going up "
+                "at all is the alert."
+            ),
+        )
+    return _INSTRUMENTS["run_length_over_sla"]
+
+
+@dataclass
+class RunLengthWatch:
+    """One activity attempt's view of how long its *run* has been going.
+
+    Cheap and stateful: two floats and a bool, ticked by the heartbeat loop.
+    Owned by the activity layer (one per attempt), which is also the only place
+    that can supply the run start time.
+
+    Attributes:
+        run_started_at_epoch: Wall-clock seconds since the epoch at which the
+            run started, taken from the workflow side. Compared against this
+            worker's own clock, which is why it is the run *length* to a
+            resolution of NTP skew — irrelevant against an SLA in hours.
+        sla_seconds: How long the run may take before it is worth an alert.
+        task_name: The task executing when the observation is made. Recorded so
+            the alert names where the run was spending its time, not only that
+            it was long.
+        workflow_type: The run's workflow type, for the metric. Bounded by the
+            number of registered workflows.
+        clock: Monotonic source for the re-assert throttle, injected for the
+            same reason ``ProgressTracker`` injects one — an asyncio loop shares
+            ``time.monotonic``, so patching it globally in tests makes the loop
+            itself misbehave.
+        wall_clock: Wall-clock source for the run age, injected so a test can
+            place a run at any age without waiting for one.
+    """
+
+    run_started_at_epoch: float
+    sla_seconds: float
+    task_name: str
+    workflow_type: str = ""
+    clock: Callable[[], float] = time.monotonic
+    wall_clock: Callable[[], float] = time.time
+    _last_observed_at: float | None = field(default=None, init=False, repr=False)
+    _reported: bool = field(default=False, init=False, repr=False)
+
+    def observe(self) -> None:
+        """Record the run's age if it is over the SLA. Never raises.
+
+        Safe to call on every heartbeat tick: it throttles itself to
+        :data:`_OBSERVE_INTERVAL_SECONDS`, and does nothing at all while the run
+        is inside its SLA.
+        """
+        try:
+            if self.sla_seconds <= 0 or self.run_started_at_epoch <= 0:
+                return
+
+            now = self.clock()
+            if (
+                self._last_observed_at is not None
+                and now - self._last_observed_at < _OBSERVE_INTERVAL_SECONDS
+            ):
+                return
+
+            age = self.wall_clock() - self.run_started_at_epoch
+            if age <= self.sla_seconds:
+                # Deliberately not stamped: a run inside its SLA is not an
+                # observation this module makes, so the first tick past the SLA
+                # reports immediately rather than up to a minute late.
+                return
+
+            self._last_observed_at = now
+
+            # The log line comes first so a metric-backend problem cannot also
+            # cost the human-readable half of the alert.
+            if not self._reported:
+                self._reported = True
+                logger.warning(
+                    "Run has been going for %.0fs, past the %.0fs run-length SLA, "
+                    "and is still running task '%s' (workflow type '%s'). Nothing "
+                    "will terminate it on time: a duration alert is what replaced "
+                    "the duration kill (ADR-0018), so decide whether this run is "
+                    "healthy-and-slow — in which case raise "
+                    "ATLAN_RUN_LENGTH_SLA_SECONDS for this app — or wedged, in "
+                    "which case terminate it and look at the task named here",
+                    age,
+                    self.sla_seconds,
+                    self.task_name,
+                    self.workflow_type or "<unknown>",
+                )
+
+            self._record(age)
+        # Best-effort observability: a clock or metric-backend problem must
+        # never fail the attempt this is only observing.
+        except Exception:
+            logger.warning(
+                "Failed to observe the run length for task '%s'; an over-long run "
+                "will be missing from the run-length SLA alert",
+                self.task_name,
+                exc_info=True,
+            )
+
+    def _record(self, age_seconds: float) -> None:
+        _run_length_histogram().record(
+            age_seconds,
+            {
+                "task.name": self.task_name,
+                "temporal.workflow.type": self.workflow_type,
+            },
+        )
+
+
+def build_run_length_watch(
+    run_started_at_epoch: float | None,
+    task_name: str,
+    workflow_type: str = "",
+    sla_seconds: float | None = None,
+) -> RunLengthWatch | None:
+    """Build one attempt's watch, or ``None`` when there is nothing to watch.
+
+    Args:
+        run_started_at_epoch: Run start, from the workflow side. ``None`` or a
+            non-positive value means the dispatching workflow predates this
+            field (a run in flight across the upgrade) or the task ran outside a
+            workflow — either way there is no run to measure, and no watch.
+        task_name: Task executing this attempt.
+        workflow_type: The run's workflow type, for the metric attribute.
+        sla_seconds: Override the process-wide SLA. Defaults to
+            :data:`RUN_LENGTH_SLA_SECONDS`; ``0`` disables.
+
+    Returns:
+        A :class:`RunLengthWatch`, or ``None`` when the SLA is disabled or the
+        run start is unknown.
+    """
+    sla = RUN_LENGTH_SLA_SECONDS if sla_seconds is None else sla_seconds
+    if sla <= 0 or not run_started_at_epoch or run_started_at_epoch <= 0:
+        return None
+    return RunLengthWatch(
+        run_started_at_epoch=run_started_at_epoch,
+        sla_seconds=sla,
+        task_name=task_name,
+        workflow_type=workflow_type,
+    )

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -1,8 +1,8 @@
 <!--
 generated-by:  capability-manifest skill (.claude/skills/capability-manifest)
 sdk-version:   3.27.2
-source-sha:    a131fd58d1a8edb846002aaf07eaf8d3ea648d5d
-source-date:   2026-08-13T17:46:10+00:00
+source-sha:    07f46ed5e21ee1f535a9d77b80e531805822507e
+source-date:   2026-08-13T18:08:24+00:00
 do-not-edit:   re-run the skill instead of hand-editing
 -->
 

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -1,8 +1,8 @@
 <!--
 generated-by:  capability-manifest skill (.claude/skills/capability-manifest)
 sdk-version:   3.27.2
-source-sha:    a3680b5d4e23869d574f3a2a7ff2e8af3e1d4659
-source-date:   2026-08-13T16:18:15+01:00
+source-sha:    a131fd58d1a8edb846002aaf07eaf8d3ea648d5d
+source-date:   2026-08-13T17:46:10+00:00
 do-not-edit:   re-run the skill instead of hand-editing
 -->
 
@@ -24,7 +24,7 @@ do-not-edit:   re-run the skill instead of hand-editing
 | `application_sdk.contracts` | Typed Pydantic Input/Output base classes, payload safety, storage and type helpers | 28 |
 | `application_sdk.credentials` | Credential resolvers (Atlan, OAuth, Git, agent), registry, vault spec | 41 |
 | `application_sdk.errors` | Structured error codes — ErrorCode dataclass and cross-component constants (APP_ERROR, HANDLER_ERROR, CONTRACT_VALIDATION, etc.) | 61 |
-| `application_sdk.execution` | Task/workflow execution — retry, heartbeat, sandbox, AppWorker, Temporal client | 20 |
+| `application_sdk.execution` | Task/workflow execution — retry, heartbeat, sandbox, AppWorker, Temporal client | 21 |
 | `application_sdk.handler` | HTTP handler framework — Handler ABC, DefaultHandler, preflight, auth, service factory | 22 |
 | `application_sdk.infrastructure` | Protocol-based infrastructure (StateStore, SecretStore, PubSub, Bindings, CapacityPool) | 38 |
 | `application_sdk.main` | Dev entry point — run_dev_combined() and AppConfig for local execution and container startup | 2 |
@@ -1476,6 +1476,13 @@ Task/workflow execution — retry, heartbeat, sandbox, AppWorker, Temporal clien
 - **Signature:** `needs_lock(max_locks: int = 5, lock_name: Optional[str] = None)`
 - **Summary:** Decorator to mark activities that require distributed locking.
 - **Defined in:** `application_sdk/execution/decorators.py`
+
+#### `retry_product_seconds`
+
+- **Import:** `from application_sdk.execution import retry_product_seconds`
+- **Signature:** `retry_product_seconds(timeout_seconds: int, *, ...)`
+- **Summary:** The worst-case total seconds a task can consume across *every* attempt.
+- **Defined in:** `application_sdk/execution/retry.py`
 
 ## `application_sdk.handler`
 

--- a/docs/concepts/monitoring.md
+++ b/docs/concepts/monitoring.md
@@ -188,6 +188,7 @@ deliberately not one-gap-sensitive — see the threshold below.
 | Elevated workflow latency | `histogram_quantile(0.99, temporal_workflow_endtoend_latency_bucket) > 300` | Warning |
 | Temporal server errors | `rate(temporal_long_request_failure_total[5m]) > 0` | Warning |
 | Task stalled (wedged but alive) | `AtlanAppTaskStalled` — see below | High |
+| Run past its length SLA | `increase(task_run_length_over_sla_seconds_count[15m]) > 0` — see below | Warning |
 
 The stall alert is **not optional while an app is in `warn`.** Warn mode cannot fail an
 activity, so an alert on this metric is what stands in for the kill: a wedged attempt is
@@ -214,6 +215,53 @@ because both emit nothing and only the wedge keeps emitting nothing. `3600` is o
 permanently-silent attempt, and N concurrent wedges reach it N times faster — so the page
 arrives soonest exactly when worker-slot exhaustion is the real risk. A single gap belongs
 on the dashboard and in the app's own work-list, not in an operator's inbox.
+
+### Run length: the run no stall and no timeout catches
+
+The stall alert above catches an attempt that goes *silent*. It cannot catch a run
+that keeps making **some** progress: every progress signal re-arms the watchdog, so
+no gap is ever observed, and with `start_to_close` raised to a backstop no timeout
+fires either. `temporal_workflow_duration_seconds` does not help — it is recorded
+when a run *ends*, so it can never describe a run that has not ended. That run is
+bounded by nothing, which is why ADR-0018 → *Bounding total time* replaces the
+duration **kill** with a duration **alert**.
+
+Every executing task attempt compares its run's age against
+`ATLAN_RUN_LENGTH_SLA_SECONDS` (24 h by default; `0` disables) on the same tick as
+its heartbeat. Past the SLA it emits:
+
+| Signal | Shape |
+|---|---|
+| `task_run_length_over_sla_seconds` | Histogram of the run's age, labels `task_name`, `temporal_workflow_type`. Recorded **only** while a run is over its SLA, and re-asserted once a minute for as long as it stays over |
+| One `WARNING` log line per attempt | The age, the SLA, the task that was running and the workflow type |
+
+```promql
+increase(task_run_length_over_sla_seconds_count[15m]) > 0
+```
+
+**A count, here, where the stall alert needs accumulated seconds** — and the
+asymmetry is the point. Gaps are emitted by every warn-mode app with an
+uninstrumented quiet spot, so only sustained silence distinguishes a wedge from a
+healthy pause. This series is emitted *only* by a run already past the length its
+own operator declared, so there is nothing to threshold: one observation is the
+finding. `histogram_quantile` over `_bucket` then answers "how far over". Because
+the observation re-asserts every minute, the window only has to exceed a minute —
+`[15m]` leaves slack and resolves within one window of the run ending.
+
+**Runbook:** [Long-running run](../runbooks/long-running-run.md) — how an operator
+separates healthy-but-slow from wedged, and what to do with each.
+
+!!! warning "Same Pushgateway requirement as the stall metric"
+
+    This series is emitted from the worker process, so in a split deployment it
+    only reaches VictoriaMetrics if `ATLAN_PROMETHEUS_PUSHGATEWAY_URL` is set.
+
+**Blind spot, stated.** The observation rides an activity's heartbeat tick, so a
+run is measured only while at least one of its tasks is executing. A run parked
+between activities, a run whose worker is gone entirely, and a task with
+heartbeating disabled are not covered — those are "no worker / no activity"
+conditions, and the worker-liveness and activity-failure alerts above are what see
+them.
 
 ---
 

--- a/docs/concepts/tasks.md
+++ b/docs/concepts/tasks.md
@@ -164,8 +164,9 @@ process startup:
 
 | Env var | Default | Controls |
 |---|---|---|
-| `ATLAN_START_TO_CLOSE_TIMEOUT_SECONDS` | `600` (10 min) | `timeout_seconds` — Temporal kills the activity after this many seconds |
+| `ATLAN_START_TO_CLOSE_TIMEOUT_SECONDS` | `600` (10 min) | `timeout_seconds` — Temporal kills the activity attempt after this many seconds |
 | `ATLAN_HEARTBEAT_TIMEOUT_SECONDS` | `60` | `heartbeat_timeout_seconds` — Temporal restarts the activity if no heartbeat is received within this window |
+| `ATLAN_SCHEDULE_TO_CLOSE_TIMEOUT_SECONDS` | unset | `schedule_to_close_seconds` — ceiling on the task's **total** time across every retry. Unset (or `0`) leaves the retry product unbounded |
 
 Set these in `atlan.yaml` (or your deployment env) to apply a fleet-wide default
 without touching every `@task` decorator:
@@ -202,6 +203,85 @@ progress signals, so a nine-hour task that writes a batch every thirty seconds n
 approaches it. See [Progress and Stalls](progress-and-stalls.md) for the full picture:
 what counts as progress, when you need `holding_progress()`, and how to read the report
 the watchdog produces for your app.
+
+All three bound **one attempt**. The ceiling on a task's *total* time across every
+attempt is a separate question, with its own answer below.
+
+### Bounding the retry product
+
+`timeout_seconds` bounds **one attempt**. The retry policy multiplies it, and
+`StartToClose` is a retryable failure in Temporal, so a wedged task can spend the
+whole product:
+
+```
+worst case per dispatch = retry_max_attempts x timeout_seconds
+```
+
+At the defaults that is 30 minutes. Against a 24-hour backstop it is 72 hours.
+The SDK leaves that product unbounded on purpose ([ADR-0018](../adr/0018-progress-aware-heartbeat.md)
+→ *Bounding total time*) — picking a total duration up front is the guess the
+whole design removes — so the ceiling is a declaration, available three ways:
+
+```python
+from application_sdk.execution.retry import retry_product_seconds
+
+class MyConnector(App):
+    # 1. Bound the total. A ceiling below timeout_seconds caps the attempt too,
+    #    so this works while inheriting a generous per-attempt backstop.
+    @task(schedule_to_close_seconds=7200)
+    async def extract(self, input: MyInput) -> MyOutput: ...
+
+    # 2. Bound at exactly what the retry policy already implies — makes today's
+    #    worst case explicit and enforced, and changes nothing about one attempt.
+    @task(
+        timeout_seconds=3600,
+        retry_max_attempts=3,
+        schedule_to_close_seconds=retry_product_seconds(3600, 3),
+    )
+    async def transform(self, input: MyInput) -> MyOutput: ...
+
+    # 3. Drop the multiplier instead — the right shape for a backstop-class task
+    #    where a retry cannot rescue anything.
+    @task(retry_max_attempts=1)
+    async def publish(self, input: MyInput) -> MyOutput: ...
+```
+
+Set `ATLAN_SCHEDULE_TO_CLOSE_TIMEOUT_SECONDS` to apply a ceiling to every task in
+the app without touching a decorator. Two caveats worth stating:
+
+- A ceiling smaller than **two** attempts makes the retry policy cosmetic — the
+  second attempt cannot start inside the window. `retry_product_seconds` exists
+  so that arithmetic is explicit rather than accidental.
+- The ceiling bounds one *dispatch*, which is what the retry policy spends.
+  Worker-eviction re-dispatches (pod SIGTERM: KEDA scale-down, spot reclaim,
+  rolling deploy) each get a fresh window by design, and are bounded separately
+  by `ATLAN_WORKER_EVICTION_MAX_RETRIES`.
+
+### The run-length SLA alert
+
+A ceiling on the retry product does not bound a run that keeps making *some*
+progress: every progress signal re-arms the stall watchdog, so it never fires,
+and no per-attempt timeout is ever reached. For that shape the SDK raises a
+duration **alert** rather than a duration kill — it cannot know how long a
+healthy run takes against a tenant it has never seen, but a run past the length
+its own operator declared is worth a human look.
+
+Every executing task attempt compares its run's age against the SLA on the same
+tick as its heartbeat. Past the SLA it logs one `WARNING` and records
+`task.run_length_over_sla` (a histogram of the run's age, re-asserted once a
+minute for as long as the run stays over), so the alert keeps firing while the
+run does and resolves once it ends.
+
+| Env var | Default | Controls |
+|---|---|---|
+| `ATLAN_RUN_LENGTH_SLA_SECONDS` | `86400` (24 h) | How long a run may take before the alert is raised. `0` disables it |
+
+Nothing terminates the run. See
+[Monitoring → Run length](monitoring.md#run-length-the-run-no-stall-and-no-timeout-catches)
+for the alert rule and the [long-running-run runbook](../runbooks/long-running-run.md)
+for what an operator does with one. An app whose healthy runs legitimately outlast
+24 hours declares its own value; that declaration is the point, and it costs one env
+var rather than a code change.
 
 ## Manual Heartbeats with Progress
 

--- a/docs/runbooks/long-running-run.md
+++ b/docs/runbooks/long-running-run.md
@@ -1,0 +1,154 @@
+# Runbook: long-running run (run-length SLA)
+
+**Signal:** `task_run_length_over_sla_seconds` — the age of a run observed past
+`ATLAN_RUN_LENGTH_SLA_SECONDS` (see
+[ADR-0018](../adr/0018-progress-aware-heartbeat.md) → *Bounding total time*).
+**Condition:** `increase(task_run_length_over_sla_seconds_count[15m]) > 0`.
+**Severity:** warning, `type: ticket`. Not a customer-visible outage on its own.
+
+---
+
+## What fired
+
+A run has been going longer than the length its own app declared, and **nothing
+will terminate it on time**. It is not stalled: it is making progress, or at least
+making it often enough that the stall watchdog never sees a gap. It has not hit a
+timeout either, because `start_to_close` is a 24h *backstop* per attempt, not a
+budget for the run.
+
+That is the shape no other signal catches:
+
+| Shape | Caught by |
+|---|---|
+| Worker crashed, OOM-killed, node lost | `heartbeat_timeout` (60s), Temporal reclaims the attempt |
+| Attempt alive but silent (wedged) | [`AtlanAppTaskStalled`](stalled-task.md) — the stall watchdog |
+| Attempt failed | Workflow failure, activity error metrics |
+| **Run long but progressing — or dribbling just enough progress to look like it** | **This alert, and only this alert** |
+
+## Why a human is in this loop at all
+
+The SDK cannot know how long a healthy run of an app takes against a tenant it has
+never seen — that is precisely the number ADR-0018 exists to stop guessing. So the
+duration *kill* was replaced with a duration *alert*, and the judgement it needs is
+yours. An alert threshold that is wrong costs you one look; a kill threshold that is
+wrong costs a tenant a run's worth of work.
+
+Note the asymmetry with the stall alert: that one needs *accumulated seconds of
+silence* because warn-mode gaps are normal fleet-wide. This series is emitted only
+by a run already past its declared length, so a single observation is the finding.
+
+## Read the alert first
+
+| Label | What it tells you |
+|---|---|
+| `app_name` | The connector (process-wide app name) |
+| `domainName` / `clusterName` | The tenant and its cluster |
+| `task_name` | The `@task` that was executing when the run was observed over its SLA — where the run is spending its time, which is usually the interesting part |
+| `temporal_workflow_type` | The workflow whose run is long |
+| `$value` | The run's age in seconds. `histogram_quantile` over `_bucket`, or the `_sum`/`_count` ratio, answers "how far over" |
+
+No workflow run id: a run id in a metric label is an unbounded-cardinality bomb
+(see [Metrics Standards](../standards/metrics.md)). Step 1 recovers it from the logs.
+
+## Step 1 — find the run
+
+Search the app's logs for the run-length line:
+
+```
+run-length SLA
+```
+
+Each occurrence carries the Temporal context the metric cannot — `workflow_run_id`,
+`workflow_id` — plus the age, the SLA and the task name in the message body. It is
+logged **once per activity attempt**, so several concurrent long-running tasks in one
+run produce one line each, and a run that outlives an attempt produces a fresh line
+for the next one.
+
+Then open the run in the tenant's Temporal UI:
+
+```
+https://<domainName>/temporal/namespaces/default/workflows?query=ExecutionStatus%3D%27Running%27
+```
+
+If nothing is running any more, the run finished on its own after the observation.
+Nothing to contain — but go to [After the incident](#after-the-incident) anyway,
+because either the SLA or the run's duration is still worth a decision.
+
+## Step 2 — is it progressing?
+
+This is the whole classification, and run length alone cannot answer it —
+healthy-but-slow and wedged-but-dribbling look identical from age.
+
+1. **The stall watchdog.** `task_no_progress_gap_seconds` for this app and task: gaps
+   accumulating means it is going quiet in stretches, and the
+   [stalled-task runbook](stalled-task.md) is the better tool. No gaps at all means it
+   is genuinely reporting progress.
+2. **The app's own throughput.** Records or batches written per minute, from the
+   connector's own metrics or its logs. Flat at zero while progress signals continue
+   is the dribbling shape: something is looping without doing work.
+3. **The tenant's size.** A run that is 30 hours into a first full extraction of a
+   very large source is a different finding from the same run against a source that
+   took 40 minutes last week. Compare with `temporal_workflow_duration_seconds` for
+   the same workflow type and tenant.
+
+## Step 3 — act
+
+| Evidence | What it is | What to do |
+|---|---|---|
+| Progress signals *and* throughput both moving; duration in line with the tenant's size | **Healthy but slow.** The SLA is the wrong number for this app, not the run | Do **not** terminate. Raise `ATLAN_RUN_LENGTH_SLA_SECONDS` for that app (see [After the incident](#after-the-incident)) and let the run finish |
+| Progress signals moving, throughput flat, age growing without bound | **Wedged while dribbling** — a retry loop that never exits, a paginator that never advances, a poll with no terminal condition | Terminate the run, then file a bug against the app naming `task_name`. This is the failure mode the alert exists for |
+| Gaps accumulating in `task_no_progress_gap_seconds` too | **A stall**, and the run length is a symptom | Follow the [stalled-task runbook](stalled-task.md) instead |
+| Source system slow or unresponsive (its own dashboards, connection errors elsewhere in the log, other tenants on the same source affected) | **Source-side degradation** | Terminate and re-run once the source is healthy, or let it finish if the source is recovering |
+
+**If you cannot tell, wait and re-check rather than guessing.** The observation
+re-asserts every minute, so `$value` climbing tells you nothing new — but throughput
+over the next 15 minutes does. Terminating is not free: it kills the whole run, and
+without checkpointing the re-run restarts from zero.
+
+**To terminate:** Temporal UI → Terminate (not Cancel). The unconditional
+auto-heartbeat carries the termination back to the worker within one
+`auto_heartbeat_seconds` interval, and the activity is cancelled at its next
+`await`. An attempt wedged inside a blocking call in a thread has no next `await`;
+the run ends but the worker slot is not reclaimed until the pod restarts. Terminating
+does not re-run anything — re-trigger from the app's or the platform's run UI.
+
+## After the incident
+
+One of two durable outcomes, and "nothing" is not one of them — an alert nobody
+resolves either way becomes noise, and this one is a judgement, not a fault:
+
+- **The run was healthy.** The app's runs legitimately outlast 24 hours, so declare
+  that: set `ATLAN_RUN_LENGTH_SLA_SECONDS` in the app's deployment env to a value
+  above its real p99 run length, with headroom. Size it from
+  `temporal_workflow_duration_seconds` for that workflow type — completed runs are
+  exactly the distribution to read. Declaring the number is the point of the alert;
+  it is not a workaround for it.
+- **The run was wedged.** File the bug with `task_name` and the throughput evidence.
+  If the task has an opaque long-running call in it, the durable fix is usually a
+  progress hook or a `holding_progress(timeout=...)` allowance at that site — see
+  [Progress and Stalls](../concepts/progress-and-stalls.md) — which converts the next
+  occurrence from "long run, cause unknown" into a stall the watchdog names and, in
+  `enforce` mode, kills without a human.
+
+Consider also whether the task wants a ceiling on its retry product
+(`schedule_to_close_seconds`) — see
+[Tasks → Bounding the retry product](../concepts/tasks.md#bounding-the-retry-product).
+A run whose length comes from three 24h attempts of the same wedge is a different fix
+from one long attempt.
+
+## Blind spots
+
+The observation rides an activity's heartbeat tick, so a run is measured **only while
+at least one of its tasks is executing**. Not covered:
+
+- A run parked between activities (waiting on a signal, or on a child workflow whose
+  own activities report under that child's run identity).
+- A run whose worker is gone entirely — that is a worker-liveness condition
+  (`ATLAN_WORKER_LIVENESS_MAX_IDLE_SECONDS`, `temporal_worker_task_slots_available`).
+- A task with heartbeating disabled (`heartbeat_timeout_seconds=None`): no tick, no
+  observation.
+
+This is a deliberate trade. Measuring run length from inside workflow code would need
+a durable timer in every run's history and would risk a non-determinism failure on
+in-flight runs at every SDK upgrade. If one of the shapes above ever produces a real
+incident, that timer — behind `workflow.patched` — is the escalation.

--- a/docs/standards/metrics.md
+++ b/docs/standards/metrics.md
@@ -213,8 +213,8 @@ canonical bounded label set is:
 | `mode` | `record_metric` callers | `WriteMode` enum (`append`, `overwrite`, …) |
 | `type` / `format` | `record_metric` callers | Bounded enumerations of write paths |
 | `error_type` | `record_metric` callers | `type(e).__name__` |
-| `task_name` | `execution/progress_telemetry.py` | Number of registered tasks per app |
-| `progress_last_label` | same | The SDK's fixed set of progress-hook labels plus each app's own hold labels — a call site, never a value |
+| `task_name` | `execution/progress_telemetry.py`, `execution/run_length.py` | Number of registered tasks per app |
+| `progress_last_label` | `execution/progress_telemetry.py` | The SDK's fixed set of progress-hook labels plus each app's own hold labels — a call site, never a value |
 | `hold_label` | same | Same set. `run_in_thread` holds are labelled by the offloaded callable's qualname, never by an argument |
 | `watchdog_mode` | same | `off`, `warn`, `enforce` |
 | `hold_bounded` / `hold_lapsed` | same | `true`, `false` — **lowercase**, since dashboard panels and alert rules filter on those literals |
@@ -246,6 +246,7 @@ Names emitted by the consolidated SDK surface (all use OTel base units
 | `http_server_active_requests` | gauge | same |
 | `temporal_*` (Rust-core families) | various | Temporal SDK Rust core, scraped via FastAPI proxy or pushed via `TemporalCoreCollector` |
 | `temporal_core_metrics_proxy_failures_total` | counter | `handler/service.py` — bumped (with `reason` label) when the in-process Temporal-core proxy fetch from `127.0.0.1:9464` fails (timeout, non-200, etc.) so `up=1` scrapes with missing `temporal_*` series are observable from VictoriaMetrics rather than only from logs |
+| `task_run_length_over_sla_seconds` | histogram | `execution/run_length.py` — age of a run observed past `ATLAN_RUN_LENGTH_SLA_SECONDS`, re-asserted once a minute while it stays over; labels `task_name`, `temporal_workflow_type`. Recorded *only* over the SLA, so `_count` rising is the alert. **Alertable**: see [Monitoring](../concepts/monitoring.md#run-length-the-run-no-stall-and-no-timeout-catches) and the [long-running-run runbook](../runbooks/long-running-run.md) |
 | `dapr_sidecar_wait_duration_seconds` | histogram | `infrastructure/_dapr/http.py` — `wait_for_dapr_sidecar()`, label `outcome` (`ready` / `reachable_not_ready` / `timed_out`); surfaces a slow/misconfigured sidecar as a boot-time metric instead of only as a downstream liveness-probe restart loop |
 | `task_no_progress_gap_seconds` | histogram | `execution/progress_telemetry.py` — one entry per no-progress gap exceeding `max_no_progress_seconds`, labels `task_name`, `progress_last_label`, `watchdog_mode` (ADR-0018). **Alertable**: `AtlanAppTaskStalled` in `atlanhq/atlan-alerts` pages on `increase(…_sum[1h]) >= 3600`, since in warn mode this signal stands in for the kill — see the [stalled-task runbook](../runbooks/stalled-task.md) |
 | `task_hold_duration_seconds` | histogram | same — one entry per released progress hold, labels `task_name`, `hold_label`, `hold_bounded`, `hold_lapsed`; every hold is recorded, since sizing an allowance means reading that site's own distribution. Work-list only, deliberately not alerted |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -157,6 +157,7 @@ nav:
       - Configuration: configuration.md
   - Runbooks:
       - Stalled Task: runbooks/stalled-task.md
+      - Long-Running Run: runbooks/long-running-run.md
   - Postmortems:
       - Shutdown Drain Delay (2026-03-27): rca-shutdown-drain-delay-2026-03-27.md
   - API Reference: https://k.atlan.dev/application-sdk/main/api

--- a/tests/unit/execution/test_retry_product_bound.py
+++ b/tests/unit/execution/test_retry_product_bound.py
@@ -13,7 +13,6 @@ correctly but never reaches the wire still fails.
 
 from __future__ import annotations
 
-import asyncio
 from datetime import timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -48,7 +47,7 @@ class _Out(Output):
     pass
 
 
-def _dispatch_kwargs(**wrapper_kwargs: object) -> dict[str, object]:
+async def _dispatch_kwargs(**wrapper_kwargs: object) -> dict[str, object]:
     """Kwargs the workflow-side wrapper hands to Temporal for one dispatch."""
     with patch(_EVICTION_RETRY_PATH, new_callable=AsyncMock) as mock_exec:
         from application_sdk.app.base import _create_task_activity_wrapper
@@ -63,7 +62,7 @@ def _dispatch_kwargs(**wrapper_kwargs: object) -> dict[str, object]:
             retry_max_interval_seconds=30,
             **wrapper_kwargs,  # type: ignore[arg-type]
         )
-        asyncio.run(wrapper(MagicMock()))
+        await wrapper(MagicMock())
 
     return dict(mock_exec.call_args.kwargs)
 
@@ -121,6 +120,14 @@ class TestResolveActivityTimeBounds:
 
 
 class TestTaskDeclaration:
+    def setup_method(self) -> None:
+        AppRegistry.reset()
+        TaskRegistry.reset()
+
+    def teardown_method(self) -> None:
+        AppRegistry.reset()
+        TaskRegistry.reset()
+
     def test_unset_by_default_so_todays_behaviour_is_unchanged(self) -> None:
         class _App(App):
             @task(timeout_seconds=600)
@@ -248,35 +255,37 @@ class TestGetActivityOptions:
 
 
 class TestWorkflowDispatch:
-    def test_no_schedule_to_close_kwarg_without_a_declared_ceiling(self) -> None:
+    async def test_no_schedule_to_close_kwarg_without_a_declared_ceiling(self) -> None:
         """Byte-identical to before this knob existed for every task that has
         not opted in — the kwarg is omitted, not passed as None."""
-        kwargs = _dispatch_kwargs(timeout_seconds=600)
+        kwargs = await _dispatch_kwargs(timeout_seconds=600)
 
         assert "schedule_to_close_timeout" not in kwargs
         assert kwargs["start_to_close_timeout"] == timedelta(seconds=600)
 
-    def test_a_declared_ceiling_reaches_the_dispatch(self) -> None:
-        kwargs = _dispatch_kwargs(timeout_seconds=600, schedule_to_close_seconds=1810)
+    async def test_a_declared_ceiling_reaches_the_dispatch(self) -> None:
+        kwargs = await _dispatch_kwargs(
+            timeout_seconds=600, schedule_to_close_seconds=1810
+        )
 
         assert kwargs["schedule_to_close_timeout"] == timedelta(seconds=1810)
         assert kwargs["start_to_close_timeout"] == timedelta(seconds=600)
 
-    def test_a_ceiling_below_one_attempt_caps_the_dispatched_start_to_close(
+    async def test_a_ceiling_below_one_attempt_caps_the_dispatched_start_to_close(
         self,
     ) -> None:
-        kwargs = _dispatch_kwargs(
+        kwargs = await _dispatch_kwargs(
             timeout_seconds=86_400, schedule_to_close_seconds=3600
         )
 
         assert kwargs["start_to_close_timeout"] == timedelta(seconds=3600)
         assert kwargs["schedule_to_close_timeout"] == timedelta(seconds=3600)
 
-    def test_bounding_at_the_retry_product_changes_nothing_about_one_attempt(
+    async def test_bounding_at_the_retry_product_changes_nothing_about_one_attempt(
         self,
     ) -> None:
         """The ceiling that makes today's worst case explicit and enforced."""
-        kwargs = _dispatch_kwargs(
+        kwargs = await _dispatch_kwargs(
             timeout_seconds=3600,
             schedule_to_close_seconds=retry_product_seconds(3600, 3),
         )

--- a/tests/unit/execution/test_retry_product_bound.py
+++ b/tests/unit/execution/test_retry_product_bound.py
@@ -27,11 +27,9 @@ from application_sdk.app.task import (
     task,
 )
 from application_sdk.contracts.base import Input, Output
+from application_sdk.execution import retry_product_seconds
 from application_sdk.execution._temporal.activities import get_activity_options
-from application_sdk.execution.retry import (
-    resolve_activity_time_bounds,
-    retry_product_seconds,
-)
+from application_sdk.execution.retry import resolve_activity_time_bounds
 
 _EVICTION_RETRY_PATH = (
     "application_sdk.execution._temporal.eviction_retry."

--- a/tests/unit/execution/test_retry_product_bound.py
+++ b/tests/unit/execution/test_retry_product_bound.py
@@ -1,0 +1,285 @@
+"""Unit tests for the bound on a task's retry product (FND-294, ADR-0018).
+
+``start_to_close`` bounds one attempt; the retry policy multiplies it. These
+tests pin the mechanism that makes the *product* boundable — and pin that the
+default still leaves it unbounded, because ADR-0018's accepted position is to
+start there deliberately and size the ceiling from warn-mode data.
+
+The dispatch assertions run through ``_create_task_activity_wrapper`` and
+``get_activity_options`` — the two code paths that actually hand timeouts to
+Temporal — rather than against the resolver alone, so a ceiling that resolves
+correctly but never reaches the wire still fails.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from application_sdk.app import App
+from application_sdk.app.registry import AppRegistry, TaskRegistry
+from application_sdk.app.task import (
+    TaskContractError,
+    _load_default_schedule_to_close_seconds,
+    get_task_metadata,
+    task,
+)
+from application_sdk.contracts.base import Input, Output
+from application_sdk.execution._temporal.activities import get_activity_options
+from application_sdk.execution.retry import (
+    resolve_activity_time_bounds,
+    retry_product_seconds,
+)
+
+_EVICTION_RETRY_PATH = (
+    "application_sdk.execution._temporal.eviction_retry."
+    "execute_activity_with_eviction_retry"
+)
+
+
+class _In(Input):
+    pass
+
+
+class _Out(Output):
+    pass
+
+
+def _dispatch_kwargs(**wrapper_kwargs: object) -> dict[str, object]:
+    """Kwargs the workflow-side wrapper hands to Temporal for one dispatch."""
+    with patch(_EVICTION_RETRY_PATH, new_callable=AsyncMock) as mock_exec:
+        from application_sdk.app.base import _create_task_activity_wrapper
+
+        mock_exec.return_value = MagicMock()
+        wrapper = _create_task_activity_wrapper(
+            app_name="qi-app",
+            task_name="extract",
+            output_type=_Out,
+            context_data={"run_id": "r1", "correlation_id": "c1"},
+            retry_max_attempts=3,
+            retry_max_interval_seconds=30,
+            **wrapper_kwargs,  # type: ignore[arg-type]
+        )
+        asyncio.run(wrapper(MagicMock()))
+
+    return dict(mock_exec.call_args.kwargs)
+
+
+# ---------------------------------------------------------------------------
+# The arithmetic: what a per-attempt ceiling costs once retries multiply it
+# ---------------------------------------------------------------------------
+
+
+class TestRetryProductSeconds:
+    def test_product_is_attempts_times_one_attempt_plus_backoff_headroom(self) -> None:
+        assert retry_product_seconds(3600, 3) == 3 * 3600 + 10
+
+    def test_the_24h_backstop_at_three_attempts_is_the_72h_worst_case(self) -> None:
+        """The number ADR-0018 accepts as the starting point, in one assertion."""
+        assert retry_product_seconds(86_400, 3) == 72 * 3600 + 10
+
+    def test_headroom_leaves_room_for_the_backoff_between_attempts(self) -> None:
+        """A ceiling of exactly attempts x attempt would fire during the last
+        backoff wait, silently costing an attempt the retry policy grants."""
+        assert retry_product_seconds(600, 2) > 2 * 600
+
+    def test_zero_and_negative_attempts_still_bound_one_attempt(self) -> None:
+        """One attempt always runs, whatever a malformed policy says."""
+        assert retry_product_seconds(600, 0) == 610
+        assert retry_product_seconds(600, -5) == 610
+
+
+# ---------------------------------------------------------------------------
+# Resolution: the one reader both dispatch paths share
+# ---------------------------------------------------------------------------
+
+
+class TestResolveActivityTimeBounds:
+    def test_no_ceiling_leaves_the_product_unbounded(self) -> None:
+        assert resolve_activity_time_bounds(600, None) == (600, None)
+
+    def test_a_ceiling_above_one_attempt_bounds_the_product_only(self) -> None:
+        assert resolve_activity_time_bounds(600, 1810) == (600, 1810)
+
+    def test_a_ceiling_below_one_attempt_caps_that_attempt_too(self) -> None:
+        """Declaring only a total is the shape an app gets while inheriting a
+        generous per-attempt backstop; the tighter number is the declaration."""
+        assert resolve_activity_time_bounds(86_400, 3600) == (3600, 3600)
+
+    def test_never_returns_an_inverted_pair(self) -> None:
+        start_to_close, schedule_to_close = resolve_activity_time_bounds(86_400, 60)
+        assert schedule_to_close is not None
+        assert start_to_close <= schedule_to_close
+
+
+# ---------------------------------------------------------------------------
+# The declaration surface: @task, and the fleet-wide env var
+# ---------------------------------------------------------------------------
+
+
+class TestTaskDeclaration:
+    def test_unset_by_default_so_todays_behaviour_is_unchanged(self) -> None:
+        class _App(App):
+            @task(timeout_seconds=600)
+            async def extract(self, input: _In) -> _Out:
+                return _Out()
+
+            async def run(self, input: _In) -> _Out:
+                return _Out()
+
+        metadata = get_task_metadata(_App.extract)
+        assert metadata is not None
+        assert metadata.schedule_to_close_seconds is None
+
+    def test_explicit_ceiling_is_carried_on_the_metadata(self) -> None:
+        class _App(App):
+            @task(timeout_seconds=600, schedule_to_close_seconds=1810)
+            async def extract(self, input: _In) -> _Out:
+                return _Out()
+
+            async def run(self, input: _In) -> _Out:
+                return _Out()
+
+        metadata = get_task_metadata(_App.extract)
+        assert metadata is not None
+        assert metadata.schedule_to_close_seconds == 1810
+
+    def test_zero_is_refused_rather_than_read_as_disabled(self) -> None:
+        """``0`` would fail every attempt before it started. ``None`` is how a
+        task opts out; the error has to say so."""
+        with pytest.raises(TaskContractError, match="Pass None"):
+
+            @task(schedule_to_close_seconds=0)
+            async def extract(input: _In) -> _Out:
+                return _Out()
+
+    def test_negative_is_refused(self) -> None:
+        with pytest.raises(TaskContractError, match="positive number of seconds"):
+
+            @task(schedule_to_close_seconds=-1)
+            async def extract(input: _In) -> _Out:
+                return _Out()
+
+
+class TestFleetWideEnvVar:
+    """The decision after warn-mode data is a config change, so the env var is
+    the surface that matters most — including its failure modes, which must cost
+    the config value and never the worker's boot."""
+
+    def test_a_positive_value_becomes_the_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("ATLAN_SCHEDULE_TO_CLOSE_TIMEOUT_SECONDS", "7200")
+        assert _load_default_schedule_to_close_seconds() == 7200
+
+    def test_unset_leaves_the_product_unbounded(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("ATLAN_SCHEDULE_TO_CLOSE_TIMEOUT_SECONDS", raising=False)
+        assert _load_default_schedule_to_close_seconds() is None
+
+    def test_zero_clears_an_inherited_ceiling(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("ATLAN_SCHEDULE_TO_CLOSE_TIMEOUT_SECONDS", "0")
+        assert _load_default_schedule_to_close_seconds() is None
+
+    def test_a_negative_value_is_ignored_rather_than_failing_every_decoration(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("ATLAN_SCHEDULE_TO_CLOSE_TIMEOUT_SECONDS", "-30")
+        assert _load_default_schedule_to_close_seconds() is None
+
+    def test_a_malformed_value_is_ignored_rather_than_failing_every_decoration(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("ATLAN_SCHEDULE_TO_CLOSE_TIMEOUT_SECONDS", "sometimes")
+        assert _load_default_schedule_to_close_seconds() is None
+
+
+# ---------------------------------------------------------------------------
+# The wire: both paths that hand timeouts to Temporal
+# ---------------------------------------------------------------------------
+
+
+class TestGetActivityOptions:
+    def setup_method(self) -> None:
+        AppRegistry.reset()
+        TaskRegistry.reset()
+
+    def teardown_method(self) -> None:
+        AppRegistry.reset()
+        TaskRegistry.reset()
+
+    def _options(self, **task_kwargs: object) -> dict[str, object]:
+        class _OptionsApp(App):
+            @task(**task_kwargs)  # type: ignore[arg-type]
+            async def extract(self, input: _In) -> _Out:
+                return _Out()
+
+            async def run(self, input: _In) -> _Out:
+                return _Out()
+
+        tasks = TaskRegistry.get_instance().get_tasks_for_app("_options-app")
+        return get_activity_options(next(t for t in tasks if t.name == "extract"))
+
+    def test_no_schedule_to_close_without_a_declared_ceiling(self) -> None:
+        options = self._options(timeout_seconds=600)
+
+        assert "schedule_to_close_timeout" not in options
+        assert options["start_to_close_timeout"] == timedelta(seconds=600)
+
+    def test_a_declared_ceiling_reaches_the_options(self) -> None:
+        options = self._options(timeout_seconds=600, schedule_to_close_seconds=1810)
+
+        assert options["schedule_to_close_timeout"] == timedelta(seconds=1810)
+        assert options["start_to_close_timeout"] == timedelta(seconds=600)
+
+    def test_a_ceiling_below_one_attempt_caps_start_to_close_in_the_options(
+        self,
+    ) -> None:
+        options = self._options(timeout_seconds=86_400, schedule_to_close_seconds=3600)
+
+        assert options["start_to_close_timeout"] == timedelta(seconds=3600)
+        assert options["schedule_to_close_timeout"] == timedelta(seconds=3600)
+
+
+class TestWorkflowDispatch:
+    def test_no_schedule_to_close_kwarg_without_a_declared_ceiling(self) -> None:
+        """Byte-identical to before this knob existed for every task that has
+        not opted in — the kwarg is omitted, not passed as None."""
+        kwargs = _dispatch_kwargs(timeout_seconds=600)
+
+        assert "schedule_to_close_timeout" not in kwargs
+        assert kwargs["start_to_close_timeout"] == timedelta(seconds=600)
+
+    def test_a_declared_ceiling_reaches_the_dispatch(self) -> None:
+        kwargs = _dispatch_kwargs(timeout_seconds=600, schedule_to_close_seconds=1810)
+
+        assert kwargs["schedule_to_close_timeout"] == timedelta(seconds=1810)
+        assert kwargs["start_to_close_timeout"] == timedelta(seconds=600)
+
+    def test_a_ceiling_below_one_attempt_caps_the_dispatched_start_to_close(
+        self,
+    ) -> None:
+        kwargs = _dispatch_kwargs(
+            timeout_seconds=86_400, schedule_to_close_seconds=3600
+        )
+
+        assert kwargs["start_to_close_timeout"] == timedelta(seconds=3600)
+        assert kwargs["schedule_to_close_timeout"] == timedelta(seconds=3600)
+
+    def test_bounding_at_the_retry_product_changes_nothing_about_one_attempt(
+        self,
+    ) -> None:
+        """The ceiling that makes today's worst case explicit and enforced."""
+        kwargs = _dispatch_kwargs(
+            timeout_seconds=3600,
+            schedule_to_close_seconds=retry_product_seconds(3600, 3),
+        )
+
+        assert kwargs["start_to_close_timeout"] == timedelta(seconds=3600)
+        assert kwargs["schedule_to_close_timeout"] == timedelta(seconds=3 * 3600 + 10)

--- a/tests/unit/execution/test_run_length.py
+++ b/tests/unit/execution/test_run_length.py
@@ -135,6 +135,16 @@ class TestObservation:
         assert observed.recorded == []
         assert observed.warnings == []
 
+    def test_a_run_at_exactly_its_sla_reports_nothing(self) -> None:
+        """The load-bearing comparison is ``age <= sla_seconds``: a run at the
+        exact boundary is still inside its SLA and must not alert."""
+        harness = _Harness(run_age=_SLA)
+        harness.tick()
+
+        observed = harness.observed()
+        assert observed.recorded == []
+        assert observed.warnings == []
+
     def test_a_run_past_its_sla_records_its_age_and_warns(self) -> None:
         harness = _Harness(run_age=_SLA + 600)
         harness.tick()
@@ -295,6 +305,33 @@ class TestSlaFromEnv:
         monkeypatch.setenv("ATLAN_RUN_LENGTH_SLA_SECONDS", "a day or so")
 
         assert _load_sla_seconds() == float(_DEFAULT_SLA_SECONDS)
+
+    def test_the_import_time_constant_is_what_production_reads(self) -> None:
+        """``build_run_length_watch`` defaults to ``RUN_LENGTH_SLA_SECONDS``,
+        which is bound once at import — so the env var's effect on the constant
+        itself is the surface worth pinning, not only the loader beneath it.
+
+        Run in a subprocess: the constant binds at import, and re-importing the
+        module in this process would mint a second ``RunLengthWatch`` class and
+        break ``isinstance`` for every sibling test that imported it by name.
+        """
+        import subprocess
+        import sys
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                "import os; "
+                "os.environ['ATLAN_RUN_LENGTH_SLA_SECONDS'] = '7200'; "
+                "from application_sdk.execution import run_length as m; "
+                "assert m.RUN_LENGTH_SLA_SECONDS == 7200.0, "
+                "f'constant bound {m.RUN_LENGTH_SLA_SECONDS}, not the env var'",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stderr
 
 
 # ---------------------------------------------------------------------------
@@ -480,7 +517,7 @@ class TestWireCompatibility:
 
 
 class TestWorkflowStampsTheRunStart:
-    def _dispatched_context(self) -> Any:
+    async def _dispatched_context(self) -> Any:
         with patch(
             "application_sdk.execution._temporal.eviction_retry."
             "execute_activity_with_eviction_retry",
@@ -496,11 +533,11 @@ class TestWorkflowStampsTheRunStart:
                 output_type=_PlumbingOut,
                 context_data={"run_id": "r1", "correlation_id": "c1"},
             )
-            asyncio.run(wrapper(MagicMock()))
+            await wrapper(MagicMock())
 
         return mock_exec.call_args.kwargs["args"][0]
 
-    def test_the_run_start_comes_from_history_not_a_clock(self) -> None:
+    async def test_the_run_start_comes_from_history_not_a_clock(self) -> None:
         """``workflow.info().start_time`` is replayed from the run's own history,
         so a replay measures the run's real age instead of restarting the clock."""
         started = datetime(2026, 8, 13, 6, 0, tzinfo=UTC)
@@ -508,11 +545,11 @@ class TestWorkflowStampsTheRunStart:
         with patch.object(
             base_module.workflow, "info", return_value=MagicMock(start_time=started)
         ):
-            context = self._dispatched_context()
+            context = await self._dispatched_context()
 
         assert context.run_started_at_epoch == started.timestamp()
 
-    def test_unknown_outside_a_workflow_context(self) -> None:
+    async def test_unknown_outside_a_workflow_context(self) -> None:
         """A local run has no run to measure — and reading the start must never
         be the thing that fails a dispatch."""
         with patch.object(
@@ -520,6 +557,6 @@ class TestWorkflowStampsTheRunStart:
             "info",
             side_effect=RuntimeError("not in workflow event loop"),
         ):
-            context = self._dispatched_context()
+            context = await self._dispatched_context()
 
         assert context.run_started_at_epoch == 0.0

--- a/tests/unit/execution/test_run_length.py
+++ b/tests/unit/execution/test_run_length.py
@@ -1,0 +1,525 @@
+"""Unit tests for the run-length SLA observation (FND-294, ADR-0018).
+
+The duration *alert* that replaces the duration *kill*: once ``start_to_close``
+is a backstop, a run that wedges while dribbling progress re-arms the stall
+watchdog on every mark and is bounded by nothing. These tests pin what the
+observation reports, what it stays quiet about, and that it can never fail the
+attempt it is only watching.
+
+Clocks are injected rather than patched globally: an asyncio loop shares
+``time.monotonic``, so patching it makes the loop itself misbehave.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from application_sdk.app import App
+from application_sdk.app import base as base_module
+from application_sdk.app.base import _create_task_activity_wrapper
+from application_sdk.app.registry import AppRegistry, TaskRegistry
+from application_sdk.app.task import task
+from application_sdk.contracts.base import Input, Output
+from application_sdk.execution import run_length as rl_mod
+from application_sdk.execution._temporal import activities as activities_module
+from application_sdk.execution._temporal.activities import (
+    TaskContext,
+    create_activity_from_task,
+)
+from application_sdk.execution._temporal.converter import create_data_converter
+from application_sdk.execution.heartbeat import auto_heartbeat_loop
+from application_sdk.execution.run_length import (
+    _DEFAULT_SLA_SECONDS,
+    _OBSERVE_INTERVAL_SECONDS,
+    RunLengthWatch,
+    _load_sla_seconds,
+    build_run_length_watch,
+)
+
+_RUN_STARTED = 1_000_000.0
+_SLA = 3600.0
+
+
+@dataclass
+class FakeClock:
+    """A clock the test advances explicitly."""
+
+    now: float
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+@dataclass
+class Observed:
+    """What a watch reported over its lifetime."""
+
+    recorded: list[Any] = field(default_factory=list)
+    warnings: list[Any] = field(default_factory=list)
+
+    @property
+    def ages(self) -> list[float]:
+        return [call.args[0] for call in self.recorded]
+
+    @property
+    def attributes(self) -> dict[str, str]:
+        assert len(self.recorded) == 1
+        return self.recorded[0].args[1]
+
+
+class _Harness:
+    """One watch, its instrument and its logger, with time under test control."""
+
+    def __init__(
+        self,
+        *,
+        run_age: float,
+        sla: float = _SLA,
+        task_name: str = "extract",
+        workflow_type: str = "MyConnectorWorkflow",
+        run_started_at_epoch: float = _RUN_STARTED,
+        record_raises: bool = False,
+    ) -> None:
+        self.monotonic = FakeClock(now=500.0)
+        self.wall = FakeClock(now=run_started_at_epoch + run_age)
+        self.histogram = MagicMock()
+        if record_raises:
+            self.histogram.record.side_effect = RuntimeError("metric backend down")
+        self.watch = RunLengthWatch(
+            run_started_at_epoch=run_started_at_epoch,
+            sla_seconds=sla,
+            task_name=task_name,
+            workflow_type=workflow_type,
+            clock=self.monotonic,
+            wall_clock=self.wall,
+        )
+
+    def tick(self, *, after_seconds: float = 0.0) -> None:
+        """Advance both clocks by the same amount, then observe once."""
+        self.monotonic.advance(after_seconds)
+        self.wall.advance(after_seconds)
+        with (
+            patch.object(rl_mod, "logger") as logger,
+            patch.object(rl_mod, "_run_length_histogram", return_value=self.histogram),
+        ):
+            self.watch.observe()
+        self._logger = logger
+
+    def observed(self) -> Observed:
+        return Observed(
+            recorded=list(self.histogram.record.call_args_list),
+            warnings=list(self._logger.warning.call_args_list),
+        )
+
+
+# ---------------------------------------------------------------------------
+# What is, and is not, an observation
+# ---------------------------------------------------------------------------
+
+
+class TestObservation:
+    def test_a_run_inside_its_sla_reports_nothing(self) -> None:
+        harness = _Harness(run_age=_SLA - 1)
+        harness.tick()
+
+        observed = harness.observed()
+        assert observed.recorded == []
+        assert observed.warnings == []
+
+    def test_a_run_past_its_sla_records_its_age_and_warns(self) -> None:
+        harness = _Harness(run_age=_SLA + 600)
+        harness.tick()
+
+        observed = harness.observed()
+        assert observed.ages == [_SLA + 600]
+        assert len(observed.warnings) == 1
+
+    def test_the_metric_names_the_workflow_and_the_running_task(self) -> None:
+        """An alert on the count has to say where the run was spending its time,
+        not only that it was long."""
+        harness = _Harness(run_age=_SLA + 1)
+        harness.tick()
+
+        assert harness.observed().attributes == {
+            "task.name": "extract",
+            "temporal.workflow.type": "MyConnectorWorkflow",
+        }
+
+    def test_the_first_tick_past_the_sla_reports_without_waiting_out_the_throttle(
+        self,
+    ) -> None:
+        """A run inside its SLA is not an observation, so it must not consume the
+        re-assert throttle on the way past the threshold."""
+        harness = _Harness(run_age=_SLA - 10)
+        harness.tick()
+        assert harness.observed().recorded == []
+
+        harness.tick(after_seconds=11)
+
+        assert harness.observed().ages == [_SLA + 1]
+
+    def test_an_unknown_run_start_reports_nothing(self) -> None:
+        """A task invoked outside a workflow, or a run dispatched by a workflow
+        that predates ``run_started_at_epoch`` and is in flight across the
+        upgrade."""
+        harness = _Harness(run_age=_SLA + 600, run_started_at_epoch=0.0)
+        harness.tick()
+
+        assert harness.observed().recorded == []
+
+    def test_a_disabled_sla_reports_nothing(self) -> None:
+        harness = _Harness(run_age=10 * _SLA, sla=0.0)
+        harness.tick()
+
+        assert harness.observed().recorded == []
+
+
+# ---------------------------------------------------------------------------
+# Re-assertion: the alert stays firing while the run does, and resolves after
+# ---------------------------------------------------------------------------
+
+
+class TestReAssertion:
+    def test_the_metric_re_asserts_so_the_alert_keeps_firing(self) -> None:
+        harness = _Harness(run_age=_SLA + 1)
+        harness.tick()
+        harness.tick(after_seconds=_OBSERVE_INTERVAL_SECONDS)
+        harness.tick(after_seconds=_OBSERVE_INTERVAL_SECONDS)
+
+        assert harness.observed().ages == [
+            _SLA + 1,
+            _SLA + 1 + _OBSERVE_INTERVAL_SECONDS,
+            _SLA + 1 + 2 * _OBSERVE_INTERVAL_SECONDS,
+        ]
+
+    def test_ticks_inside_the_throttle_window_add_no_metric_points(self) -> None:
+        """The heartbeat loop ticks every 10s by default; the alert needs minutes,
+        not a point per beat."""
+        harness = _Harness(run_age=_SLA + 1)
+        harness.tick()
+        for _ in range(5):
+            harness.tick(after_seconds=_OBSERVE_INTERVAL_SECONDS / 6)
+
+        assert len(harness.observed().recorded) == 1
+
+    def test_the_warning_is_logged_once_per_attempt_not_once_per_point(self) -> None:
+        """The metric is what an alert reads; a line per minute for three days
+        would bury it."""
+        harness = _Harness(run_age=_SLA + 1)
+        harness.tick()
+        first = harness.observed().warnings
+        harness.tick(after_seconds=_OBSERVE_INTERVAL_SECONDS)
+        second = harness.observed().warnings
+
+        assert len(first) == 1
+        assert second == []
+
+
+# ---------------------------------------------------------------------------
+# It can never fail the attempt it is watching
+# ---------------------------------------------------------------------------
+
+
+class TestBestEffort:
+    def test_a_metric_backend_failure_is_swallowed_and_complained_about(self) -> None:
+        harness = _Harness(run_age=_SLA + 1, record_raises=True)
+        harness.tick()  # must not raise
+
+        warnings = harness.observed().warnings
+        assert any("Failed to observe the run length" in str(w) for w in warnings)
+
+
+# ---------------------------------------------------------------------------
+# Construction: SLA resolution and the cases with nothing to watch
+# ---------------------------------------------------------------------------
+
+
+class TestBuildRunLengthWatch:
+    def test_builds_a_watch_for_a_known_run(self) -> None:
+        watch = build_run_length_watch(_RUN_STARTED, task_name="extract")
+
+        assert watch is not None
+        assert watch.sla_seconds == rl_mod.RUN_LENGTH_SLA_SECONDS
+
+    def test_no_watch_without_a_run_start(self) -> None:
+        assert build_run_length_watch(None, task_name="extract") is None
+        assert build_run_length_watch(0.0, task_name="extract") is None
+
+    def test_no_watch_when_the_sla_is_disabled(self) -> None:
+        assert build_run_length_watch(_RUN_STARTED, "extract", sla_seconds=0) is None
+
+    def test_an_explicit_sla_overrides_the_process_wide_one(self) -> None:
+        watch = build_run_length_watch(_RUN_STARTED, "extract", sla_seconds=60)
+
+        assert watch is not None
+        assert watch.sla_seconds == 60
+
+
+class TestSlaFromEnv:
+    def test_defaults_to_24h(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("ATLAN_RUN_LENGTH_SLA_SECONDS", raising=False)
+
+        assert _load_sla_seconds() == float(_DEFAULT_SLA_SECONDS) == 86_400.0
+
+    def test_an_app_declares_its_own_run_length(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("ATLAN_RUN_LENGTH_SLA_SECONDS", "172800")
+
+        assert _load_sla_seconds() == 172_800.0
+
+    def test_zero_disables_the_alert(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ATLAN_RUN_LENGTH_SLA_SECONDS", "0")
+
+        assert _load_sla_seconds() == 0.0
+
+    def test_a_negative_value_disables_rather_than_alerting_on_every_run(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("ATLAN_RUN_LENGTH_SLA_SECONDS", "-1")
+
+        assert _load_sla_seconds() == 0.0
+
+    def test_a_malformed_value_falls_back_to_the_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("ATLAN_RUN_LENGTH_SLA_SECONDS", "a day or so")
+
+        assert _load_sla_seconds() == float(_DEFAULT_SLA_SECONDS)
+
+
+# ---------------------------------------------------------------------------
+# The wiring: the watch rides the heartbeat tick
+# ---------------------------------------------------------------------------
+
+
+class TestHeartbeatLoopWiring:
+    @pytest.mark.asyncio
+    async def test_the_loop_observes_the_run_on_every_tick(self) -> None:
+        stop = asyncio.Event()
+        watch = MagicMock()
+        beats: list[int] = []
+
+        def beat() -> None:
+            beats.append(1)
+            if len(beats) >= 2:
+                stop.set()
+
+        await auto_heartbeat_loop(
+            interval_seconds=0.001,
+            heartbeat_fn=beat,
+            stop_event=stop,
+            task_name="extract",
+            run_length=watch,
+        )
+
+        assert watch.observe.call_count >= 1
+
+    @pytest.mark.asyncio
+    async def test_no_watch_leaves_the_loop_as_it_was(self) -> None:
+        """The default is byte-identical to before the observation existed."""
+        stop = asyncio.Event()
+        beats: list[int] = []
+
+        def beat() -> None:
+            beats.append(1)
+            stop.set()
+
+        await auto_heartbeat_loop(
+            interval_seconds=0.001,
+            heartbeat_fn=beat,
+            stop_event=stop,
+            task_name="extract",
+        )
+
+        assert beats == [1]
+
+
+# ---------------------------------------------------------------------------
+# The plumbing: the run start reaches the activity, and the watch reaches the tick
+# ---------------------------------------------------------------------------
+
+
+class _PlumbingIn(Input, allow_unbounded_fields=True):
+    name: str = "x"
+
+
+class _PlumbingOut(Output, allow_unbounded_fields=True):
+    msg: str = ""
+
+
+@pytest.fixture
+def _clean_registries() -> Any:
+    AppRegistry.reset()
+    TaskRegistry.reset()
+    yield
+    AppRegistry.reset()
+    TaskRegistry.reset()
+
+
+@pytest.mark.usefixtures("_clean_registries")
+class TestActivityPlumbing:
+    """The activity is where the two halves meet: the run start arrives on the
+    ``TaskContext``, and the watch has to reach the loop that ticks it."""
+
+    async def _run_activity(self, *, run_started_at_epoch: float) -> Any:
+        class _PlumbingApp(App):
+            @task(timeout_seconds=600)
+            async def extract(self, input: _PlumbingIn) -> _PlumbingOut:
+                return _PlumbingOut(msg="done")
+
+            async def run(self, input: _PlumbingIn) -> _PlumbingOut:
+                return await self.extract(input)
+
+        tasks = TaskRegistry.get_instance().get_tasks_for_app("_plumbing-app")
+        activity_fn = create_activity_from_task(
+            next(t for t in tasks if t.name == "extract")
+        )
+        context = TaskContext(
+            app_name="_plumbing-app",
+            task_name="extract",
+            run_id="run-1",
+            heartbeat_timeout_seconds=60,
+            auto_heartbeat_seconds=10,
+            run_started_at_epoch=run_started_at_epoch,
+        )
+
+        captured: dict[str, Any] = {}
+
+        async def fake_loop(*, stop_event: asyncio.Event, **kwargs: Any) -> None:
+            captured.update(kwargs)
+            await stop_event.wait()
+
+        with (
+            patch(
+                "application_sdk.execution.heartbeat.auto_heartbeat_loop",
+                new=fake_loop,
+            ),
+            patch.object(
+                activities_module.activity,
+                "info",
+                return_value=MagicMock(
+                    workflow_id="wf-1", workflow_type="MyConnectorWorkflow"
+                ),
+            ),
+            patch(
+                "application_sdk.infrastructure.context.get_infrastructure",
+                return_value=None,
+            ),
+        ):
+            await activity_fn(context, _PlumbingIn())
+
+        return captured.get("run_length")
+
+    @pytest.mark.asyncio
+    async def test_the_activity_hands_the_loop_a_watch_for_its_run(self) -> None:
+        watch = await self._run_activity(run_started_at_epoch=_RUN_STARTED)
+
+        assert isinstance(watch, RunLengthWatch)
+        assert watch.run_started_at_epoch == _RUN_STARTED
+        assert watch.task_name == "extract"
+        assert watch.workflow_type == "MyConnectorWorkflow"
+
+    @pytest.mark.asyncio
+    async def test_no_watch_when_the_dispatching_workflow_sent_no_run_start(
+        self,
+    ) -> None:
+        assert await self._run_activity(run_started_at_epoch=0.0) is None
+
+
+@dataclass
+class _OldTaskContext:
+    """``TaskContext`` as a worker from before this field knows it."""
+
+    app_name: str
+    task_name: str
+    run_id: str
+    workflow_id: str = "local"
+    heartbeat_timeout_seconds: int | None = 60
+    auto_heartbeat_seconds: int | None = 20
+
+
+class TestWireCompatibility:
+    """A rolling deploy runs two SDK versions against one task queue for a few
+    minutes, so a new workflow's dispatch can land on an old worker. Pinned
+    against the real converter rather than assumed: if the premise ever changes,
+    every activity dispatched during a deploy would fail on decode."""
+
+    @pytest.mark.asyncio
+    async def test_the_run_start_survives_the_wire(self) -> None:
+        converter = create_data_converter()
+        context = TaskContext(
+            app_name="a", task_name="t", run_id="r", run_started_at_epoch=_RUN_STARTED
+        )
+
+        payloads = await converter.encode([context])
+        decoded = await converter.decode(payloads, [TaskContext])
+
+        assert decoded[0].run_started_at_epoch == _RUN_STARTED
+
+    @pytest.mark.asyncio
+    async def test_an_older_worker_ignores_the_field_rather_than_failing(self) -> None:
+        converter = create_data_converter()
+        context = TaskContext(
+            app_name="a", task_name="t", run_id="r", run_started_at_epoch=_RUN_STARTED
+        )
+
+        payloads = await converter.encode([context])
+        decoded = await converter.decode(payloads, [_OldTaskContext])
+
+        assert decoded[0].task_name == "t"
+
+
+class TestWorkflowStampsTheRunStart:
+    def _dispatched_context(self) -> Any:
+        with patch(
+            "application_sdk.execution._temporal.eviction_retry."
+            "execute_activity_with_eviction_retry",
+            new_callable=AsyncMock,
+        ) as mock_exec:
+            mock_exec.return_value = MagicMock()
+            wrapper = _create_task_activity_wrapper(
+                app_name="qi-app",
+                task_name="extract",
+                timeout_seconds=600,
+                retry_max_attempts=3,
+                retry_max_interval_seconds=30,
+                output_type=_PlumbingOut,
+                context_data={"run_id": "r1", "correlation_id": "c1"},
+            )
+            asyncio.run(wrapper(MagicMock()))
+
+        return mock_exec.call_args.kwargs["args"][0]
+
+    def test_the_run_start_comes_from_history_not_a_clock(self) -> None:
+        """``workflow.info().start_time`` is replayed from the run's own history,
+        so a replay measures the run's real age instead of restarting the clock."""
+        started = datetime(2026, 8, 13, 6, 0, tzinfo=UTC)
+
+        with patch.object(
+            base_module.workflow, "info", return_value=MagicMock(start_time=started)
+        ):
+            context = self._dispatched_context()
+
+        assert context.run_started_at_epoch == started.timestamp()
+
+    def test_unknown_outside_a_workflow_context(self) -> None:
+        """A local run has no run to measure — and reading the start must never
+        be the thing that fails a dispatch."""
+        with patch.object(
+            base_module.workflow,
+            "info",
+            side_effect=RuntimeError("not in workflow event loop"),
+        ):
+            context = self._dispatched_context()
+
+        assert context.run_started_at_epoch == 0.0


### PR DESCRIPTION
Closes [FND-294](https://linear.app/atlan-epd/issue/FND-294/bound-the-retry-product-and-add-a-run-length-sla-alert). A prerequisite of the M2 release, from [ADR-0018](https://github.com/atlanhq/application-sdk/blob/main/docs/adr/0018-progress-aware-heartbeat.md) → *Bounding total time*.

## Why

`start_to_close` bounds **one attempt**. The retry policy multiplies it, and a `StartToClose` timeout is retryable in Temporal, so the real worst case per dispatch is `max_attempts × timeout_seconds` — 30 minutes at today's defaults, **72 hours** against the 24h backstop FND-296 ships.

ADR-0018's accepted position is to start there deliberately rather than guess a total duration, on two conditions. This PR lands both, and changes nothing about how any existing task runs.

## 1. A bound that is not a guess

`@task(schedule_to_close_seconds=...)`, defaulting to `ATLAN_SCHEDULE_TO_CLOSE_TIMEOUT_SECONDS`, so sizing the ceiling once warn-mode data exists is a config change rather than a redesign.

- **Unset is the default**, and sends no `schedule_to_close_timeout` at all — the kwarg is omitted rather than passed as `None`, so every task that has not opted in dispatches byte-identically to before.
- `resolve_activity_time_bounds` (`execution/retry.py`) is the **single reader** of the field, shared by both paths that hand timeouts to Temporal (`app.base._create_task_activity_wrapper` and `activities.get_activity_options`), so the pair they send cannot diverge.
- A ceiling **below** one attempt's timeout caps that attempt too, rather than sending an inverted pair. That is the shape an app gets by declaring only a total ("finish within an hour") while inheriting a generous per-attempt backstop — the tighter number is the declaration — and it removes any dependence on what a given server version does with an inversion.
- `retry_product_seconds(timeout, attempts)` makes the multiplication explicit for an app that wants exactly the ceiling its retry policy already implies, and makes the *cosmetic retry policy* trap visible: a ceiling under two attempts means attempt 2 can never start. Same `+10s` backoff headroom `gate_timeouts` uses, for the same reason.
- Honest limit, in the docstring and the docs: the ceiling bounds one **dispatch**, which is what the retry policy spends. Worker-eviction re-dispatches each get a fresh window by design, bounded separately by `ATLAN_WORKER_EVICTION_MAX_RETRIES`.

Note on `@needs_lock` + `@task`: this PR does **not** change that path. `create_activity_from_task` builds a fresh wrapper and never copies `LOCK_METADATA_KEY` from the task function, so the lock interceptor resolves the activity by name against a function that carries no lock metadata — `@task` + `@needs_lock` stays invisible to the interceptor with or without a declared ceiling. Wiring the metadata through is a separate, small change; deliberately out of scope here.

## 2. A run-length SLA alert

A run that wedges *while dribbling progress* re-arms the stall watchdog on every mark, so the watchdog never fires and no per-attempt timeout is reached. Once the ceiling is a backstop, that run is bounded by nothing.

Each executing attempt now compares its run's age against `ATLAN_RUN_LENGTH_SLA_SECONDS` (24h default; `0` disables) on the tick the heartbeat loop already runs. Past the SLA it logs one `WARNING` and records `task.run_length_over_sla` — a histogram of the run's age, labelled `task.name` and `temporal.workflow.type` — re-asserted once a minute so `increase(task_run_length_over_sla_seconds_count[15m]) > 0` keeps firing while a run is over and resolves once it ends.

An **alert**, not a kill: the SDK cannot know how long a healthy run takes against a tenant it has never seen — that is the number ADR-0018 exists to stop guessing — and an alert threshold being wrong costs a human one look, not a run's worth of work. That asymmetry is what makes a default defensible here where a default duration *ceiling* is not.

Note the deliberate difference from FND-293's stall alert, which needs *accumulated seconds of silence* because warn-mode gaps are normal fleet-wide: this series is emitted **only** by a run already past its declared length, so there is nothing to threshold and a count is the trigger.

### Where the observation lives, and why not in the workflow

The obvious implementation is a durable timer in a workflow interceptor. It is rejected deliberately:

- A timer is a **command in every run's history**, and adding a command to code that in-flight runs replay is a non-determinism hazard on every SDK upgrade — survivable only via `workflow.patched`, i.e. a marker in every run forever. Not worth that for an alert.
- So the workflow puts `workflow.info().start_time` onto `TaskContext` (deterministic, from history — a replay measures the run's real age instead of restarting the clock) and the activity does the comparison.
- **Cost, stated** in the module docstring and the runbook rather than buried: a run is observed only while at least one of its activities is executing. A run parked between activities, one whose worker is gone, and a task with heartbeating disabled are not covered — those are "no worker / no activity" conditions with their own alerts. A workflow-side timer is the named escalation if that gap ever bites.

`WARNING`, unlike the `INFO` warn-mode stall telemetry next door in `progress_telemetry`: a warn-mode stall observation is an expected observation; a run past the length its own operator declared is not.

## Docs

Rebased onto FND-293 (#3191) and FND-295 (#3194), which landed in the same sections while this was in flight, and follows the alerting shape FND-293 established rather than inventing a parallel one:

- `docs/runbooks/long-running-run.md` — new runbook mirroring `stalled-task.md`: how an operator separates healthy-but-slow from wedged-while-dribbling, what terminating actually does, and the two durable outcomes (declare the app's real run length, or fix the site). Registered in `mkdocs.yml` nav.
- `docs/concepts/monitoring.md` — alert row, the signal shapes, the PromQL, and why a **count** is right here where the stall alert needs accumulated seconds. Same Pushgateway caveat.
- `docs/concepts/tasks.md` — the arithmetic, the three ways to bound it (total ceiling, `retry_product_seconds`, `retry_max_attempts=1`), and both new env vars. FND-295's "three knobs" table gets one line noting they all bound *one attempt*, and that the total is the separate question below.
- `docs/standards/metrics.md` — metric inventory row, and `task_name`'s bound extended to this module.

## Verification

- Full unit suite green: **6995 passed**, 9 skipped, post-rebase. 51 new tests across `test_retry_product_bound.py` and `test_run_length.py`.
- `mkdocs build --strict` resolves every link and anchor added here.
- Dispatch assertions run through `_create_task_activity_wrapper` and `get_activity_options` — the code paths that actually reach Temporal — not against the resolver alone, so a ceiling that resolves correctly but never reaches the wire still fails.
- Mixed-version wire compatibility for the new `TaskContext` field is **pinned against the real pydantic converter in both directions**: a new workflow's dispatch decoded by an old worker mid-rolling-deploy ignores the field rather than failing on it.
- Conformance gate passes, with no new warnings (the two context probes carry explicit `ignore[E007]` reasons).
- `pre-commit run` (ruff, ruff-format, isort, pyright) clean.

## Security review

No new network, filesystem, credential, or auth surface. One new field on an internal activity payload (a float), and two env-var reads (integers, both fail closed to "unbounded" / "disabled" on a malformed value rather than stopping a worker booting). The run-length log line carries only a task name, a workflow type and two durations — no customer or tenant identifiers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

