### PR TITLE
ci(reviewer): surface the sandbox error carried by a `complete` event

### DIFF
--- a/.github/scripts/mothership_sandbox_dispatch.py
+++ b/.github/scripts/mothership_sandbox_dispatch.py
@@ -157,8 +157,16 @@ def process_line(line: str, st: SSEState) -> str | None:
         st.status = _jget(data, "status", default="unknown")
         st.cost = _jget(data, "cost_usd")
         if st.status == "error":
-            st.err_code = _jget(data, "error", "code", default="none")
+            # A `complete` carrying status=error is as terminal as a standalone
+            # `error` event, so flag it the same way — otherwise decide_exit and
+            # the step summary parse the reason and then throw it away, leaving
+            # the log with only "final status=error" and no code/message.
+            # Gated on there actually being detail: with an empty error object
+            # the bare `status=...` line downstream says more than `code=none`.
+            code = _jget(data, "error", "code")
+            st.err_code = code or "none"
             st.err_msg = _jget(data, "error", "message")
+            st.errored = bool(code or st.err_msg)
         return f"[complete]  status={st.status} cost_usd={st.cost}"
     return None
 

--- a/.github/scripts/sdk_evolution_dispatch.py
+++ b/.github/scripts/sdk_evolution_dispatch.py
@@ -246,8 +246,16 @@ def process_line(line: str, st: SSEState) -> str | None:
         st.status = _jget(data, "status", default="unknown")
         st.cost = _jget(data, "cost_usd")
         if st.status == "error":
-            st.err_code = _jget(data, "error", "code", default="none")
+            # A `complete` carrying status=error is as terminal as a standalone
+            # `error` event, so flag it the same way — otherwise decide_exit and
+            # the step summary parse the reason and then throw it away, leaving
+            # the log with only "final status=error" and no code/message.
+            # Gated on there actually being detail: with an empty error object
+            # the bare `status=...` line downstream says more than `code=none`.
+            code = _jget(data, "error", "code")
+            st.err_code = code or "none"
             st.err_msg = _jget(data, "error", "message")
+            st.errored = bool(code or st.err_msg)
         return f"[complete]  status={st.status} cost_usd={st.cost}"
     return None
 

--- a/.github/scripts/sdk_resolve_dispatch.py
+++ b/.github/scripts/sdk_resolve_dispatch.py
@@ -300,8 +300,16 @@ def process_line(line: str, st: SSEState) -> str | None:
         st.status = _jget(data, "status", default="unknown")
         st.cost = _jget(data, "cost_usd")
         if st.status == "error":
-            st.err_code = _jget(data, "error", "code", default="none")
+            # A `complete` carrying status=error is as terminal as a standalone
+            # `error` event, so flag it the same way — otherwise decide_exit and
+            # the step summary parse the reason and then throw it away, leaving
+            # the log with only "final status=error" and no code/message.
+            # Gated on there actually being detail: with an empty error object
+            # the bare `status=...` line downstream says more than `code=none`.
+            code = _jget(data, "error", "code")
+            st.err_code = code or "none"
             st.err_msg = _jget(data, "error", "message")
+            st.errored = bool(code or st.err_msg)
         return f"[complete]  status={st.status} cost_usd={st.cost}"
     return None
 

--- a/.github/scripts/tests/test_mothership_sandbox_dispatch.py
+++ b/.github/scripts/tests/test_mothership_sandbox_dispatch.py
@@ -57,9 +57,21 @@ def test_complete_with_error_status_fails():
         'data: {"status": "error", "error": {"code": "X", "message": "y"}}',
         "",
     )
-    code, _ = md.decide_exit(st)
+    # Regression: the parsed reason used to be dropped because a `complete`
+    # carrying status=error never set st.errored, so the log showed only
+    # "final status=error" with no code/message.
+    assert st.errored is True
+    code, msg = md.decide_exit(st)
     assert code == 1
     assert st.status == "error"
+    assert "X" in msg and "y" in msg
+
+
+def test_complete_with_error_status_and_no_detail_keeps_status_message():
+    st = _stream("event: complete", 'data: {"status": "error"}', "")
+    assert st.errored is False
+    code, msg = md.decide_exit(st)
+    assert code == 1 and "final status=error" in msg
 
 
 def test_no_events_fails():

--- a/.github/scripts/tests/test_sdk_evolution_dispatch.py
+++ b/.github/scripts/tests/test_sdk_evolution_dispatch.py
@@ -94,8 +94,9 @@ def test_successful_complete_stream():
 
 def test_error_event_fails():
     st = _stream("event: error", 'data: {"code": "boom", "message": "kaboom"}')
+    assert st.errored is True
     code, msg = sd.decide_exit(st)
-    assert code == 1 and "boom" in msg
+    assert code == 1 and "boom" in msg and "kaboom" in msg
 
 
 def test_elicitation_treated_as_error():
@@ -104,13 +105,30 @@ def test_elicitation_treated_as_error():
     assert sd.decide_exit(st)[0] == 1
 
 
-def test_complete_with_error_status_fails():
+def test_complete_with_error_status_surfaces_code_and_message():
+    # Regression: a `complete` carrying status=error used to leave st.errored
+    # False, so both consumers dropped the parsed reason and the log showed only
+    # "final status=error" with no code/message.
     st = _stream(
         "event: complete",
-        'data: {"status": "error", "error": {"code": "x", "message": "y"}}',
+        'data: {"status": "error", '
+        '"error": {"code": "upstream_error", "message": "provider returned 400"}}',
     )
+    assert st.errored is True
     code, msg = sd.decide_exit(st)
-    assert code == 1 and "x" in msg
+    assert code == 1
+    assert "upstream_error" in msg and "provider returned 400" in msg
+    out = sd.render_step_summary(st, "CRITICAL", "2026-08-19", "http://run")
+    assert "`upstream_error` provider returned 400" in out
+
+
+def test_complete_with_error_status_and_no_detail_keeps_status_message():
+    # Empty error object: there is nothing to surface, so stay on the bare
+    # status message rather than reporting a content-free `code=none`.
+    st = _stream("event: complete", 'data: {"status": "error"}')
+    assert st.errored is False
+    code, msg = sd.decide_exit(st)
+    assert code == 1 and "final status=error" in msg
 
 
 def test_no_events_fails():

--- a/.github/scripts/tests/test_sdk_resolve_dispatch.py
+++ b/.github/scripts/tests/test_sdk_resolve_dispatch.py
@@ -122,8 +122,48 @@ def test_successful_complete_stream():
 
 def test_error_event_fails():
     st = _stream("event: error", 'data: {"code": "boom", "message": "kaboom"}')
+    assert st.errored is True
     code, msg = sr.decide_exit(st)
-    assert code == 1 and "boom" in msg
+    assert code == 1 and "boom" in msg and "kaboom" in msg
+    assert "`boom` kaboom" in sr.render_step_summary(st, "1234", "http://run")
+
+
+def test_complete_with_error_status_surfaces_code_and_message():
+    # Regression: a `complete` carrying status=error used to leave st.errored
+    # False, so both consumers dropped the parsed reason and the log showed only
+    # "final status=error" with no code/message.
+    st = _stream(
+        "event: complete",
+        'data: {"status": "error", "cost_usd": "1.75", '
+        '"error": {"code": "upstream_error", "message": "provider returned 400"}}',
+    )
+    assert st.errored is True
+    code, msg = sr.decide_exit(st)
+    assert code == 1
+    assert "upstream_error" in msg and "provider returned 400" in msg
+    out = sr.render_step_summary(st, "1234", "http://run")
+    assert "`upstream_error` provider returned 400" in out
+
+
+def test_complete_with_error_status_and_no_detail_keeps_status_message():
+    # Empty error object: there is nothing to surface, so stay on the bare
+    # status message rather than reporting a content-free `code=none`.
+    st = _stream("event: complete", 'data: {"status": "error"}')
+    assert st.errored is False
+    code, msg = sr.decide_exit(st)
+    assert code == 1 and "final status=error" in msg
+
+
+def test_complete_with_error_status_does_not_mask_oob_handoff():
+    # A hard error still yields to the out-of-band hand-off row when one is
+    # found, exactly as the standalone-`error` path does.
+    st = _stream(
+        "event: complete",
+        'data: {"status": "error", "error": {"code": "c", "message": "m"}}',
+    )
+    out = sr.render_step_summary(st, "1234", "http://run", "http://comment")
+    assert "out-of-band" in out
+    assert "**Error:**" not in out
 
 
 def test_no_events_fails():


### PR DESCRIPTION
### Changelog

- A mothership `complete` event with `status=error` carries the failure's code and message in an `error` object. The dispatch scripts parsed that object into `err_code` / `err_msg` and then dropped it — `st.errored` was set only by a standalone `error` SSE event or an `elicitation`, and both consumers of the reason (`decide_exit`, `render_step_summary`) are gated on that flag. Every run that died this way logged `##[error]Sandbox final status=error (expected 'completed')` and nothing else, with no Error row in the step summary.
- Set `errored` inside the `status=error` branch so both consumers work unchanged. Gated on the error object actually carrying detail: with an empty `error: {}` the bare `status=…` message says more than `code=none message=`, so that case still falls through to it.
- Applied to all three dispatch scripts — `sdk_resolve_dispatch.py`, `sdk_evolution_dispatch.py` and `mothership_sandbox_dispatch.py` shared the defect verbatim.
- Tests assert the code and message reach both `decide_exit` and the step summary, that an empty error object keeps the status message, that a hard error still yields to an out-of-band Phase-4 hand-off, and that the standalone `error` event path does not regress.

### Additional context (e.g. screenshots, logs, links)

- Linear: [FND-634](https://linear.app/atlan-epd/issue/FND-634/sdk-resolve-never-reports-why-the-sandbox-failed)
- The review lane's Bash implementation (`.github/workflows/sdk-review.yml`) already read both sources, which is the only reason the underlying upstream fault was ever identified — the resolve lane just never got the same treatment.
- Repro pinned: with the source fix reverted, the three new `st.errored is True` assertions fail; with it applied they pass. Full `.github/scripts/tests/` run is green (2591 passed).

### Checklist

- [x] Additional tests added
- [ ] All CI checks passed
- [ ] Relevant documentation updated

---

### Copyleft License Compliance

- [ ] Have you used any code that is subject to a Copyleft license (e.g., GPL, AGPL, LGPL)?
- [ ] If yes, have you modified the code in the context of this project? please share additional details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
