### PR TITLE
feat(conformance): add granular 0-touch levers under --enforce (FND-347)

### DIFF
--- a/.github/workflows/tests-reusable.yaml
+++ b/.github/workflows/tests-reusable.yaml
@@ -52,12 +52,18 @@ name: tests-reusable
 #   A caller-supplied `test-paths` scopes the INTEGRATION job only; the unit job
 #   always runs tests/unit/.
 #
-# GitHub check name hierarchy (caller → tests-reusable):
+# GitHub check name hierarchy as the UI displays it (caller → tests-reusable):
 #   Tests / tests / Unit         (every event)
 #   Tests / tests / Integration  (merge queue if the base branch has one, else
 #                                 on the PR; skipped when there is no suite)
 #   Tests / tests / End-to-end   (label / dispatch)
 #   Tests / tests / Tests Gate   (aggregator — the required check)
+#
+# Branch protection does NOT use those display strings. A ruleset's
+# required_status_checks `context` is the check-run name, which omits the
+# workflow name: require `tests / Tests Gate` — the caller's job id, then this
+# job's name. (Verified against atlan-mysql-app's live `main` ruleset, which
+# also carries `suite / Conformance Gate`; an inline job is a single segment.)
 #
 # Nested reusable depth: caller → tests-reusable = 2 (GitHub max is 4).
 # secrets: inherit chains from the caller; the inlined e2e job reads secrets.*.

--- a/docs/standards/connector-ci-e2e.md
+++ b/docs/standards/connector-ci-e2e.md
@@ -524,6 +524,45 @@ Single-pipeline apps invoking the action remotely (`@main`) never hit this code 
 4. **Tests**: unit + integration tests under `tests/unit/` and `tests/integration/`; full-DAG e2e under `tests/e2e/` (`SQLAppE2EFullTest` subclass).
 5. **Repo secrets**: set the 7 entries from the table above.
 6. **SDK matrix**: add `<connector>-app` to the `DEFAULT_MATRIX` in apps-sdk's `matrix-builder` job (`pull_request.yaml`) so `connector-tests` fans out to your connector automatically.
+7. **Required check**: make `tests / Tests Gate` a required, unbypassable status check on the default branch, and remove any stale required checks left over from older workflows (`unit-tests`, `tests-passed`, …). Do this as soon as step 2 is merged — see below.
+
+### The tests gate does not wait on the coverage bar
+
+The exact `required_status_checks` context is **`tests / Tests Gate`** — the
+caller's job **id** (`tests:` in the scaffolded `tests.yaml`), then the gate
+job's name. The workflow name is not part of it, even though the UI's checks
+list displays it as a leading segment; verified against the live `main` rulesets
+on `atlanhq/atlan-mysql-app` (`tests / Tests Gate`, `suite / Conformance Gate`)
+and `atlanhq/application-sdk` (inline jobs are a single segment, e.g. `SDK
+Gate`). A context that matches no check protects nothing, so get this string
+right before rolling it out.
+
+Making it required is its **own** lever, with no prerequisite
+beyond the check running something real. It is **not** gated on the four-tier
+test bar, the 85% coverage target, or every tier being wired up — pytest already
+exits non-zero when it collects nothing, so a vacuous pass is not possible, and
+the gate's verdict comes from a tested driver
+([`verify-test-gate`](../../.github/actions/verify-test-gate/action.yaml)) rather
+than from a job's own exit status. Turn it on with a thin suite and grow the
+suite behind it; a suite nothing enforces has no authority and degrades under
+pressure.
+
+The bar belongs to the *other* lever — **0-touch**, meaning conformance findings
+block CI and Renovate merges its own PRs without a human. That is what
+`atlan-application-sdk-conformance bootstrap --enforce true` sets, and it is the
+one an app graduates to once its tests are meaningful. The two halves of 0-touch
+are separately expressible too, for a repo that wants one without the other:
+
+| Lever | Flag | Prerequisite |
+|---|---|---|
+| `tests / Tests Gate` is a required check | none — a GitHub branch-protection setting; no bootstrap flag governs it | none |
+| Conformance findings block CI | `--conformance-blocking true\|false` | meaningful automated tests (four-tier bar) |
+| Renovate merges without a human | `--renovate-automerge true\|false` | meaningful automated tests (four-tier bar) |
+| Both of the above at once | `--enforce true\|false` (shorthand) | as above |
+
+Coverage stays warn-only at the publish-time certification gate as well — see
+[`app-certification.md`](app-certification.md#enforcement), where unit-test
+pass/fail already blocks publish while the 85% threshold only annotates.
 
 ## Reference
 

--- a/packages/conformance/conformance/bootstrap/args.py
+++ b/packages/conformance/conformance/bootstrap/args.py
@@ -20,7 +20,22 @@ FLAGS = {
     "--services-script": "services_script",
     "--system-deps": "system_deps",
     "--enforce": "enforce",
+    "--conformance-blocking": "conformance_blocking",
+    "--renovate-automerge": "renovate_automerge",
 }
+
+# Tri-state flags: "" means "not explicitly set on this invocation" (defer to
+# autodetection, then to the shorthand, then to the hard default), and only
+# "true"/"false" are otherwise accepted. Validated together so a new one can't
+# be added to FLAGS with its validation quietly forgotten.
+#
+# ``--enforce`` is the shorthand; the other two are the individual 0-touch
+# levers it expands to. Neither of them, and not ``--enforce`` either, has any
+# bearing on whether ``tests / Tests Gate`` is a required branch-protection
+# check — that is a separate lever with no prerequisite here (FND-347).
+TRISTATE_FLAGS = ("enforce", "conformance_blocking", "renovate_automerge")
+
+_DEST_TO_FLAG = {dest: flag for flag, dest in FLAGS.items()}
 
 
 def parse_bootstrap_args(argv: list[str]) -> dict[str, str]:
@@ -38,7 +53,10 @@ def parse_bootstrap_args(argv: list[str]) -> dict[str, str]:
         "enable_e2e": "true",
         "services_script": "",
         "system_deps": "",
-        "enforce": "",  # "" = not explicitly set; "true"/"false" = explicit
+        # "" = not explicitly set; "true"/"false" = explicit. See TRISTATE_FLAGS.
+        "enforce": "",
+        "conformance_blocking": "",
+        "renovate_automerge": "",
     }
     i = 0
     while i < len(argv):
@@ -69,12 +87,14 @@ def parse_bootstrap_args(argv: list[str]) -> dict[str, str]:
         )
         sys.exit(2)
 
-    if result["enforce"] not in ("", "true", "false"):
-        print(
-            f"error: --enforce must be 'true' or 'false', got {result['enforce']!r}",
-            file=sys.stderr,
-        )
-        sys.exit(2)
+    for dest in TRISTATE_FLAGS:
+        if result[dest] not in ("", "true", "false"):
+            flag = _DEST_TO_FLAG[dest]
+            print(
+                f"error: {flag} must be 'true' or 'false', got {result[dest]!r}",
+                file=sys.stderr,
+            )
+            sys.exit(2)
 
     result["system_deps"] = normalize_system_deps(result["system_deps"])
 
@@ -115,7 +135,17 @@ Write .claude/skills/remediate/SKILL.md + all standard CI workflow shims into
 and .github/scripts/build_conformance_args.py that conformance-reusable.yaml needs on
 disk in every caller repo. All of these always overwrite (re-running eradicates drift).
 tests.yaml, renovate.json, and contract_schema.lock.json are write-if-absent by default;
-pass --enforce true|false to also update renovate.json's enforcement mode.
+pass --enforce true|false (or --renovate-automerge true|false) to also update
+renovate.json's enforcement mode.
+
+The tests gate is not one of these levers. `tests / Tests Gate` becoming a required,
+unbypassable status check on the default branch is a GitHub branch-protection setting
+that nothing here writes, and it has no prerequisite beyond the check running something
+real: it does NOT wait on the four-tier bar or the 85% coverage target, and no flag
+below turns it on or off. Make it required as soon as tests.yaml is wired (the
+scaffolded tests.yaml names the exact context string in its header). What the flags
+below govern is 0-touch — conformance blocking CI, and Renovate merging without a
+human — which is what the four-tier bar is a prerequisite for.
 
 options:
   --package-name NAME         docstring-coverage package; omit to auto-detect from an
@@ -138,13 +168,24 @@ options:
                               preserves both instead of deleting the step — checks.yml
                               is always-overwrite. To drop it, delete the step from
                               checks.yml and the txt file, then re-run.
-  --enforce true|false        enforcement mode; omit to auto-detect from an existing
+  --enforce true|false        0-touch shorthand: sets BOTH granular levers below at
+                              once. Omit to auto-detect from an existing
                               conformance.yaml (else hard-gate). Pass explicitly (either
                               value) to also force-update renovate.json.
                               true  — hard gate: conformance blocks on violations,
                                       Renovate auto-merges when CI is green.
                               false — soft/observe: conformance tracks without blocking,
                                       Renovate raises PRs but humans must merge.
+  --conformance-blocking true|false
+                              whether conformance findings block CI (conformance.yaml's
+                              exit-zero). Overrides --enforce for this lever alone;
+                              omit to take the --enforce value (explicit or detected).
+  --renovate-automerge true|false
+                              whether Renovate merges its own PRs on green
+                              (renovate.json). Overrides --enforce for this lever
+                              alone; omit to take the --enforce value (explicit or
+                              detected). Passing it explicitly force-updates
+                              renovate.json, exactly as --enforce does.
   --json                       after the normal output, print one final JSON line:
                               {"skipped": bool, "touched": [...], "unchanged": [...]}.
                               `touched` lists every path this invocation actually wrote

--- a/packages/conformance/conformance/bootstrap/command.py
+++ b/packages/conformance/conformance/bootstrap/command.py
@@ -117,7 +117,8 @@ def _sync_renovate_json(
     root: pathlib.Path, kwargs: dict[str, str], force_renovate: bool
 ) -> list[tuple[pathlib.Path, str]]:
     """renovate.json — write-if-absent normally; force-overwrite when
-    ``--enforce`` is passed explicitly so re-running with ``--enforce true``
+    ``--enforce`` or ``--renovate-automerge`` is passed explicitly so
+    re-running with ``--enforce true`` (or ``--renovate-automerge true``)
     upgrades a soft-mode repo without needing to delete the file first.
 
     Returns the ``(path, status)`` pairs this call wrote or left alone —
@@ -149,7 +150,8 @@ def _sync_renovate_json(
         return results
     print(
         f"ok (exists): {renovate_dest}"
-        "  (edit freely; pass --enforce to update enforcement mode)"
+        "  (edit freely; pass --enforce or --renovate-automerge to update"
+        " enforcement mode)"
     )
     return [(renovate_dest, "exists")]
 
@@ -254,21 +256,37 @@ def main(argv: list[str]) -> int:
             print(json.dumps({"skipped": True, "touched": [], "unchanged": []}))
         return 0
 
-    # force_renovate must reflect only an *explicit* --enforce on this
-    # invocation, captured before autodetection fills kwargs["enforce"] in
-    # from an existing conformance.yaml -- renovate.json stays write-if-absent
-    # on a bare re-run even though conformance.yaml's enforcement mode is now
-    # auto-detected.
-    force_renovate = bool(kwargs["enforce"])
+    # force_renovate must reflect only an *explicit* flag on this invocation,
+    # captured before autodetection fills kwargs["enforce"] in from an existing
+    # conformance.yaml -- renovate.json stays write-if-absent on a bare re-run
+    # even though conformance.yaml's enforcement mode is now auto-detected.
+    # --renovate-automerge counts too: it is the lever that governs exactly
+    # this file, so passing it and having the file left alone would be a no-op
+    # flag.
+    force_renovate = bool(kwargs["enforce"] or kwargs["renovate_automerge"])
     apply_bootstrap_autodetection(kwargs, root)
 
-    # Derive the two render variables from --enforce (explicit or detected).
+    # Resolve the two 0-touch levers, each independently expressible:
+    #
+    #   --conformance-blocking → exit_zero  (conformance.yaml)
+    #   --renovate-automerge   → automerge  (renovate.json)
+    #
+    # --enforce is the shorthand that sets both at once, so an explicit
+    # granular flag wins over it and an omitted one inherits it. enforce
+    # itself is explicit-or-detected here (autodetection ran above);
     # enforce="" (never set, nothing to detect) → hard defaults.
-    # enforce="false" → soft/observe mode.
-    # enforce="true"  → hard mode.
+    #
+    # Neither lever, and not --enforce either, touches the tests gate: whether
+    # `tests / Tests Gate` is a required, unbypassable check is a GitHub
+    # branch-protection setting with no prerequisite here, deliberately kept
+    # out of this derivation so the gate never waits on the 0-touch bar
+    # (FND-347).
     enforce = kwargs.pop("enforce")
-    kwargs["exit_zero"] = "true" if enforce == "false" else "false"
-    kwargs["automerge"] = "false" if enforce == "false" else "true"
+    shorthand = "false" if enforce == "false" else "true"
+    conformance_blocking = kwargs.pop("conformance_blocking") or shorthand
+    renovate_automerge = kwargs.pop("renovate_automerge") or shorthand
+    kwargs["exit_zero"] = "false" if conformance_blocking == "true" else "true"
+    kwargs["automerge"] = renovate_automerge
 
     # Structured record of every path this invocation touched or left
     # unchanged, for --json below. Populated alongside (never instead of) the

--- a/packages/conformance/conformance/bootstrap/templates/release-gate.yaml
+++ b/packages/conformance/conformance/bootstrap/templates/release-gate.yaml
@@ -7,10 +7,21 @@ name: Release Gate
 # All other PRs pass this check immediately — it exists solely to gate the
 # auto-created bump-version PRs without requiring `e2e` on every PR.
 #
-# Branch-protection targets: "Release Gate / Release Gate"
-# Add this alongside "Tests / Tests Gate" in branch protection so that:
+# Branch-protection target: "Release Gate"
+# Add this alongside "tests / Tests Gate" in branch protection so that:
 # (a) this check blocks release PRs missing the label, and (b) the
 # Tests Gate check enforces that unit, integration, and e2e tests all pass.
+#
+# Those two strings are shaped differently because a ruleset's
+# required_status_checks `context` is the check-run name, which never includes
+# the workflow name:
+#   * an inline job  → just the job's `name:`               ("Release Gate")
+#   * a job that `uses:` a reusable → "<caller job id> / <called job name>"
+#     ("tests / Tests Gate" — `tests:` is the job in tests.yaml that calls
+#     tests-reusable.yaml, whose gate job is named "Tests Gate")
+# The UI's checks list shows the workflow name as an extra leading segment;
+# that display form is not what the API matches on, and a context that matches
+# no check silently protects nothing.
 
 on:
   pull_request:
@@ -46,4 +57,4 @@ jobs:
           fi
 
           echo "Release PR has both 'release' and 'e2e' labels — gate passes."
-          echo "Test pass/fail is enforced separately by 'Tests / Tests Gate'."
+          echo "Test pass/fail is enforced separately by 'tests / Tests Gate'."

--- a/packages/conformance/conformance/bootstrap/templates/tests.yaml
+++ b/packages/conformance/conformance/bootstrap/templates/tests.yaml
@@ -16,6 +16,14 @@ name: Tests
 #                 Triggered by the 'e2e' PR label or workflow_dispatch.
 #   Tests Gate  — aggregator gate; the single required check for branch
 #                 protection.  tests must pass; e2e can be skipped.
+#                 Make it required as soon as this file is merged — it does not
+#                 wait on a coverage target or on every tier being wired up.
+#                 The exact context string to require is:
+#                   tests / Tests Gate
+#                 i.e. the `tests:` job below (which calls the reusable), then
+#                 the gate's own job name. The workflow name is NOT part of it,
+#                 even though the UI's checks list displays it. Rename the
+#                 `tests:` job and the context changes with it.
 
 on:
   push:

--- a/packages/conformance/conformance/programs/areas/ci.prose.md
+++ b/packages/conformance/conformance/programs/areas/ci.prose.md
@@ -93,7 +93,9 @@ it isn't safe to assume a C002 finding already triggered it:
    `--unit-tests-workflow` from an existing `build-and-publish.yaml` (else
    `"tests.yaml"`), `--services-script` from an existing
    `.github/test/setup-services.sh`, and `--enforce` from an existing
-   `conformance.yaml`'s `exit-zero` mode (else hard-gate). No extraction step
+   `conformance.yaml`'s `exit-zero` mode (else hard-gate) — which the two
+   granular 0-touch levers (`--conformance-blocking`, `--renovate-automerge`)
+   then inherit, since neither was named on this invocation. No extraction step
    is needed here; re-running with no flags never resets a customized value
    to a default. `--json` doesn't change any of that — it only appends one
    trailing JSON line to stdout, after the normal human-readable output.
@@ -142,8 +144,9 @@ it isn't safe to assume a C002 finding already triggered it:
   whether the drift is stale structure (safe to delete + regenerate) or an
   intentional customization worth preserving as-is.
 - **`renovate.json` drift** (file exists but content diverged) — fixing it
-  requires choosing the intended enforcement mode (`--enforce true|false`),
-  a repo-policy decision the model must not make unilaterally.
+  requires choosing the intended enforcement mode (`--enforce true|false`, or
+  `--renovate-automerge true|false` to move this file's lever alone), a
+  repo-policy decision the model must not make unilaterally.
   `classification = "judgment"`.
 
 ---

--- a/packages/conformance/conformance/programs/areas/ci.prose.md
+++ b/packages/conformance/conformance/programs/areas/ci.prose.md
@@ -110,8 +110,8 @@ it isn't safe to assume a C002 finding already triggered it:
    CLI's own code decides each entry, not the model reading prefixed prose
    lines) and how it drives `detect-fix-recheck`'s revert scope if this fix
    is later rejected by a gate. This no-flags procedure never produces a
-   `renovate.json.bak` entry itself (that only happens when `--enforce` is
-   passed explicitly), but capture it if present in `touched` rather than
+   `renovate.json.bak` entry itself (that only happens when `--enforce` or
+   `--renovate-automerge` is passed explicitly), but capture it if present in `touched` rather than
    assuming a fixed set of paths is exhaustive here too. `orthogonal_gate =
    "skip"` on both C002 and C003 (set on the rule definitions) — the Python
    test suite is skipped entirely, not just for this fix: a

--- a/packages/conformance/conformance/programs/functions/remediate-finding.prose.md
+++ b/packages/conformance/conformance/programs/functions/remediate-finding.prose.md
@@ -92,11 +92,12 @@ a structured value the model reads rather than one it has to parse. It is
 what lets `detect-fix-recheck` revert the *entire* fix, not just
 `finding.file`, if the gates below reject it. A path in the JSON line's
 `unchanged` array was left alone and is not part of `touched_files`. (The
-`backed up:` write only happens if a prior invocation passed `--enforce`
-explicitly and `renovate.json` had non-canonical content, writing a
-`renovate.json.bak` that appears in `touched` alongside `renovate.json` —
-not reachable via the no-flags procedure below, but real if this function is
-ever invoked with an explicit `--enforce`.)
+`backed up:` write only happens if a prior invocation passed `--enforce` or
+`--renovate-automerge` explicitly and `renovate.json` had non-canonical
+content, writing a `renovate.json.bak` that appears in `touched` alongside
+`renovate.json` — not reachable via the no-flags procedure below, but real if
+this function is ever invoked with an explicit `--enforce` or
+`--renovate-automerge`.)
 
 - It **always overwrites** `.claude/skills/remediate/SKILL.md` in consumer
   app repos — the very document driving this remediation loop — on every

--- a/packages/conformance/tests/test_bootstrap.py
+++ b/packages/conformance/tests/test_bootstrap.py
@@ -11,7 +11,7 @@ import json
 import pathlib
 
 import pytest
-from conformance.bootstrap.args import parse_bootstrap_args
+from conformance.bootstrap.args import BOOTSTRAP_USAGE, FLAGS, parse_bootstrap_args
 from conformance.bootstrap.autodetect import derive_app_name_from_dir
 from conformance.bootstrap.command import _bootstrap_file
 from conformance.bootstrap.render import MANAGED_ACTION_FILES, MANAGED_WORKFLOWS, render
@@ -103,6 +103,8 @@ def test_parse_bootstrap_args_defaults() -> None:
         "services_script": "",
         "system_deps": "",
         "enforce": "",
+        "conformance_blocking": "",
+        "renovate_automerge": "",
     }
 
 
@@ -529,6 +531,73 @@ def test_parse_bootstrap_args_enforce_invalid(
     assert "--enforce" in capsys.readouterr().err
 
 
+# ---------------------------------------------------------------------------
+# The two granular 0-touch levers (--conformance-blocking /
+# --renovate-automerge), which --enforce is the shorthand for. See FND-347:
+# the tests gate being a required check is a third, separate lever that none
+# of these three flags governs.
+# ---------------------------------------------------------------------------
+
+
+def test_every_flag_is_documented_in_usage() -> None:
+    """Each flag must appear in --help.
+
+    BOOTSTRAP_USAGE is the authoritative flag documentation (the parser's own
+    docstring says so), and a lever nobody can find in --help is not
+    separately expressible in any useful sense.
+    """
+    undocumented = [flag for flag in FLAGS if flag not in BOOTSTRAP_USAGE]
+    assert not undocumented
+
+
+@pytest.mark.parametrize(
+    "flag,dest",
+    [
+        ("--conformance-blocking", "conformance_blocking"),
+        ("--renovate-automerge", "renovate_automerge"),
+    ],
+)
+@pytest.mark.parametrize("value", ["true", "false"])
+def test_parse_bootstrap_args_granular_levers(flag: str, dest: str, value: str) -> None:
+    assert parse_bootstrap_args([flag, value])[dest] == value
+    assert parse_bootstrap_args([f"{flag}={value}"])[dest] == value
+
+
+@pytest.mark.parametrize(
+    "flag", ["--conformance-blocking", "--renovate-automerge", "--enforce"]
+)
+def test_parse_bootstrap_args_tristate_invalid_names_its_own_flag(
+    flag: str, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A bad value must be reported against the flag that carried it.
+
+    The three tri-state flags share one validation loop, so a shared error
+    message that always said ``--enforce`` would misdirect anyone who passed
+    a granular lever — the exact confusion these separate names exist to
+    prevent.
+    """
+    with pytest.raises(SystemExit) as exc_info:
+        parse_bootstrap_args([flag, "maybe"])
+    assert exc_info.value.code == 2
+    err = capsys.readouterr().err
+    assert flag in err
+    assert "'maybe'" in err
+
+
+@pytest.mark.parametrize(
+    "flag", ["--conformance-blocking", "--renovate-automerge", "--enforce"]
+)
+def test_parse_bootstrap_args_tristate_missing_value(
+    flag: str, capsys: pytest.CaptureFixture[str]
+) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        parse_bootstrap_args([flag])
+    assert exc_info.value.code == 2
+    err = capsys.readouterr().err
+    assert flag in err
+    assert "requires a value" in err
+
+
 _EXIT_ZERO_SCHEDULE_PREFIX = (
     "exit-zero: ${{ github.event_name == 'schedule' "
     "|| github.event_name == 'workflow_dispatch' || "
@@ -896,6 +965,126 @@ def test_cmd_bootstrap_enforce_true_force_overwrites_existing_renovate(
     _cmd_bootstrap(["--enforce", "true"])
     content = rj.read_text()
     assert '"automerge": false' not in content  # overrides removed
+
+
+# ---------------------------------------------------------------------------
+# Granular levers, end to end: each moves exactly one of the two files, and
+# --enforce still moves both (FND-347)
+# ---------------------------------------------------------------------------
+
+
+def _conformance_text(root: pathlib.Path) -> str:
+    return (root / ".github" / "workflows" / "conformance.yaml").read_text()
+
+
+def test_cmd_bootstrap_conformance_blocking_false_leaves_renovate_hard(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """--conformance-blocking false stops conformance blocking and nothing else.
+
+    This is the state --enforce could not express: observe-mode conformance
+    with Renovate auto-merge still on.
+    """
+    monkeypatch.chdir(tmp_path)
+    _cmd_bootstrap(["--conformance-blocking", "false"])
+    assert _EXIT_ZERO_SOFT in _conformance_text(tmp_path)
+    assert '"automerge": false' not in (tmp_path / "renovate.json").read_text()
+
+
+def test_cmd_bootstrap_renovate_automerge_false_leaves_conformance_blocking(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """--renovate-automerge false takes the human back into the merge, and
+    leaves conformance blocking CI."""
+    monkeypatch.chdir(tmp_path)
+    _cmd_bootstrap(["--renovate-automerge", "false"])
+    assert _EXIT_ZERO_HARD in _conformance_text(tmp_path)
+    assert '"automerge": false' in (tmp_path / "renovate.json").read_text()
+
+
+def test_cmd_bootstrap_granular_lever_overrides_enforce_shorthand(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An explicit granular lever wins over the shorthand for that lever only."""
+    monkeypatch.chdir(tmp_path)
+    _cmd_bootstrap(["--enforce", "false", "--renovate-automerge", "true"])
+    # Shorthand still governs the lever that wasn't named explicitly.
+    assert _EXIT_ZERO_SOFT in _conformance_text(tmp_path)
+    assert '"automerge": false' not in (tmp_path / "renovate.json").read_text()
+
+
+def test_cmd_bootstrap_granular_lever_inherits_detected_enforce(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A lever left unset inherits the *detected* --enforce, not the hard default.
+
+    Passing only --renovate-automerge on a soft-mode repo must not silently
+    flip conformance back to blocking: the unnamed lever keeps whatever the
+    repo's existing conformance.yaml says.
+    """
+    monkeypatch.chdir(tmp_path)
+    _cmd_bootstrap(["--enforce", "false"])
+    _cmd_bootstrap(["--renovate-automerge", "true"])
+    assert _EXIT_ZERO_SOFT in _conformance_text(tmp_path)
+    assert '"automerge": false' not in (tmp_path / "renovate.json").read_text()
+
+
+def test_cmd_bootstrap_renovate_automerge_force_updates_existing_file(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """--renovate-automerge force-updates an existing renovate.json.
+
+    renovate.json is write-if-absent, so without this the flag that governs
+    exactly that file would be a no-op on every repo that already has one.
+    """
+    monkeypatch.chdir(tmp_path)
+    _cmd_bootstrap([])
+    rj = tmp_path / "renovate.json"
+    assert '"automerge": false' not in rj.read_text()
+    _cmd_bootstrap(["--renovate-automerge", "false"])
+    assert '"automerge": false' in rj.read_text()
+
+
+def test_cmd_bootstrap_conformance_blocking_does_not_force_renovate(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """--conformance-blocking must not rewrite renovate.json.
+
+    It governs the other file, and renovate.json is write-if-absent — a
+    customised one stays customised.
+    """
+    monkeypatch.chdir(tmp_path)
+    _cmd_bootstrap([])
+    rj = tmp_path / "renovate.json"
+    rj.write_text('{"customised": true}\n')
+    _cmd_bootstrap(["--conformance-blocking", "false"])
+    assert rj.read_text() == '{"customised": true}\n'
+    assert not (tmp_path / "renovate.json.bak").exists()
+
+
+def test_cmd_bootstrap_no_lever_touches_the_tests_gate(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No enforcement lever changes tests.yaml (FND-347).
+
+    The tests gate becoming a required check is a branch-protection setting
+    with no prerequisite here; if any of these flags started rendering
+    tests.yaml differently, the gate milestone would once again be behind the
+    0-touch bar.
+    """
+    monkeypatch.chdir(tmp_path)
+    canonical = render("tests.yaml", app_name=tmp_path.name)
+    for flags in (
+        ["--enforce", "false"],
+        ["--enforce", "true"],
+        ["--conformance-blocking", "false"],
+        ["--renovate-automerge", "false"],
+    ):
+        wf = tmp_path / ".github" / "workflows" / "tests.yaml"
+        if wf.exists():
+            wf.unlink()
+        _cmd_bootstrap(flags)
+        assert wf.read_text() == canonical, f"tests.yaml varied with {flags}"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### Changelog

- **`--enforce` is unchanged.** It stays the 0-touch shorthand — it has been communicated too broadly to rename. What it always did (and only did) is derive two render variables: `exit_zero` (conformance.yaml) and `automerge` (renovate.json), both of which are 0-touch.
- **Adds the two granular levers `--enforce` expands to**, so either can move alone:
  - `--conformance-blocking true|false` → conformance.yaml's `exit-zero`
  - `--renovate-automerge true|false` → renovate.json
  - Resolution per lever: explicit granular flag → `--enforce` (explicit or autodetected) → hard default. Every existing invocation is byte-identical.
  - `--renovate-automerge` force-updates an existing `renovate.json` the way `--enforce` does; that file is otherwise write-if-absent, so the flag governing it would be a no-op on any repo that already has one.
- **Corrects the required-check context string** in every place it was shipped (see below).
- **Documents the gate lever as having no prerequisite**: `bootstrap --help`, the scaffolded `tests.yaml` header, and the connector onboarding checklist now state plainly that the tests gate becomes required immediately and does **not** wait on the four-tier bar or the 85% coverage target — no flag here turns it on or off.
- Tests: 13 new parametrised arg-parsing cases plus 7 end-to-end lever-independence cases, including one asserting that **no** enforcement flag varies `tests.yaml` (a regression guard against the gate drifting back behind the 0-touch bar) and one asserting every flag in `FLAGS` appears in `--help`.

### Additional context (e.g. screenshots, logs, links)

- Linear: [FND-347](https://linear.app/atlan-epd/issue/FND-347/split-enforce-into-two-independent-levers-gate-required-vs-0-touch) — unblocks [FND-348](https://linear.app/atlan-epd/issue/FND-348) (make the gate required across the fleet). Rationale and the corrected premise are recorded as a comment on FND-347.

**The issue asked for a mechanism split; there wasn't one to make.** `--enforce` never touched the tests gate, so the two levers were already independent in code — the gate lever simply had no expression anywhere, being a GitHub branch-protection setting. Two things already agreed: C002's drift checker reads each file's own value off disk (`_extract_exit_zero`, `extract_renovate_automerge`), so mixed-lever repos were never flagged; and `docs/standards/app-certification.md` already ships this exact split at the publish gate, where unit-test pass/fail blocks and the 85% threshold only annotates.

**Required-check context string was wrong everywhere.** A ruleset's `required_status_checks` `context` is the check-run name, which omits the workflow name:

| Job shape | Context |
|---|---|
| inline job | the job's `name:` — e.g. `SDK Gate` |
| job that `uses:` a reusable | `<caller job id> / <called job name>` — e.g. `tests / Tests Gate` |

So it is **`tests / Tests Gate`** — not `Tests / Tests Gate` (what FND-347's description, the `release-gate.yaml` template comment, and the release-gate runtime `echo` all said) and not the three-segment `Tests / tests / Tests Gate` that `tests-reusable.yaml`'s comment block documents (that is the UI's *display* hierarchy). Verified against live `main` rulesets: `atlanhq/atlan-mysql-app` carries `tests / Tests Gate` and `suite / Conformance Gate`; `atlanhq/application-sdk` carries single-segment contexts for its inline jobs. A context matching no check raises no error and gates nothing — exactly the failure a fleet rollout wouldn't notice, which is why this is fixed here rather than in FND-348.

**Blast radius of the template edits.** `release-gate.yaml` and `tests.yaml` template changes are comment-only. C002 (BootstrapWorkflowDrift) is WARN-tier, so consumer repos will show a non-blocking drift finding until their next `bootstrap` re-sync. The `.github/workflows/tests-reusable.yaml` change is likewise comment-only — no job, step, or condition touched.

**Out of scope, per the issue:** no change to the four-tier bar or to what counts as meaningful tests for 0-touch. No GitHub-settings mutation from the CLI — the conformance CLI is filesystem-only (even `renovate-scan` consumes `gh` output produced by a workflow), so applying the ruleset stays FND-348's job.

**Pre-existing, unrelated:** `tests/test_logging.py::test_l010_fires_when_rebound_via_type_alias` fails on Python 3.11 — its fixture source uses PEP 695 `type X = str`, unparseable on 3.11, so the checker returns no findings and the assert fails instead of the test skipping. Green on 3.12+. Untouched here.

**Also stale, outside this repo:** the `adopt-test-framework` skill still tells adopters to require `Tests / tests-passed`.

### Checklist

- [x] Additional tests added
- [ ] All CI checks passed
- [x] Relevant documentation updated

---

### Copyleft License Compliance

- [ ] Have you used any code that is subject to a Copyleft license (e.g., GPL, AGPL, LGPL)?
- [ ] If yes, have you modified the code in the context of this project? please share additional details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
