### PR TITLE
ci: raise the unit-test job timeout to 15 minutes (FND-346)

### DIFF
--- a/.github/workflows/sdk-tests-reusable.yaml
+++ b/.github/workflows/sdk-tests-reusable.yaml
@@ -23,7 +23,14 @@ jobs:
   unit:
     name: Unit Tests
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 10
+    # 15, matching the integration jobs below. Measured over 92 Windows unit
+    # legs, they run p50 447s / p90 527s against what was a 600s cap — a p90 at
+    # 88% of the ceiling, so an ordinarily-slow runner crosses it. Two legs were
+    # killed mid-suite that way; the job reports `cancelled`, not `failure`,
+    # which reads as CI noise rather than as a timeout. In the merge queue that
+    # ejects the PR. Linux and macOS sit near 350s and have never been close.
+    # This is headroom, not a fix — why Windows is slower is FND-346.
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Problem

`SDK Tests / Unit Tests (*, windows-latest)` carried `timeout-minutes: 10`. Measured across 92 Windows unit legs from the last ~23 SDK Gate runs:

| OS | p50 | p90 | max | cap |
| --- | --- | --- | --- | --- |
| windows-latest | 447s | **527s (88% of cap)** | 624s | 600s |
| macOS-latest | 296s | 369s | 416s | 600s |
| ubuntu-22.04 | 321s | 347s | 368s | 600s |

17 of those 92 legs finished above 500s, and two were killed at the cap. In the run that prompted this, the suite was still passing tests one second before the kill — not a hang, just out of budget.

The failure mode is easy to misread: a job that exceeds `timeout-minutes` reports `cancelled`, not `failure`, so it looks like ordinary CI noise. On `merge_group` runs it fails the gate and ejects the PR from the merge queue.

## Change

`timeout-minutes: 10` → `15` on the unit job.

15 rather than a per-OS expression: the integration and storage-emulator jobs in the same file already use 15, and a uniform cap avoids a matrix-conditional nothing else in the file needs. That is 900s against a worst observed leg of 624s — ~44% headroom, against roughly none today.

## What this does not do

This is headroom, not a fix. Investigation of why the Windows legs are slower continues in FND-346; two findings so far:

- fsync costs 7.85ms on Windows against 0.42ms on Linux (`FlushFileBuffers` flushes the device cache), which makes the per-chunk resume checkpoint in `download_file_chunked` disproportionately expensive there.
- The `--capture=no --log-cli-level=INFO -v --full-trace` flags in `.github/actions/unit-tests` cost ~34s on Windows and ~0s on Linux for a single 144-test file. A full-suite A/B is measuring whether that scales.

Neither belongs in this PR — both need their own measurement and review.
