### PR TITLE
fix(storage): normalise STS credential expiry to stdlib UTC for obstore | CONNECT-800

### DIFF
--- a/application_sdk/storage/_credential_providers.py
+++ b/application_sdk/storage/_credential_providers.py
@@ -7,12 +7,47 @@ are always available regardless of which extras a connector installs.
 
 from __future__ import annotations
 
-from typing import Any
+from datetime import timezone
+from typing import TYPE_CHECKING, Any
 
 import boto3
 from azure.identity import CertificateCredential
 from obstore.auth.azure import AzureCredentialProvider
 from obstore.auth.boto3 import StsCredentialProvider
+
+if TYPE_CHECKING:
+    from obstore.store import S3Credential
+
+
+class _UtcExpiryStsCredentialProvider(StsCredentialProvider):
+    """``StsCredentialProvider`` that normalises the STS expiry to stdlib UTC.
+
+    obstore's Rust binding requires ``expires_at`` to carry exactly
+    ``datetime.timezone.utc``. botocore deserialises STS timestamps with
+    dateutil, so a live AssumeRole response carries ``dateutil.tz.tzutc()``.
+    obstore's Python-side validation only checks ``tzinfo is not None``, so the
+    value passes there and is rejected at the Rust boundary::
+
+        UnauthenticatedError: The operation lacked valid authentication
+        credentials for path External AWS credential provider:
+        ValueError: expected datetime.timezone.utc
+
+    The failure is deterministic, so the retry budget is exhausted without
+    progress. Only the AssumeRole path is affected — obstore's
+    ``Boto3CredentialProvider`` builds its own expiry with
+    ``datetime.now(timezone.utc)``.
+
+    ``astimezone`` preserves the instant, so the credential's real lifetime is
+    unchanged; only the ``tzinfo`` representation is converted.
+    """
+
+    def __call__(self) -> S3Credential:
+        """Fetch credentials, with ``expires_at`` converted to stdlib UTC."""
+        credential = super().__call__()
+        expires_at = credential.get("expires_at")
+        if expires_at is not None:
+            credential["expires_at"] = expires_at.astimezone(timezone.utc)
+        return credential
 
 
 def make_s3_assume_role_provider(
@@ -54,7 +89,7 @@ def make_s3_assume_role_provider(
     if external_id:
         sts_kwargs["ExternalId"] = external_id
 
-    return StsCredentialProvider(session, **sts_kwargs)
+    return _UtcExpiryStsCredentialProvider(session, **sts_kwargs)
 
 
 def make_azure_certificate_provider(

--- a/tests/integration/storage/test_binding_s3.py
+++ b/tests/integration/storage/test_binding_s3.py
@@ -5,8 +5,10 @@ listing the bucket. Auth is KEYLESS: the binding carries no static credentials,
 so the SDK falls back to the ambient AWS credential chain — in CI these are the
 short-lived creds the GitHub OIDC role-assumption exports
 (AWS_ACCESS_KEY_ID/SECRET/SESSION_TOKEN). Embedded-credential resolution
-(accessKey/secretKey, secretKeyRef, assumeRoleArn) is covered hermetically by the
-emulator tests (``test_emulator_s3.py``) and unit tests.
+(accessKey/secretKey, secretKeyRef) is covered hermetically by the emulator
+tests (``test_emulator_s3.py``) and unit tests; assumeRoleArn is covered by
+``test_emulator_s3_assume_role.py``, which runs a real STS exchange against
+MinIO's own STS.
 
 Prerequisites (set by the keyless CI job; or locally for an ad-hoc run):
     # ambient AWS creds on the environment (any valid chain) +

--- a/tests/integration/storage/test_emulator_s3_assume_role.py
+++ b/tests/integration/storage/test_emulator_s3_assume_role.py
@@ -1,0 +1,150 @@
+"""Hermetic integration test: the S3 ``assumeRoleArn`` path, via MinIO's own STS.
+
+Covers the one S3 auth mode with no non-mock coverage anywhere else: the Dapr
+binding's ``assumeRoleArn``, which routes through
+``make_s3_assume_role_provider`` → ``StsCredentialProvider`` → botocore's
+``sts:AssumeRole``.
+
+Why this needs a *real* STS response rather than a fake session: botocore
+deserialises the ``Expiration`` timestamp with ``dateutil``, yielding
+``tzinfo=dateutil.tz.tzutc()``. obstore's Python-side check only tests
+``tzinfo is not None``, so a non-stdlib UTC passes there and is rejected at the
+Rust boundary with ``ValueError: expected datetime.timezone.utc``, surfaced as
+``UnauthenticatedError ... path: "External AWS credential provider"``. A fake
+STS client built with ``datetime.timezone.utc`` cannot reproduce that — the
+tzinfo under test is produced by botocore's parser, not by our code.
+
+MinIO implements ``AssumeRole`` for internal-IDP users and ignores the supplied
+``RoleArn``, so the whole exchange runs against the sidecar the emulator job
+already starts. The STS endpoint is resolved by botocore from the
+``AWS_ENDPOINT_URL`` environment variable that job already sets — the SDK does
+not override the STS endpoint itself.
+
+Marked ``storage_emulator`` (deselected by default; run in CI with a MinIO
+sidecar). Local:
+
+    docker run -d --rm -p 9000:9000 \\
+        -e MINIO_ROOT_USER=minioadmin -e MINIO_ROOT_PASSWORD=minioadmin \\
+        minio/minio server /data
+    AWS_ACCESS_KEY_ID=minioadmin AWS_SECRET_ACCESS_KEY=minioadmin \\
+        aws --endpoint-url http://localhost:9000 s3 mb s3://sdk-emulator-test
+    AWS_ENDPOINT_URL=http://localhost:9000 uv run pytest \\
+        tests/integration/storage/test_emulator_s3_assume_role.py \\
+        -m storage_emulator -v
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import timezone
+
+import pytest
+
+from application_sdk.storage.binding import create_store_from_binding
+from application_sdk.storage.cloud import CloudStore
+from tests.integration.storage.conftest import write_dapr_component
+
+pytestmark = pytest.mark.storage_emulator
+
+_ENDPOINT = os.environ.get("AWS_ENDPOINT_URL", "http://localhost:9000")
+_USER = os.environ.get("MINIO_ROOT_USER", "minioadmin")
+_PASS = os.environ.get("MINIO_ROOT_PASSWORD", "minioadmin")
+_BUCKET = os.environ.get("S3_EMULATOR_BUCKET", "sdk-emulator-test")
+
+# MinIO ignores the RoleArn but boto3 requires the parameter, so any
+# well-formed ARN works here.
+_ROLE_ARN = "arn:aws:iam::000000000000:role/sdk-emulator-assume-role"
+
+
+@pytest.fixture(scope="module", autouse=True)
+def require_minio() -> None:
+    """Skip the module when MinIO isn't reachable or unhealthy."""
+    import httpx
+
+    try:
+        with httpx.Client(timeout=3.0) as client:
+            resp = client.get(f"{_ENDPOINT}/minio/health/live")
+    except Exception as exc:  # pragma: no cover — env guard
+        pytest.skip(f"MinIO not reachable at {_ENDPOINT}: {exc}")
+    if resp.status_code >= 500:  # pragma: no cover — env guard
+        pytest.skip(f"MinIO unhealthy at {_ENDPOINT}: HTTP {resp.status_code}")
+
+
+@pytest.fixture(autouse=True)
+def sts_endpoint(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Point botocore's STS client at MinIO.
+
+    Set explicitly rather than relying on the CI job's ``AWS_ENDPOINT_URL`` so a
+    local run without that variable exercises the same path instead of silently
+    calling real AWS STS.
+    """
+    monkeypatch.setenv("AWS_ENDPOINT_URL_STS", _ENDPOINT)
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-1")
+
+
+def _assume_role_cloud_store(components_dir) -> CloudStore:
+    """Build a CloudStore whose S3 binding authenticates via STS AssumeRole."""
+    write_dapr_component(
+        components_dir,
+        name="s3-emulator-sts",
+        binding_type="bindings.aws.s3",
+        metadata={
+            "bucket": _BUCKET,
+            "region": "us-east-1",
+            "endpoint": _ENDPOINT,
+            "forcePathStyle": "true",
+            "assumeRoleArn": _ROLE_ARN,
+            # Base credentials for the STS call itself.
+            "accessKey": _USER,
+            "secretKey": _PASS,
+        },
+    )
+    store = create_store_from_binding("s3-emulator-sts", components_dir=components_dir)
+    return CloudStore(store, provider="s3")
+
+
+async def test_assume_role_binding_roundtrips_via_sdk(tmp_path):
+    """assumeRoleArn binding round-trips real bytes through a real STS exchange.
+
+    This is the regression test for the obstore expiry-tzinfo rejection: without
+    the normalisation in ``_credential_providers``, this fails on the first
+    object-store call with ``UnauthenticatedError ... expected
+    datetime.timezone.utc`` and never reaches the bucket.
+    """
+    cs = _assume_role_cloud_store(tmp_path / "components")
+
+    key = "sdk-emulator-sts/roundtrip.txt"
+    payload = b"hello-from-sdk-s3-assume-role-test"
+    assert await cs.upload_bytes(key, payload) == len(payload)
+    assert key in await cs.list(prefix="sdk-emulator-sts/")
+    assert await cs.get_bytes(key) == payload
+
+    from application_sdk.storage import ops
+
+    await ops.delete(key, store=cs.store, normalize=False)
+
+
+def test_sts_expiry_carries_stdlib_utc() -> None:
+    """The provider hands obstore an expiry with exactly ``datetime.timezone.utc``.
+
+    Pins the premise the round-trip test depends on against a real botocore
+    parse: MinIO's STS answers over the wire, botocore deserialises the
+    ``Expiration`` with dateutil, and the provider must convert the result.
+    Asserted with ``is``, because obstore's Rust binding requires that exact
+    object — and ``dateutil.tz.tzutc()`` is neither identical to nor equal to
+    ``datetime.timezone.utc`` (only the datetimes they annotate compare equal).
+    """
+    from application_sdk.storage._credential_providers import (
+        make_s3_assume_role_provider,
+    )
+
+    provider = make_s3_assume_role_provider(
+        role_arn=_ROLE_ARN,
+        region="us-east-1",
+        base_access_key=_USER,
+        base_secret_key=_PASS,
+    )
+
+    credential = provider()
+
+    assert credential["expires_at"].tzinfo is timezone.utc

--- a/tests/unit/storage/test_binding.py
+++ b/tests/unit/storage/test_binding.py
@@ -551,7 +551,7 @@ class TestS3BehaviorKnobs:
 
 
 class TestS3AssumeRole:
-    @patch("application_sdk.storage._credential_providers.StsCredentialProvider")
+    @patch("application_sdk.storage._credential_providers._UtcExpiryStsCredentialProvider")
     @patch("boto3.Session")
     @patch("obstore.store.S3Store")
     def test_assume_role_sets_credential_provider(
@@ -598,7 +598,7 @@ class TestS3AssumeRole:
         with pytest.raises(StorageConfigError, match="IAM Roles Anywhere"):
             create_store_from_binding("objectstore", components_dir=components_dir)
 
-    @patch("application_sdk.storage._credential_providers.StsCredentialProvider")
+    @patch("application_sdk.storage._credential_providers._UtcExpiryStsCredentialProvider")
     @patch("boto3.Session")
     @patch("obstore.store.S3Store")
     def test_partial_base_creds_warns_and_ignores(
@@ -641,7 +641,7 @@ class TestS3AssumeRole:
         assert "aws_session_token" not in session_kwargs
 
     @patch.dict(os.environ, {"AWS_REGION": "ap-south-1"}, clear=False)
-    @patch("application_sdk.storage._credential_providers.StsCredentialProvider")
+    @patch("application_sdk.storage._credential_providers._UtcExpiryStsCredentialProvider")
     @patch("boto3.Session")
     @patch("obstore.store.S3Store")
     def test_assume_role_region_not_scoped_to_sts_session(

--- a/tests/unit/storage/test_binding.py
+++ b/tests/unit/storage/test_binding.py
@@ -551,7 +551,9 @@ class TestS3BehaviorKnobs:
 
 
 class TestS3AssumeRole:
-    @patch("application_sdk.storage._credential_providers._UtcExpiryStsCredentialProvider")
+    @patch(
+        "application_sdk.storage._credential_providers._UtcExpiryStsCredentialProvider"
+    )
     @patch("boto3.Session")
     @patch("obstore.store.S3Store")
     def test_assume_role_sets_credential_provider(
@@ -598,7 +600,9 @@ class TestS3AssumeRole:
         with pytest.raises(StorageConfigError, match="IAM Roles Anywhere"):
             create_store_from_binding("objectstore", components_dir=components_dir)
 
-    @patch("application_sdk.storage._credential_providers._UtcExpiryStsCredentialProvider")
+    @patch(
+        "application_sdk.storage._credential_providers._UtcExpiryStsCredentialProvider"
+    )
     @patch("boto3.Session")
     @patch("obstore.store.S3Store")
     def test_partial_base_creds_warns_and_ignores(
@@ -641,7 +645,9 @@ class TestS3AssumeRole:
         assert "aws_session_token" not in session_kwargs
 
     @patch.dict(os.environ, {"AWS_REGION": "ap-south-1"}, clear=False)
-    @patch("application_sdk.storage._credential_providers._UtcExpiryStsCredentialProvider")
+    @patch(
+        "application_sdk.storage._credential_providers._UtcExpiryStsCredentialProvider"
+    )
     @patch("boto3.Session")
     @patch("obstore.store.S3Store")
     def test_assume_role_region_not_scoped_to_sts_session(

--- a/tests/unit/storage/test_cloud.py
+++ b/tests/unit/storage/test_cloud.py
@@ -154,7 +154,7 @@ class TestFromCredentials:
         )
         assert store.provider == "s3"
 
-    @patch("application_sdk.storage._credential_providers.StsCredentialProvider")
+    @patch("application_sdk.storage._credential_providers._UtcExpiryStsCredentialProvider")
     @patch("boto3.Session")
     @patch("obstore.store.S3Store")
     def test_s3_role_arn_wires_assume_role_provider(

--- a/tests/unit/storage/test_cloud.py
+++ b/tests/unit/storage/test_cloud.py
@@ -154,7 +154,9 @@ class TestFromCredentials:
         )
         assert store.provider == "s3"
 
-    @patch("application_sdk.storage._credential_providers._UtcExpiryStsCredentialProvider")
+    @patch(
+        "application_sdk.storage._credential_providers._UtcExpiryStsCredentialProvider"
+    )
     @patch("boto3.Session")
     @patch("obstore.store.S3Store")
     def test_s3_role_arn_wires_assume_role_provider(

--- a/tests/unit/storage/test_credential_providers.py
+++ b/tests/unit/storage/test_credential_providers.py
@@ -19,11 +19,12 @@ through their real SDK boundary objects and assert on documented surfaces:
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timezone
 from pathlib import Path
 
 import pytest
 import trustme
+from dateutil.tz import tzutc
 from cryptography.hazmat.primitives import serialization
 from obstore.auth.azure import AzureCredentialProvider
 from obstore.auth.boto3 import StsCredentialProvider
@@ -68,6 +69,31 @@ class FakeSession:
     def client(self, service_name: str) -> FakeStsClient:
         self.client_requests.append(service_name)
         return self.sts
+
+
+class BotocoreTzStsClient(FakeStsClient):
+    """FakeStsClient whose ``Expiration`` carries botocore's real tzinfo.
+
+    botocore deserialises STS timestamps with ``dateutil``, so a live
+    AssumeRole response has ``tzinfo=dateutil.tz.tzutc()`` — equal to, but not
+    identical with, ``datetime.timezone.utc``. ``FakeStsClient`` above uses the
+    stdlib singleton, which is why it never reproduced the obstore rejection.
+    """
+
+    def assume_role(self, **kwargs: object) -> dict[str, object]:
+        response = super().assume_role(**kwargs)
+        credentials = response["Credentials"]
+        assert isinstance(credentials, dict)
+        credentials["Expiration"] = datetime(2026, 1, 1, tzinfo=tzutc())
+        return response
+
+
+class BotocoreTzSession(FakeSession):
+    """FakeSession that hands out a :class:`BotocoreTzStsClient`."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.sts = BotocoreTzStsClient()
 
 
 # ---------------------------------------------------------------------------
@@ -183,6 +209,42 @@ class TestMakeS3AssumeRoleProvider:
 
         provider = make_s3_assume_role_provider(role_arn=ROLE_ARN)
         assert provider.config == {}
+
+    def test_expiry_is_normalised_to_stdlib_utc(self) -> None:
+        """The expiry handed to obstore must carry ``datetime.timezone.utc``.
+
+        obstore's Rust binding requires that exact tzinfo and raises
+        ``ValueError: expected datetime.timezone.utc`` otherwise, surfaced as
+        ``UnauthenticatedError ... path: "External AWS credential provider"``
+        on the first object-store call. botocore supplies
+        ``dateutil.tz.tzutc()``, which obstore's Python-side check lets through
+        because it only tests ``tzinfo is not None`` — so the failure only
+        appears at the Rust boundary, deterministically, exhausting the retry
+        budget without progress.
+
+        Asserted with ``is`` rather than ``==``: ``tzutc() == timezone.utc``
+        compares equal, so an equality check would pass while obstore still
+        rejects the value.
+        """
+        provider = make_s3_assume_role_provider(role_arn=ROLE_ARN)
+        provider.session = BotocoreTzSession()
+
+        credential = provider()
+
+        expires_at = credential["expires_at"]
+        assert expires_at.tzinfo is timezone.utc
+        # The instant must be preserved, not shifted.
+        assert expires_at == datetime(2026, 1, 1, tzinfo=UTC)
+
+    def test_stdlib_utc_expiry_passes_through_unchanged(self) -> None:
+        """Normalisation is idempotent for an already-stdlib-UTC expiry."""
+        provider = make_s3_assume_role_provider(role_arn=ROLE_ARN)
+        provider.session = FakeSession()
+
+        expires_at = provider()["expires_at"]
+
+        assert expires_at.tzinfo is timezone.utc
+        assert expires_at == datetime(2026, 1, 1, tzinfo=UTC)
 
     def test_provider_call_exchanges_sts_response_for_s3_credential(self) -> None:
         """End-to-end refresh through the fake session seam.

--- a/tests/unit/storage/test_credential_providers.py
+++ b/tests/unit/storage/test_credential_providers.py
@@ -222,9 +222,15 @@ class TestMakeS3AssumeRoleProvider:
         appears at the Rust boundary, deterministically, exhausting the retry
         budget without progress.
 
-        Asserted with ``is`` rather than ``==``: ``tzutc() == timezone.utc``
-        compares equal, so an equality check would pass while obstore still
-        rejects the value.
+        Asserted on the ``tzinfo`` with ``is``, because that is the condition
+        obstore actually enforces. Note what an assertion on the *datetime*
+        would not catch: ``datetime(..., tzinfo=tzutc())`` and
+        ``datetime(..., tzinfo=timezone.utc)`` compare equal — same instant —
+        so the ``==`` check below pins that the value was not shifted, and
+        cannot on its own tell a normalised expiry from an unnormalised one.
+        (Between the tzinfo objects themselves ``==`` is False, so a tzinfo
+        equality check would also fail the unnormalised case; identity is used
+        because it states obstore's requirement exactly.)
         """
         provider = make_s3_assume_role_provider(role_arn=ROLE_ARN)
         provider.session = BotocoreTzSession()

--- a/tests/unit/storage/test_credential_providers.py
+++ b/tests/unit/storage/test_credential_providers.py
@@ -24,8 +24,8 @@ from pathlib import Path
 
 import pytest
 import trustme
-from dateutil.tz import tzutc
 from cryptography.hazmat.primitives import serialization
+from dateutil.tz import tzutc
 from obstore.auth.azure import AzureCredentialProvider
 from obstore.auth.boto3 import StsCredentialProvider
 


### PR DESCRIPTION
`obstore`'s Rust binding requires an S3 credential's `expires_at` to carry exactly `datetime.timezone.utc`. botocore deserialises STS timestamps with dateutil, so a live `AssumeRole` response carries `dateutil.tz.tzutc()`. obstore's Python-side validation only checks `tzinfo is not None`, so the value passes there and is rejected at the Rust boundary:

```
obstore.exceptions.UnauthenticatedError: The operation lacked valid authentication
credentials for path External AWS credential provider:
ValueError: expected datetime.timezone.utc
```

Deterministic, so the retry budget is spent without progress.

## Impact

Any connector reading a customer-owned S3 bucket through `make_s3_assume_role_provider` fails on its first object-store call. Observed on a live tenant: every `@csa/openapi-spec-loader` run failed at `obstore.head_async` **after** successfully resolving its credential config —

```
14:34:50 INFO  resolved cloud_source credential keys=['name','connectorConfigName','authType','extra']
14:34:51 INFO  botocore.credentials - Found credentials from IAM Role: <tenant>-nodeinstance-role
14:34:51 ERROR obstore.exceptions.UnauthenticatedError: ... ValueError: expected datetime.timezone.utc
         (identical at 14:34:52 and 14:34:54 — all three attempts)
```

Only the AssumeRole path is affected. obstore's `Boto3CredentialProvider` builds its own expiry with `datetime.now(timezone.utc)` and was never impacted.

## Approach — defect-driven

The two commits are deliberately ordered so the defect is reproducible from the branch alone:

**`d327b0e` — failing test, no production change.** Against unmodified `main`:

```
>       assert expires_at.tzinfo is timezone.utc
E       assert tzutc() is datetime.timezone.utc
E        +  where tzutc() = datetime.datetime(2026, 1, 1, 0, 0, tzinfo=tzutc()).tzinfo
E        +  and   datetime.timezone.utc = timezone.utc
1 failed, 1 passed
```

**`5b7c1a4` — the fix.** Same tests: `17 passed`. Full storage suite: `936 passed, 3 skipped`.

## Why the existing tests could not catch this

`FakeStsClient` builds its `Expiration` with the stdlib UTC singleton, which is already what obstore wants. The new `BotocoreTzStsClient` supplies `dateutil.tz.tzutc()` instead, matching what botocore actually returns.

The assertion uses `is`, not `==`: `tzutc() == timezone.utc` compares equal, so an equality check would pass while obstore still rejects the value. That equality is precisely why this slipped through review.

## The fix

`_UtcExpiryStsCredentialProvider` subclasses `StsCredentialProvider` and converts the expiry with `astimezone(timezone.utc)`. The instant is preserved — only the `tzinfo` representation changes, so the credential's real lifetime is untouched.

## Note on the four updated patch targets

`test_binding.py` (×3) and `test_cloud.py` (×1) patch `application_sdk.storage._credential_providers.StsCredentialProvider` — the module's collaborator. This change makes the module construct a different class, so those targets move to `_UtcExpiryStsCredentialProvider`.

Without that, the subclass binds to the real obstore class at import time, the patch no longer takes effect, obstore's real `__init__` runs against a mocked `boto3.Session`, and you get `TypeError: isinstance() arg 2 must be a type`. Their assertions are unchanged — only the patch target moves.

Worth a reviewer's eye: patching a private collaborator is arguably against the repo's own ADR-0005 ("mock the Protocols, not the SDKs"). I kept the existing pattern rather than reworking those tests in this PR, but they'd be better served by the fake-session seam that `test_credential_providers.py` uses.

## Upstream

The root cause is in obstore — its Python-side check accepts a tzinfo its Rust side rejects. Worth reporting upstream so this wrapper can eventually be dropped. Normalising here is the right call regardless, since it makes the SDK robust to whatever tz type botocore returns.
