### PR TITLE
feat(conformance): add bootstrap --resync for scaffold drift (FND-356)

### DIFF
--- a/.claude/skills/remediate/SKILL.md
+++ b/.claude/skills/remediate/SKILL.md
@@ -28,7 +28,9 @@ inputs:
       mechanically pinned (SHA-resolve + repin) but always escalated to
       residue for mandatory human sign-off — assisted, not autonomous,
       remediation; C003's missing-entry case and drifted `tests.yaml`/
-      `renovate.json` still route to residue with no fix attempted; security
+      `renovate.json` still route to residue rather than being auto-applied —
+      the two drifted scaffolds with a `bootstrap --resync` remedy quoted for
+      the human, the rest with no fix attempted; security
       is suggest-only — every S-series finding is routed to residue with a
       drafted fix, never auto-applied).
       Example: --area deprecation
@@ -149,7 +151,7 @@ dispatches each finding to its area prescription.
 | dockerfile | I | ✅ Suggest-only | Findings modelled + routed to residue |
 | tests | T | ✅ Strict-only | WARNING-tier; strict mode |
 | logging | L | ✅ Implemented | Mechanical (L004, L007, L015, L017, L020) auto-fixed; judgment (L001, L002, L005, others) modelled + routed to residue |
-| ci | C | ✅ Partial | C002 (managed-file drift) and C003's absent-`.gitignore` case both mechanical via the same `bootstrap` re-sync, invoked directly for either finding. C001 (unpinned action) mechanical SHA-resolve + repin, always escalated to residue for sign-off (external lookup). C003 missing-entry and drifted `tests.yaml`/`renovate.json` → residue |
+| ci | C | ✅ Partial | C002 (managed-file drift) and C003's absent-`.gitignore` case both mechanical via the same `bootstrap` re-sync, invoked directly for either finding. C001 (unpinned action) mechanical SHA-resolve + repin, always escalated to residue for sign-off (external lookup). C003 missing-entry and drifted `tests.yaml`/`renovate.json` → residue, quoting `bootstrap --resync` (preserves each file's recognized values — tests.yaml's params, renovate.json's auto-merge mode; not auto-applied because a customization outside them is replaced and its `.bak` is gitignored, so the loss would be invisible in the diff) |
 | contract-toolkit | K | ✅ Strict-only | K001/K002 guided migration to App.pkl; verified by pkl-eval gate |
 | security | S | ✅ Suggest-only | S001/S002 (hardcoded credential / raw env access) drafted as proposed fixes routed to residue for mandatory human sign-off — never auto-applied, since no orthogonal gate can confirm a secret-relocation fix resolves the same credential |
 

--- a/packages/conformance/conformance/bootstrap/args.py
+++ b/packages/conformance/conformance/bootstrap/args.py
@@ -35,6 +35,23 @@ FLAGS = {
 # check — that is a separate lever with no prerequisite here (FND-347).
 TRISTATE_FLAGS = ("enforce", "conformance_blocking", "renovate_automerge")
 
+# Presence flags: no value, "true" when present and "false" otherwise. Declared
+# here rather than stripped from argv by the caller (the way ``--json`` is)
+# because these change what bootstrap *writes*, not how it reports — so the
+# module that owns argv validation should be the one that rejects
+# ``--resync=1``.
+#
+# ``--resync`` is deliberately one blanket flag rather than a per-file
+# ``--resync-<name>`` or a target list: it covers every write-if-absent
+# scaffold whose canonical can be re-rendered from values read back off the
+# file itself, and both current members (tests.yaml, renovate.json) carry the
+# same risk profile, so there is nothing for a caller to choose between. The
+# two write-if-absent files it does NOT cover are excluded structurally, not
+# by omission — see ``_sync_gitignore`` and ``_sync_contract_ledger``.
+PRESENCE_FLAGS = {
+    "--resync": "resync",
+}
+
 _DEST_TO_FLAG = {dest: flag for flag, dest in FLAGS.items()}
 
 
@@ -57,11 +74,16 @@ def parse_bootstrap_args(argv: list[str]) -> dict[str, str]:
         "enforce": "",
         "conformance_blocking": "",
         "renovate_automerge": "",
+        **dict.fromkeys(PRESENCE_FLAGS.values(), "false"),
     }
     i = 0
     while i < len(argv):
         arg = argv[i]
         consumed = False
+        if arg in PRESENCE_FLAGS:
+            result[PRESENCE_FLAGS[arg]] = "true"
+            i += 1
+            continue
         for flag, dest in FLAGS.items():
             if arg == flag and i + 1 < len(argv):
                 result[dest] = argv[i + 1]
@@ -136,7 +158,8 @@ and .github/scripts/build_conformance_args.py that conformance-reusable.yaml nee
 disk in every caller repo. All of these always overwrite (re-running eradicates drift).
 tests.yaml, renovate.json, and contract_schema.lock.json are write-if-absent by default;
 pass --enforce true|false (or --renovate-automerge true|false) to also update
-renovate.json's enforcement mode.
+renovate.json's enforcement mode, and --resync to pull the resyncable scaffolds'
+structure forward without disturbing their per-repo values.
 
 The tests gate is not one of these levers. `tests / Tests Gate` becoming a required,
 unbypassable status check on the default branch is a GitHub branch-protection setting
@@ -186,6 +209,35 @@ options:
                               alone; omit to take the --enforce value (explicit or
                               detected). Passing it explicitly force-updates
                               renovate.json, exactly as --enforce does.
+  --resync                    re-render the resyncable write-if-absent scaffolds from
+                              their canonical templates, so structural catch-up lands
+                              in a repo scaffolded by an older bootstrap. Covers
+                              tests.yaml and renovate.json. Off by default: these are
+                              write-if-absent precisely so apps can customise them, and
+                              a bare re-run must never clobber that.
+                              Each re-render reuses the per-repo values read back off
+                              the existing file — NOT the flags or autodetection — so
+                              it cannot silently flip a repo that turned e2e off, that
+                              deliberately left its services-script line commented out,
+                              or that runs Renovate in soft mode. To CHANGE a value,
+                              use its own flag (--enforce/--renovate-automerge) or edit
+                              the file; those win over --resync for the file they own.
+                              Anything hand-edited outside the recognised values is
+                              replaced, with the previous content kept alongside as
+                              <name>.bak (gitignored) so the edit can be reapplied.
+                              A file whose identity can't be read back — a tests.yaml
+                              with no parseable app-name, a renovate.json that isn't
+                              valid JSON — is skipped with a message rather than
+                              rewritten from guessed defaults.
+                              No-op on a file that is already canonical, judged by the
+                              same comparison C002 uses, so this rewrites exactly what
+                              C002 flags as drift and never churns a file it calls
+                              clean.
+                              Deliberately NOT covered: .gitignore (C003 remediates it
+                              additively per missing entry; a re-render would delete an
+                              app's own ignores) and contract_schema.lock.json
+                              (append-only, owned by `gen-contract-ledger`, with B005/
+                              B006 tracking its drift).
   --json                       after the normal output, print one final JSON line:
                               {"skipped": bool, "touched": [...], "unchanged": [...]}.
                               `touched` lists every path this invocation actually wrote

--- a/packages/conformance/conformance/bootstrap/command.py
+++ b/packages/conformance/conformance/bootstrap/command.py
@@ -14,9 +14,15 @@ from __future__ import annotations
 import json
 import pathlib
 import tomllib
+from collections.abc import Callable
 
 from conformance.bootstrap.args import BOOTSTRAP_USAGE, parse_bootstrap_args
 from conformance.bootstrap.autodetect import apply_bootstrap_autodetection
+from conformance.bootstrap.extract import (
+    extract_renovate_automerge,
+    extract_tests_yaml_params,
+    strip_action_pins,
+)
 from conformance.bootstrap.render import MANAGED_ACTION_FILES, MANAGED_WORKFLOWS, render
 
 _PACKAGE_NAME = "atlan-application-sdk-conformance"
@@ -94,11 +100,24 @@ def _is_inside_conformance_repo(start: pathlib.Path) -> bool:
 
 
 def _sync_tests_yaml(
-    root: pathlib.Path, kwargs: dict[str, str]
+    root: pathlib.Path, kwargs: dict[str, str], resync: bool
 ) -> list[tuple[pathlib.Path, str]]:
     """tests.yaml — write-if-absent scaffold; apps customise freely.
 
-    C002 tracks drift at WARN only. Delete + re-run to force-regenerate.
+    C002 tracks drift at WARN only.  With *resync* (``--resync``) an existing
+    file is re-rendered from the canonical template so a repo scaffolded by an
+    older bootstrap catches up structurally.
+
+    The re-render deliberately ignores *kwargs* and reads its params back off
+    the existing file instead.  kwargs' tests.yaml values come from flags and
+    autodetection, neither of which reflects what this file actually says:
+    ``enable_e2e`` is never autodetected at all (it defaults to ``"true"``),
+    so rendering from kwargs would silently switch e2e back on in a repo that
+    turned it off, and ``services_script`` is detected from the script merely
+    *existing* on disk, so it would activate a line a repo deliberately left
+    commented out.  Reading them off the file — via the same extractor C002
+    uses to decide the file drifted — keeps every per-repo choice and makes
+    the written bytes exactly the canonical the checker compares against.
 
     Returns the ``(path, status)`` pairs this call wrote or left alone, for
     ``main()``'s ``--json`` touched-files manifest.
@@ -109,21 +128,124 @@ def _sync_tests_yaml(
         tests_dest.write_text(render("tests.yaml", **kwargs), encoding="utf-8")
         print(f"scaffolded: {tests_dest}")
         return [(tests_dest, "scaffolded")]
-    print(f"ok (exists): {tests_dest}  (edit freely; C002 tracks drift at WARN)")
+    if resync:
+        return _resync_scaffold(tests_dest, "tests.yaml", _tests_yaml_resync_params)
+    print(
+        f"ok (exists): {tests_dest}"
+        "  (edit freely; C002 tracks drift at WARN — pass"
+        " --resync to re-render from the canonical)"
+    )
     return [(tests_dest, "exists")]
 
 
+def _tests_yaml_resync_params(text: str) -> dict[str, str] | None:
+    """Params to re-render *text* (a tests.yaml) with, or ``None`` to skip.
+
+    ``app_name`` is identity-defining: it names the app in every downstream CI
+    input and derives ``app-image-name``.  If it can't be read back, ``render``
+    would fall back to ``"app"`` and the resync would quietly rename the app's
+    own workflow inputs while reporting success.  Skip rather than guess — a
+    file that drifted past its own name needs a human, not a re-render.
+    """
+    params = extract_tests_yaml_params(text)
+    return params if params.get("app_name") else None
+
+
+def _renovate_json_resync_params(text: str) -> dict[str, str] | None:
+    """Params to re-render *text* (a renovate.json) with, or ``None`` to skip.
+
+    ``extract_renovate_automerge`` answers ``"true"`` for anything it cannot
+    parse.  That default is right for its other callers, but here it would
+    turn an unparseable soft-mode file into the auto-merge canonical — a
+    0-touch policy change (Renovate merging without a human) smuggled in under
+    a structural catch-up.  Only resync when the mode is genuinely read.
+    """
+    try:
+        json.loads(text)
+    except (json.JSONDecodeError, TypeError):
+        return None
+    return {"automerge": extract_renovate_automerge(text)}
+
+
+def _resync_scaffold(
+    dest: pathlib.Path,
+    template_name: str,
+    extract: Callable[[str], dict[str, str] | None],
+) -> list[tuple[pathlib.Path, str]]:
+    """Re-render an existing write-if-absent scaffold from its canonical.
+
+    One implementation for every ``--resync`` target: each differs only in
+    which template it renders and how its per-repo values are read back, so
+    the guards below — the identity check, the C002-identical comparison, the
+    backup — cannot end up applied to one target and forgotten on another.
+
+    *extract* returns the render params read off the on-disk content, or
+    ``None`` when they can't be read confidently enough to rewrite the file.
+
+    Returns the ``(path, status)`` pairs for ``main()``'s ``--json`` manifest.
+    """
+    try:
+        existing = dest.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        print(f"skipped: {dest} is unreadable ({exc}); left untouched")
+        return [(dest, "exists")]
+
+    params = extract(existing)
+    if params is None:
+        print(
+            f"skipped: {dest} has drifted too far to re-render safely"
+            " (its per-repo values can't be read back); left untouched"
+        )
+        return [(dest, "exists")]
+
+    target = render(template_name, **params)
+
+    # Pin-insensitive, matching C002's own comparison: --resync must rewrite
+    # exactly what C002 calls drift and nothing else. Comparing raw bytes
+    # instead would rewrite (and back up) a file on every run whenever an
+    # action pin differs from the template's — churn on a file the checker
+    # already considers clean.
+    if strip_action_pins(existing) == strip_action_pins(target):
+        print(f"ok (up to date): {dest}")
+        return [(dest, "unchanged")]
+
+    # Unconditional backup, unlike the --enforce force-overwrite path below —
+    # which skips it when the existing content is one of the two canonical
+    # renders. There is no equivalent recognisable set here: the
+    # overwhelmingly common case is a file that was pristine for an *older*
+    # conformance version, and old templates aren't available to recognise it.
+    # So assume the difference might be a hand edit and always leave it
+    # recoverable. `*.bak` is in the bootstrap-managed .gitignore, so this
+    # never lands in a commit, and GitHub only parses .yml/.yaml under
+    # .github/workflows/ so a backed-up workflow can't register as a second
+    # workflow either.
+    bak = dest.with_suffix(dest.suffix + ".bak")
+    bak.write_text(existing, encoding="utf-8")
+    print(f"backed up: {bak}  (previous content; reapply any hand edits from it)")
+    dest.write_text(target, encoding="utf-8")
+    print(f"updated: {dest}")
+    return [(bak, "backed_up"), (dest, "updated")]
+
+
 def _sync_renovate_json(
-    root: pathlib.Path, kwargs: dict[str, str], force_renovate: bool
+    root: pathlib.Path, kwargs: dict[str, str], force_renovate: bool, resync: bool
 ) -> list[tuple[pathlib.Path, str]]:
     """renovate.json — write-if-absent normally; force-overwrite when
     ``--enforce`` or ``--renovate-automerge`` is passed explicitly so
     re-running with ``--enforce true`` (or ``--renovate-automerge true``)
     upgrades a soft-mode repo without needing to delete the file first.
 
+    *force_renovate* and *resync* are different operations on the same file
+    and are checked in that order: the former CHANGES the enforcement mode to
+    what was asked for, the latter PRESERVES whatever mode the file already
+    declares and fixes only its structure.  So an explicit mode flag wins —
+    passing it alongside ``--resync`` is an intentional mode change, and
+    having the resync's read-back-off-disk value quietly override it would
+    make the explicit flag a no-op.
+
     Returns the ``(path, status)`` pairs this call wrote or left alone —
     possibly two entries (the ``.bak`` backup plus the updated file itself)
-    when a customised ``renovate.json`` is force-overwritten.
+    when a customised ``renovate.json`` is force-overwritten or resynced.
     """
     renovate_dest = root / "renovate.json"
     if not renovate_dest.exists():
@@ -148,10 +270,14 @@ def _sync_renovate_json(
         print(f"updated: {renovate_dest}")
         results.append((renovate_dest, "updated"))
         return results
+    if resync:
+        return _resync_scaffold(
+            renovate_dest, "renovate.json", _renovate_json_resync_params
+        )
     print(
         f"ok (exists): {renovate_dest}"
         "  (edit freely; pass --enforce or --renovate-automerge to update"
-        " enforcement mode)"
+        " enforcement mode, or --resync to fix structural drift while keeping it)"
     )
     return [(renovate_dest, "exists")]
 
@@ -264,6 +390,10 @@ def main(argv: list[str]) -> int:
     # this file, so passing it and having the file left alone would be a no-op
     # flag.
     force_renovate = bool(kwargs["enforce"] or kwargs["renovate_automerge"])
+    # Popped before autodetection and the render-kwargs derivation below: it is
+    # a write-mode toggle, not a template variable, and render() takes an exact
+    # keyword set.
+    resync = kwargs.pop("resync") == "true"
     apply_bootstrap_autodetection(kwargs, root)
 
     # Resolve the two 0-touch levers, each independently expressible:
@@ -319,9 +449,9 @@ def main(argv: list[str]) -> int:
         dest = root / dest_rel
         _record(dest, _bootstrap_file(dest, render(template_name)))
 
-    for path, status in _sync_tests_yaml(root, kwargs):
+    for path, status in _sync_tests_yaml(root, kwargs, resync):
         _record(path, status)
-    for path, status in _sync_renovate_json(root, kwargs, force_renovate):
+    for path, status in _sync_renovate_json(root, kwargs, force_renovate, resync):
         _record(path, status)
     for path, status in _sync_ci_system_deps(root, kwargs["system_deps"]):
         _record(path, status)

--- a/packages/conformance/conformance/bootstrap/extract.py
+++ b/packages/conformance/conformance/bootstrap/extract.py
@@ -61,8 +61,12 @@ _COMMENT_LINE_RE = re.compile(r"^[ \t]*#.*$", re.MULTILINE)
 _ACTION_PIN_RE = re.compile(r"@[0-9a-f]{40}(?:[ \t]+#[^\n]*)?")
 
 # tests.yaml's per-repo customised values, read back off a scaffolded file.
-_APP_NAME_RE = re.compile(r'app-name:\s+"([^"]+)"')
-_APP_IMAGE_NAME_RE = re.compile(r'app-image-name:\s+"([^"]+)"')
+# Anchored like _SERVICES_SCRIPT_RE below so a *commented-out* line (the shape
+# a renamed app most often leaves behind) can't satisfy the read-back — the
+# --resync identity guard in particular must skip rather than re-render from a
+# value the file no longer declares.
+_APP_NAME_RE = re.compile(r'^\s+app-name:\s+"([^"]+)"\s*$', re.MULTILINE)
+_APP_IMAGE_NAME_RE = re.compile(r'^\s+app-image-name:\s+"([^"]+)"\s*$', re.MULTILINE)
 _ENABLE_E2E_RE = re.compile(r"enable-e2e:\s+(true|false)")
 # Matches an *uncommented* services-script line (quoted value) in the with: block.
 _SERVICES_SCRIPT_RE = re.compile(r'^\s+services-script:\s+"([^"]+)"$', re.MULTILINE)

--- a/packages/conformance/conformance/bootstrap/extract.py
+++ b/packages/conformance/conformance/bootstrap/extract.py
@@ -55,6 +55,61 @@ _SHELL_OPERATOR_RE = re.compile(r"[;&|]")
 _COMMENT_LINE_RE = re.compile(r"^[ \t]*#.*$", re.MULTILINE)
 
 
+# Matches a pinned SHA (40 lowercase hex chars) and its optional trailing version
+# comment. Example: "@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3" →
+# "@<pinned>".
+_ACTION_PIN_RE = re.compile(r"@[0-9a-f]{40}(?:[ \t]+#[^\n]*)?")
+
+# tests.yaml's per-repo customised values, read back off a scaffolded file.
+_APP_NAME_RE = re.compile(r'app-name:\s+"([^"]+)"')
+_APP_IMAGE_NAME_RE = re.compile(r'app-image-name:\s+"([^"]+)"')
+_ENABLE_E2E_RE = re.compile(r"enable-e2e:\s+(true|false)")
+# Matches an *uncommented* services-script line (quoted value) in the with: block.
+_SERVICES_SCRIPT_RE = re.compile(r'^\s+services-script:\s+"([^"]+)"$', re.MULTILINE)
+
+
+def strip_action_pins(text: str) -> str:
+    """Return *text* with every pinned action SHA normalised to ``@<pinned>``.
+
+    Single source of truth for "compare two renders of a managed file while
+    ignoring which SHA an action is pinned at". The C002 checker uses it so
+    an automated pin bump doesn't read as drift; ``bootstrap``'s
+    ``--resync`` uses it to decide whether a re-render would
+    change anything C002 cares about, so the flag rewrites exactly the files
+    C002 flags and no others.
+    """
+    return _ACTION_PIN_RE.sub("@<pinned>", text)
+
+
+def extract_tests_yaml_params(text: str) -> dict[str, str]:
+    """Extract the per-repo customised values from a scaffolded tests.yaml.
+
+    Returns only the keys that were found; callers should pass these as kwargs
+    to ``render("tests.yaml", ...)`` so defaults apply for any that are absent.
+
+    Single source of truth for the tests.yaml scaffold's parameters — the C002
+    checker extracts them to decide what "structural drift" means for this
+    file, and ``bootstrap --resync`` extracts them to re-render it.
+    Sharing one implementation is what makes the flag's write byte-identical
+    to the canonical the checker compares against; two copies could drift into
+    a resync that leaves the finding standing.
+    """
+    params: dict[str, str] = {}
+    m = _APP_NAME_RE.search(text)
+    if m:
+        params["app_name"] = m.group(1)
+    m = _APP_IMAGE_NAME_RE.search(text)
+    if m:
+        params["app_image_name"] = m.group(1)
+    m = _ENABLE_E2E_RE.search(text)
+    if m:
+        params["enable_e2e"] = m.group(1)
+    m = _SERVICES_SCRIPT_RE.search(text)
+    if m:
+        params["services_script"] = m.group(1).strip()
+    return params
+
+
 def extract_field(text: str, field: str) -> str:
     """Return the value of ``field: <value>`` in *text*, or ``""`` if absent.
 

--- a/packages/conformance/conformance/bootstrap/templates/tests.yaml
+++ b/packages/conformance/conformance/bootstrap/templates/tests.yaml
@@ -2,8 +2,10 @@
 # and drift-tracked at WARN by conformance check C002.
 #
 # Edit it freely — drift NEVER blocks CI (C002 is WARN-only, not BLOCK).
-# To force-regenerate this file from canonical, delete it and re-run bootstrap:
-#   atlan-application-sdk-conformance bootstrap --app-name <your-app-name>
+# To pull structural updates from canonical, re-run bootstrap with --resync:
+#   atlan-application-sdk-conformance bootstrap --resync
+# (--resync preserves this file's per-repo values; pass --app-name etc. only
+#  to deliberately CHANGE them.)
 name: Tests
 
 # Unified workflow — unit + integration (testcontainers), and full-DAG e2e.

--- a/packages/conformance/conformance/docs/rules/ci.md
+++ b/packages/conformance/conformance/docs/rules/ci.md
@@ -54,7 +54,11 @@ The `atlan-application-sdk-conformance bootstrap` command installs a standard se
 workflow shims into `.github/workflows/`. This rule flags any managed file that is
 missing or whose content has diverged from what `bootstrap` would write. Re-run
 `bootstrap` to re-sync; structural drift is flagged while intentional per-repo value
-choices (e.g. `package_name`, `unit_tests_workflow_file`) are preserved.
+choices (e.g. `package_name`, `unit_tests_workflow_file`) are preserved. The exceptions
+are `tests.yaml` and `renovate.json`, write-if-absent scaffolds a bare re-run never
+rewrites — pass `--resync` to pull their structure forward, which likewise preserves
+each file's recognized per-repo values (tests.yaml's app-name, app-image-name,
+enable-e2e and services-script; renovate.json's auto-merge mode).
 
 ---
 
@@ -102,14 +106,10 @@ holding its path), `curl --retry`, and `wget --tries` / `--retry-on-http-error`.
 --retry` WITHOUT `--retry-all-errors` is still flagged: plain `--retry` covers transport
 errors but not an HTTP 503, which is the failure this rule exists for. Tuning-only
 companion flags (`curl --retry-delay` / `--retry-max-time`, `wget --waitretry`) never
-count on their own: they pace a retry but do not enable one — `wget --waitretry=10`
-without `--tries` still makes exactly one attempt.
-
-Flags are evaluated per command segment (the line is split on `&&` / `||` / `;`; a pipe
-does not split — the fetcher and the shell/`tar` it feeds are one command). So a
-complete retry on one `curl` does not excuse an incomplete retry on a sibling `curl` in
-the same logical line, and a wrapper at the head of a compound command does not cover
-fetchers in later segments.
+count on their own: they pace a retry but do not enable one — `wget `--waitretry=10`
+without `--tries` still makes exactly one attempt. Flags are evaluated per command
+segment (split on `&&` / `||` / `;`; a pipe does not split), so one curl's complete
+retry does not excuse a sibling curl's incomplete one.
 
 Not flagged: fetches whose body is read rather than installed (a version lookup, a `-o
 /dev/null` health probe — those sit in their own poll loops), and localhost URLs.

--- a/packages/conformance/conformance/programs/areas/ci.prose.md
+++ b/packages/conformance/conformance/programs/areas/ci.prose.md
@@ -10,8 +10,10 @@ description: >
   step — but always routed to residue for mandatory human sign-off afterward,
   since a live-resolved SHA cannot itself be judged trustworthy by any
   recheck; this is assisted, not autonomous, remediation.  C003's
-  missing-entry case, C004, and drifted `tests.yaml`/`renovate.json` still
-  have no authored prescription and route to residue for manual triage.
+  missing-entry case, C004, and drifted `tests.yaml`/`renovate.json` route to
+  residue for manual triage — the two drifted scaffolds with a concrete
+  `--resync` remedy quoted for the human, the rest with no authored
+  prescription at all.
 ---
 
 ### Maintains
@@ -135,19 +137,35 @@ it isn't safe to assume a C002 finding already triggered it:
 
 *Not resolved by this procedure — route to residue:*
 
-- **`tests.yaml` drift** (file exists but content diverged from canonical) —
-  `bootstrap` never overwrites an existing `tests.yaml` (write-if-absent
-  scaffold). Regenerating it requires deleting the file first, which would
-  also discard any legitimate app-specific customization outside the
-  recognized param set (app-name, app-image-name, enable-e2e,
-  services-script). `classification = "judgment"` — a human must decide
-  whether the drift is stale structure (safe to delete + regenerate) or an
-  intentional customization worth preserving as-is.
-- **`renovate.json` drift** (file exists but content diverged) — fixing it
-  requires choosing the intended enforcement mode (`--enforce true|false`, or
-  `--renovate-automerge true|false` to move this file's lever alone), a
-  repo-policy decision the model must not make unilaterally.
-  `classification = "judgment"`.
+- **`tests.yaml` / `renovate.json` drift** (file exists but content diverged
+  from canonical) — `bootstrap` never overwrites either on a bare re-run
+  (write-if-absent scaffolds). `classification = "judgment"` for both, but
+  quote the concrete remedy in the residue entry rather than leaving the human
+  to derive it:
+
+  ```
+  atlan-application-sdk-conformance bootstrap --resync
+  ```
+
+  That re-renders both files from their canonicals while reusing the values
+  read back off each existing file — `tests.yaml`'s recognized param set
+  (app-name, app-image-name, enable-e2e, services-script) and `renovate.json`'s
+  declared auto-merge mode — so the structural catch-up lands without resetting
+  any of them. Strictly less destructive than the delete-and-regenerate this
+  used to advise for `tests.yaml`, and it does NOT require choosing an
+  enforcement mode for `renovate.json` the way `--enforce` /
+  `--renovate-automerge` do: those two CHANGE the mode (a repo-policy decision
+  the model must not make unilaterally), `--resync` preserves whatever the file
+  already declares.
+
+  Both stay out of the mechanical pass anyway, and the reason is specific: a
+  customization *outside* the recognized values (an extra job, a changed
+  trigger, a repo-local packageRule) is replaced by the re-render, and while
+  the previous content is kept as `<name>.bak`, `*.bak` is in the
+  bootstrap-managed `.gitignore` — so an autonomous fix would drop that
+  customization with no trace in the resulting diff for a reviewer to catch. A
+  human must confirm the drift is stale structure and not something the app
+  meant to keep.
 
 ---
 

--- a/packages/conformance/conformance/suite/checks/bootstrap_drift.py
+++ b/packages/conformance/conformance/suite/checks/bootstrap_drift.py
@@ -15,17 +15,18 @@ package_name, etc.) are not flagged as drift — only structural changes are cau
 1. **Managed shims** (``MANAGED_WORKFLOWS`` — 14 files): always-overwrite.
    Absent or drifted → WARN finding; run bootstrap to re-sync (re-runs overwrite).
 
-2. **tests.yaml**: write-if-absent scaffold.  Bootstrap creates it once and
-   never clobbers customisations.  Drift is also tracked at WARN, never BLOCK.
-   Remediation: *delete tests.yaml* then re-run bootstrap to regenerate from
-   canonical.
+2. **tests.yaml / renovate.json**: write-if-absent scaffolds.  Bootstrap
+   creates each once and never clobbers customisations.  Drift is also tracked
+   at WARN, never BLOCK.  Remediation: re-run bootstrap with ``--resync``,
+   which re-renders them from the canonical while reusing the same values
+   extracted here — so the structural catch-up lands and the per-repo choices
+   survive.
 
 Remediation: run ``atlan-application-sdk-conformance bootstrap`` to re-sync.
 """
 
 from __future__ import annotations
 
-import re
 from pathlib import Path
 
 from conformance.bootstrap.extract import (
@@ -33,7 +34,9 @@ from conformance.bootstrap.extract import (
     extract_apt_packages,
     extract_field,
     extract_renovate_automerge,
+    extract_tests_yaml_params,
     resolve_renovate_fallback_exit_zero,
+    strip_action_pins,
 )
 from conformance.bootstrap.render import MANAGED_ACTION_FILES, MANAGED_WORKFLOWS, render
 from conformance.suite.checks._ast_common import safe_read_text
@@ -50,16 +53,6 @@ _CLI_CMD = "atlan-application-sdk-conformance bootstrap"
 # Write-if-absent scaffolds tracked alongside managed shims (WARN-only drift).
 _TESTS_WORKFLOW = "tests.yaml"
 _RENOVATE_JSON = "renovate.json"
-
-# Matches a pinned SHA (40 lowercase hex chars) and its optional trailing version
-# comment so automated pin bumps (Renovate/Dependabot) are not flagged as drift.
-# Example: "@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3" → "@<pinned>"
-_ACTION_PIN_RE = re.compile(r"@[0-9a-f]{40}(?:[ \t]+#[^\n]*)?")
-
-
-def _strip_action_pins(text: str) -> str:
-    return _ACTION_PIN_RE.sub("@<pinned>", text)
-
 
 # ---------------------------------------------------------------------------
 # Managed-shim param extractors
@@ -105,39 +98,6 @@ def _extract_exit_zero(text: str, root: Path) -> str:
     except (OSError, UnicodeDecodeError):
         return "false"
     return resolve_renovate_fallback_exit_zero(renovate_text)
-
-
-# ---------------------------------------------------------------------------
-# tests.yaml param extractors
-# ---------------------------------------------------------------------------
-
-_APP_NAME_RE = re.compile(r'app-name:\s+"([^"]+)"')
-_APP_IMAGE_NAME_RE = re.compile(r'app-image-name:\s+"([^"]+)"')
-_ENABLE_E2E_RE = re.compile(r"enable-e2e:\s+(true|false)")
-# Matches an *uncommented* services-script line (quoted value) in the with: block.
-_SERVICES_SCRIPT_RE = re.compile(r'^\s+services-script:\s+"([^"]+)"$', re.MULTILINE)
-
-
-def _extract_tests_yaml_params(text: str) -> dict[str, str]:
-    """Extract the per-repo customised values from a scaffolded tests.yaml.
-
-    Returns only the keys that were found; callers should pass these as kwargs
-    to ``render("tests.yaml", ...)`` so defaults apply for any that are absent.
-    """
-    params: dict[str, str] = {}
-    m = _APP_NAME_RE.search(text)
-    if m:
-        params["app_name"] = m.group(1)
-    m = _APP_IMAGE_NAME_RE.search(text)
-    if m:
-        params["app_image_name"] = m.group(1)
-    m = _ENABLE_E2E_RE.search(text)
-    if m:
-        params["enable_e2e"] = m.group(1)
-    m = _SERVICES_SCRIPT_RE.search(text)
-    if m:
-        params["services_script"] = m.group(1).strip()
-    return params
 
 
 # ---------------------------------------------------------------------------
@@ -203,7 +163,7 @@ def _scan_managed_action_file(
         return []
     canonical = render(template_name)
 
-    if _strip_action_pins(on_disk) == _strip_action_pins(canonical):
+    if strip_action_pins(on_disk) == strip_action_pins(canonical):
         return []
 
     return [
@@ -266,7 +226,7 @@ def _scan_managed_shim(path: Path, root: Path) -> list[Finding]:
 
     canonical = render(name, **kwargs)
 
-    if _strip_action_pins(on_disk) == _strip_action_pins(canonical):
+    if strip_action_pins(on_disk) == strip_action_pins(canonical):
         return []
 
     return [
@@ -290,10 +250,7 @@ def _scan_renovate_json(path: Path, root: Path) -> list[Finding]:
     except ValueError:
         rel = str(path)
 
-    _remediate = (
-        f"To regenerate, delete renovate.json and re-run `{_CLI_CMD}` "
-        f"(drift is informational — WARN only, never blocks CI)."
-    )
+    _warn_only = "Drift is informational — WARN only, never blocks CI."
 
     if not path.exists():
         return [
@@ -303,8 +260,9 @@ def _scan_renovate_json(path: Path, root: Path) -> list[Finding]:
                 line=1,
                 column=1,
                 message=(
-                    f"Scaffolded renovate.json is absent. "
-                    f"Run `{_CLI_CMD}` to regenerate it. " + _remediate
+                    f"Scaffolded renovate.json is absent. Run `{_CLI_CMD}` to "
+                    f"scaffold it (write-if-absent: a bare re-run is enough, "
+                    f"nothing to preserve). " + _warn_only
                 ),
             )
         ]
@@ -314,7 +272,7 @@ def _scan_renovate_json(path: Path, root: Path) -> list[Finding]:
         return []
     canonical = render(_RENOVATE_JSON, automerge=extract_renovate_automerge(on_disk))
 
-    if _strip_action_pins(on_disk) == _strip_action_pins(canonical):
+    if strip_action_pins(on_disk) == strip_action_pins(canonical):
         return []
 
     return [
@@ -325,7 +283,11 @@ def _scan_renovate_json(path: Path, root: Path) -> list[Finding]:
             column=1,
             message=(
                 "Scaffolded renovate.json has drifted from the bootstrap canonical. "
-                + _remediate
+                f"Run `{_CLI_CMD} --resync` to re-render it, keeping the auto-merge "
+                "mode this file already declares — pass --enforce or "
+                "--renovate-automerge instead only to deliberately CHANGE that mode. "
+                "Any other hand edit is replaced (kept as renovate.json.bak). "
+                + _warn_only
             ),
         )
     ]
@@ -338,10 +300,7 @@ def _scan_tests_yaml(path: Path, root: Path) -> list[Finding]:
     except ValueError:
         rel = str(path)
 
-    _remediate = (
-        f"To regenerate, delete tests.yaml and re-run `{_CLI_CMD}` "
-        f"(drift is informational — WARN only, never blocks CI)."
-    )
+    _warn_only = "Drift is informational — WARN only, never blocks CI."
 
     if not path.exists():
         return [
@@ -351,8 +310,9 @@ def _scan_tests_yaml(path: Path, root: Path) -> list[Finding]:
                 line=1,
                 column=1,
                 message=(
-                    f"Scaffolded tests.yaml is absent. "
-                    f"Run `{_CLI_CMD}` to regenerate it. " + _remediate
+                    f"Scaffolded tests.yaml is absent. Run `{_CLI_CMD}` to "
+                    f"scaffold it (write-if-absent: a bare re-run is enough, "
+                    f"nothing to preserve). " + _warn_only
                 ),
             )
         ]
@@ -363,10 +323,10 @@ def _scan_tests_yaml(path: Path, root: Path) -> list[Finding]:
 
     # Extract per-repo customised values so structural drift is caught while
     # legitimate param choices (app-name, enable-e2e, services-script) are not.
-    params = _extract_tests_yaml_params(on_disk)
+    params = extract_tests_yaml_params(on_disk)
     canonical = render(_TESTS_WORKFLOW, **params)
 
-    if _strip_action_pins(on_disk) == _strip_action_pins(canonical):
+    if strip_action_pins(on_disk) == strip_action_pins(canonical):
         return []
 
     return [
@@ -378,7 +338,10 @@ def _scan_tests_yaml(path: Path, root: Path) -> list[Finding]:
             message=(
                 "Scaffolded tests.yaml has drifted from the bootstrap canonical "
                 "(structural changes detected; param customizations are not flagged). "
-                + _remediate
+                f"Run `{_CLI_CMD} --resync` to re-render it from the "
+                "canonical, reusing the app-name/app-image-name/enable-e2e/"
+                "services-script values read back off this file. Any other hand "
+                "edit is replaced (kept as tests.yaml.bak). " + _warn_only
             ),
         )
     ]

--- a/packages/conformance/conformance/suite/checks/bootstrap_drift.py
+++ b/packages/conformance/conformance/suite/checks/bootstrap_drift.py
@@ -287,7 +287,8 @@ def _scan_renovate_json(path: Path, root: Path) -> list[Finding]:
                 "mode this file already declares — pass --enforce or "
                 "--renovate-automerge instead only to deliberately CHANGE that mode. "
                 "Any other hand edit is replaced (kept as renovate.json.bak). "
-                + _warn_only
+                "If --resync reports it skipped (the file isn't valid JSON, so "
+                "its mode can't be read back), it needs a manual fix. " + _warn_only
             ),
         )
     ]
@@ -341,7 +342,9 @@ def _scan_tests_yaml(path: Path, root: Path) -> list[Finding]:
                 f"Run `{_CLI_CMD} --resync` to re-render it from the "
                 "canonical, reusing the app-name/app-image-name/enable-e2e/"
                 "services-script values read back off this file. Any other hand "
-                "edit is replaced (kept as tests.yaml.bak). " + _warn_only
+                "edit is replaced (kept as tests.yaml.bak). If --resync reports "
+                "it skipped (no parseable app-name, so its identity can't be "
+                "read back), it needs a manual fix. " + _warn_only
             ),
         )
     ]

--- a/packages/conformance/conformance/suite/rules/ci.py
+++ b/packages/conformance/conformance/suite/rules/ci.py
@@ -60,7 +60,12 @@ RULES: tuple[RuleDefinition, ...] = (
             "flags any managed file that is missing or whose content has diverged "
             "from what `bootstrap` would write. Re-run `bootstrap` to re-sync; "
             "structural drift is flagged while intentional per-repo value choices "
-            "(e.g. `package_name`, `unit_tests_workflow_file`) are preserved."
+            "(e.g. `package_name`, `unit_tests_workflow_file`) are preserved. "
+            "The exceptions are `tests.yaml` and `renovate.json`, write-if-absent "
+            "scaffolds a bare re-run never rewrites — pass `--resync` to pull their "
+            "structure forward, which likewise preserves each file's recognized "
+            "per-repo values (tests.yaml's app-name, app-image-name, enable-e2e "
+            "and services-script; renovate.json's auto-merge mode)."
         ),
         help_uri="https://github.com/atlanhq/application-sdk/blob/main/conformance/docs/rules/ci.md#c002",
     ),

--- a/packages/conformance/tests/test_bootstrap.py
+++ b/packages/conformance/tests/test_bootstrap.py
@@ -1473,6 +1473,30 @@ def test_resync_skips_tests_yaml_with_no_readable_app_name(
     assert not (tmp_path / ".github" / "workflows" / "tests.yaml.bak").exists()
 
 
+def test_resync_skips_tests_yaml_with_only_a_commented_app_name(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A commented-out `app-name:` must not satisfy the identity guard.
+
+    That is the most common shape of a renamed app — the old line left
+    commented out. An unanchored extractor would read the stale value off the
+    comment and rewrite every downstream CI input to it while reporting
+    success; the anchored one treats the file as having no parseable app-name
+    and skips instead.
+    """
+    monkeypatch.chdir(tmp_path)
+    _cmd_bootstrap([])
+    wf = tmp_path / ".github" / "workflows" / "tests.yaml"
+    renamed = "\n".join(
+        f"# {line}" if "app-name:" in line else line
+        for line in render("tests.yaml", app_name="widget").splitlines()
+    )
+    wf.write_text(renamed)
+    _cmd_bootstrap(["--resync"])
+    assert wf.read_text() == renamed
+    assert not (tmp_path / ".github" / "workflows" / "tests.yaml.bak").exists()
+
+
 # ---------------------------------------------------------------------------
 # tests.yaml template fidelity
 # ---------------------------------------------------------------------------

--- a/packages/conformance/tests/test_bootstrap.py
+++ b/packages/conformance/tests/test_bootstrap.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import pathlib
+import re
 
 import pytest
 from conformance.bootstrap.args import BOOTSTRAP_USAGE, FLAGS, parse_bootstrap_args
@@ -105,6 +106,9 @@ def test_parse_bootstrap_args_defaults() -> None:
         "enforce": "",
         "conformance_blocking": "",
         "renovate_automerge": "",
+        # Presence flag: "false" unless --resync is passed, so a bare
+        # re-run never rewrites the write-if-absent tests.yaml scaffold.
+        "resync": "false",
     }
 
 
@@ -1129,6 +1133,344 @@ def test_cmd_bootstrap_tests_yaml_recreated_when_deleted(
     _cmd_bootstrap([])
     assert wf.exists()
     assert wf.read_text() == render("tests.yaml", app_name="myapp")
+
+
+# ---------------------------------------------------------------------------
+# Write-if-absent scaffolds — --resync
+#
+# These scaffolds are write-if-absent so apps can customise them, which left
+# their C002 drift with no proportionate remediation: the only way to pull an
+# old repo's structure forward was to delete the file and re-scaffold,
+# discarding every per-repo value with it. These lock the flag that closes
+# that gap — and, just as importantly, lock what it must NOT change.
+# ---------------------------------------------------------------------------
+
+
+def _drifted_tests_yaml(**params: str) -> str:
+    """Return a canonical tests.yaml with a structural line removed.
+
+    Deleting a line (rather than adding one) reproduces the real drift shape:
+    a repo scaffolded by an older bootstrap is *missing* what newer templates
+    added, which is exactly what C002 reports across the fleet.
+    """
+    canonical = render("tests.yaml", **params)
+    lines = canonical.splitlines(keepends=True)
+    return "".join(line for line in lines if "secrets: inherit" not in line)
+
+
+def test_resync_restores_the_canonical(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    _cmd_bootstrap([])
+    wf = tmp_path / ".github" / "workflows" / "tests.yaml"
+    wf.write_text(_drifted_tests_yaml(app_name="app"))
+    _cmd_bootstrap(["--resync"])
+    assert wf.read_text() == render("tests.yaml", app_name="app")
+
+
+def test_resync_clears_the_c002_finding(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The end-to-end property the flag exists for.
+
+    Asserted through the checker rather than by comparing bytes to a render:
+    a resync that produced a file the checker still called drifted would be
+    worse than useless, and only C002 itself can rule that out.
+    """
+    from conformance.suite.checks.bootstrap_drift import scan_path
+
+    monkeypatch.chdir(tmp_path)
+    _cmd_bootstrap([])
+    wf = tmp_path / ".github" / "workflows" / "tests.yaml"
+    wf.write_text(_drifted_tests_yaml(app_name="app"))
+    assert scan_path(wf, tmp_path), "fixture is not actually drifted"
+    _cmd_bootstrap(["--resync"])
+    assert scan_path(wf, tmp_path) == []
+
+
+def test_resync_preserves_per_repo_params(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Params are read off the file, not off the flags/autodetection.
+
+    ``enable_e2e`` is the sharp case: it is never autodetected, so a resync
+    that rendered from kwargs would silently switch e2e back on in a repo
+    that turned it off — re-enabling a live-tenant suite nobody asked for.
+    """
+    monkeypatch.chdir(tmp_path)
+    _cmd_bootstrap([])
+    wf = tmp_path / ".github" / "workflows" / "tests.yaml"
+    params = {
+        "app_name": "widget",
+        "app_image_name": "atlan-custom-widget-app",
+        "enable_e2e": "false",
+    }
+    wf.write_text(_drifted_tests_yaml(**params))
+    _cmd_bootstrap(["--resync"])
+    assert wf.read_text() == render("tests.yaml", **params)
+
+
+def test_resync_backs_up_the_previous_content(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A hand edit outside the extracted params is replaced, but recoverable."""
+    monkeypatch.chdir(tmp_path)
+    _cmd_bootstrap([])
+    wf = tmp_path / ".github" / "workflows" / "tests.yaml"
+    drifted = _drifted_tests_yaml(app_name="app") + "\n# a hand-added comment\n"
+    wf.write_text(drifted)
+    _cmd_bootstrap(["--resync"])
+    assert "# a hand-added comment" not in wf.read_text()
+    assert (
+        tmp_path / ".github" / "workflows" / "tests.yaml.bak"
+    ).read_text() == drifted
+
+
+def test_resync_backup_is_gitignored(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The backup must never be committable.
+
+    It lands inside .github/workflows/, so an un-ignored copy would show up in
+    every subsequent PR diff of a repo that ran the flag once.
+    """
+    monkeypatch.chdir(tmp_path)
+    _cmd_bootstrap([])
+    assert "*.bak" in (tmp_path / ".gitignore").read_text().splitlines()
+
+
+def test_resync_is_a_noop_when_already_canonical(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No drift → no write, and no stray .bak."""
+    monkeypatch.chdir(tmp_path)
+    _cmd_bootstrap([])
+    wf = tmp_path / ".github" / "workflows" / "tests.yaml"
+    before = wf.read_text()
+    _cmd_bootstrap(["--resync"])
+    assert wf.read_text() == before
+    assert not (tmp_path / ".github" / "workflows" / "tests.yaml.bak").exists()
+
+
+@pytest.mark.parametrize(
+    ("label", "mutate"),
+    [
+        ("canonical", lambda text: text),
+        ("structural-line-removed", lambda text: _drifted_tests_yaml(app_name="app")),
+        ("hand-added-comment", lambda text: text + "\n# hand-added\n"),
+        (
+            "repinned-action",
+            lambda text: re.sub(r"@[0-9a-f]{40}", "@" + "a" * 40, text),
+        ),
+    ],
+)
+def test_resync_writes_exactly_when_c002_flags(
+    label: str,
+    mutate: object,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The flag's trigger condition must be C002's finding condition.
+
+    Both sides go through ``strip_action_pins``, so a pin difference is drift
+    to neither — but the property that matters is the equivalence itself, not
+    which comparison implements it: a resync that wrote on something C002
+    calls clean would churn the file (and leave a .bak) on every run against
+    a finding nobody raised, and one that stayed silent on something C002
+    flags would leave the finding standing.
+    """
+    from conformance.suite.checks.bootstrap_drift import scan_path
+
+    monkeypatch.chdir(tmp_path)
+    _cmd_bootstrap([])
+    wf = tmp_path / ".github" / "workflows" / "tests.yaml"
+    wf.write_text(mutate(wf.read_text()))  # type: ignore[operator]
+    before = wf.read_text()
+
+    flagged = bool(scan_path(wf, tmp_path))
+    _cmd_bootstrap(["--resync"])
+    wrote = wf.read_text() != before
+
+    assert wrote == flagged, f"{label}: resync wrote={wrote}, C002 flagged={flagged}"
+    bak = tmp_path / ".github" / "workflows" / "tests.yaml.bak"
+    assert bak.exists() == flagged
+
+
+def test_bare_rerun_never_resyncs(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The flag is opt-in — the write-if-absent contract is unchanged without it."""
+    monkeypatch.chdir(tmp_path)
+    _cmd_bootstrap([])
+    wf = tmp_path / ".github" / "workflows" / "tests.yaml"
+    wf.write_text(_drifted_tests_yaml(app_name="app"))
+    drifted = wf.read_text()
+    _cmd_bootstrap([])
+    assert wf.read_text() == drifted
+
+
+def test_resync_scaffolds_when_absent(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Passing the flag on a repo with no tests.yaml still just scaffolds it."""
+    monkeypatch.chdir(tmp_path)
+    _cmd_bootstrap(["--resync"])
+    wf = tmp_path / ".github" / "workflows" / "tests.yaml"
+    assert wf.read_text() == render(
+        "tests.yaml", app_name=derive_app_name_from_dir(tmp_path)
+    )
+    assert not (tmp_path / ".github" / "workflows" / "tests.yaml.bak").exists()
+
+
+def test_resync_rejects_a_value(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """It is a presence flag; `--resync=true` is an error, not a silent no-op."""
+    monkeypatch.chdir(tmp_path)
+    with pytest.raises(SystemExit) as exc:
+        _cmd_bootstrap(["--resync=true"])
+    assert exc.value.code == 2
+
+
+def test_resync_reported_in_json_manifest(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Both writes reach touched_files, so a remediation pass can scope a revert."""
+    monkeypatch.chdir(tmp_path)
+    _cmd_bootstrap([])
+    wf = tmp_path / ".github" / "workflows" / "tests.yaml"
+    wf.write_text(_drifted_tests_yaml(app_name="app"))
+    capsys.readouterr()
+    _cmd_bootstrap(["--resync", "--json"])
+    payload = json.loads(capsys.readouterr().out.strip().splitlines()[-1])
+    assert ".github/workflows/tests.yaml" in payload["touched"]
+    assert ".github/workflows/tests.yaml.bak" in payload["touched"]
+
+
+# --- --resync's second target: renovate.json -------------------------------
+
+
+def _drifted_renovate_json(automerge: str) -> str:
+    """Return a canonical renovate.json with a structural key removed.
+
+    Drops `$schema` specifically: it is a key newer templates added, so its
+    absence is the real "repo scaffolded by an older bootstrap" shape, and it
+    is not the key the auto-merge mode is read from — so the fixture exercises
+    structural drift without also destroying the value the resync must
+    preserve.
+    """
+    payload = json.loads(render("renovate.json", automerge=automerge))
+    payload.pop("$schema")
+    return json.dumps(payload, indent=2) + "\n"
+
+
+def test_drifted_renovate_json_fixture_is_actually_drifted() -> None:
+    """Guard the fixture itself.
+
+    A re-serialised canonical can round-trip byte-identical, which would make
+    every test below vacuously pass by resyncing a file that was never
+    drifted.
+    """
+    for automerge in ("true", "false"):
+        assert _drifted_renovate_json(automerge) != render(
+            "renovate.json", automerge=automerge
+        )
+
+
+@pytest.mark.parametrize("automerge", ["true", "false"])
+def test_resync_restores_renovate_json_keeping_its_mode(
+    automerge: str, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The auto-merge mode is read off the file, never re-decided.
+
+    Parametrised over both modes because getting this wrong in the soft
+    direction is the expensive one: silently flipping a repo to auto-merge
+    turns a human-gated dependency lane into a 0-touch one.
+    """
+    monkeypatch.chdir(tmp_path)
+    _cmd_bootstrap([f"--renovate-automerge={automerge}"])
+    dest = tmp_path / "renovate.json"
+    dest.write_text(_drifted_renovate_json(automerge))
+    _cmd_bootstrap(["--resync"])
+    assert dest.read_text() == render("renovate.json", automerge=automerge)
+
+
+def test_resync_clears_the_renovate_json_c002_finding(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from conformance.suite.checks.bootstrap_drift import scan_path
+
+    monkeypatch.chdir(tmp_path)
+    _cmd_bootstrap([])
+    dest = tmp_path / "renovate.json"
+    dest.write_text(_drifted_renovate_json("true"))
+    assert scan_path(dest, tmp_path), "fixture is not actually drifted"
+    _cmd_bootstrap(["--resync"])
+    assert scan_path(dest, tmp_path) == []
+
+
+def test_explicit_mode_flag_beats_resync(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`--renovate-automerge` CHANGES the mode; `--resync` PRESERVES it.
+
+    Passing both is an intentional mode change, so the explicit flag must win
+    — otherwise the resync's read-back-off-disk value would silently make the
+    explicit flag a no-op.
+    """
+    monkeypatch.chdir(tmp_path)
+    _cmd_bootstrap(["--renovate-automerge=false"])
+    dest = tmp_path / "renovate.json"
+    dest.write_text(_drifted_renovate_json("false"))
+    _cmd_bootstrap(["--renovate-automerge=true", "--resync"])
+    assert dest.read_text() == render("renovate.json", automerge="true")
+
+
+# --- identity guards: skip rather than rewrite from guessed defaults --------
+
+
+def test_resync_skips_renovate_json_that_is_not_valid_json(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An unreadable mode must not resolve to the auto-merge canonical.
+
+    `extract_renovate_automerge` answers "true" for anything it can't parse —
+    right for its other callers, but here it would turn an unparseable
+    soft-mode file into a repo where Renovate merges without a human.
+    """
+    monkeypatch.chdir(tmp_path)
+    _cmd_bootstrap(["--renovate-automerge=false"])
+    dest = tmp_path / "renovate.json"
+    dest.write_text("{ this is not json\n")
+    _cmd_bootstrap(["--resync"])
+    assert dest.read_text() == "{ this is not json\n"
+    assert not (tmp_path / "renovate.json.bak").exists()
+
+
+def test_resync_skips_tests_yaml_with_no_readable_app_name(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A file drifted past its own name gets a human, not a rename.
+
+    Without the guard, `render` falls back to app_name="app" and the resync
+    quietly renames the app in every downstream CI input while reporting
+    success.
+    """
+    monkeypatch.chdir(tmp_path)
+    _cmd_bootstrap([])
+    wf = tmp_path / ".github" / "workflows" / "tests.yaml"
+    nameless = "\n".join(
+        line
+        for line in render("tests.yaml", app_name="widget").splitlines()
+        if "app-name:" not in line
+    )
+    wf.write_text(nameless)
+    _cmd_bootstrap(["--resync"])
+    assert wf.read_text() == nameless
+    assert not (tmp_path / ".github" / "workflows" / "tests.yaml.bak").exists()
 
 
 # ---------------------------------------------------------------------------

--- a/packages/conformance/tests/test_bootstrap_drift.py
+++ b/packages/conformance/tests/test_bootstrap_drift.py
@@ -433,10 +433,17 @@ def test_tests_yaml_finding_is_warn_never_block(tmp_path: pathlib.Path) -> None:
     assert rule.tier == EnforcementTier.WARN
 
 
-def test_tests_yaml_finding_message_mentions_delete_and_bootstrap(
+def test_tests_yaml_drift_message_names_the_resync_flag(
     tmp_path: pathlib.Path,
 ) -> None:
-    """Drift message tells users to delete + re-run bootstrap to remediate."""
+    """Drift message points at the flag that actually fixes it.
+
+    The remediation used to be "delete the file and re-run", which discards
+    every per-repo customisation to land a structural catch-up.
+    ``--resync`` preserves them, so the message must name it — a
+    finding whose stated fix is more destructive than necessary is one people
+    reasonably refuse to act on.
+    """
     wf_dir = tmp_path / ".github" / "workflows"
     wf_dir.mkdir(parents=True)
     wf = wf_dir / "tests.yaml"
@@ -444,8 +451,27 @@ def test_tests_yaml_finding_message_mentions_delete_and_bootstrap(
     findings = scan_path(wf, tmp_path)
     assert len(findings) == 1
     msg = findings[0].message
-    assert "delete" in msg.lower() or "regenerate" in msg.lower()
+    assert "--resync" in msg
     assert "bootstrap" in msg
+    assert "delete" not in msg.lower()
+
+
+def test_tests_yaml_absent_message_does_not_name_the_resync_flag(
+    tmp_path: pathlib.Path,
+) -> None:
+    """An absent tests.yaml is scaffolded by a bare re-run — no flag needed.
+
+    Separate message from the drift case: there is nothing on disk to
+    preserve, so telling the user to pass a preservation flag would imply the
+    bare re-run is unsafe when it is exactly the right command.
+    """
+    wf_dir = tmp_path / ".github" / "workflows"
+    wf_dir.mkdir(parents=True)
+    findings = scan_path(wf_dir / "tests.yaml", tmp_path)
+    assert len(findings) == 1
+    msg = findings[0].message
+    assert "absent" in msg.lower()
+    assert "--resync" not in msg
 
 
 # ---------------------------------------------------------------------------
@@ -491,17 +517,24 @@ def test_renovate_json_finding_is_warn_never_block(tmp_path: pathlib.Path) -> No
     assert get_rule("C002").tier == EnforcementTier.WARN
 
 
-def test_renovate_json_finding_mentions_delete_and_bootstrap(
+def test_renovate_json_drift_message_names_the_resync_flag(
     tmp_path: pathlib.Path,
 ) -> None:
-    """Drift message tells users to delete + re-run bootstrap to remediate."""
+    """Drift message points at the flag that actually fixes it.
+
+    Mirrors the tests.yaml case: the old advice was "delete and re-run", which
+    discards the file wholesale. It must also keep --resync distinct from the
+    mode flags — those CHANGE the auto-merge policy, which is not what a
+    structural catch-up should do.
+    """
     rj = tmp_path / "renovate.json"
     rj.write_text("{}\n")
     findings = scan_path(rj, tmp_path)
     assert len(findings) == 1
     msg = findings[0].message
-    assert "delete" in msg.lower() or "regenerate" in msg.lower()
+    assert "--resync" in msg
     assert "bootstrap" in msg
+    assert "delete" not in msg.lower()
 
 
 def test_all_scaffolds_clean_after_bootstrap(tmp_path: pathlib.Path) -> None:


### PR DESCRIPTION
## Why

C002 tracks drift on two **write-if-absent** scaffolds — `tests.yaml` and `renovate.json` — that a bare `bootstrap` re-run never rewrites. They are write-if-absent precisely so apps can customise them, which left their findings with no proportionate remedy: the stated fix was *"delete the file and re-run"*, which discards every per-repo value to land a structural catch-up. A finding whose fix is more destructive than necessary is one people reasonably refuse to act on, so the drift accumulates.

## What

`--resync` re-renders both scaffolds from their canonical templates, using values read back **off each existing file** — not from the flags, and not from autodetection. That distinction is the whole safety property, and it isn't theoretical:

- `enable_e2e` is never autodetected (it just defaults to `"true"`), so rendering from kwargs would switch e2e back on in a repo that turned it off — re-enabling a live-tenant suite nobody asked for.
- `services_script` is autodetected from the script merely *existing* on disk, so it would activate a line a repo deliberately left commented out.
- `renovate.json`'s auto-merge mode is repo policy. `--resync` preserves whatever the file declares; `--enforce` / `--renovate-automerge` remain the way to **change** it, and win when passed alongside `--resync` (otherwise the resync's read-back value would quietly make the explicit flag a no-op).

It no-ops on a file that is already canonical, judged by the **same pin-insensitive comparison C002 uses** — so `--resync` rewrites exactly what C002 flags and never churns a file the checker calls clean. Previous content is kept as `<name>.bak`, already covered by `*.bak` in the bootstrap-managed `.gitignore`.

### Scope of the flag

| Scaffold | Covered | Why |
|---|---|---|
| `tests.yaml` | yes | params extractable (app-name, app-image-name, enable-e2e, services-script) |
| `renovate.json` | yes | auto-merge mode extractable via the same extractor C002 compares with |
| `.gitignore` | **no** | C003 remediates it additively per missing entry; a re-render would delete an app's own ignores |
| `contract_schema.lock.json` | **no** | append-only, owned by `gen-contract-ledger`; B005/B006 track its drift |

The exclusions are structural and documented at each site, so a future member gets added deliberately rather than by omission.

### Identity guards

`--resync` refuses to rewrite a file whose identity can't be read back, rather than rendering from guessed defaults:

- **`renovate.json` that isn't valid JSON** — `extract_renovate_automerge` answers `"true"` for anything unparseable. Correct for its other callers, but here it would turn an unparseable soft-mode file into one where Renovate merges without a human.
- **`tests.yaml` with no parseable `app-name`** — `render` falls back to `"app"`, silently renaming the app in every downstream CI input while reporting success.

The second guard fired on a real connector repo during end-to-end testing: its `tests.yaml` is a hand-written workflow, not the bootstrap scaffold at all. Without the guard, `--resync` would have replaced it with the canonical scaffold. Worth knowing more broadly — on some repos a C002 "tests.yaml drifted" finding means *"never adopted the scaffold"*, not *"fell behind it"*.

### Shared-implementation discipline

`strip_action_pins` and `extract_tests_yaml_params` move out of the C002 checker into `bootstrap/extract.py`, the existing leaf module, so the checker and the resync use one implementation — two copies could drift into a resync that writes a file the checker still calls drifted. Both re-renders also go through a single `_resync_scaffold` helper, so its guards can't end up applied to one target and forgotten on the other.

### Deliberately not auto-applied by `/remediate`

A customisation *outside* the recognised values (an extra job, a changed trigger, a repo-local packageRule) is replaced by the re-render, and because the `.bak` is gitignored, an autonomous fix would drop it with **no trace in the diff** for a reviewer to catch. Drifted scaffolds still route to residue — but the residue entry and the C002 finding message now quote `--resync` instead of the destructive delete-and-regenerate. This also retires the old rationale for `renovate.json` residue ("fixing it requires choosing the enforcement mode"), which was only true because the force path rendered from kwargs rather than from extraction.

## Verification

End-to-end on scratch copies of two real connector repos:

| Repo | C002 before | after | notes |
|---|---|---|---|
| A | 3 | **0** | app-name / app-image-name preserved; services-script line correctly left commented out |
| B | 5 | **1** | soft mode preserved (`lockFileMaintenance` intact); the remaining finding is the hand-written `tests.yaml` the guard declined |

Tests cover: canonical restoration, C002 clearing (asserted *through the checker*, not by comparing to a render), param preservation, the backup, the no-op, the presence-flag rejection of a value, `--json` manifest entries, both identity guards, explicit-mode-flag precedence, and a parametrised invariant that the resync writes **iff** C002 flags.

A guard on the test fixture itself was added after catching that the first `renovate.json` drift fixture round-tripped byte-identical to the canonical — which would have made every `renovate.json` test pass vacuously by "resyncing" a file that was never drifted.

Full conformance suite green (2598 passed). Pre-commit clean including pyright.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
