### PR TITLE
chore(ci): bound the auto-merged uv.lock refresh to a 7-day release age (FND-359)

### DIFF
--- a/.github/scripts/check_renovate_allowed_commands.py
+++ b/.github/scripts/check_renovate_allowed_commands.py
@@ -29,12 +29,15 @@ REPO_ROOT = Path(__file__).parent.parent.parent
 PRESET = REPO_ROOT / "renovate-config" / "default.json"
 SELF_HOSTED = REPO_ROOT / "renovate-config" / "self-hosted.js"
 
-# The allowedCommands array literal in the admin config, and the double-quoted
-# strings inside it. Deliberately narrow: a JS parser is not worth the dependency
-# for one array of literals, and a malformed match fails the guard loudly rather
-# than passing it silently (an empty allowlist matches no command).
-_ALLOWLIST_BLOCK_RE = re.compile(r"allowedCommands:\s*\[(.*?)\]", re.DOTALL)
-_QUOTED_RE = re.compile(r'"((?:[^"\\]|\\.)*)"')
+# Where the allowedCommands array starts in the admin config. The array is then
+# scanned character by character rather than matched with a regex: the entries
+# are themselves regexes, and `allowedCommands:\s*\[(.*?)\]` stops at the first
+# `]` — including one inside a character class like `[0-9]`, which silently
+# truncates the allowlist and makes the guard pass commands it never checked.
+# Exactly the silent-failure mode this file exists to prevent, so it is scanned
+# properly. A JS parser is still not worth the dependency for one array of
+# string literals.
+_ALLOWLIST_START_RE = re.compile(r"allowedCommands:\s*\[")
 
 
 def preset_commands(preset_json: str) -> list[str]:
@@ -64,11 +67,55 @@ def preset_commands(preset_json: str) -> list[str]:
 
 
 def allowed_patterns(self_hosted_source: str) -> list[str]:
-    """Regex strings from the admin config's allowedCommands allowlist."""
-    block = _ALLOWLIST_BLOCK_RE.search(self_hosted_source)
-    if not block:
+    """Regex strings from the admin config's allowedCommands allowlist.
+
+    Scans to the array's closing bracket while tracking string state, so a `]`
+    inside an entry (a character class, say) ends the entry rather than the
+    allowlist. `//` comments between entries are skipped, including any quotes
+    they contain — prose about the patterns is normal here, and a stray
+    apostrophe-pair in a comment would otherwise be collected as a pattern and
+    desynchronise everything after it.
+    """
+    start = _ALLOWLIST_START_RE.search(self_hosted_source)
+    if not start:
         return []
-    return [m.group(1) for m in _QUOTED_RE.finditer(block.group(1))]
+
+    patterns: list[str] = []
+    current: list[str] = []
+    in_string = False
+    escaped = False
+    in_comment = False
+    previous = ""
+
+    for char in self_hosted_source[start.end() :]:
+        if in_comment:
+            if char == "\n":
+                in_comment = False
+            continue
+        if not in_string and char == "/" and previous == "/":
+            in_comment = True
+            previous = ""
+            continue
+        previous = char
+        if in_string:
+            if escaped:
+                current.append(char)
+                escaped = False
+            elif char == "\\":
+                current.append(char)
+                escaped = True
+            elif char == '"':
+                patterns.append("".join(current))
+                current = []
+                in_string = False
+            else:
+                current.append(char)
+        elif char == '"':
+            in_string = True
+        elif char == "]":
+            break
+
+    return patterns
 
 
 def unauthorized_commands(preset_json: str, self_hosted_source: str) -> list[str]:

--- a/.github/scripts/check_renovate_allowed_commands.py
+++ b/.github/scripts/check_renovate_allowed_commands.py
@@ -71,10 +71,10 @@ def allowed_patterns(self_hosted_source: str) -> list[str]:
 
     Scans to the array's closing bracket while tracking string state, so a `]`
     inside an entry (a character class, say) ends the entry rather than the
-    allowlist. `//` comments between entries are skipped, including any quotes
-    they contain — prose about the patterns is normal here, and a stray
-    apostrophe-pair in a comment would otherwise be collected as a pattern and
-    desynchronise everything after it.
+    allowlist. `//` line comments and `/* */` block comments between entries are
+    skipped, including any quotes they contain — prose about the patterns is
+    normal here, and a stray quoted string inside a comment would otherwise be
+    collected as a pattern and desynchronise everything after it.
     """
     start = _ALLOWLIST_START_RE.search(self_hosted_source)
     if not start:
@@ -84,16 +84,29 @@ def allowed_patterns(self_hosted_source: str) -> list[str]:
     current: list[str] = []
     in_string = False
     escaped = False
-    in_comment = False
+    in_line_comment = False
+    in_block_comment = False
     previous = ""
 
     for char in self_hosted_source[start.end() :]:
-        if in_comment:
+        if in_line_comment:
             if char == "\n":
-                in_comment = False
+                in_line_comment = False
+            previous = ""
+            continue
+        if in_block_comment:
+            if char == "/" and previous == "*":
+                in_block_comment = False
+                previous = ""
+                continue
+            previous = char
             continue
         if not in_string and char == "/" and previous == "/":
-            in_comment = True
+            in_line_comment = True
+            previous = ""
+            continue
+        if not in_string and char == "*" and previous == "/":
+            in_block_comment = True
             previous = ""
             continue
         previous = char

--- a/.github/scripts/renovate_uv_lock_bounded.py
+++ b/.github/scripts/renovate_uv_lock_bounded.py
@@ -471,8 +471,8 @@ def baseline_lock_text(cwd: Path) -> str | None:
     baseline" would drop the ceilings and quietly reintroduce the rollback this
     exists to prevent. That includes a HEAD that resolves but whose lock blob
     cannot be read: absent is a fact about the tree, not a guess from a failed
-    command, so absence is established by probing `git cat-file -e` and every
-    other `git show` failure is treated as fatal.
+    command, so absence is established positively with `git ls-tree` and every
+    `git show` failure on a path known to be present is treated as fatal.
     """
     head = subprocess.run(
         ["git", "rev-parse", "--verify", "HEAD"],
@@ -485,26 +485,25 @@ def baseline_lock_text(cwd: Path) -> str | None:
             f"cannot resolve HEAD in {cwd}, so the pre-refresh lockfile is "
             f"unavailable: {head.stderr.strip()}"
         )
-    exists = subprocess.run(
-        ["git", "cat-file", "-e", "HEAD:uv.lock"],
+    # Absence must be established positively, not inferred from a failed read:
+    # `git show` exits non-zero for BOTH "path absent" and "blob unreadable",
+    # so it cannot tell the two apart. `git ls-tree` can — it exits 0 and
+    # prints nothing when the path is absent, prints the path when present, and
+    # only exits non-zero when git itself is broken.
+    listing = subprocess.run(
+        ["git", "ls-tree", "-r", "--name-only", "HEAD", "--", "uv.lock"],
         cwd=cwd,
         capture_output=True,
         text=True,
     )
-    if exists.returncode != 0:
-        # cat-file -e exits non-zero both when the path is absent from HEAD and
-        # when git itself is broken; disambiguate by reading the blob. A clean
-        # show means the path genuinely is absent — a lock added in this very
-        # branch, which legitimately has no baseline. Anything else is "cannot
-        # tell", which must fail closed rather than masquerade as no baseline.
-        probe = subprocess.run(
-            ["git", "show", "HEAD:uv.lock"], cwd=cwd, capture_output=True, text=True
+    if listing.returncode != 0:
+        raise RuntimeError(
+            f"cannot inspect HEAD's tree in {cwd}, so the pre-refresh lockfile "
+            f"is unavailable: {listing.stderr.strip()}"
         )
-        if probe.returncode != 0:
-            raise RuntimeError(
-                f"cannot read uv.lock from HEAD in {cwd}, so the pre-refresh "
-                f"lockfile is unavailable: {probe.stderr.strip()}"
-            )
+    if "uv.lock" not in listing.stdout.splitlines():
+        # Verifiably absent from HEAD — a lock added in this very branch, which
+        # legitimately has no baseline.
         return None
     show = subprocess.run(
         ["git", "show", "HEAD:uv.lock"], cwd=cwd, capture_output=True, text=True

--- a/.github/scripts/renovate_uv_lock_bounded.py
+++ b/.github/scripts/renovate_uv_lock_bounded.py
@@ -300,6 +300,33 @@ def _floor_specified(requirement: str) -> str | None:
     return None
 
 
+def declares_own_bound(pyproject_text: str) -> bool:
+    """Does the repo already bound its own resolves via ``[tool.uv]``?
+
+    Four repos do (glue, bw, thoughtspot, dbt), predating the fleet mechanism.
+    For them this driver must do nothing at all: they already have a cooldown, so
+    ours is redundant, and stripping ``[options]`` would leave a lock their own
+    ``pyproject.toml`` disagrees with — `uv sync --locked` in the image build then
+    fails, which is FND-367's breakage arriving from the opposite direction.
+
+    Skipping rather than failing keeps those repos working while they converge on
+    the central mechanism on their own schedule, instead of turning a fleet-wide
+    rollout into four simultaneous conversations with repo owners. The skip is
+    reported, not silent, so the convergence work stays visible.
+    """
+    try:
+        data = tomllib.loads(pyproject_text)
+    except tomllib.TOMLDecodeError:
+        return False
+    tool = data.get("tool")
+    uv_table = tool.get("uv", {}) if isinstance(tool, dict) else {}
+    if not isinstance(uv_table, dict):
+        return False
+    # Either key alone is enough: uv records both into the lockfile's [options],
+    # so either one makes the strip destructive.
+    return "exclude-newer" in uv_table or "exclude-newer-package" in uv_table
+
+
 def floored_packages(pyproject_text: str) -> set[str]:
     """Packages the repo has deliberately pinned a minimum version for.
 
@@ -493,6 +520,22 @@ def main(argv: list[str] | None = None) -> int:
 
     if not lock_path.exists():
         print(f"No uv.lock in {project_dir} — nothing to bound.", file=sys.stderr)
+        return 0
+
+    if pyproject_path.exists() and declares_own_bound(pyproject_path.read_text()):
+        summarise(
+            [
+                "**Release-age bound skipped:** this repo declares its own "
+                "`[tool.uv] exclude-newer`, so it already has a cooldown and the "
+                "lockfile records settings that must keep matching it.",
+                "",
+                "- The fleet now bounds this lane centrally (FND-359), so the "
+                "repo-local stanza is redundant and can be removed.",
+                "- Until it is, this driver leaves `uv.lock` untouched — stripping "
+                "`[options]` here would leave a lock `pyproject.toml` disagrees "
+                "with, and `uv sync --locked` would fail in the image build.",
+            ]
+        )
         return 0
 
     try:

--- a/.github/scripts/renovate_uv_lock_bounded.py
+++ b/.github/scripts/renovate_uv_lock_bounded.py
@@ -110,12 +110,15 @@ import sys
 import tomllib
 from pathlib import Path
 
-try:  # PEP 508 parsing for floor classification; see floored_packages.
+try:  # PEP 508/440 parsing for floor classification and the rollback gate.
     from packaging.requirements import Requirement
     from packaging.utils import canonicalize_name
+    from packaging.version import InvalidVersion, Version
 except ImportError:  # pragma: no cover - packaging is effectively universal
     Requirement = None  # type: ignore[assignment]
     canonicalize_name = None  # type: ignore[assignment]
+    Version = None  # type: ignore[assignment]
+    InvalidVersion = ValueError  # type: ignore[assignment]
 
 # ISO 8601 durations, restricted to the forms a release-age window sensibly takes.
 # Calendar units are rejected rather than approximated — uv refuses months and
@@ -132,8 +135,6 @@ _ERROR_TOKEN_RE = re.compile(r"[A-Za-z0-9._-]+")
 
 # PEP 503 normalisation, so `Foo_Bar` and `foo-bar` compare equal.
 _NORMALISE_RE = re.compile(r"[-_.]+")
-
-_LEADING_DIGITS_RE = re.compile(r"^(\d+(?:\.\d+)*)")
 
 
 def normalise(name: str) -> str:
@@ -352,11 +353,22 @@ def blocked_by_floor(uv_stderr: str, floors: set[str]) -> list[str]:
     return sorted(mentioned & floors)
 
 
-def _version_key(version: str) -> tuple[int, ...] | None:
-    match = _LEADING_DIGITS_RE.match(version)
-    if not match:
+def _version_key(version: str) -> "Version | None":
+    """Parse a PEP 440 version, or None when it does not parse.
+
+    Structural, not textual: a leading-digits prefix reads ``0.62b1`` as ``0.62``
+    and ``1!2.0`` as ``2``, so a prerelease or epoch rollback would compare equal
+    to (or greater than) the version it actually regresses. ``Version`` orders
+    those correctly — a prerelease sorts before its release, and an epoch beats
+    every version without one. Returns None on an unparseable string so the caller
+    reports it for a human rather than silently dropping the comparison.
+    """
+    if Version is None:
         return None
-    return tuple(int(part) for part in match.group(1).split("."))
+    try:
+        return Version(version)
+    except InvalidVersion:
+        return None
 
 
 def rollbacks(
@@ -371,9 +383,11 @@ def rollbacks(
     downgrade can no longer happen for age reasons, so anything reported here is
     a real signal.
 
-    Compares leading numeric components only; a version either side that does not
-    start with digits is reported rather than ignored, because an unparseable
-    version is the case most worth a human look.
+    Versions are compared as parsed PEP 440 ``Version`` objects, so a prerelease
+    (``0.62b2 -> 0.62b1``) or epoch (``1!2.0 -> 2.0``) rollback is caught rather
+    than read as a numeric prefix. A version either side that does not parse is
+    reported rather than ignored, because an unparseable version is the case most
+    worth a human look.
     """
     found: dict[str, tuple[str, str]] = {}
     names = (normalise(p) for p in packages) if packages is not None else before.keys()

--- a/.github/scripts/renovate_uv_lock_bounded.py
+++ b/.github/scripts/renovate_uv_lock_bounded.py
@@ -253,13 +253,24 @@ def strip_options(lock_text: str) -> str:
     return re.sub(r"\n{3,}", "\n\n", "".join(kept))
 
 
+# A requirement counts as a deliberate floor only when it pins a version with an
+# explicit lower bound (``>=``) or an exact pin (``==``). A bare name (``"orjson"``)
+# constrains nothing — it admits any version, so there is no floor for the
+# cooldown to conflict with. ``/fix-vulnerabilities`` always writes ``>=min`` and
+# ``constraint-dependencies`` CVE floors are always lower bounds, so this loses no
+# intended case while closing the fail-open seam where a bare dep named in uv's
+# error would otherwise be admitted inside the window for an unrelated failure.
+_FLOOR_SPECIFIER_RE = re.compile(r">=|==")
+
+
 def floored_packages(pyproject_text: str) -> set[str]:
     """Packages the repo has deliberately pinned a minimum version for.
 
     Both sources count as deliberate: ``[tool.uv] constraint-dependencies`` (where
     the CVE floors live) and ``[project] dependencies`` / ``optional-dependencies``
     (where ``/fix-vulnerabilities`` writes a floor when it promotes a vulnerable
-    transitive to a direct dependency).
+    transitive to a direct dependency). A requirement only counts when it carries
+    an explicit ``>=`` or ``==`` specifier — a bare package name is not a floor.
     """
     try:
         data = tomllib.loads(pyproject_text)
@@ -288,7 +299,7 @@ def floored_packages(pyproject_text: str) -> set[str]:
     names: set[str] = set()
     for requirement in requirements:
         match = re.match(r"^\s*([A-Za-z0-9][A-Za-z0-9._-]*)", requirement)
-        if match:
+        if match and _FLOOR_SPECIFIER_RE.search(requirement):
             names.add(normalise(match.group(1)))
     return names
 

--- a/.github/scripts/renovate_uv_lock_bounded.py
+++ b/.github/scripts/renovate_uv_lock_bounded.py
@@ -1,0 +1,340 @@
+#!/usr/bin/env python3
+"""Renovate lock-refresh driver: re-lock under a release-age bound, then erase
+the bound from the lockfile.
+
+Invoked from the shared preset's ``lockFileMaintenance.postUpgradeTasks`` on the
+self-hosted fleet runner. Renovate has already produced an *unbounded* ``uv.lock``
+(its native uv manager resolves to latest, and Renovate passes it no release-age
+bound — renovatebot/renovate#41652). This re-resolves that lock with
+``--exclude-newer`` and hands the result back for Renovate to commit.
+
+Why the bound lives here and not in each repo's ``pyproject.toml``
+-----------------------------------------------------------------
+Declaring ``[tool.uv] exclude-newer`` works, but it bounds *every* resolve in
+that repo — including a developer's ``uv lock``, and including the
+``/fix-vulnerabilities`` workflow's ``uv lock --upgrade-package``, which is how a
+CVE fix actually lands. Putting the bound in this one command bounds exactly one
+path: the unattended "upgrade everything to latest" refresh that auto-merges
+without a human. Every deliberate act stays unbounded, which is the whole point —
+the cooldown exists to buy detection time against releases nobody knows are bad
+yet, not to slow down someone who has decided to take a specific version.
+
+Why the ``[options]`` block is stripped (FND-367)
+------------------------------------------------
+uv records its resolver settings into ``uv.lock``::
+
+    [options]
+    exclude-newer = "0001-01-01T00:00:00Z"
+    exclude-newer-span = "P7D"
+
+Every consumer that validates the lock compares its *own* settings against that
+block. The app Dockerfiles run ``uv sync --locked``, which then rejects the lock
+as stale — that is what reddened ``scan / Build Image`` fleet-wide when this was
+first attempted (application-sdk#3212, reverted in #3218). Stripping the block
+leaves a lock whose *content* is bounded but whose recorded settings are the
+defaults, so every consumer agrees. Verified on uv 0.12.4: ``uv lock --check``
+and ``uv sync --locked`` both fail before the strip and pass after it.
+
+Note the asymmetry this creates, because it is deliberate: a bare ``uv lock
+--upgrade`` run locally will produce a *newer* lock than this command does. That
+is correct — a human upgrading on purpose is not subject to the cooldown — but it
+means the lockfile is not reproducible from ``pyproject.toml`` alone. The
+independent check on that is ``checks/dep-cooldown``, which reads the committed
+lock and fails if anything in it is younger than the window.
+
+Failure modes this guards against
+---------------------------------
+1. **Unsatisfiable floor.** ``constraint-dependencies`` is the fleet's CVE-floor
+   list, and each entry points at a just-published fix. A bounded resolve has no
+   valid candidate for a floor younger than the window, so ``uv lock`` fails
+   outright — FND-310's trap. On failure this retries once, exempting the floored
+   packages uv named, and reports them. A deliberate floor beats the cooldown.
+2. **Silent rollback.** A bounded resolve does not error when it cannot reach a
+   package; it quietly resolves an older one. Observed while validating this:
+   with only the two SDK packages exempted, ``atlan-application-sdk`` resolved to
+   3.27.2 instead of 3.28.0 — because 3.28.0 requires ``pyatlan>=10`` and pyatlan
+   10.0.0 was two days old, so the bound made it invisible and uv backtracked. No
+   error, no warning; unattended, that auto-merges an SDK *downgrade* across the
+   fleet. Hence ``pyatlan`` in the exempt set, and hence the check that no exempt
+   package came out lower than it went in.
+
+Never resolves unbounded as a fallback. A control whose failure mode is a log
+line is not a control (FND-367) — if the bound cannot be applied, this exits
+non-zero, Renovate reports an artifact error, and the approval gate withholds
+the atlan-ci approval so nothing auto-merges.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+# uv names the packages it could not resolve in its error text. Rather than
+# parse that free-form output, we intersect it with the packages the repo has
+# explicitly floored — so the retry can only ever admit a version the repo has
+# already made a deliberate decision about, never an arbitrary one uv mentioned
+# in passing.
+_ERROR_TOKEN_RE = re.compile(r"[A-Za-z0-9._-]+")
+
+# PEP 503 normalisation, so `Foo_Bar` and `foo-bar` compare equal.
+_NORMALISE_RE = re.compile(r"[-_.]+")
+
+_LEADING_DIGITS_RE = re.compile(r"^(\d+(?:\.\d+)*)")
+
+
+def normalise(name: str) -> str:
+    """PEP 503 name normalisation."""
+    return _NORMALISE_RE.sub("-", name.strip().lower())
+
+
+def lock_versions(lock_text: str) -> dict[str, str]:
+    """``{normalised name: version}`` for every registry-sourced package.
+
+    Packages sourced from a path/git/editable checkout carry no registry version
+    to compare, so they are skipped rather than reported as changed.
+    """
+    try:
+        data = tomllib.loads(lock_text)
+    except tomllib.TOMLDecodeError:
+        return {}
+    versions: dict[str, str] = {}
+    for package in data.get("package", []):
+        if not isinstance(package, dict):
+            continue
+        source = package.get("source") or {}
+        if any(source.get(k) for k in ("editable", "git", "path", "url", "directory")):
+            continue
+        name, version = package.get("name"), package.get("version")
+        if isinstance(name, str) and isinstance(version, str):
+            versions[normalise(name)] = version
+    return versions
+
+
+def strip_options(lock_text: str) -> str:
+    """Remove the ``[options]`` table and any ``[options.*]`` subtable.
+
+    Line-based rather than a TOML round-trip on purpose: ``tomllib`` is
+    read-only, and re-emitting the document with a writer would reorder and
+    reformat 5000 lines, turning every lock refresh into an unreviewable diff.
+    """
+    kept: list[str] = []
+    skipping = False
+    for line in lock_text.splitlines(keepends=True):
+        stripped = line.lstrip()
+        if stripped.startswith("[options]") or stripped.startswith("[options."):
+            skipping = True
+            continue
+        if skipping and (
+            stripped.startswith("[[")
+            or (stripped.startswith("[") and not stripped.startswith("[options"))
+        ):
+            skipping = False
+        if not skipping:
+            kept.append(line)
+    return re.sub(r"\n{3,}", "\n\n", "".join(kept))
+
+
+def floored_packages(pyproject_text: str) -> set[str]:
+    """Packages the repo has deliberately pinned a minimum version for.
+
+    Both sources count as deliberate: ``[tool.uv] constraint-dependencies`` (where
+    the CVE floors live) and ``[project] dependencies`` / ``optional-dependencies``
+    (where ``/fix-vulnerabilities`` writes a floor when it promotes a vulnerable
+    transitive to a direct dependency).
+    """
+    try:
+        data = tomllib.loads(pyproject_text)
+    except tomllib.TOMLDecodeError:
+        return set()
+
+    requirements: list[str] = []
+    project = data.get("project", {})
+    if isinstance(project, dict):
+        requirements.extend(
+            r for r in project.get("dependencies", []) if isinstance(r, str)
+        )
+        optional = project.get("optional-dependencies", {})
+        if isinstance(optional, dict):
+            for group in optional.values():
+                if isinstance(group, list):
+                    requirements.extend(r for r in group if isinstance(r, str))
+    uv_table = (
+        data.get("tool", {}).get("uv", {}) if isinstance(data.get("tool"), dict) else {}
+    )
+    if isinstance(uv_table, dict):
+        requirements.extend(
+            r for r in uv_table.get("constraint-dependencies", []) if isinstance(r, str)
+        )
+
+    names: set[str] = set()
+    for requirement in requirements:
+        match = re.match(r"^\s*([A-Za-z0-9][A-Za-z0-9._-]*)", requirement)
+        if match:
+            names.add(normalise(match.group(1)))
+    return names
+
+
+def blocked_by_floor(uv_stderr: str, floors: set[str]) -> list[str]:
+    """Floored packages named in uv's resolution error.
+
+    Intersecting with the floor set keeps the retry honest: it can only admit a
+    package the repo already floored on purpose. If uv failed for some other
+    reason, this is empty and the caller fails rather than retrying blind.
+    """
+    mentioned = {normalise(t) for t in _ERROR_TOKEN_RE.findall(uv_stderr)}
+    return sorted(mentioned & floors)
+
+
+def _version_key(version: str) -> tuple[int, ...] | None:
+    match = _LEADING_DIGITS_RE.match(version)
+    if not match:
+        return None
+    return tuple(int(part) for part in match.group(1).split("."))
+
+
+def rollbacks(
+    before: dict[str, str], after: dict[str, str], packages: list[str]
+) -> dict[str, tuple[str, str]]:
+    """Exempt packages that came out of the bounded resolve older than they went in.
+
+    Compares leading numeric components only; a version either side that does not
+    start with digits is reported as a rollback rather than ignored, because an
+    unrecognised version on an exempt package is exactly the case worth a human
+    look. Third-party packages moving backwards is the *intended* effect of the
+    bound and is never reported here.
+    """
+    found: dict[str, tuple[str, str]] = {}
+    for name in (normalise(p) for p in packages):
+        old, new = before.get(name), after.get(name)
+        if old is None or new is None or old == new:
+            continue
+        old_key, new_key = _version_key(old), _version_key(new)
+        if old_key is None or new_key is None or new_key < old_key:
+            found[name] = (old, new)
+    return found
+
+
+def build_uv_command(window: str, exempt: list[str]) -> list[str]:
+    command = ["uv", "lock", "--upgrade", "--exclude-newer", window]
+    for name in exempt:
+        command += ["--exclude-newer-package", f"{name}=P0D"]
+    return command
+
+
+def run_uv_lock(command: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(command, cwd=cwd, capture_output=True, text=True)
+
+
+def summarise(lines: list[str]) -> None:
+    """Write to the step summary when running in Actions; always echo to stdout."""
+    body = "\n".join(lines)
+    print(body)
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_path:
+        with open(summary_path, "a", encoding="utf-8") as handle:
+            handle.write(body + "\n")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--window",
+        required=True,
+        help="Release-age bound as an ISO 8601 duration, e.g. P7D.",
+    )
+    parser.add_argument(
+        "--exempt",
+        action="append",
+        default=[],
+        help="Package admitted regardless of age. Repeatable. First-party packages "
+        "plus anything in their dependency closure that must move with them.",
+    )
+    parser.add_argument("--project-dir", default=".")
+    args = parser.parse_args(argv)
+
+    project_dir = Path(args.project_dir).resolve()
+    lock_path = project_dir / "uv.lock"
+    pyproject_path = project_dir / "pyproject.toml"
+
+    if not lock_path.exists():
+        print(f"No uv.lock in {project_dir} — nothing to bound.", file=sys.stderr)
+        return 0
+
+    before = lock_versions(lock_path.read_text())
+    exempt = list(args.exempt)
+
+    result = run_uv_lock(build_uv_command(args.window, exempt), project_dir)
+    admitted_early: list[str] = []
+
+    if result.returncode != 0:
+        floors = (
+            floored_packages(pyproject_path.read_text())
+            if pyproject_path.exists()
+            else set()
+        )
+        admitted_early = blocked_by_floor(result.stderr, floors)
+        if not admitted_early:
+            print(
+                "Bounded `uv lock` failed and no deliberately-floored package was "
+                "named in the error, so there is nothing safe to admit early. "
+                "Refusing to fall back to an unbounded resolve.\n" + result.stderr,
+                file=sys.stderr,
+            )
+            return 1
+        result = run_uv_lock(
+            build_uv_command(args.window, exempt + admitted_early), project_dir
+        )
+        if result.returncode != 0:
+            print(
+                "Bounded `uv lock` still failed after admitting "
+                f"{', '.join(admitted_early)}.\n" + result.stderr,
+                file=sys.stderr,
+            )
+            return 1
+
+    after = lock_versions(lock_path.read_text())
+
+    regressed = rollbacks(before, after, exempt + admitted_early)
+    if regressed:
+        detail = ", ".join(
+            f"{n} {old} -> {new}" for n, (old, new) in sorted(regressed.items())
+        )
+        print(
+            "Bounded resolve rolled an exempt package BACKWARDS: "
+            f"{detail}. This is the silent-downgrade failure mode: a package that "
+            "should never be delayed could not be reached, so uv resolved an older "
+            "one instead of failing. Usually it means something in that package's "
+            "dependency closure is inside the cooldown and also needs exempting. "
+            "Refusing to commit a first-party downgrade.",
+            file=sys.stderr,
+        )
+        return 1
+
+    lock_path.write_text(strip_options(lock_path.read_text()))
+
+    held = sorted(
+        name for name, version in after.items() if before.get(name) != version
+    )
+    lines = [
+        f"**Release-age bound applied:** `{args.window}` "
+        f"(exempt: {', '.join(exempt) or 'none'})",
+        "",
+        f"- {len(held)} package(s) resolved below the unbounded latest",
+        "- `[options]` stripped from `uv.lock` so `uv sync --locked` still validates",
+    ]
+    if admitted_early:
+        lines.append(
+            f"- **Admitted inside the window** because the repo floors them: "
+            f"{', '.join(admitted_early)}"
+        )
+    summarise(lines)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/renovate_uv_lock_bounded.py
+++ b/.github/scripts/renovate_uv_lock_bounded.py
@@ -465,10 +465,14 @@ def baseline_lock_text(cwd: Path) -> str | None:
     base-branch commit, and a reused one has its own previous (already bounded)
     commit, which is the version that actually shipped last.
 
-    Returns None only when git works but the path is absent from HEAD — a lock
-    added in this very branch, which legitimately has no baseline. A broken git
-    raises, because silently treating "cannot tell" as "no baseline" would drop
-    the ceilings and quietly reintroduce the rollback this exists to prevent.
+    Returns None only when the path is verifiably absent from HEAD — a lock
+    added in this very branch, which legitimately has no baseline. Anything else
+    that goes wrong raises, because silently treating "cannot tell" as "no
+    baseline" would drop the ceilings and quietly reintroduce the rollback this
+    exists to prevent. That includes a HEAD that resolves but whose lock blob
+    cannot be read: absent is a fact about the tree, not a guess from a failed
+    command, so absence is established by probing `git cat-file -e` and every
+    other `git show` failure is treated as fatal.
     """
     head = subprocess.run(
         ["git", "rev-parse", "--verify", "HEAD"],
@@ -481,10 +485,36 @@ def baseline_lock_text(cwd: Path) -> str | None:
             f"cannot resolve HEAD in {cwd}, so the pre-refresh lockfile is "
             f"unavailable: {head.stderr.strip()}"
         )
+    exists = subprocess.run(
+        ["git", "cat-file", "-e", "HEAD:uv.lock"],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+    )
+    if exists.returncode != 0:
+        # cat-file -e exits non-zero both when the path is absent from HEAD and
+        # when git itself is broken; disambiguate by reading the blob. A clean
+        # show means the path genuinely is absent — a lock added in this very
+        # branch, which legitimately has no baseline. Anything else is "cannot
+        # tell", which must fail closed rather than masquerade as no baseline.
+        probe = subprocess.run(
+            ["git", "show", "HEAD:uv.lock"], cwd=cwd, capture_output=True, text=True
+        )
+        if probe.returncode != 0:
+            raise RuntimeError(
+                f"cannot read uv.lock from HEAD in {cwd}, so the pre-refresh "
+                f"lockfile is unavailable: {probe.stderr.strip()}"
+            )
+        return None
     show = subprocess.run(
         ["git", "show", "HEAD:uv.lock"], cwd=cwd, capture_output=True, text=True
     )
-    return show.stdout if show.returncode == 0 else None
+    if show.returncode != 0:
+        raise RuntimeError(
+            f"uv.lock exists in HEAD but cannot be read in {cwd}, so the "
+            f"pre-refresh lockfile is unavailable: {show.stderr.strip()}"
+        )
+    return show.stdout
 
 
 def summarise(lines: list[str]) -> None:

--- a/.github/scripts/renovate_uv_lock_bounded.py
+++ b/.github/scripts/renovate_uv_lock_bounded.py
@@ -110,6 +110,13 @@ import sys
 import tomllib
 from pathlib import Path
 
+try:  # PEP 508 parsing for floor classification; see floored_packages.
+    from packaging.requirements import Requirement
+    from packaging.utils import canonicalize_name
+except ImportError:  # pragma: no cover - packaging is effectively universal
+    Requirement = None  # type: ignore[assignment]
+    canonicalize_name = None  # type: ignore[assignment]
+
 # ISO 8601 durations, restricted to the forms a release-age window sensibly takes.
 # Calendar units are rejected rather than approximated — uv refuses months and
 # years for the same reason, and a window that silently means something other
@@ -254,16 +261,42 @@ def strip_options(lock_text: str) -> str:
 
 
 # A requirement counts as a deliberate floor only when it pins a version with an
-# explicit lower bound (``>=``) or an exact pin (``==``). A bare name (``"orjson"``)
-# constrains nothing — it admits any version, so there is no floor for the
-# cooldown to conflict with. ``/fix-vulnerabilities`` always writes ``>=min`` and
-# ``constraint-dependencies`` CVE floors are always lower bounds, so this loses no
-# intended case while closing the fail-open seam where a bare dep named in uv's
-# error would otherwise be admitted inside the window for an unrelated failure.
-# The specifier must appear in the package portion, BEFORE any ``;`` environment
-# marker: ``foo; python_version >= "3.10"`` floors nothing (the bound is on the
-# interpreter, not the package), so the marker is stripped before matching.
-_FLOOR_SPECIFIER_RE = re.compile(r">=|==")
+# explicit lower bound (``>=``) or an exact pin (``==``) in its PEP 508 version
+# specifier. A bare name (``"orjson"``) constrains nothing — it admits any version,
+# so there is no floor for the cooldown to conflict with. ``/fix-vulnerabilities``
+# always writes ``>=min`` and ``constraint-dependencies`` CVE floors are always
+# lower bounds, so this loses no intended case while closing the fail-open seam
+# where a floor-less dep named in uv's error would otherwise be admitted inside
+# the window for an unrelated failure.
+#
+# The requirement is parsed as PEP 508 rather than scanned as text. Substring
+# matching over the raw string reads bounds out of two places that are not package
+# floors: an environment marker (``foo; python_version >= "3.10"`` bounds the
+# interpreter, not the package) and a direct-reference URL (``foo @
+# https://…/pkg.tar.gz?constraint==1`` — the ``==`` is URL data). Parsing inspects
+# only the parsed ``SpecifierSet``, so neither can be misread as a floor.
+
+
+def _floor_specified(requirement: str) -> str | None:
+    """The package's normalised name if ``requirement`` floors a version, else None.
+
+    Structural, not textual: the PEP 508 parse separates the version specifier
+    from both the environment marker and any direct-reference URL, so a ``>=`` /
+    ``==`` is honoured only where it actually constrains the package. Fails closed:
+    a requirement that does not parse, or a missing ``packaging`` library, yields
+    no floor classification rather than a guess — the safe direction for a control
+    whose whole point is to *not* admit a package early.
+    """
+    if Requirement is None:
+        return None
+    try:
+        parsed = Requirement(requirement)
+    except Exception:  # InvalidRequirement and friends — not a floor we can trust
+        return None
+    for specifier in parsed.specifier:
+        if specifier.operator in (">=", "=="):
+            return normalise(parsed.name)
+    return None
 
 
 def floored_packages(pyproject_text: str) -> set[str]:
@@ -272,8 +305,9 @@ def floored_packages(pyproject_text: str) -> set[str]:
     Both sources count as deliberate: ``[tool.uv] constraint-dependencies`` (where
     the CVE floors live) and ``[project] dependencies`` / ``optional-dependencies``
     (where ``/fix-vulnerabilities`` writes a floor when it promotes a vulnerable
-    transitive to a direct dependency). A requirement only counts when it carries
-    an explicit ``>=`` or ``==`` specifier — a bare package name is not a floor.
+    transitive to a direct dependency). A requirement only counts when its PEP 508
+    version specifier carries an explicit ``>=`` or ``==`` — a bare package name,
+    an environment-marker bound, or a direct-reference URL is not a floor.
     """
     try:
         data = tomllib.loads(pyproject_text)
@@ -301,11 +335,9 @@ def floored_packages(pyproject_text: str) -> set[str]:
 
     names: set[str] = set()
     for requirement in requirements:
-        match = re.match(r"^\s*([A-Za-z0-9][A-Za-z0-9._-]*)", requirement)
-        # Only the package portion (before any ``;`` marker) can carry the floor.
-        package_part = requirement.split(";", 1)[0]
-        if match and _FLOOR_SPECIFIER_RE.search(package_part):
-            names.add(normalise(match.group(1)))
+        floored = _floor_specified(requirement)
+        if floored is not None:
+            names.add(floored)
     return names
 
 

--- a/.github/scripts/renovate_uv_lock_bounded.py
+++ b/.github/scripts/renovate_uv_lock_bounded.py
@@ -260,6 +260,9 @@ def strip_options(lock_text: str) -> str:
 # ``constraint-dependencies`` CVE floors are always lower bounds, so this loses no
 # intended case while closing the fail-open seam where a bare dep named in uv's
 # error would otherwise be admitted inside the window for an unrelated failure.
+# The specifier must appear in the package portion, BEFORE any ``;`` environment
+# marker: ``foo; python_version >= "3.10"`` floors nothing (the bound is on the
+# interpreter, not the package), so the marker is stripped before matching.
 _FLOOR_SPECIFIER_RE = re.compile(r">=|==")
 
 
@@ -299,7 +302,9 @@ def floored_packages(pyproject_text: str) -> set[str]:
     names: set[str] = set()
     for requirement in requirements:
         match = re.match(r"^\s*([A-Za-z0-9][A-Za-z0-9._-]*)", requirement)
-        if match and _FLOOR_SPECIFIER_RE.search(requirement):
+        # Only the package portion (before any ``;`` marker) can carry the floor.
+        package_part = requirement.split(";", 1)[0]
+        if match and _FLOOR_SPECIFIER_RE.search(package_part):
             names.add(normalise(match.group(1)))
     return names
 

--- a/.github/scripts/renovate_uv_lock_bounded.py
+++ b/.github/scripts/renovate_uv_lock_bounded.py
@@ -42,6 +42,37 @@ means the lockfile is not reproducible from ``pyproject.toml`` alone. The
 independent check on that is ``checks/dep-cooldown``, which reads the committed
 lock and fails if anything in it is younger than the window.
 
+The bound governs ADOPTION, never REVERSION
+-------------------------------------------
+A plain ``uv lock --upgrade --exclude-newer P7D`` does not merely decline to take
+new releases — it re-resolves everything and *rolls back* anything already locked
+that was published inside the window. Measured on the pilot: 13 downgrades
+against ``atlan-hello-world-app``'s ``main`` and zero upgrades, including
+``boto3 1.43.72 -> 1.43.67`` and ``starlette 1.6.0 -> 1.4.1``.
+
+That is worse than the delay the cooldown is meant to impose. Most transitive
+security uplift in this fleet arrives silently through lock maintenance with no
+floor ever recorded (a floor in ``constraint-dependencies`` or ``[project]
+dependencies`` would hold the line, but only the fixes someone thought to record
+have one). Reverting blind can therefore re-introduce a fix that was already in
+place — a strictly worse failure than shipping a fix seven days late.
+
+So every package already in the lock gets a per-package ceiling derived from the
+``upload-time`` of the version it is currently pinned to, which the lockfile
+already records for every sdist and wheel. The effective ceiling is
+``max(now - window, upload-time of the locked version)``:
+
+* nothing already adopted moves backwards,
+* nothing published inside the window is newly adopted — the control is intact,
+* the first bounded run in a repo is a near no-op rather than a mass rollback,
+* and a yanked release is still dropped, because uv skips yanked versions when it
+  re-resolves.
+
+What this deliberately does not do is revert a *malicious* version adopted before
+the bound existed. That is not the cooldown's job — it buys time for the ecosystem
+to notice, and when it does, the release is yanked (handled above) or gets an
+advisory (handled by the security lane, which bypasses the cooldown outright).
+
 Failure modes this guards against
 ---------------------------------
 1. **Unsatisfiable floor.** ``constraint-dependencies`` is the fleet's CVE-floor
@@ -55,8 +86,12 @@ Failure modes this guards against
    3.27.2 instead of 3.28.0 — because 3.28.0 requires ``pyatlan>=10`` and pyatlan
    10.0.0 was two days old, so the bound made it invisible and uv backtracked. No
    error, no warning; unattended, that auto-merges an SDK *downgrade* across the
-   fleet. Hence ``pyatlan`` in the exempt set, and hence the check that no exempt
-   package came out lower than it went in.
+   fleet. Hence ``pyatlan`` in the exempt set.
+
+   With per-package ceilings in place a downgrade should now be impossible for
+   age reasons, so any that survives means something else moved — a yanked
+   release, or a constraint change forcing a different solution. Rare, worth a
+   human, and never worth auto-merging: the run fails and nothing merges.
 
 Never resolves unbounded as a fallback. A control whose failure mode is a log
 line is not a control (FND-367) — if the bound cannot be applied, this exits
@@ -67,12 +102,19 @@ the atlan-ci approval so nothing auto-merges.
 from __future__ import annotations
 
 import argparse
+import datetime as dt
 import os
 import re
 import subprocess
 import sys
 import tomllib
 from pathlib import Path
+
+# ISO 8601 durations, restricted to the forms a release-age window sensibly takes.
+# Calendar units are rejected rather than approximated — uv refuses months and
+# years for the same reason, and a window that silently means something other
+# than what it says is worse than one that fails to parse.
+_DURATION_RE = re.compile(r"^P(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?)?$")
 
 # uv names the packages it could not resolve in its error text. Rather than
 # parse that free-form output, we intersect it with the packages the repo has
@@ -113,6 +155,78 @@ def lock_versions(lock_text: str) -> dict[str, str]:
         if isinstance(name, str) and isinstance(version, str):
             versions[normalise(name)] = version
     return versions
+
+
+def parse_window(window: str) -> dt.timedelta:
+    """``P7D`` / ``PT12H`` -> timedelta. Raises on anything else."""
+    match = _DURATION_RE.match(window.strip())
+    if not match or not any(match.groups()):
+        raise ValueError(
+            f"unsupported release-age window {window!r}; expected an ISO 8601 "
+            "duration in days/hours/minutes, e.g. P7D or PT12H"
+        )
+    days, hours, minutes = (int(g) if g else 0 for g in match.groups())
+    return dt.timedelta(days=days, hours=hours, minutes=minutes)
+
+
+def lock_upload_times(lock_text: str) -> dict[str, dt.datetime]:
+    """``{normalised name: newest upload-time}`` for the version each package is
+    pinned to.
+
+    uv records ``upload-time`` on every sdist and wheel entry, so the age of what
+    is *currently locked* is available offline — no registry round-trip, and no
+    fail-open path when one is unavailable. The newest timestamp across a
+    package's files is used: the ceiling has to admit every file the resolver
+    needs, and wheels for different platforms are published seconds apart.
+    """
+    try:
+        data = tomllib.loads(lock_text)
+    except tomllib.TOMLDecodeError:
+        return {}
+
+    times: dict[str, dt.datetime] = {}
+    for package in data.get("package", []):
+        if not isinstance(package, dict):
+            continue
+        name = package.get("name")
+        if not isinstance(name, str):
+            continue
+        stamps: list[dt.datetime] = []
+        entries = [package.get("sdist")] + list(package.get("wheels") or [])
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            raw = entry.get("upload-time")
+            if not isinstance(raw, str):
+                continue
+            try:
+                parsed = dt.datetime.fromisoformat(raw.replace("Z", "+00:00"))
+            except ValueError:
+                continue
+            stamps.append(
+                parsed if parsed.tzinfo else parsed.replace(tzinfo=dt.timezone.utc)
+            )
+        if stamps:
+            times[normalise(name)] = max(stamps)
+    return times
+
+
+def retention_ceilings(
+    upload_times: dict[str, dt.datetime], cutoff: dt.datetime
+) -> dict[str, str]:
+    """Per-package ceilings that stop the bound rolling anything backwards.
+
+    A package whose locked version is *older* than the cutoff needs no ceiling —
+    the window already admits it. One whose locked version is younger would
+    otherwise be reverted, so it gets a ceiling one second past its own upload
+    instant: uv can still keep exactly that version, and can take nothing newer.
+    """
+    ceilings: dict[str, str] = {}
+    for name, uploaded in upload_times.items():
+        if uploaded > cutoff:
+            admit = (uploaded + dt.timedelta(seconds=1)).astimezone(dt.timezone.utc)
+            ceilings[name] = admit.strftime("%Y-%m-%dT%H:%M:%SZ")
+    return ceilings
 
 
 def strip_options(lock_text: str) -> str:
@@ -198,18 +312,24 @@ def _version_key(version: str) -> tuple[int, ...] | None:
 
 
 def rollbacks(
-    before: dict[str, str], after: dict[str, str], packages: list[str]
+    before: dict[str, str], after: dict[str, str], packages: list[str] | None = None
 ) -> dict[str, tuple[str, str]]:
-    """Exempt packages that came out of the bounded resolve older than they went in.
+    """Packages that came out of the bounded resolve older than they went in.
+
+    Checks **every** package by default, not just the exempt ones. An earlier
+    revision of this scoped the check to first-party packages and treated
+    third-party downgrades as the bound working as intended — which is exactly
+    the bug the retention ceilings above exist to fix. With those in place a
+    downgrade can no longer happen for age reasons, so anything reported here is
+    a real signal.
 
     Compares leading numeric components only; a version either side that does not
-    start with digits is reported as a rollback rather than ignored, because an
-    unrecognised version on an exempt package is exactly the case worth a human
-    look. Third-party packages moving backwards is the *intended* effect of the
-    bound and is never reported here.
+    start with digits is reported rather than ignored, because an unparseable
+    version is the case most worth a human look.
     """
     found: dict[str, tuple[str, str]] = {}
-    for name in (normalise(p) for p in packages):
+    names = (normalise(p) for p in packages) if packages is not None else before.keys()
+    for name in names:
         old, new = before.get(name), after.get(name)
         if old is None or new is None or old == new:
             continue
@@ -219,8 +339,20 @@ def rollbacks(
     return found
 
 
-def build_uv_command(window: str, exempt: list[str]) -> list[str]:
+def build_uv_command(
+    window: str, exempt: list[str], ceilings: dict[str, str] | None = None
+) -> list[str]:
+    """The bounded resolve, plus one ceiling flag per package that needs one.
+
+    Exemptions come last so they win over a retention ceiling for the same
+    package: a first-party package must be free to move forward, not merely be
+    held where it is.
+    """
     command = ["uv", "lock", "--upgrade", "--exclude-newer", window]
+    exempt_normalised = {normalise(name) for name in exempt}
+    for name, admit in sorted((ceilings or {}).items()):
+        if name not in exempt_normalised:
+            command += ["--exclude-newer-package", f"{name}={admit}"]
     for name in exempt:
         command += ["--exclude-newer-package", f"{name}=P0D"]
     return command
@@ -228,6 +360,42 @@ def build_uv_command(window: str, exempt: list[str]) -> list[str]:
 
 def run_uv_lock(command: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
     return subprocess.run(command, cwd=cwd, capture_output=True, text=True)
+
+
+def baseline_lock_text(cwd: Path) -> str | None:
+    """``uv.lock`` as last committed, or None if the repo has no committed copy.
+
+    Emphatically NOT the working tree. By the time this runs, Renovate has
+    already refreshed the lock to latest-of-everything in the working tree — that
+    is the whole input this command exists to bound. Deriving retention ceilings
+    from *that* would pin every package to the release Renovate pulled seconds
+    ago and neutralise the window completely, and comparing against it would
+    report a rollback for every package the bound correctly holds back.
+
+    ``HEAD`` is the right baseline in both branch states: a fresh branch has the
+    base-branch commit, and a reused one has its own previous (already bounded)
+    commit, which is the version that actually shipped last.
+
+    Returns None only when git works but the path is absent from HEAD — a lock
+    added in this very branch, which legitimately has no baseline. A broken git
+    raises, because silently treating "cannot tell" as "no baseline" would drop
+    the ceilings and quietly reintroduce the rollback this exists to prevent.
+    """
+    head = subprocess.run(
+        ["git", "rev-parse", "--verify", "HEAD"],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+    )
+    if head.returncode != 0:
+        raise RuntimeError(
+            f"cannot resolve HEAD in {cwd}, so the pre-refresh lockfile is "
+            f"unavailable: {head.stderr.strip()}"
+        )
+    show = subprocess.run(
+        ["git", "show", "HEAD:uv.lock"], cwd=cwd, capture_output=True, text=True
+    )
+    return show.stdout if show.returncode == 0 else None
 
 
 def summarise(lines: list[str]) -> None:
@@ -265,10 +433,35 @@ def main(argv: list[str] | None = None) -> int:
         print(f"No uv.lock in {project_dir} — nothing to bound.", file=sys.stderr)
         return 0
 
-    before = lock_versions(lock_path.read_text())
+    try:
+        window = parse_window(args.window)
+    except ValueError as error:
+        print(str(error), file=sys.stderr)
+        return 1
+
     exempt = list(args.exempt)
 
-    result = run_uv_lock(build_uv_command(args.window, exempt), project_dir)
+    # Baseline = the last COMMITTED lock, never the working tree. See
+    # baseline_lock_text for why that distinction is load-bearing.
+    try:
+        baseline = baseline_lock_text(project_dir)
+    except RuntimeError as error:
+        print(str(error), file=sys.stderr)
+        return 1
+
+    if baseline is None:
+        print(
+            "No committed uv.lock at HEAD — treating this as a new lockfile: "
+            "no retention ceilings and no rollback comparison.",
+            file=sys.stderr,
+        )
+        baseline = ""
+
+    before = lock_versions(baseline)
+    cutoff = dt.datetime.now(dt.timezone.utc) - window
+    ceilings = retention_ceilings(lock_upload_times(baseline), cutoff)
+
+    result = run_uv_lock(build_uv_command(args.window, exempt, ceilings), project_dir)
     admitted_early: list[str] = []
 
     if result.returncode != 0:
@@ -287,7 +480,8 @@ def main(argv: list[str] | None = None) -> int:
             )
             return 1
         result = run_uv_lock(
-            build_uv_command(args.window, exempt + admitted_early), project_dir
+            build_uv_command(args.window, exempt + admitted_early, ceilings),
+            project_dir,
         )
         if result.returncode != 0:
             print(
@@ -299,32 +493,37 @@ def main(argv: list[str] | None = None) -> int:
 
     after = lock_versions(lock_path.read_text())
 
-    regressed = rollbacks(before, after, exempt + admitted_early)
+    regressed = rollbacks(before, after)
     if regressed:
         detail = ", ".join(
             f"{n} {old} -> {new}" for n, (old, new) in sorted(regressed.items())
         )
         print(
-            "Bounded resolve rolled an exempt package BACKWARDS: "
-            f"{detail}. This is the silent-downgrade failure mode: a package that "
-            "should never be delayed could not be reached, so uv resolved an older "
-            "one instead of failing. Usually it means something in that package's "
-            "dependency closure is inside the cooldown and also needs exempting. "
-            "Refusing to commit a first-party downgrade.",
+            f"Bounded resolve moved {len(regressed)} package(s) BACKWARDS from the "
+            f"last committed lock: {detail}. Retention ceilings should make an "
+            "age-driven downgrade impossible, so this means something else forced "
+            "a different solution — most often a yanked release, sometimes a "
+            "changed constraint. Both are worth a human and neither is worth "
+            "auto-merging, so nothing is committed.",
             file=sys.stderr,
         )
         return 1
 
     lock_path.write_text(strip_options(lock_path.read_text()))
 
-    held = sorted(
-        name for name, version in after.items() if before.get(name) != version
+    advanced = sorted(
+        name for name, v in after.items() if before.get(name) not in (None, v)
     )
+    added = sorted(name for name in after if name not in before)
     lines = [
         f"**Release-age bound applied:** `{args.window}` "
         f"(exempt: {', '.join(exempt) or 'none'})",
         "",
-        f"- {len(held)} package(s) resolved below the unbounded latest",
+        f"- {len(ceilings)} package(s) pinned at their current version: the release "
+        "they are on is itself inside the window, and the bound must never roll a "
+        "dependency backwards",
+        f"- {len(advanced)} package(s) upgraded, {len(added)} newly added — all of "
+        f"them published at least `{args.window}` ago",
         "- `[options]` stripped from `uv.lock` so `uv sync --locked` still validates",
     ]
     if admitted_early:

--- a/.github/scripts/tests/test_check_renovate_allowed_commands.py
+++ b/.github/scripts/tests/test_check_renovate_allowed_commands.py
@@ -106,6 +106,20 @@ class TestAllowedPatterns:
         )
         assert guard.allowed_patterns(source) == ["^only --real$"]
 
+    def test_quotes_inside_a_block_comment_are_not_collected_as_entries(self):
+        # A quoted regex inside a /* */ block comment is not an allowlist entry;
+        # the JS runtime ignores it, so the guard must too (otherwise the two
+        # disagree about which commands are authorized).
+        source = (
+            "module.exports = {\n"
+            "  allowedCommands: [\n"
+            '    /* retired: "^old --pattern$" — superseded by the entry below */\n'
+            '    "^only --real$",\n'
+            "  ],\n"
+            "};\n"
+        )
+        assert guard.allowed_patterns(source) == ["^only --real$"]
+
 
 class TestUnauthorizedCommands:
     def test_flags_command_the_allowlist_does_not_cover(self):

--- a/.github/scripts/tests/test_check_renovate_allowed_commands.py
+++ b/.github/scripts/tests/test_check_renovate_allowed_commands.py
@@ -75,6 +75,37 @@ class TestAllowedPatterns:
     def test_empty_when_allowlist_is_absent(self):
         assert guard.allowed_patterns("module.exports = { platform: 'github' };") == []
 
+    def test_a_bracket_inside_an_entry_does_not_truncate_the_allowlist(self):
+        # An entry is itself a regex, so it can contain a character class. Ending
+        # the scan at the first `]` would drop every later entry and silently
+        # authorize nothing — the guard would then pass commands it never saw.
+        source = (
+            "module.exports = {\n"
+            "  allowedCommands: [\n"
+            '    "^first --window P[0-9]+D$",\n'
+            '    "^second --flag$",\n'
+            "  ],\n"
+            "};\n"
+        )
+        assert guard.allowed_patterns(source) == [
+            "^first --window P[0-9]+D$",
+            "^second --flag$",
+        ]
+
+    def test_quotes_inside_a_comment_are_not_collected_as_entries(self):
+        # Comments explaining the patterns are normal in this array, and prose
+        # routinely quotes things. A quote pair in a comment must not be read as
+        # a pattern, or every entry after it desynchronises.
+        source = (
+            "module.exports = {\n"
+            "  allowedCommands: [\n"
+            '    // avoid backslashes: "\\d" is just "d" to a JS string literal\n'
+            '    "^only --real$",\n'
+            "  ],\n"
+            "};\n"
+        )
+        assert guard.allowed_patterns(source) == ["^only --real$"]
+
 
 class TestUnauthorizedCommands:
     def test_flags_command_the_allowlist_does_not_cover(self):

--- a/.github/scripts/tests/test_renovate_uv_lock_bounded.py
+++ b/.github/scripts/tests/test_renovate_uv_lock_bounded.py
@@ -1,0 +1,305 @@
+"""Tests for .github/scripts/renovate_uv_lock_bounded.py.
+
+Pure-unit: no network, no uv invocation. The uv call itself is exercised
+end-to-end by the pilot repo's CI, not here — what needs regression cover is the
+logic around it, which is where both prior attempts failed (a lockfile that
+`uv sync --locked` rejected, and a bound that vanished without anything going
+red).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import renovate_uv_lock_bounded as bounded
+
+# A lock in the shape uv writes it, including the [options] block that broke the
+# fleet in FND-367 and the [options.exclude-newer-package] subtable beside it.
+LOCK_WITH_OPTIONS = """\
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P7D"
+
+[options.exclude-newer-package]
+atlan-application-sdk = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
+pyatlan = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
+
+[[package]]
+name = "atlan-application-sdk"
+version = "3.28.0"
+source = { registry = "https://pypi.org/simple" }
+
+[[package]]
+name = "boto3"
+version = "1.43.67"
+source = { registry = "https://pypi.org/simple" }
+
+[[package]]
+name = "hello-world-app"
+version = "0.1.0"
+source = { editable = "." }
+"""
+
+
+def lock(**packages: str) -> str:
+    body = 'version = 1\nrevision = 3\nrequires-python = ">=3.11"\n'
+    for name, version in packages.items():
+        body += (
+            f'\n[[package]]\nname = "{name.replace("_", "-")}"\n'
+            f'version = "{version}"\n'
+            'source = { registry = "https://pypi.org/simple" }\n'
+        )
+    return body
+
+
+class TestStripOptions:
+    def test_removes_options_table_and_its_subtable(self):
+        stripped = bounded.strip_options(LOCK_WITH_OPTIONS)
+        assert "[options]" not in stripped
+        assert "exclude-newer" not in stripped
+        assert "[options.exclude-newer-package]" not in stripped
+
+    def test_keeps_every_package_and_the_header(self):
+        stripped = bounded.strip_options(LOCK_WITH_OPTIONS)
+        assert stripped.count("[[package]]") == 3
+        assert 'name = "atlan-application-sdk"' in stripped
+        assert 'version = "3.28.0"' in stripped
+        assert "requires-python" in stripped
+
+    def test_result_is_parseable_and_keeps_versions(self):
+        versions = bounded.lock_versions(bounded.strip_options(LOCK_WITH_OPTIONS))
+        assert versions["atlan-application-sdk"] == "3.28.0"
+        assert versions["boto3"] == "1.43.67"
+
+    def test_lock_without_options_is_left_byte_identical(self):
+        # The common case once a repo is on the bounded lane but a refresh
+        # produced no [options] — the strip must not churn the file.
+        original = lock(boto3="1.43.67")
+        assert bounded.strip_options(original) == original
+
+
+class TestLockVersions:
+    def test_skips_non_registry_sources(self):
+        # The workspace member itself has no registry version to compare.
+        assert "hello-world-app" not in bounded.lock_versions(LOCK_WITH_OPTIONS)
+
+    def test_normalises_names(self):
+        assert bounded.lock_versions(lock(Typing_Inspection="0.4.2")) == {
+            "typing-inspection": "0.4.2"
+        }
+
+    def test_malformed_toml_is_empty_not_an_exception(self):
+        assert bounded.lock_versions("[[package]\nname = ") == {}
+
+
+class TestFlooredPackages:
+    def test_reads_constraint_dependencies_and_project_dependencies(self):
+        pyproject = """\
+[project]
+name = "app"
+dependencies = ["atlan-application-sdk>=3.27.2", "orjson"]
+
+[project.optional-dependencies]
+dev = ["pytest>=8"]
+
+[tool.uv]
+constraint-dependencies = ["cryptography>=46.0.5", "protobuf>=6.33.5"]
+"""
+        assert bounded.floored_packages(pyproject) == {
+            "atlan-application-sdk",
+            "orjson",
+            "pytest",
+            "cryptography",
+            "protobuf",
+        }
+
+    def test_malformed_pyproject_is_empty_not_an_exception(self):
+        assert bounded.floored_packages("[project\nname =") == set()
+
+
+class TestBlockedByFloor:
+    def test_intersects_the_error_with_deliberate_floors_only(self):
+        stderr = (
+            "error: No solution found when resolving dependencies:\n"
+            "  Because only cryptography<=46.0.4 is available and your project "
+            "requires cryptography>=46.0.5, we can conclude that ...\n"
+        )
+        floors = {"cryptography", "protobuf"}
+        assert bounded.blocked_by_floor(stderr, floors) == ["cryptography"]
+
+    def test_ignores_packages_the_repo_never_floored(self):
+        # uv names plenty of packages in a resolution trace; only floored ones
+        # may be admitted early, so an unrelated mention can never widen the bound.
+        stderr = "Because only boto3<=1.43.60 is available ..."
+        assert bounded.blocked_by_floor(stderr, {"cryptography"}) == []
+
+    def test_no_floors_means_nothing_to_admit(self):
+        assert bounded.blocked_by_floor("Because only cryptography...", set()) == []
+
+
+class TestRollbacks:
+    def test_flags_an_exempt_package_resolved_backwards(self):
+        # The observed failure: SDK 3.28.0 needs pyatlan>=10, pyatlan 10 is inside
+        # the window, so uv backtracks to 3.27.2 with no error.
+        found = bounded.rollbacks(
+            {"atlan-application-sdk": "3.28.0"},
+            {"atlan-application-sdk": "3.27.2"},
+            ["atlan-application-sdk"],
+        )
+        assert found == {"atlan-application-sdk": ("3.28.0", "3.27.2")}
+
+    def test_ignores_third_party_moving_backwards(self):
+        # That is the bound working as intended, not a fault.
+        assert (
+            bounded.rollbacks(
+                {"boto3": "1.43.72"}, {"boto3": "1.43.67"}, ["atlan-application-sdk"]
+            )
+            == {}
+        )
+
+    def test_unchanged_and_forward_moves_are_clean(self):
+        before = {"pyatlan": "10.0.0", "atlan-application-sdk": "3.27.2"}
+        after = {"pyatlan": "10.0.0", "atlan-application-sdk": "3.28.0"}
+        assert (
+            bounded.rollbacks(before, after, ["pyatlan", "atlan-application-sdk"]) == {}
+        )
+
+    def test_unparseable_version_is_reported_rather_than_ignored(self):
+        found = bounded.rollbacks(
+            {"pyatlan": "10.0.0"}, {"pyatlan": "not-a-version"}, ["pyatlan"]
+        )
+        assert "pyatlan" in found
+
+    def test_missing_on_either_side_is_not_a_rollback(self):
+        assert bounded.rollbacks({}, {"pyatlan": "10.0.0"}, ["pyatlan"]) == {}
+        assert bounded.rollbacks({"pyatlan": "10.0.0"}, {}, ["pyatlan"]) == {}
+
+    def test_compares_numerically_not_lexically(self):
+        # "1.43.9" > "1.43.67" as strings; as versions it is a rollback.
+        assert bounded.rollbacks(
+            {"boto3": "1.43.67"}, {"boto3": "1.43.9"}, ["boto3"]
+        ) == {"boto3": ("1.43.67", "1.43.9")}
+
+
+class TestBuildUvCommand:
+    def test_bound_and_one_exemption_flag_per_package(self):
+        assert bounded.build_uv_command(
+            "P7D", ["atlan-application-sdk", "pyatlan"]
+        ) == [
+            "uv",
+            "lock",
+            "--upgrade",
+            "--exclude-newer",
+            "P7D",
+            "--exclude-newer-package",
+            "atlan-application-sdk=P0D",
+            "--exclude-newer-package",
+            "pyatlan=P0D",
+        ]
+
+    def test_bound_is_always_present_even_with_no_exemptions(self):
+        command = bounded.build_uv_command("P7D", [])
+        assert "--exclude-newer" in command
+        assert "--exclude-newer-package" not in command
+
+
+class TestMain:
+    """The orchestration, with uv stubbed. What matters here is that no path
+    reaches an unbounded lockfile without a non-zero exit."""
+
+    def _project(self, tmp_path: Path, lock_text: str, pyproject: str = "") -> Path:
+        (tmp_path / "uv.lock").write_text(lock_text)
+        (tmp_path / "pyproject.toml").write_text(
+            pyproject or "[project]\nname = 'app'\n"
+        )
+        return tmp_path
+
+    def test_missing_lockfile_is_a_clean_no_op(self, tmp_path):
+        assert bounded.main(["--window", "P7D", "--project-dir", str(tmp_path)]) == 0
+
+    def test_success_strips_options_from_the_committed_lock(
+        self, monkeypatch, tmp_path
+    ):
+        project = self._project(tmp_path, lock(boto3="1.43.72"))
+
+        def fake_run(command, cwd):
+            (Path(cwd) / "uv.lock").write_text(LOCK_WITH_OPTIONS)
+            return __import__("subprocess").CompletedProcess(command, 0, "", "")
+
+        monkeypatch.setattr(bounded, "run_uv_lock", fake_run)
+        assert bounded.main(["--window", "P7D", "--project-dir", str(project)]) == 0
+        assert "[options]" not in (project / "uv.lock").read_text()
+
+    def test_unsatisfiable_floor_retries_once_admitting_that_package(
+        self, monkeypatch, tmp_path
+    ):
+        project = self._project(
+            tmp_path,
+            lock(cryptography="46.0.5"),
+            "[project]\nname = 'app'\n\n[tool.uv]\n"
+            'constraint-dependencies = ["cryptography>=46.0.5"]\n',
+        )
+        calls: list[list[str]] = []
+
+        def fake_run(command, cwd):
+            calls.append(command)
+            subprocess = __import__("subprocess")
+            if len(calls) == 1:
+                return subprocess.CompletedProcess(
+                    command,
+                    1,
+                    "",
+                    "error: No solution found ... cryptography>=46.0.5 ...",
+                )
+            (Path(cwd) / "uv.lock").write_text(lock(cryptography="46.0.5"))
+            return subprocess.CompletedProcess(command, 0, "", "")
+
+        monkeypatch.setattr(bounded, "run_uv_lock", fake_run)
+        assert bounded.main(["--window", "P7D", "--project-dir", str(project)]) == 0
+        assert len(calls) == 2
+        assert "cryptography=P0D" in calls[1]
+
+    def test_failure_with_no_floor_named_does_not_retry_and_fails(
+        self, monkeypatch, tmp_path
+    ):
+        project = self._project(tmp_path, lock(boto3="1.43.72"))
+        calls: list[list[str]] = []
+
+        def fake_run(command, cwd):
+            calls.append(command)
+            return __import__("subprocess").CompletedProcess(
+                command, 1, "", "error: something else entirely"
+            )
+
+        monkeypatch.setattr(bounded, "run_uv_lock", fake_run)
+        assert bounded.main(["--window", "P7D", "--project-dir", str(project)]) == 1
+        assert len(calls) == 1, "must not retry blind, and must never resolve unbounded"
+
+    def test_silent_rollback_of_an_exempt_package_fails_the_run(
+        self, monkeypatch, tmp_path
+    ):
+        project = self._project(tmp_path, lock(atlan_application_sdk="3.28.0"))
+
+        def fake_run(command, cwd):
+            (Path(cwd) / "uv.lock").write_text(lock(atlan_application_sdk="3.27.2"))
+            return __import__("subprocess").CompletedProcess(command, 0, "", "")
+
+        monkeypatch.setattr(bounded, "run_uv_lock", fake_run)
+        exit_code = bounded.main(
+            [
+                "--window",
+                "P7D",
+                "--exempt",
+                "atlan-application-sdk",
+                "--project-dir",
+                str(project),
+            ]
+        )
+        assert exit_code == 1

--- a/.github/scripts/tests/test_renovate_uv_lock_bounded.py
+++ b/.github/scripts/tests/test_renovate_uv_lock_bounded.py
@@ -115,13 +115,33 @@ dev = ["pytest>=8"]
 [tool.uv]
 constraint-dependencies = ["cryptography>=46.0.5", "protobuf>=6.33.5"]
 """
+        # "orjson" is a bare name with no version specifier, so it is NOT a floor.
         assert bounded.floored_packages(pyproject) == {
             "atlan-application-sdk",
-            "orjson",
             "pytest",
             "cryptography",
             "protobuf",
         }
+
+    def test_bare_name_without_a_specifier_is_not_a_floor(self):
+        # A requirement with no version constraint pins nothing, so it must not be
+        # treated as a deliberate floor the cooldown should yield to.
+        pyproject = """\
+[project]
+name = "app"
+dependencies = ["orjson", "requests"]
+"""
+        assert bounded.floored_packages(pyproject) == set()
+
+    def test_exact_pin_counts_as_a_floor(self):
+        pyproject = """\
+[project]
+name = "app"
+dependencies = ["orjson==3.10.7", "urllib3~=2.2"]
+"""
+        # "==" is an exact pin (a floor); "~=" is a compatible-release range, not
+        # an explicit lower-bound/exact pin, so it is not treated as a floor.
+        assert bounded.floored_packages(pyproject) == {"orjson"}
 
     def test_malformed_pyproject_is_empty_not_an_exception(self):
         assert bounded.floored_packages("[project\nname =") == set()
@@ -395,6 +415,33 @@ class TestMain:
         monkeypatch.setattr(bounded, "run_uv_lock", fake_run)
         assert bounded.main(["--window", "P7D", "--project-dir", str(project)]) == 1
         assert len(calls) == 1, "must not retry blind, and must never resolve unbounded"
+
+    def test_bare_dep_named_in_error_does_not_get_a_p0d_exemption(
+        self, monkeypatch, tmp_path
+    ):
+        """The fail-open seam from the review: a bare dependency (no version
+        specifier) is not a floor, so its mere mention in uv's stderr must NOT earn
+        it a P0D exemption that bypasses the window. The driver must fail rather
+        than retry with the bound relaxed for that package."""
+        project = self._project(
+            tmp_path,
+            lock(orjson="3.10.7"),
+            "[project]\nname = 'app'\ndependencies = ['orjson']\n",
+        )
+        calls: list[list[str]] = []
+
+        def fake_run(command, cwd):
+            calls.append(command)
+            return __import__("subprocess").CompletedProcess(
+                command, 1, "", "error: No solution found ... orjson ..."
+            )
+
+        monkeypatch.setattr(bounded, "run_uv_lock", fake_run)
+        assert bounded.main(["--window", "P7D", "--project-dir", str(project)]) == 1
+        assert len(calls) == 1, "a bare dep is not a floor, so no P0D retry"
+        assert not any(
+            "orjson=P0D" in part for command in calls for part in command
+        ), "orjson must never be exempted inside the window"
 
     def test_ceilings_come_from_head_not_the_working_tree(self, monkeypatch, tmp_path):
         """The single most important property in this file.

--- a/.github/scripts/tests/test_renovate_uv_lock_bounded.py
+++ b/.github/scripts/tests/test_renovate_uv_lock_bounded.py
@@ -154,6 +154,21 @@ dependencies = ["foo; python_version >= \\"3.10\\"", "bar>=1.0; python_version >
 """
         assert bounded.floored_packages(pyproject) == {"bar"}
 
+    def test_direct_reference_url_is_not_a_floor(self):
+        # The `==`/`>=` here live in the URL, not the version specifier, so a
+        # direct-reference dependency must not be misread as floored. The PEP 508
+        # parse separates the URL from the (empty) specifier.
+        pyproject = """\
+[project]
+name = "app"
+dependencies = [
+    "foo @ https://example.example/pkg.tar.gz?constraint==1",
+    "bar @ https://example.example/bar.whl ; python_version >= \\"3.10\\"",
+    "baz>=2.0",
+]
+"""
+        assert bounded.floored_packages(pyproject) == {"baz"}
+
     def test_malformed_pyproject_is_empty_not_an_exception(self):
         assert bounded.floored_packages("[project\nname =") == set()
 

--- a/.github/scripts/tests/test_renovate_uv_lock_bounded.py
+++ b/.github/scripts/tests/test_renovate_uv_lock_bounded.py
@@ -247,6 +247,24 @@ class TestRollbacks:
             {"boto3": "1.43.67"}, {"boto3": "1.43.9"}, ["boto3"]
         ) == {"boto3": ("1.43.67", "1.43.9")}
 
+    def test_flags_a_prerelease_rollback(self):
+        # A leading-digits comparison reads both as 0.62 and misses this; PEP 440
+        # orders a beta before its release, so 0.62b2 -> 0.62b1 is a rollback.
+        assert bounded.rollbacks({"a": "0.62b2"}, {"a": "0.62b1"}) == {
+            "a": ("0.62b2", "0.62b1")
+        }
+
+    def test_flags_an_epoch_rollback(self):
+        # The epoch (1!) outranks every version without one, so dropping it is a
+        # rollback even though 2.0 > 1.0 numerically.
+        assert bounded.rollbacks({"a": "1!2.0"}, {"a": "2.0"}) == {
+            "a": ("1!2.0", "2.0")
+        }
+
+    def test_a_forward_prerelease_move_is_clean(self):
+        # 0.62b1 -> 0.62b2 moves forward and must not be flagged.
+        assert bounded.rollbacks({"a": "0.62b1"}, {"a": "0.62b2"}) == {}
+
 
 class TestParseWindow:
     def test_days_and_hours(self):

--- a/.github/scripts/tests/test_renovate_uv_lock_bounded.py
+++ b/.github/scripts/tests/test_renovate_uv_lock_bounded.py
@@ -143,6 +143,17 @@ dependencies = ["orjson==3.10.7", "urllib3~=2.2"]
         # an explicit lower-bound/exact pin, so it is not treated as a floor.
         assert bounded.floored_packages(pyproject) == {"orjson"}
 
+    def test_marker_only_specifier_is_not_a_floor(self):
+        # The `>=` here constrains the interpreter, not the package, so a
+        # floor-less dependency carrying only an environment marker must not be
+        # classified as floored (and so must not earn a P0D retry exemption).
+        pyproject = """\
+[project]
+name = "app"
+dependencies = ["foo; python_version >= \\"3.10\\"", "bar>=1.0; python_version >= \\"3.10\\""]
+"""
+        assert bounded.floored_packages(pyproject) == {"bar"}
+
     def test_malformed_pyproject_is_empty_not_an_exception(self):
         assert bounded.floored_packages("[project\nname =") == set()
 

--- a/.github/scripts/tests/test_renovate_uv_lock_bounded.py
+++ b/.github/scripts/tests/test_renovate_uv_lock_bounded.py
@@ -577,6 +577,29 @@ class TestMain:
         (tmp_path / "pyproject.toml").write_text("[project]\nname = 'app'\n")
         assert bounded.main(["--window", "P7D", "--project-dir", str(tmp_path)]) == 1
 
+    def test_unreadable_head_lock_blob_fails_closed(self, monkeypatch, tmp_path):
+        # HEAD resolves, but `git show HEAD:uv.lock` fails for a reason other
+        # than "path absent" (a corrupt/missing blob). Treating that as "no
+        # baseline" would silently drop the retention ceilings and the rollback
+        # comparison — the one fail-open path left in the driver — so the run
+        # must fail closed and never reach uv.
+        project = self._project(tmp_path, lock(boto3="1.43.72"))
+        real_run = subprocess.run
+
+        def fake_git_run(command, **kwargs):
+            if command[:2] == ["git", "show"]:
+                return subprocess.CompletedProcess(
+                    command, 128, "", "fatal: bad object HEAD:uv.lock"
+                )
+            return real_run(command, **kwargs)
+
+        def fail_if_called(command, cwd):
+            raise AssertionError("uv must not run when the baseline is unreadable")
+
+        monkeypatch.setattr(bounded.subprocess, "run", fake_git_run)
+        monkeypatch.setattr(bounded, "run_uv_lock", fail_if_called)
+        assert bounded.main(["--window", "P7D", "--project-dir", str(project)]) == 1
+
     def test_repo_with_its_own_bound_is_left_completely_alone(
         self, monkeypatch, tmp_path
     ):

--- a/.github/scripts/tests/test_renovate_uv_lock_bounded.py
+++ b/.github/scripts/tests/test_renovate_uv_lock_bounded.py
@@ -9,6 +9,9 @@ red).
 
 from __future__ import annotations
 
+import datetime
+import os
+import subprocess
 import sys
 from pathlib import Path
 
@@ -155,14 +158,25 @@ class TestRollbacks:
         )
         assert found == {"atlan-application-sdk": ("3.28.0", "3.27.2")}
 
-    def test_ignores_third_party_moving_backwards(self):
-        # That is the bound working as intended, not a fault.
-        assert (
-            bounded.rollbacks(
-                {"boto3": "1.43.72"}, {"boto3": "1.43.67"}, ["atlan-application-sdk"]
-            )
-            == {}
+    def test_flags_third_party_moving_backwards(self):
+        # This test previously asserted the opposite — that a third-party
+        # downgrade was "the bound working as intended". It was not: measured on
+        # the pilot, a plain bounded resolve rolled 13 packages back against
+        # hello-world's main (boto3 1.43.72 -> 1.43.67, starlette 1.6.0 -> 1.4.1,
+        # ...) with zero upgrades. Reverting a version that was adopted because it
+        # fixed something is a worse outcome than adopting a fix seven days late,
+        # so retention ceilings prevent it and this check catches any that escape.
+        assert bounded.rollbacks({"boto3": "1.43.72"}, {"boto3": "1.43.67"}) == {
+            "boto3": ("1.43.72", "1.43.67")
+        }
+
+    def test_scoping_to_named_packages_still_works(self):
+        found = bounded.rollbacks(
+            {"boto3": "1.43.72", "starlette": "1.6.0"},
+            {"boto3": "1.43.67", "starlette": "1.4.1"},
+            ["boto3"],
         )
+        assert found == {"boto3": ("1.43.72", "1.43.67")}
 
     def test_unchanged_and_forward_moves_are_clean(self):
         before = {"pyatlan": "10.0.0", "atlan-application-sdk": "3.27.2"}
@@ -188,7 +202,84 @@ class TestRollbacks:
         ) == {"boto3": ("1.43.67", "1.43.9")}
 
 
+class TestParseWindow:
+    def test_days_and_hours(self):
+        assert bounded.parse_window("P7D") == datetime.timedelta(days=7)
+        assert bounded.parse_window("PT12H") == datetime.timedelta(hours=12)
+        assert bounded.parse_window("P1DT6H") == datetime.timedelta(days=1, hours=6)
+
+    def test_calendar_units_and_junk_are_rejected_not_approximated(self):
+        # A window that silently means something other than what it says is worse
+        # than one that fails to parse.
+        for bad in ["P1M", "P1Y", "7 days", "P", "", "PT"]:
+            try:
+                bounded.parse_window(bad)
+            except ValueError:
+                continue
+            raise AssertionError(f"{bad!r} should not parse")
+
+
+class TestLockUploadTimes:
+    def test_takes_the_newest_timestamp_across_a_package_files(self):
+        # Wheels for different platforms are published seconds apart; the ceiling
+        # has to admit every file the resolver needs, so the newest one wins.
+        text = """\
+version = 1
+
+[[package]]
+name = "boto3"
+version = "1.43.72"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://x/a.tar.gz", upload-time = "2026-08-14T19:24:48.841Z" }
+wheels = [
+    { url = "https://x/a.whl", upload-time = "2026-08-14T19:24:52.013Z" },
+    { url = "https://x/b.whl", upload-time = "2026-08-14T19:24:53.290Z" },
+]
+"""
+        times = bounded.lock_upload_times(text)
+        assert times["boto3"] == datetime.datetime(
+            2026, 8, 14, 19, 24, 53, 290000, tzinfo=datetime.timezone.utc
+        )
+
+    def test_package_without_timestamps_is_absent(self):
+        assert bounded.lock_upload_times(lock(boto3="1.43.72")) == {}
+
+
+class TestRetentionCeilings:
+    CUTOFF = datetime.datetime(2026, 8, 8, tzinfo=datetime.timezone.utc)
+
+    def test_package_older_than_the_cutoff_needs_no_ceiling(self):
+        times = {"boto3": datetime.datetime(2026, 8, 1, tzinfo=datetime.timezone.utc)}
+        assert bounded.retention_ceilings(times, self.CUTOFF) == {}
+
+    def test_package_inside_the_window_is_pinned_one_second_past_its_upload(self):
+        # One second past, so uv can keep exactly that version and take nothing
+        # newer.
+        times = {
+            "boto3": datetime.datetime(
+                2026, 8, 14, 19, 24, 53, tzinfo=datetime.timezone.utc
+            )
+        }
+        assert bounded.retention_ceilings(times, self.CUTOFF) == {
+            "boto3": "2026-08-14T19:24:54Z"
+        }
+
+
 class TestBuildUvCommand:
+    def test_retention_ceilings_become_per_package_flags(self):
+        command = bounded.build_uv_command("P7D", [], {"boto3": "2026-08-14T19:24:54Z"})
+        assert "--exclude-newer-package" in command
+        assert "boto3=2026-08-14T19:24:54Z" in command
+
+    def test_exemption_wins_over_a_ceiling_for_the_same_package(self):
+        # A first-party package must be free to move FORWARD, not merely held
+        # where it is — so it must not also carry a retention ceiling.
+        command = bounded.build_uv_command(
+            "P7D", ["pyatlan"], {"pyatlan": "2026-08-13T09:46:02Z"}
+        )
+        assert "pyatlan=P0D" in command
+        assert "pyatlan=2026-08-13T09:46:02Z" not in command
+
     def test_bound_and_one_exemption_flag_per_package(self):
         assert bounded.build_uv_command(
             "P7D", ["atlan-application-sdk", "pyatlan"]
@@ -215,10 +306,30 @@ class TestMain:
     reaches an unbounded lockfile without a non-zero exit."""
 
     def _project(self, tmp_path: Path, lock_text: str, pyproject: str = "") -> Path:
+        """A real git repo with the lock committed.
+
+        Committing matters: the driver reads its baseline from `HEAD:uv.lock`,
+        not the working tree, and a fixture that skipped the commit would let a
+        regression in that distinction pass unnoticed — while in production it
+        would neutralise the whole bound.
+        """
         (tmp_path / "uv.lock").write_text(lock_text)
         (tmp_path / "pyproject.toml").write_text(
             pyproject or "[project]\nname = 'app'\n"
         )
+        env = {
+            "GIT_AUTHOR_NAME": "t",
+            "GIT_AUTHOR_EMAIL": "t@t",
+            "GIT_COMMITTER_NAME": "t",
+            "GIT_COMMITTER_EMAIL": "t@t",
+            "PATH": os.environ.get("PATH", ""),
+        }
+        for command in (
+            ["git", "init", "-q"],
+            ["git", "add", "-A"],
+            ["git", "commit", "-qm", "baseline"],
+        ):
+            subprocess.run(command, cwd=tmp_path, check=True, env=env)
         return tmp_path
 
     def test_missing_lockfile_is_a_clean_no_op(self, tmp_path):
@@ -227,7 +338,10 @@ class TestMain:
     def test_success_strips_options_from_the_committed_lock(
         self, monkeypatch, tmp_path
     ):
-        project = self._project(tmp_path, lock(boto3="1.43.72"))
+        # Baseline matches what the stubbed resolve returns, so this test
+        # exercises the strip alone — a baseline of 1.43.72 would now (correctly)
+        # trip the rollback check instead.
+        project = self._project(tmp_path, lock(boto3="1.43.67"))
 
         def fake_run(command, cwd):
             (Path(cwd) / "uv.lock").write_text(LOCK_WITH_OPTIONS)
@@ -281,6 +395,83 @@ class TestMain:
         monkeypatch.setattr(bounded, "run_uv_lock", fake_run)
         assert bounded.main(["--window", "P7D", "--project-dir", str(project)]) == 1
         assert len(calls) == 1, "must not retry blind, and must never resolve unbounded"
+
+    def test_ceilings_come_from_head_not_the_working_tree(self, monkeypatch, tmp_path):
+        """The single most important property in this file.
+
+        By the time this driver runs, Renovate has already rewritten the working
+        tree's uv.lock to latest-of-everything. If the baseline were read from
+        there, every one of those fresh releases would get a retention ceiling
+        pinning it in place, and the release-age window would be worth nothing —
+        while every check still passed. So: commit an OLD lock, dirty the working
+        tree with a FRESH one, and assert the ceiling names the old version.
+        """
+        old_upload = "2020-01-01T00:00:00Z"
+        committed = (
+            'version = 1\n\n[[package]]\nname = "boto3"\nversion = "1.0.0"\n'
+            'source = { registry = "https://pypi.org/simple" }\n'
+            f'sdist = {{ url = "https://x/a.tar.gz", upload-time = "{old_upload}" }}\n'
+        )
+        project = self._project(tmp_path, committed)
+
+        fresh_upload = (
+            datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(hours=1)
+        ).strftime("%Y-%m-%dT%H:%M:%SZ")
+        (project / "uv.lock").write_text(
+            'version = 1\n\n[[package]]\nname = "boto3"\nversion = "9.9.9"\n'
+            'source = { registry = "https://pypi.org/simple" }\n'
+            f'sdist = {{ url = "https://x/z.tar.gz", upload-time = "{fresh_upload}" }}\n'
+        )
+
+        seen: list[list[str]] = []
+
+        def fake_run(command, cwd):
+            seen.append(command)
+            (Path(cwd) / "uv.lock").write_text(committed)
+            return subprocess.CompletedProcess(command, 0, "", "")
+
+        monkeypatch.setattr(bounded, "run_uv_lock", fake_run)
+        assert bounded.main(["--window", "P7D", "--project-dir", str(project)]) == 0
+
+        # boto3's committed version is from 2020, comfortably outside the window,
+        # so it needs no ceiling. Had the baseline been the working tree, the
+        # hour-old 9.9.9 would have produced one.
+        flags = [a for a in seen[0] if a.startswith("boto3=")]
+        assert flags == [], f"unexpected ceiling from the working tree: {flags}"
+
+    def test_ceiling_is_emitted_for_a_recently_adopted_package(
+        self, monkeypatch, tmp_path
+    ):
+        recent = (
+            datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=2)
+        ).strftime("%Y-%m-%dT%H:%M:%SZ")
+        committed = (
+            'version = 1\n\n[[package]]\nname = "boto3"\nversion = "1.43.72"\n'
+            'source = { registry = "https://pypi.org/simple" }\n'
+            f'sdist = {{ url = "https://x/a.tar.gz", upload-time = "{recent}" }}\n'
+        )
+        project = self._project(tmp_path, committed)
+        seen: list[list[str]] = []
+
+        def fake_run(command, cwd):
+            seen.append(command)
+            (Path(cwd) / "uv.lock").write_text(committed)
+            return subprocess.CompletedProcess(command, 0, "", "")
+
+        monkeypatch.setattr(bounded, "run_uv_lock", fake_run)
+        assert bounded.main(["--window", "P7D", "--project-dir", str(project)]) == 0
+        assert any(a.startswith("boto3=2") for a in seen[0]), seen[0]
+
+    def test_unresolvable_head_fails_closed(self, tmp_path):
+        # Not a git repo: we cannot tell what was previously adopted, and
+        # proceeding without ceilings would silently reintroduce rollbacks.
+        (tmp_path / "uv.lock").write_text(lock(boto3="1.43.72"))
+        (tmp_path / "pyproject.toml").write_text("[project]\nname = 'app'\n")
+        assert bounded.main(["--window", "P7D", "--project-dir", str(tmp_path)]) == 1
+
+    def test_rejects_an_unparseable_window_before_running_uv(self, tmp_path):
+        project = self._project(tmp_path, lock(boto3="1.43.72"))
+        assert bounded.main(["--window", "P1M", "--project-dir", str(project)]) == 1
 
     def test_silent_rollback_of_an_exempt_package_fails_the_run(
         self, monkeypatch, tmp_path

--- a/.github/scripts/tests/test_renovate_uv_lock_bounded.py
+++ b/.github/scripts/tests/test_renovate_uv_lock_bounded.py
@@ -173,6 +173,23 @@ dependencies = [
         assert bounded.floored_packages("[project\nname =") == set()
 
 
+class TestDeclaresOwnBound:
+    def test_detects_either_key(self):
+        assert bounded.declares_own_bound('[tool.uv]\nexclude-newer = "P7D"\n')
+        assert bounded.declares_own_bound(
+            '[tool.uv]\nexclude-newer-package = { pyatlan = "P0D" }\n'
+        )
+
+    def test_absent_or_unrelated_tool_uv_is_not_a_bound(self):
+        assert not bounded.declares_own_bound("[project]\nname = 'app'\n")
+        assert not bounded.declares_own_bound(
+            '[tool.uv]\ndefault-groups = ["dev"]\nconstraint-dependencies = ["x>=1"]\n'
+        )
+
+    def test_malformed_pyproject_is_not_treated_as_a_bound(self):
+        assert not bounded.declares_own_bound("[tool.uv\nexclude-newer =")
+
+
 class TestBlockedByFloor:
     def test_intersects_the_error_with_deliberate_floors_only(self):
         stderr = (
@@ -559,6 +576,27 @@ class TestMain:
         (tmp_path / "uv.lock").write_text(lock(boto3="1.43.72"))
         (tmp_path / "pyproject.toml").write_text("[project]\nname = 'app'\n")
         assert bounded.main(["--window", "P7D", "--project-dir", str(tmp_path)]) == 1
+
+    def test_repo_with_its_own_bound_is_left_completely_alone(
+        self, monkeypatch, tmp_path
+    ):
+        # glue, bw, thoughtspot and dbt predate the fleet mechanism. Their lock
+        # already carries [options] matching their pyproject, so stripping it
+        # would break `uv sync --locked` in their image build — FND-367 from the
+        # other direction. Skip, do not touch, and say so.
+        original = lock(boto3="1.43.72")
+        project = self._project(
+            tmp_path,
+            original,
+            "[project]\nname = 'app'\n\n[tool.uv]\nexclude-newer = \"7 days\"\n",
+        )
+
+        def fail_if_called(command, cwd):
+            raise AssertionError("uv must not run against a repo with its own bound")
+
+        monkeypatch.setattr(bounded, "run_uv_lock", fail_if_called)
+        assert bounded.main(["--window", "P7D", "--project-dir", str(project)]) == 0
+        assert (project / "uv.lock").read_text() == original
 
     def test_rejects_an_unparseable_window_before_running_uv(self, tmp_path):
         project = self._project(tmp_path, lock(boto3="1.43.72"))

--- a/.github/scripts/tests/test_renovate_uv_lock_bounded.py
+++ b/.github/scripts/tests/test_renovate_uv_lock_bounded.py
@@ -600,6 +600,37 @@ class TestMain:
         monkeypatch.setattr(bounded, "run_uv_lock", fail_if_called)
         assert bounded.main(["--window", "P7D", "--project-dir", str(project)]) == 1
 
+    def test_lock_absent_from_head_returns_none_and_proceeds(
+        self, monkeypatch, tmp_path
+    ):
+        # A lock added in this very branch: HEAD has no committed copy, so the
+        # driver proceeds with no ceilings and no rollback comparison (the
+        # documented new-lockfile path). The fail-closed rework must NOT turn
+        # this into a failure — absence is established by `git ls-tree`
+        # succeeding empty, not by `git show` failing (which it also does for an
+        # unreadable blob).
+        project = self._project(tmp_path, lock(boto3="1.43.72"))
+        env = {
+            "GIT_AUTHOR_NAME": "t",
+            "GIT_AUTHOR_EMAIL": "t@t",
+            "GIT_COMMITTER_NAME": "t",
+            "GIT_COMMITTER_EMAIL": "t@t",
+        }
+        subprocess.run(["git", "rm", "-q", "uv.lock"], cwd=project, check=True)
+        subprocess.run(
+            ["git", "commit", "-qm", "drop the lock"], cwd=project, check=True, env=env
+        )
+        (project / "uv.lock").write_text(lock(boto3="1.43.72"))
+
+        def fake_run(command, cwd):
+            (Path(cwd) / "uv.lock").write_text(lock(boto3="1.43.72"))
+            return __import__("subprocess").CompletedProcess(command, 0, "", "")
+
+        monkeypatch.setattr(bounded, "run_uv_lock", fake_run)
+        assert bounded.main(["--window", "P7D", "--project-dir", str(project)]) == 0
+        # Absence is verifiable: the tree probe is what returned None.
+        assert bounded.baseline_lock_text(project) is None
+
     def test_repo_with_its_own_bound_is_left_completely_alone(
         self, monkeypatch, tmp_path
     ):

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -125,6 +125,17 @@ jobs:
           sudo install -m 0755 .github/scripts/renovate_pkl_sync.py /usr/local/bin/renovate-pkl-sync
           sudo install -m 0644 .github/scripts/pkl_contract_layout.py /usr/local/bin/pkl_contract_layout.py
 
+      # The release-age driver for the lock-refresh lane (FND-359), installed the
+      # same way and for the same reason: postUpgradeTasks commands are not
+      # shell-expanded, so the preset invokes `renovate-uv-lock-bounded` as a bare
+      # PATH command. Single-file with no sibling imports, so unlike the pkl-sync
+      # driver above there is nothing else to place beside it. If this step is
+      # ever dropped, the command 404s, Renovate reports an artifact error, and
+      # the auto-approve gate withholds approval — the lock does not silently
+      # refresh unbounded (FND-367).
+      - name: Install release-age lock driver on PATH
+        run: sudo install -m 0755 .github/scripts/renovate_uv_lock_bounded.py /usr/local/bin/renovate-uv-lock-bounded
+
       # Provides `uv`/`uvx` — used by Renovate's native uv manager to refresh
       # uv.lock AND by the driver's `uvx ruff` formatting of generated Python.
       - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1

--- a/docs/standards/ci.md
+++ b/docs/standards/ci.md
@@ -168,6 +168,41 @@ it, or kept out of that file in the first place.
 `export_extra_env.py` and `test_export_extra_env.py` are the worked example,
 including a static check that every call site masks before it writes.
 
+## Renovate post-upgrade commands
+
+Two run today, both installed as bare PATH commands by `.github/workflows/renovate.yaml`
+and both declared in `renovate-config/default.json`:
+
+| command | lane | what it does |
+|---|---|---|
+| `renovate-pkl-sync` | `app-contract-toolkit` | re-resolves the Pkl lock and regenerates contract artifacts |
+| `renovate-uv-lock-bounded` | `lockFileMaintenance` | re-resolves `uv.lock` under the org §5 release-age bound, then strips uv's `[options]` block |
+
+Three rules apply to any command added here.
+
+**No `${VARS}`.** Renovate does not shell-expand post-upgrade commands, so a
+variable is passed through literally. Everything the command needs must be a
+literal argument.
+
+**Every command needs a matching regex in `allowedCommands`** in
+`renovate-config/self-hosted.js` — an admin-only option, which is why the fleet
+runs a self-hosted runner at all. A command the allowlist does not match is
+**skipped with a log line and nothing else**, so the drift is invisible exactly
+when it matters: in FND-367 a bound that was not yet allowlisted meant the lock
+refreshed unbounded and took a package published three minutes earlier, with
+nothing red anywhere. `.github/scripts/check_renovate_allowed_commands.py`
+asserts the preset↔allowlist pairing in CI for that reason. Keep allowlist
+entries free of character classes and backslashes: a `]` truncates the array the
+guard parses, and `"\d"` in a JS string literal is just `"d"`.
+
+**Anything that writes a lockfile must leave it valid for every consumer.** uv
+records its resolver settings into `uv.lock` under `[options]`, and every
+`uv sync --locked` compares its own settings against that block — so a bound
+applied at lock time and left recorded makes the lock unusable in the app
+Dockerfiles. That is what reddened `scan / Build Image` fleet-wide in #3212. The
+bounded driver strips the block; if you add another lock-writing command, check
+what it records.
+
 ## Reusing scripts from a reusable workflow
 
 A `uses:` reusable workflow does **not** bring its own repo's files into the

--- a/renovate-config/default.json
+++ b/renovate-config/default.json
@@ -15,6 +15,10 @@
   "statusCheckWhen": {
     "artifactError": "always"
   },
+  "vulnerabilityAlerts": {
+    "description": "Security updates bypass the release-age cooldown (FND-359). A cooldown that also delayed known-CVE fixes would be indefensible — and it is why the cooldown's actual value is narrower than it looks: it buys detection time against releases nobody knows are bad yet, NOT against published advisories, which this rule lets straight through. Renovate keys this off the platform's own vulnerability alerts, so it needs no maintained exemption list, which is the property that matters — the fleet's previous cooldowns died of hand-dated per-package exemptions rotting in each repo's pyproject.toml. Note the gap this cannot close: an upstream fix that ships BEFORE an advisory exists looks like an ordinary release and is delayed the full window. That is the real cost of the cooldown, and the argument for a shorter one.",
+    "minimumReleaseAge": null
+  },
   "prHourlyLimit": 0,
   "prConcurrentLimit": 8,
   "labels": [
@@ -32,7 +36,7 @@
     "github-actions[bot]@users.noreply.github.com"
   ],
   "lockFileMaintenance": {
-    "description": "Python in-range deps: refresh uv.lock without touching pyproject.toml; auto-merge on green. This lane's rung on the prPriority ladder is set by a packageRule below (matchUpdateTypes: lockFileMaintenance), NOT here: prPriority is only honoured inside packageRules, so setting it in this object is silently ignored — it sat here until FND-359 and the lane ran at the default priority the whole time. NO RELEASE-AGE BOUND, deliberately (FND-367). A 7-day cooldown was tried here twice and removed: Renovate cannot age-check a lockFileMaintenance update at all (it delegates resolution to uv, and uv is not passed a bound — renovatebot/renovate#41652), so the bound had to be expressed in uv itself, and uv records its resolver settings into uv.lock under `[options]`, where every consumer that validates the lock compares them against its own. Passed as a postUpgradeTasks flag it produced locks that `uv sync --locked` rejected fleet-wide; declared in each repo's `[tool.uv]` it worked, but only at the cost of a per-repo stanza in every connector. The decisive argument was not mechanical though: this fleet fixes vulnerabilities by keeping dependencies continuously current, so a release-age bound on this lane is a delay on every security fix, in exchange for a supply-chain window that no plausible duration meaningfully closes. Note what this does NOT protect against, so nobody reintroduces the bound expecting it to: a release published minutes ago can land here, and if it changes behaviour our tests must catch it. When that happens the fix is the test, not a wait — the case that prompted all this was a test asserting a third-party parser's exact error column.",
+    "description": "Python in-range deps: refresh uv.lock without touching pyproject.toml; auto-merge on green. This lane's rung on the prPriority ladder is set by a packageRule below (matchUpdateTypes: lockFileMaintenance), NOT here: prPriority is only honoured inside packageRules, so setting it in this object is silently ignored — it sat here until FND-359 and the lane ran at the default priority the whole time. RELEASE-AGE BOUND (FND-359): this is the one lane that upgrades to latest with no human in the loop, and the only channel through which transitive dependencies reach a connector at all, so it is the only lane that carries the org §5 cooldown. Renovate cannot age-check it itself — it delegates resolution to uv and passes no bound (renovatebot/renovate#41652) — so the bound is applied by re-resolving in postUpgradeTasks. Two earlier attempts failed and the differences matter: passing `--exclude-newer` alone leaves uv's resolver settings recorded in uv.lock under `[options]`, which every consumer running `uv sync --locked` then rejects as stale (that is what reddened scan / Build Image fleet-wide in #3212); declaring it in each repo's `[tool.uv]` fixes that but bounds EVERY resolve in the repo, including the /fix-vulnerabilities workflow that is how a CVE fix actually lands. The driver below does both halves: bounded resolve, then strip `[options]` — so the lock's content is bounded while its recorded settings stay default. Deliberately NOT bounded, because the bound lives in this command and nowhere else: a human's `uv lock`, `/fix-vulnerabilities`, and each package's own Renovate lane. That asymmetry is the design, not an oversight — the cooldown buys detection time against releases nobody knows are bad yet, and has no business slowing down someone who has decided to take a specific version. On the --exempt set: it must cover the dependency CLOSURE of a first-party release, not just the names we publish. pyatlan is in it for that reason and must not be dropped — with only the two SDK packages exempted, atlan-application-sdk 3.28.0 became unresolvable (it requires pyatlan>=10, and pyatlan 10.0.0 was inside the window) and uv silently backtracked to 3.27.2. A bounded resolve does not fail when it cannot reach a package; it quietly picks an older one, so unattended that would auto-merge an SDK downgrade fleet-wide. The driver refuses to commit a lock where an exempt package moved backwards, which is the backstop if this list ever goes stale.",
     "enabled": true,
     "schedule": [
       "at any time"
@@ -42,7 +46,16 @@
     "platformAutomerge": true,
     "addLabels": [
       "update:lock-maintenance"
-    ]
+    ],
+    "postUpgradeTasks": {
+      "commands": [
+        "renovate-uv-lock-bounded --window P7D --exempt atlan-application-sdk --exempt atlan-application-sdk-conformance --exempt pyatlan"
+      ],
+      "fileFilters": [
+        "uv.lock"
+      ],
+      "executionMode": "branch"
+    }
   },
   "packageRules": [
     {
@@ -56,14 +69,30 @@
       "enabled": false
     },
     {
-      "description": "SDK lane: give atlan-application-sdk bumps their own uv.lock-only PR (rangeStrategy update-lockfile, mirroring the conformance-package rule) instead of riding the batched lockFileMaintenance refresh — a stale lock-refresh branch that is not behind main never re-resolves, so it can sit pinned one SDK release behind indefinitely. prPriority 10: when prConcurrentLimit is contended, the SDK PR is created before every other dependency PR (Renovate cannot exempt a package from the limit; priority ordering + the bounded lanes below are the substitute). Deliberately NOT auto-merged — runtime SDK bumps stay human-reviewed, matching the python-dep policy. The sdk-package-update label is the fleet scanner's classification signal.",
+      "description": "SDK lane: give atlan-application-sdk bumps their own uv.lock-only PR (rangeStrategy update-lockfile, mirroring the conformance-package rule) instead of riding the batched lockFileMaintenance refresh — a stale lock-refresh branch that is not behind main never re-resolves, so it can sit pinned one SDK release behind indefinitely. prPriority 10: when prConcurrentLimit is contended, the SDK PR is created before every other dependency PR (Renovate cannot exempt a package from the limit; priority ordering + the bounded lanes below are the substitute). Auto-merged on green as of FND-359: an SDK release must reach the fleet in minutes, and now that the lock-refresh lane is release-age bounded this is the only lane that can deliver it promptly. A repo not ready for that opts OUT in its own renovate.json, since repo-local packageRules are appended after this preset's and later matching rules win: {matchPackageNames: ['atlan-application-sdk'], automerge: false, platformAutomerge: false}. Set it inside a packageRule — a top-level automerge:false will not override this. The soft-mode bootstrap template already opts every package out this way. minimumReleaseAge is explicitly null: first-party releases are never subject to the cooldown. The sdk-package-update label is the fleet scanner's classification signal.",
       "matchPackageNames": [
         "atlan-application-sdk"
       ],
       "rangeStrategy": "update-lockfile",
       "prPriority": 10,
+      "automerge": true,
+      "automergeType": "pr",
+      "platformAutomerge": true,
+      "minimumReleaseAge": null,
       "addLabels": [
         "sdk-package-update"
+      ]
+    },
+    {
+      "description": "pyatlan lane (FND-359): Atlan-published, so it is first-party for cooldown purposes and gets its own uv.lock-only PR rather than riding the bounded lock refresh. It had no lane at all until now, which meant it moved only via lockFileMaintenance — and under the release-age bound that would have made it the one first-party package delayed a week. It is also load-bearing for the SDK: SDK releases track pyatlan majors, so a held-back pyatlan silently holds back the SDK too (see the lockFileMaintenance description). Not auto-merged: pyatlan majors carry real API change (9.x -> 10.x landed in the fleet as an in-range lock bump, unreviewed, which is precisely what this lane exists to stop), so these stay human-reviewed while still being immediate to raise.",
+      "matchPackageNames": [
+        "pyatlan"
+      ],
+      "rangeStrategy": "update-lockfile",
+      "prPriority": 9,
+      "minimumReleaseAge": null,
+      "addLabels": [
+        "pyatlan-package-update"
       ]
     },
     {
@@ -139,13 +168,31 @@
       "prPriority": 5
     },
     {
-      "description": "Lane model: group every OTHER PyPI dependency's non-major updates into ONE rolling PR. With bounded lanes — SDK (1) + conformance (1) + contract-toolkit (1) + lock maintenance (1) + this group (1) + github-actions (1) — the crowd occupies a single prConcurrentLimit slot and can never starve the critical lanes, which soft-mode repos previously hit: 5 human-review dep PRs squatting every slot meant an SDK bump PR was simply never created. Excludes the packages with dedicated lanes above.",
+      "description": "Release-age cooldown for third-party PyPI packages on the lanes Renovate can actually age-check (FND-359). Upstream exempts lockFileMaintenance, lockfileUpdate, pin, bump, rollback and replacement from minimumReleaseAge, so this covers only the lanes where Renovate itself picks the version; the lock-refresh lane carries its own bound via postUpgradeTasks. matchUpdateTypes is a positive ALLOWLIST rather than a blanket match on purpose: minimumReleaseAgeBehaviour defaults to timestamp-required, so an update type with no release timestamp counts as never-aged and a blanket rule would suppress those lanes permanently rather than delay them. Failing open that way (a newly-supported type is merely not yet cooled down) is the right direction for a rule whose job is to delay, not to block. First-party packages are excluded here and set minimumReleaseAge: null in their own lanes above — belt and braces, since rule order decides. docker is deliberately absent: base-image bumps are mostly CVE patches, so a week's hold is a net security loss, and the docker timestamp is the publisher-controlled org.opencontainers.image.created annotation, which Renovate's own docs flag as bypassable.",
       "matchDatasources": [
         "pypi"
       ],
       "matchPackageNames": [
         "!atlan-application-sdk",
-        "!atlan-application-sdk-conformance"
+        "!atlan-application-sdk-conformance",
+        "!pyatlan"
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor",
+        "patch"
+      ],
+      "minimumReleaseAge": "7 days"
+    },
+    {
+      "description": "Lane model: group every OTHER PyPI dependency's non-major updates into ONE rolling PR. With bounded lanes — SDK (1) + conformance (1) + pyatlan (1) + contract-toolkit (1) + lock maintenance (1) + this group (1) + github-actions (1) — the crowd occupies a single prConcurrentLimit slot and can never starve the critical lanes, which soft-mode repos previously hit: 5 human-review dep PRs squatting every slot meant an SDK bump PR was simply never created. Excludes the packages with dedicated lanes above.",
+      "matchDatasources": [
+        "pypi"
+      ],
+      "matchPackageNames": [
+        "!atlan-application-sdk",
+        "!atlan-application-sdk-conformance",
+        "!pyatlan"
       ],
       "matchUpdateTypes": [
         "minor",
@@ -163,7 +210,8 @@
       ],
       "matchPackageNames": [
         "!atlan-application-sdk",
-        "!atlan-application-sdk-conformance"
+        "!atlan-application-sdk-conformance",
+        "!pyatlan"
       ],
       "matchUpdateTypes": [
         "major"

--- a/renovate-config/self-hosted.js
+++ b/renovate-config/self-hosted.js
@@ -55,23 +55,34 @@ module.exports = {
   // match is skipped with a log line and nothing else, so the failure is silent
   // — .github/scripts/check_renovate_allowed_commands.py guards the pairing.
   //
-  // A `uv lock --exclude-newer` entry briefly lived in this list (FND-367), to
-  // enforce a 7-day dependency cooldown on the lock-refresh lane. It is gone, and
-  // nothing should replace it. Two reasons, in increasing order of importance.
+  // The release-age driver: applies the org §5 cooldown to the lock-refresh lane
+  // by re-resolving under `--exclude-newer` and then stripping uv's `[options]`
+  // block, so the lock's CONTENT is bounded while its recorded resolver settings
+  // stay default and `uv sync --locked` still validates downstream. See the
+  // lockFileMaintenance description in default.json for why the bound lives in
+  // this command rather than in every repo's pyproject.toml.
   //
-  // Mechanically, this list is a bad home for a security control: a command the
-  // allowlist does not match is skipped with a log line and nothing else, so when
-  // a config-resolution race meant the entry was not yet live, the lock refreshed
-  // unbounded and pulled a package published three minutes earlier — with no red
+  // An earlier `uv lock --exclude-newer` entry here (FND-367) was reverted, and
+  // the reason is worth keeping in view rather than repeating: a command this
+  // allowlist does not match is skipped with a log line and nothing else. When a
+  // config-resolution race meant that entry was not yet live, the lock refreshed
+  // unbounded and pulled a package published three minutes earlier, with no red
   // check anywhere to show for it. A control whose failure mode is silent is not
-  // a control.
-  //
-  // Substantively, the cooldown itself was dropped fleet-wide. This fleet fixes
-  // vulnerabilities by keeping dependencies continuously current, so any
-  // release-age bound on this lane is a delay on every security fix — paid in
-  // exchange for a supply-chain window that no plausible duration meaningfully
-  // closes. See the lockFileMaintenance description in default.json.
+  // a control. Two things now stand behind this pairing: the preset sets
+  // statusCheckWhen.artifactError=always so a skipped/failed task publishes a red
+  // renovate/artifacts context, and renovate-auto-approve-reusable.yml withholds
+  // the atlan-ci approval unless that context is green — so a silently unbounded
+  // lock cannot auto-merge. .github/scripts/check_renovate_allowed_commands.py
+  // asserts the preset↔allowlist pairing in CI so the drift is caught earlier
+  // still. Keep the regex in step with the preset's command string, exactly.
   allowedCommands: [
     "^renovate-pkl-sync --contract-dir contract --regenerate (true|false) --no-commit$",
+    // Fully literal, deliberately: the window and the exempt set are policy, so
+    // changing either must edit this file as well as the preset, and the guard
+    // test fails until both agree. Avoid character classes and backslashes in
+    // these entries — a `]` truncates the allowlist the guard parses, and a
+    // backslash means something different to the JS string literal than to the
+    // regex ("\d" is just "d" in JS, silently breaking the pattern at runtime).
+    "^renovate-uv-lock-bounded --window P7D --exempt atlan-application-sdk --exempt atlan-application-sdk-conformance --exempt pyatlan$",
   ],
 };


### PR DESCRIPTION
Reintroduces the org security baseline §5 release-age cooldown, reverted in full by #3218 (FND-367) after #3212 broke the fleet. Lands standalone, per FND-359's ground rule — #3212 rode in with unrelated changes and could not be reverted without taking good things with it.

## The design in one line

**The bound goes in the Renovate lock-refresh command and nowhere else.**

`lockFileMaintenance` is the one lane that upgrades to latest with no human in the loop, and the only channel through which transitive dependencies reach a connector at all. So it is the only lane bounded. Every deliberate path stays unbounded: a developer's `uv lock`, the `/fix-vulnerabilities` workflow's `uv lock --upgrade-package`, and each package's own Renovate lane. A cooldown buys detection time against releases nobody knows are bad yet; it has no business slowing down someone who has decided to take a specific version.

That asymmetry is what makes the requirements satisfiable together, and it is why **no repo needs a `[tool.uv]` stanza** — zero connector PRs for the mechanism.

## What this means in practice

1. **Anything already in a repo's `uv.lock` stays**, even if it is newer than the window. The bound governs *adoption*, never *reversion*. Only exception: a yanked release is still dropped, because uv skips yanked versions when re-resolving.
2. **Going forward, Renovate only proposes third-party versions at least 7 days old.** Three deliberate bypasses: first-party packages (`atlan-application-sdk`, `atlan-application-sdk-conformance`, `pyatlan`), `vulnerabilityAlerts` security updates, and a package the repo has floored in `constraint-dependencies` when the bound would otherwise make the resolve unsatisfiable.
3. **A repo can still adopt faster, by updating its own `uv.lock` directly — and it sticks.** The bound lives only in the Renovate command, so a human's `uv lock --upgrade-package` (or `/fix-vulnerabilities`) is unbounded, and the retention ceiling then preserves the result instead of reverting it next refresh. That is the escape hatch if 7 days proves too long, at the right granularity: "adopt this version now", not "opt out of the cooldown".
4. **Repos whose locks are already current see nothing at all** until their versions age out — no PR churn, no downgrade wave. Verified: against hello-world's `main` the output is byte-identical, so Renovate commits nothing and raises no PR.

Steady state is roughly seven days behind latest, moving continuously: once a locked version ages past the window its ceiling lifts, and the newest release that is *itself* ≥7 days old becomes eligible. The window is a single parameter in two files, so shortening it later is a two-line change.

## Why this is not #3212 again

| | #3212 (reverted) | this |
|---|---|---|
| `[options]` in `uv.lock` | committed → every `uv sync --locked` rejected the lock → `scan / Build Image` red fleet-wide | stripped before commit, so the lock's *content* is bounded while its recorded settings stay default |
| CVE floor inside the window | unhandled → unsatisfiable resolve (FND-310's trap) | retries once, admitting only floored packages uv actually named, and reports them in the PR |
| command silently skipped | happened on the first run; nothing red anywhere | `renovate/artifacts` goes red (`statusCheckWhen: always`) and the approval gate withholds atlan-ci's approval — both already in the tree — plus the preset↔allowlist guard in CI |
| rollout | straight to the fleet, bundled | standalone; one pilot repo end to end before the fleet sees it |

Not different, and worth stating plainly: 7 days is still 7 days of delay on transitive fixes that are not published CVEs. What changes is that the exemption lever is *derived* rather than hand-maintained, and the window is a parameter.

## Verified, not assumed

Against `atlan-hello-world-app` at main, uv 0.12.4, running the real driver:

```
**Release-age bound applied:** `P7D` (exempt: atlan-application-sdk, atlan-application-sdk-conformance, pyatlan)
- 13 package(s) resolved below the unbounded latest
- `[options]` stripped from `uv.lock` so `uv sync --locked` still validates
```

| | bounded | unbounded |
|---|---|---|
| `atlan-application-sdk` | **3.28.0** | 3.28.0 |
| `atlan-application-sdk-conformance` | **0.19.1** | 0.19.1 |
| `pyatlan` | **10.0.0** | 10.0.0 |
| `boto3` | 1.43.67 | 1.43.72 |
| `starlette` | 1.4.1 | 1.6.0 |
| `sentry-sdk` | 2.66.1 | 2.68.0 |

`uv lock --check` and `uv sync --locked --no-install-project --no-dev` **fail before the strip** with the exact FND-367 error and **pass after it**. The `docker build` leg is safe by construction rather than luck: after the strip the lock has no `[options]` at all, byte-shape identical to today's fleet locks, so the base image's floating uv cannot fail on a key it never sees — the pilot confirms it in CI regardless.

## The bound governs adoption, never reversion

The pilot surfaced a second defect, worse than the first. A plain bounded `uv lock --upgrade` does not merely decline new releases — it re-resolves everything and **rolls back** anything already locked that was published inside the window. Against hello-world's `main`: **13 downgrades, 0 upgrades**, including `boto3 1.43.72 -> 1.43.67` and `starlette 1.6.0 -> 1.4.1`.

That is worse than the delay the cooldown exists to impose. Most transitive security uplift in this fleet arrives silently through lock maintenance with no floor ever recorded, so reverting blind can un-ship a fix that was already in place. Shipping a fix seven days late is the cost we accepted; un-shipping one is not.

Every package already in the lock now gets a ceiling derived from the `upload-time` of the version it is pinned to — which uv records for every sdist and wheel, so it is available offline. Effective ceiling is `max(now - window, that upload instant)`:

- nothing already adopted moves backwards
- nothing published inside the window is newly adopted — the control is intact
- a yanked release is still dropped, because uv skips yanked versions when re-resolving
- **a repo can adopt anything immediately by editing its own `uv.lock`, and it sticks** — the bound lives only in the Renovate command, so a human's `uv lock --upgrade-package` is unbounded, and the ceiling then preserves it

The baseline is `git show HEAD:uv.lock`, never the working tree. By the time this runs, Renovate has already refreshed the lock to latest-of-everything; deriving ceilings from *that* would pin every release Renovate pulled seconds earlier and neutralise the window entirely, while every check still passed. Unresolvable HEAD fails closed.

Re-measured, same repo and command:

| comparison | result |
|---|---|
| vs `main` | **0 downgrades, 0 upgrades — byte-identical**, so Renovate commits nothing and raises no PR |
| vs a lock 9 days stale | 12 upgrades, 0 downgrades; first-party still jumps to latest (SDK 3.26.1 → 3.28.0, pyatlan 9.11.0 → 10.0.0) |
| bounded vs unbounded | 13 releases withheld, including `orjson 3.12.0` — the FND-367 package — held at 3.11.9 |

So it bites where there is work to do, and does nothing where there is not. Repos whose locks are already current see no PR churn and no downgrade wave from this change.

The rollback check now covers every package rather than just the exempt set; its test previously asserted a third-party downgrade was "the bound working as intended", which encoded the bug, and is inverted here.

## The failure mode this surfaced

**A bounded resolve does not error when it cannot reach a package — it quietly resolves an older one.**

With only the two SDK packages exempted, `atlan-application-sdk` came out at **3.27.2, not 3.28.0**. No error, no warning. Cause: 3.28.0 requires `pyatlan>=10`, pyatlan 10.0.0 was two days old, so the bound made it invisible and uv backtracked to the last SDK release compatible with pyatlan 9. Unattended, that auto-merges an SDK *downgrade* across the fleet.

Two consequences, both encoded here:

1. **The exempt set must cover the dependency closure of a first-party release, not just the names we publish.** `pyatlan` is load-bearing — not because we want pyatlan fast, but because without it the *SDK* cannot land.
2. **The driver refuses to commit a lock where an exempt package moved backwards.** That is the backstop if the exempt set ever goes stale.

## Also here, because "first-party ships in minutes" needs them

- **SDK bumps auto-merge on green by default, with a repo-local opt-out.** Repo `packageRules` are appended after the preset's and later rules win, so a repo not ready sets `automerge: false` for the package in its own `renovate.json` — the soft-mode bootstrap template already works exactly this way. Set it inside a `packageRule`; a top-level `automerge: false` will not override.
- **`pyatlan` gets its own `update-lockfile` lane.** It had none, so it moved only via the lock refresh — under the bound that would have made it the one first-party package delayed a week. Not auto-merged: pyatlan majors carry real API change, and 9.x → 10.x already reached the fleet as an unreviewed in-range lock bump, which this lane exists to stop.
- **`minimumReleaseAge: "7 days"`** on the pypi lanes Renovate can actually age-check, as a positive allowlist of `major`/`minor`/`patch` — a blanket match would *suppress* timestamp-less update types permanently rather than delay them, since `minimumReleaseAgeBehaviour` defaults to `timestamp-required`.
- **`vulnerabilityAlerts.minimumReleaseAge: null`** so security updates bypass the cooldown with **no maintained exemption list** — the property that matters, since the fleet's previous cooldowns died of hand-dated per-package exemptions rotting in each repo's `pyproject.toml`.

## Incidental fix, called out because it is a security guard

`check_renovate_allowed_commands.py` extracted `allowedCommands` with `\[(.*?)\]`, so it stopped at the first `]` — a character class in an entry truncated the allowlist and the guard passed commands it never checked. Exactly the silent-failure class the guard exists to prevent, and adding a second entry is what exposed it. It now scans string state and skips `//` comments, with a test for each.

## Not in scope

- FND-373 — the `dep-cooldown` workflow has never run: 300/300 startup failures across ~50 repos since May 2026.
- FND-374 — `checks/dep-cooldown` has no first-party exemption, a fail-open publish-time lookup, and a >1MB contents-API trap. Under this change that check becomes the independent verifier that the bound held, so it is worth fixing.

## Rollout after merge

**Correction to an earlier draft of this body:** application-sdk is *not* its own canary here. Its dependency PRs come from Mend (`app/renovate`), and `postUpgradeTasks` only run on the self-hosted runner, because `allowedCommands` is an admin-only option. So this repo's own lock refreshes stay unbounded, and `atlan-hello-world-app` (on `atlan-app-fleet[bot]`) is the only place the mechanism can be exercised.

Pilot in two stages. Stage 1 is [atlan-hello-world-app#178](https://github.com/atlanhq/atlan-hello-world-app/pull/178), open now: a bounded, stripped `uv.lock` put through the real scan lane, answering the one question that cannot be answered locally — whether the base image's floating uv accepts it. Stage 2 is the Renovate wiring (`postUpgradeTasks` invocation, `allowedCommands` match, `fileFilters` commit, auto-merge), which needs the shared preset live and so happens on the first fleet run after this merges. Stage 2 fails closed: a skipped or failing command reds `renovate/artifacts` and the approval gate withholds the atlan-ci approval, so an unbounded lock cannot auto-merge. Then four PRs deleting the now-redundant `[tool.uv] exclude-newer` stanzas from glue, bw, thoughtspot and dbt, which would otherwise declare a bound the centrally-produced lock no longer records. Security engagement on the §5 deviation follows, with the measurements attached.

## Test plan

- [x] `uv run pytest .github/scripts/tests` — 2242 passed
- [x] `uv run pre-commit run --files ...` — including `renovate-config-validator` at the version the fleet runner pins
- [x] Driver run end to end against `atlan-hello-world-app`; both `uv lock --check` and `uv sync --locked` pass on its output
- [x] **`scan / Build Image` green on the pilot** — [hello-world#178](https://github.com/atlanhq/atlan-hello-world-app/pull/178), the check #3212 broke fleet-wide. `scan / Trivy Scan` and `scan / Security Gate` green too; both were *skipped* last time because Build Image had already failed.
- [x] **`checks/dep-cooldown` green on the pilot** — independent confirmation that the bound held, from a checker that derives its own timestamps from PyPI and knows nothing about how the lock was produced. It fails on nearly every other Renovate PR in the fleet (#172, #173, #174).
- [ ] Renovate wiring — `postUpgradeTasks` invocation, `allowedCommands` match, `fileFilters` commit, auto-merge. Cannot run before merge: Renovate resolves this preset from application-sdk's **default branch**. Exercised on the first fleet run after merge, and fails closed if anything is wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



