### PR TITLE
ci(manifest): isolate the sparse ack checkout from the full one (FND-637)

### DIFF
--- a/.github/scripts/tests/test_react_to_comment.py
+++ b/.github/scripts/tests/test_react_to_comment.py
@@ -20,7 +20,7 @@ import importlib.util
 import math
 import re
 import subprocess
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 import pytest
 import yaml
@@ -395,7 +395,12 @@ def test_every_caller_can_actually_reach_the_script() -> None:
     """A caller that never checks out the repo would fail at `python3 …`.
 
     Cheap to get wrong: two of these workflows react *before* their main
-    checkout, so they carry a sparse one just for this file.
+    checkout, so they carry a sparse one just for this file — and, since
+    FND-637, at a `path:` of its own so the sparse setting cannot leak into the
+    full checkout that follows. That makes the *path* part of the contract too:
+    the `run:` line has to name the directory the sparse checkout landed in, or
+    `python3` fails on a file that is genuinely not there. Asserting only that
+    "some checkout happened first" would not catch that.
     """
     for path in _yaml_files():
         text = path.read_text(encoding="utf-8")
@@ -405,17 +410,36 @@ def test_every_caller_can_actually_reach_the_script() -> None:
         jobs = doc.get("jobs") or {}
         for job_name, job in jobs.items():
             steps = job.get("steps") or []
-            checked_out = False
+            checkout_dirs: set[str] = set()
             for step in steps:
                 uses = str(step.get("uses") or "")
                 run = str(step.get("run") or "")
                 if uses.startswith("actions/checkout@"):
-                    checked_out = True
+                    with_block = step.get("with") or {}
+                    raw = str(with_block.get("path") or ".").strip().rstrip("/")
+                    checkout_dirs.add(raw or ".")
                 if SCRIPT_NAME in run:
-                    assert checked_out, (
+                    assert checkout_dirs, (
                         f"{path.name}:{job_name} runs {SCRIPT_NAME} with no "
                         "preceding actions/checkout"
                     )
+                    invoked = [
+                        token for token in run.split() if token.endswith(SCRIPT_NAME)
+                    ]
+                    assert invoked, (
+                        f"{path.name}:{job_name} names {SCRIPT_NAME} but the "
+                        "guard could not find the invoked path in the run body"
+                    )
+                    for token in invoked:
+                        parent = str(PurePosixPath(token).parent)
+                        # `.github/scripts/x.py` → checked out at the root;
+                        # `.ack/.github/scripts/x.py` → checked out at `.ack`.
+                        prefix = parent[: -len(".github/scripts")].rstrip("/") or "."
+                        assert prefix in checkout_dirs, (
+                            f"{path.name}:{job_name} runs '{token}', which needs "
+                            f"a checkout at '{prefix}', but this job only checks "
+                            f"out at {sorted(checkout_dirs)}"
+                        )
 
 
 # Every bot entry point that acknowledges a comment, as (workflow, job, step).

--- a/.github/scripts/tests/test_sparse_checkout_isolation.py
+++ b/.github/scripts/tests/test_sparse_checkout_isolation.py
@@ -1,0 +1,207 @@
+"""Cross-file guard: a sparse checkout must not share a path with a full one.
+
+`actions/checkout` with `sparse-checkout:` writes `core.sparseCheckout=true` into
+`.git/config` at **local** scope, plus the narrow pattern into
+`.git/info/sparse-checkout`. A later checkout into the same path then runs, in
+this order:
+
+1. `git sparse-checkout disable` — parks `core.sparseCheckout=false` in the
+   *worktree* config (`.git/config.worktree`) and sets `extensions.worktreeConfig`.
+   Worktree config shadows local, so the tree is restored at this instant.
+2. `git config --local --unset-all extensions.worktreeConfig` — makes the
+   worktree config inert. `core.sparseCheckout` reverts to **true** from the
+   local config, and the narrow pattern file is still on disk.
+3. `git checkout --force -B <ref>` — re-applies the sparse pattern.
+
+Net effect: the workspace stays sparse for the rest of the job. The failure is
+silent and far from its cause — in FND-637 it surfaced as
+`error: Failed to spawn: poe`, because `uv run` found no `pyproject.toml` and
+fell back to spawning a bare binary. Nothing in the checkout logs says the tree
+is narrow; `git sparse-checkout disable` even appears to have run.
+
+The fix is always the same: give the sparse checkout its own `path:`, so it
+never shares a git dir with the full checkout. This guard asserts that property
+structurally rather than trusting reviewers to remember the interaction.
+
+Scoping is per (file, job, path). Two sparse checkouts at the same path are fine
+— the trap needs a *full* checkout to land on a path a sparse one already
+claimed. Different jobs get different runners, so they cannot collide.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+CHECKOUT_ACTION = "actions/checkout@"
+
+# `path:` defaults to the workspace root when omitted.
+DEFAULT_PATH = "."
+
+
+def _yaml_files() -> list[Path]:
+    files = sorted((ROOT / "workflows").glob("*.y*ml"))
+    files += sorted((ROOT / "actions").glob("*/action.y*ml"))
+    return files
+
+
+def _rel(path: Path) -> str:
+    return str(path.relative_to(ROOT))
+
+
+def _normalise_path(raw: object) -> str:
+    """Collapse the spellings that name the same directory."""
+    text = str(raw or DEFAULT_PATH).strip()
+    if not text:
+        return DEFAULT_PATH
+    return str(Path(text).as_posix()).rstrip("/") or DEFAULT_PATH
+
+
+def _scopes() -> list[tuple[str, str, list[dict]]]:
+    """(file, scope, steps) per job and per composite `runs` block."""
+    scopes: list[tuple[str, str, list[dict]]] = []
+    for path in _yaml_files():
+        rel = _rel(path)
+        try:
+            doc = yaml.safe_load(path.read_text())
+        except yaml.YAMLError as exc:
+            pytest.fail(f"{rel} is not valid YAML ({exc.__class__.__name__}): {exc}")
+        if not isinstance(doc, dict):
+            continue
+        for job_id, job in (doc.get("jobs") or {}).items():
+            if isinstance(job, dict):
+                steps = [s for s in (job.get("steps") or []) if isinstance(s, dict)]
+                if steps:
+                    scopes.append((rel, f"job {job_id}", steps))
+        runs = doc.get("runs") or {}
+        if isinstance(runs, dict):
+            steps = [s for s in (runs.get("steps") or []) if isinstance(s, dict)]
+            if steps:
+                scopes.append((rel, "composite runs", steps))
+    return scopes
+
+
+def _label(step: dict, index: int) -> str:
+    return str(step.get("name") or step.get("id") or f"step #{index}")
+
+
+def collisions(steps: list[dict]) -> list[tuple[str, str, str]]:
+    """(path, sparse step, full step) for every sparse-then-full pair."""
+    claimed: dict[str, str] = {}
+    found: list[tuple[str, str, str]] = []
+    for index, step in enumerate(steps):
+        if CHECKOUT_ACTION not in str(step.get("uses") or ""):
+            continue
+        with_block = step.get("with") or {}
+        if not isinstance(with_block, dict):
+            with_block = {}
+        path = _normalise_path(with_block.get("path"))
+        if "sparse-checkout" in with_block:
+            claimed.setdefault(path, _label(step, index))
+        elif path in claimed:
+            found.append((path, claimed[path], _label(step, index)))
+    return found
+
+
+def test_no_full_checkout_reuses_a_sparse_checkout_path():
+    offenders = []
+    for rel, scope, steps in _scopes():
+        for path, sparse_step, full_step in collisions(steps):
+            offenders.append(
+                f"{rel} ({scope}): '{sparse_step}' checks out sparsely at "
+                f"'{path}', then '{full_step}' does a full checkout at the same "
+                f"path — the tree stays sparse. Give the sparse step its own "
+                f"`path:`."
+            )
+    assert not offenders, "\n".join(offenders)
+
+
+def test_guard_detects_the_fnd637_shape():
+    """The bug as it actually shipped: sparse ack, then full checkout at root."""
+    steps = [
+        {
+            "name": "Checkout reaction helper",
+            "uses": "actions/checkout@abc",
+            "with": {
+                "sparse-checkout": ".github/scripts/react_to_comment.py",
+                "sparse-checkout-cone-mode": False,
+            },
+        },
+        {"name": "Checkout PR branch", "uses": "actions/checkout@abc"},
+    ]
+    assert collisions(steps) == [
+        (".", "Checkout reaction helper", "Checkout PR branch")
+    ]
+
+
+def test_separate_paths_are_allowed():
+    steps = [
+        {
+            "name": "Checkout reaction helper",
+            "uses": "actions/checkout@abc",
+            "with": {"path": ".ack", "sparse-checkout": ".github/scripts/x.py"},
+        },
+        {"name": "Checkout PR branch", "uses": "actions/checkout@abc"},
+    ]
+    assert collisions(steps) == []
+
+
+def test_full_checkout_before_the_sparse_one_is_allowed():
+    """Order matters: only a full checkout *after* a sparse one inherits it."""
+    steps = [
+        {"name": "Checkout PR branch", "uses": "actions/checkout@abc"},
+        {
+            "name": "Checkout helper",
+            "uses": "actions/checkout@abc",
+            "with": {"sparse-checkout": ".github/scripts/x.py"},
+        },
+    ]
+    assert collisions(steps) == []
+
+
+def test_two_sparse_checkouts_at_one_path_are_allowed():
+    steps = [
+        {
+            "name": "First",
+            "uses": "actions/checkout@abc",
+            "with": {"sparse-checkout": "a.py"},
+        },
+        {
+            "name": "Second",
+            "uses": "actions/checkout@abc",
+            "with": {"sparse-checkout": "b.py"},
+        },
+    ]
+    assert collisions(steps) == []
+
+
+@pytest.mark.parametrize("spelling", [None, "", ".", "./", "./."])
+def test_root_path_spellings_collapse_to_one_path(spelling):
+    """`path: ./` and an omitted `path:` name the same directory."""
+    sparse_with: dict[str, object] = {"sparse-checkout": "a.py"}
+    if spelling is not None:
+        sparse_with["path"] = spelling
+    steps = [
+        {"name": "Sparse", "uses": "actions/checkout@abc", "with": sparse_with},
+        {"name": "Full", "uses": "actions/checkout@abc"},
+    ]
+    assert collisions(steps) == [(".", "Sparse", "Full")]
+
+
+def test_non_checkout_steps_are_ignored():
+    steps = [
+        {
+            "name": "Sparse",
+            "uses": "actions/checkout@abc",
+            "with": {"path": ".ack", "sparse-checkout": "a.py"},
+        },
+        {
+            "name": "Setup uv",
+            "uses": "astral-sh/setup-uv@abc",
+            "with": {"path": ".ack"},
+        },
+    ]
+    assert collisions(steps) == []

--- a/.github/workflows/auto-fix-vulnerabilities.yaml
+++ b/.github/workflows/auto-fix-vulnerabilities.yaml
@@ -63,9 +63,15 @@ jobs:
 
       # Sparse, and ahead of the full checkout below, so the ack stays the
       # first thing the requester sees.
+      #
+      # `path:` is load-bearing — this MUST NOT share a git dir with the full
+      # checkout below, or the workspace stays sparse for the rest of the job.
+      # See the long-form explanation in capability-manifest-regen.yaml
+      # (FND-637); the same trap applies here.
       - name: Checkout reaction helper
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          path: .ack
           sparse-checkout: .github/scripts/react_to_comment.py
           sparse-checkout-cone-mode: false
 
@@ -78,7 +84,7 @@ jobs:
           REPO: ${{ github.repository }}
           COMMENT_ID: ${{ github.event.comment.id }}
           REACTION: rocket
-        run: python3 .github/scripts/react_to_comment.py
+        run: python3 .ack/.github/scripts/react_to_comment.py
 
       - name: Mint fleet App token
         id: app-token

--- a/.github/workflows/capability-manifest-regen.yaml
+++ b/.github/workflows/capability-manifest-regen.yaml
@@ -89,10 +89,22 @@ jobs:
 
       # Sparse, and ahead of the full checkout below, so the ack stays the
       # first thing the requester sees.
+      #
+      # `path:` is load-bearing — this MUST NOT share a git dir with the full
+      # checkout below. actions/checkout writes `core.sparseCheckout=true` into
+      # `.git/config` (local scope), then the next checkout runs
+      # `git sparse-checkout disable` (which parks `false` in the *worktree*
+      # config) followed by `git config --local --unset-all
+      # extensions.worktreeConfig` — that unset makes the worktree config inert,
+      # so `core.sparseCheckout` reverts to true from local config and the
+      # narrow pattern is re-applied by the subsequent `git checkout --force`.
+      # Net effect: the workspace stays sparse, `pyproject.toml` is absent, and
+      # `uv run poe` fails with "Failed to spawn: poe" (FND-637).
       - name: Checkout reaction helper
         if: steps.pr.outputs.is_fork != 'true' && steps.pr.outputs.is_bump_version != 'true'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          path: .ack
           sparse-checkout: .github/scripts/react_to_comment.py
           sparse-checkout-cone-mode: false
 
@@ -106,7 +118,7 @@ jobs:
           REPO: ${{ github.repository }}
           COMMENT_ID: ${{ github.event.comment.id }}
           REACTION: rocket
-        run: python3 .github/scripts/react_to_comment.py
+        run: python3 .ack/.github/scripts/react_to_comment.py
 
       - name: Mint fleet App token
         id: app-token


### PR DESCRIPTION
Closes FND-637.

## What was broken

`/regen-manifest` has never worked. Every run dies at the first real step:

```
error: Failed to spawn: `poe`
  Caused by: No such file or directory (os error 2)
```

Most recent example: [run 32289386631](https://github.com/atlanhq/application-sdk/actions/runs/32289386631).

## Why

`capability-manifest-regen.yaml` does two `actions/checkout` steps into the same path — a sparse one carrying only `react_to_comment.py` (so the 🚀 ack lands before the slow full checkout), then the full checkout. That pairing does not survive `actions/checkout`'s own cleanup:

1. The sparse step writes `core.sparseCheckout=true` at **local** scope, plus the narrow pattern into `.git/info/sparse-checkout`.
2. The next checkout runs `git sparse-checkout disable`, which parks `core.sparseCheckout=false` in the **worktree** config and restores the tree — correct, for exactly as long as it lasts.
3. It then runs `git config --local --unset-all extensions.worktreeConfig`, which makes that worktree config inert. `core.sparseCheckout` reverts to `true` from local config, with the narrow pattern still on disk.
4. `git checkout --force -B <ref>` re-applies it.

The tree is narrow for the rest of the job. There is no `pyproject.toml`, so `uv run` concludes there is no project and spawns a bare `poe` that does not exist.

Nothing in the logs says "sparse" — `git sparse-checkout disable` appears to have run, and the only tell is `setup-uv` reporting `No file matched to [.../**/pyproject.toml, .../**/uv.lock, ...]` several lines earlier. Reproduced locally by replaying the three git commands in order.

The sibling `capability-manifest-check.yaml` is unaffected (single checkout), which is why drift detection works while regeneration never has.

## The fix

Give the sparse checkout its own `path: .ack`, so it never shares a git dir with the full one.

`auto-fix-vulnerabilities.yaml` carried the same latent bug and is fixed alongside. A scan of every workflow and composite action found no other jobs with the pattern.

## Guards

The failure is silent and far from its cause, so both are structural rather than a note in review:

- **`test_sparse_checkout_isolation.py`** (new) — fails on any job that pairs a sparse checkout with a later full checkout at the same path. Verified to red on the pre-fix YAML and green on the fix.
- **`test_every_caller_can_actually_reach_the_script`** (strengthened) — now checks the `run:` path resolves against a *preceding* checkout's `path:`. The old version only asked whether some checkout had happened, which the fix makes insufficient: a `path:` changed without its run line would have passed.

## Verification

- Root cause reproduced locally (git 2.50) by replaying the exact command sequence.
- Both guards verified to fail on the pre-fix state.
- Full `.github/scripts` suite: 2597 passed.
- `pre-commit` clean on all four files.

Note for review: this touches two workflow files under `.github/workflows/`. The change is confined to checkout placement and the corresponding `run:` path — no permission, trigger, token, or gate changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
