### PR TITLE
ci(pulse): probe and report Tests Gate enforcement state across the fleet (FND-349)

### DIFF
--- a/.github/scripts/detect_merge_queue.py
+++ b/.github/scripts/detect_merge_queue.py
@@ -119,20 +119,21 @@ def ref_matches(patterns: list, base_ref: str, default_branch: str) -> bool:
     return False
 
 
-def governs_branch(ruleset: dict, base_ref: str, default_branch: str) -> bool:
-    """Whether one *expanded* ruleset puts ``base_ref`` behind a merge queue."""
+def targets_branch(ruleset: dict, base_ref: str, default_branch: str) -> bool:
+    """Whether one *expanded* ruleset is live and applies to ``base_ref``.
+
+    The rule-type-agnostic half of ruleset matching: active enforcement, branch
+    target, and ``conditions.ref_name`` covering the branch. Callers add their
+    own rule-type test on top — ``governs_branch`` below asks for a merge queue;
+    ``gate_enforcement_scan.py`` asks for required status checks and pull
+    requests. Kept as one function so the two readers cannot drift on what
+    "this ruleset applies here" means.
+    """
     if not isinstance(ruleset, dict):
         return False
     if ruleset.get("enforcement") != _ACTIVE:
         return False
     if ruleset.get("target") != _BRANCH_TARGET:
-        return False
-
-    rules = ruleset.get("rules") or []
-    if not any(
-        isinstance(rule, dict) and rule.get("type") == _MERGE_QUEUE_RULE
-        for rule in rules
-    ):
         return False
 
     ref_name = ((ruleset.get("conditions") or {}).get("ref_name")) or {}
@@ -145,6 +146,18 @@ def governs_branch(ruleset: dict, base_ref: str, default_branch: str) -> bool:
     if ref_matches(exclude, base_ref, default_branch):
         return False
     return ref_matches(include, base_ref, default_branch)
+
+
+def governs_branch(ruleset: dict, base_ref: str, default_branch: str) -> bool:
+    """Whether one *expanded* ruleset puts ``base_ref`` behind a merge queue."""
+    if not targets_branch(ruleset, base_ref, default_branch):
+        return False
+
+    rules = ruleset.get("rules") or []
+    return any(
+        isinstance(rule, dict) and rule.get("type") == _MERGE_QUEUE_RULE
+        for rule in rules
+    )
 
 
 def _load(raw: str):

--- a/.github/scripts/gate_enforcement_scan.py
+++ b/.github/scripts/gate_enforcement_scan.py
@@ -826,8 +826,15 @@ def parse_arrival_nodes(payload: dict, required_context: str) -> list:
             ctx = _expect_object(ctx_node, f"{where}.contexts.nodes[{ctx_index}]")
             if ctx is None:
                 continue
-            # CheckRun exposes `name`, StatusContext exposes `context`.
-            name = ctx.get("name") or ctx.get("context")
+            # CheckRun exposes `name`, StatusContext exposes `context`. Select
+            # by *presence*, not truthiness: an `or`-chain would collapse a
+            # present-but-falsy leaf (`0`, `False`, `[]`, `{}`) to the fallback
+            # or to `None`, skipping it as "absent" — a wrong-typed leaf then
+            # silently reads as `found: False`, the false clean negative the
+            # fail-loud contract forbids.
+            name = ctx.get("name")
+            if name is None:
+                name = ctx.get("context")
             if name is None:
                 continue
             if not isinstance(name, str):

--- a/.github/scripts/gate_enforcement_scan.py
+++ b/.github/scripts/gate_enforcement_scan.py
@@ -723,52 +723,135 @@ query($owner: String!, $name: String!, $base: String!, $first: Int!) {
 """
 
 
+def _expect_object(value, path: str, *, required: bool = False) -> Optional[dict]:
+    """The value at ``path`` as a dict, or ``None`` for a JSON null.
+
+    GraphQL returns every field it was asked for, so a *null* is the schema's
+    own "nothing here" and a legitimate skip at the nested levels (a pull
+    request with no commits, a commit with no checks). ``required=True`` is for
+    the spine of the response, where a null means the read failed.
+
+    A present-but-wrong-typed value is schema drift, and it must raise here.
+    Walking it with ``(value or {}).get(...)`` instead raises ``AttributeError``
+    deep in the chain — which ``scan_repo`` does not catch, so one malformed
+    body would abort the entire fleet sweep rather than marking that one repo
+    ``unknown``. That is the same false-green-by-abort the fail-loud contract
+    exists to prevent, one level down.
+    """
+    if value is None:
+        if required:
+            raise GhError(f"malformed arrival payload: {path} is null")
+        return None
+    if not isinstance(value, dict):
+        raise GhError(
+            f"malformed arrival payload: expected {path} to be an object, "
+            f"got {type(value).__name__}"
+        )
+    return value
+
+
+def _expect_list(value, path: str, *, required: bool = False) -> list:
+    """The value at ``path`` as a list; ``[]`` for a JSON null. See _expect_object."""
+    if value is None:
+        if required:
+            raise GhError(f"malformed arrival payload: {path} is null")
+        return []
+    if not isinstance(value, list):
+        raise GhError(
+            f"malformed arrival payload: expected {path} to be a list, "
+            f"got {type(value).__name__}"
+        )
+    return value
+
+
 def parse_arrival_nodes(payload: dict, required_context: str) -> list:
     """Turn a GraphQL arrival response into ``{found, truncated}`` samples.
 
     One query per repo rather than one per pull request: the fleet sweep is
     already O(repos) on the REST side, and fanning arrival out per PR would
     multiply that by the sample size for no extra signal.
+
+    Every level is shape-checked on the way down, so "malformed" reaches the
+    caller as a ``GhError`` — and therefore as arrival ``unknown`` for that one
+    repo — structurally, rather than depending on each level remembering to
+    guard itself.
     """
-    repository = ((payload or {}).get("data") or {}).get("repository")
-    pull_requests = (
-        repository.get("pullRequests") if isinstance(repository, dict) else None
+    root = _expect_object(payload, "response", required=True)
+    data = _expect_object(root.get("data"), "data", required=True)
+    repository = _expect_object(
+        data.get("repository"), "data.repository", required=True
     )
-    if not isinstance(pull_requests, dict) or not isinstance(
-        pull_requests.get("nodes"), list
-    ):
-        # A structurally malformed body (schema drift, a null repository) must
-        # surface as arrival `unknown` — coercing it to zero samples would read
-        # as a clean "no PRs had the context" instead of "we could not read it".
-        raise GhError(
-            "malformed arrival payload: expected "
-            "data.repository.pullRequests.nodes to be a list"
-        )
-    nodes = pull_requests["nodes"]
+    pull_requests = _expect_object(
+        repository.get("pullRequests"), "data.repository.pullRequests", required=True
+    )
+    nodes = _expect_list(
+        pull_requests.get("nodes"),
+        "data.repository.pullRequests.nodes",
+        required=True,
+    )
+
     samples: list = []
-    for pr in nodes:
-        if not isinstance(pr, dict):
+    for index, node in enumerate(nodes):
+        where = f"pullRequests.nodes[{index}]"
+        pr = _expect_object(node, where)
+        if pr is None:
             continue
-        commits = ((pr.get("commits") or {}).get("nodes")) or []
-        if not commits:
+
+        commits = _expect_object(pr.get("commits"), f"{where}.commits")
+        commit_nodes = _expect_list(
+            commits.get("nodes") if commits else None, f"{where}.commits.nodes"
+        )
+        if not commit_nodes:
             continue
-        rollup = ((commits[0] or {}).get("commit") or {}).get("statusCheckRollup")
-        if not rollup:
+
+        head = _expect_object(commit_nodes[0], f"{where}.commits.nodes[0]")
+        commit = _expect_object(
+            head.get("commit") if head else None, f"{where}.commits.nodes[0].commit"
+        )
+        rollup = _expect_object(
+            commit.get("statusCheckRollup") if commit else None,
+            f"{where}.statusCheckRollup",
+        )
+        if rollup is None:
             # No checks ran on the head commit at all — carries no information
             # about whether the gate would have arrived.
             continue
-        contexts = rollup.get("contexts") or {}
-        names = {
-            (ctx.get("name") or ctx.get("context"))
-            for ctx in contexts.get("nodes") or []
-            if isinstance(ctx, dict)
-        }
-        total = contexts.get("totalCount") or 0
+
+        contexts = _expect_object(rollup.get("contexts"), f"{where}.contexts")
+        context_nodes = _expect_list(
+            contexts.get("nodes") if contexts else None, f"{where}.contexts.nodes"
+        )
+        names = set()
+        for ctx_index, ctx_node in enumerate(context_nodes):
+            ctx = _expect_object(ctx_node, f"{where}.contexts.nodes[{ctx_index}]")
+            if ctx is None:
+                continue
+            # CheckRun exposes `name`, StatusContext exposes `context`.
+            name = ctx.get("name") or ctx.get("context")
+            if name is not None:
+                names.add(name)
+
+        total = (contexts or {}).get("totalCount")
+        if total is None:
+            total = 0
+        if not isinstance(total, int) or isinstance(total, bool):
+            raise GhError(
+                f"malformed arrival payload: expected {where}.contexts.totalCount "
+                f"to be an integer, got {type(total).__name__}"
+            )
+
         samples.append(
             {
                 "number": pr.get("number"),
                 "found": required_context in names,
-                "truncated": total > len(names),
+                # Compare against the nodes actually returned, NOT the distinct
+                # names: a commit routinely carries the same context several
+                # times (a bot PR stacks 5-7 gate runs on one SHA, all but the
+                # newest cancelled), so the deduplicated set is smaller than
+                # totalCount even when nothing was truncated. Measuring against
+                # the set marked most busy repos truncated, which quietly
+                # converted real never-arriving evidence into `unknown`.
+                "truncated": total > len(context_nodes),
             }
         )
     return samples

--- a/.github/scripts/gate_enforcement_scan.py
+++ b/.github/scripts/gate_enforcement_scan.py
@@ -828,8 +828,22 @@ def parse_arrival_nodes(payload: dict, required_context: str) -> list:
                 continue
             # CheckRun exposes `name`, StatusContext exposes `context`.
             name = ctx.get("name") or ctx.get("context")
-            if name is not None:
-                names.add(name)
+            if name is None:
+                continue
+            if not isinstance(name, str):
+                # The leaf analogue of the container guards above: a present-
+                # but-wrong-typed `name`/`context` is schema drift, and must
+                # reach the caller as GhError rather than aborting the sweep
+                # (an unhashable list/dict raises an uncaught TypeError in
+                # `names.add`, which `scan_repo` does not catch) or silently
+                # misclassifying (a hashable int/bool never matches the
+                # required-context string, reading as a false `found: False`).
+                raise GhError(
+                    f"malformed arrival payload: expected "
+                    f"{where}.contexts.nodes[{ctx_index}].name/context to be a "
+                    f"string, got {type(name).__name__}"
+                )
+            names.add(name)
 
         total = (contexts or {}).get("totalCount")
         if total is None:

--- a/.github/scripts/gate_enforcement_scan.py
+++ b/.github/scripts/gate_enforcement_scan.py
@@ -649,10 +649,18 @@ def fetch_rulesets(repo: str, run: RunFn = _run_gh) -> list:
     expanded: list = []
     for entry in listing:
         if not isinstance(entry, dict) or entry.get("id") is None:
-            continue
+            raise GhError(f"malformed ruleset list entry for {repo}: {entry!r}")
         detail = _load_json(run(["api", f"repos/{repo}/rulesets/{entry['id']}"]))
-        if isinstance(detail, dict):
-            expanded.append(detail)
+        if not isinstance(detail, dict):
+            # A failed or malformed detail read must not read as "this ruleset
+            # does not exist": evaluating the repo on a partially-expanded list
+            # is the false green this scanner exists to prevent. Propagate so
+            # scan_repo records the repo `unknown`.
+            raise GhError(
+                f"could not expand ruleset {entry['id']} for {repo}: "
+                "detail fetch failed or returned a non-object"
+            )
+        expanded.append(detail)
     return expanded
 
 
@@ -722,8 +730,18 @@ def parse_arrival_nodes(payload: dict, required_context: str) -> list:
     already O(repos) on the REST side, and fanning arrival out per PR would
     multiply that by the sample size for no extra signal.
     """
-    repository = ((payload or {}).get("data") or {}).get("repository") or {}
-    nodes = ((repository.get("pullRequests") or {}).get("nodes")) or []
+    repository = ((payload or {}).get("data") or {}).get("repository")
+    if not isinstance(repository, dict) or not isinstance(
+        (repository.get("pullRequests") or {}).get("nodes"), list
+    ):
+        # A structurally malformed body (schema drift, a null repository) must
+        # surface as arrival `unknown` — coercing it to zero samples would read
+        # as a clean "no PRs had the context" instead of "we could not read it".
+        raise GhError(
+            "malformed arrival payload: expected "
+            "data.repository.pullRequests.nodes to be a list"
+        )
+    nodes = repository["pullRequests"]["nodes"]
     samples: list = []
     for pr in nodes:
         if not isinstance(pr, dict):

--- a/.github/scripts/gate_enforcement_scan.py
+++ b/.github/scripts/gate_enforcement_scan.py
@@ -1,0 +1,964 @@
+#!/usr/bin/env python3
+"""Probe whether the Tests Gate is actually *enforced* on each fleet repo, and
+emit the result as dashboard data connector-pulse can ingest.
+
+Why this exists (FND-349). Conformance detection reads repo **files**. Whether a
+status check is required — and whether it can be bypassed — is not a file; it
+lives in GitHub settings. So the one property the "enforce the test gate" work
+asserts is the one property the fleet's own drift detector cannot see. Without a
+settings probe it would be established once and then trusted forever: a repo can
+lose enforcement in one settings page, or be recreated without it, and nothing
+anywhere would report it. Silence would read exactly like compliance.
+
+This closes that hole by answering three questions per repo, on the same cadence
+as every other fleet finding:
+
+1. Is the gate context a **required** status check on the default branch?
+2. Is it **bypassable** — bypass actors on the ruleset, or a default branch that
+   does not require a pull request at all (direct push skips the check)?
+3. Is the check **actually arriving** on pull requests, or configured-but-never-
+   reporting? That third state blocks every PR with nothing red to point at, and
+   the pressure it creates is to *remove* the requirement — so it has to be
+   distinguishable from healthy enforcement rather than lumped in with it.
+
+Enumerating the fleet here (rather than having each repo self-report) is the
+whole point: a repo that has lost enforcement is *present in the output* with
+``gated: false``, instead of quietly dropping out of a dashboard built from
+whoever happened to publish. Absence of a repo means discovery failed, and that
+is itself reported.
+
+Reads, never writes. ``/repos/{repo}/rulesets`` is not administration-gated —
+``detect_merge_queue.py`` has relied on exactly that in every consumer's CI — so
+the ruleset path needs no new privilege. Classic branch protection *is* admin-
+gated; a 403 there is recorded as ``unknown`` rather than silently folded into
+"not protected", because those two mean opposite things.
+
+**Fail-loud, unlike detect_merge_queue.py.** That script fails open because a
+misdetection there costs a redundant test run. Here a misdetection would report
+an ungated repo as gated — the exact false-green this issue exists to prevent —
+so every unreadable repo lands in the output as ``status: "unknown"`` with the
+error attached, and the fleet rollup counts it separately from ``not-gated``.
+Nothing is inferred from a failed read.
+
+Output mirrors the Renovate fleet dashboard layout (``repos/<slug>.json`` +
+``fleet.json`` + append-only ``history_*.jsonl``, camelCase on the wire) so the
+existing Kryptonite deploy shape applies unchanged and connector-pulse sees one
+serialization convention across all three fleet artifacts.
+
+Extracted per docs/standards/ci.md (no branching logic in workflow ``run:``
+blocks); unit-tested in tests/test_gate_enforcement_scan.py.
+
+Environment:
+    GH_TOKEN   bearer token for the `gh` CLI. Needs repo read across the fleet
+               (the atlan-app-fleet App installation token is enough).
+
+Usage:
+    gate_enforcement_scan.py --owner atlanhq --out /tmp/gate-enforcement
+    gate_enforcement_scan.py --repos-file repos.json --out /tmp/gate-enforcement
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable, Optional
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from detect_merge_queue import targets_branch  # noqa: E402
+
+RunFn = Callable[[list], str]
+
+# The check the milestone requires. `tests` is the *caller job id* in each
+# consumer's tests.yaml, `Tests Gate` the job name inside the reusable — GitHub
+# composes the context from those two and does NOT include the workflow name.
+# Getting this wrong reads as "no repo is gated", so it is asserted against a
+# real ruleset payload in the tests rather than trusted from documentation.
+DEFAULT_REQUIRED_CONTEXT = "tests / Tests Gate"
+
+# Fleet membership is the atlan-*-app naming convention, matching
+# discover_org_consumers.py. Deliberately not filtered by "extends the Renovate
+# preset" the way that script is: a repo being off Renovate has no bearing on
+# whether its gate is enforced, and filtering on it would shrink the denominator
+# to flatter the headline number.
+DEFAULT_NAME_PATTERN = r"^atlan-[a-z0-9-]+-app$"
+
+# See discover_org_consumers.REPO_LIST_LIMIT — same cap, same loud warning when
+# the org grows into it, because a silently truncated fleet would understate the
+# ungated count.
+REPO_LIST_LIMIT = 5000
+
+_REQUIRED_STATUS_CHECKS_RULE = "required_status_checks"
+_PULL_REQUEST_RULE = "pull_request"
+
+# GitHub's `bypass_actors[].actor_type` for a GitHub App installation. Called
+# out separately because "no bot can bypass the gate" is an explicit assertion
+# of this milestone, and an App bypass is invisible among role-based entries.
+_INTEGRATION_ACTOR = "Integration"
+
+SCHEMA_VERSION = "1.0"
+
+# Per-repo verdict. Four values, not a boolean, because "we could not read it"
+# must never collapse into "it is not gated" (that would make an outage look
+# like a regression) nor into "it is gated" (a false green).
+STATUS_UNBYPASSABLE = "gated-unbypassable"
+STATUS_BYPASSABLE = "gated-bypassable"
+STATUS_NOT_GATED = "not-gated"
+STATUS_UNKNOWN = "unknown"
+
+# Arrival verdicts for the configured-but-never-reporting state.
+ARRIVAL_REPORTING = "reporting"
+ARRIVAL_INTERMITTENT = "intermittent"
+ARRIVAL_NEVER = "never-arriving"
+ARRIVAL_NO_DATA = "no-data"
+ARRIVAL_UNKNOWN = "unknown"
+
+# Finding ids. Stable strings — connector-pulse groups on them.
+FINDING_NOT_REQUIRED = "gate-not-required"
+FINDING_BYPASSABLE = "gate-bypassable"
+FINDING_BOT_BYPASS = "gate-bot-bypass"
+FINDING_DIRECT_PUSH = "gate-direct-push-permitted"
+FINDING_NOT_ARRIVING = "gate-not-arriving"
+FINDING_UNPRODUCIBLE = "gate-context-unproducible"
+FINDING_UNREADABLE = "gate-state-unreadable"
+
+# The SDK's standard location for the workflow that produces the gate context.
+#
+# Its absence is a *hint*, never a verdict. GitHub composes the context from the
+# caller job id and the reusable's job name, so any workflow file with a `tests`
+# job calling tests-reusable.yaml emits `tests / Tests Gate` — and repos in this
+# fleet do exactly that from differently-named files. Observed arrival on real
+# pull requests is the authoritative signal; this path only corroborates it.
+TESTS_WORKFLOW_PATH = ".github/workflows/tests.yaml"
+
+# Classic-branch-protection states that mean "we could not see it", as opposed
+# to `absent` (a genuine 404) or `present`.
+_CLASSIC_UNREADABLE = frozenset({"forbidden", "unknown"})
+
+
+# ---------------------------------------------------------------------------
+# API seam
+# ---------------------------------------------------------------------------
+
+
+class GhError(RuntimeError):
+    """A `gh` invocation failed. Carries the HTTP status when one is parseable.
+
+    Raised rather than swallowed: this scanner's whole value is that an
+    unreadable repo is reported as unreadable instead of guessed at.
+    """
+
+    def __init__(self, message: str, status: Optional[int] = None) -> None:
+        super().__init__(message)
+        self.status = status
+
+
+_STATUS_RE = re.compile(r"HTTP (\d{3})")
+
+
+def _run_gh(args: list) -> str:
+    """Run `gh` and return stdout; raise GhError with gh's stderr on failure.
+
+    The single seam the tests stub, mirroring detect_merge_queue.py and
+    discover_org_consumers.py — but raising where those return "", because here
+    "no data" and "an error" must not produce the same record.
+    """
+    result = subprocess.run(["gh", *args], capture_output=True, text=True)
+    if result.returncode != 0:
+        stderr = (result.stderr or "").strip()
+        match = _STATUS_RE.search(stderr)
+        raise GhError(
+            f"gh {' '.join(args[:2])} failed: {stderr or 'no stderr'}",
+            status=int(match.group(1)) if match else None,
+        )
+    return result.stdout
+
+
+def _load_json(raw: str):
+    """Parse `gh` JSON output. Returns None for empty/invalid payloads.
+
+    A ``--paginate --slurp`` listing is an array *of page arrays*, so those are
+    flattened one level; anything else passes through for the caller to
+    shape-check.
+    """
+    if not raw.strip():
+        return None
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    if (
+        isinstance(payload, list)
+        and payload
+        and all(isinstance(p, list) for p in payload)
+    ):
+        return [entry for page in payload for entry in page]
+    return payload
+
+
+# ---------------------------------------------------------------------------
+# Pure evaluation
+# ---------------------------------------------------------------------------
+
+
+def required_contexts(ruleset: dict) -> list:
+    """Every status-check context a ruleset requires, in payload order."""
+    contexts: list = []
+    for rule in ruleset.get("rules") or []:
+        if (
+            not isinstance(rule, dict)
+            or rule.get("type") != _REQUIRED_STATUS_CHECKS_RULE
+        ):
+            continue
+        params = rule.get("parameters") or {}
+        for check in params.get("required_status_checks") or []:
+            if isinstance(check, dict) and isinstance(check.get("context"), str):
+                contexts.append(check["context"])
+    return contexts
+
+
+def has_rule(ruleset: dict, rule_type: str) -> bool:
+    return any(
+        isinstance(rule, dict) and rule.get("type") == rule_type
+        for rule in ruleset.get("rules") or []
+    )
+
+
+def strict_policy(ruleset: dict) -> bool:
+    """Whether required checks must be re-run against an up-to-date base.
+
+    Reported but not scored: with a merge queue it is redundant, without one it
+    is the difference between "the gate passed on this code" and "the gate
+    passed on this code six merges ago".
+    """
+    for rule in ruleset.get("rules") or []:
+        if (
+            not isinstance(rule, dict)
+            or rule.get("type") != _REQUIRED_STATUS_CHECKS_RULE
+        ):
+            continue
+        if (rule.get("parameters") or {}).get("strict_required_status_checks_policy"):
+            return True
+    return False
+
+
+def bypass_actors(ruleset: dict) -> list:
+    """Normalise a ruleset's ``bypass_actors`` to the wire shape.
+
+    ``bypass_mode`` matters as much as the actor: ``always`` is a standing
+    exemption, ``pull_request`` only lets the actor skip the rule via a PR that
+    itself still has to satisfy everything else. Both are carried through rather
+    than flattened to a boolean.
+    """
+    out: list = []
+    for actor in ruleset.get("bypass_actors") or []:
+        if not isinstance(actor, dict):
+            continue
+        out.append(
+            {
+                "rulesetId": ruleset.get("id"),
+                "actorType": actor.get("actor_type"),
+                "actorId": actor.get("actor_id"),
+                "bypassMode": actor.get("bypass_mode"),
+            }
+        )
+    return out
+
+
+def classify_arrival(samples: list) -> tuple:
+    """Reduce per-PR context sightings to an arrival verdict.
+
+    ``samples`` is a list of ``{"found": bool, "truncated": bool}``. Presence is
+    the whole question — a PR shows several cancelled gate runs plus one live
+    one on the same SHA (the concurrency-group behaviour on bot PRs), so
+    *conclusions* are noise here and only *appearance* is signal. That also
+    sidesteps the check-runs ordering trap entirely.
+
+    A truncated sample (>100 contexts on the commit, gate not among the first
+    100) proves nothing either way, so it is excluded from the denominator
+    rather than counted as a miss.
+    """
+    conclusive = [s for s in samples if s.get("found") or not s.get("truncated")]
+    truncated = len(samples) - len(conclusive)
+    if not conclusive:
+        return (
+            ARRIVAL_UNKNOWN if truncated else ARRIVAL_NO_DATA,
+            0,
+            0,
+            truncated,
+        )
+    found = sum(1 for s in conclusive if s.get("found"))
+    if found == len(conclusive):
+        verdict = ARRIVAL_REPORTING
+    elif found == 0:
+        verdict = ARRIVAL_NEVER
+    else:
+        verdict = ARRIVAL_INTERMITTENT
+    return verdict, len(conclusive), found, truncated
+
+
+def _finding(finding_id: str, severity: str, message: str) -> dict:
+    return {"id": finding_id, "severity": severity, "message": message}
+
+
+def evaluate_repo(
+    repo: str,
+    default_branch: str,
+    rulesets: list,
+    classic_protection: str,
+    arrival_samples: Optional[list],
+    has_tests_workflow_file: Optional[bool],
+    required_context: str,
+    errors: list,
+) -> dict:
+    """Build one repo's record from already-fetched payloads. No I/O.
+
+    ``rulesets`` are *expanded* ruleset objects (the list endpoint omits rules,
+    so each must be fetched individually before it reaches here).
+    ``classic_protection`` is one of ``absent`` / ``present`` / ``forbidden``.
+    """
+    collected_at = _now()
+
+    if errors:
+        # An unreadable repo gets a record, not a guess. Everything downstream
+        # keys on `status`, and `unknown` is counted apart from `not-gated` in
+        # the rollup so an auth outage can never be misread as mass regression.
+        return {
+            "schemaVersion": SCHEMA_VERSION,
+            "repo": repo,
+            "collectedAt": collected_at,
+            "defaultBranch": default_branch,
+            "requiredContext": required_context,
+            "gated": None,
+            "unbypassable": None,
+            "status": STATUS_UNKNOWN,
+            "enforcement": None,
+            "bypass": None,
+            "arrival": {
+                "status": ARRIVAL_UNKNOWN,
+                "prsSampled": 0,
+                "prsWithContext": 0,
+                "truncatedSamples": 0,
+            },
+            "hasTestsWorkflowFile": has_tests_workflow_file,
+            "findings": [
+                _finding(
+                    FINDING_UNREADABLE,
+                    "error",
+                    "Gate enforcement state could not be read: " + "; ".join(errors),
+                )
+            ],
+            "errors": list(errors),
+        }
+
+    governing = [
+        rs for rs in rulesets if targets_branch(rs, default_branch, default_branch)
+    ]
+
+    all_contexts: list = []
+    matched_rulesets: list = []
+    actors: list = []
+    requires_pr = False
+    strict = False
+    for ruleset in governing:
+        contexts = required_contexts(ruleset)
+        if required_context in contexts:
+            matched_rulesets.append(
+                {
+                    "id": ruleset.get("id"),
+                    "name": ruleset.get("name"),
+                    "sourceType": ruleset.get("source_type"),
+                }
+            )
+            # Only the rulesets that carry the gate contribute bypass actors.
+            # A bypass on some unrelated ruleset does not exempt anyone from
+            # this check, and counting it would overstate bypassability.
+            actors.extend(bypass_actors(ruleset))
+            strict = strict or strict_policy(ruleset)
+        all_contexts.extend(contexts)
+        requires_pr = requires_pr or has_rule(ruleset, _PULL_REQUEST_RULE)
+
+    gated = bool(matched_rulesets)
+    bot_actors = [a for a in actors if a.get("actorType") == _INTEGRATION_ACTOR]
+    # Direct push is the bypass nobody configures: with no ruleset requiring a
+    # pull request, anyone with write access lands on the default branch without
+    # a PR for the check to attach to.
+    direct_push = not requires_pr
+    # An unreadable classic-protection state cannot rule out an admin
+    # enforcement exemption, so it cannot support the strongest claim. It
+    # downgrades `gated-unbypassable` to `gated-bypassable`, never to
+    # `not-gated` — the ruleset evidence for "required" was read successfully.
+    classic_unreadable = classic_protection in _CLASSIC_UNREADABLE
+    bypassable = bool(actors) or direct_push or classic_unreadable
+
+    arrival_status, sampled, with_context, truncated = classify_arrival(
+        arrival_samples or []
+    )
+
+    findings: list = []
+    if not gated:
+        findings.append(
+            _finding(
+                FINDING_NOT_REQUIRED,
+                "error",
+                f"{required_context!r} is not a required status check on "
+                f"{default_branch}"
+                + (
+                    f" (required there: {', '.join(sorted(set(all_contexts)))})"
+                    if all_contexts
+                    else " (no ruleset requires any status check on this branch)"
+                ),
+            )
+        )
+    else:
+        if actors:
+            findings.append(
+                _finding(
+                    FINDING_BYPASSABLE,
+                    "warning",
+                    f"{len(actors)} bypass actor(s) can skip the ruleset carrying "
+                    f"{required_context!r}",
+                )
+            )
+        if bot_actors:
+            findings.append(
+                _finding(
+                    FINDING_BOT_BYPASS,
+                    "error",
+                    f"{len(bot_actors)} GitHub App bypass actor(s) on the ruleset "
+                    "carrying the gate — automation can merge without it",
+                )
+            )
+        if arrival_status in (ARRIVAL_NEVER, ARRIVAL_INTERMITTENT):
+            findings.append(
+                _finding(
+                    FINDING_NOT_ARRIVING,
+                    "error",
+                    f"required but observed on only {with_context}/{sampled} recent "
+                    "pull requests — a required context that never reports blocks "
+                    "every PR and creates pressure to drop the requirement",
+                )
+            )
+        if arrival_status == ARRIVAL_NEVER and has_tests_workflow_file is False:
+            # The file corroborates the empirical miss; it does not stand in for
+            # it. A repo can produce this context from a differently-named
+            # workflow, so absence alone would be a false positive.
+            findings.append(
+                _finding(
+                    FINDING_UNPRODUCIBLE,
+                    "error",
+                    f"never observed on a pull request and no {TESTS_WORKFLOW_PATH} "
+                    "exists to produce it — every pull request will block with "
+                    "nothing red to fix",
+                )
+            )
+    if direct_push:
+        findings.append(
+            _finding(
+                FINDING_DIRECT_PUSH,
+                "error" if gated else "warning",
+                f"no active ruleset requires a pull request on {default_branch}, so a "
+                "direct push bypasses every required check",
+            )
+        )
+    if classic_unreadable:
+        findings.append(
+            _finding(
+                FINDING_UNREADABLE,
+                "warning",
+                "classic branch protection could not be read (it is admin-gated) — "
+                "reported as unreadable rather than assumed absent, so this repo "
+                "cannot be certified unbypassable",
+            )
+        )
+
+    if not gated:
+        status = STATUS_NOT_GATED
+    elif bypassable:
+        status = STATUS_BYPASSABLE
+    else:
+        status = STATUS_UNBYPASSABLE
+
+    return {
+        "schemaVersion": SCHEMA_VERSION,
+        "repo": repo,
+        "collectedAt": collected_at,
+        "defaultBranch": default_branch,
+        "requiredContext": required_context,
+        "gated": gated,
+        "unbypassable": gated and not bypassable,
+        "status": status,
+        "enforcement": {
+            "required": gated,
+            "source": "ruleset" if gated else "none",
+            "rulesets": matched_rulesets,
+            "requiredContexts": sorted(set(all_contexts)),
+            "requiresPullRequest": requires_pr,
+            "strictRequiredStatusChecksPolicy": strict,
+            "classicProtection": classic_protection,
+        },
+        "bypass": {
+            "bypassable": bypassable,
+            "actors": actors,
+            "botActors": bot_actors,
+            "directPushPermitted": direct_push,
+        },
+        "arrival": {
+            "status": arrival_status,
+            "prsSampled": sampled,
+            "prsWithContext": with_context,
+            "truncatedSamples": truncated,
+        },
+        "hasTestsWorkflowFile": has_tests_workflow_file,
+        "findings": findings,
+        "errors": [],
+    }
+
+
+def build_fleet(records: list, required_context: str) -> dict:
+    """Roll per-repo records up into the fleet aggregate.
+
+    The headline binary — how many repos are gated — is answerable from this one
+    object, which is the point: producing it must not require a manual sweep or
+    a fan-out read of every per-repo file.
+    """
+    by_status: dict = {}
+    by_finding: dict = {}
+    by_arrival: dict = {}
+    for record in records:
+        by_status[record["status"]] = by_status.get(record["status"], 0) + 1
+        arrival = (record.get("arrival") or {}).get("status", ARRIVAL_UNKNOWN)
+        by_arrival[arrival] = by_arrival.get(arrival, 0) + 1
+        for finding in record.get("findings") or []:
+            by_finding[finding["id"]] = by_finding.get(finding["id"], 0) + 1
+
+    gated = by_status.get(STATUS_UNBYPASSABLE, 0) + by_status.get(STATUS_BYPASSABLE, 0)
+    unknown = by_status.get(STATUS_UNKNOWN, 0)
+    # Denominator excludes unreadable repos: a percentage that silently absorbs
+    # an auth outage is exactly the reassuring-but-meaningless number this issue
+    # is about. `unknown` is carried alongside so the gap is visible.
+    known = len(records) - unknown
+
+    return {
+        "schemaVersion": SCHEMA_VERSION,
+        "collectedAt": _now(),
+        "requiredContext": required_context,
+        "fleetSize": len(records),
+        "gated": gated,
+        "gatedUnbypassable": by_status.get(STATUS_UNBYPASSABLE, 0),
+        "gatedBypassable": by_status.get(STATUS_BYPASSABLE, 0),
+        "notGated": by_status.get(STATUS_NOT_GATED, 0),
+        "unknown": unknown,
+        "gatedPct": round(100.0 * gated / known, 1) if known else 0.0,
+        "withTestsWorkflowFile": sum(
+            1 for r in records if r.get("hasTestsWorkflowFile")
+        ),
+        "byStatus": by_status,
+        "byArrival": by_arrival,
+        "byFinding": by_finding,
+        # Inlined so the binary count and its per-repo breakdown are one fetch.
+        "repos": [
+            {
+                "repo": r["repo"],
+                "status": r["status"],
+                "gated": r["gated"],
+                "unbypassable": r["unbypassable"],
+            }
+            for r in records
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Collection
+# ---------------------------------------------------------------------------
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def list_fleet_repos(owner: str, name_pattern: str, run: RunFn = _run_gh) -> list:
+    """Non-archived ``owner`` repos whose bare name matches ``name_pattern``.
+
+    ``gh repo list`` rather than ``gh search code``: code search is best-effort
+    and nondeterministic (see discover_org_consumers.py), and a dropped repo
+    here silently removes an ungated repo from the count.
+    """
+    raw = run(
+        [
+            "repo",
+            "list",
+            owner,
+            "--no-archived",
+            "--limit",
+            str(REPO_LIST_LIMIT),
+            "--json",
+            "nameWithOwner",
+            "--jq",
+            "[.[].nameWithOwner]",
+        ]
+    )
+    repos = _load_json(raw) or []
+    if not isinstance(repos, list):
+        raise GhError(f"unexpected `gh repo list` payload for {owner}")
+    if len(repos) >= REPO_LIST_LIMIT:
+        print(
+            f"::warning::gh repo list returned {len(repos)} repos, hitting the "
+            f"--limit {REPO_LIST_LIMIT} cap; the fleet may be truncated and an "
+            "ungated repo silently dropped. Raise REPO_LIST_LIMIT.",
+            file=sys.stderr,
+        )
+    pattern = re.compile(name_pattern)
+    return sorted(r for r in repos if pattern.match(str(r).split("/", 1)[-1]))
+
+
+def fetch_default_branch(repo: str, run: RunFn = _run_gh) -> str:
+    payload = _load_json(run(["api", f"repos/{repo}", "--jq", "{b: .default_branch}"]))
+    branch = (payload or {}).get("b") if isinstance(payload, dict) else None
+    if not branch:
+        raise GhError(f"could not read default branch for {repo}")
+    return branch
+
+
+def fetch_rulesets(repo: str, run: RunFn = _run_gh) -> list:
+    """Every active ruleset applying to ``repo``, expanded to include its rules.
+
+    ``includes_parents`` is GitHub's default and is passed explicitly: if
+    enforcement ever lands as one org-level ruleset instead of 166 repo-level
+    ones, it arrives through this same call with ``source_type: Organization``
+    and nothing below needs to change.
+    """
+    listing = _load_json(
+        run(
+            [
+                "api",
+                f"repos/{repo}/rulesets?includes_parents=true",
+                "--paginate",
+                "--slurp",
+            ]
+        )
+    )
+    if not isinstance(listing, list):
+        raise GhError(f"unexpected rulesets payload for {repo}")
+    expanded: list = []
+    for entry in listing:
+        if not isinstance(entry, dict) or entry.get("id") is None:
+            continue
+        detail = _load_json(run(["api", f"repos/{repo}/rulesets/{entry['id']}"]))
+        if isinstance(detail, dict):
+            expanded.append(detail)
+    return expanded
+
+
+def fetch_classic_protection(repo: str, branch: str, run: RunFn = _run_gh) -> str:
+    """``absent`` | ``present`` | ``forbidden``.
+
+    A 404 genuinely means unprotected. A 403 means the token cannot see it, and
+    is kept distinct — collapsing the two would let an admin-gated read report
+    as "no protection here", which is a false negative in the safe-looking
+    direction.
+    """
+    try:
+        run(["api", f"repos/{repo}/branches/{branch}/protection", "--jq", ".url"])
+    except GhError as exc:
+        if exc.status == 404:
+            return "absent"
+        if exc.status == 403:
+            return "forbidden"
+        raise
+    return "present"
+
+
+def fetch_has_tests_workflow_file(repo: str, run: RunFn = _run_gh) -> bool:
+    try:
+        run(["api", f"repos/{repo}/contents/{TESTS_WORKFLOW_PATH}", "--jq", ".sha"])
+    except GhError as exc:
+        if exc.status == 404:
+            return False
+        raise
+    return True
+
+
+_ARRIVAL_QUERY = """
+query($owner: String!, $name: String!, $base: String!, $first: Int!) {
+  repository(owner: $owner, name: $name) {
+    pullRequests(first: $first, orderBy: {field: UPDATED_AT, direction: DESC},
+                 baseRefName: $base) {
+      nodes {
+        number
+        commits(last: 1) {
+          nodes {
+            commit {
+              statusCheckRollup {
+                contexts(first: 100) {
+                  totalCount
+                  nodes {
+                    __typename
+                    ... on CheckRun { name }
+                    ... on StatusContext { context }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+
+def parse_arrival_nodes(payload: dict, required_context: str) -> list:
+    """Turn a GraphQL arrival response into ``{found, truncated}`` samples.
+
+    One query per repo rather than one per pull request: the fleet sweep is
+    already O(repos) on the REST side, and fanning arrival out per PR would
+    multiply that by the sample size for no extra signal.
+    """
+    repository = ((payload or {}).get("data") or {}).get("repository") or {}
+    nodes = ((repository.get("pullRequests") or {}).get("nodes")) or []
+    samples: list = []
+    for pr in nodes:
+        if not isinstance(pr, dict):
+            continue
+        commits = ((pr.get("commits") or {}).get("nodes")) or []
+        if not commits:
+            continue
+        rollup = ((commits[0] or {}).get("commit") or {}).get("statusCheckRollup")
+        if not rollup:
+            # No checks ran on the head commit at all — carries no information
+            # about whether the gate would have arrived.
+            continue
+        contexts = rollup.get("contexts") or {}
+        names = {
+            (ctx.get("name") or ctx.get("context"))
+            for ctx in contexts.get("nodes") or []
+            if isinstance(ctx, dict)
+        }
+        total = contexts.get("totalCount") or 0
+        samples.append(
+            {
+                "number": pr.get("number"),
+                "found": required_context in names,
+                "truncated": total > len(names),
+            }
+        )
+    return samples
+
+
+def fetch_arrival_samples(
+    repo: str,
+    default_branch: str,
+    sample_size: int,
+    required_context: str,
+    run: RunFn = _run_gh,
+) -> list:
+    owner, _, name = repo.partition("/")
+    raw = run(
+        [
+            "api",
+            "graphql",
+            "-f",
+            f"query={_ARRIVAL_QUERY}",
+            "-F",
+            f"owner={owner}",
+            "-F",
+            f"name={name}",
+            "-F",
+            f"base={default_branch}",
+            "-F",
+            f"first={sample_size}",
+        ]
+    )
+    payload = _load_json(raw)
+    if not isinstance(payload, dict):
+        raise GhError(f"unexpected arrival payload for {repo}")
+    if payload.get("errors"):
+        raise GhError(f"GraphQL errors for {repo}: {payload['errors']}")
+    return parse_arrival_nodes(payload, required_context)
+
+
+def scan_repo(
+    repo: str,
+    required_context: str,
+    sample_size: int,
+    run: RunFn = _run_gh,
+) -> dict:
+    """Collect every input for one repo, then evaluate it.
+
+    Each fetch is guarded separately so one unreadable facet (e.g. admin-gated
+    classic protection) degrades that field alone instead of discarding the
+    ruleset evidence that was read successfully.
+    """
+    errors: list = []
+    default_branch = "main"
+    rulesets: list = []
+    classic = "absent"
+    has_tests: Optional[bool] = None
+    samples: Optional[list] = None
+
+    try:
+        default_branch = fetch_default_branch(repo, run=run)
+    except GhError as exc:
+        errors.append(str(exc))
+
+    if not errors:
+        try:
+            rulesets = fetch_rulesets(repo, run=run)
+        except GhError as exc:
+            errors.append(str(exc))
+
+    if not errors:
+        try:
+            classic = fetch_classic_protection(repo, default_branch, run=run)
+        except GhError as exc:
+            # Non-fatal: the ruleset read already carries the load-bearing
+            # answer, and no fleet repo has been observed on classic protection.
+            classic = "unknown"
+            print(f"::warning::{repo}: {exc}", file=sys.stderr)
+        try:
+            has_tests = fetch_has_tests_workflow_file(repo, run=run)
+        except GhError as exc:
+            print(f"::warning::{repo}: {exc}", file=sys.stderr)
+        if sample_size > 0:
+            try:
+                samples = fetch_arrival_samples(
+                    repo, default_branch, sample_size, required_context, run=run
+                )
+            except GhError as exc:
+                print(
+                    f"::warning::{repo}: arrival probe failed: {exc}", file=sys.stderr
+                )
+
+    return evaluate_repo(
+        repo=repo,
+        default_branch=default_branch,
+        rulesets=rulesets,
+        classic_protection=classic,
+        arrival_samples=samples,
+        has_tests_workflow_file=has_tests,
+        required_context=required_context,
+        errors=errors,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Output
+# ---------------------------------------------------------------------------
+
+
+def slug_for(repo: str) -> str:
+    return repo.replace("/", "_")
+
+
+def write_outputs(records: list, fleet: dict, out_dir: Path) -> None:
+    """Write ``repos/<slug>.json``, ``fleet.json`` and append-only history.
+
+    Layout is identical to the Renovate fleet dashboard so the existing
+    Kryptonite deploy step applies with only the S3 prefix changed.
+    """
+    (out_dir / "repos").mkdir(parents=True, exist_ok=True)
+    for record in records:
+        slug = slug_for(record["repo"])
+        (out_dir / "repos" / f"{slug}.json").write_text(json.dumps(record, indent=2))
+        entry = {
+            "date": record["collectedAt"][:10],
+            "repo": record["repo"],
+            "status": record["status"],
+            "gated": record["gated"],
+            "unbypassable": record["unbypassable"],
+            "arrival": (record.get("arrival") or {}).get("status"),
+        }
+        with (out_dir / f"history_{slug}.jsonl").open("a") as fh:
+            fh.write(json.dumps(entry) + "\n")
+
+    (out_dir / "fleet.json").write_text(json.dumps(fleet, indent=2))
+    fleet_entry = {
+        "date": fleet["collectedAt"][:10],
+        "fleetSize": fleet["fleetSize"],
+        "gated": fleet["gated"],
+        "gatedUnbypassable": fleet["gatedUnbypassable"],
+        "notGated": fleet["notGated"],
+        "unknown": fleet["unknown"],
+    }
+    with (out_dir / "history_fleet.jsonl").open("a") as fh:
+        fh.write(json.dumps(fleet_entry) + "\n")
+
+
+def main(argv: Optional[list] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("--owner", default="atlanhq", help="org to enumerate")
+    parser.add_argument(
+        "--name-pattern",
+        default=DEFAULT_NAME_PATTERN,
+        help=f"regex the bare repo name must match (default: {DEFAULT_NAME_PATTERN})",
+    )
+    parser.add_argument(
+        "--repos-file",
+        type=Path,
+        default=None,
+        help="JSON array of repo full names to scan instead of discovering them",
+    )
+    parser.add_argument(
+        "--required-context",
+        default=DEFAULT_REQUIRED_CONTEXT,
+        help=f"the status check that must be required (default: {DEFAULT_REQUIRED_CONTEXT!r})",
+    )
+    parser.add_argument(
+        "--pr-sample",
+        type=int,
+        default=5,
+        help="recent pull requests per repo to probe for check arrival; 0 disables",
+    )
+    parser.add_argument("--out", type=Path, default=Path("/tmp/gate-enforcement"))
+    args = parser.parse_args(argv)
+
+    if args.repos_file:
+        repos = json.loads(args.repos_file.read_text())
+    else:
+        repos = list_fleet_repos(args.owner, args.name_pattern)
+
+    if not repos:
+        print(
+            "::error::No fleet repos discovered — refusing to publish an empty "
+            "scan, which would read as a fleet with zero ungated repos.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"Scanning {len(repos)} repos for {args.required_context!r}", file=sys.stderr)
+
+    ordered = sorted(repos)
+    records: list = []
+    for index, repo in enumerate(ordered, start=1):
+        record = scan_repo(repo, args.required_context, args.pr_sample)
+        records.append(record)
+        # Per-repo progress, not just a final tally: a fleet sweep is minutes
+        # long, and without this a stall on one slow repo is indistinguishable
+        # from a hung job.
+        print(f"[{index}/{len(ordered)}] {repo}: {record['status']}", file=sys.stderr)
+
+    fleet = build_fleet(records, args.required_context)
+    write_outputs(records, fleet, args.out)
+
+    print(
+        f"Fleet: {fleet['gated']}/{fleet['fleetSize']} gated "
+        f"({fleet['gatedUnbypassable']} unbypassable, "
+        f"{fleet['gatedBypassable']} bypassable), "
+        f"{fleet['notGated']} not gated, {fleet['unknown']} unknown",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/gate_enforcement_scan.py
+++ b/.github/scripts/gate_enforcement_scan.py
@@ -731,8 +731,11 @@ def parse_arrival_nodes(payload: dict, required_context: str) -> list:
     multiply that by the sample size for no extra signal.
     """
     repository = ((payload or {}).get("data") or {}).get("repository")
-    if not isinstance(repository, dict) or not isinstance(
-        (repository.get("pullRequests") or {}).get("nodes"), list
+    pull_requests = (
+        repository.get("pullRequests") if isinstance(repository, dict) else None
+    )
+    if not isinstance(pull_requests, dict) or not isinstance(
+        pull_requests.get("nodes"), list
     ):
         # A structurally malformed body (schema drift, a null repository) must
         # surface as arrival `unknown` — coercing it to zero samples would read
@@ -741,7 +744,7 @@ def parse_arrival_nodes(payload: dict, required_context: str) -> list:
             "malformed arrival payload: expected "
             "data.repository.pullRequests.nodes to be a list"
         )
-    nodes = repository["pullRequests"]["nodes"]
+    nodes = pull_requests["nodes"]
     samples: list = []
     for pr in nodes:
         if not isinstance(pr, dict):

--- a/.github/scripts/publish_fleet_dashboard.py
+++ b/.github/scripts/publish_fleet_dashboard.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Publish a fleet-scan output directory to the Kryptonite dashboard store.
+
+The upload half of the fleet-dashboard pattern: per-repo documents, a manifest
+of every repo present in the bucket, append-only per-repo history, and — on
+full-fleet runs only — the fleet aggregate and its history.
+
+Extracted from an inlined ``run:`` block per docs/standards/ci.md. The shell
+version carried a loop, an if, and a download → merge → re-upload sequence whose
+failure mode is silent: without a ``touch`` of the not-yet-existing history file,
+``cat`` exits 1, ``pipefail`` kills the step *after* the per-repo document has
+already uploaded, and the repo gets a summary in S3 but never a history line.
+That is exactly the class of branch YAML cannot regression-test, so it lives
+here and is covered in tests/test_publish_fleet_dashboard.py.
+
+Single-repo mode deliberately skips ``fleet.json`` and the fleet history: a scan
+of one repo has no fleet aggregate to publish, and writing one would replace the
+real fleet view with a one-repo view that reads as a catastrophic regression.
+
+Environment:
+    AWS credentials must already be configured (the caller assumes the
+    kryptonite-store role via OIDC before invoking this).
+
+Usage:
+    publish_fleet_dashboard.py --dir /tmp/gate-enforcement \\
+        --prefix gate-enforcement-dashboard
+    publish_fleet_dashboard.py --dir /tmp/gate-enforcement \\
+        --prefix gate-enforcement-dashboard --single-repo
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Callable, Optional
+
+BUCKET = "s3://kryptonite-store"
+
+# (args) -> (returncode, stdout). Not raising on failure: a missing history
+# object is a routine first-publish, and the caller distinguishes that from a
+# real error by which command failed.
+RunFn = Callable[[list], tuple]
+
+FLEET_SLUG = "fleet"
+
+
+def _run_aws(args: list) -> tuple:
+    result = subprocess.run(["aws", *args], capture_output=True, text=True)
+    if result.returncode != 0 and result.stderr:
+        print(
+            f"::debug::aws {' '.join(args[:2])}: {result.stderr.strip()}",
+            file=sys.stderr,
+        )
+    return result.returncode, result.stdout
+
+
+def _key(prefix: str, *parts: str) -> str:
+    return f"{BUCKET}/{prefix}/" + "/".join(parts)
+
+
+def upload(local: Path, prefix: str, *parts: str, run: RunFn = _run_aws) -> None:
+    code, _ = run(["s3", "cp", str(local), _key(prefix, *parts)])
+    if code != 0:
+        raise RuntimeError(f"failed to upload {local} to {_key(prefix, *parts)}")
+
+
+def merge_history(
+    local: Path, prefix: str, slug: str, tmp_dir: Path, run: RunFn = _run_aws
+) -> None:
+    """Append ``local``'s lines to the stored history for ``slug``, deduplicated.
+
+    Download → concatenate → sort -u → re-upload. ``sort -u`` is what makes a
+    same-day rerun idempotent, and it is why history lines must stay
+    byte-identical for an unchanged day.
+    """
+    existing = tmp_dir / f"existing_{slug}.jsonl"
+    # A missing object is the first publish for this repo, not an error — the
+    # download simply leaves no file behind, and an empty one stands in.
+    run(["s3", "cp", _key(prefix, "history", f"{slug}.jsonl"), str(existing)])
+    lines = existing.read_text().splitlines() if existing.exists() else []
+    lines.extend(local.read_text().splitlines())
+
+    merged = tmp_dir / f"merged_{slug}.jsonl"
+    merged.write_text("\n".join(sorted({ln for ln in lines if ln.strip()})) + "\n")
+    upload(merged, prefix, "history", f"{slug}.jsonl", run=run)
+
+
+def refresh_manifest(prefix: str, tmp_dir: Path, run: RunFn = _run_aws) -> list:
+    """Rewrite ``repos.json`` from what is actually in the bucket.
+
+    Listing the bucket rather than the local scan output on purpose: in
+    single-repo mode the local directory holds one file, and a manifest built
+    from it would hide every other repo from the dashboard.
+    """
+    code, stdout = run(["s3", "ls", _key(prefix, "repos", "")])
+    if code != 0:
+        raise RuntimeError(f"failed to list {_key(prefix, 'repos', '')}")
+    names = sorted(
+        line.split()[-1]
+        for line in stdout.splitlines()
+        if line.strip().endswith(".json")
+    )
+    manifest = tmp_dir / "repos.json"
+    manifest.write_text(json.dumps(names))
+    upload(manifest, prefix, "repos.json", run=run)
+    return names
+
+
+def publish(
+    scan_dir: Path,
+    prefix: str,
+    single_repo: bool,
+    tmp_dir: Path,
+    run: RunFn = _run_aws,
+) -> dict:
+    """Upload one scan directory. Returns a counts summary for the run log."""
+    repo_docs = sorted((scan_dir / "repos").glob("*.json"))
+    if not repo_docs:
+        raise RuntimeError(f"no per-repo documents in {scan_dir / 'repos'}")
+
+    for doc in repo_docs:
+        upload(doc, prefix, "repos", doc.name, run=run)
+
+    manifest = refresh_manifest(prefix, tmp_dir, run=run)
+
+    histories = 0
+    for history in sorted(scan_dir.glob("history_*.jsonl")):
+        slug = history.stem[len("history_") :]
+        if slug == FLEET_SLUG:
+            continue
+        merge_history(history, prefix, slug, tmp_dir, run=run)
+        histories += 1
+
+    fleet_published = False
+    if not single_repo:
+        fleet = scan_dir / "fleet.json"
+        if not fleet.exists():
+            raise RuntimeError(
+                f"{fleet} is missing on a full-fleet run — refusing to publish "
+                "per-repo data without the aggregate the dashboard reads"
+            )
+        upload(fleet, prefix, "fleet.json", run=run)
+        fleet_history = scan_dir / f"history_{FLEET_SLUG}.jsonl"
+        if fleet_history.exists():
+            merge_history(fleet_history, prefix, FLEET_SLUG, tmp_dir, run=run)
+        fleet_published = True
+
+    return {
+        "repoDocs": len(repo_docs),
+        "manifestEntries": len(manifest),
+        "historiesMerged": histories,
+        "fleetPublished": fleet_published,
+    }
+
+
+def main(argv: Optional[list] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("--dir", required=True, type=Path, help="scan output directory")
+    parser.add_argument(
+        "--prefix", required=True, help="S3 key prefix, e.g. gate-enforcement-dashboard"
+    )
+    parser.add_argument(
+        "--single-repo",
+        action="store_true",
+        help="scan covered one repo: skip fleet.json and the fleet history",
+    )
+    args = parser.parse_args(argv)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        summary = publish(args.dir, args.prefix, args.single_repo, Path(tmp))
+
+    print(
+        f"Published {summary['repoDocs']} repo docs, {summary['historiesMerged']} "
+        f"histories, manifest of {summary['manifestEntries']} "
+        f"(fleet aggregate: {'yes' if summary['fleetPublished'] else 'skipped'}) "
+        f"to {BUCKET}/{args.prefix}/",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/publish_fleet_dashboard.py
+++ b/.github/scripts/publish_fleet_dashboard.py
@@ -40,9 +40,10 @@ from typing import Callable, Optional
 
 BUCKET = "s3://kryptonite-store"
 
-# (args) -> (returncode, stdout). Not raising on failure: a missing history
-# object is a routine first-publish, and the caller distinguishes that from a
-# real error by which command failed.
+# (args) -> (returncode, stdout, stderr). Not raising on failure: a missing
+# history object is a routine first-publish, and the caller distinguishes that
+# from a real error by the download's stderr — which is why stderr is carried
+# here rather than only logged.
 RunFn = Callable[[list], tuple]
 
 FLEET_SLUG = "fleet"
@@ -55,7 +56,7 @@ def _run_aws(args: list) -> tuple:
             f"::debug::aws {' '.join(args[:2])}: {result.stderr.strip()}",
             file=sys.stderr,
         )
-    return result.returncode, result.stdout
+    return result.returncode, result.stdout, result.stderr
 
 
 def _key(prefix: str, *parts: str) -> str:
@@ -63,7 +64,7 @@ def _key(prefix: str, *parts: str) -> str:
 
 
 def upload(local: Path, prefix: str, *parts: str, run: RunFn = _run_aws) -> None:
-    code, _ = run(["s3", "cp", str(local), _key(prefix, *parts)])
+    code, _, _ = run(["s3", "cp", str(local), _key(prefix, *parts)])
     if code != 0:
         raise RuntimeError(f"failed to upload {local} to {_key(prefix, *parts)}")
 
@@ -78,9 +79,15 @@ def merge_history(
     byte-identical for an unchanged day.
     """
     existing = tmp_dir / f"existing_{slug}.jsonl"
-    # A missing object is the first publish for this repo, not an error — the
-    # download simply leaves no file behind, and an empty one stands in.
-    run(["s3", "cp", _key(prefix, "history", f"{slug}.jsonl"), str(existing)])
+    key = _key(prefix, "history", f"{slug}.jsonl")
+    # A missing object is the first publish for this repo — proceed with an
+    # empty stand-in. Any *other* download failure (AccessDenied, throttling,
+    # timeout) must abort BEFORE the upload: treating it as "no history yet"
+    # would merge only today's line and re-upload it over the stored history,
+    # silently truncating the trend line the dashboard depends on.
+    code, _, stderr = run(["s3", "cp", key, str(existing)])
+    if code != 0 and "does not exist" not in stderr:
+        raise RuntimeError(f"failed to download {key}: {stderr.strip() or 'no stderr'}")
     lines = existing.read_text().splitlines() if existing.exists() else []
     lines.extend(local.read_text().splitlines())
 
@@ -96,7 +103,7 @@ def refresh_manifest(prefix: str, tmp_dir: Path, run: RunFn = _run_aws) -> list:
     single-repo mode the local directory holds one file, and a manifest built
     from it would hide every other repo from the dashboard.
     """
-    code, stdout = run(["s3", "ls", _key(prefix, "repos", "")])
+    code, stdout, _ = run(["s3", "ls", _key(prefix, "repos", "")])
     if code != 0:
         raise RuntimeError(f"failed to list {_key(prefix, 'repos', '')}")
     names = sorted(

--- a/.github/scripts/publish_fleet_dashboard.py
+++ b/.github/scripts/publish_fleet_dashboard.py
@@ -69,6 +69,16 @@ def upload(local: Path, prefix: str, *parts: str, run: RunFn = _run_aws) -> None
         raise RuntimeError(f"failed to upload {local} to {_key(prefix, *parts)}")
 
 
+def _is_not_found(stderr: str) -> bool:
+    """True only when the aws CLI reports a genuine missing-object 404.
+
+    Matched on the ``(404)`` + ``HeadObject`` signature rather than the bare
+    ``does not exist`` substring, so a contrived non-404 error that happens to
+    embed that phrase is not misclassified as a first publish.
+    """
+    return "(404)" in stderr and "HeadObject" in stderr
+
+
 def merge_history(
     local: Path, prefix: str, slug: str, tmp_dir: Path, run: RunFn = _run_aws
 ) -> None:
@@ -86,7 +96,7 @@ def merge_history(
     # would merge only today's line and re-upload it over the stored history,
     # silently truncating the trend line the dashboard depends on.
     code, _, stderr = run(["s3", "cp", key, str(existing)])
-    if code != 0 and "does not exist" not in stderr:
+    if code != 0 and not _is_not_found(stderr):
         raise RuntimeError(f"failed to download {key}: {stderr.strip() or 'no stderr'}")
     lines = existing.read_text().splitlines() if existing.exists() else []
     lines.extend(local.read_text().splitlines())

--- a/.github/scripts/tests/test_gate_enforcement_scan.py
+++ b/.github/scripts/tests/test_gate_enforcement_scan.py
@@ -582,6 +582,11 @@ def test_nulls_along_the_walk_are_a_legitimate_skip_not_an_error():
         pytest.param({"__typename": "CheckRun", "name": {"x": 1}}, id="name-dict"),
         pytest.param({"__typename": "CheckRun", "name": 5}, id="name-int"),
         pytest.param({"__typename": "CheckRun", "name": True}, id="name-bool"),
+        # Falsy wrong-typed leaves: an `or`-chain would collapse these to the
+        # fallback/`None` and skip them as "absent", reading as a clean miss.
+        pytest.param({"__typename": "CheckRun", "name": 0}, id="name-zero"),
+        pytest.param({"__typename": "CheckRun", "name": False}, id="name-false"),
+        pytest.param({"__typename": "CheckRun", "name": []}, id="name-empty-list"),
         pytest.param(
             {"__typename": "StatusContext", "context": ["unexpected"]},
             id="context-list",
@@ -594,7 +599,9 @@ def test_a_non_string_context_leaf_raises_gh_error(ctx_node):
     An unhashable `name`/`context` (list/dict) raises an uncaught TypeError in
     `names.add(...)` — which `scan_repo` does not catch — and a hashable scalar
     (int/bool) never matches the required-context string, silently reading as
-    `found: False`. Either way a malformed body must surface as GhError so the
+    `found: False`. Falsy wrong-typed values (`0`/`False`/`[]`) are the same
+    escape one branch down: selected by truthiness they collapse to "absent"
+    and are skipped. Either way a malformed body must surface as GhError so the
     one repo degrades to `unknown` instead of aborting the fleet sweep.
     """
     pr_node = {
@@ -659,6 +666,59 @@ def test_scan_repo_reports_unknown_when_an_arrival_leaf_is_malformed():
     record = scan_repo(REPO, GATE, sample_size=5, run=run)
     assert record["status"] == STATUS_UNKNOWN
     assert _finding_ids(record) == {FINDING_UNREADABLE}
+
+
+def test_scan_repo_marks_arrival_no_data_when_a_leaf_is_malformed():
+    """The arrival facet's degradation, pinned in isolation: with healthy
+    ruleset reads, a malformed context leaf surfaces as a caught GhError, so
+    the arrival facet reads `no-data` — never `never-arriving` — while the
+    ruleset evidence still evaluates. The facet failure must not be masked by,
+    or confused with, an unrelated read error, and must not aggregate into a
+    false `NOT_ARRIVING` finding."""
+
+    def run(args: list) -> str:
+        if args[1] == f"repos/{REPO}":
+            return json.dumps({"b": "main"})
+        if args[1].startswith(f"repos/{REPO}/rulesets?"):
+            return json.dumps([[{"id": 1}]])
+        if args[1] == f"repos/{REPO}/rulesets/1":
+            return json.dumps(_ruleset())
+        if args[1] == "graphql":
+            return json.dumps(
+                _arrival_payload(
+                    {
+                        "number": 1,
+                        "commits": {
+                            "nodes": [
+                                {
+                                    "commit": {
+                                        "statusCheckRollup": {
+                                            "contexts": {
+                                                "totalCount": 1,
+                                                "nodes": [
+                                                    {
+                                                        "__typename": "CheckRun",
+                                                        "name": ["unexpected"],
+                                                    }
+                                                ],
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                    }
+                )
+            )
+        return json.dumps("ok")
+
+    record = scan_repo(REPO, GATE, sample_size=5, run=run)
+    # The ruleset read succeeded, so the repo still evaluates clean on that
+    # evidence; only the arrival facet carries the read failure.
+    assert record["status"] == STATUS_UNBYPASSABLE
+    assert record["arrival"]["status"] == ARRIVAL_NO_DATA
+    assert record["arrival"]["prsSampled"] == 0
+    assert FINDING_NOT_ARRIVING not in _finding_ids(record)
 
 
 def test_repeated_contexts_on_one_commit_are_not_truncation():

--- a/.github/scripts/tests/test_gate_enforcement_scan.py
+++ b/.github/scripts/tests/test_gate_enforcement_scan.py
@@ -491,6 +491,117 @@ def test_parse_arrival_nodes_raises_on_a_structurally_malformed_body():
         )
 
 
+def _arrival_payload(pr_node) -> dict:
+    return {"data": {"repository": {"pullRequests": {"nodes": [pr_node]}}}}
+
+
+@pytest.mark.parametrize(
+    "pr_node",
+    [
+        pytest.param({"number": 1, "commits": "unexpected"}, id="commits"),
+        pytest.param(
+            {"number": 1, "commits": {"nodes": ["unexpected"]}}, id="commits.nodes[0]"
+        ),
+        pytest.param(
+            {"number": 1, "commits": {"nodes": [{"commit": "unexpected"}]}},
+            id="commit",
+        ),
+        pytest.param(
+            {
+                "number": 1,
+                "commits": {"nodes": [{"commit": {"statusCheckRollup": "unexpected"}}]},
+            },
+            id="statusCheckRollup",
+        ),
+        pytest.param(
+            {
+                "number": 1,
+                "commits": {
+                    "nodes": [
+                        {"commit": {"statusCheckRollup": {"contexts": "unexpected"}}}
+                    ]
+                },
+            },
+            id="contexts",
+        ),
+        pytest.param("unexpected", id="pullRequests.nodes[0]"),
+    ],
+)
+def test_a_truthy_non_dict_anywhere_in_the_walk_raises_gh_error(pr_node):
+    """Every nested level, not just the spine.
+
+    `(value or {}).get(...)` raises AttributeError on a truthy non-dict, and
+    `scan_repo` catches only GhError — so one malformed body would abort the
+    whole fleet sweep instead of marking that one repo `unknown`. That is the
+    same false-green-by-abort the top-level guard prevents, one level down.
+    """
+    with pytest.raises(GhError, match="malformed arrival payload"):
+        parse_arrival_nodes(_arrival_payload(pr_node), GATE)
+
+
+def test_a_non_integer_total_count_raises_rather_than_comparing():
+    """`total > len(...)` against a string is a TypeError, uncaught, mid-sweep."""
+    payload = _arrival_payload(
+        {
+            "number": 1,
+            "commits": {
+                "nodes": [
+                    {
+                        "commit": {
+                            "statusCheckRollup": {
+                                "contexts": {"totalCount": "many", "nodes": []}
+                            }
+                        }
+                    }
+                ]
+            },
+        }
+    )
+    with pytest.raises(GhError, match="totalCount"):
+        parse_arrival_nodes(payload, GATE)
+
+
+def test_nulls_along_the_walk_are_a_legitimate_skip_not_an_error():
+    """GraphQL returns every requested field, so a null is the schema's own
+    "nothing here" — distinct from a wrong-typed value, which is drift."""
+    for pr_node in (
+        None,
+        {"number": 1, "commits": None},
+        {"number": 1, "commits": {"nodes": None}},
+        {"number": 1, "commits": {"nodes": [{"commit": None}]}},
+    ):
+        assert parse_arrival_nodes(_arrival_payload(pr_node), GATE) == []
+
+
+def test_repeated_contexts_on_one_commit_are_not_truncation():
+    """A commit routinely carries the same context several times — a bot PR
+    stacks 5-7 gate runs on one SHA, all but the newest cancelled by the
+    concurrency group. Measuring truncation against the *deduplicated* names
+    marked every busy repo truncated, which silently converted real
+    never-arriving evidence into `unknown`."""
+    nodes = [{"__typename": "CheckRun", "name": GATE} for _ in range(3)]
+    nodes += [{"__typename": "CheckRun", "name": "tests / Unit"} for _ in range(4)]
+    payload = _arrival_payload(
+        {
+            "number": 1,
+            "commits": {
+                "nodes": [
+                    {
+                        "commit": {
+                            "statusCheckRollup": {
+                                "contexts": {"totalCount": len(nodes), "nodes": nodes}
+                            }
+                        }
+                    }
+                ]
+            },
+        }
+    )
+    sample = parse_arrival_nodes(payload, GATE)[0]
+    assert sample["found"] is True
+    assert sample["truncated"] is False  # 7 returned of 7 — nothing was cut off
+
+
 def test_scan_repo_reports_unknown_when_a_ruleset_detail_fails():
     """A ruleset-detail GET that fails must not read as "no gate here" — the
     repo must go `unknown`, never be evaluated on a partially-expanded list."""

--- a/.github/scripts/tests/test_gate_enforcement_scan.py
+++ b/.github/scripts/tests/test_gate_enforcement_scan.py
@@ -573,6 +573,94 @@ def test_nulls_along_the_walk_are_a_legitimate_skip_not_an_error():
         assert parse_arrival_nodes(_arrival_payload(pr_node), GATE) == []
 
 
+@pytest.mark.parametrize(
+    "ctx_node",
+    [
+        pytest.param(
+            {"__typename": "CheckRun", "name": ["unexpected"]}, id="name-list"
+        ),
+        pytest.param({"__typename": "CheckRun", "name": {"x": 1}}, id="name-dict"),
+        pytest.param({"__typename": "CheckRun", "name": 5}, id="name-int"),
+        pytest.param({"__typename": "CheckRun", "name": True}, id="name-bool"),
+        pytest.param(
+            {"__typename": "StatusContext", "context": ["unexpected"]},
+            id="context-list",
+        ),
+    ],
+)
+def test_a_non_string_context_leaf_raises_gh_error(ctx_node):
+    """The leaf analogue of the container guards.
+
+    An unhashable `name`/`context` (list/dict) raises an uncaught TypeError in
+    `names.add(...)` — which `scan_repo` does not catch — and a hashable scalar
+    (int/bool) never matches the required-context string, silently reading as
+    `found: False`. Either way a malformed body must surface as GhError so the
+    one repo degrades to `unknown` instead of aborting the fleet sweep.
+    """
+    pr_node = {
+        "number": 1,
+        "commits": {
+            "nodes": [
+                {
+                    "commit": {
+                        "statusCheckRollup": {
+                            "contexts": {"totalCount": 1, "nodes": [ctx_node]}
+                        }
+                    }
+                }
+            ]
+        },
+    }
+    with pytest.raises(GhError, match="malformed arrival payload"):
+        parse_arrival_nodes(_arrival_payload(pr_node), GATE)
+
+
+def test_scan_repo_reports_unknown_when_an_arrival_leaf_is_malformed():
+    """Pin the downstream effect: a wrong-typed `name`/`context` leaf reaches
+    `scan_repo` as a caught GhError, not an uncaught TypeError — so the repo
+    degrades to `unknown` (fail-loud) instead of aborting the fleet sweep.
+    The ruleset-detail read also fails here so the whole record, not just the
+    arrival facet, lands on `unknown`."""
+
+    def run(args: list) -> str:
+        if args[1] == f"repos/{REPO}":
+            return json.dumps({"b": "main"})
+        if args[1].startswith(f"repos/{REPO}/rulesets?"):
+            return json.dumps([[{"id": 1}]])
+        if args[1] == "graphql":
+            return json.dumps(
+                _arrival_payload(
+                    {
+                        "number": 1,
+                        "commits": {
+                            "nodes": [
+                                {
+                                    "commit": {
+                                        "statusCheckRollup": {
+                                            "contexts": {
+                                                "totalCount": 1,
+                                                "nodes": [
+                                                    {
+                                                        "__typename": "CheckRun",
+                                                        "name": ["unexpected"],
+                                                    }
+                                                ],
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                    }
+                )
+            )
+        raise GhError("gh api failed: HTTP 429", status=429)
+
+    record = scan_repo(REPO, GATE, sample_size=5, run=run)
+    assert record["status"] == STATUS_UNKNOWN
+    assert _finding_ids(record) == {FINDING_UNREADABLE}
+
+
 def test_repeated_contexts_on_one_commit_are_not_truncation():
     """A commit routinely carries the same context several times — a bot PR
     stacks 5-7 gate runs on one SHA, all but the newest cancelled by the

--- a/.github/scripts/tests/test_gate_enforcement_scan.py
+++ b/.github/scripts/tests/test_gate_enforcement_scan.py
@@ -484,6 +484,11 @@ def test_parse_arrival_nodes_raises_on_a_structurally_malformed_body():
         parse_arrival_nodes({"data": {}}, GATE)
     with pytest.raises(GhError, match="malformed arrival payload"):
         parse_arrival_nodes({"data": {"repository": None}}, GATE)
+    with pytest.raises(GhError, match="malformed arrival payload"):
+        # a truthy non-dict pullRequests must raise GhError, not AttributeError
+        parse_arrival_nodes(
+            {"data": {"repository": {"pullRequests": "unexpected"}}}, GATE
+        )
 
 
 def test_scan_repo_reports_unknown_when_a_ruleset_detail_fails():

--- a/.github/scripts/tests/test_gate_enforcement_scan.py
+++ b/.github/scripts/tests/test_gate_enforcement_scan.py
@@ -1,0 +1,646 @@
+"""Tests for .github/scripts/gate_enforcement_scan.py.
+
+`gh` is stubbed through the module's single `run` seam (per the testability-seam
+convention in docs/standards/ci.md), so every branch — gated, ungated,
+bypassable, unreadable, and each arrival verdict — is exercised without network
+access.
+
+The load-bearing assertion in here is the *fail-loud* one: an unreadable repo
+must never produce the same record as a readable-but-ungated repo, and must
+never produce the same record as a gated one. A scanner whose whole purpose is
+to stop a false green cannot itself manufacture one out of an auth error.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from gate_enforcement_scan import (  # noqa: E402
+    ARRIVAL_INTERMITTENT,
+    ARRIVAL_NEVER,
+    ARRIVAL_NO_DATA,
+    ARRIVAL_REPORTING,
+    ARRIVAL_UNKNOWN,
+    DEFAULT_NAME_PATTERN,
+    DEFAULT_REQUIRED_CONTEXT,
+    FINDING_BOT_BYPASS,
+    FINDING_BYPASSABLE,
+    FINDING_DIRECT_PUSH,
+    FINDING_NOT_ARRIVING,
+    FINDING_NOT_REQUIRED,
+    FINDING_UNPRODUCIBLE,
+    FINDING_UNREADABLE,
+    STATUS_BYPASSABLE,
+    STATUS_NOT_GATED,
+    STATUS_UNBYPASSABLE,
+    STATUS_UNKNOWN,
+    GhError,
+    build_fleet,
+    bypass_actors,
+    classify_arrival,
+    evaluate_repo,
+    fetch_classic_protection,
+    list_fleet_repos,
+    parse_arrival_nodes,
+    required_contexts,
+    scan_repo,
+    write_outputs,
+)
+
+REPO = "atlanhq/atlan-example-app"
+GATE = DEFAULT_REQUIRED_CONTEXT
+
+
+def _ruleset(
+    *,
+    ruleset_id=1,
+    contexts=(GATE,),
+    include=("~DEFAULT_BRANCH",),
+    exclude=(),
+    enforcement="active",
+    target="branch",
+    with_pull_request=True,
+    bypass=(),
+    strict=False,
+) -> dict:
+    """A ruleset payload shaped like the real /repos/{repo}/rulesets/{id} body."""
+    rules = []
+    if with_pull_request:
+        rules.append({"type": "pull_request", "parameters": {}})
+    if contexts is not None:
+        rules.append(
+            {
+                "type": "required_status_checks",
+                "parameters": {
+                    "strict_required_status_checks_policy": strict,
+                    "required_status_checks": [
+                        {"context": c, "integration_id": 15368} for c in contexts
+                    ],
+                },
+            }
+        )
+    return {
+        "id": ruleset_id,
+        "name": "main",
+        "source_type": "Repository",
+        "target": target,
+        "enforcement": enforcement,
+        "conditions": {
+            "ref_name": {"include": list(include), "exclude": list(exclude)}
+        },
+        "rules": rules,
+        "bypass_actors": list(bypass),
+    }
+
+
+def _evaluate(**overrides) -> dict:
+    kwargs = {
+        "repo": REPO,
+        "default_branch": "main",
+        "rulesets": [_ruleset()],
+        "classic_protection": "absent",
+        "arrival_samples": [{"found": True, "truncated": False}],
+        "has_tests_workflow_file": True,
+        "required_context": GATE,
+        "errors": [],
+    }
+    kwargs.update(overrides)
+    return evaluate_repo(**kwargs)
+
+
+def _finding_ids(record: dict) -> set:
+    return {f["id"] for f in record["findings"]}
+
+
+# --- the real payload shape ------------------------------------------------
+
+
+def test_gate_context_matches_a_real_ruleset_payload():
+    """Pin the context spelling against a verbatim slice of a live ruleset.
+
+    GitHub composes the context from the *caller job id* plus the reusable
+    workflow's job name, and omits the workflow name entirely. Guessing
+    `Tests / Tests Gate` (title-cased, as the milestone prose writes it) would
+    match nothing and report the whole fleet as ungated — a silent, total false
+    negative. This is the assertion that stops that.
+    """
+    live_slice = {
+        "type": "required_status_checks",
+        "parameters": {
+            "strict_required_status_checks_policy": False,
+            "required_status_checks": [
+                {"context": "scan / Build Image", "integration_id": 15368},
+                {"context": "pre-commit", "integration_id": 15368},
+                {"context": "suite / Conformance Gate", "integration_id": 15368},
+                {"context": "tests / Tests Gate", "integration_id": 15368},
+            ],
+        },
+    }
+    contexts = required_contexts({"rules": [live_slice]})
+    assert DEFAULT_REQUIRED_CONTEXT in contexts
+
+
+def test_required_contexts_ignores_other_rule_types():
+    ruleset = _ruleset(contexts=("a", "b"))
+    assert required_contexts(ruleset) == ["a", "b"]
+
+
+# --- enforcement -----------------------------------------------------------
+
+
+def test_gated_unbypassable_is_the_only_clean_state():
+    record = _evaluate()
+    assert record["gated"] is True
+    assert record["unbypassable"] is True
+    assert record["status"] == STATUS_UNBYPASSABLE
+    assert record["findings"] == []
+
+
+def test_context_required_on_another_branch_does_not_count():
+    """A ruleset scoped to a release line says nothing about the default branch."""
+    record = _evaluate(rulesets=[_ruleset(include=("release/*",))])
+    assert record["status"] == STATUS_NOT_GATED
+    assert FINDING_NOT_REQUIRED in _finding_ids(record)
+
+
+@pytest.mark.parametrize("enforcement", ["evaluate", "disabled"])
+def test_non_active_enforcement_is_not_gated(enforcement):
+    """`evaluate` is GitHub's dry-run mode: it reports and never blocks."""
+    record = _evaluate(rulesets=[_ruleset(enforcement=enforcement)])
+    assert record["status"] == STATUS_NOT_GATED
+
+
+def test_excluded_branch_wins_over_include():
+    record = _evaluate(rulesets=[_ruleset(include=("~ALL",), exclude=("main",))])
+    assert record["status"] == STATUS_NOT_GATED
+
+
+def test_other_required_checks_are_reported_so_a_rename_is_visible():
+    """A renamed gate must read as 'not required, but these are' — not silence."""
+    record = _evaluate(rulesets=[_ruleset(contexts=("tests / Tests Gateway",))])
+    assert record["status"] == STATUS_NOT_GATED
+    assert record["enforcement"]["requiredContexts"] == ["tests / Tests Gateway"]
+    assert "tests / Tests Gateway" in record["findings"][0]["message"]
+
+
+def test_no_rulesets_at_all():
+    record = _evaluate(rulesets=[])
+    assert record["status"] == STATUS_NOT_GATED
+    assert record["enforcement"]["requiredContexts"] == []
+    assert FINDING_DIRECT_PUSH in _finding_ids(record)
+
+
+# --- bypass ----------------------------------------------------------------
+
+
+def test_bypass_actor_downgrades_to_bypassable():
+    record = _evaluate(
+        rulesets=[
+            _ruleset(
+                bypass=[
+                    {
+                        "actor_id": 5,
+                        "actor_type": "RepositoryRole",
+                        "bypass_mode": "always",
+                    }
+                ]
+            )
+        ]
+    )
+    assert record["gated"] is True
+    assert record["unbypassable"] is False
+    assert record["status"] == STATUS_BYPASSABLE
+    assert _finding_ids(record) == {FINDING_BYPASSABLE}
+    assert record["bypass"]["actors"][0]["bypassMode"] == "always"
+
+
+def test_app_bypass_is_called_out_separately():
+    """'No bot can bypass the gate' is an explicit assertion of this milestone,
+    and an App entry is invisible among role-based ones without its own finding."""
+    record = _evaluate(
+        rulesets=[
+            _ruleset(
+                bypass=[
+                    {
+                        "actor_id": 62283865,
+                        "actor_type": "Integration",
+                        "bypass_mode": "always",
+                    }
+                ]
+            )
+        ]
+    )
+    assert FINDING_BOT_BYPASS in _finding_ids(record)
+    assert len(record["bypass"]["botActors"]) == 1
+
+
+def test_bypass_on_an_unrelated_ruleset_does_not_count():
+    """A bypass only exempts the ruleset it sits on. Attributing an unrelated
+    ruleset's bypass to the gate would overstate bypassability."""
+    unrelated = _ruleset(
+        ruleset_id=2,
+        contexts=("pre-commit",),
+        bypass=[
+            {"actor_id": 5, "actor_type": "RepositoryRole", "bypass_mode": "always"}
+        ],
+    )
+    record = _evaluate(rulesets=[_ruleset(), unrelated])
+    assert record["status"] == STATUS_UNBYPASSABLE
+    assert record["bypass"]["actors"] == []
+
+
+def test_no_pull_request_requirement_means_direct_push_bypasses_everything():
+    record = _evaluate(rulesets=[_ruleset(with_pull_request=False)])
+    assert record["bypass"]["directPushPermitted"] is True
+    assert record["status"] == STATUS_BYPASSABLE
+    assert FINDING_DIRECT_PUSH in _finding_ids(record)
+
+
+def test_pull_request_rule_may_live_on_a_second_ruleset():
+    """PR-required and checks-required are commonly split across rulesets;
+    requiring both on one object would report a false direct-push hole."""
+    checks_only = _ruleset(ruleset_id=1, with_pull_request=False)
+    pr_only = _ruleset(ruleset_id=2, contexts=None, with_pull_request=True)
+    record = _evaluate(rulesets=[checks_only, pr_only])
+    assert record["bypass"]["directPushPermitted"] is False
+    assert record["status"] == STATUS_UNBYPASSABLE
+
+
+@pytest.mark.parametrize("classic", ["forbidden", "unknown"])
+def test_unreadable_classic_protection_blocks_the_unbypassable_claim(classic):
+    """Downgrades the claim, never the fact: the repo stays `gated`."""
+    record = _evaluate(classic_protection=classic)
+    assert record["gated"] is True
+    assert record["status"] == STATUS_BYPASSABLE
+    assert FINDING_UNREADABLE in _finding_ids(record)
+
+
+def test_bypass_actors_normalisation_carries_the_mode():
+    actors = bypass_actors(
+        _ruleset(
+            ruleset_id=9,
+            bypass=[
+                {
+                    "actor_id": 1,
+                    "actor_type": "OrganizationAdmin",
+                    "bypass_mode": "pull_request",
+                }
+            ],
+        )
+    )
+    assert actors == [
+        {
+            "rulesetId": 9,
+            "actorType": "OrganizationAdmin",
+            "actorId": 1,
+            "bypassMode": "pull_request",
+        }
+    ]
+
+
+# --- arrival ---------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "samples,expected",
+    [
+        ([{"found": True, "truncated": False}] * 3, ARRIVAL_REPORTING),
+        ([{"found": False, "truncated": False}] * 3, ARRIVAL_NEVER),
+        (
+            [{"found": True, "truncated": False}, {"found": False, "truncated": False}],
+            ARRIVAL_INTERMITTENT,
+        ),
+        ([], ARRIVAL_NO_DATA),
+        ([{"found": False, "truncated": True}], ARRIVAL_UNKNOWN),
+    ],
+)
+def test_classify_arrival(samples, expected):
+    assert classify_arrival(samples)[0] == expected
+
+
+def test_truncated_samples_leave_the_denominator():
+    """>100 contexts on a commit with the gate not among the first 100 proves
+    nothing; counting it as a miss would invent a never-arriving gate."""
+    verdict, sampled, found, truncated = classify_arrival(
+        [{"found": True, "truncated": False}, {"found": False, "truncated": True}]
+    )
+    assert (verdict, sampled, found, truncated) == (ARRIVAL_REPORTING, 1, 1, 1)
+
+
+def test_a_truncated_sample_that_found_the_gate_still_counts():
+    verdict, sampled, found, _ = classify_arrival([{"found": True, "truncated": True}])
+    assert (verdict, sampled, found) == (ARRIVAL_REPORTING, 1, 1)
+
+
+def test_required_but_never_arriving_is_a_finding():
+    record = _evaluate(arrival_samples=[{"found": False, "truncated": False}] * 5)
+    assert record["status"] == STATUS_UNBYPASSABLE
+    assert FINDING_NOT_ARRIVING in _finding_ids(record)
+    assert record["arrival"]["prsWithContext"] == 0
+
+
+def test_never_arriving_is_not_reported_when_the_gate_is_not_required():
+    """An ungated repo with no gate runs is ordinary, not a stall."""
+    record = _evaluate(
+        rulesets=[],
+        arrival_samples=[{"found": False, "truncated": False}] * 5,
+    )
+    assert FINDING_NOT_ARRIVING not in _finding_ids(record)
+
+
+def test_gated_never_arriving_without_a_workflow_file_is_the_deadlock_case():
+    record = _evaluate(
+        has_tests_workflow_file=False,
+        arrival_samples=[{"found": False, "truncated": False}] * 5,
+    )
+    assert FINDING_UNPRODUCIBLE in _finding_ids(record)
+
+
+def test_a_missing_workflow_file_alone_is_not_a_finding():
+    """Observed on the real fleet: repos with no `.github/workflows/tests.yaml`
+    still emit `tests / Tests Gate`, because the context is composed from the
+    caller *job id*, not the file name. Treating file absence as proof would
+    invent a deadlock on a repo whose gate demonstrably reports."""
+    record = _evaluate(
+        has_tests_workflow_file=False,
+        arrival_samples=[{"found": True, "truncated": False}] * 4,
+    )
+    assert FINDING_UNPRODUCIBLE not in _finding_ids(record)
+    assert record["findings"] == []
+
+
+def test_parse_arrival_nodes_reads_both_context_shapes():
+    """CheckRun exposes `name`, StatusContext exposes `context`; reading only
+    one silently halves the evidence."""
+    payload = {
+        "data": {
+            "repository": {
+                "pullRequests": {
+                    "nodes": [
+                        {
+                            "number": 1,
+                            "commits": {
+                                "nodes": [
+                                    {
+                                        "commit": {
+                                            "statusCheckRollup": {
+                                                "contexts": {
+                                                    "totalCount": 2,
+                                                    "nodes": [
+                                                        {
+                                                            "__typename": "CheckRun",
+                                                            "name": GATE,
+                                                        },
+                                                        {
+                                                            "__typename": "StatusContext",
+                                                            "context": "pre-commit",
+                                                        },
+                                                    ],
+                                                }
+                                            }
+                                        }
+                                    }
+                                ]
+                            },
+                        }
+                    ]
+                }
+            }
+        }
+    }
+    assert parse_arrival_nodes(payload, GATE) == [
+        {"number": 1, "found": True, "truncated": False}
+    ]
+
+
+def test_parse_arrival_nodes_flags_truncation():
+    payload = {
+        "data": {
+            "repository": {
+                "pullRequests": {
+                    "nodes": [
+                        {
+                            "number": 2,
+                            "commits": {
+                                "nodes": [
+                                    {
+                                        "commit": {
+                                            "statusCheckRollup": {
+                                                "contexts": {
+                                                    "totalCount": 140,
+                                                    "nodes": [
+                                                        {
+                                                            "__typename": "CheckRun",
+                                                            "name": "x",
+                                                        }
+                                                    ],
+                                                }
+                                            }
+                                        }
+                                    }
+                                ]
+                            },
+                        }
+                    ]
+                }
+            }
+        }
+    }
+    assert parse_arrival_nodes(payload, GATE)[0]["truncated"] is True
+
+
+def test_parse_arrival_nodes_skips_commits_with_no_checks():
+    """No rollup at all carries no information either way."""
+    payload = {
+        "data": {
+            "repository": {
+                "pullRequests": {
+                    "nodes": [
+                        {
+                            "number": 3,
+                            "commits": {
+                                "nodes": [{"commit": {"statusCheckRollup": None}}]
+                            },
+                        }
+                    ]
+                }
+            }
+        }
+    }
+    assert parse_arrival_nodes(payload, GATE) == []
+
+
+# --- fail-loud -------------------------------------------------------------
+
+
+def test_unreadable_repo_is_unknown_not_ungated():
+    """The assertion this whole module exists for."""
+    record = _evaluate(errors=["gh api failed: HTTP 401"])
+    assert record["status"] == STATUS_UNKNOWN
+    assert record["gated"] is None
+    assert record["unbypassable"] is None
+    assert _finding_ids(record) == {FINDING_UNREADABLE}
+    assert "HTTP 401" in record["findings"][0]["message"]
+
+
+def test_scan_repo_reports_unknown_when_rulesets_are_unreadable():
+    def run(args: list) -> str:
+        if args[1] == f"repos/{REPO}":
+            return json.dumps({"b": "main"})
+        raise GhError("gh api failed: HTTP 403", status=403)
+
+    record = scan_repo(REPO, GATE, sample_size=0, run=run)
+    assert record["status"] == STATUS_UNKNOWN
+
+
+def test_scan_repo_survives_a_failed_arrival_probe():
+    """A GraphQL outage must not discard the ruleset evidence already read."""
+
+    def run(args: list) -> str:
+        if args[1] == "graphql":
+            raise GhError("gh api failed: HTTP 502", status=502)
+        if args[1] == f"repos/{REPO}":
+            return json.dumps({"b": "main"})
+        if args[1].startswith(f"repos/{REPO}/rulesets?"):
+            return json.dumps([[{"id": 1}]])
+        if args[1] == f"repos/{REPO}/rulesets/1":
+            return json.dumps(_ruleset())
+        return json.dumps("ok")
+
+    record = scan_repo(REPO, GATE, sample_size=5, run=run)
+    assert record["status"] == STATUS_UNBYPASSABLE
+    assert record["arrival"]["status"] == ARRIVAL_NO_DATA
+
+
+def test_scan_repo_reads_a_gated_repo_end_to_end():
+    calls: list = []
+
+    def run(args: list) -> str:
+        calls.append(args[1])
+        if args[1] == f"repos/{REPO}":
+            return json.dumps({"b": "main"})
+        if args[1].startswith(f"repos/{REPO}/rulesets?"):
+            return json.dumps([[{"id": 1}]])
+        if args[1] == f"repos/{REPO}/rulesets/1":
+            return json.dumps(_ruleset())
+        if args[1].endswith("/protection"):
+            raise GhError("gh api failed: HTTP 404", status=404)
+        return json.dumps("sha")
+
+    record = scan_repo(REPO, GATE, sample_size=0, run=run)
+    assert record["status"] == STATUS_UNBYPASSABLE
+    assert record["enforcement"]["classicProtection"] == "absent"
+    assert record["hasTestsWorkflowFile"] is True
+    assert f"repos/{REPO}/rulesets?includes_parents=true" in calls
+
+
+@pytest.mark.parametrize("status,expected", [(404, "absent"), (403, "forbidden")])
+def test_classic_protection_distinguishes_404_from_403(status, expected):
+    """404 means unprotected; 403 means we cannot see it. Collapsing them would
+    let an admin-gated read report as 'no protection here'."""
+
+    def run(args: list) -> str:
+        raise GhError("boom", status=status)
+
+    assert fetch_classic_protection(REPO, "main", run=run) == expected
+
+
+def test_classic_protection_reraises_unexpected_failures():
+    def run(args: list) -> str:
+        raise GhError("boom", status=500)
+
+    with pytest.raises(GhError):
+        fetch_classic_protection(REPO, "main", run=run)
+
+
+# --- discovery + rollup ----------------------------------------------------
+
+
+def test_list_fleet_repos_filters_by_name_pattern():
+    def run(args: list) -> str:
+        return json.dumps(
+            [
+                "atlanhq/atlan-mysql-app",
+                "atlanhq/application-sdk",
+                "atlanhq/connectors-sql",
+                "atlanhq/atlan-openapi-app",
+            ]
+        )
+
+    assert list_fleet_repos("atlanhq", DEFAULT_NAME_PATTERN, run=run) == [
+        "atlanhq/atlan-mysql-app",
+        "atlanhq/atlan-openapi-app",
+    ]
+
+
+def test_build_fleet_counts_the_headline_binary():
+    records = [
+        _evaluate(repo="atlanhq/a"),
+        _evaluate(
+            repo="atlanhq/b",
+            rulesets=[
+                _ruleset(
+                    bypass=[
+                        {
+                            "actor_id": 5,
+                            "actor_type": "RepositoryRole",
+                            "bypass_mode": "always",
+                        }
+                    ]
+                )
+            ],
+        ),
+        _evaluate(repo="atlanhq/c", rulesets=[]),
+        _evaluate(repo="atlanhq/d", errors=["HTTP 500"]),
+    ]
+    fleet = build_fleet(records, GATE)
+    assert fleet["fleetSize"] == 4
+    assert fleet["gated"] == 2
+    assert fleet["gatedUnbypassable"] == 1
+    assert fleet["gatedBypassable"] == 1
+    assert fleet["notGated"] == 1
+    assert fleet["unknown"] == 1
+    assert len(fleet["repos"]) == 4
+
+
+def test_unknown_repos_are_excluded_from_the_percentage():
+    """An auth outage must not read as the fleet regressing."""
+    records = [_evaluate(repo="atlanhq/a")] + [
+        _evaluate(repo=f"atlanhq/{n}", errors=["HTTP 500"]) for n in "bcd"
+    ]
+    fleet = build_fleet(records, GATE)
+    assert fleet["gatedPct"] == 100.0
+    assert fleet["unknown"] == 3
+
+
+def test_write_outputs_layout(tmp_path):
+    records = [_evaluate(repo="atlanhq/atlan-mysql-app")]
+    fleet = build_fleet(records, GATE)
+    write_outputs(records, fleet, tmp_path)
+
+    repo_doc = json.loads(
+        (tmp_path / "repos" / "atlanhq_atlan-mysql-app.json").read_text()
+    )
+    assert repo_doc["repo"] == "atlanhq/atlan-mysql-app"
+    assert json.loads((tmp_path / "fleet.json").read_text())["gated"] == 1
+
+    history = (tmp_path / "history_atlanhq_atlan-mysql-app.jsonl").read_text().strip()
+    assert json.loads(history)["status"] == STATUS_UNBYPASSABLE
+    assert (
+        json.loads((tmp_path / "history_fleet.jsonl").read_text().strip())["gated"] == 1
+    )
+
+
+def test_history_is_append_only(tmp_path):
+    records = [_evaluate(repo="atlanhq/atlan-mysql-app")]
+    fleet = build_fleet(records, GATE)
+    write_outputs(records, fleet, tmp_path)
+    write_outputs(records, fleet, tmp_path)
+    lines = (tmp_path / "history_fleet.jsonl").read_text().strip().splitlines()
+    assert len(lines) == 2

--- a/.github/scripts/tests/test_gate_enforcement_scan.py
+++ b/.github/scripts/tests/test_gate_enforcement_scan.py
@@ -476,6 +476,35 @@ def test_parse_arrival_nodes_skips_commits_with_no_checks():
     assert parse_arrival_nodes(payload, GATE) == []
 
 
+def test_parse_arrival_nodes_raises_on_a_structurally_malformed_body():
+    """`{"data": {}}` or `repository: null` is GraphQL schema/response drift,
+    not "no PRs had the context" — coercing it to zero samples would read as a
+    clean `no-data` instead of `unknown`."""
+    with pytest.raises(GhError, match="malformed arrival payload"):
+        parse_arrival_nodes({"data": {}}, GATE)
+    with pytest.raises(GhError, match="malformed arrival payload"):
+        parse_arrival_nodes({"data": {"repository": None}}, GATE)
+
+
+def test_scan_repo_reports_unknown_when_a_ruleset_detail_fails():
+    """A ruleset-detail GET that fails must not read as "no gate here" — the
+    repo must go `unknown`, never be evaluated on a partially-expanded list."""
+
+    def run(args: list) -> str:
+        if args[1] == f"repos/{REPO}":
+            return json.dumps({"b": "main"})
+        if args[1].startswith(f"repos/{REPO}/rulesets?"):
+            return json.dumps([[{"id": 1}, {"id": 2}]])
+        if args[1] == f"repos/{REPO}/rulesets/1":
+            return json.dumps(_ruleset(ruleset_id=1))
+        raise GhError("gh api failed: HTTP 429", status=429)
+
+    record = scan_repo(REPO, GATE, sample_size=0, run=run)
+    assert record["status"] == STATUS_UNKNOWN
+    assert record["gated"] is None
+    assert _finding_ids(record) == {FINDING_UNREADABLE}
+
+
 # --- fail-loud -------------------------------------------------------------
 
 

--- a/.github/scripts/tests/test_publish_fleet_dashboard.py
+++ b/.github/scripts/tests/test_publish_fleet_dashboard.py
@@ -1,0 +1,188 @@
+"""Tests for .github/scripts/publish_fleet_dashboard.py.
+
+`aws` is stubbed through the module's single `run` seam, with a fake bucket
+backing it, so the download → merge → re-upload sequence is exercised end to end
+without network or credentials. The sequence is the point: its failure mode in
+the shell original was a step that uploaded the per-repo document and then died
+before ever writing a history line, leaving a dashboard with data and no trend.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from publish_fleet_dashboard import (  # noqa: E402
+    BUCKET,
+    merge_history,
+    publish,
+    refresh_manifest,
+)
+
+PREFIX = "gate-enforcement-dashboard"
+
+
+class FakeS3:
+    """A dict-backed S3 double driving the module's `run` seam."""
+
+    def __init__(self, initial=None):
+        self.objects = dict(initial or {})
+
+    def __call__(self, args: list) -> tuple:
+        if args[:2] == ["s3", "cp"]:
+            src, dst = args[2], args[3]
+            if src.startswith(BUCKET):
+                if src not in self.objects:
+                    return 1, ""  # a missing object: first publish
+                Path(dst).write_text(self.objects[src])
+                return 0, ""
+            self.objects[dst] = Path(src).read_text()
+            return 0, ""
+        if args[:2] == ["s3", "ls"]:
+            listing = "".join(
+                f"2026-08-14 12:00:00       1234 {key.rsplit('/', 1)[-1]}\n"
+                for key in sorted(self.objects)
+                if key.startswith(args[2])
+            )
+            return 0, listing
+        raise AssertionError(f"unexpected aws call: {args}")
+
+
+def _scan_dir(
+    tmp_path: Path, repos=("atlanhq_atlan-mysql-app",), with_fleet=True
+) -> Path:
+    scan = tmp_path / "scan"
+    (scan / "repos").mkdir(parents=True)
+    for slug in repos:
+        (scan / "repos" / f"{slug}.json").write_text(
+            json.dumps({"repo": slug.replace("_", "/", 1), "gated": True})
+        )
+        (scan / f"history_{slug}.jsonl").write_text(
+            json.dumps({"date": "2026-08-14", "gated": True}) + "\n"
+        )
+    if with_fleet:
+        (scan / "fleet.json").write_text(
+            json.dumps({"fleetSize": len(repos), "gated": 1})
+        )
+        (scan / "history_fleet.jsonl").write_text(
+            json.dumps({"date": "2026-08-14", "gated": 1}) + "\n"
+        )
+    return scan
+
+
+def test_full_fleet_publish_writes_every_object(tmp_path):
+    s3 = FakeS3()
+    summary = publish(
+        _scan_dir(tmp_path), PREFIX, single_repo=False, tmp_dir=tmp_path, run=s3
+    )
+
+    assert f"{BUCKET}/{PREFIX}/repos/atlanhq_atlan-mysql-app.json" in s3.objects
+    assert f"{BUCKET}/{PREFIX}/fleet.json" in s3.objects
+    assert f"{BUCKET}/{PREFIX}/history/atlanhq_atlan-mysql-app.jsonl" in s3.objects
+    assert f"{BUCKET}/{PREFIX}/history/fleet.jsonl" in s3.objects
+    assert summary["fleetPublished"] is True
+
+
+def test_first_publish_still_writes_history(tmp_path):
+    """The regression this script exists for: with no stored history object yet,
+    the merge must still produce one rather than aborting the step."""
+    s3 = FakeS3()
+    publish(_scan_dir(tmp_path), PREFIX, single_repo=False, tmp_dir=tmp_path, run=s3)
+    stored = s3.objects[f"{BUCKET}/{PREFIX}/history/atlanhq_atlan-mysql-app.jsonl"]
+    assert json.loads(stored.strip())["date"] == "2026-08-14"
+
+
+def test_history_merge_is_append_only_and_deduplicated(tmp_path):
+    key = f"{BUCKET}/{PREFIX}/history/slug.jsonl"
+    s3 = FakeS3({key: json.dumps({"date": "2026-08-13", "gated": False}) + "\n"})
+    local = tmp_path / "history_slug.jsonl"
+    local.write_text(json.dumps({"date": "2026-08-14", "gated": True}) + "\n")
+
+    merge_history(local, PREFIX, "slug", tmp_path, run=s3)
+    merge_history(local, PREFIX, "slug", tmp_path, run=s3)
+
+    lines = [ln for ln in s3.objects[key].splitlines() if ln.strip()]
+    assert len(lines) == 2  # yesterday preserved, today added once
+    assert {json.loads(ln)["date"] for ln in lines} == {"2026-08-13", "2026-08-14"}
+
+
+def test_single_repo_mode_never_touches_the_fleet_aggregate(tmp_path):
+    """A one-repo scan has no fleet view; publishing one would read as the
+    fleet collapsing to a single repo."""
+    fleet_key = f"{BUCKET}/{PREFIX}/fleet.json"
+    s3 = FakeS3({fleet_key: json.dumps({"fleetSize": 166, "gated": 5})})
+    summary = publish(
+        _scan_dir(tmp_path), PREFIX, single_repo=True, tmp_dir=tmp_path, run=s3
+    )
+
+    assert json.loads(s3.objects[fleet_key])["fleetSize"] == 166
+    assert f"{BUCKET}/{PREFIX}/history/fleet.jsonl" not in s3.objects
+    assert summary["fleetPublished"] is False
+
+
+def test_manifest_is_built_from_the_bucket_not_the_local_scan(tmp_path):
+    """In single-repo mode the local directory holds one file; a manifest built
+    from it would hide every other repo from the dashboard."""
+    s3 = FakeS3(
+        {
+            f"{BUCKET}/{PREFIX}/repos/atlanhq_atlan-openapi-app.json": "{}",
+            f"{BUCKET}/{PREFIX}/repos/atlanhq_atlan-metabase-app.json": "{}",
+        }
+    )
+    publish(_scan_dir(tmp_path), PREFIX, single_repo=True, tmp_dir=tmp_path, run=s3)
+    manifest = json.loads(s3.objects[f"{BUCKET}/{PREFIX}/repos.json"])
+    assert manifest == [
+        "atlanhq_atlan-metabase-app.json",
+        "atlanhq_atlan-mysql-app.json",
+        "atlanhq_atlan-openapi-app.json",
+    ]
+
+
+def test_refresh_manifest_ignores_non_json_keys(tmp_path):
+    s3 = FakeS3(
+        {
+            f"{BUCKET}/{PREFIX}/repos/a.json": "{}",
+            f"{BUCKET}/{PREFIX}/repos/README.txt": "x",
+        }
+    )
+    assert refresh_manifest(PREFIX, tmp_path, run=s3) == ["a.json"]
+
+
+def test_empty_scan_is_refused(tmp_path):
+    """Publishing nothing would leave a stale dashboard reading as current."""
+    scan = tmp_path / "scan"
+    (scan / "repos").mkdir(parents=True)
+    with pytest.raises(RuntimeError, match="no per-repo documents"):
+        publish(scan, PREFIX, single_repo=False, tmp_dir=tmp_path, run=FakeS3())
+
+
+def test_missing_fleet_aggregate_on_a_full_run_is_refused(tmp_path):
+    with pytest.raises(RuntimeError, match="fleet.json"):
+        publish(
+            _scan_dir(tmp_path, with_fleet=False),
+            PREFIX,
+            single_repo=False,
+            tmp_dir=tmp_path,
+            run=FakeS3(),
+        )
+
+
+def test_upload_failure_is_not_swallowed(tmp_path):
+    def failing(args: list) -> tuple:
+        if args[:2] == ["s3", "cp"] and not args[2].startswith(BUCKET):
+            return 1, ""
+        return 0, ""
+
+    with pytest.raises(RuntimeError, match="failed to upload"):
+        publish(
+            _scan_dir(tmp_path),
+            PREFIX,
+            single_repo=False,
+            tmp_dir=tmp_path,
+            run=failing,
+        )

--- a/.github/scripts/tests/test_publish_fleet_dashboard.py
+++ b/.github/scripts/tests/test_publish_fleet_dashboard.py
@@ -38,8 +38,13 @@ class FakeS3:
             src, dst = args[2], args[3]
             if src.startswith(BUCKET):
                 if src not in self.objects:
-                    # a missing object: first publish
-                    return 1, "", "fatal error: An error occurred (404): does not exist"
+                    # a missing object: first publish (the real aws CLI signature)
+                    return (
+                        1,
+                        "",
+                        "fatal error: An error occurred (404) when calling the "
+                        'HeadObject operation: Key "..." does not exist',
+                    )
                 Path(dst).write_text(self.objects[src])
                 return 0, "", ""
             self.objects[dst] = Path(src).read_text()
@@ -207,5 +212,32 @@ def test_history_download_failure_aborts_before_upload(tmp_path):
 
     with pytest.raises(RuntimeError, match="failed to download"):
         merge_history(local, PREFIX, "slug", tmp_path, run=denied)
+
+    assert s3.objects[key] == stored  # history untouched
+
+
+def test_history_download_non_404_with_not_found_phrase_is_not_first_publish(tmp_path):
+    """A non-404 error whose stderr happens to embed "does not exist" must NOT
+    be misclassified as a first publish — only the (404)+HeadObject signature
+    is. This guards the tightened NotFound predicate."""
+    key = f"{BUCKET}/{PREFIX}/history/slug.jsonl"
+    stored = json.dumps({"date": "2026-08-13", "gated": False}) + "\n"
+    s3 = FakeS3({key: stored})
+
+    def throttled(args: list) -> tuple:
+        if args[:2] == ["s3", "cp"] and args[2].startswith(BUCKET):
+            # a 503 SlowDown that mentions a key that "does not exist" — not a 404
+            return (
+                1,
+                "",
+                "fatal error: An error occurred (503) SlowDown: the requested key does not exist",
+            )
+        return s3(args)
+
+    local = tmp_path / "history_slug.jsonl"
+    local.write_text(json.dumps({"date": "2026-08-14", "gated": True}) + "\n")
+
+    with pytest.raises(RuntimeError, match="failed to download"):
+        merge_history(local, PREFIX, "slug", tmp_path, run=throttled)
 
     assert s3.objects[key] == stored  # history untouched

--- a/.github/scripts/tests/test_publish_fleet_dashboard.py
+++ b/.github/scripts/tests/test_publish_fleet_dashboard.py
@@ -38,18 +38,19 @@ class FakeS3:
             src, dst = args[2], args[3]
             if src.startswith(BUCKET):
                 if src not in self.objects:
-                    return 1, ""  # a missing object: first publish
+                    # a missing object: first publish
+                    return 1, "", "fatal error: An error occurred (404): does not exist"
                 Path(dst).write_text(self.objects[src])
-                return 0, ""
+                return 0, "", ""
             self.objects[dst] = Path(src).read_text()
-            return 0, ""
+            return 0, "", ""
         if args[:2] == ["s3", "ls"]:
             listing = "".join(
                 f"2026-08-14 12:00:00       1234 {key.rsplit('/', 1)[-1]}\n"
                 for key in sorted(self.objects)
                 if key.startswith(args[2])
             )
-            return 0, listing
+            return 0, listing, ""
         raise AssertionError(f"unexpected aws call: {args}")
 
 
@@ -175,8 +176,8 @@ def test_missing_fleet_aggregate_on_a_full_run_is_refused(tmp_path):
 def test_upload_failure_is_not_swallowed(tmp_path):
     def failing(args: list) -> tuple:
         if args[:2] == ["s3", "cp"] and not args[2].startswith(BUCKET):
-            return 1, ""
-        return 0, ""
+            return 1, "", "fatal error: upload failed"
+        return 0, "", ""
 
     with pytest.raises(RuntimeError, match="failed to upload"):
         publish(
@@ -186,3 +187,25 @@ def test_upload_failure_is_not_swallowed(tmp_path):
             tmp_dir=tmp_path,
             run=failing,
         )
+
+
+def test_history_download_failure_aborts_before_upload(tmp_path):
+    """A non-NotFound download failure (AccessDenied, throttling, timeout) must
+    NOT be treated as "no history yet": merging only today's line and uploading
+    it over the stored history would silently truncate the trend line."""
+    key = f"{BUCKET}/{PREFIX}/history/slug.jsonl"
+    stored = json.dumps({"date": "2026-08-13", "gated": False}) + "\n"
+    s3 = FakeS3({key: stored})
+
+    def denied(args: list) -> tuple:
+        if args[:2] == ["s3", "cp"] and args[2].startswith(BUCKET):
+            return 1, "", "fatal error: An error occurred (AccessDenied)"
+        return s3(args)
+
+    local = tmp_path / "history_slug.jsonl"
+    local.write_text(json.dumps({"date": "2026-08-14", "gated": True}) + "\n")
+
+    with pytest.raises(RuntimeError, match="failed to download"):
+        merge_history(local, PREFIX, "slug", tmp_path, run=denied)
+
+    assert s3.objects[key] == stored  # history untouched

--- a/.github/workflows/gate-enforcement-dashboard.yaml
+++ b/.github/workflows/gate-enforcement-dashboard.yaml
@@ -1,0 +1,129 @@
+# Update Gate Enforcement Dashboard — standalone scheduled workflow.
+#
+# Probes whether `tests / Tests Gate` is actually *enforced* on each fleet repo
+# and publishes the result to Kryptonite for connector-pulse to ingest.
+#
+# Why a central sweep rather than per-repo self-reporting (FND-349): enforcement
+# is a GitHub *setting*, not a file, so conformance detection cannot see it. If
+# each repo published its own state, a repo that lost enforcement — or whose CI
+# stopped running — would simply stop appearing, and silence would read exactly
+# like compliance. Enumerating the fleet from here means an ungated repo is
+# present in the output with `gated: false`, and a repo missing from the output
+# means discovery failed, which is itself reported.
+#
+# Read-only. The scanner calls no mutating endpoint; `/repos/{repo}/rulesets` is
+# not administration-gated (tests-reusable.yaml has relied on that in every
+# consumer via detect_merge_queue.py), so this needs no new privilege. Classic
+# branch protection IS admin-gated and a 403 there is recorded as unreadable
+# rather than assumed absent.
+#
+# Mirrors renovate-dashboard.yaml for the discovery + S3 deployment pattern, and
+# emits the same repos/<slug>.json + fleet.json + history_*.jsonl layout, so the
+# three fleet artifacts share one serialization convention.
+#
+# Two modes:
+#   Full-fleet (schedule / workflow_dispatch without repo input):
+#     Enumerates every atlan-*-app repo, updates per-repo data, fleet.json,
+#     the repos.json manifest, and all history files.
+#   Single-repo (workflow_dispatch with repo=<owner/name>):
+#     Scans only that repo. Skips fleet.json and fleet history so a partial
+#     scan never overwrites the full-fleet aggregate.
+name: Update Gate Enforcement Dashboard
+
+on:
+  schedule:
+    # Daily. Enforcement changes are rare and human-initiated, so a 6-hourly
+    # cadence would spend API budget to re-derive an unchanged answer; a day is
+    # short enough that a removed gate is caught long before the next release.
+    - cron: "30 2 * * *"
+  workflow_dispatch:
+    inputs:
+      repo:
+        description: >
+          Single repo to scan (e.g. atlanhq/atlan-mysql-app).
+          Leave empty to scan the full fleet.
+        required: false
+        default: ""
+        type: string
+
+permissions:
+  contents: read
+  id-token: write # OIDC auth for aws-actions/configure-aws-credentials
+
+concurrency:
+  # Serialize: the history download → merge → upload sequence must never race
+  # itself, and a scheduled run overlapping a manual one would interleave writes
+  # to the same S3 objects.
+  group: gate-enforcement-dashboard
+  cancel-in-progress: false
+
+jobs:
+  gate-enforcement:
+    name: Update Gate Enforcement Dashboard
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout application-sdk
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Mint fleet App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          app-id: ${{ secrets.FLEET_APP_ID }}
+          private-key: ${{ secrets.FLEET_APP_PRIVATE_KEY }}
+          owner: atlanhq
+
+      # The full-fleet / single-repo branch lives in two mutually-exclusive
+      # steps with `if:` conditions rather than an if/else inside one `run:`,
+      # per docs/standards/ci.md. Each step's shell is then straight-line.
+      - name: Scan gate enforcement state
+        if: inputs.repo == ''
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/gate_enforcement_scan.py \
+            --owner atlanhq \
+            --out /tmp/gate-enforcement
+
+      - name: Scan gate enforcement state (single repo)
+        if: inputs.repo != ''
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          SINGLE_REPO: ${{ inputs.repo }}
+        run: |
+          set -euo pipefail
+          printf '["%s"]' "$SINGLE_REPO" > /tmp/gate-repos.json
+          python3 .github/scripts/gate_enforcement_scan.py \
+            --repos-file /tmp/gate-repos.json \
+            --out /tmp/gate-enforcement
+
+      - name: Setup AWS Credentials
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6
+        with:
+          aws-region: ap-south-1
+          role-to-assume: arn:aws:iam::733936409301:role/kryptonite-store_FullAccess
+
+      # Upload runs through a tested script rather than inline shell: the
+      # download → merge → re-upload history sequence has a silent failure mode
+      # (a first publish leaves no local file, `cat` exits 1 under pipefail, and
+      # the step dies *after* the per-repo document uploaded — data in S3, no
+      # trend line) that YAML cannot regression-test. See
+      # tests/test_publish_fleet_dashboard.py.
+      - name: Deploy to Kryptonite (gate enforcement)
+        if: inputs.repo == ''
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/publish_fleet_dashboard.py \
+            --dir /tmp/gate-enforcement \
+            --prefix gate-enforcement-dashboard
+
+      - name: Deploy to Kryptonite (gate enforcement, single repo)
+        if: inputs.repo != ''
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/publish_fleet_dashboard.py \
+            --dir /tmp/gate-enforcement \
+            --prefix gate-enforcement-dashboard \
+            --single-repo


### PR DESCRIPTION
## Why

Conformance detection reads repo **files**. Whether a status check is required, and whether it can be bypassed, is a GitHub *setting* rather than a file — so the one property the test-gate milestone asserts is the one property the fleet's own drift detector cannot see.

Everything else in the fleet is continuously re-detected and re-reported. This would be established once and then trusted forever: it can be turned off in a settings page, or lost when a repo is recreated, and nothing anywhere would report it. Silence would read exactly like compliance.

This adds a settings-probe channel alongside the file-based findings. Read-only throughout — `/repos/{repo}/rulesets` is not administration-gated (`detect_merge_queue.py` has relied on that in every consumer's CI), so no new privilege is needed.

## What

| File | Role |
|---|---|
| `.github/scripts/gate_enforcement_scan.py` | Enumerates the `atlan-*-app` fleet and, per repo, reports whether the gate context is required on the default branch, whether it is bypassable, and whether the check actually arrives on recent pull requests |
| `.github/scripts/publish_fleet_dashboard.py` | The S3 upload, extracted from inline shell per `docs/standards/ci.md` |
| `.github/workflows/gate-enforcement-dashboard.yaml` | Daily refresh, publishing the `repos/` + `fleet.json` + `history/` layout the Renovate and test-readiness dashboards already use, so connector-pulse sees one serialization convention across all three |

## Design notes for review

**Central sweep, not per-repo self-reporting.** If each repo published its own state, a repo that lost enforcement would simply stop appearing — and the failure this issue names is precisely that silence reads as compliance. Enumerating from one place means an ungated repo is *present* in the output with `gated: false`, and a repo missing from the output means discovery failed, which is itself reported.

**Fail-loud, deliberately opposite to `detect_merge_queue.py`.** That script fails open because a misdetection costs a redundant test run. Here a misdetection would report an ungated repo as gated — the exact false green this exists to prevent — so an unreadable repo lands as `status: "unknown"`, is counted apart from `not-gated`, and is excluded from the gated percentage. An auth outage cannot read as a mass regression. `status` is four-valued rather than boolean for this reason.

**Arrival is observed, not inferred.** GitHub composes a check context from the caller *job id* and the reusable's job name, so the presence of a particular workflow *file* does not establish that the context can be produced — repos in this fleet demonstrably emit it from differently-named files. Observed arrival on real pull requests is the authoritative signal; the file only corroborates it. Presence, not conclusion, is what's counted, which also sidesteps the check-run ordering trap on PRs that stack several cancelled runs on one SHA.

**Shared ruleset matching.** `detect_merge_queue.py`'s active/target/`ref_name` logic is extracted into `targets_branch()` and reused rather than reimplemented, so the two readers cannot drift on what "this ruleset applies to this branch" means. Behaviour there is unchanged and its existing tests still pass.

**Why `publish_fleet_dashboard.py` exists.** The history download → merge → re-upload sequence has a silent failure mode: on a first publish the download leaves no local file, `cat` exits 1 under `pipefail`, and the step dies *after* the per-repo document has already uploaded — data in the bucket, no trend line. That is the class of branch YAML cannot regression-test, so it moved into a tested script.

## Testing

- 52 new tests across the two scripts; full `.github/scripts/tests` suite green (2007 passed).
- The gate context spelling is pinned against a verbatim slice of a live ruleset payload rather than trusted from prose — guessing it wrong would report the whole fleet as ungated, a silent and total false negative.
- Run live against the full fleet; results and the connector-pulse field contract are recorded on FND-349.

## Follow-ups

- No dashboard UI — this is the data channel only.
- First publish to the Kryptonite prefix happens on the next scheduled run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)