### PR TITLE
WIP: feat(observability): collect per-activity resource usage for tier sizing

### DIFF
--- a/application_sdk/constants.py
+++ b/application_sdk/constants.py
@@ -702,6 +702,22 @@ METRICS_CLEANUP_ENABLED = (
 )
 # Same signal-discriminator convention as LOG_FILE_NAME above — not a real file name.
 METRICS_FILE_NAME = os.environ.get("ATLAN_METRICS_FILE_NAME", "metrics.parquet")
+
+# --- Activity sizing telemetry (tier-sizing evidence) ------------------------
+# One record per activity execution, so the batch is larger and the flush slower
+# than metrics: this is offline evidence for fitting tier envelopes, not something
+# anyone watches live.
+SIZING_BATCH_SIZE = int(os.environ.get("ATLAN_SIZING_BATCH_SIZE", 500))
+SIZING_FLUSH_INTERVAL_SECONDS = int(
+    os.environ.get("ATLAN_SIZING_FLUSH_INTERVAL_SECONDS", 60)
+)
+# Longer than metrics' 30: tier fitting wants the tail, and the runs that matter
+# most for sizing are the rare big ones.
+SIZING_RETENTION_DAYS = int(os.environ.get("ATLAN_SIZING_RETENTION_DAYS", 90))
+SIZING_CLEANUP_ENABLED = (
+    os.getenv("ATLAN_SIZING_CLEANUP_ENABLED", "false").lower() == "true"
+)
+SIZING_FILE_NAME = os.environ.get("ATLAN_SIZING_FILE_NAME", "sizing.parquet")
 TRACES_FILE_NAME = os.environ.get("ATLAN_TRACES_FILE_NAME", "traces.parquet")
 
 # Segment Configuration

--- a/application_sdk/execution/_temporal/interceptors/sizing.py
+++ b/application_sdk/execution/_temporal/interceptors/sizing.py
@@ -1,28 +1,18 @@
 """Activity resource-sizing telemetry, collected at the interceptor.
 
-Why an interceptor and not a decorator. A decorator would have to be applied by
-every app author to every task method — 44 v3 apps, and the ones that forget are
-exactly the ones with no sizing data, so the dataset would be biased towards
-teams who already care about resource usage. ``create_worker`` already attaches
-the SDK's interceptors to every activity in every v3 app, so the interceptor is
-the only hook that is uniform by construction. It also needs nothing from the
-activity's signature, which matters because it has to work for tasks the SDK has
-never seen.
+An interceptor, not a decorator: ``create_worker`` already attaches SDK
+interceptors to every activity in every v3 app, whereas a decorator would be
+skipped by exactly the teams whose data is most needed. It also reads nothing from
+the activity's signature, so it works for tasks the SDK has never seen.
 
-A **sibling** of ``MetricsInterceptor`` rather than an extension of it, for two
-reasons: this one is gated and that one is unconditional, and the App Vitals
-metrics path should not gain a background task and a set of cgroup reads as a
-side effect of a sizing rollout.
+A *sibling* of ``MetricsInterceptor``, not an extension — this one is gated, and
+the App Vitals path should not gain a background task as a side effect.
 
-**Cost.** Two small file reads per poll tick and roughly four per activity, with
-no RPC. Deliberately unlike AE's ``report_memory_pressure``, whose per-tick
-``activity.heartbeat()`` is a network call — that one is a safety device whose
-readings must reach the workflow, this one only has to reach the local process.
-That difference is what makes a 1-second default defensible fleet-wide.
+Cost: ~4 file reads per activity plus 2 per poll tick, and no RPC. Unlike AE's
+``report_memory_pressure``, whose per-tick heartbeat is a network call, this only
+has to reach the local process — which is what makes a 1s default affordable.
 
-Ships **off**. Collection is enabled per tenant by
-``APPLICATION_SDK_ENABLE_SIZING_TELEMETRY``, so a version bump alone changes
-nothing.
+Ships off, and measures only the activities named in the allow-list.
 """
 
 from __future__ import annotations
@@ -44,9 +34,7 @@ from application_sdk.observability.sizing import SizingObservation, record_obser
 logger = get_logger(__name__)
 
 
-#: Allow-list value that selects every activity. The discovery case — run it on a
-#: test tenant to find out which activities actually vary with their data, then
-#: replace it with those names.
+#: Selects every activity. For a discovery pass on a test tenant, not production.
 WILDCARD = "*"
 
 
@@ -64,14 +52,10 @@ class _SizingActivityInboundInterceptor(ActivityInboundInterceptor):
     def _selected(self, activity_type: str) -> bool:
         """Whether this activity is on the allow-list.
 
-        Matches the **bare task name as well as the qualified one**. A v3 activity
-        registers with Temporal as ``"{app_name}:{task_name}"`` (see
-        ``execution._temporal.activities``), so ``activity_type`` is
-        ``"automation-engine:merge"`` — but an app author reading their own source
-        sees ``@task async def merge`` and will write ``merge``. Requiring the
-        qualified form would silently collect nothing, which is the worst outcome
-        available: the config looks right, the worker logs success, and the dataset
-        is empty. Both forms are accepted, so either spelling works.
+        Matches the bare task name as well as the qualified one. A v3 activity
+        registers as ``"{app}:{task}"``, but an author reading ``@task async def
+        merge`` writes ``merge`` — and requiring the qualified form would silently
+        collect nothing while the config looked correct.
         """
         if WILDCARD in self._activities:
             return True
@@ -81,17 +65,15 @@ class _SizingActivityInboundInterceptor(ActivityInboundInterceptor):
 
     async def execute_activity(self, input: ExecuteActivityInput) -> Any:
         info = activity.info()
-        # Filter FIRST, before the tracker. A worker polls one queue for many
-        # activities, so an unselected one has to be a bare set lookup — no cgroup
-        # reads and no poller. Deciding inside the tracker would pay the setup cost
-        # for every activity in the app just to throw the reading away.
+        # Filter before the tracker, so an unselected activity costs a set lookup
+        # rather than the tracker's setup on every activity in the app.
         if not self._selected(info.activity_type or ""):
             return await self.next.execute_activity(input)
 
         start_ns = time.monotonic_ns()
         outcome = "OK"
-        # Bound before the ``async with`` so the outer ``finally`` cannot raise
-        # NameError on the one path where the tracker never yields.
+        # Bound first so the outer ``finally`` cannot NameError if the tracker
+        # never yields.
         trace = None
         try:
             async with track_container_usage(
@@ -104,10 +86,8 @@ class _SizingActivityInboundInterceptor(ActivityInboundInterceptor):
             outcome = "ERROR"
             raise
         finally:
-            # Read the trace *after* the ``async with`` has exited. The tracker
-            # fills in the peak watermark and the CPU deltas in its own
-            # ``finally``, so reading inside the block would record a trace that
-            # is still empty.
+            # After the ``async with`` exits: the tracker fills the peak and CPU
+            # deltas in its own ``finally``, so reading inside would record nothing.
             if trace is not None:
                 duration_s = (time.monotonic_ns() - start_ns) / 1_000_000_000
                 record_observation(
@@ -124,26 +104,17 @@ class _SizingActivityInboundInterceptor(ActivityInboundInterceptor):
 
 
 class SizingTelemetryInterceptor(Interceptor):
-    """Measures what each activity execution actually consumed.
+    """Measures what each activity execution consumed.
 
-    Emits, per activity execution:
+    Per execution: ``activity.sizing.peak_memory_mib``, ``peak_memory_fraction``,
+    ``cpu_throttled_fraction`` and ``mean_cpu_cores``, plus one structured
+    ``activity_sizing_observation`` log line for offline tier fitting.
 
-    * ``activity.sizing.peak_memory_mib`` — peak cgroup memory
-    * ``activity.sizing.peak_memory_fraction`` — the utilisation view
-    * ``activity.sizing.cpu_throttled_fraction`` — CPU starvation
-    * ``activity.sizing.mean_cpu_cores`` — CPU consumed per wall second
+    ``activities`` is an opt-in allow-list; empty measures nothing, so being
+    attached is never on its own enough to make this do work.
 
-    plus one structured ``activity_sizing_observation`` log line carrying the
-    full record for offline tier fitting.
-
-    ``activities`` is an opt-in allow-list of activity names. Empty measures
-    nothing, so this interceptor being attached is never on its own enough to
-    make it do work.
-
-    Not exported from the ``interceptors`` package and not accepted via
-    ``create_worker(interceptors=...)``: it is wired only by ``create_worker``
-    when collection is enabled. Keeping it un-exported is what makes
-    double-registration — and therefore two pollers per activity — impossible by
+    Not exported and not accepted via ``create_worker(interceptors=...)``, which
+    makes double-registration — two pollers per activity — impossible by
     construction rather than by a guard list.
     """
 

--- a/application_sdk/execution/_temporal/interceptors/sizing.py
+++ b/application_sdk/execution/_temporal/interceptors/sizing.py
@@ -62,9 +62,22 @@ class _SizingActivityInboundInterceptor(ActivityInboundInterceptor):
         self._activities = activities
 
     def _selected(self, activity_type: str) -> bool:
+        """Whether this activity is on the allow-list.
+
+        Matches the **bare task name as well as the qualified one**. A v3 activity
+        registers with Temporal as ``"{app_name}:{task_name}"`` (see
+        ``execution._temporal.activities``), so ``activity_type`` is
+        ``"automation-engine:merge"`` — but an app author reading their own source
+        sees ``@task async def merge`` and will write ``merge``. Requiring the
+        qualified form would silently collect nothing, which is the worst outcome
+        available: the config looks right, the worker logs success, and the dataset
+        is empty. Both forms are accepted, so either spelling works.
+        """
         if WILDCARD in self._activities:
             return True
-        return activity_type in self._activities
+        if activity_type in self._activities:
+            return True
+        return activity_type.rpartition(":")[2] in self._activities
 
     async def execute_activity(self, input: ExecuteActivityInput) -> Any:
         info = activity.info()

--- a/application_sdk/execution/_temporal/interceptors/sizing.py
+++ b/application_sdk/execution/_temporal/interceptors/sizing.py
@@ -44,15 +44,37 @@ from application_sdk.observability.sizing import SizingObservation, record_obser
 logger = get_logger(__name__)
 
 
+#: Allow-list value that selects every activity. The discovery case — run it on a
+#: test tenant to find out which activities actually vary with their data, then
+#: replace it with those names.
+WILDCARD = "*"
+
+
 class _SizingActivityInboundInterceptor(ActivityInboundInterceptor):
     def __init__(
-        self, next: ActivityInboundInterceptor, poll_interval_seconds: float
+        self,
+        next: ActivityInboundInterceptor,
+        poll_interval_seconds: float,
+        activities: frozenset[str],
     ) -> None:
         super().__init__(next)
         self._poll_interval_seconds = poll_interval_seconds
+        self._activities = activities
+
+    def _selected(self, activity_type: str) -> bool:
+        if WILDCARD in self._activities:
+            return True
+        return activity_type in self._activities
 
     async def execute_activity(self, input: ExecuteActivityInput) -> Any:
         info = activity.info()
+        # Filter FIRST, before the tracker. A worker polls one queue for many
+        # activities, so an unselected one has to be a bare set lookup — no cgroup
+        # reads and no poller. Deciding inside the tracker would pay the setup cost
+        # for every activity in the app just to throw the reading away.
+        if not self._selected(info.activity_type or ""):
+            return await self.next.execute_activity(input)
+
         start_ns = time.monotonic_ns()
         outcome = "OK"
         # Bound before the ``async with`` so the outer ``finally`` cannot raise
@@ -101,6 +123,10 @@ class SizingTelemetryInterceptor(Interceptor):
     plus one structured ``activity_sizing_observation`` log line carrying the
     full record for offline tier fitting.
 
+    ``activities`` is an opt-in allow-list of activity names. Empty measures
+    nothing, so this interceptor being attached is never on its own enough to
+    make it do work.
+
     Not exported from the ``interceptors`` package and not accepted via
     ``create_worker(interceptors=...)``: it is wired only by ``create_worker``
     when collection is enabled. Keeping it un-exported is what makes
@@ -108,10 +134,17 @@ class SizingTelemetryInterceptor(Interceptor):
     construction rather than by a guard list.
     """
 
-    def __init__(self, poll_interval_seconds: float = 1.0) -> None:
+    def __init__(
+        self,
+        poll_interval_seconds: float = 1.0,
+        activities: frozenset[str] = frozenset(),
+    ) -> None:
         self._poll_interval_seconds = poll_interval_seconds
+        self._activities = activities
 
     def intercept_activity(
         self, next: ActivityInboundInterceptor
     ) -> ActivityInboundInterceptor:
-        return _SizingActivityInboundInterceptor(next, self._poll_interval_seconds)
+        return _SizingActivityInboundInterceptor(
+            next, self._poll_interval_seconds, self._activities
+        )

--- a/application_sdk/execution/_temporal/interceptors/sizing.py
+++ b/application_sdk/execution/_temporal/interceptors/sizing.py
@@ -1,0 +1,117 @@
+"""Activity resource-sizing telemetry, collected at the interceptor.
+
+Why an interceptor and not a decorator. A decorator would have to be applied by
+every app author to every task method — 44 v3 apps, and the ones that forget are
+exactly the ones with no sizing data, so the dataset would be biased towards
+teams who already care about resource usage. ``create_worker`` already attaches
+the SDK's interceptors to every activity in every v3 app, so the interceptor is
+the only hook that is uniform by construction. It also needs nothing from the
+activity's signature, which matters because it has to work for tasks the SDK has
+never seen.
+
+A **sibling** of ``MetricsInterceptor`` rather than an extension of it, for two
+reasons: this one is gated and that one is unconditional, and the App Vitals
+metrics path should not gain a background task and a set of cgroup reads as a
+side effect of a sizing rollout.
+
+**Cost.** Two small file reads per poll tick and roughly four per activity, with
+no RPC. Deliberately unlike AE's ``report_memory_pressure``, whose per-tick
+``activity.heartbeat()`` is a network call — that one is a safety device whose
+readings must reach the workflow, this one only has to reach the local process.
+That difference is what makes a 1-second default defensible fleet-wide.
+
+Ships **off**. Collection is enabled per tenant by
+``APPLICATION_SDK_ENABLE_SIZING_TELEMETRY``, so a version bump alone changes
+nothing.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from temporalio import activity
+from temporalio.worker import (
+    ActivityInboundInterceptor,
+    ExecuteActivityInput,
+    Interceptor,
+)
+
+from application_sdk.observability.cgroup import track_container_usage
+from application_sdk.observability.logger_adaptor import get_logger
+from application_sdk.observability.sizing import SizingObservation, record_observation
+
+logger = get_logger(__name__)
+
+
+class _SizingActivityInboundInterceptor(ActivityInboundInterceptor):
+    def __init__(
+        self, next: ActivityInboundInterceptor, poll_interval_seconds: float
+    ) -> None:
+        super().__init__(next)
+        self._poll_interval_seconds = poll_interval_seconds
+
+    async def execute_activity(self, input: ExecuteActivityInput) -> Any:
+        info = activity.info()
+        start_ns = time.monotonic_ns()
+        outcome = "OK"
+        # Bound before the ``async with`` so the outer ``finally`` cannot raise
+        # NameError on the one path where the tracker never yields.
+        trace = None
+        try:
+            async with track_container_usage(
+                poll_interval_seconds=self._poll_interval_seconds
+            ) as trace:
+                return await self.next.execute_activity(input)
+        # conformance: ignore[E004] measurement wrapper; re-raises immediately
+        # after tagging the outcome for the record.
+        except BaseException:
+            outcome = "ERROR"
+            raise
+        finally:
+            # Read the trace *after* the ``async with`` has exited. The tracker
+            # fills in the peak watermark and the CPU deltas in its own
+            # ``finally``, so reading inside the block would record a trace that
+            # is still empty.
+            if trace is not None:
+                duration_s = (time.monotonic_ns() - start_ns) / 1_000_000_000
+                record_observation(
+                    SizingObservation.from_trace(
+                        trace,
+                        activity_type=info.activity_type or "",
+                        task_queue=info.task_queue or "",
+                        workflow_type=info.workflow_type or "",
+                        attempt=info.attempt,
+                        outcome=outcome,
+                        duration_seconds=duration_s,
+                    )
+                )
+
+
+class SizingTelemetryInterceptor(Interceptor):
+    """Measures what each activity execution actually consumed.
+
+    Emits, per activity execution:
+
+    * ``activity.sizing.peak_memory_mib`` — peak cgroup memory
+    * ``activity.sizing.peak_memory_fraction`` — the utilisation view
+    * ``activity.sizing.cpu_throttled_fraction`` — CPU starvation
+    * ``activity.sizing.mean_cpu_cores`` — CPU consumed per wall second
+
+    plus one structured ``activity_sizing_observation`` log line carrying the
+    full record for offline tier fitting.
+
+    Not exported from the ``interceptors`` package and not accepted via
+    ``create_worker(interceptors=...)``: it is wired only by ``create_worker``
+    when collection is enabled. Keeping it un-exported is what makes
+    double-registration — and therefore two pollers per activity — impossible by
+    construction rather than by a guard list.
+    """
+
+    def __init__(self, poll_interval_seconds: float = 1.0) -> None:
+        self._poll_interval_seconds = poll_interval_seconds
+
+    def intercept_activity(
+        self, next: ActivityInboundInterceptor
+    ) -> ActivityInboundInterceptor:
+        return _SizingActivityInboundInterceptor(next, self._poll_interval_seconds)

--- a/application_sdk/execution/_temporal/interceptors/sizing.py
+++ b/application_sdk/execution/_temporal/interceptors/sizing.py
@@ -30,6 +30,7 @@ from temporalio.worker import (
 from application_sdk.observability.cgroup import track_container_usage
 from application_sdk.observability.logger_adaptor import get_logger
 from application_sdk.observability.sizing import SizingObservation, record_observation
+from application_sdk.observability.sizing_inputs import describe_inputs
 
 logger = get_logger(__name__)
 
@@ -90,6 +91,13 @@ class _SizingActivityInboundInterceptor(ActivityInboundInterceptor):
             # deltas in its own ``finally``, so reading inside would record nothing.
             if trace is not None:
                 duration_s = (time.monotonic_ns() - start_ns) / 1_000_000_000
+                # Sized here, not at entry: the SDK materialises durable
+                # FileReferences at the top of the activity, so the bytes are only
+                # on local disk by now — which turns this into a stat instead of an
+                # object-store call. args[1] is the Input (args[0] is TaskContext).
+                input_size = (
+                    describe_inputs(input.args[1]) if len(input.args) > 1 else None
+                )
                 record_observation(
                     SizingObservation.from_trace(
                         trace,
@@ -99,6 +107,7 @@ class _SizingActivityInboundInterceptor(ActivityInboundInterceptor):
                         attempt=info.attempt,
                         outcome=outcome,
                         duration_seconds=duration_s,
+                        input_size=input_size,
                     )
                 )
 

--- a/application_sdk/execution/_temporal/interceptors/sizing.py
+++ b/application_sdk/execution/_temporal/interceptors/sizing.py
@@ -17,6 +17,7 @@ Ships off, and measures only the activities named in the allow-list.
 
 from __future__ import annotations
 
+import os
 import time
 from typing import Any
 
@@ -30,6 +31,7 @@ from temporalio.worker import (
 from application_sdk.observability.cgroup import track_container_usage
 from application_sdk.observability.logger_adaptor import get_logger
 from application_sdk.observability.sizing import SizingObservation, record_observation
+from application_sdk.observability.sizing_census import CENSUS
 from application_sdk.observability.sizing_inputs import (
     begin_collection,
     describe_inputs,
@@ -37,6 +39,15 @@ from application_sdk.observability.sizing_inputs import (
 )
 
 logger = get_logger(__name__)
+
+
+def _pod_name() -> str | None:
+    """Which pod this row came from — the join key for overlapping executions.
+
+    Same source the OTel resource attributes use, so a sizing row and a metric from
+    the same pod agree on its name.
+    """
+    return os.environ.get("K8S_POD_NAME") or os.environ.get("HOSTNAME") or None
 
 
 #: Selects every activity. For a discovery pass on a test tenant, not production.
@@ -70,23 +81,48 @@ class _SizingActivityInboundInterceptor(ActivityInboundInterceptor):
 
     async def execute_activity(self, input: ExecuteActivityInput) -> Any:
         info = activity.info()
-        # Filter before the tracker, so an unselected activity costs a set lookup
-        # rather than the tracker's setup on every activity in the app.
-        if not self._selected(info.activity_type or ""):
-            return await self.next.execute_activity(input)
+        # EVERY activity is counted, selected or not. What invalidates attribution
+        # is whether anything else was using the pod's memory — not whether we
+        # happened to be measuring it. Counting only the allow-list would let a
+        # measured merge sharing a pod with eight unmeasured activities report
+        # concurrency_max=1, which is the exact silent lie this field exists to
+        # prevent. Cost is a lock and a dict insert; no cgroup reads.
+        token, concurrency_now = CENSUS.enter()
+        try:
+            if not self._selected(info.activity_type or ""):
+                return await self.next.execute_activity(input)
+            return await self._measured(input, info, token, concurrency_now)
+        finally:
+            CENSUS.leave(token)
 
+    async def _measured(
+        self,
+        input: ExecuteActivityInput,
+        info: Any,
+        token: int,
+        concurrency_now: int,
+    ) -> Any:
         start_ns = time.monotonic_ns()
+        # Wall-clock as well as monotonic: monotonic has no epoch, so it cannot be
+        # compared across executions, and comparing windows is the whole point.
+        started_at = time.time()
         outcome = "OK"
         # Created here so the activity's reads accumulate into it. Reporting is a
         # no-op for any activity that never got a collector, which is what keeps
         # report_input_bytes() free to call from a hot read path.
         begin_collection()
+        concurrency_max = concurrency_now
         # Bound first so the outer ``finally`` cannot NameError if the tracker
         # never yields.
         trace = None
         try:
             async with track_container_usage(
-                poll_interval_seconds=self._poll_interval_seconds
+                poll_interval_seconds=self._poll_interval_seconds,
+                # Only the sole occupant may reset the shared kernel counter.
+                # Concurrency can still rise afterwards, which inflates this peak
+                # rather than corrupting it — and concurrency_max records that it
+                # happened, so the analysis is not misled either way.
+                allow_watermark_reset=concurrency_now <= 1,
             ) as trace:
                 return await self.next.execute_activity(input)
         # conformance: ignore[E004] measurement wrapper; re-raises immediately
@@ -95,6 +131,10 @@ class _SizingActivityInboundInterceptor(ActivityInboundInterceptor):
             outcome = "ERROR"
             raise
         finally:
+            # peak(), not leave(): this activity still holds its slot until the
+            # outer wrapper releases it, and leaving early would undercount
+            # concurrency for everything else still running.
+            concurrency_max = CENSUS.peak(token)
             # After the ``async with`` exits: the tracker fills the peak and CPU
             # deltas in its own ``finally``, so reading inside would record nothing.
             if trace is not None:
@@ -115,6 +155,9 @@ class _SizingActivityInboundInterceptor(ActivityInboundInterceptor):
                         outcome=outcome,
                         duration_seconds=duration_s,
                         input_size=input_size,
+                        started_at=started_at,
+                        pod=_pod_name(),
+                        concurrency_max=concurrency_max,
                     )
                 )
             end_collection()

--- a/application_sdk/execution/_temporal/interceptors/sizing.py
+++ b/application_sdk/execution/_temporal/interceptors/sizing.py
@@ -30,7 +30,11 @@ from temporalio.worker import (
 from application_sdk.observability.cgroup import track_container_usage
 from application_sdk.observability.logger_adaptor import get_logger
 from application_sdk.observability.sizing import SizingObservation, record_observation
-from application_sdk.observability.sizing_inputs import describe_inputs
+from application_sdk.observability.sizing_inputs import (
+    begin_collection,
+    describe_inputs,
+    end_collection,
+)
 
 logger = get_logger(__name__)
 
@@ -73,6 +77,10 @@ class _SizingActivityInboundInterceptor(ActivityInboundInterceptor):
 
         start_ns = time.monotonic_ns()
         outcome = "OK"
+        # Created here so the activity's reads accumulate into it. Reporting is a
+        # no-op for any activity that never got a collector, which is what keeps
+        # report_input_bytes() free to call from a hot read path.
+        begin_collection()
         # Bound first so the outer ``finally`` cannot NameError if the tracker
         # never yields.
         trace = None
@@ -91,12 +99,11 @@ class _SizingActivityInboundInterceptor(ActivityInboundInterceptor):
             # deltas in its own ``finally``, so reading inside would record nothing.
             if trace is not None:
                 duration_s = (time.monotonic_ns() - start_ns) / 1_000_000_000
-                # Sized here, not at entry: the SDK materialises durable
-                # FileReferences at the top of the activity, so the bytes are only
-                # on local disk by now — which turns this into a stat instead of an
-                # object-store call. args[1] is the Input (args[0] is TaskContext).
-                input_size = (
-                    describe_inputs(input.args[1]) if len(input.args) > 1 else None
+                # Read after the activity: by now the readers have reported what
+                # they pulled, and any FileReference the interceptor materialised is
+                # on local disk. args[1] is the Input (args[0] is TaskContext).
+                input_size = describe_inputs(
+                    input.args[1] if len(input.args) > 1 else None
                 )
                 record_observation(
                     SizingObservation.from_trace(
@@ -110,6 +117,7 @@ class _SizingActivityInboundInterceptor(ActivityInboundInterceptor):
                         input_size=input_size,
                     )
                 )
+            end_collection()
 
 
 class SizingTelemetryInterceptor(Interceptor):

--- a/application_sdk/execution/_temporal/worker.py
+++ b/application_sdk/execution/_temporal/worker.py
@@ -737,20 +737,35 @@ def create_worker(
     # window covers them: anything they do on the way into the activity (a lock
     # wait, an output buffer) is memory this activity's pod had to hold.
     if interceptor_settings.enable_sizing_telemetry:
-        from application_sdk.execution._temporal.interceptors.sizing import (  # noqa: PLC0415 — cold path: only when sizing collection is enabled
-            SizingTelemetryInterceptor,
-        )
-
-        all_interceptors.append(
-            SizingTelemetryInterceptor(
-                poll_interval_seconds=interceptor_settings.sizing_telemetry_poll_seconds
+        _sizing_activities = interceptor_settings.sizing_telemetry_activities
+        if not _sizing_activities:
+            # Enabled with no allow-list is almost certainly a half-finished
+            # config change, and the fail-closed answer (measure nothing) is
+            # silent — so say so at startup rather than leaving someone to wonder
+            # why no rows arrived.
+            logger.warning(
+                "APPLICATION_SDK_ENABLE_SIZING_TELEMETRY is on but "
+                "APPLICATION_SDK_SIZING_TELEMETRY_ACTIVITIES is empty, so nothing "
+                "will be collected. Name the activities to measure, or set '*' to "
+                "measure all of them."
             )
-        )
-        logger.info(
-            "Activity sizing telemetry enabled (poll interval %ss). Measurement "
-            "only — no routing decisions are made from it.",
-            interceptor_settings.sizing_telemetry_poll_seconds,
-        )
+        else:
+            from application_sdk.execution._temporal.interceptors.sizing import (  # noqa: PLC0415 — cold path: only when sizing collection is enabled
+                SizingTelemetryInterceptor,
+            )
+
+            all_interceptors.append(
+                SizingTelemetryInterceptor(
+                    poll_interval_seconds=interceptor_settings.sizing_telemetry_poll_seconds,
+                    activities=_sizing_activities,
+                )
+            )
+            logger.info(
+                "Activity sizing telemetry enabled for %s (poll interval %ss). "
+                "Measurement only — no routing decisions are made from it.",
+                sorted(_sizing_activities),
+                interceptor_settings.sizing_telemetry_poll_seconds,
+            )
 
     all_interceptors.extend(interceptors or [])
 

--- a/application_sdk/execution/_temporal/worker.py
+++ b/application_sdk/execution/_temporal/worker.py
@@ -733,15 +733,12 @@ def create_worker(
 
         all_interceptors.append(LivenessInterceptor(on_activity))
 
-    # Sizing telemetry sits before the user-supplied interceptors so its measured
-    # window covers them: anything they do on the way into the activity (a lock
-    # wait, an output buffer) is memory this activity's pod had to hold.
+    # Before the user-supplied interceptors, so the measured window covers them —
+    # what they hold on the way in is memory this pod had to carry.
     if interceptor_settings.enable_sizing_telemetry:
         _sizing_activities = interceptor_settings.sizing_telemetry_activities
         if not _sizing_activities:
-            # Enabled with no allow-list is almost certainly a half-finished
-            # config change, and the fail-closed answer (measure nothing) is
-            # silent — so say so at startup rather than leaving someone to wonder
+            # Fail-closed is silent, so say so rather than leave someone wondering
             # why no rows arrived.
             logger.warning(
                 "APPLICATION_SDK_ENABLE_SIZING_TELEMETRY is on but "

--- a/application_sdk/execution/_temporal/worker.py
+++ b/application_sdk/execution/_temporal/worker.py
@@ -733,6 +733,25 @@ def create_worker(
 
         all_interceptors.append(LivenessInterceptor(on_activity))
 
+    # Sizing telemetry sits before the user-supplied interceptors so its measured
+    # window covers them: anything they do on the way into the activity (a lock
+    # wait, an output buffer) is memory this activity's pod had to hold.
+    if interceptor_settings.enable_sizing_telemetry:
+        from application_sdk.execution._temporal.interceptors.sizing import (  # noqa: PLC0415 — cold path: only when sizing collection is enabled
+            SizingTelemetryInterceptor,
+        )
+
+        all_interceptors.append(
+            SizingTelemetryInterceptor(
+                poll_interval_seconds=interceptor_settings.sizing_telemetry_poll_seconds
+            )
+        )
+        logger.info(
+            "Activity sizing telemetry enabled (poll interval %ss). Measurement "
+            "only — no routing decisions are made from it.",
+            interceptor_settings.sizing_telemetry_poll_seconds,
+        )
+
     all_interceptors.extend(interceptors or [])
 
     if interceptor_settings.enable_output_interceptor:

--- a/application_sdk/execution/settings.py
+++ b/application_sdk/execution/settings.py
@@ -77,6 +77,27 @@ class InterceptorSettings:
     Off by default, so an SDK version bump alone changes nothing and collection
     is a per-tenant decision. This is the "collect data" stage of collect →
     classify → productionise; it only measures, and never routes.
+
+    A master kill switch, independent of the allow-list below: flipping this to
+    false stops collection without anyone having to edit per-tenant lists.
+    """
+
+    sizing_telemetry_activities: frozenset[str] = frozenset()
+    """Activity names to collect sizing telemetry for. **Empty collects nothing.**
+
+    Sizing data is only worth collecting for activities whose resource use varies
+    with the data they process — a merge, a transform, an extract. Most activities
+    are fixed-cost bookkeeping, and measuring them adds rows to the dataset that
+    the tier table is fitted from without adding information.
+
+    So this is an allow-list an app author opts into by name, not a default-on
+    sweep. Empty means nothing is collected, which is the fail-closed direction:
+    a tenant that sets the enable flag and forgets the list gets no telemetry
+    rather than telemetry on everything.
+
+    ``"*"`` collects every activity. That is the discovery case — worth running on
+    a test tenant to find out *which* activities vary before choosing names, and
+    not something to ship fleet-wide.
     """
 
     sizing_telemetry_poll_seconds: float = 1.0
@@ -166,11 +187,24 @@ def load_interceptor_settings() -> InterceptorSettings:
         # value on one tenant must not stop its workers from starting.
         return max(0.0, value)
 
+    def _name_set(env_var: str) -> frozenset[str]:
+        """Parse a comma-separated activity-name allow-list.
+
+        Tolerant of stray whitespace and empty entries, because this is hand-edited
+        in a Helm values file. Anything unparseable yields an empty set, i.e. no
+        collection — never accidental collection on everything.
+        """
+        raw = os.environ.get(env_var, "")
+        return frozenset(name.strip() for name in raw.split(",") if name.strip())
+
     return InterceptorSettings(
         enable_event_interceptor=_bool("APPLICATION_SDK_ENABLE_EVENT_INTERCEPTOR"),
         enable_output_interceptor=_bool("APPLICATION_SDK_ENABLE_OUTPUT_INTERCEPTOR"),
         enable_sizing_telemetry=_bool(
             "APPLICATION_SDK_ENABLE_SIZING_TELEMETRY", default=False
+        ),
+        sizing_telemetry_activities=_name_set(
+            "APPLICATION_SDK_SIZING_TELEMETRY_ACTIVITIES"
         ),
         sizing_telemetry_poll_seconds=_float(
             "APPLICATION_SDK_SIZING_TELEMETRY_POLL_SECONDS", 1.0

--- a/application_sdk/execution/settings.py
+++ b/application_sdk/execution/settings.py
@@ -74,38 +74,27 @@ class InterceptorSettings:
     enable_sizing_telemetry: bool = False
     """Collect per-activity peak memory and CPU throttling for tier sizing.
 
-    Off by default, so an SDK version bump alone changes nothing and collection
-    is a per-tenant decision. This is the "collect data" stage of collect →
-    classify → productionise; it only measures, and never routes.
-
-    A master kill switch, independent of the allow-list below: flipping this to
-    false stops collection without anyone having to edit per-tenant lists.
+    Off by default, so a version bump alone changes nothing. A master switch
+    independent of the allow-list, so collection can be stopped without editing
+    per-tenant lists. Measures only; never routes.
     """
 
     sizing_telemetry_activities: frozenset[str] = frozenset()
-    """Activity names to collect sizing telemetry for. **Empty collects nothing.**
+    """Activity names to measure. **Empty collects nothing.**
 
-    Sizing data is only worth collecting for activities whose resource use varies
-    with the data they process — a merge, a transform, an extract. Most activities
-    are fixed-cost bookkeeping, and measuring them adds rows to the dataset that
-    the tier table is fitted from without adding information.
+    Opt-in by name: only activities whose resource use varies with their data are
+    worth measuring, and rows from fixed-cost ones add no information to the
+    dataset the tier table is fitted from. Empty is also fail-closed, so a
+    half-finished config change collects nothing rather than everything.
 
-    So this is an allow-list an app author opts into by name, not a default-on
-    sweep. Empty means nothing is collected, which is the fail-closed direction:
-    a tenant that sets the enable flag and forgets the list gets no telemetry
-    rather than telemetry on everything.
-
-    ``"*"`` collects every activity. That is the discovery case — worth running on
-    a test tenant to find out *which* activities vary before choosing names, and
-    not something to ship fleet-wide.
+    ``"*"`` measures all of them — a discovery pass on a test tenant.
     """
 
     sizing_telemetry_poll_seconds: float = 1.0
     """Peak-memory poll interval when the kernel watermark is not resettable.
 
-    Two file reads per tick with no RPC. ``0`` disables polling, which leaves
-    peak memory uncollected on any host whose ``memory.peak`` cannot be reset —
-    i.e. most kernels before 6.8 — so only set it to 0 to prove a cost concern.
+    Two file reads per tick, no RPC. ``0`` disables polling, which collects no peak
+    at all on kernels before 6.8 (where ``memory.peak`` is read-only).
     """
 
     enable_cleanup_interceptor: bool = False
@@ -183,17 +172,11 @@ def load_interceptor_settings() -> InterceptorSettings:
                 exc_info=True,
             )
             return default
-        # Negative would mean "poll in the past". Clamp rather than raise: a bad
-        # value on one tenant must not stop its workers from starting.
+        # Clamp rather than raise: a bad value must not stop workers starting.
         return max(0.0, value)
 
     def _name_set(env_var: str) -> frozenset[str]:
-        """Parse a comma-separated activity-name allow-list.
-
-        Tolerant of stray whitespace and empty entries, because this is hand-edited
-        in a Helm values file. Anything unparseable yields an empty set, i.e. no
-        collection — never accidental collection on everything.
-        """
+        """Parse a comma-separated allow-list, tolerating Helm-file whitespace."""
         raw = os.environ.get(env_var, "")
         return frozenset(name.strip() for name in raw.split(",") if name.strip())
 

--- a/application_sdk/execution/settings.py
+++ b/application_sdk/execution/settings.py
@@ -71,6 +71,22 @@ class InterceptorSettings:
     enable_output_interceptor: bool = True
     """Enable structured output collection interceptor (metrics/artifacts)."""
 
+    enable_sizing_telemetry: bool = False
+    """Collect per-activity peak memory and CPU throttling for tier sizing.
+
+    Off by default, so an SDK version bump alone changes nothing and collection
+    is a per-tenant decision. This is the "collect data" stage of collect →
+    classify → productionise; it only measures, and never routes.
+    """
+
+    sizing_telemetry_poll_seconds: float = 1.0
+    """Peak-memory poll interval when the kernel watermark is not resettable.
+
+    Two file reads per tick with no RPC. ``0`` disables polling, which leaves
+    peak memory uncollected on any host whose ``memory.peak`` cannot be reset —
+    i.e. most kernels before 6.8 — so only set it to 0 to prove a cost concern.
+    """
+
     enable_cleanup_interceptor: bool = False
     """Enable temp-directory cleanup interceptor.
 
@@ -131,8 +147,33 @@ def load_interceptor_settings() -> InterceptorSettings:
             return True
         return default
 
+    def _float(env_var: str, default: float) -> float:
+        raw = os.environ.get(env_var, "").strip()
+        if not raw:
+            return default
+        try:
+            value = float(raw)
+        except ValueError:
+            logger.warning(
+                "%s=%r is not a number; using %s",
+                env_var,
+                raw,
+                default,
+                exc_info=True,
+            )
+            return default
+        # Negative would mean "poll in the past". Clamp rather than raise: a bad
+        # value on one tenant must not stop its workers from starting.
+        return max(0.0, value)
+
     return InterceptorSettings(
         enable_event_interceptor=_bool("APPLICATION_SDK_ENABLE_EVENT_INTERCEPTOR"),
         enable_output_interceptor=_bool("APPLICATION_SDK_ENABLE_OUTPUT_INTERCEPTOR"),
+        enable_sizing_telemetry=_bool(
+            "APPLICATION_SDK_ENABLE_SIZING_TELEMETRY", default=False
+        ),
+        sizing_telemetry_poll_seconds=_float(
+            "APPLICATION_SDK_SIZING_TELEMETRY_POLL_SECONDS", 1.0
+        ),
         enable_cleanup_interceptor=_bool("APPLICATION_SDK_ENABLE_CLEANUP_INTERCEPTOR"),
     )

--- a/application_sdk/observability/cgroup.py
+++ b/application_sdk/observability/cgroup.py
@@ -1,31 +1,11 @@
 """Container-level (cgroup) resource readings for activity sizing telemetry.
 
-``resource_sampler`` reads the **process**: ``/proc/self/stat`` RSS and
-``getrusage`` CPU. That is the right instrument for the App Vitals efficiency
-metrics, and the wrong one for deciding how big a pod an activity needs.
+``resource_sampler`` reads the process; sizing needs the container. RSS is not
+what the OOM killer acts on, endpoint samples miss the peak a tier has to cover,
+and CPU seconds cannot tell a cheap activity from a throttled one.
 
-Three gaps, and each one is a wrong answer rather than a missing one:
-
-1. **RSS is not what the OOM killer acts on.** The kernel kills on the cgroup's
-   ``memory.current``, which includes page cache, kernel memory and any child
-   process. An activity that shells out, or that reads a large Parquet file
-   through the page cache, is under-measured by RSS — in the direction that
-   makes a too-small tier look safe.
-2. **Start/end point samples miss the peak.** A tier has to cover the *maximum*
-   an activity reaches, not its value at the moment it finished. A query that
-   builds a 12 GiB hash table and then releases it reads small at both ends.
-   ``compute_deltas`` averages the two endpoints, which is right for a
-   memory-time integral and useless for sizing.
-3. **CPU seconds cannot distinguish "cheap" from "starved".** An activity given
-   a 1-core quota and needing 3 will report ~1 core-second per wall second and
-   look perfectly sized. ``cpu.stat``'s throttling counters are the only signal
-   that separates the two, and they are the reason a CPU tier can be raised on
-   evidence instead of on a guess.
-
-Everything here returns ``None`` rather than raising or guessing. cgroup reads
-are genuinely fragile — vcluster and some managed runtimes expose a partial
-hierarchy — and a missing reading has to stay distinguishable from a zero one:
-sizing on a silent 0 would recommend the smallest tier for every activity.
+Every reader returns ``None`` rather than raising or guessing — a missing reading
+must stay distinguishable from a zero, or sizing picks the smallest tier.
 """
 
 from __future__ import annotations
@@ -41,9 +21,7 @@ from application_sdk.observability.resource_sampler import parse_pod_memory_limi
 
 _logger = get_logger(__name__)
 
-# cgroup v2 first, then the v1 hierarchy. Order matters: a host running v2 with
-# the v1 compatibility mounts still present must read the v2 values, because
-# those are the ones the kernel is enforcing.
+# v2 first: a host with both mounted must read v2, which is what the kernel enforces.
 _MEMORY_CURRENT_PATHS = (
     "/sys/fs/cgroup/memory.current",
     "/sys/fs/cgroup/memory/memory.usage_in_bytes",
@@ -65,9 +43,8 @@ _CPU_MAX_V2 = "/sys/fs/cgroup/cpu.max"
 _CPU_QUOTA_V1 = "/sys/fs/cgroup/cpu/cpu.cfs_quota_us"
 _CPU_PERIOD_V1 = "/sys/fs/cgroup/cpu/cpu.cfs_period_us"
 
-# v1 writes "no limit" as a near-2**63 sentinel rather than a word. Anything at
-# or above this is "unlimited", which for sizing purposes means "unknown" — the
-# pod is bounded by the node, and the node's size is not this activity's budget.
+# v1 spells "no limit" as a near-2**63 sentinel, not a word. At or above this is
+# unlimited, which for sizing means unknown.
 _V1_UNLIMITED_FLOOR = 1 << 62
 
 
@@ -103,25 +80,15 @@ def _read_int(paths: tuple[str, ...]) -> int | None:
 
 
 def memory_usage_bytes() -> int | None:
-    """Current container memory usage, or ``None`` if unreadable.
-
-    This is the counter the kernel OOM killer acts on, which is why it — not
-    RSS — is the number a memory tier has to cover.
-    """
+    """Current container memory usage — the counter the OOM killer acts on."""
     return _read_int(_MEMORY_CURRENT_PATHS)
 
 
 def memory_limit_bytes() -> int | None:
-    """The container's memory limit in bytes, or ``None``.
+    """Container memory limit, or ``None`` if unlimited/unknown.
 
-    Prefers the cgroup, then falls back to ``K8S_POD_MEMORY_LIMIT`` — the env var
-    the rest of the SDK already reads (``main``, ``execution.heartbeat``). The
-    cgroup comes first because it reflects what the kernel is enforcing; the env
-    var reflects what the manifest asked for, and they diverge whenever a
-    mutating admission controller or a VPA is in play.
-
-    ``None`` for an unlimited cgroup: an unbounded container is bounded only by
-    its node, and a node's size is not this activity's budget.
+    cgroup first (what the kernel enforces), then ``K8S_POD_MEMORY_LIMIT`` (what
+    the manifest asked for) — they diverge under a VPA or mutating webhook.
     """
     value = _read_int(_MEMORY_LIMIT_PATHS)
     if value is not None and 0 < value < _V1_UNLIMITED_FLOOR:
@@ -142,31 +109,22 @@ def memory_fraction() -> float | None:
 
 
 def memory_peak_bytes() -> int | None:
-    """The kernel's high-water mark for this cgroup, or ``None``.
+    """Kernel high-water mark, cumulative since creation or the last reset.
 
-    Cumulative since the cgroup was created **or since the last successful
-    reset**. On a worker that runs activities back to back the un-reset value is
-    a pod-lifetime watermark and therefore not attributable to any one activity
-    — which is exactly what :func:`reset_memory_peak` exists to fix.
+    Un-reset it is a pod-lifetime figure, attributable to no single activity —
+    see :func:`reset_memory_peak`.
     """
     return _read_int(_MEMORY_PEAK_PATHS)
 
 
 def reset_memory_peak() -> bool:
-    """Try to reset the kernel high-water mark. Returns whether it was *proven*.
+    """Reset the kernel high-water mark; returns whether the reset was *proven*.
 
-    A proven reset is worth a lot: it makes per-activity peak memory a **two
-    file reads per activity** measurement instead of a background poller ticking
-    every second in every worker in the fleet.
-
-    Proof, not version-sniffing. ``memory.peak`` is only writable from Linux 6.8,
-    a kernel write can succeed and be a no-op, and the v1/v2 split makes any
-    version table unreliable — so this reads the watermark back and requires it
-    to have actually dropped. If the watermark is already sitting at current
-    usage there is no drop to observe, so the reset is unprovable and this
-    returns ``False``; the caller falls back to polling, which is correct but
-    more expensive. That is the safe direction: an unproven reset would report
-    the pod's lifetime watermark as this activity's peak.
+    Proof, not version-sniffing: ``memory.peak`` is only writable from Linux 6.8
+    and a write can succeed as a no-op, so the value is read back and must have
+    dropped. Unprovable (watermark already at current usage) returns ``False``
+    and the caller polls instead — an unproven reset would report the pod's
+    lifetime watermark as this activity's peak.
     """
     before = memory_peak_bytes()
     if before is None:
@@ -191,12 +149,10 @@ def reset_memory_peak() -> bool:
 
 @dataclass(frozen=True)
 class CpuStat:
-    """A point-in-time read of the container's CPU accounting.
+    """Point-in-time container CPU accounting.
 
-    ``throttled_seconds`` is the one that matters for sizing: it is wall-clock
-    time during which runnable threads were held off the CPU because the quota
-    was exhausted. Unlike ``usage_seconds`` it cannot be confused with an
-    activity that is simply cheap.
+    ``throttled_seconds`` is the sizing signal: time runnable threads were held
+    off the CPU. Unlike ``usage_seconds`` it cannot be confused with cheapness.
     """
 
     usage_seconds: float
@@ -206,12 +162,11 @@ class CpuStat:
 
 
 def cpu_stat() -> CpuStat | None:
-    """Read container CPU usage and throttling, or ``None`` if unreadable.
+    """Container CPU usage and throttling, or ``None``.
 
-    v2 exposes everything in one ``cpu.stat`` in microseconds. v1 splits usage
-    into ``cpuacct.usage`` (nanoseconds) and throttling into ``cpu/cpu.stat``
-    (``throttled_time``, nanoseconds), so the two halves are read separately and
-    a v1 host missing ``cpuacct`` still yields the throttling counters.
+    v2 puts everything in ``cpu.stat`` (microseconds). v1 splits usage into
+    ``cpuacct.usage`` and throttling into ``cpu/cpu.stat`` (both nanoseconds),
+    read separately so a missing ``cpuacct`` still yields throttling.
     """
     raw = _read_first((_CPU_STAT_V2,))
     if raw:
@@ -253,11 +208,7 @@ def _parse_kv(raw: str) -> dict[str, float]:
 
 
 def cpu_quota_cores() -> float | None:
-    """The container's CPU limit in cores, or ``None`` if unlimited/unreadable.
-
-    The denominator for "was this activity starved": throttling only makes sense
-    against the quota that caused it.
-    """
+    """CPU limit in cores, or ``None``. The denominator for throttling."""
     raw = _read_first((_CPU_MAX_V2,))
     if raw:
         parts = raw.split()
@@ -280,12 +231,11 @@ def cpu_quota_cores() -> float | None:
 
 @dataclass
 class ContainerTrace:
-    """What one activity actually consumed, as measured at the container.
+    """What one activity consumed, measured at the container.
 
-    Deliberately records ``peak_source``. A peak from a reset kernel watermark
-    and a peak from a 1-second poller are not the same measurement — the poller
-    misses any spike shorter than its interval — and a tier derived from the two
-    mixed together would be tuned to an unknown blend of the two error profiles.
+    Records ``peak_source``: a watermark peak and a polled peak have different
+    blind spots (the poller misses sub-interval spikes), so a tier fitted to a
+    silent mix of the two is fitted to an unknown error profile.
     """
 
     peak_memory_bytes: int | None = None
@@ -310,12 +260,7 @@ class ContainerTrace:
 
     @property
     def throttled_fraction(self) -> float | None:
-        """Share of scheduling periods in which the quota was exhausted.
-
-        The headline CPU-starvation number. Above roughly 0.1 the activity spent
-        a tenth of its life waiting for CPU it was entitled to ask for, which is
-        a tier problem rather than a code problem.
-        """
+        """Share of CFS periods that exhausted the quota — the starvation number."""
         if not self.cpu_periods or self.cpu_throttled_periods is None:
             return None
         return self.cpu_throttled_periods / self.cpu_periods
@@ -327,34 +272,20 @@ async def track_container_usage(
 ) -> AsyncIterator[ContainerTrace]:
     """Measure peak memory and CPU throttling across a block.
 
-    Picks the cheapest instrument that works:
+    Picks the cheapest instrument that works, recorded as ``peak_source``:
+    ``watermark`` (reset + read, catches spikes of any duration), ``poll``
+    (background sampling, only when the reset was unprovable), or ``unavailable``
+    (no cgroup — trace stays ``None``, which is "no data", not zero).
 
-    * **watermark** — the kernel's ``memory.peak`` is reset on entry and read on
-      exit. Two reads per activity, and it catches spikes of *any* duration.
-    * **poll** — a background task samples ``memory.current``. Used only when the
-      watermark could not be reset, because an un-reset watermark reports the
-      pod's whole life rather than this activity.
-    * **unavailable** — no cgroup at all (macOS, most local dev). The block runs
-      untouched and the trace stays ``None``, which downstream must read as "no
-      data" and not as zero.
-
-    Never raises, and never fails the wrapped block: this is telemetry, and an
-    activity that succeeded must not be turned into a failure by the thing
-    measuring it. Note the contrast with AE's ``report_memory_pressure``, whose
-    watchdog raises *on purpose* — that one is a safety device, this one is an
-    instrument.
-
-    ``poll_interval_seconds <= 0`` disables polling entirely, so a fleet-wide
-    rollout can take the free watermark path and nothing else.
+    Never raises and never fails the wrapped block. ``poll_interval_seconds <= 0``
+    disables polling.
     """
     trace = ContainerTrace()
     start_cpu: CpuStat | None = None
     task: asyncio.Task[None] | None = None
 
-    # Guarded as a whole, not read by read. Every line below touches the cgroup
-    # or the event loop, and the block it wraps has to run either way — an
-    # unguarded setup read is the one place this instrument could still fail the
-    # activity it is measuring, which a test now pins.
+    # Guarded as a whole: an unguarded setup read is the one place this could
+    # still fail the activity it measures.
     try:
         trace.memory_limit_bytes = memory_limit_bytes()
         start_cpu = cpu_stat()
@@ -387,9 +318,8 @@ async def track_container_usage(
     finally:
         if task is not None:
             task.cancel()
-            # Suppresses Exception too, not just CancelledError: if a cgroup read
-            # blew up inside the poller, ``await task`` re-raises it here — on the
-            # exit path of an activity that may well have succeeded.
+            # Exception too, not just CancelledError: a cgroup read that blew up
+            # inside the poller would be re-raised here by ``await task``.
             # conformance: ignore[E003] deliberate; the poller's failure is telemetry loss and must not become the activity's failure
             with contextlib.suppress(asyncio.CancelledError, Exception):
                 await task
@@ -397,18 +327,12 @@ async def track_container_usage(
 
 
 def _finalise(trace: ContainerTrace, start_cpu: CpuStat | None) -> None:
-    """Close out a trace: read the watermark and difference the CPU counters.
-
-    Wrapped whole in a guard for the same reason the sampler is: a telemetry
-    read failing at the end of a successful activity must not surface as a
-    failure of that activity.
-    """
+    """Read the watermark and difference the CPU counters. Never raises."""
     try:
         if trace.peak_source == "watermark":
             trace.observe(memory_peak_bytes(), trace.memory_limit_bytes)
         elif trace.peak_source == "poll":
-            # One final reading, so a block shorter than the poll interval still
-            # produces a number instead of a None.
+            # Final reading, so a block shorter than the interval still yields a number.
             trace.observe(memory_usage_bytes(), trace.memory_limit_bytes)
 
         end_cpu = cpu_stat()

--- a/application_sdk/observability/cgroup.py
+++ b/application_sdk/observability/cgroup.py
@@ -77,8 +77,7 @@ def _read_first(paths: tuple[str, ...]) -> str | None:
         try:
             with open(path) as fh:
                 return fh.read().strip()
-        # conformance: ignore[E004] a missing cgroup file is the expected case off
-        # Linux and under partial hierarchies; None is the meaningful answer.
+        # conformance: ignore[E014] a missing cgroup file is the expected case off Linux and under partial hierarchies; None is the meaningful answer, and logging per read would fire on every call
         except OSError:
             continue
     return None
@@ -90,14 +89,13 @@ def _read_int(paths: tuple[str, ...]) -> int | None:
         try:
             with open(path) as fh:
                 raw = fh.read().strip()
-        # conformance: ignore[E004] see _read_first; a partial hierarchy must not raise.
+        # conformance: ignore[E014] see _read_first; a partial hierarchy must not raise and must not log per read
         except OSError:
             continue
         try:
             value = int(raw)
+        # conformance: ignore[E014] "max" (v2 unlimited) and an empty file both land here; both mean "no usable number" and must let a later path be tried
         except ValueError:
-            # "max" (v2 unlimited) lands here, as does an empty file. Both mean
-            # "no usable number", and both should let a later path be tried.
             continue
         if value >= 0:
             return value
@@ -182,8 +180,7 @@ def reset_memory_peak() -> bool:
         try:
             with open(path, "w") as fh:
                 fh.write("0")
-        # conformance: ignore[E004] read-only on <6.8 and absent off Linux; both
-        # are expected and mean "fall back to polling".
+        # conformance: ignore[E014] read-only before Linux 6.8 and absent off Linux; both are expected and mean "fall back to polling"
         except OSError:
             continue
         after = memory_peak_bytes()
@@ -268,9 +265,10 @@ def cpu_quota_cores() -> float | None:
             try:
                 quota, period = float(parts[0]), float(parts[1])
             except ValueError:
-                quota = period = 0.0
-            if quota > 0 and period > 0:
-                return quota / period
+                _logger.debug("unparseable cpu.max: %r", raw, exc_info=True)
+            else:
+                if quota > 0 and period > 0:
+                    return quota / period
 
     quota_us = _read_int((_CPU_QUOTA_V1,))
     period_us = _read_int((_CPU_PERIOD_V1,))
@@ -380,6 +378,7 @@ async def track_container_usage(
             task = asyncio.create_task(_poll())
         else:
             trace.peak_source = "unavailable"
+    # conformance: ignore[E004] telemetry setup; an instrument must never fail the block it measures
     except Exception:
         _logger.debug("container usage setup failed", exc_info=True)
 
@@ -391,8 +390,7 @@ async def track_container_usage(
             # Suppresses Exception too, not just CancelledError: if a cgroup read
             # blew up inside the poller, ``await task`` re-raises it here — on the
             # exit path of an activity that may well have succeeded.
-            # conformance: ignore[E004] deliberate; the poller's failure is
-            # telemetry loss and must not become the activity's failure.
+            # conformance: ignore[E003] deliberate; the poller's failure is telemetry loss and must not become the activity's failure
             with contextlib.suppress(asyncio.CancelledError, Exception):
                 await task
         _finalise(trace, start_cpu)
@@ -425,5 +423,6 @@ def _finalise(trace: ContainerTrace, start_cpu: CpuStat | None) -> None:
                 0, end_cpu.nr_throttled - start_cpu.nr_throttled
             )
             trace.cpu_periods = max(0, end_cpu.nr_periods - start_cpu.nr_periods)
+    # conformance: ignore[E004] telemetry finalisation; runs after a successful activity and must not turn it into a failure
     except Exception:
         _logger.debug("container usage finalisation failed", exc_info=True)

--- a/application_sdk/observability/cgroup.py
+++ b/application_sdk/observability/cgroup.py
@@ -1,0 +1,429 @@
+"""Container-level (cgroup) resource readings for activity sizing telemetry.
+
+``resource_sampler`` reads the **process**: ``/proc/self/stat`` RSS and
+``getrusage`` CPU. That is the right instrument for the App Vitals efficiency
+metrics, and the wrong one for deciding how big a pod an activity needs.
+
+Three gaps, and each one is a wrong answer rather than a missing one:
+
+1. **RSS is not what the OOM killer acts on.** The kernel kills on the cgroup's
+   ``memory.current``, which includes page cache, kernel memory and any child
+   process. An activity that shells out, or that reads a large Parquet file
+   through the page cache, is under-measured by RSS — in the direction that
+   makes a too-small tier look safe.
+2. **Start/end point samples miss the peak.** A tier has to cover the *maximum*
+   an activity reaches, not its value at the moment it finished. A query that
+   builds a 12 GiB hash table and then releases it reads small at both ends.
+   ``compute_deltas`` averages the two endpoints, which is right for a
+   memory-time integral and useless for sizing.
+3. **CPU seconds cannot distinguish "cheap" from "starved".** An activity given
+   a 1-core quota and needing 3 will report ~1 core-second per wall second and
+   look perfectly sized. ``cpu.stat``'s throttling counters are the only signal
+   that separates the two, and they are the reason a CPU tier can be raised on
+   evidence instead of on a guess.
+
+Everything here returns ``None`` rather than raising or guessing. cgroup reads
+are genuinely fragile — vcluster and some managed runtimes expose a partial
+hierarchy — and a missing reading has to stay distinguishable from a zero one:
+sizing on a silent 0 would recommend the smallest tier for every activity.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import os
+from collections.abc import AsyncIterator
+from dataclasses import dataclass, field
+
+from application_sdk.observability.logger_adaptor import get_logger
+from application_sdk.observability.resource_sampler import parse_pod_memory_limit
+
+_logger = get_logger(__name__)
+
+# cgroup v2 first, then the v1 hierarchy. Order matters: a host running v2 with
+# the v1 compatibility mounts still present must read the v2 values, because
+# those are the ones the kernel is enforcing.
+_MEMORY_CURRENT_PATHS = (
+    "/sys/fs/cgroup/memory.current",
+    "/sys/fs/cgroup/memory/memory.usage_in_bytes",
+)
+_MEMORY_LIMIT_PATHS = (
+    "/sys/fs/cgroup/memory.max",
+    "/sys/fs/cgroup/memory/memory.limit_in_bytes",
+)
+# v2 ``memory.peak`` landed in 5.19 and became writable (resettable) in 6.8.
+# v1 ``memory.max_usage_in_bytes`` has always been resettable by writing 0.
+_MEMORY_PEAK_PATHS = (
+    "/sys/fs/cgroup/memory.peak",
+    "/sys/fs/cgroup/memory/memory.max_usage_in_bytes",
+)
+_CPU_STAT_V2 = "/sys/fs/cgroup/cpu.stat"
+_CPU_STAT_V1 = "/sys/fs/cgroup/cpu/cpu.stat"
+_CPUACCT_USAGE_V1 = "/sys/fs/cgroup/cpuacct/cpuacct.usage"
+_CPU_MAX_V2 = "/sys/fs/cgroup/cpu.max"
+_CPU_QUOTA_V1 = "/sys/fs/cgroup/cpu/cpu.cfs_quota_us"
+_CPU_PERIOD_V1 = "/sys/fs/cgroup/cpu/cpu.cfs_period_us"
+
+# v1 writes "no limit" as a near-2**63 sentinel rather than a word. Anything at
+# or above this is "unlimited", which for sizing purposes means "unknown" — the
+# pod is bounded by the node, and the node's size is not this activity's budget.
+_V1_UNLIMITED_FLOOR = 1 << 62
+
+
+def _read_first(paths: tuple[str, ...]) -> str | None:
+    """Contents of the first readable path, stripped, or ``None``."""
+    for path in paths:
+        try:
+            with open(path) as fh:
+                return fh.read().strip()
+        # conformance: ignore[E004] a missing cgroup file is the expected case off
+        # Linux and under partial hierarchies; None is the meaningful answer.
+        except OSError:
+            continue
+    return None
+
+
+def _read_int(paths: tuple[str, ...]) -> int | None:
+    """First readable path parsed as a non-negative int, or ``None``."""
+    for path in paths:
+        try:
+            with open(path) as fh:
+                raw = fh.read().strip()
+        # conformance: ignore[E004] see _read_first; a partial hierarchy must not raise.
+        except OSError:
+            continue
+        try:
+            value = int(raw)
+        except ValueError:
+            # "max" (v2 unlimited) lands here, as does an empty file. Both mean
+            # "no usable number", and both should let a later path be tried.
+            continue
+        if value >= 0:
+            return value
+    return None
+
+
+def memory_usage_bytes() -> int | None:
+    """Current container memory usage, or ``None`` if unreadable.
+
+    This is the counter the kernel OOM killer acts on, which is why it — not
+    RSS — is the number a memory tier has to cover.
+    """
+    return _read_int(_MEMORY_CURRENT_PATHS)
+
+
+def memory_limit_bytes() -> int | None:
+    """The container's memory limit in bytes, or ``None``.
+
+    Prefers the cgroup, then falls back to ``K8S_POD_MEMORY_LIMIT`` — the env var
+    the rest of the SDK already reads (``main``, ``execution.heartbeat``). The
+    cgroup comes first because it reflects what the kernel is enforcing; the env
+    var reflects what the manifest asked for, and they diverge whenever a
+    mutating admission controller or a VPA is in play.
+
+    ``None`` for an unlimited cgroup: an unbounded container is bounded only by
+    its node, and a node's size is not this activity's budget.
+    """
+    value = _read_int(_MEMORY_LIMIT_PATHS)
+    if value is not None and 0 < value < _V1_UNLIMITED_FLOOR:
+        return value
+    env = parse_pod_memory_limit(os.environ.get("K8S_POD_MEMORY_LIMIT", ""))
+    return env if env > 0 else None
+
+
+def memory_fraction() -> float | None:
+    """Usage as a fraction of the limit, or ``None`` if either side is unknown."""
+    limit = memory_limit_bytes()
+    if not limit or limit <= 0:
+        return None
+    used = memory_usage_bytes()
+    if used is None:
+        return None
+    return used / limit
+
+
+def memory_peak_bytes() -> int | None:
+    """The kernel's high-water mark for this cgroup, or ``None``.
+
+    Cumulative since the cgroup was created **or since the last successful
+    reset**. On a worker that runs activities back to back the un-reset value is
+    a pod-lifetime watermark and therefore not attributable to any one activity
+    — which is exactly what :func:`reset_memory_peak` exists to fix.
+    """
+    return _read_int(_MEMORY_PEAK_PATHS)
+
+
+def reset_memory_peak() -> bool:
+    """Try to reset the kernel high-water mark. Returns whether it was *proven*.
+
+    A proven reset is worth a lot: it makes per-activity peak memory a **two
+    file reads per activity** measurement instead of a background poller ticking
+    every second in every worker in the fleet.
+
+    Proof, not version-sniffing. ``memory.peak`` is only writable from Linux 6.8,
+    a kernel write can succeed and be a no-op, and the v1/v2 split makes any
+    version table unreliable — so this reads the watermark back and requires it
+    to have actually dropped. If the watermark is already sitting at current
+    usage there is no drop to observe, so the reset is unprovable and this
+    returns ``False``; the caller falls back to polling, which is correct but
+    more expensive. That is the safe direction: an unproven reset would report
+    the pod's lifetime watermark as this activity's peak.
+    """
+    before = memory_peak_bytes()
+    if before is None:
+        return False
+    current = memory_usage_bytes()
+    if current is None or before <= current:
+        # No headroom between the watermark and current usage, so a successful
+        # reset would be indistinguishable from a silent no-op.
+        return False
+    for path in _MEMORY_PEAK_PATHS:
+        try:
+            with open(path, "w") as fh:
+                fh.write("0")
+        # conformance: ignore[E004] read-only on <6.8 and absent off Linux; both
+        # are expected and mean "fall back to polling".
+        except OSError:
+            continue
+        after = memory_peak_bytes()
+        if after is not None and after < before:
+            return True
+    return False
+
+
+@dataclass(frozen=True)
+class CpuStat:
+    """A point-in-time read of the container's CPU accounting.
+
+    ``throttled_seconds`` is the one that matters for sizing: it is wall-clock
+    time during which runnable threads were held off the CPU because the quota
+    was exhausted. Unlike ``usage_seconds`` it cannot be confused with an
+    activity that is simply cheap.
+    """
+
+    usage_seconds: float
+    nr_periods: int
+    nr_throttled: int
+    throttled_seconds: float
+
+
+def cpu_stat() -> CpuStat | None:
+    """Read container CPU usage and throttling, or ``None`` if unreadable.
+
+    v2 exposes everything in one ``cpu.stat`` in microseconds. v1 splits usage
+    into ``cpuacct.usage`` (nanoseconds) and throttling into ``cpu/cpu.stat``
+    (``throttled_time``, nanoseconds), so the two halves are read separately and
+    a v1 host missing ``cpuacct`` still yields the throttling counters.
+    """
+    raw = _read_first((_CPU_STAT_V2,))
+    if raw:
+        fields = _parse_kv(raw)
+        usage_usec = fields.get("usage_usec")
+        if usage_usec is not None:
+            return CpuStat(
+                usage_seconds=usage_usec / 1e6,
+                nr_periods=int(fields.get("nr_periods", 0)),
+                nr_throttled=int(fields.get("nr_throttled", 0)),
+                throttled_seconds=fields.get("throttled_usec", 0) / 1e6,
+            )
+
+    raw = _read_first((_CPU_STAT_V1,))
+    if raw is None:
+        return None
+    fields = _parse_kv(raw)
+    usage_ns = _read_int((_CPUACCT_USAGE_V1,))
+    return CpuStat(
+        usage_seconds=(usage_ns / 1e9) if usage_ns is not None else 0.0,
+        nr_periods=int(fields.get("nr_periods", 0)),
+        nr_throttled=int(fields.get("nr_throttled", 0)),
+        throttled_seconds=fields.get("throttled_time", 0) / 1e9,
+    )
+
+
+def _parse_kv(raw: str) -> dict[str, float]:
+    """Parse ``key value`` lines, skipping anything non-numeric."""
+    out: dict[str, float] = {}
+    for line in raw.splitlines():
+        parts = line.split()
+        if len(parts) != 2:
+            continue
+        try:
+            out[parts[0]] = float(parts[1])
+        except ValueError:
+            continue
+    return out
+
+
+def cpu_quota_cores() -> float | None:
+    """The container's CPU limit in cores, or ``None`` if unlimited/unreadable.
+
+    The denominator for "was this activity starved": throttling only makes sense
+    against the quota that caused it.
+    """
+    raw = _read_first((_CPU_MAX_V2,))
+    if raw:
+        parts = raw.split()
+        if len(parts) == 2 and parts[0] != "max":
+            try:
+                quota, period = float(parts[0]), float(parts[1])
+            except ValueError:
+                quota = period = 0.0
+            if quota > 0 and period > 0:
+                return quota / period
+
+    quota_us = _read_int((_CPU_QUOTA_V1,))
+    period_us = _read_int((_CPU_PERIOD_V1,))
+    # v1 writes -1 for unlimited, which _read_int already rejects as negative.
+    if quota_us and period_us and quota_us > 0 and period_us > 0:
+        return quota_us / period_us
+    return None
+
+
+@dataclass
+class ContainerTrace:
+    """What one activity actually consumed, as measured at the container.
+
+    Deliberately records ``peak_source``. A peak from a reset kernel watermark
+    and a peak from a 1-second poller are not the same measurement — the poller
+    misses any spike shorter than its interval — and a tier derived from the two
+    mixed together would be tuned to an unknown blend of the two error profiles.
+    """
+
+    peak_memory_bytes: int | None = None
+    peak_memory_fraction: float | None = None
+    peak_source: str = "unavailable"
+    memory_limit_bytes: int | None = None
+    cpu_seconds: float | None = None
+    cpu_throttled_seconds: float | None = None
+    cpu_throttled_periods: int | None = None
+    cpu_periods: int | None = None
+    cpu_quota_cores: float | None = None
+    samples: list[float] = field(default_factory=list)
+
+    def observe(self, used: int | None, limit: int | None) -> None:
+        """Fold one memory reading into the peak."""
+        if used is None:
+            return
+        if self.peak_memory_bytes is None or used > self.peak_memory_bytes:
+            self.peak_memory_bytes = used
+            if limit:
+                self.peak_memory_fraction = used / limit
+
+    @property
+    def throttled_fraction(self) -> float | None:
+        """Share of scheduling periods in which the quota was exhausted.
+
+        The headline CPU-starvation number. Above roughly 0.1 the activity spent
+        a tenth of its life waiting for CPU it was entitled to ask for, which is
+        a tier problem rather than a code problem.
+        """
+        if not self.cpu_periods or self.cpu_throttled_periods is None:
+            return None
+        return self.cpu_throttled_periods / self.cpu_periods
+
+
+@contextlib.asynccontextmanager
+async def track_container_usage(
+    poll_interval_seconds: float = 1.0,
+) -> AsyncIterator[ContainerTrace]:
+    """Measure peak memory and CPU throttling across a block.
+
+    Picks the cheapest instrument that works:
+
+    * **watermark** — the kernel's ``memory.peak`` is reset on entry and read on
+      exit. Two reads per activity, and it catches spikes of *any* duration.
+    * **poll** — a background task samples ``memory.current``. Used only when the
+      watermark could not be reset, because an un-reset watermark reports the
+      pod's whole life rather than this activity.
+    * **unavailable** — no cgroup at all (macOS, most local dev). The block runs
+      untouched and the trace stays ``None``, which downstream must read as "no
+      data" and not as zero.
+
+    Never raises, and never fails the wrapped block: this is telemetry, and an
+    activity that succeeded must not be turned into a failure by the thing
+    measuring it. Note the contrast with AE's ``report_memory_pressure``, whose
+    watchdog raises *on purpose* — that one is a safety device, this one is an
+    instrument.
+
+    ``poll_interval_seconds <= 0`` disables polling entirely, so a fleet-wide
+    rollout can take the free watermark path and nothing else.
+    """
+    trace = ContainerTrace()
+    start_cpu: CpuStat | None = None
+    task: asyncio.Task[None] | None = None
+
+    # Guarded as a whole, not read by read. Every line below touches the cgroup
+    # or the event loop, and the block it wraps has to run either way — an
+    # unguarded setup read is the one place this instrument could still fail the
+    # activity it is measuring, which a test now pins.
+    try:
+        trace.memory_limit_bytes = memory_limit_bytes()
+        start_cpu = cpu_stat()
+        trace.cpu_quota_cores = cpu_quota_cores()
+
+        if memory_usage_bytes() is None:
+            trace.peak_source = "unavailable"
+        elif reset_memory_peak():
+            trace.peak_source = "watermark"
+        elif poll_interval_seconds > 0:
+            trace.peak_source = "poll"
+
+            async def _poll() -> None:
+                while True:
+                    await asyncio.sleep(poll_interval_seconds)
+                    used = memory_usage_bytes()
+                    trace.observe(used, trace.memory_limit_bytes)
+                    if used is not None and trace.memory_limit_bytes:
+                        trace.samples.append(used / trace.memory_limit_bytes)
+
+            task = asyncio.create_task(_poll())
+        else:
+            trace.peak_source = "unavailable"
+    except Exception:
+        _logger.debug("container usage setup failed", exc_info=True)
+
+    try:
+        yield trace
+    finally:
+        if task is not None:
+            task.cancel()
+            # Suppresses Exception too, not just CancelledError: if a cgroup read
+            # blew up inside the poller, ``await task`` re-raises it here — on the
+            # exit path of an activity that may well have succeeded.
+            # conformance: ignore[E004] deliberate; the poller's failure is
+            # telemetry loss and must not become the activity's failure.
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await task
+        _finalise(trace, start_cpu)
+
+
+def _finalise(trace: ContainerTrace, start_cpu: CpuStat | None) -> None:
+    """Close out a trace: read the watermark and difference the CPU counters.
+
+    Wrapped whole in a guard for the same reason the sampler is: a telemetry
+    read failing at the end of a successful activity must not surface as a
+    failure of that activity.
+    """
+    try:
+        if trace.peak_source == "watermark":
+            trace.observe(memory_peak_bytes(), trace.memory_limit_bytes)
+        elif trace.peak_source == "poll":
+            # One final reading, so a block shorter than the poll interval still
+            # produces a number instead of a None.
+            trace.observe(memory_usage_bytes(), trace.memory_limit_bytes)
+
+        end_cpu = cpu_stat()
+        if start_cpu is not None and end_cpu is not None:
+            trace.cpu_seconds = max(
+                0.0, end_cpu.usage_seconds - start_cpu.usage_seconds
+            )
+            trace.cpu_throttled_seconds = max(
+                0.0, end_cpu.throttled_seconds - start_cpu.throttled_seconds
+            )
+            trace.cpu_throttled_periods = max(
+                0, end_cpu.nr_throttled - start_cpu.nr_throttled
+            )
+            trace.cpu_periods = max(0, end_cpu.nr_periods - start_cpu.nr_periods)
+    except Exception:
+        _logger.debug("container usage finalisation failed", exc_info=True)

--- a/application_sdk/observability/cgroup.py
+++ b/application_sdk/observability/cgroup.py
@@ -269,6 +269,7 @@ class ContainerTrace:
 @contextlib.asynccontextmanager
 async def track_container_usage(
     poll_interval_seconds: float = 1.0,
+    allow_watermark_reset: bool = True,
 ) -> AsyncIterator[ContainerTrace]:
     """Measure peak memory and CPU throttling across a block.
 
@@ -276,6 +277,11 @@ async def track_container_usage(
     ``watermark`` (reset + read, catches spikes of any duration), ``poll``
     (background sampling, only when the reset was unprovable), or ``unavailable``
     (no cgroup — trace stays ``None``, which is "no data", not zero).
+
+    ``allow_watermark_reset=False`` forbids the reset. Pass it when more than one
+    activity shares this process: ``memory.peak`` is a single kernel counter, so two
+    activities resetting it means each reads a peak measured from the *other's*
+    reset — wrong in an unpredictable direction, where polling is merely pod-wide.
 
     Never raises and never fails the wrapped block. ``poll_interval_seconds <= 0``
     disables polling.
@@ -293,7 +299,7 @@ async def track_container_usage(
 
         if memory_usage_bytes() is None:
             trace.peak_source = "unavailable"
-        elif reset_memory_peak():
+        elif allow_watermark_reset and reset_memory_peak():
             trace.peak_source = "watermark"
         elif poll_interval_seconds > 0:
             trace.peak_source = "poll"

--- a/application_sdk/observability/observability.py
+++ b/application_sdk/observability/observability.py
@@ -204,6 +204,19 @@ class AtlanObservability(Generic[T], ABC):
             return "sizing"
         return "other"
 
+    def _store_sink_enabled(self) -> bool:
+        """Whether this signal writes to the object store at all.
+
+        Overridable because ``ATLAN_ENABLE_OBSERVABILITY_STORE_SINK`` is one switch
+        over three very different signals. An app that turns it off to stop shipping
+        logs and metrics — AE does, via the ``ATLAN_ENABLE_OBSERVABILITY_DAPR_SINK``
+        fallback — would also silently lose a signal it explicitly opted into, with
+        no error and an empty dataset as the only symptom.
+
+        A subclass may return ``True`` when it is already gated by its own switch.
+        """
+        return ENABLE_OBSERVABILITY_STORE_SINK
+
     def _get_partition_path(self, timestamp: datetime) -> str:
         """Generate local partition path based on timestamp.
 
@@ -393,7 +406,7 @@ class AtlanObservability(Generic[T], ABC):
         - Uploads to customer bucket (DEPLOYMENT_OBJECT_STORE) always
         - Uploads to Atlan bucket (UPSTREAM_OBJECT_STORE) when ``ENABLE_ATLAN_UPLOAD=true``
         """
-        if not ENABLE_OBSERVABILITY_STORE_SINK or not records:
+        if not self._store_sink_enabled() or not records:
             return
 
         # File I/O is restricted inside Temporal's workflow sandbox — skip the

--- a/application_sdk/observability/observability.py
+++ b/application_sdk/observability/observability.py
@@ -23,6 +23,7 @@ from application_sdk.constants import (
     ENABLE_OBSERVABILITY_STORE_SINK,
     LOG_FILE_NAME,
     METRICS_FILE_NAME,
+    SIZING_FILE_NAME,
     TRACES_FILE_NAME,
     UPSTREAM_OBJECT_STORE_NAME,
 )
@@ -38,6 +39,10 @@ LOCAL_OBS_SUBDIR_MAP = {
     "logs": f"{_OBS_MODE}/logs",
     "metrics": f"{_OBS_MODE}/metrics",
     "traces": f"{_OBS_MODE}/traces",
+    # Must be added alongside the S3 prefix below, not just there: the local dir and
+    # the remote key are derived from two different maps, and a signal present in
+    # only one writes to ``other/`` locally while uploading to ``sizing/``.
+    "sizing": f"{_OBS_MODE}/sizing",
 }
 
 # Map of signal type → S3 remote key prefix
@@ -45,6 +50,10 @@ OBSERVABILITY_S3_PREFIX_MAP = {
     "logs": f"artifacts/apps/observability/{_OBS_MODE}/logs",
     "metrics": f"artifacts/apps/observability/{_OBS_MODE}/metrics",
     "traces": f"artifacts/apps/observability/{_OBS_MODE}/traces",
+    # Its own prefix rather than the "other" fallback: this is the dataset tier
+    # envelopes get fitted from, and it has to be selectable across tenants without
+    # first filtering out whatever else lands in "other".
+    "sizing": f"artifacts/apps/observability/{_OBS_MODE}/sizing",
 }
 
 
@@ -180,7 +189,7 @@ class AtlanObservability(Generic[T], ABC):
         cls._upstream_store = None
 
     def _get_signal_type(self) -> str:
-        """Map file_name to signal type (logs, metrics, traces).
+        """Map file_name to signal type (logs, metrics, traces, sizing).
 
         Returns:
             str: The signal type based on self.file_name
@@ -191,6 +200,8 @@ class AtlanObservability(Generic[T], ABC):
             return "metrics"
         elif self.file_name == TRACES_FILE_NAME:
             return "traces"
+        elif self.file_name == SIZING_FILE_NAME:
+            return "sizing"
         return "other"
 
     def _get_partition_path(self, timestamp: datetime) -> str:

--- a/application_sdk/observability/sizing.py
+++ b/application_sdk/observability/sizing.py
@@ -17,6 +17,7 @@ from opentelemetry import metrics as _otel_metrics
 
 from application_sdk.observability.cgroup import ContainerTrace
 from application_sdk.observability.logger_adaptor import get_logger
+from application_sdk.observability.sizing_inputs import InputSize
 
 _logger = get_logger(__name__)
 
@@ -52,6 +53,10 @@ class SizingObservation:
     cpu_throttled_fraction: float | None = None
     cpu_quota_cores: float | None = None
 
+    input_bytes: int | None = None
+    input_file_count: int | None = None
+    input_basis: str | None = None
+
     @property
     def mean_cpu_cores(self) -> float | None:
         """CPU consumed per wall-clock second.
@@ -62,6 +67,17 @@ class SizingObservation:
         if self.cpu_seconds is None or self.duration_seconds <= 0:
             return None
         return self.cpu_seconds / self.duration_seconds
+
+    @property
+    def peak_per_input_byte(self) -> float | None:
+        """Peak memory per input byte — the ratio a memory tier is fitted from.
+
+        ``None`` without an input size: a peak with no driver variable can size one
+        envelope but cannot key a rule.
+        """
+        if not self.input_bytes or self.peak_memory_bytes is None:
+            return None
+        return self.peak_memory_bytes / self.input_bytes
 
     @classmethod
     def from_trace(
@@ -74,6 +90,7 @@ class SizingObservation:
         attempt: int,
         outcome: str,
         duration_seconds: float,
+        input_size: InputSize | None = None,
     ) -> SizingObservation:
         return cls(
             activity_type=activity_type,
@@ -90,6 +107,9 @@ class SizingObservation:
             cpu_throttled_seconds=trace.cpu_throttled_seconds,
             cpu_throttled_fraction=trace.throttled_fraction,
             cpu_quota_cores=trace.cpu_quota_cores,
+            input_bytes=input_size.bytes if input_size else None,
+            input_file_count=input_size.file_count if input_size else None,
+            input_basis=input_size.basis if input_size else None,
         )
 
     def has_data(self) -> bool:
@@ -99,6 +119,20 @@ class SizingObservation:
         fitted from, where a null read as a zero picks the smallest tier.
         """
         return self.peak_memory_bytes is not None or self.cpu_seconds is not None
+
+
+def _input_mib():
+    if "input_mib" not in _INSTRUMENTS:
+        _INSTRUMENTS["input_mib"] = _meter().create_histogram(
+            "activity.sizing.input_mib",
+            unit="MiBy",
+            description=(
+                "Bytes of data handed to one activity execution. The driver "
+                "variable: peak memory alone says a tier is wrong, this says what "
+                "to key it on."
+            ),
+        )
+    return _INSTRUMENTS["input_mib"]
 
 
 def _meter():
@@ -175,6 +209,11 @@ def record_observation(observation: SizingObservation) -> None:
             "outcome": observation.outcome,
             "peak.source": observation.peak_source,
         }
+        if observation.input_bytes is not None:
+            _input_mib().record(
+                observation.input_bytes / _MIB,
+                {**attrs, "input.basis": observation.input_basis or "unknown"},
+            )
         if observation.peak_memory_bytes is not None:
             _peak_memory_mib().record(observation.peak_memory_bytes / _MIB, attrs)
         if observation.peak_memory_fraction is not None:

--- a/application_sdk/observability/sizing.py
+++ b/application_sdk/observability/sizing.py
@@ -231,6 +231,15 @@ def record_observation(observation: SizingObservation) -> None:
             "activity_sizing_observation %s",
             orjson.dumps(payload, default=str).decode(),
         )
+
+        # Durable copy for offline tier fitting. Separate from the log line on
+        # purpose: the log is grep-able on one tenant today, this is what reaches
+        # the upstream store and survives log retention.
+        from application_sdk.observability.sizing_sink import (  # noqa: PLC0415 — circular: the sink imports this module's record type
+            persist,
+        )
+
+        persist(observation)
     # conformance: ignore[E004] telemetry in an activity finally; a failure here must cost the observation, never the activity's real outcome
     except Exception:
         _logger.debug("sizing observation emission failed", exc_info=True)

--- a/application_sdk/observability/sizing.py
+++ b/application_sdk/observability/sizing.py
@@ -1,21 +1,10 @@
-"""What one activity execution consumed — the unit of evidence for tier sizing.
+"""What one activity execution consumed — the evidence tier sizing is fitted from.
 
-This is the collection half of "collect data → classify tiers → productionise".
-It answers one question per activity execution: *how big a pod did this actually
-need?* Nothing here decides a tier, and nothing here reads a tier — a module
-that both measured and routed would make the measurement a function of the
-routing and the calibration circular.
+Collection only: nothing here reads or decides a tier, because a measurement that
+depended on the routing would make the calibration circular.
 
-Two OTel histograms go out immediately, so a tenant is observable the day
-collection is enabled rather than after an offline analysis round-trip. The
-richer per-execution record is what the analysis skill consumes; its wire
-format and durable sink are deliberately behind :func:`record_observation` so
-they can change without touching the interceptor.
-
-**Labels are bounded on purpose.** ``activity.type`` and ``task_queue`` are
-finite per app; ``workflow_id`` is a UUID and would blow up every histogram it
-touched. That mistake has already been made once on the AE dashboards, which is
-why the rule is written down here rather than left to reviewers.
+Labels are bounded on purpose — ``workflow_id`` is a UUID and would blow up every
+histogram it touched.
 """
 
 from __future__ import annotations
@@ -41,14 +30,9 @@ _MIB = 1024 * 1024
 class SizingObservation:
     """One activity execution's measured resource envelope.
 
-    ``peak_source`` travels with the numbers rather than being dropped after
-    collection. A peak from a reset kernel watermark and a peak from a 1-second
-    poller have different blind spots — the poller cannot see a sub-second spike
-    — so a tier fitted to a silent mix of the two is fitted to an unknown error
-    profile. The analysis stage needs to be able to segment on it.
-
-    ``attempt`` matters for the same reason: a retry that inherited a warm page
-    cache is not an independent sample of the same workload.
+    ``peak_source`` and ``attempt`` travel with the numbers so analysis can segment
+    on them: watermark and polled peaks have different blind spots, and a retry on
+    a warm page cache is not an independent sample.
     """
 
     activity_type: str
@@ -72,9 +56,8 @@ class SizingObservation:
     def mean_cpu_cores(self) -> float | None:
         """CPU consumed per wall-clock second.
 
-        The number a CPU tier is set from, and only half the story on its own —
-        read it next to ``cpu_throttled_fraction``, because an activity pinned at
-        its quota reports a flattering mean precisely *because* it was starved.
+        Read next to ``cpu_throttled_fraction``: an activity pinned at its quota
+        reports a flattering mean precisely *because* it was starved.
         """
         if self.cpu_seconds is None or self.duration_seconds <= 0:
             return None
@@ -110,11 +93,10 @@ class SizingObservation:
         )
 
     def has_data(self) -> bool:
-        """Whether anything was actually measured.
+        """Whether anything was measured. A non-cgroup host produces nothing.
 
-        An observation with no peak and no CPU delta is what a non-cgroup host
-        produces. Emitting it would put a row of nulls into the dataset the tier
-        table is fitted from, and a null read as a zero picks the smallest tier.
+        Emitting an all-null row would put it in the dataset the tier table is
+        fitted from, where a null read as a zero picks the smallest tier.
         """
         return self.peak_memory_bytes is not None or self.cpu_seconds is not None
 
@@ -129,10 +111,8 @@ def _peak_memory_mib():
             "activity.sizing.peak_memory_mib",
             unit="MiBy",
             description=(
-                "Peak container memory (cgroup memory.current / memory.peak) "
-                "observed during one activity execution. This is the counter the "
-                "kernel OOM killer acts on, so it — not process RSS — is what a "
-                "memory tier has to cover."
+                "Peak container memory during one activity execution. The counter "
+                "the OOM killer acts on, so what a memory tier has to cover."
             ),
         )
     return _INSTRUMENTS["peak_mem"]
@@ -144,9 +124,8 @@ def _peak_memory_fraction():
             "activity.sizing.peak_memory_fraction",
             unit="1",
             description=(
-                "Peak container memory as a fraction of the container limit. The "
-                "utilisation view: sustained low values mean an over-provisioned "
-                "tier, values near 1.0 mean the next run may OOM."
+                "Peak container memory as a fraction of the limit. Sustained low "
+                "means over-provisioned; near 1.0 means the next run may OOM."
             ),
         )
     return _INSTRUMENTS["peak_frac"]
@@ -158,10 +137,8 @@ def _cpu_throttled_fraction():
             "activity.sizing.cpu_throttled_fraction",
             unit="1",
             description=(
-                "Share of CFS periods in which the activity's container exhausted "
-                "its CPU quota. The only signal that separates a cheap activity "
-                "from a starved one — mean CPU cannot, because a throttled "
-                "activity reports a mean pinned neatly at its quota."
+                "Share of CFS periods that exhausted the CPU quota. The only signal "
+                "separating a cheap activity from a starved one."
             ),
         )
     return _INSTRUMENTS["throttle"]
@@ -173,24 +150,21 @@ def _mean_cpu_cores():
             "activity.sizing.mean_cpu_cores",
             unit="1",
             description=(
-                "Container CPU seconds consumed per wall-clock second during one "
-                "activity execution. Read alongside cpu_throttled_fraction."
+                "Container CPU seconds per wall-clock second. Read alongside "
+                "cpu_throttled_fraction."
             ),
         )
     return _INSTRUMENTS["cpu_cores"]
 
 
 def record_observation(observation: SizingObservation) -> None:
-    """Emit one observation: OTel histograms now, durable record for analysis.
+    """Emit one observation as OTel histograms plus a structured log line.
 
-    Never raises. This is called from an activity's ``finally``, where an
-    exception would replace the activity's real outcome — success or a genuine
-    failure — with a telemetry bug.
+    Never raises — called from an activity's ``finally``, where an exception would
+    replace the activity's real outcome with a telemetry bug.
 
-    The structured log line is the sink that works on every tenant today,
-    because every tenant already ships worker logs. A durable columnar sink is a
-    separate change; it goes behind this same function so the interceptor never
-    learns where the data lands.
+    The log line is the sink that works on every tenant today; a columnar sink is a
+    separate change, hidden behind this function.
     """
     if not observation.has_data():
         return
@@ -213,8 +187,7 @@ def record_observation(observation: SizingObservation) -> None:
 
         payload = asdict(observation)
         payload["mean_cpu_cores"] = mean_cores
-        # One JSON object on one line, so a log pipeline can lift the whole
-        # dataset out with a single grep on the marker below.
+        # One JSON object per line, so a log pipeline lifts the dataset with one grep.
         _logger.info(
             "activity_sizing_observation %s",
             orjson.dumps(payload, default=str).decode(),

--- a/application_sdk/observability/sizing.py
+++ b/application_sdk/observability/sizing.py
@@ -57,6 +57,14 @@ class SizingObservation:
     input_file_count: int | None = None
     input_basis: str | None = None
 
+    # Attribution context. These three make the row self-describing: with
+    # ``pod`` + ``started_at`` + ``duration_seconds`` the analysis can join rows that
+    # overlapped and recover the in-flight set and its combined input itself, so no
+    # in-process bookkeeping of who-ran-with-whom is needed.
+    started_at: float | None = None
+    pod: str | None = None
+    concurrency_max: int = 1
+
     @property
     def mean_cpu_cores(self) -> float | None:
         """CPU consumed per wall-clock second.
@@ -67,6 +75,15 @@ class SizingObservation:
         if self.cpu_seconds is None or self.duration_seconds <= 0:
             return None
         return self.cpu_seconds / self.duration_seconds
+
+    @property
+    def is_attributable(self) -> bool:
+        """Whether the peak belongs to this activity alone.
+
+        False means the reading is pod-wide — still useful, but for fitting a pod
+        envelope, not an activity's.
+        """
+        return self.concurrency_max <= 1
 
     @property
     def peak_per_input_byte(self) -> float | None:
@@ -91,6 +108,9 @@ class SizingObservation:
         outcome: str,
         duration_seconds: float,
         input_size: InputSize | None = None,
+        started_at: float | None = None,
+        pod: str | None = None,
+        concurrency_max: int = 1,
     ) -> SizingObservation:
         return cls(
             activity_type=activity_type,
@@ -110,6 +130,9 @@ class SizingObservation:
             input_bytes=input_size.bytes if input_size else None,
             input_file_count=input_size.file_count if input_size else None,
             input_basis=input_size.basis if input_size else None,
+            started_at=started_at,
+            pod=pod,
+            concurrency_max=concurrency_max,
         )
 
     def has_data(self) -> bool:
@@ -208,6 +231,9 @@ def record_observation(observation: SizingObservation) -> None:
             "temporal.task_queue": observation.task_queue,
             "outcome": observation.outcome,
             "peak.source": observation.peak_source,
+            # Without this a dashboard averages per-activity peaks together with
+            # pod-wide ones, which is two different quantities under one name.
+            "attributable": str(observation.is_attributable).lower(),
         }
         if observation.input_bytes is not None:
             _input_mib().record(

--- a/application_sdk/observability/sizing.py
+++ b/application_sdk/observability/sizing.py
@@ -1,0 +1,224 @@
+"""What one activity execution consumed — the unit of evidence for tier sizing.
+
+This is the collection half of "collect data → classify tiers → productionise".
+It answers one question per activity execution: *how big a pod did this actually
+need?* Nothing here decides a tier, and nothing here reads a tier — a module
+that both measured and routed would make the measurement a function of the
+routing and the calibration circular.
+
+Two OTel histograms go out immediately, so a tenant is observable the day
+collection is enabled rather than after an offline analysis round-trip. The
+richer per-execution record is what the analysis skill consumes; its wire
+format and durable sink are deliberately behind :func:`record_observation` so
+they can change without touching the interceptor.
+
+**Labels are bounded on purpose.** ``activity.type`` and ``task_queue`` are
+finite per app; ``workflow_id`` is a UUID and would blow up every histogram it
+touched. That mistake has already been made once on the AE dashboards, which is
+why the rule is written down here rather than left to reviewers.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any
+
+import orjson
+from opentelemetry import metrics as _otel_metrics
+
+from application_sdk.observability.cgroup import ContainerTrace
+from application_sdk.observability.logger_adaptor import get_logger
+
+_logger = get_logger(__name__)
+
+_METER_NAME = "application_sdk.sizing"
+_INSTRUMENTS: dict[str, Any] = {}
+
+_MIB = 1024 * 1024
+
+
+@dataclass(frozen=True)
+class SizingObservation:
+    """One activity execution's measured resource envelope.
+
+    ``peak_source`` travels with the numbers rather than being dropped after
+    collection. A peak from a reset kernel watermark and a peak from a 1-second
+    poller have different blind spots — the poller cannot see a sub-second spike
+    — so a tier fitted to a silent mix of the two is fitted to an unknown error
+    profile. The analysis stage needs to be able to segment on it.
+
+    ``attempt`` matters for the same reason: a retry that inherited a warm page
+    cache is not an independent sample of the same workload.
+    """
+
+    activity_type: str
+    task_queue: str
+    workflow_type: str
+    attempt: int
+    outcome: str
+    duration_seconds: float
+
+    peak_memory_bytes: int | None = None
+    peak_memory_fraction: float | None = None
+    peak_source: str = "unavailable"
+    memory_limit_bytes: int | None = None
+
+    cpu_seconds: float | None = None
+    cpu_throttled_seconds: float | None = None
+    cpu_throttled_fraction: float | None = None
+    cpu_quota_cores: float | None = None
+
+    @property
+    def mean_cpu_cores(self) -> float | None:
+        """CPU consumed per wall-clock second.
+
+        The number a CPU tier is set from, and only half the story on its own —
+        read it next to ``cpu_throttled_fraction``, because an activity pinned at
+        its quota reports a flattering mean precisely *because* it was starved.
+        """
+        if self.cpu_seconds is None or self.duration_seconds <= 0:
+            return None
+        return self.cpu_seconds / self.duration_seconds
+
+    @classmethod
+    def from_trace(
+        cls,
+        trace: ContainerTrace,
+        *,
+        activity_type: str,
+        task_queue: str,
+        workflow_type: str,
+        attempt: int,
+        outcome: str,
+        duration_seconds: float,
+    ) -> SizingObservation:
+        return cls(
+            activity_type=activity_type,
+            task_queue=task_queue,
+            workflow_type=workflow_type,
+            attempt=attempt,
+            outcome=outcome,
+            duration_seconds=duration_seconds,
+            peak_memory_bytes=trace.peak_memory_bytes,
+            peak_memory_fraction=trace.peak_memory_fraction,
+            peak_source=trace.peak_source,
+            memory_limit_bytes=trace.memory_limit_bytes,
+            cpu_seconds=trace.cpu_seconds,
+            cpu_throttled_seconds=trace.cpu_throttled_seconds,
+            cpu_throttled_fraction=trace.throttled_fraction,
+            cpu_quota_cores=trace.cpu_quota_cores,
+        )
+
+    def has_data(self) -> bool:
+        """Whether anything was actually measured.
+
+        An observation with no peak and no CPU delta is what a non-cgroup host
+        produces. Emitting it would put a row of nulls into the dataset the tier
+        table is fitted from, and a null read as a zero picks the smallest tier.
+        """
+        return self.peak_memory_bytes is not None or self.cpu_seconds is not None
+
+
+def _meter():
+    return _otel_metrics.get_meter(_METER_NAME)
+
+
+def _peak_memory_mib():
+    if "peak_mem" not in _INSTRUMENTS:
+        _INSTRUMENTS["peak_mem"] = _meter().create_histogram(
+            "activity.sizing.peak_memory_mib",
+            unit="MiBy",
+            description=(
+                "Peak container memory (cgroup memory.current / memory.peak) "
+                "observed during one activity execution. This is the counter the "
+                "kernel OOM killer acts on, so it — not process RSS — is what a "
+                "memory tier has to cover."
+            ),
+        )
+    return _INSTRUMENTS["peak_mem"]
+
+
+def _peak_memory_fraction():
+    if "peak_frac" not in _INSTRUMENTS:
+        _INSTRUMENTS["peak_frac"] = _meter().create_histogram(
+            "activity.sizing.peak_memory_fraction",
+            unit="1",
+            description=(
+                "Peak container memory as a fraction of the container limit. The "
+                "utilisation view: sustained low values mean an over-provisioned "
+                "tier, values near 1.0 mean the next run may OOM."
+            ),
+        )
+    return _INSTRUMENTS["peak_frac"]
+
+
+def _cpu_throttled_fraction():
+    if "throttle" not in _INSTRUMENTS:
+        _INSTRUMENTS["throttle"] = _meter().create_histogram(
+            "activity.sizing.cpu_throttled_fraction",
+            unit="1",
+            description=(
+                "Share of CFS periods in which the activity's container exhausted "
+                "its CPU quota. The only signal that separates a cheap activity "
+                "from a starved one — mean CPU cannot, because a throttled "
+                "activity reports a mean pinned neatly at its quota."
+            ),
+        )
+    return _INSTRUMENTS["throttle"]
+
+
+def _mean_cpu_cores():
+    if "cpu_cores" not in _INSTRUMENTS:
+        _INSTRUMENTS["cpu_cores"] = _meter().create_histogram(
+            "activity.sizing.mean_cpu_cores",
+            unit="1",
+            description=(
+                "Container CPU seconds consumed per wall-clock second during one "
+                "activity execution. Read alongside cpu_throttled_fraction."
+            ),
+        )
+    return _INSTRUMENTS["cpu_cores"]
+
+
+def record_observation(observation: SizingObservation) -> None:
+    """Emit one observation: OTel histograms now, durable record for analysis.
+
+    Never raises. This is called from an activity's ``finally``, where an
+    exception would replace the activity's real outcome — success or a genuine
+    failure — with a telemetry bug.
+
+    The structured log line is the sink that works on every tenant today,
+    because every tenant already ships worker logs. A durable columnar sink is a
+    separate change; it goes behind this same function so the interceptor never
+    learns where the data lands.
+    """
+    if not observation.has_data():
+        return
+    try:
+        attrs = {
+            "activity.type": observation.activity_type,
+            "temporal.task_queue": observation.task_queue,
+            "outcome": observation.outcome,
+            "peak.source": observation.peak_source,
+        }
+        if observation.peak_memory_bytes is not None:
+            _peak_memory_mib().record(observation.peak_memory_bytes / _MIB, attrs)
+        if observation.peak_memory_fraction is not None:
+            _peak_memory_fraction().record(observation.peak_memory_fraction, attrs)
+        if observation.cpu_throttled_fraction is not None:
+            _cpu_throttled_fraction().record(observation.cpu_throttled_fraction, attrs)
+        mean_cores = observation.mean_cpu_cores
+        if mean_cores is not None:
+            _mean_cpu_cores().record(mean_cores, attrs)
+
+        payload = asdict(observation)
+        payload["mean_cpu_cores"] = mean_cores
+        # One JSON object on one line, so a log pipeline can lift the whole
+        # dataset out with a single grep on the marker below.
+        _logger.info(
+            "activity_sizing_observation %s",
+            orjson.dumps(payload, default=str).decode(),
+        )
+    # conformance: ignore[E004] telemetry in an activity finally; a failure here must cost the observation, never the activity's real outcome
+    except Exception:
+        _logger.debug("sizing observation emission failed", exc_info=True)

--- a/application_sdk/observability/sizing_census.py
+++ b/application_sdk/observability/sizing_census.py
@@ -1,0 +1,93 @@
+"""How many tracked activities shared this process, per activity execution.
+
+A cgroup reading is *pod-wide*. Attributing it to one activity is only valid when
+one activity was running, and worker concurrency defaults to 100
+(``TEMPORAL_MAX_CONCURRENT_ACTIVITIES``) — so most apps never satisfy that.
+
+Rather than force concurrency to 1, which would change throughput on apps that
+have nothing to do with tiering, each execution records the **maximum concurrency
+it ever saw**. That one number lets the analysis pick the right model instead of
+pooling two different ones:
+
+* ``1`` — the peak is this activity's. Fit per-activity.
+* ``>1`` — the peak is the pod's. Join rows overlapping on ``pod`` and
+  ``started_at`` to recover the in-flight set and its combined input, then fit
+  per-pod, which is the only unit a shared pod can be routed to anyway.
+
+Without it both land in one bucket, and an envelope fitted at concurrency 1 keeps
+being applied after concurrency rises — the same units meaning something different,
+with nothing in the data to say so. AE is on that path already: its
+``ATLAN_MAX_CONCURRENT_ACTIVITIES: "1"`` is documented as a temporary Daft
+mitigation, to be restored to 3.
+"""
+
+from __future__ import annotations
+
+import threading
+
+
+class _Census:
+    """Process-wide count of in-flight tracked activities.
+
+    Each caller gets back the high-water mark for *its own* window, not the count
+    at any single instant: an activity that started alone and was joined by three
+    others has a pod-wide peak, and a reading taken at entry would call it clean.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._active: dict[int, int] = {}
+        self._next_token = 0
+        self._count = 0
+
+    def enter(self) -> tuple[int, int]:
+        """Register an execution. Returns ``(token, concurrency_now)``."""
+        with self._lock:
+            self._count += 1
+            self._next_token += 1
+            token = self._next_token
+            # Every live execution may now have a higher high-water mark, so they
+            # all get updated — not just the one arriving.
+            for other in self._active:
+                if self._count > self._active[other]:
+                    self._active[other] = self._count
+            self._active[token] = self._count
+            return token, self._count
+
+    def peak(self, token: int) -> int:
+        """Max concurrency seen during this window so far, without deregistering.
+
+        Separate from :meth:`leave` because the caller needs the number while still
+        holding its slot — reading it by leaving early would drop the count while
+        the activity is genuinely still running, undercounting everyone else.
+        """
+        with self._lock:
+            return self._active.get(token, 1)
+
+    def leave(self, token: int) -> int:
+        """Deregister and return the max concurrency seen during that window.
+
+        Idempotent: a second call for the same token is a no-op returning ``1``.
+        Two callers deregister each execution (the outer wrapper always, the
+        measured path for its own bookkeeping), and an unconditional decrement
+        would under-count concurrency for every other activity in the process.
+        """
+        with self._lock:
+            if token not in self._active:
+                return 1
+            seen = self._active.pop(token)
+            self._count = max(0, self._count - 1)
+            return seen
+
+    def active(self) -> int:
+        with self._lock:
+            return self._count
+
+    def _reset_for_testing(self) -> None:
+        with self._lock:
+            self._active.clear()
+            self._count = 0
+            self._next_token = 0
+
+
+CENSUS = _Census()

--- a/application_sdk/observability/sizing_inputs.py
+++ b/application_sdk/observability/sizing_inputs.py
@@ -1,0 +1,143 @@
+"""How much data an activity was given — the driver variable for tier sizing.
+
+Peak memory alone says a tier is wrong; it cannot say what to key the tier *on*.
+That needs the input size, so a rule can be fitted and evaluated before the
+activity runs.
+
+Two sources, in order:
+
+1. **``FileReference`` fields on the Input.** Zero config, and the bytes are
+   already on local disk: the SDK materialises durable refs at the top of the
+   activity, inside the window the sizing interceptor measures, so this is a
+   local ``stat`` rather than an object-store call.
+2. **``sizing_input_bytes()`` on the Input.** The escape hatch for apps that pass
+   raw object-store paths instead of ``FileReference`` — AE's ``merge`` takes
+   ``input_prefixes: list[str]`` and would otherwise report nothing.
+
+``None`` means unknown, never 0 — a zero would fit a rule to inputs nobody sized.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Any
+
+from application_sdk.observability.logger_adaptor import get_logger
+
+_logger = get_logger(__name__)
+
+#: Optional method an Input may define to report its own size in bytes.
+SIZING_HOOK = "sizing_input_bytes"
+
+# A stat per file, so a pathological ref would walk a whole tree at activity end.
+# Bounded here rather than trusted: the number is telemetry, and a partial count
+# labelled ``truncated`` is more useful than an activity slowed down measuring
+# itself.
+_MAX_FILES_WALKED = 10_000
+
+
+@dataclass(frozen=True)
+class InputSize:
+    """Bytes an activity was handed, and where the number came from.
+
+    ``basis`` segments the data: ``file_reference`` is measured, ``hook`` is
+    whatever the app chose to report, and mixing them silently would fit one rule
+    to two different definitions of "input".
+    """
+
+    bytes: int
+    file_count: int
+    basis: str
+    truncated: bool = False
+
+
+def describe_inputs(input_data: Any) -> InputSize | None:
+    """Size an activity's input, or ``None`` if it cannot be determined.
+
+    Never raises: this runs beside a real activity and must not affect it.
+    """
+    try:
+        from_refs = _size_from_file_refs(input_data)
+        if from_refs is not None:
+            return from_refs
+        return _size_from_hook(input_data)
+    # conformance: ignore[E004] telemetry; an unsizeable input is "unknown", not a failure
+    except Exception:
+        _logger.debug("input sizing failed", exc_info=True)
+        return None
+
+
+def _size_from_file_refs(input_data: Any) -> InputSize | None:
+    """Sum the on-disk size of every materialised ``FileReference``."""
+    from application_sdk.storage.file_ref_sync import (  # noqa: PLC0415 — circular: storage imports contracts which import observability
+        _find_file_refs,
+    )
+
+    refs = _find_file_refs(input_data)
+    if not refs:
+        return None
+
+    total = 0
+    files = 0
+    truncated = False
+    for ref in refs:
+        if not ref.local_path:
+            # Durable but not materialised (``auto_materialize=False``). Sizing it
+            # would need an object-store call per activity, so it is left to the
+            # hook — the app that opted out already knows its own sizes.
+            continue
+        size, count, hit_cap = _walk(ref.local_path)
+        total += size
+        files += count
+        truncated = truncated or hit_cap
+
+    if files == 0:
+        return None
+    return InputSize(
+        bytes=total, file_count=files, basis="file_reference", truncated=truncated
+    )
+
+
+def _walk(path: str) -> tuple[int, int, bool]:
+    """``(bytes, file_count, hit_cap)`` for a file or directory tree."""
+    if os.path.isfile(path):
+        return os.path.getsize(path), 1, False
+
+    total = 0
+    files = 0
+    for root, _dirs, names in os.walk(path):
+        for name in names:
+            if files >= _MAX_FILES_WALKED:
+                return total, files, True
+            try:
+                total += os.path.getsize(os.path.join(root, name))
+                files += 1
+            # conformance: ignore[E014] a file removed mid-walk is expected; skip it
+            except OSError:
+                continue
+    return total, files, False
+
+
+def _size_from_hook(input_data: Any) -> InputSize | None:
+    """Call the Input's own ``sizing_input_bytes()``, if it defines one.
+
+    The contract is deliberately minimal — return bytes, or ``None`` if unknown —
+    so an app can reuse a number it already computed rather than being pushed into
+    the SDK's file model.
+    """
+    hook = getattr(input_data, SIZING_HOOK, None)
+    if not callable(hook):
+        return None
+    value = hook()
+    if value is None:
+        return None
+    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+        _logger.debug("%s returned %r; expected a non-negative int", SIZING_HOOK, value)
+        return None
+    file_count = getattr(input_data, "sizing_input_file_count", None)
+    return InputSize(
+        bytes=value,
+        file_count=file_count if isinstance(file_count, int) else 0,
+        basis="hook",
+    )

--- a/application_sdk/observability/sizing_inputs.py
+++ b/application_sdk/observability/sizing_inputs.py
@@ -6,29 +6,28 @@ activity runs.
 
 Two sources, in order:
 
-1. **``FileReference`` fields on the Input.** Zero config, and the bytes are
-   already on local disk: the SDK materialises durable refs at the top of the
-   activity, inside the window the sizing interceptor measures, so this is a
-   local ``stat`` rather than an object-store call.
-2. **``sizing_input_bytes()`` on the Input.** The escape hatch for apps that pass
-   raw object-store paths instead of ``FileReference`` — AE's ``merge`` takes
-   ``input_prefixes: list[str]`` and would otherwise report nothing.
+1. **Reported bytes** — what the activity actually read, via
+   :func:`report_input_bytes`. The SDK's own file readers call it, so any app going
+   through them is covered without writing code; an app fetching data its own way
+   calls it directly.
+2. **``FileReference`` fields on the Input** — a fallback disk walk, for inputs the
+   interceptor materialised rather than a reader pulling them.
 
-``None`` means unknown, never 0 — a zero would fit a rule to inputs nobody sized.
+Reported wins: it is what the activity read, where a ref only says what it was
+handed. ``None`` means unknown, never 0 — a zero would fit a rule to inputs nobody
+sized.
 """
 
 from __future__ import annotations
 
 import os
+from contextvars import ContextVar
 from dataclasses import dataclass
 from typing import Any
 
 from application_sdk.observability.logger_adaptor import get_logger
 
 _logger = get_logger(__name__)
-
-#: Optional method an Input may define to report its own size in bytes.
-SIZING_HOOK = "sizing_input_bytes"
 
 # A stat per file, so a pathological ref would walk a whole tree at activity end.
 # Bounded here rather than trusted: the number is telemetry, and a partial count
@@ -39,11 +38,11 @@ _MAX_FILES_WALKED = 10_000
 
 @dataclass(frozen=True)
 class InputSize:
-    """Bytes an activity was handed, and where the number came from.
+    """Bytes an activity read, and where the number came from.
 
-    ``basis`` segments the data: ``file_reference`` is measured, ``hook`` is
-    whatever the app chose to report, and mixing them silently would fit one rule
-    to two different definitions of "input".
+    ``basis`` segments the data: ``reported`` is what the activity read,
+    ``file_reference`` is what it was handed. Mixing them silently would fit one
+    rule to two different definitions of "input".
     """
 
     bytes: int
@@ -52,16 +51,96 @@ class InputSize:
     truncated: bool = False
 
 
+class InputCollector:
+    """Accumulates bytes read during one activity execution.
+
+    Created by the sizing interceptor and mutated in place, following
+    ``OutputInterceptor``'s collector pattern. Mutation rather than reassignment is
+    deliberate: a ContextVar *set* inside the activity may not be visible to the
+    interceptor across a thread or context boundary, whereas a shared object is.
+    """
+
+    __slots__ = ("bytes", "file_count")
+
+    def __init__(self) -> None:
+        self.bytes = 0
+        self.file_count = 0
+
+    def add(self, num_bytes: int, file_count: int = 1) -> None:
+        self.bytes += num_bytes
+        self.file_count += file_count
+
+    def has_data(self) -> bool:
+        return self.file_count > 0
+
+
+_current_inputs: ContextVar[InputCollector | None] = ContextVar(
+    "sizing_input_collector", default=None
+)
+
+
+def begin_collection() -> InputCollector:
+    """Start collecting for one activity. Called by the sizing interceptor."""
+    collector = InputCollector()
+    _current_inputs.set(collector)
+    return collector
+
+
+def end_collection() -> None:
+    """Stop collecting, so a finished activity cannot leak into the next one."""
+    _current_inputs.set(None)
+
+
+def report_input_bytes(num_bytes: int, file_count: int = 1) -> None:
+    """Report bytes this activity read, for tier-sizing telemetry.
+
+    A no-op unless sizing collection is enabled, so it is safe to call
+    unconditionally from a read path. Never raises.
+
+    The SDK's own file readers call this, so most apps need not. Call it directly
+    when an app fetches data the SDK cannot see — a driver query, a vendor client,
+    or object-store reads it issues itself.
+    """
+    try:
+        collector = _current_inputs.get()
+        if collector is None or num_bytes < 0:
+            return
+        collector.add(num_bytes, file_count)
+    # conformance: ignore[E004] telemetry on a read path; must never affect the read
+    except Exception:
+        _logger.debug("input byte reporting failed", exc_info=True)
+
+
+def report_local_paths(paths: list[str]) -> None:
+    """Report the on-disk size of files this activity read. Never raises."""
+    try:
+        if _current_inputs.get() is None:
+            return
+        for path in paths:
+            try:
+                report_input_bytes(os.path.getsize(path), 1)
+            # conformance: ignore[E014] a file removed between read and stat; skip it
+            except OSError:
+                continue
+    # conformance: ignore[E004] telemetry on a read path; must never affect the read
+    except Exception:
+        _logger.debug("input path reporting failed", exc_info=True)
+
+
 def describe_inputs(input_data: Any) -> InputSize | None:
     """Size an activity's input, or ``None`` if it cannot be determined.
 
     Never raises: this runs beside a real activity and must not affect it.
     """
     try:
-        from_refs = _size_from_file_refs(input_data)
-        if from_refs is not None:
-            return from_refs
-        return _size_from_hook(input_data)
+        collector = _current_inputs.get()
+        if collector is not None and collector.has_data():
+            return InputSize(
+                bytes=collector.bytes,
+                file_count=collector.file_count,
+                basis="reported",
+            )
+        return _size_from_file_refs(input_data)
     # conformance: ignore[E004] telemetry; an unsizeable input is "unknown", not a failure
     except Exception:
         _logger.debug("input sizing failed", exc_info=True)
@@ -84,8 +163,8 @@ def _size_from_file_refs(input_data: Any) -> InputSize | None:
     for ref in refs:
         if not ref.local_path:
             # Durable but not materialised (``auto_materialize=False``). Sizing it
-            # would need an object-store call per activity, so it is left to the
-            # hook — the app that opted out already knows its own sizes.
+            # would cost an object-store call per activity, so the app that opted
+            # out reports its own bytes instead.
             continue
         size, count, hit_cap = _walk(ref.local_path)
         total += size
@@ -117,27 +196,3 @@ def _walk(path: str) -> tuple[int, int, bool]:
             except OSError:
                 continue
     return total, files, False
-
-
-def _size_from_hook(input_data: Any) -> InputSize | None:
-    """Call the Input's own ``sizing_input_bytes()``, if it defines one.
-
-    The contract is deliberately minimal — return bytes, or ``None`` if unknown —
-    so an app can reuse a number it already computed rather than being pushed into
-    the SDK's file model.
-    """
-    hook = getattr(input_data, SIZING_HOOK, None)
-    if not callable(hook):
-        return None
-    value = hook()
-    if value is None:
-        return None
-    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
-        _logger.debug("%s returned %r; expected a non-negative int", SIZING_HOOK, value)
-        return None
-    file_count = getattr(input_data, "sizing_input_file_count", None)
-    return InputSize(
-        bytes=value,
-        file_count=file_count if isinstance(file_count, int) else 0,
-        basis="hook",
-    )

--- a/application_sdk/observability/sizing_sink.py
+++ b/application_sdk/observability/sizing_sink.py
@@ -21,10 +21,11 @@ than inferring it from which keys happen to be present.
 
 from __future__ import annotations
 
+import asyncio
 import threading
 from dataclasses import asdict
 from time import time
-from typing import Any
+from typing import Any, ClassVar
 
 from application_sdk.constants import (
     APPLICATION_NAME,
@@ -49,7 +50,47 @@ SIZING_SCHEMA_VERSION = 2
 
 
 class SizingObservabilitySink(AtlanObservability[Any]):
-    """Buffers sizing observations and uploads them as gzipped NDJSON."""
+    """Buffers sizing observations and uploads them as gzipped NDJSON.
+
+    Starts the base class's periodic flush, which is NOT optional. ``add_record``
+    only evaluates its flush condition when a record arrives, so on this workload —
+    ``maxConcurrentActivities: 1``, a merge every 15-30 minutes, KEDA scaling pods to
+    zero in between — a pod typically sees ONE record in its whole life and neither
+    trigger ever fires. The buffer then dies with the process. Every other adaptor
+    (traces, logs, metrics) starts this task; omitting it here silently wrote nothing
+    for a full day of collection.
+    """
+
+    _flush_task_started: ClassVar[bool] = False
+
+    @classmethod
+    def _reset_for_testing(cls) -> None:
+        cls._flush_task_started = False
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        if SizingObservabilitySink._flush_task_started:
+            return
+        try:
+            # Same loop-or-daemon-thread shape the traces adaptor uses: the sink is
+            # built lazily from inside an activity, so a loop is usually running,
+            # but it must also work when constructed off one.
+            try:
+                asyncio.get_running_loop().create_task(self._periodic_flush())
+            except RuntimeError:
+                threading.Thread(target=self._flush_forever, daemon=True).start()
+            SizingObservabilitySink._flush_task_started = True
+        # conformance: ignore[E004] telemetry; a sink that cannot start its flush must not stop collection
+        except Exception:
+            logger.warning("could not start the sizing flush task", exc_info=True)
+
+    def _flush_forever(self) -> None:
+        """Run the periodic flush on its own loop, for the no-running-loop case."""
+        try:
+            asyncio.run(self._periodic_flush())
+        # conformance: ignore[E004] background thread; must not take the process down
+        except Exception:
+            logger.warning("sizing flush loop stopped", exc_info=True)
 
     def process_record(self, record: Any) -> dict[str, Any]:
         """Flatten one observation into the row that gets written.
@@ -80,6 +121,18 @@ class SizingObservabilitySink(AtlanObservability[Any]):
         # and a consumer that forgets to apply it pools two different quantities.
         row["is_attributable"] = record.is_attributable
         return row
+
+    async def _flush_records(self, records: list[dict[str, Any]]) -> None:
+        """Flush, and say so at INFO.
+
+        The base logs its success at DEBUG, which is filtered in every deployment —
+        so "is the sink writing?" was unanswerable from logs and had to be settled by
+        exec'ing into a pod and forcing a flush by hand. For the one signal whose
+        whole purpose is to be collected, that is worth a line.
+        """
+        await super()._flush_records(records)
+        if records:
+            logger.info("sizing: flushed %d observation(s)", len(records))
 
     def _store_sink_enabled(self) -> bool:
         """Always on: this sink only exists when sizing collection is enabled.
@@ -151,8 +204,27 @@ def persist(observation: Any) -> None:
         logger.debug("sizing observation not persisted", exc_info=True)
 
 
+async def drain() -> None:
+    """Flush whatever is buffered. Call on worker shutdown.
+
+    The periodic task closes the gap between records; this closes the gap between
+    the last record and the process ending. KEDA scales these pods to zero, so
+    without it the final batch of every pod's life is lost — and on this workload
+    that can be most of the data.
+    """
+    sink = _sink
+    if sink is None:
+        return
+    try:
+        await sink._flush_buffer(force=True)
+    # conformance: ignore[E004] shutdown path; a failed drain must not block shutdown
+    except Exception:
+        logger.warning("sizing drain failed; buffered rows lost", exc_info=True)
+
+
 def _reset_for_testing() -> None:
     """Drop the process-wide sink so a test can build its own."""
     global _sink
     with _sink_lock:
         _sink = None
+    SizingObservabilitySink._reset_for_testing()

--- a/application_sdk/observability/sizing_sink.py
+++ b/application_sdk/observability/sizing_sink.py
@@ -42,7 +42,9 @@ logger = get_logger(__name__)
 
 #: Bump on any change to the record's fields or their meaning. Rows are read
 #: months after they were written, mixed across SDK versions.
-SIZING_SCHEMA_VERSION = 1
+#: 2 — added started_at / pod / concurrency_max / is_attributable. A v1 row cannot
+#: say whether its peak was pod-wide, so v1 and v2 must not be pooled.
+SIZING_SCHEMA_VERSION = 2
 
 
 class SizingObservabilitySink(AtlanObservability[Any]):
@@ -66,6 +68,10 @@ class SizingObservabilitySink(AtlanObservability[Any]):
         # Derived here so every consumer computes them identically.
         row["mean_cpu_cores"] = record.mean_cpu_cores
         row["peak_per_input_byte"] = record.peak_per_input_byte
+        # Written out rather than left for the reader to derive from
+        # concurrency_max: it is the flag that decides which model a row feeds,
+        # and a consumer that forgets to apply it pools two different quantities.
+        row["is_attributable"] = record.is_attributable
         return row
 
     def export_record(self, record: Any) -> None:

--- a/application_sdk/observability/sizing_sink.py
+++ b/application_sdk/observability/sizing_sink.py
@@ -1,0 +1,130 @@
+"""Durable sink for activity sizing observations.
+
+The OTel histograms in ``sizing`` answer "is this tier wrong". Fitting a rule that
+predicts a tier needs the rows themselves — a histogram bucket cannot give you
+``peak_per_input_byte`` per execution — so each observation is also buffered and
+uploaded as a record.
+
+**Rides the existing observability pipeline rather than adding one.**
+``AtlanObservability`` already does batching, hive partitioning by
+year/month/day/hour, gzipped NDJSON, upload to the deployment store *and* the
+upstream Atlan store when ``ENABLE_ATLAN_UPLOAD`` is set, and retention cleanup.
+That upstream leg is also what makes cross-tenant collection work: records from
+every tenant land under one prefix, already partitioned, with no new transport to
+build or secure.
+
+Every record carries ``schema_version``. The fields here will change — a driver
+variable will be added, a basis renamed — and an analysis reading a mixed pile of
+rows has to be able to tell which contract each one was written against rather
+than inferring it from which keys happen to be present.
+"""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import asdict
+from typing import Any
+
+from application_sdk.constants import (
+    APPLICATION_NAME,
+    DEPLOYMENT_NAME,
+    SIZING_BATCH_SIZE,
+    SIZING_CLEANUP_ENABLED,
+    SIZING_FILE_NAME,
+    SIZING_FLUSH_INTERVAL_SECONDS,
+    SIZING_RETENTION_DAYS,
+)
+from application_sdk.observability.logger_adaptor import get_logger
+from application_sdk.observability.observability import AtlanObservability
+from application_sdk.observability.utils import get_observability_dir
+
+logger = get_logger(__name__)
+
+#: Bump on any change to the record's fields or their meaning. Rows are read
+#: months after they were written, mixed across SDK versions.
+SIZING_SCHEMA_VERSION = 1
+
+
+class SizingObservabilitySink(AtlanObservability[Any]):
+    """Buffers sizing observations and uploads them as gzipped NDJSON."""
+
+    def process_record(self, record: Any) -> dict[str, Any]:
+        """Flatten one observation into the row that gets written.
+
+        ``app`` and ``deployment`` are stamped here rather than left to the
+        partition path: once records from many tenants sit under one upstream
+        prefix, a row that cannot say which tenant it came from cannot be used to
+        fit that tenant's tiers — and cross-tenant rows must not be pooled blindly,
+        since a tenant's data volume is the very thing being measured.
+        """
+        row: dict[str, Any] = {
+            "schema_version": SIZING_SCHEMA_VERSION,
+            "app": APPLICATION_NAME,
+            "deployment": DEPLOYMENT_NAME,
+        }
+        row.update(asdict(record))
+        # Derived here so every consumer computes them identically.
+        row["mean_cpu_cores"] = record.mean_cpu_cores
+        row["peak_per_input_byte"] = record.peak_per_input_byte
+        return row
+
+    def export_record(self, record: Any) -> None:
+        """No-op: the OTel histograms are emitted by ``sizing.record_observation``.
+
+        Kept separate on purpose. Metrics are for watching, these rows are for
+        fitting, and emitting the histograms from here would tie a live dashboard's
+        correctness to a batching sink's flush schedule.
+        """
+
+
+_sink: SizingObservabilitySink | None = None
+_sink_lock = threading.Lock()
+
+
+def get_sink() -> SizingObservabilitySink | None:
+    """The process-wide sink, created on first use, or ``None`` if unavailable.
+
+    Lazy because constructing it touches the filesystem and registers a flush
+    task; a worker with collection disabled should pay neither.
+    """
+    global _sink
+    if _sink is not None:
+        return _sink
+    with _sink_lock:
+        if _sink is None:
+            try:
+                _sink = SizingObservabilitySink(
+                    batch_size=SIZING_BATCH_SIZE,
+                    flush_interval=SIZING_FLUSH_INTERVAL_SECONDS,
+                    retention_days=SIZING_RETENTION_DAYS,
+                    cleanup_enabled=SIZING_CLEANUP_ENABLED,
+                    data_dir=get_observability_dir(),
+                    file_name=SIZING_FILE_NAME,
+                )
+            # conformance: ignore[E004] telemetry; a sink that cannot be built must not stop collection
+            except Exception:
+                logger.debug("sizing sink unavailable", exc_info=True)
+                return None
+    return _sink
+
+
+def persist(observation: Any) -> None:
+    """Buffer one observation for upload. Never raises.
+
+    Called from an activity's ``finally``, so a sink failure has to cost the record
+    rather than the activity's real outcome.
+    """
+    try:
+        sink = get_sink()
+        if sink is not None:
+            sink.add_record(observation)
+    # conformance: ignore[E004] telemetry in an activity finally; never fail the activity
+    except Exception:
+        logger.debug("sizing observation not persisted", exc_info=True)
+
+
+def _reset_for_testing() -> None:
+    """Drop the process-wide sink so a test can build its own."""
+    global _sink
+    with _sink_lock:
+        _sink = None

--- a/application_sdk/observability/sizing_sink.py
+++ b/application_sdk/observability/sizing_sink.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import threading
 from dataclasses import asdict
+from time import time
 from typing import Any
 
 from application_sdk.constants import (
@@ -63,6 +64,12 @@ class SizingObservabilitySink(AtlanObservability[Any]):
             "schema_version": SIZING_SCHEMA_VERSION,
             "app": APPLICATION_NAME,
             "deployment": DEPLOYMENT_NAME,
+            # REQUIRED by the base class: _flush_records partitions on it
+            # (datetime.fromtimestamp(record["timestamp"])) and raises KeyError
+            # without it — swallowed as best-effort telemetry, so the only symptom
+            # would be an empty prefix. The execution's start, not the flush time,
+            # so a row lands in the hour the activity actually ran.
+            "timestamp": record.started_at if record.started_at else time(),
         }
         row.update(asdict(record))
         # Derived here so every consumer computes them identically.
@@ -73,6 +80,21 @@ class SizingObservabilitySink(AtlanObservability[Any]):
         # and a consumer that forgets to apply it pools two different quantities.
         row["is_attributable"] = record.is_attributable
         return row
+
+    def _store_sink_enabled(self) -> bool:
+        """Always on: this sink only exists when sizing collection is enabled.
+
+        ``ATLAN_ENABLE_OBSERVABILITY_STORE_SINK`` gates logs, metrics and traces
+        together, and an app that turns it off to stop shipping those would
+        otherwise lose the sizing dataset too — silently, since the only symptom is
+        an empty prefix. AE is exactly that app: it sets the DAPR-sink fallback to
+        false, which resolves this to false.
+
+        Not a loosening of that switch. Collection is already gated twice, by
+        APPLICATION_SDK_ENABLE_SIZING_TELEMETRY and by the per-activity allow-list,
+        so nothing is written unless an operator asked for it by name.
+        """
+        return True
 
     def export_record(self, record: Any) -> None:
         """No-op: the OTel histograms are emitted by ``sizing.record_observation``.

--- a/application_sdk/storage/formats/utils.py
+++ b/application_sdk/storage/formats/utils.py
@@ -90,6 +90,21 @@ def find_local_files_by_extension(
     return []
 
 
+def _report_sizing_inputs(paths: list[str]) -> None:
+    """Report these files' bytes for tier-sizing telemetry.
+
+    Sits on the one path every SDK reader goes through, so an app using
+    ``ParquetFileReader`` / ``JsonFileReader`` contributes the driver variable
+    without writing any code. Inert unless sizing collection is enabled, and it
+    never raises.
+    """
+    from application_sdk.observability.sizing_inputs import (  # noqa: PLC0415 — circular: observability.sizing_inputs reads storage contracts
+        report_local_paths,
+    )
+
+    report_local_paths(paths)
+
+
 async def _download_files(
     path: str,
     file_extension: str,
@@ -124,6 +139,7 @@ async def _download_files(
             file_extension,
             path,
         )
+        _report_sizing_inputs(local_files)
         return local_files
 
     # Step 2: Download from object store with SHA-256 integrity checking
@@ -179,6 +195,7 @@ async def _download_files(
                 len(downloaded_paths),
                 file_extension,
             )
+            _report_sizing_inputs(downloaded_paths)
             return downloaded_paths
 
         raise ObjectStoreReadError(

--- a/tests/unit/execution/test_worker.py
+++ b/tests/unit/execution/test_worker.py
@@ -417,17 +417,13 @@ class TestCreateWorker:
         )
 
     def test_sizing_interceptor_absent_by_default(self, monkeypatch) -> None:
-        """An SDK version bump alone must not start measuring anything."""
+        """A version bump alone must not start measuring anything."""
         assert self._has_sizing(self._interceptors_for(monkeypatch)) is False
 
     def test_sizing_interceptor_absent_when_enabled_with_no_allow_list(
         self, monkeypatch
     ) -> None:
-        """Enabled but unnamed collects nothing, and costs nothing.
-
-        The allow-list is checked at wiring time as well as per-activity, so an
-        empty list does not even attach the interceptor.
-        """
+        """Enabled but unnamed collects nothing — and is not even attached."""
         interceptors = self._interceptors_for(
             monkeypatch, APPLICATION_SDK_ENABLE_SIZING_TELEMETRY="true"
         )

--- a/tests/unit/execution/test_worker.py
+++ b/tests/unit/execution/test_worker.py
@@ -380,6 +380,82 @@ class TestCreateWorker:
         with pytest.raises(WorkerInterceptorDuplicateError):
             create_worker(client, interceptors=[TraceInterceptor()])
 
+    # ── sizing telemetry wiring ───────────────────────────────────────────
+
+    def _interceptors_for(self, monkeypatch, **env) -> list:
+        """Return the interceptor list ``create_worker`` hands to Temporal."""
+
+        class _SizingApp(App):
+            async def run(self, input: _WorkerInput) -> _WorkerOutput:
+                return _WorkerOutput()
+
+        for key in (
+            "APPLICATION_SDK_ENABLE_SIZING_TELEMETRY",
+            "APPLICATION_SDK_SIZING_TELEMETRY_ACTIVITIES",
+        ):
+            monkeypatch.delenv(key, raising=False)
+        for key, value in env.items():
+            monkeypatch.setenv(key, value)
+
+        client = _make_mock_client()
+        captured: dict = {}
+
+        def capture_worker(*args, **kwargs):
+            captured.update(kwargs)
+            return mock.MagicMock()
+
+        with mock.patch(
+            "application_sdk.execution._temporal.worker.Worker",
+            side_effect=capture_worker,
+        ):
+            create_worker(client)
+        return list(captured.get("interceptors") or [])
+
+    def _has_sizing(self, interceptors: list) -> bool:
+        return any(
+            type(i).__name__ == "SizingTelemetryInterceptor" for i in interceptors
+        )
+
+    def test_sizing_interceptor_absent_by_default(self, monkeypatch) -> None:
+        """An SDK version bump alone must not start measuring anything."""
+        assert self._has_sizing(self._interceptors_for(monkeypatch)) is False
+
+    def test_sizing_interceptor_absent_when_enabled_with_no_allow_list(
+        self, monkeypatch
+    ) -> None:
+        """Enabled but unnamed collects nothing, and costs nothing.
+
+        The allow-list is checked at wiring time as well as per-activity, so an
+        empty list does not even attach the interceptor.
+        """
+        interceptors = self._interceptors_for(
+            monkeypatch, APPLICATION_SDK_ENABLE_SIZING_TELEMETRY="true"
+        )
+        assert self._has_sizing(interceptors) is False
+
+    def test_sizing_interceptor_attached_for_named_activities(
+        self, monkeypatch
+    ) -> None:
+        interceptors = self._interceptors_for(
+            monkeypatch,
+            APPLICATION_SDK_ENABLE_SIZING_TELEMETRY="true",
+            APPLICATION_SDK_SIZING_TELEMETRY_ACTIVITIES="merge,fetch_entities",
+        )
+        sizing = [
+            i for i in interceptors if type(i).__name__ == "SizingTelemetryInterceptor"
+        ]
+        assert len(sizing) == 1
+        assert sizing[0]._activities == frozenset({"merge", "fetch_entities"})
+
+    def test_sizing_interceptor_absent_when_list_set_but_switch_off(
+        self, monkeypatch
+    ) -> None:
+        """The master switch wins, so collection stops without editing lists."""
+        interceptors = self._interceptors_for(
+            monkeypatch, APPLICATION_SDK_SIZING_TELEMETRY_ACTIVITIES="merge"
+        )
+        assert self._has_sizing(interceptors) is False
+
     # ── max_concurrent_workflow_tasks (BLDX-1282) ─────────────────────────
 
     def test_max_concurrent_workflow_tasks_forwarded_when_set(self) -> None:

--- a/tests/unit/interceptors/test_sizing_interceptor.py
+++ b/tests/unit/interceptors/test_sizing_interceptor.py
@@ -1,0 +1,450 @@
+"""Unit tests for SizingTelemetryInterceptor and the observation record."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from application_sdk.execution._temporal.interceptors.sizing import (
+    SizingTelemetryInterceptor,
+    _SizingActivityInboundInterceptor,
+)
+from application_sdk.execution.settings import load_interceptor_settings
+from application_sdk.observability import sizing as sizing_module
+from application_sdk.observability.cgroup import ContainerTrace
+from application_sdk.observability.sizing import SizingObservation
+
+_ACTIVITY_TARGET = "application_sdk.execution._temporal.interceptors.sizing.activity"
+_TRACKER_TARGET = (
+    "application_sdk.execution._temporal.interceptors.sizing.track_container_usage"
+)
+_RECORD_TARGET = (
+    "application_sdk.execution._temporal.interceptors.sizing.record_observation"
+)
+_METER_TARGET = "application_sdk.observability.sizing._otel_metrics.get_meter"
+
+
+@dataclass
+class MockActivityInfo:
+    activity_type: str = "merge"
+    activity_id: str = "act-id"
+    task_queue: str = "app-worker"
+    workflow_id: str = "wf-id"
+    workflow_run_id: str = "run-id"
+    workflow_type: str = "MergeWorkflow"
+    attempt: int = 1
+
+
+@dataclass
+class MockExecuteActivityInput:
+    headers: dict = field(default_factory=dict)
+    args: list = field(default_factory=list)
+
+
+def _tracker(trace: ContainerTrace, *, fill_on_exit: ContainerTrace | None = None):
+    """A stand-in for ``track_container_usage``.
+
+    ``fill_on_exit`` reproduces the real contract: the tracker populates the peak
+    and the CPU deltas in *its* ``finally``, after the ``async with`` body has
+    run. A test double that pre-fills everything would pass even if the
+    interceptor read the trace from inside the block, which is the one ordering
+    mistake that silently produces all-zero telemetry.
+    """
+    import contextlib
+
+    @contextlib.asynccontextmanager
+    async def _cm(poll_interval_seconds: float = 1.0):
+        try:
+            yield trace
+        finally:
+            if fill_on_exit is not None:
+                trace.peak_memory_bytes = fill_on_exit.peak_memory_bytes
+                trace.peak_memory_fraction = fill_on_exit.peak_memory_fraction
+                trace.peak_source = fill_on_exit.peak_source
+                trace.cpu_seconds = fill_on_exit.cpu_seconds
+
+    return _cm
+
+
+class TestSizingObservation:
+    def test_mean_cpu_cores(self):
+        obs = SizingObservation(
+            activity_type="merge",
+            task_queue="q",
+            workflow_type="W",
+            attempt=1,
+            outcome="OK",
+            duration_seconds=20.0,
+            cpu_seconds=30.0,
+        )
+        assert obs.mean_cpu_cores == pytest.approx(1.5)
+
+    def test_mean_cpu_cores_none_without_cpu(self):
+        obs = SizingObservation(
+            activity_type="merge",
+            task_queue="q",
+            workflow_type="W",
+            attempt=1,
+            outcome="OK",
+            duration_seconds=20.0,
+        )
+        assert obs.mean_cpu_cores is None
+
+    def test_mean_cpu_cores_none_for_zero_duration(self):
+        """No divide-by-zero, and no infinite core count on a sub-tick activity."""
+        obs = SizingObservation(
+            activity_type="merge",
+            task_queue="q",
+            workflow_type="W",
+            attempt=1,
+            outcome="OK",
+            duration_seconds=0.0,
+            cpu_seconds=1.0,
+        )
+        assert obs.mean_cpu_cores is None
+
+    def test_has_data_is_false_when_nothing_was_measured(self):
+        """A non-cgroup host must produce no row, not a row of nulls.
+
+        A null peak read downstream as a zero would fit the smallest tier to an
+        activity nobody measured.
+        """
+        obs = SizingObservation(
+            activity_type="merge",
+            task_queue="q",
+            workflow_type="W",
+            attempt=1,
+            outcome="OK",
+            duration_seconds=1.0,
+        )
+        assert obs.has_data() is False
+
+    def test_has_data_is_true_with_cpu_only(self):
+        obs = SizingObservation(
+            activity_type="merge",
+            task_queue="q",
+            workflow_type="W",
+            attempt=1,
+            outcome="OK",
+            duration_seconds=1.0,
+            cpu_seconds=0.5,
+        )
+        assert obs.has_data() is True
+
+    def test_from_trace_carries_peak_source_and_throttling(self):
+        trace = ContainerTrace(
+            peak_memory_bytes=6 * 1024**3,
+            peak_memory_fraction=0.75,
+            peak_source="poll",
+            memory_limit_bytes=8 * 1024**3,
+            cpu_seconds=12.0,
+            cpu_throttled_seconds=3.0,
+            cpu_periods=100,
+            cpu_throttled_periods=25,
+            cpu_quota_cores=2.0,
+        )
+        obs = SizingObservation.from_trace(
+            trace,
+            activity_type="merge",
+            task_queue="q",
+            workflow_type="W",
+            attempt=2,
+            outcome="OK",
+            duration_seconds=10.0,
+        )
+        assert obs.peak_source == "poll"
+        assert obs.cpu_throttled_fraction == pytest.approx(0.25)
+        assert obs.cpu_quota_cores == 2.0
+        assert obs.attempt == 2
+
+
+class TestRecordObservation:
+    @pytest.fixture
+    def mock_meter(self):
+        sizing_module._INSTRUMENTS.clear()
+        m = MagicMock()
+        with patch(_METER_TARGET, return_value=m):
+            yield m
+        sizing_module._INSTRUMENTS.clear()
+
+    def _obs(self, **overrides):
+        base = {
+            "activity_type": "merge",
+            "task_queue": "app-worker",
+            "workflow_type": "MergeWorkflow",
+            "attempt": 1,
+            "outcome": "OK",
+            "duration_seconds": 10.0,
+            "peak_memory_bytes": 2 * 1024**3,
+            "peak_memory_fraction": 0.5,
+            "peak_source": "watermark",
+            "memory_limit_bytes": 4 * 1024**3,
+            "cpu_seconds": 5.0,
+            "cpu_throttled_fraction": 0.1,
+            "cpu_quota_cores": 1.0,
+        }
+        base.update(overrides)
+        return SizingObservation(**base)
+
+    def test_records_peak_in_mib(self, mock_meter):
+        sizing_module.record_observation(self._obs())
+        hist = mock_meter.create_histogram.return_value
+        recorded = [c[0][0] for c in hist.record.call_args_list]
+        assert 2048.0 in recorded
+
+    def test_labels_are_bounded(self, mock_meter):
+        """No workflow_id. It is a UUID and would blow up every histogram."""
+        sizing_module.record_observation(self._obs())
+        hist = mock_meter.create_histogram.return_value
+        attrs = hist.record.call_args_list[0][0][1]
+        assert set(attrs) == {
+            "activity.type",
+            "temporal.task_queue",
+            "outcome",
+            "peak.source",
+        }
+
+    def test_emits_nothing_when_there_is_no_data(self, mock_meter):
+        sizing_module.record_observation(
+            self._obs(
+                peak_memory_bytes=None,
+                peak_memory_fraction=None,
+                cpu_seconds=None,
+                cpu_throttled_fraction=None,
+            )
+        )
+        mock_meter.create_histogram.return_value.record.assert_not_called()
+
+    def test_never_raises_when_the_meter_is_broken(self, mock_meter):
+        """Called from an activity's finally; raising would replace its outcome."""
+        mock_meter.create_histogram.side_effect = RuntimeError("otel down")
+        sizing_module.record_observation(self._obs())  # must not raise
+
+    def test_logs_one_json_line_with_the_marker(self, mock_meter):
+        with patch.object(sizing_module, "_logger") as mock_log:
+            sizing_module.record_observation(self._obs())
+        msg, payload = mock_log.info.call_args[0]
+        assert "activity_sizing_observation" in msg
+        import orjson
+
+        parsed = orjson.loads(payload)
+        assert parsed["activity_type"] == "merge"
+        assert parsed["peak_source"] == "watermark"
+        assert parsed["mean_cpu_cores"] == pytest.approx(0.5)
+
+
+class TestSizingInterceptor:
+    @pytest.fixture
+    def mock_next(self):
+        n = AsyncMock()
+        n.execute_activity = AsyncMock(return_value="ok")
+        return n
+
+    async def test_returns_the_activity_result(self, mock_next):
+        interceptor = _SizingActivityInboundInterceptor(mock_next, 1.0)
+        with (
+            patch(_ACTIVITY_TARGET) as mock_act,
+            patch(_TRACKER_TARGET, _tracker(ContainerTrace())),
+            patch(_RECORD_TARGET),
+        ):
+            mock_act.info.return_value = MockActivityInfo()
+            assert (
+                await interceptor.execute_activity(MockExecuteActivityInput()) == "ok"
+            )
+
+    async def test_reads_the_trace_after_the_tracker_exits(self, mock_next):
+        """The ordering bug that would make every peak zero.
+
+        ``track_container_usage`` fills the watermark and the CPU deltas in its
+        own ``finally``. Recording from inside the ``async with`` body would
+        capture an empty trace and every collected peak would be null.
+        """
+        filled = ContainerTrace(
+            peak_memory_bytes=9 * 1024**3,
+            peak_memory_fraction=0.9,
+            peak_source="watermark",
+            cpu_seconds=4.0,
+        )
+        with (
+            patch(_ACTIVITY_TARGET) as mock_act,
+            patch(
+                _TRACKER_TARGET,
+                _tracker(ContainerTrace(), fill_on_exit=filled),
+            ),
+            patch(_RECORD_TARGET) as mock_record,
+        ):
+            mock_act.info.return_value = MockActivityInfo()
+            await interceptor_execute(mock_next)
+
+        obs = mock_record.call_args[0][0]
+        assert obs.peak_memory_bytes == 9 * 1024**3
+        assert obs.peak_source == "watermark"
+
+    async def test_tags_a_failure_as_error_and_still_records(self, mock_next):
+        """A failed activity is the most sizing-relevant sample there is."""
+        mock_next.execute_activity = AsyncMock(side_effect=ValueError("boom"))
+        interceptor = _SizingActivityInboundInterceptor(mock_next, 1.0)
+        trace = ContainerTrace(peak_memory_bytes=1024, peak_source="poll")
+        with (
+            patch(_ACTIVITY_TARGET) as mock_act,
+            patch(_TRACKER_TARGET, _tracker(trace)),
+            patch(_RECORD_TARGET) as mock_record,
+        ):
+            mock_act.info.return_value = MockActivityInfo()
+            with pytest.raises(ValueError, match="boom"):
+                await interceptor.execute_activity(MockExecuteActivityInput())
+
+        obs = mock_record.call_args[0][0]
+        assert obs.outcome == "ERROR"
+        assert obs.peak_memory_bytes == 1024
+
+    async def test_carries_the_activity_identity(self, mock_next):
+        interceptor = _SizingActivityInboundInterceptor(mock_next, 1.0)
+        with (
+            patch(_ACTIVITY_TARGET) as mock_act,
+            patch(_TRACKER_TARGET, _tracker(ContainerTrace(peak_memory_bytes=1))),
+            patch(_RECORD_TARGET) as mock_record,
+        ):
+            mock_act.info.return_value = MockActivityInfo(
+                activity_type="fetch_entities", task_queue="heavy", attempt=3
+            )
+            await interceptor.execute_activity(MockExecuteActivityInput())
+
+        obs = mock_record.call_args[0][0]
+        assert obs.activity_type == "fetch_entities"
+        assert obs.task_queue == "heavy"
+        assert obs.attempt == 3
+        assert obs.duration_seconds >= 0
+
+    async def test_poll_interval_is_passed_through(self, mock_next):
+        captured = {}
+
+        import contextlib
+
+        @contextlib.asynccontextmanager
+        async def _cm(poll_interval_seconds: float = 1.0):
+            captured["interval"] = poll_interval_seconds
+            yield ContainerTrace()
+
+        interceptor = SizingTelemetryInterceptor(
+            poll_interval_seconds=0.25
+        ).intercept_activity(mock_next)
+        with (
+            patch(_ACTIVITY_TARGET) as mock_act,
+            patch(_TRACKER_TARGET, _cm),
+            patch(_RECORD_TARGET),
+        ):
+            mock_act.info.return_value = MockActivityInfo()
+            await interceptor.execute_activity(MockExecuteActivityInput())
+
+        assert captured["interval"] == 0.25
+
+
+class TestAgainstTheRealTracker:
+    """The doubles above pin the interceptor's contract; this pins the wiring.
+
+    Every test in ``TestSizingInterceptor`` patches ``track_container_usage``, so
+    all of them would keep passing if the real tracker and the real interceptor
+    disagreed about when the trace is complete. This one runs both for real
+    against a fake cgroup on disk.
+    """
+
+    async def test_a_peak_reaches_the_observation(self, tmp_path, monkeypatch):
+        from application_sdk.observability import cgroup
+
+        peak = tmp_path / "memory.peak"
+        peak.write_text("5000")
+        current = tmp_path / "memory.current"
+        current.write_text("1000")
+        limit = tmp_path / "memory.max"
+        limit.write_text("20000")
+        monkeypatch.setattr(cgroup, "_MEMORY_PEAK_PATHS", (str(peak),))
+        monkeypatch.setattr(cgroup, "_MEMORY_CURRENT_PATHS", (str(current),))
+        monkeypatch.setattr(cgroup, "_MEMORY_LIMIT_PATHS", (str(limit),))
+
+        async def _work(_input):
+            peak.write_text("15000")  # the kernel recording a spike mid-activity
+            return "ok"
+
+        nxt = AsyncMock()
+        nxt.execute_activity = _work
+        interceptor = _SizingActivityInboundInterceptor(nxt, 0)
+
+        with (
+            patch(_ACTIVITY_TARGET) as mock_act,
+            patch(_RECORD_TARGET) as mock_record,
+        ):
+            mock_act.info.return_value = MockActivityInfo()
+            assert (
+                await interceptor.execute_activity(MockExecuteActivityInput()) == "ok"
+            )
+
+        obs = mock_record.call_args[0][0]
+        assert obs.peak_memory_bytes == 15000
+        assert obs.peak_memory_fraction == pytest.approx(0.75)
+        assert obs.peak_source == "watermark"
+        assert obs.has_data() is True
+
+    async def test_no_cgroup_produces_no_row(self, tmp_path, monkeypatch):
+        """Local dev and macOS. Nothing measured must mean nothing recorded."""
+        from application_sdk.observability import cgroup
+
+        missing = (str(tmp_path / "nope"),)
+        monkeypatch.setattr(cgroup, "_MEMORY_PEAK_PATHS", missing)
+        monkeypatch.setattr(cgroup, "_MEMORY_CURRENT_PATHS", missing)
+        monkeypatch.setattr(cgroup, "_MEMORY_LIMIT_PATHS", missing)
+        monkeypatch.setattr(cgroup, "_CPU_STAT_V2", str(tmp_path / "nope"))
+        monkeypatch.setattr(cgroup, "_CPU_STAT_V1", str(tmp_path / "nope"))
+        monkeypatch.delenv("K8S_POD_MEMORY_LIMIT", raising=False)
+
+        nxt = AsyncMock()
+        nxt.execute_activity = AsyncMock(return_value="ok")
+        interceptor = _SizingActivityInboundInterceptor(nxt, 1.0)
+
+        with (
+            patch(_ACTIVITY_TARGET) as mock_act,
+            patch.object(sizing_module, "_logger") as mock_log,
+            patch(_METER_TARGET) as mock_meter,
+        ):
+            mock_act.info.return_value = MockActivityInfo()
+            await interceptor.execute_activity(MockExecuteActivityInput())
+
+        mock_log.info.assert_not_called()
+        mock_meter.assert_not_called()
+
+
+async def interceptor_execute(mock_next):
+    interceptor = _SizingActivityInboundInterceptor(mock_next, 1.0)
+    return await interceptor.execute_activity(MockExecuteActivityInput())
+
+
+class TestSizingSettings:
+    def test_off_by_default(self, monkeypatch):
+        """An SDK version bump alone must change nothing on any tenant."""
+        monkeypatch.delenv("APPLICATION_SDK_ENABLE_SIZING_TELEMETRY", raising=False)
+        assert load_interceptor_settings().enable_sizing_telemetry is False
+
+    def test_enabled_by_env(self, monkeypatch):
+        monkeypatch.setenv("APPLICATION_SDK_ENABLE_SIZING_TELEMETRY", "true")
+        assert load_interceptor_settings().enable_sizing_telemetry is True
+
+    def test_poll_seconds_default(self, monkeypatch):
+        monkeypatch.delenv(
+            "APPLICATION_SDK_SIZING_TELEMETRY_POLL_SECONDS", raising=False
+        )
+        assert load_interceptor_settings().sizing_telemetry_poll_seconds == 1.0
+
+    def test_poll_seconds_override(self, monkeypatch):
+        monkeypatch.setenv("APPLICATION_SDK_SIZING_TELEMETRY_POLL_SECONDS", "0.5")
+        assert load_interceptor_settings().sizing_telemetry_poll_seconds == 0.5
+
+    def test_garbage_poll_seconds_falls_back(self, monkeypatch):
+        """A bad env value must not stop a tenant's workers from starting."""
+        monkeypatch.setenv("APPLICATION_SDK_SIZING_TELEMETRY_POLL_SECONDS", "soon")
+        assert load_interceptor_settings().sizing_telemetry_poll_seconds == 1.0
+
+    def test_negative_poll_seconds_is_clamped(self, monkeypatch):
+        monkeypatch.setenv("APPLICATION_SDK_SIZING_TELEMETRY_POLL_SECONDS", "-5")
+        assert load_interceptor_settings().sizing_telemetry_poll_seconds == 0.0

--- a/tests/unit/interceptors/test_sizing_interceptor.py
+++ b/tests/unit/interceptors/test_sizing_interceptor.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from application_sdk.execution._temporal.interceptors.sizing import (
+    WILDCARD,
     SizingTelemetryInterceptor,
     _SizingActivityInboundInterceptor,
 )
@@ -243,7 +244,9 @@ class TestSizingInterceptor:
         return n
 
     async def test_returns_the_activity_result(self, mock_next):
-        interceptor = _SizingActivityInboundInterceptor(mock_next, 1.0)
+        interceptor = _SizingActivityInboundInterceptor(
+            mock_next, 1.0, frozenset({"merge"})
+        )
         with (
             patch(_ACTIVITY_TARGET) as mock_act,
             patch(_TRACKER_TARGET, _tracker(ContainerTrace())),
@@ -285,7 +288,9 @@ class TestSizingInterceptor:
     async def test_tags_a_failure_as_error_and_still_records(self, mock_next):
         """A failed activity is the most sizing-relevant sample there is."""
         mock_next.execute_activity = AsyncMock(side_effect=ValueError("boom"))
-        interceptor = _SizingActivityInboundInterceptor(mock_next, 1.0)
+        interceptor = _SizingActivityInboundInterceptor(
+            mock_next, 1.0, frozenset({"merge"})
+        )
         trace = ContainerTrace(peak_memory_bytes=1024, peak_source="poll")
         with (
             patch(_ACTIVITY_TARGET) as mock_act,
@@ -301,12 +306,15 @@ class TestSizingInterceptor:
         assert obs.peak_memory_bytes == 1024
 
     async def test_carries_the_activity_identity(self, mock_next):
-        interceptor = _SizingActivityInboundInterceptor(mock_next, 1.0)
+        interceptor = _SizingActivityInboundInterceptor(
+            mock_next, 1.0, frozenset({"merge"})
+        )
         with (
             patch(_ACTIVITY_TARGET) as mock_act,
             patch(_TRACKER_TARGET, _tracker(ContainerTrace(peak_memory_bytes=1))),
             patch(_RECORD_TARGET) as mock_record,
         ):
+            interceptor._activities = frozenset({"fetch_entities"})
             mock_act.info.return_value = MockActivityInfo(
                 activity_type="fetch_entities", task_queue="heavy", attempt=3
             )
@@ -329,7 +337,7 @@ class TestSizingInterceptor:
             yield ContainerTrace()
 
         interceptor = SizingTelemetryInterceptor(
-            poll_interval_seconds=0.25
+            poll_interval_seconds=0.25, activities=frozenset({"merge"})
         ).intercept_activity(mock_next)
         with (
             patch(_ACTIVITY_TARGET) as mock_act,
@@ -370,7 +378,7 @@ class TestAgainstTheRealTracker:
 
         nxt = AsyncMock()
         nxt.execute_activity = _work
-        interceptor = _SizingActivityInboundInterceptor(nxt, 0)
+        interceptor = _SizingActivityInboundInterceptor(nxt, 0, frozenset({"merge"}))
 
         with (
             patch(_ACTIVITY_TARGET) as mock_act,
@@ -401,7 +409,7 @@ class TestAgainstTheRealTracker:
 
         nxt = AsyncMock()
         nxt.execute_activity = AsyncMock(return_value="ok")
-        interceptor = _SizingActivityInboundInterceptor(nxt, 1.0)
+        interceptor = _SizingActivityInboundInterceptor(nxt, 1.0, frozenset({"merge"}))
 
         with (
             patch(_ACTIVITY_TARGET) as mock_act,
@@ -416,8 +424,91 @@ class TestAgainstTheRealTracker:
 
 
 async def interceptor_execute(mock_next):
-    interceptor = _SizingActivityInboundInterceptor(mock_next, 1.0)
+    interceptor = _SizingActivityInboundInterceptor(
+        mock_next, 1.0, frozenset({"merge"})
+    )
     return await interceptor.execute_activity(MockExecuteActivityInput())
+
+
+class TestActivityAllowList:
+    """Only the activities a dev names get measured."""
+
+    @pytest.fixture
+    def mock_next(self):
+        n = AsyncMock()
+        n.execute_activity = AsyncMock(return_value="ok")
+        return n
+
+    async def test_unselected_activity_is_never_measured(self, mock_next):
+        interceptor = _SizingActivityInboundInterceptor(
+            mock_next, 1.0, frozenset({"merge"})
+        )
+        with (
+            patch(_ACTIVITY_TARGET) as mock_act,
+            patch(_TRACKER_TARGET) as mock_tracker,
+            patch(_RECORD_TARGET) as mock_record,
+        ):
+            mock_act.info.return_value = MockActivityInfo(activity_type="write_state")
+            assert (
+                await interceptor.execute_activity(MockExecuteActivityInput()) == "ok"
+            )
+
+        # The tracker is never even constructed: an unselected activity must cost a
+        # set lookup, not a cgroup probe. Asserting on the tracker rather than on
+        # the record is what pins that — filtering later would still record nothing
+        # while paying the setup on every activity in the app.
+        mock_tracker.assert_not_called()
+        mock_record.assert_not_called()
+
+    async def test_selected_activity_is_measured(self, mock_next):
+        interceptor = _SizingActivityInboundInterceptor(
+            mock_next, 1.0, frozenset({"merge", "fetch_entities"})
+        )
+        with (
+            patch(_ACTIVITY_TARGET) as mock_act,
+            patch(_TRACKER_TARGET, _tracker(ContainerTrace(peak_memory_bytes=1))),
+            patch(_RECORD_TARGET) as mock_record,
+        ):
+            mock_act.info.return_value = MockActivityInfo(activity_type="merge")
+            await interceptor.execute_activity(MockExecuteActivityInput())
+        mock_record.assert_called_once()
+
+    async def test_empty_allow_list_measures_nothing(self, mock_next):
+        """Fails closed: attached but empty must be inert."""
+        interceptor = _SizingActivityInboundInterceptor(mock_next, 1.0, frozenset())
+        with (
+            patch(_ACTIVITY_TARGET) as mock_act,
+            patch(_TRACKER_TARGET) as mock_tracker,
+            patch(_RECORD_TARGET) as mock_record,
+        ):
+            mock_act.info.return_value = MockActivityInfo(activity_type="merge")
+            await interceptor.execute_activity(MockExecuteActivityInput())
+        mock_tracker.assert_not_called()
+        mock_record.assert_not_called()
+
+    async def test_wildcard_measures_everything(self, mock_next):
+        interceptor = _SizingActivityInboundInterceptor(
+            mock_next, 1.0, frozenset({WILDCARD})
+        )
+        with (
+            patch(_ACTIVITY_TARGET) as mock_act,
+            patch(_TRACKER_TARGET, _tracker(ContainerTrace(peak_memory_bytes=1))),
+            patch(_RECORD_TARGET) as mock_record,
+        ):
+            mock_act.info.return_value = MockActivityInfo(activity_type="anything")
+            await interceptor.execute_activity(MockExecuteActivityInput())
+        mock_record.assert_called_once()
+
+    async def test_a_failing_unselected_activity_still_propagates(self, mock_next):
+        """The passthrough path must not change failure behaviour either."""
+        mock_next.execute_activity = AsyncMock(side_effect=ValueError("boom"))
+        interceptor = _SizingActivityInboundInterceptor(
+            mock_next, 1.0, frozenset({"merge"})
+        )
+        with patch(_ACTIVITY_TARGET) as mock_act:
+            mock_act.info.return_value = MockActivityInfo(activity_type="other")
+            with pytest.raises(ValueError, match="boom"):
+                await interceptor.execute_activity(MockExecuteActivityInput())
 
 
 class TestSizingSettings:
@@ -448,3 +539,31 @@ class TestSizingSettings:
     def test_negative_poll_seconds_is_clamped(self, monkeypatch):
         monkeypatch.setenv("APPLICATION_SDK_SIZING_TELEMETRY_POLL_SECONDS", "-5")
         assert load_interceptor_settings().sizing_telemetry_poll_seconds == 0.0
+
+    def test_activities_default_to_empty(self, monkeypatch):
+        """Unset must mean nothing measured, never everything measured."""
+        monkeypatch.delenv("APPLICATION_SDK_SIZING_TELEMETRY_ACTIVITIES", raising=False)
+        assert load_interceptor_settings().sizing_telemetry_activities == frozenset()
+
+    def test_activities_are_parsed(self, monkeypatch):
+        monkeypatch.setenv(
+            "APPLICATION_SDK_SIZING_TELEMETRY_ACTIVITIES", "merge,fetch_entities"
+        )
+        assert load_interceptor_settings().sizing_telemetry_activities == frozenset(
+            {"merge", "fetch_entities"}
+        )
+
+    def test_activities_tolerate_helm_whitespace_and_empty_entries(self, monkeypatch):
+        """Hand-edited in a values file, so ' merge , , transform ' has to work."""
+        monkeypatch.setenv(
+            "APPLICATION_SDK_SIZING_TELEMETRY_ACTIVITIES", " merge , , transform ,"
+        )
+        assert load_interceptor_settings().sizing_telemetry_activities == frozenset(
+            {"merge", "transform"}
+        )
+
+    def test_wildcard_is_parsed(self, monkeypatch):
+        monkeypatch.setenv("APPLICATION_SDK_SIZING_TELEMETRY_ACTIVITIES", "*")
+        assert load_interceptor_settings().sizing_telemetry_activities == frozenset(
+            {"*"}
+        )

--- a/tests/unit/interceptors/test_sizing_interceptor.py
+++ b/tests/unit/interceptors/test_sizing_interceptor.py
@@ -411,6 +411,66 @@ class TestAgainstTheRealTracker:
         mock_meter.assert_not_called()
 
 
+class TestInputSizeReachesTheRecord:
+    """The driver variable has to arrive on the same row as the peak."""
+
+    @pytest.fixture
+    def mock_next(self):
+        n = AsyncMock()
+        n.execute_activity = AsyncMock(return_value="ok")
+        return n
+
+    def _input_with(self, tmp_path, size: int):
+        from pydantic import BaseModel
+
+        from application_sdk.contracts.types import FileReference
+
+        f = tmp_path / "in.parquet"
+        f.write_bytes(b"x" * size)
+
+        class _In(BaseModel):
+            ref: FileReference
+
+        # args[0] is TaskContext, args[1] is the Input — matching the v3
+        # activity signature the interceptor reads.
+        return MockExecuteActivityInput(
+            args=[object(), _In(ref=FileReference(local_path=str(f)))]
+        )
+
+    async def _run(self, mock_next, activity_input):
+        interceptor = _SizingActivityInboundInterceptor(
+            mock_next, 1.0, frozenset({"merge"})
+        )
+        with (
+            patch(_ACTIVITY_TARGET) as mock_act,
+            patch(_TRACKER_TARGET, _tracker(ContainerTrace(peak_memory_bytes=3000))),
+            patch(_RECORD_TARGET) as mock_record,
+        ):
+            mock_act.info.return_value = MockActivityInfo(activity_type="merge")
+            await interceptor.execute_activity(activity_input)
+        return mock_record.call_args[0][0]
+
+    async def test_file_reference_size_is_recorded(self, mock_next, tmp_path):
+        obs = await self._run(mock_next, self._input_with(tmp_path, 1000))
+        assert obs.input_bytes == 1000
+        assert obs.input_basis == "file_reference"
+        assert obs.peak_per_input_byte == pytest.approx(3.0)
+
+    async def test_no_input_args_is_not_an_error(self, mock_next):
+        """Activities with no Input still produce a peak row, just no driver."""
+        obs = await self._run(mock_next, MockExecuteActivityInput())
+        assert obs.input_bytes is None
+        assert obs.peak_memory_bytes == 3000
+
+    async def test_unsizeable_input_still_records_the_peak(self, mock_next):
+        """An input the sizer cannot read must not cost the peak measurement."""
+        obs = await self._run(
+            mock_next, MockExecuteActivityInput(args=[object(), "not a model"])
+        )
+        assert obs.input_bytes is None
+        assert obs.peak_memory_bytes == 3000
+
+
 async def interceptor_execute(mock_next):
     interceptor = _SizingActivityInboundInterceptor(
         mock_next, 1.0, frozenset({"merge"})

--- a/tests/unit/interceptors/test_sizing_interceptor.py
+++ b/tests/unit/interceptors/test_sizing_interceptor.py
@@ -47,11 +47,8 @@ class MockExecuteActivityInput:
 def _tracker(trace: ContainerTrace, *, fill_on_exit: ContainerTrace | None = None):
     """A stand-in for ``track_container_usage``.
 
-    ``fill_on_exit`` reproduces the real contract: the tracker populates the peak
-    and the CPU deltas in *its* ``finally``, after the ``async with`` body has
-    run. A test double that pre-fills everything would pass even if the
-    interceptor read the trace from inside the block, which is the one ordering
-    mistake that silently produces all-zero telemetry.
+    ``fill_on_exit`` reproduces the real contract — the tracker fills the trace in
+    *its* ``finally`` — so a double that pre-filled it would hide the ordering bug.
     """
     import contextlib
 
@@ -94,7 +91,7 @@ class TestSizingObservation:
         assert obs.mean_cpu_cores is None
 
     def test_mean_cpu_cores_none_for_zero_duration(self):
-        """No divide-by-zero, and no infinite core count on a sub-tick activity."""
+        """No divide-by-zero on a sub-tick activity."""
         obs = SizingObservation(
             activity_type="merge",
             task_queue="q",
@@ -107,11 +104,8 @@ class TestSizingObservation:
         assert obs.mean_cpu_cores is None
 
     def test_has_data_is_false_when_nothing_was_measured(self):
-        """A non-cgroup host must produce no row, not a row of nulls.
-
-        A null peak read downstream as a zero would fit the smallest tier to an
-        activity nobody measured.
-        """
+        """A non-cgroup host produces no row — a null read as zero fits the
+        smallest tier to an activity nobody measured."""
         obs = SizingObservation(
             activity_type="merge",
             task_queue="q",
@@ -196,7 +190,7 @@ class TestRecordObservation:
         assert 2048.0 in recorded
 
     def test_labels_are_bounded(self, mock_meter):
-        """No workflow_id. It is a UUID and would blow up every histogram."""
+        """No workflow_id — a UUID would blow up every histogram."""
         sizing_module.record_observation(self._obs())
         hist = mock_meter.create_histogram.return_value
         attrs = hist.record.call_args_list[0][0][1]
@@ -258,12 +252,8 @@ class TestSizingInterceptor:
             )
 
     async def test_reads_the_trace_after_the_tracker_exits(self, mock_next):
-        """The ordering bug that would make every peak zero.
-
-        ``track_container_usage`` fills the watermark and the CPU deltas in its
-        own ``finally``. Recording from inside the ``async with`` body would
-        capture an empty trace and every collected peak would be null.
-        """
+        """Recording inside the ``async with`` would capture an empty trace and
+        null every collected peak."""
         filled = ContainerTrace(
             peak_memory_bytes=9 * 1024**3,
             peak_memory_fraction=0.9,
@@ -351,12 +341,10 @@ class TestSizingInterceptor:
 
 
 class TestAgainstTheRealTracker:
-    """The doubles above pin the interceptor's contract; this pins the wiring.
+    """The doubles above pin the contract; this pins the wiring.
 
-    Every test in ``TestSizingInterceptor`` patches ``track_container_usage``, so
-    all of them would keep passing if the real tracker and the real interceptor
-    disagreed about when the trace is complete. This one runs both for real
-    against a fake cgroup on disk.
+    Everything in ``TestSizingInterceptor`` patches the tracker, so all of it would
+    pass if tracker and interceptor disagreed on when the trace is complete.
     """
 
     async def test_a_peak_reaches_the_observation(self, tmp_path, monkeypatch):
@@ -396,7 +384,7 @@ class TestAgainstTheRealTracker:
         assert obs.has_data() is True
 
     async def test_no_cgroup_produces_no_row(self, tmp_path, monkeypatch):
-        """Local dev and macOS. Nothing measured must mean nothing recorded."""
+        """Nothing measured must mean nothing recorded."""
         from application_sdk.observability import cgroup
 
         missing = (str(tmp_path / "nope"),)
@@ -453,10 +441,8 @@ class TestActivityAllowList:
                 await interceptor.execute_activity(MockExecuteActivityInput()) == "ok"
             )
 
-        # The tracker is never even constructed: an unselected activity must cost a
-        # set lookup, not a cgroup probe. Asserting on the tracker rather than on
-        # the record is what pins that — filtering later would still record nothing
-        # while paying the setup on every activity in the app.
+        # Asserting on the tracker, not the record: filtering later would also
+        # record nothing while still paying setup on every activity.
         mock_tracker.assert_not_called()
         mock_record.assert_not_called()
 
@@ -500,11 +486,8 @@ class TestActivityAllowList:
         mock_record.assert_called_once()
 
     async def test_bare_name_matches_the_qualified_activity_type(self, mock_next):
-        """A v3 activity registers as "{app}:{task}", but a dev writes the task name.
-
-        Requiring "automation-engine:merge" would silently collect nothing while
-        the config looked correct — so the bare name has to match.
-        """
+        """A v3 activity registers as "{app}:{task}" but a dev writes the task name;
+        requiring the qualified form would silently collect nothing."""
         interceptor = _SizingActivityInboundInterceptor(
             mock_next, 1.0, frozenset({"merge"})
         )
@@ -521,7 +504,7 @@ class TestActivityAllowList:
         assert mock_record.call_args[0][0].activity_type == "automation-engine:merge"
 
     async def test_qualified_name_also_matches(self, mock_next):
-        """Both spellings work, so an app with two same-named tasks can disambiguate."""
+        """Both spellings work, so same-named tasks can be disambiguated."""
         interceptor = _SizingActivityInboundInterceptor(
             mock_next, 1.0, frozenset({"automation-engine:merge"})
         )
@@ -554,7 +537,7 @@ class TestActivityAllowList:
         mock_record.assert_not_called()
 
     async def test_a_failing_unselected_activity_still_propagates(self, mock_next):
-        """The passthrough path must not change failure behaviour either."""
+        """The passthrough path must not change failure behaviour."""
         mock_next.execute_activity = AsyncMock(side_effect=ValueError("boom"))
         interceptor = _SizingActivityInboundInterceptor(
             mock_next, 1.0, frozenset({"merge"})
@@ -567,7 +550,7 @@ class TestActivityAllowList:
 
 class TestSizingSettings:
     def test_off_by_default(self, monkeypatch):
-        """An SDK version bump alone must change nothing on any tenant."""
+        """A version bump alone must change nothing on any tenant."""
         monkeypatch.delenv("APPLICATION_SDK_ENABLE_SIZING_TELEMETRY", raising=False)
         assert load_interceptor_settings().enable_sizing_telemetry is False
 
@@ -586,7 +569,7 @@ class TestSizingSettings:
         assert load_interceptor_settings().sizing_telemetry_poll_seconds == 0.5
 
     def test_garbage_poll_seconds_falls_back(self, monkeypatch):
-        """A bad env value must not stop a tenant's workers from starting."""
+        """A bad env value must not stop workers starting."""
         monkeypatch.setenv("APPLICATION_SDK_SIZING_TELEMETRY_POLL_SECONDS", "soon")
         assert load_interceptor_settings().sizing_telemetry_poll_seconds == 1.0
 
@@ -595,7 +578,7 @@ class TestSizingSettings:
         assert load_interceptor_settings().sizing_telemetry_poll_seconds == 0.0
 
     def test_activities_default_to_empty(self, monkeypatch):
-        """Unset must mean nothing measured, never everything measured."""
+        """Unset means nothing measured, never everything."""
         monkeypatch.delenv("APPLICATION_SDK_SIZING_TELEMETRY_ACTIVITIES", raising=False)
         assert load_interceptor_settings().sizing_telemetry_activities == frozenset()
 
@@ -608,7 +591,7 @@ class TestSizingSettings:
         )
 
     def test_activities_tolerate_helm_whitespace_and_empty_entries(self, monkeypatch):
-        """Hand-edited in a values file, so ' merge , , transform ' has to work."""
+        """Hand-edited in a values file, so stray whitespace has to work."""
         monkeypatch.setenv(
             "APPLICATION_SDK_SIZING_TELEMETRY_ACTIVITIES", " merge , , transform ,"
         )

--- a/tests/unit/interceptors/test_sizing_interceptor.py
+++ b/tests/unit/interceptors/test_sizing_interceptor.py
@@ -52,8 +52,13 @@ def _tracker(trace: ContainerTrace, *, fill_on_exit: ContainerTrace | None = Non
     """
     import contextlib
 
+    calls: list[dict] = []
+
     @contextlib.asynccontextmanager
-    async def _cm(poll_interval_seconds: float = 1.0):
+    async def _cm(
+        poll_interval_seconds: float = 1.0, allow_watermark_reset: bool = True
+    ):
+        calls.append({"allow_watermark_reset": allow_watermark_reset})
         try:
             yield trace
         finally:
@@ -63,6 +68,7 @@ def _tracker(trace: ContainerTrace, *, fill_on_exit: ContainerTrace | None = Non
                 trace.peak_source = fill_on_exit.peak_source
                 trace.cpu_seconds = fill_on_exit.cpu_seconds
 
+    _cm.calls = calls  # type: ignore[attr-defined]
     return _cm
 
 
@@ -199,6 +205,7 @@ class TestRecordObservation:
             "temporal.task_queue",
             "outcome",
             "peak.source",
+            "attributable",
         }
 
     def test_emits_nothing_when_there_is_no_data(self, mock_meter):
@@ -322,7 +329,9 @@ class TestSizingInterceptor:
         import contextlib
 
         @contextlib.asynccontextmanager
-        async def _cm(poll_interval_seconds: float = 1.0):
+        async def _cm(
+            poll_interval_seconds: float = 1.0, allow_watermark_reset: bool = True
+        ):
             captured["interval"] = poll_interval_seconds
             yield ContainerTrace()
 
@@ -469,6 +478,239 @@ class TestInputSizeReachesTheRecord:
         )
         assert obs.input_bytes is None
         assert obs.peak_memory_bytes == 3000
+
+
+class TestConcurrencyAttribution:
+    """The peak is pod-wide unless one activity had the process to itself."""
+
+    @pytest.fixture(autouse=True)
+    def clean_census(self):
+        from application_sdk.observability.sizing_census import CENSUS
+
+        CENSUS._reset_for_testing()
+        yield
+        CENSUS._reset_for_testing()
+
+    @pytest.fixture
+    def mock_next(self):
+        n = AsyncMock()
+        n.execute_activity = AsyncMock(return_value="ok")
+        return n
+
+    async def test_alone_allows_the_watermark_reset(self, mock_next):
+        tracker = _tracker(ContainerTrace(peak_memory_bytes=1))
+        interceptor = _SizingActivityInboundInterceptor(
+            mock_next, 1.0, frozenset({"merge"})
+        )
+        with (
+            patch(_ACTIVITY_TARGET) as mock_act,
+            patch(_TRACKER_TARGET, tracker),
+            patch(_RECORD_TARGET) as mock_record,
+        ):
+            mock_act.info.return_value = MockActivityInfo(activity_type="merge")
+            await interceptor.execute_activity(MockExecuteActivityInput())
+
+        assert tracker.calls[0]["allow_watermark_reset"] is True
+        obs = mock_record.call_args[0][0]
+        assert obs.concurrency_max == 1
+        assert obs.is_attributable is True
+
+    async def test_concurrent_forbids_the_watermark_reset(self, mock_next):
+        """Two activities resetting one kernel counter is cross-talk, not noise.
+
+        Each would read a peak measured from the other's reset — wrong in an
+        unpredictable direction, where a pod-wide poll is merely coarse.
+        """
+        import asyncio
+
+        started = asyncio.Event()
+        release = asyncio.Event()
+
+        async def slow(_input):
+            started.set()
+            await release.wait()
+            return "ok"
+
+        tracker = _tracker(ContainerTrace(peak_memory_bytes=1))
+        first_next = AsyncMock()
+        first_next.execute_activity = slow
+        first = _SizingActivityInboundInterceptor(first_next, 1.0, frozenset({"merge"}))
+        second = _SizingActivityInboundInterceptor(mock_next, 1.0, frozenset({"merge"}))
+
+        with (
+            patch(_ACTIVITY_TARGET) as mock_act,
+            patch(_TRACKER_TARGET, tracker),
+            patch(_RECORD_TARGET) as mock_record,
+        ):
+            mock_act.info.return_value = MockActivityInfo(activity_type="merge")
+            task = asyncio.create_task(
+                first.execute_activity(MockExecuteActivityInput())
+            )
+            await started.wait()
+            # Second activity enters while the first is still in flight.
+            await second.execute_activity(MockExecuteActivityInput())
+            release.set()
+            await task
+
+        # The second saw concurrency 2 at entry, so it must not reset.
+        assert tracker.calls[1]["allow_watermark_reset"] is False
+        observations = [c[0][0] for c in mock_record.call_args_list]
+        assert all(o.concurrency_max == 2 for o in observations)
+        assert all(o.is_attributable is False for o in observations)
+
+    async def test_first_activity_records_the_high_water_mark(self, mock_next):
+        """It was alone at entry but not for its whole window."""
+        import asyncio
+
+        started = asyncio.Event()
+        release = asyncio.Event()
+
+        async def slow(_input):
+            started.set()
+            await release.wait()
+            return "ok"
+
+        first_next = AsyncMock()
+        first_next.execute_activity = slow
+        first = _SizingActivityInboundInterceptor(first_next, 1.0, frozenset({"merge"}))
+        second = _SizingActivityInboundInterceptor(mock_next, 1.0, frozenset({"merge"}))
+
+        with (
+            patch(_ACTIVITY_TARGET) as mock_act,
+            patch(_TRACKER_TARGET, _tracker(ContainerTrace(peak_memory_bytes=1))),
+            patch(_RECORD_TARGET) as mock_record,
+        ):
+            mock_act.info.return_value = MockActivityInfo(activity_type="merge")
+            task = asyncio.create_task(
+                first.execute_activity(MockExecuteActivityInput())
+            )
+            await started.wait()
+            await second.execute_activity(MockExecuteActivityInput())
+            release.set()
+            await task
+
+        first_obs = [c[0][0] for c in mock_record.call_args_list][-1]
+        assert first_obs.concurrency_max == 2
+        assert first_obs.is_attributable is False
+
+    async def test_records_the_join_keys(self, mock_next, monkeypatch):
+        """pod + started_at + duration is what lets analysis rebuild the overlap."""
+        monkeypatch.setenv("K8S_POD_NAME", "ae-heavy-7f9c")
+        interceptor = _SizingActivityInboundInterceptor(
+            mock_next, 1.0, frozenset({"merge"})
+        )
+        with (
+            patch(_ACTIVITY_TARGET) as mock_act,
+            patch(_TRACKER_TARGET, _tracker(ContainerTrace(peak_memory_bytes=1))),
+            patch(_RECORD_TARGET) as mock_record,
+        ):
+            mock_act.info.return_value = MockActivityInfo(activity_type="merge")
+            await interceptor.execute_activity(MockExecuteActivityInput())
+
+        obs = mock_record.call_args[0][0]
+        assert obs.pod == "ae-heavy-7f9c"
+        assert obs.started_at is not None and obs.started_at > 1_600_000_000
+        assert obs.duration_seconds >= 0
+
+    async def test_falls_back_to_hostname(self, mock_next, monkeypatch):
+        monkeypatch.delenv("K8S_POD_NAME", raising=False)
+        monkeypatch.setenv("HOSTNAME", "worker-abc")
+        interceptor = _SizingActivityInboundInterceptor(
+            mock_next, 1.0, frozenset({"merge"})
+        )
+        with (
+            patch(_ACTIVITY_TARGET) as mock_act,
+            patch(_TRACKER_TARGET, _tracker(ContainerTrace(peak_memory_bytes=1))),
+            patch(_RECORD_TARGET) as mock_record,
+        ):
+            mock_act.info.return_value = MockActivityInfo(activity_type="merge")
+            await interceptor.execute_activity(MockExecuteActivityInput())
+
+        assert mock_record.call_args[0][0].pod == "worker-abc"
+
+    async def test_census_is_released_on_failure(self, mock_next):
+        """A leaked census entry would inflate concurrency for the pod's lifetime."""
+        from application_sdk.observability.sizing_census import CENSUS
+
+        mock_next.execute_activity = AsyncMock(side_effect=ValueError("boom"))
+        interceptor = _SizingActivityInboundInterceptor(
+            mock_next, 1.0, frozenset({"merge"})
+        )
+        with (
+            patch(_ACTIVITY_TARGET) as mock_act,
+            patch(_TRACKER_TARGET, _tracker(ContainerTrace(peak_memory_bytes=1))),
+            patch(_RECORD_TARGET),
+        ):
+            mock_act.info.return_value = MockActivityInfo(activity_type="merge")
+            with pytest.raises(ValueError):
+                await interceptor.execute_activity(MockExecuteActivityInput())
+
+        assert CENSUS.active() == 0
+
+    async def test_an_unmeasured_activity_still_invalidates_attribution(
+        self, mock_next
+    ):
+        """The census counts every activity, not just the allow-listed ones.
+
+        What breaks attribution is another activity using the pod's memory —
+        not whether we happened to be measuring it. Counting only the allow-list
+        would let a measured merge sharing a pod with unmeasured work report
+        concurrency_max=1, which is precisely the silent lie this field prevents.
+        """
+        import asyncio
+
+        started = asyncio.Event()
+        release = asyncio.Event()
+
+        async def slow(_input):
+            started.set()
+            await release.wait()
+            return "ok"
+
+        untracked_next = AsyncMock()
+        untracked_next.execute_activity = slow
+        untracked = _SizingActivityInboundInterceptor(
+            untracked_next, 1.0, frozenset({"merge"})
+        )
+        tracked = _SizingActivityInboundInterceptor(
+            mock_next, 1.0, frozenset({"merge"})
+        )
+
+        with (
+            patch(_ACTIVITY_TARGET) as mock_act,
+            patch(_TRACKER_TARGET, _tracker(ContainerTrace(peak_memory_bytes=1))),
+            patch(_RECORD_TARGET) as mock_record,
+        ):
+            # An activity NOT on the allow-list, holding the pod.
+            mock_act.info.return_value = MockActivityInfo(activity_type="write_state")
+            task = asyncio.create_task(
+                untracked.execute_activity(MockExecuteActivityInput())
+            )
+            await started.wait()
+            # Now a measured one runs alongside it.
+            mock_act.info.return_value = MockActivityInfo(activity_type="merge")
+            await tracked.execute_activity(MockExecuteActivityInput())
+            release.set()
+            await task
+
+        # Only the merge produced a row, and it knows it was not alone.
+        assert mock_record.call_count == 1
+        obs = mock_record.call_args[0][0]
+        assert obs.concurrency_max == 2
+        assert obs.is_attributable is False
+
+    async def test_the_census_is_released_for_unselected_activities(self, mock_next):
+        """Counted, but never leaked — an unreleased slot would inflate forever."""
+        from application_sdk.observability.sizing_census import CENSUS
+
+        interceptor = _SizingActivityInboundInterceptor(
+            mock_next, 1.0, frozenset({"merge"})
+        )
+        with patch(_ACTIVITY_TARGET) as mock_act:
+            mock_act.info.return_value = MockActivityInfo(activity_type="other")
+            await interceptor.execute_activity(MockExecuteActivityInput())
+
+        assert CENSUS.active() == 0
 
 
 async def interceptor_execute(mock_next):

--- a/tests/unit/interceptors/test_sizing_interceptor.py
+++ b/tests/unit/interceptors/test_sizing_interceptor.py
@@ -499,6 +499,60 @@ class TestActivityAllowList:
             await interceptor.execute_activity(MockExecuteActivityInput())
         mock_record.assert_called_once()
 
+    async def test_bare_name_matches_the_qualified_activity_type(self, mock_next):
+        """A v3 activity registers as "{app}:{task}", but a dev writes the task name.
+
+        Requiring "automation-engine:merge" would silently collect nothing while
+        the config looked correct — so the bare name has to match.
+        """
+        interceptor = _SizingActivityInboundInterceptor(
+            mock_next, 1.0, frozenset({"merge"})
+        )
+        with (
+            patch(_ACTIVITY_TARGET) as mock_act,
+            patch(_TRACKER_TARGET, _tracker(ContainerTrace(peak_memory_bytes=1))),
+            patch(_RECORD_TARGET) as mock_record,
+        ):
+            mock_act.info.return_value = MockActivityInfo(
+                activity_type="automation-engine:merge"
+            )
+            await interceptor.execute_activity(MockExecuteActivityInput())
+        mock_record.assert_called_once()
+        assert mock_record.call_args[0][0].activity_type == "automation-engine:merge"
+
+    async def test_qualified_name_also_matches(self, mock_next):
+        """Both spellings work, so an app with two same-named tasks can disambiguate."""
+        interceptor = _SizingActivityInboundInterceptor(
+            mock_next, 1.0, frozenset({"automation-engine:merge"})
+        )
+        with (
+            patch(_ACTIVITY_TARGET) as mock_act,
+            patch(_TRACKER_TARGET, _tracker(ContainerTrace(peak_memory_bytes=1))),
+            patch(_RECORD_TARGET) as mock_record,
+        ):
+            mock_act.info.return_value = MockActivityInfo(
+                activity_type="automation-engine:merge"
+            )
+            await interceptor.execute_activity(MockExecuteActivityInput())
+        mock_record.assert_called_once()
+
+    async def test_qualified_entry_does_not_match_another_app(self, mock_next):
+        """The qualified form must stay a narrowing, not a no-op."""
+        interceptor = _SizingActivityInboundInterceptor(
+            mock_next, 1.0, frozenset({"automation-engine:merge"})
+        )
+        with (
+            patch(_ACTIVITY_TARGET) as mock_act,
+            patch(_TRACKER_TARGET) as mock_tracker,
+            patch(_RECORD_TARGET) as mock_record,
+        ):
+            mock_act.info.return_value = MockActivityInfo(
+                activity_type="publish-app:merge"
+            )
+            await interceptor.execute_activity(MockExecuteActivityInput())
+        mock_tracker.assert_not_called()
+        mock_record.assert_not_called()
+
     async def test_a_failing_unselected_activity_still_propagates(self, mock_next):
         """The passthrough path must not change failure behaviour either."""
         mock_next.execute_activity = AsyncMock(side_effect=ValueError("boom"))

--- a/tests/unit/observability/test_cgroup.py
+++ b/tests/unit/observability/test_cgroup.py
@@ -1,10 +1,8 @@
 """Unit tests for container-level (cgroup) sizing telemetry.
 
-These build a real fake cgroup hierarchy on disk and repoint the module's path
-constants at it, rather than mocking ``open``. The parsing quirks that matter
-here are all *file-shaped* — v2's literal ``max``, v1's near-2**63 sentinel, a
-read-only ``memory.peak``, a v1 host with no ``cpuacct`` mount — and a mocked
-``open`` would let the code pass while getting every one of them wrong.
+Builds a fake cgroup hierarchy on disk rather than mocking ``open``: the quirks
+that matter are file-shaped (v2's literal ``max``, v1's 2**63 sentinel, a
+read-only ``memory.peak``, a missing ``cpuacct`` mount).
 """
 
 import asyncio
@@ -44,12 +42,7 @@ class TestMemoryUsage:
         assert cgroup.memory_usage_bytes() is None
 
     def test_malformed_file_falls_through_to_the_next_path(self, tmp_path, monkeypatch):
-        """A garbage v2 file must not shadow a good v1 one.
-
-        Some runtimes present an empty ``memory.current``. Returning None there
-        would report "no data" while a perfectly readable v1 value sat one path
-        away.
-        """
+        """A garbage v2 file must not shadow a readable v1 one."""
         bad = _write(tmp_path, "memory.current", "not-a-number")
         good = _write(tmp_path, "usage_in_bytes", "777")
         monkeypatch.setattr(cgroup, "_MEMORY_CURRENT_PATHS", (bad, good))
@@ -58,12 +51,7 @@ class TestMemoryUsage:
 
 class TestMemoryLimit:
     def test_cgroup_wins_over_env(self, tmp_path, monkeypatch):
-        """The kernel's enforced limit beats the manifest's requested one.
-
-        They diverge whenever a mutating admission controller or a VPA has
-        rewritten the pod spec, and the enforced number is the one an OOM will
-        actually happen at.
-        """
+        """The enforced limit beats the requested one — they diverge under a VPA."""
         p = _write(tmp_path, "memory.max", str(2 * 1024**3))
         monkeypatch.setattr(cgroup, "_MEMORY_LIMIT_PATHS", (p,))
         monkeypatch.setenv("K8S_POD_MEMORY_LIMIT", "16Gi")
@@ -76,11 +64,7 @@ class TestMemoryLimit:
         assert cgroup.memory_limit_bytes() == 4 * 1024**3
 
     def test_v1_unlimited_sentinel_falls_back_to_env(self, tmp_path, monkeypatch):
-        """v1 spells unlimited as a huge number, not a word.
-
-        Taking it literally would make every fraction ~0.0 and every activity
-        look like it fits in the smallest tier.
-        """
+        """Taken literally, v1's sentinel makes every activity look tiny."""
         p = _write(tmp_path, "limit_in_bytes", str(9223372036854771712))
         monkeypatch.setattr(cgroup, "_MEMORY_LIMIT_PATHS", (p,))
         monkeypatch.setenv("K8S_POD_MEMORY_LIMIT", "1Gi")
@@ -131,9 +115,7 @@ class TestResetMemoryPeak:
     ):
         """No headroom to observe a drop means the reset cannot be proven.
 
-        Returning True here would be a guess, and the cost of a wrong guess is
-        reporting the pod's lifetime watermark as this activity's peak — which
-        silently over-sizes every tier derived from it.
+        Guessing True would report the pod's lifetime watermark as this peak.
         """
         monkeypatch.setattr(
             cgroup, "_MEMORY_PEAK_PATHS", (_write(tmp_path, "memory.peak", "1000"),)
@@ -181,11 +163,7 @@ class TestCpuStat:
         assert stat.throttled_seconds == pytest.approx(0.75)
 
     def test_v1_uses_nanoseconds(self, tmp_path, monkeypatch):
-        """v1 counts in ns and names the field ``throttled_time``.
-
-        Reading it with the v2 microsecond divisor would understate throttling
-        by 1000x, i.e. report a starved activity as perfectly sized.
-        """
+        """v1 counts ns; the v2 divisor would understate throttling 1000x."""
         monkeypatch.setattr(cgroup, "_CPU_STAT_V2", str(tmp_path / "nope"))
         monkeypatch.setattr(
             cgroup,
@@ -208,7 +186,7 @@ class TestCpuStat:
         assert stat.nr_throttled == 40
 
     def test_v1_without_cpuacct_still_returns_throttling(self, tmp_path, monkeypatch):
-        """The throttling half is the sizing signal; don't lose it to a missing mount."""
+        """Throttling is the sizing signal; don't lose it to a missing mount."""
         monkeypatch.setattr(cgroup, "_CPU_STAT_V2", str(tmp_path / "nope"))
         monkeypatch.setattr(
             cgroup,
@@ -275,7 +253,7 @@ class TestContainerTrace:
         assert trace.throttled_fraction == pytest.approx(0.25)
 
     def test_throttled_fraction_none_without_periods(self):
-        """Zero periods means the activity was too short to schedule, not 0% throttled."""
+        """Zero periods means too short to schedule, not 0% throttled."""
         assert cgroup.ContainerTrace(cpu_periods=0).throttled_fraction is None
         assert cgroup.ContainerTrace().throttled_fraction is None
 
@@ -285,11 +263,9 @@ class TestTrackContainerUsage:
     async def test_watermark_mode_catches_a_spike_that_ended(
         self, tmp_path, monkeypatch
     ):
-        """The whole point of the watermark: a spike that has already been freed.
+        """A spike already freed by the time the block exits.
 
-        Current usage is back to 1000 by the time the block exits, so an
-        endpoint-only sampler reports 1000 and would size the tier at a tenth of
-        what the activity actually needed.
+        An endpoint-only sampler would read 1000 and size the tier 10x too small.
         """
         peak = tmp_path / "memory.peak"
         peak.write_text("5000")
@@ -348,7 +324,7 @@ class TestTrackContainerUsage:
 
     @pytest.mark.asyncio
     async def test_unavailable_when_there_is_no_cgroup(self, tmp_path, monkeypatch):
-        """macOS and most local dev. Must be None, never 0."""
+        """macOS and local dev. Must be None, never 0."""
         monkeypatch.setattr(cgroup, "_MEMORY_CURRENT_PATHS", _missing(tmp_path))
         monkeypatch.setattr(cgroup, "_MEMORY_PEAK_PATHS", _missing(tmp_path))
         monkeypatch.setattr(cgroup, "_CPU_STAT_V2", str(tmp_path / "nope"))
@@ -386,7 +362,7 @@ class TestTrackContainerUsage:
 
     @pytest.mark.asyncio
     async def test_never_fails_a_successful_block(self, tmp_path, monkeypatch):
-        """An instrument that can fail the thing it measures is worse than none."""
+        """An instrument must not fail the thing it measures."""
         monkeypatch.setattr(cgroup, "_MEMORY_CURRENT_PATHS", _missing(tmp_path))
         monkeypatch.setattr(cgroup, "_MEMORY_PEAK_PATHS", _missing(tmp_path))
         monkeypatch.setattr(
@@ -403,11 +379,8 @@ class TestTrackContainerUsage:
     async def test_a_poller_that_raises_does_not_fail_the_block(
         self, tmp_path, monkeypatch
     ):
-        """``await task`` on the exit path re-raises whatever the poller hit.
-
-        The cgroup can genuinely disappear mid-activity (a remount, a vcluster
-        hiccup), and that must cost telemetry, not the activity's result.
-        """
+        """``await task`` on exit re-raises what the poller hit; that must cost
+        telemetry, not the activity's result."""
         current = tmp_path / "memory.current"
         current.write_text("1000")
         monkeypatch.setattr(cgroup, "_MEMORY_PEAK_PATHS", _missing(tmp_path))
@@ -443,7 +416,7 @@ class TestTrackContainerUsage:
 
     @pytest.mark.asyncio
     async def test_poll_task_is_cancelled_on_exit(self, tmp_path, monkeypatch):
-        """A leaked poller per activity would accumulate for the pod's lifetime."""
+        """A leaked poller per activity accumulates for the pod's lifetime."""
         monkeypatch.setattr(cgroup, "_MEMORY_PEAK_PATHS", _missing(tmp_path))
         monkeypatch.setattr(
             cgroup,

--- a/tests/unit/observability/test_cgroup.py
+++ b/tests/unit/observability/test_cgroup.py
@@ -1,0 +1,456 @@
+"""Unit tests for container-level (cgroup) sizing telemetry.
+
+These build a real fake cgroup hierarchy on disk and repoint the module's path
+constants at it, rather than mocking ``open``. The parsing quirks that matter
+here are all *file-shaped* — v2's literal ``max``, v1's near-2**63 sentinel, a
+read-only ``memory.peak``, a v1 host with no ``cpuacct`` mount — and a mocked
+``open`` would let the code pass while getting every one of them wrong.
+"""
+
+import asyncio
+import os
+
+import pytest
+
+from application_sdk.observability import cgroup
+
+
+def _write(tmp_path, name: str, contents: str) -> str:
+    path = tmp_path / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(contents)
+    return str(path)
+
+
+def _missing(tmp_path) -> tuple[str, ...]:
+    return (str(tmp_path / "does-not-exist"),)
+
+
+class TestMemoryUsage:
+    def test_reads_v2(self, tmp_path, monkeypatch):
+        p = _write(tmp_path, "memory.current", "4096\n")
+        monkeypatch.setattr(cgroup, "_MEMORY_CURRENT_PATHS", (p,))
+        assert cgroup.memory_usage_bytes() == 4096
+
+    def test_falls_back_to_v1(self, tmp_path, monkeypatch):
+        v1 = _write(tmp_path, "usage_in_bytes", "8192")
+        monkeypatch.setattr(
+            cgroup, "_MEMORY_CURRENT_PATHS", (str(tmp_path / "nope"), v1)
+        )
+        assert cgroup.memory_usage_bytes() == 8192
+
+    def test_none_when_absent(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(cgroup, "_MEMORY_CURRENT_PATHS", _missing(tmp_path))
+        assert cgroup.memory_usage_bytes() is None
+
+    def test_malformed_file_falls_through_to_the_next_path(self, tmp_path, monkeypatch):
+        """A garbage v2 file must not shadow a good v1 one.
+
+        Some runtimes present an empty ``memory.current``. Returning None there
+        would report "no data" while a perfectly readable v1 value sat one path
+        away.
+        """
+        bad = _write(tmp_path, "memory.current", "not-a-number")
+        good = _write(tmp_path, "usage_in_bytes", "777")
+        monkeypatch.setattr(cgroup, "_MEMORY_CURRENT_PATHS", (bad, good))
+        assert cgroup.memory_usage_bytes() == 777
+
+
+class TestMemoryLimit:
+    def test_cgroup_wins_over_env(self, tmp_path, monkeypatch):
+        """The kernel's enforced limit beats the manifest's requested one.
+
+        They diverge whenever a mutating admission controller or a VPA has
+        rewritten the pod spec, and the enforced number is the one an OOM will
+        actually happen at.
+        """
+        p = _write(tmp_path, "memory.max", str(2 * 1024**3))
+        monkeypatch.setattr(cgroup, "_MEMORY_LIMIT_PATHS", (p,))
+        monkeypatch.setenv("K8S_POD_MEMORY_LIMIT", "16Gi")
+        assert cgroup.memory_limit_bytes() == 2 * 1024**3
+
+    def test_v2_literal_max_falls_back_to_env(self, tmp_path, monkeypatch):
+        p = _write(tmp_path, "memory.max", "max\n")
+        monkeypatch.setattr(cgroup, "_MEMORY_LIMIT_PATHS", (p,))
+        monkeypatch.setenv("K8S_POD_MEMORY_LIMIT", "4Gi")
+        assert cgroup.memory_limit_bytes() == 4 * 1024**3
+
+    def test_v1_unlimited_sentinel_falls_back_to_env(self, tmp_path, monkeypatch):
+        """v1 spells unlimited as a huge number, not a word.
+
+        Taking it literally would make every fraction ~0.0 and every activity
+        look like it fits in the smallest tier.
+        """
+        p = _write(tmp_path, "limit_in_bytes", str(9223372036854771712))
+        monkeypatch.setattr(cgroup, "_MEMORY_LIMIT_PATHS", (p,))
+        monkeypatch.setenv("K8S_POD_MEMORY_LIMIT", "1Gi")
+        assert cgroup.memory_limit_bytes() == 1024**3
+
+    def test_none_when_unlimited_and_no_env(self, tmp_path, monkeypatch):
+        p = _write(tmp_path, "memory.max", "max")
+        monkeypatch.setattr(cgroup, "_MEMORY_LIMIT_PATHS", (p,))
+        monkeypatch.delenv("K8S_POD_MEMORY_LIMIT", raising=False)
+        assert cgroup.memory_limit_bytes() is None
+
+    def test_fraction(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            cgroup,
+            "_MEMORY_CURRENT_PATHS",
+            (_write(tmp_path, "memory.current", "512"),),
+        )
+        monkeypatch.setattr(
+            cgroup, "_MEMORY_LIMIT_PATHS", (_write(tmp_path, "memory.max", "2048"),)
+        )
+        assert cgroup.memory_fraction() == 0.25
+
+    def test_fraction_is_none_without_a_limit(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            cgroup,
+            "_MEMORY_CURRENT_PATHS",
+            (_write(tmp_path, "memory.current", "512"),),
+        )
+        monkeypatch.setattr(cgroup, "_MEMORY_LIMIT_PATHS", _missing(tmp_path))
+        monkeypatch.delenv("K8S_POD_MEMORY_LIMIT", raising=False)
+        assert cgroup.memory_fraction() is None
+
+
+class TestResetMemoryPeak:
+    def test_proven_reset(self, tmp_path, monkeypatch):
+        peak = _write(tmp_path, "memory.peak", "5000")
+        monkeypatch.setattr(cgroup, "_MEMORY_PEAK_PATHS", (peak,))
+        monkeypatch.setattr(
+            cgroup,
+            "_MEMORY_CURRENT_PATHS",
+            (_write(tmp_path, "memory.current", "1000"),),
+        )
+        assert cgroup.reset_memory_peak() is True
+        assert cgroup.memory_peak_bytes() == 0
+
+    def test_unprovable_when_watermark_equals_current_usage(
+        self, tmp_path, monkeypatch
+    ):
+        """No headroom to observe a drop means the reset cannot be proven.
+
+        Returning True here would be a guess, and the cost of a wrong guess is
+        reporting the pod's lifetime watermark as this activity's peak — which
+        silently over-sizes every tier derived from it.
+        """
+        monkeypatch.setattr(
+            cgroup, "_MEMORY_PEAK_PATHS", (_write(tmp_path, "memory.peak", "1000"),)
+        )
+        monkeypatch.setattr(
+            cgroup,
+            "_MEMORY_CURRENT_PATHS",
+            (_write(tmp_path, "memory.current", "1000"),),
+        )
+        assert cgroup.reset_memory_peak() is False
+
+    def test_read_only_peak_is_not_proven(self, tmp_path, monkeypatch):
+        """``memory.peak`` is read-only before Linux 6.8 — the common case."""
+        peak = tmp_path / "memory.peak"
+        peak.write_text("5000")
+        os.chmod(peak, 0o444)
+        monkeypatch.setattr(cgroup, "_MEMORY_PEAK_PATHS", (str(peak),))
+        monkeypatch.setattr(
+            cgroup,
+            "_MEMORY_CURRENT_PATHS",
+            (_write(tmp_path, "memory.current", "1000"),),
+        )
+        assert cgroup.reset_memory_peak() is False
+
+    def test_false_when_no_cgroup(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(cgroup, "_MEMORY_PEAK_PATHS", _missing(tmp_path))
+        monkeypatch.setattr(cgroup, "_MEMORY_CURRENT_PATHS", _missing(tmp_path))
+        assert cgroup.reset_memory_peak() is False
+
+
+class TestCpuStat:
+    def test_v2(self, tmp_path, monkeypatch):
+        p = _write(
+            tmp_path,
+            "cpu.stat",
+            "usage_usec 2500000\nuser_usec 2000000\nsystem_usec 500000\n"
+            "nr_periods 100\nnr_throttled 30\nthrottled_usec 750000\n",
+        )
+        monkeypatch.setattr(cgroup, "_CPU_STAT_V2", p)
+        stat = cgroup.cpu_stat()
+        assert stat is not None
+        assert stat.usage_seconds == pytest.approx(2.5)
+        assert stat.nr_periods == 100
+        assert stat.nr_throttled == 30
+        assert stat.throttled_seconds == pytest.approx(0.75)
+
+    def test_v1_uses_nanoseconds(self, tmp_path, monkeypatch):
+        """v1 counts in ns and names the field ``throttled_time``.
+
+        Reading it with the v2 microsecond divisor would understate throttling
+        by 1000x, i.e. report a starved activity as perfectly sized.
+        """
+        monkeypatch.setattr(cgroup, "_CPU_STAT_V2", str(tmp_path / "nope"))
+        monkeypatch.setattr(
+            cgroup,
+            "_CPU_STAT_V1",
+            _write(
+                tmp_path,
+                "v1/cpu.stat",
+                "nr_periods 200\nnr_throttled 40\nthrottled_time 1500000000\n",
+            ),
+        )
+        monkeypatch.setattr(
+            cgroup,
+            "_CPUACCT_USAGE_V1",
+            _write(tmp_path, "v1/cpuacct.usage", "3000000000"),
+        )
+        stat = cgroup.cpu_stat()
+        assert stat is not None
+        assert stat.usage_seconds == pytest.approx(3.0)
+        assert stat.throttled_seconds == pytest.approx(1.5)
+        assert stat.nr_throttled == 40
+
+    def test_v1_without_cpuacct_still_returns_throttling(self, tmp_path, monkeypatch):
+        """The throttling half is the sizing signal; don't lose it to a missing mount."""
+        monkeypatch.setattr(cgroup, "_CPU_STAT_V2", str(tmp_path / "nope"))
+        monkeypatch.setattr(
+            cgroup,
+            "_CPU_STAT_V1",
+            _write(tmp_path, "v1/cpu.stat", "nr_periods 10\nnr_throttled 5\n"),
+        )
+        monkeypatch.setattr(cgroup, "_CPUACCT_USAGE_V1", str(tmp_path / "nope"))
+        stat = cgroup.cpu_stat()
+        assert stat is not None
+        assert stat.usage_seconds == 0.0
+        assert stat.nr_throttled == 5
+
+    def test_none_when_absent(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(cgroup, "_CPU_STAT_V2", str(tmp_path / "nope"))
+        monkeypatch.setattr(cgroup, "_CPU_STAT_V1", str(tmp_path / "nope-either"))
+        assert cgroup.cpu_stat() is None
+
+
+class TestCpuQuota:
+    def test_v2(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            cgroup, "_CPU_MAX_V2", _write(tmp_path, "cpu.max", "150000 100000\n")
+        )
+        assert cgroup.cpu_quota_cores() == pytest.approx(1.5)
+
+    def test_v2_max_falls_back_to_v1(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            cgroup, "_CPU_MAX_V2", _write(tmp_path, "cpu.max", "max 100000")
+        )
+        monkeypatch.setattr(
+            cgroup, "_CPU_QUOTA_V1", _write(tmp_path, "quota", "200000")
+        )
+        monkeypatch.setattr(
+            cgroup, "_CPU_PERIOD_V1", _write(tmp_path, "period", "100000")
+        )
+        assert cgroup.cpu_quota_cores() == pytest.approx(2.0)
+
+    def test_v1_unlimited_is_none(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(cgroup, "_CPU_MAX_V2", str(tmp_path / "nope"))
+        monkeypatch.setattr(cgroup, "_CPU_QUOTA_V1", _write(tmp_path, "quota", "-1"))
+        monkeypatch.setattr(
+            cgroup, "_CPU_PERIOD_V1", _write(tmp_path, "period", "100000")
+        )
+        assert cgroup.cpu_quota_cores() is None
+
+
+class TestContainerTrace:
+    def test_observe_keeps_the_maximum(self):
+        trace = cgroup.ContainerTrace(memory_limit_bytes=1000)
+        trace.observe(400, 1000)
+        trace.observe(900, 1000)
+        trace.observe(600, 1000)
+        assert trace.peak_memory_bytes == 900
+        assert trace.peak_memory_fraction == pytest.approx(0.9)
+
+    def test_observe_ignores_none(self):
+        trace = cgroup.ContainerTrace(memory_limit_bytes=1000)
+        trace.observe(400, 1000)
+        trace.observe(None, 1000)
+        assert trace.peak_memory_bytes == 400
+
+    def test_throttled_fraction(self):
+        trace = cgroup.ContainerTrace(cpu_periods=200, cpu_throttled_periods=50)
+        assert trace.throttled_fraction == pytest.approx(0.25)
+
+    def test_throttled_fraction_none_without_periods(self):
+        """Zero periods means the activity was too short to schedule, not 0% throttled."""
+        assert cgroup.ContainerTrace(cpu_periods=0).throttled_fraction is None
+        assert cgroup.ContainerTrace().throttled_fraction is None
+
+
+class TestTrackContainerUsage:
+    @pytest.mark.asyncio
+    async def test_watermark_mode_catches_a_spike_that_ended(
+        self, tmp_path, monkeypatch
+    ):
+        """The whole point of the watermark: a spike that has already been freed.
+
+        Current usage is back to 1000 by the time the block exits, so an
+        endpoint-only sampler reports 1000 and would size the tier at a tenth of
+        what the activity actually needed.
+        """
+        peak = tmp_path / "memory.peak"
+        peak.write_text("5000")
+        monkeypatch.setattr(cgroup, "_MEMORY_PEAK_PATHS", (str(peak),))
+        monkeypatch.setattr(
+            cgroup,
+            "_MEMORY_CURRENT_PATHS",
+            (_write(tmp_path, "memory.current", "1000"),),
+        )
+        monkeypatch.setattr(
+            cgroup, "_MEMORY_LIMIT_PATHS", (_write(tmp_path, "memory.max", "10000"),)
+        )
+
+        async with cgroup.track_container_usage() as trace:
+            peak.write_text("9000")  # the kernel observing the spike
+
+        assert trace.peak_source == "watermark"
+        assert trace.peak_memory_bytes == 9000
+        assert trace.peak_memory_fraction == pytest.approx(0.9)
+
+    @pytest.mark.asyncio
+    async def test_poll_mode_when_the_watermark_is_unavailable(
+        self, tmp_path, monkeypatch
+    ):
+        current = tmp_path / "memory.current"
+        current.write_text("1000")
+        monkeypatch.setattr(cgroup, "_MEMORY_PEAK_PATHS", _missing(tmp_path))
+        monkeypatch.setattr(cgroup, "_MEMORY_CURRENT_PATHS", (str(current),))
+        monkeypatch.setattr(
+            cgroup, "_MEMORY_LIMIT_PATHS", (_write(tmp_path, "memory.max", "10000"),)
+        )
+
+        async with cgroup.track_container_usage(poll_interval_seconds=0.01) as trace:
+            current.write_text("7000")
+            await asyncio.sleep(0.05)
+            current.write_text("2000")
+            await asyncio.sleep(0.05)
+
+        assert trace.peak_source == "poll"
+        assert trace.peak_memory_bytes == 7000
+        assert trace.samples
+
+    @pytest.mark.asyncio
+    async def test_zero_interval_disables_polling(self, tmp_path, monkeypatch):
+        """The fleet-wide default has to be able to cost nothing."""
+        monkeypatch.setattr(cgroup, "_MEMORY_PEAK_PATHS", _missing(tmp_path))
+        monkeypatch.setattr(
+            cgroup,
+            "_MEMORY_CURRENT_PATHS",
+            (_write(tmp_path, "memory.current", "1000"),),
+        )
+        async with cgroup.track_container_usage(poll_interval_seconds=0) as trace:
+            pass
+        assert trace.peak_source == "unavailable"
+        assert trace.peak_memory_bytes is None
+
+    @pytest.mark.asyncio
+    async def test_unavailable_when_there_is_no_cgroup(self, tmp_path, monkeypatch):
+        """macOS and most local dev. Must be None, never 0."""
+        monkeypatch.setattr(cgroup, "_MEMORY_CURRENT_PATHS", _missing(tmp_path))
+        monkeypatch.setattr(cgroup, "_MEMORY_PEAK_PATHS", _missing(tmp_path))
+        monkeypatch.setattr(cgroup, "_CPU_STAT_V2", str(tmp_path / "nope"))
+        monkeypatch.setattr(cgroup, "_CPU_STAT_V1", str(tmp_path / "nope"))
+
+        async with cgroup.track_container_usage() as trace:
+            pass
+
+        assert trace.peak_source == "unavailable"
+        assert trace.peak_memory_bytes is None
+        assert trace.cpu_seconds is None
+
+    @pytest.mark.asyncio
+    async def test_cpu_counters_are_differenced(self, tmp_path, monkeypatch):
+        stat = tmp_path / "cpu.stat"
+        stat.write_text(
+            "usage_usec 1000000\nnr_periods 100\nnr_throttled 10\n"
+            "throttled_usec 500000\n"
+        )
+        monkeypatch.setattr(cgroup, "_CPU_STAT_V2", str(stat))
+        monkeypatch.setattr(cgroup, "_MEMORY_CURRENT_PATHS", _missing(tmp_path))
+        monkeypatch.setattr(cgroup, "_MEMORY_PEAK_PATHS", _missing(tmp_path))
+
+        async with cgroup.track_container_usage() as trace:
+            stat.write_text(
+                "usage_usec 4000000\nnr_periods 400\nnr_throttled 100\n"
+                "throttled_usec 2500000\n"
+            )
+
+        assert trace.cpu_seconds == pytest.approx(3.0)
+        assert trace.cpu_throttled_seconds == pytest.approx(2.0)
+        assert trace.cpu_throttled_periods == 90
+        assert trace.cpu_periods == 300
+        assert trace.throttled_fraction == pytest.approx(0.3)
+
+    @pytest.mark.asyncio
+    async def test_never_fails_a_successful_block(self, tmp_path, monkeypatch):
+        """An instrument that can fail the thing it measures is worse than none."""
+        monkeypatch.setattr(cgroup, "_MEMORY_CURRENT_PATHS", _missing(tmp_path))
+        monkeypatch.setattr(cgroup, "_MEMORY_PEAK_PATHS", _missing(tmp_path))
+        monkeypatch.setattr(
+            cgroup, "cpu_stat", lambda: (_ for _ in ()).throw(RuntimeError("boom"))
+        )
+
+        async with cgroup.track_container_usage() as trace:
+            result = "done"
+
+        assert result == "done"
+        assert trace.cpu_seconds is None
+
+    @pytest.mark.asyncio
+    async def test_a_poller_that_raises_does_not_fail_the_block(
+        self, tmp_path, monkeypatch
+    ):
+        """``await task`` on the exit path re-raises whatever the poller hit.
+
+        The cgroup can genuinely disappear mid-activity (a remount, a vcluster
+        hiccup), and that must cost telemetry, not the activity's result.
+        """
+        current = tmp_path / "memory.current"
+        current.write_text("1000")
+        monkeypatch.setattr(cgroup, "_MEMORY_PEAK_PATHS", _missing(tmp_path))
+        monkeypatch.setattr(cgroup, "_MEMORY_CURRENT_PATHS", (str(current),))
+
+        calls = {"n": 0}
+        real = cgroup.memory_usage_bytes
+
+        def flaky():
+            calls["n"] += 1
+            if calls["n"] > 1:  # the first call is the setup availability probe
+                raise RuntimeError("cgroup went away")
+            return real()
+
+        monkeypatch.setattr(cgroup, "memory_usage_bytes", flaky)
+
+        async with cgroup.track_container_usage(poll_interval_seconds=0.01) as trace:
+            await asyncio.sleep(0.05)
+            result = "done"
+
+        assert result == "done"
+        assert trace.peak_source == "poll"
+
+    @pytest.mark.asyncio
+    async def test_propagates_the_blocks_own_error(self, tmp_path, monkeypatch):
+        """Telemetry must not swallow the activity's failure either."""
+        monkeypatch.setattr(cgroup, "_MEMORY_CURRENT_PATHS", _missing(tmp_path))
+        monkeypatch.setattr(cgroup, "_MEMORY_PEAK_PATHS", _missing(tmp_path))
+
+        with pytest.raises(ValueError, match="activity failed"):
+            async with cgroup.track_container_usage():
+                raise ValueError("activity failed")
+
+    @pytest.mark.asyncio
+    async def test_poll_task_is_cancelled_on_exit(self, tmp_path, monkeypatch):
+        """A leaked poller per activity would accumulate for the pod's lifetime."""
+        monkeypatch.setattr(cgroup, "_MEMORY_PEAK_PATHS", _missing(tmp_path))
+        monkeypatch.setattr(
+            cgroup,
+            "_MEMORY_CURRENT_PATHS",
+            (_write(tmp_path, "memory.current", "1000"),),
+        )
+        before = len(asyncio.all_tasks())
+        async with cgroup.track_container_usage(poll_interval_seconds=0.01):
+            await asyncio.sleep(0.02)
+        assert len(asyncio.all_tasks()) <= before

--- a/tests/unit/observability/test_observability_sdr_upload.py
+++ b/tests/unit/observability/test_observability_sdr_upload.py
@@ -110,11 +110,13 @@ class TestObsModeDerivation:
             "logs": "sdr/logs",
             "metrics": "sdr/metrics",
             "traces": "sdr/traces",
+            "sizing": "sdr/sizing",
         }
         assert mod.OBSERVABILITY_S3_PREFIX_MAP == {
             "logs": "artifacts/apps/observability/sdr/logs",
             "metrics": "artifacts/apps/observability/sdr/metrics",
             "traces": "artifacts/apps/observability/sdr/traces",
+            "sizing": "artifacts/apps/observability/sdr/sizing",
         }
 
     def test_non_sdr_mode_when_atlan_upload_disabled(self):

--- a/tests/unit/observability/test_sizing_census.py
+++ b/tests/unit/observability/test_sizing_census.py
@@ -1,0 +1,111 @@
+"""Unit tests for the concurrency census."""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from application_sdk.observability.sizing_census import CENSUS
+
+
+@pytest.fixture(autouse=True)
+def clean():
+    CENSUS._reset_for_testing()
+    yield
+    CENSUS._reset_for_testing()
+
+
+class TestCensus:
+    def test_alone_is_one(self):
+        token, now = CENSUS.enter()
+        assert now == 1
+        assert CENSUS.leave(token) == 1
+
+    def test_counts_overlap(self):
+        a, _ = CENSUS.enter()
+        b, now_b = CENSUS.enter()
+        assert now_b == 2
+        assert CENSUS.leave(b) == 2
+        assert CENSUS.leave(a) == 2
+
+    def test_reports_the_high_water_mark_not_the_entry_count(self):
+        """An activity that started alone and was joined has a pod-wide peak.
+
+        Reading the count at entry would call that reading clean, which is the
+        whole failure this field exists to prevent.
+        """
+        a, now_a = CENSUS.enter()
+        assert now_a == 1  # A genuinely was alone at entry
+        b, _ = CENSUS.enter()
+        CENSUS.leave(b)
+        assert CENSUS.leave(a) == 2  # ...but not for its whole window
+
+    def test_a_later_arrival_is_not_credited_with_earlier_peaks(self):
+        """C started after the crowd left, so C's window really was quiet."""
+        a, _ = CENSUS.enter()
+        b, _ = CENSUS.enter()
+        CENSUS.leave(a)
+        CENSUS.leave(b)
+        c, now_c = CENSUS.enter()
+        assert now_c == 1
+        assert CENSUS.leave(c) == 1
+
+    def test_count_returns_to_zero(self):
+        a, _ = CENSUS.enter()
+        b, _ = CENSUS.enter()
+        CENSUS.leave(a)
+        CENSUS.leave(b)
+        assert CENSUS.active() == 0
+
+    def test_unknown_token_is_tolerated(self):
+        """A double-leave must not corrupt the count for everyone else."""
+        a, _ = CENSUS.enter()
+        assert CENSUS.leave(a) == 1
+        assert CENSUS.leave(a) == 1  # already gone
+        assert CENSUS.active() == 0
+
+    def test_thread_safe(self):
+        """Activities run on the event loop, but the executor path is threaded."""
+        results: list[int] = []
+        lock = threading.Lock()
+
+        def work():
+            token, _ = CENSUS.enter()
+            seen = CENSUS.leave(token)
+            with lock:
+                results.append(seen)
+
+        threads = [threading.Thread(target=work) for _ in range(40)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert len(results) == 40
+        assert all(r >= 1 for r in results)
+        assert CENSUS.active() == 0
+
+
+class TestPeakAndIdempotentLeave:
+    def test_peak_does_not_deregister(self):
+        """The caller needs its number while still holding its slot."""
+        a, _ = CENSUS.enter()
+        b, _ = CENSUS.enter()
+        assert CENSUS.peak(a) == 2
+        assert CENSUS.active() == 2  # peak() must not have released anything
+        CENSUS.leave(a)
+        CENSUS.leave(b)
+
+    def test_leave_is_idempotent(self):
+        """Two callers deregister each execution; decrementing twice undercounts."""
+        a, _ = CENSUS.enter()
+        b, _ = CENSUS.enter()
+        assert CENSUS.leave(a) == 2
+        assert CENSUS.leave(a) == 1  # second call is a no-op
+        assert CENSUS.active() == 1  # b is still running and still counted
+        CENSUS.leave(b)
+        assert CENSUS.active() == 0
+
+    def test_peak_for_an_unknown_token(self):
+        assert CENSUS.peak(99999) == 1

--- a/tests/unit/observability/test_sizing_inputs.py
+++ b/tests/unit/observability/test_sizing_inputs.py
@@ -11,7 +11,11 @@ from application_sdk.contracts.types import FileReference
 from application_sdk.observability.sizing_inputs import (
     InputSize,
     _walk,
+    begin_collection,
     describe_inputs,
+    end_collection,
+    report_input_bytes,
+    report_local_paths,
 )
 
 
@@ -24,23 +28,6 @@ class _Model(BaseModel):
     ref: FileReference | None = None
     refs: list[FileReference] = []
     nested: _Nested | None = None
-
-
-class _HookModel(BaseModel):
-    prefixes: list[str] = []
-
-    def sizing_input_bytes(self) -> int | None:
-        return 4096
-
-
-class _BadHookModel(BaseModel):
-    def sizing_input_bytes(self):
-        return "big"
-
-
-class _NoneHookModel(BaseModel):
-    def sizing_input_bytes(self) -> int | None:
-        return None
 
 
 def _file(tmp_path, name: str, size: int) -> str:
@@ -84,8 +71,8 @@ class TestFileReferenceSizing:
     def test_unmaterialised_ref_is_skipped(self):
         """``auto_materialize=False`` leaves no local path.
 
-        Sizing it would need an object-store call per activity; the app that opted
-        out already knows its own sizes and can use the hook.
+        Sizing it would cost an object-store call per activity; the app that opted
+        out reports its own bytes instead.
         """
         model = _Model(
             ref=FileReference(storage_path="s3://bucket/key", is_durable=True)
@@ -123,66 +110,79 @@ class TestFileReferenceSizing:
         assert got.truncated is True
 
 
-class TestHook:
-    def test_hook_is_used_when_there_are_no_refs(self):
-        """AE's merge takes raw prefixes, so refs find nothing and the hook answers."""
-        got = describe_inputs(_HookModel(prefixes=["a/", "b/"]))
-        assert got == InputSize(bytes=4096, file_count=0, basis="hook")
+class TestReportedBytes:
+    """The path AE's merge uses: readers report what they actually pulled."""
 
-    def test_file_references_win_over_the_hook(self, tmp_path):
-        """Measured beats self-reported when both are available."""
+    @pytest.fixture(autouse=True)
+    def collector(self):
+        c = begin_collection()
+        yield c
+        end_collection()
 
-        class _Both(_Model):
-            def sizing_input_bytes(self) -> int | None:
-                return 999_999
+    def test_reported_bytes_are_summed(self):
+        report_input_bytes(1000)
+        report_input_bytes(2000, file_count=3)
+        got = describe_inputs(_Model())
+        assert got == InputSize(bytes=3000, file_count=4, basis="reported")
 
+    def test_reported_wins_over_file_references(self, tmp_path):
+        """Reported is what the activity read; a ref is only what it was handed."""
+        report_input_bytes(7)
         got = describe_inputs(
-            _Both(ref=FileReference(local_path=_file(tmp_path, "a", 7)))
+            _Model(ref=FileReference(local_path=_file(tmp_path, "a", 999)))
+        )
+        assert got is not None
+        assert got.basis == "reported"
+        assert got.bytes == 7
+
+    def test_report_local_paths(self, tmp_path):
+        paths = [_file(tmp_path, "a", 100), _file(tmp_path, "b", 250)]
+        report_local_paths(paths)
+        got = describe_inputs(None)
+        assert got is not None
+        assert got.bytes == 350
+        assert got.file_count == 2
+
+    def test_missing_path_is_skipped_not_fatal(self, tmp_path):
+        report_local_paths([_file(tmp_path, "a", 100), str(tmp_path / "gone")])
+        got = describe_inputs(None)
+        assert got is not None
+        assert got.bytes == 100
+        assert got.file_count == 1
+
+    def test_negative_report_is_ignored(self):
+        report_input_bytes(-5)
+        assert describe_inputs(_Model()) is None
+
+    def test_nothing_reported_falls_back_to_refs(self, tmp_path):
+        got = describe_inputs(
+            _Model(ref=FileReference(local_path=_file(tmp_path, "a", 42)))
         )
         assert got is not None
         assert got.basis == "file_reference"
-        assert got.bytes == 7
 
-    def test_hook_returning_none_is_unknown(self):
-        assert describe_inputs(_NoneHookModel()) is None
 
-    def test_non_int_hook_is_rejected(self):
-        """A wrong-typed hook must not poison the dataset."""
-        assert describe_inputs(_BadHookModel()) is None
+class TestCollectorLifecycle:
+    def test_reporting_without_a_collector_is_a_no_op(self):
+        """Safe to call from a hot read path when collection is disabled."""
+        end_collection()
+        report_input_bytes(1000)  # must not raise
+        report_local_paths(["/nonexistent"])
+        assert describe_inputs(_Model()) is None
 
-    def test_negative_hook_is_rejected(self):
-        class _Neg(BaseModel):
-            def sizing_input_bytes(self) -> int | None:
-                return -1
+    def test_end_collection_prevents_leaking_into_the_next_activity(self):
+        """A worker runs activities back to back on the same context."""
+        begin_collection()
+        report_input_bytes(500)
+        end_collection()
+        assert describe_inputs(_Model()) is None
 
-        assert describe_inputs(_Neg()) is None
-
-    def test_bool_is_not_an_int_here(self):
-        """``True`` is an int subclass and would read as 1 byte."""
-
-        class _Bool(BaseModel):
-            def sizing_input_bytes(self):
-                return True
-
-        assert describe_inputs(_Bool()) is None
-
-    def test_raising_hook_does_not_propagate(self):
-        class _Boom(BaseModel):
-            def sizing_input_bytes(self) -> int | None:
-                raise RuntimeError("boom")
-
-        assert describe_inputs(_Boom()) is None
-
-    def test_file_count_from_companion_attribute(self):
-        class _WithCount(BaseModel):
-            sizing_input_file_count: int = 12
-
-            def sizing_input_bytes(self) -> int | None:
-                return 100
-
-        got = describe_inputs(_WithCount())
-        assert got is not None
-        assert got.file_count == 12
+    def test_begin_collection_starts_clean(self):
+        begin_collection()
+        report_input_bytes(500)
+        begin_collection()
+        assert describe_inputs(_Model()) is None
+        end_collection()
 
 
 class TestRobustness:
@@ -241,3 +241,42 @@ class TestPeakPerInputByte:
             peak_memory_bytes=6 * 1024**3,
         )
         assert obs.peak_per_input_byte is None
+
+
+class TestReaderChokepoint:
+    """The path that makes AE's merge work without AE writing any code.
+
+    ``_download_files`` is the one function every SDK Parquet/JSON read goes
+    through, so instrumenting it there covers merge's Parquet inputs — merge takes
+    raw ``input_prefixes``, has no FileReference, and would otherwise report
+    nothing at all.
+    """
+
+    async def test_locally_present_files_are_reported(self, tmp_path):
+        from application_sdk.storage.formats.utils import _download_files
+
+        _file(tmp_path, "p/a.parquet", 300)
+        _file(tmp_path, "p/b.parquet", 700)
+
+        begin_collection()
+        try:
+            found = await _download_files(str(tmp_path / "p"), ".parquet")
+            assert len(found) == 2
+            got = describe_inputs(None)
+        finally:
+            end_collection()
+
+        assert got is not None
+        assert got.bytes == 1000
+        assert got.file_count == 2
+        assert got.basis == "reported"
+
+    async def test_inert_when_collection_is_off(self, tmp_path):
+        """A read path must cost nothing when sizing telemetry is disabled."""
+        from application_sdk.storage.formats.utils import _download_files
+
+        _file(tmp_path, "p/a.parquet", 300)
+        end_collection()
+        found = await _download_files(str(tmp_path / "p"), ".parquet")
+        assert len(found) == 1
+        assert describe_inputs(None) is None

--- a/tests/unit/observability/test_sizing_inputs.py
+++ b/tests/unit/observability/test_sizing_inputs.py
@@ -1,0 +1,243 @@
+"""Unit tests for input sizing — the driver variable for tier fitting."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from pydantic import BaseModel
+
+from application_sdk.contracts.types import FileReference
+from application_sdk.observability.sizing_inputs import (
+    InputSize,
+    _walk,
+    describe_inputs,
+)
+
+
+class _Nested(BaseModel):
+    ref: FileReference | None = None
+
+
+class _Model(BaseModel):
+    name: str = "x"
+    ref: FileReference | None = None
+    refs: list[FileReference] = []
+    nested: _Nested | None = None
+
+
+class _HookModel(BaseModel):
+    prefixes: list[str] = []
+
+    def sizing_input_bytes(self) -> int | None:
+        return 4096
+
+
+class _BadHookModel(BaseModel):
+    def sizing_input_bytes(self):
+        return "big"
+
+
+class _NoneHookModel(BaseModel):
+    def sizing_input_bytes(self) -> int | None:
+        return None
+
+
+def _file(tmp_path, name: str, size: int) -> str:
+    p = tmp_path / name
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_bytes(b"x" * size)
+    return str(p)
+
+
+class TestFileReferenceSizing:
+    def test_single_file(self, tmp_path):
+        model = _Model(ref=FileReference(local_path=_file(tmp_path, "a.parquet", 500)))
+        got = describe_inputs(model)
+        assert got == InputSize(bytes=500, file_count=1, basis="file_reference")
+
+    def test_directory_is_walked(self, tmp_path):
+        _file(tmp_path, "d/1.parquet", 100)
+        _file(tmp_path, "d/2.parquet", 250)
+        _file(tmp_path, "d/sub/3.parquet", 50)
+        model = _Model(ref=FileReference(local_path=str(tmp_path / "d")))
+        got = describe_inputs(model)
+        assert got is not None
+        assert got.bytes == 400
+        assert got.file_count == 3
+
+    def test_sums_across_fields_and_nesting(self, tmp_path):
+        """merge-shaped inputs put several refs in a list, sometimes nested."""
+        model = _Model(
+            ref=FileReference(local_path=_file(tmp_path, "a", 10)),
+            refs=[
+                FileReference(local_path=_file(tmp_path, "b", 20)),
+                FileReference(local_path=_file(tmp_path, "c", 30)),
+            ],
+            nested=_Nested(ref=FileReference(local_path=_file(tmp_path, "d", 40))),
+        )
+        got = describe_inputs(model)
+        assert got is not None
+        assert got.bytes == 100
+        assert got.file_count == 4
+
+    def test_unmaterialised_ref_is_skipped(self):
+        """``auto_materialize=False`` leaves no local path.
+
+        Sizing it would need an object-store call per activity; the app that opted
+        out already knows its own sizes and can use the hook.
+        """
+        model = _Model(
+            ref=FileReference(storage_path="s3://bucket/key", is_durable=True)
+        )
+        assert describe_inputs(model) is None
+
+    def test_no_refs_returns_none(self):
+        assert describe_inputs(_Model()) is None
+
+    def test_missing_path_is_none_not_zero(self, tmp_path):
+        """A ref pointing at nothing is unknown; 0 would fit a rule to nothing."""
+        model = _Model(ref=FileReference(local_path=str(tmp_path / "gone")))
+        assert describe_inputs(model) is None
+
+    def test_walk_is_capped(self, tmp_path, monkeypatch):
+        import application_sdk.observability.sizing_inputs as mod
+
+        monkeypatch.setattr(mod, "_MAX_FILES_WALKED", 3)
+        for i in range(10):
+            _file(tmp_path, f"many/{i}", 10)
+        total, count, hit_cap = _walk(str(tmp_path / "many"))
+        assert hit_cap is True
+        assert count == 3
+        assert total == 30
+
+    def test_truncation_is_reported(self, tmp_path, monkeypatch):
+        """A partial count must be labelled, not silently passed off as complete."""
+        import application_sdk.observability.sizing_inputs as mod
+
+        monkeypatch.setattr(mod, "_MAX_FILES_WALKED", 2)
+        for i in range(5):
+            _file(tmp_path, f"d/{i}", 10)
+        got = describe_inputs(_Model(ref=FileReference(local_path=str(tmp_path / "d"))))
+        assert got is not None
+        assert got.truncated is True
+
+
+class TestHook:
+    def test_hook_is_used_when_there_are_no_refs(self):
+        """AE's merge takes raw prefixes, so refs find nothing and the hook answers."""
+        got = describe_inputs(_HookModel(prefixes=["a/", "b/"]))
+        assert got == InputSize(bytes=4096, file_count=0, basis="hook")
+
+    def test_file_references_win_over_the_hook(self, tmp_path):
+        """Measured beats self-reported when both are available."""
+
+        class _Both(_Model):
+            def sizing_input_bytes(self) -> int | None:
+                return 999_999
+
+        got = describe_inputs(
+            _Both(ref=FileReference(local_path=_file(tmp_path, "a", 7)))
+        )
+        assert got is not None
+        assert got.basis == "file_reference"
+        assert got.bytes == 7
+
+    def test_hook_returning_none_is_unknown(self):
+        assert describe_inputs(_NoneHookModel()) is None
+
+    def test_non_int_hook_is_rejected(self):
+        """A wrong-typed hook must not poison the dataset."""
+        assert describe_inputs(_BadHookModel()) is None
+
+    def test_negative_hook_is_rejected(self):
+        class _Neg(BaseModel):
+            def sizing_input_bytes(self) -> int | None:
+                return -1
+
+        assert describe_inputs(_Neg()) is None
+
+    def test_bool_is_not_an_int_here(self):
+        """``True`` is an int subclass and would read as 1 byte."""
+
+        class _Bool(BaseModel):
+            def sizing_input_bytes(self):
+                return True
+
+        assert describe_inputs(_Bool()) is None
+
+    def test_raising_hook_does_not_propagate(self):
+        class _Boom(BaseModel):
+            def sizing_input_bytes(self) -> int | None:
+                raise RuntimeError("boom")
+
+        assert describe_inputs(_Boom()) is None
+
+    def test_file_count_from_companion_attribute(self):
+        class _WithCount(BaseModel):
+            sizing_input_file_count: int = 12
+
+            def sizing_input_bytes(self) -> int | None:
+                return 100
+
+        got = describe_inputs(_WithCount())
+        assert got is not None
+        assert got.file_count == 12
+
+
+class TestRobustness:
+    def test_none_input(self):
+        assert describe_inputs(None) is None
+
+    def test_primitive_input(self):
+        assert describe_inputs("just a string") is None
+
+    def test_permission_error_mid_walk_is_skipped(self, tmp_path, monkeypatch):
+        """A file removed or unreadable mid-walk must not lose the whole reading."""
+        _file(tmp_path, "d/a", 100)
+        _file(tmp_path, "d/b", 200)
+        real = os.path.getsize
+        calls = {"n": 0}
+
+        def flaky(path):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise OSError("vanished")
+            return real(path)
+
+        monkeypatch.setattr(os.path, "getsize", flaky)
+        got = describe_inputs(_Model(ref=FileReference(local_path=str(tmp_path / "d"))))
+        assert got is not None
+        assert got.file_count == 1
+        assert got.bytes in (100, 200)
+
+
+class TestPeakPerInputByte:
+    def test_ratio(self):
+        from application_sdk.observability.sizing import SizingObservation
+
+        obs = SizingObservation(
+            activity_type="merge",
+            task_queue="q",
+            workflow_type="W",
+            attempt=1,
+            outcome="OK",
+            duration_seconds=1.0,
+            peak_memory_bytes=6 * 1024**3,
+            input_bytes=2 * 1024**3,
+        )
+        assert obs.peak_per_input_byte == pytest.approx(3.0)
+
+    def test_none_without_an_input_size(self):
+        from application_sdk.observability.sizing import SizingObservation
+
+        obs = SizingObservation(
+            activity_type="merge",
+            task_queue="q",
+            workflow_type="W",
+            attempt=1,
+            outcome="OK",
+            duration_seconds=1.0,
+            peak_memory_bytes=6 * 1024**3,
+        )
+        assert obs.peak_per_input_byte is None

--- a/tests/unit/observability/test_sizing_sink.py
+++ b/tests/unit/observability/test_sizing_sink.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import gzip
 import pathlib
 from unittest.mock import MagicMock, patch
@@ -289,3 +290,88 @@ class TestRecordObservationPersists:
                 _observation(peak_memory_bytes=None, cpu_seconds=None)
             )
         mock_persist.assert_not_called()
+
+
+class TestTheFlushActuallyHappens:
+    """The bug this class exists for: a full day of collection wrote nothing.
+
+    ``add_record`` only evaluates its flush condition when a record ARRIVES. On this
+    workload — maxConcurrentActivities 1, a merge every 15-30 min, KEDA scaling pods
+    to zero between them — a pod usually sees ONE record and neither the 500-row
+    batch nor the 60s interval is ever re-checked. The buffer died with the process.
+    Every sibling adaptor starts ``_periodic_flush``; this sink did not.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_periodic_flush_task_is_started(self, tmp_path):
+        sizing_sink._reset_for_testing()
+        started = []
+        real = SizingObservabilitySink._periodic_flush
+
+        async def spy(self):
+            started.append(True)
+
+        with (
+            patch.object(SizingObservabilitySink, "_periodic_flush", spy),
+            patch.object(
+                sizing_sink, "get_observability_dir", return_value=str(tmp_path)
+            ),
+        ):
+            sizing_sink.get_sink()
+            await asyncio.sleep(0)  # let the created task run
+        assert (
+            started
+        ), "no periodic flush task was started — the buffer would never drain"
+        sizing_sink._reset_for_testing()
+        SizingObservabilitySink._periodic_flush = real
+
+    @pytest.mark.asyncio
+    async def test_one_record_then_shutdown_is_not_lost(self, sink):
+        """The exact shape that lost a day of data."""
+        flushed: list[list] = []
+
+        async def capture(records):
+            flushed.append(records)
+
+        sizing_sink._sink = sink
+        with patch.object(sink, "_flush_records", capture):
+            sink.add_record(_observation())  # a single record, no second one
+            assert not flushed, "premature flush would make this test vacuous"
+            await sizing_sink.drain()
+        sizing_sink._reset_for_testing()
+
+        assert flushed, "the single buffered row was dropped on shutdown"
+        assert flushed[0][0]["activity_type"] == "automation-engine:merge"
+
+    @pytest.mark.asyncio
+    async def test_drain_is_safe_with_no_sink(self):
+        sizing_sink._reset_for_testing()
+        await sizing_sink.drain()  # must not raise
+
+    @pytest.mark.asyncio
+    async def test_drain_never_raises(self, sink):
+        """Runs on the shutdown path; a failure must not block termination."""
+        sizing_sink._sink = sink
+        with patch.object(
+            sink, "_flush_buffer", side_effect=RuntimeError("store gone")
+        ):
+            await sizing_sink.drain()  # must not raise
+        sizing_sink._reset_for_testing()
+
+    @pytest.mark.asyncio
+    async def test_flush_logs_at_info(self, sink, tmp_path):
+        """'Is it writing?' must be answerable from logs, not by exec-ing into a pod.
+
+        The base class logs its success at DEBUG, which every deployment filters.
+        """
+
+        async def fake_upload(remote_key, local_path, **kw):
+            return None
+
+        with (
+            patch("application_sdk.storage.upload_file", new=fake_upload),
+            patch.object(sizing_sink, "logger") as mock_log,
+        ):
+            await sink._flush_records([sink.process_record(_observation())])
+        msgs = " ".join(str(c) for c in mock_log.info.call_args_list)
+        assert "flushed" in msgs

--- a/tests/unit/observability/test_sizing_sink.py
+++ b/tests/unit/observability/test_sizing_sink.py
@@ -39,6 +39,9 @@ def _observation(**overrides) -> SizingObservation:
         "input_bytes": 2 * 1024**3,
         "input_file_count": 24,
         "input_basis": "reported",
+        "started_at": 1755690000.0,
+        "pod": "ae-heavy-7f9c",
+        "concurrency_max": 1,
     }
     base.update(overrides)
     return SizingObservation(**base)
@@ -112,6 +115,20 @@ class TestProcessRecord:
         row = sink.process_record(_observation(input_bytes=None, cpu_seconds=None))
         assert row["peak_per_input_byte"] is None
         assert row["mean_cpu_cores"] is None
+
+    def test_carries_the_join_keys(self, sink):
+        """pod + started_at + duration is how overlap is rebuilt at analysis time."""
+        row = sink.process_record(_observation())
+        assert row["pod"] == "ae-heavy-7f9c"
+        assert row["started_at"] == 1755690000.0
+        assert row["duration_seconds"] == 47.2
+
+    def test_attributability_is_written_not_derived(self, sink):
+        """A consumer that forgets the flag would pool activity and pod peaks."""
+        assert sink.process_record(_observation())["is_attributable"] is True
+        row = sink.process_record(_observation(concurrency_max=6))
+        assert row["concurrency_max"] == 6
+        assert row["is_attributable"] is False
 
     def test_export_record_is_a_no_op(self, sink):
         """Histograms come from record_observation, not from the batching sink."""

--- a/tests/unit/observability/test_sizing_sink.py
+++ b/tests/unit/observability/test_sizing_sink.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import gzip
+import pathlib
 from unittest.mock import MagicMock, patch
 
+import orjson
 import pytest
 
 from application_sdk.constants import SIZING_FILE_NAME
@@ -80,6 +83,80 @@ class TestSignalRouting:
     def test_signal_type_is_sizing(self, sink):
         """Drives the partition path, so a wrong answer buries the dataset."""
         assert sink._get_signal_type() == "sizing"
+
+
+class TestStoreSinkGate:
+    """The sizing sink must not be switched off by an unrelated signal's flag."""
+
+    def test_sizing_ignores_the_shared_store_sink_flag(self, sink):
+        """AE resolves ENABLE_OBSERVABILITY_STORE_SINK to False.
+
+        It sets ATLAN_ENABLE_OBSERVABILITY_DAPR_SINK=false to stop shipping logs and
+        metrics, and the store-sink flag falls back to it. Without this override the
+        sizing dataset would be empty on AE with no error anywhere — the exact
+        deployment we built this for.
+        """
+        assert sink._store_sink_enabled() is True
+
+    def test_other_signals_still_respect_it(self, tmp_path):
+        """The override is scoped to sizing, not a loosening of the switch."""
+        from application_sdk.constants import LOG_FILE_NAME
+        from application_sdk.observability.observability import AtlanObservability
+
+        class _Other(AtlanObservability):
+            def process_record(self, record):
+                return {}
+
+            def export_record(self, record):
+                return None
+
+        other = _Other(
+            batch_size=1,
+            flush_interval=3600,
+            retention_days=1,
+            cleanup_enabled=False,
+            data_dir=str(tmp_path),
+            file_name=LOG_FILE_NAME,
+        )
+        with patch(
+            "application_sdk.observability.observability.ENABLE_OBSERVABILITY_STORE_SINK",
+            False,
+        ):
+            assert other._store_sink_enabled() is False
+
+    @pytest.mark.asyncio
+    async def test_a_flush_uploads_with_the_shared_flag_off(self, sink, tmp_path):
+        """End to end: the flush must reach the object store, flag or no flag.
+
+        Asserts on the upload rather than a leftover local file — the base uploads
+        and then deletes the staged file, so a passing local-file check would only
+        prove the flush crashed before cleanup.
+        """
+        uploads: list[tuple[str, str]] = []
+
+        async def fake_upload(remote_key, local_path, **kwargs):
+            body = gzip.decompress(pathlib.Path(local_path).read_bytes()).decode()
+            uploads.append((remote_key, body))
+
+        with (
+            patch(
+                "application_sdk.observability.observability.ENABLE_OBSERVABILITY_STORE_SINK",
+                False,
+            ),
+            patch("application_sdk.storage.upload_file", new=fake_upload),
+        ):
+            await sink._flush_records([sink.process_record(_observation())])
+
+        assert uploads, "sizing flush uploaded nothing"
+        remote_key, body = uploads[0]
+        assert "/sizing/" in remote_key
+        # Hive-partitioned on the execution's start, not the flush time.
+        assert "year=" in remote_key and "hour=" in remote_key
+        row = orjson.loads(body.splitlines()[0])
+        assert row["activity_type"] == "automation-engine:merge"
+        assert row["schema_version"] == SIZING_SCHEMA_VERSION
+        assert row["concurrency_max"] == 1
+        assert row["peak_per_input_byte"] == pytest.approx(3.0)
 
 
 class TestProcessRecord:

--- a/tests/unit/observability/test_sizing_sink.py
+++ b/tests/unit/observability/test_sizing_sink.py
@@ -1,0 +1,197 @@
+"""Unit tests for the durable sizing sink."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from application_sdk.constants import SIZING_FILE_NAME
+from application_sdk.observability import sizing_sink
+from application_sdk.observability.observability import (
+    LOCAL_OBS_SUBDIR_MAP,
+    OBSERVABILITY_S3_PREFIX_MAP,
+)
+from application_sdk.observability.sizing import SizingObservation
+from application_sdk.observability.sizing_sink import (
+    SIZING_SCHEMA_VERSION,
+    SizingObservabilitySink,
+    persist,
+)
+
+
+def _observation(**overrides) -> SizingObservation:
+    base = {
+        "activity_type": "automation-engine:merge",
+        "task_queue": "atlan-automation-engine-heavy",
+        "workflow_type": "AutomationWorkflow",
+        "attempt": 1,
+        "outcome": "OK",
+        "duration_seconds": 47.2,
+        "peak_memory_bytes": 6 * 1024**3,
+        "peak_memory_fraction": 0.375,
+        "peak_source": "poll",
+        "memory_limit_bytes": 16 * 1024**3,
+        "cpu_seconds": 78.4,
+        "cpu_throttled_seconds": 12.1,
+        "cpu_throttled_fraction": 0.31,
+        "cpu_quota_cores": 2.0,
+        "input_bytes": 2 * 1024**3,
+        "input_file_count": 24,
+        "input_basis": "reported",
+    }
+    base.update(overrides)
+    return SizingObservation(**base)
+
+
+@pytest.fixture
+def sink(tmp_path):
+    sizing_sink._reset_for_testing()
+    s = SizingObservabilitySink(
+        batch_size=1000,
+        flush_interval=3600,
+        retention_days=1,
+        cleanup_enabled=False,
+        data_dir=str(tmp_path),
+        file_name=SIZING_FILE_NAME,
+    )
+    yield s
+    sizing_sink._reset_for_testing()
+
+
+class TestSignalRouting:
+    def test_sizing_has_its_own_s3_prefix(self):
+        """Not the ``other`` fallback: it must be selectable across tenants."""
+        assert "sizing" in OBSERVABILITY_S3_PREFIX_MAP
+        assert OBSERVABILITY_S3_PREFIX_MAP["sizing"].endswith("/sizing")
+
+    def test_local_and_remote_maps_agree(self):
+        """Two separate maps drive the local dir and the remote key.
+
+        A signal in only one of them writes to ``other/`` on disk while uploading to
+        ``sizing/`` — consistent enough to work, confusing enough to lose.
+        """
+        assert LOCAL_OBS_SUBDIR_MAP["sizing"].endswith("/sizing")
+        assert set(LOCAL_OBS_SUBDIR_MAP) == set(OBSERVABILITY_S3_PREFIX_MAP)
+
+    def test_signal_type_is_sizing(self, sink):
+        """Drives the partition path, so a wrong answer buries the dataset."""
+        assert sink._get_signal_type() == "sizing"
+
+
+class TestProcessRecord:
+    def test_carries_the_schema_version(self, sink):
+        """Rows are read months later, mixed across SDK versions."""
+        row = sink.process_record(_observation())
+        assert row["schema_version"] == SIZING_SCHEMA_VERSION
+
+    def test_stamps_app_and_deployment(self, sink):
+        """Cross-tenant rows sit under one prefix; a row must name its origin.
+
+        Pooling tenants blindly would be wrong anyway — a tenant's data volume is
+        the very thing being measured.
+        """
+        row = sink.process_record(_observation())
+        assert "app" in row
+        assert "deployment" in row
+
+    def test_flattens_the_measurements(self, sink):
+        row = sink.process_record(_observation())
+        assert row["activity_type"] == "automation-engine:merge"
+        assert row["peak_memory_bytes"] == 6 * 1024**3
+        assert row["cpu_throttled_fraction"] == 0.31
+        assert row["input_basis"] == "reported"
+
+    def test_precomputes_the_derived_ratios(self, sink):
+        """Derived once here so every consumer computes them identically."""
+        row = sink.process_record(_observation())
+        assert row["peak_per_input_byte"] == pytest.approx(3.0)
+        assert row["mean_cpu_cores"] == pytest.approx(78.4 / 47.2)
+
+    def test_derived_ratios_are_none_when_undefined(self, sink):
+        row = sink.process_record(_observation(input_bytes=None, cpu_seconds=None))
+        assert row["peak_per_input_byte"] is None
+        assert row["mean_cpu_cores"] is None
+
+    def test_export_record_is_a_no_op(self, sink):
+        """Histograms come from record_observation, not from the batching sink."""
+        assert sink.export_record(_observation()) is None
+
+
+class TestPersist:
+    def test_buffers_the_observation(self, tmp_path):
+        sizing_sink._reset_for_testing()
+        fake = MagicMock()
+        with patch.object(sizing_sink, "get_sink", return_value=fake):
+            persist(_observation())
+        fake.add_record.assert_called_once()
+
+    def test_never_raises_when_the_sink_is_broken(self):
+        """Called from an activity's finally; must cost the record, not the run."""
+        with patch.object(
+            sizing_sink, "get_sink", side_effect=RuntimeError("no store")
+        ):
+            persist(_observation())  # must not raise
+
+    def test_never_raises_when_add_record_fails(self):
+        fake = MagicMock()
+        fake.add_record.side_effect = RuntimeError("buffer full")
+        with patch.object(sizing_sink, "get_sink", return_value=fake):
+            persist(_observation())  # must not raise
+
+    def test_unavailable_sink_is_tolerated(self):
+        with patch.object(sizing_sink, "get_sink", return_value=None):
+            persist(_observation())  # must not raise
+
+
+class TestGetSink:
+    def test_is_cached(self, tmp_path):
+        """One sink per process — a second would double-buffer and double-upload."""
+        sizing_sink._reset_for_testing()
+        with patch.object(
+            sizing_sink, "get_observability_dir", return_value=str(tmp_path)
+        ):
+            first = sizing_sink.get_sink()
+            second = sizing_sink.get_sink()
+        assert first is second
+        sizing_sink._reset_for_testing()
+
+    def test_returns_none_when_construction_fails(self):
+        """A worker whose observability dir is unwritable must still run activities."""
+        sizing_sink._reset_for_testing()
+        with patch.object(
+            sizing_sink,
+            "SizingObservabilitySink",
+            side_effect=OSError("read-only fs"),
+        ):
+            assert sizing_sink.get_sink() is None
+        sizing_sink._reset_for_testing()
+
+
+class TestRecordObservationPersists:
+    def test_record_observation_reaches_the_sink(self):
+        """The wiring: histograms and the durable row come from the same call."""
+        from application_sdk.observability import sizing as sizing_module
+
+        with (
+            patch("application_sdk.observability.sizing_sink.persist") as mock_persist,
+            patch(
+                "application_sdk.observability.sizing._otel_metrics.get_meter",
+                return_value=MagicMock(),
+            ),
+        ):
+            sizing_module._INSTRUMENTS.clear()
+            sizing_module.record_observation(_observation())
+            sizing_module._INSTRUMENTS.clear()
+
+        mock_persist.assert_called_once()
+
+    def test_nothing_measured_is_not_persisted(self):
+        """An all-null row must not enter the dataset tiers are fitted from."""
+        from application_sdk.observability import sizing as sizing_module
+
+        with patch("application_sdk.observability.sizing_sink.persist") as mock_persist:
+            sizing_module.record_observation(
+                _observation(peak_memory_bytes=None, cpu_seconds=None)
+            )
+        mock_persist.assert_not_called()


### PR DESCRIPTION
### Changelog

Collects per-activity resource usage so worker tier envelopes can be re-derived from measured data instead of estimated. **Collection only — nothing here reads or decides a tier.** Ships off.

- **`application_sdk/observability/cgroup.py`** (new) — container-level readers: `memory.current` / `memory.max` / `memory.peak` and `cpu.stat` (`usage_usec`, `nr_periods`, `nr_throttled`, `throttled_usec`), cgroup v2 with v1 fallbacks, plus `track_container_usage()` as an async context manager.
- **`application_sdk/observability/sizing.py`** (new) — `SizingObservation` record, four OTel histograms (`activity.sizing.peak_memory_mib` / `peak_memory_fraction` / `cpu_throttled_fraction` / `mean_cpu_cores`), and one structured `activity_sizing_observation` log line per execution.
- **`interceptors/sizing.py`** (new) — `SizingTelemetryInterceptor`, wired by `create_worker`, gated on an allow-list of activity names.
- **`execution/settings.py`** — `APPLICATION_SDK_ENABLE_SIZING_TELEMETRY` (default `false`), `APPLICATION_SDK_SIZING_TELEMETRY_ACTIVITIES` (default empty), `APPLICATION_SDK_SIZING_TELEMETRY_POLL_SECONDS` (default `1.0`).

### Why not extend `resource_sampler`

It reads the *process*, which is the right instrument for App Vitals and the wrong one for sizing:

1. **RSS is not what the OOM killer acts on** — the kernel kills on the cgroup's `memory.current`, which includes page cache and any child process. An activity reading a large Parquet file through the page cache is under-measured, in the direction that makes a too-small tier look safe.
2. **Start/end point samples miss the peak** — a tier has to cover the maximum, not the value at the moment the activity finished. A query that builds a 12 GiB hash table and releases it reads small at both ends.
3. **CPU seconds cannot distinguish cheap from starved** — an activity given a 1-core quota and needing 3 reports ~1 core-second per wall second and looks perfectly sized. `cpu.stat`'s throttling counters are the only signal that separates the two.

### Design notes for review

**Peak memory takes the cheapest instrument that works.** `memory.peak` is reset on entry and read on exit (two file reads per activity, catches spikes of any duration); the background poller is used only when that reset cannot be **proven**. Proof rather than kernel-version sniffing — `memory.peak` is only writable from Linux 6.8, a write can succeed as a no-op, and the v1/v2 split makes any version table unreliable — so it reads the watermark back and requires it to have dropped. An unproven reset would report the pod's lifetime watermark as this activity's peak. `peak_source` is recorded on every observation because a watermark peak and a polled peak have different blind spots.

**A 1-second poll default is affordable because there is no RPC.** Deliberately unlike AE's `report_memory_pressure`, whose per-tick `activity.heartbeat()` is a network call — that one is a safety device whose readings must reach the workflow; this one only has to reach the local process.

**An interceptor, not a decorator.** A decorator has to be applied by every app author to every task method, and the teams that forget are exactly the ones with no sizing data — so the dataset would skew towards teams who already care about resource usage. `create_worker` already attaches SDK interceptors to every activity in every v3 app.

**A sibling of `MetricsInterceptor`, not an extension.** This one is gated and that one is unconditional; the App Vitals path should not gain a background task and a set of cgroup reads as a side effect of a sizing rollout. Not exported from the `interceptors` package and not accepted via `create_worker(interceptors=...)`, which makes double-registration — and therefore two pollers per activity — impossible by construction rather than by a guard list.

**Empty allow-list collects nothing.** Sizing data is only worth collecting for activities whose resource use varies with the data they process; most activities are fixed-cost bookkeeping, and measuring them adds rows without adding information. Empty is also the fail-closed direction, so a tenant that sets the enable flag and forgets the list gets no telemetry rather than telemetry on everything. Since that is silent, the worker warns at startup. `"*"` selects everything, for a discovery pass on a test tenant.

**The allow-list matches the bare task name as well as the qualified one.** A v3 activity registers as `"{app_name}:{task_name}"`, so `activity_type` is `"automation-engine:merge"` — but an author reading `@task async def merge` will write `merge`. Matching only the qualified form silently collected nothing: config looks right, worker logs the activities it is measuring, dataset comes back empty. A qualified entry still narrows to one app.

**Nulls stay distinguishable from zeros.** Every reader returns `None` rather than raising or guessing, and an observation with nothing measured is dropped rather than emitted — a null read downstream as a zero would fit the smallest tier to an activity nobody measured.

**Telemetry never fails the activity it measures.** The setup block, the poller-cancel path and the finalisation are each guarded; tests pin all three, including that the block's own exception still propagates.

### Additional context

- Companion AE change: atlanhq/atlan-automation-engine-app#1089 (`6cf5f0bc`). AE builds its own worker and so owns its own interceptor list, meaning SDK interceptors reach the whole fleet *except* AE — it needs the interceptor attached by hand. That change is inert until this ships, since AE pins `>=3.15.1` and 3.15.1 has neither the interceptor nor the settings fields.
- This is the "collect data" stage of collect → classify tiers → productionise. Still to come: an `input_bytes` driver variable, a durable columnar sink (the structured log line is the only sink today), cross-tenant curation, and the analysis that emits the tier table.

### Checklist
- [x] Additional tests added — 70 new tests (34 cgroup, 32 interceptor/record/settings, 4 worker wiring); 7290 unit tests pass; pre-commit incl. pyright clean
- [ ] All CI checks passed
- [ ] Relevant documentation updated

> [!WARNING]
> **Not verified on a real cgroup.** Everything is tested against fake hierarchies on disk (macOS has no cgroup). Which peak mode actually engages on a tenant — `watermark` or `poll` — depends on the node kernel, and `memory.peak` is only resettable from 6.8, so `poll` is the likely path on current GKE/EKS nodes. `peak_source` is on every observation so this is checkable the moment collection is switched on. This is the main reason the PR is a draft.

> [!NOTE]
> **Conformance.** 9 findings remain in the new files (broad-except guards, `contextlib.suppress`, loop-swallowed `OSError`) — the same intentional-and-documented class as the existing observability interceptors, which report the same codes despite carrying `# conformance: ignore[...]` comments (those are advisory, not machine-enforced). Repo total went 523 → 519, because conformance caught four real issues in this code: an assign-only `except`, `json` → `orjson`, and a missing `exc_info=True`.

---

### Copyleft License Compliance

- [ ] Have you used any code that is subject to a Copyleft license (e.g., GPL, AGPL, LGPL)?
- [ ] If yes, have you modified the code in the context of this project? please share additional details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
