### PR TITLE
ci: narrow the defaulted e2e cloud fan-out to the tenant secret's keys (FND-354)

### DIFF
--- a/.github/actions/discover-e2e-suites/action.yaml
+++ b/.github/actions/discover-e2e-suites/action.yaml
@@ -30,6 +30,23 @@ inputs:
       caller's matrix by default is the wrong direction to fail in.
     required: false
     default: "none"
+  available-clouds:
+    description: |
+      Comma-separated cloud keys that E2E_TENANT_MATRIX_JSON actually carries.
+      The KEY LIST, never the payload — the credentials belong to the per-leg
+      tenant resolver, which is the only thing that needs them.
+
+      Narrows the DEFAULTED `clouds` list to the intersection, warning about
+      each cloud it drops, so taking a cloud out of the secret narrows the
+      fan-out fleet-wide instead of reding one leg in every e2e-running repo
+      (FND-354). A cloud named explicitly in `clouds` is never narrowed away:
+      it reaches the resolver and still fails there, because somebody asserted
+      it should run.
+
+      Empty (the default) means "not known here" and narrows nothing, which is
+      the pre-FND-354 behaviour a caller without the secret already gets.
+    required: false
+    default: ""
   clouds-only:
     description: |
       "true" emits only the cloud dimension, with no file dimension, for
@@ -64,10 +81,12 @@ runs:
       env:
         TEST_DIR: ${{ inputs.test-dir }}
         CLOUDS: ${{ inputs.clouds }}
+        AVAILABLE_CLOUDS: ${{ inputs.available-clouds }}
         CLOUDS_ONLY_FLAG: ${{ inputs.clouds-only == 'true' && '--clouds-only' || '' }}
       run: |
         set -euo pipefail
         python3 "${{ github.action_path }}/discover_e2e_suites.py" \
           --test-dir "$TEST_DIR" \
           --clouds "$CLOUDS" \
+          --available-clouds "$AVAILABLE_CLOUDS" \
           ${CLOUDS_ONLY_FLAG} >> "$GITHUB_OUTPUT"

--- a/.github/actions/discover-e2e-suites/discover_e2e_suites.py
+++ b/.github/actions/discover-e2e-suites/discover_e2e_suites.py
@@ -40,6 +40,29 @@ Three ``--clouds`` values, and the reason the empty one is not "no clouds":
   for a caller without the tenant-matrix secret, or an operator deliberately
   falling back to the single legacy tenant.
 
+Defaulted narrows, named does not (FND-354)
+-------------------------------------------
+``--available-clouds`` carries the cloud KEYS that ``E2E_TENANT_MATRIX_JSON``
+actually holds — the key list, never the blob; the credentials stay in
+``resolve_e2e_tenant.py``, which is the only thing that needs them. The two
+``--clouds`` forms treat it differently, and the difference is the point:
+
+* **defaulted** (``""``) → ``DEFAULT_CLOUDS ∩ available``, with a ``::warning::``
+  naming every dropped cloud. Nobody asked for that cloud; ``DEFAULT_CLOUDS``
+  did. Before FND-354 the defaulted list was emitted whole, so removing a cloud
+  from the secret — the one lever that is fleet-wide and needs no PR — made
+  ``resolve_e2e_tenant.py`` hard-fail that leg in *every* e2e-running repo
+  instead of narrowing the fan-out. The obvious incident hatch did the opposite
+  of what an operator reaches for it to do. It now narrows, out loud.
+* **named** (``--clouds aws,azure``) → passed through untouched, so a cloud that
+  is absent from the secret still reaches the resolver and still exits non-zero.
+  Someone asserted that cloud should run; skipping it silently really would be a
+  coverage hole.
+
+Intersection only, never union: a fourth key appearing in the secret does not
+widen the fleet's fan-out behind ``DEFAULT_CLOUDS``'s back. Widening stays a
+deliberate edit here.
+
 ``--clouds-only`` emits the cloud dimension *without* the file dimension, for
 callers that target a whole directory rather than fanning out per file
 (``e2e-full-reusable.yaml``).
@@ -56,6 +79,7 @@ import argparse
 import json
 import re
 import sys
+from collections.abc import Iterable
 from pathlib import Path
 
 _SANITIZE_RE = re.compile(r"[^a-z0-9]+")
@@ -71,6 +95,10 @@ DEFAULT_CLOUDS = ("aws", "azure", "gcp")
 NO_CLOUDS = "none"
 
 
+class CloudSelectionError(ValueError):
+    """The requested cloud fan-out cannot be satisfied."""
+
+
 def _leg_name(path: Path) -> str:
     """Derive a stable, filesystem-safe leg label from a test file path.
 
@@ -84,28 +112,86 @@ def _leg_name(path: Path) -> str:
     return _SANITIZE_RE.sub("-", stem.lower()).strip("-") or "e2e"
 
 
-def parse_clouds(raw: str) -> list[str]:
-    """Return the ordered, de-duplicated cloud list for a ``--clouds`` value.
+def _split_clouds(raw: str) -> list[str]:
+    """Split a comma-separated cloud list into sanitized, de-duplicated keys.
 
-    Accepts the comma-separated form the workflow input carries. ``""`` yields
-    :data:`DEFAULT_CLOUDS` and ``"none"`` yields no clouds — see the module
-    docstring for why round that way. Blank entries inside a list are dropped so
-    a trailing comma is a no-op rather than a leg named "". Order is the
-    caller's, not sorted: the operator writes ``aws,azure,gcp`` and the legs
-    should read in that order.
+    Blank entries are dropped so a trailing comma is a no-op rather than a leg
+    named "". Order is the caller's, not sorted: the operator writes
+    ``aws,azure,gcp`` and the legs should read in that order.
     """
-    stripped = raw.strip()
-    if not stripped:
-        return list(DEFAULT_CLOUDS)
-    if stripped.lower() == NO_CLOUDS:
-        return []
-
     out: list[str] = []
     for token in raw.split(","):
         cloud = _SANITIZE_RE.sub("-", token.strip().lower()).strip("-")
         if cloud and cloud not in out:
             out.append(cloud)
     return out
+
+
+def _defaulted_clouds(available: Iterable[str] | None) -> list[str]:
+    """Return :data:`DEFAULT_CLOUDS` narrowed to what the tenant secret carries.
+
+    *available* is the tenant matrix's key list. Empty or ``None`` means "not
+    known here" — no secret shared with this repo, or a payload that could not
+    be read — and narrowing is then skipped entirely, which is exactly the
+    pre-FND-354 behaviour.
+
+    Narrowing is an intersection, never a union: a key in the secret that is not
+    in :data:`DEFAULT_CLOUDS` does not widen the fan-out. Removing a cloud from
+    the secret is meant to be the fleet-wide incident hatch; adding one is a
+    coverage decision that belongs in this file, where it is reviewed.
+    """
+    have = set(_split_clouds(",".join(available or ())))
+    if not have:
+        return list(DEFAULT_CLOUDS)
+
+    kept = [cloud for cloud in DEFAULT_CLOUDS if cloud in have]
+    dropped = [cloud for cloud in DEFAULT_CLOUDS if cloud not in have]
+    if not kept:
+        raise CloudSelectionError(
+            "E2E_TENANT_MATRIX_JSON carries no cloud from the SDK's default "
+            f"fan-out (default: {', '.join(DEFAULT_CLOUDS)}; secret: "
+            f"{', '.join(sorted(have))}). Narrowing to nothing would emit zero "
+            "legs and green the gate having run no e2e at all, so this fails "
+            "instead. Restore a default cloud's entry in the secret, or pass "
+            "e2e-clouds explicitly to run the clouds the secret does carry."
+        )
+    if dropped:
+        print(
+            "::warning::Cloud fan-out narrowed to what E2E_TENANT_MATRIX_JSON "
+            f"carries: running {', '.join(kept)}; dropped "
+            f"{', '.join(dropped)} (in the SDK default list, absent from the "
+            "secret). This run has LESS cross-CSP coverage than the SDK ships. "
+            "Nothing named these clouds — the default list did — so they are "
+            "narrowed rather than failed; name a cloud in e2e-clouds to make "
+            "its absence a hard failure instead.",
+            file=sys.stderr,
+        )
+    return kept
+
+
+def parse_clouds(raw: str, available: Iterable[str] | None = None) -> list[str]:
+    """Return the ordered, de-duplicated cloud list for a ``--clouds`` value.
+
+    Accepts the comma-separated form the workflow input carries. ``""`` yields
+    :data:`DEFAULT_CLOUDS` and ``"none"`` yields no clouds — see the module
+    docstring for why round that way.
+
+    *available* (the tenant matrix's cloud keys) narrows the **defaulted** list
+    only. An explicitly named cloud is passed through even when it is absent
+    from *available*, so the per-leg resolver still hard-fails on it. That
+    asymmetry is the whole of FND-354 and is pinned by
+    ``test_a_named_absent_cloud_still_reaches_the_resolver``.
+
+    Raises :class:`CloudSelectionError` when narrowing would leave no clouds at
+    all.
+    """
+    stripped = raw.strip()
+    if not stripped:
+        return _defaulted_clouds(available)
+    if stripped.lower() == NO_CLOUDS:
+        return []
+
+    return _split_clouds(raw)
 
 
 def discover(test_dir: str, clouds: list[str] | None = None) -> list[dict[str, str]]:
@@ -182,6 +268,18 @@ def main(argv: list[str] | None = None) -> int:
         ),
     )
     parser.add_argument(
+        "--available-clouds",
+        default="",
+        help=(
+            "Comma-separated cloud keys that E2E_TENANT_MATRIX_JSON actually "
+            "carries — the KEY LIST, never the payload. Narrows the DEFAULTED "
+            "--clouds list (and warns about each cloud it drops) so removing a "
+            "cloud from the secret takes it out of the rotation fleet-wide "
+            "instead of reding a leg in every repo. An explicitly named cloud "
+            "is never narrowed. Empty = unknown; nothing is narrowed."
+        ),
+    )
+    parser.add_argument(
         "--clouds-only",
         action="store_true",
         help=(
@@ -192,7 +290,11 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(sys.argv[1:] if argv is None else argv)
 
-    clouds = parse_clouds(args.clouds)
+    try:
+        clouds = parse_clouds(args.clouds, _split_clouds(args.available_clouds))
+    except CloudSelectionError as exc:
+        print(f"::error::{exc}", file=sys.stderr)
+        return 1
 
     if args.clouds_only:
         # No suites to count in this mode: the caller runs one pytest target per

--- a/.github/scripts/e2e_tenant_matrix_clouds.py
+++ b/.github/scripts/e2e_tenant_matrix_clouds.py
@@ -1,0 +1,120 @@
+"""Print the cloud KEYS that ``E2E_TENANT_MATRIX_JSON`` carries, and nothing else.
+
+Why this exists (FND-354)
+-------------------------
+Removing a cloud from the tenant matrix secret is the only lever for taking a
+cloud out of the e2e rotation that is fleet-wide, needs no connector PR, and
+takes effect on the next run — which is exactly what an operator reaches for
+when that cloud's tenant is down mid-incident. It used to do the opposite:
+``discover_e2e_suites.py`` never saw the secret, so the defaulted fan-out still
+emitted a leg for the removed cloud and ``resolve_e2e_tenant.py`` hard-failed it
+in *every* e2e-running repo.
+
+Teaching discovery to narrow the defaulted list needs it to see which clouds the
+secret holds. This script is the bridge, and it is deliberately the narrowest
+one that works: the payload comes in, one comma-separated list of **key names**
+goes out::
+
+    python3 e2e_tenant_matrix_clouds.py --matrix-json "$E2E_TENANT_MATRIX_JSON" \
+      >> "$GITHUB_OUTPUT"        # clouds=aws,gcp
+
+The credentials never leave this process. Discovery is handed the key list, not
+the blob, so the only script that can see a tenant credential remains
+``resolve_e2e_tenant.py`` — and it renders exactly one cloud's entry per leg.
+
+Keys, not validity
+------------------
+A key counts as available because it is present, not because its entry is
+well-formed. A cloud whose entry is missing ``client_secret`` is a coverage hole
+that must stay red, and ``resolve_e2e_tenant.py`` already reports it precisely
+per leg; silently narrowing it away here would convert that red into a run that
+looks complete and is not.
+
+Degradation
+-----------
+An unusable payload prints an empty list and warns, rather than failing. Empty
+means "not known", discovery then narrows nothing, and the run behaves exactly
+as it did before FND-354 — including whatever error ``resolve_e2e_tenant.py``
+raises per leg, which is the one that can name the actual defect in the secret.
+Failing here instead would replace that precise per-leg diagnosis with a
+discovery-time failure that knows strictly less.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+
+class MatrixCloudsError(ValueError):
+    """The tenant matrix payload cannot be read as a cloud-keyed object."""
+
+
+def cloud_keys(matrix_json: str) -> list[str]:
+    """Return the sorted cloud keys in *matrix_json*.
+
+    An empty payload yields no keys: the secret is not shared with this repo,
+    and the caller already treats that as "no cloud dimension at all".
+
+    Sorted rather than insertion-ordered because nothing downstream takes its
+    leg order from here — discovery orders by :data:`DEFAULT_CLOUDS` — so a
+    stable order is worth more than the secret author's.
+    """
+    payload = matrix_json.strip()
+    if not payload:
+        return []
+
+    try:
+        parsed = json.loads(payload)
+    except json.JSONDecodeError as exc:
+        raise MatrixCloudsError(
+            f"E2E_TENANT_MATRIX_JSON is not valid JSON ({exc})."
+        ) from exc
+    if not isinstance(parsed, dict):
+        raise MatrixCloudsError(
+            "E2E_TENANT_MATRIX_JSON must be a JSON object keyed by cloud, got "
+            f"{type(parsed).__name__}."
+        )
+
+    # str() rather than a type assertion: JSON object keys are always strings.
+    return sorted(str(key).strip() for key in parsed if str(key).strip())
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--matrix-json",
+        default="",
+        help=(
+            "E2E_TENANT_MATRIX_JSON: cloud -> credential map. Only its keys are "
+            "read, and only its keys are ever printed."
+        ),
+    )
+    args = parser.parse_args(sys.argv[1:] if argv is None else argv)
+
+    try:
+        clouds = cloud_keys(args.matrix_json)
+    except MatrixCloudsError as exc:
+        # Never echo the payload, not even a fragment of it: the JSONDecodeError
+        # text carries a position, not content, and that is all that is quoted.
+        print(
+            f"::warning::{exc} The e2e cloud fan-out cannot be narrowed to what "
+            "the secret carries, so it falls back to the SDK's full default "
+            "list. A cloud the secret does not carry will fail its leg with the "
+            "per-leg resolver's message, which names the actual defect.",
+            file=sys.stderr,
+        )
+        clouds = []
+
+    print(
+        f"Tenant matrix carries {len(clouds)} cloud(s): "
+        f"{', '.join(clouds) or 'none'}",
+        file=sys.stderr,
+    )
+    print(f"clouds={','.join(clouds)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/resolve_e2e_tenant.py
+++ b/.github/scripts/resolve_e2e_tenant.py
@@ -129,7 +129,12 @@ def _entry(matrix_json: str, cloud: str) -> dict[str, str]:
         raise TenantMatrixError(
             f"cloud {cloud!r} is not in E2E_TENANT_MATRIX_JSON (available: "
             f"{available}). A cloud named in the workflow's e2e-clouds input "
-            "but missing from the secret is a coverage hole, not a leg to skip."
+            "but missing from the secret is a coverage hole, not a leg to skip. "
+            "Since FND-354 the DEFAULTED cloud list is narrowed to the secret's "
+            "keys at discovery, so reaching this means either that this cloud "
+            "was named explicitly (drop it from e2e-clouds, or add its entry to "
+            "the secret) or that discovery could not read the secret's keys — "
+            "in which case the discover job carries a ::warning:: saying so."
         )
 
     entry = parsed[cloud]

--- a/.github/scripts/tests/test_discover_e2e_suites.py
+++ b/.github/scripts/tests/test_discover_e2e_suites.py
@@ -19,6 +19,7 @@ sys.path.insert(
 
 from discover_e2e_suites import (  # noqa: E402
     DEFAULT_CLOUDS,
+    CloudSelectionError,
     discover,
     main,
     parse_clouds,
@@ -259,3 +260,120 @@ def test_clouds_only_with_empty_uses_the_default_list(capsys, tmp_path: Path) ->
     main(["--test-dir", str(tmp_path), "--clouds", "", "--clouds-only"])
     out = capsys.readouterr().out
     assert [e["cloud"] for e in _matrix(out)["include"]] == list(DEFAULT_CLOUDS)
+
+
+# ── Defaulted narrows to the secret's keys, named does not (FND-354) ─────────
+#
+# The two branches below are the whole of FND-354, and they are exactly the pair
+# a later reader is liable to flatten into one — they "both just check the cloud
+# list". They do the opposite thing on purpose:
+#
+#   defaulted + absent -> dropped with a warning. Nobody named it; DEFAULT_CLOUDS
+#     did. Editing the secret is the only cloud-rotation lever that is fleet-wide
+#     and needs no PR, so it has to narrow rather than red a leg in every repo.
+#   named + absent     -> still emitted, so the per-leg resolver still exits
+#     non-zero. Someone asserted that cloud should run; a silent skip there is a
+#     coverage hole.
+#
+# Delete either and the lever breaks in one direction or the other, silently.
+
+
+def test_a_defaulted_absent_cloud_is_dropped_with_a_warning(capsys) -> None:
+    clouds = parse_clouds("", ["aws", "gcp"])
+    assert clouds == ["aws", "gcp"]
+
+    warning = capsys.readouterr().err
+    assert "::warning::" in warning
+    assert "azure" in warning, "the dropped cloud must be named, not just counted"
+    assert "aws, gcp" in warning, "the surviving fan-out must be stated too"
+
+
+def test_a_named_absent_cloud_still_reaches_the_resolver(capsys) -> None:
+    # No narrowing and no warning: the per-leg tenant resolver is meant to fail
+    # this leg, which is what makes an explicitly named cloud an assertion.
+    assert parse_clouds("aws,azure", ["aws", "gcp"]) == ["aws", "azure"]
+    assert capsys.readouterr().err == ""
+
+
+def test_narrowing_is_silent_when_nothing_is_dropped(capsys) -> None:
+    assert parse_clouds("", list(DEFAULT_CLOUDS)) == list(DEFAULT_CLOUDS)
+    assert "::warning::" not in capsys.readouterr().err
+
+
+@pytest.mark.parametrize("available", [None, [], [""], ["  "]])
+def test_unknown_availability_narrows_nothing(available) -> None:
+    # "" is what a skipped key-reading step emits — no secret shared with the
+    # repo, or a payload that could not be parsed. Narrowing on that would turn
+    # an unreadable secret into a silently smaller matrix.
+    assert parse_clouds("", available) == list(DEFAULT_CLOUDS)
+
+
+def test_an_extra_key_in_the_secret_does_not_widen_the_fan_out(capsys) -> None:
+    # Intersection, never union. Adding a fourth CSP stays a reviewed edit to
+    # DEFAULT_CLOUDS; a stray key in the secret must not fan out to a cloud the
+    # SDK does not ship.
+    assert parse_clouds("", ["aws", "azure", "gcp", "onprem"]) == list(DEFAULT_CLOUDS)
+    assert "::warning::" not in capsys.readouterr().err
+
+
+def test_availability_does_not_resurrect_the_none_sentinel() -> None:
+    assert parse_clouds("none", ["aws", "azure", "gcp"]) == []
+
+
+def test_narrowing_to_nothing_is_an_error_not_an_empty_matrix() -> None:
+    # Zero legs would leave `count` (the SUITE count) non-zero, so the caller's
+    # "requested but nothing found" guard would not fire and the gate would go
+    # green having run no e2e at all.
+    with pytest.raises(CloudSelectionError) as excinfo:
+        parse_clouds("", ["onprem"])
+    assert "onprem" in str(excinfo.value)
+
+
+def test_main_narrows_the_defaulted_list_from_available_clouds(
+    capsys, tmp_path: Path
+) -> None:
+    e2e = tmp_path / "tests" / "e2e"
+    _mk(e2e, "test_one.py")
+    rc = main(["--test-dir", str(e2e), "--clouds", "", "--available-clouds", "aws,gcp"])
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert [e["cloud"] for e in _matrix(captured.out)["include"]] == ["aws", "gcp"]
+    assert "leg-count=2" in captured.out.splitlines()
+    assert "::warning::" in captured.err
+
+
+def test_main_does_not_narrow_an_explicit_list(capsys, tmp_path: Path) -> None:
+    e2e = tmp_path / "tests" / "e2e"
+    _mk(e2e, "test_one.py")
+    rc = main(
+        ["--test-dir", str(e2e), "--clouds", "azure", "--available-clouds", "aws,gcp"]
+    )
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert [e["cloud"] for e in _matrix(out)["include"]] == ["azure"]
+
+
+def test_main_exits_non_zero_when_narrowing_empties_the_fan_out(
+    capsys, tmp_path: Path
+) -> None:
+    e2e = tmp_path / "tests" / "e2e"
+    _mk(e2e, "test_one.py")
+    rc = main(["--test-dir", str(e2e), "--clouds", "", "--available-clouds", "onprem"])
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "::error::" in captured.err
+    # Nothing may be written to $GITHUB_OUTPUT on the failing path, or the
+    # caller reads a matrix from a run that errored.
+    assert captured.out == ""
+
+
+def test_clouds_only_narrows_the_same_way(capsys, tmp_path: Path) -> None:
+    # prepare-tenant installs from this matrix; it must cover exactly the clouds
+    # the legs run against, so the two call sites narrow identically.
+    rc = main(
+        ["--test-dir", str(tmp_path), "--clouds-only", "--available-clouds", "aws,gcp"]
+    )
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert [e["cloud"] for e in _matrix(out)["include"]] == ["aws", "gcp"]
+    assert "count=2" in out.splitlines()

--- a/.github/scripts/tests/test_e2e_cloud_narrowing_wiring.py
+++ b/.github/scripts/tests/test_e2e_cloud_narrowing_wiring.py
@@ -1,0 +1,147 @@
+"""Guards for the FND-354 cloud-narrowing wiring in both e2e reusables.
+
+The behaviour being protected is that *editing `E2E_TENANT_MATRIX_JSON` is the
+fleet-wide cloud-rotation lever*: removing a cloud narrows the fan-out on the
+next run of every repo, with no connector PR and no SDK PR. That only holds if
+discovery is actually handed the secret's key list — and the failure mode of
+losing the wiring is not a red build. It is the pre-FND-354 behaviour: a
+defaulted leg for a cloud the secret no longer carries, hard-failing in every
+e2e-running repo, at the moment an operator reached for the lever to stop
+exactly that.
+
+Deliberately YAML-shape assertions: the wiring is GitHub Actions' own (step
+outputs, skipped-step semantics, action inputs) and cannot be exercised without
+a runner. The narrowing *logic* is unit-tested in test_discover_e2e_suites.py.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+#: The two reusables that fan an e2e run out over clouds, and the job in each
+#: that decides the fan-out. Both must narrow, or the lever works in one
+#: workflow and not the other — which is worse than not working at all, because
+#: the operator cannot tell which they are looking at.
+_WORKFLOWS = {
+    ".github/workflows/tests-reusable.yaml": "discover-e2e",
+    ".github/workflows/e2e-full-reusable.yaml": "plan-clouds",
+}
+
+_DISCOVER_ACTION = "atlanhq/application-sdk/.github/actions/discover-e2e-suites@main"
+_KEYS_SCRIPT = "e2e_tenant_matrix_clouds.py"
+_KEYS_STEP_ID = "matrix-clouds"
+_AVAILABLE = "${{ steps.%s.outputs.clouds }}" % _KEYS_STEP_ID
+
+#: A mention of the tenant-matrix secret, with `op` capturing the comparison
+#: that makes it a presence test rather than a substitution of its value.
+_SECRET_MENTION = re.compile(r"secrets\.E2E_TENANT_MATRIX_JSON\s*(?P<op>[=!]=)?")
+
+
+@pytest.fixture(scope="module", params=sorted(_WORKFLOWS))
+def steps(request: pytest.FixtureRequest) -> list[dict[str, Any]]:
+    """Every step of the cloud-planning job, for each workflow in turn."""
+    workflow = yaml.safe_load((_REPO_ROOT / request.param).read_text(encoding="utf-8"))
+    return workflow["jobs"][_WORKFLOWS[request.param]]["steps"]
+
+
+def _keys_step(steps: list[dict[str, Any]]) -> dict[str, Any]:
+    matching = [s for s in steps if s.get("id") == _KEYS_STEP_ID]
+    assert len(matching) == 1, (
+        f"expected exactly one `id: {_KEYS_STEP_ID}` step reading the tenant "
+        "matrix's cloud keys; without it the defaulted fan-out cannot narrow"
+    )
+    return matching[0]
+
+
+def _discover_steps(steps: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    matching = [s for s in steps if s.get("uses") == _DISCOVER_ACTION]
+    assert matching, "the cloud-planning job must invoke the discovery action"
+    return matching
+
+
+def test_the_key_list_is_read_from_the_secret(steps: list[dict[str, Any]]) -> None:
+    step = _keys_step(steps)
+    assert _KEYS_SCRIPT in step["run"], (
+        "the keys must come from the tested script, not from inline jq/python — "
+        "branching in YAML cannot be regression-tested (docs/standards/ci.md)"
+    )
+    assert step["env"]["E2E_TENANT_MATRIX_JSON"] == (
+        "${{ secrets.E2E_TENANT_MATRIX_JSON }}"
+    )
+    assert (
+        '>> "$GITHUB_OUTPUT"' in step["run"]
+    ), "the key list has to reach the discovery step as a step output"
+
+
+def test_the_key_step_is_skipped_without_the_secret(
+    steps: list[dict[str, Any]],
+) -> None:
+    # A skipped step's outputs are "", which discovery reads as "not known" and
+    # narrows nothing. Running it unconditionally would instead hand discovery
+    # an empty key list derived from an empty secret — same string, and today
+    # that also narrows nothing, but the equivalence is incidental and the
+    # `if:` is what keeps it from mattering.
+    assert _keys_step(steps)["if"] == "env.HAS_TENANT_MATRIX != ''"
+
+
+def test_every_discovery_invocation_is_narrowed(steps: list[dict[str, Any]]) -> None:
+    # tests-reusable.yaml calls the action twice — the suite × cloud matrix and
+    # the cloud-only matrix prepare-tenant installs from. A narrowing applied to
+    # one and not the other means preparing a tenant for a cloud no leg runs on,
+    # or worse, running legs on a cloud nothing installed to.
+    for step in _discover_steps(steps):
+        assert step["with"].get("available-clouds") == _AVAILABLE, (
+            f"`{step.get('name', step['uses'])}` must pass the tenant matrix's "
+            "cloud keys, or its defaulted fan-out still emits legs for clouds "
+            "the secret no longer carries"
+        )
+
+
+def test_the_blob_never_reaches_discovery(steps: list[dict[str, Any]]) -> None:
+    # The key list crosses this boundary; the credentials do not. Only
+    # the per-leg tenant resolver needs them, and it renders exactly one cloud's
+    # entry per leg — the least-privilege property FND-6 built in.
+    #
+    # Naming the secret to test its PRESENCE is fine and is what the `clouds`
+    # expression already does; interpolating its VALUE is not. So every mention
+    # must be a comparison, not a substitution.
+    for step in _discover_steps(steps):
+        for name, value in step["with"].items():
+            for mention in _SECRET_MENTION.finditer(str(value)):
+                assert mention.group("op"), (
+                    f"`{name}` interpolates E2E_TENANT_MATRIX_JSON's VALUE into "
+                    "discovery — pass the cloud key list instead; the payload "
+                    "belongs to the per-leg tenant resolver, which renders one "
+                    "cloud's entry per leg"
+                )
+
+
+def test_the_scripts_checkout_is_pinned_to_this_workflows_sha(
+    steps: list[dict[str, Any]],
+) -> None:
+    # The script is executed, so its provenance is pinned to the workflow file
+    # running it rather than to @main or to a caller-supplied ref. It is also
+    # what makes this change testable on the branch that makes it: an action
+    # pinned @main cannot see a new input until it lands.
+    checkouts = [
+        s
+        for s in steps
+        if str(s.get("uses", "")).startswith("actions/checkout@")
+        and s.get("with", {}).get("repository") == "atlanhq/application-sdk"
+    ]
+    assert len(checkouts) == 1, (
+        "the keys script has to be fetched from the SDK: the cloud-planning job "
+        "checks out the CALLER's tree, which has no .github/scripts of ours"
+    )
+    with_ = checkouts[0]["with"]
+    assert with_["ref"] == "${{ job.workflow_sha }}"
+    assert with_["path"] == "application-sdk-scripts"
+    assert with_["sparse-checkout"] == ".github/scripts"
+    assert with_["persist-credentials"] is False

--- a/.github/scripts/tests/test_e2e_tenant_matrix_clouds.py
+++ b/.github/scripts/tests/test_e2e_tenant_matrix_clouds.py
@@ -1,0 +1,108 @@
+"""Tests for .github/scripts/e2e_tenant_matrix_clouds.py (FND-354).
+
+The script is the only thing that reads ``E2E_TENANT_MATRIX_JSON`` outside the
+per-leg resolver, so two properties matter more than the parsing: it emits KEYS
+and never values, and an unusable payload degrades to "not known" rather than
+failing the run out from under the resolver's precise per-leg diagnosis.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from e2e_tenant_matrix_clouds import MatrixCloudsError, cloud_keys, main  # noqa: E402
+
+_SECRET = "s3cr3t-client-secret"
+_MATRIX = {
+    "aws": {
+        "tenant": "tenant-a.example.com",
+        "client_id": "id-a",
+        "client_secret": _SECRET,
+        "api_key": "key-a",
+    },
+    "gcp": {
+        "tenant": "tenant-b.example.com",
+        "client_id": "id-b",
+        "client_secret": _SECRET,
+        "api_key": "key-b",
+    },
+}
+
+
+def _clouds(out: str) -> str:
+    line = next(ln for ln in out.splitlines() if ln.startswith("clouds="))
+    return line[len("clouds=") :]
+
+
+def test_returns_the_cloud_keys_sorted() -> None:
+    assert cloud_keys(json.dumps({"gcp": {}, "aws": {}, "azure": {}})) == [
+        "aws",
+        "azure",
+        "gcp",
+    ]
+
+
+def test_empty_payload_yields_no_keys() -> None:
+    # The secret is not shared with this repo; the caller already collapses the
+    # cloud dimension to "none" in that case.
+    assert cloud_keys("") == []
+    assert cloud_keys("   ") == []
+
+
+def test_a_key_counts_as_available_even_with_a_broken_entry() -> None:
+    # Presence, not validity. A cloud whose entry is missing client_secret is a
+    # coverage hole that must stay red — the per-leg tenant resolver names the
+    # missing field per leg. Narrowing it away here would turn that red into a
+    # run that looks complete and is not.
+    assert cloud_keys(json.dumps({"aws": {}, "gcp": None})) == ["aws", "gcp"]
+
+
+@pytest.mark.parametrize("payload", ["{not json", '["aws"]', '"aws"', "42"])
+def test_unusable_payloads_raise(payload: str) -> None:
+    with pytest.raises(MatrixCloudsError):
+        cloud_keys(payload)
+
+
+def test_main_prints_the_keys_as_a_github_output(capsys) -> None:
+    rc = main(["--matrix-json", json.dumps(_MATRIX)])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert _clouds(out) == "aws,gcp"
+
+
+def test_main_never_prints_a_credential(capsys) -> None:
+    main(["--matrix-json", json.dumps(_MATRIX)])
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err
+    for value in ("id-a", "key-a", "tenant-a.example.com", _SECRET):
+        assert value not in combined, (
+            "only cloud KEYS may cross this boundary — stdout here is redirected "
+            "into $GITHUB_OUTPUT and stderr is the run log, and neither is masked "
+            "for a value extracted out of a registered blob"
+        )
+
+
+def test_main_degrades_to_no_keys_and_warns_on_a_bad_payload(capsys) -> None:
+    # Exit 0 with an empty list, deliberately: empty means "not known",
+    # discovery then narrows nothing, and the run behaves exactly as it did
+    # before FND-354 — including the per-leg resolver error, which is the one
+    # that can name the actual defect in the secret.
+    rc = main(["--matrix-json", '{"aws": '])
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert _clouds(captured.out) == ""
+    assert "::warning::" in captured.err
+
+
+def test_main_does_not_echo_the_payload_when_it_cannot_be_parsed(capsys) -> None:
+    # A malformed blob is still a blob full of credentials. The decode error's
+    # position is quotable; its content is not.
+    main(["--matrix-json", '{"aws": {"client_secret": "' + _SECRET + '"'])
+    captured = capsys.readouterr()
+    assert _SECRET not in captured.out + captured.err

--- a/.github/scripts/tests/test_resolve_e2e_tenant.py
+++ b/.github/scripts/tests/test_resolve_e2e_tenant.py
@@ -295,11 +295,24 @@ _CALL_SITE_SUFFIXES = ("*.y*ml", "*.sh", "*.py")
 # test_export_extra_env.py: it names this module in its own `_NOT_A_CALLER`
 # exclusion (the twin guard has to know this one exists), which is a live
 # non-comment mention but never an invocation.
+#
+# The two FND-354 scripts name this module for the opposite reason: each states
+# in its own docstring that it handles cloud KEYS and never credentials, and
+# that this module remains the only thing that sees a tenant's entry. They are
+# the *statement* of that boundary, so an invocation appearing in either would
+# contradict the file it sits in — which is the reviewer's cue, since the
+# exclusion itself would hide it from this guard. Kept to the two files whose
+# prose carries the crux; everything else in FND-354 refers to "the per-leg
+# tenant resolver" instead, precisely so it stays inside this net.
 _NOT_A_CALLER = frozenset(
     {
         _MODULE_PATH.resolve(),
         Path(__file__).resolve(),
         (Path(__file__).parent / "test_export_extra_env.py").resolve(),
+        (
+            _REPO_ROOT / ".github/actions/discover-e2e-suites/discover_e2e_suites.py"
+        ).resolve(),
+        (_REPO_ROOT / ".github/scripts/e2e_tenant_matrix_clouds.py").resolve(),
     }
 )
 

--- a/.github/workflows/e2e-full-reusable.yaml
+++ b/.github/workflows/e2e-full-reusable.yaml
@@ -193,10 +193,14 @@ on:
           so the cloud is the only matrix dimension.
 
           Empty (the default) means the SDK's current cloud list, which lives in
-          discover_e2e_suites.py's DEFAULT_CLOUDS. Pass "none" to collapse back
-          to the single legacy tenant. Forced to "none" when
-          E2E_TENANT_MATRIX_JSON is not available to the calling repo, which
-          keeps un-onboarded repos on today's behaviour.
+          discover_e2e_suites.py's DEFAULT_CLOUDS, intersected with the clouds
+          E2E_TENANT_MATRIX_JSON actually carries — so dropping a cloud from the
+          secret takes it out of the rotation fleet-wide (FND-354). A cloud
+          named here explicitly is never narrowed away: it fails its leg, since
+          naming it asserts it should run. Pass "none" to collapse back to the
+          single legacy tenant. Forced to "none" when E2E_TENANT_MATRIX_JSON is
+          not available to the calling repo, which keeps un-onboarded repos on
+          today's behaviour.
         required: false
         type: string
         default: ""
@@ -259,11 +263,42 @@ jobs:
         with:
           persist-credentials: false
 
+      # ── Which clouds the secret actually carries (FND-354) ─────────────────
+      # See tests-reusable.yaml's equivalent pair for why this is a sparse
+      # checkout at `job.workflow_sha` rather than another @main action, and why
+      # only the KEY LIST crosses into discovery. No `token:` here: this
+      # workflow declares no ORG_PAT_GITHUB, and application-sdk is public, so
+      # the caller's default token reads it.
+      - name: Fetch SDK CI scripts (tenant-matrix cloud keys)
+        if: env.HAS_TENANT_MATRIX != ''
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: atlanhq/application-sdk
+          ref: ${{ job.workflow_sha }}
+          sparse-checkout: .github/scripts
+          sparse-checkout-cone-mode: false
+          path: application-sdk-scripts
+          persist-credentials: false
+
+      - name: Read the tenant matrix's cloud keys
+        id: matrix-clouds
+        if: env.HAS_TENANT_MATRIX != ''
+        env:
+          E2E_TENANT_MATRIX_JSON: ${{ secrets.E2E_TENANT_MATRIX_JSON }}
+        run: |
+          set -euo pipefail
+          python3 application-sdk-scripts/.github/scripts/e2e_tenant_matrix_clouds.py \
+            --matrix-json "$E2E_TENANT_MATRIX_JSON" >> "$GITHUB_OUTPUT"
+
       - name: Plan clouds
         id: plan
         uses: atlanhq/application-sdk/.github/actions/discover-e2e-suites@main
         with:
           clouds-only: "true"
+          # Narrows the DEFAULTED cloud list to what the secret carries, so a
+          # cloud removed from E2E_TENANT_MATRIX_JSON drops out of the rotation
+          # instead of reding its leg. An explicitly named cloud still fails.
+          available-clouds: ${{ steps.matrix-clouds.outputs.clouds }}
           # Without the tenant map every leg would resolve the same fallback
           # tenant, so N legs would masquerade as N clouds of coverage. Written
           # negated for the same reason as in tests-reusable.yaml: "" is falsy in

--- a/.github/workflows/tests-reusable.yaml
+++ b/.github/workflows/tests-reusable.yaml
@@ -163,11 +163,17 @@ on:
           discover_e2e_suites.py's DEFAULT_CLOUDS — deliberately NOT restated
           here, so adding a fourth CSP is one edit rather than one per repo, and
           so an app forwarding an untouched dispatch input doesn't opt out of
-          the matrix by accident.
+          the matrix by accident — intersected with the clouds the tenant secret
+          actually carries (FND-354). Removing a cloud's entry from
+          E2E_TENANT_MATRIX_JSON is therefore the fleet-wide way to take it out
+          of the rotation while its tenant is down: one secret edit, no PR,
+          effective next run, and warned about in the log of every run it
+          narrows. A cloud named HERE is never narrowed away — it reaches the
+          per-leg resolver and fails there, because naming it asserts it should
+          run.
 
           Narrow it to re-run one cloud ("aws"), or pass "none" to collapse back
-          to the single legacy tenant — the escape hatch when a tenant is down
-          and the fleet should not be blocked on it. Forced to "none" when
+          to the single legacy tenant. Forced to "none" when
           E2E_TENANT_MATRIX_JSON is not shared with the calling repo, which is
           what keeps un-onboarded repos on their existing behaviour.
       timeout-minutes:
@@ -935,11 +941,52 @@ jobs:
         with:
           persist-credentials: false
 
+      # ── Which clouds the secret actually carries (FND-354) ─────────────────
+      # Sparse-checked-out rather than folded into the discover action, and
+      # `ref: job.workflow_sha` rather than @main, for the reason the source-
+      # credential export gives at length: an action pinned @main cannot see a
+      # change until it lands, whereas a script pulled at the workflow's own SHA
+      # is testable on the branch that changes it. `repository:` stays hardcoded
+      # so the executed payload's provenance is pinned; application-sdk is
+      # public, so the caller's default token reads it when ORG_PAT_GITHUB is
+      # not shared.
+      - name: Fetch SDK CI scripts (tenant-matrix cloud keys)
+        if: env.HAS_TENANT_MATRIX != ''
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: atlanhq/application-sdk
+          ref: ${{ job.workflow_sha }}
+          sparse-checkout: .github/scripts
+          sparse-checkout-cone-mode: false
+          path: application-sdk-scripts
+          token: ${{ secrets.ORG_PAT_GITHUB || github.token }}
+          persist-credentials: false
+
+      # The KEY LIST, never the blob: the credentials stay with the per-leg
+      # resolver, which is the only thing that needs them. Skipped without the
+      # secret, and a skipped step's output is "" — which discovery reads as
+      # "not known" and narrows nothing, the same as before FND-354.
+      - name: Read the tenant matrix's cloud keys
+        id: matrix-clouds
+        if: env.HAS_TENANT_MATRIX != ''
+        env:
+          E2E_TENANT_MATRIX_JSON: ${{ secrets.E2E_TENANT_MATRIX_JSON }}
+        run: |
+          set -euo pipefail
+          python3 application-sdk-scripts/.github/scripts/e2e_tenant_matrix_clouds.py \
+            --matrix-json "$E2E_TENANT_MATRIX_JSON" >> "$GITHUB_OUTPUT"
+
       - name: Discover suites
         id: discover
         uses: atlanhq/application-sdk/.github/actions/discover-e2e-suites@main
         with:
           test-dir: ${{ inputs.e2e-test-path }}
+          # Narrows the DEFAULTED cloud list to what the secret carries, so
+          # dropping a cloud from E2E_TENANT_MATRIX_JSON takes it out of the
+          # rotation fleet-wide instead of reding one leg in every repo that
+          # runs e2e. A cloud named explicitly in e2e-clouds is NOT narrowed —
+          # it reaches the resolver and still fails there. FND-354.
+          available-clouds: ${{ steps.matrix-clouds.outputs.clouds }}
           # The cloud dimension is only meaningful when the tenant map exists;
           # without it every leg would resolve the same fallback tenant, so N
           # identical runs would masquerade as N clouds of coverage. Collapsing
@@ -969,6 +1016,11 @@ jobs:
         with:
           clouds-only: "true"
           clouds: ${{ secrets.E2E_TENANT_MATRIX_JSON == '' && 'none' || inputs.e2e-clouds }}
+          # Same narrowing as the full matrix above, from the same step output:
+          # prepare-tenant must install onto exactly the clouds the legs then
+          # run against, and a cloud it prepared but no leg used (or vice versa)
+          # is the drift the duplicated `clouds` expression already guards.
+          available-clouds: ${{ steps.matrix-clouds.outputs.clouds }}
 
       # A repo that has not been granted the tenant-matrix secret silently gets
       # one cloud's worth of coverage from a workflow that asked for three.

--- a/docs/standards/connector-ci-e2e.md
+++ b/docs/standards/connector-ci-e2e.md
@@ -174,7 +174,10 @@ One secret rather than four per cloud because a `strategy.matrix` value cannot
 index the `secrets` context, and the reusable workflows declare their
 `workflow_call` secrets explicitly — so per-cloud names would have to be
 re-declared for every cloud ever added. Adding a fourth CSP is a secret edit and
-a one-line change to `DEFAULT_CLOUDS`; no app repo changes at all.
+a one-line change to `DEFAULT_CLOUDS`; no app repo changes at all. Both halves
+are needed to *add* one — the narrowing below is an intersection, never a union,
+so a key appearing in the secret does not widen the fleet's fan-out behind
+`DEFAULT_CLOUDS`'s back. Removing a cloud needs only the secret edit.
 
 `"tenant_id"` is the tenant's **vcluster instance name** (`markeznp37`, `home-mt`)
 — *not* its hostname, which is what `"tenant"` holds. It is required only by the
@@ -250,18 +253,42 @@ on each app's `tests.yaml`:
 
 | Value | Meaning |
 |---|---|
-| `""` (default) | The SDK's current list — `DEFAULT_CLOUDS` in `discover_e2e_suites.py`. Deliberately not "no clouds": an untouched GitHub input arrives as `""`, and that must not silently opt a repo out. |
-| `aws` (or any subset) | Just those clouds. Use this to re-run one cloud, or to keep the fleet moving while one tenant is down. |
+| `""` (default) | The SDK's current list — `DEFAULT_CLOUDS` in `discover_e2e_suites.py` — **intersected with the clouds `E2E_TENANT_MATRIX_JSON` actually carries**. Deliberately not "no clouds": an untouched GitHub input arrives as `""`, and that must not silently opt a repo out. |
+| `aws` (or any subset) | Just those clouds, for re-running one cloud on one repo. Exact, and never narrowed: a named cloud the secret does not carry fails its leg. |
 | `none` | No cloud dimension — one leg against the single fallback tenant. |
 
 Every cloud is a **required** leg: the matrix is `fail-fast: false` and the Tests
 Gate reads `needs.e2e.result`, the matrix aggregate, so any cloud failing reds the
-gate. Narrowing `e2e-clouds` is the escape hatch, and trimming the secret to one
-key is the org-wide one.
+gate.
+
+### Taking a cloud out of the rotation
+
+**Remove its entry from `E2E_TENANT_MATRIX_JSON`.** That is the whole hatch: one
+secret edit, fleet-wide, effective on the next run, no connector PR and no SDK
+PR. The `Discover e2e suites` job reads the secret's *keys* (never its values —
+`e2e_tenant_matrix_clouds.py` emits a key list and nothing else), hands them to
+discovery, and the defaulted fan-out narrows to the intersection with a
+`::warning::` naming every cloud it dropped. A run that got two clouds when the
+SDK ships three says so in its own log.
+
+Defaulted narrows; **named does not**. `e2e-clouds: aws,azure` naming a cloud the
+secret does not carry still reaches `resolve_e2e_tenant.py` and still exits
+non-zero — somebody asserted that cloud should run, and skipping it silently
+would be a coverage hole rather than a narrowing. The asymmetry is deliberate and
+is pinned by `test_a_defaulted_absent_cloud_is_dropped_with_a_warning` /
+`test_a_named_absent_cloud_still_reaches_the_resolver`; it is the kind of
+distinction a later reader flattens on the grounds that both paths "just check
+the cloud list" (FND-354).
+
+Narrowing to *nothing* is an error, not an empty matrix: a secret carrying none
+of `DEFAULT_CLOUDS` fails discovery rather than emitting zero legs, which would
+green the gate having run no e2e at all.
 
 When the secret is not available to a repo, `clouds` is forced to `none` and the
 `Discover e2e suites` job emits a `::warning::` saying so — a run that asked for
-three clouds and got one must not look identical to one that got three.
+three clouds and got one must not look identical to one that got three. The same
+applies when the payload cannot be parsed: the key read degrades to "not known",
+narrowing is skipped, and the per-leg resolver still reports the real defect.
 
 ### Requiring a tenant ID on the install path
 


### PR DESCRIPTION
Closes FND-354.

Dropping a cloud from `E2E_TENANT_MATRIX_JSON` is the only cloud-rotation lever that is fleet-wide, needs no connector PR, and takes effect on the next run — which is exactly what an operator reaches for when that cloud's tenant is down. It did the opposite. `discover_e2e_suites.py` never saw the secret, so `--clouds ""` (what every repo sends, since `e2e-clouds` defaults to empty) always expanded to `DEFAULT_CLOUDS`, and `resolve_e2e_tenant.py` then hard-failed the leg for the removed cloud **in every e2e-running repo**.

## The fix

`parse_clouds(raw, available)` now distinguishes a **defaulted** cloud list from a **named** one, because the right behaviour differs:

| `--clouds` | cloud absent from the secret | why |
| --- | --- | --- |
| `""` (defaulted) | dropped, with a `::warning::` naming it | nobody asked for that cloud — `DEFAULT_CLOUDS` did |
| `aws,azure` (named) | passed through, leg still fails | somebody asserted that cloud should run; a silent skip is a coverage hole |

Two further properties:

- **Intersection, never union.** A fourth key appearing in the secret does not widen the fleet's fan-out behind `DEFAULT_CLOUDS`'s back. Removing a cloud is now the secret edit alone; adding one still needs both.
- **Narrowing to nothing is an error, not an empty matrix.** `count` is the *suite* count, so zero legs would sail past the "requested but nothing found" guard and green the gate having run no e2e at all.

## Getting the keys to discovery

New `.github/scripts/e2e_tenant_matrix_clouds.py`: the payload goes in, one comma-separated list of **key names** comes out, and nothing else. Discovery is handed the key list, never the blob, so the only script that can see a tenant credential remains `resolve_e2e_tenant.py` — which renders exactly one cloud's entry per leg.

A key counts as available because it is *present*, not because its entry is well-formed: a cloud whose entry is missing `client_secret` is a coverage hole that must stay red, and the per-leg resolver already reports it precisely.

## Two judgement calls

1. **Sparse checkout at `job.workflow_sha`, not a second `@main` composite action.** A new action referenced `@main` would not exist on main until this lands, so `discover-e2e` / `plan-clouds` would fail hard on this very branch. The existing source-credential-export pattern has neither problem and keeps the logic in a pytest'd script per `docs/standards/ci.md`. Note the new `available-clouds` **action input** is still `@main`-pinned, so the narrowing itself only takes effect once this merges — a soft no-op on the branch, not a breakage.
2. **A malformed payload degrades to "not known" rather than failing discovery.** Empty keys → narrow nothing → exactly today's behaviour, including the per-leg resolver error, which is the message that can actually name the defect in the secret. Failing at discovery would replace a precise diagnosis with one that knows strictly less.

## Guards

The defaulted/named asymmetry is the kind a later reader flattens on the grounds that both paths "just check the cloud list", so both directions are pinned:

- `test_a_defaulted_absent_cloud_is_dropped_with_a_warning` / `test_a_named_absent_cloud_still_reaches_the_resolver`
- no-widening, unknown-availability, and empty-intersection-errors
- `test_e2e_cloud_narrowing_wiring.py` parametrises over **both** reusables and asserts every discovery invocation is narrowed, and that the secret's *value* never crosses into discovery (a presence test on it is allowed; interpolating it is not)

Three new prose mentions of `resolve_e2e_tenant` tripped its call-site audit. Reworded all but the two module docstrings where the name is the crux; those two are added to `_NOT_A_CALLER` with the reasoning, so the guard stays as tight as it was everywhere else.

## Also in this PR

- Both reusables wired, including `tests-reusable.yaml`'s cloud-only invocation that `prepare-tenant` installs from — a cloud prepared but not run (or run but not prepared) is exactly the drift the duplicated `clouds` expression already guards.
- `resolve_e2e_tenant.py`'s error message no longer claims the leg's cloud was named in `e2e-clouds` when in the universal empty-input case it was not.
- `docs/standards/connector-ci-e2e.md`: new "Taking a cloud out of the rotation" section.

## Verification

1990 CI-script tests pass; pre-commit clean (ruff, isort, pyright, check-yaml).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
