### PR TITLE
ci(docs): decouple the artifact-gate rationale from the removed cooldown

### DIFF
--- a/.github/scripts/tests/test_renovate_artifact_gate.py
+++ b/.github/scripts/tests/test_renovate_artifact_gate.py
@@ -2,10 +2,22 @@
 
 `renovate-auto-approve-reusable.yml` withholds the atlan-ci code-owner approval
 unless Renovate's own `renovate/artifacts` commit status is green. That gate is
-the only thing stopping a failed post-upgrade task from auto-merging: Renovate
-commits and raises the PR regardless, and platform automerge never consults
-`artifactErrors`, so a failed release-age-bounded `uv lock` would otherwise land
-an unbounded lock file unattended.
+the only thing stopping a branch whose artifacts failed to update from
+auto-merging: Renovate records the error, then commits and raises the PR
+regardless, and platform automerge never consults `artifactErrors` — so the PR
+merges on the strength of the checks it did pass, with nothing red to show for
+the part that did not happen. The contract-toolkit lane is the live case: if the
+renovate-pkl-sync driver fails or is skipped, the PR lands a toolkit version bump
+whose regenerated `app/generated/**` does not match it.
+
+Note the failure this has to survive is a silent one. A post-upgrade command the
+runner's admin-only `allowedCommands` allowlist does not match is skipped with a
+log line and nothing else, so "the command did not run" and "the command ran
+clean" are indistinguishable without this status.
+
+(The gate was built for a 7-day release-age bound on the uv.lock lane, which was
+removed fleet-wide in FND-367 — the reasoning above never depended on it. Do not
+retire this alongside anything cooldown-shaped; see FND-359 if it returns.)
 
 The classification is one `gh api --jq` line, and every interesting failure mode
 lives inside it — an empty match must read as "missing" (jq emits nothing for

--- a/.github/workflows/renovate-auto-approve-reusable.yml
+++ b/.github/workflows/renovate-auto-approve-reusable.yml
@@ -258,12 +258,16 @@ jobs:
             #    commits whatever its own artifact update produced, raises the PR,
             #    and still enables platform automerge (getPlatformPrOptions never
             #    consults artifactErrors — only Renovate's own *branch* automerge
-            #    is gated on them, and this fleet uses automergeType=pr). For the
-            #    fleet preset's release-age-bounded `uv lock` that means an
-            #    UNBOUNDED uv.lock would sail through on this approval, silently
-            #    defeating the cooldown on the one lane it covers. Same for a
-            #    pkl-sync failure, which would land stale generated contract
-            #    artifacts. So this gate is the enforcement point.
+            #    is gated on them, and this fleet uses automergeType=pr). So the
+            #    PR merges on the strength of the checks it did pass, with nothing
+            #    red to show for the part that did not happen: a pkl-sync failure
+            #    lands a toolkit bump whose generated contract artifacts do not
+            #    match it, and a lock refresh that could not resolve lands a lock
+            #    inconsistent with the change it claims to make. Worse, a command
+            #    the runner's allowedCommands allowlist does not match is skipped
+            #    with a log line and nothing else — "did not run" and "ran clean"
+            #    are indistinguishable without this status. So this gate is the
+            #    enforcement point.
             #
             #    The preset sets statusCheckWhen.artifactError=always so the
             #    context is published green on healthy branches too — that is what


### PR DESCRIPTION
Comments only. The gate, its classification line and its tests are unchanged; 15 tests pass.

## Why

The `renovate/artifacts` approval gate (#3212) was built to stop a failed release-age-bounded `uv lock` from auto-merging an unbounded lockfile. That cooldown was removed fleet-wide in #3218 (FND-367), so the test docstring and the workflow comment now both justify the gate by a mechanism that no longer exists.

That's the "looks orphaned, gets reverted by association" risk. The gate is load-bearing and has nothing to do with the cooldown.

## What the rationale says now

Renovate records an artifact error, then commits and raises the PR anyway, and platform automerge never consults `artifactErrors` (`getPlatformPrOptions` computes `usePlatformAutomerge` from `automerge` + `automergeType` + `platformAutomerge` only). So the PR merges on the strength of the checks it did pass, with nothing red to show for the part that did not happen.

Restated on the cases that are actually live:

- **contract-toolkit lane** — if the `renovate-pkl-sync` driver fails or is skipped, the PR lands a toolkit version bump whose regenerated `app/generated/**` does not match it.
- **any lock refresh that could not resolve** — the PR lands a lock inconsistent with the change it claims to make.

It also now names the failure the gate has to survive, which was implicit before: a post-upgrade command the runner's admin-only `allowedCommands` allowlist does not match is **skipped with a log line and nothing else**, so "did not run" and "ran clean" are indistinguishable without this status. Not hypothetical — that is exactly how the cooldown failed open on the run that introduced it.

A short parenthetical records that the cooldown was the original motivator and points at FND-359 if it returns, so the history isn't lost and nobody re-derives it.

## Not in this PR

`renovate-auto-approve-reusable.yml` still carries ~150 lines of inline branchy bash, against `docs/standards/ci.md`. Pre-existing, and tracked separately rather than smuggled into a comment-only change.

Closes FND-362
