### PR TITLE
fix(observability): gate loguru diagnose behind ATLAN_LOG_DIAGNOSE, default off

### DIFF
--- a/application_sdk/constants.py
+++ b/application_sdk/constants.py
@@ -616,6 +616,17 @@ OTEL_EXPORTER_OTLP_ENDPOINT: str = os.getenv(
 )
 #: Whether to enable OpenTelemetry log export
 ENABLE_OTLP_LOGS: bool = os.getenv("ENABLE_OTLP_LOGS", "false").lower() == "true"
+#: Whether console tracebacks annotate each frame with the *values* of the names
+#: on its source line (loguru's ``diagnose``). Default is False, unlike loguru's
+#: own default of True: those values reach the console verbatim, so a local
+#: holding a token or a credential dict renders its contents onto a live
+#: worker's stderr. Frames themselves are always kept — ``backtrace`` is
+#: untouched — so only the value annotation is gated.
+#:
+#: Deliberately its own variable rather than a function of ``LOG_LEVEL``: raising
+#: a tenant's log verbosity to DEBUG must not silently re-enable value rendering.
+#: Set to True for local debugging, where the annotation is genuinely useful.
+ENABLE_LOG_DIAGNOSE: bool = os.getenv("ATLAN_LOG_DIAGNOSE", "false").lower() == "true"
 #: Whether to emit SDK logger output during Temporal workflow replay.
 #: Default is False, matching Temporal's native ``workflow.logger`` behaviour.
 #: Set to True to re-enable replay logs for debugging (e.g. when using the

--- a/application_sdk/observability/logger_adaptor.py
+++ b/application_sdk/observability/logger_adaptor.py
@@ -18,6 +18,7 @@ from opentelemetry.trace.span import TraceFlags
 from application_sdk.constants import (
     APPLICATION_NAME,
     DEPLOYMENT_NAME,
+    ENABLE_LOG_DIAGNOSE,
     ENABLE_OBSERVABILITY_STORE_SINK,
     ENABLE_OTLP_LOGS,
     ENABLE_OTLP_WORKFLOW_LOGS,
@@ -819,12 +820,28 @@ class AtlanLoggerAdapter(AtlanObservability[Any]):
         # descriptor classify benign records as INFO instead of ERROR. Records
         # at WARNING and below go to stdout; ERROR/CRITICAL/exception records
         # stay on stderr. Matches uvicorn/gunicorn conventions.
+        # `diagnose` is passed explicitly because loguru defaults it to True: it
+        # annotates each traceback frame with the *values* of the names on its source
+        # line, so a credential dict passed to a failing call renders its contents
+        # onto the console. ENABLE_LOG_DIAGNOSE defaults to False, and gates only the
+        # annotation — `backtrace` is untouched, so every frame, including those
+        # beyond the catch point, is kept either way.
+        #
+        # Volume was the symptom that surfaced this: value annotation accounted for
+        # 48% of the bytes in a CI unit-test job's 16 MB log, nearly all of it from
+        # tests that exercise an error path, log the expected exception, and pass.
+        #
+        # The OTLP and object-store sink takes no such flag: it reads structured
+        # fields off the record and builds its own traceback via
+        # `_format_exception_stacktrace`, which never carried local values. So this
+        # changes console output only; nothing queryable downstream moves.
         _ERROR_LEVEL_NO = SEVERITY_MAPPING["ERROR"]
         self.logger.add(
             sys.stdout,
             format=get_log_format,
             level=SEVERITY_MAPPING[LOG_LEVEL],
             colorize=colorize,
+            diagnose=ENABLE_LOG_DIAGNOSE,
             filter=lambda record: record["level"].no < _ERROR_LEVEL_NO,
         )
         self.logger.add(
@@ -832,6 +849,7 @@ class AtlanLoggerAdapter(AtlanObservability[Any]):
             format=get_log_format,
             level=max(SEVERITY_MAPPING[LOG_LEVEL], _ERROR_LEVEL_NO),
             colorize=colorize,
+            diagnose=ENABLE_LOG_DIAGNOSE,
         )
 
         # OTLP log export — primary exporter to OTEL_EXPORTER_OTLP_ENDPOINT,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -216,6 +216,7 @@ Used by `RedisCapacityPool` for distributed slot locking. Leave empty if you use
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `ATLAN_LOG_LEVEL` | `INFO` | Log level (`DEBUG`, `INFO`, `WARNING`, `ERROR`). **Fallback:** `LOG_LEVEL`. `CRITICAL` is accepted by loguru but prohibited in app code per [ADR-0011](adr/0011-logging-level-guidelines.md). |
+| `ATLAN_LOG_DIAGNOSE` | `false` | Annotate console tracebacks with the **values** of the names on each frame's source line (loguru's `diagnose`). Off by default, unlike loguru's own default: those values print verbatim, so a credential dict passed to a failing call has its contents rendered onto stderr. Useful locally; leave off anywhere real credentials exist. Independent of `ATLAN_LOG_LEVEL` by design — raising verbosity to `DEBUG` does not re-enable it. Traceback frames are unaffected either way. |
 | `ATLAN_LOG_BATCH_SIZE` | `100` | Records buffered before flushing to the object-store sink. |
 | `ATLAN_LOG_FLUSH_INTERVAL_SECONDS` | `10` | Seconds between object-store sink flushes. |
 | `ATLAN_LOG_RETENTION_DAYS` | `30` | Days to retain log files in the object store before cleanup. |

--- a/tests/unit/observability/test_logger_adaptor.py
+++ b/tests/unit/observability/test_logger_adaptor.py
@@ -1,9 +1,12 @@
 import logging
+import os
+import subprocess
 import sys
 import warnings
 from collections.abc import Generator
 from contextlib import contextmanager
 from datetime import datetime
+from pathlib import Path
 from typing import Any
 from unittest import mock
 
@@ -3160,3 +3163,89 @@ class TestOtlpShutdownFlush:
         finally:
             adapter.logger_provider = None
             la._otlp_shutdown_done.clear()
+
+
+# loguru annotates each traceback frame with the values of the names on its source
+# line, so the canary has to be passed to the failing call to be rendered at all.
+_DIAGNOSE_PROBE = """
+import sys
+
+from application_sdk.observability.logger_adaptor import get_logger
+
+CANARY = "canary-local-value"
+
+
+def _explode(payload):
+    raise RuntimeError("deliberate")
+
+
+def _raise():
+    creds = {"client_secret": CANARY}
+    _explode(creds)
+
+
+logger = get_logger(__name__)
+try:
+    _raise()
+except RuntimeError:
+    logger.error("probe", exc_info=True)
+sys.stderr.flush()
+"""
+
+_DIAGNOSE_CANARY = "canary-local-value"
+
+
+class TestDiagnoseGating:
+    """loguru's ``diagnose`` renders the *values* of the names on each traceback
+    frame's source line, so a credential dict passed to a failing call has its
+    contents printed. It defaults to True in loguru; ``ENABLE_LOG_DIAGNOSE`` gates it
+    off unless explicitly asked for.
+
+    Driven through a subprocess because the adapter binds to the process's real
+    ``sys.stderr`` when it registers sinks, and because the flag is read from the
+    environment at import. The enabled case doubles as the control: it proves the
+    canary reaches a rendered frame and that loguru still annotates values, so the
+    disabled case cannot pass for the wrong reason.
+    """
+
+    def _run_probe(self, tmp_path: Path, env_overrides: dict[str, str]) -> str:
+        probe = tmp_path / "diagnose_probe.py"
+        probe.write_text(_DIAGNOSE_PROBE, encoding="utf-8")
+        env = {
+            **os.environ,
+            # Console sinks only: no exporter, no object store, no network.
+            "ENABLE_OTLP_LOGS": "false",
+            "ENABLE_OBSERVABILITY_STORE_SINK": "false",
+        }
+        env.pop("ATLAN_LOG_DIAGNOSE", None)
+        env.update(env_overrides)
+        result = subprocess.run(
+            [sys.executable, str(probe)],
+            capture_output=True,
+            text=True,
+            env=env,
+            cwd=str(Path(__file__).resolve().parents[3]),
+        )
+        assert "RuntimeError" in result.stderr, (
+            f"probe never logged the exception:\nstdout={result.stdout}\n"
+            f"stderr={result.stderr}"
+        )
+        return result.stderr
+
+    def test_local_values_are_not_rendered_by_default(self, tmp_path: Path) -> None:
+        stderr = self._run_probe(tmp_path, {})
+        assert _DIAGNOSE_CANARY not in stderr
+        # Frames must survive: ``backtrace`` is untouched, and a traceback without
+        # frames would be its own regression.
+        assert "_explode" in stderr
+
+    def test_local_values_are_rendered_when_explicitly_enabled(
+        self, tmp_path: Path
+    ) -> None:
+        stderr = self._run_probe(tmp_path, {"ATLAN_LOG_DIAGNOSE": "true"})
+        assert _DIAGNOSE_CANARY in stderr
+
+    def test_gate_is_not_derived_from_log_level(self, tmp_path: Path) -> None:
+        """Raising a tenant's verbosity to DEBUG must not re-enable value rendering."""
+        stderr = self._run_probe(tmp_path, {"ATLAN_LOG_LEVEL": "DEBUG"})
+        assert _DIAGNOSE_CANARY not in stderr

--- a/tests/unit/observability/test_logger_adaptor.py
+++ b/tests/unit/observability/test_logger_adaptor.py
@@ -3218,6 +3218,18 @@ class TestDiagnoseGating:
             "ENABLE_OBSERVABILITY_STORE_SINK": "false",
         }
         env.pop("ATLAN_LOG_DIAGNOSE", None)
+        # Pin the log level, or an ambient one decides whether the probe logs at all:
+        # the stderr sink sits at ``max(LOG_LEVEL, ERROR)``, so a shell or image
+        # carrying ``LOG_LEVEL=CRITICAL`` filters out the probe's ``logger.error`` and
+        # every assertion below fails for a reason unrelated to diagnose.
+        #
+        # Both names are popped before the default is applied, because a bare
+        # ``setdefault`` would not dislodge an ambient ``ATLAN_LOG_LEVEL=CRITICAL`` —
+        # the key is already present, so the default never lands. ``env_overrides`` is
+        # applied afterwards, so the log-level test still controls its own override.
+        env.pop("LOG_LEVEL", None)  # the fallback that ATLAN_LOG_LEVEL supersedes
+        env.pop("ATLAN_LOG_LEVEL", None)
+        env["ATLAN_LOG_LEVEL"] = "ERROR"
         env.update(env_overrides)
         result = subprocess.run(
             [sys.executable, str(probe)],


### PR DESCRIPTION
### Changelog

- **Gate loguru's `diagnose` behind `ATLAN_LOG_DIAGNOSE`, defaulting off.** loguru defaults it to `True`, and neither console sink overrode it, so every traceback annotated each frame with the **values** of the names on its source line — a credential dict passed to a failing call had its contents printed to a live worker's stderr.
- **Only the annotation is gated.** `backtrace` is untouched, so every frame, including those beyond the catch point, is kept either way. Set `ATLAN_LOG_DIAGNOSE=true` for local debugging, where the annotation is genuinely useful.
- **The flag is its own variable, not a function of `LOG_LEVEL`.** Raising a tenant's verbosity to `DEBUG` must not silently re-enable value rendering. A test pins that specifically.
- **Nothing queryable downstream moves.** The OTLP and object-store sink reads structured fields off the record and builds its traceback via `_format_exception_stacktrace`, which never carried local values. This changes console output only.
- Documented in `docs/configuration.md`; 3 tests added.

### Additional context (e.g. screenshots, logs, links)

- **Supersedes the approach in #3183** (draft, `bichitra/log-diagnose-redaction`). That PR uncovered this problem — a prior incident where a token payload was rendered by diagnose — and kept diagnose *on* behind a redaction wrapper that scrubs known secret shapes, failing closed to `diagnose=False` if the wrapper could not bind. The conclusion reached there was that diagnose should simply be off by default; this PR is that action. Two consequences for #3183: its redaction machinery is now only relevant to the explicit opt-in path, and it edits the same two `logger.add()` calls, so it will need a rebase on top of this.
- Redaction is a denylist — it can only scrub the secret shapes it recognises. Defaulting the annotation off is the allowlist-shaped default: nothing renders unless someone asks for it, whatever shape it takes.
- FND-440: https://linear.app/atlan-epd/issue/FND-440/disable-loguru-diagnose-on-the-stdoutstderr-sinks-renders-local
- **How this surfaced:** investigating an unrelated CI failure on #3267, where GitHub was truncating the unit-test log. Attribution of that job's 16.1 MB / 92,713 lines:

  | Shape | Size |
  |---|---|
  | diagnose value annotations | 7.7 MB / 43,972 lines — **48% of all bytes** |
  | traceback frame lines | 12,369 |
  | annotated traceback blocks | 11,192 |
  | those blocks' test outcome | **192 PASSED, 0 FAILED** |

  Almost all of it comes from tests that exercise an error path, log the expected exception, and pass. The failure summary that actually mattered was 8 lines. Re-running `tests/unit/infrastructure` under the CI invocation (`--capture=no --log-cli-level=INFO -v`) measures a **46% reduction** (237,888 → 123,051 bytes), matching the projection.
- **The tests can fail.** The enabled case doubles as the control: it proves the canary reaches a rendered frame and that loguru still annotates values, so the default-off assertions cannot pass for the wrong reason. Confirmed both default-off tests fail when diagnose is left on. They run the probe in a subprocess because the adapter binds to the process's real `sys.stderr` when it registers sinks, and because the flag is read from the environment at import.
- 7186 unit tests pass; pre-commit clean including pyright.

### Checklist

- [x] Additional tests added
- [ ] All CI checks passed
- [x] Relevant documentation updated

---

### Copyleft License Compliance

- [ ] Have you used any code that is subject to a Copyleft license (e.g., GPL, AGPL, LGPL)?
- [ ] If yes, have you modified the code in the context of this project? please share additional details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
