### PR TITLE
fix(conformance): feed e2e evidence and cross-CSP coverage to the test-readiness scorecard (FND-33, FND-34)

### DIFF
--- a/.github/actions/discover-e2e-suites/action.yaml
+++ b/.github/actions/discover-e2e-suites/action.yaml
@@ -65,6 +65,13 @@ outputs:
   leg-count:
     description: Number of matrix legs emitted (suites × clouds).
     value: ${{ steps.discover.outputs.leg-count }}
+  clouds:
+    description: |
+      The resolved cloud list, comma-separated; "" means no cloud dimension
+      (the legacy single-tenant fallback). Emitted from the same `parse_clouds`
+      call that decided the fan-out, so a consumer recording cross-CSP coverage
+      cannot disagree with the coverage that actually ran (FND-34).
+    value: ${{ steps.discover.outputs.clouds }}
 
 runs:
   using: composite

--- a/.github/actions/discover-e2e-suites/discover_e2e_suites.py
+++ b/.github/actions/discover-e2e-suites/discover_e2e_suites.py
@@ -15,6 +15,14 @@ consumes:
               but nothing found" guard is about suites, and a cloud fan-out over
               zero suites is still zero suites.
   leg-count — number of matrix legs actually emitted (suites × clouds).
+  clouds    — the RESOLVED cloud list, comma-separated ("" for no cloud
+              dimension). The matrix already carries it per leg, but only a
+              consumer that parses the matrix can see it, and "which clouds did
+              this repo actually run against" is a fact the test-readiness
+              scorecard records descriptively (FND-34). Emitting it here means
+              the answer comes from the same ``parse_clouds`` call that decided
+              the fan-out, so the recorded coverage cannot disagree with the
+              coverage that ran.
 
 Cross-CSP fan-out (FND-6)
 -------------------------
@@ -309,6 +317,7 @@ def main(argv: list[str] | None = None) -> int:
         print(f"matrix={matrix}")
         print(f"count={len(entries)}")
         print(f"leg-count={len(entries)}")
+        print(f"clouds={','.join(clouds)}")
         return 0
 
     suites = discover(args.test_dir)
@@ -340,6 +349,11 @@ def main(argv: list[str] | None = None) -> int:
     print(f"matrix={matrix}")
     print(f"count={len(suites)}")
     print(f"leg-count={len(entries)}")
+    # Empty means "no cloud dimension" — the legacy single-tenant fallback — and
+    # the consumer must be able to tell that apart from "e2e never ran", which is
+    # why the scorecard omits the field entirely in the latter case rather than
+    # recording an empty list.
+    print(f"clouds={','.join(clouds)}")
     return 0
 
 

--- a/.github/scripts/build_scorecard_args.py
+++ b/.github/scripts/build_scorecard_args.py
@@ -1,0 +1,135 @@
+"""Build the `scorecard` argument list for atlan-application-sdk-conformance.
+
+The scorecard job feeds evidence from up to three tiers plus two descriptive
+cross-CSP fields, and three of those arguments are *conditional* — which is
+exactly the branching docs/standards/ci.md keeps out of YAML.  Callers do::
+
+    mapfile -t sc_args < <(python .github/scripts/build_scorecard_args.py)
+    uvx atlan-application-sdk-conformance scorecard "${sc_args[@]}"
+
+Everything is read from the environment (set by a GitHub Actions ``env:``
+block), so the workflow stays straight-line.
+
+The three conditional rules, and why each is a rule rather than a default:
+
+``--e2e-junit``
+    Passed only when the e2e job actually RAN (``E2E_RESULT`` is neither empty
+    nor ``skipped``).  A *failed* e2e still counts — its junit is exactly the
+    evidence the scorecard should reflect.  Passing the glob unconditionally
+    would be almost harmless (the CLI treats "matched nothing" as
+    not-applicable), but "the job was skipped" is knowable here and saying so
+    explicitly keeps the two ways of learning it from drifting.
+
+``--cross-cloud-configured``
+    Passed whenever the configured-clouds resolution SUCCEEDED
+    (``CONFIGURED_KNOWN``), including when it resolved to *no* clouds — that is
+    the "repo has no tenant matrix" state, which is a fact, not an absence.
+    Omitted when the resolution failed or e2e is disabled for the repo, where
+    nothing is known.
+
+``--cross-cloud-observed``
+    Passed only when e2e ran, on the same rule as ``--e2e-junit``.  Observed
+    coverage is inherently sparse (the scorecard runs on push/merge_group; e2e
+    runs on label/dispatch), which is precisely why ``configured`` is the field
+    that carries rollout visibility.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+#: Job results that mean "this job did not produce evidence". A GitHub `needs.
+#: <job>.result` is one of success/failure/cancelled/skipped, and is "" when the
+#: job is not in `needs` at all.
+_DID_NOT_RUN = frozenset({"", "skipped"})
+
+
+def e2e_ran(e2e_result: str) -> bool:
+    """Whether the e2e job produced evidence worth reading.
+
+    ``failure`` counts: a red e2e run is evidence, and suppressing it would let
+    an app's scorecard improve by having its e2e break.  ``cancelled`` also
+    counts — a cancelled matrix can still have uploaded finished legs, and the
+    CLI's glob no-ops when it did not.
+    """
+    return e2e_result.strip().lower() not in _DID_NOT_RUN
+
+
+def build_args(
+    *,
+    repo: str,
+    commit: str,
+    out: str,
+    unit_junit: str,
+    unit_coverage: str,
+    integration_junit: str,
+    integration_coverage: str,
+    e2e_junit_glob: str,
+    e2e_result: str,
+    configured_clouds: str,
+    configured_known: bool,
+    observed_clouds: str,
+) -> list[str]:
+    args = [
+        "--unit-junit",
+        unit_junit,
+        "--unit-coverage",
+        unit_coverage,
+        # Always passed: a missing integration junit scores an empty tier, so an
+        # app with no integration suite still counts it against the grade.
+        "--integration-junit",
+        integration_junit,
+        "--integration-coverage",
+        integration_coverage,
+    ]
+
+    ran = e2e_ran(e2e_result)
+    if ran and e2e_junit_glob:
+        args += ["--e2e-junit", e2e_junit_glob]
+    # Both cross-CSP values may legitimately be EMPTY — "" is the degraded
+    # single-tenant state, which is a fact rather than an absence — so they are
+    # emitted as empty lines and the caller's `mapfile` must keep them.
+    if configured_known:
+        args += ["--cross-cloud-configured", configured_clouds]
+    if ran:
+        args += ["--cross-cloud-observed", observed_clouds]
+
+    # Deliberately LAST, and deliberately a value that is never empty: the caller
+    # reads this with `mapfile`, and a trailing empty line is exactly the element
+    # a `raw=$(...)` capture (command substitution strips trailing newlines)
+    # would silently drop — turning `--cross-cloud-observed ""` into a dangling
+    # flag and an argparse error. Ending on a non-empty argument means the
+    # encoding does not depend on that subtlety at all.
+    return args + ["--repo", repo, "--commit", commit, "--out", out]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.parse_args(argv)
+
+    env = os.environ.get
+    args = build_args(
+        repo=env("REPO", ""),
+        commit=env("SHA", ""),
+        out=env("OUT", "results/test-readiness.json"),
+        unit_junit=env("UNIT_JUNIT", ""),
+        unit_coverage=env("UNIT_COVERAGE", ""),
+        integration_junit=env("INTEGRATION_JUNIT", ""),
+        integration_coverage=env("INTEGRATION_COVERAGE", ""),
+        e2e_junit_glob=env("E2E_JUNIT_GLOB", ""),
+        e2e_result=env("E2E_RESULT", ""),
+        configured_clouds=env("CONFIGURED_CLOUDS", ""),
+        configured_known=env("CONFIGURED_KNOWN", "").lower() == "true",
+        observed_clouds=env("OBSERVED_CLOUDS", ""),
+    )
+    # stdout IS this script's output mechanism — the workflow reads it with
+    # `mapfile`, not a logger — so the ruff T201 exemption matches
+    # build_conformance_args.py, which is consumed the same way.
+    print("\n".join(args))  # noqa: T201
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/tests/test_build_scorecard_args.py
+++ b/.github/scripts/tests/test_build_scorecard_args.py
@@ -1,0 +1,209 @@
+"""Tests for the scorecard argument builder (FND-33 / FND-34).
+
+The three conditional arguments each encode a decision that is easy to reverse
+by accident and impossible to notice afterwards — a scorecard that scored an
+absent tier as zero, or recorded cross-CSP coverage it never observed, looks
+exactly like a correct one.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parents[1] / "build_scorecard_args.py"
+
+_spec = importlib.util.spec_from_file_location("build_scorecard_args", _SCRIPT)
+assert _spec and _spec.loader
+build_scorecard_args = importlib.util.module_from_spec(_spec)
+sys.modules["build_scorecard_args"] = build_scorecard_args
+_spec.loader.exec_module(build_scorecard_args)
+
+build_args = build_scorecard_args.build_args
+e2e_ran = build_scorecard_args.e2e_ran
+
+_BASE = {
+    "repo": "atlanhq/atlan-openapi-app",
+    "commit": "deadbeef",
+    "out": "results/test-readiness.json",
+    "unit_junit": "unit-evidence/results/test-results.xml",
+    "unit_coverage": "unit-evidence/coverage.json",
+    "integration_junit": "integration-evidence/results/test-results.xml",
+    "integration_coverage": "integration-evidence/coverage.json",
+    "e2e_junit_glob": "e2e-evidence/*/results/sdr-test-results.xml",
+    "e2e_result": "skipped",
+    "configured_clouds": "",
+    "configured_known": False,
+    "observed_clouds": "",
+}
+
+
+def _args(**overrides: object) -> list[str]:
+    return build_args(**{**_BASE, **overrides})  # type: ignore[arg-type]
+
+
+def _value_after(args: list[str], flag: str) -> str | None:
+    return args[args.index(flag) + 1] if flag in args else None
+
+
+# ── The always-on tiers ──────────────────────────────────────────────────────
+
+
+def test_unit_and_integration_are_always_passed() -> None:
+    # A missing integration junit scores an empty tier ON PURPOSE: an app with no
+    # integration suite must still have that count against its grade.
+    args = _args()
+    assert _value_after(args, "--unit-junit") == _BASE["unit_junit"]
+    assert _value_after(args, "--integration-junit") == _BASE["integration_junit"]
+    assert _value_after(args, "--repo") == _BASE["repo"]
+    assert _value_after(args, "--commit") == "deadbeef"
+    assert _value_after(args, "--out") == _BASE["out"]
+
+
+# ── e2e evidence: absent must never read as zero ─────────────────────────────
+
+
+@pytest.mark.parametrize("result", ["skipped", "", "  ", "SKIPPED"])
+def test_a_skipped_e2e_passes_no_evidence_flags(result: str) -> None:
+    """The routine push. Omitting the flag leaves the tier not-applicable.
+
+    Passing an empty glob instead would still work — the CLI treats "matched
+    nothing" as not-applicable — but "the job was skipped" is knowable here, and
+    two ways of learning the same fact are two ways to drift.
+    """
+    args = _args(e2e_result=result)
+    assert "--e2e-junit" not in args
+    assert "--cross-cloud-observed" not in args
+
+
+@pytest.mark.parametrize("result", ["success", "failure", "cancelled"])
+def test_a_failed_e2e_still_contributes_evidence(result: str) -> None:
+    """A red e2e run is evidence.
+
+    Suppressing it would let an app's scorecard IMPROVE by having its e2e break
+    — the tier would go not-applicable and its weight renormalize away.
+    """
+    args = _args(e2e_result=result)
+    assert _value_after(args, "--e2e-junit") == _BASE["e2e_junit_glob"]
+    assert e2e_ran(result) is True
+
+
+def test_no_glob_configured_passes_no_e2e_junit() -> None:
+    assert "--e2e-junit" not in _args(e2e_result="success", e2e_junit_glob="")
+
+
+# ── cross-CSP: configured is the rollout signal, observed the verification one ─
+
+
+def test_configured_lands_even_when_e2e_did_not_run() -> None:
+    """The whole point of `configured`: it needs no e2e run.
+
+    It is the only field that reaches central visibility on the routine
+    push/merge_group path, where e2e is skipped.
+    """
+    args = _args(configured_known=True, configured_clouds="aws,azure,gcp")
+    assert _value_after(args, "--cross-cloud-configured") == "aws,azure,gcp"
+    assert "--cross-cloud-observed" not in args
+
+
+def test_configured_empty_is_recorded_not_omitted() -> None:
+    """ "Repo has no tenant matrix" is a fact — the degraded state, not unknown.
+
+    Collapsing it into "unknown" makes a repo nobody onboarded indistinguishable
+    from one that is fully covered, which is the gap FND-34 exists to close.
+    """
+    args = _args(configured_known=True, configured_clouds="")
+    assert "--cross-cloud-configured" in args
+    assert _value_after(args, "--cross-cloud-configured") == ""
+
+
+def test_configured_is_omitted_when_resolution_failed() -> None:
+    """Resolution failed (or e2e is disabled for the repo) → say nothing."""
+    assert "--cross-cloud-configured" not in _args(configured_known=False)
+
+
+def test_observed_rides_only_on_runs_where_e2e_ran() -> None:
+    args = _args(e2e_result="success", observed_clouds="aws,azure")
+    assert _value_after(args, "--cross-cloud-observed") == "aws,azure"
+
+
+def test_observed_empty_records_the_single_tenant_fallback() -> None:
+    """e2e ran with no cloud dimension — degraded, and distinct from "did not run".
+
+    The flag is still passed, so the CLI records `observed: []`. Dropping the
+    flag here would make a degraded run indistinguishable from a run where e2e
+    never happened.
+    """
+    args = _args(e2e_result="success", observed_clouds="")
+    assert "--cross-cloud-observed" in args
+    assert _value_after(args, "--cross-cloud-observed") == ""
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {},
+        {"configured_known": True, "configured_clouds": ""},
+        {"e2e_result": "success", "observed_clouds": ""},
+        {
+            "e2e_result": "success",
+            "observed_clouds": "",
+            "configured_known": True,
+            "configured_clouds": "",
+        },
+    ],
+)
+def test_the_last_argument_is_never_empty(overrides: dict[str, object]) -> None:
+    """The caller reads this with `mapfile`, and a trailing empty line is fragile.
+
+    Either cross-CSP value may legitimately be "", and a `raw=$(...)` capture
+    strips trailing newlines — which would drop that element and leave
+    `--cross-cloud-observed` dangling, so argparse would eat the NEXT flag as
+    its value. Ending on a non-empty argument removes the dependency entirely.
+    """
+    assert _args(**overrides)[-1] != ""
+
+
+# ── The env-driven entrypoint ────────────────────────────────────────────────
+
+
+def test_main_reads_the_environment_and_prints_one_arg_per_line(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    for key, value in {
+        "REPO": "atlanhq/atlan-openapi-app",
+        "SHA": "cafe",
+        "UNIT_JUNIT": "u.xml",
+        "UNIT_COVERAGE": "u.json",
+        "INTEGRATION_JUNIT": "i.xml",
+        "INTEGRATION_COVERAGE": "i.json",
+        "E2E_JUNIT_GLOB": "e2e-evidence/*/results/sdr-test-results.xml",
+        "E2E_RESULT": "success",
+        "CONFIGURED_CLOUDS": "aws,gcp",
+        "CONFIGURED_KNOWN": "true",
+        "OBSERVED_CLOUDS": "aws",
+    }.items():
+        monkeypatch.setenv(key, value)
+
+    assert build_scorecard_args.main([]) == 0
+    lines = capsys.readouterr().out.splitlines()
+    assert _value_after(lines, "--cross-cloud-configured") == "aws,gcp"
+    assert _value_after(lines, "--cross-cloud-observed") == "aws"
+    assert _value_after(lines, "--e2e-junit").endswith("sdr-test-results.xml")
+    # Default when OUT is unset, so a caller that forgets it still writes where
+    # the upload step looks.
+    assert _value_after(lines, "--out") == "results/test-readiness.json"
+
+
+def test_main_treats_a_non_true_known_flag_as_unknown(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # `steps.<id>.outcome == 'success'` renders "false" when the step was
+    # skipped or failed; anything that is not exactly "true" must not record.
+    monkeypatch.setenv("CONFIGURED_KNOWN", "false")
+    monkeypatch.setenv("E2E_RESULT", "skipped")
+    assert build_scorecard_args.main([]) == 0
+    assert "--cross-cloud-configured" not in capsys.readouterr().out

--- a/.github/scripts/tests/test_discover_e2e_suites.py
+++ b/.github/scripts/tests/test_discover_e2e_suites.py
@@ -205,6 +205,50 @@ def test_main_count_is_suites_and_leg_count_is_legs(capsys, tmp_path: Path) -> N
     assert len(_matrix(out)["include"]) == 6
 
 
+def test_main_emits_the_resolved_cloud_list(capsys, tmp_path: Path) -> None:
+    """The `clouds` output is what the scorecard records as observed coverage.
+
+    It comes from the same `parse_clouds` call that built the matrix, so
+    "what we recorded as covered" cannot disagree with "what ran" (FND-34).
+    """
+    e2e = tmp_path / "tests" / "e2e"
+    _mk(e2e, "test_one.py")
+    main(["--test-dir", str(e2e), "--clouds", "aws,azure,gcp"])
+    assert "clouds=aws,azure,gcp" in capsys.readouterr().out.splitlines()
+
+
+def test_main_clouds_output_is_narrowed_like_the_matrix(capsys, tmp_path: Path) -> None:
+    # Recording the REQUESTED list rather than the resolved one would report
+    # coverage the run did not have — worse than reporting none.
+    e2e = tmp_path / "tests" / "e2e"
+    _mk(e2e, "test_one.py")
+    main(["--test-dir", str(e2e), "--clouds", "", "--available-clouds", "aws,gcp"])
+    assert "clouds=aws,gcp" in capsys.readouterr().out.splitlines()
+
+
+def test_main_clouds_output_is_empty_without_a_cloud_dimension(
+    capsys, tmp_path: Path
+) -> None:
+    """The degraded single-tenant fallback records as "", not as absent.
+
+    A consumer must be able to tell "ran against one legacy tenant" from "e2e
+    never ran"; the latter is signalled by the field being omitted upstream.
+    """
+    e2e = tmp_path / "tests" / "e2e"
+    _mk(e2e, "test_one.py")
+    main(["--test-dir", str(e2e), "--clouds", "none"])
+    assert "clouds=" in capsys.readouterr().out.splitlines()
+
+
+def test_clouds_only_also_emits_the_resolved_cloud_list(capsys, tmp_path: Path) -> None:
+    # The scorecard job resolves `configured` through this mode, so the output
+    # has to exist on both paths or the rollout signal is missing exactly where
+    # it is read.
+    rc = main(["--clouds", "aws,azure", "--clouds-only"])
+    assert rc == 0
+    assert "clouds=aws,azure" in capsys.readouterr().out.splitlines()
+
+
 def test_main_logs_the_fan_out_explicitly(capsys, tmp_path: Path) -> None:
     e2e = tmp_path / "tests" / "e2e"
     _mk(e2e, "test_one.py")

--- a/.github/scripts/tests/test_prepare_tenant_wiring.py
+++ b/.github/scripts/tests/test_prepare_tenant_wiring.py
@@ -557,17 +557,25 @@ def test_the_gate_is_told_about_the_lease() -> None:
 # ── The two cloud fan-outs must agree ────────────────────────────────────────
 
 
-def test_suite_and_cloud_discovery_use_the_same_clouds_expression() -> None:
+def test_suite_and_cloud_discovery_use_the_same_clouds_expression(jobs: dict) -> None:  # type: ignore[type-arg]
     """A prepare-tenant that missed a cloud the legs then ran against is a
     silent coverage hole, not a visible failure — so the two `clouds:` inputs
-    are asserted identical rather than merely both present."""
-    text = _WORKFLOW.read_text(encoding="utf-8")
+    are asserted identical rather than merely both present.
+
+    Keyed on the discovery action's `with.clouds` rather than on every line
+    reading `clouds:`, which also matched the job OUTPUT of the same name added
+    for the scorecard's cross-CSP record (FND-34) — an unrelated key that has no
+    fan-out to agree with.
+    """
     exprs = [
-        line.split("clouds:", 1)[1].strip()
-        for line in text.splitlines()
-        if line.strip().startswith("clouds:")
+        step["with"]["clouds"]
+        for step in jobs["discover-e2e"]["steps"]
+        if "discover-e2e-suites@" in str(step.get("uses", ""))
     ]
-    assert len(exprs) == 2, f"expected exactly two `clouds:` inputs, found {len(exprs)}"
+    assert len(exprs) == 2, (
+        f"expected exactly two discovery invocations, found {len(exprs)} — the "
+        "suite fan-out and the cloud-only fan-out prepare-tenant installs from"
+    )
     assert exprs[0] == exprs[1], (
         "the suite fan-out and the cloud fan-out resolve different cloud lists; "
         f"{exprs[0]!r} vs {exprs[1]!r}"

--- a/.github/scripts/tests/test_scorecard_e2e_wiring.py
+++ b/.github/scripts/tests/test_scorecard_e2e_wiring.py
@@ -1,0 +1,267 @@
+"""Guards for the FND-33 / FND-34 scorecard wiring in tests-reusable.yaml.
+
+What is being protected is that **absence stays absence**. Every failure mode
+here is silent: a scorecard that scored a tier nobody ran, or recorded cross-CSP
+coverage nobody exercised, is a well-formed document that publishes cleanly and
+tells the fleet dashboard something untrue. Nothing goes red.
+
+Deliberately YAML-shape assertions: the wiring is GitHub Actions' own (job
+`needs`, skipped-job semantics, artifact download modes) and cannot be exercised
+without a runner. The scoring logic is unit-tested in the conformance package's
+test_scorecard_* modules, and the argument-selection logic in
+test_build_scorecard_args.py.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_WORKFLOW = _REPO_ROOT / ".github/workflows/tests-reusable.yaml"
+
+_DOWNLOAD = "actions/download-artifact@"
+_ARGS_SCRIPT = "build_scorecard_args.py"
+
+
+@pytest.fixture(scope="module")
+def jobs() -> dict[str, Any]:
+    return yaml.safe_load(_WORKFLOW.read_text(encoding="utf-8"))["jobs"]
+
+
+@pytest.fixture(scope="module")
+def scorecard(jobs: dict[str, Any]) -> dict[str, Any]:
+    return jobs["scorecard"]
+
+
+def _steps_using(job: dict[str, Any], prefix: str) -> list[dict[str, Any]]:
+    return [s for s in job["steps"] if str(s.get("uses", "")).startswith(prefix)]
+
+
+# ── The evidence has to be reachable at all ──────────────────────────────────
+
+
+def test_the_scorecard_needs_the_e2e_jobs(scorecard: dict[str, Any]) -> None:
+    # Without these in `needs`, `needs.e2e.result` and the discovered cloud list
+    # are simply absent, and the e2e tier is not-applicable on EVERY run of
+    # EVERY app — which is the state FND-33 exists to end.
+    assert {"discover-e2e", "e2e"} <= set(scorecard["needs"])
+
+
+def test_a_skipped_e2e_does_not_skip_the_scorecard(scorecard: dict[str, Any]) -> None:
+    """`needs` is gated separately from `if:`, and a skipped need fails it.
+
+    e2e is skipped on the routine push — the overwhelmingly common case — so
+    losing `always()` here would stop emitting scorecards fleet-wide rather
+    than emit one without e2e.
+    """
+    assert scorecard["if"].startswith("always()")
+
+
+def test_the_scorecard_still_never_runs_on_pull_request(
+    scorecard: dict[str, Any],
+) -> None:
+    # On a PR the integration job is skipped, so a scorecard would publish a
+    # zeroed integration tier: a fabricated regression. This is also why letting
+    # the scorecard ride the `e2e`-labelled PR path was rejected as the answer to
+    # the trigger-overlap question.
+    assert "github.event_name != 'pull_request'" in scorecard["if"]
+
+
+# ── Per-leg junits must not be merged into one ───────────────────────────────
+
+
+def _e2e_download(job: dict[str, Any]) -> dict[str, Any]:
+    matching = [
+        s
+        for s in _steps_using(job, _DOWNLOAD)
+        if "sdr-integration-tests" in str(s.get("with", {}).get("pattern", ""))
+    ]
+    assert len(matching) == 1, "expected exactly one e2e evidence download"
+    return matching[0]
+
+
+def test_e2e_evidence_is_downloaded_by_pattern_not_exact_name(
+    scorecard: dict[str, Any],
+) -> None:
+    # Since FND-6 each leg's artifact is suffixed with the leg name (which now
+    # includes the cloud), so the historical exact name matches nothing and the
+    # download quietly no-ops under continue-on-error.
+    with_ = _e2e_download(scorecard)["with"]
+    assert with_["pattern"].endswith("*-results")
+    assert "name" not in with_
+
+
+def test_e2e_legs_are_kept_apart_on_disk(scorecard: dict[str, Any]) -> None:
+    """merge-multiple would have the legs overwrite each other.
+
+    Every leg carries its junit at the SAME inner path
+    (`results/sdr-test-results.xml`), so flattening leaves ONE file and the
+    scorecard scores a single arbitrary leg as if it were the whole run.
+    """
+    assert _e2e_download(scorecard)["with"].get("merge-multiple") is not True
+
+
+def test_the_e2e_download_is_best_effort(scorecard: dict[str, Any]) -> None:
+    # No artifacts (e2e did not run) must leave the tier not-applicable, not
+    # fail a reporting job.
+    assert _e2e_download(scorecard)["continue-on-error"] is True
+
+
+def test_the_callback_download_matches_the_per_leg_names_too(
+    jobs: dict[str, Any],
+) -> None:
+    # report-to-sdk renders the SDK-side check body from this artifact; it hit
+    # the same FND-6 rename and fell back to a plain body on every cross-CSP run.
+    # merge-multiple is correct there and wrong above: that job wants exactly one
+    # rendered pr-comment-body.md, this one wants every junit kept apart.
+    download = [
+        s
+        for s in _steps_using(jobs["report-to-sdk"], _DOWNLOAD)
+        if "sdr-integration-tests" in str(s.get("with", {}))
+    ]
+    assert len(download) == 1
+    assert download[0]["with"]["pattern"].endswith("*-results")
+
+
+# ── Argument selection stays in the tested script ────────────────────────────
+
+
+def _generate_step(job: dict[str, Any]) -> dict[str, Any]:
+    matching = [s for s in job["steps"] if _ARGS_SCRIPT in str(s.get("run", ""))]
+    assert len(matching) == 1, (
+        "the scorecard CLI's conditional arguments must come from the tested "
+        f"{_ARGS_SCRIPT}, not from inlined shell — branching in YAML cannot be "
+        "regression-tested (docs/standards/ci.md)"
+    )
+    return matching[0]
+
+
+def test_the_generate_step_passes_the_job_results_the_script_needs(
+    scorecard: dict[str, Any],
+) -> None:
+    env = _generate_step(scorecard)["env"]
+    assert env["E2E_RESULT"] == "${{ needs.e2e.result }}"
+    assert env["OBSERVED_CLOUDS"] == "${{ needs.discover-e2e.outputs.clouds }}"
+    assert env["CONFIGURED_KNOWN"] == (
+        "${{ steps.configured-clouds.outcome == 'success' }}"
+    )
+    assert env["CONFIGURED_CLOUDS"] == "${{ steps.configured-clouds.outputs.clouds }}"
+
+
+def test_the_e2e_glob_is_not_expanded_by_the_shell(scorecard: dict[str, Any]) -> None:
+    # The CLI expands it. Expanding it in the shell would need a loop this file
+    # is not allowed to contain, and a bash glob that matches nothing expands to
+    # the literal pattern — which the CLI would then read as a missing file.
+    step = _generate_step(scorecard)
+    assert "*" in step["env"]["E2E_JUNIT_GLOB"]
+    assert step["env"]["E2E_JUNIT_GLOB"] not in step["run"]
+
+
+def test_the_scorecard_never_fails_the_run(scorecard: dict[str, Any]) -> None:
+    # Reporting, not a gate: an older published conformance that does not yet
+    # understand the new flags must warn, never redden a merge-queue entry.
+    assert "::warning::" in _generate_step(scorecard)["run"]
+
+
+# ── `configured` is the field that must land on EVERY emission ───────────────
+
+
+def _configured_step(job: dict[str, Any]) -> dict[str, Any]:
+    matching = [s for s in job["steps"] if s.get("id") == "configured-clouds"]
+    assert len(matching) == 1
+    return matching[0]
+
+
+def test_configured_is_resolved_without_needing_an_e2e_run(
+    scorecard: dict[str, Any],
+) -> None:
+    """The rollout signal only works if it does not depend on e2e running.
+
+    The scorecard runs on push/merge_group and e2e on label/dispatch, so a
+    `configured` gated on the e2e job would be exactly as sparse as `observed`
+    and FND-34 would deliver nothing on the routine path.
+    """
+    step = _configured_step(scorecard)
+    assert "needs.e2e" not in str(step.get("if", ""))
+    assert "needs.discover-e2e" not in str(step.get("if", ""))
+
+
+def test_configured_uses_the_same_driver_and_narrowing_as_discovery(
+    scorecard: dict[str, Any], jobs: dict[str, Any]
+) -> None:
+    # Re-deriving the list independently would let the recorded rollout state
+    # drift from the fan-out that actually happens.
+    step = _configured_step(scorecard)
+    assert "discover_e2e_suites.py" in step["run"]
+    assert "--clouds-only" in step["run"]
+    assert (
+        step["env"]["AVAILABLE_CLOUDS"] == "${{ steps.matrix-clouds.outputs.clouds }}"
+    )
+
+    discovery_clouds = next(
+        s["with"]["clouds"]
+        for s in jobs["discover-e2e"]["steps"]
+        if s.get("id") == "discover"
+    )
+    assert step["env"]["CLOUDS"] == discovery_clouds, (
+        "the `clouds` expression must be identical to discovery's, or the "
+        "recorded configuration is not the configuration that would run"
+    )
+
+
+def test_resolving_configured_can_never_redden_the_job(
+    scorecard: dict[str, Any],
+) -> None:
+    # The driver exits non-zero when narrowing would leave no clouds at all; the
+    # step's `outcome` is then the "not known" signal, not a failure.
+    assert _configured_step(scorecard)["continue-on-error"] is True
+
+
+def test_the_tenant_matrix_blob_never_leaves_the_keys_step(
+    scorecard: dict[str, Any],
+) -> None:
+    # The KEY LIST crosses this boundary; the credentials do not. Same posture as
+    # discover-e2e, pinned by test_e2e_cloud_narrowing_wiring.py there.
+    keys_steps = [s for s in scorecard["steps"] if s.get("id") == "matrix-clouds"]
+    assert len(keys_steps) == 1
+    assert keys_steps[0]["env"]["E2E_TENANT_MATRIX_JSON"] == (
+        "${{ secrets.E2E_TENANT_MATRIX_JSON }}"
+    )
+    for step in scorecard["steps"]:
+        if step.get("id") == "matrix-clouds":
+            continue
+        assert "secrets.E2E_TENANT_MATRIX_JSON }}" not in str(step.get("env", {})), (
+            f"`{step.get('name', step.get('id'))}` interpolates the tenant "
+            "matrix's VALUE; only its cloud key list may leave that step"
+        )
+
+
+def test_the_sdk_scripts_checkout_is_pinned_to_this_workflows_sha(
+    scorecard: dict[str, Any],
+) -> None:
+    # Both executed payloads (the arg builder and the discovery driver) come from
+    # the workflow's own SHA, so a PR that changes them self-tests on its branch
+    # rather than waiting for main.
+    checkouts = [
+        s
+        for s in _steps_using(scorecard, "actions/checkout@")
+        if s.get("with", {}).get("repository") == "atlanhq/application-sdk"
+    ]
+    assert len(checkouts) == 1
+    with_ = checkouts[0]["with"]
+    assert with_["ref"] == "${{ job.workflow_sha }}"
+    assert with_["persist-credentials"] is False
+    sparse = with_["sparse-checkout"]
+    assert ".github/scripts" in sparse
+    assert ".github/actions/discover-e2e-suites" in sparse
+
+
+def test_discover_e2e_exposes_the_resolved_cloud_list(jobs: dict[str, Any]) -> None:
+    assert (
+        jobs["discover-e2e"]["outputs"]["clouds"]
+        == "${{ steps.discover.outputs.clouds }}"
+    ), "the observed cloud list must come from the matrix-building call itself"

--- a/.github/workflows/tests-reusable.yaml
+++ b/.github/workflows/tests-reusable.yaml
@@ -902,6 +902,14 @@ jobs:
       # e2e-full-reusable.yaml's plan-clouds has always guarded on the count for
       # exactly this reason.
       cloud-count: ${{ steps.discover-clouds.outputs.count }}
+      # The resolved cloud list as a flat string, for the scorecard's descriptive
+      # `observed` field (FND-34). Taken from the SAME action call that emitted
+      # the matrix, so "what we recorded as covered" and "what actually ran"
+      # cannot disagree — the failure mode that makes a coverage metric worse
+      # than no metric. Empty means no cloud dimension: the legs ran against the
+      # single legacy tenant. The scorecard records that as `observed: []`, which
+      # is distinct from omitting the field when e2e never ran at all.
+      clouds: ${{ steps.discover.outputs.clouds }}
     env:
       # Job-level so the step-level `if:` below can read it — a step condition
       # cannot reference the `secrets` context directly.
@@ -2112,12 +2120,25 @@ jobs:
           SDK_REF: ${{ inputs.application-sdk-ref }}
         run: echo "::warning::Dispatching application-sdk ref ${SDK_REF} predates the callback scripts; used main's copy instead. Merge main into that SDK branch to silence this."
 
+      # `pattern` + merge-multiple, not the bare `name`. Since FND-6 the e2e
+      # matrix suffixes each leg's artifact with the leg name, so the exact
+      # un-suffixed name matched nothing and this download quietly no-opped
+      # under continue-on-error — build_callback_summary.py then fell back to
+      # its plain body on every cross-CSP run.
+      #
+      # merge-multiple is right HERE and wrong in the scorecard job, for the
+      # same reason in both places: it flattens every leg into one directory, so
+      # same-named files overwrite. What this step wants is exactly one rendered
+      # pr-comment-body.md; what the scorecard wants is every leg's junit kept
+      # apart. The body is one arbitrary leg's, which is why the authoritative
+      # verdict is the gate line appended below rather than anything in it.
       - name: Download connector e2e results
         if: needs.e2e.result != 'skipped'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         continue-on-error: true
         with:
-          name: sdr-integration-tests-${{ inputs.app-name }}-results
+          pattern: sdr-integration-tests-${{ inputs.app-name }}*-results
+          merge-multiple: true
           path: connector-results
 
       # THE verdict. Same action, same inputs as the Tests Gate job below, so
@@ -2200,28 +2221,88 @@ jobs:
             --details-url "$RUN_URL"
 
   # ── Test-readiness scorecard (per-tier aggregation) ──────────────────────
-  # Combines the unit + integration jobs' evidence (junit + coverage.json) into
-  # one quantified scorecard artifact. Non-PR only (push / merge_group), where
-  # both tiers actually ran — on a PR integration is skipped, so a scorecard
-  # would misreport it. Best-effort and NOT part of the Tests Gate: a failure
-  # here (or an older published conformance predating the per-tier CLI) only
-  # warns. e2e is intentionally not fed — it runs label/dispatch-gated via a
-  # non-junit SDR artifact, so the scorecard marks the e2e tier not-applicable
-  # (no grade cap) rather than dragging every run to a capped B.
+  # Combines the unit + integration + e2e jobs' evidence (junit + coverage.json)
+  # into one quantified scorecard artifact. Non-PR only (push / merge_group),
+  # where unit and integration actually ran — on a PR integration is skipped, so
+  # a scorecard would misreport it. Best-effort and NOT part of the Tests Gate: a
+  # failure here (or an older published conformance predating the per-tier CLI)
+  # only warns.
+  #
+  # ── Why e2e evidence is sparse, and why that is the design (FND-33) ──────
+  # This job runs on push/merge_group; discover-e2e/e2e run on
+  # `workflow_dispatch + run_e2e=true` or an `e2e`-labelled PR. The two barely
+  # intersect: only a dispatched run on the default branch carries both. Three
+  # ways out were considered and this is the one that survives contact with how
+  # the artifact is consumed:
+  #
+  #   * Also run on the e2e-labelled PR path — DEAD. update-dashboard.yaml picks
+  #     the newest DEFAULT-BRANCH Tests run carrying a live scorecard artifact,
+  #     so a PR-run scorecard is never ingested. Worse, on a PR the integration
+  #     job is skipped, so such a scorecard would publish a zeroed integration
+  #     tier: a fabricated regression, which is exactly what this job's `if:`
+  #     already exists to prevent.
+  #   * A separate durable e2e record connector-pulse reads independently —
+  #     a larger build, and premature: nothing yet needs e2e evidence at a
+  #     cadence the scorecard cannot supply.
+  #   * Accept sparsity, and make ABSENCE HONEST — this. When e2e did not run,
+  #     the tier stays `applicable: false` and the `e2e-present` gate stays
+  #     `na`: excluded from the aggregate, no grade cap, not scored zero.
+  #
+  # The consequence to hold onto: a routine push emits a scorecard that says
+  # "e2e not measured", never "e2e failing". connector-pulse must render the
+  # e2e tier's absence as unknown, not as a zero.
+  #
+  # The cross-CSP fields are what carry rollout visibility between those sparse
+  # runs (FND-34): `configured` is derivable from the tenant-matrix secret alone
+  # and so lands on EVERY emission, while `observed` rides along only when e2e
+  # ran. Both are descriptive — no Check reads them and no Gate caps on them, so
+  # recording them cannot move any app's grade.
   scorecard:
     name: Test-readiness scorecard
-    needs: [unit, detect-integration, integration]
+    # discover-e2e and e2e join `needs` so their evidence and their resolved
+    # cloud list are reachable. `always()` is already in the `if:` below, which
+    # is what keeps a SKIPPED e2e (the routine case) from skipping this job —
+    # a job's `needs` gate is evaluated separately from its `if:`, and without a
+    # status-check function GitHub applies an implicit success() that a skipped
+    # need does not satisfy.
+    needs: [unit, detect-integration, integration, discover-e2e, e2e]
     if: always() && github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
       contents: read
+    env:
+      # Job-level so the step-level `if:` below can read it — a step condition
+      # cannot reference the `secrets` context directly. Same shape as
+      # discover-e2e, deliberately: both answer "is this repo wired for the
+      # cross-CSP matrix", and two different answers would be a bug.
+      HAS_TENANT_MATRIX: ${{ secrets.E2E_TENANT_MATRIX_JSON != '' && 'true' || '' }}
     steps:
       - name: Install uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           version: "0.12.5"
           enable-cache: true
+
+      # The SDK's arg builder and the discovery driver. `ref: job.workflow_sha`
+      # rather than @main for the reason discover-e2e gives at length: a script
+      # pulled at the workflow's own SHA is testable on the branch that changes
+      # it, whereas an action pinned @main cannot see a change until it lands.
+      # `repository:` stays hardcoded so the executed payload's provenance is
+      # pinned; application-sdk is public, so the caller's default token reads it
+      # when ORG_PAT_GITHUB is not shared.
+      - name: Fetch SDK CI scripts
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: atlanhq/application-sdk
+          ref: ${{ job.workflow_sha }}
+          sparse-checkout: |
+            .github/scripts
+            .github/actions/discover-e2e-suites
+          sparse-checkout-cone-mode: false
+          path: application-sdk-scripts
+          token: ${{ secrets.ORG_PAT_GITHUB || github.token }}
+          persist-credentials: false
 
       # Both downloads are best-effort: unit always uploads its artifact, but
       # integration is absent when it had no suite / was skipped — the CLI then
@@ -2240,26 +2321,106 @@ jobs:
           name: integration-test-results
           path: integration-evidence
 
+      # `pattern:` with merge-multiple LEFT OFF, and that is the whole point:
+      # the e2e matrix emits one artifact per suite × cloud leg (FND-6) and each
+      # carries a junit at the SAME inner path, so merging would have the legs
+      # overwrite each other and the scorecard would silently score one leg as
+      # if it were the run. Unmerged, each lands under its own artifact-named
+      # directory and the CLI's glob picks up all of them.
+      #
+      # The pattern also matches the legacy un-suffixed name, so a caller still
+      # emitting a single e2e artifact is covered by the same expression.
+      #
+      # Best-effort: no e2e run means no artifacts, `download-artifact` fails,
+      # and the glob below resolves to nothing — which the CLI reads as "e2e not
+      # applicable", never as "e2e scored zero".
+      - name: Download e2e evidence (one artifact per leg)
+        if: needs.e2e.result != 'skipped'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        continue-on-error: true
+        with:
+          pattern: sdr-integration-tests-${{ inputs.app-name }}*-results
+          path: e2e-evidence
+
+      # ── What this repo is WIRED for, whether or not e2e ran (FND-34) ───────
+      # The rollout signal. It needs no e2e run — only the tenant matrix's key
+      # list and the requested fan-out — so it lands on every scorecard emission,
+      # which is what makes an un-onboarded repo distinguishable from a covered
+      # one at the point of central visibility. The `::warning::` in
+      # discover-e2e is the only other signal, and it is per-run, ephemeral, and
+      # buried in one app repo's Actions log.
+      - name: Read the tenant matrix's cloud keys
+        id: matrix-clouds
+        if: inputs.enable-e2e && env.HAS_TENANT_MATRIX != ''
+        env:
+          E2E_TENANT_MATRIX_JSON: ${{ secrets.E2E_TENANT_MATRIX_JSON }}
+        run: |
+          set -euo pipefail
+          python3 application-sdk-scripts/.github/scripts/e2e_tenant_matrix_clouds.py \
+            --matrix-json "$E2E_TENANT_MATRIX_JSON" >> "$GITHUB_OUTPUT"
+
+      # The same driver, the same `clouds` expression and the same narrowing as
+      # discover-e2e — so `configured` is the list discovery WOULD resolve, not
+      # an independent re-derivation that could drift from it. Duplicated
+      # verbatim for the reason the second discover call in discover-e2e gives:
+      # a hand-rolled equivalent is new untested logic doing what the driver
+      # already does.
+      #
+      # continue-on-error because this must never redden a reporting job:
+      # `--clouds-only` exits non-zero when narrowing would leave no clouds at
+      # all, and the step's `outcome` is then the "not known" signal that omits
+      # the field entirely.
+      - name: Resolve the clouds this repo is configured for
+        id: configured-clouds
+        if: inputs.enable-e2e
+        continue-on-error: true
+        env:
+          CLOUDS: ${{ secrets.E2E_TENANT_MATRIX_JSON == '' && 'none' || inputs.e2e-clouds }}
+          AVAILABLE_CLOUDS: ${{ steps.matrix-clouds.outputs.clouds }}
+        run: |
+          set -euo pipefail
+          python3 application-sdk-scripts/.github/actions/discover-e2e-suites/discover_e2e_suites.py \
+            --clouds-only \
+            --clouds "$CLOUDS" \
+            --available-clouds "$AVAILABLE_CLOUDS" >> "$GITHUB_OUTPUT"
+
       - name: Generate test-readiness scorecard
         shell: bash
         env:
           REPO: ${{ github.repository }}
           SHA: ${{ github.sha }}
+          OUT: results/test-readiness.json
+          UNIT_JUNIT: unit-evidence/results/test-results.xml
+          UNIT_COVERAGE: unit-evidence/coverage.json
+          INTEGRATION_JUNIT: integration-evidence/results/test-results.xml
+          INTEGRATION_COVERAGE: integration-evidence/coverage.json
+          # Quoted through to the CLI, which expands it: the legs' artifact
+          # directories are only known at download time, and expanding it in the
+          # shell would need a loop this file is not allowed to contain
+          # (docs/standards/ci.md).
+          E2E_JUNIT_GLOB: e2e-evidence/*/results/sdr-test-results.xml
+          E2E_RESULT: ${{ needs.e2e.result }}
+          CONFIGURED_CLOUDS: ${{ steps.configured-clouds.outputs.clouds }}
+          CONFIGURED_KNOWN: ${{ steps.configured-clouds.outcome == 'success' }}
+          OBSERVED_CLOUDS: ${{ needs.discover-e2e.outputs.clouds }}
         run: |
           [ -f unit-evidence/results/test-results.xml ] || { echo "no unit junit; skipping scorecard"; exit 0; }
           mkdir -p results
-          # Integration flags may point at missing files (no suite / skipped) —
-          # the CLI scores those as an empty integration tier. Trailing `|| echo`
-          # keeps this non-blocking: an older published conformance without the
-          # per-tier CLI must never redden the run (works once 0.17.0 publishes).
-          uvx atlan-application-sdk-conformance scorecard \
-            --unit-junit unit-evidence/results/test-results.xml \
-            --unit-coverage unit-evidence/coverage.json \
-            --integration-junit integration-evidence/results/test-results.xml \
-            --integration-coverage integration-evidence/coverage.json \
-            --repo "$REPO" \
-            --commit "$SHA" \
-            --out results/test-readiness.json \
+          # All conditional argument-building lives in the tested script, so this
+          # block stays straight-line (docs/standards/ci.md).
+          mapfile -t sc_args < <(python3 application-sdk-scripts/.github/scripts/build_scorecard_args.py)
+          # Trailing `|| echo` keeps this non-blocking: an older published
+          # conformance without the per-tier/e2e CLI must never redden the run.
+          #
+          # There IS a window. `uvx` resolves the newest PUBLISHED conformance,
+          # and --cross-cloud-configured / a repeatable --e2e-junit only exist
+          # from 0.21.0; until that publishes, argparse rejects them, this step
+          # warns, and no scorecard artifact is produced for that run. The
+          # dashboard already tolerates that — update-dashboard.yaml walks back
+          # through the last 20 completed runs for one that still carries a live
+          # scorecard — and the same gap was accepted when the per-tier flags
+          # landed ahead of 0.17.0. It closes on the next conformance release.
+          uvx atlan-application-sdk-conformance scorecard "${sc_args[@]}" \
             || echo "::warning::test-readiness scorecard generation failed (skipped)"
 
       # `upload-artifact` classifies the artifact service's finalize 403 as

--- a/docs/standards/connector-ci-e2e.md
+++ b/docs/standards/connector-ci-e2e.md
@@ -290,6 +290,61 @@ three clouds and got one must not look identical to one that got three. The same
 applies when the payload cannot be parsed: the key read degrades to "not known",
 narrowing is skipped, and the per-leg resolver still reports the real defect.
 
+### Reporting coverage to the test-readiness scorecard
+
+The `::warning::` above is per-run, ephemeral and buried in one app repo's
+Actions log, and nothing fails either way — so at any point of *central*
+visibility a repo running degraded looks identical to a fully covered one. The
+`scorecard` job closes that (FND-33, FND-34): it feeds the e2e tier's evidence
+and records cross-CSP coverage into `results/test-readiness.json`, which
+`update-dashboard.yaml` publishes and connector-pulse ingests as the
+`test_readiness` metric.
+
+**Two facts, kept apart.** `raw.crossCloud.configured` is what this repo is
+*wired* for — the requested fan-out narrowed exactly as discovery would narrow
+it, resolved from the tenant matrix's key list with no e2e run required.
+`raw.crossCloud.observed` is what a run actually *exercised*, from the
+`clouds` output of the same discovery call that built the matrix. Collapsing
+them would make "not rolled out" indistinguishable from "rolled out and
+broken", which is a state apps really are in.
+
+**Absent is not zero.** Three states have to stay distinguishable, and the wire
+format carries all three because `exclude_none=True` drops an unset field:
+
+| Wire | Meaning |
+|---|---|
+| `crossCloud` absent, or `observed` absent | e2e did not run — nothing is known |
+| `observed: []` | e2e ran with no cloud dimension: the degraded single-tenant fallback |
+| `observed: ["aws","azure"]` | e2e ran on those clouds |
+
+The same rule governs the tier itself: when e2e did not run the `e2e` tier stays
+`applicable: false` and the `e2e-present` gate stays `na` — excluded from the
+aggregate, no grade cap. Scoring absent evidence as zero would drag every app's
+grade on every routine push.
+
+**Neither field is scored.** No `Check` reads them and no `Gate` caps on them.
+Promoting cross-CSP to a scored dimension before the fleet is onboarded would
+move every app's aggregate down at once, so a rollout would read as a fleet-wide
+regression. Record first; score once a low value is actionable.
+
+**`observed` is sparse, and that is structural.** The `scorecard` job runs on
+push/merge_group; e2e runs on `workflow_dispatch + run_e2e=true` or an
+`e2e`-labelled PR. Only a dispatched run on the default branch carries both, so
+`observed` appears on those runs and not the rest. It cannot be fixed by also
+running the scorecard on the PR path: `update-dashboard.yaml` only ingests
+default-branch runs, and on a PR the integration job is skipped, so such a
+scorecard would publish a zeroed integration tier — a fabricated regression.
+This is precisely why `configured`, which needs no e2e run, is the field that
+carries rollout visibility.
+
+**Per-leg junits are merged worst-case per test.** Each leg uploads a junit at
+the same inner path, so the scorecard downloads them unmerged (`pattern:`
+without `merge-multiple`) and folds them on `(classname, name)`, taking the
+worst outcome across legs. Summing would make the denominator a function of how
+many clouds a repo has onboarded — a failure on one of three clouds would score
+better than the same failure on the only cloud, so onboarding a cloud would
+*raise* the score by diluting an existing failure.
+
 ### Requiring a tenant ID on the install path
 
 That degradation is honest for a repo that only *runs legs against* a tenant, and

--- a/packages/conformance/conformance/scorecard/cli.py
+++ b/packages/conformance/conformance/scorecard/cli.py
@@ -7,8 +7,14 @@ Post tier-split, unit and integration run as separate CI jobs, so evidence
 arrives per-tier: a dedicated aggregation job downloads both jobs' artifacts and
 invokes this with per-tier flags.  unit + integration are always scored (a
 missing junit → an empty, zero-scored tier, so a missing integration suite
-still counts against the grade); e2e is scored only when ``--e2e-junit`` is
-supplied — otherwise the e2e tier is marked not-applicable.
+still counts against the grade); e2e is scored only when ``--e2e-junit``
+resolves to at least one file — otherwise the e2e tier is marked not-applicable.
+
+``--e2e-junit`` is repeatable and each value may be a **glob**, because the e2e
+matrix emits one artifact per suite × cloud leg (FND-6).  Resolving the glob
+here rather than in the workflow keeps the "how many legs ran" branching out of
+YAML, and makes "matched nothing" mean *not applicable* rather than *scored
+zero* — absent evidence must never drag an app's grade (FND-33).
 
 This is the one impure edge: it touches the filesystem and stamps
 ``generatedAt``.  All scoring logic lives in the pure ``readers`` + ``compute``.
@@ -20,6 +26,9 @@ Usage::
         --unit-coverage unit/coverage.json \\
         --integration-junit integration/results/test-results.xml \\
         --integration-coverage integration/coverage.json \\
+        --e2e-junit 'e2e-evidence/*/results/sdr-test-results.xml' \\
+        --cross-cloud-configured aws,azure,gcp \\
+        --cross-cloud-observed aws,azure \\
         --repo "$GITHUB_REPOSITORY" --commit "$GITHUB_SHA" \\
         --out results/test-readiness.json
 """
@@ -32,10 +41,16 @@ import json
 from pathlib import Path
 
 from conformance.scorecard.compute import build_scorecard
-from conformance.scorecard.readers import parse_coverage_json, parse_junit_tier
+from conformance.scorecard.readers import (
+    parse_coverage_json,
+    parse_junit_tier,
+    parse_junit_tier_merged,
+    resolve_junit_paths,
+)
 from conformance.scorecard.rubric import load_rubric
 from conformance.scorecard.schema import (
     CoverageMetrics,
+    CrossCloudCoverage,
     RawTests,
     TierName,
     TierTestCounts,
@@ -71,6 +86,18 @@ def _coverage(path: str | None) -> CoverageMetrics | None:
     return None
 
 
+def _clouds(raw: str | None) -> list[str] | None:
+    """Split a comma-separated cloud list; ``None`` (flag absent) stays ``None``.
+
+    The distinction is the whole point of the field: ``None`` is omitted from
+    the artifact and means "not known", while ``""`` yields ``[]`` and means
+    "known, and it is no clouds" — the degraded single-tenant fallback.
+    """
+    if raw is None:
+        return None
+    return [c for c in (part.strip() for part in raw.split(",")) if c]
+
+
 def main(argv: list[str]) -> int:
     parser = argparse.ArgumentParser(
         prog="atlan-application-sdk-conformance scorecard",
@@ -82,9 +109,15 @@ def main(argv: list[str]) -> int:
     )
     parser.add_argument(
         "--e2e-junit",
+        action="append",
         default=None,
-        help="E2E tier junit XML. Omit when e2e did not run — the e2e tier is "
-        "then marked not-applicable (no grade cap, excluded from the aggregate).",
+        metavar="PATH_OR_GLOB",
+        help="E2E tier junit XML; repeatable, and each value may be a glob "
+        "(the e2e matrix emits one artifact per suite x cloud leg). Legs are "
+        "folded worst-case per test, so a test failing on any cloud does not "
+        "pass. Omit — or pass a glob that matches nothing — when e2e did not "
+        "run: the e2e tier is then marked not-applicable (no grade cap, "
+        "excluded from the aggregate) rather than scored zero.",
     )
     parser.add_argument("--unit-coverage", default=None, help="Unit coverage.json.")
     parser.add_argument(
@@ -106,6 +139,23 @@ def main(argv: list[str]) -> int:
     parser.add_argument(
         "--app", default=None, help="App name (default: derived from --repo)."
     )
+    parser.add_argument(
+        "--cross-cloud-configured",
+        default=None,
+        metavar="CLOUDS",
+        help="Comma-separated clouds this repo's e2e is WIRED for (the "
+        "requested fan-out narrowed to what the tenant matrix carries for it). "
+        "Descriptive only, never scored. Omit when unknown; an empty value "
+        "records 'no cloud dimension', which is a different fact from omitting.",
+    )
+    parser.add_argument(
+        "--cross-cloud-observed",
+        default=None,
+        metavar="CLOUDS",
+        help="Comma-separated clouds an e2e run actually EXERCISED. Pass only "
+        "when e2e ran; omitting it records that nothing is known about "
+        "cross-CSP coverage for this run, which must not read as zero.",
+    )
     parser.add_argument("--rubric", default="v1", help="Rubric version (default: v1).")
     parser.add_argument(
         "--tool-version",
@@ -126,16 +176,32 @@ def main(argv: list[str]) -> int:
     if not unit_junit:
         parser.error("at least --unit-junit (or the deprecated --junit) is required")
 
+    # One or many per-leg e2e junits, resolved from repeatable globs. Empty
+    # means e2e did not run (or uploaded nothing) — NOT that it scored zero.
+    e2e_paths = resolve_junit_paths(args.e2e_junit or [])
+    if args.e2e_junit and not e2e_paths:
+        print(
+            "warning: no e2e junit matched "
+            f"{', '.join(args.e2e_junit)} — e2e tier marked not-applicable"
+        )
+
     tests = RawTests(
         unit=_counts(unit_junit),
         integration=_counts(args.integration_junit),
-        e2e=_counts(args.e2e_junit),
+        e2e=parse_junit_tier_merged(e2e_paths),
     )
 
-    # unit + integration are always measured; e2e only when its junit is given.
+    # unit + integration are always measured; e2e only when evidence resolved.
     measured_tiers: set[TierName] = {"unit", "integration"}
-    if args.e2e_junit:
+    if e2e_paths:
         measured_tiers.add("e2e")
+        print(f"e2e evidence: {len(e2e_paths)} leg junit(s) merged worst-case per test")
+
+    cross_cloud = None
+    configured = _clouds(args.cross_cloud_configured)
+    observed = _clouds(args.cross_cloud_observed)
+    if configured is not None or observed is not None:
+        cross_cloud = CrossCloudCoverage(configured=configured, observed=observed)
 
     coverage: dict[TierName, CoverageMetrics] = {}
     if (unit_cov := _coverage(unit_coverage)) is not None:
@@ -153,6 +219,7 @@ def main(argv: list[str]) -> int:
         commit_sha=args.commit,
         tool_version=args.tool_version or __version__,
         generated_at=_now_iso(),
+        cross_cloud=cross_cloud,
     )
 
     out_path = Path(args.out)

--- a/packages/conformance/conformance/scorecard/compute.py
+++ b/packages/conformance/conformance/scorecard/compute.py
@@ -29,6 +29,7 @@ from conformance.scorecard.schema import (
     Aggregate,
     Check,
     CoverageMetrics,
+    CrossCloudCoverage,
     Gate,
     Grade,
     Maturity,
@@ -169,12 +170,16 @@ def build_scorecard(
     commit_sha: str | None,
     tool_version: str,
     generated_at: str,
+    cross_cloud: CrossCloudCoverage | None = None,
 ) -> Scorecard:
     """Assemble a :class:`Scorecard` from raw evidence and a rubric.
 
     Deterministic and IO-free; ``generated_at`` is supplied by the caller.
     ``coverage`` is a per-tier map; ``measured_tiers`` names the tiers exercised
     in this run (drives applicability + aggregate renormalization).
+
+    ``cross_cloud`` is carried through to ``raw`` verbatim and never scored — no
+    check reads it and no gate caps on it (see :class:`CrossCloudCoverage`).
     """
     tiers = [
         _score_tier(
@@ -228,5 +233,5 @@ def build_scorecard(
         aggregate=aggregate,
         tiers=tiers,
         gates=gates,
-        raw=RawMetrics(coverage=coverage, tests=tests),
+        raw=RawMetrics(coverage=coverage, tests=tests, cross_cloud=cross_cloud),
     )

--- a/packages/conformance/conformance/scorecard/readers.py
+++ b/packages/conformance/conformance/scorecard/readers.py
@@ -99,13 +99,19 @@ def parse_junit_tier(path: str | Path) -> TierTestCounts:
 
 
 def resolve_junit_paths(patterns: Iterable[str]) -> list[str]:
-    """Expand *patterns* (plain paths or globs) into existing files, de-duplicated.
+    """Expand *patterns* (plain paths or globs) into existing junit files, de-duplicated.
 
     The e2e tier arrives as N per-leg artifacts (one per suite × cloud since
     FND-6), so the CLI is handed a glob rather than a list the workflow would
     have to build with shell branching.  A pattern that matches nothing yields
     nothing — which the caller reads as "e2e did not run", never as "e2e ran and
     scored zero".
+
+    A match is only kept if it looks like a junit document — a ``.xml`` file
+    whose root element is ``<testsuite>`` or ``<testsuites>``.  Without that
+    gate a broad caller glob would either crash the scorecard (binary / non-XML
+    match handed to ``ET.parse``) or silently fold an unrelated XML's
+    ``<testcase>`` elements into the e2e counts.
     """
     seen: dict[str, None] = {}
     for pattern in patterns:
@@ -115,9 +121,27 @@ def resolve_junit_paths(patterns: Iterable[str]) -> list[str]:
         # A plain (non-glob) path is its own match; glob returns it only when it
         # exists, which is the same existence check the single-file reader does.
         for match in matches:
-            if Path(match).is_file():
+            if _is_junit_file(match):
                 seen.setdefault(match, None)
     return list(seen)
+
+
+def _is_junit_file(path: str) -> bool:
+    """Cheap "is this a junit XML?" gate for glob matches.
+
+    Checks the ``.xml`` suffix first (a directory or suffix-less file never
+    reaches the parser), then reads just the root element — not the whole tree —
+    so a malformed tail cannot reject a file whose root is genuine junit.
+    """
+    candidate = Path(path)
+    if candidate.suffix != ".xml" or not candidate.is_file():
+        return False
+    try:
+        for _event, element in ET.iterparse(str(candidate), events=("start",)):
+            return element.tag in ("testsuite", "testsuites")
+    except ET.ParseError:
+        return False
+    return False
 
 
 def parse_junit_tier_merged(paths: Iterable[str | Path]) -> TierTestCounts:

--- a/packages/conformance/conformance/scorecard/readers.py
+++ b/packages/conformance/conformance/scorecard/readers.py
@@ -13,9 +13,11 @@ catch-all base tier).
 
 from __future__ import annotations
 
+import glob as _glob
 import json
 import re
 import xml.etree.ElementTree as ET
+from collections.abc import Iterable
 from pathlib import Path
 
 from conformance.scorecard.schema import (
@@ -26,6 +28,11 @@ from conformance.scorecard.schema import (
 )
 
 _SEGMENT_SPLIT = re.compile(r"[./\\]+")
+
+#: Outcome names, ordered worst-last.  Used to fold one test's results across
+#: several per-leg junits down to a single outcome — see
+#: :func:`parse_junit_tier_merged` for why ``passed`` outranks ``skipped``.
+_OUTCOME_RANK: dict[str, int] = {"skipped": 0, "passed": 1, "failed": 2, "errors": 3}
 
 
 def tier_for_path(path: str) -> TierName:
@@ -91,18 +98,93 @@ def parse_junit_tier(path: str | Path) -> TierTestCounts:
     return counts
 
 
+def resolve_junit_paths(patterns: Iterable[str]) -> list[str]:
+    """Expand *patterns* (plain paths or globs) into existing files, de-duplicated.
+
+    The e2e tier arrives as N per-leg artifacts (one per suite × cloud since
+    FND-6), so the CLI is handed a glob rather than a list the workflow would
+    have to build with shell branching.  A pattern that matches nothing yields
+    nothing — which the caller reads as "e2e did not run", never as "e2e ran and
+    scored zero".
+    """
+    seen: dict[str, None] = {}
+    for pattern in patterns:
+        if not pattern:
+            continue
+        matches = sorted(_glob.glob(pattern))
+        # A plain (non-glob) path is its own match; glob returns it only when it
+        # exists, which is the same existence check the single-file reader does.
+        for match in matches:
+            if Path(match).is_file():
+                seen.setdefault(match, None)
+    return list(seen)
+
+
+def parse_junit_tier_merged(paths: Iterable[str | Path]) -> TierTestCounts:
+    """Fold N per-leg junits for ONE tier into a single worst-case count.
+
+    The e2e matrix runs each suite once per cloud, so the same test id appears
+    in several junits.  Tests are keyed on ``(classname, name)`` and folded to
+    their **worst** outcome across legs, rather than summed:
+
+    * Summing would make the pass rate a function of how many clouds a repo has
+      onboarded — a failure on one of three clouds reads better (11/12) than the
+      same failure on the only cloud (3/4).  Onboarding a cloud would *raise*
+      the score by diluting an existing failure, which is precisely backwards.
+    * Worst-case keeps the denominator at "distinct e2e tests" and treats a test
+      that fails on any supported cloud as not passing, which is what
+      "e2e-ready" has to mean.
+
+    ``passed`` outranks ``skipped`` deliberately: a test that ran green on one
+    cloud and self-skipped on another (absent creds) genuinely ran, and
+    :attr:`TierTestCounts.ran` excludes skips.  Ranking skip highest would erase
+    the evidence a leg actually produced.
+
+    ``duration_sec`` is the per-test **max** across legs, matching the per-test
+    dedup — a sum would count the same test's wall time once per cloud.
+    """
+    worst: dict[tuple[str, str], str] = {}
+    longest: dict[tuple[str, str], float] = {}
+
+    for path in paths:
+        for testcase in ET.parse(str(path)).getroot().iter("testcase"):
+            key = (testcase.get("classname") or "", testcase.get("name") or "")
+            outcome = _outcome(testcase)
+            if _OUTCOME_RANK[outcome] > _OUTCOME_RANK.get(worst.get(key, ""), -1):
+                worst[key] = outcome
+            longest[key] = max(
+                longest.get(key, 0.0), float(testcase.get("time") or 0.0)
+            )
+
+    counts = TierTestCounts()
+    for key, outcome in worst.items():
+        counts.total += 1
+        counts.duration_sec += longest[key]
+        setattr(counts, outcome, getattr(counts, outcome) + 1)
+    return counts
+
+
+def _outcome(testcase: ET.Element) -> str:
+    """Classify one ``<testcase>`` (error > failure > skipped > pass).
+
+    error takes precedence over failure, matching how pytest reports
+    collection/fixture errors distinctly from assertion failures.
+    """
+    if testcase.find("error") is not None:
+        return "errors"
+    if testcase.find("failure") is not None:
+        return "failed"
+    if testcase.find("skipped") is not None:
+        return "skipped"
+    return "passed"
+
+
 def _tally(counts: TierTestCounts, testcase: ET.Element) -> None:
     """Fold one ``<testcase>`` into *counts* (error > failure > skipped > pass)."""
     counts.total += 1
     counts.duration_sec += float(testcase.get("time") or 0.0)
-    if testcase.find("error") is not None:
-        counts.errors += 1
-    elif testcase.find("failure") is not None:
-        counts.failed += 1
-    elif testcase.find("skipped") is not None:
-        counts.skipped += 1
-    else:
-        counts.passed += 1
+    outcome = _outcome(testcase)
+    setattr(counts, outcome, getattr(counts, outcome) + 1)
 
 
 def parse_coverage_json(path: str | Path) -> CoverageMetrics:

--- a/packages/conformance/conformance/scorecard/schema.py
+++ b/packages/conformance/conformance/scorecard/schema.py
@@ -100,6 +100,40 @@ class RawTests(BaseModel):
         return getattr(self, name)
 
 
+class CrossCloudCoverage(BaseModel):
+    """Which CSPs this repo's e2e is wired for, and which it actually exercised.
+
+    Descriptive, **not scored**: no :class:`Check` and no :class:`Gate` reads
+    these.  Promoting cross-CSP coverage to a scored dimension the moment it
+    ships would move every app's aggregate downward at once, so a rollout would
+    read as a fleet-wide regression (FND-34).  Record first; score once the
+    fleet is onboarded and a low value is actionable.
+
+    The two fields answer different questions and must not be collapsed — an app
+    can be configured for three clouds and have two failing, which is a
+    different problem from an app nobody has onboarded yet.
+
+    Absence is a third state, and load-bearing.  ``exclude_none=True`` drops an
+    unset field entirely, so ``observed`` omitted means "e2e did not run, we know
+    nothing", while ``observed: []`` means "e2e ran with no cloud dimension" —
+    the degraded single-tenant fallback.  A consumer that reads absent as zero
+    shows the whole fleet as failing forever regardless of onboarding.
+    """
+
+    configured: list[str] | None = None
+    """Clouds this repo is *wired* for: the requested fan-out narrowed to what
+    ``E2E_TENANT_MATRIX_JSON`` carries for it.  Derivable without running e2e,
+    so it lands on every scorecard emission — this is the rollout signal.
+    ``[]`` means no cloud dimension (no tenant matrix shared with the repo)."""
+
+    observed: list[str] | None = None
+    """Clouds an e2e run actually exercised.  Present only on runs where the
+    e2e job ran, which is label/dispatch-gated — this is the verification
+    signal, and it is sparse by construction."""
+
+    model_config = _COMMON
+
+
 class RawMetrics(BaseModel):
     """The underlying measured numbers, for dashboard drill-down and recompute."""
 
@@ -110,6 +144,10 @@ class RawMetrics(BaseModel):
     model *fields*, not dict keys, so they stay lowercase on the wire."""
 
     tests: RawTests = Field(default_factory=RawTests)
+
+    cross_cloud: CrossCloudCoverage | None = None
+    """Descriptive cross-CSP e2e coverage; omitted entirely when unknown.
+    Additive and non-breaking — older consumers ignore the key."""
 
     model_config = _COMMON
 

--- a/packages/conformance/conformance/scorecard/scorecard-schema-1.0.json
+++ b/packages/conformance/conformance/scorecard/scorecard-schema-1.0.json
@@ -126,6 +126,43 @@
       "title": "CoverageMetrics",
       "type": "object"
     },
+    "CrossCloudCoverage": {
+      "description": "Which CSPs this repo's e2e is wired for, and which it actually exercised.\n\nDescriptive, **not scored**: no :class:`Check` and no :class:`Gate` reads\nthese.  Promoting cross-CSP coverage to a scored dimension the moment it\nships would move every app's aggregate downward at once, so a rollout would\nread as a fleet-wide regression (FND-34).  Record first; score once the\nfleet is onboarded and a low value is actionable.\n\nThe two fields answer different questions and must not be collapsed \u2014 an app\ncan be configured for three clouds and have two failing, which is a\ndifferent problem from an app nobody has onboarded yet.\n\nAbsence is a third state, and load-bearing.  ``exclude_none=True`` drops an\nunset field entirely, so ``observed`` omitted means \"e2e did not run, we know\nnothing\", while ``observed: []`` means \"e2e ran with no cloud dimension\" \u2014\nthe degraded single-tenant fallback.  A consumer that reads absent as zero\nshows the whole fleet as failing forever regardless of onboarding.",
+      "properties": {
+        "configured": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Configured"
+        },
+        "observed": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Observed"
+        }
+      },
+      "title": "CrossCloudCoverage",
+      "type": "object"
+    },
     "Gate": {
       "description": "A SonarQube-style quality gate that can cap the grade regardless of score.",
       "properties": {
@@ -174,6 +211,17 @@
         },
         "tests": {
           "$ref": "#/$defs/RawTests"
+        },
+        "crossCloud": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CrossCloudCoverage"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         }
       },
       "title": "RawMetrics",

--- a/packages/conformance/tests/test_scorecard_cli.py
+++ b/packages/conformance/tests/test_scorecard_cli.py
@@ -83,6 +83,123 @@ def test_cli_with_e2e_junit_marks_e2e_applicable(tmp_path: Path) -> None:
     assert next(g for g in sc.gates if g.id == "e2e-present").status == "pass"
 
 
+def _run(tmp_path: Path, out: Path, *extra: str) -> Scorecard:
+    rc = main(
+        [
+            "--unit-junit",
+            str(_junit(tmp_path, "unit", passed=10)),
+            "--integration-junit",
+            str(_junit(tmp_path, "integration", passed=3)),
+            "--repo",
+            "atlanhq/atlan-openapi-app",
+            "--out",
+            str(out),
+            *extra,
+        ]
+    )
+    assert rc == 0
+    return Scorecard.model_validate(json.loads(out.read_text(encoding="utf-8")))
+
+
+def _leg_junit(root: Path, leg: str, *, passed: int = 0, failed: int = 0) -> None:
+    """Write one leg's artifact at the layout `download-artifact` produces."""
+    leg_dir = root / f"sdr-integration-tests-openapi-{leg}-results" / "results"
+    leg_dir.mkdir(parents=True)
+    cases = "".join(
+        f'<testcase classname="tests.e2e.test_s" name="p{i}" time="1"/>'
+        for i in range(passed)
+    ) + "".join(
+        f'<testcase classname="tests.e2e.test_s" name="f{i}" time="1"><failure/>'
+        "</testcase>"
+        for i in range(failed)
+    )
+    (leg_dir / "sdr-test-results.xml").write_text(
+        f"<testsuites><testsuite name='pytest'>{cases}</testsuite></testsuites>",
+        encoding="utf-8",
+    )
+
+
+def test_cli_e2e_glob_merges_every_leg(tmp_path: Path) -> None:
+    """The FND-33 wiring: one glob, N per-leg artifacts, one e2e tier."""
+    evidence = tmp_path / "e2e-evidence"
+    _leg_junit(evidence, "suite-aws", passed=2)
+    _leg_junit(evidence, "suite-azure", passed=1, failed=1)
+
+    sc = _run(
+        tmp_path,
+        tmp_path / "sc.json",
+        "--e2e-junit",
+        str(evidence / "*" / "results" / "sdr-test-results.xml"),
+    )
+    assert next(t for t in sc.tiers if t.name == "e2e").applicable is True
+    # Worst-case per test: p0/p1 pass everywhere, f0 fails on azure. Two legs of
+    # two tests are TWO distinct tests, not four.
+    assert sc.raw.tests.e2e.total == 3
+    assert sc.raw.tests.e2e.failed == 1
+
+
+def test_cli_e2e_glob_matching_nothing_leaves_the_tier_not_applicable(
+    tmp_path: Path,
+) -> None:
+    """e2e skipped must not fabricate empty evidence and cap the grade at B."""
+    sc = _run(
+        tmp_path,
+        tmp_path / "sc.json",
+        "--e2e-junit",
+        str(tmp_path / "e2e-evidence" / "*" / "results" / "sdr-test-results.xml"),
+    )
+    assert next(t for t in sc.tiers if t.name == "e2e").applicable is False
+    assert next(g for g in sc.gates if g.id == "e2e-present").status == "na"
+    assert "e2e-present" not in sc.aggregate.capped_by
+
+
+def test_cli_records_cross_cloud_configured_and_observed(tmp_path: Path) -> None:
+    sc = _run(
+        tmp_path,
+        tmp_path / "sc.json",
+        "--cross-cloud-configured",
+        "aws,azure,gcp",
+        "--cross-cloud-observed",
+        "aws",
+    )
+    assert sc.raw.cross_cloud is not None
+    assert sc.raw.cross_cloud.configured == ["aws", "azure", "gcp"]
+    assert sc.raw.cross_cloud.observed == ["aws"]
+
+
+def test_cli_cross_cloud_absent_is_omitted_not_empty(tmp_path: Path) -> None:
+    """Three states stay distinguishable on the wire (FND-34)."""
+    out = tmp_path / "sc.json"
+    sc = _run(tmp_path, out)
+    assert sc.raw.cross_cloud is None
+    assert "crossCloud" not in json.loads(out.read_text(encoding="utf-8"))["raw"]
+
+
+def test_cli_cross_cloud_empty_configured_records_the_degraded_state(
+    tmp_path: Path,
+) -> None:
+    """ "No tenant matrix" is a fact worth recording, not the same as unknown."""
+    out = tmp_path / "sc.json"
+    sc = _run(tmp_path, out, "--cross-cloud-configured", "")
+    assert sc.raw.cross_cloud is not None
+    assert sc.raw.cross_cloud.configured == []
+    # observed stays absent — e2e told us nothing about what ran.
+    assert sc.raw.cross_cloud.observed is None
+    raw = json.loads(out.read_text(encoding="utf-8"))["raw"]
+    assert raw["crossCloud"] == {"configured": []}
+
+
+def test_cli_cross_cloud_is_never_scored(tmp_path: Path) -> None:
+    """Descriptive only: recording it must not move the grade (FND-34)."""
+    plain = _run(tmp_path, tmp_path / "a.json")
+    with_clouds = _run(
+        tmp_path, tmp_path / "b.json", "--cross-cloud-configured", "aws,azure,gcp"
+    )
+    assert with_clouds.aggregate.score == plain.aggregate.score
+    assert with_clouds.aggregate.grade == plain.aggregate.grade
+    assert [g.id for g in with_clouds.gates] == [g.id for g in plain.gates]
+
+
 def test_cli_requires_unit_junit(tmp_path: Path) -> None:
     with pytest.raises(SystemExit):
         main(["--repo", "atlanhq/atlan-x-app", "--out", str(tmp_path / "x.json")])

--- a/packages/conformance/tests/test_scorecard_readers.py
+++ b/packages/conformance/tests/test_scorecard_readers.py
@@ -9,6 +9,8 @@ from conformance.scorecard.readers import (
     parse_coverage_json,
     parse_junit,
     parse_junit_tier,
+    parse_junit_tier_merged,
+    resolve_junit_paths,
     tier_for_path,
 )
 from conformance.scorecard.schema import CoverageMetrics, RawTests, TierTestCounts
@@ -108,6 +110,129 @@ def test_parse_junit_accepts_testsuite_root(tmp_path: Path) -> None:
     tests = parse_junit(xml)
     assert tests.unit.total == 1
     assert tests.unit.passed == 1
+
+
+# ---------------------------------------------------------------------------
+# Per-leg e2e evidence (FND-33): N junits, one per suite x cloud
+# ---------------------------------------------------------------------------
+
+
+def _leg(tmp_path: Path, name: str, *cases: tuple[str, str, float]) -> Path:
+    """Write a one-suite junit; each case is ``(test_name, outcome, time)``."""
+    child = {
+        "passed": "",
+        "failed": "<failure/>",
+        "errors": "<error/>",
+        "skipped": "<skipped/>",
+    }
+    body = "".join(
+        f'<testcase classname="tests.e2e.test_s" name="{case}" time="{t}">'
+        f"{child[outcome]}</testcase>"
+        for case, outcome, t in cases
+    )
+    path = tmp_path / f"{name}.xml"
+    path.write_text(
+        f'<testsuites><testsuite name="pytest" tests="{len(cases)}">{body}'
+        "</testsuite></testsuites>",
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_merged_legs_dedupe_the_same_test_across_clouds(tmp_path: Path) -> None:
+    """Three clouds x two tests is two tests, not six.
+
+    Summing would make the denominator a function of how many clouds a repo has
+    onboarded, so onboarding a cloud would raise the pass rate by diluting an
+    existing failure.
+    """
+    legs = [
+        _leg(tmp_path, cloud, ("t_a", "passed", 1.0), ("t_b", "passed", 2.0))
+        for cloud in ("aws", "azure", "gcp")
+    ]
+    counts = parse_junit_tier_merged(legs)
+    assert counts.total == 2
+    assert counts.passed == 2
+    assert counts.ran == 2
+    assert counts.green is True
+
+
+def test_merged_legs_take_the_worst_outcome_per_test(tmp_path: Path) -> None:
+    """A test failing on ONE cloud is not passing."""
+    counts = parse_junit_tier_merged(
+        [
+            _leg(tmp_path, "aws", ("t_a", "passed", 1.0), ("t_b", "passed", 1.0)),
+            _leg(tmp_path, "azure", ("t_a", "passed", 1.0), ("t_b", "failed", 1.0)),
+        ]
+    )
+    assert counts.total == 2
+    assert counts.passed == 1
+    assert counts.failed == 1
+    assert counts.green is False
+
+
+def test_merged_legs_rank_error_above_failure(tmp_path: Path) -> None:
+    counts = parse_junit_tier_merged(
+        [
+            _leg(tmp_path, "aws", ("t_a", "failed", 1.0)),
+            _leg(tmp_path, "azure", ("t_a", "errors", 1.0)),
+        ]
+    )
+    assert counts.errors == 1
+    assert counts.failed == 0
+
+
+def test_merged_legs_prefer_a_real_run_over_a_skip(tmp_path: Path) -> None:
+    """A pass on one cloud and a self-skip on another is a test that RAN.
+
+    Ranking skip highest would erase the evidence a leg actually produced and
+    push the tier back to ``present: false``.
+    """
+    counts = parse_junit_tier_merged(
+        [
+            _leg(tmp_path, "aws", ("t_a", "passed", 1.0)),
+            _leg(tmp_path, "azure", ("t_a", "skipped", 0.0)),
+        ]
+    )
+    assert counts.passed == 1
+    assert counts.skipped == 0
+    assert counts.ran == 1
+    assert counts.present is True
+
+
+def test_merged_legs_take_the_max_duration_per_test(tmp_path: Path) -> None:
+    counts = parse_junit_tier_merged(
+        [
+            _leg(tmp_path, "aws", ("t_a", "passed", 1.5)),
+            _leg(tmp_path, "azure", ("t_a", "passed", 4.0)),
+        ]
+    )
+    assert counts.duration_sec == pytest.approx(4.0)
+
+
+def test_merged_with_no_paths_is_empty_not_an_error() -> None:
+    counts = parse_junit_tier_merged([])
+    assert counts.total == 0
+    assert counts.present is False
+
+
+def test_resolve_junit_paths_expands_globs_and_dedupes(tmp_path: Path) -> None:
+    for cloud in ("aws", "azure"):
+        leg_dir = tmp_path / f"suite-{cloud}" / "results"
+        leg_dir.mkdir(parents=True)
+        (leg_dir / "sdr-test-results.xml").write_text("<testsuites/>", encoding="utf-8")
+    pattern = str(tmp_path / "*" / "results" / "sdr-test-results.xml")
+    # The same file reached by a glob and by its literal path resolves once.
+    resolved = resolve_junit_paths(
+        [pattern, str(tmp_path / "suite-aws" / "results" / "sdr-test-results.xml")]
+    )
+    assert len(resolved) == 2
+
+
+def test_resolve_junit_paths_matching_nothing_is_empty(tmp_path: Path) -> None:
+    """Absent evidence must be distinguishable from zero-scored evidence."""
+    assert resolve_junit_paths([str(tmp_path / "*" / "nope.xml")]) == []
+    assert resolve_junit_paths([""]) == []
 
 
 def test_parse_coverage_json_totals_and_branch() -> None:

--- a/packages/conformance/tests/test_scorecard_readers.py
+++ b/packages/conformance/tests/test_scorecard_readers.py
@@ -235,6 +235,44 @@ def test_resolve_junit_paths_matching_nothing_is_empty(tmp_path: Path) -> None:
     assert resolve_junit_paths([""]) == []
 
 
+def test_resolve_junit_paths_skips_a_directory_match(tmp_path: Path) -> None:
+    """A glob can land on a directory named *.xml — never hand that to ET.parse."""
+    (tmp_path / "results.xml").mkdir()
+    (tmp_path / "real.xml").write_text("<testsuites/>", encoding="utf-8")
+    resolved = resolve_junit_paths([str(tmp_path / "*.xml")])
+    assert resolved == [str(tmp_path / "real.xml")]
+
+
+def test_resolve_junit_paths_skips_a_non_junit_xml(tmp_path: Path) -> None:
+    """An unrelated XML must not fold its <testcase> elements into e2e counts."""
+    (tmp_path / "pom.xml").write_text(
+        "<project><modelVersion>4.0.0</modelVersion></project>", encoding="utf-8"
+    )
+    (tmp_path / "results.xml").write_text("<testsuites/>", encoding="utf-8")
+    resolved = resolve_junit_paths([str(tmp_path / "*.xml")])
+    assert resolved == [str(tmp_path / "results.xml")]
+
+
+def test_resolve_junit_paths_skips_a_malformed_xml(tmp_path: Path) -> None:
+    """A truncated / binary-ish .xml must not crash the scorecard."""
+    (tmp_path / "broken.xml").write_bytes(b"\x00\x01not xml")
+    (tmp_path / "real.xml").write_text(
+        '<testsuite name="pytest" tests="1"/>', encoding="utf-8"
+    )
+    resolved = resolve_junit_paths([str(tmp_path / "*.xml")])
+    assert resolved == [str(tmp_path / "real.xml")]
+
+
+def test_resolve_junit_paths_accepts_a_testsuite_root(tmp_path: Path) -> None:
+    """Both junit root forms (<testsuites> and bare <testsuite>) are accepted."""
+    (tmp_path / "suites.xml").write_text("<testsuites/>", encoding="utf-8")
+    (tmp_path / "single.xml").write_text(
+        '<testsuite name="pytest" tests="0"/>', encoding="utf-8"
+    )
+    resolved = resolve_junit_paths([str(tmp_path / "*.xml")])
+    assert resolved == [str(tmp_path / "single.xml"), str(tmp_path / "suites.xml")]
+
+
 def test_parse_coverage_json_totals_and_branch() -> None:
     cov = parse_coverage_json(_FIXTURES / "coverage.json")
     assert isinstance(cov, CoverageMetrics)


### PR DESCRIPTION
Closes FND-33 and FND-34.

Implemented together because they edit the same three surfaces — the `scorecard` job, the scorecard model, and the `discover-e2e-suites` driver — so splitting them would have meant two PRs colliding on one job block.

## The problem

The scorecard has modelled a first-class `e2e` tier since it shipped and received none of it. The job needed only `unit` + `integration`, so fleet-wide: `raw.tests.e2e` was always zeroed, the tier was always `applicable: false`, and the `e2e-present` gate was permanently `na`. connector-pulse's `test_readiness` metric said nothing at all about e2e, for every app.

Separately, a repo running degraded cross-CSP coverage (no `E2E_TENANT_MATRIX_JSON` shared with it) was indistinguishable from a fully covered one at any point of central visibility. The only signal was a `::warning::` — per-run, ephemeral, buried in one app repo's Actions log.

## FND-33's open question, settled: accept sparsity, make absence honest

The `scorecard` job runs on push/merge_group; `discover-e2e`/`e2e` run on `workflow_dispatch + run_e2e=true` or an `e2e`-labelled PR. Those barely intersect.

**Running the scorecard on the e2e-labelled PR path is dead, not merely unattractive.** `update-dashboard.yaml` walks the last 20 *completed default-branch* Tests runs for one carrying a live scorecard artifact — a PR-run scorecard is never ingested. And on a PR the `integration` job is skipped, so such a scorecard would publish a zeroed integration tier: a fabricated regression, which is exactly what the job's existing `!= 'pull_request'` guard exists to prevent.

A separate durable e2e record (option 3) is a larger build and premature.

So: **option 1**, with the consequence stated in the workflow and in `docs/standards/connector-ci-e2e.md`. A routine push emits a scorecard saying *"e2e not measured"*, never *"e2e failing"*. Absent evidence keeps the tier `applicable: false` and the gate `na` — excluded from the aggregate, no grade cap — rather than scoring zero and dragging every app's grade.

## Combining N per-leg junits: worst-case per test

Since FND-6 the matrix emits one artifact per suite × cloud. Legs are keyed on `(classname, name)` and folded to their **worst** outcome, not summed.

Summing would make the denominator a function of how many clouds a repo has onboarded: a failure on one of three clouds scores 11/12, the same failure on the only cloud scores 3/4. **Onboarding a cloud would raise the score by diluting an existing failure** — precisely backwards.

One deliberate asymmetry: `passed` outranks `skipped`, so a test green on aws and self-skipped on azure counts as having run. Ranking skip highest would erase evidence a leg actually produced.

## FND-34: two facts, kept apart, neither scored

`raw.crossCloud.configured` — what the repo is *wired* for. Resolved inside the scorecard job from the tenant matrix's key list plus `e2e-clouds`, with **no e2e run required**, so it lands on every emission. This is what carries rollout visibility, since `observed` is sparse by construction.

It re-uses `discover_e2e_suites.py --clouds-only` with the byte-identical `clouds:` expression discovery uses, rather than re-deriving the list — otherwise the recorded rollout state could drift from the fan-out that would actually happen. A test asserts the two expressions are equal.

`raw.crossCloud.observed` — what a run actually *exercised*, from a new `clouds` output on the discovery action, emitted by the same `parse_clouds` call that built the matrix.

**Neither is scored.** No `Check` reads them, no `Gate` caps on them, and a test pins that recording them cannot move an app's score, grade or gate set. Promotion to a scored dimension stays behind FND-31 + fleet onboarding — shipping it now would move every app's aggregate down at once and a rollout would read as a fleet-wide regression.

**Three states stay distinguishable** (`exclude_none=True` carries all three):

| Wire | Meaning |
| --- | --- |
| `crossCloud` absent, or `observed` absent | e2e did not run — nothing known |
| `observed: []` | e2e ran with no cloud dimension: degraded / not onboarded |
| `observed: ["aws","azure"]` | e2e ran on those clouds |

## Also fixed

`report-to-sdk` downloaded the exact `sdr-integration-tests-<app>-results` name, which has matched nothing since FND-6 suffixed each leg. Under `continue-on-error` it silently no-opped and the SDK-side check fell back to a plain body on every cross-CSP run. Now `pattern:` + `merge-multiple: true` — correct *there* (that job wants one rendered `pr-comment-body.md`), and deliberately **not** used in the scorecard job, where merging would have the legs overwrite each other's junit.

## Notes for review

- Conditional argument building lives in a tested `build_scorecard_args.py` per `docs/standards/ci.md`; the workflow `run:` stays straight-line.
- `--out` is emitted last, and always non-empty: either cross-CSP value may legitimately be `""`, and a trailing empty line is the element a `raw=$(...)` capture would silently drop, leaving a dangling flag.
- Adding a `clouds` job output tripped a *text-scan* guard in `test_prepare_tenant_wiring.py` that counted every line reading `clouds:`. Retargeted at the discovery action's `with.clouds` — strictly stronger, and no longer tripped by unrelated keys of the same name.
- `scorecard-schema-1.0.json` regenerated; the freshness test keeps it honest.

## Sequencing / known gap

`uvx` resolves the newest *published* conformance, and the repeatable `--e2e-junit` + `--cross-cloud-*` flags only exist from 0.21.0. Until that publishes, argparse rejects them, the step warns, and no scorecard artifact is produced for that run. The dashboard tolerates it (it walks back 20 runs for a live artifact), and this is the same gap accepted when the per-tier flags landed ahead of 0.17.0. It closes on the next conformance release.

**Correcting an earlier note in this description:** I first wrote that connector-pulse "must render the e2e tier's `applicable: false` as unknown, not zero". It already does, and better than that — `_overlay_e2e_tier_score` in `test_readiness_service.py` fills a not-applicable e2e tier from an independent GitHub Actions scan of the connector's last real e2e run, and explicitly leaves a *real* measurement untouched when one is present. So this PR slots in with no consumer change required for the e2e tier: scorecard-native evidence now wins on dispatched runs, and the existing scan still covers every other run.

**Does the reporting survive the different trigger points?** Yes, and the two halves are worth separating:

- **integration** — runs on `merge_group`, `push` and `workflow_dispatch`, and is skipped only on PRs whose base has a merge queue (plus when the connector ships no suite). The scorecard never runs on PRs, so integration evidence is present on *every* scorecard emission. No gap.
- **e2e** — lands only on the dispatch path, and is then superseded in the per-repo doc by the next routine push's scorecard. That transience is covered downstream by the Actions-scan overlay above, so the displayed e2e tier is "last known real run" rather than blank.
- **`crossCloud.observed`** has no such overlay and is genuinely sparse — which is exactly why `configured` (recorded on every emission, no e2e run needed) is the field carrying rollout visibility.

**Consumer branch:** `chrishehim/fnd-34-cross-csp` in connector-pulse ingests `raw.crossCloud` — normalises it per repo with an explicit `unknown`/`degraded`/`onboarded` state, adds `crossCloudCounts` + `crossCloudConfiguredCounts` to the fleet rollup, and keeps absent out of the onboarding ratio. connector-pulse #596 remains the prerequisite for the per-tier alignment.

## Tests

- `.github/scripts/tests/` — 2463 passed
- `packages/conformance/tests/` — 2658 passed, 1 skipped, 1 xfailed
- pre-commit clean (ruff, ruff-format, pyright, check-yaml, isort)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
