### PR TITLE
ci(security): down-scope the fleet App token on the bot-branch push lanes (FND-395)

### DIFF
--- a/.github/workflows/dependabot-requirements-sync.yaml
+++ b/.github/workflows/dependabot-requirements-sync.yaml
@@ -35,6 +35,10 @@ jobs:
           private-key: ${{ secrets.FLEET_APP_PRIVATE_KEY }}
           owner: atlanhq
           repositories: application-sdk
+          # Same reasoning as renovate-lock-cooldown.yaml (FND-395): this job
+          # runs from the pushed branch, so the token it mints should carry only
+          # the permission the job uses. Checkout plus one push is contents.
+          permission-contents: write
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/renovate-lock-cooldown.yaml
+++ b/.github/workflows/renovate-lock-cooldown.yaml
@@ -99,6 +99,17 @@ jobs:
           private-key: ${{ secrets.FLEET_APP_PRIVATE_KEY }}
           owner: atlanhq
           repositories: application-sdk
+          # Down-scope to the one permission this lane uses (FND-395). An
+          # installation token has no *branch* scope — that is what the `bot
+          # branches` ruleset is for — but it does have a permission scope, and
+          # by default this step mints the App's whole installation grant on
+          # this repo. Since the workflow definition and the scripts it runs
+          # both come from the pushed branch, whatever the token can do is
+          # reachable from that branch: contents-only is a materially smaller
+          # blast radius than the full grant. The commit status published below
+          # is written with GITHUB_TOKEN, so `statuses` is deliberately absent
+          # here rather than an omission.
+          permission-contents: write
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:


### PR DESCRIPTION
## What

Declares `permission-contents: write` on the `create-github-app-token` step in the two workflows that trigger on a push to a bot-owned branch:

- `.github/workflows/renovate-lock-cooldown.yaml`
- `.github/workflows/dependabot-requirements-sync.yaml`

## Why

Both workflows trigger on `push` to a `renovate/**` (or `dependabot/**`) branch, check out `${{ github.ref }}`, and execute scripts from the pushed content. On a `push` event GitHub runs the workflow definition at the pushed SHA, so the workflow file and the scripts it calls are both input from that branch — and they run alongside a minted App token.

An installation token has no *branch* scope; there is no GitHub API for one. Restricting who may push these branches is branch configuration, which lives outside the repo and is tracked in FND-395.

What the token *does* have is a permission scope, and by default this step mints the App's entire installation grant on the repo. Each of these jobs needs exactly one permission — a checkout and a push. Declaring `permission-contents: write` drops everything else, so the grant reachable from a bot branch is contents-only rather than the full installation.

The cooldown lane also publishes a commit status. That is written with `GITHUB_TOKEN`, not the App token (publishing a status needs no identity that re-triggers anything), so `statuses` is deliberately absent from the App scope rather than overlooked.

## Not a behaviour change

`permission-contents: write` is what both lanes were already exercising. The push that re-triggers the PR's required checks still comes from a real non-`github-actions[bot]` identity, which is the whole reason these lanes mint an App token in the first place.

## Verification

- `permission-contents` confirmed present on the pinned action version (`bcd2ba4`, v3).
- `uv run pre-commit run --files <both workflows>` — clean.
- `uv run pytest .github/scripts/tests/test_bound_lock_branch.py` — 17 passed.
- The lanes themselves exercise on the next Renovate push to `renovate/lock-file-maintenance`.
