### PR TITLE
feat(contract-toolkit): add typed object-row Repeater widget

### DIFF
--- a/contract-toolkit/README.md
+++ b/contract-toolkit/README.md
@@ -417,6 +417,7 @@ Used inside `uiConfig.tasks` — reference them as `Widgets.*`:
 | `Widgets.PasswordInput` | `password` | `str` |
 | `Widgets.NumericInput` | `inputNumber` | `int` |
 | `Widgets.InputRepeater` | `inputRepeater` | `list[str]` |
+| `Widgets.Repeater` | `Repeater` | `list[dict]` |
 
 `TextInput` and `TextBoxInput` support an optional `validation` block for opt-in
 JSON or regex validation (`new { type = "json"; formatOnBlur = true }` or

--- a/contract-toolkit/docs/reference.md
+++ b/contract-toolkit/docs/reference.md
@@ -1375,6 +1375,7 @@ class UIRule {
 | `PasswordInput` | `password` | `str` | Masked input |
 | `NumericInput` | `inputNumber` | `int` | `default`, `placeholderValue` |
 | `InputRepeater` | `inputRepeater` | `list[str]` | Repeatable text inputs. `placeholderText`, `validationRules` |
+| `Repeater` | `Repeater` | `list[dict]` | Repeatable rows of typed child `inputs` compiled into a list of row objects. `defaultRowCount`, `minRows`, `maxRows`, `emitArray`, `allowJsonImport`. Nest in credential `extraFields` via `NamedWidget` |
 
 ##### `validation` (WidgetValidation)
 

--- a/contract-toolkit/src/App.pkl
+++ b/contract-toolkit/src/App.pkl
@@ -93,6 +93,7 @@ typealias SqlTree = Widgets.SqlTree
 typealias ConditionalInput = Widgets.ConditionalInput
 typealias Condition = Widgets.Condition
 typealias InputRepeater = Widgets.InputRepeater
+typealias Repeater = Widgets.Repeater
 typealias Schedule = Widgets.Schedule
 typealias CustomWidget = Widgets.CustomWidget
 

--- a/contract-toolkit/src/Config.pkl
+++ b/contract-toolkit/src/Config.pkl
@@ -691,6 +691,21 @@ class Widget {
   /// For custom frontend widgets — plural list of connector names (distinct from
   /// scalar `connectorName` used by connectionSelector).
   connectorNames: List<String>?
+
+  /// For Repeater widgets — number of rows rendered for a brand-new form.
+  defaultItems: Int?
+
+  /// For Repeater widgets — minimum number of rows; row removal is disabled at this count.
+  minItems: Int?
+
+  /// For Repeater widgets — maximum number of rows; row addition is disabled at this count.
+  maxItems: Int?
+
+  /// For Repeater widgets — emit the compiled value as a real JSON array instead of a JSON string.
+  shouldEmitArray: Boolean?
+
+  /// For Repeater widgets — show the bulk "Import JSON" action that replaces the current rows.
+  canImportJson: Boolean?
 }
 
 /// Widget that allows you to enter arbitrary text into a single-line text input field,
@@ -2199,6 +2214,73 @@ class InputRepeater extends UIElement {
     widget = "inputRepeater"
     placeholder = placeholderText
     rules = validationRules
+  }
+}
+
+/// Widget that renders repeatable rows of typed child inputs and compiles them
+/// into a list of row objects (e.g. multi-target credentials: N ports, or N
+/// `{database, port}` pairs under one shared host).
+///
+/// Each row renders every child in [inputs]; the compiled value is a list of
+/// `{key: value}` objects — emitted as a real JSON array when [emitArray] is
+/// true (the default), or as a JSON-stringified array for legacy consumers when
+/// false. Row add/remove is bounded by [minRows]/[maxRows], and
+/// [allowJsonImport] adds a bulk "Import JSON" action that replaces the rows.
+///
+/// Unlike [InputRepeater] (a repeatable list of single text inputs emitting
+/// `list[str]`), each Repeater row is an object with typed child widgets.
+///
+/// Typically nested inside a credential auth pane's `extraFields` via
+/// `NamedWidget` so the compiled value lands under the credential's `extra`
+/// object (e.g. `basic.extra.targets`):
+/// ```
+/// extraFields {
+///   new NamedWidget {
+///     name = "targets"
+///     widget = new Config.Repeater {
+///       title = "Ports"
+///       inputs {
+///         ["port"] = new Config.TextInput { title = "Port"; required = false }
+///       }
+///       maxRows = 100
+///       allowJsonImport = true
+///     }
+///   }
+/// }
+/// ```
+class Repeater extends UIElement {
+  fixed type = "string"
+  required: Boolean? = false
+
+  /// Child inputs rendered inside every row, keyed by the row-object key each emits.
+  hidden inputs: Mapping<String(lower_snake_case), UIElement>
+
+  /// (Optional) Number of rows rendered for a brand-new form (frontend defaults to 1).
+  hidden defaultRowCount: Int?
+
+  /// Minimum number of rows; row removal is disabled at this count.
+  hidden minRows: Int = 1
+
+  /// (Optional) Maximum number of rows; row addition is disabled at this count.
+  hidden maxRows: Int?
+
+  /// Emit the compiled value as a real JSON array instead of a JSON string.
+  hidden emitArray: Boolean = true
+
+  /// Show the bulk "Import JSON" action that replaces the current rows.
+  hidden allowJsonImport: Boolean = false
+
+  /// (Generated) Details of the child inputs rendered inside every row.
+  fixed properties: Map<String, UIElement> = inputs.toMap()
+
+  /// (Generated) Internal configuration for the UI's rendering.
+  fixed ui {
+    widget = "Repeater"
+    defaultItems = defaultRowCount
+    minItems = minRows
+    maxItems = maxRows
+    shouldEmitArray = emitArray
+    canImportJson = allowJsonImport
   }
 }
 

--- a/contract-toolkit/src/Widgets.pkl
+++ b/contract-toolkit/src/Widgets.pkl
@@ -514,6 +514,21 @@ class Widget {
 
   /// For custom frontend widgets — plural list of connector names.
   connectorNames: List<String>?
+
+  /// For Repeater widgets — number of rows rendered for a brand-new form.
+  defaultItems: Int?
+
+  /// For Repeater widgets — minimum number of rows; row removal is disabled at this count.
+  minItems: Int?
+
+  /// For Repeater widgets — maximum number of rows; row addition is disabled at this count.
+  maxItems: Int?
+
+  /// For Repeater widgets — emit the compiled value as a real JSON array instead of a JSON string.
+  shouldEmitArray: Boolean?
+
+  /// For Repeater widgets — show the bulk "Import JSON" action that replaces the current rows.
+  canImportJson: Boolean?
 }
 
 /// Widget that allows you to enter arbitrary text into a single-line text input field.
@@ -1451,6 +1466,73 @@ class InputRepeater extends UIElement {
     widget = "inputRepeater"
     placeholder = placeholderText
     rules = validationRules
+  }
+}
+
+/// Widget that renders repeatable rows of typed child inputs and compiles them
+/// into a list of row objects (e.g. multi-target credentials: N ports, or N
+/// `{database, port}` pairs under one shared host).
+///
+/// Each row renders every child in [inputs]; the compiled value is a list of
+/// `{key: value}` objects — emitted as a real JSON array when [emitArray] is
+/// true (the default), or as a JSON-stringified array for legacy consumers when
+/// false. Row add/remove is bounded by [minRows]/[maxRows], and
+/// [allowJsonImport] adds a bulk "Import JSON" action that replaces the rows.
+///
+/// Unlike [InputRepeater] (a repeatable list of single text inputs emitting
+/// `list[str]`), each Repeater row is an object with typed child widgets.
+///
+/// Typically nested inside a credential auth pane's `extraFields` via
+/// `NamedWidget` so the compiled value lands under the credential's `extra`
+/// object (e.g. `basic.extra.targets`):
+/// ```
+/// extraFields {
+///   new NamedWidget {
+///     name = "targets"
+///     widget = new Widgets.Repeater {
+///       title = "Ports"
+///       inputs {
+///         ["port"] = new Widgets.TextInput { title = "Port"; required = false }
+///       }
+///       maxRows = 100
+///       allowJsonImport = true
+///     }
+///   }
+/// }
+/// ```
+class Repeater extends UIElement {
+  fixed type = "string"
+  required: Boolean? = false
+
+  /// Child inputs rendered inside every row, keyed by the row-object key each emits.
+  hidden inputs: Mapping<String(lower_snake_case), UIElement>
+
+  /// (Optional) Number of rows rendered for a brand-new form (frontend defaults to 1).
+  hidden defaultRowCount: Int?
+
+  /// Minimum number of rows; row removal is disabled at this count.
+  hidden minRows: Int = 1
+
+  /// (Optional) Maximum number of rows; row addition is disabled at this count.
+  hidden maxRows: Int?
+
+  /// Emit the compiled value as a real JSON array instead of a JSON string.
+  hidden emitArray: Boolean = true
+
+  /// Show the bulk "Import JSON" action that replaces the current rows.
+  hidden allowJsonImport: Boolean = false
+
+  /// (Generated) Details of the child inputs rendered inside every row.
+  fixed properties: Map<String, UIElement> = inputs.toMap()
+
+  /// (Generated) Internal configuration for the UI's rendering.
+  fixed ui {
+    widget = "Repeater"
+    defaultItems = defaultRowCount
+    minItems = minRows
+    maxItems = maxRows
+    shouldEmitArray = emitArray
+    canImportJson = allowJsonImport
   }
 }
 

--- a/contract-toolkit/tests/repeater_widget_test.pkl
+++ b/contract-toolkit/tests/repeater_widget_test.pkl
@@ -1,0 +1,222 @@
+/// Tests for the object-row `Repeater` widget (Config.pkl + Widgets.pkl parity)
+/// and its placement inside a JDBC auth pane's `extraFields` via `NamedWidget`,
+/// where the compiled value lands at `basic.extra.targets` in the credential
+/// configmap — the multi-target credential shape (N ports / {database, port}
+/// pairs under one shared host) consumed by the frontend `Repeater` widget.
+amends "pkl:test"
+
+import "pkl:json"
+import "../src/App.pkl" as App
+import "../src/Config.pkl"
+import "../src/Connectors.pkl"
+import "../src/NativeApp.pkl"
+import "../src/Widgets.pkl" as Widgets
+
+local appRepeaterRendering = (App) {
+  name = "repeater-rendering-test"
+  displayName = "Repeater Rendering Test"
+  connector = Connectors.TERADATA
+  icon = "https://example.com/icon.svg"
+
+  credentialUrlGroup = new App.AdvancedJDBCUrlGroup {
+    protocol = ""
+    urlAddonBefore = "driver://"
+    hostField = new App.FieldSpec {
+      name = "host"
+      displayName = "Host"
+      placeholder = "host.example.com"
+    }
+    portField = new App.FieldSpec {
+      name = "port"
+      fieldType = "number"
+      displayName = "Port"
+      defaultValue = "1025"
+      required = false
+    }
+  }
+
+  credentialAuthOptions {
+    ["basic"] = new App.JDBCUrlAuthOption {
+      label = "Basic"
+      nestedLabel = "Basic"
+      urlPartMapping = new App.UrlPartMapping {
+        hostname = "host"
+        searchParams {
+          ["PORT"] = new App.UrlRef { field = "port" }
+        }
+      }
+      fields {
+        new App.FieldSpec { name = "username"; displayName = "Username" }
+        new App.FieldSpec { name = "password"; sensitive = true; displayName = "Password" }
+      }
+      extraFields {
+        new App.NamedWidget {
+          name = "targets"
+          widget = new Widgets.Repeater {
+            title = "Ports"
+            inputs {
+              ["port"] = new Widgets.TextInput { title = "Port"; required = false }
+            }
+            maxRows = 100
+            allowJsonImport = true
+          }
+        }
+      }
+    }
+  }
+
+  uiConfig = new App.UIConfig {
+    tasks {
+      ["Credential"] {
+        inputs {
+          ["credential-guid"] = new App.CredentialInput {
+            credType = "atlan-connectors-repeater-rendering-test"
+          }
+        }
+      }
+    }
+  }
+}
+
+local nativeRepeaterRendering = (NativeApp) {
+  name = "native-repeater-rendering-test"
+  displayName = "Native Repeater Rendering Test"
+  connector = Connectors.TERADATA
+  icon = "https://example.com/icon.svg"
+  workflowType = "NativeRepeaterRenderingTestWorkflow"
+
+  credentialUrlGroup = new NativeApp.AdvancedJDBCUrlGroup {
+    protocol = ""
+    urlAddonBefore = "driver://"
+    hostField = new NativeApp.FieldSpec {
+      name = "host"
+      displayName = "Host"
+      placeholder = "host.example.com"
+    }
+    portField = new NativeApp.FieldSpec {
+      name = "port"
+      fieldType = "number"
+      displayName = "Port"
+      defaultValue = "1025"
+      required = false
+    }
+  }
+
+  credentialAuthOptions {
+    ["basic"] = new NativeApp.JDBCUrlAuthOption {
+      label = "Basic"
+      nestedLabel = "Basic"
+      urlPartMapping = new NativeApp.UrlPartMapping {
+        hostname = "host"
+        searchParams {
+          ["PORT"] = new NativeApp.UrlRef { field = "port" }
+        }
+      }
+      fields {
+        new NativeApp.FieldSpec { name = "username"; displayName = "Username" }
+        new NativeApp.FieldSpec { name = "password"; sensitive = true; displayName = "Password" }
+      }
+      extraFields {
+        new NativeApp.NamedWidget {
+          name = "targets"
+          widget = new Config.Repeater {
+            title = "Ports"
+            inputs {
+              ["port"] = new Config.TextInput { title = "Port"; required = false }
+            }
+            maxRows = 100
+            allowJsonImport = true
+          }
+        }
+      }
+    }
+  }
+
+  uiConfig = new Config.UIConfig {
+    tasks {
+      ["Credential"] {
+        inputs {
+          ["credential-guid"] = new Config.CredentialInput {
+            credType = "atlan-connectors-native-repeater-rendering-test"
+          }
+        }
+      }
+    }
+  }
+}
+
+local appCredentialJson: String =
+  appRepeaterRendering.output.files["app/generated/atlan-connectors-repeater-rendering-test.json"].text
+
+local nativeCredentialJson: String =
+  nativeRepeaterRendering.output.files["atlan-connectors-native-repeater-rendering-test.json"].text
+
+local appCredential = new json.Parser { useMapping = true }.parse(appCredentialJson)
+local nativeCredential = new json.Parser { useMapping = true }.parse(nativeCredentialJson)
+
+local appTargets =
+  appCredential["config"]["properties"]["jdbcUrl"]["properties"]["basic"]["properties"]["extra"]["properties"]["targets"]
+local nativeTargets =
+  nativeCredential["config"]["properties"]["jdbcUrl"]["properties"]["basic"]["properties"]["extra"]["properties"]["targets"]
+
+local widgetsRepeaterDefaults = new json.Parser { useMapping = true }.parse(new JsonRenderer {}.renderDocument(
+  new Widgets.Repeater {
+    title = "Targets"
+    inputs {
+      ["database"] = new Widgets.TextInput { title = "Database" }
+      ["port"] = new Widgets.TextInput { title = "Port" }
+    }
+  }
+))
+local configRepeaterDefaults = new json.Parser { useMapping = true }.parse(new JsonRenderer {}.renderDocument(
+  new Config.Repeater {
+    title = "Targets"
+    inputs {
+      ["database"] = new Config.TextInput { title = "Database" }
+      ["port"] = new Config.TextInput { title = "Port" }
+    }
+  }
+))
+
+facts {
+  ["App.pkl renders a NamedWidget Repeater under the auth pane extra object"] {
+    appTargets["type"] == "string"
+    appTargets["ui"]["widget"] == "Repeater"
+    appTargets["ui"]["label"] == "Ports"
+    appTargets["ui"]["minItems"] == 1
+    appTargets["ui"]["maxItems"] == 100
+    appTargets["ui"]["shouldEmitArray"] == true
+    appTargets["ui"]["canImportJson"] == true
+    appTargets["properties"]["port"]["ui"]["widget"] == "input"
+    appTargets["properties"]["port"]["ui"]["label"] == "Port"
+  }
+
+  ["NativeApp.pkl renders a NamedWidget Repeater under the auth pane extra object"] {
+    nativeTargets["type"] == "string"
+    nativeTargets["ui"]["widget"] == "Repeater"
+    nativeTargets["ui"]["label"] == "Ports"
+    nativeTargets["ui"]["minItems"] == 1
+    nativeTargets["ui"]["maxItems"] == 100
+    nativeTargets["ui"]["shouldEmitArray"] == true
+    nativeTargets["ui"]["canImportJson"] == true
+    nativeTargets["properties"]["port"]["ui"]["widget"] == "input"
+    nativeTargets["properties"]["port"]["ui"]["label"] == "Port"
+  }
+
+  ["Repeater defaults: emitArray on, JSON import off, defaultItems omitted, rows bounded below at 1"] {
+    widgetsRepeaterDefaults["ui"]["shouldEmitArray"] == true
+    widgetsRepeaterDefaults["ui"]["canImportJson"] == false
+    !widgetsRepeaterDefaults["ui"].containsKey("defaultItems")
+    !widgetsRepeaterDefaults["ui"].containsKey("maxItems")
+    widgetsRepeaterDefaults["ui"]["minItems"] == 1
+  }
+
+  ["Repeater rows carry every child input as a typed property"] {
+    widgetsRepeaterDefaults["properties"].keys.toList() == List("database", "port")
+    widgetsRepeaterDefaults["properties"]["database"]["type"] == "string"
+  }
+
+  ["Config.pkl and Widgets.pkl render the Repeater identically"] {
+    configRepeaterDefaults == widgetsRepeaterDefaults
+  }
+}


### PR DESCRIPTION
## Triage

Multi-target credentials (CONNECT-849 / NWM: crawl N ports — later N `{database, port}` pairs — under one shared host) need the frontend's `Repeater` widget (atlanhq/atlan-frontend#30902). Its configmap property carries typed child widgets in a sibling `properties` map:

```json
"targets": {
  "type": "string",
  "ui": { "widget": "Repeater", "minItems": 1, "maxItems": 100, "shouldEmitArray": true, "canImportJson": true },
  "properties": { "port": { "type": "string", "ui": { "label": "Port" } } }
}
```

The toolkit cannot express this today: `InputRepeater` is the string-list widget (no children), and `CustomWidget` can set `ui.widget` but has no child-`properties` support. The only workaround is `NamedProperty` with a hand-authored untyped JSON blob — verified working end-to-end against the frontend, but not an interface to repeat across connectors (the pattern is intended to extend to Postgres and others).

## Design

- New `class Repeater extends UIElement` in **both** widget catalogs (`Config.pkl` for NativeApp contracts, `Widgets.pkl` for App contracts), modeled directly on `NestedInput`: `inputs: Mapping<String, UIElement>` → sibling `properties` map.
- `defaultRowCount` / `minRows` / `maxRows` / `emitArray` / `allowJsonImport` render to `ui.defaultItems` / `minItems` / `maxItems` / `shouldEmitArray` / `canImportJson` — the exact frontend contract. The five ui keys are added to both `Widget` classes as nullable fields (omitted when unset).
- **No renderer changes**: the class rides the existing `NamedWidget` pass-through in credential auth-pane field listings, so apps write:

```pkl
extraFields {
  new NamedWidget {
    name = "targets"
    widget = new Widgets.Repeater {
      title = "Ports"
      inputs { ["port"] = new Widgets.TextInput { title = "Port"; required = false } }
      maxRows = 100
      allowJsonImport = true
    }
  }
}
```

- `emitArray` defaults to `true` (the agreed Cosmos-style shape: a real JSON array under `extra`); legacy stringified emission is opt-out.

## Value flow

`app.pkl` → `make generate` → `atlan-connectors-<name>.json` → SDK serves `/workflows/v1/configmap/atlan-connectors-<name>` → Heracles proxies to the frontend credential form → `formBlock.vue` renders the `Repeater` compound widget → compiled row array lands at `credential-guid.basic.extra.targets` → app compiles one JDBC URL per target at runtime.

## Compatibility

Purely additive. `./scripts/regenerate-all.sh` produces zero drift in committed example output.

## Validation

- `pkl test tests/*.pkl`: 302 tests / 731 asserts pass, including new `tests/repeater_widget_test.pkl` (App + NativeApp rendering under `basic.extra.properties.targets`, defaults, Config/Widgets parity)
- `./scripts/check-invariants.sh`: pass
- `uv run python scripts/test-sdk-import.py`: 38 files OK
- Frontend contract verified live: the identical property JSON was injected into a tenant-served `atlan-connectors-sap-ase` configmap and rendered/exercised against atlan-frontend#30902 (row add/remove, JSON import incl. malformed input, compiled array emission, no internal-key leakage into the credential payload)

🤖 Generated with [Claude Code](https://claude.com/claude-code)