### PR TITLE
refactor(credentials): collapse the agent_json tolerance guards into one ingress normaliser

### DIFF
--- a/application_sdk/credentials/__init__.py
+++ b/application_sdk/credentials/__init__.py
@@ -32,6 +32,10 @@ Public API::
         # Errors
         CredentialError, CredentialNotFoundError,
         CredentialParseError, CredentialValidationError,
+
+        # agent_json ingress normalisation
+        normalize_agent_json, lift_agent_json, declared_agent_spec_type,
+        AGENT_JSON_ALIASES,
     )
 """
 
@@ -53,6 +57,12 @@ from application_sdk.credentials.errors import (
     CredentialValidationError,
 )
 from application_sdk.credentials.git import GitSshCredential, GitTokenCredential
+from application_sdk.credentials.ingress import (
+    AGENT_JSON_ALIASES,
+    declared_agent_spec_type,
+    lift_agent_json,
+    normalize_agent_json,
+)
 from application_sdk.credentials.oauth import OAuthTokenError, OAuthTokenService
 from application_sdk.credentials.ref import (
     CredentialRef,
@@ -91,6 +101,11 @@ __all__ = [
     "CredentialRef",
     "CredentialResolvable",
     "AgentCredentialSpec",
+    # agent_json ingress normalisation
+    "normalize_agent_json",
+    "lift_agent_json",
+    "declared_agent_spec_type",
+    "AGENT_JSON_ALIASES",
     # Factory functions
     "api_key_ref",
     "basic_ref",

--- a/application_sdk/credentials/ingress.py
+++ b/application_sdk/credentials/ingress.py
@@ -105,13 +105,25 @@ def normalize_agent_json(
 
     try:
         return spec_type.model_validate(value)
-    except (ValidationError, CredentialError):
+    except (ValidationError, CredentialError) as exc:
+        # Never log exc_info here: pydantic v2 renders the failing field's own
+        # input_value into the traceback, and a spec carries connector
+        # credential extras as flat dotted keys (``basic.password``,
+        # ``api-key``, …) — so a traceback of a rejection lands the raw
+        # rejected value in logs. The sanitised error list (no input, no
+        # context, no URL) keeps the field path and the reason, which is what
+        # a debugger needs.
+        details = (
+            exc.errors(include_url=False, include_input=False, include_context=False)
+            if isinstance(exc, ValidationError)
+            else []
+        )
         logger.debug(
             "agent_json is not a valid %s; treating the request as having no "
             "agent reference (typically a marketplace-package placeholder "
-            "default replayed from the connection record)",
+            "default replayed from the connection record): %s",
             spec_type.__name__,
-            exc_info=True,
+            details or str(exc),
         )
         return None
 
@@ -201,10 +213,16 @@ def _freshness(binding: tuple[str, Any]) -> tuple[int, int]:
     snapshot that lags behind the user's edits. Picking the wrong one silently
     runs against stale credentials. So prefer a parsed object over a
     serialized string (freshness), then the canonical hyphen spelling
-    (tie-break), then discovery order (stable sort).
+    (tie-break), then discovery order (stable sort). A typed
+    :class:`AgentCredentialSpec` counts as parsed — it is the most-processed
+    form, so ranking it with the serialized strings would let a stale string
+    snapshot beat a current typed spec.
     """
     alias, raw = binding
-    return (1 if isinstance(raw, dict) else 0, 1 if alias == "agent-json" else 0)
+    return (
+        1 if isinstance(raw, (dict, AgentCredentialSpec)) else 0,
+        1 if alias == "agent-json" else 0,
+    )
 
 
 def _first_valid(bindings: list[tuple[str, Any]]) -> AgentCredentialSpec | None:
@@ -218,9 +236,11 @@ def _first_valid(bindings: list[tuple[str, Any]]) -> AgentCredentialSpec | None:
         spec = normalize_agent_json(raw)
         if spec is not None:
             return spec
-    logger.debug(
-        "No agent-json binding in this request is a valid AgentCredentialSpec; "
-        "handling it as direct mode"
+    logger.warning(
+        "Discarding %d present-but-invalid agent-json binding(s); handling the "
+        "request as direct mode (usually a marketplace placeholder, but a "
+        "genuinely malformed agent reference downgrades the same way)",
+        len(bindings),
     )
     return None
 

--- a/application_sdk/credentials/ingress.py
+++ b/application_sdk/credentials/ingress.py
@@ -113,17 +113,22 @@ def normalize_agent_json(
         # rejected value in logs. The sanitised error list (no input, no
         # context, no URL) keeps the field path and the reason, which is what
         # a debugger needs.
+        # Fully resolved before the call, not composed inside it: a log
+        # argument is evaluated eagerly whatever the level, so the sanitising
+        # has to be the only thing that ever runs. A CredentialParseError's own
+        # text names the parse failure without quoting the payload, so it is
+        # safe to pass through.
         details = (
             exc.errors(include_url=False, include_input=False, include_context=False)
             if isinstance(exc, ValidationError)
-            else []
+            else str(exc)
         )
         logger.debug(
             "agent_json is not a valid %s; treating the request as having no "
             "agent reference (typically a marketplace-package placeholder "
             "default replayed from the connection record): %s",
             spec_type.__name__,
-            details or str(exc),
+            details,
         )
         return None
 

--- a/application_sdk/credentials/ingress.py
+++ b/application_sdk/credentials/ingress.py
@@ -1,0 +1,258 @@
+"""Ingress normalisation for the ``agent_json`` wire field.
+
+``agent_json`` names an agent-shape credential *reference* (SDR /
+customer-infra runs).  It reaches the SDK in an arbitrary combination of
+
+* three **alias** spellings — ``agent_json``, ``agentJson``, ``agent-json``;
+* four **container positions** — top level, ``metadata``,
+  ``connection_config``, and ``credentials`` (the last in both the v2 dict
+  and the v3 ``list[{key, value}]`` shape);
+* three **types** — a JSON string, a dict, or an already-typed
+  :class:`~application_sdk.credentials.spec.AgentCredentialSpec`;
+
+and any of those may carry a meaningless **placeholder** rather than a real
+reference.  The placeholder is not generated per request: it is a v2 Argo
+workflow-template default in ``marketplace-packages`` that submits every
+field name as its own value (``{"agent-name": "agent-name", "port": "port",
+…}``) because a sibling Argo param indexes straight into the JSON and must
+evaluate even in direct mode.  That blob is persisted on the connection
+record and replayed verbatim into v3 typed requests, so fixing the templates
+stops new poison but cannot clean the connections that already carry it.
+
+This module is the single place that tolerates all of the above.  Two
+entry points, one lenient policy — *anything meaningless is absent*:
+
+:func:`normalize_agent_json`
+    type layer — one value → :class:`AgentCredentialSpec` or ``None``.
+:func:`lift_agent_json`
+    wire-body layer — find the freshest binding across every alias and
+    position, strip them all, and promote the typed spec to the canonical
+    top-level ``agent_json`` key.
+
+Every reader downstream takes the typed field only; none of them re-parses,
+re-searches, or re-tolerates.  ``is_populated()`` stays the *consumers'*
+call: a spec that validates but carries no fetch anchor is promoted here and
+rejected (or not) by whoever resolves it.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any, Final, TypeVar, get_args
+
+from pydantic import BaseModel, ValidationError
+
+from application_sdk.credentials.errors import CredentialError
+from application_sdk.credentials.spec import AgentCredentialSpec
+from application_sdk.observability.logger_adaptor import get_logger
+
+logger = get_logger(__name__)
+
+AGENT_JSON_ALIASES: Final[tuple[str, ...]] = ("agent_json", "agentJson", "agent-json")
+"""Every spelling the field arrives under, in discovery order.
+
+``agent-json`` is the canonical frontend spelling; the other two are what
+heracles and AE forward.  All three can appear in one request at once.
+"""
+
+_CONTAINERS: Final[tuple[str, ...]] = ("metadata", "connection_config", "credentials")
+"""Request containers a binding may be nested in, in discovery order."""
+
+_EMPTY_STRINGS: Final[frozenset[str]] = frozenset({"", "{}"})
+
+SpecT = TypeVar("SpecT", bound=AgentCredentialSpec)
+
+
+def normalize_agent_json(
+    value: Any,
+    *,
+    spec_type: type[SpecT] = AgentCredentialSpec,
+) -> SpecT | None:
+    """Canonicalise one ``agent_json`` value to a typed spec, or ``None``.
+
+    Accepts every type the field arrives as — a JSON string, a dict, an
+    existing spec — and returns an instance of *spec_type*.  Returns ``None``
+    for anything that cannot be a reference: absent, empty (``""``, ``"{}"``,
+    ``{}``), unparseable JSON, a non-object JSON value, or a payload that does
+    not validate against *spec_type* (the placeholder above — ``port`` is the
+    spec's only non-``str`` field, so ``"port": "port"`` coerces to a dict yet
+    fails typed validation).
+
+    ``None`` means "no agent reference here", never "the caller should try
+    harder".  Callers route on the typed result; nobody catches a parse error.
+
+    Args:
+        value: The raw field value, in any accepted wire shape.
+        spec_type: The spec class to validate against.  Pass the connector's
+            :class:`AgentCredentialSpec` subclass when the reader's field
+            declares one, so the reader gets the type it asked for.
+
+    Returns:
+        A *spec_type* instance, or ``None``.
+    """
+    if value is None:
+        return None
+    if isinstance(value, str) and value.strip() in _EMPTY_STRINGS:
+        return None
+    if isinstance(value, dict) and not value:
+        return None
+    if isinstance(value, spec_type):
+        return value
+    if isinstance(value, AgentCredentialSpec):
+        # A base spec where a subclass is declared: round-trip through the
+        # wire dict so the reader gets its own type rather than the base.
+        value = value.to_raw_dict()
+
+    try:
+        return spec_type.model_validate(value)
+    except (ValidationError, CredentialError):
+        logger.debug(
+            "agent_json is not a valid %s; treating the request as having no "
+            "agent reference (typically a marketplace-package placeholder "
+            "default replayed from the connection record)",
+            spec_type.__name__,
+            exc_info=True,
+        )
+        return None
+
+
+def declared_agent_spec_type(model_cls: type[BaseModel]) -> type[AgentCredentialSpec]:
+    """The spec class *model_cls* declares for its ``agent_json`` field.
+
+    A connector may narrow the field to its own :class:`AgentCredentialSpec`
+    subclass (with ``extra="forbid"`` and every dotted key declared).  Passing
+    the declared type to :func:`normalize_agent_json` means the reader gets the
+    type it asked for, validated by the rules it asked for — rather than a base
+    spec its own field would then reject.
+
+    Falls back to :class:`AgentCredentialSpec` when the field is absent or
+    declares something else.
+    """
+    field = model_cls.model_fields.get("agent_json")
+    annotation = getattr(field, "annotation", None)
+    for candidate in (annotation, *get_args(annotation)):
+        if isinstance(candidate, type) and issubclass(candidate, AgentCredentialSpec):
+            return candidate
+    return AgentCredentialSpec
+
+
+def lift_agent_json(body: dict[str, Any]) -> dict[str, Any]:
+    """Promote the freshest ``agent_json`` binding in *body* to a typed field.
+
+    Handler requests arrive as the frontend form payload forwarded verbatim by
+    heracles, so the binding may sit at the top level or nested in any of
+    :data:`_CONTAINERS`, under any of :data:`AGENT_JSON_ALIASES`, and several
+    copies may arrive at once.  Returns a copy of *body* with
+
+    * every agent-json key removed from every container — a binding left
+      inside ``credentials`` would be flattened into a bogus credential pair
+      by the v2→v3 credential shim; and
+    * ``body["agent_json"]`` set to the typed spec, when one of the copies is
+      a real reference.
+
+    When no copy is a real reference the keys are still stripped and no typed
+    field is set: the request proceeds as direct mode.  A body carrying no
+    binding at all is returned unchanged.
+
+    Trade-off: an SDR user whose spec is genuinely malformed (a non-numeric
+    ``port`` they typed themselves) sees "no agent detected" rather than a
+    field-level error.  That is deliberate — the alternative is rejecting
+    every direct-mode request whose form merely renders the agent widget.
+    """
+    bindings = list(_iter_bindings(body))
+    if not bindings:
+        return body
+
+    lifted = _strip_agent_json(body)
+    spec = _first_valid(bindings)
+    if spec is not None:
+        lifted["agent_json"] = spec
+    return lifted
+
+
+def _iter_bindings(body: dict[str, Any]) -> Iterator[tuple[str, Any]]:
+    """Every agent-json binding in *body* as ``(alias, raw_value)``.
+
+    Discovery order is top level then each container, alias order within
+    each — the order ties are broken in (see :func:`_freshness`).
+    """
+    for alias in AGENT_JSON_ALIASES:
+        if alias in body:
+            yield alias, body[alias]
+
+    for container in _CONTAINERS:
+        value = body.get(container)
+        if isinstance(value, dict):
+            for alias in AGENT_JSON_ALIASES:
+                if alias in value:
+                    yield alias, value[alias]
+        elif isinstance(value, list):  # v3 credentials: list[{key, value}]
+            for item in value:
+                if isinstance(item, dict) and item.get("key") in AGENT_JSON_ALIASES:
+                    yield item["key"], item.get("value")
+
+
+def _freshness(binding: tuple[str, Any]) -> tuple[int, int]:
+    """Preference key for competing bindings (higher wins).
+
+    The copies are *not* interchangeable. The frontend normalises its form
+    into duplicate keys: the live ``agent-json`` (hyphen) holds the current
+    form object, while ``agent_json`` (underscore) is a serialized string
+    snapshot that lags behind the user's edits. Picking the wrong one silently
+    runs against stale credentials. So prefer a parsed object over a
+    serialized string (freshness), then the canonical hyphen spelling
+    (tie-break), then discovery order (stable sort).
+    """
+    alias, raw = binding
+    return (1 if isinstance(raw, dict) else 0, 1 if alias == "agent-json" else 0)
+
+
+def _first_valid(bindings: list[tuple[str, Any]]) -> AgentCredentialSpec | None:
+    """The freshest binding that normalises to a real spec, or ``None``.
+
+    Falls through to the next-freshest copy rather than giving up on the
+    freshest: a request carrying a placeholder object next to a real
+    serialized string is an agent run, not a direct one.
+    """
+    for _alias, raw in sorted(bindings, key=_freshness, reverse=True):
+        spec = normalize_agent_json(raw)
+        if spec is not None:
+            return spec
+    logger.debug(
+        "No agent-json binding in this request is a valid AgentCredentialSpec; "
+        "handling it as direct mode"
+    )
+    return None
+
+
+def _strip_agent_json(body: dict[str, Any]) -> dict[str, Any]:
+    """Copy of *body* with every agent-json key removed from every container.
+
+    Runs whenever a binding was found, whether or not it gets promoted: a
+    placeholder left inside ``credentials`` becomes a bogus credential pair
+    just as readily as a real spec would.  Stale top-level aliases go too, so
+    the promoted value is the only one Pydantic's ``AliasChoices`` can see.
+    """
+    stripped: dict[str, Any] = {}
+    for key, value in body.items():
+        if key in AGENT_JSON_ALIASES:
+            continue  # re-added canonically by the caller, if valid
+        if key in ("metadata", "connection_config") and isinstance(value, dict):
+            stripped[key] = {
+                k: v for k, v in value.items() if k not in AGENT_JSON_ALIASES
+            }
+        elif key == "credentials" and isinstance(value, dict):
+            stripped[key] = {
+                k: v for k, v in value.items() if k not in AGENT_JSON_ALIASES
+            }
+        elif key == "credentials" and isinstance(value, list):
+            stripped[key] = [
+                item
+                for item in value
+                if not (
+                    isinstance(item, dict) and item.get("key") in AGENT_JSON_ALIASES
+                )
+            ]
+        else:
+            stripped[key] = value
+    return stripped

--- a/application_sdk/credentials/ref.py
+++ b/application_sdk/credentials/ref.py
@@ -248,30 +248,15 @@ class CredentialRef(BaseModel, frozen=True):
             stacklevel=2,
         )
 
-        from application_sdk.credentials.spec import (  # noqa: PLC0415 — circular: credentials/__init__.py loads sibling modules
-            AgentCredentialSpec,
+        from application_sdk.credentials.ingress import (  # noqa: PLC0415 — circular: credentials/__init__.py loads sibling modules
+            normalize_agent_json,
         )
 
         method = (workflow_args.get("extraction_method") or "").strip().lower()
-        raw_agent = workflow_args.get("agent_json")
 
-        # Build a spec from whatever shape agent_json arrived in.
-        # AgentCredentialSpec's model_validator handles str, dict, and spec.
-        spec: AgentCredentialSpec | None = None
-        if raw_agent is not None:
-            if isinstance(raw_agent, AgentCredentialSpec):
-                spec = raw_agent
-            else:
-                try:
-                    spec = AgentCredentialSpec.model_validate(raw_agent)
-                # conformance: ignore[E004] probe/feature-detect: parse failure is benign; caller treats unparseable agent_json as absent
-                except Exception:
-                    logger.debug(
-                        "Failed to parse agent_json, treating as unpopulated",
-                        exc_info=True,
-                    )
-                    spec = None
-
+        # Raw workflow args, so agent_json may still be a JSON string, a dict, a
+        # spec, or a placeholder. One ingress normaliser owns all of that.
+        spec = normalize_agent_json(workflow_args.get("agent_json"))
         agent_populated = spec is not None and spec.is_populated()
 
         if method == "agent" and agent_populated:

--- a/application_sdk/credentials/spec.py
+++ b/application_sdk/credentials/spec.py
@@ -123,7 +123,15 @@ class AgentCredentialSpec(BaseModel):
     @model_validator(mode="before")
     @classmethod
     def _accept_string_or_dict(cls, data: Any) -> Any:
-        """Accept a JSON string, dict, or existing spec instance."""
+        """Accept a JSON string, dict, or existing spec instance.
+
+        The type layer of the field's ingress, and the only one: this is what
+        :func:`application_sdk.credentials.ingress.normalize_agent_json` calls,
+        and that function is the only lenient entry point — it turns the
+        exception raised here into "no agent reference". Readers take the typed
+        field; a reader catching a parse error is a guard that should have been
+        an ingress call.
+        """
         if isinstance(data, str):
             if not data or data.strip() in ("", "{}"):
                 return {"agent-name": ""}

--- a/application_sdk/execution/_temporal/preflight_gate.py
+++ b/application_sdk/execution/_temporal/preflight_gate.py
@@ -38,6 +38,7 @@ from temporalio.exceptions import TimeoutType
 
 with workflow.unsafe.imports_passed_through():
     from application_sdk.credentials.errors import CredentialNotFoundError
+    from application_sdk.credentials.ingress import normalize_agent_json
     from application_sdk.credentials.ref import CredentialRef, CredentialResolvable
     from application_sdk.credentials.resolver import CredentialResolver
     from application_sdk.credentials.spec import AgentCredentialSpec
@@ -276,7 +277,13 @@ class PreflightGateInput(BaseModel):
         base_kw: dict[str, Any] = dict(
             extraction_method=getattr(input_data, "extraction_method", "") or "",
             credential_guid=getattr(input_data, "credential_guid", "") or "",
-            agent_json=getattr(input_data, "agent_json", None),
+            # Normalised, not passed through: a custom input may still carry the
+            # raw wire value (a JSON string, or the marketplace-package
+            # placeholder that fails typed validation). Before this, such a value
+            # failed the construction below and cost the gate its
+            # extraction_method and credential_guid too — degrading credential
+            # resolution silently instead of just having no agent reference.
+            agent_json=normalize_agent_json(getattr(input_data, "agent_json", None)),
             credential_ref=getattr(input_data, "credential_ref", None),
             entrypoint=entrypoint,
             credential_ref_fields=credential_ref_fields,
@@ -284,13 +291,29 @@ class PreflightGateInput(BaseModel):
         )
         try:
             return cls(**base_kw)
-        except ValidationError:
+        except ValidationError as exc:
+            # Drop only the fields that actually failed, so one oddly-shaped
+            # field cannot cost the gate its routing triple (extraction_method /
+            # credential_guid / entrypoint) — without those the gate resolves the
+            # wrong credential, or none, and reports a fail-open verdict nobody
+            # can trace back to this line.
+            rejected = {str(error["loc"][0]) for error in exc.errors() if error["loc"]}
             logger.warning(
-                "Extraction input did not fit PreflightGateInput; using a minimal "
-                "gate input so the gate still runs",
+                "Extraction input did not fit PreflightGateInput; dropping the "
+                "rejected field(s) %s and keeping the rest",
+                sorted(rejected),
                 exc_info=True,
             )
-            return cls(entrypoint=entrypoint)
+            kept = {k: v for k, v in base_kw.items() if k not in rejected}
+            try:
+                return cls(**kept)
+            except ValidationError:
+                logger.warning(
+                    "Extraction input still did not fit PreflightGateInput; using "
+                    "a minimal gate input so the gate still runs",
+                    exc_info=True,
+                )
+                return cls(entrypoint=entrypoint)
 
 
 def preflight_gate_activity_name(app_name: str) -> str:

--- a/application_sdk/handler/service.py
+++ b/application_sdk/handler/service.py
@@ -164,8 +164,8 @@ class _RequestContractError(Exception):
 
     def __init__(self, cause: ValidationError) -> None:
         super().__init__(str(cause))
+        # The pydantic failure, kept so the handler can name the fields.
         self.cause = cause
-        """The pydantic failure, kept so the handler can name the fields."""
 
 
 def _validate_request(model: type[ModelT], body: dict[str, Any]) -> ModelT:

--- a/application_sdk/handler/service.py
+++ b/application_sdk/handler/service.py
@@ -1216,6 +1216,25 @@ def _register_workflow_routes(
 
         except HTTPException:
             raise
+        except ValidationError as e:
+            # The form endpoints (auth/check/metadata) validate their own body
+            # *outside* any error boundary, so their ValidationError propagates
+            # to the app-level 422 handler. Here the body is validated *inside*
+            # this try, and Starlette's exception middleware routes *any*
+            # exception escaping the route to a registered handler — so a bare
+            # re-raise would still reach the 422 handler. Convert instead:
+            # an internal validation failure on /start is a 500, never "the
+            # request did not fit the contract".
+            # conformance: ignore[L009] boundary handler logs the real exception (exc_info) then raises a sanitized HTTPException `from None`; the log is the only server-side record of the actual failure.
+            logger.error(
+                "Workflow input validation failed for app %s: %s",
+                app_name,
+                e,
+                exc_info=True,
+            )
+            raise HTTPException(
+                status_code=500, detail="Failed to start workflow"
+            ) from None
         except TypeError as e:
             # conformance: ignore[L009] boundary handler logs the real exception (exc_info) then raises a sanitized HTTPException `from None`; the log is the only server-side record of the actual failure.
             logger.error(
@@ -2580,9 +2599,13 @@ def create_app_handler_service(
         opaque JSON-decode failure with no hint of which field was wrong. The
         offending field name is the whole diagnosis, so say it.
 
-        Only ingress validation reaches here — each endpoint wraps its own body
-        in a broad ``except`` that answers 500 — so a 422 always means "the
-        request did not fit the contract", never "the handler failed".
+        Only ingress validation reaches here: the form endpoints (auth /
+        preflight / metadata) validate their body *before* entering their
+        error boundary, so their contract failures propagate to this handler,
+        while ``/start`` validates inside its boundary and explicitly
+        re-raises ``ValidationError`` past this handler — so a 422 always
+        means "the request did not fit the contract", never "the handler
+        failed".
 
         Pydantic's ``input`` and ``ctx`` are omitted: the rejected value can be
         a credential, and the field path plus the reason is what a caller can

--- a/application_sdk/handler/service.py
+++ b/application_sdk/handler/service.py
@@ -52,6 +52,7 @@ from fastapi import Query, Request, UploadFile
 from fastapi.responses import HTMLResponse, JSONResponse, Response
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel as PydanticBaseModel
+from pydantic import ValidationError
 from temporalio.client import WorkflowFailureError
 
 from application_sdk._runtime.offload import run_in_thread
@@ -61,6 +62,7 @@ from application_sdk.common.task_queue import (
 )
 from application_sdk.constants import CONTRACT_GENERATED_DIR as _CONTRACT_GENERATED_DIR
 from application_sdk.constants import DEPLOYMENT_NAME, LOCAL_ENVIRONMENT
+from application_sdk.credentials.ingress import lift_agent_json
 from application_sdk.errors import AppError
 from application_sdk.errors.categories import FailureCategory
 from application_sdk.handler.base import Handler, HandlerError
@@ -154,104 +156,6 @@ _CREDENTIAL_KEYS = frozenset(
 )
 
 
-_AGENT_JSON_KEYS = ("agent_json", "agentJson", "agent-json")
-
-
-def _coerce_agent_json(value: Any) -> dict[str, Any] | None:
-    """Return *value* as an agent-json dict, or ``None`` if it isn't one.
-
-    Form fields cross the wire as JSON strings, so an agent-json binding may
-    arrive either already-parsed (``dict``) or as a serialized string."""
-    if isinstance(value, dict):
-        return value if value else None
-    if isinstance(value, str) and value.strip():
-        try:
-            parsed = json.loads(value)
-        except (ValueError, TypeError):
-            return None
-        return parsed if isinstance(parsed, dict) and parsed else None
-    return None
-
-
-def _rank_agent_json(raw: Any, key: str) -> int:
-    """Preference score for competing agent-json bindings (higher wins).
-
-    A request can carry several agent-json copies at once, and they are *not*
-    interchangeable. The FE normalizes its form into duplicate keys: the live
-    ``agent-json`` (hyphen) holds the current form object, while ``agent_json``
-    (underscore) is a serialized string snapshot that lags behind edits. Picking
-    the wrong one silently runs the check against stale credentials. So prefer a
-    parsed object over a serialized string (freshness), and the canonical hyphen
-    ``agent-json`` over the underscore/camel aliases (tie-break)."""
-    return (2 if isinstance(raw, dict) else 0) + (1 if key == "agent-json" else 0)
-
-
-def _lift_agent_json(body: dict[str, Any]) -> dict[str, Any]:
-    """Surface the freshest agent-json binding to the top level for SDR detection.
-
-    The three endpoints detect SDR (customer-infra) runs by reading a *top-level*
-    ``agent_json`` off the typed input. Heracles, however, forwards the FE payload
-    verbatim: the agent-json arrives nested inside ``metadata``/``connection_config``
-    (the form's ``agent-json`` field → app ``metadata``) or inside ``credentials``
-    (the credential object), and the FE may include *several* copies at once (a
-    live object plus a stale serialized string, under hyphen and underscore keys).
-
-    Pick the highest-ranked copy (see :func:`_rank_agent_json`) across the top
-    level and every container, surface it as top-level ``agent_json`` (overriding
-    any stale top-level alias Pydantic would otherwise resolve first), and strip
-    every agent-json key from the containers so credential flattening never turns
-    one into a bogus pair. No-op when none is found (direct-mode requests)."""
-    best_rank = -1
-    best_aj: dict[str, Any] | None = None
-
-    for key in _AGENT_JSON_KEYS:
-        if key in body:
-            aj = _coerce_agent_json(body[key])
-            rank = _rank_agent_json(body[key], key)
-            if aj is not None and rank > best_rank:
-                best_rank, best_aj = rank, aj
-
-    for container in ("metadata", "connection_config", "credentials"):
-        c = body.get(container)
-        if isinstance(c, dict):
-            for key in _AGENT_JSON_KEYS:
-                if key in c:
-                    aj = _coerce_agent_json(c[key])
-                    rank = _rank_agent_json(c[key], key)
-                    if aj is not None and rank > best_rank:
-                        best_rank, best_aj = rank, aj
-        elif isinstance(c, list):  # v3 credentials: list[{key, value}]
-            for item in c:
-                if isinstance(item, dict) and item.get("key") in _AGENT_JSON_KEYS:
-                    raw = item.get("value")
-                    aj = _coerce_agent_json(raw)
-                    rank = _rank_agent_json(raw, item["key"])
-                    if aj is not None and rank > best_rank:
-                        best_rank, best_aj = rank, aj
-
-    if best_aj is None:
-        return body
-
-    result: dict[str, Any] = {}
-    for k, v in body.items():
-        if k in _AGENT_JSON_KEYS:
-            continue  # drop stale top-level aliases; re-added canonically below
-        if k in ("metadata", "connection_config") and isinstance(v, dict):
-            result[k] = {kk: vv for kk, vv in v.items() if kk not in _AGENT_JSON_KEYS}
-        elif k == "credentials" and isinstance(v, list):
-            result[k] = [
-                i
-                for i in v
-                if not (isinstance(i, dict) and i.get("key") in _AGENT_JSON_KEYS)
-            ]
-        elif k == "credentials" and isinstance(v, dict):
-            result[k] = {kk: vv for kk, vv in v.items() if kk not in _AGENT_JSON_KEYS}
-        else:
-            result[k] = v
-    result["agent_json"] = best_aj
-    return result
-
-
 # v2-compat: remove when Heracles sends credentials in v3 list[{key, value}] format.
 def _normalize_credentials(body: dict[str, Any]) -> dict[str, Any]:
     """Normalize v2 credential formats to v3 list[{key, value}] format.
@@ -297,7 +201,7 @@ def _normalize_credentials(body: dict[str, Any]) -> dict[str, Any]:
 
 def _normalize_preflight_request(body: dict[str, Any]) -> dict[str, Any]:
     """Normalize preflight-specific compatibility fields before validation."""
-    normalized = _normalize_credentials(_lift_agent_json(body))
+    normalized = _normalize_credentials(lift_agent_json(body))
     has_metadata = "metadata" in normalized and normalized["metadata"] is not None
     has_connection_config = (
         "connection_config" in normalized
@@ -2663,6 +2567,56 @@ def create_app_handler_service(
     )
     app.add_middleware(LogMiddleware)
 
+    @app.exception_handler(ValidationError)
+    async def _handle_request_validation_error(
+        request: Request, exc: Exception
+    ) -> JSONResponse:
+        """Turn a request-body validation failure into a 422 naming the field.
+
+        The form endpoints validate their own body (they have to normalise v2
+        wire shapes first), so FastAPI's own ``RequestValidationError`` handling
+        never sees it: an unhandled ``ValidationError`` becomes Starlette's
+        plain-text ``Internal Server Error``, which reaches the caller as an
+        opaque JSON-decode failure with no hint of which field was wrong. The
+        offending field name is the whole diagnosis, so say it.
+
+        Only ingress validation reaches here — each endpoint wraps its own body
+        in a broad ``except`` that answers 500 — so a 422 always means "the
+        request did not fit the contract", never "the handler failed".
+
+        Pydantic's ``input`` and ``ctx`` are omitted: the rejected value can be
+        a credential, and the field path plus the reason is what a caller can
+        act on.
+        """
+        errors = (
+            exc.errors(include_url=False, include_input=False, include_context=False)
+            if isinstance(exc, ValidationError)
+            else []
+        )
+        detail = [
+            {
+                "field": ".".join(str(part) for part in error["loc"]),
+                "message": error["msg"],
+                "type": error["type"],
+            }
+            for error in errors
+        ]
+        fields = ", ".join(item["field"] for item in detail if item["field"]) or "body"
+        logger.warning(
+            "Rejected a malformed request to %s for app %s: invalid field(s) %s",
+            request.url.path,
+            app_name,
+            fields,
+        )
+        return JSONResponse(
+            status_code=422,
+            content={
+                "success": False,
+                "message": f"Invalid request: {fields}",
+                "detail": detail,
+            },
+        )
+
     def _create_context(credentials: list[HandlerCredential]) -> HandlerContext:
         return HandlerContext(
             app_name=app_name,
@@ -2678,7 +2632,7 @@ def create_app_handler_service(
 
     @app.post("/workflows/v1/auth")
     async def test_auth(request: Request) -> JSONResponse:
-        body = _normalize_credentials(_lift_agent_json(await request.json()))
+        body = _normalize_credentials(lift_agent_json(await request.json()))
         auth_input = AuthInput.model_validate(body)
         credentials = [
             HandlerCredential(key=c.key, value=c.value) for c in auth_input.credentials
@@ -2906,7 +2860,7 @@ def create_app_handler_service(
 
     @app.post("/workflows/v1/metadata")
     async def fetch_metadata(request: Request) -> JSONResponse:
-        body = _normalize_credentials(_lift_agent_json(await request.json()))
+        body = _normalize_credentials(lift_agent_json(await request.json()))
         metadata_input = MetadataInput.model_validate(body)
         # The widget routing key (``metadataTemplateKey`` / ``type`` on the
         # wire) now lands in its documented home, ``metadata_template_key``,

--- a/application_sdk/handler/service.py
+++ b/application_sdk/handler/service.py
@@ -41,7 +41,7 @@ from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime, timedelta
 from pathlib import Path, PurePosixPath
 from types import ModuleType
-from typing import TYPE_CHECKING, Annotated, Any, cast
+from typing import TYPE_CHECKING, Annotated, Any, TypeVar, cast
 from uuid import uuid4
 
 import orjson
@@ -140,6 +140,45 @@ def _record_proxy_failure(
     )
     counter.add(1, {"reason": reason})
     logger.warning(log_message, *log_args, exc_info=exc_info)
+
+
+ModelT = TypeVar("ModelT", bound=PydanticBaseModel)
+
+
+class _RequestContractError(Exception):
+    """A request body did not fit its typed contract at ingress → 422.
+
+    The marker *is* the enforcement. The 422 handler is registered on this
+    type, not on pydantic's ``ValidationError``, so an endpoint gets a
+    contract-shaped answer only by validating through
+    :func:`_validate_request` — which is also the only place that decides a
+    failure is the caller's fault. A ``ValidationError`` raised anywhere else
+    (inside an endpoint's error boundary, in handler business logic, in an
+    output contract) keeps that endpoint's own 500 and can never be
+    mistaken for a malformed request.
+
+    Which endpoints answer 422 is therefore visible in the call sites rather
+    than asserted in prose, and the default for a new endpoint is the safe
+    one: a bare ``model_validate`` still yields a 500.
+    """
+
+    def __init__(self, cause: ValidationError) -> None:
+        super().__init__(str(cause))
+        self.cause = cause
+        """The pydantic failure, kept so the handler can name the fields."""
+
+
+def _validate_request(model: type[ModelT], body: dict[str, Any]) -> ModelT:
+    """Validate an already-normalised request body into its typed contract.
+
+    Raises :class:`_RequestContractError` so the app-level handler answers 422
+    naming the offending field. Use this for anything a *caller* controls; use
+    ``model_validate`` directly where a failure would be an internal bug.
+    """
+    try:
+        return model.model_validate(body)
+    except ValidationError as exc:
+        raise _RequestContractError(exc) from exc
 
 
 _CREDENTIAL_KEYS = frozenset(
@@ -1217,14 +1256,13 @@ def _register_workflow_routes(
         except HTTPException:
             raise
         except ValidationError as e:
-            # The form endpoints (auth/check/metadata) validate their own body
-            # *outside* any error boundary, so their ValidationError propagates
-            # to the app-level 422 handler. Here the body is validated *inside*
-            # this try, and Starlette's exception middleware routes *any*
-            # exception escaping the route to a registered handler — so a bare
-            # re-raise would still reach the 422 handler. Convert instead:
-            # an internal validation failure on /start is a 500, never "the
-            # request did not fit the contract".
+            # /start validates the app's own input contract, which the caller
+            # does not own — so this is an internal failure, not a malformed
+            # request, and it answers a sanitized 500 with the real cause in
+            # the log. It cannot reach the 422 handler (that one is registered
+            # on _RequestContractError, which only _validate_request raises);
+            # catching here is what turns Starlette's plain-text 500 into the
+            # boundary's own logged, sanitized one.
             # conformance: ignore[L009] boundary handler logs the real exception (exc_info) then raises a sanitized HTTPException `from None`; the log is the only server-side record of the actual failure.
             logger.error(
                 "Workflow input validation failed for app %s: %s",
@@ -2586,11 +2624,11 @@ def create_app_handler_service(
     )
     app.add_middleware(LogMiddleware)
 
-    @app.exception_handler(ValidationError)
-    async def _handle_request_validation_error(
+    @app.exception_handler(_RequestContractError)
+    async def _handle_request_contract_error(
         request: Request, exc: Exception
     ) -> JSONResponse:
-        """Turn a request-body validation failure into a 422 naming the field.
+        """Turn a request-body contract failure into a 422 naming the field.
 
         The form endpoints validate their own body (they have to normalise v2
         wire shapes first), so FastAPI's own ``RequestValidationError`` handling
@@ -2599,21 +2637,21 @@ def create_app_handler_service(
         opaque JSON-decode failure with no hint of which field was wrong. The
         offending field name is the whole diagnosis, so say it.
 
-        Only ingress validation reaches here: the form endpoints (auth /
-        preflight / metadata) validate their body *before* entering their
-        error boundary, so their contract failures propagate to this handler,
-        while ``/start`` validates inside its boundary and explicitly
-        re-raises ``ValidationError`` past this handler — so a 422 always
-        means "the request did not fit the contract", never "the handler
-        failed".
+        Registered on :class:`_RequestContractError`, never on pydantic's
+        ``ValidationError``: reaching here takes an explicit
+        :func:`_validate_request` call, so a 422 always means "the request did
+        not fit the contract" and no other validation failure in the process
+        can be reported as the caller's fault. See the marker's docstring.
 
         Pydantic's ``input`` and ``ctx`` are omitted: the rejected value can be
         a credential, and the field path plus the reason is what a caller can
         act on.
         """
         errors = (
-            exc.errors(include_url=False, include_input=False, include_context=False)
-            if isinstance(exc, ValidationError)
+            exc.cause.errors(
+                include_url=False, include_input=False, include_context=False
+            )
+            if isinstance(exc, _RequestContractError)
             else []
         )
         detail = [
@@ -2656,7 +2694,7 @@ def create_app_handler_service(
     @app.post("/workflows/v1/auth")
     async def test_auth(request: Request) -> JSONResponse:
         body = _normalize_credentials(lift_agent_json(await request.json()))
-        auth_input = AuthInput.model_validate(body)
+        auth_input = _validate_request(AuthInput, body)
         credentials = [
             HandlerCredential(key=c.key, value=c.value) for c in auth_input.credentials
         ]
@@ -2753,7 +2791,7 @@ def create_app_handler_service(
     @app.post("/workflows/v1/check")
     async def preflight_check(request: Request) -> JSONResponse:
         body = _normalize_preflight_request(await request.json())
-        preflight_input = PreflightInput.model_validate(body)
+        preflight_input = _validate_request(PreflightInput, body)
         credentials = [
             HandlerCredential(key=c.key, value=c.value)
             for c in preflight_input.credentials
@@ -2884,7 +2922,7 @@ def create_app_handler_service(
     @app.post("/workflows/v1/metadata")
     async def fetch_metadata(request: Request) -> JSONResponse:
         body = _normalize_credentials(lift_agent_json(await request.json()))
-        metadata_input = MetadataInput.model_validate(body)
+        metadata_input = _validate_request(MetadataInput, body)
         # The widget routing key (``metadataTemplateKey`` / ``type`` on the
         # wire) now lands in its documented home, ``metadata_template_key``,
         # via the field's validation alias. Mirror it onto ``object_filter``

--- a/application_sdk/templates/contracts/sql_metadata.py
+++ b/application_sdk/templates/contracts/sql_metadata.py
@@ -18,6 +18,10 @@ from application_sdk.common.sql_filters import (
 )
 from application_sdk.contracts.base import Input, Output, PublishInputMixin
 from application_sdk.contracts.types import ConnectionRef, FileReference, MaxItems
+from application_sdk.credentials.ingress import (
+    declared_agent_spec_type,
+    normalize_agent_json,
+)
 from application_sdk.credentials.ref import CredentialRef
 from application_sdk.credentials.spec import AgentCredentialSpec
 from application_sdk.errors.wire import FailureDetails
@@ -145,6 +149,35 @@ class ExtractionInput(Input):
     the spec's model validator normalises all three forms.
     """
 
+    # Declared *before* ``_normalize_ae_payload`` so it runs *after* it:
+    # pydantic applies ``mode="before"`` model validators in reverse definition
+    # order, and this one must see the ``agent_json`` that validator lifts out
+    # of a nested AE ``metadata`` block.
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize_agent_json(cls, data: Any) -> Any:
+        """Canonicalise ``agent_json`` to the declared spec type, or ``None``.
+
+        AE replays whatever the connection record carries, which for eleven
+        marketplace packages is a placeholder blob that coerces to a dict but
+        fails typed validation. One ingress normaliser decides that for every
+        reader (see :mod:`application_sdk.credentials.ingress`); this contract
+        just applies it, so a placeholder lands as ``None`` instead of failing
+        the whole extraction input.
+
+        Validated against the *declared* field type, so a connector that
+        narrows ``agent_json`` to its own :class:`AgentCredentialSpec` subclass
+        gets that subclass — and its stricter validation.
+        """
+        if not isinstance(data, dict) or "agent_json" not in data:
+            return data
+        return {
+            **data,
+            "agent_json": normalize_agent_json(
+                data["agent_json"], spec_type=declared_agent_spec_type(cls)
+            ),
+        }
+
     @model_validator(mode="before")
     @classmethod
     def _normalize_ae_payload(cls, data: Any) -> Any:
@@ -189,22 +222,6 @@ class ExtractionInput(Input):
 
         if updates:
             data = {**data, **updates}
-        return data
-
-    @model_validator(mode="before")
-    @classmethod
-    def _skip_agent_json_for_direct(cls, data: Any) -> Any:
-        """Null out agent_json when extraction_method is direct.
-
-        In direct mode, agent_json may contain placeholder values (e.g.
-        ``"port": "port"``) that fail AgentCredentialSpec validation.
-        Since agent_json is only used for agent-based extraction, we
-        discard it for direct mode.
-        """
-        if isinstance(data, dict):
-            method = data.get("extraction_method", "")
-            if method != "agent" and "agent_json" in data:
-                data = {**data, "agent_json": None}
         return data
 
     output_prefix: str = ""

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -1,8 +1,8 @@
 <!--
 generated-by:  capability-manifest skill (.claude/skills/capability-manifest)
 sdk-version:   3.28.0
-source-sha:    c2d4cc992a0e6aaa5600ff76c3f8bc57b5d0642e
-source-date:   2026-08-17T12:11:56Z
+source-sha:    5b5599430dacc5b98e1f0d8758b66be8d6a8acad
+source-date:   2026-08-18T07:47:50Z
 do-not-edit:   re-run the skill instead of hand-editing
 -->
 
@@ -22,7 +22,7 @@ do-not-edit:   re-run the skill instead of hand-editing
 | `application_sdk.clients` | Connection clients (SQL, Redis, Azure) and ClientInterface ABC | 11 |
 | `application_sdk.common` | Shared utilities — SQL filters, concurrency helpers, TaskStatistics, DataframeType | 11 |
 | `application_sdk.contracts` | Typed Pydantic Input/Output base classes, payload safety, storage and type helpers | 28 |
-| `application_sdk.credentials` | Credential resolvers (Atlan, OAuth, Git, agent), registry, vault spec | 41 |
+| `application_sdk.credentials` | Credential resolvers (Atlan, OAuth, Git, agent), registry, vault spec | 45 |
 | `application_sdk.errors` | Structured error codes — ErrorCode dataclass and cross-component constants (APP_ERROR, HANDLER_ERROR, CONTRACT_VALIDATION, etc.) | 61 |
 | `application_sdk.execution` | Task/workflow execution — retry, heartbeat, sandbox, AppWorker, Temporal client | 21 |
 | `application_sdk.handler` | HTTP handler framework — Handler ABC, DefaultHandler, preflight, auth, service factory | 22 |
@@ -829,6 +829,13 @@ Credential resolvers (Atlan, OAuth, Git, agent), registry, vault spec
 - **Summary:** Create a pyatlan_v9 AsyncAtlanClient from a resolved Atlan credential.
 - **Defined in:** `application_sdk/credentials/atlan_client.py`
 
+#### `declared_agent_spec_type`
+
+- **Import:** `from application_sdk.credentials import declared_agent_spec_type`
+- **Signature:** `declared_agent_spec_type(model_cls: type[BaseModel])`
+- **Summary:** The spec class *model_cls* declares for its ``agent_json`` field.
+- **Defined in:** `application_sdk/credentials/ingress.py`
+
 #### `expand_dotted_keys`
 
 - **Import:** `from application_sdk.credentials import expand_dotted_keys`
@@ -871,6 +878,20 @@ Credential resolvers (Atlan, OAuth, Git, agent), registry, vault spec
 - **Summary:** Create a CredentialRef from a platform-issued credential GUID.
 - **Defined in:** `application_sdk/credentials/ref.py`
 
+#### `lift_agent_json`
+
+- **Import:** `from application_sdk.credentials import lift_agent_json`
+- **Signature:** `lift_agent_json(body: dict[str, Any])`
+- **Summary:** Promote the freshest ``agent_json`` binding in *body* to a typed field.
+- **Defined in:** `application_sdk/credentials/ingress.py`
+
+#### `normalize_agent_json`
+
+- **Import:** `from application_sdk.credentials import normalize_agent_json`
+- **Signature:** `normalize_agent_json(value: Any, *, spec_type: type[SpecT] = AgentCredentialSpec)`
+- **Summary:** Canonicalise one ``agent_json`` value to a typed spec, or ``None``.
+- **Defined in:** `application_sdk/credentials/ingress.py`
+
 #### `oauth_client_ref`
 
 - **Import:** `from application_sdk.credentials import oauth_client_ref`
@@ -898,6 +919,15 @@ Credential resolvers (Atlan, OAuth, Git, agent), registry, vault spec
 - **Signature:** `transform_agent_credentials(agent_json: dict[str, Any])`
 - **Summary:** Transform raw agent JSON into the format connectors expect.
 - **Defined in:** `application_sdk/common/transforms.py`
+
+### Constants and Enums
+
+#### `AGENT_JSON_ALIASES`
+
+- **Import:** `from application_sdk.credentials import AGENT_JSON_ALIASES`
+- **Signature:** `AGENT_JSON_ALIASES: Final[tuple[str, ...]]`
+- **Summary:** Every spelling the field arrives under, in discovery order.
+- **Defined in:** `application_sdk/credentials/ingress.py`
 
 ## `application_sdk.errors`
 

--- a/docs/concepts/credentials.md
+++ b/docs/concepts/credentials.md
@@ -191,6 +191,49 @@ See [Testing Apps](apps.md#testing-apps) and [Integration Testing](../guides/int
 
 ---
 
+## agent_json ingress
+
+`agent_json` names an agent-shape credential *reference* used by SDR
+(customer-infra) runs. It reaches the SDK in an arbitrary combination of three
+alias spellings (`agent_json`, `agentJson`, `agent-json`), four container
+positions (top level, `metadata`, `connection_config`, `credentials` — the last
+in both the v2 dict and the v3 `list[{key, value}]` shape) and three types (JSON
+string, dict, `AgentCredentialSpec`). It may also carry a meaningless
+placeholder: eleven marketplace packages default the Argo `agent-json` param to
+a blob whose values are the key names (`{"port": "port", ...}`), that blob is
+persisted on the connection record, and it is replayed verbatim into v3 typed
+requests.
+
+`application_sdk.credentials.ingress` is the only place that tolerates any of
+that. **Every reader takes the typed field.** Do not add a guard of your own.
+
+```python
+from application_sdk.credentials import lift_agent_json, normalize_agent_json
+
+# One value -> a typed spec, or None. None means "no agent reference here":
+# absent, empty, unparseable, or a placeholder that fails typed validation.
+spec = normalize_agent_json(raw_value)
+
+# A whole request body -> the same body with every agent-json key stripped from
+# every container and the typed spec promoted to `body["agent_json"]`.
+body = lift_agent_json(await request.json())
+```
+
+Two things stay outside the normaliser:
+
+- **`is_populated()` is the consumers' call.** A spec that validates but carries
+  no fetch anchor (a name with no `secret-path`) is a real reference as far as
+  ingress is concerned; whoever resolves it decides whether that is usable.
+- **Connector subclasses.** Pass `spec_type=` (or use
+  `declared_agent_spec_type(MyInput)`) when the reader's field narrows
+  `agent_json` to an `AgentCredentialSpec` subclass, so validation uses that
+  subclass's rules and the reader gets the type it declared.
+
+A malformed body reaching a handler endpoint is answered with **422** naming the
+offending field, not a plain-text 500.
+
+---
+
 ## Utility: parse_credentials_extra
 
 For connectors that receive credentials as a flat dict (e.g. from Heracles), use `parse_credentials_extra` to extract nested fields:

--- a/tests/unit/credentials/test_ingress.py
+++ b/tests/unit/credentials/test_ingress.py
@@ -193,6 +193,20 @@ class TestLiftAgentJson:
         out = lift_agent_json({"metadata": {"agent_json": self._STALE}})
         assert self._raw(out)["basic.username"] == "username"
 
+    def test_typed_spec_beats_a_stale_serialized_string(self) -> None:
+        """A typed spec is the most-processed form — it must rank as parsed.
+
+        Ranking it with the serialized strings would let a stale string
+        snapshot (which lags the user's edits) beat a current typed spec —
+        the stale-credential selection the freshness ordering exists to
+        prevent.
+        """
+        typed = AgentCredentialSpec.model_validate(self._FRESH)
+        out = lift_agent_json(
+            {"metadata": {"agent_json": self._STALE, "agentJson": typed}}
+        )
+        assert self._raw(out)["basic.username"] == "USERNAME"
+
     def test_top_level_fresh_hyphen_overrides_stale_underscore(self) -> None:
         out = lift_agent_json({"agent_json": self._STALE, "agent-json": self._FRESH})
         assert self._raw(out)["basic.username"] == "USERNAME"

--- a/tests/unit/credentials/test_ingress.py
+++ b/tests/unit/credentials/test_ingress.py
@@ -1,0 +1,313 @@
+"""Tests for the ``agent_json`` ingress normaliser.
+
+These are the behavioural contract for every reader of the field: the six
+places that each used to tolerate the wire variety on their own now delegate
+here, so this file is where the tolerance is pinned.
+"""
+
+from __future__ import annotations
+
+import json
+
+from pydantic import BaseModel, ConfigDict
+
+from application_sdk.credentials.ingress import (
+    declared_agent_spec_type,
+    lift_agent_json,
+    normalize_agent_json,
+)
+from application_sdk.credentials.spec import AgentCredentialSpec
+
+# The marketplace-package template default: every field name submitted as its
+# own value, because a sibling Argo param indexes straight into the JSON and has
+# to evaluate even in direct mode. ``port`` is the spec's only non-str field, so
+# this coerces to a dict yet fails typed validation.
+PLACEHOLDER = {
+    "agent-name": "agent-name",
+    "aws-auth-method": "aws-auth-method",
+    "host": "host",
+    "port": "port",
+    "secret-manager": "secret-manager",
+}
+
+REAL = {
+    "agent-name": "acme-agent",
+    "secret-path": "arn:aws:secretsmanager:us-east-1:1:secret:x",
+    "host": "db.example.com",
+    "port": 1521,
+}
+
+
+class TestNormalizeAgentJson:
+    """``normalize_agent_json``: one value → a typed spec, or ``None``."""
+
+    def test_dict_becomes_a_spec(self) -> None:
+        spec = normalize_agent_json(REAL)
+        assert spec is not None
+        assert spec.agent_name == "acme-agent"
+        assert spec.port == 1521
+
+    def test_json_string_becomes_a_spec(self) -> None:
+        spec = normalize_agent_json(json.dumps(REAL))
+        assert spec is not None
+        assert spec.agent_name == "acme-agent"
+
+    def test_existing_spec_passes_through_unchanged(self) -> None:
+        original = AgentCredentialSpec.model_validate(REAL)
+        assert normalize_agent_json(original) is original
+
+    def test_connector_dotted_keys_survive(self) -> None:
+        spec = normalize_agent_json({"agent-name": "acme", "basic.username": "u"})
+        assert spec is not None
+        assert spec.to_raw_dict()["basic.username"] == "u"
+
+    def test_placeholder_is_absent(self) -> None:
+        assert normalize_agent_json(PLACEHOLDER) is None
+
+    def test_meaningless_values_are_absent(self) -> None:
+        for value in (None, "", "  ", "{}", {}, "{", "not json", "[1, 2]", '"x"'):
+            assert normalize_agent_json(value) is None, value
+
+    def test_valid_but_unpopulated_spec_is_kept(self) -> None:
+        """``is_populated()`` is the consumers' call, not ingress's. A name-only
+        spec parses, so it is returned and left for the resolver to reject."""
+        spec = normalize_agent_json({"agent-name": "acme"})
+        assert spec is not None
+        assert not spec.is_populated()
+
+    def test_spec_type_narrows_validation(self) -> None:
+        class StrictSpec(AgentCredentialSpec):
+            model_config = ConfigDict(
+                extra="forbid", frozen=True, populate_by_name=True
+            )
+
+        assert normalize_agent_json(REAL, spec_type=StrictSpec) is not None
+        # ``basic.username`` is not declared on the subclass → forbidden.
+        assert (
+            normalize_agent_json(
+                {"agent-name": "acme", "basic.username": "u"}, spec_type=StrictSpec
+            )
+            is None
+        )
+
+    def test_base_spec_is_revalidated_against_a_narrower_type(self) -> None:
+        """A reader declaring a subclass gets the subclass, not the base — its
+        own field would reject a base instance."""
+
+        class StrictSpec(AgentCredentialSpec):
+            model_config = ConfigDict(
+                extra="forbid", frozen=True, populate_by_name=True
+            )
+
+        base = AgentCredentialSpec.model_validate(REAL)
+        narrowed = normalize_agent_json(base, spec_type=StrictSpec)
+        assert isinstance(narrowed, StrictSpec)
+        assert narrowed.agent_name == "acme-agent"
+
+
+class TestDeclaredAgentSpecType:
+    """``declared_agent_spec_type``: read the spec class a model asks for."""
+
+    def test_base_annotation(self) -> None:
+        class _Input(BaseModel):
+            agent_json: AgentCredentialSpec | None = None
+
+        assert declared_agent_spec_type(_Input) is AgentCredentialSpec
+
+    def test_subclass_annotation(self) -> None:
+        class _Spec(AgentCredentialSpec):
+            pass
+
+        class _Input(BaseModel):
+            agent_json: _Spec | None = None
+
+        assert declared_agent_spec_type(_Input) is _Spec
+
+    def test_missing_field_falls_back_to_the_base(self) -> None:
+        class _Input(BaseModel):
+            pass
+
+        assert declared_agent_spec_type(_Input) is AgentCredentialSpec
+
+
+class TestLiftAgentJson:
+    """``lift_agent_json``: surface the freshest binding as a typed field.
+
+    Heracles forwards the frontend payload verbatim, so the binding can arrive
+    nested (metadata / connection_config / credentials) and in several competing
+    copies at once — a live hyphen ``agent-json`` object next to a stale
+    underscore ``agent_json`` serialized string. The lift must surface the
+    freshest copy at the canonical top-level ``agent_json`` key, typed.
+    """
+
+    _FRESH = {"agent-name": "acme", "basic.username": "USERNAME", "host": "h"}
+    _STALE = '{"agent-name": "acme", "basic.username": "username", "host": "h"}'
+
+    @staticmethod
+    def _raw(body: dict) -> dict:
+        """The promoted spec back as a wire dict, for comparison."""
+        return body["agent_json"].to_raw_dict()
+
+    def test_promotes_a_typed_spec_not_a_dict(self) -> None:
+        out = lift_agent_json({"metadata": {"agent-json": self._FRESH}})
+        assert isinstance(out["agent_json"], AgentCredentialSpec)
+
+    # ---- competing copies -------------------------------------------------
+
+    def test_object_beats_string_and_hyphen_beats_underscore(self) -> None:
+        # A parsed object is the live form state; a serialized string is a
+        # snapshot that lags behind the user's edits.
+        both = lift_agent_json(
+            {"metadata": {"agent_json": self._STALE, "agent-json": self._FRESH}}
+        )
+        assert self._raw(both)["basic.username"] == "USERNAME"
+        # ...and among two strings, the canonical hyphen spelling wins.
+        strings = lift_agent_json(
+            {
+                "metadata": {
+                    "agent_json": self._STALE,
+                    "agent-json": json.dumps(self._FRESH),
+                }
+            }
+        )
+        assert self._raw(strings)["basic.username"] == "USERNAME"
+
+    def test_sage_shape_picks_fresh_object_over_stale_string(self) -> None:
+        # /sage: heracles forwards formData -> metadata carrying BOTH copies.
+        body = {
+            "credentials": {"connectorConfigName": "atlan-connectors-mssql"},
+            "metadata": {
+                "agent_json": self._STALE,
+                "agent-json": self._FRESH,
+                "extraction-method": "agent",
+            },
+        }
+        out = lift_agent_json(body)
+        assert self._raw(out)["basic.username"] == "USERNAME"
+        # both agent-json keys stripped from the container
+        assert "agent_json" not in out["metadata"]
+        assert "agent-json" not in out["metadata"]
+        assert out["metadata"]["extraction-method"] == "agent"
+
+    def test_serialized_string_used_as_fallback_when_no_object(self) -> None:
+        out = lift_agent_json({"metadata": {"agent_json": self._STALE}})
+        assert self._raw(out)["basic.username"] == "username"
+
+    def test_top_level_fresh_hyphen_overrides_stale_underscore(self) -> None:
+        out = lift_agent_json({"agent_json": self._STALE, "agent-json": self._FRESH})
+        assert self._raw(out)["basic.username"] == "USERNAME"
+        # stale aliases are dropped; only the canonical top-level key remains
+        assert "agent-json" not in out
+
+    def test_top_level_wins_over_a_nested_copy_of_equal_freshness(self) -> None:
+        out = lift_agent_json(
+            {
+                "agent-json": self._FRESH,
+                "metadata": {"agent-json": {"agent-name": "other"}},
+            }
+        )
+        assert out["agent_json"].agent_name == "acme"
+
+    # ---- positions --------------------------------------------------------
+
+    def test_agent_json_inside_credentials_dict(self) -> None:
+        out = lift_agent_json(
+            {"credentials": {"agent-json": self._FRESH, "connectorConfigName": "x"}}
+        )
+        assert out["agent_json"].agent_name == "acme"
+        assert "agent-json" not in out["credentials"]
+        assert out["credentials"]["connectorConfigName"] == "x"
+
+    def test_agent_json_inside_v3_credentials_list(self) -> None:
+        out = lift_agent_json(
+            {
+                "credentials": [
+                    {"key": "agent-json", "value": self._FRESH},
+                    {"key": "connectorConfigName", "value": "x"},
+                ]
+            }
+        )
+        assert out["agent_json"].agent_name == "acme"
+        assert all(c["key"] != "agent-json" for c in out["credentials"])
+
+    def test_agent_json_inside_connection_config(self) -> None:
+        out = lift_agent_json({"connection_config": {"agentJson": self._FRESH}})
+        assert out["agent_json"].agent_name == "acme"
+        assert "agentJson" not in out["connection_config"]
+
+    # ---- nothing to lift --------------------------------------------------
+
+    def test_direct_mode_body_unchanged(self) -> None:
+        body = {"credentials": {"host": "h", "username": "u"}}
+        assert lift_agent_json(body) == body
+
+    def test_empty_agent_json_ignored(self) -> None:
+        assert "agent_json" not in lift_agent_json({"metadata": {"agent-json": {}}})
+        assert "agent_json" not in lift_agent_json({"metadata": {"agent_json": ""}})
+
+    def test_unparseable_string_ignored(self) -> None:
+        assert "agent_json" not in lift_agent_json({"metadata": {"agent_json": "{"}})
+
+    # ---- rendered-but-unfilled agent widget (placeholder values) ----------
+    #
+    # Promoting the placeholder made PreflightInput/AuthInput/MetadataInput raise
+    # an unhandled ValidationError -> plain-text 500 -> opaque JSON-decode error
+    # at the caller, on every direct-mode request whose form renders the widget.
+
+    def test_placeholder_widget_is_not_promoted(self) -> None:
+        out = lift_agent_json({"metadata": {"agent-json": PLACEHOLDER}})
+        assert (
+            "agent_json" not in out
+        ), "a placeholder spec must not reach the typed agent_json field"
+
+    def test_placeholder_inside_credentials_is_still_stripped(self) -> None:
+        """Not promoted, but still removed — otherwise the v2→v3 credential shim
+        flattens it into a bogus ``agent-json`` credential pair."""
+        out = lift_agent_json({"credentials": {"agent-json": PLACEHOLDER, "host": "h"}})
+        assert "agent_json" not in out
+        assert "agent-json" not in out["credentials"]
+        assert out["credentials"]["host"] == "h"
+
+    def test_placeholder_in_v3_credentials_list_is_still_stripped(self) -> None:
+        out = lift_agent_json(
+            {
+                "credentials": [
+                    {"key": "agent-json", "value": PLACEHOLDER},
+                    {"key": "host", "value": "h"},
+                ]
+            }
+        )
+        assert "agent_json" not in out
+        assert all(c["key"] != "agent-json" for c in out["credentials"])
+
+    def test_real_spec_is_still_promoted(self) -> None:
+        out = lift_agent_json({"metadata": {"agent-json": REAL}})
+        assert out["agent_json"] == AgentCredentialSpec.model_validate(REAL)
+
+    def test_real_spec_wins_over_a_placeholder_copy(self) -> None:
+        out = lift_agent_json(
+            {"metadata": {"agent-json": REAL, "agent_json": json.dumps(REAL)}}
+        )
+        assert out["agent_json"].agent_name == "acme-agent"
+
+    def test_falls_through_a_fresher_placeholder_to_a_real_copy(self) -> None:
+        """A placeholder object next to a real serialized string is an agent
+        run, not a direct one: freshness ranks the copies, validity picks the
+        winner among them."""
+        out = lift_agent_json(
+            {
+                "metadata": {
+                    "agent-json": PLACEHOLDER,
+                    "agent_json": json.dumps(REAL),
+                }
+            }
+        )
+        assert out["agent_json"].agent_name == "acme-agent"
+
+    def test_valid_but_unpopulated_spec_is_still_promoted(self) -> None:
+        """A name-only spec parses, so it is promoted and left for the SDR
+        resolver's ``is_populated()`` check to reject."""
+        out = lift_agent_json({"metadata": {"agent-json": {"agent-name": "acme"}}})
+        assert out["agent_json"] == AgentCredentialSpec.model_validate(
+            {"agent-name": "acme"}
+        )

--- a/tests/unit/execution/test_preflight_gate_activity.py
+++ b/tests/unit/execution/test_preflight_gate_activity.py
@@ -506,7 +506,10 @@ class TestPreflightGateActivity:
     ) -> None:
         # An input field that won't fit PreflightGateInput (e.g. credential_ref
         # as a plain string rather than a CredentialRef) triggers ValidationError.
-        # The gate must degrade to a minimal input, never raise.
+        # The gate must degrade, never raise — and degrade *only* the rejected
+        # field: dropping the routing triple with it makes the gate resolve the
+        # wrong credential, or none, and report a fail-open verdict nobody can
+        # trace back to the offending field.
         class _Inp:
             extraction_method = "direct"
             credential_guid = "g-9"
@@ -515,8 +518,49 @@ class TestPreflightGateActivity:
 
         gate_input = PreflightGateInput.from_extraction_input(_Inp(), "crawl")
         assert gate_input.entrypoint == "crawl"  # built, did not raise
-        # Minimal fallback: routing fields from the bad input are not present
-        assert gate_input.credential_guid == ""
+        assert gate_input.credential_ref is None  # the rejected field, dropped
+        assert gate_input.extraction_method == "direct"  # routing survives
+        assert gate_input.credential_guid == "g-9"
+
+    def test_from_extraction_input_keeps_routing_past_a_placeholder_agent_json(
+        self,
+    ) -> None:
+        # The live shape of this bug: AE replays the marketplace-package
+        # placeholder blob onto a direct-mode run. It is not an agent reference
+        # (``port`` is the spec's only non-str field), and it used to fail the
+        # whole gate input — silently costing the gate its extraction_method and
+        # credential_guid, so credential resolution degraded with no report.
+        class _Inp:
+            extraction_method = "direct"
+            credential_guid = "g-9"
+            agent_json = {
+                "agent-name": "agent-name",
+                "host": "host",
+                "port": "port",
+                "secret-manager": "secret-manager",
+            }
+            credential_ref = None
+
+        gate_input = PreflightGateInput.from_extraction_input(_Inp(), "crawl")
+        assert gate_input.agent_json is None  # placeholder is not a reference
+        assert gate_input.extraction_method == "direct"
+        assert gate_input.credential_guid == "g-9"
+
+    def test_from_extraction_input_normalizes_a_serialized_agent_json(self) -> None:
+        # A custom input may still carry the raw wire value; the gate's field is
+        # typed, so ingress normalisation happens here rather than at each reader.
+        class _Inp:
+            extraction_method = "agent"
+            credential_guid = ""
+            agent_json = json.dumps(
+                {"agent-name": "acme", "secret-path": "arn:x", "port": 1521}
+            )
+            credential_ref = None
+
+        gate_input = PreflightGateInput.from_extraction_input(_Inp(), "crawl")
+        assert gate_input.agent_json is not None
+        assert gate_input.agent_json.agent_name == "acme"
+        assert gate_input.agent_json.port == 1521
 
     async def test_gate_mirrors_config_into_metadata_and_connection_config(
         self,

--- a/tests/unit/handler/test_service.py
+++ b/tests/unit/handler/test_service.py
@@ -7082,6 +7082,47 @@ class TestAgentJsonIngressOnTheHandlerPath:
         assert validated.agent_json.agent_name == "acme-agent"
         assert validated.agent_json.is_populated()
 
+    def test_start_internal_validation_failure_stays_a_500(self) -> None:
+        """``/start`` validates its body *inside* its error boundary.
+
+        The app-level 422 handler exists for the form endpoints (auth /
+        preflight / metadata), which validate *outside* any boundary. A
+        ValidationError escaping ``/start``'s boundary is an internal bug, so
+        ``/start`` re-raises it past the 422 handler — it must surface as the
+        sanitized 500 the boundary answers, never as "the request did not fit
+        the contract".
+        """
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from application_sdk.app.base import App
+        from application_sdk.app.entrypoint import entrypoint
+
+        class _StartValidationApp(App):
+            @entrypoint
+            async def run(self, input: _RoutingInput) -> _RoutingOutput:
+                return _RoutingOutput()
+
+        svc = create_app_handler_service(
+            _TestHandler(),
+            app_name="start-validation",
+            app_class=_StartValidationApp,
+            temporal_host="temporal:7233",
+        )
+        patcher = patch(
+            "application_sdk.handler.service._get_temporal_client",
+            new=AsyncMock(return_value=MagicMock()),
+        )
+        patcher.start()
+        try:
+            # Input.correlation_id is a `str`; pydantic v2 rejects an int, so
+            # model_validate raises inside the /start try block.
+            response = TestClient(svc, raise_server_exceptions=False).post(
+                "/workflows/v1/start", json={"correlation_id": 123}
+            )
+            assert response.status_code == 500
+        finally:
+            patcher.stop()
+
 
 class TestManifestPostTransport:
     """``POST /manifest`` — the body transport for ``fe_inputs`` (CSA-539).

--- a/tests/unit/handler/test_service.py
+++ b/tests/unit/handler/test_service.py
@@ -7043,7 +7043,15 @@ class TestAgentJsonIngressOnTheHandlerPath:
         validated = PreflightInput.model_validate(body)  # must not raise
         assert validated.agent_json is None
 
-    def test_malformed_body_is_a_422_naming_the_field(self) -> None:
+    @pytest.mark.parametrize(
+        "endpoint",
+        [
+            "/workflows/v1/auth",
+            "/workflows/v1/check",
+            "/workflows/v1/metadata",
+        ],
+    )
+    def test_malformed_body_is_a_422_naming_the_field(self, endpoint: str) -> None:
         """A body that does not fit the contract must say which field.
 
         The endpoints validate their own body (they normalise v2 wire shapes
@@ -7051,10 +7059,16 @@ class TestAgentJsonIngressOnTheHandlerPath:
         plain-text 500 — reaching the caller as an opaque JSON-decode error with
         no hint of the offending field. That is why the placeholder bug above
         took a full investigation to pin.
+
+        Parameterized over the three ingress endpoints (auth / check /
+        metadata): all route through the same ``_validate_request`` call and
+        their contracts share ``timeout_seconds: int``, so the same malformed
+        body proves each route answers a field-named 422 (route-drift
+        protection, not just the shared mechanism).
         """
         client = _make_client()
         response = client.post(
-            "/workflows/v1/check",
+            endpoint,
             json={"credentials": [], "timeout_seconds": "not-a-number"},
         )
 
@@ -7116,7 +7130,6 @@ class TestAgentJsonIngressOnTheHandlerPath:
         every internal validation failure — anywhere in the app, including a
         handler's own models — into "the request did not fit the contract".
         """
-        outer = self
 
         class _StrayValidationHandler(_TestHandler):
             async def preflight_check(self, input: PreflightInput) -> PreflightOutput:

--- a/tests/unit/handler/test_service.py
+++ b/tests/unit/handler/test_service.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 
 import pytest
 from fastapi.testclient import TestClient
+from pydantic import ValidationError
 
 from application_sdk.contracts.base import Input, Output
 from application_sdk.handler.base import DefaultHandler, Handler, HandlerError
@@ -34,6 +35,8 @@ from application_sdk.handler.service import (
     _flatten_to_pairs,
     _normalize_credentials,
     _normalize_preflight_request,
+    _RequestContractError,
+    _validate_request,
     _wrap_response,
     create_app_handler_service,
 )
@@ -7081,6 +7084,57 @@ class TestAgentJsonIngressOnTheHandlerPath:
         assert validated.agent_json is not None
         assert validated.agent_json.agent_name == "acme-agent"
         assert validated.agent_json.is_populated()
+
+    def test_only_an_explicit_ingress_call_can_answer_422(self) -> None:
+        """The structural half of the rule the docstrings describe.
+
+        A 422 requires ``_validate_request``, which is the only thing that
+        raises the marker the handler is registered on. A bare
+        ``model_validate`` — a future endpoint validating inside its own error
+        boundary, an output contract, a handler's own model — raises plain
+        pydantic and so cannot be reported as the caller's fault. Without this,
+        "which endpoints validate outside their boundary" is a convention held
+        up by prose, and forgetting it silently returns a wrong 422.
+        """
+        bad = {"timeout_seconds": "not-a-number"}
+
+        with pytest.raises(_RequestContractError) as ingress:
+            _validate_request(PreflightInput, bad)
+        # The pydantic failure is carried, not flattened — the handler needs
+        # the field paths.
+        assert ingress.value.cause.errors()[0]["loc"] == ("timeout_seconds",)
+
+        # ...and the bare call is untouched: still plain pydantic.
+        with pytest.raises(ValidationError):
+            PreflightInput.model_validate(bad)
+
+    def test_a_stray_validation_error_is_not_a_422(self) -> None:
+        """A ValidationError escaping a route is a 500, whatever raises it.
+
+        Starlette routes any escaping exception to a registered handler, so
+        registering the 422 on pydantic's ``ValidationError`` would have turned
+        every internal validation failure — anywhere in the app, including a
+        handler's own models — into "the request did not fit the contract".
+        """
+        outer = self
+
+        class _StrayValidationHandler(_TestHandler):
+            async def preflight_check(self, input: PreflightInput) -> PreflightOutput:
+                # Business logic validating something of its own, mid-request.
+                outer_model = type(input)
+                outer_model.model_validate({"timeout_seconds": "not-a-number"})
+                raise AssertionError("unreachable")
+
+        client = TestClient(
+            create_app_handler_service(
+                _StrayValidationHandler(), app_name="stray-validation"
+            ),
+            raise_server_exceptions=False,
+        )
+        response = client.post("/workflows/v1/check", json={"credentials": []})
+
+        assert response.status_code == 500
+        assert response.json()["detail"] == "Internal server error"
 
     def test_start_internal_validation_failure_stays_a_500(self) -> None:
         """``/start`` validates its body *inside* its error boundary.

--- a/tests/unit/handler/test_service.py
+++ b/tests/unit/handler/test_service.py
@@ -32,9 +32,8 @@ from application_sdk.handler.contracts import (
 )
 from application_sdk.handler.service import (
     _flatten_to_pairs,
-    _lift_agent_json,
     _normalize_credentials,
-    _rank_agent_json,
+    _normalize_preflight_request,
     _wrap_response,
     create_app_handler_service,
 )
@@ -7000,83 +6999,88 @@ class TestDefaultEntrypoint:
             patcher.stop()
 
 
-class TestAgentJsonLift:
-    """`_lift_agent_json` / `_rank_agent_json`: surface the freshest agent-json.
+class TestAgentJsonIngressOnTheHandlerPath:
+    """The handler path's end of the ``agent_json`` ingress normaliser.
 
-    Heracles forwards the FE payload verbatim, so the agent-json binding can
-    arrive nested (metadata / connection_config / credentials) and in several
-    competing copies at once — a live hyphen `agent-json` object next to a stale
-    underscore `agent_json` serialized string. The lift must surface the freshest
-    copy at the canonical top-level ``agent_json`` key for downstream consumers.
+    The normaliser itself is pinned in
+    ``tests/unit/credentials/test_ingress.py``; this covers what the request
+    path adds — the normalized body must be accepted by the typed input, and a
+    body that is genuinely malformed must come back as a 422 naming the field
+    rather than a plain-text 500.
     """
 
-    _FRESH = {"agent-name": "acme", "basic.username": "USERNAME", "host": "h"}
-    _STALE = '{"agent-name": "acme", "basic.username": "username", "host": "h"}'
+    _PLACEHOLDER = {
+        "agent-name": "agent-name",
+        "aws-auth-method": "aws-auth-method",
+        "host": "host",
+        "port": "port",
+        "secret-manager": "secret-manager",
+    }
 
-    def test_rank_prefers_object_over_string_and_hyphen_over_underscore(self) -> None:
-        assert _rank_agent_json({}, "agent-json") > _rank_agent_json({}, "agent_json")
-        assert _rank_agent_json({}, "agent_json") > _rank_agent_json("{}", "agent-json")
-        # object beats string even when the string uses the canonical hyphen key
-        assert _rank_agent_json({}, "agent_json") > _rank_agent_json("{}", "agent_json")
+    def test_placeholder_widget_body_still_validates(self) -> None:
+        """The regression: the normalized body must be accepted by the typed input.
 
-    def test_sage_shape_picks_fresh_object_over_stale_string(self) -> None:
-        # /sage: heracles forwards formData -> metadata carrying BOTH copies.
-        body = {
-            "credentials": {"connectorConfigName": "atlan-connectors-mssql"},
-            "metadata": {
-                "agent_json": self._STALE,
-                "agent-json": self._FRESH,
-                "extraction-method": "agent",
-            },
-        }
-        out = _lift_agent_json(body)
-        assert out["agent_json"] == self._FRESH
-        assert out["agent_json"]["basic.username"] == "USERNAME"
-        # both agent-json keys stripped from the container
-        assert "agent_json" not in out["metadata"]
-        assert "agent-json" not in out["metadata"]
-        assert out["metadata"]["extraction-method"] == "agent"
-
-    def test_serialized_string_used_as_fallback_when_no_object(self) -> None:
-        out = _lift_agent_json({"metadata": {"agent_json": self._STALE}})
-        assert out["agent_json"]["basic.username"] == "username"
-
-    def test_top_level_fresh_hyphen_overrides_stale_underscore(self) -> None:
-        out = _lift_agent_json({"agent_json": self._STALE, "agent-json": self._FRESH})
-        assert out["agent_json"] == self._FRESH
-        # stale aliases are dropped; only the canonical top-level key remains
-        assert "agent-json" not in out
-
-    def test_agent_json_inside_credentials_dict(self) -> None:
-        out = _lift_agent_json(
-            {"credentials": {"agent-json": self._FRESH, "connectorConfigName": "x"}}
-        )
-        assert out["agent_json"] == self._FRESH
-        assert "agent-json" not in out["credentials"]
-        assert out["credentials"]["connectorConfigName"] == "x"
-
-    def test_agent_json_inside_v3_credentials_list(self) -> None:
-        out = _lift_agent_json(
+        A rendered-but-unfilled agent widget submits every field name as its own
+        value. ``port`` is ``AgentCredentialSpec``'s only non-str field, so the
+        payload coerces to a dict but fails typed validation — promoting it made
+        every direct-mode request whose form renders the widget 500.
+        """
+        body = _normalize_preflight_request(
             {
-                "credentials": [
-                    {"key": "agent-json", "value": self._FRESH},
-                    {"key": "connectorConfigName", "value": "x"},
-                ]
+                "connector": "oracle",
+                "entrypoint": "miner",
+                "credentials": {"extra": {}},
+                "metadata": {
+                    "agent_json": json.dumps(self._PLACEHOLDER),
+                    "agent-json": json.dumps(self._PLACEHOLDER),
+                    "extraction_method": "query_history",
+                },
             }
         )
-        assert out["agent_json"] == self._FRESH
-        assert all(c["key"] != "agent-json" for c in out["credentials"])
+        validated = PreflightInput.model_validate(body)  # must not raise
+        assert validated.agent_json is None
 
-    def test_direct_mode_body_unchanged(self) -> None:
-        body = {"credentials": {"host": "h", "username": "u"}}
-        assert _lift_agent_json(body) == body
+    def test_malformed_body_is_a_422_naming_the_field(self) -> None:
+        """A body that does not fit the contract must say which field.
 
-    def test_empty_agent_json_ignored(self) -> None:
-        assert "agent_json" not in _lift_agent_json({"metadata": {"agent-json": {}}})
-        assert "agent_json" not in _lift_agent_json({"metadata": {"agent_json": ""}})
+        The endpoints validate their own body (they normalise v2 wire shapes
+        first), so an unhandled ValidationError used to become Starlette's
+        plain-text 500 — reaching the caller as an opaque JSON-decode error with
+        no hint of the offending field. That is why the placeholder bug above
+        took a full investigation to pin.
+        """
+        client = _make_client()
+        response = client.post(
+            "/workflows/v1/check",
+            json={"credentials": [], "timeout_seconds": "not-a-number"},
+        )
 
-    def test_unparseable_string_ignored(self) -> None:
-        assert "agent_json" not in _lift_agent_json({"metadata": {"agent_json": "{"}})
+        assert response.status_code == 422
+        body = response.json()
+        assert body["success"] is False
+        assert "timeout_seconds" in body["message"]
+        assert body["detail"][0]["field"] == "timeout_seconds"
+        # The rejected value may be a credential — never echo it back.
+        assert "not-a-number" not in json.dumps(body)
+
+    def test_real_spec_reaches_the_typed_input(self) -> None:
+        body = _normalize_preflight_request(
+            {
+                "credentials": {"extra": {}},
+                "metadata": {
+                    "agent-json": {
+                        "agent-name": "acme-agent",
+                        "secret-path": "arn:aws:secretsmanager:us-east-1:1:secret:x",
+                        "host": "db.example.com",
+                        "port": 1521,
+                    }
+                },
+            }
+        )
+        validated = PreflightInput.model_validate(body)
+        assert validated.agent_json is not None
+        assert validated.agent_json.agent_name == "acme-agent"
+        assert validated.agent_json.is_populated()
 
 
 class TestManifestPostTransport:

--- a/tests/unit/templates/test_sql_metadata_extractor.py
+++ b/tests/unit/templates/test_sql_metadata_extractor.py
@@ -155,7 +155,15 @@ class TestTypedTaskInputs:
 
 
 class TestExtractionInputAgentJsonValidation:
-    """Tests for _skip_agent_json_for_direct model validator."""
+    """``agent_json`` normalisation on the AE / workflow-args path.
+
+    AE replays whatever the connection record carries, so the field arrives as a
+    JSON string, a dict, or the marketplace-package placeholder blob. The
+    contract delegates to the one ingress normaliser
+    (:mod:`application_sdk.credentials.ingress`, pinned in
+    ``tests/unit/credentials/test_ingress.py``) rather than tolerating any of
+    that itself; these cases pin that it is wired up, in both nesting positions.
+    """
 
     def test_direct_mode_nulls_invalid_agent_json(self) -> None:
         """agent_json with placeholder values (port='port') is accepted in direct mode."""
@@ -204,6 +212,41 @@ class TestExtractionInputAgentJsonValidation:
             }
         )
         assert inp.agent_json is None
+
+    def test_placeholder_nested_in_ae_metadata_is_nulled(self) -> None:
+        """The nesting the old direct-mode guard could not see: pydantic applies
+        before-validators in reverse definition order, so the guard ran before
+        ``_normalize_ae_payload`` lifted ``agent-json`` out of ``metadata`` and
+        the placeholder failed the whole input."""
+        inp = ExtractionInput.model_validate(
+            {
+                "extraction_method": "direct",
+                "credential_guid": "test-guid",
+                "metadata": {
+                    "agent-json": {
+                        "agent-name": "agent-name",
+                        "host": "host",
+                        "port": "port",
+                    }
+                },
+            }
+        )
+        assert inp.agent_json is None
+        assert inp.credential_guid == "test-guid"
+
+    def test_valid_spec_survives_direct_mode(self) -> None:
+        """A real spec is no longer discarded just because the run is direct:
+        routing is ``extraction_method``'s job, and the readers already check it.
+        """
+        inp = ExtractionInput.model_validate(
+            {
+                "extraction_method": "direct",
+                "credential_guid": "test-guid",
+                "agent_json": {"agent-name": "acme", "secret-path": "arn:x"},
+            }
+        )
+        assert inp.agent_json is not None
+        assert inp.agent_json.agent_name == "acme"
 
     def test_no_agent_json_still_works(self) -> None:
         """ExtractionInput without agent_json works for both direct and agent."""


### PR DESCRIPTION
Closes FND-430.

## Why

`agent_json` arrives in an arbitrary combination of 3 alias spellings × 4 container positions × 3 types, and any of those may be a meaningless placeholder — a v2 Argo workflow-template default that eleven marketplace packages carry, persisted on the connection record and replayed verbatim into v3 typed requests. **A source fix upstream stops new poison but cannot clean existing connections, and there is no backfill — so one guard is permanent and load-bearing. Six were not.**

Six places tolerated it independently, each invented locally in response to its own incident, and every new consumer of the field grew a seventh. `_lift_agent_json` alone had been patched three times.

## What

One normaliser, in `credentials/` where the type lives. Two entry points, one policy — *anything meaningless is absent*:

```python
normalize_agent_json(value, *, spec_type=AgentCredentialSpec) -> AgentCredentialSpec | None
lift_agent_json(body) -> dict          # the same body, typed spec promoted
declared_agent_spec_type(model_cls)    # the spec class a reader's field declares
```

Readers take the typed field. Deleted: the handler's `_coerce` / `_rank` / `_lift` trio, `ExtractionInput._skip_agent_json_for_direct`, and `CredentialRef.from_workflow_args`'s `except`-swallow. `AgentCredentialSpec._accept_string_or_dict` stays as the *delegated* type layer — the normaliser is the only lenient wrapper around it, and duplicating the parse in ingress would have re-created the thing this removes.

## Behaviour changes

| | before | after |
| --- | --- | --- |
| Placeholder on a direct-mode `/check` | unhandled `ValidationError` → plain-text **500** | **200**, handled as direct mode |
| Malformed body on any handler endpoint | plain-text **500**, opaque JSON-decode error at the caller | **422** naming the field |
| Placeholder reaching the preflight gate | gate loses `extraction_method` **and** `credential_guid` — credential resolution degrades silently | routing triple survives; only the fields that actually failed are dropped |
| Placeholder nested in an AE `metadata` block | failed the whole `ExtractionInput`, **in agent mode too** | normalised to `None` |
| Placeholder object next to a real serialized copy | dropped both → direct mode | falls through to the real copy |
| A valid spec on a direct-mode run | nulled unconditionally | kept — routing is `extraction_method`'s job, and every reader already checks it |

The 422 body is `{"success": false, "message": "Invalid request: agent_json.port", "detail": [{field, message, type}]}`. Pydantic's `input` and `ctx` are omitted: the rejected value can be a credential. Only ingress validation reaches the handler — each endpoint already answers 500 for failures inside its own body.

## Three things worth a reviewer's eye

1. **Site 4's real bug was validator ordering, not direct-mode policy.** Pydantic applies `mode="before"` model validators in *reverse* definition order, so `_skip_agent_json_for_direct` ran **before** `_normalize_ae_payload` lifted `agent-json` out of a nested AE `metadata` block. The replacement is deliberately declared *above* `_normalize_ae_payload` so it runs *after* it; there is a comment saying so, because it reads backwards.
2. **`_rank_agent_json` could not just be deleted.** "Parsed object beats serialized string" is freshness, not an alias artefact — the FE really does send a live object next to a stale string snapshot. It is now a stable sort key (`is_dict`, `is_hyphen`, discovery order) that reproduces the old scores exactly, and the lift falls through to the next copy rather than giving up on the freshest.
3. **`lift_agent_json` promotes the spec instance, not a raw dict.** "Every reader takes the typed field" is only true if the lift emits one; it also removes a third parse.

Policy differences are a parameter, not a re-implementation: `spec_type` narrows validation to a connector's own `AgentCredentialSpec` subclass on both the AE and gate paths. `is_populated()` is untouched and stays the consumers' call.

## Supersedes #3233

This includes #3233's behaviour and all 7 of its tests. #3233 should be closed in favour of this, or merged first and this rebased onto it — flagging rather than deciding, since it isn't mine.

## Verification

- The 16 behavioural cases the guards accumulated move to `tests/unit/credentials/test_ingress.py`, same inputs, plus cases pinning the gate fix, the AE nesting, the fall-through, and subclass narrowing.
- 7146 unit tests pass; `pre-commit run --all-files` clean (ruff, ruff-format, isort, pyright).
- `atlan-application-sdk-conformance detect` exits 0 with **no** new findings in the changed files.
- End-to-end smoke of the reported repro (direct-mode Oracle, placeholder under both `metadata` aliases) → `POST /workflows/v1/check` returns 200.

## Non-goals, unchanged

No `connectionWorkflowConfiguration` backfill. No change to the eleven marketplace-package template defaults — those packages are already slated for automation-engine migration.

## Security-relevant note for review

The new 422 path serialises Pydantic error metadata. It deliberately excludes `input` and `ctx` so a rejected credential value is never echoed back to the caller; a test asserts the rejected value is absent from the response body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
