### PR TITLE
fix(handler): don't promote a placeholder agent-json to the typed field

### DIFF
--- a/application_sdk/handler/service.py
+++ b/application_sdk/handler/service.py
@@ -52,6 +52,7 @@ from fastapi import Query, Request, UploadFile
 from fastapi.responses import HTMLResponse, JSONResponse, Response
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel as PydanticBaseModel
+from pydantic import ValidationError
 from temporalio.client import WorkflowFailureError
 
 from application_sdk._runtime.offload import run_in_thread
@@ -186,6 +187,96 @@ def _rank_agent_json(raw: Any, key: str) -> int:
     return (2 if isinstance(raw, dict) else 0) + (1 if key == "agent-json" else 0)
 
 
+def _parses_as_agent_spec(candidate: dict[str, Any]) -> bool:
+    """Whether *candidate* is a well-formed :class:`AgentCredentialSpec`.
+
+    A rendered-but-unfilled agent widget submits every field name as its own
+    value (``{"agent-name": "agent-name", "host": "host", "port": "port", …}``).
+    ``port`` is the spec's only non-``str`` field, so such a payload is coercible
+    to a dict yet fails typed validation. Promoting it to the typed ``agent_json``
+    field therefore turns an optional, unused widget into an unhandled
+    ``ValidationError`` — a 500 on *every* direct-mode request whose form renders
+    the widget, surfacing to the caller as an opaque JSON-decode error rather
+    than anything actionable.
+
+    ``ExtractionInput._skip_agent_json_for_direct`` already discards these on the
+    extraction path for exactly this reason; this is the handler-path equivalent.
+    """
+    from application_sdk.credentials.spec import (  # noqa: PLC0415 — avoid import cycle at module load
+        AgentCredentialSpec,
+    )
+
+    try:
+        AgentCredentialSpec.model_validate(candidate)
+    except ValidationError:
+        return False
+    return True
+
+
+def _select_agent_json(body: dict[str, Any]) -> dict[str, Any] | None:
+    """The highest-ranked agent-json binding in *body*, or ``None`` if absent.
+
+    Searches the top level plus every container the FE may nest a copy in.
+    Ranking is :func:`_rank_agent_json` — freshest copy wins.
+    """
+    selected_spec: dict[str, Any] | None = None
+    selected_rank = -1
+
+    def consider(raw_value: Any, key: str) -> None:
+        nonlocal selected_spec, selected_rank
+        candidate = _coerce_agent_json(raw_value)
+        rank = _rank_agent_json(raw_value, key)
+        if candidate is not None and rank > selected_rank:
+            selected_spec, selected_rank = candidate, rank
+
+    for key in _AGENT_JSON_KEYS:
+        if key in body:
+            consider(body[key], key)
+
+    for container in ("metadata", "connection_config", "credentials"):
+        container_value = body.get(container)
+        if isinstance(container_value, dict):
+            for key in _AGENT_JSON_KEYS:
+                if key in container_value:
+                    consider(container_value[key], key)
+        elif isinstance(container_value, list):  # v3 credentials: list[{key, value}]
+            for item in container_value:
+                if isinstance(item, dict) and item.get("key") in _AGENT_JSON_KEYS:
+                    consider(item.get("value"), item["key"])
+
+    return selected_spec
+
+
+def _strip_agent_json_keys(body: dict[str, Any]) -> dict[str, Any]:
+    """Copy of *body* with every agent-json key removed from every container.
+
+    Runs whenever a binding was found, whether or not it gets promoted: leaving
+    one inside ``credentials`` would let :func:`_normalize_credentials` flatten it
+    into a bogus credential pair.
+    """
+    stripped: dict[str, Any] = {}
+    for key, value in body.items():
+        if key in _AGENT_JSON_KEYS:
+            continue  # drop stale top-level aliases; re-added canonically by the caller
+        if key in ("metadata", "connection_config") and isinstance(value, dict):
+            stripped[key] = {
+                k: v for k, v in value.items() if k not in _AGENT_JSON_KEYS
+            }
+        elif key == "credentials" and isinstance(value, list):
+            stripped[key] = [
+                item
+                for item in value
+                if not (isinstance(item, dict) and item.get("key") in _AGENT_JSON_KEYS)
+            ]
+        elif key == "credentials" and isinstance(value, dict):
+            stripped[key] = {
+                k: v for k, v in value.items() if k not in _AGENT_JSON_KEYS
+            }
+        else:
+            stripped[key] = value
+    return stripped
+
+
 def _lift_agent_json(body: dict[str, Any]) -> dict[str, Any]:
     """Surface the freshest agent-json binding to the top level for SDR detection.
 
@@ -200,56 +291,32 @@ def _lift_agent_json(body: dict[str, Any]) -> dict[str, Any]:
     level and every container, surface it as top-level ``agent_json`` (overriding
     any stale top-level alias Pydantic would otherwise resolve first), and strip
     every agent-json key from the containers so credential flattening never turns
-    one into a bogus pair. No-op when none is found (direct-mode requests)."""
-    best_rank = -1
-    best_aj: dict[str, Any] | None = None
+    one into a bogus pair. No-op when none is found (direct-mode requests).
 
-    for key in _AGENT_JSON_KEYS:
-        if key in body:
-            aj = _coerce_agent_json(body[key])
-            rank = _rank_agent_json(body[key], key)
-            if aj is not None and rank > best_rank:
-                best_rank, best_aj = rank, aj
+    A binding that is not a well-formed spec — the rendered-but-unfilled widget
+    described in :func:`_parses_as_agent_spec` — is stripped but **not** promoted:
+    the request proceeds as direct mode instead of failing typed validation. The
+    strip still happens, because the bogus-credential-pair hazard above applies to
+    a placeholder just as much as to a real spec.
 
-    for container in ("metadata", "connection_config", "credentials"):
-        c = body.get(container)
-        if isinstance(c, dict):
-            for key in _AGENT_JSON_KEYS:
-                if key in c:
-                    aj = _coerce_agent_json(c[key])
-                    rank = _rank_agent_json(c[key], key)
-                    if aj is not None and rank > best_rank:
-                        best_rank, best_aj = rank, aj
-        elif isinstance(c, list):  # v3 credentials: list[{key, value}]
-            for item in c:
-                if isinstance(item, dict) and item.get("key") in _AGENT_JSON_KEYS:
-                    raw = item.get("value")
-                    aj = _coerce_agent_json(raw)
-                    rank = _rank_agent_json(raw, item["key"])
-                    if aj is not None and rank > best_rank:
-                        best_rank, best_aj = rank, aj
-
-    if best_aj is None:
+    Trade-off: an SDR user whose spec is genuinely malformed (say a non-numeric
+    ``port`` they typed themselves) sees "no agent detected" rather than a
+    field-level error. That is deliberate — the alternative is rejecting every
+    direct-mode request whose form merely renders the widget."""
+    selected_spec = _select_agent_json(body)
+    if selected_spec is None:
         return body
 
-    result: dict[str, Any] = {}
-    for k, v in body.items():
-        if k in _AGENT_JSON_KEYS:
-            continue  # drop stale top-level aliases; re-added canonically below
-        if k in ("metadata", "connection_config") and isinstance(v, dict):
-            result[k] = {kk: vv for kk, vv in v.items() if kk not in _AGENT_JSON_KEYS}
-        elif k == "credentials" and isinstance(v, list):
-            result[k] = [
-                i
-                for i in v
-                if not (isinstance(i, dict) and i.get("key") in _AGENT_JSON_KEYS)
-            ]
-        elif k == "credentials" and isinstance(v, dict):
-            result[k] = {kk: vv for kk, vv in v.items() if kk not in _AGENT_JSON_KEYS}
-        else:
-            result[k] = v
-    result["agent_json"] = best_aj
-    return result
+    lifted = _strip_agent_json_keys(body)
+    if _parses_as_agent_spec(selected_spec):
+        lifted["agent_json"] = selected_spec
+    else:
+        logger.debug(
+            "Discarding an agent-json binding that is not a valid "
+            "AgentCredentialSpec (typically a rendered-but-unfilled agent "
+            "widget); handling this request as direct mode."
+        )
+    return lifted
 
 
 # v2-compat: remove when Heracles sends credentials in v3 list[{key, value}] format.

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -1,8 +1,8 @@
 <!--
 generated-by:  capability-manifest skill (.claude/skills/capability-manifest)
-sdk-version:   3.27.2
-source-sha:    07f46ed5e21ee1f535a9d77b80e531805822507e
-source-date:   2026-08-13T18:08:24+00:00
+sdk-version:   3.28.0
+source-sha:    1445f115f696ff7a8323668214c941c101b6d502
+source-date:   2026-08-17T04:29:13+05:30
 do-not-edit:   re-run the skill instead of hand-editing
 -->
 
@@ -2733,9 +2733,9 @@ Strongly-typed Pydantic models for SDK methods. Contracts in `application_sdk.co
   - `credentials: list[HandlerCredential]` `= []` — Credentials to authenticate with.
   - `connection_id: str` `= ''` — Optional connection ID for context.
   - `entrypoint: str` `= ''` — Bare entry-point name (e.g. ``asset-export-advanced``) — authoritative
-  - `entrypoint_ref: str` `= Field(default='', validation_alias=(AliasChoices('entrypoint_ref', 'connector')), serialization_alias='connector')` — App-qualified entry-point reference (``{app_name}-{entrypoint.name}``).
+  - `entrypoint_ref: str` `= Field(default='', validation_alias=AliasChoices('entrypoint_ref', 'connector'), serialization_alias='connector')` — App-qualified entry-point reference (``{app_name}-{entrypoint.name}``).
   - `timeout_seconds: int` `= 30` — Maximum seconds to wait for auth response.
-  - `agent_json: AgentCredentialSpec | None` `= Field(default=None, validation_alias=(AliasChoices('agent_json', 'agentJson', 'agent-json')))` — Optional agent-shape credential *reference* (SDR / customer-infra only).
+  - `agent_json: AgentCredentialSpec | None` `= Field(default=None, validation_alias=AliasChoices('agent_json', 'agentJson', 'agent-json'))` — Optional agent-shape credential *reference* (SDR / customer-infra only).
 - **Defined in:** `application_sdk/handler/contracts.py`
 
 #### `AuthOutput`
@@ -2839,14 +2839,14 @@ Strongly-typed Pydantic models for SDK methods. Contracts in `application_sdk.co
 - **Fields:**
   - `credentials: list[HandlerCredential]` `= []` — Credentials to use for metadata discovery.
   - `entrypoint: str` `= ''` — Bare entry-point name (e.g. ``asset-export-advanced``) — authoritative
-  - `entrypoint_ref: str` `= Field(default='', validation_alias=(AliasChoices('entrypoint_ref', 'connector')), serialization_alias='connector')` — App-qualified entry-point reference (``{app_name}-{entrypoint.name}``).
-  - `metadata_template_key: str` `= Field(default='', validation_alias=(AliasChoices('metadata_template_key', 'metadataTemplateKey', 'type')))` — Metadata source routing key for multi-source metadata widgets (e.g.
+  - `entrypoint_ref: str` `= Field(default='', validation_alias=AliasChoices('entrypoint_ref', 'connector'), serialization_alias='connector')` — App-qualified entry-point reference (``{app_name}-{entrypoint.name}``).
+  - `metadata_template_key: str` `= Field(default='', validation_alias=AliasChoices('metadata_template_key', 'metadataTemplateKey', 'type'))` — Metadata source routing key for multi-source metadata widgets (e.g.
   - `connection_config: BaseConnectionConfig` `= Field(default_factory=BaseConnectionConfig)` — Connection configuration.
   - `object_filter: str` `= ''` — Filter pattern (e.g., 'public.*', 'mydb.myschema.*').
   - `include_fields: bool` `= True` — Whether to include field/column details.
   - `max_objects: int` `= 1000` — Maximum number of objects to return.
   - `timeout_seconds: int` `= 120` — Maximum seconds to wait for metadata fetch.
-  - `agent_json: AgentCredentialSpec | None` `= Field(default=None, validation_alias=(AliasChoices('agent_json', 'agentJson', 'agent-json')))` — Optional agent-shape credential *reference* (SDR / customer-infra only).
+  - `agent_json: AgentCredentialSpec | None` `= Field(default=None, validation_alias=AliasChoices('agent_json', 'agentJson', 'agent-json'))` — Optional agent-shape credential *reference* (SDR / customer-infra only).
 - **Defined in:** `application_sdk/handler/contracts.py`
 
 #### `MetadataOutput`
@@ -2879,12 +2879,12 @@ Strongly-typed Pydantic models for SDK methods. Contracts in `application_sdk.co
   - `credentials: list[HandlerCredential]` `= []` — Credentials to use during preflight.
   - `credentials_by_name: dict[str, list[HandlerCredential]]` `= Field(default_factory=dict)` — Resolved credentials grouped by ref name for multi-credential apps.
   - `entrypoint: str` `= ''` — Bare entry-point name (e.g. ``asset-export-advanced``) — authoritative
-  - `entrypoint_ref: str` `= Field(default='', validation_alias=(AliasChoices('entrypoint_ref', 'connector')), serialization_alias='connector')` — App-qualified entry-point reference (``{app_name}-{entrypoint.name}``).
+  - `entrypoint_ref: str` `= Field(default='', validation_alias=AliasChoices('entrypoint_ref', 'connector'), serialization_alias='connector')` — App-qualified entry-point reference (``{app_name}-{entrypoint.name}``).
   - `connection_config: BaseConnectionConfig` `= Field(default_factory=BaseConnectionConfig)` — Connection configuration (host, port, database, etc.).
   - `metadata: BaseMetadataConfig` `= Field(default_factory=BaseMetadataConfig)` — Form-level metadata forwarded by heracles alongside the credential.
   - `checks_to_run: list[str]` `= []` — Specific checks to run (empty = run all).
   - `timeout_seconds: int` `= 60` — Maximum seconds the handler has to run all checks.
-  - `agent_json: AgentCredentialSpec | None` `= Field(default=None, validation_alias=(AliasChoices('agent_json', 'agentJson', 'agent-json')))` — Optional agent-shape credential *reference* (SDR / customer-infra only).
+  - `agent_json: AgentCredentialSpec | None` `= Field(default=None, validation_alias=AliasChoices('agent_json', 'agentJson', 'agent-json'))` — Optional agent-shape credential *reference* (SDR / customer-infra only).
 - **Defined in:** `application_sdk/handler/contracts.py`
 
 #### `PreflightOutput`

--- a/tests/unit/handler/test_service.py
+++ b/tests/unit/handler/test_service.py
@@ -377,9 +377,9 @@ class TestAuthEndpoint:
         """If someone adds a new AuthStatus without updating the map, this
         test catches it."""
         for status in AuthStatus:
-            assert isinstance(status.http_status, int), (
-                f"{status} missing from _AUTH_STATUS_HTTP_CODES"
-            )
+            assert isinstance(
+                status.http_status, int
+            ), f"{status} missing from _AUTH_STATUS_HTTP_CODES"
 
 
 class TestPreflightEndpoint:
@@ -1298,9 +1298,9 @@ class TestStartWorkflowRouting:
             # The started workflow name must end in ':extract', not ':load'
             started_name = mock_client.start_workflow.call_args[0][0]
             assert ":load" not in started_name, f"load was dispatched: {started_name!r}"
-            assert started_name.endswith(":extract"), (
-                f"Expected :extract, got {started_name!r}"
-            )
+            assert started_name.endswith(
+                ":extract"
+            ), f"Expected :extract, got {started_name!r}"
             assert not any(
                 issubclass(w.category, DeprecationWarning) for w in caught
             ), "Canonical ?entrypoint= path must not emit DeprecationWarning"
@@ -1707,18 +1707,18 @@ class TestStartWorkflowInvocability:
                 resp = client.post(
                     f"/workflows/v1/start?entrypoint={ep_name}", json={"name": "x"}
                 )
-                assert resp.status_code == 200, (
-                    f"?entrypoint={ep_name} returned {resp.status_code}"
-                )
+                assert (
+                    resp.status_code == 200
+                ), f"?entrypoint={ep_name} returned {resp.status_code}"
                 wf_name = self._started_workflow_name(mock_client)
                 if ep_suffix is None:
-                    assert ":" not in wf_name, (
-                        f"?entrypoint={ep_name}: expected bare name (no colon), got {wf_name!r}"
-                    )
+                    assert (
+                        ":" not in wf_name
+                    ), f"?entrypoint={ep_name}: expected bare name (no colon), got {wf_name!r}"
                 else:
-                    assert wf_name.endswith(ep_suffix), (
-                        f"?entrypoint={ep_name}: expected suffix {ep_suffix!r}, got {wf_name!r}"
-                    )
+                    assert wf_name.endswith(
+                        ep_suffix
+                    ), f"?entrypoint={ep_name}: expected suffix {ep_suffix!r}, got {wf_name!r}"
             finally:
                 patcher.stop()
 
@@ -2244,9 +2244,9 @@ class TestWorkflowConfigValidation:
             "/workflows/v1/config/valid-id",
             params={"type": type_param},
         )
-        assert response.status_code == 422, (
-            f"Expected 422 from FastAPI pattern validator for type={type_param!r}, got {response.status_code}"
-        )
+        assert (
+            response.status_code == 422
+        ), f"Expected 422 from FastAPI pattern validator for type={type_param!r}, got {response.status_code}"
 
     @pytest.mark.parametrize(
         "type_param",
@@ -2259,9 +2259,9 @@ class TestWorkflowConfigValidation:
             params={"type": type_param},
             json={"key": "value"},
         )
-        assert response.status_code == 422, (
-            f"Expected 422 from FastAPI pattern validator for type={type_param!r}, got {response.status_code}"
-        )
+        assert (
+            response.status_code == 422
+        ), f"Expected 422 from FastAPI pattern validator for type={type_param!r}, got {response.status_code}"
 
     @pytest.mark.parametrize(
         "config_id",
@@ -2271,9 +2271,9 @@ class TestWorkflowConfigValidation:
         """Valid config_ids pass the regex check (result is 503/404 without a store, not 400)."""
         client = _make_client()
         response = client.get(f"/workflows/v1/config/{config_id}")
-        assert response.status_code != 400, (
-            f"Valid config_id {config_id!r} was wrongly rejected"
-        )
+        assert (
+            response.status_code != 400
+        ), f"Valid config_id {config_id!r} was wrongly rejected"
 
 
 class TestDaprSubscribeEndpoint:
@@ -7103,9 +7103,9 @@ class TestAgentJsonLift:
 
     def test_placeholder_widget_is_not_promoted(self) -> None:
         out = _lift_agent_json({"metadata": {"agent-json": self._PLACEHOLDER}})
-        assert "agent_json" not in out, (
-            "a placeholder spec must not reach the typed agent_json field"
-        )
+        assert (
+            "agent_json" not in out
+        ), "a placeholder spec must not reach the typed agent_json field"
 
     def test_placeholder_widget_body_still_validates(self) -> None:
         """The regression: the normalized body must be accepted by the typed input."""

--- a/tests/unit/handler/test_service.py
+++ b/tests/unit/handler/test_service.py
@@ -34,6 +34,7 @@ from application_sdk.handler.service import (
     _flatten_to_pairs,
     _lift_agent_json,
     _normalize_credentials,
+    _normalize_preflight_request,
     _rank_agent_json,
     _wrap_response,
     create_app_handler_service,
@@ -376,9 +377,9 @@ class TestAuthEndpoint:
         """If someone adds a new AuthStatus without updating the map, this
         test catches it."""
         for status in AuthStatus:
-            assert isinstance(
-                status.http_status, int
-            ), f"{status} missing from _AUTH_STATUS_HTTP_CODES"
+            assert isinstance(status.http_status, int), (
+                f"{status} missing from _AUTH_STATUS_HTTP_CODES"
+            )
 
 
 class TestPreflightEndpoint:
@@ -1297,9 +1298,9 @@ class TestStartWorkflowRouting:
             # The started workflow name must end in ':extract', not ':load'
             started_name = mock_client.start_workflow.call_args[0][0]
             assert ":load" not in started_name, f"load was dispatched: {started_name!r}"
-            assert started_name.endswith(
-                ":extract"
-            ), f"Expected :extract, got {started_name!r}"
+            assert started_name.endswith(":extract"), (
+                f"Expected :extract, got {started_name!r}"
+            )
             assert not any(
                 issubclass(w.category, DeprecationWarning) for w in caught
             ), "Canonical ?entrypoint= path must not emit DeprecationWarning"
@@ -1706,18 +1707,18 @@ class TestStartWorkflowInvocability:
                 resp = client.post(
                     f"/workflows/v1/start?entrypoint={ep_name}", json={"name": "x"}
                 )
-                assert (
-                    resp.status_code == 200
-                ), f"?entrypoint={ep_name} returned {resp.status_code}"
+                assert resp.status_code == 200, (
+                    f"?entrypoint={ep_name} returned {resp.status_code}"
+                )
                 wf_name = self._started_workflow_name(mock_client)
                 if ep_suffix is None:
-                    assert (
-                        ":" not in wf_name
-                    ), f"?entrypoint={ep_name}: expected bare name (no colon), got {wf_name!r}"
+                    assert ":" not in wf_name, (
+                        f"?entrypoint={ep_name}: expected bare name (no colon), got {wf_name!r}"
+                    )
                 else:
-                    assert wf_name.endswith(
-                        ep_suffix
-                    ), f"?entrypoint={ep_name}: expected suffix {ep_suffix!r}, got {wf_name!r}"
+                    assert wf_name.endswith(ep_suffix), (
+                        f"?entrypoint={ep_name}: expected suffix {ep_suffix!r}, got {wf_name!r}"
+                    )
             finally:
                 patcher.stop()
 
@@ -2243,9 +2244,9 @@ class TestWorkflowConfigValidation:
             "/workflows/v1/config/valid-id",
             params={"type": type_param},
         )
-        assert (
-            response.status_code == 422
-        ), f"Expected 422 from FastAPI pattern validator for type={type_param!r}, got {response.status_code}"
+        assert response.status_code == 422, (
+            f"Expected 422 from FastAPI pattern validator for type={type_param!r}, got {response.status_code}"
+        )
 
     @pytest.mark.parametrize(
         "type_param",
@@ -2258,9 +2259,9 @@ class TestWorkflowConfigValidation:
             params={"type": type_param},
             json={"key": "value"},
         )
-        assert (
-            response.status_code == 422
-        ), f"Expected 422 from FastAPI pattern validator for type={type_param!r}, got {response.status_code}"
+        assert response.status_code == 422, (
+            f"Expected 422 from FastAPI pattern validator for type={type_param!r}, got {response.status_code}"
+        )
 
     @pytest.mark.parametrize(
         "config_id",
@@ -2270,9 +2271,9 @@ class TestWorkflowConfigValidation:
         """Valid config_ids pass the regex check (result is 503/404 without a store, not 400)."""
         client = _make_client()
         response = client.get(f"/workflows/v1/config/{config_id}")
-        assert (
-            response.status_code != 400
-        ), f"Valid config_id {config_id!r} was wrongly rejected"
+        assert response.status_code != 400, (
+            f"Valid config_id {config_id!r} was wrongly rejected"
+        )
 
 
 class TestDaprSubscribeEndpoint:
@@ -7077,6 +7078,94 @@ class TestAgentJsonLift:
 
     def test_unparseable_string_ignored(self) -> None:
         assert "agent_json" not in _lift_agent_json({"metadata": {"agent_json": "{"}})
+
+    # ---- rendered-but-unfilled agent widget (placeholder values) ----------
+    #
+    # The FE submits every field name as its own value when the agent widget is
+    # rendered but never filled in. ``port`` is AgentCredentialSpec's only
+    # non-str field, so the payload coerces to a dict but fails typed validation.
+    # Promoting it made PreflightInput/AuthInput/MetadataInput raise an unhandled
+    # ValidationError -> plain-text 500 -> opaque JSON-decode error at the caller,
+    # on every direct-mode request whose form renders the widget.
+    _PLACEHOLDER = {
+        "agent-name": "agent-name",
+        "aws-auth-method": "aws-auth-method",
+        "host": "host",
+        "port": "port",
+        "secret-manager": "secret-manager",
+    }
+    _REAL = {
+        "agent-name": "acme-agent",
+        "secret-path": "arn:aws:secretsmanager:us-east-1:1:secret:x",
+        "host": "db.example.com",
+        "port": 1521,
+    }
+
+    def test_placeholder_widget_is_not_promoted(self) -> None:
+        out = _lift_agent_json({"metadata": {"agent-json": self._PLACEHOLDER}})
+        assert "agent_json" not in out, (
+            "a placeholder spec must not reach the typed agent_json field"
+        )
+
+    def test_placeholder_widget_body_still_validates(self) -> None:
+        """The regression: the normalized body must be accepted by the typed input."""
+        body = _normalize_preflight_request(
+            {
+                "connector": "oracle",
+                "entrypoint": "miner",
+                "credentials": {"extra": {}},
+                "metadata": {
+                    "agent_json": json.dumps(self._PLACEHOLDER),
+                    "agent-json": json.dumps(self._PLACEHOLDER),
+                    "extraction_method": "query_history",
+                },
+            }
+        )
+        PreflightInput.model_validate(body)  # must not raise
+
+    def test_placeholder_inside_credentials_is_still_stripped(self) -> None:
+        """Not promoted, but still removed — otherwise _normalize_credentials
+        flattens it into a bogus `agent-json` credential pair."""
+        out = _lift_agent_json(
+            {"credentials": {"agent-json": self._PLACEHOLDER, "host": "h"}}
+        )
+        assert "agent_json" not in out
+        assert "agent-json" not in out["credentials"]
+        assert out["credentials"]["host"] == "h"
+
+    def test_placeholder_in_v3_credentials_list_is_still_stripped(self) -> None:
+        out = _lift_agent_json(
+            {
+                "credentials": [
+                    {"key": "agent-json", "value": self._PLACEHOLDER},
+                    {"key": "host", "value": "h"},
+                ]
+            }
+        )
+        assert "agent_json" not in out
+        assert all(c["key"] != "agent-json" for c in out["credentials"])
+
+    def test_real_spec_is_still_promoted(self) -> None:
+        out = _lift_agent_json({"metadata": {"agent-json": self._REAL}})
+        assert out["agent_json"] == self._REAL
+
+    def test_real_spec_wins_over_a_placeholder_copy(self) -> None:
+        """Rank prefers the parsed object; validity must not un-rank the winner."""
+        out = _lift_agent_json(
+            {
+                "metadata": {
+                    "agent-json": self._REAL,
+                    "agent_json": json.dumps(self._REAL),
+                }
+            }
+        )
+        assert out["agent_json"] == self._REAL
+
+    def test_valid_but_unpopulated_spec_is_still_promoted(self) -> None:
+        """is_populated() is the consumers' call, not the lift's. A name-only spec
+        parses, so it is promoted and left for sdr.py to reject."""
+        out = _lift_agent_json({"metadata": {"agent-json": {"agent-name": "acme"}}})
+        assert out["agent_json"] == {"agent-name": "acme"}
 
 
 class TestManifestPostTransport:


### PR DESCRIPTION
### Changelog

- `_lift_agent_json` no longer promotes an agent-json binding that fails `AgentCredentialSpec` validation. A rendered-but-unfilled agent widget submits every field name as its own value — `{"agent-name": "agent-name", "host": "host", "port": "port", …}`. `port` is the spec's only non-`str` field (`spec.py:100`), so that payload coerces to a dict but fails typed validation on `AuthInput` / `PreflightInput` / `MetadataInput`. The unhandled `ValidationError` becomes Starlette's plain-text `Internal Server Error`, so the caller sees an opaque JSON-decode error instead of anything actionable — on **every direct-mode request whose form merely renders the widget**.
- Split selection (`_select_agent_json`) from stripping (`_strip_agent_json_keys`) so an unpromoted binding is **still stripped**. Returning `body` early instead would leave a placeholder inside `credentials` for `_normalize_credentials` to flatten into a bogus credential pair — precisely the hazard the strip exists to prevent, and something the current code already avoids for placeholders (they are coercible, so they are stripped today).
- Renamed opaque locals: `best_aj`/`best_rank`/`aj`/`c`/`raw` → `selected_spec`/`selected_rank`/`candidate`/`container_value`/`raw_value`.

### Additional context

**Introduced in v3.27.0** by #2914 (`_lift_agent_json`); also present in v3.27.1, v3.27.2 and v3.28.0 — reproduced against an installed 3.28.0.

Observed on a **direct-mode** Oracle connection (`connectionWorkflowConfiguration.extraction-method: "direct"`, `credentials-fetch-strategy: "credential_guid"`). Both `/workflows/v1/check` modes fail identically in ~1.4 ms:

```
error_type=ValidationError   duration_ms=1.44
agent_json.port: Input should be a valid integer, unable to parse string as an integer
```

`method="direct"` (crawler) ×5 and `method="query_history"` (miner) ×4, all on the same pod, all on SDK 3.27.1. Tenants on 3.26.1 are unaffected; the same tenant returned 200 before its SDK bump.

The SDK already knows about this payload shape — `ExtractionInput._skip_agent_json_for_direct` discards it on the extraction path and cites `"port": "port"` by name:

> "In direct mode, agent_json may contain placeholder values (e.g. `"port": "port"`) that fail AgentCredentialSpec validation. Since agent_json is only used for agent-based extraction, we discard it for direct mode."

This PR is the handler-path equivalent of that guard.

**Exposure:** 15 apps in the monorepo declare an `agent` widget (bigquery, databricks, glue, hive, kafka, looker, mssql, mysql, oracle, redshift, salesforce, snowflake, tableau, teradata, trino). Any of them 500s its UI preflight once its server reaches ≥3.27.0; oracle, kafka and mysql are already there. As Renovate rolls the SDK forward, the rest follow.

**Deliberately scoped to parseability, not `is_populated()`.** Consumers already call `is_populated()` themselves (`sdr.py:465`, `sdr.py:473`), so a valid-but-stub spec keeps its current behaviour and is still rejected downstream. Gating here would change behaviour for valid stubs beyond this defect.

**Trade-off, documented in the docstring:** an SDR user whose spec is genuinely malformed (e.g. a non-numeric `port` they typed themselves) now sees "no agent detected" rather than a field-level error. That is the deliberate choice — the alternative is rejecting every direct-mode request whose form renders the widget.

**Follow-ups, not in this PR:**
- An unhandled `ValidationError` on `/workflows/v1/check` should return 422 with the offending field, not a plain-text 500. That is why this took a full investigation to pin, and it affects every connector.
- The injected preflight gate omits `agent_json` from its `PreflightInput` (`preflight_gate.py`), so gate-path SDR runs get a strictly weaker credential resolution than the HTTP path does. Worth aligning separately.

### Checklist

- [x] Additional tests added
- [ ] All CI checks passed
- [ ] Relevant documentation updated

7 new cases in `TestAgentJsonLift`: placeholder not promoted; the normalized body validates end-to-end; placeholder still stripped from both the dict and v3-list credential shapes; real spec still promoted; ranking unaffected by the new gate; valid-but-unpopulated spec still promoted. The **9 existing `TestAgentJsonLift` cases pass unmodified** — the refactor preserves the contract. `tests/unit/handler/` is green at 443 passed.

---

### Copyleft License Compliance

- [ ] Have you used any code that is subject to a Copyleft license (e.g., GPL, AGPL, LGPL)?
- [ ] If yes, have you modified the code in the context of this project? please share additional details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0198KaF5HneN3uMyuH6JosGn
