### PR TITLE
ci(pr-checks): drop the per-commit convention gate, keep the PR-title one

### DIFF
--- a/.github/scripts/tests/test_conventional_commits_gates.py
+++ b/.github/scripts/tests/test_conventional_commits_gates.py
@@ -235,3 +235,39 @@ def test_fail_step_still_fires_on_a_fork_pr() -> None:
         evaluate(gate, _contexts(event="pull_request", violation="true", fork=True))
         is True
     )
+
+
+# ── This repo polices the PR title, never the branch's commits ───────────────
+#
+# application-sdk is squash-merge-only, with the squash subject taken from the
+# PR title and the squash body left blank, so a branch's individual commit
+# subjects are discarded at merge. A per-commit convention gate here blocks on
+# text that cannot reach main, the changelog, or the version bump — and it did:
+# a correctly-titled PR stayed red on a WIP commit subject. Dropping it is only
+# safe while the title itself is still gated, so both halves of that trade are
+# pinned here rather than left to a comment.
+
+_PR_CHECKS = _REPO_ROOT / ".github/workflows/pull_request.yaml"
+_TITLE_GUARD = _REPO_ROOT / ".github/workflows/pr-title-convention.yaml"
+
+
+def test_pr_checks_does_not_gate_individual_commit_subjects() -> None:
+    body = _PR_CHECKS.read_text(encoding="utf-8")
+    assert "action-conventional-commits" not in body, (
+        "PR Checks gates every commit subject on the branch again. Those "
+        "subjects are dropped by the squash merge, so this can only ever fail "
+        "a PR whose merged history would have been fine. Gate the PR title "
+        "instead — pr-title-convention.yaml already does."
+    )
+
+
+def test_the_pr_title_is_still_gated() -> None:
+    """The removal above is conditional on this check existing."""
+    jobs = _load(_TITLE_GUARD)["jobs"]
+    names = {job.get("name") for job in jobs.values()}
+    assert "Validate PR title" in names, (
+        "pr-title-convention.yaml no longer publishes a 'Validate PR title' "
+        "check. With the per-commit gate gone, nothing validates the string "
+        "that becomes the squash subject — which drives both the changelog "
+        "and the release version bump."
+    )

--- a/.github/scripts/tests/test_conventional_commits_gates.py
+++ b/.github/scripts/tests/test_conventional_commits_gates.py
@@ -252,6 +252,9 @@ _TITLE_GUARD = _REPO_ROOT / ".github/workflows/pr-title-convention.yaml"
 
 
 def test_pr_checks_does_not_gate_individual_commit_subjects() -> None:
+    """Tripwire for the string form plus a structural check on the jobs: a
+    per-commit gate reintroduced as a shell `run:` step (no action name to
+    match) must still fail here."""
     body = _PR_CHECKS.read_text(encoding="utf-8")
     assert "action-conventional-commits" not in body, (
         "PR Checks gates every commit subject on the branch again. Those "
@@ -259,15 +262,43 @@ def test_pr_checks_does_not_gate_individual_commit_subjects() -> None:
         "a PR whose merged history would have been fine. Gate the PR title "
         "instead — pr-title-convention.yaml already does."
     )
+    for job_id, job in _load(_PR_CHECKS)["jobs"].items():
+        assert "conventional-commit" not in job_id.lower(), (
+            f"PR Checks job {job_id!r} reintroduces a per-commit convention "
+            "gate. Branch commit subjects are dropped by the squash merge — "
+            "gate the PR title instead (pr-title-convention.yaml already does)."
+        )
+        assert "conventional-commit" not in str(job.get("name", "")).lower(), (
+            f"PR Checks job {job_id!r} is named {job['name']!r}, reintroducing "
+            "a per-commit convention gate. Gate the PR title instead."
+        )
 
 
 def test_the_pr_title_is_still_gated() -> None:
-    """The removal above is conditional on this check existing."""
-    jobs = _load(_TITLE_GUARD)["jobs"]
+    """The removal above is conditional on this check existing — and actually
+    running: a workflow that kept the job name while losing its trigger or its
+    validation steps would leave nothing policing the squash subject."""
+    guard = _load(_TITLE_GUARD)
+    jobs = guard["jobs"]
     names = {job.get("name") for job in jobs.values()}
     assert "Validate PR title" in names, (
         "pr-title-convention.yaml no longer publishes a 'Validate PR title' "
         "check. With the per-commit gate gone, nothing validates the string "
         "that becomes the squash subject — which drives both the changelog "
         "and the release version bump."
+    )
+    triggers = guard.get("on", guard.get(True))
+    assert triggers is not None and "pull_request" in triggers, (
+        "pr-title-convention.yaml no longer triggers on pull_request, so the "
+        "'Validate PR title' job above would never run for a PR."
+    )
+    job = next(job for job in jobs.values() if job.get("name") == "Validate PR title")
+    step_names = [step.get("name") for step in job.get("steps", [])]
+    assert "Validate PR title against changed files" in step_names, (
+        "The 'Validate PR title' job lost its validation step — the check "
+        "would pass every title."
+    )
+    assert "Fail on invalid PR title" in step_names, (
+        "The 'Validate PR title' job lost its fail step — a violation would "
+        "no longer turn the check red."
     )

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -102,38 +102,21 @@ jobs:
           fi
           python3 .github/scripts/sdk_changes_non_md.py
 
-  # Required status check — the JOB has no `if:` so it always runs and always
-  # concludes. The real validation step is gated to PR (non-fork) events: the
-  # webiny action needs ORG_PAT_GITHUB, which fork PRs don't get, and merge_group
-  # entries have no PR commits to inspect. On those paths a no-op success step
-  # keeps the required context green instead of leaving it "skipped" (which would
-  # block fork PRs / the merge queue). The PR title — which becomes the squash
-  # commit subject — is independently enforced by "Validate PR title".
-  commits:
-    name: Conventional Commits
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork != true
-        with:
-          fetch-depth: 0
-      - name: Mint fleet App token
-        id: app-token
-        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork != true
-        continue-on-error: true
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
-        with:
-          app-id: ${{ secrets.FLEET_APP_ID }}
-          private-key: ${{ secrets.FLEET_APP_PRIVATE_KEY }}
-          owner: atlanhq
-          repositories: ${{ github.event.repository.name }}
-      - uses: webiny/action-conventional-commits@7f91b1595ca1951cdb671ddc9f07a49081ec5b69 # v1.4.2
-        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork != true
-        with:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token || secrets.ORG_PAT_GITHUB }}
-      - name: Skip on fork PR / merge_group
-        if: github.event_name == 'merge_group' || github.event.pull_request.head.repo.fork == true
-        run: echo "Commit-convention check not applicable here (fork PR or merge_group); PR title is enforced by Validate PR title."
+  # There is deliberately NO per-commit convention check here. This repo is
+  # squash-merge-only (`allow_squash_merge` is the only method enabled) with
+  # `squash_merge_commit_title: PR_TITLE` and `squash_merge_commit_message:
+  # BLANK`, so the branch's individual commit subjects are discarded at merge
+  # and never reach main. A gate on them polices text that cannot appear in the
+  # history, the changelog, or the release-version bump — all three of which
+  # read squash subjects, i.e. PR titles.
+  #
+  # The string that DOES survive is enforced, by two checks:
+  #   * "Validate PR title" (pr-title-convention.yaml) — this repo's own
+  #     path-aware rules, which are stricter than plain conventional commits
+  #     because the title drives which component's release/changelog a merge
+  #     lands in (application_sdk/ vs contract-toolkit/ vs packages/conformance/).
+  #   * the fleet's commits.yaml reusable — the path-agnostic grammar guard the
+  #     connector repos call. Not used here; this repo has the stricter one.
 
   docstr:
     name: Docstring Coverage
@@ -197,7 +180,7 @@ jobs:
 
   # NOTE: SDK unit / integration / storage-emulator tests moved to
   # sdk-tests-reusable.yaml and now run under the composing sdk-gate.yaml.
-  # The orthogonal checks below (commits, docstring coverage, Trivy scans) and
+  # The orthogonal checks below (docstring coverage, Trivy scans) and
   # the connector e2e dispatch stay here.
 
   matrix-builder:

--- a/docs/standards/commits.md
+++ b/docs/standards/commits.md
@@ -111,6 +111,28 @@ This reverts commit abc123def456.
 - **Review the diff**: Always review your changes before committing
 - **Scan before pushing**: For Dockerfile or dependency changes, run security scans before pushing (see [build-security.md](build-security.md))
 
+## What CI enforces
+
+CI gates the **PR title**, not the individual commits on your branch.
+
+This repo is squash-merge-only, and the squash subject is the PR title (the
+squash body is left blank), so your branch's commit subjects are discarded at
+merge. The PR title is the only string that reaches `main` — and the only one
+`update_changelog.py` and `release.py` read. Gate it, and the history, the
+changelog, and the version bump all follow.
+
+- **`Validate PR title`** (`.github/workflows/pr-title-convention.yaml`) is the
+  required check. Its rules are stricter than plain conventional commits: the
+  allowed type depends on which component the PR touches, because the title
+  decides which changelog and which release a merge lands in. The rules are
+  documented at the top of that workflow.
+- Connector and app repos get the general, path-agnostic grammar guard instead,
+  via the `.github/workflows/commits.yaml` reusable in this repo.
+
+The format above still applies to your commits — it keeps `git log` on a branch
+readable and makes a commit easy to lift into a title — but nothing fails a
+build over it.
+
 ## Tools
 
 Consider using tools to help enforce conventional commits:


### PR DESCRIPTION
## What

Removes the `Conventional Commits` job from `PR Checks`. Keeps — and documents — the PR-title guard that actually matters.

## Why

`application-sdk` is squash-merge-only:

| setting | value |
|---|---|
| `allow_squash_merge` | `true` (the only method enabled) |
| `squash_merge_commit_title` | `PR_TITLE` |
| `squash_merge_commit_message` | `BLANK` |

So a branch's individual commit subjects are **discarded at merge**. They never reach `main`, the changelog, or the version bump. The `Conventional Commits` job gated exactly those subjects — it could only ever block a PR whose merged history would have been fine.

That is not hypothetical: #3247 had the correct title `ci(fix): build ARM images on native ARM machine` and sat red on a WIP commit subject.

## What still gates the string that survives

Everything downstream reads the squash subject, which is the PR title — `update_changelog.py` files it into a changelog section, `release.py` derives the semver bump from it. Two checks cover it, both unchanged by this PR:

- **`Validate PR title`** (`pr-title-convention.yaml`) — this repo's own guard, and *stricter* than plain conventional commits: the allowed type depends on which component the PR touches, because the title decides which changelog and which release a merge lands in.
- **`commits.yaml`** — the path-agnostic reusable the connector/app fleet calls. Unaffected by this PR; those repos already check the PR title, not commits.

## Merge order — please read

`Conventional Commits` is currently a **required status check** on `main`. Once this merges the job no longer exists, so the context never reports.

**Drop it from the ruleset before merging this PR**, otherwise this PR (and every other open one) sits pending forever rather than failing.

## Tests

`test_conventional_commits_gates.py` gains two guards, so the trade is pinned rather than left to a comment:

- `test_pr_checks_does_not_gate_individual_commit_subjects` — the per-commit gate cannot silently come back.
- `test_the_pr_title_is_still_gated` — the removal is only safe while `Validate PR title` exists, so removing *that* now fails here.

`docs/standards/commits.md` gains a "What CI enforces" section stating that the convention still applies to commits as a style guide, but only the PR title is gated.

## Separately

`pr_title_convention.py` has an unrelated hole: zone `sdk` (any PR touching `application_sdk/`) returns "no restriction", so a malformed title like `nativebuild` passes and lands verbatim in the changelog. Not touched here — flagging it for a follow-up.
