### PR TITLE
ci(fix): make the comment reaction best-effort so a 503 can't kill a bot job

### DIFF
--- a/.github/scripts/react_to_comment.py
+++ b/.github/scripts/react_to_comment.py
@@ -40,6 +40,7 @@ Configuration (all via env, matching the sibling scripts):
 
 from __future__ import annotations
 
+import math
 import os
 import re
 import subprocess
@@ -71,6 +72,17 @@ VALID_REACTIONS = frozenset(
 DEFAULT_REACTION = "eyes"
 DEFAULT_MAX_ATTEMPTS = 3
 DEFAULT_BACKOFF_SECONDS = 2.0
+
+# Module-local seams, so a test can replace the sleep or the subprocess call
+# without patching the global `time`/`subprocess` modules out from under
+# everything else in the process.
+#
+# Both are read inside `react()` rather than used as default argument values.
+# A default binds the object at import time, so patching the module attribute
+# afterwards has no effect — and a test that patches `subprocess.run` and then
+# watches the real `gh` fail still sees exit 0, passing for the wrong reason.
+_SLEEP: Callable[[float], None] = time.sleep
+_RUN: Runner = subprocess.run
 
 _HTTP_STATUS = re.compile(r"\(HTTP (\d{3})\)")
 
@@ -124,14 +136,19 @@ def react(
     *,
     max_attempts: int = DEFAULT_MAX_ATTEMPTS,
     backoff_seconds: float = DEFAULT_BACKOFF_SECONDS,
-    runner: Runner = subprocess.run,
-    sleeper: Callable[[float], None] = time.sleep,
+    runner: Runner | None = None,
+    sleeper: Callable[[float], None] | None = None,
 ) -> bool:
     """POST the reaction, retrying transient failures. True iff it landed.
 
-    `sleeper` is injected rather than calling `time.sleep` directly so the
-    tests can assert the backoff schedule without spending it.
+    `runner` and `sleeper` are injectable so tests can drive the retry path
+    and assert the backoff schedule without issuing an API call or spending
+    the wait. See `_RUN`/`_SLEEP` for why they resolve here.
     """
+    if runner is None:
+        runner = _RUN
+    if sleeper is None:
+        sleeper = _SLEEP
     args = [
         "gh",
         "api",
@@ -193,6 +210,14 @@ def _positive_float(name: str, default: float) -> float:
         value = float(raw)
     except ValueError:
         print(f"::warning::{name}={raw!r} is not a number; using {default}")
+        return default
+    # `float()` happily returns inf/nan, and `inf > 0` is True — which would
+    # reach `time.sleep(inf)` and raise OverflowError, failing the step. That
+    # is exactly the always-exit-0 contract this script exists to hold, broken
+    # by its own configuration parsing. `_positive_int` needs no equivalent:
+    # `int('inf')` is a ValueError, already handled above.
+    if not math.isfinite(value):
+        print(f"::warning::{name}={raw!r} is not finite; using {default}")
         return default
     return value if value > 0 else default
 

--- a/.github/scripts/react_to_comment.py
+++ b/.github/scripts/react_to_comment.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""Post a best-effort emoji reaction on the comment that triggered a workflow.
+
+Why this is a script and not four lines of inline `github-script`
+----------------------------------------------------------------
+Every bot entry point in this repo opens by reacting to the triggering
+`@mention` comment — 👀 "seen and running", 😕 "seen and declined", 🚀
+"seen and dispatching". The reaction is pure UX: it tells a human their
+comment registered, seconds before any real output exists.
+
+It used to be the *first* API call of the dispatch job, unguarded. On
+2026-08-17 GitHub returned `HTTP 503` from
+`POST /repos/{repo}/issues/comments/{id}/reactions` for a few seconds, and
+because an unhandled rejection in `actions/github-script` fails the step,
+the whole `sdk-review-dispatch` job died before it ever fetched the PR head
+or dispatched the mothership session. Two `@sdk-review` requests were lost
+outright — no review, no comment, nothing on the PR to say why. A cosmetic
+call had become a single point of failure for the review pipeline.
+
+So the contract here is deliberately lopsided:
+
+  * Transient failures are retried on a bounded backoff.
+  * Every failure — transient or not — is surfaced as a `::warning::`.
+  * The exit code is **always 0**. A missing emoji must never take down the
+    load-bearing work that follows it in the job.
+
+That "always 0" is the whole point, and it is why this is separate from
+`sdk_review_approve.py`, which is the mirror image: its label write *is*
+load-bearing, so it reports failure rather than swallowing it (a silently
+skipped label there strands an approval permanently).
+
+Configuration (all via env, matching the sibling scripts):
+
+    REPO                    owner/repo, required
+    COMMENT_ID              triggering comment id; blank/absent → no-op
+    REACTION                one of GitHub's reaction contents, default `eyes`
+    REACT_MAX_ATTEMPTS      total attempts including the first, default 3
+    REACT_BACKOFF_SECONDS   base backoff, doubled per retry, default 2
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+import time
+from typing import Callable, Protocol
+
+
+class Runner(Protocol):
+    def __call__(self, *args, **kwargs) -> subprocess.CompletedProcess: ...
+
+
+# GitHub's fixed reaction vocabulary. A typo here is a 422 on every run of a
+# workflow that may only fire a few times a week, so it is worth catching
+# locally instead of discovering it in a job log.
+VALID_REACTIONS = frozenset(
+    {
+        "+1",
+        "-1",
+        "laugh",
+        "confused",
+        "heart",
+        "hooray",
+        "rocket",
+        "eyes",
+    }
+)
+
+DEFAULT_REACTION = "eyes"
+DEFAULT_MAX_ATTEMPTS = 3
+DEFAULT_BACKOFF_SECONDS = 2.0
+
+_HTTP_STATUS = re.compile(r"\(HTTP (\d{3})\)")
+
+# Failure text that is worth a second attempt. Split from the HTTP-status check
+# because these arrive as transport errors with no status at all.
+_TRANSIENT_PHRASES = (
+    "connection reset",
+    "connection refused",
+    "no such host",
+    "i/o timeout",
+    "timeout awaiting",
+    "unexpected eof",
+    "tls handshake",
+    "server error",
+)
+
+
+def http_status(stderr: str) -> int | None:
+    """The HTTP status `gh` reported, if it reported one."""
+    match = _HTTP_STATUS.search(stderr)
+    return int(match.group(1)) if match else None
+
+
+def is_transient(stderr: str) -> bool:
+    """Whether a failed `gh` invocation is worth retrying.
+
+    Retryable: any 5xx (the 503 that motivated this script), 429, a rate-limit
+    message, and bare transport errors that carry no status.
+
+    Not retryable: 401/403 (token lacks the scope), 404 (comment deleted mid
+    run), 422 (bad reaction content). Retrying those burns the job's remaining
+    budget to arrive at the same answer, so they warn once and stop.
+    """
+    lowered = stderr.lower()
+    status = http_status(stderr)
+    if status is not None:
+        if status == 403 and "rate limit" in lowered:
+            # Primary/secondary throttles are reported as 403, not 429, and
+            # unlike a genuine permission 403 they do clear on their own.
+            return True
+        return status >= 500 or status == 429
+    if "rate limit" in lowered or "abuse detection" in lowered:
+        return True
+    return any(phrase in lowered for phrase in _TRANSIENT_PHRASES)
+
+
+def react(
+    repo: str,
+    comment_id: str,
+    reaction: str,
+    *,
+    max_attempts: int = DEFAULT_MAX_ATTEMPTS,
+    backoff_seconds: float = DEFAULT_BACKOFF_SECONDS,
+    runner: Runner = subprocess.run,
+    sleeper: Callable[[float], None] = time.sleep,
+) -> bool:
+    """POST the reaction, retrying transient failures. True iff it landed.
+
+    `sleeper` is injected rather than calling `time.sleep` directly so the
+    tests can assert the backoff schedule without spending it.
+    """
+    args = [
+        "gh",
+        "api",
+        f"repos/{repo}/issues/comments/{comment_id}/reactions",
+        "-X",
+        "POST",
+        "-f",
+        f"content={reaction}",
+        "--silent",
+    ]
+
+    for attempt in range(1, max_attempts + 1):
+        result = runner(args, capture_output=True, text=True, check=False)
+        if result.returncode == 0:
+            print(f"Reacted :{reaction}: on comment {comment_id}")
+            return True
+
+        stderr = (result.stderr or "").strip()
+        last = attempt == max_attempts
+        if not is_transient(stderr):
+            print(
+                f"::warning::could not react :{reaction}: on comment "
+                f"{comment_id} (not retryable): {stderr}"
+            )
+            return False
+        if last:
+            break
+        delay = backoff_seconds * (2 ** (attempt - 1))
+        print(
+            f"::notice::reaction attempt {attempt}/{max_attempts} failed "
+            f"({stderr}); retrying in {delay:g}s"
+        )
+        sleeper(delay)
+
+    print(
+        f"::warning::could not react :{reaction}: on comment {comment_id} "
+        f"after {max_attempts} attempts: {stderr}"
+    )
+    return False
+
+
+def _positive_int(name: str, default: int) -> int:
+    raw = (os.environ.get(name) or "").strip()
+    if not raw:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        print(f"::warning::{name}={raw!r} is not an integer; using {default}")
+        return default
+    return value if value > 0 else default
+
+
+def _positive_float(name: str, default: float) -> float:
+    raw = (os.environ.get(name) or "").strip()
+    if not raw:
+        return default
+    try:
+        value = float(raw)
+    except ValueError:
+        print(f"::warning::{name}={raw!r} is not a number; using {default}")
+        return default
+    return value if value > 0 else default
+
+
+def main() -> int:
+    repo = (os.environ.get("REPO") or "").strip()
+    comment_id = (os.environ.get("COMMENT_ID") or "").strip()
+    reaction = (os.environ.get("REACTION") or "").strip() or DEFAULT_REACTION
+
+    if not comment_id:
+        # workflow_dispatch and schedule triggers have no comment to react to.
+        # Not an error — the caller is allowed to invoke this unconditionally.
+        print("No COMMENT_ID; nothing to react to.")
+        return 0
+    if not repo:
+        print("::warning::REPO is unset; skipping reaction.")
+        return 0
+    if reaction not in VALID_REACTIONS:
+        print(
+            f"::warning::{reaction!r} is not a GitHub reaction "
+            f"({', '.join(sorted(VALID_REACTIONS))}); skipping."
+        )
+        return 0
+
+    react(
+        repo,
+        comment_id,
+        reaction,
+        max_attempts=_positive_int("REACT_MAX_ATTEMPTS", DEFAULT_MAX_ATTEMPTS),
+        backoff_seconds=_positive_float(
+            "REACT_BACKOFF_SECONDS", DEFAULT_BACKOFF_SECONDS
+        ),
+    )
+    # Always 0. See the module docstring: the reaction is never allowed to be
+    # the reason a job fails.
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/react_to_comment.py
+++ b/.github/scripts/react_to_comment.py
@@ -161,7 +161,20 @@ def react(
     ]
 
     for attempt in range(1, max_attempts + 1):
-        result = runner(args, capture_output=True, text=True, check=False)
+        try:
+            result = runner(args, capture_output=True, text=True, check=False)
+        except Exception as exc:  # noqa: BLE001 — see below
+            # A missing or non-executable `gh` raises FileNotFoundError before
+            # any CompletedProcess exists, and nothing else in this file would
+            # catch it — the exception would escape main() and fail the step,
+            # which is the exact always-exit-0 contract this script exists to
+            # hold. The boundary is deliberately broad: ANY raise from the
+            # spawn path is a reason to warn and degrade, never to fail.
+            print(
+                f"::warning::could not react :{reaction}: on comment "
+                f"{comment_id} (runner raised): {exc}"
+            )
+            return False
         if result.returncode == 0:
             print(f"Reacted :{reaction}: on comment {comment_id}")
             return True
@@ -181,7 +194,14 @@ def react(
             f"::notice::reaction attempt {attempt}/{max_attempts} failed "
             f"({stderr}); retrying in {delay:g}s"
         )
-        sleeper(delay)
+        try:
+            sleeper(delay)
+        except Exception as exc:  # noqa: BLE001 — same contract as above
+            print(
+                f"::warning::could not react :{reaction}: on comment "
+                f"{comment_id} (sleeper raised): {exc}"
+            )
+            return False
 
     print(
         f"::warning::could not react :{reaction}: on comment {comment_id} "

--- a/.github/scripts/tests/test_react_to_comment.py
+++ b/.github/scripts/tests/test_react_to_comment.py
@@ -17,6 +17,7 @@ for the reactions API inline again, which is the shape the bug had.
 from __future__ import annotations
 
 import importlib.util
+import math
 import re
 import subprocess
 from pathlib import Path
@@ -205,7 +206,7 @@ def test_main_always_exits_zero_however_the_reaction_fails(
     monkeypatch.setenv("COMMENT_ID", COMMENT_ID)
     monkeypatch.setenv("REACTION", "eyes")
     monkeypatch.setenv("REACT_BACKOFF_SECONDS", "0.001")
-    monkeypatch.setattr(react_mod.subprocess, "run", lambda *a, **k: fail(stderr))
+    monkeypatch.setattr(react_mod, "_RUN", lambda *a, **k: fail(stderr))
 
     assert react_mod.main() == 0
 
@@ -218,7 +219,7 @@ def test_main_no_ops_without_a_comment_id(monkeypatch: pytest.MonkeyPatch) -> No
     def explode(*a, **k):
         raise AssertionError("should not have called gh")
 
-    monkeypatch.setattr(react_mod.subprocess, "run", explode)
+    monkeypatch.setattr(react_mod, "_RUN", explode)
     assert react_mod.main() == 0
 
 
@@ -232,12 +233,12 @@ def test_main_rejects_a_reaction_github_does_not_have(
     def explode(*a, **k):
         raise AssertionError("should not have called gh")
 
-    monkeypatch.setattr(react_mod.subprocess, "run", explode)
+    monkeypatch.setattr(react_mod, "_RUN", explode)
     assert react_mod.main() == 0
 
 
-@pytest.mark.parametrize("raw", ["", "nonsense", "0", "-4"])
-def test_malformed_tuning_env_falls_back_to_the_default(
+@pytest.mark.parametrize("raw", ["", "nonsense", "0", "-4", "inf", "nan"])
+def test_malformed_attempt_count_falls_back_to_the_default(
     monkeypatch: pytest.MonkeyPatch, raw: str
 ) -> None:
     monkeypatch.setenv("REACT_MAX_ATTEMPTS", raw)
@@ -245,6 +246,55 @@ def test_malformed_tuning_env_falls_back_to_the_default(
         react_mod._positive_int("REACT_MAX_ATTEMPTS", react_mod.DEFAULT_MAX_ATTEMPTS)
         == react_mod.DEFAULT_MAX_ATTEMPTS
     )
+
+
+@pytest.mark.parametrize(
+    "raw", ["", "nonsense", "0", "-4", "inf", "-inf", "Infinity", "nan"]
+)
+def test_malformed_backoff_falls_back_to_the_default(
+    monkeypatch: pytest.MonkeyPatch, raw: str
+) -> None:
+    """`float('inf') > 0` is True, so a naive positivity check lets it through.
+
+    It would then reach `time.sleep(inf)`, which raises OverflowError and exits
+    non-zero — the always-exit-0 contract broken by the script's own config
+    parsing, from an env var a caller could set to anything.
+    """
+    monkeypatch.setenv("REACT_BACKOFF_SECONDS", raw)
+    assert (
+        react_mod._positive_float(
+            "REACT_BACKOFF_SECONDS", react_mod.DEFAULT_BACKOFF_SECONDS
+        )
+        == react_mod.DEFAULT_BACKOFF_SECONDS
+    )
+
+
+def test_non_finite_backoff_never_reaches_sleep(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end through `main`, which wires the real `time.sleep`.
+
+    The stand-in raises on a non-finite delay the way `time.sleep` does, so
+    this fails if the guard is removed rather than passing on a mock that
+    tolerates anything.
+    """
+    slept: list[float] = []
+
+    def strict_sleep(seconds: float) -> None:
+        if not math.isfinite(seconds):
+            raise OverflowError("cannot convert float infinity to integer")
+        slept.append(seconds)
+
+    monkeypatch.setenv("REPO", REPO)
+    monkeypatch.setenv("COMMENT_ID", COMMENT_ID)
+    monkeypatch.setenv("REACTION", "eyes")
+    monkeypatch.setenv("REACT_BACKOFF_SECONDS", "inf")
+    monkeypatch.setenv("REACT_MAX_ATTEMPTS", "2")
+    monkeypatch.setattr(react_mod, "_RUN", lambda *a, **k: fail(GH_503))
+    monkeypatch.setattr(react_mod, "_SLEEP", strict_sleep)
+
+    assert react_mod.main() == 0
+    assert slept == [react_mod.DEFAULT_BACKOFF_SECONDS]
 
 
 # --------------------------------------------------------------------------
@@ -313,14 +363,25 @@ def test_every_caller_can_actually_reach_the_script() -> None:
                     )
 
 
-def test_callers_pass_the_env_the_script_reads() -> None:
-    """`REPO` and `COMMENT_ID` are read from env, so a typo is silent.
+# Every bot entry point that acknowledges a comment, as (workflow, job, step).
+#
+# Pinned exactly rather than counted. A `>= 5` lower bound would stay green if
+# one of these lost its ack while an unrelated sixth caller was added
+# elsewhere — the count balances, the entry point goes silent, and the guard
+# that exists to notice says nothing. Adding a genuinely new caller is
+# supposed to require editing this list.
+EXPECTED_CALLERS = {
+    ("sdk-review.yml", "react-on-skip", "React to skipped trigger"),
+    ("sdk-review.yml", "sdk-review-dispatch", "React to comment"),
+    ("sdk-resolve.yml", "sdk-resolve-dispatch", "Acknowledge with a reaction"),
+    ("auto-fix-vulnerabilities.yaml", "auto-fix", "React to comment"),
+    ("capability-manifest-regen.yaml", "regen", "React to comment"),
+}
 
-    Without `REPO` the script warns and no-ops; without `GH_TOKEN` every
-    attempt 401s. Both look like "the emoji just didn't appear".
-    """
-    required = {"GH_TOKEN", "REPO", "COMMENT_ID"}
-    seen_callers = 0
+
+def _caller_steps() -> dict[tuple[str, str, str], dict]:
+    """Every `(workflow, job, step name)` that invokes the helper."""
+    found: dict[tuple[str, str, str], dict] = {}
     for path in _yaml_files():
         text = path.read_text(encoding="utf-8")
         if SCRIPT_NAME not in text:
@@ -328,16 +389,44 @@ def test_callers_pass_the_env_the_script_reads() -> None:
         doc = yaml.safe_load(text)
         for job_name, job in (doc.get("jobs") or {}).items():
             for step in job.get("steps") or []:
-                if SCRIPT_NAME not in str(step.get("run") or ""):
-                    continue
-                seen_callers += 1
-                env = set(step.get("env") or {})
-                missing = required - env
-                assert not missing, (
-                    f"{path.name}:{job_name} step "
-                    f"{step.get('name')!r} is missing env {sorted(missing)}"
-                )
-    assert seen_callers >= 5, (
-        "expected every bot entry point to route through the helper; "
-        f"found only {seen_callers}"
+                if SCRIPT_NAME in str(step.get("run") or ""):
+                    found[(path.name, job_name, str(step.get("name")))] = step
+    return found
+
+
+def test_the_caller_set_is_exactly_what_we_expect() -> None:
+    actual = set(_caller_steps())
+    assert actual == EXPECTED_CALLERS, (
+        f"lost acks: {sorted(EXPECTED_CALLERS - actual)}; "
+        f"new callers to add to EXPECTED_CALLERS: {sorted(actual - EXPECTED_CALLERS)}"
     )
+
+
+def test_callers_pass_the_env_the_script_reads() -> None:
+    """`REPO` and `COMMENT_ID` are read from env, so a typo is silent.
+
+    Without `REPO` the script warns and no-ops; without `GH_TOKEN` every
+    attempt 401s. Both look like "the emoji just didn't appear".
+    """
+    required = {"GH_TOKEN", "REPO", "COMMENT_ID"}
+    for caller, step in _caller_steps().items():
+        missing = required - set(step.get("env") or {})
+        assert not missing, f"{caller} is missing env {sorted(missing)}"
+
+
+def test_every_caller_workflow_grants_issues_write() -> None:
+    """The reactions endpoint needs `issues: write`, even for a PR comment.
+
+    `/issues/comments/{id}/reactions` is not covered by `pull-requests:
+    write`. Two of these workflows were missing it. Now that the helper warns
+    and exits 0 instead of failing the step, a permissions trim here would
+    silence an ack permanently with nothing red to show for it — which is
+    precisely why this is asserted rather than left to be noticed.
+    """
+    for path in {WORKFLOW_DIR / name for name, _, _ in EXPECTED_CALLERS}:
+        doc = yaml.safe_load(path.read_text(encoding="utf-8"))
+        permissions = doc.get("permissions") or {}
+        assert permissions.get("issues") == "write", (
+            f"{path.name} reacts to comments but grants "
+            f"issues={permissions.get('issues')!r}"
+        )

--- a/.github/scripts/tests/test_react_to_comment.py
+++ b/.github/scripts/tests/test_react_to_comment.py
@@ -190,6 +190,45 @@ def test_the_request_targets_the_comment_reactions_endpoint() -> None:
     assert "POST" in args
 
 
+def test_a_runner_that_raises_warns_and_returns_false() -> None:
+    """A missing/non-executable `gh` raises before any CompletedProcess exists.
+
+    `subprocess.run` raises FileNotFoundError when the binary is absent; the
+    always-exit-0 contract has to hold for that too, not just for non-zero
+    return codes — an exception escaping `main()` fails the step exactly the
+    way the unguarded 503 did.
+    """
+
+    def missing_gh(*args, **kwargs) -> subprocess.CompletedProcess:
+        raise FileNotFoundError(2, "No such file or directory", "gh")
+
+    assert (
+        react_mod.react(
+            REPO, COMMENT_ID, "eyes", runner=missing_gh, sleeper=RecordingSleeper()
+        )
+        is False
+    )
+
+
+def test_a_sleeper_that_raises_warns_and_returns_false() -> None:
+    """Same boundary one call later: the wait between attempts must not kill
+    the job either."""
+
+    def broken_sleeper(_seconds: float) -> None:
+        raise OverflowError("timestamp out of range for platform time_t")
+
+    assert (
+        react_mod.react(
+            REPO,
+            COMMENT_ID,
+            "eyes",
+            runner=RecordingRunner(fail(GH_503)),
+            sleeper=broken_sleeper,
+        )
+        is False
+    )
+
+
 # --------------------------------------------------------------------------
 # The exit-code contract — the actual point of the script
 # --------------------------------------------------------------------------
@@ -207,6 +246,22 @@ def test_main_always_exits_zero_however_the_reaction_fails(
     monkeypatch.setenv("REACTION", "eyes")
     monkeypatch.setenv("REACT_BACKOFF_SECONDS", "0.001")
     monkeypatch.setattr(react_mod, "_RUN", lambda *a, **k: fail(stderr))
+
+    assert react_mod.main() == 0
+
+
+def test_main_exits_zero_even_when_the_runner_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end for the spawn-failure path: `gh` absent → warning, exit 0."""
+    monkeypatch.setenv("REPO", REPO)
+    monkeypatch.setenv("COMMENT_ID", COMMENT_ID)
+    monkeypatch.setenv("REACTION", "eyes")
+
+    def missing_gh(*args, **kwargs) -> subprocess.CompletedProcess:
+        raise FileNotFoundError(2, "No such file or directory", "gh")
+
+    monkeypatch.setattr(react_mod, "_RUN", missing_gh)
 
     assert react_mod.main() == 0
 

--- a/.github/scripts/tests/test_react_to_comment.py
+++ b/.github/scripts/tests/test_react_to_comment.py
@@ -1,0 +1,343 @@
+"""Tests for the best-effort comment-reaction helper.
+
+The regression these pin: on 2026-08-17 a transient `HTTP 503` from
+`POST /issues/comments/{id}/reactions` failed the `sdk-review-dispatch` job
+outright — the reaction was the job's first API call and an unhandled
+rejection in `actions/github-script` fails the step. Two `@sdk-review`
+requests were dropped before the mothership session was ever created.
+
+So the assertions here are mostly about what does *not* happen: a failing
+reaction never propagates a non-zero exit, and a transient one gets a second
+chance before it is given up on.
+
+There is also a cross-file guard at the bottom asserting no workflow reaches
+for the reactions API inline again, which is the shape the bug had.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+SPEC = importlib.util.spec_from_file_location(
+    "react_to_comment", Path(__file__).resolve().parents[1] / "react_to_comment.py"
+)
+react_mod = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(react_mod)
+
+
+REPO = "atlanhq/application-sdk"
+COMMENT_ID = "5318632555"
+
+# Verbatim from the failed run (job 95463483353), minus the response dump.
+GH_503 = (
+    "gh: No server is currently available to service your request. "
+    "Sorry about that. Please try resubmitting your request and contact us "
+    "if the problem persists. (HTTP 503)"
+)
+GH_403_PERMS = "gh: Resource not accessible by integration (HTTP 403)"
+GH_403_RATE = "gh: API rate limit exceeded for user ID 62283865. (HTTP 403)"
+GH_404 = "gh: Not Found (HTTP 404)"
+GH_422 = "gh: Validation Failed (HTTP 422)"
+
+
+def ok() -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+
+
+def fail(stderr: str) -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr=stderr)
+
+
+class RecordingRunner:
+    """A `subprocess.run` stand-in that replays a scripted list of results."""
+
+    def __init__(self, *results: subprocess.CompletedProcess):
+        self._results = list(results)
+        self.calls: list[list[str]] = []
+
+    def __call__(self, args, **kwargs) -> subprocess.CompletedProcess:
+        self.calls.append(list(args))
+        if not self._results:
+            raise AssertionError(f"unexpected extra invocation: {args}")
+        return self._results.pop(0)
+
+
+class RecordingSleeper:
+    def __init__(self) -> None:
+        self.delays: list[float] = []
+
+    def __call__(self, seconds: float) -> None:
+        self.delays.append(seconds)
+
+
+# --------------------------------------------------------------------------
+# Transience classification
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "stderr",
+    [
+        GH_503,
+        "gh: Bad gateway (HTTP 502)",
+        "gh: Gateway Timeout (HTTP 504)",
+        "gh: Internal Server Error (HTTP 500)",
+        "gh: Too Many Requests (HTTP 429)",
+        GH_403_RATE,
+        "gh: You have exceeded a secondary rate limit",
+        "error connecting to api.github.com: connection reset by peer",
+        "Post https://api.github.com/...: unexpected EOF",
+    ],
+)
+def test_transient_failures_are_retryable(stderr: str) -> None:
+    assert react_mod.is_transient(stderr) is True
+
+
+@pytest.mark.parametrize("stderr", [GH_403_PERMS, GH_404, GH_422])
+def test_terminal_failures_are_not_retryable(stderr: str) -> None:
+    assert react_mod.is_transient(stderr) is False
+
+
+def test_permission_403_is_not_confused_with_a_throttle_403() -> None:
+    """Both are 403; only one clears on its own.
+
+    A token missing `issues: write` fails identically on every attempt, so
+    retrying it just spends the job's budget to reach the same answer.
+    """
+    assert react_mod.is_transient(GH_403_RATE) is True
+    assert react_mod.is_transient(GH_403_PERMS) is False
+
+
+# --------------------------------------------------------------------------
+# Retry behaviour
+# --------------------------------------------------------------------------
+
+
+def test_first_attempt_success_makes_one_call() -> None:
+    runner = RecordingRunner(ok())
+    sleeper = RecordingSleeper()
+
+    assert (
+        react_mod.react(REPO, COMMENT_ID, "eyes", runner=runner, sleeper=sleeper)
+        is True
+    )
+    assert len(runner.calls) == 1
+    assert sleeper.delays == []
+
+
+def test_the_503_that_broke_dispatch_is_retried_and_succeeds() -> None:
+    runner = RecordingRunner(fail(GH_503), ok())
+    sleeper = RecordingSleeper()
+
+    assert (
+        react_mod.react(REPO, COMMENT_ID, "eyes", runner=runner, sleeper=sleeper)
+        is True
+    )
+    assert len(runner.calls) == 2
+    assert sleeper.delays == [2.0]
+
+
+def test_backoff_doubles_and_stops_at_the_attempt_cap() -> None:
+    runner = RecordingRunner(fail(GH_503), fail(GH_503), fail(GH_503))
+    sleeper = RecordingSleeper()
+
+    assert (
+        react_mod.react(
+            REPO,
+            COMMENT_ID,
+            "eyes",
+            max_attempts=3,
+            backoff_seconds=2,
+            runner=runner,
+            sleeper=sleeper,
+        )
+        is False
+    )
+    assert len(runner.calls) == 3
+    # Two waits for three attempts — never a trailing sleep after the last try,
+    # which would just burn job time before giving up anyway.
+    assert sleeper.delays == [2.0, 4.0]
+
+
+def test_terminal_failure_stops_immediately() -> None:
+    runner = RecordingRunner(fail(GH_403_PERMS))
+    sleeper = RecordingSleeper()
+
+    assert (
+        react_mod.react(REPO, COMMENT_ID, "eyes", runner=runner, sleeper=sleeper)
+        is False
+    )
+    assert len(runner.calls) == 1
+    assert sleeper.delays == []
+
+
+def test_the_request_targets_the_comment_reactions_endpoint() -> None:
+    runner = RecordingRunner(ok())
+    react_mod.react(REPO, COMMENT_ID, "rocket", runner=runner, sleeper=lambda _: None)
+
+    args = runner.calls[0]
+    assert args[:2] == ["gh", "api"]
+    assert f"repos/{REPO}/issues/comments/{COMMENT_ID}/reactions" in args
+    assert "content=rocket" in args
+    assert "POST" in args
+
+
+# --------------------------------------------------------------------------
+# The exit-code contract — the actual point of the script
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "stderr",
+    [GH_503, GH_403_PERMS, GH_404, GH_422, "totally unrecognised failure"],
+)
+def test_main_always_exits_zero_however_the_reaction_fails(
+    monkeypatch: pytest.MonkeyPatch, stderr: str
+) -> None:
+    monkeypatch.setenv("REPO", REPO)
+    monkeypatch.setenv("COMMENT_ID", COMMENT_ID)
+    monkeypatch.setenv("REACTION", "eyes")
+    monkeypatch.setenv("REACT_BACKOFF_SECONDS", "0.001")
+    monkeypatch.setattr(react_mod.subprocess, "run", lambda *a, **k: fail(stderr))
+
+    assert react_mod.main() == 0
+
+
+def test_main_no_ops_without_a_comment_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    """workflow_dispatch has no comment; the caller may still invoke this."""
+    monkeypatch.setenv("REPO", REPO)
+    monkeypatch.setenv("COMMENT_ID", "")
+
+    def explode(*a, **k):
+        raise AssertionError("should not have called gh")
+
+    monkeypatch.setattr(react_mod.subprocess, "run", explode)
+    assert react_mod.main() == 0
+
+
+def test_main_rejects_a_reaction_github_does_not_have(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("REPO", REPO)
+    monkeypatch.setenv("COMMENT_ID", COMMENT_ID)
+    monkeypatch.setenv("REACTION", "thumbsup")  # the API name is '+1'
+
+    def explode(*a, **k):
+        raise AssertionError("should not have called gh")
+
+    monkeypatch.setattr(react_mod.subprocess, "run", explode)
+    assert react_mod.main() == 0
+
+
+@pytest.mark.parametrize("raw", ["", "nonsense", "0", "-4"])
+def test_malformed_tuning_env_falls_back_to_the_default(
+    monkeypatch: pytest.MonkeyPatch, raw: str
+) -> None:
+    monkeypatch.setenv("REACT_MAX_ATTEMPTS", raw)
+    assert (
+        react_mod._positive_int("REACT_MAX_ATTEMPTS", react_mod.DEFAULT_MAX_ATTEMPTS)
+        == react_mod.DEFAULT_MAX_ATTEMPTS
+    )
+
+
+# --------------------------------------------------------------------------
+# Cross-file guard: no workflow may react inline again
+# --------------------------------------------------------------------------
+
+WORKFLOW_DIR = Path(__file__).resolve().parents[3] / ".github" / "workflows"
+ACTIONS_DIR = Path(__file__).resolve().parents[3] / ".github" / "actions"
+SCRIPT_NAME = "react_to_comment.py"
+
+# The Octokit call this script replaced. Matched as raw text rather than by
+# walking the parsed YAML because it lives inside `github-script`'s JS body,
+# which YAML sees as an opaque string.
+INLINE_REACTION = re.compile(r"reactions\.createForIssueComment")
+
+
+def _yaml_files() -> list[Path]:
+    files = sorted(WORKFLOW_DIR.glob("*.y*ml"))
+    files += sorted(ACTIONS_DIR.glob("*/action.y*ml"))
+    assert files, "no workflow YAML found — the guard is pointed at the wrong path"
+    return files
+
+
+def test_no_workflow_reacts_inline() -> None:
+    """An inline reaction is an unguarded API call in the middle of a job.
+
+    Reads the tree rather than a checked-in list, so a newly added entry point
+    that reaches for the reactions API directly fails here instead of quietly
+    reintroducing the single point of failure.
+    """
+    offenders = [
+        path.relative_to(WORKFLOW_DIR.parents[1]).as_posix()
+        for path in _yaml_files()
+        if INLINE_REACTION.search(path.read_text(encoding="utf-8"))
+    ]
+    assert offenders == [], (
+        "these call the reactions API inline; route them through "
+        f".github/scripts/{SCRIPT_NAME} instead: {offenders}"
+    )
+
+
+def test_every_caller_can_actually_reach_the_script() -> None:
+    """A caller that never checks out the repo would fail at `python3 …`.
+
+    Cheap to get wrong: two of these workflows react *before* their main
+    checkout, so they carry a sparse one just for this file.
+    """
+    for path in _yaml_files():
+        text = path.read_text(encoding="utf-8")
+        if SCRIPT_NAME not in text:
+            continue
+        doc = yaml.safe_load(text)
+        jobs = doc.get("jobs") or {}
+        for job_name, job in jobs.items():
+            steps = job.get("steps") or []
+            checked_out = False
+            for step in steps:
+                uses = str(step.get("uses") or "")
+                run = str(step.get("run") or "")
+                if uses.startswith("actions/checkout@"):
+                    checked_out = True
+                if SCRIPT_NAME in run:
+                    assert checked_out, (
+                        f"{path.name}:{job_name} runs {SCRIPT_NAME} with no "
+                        "preceding actions/checkout"
+                    )
+
+
+def test_callers_pass_the_env_the_script_reads() -> None:
+    """`REPO` and `COMMENT_ID` are read from env, so a typo is silent.
+
+    Without `REPO` the script warns and no-ops; without `GH_TOKEN` every
+    attempt 401s. Both look like "the emoji just didn't appear".
+    """
+    required = {"GH_TOKEN", "REPO", "COMMENT_ID"}
+    seen_callers = 0
+    for path in _yaml_files():
+        text = path.read_text(encoding="utf-8")
+        if SCRIPT_NAME not in text:
+            continue
+        doc = yaml.safe_load(text)
+        for job_name, job in (doc.get("jobs") or {}).items():
+            for step in job.get("steps") or []:
+                if SCRIPT_NAME not in str(step.get("run") or ""):
+                    continue
+                seen_callers += 1
+                env = set(step.get("env") or {})
+                missing = required - env
+                assert not missing, (
+                    f"{path.name}:{job_name} step "
+                    f"{step.get('name')!r} is missing env {sorted(missing)}"
+                )
+    assert seen_callers >= 5, (
+        "expected every bot entry point to route through the helper; "
+        f"found only {seen_callers}"
+    )

--- a/.github/workflows/auto-fix-vulnerabilities.yaml
+++ b/.github/workflows/auto-fix-vulnerabilities.yaml
@@ -37,6 +37,10 @@ permissions:
   contents: write
   pull-requests: write
   actions: read
+  # Same gap as capability-manifest-regen: `/issues/comments/{id}/reactions`
+  # needs `issues: write` even for a PR comment. Fixed here too rather than
+  # only where review caught it — both are 🚀 acks on the same endpoint.
+  issues: write
 
 jobs:
   auto-fix:

--- a/.github/workflows/auto-fix-vulnerabilities.yaml
+++ b/.github/workflows/auto-fix-vulnerabilities.yaml
@@ -57,16 +57,24 @@ jobs:
             core.setOutput('branch', pr.data.head.ref);
             core.setOutput('number', context.issue.number);
 
-      - name: React to comment
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+      # Sparse, and ahead of the full checkout below, so the ack stays the
+      # first thing the requester sees.
+      - name: Checkout reaction helper
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          script: |
-            await github.rest.reactions.createForIssueComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              comment_id: context.payload.comment.id,
-              content: 'rocket',
-            });
+          sparse-checkout: .github/scripts/react_to_comment.py
+          sparse-checkout-cone-mode: false
+
+      # Best-effort: the reaction is cosmetic, so a transient reactions-API
+      # failure must not take the fix run down with it. The script exits 0
+      # whatever happens.
+      - name: React to comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+          REACTION: rocket
+        run: python3 .github/scripts/react_to_comment.py
 
       - name: Mint fleet App token
         id: app-token

--- a/.github/workflows/capability-manifest-regen.yaml
+++ b/.github/workflows/capability-manifest-regen.yaml
@@ -81,17 +81,26 @@ jobs:
               body: 'ℹ️ `/regen-manifest` is skipped on version-bump branches.',
             });
 
+      # Sparse, and ahead of the full checkout below, so the ack stays the
+      # first thing the requester sees.
+      - name: Checkout reaction helper
+        if: steps.pr.outputs.is_fork != 'true' && steps.pr.outputs.is_bump_version != 'true'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          sparse-checkout: .github/scripts/react_to_comment.py
+          sparse-checkout-cone-mode: false
+
+      # Best-effort: the reaction is cosmetic, so a transient reactions-API
+      # failure must not take the regen run down with it. The script exits 0
+      # whatever happens.
       - name: React to comment
         if: steps.pr.outputs.is_fork != 'true' && steps.pr.outputs.is_bump_version != 'true'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
-        with:
-          script: |
-            await github.rest.reactions.createForIssueComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              comment_id: context.payload.comment.id,
-              content: 'rocket',
-            });
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+          REACTION: rocket
+        run: python3 .github/scripts/react_to_comment.py
 
       - name: Mint fleet App token
         id: app-token

--- a/.github/workflows/capability-manifest-regen.yaml
+++ b/.github/workflows/capability-manifest-regen.yaml
@@ -23,6 +23,12 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  # The reactions endpoint is `/issues/comments/{id}/reactions` — a PR comment
+  # is an issue comment, so `pull-requests: write` does not cover it. Without
+  # this the ack 403s on every run; the helper now warns and exits 0 rather
+  # than failing the job, which would make a permanently missing ack the
+  # silent steady state.
+  issues: write
 
 jobs:
   regen:

--- a/.github/workflows/sdk-resolve.yml
+++ b/.github/workflows/sdk-resolve.yml
@@ -91,19 +91,26 @@ jobs:
       # Acknowledge with an eyes reaction AND a visible comment carrying the
       # run link, so the requester has an immediate status handle to follow
       # (the sandbox loop runs out-of-band for many minutes).
-      - name: Acknowledge + link the run
+      # Split in two on purpose. The reaction is cosmetic and best-effort; the
+      # comment carrying the run link is the actual status handle. When both
+      # lived in one script, a transient failure on the reaction meant the
+      # requester got neither — and no way to find the run.
+      - name: Acknowledge with a reaction
+        if: github.event_name == 'issue_comment'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+          REACTION: eyes
+        run: python3 .github/scripts/react_to_comment.py
+
+      - name: Link the run
         if: github.event_name == 'issue_comment'
         env:
           GHA_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
-            await github.rest.reactions.createForIssueComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              comment_id: context.payload.comment.id,
-              content: 'eyes',
-            });
             const body = [
               `<!-- SDK_RESOLVE_STARTED -->`,
               `🤖 **SDK Resolve started.** Driving this PR toward merge-ready — fixing CI + every \`@sdk-review\` finding, then requesting human review.`,

--- a/.github/workflows/sdk-review.yml
+++ b/.github/workflows/sdk-review.yml
@@ -197,21 +197,26 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
-      - name: React to skipped trigger
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+      # Sparse: this job exists only to leave a reaction, so it pulls the one
+      # file it needs rather than the tree.
+      - name: Checkout reaction helper
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          script: |
-            // React with 'confused' (😕) to signal "seen, consciously declined".
-            // The dispatch job uses 'eyes' (👀) for proceed — keeping distinct
-            // reactions means a user can tell "seen and running" (👀) from "seen
-            // and skipped" (😕) without reading the workflow log.
-            // No new PR comment — that would be noise the resolver may re-read.
-            await github.rest.reactions.createForIssueComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              comment_id: context.payload.comment.id,
-              content: 'confused',
-            });
+          sparse-checkout: .github/scripts/react_to_comment.py
+          sparse-checkout-cone-mode: false
+
+      # React with 'confused' (😕) to signal "seen, consciously declined".
+      # The dispatch job uses 'eyes' (👀) for proceed — keeping distinct
+      # reactions means a user can tell "seen and running" (👀) from "seen
+      # and skipped" (😕) without reading the workflow log.
+      # No new PR comment — that would be noise the resolver may re-read.
+      - name: React to skipped trigger
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+          REACTION: confused
+        run: python3 .github/scripts/react_to_comment.py
 
   sdk-review-dispatch:
     needs: gate
@@ -270,21 +275,23 @@ jobs:
             core.setOutput('pr_number', prNumber);
             core.setOutput('commenter_intent', intent);
 
-      - name: React to comment + ensure labels exist
+      # Best-effort, never fatal. This used to be the opening lines of the
+      # step below, unguarded — and a transient HTTP 503 from the reactions
+      # API killed the whole dispatch job before it reached the mothership
+      # call, losing the review request entirely. The script always exits 0.
+      # `COMMENT_ID` is blank on workflow_dispatch, which the script no-ops on.
+      - name: React to comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          COMMENT_ID: ${{ steps.parse.outputs.comment_id }}
+          REACTION: eyes
+        run: python3 .github/scripts/react_to_comment.py
+
+      - name: Ensure labels exist
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
-            // Only react when triggered by a real comment (workflow_dispatch
-            // has no comment to react to).
-            if (context.eventName === 'issue_comment') {
-              await github.rest.reactions.createForIssueComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: context.payload.comment.id,
-                content: 'eyes',
-              });
-            }
-
             const labels = [
               { name: 'sdk-review-approved', color: '0e8a16', description: 'SDK review (mothership) approved' },
               { name: 'sdk-review-needs-human', color: 'd93f0b', description: 'SDK review (mothership) needs human decision' },


### PR DESCRIPTION
## What

Every bot entry point in this repo opens by reacting to the triggering `@mention` comment — 👀 "seen and running", 🚀 "seen and dispatching", 😕 "seen and declined". That reaction was an unguarded Octokit call inside `actions/github-script`, and an unhandled rejection there fails the step.

So a cosmetic API call was a single point of failure for whatever the job actually existed to do.

## Why now

On 2026-08-17 GitHub returned `HTTP 503` from `POST /repos/{repo}/issues/comments/{id}/reactions` for a few seconds. Because the reaction was the *first* API call in `sdk-review-dispatch`, the job died before it fetched the PR head or dispatched the mothership session:

```
RequestError [HttpError]: No server is currently available to service your request.
  status: 503
  url: '.../issues/comments/5318632555/reactions'
##[error]Unhandled error: HttpError: No server is currently available ...
```

Two `@sdk-review` requests were dropped outright — no review, no comment, nothing on the PR to say why. The same 503 wave also took out `sdk-review-approve-on-verdict`.

Affected runs: [32055135058](https://github.com/atlanhq/application-sdk/actions/runs/32055135058), [32055108079](https://github.com/atlanhq/application-sdk/actions/runs/32055108079).

## How

All five call sites now route through `.github/scripts/react_to_comment.py`:

- **Retries** transient failures — any 5xx, 429, primary/secondary throttles, and bare transport errors that carry no status — on a bounded doubling backoff (3 attempts, 2s base).
- **Stops immediately** on terminal ones — 401/403-permissions, 404 (comment deleted mid-run), 422 (bad reaction content). Retrying those spends the job's budget to reach the same answer.
- **Always exits 0.** A missing emoji must never be the reason a job fails.

That last part is deliberately the inverse of `sdk_review_approve.py`, whose label write *is* load-bearing and reports failure instead of swallowing it — a silently skipped label there strands an approval permanently. A missing emoji strands nothing.

Two details worth flagging in review:

1. **`sdk-resolve`'s ack is split in two.** The reaction and the run-link comment shared one script, so a transient reaction failure cost the requester the run link too — the one thing that makes an out-of-band job followable. The comment stays strict; only the reaction is best-effort.
2. **Two workflows react before their main checkout** (`auto-fix-vulnerabilities`, `capability-manifest-regen`). They carry a sparse checkout of just this one file rather than being reordered, so the ack stays the first thing the requester sees even if the full checkout is slow or fails.

## Tests

32 new tests in `.github/scripts/tests/test_react_to_comment.py`:

- The verbatim 503 stderr from the failed run, retried and succeeding.
- The 403-throttle vs 403-permissions split — both are 403, only one clears on its own.
- The backoff schedule (`[2.0, 4.0]` for 3 attempts, no trailing sleep before giving up).
- The exit-0 contract across every failure class, including unrecognised ones.
- A **cross-file guard** that reds if any workflow or composite action reaches for `reactions.createForIssueComment` inline again, plus checks that every caller has a preceding `actions/checkout` and passes the env the script reads.

The guard was verified to actually fail when the pattern is reintroduced — not a test that always passes.

Full suite: `2329 passed`. Pre-commit clean.

## Out of scope

The `createLabel` loop that followed the old reaction in `sdk-review-dispatch` swallows 422 but rethrows everything else, so a 503 *there* can still kill dispatch. Same shape, left alone deliberately — happy to fold it in if reviewers would rather it went with this.
