### PR TITLE
feat(execution): warn by default, with the 24h backstop in the same release (FND-296)

### DIFF
--- a/application_sdk/_runtime/progress.py
+++ b/application_sdk/_runtime/progress.py
@@ -81,11 +81,12 @@ logger = get_logger(__name__)
 #: may this attempt be silent?", not "how much data does this tenant have?".
 #:
 #: One number with two uses, deliberately not two numbers. The stall watchdog
-#: takes it as ``max_no_progress_seconds`` (the per-task flag that carries it is
-#: FND-296's), and the warn-mode hold report takes it as the floor above which a
-#: hold is worth naming in the log — a hold longer than the budget is exactly a
-#: hold that *would* have tripped the watchdog had it not been vouched for,
-#: which is the work-list criterion.
+#: takes it as ``max_no_progress_seconds`` — this is the fallback beneath
+#: ``ATLAN_MAX_NO_PROGRESS_SECONDS`` and ``@task(max_no_progress_seconds=...)``,
+#: both resolved in :mod:`application_sdk.execution.progress` — and the warn-mode
+#: hold report takes it as the floor above which a hold is worth naming in the
+#: log: a hold longer than the budget is exactly a hold that *would* have tripped
+#: the watchdog had it not been vouched for, which is the work-list criterion.
 DEFAULT_MAX_NO_PROGRESS_SECONDS = 900.0
 
 

--- a/application_sdk/app/base.py
+++ b/application_sdk/app/base.py
@@ -87,6 +87,7 @@ from application_sdk.observability.logger_adaptor import (
 from application_sdk.observability.observability import AtlanObservability
 
 if TYPE_CHECKING:
+    from application_sdk.execution.progress import ProgressWatchdogMode
     from application_sdk.validation import AssetValidationReport
 
 _task_logger = get_logger(__name__)
@@ -2413,6 +2414,8 @@ def _wrap_instance_tasks(app_instance: Any, context_data: dict[str, Any]) -> Non
                     task_meta.retry_policy,
                     pool=task_meta.pool,
                     schedule_to_close_seconds=task_meta.schedule_to_close_seconds,
+                    progress_watchdog=task_meta.progress_watchdog,
+                    max_no_progress_seconds=task_meta.max_no_progress_seconds,
                 )
                 setattr(app_instance, attr_name, wrapper)
 
@@ -2431,6 +2434,8 @@ def _create_task_activity_wrapper(
     *,
     pool: str | None = None,
     schedule_to_close_seconds: int | None = None,
+    progress_watchdog: "ProgressWatchdogMode | None" = None,
+    max_no_progress_seconds: float | None = None,
 ) -> Any:
     """Create a wrapper that executes a task as a Temporal activity.
 
@@ -2456,6 +2461,13 @@ def _create_task_activity_wrapper(
             and leaves the retry product unbounded — ``retry_max_attempts ×
             timeout_seconds``. Resolved against ``timeout_seconds`` by
             :func:`~application_sdk.execution.retry.resolve_activity_time_bounds`.
+        progress_watchdog: The task's declared stall-watchdog mode, or ``None``
+            to inherit the fleet-wide setting. Forwarded verbatim onto the
+            ``TaskContext``; the activity side resolves it, so this path holds
+            no opinion about what the default is.
+        max_no_progress_seconds: The task's declared no-progress allowance in
+            seconds, or ``None`` to inherit the fleet-wide one. Forwarded
+            verbatim, for the same reason.
 
     Returns:
         Async function that executes the task as an activity.
@@ -2518,6 +2530,13 @@ def _create_task_activity_wrapper(
             # Sourced from history rather than a clock, so a replayed run
             # measures its real age instead of restarting the clock.
             run_started_at_epoch=_run_started_at_epoch(),
+            # The task's own declaration, unresolved. Both are `None` for the
+            # overwhelming majority of tasks, which is the point: nothing here
+            # has to know that the fleet default is `warn` (ADR-0018), and an
+            # operator changing it on the worker does not need every workflow to
+            # be re-dispatched to take effect.
+            progress_watchdog=progress_watchdog,
+            max_no_progress_seconds=max_no_progress_seconds,
         )
 
         # Build heartbeat timeout if enabled

--- a/application_sdk/app/task.py
+++ b/application_sdk/app/task.py
@@ -21,7 +21,16 @@ import re
 import warnings
 from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, ClassVar, TypeVar, cast, get_type_hints, overload
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    ClassVar,
+    NoReturn,
+    TypeVar,
+    cast,
+    get_type_hints,
+    overload,
+)
 
 from application_sdk.common._env import env_int
 from application_sdk.contracts.base import Input, Output
@@ -114,13 +123,15 @@ def _validate_watchdog_declaration(
 
     budget: float | None = None
     if max_no_progress_seconds is not None:
-        try:
-            budget = float(max_no_progress_seconds)
-        # A non-numeric allowance is the same author error as a nonsensical one,
-        # and gets the same message: `not math.isfinite(nan)` is True.
-        except (TypeError, ValueError):
-            budget = float("nan")
-        if not math.isfinite(budget) or budget <= 0:
+
+        def _reject_allowance() -> NoReturn:
+            """Both ways an allowance can be unusable get the same message.
+
+            A closure rather than a pre-built exception because
+            ``TaskContractError.__init__`` warns on construction, and rather than
+            a NaN sentinel threaded to a later branch because a non-numeric
+            allowance should visibly raise where it is detected.
+            """
             raise TaskContractError(
                 f"max_no_progress_seconds={max_no_progress_seconds!r} must be a "
                 "finite positive number of seconds. A zero or negative allowance "
@@ -128,6 +139,13 @@ def _validate_watchdog_declaration(
                 "progress_watchdog='off' to disable the watchdog deliberately, or "
                 "omit this to inherit the fleet-wide allowance."
             ) from None
+
+        try:
+            budget = float(max_no_progress_seconds)
+        except (TypeError, ValueError):
+            _reject_allowance()
+        if not math.isfinite(budget) or budget <= 0:
+            _reject_allowance()
 
     return mode, budget
 

--- a/application_sdk/app/task.py
+++ b/application_sdk/app/task.py
@@ -16,6 +16,7 @@ Tasks support heartbeating for long-running operations:
 """
 
 import inspect
+import math
 import re
 import warnings
 from collections.abc import Callable
@@ -29,6 +30,7 @@ from application_sdk.errors.leaves import InvalidInputError
 from application_sdk.observability.logger_adaptor import get_logger
 
 if TYPE_CHECKING:
+    from application_sdk.execution.progress import ProgressWatchdogMode
     from application_sdk.execution.retry import RetryPolicy
 
 logger = get_logger(__name__)
@@ -38,11 +40,96 @@ F = TypeVar("F", bound=Callable[..., Any])
 # Sentinel for "use default" - allows None to mean "disable"
 _USE_DEFAULT = object()
 
+#: The ``start_to_close`` backstop, in seconds (ADR-0018 → *Rollout* step 3).
+#:
+#: 24 hours, and deliberately not a number anyone is meant to tune. Before this,
+#: the default was 600s and every app overrode it with a guess — 2h, 6h, a
+#: "weight class" — because the question it asks (*how long should this whole
+#: activity take?*) scales with tenant size and is unanswerable at the desk. A
+#: backstop asks nothing: it is the last-resort bound for an attempt that
+#: something else should already have caught.
+#:
+#: What makes it safe to raise is the stall watchdog landing in the same
+#: release: a wedged-but-alive attempt is now *detected* one
+#: ``max_no_progress_seconds`` in, and killed there wherever an app enforces.
+#: The regression this accepts, in warn mode, is that a wedge is contained by an
+#: alert and a human rather than by the small ceiling that used to kill it
+#: accidentally — see ADR-0018 → *Migration*.
+_START_TO_CLOSE_BACKSTOP_SECONDS = 86_400
+
 # Env-var-driven defaults for @task timeouts. Read once at import time so the
 # value is stable for the process lifetime (same pattern as constants.py).
 # Apps that need a different per-task value pass it explicitly to @task().
 _DEFAULT_HEARTBEAT_TIMEOUT_SECONDS: int = env_int("ATLAN_HEARTBEAT_TIMEOUT_SECONDS", 60)
-_DEFAULT_TIMEOUT_SECONDS: int = env_int("ATLAN_START_TO_CLOSE_TIMEOUT_SECONDS", 600)
+_DEFAULT_TIMEOUT_SECONDS: int = env_int(
+    "ATLAN_START_TO_CLOSE_TIMEOUT_SECONDS", _START_TO_CLOSE_BACKSTOP_SECONDS
+)
+
+
+def _validate_watchdog_declaration(
+    progress_watchdog: "ProgressWatchdogMode | str | None",
+    max_no_progress_seconds: float | None,
+) -> "tuple[ProgressWatchdogMode | None, float | None]":
+    """Validate an explicitly declared watchdog mode and allowance.
+
+    Only reached when the author passed one, which is what lets this module stay
+    free of an ``application_sdk.execution`` import at module scope: ``app/``
+    sits *below* ``execution/`` in the import graph (``execution/__init__`` →
+    ``_temporal`` → ``app.registry`` → ``app.base`` → this module), so importing
+    the enum eagerly here deadlocks the very first import of the SDK. Undeclared
+    tasks carry ``None`` all the way to the activity, which resolves the
+    fleet-wide default in a layer that *can* see the enum — see
+    :func:`~application_sdk.execution.progress.resolve_watchdog_mode`.
+
+    Args:
+        progress_watchdog: The declared mode — a :class:`ProgressWatchdogMode`,
+            or one of its string values.
+        max_no_progress_seconds: The declared allowance in seconds.
+
+    Returns:
+        The pair, with the mode coerced to a :class:`ProgressWatchdogMode`.
+
+    Raises:
+        TaskContractError: If either value is unusable. Raised at *decoration*
+            time rather than swallowed, unlike the env-var readers next door: a
+            typo in one deployment manifest must not stop a worker booting, but
+            a typo in an app's own source is a bug its author should see at
+            import.
+    """
+    from application_sdk.execution.progress import (  # noqa: PLC0415 — app/ cannot import execution/ at module scope; see the docstring
+        ProgressWatchdogMode,
+    )
+
+    mode: ProgressWatchdogMode | None = None
+    if progress_watchdog is not None:
+        try:
+            mode = ProgressWatchdogMode(progress_watchdog)
+        except ValueError:
+            raise TaskContractError(
+                f"progress_watchdog={progress_watchdog!r} is not a valid mode. "
+                f"Use one of {', '.join(repr(m.value) for m in ProgressWatchdogMode)} "
+                "(or the ProgressWatchdogMode enum). Omit it to inherit the "
+                "fleet-wide default from ATLAN_PROGRESS_WATCHDOG."
+            ) from None
+
+    budget: float | None = None
+    if max_no_progress_seconds is not None:
+        try:
+            budget = float(max_no_progress_seconds)
+        # A non-numeric allowance is the same author error as a nonsensical one,
+        # and gets the same message: `not math.isfinite(nan)` is True.
+        except (TypeError, ValueError):
+            budget = float("nan")
+        if not math.isfinite(budget) or budget <= 0:
+            raise TaskContractError(
+                f"max_no_progress_seconds={max_no_progress_seconds!r} must be a "
+                "finite positive number of seconds. A zero or negative allowance "
+                "makes every attempt stall on its first watchdog tick; pass "
+                "progress_watchdog='off' to disable the watchdog deliberately, or "
+                "omit this to inherit the fleet-wide allowance."
+            ) from None
+
+    return mode, budget
 
 
 def _load_default_schedule_to_close_seconds() -> int | None:
@@ -143,7 +230,13 @@ class TaskMetadata:
 
     timeout_seconds: int = _DEFAULT_TIMEOUT_SECONDS
     """Default timeout for this task. Defaults to ATLAN_START_TO_CLOSE_TIMEOUT_SECONDS
-    env var, or 600s (10 minutes) if unset.
+    env var, or 86400s (24 hours) if unset.
+
+    A **backstop**, not a duration budget (ADR-0018): the last-resort bound on an
+    attempt that the stall watchdog should already have caught. Do not tune it —
+    the question it asks scales with tenant size, which is what made it
+    unguessable. To bound a wedge in *minutes* rather than at the backstop,
+    declare holds and set :attr:`progress_watchdog` to ``enforce``.
 
     Bounds ONE attempt. The retry policy multiplies it — see
     :attr:`schedule_to_close_seconds` for the ceiling on the product."""
@@ -192,6 +285,30 @@ class TaskMetadata:
     Set to None to disable auto-heartbeating (use manual heartbeats only).
     Should be less than heartbeat_timeout_seconds (recommended: 1/6 of timeout).
     Default: 10 seconds."""
+
+    progress_watchdog: "ProgressWatchdogMode | None" = None
+    """How the stall watchdog reacts to a no-progress gap on this task.
+
+    ``None`` — the default — means *this task declares nothing*, and the
+    fleet-wide default applies: ``warn`` unless ``ATLAN_PROGRESS_WATCHDOG`` says
+    otherwise. It is deliberately not ``ProgressWatchdogMode.WARN`` here: the
+    absence of a declaration and a declaration of ``warn`` are different facts,
+    and only the first one follows an operator turning the fleet ``off``.
+
+    Resolved against the process-wide setting by
+    :func:`~application_sdk.execution.progress.resolve_watchdog_mode` in the
+    activity, which is the layer that runs the watchdog and therefore the layer
+    whose env the kill-switch has to read."""
+
+    max_no_progress_seconds: float | None = None
+    """How long this task may go without an observable progress signal, in seconds.
+
+    ``None`` inherits the fleet-wide allowance (``ATLAN_MAX_NO_PROGRESS_SECONDS``,
+    900s by default). Roughly app-independent on purpose: it answers *"how long
+    may this attempt be silent?"*, not *"how much data does this tenant have?"* —
+    so a task that legitimately goes quiet for a long time wants a hold at that
+    call site (:func:`~application_sdk.execution.progress.holding_progress`),
+    not a bigger number here."""
 
 
 def _validate_task_signature(
@@ -307,6 +424,8 @@ def task(
     heartbeat_timeout_seconds: int | None | object = _USE_DEFAULT,
     auto_heartbeat_seconds: int | None | object = _USE_DEFAULT,
     pool: str | None = None,
+    progress_watchdog: "ProgressWatchdogMode | str | None" = None,
+    max_no_progress_seconds: float | None = None,
 ) -> Callable[[F], F]: ...
 
 
@@ -323,6 +442,8 @@ def task(
     heartbeat_timeout_seconds: int | None | object = _USE_DEFAULT,
     auto_heartbeat_seconds: int | None | object = _USE_DEFAULT,
     pool: str | None = None,
+    progress_watchdog: "ProgressWatchdogMode | str | None" = None,
+    max_no_progress_seconds: float | None = None,
 ) -> F | Callable[[F], F]:
     """Decorator to mark a method as a task (Temporal activity).
 
@@ -382,11 +503,14 @@ def task(
         func: The function to decorate (when used without parentheses).
         name: Override the task name (defaults to function name).
         description: Human-readable description.
-        timeout_seconds: Activity timeout in seconds — the ``start_to_close``
-            budget for **one attempt**, which the retry policy then multiplies.
+        timeout_seconds: Activity ``start_to_close`` bound in seconds — the
+            **backstop** on one attempt, which the retry policy then multiplies.
             Defaults to ``ATLAN_START_TO_CLOSE_TIMEOUT_SECONDS`` env var, or
-            600 s (10 min) if unset. Explicit values take precedence over the
-            env var.
+            86400 s (24 h) if unset. Explicit values take precedence over the
+            env var, but ADR-0018's position is that this is no longer a number
+            worth tuning: a wedged-but-alive attempt is caught by the stall
+            watchdog in minutes, and a legitimately long one should not die at a
+            guessed ceiling.
         schedule_to_close_seconds: Ceiling on the task's **total** time across
             every attempt, in seconds. ``None`` — the default — leaves the retry
             product unbounded, so the real worst case is
@@ -424,6 +548,26 @@ def task(
             mixed or upper case would create a lookup mismatch. Unset tasks run
             on the workflow's own task queue (default, backward-compatible
             behavior).
+        progress_watchdog: How the stall watchdog reacts to a no-progress gap on
+            this task — ``"off"``, ``"warn"`` or ``"enforce"``, or the
+            :class:`~application_sdk.execution.progress.ProgressWatchdogMode`
+            enum. ``None`` — the default — inherits the fleet-wide setting
+            (``ATLAN_PROGRESS_WATCHDOG``, ``warn`` when unset). Declare
+            ``"enforce"`` once this task's remaining gaps are inside declared
+            holds or under budget, **verified against a large-tenant profile**:
+            a small run hides the tail gaps, and a stall kill retries, so an
+            under-instrumented task burns the same wasted work up to three times
+            before failing.
+        max_no_progress_seconds: How long this task may be silent before the
+            watchdog calls it stalled. ``None`` inherits the fleet-wide
+            allowance (``ATLAN_MAX_NO_PROGRESS_SECONDS``, 900 s when unset).
+            This is not the beat interval (that is ``auto_heartbeat_seconds``,
+            and it is unconditional) and not a duration budget — it measures the
+            *gap* between progress signals, so a nine-hour task writing a batch
+            every thirty seconds never approaches it. A single step that goes
+            quiet for longer wants
+            :func:`~application_sdk.execution.progress.holding_progress` at that
+            call site, not a bigger number here.
 
     Returns:
         The decorated function with task metadata attached.
@@ -478,6 +622,16 @@ def task(
             "before it started."
         )
 
+    # Only touched when the author declared one of the two, which keeps the
+    # `application_sdk.execution` import out of the SDK's own import-time
+    # decorations in `app/base.py` — see _validate_watchdog_declaration.
+    resolved_watchdog: "ProgressWatchdogMode | None" = None
+    resolved_no_progress: float | None = None
+    if progress_watchdog is not None or max_no_progress_seconds is not None:
+        resolved_watchdog, resolved_no_progress = _validate_watchdog_declaration(
+            progress_watchdog, max_no_progress_seconds
+        )
+
     def decorator(fn: F) -> F:
         task_name = name or getattr(fn, "__name__", repr(fn))
 
@@ -500,6 +654,8 @@ def task(
             retry_max_interval_seconds=retry_max_interval_seconds,
             heartbeat_timeout_seconds=resolved_heartbeat_timeout,
             auto_heartbeat_seconds=resolved_auto_heartbeat,
+            progress_watchdog=resolved_watchdog,
+            max_no_progress_seconds=resolved_no_progress,
         )
 
         return fn

--- a/application_sdk/constants.py
+++ b/application_sdk/constants.py
@@ -382,6 +382,12 @@ WORKFLOW_AUTH_CLIENT_SECRET_KEY = os.getenv(
 #   ATLAN_SCHEDULE_TO_CLOSE_TIMEOUT_SECONDS → default schedule_to_close_seconds for
 #     @task: the ceiling on a task's total time across every retry. Unset leaves
 #     the retry product unbounded (ADR-0018 → Bounding total time).
+# The stall watchdog's two fleet-wide settings are read in
+# application_sdk/execution/progress.py, because the activity worker running the
+# watchdog is the side that has to resolve them:
+#   ATLAN_PROGRESS_WATCHDOG → PROGRESS_WATCHDOG_MODE (off/warn/enforce, default warn;
+#     'off' is the kill-switch and beats a per-task declaration)
+#   ATLAN_MAX_NO_PROGRESS_SECONDS → MAX_NO_PROGRESS_SECONDS (default 900)
 # The run-length SLA that alerts on an over-long run — the duration signal that
 # replaces the duration kill — is read in application_sdk/execution/run_length.py:
 #   ATLAN_RUN_LENGTH_SLA_SECONDS → RUN_LENGTH_SLA_SECONDS (default 86400, 0 disables)

--- a/application_sdk/execution/_temporal/activities.py
+++ b/application_sdk/execution/_temporal/activities.py
@@ -51,6 +51,14 @@ logger = get_logger(__name__)
 # 50–250 KB — well inside Temporal's default 2 MB payload limit.
 _MAX_CHAIN_DEPTH = 50
 
+#: Tick interval for the stall-watchdog loop on an attempt that has heartbeating
+#: disabled. The loop there exists only to run the watchdog — the heartbeat
+#: controller is the Noop one, so nothing is heartbeated — and a pure watchdog
+#: tick needs no operator-facing knob. Twenty seconds matches the default
+#: heartbeat interval, so a no-heartbeat attempt is observed at the same cadence
+#: as a heartbeating one.
+_WATCHDOG_ONLY_TICK_SECONDS = 20
+
 
 def _sever_cause_chain(exc: BaseException) -> None:
     """Sever the __cause__/__context__ chain at _MAX_CHAIN_DEPTH.
@@ -340,14 +348,39 @@ def create_activity_from_task(
         stop_event = asyncio.Event()
         heartbeat_task = None
 
+        # Resolve the allowance once per attempt and hand it to both consumers —
+        # the hold observer (whose ``budget_seconds`` docstring names the task's
+        # ``max_no_progress_seconds``) and the watchdog below. Resolving here
+        # rather than inside each keeps the environment consulted the one the
+        # attempt runs in, and keeps the two reports agreeing on one number.
+        resolved_no_progress_seconds = resolve_max_no_progress_seconds(
+            context.max_no_progress_seconds
+        )
+
         with bind_progress_tracker(
-            ProgressTracker(on_hold_closed=closed_hold_observer(context.task_name))
+            ProgressTracker(
+                on_hold_closed=closed_hold_observer(
+                    context.task_name, budget_seconds=resolved_no_progress_seconds
+                )
+            )
         ) as tracker:
             try:
-                if (
-                    context.heartbeat_timeout_seconds is not None
-                    and context.auto_heartbeat_seconds is not None
-                ):
+                # Resolved here rather than on the workflow side so the
+                # environment consulted is the one the watchdog runs in — which
+                # is what makes `off` a kill-switch an operator can throw on the
+                # worker, and what makes a run dispatched before these fields
+                # existed land on the fleet default rather than on nothing.
+                watchdog_mode = resolve_watchdog_mode(context.progress_watchdog)
+
+                # The watchdog must run on every attempt it governs — including
+                # one with heartbeating disabled, where a wedge is otherwise
+                # bounded only by the duration backstop. Gating the loop on the
+                # heartbeat config would let a declared `enforce` silently never
+                # kill a wedge on exactly the tasks the design says it protects.
+                # So the loop starts whenever the resolved mode is not `off`;
+                # with heartbeating disabled it rides a NoopHeartbeatController
+                # beat (a pure watchdog tick that emits no Temporal heartbeat).
+                if watchdog_mode is not ProgressWatchdogMode.OFF:
                     # Captured here, in the attempt's own task. The handler below
                     # runs inside the heartbeat task, where
                     # `asyncio.current_task()` would be the watchdog itself — it
@@ -385,22 +418,21 @@ def create_activity_from_task(
                                 task_name=context.task_name,
                                 workflow_type=_current_workflow_type(),
                             ),
-                            interval_seconds=context.auto_heartbeat_seconds,
+                            # The beat interval. With heartbeating disabled the
+                            # loop exists only to run the watchdog, so it ticks on
+                            # a fixed beat rather than a (``None``) heartbeat
+                            # interval — the controller below is then the Noop
+                            # one, so the tick emits no Temporal heartbeat.
+                            interval_seconds=(
+                                context.auto_heartbeat_seconds
+                                if context.auto_heartbeat_seconds is not None
+                                else _WATCHDOG_ONLY_TICK_SECONDS
+                            ),
                             heartbeat_fn=heartbeat_controller.heartbeat_keepalive,
                             stop_event=stop_event,
                             task_name=context.task_name,
-                            # Resolved here rather than on the workflow side so
-                            # the environment consulted is the one the watchdog
-                            # runs in — which is what makes `off` a kill-switch
-                            # an operator can throw on the worker, and what makes
-                            # a run dispatched before these fields existed land
-                            # on the fleet default rather than on nothing.
-                            watchdog_mode=resolve_watchdog_mode(
-                                context.progress_watchdog
-                            ),
-                            max_no_progress_seconds=resolve_max_no_progress_seconds(
-                                context.max_no_progress_seconds
-                            ),
+                            watchdog_mode=watchdog_mode,
+                            max_no_progress_seconds=resolved_no_progress_seconds,
                             progress=tracker,
                             on_stall=on_stall,
                         )

--- a/application_sdk/execution/_temporal/activities.py
+++ b/application_sdk/execution/_temporal/activities.py
@@ -53,10 +53,10 @@ _MAX_CHAIN_DEPTH = 50
 
 #: Tick interval for the stall-watchdog loop on an attempt that has heartbeating
 #: disabled. The loop there exists only to run the watchdog — the heartbeat
-#: controller is the Noop one, so nothing is heartbeated — and a pure watchdog
-#: tick needs no operator-facing knob. Twenty seconds matches the default
-#: heartbeat interval, so a no-heartbeat attempt is observed at the same cadence
-#: as a heartbeating one.
+#: function is a Noop, so nothing is heartbeated — and a pure watchdog tick
+#: needs no operator-facing knob. Twenty seconds simply keeps a no-heartbeat
+#: attempt observed at a heartbeat-like cadence; it is not derived from the
+#: auto-heartbeat default (10s, per the ``@task`` decorator).
 _WATCHDOG_ONLY_TICK_SECONDS = 20
 
 
@@ -428,7 +428,20 @@ def create_activity_from_task(
                                 if context.auto_heartbeat_seconds is not None
                                 else _WATCHDOG_ONLY_TICK_SECONDS
                             ),
-                            heartbeat_fn=heartbeat_controller.heartbeat_keepalive,
+                            # The heartbeat the tick emits — *not* the controller
+                            # built above. With auto-heartbeating disabled
+                            # (``auto_heartbeat_seconds=None``) the author opted
+                            # out of automatic keepalives, so the loop ticks the
+                            # watchdog through a Noop beat and the task's manual
+                            # ``heartbeat()`` calls — on the real controller —
+                            # stay the only Temporal heartbeats sent. (With
+                            # heartbeating off entirely the Noop beat is a
+                            # no-op either way, so one selection covers both.)
+                            heartbeat_fn=(
+                                heartbeat_controller.heartbeat_keepalive
+                                if context.auto_heartbeat_seconds is not None
+                                else NoopHeartbeatController().heartbeat_keepalive
+                            ),
                             stop_event=stop_event,
                             task_name=context.task_name,
                             watchdog_mode=watchdog_mode,

--- a/application_sdk/execution/_temporal/activities.py
+++ b/application_sdk/execution/_temporal/activities.py
@@ -25,6 +25,11 @@ from application_sdk.app.task import TaskMetadata
 from application_sdk.constants import LOCAL_WORKFLOW_ID, TRACKED_FILE_REFS_KEY
 from application_sdk.contracts.base import Input, Output
 from application_sdk.contracts.types import FileReference
+from application_sdk.execution.progress import (
+    ProgressWatchdogMode,
+    resolve_max_no_progress_seconds,
+    resolve_watchdog_mode,
+)
 from application_sdk.observability.logger_adaptor import get_logger
 
 if TYPE_CHECKING:
@@ -171,6 +176,21 @@ class TaskContext:
     still in flight across an SDK upgrade. Epoch seconds rather than a
     ``datetime`` so the value is one float on the wire and needs no timezone
     round-trip to be subtracted from this worker's clock."""
+
+    progress_watchdog: ProgressWatchdogMode | None = None
+    """This task's declared stall-watchdog mode, or ``None`` for "declares nothing".
+
+    Carries the *declaration*, not the resolved mode, so the fleet-wide default
+    and the ``off`` kill-switch are read in the worker actually running the
+    watchdog (:func:`~application_sdk.execution.progress.resolve_watchdog_mode`).
+    That also makes the field's absence do the right thing: a run dispatched by a
+    workflow that predates it lands on the fleet default, so a worker upgrade is
+    enough to start producing that app's warn-mode work-list."""
+
+    max_no_progress_seconds: float | None = None
+    """This task's declared no-progress allowance in seconds, or ``None`` to
+    inherit the fleet-wide one. Resolved alongside
+    :attr:`progress_watchdog`, for the same reasons."""
 
 
 def _current_workflow_type() -> str:
@@ -369,12 +389,18 @@ def create_activity_from_task(
                             heartbeat_fn=heartbeat_controller.heartbeat_keepalive,
                             stop_event=stop_event,
                             task_name=context.task_name,
-                            # `watchdog_mode` and `max_no_progress_seconds` are
-                            # deliberately absent: their defaults leave the
-                            # watchdog inert, and the per-task flag and budget
-                            # that turn it on are FND-296's. Injecting the
-                            # handler now means enabling the watchdog is a config
-                            # change rather than a second seam.
+                            # Resolved here rather than on the workflow side so
+                            # the environment consulted is the one the watchdog
+                            # runs in — which is what makes `off` a kill-switch
+                            # an operator can throw on the worker, and what makes
+                            # a run dispatched before these fields existed land
+                            # on the fleet default rather than on nothing.
+                            watchdog_mode=resolve_watchdog_mode(
+                                context.progress_watchdog
+                            ),
+                            max_no_progress_seconds=resolve_max_no_progress_seconds(
+                                context.max_no_progress_seconds
+                            ),
                             progress=tracker,
                             on_stall=on_stall,
                         )

--- a/application_sdk/execution/progress.py
+++ b/application_sdk/execution/progress.py
@@ -24,6 +24,8 @@ Keeping it here is also what lets the substrate stay free of any
 ``storage.ops`` transitively.
 """
 
+import os
+
 from application_sdk._runtime.progress import (
     DEFAULT_MAX_NO_PROGRESS_SECONDS,
     ClosedHold,
@@ -34,10 +36,16 @@ from application_sdk._runtime.progress import (
     declared_hold_active,
     holding_progress,
 )
+from application_sdk.common._env import env_int
 from application_sdk.contracts.base import SerializableEnum
+from application_sdk.observability.logger_adaptor import get_logger
+
+logger = get_logger(__name__)
 
 __all__ = [
     "DEFAULT_MAX_NO_PROGRESS_SECONDS",
+    "MAX_NO_PROGRESS_SECONDS",
+    "PROGRESS_WATCHDOG_MODE",
     "ClosedHold",
     "ProgressTracker",
     "ProgressWatchdogMode",
@@ -46,6 +54,8 @@ __all__ = [
     "current_progress_tracker",
     "declared_hold_active",
     "holding_progress",
+    "resolve_max_no_progress_seconds",
+    "resolve_watchdog_mode",
 ]
 
 
@@ -74,3 +84,124 @@ class ProgressWatchdogMode(SerializableEnum):
     ENFORCE = "enforce"
     """Report the gap, then fail the activity through the injected
     ``on_stall`` handler."""
+
+
+def _load_watchdog_mode() -> ProgressWatchdogMode:
+    """Read the fleet-wide watchdog mode. ``warn`` unless told otherwise.
+
+    ``warn`` is the default because it *cannot fail an activity*, so an opt-in
+    would buy nothing and would cost a ~20-team coordination step of exactly the
+    kind FND-165 documents stalling (ADR-0018 → *Warn mode is the default,
+    fleet-wide*). The env var is therefore mostly the ``off`` kill-switch: a
+    deployment that needs even the telemetry gone sets it without a code change
+    and without waiting on an SDK release.
+
+    Never raises. An unreadable value falls back to ``warn`` with a complaint
+    rather than stopping the worker booting: a typo in one deployment manifest
+    must cost one config value, not the process.
+    """
+    raw = os.environ.get("ATLAN_PROGRESS_WATCHDOG", "").strip().lower()
+    if not raw:
+        return ProgressWatchdogMode.WARN
+
+    # A lookup rather than `ProgressWatchdogMode(raw)` in a try/except: a typo is
+    # not an exceptional condition here, and the traceback from a failed enum
+    # lookup would tell the operator reading this line nothing the message does
+    # not already say.
+    mode = {m.value: m for m in ProgressWatchdogMode}.get(raw)
+    if mode is not None:
+        return mode
+
+    logger.warning(
+        "Ignoring ATLAN_PROGRESS_WATCHDOG=%r: expected one of %s. Falling back "
+        "to '%s', so no-progress gaps are still reported and nothing is failed "
+        "for them",
+        raw,
+        ", ".join(repr(m.value) for m in ProgressWatchdogMode),
+        ProgressWatchdogMode.WARN.value,
+    )
+    return ProgressWatchdogMode.WARN
+
+
+def _load_max_no_progress_seconds() -> float:
+    """Read the fleet-wide no-progress allowance, in seconds.
+
+    Defaults to :data:`DEFAULT_MAX_NO_PROGRESS_SECONDS` (900s). ADR-0018 →
+    *Decisions taken* records that number as provisional and settled by
+    measurement rather than argument, which is exactly why it is an env var: the
+    fleet's warn-mode gap distribution sets the real value (FND-297) as a config
+    change rather than an SDK release.
+
+    Never raises, and never yields an unusable allowance: zero or negative would
+    make every attempt stall on its first tick, which in an enforcing app turns
+    one typo into a fleet-wide kill switch.
+    """
+    raw = env_int("ATLAN_MAX_NO_PROGRESS_SECONDS", 0)
+    if raw > 0:
+        return float(raw)
+    if raw < 0:
+        logger.warning(
+            "Ignoring ATLAN_MAX_NO_PROGRESS_SECONDS=%d: a no-progress allowance "
+            "must be positive. Falling back to %.0fs — set ATLAN_PROGRESS_WATCHDOG "
+            "to 'off' to disable the watchdog deliberately",
+            raw,
+            DEFAULT_MAX_NO_PROGRESS_SECONDS,
+        )
+    return DEFAULT_MAX_NO_PROGRESS_SECONDS
+
+
+#: The fleet-wide watchdog mode, read once at import so it is stable for the
+#: process lifetime (the same pattern as the ``@task`` timeout defaults and
+#: ``RUN_LENGTH_SLA_SECONDS``).
+PROGRESS_WATCHDOG_MODE: ProgressWatchdogMode = _load_watchdog_mode()
+
+#: The fleet-wide no-progress allowance in seconds, read once at import.
+MAX_NO_PROGRESS_SECONDS: float = _load_max_no_progress_seconds()
+
+
+def resolve_watchdog_mode(
+    declared: ProgressWatchdogMode | None,
+) -> ProgressWatchdogMode:
+    """Resolve one task's effective mode against the process-wide setting.
+
+    Two rules, and the second is the whole reason this is a function rather than
+    an ``or``:
+
+    1. A task that declares nothing inherits :data:`PROGRESS_WATCHDOG_MODE`.
+    2. **``off`` in the environment wins over any declaration.** It is the
+       kill-switch ADR-0018 → *Rollout* step 3 ships alongside warn-by-default,
+       and a switch a per-task ``enforce`` could out-vote would be no use to the
+       operator holding it during an incident — which is the only time it gets
+       thrown.
+
+    Resolved on the activity side on purpose: the watchdog runs there, so the
+    environment that has to be consulted is the one the watchdog is running in,
+    not the workflow's.
+
+    Args:
+        declared: The task's own ``progress_watchdog``, or ``None`` when it
+            declares nothing.
+
+    Returns:
+        The mode the watchdog should run in for this attempt.
+    """
+    if PROGRESS_WATCHDOG_MODE is ProgressWatchdogMode.OFF:
+        return ProgressWatchdogMode.OFF
+    return declared or PROGRESS_WATCHDOG_MODE
+
+
+def resolve_max_no_progress_seconds(declared: float | None) -> float:
+    """Resolve one task's effective allowance against the process-wide setting.
+
+    No kill-switch rule here, unlike :func:`resolve_watchdog_mode`: turning the
+    watchdog off is what ``off`` is for, and an env var that could silently
+    shrink a task's declared allowance would be a fleet-wide false-kill
+    generator wearing a config knob's clothes.
+
+    Args:
+        declared: The task's own ``max_no_progress_seconds``, or ``None``.
+
+    Returns:
+        The allowance in seconds.
+    """
+    return MAX_NO_PROGRESS_SECONDS if declared is None else declared

--- a/application_sdk/execution/progress.py
+++ b/application_sdk/execution/progress.py
@@ -73,8 +73,21 @@ class ProgressWatchdogMode(SerializableEnum):
     """
 
     OFF = "off"
-    """Inert. Nothing is observed and nothing is reported — byte-identical to
-    pre-ADR-0018 behaviour. A kill-switch, not the normal state."""
+    """No gap is reported and no attempt is ever failed. A kill-switch, not the
+    normal state.
+
+    Precisely: the watchdog does not run, so ``task_no_progress_gap_seconds`` and
+    its INFO log stop entirely. What does *not* stop is the hold telemetry —
+    ``activities.py`` attaches the ``on_hold_closed`` observer to every attempt's
+    tracker regardless of mode, so ``task_hold_duration_seconds`` still records
+    once per released hold (i.e. once per ``run_in_thread`` offload). Marking
+    progress also still happens, at the cost of a clock read.
+
+    That is deliberate — a hold observation is an author's work-list entry, not a
+    watchdog action — but it means ``off`` is *not* byte-identical to
+    pre-ADR-0018 behaviour, and it is not the lever for reducing wedge exposure:
+    the bound on a wedged attempt is ``start_to_close``, which this does not
+    touch. See the [stalled-task runbook](../../docs/runbooks/stalled-task.md)."""
 
     WARN = "warn"
     """Report every gap as a metric and an INFO log; never fail an activity.

--- a/docs/adr/0018-progress-aware-heartbeat.md
+++ b/docs/adr/0018-progress-aware-heartbeat.md
@@ -970,6 +970,26 @@ Warn mode is what makes this checkable rather than aspirational.
    repository, the exported Prometheus contract is pinned by
    `tests/unit/execution/test_progress_telemetry_exposition.py` so a rename here
    cannot silently disable the containment.
+
+   The step itself landed as FND-296. Two details of the shape are worth recording
+   because they are not obvious from the description above:
+
+   - **The flag carries a declaration, not a resolved mode.** `TaskMetadata.progress_watchdog`
+     and the `TaskContext` field are `None` for a task that declares nothing, and the
+     activity worker resolves `None` against `ATLAN_PROGRESS_WATCHDOG` on its own side.
+     That is what makes `off` a kill-switch an operator can throw on a worker without
+     re-dispatching in-flight runs, and what makes a run dispatched by a workflow
+     predating the field land on the fleet default rather than on nothing. `off` in the
+     environment beats a per-task `enforce` for the same reason; the allowance
+     (`ATLAN_MAX_NO_PROGRESS_SECONDS`) deliberately has no such override, since an env
+     var that could silently shrink a declared allowance would be a fleet-wide
+     false-kill generator.
+   - **`app/` cannot import `execution/` at module scope** (`execution/__init__` →
+     `_temporal` → `app.registry` → `app.base` → `app.task`), so `app/task.py` reaches
+     `ProgressWatchdogMode` only inside the validation path that an explicit declaration
+     triggers. This is why the enum stays where [ADR-0019](0019-runtime-substrate-layer.md)
+     put it and the default resolution lives in `execution/progress.py` rather than
+     beside the other `@task` env defaults.
 4. **Ship the conformance rule and the toolkit floor.** Both are independent of the
    `@task` work and both deliver immediately: the floor stops the next app shipping
    a 2h node timeout, and the rule keeps un-held opaque sites visible once teams

--- a/docs/concepts/progress-and-stalls.md
+++ b/docs/concepts/progress-and-stalls.md
@@ -363,9 +363,20 @@ release channel, k8s topology) is reachable through `target_info` — see
 
 | Mode | Behaviour |
 |---|---|
-| `off` | Inert. Nothing is observed, nothing is reported. A kill-switch, not a normal state |
+| `off` | No gap is reported and nothing is ever failed. A kill-switch, not a normal state |
 | `warn` | The watchdog runs and reports; it can never fail an activity. **The default** |
 | `enforce` | Reports the gap, then fails the attempt |
+
+Two things `off` does **not** do, both worth knowing before you reach for it:
+
+- **It is not fully inert.** The gap metric and its log stop, but the hold
+  telemetry does not — `task_hold_duration_seconds` still records once per
+  released hold, i.e. once per `run_in_thread` offload, because a hold
+  observation is a work-list entry rather than a watchdog action.
+- **It does not shorten anything.** A wedged attempt is bounded by
+  `timeout_seconds`, which `off` does not touch — so it makes a wedge *invisible*
+  without making it *cheaper*. If that is the problem you have, the lever is the
+  backstop; see the [stalled-task runbook](../runbooks/stalled-task.md#if-wedging-turns-out-to-be-far-more-common-than-expected).
 
 Warn is the default fleet-wide because it cannot fail anything, which means nobody has
 to opt in and every app starts producing its own work-list on upgrade. See

--- a/docs/concepts/progress-and-stalls.md
+++ b/docs/concepts/progress-and-stalls.md
@@ -14,16 +14,6 @@ attempt is failed with a `TaskStalledError` naming the last signal it saw.
 This page is what an app author needs in order to act. [ADR-0018](../adr/0018-progress-aware-heartbeat.md)
 is the design record behind it; you should not need to read it to fix your app.
 
-!!! note "Rollout status"
-
-    The progress signals described here — the framework hooks, the automatic holds and
-    `holding_progress()` — are live now. The two settings that *act* on them,
-    `progress_watchdog` and `max_no_progress_seconds`, arrive together with the 24h
-    `start_to_close` backstop in the release that turns the watchdog on fleet-wide in
-    `warn`. Until then `timeout_seconds` keeps its 600s default and nothing observes the
-    signals. Nothing below changes when that release lands; it is written for the state
-    you will be in.
-
 ---
 
 ## The one rule
@@ -87,6 +77,43 @@ Three clarifications, because each is a real misread:
 
 There is a fourth setting, `progress_watchdog`, which is a mode rather than a
 duration: `off`, `warn` or `enforce`. See [Modes](#modes-off-warn-enforce).
+
+### Setting them
+
+Both are `@task` arguments, and both default to *"inherit the fleet-wide value"* — which
+is what almost every task should do:
+
+```python
+class MyConnector(App):
+    # The normal case: declare nothing. warn mode, a 900s allowance, a 24h backstop.
+    @task
+    async def extract(self, input: MyInput) -> MyOutput: ...
+
+    # Once this task's gaps are inside declared holds or under budget — verified
+    # against a large tenant, not a smoke test.
+    @task(progress_watchdog="enforce")
+    async def transform(self, input: MyInput) -> MyOutput: ...
+```
+
+The fleet-wide values come from the environment, so an operator can change them without
+an app release:
+
+| Env var | Default | Controls |
+|---|---|---|
+| `ATLAN_PROGRESS_WATCHDOG` | `warn` | The mode for every task that does not declare one |
+| `ATLAN_MAX_NO_PROGRESS_SECONDS` | `900` | The allowance for every task that does not declare one |
+
+`ATLAN_PROGRESS_WATCHDOG=off` is the **kill-switch**, and it is the one place the
+environment beats a per-task declaration: a task pinned to `enforce` still goes inert.
+A switch that a decorator could out-vote would be no use to the operator holding it
+during an incident, which is the only time it gets thrown. In the other direction the
+env var only fills in a blank — it can never shrink an allowance a task declared for
+itself, because that would be a fleet-wide false-kill generator wearing a config knob's
+clothes.
+
+Both are read on the **worker running the activity**, not on the workflow side, so a
+change takes effect on the next attempt rather than needing every in-flight run
+re-dispatched.
 
 ## What the SDK covers for you
 
@@ -341,7 +368,8 @@ release channel, k8s topology) is reachable through `target_info` — see
 | `enforce` | Reports the gap, then fails the attempt |
 
 Warn is the default fleet-wide because it cannot fail anything, which means nobody has
-to opt in and every app starts producing its own work-list on upgrade.
+to opt in and every app starts producing its own work-list on upgrade. See
+[Setting them](#setting-them) for the `@task` arguments and the env vars behind them.
 
 ### When a stall does fail an attempt
 

--- a/docs/concepts/tasks.md
+++ b/docs/concepts/tasks.md
@@ -159,14 +159,16 @@ There is no `@auto_heartbeater` decorator in v3. Heartbeating is declarative.
 
 ### Process-wide timeout defaults via env vars
 
-When no explicit value is passed to `@task`, the framework reads two env vars at
+When no explicit value is passed to `@task`, the framework reads these env vars at
 process startup:
 
 | Env var | Default | Controls |
 |---|---|---|
-| `ATLAN_START_TO_CLOSE_TIMEOUT_SECONDS` | `600` (10 min) | `timeout_seconds` — Temporal kills the activity attempt after this many seconds |
+| `ATLAN_START_TO_CLOSE_TIMEOUT_SECONDS` | `86400` (24 h) | `timeout_seconds` — Temporal kills the activity attempt after this many seconds |
 | `ATLAN_HEARTBEAT_TIMEOUT_SECONDS` | `60` | `heartbeat_timeout_seconds` — Temporal restarts the activity if no heartbeat is received within this window |
 | `ATLAN_SCHEDULE_TO_CLOSE_TIMEOUT_SECONDS` | unset | `schedule_to_close_seconds` — ceiling on the task's **total** time across every retry. Unset (or `0`) leaves the retry product unbounded |
+| `ATLAN_PROGRESS_WATCHDOG` | `warn` | `progress_watchdog` — the stall watchdog's mode. `off` is a kill-switch that beats a per-task declaration |
+| `ATLAN_MAX_NO_PROGRESS_SECONDS` | `900` | `max_no_progress_seconds` — how long an attempt may be silent before the watchdog reports a gap |
 
 Set these in `atlan.yaml` (or your deployment env) to apply a fleet-wide default
 without touching every `@task` decorator:
@@ -191,11 +193,11 @@ question each one answers:
 |---|---|---|---|
 | `heartbeat_timeout_seconds` | 60s | *"Is anything beating at all?"* — crash, OOM kill, node loss, a fully blocked event loop | No |
 | `max_no_progress_seconds` | 900s | *"How long may this attempt be silent before it counts as stalled?"* — wedged-but-alive | Rarely |
-| `timeout_seconds` (`start_to_close`) | 600s today; a 24h backstop once the stall watchdog ships | *"What is the absolute ceiling on one attempt?"* | No — it becomes a backstop, not a budget |
+| `timeout_seconds` (`start_to_close`) | a 24h backstop | *"What is the absolute ceiling on one attempt?"* | No — it is a backstop, not a budget |
 
-`max_no_progress_seconds` and the `progress_watchdog` mode arrive with the release that
-raises `timeout_seconds` to its backstop value; the progress signals they act on are
-already live.
+There is a fourth setting, `progress_watchdog` (`off` / `warn` / `enforce`, defaulting
+to `warn` fleet-wide), which decides what the watchdog *does* with a gap rather than how
+long a gap may be.
 
 `max_no_progress_seconds` is **not** the beat interval (that is `auto_heartbeat_seconds`,
 and it is unconditional) and **not** a duration budget — it measures the *gap* between
@@ -217,7 +219,7 @@ whole product:
 worst case per dispatch = retry_max_attempts x timeout_seconds
 ```
 
-At the defaults that is 30 minutes. Against a 24-hour backstop it is 72 hours.
+At the defaults — three attempts against the 24-hour backstop — that is 72 hours.
 The SDK leaves that product unbounded on purpose ([ADR-0018](../adr/0018-progress-aware-heartbeat.md)
 → *Bounding total time*) — picking a total duration up front is the guess the
 whole design removes — so the ceiling is a declaration, available three ways:

--- a/docs/guides/architecture.md
+++ b/docs/guides/architecture.md
@@ -69,13 +69,16 @@ Tasks are where side effects happen. Each completed task is a durable checkpoint
 
 ```python
 @task(
-    timeout_seconds=600,            # Activity start-to-close timeout (default 10 min)
     retry_max_attempts=3,           # Default 3 retries
     retry_max_interval_seconds=30,  # Max backoff between retries
 )
 async def my_task(self, input: TaskInput) -> TaskOutput:
     ...
 ```
+
+`timeout_seconds` (the activity's `start_to_close` bound) defaults to a **24-hour
+backstop** and is not a number to tune — a wedged-but-alive attempt is caught by the
+stall watchdog in minutes instead. See [Progress and Stalls](../concepts/progress-and-stalls.md).
 
 - `@task` validates the single-model contract (one `Input` model, one `Output` model) **at class definition time** — before any code runs.
 - Tasks run outside the Temporal sandbox; they can import any library without passthrough concerns.

--- a/docs/runbooks/stalled-task.md
+++ b/docs/runbooks/stalled-task.md
@@ -166,6 +166,52 @@ An app that has worked through its work-list can then flip to `enforce`, verifie
 against a large-tenant/tail profile — at which point the SDK kills these attempts
 in minutes and this runbook stops applying to it.
 
+## If wedging turns out to be far more common than expected
+
+Everything above assumes a wedge is rare enough that a human per firing is a
+sensible control. ADR-0018 accepts that regression explicitly *because the wedge
+rate was unknown* — warn mode is what measures it. If the measurement comes back
+saying wedges are common, and worker slots are being burnt doing nothing, this is
+the section you want.
+
+**First, the counter-intuitive part: `ATLAN_PROGRESS_WATCHDOG=off` is not the
+lever.** The resources are being burnt by the **24h backstop**, not by the
+watchdog. The watchdog costs one metric per gap and is the only reason you can
+see the problem at all; turning it off leaves every wedge exactly where it is and
+blinds you to it. It is the switch for *"I want the telemetry gone"*, not for
+*"wedges are eating my fleet"*.
+
+| Lever (env var) | What it does | Reach for it when |
+|---|---|---|
+| `ATLAN_START_TO_CLOSE_TIMEOUT_SECONDS=600` | The real revert — restores the pre-ADR-0018 ceiling and its ~30-min-per-dispatch worst case, including the accidental kill | You want the previous behaviour back, fleet-wide or for one app |
+| `ATLAN_SCHEDULE_TO_CLOSE_TIMEOUT_SECONDS=<seconds>` | Bounds the **retry product** (72h → whatever you set) while leaving one attempt generous | You want the blast radius capped but long single attempts still working |
+| `ATLAN_PROGRESS_WATCHDOG=enforce` | The SDK kills each wedge itself at `max_no_progress_seconds`, collapsing the worst case from 72h to roughly 45 min | The wedges are visible as *gaps* **and** the affected apps are instrumented |
+| `ATLAN_PROGRESS_WATCHDOG=off` | Stops gap reporting and enforcement. **Does not reduce wedge exposure** | Never, for this problem |
+
+### Which lever depends on where the wedges are
+
+The two shapes need different levers, and the metrics already tell them apart:
+
+| What you see | Shape | What works |
+|---|---|---|
+| `task_no_progress_gap_seconds` firing | Wedged in async code or a quiet loop | `enforce` catches it one budget in |
+| `task_hold_duration_seconds{hold_bounded="false"}` long, **no** gap metric | Wedged inside a blocking `run_in_thread` call | `enforce` does **nothing** — the unbounded auto-hold is vouching for it by design. Only the backstop revert or a `schedule_to_close` ceiling bounds these |
+
+If the wedges are the second shape, do not reach for `enforce` and expect relief.
+
+### Two things to know before you flip anything
+
+- **All of these are read once at process start**, so any of them needs a **worker
+  restart** to take effect. None is a live toggle. Plan the restart into the
+  mitigation rather than discovering it mid-incident.
+- **An explicit `@task(timeout_seconds=...)` beats the env var.** Apps that
+  hard-code their own timeouts never took the 24h backstop, so the revert does not
+  reach them — and they are not the apps whose exposure changed.
+
+Whichever lever you use, record it: the wedge rate is the number ADR-0018 →
+*Migration* says decides whether the fleet enforces, and a mitigation applied
+without a note is a measurement lost.
+
 ## If you suspect a wedge and no alert fired
 
 The alert is only as good as its inputs. In order of likelihood:
@@ -177,8 +223,8 @@ The alert is only as good as its inputs. In order of likelihood:
    SDK series, e.g. `temporal_activity_executions_total{app_name="<app>"}`. If
    that is missing while activities are visibly running, fix the metrics path
    first — the stall alert cannot fire for that app.
-2. **The watchdog is off for that task.** `watchdog_mode="off"` observes nothing.
-   Confirm on the dashboard's mode panel.
+2. **The watchdog is off for that task.** `watchdog_mode="off"` reports no gaps
+   (its hold observations still record). Confirm on the dashboard's mode panel.
 3. **A hold is vouching for the site.** An unbounded hold — every
    `run_in_thread` offload takes one — suppresses the stall watchdog for the
    whole call by design, so a wedged *blocking* call produces **no gap metric**.

--- a/docs/upgrade-guide-v3.md
+++ b/docs/upgrade-guide-v3.md
@@ -1045,9 +1045,13 @@ Two histograms and the occasional INFO log line. Warn-mode findings are delibera
 **never** WARNING-level — a stall observation under a fleet-wide default is an expected
 observation, not an alert.
 
-If you need even that gone, `ATLAN_PROGRESS_WATCHDOG=off` — or `progress_watchdog="off"`
-on a single `@task` — is the kill-switch. It makes the whole mechanism inert. It is not
-the normal state, and it also switches off the report you would otherwise use later.
+If you need most of that gone, `ATLAN_PROGRESS_WATCHDOG=off` — or
+`progress_watchdog="off"` on a single `@task` — is the kill-switch: no gap is reported
+and nothing is ever failed. It is not the normal state, and it also switches off the
+report you would otherwise use later. Note it is not *completely* inert — hold
+observations still record, since those are a work-list entry rather than a watchdog
+action — and it does not shorten a wedged attempt, which is bounded by
+`timeout_seconds` either way.
 
 ### One knob did change value: `timeout_seconds`
 

--- a/docs/upgrade-guide-v3.md
+++ b/docs/upgrade-guide-v3.md
@@ -1026,7 +1026,7 @@ guess.
 
 **There is no migration task here.** This step exists to tell you that, precisely.
 
-### On upgrade, nothing fails differently
+### On upgrade, no failure *semantics* change (the default timeout and telemetry do)
 
 - You land in **`warn` mode**, which cannot fail an activity. It observes and reports.
 - `heartbeat_timeout_seconds` keeps its meaning and its 60s default. Crash, OOM and

--- a/docs/upgrade-guide-v3.md
+++ b/docs/upgrade-guide-v3.md
@@ -1026,10 +1026,6 @@ guess.
 
 **There is no migration task here.** This step exists to tell you that, precisely.
 
-> The progress signals the watchdog reads are already live. The settings that act on
-> them — `progress_watchdog` and `max_no_progress_seconds` — arrive together with the
-> 24h backstop, in the release that turns the watchdog on fleet-wide in `warn`.
-
 ### On upgrade, nothing fails differently
 
 - You land in **`warn` mode**, which cannot fail an activity. It observes and reports.
@@ -1049,9 +1045,25 @@ Two histograms and the occasional INFO log line. Warn-mode findings are delibera
 **never** WARNING-level — a stall observation under a fleet-wide default is an expected
 observation, not an alert.
 
-If you need even that gone, `progress_watchdog="off"` is the kill-switch. It makes the
-whole mechanism inert. It is not the normal state, and it also switches off the report
-you would otherwise use later.
+If you need even that gone, `ATLAN_PROGRESS_WATCHDOG=off` — or `progress_watchdog="off"`
+on a single `@task` — is the kill-switch. It makes the whole mechanism inert. It is not
+the normal state, and it also switches off the report you would otherwise use later.
+
+### One knob did change value: `timeout_seconds`
+
+`ATLAN_START_TO_CLOSE_TIMEOUT_SECONDS` now defaults to **86400** (24 h) instead of 600.
+Nothing changes for a task that passes `timeout_seconds=` explicitly — which, if your app
+weight-classed its tasks, is most of them. Those explicit numbers are now the thing worth
+deleting: they are the guesses ADR-0018 exists to remove, and with the backstop in place
+a legitimately long attempt no longer needs one to survive. Delete them at your own pace;
+nothing forces it.
+
+The one consequence to be aware of is on the other side of the trade: a *wedged* attempt
+is no longer killed by a small ceiling, so while your app is in `warn` its containment is
+the `AtlanAppTaskStalled` alert plus a human rather than an automatic kill. Detection
+improves — a wedge is now visible one budget in, where before it was only ever killed by
+luck. See [ADR-0018 → Migration](adr/0018-progress-aware-heartbeat.md#migration--backward-compatibility--what-if-i-do-nothing)
+for why that trade is the one being made.
 
 ### Declaring holds is an eventual optimisation, not an upgrade task
 

--- a/tests/unit/app/test_task.py
+++ b/tests/unit/app/test_task.py
@@ -416,6 +416,131 @@ class TestTaskEnvVarDefaults:
 
 
 # =============================================================================
+# @task stall watchdog (ADR-0018 / FND-296)
+# =============================================================================
+
+
+class TestTaskDurationBackstop:
+    """``timeout_seconds`` stops being a duration budget and becomes a backstop."""
+
+    def test_the_default_is_the_24h_backstop(self) -> None:
+        """The relief half of FND-296, and the one thing that changes on upgrade.
+
+        It ships in the same release as warn mode on purpose: coupling it to
+        ``enforce`` would leave every app dying at its guessed ceiling while the
+        fleet gathered data, so "no upgrade task" would buy nobody anything
+        (ADR-0018 → *Migration*).
+        """
+        from application_sdk.app.task import _START_TO_CLOSE_BACKSTOP_SECONDS
+
+        class MyApp:
+            @task
+            async def my_task(self, input: SimpleInput) -> SimpleOutput:
+                return SimpleOutput()
+
+        metadata = get_task_metadata(MyApp.my_task)
+        assert metadata is not None
+        assert metadata.timeout_seconds == _START_TO_CLOSE_BACKSTOP_SECONDS == 86_400
+
+    def test_an_app_that_still_declares_one_keeps_it(self) -> None:
+        """Deleting the guesses is an optimisation, not a migration step."""
+
+        class MyApp:
+            @task(timeout_seconds=7200)
+            async def my_task(self, input: SimpleInput) -> SimpleOutput:
+                return SimpleOutput()
+
+        metadata = get_task_metadata(MyApp.my_task)
+        assert metadata is not None
+        assert metadata.timeout_seconds == 7200
+
+
+class TestTaskProgressWatchdog:
+    """``@task(progress_watchdog=..., max_no_progress_seconds=...)``."""
+
+    def test_declaring_nothing_stores_nothing(self) -> None:
+        """``None``, not ``WARN``.
+
+        "Declares nothing" and "declares warn" are different facts: only the
+        first one follows an operator moving the fleet, and only the first one
+        yields to the ``off`` kill-switch without argument.
+        """
+
+        class MyApp:
+            @task
+            async def my_task(self, input: SimpleInput) -> SimpleOutput:
+                return SimpleOutput()
+
+        metadata = get_task_metadata(MyApp.my_task)
+        assert metadata is not None
+        assert metadata.progress_watchdog is None
+        assert metadata.max_no_progress_seconds is None
+
+    @pytest.mark.parametrize("declared", ["off", "warn", "enforce"])
+    def test_a_string_mode_is_coerced_to_the_enum(self, declared: str) -> None:
+        """The enum is a ``StrEnum``, so the string form is the ergonomic one."""
+        from application_sdk.execution.progress import ProgressWatchdogMode
+
+        class MyApp:
+            @task(progress_watchdog=declared)
+            async def my_task(self, input: SimpleInput) -> SimpleOutput:
+                return SimpleOutput()
+
+        metadata = get_task_metadata(MyApp.my_task)
+        assert metadata is not None
+        assert metadata.progress_watchdog is ProgressWatchdogMode(declared)
+
+    def test_the_enum_is_accepted_directly(self) -> None:
+        from application_sdk.execution.progress import ProgressWatchdogMode
+
+        class MyApp:
+            @task(progress_watchdog=ProgressWatchdogMode.ENFORCE)
+            async def my_task(self, input: SimpleInput) -> SimpleOutput:
+                return SimpleOutput()
+
+        metadata = get_task_metadata(MyApp.my_task)
+        assert metadata is not None
+        assert metadata.progress_watchdog is ProgressWatchdogMode.ENFORCE
+
+    def test_an_unknown_mode_is_rejected_at_decoration(self) -> None:
+        """Loud at import, unlike the env-var reader next door.
+
+        A typo in a deployment manifest must not stop a worker booting; a typo in
+        an app's own source is a bug its author should see immediately.
+        """
+        with pytest.raises(TaskContractError, match="not a valid mode"):
+
+            class MyApp:
+                @task(progress_watchdog="enfroce")
+                async def my_task(self, input: SimpleInput) -> SimpleOutput:
+                    return SimpleOutput()
+
+    def test_a_declared_allowance_is_stored_as_seconds(self) -> None:
+        class MyApp:
+            @task(max_no_progress_seconds=1800)
+            async def my_task(self, input: SimpleInput) -> SimpleOutput:
+                return SimpleOutput()
+
+        metadata = get_task_metadata(MyApp.my_task)
+        assert metadata is not None
+        assert metadata.max_no_progress_seconds == 1800.0
+
+    @pytest.mark.parametrize("bad", [0, -1, float("nan"), float("inf")])
+    def test_an_unusable_allowance_is_rejected(self, bad: float) -> None:
+        """Zero stalls every attempt on its first tick; NaN slips past ``<= 0``.
+
+        In an enforcing task either one is a kill switch wearing a config knob's
+        clothes, so neither is allowed to reach a decoration.
+        """
+        with pytest.raises(TaskContractError, match="finite positive"):
+
+            class MyApp:
+                @task(max_no_progress_seconds=bad)
+                async def my_task(self, input: SimpleInput) -> SimpleOutput:
+                    return SimpleOutput()
+
+
+# =============================================================================
 # @task pool field
 # =============================================================================
 

--- a/tests/unit/execution/test_stall_failure.py
+++ b/tests/unit/execution/test_stall_failure.py
@@ -51,7 +51,10 @@ from application_sdk.execution._temporal.activities import (
     create_activity_from_task,
 )
 from application_sdk.execution.errors import ApplicationError
-from application_sdk.execution.heartbeat import NoopHeartbeatController
+from application_sdk.execution.heartbeat import (
+    NoopHeartbeatController,
+    TemporalHeartbeatController,
+)
 from application_sdk.execution.heartbeat import (
     auto_heartbeat_loop as _real_auto_heartbeat_loop,
 )
@@ -86,11 +89,16 @@ def _activity_for(app_name: str, task_name: str) -> ActivityFn:
     )
 
 
+_HEARTBEAT_DEFAULT = object()
+
+
 def _task_context(
     app_name: str,
     task_name: str,
     *,
     heartbeating: bool = True,
+    heartbeat_timeout_seconds: int | None | object = _HEARTBEAT_DEFAULT,
+    auto_heartbeat_seconds: int | None | object = _HEARTBEAT_DEFAULT,
     progress_watchdog: ProgressWatchdogMode | None = None,
     max_no_progress_seconds: float | None = None,
 ) -> TaskContext:
@@ -98,8 +106,16 @@ def _task_context(
         app_name=app_name,
         task_name=task_name,
         run_id="run-1",
-        heartbeat_timeout_seconds=60 if heartbeating else None,
-        auto_heartbeat_seconds=10 if heartbeating else None,
+        heartbeat_timeout_seconds=(
+            (60 if heartbeating else None)
+            if heartbeat_timeout_seconds is _HEARTBEAT_DEFAULT
+            else cast("int | None", heartbeat_timeout_seconds)
+        ),
+        auto_heartbeat_seconds=(
+            (10 if heartbeating else None)
+            if auto_heartbeat_seconds is _HEARTBEAT_DEFAULT
+            else cast("int | None", auto_heartbeat_seconds)
+        ),
         progress_watchdog=progress_watchdog,
         max_no_progress_seconds=max_no_progress_seconds,
     )
@@ -653,13 +669,105 @@ class TestWatchdogWiring:
 
         assert result.msg == "ok"
         # One loop, in the inherited warn mode, ticking on the watchdog-only beat
-        # (no heartbeat interval to reuse) and heartbeating through the Noop
-        # controller — so nothing reaches Temporal, but a gap is still observed.
+        # (no heartbeat interval to reuse) and heartbeating through a Noop beat —
+        # so nothing reaches Temporal, but a gap is still observed.
         assert len(loop_calls) == 1
         assert loop_calls[0]["watchdog_mode"] is ProgressWatchdogMode.WARN
         assert loop_calls[0]["interval_seconds"] == _WATCHDOG_ONLY_TICK_SECONDS
         assert isinstance(
             loop_calls[0]["heartbeat_fn"].__self__, NoopHeartbeatController
+        )
+
+    async def test_manual_heartbeats_get_no_automatic_keepalive(self) -> None:
+        """Manual-heartbeat tasks opted out of auto-heartbeats, watchdog or not.
+
+        The seam must not widen: ``heartbeat_timeout_seconds`` set with
+        ``auto_heartbeat_seconds=None`` means *manual* heartbeating — the task's
+        own ``heartbeat()`` calls, on the real Temporal controller — and the
+        loop the watchdog rides must not add automatic keepalives the author
+        disabled. So the loop ticks through a Noop beat while the controller
+        handed to the task stays Temporal.
+        """
+        loop_calls: list[dict[str, Any]] = []
+
+        class _ManualApp(App):
+            @task(timeout_seconds=600)
+            async def manual(self, input: _StallIn) -> _StallOut:
+                return _StallOut(msg="ok")
+
+            async def run(self, input: _StallIn) -> _StallOut:
+                return await self.manual(input)
+
+        async def loop(*, stop_event: asyncio.Event, **kwargs: Any) -> None:
+            loop_calls.append(kwargs)
+            await stop_event.wait()
+
+        _ManualApp()
+        activity_fn = _activity_for("_manual-app", "manual")
+
+        with mock.patch(_HEARTBEAT_LOOP, new=loop):
+            result = await activity_fn(
+                _task_context(
+                    "_manual-app",
+                    "manual",
+                    heartbeat_timeout_seconds=60,
+                    auto_heartbeat_seconds=None,
+                ),
+                _StallIn(),
+            )
+
+        assert result.msg == "ok"
+        # One loop — the watchdog still runs in the inherited warn mode — but
+        # ticking on the watchdog-only beat through a Noop heartbeat, so no
+        # automatic Temporal keepalive is emitted for a task that asked for
+        # none.
+        assert len(loop_calls) == 1
+        assert loop_calls[0]["watchdog_mode"] is ProgressWatchdogMode.WARN
+        assert loop_calls[0]["interval_seconds"] == _WATCHDOG_ONLY_TICK_SECONDS
+        assert isinstance(
+            loop_calls[0]["heartbeat_fn"].__self__, NoopHeartbeatController
+        )
+
+    async def test_auto_heartbeat_keeps_the_temporal_beat(self) -> None:
+        """The ordinary path is untouched: auto-heartbeating rides the real beat.
+
+        With an auto-heartbeat interval configured the loop must keep emitting
+        keepalives through the task's own Temporal controller — the beat is the
+        crash detector, and selecting the Noop here would silently blind it.
+        """
+        loop_calls: list[dict[str, Any]] = []
+
+        class _BeatApp(App):
+            @task(timeout_seconds=600)
+            async def beat(self, input: _StallIn) -> _StallOut:
+                return _StallOut(msg="ok")
+
+            async def run(self, input: _StallIn) -> _StallOut:
+                return await self.beat(input)
+
+        async def loop(*, stop_event: asyncio.Event, **kwargs: Any) -> None:
+            loop_calls.append(kwargs)
+            await stop_event.wait()
+
+        _BeatApp()
+        activity_fn = _activity_for("_beat-app", "beat")
+
+        with mock.patch(_HEARTBEAT_LOOP, new=loop):
+            result = await activity_fn(
+                _task_context(
+                    "_beat-app",
+                    "beat",
+                    heartbeat_timeout_seconds=60,
+                    auto_heartbeat_seconds=10,
+                ),
+                _StallIn(),
+            )
+
+        assert result.msg == "ok"
+        assert len(loop_calls) == 1
+        assert loop_calls[0]["interval_seconds"] == 10
+        assert isinstance(
+            loop_calls[0]["heartbeat_fn"].__self__, TemporalHeartbeatController
         )
 
 

--- a/tests/unit/execution/test_stall_failure.py
+++ b/tests/unit/execution/test_stall_failure.py
@@ -46,15 +46,16 @@ from application_sdk.execution import progress_telemetry as telemetry_module
 from application_sdk.execution import shutdown as shutdown_module
 from application_sdk.execution._temporal import activities as activities_module
 from application_sdk.execution._temporal.activities import (
+    _WATCHDOG_ONLY_TICK_SECONDS,
     TaskContext,
     create_activity_from_task,
 )
 from application_sdk.execution.errors import ApplicationError
+from application_sdk.execution.heartbeat import NoopHeartbeatController
 from application_sdk.execution.heartbeat import (
     auto_heartbeat_loop as _real_auto_heartbeat_loop,
 )
 from application_sdk.execution.progress import (
-    MAX_NO_PROGRESS_SECONDS,
     ClosedHold,
     ProgressTracker,
     ProgressWatchdogMode,
@@ -459,13 +460,23 @@ class TestWatchdogWiring:
         assert seen["progress"] is from_body[0]
         assert callable(seen["on_stall"])
 
-    async def test_the_activity_supplies_the_resolved_config(self) -> None:
+    async def test_the_activity_supplies_the_resolved_config(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """A task that declares nothing still arrives at the loop in warn mode.
 
         The whole of FND-296 in one assertion: no opt-in, no per-app step, and
         the mode reaching the watchdog is the fleet default rather than ``OFF``.
         The budget comes with it, since a mode with no allowance is inert.
+
+        Both constants are pinned rather than read from the environment: a worker
+        started with ``ATLAN_PROGRESS_WATCHDOG=enforce`` (or a custom allowance)
+        would otherwise make this assert a non-default.
         """
+        monkeypatch.setattr(
+            progress_module, "PROGRESS_WATCHDOG_MODE", ProgressWatchdogMode.WARN
+        )
+        monkeypatch.setattr(progress_module, "MAX_NO_PROGRESS_SECONDS", 900.0)
         seen: dict[str, Any] = {}
 
         class _InheritingApp(App):
@@ -487,7 +498,54 @@ class TestWatchdogWiring:
             await activity_fn(_task_context("_inheriting-app", "inherits"), _StallIn())
 
         assert seen["watchdog_mode"] is ProgressWatchdogMode.WARN
-        assert seen["max_no_progress_seconds"] == MAX_NO_PROGRESS_SECONDS
+        assert seen["max_no_progress_seconds"] == 900.0
+
+    async def test_the_hold_observer_gets_the_resolved_allowance(self) -> None:
+        """A declared ``max_no_progress_seconds`` reaches the hold observer too.
+
+        The observer's ``budget_seconds`` is the floor above which an unbounded
+        hold is worth naming; left at the default it would ignore the task's own
+        allowance, under-reporting holds past a smaller budget and over-reporting
+        ones under a larger one.
+        """
+        built: dict[str, Any] = {}
+
+        def observer(task_name: str, *, budget_seconds: float) -> None:
+            built["task_name"] = task_name
+            built["budget_seconds"] = budget_seconds
+            return None
+
+        class _DeclaringApp(App):
+            @task(max_no_progress_seconds=42)
+            async def declares(self, input: _StallIn) -> _StallOut:
+                return _StallOut(msg="ok")
+
+            async def run(self, input: _StallIn) -> _StallOut:
+                return await self.declares(input)
+
+        async def loop(*, stop_event: asyncio.Event, **_kwargs: Any) -> None:
+            await stop_event.wait()
+
+        _DeclaringApp()
+        activity_fn = _activity_for("_declaring-app", "declares")
+
+        # ``closed_hold_observer`` is imported function-locally from
+        # ``progress_telemetry`` (a circular-import workaround), so the patch has
+        # to land on the source module, not on ``activities``.
+        with (
+            mock.patch(_HEARTBEAT_LOOP, new=loop),
+            mock.patch.object(
+                telemetry_module, "closed_hold_observer", side_effect=observer
+            ),
+        ):
+            await activity_fn(
+                _task_context(
+                    "_declaring-app", "declares", max_no_progress_seconds=42.0
+                ),
+                _StallIn(),
+            )
+
+        assert built["budget_seconds"] == 42.0
 
     async def test_a_declaration_on_the_wire_reaches_the_loop(self) -> None:
         """What an app flips in rollout step 6, arriving from the dispatch side."""
@@ -529,9 +587,10 @@ class TestWatchdogWiring:
 
         Resolution happens here rather than on the workflow side precisely so an
         operator can throw the switch without every in-flight run needing to be
-        re-dispatched to notice.
+        re-dispatched to notice. A resolved ``off`` starts no loop at all — the
+        one mode that is genuinely inert for no-progress *detection*.
         """
-        seen: dict[str, Any] = {}
+        loop_calls: list[dict[str, Any]] = []
 
         class _PinnedApp(App):
             @task(progress_watchdog="enforce")
@@ -542,7 +601,7 @@ class TestWatchdogWiring:
                 return await self.pinned(input)
 
         async def loop(*, stop_event: asyncio.Event, **kwargs: Any) -> None:
-            seen.update(kwargs)
+            loop_calls.append(kwargs)
             await stop_event.wait()
 
         _PinnedApp()
@@ -561,14 +620,15 @@ class TestWatchdogWiring:
                 _StallIn(),
             )
 
-        assert seen["watchdog_mode"] is ProgressWatchdogMode.OFF
+        assert loop_calls == []
 
-    async def test_no_heartbeat_loop_means_no_watchdog(self) -> None:
-        """A task with heartbeating disabled runs no loop, so nothing can stall it.
+    async def test_no_heartbeat_still_runs_the_watchdog(self) -> None:
+        """A task with heartbeating disabled is exactly the one the watchdog protects.
 
-        Recorded rather than asserted as desirable: the tracker is bound for such
-        a task, but the watchdog lives in the auto-heartbeat loop, so today the
-        duration backstop is that task's only bound.
+        The seam gates on the resolved mode, not the heartbeat config: with the
+        fleet default (``warn``) and no heartbeat, the loop still starts — riding
+        a NoopHeartbeatController beat that emits no Temporal heartbeat — so a
+        wedge is observed rather than left to the duration backstop alone.
         """
         loop_calls: list[dict[str, Any]] = []
 
@@ -580,8 +640,9 @@ class TestWatchdogWiring:
             async def run(self, input: _StallIn) -> _StallOut:
                 return await self.nobeat(input)
 
-        async def loop(**kwargs: Any) -> None:
+        async def loop(*, stop_event: asyncio.Event, **kwargs: Any) -> None:
             loop_calls.append(kwargs)
+            await stop_event.wait()
 
         activity_fn = _activity_for("_no-beat-app", "nobeat")
 
@@ -591,7 +652,15 @@ class TestWatchdogWiring:
             )
 
         assert result.msg == "ok"
-        assert loop_calls == []
+        # One loop, in the inherited warn mode, ticking on the watchdog-only beat
+        # (no heartbeat interval to reuse) and heartbeating through the Noop
+        # controller — so nothing reaches Temporal, but a gap is still observed.
+        assert len(loop_calls) == 1
+        assert loop_calls[0]["watchdog_mode"] is ProgressWatchdogMode.WARN
+        assert loop_calls[0]["interval_seconds"] == _WATCHDOG_ONLY_TICK_SECONDS
+        assert isinstance(
+            loop_calls[0]["heartbeat_fn"].__self__, NoopHeartbeatController
+        )
 
 
 class TestDeclarationReachesTheWire:
@@ -723,13 +792,13 @@ class TestOffIsNotFullyInert:
     lever that does not move.
     """
 
-    async def _run_in_off_mode(self) -> tuple[dict[str, Any], list[ClosedHold]]:
+    async def _run_in_off_mode(self) -> tuple[list[dict[str, Any]], list[ClosedHold]]:
         """Run one attempt in ``off`` mode; the task body takes and releases a hold.
 
-        Returns what the heartbeat loop was handed, and every hold observation
+        Returns every call made to the heartbeat loop, and every hold observation
         that actually reached the telemetry layer.
         """
-        seen: dict[str, Any] = {}
+        loop_calls: list[dict[str, Any]] = []
         observed: list[ClosedHold] = []
 
         class _OffApp(App):
@@ -745,7 +814,7 @@ class TestOffIsNotFullyInert:
                 return await self.quiet_step(input)
 
         async def loop(*, stop_event: asyncio.Event, **kwargs: Any) -> None:
-            seen.update(kwargs)
+            loop_calls.append(kwargs)
             await stop_event.wait()
 
         _OffApp()
@@ -766,14 +835,18 @@ class TestOffIsNotFullyInert:
                 _StallIn(),
             )
 
-        return seen, observed
+        return loop_calls, observed
 
     async def test_the_watchdog_never_acts(self) -> None:
-        """``auto_heartbeat_loop`` leaves the budget unset for ``OFF``, so no gap
-        is ever measured and ``on_stall`` can never be called."""
-        seen, _ = await self._run_in_off_mode()
+        """``off`` starts no watchdog loop at all, so no gap is ever measured and
+        ``on_stall`` can never be called.
 
-        assert seen["watchdog_mode"] is ProgressWatchdogMode.OFF
+        The seam gates on the resolved mode now, not the heartbeat config: a
+        resolved ``off`` is the one mode that starts nothing, which is what makes
+        it a real kill-switch for no-progress *detection*."""
+        loop_calls, _ = await self._run_in_off_mode()
+
+        assert loop_calls == []
 
     async def test_hold_telemetry_still_records(self) -> None:
         """The observer is attached at ``bind_progress_tracker``, not gated on mode.

--- a/tests/unit/execution/test_stall_failure.py
+++ b/tests/unit/execution/test_stall_failure.py
@@ -42,6 +42,7 @@ from application_sdk.contracts.base import Input, Output
 from application_sdk.errors.leaves import WORKER_EVICTED_TYPE, TaskStalledError
 from application_sdk.errors.wire import FailureDetails
 from application_sdk.execution import progress as progress_module
+from application_sdk.execution import progress_telemetry as telemetry_module
 from application_sdk.execution import shutdown as shutdown_module
 from application_sdk.execution._temporal import activities as activities_module
 from application_sdk.execution._temporal.activities import (
@@ -54,9 +55,11 @@ from application_sdk.execution.heartbeat import (
 )
 from application_sdk.execution.progress import (
     MAX_NO_PROGRESS_SECONDS,
+    ClosedHold,
     ProgressTracker,
     ProgressWatchdogMode,
     current_progress_tracker,
+    holding_progress,
     resolve_watchdog_mode,
 )
 
@@ -707,3 +710,79 @@ class TestDeclarationReachesTheWire:
         assert resolve_watchdog_mode(decoded[0].progress_watchdog) is (
             ProgressWatchdogMode.WARN
         )
+
+
+class TestOffIsNotFullyInert:
+    """``off`` stops the watchdog, not every observation — and not the exposure.
+
+    Documented in three places (the enum, Progress & Stalls, the stalled-task
+    runbook) because it is the kind of claim an operator acts on mid-incident.
+    Pinned here so the docs and the code cannot drift apart: someone "fixing"
+    ``off`` to be genuinely inert would silently drop the hold work-list, and
+    someone reading ``off`` as a way to shorten a wedge would be reaching for a
+    lever that does not move.
+    """
+
+    async def _run_in_off_mode(self) -> tuple[dict[str, Any], list[ClosedHold]]:
+        """Run one attempt in ``off`` mode; the task body takes and releases a hold.
+
+        Returns what the heartbeat loop was handed, and every hold observation
+        that actually reached the telemetry layer.
+        """
+        seen: dict[str, Any] = {}
+        observed: list[ClosedHold] = []
+
+        class _OffApp(App):
+            @task
+            async def quiet_step(self, input: _StallIn) -> _StallOut:
+                # The shape every `run_in_thread` offload produces: one hold,
+                # entered and released inside the attempt.
+                async with holding_progress("vendor.export", timeout=None):
+                    pass
+                return _StallOut(msg="ok")
+
+            async def run(self, input: _StallIn) -> _StallOut:
+                return await self.quiet_step(input)
+
+        async def loop(*, stop_event: asyncio.Event, **kwargs: Any) -> None:
+            seen.update(kwargs)
+            await stop_event.wait()
+
+        _OffApp()
+        activity_fn = _activity_for("_off-app", "quiet_step")
+
+        with (
+            mock.patch(_HEARTBEAT_LOOP, new=loop),
+            mock.patch.object(
+                telemetry_module,
+                "record_closed_hold",
+                side_effect=lambda closed, **_kw: observed.append(closed),
+            ),
+        ):
+            await activity_fn(
+                _task_context(
+                    "_off-app", "quiet_step", progress_watchdog=ProgressWatchdogMode.OFF
+                ),
+                _StallIn(),
+            )
+
+        return seen, observed
+
+    async def test_the_watchdog_never_acts(self) -> None:
+        """``auto_heartbeat_loop`` leaves the budget unset for ``OFF``, so no gap
+        is ever measured and ``on_stall`` can never be called."""
+        seen, _ = await self._run_in_off_mode()
+
+        assert seen["watchdog_mode"] is ProgressWatchdogMode.OFF
+
+    async def test_hold_telemetry_still_records(self) -> None:
+        """The observer is attached at ``bind_progress_tracker``, not gated on mode.
+
+        So ``task_hold_duration_seconds`` keeps recording once per released hold
+        — once per ``run_in_thread`` offload — which is why ``off`` is not
+        byte-identical to pre-ADR-0018 behaviour, and why the docs no longer say
+        it is.
+        """
+        _, observed = await self._run_in_off_mode()
+
+        assert [h.label for h in observed] == ["vendor.export"]

--- a/tests/unit/execution/test_stall_failure.py
+++ b/tests/unit/execution/test_stall_failure.py
@@ -12,19 +12,23 @@ and still be wrong in production:
    eviction won that race the attempt would be re-dispatched by the
    workflow-side eviction-retry loop *outside* the normal retry budget, so the
    matrix of (stall, shutting down) is pinned in all four corners.
-3. **What is wired, and what deliberately is not.** The handler is injected now;
-   the mode and the budget that make the watchdog act are FND-296's, so on this
-   branch the watchdog is inert and the behaviour change is zero. A test asserts
-   that absence rather than trusting it.
+3. **What the activity supplies to the watchdog.** Since FND-296 the mode and the
+   budget are resolved in the activity and passed to the loop, and a task that
+   declares nothing arrives in ``warn`` — the fleet default, with no opt-in.
+   Resolution happens on the activity side so ``off`` in the worker's
+   environment is a real kill-switch, and so a run dispatched before these
+   fields existed lands on the default rather than on nothing. All of that is
+   asserted rather than trusted.
 
 The end-to-end test drives the *real* watchdog inside the *real* activity body,
-with only the enforce config injected — no patched clock (an asyncio loop shares
-``time.monotonic``), just a 10 ms tick against a 50 ms budget.
+with only the enforce config overridden — no patched clock (an asyncio loop
+shares ``time.monotonic``), just a 10 ms tick against a 50 ms budget.
 """
 
 from __future__ import annotations
 
 import asyncio
+import dataclasses
 from collections.abc import Awaitable, Callable
 from typing import Any, cast
 from unittest import mock
@@ -37,6 +41,7 @@ from application_sdk.app.task import task
 from application_sdk.contracts.base import Input, Output
 from application_sdk.errors.leaves import WORKER_EVICTED_TYPE, TaskStalledError
 from application_sdk.errors.wire import FailureDetails
+from application_sdk.execution import progress as progress_module
 from application_sdk.execution import shutdown as shutdown_module
 from application_sdk.execution._temporal import activities as activities_module
 from application_sdk.execution._temporal.activities import (
@@ -48,9 +53,11 @@ from application_sdk.execution.heartbeat import (
     auto_heartbeat_loop as _real_auto_heartbeat_loop,
 )
 from application_sdk.execution.progress import (
+    MAX_NO_PROGRESS_SECONDS,
     ProgressTracker,
     ProgressWatchdogMode,
     current_progress_tracker,
+    resolve_watchdog_mode,
 )
 
 _HEARTBEAT_LOOP = "application_sdk.execution.heartbeat.auto_heartbeat_loop"
@@ -76,7 +83,12 @@ def _activity_for(app_name: str, task_name: str) -> ActivityFn:
 
 
 def _task_context(
-    app_name: str, task_name: str, *, heartbeating: bool = True
+    app_name: str,
+    task_name: str,
+    *,
+    heartbeating: bool = True,
+    progress_watchdog: ProgressWatchdogMode | None = None,
+    max_no_progress_seconds: float | None = None,
 ) -> TaskContext:
     return TaskContext(
         app_name=app_name,
@@ -84,27 +96,30 @@ def _task_context(
         run_id="run-1",
         heartbeat_timeout_seconds=60 if heartbeating else None,
         auto_heartbeat_seconds=10 if heartbeating else None,
+        progress_watchdog=progress_watchdog,
+        max_no_progress_seconds=max_no_progress_seconds,
     )
 
 
 def _enforcing_watchdog(
     *, budget_seconds: float = 0.05, tick_seconds: float = 0.01
 ) -> Callable[..., Awaitable[None]]:
-    """The real auto-heartbeat loop, with the config FND-296 will supply.
+    """The real auto-heartbeat loop, sped up and pinned to ``enforce``.
 
     Everything under test stays real — the tick, the gap arithmetic, the
-    ``on_stall`` call, the loop returning immediately after enforcing. Only
-    ``watchdog_mode`` and ``max_no_progress_seconds`` are injected, since
-    ``activities.py`` has nothing to read them from yet.
+    ``on_stall`` call, the loop returning immediately after enforcing. The three
+    values ``activities.py`` supplies are *overridden* rather than added: since
+    FND-296 it does pass a mode and a budget, and a test that waited for the
+    fleet default (``warn``, 900s) would neither enforce nor finish this decade.
+    That the real wiring passes the resolved pair at all is asserted separately,
+    in :meth:`TestWatchdogWiring.test_the_activity_supplies_the_resolved_config`.
     """
 
     async def loop(**kwargs: Any) -> None:
         kwargs["interval_seconds"] = tick_seconds
-        await _real_auto_heartbeat_loop(
-            **kwargs,
-            max_no_progress_seconds=budget_seconds,
-            watchdog_mode=ProgressWatchdogMode.ENFORCE,
-        )
+        kwargs["max_no_progress_seconds"] = budget_seconds
+        kwargs["watchdog_mode"] = ProgressWatchdogMode.ENFORCE
+        await _real_auto_heartbeat_loop(**kwargs)
 
     return loop
 
@@ -441,35 +456,109 @@ class TestWatchdogWiring:
         assert seen["progress"] is from_body[0]
         assert callable(seen["on_stall"])
 
-    async def test_the_watchdog_config_is_left_to_the_flag(self) -> None:
-        """No mode and no budget, so the watchdog is inert on this branch.
+    async def test_the_activity_supplies_the_resolved_config(self) -> None:
+        """A task that declares nothing still arrives at the loop in warn mode.
 
-        This is what makes the claim "zero behaviour change" checkable rather
-        than argued: the handler is injected, and turning the watchdog on is a
-        config change (FND-296), not another seam.
+        The whole of FND-296 in one assertion: no opt-in, no per-app step, and
+        the mode reaching the watchdog is the fleet default rather than ``OFF``.
+        The budget comes with it, since a mode with no allowance is inert.
         """
         seen: dict[str, Any] = {}
 
-        class _InertApp(App):
-            @task(timeout_seconds=600)
-            async def inert(self, input: _StallIn) -> _StallOut:
+        class _InheritingApp(App):
+            @task
+            async def inherits(self, input: _StallIn) -> _StallOut:
                 return _StallOut(msg="ok")
 
             async def run(self, input: _StallIn) -> _StallOut:
-                return await self.inert(input)
+                return await self.inherits(input)
 
         async def loop(*, stop_event: asyncio.Event, **kwargs: Any) -> None:
             seen.update(kwargs)
             await stop_event.wait()
 
-        _InertApp()
-        activity_fn = _activity_for("_inert-app", "inert")
+        _InheritingApp()
+        activity_fn = _activity_for("_inheriting-app", "inherits")
 
         with mock.patch(_HEARTBEAT_LOOP, new=loop):
-            await activity_fn(_task_context("_inert-app", "inert"), _StallIn())
+            await activity_fn(_task_context("_inheriting-app", "inherits"), _StallIn())
 
-        assert "watchdog_mode" not in seen
-        assert "max_no_progress_seconds" not in seen
+        assert seen["watchdog_mode"] is ProgressWatchdogMode.WARN
+        assert seen["max_no_progress_seconds"] == MAX_NO_PROGRESS_SECONDS
+
+    async def test_a_declaration_on_the_wire_reaches_the_loop(self) -> None:
+        """What an app flips in rollout step 6, arriving from the dispatch side."""
+        seen: dict[str, Any] = {}
+
+        class _EnforcingApp(App):
+            @task(progress_watchdog="enforce", max_no_progress_seconds=42)
+            async def strict(self, input: _StallIn) -> _StallOut:
+                return _StallOut(msg="ok")
+
+            async def run(self, input: _StallIn) -> _StallOut:
+                return await self.strict(input)
+
+        async def loop(*, stop_event: asyncio.Event, **kwargs: Any) -> None:
+            seen.update(kwargs)
+            await stop_event.wait()
+
+        _EnforcingApp()
+        activity_fn = _activity_for("_enforcing-app", "strict")
+
+        with mock.patch(_HEARTBEAT_LOOP, new=loop):
+            await activity_fn(
+                _task_context(
+                    "_enforcing-app",
+                    "strict",
+                    progress_watchdog=ProgressWatchdogMode.ENFORCE,
+                    max_no_progress_seconds=42.0,
+                ),
+                _StallIn(),
+            )
+
+        assert seen["watchdog_mode"] is ProgressWatchdogMode.ENFORCE
+        assert seen["max_no_progress_seconds"] == 42.0
+
+    async def test_the_kill_switch_is_read_on_the_worker(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``off`` in the activity worker's environment beats a per-task ``enforce``.
+
+        Resolution happens here rather than on the workflow side precisely so an
+        operator can throw the switch without every in-flight run needing to be
+        re-dispatched to notice.
+        """
+        seen: dict[str, Any] = {}
+
+        class _PinnedApp(App):
+            @task(progress_watchdog="enforce")
+            async def pinned(self, input: _StallIn) -> _StallOut:
+                return _StallOut(msg="ok")
+
+            async def run(self, input: _StallIn) -> _StallOut:
+                return await self.pinned(input)
+
+        async def loop(*, stop_event: asyncio.Event, **kwargs: Any) -> None:
+            seen.update(kwargs)
+            await stop_event.wait()
+
+        _PinnedApp()
+        activity_fn = _activity_for("_pinned-app", "pinned")
+        monkeypatch.setattr(
+            progress_module, "PROGRESS_WATCHDOG_MODE", ProgressWatchdogMode.OFF
+        )
+
+        with mock.patch(_HEARTBEAT_LOOP, new=loop):
+            await activity_fn(
+                _task_context(
+                    "_pinned-app",
+                    "pinned",
+                    progress_watchdog=ProgressWatchdogMode.ENFORCE,
+                ),
+                _StallIn(),
+            )
+
+        assert seen["watchdog_mode"] is ProgressWatchdogMode.OFF
 
     async def test_no_heartbeat_loop_means_no_watchdog(self) -> None:
         """A task with heartbeating disabled runs no loop, so nothing can stall it.
@@ -500,3 +589,121 @@ class TestWatchdogWiring:
 
         assert result.msg == "ok"
         assert loop_calls == []
+
+
+class TestDeclarationReachesTheWire:
+    """The dispatch half: a ``@task`` declaration has to survive the trip.
+
+    ``TaskMetadata`` → ``_create_task_activity_wrapper`` → ``TaskContext`` →
+    (Temporal) → the activity. The activity end is covered above; this is
+    everything before it.
+    """
+
+    async def _dispatched_context(
+        self,
+        *,
+        progress_watchdog: ProgressWatchdogMode | None = None,
+        max_no_progress_seconds: float | None = None,
+    ) -> TaskContext:
+        from application_sdk.app.base import (  # noqa: PLC0415 — private dispatch seam, imported where it is used
+            _create_task_activity_wrapper,
+        )
+
+        with mock.patch(
+            "application_sdk.execution._temporal.eviction_retry."
+            "execute_activity_with_eviction_retry",
+            new_callable=mock.AsyncMock,
+        ) as dispatched:
+            dispatched.return_value = mock.MagicMock()
+            wrapper = _create_task_activity_wrapper(
+                app_name="_dispatch-app",
+                task_name="extract",
+                timeout_seconds=600,
+                retry_max_attempts=3,
+                retry_max_interval_seconds=30,
+                output_type=_StallOut,
+                context_data={"run_id": "r1"},
+                progress_watchdog=progress_watchdog,
+                max_no_progress_seconds=max_no_progress_seconds,
+            )
+            await wrapper(mock.MagicMock())
+
+        return cast("TaskContext", dispatched.call_args.kwargs["args"][0])
+
+    async def test_a_task_that_declares_nothing_sends_nothing(self) -> None:
+        """``None`` on the wire, not a resolved ``warn``.
+
+        The distinction is the kill-switch: a resolved mode baked in at dispatch
+        would make an operator's ``off`` on the worker a no-op for every run
+        already in flight.
+        """
+        context = await self._dispatched_context()
+
+        assert context.progress_watchdog is None
+        assert context.max_no_progress_seconds is None
+
+    async def test_a_declaration_is_carried_verbatim(self) -> None:
+        context = await self._dispatched_context(
+            progress_watchdog=ProgressWatchdogMode.ENFORCE,
+            max_no_progress_seconds=42.0,
+        )
+
+        assert context.progress_watchdog is ProgressWatchdogMode.ENFORCE
+        assert context.max_no_progress_seconds == 42.0
+
+    async def test_the_declaration_survives_the_converter(self) -> None:
+        """Pinned against the real converter, not assumed.
+
+        A ``StrEnum`` on an activity argument is a new shape for ``TaskContext``,
+        and every dispatch would fail on decode if it did not round-trip.
+        """
+        from application_sdk.execution._temporal.converter import (  # noqa: PLC0415 — cold path, imported where it is used
+            create_data_converter,
+        )
+
+        converter = create_data_converter()
+        context = TaskContext(
+            app_name="a",
+            task_name="t",
+            run_id="r",
+            progress_watchdog=ProgressWatchdogMode.ENFORCE,
+            max_no_progress_seconds=42.0,
+        )
+
+        payloads = await converter.encode([context])
+        decoded = await converter.decode(payloads, [TaskContext])
+
+        assert decoded[0].progress_watchdog is ProgressWatchdogMode.ENFORCE
+        assert decoded[0].max_no_progress_seconds == 42.0
+
+    async def test_a_dispatch_from_before_these_fields_lands_on_the_default(
+        self,
+    ) -> None:
+        """A run in flight across the upgrade decodes to "declares nothing".
+
+        Which is the whole reason the wire carries the declaration rather than
+        the resolved mode: that run starts producing warn-mode telemetry as soon
+        as the *worker* is upgraded, with no re-dispatch.
+        """
+        from application_sdk.execution._temporal.converter import (  # noqa: PLC0415 — cold path, imported where it is used
+            create_data_converter,
+        )
+
+        @dataclasses.dataclass
+        class _OldTaskContext:
+            """``TaskContext`` as a worker from before FND-296 built it."""
+
+            app_name: str
+            task_name: str
+            run_id: str
+
+        converter = create_data_converter()
+        payloads = await converter.encode(
+            [_OldTaskContext(app_name="a", task_name="t", run_id="r")]
+        )
+        decoded = await converter.decode(payloads, [TaskContext])
+
+        assert decoded[0].progress_watchdog is None
+        assert resolve_watchdog_mode(decoded[0].progress_watchdog) is (
+            ProgressWatchdogMode.WARN
+        )

--- a/tests/unit/execution/test_watchdog_defaults.py
+++ b/tests/unit/execution/test_watchdog_defaults.py
@@ -1,0 +1,189 @@
+"""The fleet-wide watchdog settings, and how a task's declaration resolves against them.
+
+FND-296 ships the stall watchdog on by default in ``warn`` and raises
+``start_to_close`` to a 24h backstop in the same release (ADR-0018 → *Rollout*
+step 3). Both halves of that sentence are load-bearing and both are pinned here:
+
+- ``warn`` really is what an app that declares nothing gets, because an opt-in
+  would have bought nothing (warn cannot fail an activity) at the cost of a
+  ~20-team coordination step.
+- ``off`` really is a kill-switch — it beats a per-task ``enforce``, because the
+  only time it gets thrown is an incident, and a switch a decorator can out-vote
+  is no switch.
+- The allowance has *no* such override, deliberately: an env var that could
+  silently shrink an allowance a task declared for itself would be a fleet-wide
+  false-kill generator.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+
+from application_sdk._runtime.progress import DEFAULT_MAX_NO_PROGRESS_SECONDS
+from application_sdk.execution import progress as progress_mod
+from application_sdk.execution.progress import (
+    ProgressWatchdogMode,
+    _load_max_no_progress_seconds,
+    _load_watchdog_mode,
+    resolve_max_no_progress_seconds,
+    resolve_watchdog_mode,
+)
+
+
+class TestModeEnvVar:
+    def test_unset_means_warn(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The headline property of this release: nobody opts in."""
+        monkeypatch.delenv("ATLAN_PROGRESS_WATCHDOG", raising=False)
+
+        assert _load_watchdog_mode() is ProgressWatchdogMode.WARN
+
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ("off", ProgressWatchdogMode.OFF),
+            ("warn", ProgressWatchdogMode.WARN),
+            ("enforce", ProgressWatchdogMode.ENFORCE),
+            ("  ENFORCE  ", ProgressWatchdogMode.ENFORCE),
+        ],
+    )
+    def test_every_mode_is_settable(
+        self, monkeypatch: pytest.MonkeyPatch, raw: str, expected: ProgressWatchdogMode
+    ) -> None:
+        monkeypatch.setenv("ATLAN_PROGRESS_WATCHDOG", raw)
+
+        assert _load_watchdog_mode() is expected
+
+    def test_a_typo_falls_back_to_warn_instead_of_raising(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A bad value in one deployment manifest costs one config value, not a worker.
+
+        Raising here would stop the process booting, which is a far worse outcome
+        than reporting gaps nobody asked for.
+        """
+        monkeypatch.setenv("ATLAN_PROGRESS_WATCHDOG", "enfroce")
+
+        assert _load_watchdog_mode() is ProgressWatchdogMode.WARN
+
+    def test_the_import_time_constant_is_what_production_reads(self) -> None:
+        """The constant binds once at import, so that binding is the real surface.
+
+        Subprocess, for the reason the sibling run-length test gives: re-importing
+        the module in-process would mint a second ``ProgressWatchdogMode`` and
+        break ``is`` comparisons for every test that imported it by name.
+        """
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                "import os; "
+                "os.environ['ATLAN_PROGRESS_WATCHDOG'] = 'off'; "
+                "from application_sdk.execution import progress as m; "
+                "assert m.PROGRESS_WATCHDOG_MODE is m.ProgressWatchdogMode.OFF, "
+                "f'constant bound {m.PROGRESS_WATCHDOG_MODE}, not the env var'",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stderr
+
+
+class TestAllowanceEnvVar:
+    def test_unset_means_the_adr_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("ATLAN_MAX_NO_PROGRESS_SECONDS", raising=False)
+
+        assert _load_max_no_progress_seconds() == DEFAULT_MAX_NO_PROGRESS_SECONDS == 900
+
+    def test_a_positive_value_is_taken(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ATLAN_MAX_NO_PROGRESS_SECONDS", "1800")
+
+        assert _load_max_no_progress_seconds() == 1800.0
+
+    @pytest.mark.parametrize("raw", ["0", "-1", "fifteen minutes"])
+    def test_an_unusable_value_falls_back_rather_than_disabling(
+        self, monkeypatch: pytest.MonkeyPatch, raw: str
+    ) -> None:
+        """Zero would stall every attempt on its first tick.
+
+        In an enforcing app that turns one typo into a fleet-wide kill switch, so
+        the allowance never resolves to something the watchdog would act on
+        immediately. Turning the watchdog off is what ``off`` is for.
+        """
+        monkeypatch.setenv("ATLAN_MAX_NO_PROGRESS_SECONDS", raw)
+
+        assert _load_max_no_progress_seconds() == DEFAULT_MAX_NO_PROGRESS_SECONDS
+
+
+class TestResolveMode:
+    def test_no_declaration_inherits_the_fleet_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            progress_mod, "PROGRESS_WATCHDOG_MODE", ProgressWatchdogMode.WARN
+        )
+
+        assert resolve_watchdog_mode(None) is ProgressWatchdogMode.WARN
+
+    def test_a_declaration_beats_the_fleet_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Rollout step 6: an app flips itself to enforce when it wants the guarantee."""
+        monkeypatch.setattr(
+            progress_mod, "PROGRESS_WATCHDOG_MODE", ProgressWatchdogMode.WARN
+        )
+
+        assert resolve_watchdog_mode(ProgressWatchdogMode.ENFORCE) is (
+            ProgressWatchdogMode.ENFORCE
+        )
+
+    def test_the_fleet_can_be_moved_without_touching_a_decorator(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            progress_mod, "PROGRESS_WATCHDOG_MODE", ProgressWatchdogMode.ENFORCE
+        )
+
+        assert resolve_watchdog_mode(None) is ProgressWatchdogMode.ENFORCE
+
+    @pytest.mark.parametrize(
+        "declared",
+        [None, ProgressWatchdogMode.WARN, ProgressWatchdogMode.ENFORCE],
+    )
+    def test_off_in_the_environment_beats_every_declaration(
+        self, monkeypatch: pytest.MonkeyPatch, declared: ProgressWatchdogMode | None
+    ) -> None:
+        """The kill-switch has to actually switch things off.
+
+        An operator reaches for it mid-incident; a task pinned to ``enforce`` in
+        source they may not own must not out-vote it.
+        """
+        monkeypatch.setattr(
+            progress_mod, "PROGRESS_WATCHDOG_MODE", ProgressWatchdogMode.OFF
+        )
+
+        assert resolve_watchdog_mode(declared) is ProgressWatchdogMode.OFF
+
+
+class TestResolveAllowance:
+    def test_no_declaration_inherits_the_fleet_allowance(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(progress_mod, "MAX_NO_PROGRESS_SECONDS", 1200.0)
+
+        assert resolve_max_no_progress_seconds(None) == 1200.0
+
+    @pytest.mark.parametrize("declared", [60.0, 7200.0])
+    def test_a_declared_allowance_always_wins(
+        self, monkeypatch: pytest.MonkeyPatch, declared: float
+    ) -> None:
+        """In both directions — there is no kill-switch analogue for the allowance.
+
+        An env var that could shrink a declared allowance would false-kill the
+        very sites whose authors had already sized them.
+        """
+        monkeypatch.setattr(progress_mod, "MAX_NO_PROGRESS_SECONDS", 900.0)
+
+        assert resolve_max_no_progress_seconds(declared) == declared

--- a/tests/unit/execution/test_watchdog_defaults.py
+++ b/tests/unit/execution/test_watchdog_defaults.py
@@ -139,6 +139,23 @@ class TestResolveMode:
             ProgressWatchdogMode.ENFORCE
         )
 
+    def test_a_declaration_beats_a_stronger_fleet_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The boundary that proves a declaration — not just ``None`` — wins.
+
+        Fleet ``enforce`` with a task pinned to ``warn`` resolves to ``warn``:
+        the matrix above pins a declaration beating a weaker fleet mode, and this
+        pins it beating a stronger one. Only ``off`` overrides a declaration.
+        """
+        monkeypatch.setattr(
+            progress_mod, "PROGRESS_WATCHDOG_MODE", ProgressWatchdogMode.ENFORCE
+        )
+
+        assert resolve_watchdog_mode(ProgressWatchdogMode.WARN) is (
+            ProgressWatchdogMode.WARN
+        )
+
     def test_the_fleet_can_be_moved_without_touching_a_decorator(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
Closes [FND-296](https://linear.app/atlan-epd/issue/FND-296/ship-warn-by-default-and-the-24h-backstop-in-one-release). ADR-0018 → *Rollout* step 3 — the release that delivers the actual relief.

## What changes

The stall watchdog now runs fleet-wide in `warn`, and `start_to_close` defaults to a **24h backstop** (86400s) instead of 600s. Both halves ship together on purpose: coupling the backstop to `enforce` would mean warn mode delivers no relief at all — apps would keep dying at guessed ceilings while the fleet gathers the data that sizes the allowance, so "no upgrade task" would buy nobody anything.

`@task` / `TaskMetadata` gain two settings, both defaulting to `None`:

| Setting | `None` means | Env var | Default |
|---|---|---|---|
| `progress_watchdog` | inherit the fleet mode | `ATLAN_PROGRESS_WATCHDOG` | `warn` |
| `max_no_progress_seconds` | inherit the fleet allowance | `ATLAN_MAX_NO_PROGRESS_SECONDS` | `900` |

```python
@task                                     # warn, 900s, 24h backstop — no opt-in
async def extract(self, i: In) -> Out: ...

@task(progress_watchdog="enforce")        # rollout step 6, per app, per task
async def transform(self, i: In) -> Out: ...
```

## The one design decision worth reviewing

**The wire carries the *declaration*, not a resolved mode.** `TaskContext.progress_watchdog` is `None` for the overwhelming majority of tasks, and the activity resolves it against its own environment. Three things follow, and none of them work if resolution happens at dispatch:

- **`off` is a real kill-switch.** An operator sets it on the worker, it takes effect on the next attempt without re-dispatching in-flight runs, and it beats a per-task `enforce`. A switch a decorator can out-vote is no use to the person holding it mid-incident — which is the only time it gets thrown.
- **A pre-upgrade dispatch lands on the fleet default.** A run in flight across the upgrade decodes the missing field to `None`, so a *worker* upgrade alone starts producing that app's work-list. Pinned against the real converter.
- **The allowance gets no such override.** An env var that could silently shrink an allowance a task declared for itself would be a fleet-wide false-kill generator. `off` is what turns the watchdog off.

## Layering note

`app/` cannot import `execution/` at module scope (`execution/__init__` → `_temporal` → `app.registry` → `app.base` → `app.task`; verified — it deadlocks the first import of the SDK). So `app/task.py` reaches `ProgressWatchdogMode` only inside the validation path an *explicit* declaration triggers, and the fleet defaults live in `execution/progress.py`. This keeps the enum exactly where [ADR-0019](https://github.com/atlanhq/application-sdk/blob/main/docs/adr/0019-runtime-substrate-layer.md) put it. Both points are recorded in ADR-0018's rollout section.

## The regression this accepts, stated

While an app is in `warn`, wedge containment is the `AtlanAppTaskStalled` alert plus a human rather than the small ceiling that used to kill a wedge by accident. **Detection improves** — a wedge is now visible one budget in, where before it was only ever killed by luck, never diagnosed. Exposure scales with the wedge rate, which is the exact unknown this release starts measuring. The alert (FND-293) is why that trade is takeable at all.

## Upgrade impact

Nothing fails differently. `heartbeat_timeout_seconds` keeps its meaning and its 60s default, no knob changes meaning, and the added cost is telemetry. The one thing that changes in an app's favour is immediate: a legitimately long attempt stops dying at a guessed ceiling. Apps that pass `timeout_seconds=` explicitly are unaffected — deleting those guesses is an optimisation they schedule for themselves.

## Verification

- Full unit suite: **7087 passed**, 9 skipped.
- Conformance gate: **0 blocking violations** (228 warnings, all pre-existing).
- Pre-commit (ruff, ruff-format, isort, pyright): clean.
- New: `tests/unit/execution/test_watchdog_defaults.py` (env parsing, both resolvers, the `off` precedence rule, the import-time binding in a subprocess); `TestWatchdogWiring` / `TestDeclarationReachesTheWire` in `test_stall_failure.py` (a declaring-nothing task arrives in `warn`; a declaration survives `TaskMetadata` → wrapper → `TaskContext` → converter; a pre-FND-296 payload decodes to `None`); `TestTaskDurationBackstop` / `TestTaskProgressWatchdog` in `test_task.py`.
- `test_stall_failure.py`'s `_enforcing_watchdog` now *overrides* rather than adds the loop's mode/budget kwargs — the activity supplies them since this change, and the previous helper would have silently killed the watchdog task with a duplicate-kwarg `TypeError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
