### PR TITLE
ci(renovate): extract the Renovate auto-approval conditions into a tested script

### DIFF
--- a/.github/scripts/renovate_approval_conditions.py
+++ b/.github/scripts/renovate_approval_conditions.py
@@ -1,0 +1,555 @@
+#!/usr/bin/env python3
+"""Approval gate for Renovate dependency-only PRs — the atlan-ci code-owner review.
+
+Driver for ``.github/workflows/renovate-auto-approve-reusable.yml``. Every
+consumer repo in the fleet calls that reusable at ``@main``, so this file is the
+single decision point for what gets an unattended code-owner approval and
+therefore for what auto-merges. It is extracted from the workflow's inlined bash
+(FND-372) precisely because a wrong condition here does not fail loudly — it
+approves something it should not.
+
+An approval is posted iff ALL of the following hold, evaluated in this order and
+short-circuiting on the first failure (later conditions cost an API call, so the
+order is load-bearing for cost as well as for the log):
+
+  a. author is a Renovate bot — ``atlan-app-fleet[bot]`` (self-hosted fleet
+     runner) or ``renovate[bot]`` (Mend; application-sdk itself is still on it)
+  b. the PR is open and not a draft
+  c. the PR's current HEAD still matches the SHA being evaluated (race guard)
+  d. every changed file is dependency-related (see :func:`non_dep_files`)
+  e. every ruleset-required check is green (``gh pr checks --required``)
+  f. Renovate's own ``renovate/artifacts`` commit status is ``success``
+  g. atlan-ci has not already posted an APPROVED review with our signature
+
+**Fail closed.** Every condition withholds approval on anything other than an
+affirmative signal. A missing value is never a falsy default that reads as
+"fine": an absent ``renovate/artifacts`` context classifies as ``"missing"`` and
+blocks, and a metadata call that errors aborts the step rather than proceeding on
+a partial view. When adding a condition, make the negative case the default.
+
+**Per-PR isolation.** A commit can be the HEAD of several open PRs. Each is
+evaluated independently and a failing *condition* skips only that PR. An API
+*error*, by contrast, aborts the whole step with a non-zero exit — that is the
+inherited ``set -euo pipefail`` behaviour and it is deliberate: a red step is
+visible, and the next workflow_run completion re-evaluates everything anyway.
+
+Environment:
+    GH_TOKEN                PAT owned by atlan-ci (repo read + PR write).
+    REPO                    owner/name — in a reusable workflow ``github.repository``
+                            is the *calling* repo, which is what we want.
+    EVENT_NAME              'workflow_run' or 'workflow_dispatch'.
+    RUN_SHA                 workflow_run head_sha (empty for dispatch).
+    DISPATCH_PR             PR number (workflow_dispatch manual testing).
+    EXTRA_DEP_PATTERN       optional ERE alternation of repo-specific dependency
+                            paths, appended to the built-in allowlist.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from collections.abc import Callable
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Constants that other automation keys off. Changing any of these is a
+# cross-repo change, not a local one.
+# ---------------------------------------------------------------------------
+
+#: Leading line of the approval body. This is a STABLE SIGNATURE: the
+#: idempotency check (condition g) matches on it, the fleet dashboard scanner
+#: (packages/conformance/conformance/renovate/scan.py) reads it, and the
+#: @sdk-review workflows deliberately do NOT match it so the two never collide.
+APPROVAL_SIGNATURE = "**Renovate auto-approval:**"
+
+#: The login the gate's GH_TOKEN acts as, and whose prior approvals count for
+#: idempotency. atlan-ci is a real User account listed in CODEOWNERS — GitHub
+#: Apps cannot be code owners, which is why this one path keeps using the PAT.
+APPROVER_LOGIN = "atlan-ci"
+
+#: Renovate identities whose PRs are eligible. Keep BOTH: atlan-app-fleet[bot]
+#: is the self-hosted fleet runner; renovate[bot] is the Mend-hosted app, which
+#: application-sdk itself still uses for its own workflow-action updates. Do not
+#: drop renovate[bot] while application-sdk remains on Mend.
+RENOVATE_AUTHORS = ("atlan-app-fleet[bot]", "renovate[bot]")
+
+#: Renovate's own artifact-update status context (condition f).
+ARTIFACT_CONTEXT = "renovate/artifacts"
+
+#: Sentinel for "no ``renovate/artifacts`` state could be read". Deliberately a
+#: value that is not ``success`` rather than an empty string or None, so it
+#: prints usefully in the skip log and can never be mistaken for green.
+ARTIFACT_MISSING = "missing"
+
+#: Prefix allowlist: anything under .github/ is dependency-related (Renovate
+#: pins actions there). Matched as a prefix, not a whole path — subdirectories
+#: are in scope, and a lookalike like ``x.github/…`` is not.
+DOT_GITHUB_PREFIX = ".github/"
+
+#: Whole-path allowlist, an ERE alternation applied with full-match semantics —
+#: the Python equivalent of the workflow's original ``grep -vxE``.
+#:
+#: Lock/manifest files match at ANY depth via the ``(.*/)?`` prefix, so a
+#: monorepo's packages/conformance/uv.lock or apps/*/contract/PklProject ride the
+#: gate. That covers everything a Renovate app-contract-toolkit bump touches: the
+#: Pkl pin + lock (contract/PklProject, contract/PklProject.deps.json).
+#:
+#: The regenerated artifacts (app/generated/**, atlan.yaml, app.yaml) are matched
+#: ROOT-ONLY, with no ``(.*/)?`` prefix. renovate-pkl-sync only ever writes them
+#: at the repo root, so an unrelated app.yaml/atlan.yaml elsewhere in a consumer
+#: tree must NOT ride this gate. They are otherwise a deterministic function of
+#: the contract and the (already auto-merged) toolkit version.
+DEP_FILE_RE = (
+    r"(.*/)?uv\.lock"
+    r"|(.*/)?package-lock\.json"
+    r"|(.*/)?requirements\.txt"
+    r"|(.*/)?pyproject\.toml"
+    r"|(.*/)?contract/PklProject"
+    r"|(.*/)?contract/PklProject\.deps\.json"
+    r"|app/generated/.*"
+    r"|atlan\.yaml"
+    r"|app\.yaml"
+)
+
+APPROVAL_BODY = (
+    f"{APPROVAL_SIGNATURE} all required CI checks passed.\n"
+    "\n"
+    "This is an automated code-owner approval posted by `atlan-ci` for a\n"
+    "dependency-only Renovate PR. It is automatically dismissed on any new\n"
+    "push (`dismiss_stale_reviews_on_push`) and re-posted once the new\n"
+    "HEAD's required checks are green."
+)
+
+Runner = Callable[..., subprocess.CompletedProcess]
+
+
+class GhError(RuntimeError):
+    """A ``gh`` call whose failure must abort the step rather than be absorbed.
+
+    Used only for the calls the original bash left ungated under ``set -e``:
+    the dispatch PR lookup, per-PR metadata, the changed-file listing and the
+    review listing. Absorbing these would mean deciding on a partial view of the
+    PR — the one thing this gate must never do.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Pure conditions. Each returns (ok, message); the message is the ONLY
+# observability on why a Renovate PR was not approved, so it always names the
+# value that failed, never just the condition.
+# ---------------------------------------------------------------------------
+
+
+def check_author(pr: str, author: str) -> tuple[bool, str]:
+    """Condition (a): the PR must come from a Renovate bot."""
+    if author not in RENOVATE_AUTHORS:
+        return False, f"PR #{pr}: author is '{author}', not a Renovate bot — skipping."
+    return True, ""
+
+
+def check_open(pr: str, state: str, draft: bool) -> tuple[bool, str]:
+    """Condition (b): the PR must be open and not a draft."""
+    if state != "open" or draft:
+        return (
+            False,
+            f"PR #{pr}: state='{state}' draft='{_json_bool(draft)}' — skipping.",
+        )
+    return True, ""
+
+
+def check_head_unchanged(pr: str, head_sha: str, eval_sha: str) -> tuple[bool, str]:
+    """Condition (c): race guard — bail if HEAD moved since the event fired.
+
+    Approving a SHA that is no longer HEAD would attach a code-owner review to
+    work whose checks were never evaluated. The push that moved HEAD fires its
+    own run, so skipping here loses nothing.
+    """
+    if head_sha != eval_sha:
+        return (
+            False,
+            f"PR #{pr}: HEAD moved ({eval_sha} → {head_sha}). "
+            "Skipping — a later run will re-evaluate.",
+        )
+    return True, ""
+
+
+def non_dep_files(filenames: list[str], extra_pattern: str = "") -> list[str]:
+    """Condition (d): return the changed files that are NOT dependency-related.
+
+    A file is dependency-related iff it sits under ``.github/`` (prefix match) or
+    fully matches :data:`DEP_FILE_RE`, optionally extended by the caller's
+    ``extra_dep_file_pattern``. An empty list means the PR is dep-only.
+
+    ``extra_pattern`` is appended as a further ERE alternation branch, matching
+    the original ``DEP_FILE_RE="${DEP_FILE_RE}|${EXTRA_DEP_PATTERN}"``. Full-match
+    semantics come from :func:`re.fullmatch`, standing in for ``grep -vxE``.
+
+    An unparseable ``extra_pattern`` raises ``re.error``, which aborts the step.
+    That is a DELIBERATE divergence from the bash this replaces: there the
+    invalid-regex ``grep`` exit was swallowed by the trailing ``|| true``, which
+    produced an empty non-dep list — i.e. a repo with a typo'd
+    ``extra_dep_file_pattern`` would have had *every* changed file approved,
+    source files included. Failing the step is the fail-closed direction.
+    """
+    pattern = DEP_FILE_RE
+    if extra_pattern:
+        pattern = f"{pattern}|{extra_pattern}"
+    compiled = re.compile(pattern)
+    return [
+        f
+        for f in filenames
+        if f and not f.startswith(DOT_GITHUB_PREFIX) and not compiled.fullmatch(f)
+    ]
+
+
+def classify_artifact_state(payload: Any) -> str:
+    """Condition (f): reduce a combined-status payload to a single state string.
+
+    Returns the state of the FIRST ``renovate/artifacts`` status, or
+    :data:`ARTIFACT_MISSING` when the payload carries none, is the wrong shape,
+    or could not be fetched at all (``payload is None``).
+
+    Reading "missing" as not-green is only safe because the fleet preset sets
+    ``statusCheckWhen.artifactError = "always"``, so the context is published
+    green on healthy branches too. Renovate's default publishes it only on error,
+    under which every healthy branch would read as missing and stall unapproved —
+    see the guard in ``tests/test_renovate_artifact_gate.py``.
+
+    Why this gate exists at all: a failed ``postUpgradeTasks`` command does not
+    stop Renovate. It commits whatever its own artifact update produced, raises
+    the PR, and still enables platform automerge (``getPlatformPrOptions`` never
+    consults ``artifactErrors``; only Renovate's own *branch* automerge is gated
+    on them, and this fleet uses ``automergeType=pr``). So the PR would merge on
+    the strength of the checks it did pass, with nothing red to show for the part
+    that did not happen — a pkl-sync failure landing a toolkit bump whose
+    generated artifacts do not match it, or a lock refresh that could not
+    resolve. Worse, a command the runner's ``allowedCommands`` allowlist does not
+    match is skipped with a log line and nothing else, so "did not run" and "ran
+    clean" are indistinguishable without this status.
+    """
+    if not isinstance(payload, dict):
+        return ARTIFACT_MISSING
+    statuses = payload.get("statuses")
+    if not isinstance(statuses, list):
+        return ARTIFACT_MISSING
+    for entry in statuses:
+        if isinstance(entry, dict) and entry.get("context") == ARTIFACT_CONTEXT:
+            state = entry.get("state")
+            return state if isinstance(state, str) else ARTIFACT_MISSING
+    return ARTIFACT_MISSING
+
+
+def count_signature_approvals(reviews: list[Any]) -> int:
+    """Condition (g): count live atlan-ci approvals bearing our signature.
+
+    Only ``APPROVED`` counts. A push-dismissed review has state ``DISMISSED``, so
+    it does not match and a fresh approval is correctly posted on the next green
+    run. A human's approval, or an atlan-ci review carrying a different signature
+    (``**SDK reviewer's verdict:**``), does not suppress ours.
+    """
+    return sum(
+        1
+        for r in reviews
+        if isinstance(r, dict)
+        and (r.get("user") or {}).get("login") == APPROVER_LOGIN
+        and r.get("state") == "APPROVED"
+        and str(r.get("body") or "").startswith(APPROVAL_SIGNATURE)
+    )
+
+
+def _json_bool(value: bool) -> str:
+    """Render a bool the way the original bash logged it (jq's lowercase form)."""
+    return "true" if value else "false"
+
+
+# ---------------------------------------------------------------------------
+# gh I/O. Every call goes through _gh so tests can stub the external tool and
+# let the rest of the module run for real (docs/standards/ci.md, "Testability
+# seam").
+# ---------------------------------------------------------------------------
+
+
+def _gh(args: list[str], runner: Runner) -> subprocess.CompletedProcess:
+    return runner(["gh", *args], check=False, capture_output=True, text=True)
+
+
+def _gh_json(args: list[str], runner: Runner, *, what: str) -> Any:
+    """Run a ``gh api`` call and parse its JSON body, or raise :class:`GhError`.
+
+    Deliberately does NOT pass ``--jq``: shaping the payload here rather than in
+    a jq filter keeps every classification decision inside a unit-testable pure
+    function. A non-2xx response writes an error body to stdout, so the exit code
+    — not the presence of output — is what decides.
+    """
+    result = _gh(args, runner)
+    if result.returncode != 0:
+        raise GhError(f"{what}: gh exited {result.returncode}")
+    raw = (result.stdout or "").strip()
+    if not raw:
+        raise GhError(f"{what}: gh returned an empty body")
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise GhError(f"{what}: could not parse gh output as JSON ({exc})") from exc
+    return _flatten_pages(payload)
+
+
+def _flatten_pages(payload: Any) -> Any:
+    """Flatten a ``--paginate --slurp`` listing (an array *of page arrays*).
+
+    ``gh api --paginate`` alone emits one JSON document per page, and combining
+    it with ``--jq`` applies the filter per page — which is how the original
+    bash's ``| length`` review count could emit ``"0\\n0"`` for a two-page PR and
+    read as "already approved". ``--slurp`` collapses the pages into one array,
+    and this flattens that array one level.
+    """
+    if (
+        isinstance(payload, list)
+        and payload
+        and all(isinstance(p, list) for p in payload)
+    ):
+        return [item for page in payload for item in page]
+    return payload
+
+
+def resolve_prs(
+    repo: str, event_name: str, run_sha: str, dispatch_pr: str, runner: Runner
+) -> tuple[list[str], str]:
+    """Return ``(pr_numbers, eval_sha)`` for the triggering event.
+
+    ``workflow_dispatch`` evaluates exactly the PR it was given, at that PR's
+    current HEAD. ``workflow_run`` evaluates every OPEN PR whose HEAD is the
+    completed run's SHA — a single commit can be the HEAD of several.
+
+    The two lookups fail differently, matching the original bash: the dispatch
+    lookup raises (a manual re-evaluation of a PR that cannot be read is a
+    mistake worth surfacing), while a failed commit→PRs lookup yields no
+    candidates and the step exits cleanly. Both approve nothing.
+    """
+    if event_name == "workflow_dispatch":
+        meta = _gh_json(
+            ["api", f"repos/{repo}/pulls/{dispatch_pr}"],
+            runner,
+            what=f"resolving HEAD of dispatched PR #{dispatch_pr}",
+        )
+        if not isinstance(meta, dict):
+            raise GhError(
+                f"resolving HEAD of dispatched PR #{dispatch_pr}: unexpected payload shape"
+            )
+        eval_sha = str((meta.get("head") or {}).get("sha") or "")
+        return ([dispatch_pr] if dispatch_pr else []), eval_sha
+
+    try:
+        listing = _gh_json(
+            ["api", f"repos/{repo}/commits/{run_sha}/pulls"],
+            runner,
+            what=f"listing PRs for {run_sha}",
+        )
+    except GhError:
+        return [], run_sha
+    if not isinstance(listing, list):
+        return [], run_sha
+    return [
+        str(pr["number"])
+        for pr in listing
+        if isinstance(pr, dict) and pr.get("state") == "open" and pr.get("number")
+    ], run_sha
+
+
+def fetch_pr_meta(repo: str, pr: str, runner: Runner) -> dict[str, Any]:
+    payload = _gh_json(
+        ["api", f"repos/{repo}/pulls/{pr}"], runner, what=f"fetching PR #{pr}"
+    )
+    if not isinstance(payload, dict):
+        raise GhError(f"fetching PR #{pr}: unexpected payload shape")
+    return payload
+
+
+def fetch_filenames(repo: str, pr: str, runner: Runner) -> list[str]:
+    payload = _gh_json(
+        ["api", f"repos/{repo}/pulls/{pr}/files", "--paginate", "--slurp"],
+        runner,
+        what=f"listing changed files for PR #{pr}",
+    )
+    if not isinstance(payload, list):
+        raise GhError(f"listing changed files for PR #{pr}: unexpected payload shape")
+    return [f["filename"] for f in payload if isinstance(f, dict) and f.get("filename")]
+
+
+def required_checks_green(repo: str, pr: str, runner: Runner) -> bool:
+    """Condition (e): ``gh pr checks --required`` exits 0 iff every required check
+    is passing or skipping.
+
+    Non-required failures are correctly excluded — the ruleset, not this script,
+    decides what "required" means, so a repo changing its required contexts needs
+    no change here. Pending required checks exit non-zero; a later workflow_run
+    completion re-fires and re-evaluates.
+    """
+    result = _gh(["pr", "checks", pr, "--repo", repo, "--required"], runner)
+    # Echo gh's own table so the step log still shows which check was red.
+    for stream in (result.stdout, result.stderr):
+        if stream and stream.strip():
+            print(stream.rstrip())
+    return result.returncode == 0
+
+
+def fetch_artifact_state(repo: str, eval_sha: str, runner: Runner) -> str:
+    """Read the ``renovate/artifacts`` state for ``eval_sha``, fail-closed.
+
+    Unlike the metadata calls, an API error here does NOT abort: it classifies as
+    :data:`ARTIFACT_MISSING`, which withholds approval just the same. Absorbing
+    it is safe precisely because the absorbed value is already the blocking one.
+    """
+    try:
+        payload = _gh_json(
+            ["api", f"repos/{repo}/commits/{eval_sha}/status"],
+            runner,
+            what=f"reading commit status for {eval_sha}",
+        )
+    except GhError:
+        return ARTIFACT_MISSING
+    return classify_artifact_state(payload)
+
+
+def fetch_reviews(repo: str, pr: str, runner: Runner) -> list[Any]:
+    payload = _gh_json(
+        ["api", f"repos/{repo}/pulls/{pr}/reviews", "--paginate", "--slurp"],
+        runner,
+        what=f"listing reviews for PR #{pr}",
+    )
+    if not isinstance(payload, list):
+        raise GhError(f"listing reviews for PR #{pr}: unexpected payload shape")
+    return payload
+
+
+def approve(repo: str, pr: str, runner: Runner) -> None:
+    """Post the atlan-ci code-owner approval. A failure aborts the step."""
+    runner(
+        [
+            "gh",
+            "pr",
+            "review",
+            pr,
+            "--repo",
+            repo,
+            "--approve",
+            "--body",
+            APPROVAL_BODY,
+        ],
+        check=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Orchestration
+# ---------------------------------------------------------------------------
+
+
+def process_pr(
+    repo: str, pr: str, eval_sha: str, extra_pattern: str, runner: Runner
+) -> bool:
+    """Evaluate one PR and approve it if every condition holds.
+
+    Returns True iff a new approval was posted. Conditions are evaluated in the
+    documented order and each fetch happens only once the cheaper conditions
+    ahead of it have passed, so a non-Renovate PR costs one API call, not six.
+    """
+    meta = fetch_pr_meta(repo, pr, runner)
+    author = str(((meta.get("user") or {}).get("login")) or "")
+    state = str(meta.get("state") or "")
+    draft = bool(meta.get("draft"))
+    head_sha = str(((meta.get("head") or {}).get("sha")) or "")
+
+    for ok, message in (
+        check_author(pr, author),
+        check_open(pr, state, draft),
+        check_head_unchanged(pr, head_sha, eval_sha),
+    ):
+        if not ok:
+            print(message)
+            return False
+
+    # d. All changed files must be dependency-related.
+    filenames = fetch_filenames(repo, pr, runner)
+    if not filenames:
+        print(f"PR #{pr}: no changed files found — skipping.")
+        return False
+    offenders = non_dep_files(filenames, extra_pattern)
+    if offenders:
+        print(f"PR #{pr}: contains non-dependency files:")
+        for name in offenders:
+            print(f"  {name}")
+        print("Skipping.")
+        return False
+    print(f"PR #{pr}: all changed files are dependency-related.")
+
+    # e. All ruleset-required checks must be green.
+    print(f"PR #{pr}: checking required CI status...")
+    if not required_checks_green(repo, pr, runner):
+        print(f"PR #{pr}: required checks not yet all green — skipping.")
+        return False
+    print(f"PR #{pr}: all required checks are green.")
+
+    # f. Renovate's artifact status must be green.
+    artifact_state = fetch_artifact_state(repo, eval_sha, runner)
+    if artifact_state != "success":
+        print(
+            f"PR #{pr}: {ARTIFACT_CONTEXT} is '{artifact_state}', "
+            "not 'success' — skipping."
+        )
+        return False
+    print(f"PR #{pr}: {ARTIFACT_CONTEXT} is green.")
+
+    # g. Idempotency.
+    if count_signature_approvals(fetch_reviews(repo, pr, runner)):
+        print(
+            f"PR #{pr}: atlan-ci has already approved with the Renovate "
+            "signature — skipping."
+        )
+        return False
+
+    approve(repo, pr, runner)
+    print(f"✅ Approved PR #{pr} as atlan-ci (Renovate auto-approval).")
+    return True
+
+
+def main(runner: Runner = subprocess.run) -> int:
+    repo = os.environ["REPO"]
+    event_name = os.environ.get("EVENT_NAME", "workflow_run")
+    run_sha = os.environ.get("RUN_SHA", "")
+    dispatch_pr = os.environ.get("DISPATCH_PR", "")
+    extra_pattern = os.environ.get("EXTRA_DEP_PATTERN", "")
+
+    try:
+        pr_numbers, eval_sha = resolve_prs(
+            repo, event_name, run_sha, dispatch_pr, runner
+        )
+        if not pr_numbers:
+            print(f"No open PRs found for SHA {eval_sha} — nothing to do.")
+            return 0
+        for pr in pr_numbers:
+            print(f"--- Evaluating PR #{pr} ---")
+            process_pr(repo, pr, eval_sha, extra_pattern, runner)
+    except GhError as exc:
+        # Abort rather than continue on a partial view — the inherited
+        # `set -euo pipefail` semantics. A red step is visible; the next
+        # workflow_run completion re-evaluates every candidate PR anyway.
+        print(f"::error::{exc}")
+        return 1
+    except re.error as exc:
+        # A malformed extra_dep_file_pattern from the caller. Fail the step
+        # rather than fall back to a permissive allowlist — see non_dep_files.
+        print(
+            f"::error::extra_dep_file_pattern is not a valid regular expression "
+            f"({exc}). No PR was approved. Fix the pattern in the caller's "
+            "`with: extra_dep_file_pattern:`."
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/tests/test_renovate_approval_conditions.py
+++ b/.github/scripts/tests/test_renovate_approval_conditions.py
@@ -1,0 +1,897 @@
+"""Tests for .github/scripts/renovate_approval_conditions.py — the fleet's
+code-owner approval boundary for Renovate PRs.
+
+Every consumer repo calls the reusable workflow that drives this script, and it
+decides what auto-merges unattended, so the bar here is not "the conditions are
+implemented" but "no non-affirmative signal reaches the approval". The suite is
+organised accordingly:
+
+  * pure conditions, one class each, negative cases first;
+  * :class:`TestFailClosed`, a sweep asserting that *nothing* but an affirmative
+    signal approves;
+  * :class:`TestExtractionParity`, the decision + log-line table characterised
+    from the inline bash this replaced (FND-372), so the extraction stays
+    provably behaviour-preserving rather than merely plausible;
+  * :class:`TestDeliberateDivergences`, the two places the Python intentionally
+    does NOT match that bash, each with the reason it is the safe direction.
+
+The parity table was produced by running the workflow's original `run:` block
+against a stubbed `gh` (real `jq`) over this exact scenario matrix and recording
+the decision, exit status and stdout. 43 of 44 scenarios reproduce byte for
+byte; the divergences are the two below.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import renovate_approval_conditions as gate  # noqa: E402
+
+SHA = "abc123"
+REPO = "owner/repo"
+
+
+# ---------------------------------------------------------------------------
+# Fixture builders — mirror the real GitHub payload shapes, because the script
+# reads raw API JSON rather than a pre-shaped --jq projection.
+# ---------------------------------------------------------------------------
+
+
+def pr_payload(author="renovate[bot]", state="open", draft=False, head=SHA):
+    return {
+        "user": {"login": author},
+        "state": state,
+        "draft": draft,
+        "head": {"sha": head},
+    }
+
+
+def file_payload(*names):
+    return [{"filename": n} for n in names]
+
+
+def status_payload(*pairs):
+    return {"statuses": [{"context": c, "state": s} for c, s in pairs]}
+
+
+GREEN_ARTIFACTS = status_payload((gate.ARTIFACT_CONTEXT, "success"))
+
+APPROVED_REVIEW = {
+    "user": {"login": "atlan-ci"},
+    "state": "APPROVED",
+    "body": f"{gate.APPROVAL_SIGNATURE} all required CI checks passed.\n",
+}
+DISMISSED_REVIEW = {**APPROVED_REVIEW, "state": "DISMISSED"}
+HUMAN_REVIEW = {"user": {"login": "someone"}, "state": "APPROVED", "body": "lgtm"}
+SDK_REVIEW_APPROVAL = {
+    "user": {"login": "atlan-ci"},
+    "state": "APPROVED",
+    "body": "**SDK reviewer's verdict:** approved",
+}
+
+
+class FakeGh:
+    """Stand-in for the `gh` CLI, serving canned payloads and recording calls.
+
+    ``None`` for a payload simulates a non-2xx response: gh writes an error body
+    to stdout and exits non-zero, which is the case the gate must never parse as
+    a state. Listings served for ``--paginate --slurp`` are wrapped in an outer
+    array, exactly as gh emits pages.
+    """
+
+    def __init__(
+        self,
+        *,
+        meta=None,
+        commit_pulls=None,
+        files=None,
+        status=None,
+        reviews=None,
+        checks_exit=0,
+    ):
+        self.meta = pr_payload() if meta is _UNSET else meta
+        self.commit_pulls = (
+            [{"state": "open", "number": 7}] if commit_pulls is _UNSET else commit_pulls
+        )
+        self.files = file_payload("uv.lock") if files is _UNSET else files
+        self.status = GREEN_ARTIFACTS if status is _UNSET else status
+        self.reviews = [] if reviews is _UNSET else reviews
+        self.checks_exit = checks_exit
+        self.calls: list[list[str]] = []
+        self.approvals: list[list[str]] = []
+
+    @staticmethod
+    def _respond(payload, *, slurp=False):
+        if payload is None:
+            return json.dumps({"message": "Not Found"}), 1
+        return json.dumps([payload] if slurp else payload), 0
+
+    def __call__(self, cmd, check=False, capture_output=False, text=False):
+        self.calls.append(cmd)
+        args = cmd[1:]
+        out, rc = "", 0
+        if args[0] == "api":
+            path = args[1]
+            if path.endswith("/files"):
+                out, rc = self._respond(self.files, slurp=True)
+            elif path.endswith("/reviews"):
+                out, rc = self._respond(self.reviews, slurp=True)
+            elif path.endswith("/status"):
+                out, rc = self._respond(self.status)
+            elif path.endswith("/pulls"):
+                out, rc = self._respond(self.commit_pulls)
+            else:
+                out, rc = self._respond(self.meta)
+        elif args[:2] == ["pr", "checks"]:
+            rc = self.checks_exit
+        elif args[:2] == ["pr", "review"]:
+            self.approvals.append(cmd)
+        return subprocess.CompletedProcess(cmd, rc, stdout=out, stderr="")
+
+    @property
+    def api_paths(self) -> list[str]:
+        return [c[2] for c in self.calls if c[1] == "api"]
+
+
+class _Unset:
+    def __repr__(self):  # pragma: no cover - debugging aid
+        return "<default>"
+
+
+_UNSET = _Unset()
+
+
+def _defaults(**over):
+    base = dict(
+        meta=_UNSET,
+        commit_pulls=_UNSET,
+        files=_UNSET,
+        status=_UNSET,
+        reviews=_UNSET,
+        checks_exit=0,
+    )
+    base.update(over)
+    return base
+
+
+def run_main(monkeypatch, *, env=None, capsys=None, **gh_kwargs):
+    """Drive ``main`` end to end against a :class:`FakeGh`."""
+    environ = {
+        "REPO": REPO,
+        "EVENT_NAME": "workflow_run",
+        "RUN_SHA": SHA,
+        "DISPATCH_PR": "",
+        "EXTRA_DEP_PATTERN": "",
+    }
+    environ.update(env or {})
+    for key, value in environ.items():
+        monkeypatch.setenv(key, value)
+    fake = FakeGh(**_defaults(**gh_kwargs))
+    code = gate.main(fake)
+    log = capsys.readouterr().out if capsys else ""
+    return code, fake, log
+
+
+# ---------------------------------------------------------------------------
+# Condition (a): author
+# ---------------------------------------------------------------------------
+
+
+class TestAuthor:
+    @pytest.mark.parametrize(
+        "author", ["a-human", "dependabot[bot]", "", "renovate", "atlan-app-fleet"]
+    )
+    def test_non_renovate_authors_are_refused(self, author):
+        ok, msg = gate.check_author("7", author)
+        assert not ok
+        # The skip log is the only observability on why a PR was not approved,
+        # so it must name the value that failed, not just the condition.
+        assert f"author is '{author}'" in msg
+
+    @pytest.mark.parametrize("author", ["atlan-app-fleet[bot]", "renovate[bot]"])
+    def test_both_renovate_identities_are_accepted(self, author):
+        assert gate.check_author("7", author)[0]
+
+    def test_mend_identity_is_still_shipped(self):
+        # application-sdk itself is still on Mend-hosted Renovate for its own
+        # workflow-action updates. Dropping renovate[bot] silently stops
+        # approving those; keep both until the SDK moves to the fleet runner.
+        assert "renovate[bot]" in gate.RENOVATE_AUTHORS
+        assert "atlan-app-fleet[bot]" in gate.RENOVATE_AUTHORS
+
+
+# ---------------------------------------------------------------------------
+# Condition (b): open and not draft
+# ---------------------------------------------------------------------------
+
+
+class TestOpenNotDraft:
+    @pytest.mark.parametrize(
+        "state,draft",
+        [("closed", False), ("merged", False), ("", False), ("open", True)],
+    )
+    def test_anything_but_open_and_undrafted_is_refused(self, state, draft):
+        assert not gate.check_open("7", state, draft)[0]
+
+    def test_open_undrafted_passes(self):
+        assert gate.check_open("7", "open", False)[0]
+
+    def test_message_reports_the_jq_style_lowercase_bool(self):
+        # Matches the log the inline bash emitted (jq renders booleans
+        # lowercase), so operators reading old and new runs see one format.
+        assert "draft='true'" in gate.check_open("7", "open", True)[1]
+        assert "draft='false'" in gate.check_open("7", "closed", False)[1]
+
+
+# ---------------------------------------------------------------------------
+# Condition (c): race guard
+# ---------------------------------------------------------------------------
+
+
+class TestHeadUnchanged:
+    def test_matching_sha_passes(self):
+        assert gate.check_head_unchanged("7", SHA, SHA)[0]
+
+    def test_moved_head_is_refused(self):
+        ok, msg = gate.check_head_unchanged("7", "deadbeef", SHA)
+        assert not ok
+        assert SHA in msg and "deadbeef" in msg
+
+    def test_empty_head_is_refused(self):
+        # A metadata payload missing .head.sha must not compare equal to the
+        # evaluated SHA by way of an empty default.
+        assert not gate.check_head_unchanged("7", "", SHA)[0]
+
+
+# ---------------------------------------------------------------------------
+# Condition (d): the changed-file allowlist
+# ---------------------------------------------------------------------------
+
+
+class TestDepFileAllowlist:
+    @pytest.mark.parametrize(
+        "path",
+        [
+            ".github/workflows/tests.yaml",
+            ".github/dependabot.yml",
+            "uv.lock",
+            "packages/conformance/uv.lock",
+            "package-lock.json",
+            "requirements.txt",
+            "pyproject.toml",
+            "sub/dir/pyproject.toml",
+            "contract/PklProject",
+            "contract/PklProject.deps.json",
+            "apps/foo/contract/PklProject",
+            "app/generated/contract.pkl",
+            "app/generated/nested/deep.pkl",
+            "atlan.yaml",
+            "app.yaml",
+        ],
+    )
+    def test_dependency_paths_are_allowed(self, path):
+        assert gate.non_dep_files([path]) == []
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "README.md",
+            "application_sdk/foo.py",
+            "Dockerfile",
+            # Lookalikes: the .github rule is a path prefix, not a substring.
+            "x.github/foo.yml",
+            "docs/.github/foo.yml",
+            # The `.` in the manifest names is a literal, not "any character".
+            "uvXlock",
+            # ...and the (.*/)? prefix requires a directory boundary.
+            "myuv.lock",
+            "notrequirements.txt",
+        ],
+    )
+    def test_non_dependency_paths_are_refused(self, path):
+        assert gate.non_dep_files([path]) == [path]
+
+    @pytest.mark.parametrize(
+        "path", ["sub/atlan.yaml", "sub/app.yaml", "x/app/generated/a.pkl"]
+    )
+    def test_generated_artifacts_are_root_only(self, path):
+        # renovate-pkl-sync only ever writes these at the repo root. An
+        # unrelated app.yaml/atlan.yaml elsewhere in a consumer tree is ordinary
+        # source and must not ride this gate.
+        assert gate.non_dep_files([path]) == [path]
+
+    def test_one_bad_file_among_many_good_ones_is_reported(self):
+        files = ["uv.lock", "pyproject.toml", "application_sdk/foo.py"]
+        assert gate.non_dep_files(files) == ["application_sdk/foo.py"]
+
+    def test_all_offenders_are_reported_not_just_the_first(self):
+        # The skip log lists them; truncating to one would hide what else the
+        # PR touched.
+        assert gate.non_dep_files(["a.py", "uv.lock", "b.py"]) == ["a.py", "b.py"]
+
+    def test_extra_pattern_extends_the_allowlist(self):
+        extra = r"packages/conformance/conformance/bootstrap/templates/.+\.ya?ml"
+        path = "packages/conformance/conformance/bootstrap/templates/tests.yaml"
+        assert gate.non_dep_files([path], extra) == []
+        # ...and only when the caller actually declares it.
+        assert gate.non_dep_files([path]) == [path]
+
+    def test_extra_pattern_is_whole_line_matched(self):
+        # Appended as another ERE alternation branch under full-match semantics
+        # (the Python stand-in for `grep -vxE`), so a partial match must not
+        # sneak a longer path through.
+        assert gate.non_dep_files(["vendor/x.txt"], r"x\.txt") == ["vendor/x.txt"]
+        assert gate.non_dep_files(["x.txt"], r"x\.txt") == []
+
+    def test_empty_filenames_are_ignored(self):
+        assert gate.non_dep_files(["", "uv.lock"]) == []
+
+
+# ---------------------------------------------------------------------------
+# Condition (f): renovate/artifacts classification
+#
+# This is the case the gate exists for. A failed postUpgradeTasks command does
+# not stop Renovate — it commits, raises the PR and still enables platform
+# automerge — so an artifacts status that is anything other than green must
+# withhold approval, and a status that is ABSENT must too.
+# ---------------------------------------------------------------------------
+
+
+class TestArtifactState:
+    def test_green_is_success(self):
+        assert gate.classify_artifact_state(GREEN_ARTIFACTS) == "success"
+
+    @pytest.mark.parametrize("state", ["failure", "pending", "error"])
+    def test_other_states_are_passed_through_verbatim(self, state):
+        # Reported verbatim so the skip log says which, not merely "not green".
+        assert (
+            gate.classify_artifact_state(status_payload((gate.ARTIFACT_CONTEXT, state)))
+            == state
+        )
+
+    def test_absent_context_reads_as_missing(self):
+        # The transition case: branches created before statusCheckWhen=always,
+        # and any branch Renovate has not committed to. Must NOT read as green.
+        assert (
+            gate.classify_artifact_state(status_payload(("ci/build", "success")))
+            == gate.ARTIFACT_MISSING
+        )
+
+    def test_empty_status_list_reads_as_missing(self):
+        assert gate.classify_artifact_state(status_payload()) == gate.ARTIFACT_MISSING
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            None,  # the fetch failed outright
+            {},  # no statuses key
+            {"statuses": None},
+            {"statuses": "success"},  # wrong type
+            {"message": "Not Found"},  # a non-2xx error body
+            [],  # wrong top-level shape
+            {"statuses": [{"context": gate.ARTIFACT_CONTEXT}]},  # no state key
+            {"statuses": [{"context": gate.ARTIFACT_CONTEXT, "state": None}]},
+        ],
+    )
+    def test_unreadable_payloads_read_as_missing(self, payload):
+        assert gate.classify_artifact_state(payload) == gate.ARTIFACT_MISSING
+
+    def test_first_matching_status_wins(self):
+        # GitHub's combined-status endpoint lists the newest first; taking the
+        # first preserves the original `| first` semantics.
+        payload = status_payload(
+            (gate.ARTIFACT_CONTEXT, "failure"), (gate.ARTIFACT_CONTEXT, "success")
+        )
+        assert gate.classify_artifact_state(payload) == "failure"
+
+    def test_missing_sentinel_is_not_success(self):
+        assert gate.ARTIFACT_MISSING != "success"
+
+    def test_api_error_does_not_abort_the_step(self):
+        # Unlike the metadata calls, an unreadable status classifies as missing
+        # rather than raising — safe only because "missing" already blocks.
+        fake = FakeGh(**_defaults(status=None))
+        assert gate.fetch_artifact_state(REPO, SHA, fake) == gate.ARTIFACT_MISSING
+
+
+# ---------------------------------------------------------------------------
+# Condition (g): idempotency
+# ---------------------------------------------------------------------------
+
+
+class TestSignatureApprovals:
+    def test_matching_approval_counts(self):
+        assert gate.count_signature_approvals([APPROVED_REVIEW]) == 1
+
+    def test_dismissed_approval_does_not_count(self):
+        # dismiss_stale_reviews_on_push turns our review into DISMISSED, which
+        # must let a fresh approval be posted for the new HEAD.
+        assert gate.count_signature_approvals([DISMISSED_REVIEW]) == 0
+
+    def test_human_approval_does_not_count(self):
+        assert gate.count_signature_approvals([HUMAN_REVIEW]) == 0
+
+    def test_sdk_review_approval_does_not_count(self):
+        # @sdk-review posts as atlan-ci too but with its own signature. The two
+        # automations are deliberately decoupled; neither may suppress the other.
+        assert gate.count_signature_approvals([SDK_REVIEW_APPROVAL]) == 0
+
+    @pytest.mark.parametrize(
+        "review",
+        [
+            {"user": None, "state": "APPROVED", "body": gate.APPROVAL_SIGNATURE},
+            {"user": {}, "state": "APPROVED", "body": gate.APPROVAL_SIGNATURE},
+            {"user": {"login": "atlan-ci"}, "state": "APPROVED", "body": None},
+            "not-a-dict",
+        ],
+    )
+    def test_malformed_entries_do_not_count(self, review):
+        assert gate.count_signature_approvals([review]) == 0
+
+    def test_signature_is_the_documented_stable_string(self):
+        # The dashboard scanner and this gate both key off it; changing it is a
+        # cross-repo change, so pin the literal.
+        assert gate.APPROVAL_SIGNATURE == "**Renovate auto-approval:**"
+
+    def test_approval_body_starts_with_the_signature(self):
+        assert gate.APPROVAL_BODY.startswith(gate.APPROVAL_SIGNATURE)
+        assert (
+            gate.count_signature_approvals(
+                [
+                    {
+                        "user": {"login": "atlan-ci"},
+                        "state": "APPROVED",
+                        "body": gate.APPROVAL_BODY,
+                    }
+                ]
+            )
+            == 1
+        )
+
+
+# ---------------------------------------------------------------------------
+# PR resolution
+# ---------------------------------------------------------------------------
+
+
+class TestResolvePrs:
+    def test_workflow_run_selects_open_prs_at_the_run_sha(self):
+        fake = FakeGh(
+            **_defaults(
+                commit_pulls=[
+                    {"state": "open", "number": 7},
+                    {"state": "closed", "number": 8},
+                    {"state": "open", "number": 9},
+                ]
+            )
+        )
+        assert gate.resolve_prs(REPO, "workflow_run", SHA, "", fake) == (
+            ["7", "9"],
+            SHA,
+        )
+
+    def test_workflow_run_api_error_yields_no_candidates(self):
+        # A failed commit→PRs lookup must not populate the candidate list with
+        # tokens scraped from the error body — the bug the original bash's
+        # exit-code gate was added to fix.
+        fake = FakeGh(**_defaults(commit_pulls=None))
+        assert gate.resolve_prs(REPO, "workflow_run", SHA, "", fake) == ([], SHA)
+
+    def test_dispatch_evaluates_the_named_pr_at_its_current_head(self):
+        fake = FakeGh(**_defaults(meta=pr_payload(head="feedface")))
+        assert gate.resolve_prs(REPO, "workflow_dispatch", "", "7", fake) == (
+            ["7"],
+            "feedface",
+        )
+
+    def test_dispatch_api_error_aborts(self):
+        fake = FakeGh(**_defaults(meta=None))
+        with pytest.raises(gate.GhError):
+            gate.resolve_prs(REPO, "workflow_dispatch", "", "7", fake)
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed sweep
+# ---------------------------------------------------------------------------
+
+
+class TestFailClosed:
+    """No non-affirmative signal may produce an approval."""
+
+    @pytest.mark.parametrize(
+        "name,kwargs",
+        [
+            ("author", dict(meta=pr_payload(author="a-human"))),
+            ("closed", dict(meta=pr_payload(state="closed"))),
+            ("draft", dict(meta=pr_payload(draft=True))),
+            ("head moved", dict(meta=pr_payload(head="deadbeef"))),
+            (
+                "head missing",
+                dict(meta={"user": {"login": "renovate[bot]"}, "state": "open"}),
+            ),
+            ("no files", dict(files=[])),
+            ("source file", dict(files=file_payload("uv.lock", "src/a.py"))),
+            ("checks red", dict(checks_exit=1)),
+            ("checks pending", dict(checks_exit=8)),
+            (
+                "artifacts failure",
+                dict(status=status_payload((gate.ARTIFACT_CONTEXT, "failure"))),
+            ),
+            (
+                "artifacts pending",
+                dict(status=status_payload((gate.ARTIFACT_CONTEXT, "pending"))),
+            ),
+            ("artifacts absent", dict(status=status_payload(("ci/build", "success")))),
+            ("artifacts unreadable", dict(status=None)),
+            ("already approved", dict(reviews=[APPROVED_REVIEW])),
+        ],
+    )
+    def test_nothing_but_a_clean_pr_is_approved(
+        self, monkeypatch, capsys, name, kwargs
+    ):
+        _code, fake, _log = run_main(monkeypatch, capsys=capsys, **kwargs)
+        assert fake.approvals == [], f"{name} produced an approval"
+
+    @pytest.mark.parametrize("field", ["meta", "files", "reviews"])
+    def test_metadata_api_errors_abort_without_approving(
+        self, monkeypatch, capsys, field
+    ):
+        # Inherited `set -euo pipefail` semantics: deciding on a partial view of
+        # a PR is the one thing this gate must never do, so an unreadable
+        # metadata/file/review listing fails the step outright.
+        code, fake, log = run_main(monkeypatch, capsys=capsys, **{field: None})
+        assert code == 1
+        assert fake.approvals == []
+        assert "::error::" in log
+
+    def test_a_clean_pr_is_still_approved(self, monkeypatch, capsys):
+        # The control: without it, every assertion above passes on a gate that
+        # approves nothing at all.
+        code, fake, log = run_main(monkeypatch, capsys=capsys)
+        assert code == 0
+        assert len(fake.approvals) == 1
+        assert "✅ Approved PR #7" in log
+
+
+# ---------------------------------------------------------------------------
+# Orchestration: ordering, cost, isolation
+# ---------------------------------------------------------------------------
+
+
+class TestOrchestration:
+    def test_each_open_pr_at_the_sha_is_evaluated(self, monkeypatch, capsys):
+        # A commit can be the HEAD of several PRs; all of them get approved.
+        _code, fake, log = run_main(
+            monkeypatch,
+            capsys=capsys,
+            commit_pulls=[
+                {"state": "open", "number": 7},
+                {"state": "open", "number": 8},
+            ],
+        )
+        assert [c[3] for c in fake.approvals] == ["7", "8"]
+        assert "--- Evaluating PR #7 ---" in log and "--- Evaluating PR #8 ---" in log
+
+    def test_one_pr_failing_a_condition_does_not_abort_the_rest(
+        self, monkeypatch, capsys
+    ):
+        # Per-PR isolation. PR #7's HEAD has moved; #8 is clean and must still
+        # be approved.
+        calls: list[str] = []
+
+        class Isolating(FakeGh):
+            def __call__(self, cmd, **kw):
+                calls.append(" ".join(cmd))
+                if cmd[1] == "api" and cmd[2].endswith("/pulls/7"):
+                    return subprocess.CompletedProcess(
+                        cmd, 0, stdout=json.dumps(pr_payload(head="moved")), stderr=""
+                    )
+                return super().__call__(cmd, **kw)
+
+        for key, value in {
+            "REPO": REPO,
+            "EVENT_NAME": "workflow_run",
+            "RUN_SHA": SHA,
+            "DISPATCH_PR": "",
+            "EXTRA_DEP_PATTERN": "",
+        }.items():
+            monkeypatch.setenv(key, value)
+        fake = Isolating(
+            **_defaults(
+                commit_pulls=[
+                    {"state": "open", "number": 7},
+                    {"state": "open", "number": 8},
+                ]
+            )
+        )
+        code = gate.main(fake)
+        log = capsys.readouterr().out
+        assert code == 0
+        assert "PR #7: HEAD moved" in log
+        assert [c[3] for c in fake.approvals] == ["8"]
+
+    def test_conditions_short_circuit_before_paying_for_later_calls(
+        self, monkeypatch, capsys
+    ):
+        # A non-Renovate PR costs one API call, not six. This is also why the
+        # evaluation order in the module docstring is load-bearing.
+        _code, fake, _log = run_main(
+            monkeypatch, capsys=capsys, meta=pr_payload(author="a-human")
+        )
+        assert not any(
+            p.endswith(("/files", "/reviews", "/status")) for p in fake.api_paths
+        )
+
+    def test_artifact_status_is_read_before_the_review_is_posted(
+        self, monkeypatch, capsys
+    ):
+        _code, fake, _log = run_main(monkeypatch, capsys=capsys)
+        joined = [" ".join(c) for c in fake.calls]
+        status_at = next(i for i, c in enumerate(joined) if c.endswith("/status"))
+        review_at = next(i for i, c in enumerate(joined) if "pr review" in c)
+        assert status_at < review_at
+
+    def test_no_open_prs_exits_clean_without_touching_anything(
+        self, monkeypatch, capsys
+    ):
+        code, fake, log = run_main(monkeypatch, capsys=capsys, commit_pulls=[])
+        assert code == 0
+        assert fake.approvals == []
+        assert f"No open PRs found for SHA {SHA}" in log
+
+    def test_approval_is_posted_as_a_review_with_the_exact_body(
+        self, monkeypatch, capsys
+    ):
+        _code, fake, _log = run_main(monkeypatch, capsys=capsys)
+        cmd = fake.approvals[0]
+        assert cmd[:6] == ["gh", "pr", "review", "7", "--repo", REPO]
+        assert "--approve" in cmd
+        assert cmd[cmd.index("--body") + 1] == gate.APPROVAL_BODY
+
+    def test_dispatch_path_evaluates_the_named_pr(self, monkeypatch, capsys):
+        _code, fake, log = run_main(
+            monkeypatch,
+            capsys=capsys,
+            env={"EVENT_NAME": "workflow_dispatch", "RUN_SHA": "", "DISPATCH_PR": "7"},
+        )
+        assert len(fake.approvals) == 1
+        assert "--- Evaluating PR #7 ---" in log
+
+    def test_required_checks_use_the_ruleset_not_a_hardcoded_list(
+        self, monkeypatch, capsys
+    ):
+        # `gh pr checks --required` defers to the repo's own ruleset, so a repo
+        # changing its required contexts needs no change here. A hardcoded list
+        # would drift silently.
+        _code, fake, _log = run_main(monkeypatch, capsys=capsys)
+        checks = next(c for c in fake.calls if c[1:3] == ["pr", "checks"])
+        assert "--required" in checks
+
+    def test_paginated_listings_are_slurped_and_flattened(self, monkeypatch, capsys):
+        # `gh api --paginate` alone emits one document per page. Every paginated
+        # call must ask for --slurp so the pages arrive as one array.
+        _code, fake, _log = run_main(monkeypatch, capsys=capsys)
+        for cmd in fake.calls:
+            if cmd[1] == "api" and "--paginate" in cmd:
+                assert "--slurp" in cmd, cmd
+
+    def test_multi_page_review_listings_are_flattened(self):
+        assert gate._flatten_pages([[HUMAN_REVIEW], [APPROVED_REVIEW]]) == [
+            HUMAN_REVIEW,
+            APPROVED_REVIEW,
+        ]
+
+
+# ---------------------------------------------------------------------------
+# Extraction parity (FND-372)
+# ---------------------------------------------------------------------------
+
+
+class TestExtractionParity:
+    """Decision + log table characterised from the inline bash this replaced.
+
+    Each case was executed against the workflow's original `run:` block with a
+    stubbed `gh` before any code moved, and the expected log lines below are the
+    lines that block actually printed. They are asserted verbatim because the
+    skip log is the only observability on why a Renovate PR was not approved —
+    a refactor that keeps the decision but loses the reason is still a
+    regression.
+    """
+
+    CASES = [
+        (
+            "clean renovate PR",
+            {},
+            True,
+            ["✅ Approved PR #7 as atlan-ci (Renovate auto-approval)."],
+        ),
+        (
+            "fleet bot author",
+            dict(meta=pr_payload(author="atlan-app-fleet[bot]")),
+            True,
+            ["✅ Approved PR #7 as atlan-ci (Renovate auto-approval)."],
+        ),
+        (
+            "human author",
+            dict(meta=pr_payload(author="a-human")),
+            False,
+            ["PR #7: author is 'a-human', not a Renovate bot — skipping."],
+        ),
+        (
+            "closed PR",
+            dict(meta=pr_payload(state="closed")),
+            False,
+            ["PR #7: state='closed' draft='false' — skipping."],
+        ),
+        (
+            "draft PR",
+            dict(meta=pr_payload(draft=True)),
+            False,
+            ["PR #7: state='open' draft='true' — skipping."],
+        ),
+        (
+            "HEAD moved",
+            dict(meta=pr_payload(head="deadbeef")),
+            False,
+            [
+                f"PR #7: HEAD moved ({SHA} → deadbeef). "
+                "Skipping — a later run will re-evaluate."
+            ],
+        ),
+        (
+            "no changed files",
+            dict(files=[]),
+            False,
+            ["PR #7: no changed files found — skipping."],
+        ),
+        (
+            "source file present",
+            dict(files=file_payload("uv.lock", "application_sdk/foo.py")),
+            False,
+            [
+                "PR #7: contains non-dependency files:",
+                "  application_sdk/foo.py",
+                "Skipping.",
+            ],
+        ),
+        (
+            "required checks red",
+            dict(checks_exit=1),
+            False,
+            [
+                "PR #7: checking required CI status...",
+                "PR #7: required checks not yet all green — skipping.",
+            ],
+        ),
+        (
+            "artifacts failed",
+            dict(status=status_payload((gate.ARTIFACT_CONTEXT, "failure"))),
+            False,
+            ["PR #7: renovate/artifacts is 'failure', not 'success' — skipping."],
+        ),
+        (
+            "artifacts absent",
+            dict(status=status_payload(("ci/build", "success"))),
+            False,
+            ["PR #7: renovate/artifacts is 'missing', not 'success' — skipping."],
+        ),
+        (
+            "artifacts unreadable",
+            dict(status=None),
+            False,
+            ["PR #7: renovate/artifacts is 'missing', not 'success' — skipping."],
+        ),
+        (
+            "already approved",
+            dict(reviews=[APPROVED_REVIEW]),
+            False,
+            [
+                "PR #7: atlan-ci has already approved with the Renovate "
+                "signature — skipping."
+            ],
+        ),
+        (
+            "dismissed approval is re-posted",
+            dict(reviews=[DISMISSED_REVIEW]),
+            True,
+            ["✅ Approved PR #7 as atlan-ci (Renovate auto-approval)."],
+        ),
+        (
+            "human approval does not suppress ours",
+            dict(reviews=[HUMAN_REVIEW]),
+            True,
+            ["✅ Approved PR #7 as atlan-ci (Renovate auto-approval)."],
+        ),
+        (
+            "no open PRs at the SHA",
+            dict(commit_pulls=[]),
+            False,
+            [f"No open PRs found for SHA {SHA} — nothing to do."],
+        ),
+        (
+            "commit→PRs lookup failed",
+            dict(commit_pulls=None),
+            False,
+            [f"No open PRs found for SHA {SHA} — nothing to do."],
+        ),
+        (
+            "only closed PRs at the SHA",
+            dict(commit_pulls=[{"state": "closed", "number": 7}]),
+            False,
+            [f"No open PRs found for SHA {SHA} — nothing to do."],
+        ),
+    ]
+
+    @pytest.mark.parametrize(
+        "name,kwargs,approves,expected_lines",
+        CASES,
+        ids=[c[0] for c in CASES],
+    )
+    def test_matches_the_characterised_bash(
+        self, monkeypatch, capsys, name, kwargs, approves, expected_lines
+    ):
+        _code, fake, log = run_main(monkeypatch, capsys=capsys, **kwargs)
+        assert bool(fake.approvals) is approves, name
+        for line in expected_lines:
+            assert line in log, f"{name}: missing log line {line!r}"
+
+    def test_approval_body_is_byte_identical_to_the_bash_heredoc(self):
+        # Consumers see this text on every Renovate PR, and its first line is the
+        # idempotency signature — so it is pinned in full, not by prefix.
+        assert gate.APPROVAL_BODY == (
+            "**Renovate auto-approval:** all required CI checks passed.\n"
+            "\n"
+            "This is an automated code-owner approval posted by `atlan-ci` for a\n"
+            "dependency-only Renovate PR. It is automatically dismissed on any new\n"
+            "push (`dismiss_stale_reviews_on_push`) and re-posted once the new\n"
+            "HEAD's required checks are green."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Deliberate divergences from the extracted bash
+# ---------------------------------------------------------------------------
+
+
+class TestDeliberateDivergences:
+    """The two places this script does NOT reproduce the bash it replaced.
+
+    Both move in the fail-closed direction: the bash approved something it
+    should not have, and this refuses. Recorded here so a future reader can tell
+    an intentional correction from an extraction slip.
+    """
+
+    def test_invalid_extra_pattern_fails_the_step_instead_of_approving_everything(
+        self, monkeypatch, capsys
+    ):
+        # The bash built the allowlist by string-appending extra_dep_file_pattern
+        # into a `grep -vxE` whose non-zero exit was swallowed by `|| true`. An
+        # unparseable pattern therefore made grep exit 2, the non-dep list come
+        # back empty, and EVERY changed file — source included — read as
+        # dependency-related. Characterising the original confirmed it: a PR
+        # touching src/evil.py was approved. Refusing is the safe direction.
+        code, fake, log = run_main(
+            monkeypatch,
+            capsys=capsys,
+            env={"EXTRA_DEP_PATTERN": "["},
+            files=file_payload("src/evil.py"),
+        )
+        assert code == 1
+        assert fake.approvals == []
+        assert "extra_dep_file_pattern is not a valid regular expression" in log
+
+    def test_a_second_page_of_reviews_does_not_block_approval(self):
+        # The bash counted approvals with `gh api --paginate --jq '... | length'`,
+        # and --jq is applied PER PAGE — so a PR with two pages of reviews and no
+        # prior approval produced "0\n0", which its `!= "0"` test read as
+        # "already approved" and never approved again. --slurp collapses the
+        # pages, so the count is one number.
+        pages = [[HUMAN_REVIEW] * 30, [HUMAN_REVIEW]]
+        assert gate.count_signature_approvals(gate._flatten_pages(pages)) == 0

--- a/.github/scripts/tests/test_renovate_artifact_gate.py
+++ b/.github/scripts/tests/test_renovate_artifact_gate.py
@@ -94,31 +94,31 @@ class TestWorkflowWiring:
                 keyword not in run
             ), f"conditional shell ({keyword!r}) is back in the run: block"
 
-    def test_script_checkout_ref_cannot_evaluate_to_empty(self):
+    def test_script_checkout_ref_is_a_literal_that_cannot_be_empty(self):
         # Regression, found by piloting this gate from a consumer repo before
-        # merge: `ref: ${{ github.job_workflow_sha }}` renders EMPTY here, so
-        # checkout omitted the input entirely and fetched the default branch —
-        # a GREEN step that silently checked out a different commit's script
-        # than the workflow the caller pinned. It only surfaced because the
-        # script did not exist on main yet; after merge it would have run the
-        # wrong version quietly.
+        # merge: `ref: ${{ github.job_workflow_sha }}` renders EMPTY, so
+        # actions/checkout treated the input as unsupplied and fetched the
+        # default branch — a GREEN step that silently checked out a different
+        # commit's script than the workflow the caller pinned. It only surfaced
+        # because the script did not exist on main yet; after merge that mode
+        # would have run the wrong version quietly.
         #
-        # So the ref must come from a declared input with a default, which has
-        # no unset mode. Assert both halves: the expression, and the default
-        # that keeps every existing @main caller on today's behaviour.
+        # `main` is the right literal because every caller pins the reusable at
+        # @main. The assertion that matters is the second one: the ref must not
+        # come from an expression at all, since any expression can evaluate to
+        # empty and checkout reads empty as "not supplied".
         workflow = yaml.safe_load(_WORKFLOW.read_text())
         steps = workflow["jobs"]["renovate-auto-approve"]["steps"]
         checkout = next(
             s for s in steps if str(s.get("uses", "")).startswith("actions/checkout@")
         )
-        assert checkout["with"]["ref"] == "${{ inputs.sdk_ref }}"
+        ref = checkout["with"]["ref"]
+        assert ref == "main"
+        assert "${{" not in str(ref), (
+            "the checkout ref must be a literal — an expression that evaluates "
+            "to empty makes checkout silently take the default branch"
+        )
         assert checkout["with"]["path"] == ".sdk-scripts"
-
-        # `on` parses as a bool key in YAML 1.1, hence the lookup dance.
-        triggers = workflow.get("on") or workflow[True]
-        sdk_ref = triggers["workflow_call"]["inputs"]["sdk_ref"]
-        assert sdk_ref["default"] == "main"
-        assert sdk_ref["required"] is False
 
     def test_driver_path_resolves(self):
         # The reusable sparse-checks-out the SDK scripts into .sdk-scripts, so

--- a/.github/scripts/tests/test_renovate_artifact_gate.py
+++ b/.github/scripts/tests/test_renovate_artifact_gate.py
@@ -94,6 +94,21 @@ class TestWorkflowWiring:
                 keyword not in run
             ), f"conditional shell ({keyword!r}) is back in the run: block"
 
+    def test_script_checkout_tracks_the_workflow_commit(self):
+        # The conditions live in the script and the wiring lives in this YAML;
+        # fetching them from different commits is a skew that must not be
+        # expressible. `job_workflow_sha` is the commit of the reusable file the
+        # caller resolved, so the ref the caller pins is the single switch — and
+        # a consumer can point `uses:` at a branch to pilot a gate change end to
+        # end, which a hardcoded `ref: main` makes impossible.
+        workflow = yaml.safe_load(_WORKFLOW.read_text())
+        steps = workflow["jobs"]["renovate-auto-approve"]["steps"]
+        checkout = next(
+            s for s in steps if str(s.get("uses", "")).startswith("actions/checkout@")
+        )
+        assert checkout["with"]["ref"] == "${{ github.job_workflow_sha }}"
+        assert checkout["with"]["path"] == ".sdk-scripts"
+
     def test_driver_path_resolves(self):
         # The reusable sparse-checks-out the SDK scripts into .sdk-scripts, so
         # the invoked path is prefixed. Assert the file it points at exists.

--- a/.github/scripts/tests/test_renovate_artifact_gate.py
+++ b/.github/scripts/tests/test_renovate_artifact_gate.py
@@ -1,12 +1,12 @@
 """Behavioural guard for the renovate/artifacts approval condition (FND-362).
 
-`renovate-auto-approve-reusable.yml` withholds the atlan-ci code-owner approval
-unless Renovate's own `renovate/artifacts` commit status is green. That gate is
-the only thing stopping a branch whose artifacts failed to update from
-auto-merging: Renovate records the error, then commits and raises the PR
-regardless, and platform automerge never consults `artifactErrors` — so the PR
-merges on the strength of the checks it did pass, with nothing red to show for
-the part that did not happen. The contract-toolkit lane is the live case: if the
+The Renovate auto-approval withholds the atlan-ci code-owner approval unless
+Renovate's own `renovate/artifacts` commit status is green. That gate is the only
+thing stopping a branch whose artifacts failed to update from auto-merging:
+Renovate records the error, then commits and raises the PR regardless, and
+platform automerge never consults `artifactErrors` — so the PR merges on the
+strength of the checks it did pass, with nothing red to show for the part that
+did not happen. The contract-toolkit lane is the live case: if the
 renovate-pkl-sync driver fails or is skipped, the PR lands a toolkit version bump
 whose regenerated `app/generated/**` does not match it.
 
@@ -19,176 +19,51 @@ clean" are indistinguishable without this status.
 removed fleet-wide in FND-367 — the reasoning above never depended on it. Do not
 retire this alongside anything cooldown-shaped; see FND-359 if it returns.)
 
-The classification is one `gh api --jq` line, and every interesting failure mode
-lives inside it — an empty match must read as "missing" (jq emits nothing for
-`first` over an empty array unless the `// "missing"` default catches it), and a
-non-2xx response must not be parsed as a state. A textual assertion would prove
-the line is present but not that it classifies correctly, so these tests lift the
-real line out of the YAML and execute it against a stubbed `gh`.
+**Scope of this file.** Classification and gate wiring are now ordinary unit
+tests over `renovate_approval_conditions.py`, and live in
+`test_renovate_approval_conditions.py` alongside the other six conditions — this
+file no longer lifts a `gh api --jq` line out of the workflow YAML and executes
+it against a stubbed shell (FND-372 moved the logic out of the YAML, so that
+scaffolding had nothing left to test).
 
-Requires `jq` and `bash`, both present on the runners this suite targets.
+What remains here are the two properties that are NOT expressible inside the
+gate, because they are about the world the gate assumes:
+
+  1. the fleet Renovate preset publishes the status on healthy branches, which
+     is the only reason "missing" may be read as not-green rather than stalling
+     every clean PR; and
+  2. the workflow still routes through the driver that enforces it at all.
 """
 
 from __future__ import annotations
 
 import json
-import re
-import subprocess
 import sys
 from pathlib import Path
 
-import pytest
 import yaml
 
-sys.path.insert(0, str(Path(__file__).resolve().parent))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import renovate_approval_conditions as gate  # noqa: E402
 
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 _WORKFLOW = _REPO_ROOT / ".github/workflows/renovate-auto-approve-reusable.yml"
-
-_GREEN = '{"statuses":[{"context":"renovate/artifacts","state":"success"}]}'
-_RED = '{"statuses":[{"context":"renovate/artifacts","state":"failure"}]}'
-_PENDING = '{"statuses":[{"context":"renovate/artifacts","state":"pending"}]}'
-_OTHER_ONLY = '{"statuses":[{"context":"ci/build","state":"success"}]}'
-_NO_STATUSES = '{"statuses":[]}'
-_API_ERROR = '{"message":"Not Found"}'
+_DRIVER = "renovate_approval_conditions.py"
 
 
-def _approval_run_block() -> str:
-    """The shell body of the approval step."""
+def _approval_step_run() -> str:
+    """The shell body of the step that runs the approval gate."""
     workflow = yaml.safe_load(_WORKFLOW.read_text())
     steps = workflow["jobs"]["renovate-auto-approve"]["steps"]
     for step in steps:
         run = step.get("run", "")
-        if "gh pr review" in run:
+        if _DRIVER in run:
             return run
-    raise AssertionError("no step in the workflow posts a review")
+    raise AssertionError(f"no step in {_WORKFLOW.name} invokes {_DRIVER}")
 
 
-def _artifact_state_snippet() -> str:
-    """The real ARTIFACT_STATE assignment, lifted verbatim from the workflow."""
-    block = _approval_run_block()
-    match = re.search(
-        r"^\s*ARTIFACT_STATE=\$\(gh api.*?\)\s*$",
-        block,
-        re.MULTILINE | re.DOTALL,
-    )
-    assert match, "ARTIFACT_STATE assignment not found in the approval step"
-    return match.group(0).strip()
-
-
-#: Stub standing in for `gh api`. It must apply `--jq` itself, exactly as gh
-#: does, or the test would exercise a filter the shipped command never runs —
-#: and the jq filter is the part of this gate most able to be subtly wrong.
-_GH_STUB = """#!/usr/bin/env bash
-filter=""
-prev=""
-for arg in "$@"; do
-  if [ "$prev" = "--jq" ]; then filter="$arg"; fi
-  prev="$arg"
-done
-if [ -n "$filter" ]; then
-  printf '%s' "$PAYLOAD" | jq -r "$filter"
-  status=$?
-else
-  printf '%s' "$PAYLOAD"
-  status=0
-fi
-if [ "$EXIT_CODE" != "0" ]; then exit "$EXIT_CODE"; fi
-exit "$status"
-"""
-
-
-def _classify(tmp_path: Path, payload: str, exit_code: int = 0) -> str:
-    """Run the lifted snippet with a stubbed `gh` and return ARTIFACT_STATE."""
-    stub = tmp_path / "gh"
-    stub.write_text(_GH_STUB)
-    stub.chmod(0o755)
-
-    script = tmp_path / "probe.sh"
-    script.write_text(
-        "set -euo pipefail\n"
-        'REPO="owner/repo"\n'
-        'EVAL_SHA="deadbeef"\n'
-        f"{_artifact_state_snippet()}\n"
-        'printf "%s" "$ARTIFACT_STATE"\n'
-    )
-
-    result = subprocess.run(
-        ["bash", str(script)],
-        capture_output=True,
-        text=True,
-        env={
-            "PATH": f"{tmp_path}:/usr/bin:/bin:/usr/local/bin",
-            "PAYLOAD": payload,
-            "EXIT_CODE": str(exit_code),
-        },
-        check=True,
-    )
-    return result.stdout.strip()
-
-
-class TestClassification:
-    def test_green_status_classifies_as_success(self, tmp_path):
-        assert _classify(tmp_path, _GREEN) == "success"
-
-    def test_red_status_is_not_success(self, tmp_path):
-        assert _classify(tmp_path, _RED) == "failure"
-
-    def test_pending_status_is_not_success(self, tmp_path):
-        assert _classify(tmp_path, _PENDING) == "pending"
-
-    def test_absent_context_reads_as_missing(self, tmp_path):
-        # The transition case: branches created before statusCheckWhen=always,
-        # and any branch Renovate has not committed to. Must NOT read as green.
-        assert _classify(tmp_path, _OTHER_ONLY) == "missing"
-
-    def test_empty_status_list_reads_as_missing(self, tmp_path):
-        assert _classify(tmp_path, _NO_STATUSES) == "missing"
-
-    def test_api_error_body_reads_as_missing(self, tmp_path):
-        # A non-2xx response writes a JSON error object to stdout; parsing it as
-        # a status list must not silently yield something that compares equal to
-        # "success".
-        assert _classify(tmp_path, _API_ERROR, exit_code=1) == "missing"
-
-    @pytest.mark.parametrize(
-        "payload,exit_code",
-        [
-            (_RED, 0),
-            (_PENDING, 0),
-            (_OTHER_ONLY, 0),
-            (_NO_STATUSES, 0),
-            (_API_ERROR, 1),
-        ],
-    )
-    def test_nothing_but_a_green_status_compares_equal_to_success(
-        self, tmp_path, payload, exit_code
-    ):
-        assert _classify(tmp_path, payload, exit_code) != "success"
-
-
-class TestGateWiring:
-    def test_gate_fails_closed_on_anything_but_success(self):
-        block = _approval_run_block()
-        assert '[ "$ARTIFACT_STATE" != "success" ]' in block, (
-            "the gate must compare against success (fail closed); an "
-            "`= failure` style check would approve on a missing status"
-        )
-
-    def test_gate_skips_the_pr_rather_than_falling_through(self):
-        block = _approval_run_block()
-        parts = block.split('[ "$ARTIFACT_STATE" != "success" ]', 1)
-        assert len(parts) == 2, "the fail-closed comparison is missing entirely"
-        body = parts[1].split("fi", 1)[0]
-        assert "continue" in body, (
-            "the gate must `continue` to the next PR when the status is not "
-            "green; falling through would approve it anyway"
-        )
-
-    def test_gate_runs_before_the_approval_is_posted(self):
-        block = _approval_run_block()
-        assert block.index("ARTIFACT_STATE=") < block.index("gh pr review")
-
+class TestPresetContract:
     def test_preset_publishes_the_status_on_healthy_branches(self):
         # The gate treats a missing context as not-green, which is only safe
         # because the fleet preset flips statusCheckWhen.artifactError to
@@ -196,3 +71,32 @@ class TestGateWiring:
         # error, and every healthy branch would stall unapproved.
         preset = json.loads((_REPO_ROOT / "renovate-config/default.json").read_text())
         assert preset["statusCheckWhen"]["artifactError"] == "always"
+
+    def test_gate_reads_the_context_the_preset_publishes(self):
+        # Both halves of the contract have to name the same string; a rename on
+        # either side silently turns every PR's status into "missing".
+        assert gate.ARTIFACT_CONTEXT == "renovate/artifacts"
+
+
+class TestWorkflowWiring:
+    def test_workflow_invokes_the_gate_driver(self):
+        # Presence of the condition in Python is worth nothing if the workflow
+        # stops calling the script that evaluates it.
+        assert _DRIVER in _approval_step_run()
+
+    def test_approval_step_has_no_inlined_conditional_shell(self):
+        # docs/standards/ci.md: the `run:` block must be a straight-line
+        # invocation. This is also what keeps the conditions testable at all —
+        # the reason this file no longer has to lift a line out of the YAML.
+        run = _approval_step_run()
+        for keyword in ("if ", "else", "fi", "for ", "while ", "case ", "continue"):
+            assert (
+                keyword not in run
+            ), f"conditional shell ({keyword!r}) is back in the run: block"
+
+    def test_driver_path_resolves(self):
+        # The reusable sparse-checks-out the SDK scripts into .sdk-scripts, so
+        # the invoked path is prefixed. Assert the file it points at exists.
+        run = _approval_step_run()
+        invoked = next(tok for tok in run.split() if tok.endswith(_DRIVER))
+        assert (_REPO_ROOT / invoked.removeprefix(".sdk-scripts/")).is_file()

--- a/.github/scripts/tests/test_renovate_artifact_gate.py
+++ b/.github/scripts/tests/test_renovate_artifact_gate.py
@@ -94,20 +94,31 @@ class TestWorkflowWiring:
                 keyword not in run
             ), f"conditional shell ({keyword!r}) is back in the run: block"
 
-    def test_script_checkout_tracks_the_workflow_commit(self):
-        # The conditions live in the script and the wiring lives in this YAML;
-        # fetching them from different commits is a skew that must not be
-        # expressible. `job_workflow_sha` is the commit of the reusable file the
-        # caller resolved, so the ref the caller pins is the single switch — and
-        # a consumer can point `uses:` at a branch to pilot a gate change end to
-        # end, which a hardcoded `ref: main` makes impossible.
+    def test_script_checkout_ref_cannot_evaluate_to_empty(self):
+        # Regression, found by piloting this gate from a consumer repo before
+        # merge: `ref: ${{ github.job_workflow_sha }}` renders EMPTY here, so
+        # checkout omitted the input entirely and fetched the default branch —
+        # a GREEN step that silently checked out a different commit's script
+        # than the workflow the caller pinned. It only surfaced because the
+        # script did not exist on main yet; after merge it would have run the
+        # wrong version quietly.
+        #
+        # So the ref must come from a declared input with a default, which has
+        # no unset mode. Assert both halves: the expression, and the default
+        # that keeps every existing @main caller on today's behaviour.
         workflow = yaml.safe_load(_WORKFLOW.read_text())
         steps = workflow["jobs"]["renovate-auto-approve"]["steps"]
         checkout = next(
             s for s in steps if str(s.get("uses", "")).startswith("actions/checkout@")
         )
-        assert checkout["with"]["ref"] == "${{ github.job_workflow_sha }}"
+        assert checkout["with"]["ref"] == "${{ inputs.sdk_ref }}"
         assert checkout["with"]["path"] == ".sdk-scripts"
+
+        # `on` parses as a bool key in YAML 1.1, hence the lookup dance.
+        triggers = workflow.get("on") or workflow[True]
+        sdk_ref = triggers["workflow_call"]["inputs"]["sdk_ref"]
+        assert sdk_ref["default"] == "main"
+        assert sdk_ref["required"] is False
 
     def test_driver_path_resolves(self):
         # The reusable sparse-checks-out the SDK scripts into .sdk-scripts, so

--- a/.github/workflows/renovate-auto-approve-reusable.yml
+++ b/.github/workflows/renovate-auto-approve-reusable.yml
@@ -146,11 +146,21 @@ jobs:
       # (docs/standards/ci.md, "Reusing scripts from a reusable workflow").
       # Nothing else is checked out: the gate reads the PR entirely through the
       # API and never touches the consumer's working tree.
+      #
+      # ref is job_workflow_sha — the commit of THIS reusable workflow file, not
+      # a hardcoded `main`. The two must move together: the conditions live in
+      # the script and the wiring lives in this YAML, so fetching the script from
+      # a different commit than the workflow the caller resolved is a skew we do
+      # not want to be able to express. It also makes the ref the caller pins the
+      # single switch — a consumer can point its `uses:` at a branch to pilot a
+      # change to the gate end to end, which a hardcoded ref makes impossible.
+      # If the expression were ever empty, checkout falls back to the default
+      # branch, i.e. exactly the old `main` behaviour.
       - name: Fetch approval-gate script
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: atlanhq/application-sdk
-          ref: main
+          ref: ${{ github.job_workflow_sha }}
           sparse-checkout: .github/scripts
           sparse-checkout-cone-mode: false
           path: .sdk-scripts

--- a/.github/workflows/renovate-auto-approve-reusable.yml
+++ b/.github/workflows/renovate-auto-approve-reusable.yml
@@ -39,7 +39,7 @@
 #   approvals posted here. Human comments do not auto-dismiss this approval;
 #   freshness is guaranteed by the ruleset's dismiss_stale_reviews_on_push.
 #
-# Approval conditions (ALL must hold — see step comments in the bash below):
+# Approval conditions (ALL must hold):
 #   1. PR author is a Renovate bot: atlan-app-fleet[bot] (self-hosted fleet
 #      runner) or renovate[bot] (Mend — still used by application-sdk itself)
 #   2. PR is open and not a draft
@@ -48,9 +48,20 @@
 #      pyproject.toml, the Pkl toolkit pin + lock (contract/PklProject[.deps.json]),
 #      or the regenerated contract artifacts (app/generated/**, atlan.yaml, app.yaml)
 #   5. All ruleset-required checks are green (gh pr checks --required exits 0)
-#   6. Renovate's own renovate/artifacts status is green — see the step comment;
-#      this is what stops a failed post-upgrade task from auto-merging
+#   6. Renovate's own renovate/artifacts status is green — this is what stops a
+#      failed post-upgrade task from auto-merging
 #   7. atlan-ci has not already posted an APPROVED review with this signature
+#
+# Where that logic lives:
+#   .github/scripts/renovate_approval_conditions.py, unit-tested by
+#   .github/scripts/tests/test_renovate_approval_conditions.py — per
+#   docs/standards/ci.md, branching logic does not belong in a `run:` block
+#   because it cannot be regression-tested there. That matters more here than
+#   the line count suggests: this is the code-owner approval for every Renovate
+#   PR in the fleet, consumers pin it at @main, and a wrong condition does not
+#   fail loudly — it approves something it should not. The full rationale for
+#   each condition, and for the fail-closed defaults, is in that script's
+#   docstrings (FND-372).
 #
 # Trigger rationale lives in the caller — each consumer lists the workflow names
 # that produce its required status checks, which differ per repo.
@@ -88,10 +99,11 @@ on:
           Optional extra ERE alternation of repo-specific dependency file paths
           to treat as auto-approvable, appended to the built-in allowlist (which
           already covers .github/ and lock/manifest/contract files). Each branch
-          is whole-line matched (grep -vxE), so anchor to full workspace-relative
-          paths, e.g. 'packages/conformance/.../templates/.+\.ya?ml'. This is how
-          a repo declares its OWN dep-managed source paths without hard-coding any
-          app-specific path into this shared workflow.
+          is whole-path matched, so anchor to full workspace-relative paths,
+          e.g. 'packages/conformance/.../templates/.+\.ya?ml'. This is how a repo
+          declares its OWN dep-managed source paths without hard-coding any
+          app-specific path into this shared workflow. A pattern that does not
+          compile fails the step rather than widening the allowlist.
         required: false
         default: ""
         type: string
@@ -128,6 +140,21 @@ jobs:
       group: renovate-auto-approve-${{ inputs.head_sha || inputs.pr_number }}
       cancel-in-progress: false
     steps:
+      # A `uses:` reusable workflow does NOT bring its own repo's files into the
+      # caller's checkout, so the consumer repo has no copy of the gate script.
+      # Same .sdk-scripts pattern as renovate-pkl-sync.yaml / release-version-bump.yaml
+      # (docs/standards/ci.md, "Reusing scripts from a reusable workflow").
+      # Nothing else is checked out: the gate reads the PR entirely through the
+      # API and never touches the consumer's working tree.
+      - name: Fetch approval-gate script
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: atlanhq/application-sdk
+          ref: main
+          sparse-checkout: .github/scripts
+          sparse-checkout-cone-mode: false
+          path: .sdk-scripts
+
       - name: Auto-approve if Renovate dep-only PR and all required checks are green
         env:
           # secrets.org_pat: old explicit-passthrough callers. secrets.ORG_PAT_GITHUB:
@@ -138,182 +165,7 @@ jobs:
           RUN_SHA: ${{ inputs.head_sha }}
           DISPATCH_PR: ${{ inputs.pr_number }}
           EXTRA_DEP_PATTERN: ${{ inputs.extra_dep_file_pattern }}
-        run: |
-          set -euo pipefail
-
-          # ── 1. Resolve candidate PR number(s) and the SHA to evaluate ────────
-          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-            EVAL_SHA=$(gh api "repos/${REPO}/pulls/${DISPATCH_PR}" --jq '.head.sha')
-            PR_NUMBERS="$DISPATCH_PR"
-          else
-            EVAL_SHA="$RUN_SHA"
-            # A single commit can be the HEAD of multiple PRs in rare cases;
-            # handle them all.
-            #
-            # Gate the assignment on exit code — a non-2xx gh api response
-            # writes the JSON error body to stdout, which would otherwise
-            # populate PR_NUMBERS with garbage tokens.
-            if ! PR_NUMBERS=$(gh api "repos/${REPO}/commits/${EVAL_SHA}/pulls" \
-                --jq '.[] | select(.state == "open") | .number' 2>/dev/null); then
-              PR_NUMBERS=""
-            fi
-          fi
-
-          if [ -z "$PR_NUMBERS" ]; then
-            echo "No open PRs found for SHA ${EVAL_SHA} — nothing to do."
-            exit 0
-          fi
-
-          # ── 2. Evaluate each candidate PR ────────────────────────────────────
-          for PR_NUM in $PR_NUMBERS; do
-            echo "--- Evaluating PR #${PR_NUM} ---"
-
-            # Fetch all relevant PR metadata in one API call.
-            PR_META=$(gh api "repos/${REPO}/pulls/${PR_NUM}" \
-              --jq '{author: .user.login, state: .state, draft: .draft, head_sha: .head.sha}')
-            AUTHOR=$(printf '%s' "$PR_META"   | jq -r .author)
-            STATE=$(printf '%s'  "$PR_META"   | jq -r .state)
-            DRAFT=$(printf '%s'  "$PR_META"   | jq -r .draft)
-            HEAD_SHA=$(printf '%s' "$PR_META" | jq -r .head_sha)
-
-            # a. Author must be a Renovate bot. Keep BOTH: atlan-app-fleet[bot]
-            #    is the self-hosted fleet runner; renovate[bot] is the Mend-hosted
-            #    app, which application-sdk itself still uses for its own
-            #    workflow-action updates. Do not drop renovate[bot] while
-            #    application-sdk remains on Mend.
-            if [ "$AUTHOR" != "atlan-app-fleet[bot]" ] && [ "$AUTHOR" != "renovate[bot]" ]; then
-              echo "PR #${PR_NUM}: author is '${AUTHOR}', not a Renovate bot — skipping."
-              continue
-            fi
-
-            # b. PR must be open and not a draft.
-            if [ "$STATE" != "open" ] || [ "$DRAFT" = "true" ]; then
-              echo "PR #${PR_NUM}: state='${STATE}' draft='${DRAFT}' — skipping."
-              continue
-            fi
-
-            # c. Race guard: bail if HEAD moved since this event fired.
-            if [ "$HEAD_SHA" != "$EVAL_SHA" ]; then
-              echo "PR #${PR_NUM}: HEAD moved (${EVAL_SHA} → ${HEAD_SHA}). Skipping — a later run will re-evaluate."
-              continue
-            fi
-
-            # d. All changed files must be dependency-related.
-            #    Allowed: anything under .github/, or lock/manifest files at
-            #    any depth: uv.lock, package-lock.json, requirements.txt,
-            #    pyproject.toml — plus everything a Renovate app-contract-toolkit
-            #    bump touches: the Pkl pin + lock (contract/PklProject,
-            #    contract/PklProject.deps.json) and the artifacts that
-            #    renovate-pkl-sync regenerates from them (app/generated/**,
-            #    atlan.yaml, app.yaml). The generated artifacts are a
-            #    deterministic function of the contract and the (already
-            #    auto-merged) toolkit version, so they ride the same gate.
-            #    The (.*/)? prefix lets the lock/manifest and contract/PklProject
-            #    patterns match workspace-relative paths too (e.g.
-            #    packages/conformance/uv.lock, a monorepo apps/*/contract/...).
-            #    The generated artifacts are matched root-only (no prefix):
-            #    renovate-pkl-sync only ever writes them at the repo root, so an
-            #    unrelated app.yaml/atlan.yaml elsewhere in a consumer tree must
-            #    NOT ride this gate.
-            FILENAMES=$(gh api "repos/${REPO}/pulls/${PR_NUM}/files" \
-              --paginate --jq '.[].filename')
-            if [ -z "$FILENAMES" ]; then
-              echo "PR #${PR_NUM}: no changed files found — skipping."
-              continue
-            fi
-
-            #    A caller may extend the allowlist with its own dep-managed
-            #    source paths via extra_dep_file_pattern (kept out of this shared
-            #    workflow so no app-specific path is hard-coded here).
-            DEP_FILE_RE='(.*/)?uv\.lock|(.*/)?package-lock\.json|(.*/)?requirements\.txt|(.*/)?pyproject\.toml|(.*/)?contract/PklProject|(.*/)?contract/PklProject\.deps\.json|app/generated/.*|atlan\.yaml|app\.yaml'
-            if [ -n "${EXTRA_DEP_PATTERN:-}" ]; then
-              DEP_FILE_RE="${DEP_FILE_RE}|${EXTRA_DEP_PATTERN}"
-            fi
-            NON_DEP_FILES=$(echo "$FILENAMES" \
-              | grep -v '^\.github/' \
-              | grep -vxE "$DEP_FILE_RE" \
-              || true)
-            if [ -n "$NON_DEP_FILES" ]; then
-              echo "PR #${PR_NUM}: contains non-dependency files:"
-              echo "$NON_DEP_FILES" | sed 's/^/  /'
-              echo "Skipping."
-              continue
-            fi
-            echo "PR #${PR_NUM}: all changed files are dependency-related."
-
-            # e. All ruleset-required checks must be green.
-            #    `gh pr checks --required` exits 0 iff every required check is
-            #    passing or skipping. Non-required failures are correctly excluded.
-            #    Pending required checks produce a non-zero exit; a later
-            #    workflow_run completion will re-fire.
-            echo "PR #${PR_NUM}: checking required CI status..."
-            if ! gh pr checks "${PR_NUM}" --repo "${REPO}" --required; then
-              echo "PR #${PR_NUM}: required checks not yet all green — skipping."
-              continue
-            fi
-            echo "PR #${PR_NUM}: all required checks are green."
-
-            # f. Renovate's artifact status must be green.
-            #    A failed postUpgradeTasks command does NOT stop Renovate: it
-            #    commits whatever its own artifact update produced, raises the PR,
-            #    and still enables platform automerge (getPlatformPrOptions never
-            #    consults artifactErrors — only Renovate's own *branch* automerge
-            #    is gated on them, and this fleet uses automergeType=pr). So the
-            #    PR merges on the strength of the checks it did pass, with nothing
-            #    red to show for the part that did not happen: a pkl-sync failure
-            #    lands a toolkit bump whose generated contract artifacts do not
-            #    match it, and a lock refresh that could not resolve lands a lock
-            #    inconsistent with the change it claims to make. Worse, a command
-            #    the runner's allowedCommands allowlist does not match is skipped
-            #    with a log line and nothing else — "did not run" and "ran clean"
-            #    are indistinguishable without this status. So this gate is the
-            #    enforcement point.
-            #
-            #    The preset sets statusCheckWhen.artifactError=always so the
-            #    context is published green on healthy branches too — that is what
-            #    lets "missing" be read as not-green rather than as "fine". Fail
-            #    closed: anything other than success withholds approval, including
-            #    an API error. Renovate only sets this status on runs where it
-            #    commits to the branch, so PRs already open when this shipped
-            #    acquire it on their next rebase; until then they are not
-            #    auto-approved, and the caller's workflow_dispatch can re-evaluate
-            #    one on demand.
-            ARTIFACT_STATE=$(gh api "repos/${REPO}/commits/${EVAL_SHA}/status" \
-              --jq '[.statuses[] | select(.context=="renovate/artifacts") | .state] | first // "missing"' \
-              2>/dev/null || echo "missing")
-            if [ "$ARTIFACT_STATE" != "success" ]; then
-              echo "PR #${PR_NUM}: renovate/artifacts is '${ARTIFACT_STATE}', not 'success' — skipping."
-              continue
-            fi
-            echo "PR #${PR_NUM}: renovate/artifacts is green."
-
-            # g. Idempotency: skip if atlan-ci already has an APPROVED review
-            #    bearing our signature. Push-dismissed reviews have state
-            #    DISMISSED (not APPROVED) so they won't match here — a fresh
-            #    approval is correctly posted on the next green run.
-            EXISTING=$(gh api "repos/${REPO}/pulls/${PR_NUM}/reviews" --paginate \
-              --jq '[.[] | select(.user.login == "atlan-ci"
-                                   and .state == "APPROVED"
-                                   and ((.body // "") | startswith("**Renovate auto-approval:**")))] | length')
-            if [ "$EXISTING" != "0" ]; then
-              echo "PR #${PR_NUM}: atlan-ci has already approved with the Renovate signature — skipping."
-              continue
-            fi
-
-            # ── 3. Post the atlan-ci code-owner approval ──────────────────────
-            # NOTE: the leading line is a STABLE SIGNATURE used by the idempotency
-            # guard above. Keep it in sync with that check if it ever changes.
-            APPROVE_BODY=$(printf '%s\n' \
-              "**Renovate auto-approval:** all required CI checks passed." \
-              "" \
-              "This is an automated code-owner approval posted by \`atlan-ci\` for a" \
-              "dependency-only Renovate PR. It is automatically dismissed on any new" \
-              "push (\`dismiss_stale_reviews_on_push\`) and re-posted once the new" \
-              "HEAD's required checks are green." \
-              "")
-            gh pr review "${PR_NUM}" --repo "${REPO}" --approve --body "$APPROVE_BODY"
-            echo "✅ Approved PR #${PR_NUM} as atlan-ci (Renovate auto-approval)."
-          done
+        run: python3 .sdk-scripts/.github/scripts/renovate_approval_conditions.py
 
       - name: Mint fleet App token for dashboard dispatch
         if: always()

--- a/.github/workflows/renovate-auto-approve-reusable.yml
+++ b/.github/workflows/renovate-auto-approve-reusable.yml
@@ -107,6 +107,18 @@ on:
         required: false
         default: ""
         type: string
+      sdk_ref:
+        description: >
+          application-sdk ref to fetch the approval-gate script from. Consumers
+          should leave this at the default: it must match the ref they pin this
+          reusable at in `uses:`, and everything pins @main. Override it only to
+          pilot a change to the gate — point `uses:` and this input at the same
+          branch and the run exercises the real gate end to end before the change
+          is on main. There is no way to derive this automatically; see the
+          comment on the checkout step for why.
+        required: false
+        default: "main"
+        type: string
     secrets:
       org_pat:
         description: >
@@ -147,20 +159,20 @@ jobs:
       # Nothing else is checked out: the gate reads the PR entirely through the
       # API and never touches the consumer's working tree.
       #
-      # ref is job_workflow_sha — the commit of THIS reusable workflow file, not
-      # a hardcoded `main`. The two must move together: the conditions live in
-      # the script and the wiring lives in this YAML, so fetching the script from
-      # a different commit than the workflow the caller resolved is a skew we do
-      # not want to be able to express. It also makes the ref the caller pins the
-      # single switch — a consumer can point its `uses:` at a branch to pilot a
-      # change to the gate end to end, which a hardcoded ref makes impossible.
-      # If the expression were ever empty, checkout falls back to the default
-      # branch, i.e. exactly the old `main` behaviour.
+      # The ref is an explicit input defaulting to `main`, NOT an expression that
+      # can evaluate to nothing. `${{ github.job_workflow_sha }}` looks like the
+      # right answer — it is documented as the commit of the reusable workflow
+      # file the caller resolved — but it renders EMPTY in this context (it is an
+      # OIDC claim, not a usable expression value). checkout then silently omits
+      # `ref` and takes the default branch, so the step goes green having fetched
+      # a different commit's script than the workflow the caller pinned. An input
+      # with a default has no such mode: an unset value is impossible and a bad
+      # one fails the checkout outright.
       - name: Fetch approval-gate script
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: atlanhq/application-sdk
-          ref: ${{ github.job_workflow_sha }}
+          ref: ${{ inputs.sdk_ref }}
           sparse-checkout: .github/scripts
           sparse-checkout-cone-mode: false
           path: .sdk-scripts

--- a/.github/workflows/renovate-auto-approve-reusable.yml
+++ b/.github/workflows/renovate-auto-approve-reusable.yml
@@ -107,18 +107,6 @@ on:
         required: false
         default: ""
         type: string
-      sdk_ref:
-        description: >
-          application-sdk ref to fetch the approval-gate script from. Consumers
-          should leave this at the default: it must match the ref they pin this
-          reusable at in `uses:`, and everything pins @main. Override it only to
-          pilot a change to the gate — point `uses:` and this input at the same
-          branch and the run exercises the real gate end to end before the change
-          is on main. There is no way to derive this automatically; see the
-          comment on the checkout step for why.
-        required: false
-        default: "main"
-        type: string
     secrets:
       org_pat:
         description: >
@@ -159,20 +147,22 @@ jobs:
       # Nothing else is checked out: the gate reads the PR entirely through the
       # API and never touches the consumer's working tree.
       #
-      # The ref is an explicit input defaulting to `main`, NOT an expression that
-      # can evaluate to nothing. `${{ github.job_workflow_sha }}` looks like the
-      # right answer — it is documented as the commit of the reusable workflow
-      # file the caller resolved — but it renders EMPTY in this context (it is an
-      # OIDC claim, not a usable expression value). checkout then silently omits
-      # `ref` and takes the default branch, so the step goes green having fetched
-      # a different commit's script than the workflow the caller pinned. An input
-      # with a default has no such mode: an unset value is impossible and a bad
-      # one fails the checkout outright.
+      # `ref: main` is a literal on purpose. Do NOT replace it with
+      # `${{ github.job_workflow_sha }}` — that is documented as the commit of
+      # the reusable workflow file the caller resolved, which looks like exactly
+      # the right way to keep this script in step with this YAML, but it renders
+      # EMPTY (it is an OIDC claim, not a usable expression value). checkout then
+      # treats `ref` as unsupplied and takes the default branch, so the step goes
+      # green having fetched a different commit's script. See docs/standards/ci.md.
+      #
+      # Every caller pins this reusable at @main, so `main` is the matching ref.
+      # To pilot a change to the gate from a consumer repo, temporarily point both
+      # this ref and the caller's `uses:` at the branch, and revert before merge.
       - name: Fetch approval-gate script
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: atlanhq/application-sdk
-          ref: ${{ inputs.sdk_ref }}
+          ref: main
           sparse-checkout: .github/scripts
           sparse-checkout-cone-mode: false
           path: .sdk-scripts

--- a/docs/standards/ci.md
+++ b/docs/standards/ci.md
@@ -191,6 +191,39 @@ sparse-checkout it into a side path and invoke from there — the
 The driver runs from the consumer's working directory, so it acts on the
 consumer's files; `.sdk-scripts` only holds SDK code and must never be staged.
 
+### Do not try to derive the ref from `github.job_workflow_sha`
+
+`ref: main` above is deliberate and is the default answer. Every consumer pins
+these reusables at `@main`, and several checkouts of this repo pin `main` for a
+stronger reason — they fetch *content* that must reflect `main` whatever ref the
+caller is on (`trivy-container.yaml`'s base allowlist,
+`vuln-reconcile-on-release.yml`'s scan baseline,
+`contract-toolkit-publish.yml`'s published content). Those carry their reasoning
+inline; leave them as they are.
+
+The tempting "improvement" is to derive the ref so the script always matches the
+workflow that resolved it. `${{ github.job_workflow_sha }}` is documented in the
+`github` context as exactly that — the commit of the reusable workflow file the
+caller resolved. **It renders empty.** It is an OIDC token claim, not a usable
+expression value.
+
+The failure is silent and the wrong way round: `actions/checkout` treats an
+empty `ref` as *not supplied* and takes the default branch, so the step goes
+**green having fetched a different commit's script than the workflow the caller
+pinned** — the wrong version of every code path, with nothing red to show for
+it. FND-372 hit this; it only surfaced because the script did not exist on
+`main` yet, so the *next* step died on a missing file.
+
+Generalising: never let a `with:` value that must not be blank come from an
+expression that can evaluate to empty. Prefer a shape where "unset" cannot be
+expressed over a guard that checks for it after the fact — a declared input with
+a default, or a literal.
+
+**When verifying any change to a workflow like this, read the checkout step's
+logged `ref:` rather than concluding from a green tick.** A step that fetched the
+wrong ref still passes; it is the next step that fails, and only if what it
+wanted happens to be absent from the fallback.
+
 ## `concurrency:` is not a lock, and not a queue
 
 **Rule:** never use a `concurrency:` group to protect a shared external resource


### PR DESCRIPTION
Resolves [FND-372](https://linear.app/atlan-epd/issue/FND-372/extract-the-renovate-auto-approval-conditions-out-of-inline-workflow).

## Why

`renovate-auto-approve-reusable.yml` decided whether to post the `atlan-ci` code-owner approval in ~150 lines of inline branchy bash. Every consumer repo in the fleet calls it at `@main`, and it is the gate that decides what auto-merges unattended — so a wrong condition there does not fail loudly, it approves something it should not. `docs/standards/ci.md` forbids the shape for exactly that reason: branching logic in YAML cannot be regression-tested.

## What changed

- All seven conditions move to `.github/scripts/renovate_approval_conditions.py`, each a pure function returning `(ok, message)`, with `gh` I/O behind a single seam. Stdlib only.
- The `run:` block is now a straight-line call. The reusable sparse-checks-out the SDK scripts into `.sdk-scripts` (the `renovate-pkl-sync.yaml` / `release-version-bump.yaml` pattern), since a `uses:` reusable does not bring its own repo's files into the caller's checkout. Every known caller pins `@main`, matching the script checkout ref.
- No `--jq` remains. Every call fetches raw JSON and shapes it in Python, so each classification decision sits in a unit-testable function rather than a shell string.

## The extraction was measured, not assumed

Before moving anything, a throwaway differential harness lifted the original `run:` block out of the YAML and executed it against a stubbed `gh` (real `jq`, so the jq filters actually ran) over a 44-scenario matrix — every condition, every fail-closed edge, PR resolution, per-PR isolation. It recorded exit code, whether `gh pr review --approve` fired and with what body, and the full stdout log per scenario.

**43 of 44 scenarios reproduce byte for byte**: decision, exit status, and every skip-log line. That table is committed as `TestExtractionParity`, so parity is a standing assertion rather than a one-time measurement.

## Two deliberate divergences — both fail-closed corrections

Both were live bugs the characterisation surfaced, and both are named tests in `TestDeliberateDivergences` so a future reader can tell a correction from an extraction slip.

**1. An invalid `extra_dep_file_pattern` no longer approves everything.** The bash string-appended the caller's pattern into a `grep -vxE` whose non-zero exit was swallowed by the trailing `|| true`. `grep` exits **2** on an invalid regex, not just 1 on no-match — so an unparseable pattern emptied the non-dep file list and *every* changed file, source included, read as dependency-related. Confirmed live against the original: a PR touching `src/evil.py` was approved. The script now fails the step with an `::error::` naming the bad pattern.

**2. A second page of reviews no longer blocks approval.** The idempotency count was `gh api --paginate --jq '… | length'`, and `--jq` is applied *per page* — so a PR with two pages of reviews and no prior approval emitted `"0\n0"`, which the `!= "0"` test read as "already approved" and never approved again. `--paginate --slurp` plus a one-level flatten gives a single count.

## Preserved deliberately

- **Per-PR isolation** for conditions — one PR failing skips only that PR.
- **API errors on the metadata / files / reviews calls still abort the whole step** with a non-zero exit. That is the inherited `set -euo pipefail` behaviour, kept rather than "improved" into a per-PR skip: deciding on a partial view of a PR is the one thing this gate must never do, a red step is visible, and the next `workflow_run` completion re-evaluates every candidate anyway.
- The `commits/{sha}/pulls` lookup and the `renovate/artifacts` status stay *tolerated* (→ no candidates / → `"missing"`), safe only because the absorbed value is already the blocking one.
- Skip-log wording is byte-identical, jq's lowercase `draft='true'` included, so old and new runs read the same.
- The approval body is pinned in full rather than by prefix — its first line is the stable signature that both the idempotency check and the fleet dashboard scanner key off.

## Tests

- 133 tests across `test_renovate_approval_conditions.py` and `test_renovate_artifact_gate.py`; full `.github/scripts/tests` suite green (2214 passed).
- `test_renovate_artifact_gate.py` now calls the extracted function instead of lifting a `gh api --jq` line out of the YAML. What remains there is only what the gate cannot express about itself: the preset contract (`statusCheckWhen.artifactError = "always"`, the reason "missing" may be read as not-green) and that the workflow still routes through the driver.

## Security-relevant note for review

This PR touches the fleet's code-owner approval gate. Both divergences above narrow what gets approved, except the pagination one, which *unblocks* approval on PRs with more than one page of reviews — worth a look during review. No credential handling changed; the step still uses the `atlan-ci` PAT for the same reason as before (GitHub Apps cannot be CODEOWNERS).

## Verification still outstanding

The issue's last acceptance item — "verified on a real Renovate PR" — cannot be done pre-merge: this repo's caller and every consumer pin the reusable at `@main`, so the new path only goes live once this lands. I'll confirm on the first Renovate PR after merge that a clean one is still approved and a failing one still is not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
