### PR TITLE
ci(reviewer): fail sdk-review when a completed run posts no verdict

### DIFF
--- a/.github/scripts/sdk_review_verdict_gate.py
+++ b/.github/scripts/sdk_review_verdict_gate.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""Fail the SDK review job when a completed run delivered no verdict.
+
+A review that runs to `status=completed`, bills a real cost, and posts nothing
+to the PR is the worst outcome the pipeline can produce: the check is green,
+the bot is silent, and the only trace is a `::warning::` annotation nobody
+reads. `sdk_review_approve.py` treats "no summary comment" as SKIPPED (a
+legitimate no-op for the many other reasons a stamp is declined), so nothing
+downstream turns that silence into a signal. This gate does.
+
+Relationship to the dispatch step's soft-success rule (sdk-review.yml): that
+rule exists for the opposite case — the summary WAS posted and mothership then
+crashed in finalize/cleanup, so the stream broke after delivery (see the RCA
+for run 29001242204). The two conditions are disjoint:
+
+    soft-success : final_status != completed  AND  a verdict was posted
+    this gate    : final_status == completed  AND  no verdict was posted
+
+so this runs as an additional check rather than an edit to `fail_or_warn`.
+
+Fail-open is deliberate everywhere the count cannot be established (comment
+listing fails after retries, no PR number, no window lower bound). A false red
+on a review that was in fact delivered is the failure mode the RCA above was
+written about; a warning annotation plus a green check is the lesser harm when
+we genuinely do not know.
+
+Environment:
+    REPO                 owner/repo (e.g. atlanhq/application-sdk)
+    PR_NUMBER            pull request number
+    FINAL_STATUS         the sandbox's terminal status from the dispatch step
+    FINAL_COST           run cost, rendered in the PR comment (optional)
+    STARTER_STARTED_AT   ISO-8601 lower bound: the starter comment's timestamp,
+                         set by this run's own starter step. Comments older
+                         than this belong to a previous trigger.
+    GHA_RUN_URL          link to this workflow run (optional)
+    GH_TOKEN             consumed by `gh` for auth (not read here directly)
+    GITHUB_OUTPUT        path to the step-output file (optional)
+
+Outputs:
+    verdict_delivered   true | false | unknown
+    summary_count       number of in-window summary comments (-1 when unknown)
+
+Exit code:
+    1  when a completed run posted no verdict (the defect this gate exists for)
+    0  otherwise, including every fail-open path
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import time
+from collections.abc import Callable
+from datetime import datetime, timezone
+
+# Both markers count as a delivered verdict. `sdk_review_approve.py` accepts
+# the legacy `<!-- TEST_SDK_REVIEW -->` form too, and a gate that failed a run
+# the approver would have happily stamped would be worse than no gate.
+SUMMARY_MARKERS = ("<!-- SDK_REVIEW -->", "<!-- TEST_SDK_REVIEW -->")
+
+# Our own marker. Deliberately not a `<!-- SDK_REVIEW -->` prefix so this
+# comment can never be mistaken for a verdict by the counters above, by
+# `sdk_review_approve.py`, or by `sdk_review_gate.py`.
+NO_VERDICT_MARKER = "<!-- SDK_REVIEW_NO_VERDICT -->"
+
+FETCH_ATTEMPTS = 3
+FETCH_BACKOFF_S = 5.0
+
+# A zero count is re-read before it is believed. The summary is posted in
+# Phase 3, before the `complete` event, but the listing endpoint is not
+# read-after-write consistent — a comment written seconds ago can be missing
+# from the next GET. Confirming the zero costs 20s on the failure path only.
+RECHECK_ATTEMPTS = 3
+RECHECK_DELAY_S = 10.0
+
+Runner = Callable[..., subprocess.CompletedProcess]
+Sleeper = Callable[[float], None]
+
+
+def parse_ts(value: str) -> datetime | None:
+    """Parse a GitHub/JS ISO-8601 timestamp, tolerating the `Z` suffix.
+
+    Compared as datetimes rather than strings because the two sides differ in
+    precision: `new Date().toISOString()` carries milliseconds
+    (`...:03.371Z`), the REST API's `created_at` does not (`...:03Z`).
+    """
+    text = (value or "").strip()
+    if not text:
+        return None
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def fetch_comments(
+    repo: str,
+    pr_number: str,
+    runner: Runner = subprocess.run,
+    sleeper: Sleeper = time.sleep,
+) -> list[dict] | None:
+    """Every comment on the PR, or None when the query could not be completed.
+
+    None (not []) on failure so callers can tell "no verdict" from "we could
+    not look" — the difference between a red check and a fail-open warning.
+
+    `--slurp` rather than `--jq`: `gh api` rejects the two together, and a
+    slurped page array keeps multi-line bodies intact.
+    """
+    for attempt in range(1, FETCH_ATTEMPTS + 1):
+        result = runner(
+            [
+                "gh",
+                "api",
+                f"repos/{repo}/issues/{pr_number}/comments",
+                "--paginate",
+                "--slurp",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode == 0:
+            try:
+                pages = json.loads(result.stdout or "[]")
+            except json.JSONDecodeError as exc:
+                print(f"Could not parse PR comments on attempt {attempt}: {exc}")
+                pages = None
+            if pages is not None:
+                comments: list[dict] = []
+                for page in pages:
+                    # An un-paginated response is a bare array of comments;
+                    # --slurp wraps it in one more level. Tolerate both.
+                    if isinstance(page, list):
+                        comments.extend(c for c in page if isinstance(c, dict))
+                    elif isinstance(page, dict):
+                        comments.append(page)
+                return comments
+        else:
+            print(
+                f"Could not list PR comments on attempt {attempt} "
+                f"(exit {result.returncode}): {(result.stderr or '').strip()[:200]}"
+            )
+        if attempt < FETCH_ATTEMPTS:
+            sleeper(FETCH_BACKOFF_S)
+    return None
+
+
+def count_summaries(comments: list[dict], since: datetime) -> int:
+    """Summary comments created at or after `since`.
+
+    The lower bound is what stops a verdict from a *previous* trigger — same
+    PR, older head — from vouching for this run.
+    """
+    count = 0
+    for comment in comments:
+        body = comment.get("body") or ""
+        if not any(marker in body for marker in SUMMARY_MARKERS):
+            continue
+        created = parse_ts(str(comment.get("created_at") or ""))
+        if created is None or created < since:
+            continue
+        count += 1
+    return count
+
+
+def no_verdict_body(pr_number: str, cost: str, run_url: str) -> str:
+    """The PR comment a silent run gets, so the requester learns it here."""
+    lines = [
+        NO_VERDICT_MARKER,
+        "🟥 **SDK Review finished without posting a verdict.**",
+        "",
+        (
+            f"The sandbox run for PR #{pr_number} reached `status=completed`"
+            + (f" (cost `${cost}`)" if cost and cost != "unknown" else "")
+            + " but no review summary comment reached this PR — so there is "
+            "nothing to read and nothing was approved."
+        ),
+        "",
+        "This is a failure of the review pipeline, not a statement about the code.",
+        "",
+        "Re-tag `@sdk-review` to run it again.",
+    ]
+    if run_url:
+        lines += ["", f"[Workflow run that dropped the verdict]({run_url})"]
+    return "\n".join(lines)
+
+
+def post_comment(
+    repo: str, pr_number: str, body: str, runner: Runner = subprocess.run
+) -> bool:
+    """Post `body` to the PR. Never raises: this runs on a path that is already
+    failing the job, and a comment that could not be posted must not mask the
+    red check that is the primary signal."""
+    result = runner(
+        [
+            "gh",
+            "api",
+            f"repos/{repo}/issues/{pr_number}/comments",
+            "-X",
+            "POST",
+            "-f",
+            f"body={body}",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        print(
+            f"::warning::could not post the no-verdict comment on PR #{pr_number} "
+            f"(exit {result.returncode}): {(result.stderr or '').strip()[:200]}"
+        )
+        return False
+    return True
+
+
+def set_output(key: str, value: str) -> None:
+    path = os.environ.get("GITHUB_OUTPUT")
+    line = f"{key}={value}\n"
+    if path:
+        with open(path, "a") as handle:
+            handle.write(line)
+    else:
+        print(f"OUTPUT: {key}={value}")
+
+
+def _fail_open(reason: str) -> int:
+    print(f"::warning::verdict-delivery gate could not run: {reason} — not gating.")
+    set_output("verdict_delivered", "unknown")
+    set_output("summary_count", "-1")
+    return 0
+
+
+def main(runner: Runner = subprocess.run, sleeper: Sleeper = time.sleep) -> int:
+    repo = os.environ.get("REPO", "")
+    pr_number = os.environ.get("PR_NUMBER", "")
+    final_status = os.environ.get("FINAL_STATUS", "").strip()
+    cost = os.environ.get("FINAL_COST", "").strip()
+    run_url = os.environ.get("GHA_RUN_URL", "").strip()
+    since = parse_ts(os.environ.get("STARTER_STARTED_AT", ""))
+
+    # Only a run that claims it finished cleanly is in scope. Every other
+    # terminal state is already adjudicated by the dispatch step's
+    # `fail_or_warn`, which owns the soft-success rule for delivered-then-
+    # dropped reviews. Re-deciding it here would risk contradicting it.
+    if final_status != "completed":
+        print(
+            f"::notice::verdict-delivery gate: final_status='{final_status or 'none'}' "
+            f"is not 'completed' — the dispatch step owns this outcome."
+        )
+        set_output("verdict_delivered", "unknown")
+        set_output("summary_count", "-1")
+        return 0
+
+    if not repo or not pr_number:
+        return _fail_open("no repo/PR number")
+    if since is None:
+        return _fail_open("no usable STARTER_STARTED_AT lower bound")
+
+    count = 0
+    for attempt in range(1, RECHECK_ATTEMPTS + 1):
+        comments = fetch_comments(repo, pr_number, runner, sleeper)
+        if comments is None:
+            return _fail_open(f"could not list comments on PR #{pr_number}")
+        count = count_summaries(comments, since)
+        if count > 0:
+            break
+        if attempt < RECHECK_ATTEMPTS:
+            print(
+                f"No in-window summary comment on PR #{pr_number} (attempt "
+                f"{attempt}/{RECHECK_ATTEMPTS}) — re-reading in "
+                f"{RECHECK_DELAY_S:.0f}s in case the listing has not caught up."
+            )
+            sleeper(RECHECK_DELAY_S)
+
+    set_output("summary_count", str(count))
+
+    if count > 0:
+        set_output("verdict_delivered", "true")
+        print(
+            f"::notice::verdict-delivery gate: {count} SDK review summary "
+            f"comment(s) posted on PR #{pr_number} since {since.isoformat()}."
+        )
+        return 0
+
+    set_output("verdict_delivered", "false")
+    post_comment(repo, pr_number, no_verdict_body(pr_number, cost, run_url), runner)
+    print(
+        f"::error::SDK Review completed (cost=${cost or 'unknown'}) but posted no "
+        f"verdict comment on PR #{pr_number}. The run spent budget and delivered "
+        f"nothing — failing so this is visible as a red check instead of a green "
+        f"one. Re-tag @sdk-review to retry."
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/tests/test_sdk_review_verdict_gate.py
+++ b/.github/scripts/tests/test_sdk_review_verdict_gate.py
@@ -297,6 +297,41 @@ def test_gate_precedes_the_approval_so_a_silent_run_cannot_be_stamped():
     assert steps[approve]["if"].startswith("success()")
 
 
+def test_stamp_step_consumes_the_gate_output():
+    """The gate's output only reaches the PR through this env line. Drop it and
+    a completed-but-silent run stamps '✅ Completed' again — the exact
+    reassurance this change exists to remove."""
+    stamp = next(
+        s
+        for s in dispatch_job()["steps"]
+        if s.get("name") == "Stamp cost + status onto starter comment"
+    )
+
+    assert (
+        stamp["env"]["VERDICT_DELIVERED"]
+        == "${{ steps.verdict.outputs.verdict_delivered }}"
+    )
+
+
+def test_stamp_step_switches_wording_on_the_exact_gate_string():
+    """'false' is the only value the gate emits for a silent run — 'unknown'
+    and '' mean it fell open or never ran. An inverted or loosened comparison
+    would either re-hide the failure or red-flag every healthy review."""
+    stamp = next(
+        s
+        for s in dispatch_job()["steps"]
+        if s.get("name") == "Stamp cost + status onto starter comment"
+    )
+    script = stamp["with"]["script"]
+
+    assert "const noVerdict = process.env.VERDICT_DELIVERED === 'false';" in script
+    # The no-verdict verb must be chosen ahead of the two '✅ Completed'
+    # branches, which both match a completed-but-silent run.
+    assert script.index("noVerdict ? '🟥") < script.index("'✅ **Completed**'")
+    assert "posted no verdict" in script
+    assert "Re-tag" in script
+
+
 def test_soft_success_rule_is_still_intact():
     """The delivered-then-dropped case (run 29001242204) must keep passing:
     `fail_or_warn` still downgrades to a warning when a verdict was posted."""

--- a/.github/scripts/tests/test_sdk_review_verdict_gate.py
+++ b/.github/scripts/tests/test_sdk_review_verdict_gate.py
@@ -1,0 +1,311 @@
+"""Tests for the completed-but-silent SDK review gate (FND-635).
+
+Three runs on 2026-08-19 finished `status=completed`, billed up to $7.98, and
+posted nothing to the PR — and the workflow exited 0 every time. These cover
+both directions of the fix: a completed run with no in-window verdict must fail
+the job, and the pre-existing soft-success path (verdict posted, stream broke
+afterwards) must keep passing.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+SPEC = importlib.util.spec_from_file_location(
+    "sdk_review_verdict_gate",
+    Path(__file__).resolve().parents[1] / "sdk_review_verdict_gate.py",
+)
+verdict_gate = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(verdict_gate)
+
+WORKFLOW = (
+    Path(__file__).resolve().parents[3] / ".github" / "workflows" / "sdk-review.yml"
+)
+
+# The starter step stamps `new Date().toISOString()` — milliseconds included.
+# The REST API's created_at has none. The gate must compare them correctly.
+STARTED_AT = "2026-08-19T18:56:03.371Z"
+BEFORE = "2026-08-19T17:10:00Z"
+AFTER = "2026-08-19T19:04:11Z"
+
+
+def summary_comment(created_at: str, marker: str = "<!-- SDK_REVIEW -->") -> dict:
+    return {
+        "created_at": created_at,
+        "body": (
+            f"{marker}\n"
+            "<!-- VERDICT: READY_TO_MERGE -->\n"
+            "<!-- REVIEWED_HEAD: 0cab6b6e4eff94f28f249e1319ab74d55e1f7abc -->\n"
+            "## SDK Review (mothership)\n"
+        ),
+    }
+
+
+def starter_comment(created_at: str) -> dict:
+    return {
+        "created_at": created_at,
+        "body": "<!-- SDK_REVIEW_STARTED -->\n🔍 **SDK Review (mothership)** triggered.",
+    }
+
+
+class FakeGh:
+    """Records `gh` invocations and replays canned comment listings."""
+
+    def __init__(
+        self,
+        comments: list[dict] | None = None,
+        list_exit: int = 0,
+        stdout: str | None = None,
+        post_exit: int = 0,
+    ) -> None:
+        self.comments = comments if comments is not None else []
+        self.list_exit = list_exit
+        self.stdout = stdout
+        self.post_exit = post_exit
+        self.list_calls = 0
+        self.posted: list[str] = []
+
+    def __call__(self, args, **_kwargs) -> subprocess.CompletedProcess:
+        if "-X" in args and "POST" in args:
+            body = next(a[len("body=") :] for a in args if a.startswith("body="))
+            self.posted.append(body)
+            return subprocess.CompletedProcess(args, self.post_exit, "", "boom")
+        self.list_calls += 1
+        if self.list_exit != 0:
+            return subprocess.CompletedProcess(args, self.list_exit, "", "HTTP 502")
+        # --slurp wraps each page's array in an outer array.
+        out = self.stdout if self.stdout is not None else json.dumps([self.comments])
+        return subprocess.CompletedProcess(args, 0, out, "")
+
+
+@pytest.fixture
+def env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    """Base environment for a completed run on PR #3284."""
+    output = tmp_path / "gha_output"
+    output.write_text("")
+    for key, value in {
+        "REPO": "atlanhq/application-sdk",
+        "PR_NUMBER": "3284",
+        "FINAL_STATUS": "completed",
+        "FINAL_COST": "7.98",
+        "STARTER_STARTED_AT": STARTED_AT,
+        "GHA_RUN_URL": "https://github.com/atlanhq/application-sdk/actions/runs/32285618316",
+        "GITHUB_OUTPUT": str(output),
+    }.items():
+        monkeypatch.setenv(key, value)
+    return output
+
+
+def outputs(path: Path) -> dict[str, str]:
+    return dict(
+        line.split("=", 1) for line in path.read_text().splitlines() if "=" in line
+    )
+
+
+# --- the defect this gate exists for -------------------------------------
+
+
+def test_completed_with_no_summary_fails(env: Path):
+    gh = FakeGh(comments=[starter_comment(STARTED_AT)])
+
+    assert verdict_gate.main(gh, lambda _s: None) == 1
+    assert outputs(env)["verdict_delivered"] == "false"
+    assert outputs(env)["summary_count"] == "0"
+
+
+def test_zero_is_confirmed_before_the_job_is_failed(env: Path):
+    """The listing is not read-after-write consistent, so a single empty read
+    is not proof. Re-read before turning silence into a red check."""
+    gh = FakeGh(comments=[])
+
+    assert verdict_gate.main(gh, lambda _s: None) == 1
+    assert gh.list_calls == verdict_gate.RECHECK_ATTEMPTS
+
+
+def test_a_late_arriving_summary_is_picked_up_by_the_recheck(env: Path):
+    reads: list[int] = []
+
+    def late(args, **_kwargs):
+        reads.append(1)
+        payload = [] if len(reads) == 1 else [summary_comment(AFTER)]
+        return subprocess.CompletedProcess(args, 0, json.dumps([payload]), "")
+
+    assert verdict_gate.main(late, lambda _s: None) == 0
+    assert len(reads) == 2
+
+
+def test_failure_posts_a_comment_naming_the_retry(env: Path):
+    gh = FakeGh(comments=[])
+
+    verdict_gate.main(gh, lambda _s: None)
+
+    assert len(gh.posted) == 1
+    body = gh.posted[0]
+    assert body.startswith(verdict_gate.NO_VERDICT_MARKER)
+    assert "@sdk-review" in body
+    assert "7.98" in body
+    # Must never look like a verdict to the counters or to the approver.
+    assert "<!-- SDK_REVIEW -->" not in body
+
+
+def test_summary_from_a_previous_trigger_does_not_count(env: Path):
+    """The window bound is what stops an older head's verdict vouching for this run."""
+    gh = FakeGh(comments=[summary_comment(BEFORE)])
+
+    assert verdict_gate.main(gh, lambda _s: None) == 1
+    assert outputs(env)["summary_count"] == "0"
+
+
+# --- the inverse: delivered reviews stay green ---------------------------
+
+
+def test_completed_with_an_in_window_summary_passes(env: Path):
+    gh = FakeGh(comments=[starter_comment(STARTED_AT), summary_comment(AFTER)])
+
+    assert verdict_gate.main(gh, lambda _s: None) == 0
+    assert outputs(env)["verdict_delivered"] == "true"
+    assert gh.posted == []
+
+
+def test_mixed_precision_timestamps_are_compared_as_instants(env: Path):
+    """`created_at` has second precision, `started_at` milliseconds. Compared
+    as strings, "…:03Z" sorts AFTER "…:03.371Z" ('Z' > '.') and a pre-window
+    comment would vouch for this run; compared as instants it does not."""
+    gh = FakeGh(comments=[summary_comment("2026-08-19T18:56:03Z")])
+    assert verdict_gate.main(gh, lambda _s: None) == 1
+
+    gh = FakeGh(comments=[summary_comment("2026-08-19T18:56:04Z")])
+    assert verdict_gate.main(gh, lambda _s: None) == 0
+
+
+def test_legacy_test_marker_counts_as_delivered(env: Path):
+    gh = FakeGh(comments=[summary_comment(AFTER, "<!-- TEST_SDK_REVIEW -->")])
+
+    assert verdict_gate.main(gh, lambda _s: None) == 0
+
+
+def test_non_completed_status_is_left_to_the_dispatch_step(
+    env: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Stream broke after the verdict was posted → the dispatch step's
+    soft-success rule owns it, and this gate must not re-decide it."""
+    monkeypatch.setenv("FINAL_STATUS", "error")
+    gh = FakeGh(comments=[])
+
+    assert verdict_gate.main(gh, lambda _s: None) == 0
+    assert gh.list_calls == 0
+    assert gh.posted == []
+    assert outputs(env)["verdict_delivered"] == "unknown"
+
+
+# --- fail-open paths ------------------------------------------------------
+
+
+def test_unreadable_comment_list_fails_open_after_retries(env: Path):
+    gh = FakeGh(list_exit=1)
+
+    assert verdict_gate.main(gh, lambda _s: None) == 0
+    assert gh.list_calls == verdict_gate.FETCH_ATTEMPTS
+    assert outputs(env)["verdict_delivered"] == "unknown"
+    assert gh.posted == []
+
+
+def test_transient_list_failure_is_retried_then_succeeds(env: Path):
+    calls: list[int] = []
+
+    def flaky(args, **kwargs):
+        calls.append(1)
+        if len(calls) == 1:
+            return subprocess.CompletedProcess(args, 1, "", "HTTP 502")
+        return subprocess.CompletedProcess(
+            args, 0, json.dumps([[summary_comment(AFTER)]]), ""
+        )
+
+    assert verdict_gate.main(flaky, lambda _s: None) == 0
+    assert outputs(env)["verdict_delivered"] == "true"
+
+
+def test_unparseable_payload_fails_open(env: Path):
+    gh = FakeGh(stdout="not json")
+
+    assert verdict_gate.main(gh, lambda _s: None) == 0
+    assert outputs(env)["verdict_delivered"] == "unknown"
+
+
+def test_missing_window_bound_fails_open(env: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("STARTER_STARTED_AT", "")
+    gh = FakeGh(comments=[])
+
+    assert verdict_gate.main(gh, lambda _s: None) == 0
+    assert gh.list_calls == 0
+    assert outputs(env)["verdict_delivered"] == "unknown"
+
+
+def test_missing_pr_number_fails_open(env: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("PR_NUMBER", "")
+    gh = FakeGh(comments=[])
+
+    assert verdict_gate.main(gh, lambda _s: None) == 0
+    assert outputs(env)["verdict_delivered"] == "unknown"
+
+
+def test_unpostable_comment_still_fails_the_job(env: Path):
+    """The red check is the primary signal; a failed comment must not mask it."""
+    gh = FakeGh(comments=[], post_exit=1)
+
+    assert verdict_gate.main(gh, lambda _s: None) == 1
+
+
+# --- workflow wiring ------------------------------------------------------
+
+
+def dispatch_job() -> dict:
+    workflow = yaml.safe_load(WORKFLOW.read_text())
+    return workflow["jobs"]["sdk-review-dispatch"]
+
+
+def test_workflow_runs_the_gate_after_dispatch():
+    steps = dispatch_job()["steps"]
+    names = [s.get("name", "") for s in steps]
+    gate = next(s for s in steps if s.get("id") == "verdict")
+
+    assert "sdk_review_verdict_gate.py" in gate["run"]
+    assert names.index("Verify the review delivered a verdict") > names.index(
+        "Dispatch to mothership Rover Direct API"
+    )
+    # Without the window bound and the terminal status the gate can only fail
+    # open, which would make it decorative.
+    for key in ("PR_NUMBER", "FINAL_STATUS", "STARTER_STARTED_AT", "GH_TOKEN"):
+        assert key in gate["env"]
+
+
+def test_gate_precedes_the_approval_so_a_silent_run_cannot_be_stamped():
+    steps = dispatch_job()["steps"]
+    names = [s.get("name", "") for s in steps]
+    approve = names.index("Approve PR as atlan-ci (counts as code-owner)")
+
+    assert names.index("Verify the review delivered a verdict") < approve
+    # `success()` is what makes the ordering load-bearing: a failed gate must
+    # skip the approval rather than merely precede it.
+    assert steps[approve]["if"].startswith("success()")
+
+
+def test_soft_success_rule_is_still_intact():
+    """The delivered-then-dropped case (run 29001242204) must keep passing:
+    `fail_or_warn` still downgrades to a warning when a verdict was posted."""
+    dispatch = next(s for s in dispatch_job()["steps"] if s.get("id") == "dispatch")[
+        "run"
+    ]
+
+    assert 'if [ "$VERDICT_POSTED" = "1" ]; then' in dispatch
+    assert (
+        "::warning::${msg} — but a SDK_REVIEW summary comment was already posted"
+        in (dispatch)
+    )

--- a/.github/workflows/sdk-review.yml
+++ b/.github/workflows/sdk-review.yml
@@ -34,6 +34,9 @@
 #                            <!-- TEST_SDK_REVIEW --> marker is also
 #                            accepted for in-flight PRs that pre-date the
 #                            promotion)
+#   comment marker         = <!-- SDK_REVIEW_NO_VERDICT --> (posted only when
+#                            a completed run delivered no summary at all; see
+#                            the `verdict` step)
 #
 # Required configuration:
 #   secrets.HARNESS_TOKEN              Bearer token for /api/sandbox/execute.
@@ -1019,6 +1022,32 @@ jobs:
 
           echo "SDK Review (mothership) completed successfully (cost=${FINAL_COST})."
 
+      # A run that reaches `status=completed`, bills a real cost and posts
+      # nothing to the PR is a defect, not a no-op. `sdk_review_approve.py`
+      # treats "no summary comment" as SKIPPED (a legitimate no-op for its
+      # other decline reasons), so without this step the workflow exits 0 on
+      # a review that delivered nothing — green check, silent bot, warning
+      # annotation nobody reads.
+      #
+      # Additive on purpose: the soft-success rule inside `dispatch` covers
+      # the disjoint case (verdict posted, stream broke afterwards), so this
+      # is a separate check rather than an edit to `fail_or_warn`. The gate
+      # fails open whenever it cannot establish the count — a false red on a
+      # delivered review is the failure mode the run-29001242204 RCA was
+      # written about.
+      - name: Verify the review delivered a verdict
+        id: verdict
+        if: success() && steps.parse.outputs.pr_number != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ steps.parse.outputs.pr_number }}
+          FINAL_STATUS: ${{ steps.dispatch.outputs.final_status }}
+          FINAL_COST: ${{ steps.dispatch.outputs.final_cost }}
+          STARTER_STARTED_AT: ${{ steps.starter.outputs.started_at }}
+          GHA_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: python3 .github/scripts/sdk_review_verdict_gate.py
+
       # Cancelling this job does NOT stop the sandbox.
       #
       # mothership runs the sandbox on a thread-pool executor with a
@@ -1067,6 +1096,10 @@ jobs:
           FINAL_ERR_CODE: ${{ steps.dispatch.outputs.final_err_code }}
           FINAL_ERR_MSG: ${{ steps.dispatch.outputs.final_err_msg }}
           DISPATCH_OUTCOME: ${{ steps.dispatch.outcome }}
+          # 'false' only when the verdict gate positively established that a
+          # completed run posted nothing. 'unknown'/'' means it fell open or
+          # never ran, and the stamp keeps its usual wording.
+          VERDICT_DELIVERED: ${{ steps.verdict.outputs.verdict_delivered }}
         with:
           script: |
             const commentId = parseInt(process.env.STARTER_COMMENT_ID, 10);
@@ -1095,11 +1128,19 @@ jobs:
             // lie. Give cancels their own verb and say what we did about
             // the sandbox.
             const cancelled = process.env.DISPATCH_OUTCOME === 'cancelled';
-            const verb = finalStatus === 'completed' ? '✅ **Completed**' :
+            // A completed run that posted no verdict must not read as
+            // "✅ Completed" here — that stamp is exactly the reassurance
+            // that made this failure mode invisible.
+            const noVerdict = process.env.VERDICT_DELIVERED === 'false';
+            const verb = noVerdict ? '🟥 **Completed but posted no verdict**' :
+                         finalStatus === 'completed' ? '✅ **Completed**' :
                          process.env.DISPATCH_OUTCOME === 'success' ? '✅ **Completed**' :
                          cancelled ? '🟡 **Cancelled**' :
                          '🟥 **Run ended without a clean completion**';
             let footer = `\n\n---\n${verb} — status \`${finalStatus}\`, cost \`$${finalCost}\`, duration ${durationTxt}.`;
+            if (noVerdict) {
+              footer += `\nThe run finished and billed, but no review summary reached this PR. Re-tag \`@sdk-review\` to retry.`;
+            }
             if (cancelled) {
               footer += `\nThe sandbox was asked to stop (\`DELETE /api/sandbox/session\`). If that request did not land, a review comment may still arrive from the in-flight run — check the workflow log for a termination warning.`;
             }


### PR DESCRIPTION
Closes FND-635.

## Problem

Three review runs on 2026-08-19 finished `status=completed`, billed up to $7.98, and posted nothing to the PR — and the workflow exited 0 every time. From the requester's side that is the worst available failure mode: green check, silent bot, and a `::warning::` annotation nobody reads. On one of them the log even shows the model reaching `READY_TO_MERGE` — it just never posted it.

`sdk_review_approve.py` returns `StampOutcome(SKIPPED, …, "no summary comment")`, which is a legitimate no-op for its other decline reasons, so nothing downstream turned that silence into a signal. The dispatch step computes `VERDICT_POSTED` but only consumes it in the direction of leniency (`fail_or_warn`); nothing acted on the inverse.

## Change

A new `verdict` step in `sdk-review-dispatch`, running `.github/scripts/sdk_review_verdict_gate.py`, placed after `dispatch` and before the approval steps. It fails the job on exactly the condition the soft-success rule does not cover:

| | soft-success (existing) | this gate (new) |
| -- | -- | -- |
| final status | `!= completed` | `== completed` |
| verdict posted | yes | no |

Disjoint by construction, so this is an additional check rather than an edit to `fail_or_warn` — the delivered-then-dropped path (run `29001242204`) keeps soft-succeeding untouched, and a test asserts that leniency is still in the shell.

Logic lives in a tested Python script rather than more inline conditional shell, per `docs/standards/ci.md`.

## What the requester now sees

1. A red check instead of a green one.
2. A `<!-- SDK_REVIEW_NO_VERDICT -->` comment on the PR: run completed, cost `$X`, nothing delivered, re-tag `@sdk-review`. Deliberately not a `<!-- SDK_REVIEW -->` prefix, so no counter and not the approver can mistake it for a verdict.
3. The starter comment stamps `🟥 Completed but posted no verdict` instead of `✅ Completed` — that tick was the reassurance that made the failure invisible.
4. Approval steps skip (`if: success()`), and the existing `Set sdk-review status to failure` net turns the `sdk-review` commit status red.

## Judgment calls

- **Fails open on every "cannot determine" path** — listing errors after 3 retries, no PR number, no `STARTER_STARTED_AT` bound. A false red on a review that *was* delivered is the exact regression the run-`29001242204` RCA was written about, so uncertainty resolves to a warning and a green check.
- **A zero count is re-read twice more, 10s apart, before it is believed.** The comments listing is not read-after-write consistent and the summary lands seconds before the `complete` event. Costs 20s on the failure path only.
- **Counts the legacy `<!-- TEST_SDK_REVIEW -->` marker too.** The inline count only looks for `<!-- SDK_REVIEW -->`, but the approver accepts both; failing a run the approver would have stamped would be worse than no gate.
- **Timestamps compared as instants, not strings.** `started_at` carries milliseconds, REST `created_at` does not — string-compared, `…:03Z` sorts *after* `…:03.371Z`, letting a pre-window comment vouch for the run.

## Verification

`.github/scripts/tests/test_sdk_review_verdict_gate.py` — 18 tests covering both directions the ticket asked for (completed + zero in-window summaries → non-zero exit; posted-then-stream-broke → still soft-succeeds), the fail-open paths, the recheck, and the workflow wiring (gate ordered before the approval, `success()` making that ordering load-bearing).

Full suite: `uv run --extra workflows --with pytest python -m pytest .github/scripts/tests -q` → 2604 passed. Pre-commit clean on all three files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)