### PR TITLE
fix(worker): instrument the poll loop to identify a parked worker (ARUN-1127)

### DIFF
--- a/application_sdk/constants.py
+++ b/application_sdk/constants.py
@@ -174,6 +174,16 @@ TEMPORAL_PROMETHEUS_BIND_ADDRESS = os.getenv(
 TEMPORAL_CORE_METRICS_PROXY_TIMEOUT_SECONDS: float = float(
     os.getenv("ATLAN_TEMPORAL_CORE_METRICS_PROXY_TIMEOUT_SECONDS", "5.0")
 )
+#: Upper bound on the bytes read from the loopback metrics endpoint when
+#: reading sdk-core's poller gauge for diagnostics. The endpoint is local and
+#: diagnostics-only, but a high-cardinality or misbehaving exporter could
+#: otherwise make the observer allocate an unbounded string every interval.
+#: Oversize is treated as unknown (``None``), never as zero. ~1 MiB is far
+#: above a healthy exposition (~460 series) and far below anything that could
+#: pressure the worker.
+TEMPORAL_CORE_METRICS_MAX_BYTES: int = int(
+    os.getenv("ATLAN_TEMPORAL_CORE_METRICS_MAX_BYTES", str(1024 * 1024))
+)
 
 # Prometheus Pushgateway (worker-only deployments)
 #: Pushgateway URL workers push to. Empty disables push (combined-mode

--- a/application_sdk/execution/_temporal/worker.py
+++ b/application_sdk/execution/_temporal/worker.py
@@ -126,7 +126,9 @@ async def read_core_poller_counts() -> dict[str, float] | None:
             # Stream so the read is genuinely bounded: reject on a declared
             # oversize Content-Length, else accumulate chunks and bail the
             # moment the running total crosses the cap — so even a chunked or
-            # under-reported response never allocates more than the cap. An
+            # under-reported response never allocates more than the cap in
+            # aggregate. Passing chunk_size=cap also bounds each single
+            # allocation, so one oversize chunk cannot be read in full. An
             # unbounded response.text would let a high-cardinality or
             # misbehaving local exporter allocate an unbounded string each
             # interval. Oversize is unknown (None), never zero.
@@ -152,7 +154,9 @@ async def read_core_poller_counts() -> dict[str, float] | None:
                 chunks: list[bytes] = []
                 received = 0
                 oversize = False
-                async for chunk in response.aiter_bytes():
+                async for chunk in response.aiter_bytes(
+                    chunk_size=TEMPORAL_CORE_METRICS_MAX_BYTES
+                ):
                     received += len(chunk)
                     if received > TEMPORAL_CORE_METRICS_MAX_BYTES:
                         oversize = True
@@ -838,7 +842,20 @@ def create_worker(
 
     async def _fatal_error_hook(exc: BaseException) -> None:
         # Always log — the diagnostic must not depend on a caller opting in.
-        await _log_worker_fatal_error(exc)
+        # Guard even this mandatory path: if rendering the cause chain itself
+        # raises (e.g. an exception whose ``__str__`` blows up), fall back to a
+        # minimal line that does not render ``exc`` — otherwise the hook
+        # propagates and temporalio's own "Fatal error handler failed" wrapper
+        # silently swaps in, losing the rich cause-chain log this hook exists
+        # to produce.
+        try:
+            await _log_worker_fatal_error(exc)
+        except BaseException:
+            logger.error(
+                "Temporal worker poll loop failed fatally (cause chain "
+                "unavailable: rendering the exception raised %s)",
+                type(exc).__name__,
+            )
         if on_fatal_error is None:
             return
         try:

--- a/application_sdk/execution/_temporal/worker.py
+++ b/application_sdk/execution/_temporal/worker.py
@@ -220,10 +220,15 @@ async def _log_worker_fatal_error(exc: BaseException) -> None:
     no ``poll loop failed`` line never raised at all, which distinguishes a
     swallowed fatal from a poll loop that parked without erroring (ARUN-1127).
     """
+    # exc_info=exc, not True: ``Worker.run`` retrieves the fatal with
+    # ``task.exception()`` and calls this hook outside any ``except`` block, so
+    # no exception is being handled. ``exc_info=True`` would resolve to
+    # ``sys.exc_info()`` — empty here — and render "NoneType: None" instead of
+    # the traceback this log exists to capture.
     logger.error(
         "Temporal worker poll loop failed fatally; cause chain: %s",
         " <- ".join(describe_exception_chain(exc)),
-        exc_info=True,
+        exc_info=exc,
     )
 
 

--- a/application_sdk/execution/_temporal/worker.py
+++ b/application_sdk/execution/_temporal/worker.py
@@ -123,12 +123,13 @@ async def read_core_poller_counts() -> dict[str, float] | None:
         async with httpx.AsyncClient(
             timeout=TEMPORAL_CORE_METRICS_PROXY_TIMEOUT_SECONDS
         ) as http_client:
-            # Stream so the read is genuinely bounded: reject on a declared
-            # oversize Content-Length, else accumulate chunks and bail the
-            # moment the running total crosses the cap — so even a chunked or
-            # under-reported response never allocates more than the cap in
-            # aggregate. Passing chunk_size=cap also bounds each single
-            # allocation, so one oversize chunk cannot be read in full. An
+            # Stream so the read is bounded: reject on a declared oversize
+            # Content-Length, else accumulate chunks and bail the moment the
+            # running total crosses the cap. Passing chunk_size=cap bounds each
+            # chunk yielded to this loop; the running-total check bounds the
+            # retained bytes. (httpx may still buffer an individual raw
+            # transport chunk internally above the cap, so this bounds what the
+            # loop retains rather than every transient allocation.) An
             # unbounded response.text would let a high-cardinality or
             # misbehaving local exporter allocate an unbounded string each
             # interval. Oversize is unknown (None), never zero.
@@ -847,7 +848,9 @@ def create_worker(
         # minimal line that does not render ``exc`` — otherwise the hook
         # propagates and temporalio's own "Fatal error handler failed" wrapper
         # silently swaps in, losing the rich cause-chain log this hook exists
-        # to produce.
+        # to produce. exc_info=True logs the traceback of the *rendering
+        # failure* (the ordinary exception raised while logging), never
+        # ``exc`` — so the original fatal is still not re-rendered on this path.
         try:
             await _log_worker_fatal_error(exc)
         except BaseException:
@@ -855,6 +858,7 @@ def create_worker(
                 "Temporal worker poll loop failed fatally (cause chain "
                 "unavailable: rendering the exception raised %s)",
                 type(exc).__name__,
+                exc_info=True,
             )
         if on_fatal_error is None:
             return

--- a/application_sdk/execution/_temporal/worker.py
+++ b/application_sdk/execution/_temporal/worker.py
@@ -124,7 +124,9 @@ async def read_core_poller_counts() -> dict[str, float] | None:
             timeout=TEMPORAL_CORE_METRICS_PROXY_TIMEOUT_SECONDS
         ) as http_client:
             # Stream so the read is genuinely bounded: reject on a declared
-            # oversize Content-Length, else cap the bytes actually read. An
+            # oversize Content-Length, else accumulate chunks and bail the
+            # moment the running total crosses the cap — so even a chunked or
+            # under-reported response never allocates more than the cap. An
             # unbounded response.text would let a high-cardinality or
             # misbehaving local exporter allocate an unbounded string each
             # interval. Oversize is unknown (None), never zero.
@@ -147,15 +149,23 @@ async def read_core_poller_counts() -> dict[str, float] | None:
                         TEMPORAL_CORE_METRICS_MAX_BYTES,
                     )
                     return None
-                body = await response.aread()
-                if len(body) > TEMPORAL_CORE_METRICS_MAX_BYTES:
+                chunks: list[bytes] = []
+                received = 0
+                oversize = False
+                async for chunk in response.aiter_bytes():
+                    received += len(chunk)
+                    if received > TEMPORAL_CORE_METRICS_MAX_BYTES:
+                        oversize = True
+                        break
+                    chunks.append(chunk)
+                if oversize:
                     logger.debug(
                         "Temporal-core metrics endpoint %s exceeded %d bytes; poller count unknown",
                         url,
                         TEMPORAL_CORE_METRICS_MAX_BYTES,
                     )
                     return None
-                payload = body.decode("utf-8", errors="replace")
+                payload = b"".join(chunks).decode("utf-8", errors="replace")
     except Exception:
         logger.debug(
             "Temporal-core metrics endpoint %s unreachable; poller count unknown",

--- a/application_sdk/execution/_temporal/worker.py
+++ b/application_sdk/execution/_temporal/worker.py
@@ -50,6 +50,142 @@ logger = get_logger(__name__)
 # type, so only never-retryable types belong here.
 _WORKFLOW_FAILURE_EXCEPTION_TYPES: tuple[type[BaseException], ...] = (ValidationError,)
 
+# Depth cap for rendering an exception's cause chain. temporalio's poll fatal is
+# two links deep; anything much longer is a runaway chain, not diagnostics.
+_MAX_FATAL_CHAIN_DEPTH = 10
+
+# sdk-core publishes its poller gauge under this family name (the ``temporal_``
+# prefix is core's default). Both spellings are accepted so a future prefix
+# change does not silently zero the reading.
+_CORE_POLLER_GAUGE_NAMES = ("temporal_num_pollers", "num_pollers")
+# Preferred label to key the gauge by; core sets ``poller_type``
+# (``workflow_task`` / ``activity_task`` / ``sticky_workflow_task`` / ...).
+_CORE_POLLER_TYPE_LABELS = ("poller_type", "worker_type")
+
+
+def describe_exception_chain(exc: BaseException) -> list[str]:
+    """Render an exception and its ``__cause__``/``__context__`` chain.
+
+    A Temporal poll fatal reaches Python wrapped twice — the Rust bridge raises
+    ``RuntimeError("Poll failure: Unhandled grpc error when polling: Status {
+    code: PermissionDenied, ... }")`` and ``temporalio.worker`` re-wraps that as
+    ``RuntimeError("Activity worker failed") from err``. So ``str(exc)`` says
+    nothing at all about *why* the poll died: the gRPC status name only exists
+    further down the chain. Each link is rendered ``ClassName: message`` so the
+    status reaches the logs.
+
+    Cycle-protected and capped at ``_MAX_FATAL_CHAIN_DEPTH`` links.
+    """
+    chain: list[str] = []
+    seen: set[int] = set()
+    current: BaseException | None = exc
+    while current is not None and id(current) not in seen:
+        if len(chain) >= _MAX_FATAL_CHAIN_DEPTH:
+            chain.append("... chain truncated")
+            break
+        seen.add(id(current))
+        chain.append(f"{type(current).__name__}: {current}")
+        # __cause__ is the explicit ``raise ... from``; __context__ covers an
+        # implicit chain raised while handling another error.
+        current = current.__cause__ or current.__context__
+    return chain
+
+
+async def read_core_poller_counts() -> dict[str, float] | None:
+    """Read sdk-core's live poller gauge from its local Prometheus endpoint.
+
+    This is the in-process answer to "is this worker actually polling?".
+    sdk-core maintains ``temporal_num_pollers`` as a gauge, labelled by poller
+    type, so a worker whose poll loop has died reads ``0`` while a
+    legitimately-idle worker still reads its configured poller count. Unlike
+    asking the Temporal frontend (``DescribeTaskQueue``), it needs no network
+    call, no task-queue read permission, and cannot go blind during the very
+    auth outage that kills the poll loop.
+
+    Returns a ``{poller_type: count}`` mapping, or ``None`` when the endpoint
+    could not be read — which means *unknown*, never zero. ``None`` is expected
+    when core's Prometheus exporter is disabled
+    (``ATLAN_TEMPORAL_PROMETHEUS_BIND_ADDRESS``).
+    """
+    import httpx  # noqa: PLC0415 — cold path: diagnostics only
+    from prometheus_client.parser import (  # noqa: PLC0415 — cold path: diagnostics only
+        text_string_to_metric_families,
+    )
+
+    from application_sdk.constants import (  # noqa: PLC0415 — cold path: diagnostics only
+        TEMPORAL_CORE_METRICS_PROXY_TIMEOUT_SECONDS,
+        TEMPORAL_PROMETHEUS_BIND_ADDRESS,
+    )
+
+    url = f"http://{TEMPORAL_PROMETHEUS_BIND_ADDRESS}/metrics"
+    try:
+        async with httpx.AsyncClient(
+            timeout=TEMPORAL_CORE_METRICS_PROXY_TIMEOUT_SECONDS
+        ) as http_client:
+            response = await http_client.get(url)
+        if response.status_code != 200:
+            logger.debug(
+                "Temporal-core metrics endpoint %s returned HTTP %d; poller count unknown",
+                url,
+                response.status_code,
+            )
+            return None
+        payload = response.text
+    except Exception:
+        logger.debug(
+            "Temporal-core metrics endpoint %s unreachable; poller count unknown",
+            url,
+            exc_info=True,
+        )
+        return None
+
+    counts: dict[str, float] = {}
+    try:
+        for family in text_string_to_metric_families(payload):
+            if family.name not in _CORE_POLLER_GAUGE_NAMES:
+                continue
+            for sample in family.samples:
+                key = next(
+                    (
+                        sample.labels[label]
+                        for label in _CORE_POLLER_TYPE_LABELS
+                        if label in sample.labels
+                    ),
+                    "unlabelled",
+                )
+                counts[key] = counts.get(key, 0.0) + sample.value
+    except Exception:
+        logger.debug(
+            "Could not parse Temporal-core metrics from %s; poller count unknown",
+            url,
+            exc_info=True,
+        )
+        return None
+
+    # The family being absent entirely is not the same as a zero reading: core
+    # only registers the gauge once a worker has started polling at least once.
+    return counts or None
+
+
+async def _log_worker_fatal_error(exc: BaseException) -> None:
+    """``on_fatal_error`` hook — log the fatal that took the poll loop down.
+
+    ``Worker.run`` invokes this the moment any poll task raises, *before* the
+    ``async with`` teardown runs. That matters: ``Worker.__aexit__`` re-raises a
+    captured fatal only when the body exits via ``CancelledError``, so a fatal
+    that races a shutdown is otherwise dropped silently. This hook always sees
+    it.
+
+    Its *absence* is a signal in its own right. A worker with zero pollers and
+    no ``poll loop failed`` line never raised at all, which distinguishes a
+    swallowed fatal from a poll loop that parked without erroring (ARUN-1127).
+    """
+    logger.error(
+        "Temporal worker poll loop failed fatally; cause chain: %s",
+        " <- ".join(describe_exception_chain(exc)),
+        exc_info=True,
+    )
+
 
 def _resolve_gate_enforcement(app_cls: type | None) -> bool:
     """Resolve the preflight gate's posture for one app.
@@ -315,6 +451,7 @@ def create_worker(
     interceptors: list[TemporalInterceptor] | None = None,
     enable_pushgateway: bool = False,
     on_activity: Callable[[], None] | None = None,
+    on_fatal_error: Callable[[BaseException], None] | None = None,
 ) -> AppWorker:
     """Create a Temporal worker for registered Apps.
 
@@ -363,6 +500,11 @@ def create_worker(
             heartbeat. The main entry point wires this to
             ``WorkerHealthServer.record_activity`` so the ``/live`` probe can
             reflect real worker progress.
+        on_fatal_error: Optional callback fired when a poll loop dies fatally.
+            The SDK always logs the fatal's full cause chain first (that hook is
+            the only place a fatal is guaranteed to be observed — see
+            ``_log_worker_fatal_error``); this callback is additive, and the main
+            entry point wires it to ``WorkerHealthServer.record_worker_fatal``.
 
     Returns:
         AppWorker wrapping a configured Temporal Worker (not yet started).
@@ -659,10 +801,24 @@ def create_worker(
             versioning_behavior.name,
         )
 
+    async def _fatal_error_hook(exc: BaseException) -> None:
+        # Always log — the diagnostic must not depend on a caller opting in.
+        await _log_worker_fatal_error(exc)
+        if on_fatal_error is None:
+            return
+        try:
+            on_fatal_error(exc)
+        except Exception:
+            logger.warning(
+                "on_fatal_error callback failed; the fatal itself is already logged",
+                exc_info=True,
+            )
+
     worker_kwargs: dict = dict(
         task_queue=task_queue,
         workflows=app_workflows,
         activities=task_activities,
+        on_fatal_error=_fatal_error_hook,
         workflow_runner=workflow_runner,
         interceptors=all_interceptors,
         max_concurrent_activities=max_concurrent_activities,

--- a/application_sdk/execution/_temporal/worker.py
+++ b/application_sdk/execution/_temporal/worker.py
@@ -113,6 +113,7 @@ async def read_core_poller_counts() -> dict[str, float] | None:
     )
 
     from application_sdk.constants import (  # noqa: PLC0415 — cold path: diagnostics only
+        TEMPORAL_CORE_METRICS_MAX_BYTES,
         TEMPORAL_CORE_METRICS_PROXY_TIMEOUT_SECONDS,
         TEMPORAL_PROMETHEUS_BIND_ADDRESS,
     )
@@ -122,15 +123,39 @@ async def read_core_poller_counts() -> dict[str, float] | None:
         async with httpx.AsyncClient(
             timeout=TEMPORAL_CORE_METRICS_PROXY_TIMEOUT_SECONDS
         ) as http_client:
-            response = await http_client.get(url)
-        if response.status_code != 200:
-            logger.debug(
-                "Temporal-core metrics endpoint %s returned HTTP %d; poller count unknown",
-                url,
-                response.status_code,
-            )
-            return None
-        payload = response.text
+            # Stream so the read is genuinely bounded: reject on a declared
+            # oversize Content-Length, else cap the bytes actually read. An
+            # unbounded response.text would let a high-cardinality or
+            # misbehaving local exporter allocate an unbounded string each
+            # interval. Oversize is unknown (None), never zero.
+            async with http_client.stream("GET", url) as response:
+                if response.status_code != 200:
+                    logger.debug(
+                        "Temporal-core metrics endpoint %s returned HTTP %d; poller count unknown",
+                        url,
+                        response.status_code,
+                    )
+                    return None
+                content_length = response.headers.get("content-length")
+                if content_length is not None and int(content_length) > (
+                    TEMPORAL_CORE_METRICS_MAX_BYTES
+                ):
+                    logger.debug(
+                        "Temporal-core metrics endpoint %s declared %s bytes (cap %d); poller count unknown",
+                        url,
+                        content_length,
+                        TEMPORAL_CORE_METRICS_MAX_BYTES,
+                    )
+                    return None
+                body = await response.aread()
+                if len(body) > TEMPORAL_CORE_METRICS_MAX_BYTES:
+                    logger.debug(
+                        "Temporal-core metrics endpoint %s exceeded %d bytes; poller count unknown",
+                        url,
+                        TEMPORAL_CORE_METRICS_MAX_BYTES,
+                    )
+                    return None
+                payload = body.decode("utf-8", errors="replace")
     except Exception:
         logger.debug(
             "Temporal-core metrics endpoint %s unreachable; poller count unknown",

--- a/application_sdk/execution/_temporal/worker.py
+++ b/application_sdk/execution/_temporal/worker.py
@@ -853,9 +853,13 @@ def create_worker(
         # minimal line that does not render ``exc`` — otherwise the hook
         # propagates and temporalio's own "Fatal error handler failed" wrapper
         # silently swaps in, losing the rich cause-chain log this hook exists
-        # to produce. exc_info=True logs the traceback of the *rendering
-        # failure* (the ordinary exception raised while logging), never
-        # ``exc`` — so the original fatal is still not re-rendered on this path.
+        # to produce. exc_info=True here logs the traceback of the *rendering
+        # failure*, not of ``exc``. That masks the link whose rendering failed
+        # (it appears as a ``<exception str() failed>`` placeholder); chain links
+        # that rendered before the failure may still appear, so this bounds which
+        # link is lost, not what the log can contain. No new exposure either way:
+        # those same messages reach the logs on the primary path whenever
+        # rendering succeeds.
         try:
             await _log_worker_fatal_error(exc)
         except BaseException:

--- a/application_sdk/main.py
+++ b/application_sdk/main.py
@@ -26,6 +26,7 @@ __all__ = [
 
 import argparse
 import asyncio
+import contextlib
 import faulthandler
 import os
 import random
@@ -972,6 +973,105 @@ _WORKER_RESTART_BACKOFF_CAP_SECONDS = _env_int(
     "ATLAN_WORKER_RESTART_BACKOFF_CAP_SECONDS", 30
 )
 _WORKER_HEALTHY_RUN_SECONDS = _env_int("ATLAN_WORKER_HEALTHY_RUN_SECONDS", 300)
+# Poll-state diagnostics (ARUN-1127). How often to read sdk-core's live poller
+# gauge and log a transition. Purely observational — set to 0 to disable.
+_WORKER_POLL_DIAGNOSTIC_INTERVAL_SECONDS = _env_int(
+    "ATLAN_WORKER_POLL_DIAGNOSTIC_INTERVAL_SECONDS", 60
+)
+
+
+async def _observe_worker_poll_state(
+    *,
+    shutdown_event: asyncio.Event,
+    health_server: Any = None,
+    interval: float = 0,
+) -> None:
+    """Log whether this worker is actually polling, and never act on it.
+
+    A worker can be alive, healthy on every probe, refreshing its Temporal token
+    — and have zero pollers on its task queue, doing no work until a human
+    restarts the pod (ARUN-1127 / BLDX-1552). Two candidate mechanisms produce
+    that shape and they need opposite fixes:
+
+    1. A fatal that was raised and then swallowed. ``Worker.__aexit__`` re-raises
+       a captured fatal only when the body exits via ``CancelledError``, so a
+       fatal racing a shutdown is dropped. Temporal's ``on_fatal_error`` hook
+       (wired in ``create_worker``) always sees it, so this case leaves a
+       ``poll loop failed fatally`` line in the logs.
+    2. A poll loop that stopped without ever raising. No exception exists, so
+       nothing in-process can be made to observe it after the fact.
+
+    This observer records the evidence that tells them apart — sdk-core's live
+    poller gauge alongside the fatal count — and deliberately draws no
+    conclusion: it never raises, never restarts the worker, and never flips a
+    probe. The mechanism has not been established on a live tenant yet, and a
+    remedy built on the wrong one either tears down healthy workers or hides the
+    outage behind a self-healing loop that cannot heal it.
+
+    Logs a transition (INFO) rather than every reading, so a long-running worker
+    stays quiet until something changes; a zero or unknown reading is a WARNING.
+
+    Args:
+        shutdown_event: Set on SIGINT/SIGTERM; ends the observer cleanly.
+        health_server: Optional ``WorkerHealthServer`` to record readings on, so
+            the counts are also reachable over ``/live`` and ``/ready``.
+        interval: Seconds between readings. Non-positive disables the observer.
+    """
+    if interval <= 0:
+        logger.debug("Worker poll-state diagnostics disabled (interval=%s)", interval)
+        return
+
+    from application_sdk.execution._temporal.worker import (  # noqa: PLC0415 — cold path: diagnostics only
+        read_core_poller_counts,
+    )
+
+    # Sentinel distinct from every real state, so the first reading always logs.
+    previous_state: str | None = None
+
+    while not shutdown_event.is_set():
+        # Wait first: core registers the gauge only once a worker has polled at
+        # least once, so a reading taken at t=0 always reports "unknown".
+        try:
+            await asyncio.wait_for(shutdown_event.wait(), timeout=interval)
+            return
+        except TimeoutError:  # conformance: ignore[E002] the interval elapsing without a shutdown is the expected path, not an error
+            pass
+
+        try:
+            counts = await read_core_poller_counts()
+            if health_server is not None:
+                health_server.record_poller_counts(counts)
+
+            if counts is None:
+                state = "unknown"
+            elif sum(counts.values()) > 0:
+                state = "polling"
+            else:
+                state = "zero"
+
+            if state == "zero":
+                logger.warning(
+                    "Worker reports 0 active pollers (poller gauge %s) — it is "
+                    "alive but claiming no work from its task queue; check the "
+                    "logs for a 'poll loop failed fatally' line, whose presence "
+                    "or absence identifies the failure mechanism (ARUN-1127)",
+                    counts,
+                )
+            elif state == "unknown":
+                if previous_state != "unknown":
+                    logger.warning(
+                        "Worker poll-state unknown: sdk-core's poller gauge could "
+                        "not be read, so a parked poll loop would be invisible. "
+                        "Check that core's Prometheus exporter is enabled "
+                        "(ATLAN_TEMPORAL_PROMETHEUS_BIND_ADDRESS)"
+                    )
+            elif state != previous_state:
+                logger.info("Worker poll state: active pollers %s", counts)
+
+            previous_state = state
+        except Exception:
+            # An observer must never take the worker down with it.
+            logger.warning("Worker poll-state observation failed", exc_info=True)
 
 
 async def _run_worker_with_restart(
@@ -980,6 +1080,7 @@ async def _run_worker_with_restart(
     shutdown_event: asyncio.Event,
     auth_manager: Any = None,
     client: Any = None,
+    health_server: Any = None,
 ) -> None:
     """Run a Temporal worker under a bounded restart supervisor.
 
@@ -1001,7 +1102,41 @@ async def _run_worker_with_restart(
         auth_manager: Optional; when present its token is force-refreshed before
             each restart to recover from stale/expired tokens.
         client: The Temporal client passed to ``auth_manager.force_refresh``.
+        health_server: Optional ``WorkerHealthServer``; receives the poll-state
+            observer's readings so they are also reachable over the probes.
     """
+    # Runs for the whole supervised lifetime, across worker rebuilds, so a
+    # rebuilt worker that comes back without pollers is still observed. Purely
+    # observational — it never raises and never restarts anything, so it is not
+    # raced against the worker.
+    observer = asyncio.ensure_future(
+        _observe_worker_poll_state(
+            shutdown_event=shutdown_event,
+            health_server=health_server,
+            interval=_WORKER_POLL_DIAGNOSTIC_INTERVAL_SECONDS,
+        )
+    )
+    try:
+        await _supervise_worker(
+            build_worker=build_worker,
+            shutdown_event=shutdown_event,
+            auth_manager=auth_manager,
+            client=client,
+        )
+    finally:
+        observer.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await observer
+
+
+async def _supervise_worker(
+    *,
+    build_worker: Callable[[], Any],
+    shutdown_event: asyncio.Event,
+    auth_manager: Any = None,
+    client: Any = None,
+) -> None:
+    """The restart loop itself; see ``_run_worker_with_restart`` for the contract."""
     consecutive_failures = 0
 
     while not shutdown_event.is_set():
@@ -1058,8 +1193,11 @@ async def _run_worker_with_restart(
 
             # Full-jitter exponential backoff (matches create_temporal_client),
             # raced against shutdown so SIGTERM stays responsive during backoff.
+            # Clamp the exponent: the cap already bounds the result, but a raised
+            # ATLAN_WORKER_MAX_CONSECUTIVE_RESTARTS would otherwise compute an
+            # arbitrarily large power of two just to throw it away.
             cap_at_attempt = min(
-                2 ** (consecutive_failures - 1),
+                2 ** min(consecutive_failures - 1, 16),
                 _WORKER_RESTART_BACKOFF_CAP_SECONDS,
             )
             delay = random.uniform(0, cap_at_attempt)
@@ -1212,6 +1350,7 @@ async def run_worker_mode(config: AppConfig) -> None:
             handler=handler_for_sdr,
             enable_pushgateway=True,
             on_activity=health_server.record_activity,
+            on_fatal_error=health_server.record_worker_fatal,
         )
 
     # Log registrations
@@ -1247,6 +1386,7 @@ async def run_worker_mode(config: AppConfig) -> None:
             shutdown_event=shutdown_event,
             auth_manager=auth_manager,
             client=client,
+            health_server=health_server,
         )
 
     from application_sdk.infrastructure.context import (  # noqa: PLC0415 — cold path: only when infrastructure init is needed
@@ -1491,6 +1631,7 @@ async def run_combined_mode(config: AppConfig) -> None:
             task_queue=config.task_queue,
             handler=handler,
             on_activity=health_server.record_activity,
+            on_fatal_error=health_server.record_worker_fatal,
         )
 
     for registered_app in AppRegistry.get_instance().list_apps():
@@ -1573,6 +1714,7 @@ async def run_combined_mode(config: AppConfig) -> None:
                 shutdown_event=shutdown_event,
                 auth_manager=auth_manager,
                 client=client,
+                health_server=health_server,
             ),
         )
 

--- a/application_sdk/main.py
+++ b/application_sdk/main.py
@@ -1008,8 +1008,11 @@ async def _observe_worker_poll_state(
     remedy built on the wrong one either tears down healthy workers or hides the
     outage behind a self-healing loop that cannot heal it.
 
-    Logs a transition (INFO) rather than every reading, so a long-running worker
-    stays quiet until something changes; a zero or unknown reading is a WARNING.
+    Logs a transition rather than every reading, so a long-running worker stays
+    quiet until something changes: an active-pollers reading is an INFO on change,
+    and a zero or unknown reading is a WARNING logged once per transition into
+    that state (not on every interval, so a parked worker does not drown the
+    ``poll loop failed fatally`` line in repeats).
 
     Args:
         shutdown_event: Set on SIGINT/SIGTERM; ends the observer cleanly.
@@ -1050,13 +1053,18 @@ async def _observe_worker_poll_state(
                 state = "zero"
 
             if state == "zero":
-                logger.warning(
-                    "Worker reports 0 active pollers (poller gauge %s) — it is "
-                    "alive but claiming no work from its task queue; check the "
-                    "logs for a 'poll loop failed fatally' line, whose presence "
-                    "or absence identifies the failure mechanism (ARUN-1127)",
-                    counts,
-                )
+                # Transition-gated like "unknown" below: warn once when the
+                # worker parks, not on every interval, so a parked worker does
+                # not bury the "poll loop failed fatally" line this PR exists
+                # to surface. A return to "polling" and back re-arms it.
+                if previous_state != "zero":
+                    logger.warning(
+                        "Worker reports 0 active pollers (poller gauge %s) — it is "
+                        "alive but claiming no work from its task queue; check the "
+                        "logs for a 'poll loop failed fatally' line, whose presence "
+                        "or absence identifies the failure mechanism (ARUN-1127)",
+                        counts,
+                    )
             elif state == "unknown":
                 if previous_state != "unknown":
                     logger.warning(

--- a/application_sdk/server/health.py
+++ b/application_sdk/server/health.py
@@ -291,6 +291,11 @@ class WorkerHealthServer:
                         "last_activity": last_activity_iso,
                         "idle_seconds": idle_seconds,
                         "max_idle_seconds": self._max_idle_seconds,
+                        # The poll-loop evidence matters most on this 503: it is
+                        # the probe an operator reaches for when the worker looks
+                        # stalled, so surface the same diagnostics the healthy
+                        # branch serves.
+                        **self._poll_diagnostics(),
                     },
                 )
 

--- a/application_sdk/server/health.py
+++ b/application_sdk/server/health.py
@@ -145,6 +145,16 @@ class WorkerHealthServer:
         self._started_at: datetime | None = None
         self._last_activity: datetime | None = None
         self._request_count: int = 0
+        # Poll-loop diagnostics (ARUN-1127). These are observational only: none
+        # of them flips a probe, because the mechanism behind a parked poll loop
+        # is not yet established and a probe that acts on a guess can kill a
+        # healthy worker. They exist so the mechanism can be read off a live
+        # tenant. See ``main.py::_observe_worker_poll_state``.
+        self._last_fatal_at: datetime | None = None
+        self._last_fatal_type: str | None = None
+        self._fatal_count: int = 0
+        self._last_poller_counts: dict[str, float] | None = None
+        self._last_poller_read_at: datetime | None = None
         # Reject non-finite windows to match the env loader
         # (``_load_worker_liveness_max_idle_seconds``): an ``inf`` window is set
         # but can never trip (``idle > inf`` is always False) and ``nan``
@@ -172,6 +182,43 @@ class WorkerHealthServer:
         Call this when the worker processes a task to update liveness tracking.
         """
         self._last_activity = _utc_now()
+
+    def record_worker_fatal(self, exc: BaseException) -> None:
+        """Record that a worker poll loop died with a fatal error.
+
+        Wired to Temporal's ``on_fatal_error`` hook, which fires the moment a
+        poll task raises. Only the exception *type* is retained: the full cause
+        chain goes to the logs instead, because the probe payload is served over
+        HTTP and a gRPC status repr can carry response metadata.
+        """
+        self._last_fatal_at = _utc_now()
+        self._last_fatal_type = type(exc).__name__
+        self._fatal_count += 1
+
+    def record_poller_counts(self, counts: dict[str, float] | None) -> None:
+        """Record sdk-core's live poller gauge, keyed by poller type.
+
+        ``None`` means the gauge could not be read (unknown), which is recorded
+        as such and never as zero.
+        """
+        self._last_poller_counts = counts
+        self._last_poller_read_at = _utc_now()
+
+    def _poll_diagnostics(self) -> dict[str, Any]:
+        """Poll-loop diagnostic fields shared by ``/ready`` and ``/live``."""
+        return {
+            "poller_counts": self._last_poller_counts,
+            "poller_counts_read_at": (
+                self._last_poller_read_at.isoformat()
+                if self._last_poller_read_at
+                else None
+            ),
+            "last_fatal_at": (
+                self._last_fatal_at.isoformat() if self._last_fatal_at else None
+            ),
+            "last_fatal_type": self._last_fatal_type,
+            "fatal_count": self._fatal_count,
+        }
 
     async def check_health(self) -> HealthStatus:
         """Basic health check - is the process running?
@@ -210,7 +257,10 @@ class WorkerHealthServer:
         return HealthStatus(
             healthy=True,
             message="Worker is ready",
-            details={"identity": self._temporal_client.identity},
+            details={
+                "identity": self._temporal_client.identity,
+                **self._poll_diagnostics(),
+            },
         )
 
     async def check_live(self) -> HealthStatus:
@@ -247,7 +297,10 @@ class WorkerHealthServer:
         return HealthStatus(
             healthy=True,
             message="Worker is responsive",
-            details={"last_activity": last_activity_iso},
+            details={
+                "last_activity": last_activity_iso,
+                **self._poll_diagnostics(),
+            },
         )
 
     async def _handle_request(

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -85,6 +85,11 @@ Bounds the restart supervisor that rebuilds the worker after a fatal poll error 
 | `ATLAN_WORKER_MAX_CONSECUTIVE_RESTARTS` | `10` | Consecutive worker-fatal failures tolerated before the supervisor gives up and re-raises, so a persistent misconfiguration still fails loud instead of hot-looping. The counter resets after a healthy run window. |
 | `ATLAN_WORKER_RESTART_BACKOFF_CAP_SECONDS` | `30` | Upper bound (seconds) for the full-jitter exponential backoff between worker restarts. The backoff is raced against shutdown so SIGTERM stays responsive. |
 | `ATLAN_WORKER_HEALTHY_RUN_SECONDS` | `300` | A worker that ran at least this long (seconds) before failing is treated as a fresh incident, resetting the consecutive-failure streak. |
+| `ATLAN_WORKER_POLL_DIAGNOSTIC_INTERVAL_SECONDS` | `60` | How often (seconds) to read Temporal core's live poller gauge and log a state transition, so a worker that is alive but claiming no work is visible in logs and in the `/live` / `/ready` probe details. Purely observational — it never restarts the worker and never flips a probe. Set to `0` to disable. |
+
+Reading the poller gauge requires Temporal core's Prometheus exporter, bound by
+`ATLAN_TEMPORAL_PROMETHEUS_BIND_ADDRESS` (default `127.0.0.1:9464`). When it is
+unavailable the poll state is reported as *unknown*, never as zero.
 
 ### TLS
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -86,6 +86,7 @@ Bounds the restart supervisor that rebuilds the worker after a fatal poll error 
 | `ATLAN_WORKER_RESTART_BACKOFF_CAP_SECONDS` | `30` | Upper bound (seconds) for the full-jitter exponential backoff between worker restarts. The backoff is raced against shutdown so SIGTERM stays responsive. |
 | `ATLAN_WORKER_HEALTHY_RUN_SECONDS` | `300` | A worker that ran at least this long (seconds) before failing is treated as a fresh incident, resetting the consecutive-failure streak. |
 | `ATLAN_WORKER_POLL_DIAGNOSTIC_INTERVAL_SECONDS` | `60` | How often (seconds) to read Temporal core's live poller gauge and log a state transition, so a worker that is alive but claiming no work is visible in logs and in the `/live` / `/ready` probe details. Purely observational — it never restarts the worker and never flips a probe. Set to `0` to disable. |
+| `ATLAN_TEMPORAL_CORE_METRICS_MAX_BYTES` | `1048576` | Upper bound (bytes) on the metrics payload read from the loopback endpoint when reading Temporal core's poller gauge for the poll-state diagnostic. Guards the observer against an unbounded allocation if the local exporter misbehaves or grows high-cardinality. An oversize payload is reported as *unknown*, never as zero. |
 
 Reading the poller gauge requires Temporal core's Prometheus exporter, bound by
 `ATLAN_TEMPORAL_PROMETHEUS_BIND_ADDRESS` (default `127.0.0.1:9464`). When it is

--- a/tests/unit/execution/test_worker.py
+++ b/tests/unit/execution/test_worker.py
@@ -1241,15 +1241,30 @@ class TestReadCorePollerCounts:
         'temporal_request_total{operation="PollActivityTaskQueue"} 41.0\n'
     )
 
-    def _response(self, status_code: int = 200, text: str | None = None) -> mock.Mock:
+    def _response(
+        self,
+        status_code: int = 200,
+        text: str | None = None,
+        content_length: str | None = None,
+    ) -> mock.Mock:
+        body = (self._EXPOSITION if text is None else text).encode()
         response = mock.Mock()
         response.status_code = status_code
-        response.text = self._EXPOSITION if text is None else text
+        headers = {}
+        if content_length is not None:
+            headers["content-length"] = content_length
+        response.headers = headers
+        response.aread = mock.AsyncMock(return_value=body)
+        # ``client.stream`` returns an async context manager yielding the response.
+        stream_ctx = mock.AsyncMock()
+        stream_ctx.__aenter__ = mock.AsyncMock(return_value=response)
+        stream_ctx.__aexit__ = mock.AsyncMock(return_value=False)
+        response._stream_ctx = stream_ctx
         return response
 
     def _patch_client(self, response: mock.Mock) -> mock.patch:
         client = mock.AsyncMock()
-        client.get = mock.AsyncMock(return_value=response)
+        client.stream = mock.Mock(return_value=response._stream_ctx)
         client.__aenter__ = mock.AsyncMock(return_value=client)
         client.__aexit__ = mock.AsyncMock(return_value=False)
         return mock.patch("httpx.AsyncClient", return_value=client)
@@ -1274,9 +1289,22 @@ class TestReadCorePollerCounts:
         assert counts == {"workflow_task": 0.0}
 
     @pytest.mark.asyncio
+    async def test_oversize_content_length_is_unknown_not_zero(self) -> None:
+        """A declared-oversize exposition is unknown, never a zero count."""
+        with self._patch_client(self._response(content_length=str(100 * 1024 * 1024))):
+            assert await read_core_poller_counts() is None
+
+    @pytest.mark.asyncio
+    async def test_oversize_body_is_unknown_not_zero(self) -> None:
+        """An actually-oversize body (no/!accurate Content-Length) is unknown."""
+        body = "x" * (1024 * 1024 + 1)
+        with self._patch_client(self._response(text=body)):
+            assert await read_core_poller_counts() is None
+
+    @pytest.mark.asyncio
     async def test_unreachable_endpoint_is_unknown_not_zero(self) -> None:
         client = mock.AsyncMock()
-        client.get = mock.AsyncMock(side_effect=OSError("connection refused"))
+        client.stream = mock.Mock(side_effect=OSError("connection refused"))
         client.__aenter__ = mock.AsyncMock(return_value=client)
         client.__aexit__ = mock.AsyncMock(return_value=False)
 

--- a/tests/unit/execution/test_worker.py
+++ b/tests/unit/execution/test_worker.py
@@ -1246,6 +1246,7 @@ class TestReadCorePollerCounts:
         status_code: int = 200,
         text: str | None = None,
         content_length: str | None = None,
+        chunk_size: int | None = None,
     ) -> mock.Mock:
         body = (self._EXPOSITION if text is None else text).encode()
         response = mock.Mock()
@@ -1254,7 +1255,15 @@ class TestReadCorePollerCounts:
         if content_length is not None:
             headers["content-length"] = content_length
         response.headers = headers
-        response.aread = mock.AsyncMock(return_value=body)
+
+        # ``aiter_bytes`` yields the body in chunks so the incremental,
+        # byte-capped accumulation path is exercised (not a single bulk read).
+        async def _aiter():
+            step = chunk_size if chunk_size else len(body) or 1
+            for offset in range(0, len(body), step):
+                yield body[offset : offset + step]
+
+        response.aiter_bytes = lambda: _aiter()
         # ``client.stream`` returns an async context manager yielding the response.
         stream_ctx = mock.AsyncMock()
         stream_ctx.__aenter__ = mock.AsyncMock(return_value=response)
@@ -1299,6 +1308,16 @@ class TestReadCorePollerCounts:
         """An actually-oversize body (no/!accurate Content-Length) is unknown."""
         body = "x" * (1024 * 1024 + 1)
         with self._patch_client(self._response(text=body)):
+            assert await read_core_poller_counts() is None
+
+    @pytest.mark.asyncio
+    async def test_oversize_chunked_stream_is_bounded(self) -> None:
+        """A chunked response with no Content-Length must bail on the running
+        byte total, not after an unbounded bulk read of the full body."""
+        # 1 MiB + 1 byte, delivered as many small chunks: the cap must trip on
+        # the accumulated total, proving the read is genuinely bounded.
+        body = "x" * (1024 * 1024 + 1)
+        with self._patch_client(self._response(text=body, chunk_size=4096)):
             assert await read_core_poller_counts() is None
 
     @pytest.mark.asyncio

--- a/tests/unit/execution/test_worker.py
+++ b/tests/unit/execution/test_worker.py
@@ -1246,7 +1246,7 @@ class TestReadCorePollerCounts:
         status_code: int = 200,
         text: str | None = None,
         content_length: str | None = None,
-        chunk_size: int | None = None,
+        force_chunk_size: int | None = None,
     ) -> mock.Mock:
         body = (self._EXPOSITION if text is None else text).encode()
         response = mock.Mock()
@@ -1258,12 +1258,14 @@ class TestReadCorePollerCounts:
 
         # ``aiter_bytes`` yields the body in chunks so the incremental,
         # byte-capped accumulation path is exercised (not a single bulk read).
-        async def _aiter():
-            step = chunk_size if chunk_size else len(body) or 1
+        # The implementation passes ``chunk_size=cap``; ``force_chunk_size``
+        # overrides it so a test can force many small chunks regardless.
+        async def _aiter(chunk_size: int | None = None):
+            step = force_chunk_size or chunk_size or len(body) or 1
             for offset in range(0, len(body), step):
                 yield body[offset : offset + step]
 
-        response.aiter_bytes = lambda: _aiter()
+        response.aiter_bytes = _aiter
         # ``client.stream`` returns an async context manager yielding the response.
         stream_ctx = mock.AsyncMock()
         stream_ctx.__aenter__ = mock.AsyncMock(return_value=response)
@@ -1317,7 +1319,7 @@ class TestReadCorePollerCounts:
         # 1 MiB + 1 byte, delivered as many small chunks: the cap must trip on
         # the accumulated total, proving the read is genuinely bounded.
         body = "x" * (1024 * 1024 + 1)
-        with self._patch_client(self._response(text=body, chunk_size=4096)):
+        with self._patch_client(self._response(text=body, force_chunk_size=4096)):
             assert await read_core_poller_counts() is None
 
     @pytest.mark.asyncio

--- a/tests/unit/execution/test_worker.py
+++ b/tests/unit/execution/test_worker.py
@@ -26,6 +26,7 @@ from application_sdk.execution._temporal._activity_errors import (
 from application_sdk.execution._temporal.worker import (
     _MAX_FATAL_CHAIN_DEPTH,
     AppWorker,
+    _log_worker_fatal_error,
     _resolve_gate_enforcement,
     create_worker,
     describe_exception_chain,
@@ -1226,6 +1227,29 @@ class TestDescribeExceptionChain:
 
         assert len(chain) == _MAX_FATAL_CHAIN_DEPTH + 1
         assert chain[-1] == "... chain truncated"
+
+
+class TestLogWorkerFatalError:
+    """Tests for the ``on_fatal_error`` diagnostic log."""
+
+    @pytest.mark.asyncio
+    async def test_passes_the_exception_object_as_exc_info(self) -> None:
+        """``exc_info=True`` renders "NoneType: None" on this path.
+
+        ``Worker.run`` retrieves the fatal with ``task.exception()`` and invokes
+        the hook outside any ``except`` block, so ``sys.exc_info()`` is empty and
+        only passing the object itself yields a traceback. Pinning the value
+        keeps a future edit from quietly reverting to ``True`` and dropping the
+        traceback this log exists to capture.
+        """
+        exc = RuntimeError("Activity worker failed")
+
+        with mock.patch(
+            "application_sdk.execution._temporal.worker.logger"
+        ) as mock_logger:
+            await _log_worker_fatal_error(exc)
+
+        assert mock_logger.error.call_args.kwargs["exc_info"] is exc
 
 
 class TestReadCorePollerCounts:

--- a/tests/unit/execution/test_worker.py
+++ b/tests/unit/execution/test_worker.py
@@ -24,9 +24,12 @@ from application_sdk.execution._temporal._activity_errors import (
     WorkerInterceptorDuplicateError,
 )
 from application_sdk.execution._temporal.worker import (
+    _MAX_FATAL_CHAIN_DEPTH,
     AppWorker,
     _resolve_gate_enforcement,
     create_worker,
+    describe_exception_chain,
+    read_core_poller_counts,
 )
 
 DRAIN_DELAY_PATCH = (
@@ -1160,3 +1163,136 @@ class TestWorkflowFailureExceptionTypes:
         declared = self._declared_types()
         assert not issubclass(asyncio.CancelledError, declared)
         assert not issubclass(ActivityError, declared)
+
+
+class TestDescribeExceptionChain:
+    """Tests for ``describe_exception_chain`` (ARUN-1127 instrumentation)."""
+
+    def test_renders_the_real_shape_of_a_temporal_poll_fatal(self) -> None:
+        """The gRPC status only exists below the wrapper, so the chain must be walked.
+
+        This is the exact shape temporalio produces: the Rust bridge raises
+        ``RuntimeError("Poll failure: ... Status { code: PermissionDenied ... }")``
+        and ``temporalio.worker`` re-wraps it as ``RuntimeError("Activity worker
+        failed") from err``. ``str(exc)`` alone therefore carries no diagnosis at
+        all — which is why classifying on it cannot work.
+        """
+        bridge_error = RuntimeError(
+            "Poll failure: Unhandled grpc error when polling: "
+            'Status { code: PermissionDenied, message: "Request unauthorized." }'
+        )
+        try:
+            try:
+                raise bridge_error
+            except RuntimeError as err:
+                raise RuntimeError("Activity worker failed") from err
+        except RuntimeError as top:
+            chain = describe_exception_chain(top)
+
+        assert chain[0] == "RuntimeError: Activity worker failed"
+        assert "PermissionDenied" in chain[1]
+        assert "PermissionDenied" not in chain[0]
+
+    def test_follows_context_when_there_is_no_explicit_cause(self) -> None:
+        try:
+            try:
+                raise ValueError("inner")
+            except ValueError:
+                raise RuntimeError("outer")  # noqa: B904 — implicit chain is the point
+        except RuntimeError as top:
+            chain = describe_exception_chain(top)
+
+        assert chain == ["RuntimeError: outer", "ValueError: inner"]
+
+    def test_cycle_does_not_hang(self) -> None:
+        first = RuntimeError("first")
+        second = RuntimeError("second")
+        first.__cause__ = second
+        second.__cause__ = first
+
+        chain = describe_exception_chain(first)
+
+        assert chain == ["RuntimeError: first", "RuntimeError: second"]
+
+    def test_depth_is_capped(self) -> None:
+        head = RuntimeError("link-0")
+        current = head
+        for index in range(1, 30):
+            nxt = RuntimeError(f"link-{index}")
+            current.__cause__ = nxt
+            current = nxt
+
+        chain = describe_exception_chain(head)
+
+        assert len(chain) == _MAX_FATAL_CHAIN_DEPTH + 1
+        assert chain[-1] == "... chain truncated"
+
+
+class TestReadCorePollerCounts:
+    """Tests for ``read_core_poller_counts`` (the in-process poll-liveness read)."""
+
+    _EXPOSITION = (
+        "# HELP temporal_num_pollers Current number of pollers\n"
+        "# TYPE temporal_num_pollers gauge\n"
+        'temporal_num_pollers{poller_type="workflow_task",task_queue="q"} 2.0\n'
+        'temporal_num_pollers{poller_type="activity_task",task_queue="q"} 3.0\n'
+        "# HELP temporal_request_total Requests\n"
+        "# TYPE temporal_request_total counter\n"
+        'temporal_request_total{operation="PollActivityTaskQueue"} 41.0\n'
+    )
+
+    def _response(self, status_code: int = 200, text: str | None = None) -> mock.Mock:
+        response = mock.Mock()
+        response.status_code = status_code
+        response.text = self._EXPOSITION if text is None else text
+        return response
+
+    def _patch_client(self, response: mock.Mock) -> mock.patch:
+        client = mock.AsyncMock()
+        client.get = mock.AsyncMock(return_value=response)
+        client.__aenter__ = mock.AsyncMock(return_value=client)
+        client.__aexit__ = mock.AsyncMock(return_value=False)
+        return mock.patch("httpx.AsyncClient", return_value=client)
+
+    @pytest.mark.asyncio
+    async def test_sums_the_gauge_by_poller_type(self) -> None:
+        with self._patch_client(self._response()):
+            counts = await read_core_poller_counts()
+
+        assert counts == {"workflow_task": 2.0, "activity_task": 3.0}
+
+    @pytest.mark.asyncio
+    async def test_zero_pollers_reads_as_zero_not_unknown(self) -> None:
+        """A dead poll loop must be distinguishable from an unreadable endpoint."""
+        exposition = (
+            "# TYPE temporal_num_pollers gauge\n"
+            'temporal_num_pollers{poller_type="workflow_task"} 0.0\n'
+        )
+        with self._patch_client(self._response(text=exposition)):
+            counts = await read_core_poller_counts()
+
+        assert counts == {"workflow_task": 0.0}
+
+    @pytest.mark.asyncio
+    async def test_unreachable_endpoint_is_unknown_not_zero(self) -> None:
+        client = mock.AsyncMock()
+        client.get = mock.AsyncMock(side_effect=OSError("connection refused"))
+        client.__aenter__ = mock.AsyncMock(return_value=client)
+        client.__aexit__ = mock.AsyncMock(return_value=False)
+
+        with mock.patch("httpx.AsyncClient", return_value=client):
+            assert await read_core_poller_counts() is None
+
+    @pytest.mark.asyncio
+    async def test_non_200_is_unknown(self) -> None:
+        with self._patch_client(self._response(status_code=503)):
+            assert await read_core_poller_counts() is None
+
+    @pytest.mark.asyncio
+    async def test_absent_gauge_family_is_unknown(self) -> None:
+        """Core registers the gauge only once polling starts; absent != zero."""
+        exposition = (
+            "# TYPE temporal_request_total counter\ntemporal_request_total 1.0\n"
+        )
+        with self._patch_client(self._response(text=exposition)):
+            assert await read_core_poller_counts() is None

--- a/tests/unit/server/test_health.py
+++ b/tests/unit/server/test_health.py
@@ -84,6 +84,16 @@ class TestCheckLive:
         assert status.details["last_activity"] == stale.isoformat()
         assert status.details["max_idle_seconds"] == 30
         assert status.message == "No worker activity within liveness window"
+        # The 503 is the probe an operator reaches for first, so it must carry
+        # the same poll-loop evidence the healthy branch serves.
+        for key in (
+            "poller_counts",
+            "poller_counts_read_at",
+            "last_fatal_at",
+            "last_fatal_type",
+            "fatal_count",
+        ):
+            assert key in status.details
 
     @pytest.mark.asyncio
     async def test_idle_window_healthy_at_exact_boundary(self):

--- a/tests/unit/server/test_health.py
+++ b/tests/unit/server/test_health.py
@@ -7,6 +7,7 @@ tests/integration/server/test_health.py.
 """
 
 import math
+from dataclasses import dataclass
 from datetime import timedelta
 from unittest.mock import patch
 
@@ -131,3 +132,73 @@ class TestCheckLive:
         assert server._max_idle_seconds is None
         server._last_activity = _utc_now() - timedelta(hours=1)
         assert (await server.check_live()).healthy is True
+
+
+@dataclass(frozen=True)
+class _StubTemporalClient:
+    """Satisfies ``TemporalClientProtocol`` for readiness checks."""
+
+    identity: str
+
+
+class TestPollDiagnostics:
+    """Poll-loop diagnostics are observational only (ARUN-1127).
+
+    The mechanism behind a parked poll loop is not established yet, so none of
+    these fields may flip a probe — a probe acting on a guess kills healthy
+    workers.
+    """
+
+    @pytest.mark.asyncio
+    async def test_fatal_and_poller_counts_surface_in_live_details(self):
+        server = WorkerHealthServer(host="127.0.0.1", port=0)
+        server.record_worker_fatal(RuntimeError("Activity worker failed"))
+        server.record_poller_counts({"workflow_task": 0.0})
+
+        status = await server.check_live()
+
+        assert status.details["last_fatal_type"] == "RuntimeError"
+        assert status.details["fatal_count"] == 1
+        assert status.details["poller_counts"] == {"workflow_task": 0.0}
+        assert status.details["poller_counts_read_at"] is not None
+
+    @pytest.mark.asyncio
+    async def test_fatal_message_is_not_exposed_over_http(self):
+        """Only the exception type is retained; the chain goes to the logs.
+
+        The probe payload is served over HTTP and a gRPC status repr can carry
+        response metadata, so the message must not land in it.
+        """
+        server = WorkerHealthServer(host="127.0.0.1", port=0)
+        server.record_worker_fatal(RuntimeError("Poll failure: token abcdef123"))
+
+        details = (await server.check_live()).details
+
+        assert "abcdef123" not in str(details)
+
+    @pytest.mark.asyncio
+    async def test_zero_pollers_does_not_flip_live_unhealthy(self):
+        server = WorkerHealthServer(host="127.0.0.1", port=0)
+        server.record_poller_counts({"workflow_task": 0.0, "activity_task": 0.0})
+        server.record_worker_fatal(RuntimeError("Workflow worker failed"))
+
+        assert (await server.check_live()).healthy is True
+
+    @pytest.mark.asyncio
+    async def test_unknown_reading_stays_none_not_zero(self):
+        """An unreadable gauge is recorded as unknown, never as a zero count."""
+        server = WorkerHealthServer(host="127.0.0.1", port=0)
+        server.record_poller_counts(None)
+
+        assert (await server.check_live()).details["poller_counts"] is None
+
+    @pytest.mark.asyncio
+    async def test_ready_details_carry_the_same_diagnostics(self):
+        server = WorkerHealthServer(host="127.0.0.1", port=0)
+        server.set_temporal_client(_StubTemporalClient(identity="1@host"))
+        server.record_poller_counts({"activity_task": 4.0})
+
+        details = (await server.check_ready()).details
+
+        assert details["identity"] == "1@host"
+        assert details["poller_counts"] == {"activity_task": 4.0}

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -2621,6 +2621,43 @@ class TestObserveWorkerPollState:
         assert {"workflow_task": 0.0, "activity_task": 0.0} in health.readings
         assert mock_logger.warning.called
 
+    async def test_zero_pollers_warns_once_per_park_not_per_tick(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A sustained zero state warns on the transition, not every interval.
+
+        A parked worker emitting one WARNING per interval would bury the very
+        ``poll loop failed fatally`` line this instrumentation exists to surface,
+        so the zero branch is transition-gated like the unknown branch.
+        """
+        monkeypatch.setattr(
+            "application_sdk.execution._temporal.worker.read_core_poller_counts",
+            AsyncMock(return_value={"workflow_task": 0.0, "activity_task": 0.0}),
+        )
+        health = _RecordingHealthServer()
+        shutdown = asyncio.Event()
+
+        async def stop_soon() -> None:
+            await asyncio.sleep(0.09)  # several 0.01s ticks, one continuous park
+            shutdown.set()
+
+        stopper = asyncio.create_task(stop_soon())
+        with patch("application_sdk.main.logger") as mock_logger:
+            await asyncio.wait_for(
+                _observe_worker_poll_state(
+                    shutdown_event=shutdown, health_server=health, interval=0.01
+                ),
+                timeout=2.0,
+            )
+        await stopper
+
+        zero_warnings = [
+            call
+            for call in mock_logger.warning.call_args_list
+            if "0 active pollers" in str(call)
+        ]
+        assert len(zero_warnings) == 1
+
     async def test_unknown_reading_is_not_reported_as_zero(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -2630,19 +2630,28 @@ class TestObserveWorkerPollState:
         ``poll loop failed fatally`` line this instrumentation exists to surface,
         so the zero branch is transition-gated like the unknown branch.
         """
-        reader = AsyncMock(return_value={"workflow_task": 0.0, "activity_task": 0.0})
+        health = _RecordingHealthServer()
+        shutdown = asyncio.Event()
+        zero = {"workflow_task": 0.0, "activity_task": 0.0}
+
+        # Event-driven, not wall-clock: the mocked reader itself sets shutdown
+        # once it has been awaited twice, so the sustained park spans multiple
+        # ticks by construction and the test cannot race a slow CI runner.
+        calls = 0
+
+        async def _read_then_stop():
+            nonlocal calls
+            calls += 1
+            if calls >= 2:
+                shutdown.set()
+            return zero
+
+        reader = AsyncMock(side_effect=_read_then_stop)
         monkeypatch.setattr(
             "application_sdk.execution._temporal.worker.read_core_poller_counts",
             reader,
         )
-        health = _RecordingHealthServer()
-        shutdown = asyncio.Event()
 
-        async def stop_soon() -> None:
-            await asyncio.sleep(0.09)  # several 0.01s ticks, one continuous park
-            shutdown.set()
-
-        stopper = asyncio.create_task(stop_soon())
         with patch("application_sdk.main.logger") as mock_logger:
             await asyncio.wait_for(
                 _observe_worker_poll_state(
@@ -2650,11 +2659,10 @@ class TestObserveWorkerPollState:
                 ),
                 timeout=2.0,
             )
-        await stopper
 
-        # Prove multiple ticks actually ran during the sustained park — otherwise
-        # a single tick before shutdown would also satisfy the count assertion and
-        # leave the transition-gating unproven.
+        # Multiple ticks ran during the sustained park (the reader drove shutdown
+        # only after its second call), so a single tick could not have produced
+        # the count below — the transition-gating is genuinely exercised.
         assert reader.await_count >= 2
         zero_warnings = [
             call

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -23,6 +23,7 @@ from application_sdk.main import (
     _log_dapr_components,
     _log_process_memory_baseline,
     _loop_exception_handler,
+    _observe_worker_poll_state,
     _parse_all_component_yamls,
     _parse_workflow_max_timeout_hours,
     _run_worker_with_restart,
@@ -2558,3 +2559,151 @@ class TestRunWorkerWithRestart:
         await _run_worker_with_restart(build_worker=build, shutdown_event=shutdown)
 
         assert calls["n"] == 5
+
+
+class _RecordingHealthServer:
+    """Records the poll-state readings the observer reports."""
+
+    def __init__(self) -> None:
+        self.readings: list[dict[str, float] | None] = []
+
+    def record_poller_counts(self, counts: dict[str, float] | None) -> None:
+        self.readings.append(counts)
+
+
+class TestObserveWorkerPollState:
+    """Tests for the poll-state observer (ARUN-1127 instrumentation).
+
+    The observer exists to identify the failure mechanism on a live tenant, so
+    the contract under test is that it *reports* and never *acts*: no raise, no
+    restart, and ``None`` (unreadable) is never collapsed into zero.
+    """
+
+    async def test_disabled_interval_returns_immediately(self) -> None:
+        """A non-positive interval disables the observer entirely."""
+        health = _RecordingHealthServer()
+        shutdown = asyncio.Event()
+
+        await asyncio.wait_for(
+            _observe_worker_poll_state(
+                shutdown_event=shutdown, health_server=health, interval=0
+            ),
+            timeout=1.0,
+        )
+
+        assert health.readings == []
+
+    async def test_zero_pollers_warns_and_never_raises(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A zero reading is the zombie signature: warn, record, never raise."""
+        monkeypatch.setattr(
+            "application_sdk.execution._temporal.worker.read_core_poller_counts",
+            AsyncMock(return_value={"workflow_task": 0.0, "activity_task": 0.0}),
+        )
+        health = _RecordingHealthServer()
+        shutdown = asyncio.Event()
+
+        async def stop_soon() -> None:
+            await asyncio.sleep(0.05)
+            shutdown.set()
+
+        stopper = asyncio.create_task(stop_soon())
+        with patch("application_sdk.main.logger") as mock_logger:
+            await asyncio.wait_for(
+                _observe_worker_poll_state(
+                    shutdown_event=shutdown, health_server=health, interval=0.01
+                ),
+                timeout=2.0,
+            )
+        await stopper
+
+        assert {"workflow_task": 0.0, "activity_task": 0.0} in health.readings
+        assert mock_logger.warning.called
+
+    async def test_unknown_reading_is_not_reported_as_zero(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An unreadable gauge records None (unknown), never a zero count."""
+        monkeypatch.setattr(
+            "application_sdk.execution._temporal.worker.read_core_poller_counts",
+            AsyncMock(return_value=None),
+        )
+        health = _RecordingHealthServer()
+        shutdown = asyncio.Event()
+
+        async def stop_soon() -> None:
+            await asyncio.sleep(0.05)
+            shutdown.set()
+
+        stopper = asyncio.create_task(stop_soon())
+        await asyncio.wait_for(
+            _observe_worker_poll_state(
+                shutdown_event=shutdown, health_server=health, interval=0.01
+            ),
+            timeout=2.0,
+        )
+        await stopper
+
+        assert health.readings
+        assert all(reading is None for reading in health.readings)
+
+    async def test_read_failure_does_not_stop_the_observer(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A raising reader is swallowed — an observer never takes the worker down."""
+        monkeypatch.setattr(
+            "application_sdk.execution._temporal.worker.read_core_poller_counts",
+            AsyncMock(side_effect=RuntimeError("boom")),
+        )
+        shutdown = asyncio.Event()
+
+        async def stop_soon() -> None:
+            await asyncio.sleep(0.05)
+            shutdown.set()
+
+        stopper = asyncio.create_task(stop_soon())
+        # Must return cleanly on shutdown despite every read raising.
+        await asyncio.wait_for(
+            _observe_worker_poll_state(
+                shutdown_event=shutdown, health_server=None, interval=0.01
+            ),
+            timeout=2.0,
+        )
+        await stopper
+
+    async def test_supervisor_starts_and_stops_the_observer(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The supervisor owns the observer's lifetime, across worker rebuilds."""
+        monkeypatch.setattr(
+            "application_sdk.main._WORKER_POLL_DIAGNOSTIC_INTERVAL_SECONDS", 0.01
+        )
+        reader = AsyncMock(return_value={"workflow_task": 2.0})
+        monkeypatch.setattr(
+            "application_sdk.execution._temporal.worker.read_core_poller_counts",
+            reader,
+        )
+        health = _RecordingHealthServer()
+        shutdown = asyncio.Event()
+
+        def _stop_later() -> None:
+            asyncio.get_running_loop().call_later(0.05, shutdown.set)
+
+        def build() -> _FakeWorker:
+            return _FakeWorker(fail=False, on_enter=_stop_later)
+
+        await asyncio.wait_for(
+            _run_worker_with_restart(
+                build_worker=build,
+                shutdown_event=shutdown,
+                health_server=health,
+            ),
+            timeout=3.0,
+        )
+
+        assert health.readings, "observer never ran alongside the worker"
+        # Stopped with the supervisor: no reading lands after it returned.
+        readings_at_return = len(health.readings)
+        await asyncio.sleep(0.05)
+        assert len(health.readings) == readings_at_return

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -2630,9 +2630,10 @@ class TestObserveWorkerPollState:
         ``poll loop failed fatally`` line this instrumentation exists to surface,
         so the zero branch is transition-gated like the unknown branch.
         """
+        reader = AsyncMock(return_value={"workflow_task": 0.0, "activity_task": 0.0})
         monkeypatch.setattr(
             "application_sdk.execution._temporal.worker.read_core_poller_counts",
-            AsyncMock(return_value={"workflow_task": 0.0, "activity_task": 0.0}),
+            reader,
         )
         health = _RecordingHealthServer()
         shutdown = asyncio.Event()
@@ -2651,6 +2652,10 @@ class TestObserveWorkerPollState:
             )
         await stopper
 
+        # Prove multiple ticks actually ran during the sustained park — otherwise
+        # a single tick before shutdown would also satisfy the count assertion and
+        # leave the transition-gating unproven.
+        assert reader.await_count >= 2
         zero_warnings = [
             call
             for call in mock_logger.warning.call_args_list


### PR DESCRIPTION
## Problem (ARUN-1127)

A worker can be alive, healthy on every probe, refreshing its Temporal token — and have **zero pollers** on its task queue, doing no work until a human restarts the pod. Every run stalls with only `WORKFLOW_TASK_SCHEDULED`, `/live` and `/ready` return 200, and the pod shows 0 restarts.

**We do not yet know why.** Two mechanisms produce exactly that shape, and they need opposite remedies:

1. **A fatal that was raised and then swallowed.** `Worker.__aenter__` runs `run()` in a side task and cancels the body task on a fatal; `Worker.__aexit__` re-raises the captured fatal **only** `if exc_type is asyncio.CancelledError` (`temporalio/worker/_worker.py:874`). A fatal that races a shutdown is therefore dropped silently. Closing this needs nothing more than awaiting the worker's own run task.
2. **A poll loop that stopped without ever raising.** No exception exists at all, so nothing in-process can be made to observe it after the fact. Closing this needs an out-of-band liveness signal.

The failure is rare, tenant-specific, and does not reproduce locally, so it has never been observed closely enough to tell them apart.

## What this PR does

Ships the evidence to identify the mechanism on a live tenant, and **deliberately acts on none of it** — no restart, no probe flip, no new failure path. A remedy built on the wrong mechanism either tears down healthy workers or hides the outage behind a self-healing loop that cannot heal it.

### 1. `on_fatal_error` hook — does a fatal exist at all?

Temporal invokes `on_fatal_error` the instant a poll task raises (`_worker.py:758`), **before** the `async with` teardown can swallow anything. It is the one place a poll fatal is guaranteed to be seen, so it is now always wired in `create_worker`.

It logs the **full cause chain**, which matters more than it looks. `str(exc)` carries no diagnosis whatsoever:

- `bridge/src/worker.rs:589` — `PyRuntimeError::new_err(format!("Poll failure: {err}"))`
- `crates/common/src/errors.rs:27` — `#[error("Unhandled grpc error when polling: {0:?}")] TonicError(#[from] tonic::Status)`
- `worker/_activity.py:170` — `raise RuntimeError("Activity worker failed") from err`

So `str(exc)` is literally `"Activity worker failed"`; the gRPC status name only exists further down the chain. `describe_exception_chain` walks it (cycle-protected, depth-capped) so the status reaches the logs.

**The hook's absence is itself the signal.** Zero pollers plus no `poll loop failed fatally` line means nothing ever raised — mechanism 2. Zero pollers plus the line means mechanism 1.

### 2. `read_core_poller_counts` — is this worker polling?

sdk-core already maintains a `num_pollers` **gauge**, labelled by poller type, on its local Prometheus endpoint (`crates/sdk-core/src/telemetry/metrics.rs:61,286,482`). That is the direct answer to "is this worker polling?", and it beats asking the frontend via `DescribeTaskQueue`:

- no network call, so it cannot go blind during the very auth outage that kills the poll loop
- no task-queue read permission needed
- no root-partition ambiguity (`DescribeTaskQueue` in default mode reads one partition and does not aggregate)
- per-poller-type, not a boolean

An unreadable endpoint reads as **unknown**, never as zero — a distinction the tests pin.

### 3. `_observe_worker_poll_state` — record, never act

Reads the gauge on an interval for the whole supervised lifetime, across worker rebuilds, so a *rebuilt* worker that comes back without pollers is still observed. Logs transitions rather than every tick, so a long-running worker stays quiet until something changes; zero or unknown is a WARNING. It never raises, never restarts the worker, and is not raced against it.

`WorkerHealthServer` records both signals so they are also reachable over `/live` and `/ready`. Only the fatal's **type** is retained, never its message — the probe payload is served over HTTP and a gRPC status repr can carry response metadata.

### 4. One unconditional fix

Clamps the restart backoff exponent (`2 ** min(n - 1, 16)`). Correct under either mechanism: the cap already bounds the delay, but a raised `ATLAN_WORKER_MAX_CONSECUTIVE_RESTARTS` would compute an arbitrarily large power of two only to discard it.

## New env

| Variable | Default | Notes |
|---|---|---|
| `ATLAN_WORKER_POLL_DIAGNOSTIC_INTERVAL_SECONDS` | `60` | `0` disables the observer entirely |

Reading the gauge needs core's Prometheus exporter (`ATLAN_TEMPORAL_PROMETHEUS_BIND_ADDRESS`, default `127.0.0.1:9464`).

## How to get the answer

1. Merge and release — nothing here changes worker behaviour, so it can ship on the normal cadence.
2. The trigger is reproducible platform-side: ARUN-1128 is a JWKS signing-key cache skew with `refreshInterval: 1m0s` and no refresh-on-miss, so rotating the frontend signing key on a test tenant induces the window deliberately rather than waiting for a recurrence.
3. Read the logs for a `poll loop failed fatally` line alongside the poller gauge. That pair identifies the mechanism, and the remedy follows from it.

**One thing to confirm while this is in review:** do these logs and metrics actually egress from an SDR deployment on customer infrastructure, or does `enable_pushgateway=False` in combined mode leave them on a local `/metrics` nobody scrapes? If they don't reach our observability stack, that gap is the real root cause of this incident class, not the poll loop.

## Relationship to #3257

#3257 builds a `DescribeTaskQueue` watchdog and reverses the supervisor's fail-loud cap, both on the assumption that mechanism 2 is the cause. Its diagnosis may well be right, but three review rounds have gone into progressively refining a classifier that matches on the text of an error nobody has captured from a live occurrence — which is the cost of fixing before measuring. Proposing #3257 goes to draft until this instrumentation answers the question, then it either lands largely as-is (mechanism 2) or reduces to a few lines (mechanism 1).

## Testing

- 7178 unit tests pass (`uv run pytest tests/unit`).
- New: `TestDescribeExceptionChain` (renders the real two-wrapper poll-fatal shape; context fallback; cycle; depth cap), `TestReadCorePollerCounts` (sums by poller type; zero reads as zero; unreachable / non-200 / absent family all read as unknown), `TestObserveWorkerPollState` (disabled interval; zero warns and never raises; unknown is not collapsed to zero; a raising reader doesn't stop the observer; the supervisor starts and stops it), `TestPollDiagnostics` (both signals surface in `/live` and `/ready`; the fatal message is not exposed over HTTP; zero pollers does not flip `/live`).
- `uv run pre-commit run` clean (ruff, ruff-format, isort, pyright).
- Conformance gate passes: 0 failing.
