### PR TITLE
fix(mcp): bind app instance in tool registration and migrate to fastmcp 3.x API

### DIFF
--- a/application_sdk/handler/service.py
+++ b/application_sdk/handler/service.py
@@ -2624,7 +2624,13 @@ def create_app_handler_service(
             from application_sdk.server.mcp import (  # noqa: PLC0415 — cold path: only when ENABLE_MCP set
                 MCPServer,
             )
-        except ImportError as e:
+        except ModuleNotFoundError as e:
+            # Only the mcp extra's own dependency (fastmcp) being absent means
+            # "extra not installed". Any other ModuleNotFoundError in the import
+            # chain is an unrelated broken import — re-raise it unchanged so the
+            # user isn't sent to reinstall the extra when the fault is elsewhere.
+            if e.name != "fastmcp" and not (e.name or "").startswith("fastmcp."):
+                raise
             raise RuntimeError(
                 "ENABLE_MCP is set but the MCP dependencies are not installed. "
                 "Install the SDK with the 'mcp' extra "

--- a/application_sdk/handler/service.py
+++ b/application_sdk/handler/service.py
@@ -2620,9 +2620,16 @@ def create_app_handler_service(
             asynccontextmanager,
         )
 
-        from application_sdk.server.mcp import (  # noqa: PLC0415 — cold path: only when ENABLE_MCP set
-            MCPServer,
-        )
+        try:
+            from application_sdk.server.mcp import (  # noqa: PLC0415 — cold path: only when ENABLE_MCP set
+                MCPServer,
+            )
+        except ImportError as e:
+            raise RuntimeError(
+                "ENABLE_MCP is set but the MCP dependencies are not installed. "
+                "Install the SDK with the 'mcp' extra "
+                "(e.g. `uv add 'atlan-application-sdk[mcp]'`) or unset ENABLE_MCP."
+            ) from e
 
         _mcp_server = MCPServer(application_name=app_name)
 

--- a/application_sdk/server/mcp/server.py
+++ b/application_sdk/server/mcp/server.py
@@ -6,7 +6,9 @@ activities marked with @mcp_tool decorators and mounts them on FastAPI
 using streamable HTTP transport.
 """
 
-from typing import Optional
+import functools
+import inspect
+from typing import Any, Callable, Optional
 
 from fastmcp import FastMCP
 from fastmcp.server.http import StarletteWithLifespan
@@ -16,9 +18,47 @@ from application_sdk.observability.logger_adaptor import get_logger
 from application_sdk.server.mcp.models import MCPMetadata
 
 
+def _bind_task_for_mcp(app_name: str, task_meta: Any) -> Callable[..., Any]:
+    """Return an MCP-callable wrapper around an unbound ``@task`` method.
+
+    ``TaskMetadata.func`` is the original *unbound* method, so handing it to
+    FastMCP directly leaks ``self`` into the tool's JSON schema and every call
+    fails validation. Mirror the Temporal execution path instead: instantiate
+    the owning App class per call (``AppRegistry.get(app_name).app_cls()``) and
+    invoke the original function against that instance. ``self`` is removed
+    from the advertised signature so the schema only carries the task's Input.
+
+    The App class is resolved lazily at call time, not registration time,
+    because MCP registration runs during server startup and must not depend on
+    AppRegistry population order.
+    """
+    func = task_meta.func
+    signature = inspect.signature(func)
+    if "self" not in signature.parameters:
+        return func
+
+    @functools.wraps(func)
+    async def _invoke(*args: Any, **kwargs: Any) -> Any:
+        from application_sdk.app.registry import (  # noqa: PLC0415 — circular: app.registry imports execution-related modules
+            AppRegistry,
+        )
+
+        app_instance = AppRegistry.get_instance().get(app_name).app_cls()
+        return await func(app_instance, *args, **kwargs)
+
+    _invoke.__signature__ = signature.replace(  # type: ignore[attr-defined]
+        parameters=[
+            param
+            for param_name, param in signature.parameters.items()
+            if param_name != "self"
+        ]
+    )
+    return _invoke
+
+
 class MCPServer:
     """
-    MCP Server using FastMCP 2.0 with FastAPI mounting capability.
+    MCP Server using FastMCP with FastAPI mounting capability.
 
     This server automatically discovers activities marked with @mcp_tool
     and creates a FastMCP server that can be mounted on FastAPI.
@@ -40,7 +80,7 @@ class MCPServer:
         self.server = FastMCP(
             name=f"{application_name} MCP",
             instructions=instructions,
-            on_duplicate_tools="error",
+            on_duplicate="error",
         )
 
     async def register_tools_from_registry(self, app_name: str) -> None:
@@ -50,6 +90,11 @@ class MCPServer:
         ``(WorkflowInterface, ActivitiesInterface)`` pairs, it reads
         ``TaskRegistry`` for the given app and checks each ``TaskMetadata.func``
         for the ``MCP_METADATA_KEY`` attribute set by ``@mcp_tool``.
+
+        Tool calls execute in-process in the server (no Temporal hop), against
+        a fresh App instance per call — matching the Temporal activity
+        execution model. ``@task`` timeout/retry semantics do NOT apply on the
+        MCP path.
 
         Args:
             app_name: The app name used to look up tasks in the registry.
@@ -78,7 +123,7 @@ class MCPServer:
                     mcp_metadata.description,
                 )
                 self.server.tool(
-                    task_meta.func,
+                    _bind_task_for_mcp(app_name, task_meta),
                     name=mcp_metadata.name,
                     description=mcp_metadata.description,
                     *mcp_metadata.args,
@@ -91,11 +136,11 @@ class MCPServer:
                     mcp_metadata.name,
                 )
 
-        tools = await self.server.get_tools()
+        tools = await self.server.list_tools()
         self.logger.info(
             "Registered %d MCP tools from registry: %s",
             len(tools),
-            list(tools.keys()),
+            [tool.name for tool in tools],
         )
 
     async def get_http_app(self) -> StarletteWithLifespan:

--- a/docs/concepts/mcp.md
+++ b/docs/concepts/mcp.md
@@ -10,7 +10,7 @@ MCP integration allows you to expose your application's tasks as AI tools that c
 
 - **Zero-code AI integration**: Simply add the `@mcp_tool` decorator to existing tasks
 - **Automatic parameter flattening**: Pydantic models are automatically expanded into individual parameters for better AI experience
-- **FastMCP 2.0 compatibility**: Uses the latest MCP server implementation with streamable HTTP transport
+- **FastMCP 3.x compatibility**: Uses the latest MCP server implementation with streamable HTTP transport
 - **Hot-pluggable**: Enable/disable MCP without changing your core application logic
 
 ## Installation

--- a/tests/unit/server/mcp/conftest.py
+++ b/tests/unit/server/mcp/conftest.py
@@ -1,0 +1,78 @@
+"""Shared probe App for the MCP server tests.
+
+The MCP tests deliberately avoid mocking FastMCP or the registries: a real
+``App`` subclass registers itself with the real ``AppRegistry`` /
+``TaskRegistry``, and the tests drive a real FastMCP server. This module owns
+the probe App so both the in-memory transport tests and the mounted-HTTP tests
+exercise the same task surface.
+"""
+
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+
+import pytest
+
+from application_sdk.app.base import App
+from application_sdk.app.registry import AppRegistry, TaskRegistry
+from application_sdk.app.task import task
+from application_sdk.contracts.base import Input, Output
+from application_sdk.server.mcp.decorators import mcp_tool
+
+APP_NAME = "mcp-probe-app"
+
+
+# Plain Pydantic subclasses — @dataclass would generate a conflicting __init__
+# that breaks Pydantic's __pydantic_fields_set__ initialisation.
+class ProbeInput(Input):
+    value: str = ""
+
+
+class ProbeOutput(Output):
+    result: str = ""
+
+
+@dataclass
+class ProbeApp:
+    """The probe App class plus the instances the SDK bound to each call."""
+
+    app_cls: type[App]
+    instances: list[App] = field(default_factory=list)
+
+
+@pytest.fixture
+def probe() -> Iterator[ProbeApp]:
+    """Register a real App whose tasks cover every discovery branch.
+
+    The registries are process-wide singletons, so they are reset around the
+    fixture and the App class is declared inside it — that keeps registration
+    from leaking into (or being clobbered by) other modules.
+    """
+    AppRegistry.reset()
+    TaskRegistry.reset()
+    instances: list[App] = []
+
+    class McpProbeApp(App):
+        name = APP_NAME
+
+        async def run(self, input: ProbeInput) -> ProbeOutput:
+            return ProbeOutput(result=input.value)
+
+        @task
+        @mcp_tool(name="fetch_schemas", description="Fetch all schemas")
+        async def fetch_schemas(self, input: ProbeInput) -> ProbeOutput:
+            instances.append(self)
+            return ProbeOutput(result=f"schemas:{input.value}")
+
+        @task
+        @mcp_tool(name="hidden_op", description="Hidden op", visible=False)
+        async def hidden_op(self, input: ProbeInput) -> ProbeOutput:
+            return ProbeOutput(result="hidden")
+
+        @task
+        async def plain_task(self, input: ProbeInput) -> ProbeOutput:
+            return ProbeOutput(result="plain")
+
+    yield ProbeApp(app_cls=McpProbeApp, instances=instances)
+
+    AppRegistry.reset()
+    TaskRegistry.reset()

--- a/tests/unit/server/mcp/conftest.py
+++ b/tests/unit/server/mcp/conftest.py
@@ -17,6 +17,10 @@ from application_sdk.app.registry import AppRegistry, TaskRegistry
 from application_sdk.app.task import task
 from application_sdk.contracts.base import Input, Output
 from application_sdk.server.mcp.decorators import mcp_tool
+from application_sdk.testing import clean_app_registry, clean_task_registry
+
+# Referenced so the fixture signatures below pick them up as dependencies.
+__all__ = ["clean_app_registry", "clean_task_registry"]
 
 APP_NAME = "mcp-probe-app"
 
@@ -40,15 +44,17 @@ class ProbeApp:
 
 
 @pytest.fixture
-def probe() -> Iterator[ProbeApp]:
+def probe(
+    clean_app_registry: AppRegistry,
+    clean_task_registry: TaskRegistry,
+) -> Iterator[ProbeApp]:
     """Register a real App whose tasks cover every discovery branch.
 
     The registries are process-wide singletons, so they are reset around the
-    fixture and the App class is declared inside it — that keeps registration
-    from leaking into (or being clobbered by) other modules.
+    fixture (via the shared ``clean_*_registry`` fixtures) and the App class is
+    declared inside it — that keeps registration from leaking into (or being
+    clobbered by) other modules.
     """
-    AppRegistry.reset()
-    TaskRegistry.reset()
     instances: list[App] = []
 
     class McpProbeApp(App):
@@ -73,6 +79,3 @@ def probe() -> Iterator[ProbeApp]:
             return ProbeOutput(result="plain")
 
     yield ProbeApp(app_cls=McpProbeApp, instances=instances)
-
-    AppRegistry.reset()
-    TaskRegistry.reset()

--- a/tests/unit/server/mcp/test_mcp_http_mount.py
+++ b/tests/unit/server/mcp/test_mcp_http_mount.py
@@ -172,11 +172,44 @@ class TestMissingExtra:
     ) -> None:
         """ENABLE_MCP without the extra installed must say what to install.
 
-        ``None`` in sys.modules makes the import raise ImportError, which is
-        what a missing ``mcp`` extra looks like from inside the lifespan.
+        ``None`` in sys.modules makes ``import fastmcp`` raise a
+        ``ModuleNotFoundError`` named ``fastmcp`` — the real signal that the
+        ``mcp`` extra is not installed. The lifespan catches that specific case
+        and rewrites it with install instructions; an unrelated broken import
+        inside the chain is re-raised unchanged (see the sibling test).
+        """
+        monkeypatch.setattr(constants, "ENABLE_MCP", True)
+        # Evict every cached application_sdk.server.mcp* and fastmcp* module so
+        # the `from fastmcp import FastMCP` at the top of server.py re-runs and
+        # hits the nulled fastmcp below — earlier tests in this module import
+        # the real chain and leave it in sys.modules.
+        for mod in [
+            m
+            for m in sys.modules
+            if m == "fastmcp"
+            or m.startswith("fastmcp.")
+            or m == "application_sdk.server.mcp"
+            or m.startswith("application_sdk.server.mcp.")
+        ]:
+            monkeypatch.delitem(sys.modules, mod, raising=False)
+        monkeypatch.setitem(sys.modules, "fastmcp", None)
+
+        with pytest.raises(RuntimeError, match="'mcp' extra"):
+            create_app_handler_service(DefaultHandler(), app_name=APP_NAME)
+
+    def test_unrelated_import_error_is_reraised_unchanged(
+        self, probe: ProbeApp, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A broken import *inside* the MCP chain must not be misreported.
+
+        If ``application_sdk.server.mcp`` itself fails to import for a reason
+        other than the extra being absent (an SDK-internal bug, a broken
+        transitive dep), the broad "install the mcp extra" message would send
+        the user to reinstall when the fault is elsewhere. The lifespan must
+        re-raise that ``ModuleNotFoundError`` unchanged instead.
         """
         monkeypatch.setattr(constants, "ENABLE_MCP", True)
         monkeypatch.setitem(sys.modules, "application_sdk.server.mcp", None)
 
-        with pytest.raises(RuntimeError, match="'mcp' extra"):
+        with pytest.raises(ModuleNotFoundError):
             create_app_handler_service(DefaultHandler(), app_name=APP_NAME)

--- a/tests/unit/server/mcp/test_mcp_http_mount.py
+++ b/tests/unit/server/mcp/test_mcp_http_mount.py
@@ -1,0 +1,182 @@
+"""Tests for the MCP server as it is actually served: mounted on the handler.
+
+``create_app_handler_service(..., ENABLE_MCP)`` mounts the FastMCP app on the
+FastAPI handler under ``/mcp`` from inside the lifespan. That mount — real
+FastAPI, real starlette, real fastmcp streamable HTTP — is the path an
+Automation Engine agent talks to, and it is the path that broke on a tenant
+while the mocked unit tests stayed green. These tests speak MCP over the ASGI
+transport (no port, no subprocess, no Temporal) so the wire shape is asserted,
+not assumed.
+
+Test Case Summary:
++------------------------------------------+-------------------------------------------+
+| Test                                     | Purpose                                   |
++------------------------------------------+-------------------------------------------+
+| test_initialize_handshake_succeeds       | lifespan mounts /mcp and the session      |
+|                                          | handshake completes on the pinned fastmcp |
+| test_tools_list_advertises_only_input    | tools/list over HTTP: the schema an agent |
+|                                          | receives carries `input` only, no `self`  |
+| test_tools_call_executes_task            | tools/call runs the task body in-process  |
+|                                          | and returns its Output                    |
+| test_missing_mcp_extra_raises_actionable | ENABLE_MCP without the `mcp` extra fails  |
+|                                          | with install instructions, not            |
+|                                          | ModuleNotFoundError                       |
++------------------------------------------+-------------------------------------------+
+"""
+
+import json
+import sys
+from collections.abc import Iterator
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from application_sdk import constants
+from application_sdk.handler.base import DefaultHandler
+from application_sdk.handler.service import create_app_handler_service
+from tests.unit.server.mcp.conftest import APP_NAME, ProbeApp
+
+_MCP_HEADERS = {
+    "Accept": "application/json, text/event-stream",
+    "Content-Type": "application/json",
+}
+
+
+@dataclass
+class McpSession:
+    """A minimal MCP streamable-HTTP client over the mounted ASGI route.
+
+    fastmcp's own client cannot drive an ASGI app in-process, so the JSON-RPC
+    envelope is spelled out here — which also makes the assertions be about the
+    bytes an agent receives.
+    """
+
+    client: TestClient
+    session_id: str = ""
+    next_id: int = 1
+
+    def rpc(self, method: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
+        """Send a request and return its JSON-RPC ``result``."""
+        response = self.client.post(
+            "/mcp",
+            json={
+                "jsonrpc": "2.0",
+                "id": self.next_id,
+                "method": method,
+                "params": params or {},
+            },
+            headers=self._headers(),
+        )
+        self.next_id += 1
+        assert response.status_code == 200, response.text
+        self.session_id = self.session_id or response.headers.get("mcp-session-id", "")
+        payload = _sse_json(response.text)
+        assert "error" not in payload, payload
+        return payload["result"]
+
+    def notify(self, method: str) -> None:
+        response = self.client.post(
+            "/mcp",
+            json={"jsonrpc": "2.0", "method": method},
+            headers=self._headers(),
+        )
+        assert response.status_code == 202, response.text
+
+    def _headers(self) -> dict[str, str]:
+        headers = dict(_MCP_HEADERS)
+        if self.session_id:
+            headers["mcp-session-id"] = self.session_id
+        return headers
+
+
+def _sse_json(body: str) -> dict[str, Any]:
+    """Extract the JSON-RPC payload from a text/event-stream response."""
+    for line in body.splitlines():
+        if line.startswith("data: "):
+            return json.loads(line.removeprefix("data: "))
+    raise AssertionError(f"no SSE data frame in response: {body!r}")
+
+
+@pytest.fixture(autouse=True)
+def _reset_service_globals() -> Iterator[None]:
+    """Keep the handler service's module globals from leaking across tests."""
+    from application_sdk.handler import service as svc
+    from application_sdk.infrastructure import clear_infrastructure
+
+    def _reset() -> None:
+        svc._temporal_client = None
+        svc._workflow_config = svc.WorkflowClientConfig()
+        svc._secret_store = None
+        svc._storage = None
+        clear_infrastructure()
+
+    _reset()
+    yield
+    _reset()
+
+
+@pytest.fixture
+def session(probe: ProbeApp, monkeypatch: pytest.MonkeyPatch) -> Iterator[McpSession]:
+    """An initialized MCP session against the mounted handler service."""
+    monkeypatch.setattr(constants, "ENABLE_MCP", True)
+    app = create_app_handler_service(DefaultHandler(), app_name=APP_NAME)
+
+    # Entering the TestClient runs the lifespan, which is what mounts /mcp.
+    with TestClient(app) as client:
+        mcp = McpSession(client=client)
+        mcp.rpc(
+            "initialize",
+            {
+                "protocolVersion": "2025-06-18",
+                "capabilities": {},
+                "clientInfo": {"name": "probe", "version": "1.0"},
+            },
+        )
+        mcp.notify("notifications/initialized")
+        yield mcp
+
+
+class TestMountedMcpRoute:
+    def test_initialize_handshake_succeeds(self, session: McpSession) -> None:
+        """The session fixture completed the handshake, so /mcp is really mounted."""
+        assert session.session_id
+
+    def test_tools_list_advertises_only_input(self, session: McpSession) -> None:
+        result = session.rpc("tools/list")
+
+        tools = {tool["name"]: tool for tool in result["tools"]}
+        assert set(tools) == {"fetch_schemas"}
+        schema = tools["fetch_schemas"]["inputSchema"]
+        assert set(schema["properties"]) == {"input"}
+        assert "self" not in json.dumps(schema)
+
+    def test_tools_call_executes_task(
+        self, session: McpSession, probe: ProbeApp
+    ) -> None:
+        result = session.rpc(
+            "tools/call",
+            {"name": "fetch_schemas", "arguments": {"input": {"value": "http"}}},
+        )
+
+        assert result["isError"] is False
+        assert result["structuredContent"]["result"] == "schemas:http"
+        assert len(probe.instances) == 1
+        assert isinstance(probe.instances[0], probe.app_cls)
+
+
+class TestMissingExtra:
+    def test_missing_mcp_extra_raises_actionable_error(
+        self, probe: ProbeApp, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """ENABLE_MCP without the extra installed must say what to install.
+
+        ``None`` in sys.modules makes the import raise ImportError, which is
+        what a missing ``mcp`` extra looks like from inside the lifespan.
+        """
+        monkeypatch.setattr(constants, "ENABLE_MCP", True)
+        monkeypatch.setitem(sys.modules, "application_sdk.server.mcp", None)
+
+        with pytest.raises(RuntimeError, match="'mcp' extra"):
+            create_app_handler_service(DefaultHandler(), app_name=APP_NAME)

--- a/tests/unit/server/mcp/test_mcp_server_v3.py
+++ b/tests/unit/server/mcp/test_mcp_server_v3.py
@@ -70,7 +70,7 @@ async def _plain_task(self: Any, input: Any) -> Any:
 def mcp_server() -> MCPServer:
     with patch("application_sdk.server.mcp.server.FastMCP") as mock_fastmcp:
         mock_inner = MagicMock()
-        mock_inner.get_tools = AsyncMock(return_value={})
+        mock_inner.list_tools = AsyncMock(return_value=[])
         mock_fastmcp.return_value = mock_inner
         return MCPServer(application_name="test-app")
 
@@ -141,7 +141,7 @@ class TestRegisterToolsFromRegistry:
             await mcp_server.register_tools_from_registry("test-app")
 
         mcp_server.server.tool.assert_not_called()  # type: ignore[union-attr]
-        mcp_server.server.get_tools.assert_called_once()  # type: ignore[union-attr]
+        mcp_server.server.list_tools.assert_called_once()  # type: ignore[union-attr]
 
     async def test_custom_name_and_description(self, mcp_server: MCPServer) -> None:
         @mcp_tool(name="my_custom_tool", description="My custom description")
@@ -159,3 +159,76 @@ class TestRegisterToolsFromRegistry:
         call_kwargs = mcp_server.server.tool.call_args.kwargs  # type: ignore[union-attr]
         assert call_kwargs["name"] == "my_custom_tool"
         assert call_kwargs["description"] == "My custom description"
+
+    async def test_unbound_self_stripped_from_signature(
+        self, mcp_server: MCPServer
+    ) -> None:
+        """The callable handed to FastMCP must not advertise ``self``.
+
+        TaskMetadata.func is the unbound mixin method; registering it directly
+        would leak ``self`` into the tool JSON schema and every call would fail
+        validation with "Missing required argument: self".
+        """
+        import inspect
+
+        tasks = [_make_task_meta(_fetch_schemas)]
+
+        with patch(
+            "application_sdk.app.registry.TaskRegistry.get_instance"
+        ) as mock_reg:
+            mock_reg.return_value.get_tasks_for_app.return_value = tasks
+            await mcp_server.register_tools_from_registry("test-app")
+
+        registered_fn = mcp_server.server.tool.call_args.args[0]  # type: ignore[union-attr]
+        params = list(inspect.signature(registered_fn).parameters)
+        assert "self" not in params
+        assert params == ["input"]
+
+    async def test_wrapper_binds_fresh_app_instance(
+        self, mcp_server: MCPServer
+    ) -> None:
+        """Calling the registered wrapper must execute against a per-call
+        instance of the owning App class, mirroring the Temporal path."""
+        seen_selves = []
+
+        @mcp_tool(name="probe", description="probe")
+        async def _probe(self: Any, input: Any) -> Any:
+            seen_selves.append(self)
+            return "ok"
+
+        class _FakeApp:
+            pass
+
+        tasks = [_make_task_meta(_probe)]
+
+        with patch(
+            "application_sdk.app.registry.TaskRegistry.get_instance"
+        ) as mock_task_reg:
+            mock_task_reg.return_value.get_tasks_for_app.return_value = tasks
+            await mcp_server.register_tools_from_registry("test-app")
+
+        registered_fn = mcp_server.server.tool.call_args.args[0]  # type: ignore[union-attr]
+
+        with patch(
+            "application_sdk.app.registry.AppRegistry.get_instance"
+        ) as mock_app_reg:
+            mock_app_reg.return_value.get.return_value.app_cls = _FakeApp
+            result_one = await registered_fn(input=None)
+            result_two = await registered_fn(input=None)
+
+        assert result_one == "ok" and result_two == "ok"
+        assert all(isinstance(s, _FakeApp) for s in seen_selves)
+        assert seen_selves[0] is not seen_selves[1]
+
+
+class TestFastMCPConstruction:
+    def test_on_duplicate_kwarg(self) -> None:
+        """Guards the fastmcp 3.x API: ``on_duplicate_tools`` was removed in
+        fastmcp 3.0 in favour of ``on_duplicate`` — passing the old kwarg is a
+        TypeError at startup."""
+        with patch("application_sdk.server.mcp.server.FastMCP") as mock_fastmcp:
+            MCPServer(application_name="test-app")
+
+        call_kwargs = mock_fastmcp.call_args.kwargs
+        assert call_kwargs["on_duplicate"] == "error"
+        assert "on_duplicate_tools" not in call_kwargs

--- a/tests/unit/server/mcp/test_mcp_server_v3.py
+++ b/tests/unit/server/mcp/test_mcp_server_v3.py
@@ -1,234 +1,157 @@
 """Unit tests for MCPServer.register_tools_from_registry() (v3 discovery path).
 
-Verifies that the v3 task-registry-based tool discovery works the same way as
-the v2 ``register_tools()`` path: visible ``@mcp_tool``-decorated ``@task``
-methods are registered, hidden ones are skipped, and plain tasks (no decorator)
-are ignored.
+These tests run against **real fastmcp** — there is no FastMCP mock in this
+module. A real ``App`` subclass registers itself with the real ``AppRegistry`` /
+``TaskRegistry``, and the server is driven through fastmcp's in-memory client
+transport (``fastmcp.Client(server)``), so the advertised JSON schema is the one
+fastmcp actually generates and every call goes through fastmcp's own argument
+validation and result serialization. Nothing external is involved: no port, no
+subprocess, no Temporal server.
+
+Why no mock: mocking FastMCP is what let three breaks ship. A ``MagicMock``
+accepts any constructor kwarg (so the fastmcp 2.x ``on_duplicate_tools=``
+survived the 3.x bump), auto-creates any method (so the removed ``get_tools()``
+still "worked"), and never builds a tool schema (so ``self`` leaking into every
+tool's schema was invisible). Each of those is asserted here behaviourally.
 
 Test Case Summary:
-+--------------------------------------+----------------------------------------------+
-| Test                                 | Purpose                                      |
-+--------------------------------------+----------------------------------------------+
-| test_visible_tool_registered         | @mcp_tool(visible=True) task registers       |
-| test_hidden_tool_skipped             | @mcp_tool(visible=False) task is skipped     |
-| test_plain_task_skipped              | task without @mcp_tool is skipped            |
-| test_multiple_tools                  | multiple decorated tasks all register        |
-| test_empty_registry                  | app with no tasks registers nothing          |
-| test_custom_name_and_description     | name/description overrides pass through      |
-+--------------------------------------+----------------------------------------------+
++-------------------------------------------+-------------------------------------------+
+| Test                                      | Purpose                                   |
++-------------------------------------------+-------------------------------------------+
+| test_only_visible_decorated_tasks_exposed | visible @mcp_tool tasks are the only      |
+|                                           | tools: hidden, plain and inherited        |
+|                                           | @task methods are absent                  |
+| test_schema_omits_self                    | tool schema carries `input` only — `self` |
+|                                           | must not leak (real fastmcp schema gen)   |
+| test_name_and_description_from_decorator  | decorator name/description reach the wire |
+| test_call_returns_task_result             | a real MCP call executes the task body    |
+| test_each_call_binds_fresh_app_instance   | per-call App instantiation, mirroring the |
+|                                           | Temporal activity path                    |
+| test_duplicate_tool_name_is_an_error      | on_duplicate="error" is really wired      |
+|                                           | (fastmcp's default only warns)            |
+| test_http_app_exposes_mcp_route           | http_app() builds on the pinned fastmcp / |
+|                                           | starlette pair and serves /mcp            |
+| test_app_with_no_tasks_registers_nothing  | unknown app registers no tools            |
++-------------------------------------------+-------------------------------------------+
 """
 
-from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+import json
 
 import pytest
+from fastmcp import Client
 
 from application_sdk.server.mcp import MCPServer
-from application_sdk.server.mcp.decorators import mcp_tool
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-def _make_task_meta(func: Any, name: str = "") -> MagicMock:
-    """Return a minimal TaskMetadata-like mock."""
-    meta = MagicMock()
-    meta.name = name or func.__name__
-    meta.func = func
-    return meta
-
-
-# ---------------------------------------------------------------------------
-# Sample callables decorated with @mcp_tool
-# ---------------------------------------------------------------------------
-
-
-@mcp_tool(name="fetch_schemas", description="Fetch all schemas")
-async def _fetch_schemas(self: Any, input: Any) -> Any:
-    """Fetch schemas task."""
-    return None
-
-
-@mcp_tool(name="hidden_op", description="Hidden op", visible=False)
-async def _hidden_op(self: Any, input: Any) -> Any:
-    """Hidden task."""
-    return None
-
-
-async def _plain_task(self: Any, input: Any) -> Any:
-    """Task with no @mcp_tool decorator."""
-    return None
-
-
-# ---------------------------------------------------------------------------
-# Fixture
-# ---------------------------------------------------------------------------
+from tests.unit.server.mcp.conftest import APP_NAME, ProbeApp
 
 
 @pytest.fixture
-def mcp_server() -> MCPServer:
-    with patch("application_sdk.server.mcp.server.FastMCP") as mock_fastmcp:
-        mock_inner = MagicMock()
-        mock_inner.list_tools = AsyncMock(return_value=[])
-        mock_fastmcp.return_value = mock_inner
-        return MCPServer(application_name="test-app")
+async def mcp_server(probe: ProbeApp) -> MCPServer:
+    """A real MCPServer with the probe app's tools registered."""
+    server = MCPServer(application_name=APP_NAME)
+    await server.register_tools_from_registry(APP_NAME)
+    return server
 
 
 # ---------------------------------------------------------------------------
-# Tests
+# Discovery — what the client actually sees
 # ---------------------------------------------------------------------------
 
 
-class TestRegisterToolsFromRegistry:
-    async def test_visible_tool_registered(self, mcp_server: MCPServer) -> None:
-        tasks = [_make_task_meta(_fetch_schemas)]
-
-        with patch(
-            "application_sdk.app.registry.TaskRegistry.get_instance"
-        ) as mock_reg:
-            mock_reg.return_value.get_tasks_for_app.return_value = tasks
-            await mcp_server.register_tools_from_registry("test-app")
-
-        mcp_server.server.tool.assert_called_once()  # type: ignore[union-attr]
-        call_kwargs = mcp_server.server.tool.call_args.kwargs  # type: ignore[union-attr]
-        assert call_kwargs["name"] == "fetch_schemas"
-        assert call_kwargs["description"] == "Fetch all schemas"
-
-    async def test_hidden_tool_skipped(self, mcp_server: MCPServer) -> None:
-        tasks = [_make_task_meta(_hidden_op)]
-
-        with patch(
-            "application_sdk.app.registry.TaskRegistry.get_instance"
-        ) as mock_reg:
-            mock_reg.return_value.get_tasks_for_app.return_value = tasks
-            await mcp_server.register_tools_from_registry("test-app")
-
-        mcp_server.server.tool.assert_not_called()  # type: ignore[union-attr]
-
-    async def test_plain_task_skipped(self, mcp_server: MCPServer) -> None:
-        tasks = [_make_task_meta(_plain_task)]
-
-        with patch(
-            "application_sdk.app.registry.TaskRegistry.get_instance"
-        ) as mock_reg:
-            mock_reg.return_value.get_tasks_for_app.return_value = tasks
-            await mcp_server.register_tools_from_registry("test-app")
-
-        mcp_server.server.tool.assert_not_called()  # type: ignore[union-attr]
-
-    async def test_multiple_tools(self, mcp_server: MCPServer) -> None:
-        tasks = [
-            _make_task_meta(_fetch_schemas),
-            _make_task_meta(_hidden_op),
-            _make_task_meta(_plain_task),
-        ]
-
-        with patch(
-            "application_sdk.app.registry.TaskRegistry.get_instance"
-        ) as mock_reg:
-            mock_reg.return_value.get_tasks_for_app.return_value = tasks
-            await mcp_server.register_tools_from_registry("test-app")
-
-        # Only _fetch_schemas is visible
-        assert mcp_server.server.tool.call_count == 1  # type: ignore[union-attr]
-
-    async def test_empty_registry(self, mcp_server: MCPServer) -> None:
-        with patch(
-            "application_sdk.app.registry.TaskRegistry.get_instance"
-        ) as mock_reg:
-            mock_reg.return_value.get_tasks_for_app.return_value = []
-            await mcp_server.register_tools_from_registry("test-app")
-
-        mcp_server.server.tool.assert_not_called()  # type: ignore[union-attr]
-        mcp_server.server.list_tools.assert_called_once()  # type: ignore[union-attr]
-
-    async def test_custom_name_and_description(self, mcp_server: MCPServer) -> None:
-        @mcp_tool(name="my_custom_tool", description="My custom description")
-        async def _custom(self: Any, input: Any) -> Any:
-            return None
-
-        tasks = [_make_task_meta(_custom)]
-
-        with patch(
-            "application_sdk.app.registry.TaskRegistry.get_instance"
-        ) as mock_reg:
-            mock_reg.return_value.get_tasks_for_app.return_value = tasks
-            await mcp_server.register_tools_from_registry("test-app")
-
-        call_kwargs = mcp_server.server.tool.call_args.kwargs  # type: ignore[union-attr]
-        assert call_kwargs["name"] == "my_custom_tool"
-        assert call_kwargs["description"] == "My custom description"
-
-    async def test_unbound_self_stripped_from_signature(
+class TestToolDiscovery:
+    async def test_only_visible_decorated_tasks_exposed(
         self, mcp_server: MCPServer
     ) -> None:
-        """The callable handed to FastMCP must not advertise ``self``.
+        """visible=True @mcp_tool tasks, and nothing else.
 
-        TaskMetadata.func is the unbound mixin method; registering it directly
-        would leak ``self`` into the tool JSON schema and every call would fail
-        validation with "Missing required argument: self".
+        The probe app also carries a hidden tool, an undecorated @task, and the
+        @task methods it inherits from App (cleanup_files, upload, ...) — none
+        of which may be advertised.
         """
-        import inspect
+        async with Client(mcp_server.server) as client:
+            names = {tool.name for tool in await client.list_tools()}
 
-        tasks = [_make_task_meta(_fetch_schemas)]
+        assert names == {"fetch_schemas"}
 
-        with patch(
-            "application_sdk.app.registry.TaskRegistry.get_instance"
-        ) as mock_reg:
-            mock_reg.return_value.get_tasks_for_app.return_value = tasks
-            await mcp_server.register_tools_from_registry("test-app")
+    async def test_schema_omits_self(self, mcp_server: MCPServer) -> None:
+        """The tool schema must carry the task's Input and nothing else.
 
-        registered_fn = mcp_server.server.tool.call_args.args[0]  # type: ignore[union-attr]
-        params = list(inspect.signature(registered_fn).parameters)
-        assert "self" not in params
-        assert params == ["input"]
+        TaskMetadata.func is the unbound method; handing it to FastMCP directly
+        put ``self`` in the schema as a required argument and every call died
+        with "Missing required argument: self". This asserts against the schema
+        fastmcp really generates, which is what makes it a regression test.
+        """
+        async with Client(mcp_server.server) as client:
+            tool = next(
+                t for t in await client.list_tools() if t.name == "fetch_schemas"
+            )
 
-    async def test_wrapper_binds_fresh_app_instance(
+        assert set(tool.inputSchema["properties"]) == {"input"}
+        assert tool.inputSchema["required"] == ["input"]
+        assert "self" not in json.dumps(tool.inputSchema)
+
+    async def test_name_and_description_from_decorator(
         self, mcp_server: MCPServer
     ) -> None:
-        """Calling the registered wrapper must execute against a per-call
-        instance of the owning App class, mirroring the Temporal path."""
-        seen_selves = []
+        async with Client(mcp_server.server) as client:
+            tool = next(
+                t for t in await client.list_tools() if t.name == "fetch_schemas"
+            )
 
-        @mcp_tool(name="probe", description="probe")
-        async def _probe(self: Any, input: Any) -> Any:
-            seen_selves.append(self)
-            return "ok"
-
-        class _FakeApp:
-            pass
-
-        tasks = [_make_task_meta(_probe)]
-
-        with patch(
-            "application_sdk.app.registry.TaskRegistry.get_instance"
-        ) as mock_task_reg:
-            mock_task_reg.return_value.get_tasks_for_app.return_value = tasks
-            await mcp_server.register_tools_from_registry("test-app")
-
-        registered_fn = mcp_server.server.tool.call_args.args[0]  # type: ignore[union-attr]
-
-        with patch(
-            "application_sdk.app.registry.AppRegistry.get_instance"
-        ) as mock_app_reg:
-            mock_app_reg.return_value.get.return_value.app_cls = _FakeApp
-            result_one = await registered_fn(input=None)
-            result_two = await registered_fn(input=None)
-
-        assert result_one == "ok" and result_two == "ok"
-        assert all(isinstance(s, _FakeApp) for s in seen_selves)
-        assert seen_selves[0] is not seen_selves[1]
+        assert tool.description == "Fetch all schemas"
 
 
-class TestFastMCPConstruction:
-    def test_on_duplicate_kwarg(self) -> None:
-        """Guards the fastmcp 3.x API: ``on_duplicate_tools`` was removed in
-        fastmcp 3.0 in favour of ``on_duplicate`` — passing the old kwarg is a
-        TypeError at startup."""
-        with patch("application_sdk.server.mcp.server.FastMCP") as mock_fastmcp:
-            MCPServer(application_name="test-app")
+# ---------------------------------------------------------------------------
+# Execution — a real MCP call, end to end in-process
+# ---------------------------------------------------------------------------
 
-        call_kwargs = mock_fastmcp.call_args.kwargs
-        assert call_kwargs["on_duplicate"] == "error"
-        assert "on_duplicate_tools" not in call_kwargs
+
+class TestToolExecution:
+    async def test_call_returns_task_result(self, mcp_server: MCPServer) -> None:
+        async with Client(mcp_server.server) as client:
+            result = await client.call_tool("fetch_schemas", {"input": {"value": "a"}})
+
+        assert result.structured_content is not None
+        assert result.structured_content["result"] == "schemas:a"
+
+    async def test_each_call_binds_fresh_app_instance(
+        self, mcp_server: MCPServer, probe: ProbeApp
+    ) -> None:
+        """Each call runs against its own App instance, as on the Temporal path."""
+        async with Client(mcp_server.server) as client:
+            await client.call_tool("fetch_schemas", {"input": {"value": "a"}})
+            await client.call_tool("fetch_schemas", {"input": {"value": "b"}})
+
+        assert len(probe.instances) == 2
+        assert all(isinstance(i, probe.app_cls) for i in probe.instances)
+        assert probe.instances[0] is not probe.instances[1]
+
+
+# ---------------------------------------------------------------------------
+# fastmcp wiring — the API surface the mocks used to hide
+# ---------------------------------------------------------------------------
+
+
+class TestFastMCPWiring:
+    async def test_duplicate_tool_name_is_an_error(self, mcp_server: MCPServer) -> None:
+        """``on_duplicate="error"`` has to reach the real FastMCP constructor.
+
+        fastmcp's default is to warn and replace, so a second registration
+        raising is the observable proof the kwarg landed — the fastmcp 2.x
+        spelling (``on_duplicate_tools=``) is a TypeError on 3.x and never gets
+        this far.
+        """
+        with pytest.raises(ValueError, match="already exists"):
+            await mcp_server.register_tools_from_registry(APP_NAME)
+
+    async def test_http_app_exposes_mcp_route(self, mcp_server: MCPServer) -> None:
+        """http_app() must build against the pinned fastmcp/starlette pair."""
+        http_app = await mcp_server.get_http_app()
+
+        assert "/mcp" in {getattr(route, "path", "") for route in http_app.routes}
+
+    async def test_app_with_no_tasks_registers_nothing(self) -> None:
+        server = MCPServer(application_name="unregistered-app")
+
+        await server.register_tools_from_registry("unregistered-app")
+
+        assert await server.server.list_tools() == []


### PR DESCRIPTION
## Problem

`ENABLE_MCP=true` is broken end-to-end today. Verified against a real app (critical-assets / EnrichmentStudio) with an Automation Engine agent calling over streamable HTTP:

1. **Every MCP tool call fails validation.** `register_tools_from_registry` hands the raw **unbound** `@task` method to FastMCP, so `self` leaks into the tool's JSON schema as a required argument. Discovery works; every call dies with `Missing required argument: self`.
2. **Startup crashes on the pinned fastmcp.** The `mcp` extra pins `fastmcp>=3.2,<4` (lock: 3.4.7) but the code uses the 2.x API: `FastMCP(on_duplicate_tools=...)` is a `TypeError` on 3.x, and `get_tools()` no longer exists. CI never caught either break because the unit tests mock FastMCP entirely.
3. **Missing-extra DX.** `ENABLE_MCP=true` without the `mcp` extra installed dies with a raw `ModuleNotFoundError` mid-lifespan.

## Fix

- **Bind per call, strip `self` from the schema.** Registration now wraps the task method: the advertised signature drops `self`, and each call executes against a fresh App instance (`AppRegistry.get(app_name).app_cls()`) — the same per-call instantiation the Temporal activity path uses (`execution/_temporal/activities.py`). `functools.partial` is not an option: FastMCP 3.x rejects partials outright.
- **fastmcp 3.x API**: `on_duplicate=` and `list_tools()`.
- **Actionable startup error** when `ENABLE_MCP` is set but the extra is missing.

## Not in scope (known follow-ups)

- MCP-path calls get a bare App instance — no `AppContext`/`TaskExecutionContext` (heartbeat, state stores). Tasks relying on `self._context` need a follow-up that mirrors the worker's context setup.
- `@task` timeout/retry semantics do not apply on the MCP path (in-process execution, no Temporal). Documented in the registration docstring.
- fastmcp 3.x pulls starlette ≥1.0, which removes `add_event_handler` — apps still using it (e.g. via `fastapi_app.add_event_handler`) must migrate to lifespan handlers when they adopt the `mcp` extra.

## Testing

- In-memory smoke against **real fastmcp 3.4.7** (`fastmcp.Client`): tool schema exposes only `input` (no `self`), call executes against a fresh app instance and returns the body's result.
- `tests/unit/server/mcp/` + `tests/unit/decorators/test_mcp_tool.py`: **34 passed**, including new tests for self-stripping, per-call instance binding, and the `on_duplicate` constructor kwarg (guards the 3.x API regression the old mocks hid).
- pre-commit (ruff, ruff-format, isort, pyright) clean on changed files.
- Full E2E previously verified on fastmcp 2.14.7 with the same wrapper approach: AE agent → `mcp_servers` → app `/mcp` → tool executed in server process (PID-matched), response round-tripped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UtPRzcnmhNpYuhKTdBMkoF