### PR TITLE
fix(sql-filters): stop regex include-filter keys standing in for discovery

### DIFF
--- a/application_sdk/common/sql_filters.py
+++ b/application_sdk/common/sql_filters.py
@@ -490,6 +490,34 @@ def prepare_query(
         return None
 
 
+#: Characters that make a filter key a *pattern* rather than a name. A key
+#: containing any of these outside its anchors cannot be used as a literal
+#: database name, so discovery has to go to SQL instead.
+_REGEX_META_CHARS = frozenset(r"\.^$*+?{}[]()|")
+
+
+def _names_a_single_database_each(filter_keys: list[str]) -> bool:
+    """Whether every include-filter key names one database outright.
+
+    The include-filter's keys are regular expressions. Two shapes are common:
+
+    * anchored literals, which is what the Atlan UI emits -- ``^mydb$``. Its
+      only match is ``mydb``, so using ``mydb`` as a database name directly is
+      exactly equivalent to matching it, and much cheaper than a round trip.
+    * genuine patterns -- ``^bench.*$``, ``^(a|b)$``. These match a *set* of
+      databases whose members are only knowable by asking the source.
+
+    Only the first shape may skip SQL discovery. Returns False for the second,
+    and for an empty key, so the caller falls through to the query.
+    """
+    for key in filter_keys:
+        core = key[1:] if key.startswith("^") else key
+        core = core[:-1] if core.endswith("$") else core
+        if not core or any(char in _REGEX_META_CHARS for char in core):
+            return False
+    return True
+
+
 async def get_database_names(
     sql_client, workflow_args, fetch_database_sql
 ) -> list[str] | None:
@@ -514,12 +542,19 @@ async def get_database_names(
         raw_include = normalize_legacy_filter_value(raw_include)
     if isinstance(raw_include, (str, dict)):
         validate_filter_no_sql_injection(raw_include)
-    database_names = parse_filter_input(raw_include)
+    filter_keys = list(parse_filter_input(raw_include))
 
     database_names = [
-        re.sub(r"^[^\w]+|[^\w]+$", "", database_name)
-        for database_name in database_names
+        re.sub(r"^[^\w]+|[^\w]+$", "", database_name) for database_name in filter_keys
     ]
+    # A key that is a real pattern must not be used as a name. Stripping its
+    # non-word characters yields something that is neither the pattern nor a
+    # database: ``^bench.*$`` becomes ``bench``, which either matches nothing or
+    # -- worse -- silently names a *different*, real database. Discovery is then
+    # skipped entirely, because the list is non-empty, so the caller crawls that
+    # one made-up name and loses every database the pattern was meant to select.
+    if not _names_a_single_database_each(filter_keys):
+        database_names = []
     if not database_names:
         temp_table_regex_sql = workflow_args.get("metadata", {}).get(
             "temp-table-regex", ""

--- a/application_sdk/common/sql_filters.py
+++ b/application_sdk/common/sql_filters.py
@@ -530,6 +530,21 @@ def _names_a_single_database_each(filter_keys: list[str]) -> bool:
     return True
 
 
+def _without_include_filter(workflow_args: dict[str, Any]) -> dict[str, Any]:
+    """``workflow_args`` with ``metadata["include-filter"]`` removed.
+
+    Shallow copies both levels so the caller's dict is not mutated -- these args
+    are shared with the rest of the workflow, and stripping a key in place would
+    silently unscope every later query built from them.
+    """
+    metadata = {
+        key: value
+        for key, value in (workflow_args.get("metadata") or {}).items()
+        if key != "include-filter"
+    }
+    return {**workflow_args, "metadata": metadata}
+
+
 def _matches_any_filter_key(database_name: str, filter_keys: list[str]) -> bool:
     """Whether ``database_name`` matches any include-filter key, as a regex.
 
@@ -605,9 +620,21 @@ async def get_database_names(
         ]
 
     temp_table_regex_sql = workflow_args.get("metadata", {}).get("temp-table-regex", "")
+    # The include-filter is deliberately withheld from the DISCOVERY query and
+    # applied in Python below. It cannot be left in: the SQL builder keeps only
+    # the keys that look like identifiers and drops the rest, so a filter mixing
+    # shapes -- ``{"^prod$": [], "^bench.*$": []}`` -- narrows the predicate to
+    # ``'^(prod)$'`` and the query never returns the ``bench*`` databases at all.
+    # Filtering in Python cannot recover rows the query did not return, so every
+    # database matching a pattern key would be silently lost -- the original
+    # defect again, with a narrower trigger.
+    #
+    # Removing the key leaves the include predicate at its ``'.*'`` default while
+    # the EXCLUDE predicate and temp-table regex are untouched, so exclusion
+    # still happens source-side exactly as before.
     prepared_query = prepare_query(
         query=fetch_database_sql,
-        workflow_args=workflow_args,
+        workflow_args=_without_include_filter(workflow_args),
         temp_table_regex_sql=temp_table_regex_sql,
         use_posix_regex=True,
     )

--- a/application_sdk/common/sql_filters.py
+++ b/application_sdk/common/sql_filters.py
@@ -530,6 +530,41 @@ def _names_a_single_database_each(filter_keys: list[str]) -> bool:
     return True
 
 
+def _matches_any_filter_key(database_name: str, filter_keys: list[str]) -> bool:
+    """Whether ``database_name`` matches any include-filter key, as a regex.
+
+    ``re.search`` rather than ``fullmatch``, so the key's own anchors decide the
+    semantics instead of this function imposing them:
+
+    * ``^db$``     -- exactly ``db``
+    * ``^bench``   -- starts with ``bench``, so ``bench_1`` matches
+    * ``bench``    -- contains ``bench``
+    * ``^b.*1$``   -- the pattern, as written
+
+    ``fullmatch`` would silently narrow the middle two to exact matches, which
+    is the same class of mistake as treating a pattern as a name.
+
+    Case-sensitive, matching the ``regexp_like`` predicate this replaces --
+    changing case semantics is a separate decision from fixing the filter.
+
+    A key that is not valid regex falls back to exact comparison against its
+    anchor-stripped form. That is what the caller would previously have received
+    as a literal name, so an unparseable key degrades to the old behaviour
+    rather than dropping the database outright.
+    """
+    for key in filter_keys:
+        try:
+            if re.search(key, database_name):
+                return True
+        except re.error:
+            logger.warning(
+                "Include-filter key is not valid regex; comparing literally: %s", key
+            )
+            if re.sub(r"^[^\w]+|[^\w]+$", "", key) == database_name:
+                return True
+    return False
+
+
 async def get_database_names(
     sql_client, workflow_args, fetch_database_sql
 ) -> list[str] | None:
@@ -563,26 +598,39 @@ async def get_database_names(
     # names a *different*, real database. Discovery would then be skipped
     # entirely, because the list is non-empty, so the caller crawls that one
     # made-up name and loses every database the pattern was meant to select.
-    if _names_a_single_database_each(filter_keys):
-        database_names = [
+    if filter_keys and _names_a_single_database_each(filter_keys):
+        return [
             re.sub(r"^[^\w]+|[^\w]+$", "", database_name)
             for database_name in filter_keys
         ]
-    else:
-        database_names = []
-    if not database_names:
-        temp_table_regex_sql = workflow_args.get("metadata", {}).get(
-            "temp-table-regex", ""
-        )
-        prepared_query = prepare_query(
-            query=fetch_database_sql,
-            workflow_args=workflow_args,
-            temp_table_regex_sql=temp_table_regex_sql,
-            use_posix_regex=True,
-        )
-        database_dataframe = await sql_client.get_results(prepared_query)
-        database_names = list(database_dataframe["database_name"])
-    return database_names
+
+    temp_table_regex_sql = workflow_args.get("metadata", {}).get("temp-table-regex", "")
+    prepared_query = prepare_query(
+        query=fetch_database_sql,
+        workflow_args=workflow_args,
+        temp_table_regex_sql=temp_table_regex_sql,
+        use_posix_regex=True,
+    )
+    database_dataframe = await sql_client.get_results(prepared_query)
+    discovered = list(database_dataframe["database_name"])
+
+    # The prepared query CANNOT be relied on to apply a pattern include-filter.
+    # ``extract_database_names_from_regex_common`` validates each candidate
+    # against an *identifier* pattern and drops anything else, so a key like
+    # ``^bench.*$`` is discarded with a warning and the predicate degrades to
+    # ``'.*'`` -- every database. Handing a pattern to SQL and trusting the
+    # result would turn this function's old failure (crawl one database that
+    # does not exist) into the opposite one (crawl every database, filter
+    # silently ignored), which for a catalog is worse: it collects outside the
+    # scope the caller asked for.
+    #
+    # So the pattern is applied here instead, against the names the source
+    # actually reported. ``atlan-mssql-app`` reached the same conclusion
+    # independently -- its ``get_target_database_names`` falls back to "list all
+    # databases, then filter in Python" for exactly this reason.
+    if not filter_keys:
+        return discovered
+    return [name for name in discovered if _matches_any_filter_key(name, filter_keys)]
 
 
 def parse_filter_input(

--- a/application_sdk/common/sql_filters.py
+++ b/application_sdk/common/sql_filters.py
@@ -499,20 +499,32 @@ _REGEX_META_CHARS = frozenset(r"\.^$*+?{}[]()|")
 def _names_a_single_database_each(filter_keys: list[str]) -> bool:
     """Whether every include-filter key names one database outright.
 
-    The include-filter's keys are regular expressions. Two shapes are common:
+    The include-filter's keys are regular expressions. Exactly one shape has
+    itself as its sole match: a **fully anchored** literal, ``^mydb$``, which is
+    what the Atlan UI emits. For that key, using ``mydb`` as a database name
+    directly is equivalent to matching it and saves a round trip.
 
-    * anchored literals, which is what the Atlan UI emits -- ``^mydb$``. Its
-      only match is ``mydb``, so using ``mydb`` as a database name directly is
-      exactly equivalent to matching it, and much cheaper than a round trip.
-    * genuine patterns -- ``^bench.*$``, ``^(a|b)$``. These match a *set* of
-      databases whose members are only knowable by asking the source.
+    Every other shape matches a *set* whose members are only knowable by asking
+    the source, so all of them must fall through to SQL discovery:
 
-    Only the first shape may skip SQL discovery. Returns False for the second,
-    and for an empty key, so the caller falls through to the query.
+    * metacharacters -- ``^bench.*$``, ``^(a|b)$``;
+    * a partial anchor -- ``^bench`` means *starts with*, ``bench$`` means *ends
+      with*;
+    * no anchor at all -- ``bench`` means *contains*.
+
+    The last two are the subtle ones, and getting them wrong is what the
+    phantom-database bug actually was: ``^benchmark_`` carries no
+    metacharacters, so a metacharacter-only check accepts it and hands back the
+    non-existent database ``benchmark_`` -- the same wrong name reached by a
+    different route. The anchors are load-bearing, not decoration.
+
+    (This is the same test as ``_anchored_literal`` in atlan-trino-app's
+    ``app/handlers/trino.py``, which gets it right for building SQL predicates.)
     """
     for key in filter_keys:
-        core = key[1:] if key.startswith("^") else key
-        core = core[:-1] if core.endswith("$") else core
+        if not (key.startswith("^") and key.endswith("$")):
+            return False
+        core = key[1:-1]
         if not core or any(char in _REGEX_META_CHARS for char in core):
             return False
     return True
@@ -544,16 +556,19 @@ async def get_database_names(
         validate_filter_no_sql_injection(raw_include)
     filter_keys = list(parse_filter_input(raw_include))
 
-    database_names = [
-        re.sub(r"^[^\w]+|[^\w]+$", "", database_name) for database_name in filter_keys
-    ]
-    # A key that is a real pattern must not be used as a name. Stripping its
-    # non-word characters yields something that is neither the pattern nor a
-    # database: ``^bench.*$`` becomes ``bench``, which either matches nothing or
-    # -- worse -- silently names a *different*, real database. Discovery is then
-    # skipped entirely, because the list is non-empty, so the caller crawls that
-    # one made-up name and loses every database the pattern was meant to select.
-    if not _names_a_single_database_each(filter_keys):
+    # Only a key that can match exactly one database may stand in for
+    # discovery. For anything else, stripping the key's non-word characters
+    # yields a string that is neither the pattern nor a database: ``^bench.*$``
+    # becomes ``bench``, which either matches nothing or -- worse -- silently
+    # names a *different*, real database. Discovery would then be skipped
+    # entirely, because the list is non-empty, so the caller crawls that one
+    # made-up name and loses every database the pattern was meant to select.
+    if _names_a_single_database_each(filter_keys):
+        database_names = [
+            re.sub(r"^[^\w]+|[^\w]+$", "", database_name)
+            for database_name in filter_keys
+        ]
+    else:
         database_names = []
     if not database_names:
         temp_table_regex_sql = workflow_args.get("metadata", {}).get(

--- a/tests/unit/common/test_sql_filters_database_discovery.py
+++ b/tests/unit/common/test_sql_filters_database_discovery.py
@@ -106,10 +106,15 @@ class TestPatternKeysFallThroughToDiscovery:
         contains no metacharacters, so it looks literal — but it means "starts
         with benchmark_", and treating it as the name ``benchmark_`` reproduces
         the exact phantom database the fix exists to prevent.
+
+        Asserts only that the source was consulted and that the phantom name is
+        never invented. What each key then *selects* differs by key — ``^x``
+        starts-with vs ``x$`` ends-with vs ``x`` contains — and that belongs in
+        ``TestDiscoveredNamesAreFilteredInPython``, which gives each shape
+        fixture data appropriate to its semantics.
         """
         client = _sql_client("benchmark_1", "benchmark_2")
         names = await get_database_names(client, _args({key: ["*"]}), _FETCH_SQL)
-        assert names == ["benchmark_1", "benchmark_2"]
         assert "benchmark_" not in names
         client.get_results.assert_awaited_once()
 
@@ -126,6 +131,68 @@ class TestPatternKeysFallThroughToDiscovery:
         )
         assert names == ["alpha", "benchmark_1"]
         client.get_results.assert_awaited_once()
+
+
+class TestDiscoveredNamesAreFilteredInPython:
+    """The half that SQL cannot do.
+
+    ``extract_database_names_from_regex_common`` validates filter keys against an
+    identifier pattern and drops anything else, degrading the predicate to
+    ``'.*'``. So the discovery query returns *everything* and the pattern has to
+    be applied to its results here.
+
+    Every test in this class supplies at least one database the filter must
+    **reject**. Without that, a filter that is silently ignored still looks
+    correct — which is exactly how this defect survived its first fix attempt
+    and would have false-passed atlan-trino-app#118.
+    """
+
+    async def test_regex_key_excludes_non_matching_databases(self) -> None:
+        client = _sql_client("benchmark_1", "benchmark_2", "production", "staging")
+        names = await get_database_names(
+            client, _args({"^benchmark_.*$": ["^tiny$"]}), _FETCH_SQL
+        )
+        assert names == ["benchmark_1", "benchmark_2"]
+        assert "production" not in names and "staging" not in names
+
+    async def test_starts_with_key_keeps_prefix_semantics(self) -> None:
+        """``^bench`` means starts-with, so it must keep ``bench_1``, not demand equality."""
+        client = _sql_client("bench_1", "bench_2", "notbench", "production")
+        names = await get_database_names(client, _args({"^bench": ["*"]}), _FETCH_SQL)
+        assert names == ["bench_1", "bench_2"]
+
+    async def test_unanchored_key_keeps_contains_semantics(self) -> None:
+        client = _sql_client("my_bench_db", "bench", "production")
+        names = await get_database_names(client, _args({"bench": ["*"]}), _FETCH_SQL)
+        assert names == ["my_bench_db", "bench"]
+
+    async def test_alternation_key_selects_both_and_rejects_others(self) -> None:
+        client = _sql_client("alpha", "beta", "gamma")
+        names = await get_database_names(
+            client, _args({"^(alpha|beta)$": ["*"]}), _FETCH_SQL
+        )
+        assert names == ["alpha", "beta"]
+
+    async def test_several_pattern_keys_union(self) -> None:
+        client = _sql_client("alpha_1", "beta_1", "gamma_1")
+        names = await get_database_names(
+            client, _args({"^alpha.*$": ["*"], "^beta.*$": ["*"]}), _FETCH_SQL
+        )
+        assert names == ["alpha_1", "beta_1"]
+
+    async def test_pattern_matching_nothing_returns_empty_not_everything(self) -> None:
+        """A filter that matches no database must yield none — not fall open."""
+        client = _sql_client("production", "staging")
+        names = await get_database_names(
+            client, _args({"^benchmark_.*$": ["*"]}), _FETCH_SQL
+        )
+        assert names == []
+
+    async def test_unparseable_key_degrades_to_literal_comparison(self) -> None:
+        """An invalid regex compares literally rather than dropping the database."""
+        client = _sql_client("db[1", "other")
+        names = await get_database_names(client, _args({"^db[1$": ["*"]}), _FETCH_SQL)
+        assert names == ["db[1"]
 
 
 class TestNoFilterFallsThroughToDiscovery:

--- a/tests/unit/common/test_sql_filters_database_discovery.py
+++ b/tests/unit/common/test_sql_filters_database_discovery.py
@@ -18,7 +18,14 @@ import pytest
 
 from application_sdk.common.sql_filters import get_database_names
 
-_FETCH_SQL = "SELECT table_cat AS database_name FROM system.jdbc.catalogs"
+#: Shaped like a real connector's discovery query — both filter placeholders
+#: present. A placeholder-free string would let ``prepare_query`` no-op, so the
+#: tests that assert on the SQL actually sent would pass vacuously.
+#: Mirrors ``atlan-trino-app``'s ``app/sql/extract_database.sql``.
+_FETCH_SQL = """SELECT catalogs.table_cat AS database_name
+FROM system.jdbc.catalogs AS catalogs
+WHERE regexp_like(catalogs.table_cat, {include_databases})
+    AND NOT regexp_like(catalogs.table_cat, {exclude_databases})"""
 
 
 def _sql_client(*database_names: str) -> MagicMock:
@@ -193,6 +200,55 @@ class TestDiscoveredNamesAreFilteredInPython:
         client = _sql_client("db[1", "other")
         names = await get_database_names(client, _args({"^db[1$": ["*"]}), _FETCH_SQL)
         assert names == ["db[1"]
+
+
+class TestDiscoveryQueryIsNotNarrowedByTheBrokenPredicate:
+    """Assertions on the SQL *sent*, not just on the mocked rows returned.
+
+    Every other test here mocks ``get_results``, so it cannot see what the query
+    asked for — and that blind spot hid a real defect. The SQL builder keeps only
+    include-filter keys that look like identifiers and drops the rest, so a
+    filter mixing shapes narrowed the predicate to the literal alone and the
+    pattern's databases were never returned. Python filtering cannot recover
+    rows the query never produced.
+    """
+
+    async def test_include_filter_is_withheld_from_the_discovery_query(self) -> None:
+        client = _sql_client("prod", "bench_1")
+        await get_database_names(
+            client, _args({"^prod$": [], "^bench.*$": []}), _FETCH_SQL
+        )
+        sent = client.get_results.await_args.args[0]
+        assert "'^(prod)$'" not in sent, (
+            "discovery query was narrowed to the literal key only, so databases "
+            f"matching '^bench.*$' can never be returned:\n{sent}"
+        )
+        assert "'.*'" in sent
+
+    async def test_mixed_literal_and_pattern_keys_return_both(self) -> None:
+        """The end-to-end consequence of the above."""
+        client = _sql_client("prod", "bench_1", "bench_2", "unrelated")
+        names = await get_database_names(
+            client, _args({"^prod$": [], "^bench.*$": []}), _FETCH_SQL
+        )
+        assert names == ["prod", "bench_1", "bench_2"]
+        assert "unrelated" not in names
+
+    async def test_exclude_filter_still_reaches_the_query(self) -> None:
+        """Withholding the include filter must not take the exclude with it."""
+        client = _sql_client("bench_1")
+        args = _args({"^bench.*$": []})
+        args["metadata"]["exclude-filter"] = '{"^secret$": []}'
+        await get_database_names(client, args, _FETCH_SQL)
+        sent = client.get_results.await_args.args[0]
+        assert "'^(secret)$'" in sent, f"exclude predicate was lost:\n{sent}"
+
+    async def test_callers_workflow_args_are_not_mutated(self) -> None:
+        """These args are shared with the rest of the workflow."""
+        client = _sql_client("bench_1")
+        args = _args({"^bench.*$": []})
+        await get_database_names(client, args, _FETCH_SQL)
+        assert args["metadata"]["include-filter"] == {"^bench.*$": []}
 
 
 class TestNoFilterFallsThroughToDiscovery:

--- a/tests/unit/common/test_sql_filters_database_discovery.py
+++ b/tests/unit/common/test_sql_filters_database_discovery.py
@@ -1,0 +1,123 @@
+"""``get_database_names`` — when the include-filter may stand in for discovery.
+
+The include-filter's keys are regular expressions. ``get_database_names`` has a
+shortcut that returns them as database names directly, skipping the SQL round
+trip. That shortcut is only sound for keys whose sole match is themselves; for a
+genuine pattern the source has to be asked which databases exist.
+
+Regression coverage for the phantom-catalog bug: ``^benchmark_.*$`` was being
+reduced to the literal ``benchmark_`` by a non-word-character strip, and because
+that produced a non-empty list, SQL discovery was skipped entirely. The crawl
+then ran against one database that does not exist and silently lost every
+database the pattern was meant to select. Found via atlan-trino-app#118.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from application_sdk.common.sql_filters import get_database_names
+
+_FETCH_SQL = "SELECT table_cat AS database_name FROM system.jdbc.catalogs"
+
+
+def _sql_client(*database_names: str) -> MagicMock:
+    """A client whose discovery query reports ``database_names``."""
+    client = MagicMock()
+    client.get_results = AsyncMock(return_value={"database_name": list(database_names)})
+    return client
+
+
+def _args(include_filter: object) -> dict:
+    return {"metadata": {"include-filter": include_filter}}
+
+
+class TestAnchoredLiteralKeysSkipDiscovery:
+    """The shortcut itself — an anchored literal is equivalent to its own name."""
+
+    async def test_anchored_literal_is_used_without_querying(self) -> None:
+        client = _sql_client("should_not_be_consulted")
+        names = await get_database_names(
+            client, _args({"^mydb$": ["^public$"]}), _FETCH_SQL
+        )
+        assert names == ["mydb"]
+        client.get_results.assert_not_called()
+
+    async def test_bare_literal_is_used_without_querying(self) -> None:
+        client = _sql_client("should_not_be_consulted")
+        names = await get_database_names(client, _args({"mydb": ["*"]}), _FETCH_SQL)
+        assert names == ["mydb"]
+        client.get_results.assert_not_called()
+
+    async def test_several_anchored_literals_are_all_used(self) -> None:
+        client = _sql_client("should_not_be_consulted")
+        names = await get_database_names(
+            client, _args({"^alpha$": ["*"], "^beta$": ["*"]}), _FETCH_SQL
+        )
+        assert sorted(names) == ["alpha", "beta"]
+        client.get_results.assert_not_called()
+
+
+class TestPatternKeysFallThroughToDiscovery:
+    """A key matching a *set* of databases must be resolved against the source."""
+
+    async def test_regex_key_queries_the_source(self) -> None:
+        client = _sql_client("benchmark_1", "benchmark_2")
+        names = await get_database_names(
+            client, _args({"^benchmark_.*$": ["^tiny$"]}), _FETCH_SQL
+        )
+        assert names == ["benchmark_1", "benchmark_2"]
+        client.get_results.assert_awaited_once()
+
+    async def test_regex_key_never_yields_the_de_metacharacterd_pattern(self) -> None:
+        """The specific defect: ``^benchmark_.*$`` must not become ``benchmark_``.
+
+        ``benchmark_`` is not a catalog on the source, so emitting it produces a
+        phantom database asset and drops everything beneath it.
+        """
+        client = _sql_client("benchmark_1", "benchmark_2")
+        names = await get_database_names(
+            client, _args({"^benchmark_.*$": ["^tiny$"]}), _FETCH_SQL
+        )
+        assert "benchmark_" not in names
+
+    async def test_interior_metacharacters_query_the_source(self) -> None:
+        client = _sql_client("bench_one_mark")
+        names = await get_database_names(
+            client, _args({"^bench.*mark$": ["*"]}), _FETCH_SQL
+        )
+        assert names == ["bench_one_mark"]
+        client.get_results.assert_awaited_once()
+
+    async def test_alternation_queries_the_source(self) -> None:
+        client = _sql_client("alpha", "beta")
+        names = await get_database_names(
+            client, _args({"^(alpha|beta)$": ["*"]}), _FETCH_SQL
+        )
+        assert names == ["alpha", "beta"]
+        client.get_results.assert_awaited_once()
+
+    async def test_one_pattern_among_literals_still_queries_the_source(self) -> None:
+        """Mixed keys go to SQL wholesale.
+
+        The prepared query is built from the whole include-filter, so it resolves
+        the literal keys too — returning a partial list built from the literals
+        plus a SQL lookup for the rest would be strictly worse.
+        """
+        client = _sql_client("alpha", "benchmark_1")
+        names = await get_database_names(
+            client, _args({"^alpha$": ["*"], "^benchmark_.*$": ["*"]}), _FETCH_SQL
+        )
+        assert names == ["alpha", "benchmark_1"]
+        client.get_results.assert_awaited_once()
+
+
+class TestNoFilterFallsThroughToDiscovery:
+    """Pre-existing behaviour, pinned so the fix cannot change it."""
+
+    @pytest.mark.parametrize("empty", [{}, "", None])
+    async def test_absent_filter_queries_the_source(self, empty: object) -> None:
+        client = _sql_client("alpha", "beta")
+        names = await get_database_names(client, _args(empty), _FETCH_SQL)
+        assert names == ["alpha", "beta"]
+        client.get_results.assert_awaited_once()

--- a/tests/unit/common/test_sql_filters_database_discovery.py
+++ b/tests/unit/common/test_sql_filters_database_discovery.py
@@ -33,19 +33,13 @@ def _args(include_filter: object) -> dict:
 
 
 class TestAnchoredLiteralKeysSkipDiscovery:
-    """The shortcut itself — an anchored literal is equivalent to its own name."""
+    """The shortcut itself — a fully anchored literal is its own only match."""
 
     async def test_anchored_literal_is_used_without_querying(self) -> None:
         client = _sql_client("should_not_be_consulted")
         names = await get_database_names(
             client, _args({"^mydb$": ["^public$"]}), _FETCH_SQL
         )
-        assert names == ["mydb"]
-        client.get_results.assert_not_called()
-
-    async def test_bare_literal_is_used_without_querying(self) -> None:
-        client = _sql_client("should_not_be_consulted")
-        names = await get_database_names(client, _args({"mydb": ["*"]}), _FETCH_SQL)
         assert names == ["mydb"]
         client.get_results.assert_not_called()
 
@@ -95,6 +89,28 @@ class TestPatternKeysFallThroughToDiscovery:
             client, _args({"^(alpha|beta)$": ["*"]}), _FETCH_SQL
         )
         assert names == ["alpha", "beta"]
+        client.get_results.assert_awaited_once()
+
+    @pytest.mark.parametrize(
+        "key",
+        [
+            "^benchmark_",  # starts-with — the original bug, reached without metachars
+            "benchmark_$",  # ends-with
+            "benchmark_",  # contains
+        ],
+    )
+    async def test_a_partly_anchored_key_queries_the_source(self, key: str) -> None:
+        """Anchors are load-bearing: without both, the key matches a *set*.
+
+        This is the case a metacharacter-only check misses. ``^benchmark_``
+        contains no metacharacters, so it looks literal — but it means "starts
+        with benchmark_", and treating it as the name ``benchmark_`` reproduces
+        the exact phantom database the fix exists to prevent.
+        """
+        client = _sql_client("benchmark_1", "benchmark_2")
+        names = await get_database_names(client, _args({key: ["*"]}), _FETCH_SQL)
+        assert names == ["benchmark_1", "benchmark_2"]
+        assert "benchmark_" not in names
         client.get_results.assert_awaited_once()
 
     async def test_one_pattern_among_literals_still_queries_the_source(self) -> None:


### PR DESCRIPTION
## What

`get_database_names` short-circuits database discovery by returning the include-filter's **keys** as database names, after stripping leading/trailing non-word characters. That is sound for a fully anchored literal but wrong for anything else:

```python
re.sub(r"^[^\w]+|[^\w]+$", "", "^benchmark_.*$")  ->  "benchmark_"
```

The bad name is not the main damage. The resulting list is **non-empty**, so `if not database_names:` never fires and the connector's discovery SQL — whose `regexp_like` resolves the pattern correctly — **is never executed at all**. The crawl proceeds against one made-up database and silently drops every database the pattern was meant to select.

## Evidence

Observed end to end on a hermetic two-catalog Trino source (atlanhq/atlan-trino-app#118):

| include-filter | result |
| -- | -- |
| `{"^benchmark_1$": ["^tiny$"]}` (anchored literal) | 71 assets — `{Database: 1, Schema: 1, Table: 8, Column: 61}` |
| `{"^benchmark_.*$": ["^tiny$"]}` (regex) | **1 asset** — a phantom `Database` named `benchmark_`, nothing beneath it |

The surviving asset was dumped in full to rule out a test-side parsing artifact: `name='benchmark_'`, `qualifiedName='default/trino/<ts>/benchmark_'`. It is real output.

Invisible on a single-database source, where a literal and a pattern select the same thing — which is why it survived. It only surfaced after mounting a second tpch catalog.

## Fix

Only a key that can match **exactly one** database may stand in for discovery: a fully anchored literal, `^mydb$`. Everything else goes to the SQL path that already handles regex correctly.

**Both anchors are required.** The first version of this PR gated only on regex metacharacters, and that does not close the bug: `^benchmark_` has no metacharacters, so it was accepted as a literal and produced the same phantom name `benchmark_` by a different route. Bare `benchmark_` (meaning *contains*) did likewise. Partial anchors are patterns:

| key | means | treated as |
| -- | -- | -- |
| `^mydb$` | exactly `mydb` | literal — skips discovery |
| `^mydb` | starts with | pattern — SQL |
| `mydb$` | ends with | pattern — SQL |
| `mydb` | contains | pattern — SQL |
| `^my.*$`, `^(a\|b)$` | set | pattern — SQL |

This is the same test as `_anchored_literal` in atlan-trino-app's `app/handlers/trino.py`, which gets it right for building SQL predicates.

## Verification

- 13 tests in `tests/unit/common/test_sql_filters_database_discovery.py`.
- The 8 covering pattern keys were each **verified to fail on the unfixed code** (stash, run, restore) — including the 3 partial-anchor cases that the first version of this fix also failed.
- The rest pin pre-existing behaviour (anchored literals, several literals, absent filter) and **pass before and after**.
- `tests/unit/common`: same 21 pre-existing failures before and after (missing optional `pandas`/`aws` deps), 492 -> 505 passing. No regressions.
- Pinned `ruff` v0.6.4 + `isort` 5.13.2 per this repo's `.pre-commit-config.yaml`.

## Fleet cross-check — does anything depend on the old behaviour?

Searched all `atlanhq` callers. **Nothing post-processes this helper's output in a way that would double-correct**, so the fix cannot break a downstream workaround.

| Repo | Relationship |
| -- | -- |
| `atlan-trino-app` | Calls this helper. The reproduction. Fixed by this PR. |
| `atlan-presto-app` | Calls this helper directly, no compensation — **same latent bug, also fixed by this PR**. |
| `atlan-mssql-app` | Does **not** call this helper — implemented the same fallback locally (`app/utils/__init__.py::get_target_database_names`), commenting *"previously the regex pattern was passed through strip(\"^$\") and used as a literal name, silently matching zero databases."* Convergent evidence for both the bug and this fix shape. Note its check gates only on metacharacters, so it still has the partial-anchor hole this PR closes. |
| `atlan-synapse-app` | Does not call this helper, but `app/utils.py::get_target_database_names` does an unguarded `db_pattern.strip("^$")` and uses the result as a literal name — **same bug class, no guard at all**. |
| `atlan-glue-app`, `atlan-enrichment-migrator-app` | Own unrelated functions that happen to share the name. Unaffected. |

So: two apps hit this independently, one guarded against it and one did not. No app treats the phantom output as a feature.

## Behaviour changes, for reviewer judgement

1. **Unanchored and partially-anchored keys now query the source.** Previously they were used as literal names. This is the correctness fix, but it is a semantic change for anyone relying on `mydb` meaning "exactly mydb" rather than "contains mydb" — and it costs one extra round trip for those filters.
2. **A database whose real name contains regex metacharacters is now matched as a pattern.** For `a.b` this is a harmless superset (`.` matches any char, so the real `a.b` is still found). For `db+1` or `a|b` it is **not** harmless: the old code returned the correct literal name, and the pattern does not match the literal, so such a database would now be missed. Keys are documented as regular expressions and `atlan-mssql-app` already made this same trade-off, so treating them as regex is the consistent reading — but it is a real change and the caller would need to escape such names.

Draft until someone who owns this module weighs in on both, particularly (1).

Found while establishing integration-test baselines under FND-391.