### PR TITLE
ci(fix): reconcile sdk-review approvals a rate-limited stamp lost (FND-314)

### DIFF
--- a/.github/scripts/sdk_review_approve.py
+++ b/.github/scripts/sdk_review_approve.py
@@ -40,8 +40,8 @@ The old code sent label errors to /dev/null under `|| true`, so that failure was
 invisible. Here a delete that 404s is tolerated (the label was already absent)
 and anything else is surfaced as a ::warning::.
 
-Two callers
------------
+Three callers
+-------------
 The fast path (`sdk-review-approve-on-verdict.yml`) passes the verdict comment
 in via COMMENT_BODY, straight off the `issue_comment` event, and owns the
 `sdk-review` commit status.
@@ -53,13 +53,22 @@ not write the commit status (its workflow has its own failure-path step), and
 sets REQUIRE_APPROVED_LABEL so it will not approve a verdict something has since
 invalidated.
 
+The reconciler (`sdk_review_reconcile.py`, on a cron) drives this per PR with the
+same environment as the slow path, plus APPROVE_MAX_ATTEMPTS=1: it exists to
+recover approvals the other two paths lost, so retrying in-process would only
+duplicate the loop it already is. That also holds it to exactly one `atlan-ci`
+request per PR it approves.
+
 That label guard is the solo-approval safety property. `sdk-review-approved` is
 the one signal every invalidator clears: `dismiss-on-human` strips it (and
 notably does NOT touch the commit status, so the status cannot substitute),
 `downgrade-on-ci-failure` strips it, `reset-on-push` strips it. It is therefore
 read from a snapshot taken BEFORE this run reconciles labels — the shell version
 read it back after adding it, so the guard could only ever see the label it had
-just written and never fired.
+just written and never fired — and, when it fires on a READY verdict, it bails
+before writing anything at all. Reconciling labels first would re-add
+`sdk-review-approved` on the way to declining the approval, resurrecting the
+signal the invalidator had just stripped.
 
 Environment:
     REPO                        owner/repo (e.g. atlanhq/application-sdk)
@@ -285,17 +294,25 @@ class Client:
         ids = [comment.get("id", 0) for comment in self._summary_comments()]
         return max(ids) if ids else 0
 
-    def latest_summary_body(self) -> str:
-        """Body of the newest SDK review summary comment, or "" if none.
+    def latest_summary_comment(self) -> dict | None:
+        """The newest SDK review summary comment, or None if the PR has none.
 
         Ids are monotonic, so max-by-id is the newest — not merely the last in
         page order.
+
+        Returns the whole comment rather than just its body so a caller that
+        also needs the metadata (`sdk_review_reconcile.py` reads `created_at`
+        to age-gate a verdict) can get both from one listing request.
         """
         comments = self._summary_comments()
         if not comments:
-            return ""
-        newest = max(comments, key=lambda comment: comment.get("id", 0))
-        return newest.get("body") or ""
+            return None
+        return max(comments, key=lambda comment: comment.get("id", 0))
+
+    def latest_summary_body(self) -> str:
+        """Body of the newest SDK review summary comment, or "" if none."""
+        newest = self.latest_summary_comment()
+        return (newest or {}).get("body") or ""
 
     def current_labels(self) -> set[str]:
         result = self.run(
@@ -595,6 +612,34 @@ def main(
     # label was standing when this run started, which the post-reconcile state
     # can no longer answer.
     labels_before = client.current_labels()
+
+    # Solo-approval guard, checked BEFORE any write. Every invalidator —
+    # dismiss-on-human, downgrade-on-ci-failure, reset-on-push — clears this
+    # label, so its absence under a READY verdict means something has spoken
+    # since and this verdict no longer stands.
+    #
+    # Bailing here rather than after the label reconcile matters: `label_plan`
+    # would otherwise re-add `sdk-review-approved` on the way to declining the
+    # approval, resurrecting the very signal the invalidator had just stripped.
+    # The PR would then wear the label with no approval behind it — and the
+    # reconciler cron, which gates on exactly that label, would read the
+    # resurrected label as a lost stamp and approve on the next tick.
+    #
+    # Only READY is gated: a NEEDS_FIXES/NEEDS_HUMAN verdict still has to clear
+    # labels and dismiss a stale approval regardless of what the label says.
+    if (
+        verdict == READY
+        and require_approved_label
+        and APPROVED_LABEL not in labels_before
+    ):
+        print(
+            f"::notice::PR #{pr_number}: `{APPROVED_LABEL}` was not present when "
+            f"this run started (a downgrade, dismissal or push likely intervened) "
+            f"— skipping approval, and leaving labels untouched so the label is "
+            f"not resurrected."
+        )
+        return 0
+
     to_add, to_remove = label_plan(verdict, labels_before)
     added_ok = client.add_labels(to_add)
     for label in sorted(to_remove):
@@ -631,18 +676,6 @@ def main(
         if write_status:
             client.post_status(head_sha, state, description)
         print(f"Verdict '{verdict}' is not READY TO MERGE — no approval posted.")
-        return 0
-
-    # Solo-approval guard (slow path). Every invalidator — dismiss-on-human,
-    # downgrade-on-ci-failure, reset-on-push — clears this label, so its absence
-    # means something has spoken since the verdict and the approval must not be
-    # (re-)posted.
-    if require_approved_label and APPROVED_LABEL not in labels_before:
-        print(
-            f"::notice::PR #{pr_number}: `{APPROVED_LABEL}` was not present when "
-            f"this run started (a downgrade, dismissal or push likely intervened) "
-            f"— skipping approval."
-        )
         return 0
 
     # Don't double-approve: sdk-review.yml's slow path runs the same stamp after

--- a/.github/scripts/sdk_review_reconcile.py
+++ b/.github/scripts/sdk_review_reconcile.py
@@ -1,0 +1,368 @@
+#!/usr/bin/env python3
+"""Re-drive SDK review approvals that were computed but never posted.
+
+Why this exists
+---------------
+`sdk-review-approve-on-verdict.yml` computes the verdict and then posts the
+formal approval as `atlan-ci` — the CODEOWNER whose approval satisfies branch
+protection on `main`. When that one POST fails, the run dies and nothing retries
+it: the PR sits with a posted review summary, the `sdk-review-approved` label,
+and no approving review. Recovery was entirely manual (`gh run rerun --failed`).
+
+The trigger has been `atlan-ci` exhausting its 5,000 req/hr primary REST quota.
+The token split in #3162 cut that path's `atlan-ci` spend to exactly one request
+and added rate-limit-aware retry, which shrinks the window but cannot close it:
+primary quota can reset up to an hour out, and the stamper deliberately fails
+fast rather than hold a runner that long. `issue_comment` workflows also always
+execute from the default branch, so that hardening can only protect PRs opened
+after it lands — it could not protect its own approval.
+
+This reconciler is the durable answer because it does not care *why* the stamp
+was lost. It sweeps open PRs on a cron and re-invokes the existing stamper for
+any PR whose verdict still stands but whose approval is missing.
+
+Guards (all four must hold before a PR is touched)
+--------------------------------------------------
+1. `sdk-review-approved` is still on the PR. This is the solo-approval safety
+   property: it is the one signal every invalidator clears — `dismiss-on-human`
+   strips it (and notably does NOT touch the commit status, so the status cannot
+   substitute), `downgrade-on-ci-failure` strips it, `reset-on-push` strips it.
+   Reconciling without it would re-approve PRs a human has already engaged with.
+2. No `atlan-ci` APPROVED review already carries the bot signature — so a
+   healthy PR is a no-op and never collects a duplicate approval.
+3. The newest `mothership-ai[bot]` verdict comment says READY_TO_MERGE and its
+   REVIEWED_HEAD equals the PR's live head. Reconciling a verdict whose head has
+   moved would bless unreviewed code.
+4. That verdict comment is at least `--min-age-minutes` old, so the reconciler
+   cannot race a fast-path run that is still in flight for the same comment (its
+   job ceiling is 10 minutes, including rate-limit backoff). The cost is latency:
+   recovery lands one grace period plus up to one cron interval after the loss,
+   not within a single interval.
+
+The stamper re-checks 1, 2 and 3 itself against fresh reads, so a dismissal
+landing between this sweep and the stamp is still caught. The checks here are a
+prefilter — they keep the sweep cheap and tell us when a reconcile actually
+happened, which is the signal worth alerting on.
+
+What it deliberately does not do
+--------------------------------
+It does not write the `sdk-review` commit status (WRITE_STATUS=false). A green
+status with no approving review is exactly the misleading state that made this
+failure mode look like success in the first place. The approval is the thing
+that was lost and the thing worth restoring; the status is left to whichever
+path owns it.
+
+Request budget
+--------------
+Everything runs on the fleet App token, which carries its own quota — a
+reconciler that polled every PR on the `atlan-ci` PAT would become a new source
+of the exhaustion it exists to recover from. Per tick that is one paginated PR
+listing, plus two reads per labelled PR (reviews, then comments). The
+`atlan-ci` PAT is spent only inside the stamper's APPROVE call, and
+APPROVE_MAX_ATTEMPTS=1 holds that to exactly one request per PR approved: this
+cron *is* the retry loop, so retrying in-process would only duplicate it.
+
+Exit status:
+    0  swept cleanly (whether or not anything needed reconciling)
+    1  at least one PR needed reconciling and the approval still could not be
+       posted — the run goes red so a worsening quota problem stays visible
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+import sdk_review_approve as approve  # noqa: E402  (needs the sys.path bootstrap)
+
+Runner = Callable[..., subprocess.CompletedProcess]
+
+# Long enough to clear the fast path's 10-minute job ceiling (checkout, plus
+# APPROVE_MAX_WAIT_SECONDS of rate-limit backoff), so a verdict this reconciler
+# acts on cannot still be in flight elsewhere.
+DEFAULT_MIN_AGE_MINUTES = 12
+
+RECONCILED = "reconciled"
+FAILED = "failed"
+SKIPPED = "skipped"
+
+
+@dataclass(frozen=True)
+class Outcome:
+    """What the sweep did about one PR, and why."""
+
+    number: int
+    action: str
+    reason: str
+
+
+def list_open_prs(repo: str, runner: Runner) -> list[dict]:
+    """Every open PR, with `head` and `labels` already populated.
+
+    Those two fields are why this lists PRs rather than searching: the label
+    prefilter and the head comparison both come free with the listing, so an
+    unlabelled PR costs zero further requests.
+
+    `--paginate` follows Link: rel="next", so a repo with more than 100 open
+    PRs does not silently lose coverage of the rest.
+    """
+    result = runner(
+        [
+            "gh",
+            "api",
+            "--paginate",
+            f"repos/{repo}/pulls?state=open&per_page=100",
+            "--jq",
+            ".[] | tojson",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise SystemExit(
+            f"::error::failed to list open PRs for {repo}: {result.stderr}"
+        )
+    return [json.loads(line) for line in result.stdout.splitlines() if line.strip()]
+
+
+def label_names(pr: dict) -> set[str]:
+    return {label.get("name", "") for label in pr.get("labels") or []}
+
+
+def comment_age(comment: dict, now: datetime) -> timedelta | None:
+    """How long ago `comment` was created, or None if that cannot be read.
+
+    An unreadable timestamp means the age gate cannot be evaluated, and the
+    caller treats that as "too young" — the conservative direction.
+    """
+    created = comment.get("created_at")
+    if not created:
+        return None
+    try:
+        created_dt = datetime.fromisoformat(created.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return now - created_dt
+
+
+@contextmanager
+def stamper_env(values: dict[str, str]) -> Iterator[None]:
+    """Set `values` in os.environ for the block, then restore what was there.
+
+    The stamper reads its inputs from the environment (it is normally a workflow
+    step). Driving it per PR means rewriting those keys in a loop, so they are
+    restored afterwards rather than left to leak into the next iteration.
+    """
+    previous = {key: os.environ.get(key) for key in values}
+    os.environ.update(values)
+    try:
+        yield
+    finally:
+        for key, value in previous.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+
+def stamp(repo: str, pr_number: int, head_sha: str, runner: Runner) -> bool:
+    """Invoke the stamper for one PR. True when the approval landed.
+
+    The environment matches the slow path (`sdk-review.yml`) — no event payload,
+    no commit-status write, label guard on — with retries disabled, because this
+    cron is itself the retry loop.
+    """
+    env = {
+        "REPO": repo,
+        "PR_NUMBER": str(pr_number),
+        # Empty: re-read the newest summary comment off the PR rather than an
+        # event payload. There is no event here.
+        "COMMENT_BODY": "",
+        "TRIGGERING_COMMENT_ID": "",
+        # Staleness guard, re-evaluated against a fresh read inside the stamper.
+        "EXPECTED_HEAD": head_sha,
+        # A green `sdk-review` status with no approving review is the state this
+        # whole mechanism exists to avoid creating.
+        "WRITE_STATUS": "false",
+        # Solo-approval guard: refuse if `sdk-review-approved` has gone in the
+        # gap between this sweep's listing and the stamp.
+        "REQUIRE_APPROVED_LABEL": "true",
+        # Exactly one `atlan-ci` request per PR approved. Waiting out a primary
+        # quota reset in-process is what the stamper already declines to do; the
+        # next tick is the retry.
+        "APPROVE_MAX_ATTEMPTS": "1",
+        "APPROVE_MAX_WAIT_SECONDS": "0",
+    }
+    with stamper_env(env):
+        return approve.main(runner=runner) == 0
+
+
+def sweep(
+    repo: str,
+    *,
+    runner: Runner = subprocess.run,
+    min_age: timedelta = timedelta(minutes=DEFAULT_MIN_AGE_MINUTES),
+    now: datetime | None = None,
+    dry_run: bool = False,
+) -> list[Outcome]:
+    """Reconcile every open PR whose standing verdict lost its approval.
+
+    Ordering is by cost: the label check is free (the PR listing carries
+    labels), the review listing short-circuits the healthy majority, and only
+    then is the comment listing spent.
+    """
+    now = now or datetime.now(timezone.utc)
+    outcomes: list[Outcome] = []
+
+    for pr in list_open_prs(repo, runner):
+        number = pr.get("number")
+        if number is None:
+            continue
+
+        if approve.APPROVED_LABEL not in label_names(pr):
+            continue
+
+        client = approve.Client(repo, str(number), runner)
+
+        if client.bot_approval_ids():
+            outcomes.append(Outcome(number, SKIPPED, "already approved"))
+            continue
+
+        comment = client.latest_summary_comment()
+        if comment is None:
+            outcomes.append(Outcome(number, SKIPPED, "no verdict comment"))
+            continue
+
+        body = comment.get("body") or ""
+        verdict = approve.extract_verdict(body)
+        if verdict != approve.READY:
+            outcomes.append(Outcome(number, SKIPPED, f"verdict is {verdict}"))
+            continue
+
+        reviewed_head = approve.extract_reviewed_head(body)
+        head_sha = ((pr.get("head") or {}).get("sha") or "").strip()
+        if not reviewed_head or not head_sha or reviewed_head != head_sha:
+            outcomes.append(
+                Outcome(
+                    number,
+                    SKIPPED,
+                    f"head moved past the verdict ({reviewed_head} -> {head_sha})",
+                )
+            )
+            continue
+
+        age = comment_age(comment, now)
+        if age is None or age < min_age:
+            outcomes.append(Outcome(number, SKIPPED, "verdict too recent to be lost"))
+            continue
+
+        if dry_run:
+            outcomes.append(Outcome(number, SKIPPED, "would reconcile (dry run)"))
+            continue
+
+        if not stamp(repo, number, head_sha, runner):
+            outcomes.append(Outcome(number, FAILED, "approval could not be posted"))
+        elif client.bot_approval_ids():
+            outcomes.append(Outcome(number, RECONCILED, f"approved at {head_sha}"))
+        else:
+            # The stamper exits 0 both when it approved and when one of its own
+            # guards declined — it re-reads the label, head and comments, so a
+            # dismissal landing between this sweep's listing and the stamp is
+            # caught there. Confirming the review exists is what separates the
+            # two, and the whole point of this cron is not to report a recovery
+            # that did not happen.
+            outcomes.append(
+                Outcome(number, SKIPPED, "the stamper declined — verdict invalidated")
+            )
+
+    return outcomes
+
+
+def report(outcomes: list[Outcome], repo: str) -> None:
+    """Log the sweep, and annotate anything that was not a plain no-op.
+
+    Reconciling is not routine — it means a stamp was lost upstream — so it is
+    a ::warning:: rather than a ::notice::, and it lands in the job summary too.
+    Silent recovery would hide a worsening rate-limit problem, which is the
+    thing most worth knowing about here.
+    """
+    for outcome in outcomes:
+        print(f"PR #{outcome.number}: {outcome.action} — {outcome.reason}")
+
+    reconciled = [o for o in outcomes if o.action == RECONCILED]
+    failed = [o for o in outcomes if o.action == FAILED]
+
+    for outcome in reconciled:
+        print(
+            f"::warning::PR #{outcome.number}: a READY_TO_MERGE verdict had lost "
+            f"its atlan-ci approval; the reconciler posted it ({outcome.reason}). "
+            f"The stamper that should have posted it failed — check that run."
+        )
+    for outcome in failed:
+        print(
+            f"::error::PR #{outcome.number}: a READY_TO_MERGE verdict is still "
+            f"missing its atlan-ci approval and the reconciler could not post it "
+            f"either. atlan-ci quota is likely still exhausted."
+        )
+
+    if not reconciled and not failed:
+        print("Nothing to reconcile.")
+
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not summary_path or not (reconciled or failed):
+        return
+    lines = ["## SDK review approvals reconciled", ""]
+    for outcome in reconciled + failed:
+        url = f"https://github.com/{repo}/pull/{outcome.number}"
+        lines.append(
+            f"- **{outcome.action}** [#{outcome.number}]({url}) — {outcome.reason}"
+        )
+    with open(summary_path, "a", encoding="utf-8") as handle:
+        handle.write("\n".join(lines) + "\n")
+
+
+def main(argv: list[str] | None = None, runner: Runner = subprocess.run) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo", required=True, help="owner/repo, e.g. atlanhq/application-sdk"
+    )
+    parser.add_argument(
+        "--min-age-minutes",
+        type=int,
+        default=DEFAULT_MIN_AGE_MINUTES,
+        help=(
+            "Age a verdict comment must reach before its missing approval counts "
+            "as lost rather than in flight (default "
+            f"{DEFAULT_MIN_AGE_MINUTES}min, above the fast path's 10min ceiling)."
+        ),
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report which PRs would be reconciled without approving any of them.",
+    )
+    args = parser.parse_args(argv)
+
+    outcomes = sweep(
+        args.repo,
+        runner=runner,
+        min_age=timedelta(minutes=args.min_age_minutes),
+        dry_run=args.dry_run,
+    )
+    report(outcomes, args.repo)
+    return 1 if any(outcome.action == FAILED for outcome in outcomes) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/tests/test_sdk_review_approve.py
+++ b/.github/scripts/tests/test_sdk_review_approve.py
@@ -597,10 +597,22 @@ def test_label_guard_reads_the_snapshot_not_the_label_it_just_wrote(monkeypatch)
     """
     gh = slow_gh(labels=[])
     assert run_main(gh, monkeypatch, **slow_env()) == 0
-    # It still reconciles labels (that part is unconditional)...
-    assert gh.called(is_label_add)
-    # ...but the freshly-added label must not satisfy its own guard.
     assert gh.called(is_approve) == []
+
+
+def test_a_fired_label_guard_does_not_resurrect_the_stripped_label(monkeypatch):
+    """Bailing must happen before the label reconcile, not after it.
+
+    `sdk-review-approved` is what every invalidator strips and what
+    sdk_review_reconcile.py's cron gates on. Re-adding it on the way to
+    declining the approval would leave the PR wearing a label with nothing
+    behind it, and the next reconciler tick would read that as a lost stamp and
+    approve a verdict a human had deliberately cleared.
+    """
+    gh = slow_gh(labels=[])
+    assert run_main(gh, monkeypatch, **slow_env()) == 0
+    assert gh.called(is_label_add) == []
+    assert gh.called(lambda a: "DELETE" in a) == []
 
 
 def test_fast_path_does_not_require_the_label(monkeypatch):

--- a/.github/scripts/tests/test_sdk_review_reconcile.py
+++ b/.github/scripts/tests/test_sdk_review_reconcile.py
@@ -1,0 +1,490 @@
+"""Tests for the SDK review approval reconciler.
+
+The regression these pin: a PR whose READY_TO_MERGE verdict still stands but
+whose `atlan-ci` approval was lost (rate-limited stamper) must get one posted
+without a human re-running a job — and *only* such a PR. Every guard that stops
+the reconciler blessing something it should not is asserted here, because the
+thing it drives is a CODEOWNER approval on `main`.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parents[1]
+
+
+def _load(name: str):
+    spec = importlib.util.spec_from_file_location(name, SCRIPTS / f"{name}.py")
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    # Registered before exec: @dataclass resolves annotations through
+    # sys.modules[cls.__module__], which is absent for a bare module_from_spec.
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+approve = _load("sdk_review_approve")
+reconcile = _load("sdk_review_reconcile")
+
+
+REPO = "atlanhq/application-sdk"
+PR = 7
+HEAD = "a2f276a06384ad38ba3e2e96820a313ed3859db2"
+OTHER = "51c160b06a2a350289c7d779f4ab887503f98685"
+
+APP_TOKEN = "app-token"
+PAT = "pat-atlan-ci"
+
+NOW = datetime(2026, 8, 17, 12, 0, 0, tzinfo=timezone.utc)
+OLD = "2026-08-17T11:00:00Z"  # an hour before NOW — past the age gate
+RECENT = "2026-08-17T11:59:00Z"  # a minute before NOW — still possibly in flight
+
+RATE_LIMIT_STDERR = "gh: API rate limit exceeded for user ID 62283865. (HTTP 403)"
+
+
+def ok(stdout: str = "") -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
+
+
+def fail(stderr: str, code: int = 1) -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(
+        args=[], returncode=code, stdout="", stderr=stderr
+    )
+
+
+def verdict_body(verdict: str = "READY_TO_MERGE", head: str = HEAD) -> str:
+    return (
+        "<!-- SDK_REVIEW -->\n"
+        f"<!-- VERDICT: {verdict} -->\n"
+        f"<!-- REVIEWED_HEAD: {head} -->\n"
+        "## SDK Review (mothership)\n"
+    )
+
+
+def comment(
+    body: str | None = None,
+    created_at: str = OLD,
+    login: str = "mothership-ai[bot]",
+    comment_id: int = 5,
+) -> dict:
+    return {
+        "id": comment_id,
+        "body": verdict_body() if body is None else body,
+        "created_at": created_at,
+        "user": {"login": login},
+    }
+
+
+def pull(
+    number: int = PR,
+    head: str = HEAD,
+    labels: list[str] | None = None,
+) -> dict:
+    names = ["sdk-review-approved"] if labels is None else labels
+    return {
+        "number": number,
+        "head": {"sha": head},
+        "labels": [{"name": name} for name in names],
+    }
+
+
+def bot_approval() -> dict:
+    return {
+        "id": 91,
+        "state": "APPROVED",
+        "user": {"login": "atlan-ci"},
+        "body": approve.APPROVAL_SIGNATURE + " READY TO MERGE.",
+    }
+
+
+class FakeGH:
+    """Records every `gh` invocation and answers from registered matchers."""
+
+    def __init__(self) -> None:
+        self.calls: list[list[str]] = []
+        self.tokens: list[str | None] = []
+        self.matchers: list[tuple] = []
+
+    def on(self, predicate, response) -> None:
+        """Later registrations override earlier ones, so a test can re-point a
+        path that `base_gh()` already stubbed."""
+        self.matchers.append((predicate, response))
+
+    def __call__(self, argv, **kwargs):
+        self.calls.append(list(argv))
+        env = kwargs.get("env") or {}
+        self.tokens.append(env.get("GH_TOKEN"))
+        for predicate, response in reversed(self.matchers):
+            if predicate(argv):
+                return response() if callable(response) else response
+        return ok()
+
+    def called(self, predicate) -> list[list[str]]:
+        return [argv for argv in self.calls if predicate(argv)]
+
+    def approver_calls(self) -> list[list[str]]:
+        return [argv for argv, token in zip(self.calls, self.tokens) if token == PAT]
+
+
+def is_pr_list(argv) -> bool:
+    # `--paginate` sits before the path here, so match on any positional.
+    return argv[1] == "api" and any(
+        arg.startswith(f"repos/{REPO}/pulls?state=open") for arg in argv
+    )
+
+
+def is_review_list(argv) -> bool:
+    return (
+        argv[1] == "api"
+        and argv[2] == f"repos/{REPO}/pulls/{PR}/reviews"
+        and "--paginate" in argv
+    )
+
+
+def is_approve(argv) -> bool:
+    return (
+        argv[1] == "api"
+        and argv[2] == f"repos/{REPO}/pulls/{PR}/reviews"
+        and "POST" in argv
+    )
+
+
+def is_status(argv) -> bool:
+    return argv[1] == "api" and argv[2].startswith(f"repos/{REPO}/statuses/")
+
+
+def is_label_write(argv) -> bool:
+    return argv[1] == "api" and f"repos/{REPO}/issues/{PR}/labels" in argv[2]
+
+
+def base_gh(
+    prs: list[dict] | None = None,
+    comments: list[dict] | None = None,
+    reviews: list[dict] | None = None,
+    labels: list[str] | None = None,
+) -> FakeGH:
+    """A repo where PR #7 carries a standing READY verdict and no approval."""
+    gh = FakeGH()
+    gh.on(
+        is_pr_list,
+        ok("\n".join(json.dumps(pr) for pr in (prs if prs is not None else [pull()]))),
+    )
+    # Stateful on purpose: a successful APPROVE has to become visible to the
+    # next review listing, because that read-back is how the sweep tells an
+    # actual recovery from a stamp its own guards declined.
+    gh.on(
+        is_review_list,
+        lambda: ok(
+            json.dumps(
+                [(reviews or []) + ([bot_approval()] if gh.called(is_approve) else [])]
+            )
+        ),
+    )
+    gh.on(
+        lambda a: a[2] == f"repos/{REPO}/issues/{PR}/comments",
+        ok(json.dumps([comments if comments is not None else [comment()]])),
+    )
+    # Read back by the stamper itself (fresh head + label snapshot).
+    gh.on(lambda a: a[2] == f"repos/{REPO}/pulls/{PR}", ok(HEAD + "\n"))
+    gh.on(
+        lambda a: a[2] == f"repos/{REPO}/issues/{PR}" and "--jq" in a,
+        ok("\n".join(["sdk-review-approved"] if labels is None else labels)),
+    )
+    return gh
+
+
+@pytest.fixture(autouse=True)
+def _tokens(monkeypatch):
+    monkeypatch.setenv("GH_TOKEN", APP_TOKEN)
+    monkeypatch.setenv("APPROVER_TOKEN", PAT)
+
+
+def run_sweep(gh: FakeGH, **kwargs) -> list:
+    return reconcile.sweep(REPO, runner=gh, now=NOW, **kwargs)
+
+
+# --- the recovery this exists for ----------------------------------------
+
+
+def test_lost_approval_is_reconciled():
+    gh = base_gh()
+    outcomes = run_sweep(gh)
+
+    assert [(o.number, o.action) for o in outcomes] == [(PR, reconcile.RECONCILED)]
+    posted = gh.called(is_approve)
+    assert len(posted) == 1
+    # Pinned to the reviewed sha, not merely "the head at POST time".
+    assert f"commit_id={HEAD}" in posted[0]
+
+
+def test_reconcile_spends_exactly_one_atlan_ci_request():
+    """The reconciler must not become a new source of the exhaustion it recovers
+    from: every read runs on the App token, the PAT only on the APPROVE."""
+    gh = base_gh()
+    run_sweep(gh)
+
+    approver = gh.approver_calls()
+    assert len(approver) == 1
+    assert is_approve(approver[0])
+
+
+def test_reconcile_does_not_green_the_sdk_review_status():
+    """A green `sdk-review` check with no approving review is the misleading
+    state this whole mechanism exists to avoid — the reconciler never writes it."""
+    gh = base_gh()
+    run_sweep(gh)
+
+    assert gh.called(is_status) == []
+
+
+# --- guards ---------------------------------------------------------------
+
+
+def test_pr_without_the_approved_label_is_left_alone():
+    """`sdk-review-approved` is the one signal every invalidator clears, so its
+    absence means a dismissal, downgrade or push has spoken since the verdict."""
+    gh = base_gh(prs=[pull(labels=["needs-triage"])])
+    outcomes = run_sweep(gh)
+
+    assert outcomes == []
+    assert gh.called(is_approve) == []
+    # Not even the review listing is spent on an unlabelled PR.
+    assert gh.called(is_review_list) == []
+
+
+def test_label_stripped_between_the_sweep_and_the_stamp_still_blocks():
+    """The sweep's listing can be stale by the time the stamp runs; the stamper
+    re-reads the label under REQUIRE_APPROVED_LABEL and refuses."""
+    gh = base_gh(labels=[])  # the stamper's own label read comes back empty
+    outcomes = run_sweep(gh)
+
+    assert [o.action for o in outcomes] == [reconcile.SKIPPED]
+    assert "declined" in outcomes[0].reason
+    assert gh.called(is_approve) == []
+
+
+def test_declining_the_stamp_does_not_resurrect_the_stripped_label():
+    """The label is what this cron gates on. If declining to approve re-added
+    it, the next tick would read the resurrected label as a lost stamp and
+    approve a PR whose verdict an invalidator had deliberately cleared."""
+    gh = base_gh(labels=[])
+    run_sweep(gh)
+
+    assert gh.called(is_label_write) == []
+
+
+def test_a_declined_stamp_is_not_reported_as_a_recovery(capsys):
+    """Exit 0 from the stamper means "approved OR guarded"; reporting the second
+    as a recovery would be the same class of lie this cron exists to catch."""
+    gh = base_gh(labels=[])
+    reconcile.report(run_sweep(gh), REPO)
+
+    assert "::warning::" not in capsys.readouterr().out
+
+
+def test_head_moved_past_the_verdict_is_left_alone():
+    gh = base_gh(prs=[pull(head=OTHER)])
+    outcomes = run_sweep(gh)
+
+    assert [o.action for o in outcomes] == [reconcile.SKIPPED]
+    assert "head moved" in outcomes[0].reason
+    assert gh.called(is_approve) == []
+
+
+def test_existing_bot_approval_is_a_no_op():
+    gh = base_gh(reviews=[bot_approval()])
+    outcomes = run_sweep(gh)
+
+    assert [o.action for o in outcomes] == [reconcile.SKIPPED]
+    assert outcomes[0].reason == "already approved"
+    assert gh.called(is_approve) == []
+    # Short-circuits before the comment listing is spent.
+    assert gh.called(lambda a: a[2].endswith(f"issues/{PR}/comments")) == []
+
+
+def test_a_human_approval_does_not_count_as_the_bot_approval():
+    """Only an atlan-ci review bearing the bot signature proves the stamp
+    landed; a human approval is a different thing entirely."""
+    human = {
+        "id": 4,
+        "state": "APPROVED",
+        "user": {"login": "some-engineer"},
+        "body": "lgtm",
+    }
+    gh = base_gh(reviews=[human])
+    outcomes = run_sweep(gh)
+
+    assert [o.action for o in outcomes] == [reconcile.RECONCILED]
+
+
+def test_non_ready_verdict_is_left_alone():
+    gh = base_gh(comments=[comment(body=verdict_body("NEEDS_FIXES"))])
+    outcomes = run_sweep(gh)
+
+    assert [o.action for o in outcomes] == [reconcile.SKIPPED]
+    assert gh.called(is_approve) == []
+
+
+def test_forged_verdict_comment_from_another_login_is_ignored():
+    """A marker alone is not proof of authorship; only mothership-ai[bot]'s
+    verdicts may drive the atlan-ci approval."""
+    gh = base_gh(comments=[comment(login="drive-by")])
+    outcomes = run_sweep(gh)
+
+    assert [o.action for o in outcomes] == [reconcile.SKIPPED]
+    assert outcomes[0].reason == "no verdict comment"
+    assert gh.called(is_approve) == []
+
+
+def test_verdict_without_reviewed_head_is_left_alone():
+    gh = base_gh(
+        comments=[comment(body="<!-- SDK_REVIEW -->\n### Verdict: READY TO MERGE")]
+    )
+    outcomes = run_sweep(gh)
+
+    assert [o.action for o in outcomes] == [reconcile.SKIPPED]
+    assert gh.called(is_approve) == []
+
+
+def test_recent_verdict_is_left_to_the_fast_path():
+    """A fast-path run for the same comment may still be retrying; reconciling
+    underneath it would risk a duplicate approval."""
+    gh = base_gh(comments=[comment(created_at=RECENT)])
+    outcomes = run_sweep(gh)
+
+    assert [o.action for o in outcomes] == [reconcile.SKIPPED]
+    assert outcomes[0].reason == "verdict too recent to be lost"
+    assert gh.called(is_approve) == []
+
+
+def test_unparseable_comment_timestamp_is_treated_as_too_recent():
+    gh = base_gh(comments=[comment(created_at="not-a-date")])
+    outcomes = run_sweep(gh)
+
+    assert [o.action for o in outcomes] == [reconcile.SKIPPED]
+    assert gh.called(is_approve) == []
+
+
+def test_dry_run_reports_without_approving():
+    gh = base_gh()
+    outcomes = run_sweep(gh, dry_run=True)
+
+    assert [o.action for o in outcomes] == [reconcile.SKIPPED]
+    assert "would reconcile" in outcomes[0].reason
+    assert gh.called(is_approve) == []
+
+
+# --- failure reporting ----------------------------------------------------
+
+
+def test_still_rate_limited_reports_failed_and_does_not_retry_in_process():
+    """APPROVE_MAX_ATTEMPTS=1: this cron is the retry loop, so the stamper must
+    not hold the runner waiting out a primary-quota reset."""
+    gh = base_gh()
+    gh.on(is_approve, fail(RATE_LIMIT_STDERR))
+    outcomes = run_sweep(gh)
+
+    assert [o.action for o in outcomes] == [reconcile.FAILED]
+    assert len(gh.called(is_approve)) == 1
+    assert gh.called(is_status) == []
+
+
+def test_main_exits_nonzero_when_a_reconcile_failed(monkeypatch, capsys):
+    monkeypatch.setattr(
+        reconcile,
+        "sweep",
+        lambda *args, **kwargs: [
+            reconcile.Outcome(PR, reconcile.FAILED, "approval could not be posted")
+        ],
+    )
+    assert reconcile.main(["--repo", REPO]) == 1
+    assert "::error::" in capsys.readouterr().out
+
+
+def test_main_exits_zero_and_says_so_when_there_is_nothing_to_do(monkeypatch, capsys):
+    monkeypatch.setattr(reconcile, "sweep", lambda *args, **kwargs: [])
+    assert reconcile.main(["--repo", REPO]) == 0
+    assert "Nothing to reconcile." in capsys.readouterr().out
+
+
+def test_reconciling_emits_a_warning_annotation(capsys):
+    """Silent recovery would hide a worsening rate-limit problem."""
+    reconcile.report(
+        [reconcile.Outcome(PR, reconcile.RECONCILED, f"approved at {HEAD}")], REPO
+    )
+
+    out = capsys.readouterr().out
+    assert "::warning::" in out
+    assert f"PR #{PR}" in out
+
+
+def test_reconciling_writes_a_job_summary(tmp_path, monkeypatch):
+    summary = tmp_path / "summary.md"
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary))
+    reconcile.report([reconcile.Outcome(PR, reconcile.RECONCILED, "approved")], REPO)
+
+    written = summary.read_text()
+    assert f"https://github.com/{REPO}/pull/{PR}" in written
+
+
+def test_quiet_sweep_writes_no_job_summary(tmp_path, monkeypatch):
+    summary = tmp_path / "summary.md"
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary))
+    reconcile.report(
+        [reconcile.Outcome(PR, reconcile.SKIPPED, "already approved")], REPO
+    )
+
+    assert not summary.exists()
+
+
+# --- environment hygiene --------------------------------------------------
+
+
+def test_stamper_env_is_restored_after_each_pr(monkeypatch):
+    """The stamper reads its inputs from os.environ, so driving it in a loop
+    must not leak one PR's settings into the next iteration — or into whatever
+    else shares this process."""
+    monkeypatch.setenv("WRITE_STATUS", "true")
+    monkeypatch.delenv("PR_NUMBER", raising=False)
+
+    with reconcile.stamper_env({"WRITE_STATUS": "false", "PR_NUMBER": "7"}):
+        pass
+
+    assert os.environ["WRITE_STATUS"] == "true"
+    assert "PR_NUMBER" not in os.environ
+
+
+def test_sweep_covers_every_labelled_pr():
+    gh = base_gh(prs=[pull(number=3, labels=[]), pull(number=PR)])
+    outcomes = run_sweep(gh)
+
+    # The unlabelled PR is not reported at all; the labelled one is reconciled.
+    assert [(o.number, o.action) for o in outcomes] == [(PR, reconcile.RECONCILED)]
+
+
+def test_pr_listing_failure_is_loud():
+    gh = FakeGH()
+    gh.on(is_pr_list, fail("boom"))
+
+    with pytest.raises(SystemExit, match="failed to list open PRs"):
+        run_sweep(gh)
+
+
+# --- min-age plumbing -----------------------------------------------------
+
+
+def test_min_age_is_configurable():
+    gh = base_gh(comments=[comment(created_at=RECENT)])
+    outcomes = run_sweep(gh, min_age=timedelta(seconds=30))
+
+    assert [o.action for o in outcomes] == [reconcile.RECONCILED]

--- a/.github/workflows/sdk-review-reconcile.yml
+++ b/.github/workflows/sdk-review-reconcile.yml
@@ -1,0 +1,90 @@
+# Safety net for the SDK review approval path: post approvals that were
+# computed but never landed.
+#
+# Why this exists:
+#   `sdk-review-approve-on-verdict.yml` computes the verdict and then posts the
+#   formal approval as `atlan-ci` — the CODEOWNER whose approval satisfies
+#   branch protection on `main`. When that one POST fails (the trigger has been
+#   `atlan-ci` exhausting its 5,000 req/hr primary REST quota) the run dies and
+#   nothing retries it. The PR is left with a review summary, the
+#   `sdk-review-approved` label, and no approving review — and recovery was a
+#   human noticing and running `gh run rerun --failed` by hand.
+#
+#   PR #3162 shrank that window (one `atlan-ci` request per fire instead of ~15,
+#   plus rate-limit-aware retry) but could not close it: primary quota can reset
+#   up to an hour out and the stamper deliberately fails fast rather than hold a
+#   runner that long. This sweep is the durable answer because it does not care
+#   why the stamp was lost.
+#
+# Guards live in .github/scripts/sdk_review_reconcile.py, tested in
+# .github/scripts/tests/. In short: the `sdk-review-approved` label must still
+# be on the PR (every invalidator clears it), the newest mothership-ai[bot]
+# verdict must be READY_TO_MERGE at the PR's live head, there must be no
+# existing bot approval, and the verdict must be old enough that no fast-path
+# run could still be in flight for it.
+#
+# 10-minute cadence. Per tick that is one paginated PR listing plus two reads
+# per `sdk-review-approved` PR — negligible against the fleet App token's own
+# quota, which is the point: a reconciler polling every PR on the `atlan-ci` PAT
+# would become a new source of the exhaustion it exists to recover from. The PAT
+# is spent only on the APPROVE call, once per PR actually approved.
+
+name: SDK Review — reconcile lost approvals
+
+on:
+  schedule:
+    - cron: "*/10 * * * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Report which PRs would be reconciled without approving any"
+        type: boolean
+        default: false
+
+# github.token only needs contents:read for the checkout; every API call the
+# sweep makes runs under the fleet App token minted below, and the one APPROVE
+# runs under the atlan-ci PAT.
+permissions:
+  contents: read
+
+concurrency:
+  group: sdk-review-reconcile
+  cancel-in-progress: false
+
+jobs:
+  reconcile:
+    name: Re-drive missing atlan-ci approvals
+    runs-on: ubuntu-latest
+    # Without an explicit ceiling this inherits GitHub's 6h default. Paired with
+    # cancel-in-progress: false, a hung run would queue every subsequent tick
+    # behind it instead of just skipping a cycle.
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          sparse-checkout: .github/scripts
+          sparse-checkout-cone-mode: false
+
+      - name: Mint fleet App token
+        # Carries its own rate-limit quota, independent of the `atlan-ci` user
+        # quota that ORG_PAT_GITHUB draws on. Same App the stamper uses.
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          app-id: ${{ secrets.FLEET_APP_ID }}
+          private-key: ${{ secrets.FLEET_APP_PRIVATE_KEY }}
+          owner: atlanhq
+          repositories: application-sdk
+
+      - name: Reconcile lost approvals
+        env:
+          # Every call the sweep makes, and every call the stamper makes except
+          # APPROVE.
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          # The APPROVE call only — atlan-ci is the CODEOWNER whose approval
+          # satisfies branch protection.
+          APPROVER_TOKEN: ${{ secrets.ORG_PAT_GITHUB }}
+        run: |
+          python3 .github/scripts/sdk_review_reconcile.py \
+            --repo "${{ github.repository }}" \
+            ${{ inputs.dry_run && '--dry-run' || '' }}


### PR DESCRIPTION
Closes FND-314. Follow-up 3 from #3162.

## The gap

When `@sdk-review` returns `READY_TO_MERGE` but the `atlan-ci` approval POST fails, the run dies and nothing re-drives it. The PR is left with a green review summary, the `sdk-review-approved` label, and no approving review — a state that reads as "the bot is done" while the merge gate is still blocked. Recovery was a human noticing and running `gh run rerun --failed`; on 2026-08-12 that was needed three separate times.

#3162 shrank the window — one `atlan-ci` request per fire instead of ~15, plus rate-limit-aware retry — but could not close it:

* Primary quota can reset up to an hour out, and the stamper deliberately fails fast rather than hold a runner that long. That unrecovered case is by design.
* `issue_comment` workflows always execute from the default branch, so the hardening only protects PRs after it lands on `main` — it could not protect its own approval.

A reconciler is the durable answer because it is independent of *why* the stamp was lost.

## What this adds

`.github/workflows/sdk-review-reconcile.yml` — a 10-minute cron (plus `workflow_dispatch` with a `dry_run` input) driving `.github/scripts/sdk_review_reconcile.py`. The sweep re-invokes the existing `sdk_review_approve.py` per PR rather than reimplementing any of its logic.

Four guards, all required before a PR is touched:

1. **`sdk-review-approved` is still on the PR.** The one signal every invalidator clears — `dismiss-on-human` strips it (and notably does *not* touch the commit status, so the status cannot substitute), `downgrade-on-ci-failure` strips it, `reset-on-push` strips it. Reconciling without it would re-approve PRs a human has already engaged with.
2. **No existing `atlan-ci` approval with the bot signature.** A healthy PR is a no-op and never collects a duplicate.
3. **The newest `mothership-ai[bot]` verdict is `READY_TO_MERGE` and its `REVIEWED_HEAD` equals the PR's live head.** Reconciling past a push would bless unreviewed code.
4. **That verdict is at least 12 minutes old** (`--min-age-minutes`). Not in the original design — added because without it the sweep can race a fast-path run still in flight for the same comment (its job ceiling is 10 minutes including backoff) and both could POST. The cost is latency: recovery lands one grace period plus up to one interval after the loss, ~22 min worst case, rather than within a single interval.

The stamper re-checks 1–3 itself against fresh reads, so a dismissal landing mid-sweep is still caught. The sweep's own checks are a prefilter that keeps it cheap and tells us when a recovery actually happened.

## Safety properties

* **Never writes the `sdk-review` commit status** (`WRITE_STATUS=false`). A green status with no approving review is the misleading state this whole mechanism exists to avoid creating.
* **Every read runs on the fleet App token.** A reconciler polling every PR on the `atlan-ci` PAT would become a new source of the exhaustion it exists to recover from. Guard order is by cost: the label check is free (the `/pulls` listing carries `labels` and `head.sha`), the review listing short-circuits the healthy majority, and only then is the comment listing spent — ~3 App requests per tick on this repo today.
* **`APPROVE_MAX_ATTEMPTS=1`**, so the PAT is spent on exactly one request per PR approved. This cron *is* the retry loop; retrying in-process would only duplicate it.
* **The sweep confirms the approval landed** rather than trusting the stamper's exit code, which is 0 both when it approved and when one of its own guards declined. Reporting a recovery that did not happen would be the same class of lie this PR is about.

## Bug fixed en route

`sdk_review_approve.py` reconciled labels **before** evaluating `REQUIRE_APPROVED_LABEL`. So when the guard fired — verdict invalidated by a dismissal, downgrade or push — `label_plan()` had already re-added `sdk-review-approved` on the way to declining the approval. The PR would then wear the label with nothing behind it, and since this reconciler gates on exactly that label, the *next* tick would read the resurrected label as a lost stamp and approve a verdict a human had deliberately cleared.

The guard now bails before any write. Only `READY` is gated: a `NEEDS_FIXES`/`NEEDS_HUMAN` verdict still has to clear labels and dismiss a stale approval regardless of what the label says. This also affected the existing slow path in `sdk-review.yml`, just without a cron to compound it.

## Signal

A reconcile emits a `::warning::` plus a job-summary entry with the PR link, and names the stamper run that should have posted it. A reconcile that still cannot post reds the run. Silent recovery would hide a worsening rate-limit problem, which is the thing most worth knowing about here.

## Tests

26 new in `.github/scripts/tests/test_sdk_review_reconcile.py`, one per guard plus the label-resurrection regression and the request-budget assertion. The `atlan-ci`-request count is asserted directly by tracking which token each stubbed `gh` call carried. Full `.github/scripts/tests` suite (2297) passes; pre-commit clean.

## Rollout

The cron is inert until this merges — scheduled workflows only run from the default branch. First run can be exercised with `workflow_dispatch` + `dry_run: true`, which reports which PRs *would* be reconciled without approving any.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
