### PR TITLE
chore(gate-enforcement): retract the direct-push claim — it measured our own blind spot

### DIFF
--- a/.github/scripts/gate_enforcement_scan.py
+++ b/.github/scripts/gate_enforcement_scan.py
@@ -14,9 +14,10 @@ This closes that hole by answering three questions per repo, on the same cadence
 as every other fleet finding:
 
 1. Is the gate context a **required** status check on the default branch?
-2. Does the default branch **require a pull request at all**? Without one there
-   is no PR for the check to attach to, so a direct push lands unchecked and the
-   requirement is decorative.
+2. Does a **ruleset** require a pull request on that branch? Without one, no
+   ruleset stands between a write-access push and the default branch — though
+   see the `rulesetRequiresPullRequest` note below for what that does *not*
+   establish.
 3. Is the check **actually arriving** on pull requests, or configured-but-never-
    reporting? That third state blocks every PR with nothing red to point at, and
    the pressure it creates is to *remove* the requirement — so it has to be
@@ -27,6 +28,19 @@ GitHub omits the field entirely for a non-admin caller, so with a fleet-scoped
 token "no bypass" and "cannot see bypass" are the same bytes, and the repo reads
 as clean either way. An unanswerable question is left unanswered rather than
 answered wrongly.
+
+**Nor is "a direct push is permitted"** — schema 3.0 retracted it, for the same
+reason one layer down. Rulesets are only one of two enforcement mechanisms;
+classic branch protection is the other, it is admin-gated, and this token does
+not have admin. Worse, GitHub does not distinguish the two answers: a repo with
+no classic protection returns 404 ``"Branch not protected"``, and a repo whose
+protection we may not read returns 404 ``"Not Found"``. The first sweep to
+publish the claim reported 69/77 repos as permitting direct pushes — which was
+exactly the set of repos whose classic protection was unreadable, i.e. a
+restatement of the token's own blind spot dressed as a fleet finding. So this
+scanner now reports only what rulesets prove
+(``enforcement.rulesetRequiresPullRequest``) and leaves the direct-push question
+to a consumer that holds ``administration: read``.
 
 Enumerating the fleet here (rather than having each repo self-report) is the
 whole point: a repo that has lost enforcement is *present in the output* with
@@ -102,7 +116,7 @@ REPO_LIST_LIMIT = 5000
 _REQUIRED_STATUS_CHECKS_RULE = "required_status_checks"
 _PULL_REQUEST_RULE = "pull_request"
 
-SCHEMA_VERSION = "2.0"
+SCHEMA_VERSION = "3.0"
 
 # Per-repo verdict. Three values, not a boolean, because "we could not read it"
 # must never collapse into "it is not gated" (that would make an outage look
@@ -114,8 +128,10 @@ SCHEMA_VERSION = "2.0"
 # pull-requests read by design, so absent and none are indistinguishable to it,
 # and a repo with standing admin bypass reads as clean. That is the precise
 # false green this scanner exists to prevent, so the claim is not made at all
-# rather than made unreliably. `enforcement.directPushPermitted` is the one
-# bypass-shaped signal this token *can* see, and it is derived from `rules`.
+# rather than made unreliably. The same test retired `directPushPermitted` in
+# schema 3.0: see the module docstring. What is left is
+# `enforcement.rulesetRequiresPullRequest`, which claims only what `rules`
+# actually shows and names the mechanism it is scoped to.
 STATUS_GATED = "gated"
 STATUS_NOT_GATED = "not-gated"
 STATUS_UNKNOWN = "unknown"
@@ -129,7 +145,10 @@ ARRIVAL_UNKNOWN = "unknown"
 
 # Finding ids. Stable strings — connector-pulse groups on them.
 FINDING_NOT_REQUIRED = "gate-not-required"
-FINDING_DIRECT_PUSH = "gate-direct-push-permitted"
+# `gate-direct-push-permitted` was removed in schema 3.0 along with the field it
+# reported on. Not reused for anything else — connector-pulse groups findings by
+# these strings, and recycling a retired id would silently merge two different
+# claims in any stored snapshot's `byFinding` rollup.
 FINDING_NOT_ARRIVING = "gate-not-arriving"
 FINDING_UNPRODUCIBLE = "gate-context-unproducible"
 FINDING_UNREADABLE = "gate-state-unreadable"
@@ -355,12 +374,6 @@ def evaluate_repo(
         requires_pr = requires_pr or has_rule(ruleset, _PULL_REQUEST_RULE)
 
     gated = bool(matched_rulesets)
-    # Not a bypass *actor* — a structural hole, and the one this token can
-    # actually see. With no ruleset requiring a pull request, anyone with write
-    # access lands on the default branch without a PR for the check to attach
-    # to, so the requirement never applies. Derived from the `pull_request` rule,
-    # which is part of `rules` and therefore visible at plain repo-read.
-    direct_push = not requires_pr
 
     arrival_status, sampled, with_context, truncated = classify_arrival(
         arrival_samples or []
@@ -405,15 +418,6 @@ def evaluate_repo(
                     "nothing red to fix",
                 )
             )
-    if direct_push:
-        findings.append(
-            _finding(
-                FINDING_DIRECT_PUSH,
-                "error" if gated else "warning",
-                f"no active ruleset requires a pull request on {default_branch}, so a "
-                "direct push bypasses every required check",
-            )
-        )
     return {
         "schemaVersion": SCHEMA_VERSION,
         "repo": repo,
@@ -427,8 +431,12 @@ def evaluate_repo(
             "source": "ruleset" if gated else "none",
             "rulesets": matched_rulesets,
             "requiredContexts": sorted(set(all_contexts)),
-            "requiresPullRequest": requires_pr,
-            "directPushPermitted": direct_push,
+            # Scoped to rulesets in the name, because rulesets are the only
+            # mechanism this token can read. False means "no ruleset requires a
+            # PR here" — NOT "a direct push is permitted": classic branch
+            # protection could be requiring one invisibly. See the module
+            # docstring for why the stronger claim was retracted in 3.0.
+            "rulesetRequiresPullRequest": requires_pr,
             "strictRequiredStatusChecksPolicy": strict,
         },
         "arrival": {
@@ -479,10 +487,14 @@ def build_fleet(records: list, required_context: str) -> dict:
         "withTestsWorkflowFile": sum(
             1 for r in records if r.get("hasTestsWorkflowFile")
         ),
-        "directPushPermitted": sum(
+        # Counted the way it reads: how many repos a ruleset requires a PR on.
+        # The old `directPushPermitted` counted the inverse and called it a
+        # bypass count, which turned "no ruleset PR rule" into a claim about
+        # classic branch protection that this token cannot see.
+        "rulesetRequiresPullRequest": sum(
             1
             for r in records
-            if (r.get("enforcement") or {}).get("directPushPermitted")
+            if (r.get("enforcement") or {}).get("rulesetRequiresPullRequest")
         ),
         "byStatus": by_status,
         "byArrival": by_arrival,
@@ -911,7 +923,7 @@ def write_outputs(records: list, fleet: dict, out_dir: Path) -> None:
         "gated": fleet["gated"],
         "notGated": fleet["notGated"],
         "unknown": fleet["unknown"],
-        "directPushPermitted": fleet["directPushPermitted"],
+        "rulesetRequiresPullRequest": fleet["rulesetRequiresPullRequest"],
     }
     with (out_dir / "history_fleet.jsonl").open("a") as fh:
         fh.write(json.dumps(fleet_entry) + "\n")
@@ -978,7 +990,8 @@ def main(argv: Optional[list] = None) -> int:
     print(
         f"Fleet: {fleet['gated']}/{fleet['fleetSize']} gated, "
         f"{fleet['notGated']} not gated, {fleet['unknown']} unknown; "
-        f"{fleet['directPushPermitted']} permit a direct push to the default branch",
+        f"a ruleset requires a pull request on "
+        f"{fleet['rulesetRequiresPullRequest']}/{fleet['fleetSize']}",
         file=sys.stderr,
     )
     return 0

--- a/.github/scripts/tests/test_gate_enforcement_scan.py
+++ b/.github/scripts/tests/test_gate_enforcement_scan.py
@@ -28,7 +28,6 @@ from gate_enforcement_scan import (  # noqa: E402
     ARRIVAL_UNKNOWN,
     DEFAULT_NAME_PATTERN,
     DEFAULT_REQUIRED_CONTEXT,
-    FINDING_DIRECT_PUSH,
     FINDING_NOT_ARRIVING,
     FINDING_NOT_REQUIRED,
     FINDING_UNPRODUCIBLE,
@@ -185,7 +184,7 @@ def test_no_rulesets_at_all():
     record = _evaluate(rulesets=[])
     assert record["status"] == STATUS_NOT_GATED
     assert record["enforcement"]["requiredContexts"] == []
-    assert FINDING_DIRECT_PUSH in _finding_ids(record)
+    assert record["enforcement"]["rulesetRequiresPullRequest"] is False
 
 
 # --- bypass is not claimed --------------------------------------------------
@@ -255,23 +254,50 @@ def test_the_record_reads_identically_with_and_without_visible_bypass_actors():
     assert admin_view == fleet_view
 
 
-def test_no_pull_request_requirement_is_still_reported():
-    """The one bypass-shaped hole this token CAN see: it comes from `rules`,
-    which plain repo-read returns in full. With no PR required there is no pull
-    request for the check to attach to, so the requirement never applies."""
+def test_absent_pull_request_rule_is_reported_as_a_ruleset_fact_only():
+    """What `rules` shows, and nothing beyond it.
+
+    A missing `pull_request` rule means no *ruleset* requires a PR here. It does
+    NOT mean a direct push is permitted — classic branch protection is the other
+    enforcement mechanism, it is admin-gated, and this token cannot read it. So
+    the field is named for its scope and no finding is raised: an unprovable
+    claim is left unmade.
+    """
     record = _evaluate(rulesets=[_ruleset(with_pull_request=False)])
-    assert record["enforcement"]["directPushPermitted"] is True
+    assert record["enforcement"]["rulesetRequiresPullRequest"] is False
     assert record["status"] == STATUS_GATED  # still required — a separate fact
-    assert FINDING_DIRECT_PUSH in _finding_ids(record)
+    assert record["findings"] == []
+
+
+def test_the_retracted_direct_push_claim_is_not_reported_anywhere():
+    """Regression guard for the second false green (schema 3.0).
+
+    `directPushPermitted` was `not requires_pr`, published as a fleet finding on
+    69 of 77 repos — which was exactly the set whose classic branch protection
+    the token could not read. GitHub returns 404 for both "no classic protection"
+    (`"Branch not protected"`) and "you may not look" (`"Not Found"`), so the
+    field could only ever restate the token's blind spot.
+
+    Same shape of mistake as `bypass_actors`, so it gets the same guard: assert
+    the payload makes no direct-push claim at all, under the exact input that
+    used to produce one.
+    """
+    record = _evaluate(rulesets=[_ruleset(with_pull_request=False)])
+    assert "directPushPermitted" not in record["enforcement"]
+    assert not any("directpush" in key.lower() for key in record["enforcement"])
+    assert not any(
+        "direct-push" in finding["id"] or "direct push" in finding["message"]
+        for finding in record["findings"]
+    )
 
 
 def test_pull_request_rule_may_live_on_a_second_ruleset():
     """PR-required and checks-required are commonly split across rulesets;
-    requiring both on one object would report a false direct-push hole."""
+    requiring both on one object would understate PR coverage."""
     checks_only = _ruleset(ruleset_id=1, with_pull_request=False)
     pr_only = _ruleset(ruleset_id=2, contexts=None, with_pull_request=True)
     record = _evaluate(rulesets=[checks_only, pr_only])
-    assert record["enforcement"]["directPushPermitted"] is False
+    assert record["enforcement"]["rulesetRequiresPullRequest"] is True
     assert record["findings"] == []
 
 
@@ -835,7 +861,10 @@ def test_build_fleet_counts_the_headline_binary():
     fleet = build_fleet(records, GATE)
     assert fleet["fleetSize"] == 4
     assert fleet["gated"] == 2
-    assert fleet["directPushPermitted"] == 2  # the ungated repo also has no PR rule
+    # Only repo `a` has a ruleset with a `pull_request` rule: `b` was built
+    # without one and `c` has no rulesets, while `d` is unreadable and carries no
+    # enforcement object at all.
+    assert fleet["rulesetRequiresPullRequest"] == 1
     assert fleet["notGated"] == 1
     assert fleet["unknown"] == 1
     assert len(fleet["repos"]) == 4


### PR DESCRIPTION
## What

Schema 3.0 of the gate-enforcement record: retract `enforcement.directPushPermitted`, rename `requiresPullRequest` → `rulesetRequiresPullRequest`, drop the `gate-direct-push-permitted` finding.

## Why

`directPushPermitted` was `not requires_pr` — "no ruleset requires a pull request" published as "a direct push bypasses every required check". The first sweep to ship it flagged **69 of 77** fleet repos, which reads as a fleet-wide emergency.

It isn't one. Rulesets are only one of GitHub's two enforcement mechanisms; classic branch protection is the other, it's admin-gated, and the fleet App token has no admin. So a repo may be requiring a PR invisibly.

And GitHub gives the two negatives the same status code with different bodies:

| Response | Meaning |
|---|---|
| 404 `"Branch not protected"` | authorized negative — genuinely no classic BP |
| 404 `"Not Found"` | permission-masked — tells you nothing |

Probing all 77 tracked repos with a maintain-level token separates them, and the split is exact:

```
masked "Not Found"  (cannot tell)          71   —  69 of them flagged
"Branch not protected" (real negative)      6   —   0 of them flagged
```

**The 69 was precisely the set whose classic protection was unreadable.** The field restated the token's own blind spot as a fleet finding.

This is the same shape of mistake as `bypass_actors` in schema 2.0, one layer down: a field that is only correct under a token we don't hold. It gets the same treatment — the claim is withdrawn rather than made unreliably.

No extra API call is spent trying to rescue it. This token would 404 on every repo either way, so querying classic BP would burn rate-limit quota to learn nothing.

## Changes

- **Drop** `enforcement.directPushPermitted` and the `gate-direct-push-permitted` finding.
- **Rename** `requiresPullRequest` → `rulesetRequiresPullRequest`. Identical bit, un-negated, named for the mechanism it can actually see. `false` means "no ruleset requires a PR" and licenses no inference about direct pushes.
- **Fleet rollup** counts `rulesetRequiresPullRequest` instead of its inverse; `history_fleet.jsonl` and the stderr summary follow.
- `SCHEMA_VERSION` → `3.0`.

The retired finding id is **not** recycled — connector-pulse groups by these strings, and reusing one would silently merge two different claims in any stored snapshot's `byFinding` rollup.

## Follow-up

Answering the direct-push question for real needs a consumer holding `administration: read`. Until one exists the question stays open rather than answered wrongly.

## Testing

`.github/scripts/tests/test_gate_enforcement_scan.py` — **58 passed**, `ruff check` clean.

New regression guards, mirroring the existing `bypass_actors` ones:
- `test_the_retracted_direct_push_claim_is_not_reported_anywhere` — under the exact input that used to produce the claim, asserts no direct-push field, key, finding id, or message survives.
- `test_absent_pull_request_rule_is_reported_as_a_ruleset_fact_only` — a missing `pull_request` rule sets the boolean and raises no finding.

## Downstream

connector-pulse companion PR follows this one, so it has a real 3.0 payload to read: atlanhq/connector-pulse#875

🤖 Generated with [Claude Code](https://claude.com/claude-code)
