### PR TITLE
chore(testing): calibrate the event-loop starvation guard against a control (FND-360)

### DIFF
--- a/tests/unit/templates/test_sql_app_event_loop.py
+++ b/tests/unit/templates/test_sql_app_event_loop.py
@@ -12,6 +12,16 @@ no await anywhere in the loop, so its hold scales with the source table.
 Both tests drive the real method while a ticker coroutine counts how often the
 loop got to run something else, so they assert the property that matters rather
 than which callable was handed to ``run_in_thread``.
+
+The tick count on its own measures how much CPU the loop thread got, not
+whether the body offloaded: a *correctly* offloaded block scores 27 ticks on an
+idle machine and 4 with a handful of unrelated GIL-holding threads in the
+process, with wall-clock elapsed unchanged either way. An absolute threshold
+therefore fails on a loaded shared runner with nothing wrong (FND-360). Each
+test instead measures a known-good offload of the same length on the same
+runner, moments away, and requires the subject to reach ``MIN_TICK_RATIO`` of
+it — runner noise moves both numbers together, while a body that blocks the
+loop scores ~0 against whatever the control scored.
 """
 
 from __future__ import annotations
@@ -40,7 +50,16 @@ T = TypeVar("T")
 
 BLOCK_SECONDS = 0.3
 TICK_SECONDS = 0.01
-MIN_TICKS = 5
+
+#: Share of the control's ticks a non-blocking body must reach. Half leaves room
+#: for the runner's load to drift between the two measurements while staying far
+#: above what a body that holds the loop can score.
+MIN_TICK_RATIO = 0.5
+
+#: Below this the control itself could not schedule enough ticks to tell a
+#: healthy body from a blocking one, so the run says so rather than passing
+#: vacuously or failing on the runner's behalf.
+MIN_CONTROL_TICKS = 4
 
 
 class _FakeSqlClient(BaseSQLClient):
@@ -113,6 +132,38 @@ async def count_ticks_during(work: Callable[[], Awaitable[T]]) -> tuple[T, int]:
     return result, ticks
 
 
+async def control_ticks() -> int:
+    """Ticks a correctly-offloaded block of the same length gets on this runner.
+
+    Deliberately stdlib — ``asyncio.to_thread``, never the SDK's
+    ``run_in_thread`` — so that a regression *inside* the SDK's own offload path
+    collapses the subject's ticks without also collapsing the baseline it is
+    measured against.
+    """
+    _, ticks = await count_ticks_during(
+        lambda: asyncio.to_thread(time.sleep, BLOCK_SECONDS)
+    )
+    return ticks
+
+
+def assert_loop_stayed_live(*, method: str, ticks: int, control: int) -> None:
+    """Fail if *method* left the loop less responsive than a known-good offload."""
+    if control < MIN_CONTROL_TICKS:
+        pytest.skip(
+            f"runner too starved to measure: a stdlib offload of "
+            f"{BLOCK_SECONDS}s scored only {control} ticks, so no threshold "
+            "distinguishes a healthy body from a blocking one"
+        )
+
+    floor = control * MIN_TICK_RATIO
+    assert ticks >= floor, (
+        f"{method} stalled the event loop: {ticks} ticks against {control} for "
+        f"an offload of the same length on this runner (floor {floor:.1f}) — a "
+        "starved loop cannot run the auto-heartbeat, which is what gets healthy "
+        "activities killed on heartbeat_timeout"
+    )
+
+
 def _extract_input(tmp_path: Path) -> ExtractionTaskInput:
     return ExtractionTaskInput(
         workflow_id="wf-test",
@@ -157,6 +208,7 @@ async def test_transform_entity_does_not_block_the_loop(
             f.write(orjson.dumps({"database_name": name}))
             f.write(b"\n")
 
+    control = await control_ticks()
     result, ticks = await count_ticks_during(
         lambda: app._transform_entity(
             entity_type="database",
@@ -167,11 +219,7 @@ async def test_transform_entity_does_not_block_the_loop(
 
     assert result.total_record_count == 2
     assert app.mapped == 2, "the mapper never ran"
-    assert ticks >= MIN_TICKS, (
-        f"_transform_entity stalled the event loop ({ticks} ticks) — a starved "
-        "loop cannot run the auto-heartbeat, which is what gets healthy "
-        "activities killed on heartbeat_timeout"
-    )
+    assert_loop_stayed_live(method="_transform_entity", ticks=ticks, control=control)
 
 
 async def test_extract_entity_does_not_block_the_loop(
@@ -189,6 +237,10 @@ async def test_extract_entity_does_not_block_the_loop(
 
     monkeypatch.setattr("application_sdk.templates.sql_app.orjson.dumps", _slow_dumps)
 
+    # Measured after the patch and immediately before the subject: the control
+    # never serialises, so it cannot spend the one-shot cost above, and the two
+    # measurements sit close enough together to see the same runner load.
+    control = await control_ticks()
     result, ticks = await count_ticks_during(
         lambda: app._extract_entity(
             entity_type="database",
@@ -199,10 +251,7 @@ async def test_extract_entity_does_not_block_the_loop(
 
     assert result.total_record_count == 2
     assert slowed["done"], "the serialise path never ran"
-    assert ticks >= MIN_TICKS, (
-        f"_extract_entity stalled the event loop ({ticks} ticks) — a starved "
-        "loop cannot run the auto-heartbeat"
-    )
+    assert_loop_stayed_live(method="_extract_entity", ticks=ticks, control=control)
 
 
 async def test_extract_entity_never_hands_the_file_handle_to_a_thread(


### PR DESCRIPTION
## What

The FND-282 starvation guards in `tests/unit/templates/test_sql_app_event_loop.py` asserted an absolute floor of 5 ticks from a 10 ms ticker while a 0.3 s block was offloaded. That tick count measures how much CPU the loop thread got, not whether the body offloaded.

This replaces the constant with a control measured in the same test: the ticker is timed over `asyncio.to_thread(time.sleep, BLOCK_SECONDS)` — a known-good offload of the same length on the same runner, moments away — and the subject must reach half of it.

The control is deliberately stdlib, never the SDK's `run_in_thread`, so a regression *inside* the SDK's own offload path collapses the subject without also collapsing the baseline it is judged against.

When the control itself lands under four ticks, no threshold separates a healthy body from a blocking one, so the test skips with that reason rather than passing vacuously or failing on the runner's behalf.

## Why

[Run 31811262318](https://github.com/atlanhq/application-sdk/actions/runs/31811262318/job/94802247650) failed in the merge queue on `SDK Tests / Unit Tests (3.12, macOS-latest)` at `_extract_entity stalled the event loop (3 ticks)`. The other eleven unit-test legs — including macOS 3.11 and 3.14 — passed the same commit, and the wall-clock elapsed for that test was normal.

A correctly offloaded 0.3 s block, with zero SDK code involved, degrades purely from unrelated in-process CPU threads:

| competing GIL-holding threads | 0 | 1 | 2 | 4 |
|---|---|---|---|---|
| pure-Python burner | 27 | 13 | 12 | **4** |
| orjson burner | 27 | 12 | 10 | **6** |
| gzip burner (releases the GIL) | 27 | 27 | 27 | 27 |

Normal elapsed plus a collapsed tick count is the signature of a starved runner, not a stalled loop — reachable on a 3-core shared runner partway through a 7101-test single-process suite.

## Verification

| scenario | old assertion | new assertion |
|---|---|---|
| idle machine | pass (27 ticks) | pass (27 vs control 27) |
| 12 GIL-holding threads in-process | **fail — `3 ticks`, the CI failure verbatim** | pass |
| serialisation inlined (regression injected), idle | fail | **fail — 0 ticks vs control 27, floor 13.5** |
| regression injected, under load | fail | **fail — 0 ticks vs control 4, floor 2.0** |

The loaded row reproduces the CI failure in-process with no SDK change. The last row is the one that earns the change: a ratio test could have gone blind under load, and it does not — a blocked loop scores 0 against any control. Under that heaviest load the transform test skipped (control 3 < 4) while the extract test still judged and failed.

Test-only change; no product code touched. `tests/unit/templates/` is 387 passed, pre-commit clean.

Closes FND-360.