### PR TITLE
proposal(common): reraise_unless_tolerated — stop masking classified failures as empty results

### DIFF
--- a/application_sdk/common/exception_guards.py
+++ b/application_sdk/common/exception_guards.py
@@ -1,0 +1,38 @@
+"""Guard against a tolerated exception silently masking a real failure.
+
+Proposal for BLDX-1625 — see the PR description for open questions. Not yet
+adopted anywhere; nothing in the SDK or fleet calls this today.
+
+Context: at least six connector apps (thoughtspot, gcs, atlan-iceberg-app,
+atlan-soda-app, atlan-adls-app, atlan-databricks-app) independently hit and
+separately hand-patched the same defect — a broad ``except Exception`` meant
+to tolerate one known-benign outcome (a missing table, an empty prefix) was
+also catching everything else, including a rate limit or an auth failure,
+and reporting all of it as the same empty/``None`` result. A caller cannot
+tell "the source genuinely has nothing" from "something broke and we hid
+it" — and reporting the latter as the former is how a transient throttle
+gets published as a truncated, asset-deleting crawl.
+"""
+
+from __future__ import annotations
+
+
+def reraise_unless_tolerated(
+    exc: BaseException,
+    *,
+    tolerated: tuple[type[BaseException], ...],
+) -> None:
+    """Re-raise ``exc`` unless its type is explicitly declared tolerable here.
+
+    Call this as the first line of an ``except Exception as exc:`` block that
+    is about to degrade to an empty/``None`` result. ``tolerated`` is an
+    allowlist, not a denylist: the caller names exactly the outcomes that are
+    known-benign at this call site (e.g. a catalog's own not-found type), and
+    everything else — including a typed ``AppError`` subclass the SDK or a
+    lower layer already raised, such as ``RateLimitedError`` or ``AuthError``
+    — escapes unchanged. A no-op when ``exc`` matches ``tolerated``; the
+    caller's existing tolerance logic runs as before.
+    """
+    if isinstance(exc, tolerated):
+        return
+    raise exc

--- a/tests/unit/common/test_exception_guards.py
+++ b/tests/unit/common/test_exception_guards.py
@@ -1,0 +1,47 @@
+"""BLDX-1625 proposal: reraise_unless_tolerated must not let an unlisted
+exception — especially an already-typed AppError — get swallowed."""
+
+from __future__ import annotations
+
+import pytest
+
+from application_sdk.common.exception_guards import reraise_unless_tolerated
+from application_sdk.errors.leaves import AuthError, RateLimitedError
+
+
+class CatalogNotFoundError(Exception):
+    pass
+
+
+def test_tolerated_type_is_a_no_op():
+    reraise_unless_tolerated(
+        CatalogNotFoundError("gone"), tolerated=(CatalogNotFoundError,)
+    )
+
+
+def test_untolerated_type_escapes():
+    with pytest.raises(ValueError, match="boom"):
+        reraise_unless_tolerated(ValueError("boom"), tolerated=(CatalogNotFoundError,))
+
+
+def test_a_typed_app_error_escapes_even_with_a_broad_tolerated_set():
+    """The whole point: a caller tolerating plain Exception subclasses must
+    not accidentally swallow a classification a lower layer already made."""
+    with pytest.raises(RateLimitedError):
+        reraise_unless_tolerated(
+            RateLimitedError(message="throttled"), tolerated=(CatalogNotFoundError,)
+        )
+
+
+def test_subclass_of_a_tolerated_type_is_also_a_no_op():
+    class SpecificNotFound(CatalogNotFoundError):
+        pass
+
+    reraise_unless_tolerated(
+        SpecificNotFound("gone"), tolerated=(CatalogNotFoundError,)
+    )
+
+
+def test_empty_tolerated_set_always_reraises():
+    with pytest.raises(AuthError):
+        reraise_unless_tolerated(AuthError(message="bad token"), tolerated=())


### PR DESCRIPTION
**Draft — not merge-ready. Opened for discussion per BLDX-1625, not as a finished design.**

## The problem

At least six connector apps have independently hit and separately hand-patched the same defect: a broad `except Exception` meant to tolerate one known-benign outcome (a missing table, an empty object-store prefix) also caught everything else, and reported all of it as the same empty/`None` result. A caller can't tell "the source genuinely has nothing" from "something broke and got hidden" — and reporting the latter as the former is how a transient failure (rate limit, auth expiry) publishes as a truncated, asset-deleting crawl instead of failing loudly.

Confirmed instances: thoughtspot, gcs, `atlan-iceberg-app` (fixed in [PR #94](https://github.com/atlanhq/atlan-iceberg-app/pull/94) + a follow-up, [CONNECT-951](https://linear.app/atlan-epd/issue/CONNECT-951)), `atlan-soda-app` (`StageCountMismatchError`), `atlan-adls-app` (`TransformBatchError`), `atlan-databricks-app` (narrowed `except`, pinned by `test_programmer_bug_is_not_swallowed`). Each app invented its own guard. `application_sdk` has no shared one, and `connector-os`'s `knowledge/practices/failure-patterns.md` has an `error-handling` category already scaffolded and empty — the intended home for this doesn't have it yet.

## What this proposes

`atlan-iceberg-app`'s own fix (PR #94) added `reraise_if_throttled` — hardcoded to protect exactly one classification (a catalog rate limit) from being swallowed by a tolerant `except`. This generalizes that shape into `application_sdk/common/exception_guards.py`:

```python
def reraise_unless_tolerated(
    exc: BaseException,
    *,
    tolerated: tuple[type[BaseException], ...],
) -> None:
    if isinstance(exc, tolerated):
        return
    raise exc
```

The caller declares what IS tolerable at this call site (an allowlist — e.g. `(NoSuchTableError,)`), and everything else escapes unchanged, including an already-typed `AppError` a lower layer raised (`RateLimitedError`, `AuthError`, ...). Deliberately does **not** introduce a new error type — the SDK's existing `DataIntegrityError`/`InternalError` leaves already cover "something unexpected happened here" for callers who want a classified surface instead of a raw passthrough.

Tests in `tests/unit/common/test_exception_guards.py` pin: a tolerated type is a no-op, an untolerated type escapes, a subclass of a tolerated type is still tolerated, and — the actual point — a typed `AppError` (e.g. `RateLimitedError`) escapes even when the caller's `tolerated` set is broad, so a lower layer's classification is never silently discarded.

## Open questions for the SDK team

1. **Right shape?** A bare function vs. a context manager (`with tolerate(NoSuchTableError): ...`) vs. a decorator. The function form is the smallest diff to adopt at an existing call site; a context manager reads better at the call site but changes more code per adoption.
2. **Right location?** Landed in `application_sdk/common/` next to the other small utilities — could also fit under `application_sdk/errors/` since it's error-handling-shaped, not a general utility.
3. **Does this fully solve the six known instances, or only the shape where a caller already knows the tolerable type at the call site?** Some existing per-app patches (e.g. `atlan-databricks-app`'s narrowed `except`) classify by string-matching the exception message rather than `isinstance`, because the underlying client library doesn't raise typed exceptions. This helper doesn't cover that shape — worth deciding whether it should, or whether that stays a per-app concern.
4. **Adoption path** — once a shape is agreed, should this be backfilled into the six known apps as follow-up tickets, or left for each app to pick up opportunistically?

Not touching `connector-os`'s empty `error-handling` doc slot in this PR — wanted the shape agreed here first so the doc reflects what actually shipped, not what was proposed.