### PR TITLE
ci(fix): pre-flight the approver quota in the sdk-review reconciler (FND-314)

### DIFF
--- a/.github/scripts/sdk_review_approve.py
+++ b/.github/scripts/sdk_review_approve.py
@@ -726,7 +726,15 @@ def stamp_verdict(
         if stale is None:
             # Cannot see the reviews, so cannot clear a superseded approval. The
             # merge gate would stay open on it, which is the wrong way to fail —
-            # so leave everything else as-is and fail loudly to be re-driven.
+            # so leave the approval itself untouched and fail loudly to be
+            # re-driven. The failure status is still written: without it a prior
+            # green `sdk-review` status on this same head would outlive the
+            # verdict that superseded it. The status POST is independent of the
+            # reviews listing, and post_status is already best-effort (it warns
+            # rather than raising), so a second degradation costs a warning, not
+            # a harder failure.
+            if write_status:
+                client.post_status(head_sha, state, description)
             print(
                 f"::error::PR #{pr_number}: verdict is {verdict} but the review "
                 f"listing could not be read, so a stale bot approval cannot be "

--- a/.github/scripts/sdk_review_approve.py
+++ b/.github/scripts/sdk_review_approve.py
@@ -54,10 +54,11 @@ sets REQUIRE_APPROVED_LABEL so it will not approve a verdict something has since
 invalidated.
 
 The reconciler (`sdk_review_reconcile.py`, on a cron) drives this per PR with the
-same environment as the slow path, plus APPROVE_MAX_ATTEMPTS=1: it exists to
-recover approvals the other two paths lost, so retrying in-process would only
-duplicate the loop it already is. That also holds it to exactly one `atlan-ci`
-request per PR it approves.
+same environment as the slow path, on a short retry budget: it exists to recover
+approvals the other two paths lost, so waiting out a long rate-limit window
+in-process would only duplicate the loop it already is. It calls
+`stamp_verdict()` rather than `main()`, because it has to report whether an
+approval was actually posted and an exit code cannot say.
 
 That label guard is the solo-approval safety property. `sdk-review-approved` is
 the one signal every invalidator clears: `dismiss-on-human` strips it (and
@@ -90,9 +91,11 @@ Environment:
     APPROVE_MAX_ATTEMPTS        default 3
     APPROVE_MAX_WAIT_SECONDS    total sleep budget across retries, default 120
 
-Exit status:
+Exit status (`main()`; in-process callers should read `stamp_verdict()`'s action
+instead, which separates "approved" from "a guard declined"):
     0  stamped, or intentionally skipped by a guard
-    1  verdict was READY_TO_MERGE but the approval could not be posted
+    1  the verdict could not be stamped: the approval failed, or the review
+       listing could not be read and approving blind is not an option
 """
 
 from __future__ import annotations
@@ -103,9 +106,37 @@ import re
 import subprocess
 import time
 from collections.abc import Callable
+from dataclasses import dataclass
 
 Runner = Callable[..., subprocess.CompletedProcess]
 Sleeper = Callable[[float], None]
+
+APPROVED = "approved"
+SKIPPED = "skipped"
+FAILED = "failed"
+
+
+@dataclass(frozen=True)
+class StampOutcome:
+    """What a stamp run did, for callers that need more than an exit code.
+
+    An exit status cannot separate "posted the approval" from "a guard declined
+    to" — both are a successful run, and `main()` returns 0 for each. The
+    reconciler needs that distinction to report an actual recovery rather than
+    guess at one.
+
+    Recovering it from a follow-up read does not work: GitHub's reviews listing
+    is read-after-write eventually consistent, so an approval posted moments ago
+    can be missing from the very next listing. The reconciler's first live run
+    did exactly that — approved PR #3232, re-read, saw nothing, and reported
+    that the stamper had declined. So the stamper says what it did instead of
+    the caller inferring it.
+    """
+
+    action: str
+    exit_code: int
+    detail: str = ""
+
 
 SUMMARY_MARKERS = ("<!-- SDK_REVIEW -->", "<!-- TEST_SDK_REVIEW -->")
 
@@ -255,17 +286,30 @@ class Client:
             return None
         return result.stdout.strip() or None
 
-    def _paginated(self, path: str) -> list[dict]:
-        """Flatten a `--paginate --slurp` response into a list of objects."""
+    def _paginated(self, path: str) -> list[dict] | None:
+        """Flatten a `--paginate --slurp` response, or None if it could not be read.
+
+        None and `[]` are deliberately different values. They used to be the
+        same one, and that collapsed "the API did not answer" into "there is
+        nothing there" — which is safe for a comment listing (no verdict means
+        do nothing) and dangerous for a review listing, where "no approvals
+        exist" is the precondition for posting one.
+
+        Seen in production on 2026-08-17: GitHub's reviews endpoint began
+        returning `404` (and, to other tokens, truncated JSON) for PRs that
+        plainly had reviews. Every caller read that as an empty list, so the
+        duplicate-approval guard was satisfied by an outage and `atlan-ci`
+        re-approved the same PR once per reconciler tick.
+        """
         result = self.run(["api", f"repos/{self.repo}/{path}", "--paginate", "--slurp"])
         if result.returncode != 0:
             print(f"::warning::could not list {path}: {result.stderr.strip()}")
-            return []
+            return None
         try:
             pages = json.loads(result.stdout or "[]")
         except json.JSONDecodeError as exc:
             print(f"::warning::could not parse {path} ({exc})")
-            return []
+            return None
         items: list[dict] = []
         for page in pages:
             # An un-paginated response is a bare array; --slurp adds one level.
@@ -282,10 +326,13 @@ class Client:
         A marker alone is not proof of authorship, so a forged verdict comment
         from any other login is filtered out here — covering both
         `newest_summary_comment_id()` and `latest_summary_body()` at once.
+
+        An unreadable listing collapses to empty here, which is the safe
+        direction for this one: no verdict found means no stamp is applied.
         """
         return [
             comment
-            for comment in self._paginated(f"issues/{self.pr_number}/comments")
+            for comment in (self._paginated(f"issues/{self.pr_number}/comments") or [])
             if _is_verdict_comment(comment)
         ]
 
@@ -398,11 +445,21 @@ class Client:
         else:
             print(f"Set sdk-review status: {state} ({description})")
 
-    def bot_approval_ids(self) -> list[int]:
-        """Ids of live atlan-ci approvals bearing our signature."""
+    def bot_approval_ids(self) -> list[int] | None:
+        """Ids of live atlan-ci approvals bearing our signature, or None.
+
+        None means the review listing could not be read, which every caller must
+        treat as "cannot prove there is no approval" rather than "there is no
+        approval". Approving on an unreadable listing is how a GitHub
+        degradation turns into a pile of duplicate approvals; dismissing on one
+        would be worse.
+        """
+        reviews = self._paginated(f"pulls/{self.pr_number}/reviews")
+        if reviews is None:
+            return None
         return [
             review.get("id")
-            for review in self._paginated(f"pulls/{self.pr_number}/reviews")
+            for review in reviews
             if review.get("state") == "APPROVED"
             and (review.get("user") or {}).get("login") == "atlan-ci"
             and (review.get("body") or "").startswith(APPROVAL_SIGNATURE)
@@ -520,11 +577,12 @@ def post_approval_with_retry(
     return False
 
 
-def main(
+def stamp_verdict(
     runner: Runner = subprocess.run,
     sleeper: Sleeper = time.sleep,
     now: Callable[[], float] = time.time,
-) -> int:
+) -> StampOutcome:
+    """Apply the verdict's labels, approval and status. See module docstring."""
     repo = os.environ.get("REPO", "")
     pr_number = os.environ.get("PR_NUMBER", "")
     body = os.environ.get("COMMENT_BODY", "")
@@ -549,7 +607,7 @@ def main(
                 f"#{pr_number} — skipping (the sandbox may have errored before "
                 f"posting)."
             )
-            return 0
+            return StampOutcome(SKIPPED, 0, "no summary comment")
 
     verdict = extract_verdict(body)
     if not verdict:
@@ -557,7 +615,7 @@ def main(
             f"::warning::PR #{pr_number}: could not extract a verdict from the "
             f"mothership-ai comment. Skipping."
         )
-        return 0
+        return StampOutcome(SKIPPED, 0, "no verdict in the comment")
     print(f"Detected verdict: '{verdict}'")
 
     # A comment with no REVIEWED_HEAD predates the stamp; its reviewed sha
@@ -568,12 +626,12 @@ def main(
             f"::warning::PR #{pr_number}: verdict comment has no REVIEWED_HEAD "
             f"marker — cannot confirm which sha was reviewed; skipping all stamps."
         )
-        return 0
+        return StampOutcome(SKIPPED, 0, "verdict has no REVIEWED_HEAD")
 
     head_sha = client.head_sha()
     if not head_sha:
         print(f"::warning::PR #{pr_number}: HEAD unresolvable — skipping all stamps.")
-        return 0
+        return StampOutcome(SKIPPED, 0, "head unresolvable")
 
     # The verdict was computed for reviewed_head. A push since then means the
     # current head is unreviewed, and stamping it would bless unreviewed code.
@@ -582,7 +640,7 @@ def main(
             f"::warning::PR #{pr_number}: verdict was computed for {reviewed_head} "
             f"but current head is {head_sha} — skipping all stamps."
         )
-        return 0
+        return StampOutcome(SKIPPED, 0, "head moved past the verdict")
 
     # Belt-and-suspenders for the slow path: the review can take 10–30 minutes,
     # and the sandbox could in principle have reviewed a sha other than the one
@@ -592,7 +650,7 @@ def main(
             f"::warning::PR #{pr_number}: head is {head_sha} but this run was "
             f"dispatched for {expected_head} — skipping all stamps."
         )
-        return 0
+        return StampOutcome(SKIPPED, 0, "head is not the dispatched sha")
 
     # The job's concurrency group serialises runs per PR, but GitHub's queue is
     # not event-time ordered: after waiting, this run may execute after a newer
@@ -606,7 +664,7 @@ def main(
                 f"(id={newest_id}) supersedes this one (id={triggering_id}) — "
                 f"skipping."
             )
-            return 0
+            return StampOutcome(SKIPPED, 0, "superseded by a newer verdict")
 
     # Snapshot BEFORE reconciling: `require_approved_label` asks whether the
     # label was standing when this run started, which the post-reconcile state
@@ -638,7 +696,7 @@ def main(
             f"— skipping approval, and leaving labels untouched so the label is "
             f"not resurrected."
         )
-        return 0
+        return StampOutcome(SKIPPED, 0, "the approved label was already stripped")
 
     to_add, to_remove = label_plan(verdict, labels_before)
     added_ok = client.add_labels(to_add)
@@ -658,13 +716,23 @@ def main(
             f"pending. Without the label a later CI failure could not auto-dismiss "
             f"the approval. Restore `issues: write` for the App token and re-run."
         )
-        return 1
+        return StampOutcome(FAILED, 1, "could not add the approved label")
 
     if verdict != READY:
         # sdk-review-dismiss-on-human.yml only fires on HUMAN activity, so when a
         # newer verdict supersedes a prior READY_TO_MERGE the stale bot approval
         # has to be cleared here or the merge gate stays open on it.
         stale = client.bot_approval_ids()
+        if stale is None:
+            # Cannot see the reviews, so cannot clear a superseded approval. The
+            # merge gate would stay open on it, which is the wrong way to fail —
+            # so leave everything else as-is and fail loudly to be re-driven.
+            print(
+                f"::error::PR #{pr_number}: verdict is {verdict} but the review "
+                f"listing could not be read, so a stale bot approval cannot be "
+                f"dismissed. Re-run once the API recovers."
+            )
+            return StampOutcome(FAILED, 1, "review listing unreadable")
         if stale:
             message = (
                 f"Newer SDK review verdict ({verdict}) supersedes the prior bot "
@@ -676,22 +744,38 @@ def main(
         if write_status:
             client.post_status(head_sha, state, description)
         print(f"Verdict '{verdict}' is not READY TO MERGE — no approval posted.")
-        return 0
+        return StampOutcome(SKIPPED, 0, f"verdict is {verdict}")
 
     # Don't double-approve: sdk-review.yml's slow path runs the same stamp after
-    # the SSE stream closes.
-    if client.bot_approval_ids():
+    # the SSE stream closes, and the reconciler cron runs it again every ten
+    # minutes. This guard is the only thing standing between those three callers
+    # and a pile of identical approvals, so it must fail CLOSED.
+    #
+    # It did not, until 2026-08-17: an unreadable listing came back as `[]`,
+    # which reads as "no approval exists" — the precondition for posting one. A
+    # GitHub degradation returning 404 on the reviews endpoint therefore had
+    # `atlan-ci` re-approve the same PR on every reconciler tick.
+    existing = client.bot_approval_ids()
+    if existing is None:
+        print(
+            f"::error::PR #{pr_number}: the review listing could not be read, so "
+            f"it is unknowable whether atlan-ci has already approved. Refusing to "
+            f"approve blind — that is how an API outage turns into duplicate "
+            f"approvals. The next run will retry."
+        )
+        return StampOutcome(FAILED, 1, "review listing unreadable")
+    if existing:
         print(
             f"atlan-ci has already approved PR #{pr_number} with the bot "
             f"signature — skipping."
         )
         if write_status:
             client.post_status(head_sha, state, description)
-        return 0
+        return StampOutcome(SKIPPED, 0, "already approved")
 
     if not approver_token:
         print("::error::APPROVER_TOKEN is not set — cannot post a codeowner approval.")
-        return 1
+        return StampOutcome(FAILED, 1, "APPROVER_TOKEN is unset")
 
     approved = post_approval_with_retry(
         client,
@@ -711,12 +795,22 @@ def main(
             f"the merge gate stays blocked. Re-run this workflow, or comment "
             f"`@sdk-review`, once quota has recovered."
         )
-        return 1
+        return StampOutcome(FAILED, 1, "approval could not be posted")
 
     print(f"Approved PR #{pr_number} as atlan-ci (commit_id={head_sha}).")
     if write_status:
         client.post_status(head_sha, state, description)
-    return 0
+    return StampOutcome(APPROVED, 0, f"approved at {head_sha}")
+
+
+def main(
+    runner: Runner = subprocess.run,
+    sleeper: Sleeper = time.sleep,
+    now: Callable[[], float] = time.time,
+) -> int:
+    """Exit-code wrapper for the workflow steps. In-process callers that need to
+    know WHAT happened should call `stamp_verdict()` and read its action."""
+    return stamp_verdict(runner=runner, sleeper=sleeper, now=now).exit_code
 
 
 if __name__ == "__main__":

--- a/.github/scripts/sdk_review_reconcile.py
+++ b/.github/scripts/sdk_review_reconcile.py
@@ -270,8 +270,16 @@ def stamp(
     *,
     sleeper: Callable[[float], None] = time.sleep,
     clock: Callable[[], float] = time.time,
-) -> bool:
-    """Invoke the stamper for one PR. True when the approval landed.
+) -> approve.StampOutcome:
+    """Invoke the stamper for one PR and return what it actually did.
+
+    `stamp_verdict` reports its own action rather than the caller inferring one
+    from the exit code, which cannot separate "approved" from "a guard
+    declined". Inferring it from a follow-up read of the reviews listing does
+    not work either — that listing is read-after-write eventually consistent,
+    and the first live run of this cron approved PR #3232, re-read, saw nothing,
+    and reported a decline.
+
 
     The environment matches the slow path (`sdk-review.yml`) — no event payload,
     no commit-status write, label guard on — with only a short retry budget,
@@ -302,33 +310,34 @@ def stamp(
         "APPROVE_MAX_WAIT_SECONDS": "45",
     }
     with stamper_env(env):
-        return approve.main(runner=runner, sleeper=sleeper, now=clock) == 0
+        return approve.stamp_verdict(runner=runner, sleeper=sleeper, now=clock)
 
 
-def _quota_outcome(
-    number: int, quota: Quota, age: timedelta, now: datetime, stale_after: timedelta
+def _blocked_outcome(
+    number: int, blocker: str, age: timedelta, stale_after: timedelta
 ) -> Outcome:
-    """Classify a PR we cannot approve because the approver has no quota left.
+    """Classify a PR that is owed an approval we cannot currently post.
 
-    Deferring is the normal case and must not go red: the quota resets hourly
-    and the next tick after that reset posts the approval, so a red run per tick
-    for an hour would bury the signal it is supposed to raise. But a verdict that
-    has outlived a full window has watched a reset come and go without
-    recovering, which is not self-healing and does need a human.
+    Deferring is the normal case and must not go red. Both blockers this covers
+    — a spent quota, an unreadable review listing — are transient by nature, and
+    a red run per tick while one clears would bury the signal it is supposed to
+    raise.
+
+    But neither is transient forever. A verdict still unapproved past
+    `stale_after` has outlived a full quota window, which means a reset came and
+    went without recovery, or an API degradation has outlasted any reasonable
+    blip. That does need a human, so it reds the run. Without this the reconciler
+    could sit in a permanently green "skipped" loop through an outage, saying
+    nothing — the same silence the whole workflow exists to break.
     """
-    resets_in = quota.resets_in(now)
     if age > stale_after:
         return Outcome(
             number,
             FAILED,
-            f"unapproved for {age.total_seconds() / 60:.0f}min with atlan-ci quota "
-            f"exhausted — a reset has already passed without recovery",
+            f"unapproved for {age.total_seconds() / 60:.0f}min — {blocker}, and "
+            f"that has now outlasted a full quota window",
         )
-    return Outcome(
-        number,
-        DEFERRED,
-        f"atlan-ci quota exhausted; resets in {resets_in // 60}min",
-    )
+    return Outcome(number, DEFERRED, blocker)
 
 
 def sweep(
@@ -343,10 +352,14 @@ def sweep(
 ) -> list[Outcome]:
     """Reconcile every open PR whose standing verdict lost its approval.
 
-    Ordering is by cost: the label check is free (the PR listing carries
-    labels), the review listing short-circuits the healthy majority, and only
-    then is the comment listing spent. The approver's quota is read at most once
-    per run, and only once a PR has actually earned an approval attempt.
+    The label check is free (the PR listing carries labels) and screens out
+    almost everything. The comment listing comes next, then the review listing —
+    deliberately in that order, even though reviews would short-circuit more
+    PRs. The review check needs the verdict's age to decide whether an
+    unreadable listing is a blip to defer or an outage to escalate, and the age
+    comes from the comment. One extra App-token read per labelled PR buys an
+    escalation path that would otherwise not exist. The approver's quota is read
+    at most once per run, and only once a PR has actually earned an attempt.
     """
     now = now or datetime.now(timezone.utc)
     approver_token = os.environ.get("APPROVER_TOKEN", "")
@@ -363,10 +376,6 @@ def sweep(
             continue
 
         client = approve.Client(repo, str(number), runner)
-
-        if client.bot_approval_ids():
-            outcomes.append(Outcome(number, SKIPPED, "already approved"))
-            continue
 
         comment = client.latest_summary_comment()
         if comment is None:
@@ -396,6 +405,26 @@ def sweep(
             outcomes.append(Outcome(number, SKIPPED, "verdict too recent to be lost"))
             continue
 
+        # None is not []: an unreadable listing cannot prove there is no
+        # approval, and treating it as proof is what turned a GitHub degradation
+        # into duplicate approvals on every tick. Checked after `age` so a
+        # listing that stays broken can escalate rather than skip forever.
+        approvals = client.bot_approval_ids()
+        if approvals is None:
+            outcomes.append(
+                _blocked_outcome(
+                    number,
+                    "the review listing is unreadable, so it is unknowable "
+                    "whether an approval already exists",
+                    age,
+                    stale_after,
+                )
+            )
+            continue
+        if approvals:
+            outcomes.append(Outcome(number, SKIPPED, "already approved"))
+            continue
+
         if dry_run:
             outcomes.append(Outcome(number, SKIPPED, "would reconcile (dry run)"))
             continue
@@ -405,7 +434,15 @@ def sweep(
         if not quota_checked:
             quota, quota_checked = approver_quota(runner, approver_token), True
         if quota is not None and quota.exhausted:
-            outcomes.append(_quota_outcome(number, quota, age, now, stale_after))
+            outcomes.append(
+                _blocked_outcome(
+                    number,
+                    f"atlan-ci quota exhausted; resets in "
+                    f"{quota.resets_in(now) // 60}min",
+                    age,
+                    stale_after,
+                )
+            )
             continue
 
         stamped = stamp(
@@ -416,28 +453,33 @@ def sweep(
             sleeper=sleeper,
             clock=now.timestamp,
         )
-        if not stamped:
+        if stamped.action == approve.APPROVED:
+            outcomes.append(Outcome(number, RECONCILED, stamped.detail))
+        elif stamped.action == approve.SKIPPED:
+            # The stamper re-reads the label, head and comments, so a dismissal
+            # landing between this sweep's listing and the stamp is caught
+            # there. It says so itself rather than us inferring it.
+            outcomes.append(
+                Outcome(number, SKIPPED, f"the stamper declined — {stamped.detail}")
+            )
+        else:
             # Re-read the meter rather than parsing the stamper's stderr: the
             # quota can empty between the pre-flight and the POST (other
             # `atlan-ci` workflows share it), and that race is a deferral, not a
             # failure. Free, and only on a path that has already failed.
             quota = approver_quota(runner, approver_token)
             if quota is not None and quota.exhausted:
-                outcomes.append(_quota_outcome(number, quota, age, now, stale_after))
+                outcomes.append(
+                    _blocked_outcome(
+                        number,
+                        f"atlan-ci quota emptied mid-run; resets in "
+                        f"{quota.resets_in(now) // 60}min",
+                        age,
+                        stale_after,
+                    )
+                )
             else:
-                outcomes.append(Outcome(number, FAILED, "approval could not be posted"))
-        elif client.bot_approval_ids():
-            outcomes.append(Outcome(number, RECONCILED, f"approved at {head_sha}"))
-        else:
-            # The stamper exits 0 both when it approved and when one of its own
-            # guards declined — it re-reads the label, head and comments, so a
-            # dismissal landing between this sweep's listing and the stamp is
-            # caught there. Confirming the review exists is what separates the
-            # two, and the whole point of this cron is not to report a recovery
-            # that did not happen.
-            outcomes.append(
-                Outcome(number, SKIPPED, "the stamper declined — verdict invalidated")
-            )
+                outcomes.append(Outcome(number, FAILED, stamped.detail))
 
     return outcomes
 
@@ -471,8 +513,8 @@ def report(outcomes: list[Outcome], repo: str) -> None:
     for outcome in deferred:
         print(
             f"::warning::PR #{outcome.number}: a READY_TO_MERGE verdict is owed an "
-            f"atlan-ci approval but the quota is spent ({outcome.reason}). No "
-            f"request was made. The next run after the reset will post it."
+            f"atlan-ci approval, but {outcome.reason}. No approval was attempted; "
+            f"a later run will post it once that clears."
         )
     for outcome in failed:
         print(

--- a/.github/scripts/sdk_review_reconcile.py
+++ b/.github/scripts/sdk_review_reconcile.py
@@ -58,14 +58,42 @@ Everything runs on the fleet App token, which carries its own quota — a
 reconciler that polled every PR on the `atlan-ci` PAT would become a new source
 of the exhaustion it exists to recover from. Per tick that is one paginated PR
 listing, plus two reads per labelled PR (reviews, then comments). The
-`atlan-ci` PAT is spent only inside the stamper's APPROVE call, and
-APPROVE_MAX_ATTEMPTS=1 holds that to exactly one request per PR approved: this
-cron *is* the retry loop, so retrying in-process would only duplicate it.
+`atlan-ci` PAT is spent on one request per PR approved.
+
+Quota pre-flight
+----------------
+Before the first approval attempt of a run, the approver's core quota is read
+via `GET /rate_limit` — free, by GitHub's own definition, and it does not count
+against the quota it reports. If the quota is spent, no APPROVE is attempted at
+all. The original shape discovered exhaustion by taking a 403, which spends a
+doomed request to learn something a free one already knows, and repeatedly
+hammering an exhausted primary limit is what escalates it into a secondary or
+abuse block. The meter is read at most once per run (plus once more on a failed
+stamp, to tell an exhausted-mid-run race from a real failure).
+
+Deferral vs failure
+-------------------
+"Quota spent" is a DEFERRAL, not a failure: the window resets hourly and the
+next tick after that posts the approval. It is annotated loudly and lands in the
+job summary, but the run stays green — reddening once every ten minutes for an
+hour trains everyone to ignore precisely the annotation that matters when the
+problem does not clear.
+
+A verdict that has been unapproved for longer than `--stale-after-minutes`
+(default 90, above one full quota window plus a couple of intervals) has watched
+a reset come and go without recovering. That is not self-healing, so it reds the
+run.
+
+In-process retry is limited to a single extra attempt inside a 45s budget, which
+exists only for a SECONDARY throttle — those clear in seconds and carry their
+own short window. Waiting out a PRIMARY reset in-process would hold a runner for
+up to an hour, which is exactly what #3162 declined to do, and is unnecessary
+here: the cron is already the long retry loop.
 
 Exit status:
-    0  swept cleanly (whether or not anything needed reconciling)
-    1  at least one PR needed reconciling and the approval still could not be
-       posted — the run goes red so a worsening quota problem stays visible
+    0  swept cleanly, including approvals deferred to the next quota window
+    1  a verdict is unapproved for a reason that will not fix itself — a
+       non-quota failure, or quota exhaustion outliving a full reset
 """
 
 from __future__ import annotations
@@ -75,6 +103,7 @@ import json
 import os
 import subprocess
 import sys
+import time
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -92,8 +121,16 @@ Runner = Callable[..., subprocess.CompletedProcess]
 # acts on cannot still be in flight elsewhere.
 DEFAULT_MIN_AGE_MINUTES = 12
 
+# Past this, an unapproved verdict is no longer explainable as "waiting for the
+# next quota window". `atlan-ci`'s primary quota resets hourly, so a verdict that
+# has outlived a full window plus a couple of cron intervals has seen at least
+# one reset come and go without recovering — that is a human's problem, not a
+# self-healing one, and the run goes red.
+DEFAULT_STALE_AFTER_MINUTES = 90
+
 RECONCILED = "reconciled"
 FAILED = "failed"
+DEFERRED = "deferred"
 SKIPPED = "skipped"
 
 
@@ -104,6 +141,21 @@ class Outcome:
     number: int
     action: str
     reason: str
+
+
+@dataclass(frozen=True)
+class Quota:
+    """A snapshot of the approver's primary (core) REST quota."""
+
+    remaining: int
+    reset: int
+
+    @property
+    def exhausted(self) -> bool:
+        return self.remaining < 1
+
+    def resets_in(self, now: datetime) -> int:
+        return max(0, self.reset - int(now.timestamp()))
 
 
 def list_open_prs(repo: str, runner: Runner) -> list[dict]:
@@ -134,6 +186,40 @@ def list_open_prs(repo: str, runner: Runner) -> list[dict]:
             f"::error::failed to list open PRs for {repo}: {result.stderr}"
         )
     return [json.loads(line) for line in result.stdout.splitlines() if line.strip()]
+
+
+def approver_quota(runner: Runner, token: str) -> Quota | None:
+    """The approver's core quota, or None if it cannot be read.
+
+    `GET /rate_limit` is documented as not counting against the quota it
+    reports, so this is a free pre-flight — which is the whole point. Attempting
+    an APPROVE against an exhausted quota spends nothing useful (the 403 is the
+    only outcome) and repeated rejected requests are what escalate a primary
+    exhaustion into a secondary/abuse block. Reading first costs nothing and
+    tells us whether there is any point trying.
+
+    None means "unreadable", which callers treat as "go ahead and try": a
+    failure to read the meter is not evidence the tank is empty.
+    """
+    if not token:
+        return None
+    result = runner(
+        ["gh", "api", "rate_limit", "--jq", ".resources.core | .remaining, .reset"],
+        capture_output=True,
+        text=True,
+        check=False,
+        env={**os.environ, "GH_TOKEN": token},
+    )
+    if result.returncode != 0:
+        print(f"::warning::could not read the approver's rate limit: {result.stderr}")
+        return None
+    fields = result.stdout.split()
+    if len(fields) != 2:
+        return None
+    try:
+        return Quota(remaining=int(fields[0]), reset=int(fields[1]))
+    except ValueError:
+        return None
 
 
 def label_names(pr: dict) -> set[str]:
@@ -176,12 +262,20 @@ def stamper_env(values: dict[str, str]) -> Iterator[None]:
                 os.environ[key] = value
 
 
-def stamp(repo: str, pr_number: int, head_sha: str, runner: Runner) -> bool:
+def stamp(
+    repo: str,
+    pr_number: int,
+    head_sha: str,
+    runner: Runner,
+    *,
+    sleeper: Callable[[float], None] = time.sleep,
+    clock: Callable[[], float] = time.time,
+) -> bool:
     """Invoke the stamper for one PR. True when the approval landed.
 
     The environment matches the slow path (`sdk-review.yml`) — no event payload,
-    no commit-status write, label guard on — with retries disabled, because this
-    cron is itself the retry loop.
+    no commit-status write, label guard on — with only a short retry budget,
+    because this cron is itself the retry loop for anything longer.
     """
     env = {
         "REPO": repo,
@@ -198,14 +292,43 @@ def stamp(repo: str, pr_number: int, head_sha: str, runner: Runner) -> bool:
         # Solo-approval guard: refuse if `sdk-review-approved` has gone in the
         # gap between this sweep's listing and the stamp.
         "REQUIRE_APPROVED_LABEL": "true",
-        # Exactly one `atlan-ci` request per PR approved. Waiting out a primary
-        # quota reset in-process is what the stamper already declines to do; the
-        # next tick is the retry.
-        "APPROVE_MAX_ATTEMPTS": "1",
-        "APPROVE_MAX_WAIT_SECONDS": "0",
+        # One `atlan-ci` request on the success path. The second attempt exists
+        # only for a SECONDARY throttle, which clears in seconds and is worth
+        # waiting out inline; the quota pre-flight above already catches primary
+        # exhaustion, and the stamper bails immediately on a reset it cannot
+        # reach inside this budget. Anything longer than 45s is the next tick's
+        # job, not this runner's.
+        "APPROVE_MAX_ATTEMPTS": "2",
+        "APPROVE_MAX_WAIT_SECONDS": "45",
     }
     with stamper_env(env):
-        return approve.main(runner=runner) == 0
+        return approve.main(runner=runner, sleeper=sleeper, now=clock) == 0
+
+
+def _quota_outcome(
+    number: int, quota: Quota, age: timedelta, now: datetime, stale_after: timedelta
+) -> Outcome:
+    """Classify a PR we cannot approve because the approver has no quota left.
+
+    Deferring is the normal case and must not go red: the quota resets hourly
+    and the next tick after that reset posts the approval, so a red run per tick
+    for an hour would bury the signal it is supposed to raise. But a verdict that
+    has outlived a full window has watched a reset come and go without
+    recovering, which is not self-healing and does need a human.
+    """
+    resets_in = quota.resets_in(now)
+    if age > stale_after:
+        return Outcome(
+            number,
+            FAILED,
+            f"unapproved for {age.total_seconds() / 60:.0f}min with atlan-ci quota "
+            f"exhausted — a reset has already passed without recovery",
+        )
+    return Outcome(
+        number,
+        DEFERRED,
+        f"atlan-ci quota exhausted; resets in {resets_in // 60}min",
+    )
 
 
 def sweep(
@@ -213,17 +336,23 @@ def sweep(
     *,
     runner: Runner = subprocess.run,
     min_age: timedelta = timedelta(minutes=DEFAULT_MIN_AGE_MINUTES),
+    stale_after: timedelta = timedelta(minutes=DEFAULT_STALE_AFTER_MINUTES),
     now: datetime | None = None,
     dry_run: bool = False,
+    sleeper: Callable[[float], None] = time.sleep,
 ) -> list[Outcome]:
     """Reconcile every open PR whose standing verdict lost its approval.
 
     Ordering is by cost: the label check is free (the PR listing carries
     labels), the review listing short-circuits the healthy majority, and only
-    then is the comment listing spent.
+    then is the comment listing spent. The approver's quota is read at most once
+    per run, and only once a PR has actually earned an approval attempt.
     """
     now = now or datetime.now(timezone.utc)
+    approver_token = os.environ.get("APPROVER_TOKEN", "")
     outcomes: list[Outcome] = []
+    quota_checked = False
+    quota: Quota | None = None
 
     for pr in list_open_prs(repo, runner):
         number = pr.get("number")
@@ -271,8 +400,32 @@ def sweep(
             outcomes.append(Outcome(number, SKIPPED, "would reconcile (dry run)"))
             continue
 
-        if not stamp(repo, number, head_sha, runner):
-            outcomes.append(Outcome(number, FAILED, "approval could not be posted"))
+        # Read the meter once per run, and only now — a sweep that finds nothing
+        # to approve should not spend a request establishing that it could have.
+        if not quota_checked:
+            quota, quota_checked = approver_quota(runner, approver_token), True
+        if quota is not None and quota.exhausted:
+            outcomes.append(_quota_outcome(number, quota, age, now, stale_after))
+            continue
+
+        stamped = stamp(
+            repo,
+            number,
+            head_sha,
+            runner,
+            sleeper=sleeper,
+            clock=now.timestamp,
+        )
+        if not stamped:
+            # Re-read the meter rather than parsing the stamper's stderr: the
+            # quota can empty between the pre-flight and the POST (other
+            # `atlan-ci` workflows share it), and that race is a deferral, not a
+            # failure. Free, and only on a path that has already failed.
+            quota = approver_quota(runner, approver_token)
+            if quota is not None and quota.exhausted:
+                outcomes.append(_quota_outcome(number, quota, age, now, stale_after))
+            else:
+                outcomes.append(Outcome(number, FAILED, "approval could not be posted"))
         elif client.bot_approval_ids():
             outcomes.append(Outcome(number, RECONCILED, f"approved at {head_sha}"))
         else:
@@ -296,11 +449,17 @@ def report(outcomes: list[Outcome], repo: str) -> None:
     a ::warning:: rather than a ::notice::, and it lands in the job summary too.
     Silent recovery would hide a worsening rate-limit problem, which is the
     thing most worth knowing about here.
+
+    A deferral is the one case that is loud but not red. It says the approval is
+    owed and the quota is gone, which the next tick after the reset will fix on
+    its own; reddening the run once per tick for an hour would train everyone to
+    ignore exactly the annotation that matters when it does not fix itself.
     """
     for outcome in outcomes:
         print(f"PR #{outcome.number}: {outcome.action} — {outcome.reason}")
 
     reconciled = [o for o in outcomes if o.action == RECONCILED]
+    deferred = [o for o in outcomes if o.action == DEFERRED]
     failed = [o for o in outcomes if o.action == FAILED]
 
     for outcome in reconciled:
@@ -309,21 +468,27 @@ def report(outcomes: list[Outcome], repo: str) -> None:
             f"its atlan-ci approval; the reconciler posted it ({outcome.reason}). "
             f"The stamper that should have posted it failed — check that run."
         )
+    for outcome in deferred:
+        print(
+            f"::warning::PR #{outcome.number}: a READY_TO_MERGE verdict is owed an "
+            f"atlan-ci approval but the quota is spent ({outcome.reason}). No "
+            f"request was made. The next run after the reset will post it."
+        )
     for outcome in failed:
         print(
             f"::error::PR #{outcome.number}: a READY_TO_MERGE verdict is still "
             f"missing its atlan-ci approval and the reconciler could not post it "
-            f"either. atlan-ci quota is likely still exhausted."
+            f"either — {outcome.reason}."
         )
 
-    if not reconciled and not failed:
+    if not (reconciled or deferred or failed):
         print("Nothing to reconcile.")
 
     summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
-    if not summary_path or not (reconciled or failed):
+    if not summary_path or not (reconciled or deferred or failed):
         return
     lines = ["## SDK review approvals reconciled", ""]
-    for outcome in reconciled + failed:
+    for outcome in reconciled + deferred + failed:
         url = f"https://github.com/{repo}/pull/{outcome.number}"
         lines.append(
             f"- **{outcome.action}** [#{outcome.number}]({url}) — {outcome.reason}"
@@ -348,6 +513,16 @@ def main(argv: list[str] | None = None, runner: Runner = subprocess.run) -> int:
         ),
     )
     parser.add_argument(
+        "--stale-after-minutes",
+        type=int,
+        default=DEFAULT_STALE_AFTER_MINUTES,
+        help=(
+            "Age past which an unapproved verdict blocked on quota stops counting "
+            "as self-healing and reds the run (default "
+            f"{DEFAULT_STALE_AFTER_MINUTES}min, above one hourly quota window)."
+        ),
+    )
+    parser.add_argument(
         "--dry-run",
         action="store_true",
         help="Report which PRs would be reconciled without approving any of them.",
@@ -358,6 +533,7 @@ def main(argv: list[str] | None = None, runner: Runner = subprocess.run) -> int:
         args.repo,
         runner=runner,
         min_age=timedelta(minutes=args.min_age_minutes),
+        stale_after=timedelta(minutes=args.stale_after_minutes),
         dry_run=args.dry_run,
     )
     report(outcomes, args.repo)

--- a/.github/scripts/tests/test_sdk_review_approve.py
+++ b/.github/scripts/tests/test_sdk_review_approve.py
@@ -680,13 +680,35 @@ def test_ready_refuses_to_approve_when_the_listing_is_unreadable(monkeypatch, ca
 
 
 def test_non_ready_fails_loudly_when_stale_approvals_cannot_be_listed(monkeypatch):
-    """Failing to dismiss leaves the merge gate open on a superseded approval."""
+    """Failing to dismiss leaves the merge gate open on a superseded approval.
+
+    The run still writes the failure status: returning before the write would
+    let a prior green `sdk-review` status on this head outlive the verdict that
+    superseded it. The status POST does not depend on the reviews listing, so
+    one degradation does not excuse the other silence."""
     gh = base_gh()
     gh.on(is_review_list, fail("gh: Not Found (HTTP 404)"))
 
     code = run_main(gh, monkeypatch, COMMENT_BODY=verdict_comment("NEEDS_FIXES"))
     assert code == 1
     assert gh.called(lambda a: "dismissals" in a[2]) == []
+    (status,) = gh.called(is_status)
+    assert "state=failure" in status
+
+
+def test_non_ready_unreadable_listing_respects_write_status_false(monkeypatch):
+    """The slow path (WRITE_STATUS=false) owns no status writes, even here."""
+    gh = base_gh()
+    gh.on(is_review_list, fail("gh: Not Found (HTTP 404)"))
+
+    code = run_main(
+        gh,
+        monkeypatch,
+        COMMENT_BODY=verdict_comment("NEEDS_FIXES"),
+        WRITE_STATUS="false",
+    )
+    assert code == 1
+    assert gh.called(is_status) == []
 
 
 # --- stamp_verdict() reports what it did ----------------------------------

--- a/.github/scripts/tests/test_sdk_review_approve.py
+++ b/.github/scripts/tests/test_sdk_review_approve.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import importlib.util
 import json
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -20,6 +21,9 @@ SPEC = importlib.util.spec_from_file_location(
 )
 approve = importlib.util.module_from_spec(SPEC)
 assert SPEC.loader is not None
+# Registered before exec: @dataclass resolves annotations through
+# sys.modules[cls.__module__], which is absent for a bare module_from_spec.
+sys.modules["sdk_review_approve"] = approve
 SPEC.loader.exec_module(approve)
 
 
@@ -642,6 +646,88 @@ def test_slow_path_skips_freshness_check_since_it_fetched_the_newest(monkeypatch
     gh = slow_gh(labels=["sdk-review-approved"])
     assert run_main(gh, monkeypatch, **slow_env(), TRIGGERING_COMMENT_ID="0") == 0
     assert len(gh.called(is_approve)) == 1
+
+
+# --- an unreadable review listing must fail CLOSED ------------------------
+#
+# Regression from 2026-08-17: GitHub's reviews endpoint began returning 404 for
+# PRs that plainly had reviews. `_paginated` collapsed that to `[]`, which reads
+# as "no approval exists" — the precondition for posting one — so `atlan-ci`
+# re-approved the same PR on every reconciler tick, silently.
+
+
+def test_bot_approval_ids_is_none_when_the_listing_fails():
+    """None and [] must not be the same value: one means "cannot tell"."""
+    gh = base_gh()
+    gh.on(is_review_list, fail("gh: Not Found (HTTP 404)"))
+    assert approve.Client(REPO, PR, gh).bot_approval_ids() is None
+
+
+def test_bot_approval_ids_is_none_when_the_listing_is_unparseable():
+    gh = base_gh()
+    gh.on(is_review_list, ok("{not json"))
+    assert approve.Client(REPO, PR, gh).bot_approval_ids() is None
+
+
+def test_ready_refuses_to_approve_when_the_listing_is_unreadable(monkeypatch, capsys):
+    gh = base_gh(labels=["sdk-review-approved"])
+    gh.on(is_review_list, fail("gh: Not Found (HTTP 404)"))
+
+    assert run_main(gh, monkeypatch) == 1
+    assert gh.called(is_approve) == [], "approving blind is how outages duplicate"
+    assert gh.called(is_status) == []
+    assert "::error::" in capsys.readouterr().out
+
+
+def test_non_ready_fails_loudly_when_stale_approvals_cannot_be_listed(monkeypatch):
+    """Failing to dismiss leaves the merge gate open on a superseded approval."""
+    gh = base_gh()
+    gh.on(is_review_list, fail("gh: Not Found (HTTP 404)"))
+
+    code = run_main(gh, monkeypatch, COMMENT_BODY=verdict_comment("NEEDS_FIXES"))
+    assert code == 1
+    assert gh.called(lambda a: "dismissals" in a[2]) == []
+
+
+# --- stamp_verdict() reports what it did ----------------------------------
+
+
+def test_stamp_verdict_reports_an_approval(monkeypatch):
+    gh = base_gh(labels=["sdk-review-approved"])
+    for key, value in {
+        "REPO": REPO,
+        "PR_NUMBER": PR,
+        "COMMENT_BODY": verdict_comment(),
+        "TRIGGERING_COMMENT_ID": "5",
+        "APPROVER_TOKEN": "pat-atlan-ci",
+        "GH_TOKEN": "app-token",
+    }.items():
+        monkeypatch.setenv(key, value)
+
+    outcome = approve.stamp_verdict(runner=gh)
+    assert outcome.action == approve.APPROVED
+    assert outcome.exit_code == 0
+
+
+def test_stamp_verdict_distinguishes_a_declining_guard_from_an_approval(monkeypatch):
+    """Both exit 0; only the action separates them. That distinction is what the
+    reconciler reports on, and inferring it from a re-read was racy."""
+    gh = slow_gh(labels=[])
+    for key, value in {
+        "REPO": REPO,
+        "PR_NUMBER": PR,
+        "COMMENT_BODY": "",
+        "EXPECTED_HEAD": HEAD,
+        "REQUIRE_APPROVED_LABEL": "true",
+        "APPROVER_TOKEN": "pat-atlan-ci",
+        "GH_TOKEN": "app-token",
+    }.items():
+        monkeypatch.setenv(key, value)
+
+    outcome = approve.stamp_verdict(runner=gh)
+    assert outcome.action == approve.SKIPPED
+    assert outcome.exit_code == 0
+    assert "label" in outcome.detail
 
 
 def test_label_delete_404_is_tolerated(capsys):

--- a/.github/scripts/tests/test_sdk_review_reconcile.py
+++ b/.github/scripts/tests/test_sdk_review_reconcile.py
@@ -167,14 +167,24 @@ def is_label_write(argv) -> bool:
     return argv[1] == "api" and f"repos/{REPO}/issues/{PR}/labels" in argv[2]
 
 
+def is_rate_limit(argv) -> bool:
+    return argv[1] == "api" and argv[2] == "rate_limit"
+
+
+RESET = int(NOW.timestamp()) + 1800  # half an hour out
+
+
 def base_gh(
     prs: list[dict] | None = None,
     comments: list[dict] | None = None,
     reviews: list[dict] | None = None,
     labels: list[str] | None = None,
+    quota_remaining: int = 4999,
+    quota_reset: int = RESET,
 ) -> FakeGH:
     """A repo where PR #7 carries a standing READY verdict and no approval."""
     gh = FakeGH()
+    gh.on(is_rate_limit, lambda: ok(f"{quota_remaining}\n{quota_reset}\n"))
     gh.on(
         is_pr_list,
         ok("\n".join(json.dumps(pr) for pr in (prs if prs is not None else [pull()]))),
@@ -210,7 +220,12 @@ def _tokens(monkeypatch):
 
 
 def run_sweep(gh: FakeGH, **kwargs) -> list:
-    return reconcile.sweep(REPO, runner=gh, now=NOW, **kwargs)
+    """Sweep with a recorded sleeper, so a retry path never really sleeps."""
+    slept: list[float] = []
+    kwargs.setdefault("sleeper", slept.append)
+    outcomes = reconcile.sweep(REPO, runner=gh, now=NOW, **kwargs)
+    gh.slept = slept  # type: ignore[attr-defined]
+    return outcomes
 
 
 # --- the recovery this exists for ----------------------------------------
@@ -227,15 +242,21 @@ def test_lost_approval_is_reconciled():
     assert f"commit_id={HEAD}" in posted[0]
 
 
-def test_reconcile_spends_exactly_one_atlan_ci_request():
+def test_reconcile_spends_exactly_one_quota_bearing_atlan_ci_request():
     """The reconciler must not become a new source of the exhaustion it recovers
-    from: every read runs on the App token, the PAT only on the APPROVE."""
+    from: every read runs on the App token, the PAT only on the APPROVE.
+
+    The pre-flight meter read also carries the PAT, but `GET /rate_limit` does
+    not count against the quota it reports — so the budget that matters is
+    "one APPROVE", not "one request".
+    """
     gh = base_gh()
     run_sweep(gh)
 
     approver = gh.approver_calls()
-    assert len(approver) == 1
-    assert is_approve(approver[0])
+    assert [argv for argv in approver if is_approve(argv)] != []
+    assert len([argv for argv in approver if is_approve(argv)]) == 1
+    assert all(is_approve(argv) or is_rate_limit(argv) for argv in approver)
 
 
 def test_reconcile_does_not_green_the_sdk_review_status():
@@ -384,19 +405,139 @@ def test_dry_run_reports_without_approving():
     assert gh.called(is_approve) == []
 
 
-# --- failure reporting ----------------------------------------------------
+# --- quota pre-flight -----------------------------------------------------
 
 
-def test_still_rate_limited_reports_failed_and_does_not_retry_in_process():
-    """APPROVE_MAX_ATTEMPTS=1: this cron is the retry loop, so the stamper must
-    not hold the runner waiting out a primary-quota reset."""
-    gh = base_gh()
-    gh.on(is_approve, fail(RATE_LIMIT_STDERR))
+def test_exhausted_quota_spends_no_approve_request_at_all():
+    """The original shape discovered exhaustion by taking a 403 — a doomed
+    request to learn what a free one already knows. Repeatedly hammering an
+    exhausted primary limit is also how it escalates to an abuse block."""
+    gh = base_gh(quota_remaining=0)
+    outcomes = run_sweep(gh)
+
+    assert [o.action for o in outcomes] == [reconcile.DEFERRED]
+    assert gh.called(is_approve) == []
+    assert gh.approver_calls() == [
+        argv for argv in gh.calls if is_rate_limit(argv)
+    ], "the only atlan-ci request should be the free meter read"
+
+
+def test_deferral_names_the_reset_and_does_not_red_the_run(capsys):
+    """Deferring is the self-healing case: the next tick after the reset posts
+    it. A red run every ten minutes for an hour would bury the annotation that
+    matters when it does NOT clear."""
+    gh = base_gh(quota_remaining=0)
+    outcomes = run_sweep(gh)
+    reconcile.report(outcomes, REPO)
+
+    assert "resets in 30min" in outcomes[0].reason
+    out = capsys.readouterr().out
+    assert "::warning::" in out
+    assert "::error::" not in out
+
+
+def test_main_stays_green_on_a_deferral(monkeypatch):
+    monkeypatch.setattr(
+        reconcile,
+        "sweep",
+        lambda *args, **kwargs: [
+            reconcile.Outcome(PR, reconcile.DEFERRED, "atlan-ci quota exhausted")
+        ],
+    )
+    assert reconcile.main(["--repo", REPO]) == 0
+
+
+def test_a_verdict_outliving_a_full_quota_window_reds_the_run():
+    """Past one hourly reset, "waiting for quota" stops being an explanation."""
+    gh = base_gh(
+        quota_remaining=0, comments=[comment(created_at="2026-08-17T09:00:00Z")]
+    )
     outcomes = run_sweep(gh)
 
     assert [o.action for o in outcomes] == [reconcile.FAILED]
+    assert "without recovery" in outcomes[0].reason
+    assert gh.called(is_approve) == []
+
+
+def test_quota_is_read_once_per_run_not_once_per_pr():
+    gh = base_gh(
+        quota_remaining=0,
+        prs=[pull(number=PR), pull(number=11), pull(number=12)],
+    )
+    run_sweep(gh)
+
+    assert len(gh.called(is_rate_limit)) == 1
+
+
+def test_no_candidates_means_no_quota_read():
+    """A sweep with nothing to approve must not spend a request establishing
+    that it could have."""
+    gh = base_gh(reviews=[bot_approval()])
+    run_sweep(gh)
+
+    assert gh.called(is_rate_limit) == []
+
+
+def test_unreadable_quota_still_attempts_the_approval():
+    """Failing to read the meter is not evidence the tank is empty."""
+    gh = base_gh()
+    gh.on(is_rate_limit, fail("network go boom"))
+    outcomes = run_sweep(gh)
+
+    assert [o.action for o in outcomes] == [reconcile.RECONCILED]
     assert len(gh.called(is_approve)) == 1
+
+
+# --- failure reporting ----------------------------------------------------
+
+
+def test_quota_emptying_mid_run_is_a_deferral_not_a_failure():
+    """Other `atlan-ci` workflows share the quota, so it can empty between the
+    pre-flight and the POST. That race is a deferral; re-reading the meter is
+    how we tell it from a real failure without parsing stderr."""
+    gh = base_gh()
+    gh.on(is_approve, fail(RATE_LIMIT_STDERR))
+    # Full at pre-flight, empty by the time we ask again.
+    reads = {"n": 0}
+
+    def meter():
+        reads["n"] += 1
+        return ok(f"{0 if reads['n'] > 1 else 4999}\n{RESET}\n")
+
+    gh.on(is_rate_limit, meter)
+    outcomes = run_sweep(gh)
+
+    assert [o.action for o in outcomes] == [reconcile.DEFERRED]
     assert gh.called(is_status) == []
+
+
+def test_a_non_quota_approval_failure_is_a_real_failure():
+    gh = base_gh()
+    gh.on(is_approve, fail("gh: Validation Failed (HTTP 422)"))
+    outcomes = run_sweep(gh)
+
+    assert [o.action for o in outcomes] == [reconcile.FAILED]
+    assert outcomes[0].reason == "approval could not be posted"
+    assert gh.called(is_status) == []
+
+
+def test_secondary_throttle_gets_one_inline_retry():
+    """Secondary limits clear in seconds, so a single short retry is worth it —
+    unlike a primary reset, which the next tick handles instead of this runner."""
+    gh = base_gh()
+    attempts = {"n": 0}
+
+    def approve_once_then_succeed():
+        attempts["n"] += 1
+        if attempts["n"] == 1:
+            return fail("You have exceeded a secondary rate limit (HTTP 403)")
+        return ok()
+
+    gh.on(is_approve, approve_once_then_succeed)
+    outcomes = run_sweep(gh)
+
+    assert [o.action for o in outcomes] == [reconcile.RECONCILED]
+    assert len(gh.called(is_approve)) == 2
 
 
 def test_main_exits_nonzero_when_a_reconcile_failed(monkeypatch, capsys):

--- a/.github/scripts/tests/test_sdk_review_reconcile.py
+++ b/.github/scripts/tests/test_sdk_review_reconcile.py
@@ -329,8 +329,6 @@ def test_existing_bot_approval_is_a_no_op():
     assert [o.action for o in outcomes] == [reconcile.SKIPPED]
     assert outcomes[0].reason == "already approved"
     assert gh.called(is_approve) == []
-    # Short-circuits before the comment listing is spent.
-    assert gh.called(lambda a: a[2].endswith(f"issues/{PR}/comments")) == []
 
 
 def test_a_human_approval_does_not_count_as_the_bot_approval():
@@ -405,6 +403,80 @@ def test_dry_run_reports_without_approving():
     assert gh.called(is_approve) == []
 
 
+# --- the two regressions from the first live fire -------------------------
+
+
+def test_a_reconcile_is_reported_even_when_the_listing_has_not_caught_up():
+    """GitHub's reviews listing is read-after-write eventually consistent.
+
+    The first live run of this cron approved PR #3232, re-read the listing, saw
+    nothing, and reported "the stamper declined" — then printed "Nothing to
+    reconcile". A real recovery went unannounced, which is the one thing this
+    workflow exists to announce. The stamper now says what it did, so the
+    listing lagging cannot rewrite history.
+    """
+    gh = base_gh()
+    # Never shows the approval, however many times it is asked.
+    gh.on(is_review_list, ok(json.dumps([[]])))
+    outcomes = run_sweep(gh)
+
+    assert [o.action for o in outcomes] == [reconcile.RECONCILED]
+    assert len(gh.called(is_approve)) == 1
+
+
+def test_an_unreadable_listing_never_approves_blind():
+    """Regression from the 2026-08-17 degradation: `_paginated` returned `[]` on
+    a 404, which reads as "no approval exists" — the precondition for posting
+    one. atlan-ci re-approved the same PR on every tick, silently."""
+    gh = base_gh()
+    gh.on(is_review_list, fail("gh: Not Found (HTTP 404)"))
+    outcomes = run_sweep(gh)
+
+    assert [o.action for o in outcomes] == [reconcile.DEFERRED]
+    assert "unreadable" in outcomes[0].reason
+    assert gh.called(is_approve) == []
+
+
+def test_an_unreadable_listing_is_not_reported_as_a_recovery(capsys):
+    gh = base_gh()
+    gh.on(is_review_list, fail("gh: Not Found (HTTP 404)"))
+    reconcile.report(run_sweep(gh), REPO)
+
+    out = capsys.readouterr().out
+    assert "had lost" not in out, "a blocked sweep is not a recovery"
+    assert "::error::" not in out, "a transient outage is not a human's problem yet"
+
+
+def test_an_outage_outlasting_a_quota_window_stops_being_a_deferral():
+    """Otherwise the reconciler sits in a permanently green skipped loop through
+    an outage, saying nothing — the same silence it exists to break."""
+    gh = base_gh(comments=[comment(created_at="2026-08-17T09:00:00Z")])
+    gh.on(is_review_list, fail("gh: Not Found (HTTP 404)"))
+    outcomes = run_sweep(gh)
+
+    assert [o.action for o in outcomes] == [reconcile.FAILED]
+    assert "outlasted a full quota window" in outcomes[0].reason
+    assert gh.called(is_approve) == []
+
+
+def test_a_listing_that_breaks_mid_stamp_is_a_failure_not_a_silent_approval():
+    """Readable at the prefilter, broken by the time the stamper re-checks."""
+    gh = base_gh()
+    reads = {"n": 0}
+
+    def listing():
+        reads["n"] += 1
+        if reads["n"] == 1:
+            return ok(json.dumps([[]]))
+        return fail("gh: Not Found (HTTP 404)")
+
+    gh.on(is_review_list, listing)
+    outcomes = run_sweep(gh)
+
+    assert [o.action for o in outcomes] == [reconcile.FAILED]
+    assert gh.called(is_approve) == []
+
+
 # --- quota pre-flight -----------------------------------------------------
 
 
@@ -455,7 +527,7 @@ def test_a_verdict_outliving_a_full_quota_window_reds_the_run():
     outcomes = run_sweep(gh)
 
     assert [o.action for o in outcomes] == [reconcile.FAILED]
-    assert "without recovery" in outcomes[0].reason
+    assert "outlasted a full quota window" in outcomes[0].reason
     assert gh.called(is_approve) == []
 
 

--- a/.github/workflows/sdk-review-reconcile.yml
+++ b/.github/workflows/sdk-review-reconcile.yml
@@ -28,6 +28,19 @@
 # quota, which is the point: a reconciler polling every PR on the `atlan-ci` PAT
 # would become a new source of the exhaustion it exists to recover from. The PAT
 # is spent only on the APPROVE call, once per PR actually approved.
+#
+# Quota-aware: before the first approval of a run it reads `GET /rate_limit` on
+# the approver (free — it does not count against the quota it reports) and
+# attempts nothing if the quota is spent. Taking a 403 to discover that spends a
+# doomed request, and hammering an exhausted primary limit is how it escalates
+# into a secondary/abuse block.
+#
+# A quota-blocked approval is a DEFERRAL: annotated and summarised, but the run
+# stays green, because the next tick after the hourly reset posts it. Going red
+# every ten minutes for an hour would bury the annotation that matters when the
+# problem does not clear on its own. A verdict still unapproved past
+# --stale-after-minutes (90) has outlived a full reset without recovering, and
+# that does red the run.
 
 name: SDK Review — reconcile lost approvals
 


### PR DESCRIPTION
Follow-up to #3237 (FND-314), driven by its first real fire: [run 32035469782](https://github.com/atlanhq/application-sdk/actions/runs/32035469782/job/95404769830).

## What that run showed

The reconciler worked. It found two genuinely lost approvals — #3232 and #3184, both carrying `sdk-review-approved` with a current-head `READY_TO_MERGE` verdict and no `atlan-ci` review — and refused to pretend otherwise. But *how* it failed was wasteful and noisy:

```
Warning: approval attempt 1/1 failed: gh: API rate limit exceeded for user ID 62283865 (HTTP 403)
Error: PR #3232: verdict is READY_TO_MERGE but the atlan-ci approval could not be posted.
Error: PR #3184: verdict is READY_TO_MERGE but the atlan-ci approval could not be posted.
Error: Process completed with exit code 1.
```

Two problems, both fixed here.

## 1. It spent a doomed request to learn what a free one already knows

`GET /rate_limit` does not count against the quota it reports. The meter is now read **once per run**, before the first approval attempt, and if the quota is spent no APPROVE is sent at all.

Beyond the wasted request: repeatedly hammering an exhausted primary limit is what escalates it into a secondary or abuse block. Not making the request is strictly better than making it and losing.

The read is lazy — a sweep that finds nothing to approve does not spend a request establishing that it could have.

## 2. It reddened on a condition that fixes itself

The primary quota resets hourly and the next tick posts the approval. Going red once every ten minutes for an hour trains everyone to ignore precisely the annotation that matters when the problem *doesn't* clear.

So quota-blocked approvals are now a **deferral**: loud — a `::warning::` naming the reset time, plus a job-summary line — but the run stays green.

Red is reserved for what a human must act on:

* a non-quota approval failure (e.g. a 422), or
* a verdict unapproved for longer than `--stale-after-minutes` (default 90, above one full window plus a couple of cron intervals). Past that, a reset has already come and gone without recovery, which is no longer self-healing.

A stamp that fails anyway **re-reads the meter rather than parsing stderr**: other `atlan-ci` workflows share the quota, so it can empty between the pre-flight and the POST, and that race is a deferral rather than a failure.

## On the "just retry-after" alternative

Retry-after is right for a **secondary** throttle — those clear in seconds and the stamper already distinguishes them (`is_secondary_rate_limit`). #3237 disabled that along with everything else by setting `APPROVE_MAX_ATTEMPTS=1`; this restores a single extra attempt inside a 45s budget.

It is wrong for a **primary** reset, which can be an hour out. Waiting for that in-process holds a runner for an hour, which is exactly what #3162 deliberately declined to do, and it is unnecessary — the cron is already the long retry loop.

The budget the acceptance criteria care about is unchanged: **one APPROVE per PR approved**. The pre-flight read carries the PAT too, but does not consume quota, and the test asserts that distinction rather than blurring it.

## Tests

9 new, 35 total in `.github/scripts/tests/test_sdk_review_reconcile.py`:

* exhausted quota spends **zero** APPROVE requests
* deferral names the reset and does not red the run; `main()` exits 0
* a verdict outliving a full window **does** red the run
* the meter is read once per run, not once per PR — and not at all with no candidates
* an unreadable meter still attempts the approval (failing to read the gauge is not evidence the tank is empty)
* quota emptying mid-run is a deferral; a 422 is a real failure
* a secondary throttle gets its one inline retry

Sweep now takes an injected `sleeper`/`clock` so the retry path is exercised without a real 15s sleep. Full `.github/scripts/tests` suite passes; pre-commit clean.

## Not included

`uv.lock` on `main` is still stale (`atlan-application-sdk-conformance` 0.19.1 vs 0.20.0 in `packages/conformance`) — #3234 shipped the bump without refreshing it. #3228 fixes it but is deadlocked on `renovate/artifacts` being per-SHA; #3232 is the real fix for that. Deliberately left out of this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
