### PR TITLE
ci(base-image): build app-runtime-base natively per architecture

### DIFF
--- a/.github/scripts/create_multiarch_manifest.py
+++ b/.github/scripts/create_multiarch_manifest.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Combine per-architecture images into a manifest list under each target tag.
+
+The image builds in this repo run one architecture per job, on a runner native
+to it, because emulating the other half under QEMU costs 5-10x. That leaves two
+single-arch images that nothing can pull by the real tag until they are joined
+into a manifest list — this is the join.
+
+``docker buildx imagetools create`` copies the source manifests (and any blobs
+the target registry is missing) and writes an index referencing them. The index
+bytes are a function of the child digests alone, so pushing the same sources to
+two registries yields the SAME index digest in both — the cross-registry digest
+parity that ``docs/standards/build-security.md`` promises for
+``app-runtime-base``, and that ``resolve_base_redirect.py`` fails closed on.
+
+Targets are grouped by repository and one ``create`` is issued per repository
+with every tag of that repository attached. Grouping matters: a single call
+mixing repositories would re-copy the blobs once per name, and on a
+cross-registry ladder that is the whole image re-uploaded several times over.
+
+Exits non-zero if any ``docker`` invocation fails. The push is NOT transactional
+across repositories — see the recovery note in build-security.md.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from collections import OrderedDict
+
+
+def run(cmd: list) -> None:
+    """Execute *cmd* and raise on non-zero exit.
+
+    A single thin wrapper so tests can monkeypatch the external ``docker`` call
+    while letting the grouping logic run for real.
+    """
+    print(f"$ {' '.join(cmd)}")
+    subprocess.run(cmd, check=True)
+
+
+def parse_tags(tags: str) -> list:
+    """Split a newline-delimited tag list, dropping blank lines.
+
+    The workflow passes this straight from a job output, which round-trips
+    through a heredoc and so tends to carry a trailing newline.
+    """
+    return [line.strip() for line in tags.splitlines() if line.strip()]
+
+
+def group_by_repo(tags: list) -> "OrderedDict[str, list]":
+    """Map ``repo -> [full tag, ...]``, preserving first-seen repo order.
+
+    A reference is ``<repo>:<tag>`` where the repo may itself contain a colon
+    (a registry port, e.g. ``localhost:5000/x:1``), so the split is on the LAST
+    colon — and only when it appears after the final ``/``.
+    """
+    grouped: "OrderedDict[str, list]" = OrderedDict()
+    for ref in tags:
+        repo, sep, tag = ref.rpartition(":")
+        if not sep or "/" in tag:
+            raise ValueError(f"not a tagged reference: {ref!r}")
+        grouped.setdefault(repo, []).append(ref)
+    return grouped
+
+
+def create_manifests(tags: list, sources: list) -> list:
+    """Issue one ``imagetools create`` per repository. Returns the commands run."""
+    if not sources:
+        raise ValueError("at least one --source is required")
+    if not tags:
+        raise ValueError("at least one tag is required")
+
+    commands = []
+    for repo, refs in group_by_repo(tags).items():
+        cmd = ["docker", "buildx", "imagetools", "create"]
+        for ref in refs:
+            cmd += ["--tag", ref]
+        cmd += list(sources)
+        print(f"Creating manifest list in {repo} for {len(refs)} tag(s)")
+        run(cmd)
+        commands.append(cmd)
+    return commands
+
+
+def inspect(tags: list) -> None:
+    """Print the resulting index for each tag, so the log shows both platforms."""
+    for ref in tags:
+        run(["docker", "buildx", "imagetools", "inspect", ref])
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--tags",
+        required=True,
+        help="Newline-delimited target references to create the manifest under.",
+    )
+    parser.add_argument(
+        "--source",
+        action="append",
+        default=[],
+        required=True,
+        help="A per-arch image reference. Repeat once per architecture.",
+    )
+    parser.add_argument(
+        "--inspect",
+        action="store_true",
+        help="Print the resulting index for every tag after creating it.",
+    )
+    args = parser.parse_args()
+
+    tags = parse_tags(args.tags)
+    try:
+        create_manifests(tags, args.source)
+    except (ValueError, subprocess.CalledProcessError) as exc:
+        print(f"::error::{exc}", file=sys.stderr)
+        return 1
+
+    if args.inspect:
+        inspect(tags)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/harbor_release_tags.py
+++ b/.github/scripts/harbor_release_tags.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Compute the ``app-runtime-base`` tag ladder for a Harbor/GHCR release.
+
+Lifted verbatim out of the inline shell in
+``.github/workflows/harbor-release.yaml``: the tag-prefix branch and the
+event-dependent ladder are both `if`/`else` chains, which
+``docs/standards/ci.md`` keeps out of workflow ``run:`` blocks so they can be
+regression-tested. Behaviour is unchanged from that shell.
+
+Two decisions live here.
+
+**The prefix** labels non-release builds:
+
+* ``release`` event -> always ``main``. Release image tags are the version
+  ladder below, never prefix-scoped, so the prefix is only a label.
+* explicit ``--tag-prefix-input`` -> used as given, after a charset check. A
+  prefix reaches a registry reference, so anything outside
+  ``[A-Za-z0-9._-]`` is rejected rather than sanitised: silently rewriting an
+  operator's input would publish a tag they did not ask for.
+* otherwise -> the branch name, with every other character collapsed to ``-``.
+
+**The ladder** is published to both registries (identical manifest, see
+``docs/standards/build-security.md``):
+
+* stable release -> ``:latest``, ``:X.Y.Z``, ``:X.Y``, ``:X``, ``:sha-<sha>``.
+* pre-release (any version containing ``-``, e.g. ``3.1.0-rc1``) -> ``:X.Y.Z``
+  and ``:sha-<sha>`` only. A pre-release must never advance ``:latest`` or the
+  floating major/minor aliases, which tenants resolve.
+* ``workflow_dispatch`` -> ``:<prefix>-latest``, ``:<prefix>-<version>``,
+  ``:sha-<sha>``.
+
+Writes ``tag_prefix``, ``version``, ``sha`` and the newline-delimited ``tags``
+to ``$GITHUB_OUTPUT`` (or stdout when unset).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import secrets
+import sys
+
+#: Registries that receive the identical manifest for every tag below.
+REPOS = (
+    "registry.atlan.com/public/app-runtime-base",
+    "ghcr.io/atlanhq/app-runtime-base",
+)
+
+#: Characters legal in a tag prefix. Matches the grep in the shell this replaces.
+_PREFIX_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+
+#: Length of the short SHA used in `:sha-<sha>`.
+_SHORT_SHA = 7
+
+
+class PrefixError(ValueError):
+    """An explicitly supplied ``--tag-prefix`` is not registry-safe."""
+
+
+def sanitize_branch(ref_name: str) -> str:
+    """Collapse every run of characters illegal in a tag into a single ``-``.
+
+    Mirrors ``tr -cs 'A-Za-z0-9._-' '-'``: `-s` squeezes repeats, so
+    ``feat/my branch`` becomes ``feat-my-branch``, not ``feat-my-branch``
+    with a doubled separator.
+    """
+    return re.sub(r"[^A-Za-z0-9._-]+", "-", ref_name)
+
+
+def resolve_prefix(event_name: str, tag_prefix_input: str, ref_name: str) -> str:
+    """Return the tag prefix for this run.
+
+    Raises:
+        PrefixError: ``tag_prefix_input`` contains characters that are not
+            legal in an image tag.
+    """
+    if event_name == "release":
+        return "main"
+    if tag_prefix_input:
+        if not _PREFIX_RE.match(tag_prefix_input):
+            raise PrefixError(
+                f"Invalid tag_prefix {tag_prefix_input!r}: must match ^[A-Za-z0-9._-]+$"
+            )
+        return tag_prefix_input
+    return sanitize_branch(ref_name)
+
+
+def is_prerelease(version: str) -> bool:
+    """A version carrying a pre-release segment, i.e. containing ``-``.
+
+    Matches the shell's ``grep -qvF '-'`` test rather than parsing semver:
+    the ladder only needs "does this advance the floating aliases or not".
+    """
+    return "-" in version
+
+
+def tag_suffixes(event_name: str, version: str, prefix: str, short_sha: str) -> list:
+    """Return the tag suffixes (the part after ``<repo>:``) for this run."""
+    sha_tag = f"sha-{short_sha}"
+    if event_name != "release":
+        return [f"{prefix}-latest", f"{prefix}-{version}", sha_tag]
+    if is_prerelease(version):
+        return [version, sha_tag]
+    major = version.split(".")[0]
+    minor = ".".join(version.split(".")[:2])
+    return ["latest", version, minor, major, sha_tag]
+
+
+def build_tags(event_name: str, version: str, prefix: str, short_sha: str) -> list:
+    """Return every fully-qualified tag, one repo's ladder after the other."""
+    suffixes = tag_suffixes(event_name, version, prefix, short_sha)
+    return [f"{repo}:{suffix}" for repo in REPOS for suffix in suffixes]
+
+
+def read_version(pyproject_path: str) -> str:
+    """Return the ``version = "..."`` value from a pyproject's top level.
+
+    Reads the first top-level ``version =`` assignment, which is what the
+    ``awk -F'"' '/^version = /'`` in the shell did — anchored at column 0, so
+    a ``version`` key nested inside a table is not matched.
+    """
+    with open(pyproject_path, encoding="utf-8") as fh:
+        for line in fh:
+            match = re.match(r'^version\s*=\s*"([^"]+)"', line)
+            if match:
+                return match.group(1)
+    raise ValueError(f'no top-level `version = "..."` found in {pyproject_path}')
+
+
+def _write_outputs(pairs: dict) -> None:
+    """Emit ``key=value`` pairs to $GITHUB_OUTPUT, heredoc-quoting multi-line ones."""
+    target = os.environ.get("GITHUB_OUTPUT")
+    lines = []
+    for key, value in pairs.items():
+        if "\n" in value:
+            delim = f"EOF_{secrets.token_hex(8)}"
+            lines.append(f"{key}<<{delim}\n{value}\n{delim}")
+        else:
+            lines.append(f"{key}={value}")
+    body = "\n".join(lines) + "\n"
+    if target:
+        with open(target, "a", encoding="utf-8") as fh:
+            fh.write(body)
+    else:
+        sys.stdout.write(body)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--event-name", required=True)
+    parser.add_argument("--ref-name", required=True)
+    parser.add_argument("--sha", required=True, help="Full commit SHA; truncated here.")
+    parser.add_argument("--tag-prefix", default="", help="Explicit prefix, if any.")
+    parser.add_argument("--pyproject", default="pyproject.toml")
+    args = parser.parse_args()
+
+    try:
+        prefix = resolve_prefix(args.event_name, args.tag_prefix, args.ref_name)
+    except PrefixError as exc:
+        print(f"::error::{exc}", file=sys.stderr)
+        return 1
+
+    version = read_version(args.pyproject)
+    short_sha = args.sha[:_SHORT_SHA]
+    tags = build_tags(args.event_name, version, prefix, short_sha)
+
+    print(f"Event: {args.event_name}  version: {version}  prefix: {prefix}")
+    print("Tags:")
+    for tag in tags:
+        print(f"  {tag}")
+
+    _write_outputs(
+        {
+            "tag_prefix": prefix,
+            "version": version,
+            "sha": short_sha,
+            "tags": "\n".join(tags),
+        }
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/tests/test_base_image_native_builds.py
+++ b/.github/scripts/tests/test_base_image_native_builds.py
@@ -1,0 +1,265 @@
+"""Guards for the native-per-architecture builds of `app-runtime-base`.
+
+Every property here fails SILENTLY if it regresses, which is the only reason
+these are tests rather than comments:
+
+* An emulated arm64 leg still succeeds. `platform: linux/arm64` on an x64
+  runner builds under QEMU and produces a correct image, several times slower.
+  A review sees a passing build and a one-word diff.
+* A clobbered build cache still succeeds. Two legs writing one unscoped
+  `type=gha` scope overwrite each other's manifest and both go cold on the next
+  run; the only symptom is time.
+* A shared concurrency group still succeeds. A job-level `concurrency` on a
+  matrix job resolves to the same key for every leg unless the matrix context
+  is in it, so one leg cancels the other and the merge job never finds both.
+
+The same properties on the *connector* image paths are pinned in
+test_build_app_image_action.py; this file covers the two workflows that publish
+the base image those paths build FROM.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import harbor_release_tags  # noqa: E402
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_HARBOR = _REPO_ROOT / ".github/workflows/harbor-release.yaml"
+_GHCR = _REPO_ROOT / ".github/workflows/build-image.yaml"
+
+#: (workflow path, build job, merge job) for each base-image publisher.
+_PUBLISHERS = (
+    pytest.param(_HARBOR, "build", "merge", id="harbor-release"),
+    pytest.param(_GHCR, "push-to-ghcr", "merge-ghcr", id="build-image"),
+)
+
+
+def _load(path: Path) -> dict:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def _job(path: Path, name: str) -> dict:
+    jobs = _load(path)["jobs"]
+    assert name in jobs, f"{path.name} has no job {name!r}; jobs are {sorted(jobs)}"
+    return jobs[name]
+
+
+def _legs(job: dict) -> dict:
+    """Return ``{arch: matrix leg}`` for a build job."""
+    include = job["strategy"]["matrix"]["include"]
+    return {leg["arch"]: leg for leg in include}
+
+
+def _step_with(job: dict, needle: str) -> dict:
+    for step in job["steps"]:
+        if needle in str(step.get("uses", "")) or needle in str(step.get("name", "")):
+            return step
+    raise AssertionError(f"no step matching {needle!r} in job")
+
+
+# ── Native runners ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("path, build, _merge", _PUBLISHERS)
+def test_each_architecture_builds_on_a_runner_native_to_it(
+    path: Path, build: str, _merge: str
+) -> None:
+    job = _job(path, build)
+    assert job["runs-on"] == "${{ matrix.runner }}", (
+        f"{path.name}:{build} pins a single runner, so one architecture is "
+        "emulated. The runner must come from the matrix."
+    )
+
+    legs = _legs(job)
+    assert set(legs) == {"amd64", "arm64"}, (
+        f"{path.name} publishes {sorted(legs)}. The base image needs BOTH: "
+        "arm64 for tenant nodes, amd64 for CI and local development. Dropping "
+        "one retargets the image rather than speeding it up."
+    )
+
+    for arch, leg in legs.items():
+        assert leg["platform"] == f"linux/{arch}", (
+            f"the {arch} leg builds {leg['platform']!r} — the arch label and the "
+            "platform have drifted, so the tag says one thing and the image is "
+            "another."
+        )
+
+    assert "arm" in legs["arm64"]["runner"], (
+        f"the arm64 leg runs on {legs['arm64']['runner']!r}, which is not an ARM "
+        "runner — that build is emulated. Use `ubuntu-24.04-arm`."
+    )
+    assert "arm" not in legs["amd64"]["runner"]
+
+
+@pytest.mark.parametrize("path, build, _merge", _PUBLISHERS)
+def test_a_failing_architecture_does_not_cancel_the_other(
+    path: Path, build: str, _merge: str
+) -> None:
+    """Whether ONE arch or BOTH broke is the entire diagnosis."""
+    assert _job(path, build)["strategy"]["fail-fast"] is False
+
+
+# ── The legs do not collide ──────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("path, build, _merge", _PUBLISHERS)
+def test_the_legs_do_not_share_a_build_cache_scope(
+    path: Path, build: str, _merge: str
+) -> None:
+    """secure-build-push-apps defaults to an unscoped `type=gha`."""
+    build_step = _step_with(_job(path, build), "secure-build-push-apps")
+    for key in ("cache-from", "cache-to"):
+        value = build_step["with"].get(key, "")
+        assert "scope=" in value, (
+            f"{path.name}:{build} leaves `{key}` unscoped, so the two legs "
+            "overwrite each other's cache manifest and both go cold — visible "
+            "only as build time."
+        )
+        assert "matrix.platform" in value or "matrix.arch" in value, (
+            f"{path.name}:{build} scopes `{key}` to a constant, which is the "
+            "same collision with extra steps."
+        )
+
+
+@pytest.mark.parametrize("path, build, _merge", _PUBLISHERS)
+def test_the_legs_do_not_share_a_concurrency_group(
+    path: Path, build: str, _merge: str
+) -> None:
+    job = _job(path, build)
+    group = job.get("concurrency", {}).get("group")
+    if group is None:
+        pytest.skip("job declares no concurrency group")
+    assert "matrix.arch" in group or "matrix.platform" in group, (
+        f"{path.name}:{build} shares one concurrency group across the matrix, "
+        "so the legs cancel each other and only one architecture is ever "
+        "pushed. Put the matrix context in the group key."
+    )
+
+
+@pytest.mark.parametrize("path, build, _merge", _PUBLISHERS)
+def test_the_legs_do_not_share_a_tag(path: Path, build: str, _merge: str) -> None:
+    """Both legs pushing one tag means whichever finishes last wins and the
+    published image is single-arch — with no error anywhere."""
+    build_step = _step_with(_job(path, build), "secure-build-push-apps")
+    tags = str(build_step["with"]["tags"])
+    assert (
+        "matrix.arch" in tags or "matrix.platform" in tags
+    ), f"{path.name}:{build} pushes both architectures to the same tag."
+
+
+# ── The merge job puts them back together ────────────────────────────────────
+
+
+@pytest.mark.parametrize("path, build, merge", _PUBLISHERS)
+def test_a_merge_job_waits_for_every_build_leg(
+    path: Path, build: str, merge: str
+) -> None:
+    """Without this the per-arch tags are all that is ever published, and every
+    consumer's `FROM` fails on `no match for platform in manifest`."""
+    needs = _job(path, merge)["needs"]
+    needs = [needs] if isinstance(needs, str) else needs
+    assert build in needs, f"{path.name}:{merge} does not wait for {build!r}"
+
+
+@pytest.mark.parametrize("path, build, merge", _PUBLISHERS)
+def test_the_merge_job_combines_both_architectures(
+    path: Path, build: str, merge: str
+) -> None:
+    body = yaml.dump(_job(path, merge))
+    assert "amd64" in body and "arm64" in body, (
+        f"{path.name}:{merge} does not reference both per-arch images, so the "
+        "manifest it publishes cannot be multi-arch."
+    )
+
+
+# ── The published ladder still reaches both registries ───────────────────────
+
+
+def test_harbor_release_still_publishes_to_both_registries() -> None:
+    """The GHCR mirror is what keeps app CI off Harbor's S3 egress. Losing it
+    is a cost regression that nothing else reports."""
+    registries = {repo.split("/")[0] for repo in harbor_release_tags.REPOS}
+    assert registries == {"registry.atlan.com", "ghcr.io"}
+
+
+def test_only_the_merge_job_holds_the_harbor_credential() -> None:
+    """The per-arch legs push half-images. Harbor's project is the public,
+    partner-facing catalog, so it must never see an `-amd64` tag — the build
+    legs simply cannot reach it."""
+    build_job = yaml.dump(_job(_HARBOR, "build"))
+    merge_job = yaml.dump(_job(_HARBOR, "merge"))
+    assert "HARBOR_PASSWORD" not in build_job, (
+        "the per-arch build job can log in to Harbor. It pushes arch-suffixed "
+        "staging tags, which do not belong in the public catalog."
+    )
+    assert "HARBOR_PASSWORD" in merge_job
+
+
+def test_the_staging_tags_the_merge_reads_are_the_ones_the_build_wrote() -> None:
+    """These are two separate expressions in two jobs; if they drift, the merge
+    fails on a missing manifest at release time and nowhere earlier."""
+    workflow = _load(_HARBOR)
+    prepare_outputs = workflow["jobs"]["prepare"]["outputs"]
+    assert "staging_base" in prepare_outputs, (
+        "the staging repository is no longer a shared output, so the build and "
+        "merge jobs each spell it out and can drift apart."
+    )
+
+    build_tags = str(
+        _step_with(_job(_HARBOR, "build"), "secure-build-push-apps")["with"]["tags"]
+    )
+    merge_body = yaml.dump(_job(_HARBOR, "merge"))
+    for fragment in ("staging_base", "outputs.sha"):
+        assert fragment in build_tags, f"build tag lost {fragment!r}"
+        assert fragment in merge_body, f"merge source lost {fragment!r}"
+
+
+# ── Coverage ─────────────────────────────────────────────────────────────────
+
+
+#: Workflows that reference `app-runtime-base` but only CONSUME it — they pull,
+#: scan, or read the tag rather than producing it. Reviewed by hand; the test
+#: below fails when a new workflow appears so the classification is a decision
+#: someone makes, not one the test makes for itself.
+_CONSUMERS_ONLY = frozenset(
+    {
+        # Builds app images FROM the base; per-arch native runners are pinned in
+        # test_build_app_image_action.py, not here.
+        "build-and-publish-app.yaml",
+        "pull_request.yaml",
+        # Read the tag / scan the published image.
+        "check-dapr-version.yaml",
+        "daily-security-scan.yml",
+        "update-dashboard.yaml",
+        "v3-readiness-check.yaml",
+        "vuln-reconcile-on-release.yml",
+    }
+)
+
+
+def test_every_base_image_publisher_is_covered() -> None:
+    """A third workflow publishing app-runtime-base could otherwise emulate
+    freely. Anchors the parametrisation to the tree rather than to itself."""
+    referencing = {
+        path.name
+        for path in (_REPO_ROOT / ".github/workflows").glob("*.y*ml")
+        if "app-runtime-base" in path.read_text(encoding="utf-8")
+    }
+
+    unclassified = referencing - {_HARBOR.name, _GHCR.name} - _CONSUMERS_ONLY
+    assert not unclassified, (
+        f"{sorted(unclassified)} reference app-runtime-base and are classified "
+        "neither way. If one PUBLISHES the base image, add it to _PUBLISHERS so "
+        "its runners are checked; if it only consumes it, add it to "
+        "_CONSUMERS_ONLY."
+    )
+
+    stale = _CONSUMERS_ONLY - referencing
+    assert not stale, f"_CONSUMERS_ONLY lists workflows that are gone: {sorted(stale)}"

--- a/.github/scripts/tests/test_create_multiarch_manifest.py
+++ b/.github/scripts/tests/test_create_multiarch_manifest.py
@@ -1,0 +1,147 @@
+"""Tests for .github/scripts/create_multiarch_manifest.py.
+
+The join between the per-arch builds and what anyone actually pulls. The
+properties worth pinning are the ones whose failure is invisible in a green
+run: a tag silently left off the index, or the whole image re-uploaded once per
+name because the targets were not grouped.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import create_multiarch_manifest as mod  # noqa: E402
+
+HARBOR = "registry.atlan.com/public/app-runtime-base"
+GHCR = "ghcr.io/atlanhq/app-runtime-base"
+SOURCES = [f"{GHCR}:sha-abc1234-amd64", f"{GHCR}:sha-abc1234-arm64"]
+
+
+@pytest.fixture()
+def calls(monkeypatch: pytest.MonkeyPatch) -> list:
+    """Capture the docker invocations instead of running them."""
+    recorded: list = []
+    monkeypatch.setattr(mod, "run", lambda cmd: recorded.append(list(cmd)))
+    return recorded
+
+
+# ── Grouping ─────────────────────────────────────────────────────────────────
+
+
+def test_one_create_per_repository(calls: list) -> None:
+    """Not one per tag. A ladder of five tags across two registries is two
+    calls; ten would re-copy the image eight extra times."""
+    tags = [f"{HARBOR}:latest", f"{HARBOR}:3", f"{GHCR}:latest", f"{GHCR}:3"]
+    mod.create_manifests(tags, SOURCES)
+    assert len(calls) == 2
+
+
+def test_every_tag_reaches_the_index(calls: list) -> None:
+    """A dropped tag is invisible: the job stays green and the alias simply
+    keeps pointing at the previous release."""
+    tags = [f"{HARBOR}:latest", f"{HARBOR}:3.1.4", f"{HARBOR}:3.1", f"{GHCR}:latest"]
+    mod.create_manifests(tags, SOURCES)
+
+    tagged = [
+        arg for cmd in calls for arg, flag in zip(cmd[1:], cmd) if flag == "--tag"
+    ]
+    assert sorted(tagged) == sorted(tags)
+
+
+def test_both_architectures_are_passed_as_sources(calls: list) -> None:
+    """One source would produce a single-arch index that still pulls fine on
+    the runner that built it — and fails on the tenant's node."""
+    mod.create_manifests([f"{HARBOR}:latest"], SOURCES)
+    assert calls[0][-2:] == SOURCES
+
+
+def test_sources_come_after_the_tag_flags(calls: list) -> None:
+    """`imagetools create [OPTIONS] [SOURCE...]` — a source before a --tag is
+    parsed as the flag's value."""
+    mod.create_manifests([f"{HARBOR}:latest", f"{HARBOR}:3"], SOURCES)
+    cmd = calls[0]
+    assert cmd.index("--tag") < cmd.index(SOURCES[0])
+
+
+def test_repository_order_follows_first_appearance(calls: list) -> None:
+    """Harbor first means a partial failure leaves the public catalog advanced
+    and GHCR behind — the direction build-security.md's recovery note assumes."""
+    tags = [f"{HARBOR}:latest", f"{GHCR}:latest", f"{HARBOR}:3"]
+    mod.create_manifests(tags, SOURCES)
+    assert calls[0][calls[0].index("--tag") + 1].startswith(HARBOR)
+    assert calls[1][calls[1].index("--tag") + 1].startswith(GHCR)
+
+
+def test_grouping_splits_on_the_tag_not_the_registry_port() -> None:
+    """`localhost:5000/x:1` has two colons; splitting on the first yields a
+    nonsense repo and would scatter one repo's tags across several calls."""
+    grouped = mod.group_by_repo(["localhost:5000/x:1", "localhost:5000/x:2"])
+    assert list(grouped) == ["localhost:5000/x"]
+
+
+def test_an_untagged_reference_is_rejected() -> None:
+    """Passing a bare repo to `create --tag` would publish `:latest` silently."""
+    with pytest.raises(ValueError):
+        mod.group_by_repo(["registry.atlan.com/public/app-runtime-base"])
+
+
+# ── Input handling ───────────────────────────────────────────────────────────
+
+
+def test_blank_lines_from_the_heredoc_are_dropped() -> None:
+    assert mod.parse_tags(f"{HARBOR}:latest\n\n  \n{GHCR}:latest\n") == [
+        f"{HARBOR}:latest",
+        f"{GHCR}:latest",
+    ]
+
+
+def test_no_tags_is_an_error() -> None:
+    """Silently doing nothing here means the release publishes no pullable tag."""
+    with pytest.raises(ValueError):
+        mod.create_manifests([], SOURCES)
+
+
+def test_no_sources_is_an_error() -> None:
+    with pytest.raises(ValueError):
+        mod.create_manifests([f"{HARBOR}:latest"], [])
+
+
+# ── Failure propagation ──────────────────────────────────────────────────────
+
+
+def test_a_docker_failure_is_not_swallowed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A half-published ladder must fail the job so the re-run path is taken."""
+
+    def boom(cmd: list) -> None:
+        raise subprocess.CalledProcessError(1, cmd)
+
+    monkeypatch.setattr(mod, "run", boom)
+    with pytest.raises(subprocess.CalledProcessError):
+        mod.create_manifests([f"{HARBOR}:latest"], SOURCES)
+
+
+def test_main_reports_a_docker_failure_as_a_nonzero_exit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def boom(cmd: list) -> None:
+        raise subprocess.CalledProcessError(1, cmd)
+
+    monkeypatch.setattr(mod, "run", boom)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "create_multiarch_manifest.py",
+            "--tags",
+            f"{HARBOR}:latest",
+            "--source",
+            SOURCES[0],
+        ],
+    )
+    assert mod.main() == 1

--- a/.github/scripts/tests/test_harbor_release_tags.py
+++ b/.github/scripts/tests/test_harbor_release_tags.py
@@ -1,0 +1,181 @@
+"""Tests for .github/scripts/harbor_release_tags.py.
+
+Covers the branching that used to be inlined in the *Compute tag prefix* and
+*Compute image tags* steps of harbor-release.yaml. The ladder decides what a
+tenant resolves `app-runtime-base:latest` (and `:3`, and `:3.1`) to, so the
+cases that matter most are the ones that must NOT advance those aliases.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import harbor_release_tags as mod  # noqa: E402
+
+HARBOR = "registry.atlan.com/public/app-runtime-base"
+GHCR = "ghcr.io/atlanhq/app-runtime-base"
+
+
+def _suffixes(tags: list, repo: str) -> list:
+    return [t.split(":", 1)[1] for t in tags if t.startswith(f"{repo}:")]
+
+
+# ── The prefix ───────────────────────────────────────────────────────────────
+
+
+def test_release_always_labels_itself_main() -> None:
+    """Release tags are the version ladder; the prefix is only a label."""
+    assert mod.resolve_prefix("release", "", "refs/tags/v3.1.0") == "main"
+
+
+def test_release_ignores_an_explicit_prefix() -> None:
+    """The `release` branch is checked first in the shell this replaces."""
+    assert mod.resolve_prefix("release", "someprefix", "main") == "main"
+
+
+def test_explicit_prefix_is_used_verbatim() -> None:
+    assert (
+        mod.resolve_prefix("workflow_dispatch", "refactor-v3", "main") == "refactor-v3"
+    )
+
+
+@pytest.mark.parametrize(
+    "bad",
+    ["has space", "slash/prefix", "semi;colon", "quote'", "dollar$", "at@sign"],
+)
+def test_an_unsafe_explicit_prefix_is_rejected_not_sanitised(bad: str) -> None:
+    """A prefix reaches a registry reference. Silently rewriting an operator's
+    input would publish a tag they did not ask for, so this fails instead."""
+    with pytest.raises(mod.PrefixError):
+        mod.resolve_prefix("workflow_dispatch", bad, "main")
+
+
+def test_branch_name_is_sanitised_when_no_prefix_given() -> None:
+    assert (
+        mod.resolve_prefix("workflow_dispatch", "", "feat/my branch")
+        == "feat-my-branch"
+    )
+
+
+def test_runs_of_illegal_characters_collapse_to_one_separator() -> None:
+    """`tr -cs` squeezes repeats; a naive per-character replace would not."""
+    assert mod.sanitize_branch("feat//my   branch") == "feat-my-branch"
+
+
+def test_a_legal_branch_name_is_untouched() -> None:
+    assert mod.sanitize_branch("release-3.1.0_rc") == "release-3.1.0_rc"
+
+
+# ── The ladder ───────────────────────────────────────────────────────────────
+
+
+def test_stable_release_publishes_the_full_alias_ladder() -> None:
+    tags = mod.build_tags("release", "3.1.4", "main", "abc1234")
+    assert _suffixes(tags, HARBOR) == [
+        "latest",
+        "3.1.4",
+        "3.1",
+        "3",
+        "sha-abc1234",
+    ]
+
+
+@pytest.mark.parametrize("version", ["3.1.0-rc1", "3.1.0-alpha.1", "4.0.0-beta"])
+def test_a_prerelease_never_advances_a_floating_alias(version: str) -> None:
+    """`:latest`, `:MAJOR` and `:MAJOR.MINOR` are what tenants resolve. A
+    pre-release moving any of them ships an unstable base fleet-wide."""
+    suffixes = _suffixes(mod.build_tags("release", version, "main", "abc1234"), HARBOR)
+    assert suffixes == [version, "sha-abc1234"]
+    assert "latest" not in suffixes
+    assert not any(s in {"3", "3.1", "4", "4.0"} for s in suffixes)
+
+
+def test_workflow_dispatch_scopes_every_alias_to_the_prefix() -> None:
+    """A dev build must not collide with the release ladder."""
+    suffixes = _suffixes(
+        mod.build_tags("workflow_dispatch", "3.1.4", "refactor-v3", "abc1234"), HARBOR
+    )
+    assert suffixes == ["refactor-v3-latest", "refactor-v3-3.1.4", "sha-abc1234"]
+    assert "latest" not in suffixes
+
+
+def test_both_registries_get_an_identical_ladder() -> None:
+    """The two registries must be interchangeable for a given tag — that is the
+    whole premise of the GHCR base redirect in build-and-publish-app.yaml."""
+    tags = mod.build_tags("release", "3.1.4", "main", "abc1234")
+    assert _suffixes(tags, HARBOR) == _suffixes(tags, GHCR)
+
+
+def test_harbor_and_ghcr_are_the_only_targets() -> None:
+    assert set(mod.REPOS) == {HARBOR, GHCR}
+
+
+@pytest.mark.parametrize(
+    "version, prerelease",
+    [("3.1.4", False), ("3.1.0-rc1", True), ("0.0.1", False), ("1.0.0-x", True)],
+)
+def test_prerelease_detection(version: str, prerelease: bool) -> None:
+    assert mod.is_prerelease(version) is prerelease
+
+
+def test_the_sha_tag_is_always_present() -> None:
+    """The only immutable reference in the ladder — the recovery path in
+    build-security.md depends on it existing for every event."""
+    for event, version in [
+        ("release", "3.1.4"),
+        ("release", "3.1.4-rc1"),
+        ("workflow_dispatch", "3.1.4"),
+    ]:
+        suffixes = _suffixes(mod.build_tags(event, version, "p", "abc1234"), HARBOR)
+        assert "sha-abc1234" in suffixes
+
+
+# ── Version discovery ────────────────────────────────────────────────────────
+
+
+def test_version_is_read_from_the_top_level_of_pyproject(tmp_path: Path) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text('[project]\nname = "x"\nversion = "3.1.4"\n', encoding="utf-8")
+    assert mod.read_version(str(pyproject)) == "3.1.4"
+
+
+def test_an_indented_version_key_is_not_mistaken_for_the_project_version(
+    tmp_path: Path,
+) -> None:
+    """The awk this replaces anchored at column 0. A nested table's `version`
+    would otherwise win and tag the release with a dependency's number."""
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        '[tool.other]\n  version = "9.9.9"\n\nversion = "3.1.4"\n', encoding="utf-8"
+    )
+    assert mod.read_version(str(pyproject)) == "3.1.4"
+
+
+def test_a_pyproject_without_a_version_is_an_error(tmp_path: Path) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text('[project]\nname = "x"\n', encoding="utf-8")
+    with pytest.raises(ValueError):
+        mod.read_version(str(pyproject))
+
+
+# ── Output plumbing ──────────────────────────────────────────────────────────
+
+
+def test_the_multiline_tag_list_is_heredoc_quoted(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A bare `tags=<multi-line>` truncates at the first newline, so the merge
+    job would create the manifest under only the first tag."""
+    out = tmp_path / "out.txt"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(out))
+    mod._write_outputs({"tag_prefix": "main", "tags": "a\nb\nc"})
+
+    body = out.read_text(encoding="utf-8")
+    assert "tag_prefix=main" in body
+    assert "tags<<EOF_" in body
+    assert "\na\nb\nc\n" in body

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -39,11 +39,41 @@ jobs:
         shell: bash
         run: echo "sha=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
 
+  # ONE ARCHITECTURE PER JOB, EACH ON A RUNNER NATIVE TO IT.
+  #
+  # This job used to be a single `ubuntu-latest` build with
+  # `platforms: linux/amd64,linux/arm64`, which builds the arm64 half under
+  # QEMU — measured across the org at 5-10x native, and already designed
+  # against on this repo's other image paths (pull_request.yaml's
+  # build-sdk-base-image, tests-reusable.yaml's build-e2e-image). Two native
+  # jobs in parallel cost about one build; one job emulating costs several.
+  #
+  # The emulated leg never fails, it is only slow, so nothing here reports the
+  # regression if a future edit collapses the matrix back onto ubuntu-latest.
+  # test_base_image_native_builds pins the pairing instead.
   push-to-ghcr:
-    runs-on: ubuntu-latest
+    name: Build (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
     needs: prepare
+    strategy:
+      # Knowing whether ONE arch or BOTH failed is the diagnosis when a build
+      # breaks on an architecture rather than in general.
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            platform: linux/amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            platform: linux/arm64
+            # NOT ubuntu-latest — see the note above the job.
+            runner: ubuntu-24.04-arm
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}-ghcr
+      # The arch is part of the group on purpose. A job-level `concurrency` on a
+      # matrix job resolves to the SAME group for every leg unless the matrix
+      # context is in the key, so without `${{ matrix.arch }}` the two legs
+      # would cancel each other and only one arch would ever be pushed.
+      group: ${{ github.workflow }}-${{ github.ref }}-ghcr-${{ matrix.arch }}
       cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
     timeout-minutes: 20
     steps:
@@ -77,9 +107,18 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.platform }}
+          # The action defaults to an UNSCOPED `type=gha`. With one job that was
+          # fine; with two, both legs would write the same cache manifest, each
+          # overwriting the other, and both would go cold on every later run —
+          # silently, since a cache miss only costs time. `mode=min` matches the
+          # action's own default: this change is about where the build runs, not
+          # about how much of it is cached.
+          cache-from: type=gha,scope=${{ matrix.platform }}
+          cache-to: type=gha,mode=min,scope=${{ matrix.platform }}
+          # Arch-suffixed — merged into the real tag by merge-ghcr below.
           tags: |
-            ghcr.io/atlanhq/app-runtime-base-${{ needs.prepare.outputs.lowercase_branch }}:sha-${{ needs.prepare.outputs.sha }}
+            ghcr.io/atlanhq/app-runtime-base-${{ needs.prepare.outputs.lowercase_branch }}:sha-${{ needs.prepare.outputs.sha }}-${{ matrix.arch }}
           build-args: |
             ACCESS_TOKEN_USR=$GITHUB_ACTOR
             ACCESS_TOKEN_PWD=${{ secrets.ORG_PAT_GITHUB }}
@@ -90,3 +129,34 @@ jobs:
         env:
           DOCKER_CLIENT_TIMEOUT: 600
           COMPOSE_HTTP_TIMEOUT: 600
+
+  # Combines the two arch images into the manifest list consumers actually pull.
+  # Until this job runs, `:sha-<sha>` does not exist — only `:sha-<sha>-amd64`
+  # and `:sha-<sha>-arm64` do.
+  merge-ghcr:
+    name: Merge & Push Manifest
+    runs-on: ubuntu-latest
+    needs: [prepare, push-to-ghcr]
+    timeout-minutes: 10
+    steps:
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+
+      - name: Login to GitHub Registry
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.ORG_PAT_GITHUB }}
+
+      - name: Create and push multi-arch manifest
+        env:
+          IMAGE: ghcr.io/atlanhq/app-runtime-base-${{ needs.prepare.outputs.lowercase_branch }}:sha-${{ needs.prepare.outputs.sha }}
+        run: |
+          set -euo pipefail
+          docker buildx imagetools create \
+            --tag "${IMAGE}" \
+            "${IMAGE}-amd64" \
+            "${IMAGE}-arm64"
+          echo "Multi-arch manifest pushed: ${IMAGE}"
+          docker buildx imagetools inspect "${IMAGE}"

--- a/.github/workflows/harbor-release.yaml
+++ b/.github/workflows/harbor-release.yaml
@@ -1,3 +1,32 @@
+# Publishes `app-runtime-base` — the image every Atlan app Dockerfile builds
+# FROM — to Harbor and GHCR under an identical manifest digest.
+#
+# ONE ARCHITECTURE PER JOB, EACH ON A RUNNER NATIVE TO IT.
+#
+# This was a single `ubuntu-latest` job with
+# `platforms: linux/amd64,linux/arm64`, which builds the arm64 half under QEMU
+# — measured across the org at 5-10x native, and already designed against on
+# this repo's other image paths (pull_request.yaml's build-sdk-base-image,
+# tests-reusable.yaml's build-e2e-image). An emulated leg never fails, it is
+# only slow, so nothing reports the regression if a future edit collapses the
+# matrix back onto ubuntu-latest; test_base_image_native_builds pins it.
+#
+# Splitting the build means the two registries can no longer be fed by one
+# `buildx --push`. The shape is now build -> merge:
+#
+#   prepare  computes the tag ladder (harbor_release_tags.py).
+#   build    per-arch, native. Pushes ONLY arch-suffixed staging tags, and only
+#            to GHCR — Harbor's project is the public, partner-facing catalog
+#            and must not accumulate `-amd64`/`-arm64` half-images.
+#   merge    joins the two staging images into an index and writes it under
+#            every ladder tag on BOTH registries
+#            (create_multiarch_manifest.py).
+#
+# Digest parity survives that change: an index's bytes are a function of its
+# child digests, so the same two children pushed to two registries produce the
+# same index digest. resolve_base_redirect.py fails closed on any skew, and
+# docs/standards/build-security.md documents the property and the recovery.
+
 name: Publish Harbor Image (Release)
 
 on:
@@ -14,12 +43,61 @@ permissions:
   actions: read
 
 jobs:
-  push-to-harbor:
+  prepare:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      tag_prefix: ${{ steps.tags.outputs.tag_prefix }}
+      version: ${{ steps.tags.outputs.version }}
+      sha: ${{ steps.tags.outputs.sha }}
+      tags: ${{ steps.tags.outputs.tags }}
+      staging_base: ghcr.io/atlanhq/app-runtime-base
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      # The prefix branch and the release/pre-release/dispatch ladder were both
+      # inline `if`/`else` shell. docs/standards/ci.md keeps that out of `run:`
+      # blocks so it can be regression-tested — see
+      # tests/test_harbor_release_tags.py.
+      - name: Compute image tags
+        id: tags
+        env:
+          TAG_PREFIX_INPUT: ${{ inputs.tag_prefix }}
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/harbor_release_tags.py \
+            --event-name "${{ github.event_name }}" \
+            --ref-name "${GITHUB_REF_NAME}" \
+            --sha "${GITHUB_SHA}" \
+            --tag-prefix "${TAG_PREFIX_INPUT:-}"
+
+  build:
+    name: Build (${{ matrix.arch }})
+    needs: prepare
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      # Knowing whether ONE arch or BOTH failed is the diagnosis when a build
+      # breaks on an architecture rather than in general.
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            platform: linux/amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            platform: linux/arm64
+            # NOT ubuntu-latest — see the note at the top of this file.
+            runner: ubuntu-24.04-arm
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}-harbor
+      # The arch is part of the group on purpose. A job-level `concurrency` on a
+      # matrix job resolves to the SAME group for every leg unless the matrix
+      # context is in the key, so without `${{ matrix.arch }}` the two legs
+      # would cancel each other and the merge below would never find both.
+      group: ${{ github.workflow }}-${{ github.ref }}-harbor-${{ matrix.arch }}
       cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -29,96 +107,8 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
-      - name: Compute tag prefix
-        id: tag_prefix
-        env:
-          TAG_PREFIX_INPUT: ${{ inputs.tag_prefix }}
-        run: |
-          if [ "${{ github.event_name }}" = "release" ]; then
-            # Release builds use 'main' as the branch label.
-            # Actual image tags are computed separately in the 'Compute image tags' step.
-            echo "value=main" >> "$GITHUB_OUTPUT"
-          elif [ -n "${TAG_PREFIX_INPUT:-}" ]; then
-            if ! printf '%s' "$TAG_PREFIX_INPUT" | grep -Eq '^[A-Za-z0-9._-]+$'; then
-              echo "Invalid tag_prefix: must match ^[A-Za-z0-9._-]+$" >&2
-              exit 1
-            fi
-            echo "value=${TAG_PREFIX_INPUT}" >> "$GITHUB_OUTPUT"
-          else
-            # Sanitize branch name: replace any char not in [A-Za-z0-9._-] with '-'
-            sanitized=$(printf '%s' "${GITHUB_REF_NAME}" | tr -cs 'A-Za-z0-9._-' '-')
-            echo "value=${sanitized}" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Get SDK version
-        id: get_version
-        run: echo "version=$(awk -F'"' '/^version = / {print $2}' pyproject.toml)" >> "$GITHUB_OUTPUT"
-
-      - name: Get short commit SHA
-        id: get_sha
-        run: echo "sha=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
-
-      - name: Compute image tags
-        id: image_tags
-        env:
-          VERSION: ${{ steps.get_version.outputs.version }}
-          PREFIX: ${{ steps.tag_prefix.outputs.value }}
-          SHA: ${{ steps.get_sha.outputs.sha }}
-          EVENT_NAME: ${{ github.event_name }}
-        run: |
-          MAJOR=$(echo "$VERSION" | cut -d. -f1)
-          MINOR=$(echo "$VERSION" | cut -d. -f1-2)
-          # Publish the SAME digest to both registries in one buildx push:
-          #   - registry.atlan.com : external/partner + tenant distribution (S3-backed)
-          #   - ghcr.io            : base for our own app CI. Harbor 307-redirects blobs
-          #                          to S3, so every internal base pull bills as S3
-          #                          DataTransfer-Out; GHCR pulls from GitHub-hosted
-          #                          runners are free. One push => both registries
-          #                          reference an identical manifest, so provenance and
-          #                          the Trivy report from secure-build-push-apps describe
-          #                          the same artifact wherever it is pulled from. That
-          #                          report is advisory and amd64-only (the action scans a
-          #                          separate single-platform build and runs in feedback
-          #                          mode) — it is not a gate on either registry.
-          # The push is NOT transactional across registries: if the GHCR leg fails after
-          # the Harbor names have landed, re-run this workflow run rather than cutting a
-          # new release — every tag is re-pushed to both registries, so the floating
-          # aliases cannot stay skewed. See docs/standards/build-security.md.
-          REPOS="registry.atlan.com/public/app-runtime-base ghcr.io/atlanhq/app-runtime-base"
-          : > /tmp/tags.txt
-          for REPO in $REPOS; do
-            if [ "$EVENT_NAME" = "release" ] && echo "$VERSION" | grep -qvF '-'; then
-              # Stable release: publish full alias ladder (exact, minor, major, latest) + immutable sha
-              printf '%s\n' \
-                "${REPO}:latest" \
-                "${REPO}:${VERSION}" \
-                "${REPO}:${MINOR}" \
-                "${REPO}:${MAJOR}" \
-                "${REPO}:sha-${SHA}" >> /tmp/tags.txt
-            elif [ "$EVENT_NAME" = "release" ]; then
-              # Pre-release (rc/alpha/beta): exact version + sha only — no aliases that could
-              # cause :latest or major/minor tags to point at a non-stable image
-              printf '%s\n' \
-                "${REPO}:${VERSION}" \
-                "${REPO}:sha-${SHA}" >> /tmp/tags.txt
-            else
-              # workflow_dispatch: prefix-scoped tags for branch/dev builds
-              printf '%s\n' \
-                "${REPO}:${PREFIX}-latest" \
-                "${REPO}:${PREFIX}-${VERSION}" \
-                "${REPO}:sha-${SHA}" >> /tmp/tags.txt
-            fi
-          done
-          DELIM=$(openssl rand -hex 8)
-          { echo "value<<${DELIM}"; cat /tmp/tags.txt; echo "${DELIM}"; } >> "$GITHUB_OUTPUT"
-
-      - name: Log in to Atlan Harbor Registry
-        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
-        with:
-          registry: registry.atlan.com
-          username: ${{ secrets.HARBOR_USERNAME }}
-          password: ${{ secrets.HARBOR_PASSWORD }}
-
+      # Harbor is deliberately absent here: this job pushes staging tags to GHCR
+      # only. The merge job holds the Harbor credential.
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
@@ -143,17 +133,75 @@ jobs:
           owner: atlanhq
           repositories: ${{ github.event.repository.name }}
 
-      - name: Build, scan, and push image to Harbor
+      # The Trivy report from this action is advisory (feedback mode, not a
+      # gate). It used to describe amd64 only, because the action scans a
+      # separate native single-platform build and every caller ran on x64 — so
+      # the arm64 half of a released base image was never scanned at all. With
+      # one native job per arch it now scans each arch on its own runner.
+      - name: Build, scan, and push staging image
         id: harbor_docker_build
         uses: ./.github/actions/secure-build-push-apps
         with:
-          branch: ${{ steps.tag_prefix.outputs.value }}
+          branch: ${{ needs.prepare.outputs.tag_prefix }}
           context: .
           file: ./Dockerfile
           push: true
-          platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.image_tags.outputs.value }}
+          platforms: ${{ matrix.platform }}
+          # The action defaults to an UNSCOPED `type=gha`, so without a per-arch
+          # scope the two legs overwrite each other's cache manifest and both go
+          # cold on every later run — silently, since a cache miss only costs
+          # time. `mode=min` matches the action's own default: this change is
+          # about where the build runs, not about how much of it is cached.
+          cache-from: type=gha,scope=${{ matrix.platform }}
+          cache-to: type=gha,mode=min,scope=${{ matrix.platform }}
+          tags: ${{ needs.prepare.outputs.staging_base }}:sha-${{ needs.prepare.outputs.sha }}-${{ matrix.arch }}
           github-token: ${{ steps.app-token.outputs.token || secrets.ORG_PAT_GITHUB }}
         env:
           DOCKER_CLIENT_TIMEOUT: 600
           COMPOSE_HTTP_TIMEOUT: 600
+
+  merge:
+    name: Merge & Push Manifest
+    needs: [prepare, build]
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          sparse-checkout: .github/scripts
+          sparse-checkout-cone-mode: false
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+
+      - name: Log in to Atlan Harbor Registry
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
+        with:
+          registry: registry.atlan.com
+          username: ${{ secrets.HARBOR_USERNAME }}
+          password: ${{ secrets.HARBOR_PASSWORD }}
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.ORG_PAT_GITHUB }}
+
+      # One `imagetools create` per repository, each attaching that repository's
+      # whole ladder in a single call — see create_multiarch_manifest.py for why
+      # the grouping matters. Not transactional across registries: if the Harbor
+      # leg lands and the GHCR leg fails, RE-RUN this job rather than cutting a
+      # new release. Every tag is rewritten from the same two staging images, so
+      # the operation is idempotent. See docs/standards/build-security.md.
+      - name: Create and push multi-arch manifests
+        env:
+          TAGS: ${{ needs.prepare.outputs.tags }}
+          STAGING: ${{ needs.prepare.outputs.staging_base }}:sha-${{ needs.prepare.outputs.sha }}
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/create_multiarch_manifest.py \
+            --tags "${TAGS}" \
+            --source "${STAGING}-amd64" \
+            --source "${STAGING}-arm64" \
+            --inspect

--- a/docs/standards/build-security.md
+++ b/docs/standards/build-security.md
@@ -11,8 +11,8 @@
 
 ## Base image registries
 
-`app-runtime-base` is published to two registries from a single `docker buildx --push`
-in `.github/workflows/harbor-release.yaml`, so both carry an **identical manifest digest**
+`app-runtime-base` is published to two registries by
+`.github/workflows/harbor-release.yaml`, and both carry an **identical manifest digest**
 for a given tag:
 
 | Registry | Ref | Audience |
@@ -26,17 +26,44 @@ blob redirects on, so a base-image pull 307s to a presigned S3 URL and bills as
 resolve to the same digest, an app can be pointed at either without changing what it
 builds on.
 
+### How a release is built
+
+Three jobs, because the image is multi-arch and **each architecture is built on a runner
+native to it** — `ubuntu-latest` for amd64, `ubuntu-24.04-arm` for arm64. A single job
+with `--platform linux/amd64,linux/arm64` emulates the non-native half under QEMU at
+5-10x native, and it does so without failing, so nothing reports the regression.
+`test_base_image_native_builds.py` pins the pairing.
+
+| Job | Does |
+|---|---|
+| `prepare` | Computes the tag ladder (`harbor_release_tags.py`). |
+| `build` (×2, native) | Builds and Trivy-scans one architecture; pushes an arch-suffixed **staging** tag to GHCR only. Harbor's project is the public catalog and never sees a half-image, so the build jobs hold no Harbor credential. |
+| `merge` | Joins the two staging images into an index and writes it under every ladder tag on **both** registries (`create_multiarch_manifest.py`). |
+
+Digest parity holds across that split: an index's bytes are a function of its child
+digests, so the same two children written to two registries produce the same index digest.
+`resolve_base_redirect.py` fails closed on any skew.
+
+Each architecture is now Trivy-scanned on its own runner. Previously the action scanned a
+separate native single-platform build on an x64 runner, so the **arm64 half of a released
+base image was never scanned at all**. The report remains advisory (feedback mode), not a
+gate.
+
 ### If a release publish fails partway
 
-The push is not transactional across registries — buildkit pushes each name in sequence.
-A GHCR-side failure (PAT rotation, GHCR incident) can therefore fail the job *after* the
-Harbor tags have landed, leaving the floating aliases (`:latest`, `:MAJOR`, `:MAJOR.MINOR`)
-advanced on Harbor but not on GHCR.
+The push is not transactional across registries — `merge` writes one registry's ladder
+after the other. A GHCR-side failure (PAT rotation, GHCR incident) can therefore fail the
+job *after* the Harbor tags have landed, leaving the floating aliases (`:latest`,
+`:MAJOR`, `:MAJOR.MINOR`) advanced on Harbor but not on GHCR.
 
 **Recovery: re-run the failed workflow run** (Actions → the failed run → *Re-run jobs*).
-Do not cut a new release. Every tag is re-pushed to both registries from one build, so the
-re-run restores parity; the tags are mutable, so the operation is idempotent. Cutting a new
-release instead would leave the skipped version permanently absent from GHCR.
+Do not cut a new release. Every tag is rewritten on both registries from the same two
+staging images, so the re-run restores parity; the tags are mutable, so the operation is
+idempotent. Cutting a new release instead would leave the skipped version permanently
+absent from GHCR.
+
+If only `merge` failed, re-running that job alone is enough — the staging images from the
+build legs are still in GHCR under `:sha-<sha>-amd64` / `:sha-<sha>-arm64`.
 
 App builds do not silently ride out that window. When an app opts into
 `use_ghcr_base` (see below), `build-and-publish-app.yaml` resolves the base tag on


### PR DESCRIPTION
Companion to #3247, which does the same thing for the app publish path. This covers the two workflows that publish `app-runtime-base` — the image every app Dockerfile builds `FROM`.

## The problem

Both `harbor-release.yaml` and `build-image.yaml` built `linux/amd64,linux/arm64` in **one `ubuntu-latest` job**, so the arm64 half went through QEMU. The org has measured that at 5-10x native and already designed against it on this repo's *other* image paths — `pull_request.yaml`'s `build-sdk-base-image` and `tests-reusable.yaml`'s `build-e2e-image` both use `ubuntu-24.04-arm`. The base-image publishers were the ones left behind.

An emulated leg never fails. It is only slow. Nothing reported it.

## What changed

Both are now **one architecture per job, on a runner native to it**, joined by a merge job.

`harbor-release.yaml` needed more than a matrix, because the split means the two registries can no longer be fed by one `buildx --push`:

| Job | Does |
|---|---|
| `prepare` | Computes the tag ladder. |
| `build` (×2, native) | Builds + Trivy-scans one arch. Pushes an arch-suffixed **staging** tag to **GHCR only**. |
| `merge` | Joins the two staging images into an index, writes it under every ladder tag on **both** registries. |

Harbor's project is the public, partner-facing catalog, so it must never see an `-amd64` half-image — the build jobs hold **no Harbor credential** at all, which is pinned by a test rather than left to care.

**Digest parity survives.** An index's bytes are a function of its child digests, so the same two children written to two registries produce the same index digest. `resolve_base_redirect.py` still fails closed on any skew. `docs/standards/build-security.md` is updated for the new shape and the new recovery path (if only `merge` failed, re-running that one job is enough — the staging images are still in GHCR).

## Three things that fail silently

All pinned in `test_base_image_native_builds.py`, and each verified to actually fail when the property is broken:

1. **Concurrency.** A job-level `concurrency` on a matrix job resolves to the *same* group for every leg unless the matrix context is in the key — the two legs would have cancelled each other and merge would never find both. `${{ matrix.arch }}` is now in the group.
2. **Cache scope.** `secure-build-push-apps` defaults to an **unscoped** `type=gha`. Two legs would overwrite each other's cache manifest and both go cold on every later run. Now scoped per platform. (`mode=min` is kept — the action's own default; this PR is about *where* the build runs, not how much is cached.)
3. **Tag collision.** Both legs writing one tag publishes whichever finished last, single-arch, with no error anywhere.

## Side effect: arm64 was never being scanned

`secure-build-push-apps` scans a separate **native single-platform** build. Every caller ran on x64, so the Trivy report described amd64 only — the arm64 half of every released base image went unscanned. Each arch is now scanned on its own runner. Still advisory (feedback mode), not a gate, so this changes coverage and not enforcement.

## Shell → tested scripts

The tag-prefix branch and the release / pre-release / `workflow_dispatch` ladder were inline `if`/`else`, which `docs/standards/ci.md` keeps out of `run:` blocks. They move to `harbor_release_tags.py`, behaviour unchanged, now covered — including the case with the worst blast radius and no prior coverage at all: **a pre-release must never advance `:latest`, `:MAJOR` or `:MAJOR.MINOR`**, which every tenant resolves.

`create_multiarch_manifest.py` does the join, issuing one `imagetools create` per *repository* with that repository's whole ladder attached — grouping matters, since a call per tag would re-copy the image once per name.

New tests: 18 + 21 + 19.

## Risk

`harbor-release.yaml` only runs on release publish, so it is not exercised by this PR's CI. It has a `workflow_dispatch` path with a `tag_prefix` input that publishes prefix-scoped tags and never touches `:latest` or the floating aliases — **worth one dispatch run on a throwaway prefix before the next release.**

`build-image.yaml` runs on push to `main`, so it self-verifies on merge.

## Not in scope: `build-apps-image.yaml` stays emulated, deliberately

It has the same single-runner matrix, and it is **not** dead glue — an earlier read of mine said so and was wrong. It is the build target of the *legacy* publish path:

```
push -> caller's build-and-publish.yaml -> publish-app.yaml@main
     -> `atlan app publish` (CLI)
     -> workflow_dispatch of the caller's own build-image.yaml
     -> build-apps-image.yaml@main
```

That CLI dispatch is why those callers keep a `workflow_dispatch`-only `build-image.yaml`. The double build is exactly what `build-and-publish-app.yaml` (and #3247) exists to replace.

Its one remaining external caller, `atlan-csa-csv-composite-app`, is being left on this path as a known outlier: it is dormant (last successful publish 2026-04-07) and its last two publishes failed on the blocking Trivy allowlist gate, which the modern path does not have. Migrating it would flip that gate off as a side effect, so it is a separate, deliberate decision rather than part of this change.

So the legacy path gets no native-ARM fix here: the only build it would speed up is one nobody runs, and there is no active caller to validate the change against. If that repo is ever migrated or retired, `build-apps-image.yaml` and `publish-app.yaml` go with it.
