### PR TITLE
feat(conformance): add P044 for app-level prefix transfers (FND-433)

### DIFF
--- a/packages/conformance/conformance/docs/rules/prescriptions.md
+++ b/packages/conformance/conformance/docs/rules/prescriptions.md
@@ -5,7 +5,7 @@
 
 # Prescription Rules (P-series)
 
-**42 rules** · Checker: `suite.checks.prescriptions` (P001–P003, P008–P015), `suite.checks.orchestration` (P004–P007, scans test files too), `suite.checks.entrypoint_alignment` (P016), `suite.checks.entrypoint` (P017–P018, scans test files too), `suite.checks.client_seam` (P019), `suite.checks.determinism` (P020–P024, P031), `suite.checks.app_name_alignment` (P025), `suite.checks.sdr` (P029/P030, P037/P038/P039, P041), `suite.checks.transform_templates` (P040, scans template YAML) (all AST-based / cross-artifact)
+**43 rules** · Checker: `suite.checks.prescriptions` (P001–P003, P008–P015), `suite.checks.orchestration` (P004–P007, scans test files too), `suite.checks.entrypoint_alignment` (P016), `suite.checks.entrypoint` (P017–P018, scans test files too), `suite.checks.client_seam` (P019), `suite.checks.determinism` (P020–P024, P031), `suite.checks.app_name_alignment` (P025), `suite.checks.sdr` (P029/P030, P037/P038/P039, P041), `suite.checks.transform_templates` (P040, scans template YAML) (all AST-based / cross-artifact)
 
 Suppress a finding on the violating line or the line directly above it:
 
@@ -65,6 +65,7 @@ reassigned.
 | [P040](#p040) | `TransformTemplateReservedKeyword` | `warn` | `app` | `transform-templates` | — | 0.18.0 |
 | [P041](#p041) | `SdrHardPreflightGate` | `warn` | `app` | `sdr-readiness` | — | 0.18.0 |
 | [P042](#p042) | `SdrHandRolledUploadBridge` | `warn` | `app` | `sdr-readiness` | — | 0.18.0 |
+| [P044](#p044) | `DirectStoragePrefixTransfer` | `warn` | `app` | `storage-seam` | — | 0.20.0 |
 
 ---
 
@@ -1706,5 +1707,62 @@ This is a WARN, and deliberately a *lower*-urgency one than P030: the app is wor
 today.  The deadline is v4.0, not the next run — which is why the rule carries
 `superseded_by: sdk>=4.0.0`.  It retires when that removal lands and the shape stops
 being expressible.
+
+---
+
+## P044 — `DirectStoragePrefixTransfer` {#p044}
+
+**Tier:** `warn` · **Scope:** `app` · **Category:** `storage-seam` · **Autofixable:** — · **Since:** 0.20.0
+
+> App transfers whole prefixes via storage.upload_prefix/download_prefix instead of FileReference + App.upload()/App.download()
+
+**Rationale:** An app moving whole prefixes with storage.upload_prefix/download_prefix is using a
+sanctioned SDK function at the wrong level, which is why no existing rule catches it:
+P009 fires only on apps constructing their own store, and P030/P042 are gated on
+self_deployed_runtime and so never run for a direct-flow app. What the app gives up is
+everything layered above the primitive — App.upload()'s ADR-0014 dual-write routing, the
+canonical artifacts/apps/{app}/workflows/{workflow_id}/{run_id} prefix, @task
+retry/replay, and FileReference's per-file SHA-256 sidecars, whose whole purpose is
+detecting the partial or corrupt file that a per-directory non-emptiness check cannot
+see. Apps that hand-roll this reliably re-derive the missing guards later and get them
+subtly wrong: one connector's wrapper skipped the download whenever the target directory
+was already non-empty, which for a multi-writer fan-out prefix means a co-located reader
+silently sees a subset of the data. Customer impact: a silent subset. Some of the
+customer's metadata is extracted, the run reports success, and the assets that never
+arrived look indistinguishable from assets the source does not have — so it is the
+customer who finds the gap, if anyone does.
+
+App source calls `upload_prefix` / `download_prefix` (or imports them from
+`application_sdk.storage`) to move artifacts itself, rather than declaring the data on
+the contract and letting the SDK move it.
+
+These are real SDK functions, so this is not the build-your-own-store shape **P009**
+describes — it is the sanctioned seam used one level too low. The storage contract in
+this module's docstring names the two supported paths:
+
+* **task-to-task** data → a `FileReference` field on the contract. The   activity
+interceptor persists it after the producing task and   materialises it before the
+consuming one, with a per-file SHA-256   sidecar so a partial or corrupt transfer is
+detected rather than   reused. * **phase/app hand-off** → `App.upload()` /
+`App.download()`, which   add dual-write routing, the canonical artifact prefix, and
+`@task`   retry/replay.
+
+**Fix by hoisting, not by substituting in place.** `App.upload()` is itself a framework
+task, so calling it where the prefix call used to sit — inside a `@task` — trades this
+finding for a **P008** violation. Move the transfer to `run()` / the `@entrypoint`, one
+call per phase, and let the tasks below it read and write local paths.
+
+Not every prefix call is wrong. A genuine bulk transfer with no contract boundary to
+hang a reference on — a state directory synced wholesale, a one-off migration script —
+is a legitimate use. Suppress those with an inline `# conformance: ignore[P044]
+<reason>`, which stays visible in SARIF rather than disappearing.
+
+Tier note: this lands at WARN because the pattern is fleet-wide, not isolated — a sweep
+of `atlanhq` found app-code calls in roughly 34 consumer repos, five of them sharing a
+copied `app/workflow/io.py`. It graduates to BLOCK once that count is falling rather
+than flat. It is deliberately a separate id from **P030** for the same reason P030 and
+P042 are separate: absence of `App.upload()` in SDR mode is a proven customer-data-loss
+class and blocks, while absence in the direct flow is legitimate — `persist_file_refs`
+performs that transfer automatically — so the two shapes cannot share a tier.
 
 ---

--- a/packages/conformance/conformance/docs/rules/prescriptions.md
+++ b/packages/conformance/conformance/docs/rules/prescriptions.md
@@ -65,7 +65,7 @@ reassigned.
 | [P040](#p040) | `TransformTemplateReservedKeyword` | `warn` | `app` | `transform-templates` | — | 0.18.0 |
 | [P041](#p041) | `SdrHardPreflightGate` | `warn` | `app` | `sdr-readiness` | — | 0.18.0 |
 | [P042](#p042) | `SdrHandRolledUploadBridge` | `warn` | `app` | `sdr-readiness` | — | 0.18.0 |
-| [P044](#p044) | `DirectStoragePrefixTransfer` | `warn` | `app` | `storage-seam` | — | 0.20.0 |
+| [P044](#p044) | `DirectStoragePrefixTransfer` | `warn` | `app` | `storage-seam` | — | 0.21.0 |
 
 ---
 
@@ -1712,7 +1712,7 @@ being expressible.
 
 ## P044 — `DirectStoragePrefixTransfer` {#p044}
 
-**Tier:** `warn` · **Scope:** `app` · **Category:** `storage-seam` · **Autofixable:** — · **Since:** 0.20.0
+**Tier:** `warn` · **Scope:** `app` · **Category:** `storage-seam` · **Autofixable:** — · **Since:** 0.21.0
 
 > App transfers whole prefixes via storage.upload_prefix/download_prefix instead of FileReference + App.upload()/App.download()
 
@@ -1740,12 +1740,13 @@ These are real SDK functions, so this is not the build-your-own-store shape **P0
 describes — it is the sanctioned seam used one level too low. The storage contract in
 this module's docstring names the two supported paths:
 
-* **task-to-task** data → a `FileReference` field on the contract. The   activity
-interceptor persists it after the producing task and   materialises it before the
-consuming one, with a per-file SHA-256   sidecar so a partial or corrupt transfer is
-detected rather than   reused. * **phase/app hand-off** → `App.upload()` /
-`App.download()`, which   add dual-write routing, the canonical artifact prefix, and
-`@task`   retry/replay.
+* **task-to-task** data → a `FileReference` field on the contract. The activity
+interceptor persists it after the producing task and materialises it before the
+consuming one, with a per-file SHA-256 sidecar so a partial or corrupt transfer is
+detected rather than reused.
+
+* **phase/app hand-off** → `App.upload()` / `App.download()`, which add dual-write
+routing, the canonical artifact prefix, and `@task` retry/replay.
 
 **Fix by hoisting, not by substituting in place.** `App.upload()` is itself a framework
 task, so calling it where the prefix call used to sit — inside a `@task` — trades this

--- a/packages/conformance/conformance/programs/areas/prescriptions.prose.md
+++ b/packages/conformance/conformance/programs/areas/prescriptions.prose.md
@@ -57,7 +57,7 @@ raw type in an opaque SDK type) that no import edit can perform.  All four draft
 proposal for human review and never auto-apply.  (These rules are backed by a
 separate, test-scanning `suite.checks.orchestration` check — see its module docs.)
 
-The storage-seam rules (P008–P012) are also P-series and suggest-only: they
+The storage-seam rules (P008–P012, P044) are also P-series and suggest-only: they
 describe structural workflow refactors (data-flow topology, store-routing
 contracts, durability-field ownership) that no local import rewrite can perform,
 and the orthogonal gate is non-protective for structural regressions not yet
@@ -241,7 +241,8 @@ is always `"judgment"`:
   stop re-exporting it) — a public-contract refactor. Route to residue with that
   guidance. Do not attempt a mechanical edit.
 
-**Storage-seam rules (P008–P012)** — all suggest-only, scope=app, WARN-tier;
+**Storage-seam rules (P008–P012, P044)** — all suggest-only, scope=app,
+WARN-tier;
 `classification` is always `"judgment"`.  Read the full function/class context
 around `finding.line` before drafting any proposal.
 
@@ -300,6 +301,31 @@ around `finding.line` before drafting any proposal.
   propose renaming the field to clarify the semantics (e.g. `storage_uri`) and
   suppressing P012 with justification; state why the value is stable across
   workers.
+
+- **P044 DirectStoragePrefixTransfer** — app code calls
+  `storage.upload_prefix(...)` / `download_prefix(...)`, moving a whole prefix
+  itself instead of declaring the data on the contract.  These are real SDK
+  functions, so this is not P009's build-your-own-store shape; it is the
+  sanctioned seam used one level below the storage contract.  Draft a proposal
+  that names which of the two supported paths applies, because they are not
+  interchangeable:
+  - **task-to-task data** — replace with a `FileReference` field on the contract
+    (same producing/consuming pattern as P011/P012).  The interceptor persists
+    it after the producing task and materialises it before the consuming one,
+    with a per-file SHA-256 sidecar; that is what makes a partial transfer
+    detectable, which a directory-level non-emptiness check cannot do.
+  - **phase or app hand-off** — replace with `App.upload()` / `App.download()`
+    **hoisted to `run()` or the `@entrypoint`**, one call per phase.  State this
+    explicitly in the proposal: leaving the call where the prefix call sat is a
+    `@task` body, and `App.upload`/`download` are themselves framework tasks, so
+    an in-place substitution trades a P044 finding for a P008 one.  Never
+    propose that.
+  If the transfer is a genuine bulk sync with no contract boundary to hang a
+  reference on (a state directory synced wholesale, a one-off migration script),
+  propose an inline `# conformance: ignore[P044] <reason>` instead and say why
+  no contract boundary exists.  Do not propose a fix that merely moves the
+  prefix call to a different module — the finding is about the level of the
+  abstraction, not its location.
 
 **Client-seam rule (P019)** — suggest-only, scope=both, WARN-tier;
 `classification` is always `"judgment"`.  Read the full function/class context

--- a/packages/conformance/conformance/suite/checks/prescriptions/__init__.py
+++ b/packages/conformance/conformance/suite/checks/prescriptions/__init__.py
@@ -94,6 +94,7 @@ from ._error_code_prefix import (
 from ._file_reference import check_p010
 from ._framework_transfer import check_p008
 from ._getattr_contract_field import check_p026
+from ._prefix_transfer import check_p044
 from ._qualified_name import check_p028
 from ._store_construction import check_p009
 from ._typed_boundaries import check_p013_p014
@@ -138,6 +139,7 @@ def scan_text(text: str, file: str) -> list[Finding]:
     findings_p015 = check_p015(tree, file, directives)
     findings_p026 = check_p026(tree, file, directives)
     findings_p028 = check_p028(tree, file, directives)
+    findings_p044 = check_p044(tree, file, directives)
 
     return (
         p001._findings
@@ -150,11 +152,12 @@ def scan_text(text: str, file: str) -> list[Finding]:
         + findings_p015
         + findings_p026
         + findings_p028
+        + findings_p044
     )
 
 
 def scan_path(path: Path, root: Path) -> list[Finding]:
-    """Scan a single Python file (P001 + P002 + P008–P012 + P015 + P026 + P028).
+    """Scan a single Python file (P001 + P002 + P008–P012 + P015 + P026 + P028 + P044).
 
     P003, P013, P014 and P027 require :func:`scan_all` for cross-file resolution.
     """
@@ -239,7 +242,7 @@ def scan_all(paths: list[Path], root: Path) -> list[Finding]:
         p002_checker.visit(tree)
         findings.extend(p002_checker._findings)
 
-        # P008–P012, P015, P026, P028 (per-file)
+        # P008–P012, P015, P026, P028, P044 (per-file)
         findings.extend(check_p008(tree, rel_str, directives))
         findings.extend(check_p009(tree, rel_str, directives))
         findings.extend(check_p010(tree, rel_str, directives))
@@ -248,6 +251,7 @@ def scan_all(paths: list[Path], root: Path) -> list[Finding]:
         findings.extend(check_p015(tree, rel_str, directives))
         findings.extend(check_p026(tree, rel_str, directives))
         findings.extend(check_p028(tree, rel_str, directives))
+        findings.extend(check_p044(tree, rel_str, directives))
 
         # Class registry for P003 and P013/P014 — de-alias base names so aliased
         # imports of leaf/base classes don't hide the real ancestry.

--- a/packages/conformance/conformance/suite/checks/prescriptions/_prefix_transfer.py
+++ b/packages/conformance/conformance/suite/checks/prescriptions/_prefix_transfer.py
@@ -1,0 +1,152 @@
+"""P044 DirectStoragePrefixTransfer — app moves prefixes itself.
+
+``storage.upload_prefix`` / ``download_prefix`` are real SDK functions, so this
+is *not* the build-your-own-store shape :mod:`._store_construction` (P009)
+describes. It is the sanctioned seam used one level too low: the app takes on
+the transfer instead of declaring the data on its contract and letting the SDK
+move it.
+
+Why no existing rule covers it
+------------------------------
+* **P009** fires on constructing a store or cloud client — an app calling an SDK
+  function is not that.
+* **P030** / **P042** are gated on ``self_deployed_runtime: true``, so for a
+  direct-flow app the entire SDR series short-circuits before it can ask whether
+  ``App.upload()`` is used at all.
+
+Deliberately a *presence* check, not an absence check
+----------------------------------------------------
+"App never calls ``App.upload()``" is the wrong predicate outside SDR: for
+task-to-task data ``persist_file_refs`` uploads every ephemeral
+``FileReference`` in a task's output and ``materialize_file_refs`` fetches it
+back, so an app that declares references correctly needs no explicit upload at
+all. Flagging absence would fire on precisely the apps doing it right. Flagging
+the prefix call is unambiguous in both modes.
+
+Scope of the match
+------------------
+Only the two *prefix* transfer helpers, matched on the callee name plus the
+import that brought it in. Single-object helpers (``upload_file``,
+``download_file``) are out of scope: they are the right tool for the cases where
+a caller genuinely holds one file and no contract boundary to hang a reference
+on. Both the ``from application_sdk.storage import upload_prefix`` form and the
+attribute form (``storage.upload_prefix(...)``, ``ops.download_prefix(...)``)
+are matched; a same-named local helper is not, because the name must resolve to
+an ``application_sdk`` import in the same file.
+"""
+
+from __future__ import annotations
+
+import ast
+
+from conformance.suite.checks._ast_common import _IgnoreDirective, make_finding
+from conformance.suite.schema.findings import Finding
+
+#: The prefix-level transfer helpers. Single-object transfers are out of scope.
+_PREFIX_TRANSFERS: frozenset[str] = frozenset({"upload_prefix", "download_prefix"})
+
+_SDK_STORAGE_ROOT = "application_sdk"
+
+
+def _sdk_storage_bindings(tree: ast.AST) -> tuple[set[str], set[str]]:
+    """Return ``(direct_names, module_aliases)`` bound to SDK storage in this file.
+
+    ``direct_names`` are prefix helpers pulled in by
+    ``from application_sdk.storage import upload_prefix`` (honouring ``as``
+    aliases). ``module_aliases`` are names bound to an SDK storage *module* by
+    ``import application_sdk.storage as storage`` or
+    ``from application_sdk import storage``, so an attribute call through them
+    can be resolved.
+
+    Anything not traceable to an ``application_sdk`` import is left alone: a
+    local ``upload_prefix`` helper is a different function that happens to share
+    a name.
+    """
+    direct: set[str] = set()
+    aliases: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            if not (module == _SDK_STORAGE_ROOT or module.startswith(f"{_SDK_STORAGE_ROOT}.")):
+                continue
+            for alias in node.names:
+                bound = alias.asname or alias.name
+                if alias.name in _PREFIX_TRANSFERS:
+                    direct.add(bound)
+                elif alias.name == "storage" or alias.name.endswith("ops"):
+                    # `from application_sdk import storage`
+                    aliases.add(bound)
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                if not alias.name.startswith(f"{_SDK_STORAGE_ROOT}."):
+                    continue
+                if alias.asname:
+                    aliases.add(alias.asname)
+                else:
+                    # `import application_sdk.storage` binds the root package;
+                    # the call site then reads application_sdk.storage.x(...).
+                    aliases.add(alias.name.split(".")[0])
+    return direct, aliases
+
+
+def _called_prefix_helper(
+    node: ast.Call, direct: set[str], aliases: set[str]
+) -> str | None:
+    """Name of the prefix helper *node* calls, or ``None``."""
+    func = node.func
+    if isinstance(func, ast.Name):
+        return func.id if func.id in direct else None
+    if isinstance(func, ast.Attribute) and func.attr in _PREFIX_TRANSFERS:
+        # Resolve the receiver chain's root: storage.upload_prefix(...) or
+        # application_sdk.storage.upload_prefix(...).
+        receiver: ast.expr = func.value
+        while isinstance(receiver, ast.Attribute):
+            receiver = receiver.value
+        if isinstance(receiver, ast.Name) and receiver.id in aliases:
+            return func.attr
+    return None
+
+
+def check_p044(
+    tree: ast.AST,
+    filename: str,
+    directives: dict[int, _IgnoreDirective],
+) -> list[Finding]:
+    """Emit P044 for each prefix-level transfer the app performs itself."""
+    direct, aliases = _sdk_storage_bindings(tree)
+    if not direct and not aliases:
+        return []
+
+    findings: list[Finding] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        helper = _called_prefix_helper(node, direct, aliases)
+        if helper is None:
+            continue
+        direction = "upload" if helper.startswith("upload") else "download"
+        findings.append(
+            make_finding(
+                filename=filename,
+                rule_id="P044",
+                node=node,
+                message=(
+                    f"{helper}() moves a whole prefix from app code. This is an SDK "
+                    "function used one level below the storage contract, so P009 "
+                    "(build-your-own-store) does not fire and — outside SDR — neither "
+                    "does P030. Declare the data on the contract as a FileReference "
+                    "for task-to-task flow, or call "
+                    f"App.{direction}() for a phase hand-off. Hoist that call to "
+                    "run()/@entrypoint rather than leaving it where this one sits: "
+                    "App.upload()/download() are framework tasks, so calling them "
+                    "inside a @task trades this finding for P008. What the prefix "
+                    "call gives up is dual-write routing, the canonical artifact "
+                    "prefix, @task retry/replay, and the per-file SHA-256 sidecar "
+                    "that detects a partial transfer a directory-level check cannot. "
+                    "For a genuine bulk sync with no contract boundary, suppress with "
+                    "'# conformance: ignore[P044] <reason>'."
+                ),
+                directives=directives,
+            )
+        )
+    return findings

--- a/packages/conformance/conformance/suite/checks/prescriptions/_prefix_transfer.py
+++ b/packages/conformance/conformance/suite/checks/prescriptions/_prefix_transfer.py
@@ -31,8 +31,15 @@ import that brought it in. Single-object helpers (``upload_file``,
 a caller genuinely holds one file and no contract boundary to hang a reference
 on. Both the ``from application_sdk.storage import upload_prefix`` form and the
 attribute form (``storage.upload_prefix(...)``, ``ops.download_prefix(...)``)
-are matched; a same-named local helper is not, because the name must resolve to
-an ``application_sdk`` import in the same file.
+are matched.
+
+The gate is the *import path*, not the ``application_sdk`` prefix: the name has
+to come from one of the two modules that actually expose the prefix helpers —
+``application_sdk.storage``, or ``application_sdk.storage.batch`` where they are
+defined. Anything else is a different function that happens to share a name and
+is left alone: a same-named local helper, a same-named symbol imported from
+another ``application_sdk`` subpackage, or an attribute call through an alias
+bound to an unrelated ``application_sdk`` module.
 """
 
 from __future__ import annotations
@@ -45,82 +52,88 @@ from conformance.suite.schema.findings import Finding
 #: The prefix-level transfer helpers. Single-object transfers are out of scope.
 _PREFIX_TRANSFERS: frozenset[str] = frozenset({"upload_prefix", "download_prefix"})
 
-_SDK_STORAGE_ROOT = "application_sdk"
+#: The only import paths that expose the prefix helpers. ``batch`` defines them;
+#: ``storage`` (the package) re-exports them. Matching the full dotted path
+#: rather than an ``application_sdk`` prefix is what keeps unrelated
+#: ``application_sdk.*`` sources — which cannot supply these names — out.
+_PREFIX_MODULE_PATHS: frozenset[str] = frozenset(
+    {"application_sdk.storage", "application_sdk.storage.batch"}
+)
 
-#: Submodules of ``application_sdk`` whose attribute namespace exposes the
-#: prefix helpers. ``batch`` defines them; ``storage`` (the package) re-exports
-#: them. Keyed by the final module segment as written in the import.
-_STORAGE_MODULES_WITH_PREFIX: frozenset[str] = frozenset({"batch", "storage"})
+
+def _dotted_name(node: ast.expr) -> str | None:
+    """Flatten ``a.b.c`` to ``"a.b.c"``; ``None`` if the chain is not all names."""
+    parts: list[str] = []
+    current: ast.expr = node
+    while isinstance(current, ast.Attribute):
+        parts.append(current.attr)
+        current = current.value
+    if not isinstance(current, ast.Name):
+        return None
+    parts.append(current.id)
+    return ".".join(reversed(parts))
 
 
 def _sdk_storage_bindings(tree: ast.AST) -> tuple[set[str], set[str]]:
-    """Return ``(direct_names, module_aliases)`` bound to SDK storage in this file.
+    """Return ``(direct_names, receivers)`` bound to SDK storage in this file.
 
     ``direct_names`` are prefix helpers pulled in by
     ``from application_sdk.storage import upload_prefix`` (honouring ``as``
-    aliases). ``module_aliases`` are names bound to an SDK storage *module* that
-    exposes the prefix helpers, so an attribute call through them can be
-    resolved.
+    aliases). ``receivers`` are dotted receiver strings that resolve to a module
+    exposing the prefix helpers, so an attribute call through one can be
+    resolved: ``storage`` for ``from application_sdk import storage``, ``ops``
+    for ``import application_sdk.storage.batch as ops``, and
+    ``application_sdk.storage`` for a plain ``import application_sdk.storage``.
 
-    The module gate keys on the import *source*, not the local alias text: any
-    ``from application_sdk.storage import <module>`` /
-    ``import application_sdk.storage.<module>`` that names a module exposing
-    ``upload_prefix``/``download_prefix`` (``batch`` — where they are defined —
-    or the ``storage`` package that re-exports them) registers its bound name.
-    That is what matches ``from application_sdk.storage import batch`` and
-    ``from application_sdk.storage import batch as ops``; keying on the alias
-    text (``storage`` / ``*ops``) instead would miss both.
-
-    Anything not traceable to an ``application_sdk`` import is left alone: a
-    local ``upload_prefix`` helper is a different function that happens to share
-    a name.
+    Both gates key on the import *path*, not the local alias text: any import
+    naming ``application_sdk.storage`` or ``application_sdk.storage.batch``
+    registers its bound name, whatever that name is. That is what matches
+    ``from application_sdk.storage import batch as ops`` while leaving
+    ``from application_sdk.contracts import storage`` alone — the alias text is
+    the same shape in both, the import source is not.
     """
     direct: set[str] = set()
-    aliases: set[str] = set()
+    receivers: set[str] = set()
     for node in ast.walk(tree):
         if isinstance(node, ast.ImportFrom):
             module = node.module or ""
-            if not (
-                module == _SDK_STORAGE_ROOT
-                or module.startswith(f"{_SDK_STORAGE_ROOT}.")
-            ):
-                continue
             for alias in node.names:
                 bound = alias.asname or alias.name
-                if alias.name in _PREFIX_TRANSFERS:
+                if alias.name in _PREFIX_TRANSFERS and module in _PREFIX_MODULE_PATHS:
                     direct.add(bound)
-                elif alias.name in _STORAGE_MODULES_WITH_PREFIX:
+                elif f"{module}.{alias.name}" in _PREFIX_MODULE_PATHS:
                     # `from application_sdk import storage`,
-                    # `from application_sdk.storage import batch[ as ops]`, etc.
-                    # Resolved by import source, so the alias text is free.
-                    aliases.add(bound)
+                    # `from application_sdk.storage import batch[ as ops]`.
+                    receivers.add(bound)
         elif isinstance(node, ast.Import):
             for alias in node.names:
-                if not alias.name.startswith(f"{_SDK_STORAGE_ROOT}."):
+                if alias.name not in _PREFIX_MODULE_PATHS:
                     continue
                 if alias.asname:
-                    aliases.add(alias.asname)
+                    receivers.add(alias.asname)
                 else:
-                    # `import application_sdk.storage` binds the root package;
-                    # the call site then reads application_sdk.storage.x(...).
-                    aliases.add(alias.name.split(".")[0])
-    return direct, aliases
+                    # `import application_sdk.storage[.batch]` binds the root
+                    # package; the call site reads the full dotted path back,
+                    # and every ancestor package is bound along with it.
+                    segments = alias.name.split(".")
+                    for end in range(1, len(segments) + 1):
+                        path = ".".join(segments[:end])
+                        if path in _PREFIX_MODULE_PATHS:
+                            receivers.add(path)
+    return direct, receivers
 
 
 def _called_prefix_helper(
-    node: ast.Call, direct: set[str], aliases: set[str]
+    node: ast.Call, direct: set[str], receivers: set[str]
 ) -> str | None:
     """Name of the prefix helper *node* calls, or ``None``."""
     func = node.func
     if isinstance(func, ast.Name):
         return func.id if func.id in direct else None
     if isinstance(func, ast.Attribute) and func.attr in _PREFIX_TRANSFERS:
-        # Resolve the receiver chain's root: storage.upload_prefix(...) or
-        # application_sdk.storage.upload_prefix(...).
-        receiver: ast.expr = func.value
-        while isinstance(receiver, ast.Attribute):
-            receiver = receiver.value
-        if isinstance(receiver, ast.Name) and receiver.id in aliases:
+        # storage.upload_prefix(...) or application_sdk.storage.upload_prefix(...)
+        receiver = _dotted_name(func.value)
+        if receiver is not None and receiver in receivers:
             return func.attr
     return None
 
@@ -131,15 +144,15 @@ def check_p044(
     directives: dict[int, _IgnoreDirective],
 ) -> list[Finding]:
     """Emit P044 for each prefix-level transfer the app performs itself."""
-    direct, aliases = _sdk_storage_bindings(tree)
-    if not direct and not aliases:
+    direct, receivers = _sdk_storage_bindings(tree)
+    if not direct and not receivers:
         return []
 
     findings: list[Finding] = []
     for node in ast.walk(tree):
         if not isinstance(node, ast.Call):
             continue
-        helper = _called_prefix_helper(node, direct, aliases)
+        helper = _called_prefix_helper(node, direct, receivers)
         if helper is None:
             continue
         direction = "upload" if helper.startswith("upload") else "download"

--- a/packages/conformance/conformance/suite/checks/prescriptions/_prefix_transfer.py
+++ b/packages/conformance/conformance/suite/checks/prescriptions/_prefix_transfer.py
@@ -47,16 +47,29 @@ _PREFIX_TRANSFERS: frozenset[str] = frozenset({"upload_prefix", "download_prefix
 
 _SDK_STORAGE_ROOT = "application_sdk"
 
+#: Submodules of ``application_sdk`` whose attribute namespace exposes the
+#: prefix helpers. ``batch`` defines them; ``storage`` (the package) re-exports
+#: them. Keyed by the final module segment as written in the import.
+_STORAGE_MODULES_WITH_PREFIX: frozenset[str] = frozenset({"batch", "storage"})
+
 
 def _sdk_storage_bindings(tree: ast.AST) -> tuple[set[str], set[str]]:
     """Return ``(direct_names, module_aliases)`` bound to SDK storage in this file.
 
     ``direct_names`` are prefix helpers pulled in by
     ``from application_sdk.storage import upload_prefix`` (honouring ``as``
-    aliases). ``module_aliases`` are names bound to an SDK storage *module* by
-    ``import application_sdk.storage as storage`` or
-    ``from application_sdk import storage``, so an attribute call through them
-    can be resolved.
+    aliases). ``module_aliases`` are names bound to an SDK storage *module* that
+    exposes the prefix helpers, so an attribute call through them can be
+    resolved.
+
+    The module gate keys on the import *source*, not the local alias text: any
+    ``from application_sdk.storage import <module>`` /
+    ``import application_sdk.storage.<module>`` that names a module exposing
+    ``upload_prefix``/``download_prefix`` (``batch`` — where they are defined —
+    or the ``storage`` package that re-exports them) registers its bound name.
+    That is what matches ``from application_sdk.storage import batch`` and
+    ``from application_sdk.storage import batch as ops``; keying on the alias
+    text (``storage`` / ``*ops``) instead would miss both.
 
     Anything not traceable to an ``application_sdk`` import is left alone: a
     local ``upload_prefix`` helper is a different function that happens to share
@@ -76,8 +89,10 @@ def _sdk_storage_bindings(tree: ast.AST) -> tuple[set[str], set[str]]:
                 bound = alias.asname or alias.name
                 if alias.name in _PREFIX_TRANSFERS:
                     direct.add(bound)
-                elif alias.name == "storage" or alias.name.endswith("ops"):
-                    # `from application_sdk import storage`
+                elif alias.name in _STORAGE_MODULES_WITH_PREFIX:
+                    # `from application_sdk import storage`,
+                    # `from application_sdk.storage import batch[ as ops]`, etc.
+                    # Resolved by import source, so the alias text is free.
                     aliases.add(bound)
         elif isinstance(node, ast.Import):
             for alias in node.names:

--- a/packages/conformance/conformance/suite/checks/prescriptions/_prefix_transfer.py
+++ b/packages/conformance/conformance/suite/checks/prescriptions/_prefix_transfer.py
@@ -67,7 +67,10 @@ def _sdk_storage_bindings(tree: ast.AST) -> tuple[set[str], set[str]]:
     for node in ast.walk(tree):
         if isinstance(node, ast.ImportFrom):
             module = node.module or ""
-            if not (module == _SDK_STORAGE_ROOT or module.startswith(f"{_SDK_STORAGE_ROOT}.")):
+            if not (
+                module == _SDK_STORAGE_ROOT
+                or module.startswith(f"{_SDK_STORAGE_ROOT}.")
+            ):
                 continue
             for alias in node.names:
                 bound = alias.asname or alias.name

--- a/packages/conformance/conformance/suite/rules/storage.py
+++ b/packages/conformance/conformance/suite/rules/storage.py
@@ -234,4 +234,81 @@ RULES: tuple[RuleDefinition, ...] = (
         ),
         help_uri="https://github.com/atlanhq/application-sdk/blob/main/packages/conformance/conformance/docs/rules/prescriptions.md#p012",
     ),
+    RuleDefinition(
+        id="P044",
+        scope=RuleScope.APP,
+        name="DirectStoragePrefixTransfer",
+        tier=EnforcementTier.WARN,
+        mechanism=RuleMechanism.STATIC,
+        category="storage-seam",
+        autofixable=False,
+        orthogonal_gate="tests",
+        since="0.20.0",
+        rationale=(
+            "An app moving whole prefixes with storage.upload_prefix/download_prefix is "
+            "using a sanctioned SDK function at the wrong level, which is why no existing "
+            "rule catches it: P009 fires only on apps constructing their own store, and "
+            "P030/P042 are gated on self_deployed_runtime and so never run for a "
+            "direct-flow app. What the app gives up is everything layered above the "
+            "primitive — App.upload()'s ADR-0014 dual-write routing, the canonical "
+            "artifacts/apps/{app}/workflows/{workflow_id}/{run_id} prefix, @task "
+            "retry/replay, and FileReference's per-file SHA-256 sidecars, whose whole "
+            "purpose is detecting the partial or corrupt file that a per-directory "
+            "non-emptiness check cannot see. Apps that hand-roll this reliably re-derive "
+            "the missing guards later and get them subtly wrong: one connector's wrapper "
+            "skipped the download whenever the target directory was already non-empty, "
+            "which for a multi-writer fan-out prefix means a co-located reader silently "
+            "sees a subset of the data. "
+            "Customer impact: a silent subset. Some of the customer's metadata is "
+            "extracted, the run reports success, and the assets that never arrived look "
+            "indistinguishable from assets the source does not have — so it is the "
+            "customer who finds the gap, if anyone does."
+        ),
+        short_description=(
+            "App transfers whole prefixes via storage.upload_prefix/download_prefix "
+            "instead of FileReference + App.upload()/App.download()"
+        ),
+        full_description=(
+            "App source calls ``upload_prefix`` / ``download_prefix`` (or imports them\n"
+            "from ``application_sdk.storage``) to move artifacts itself, rather than\n"
+            "declaring the data on the contract and letting the SDK move it.\n"
+            "\n"
+            "These are real SDK functions, so this is not the\n"
+            "build-your-own-store shape **P009** describes — it is the sanctioned seam\n"
+            "used one level too low. The storage contract in this module's docstring\n"
+            "names the two supported paths:\n"
+            "\n"
+            "* **task-to-task** data → a ``FileReference`` field on the contract. The\n"
+            "  activity interceptor persists it after the producing task and\n"
+            "  materialises it before the consuming one, with a per-file SHA-256\n"
+            "  sidecar so a partial or corrupt transfer is detected rather than\n"
+            "  reused.\n"
+            "* **phase/app hand-off** → ``App.upload()`` / ``App.download()``, which\n"
+            "  add dual-write routing, the canonical artifact prefix, and ``@task``\n"
+            "  retry/replay.\n"
+            "\n"
+            "**Fix by hoisting, not by substituting in place.** ``App.upload()`` is\n"
+            "itself a framework task, so calling it where the prefix call used to sit\n"
+            "— inside a ``@task`` — trades this finding for a **P008** violation. Move\n"
+            "the transfer to ``run()`` / the ``@entrypoint``, one call per phase, and\n"
+            "let the tasks below it read and write local paths.\n"
+            "\n"
+            "Not every prefix call is wrong. A genuine bulk transfer with no contract\n"
+            "boundary to hang a reference on — a state directory synced wholesale, a\n"
+            "one-off migration script — is a legitimate use. Suppress those with an\n"
+            "inline ``# conformance: ignore[P044] <reason>``, which stays visible in\n"
+            "SARIF rather than disappearing.\n"
+            "\n"
+            "Tier note: this lands at WARN because the pattern is fleet-wide, not\n"
+            "isolated — a sweep of ``atlanhq`` found app-code calls in roughly 34\n"
+            "consumer repos, five of them sharing a copied ``app/workflow/io.py``. It\n"
+            "graduates to BLOCK once that count is falling rather than flat. It is\n"
+            "deliberately a separate id from **P030** for the same reason P030 and P042\n"
+            "are separate: absence of ``App.upload()`` in SDR mode is a proven\n"
+            "customer-data-loss class and blocks, while absence in the direct flow is\n"
+            "legitimate — ``persist_file_refs`` performs that transfer automatically —\n"
+            "so the two shapes cannot share a tier.\n"
+        ),
+        help_uri="https://github.com/atlanhq/application-sdk/blob/main/packages/conformance/conformance/docs/rules/prescriptions.md#p044",
+    ),
 )

--- a/packages/conformance/conformance/suite/rules/storage.py
+++ b/packages/conformance/conformance/suite/rules/storage.py
@@ -243,7 +243,7 @@ RULES: tuple[RuleDefinition, ...] = (
         category="storage-seam",
         autofixable=False,
         orthogonal_gate="tests",
-        since="0.20.0",
+        since="0.21.0",
         rationale=(
             "An app moving whole prefixes with storage.upload_prefix/download_prefix is "
             "using a sanctioned SDK function at the wrong level, which is why no existing "
@@ -278,14 +278,15 @@ RULES: tuple[RuleDefinition, ...] = (
             "used one level too low. The storage contract in this module's docstring\n"
             "names the two supported paths:\n"
             "\n"
-            "* **task-to-task** data → a ``FileReference`` field on the contract. The\n"
-            "  activity interceptor persists it after the producing task and\n"
-            "  materialises it before the consuming one, with a per-file SHA-256\n"
-            "  sidecar so a partial or corrupt transfer is detected rather than\n"
-            "  reused.\n"
-            "* **phase/app hand-off** → ``App.upload()`` / ``App.download()``, which\n"
-            "  add dual-write routing, the canonical artifact prefix, and ``@task``\n"
-            "  retry/replay.\n"
+            "* **task-to-task** data → a ``FileReference`` field on the contract."
+            " The activity interceptor persists it after the producing task and"
+            " materialises it before the consuming one, with a per-file SHA-256"
+            " sidecar so a partial or corrupt transfer is detected rather than"
+            " reused.\n"
+            "\n"
+            "* **phase/app hand-off** → ``App.upload()`` / ``App.download()``, which"
+            " add dual-write routing, the canonical artifact prefix, and ``@task``"
+            " retry/replay.\n"
             "\n"
             "**Fix by hoisting, not by substituting in place.** ``App.upload()`` is\n"
             "itself a framework task, so calling it where the prefix call used to sit\n"

--- a/packages/conformance/tests/test_catalog.py
+++ b/packages/conformance/tests/test_catalog.py
@@ -330,6 +330,7 @@ def test_catalog_app_scoped_rules_are_the_expected_set() -> None:
         "P040",
         "P041",
         "P042",
+        "P044",
         "C002",
         "D001",
         "D002",
@@ -608,6 +609,7 @@ def test_catalog_p_series_present() -> None:
         "P040",
         "P041",
         "P042",
+        "P044",
     }
     missing = expected - p_ids
     assert not missing, f"Missing P-series rules: {missing}"

--- a/packages/conformance/tests/test_prefix_transfer.py
+++ b/packages/conformance/tests/test_prefix_transfer.py
@@ -56,6 +56,33 @@ def test_flags_module_attribute_form() -> None:
     assert len(findings) == 1
 
 
+def test_flags_batch_module_plain_import() -> None:
+    """The prefix helpers live in ``application_sdk/storage/batch.py``, so this
+    is the most natural module form — the gate resolves the import *source*, so
+    a ``batch`` binding must register even though its name is neither ``storage``
+    nor ``*ops``."""
+    findings = _check(
+        "from application_sdk.storage import batch\n"
+        "\n"
+        "async def go(local, prefix):\n"
+        "    await batch.upload_prefix(local, prefix)\n"
+    )
+    assert len(findings) == 1
+
+
+def test_flags_batch_module_aliased_as_ops() -> None:
+    """``batch as ops`` reaches the same helpers through a renamed module
+    binding; the docstring's attribute form (``ops.download_prefix(...)``) only
+    holds if the gate keys on the import source rather than the alias text."""
+    findings = _check(
+        "from application_sdk.storage import batch as ops\n"
+        "\n"
+        "async def go(prefix, d):\n"
+        "    await ops.download_prefix(prefix, d)\n"
+    )
+    assert len(findings) == 1
+
+
 def test_flags_dotted_import_form() -> None:
     findings = _check(
         "import application_sdk.storage\n"

--- a/packages/conformance/tests/test_prefix_transfer.py
+++ b/packages/conformance/tests/test_prefix_transfer.py
@@ -1,0 +1,215 @@
+"""P044 DirectStoragePrefixTransfer.
+
+The rule closes a gap two existing rules each miss for a structural reason, so
+the negative cases below matter as much as the positive ones: P009 does not fire
+because the app calls a real SDK function, and P030/P042 do not fire because they
+are gated on ``self_deployed_runtime``.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from conformance.suite.checks.prescriptions import check_p044, scan_path
+from conformance.suite.checks._ast_common import _parse_directives
+
+
+def _check(src: str, filename: str = "app/io.py") -> list:
+    return check_p044(ast.parse(src), filename, _parse_directives(src))
+
+
+# ── positive ────────────────────────────────────────────────────────────────
+
+
+def test_flags_direct_import_form() -> None:
+    findings = _check(
+        "from application_sdk.storage import upload_prefix\n"
+        "\n"
+        "async def go(local, prefix):\n"
+        "    await upload_prefix(local, prefix)\n"
+    )
+    assert [f.rule_id for f in findings] == ["P044"]
+    assert findings[0].line == 4
+    assert "upload_prefix()" in findings[0].message
+
+
+def test_flags_download_and_names_the_matching_app_method() -> None:
+    """The hint has to name App.download() for a download, not App.upload()."""
+    findings = _check(
+        "from application_sdk.storage import download_prefix\n"
+        "\n"
+        "async def go(prefix, d):\n"
+        "    await download_prefix(prefix=prefix, local_dir=d)\n"
+    )
+    assert len(findings) == 1
+    assert "App.download()" in findings[0].message
+
+
+def test_flags_module_attribute_form() -> None:
+    findings = _check(
+        "from application_sdk import storage\n"
+        "\n"
+        "async def go(local, prefix):\n"
+        "    await storage.upload_prefix(local, prefix)\n"
+    )
+    assert len(findings) == 1
+
+
+def test_flags_dotted_import_form() -> None:
+    findings = _check(
+        "import application_sdk.storage\n"
+        "\n"
+        "async def go(local, prefix):\n"
+        "    await application_sdk.storage.upload_prefix(local, prefix)\n"
+    )
+    assert len(findings) == 1
+
+
+def test_flags_aliased_import() -> None:
+    findings = _check(
+        "from application_sdk.storage import upload_prefix as push\n"
+        "\n"
+        "async def go(local, prefix):\n"
+        "    await push(local, prefix)\n"
+    )
+    assert len(findings) == 1
+
+
+def test_flags_a_lazy_import_inside_a_function() -> None:
+    """The connector that motivated this rule imports inside the function body
+    to avoid a module-level cost, so a module-level-only scan would miss it."""
+    findings = _check(
+        "async def go(local, prefix):\n"
+        "    from application_sdk.storage import upload_prefix\n"
+        "\n"
+        "    await upload_prefix(local, prefix)\n"
+    )
+    assert len(findings) == 1
+
+
+def test_reports_every_call_site() -> None:
+    findings = _check(
+        "from application_sdk.storage import upload_prefix\n"
+        "\n"
+        "async def a(x, y):\n"
+        "    await upload_prefix(x, y)\n"
+        "\n"
+        "async def b(x, y):\n"
+        "    await upload_prefix(x, y)\n"
+    )
+    assert [f.line for f in findings] == [4, 7]
+
+
+# ── negative ────────────────────────────────────────────────────────────────
+
+
+def test_same_named_local_helper_is_not_flagged() -> None:
+    """The name must resolve to an application_sdk import in the same file — a
+    local helper that happens to share the name is a different function."""
+    findings = _check(
+        "def upload_prefix(local, prefix):\n"
+        "    return None\n"
+        "\n"
+        "def go(x, y):\n"
+        "    return upload_prefix(x, y)\n"
+    )
+    assert findings == []
+
+
+def test_single_object_transfers_are_out_of_scope() -> None:
+    """upload_file/download_file are the right tool when the caller holds one
+    file and has no contract boundary to hang a reference on."""
+    findings = _check(
+        "from application_sdk.storage import download_file, upload_file\n"
+        "\n"
+        "async def go(key, path):\n"
+        "    await upload_file(key, path)\n"
+        "    await download_file(key, path)\n"
+    )
+    assert findings == []
+
+
+def test_app_upload_is_not_flagged() -> None:
+    """The sanctioned shape must be silent, or the rule contradicts its own fix."""
+    findings = _check(
+        "from application_sdk.contracts.storage import UploadInput\n"
+        "\n"
+        "class App:\n"
+        "    async def run(self, d):\n"
+        "        await self.upload(UploadInput(local_path=d))\n"
+    )
+    assert findings == []
+
+
+def test_third_party_prefix_helper_is_not_flagged() -> None:
+    findings = _check(
+        "from some_other_lib.storage import upload_prefix\n"
+        "\n"
+        "async def go(x, y):\n"
+        "    await upload_prefix(x, y)\n"
+    )
+    assert findings == []
+
+
+def test_inline_suppression_is_honoured_and_stays_visible() -> None:
+    findings = _check(
+        "from application_sdk.storage import upload_prefix\n"
+        "\n"
+        "async def go(local, prefix):\n"
+        "    # conformance: ignore[P044] wholesale state-dir sync, no contract boundary\n"
+        "    await upload_prefix(local, prefix)\n"
+    )
+    # Suppressed, not dropped: it still reaches SARIF in its own category.
+    assert len(findings) == 1
+    assert findings[0].suppressed
+
+
+# ── interaction with the rules it complements ───────────────────────────────
+
+
+def test_does_not_co_fire_with_p008_on_one_site(tmp_path: Path) -> None:
+    """P008 flags self.upload()/self.download() inside a @task; P044 flags the
+    prefix primitives. Disjoint by subject, so one call site can never be both —
+    which matters because their fixes pull in opposite directions (P008 says move
+    the transfer out of the task, P044 says adopt the very method P008 guards)."""
+    src = (
+        "from application_sdk.app import task\n"
+        "from application_sdk.storage import upload_prefix\n"
+        "\n"
+        "class A:\n"
+        "    @task()\n"
+        "    async def t(self, d, prefix):\n"
+        "        await upload_prefix(d, prefix)\n"
+        "        await self.upload(d)\n"
+    )
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text('[project]\nname = "my-connector"\n', encoding="utf-8")
+    target = tmp_path / "app" / "io.py"
+    target.parent.mkdir(parents=True)
+    target.write_text(src, encoding="utf-8")
+
+    by_rule: dict[str, list[int]] = {}
+    for f in scan_path(target, tmp_path):
+        by_rule.setdefault(f.rule_id, []).append(f.line)
+
+    # The prefix call is P044's alone; the self.upload() call is P008's alone.
+    assert by_rule.get("P044") == [7]
+    assert by_rule.get("P008") == [8]
+
+
+def test_p009_stays_silent_on_the_sanctioned_seam() -> None:
+    """The reason this rule had to exist: P009 fires on an app constructing its
+    own store, and calling an SDK function is not that."""
+    from conformance.suite.checks.prescriptions import check_p009
+
+    src = (
+        "from application_sdk.storage import upload_prefix\n"
+        "\n"
+        "async def go(x, y):\n"
+        "    await upload_prefix(x, y)\n"
+    )
+    tree = ast.parse(src)
+    directives = _parse_directives(src)
+    assert check_p009(tree, "app/io.py", directives) == []
+    assert len(check_p044(tree, "app/io.py", directives)) == 1

--- a/packages/conformance/tests/test_prefix_transfer.py
+++ b/packages/conformance/tests/test_prefix_transfer.py
@@ -11,8 +11,8 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 
-from conformance.suite.checks.prescriptions import check_p044, scan_path
 from conformance.suite.checks._ast_common import _parse_directives
+from conformance.suite.checks.prescriptions import check_p044, scan_path
 
 
 def _check(src: str, filename: str = "app/io.py") -> list:

--- a/packages/conformance/tests/test_prefix_transfer.py
+++ b/packages/conformance/tests/test_prefix_transfer.py
@@ -93,6 +93,31 @@ def test_flags_dotted_import_form() -> None:
     assert len(findings) == 1
 
 
+def test_flags_dotted_batch_import_aliased() -> None:
+    """``import application_sdk.storage.batch as ops`` binds the defining module
+    under a free name — the Import branch has to resolve it by path, exactly as
+    the ImportFrom branch does."""
+    findings = _check(
+        "import application_sdk.storage.batch as ops\n"
+        "\n"
+        "async def go(local, prefix):\n"
+        "    await ops.upload_prefix(local, prefix)\n"
+    )
+    assert len(findings) == 1
+
+
+def test_flags_dotted_batch_import_plain() -> None:
+    """The plain dotted form binds the root package, so the call site spells the
+    whole path back out."""
+    findings = _check(
+        "import application_sdk.storage.batch\n"
+        "\n"
+        "async def go(prefix, d):\n"
+        "    await application_sdk.storage.batch.download_prefix(prefix, d)\n"
+    )
+    assert len(findings) == 1
+
+
 def test_flags_aliased_import() -> None:
     findings = _check(
         "from application_sdk.storage import upload_prefix as push\n"
@@ -165,6 +190,56 @@ def test_app_upload_is_not_flagged() -> None:
         "class App:\n"
         "    async def run(self, d):\n"
         "        await self.upload(UploadInput(local_path=d))\n"
+    )
+    assert findings == []
+
+
+def test_same_named_helper_from_another_sdk_subpackage_is_not_flagged() -> None:
+    """The gate is the import *path*, not the ``application_sdk`` prefix: only
+    ``application_sdk.storage`` and ``application_sdk.storage.batch`` expose these
+    helpers, so a same-named symbol from anywhere else in the SDK is a different
+    function."""
+    findings = _check(
+        "from application_sdk.contracts.types import upload_prefix\n"
+        "\n"
+        "async def go(x, y):\n"
+        "    await upload_prefix(x, y)\n"
+    )
+    assert findings == []
+
+
+def test_same_named_module_from_another_sdk_subpackage_is_not_flagged() -> None:
+    """``from application_sdk.contracts import storage`` binds the alias text the
+    attribute form looks for, from a module that does not have the helpers."""
+    findings = _check(
+        "from application_sdk.contracts import storage\n"
+        "\n"
+        "async def go(x, y):\n"
+        "    await storage.upload_prefix(x, y)\n"
+    )
+    assert findings == []
+
+
+def test_unrelated_storage_submodule_alias_is_not_flagged() -> None:
+    """``application_sdk.storage.formats.parquet`` is under the storage package
+    but is not one of the two modules that re-export or define the helpers."""
+    findings = _check(
+        "import application_sdk.storage.formats.parquet as pq\n"
+        "\n"
+        "async def go(x, y):\n"
+        "    await pq.upload_prefix(x, y)\n"
+    )
+    assert findings == []
+
+
+def test_unrelated_sdk_import_does_not_license_a_dotted_call() -> None:
+    """Importing some other part of the SDK must not register the root package as
+    a receiver — otherwise any ``application_sdk.*.upload_prefix(...)`` matches."""
+    findings = _check(
+        "import application_sdk.contracts\n"
+        "\n"
+        "async def go(x, y):\n"
+        "    await application_sdk.storage.upload_prefix(x, y)\n"
     )
     assert findings == []
 


### PR DESCRIPTION
Related: FND-433

## The gap

An app that moves whole prefixes with `storage.upload_prefix` / `download_prefix` slips past the entire suite. Not by accident — by three structural exemptions that each individually make sense:

| rule | why it stays silent |
|---|---|
| `P009 ManualObjectStoreConstruction` | fires on an app constructing its own store or cloud client. Calling a real SDK function is not that. |
| `P030 SdrUploadNotCalled` | `checks/sdr.py` opens with `if not _is_sdr_app(root): return []`. An app with `self_deployed_runtime: false` short-circuits the whole SDR series before it can ask whether `App.upload()` is used at all. |
| `P042 SdrHandRolledUploadBridge` | same gate, and specific to an `upload_to_atlan` bridge. |

A connector reached its **fourth** round of OOM patches with a hand-rolled `app/workflow/io.py` wrapping these primitives, and the suite never mentioned the pattern once. `P012` fired 11 times on the path-string fields that *should* be `FileReference`s — the right signal, but downstream of the cause.

## Why this is a new id, not a broadening of P030

The obvious move is to drop P030's SDR gate. That would be wrong: **absence of `App.upload()` is legitimate in the direct flow.** `persist_file_refs` uploads every ephemeral `FileReference` in a task's output and `materialize_file_refs` fetches it back before the consuming task, so an app that declares its references correctly needs no explicit upload at all. An absence check outside SDR fires on precisely the apps doing it right.

So `P044` flags the **presence of the wrong thing**, not the absence of the right thing — and the two shapes cannot share a tier:

- `P030`'s absence shape is a **proven customer-data-loss class** (4 of 15 swept connectors had a real silent-zero-asset publish behind a finding presumed false) and is BLOCK, deliberately graduated in FND-311.
- `P044`'s shape is a **fleet-wide convention**. A sweep of `atlanhq` found app-code calls in roughly **34 consumer repos**, five of them sharing a copied `app/workflow/io.py`:

  ```
  atlan-microstrategy-app:app/workflow/io.py
  atlan-qlik-sense-app:app/workflow/io.py
  atlan-salesforce-app:app/workflow/io.py
  atlan-sigma-app:app/workflow/io.py
  atlan-tableau-app:app/workflow/io.py
  ```

`EnforcementTier` is per-rule, so folding them together would either red-gate ~34 repos on merge or regress P030's protection against the worst failure class we have. Hence: **`P044`, WARN, `scope=app`, no SDR gate** — graduating to BLOCK once the fleet count is falling rather than flat. Same reasoning that already keeps P030 and P042 as separate ids rather than one rule with two messages.

## What it costs an app to hand-roll this

Everything layered above the primitive: `App.upload()`'s ADR-0014 dual-write routing, the canonical `artifacts/apps/{app}/workflows/{workflow_id}/{run_id}` prefix, `@task` retry/replay, and `FileReference`'s **per-file SHA-256 sidecars** — whose entire purpose is detecting the partial or corrupt file that a per-directory check cannot see.

Apps that hand-roll it reliably re-derive the missing guards later and get them subtly wrong. The motivating connector's wrapper skips the download whenever the target directory is already non-empty; for a multi-writer fan-out prefix that means a co-located reader silently sees a **subset** of the data, and its own docstring says so.

## Scope of the match

Deliberately narrow, so it stays a true positive:

- **Only the two prefix helpers.** `upload_file` / `download_file` stay out — they are the right tool when a caller holds one file and has no contract boundary to hang a reference on.
- **The callee must resolve to an `application_sdk` import in the same file**, so a local helper sharing the name is untouched.
- **Both call forms**, including a lazy import inside a function body — which is how the motivating connector writes it, so a module-level-only scan would miss it.

## Remediation (same PR, per the skill)

The prescription in `programs/areas/prescriptions.prose.md` names which of the two supported paths applies, and says **explicitly never to substitute `App.upload()` in place**: it is itself a framework task, so leaving the call inside a `@task` trades a `P044` finding for a `P008` one. It must be hoisted to `run()` / the `@entrypoint`, one call per phase. Verified against the model app — all four of `atlan-metabase-app`'s `self.upload`/`self.download` calls sit in `@entrypoint` methods, never in a `@task`.

A genuine bulk sync with no contract boundary is a legitimate use and gets an inline suppression, which stays visible in SARIF.

## Verification

- **2681 tests pass, 1 xfailed** (2679 before; 14 new tests plus 2 meta-test set updates), re-run after rebasing onto current `main`.
- **Fires on the real app** it was written for, at both sites:
  ```
  [P044] [WARN] app/workflow/io.py:536:11   upload_prefix() moves a whole prefix from app code…
  [P044] [WARN] app/workflow/io.py:593:15   download_prefix() moves a whole prefix from app code…
  ```
- **Silent on the SDK itself** (`scope=app`): 0 findings running the P series against this repo.
- **Interaction tests, not just unit tests** — one pins that `P044` and `P008` cannot co-fire on a single site (their fixes pull in opposite directions, so a shared site would oscillate the remediation loop); another pins that `P009` stays silent on the sanctioned seam, which is the reason this rule had to exist.
- `gen-rule-docs` regenerated.
- Repo-root `pre-commit run --all-files`: green except a **pre-existing** pyright error in `application_sdk/storage/formats/parquet.py:86` — confirmed identical with these changes stashed, and that file is untouched here.
