### PR TITLE
chore(gate-enforcement): the fix is rulesets, not a wider token

### DIFF
--- a/.github/scripts/gate_enforcement_scan.py
+++ b/.github/scripts/gate_enforcement_scan.py
@@ -39,8 +39,21 @@ publish the claim reported 69/77 repos as permitting direct pushes — which was
 exactly the set of repos whose classic protection was unreadable, i.e. a
 restatement of the token's own blind spot dressed as a fleet finding. So this
 scanner now reports only what rulesets prove
-(``enforcement.rulesetRequiresPullRequest``) and leaves the direct-push question
-to a consumer that holds ``administration: read``.
+(``enforcement.rulesetRequiresPullRequest``).
+
+The resolution is **not** to widen this token — the fleet App will never hold
+``administration: read``. It is to move the state somewhere readable: every
+connector app migrates off classic branch protection onto rulesets, which
+``/repos/{repo}/rulesets`` returns in full at plain repo-read. That makes the
+migration self-measuring, since ``rulesetRequiresPullRequest`` climbing across
+the fleet *is* the completion signal, and it needs no new privilege.
+
+Note the direction of the residual error, because it is the forgiving one: an
+unreadable classic protection can only make this scanner *understate* how
+protected a repo is (it reports "no ruleset requires a PR" on a repo that classic
+protection may well be gating). It can never overstate it. The retracted field
+was therefore a false alarm rather than a false green — which is still worth
+retracting, but is the opposite of the ``bypass_actors`` failure above.
 
 Enumerating the fleet here (rather than having each repo self-report) is the
 whole point: a repo that has lost enforcement is *present in the output* with


### PR DESCRIPTION
Docs + one tooltip. No behaviour change.

## Wrong resolution named

Schema 3.0 said the retracted direct-push claim would be answered by "a consumer holding `administration: read`". That grant is off the table — the fleet App will never hold admin on connector repos.

The actual plan: move the state somewhere readable. Every connector app migrates off classic branch protection onto **rulesets**, which `/repos/{repo}/rulesets` returns in full at plain repo-read.

Nice property that falls out — the migration measures itself on the dashboard that motivated it. `rulesetRequiresPullRequest` climbing toward the full roster *is* the completion signal (8/77 today), and the trends series already plots it with no new privilege.

## Direction of the error, corrected

The retracted field was described as a false *green*, by analogy to `bypass_actors`. It was the opposite.

Unreadable classic protection can only make the sweep **understate** how protected a repo is — it reports "no ruleset requires a PR" on a repo that classic protection may well be gating. So 69/77 was a **false alarm**, not a hidden hole. Still worth retracting, but the direction changes how the number should be read: the fleet was likely safer than the dashboard claimed, and the migration buys observability rather than closing 69 security gaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
