### PR TITLE
fix(storage): let the dual-write deployment leg express a same-store copy (FND-536)

### DIFF
--- a/application_sdk/app/base.py
+++ b/application_sdk/app/base.py
@@ -1288,10 +1288,18 @@ class App(ABC):
         result: UploadOutput | None = None
         deferred_required_error: Exception | None = None
         for target_store, label, fatal in targets:
-            # When writing to the deployment store, it is already the source for the
-            # cross-store fallback — passing it as _source_store would add a redundant
-            # SHA-256 sidecar lookup against itself. Skip it in that case.
-            source_store = None if target_store is deployment else self.context.storage
+            # FND-536: every leg — including the deployment leg — gets the
+            # deployment store as its fallback source. Withholding it there made
+            # a deployment→deployment copy inexpressible: with ``local_path``
+            # absent (cross-pod / ref-only, the shape the P042 bridges use)
+            # ``transfer.upload`` could not take its deployment-store fallback
+            # branch and raised "local_path does not exist", which is a spurious
+            # WARNING under ``best_effort`` and fails the run under ``required``.
+            # Passing it costs nothing on the local-present paths: the directory
+            # reconcile is gated on a *distinct* source store, the single-file
+            # path never reads it, and ``_upload_from_store`` short-circuits a
+            # same-store copy of an identical key without any sidecar GET.
+            source_store = self.context.storage
             try:
                 out = await _upload(
                     input.local_path,

--- a/application_sdk/storage/transfer.py
+++ b/application_sdk/storage/transfer.py
@@ -133,6 +133,8 @@ async def _upload_from_store(
     source_key: str,
     target_store: ObjectStore,
     target_key: str,
+    *,
+    source_listed: bool = False,
 ) -> tuple[bool, str]:
     """Upload a single file from *source_store* to *target_store*.
 
@@ -150,18 +152,36 @@ async def _upload_from_store(
       the source's sidecar, the upload against what the target reports back,
       and ``upload_file`` writes the target's own sidecar (FND-306).
 
+    Args:
+        source_store: Store to read *source_key* from.
+        source_key: Key to copy.
+        target_store: Store to write *target_key* to.
+        target_key: Destination key.
+        source_listed: ``True`` when the caller obtained *source_key* by listing
+            *source_store*, which proves the object is there.  Lets the
+            same-object guard skip its existence HEAD; leave ``False`` whenever
+            the key came from a caller-supplied ``FileReference``.
+
     Returns ``(transferred, reason)``.
     """
     from application_sdk.storage.ops import (  # noqa: PLC0415 — circular: storage/__init__.py loads sibling modules
         download_file_chunked,
+        exists,
         upload_file,
     )
 
     if source_store is target_store and source_key == target_key:
         # Copying an object onto itself: no bytes to move and no sidecar to
-        # compare. Still progress for the heartbeat — one key resolved.
-        current_progress_tracker().mark_progress("storage.copy_file")
-        return False, "skipped:same_object"
+        # compare. But "satisfied" must mean the object is actually there — a
+        # stale FileReference pinned to a key that was never written would
+        # otherwise buy a durable-looking success out of nothing. When the key
+        # came from a listing that is already proven; otherwise one HEAD settles
+        # it, and an absent object falls through to the copy path below, which
+        # fails with the same not-found error any other leg would raise.
+        if source_listed or await exists(source_key, source_store, normalize=False):
+            # Still progress for the heartbeat — one key resolved.
+            current_progress_tracker().mark_progress("storage.copy_file")
+            return False, "skipped:same_object"
 
     if await _cross_store_sha256_match(
         source_store, source_key, target_store, target_key
@@ -668,7 +688,11 @@ async def upload(
                 )
             async with sem:
                 ok, _ = await _upload_from_store(
-                    source_resolved, source_key, resolved, target_key
+                    source_resolved,
+                    source_key,
+                    resolved,
+                    target_key,
+                    source_listed=True,  # came from _list_source_data_keys
                 )
                 return ok
 
@@ -733,6 +757,7 @@ async def upload(
                         source_key,
                         resolved,
                         f"{fallback_prefix}/{rel}" if fallback_prefix else rel,
+                        source_listed=True,  # came from _list_source_data_keys
                     )
                     return ok
 

--- a/application_sdk/storage/transfer.py
+++ b/application_sdk/storage/transfer.py
@@ -142,9 +142,14 @@ async def _upload_from_store(
 
     * Step 0 — same-object guard: when *source_store* and *target_store* are the
       same store and the keys are identical, the object already is its own
-      destination.  Returns immediately, without even the two sidecar GETs the
-      SHA-256 dedup would cost.  This is the key-preserving
-      deployment→deployment leg of the ADR-0014 dual write (FND-536).
+      destination — **provided it is there**.  Presence is taken from
+      *source_listed*, or established with one HEAD when the key came from a
+      caller-supplied ``FileReference``; only then does this return immediately,
+      without even the two sidecar GETs the SHA-256 dedup would cost.  An absent
+      object falls through to the copy path below and raises
+      ``StorageNotFoundError`` like any other leg would.  This is the
+      key-preserving deployment→deployment leg of the ADR-0014 dual write
+      (FND-536).
     * Step 1 — cross-store SHA-256 dedup: skips the transfer when both stores
       already hold the same content at their respective keys.
     * Step 3 — deployment-store fallback: downloads to a temporary local file

--- a/application_sdk/storage/transfer.py
+++ b/application_sdk/storage/transfer.py
@@ -138,6 +138,11 @@ async def _upload_from_store(
 
     Implements steps 1 and 3 of the three-step upload strategy:
 
+    * Step 0 — same-object guard: when *source_store* and *target_store* are the
+      same store and the keys are identical, the object already is its own
+      destination.  Returns immediately, without even the two sidecar GETs the
+      SHA-256 dedup would cost.  This is the key-preserving
+      deployment→deployment leg of the ADR-0014 dual write (FND-536).
     * Step 1 — cross-store SHA-256 dedup: skips the transfer when both stores
       already hold the same content at their respective keys.
     * Step 3 — deployment-store fallback: downloads to a temporary local file
@@ -151,6 +156,12 @@ async def _upload_from_store(
         download_file_chunked,
         upload_file,
     )
+
+    if source_store is target_store and source_key == target_key:
+        # Copying an object onto itself: no bytes to move and no sidecar to
+        # compare. Still progress for the heartbeat — one key resolved.
+        current_progress_tracker().mark_progress("storage.copy_file")
+        return False, "skipped:same_object"
 
     if await _cross_store_sha256_match(
         source_store, source_key, target_store, target_key

--- a/docs/adr/0014-two-store-storage-architecture.md
+++ b/docs/adr/0014-two-store-storage-architecture.md
@@ -133,7 +133,11 @@ prefix to the destination key. Two shapes follow:
   hand-rolled `upload_to_atlan` bridges do): source and target key are the same
   object, so `_upload_from_store` returns immediately with
   `reason="skipped:same_object"` — no bytes, and not even the two sidecar GETs
-  the cross-store SHA-256 dedup would cost;
+  the cross-store SHA-256 dedup would cost. "Already satisfied" is conditional on
+  the object being there: keys that came from a listing of the source store are
+  proven present, and a caller-supplied `ref` costs one HEAD, so a stale `ref`
+  pinned to a key that was never written still fails with
+  `StorageNotFoundError` rather than buying a durable-looking success;
 - **destination not pinned**: a real copy runs, which is what keeps the
   identical-key invariant above true for the ref-only case.
 

--- a/docs/adr/0014-two-store-storage-architecture.md
+++ b/docs/adr/0014-two-store-storage-architecture.md
@@ -119,6 +119,30 @@ The deployment-write failure is **never** allowed to suppress the upstream
 write — the upstream write (Atlan handoff) always runs even if the customer-bucket
 mirror failed, so a copy lands somewhere regardless.
 
+#### Ref-only uploads: the deployment leg copies within its own store (FND-536)
+
+When the artifacts are **already in the deployment store** and no local copy
+exists on the uploading pod — a cross-pod / KEDA-scaled hand-off, or a caller
+passing only `UploadInput.ref` — both legs take `transfer.upload`'s
+deployment-store fallback branch. Every leg is therefore handed
+`_source_store=self.context.storage`, including the deployment leg itself, so
+the deployment write is a copy *within* the deployment store from the ref's
+prefix to the destination key. Two shapes follow:
+
+- **destination pinned to the ref's own prefix** (key-preserving, as the
+  hand-rolled `upload_to_atlan` bridges do): source and target key are the same
+  object, so `_upload_from_store` returns immediately with
+  `reason="skipped:same_object"` — no bytes, and not even the two sidecar GETs
+  the cross-store SHA-256 dedup would cost;
+- **destination not pinned**: a real copy runs, which is what keeps the
+  identical-key invariant above true for the ref-only case.
+
+Withholding the source store from the deployment leg (pre-FND-536) made a
+deployment→deployment copy inexpressible: the leg fell through to `StorageError
+("local_path does not exist …")`, which is a spurious `WARNING` under
+`best_effort` and a **failed run** under `required`, even though the upstream
+leg had done its job.
+
 ### Connector responsibility
 
 Connectors that hand artifacts to Atlan system apps **must** call `App.upload()`

--- a/docs/concepts/apps.md
+++ b/docs/concepts/apps.md
@@ -251,6 +251,21 @@ Two cleanup tasks and two transfer tasks are available on every `App`:
 - `upload(UploadInput(...))` — pushes a local file or directory to object storage. Routes to the Atlan-owned `atlan-objectstore` (`infra.upstream_storage`) in SDR deployments; falls back to the customer-owned `objectstore` (`infra.storage`) in local dev. This is the explicit hand-off step that downstream Atlan system apps (publish, lineage, quality) consume. See [file-reference.md](file-reference.md) and [ADR-0014](../adr/0014-two-store-storage-architecture.md).
 - `download(DownloadInput(...))` — pulls a file or directory from object storage to a local path.
 
+**`upload()` does not require the files on the calling pod.** When `local_path`
+is absent — a cross-pod hand-off where the tasks that produced the tree ran on
+other workers, or a caller that only has a `FileReference` — pass
+`UploadInput(ref=...)` and the upload streams from the deployment store at
+`ref.storage_path` instead of the local filesystem. Pass `storage_path` too to
+pin the destination and the copy is key-preserving; leave it off and the
+artifacts land under the canonical run prefix for the tier. A key-preserving
+copy whose source and destination are the same object is recognised as already
+satisfied (`reason="skipped:same_object"`) rather than moving bytes — but a
+`ref` pointing at a key that was never written still fails loudly with
+`StorageNotFoundError`. A partially-present local directory gets both: the local
+files plus anything present only in the store. See
+[file-reference.md](file-reference.md) and
+[ADR-0014](../adr/0014-two-store-storage-architecture.md).
+
 Both transfer tasks validate the bytes they move. An upload confirms the local file did not shrink while it was read and that the store recorded what was sent, and records a `{key}.sha256` sidecar; a download confirms it wrote as many bytes as the store declared and, when a sidecar exists, that the content hashes to it. An artifact whose producer died mid-write therefore fails at the transfer boundary with a non-retryable `StorageIntegrityError` naming the file and both digests, rather than reaching a parser as an unattributable `Malformed JSON`. The checks live in the transfer primitives, so every path — these tasks, `FileReference` persist/materialize, prefix transfers, the writer chunk uploads — is covered by the same code. See [storage.md](storage.md#transfer-integrity).
 
 **Writer output is staged, then published at `close()`.** A `Writer` (parquet, JSON) never writes into its output directory directly — it writes into a private staging tree (a sibling directory, not inside the output) and publishes into the output directory in one step when `close()` returns. Files produced by that writer are therefore absent from the output directory until `close()` completes; a writer that is cancelled or fails before `close()` publishes nothing. This is what stops a cancelled attempt's orphaned writer from colliding with, or being adopted into, a retry's output. The published filenames and object-store keys are unchanged — only the timing of when files appear in the output directory moves to `close()`. Note that publishing only *adds*: content already sitting in a reused output directory is left in place, and a deferred writer's `FileReference` walks the whole directory, so it adopts that content too.

--- a/docs/concepts/apps.md
+++ b/docs/concepts/apps.md
@@ -261,8 +261,10 @@ artifacts land under the canonical run prefix for the tier. A key-preserving
 copy whose source and destination are the same object is recognised as already
 satisfied (`reason="skipped:same_object"`) rather than moving bytes — but a
 `ref` pointing at a key that was never written still fails loudly with
-`StorageNotFoundError`. A partially-present local directory gets both: the local
-files plus anything present only in the store. See
+`StorageNotFoundError`. A partially-present local directory gets both — the
+local files plus anything present only in the store — but only when the
+destination is a *different* store (an SDR hand-off to the upstream store);
+within a single store the local tree stays authoritative. See
 [file-reference.md](file-reference.md) and
 [ADR-0014](../adr/0014-two-store-storage-architecture.md).
 

--- a/docs/concepts/file-reference.md
+++ b/docs/concepts/file-reference.md
@@ -435,9 +435,13 @@ Two behaviours worth knowing:
   this shape. A `ref` pointing at a key that was never written is *not* silently
   treated as satisfied — it fails with `StorageNotFoundError`.
 
-A **partially**-present local directory gets both halves: the local files are
-uploaded and anything present only in the store is streamed, so the destination
-copy is complete regardless of which pod produced what.
+A **partially**-present local directory gets both halves **when the destination
+is a different store** — i.e. an SDR hand-off to the upstream store: the local
+files are uploaded and anything present only in the deployment store is
+streamed, so the destination copy is complete regardless of which pod produced
+what. Within a single store the local directory stays authoritative and
+store-only files are not merged in; there is no second store to reconcile
+against, so a partial local tree publishes as partial.
 
 Deriving the ref is automatic — passing `local_path` alone gives you the same
 fallback, since the SDK derives `ref` from it. Pass `ref` explicitly when the

--- a/docs/concepts/file-reference.md
+++ b/docs/concepts/file-reference.md
@@ -360,6 +360,7 @@ await self.upload(input: UploadInput) -> UploadOutput
 ```python
 class UploadInput(BaseModel):
     local_path: str = ""                       # path to the file or directory on disk
+    ref: FileReference | None = None           # upload from a store key instead of local disk
     tier: StorageTier = StorageTier.RETAINED   # where to store it
     storage_path: str | None = None            # override the full destination key
     storage_subdir: str | None = None          # append a subdir under the run prefix
@@ -369,7 +370,8 @@ class UploadInput(BaseModel):
 
 | Field | Required | Description |
 |---|---|---|
-| `local_path` | Yes | Path to the file or directory to upload. Defaults to `""` (must be set before calling `App.upload()`). |
+| `local_path` | One of `local_path` / `ref` | Path to the file or directory to upload. Defaults to `""`. |
+| `ref` | One of `local_path` / `ref` | Existing `FileReference` to upload **from**: its `storage_path` is the deployment-store source key used when `local_path` is absent on this pod. See [Uploading without a local copy](#uploading-without-a-local-copy). Symmetric with `DownloadInput.ref`. |
 | `tier` | No (default `RETAINED`) | Tier that controls the destination prefix and cleanup policy. |
 | `storage_path` | No | Fully-qualified destination key. Overrides the auto-generated path. Use this when you need an exact fixed path (e.g. `argo-artifacts/spec.json`). |
 | `storage_subdir` | No | Subdirectory appended under the run prefix. Useful for grouping related uploads without spelling out the full path. |
@@ -402,6 +404,48 @@ artifacts/apps/{app_name}/workflows/{run_id}/{storage_subdir}/{filename}
 
 TRANSIENT and PERSISTENT tiers ignore `storage_subdir`.
 
+### Uploading without a local copy
+
+`App.upload()` does **not** require the artifacts to be on the calling pod. When
+`local_path` is absent, it streams from the deployment store at
+`ref.storage_path` instead of the local filesystem — so it works when the tasks
+that produced the tree ran on other workers (KEDA-scaled SDR), when the writer
+deleted its local copy (`use_consolidation=True`), or when the caller only ever
+had a `FileReference`:
+
+```python
+# The transformed tree is in the deployment store; this pod never held it.
+result = await self.upload(
+    UploadInput(
+        ref=staged_ref,                    # source: deployment store at staged_ref.storage_path
+        storage_path=staged_ref.storage_path,  # pin the destination → key-preserving
+        tier=StorageTier.RETAINED,
+    )
+)
+```
+
+Two behaviours worth knowing:
+
+- **Pin `storage_path` to the ref's own prefix** and the copy is key-preserving —
+  each key keeps its name in the destination store. Leave it off and the
+  artifacts land under the canonical prefix for the tier (see the table above).
+- **A copy whose source and destination are the same object is already
+  satisfied**: it is recognised and skipped (`reason="skipped:same_object"`)
+  rather than moving bytes. That is what makes the two-store dual write free in
+  this shape. A `ref` pointing at a key that was never written is *not* silently
+  treated as satisfied — it fails with `StorageNotFoundError`.
+
+A **partially**-present local directory gets both halves: the local files are
+uploaded and anything present only in the store is streamed, so the destination
+copy is complete regardless of which pod produced what.
+
+Deriving the ref is automatic — passing `local_path` alone gives you the same
+fallback, since the SDK derives `ref` from it. Pass `ref` explicitly when the
+source key is not the mirror of a local path. Either way, the artifact must have
+reached the deployment store in the first place: that happens when a `@task`
+**returns** a `FileReference` (the interceptor persists it), and a ref created
+with `is_durable=True` opts out of that copy — leaving nothing to fall back to.
+
 ### UploadOutput
 
 ```python
@@ -415,7 +459,7 @@ class UploadOutput(BaseModel):
 |---|---|
 | `ref` | Durable `FileReference` with `is_durable=True` and `storage_path` set. `file_count` reflects the number of files uploaded (1 for a single file, N for a directory). |
 | `synced` | `True` if at least one file was transferred to the store. `False` when all files were skipped (e.g. `skip_if_exists=True` and every file already matched its SHA-256 sidecar). |
-| `reason` | Short string describing the transfer outcome. Typical values: `"uploaded"`, `"skipped:hash_match"`, `"empty"`. Useful for logging. |
+| `reason` | Short string describing the transfer outcome. Typical values: `"uploaded"`, `"skipped:hash_match"`, `"skipped:same_object"` (source and destination are the same object — see [Uploading without a local copy](#uploading-without-a-local-copy)), `"empty"`. Useful for logging. |
 
 The returned `ref` is already durable — you can pass it as a `FileReference` field on a subsequent task's Input.
 

--- a/tests/integration/test_app_upload_routing.py
+++ b/tests/integration/test_app_upload_routing.py
@@ -32,6 +32,13 @@ New invariants added for BLDX-1464 (artifact dual-write):
 (i_fail_hard) Deployment write fails + required mode → upstream still written
     first, then run fails with the deployment exception.
 
+New invariants added for FND-536 (ref-only / deployment→deployment copy):
+
+(j) A ref-only upload (bytes already in the deployment store, no local copy)
+    satisfies the deployment leg instead of failing it: key-preserving is a
+    silent no-op, and an unpinned destination lands the identical key in both
+    stores.
+
 See:
   docs/concepts/file-reference.md   (decision matrix and lifecycle)
   docs/adr/0014-two-store-storage-architecture.md   (full rationale)
@@ -708,6 +715,141 @@ async def test_app_upload_dual_write_failure_required_raises_after_upstream(
         f"Upstream write did not complete before the required-mode exception. "
         f"upstream_keys={upstream_keys}"
     )
+
+
+# ---------------------------------------------------------------------------
+# (j) FND-536: a ref-only upload (local absent) satisfies the deployment leg
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_app_upload_ref_only_key_preserving_satisfies_deployment_leg(
+    tmp_path, monkeypatch, dual_write_required
+):
+    """The P042 bridge shape — bytes already in the deployment store, no local
+    copy, destination pinned to the ref's own prefix — must satisfy the
+    deployment leg of the dual write rather than failing it.
+
+    Before FND-536 the deployment leg was handed no fallback source, so
+    ``transfer.upload`` fell through to "local_path does not exist": a spurious
+    WARNING under ``best_effort`` and, as pinned here, a failed run under
+    ``required``.  The deployment leg is asserted silent (no warning, no error)
+    *and* the run is asserted to reach the upstream keys — an empty-log assertion
+    alone would also pass if the upload had been skipped wholesale.
+    """
+    from application_sdk.storage.ops import upload_file
+
+    deployment_store = create_local_store(tmp_path / "deployment")
+    upstream_root = tmp_path / "upstream"
+    upstream_store = create_local_store(upstream_root)
+
+    # Pod A wrote the transformed tree to the deployment store; this pod never
+    # held it locally.
+    src_prefix = "artifacts/apps/test-app/workflows/wf-p042/run-p042/transformed"
+    src_file = tmp_path / "entities.json"
+    for entity_type in ("table", "column"):
+        src_file.write_bytes(b'{"typeName": "%s"}\n' % entity_type.encode())
+        await upload_file(
+            f"{src_prefix}/{entity_type}/entities.json",
+            src_file,
+            deployment_store,
+            normalize=False,
+        )
+    src_file.unlink()
+
+    missing_local = str(tmp_path / "never-created" / "transformed")
+    ref = FileReference(local_path=missing_local, storage_path=src_prefix)
+
+    app = _make_app(deployment_store, upstream_store=upstream_store, run_id="run-p042")
+
+    # Spy on the fan-out's own failure reporting: any deployment-leg failure —
+    # fatal or not — goes through one of these two calls.
+    import application_sdk.app.base as _base_mod
+
+    warnings: list[tuple] = []
+    errors: list[tuple] = []
+    monkeypatch.setattr(
+        _base_mod._task_logger,
+        "warning",
+        lambda *a, **kw: warnings.append(a),
+    )
+    monkeypatch.setattr(
+        _base_mod._task_logger,
+        "error",
+        lambda *a, **kw: errors.append(a),
+    )
+
+    # required mode: any deployment-leg failure would raise here.
+    result = await app.upload(
+        UploadInput(ref=ref, storage_path=src_prefix, tier=StorageTier.RETAINED)
+    )
+
+    assert not warnings, f"deployment leg logged a spurious WARNING: {warnings}"
+    assert not errors, f"deployment leg logged an ERROR: {errors}"
+
+    # The upstream leg did the real work, key-preserving.
+    upstream_keys = {
+        k
+        for k in await list_keys("", store=upstream_store)
+        if not k.endswith(".sha256")
+    }
+    assert upstream_keys == {
+        f"{src_prefix}/table/entities.json",
+        f"{src_prefix}/column/entities.json",
+    }
+    assert result.ref.file_count == 2
+
+
+@pytest.mark.integration
+async def test_app_upload_ref_only_lands_identical_keys_in_both_stores(
+    tmp_path, dual_write_enabled
+):
+    """Ref-only upload with no pinned ``storage_path``: the deployment leg now
+    copies within the deployment store to the canonical run prefix, so ADR-0014's
+    "identical key in both stores" invariant holds for the cross-pod case too.
+    """
+    from application_sdk.storage.ops import upload_file
+
+    deployment_root = tmp_path / "deployment"
+    deployment_store = create_local_store(deployment_root)
+    upstream_store = create_local_store(tmp_path / "upstream")
+
+    src_prefix = "artifacts/apps/test-app/workflows/wf-xpod/run-xpod/transformed"
+    src_file = tmp_path / "entities.json"
+    src_file.write_bytes(b'{"typeName": "Table"}\n')
+    await upload_file(
+        f"{src_prefix}/table/entities.json", src_file, deployment_store, normalize=False
+    )
+    src_file.unlink()
+
+    missing_local = str(tmp_path / "never-created" / "transformed")
+    app = _make_app(deployment_store, upstream_store=upstream_store, run_id="run-xpod")
+
+    result = await app.upload(
+        UploadInput(
+            ref=FileReference(local_path=missing_local, storage_path=src_prefix),
+            tier=StorageTier.RETAINED,
+        )
+    )
+
+    # A directory upload's ref carries the canonical trailing-slash prefix.
+    target_prefix = (result.ref.storage_path or "").rstrip("/")
+    assert target_prefix and target_prefix != src_prefix, (
+        "test premise: with no pinned storage_path the destination must be the "
+        f"derived run prefix, not the ref's own ({target_prefix!r})"
+    )
+
+    def _data_keys(keys):
+        return {k for k in keys if not k.endswith(".sha256")}
+
+    upstream_keys = _data_keys(await list_keys("", store=upstream_store))
+    deployment_keys = _data_keys(await list_keys("", store=deployment_store))
+
+    expected = f"{target_prefix}/table/entities.json"
+    assert upstream_keys == {expected}
+    # Deployment store holds both its original ref copy and the mirror at the
+    # identical key the upstream write used.
+    assert deployment_keys == {f"{src_prefix}/table/entities.json", expected}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_app_upload_routing.py
+++ b/tests/integration/test_app_upload_routing.py
@@ -816,7 +816,8 @@ async def test_app_upload_ref_only_lands_identical_keys_in_both_stores(
 
     src_prefix = "artifacts/apps/test-app/workflows/wf-xpod/run-xpod/transformed"
     src_file = tmp_path / "entities.json"
-    src_file.write_bytes(b'{"typeName": "Table"}\n')
+    payload = b'{"typeName": "Table", "attributes": {"name": "orders"}}\n'
+    src_file.write_bytes(payload)
     await upload_file(
         f"{src_prefix}/table/entities.json", src_file, deployment_store, normalize=False
     )
@@ -850,6 +851,14 @@ async def test_app_upload_ref_only_lands_identical_keys_in_both_stores(
     # Deployment store holds both its original ref copy and the mirror at the
     # identical key the upstream write used.
     assert deployment_keys == {f"{src_prefix}/table/entities.json", expected}
+
+    # Read the bytes back from both stores: "identical key" is only worth
+    # anything if the object under it is identical too — the right key holding
+    # truncated or altered content would satisfy a key-only assertion.
+    from application_sdk.storage.ops import _get_bytes
+
+    assert await _get_bytes(expected, upstream_store, normalize=False) == payload
+    assert await _get_bytes(expected, deployment_store, normalize=False) == payload
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/storage/test_transfer.py
+++ b/tests/unit/storage/test_transfer.py
@@ -881,6 +881,11 @@ class TestUploadSameStoreCopy:
 
         return set(await list_data_keys("", store, normalize=False))
 
+    async def _read(self, store, key: str) -> bytes | None:
+        from application_sdk.storage.ops import _get_bytes
+
+        return await _get_bytes(key, store, normalize=False)
+
     async def test_key_preserving_dir_copy_is_a_noop(self, tmp_path) -> None:
         """Local absent, source store IS the target store, and the destination
         prefix is pinned to the source prefix: every key is its own destination.
@@ -930,7 +935,8 @@ class TestUploadSameStoreCopy:
 
         store = create_memory_store()
         src_prefix = "artifacts/apps/postgres/wf/run/transformed"
-        await self._seed(store, f"{src_prefix}/table/entities.json", b"T")
+        payload = b'{"typeName": "Table", "attributes": {"name": "orders"}}\n'
+        await self._seed(store, f"{src_prefix}/table/entities.json", payload)
 
         missing_local = str(tmp_path / "never-created" / "transformed")
 
@@ -950,6 +956,12 @@ class TestUploadSameStoreCopy:
             f"{src_prefix}/table/entities.json",  # source retained
             "dest/transformed/table/entities.json",  # copy landed
         }
+        # Read the bytes back: the right key holding truncated or altered
+        # content would satisfy a key-only assertion.
+        assert (
+            await self._read(store, "dest/transformed/table/entities.json") == payload
+        )
+        assert await self._read(store, f"{src_prefix}/table/entities.json") == payload
 
     async def test_key_preserving_single_file_copy_is_a_noop(self, tmp_path) -> None:
         """Single-file fallback shape of the same guard, and the reason string
@@ -977,3 +989,55 @@ class TestUploadSameStoreCopy:
         assert out.ref.file_count == 1
         assert out.synced == 0
         assert out.reason == "skipped:same_object"
+
+    async def test_same_key_with_absent_source_object_still_raises(
+        self, tmp_path
+    ) -> None:
+        """ "Satisfied" must mean the object is there. A stale ``FileReference``
+        pinned to a key that was never written must not buy a durable-looking
+        success out of the same-object guard — it fails with the same not-found
+        error any other leg would raise."""
+        from application_sdk.contracts.types import FileReference
+        from application_sdk.storage.errors import StorageNotFoundError
+
+        store = create_memory_store()  # nothing seeded — the key does not exist
+        key = "artifacts/apps/postgres/wf/run/transformed/entities.json"
+        missing_local = str(tmp_path / "never-created" / "entities.json")
+
+        with pytest.raises(StorageNotFoundError):
+            await upload(
+                missing_local,
+                storage_path=key,
+                store=store,
+                _source_ref=FileReference(local_path=missing_local, storage_path=key),
+                _source_store=store,
+            )
+
+    async def test_listed_source_keys_skip_the_existence_head(self, tmp_path) -> None:
+        """Keys enumerated from the source store are already proven present, so
+        the directory fallback must not pay a HEAD per key to re-establish it."""
+        from application_sdk.contracts.types import FileReference
+
+        store = create_memory_store()
+        prefix = "artifacts/apps/postgres/wf/run/transformed"
+        await self._seed(store, f"{prefix}/table/entities.json", b"T")
+        await self._seed(store, f"{prefix}/column/entities.json", b"C")
+
+        missing_local = str(tmp_path / "never-created" / "transformed")
+
+        with patch(
+            "application_sdk.storage.ops.exists", side_effect=AssertionError("HEAD")
+        ) as exists_spy:
+            out = await upload(
+                missing_local,
+                storage_path=prefix,
+                store=store,
+                _source_ref=FileReference(
+                    local_path=missing_local, storage_path=prefix
+                ),
+                _source_store=store,
+            )
+
+        exists_spy.assert_not_called()
+        assert out.ref.file_count == 2
+        assert out.synced == 0

--- a/tests/unit/storage/test_transfer.py
+++ b/tests/unit/storage/test_transfer.py
@@ -854,3 +854,126 @@ def test_reconcile_prefix_alignment_holds_across_helpers() -> None:
             source_dir_prefix
         ), f"{persisted!r} not under {source_dir_prefix!r}"
         assert persisted.removeprefix(source_dir_prefix) == f"{typename}/entities.json"
+
+
+class TestUploadSameStoreCopy:
+    """FND-536: a deployment→deployment copy must be expressible.
+
+    ``App.upload`` hands every dual-write leg the deployment store as its
+    fallback source, so the deployment leg of an ADR-0014 dual write reaches the
+    local-absent fallback branch instead of raising "local_path does not exist".
+    Two shapes matter:
+
+    * keys pinned to the source prefix (the P042 bridge shape) — every copy is
+      an object onto itself, so it must short-circuit without moving bytes and
+      without the sidecar GETs the cross-store dedup would cost;
+    * keys not pinned — a real copy inside the one store, which is what keeps
+      ADR-0014's "identical key in both stores" promise for the ref-only case.
+    """
+
+    async def _seed(self, store, key: str, data: bytes) -> None:
+        from application_sdk.storage.ops import _put
+
+        await _put(key, data, store, normalize=False)
+
+    async def _data_keys(self, store) -> set[str]:
+        from application_sdk.storage.batch import list_data_keys
+
+        return set(await list_data_keys("", store, normalize=False))
+
+    async def test_key_preserving_dir_copy_is_a_noop(self, tmp_path) -> None:
+        """Local absent, source store IS the target store, and the destination
+        prefix is pinned to the source prefix: every key is its own destination.
+        No bytes move, no sidecar is read, and the upload still reports the full
+        file count so the caller sees the prefix as satisfied."""
+        from application_sdk.contracts.types import FileReference
+
+        store = create_memory_store()
+        prefix = "artifacts/apps/postgres/wf/run/transformed"
+        await self._seed(store, f"{prefix}/table/entities.json", b"T")
+        await self._seed(store, f"{prefix}/column/entities.json", b"C")
+
+        missing_local = str(tmp_path / "never-created" / "transformed")
+
+        # Patch the dedup helper, not the store: proves the same-object guard
+        # returns *before* the two sidecar GETs, which is the whole point of
+        # placing it ahead of the SHA-256 check.
+        with patch(
+            "application_sdk.storage.transfer._cross_store_sha256_match"
+        ) as dedup_spy:
+            out = await upload(
+                missing_local,
+                storage_path=prefix,
+                store=store,
+                _source_ref=FileReference(
+                    local_path=missing_local, storage_path=prefix
+                ),
+                _source_store=store,
+            )
+
+        dedup_spy.assert_not_called()
+        assert out.ref.file_count == 2
+        assert out.synced == 0  # nothing transferred
+        # The source objects are untouched — not deleted, not rewritten.
+        assert await self._data_keys(store) == {
+            f"{prefix}/table/entities.json",
+            f"{prefix}/column/entities.json",
+        }
+
+    async def test_unpinned_dir_copy_moves_bytes_within_the_store(
+        self, tmp_path
+    ) -> None:
+        """Same store, but the destination prefix differs from the source's: a
+        real copy runs, so the one store ends up holding the artifacts under the
+        canonical run prefix as well as the ref prefix."""
+        from application_sdk.contracts.types import FileReference
+
+        store = create_memory_store()
+        src_prefix = "artifacts/apps/postgres/wf/run/transformed"
+        await self._seed(store, f"{src_prefix}/table/entities.json", b"T")
+
+        missing_local = str(tmp_path / "never-created" / "transformed")
+
+        out = await upload(
+            missing_local,
+            storage_path="dest/transformed",
+            store=store,
+            _source_ref=FileReference(
+                local_path=missing_local, storage_path=src_prefix
+            ),
+            _source_store=store,
+        )
+
+        assert out.ref.file_count == 1
+        assert out.synced == 1
+        assert await self._data_keys(store) == {
+            f"{src_prefix}/table/entities.json",  # source retained
+            "dest/transformed/table/entities.json",  # copy landed
+        }
+
+    async def test_key_preserving_single_file_copy_is_a_noop(self, tmp_path) -> None:
+        """Single-file fallback shape of the same guard, and the reason string
+        says *why* it skipped — no hash was compared."""
+        from application_sdk.contracts.types import FileReference
+
+        store = create_memory_store()
+        key = "artifacts/apps/postgres/wf/run/transformed/entities.json"
+        await self._seed(store, key, b"T")
+
+        missing_local = str(tmp_path / "never-created" / "entities.json")
+
+        with patch(
+            "application_sdk.storage.transfer._cross_store_sha256_match"
+        ) as dedup_spy:
+            out = await upload(
+                missing_local,
+                storage_path=key,
+                store=store,
+                _source_ref=FileReference(local_path=missing_local, storage_path=key),
+                _source_store=store,
+            )
+
+        dedup_spy.assert_not_called()
+        assert out.ref.file_count == 1
+        assert out.synced == 0
+        assert out.reason == "skipped:same_object"


### PR DESCRIPTION
Closes [FND-536](https://linear.app/atlan-epd/issue/FND-536/appupload-cannot-express-a-deploymentupstream-copy-the-dual-write).

## The bug

`App.upload()` withheld the fallback source store from the deployment leg of the ADR-0014 dual write:

```python
source_store = None if target_store is deployment else self.context.storage
```

That made a deployment→deployment copy inexpressible. When the artifacts are already in the deployment store and there is **no local copy on the uploading pod** — a cross-pod / KEDA-scaled hand-off, or a caller passing only `UploadInput.ref` — `transfer.upload` cannot take its deployment-store fallback branch (it requires a resolved source) and falls through to:

```python
raise StorageError(f"local_path does not exist or is not a file/directory: {local_path}")
```

- `ATLAN_DEPLOYMENT_ARTIFACT_DUAL_WRITE=best_effort` (default): one spurious WARNING per upload that reads like a real failure, even though the upstream leg did its job.
- `ATLAN_DEPLOYMENT_ARTIFACT_DUAL_WRITE=required`: the deferred error **fails the run**.

Surfaced while migrating the hand-rolled `upload_to_atlan` bridges (P042) to `App.upload()` — that shape is exactly "bytes already in the deployment store, copy them upstream preserving keys".

## The fix

1. **`application_sdk/app/base.py`** — every leg now gets `_source_store=self.context.storage`, including the deployment leg.
2. **`application_sdk/storage/transfer.py`** — `_upload_from_store` gained a same-object guard **ahead of** the cross-store SHA-256 dedup: same store + same key returns `(False, "skipped:same_object")` immediately.

Two shapes follow:

- **destination pinned to the ref's own prefix** (key-preserving, what the bridges do): every copy is an object onto itself, so it short-circuits with no bytes moved and not even the two sidecar GETs the dedup would cost.
- **destination not pinned**: a real copy runs inside the deployment store, which is what keeps ADR-0014's *"identical key in both stores"* invariant true for the ref-only case.

### Why not just skip the deployment leg

That was the ticket's suggestion, and it is subtly worse:

- it breaks the identical-key invariant for an unpinned destination — the returned `FileReference` would not be readable from the deployment store;
- it needs a `len(targets) > 1` guard, because in the single-target (non-SDR) case there is no other leg to carry the upload, so the skip converts a `StorageError` into `_InternalError("fan-out captured no result")`. Passing the source store fixes that case too: a ref-only `App.upload()` in a non-SDR deployment now works instead of raising.

## Cost on the hot paths: none

- the directory reconcile is already gated on a **distinct** source store (`source_resolved is not resolved`), so no extra LIST for local-present uploads;
- the single-file path never reads `_source_store`;
- the only new cost is one bounded LIST on the deployment leg of a ref-only upload.

The removed comment claimed the old shape avoided "a redundant SHA-256 sidecar lookup against itself" — that lookup was already unreachable through the reconcile guard.

## Verification

- Both new integration tests were confirmed to **fail before the fix**; the `required`-mode one fails with exactly the reported `raise deferred_required_error`.
- New tests: 3 unit (`TestUploadSameStoreCopy` — key-preserving dir no-op with the dedup helper spied as never-called, unpinned dir copy, single-file `reason="skipped:same_object"`) and 2 integration (invariant `(j)` in `test_app_upload_routing.py`: `required` mode with a silent deployment leg, and identical keys landing in both stores).
- `tests/unit` 7216 passed; `tests/integration -m integration` 178 passed.
- pre-commit (ruff, ruff-format, isort, pyright) clean; `conformance detect` reports no findings on the changed lines.
- ADR-0014 gained a "Ref-only uploads: the deployment leg copies within its own store" subsection.

## Downstream note

Once this ships, a dual-write deployment-leg WARNING in a P042 connector run is **no longer expected** and should be treated as a real signal. The mitigation in those PRs (passing `local_path` alongside `ref`) stops being load-bearing and can be dropped at their next SDK bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
