### PR TITLE
ci(reviewer): dedupe @sdk-review triggers under the lock, collapse duplicate verdicts (FND-636)

### DIFF
--- a/.github/scripts/sdk_review_dedupe_verdicts.py
+++ b/.github/scripts/sdk_review_dedupe_verdicts.py
@@ -8,17 +8,29 @@ replays the assistant turn, and the tool call in that turn — `gh api …
 that is model-dependent; the vulnerability is not, which is why the fix is
 post-hoc and deterministic rather than another instruction in the prompt.
 
-So: after the sandbox stream closes, count the summaries this run posted. One
-is the normal case. More than one means a replay, and every copy but the newest
-is minimized as a duplicate (GraphQL `minimizeComment`) with a warning
-annotation. Bodies are never edited — the summary footer carries the run URL
-that the sandbox's own replay guard greps for (ORCHESTRATION.md Phase 0 §6b),
-and the newest copy stays visible so `last_reviewed_head()` and
-`sdk_review_approve.py` keep reading the verdict they read before.
+So: after the sandbox stream closes, find the summaries this run posted. One is
+the normal case. More than one means a replay, and every copy but the newest is
+minimized as a duplicate (GraphQL `minimizeComment`) with a warning annotation.
+Bodies are never edited, and the newest copy stays visible so
+`last_reviewed_head()` and `sdk_review_approve.py` keep reading the verdict they
+read before.
 
 Minimizing rather than deleting is deliberate: the duplicates are evidence of a
 mothership-side replay, and a reader chasing "why did I get five emails" needs
 to be able to expand them.
+
+**Ownership is decided by the run URL, not by a time window.** Every summary
+carries `**Run:** …(<GHA_RUN_URL>)` — required by ORCHESTRATION.md §3e and
+already load-bearing for the sandbox's own replay guard (§6b) — so matching it
+is exact. A time window is not: a zombie sandbox that outlived its cancelled job
+posts minutes later, and a human-triggered run always passes the locked gate, so
+a summary belonging to someone else can land inside our window. Counting it as
+ours would minimize our own verdict as the DUPLICATE, or report a delivered
+review when our sandbox never posted one.
+
+If no summary carries our run URL we fall back to the window, narrowed to
+summaries whose `REVIEWED_HEAD` is ours (or absent), and minimize NOTHING —
+without exact attribution, hiding a comment risks hiding someone else's review.
 
 Also reports whether a verdict was posted at all, which is what the dispatch
 step's soft-success rule turns on — a run whose stream broke *after* the
@@ -27,10 +39,13 @@ summary landed has delivered its review and must not fail the PR check.
 Environment:
     REPO             owner/repo
     PR_NUMBER        pull request number
-    SINCE            ISO8601 lower bound: only summaries created at or after
-                     this instant count as "this run's". Empty disables both
-                     the count and any minimizing (with no bound we cannot
-                     tell our own summary from a previous head's).
+    GHA_RUN_URL      this run's Actions run URL — the ownership key
+    HEAD_SHA         the sha this run was dispatched for, for the fallback
+    SINCE            ISO8601 lower bound for the fallback only. Floored to
+                     whole seconds before comparing: GitHub records
+                     `created_at` to the second, so an unfloored
+                     `…:39.900Z` bound excludes a verdict posted at
+                     `…:39.950Z` and stored as `…:39Z`.
     DEDUPE_OUTPUT    path to write `key=value` results to (optional; falls
                      back to GITHUB_OUTPUT, then stdout)
     DRY_RUN          "true" to report without minimizing
@@ -40,6 +55,7 @@ Outputs:
     verdict_posted        1 if this run posted at least one summary, else 0
     verdict_count         how many summaries this run posted
     minimized_count       how many were minimized
+    attribution           run-url | window-fallback | none
 
 Always exits 0. This runs between the sandbox finishing and the dispatch step
 deciding pass/fail; turning a tidy-up failure into a red review check would
@@ -58,6 +74,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent))
 
 from sdk_review_gate import (  # noqa: E402  (needs the sys.path bootstrap)
+    REVIEWED_HEAD_RE,
     SUMMARY_MARKER,
     Runner,
     fetch_comments,
@@ -80,33 +97,72 @@ def _parsed(stamp: str) -> datetime | None:
 
 
 def created_at_or_after(stamp: str, bound: str) -> bool:
-    """Whether `stamp` is at or after `bound`.
+    """Whether `stamp` is at or after `bound`, both floored to the second.
 
     Parsed rather than string-compared because the two sides are produced by
     different writers with different precision: GitHub stamps comments to the
     second (`…:39Z`) while the starter step records `new Date().toISOString()`
-    (`…:39.123Z`). Lexicographically "Z" > "." — so a comment created *before*
-    the bound, in the same second, sorts after it and would be counted as ours.
+    (`…:39.123Z`). That mismatch bites in both directions, so the comparison
+    discards sub-second precision on both sides:
+
+    - lexicographically "Z" > ".", so `…:39Z >= …:39.123Z` is True as strings
+      and a comment created *before* the bound would count as ours;
+    - as instants, a verdict posted at `…:39.950Z` is stored as `…:39Z` and
+      parses to `39.000`, which is *before* a `…:39.900Z` bound — excluding the
+      verdict this run just posted, reporting no verdict, and hard-failing a
+      review that was delivered.
     """
     left, right = _parsed(stamp), _parsed(bound)
     if left is None or right is None:
         return stamp >= bound  # last resort; both shapes are ISO8601 in practice
-    return left >= right
+    return left.replace(microsecond=0) >= right.replace(microsecond=0)
 
 
-def this_runs_summaries(comments: list[dict], since: str) -> list[dict]:
-    """This run's summary comments, oldest first."""
-    mine = [
-        c
-        for c in comments
-        if SUMMARY_MARKER in (c.get("body") or "")
-        and created_at_or_after(str(c.get("created_at") or ""), since)
-    ]
+def _oldest_first(comments: list[dict]) -> list[dict]:
     # created_at has second precision, so same-second duplicates tie; comment
     # ids increase monotonically and break the tie in posting order.
     return sorted(
-        mine, key=lambda c: (str(c.get("created_at") or ""), c.get("id") or 0)
+        comments, key=lambda c: (str(c.get("created_at") or ""), c.get("id") or 0)
     )
+
+
+def _summaries(comments: list[dict]) -> list[dict]:
+    return [c for c in comments if SUMMARY_MARKER in (c.get("body") or "")]
+
+
+def summaries_by_run_url(comments: list[dict], run_url: str) -> list[dict]:
+    """Summaries this run posted, identified exactly, oldest first.
+
+    ORCHESTRATION.md §3e makes `**Run:** …(<GHA_RUN_URL>)` mandatory on every
+    summary, so the run URL is an exact ownership key — a replayed turn re-posts
+    the same body and therefore the same URL, while another run's summary can
+    never carry ours.
+    """
+    if not run_url:
+        return []
+    return _oldest_first(
+        [c for c in _summaries(comments) if run_url in (c.get("body") or "")]
+    )
+
+
+def summaries_in_window(comments: list[dict], since: str, head_sha: str) -> list[dict]:
+    """Fallback attribution: our window, narrowed to our reviewed head.
+
+    Only reached when no summary carries our run URL, i.e. the sandbox omitted
+    the footer §3e requires. The head narrowing is what keeps a zombie
+    sandbox's summary for an older sha out of the count; a summary with no
+    `REVIEWED_HEAD` at all predates that marker and is admitted rather than
+    hard-failing a review that may well have been delivered.
+    """
+    kept = []
+    for comment in _summaries(comments):
+        if not created_at_or_after(str(comment.get("created_at") or ""), since):
+            continue
+        stamped = REVIEWED_HEAD_RE.search(comment.get("body") or "")
+        if stamped and head_sha and stamped.group(1) != head_sha:
+            continue
+        kept.append(comment)
+    return _oldest_first(kept)
 
 
 def minimize(node_id: str, runner: Runner = subprocess.run) -> bool:
@@ -151,27 +207,47 @@ def make_writer() -> Writer:
 def main(runner: Runner = subprocess.run) -> int:
     repo = os.environ.get("REPO", "")
     pr_number = os.environ.get("PR_NUMBER", "")
+    run_url = os.environ.get("GHA_RUN_URL", "").strip()
+    head_sha = os.environ.get("HEAD_SHA", "").strip()
     since = os.environ.get("SINCE", "").strip()
     dry_run = os.environ.get("DRY_RUN", "") == "true"
     write = make_writer()
 
-    if not (repo and pr_number and since):
-        # No bound means no way to attribute a summary to this run. Report
-        # nothing found and touch nothing.
+    if not (repo and pr_number and (run_url or since)):
+        # Nothing to attribute by. Report nothing found and touch nothing.
         print(
             "::notice::sdk-review verdict dedupe: skipped "
             f"(repo={repo or 'unset'} pr={pr_number or 'unset'} "
-            f"since={since or 'unset'})"
+            f"run_url={run_url or 'unset'} since={since or 'unset'})"
         )
         write("verdict_posted", "0")
         write("verdict_count", "0")
         write("minimized_count", "0")
+        write("attribution", "none")
         return 0
 
-    summaries = this_runs_summaries(fetch_comments(repo, pr_number, runner), since)
+    comments = fetch_comments(repo, pr_number, runner)
+    summaries = summaries_by_run_url(comments, run_url)
+    attribution = "run-url"
+    if not summaries:
+        # No summary carries our run URL. Either we posted nothing, or the
+        # sandbox dropped the footer §3e requires. Either way attribution is
+        # inexact from here on, so we report but never hide.
+        summaries = summaries_in_window(comments, since, head_sha) if since else []
+        attribution = "window-fallback" if summaries else "none"
+        if summaries:
+            print(
+                f"::warning::{len(summaries)} SDK review summary comment(s) fall in "
+                f"this run's window but none carries this run's URL ({run_url}); the "
+                "sandbox likely dropped the required **Run:** footer "
+                "(ORCHESTRATION.md §3e). Counting them for the soft-success rule but "
+                "minimizing nothing — without exact attribution a duplicate cannot be "
+                "told from another run's review."
+            )
+
     minimized = 0
 
-    if len(summaries) > 1:
+    if attribution == "run-url" and len(summaries) > 1:
         newest = summaries[-1]
         stale = summaries[:-1]
         print(
@@ -197,9 +273,10 @@ def main(runner: Runner = subprocess.run) -> int:
     write("verdict_posted", "1" if summaries else "0")
     write("verdict_count", str(len(summaries)))
     write("minimized_count", str(minimized))
+    write("attribution", attribution)
     print(
         f"::notice::sdk-review verdict dedupe: {len(summaries)} summary comment(s) "
-        f"from this run, {minimized} minimized."
+        f"from this run (attribution={attribution}), {minimized} minimized."
     )
     return 0
 

--- a/.github/scripts/sdk_review_dedupe_verdicts.py
+++ b/.github/scripts/sdk_review_dedupe_verdicts.py
@@ -19,18 +19,14 @@ Minimizing rather than deleting is deliberate: the duplicates are evidence of a
 mothership-side replay, and a reader chasing "why did I get five emails" needs
 to be able to expand them.
 
-**Ownership is decided by the run URL, not by a time window.** Every summary
-carries `**Run:** …(<GHA_RUN_URL>)` — required by ORCHESTRATION.md §3e and
-already load-bearing for the sandbox's own replay guard (§6b) — so matching it
-is exact. A time window is not: a zombie sandbox that outlived its cancelled job
-posts minutes later, and a human-triggered run always passes the locked gate, so
-a summary belonging to someone else can land inside our window. Counting it as
-ours would minimize our own verdict as the DUPLICATE, or report a delivered
-review when our sandbox never posted one.
+Ownership is decided in `sdk_review_summaries.attribute()`, shared with
+`sdk_review_verdict_gate.py` so the step that minimizes extras and the step that
+fails on none cannot disagree about whose summary a comment is. Read that module
+for why the run URL is the key and the time window is only a fallback.
 
-If no summary carries our run URL we fall back to the window, narrowed to
-summaries whose `REVIEWED_HEAD` is ours (or absent), and minimize NOTHING —
-without exact attribution, hiding a comment risks hiding someone else's review.
+Under the fallback we minimize NOTHING: it establishes that a summary is not
+another run's, not that it is ours, and hiding a comment on that basis risks
+hiding someone else's review.
 
 Also reports whether a verdict was posted at all, which is what the dispatch
 step's soft-success rule turns on — a run whose stream broke *after* the
@@ -41,11 +37,7 @@ Environment:
     PR_NUMBER        pull request number
     GHA_RUN_URL      this run's Actions run URL — the ownership key
     HEAD_SHA         the sha this run was dispatched for, for the fallback
-    SINCE            ISO8601 lower bound for the fallback only. Floored to
-                     whole seconds before comparing: GitHub records
-                     `created_at` to the second, so an unfloored
-                     `…:39.900Z` bound excludes a verdict posted at
-                     `…:39.950Z` and stored as `…:39Z`.
+    SINCE            ISO8601 lower bound, used only by the fallback tier
     DEDUPE_OUTPUT    path to write `key=value` results to (optional; falls
                      back to GITHUB_OUTPUT, then stdout)
     DRY_RUN          "true" to report without minimizing
@@ -68,16 +60,18 @@ import os
 import subprocess
 import sys
 from collections.abc import Callable
-from datetime import datetime
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
 
 from sdk_review_gate import (  # noqa: E402  (needs the sys.path bootstrap)
-    REVIEWED_HEAD_RE,
-    SUMMARY_MARKER,
     Runner,
     fetch_comments,
+)
+from sdk_review_summaries import (  # noqa: E402  (needs the sys.path bootstrap)
+    BY_RUN_URL,
+    attribute,
+    parse_ts,
 )
 
 MINIMIZE_MUTATION = (
@@ -86,83 +80,6 @@ MINIMIZE_MUTATION = (
 )
 
 Writer = Callable[[str, str], None]
-
-
-def _parsed(stamp: str) -> datetime | None:
-    """`2026-08-19T18:09:39Z` / `…39.123Z` as an aware datetime, or None."""
-    try:
-        return datetime.fromisoformat(stamp.strip().replace("Z", "+00:00"))
-    except ValueError:
-        return None
-
-
-def created_at_or_after(stamp: str, bound: str) -> bool:
-    """Whether `stamp` is at or after `bound`, both floored to the second.
-
-    Parsed rather than string-compared because the two sides are produced by
-    different writers with different precision: GitHub stamps comments to the
-    second (`…:39Z`) while the starter step records `new Date().toISOString()`
-    (`…:39.123Z`). That mismatch bites in both directions, so the comparison
-    discards sub-second precision on both sides:
-
-    - lexicographically "Z" > ".", so `…:39Z >= …:39.123Z` is True as strings
-      and a comment created *before* the bound would count as ours;
-    - as instants, a verdict posted at `…:39.950Z` is stored as `…:39Z` and
-      parses to `39.000`, which is *before* a `…:39.900Z` bound — excluding the
-      verdict this run just posted, reporting no verdict, and hard-failing a
-      review that was delivered.
-    """
-    left, right = _parsed(stamp), _parsed(bound)
-    if left is None or right is None:
-        return stamp >= bound  # last resort; both shapes are ISO8601 in practice
-    return left.replace(microsecond=0) >= right.replace(microsecond=0)
-
-
-def _oldest_first(comments: list[dict]) -> list[dict]:
-    # created_at has second precision, so same-second duplicates tie; comment
-    # ids increase monotonically and break the tie in posting order.
-    return sorted(
-        comments, key=lambda c: (str(c.get("created_at") or ""), c.get("id") or 0)
-    )
-
-
-def _summaries(comments: list[dict]) -> list[dict]:
-    return [c for c in comments if SUMMARY_MARKER in (c.get("body") or "")]
-
-
-def summaries_by_run_url(comments: list[dict], run_url: str) -> list[dict]:
-    """Summaries this run posted, identified exactly, oldest first.
-
-    ORCHESTRATION.md §3e makes `**Run:** …(<GHA_RUN_URL>)` mandatory on every
-    summary, so the run URL is an exact ownership key — a replayed turn re-posts
-    the same body and therefore the same URL, while another run's summary can
-    never carry ours.
-    """
-    if not run_url:
-        return []
-    return _oldest_first(
-        [c for c in _summaries(comments) if run_url in (c.get("body") or "")]
-    )
-
-
-def summaries_in_window(comments: list[dict], since: str, head_sha: str) -> list[dict]:
-    """Fallback attribution: our window, narrowed to our reviewed head.
-
-    Only reached when no summary carries our run URL, i.e. the sandbox omitted
-    the footer §3e requires. The head narrowing is what keeps a zombie
-    sandbox's summary for an older sha out of the count; a summary with no
-    `REVIEWED_HEAD` at all predates that marker and is admitted rather than
-    hard-failing a review that may well have been delivered.
-    """
-    kept = []
-    for comment in _summaries(comments):
-        if not created_at_or_after(str(comment.get("created_at") or ""), since):
-            continue
-        stamped = REVIEWED_HEAD_RE.search(comment.get("body") or "")
-        if stamped and head_sha and stamped.group(1) != head_sha:
-            continue
-        kept.append(comment)
-    return _oldest_first(kept)
 
 
 def minimize(node_id: str, runner: Runner = subprocess.run) -> bool:
@@ -227,27 +144,22 @@ def main(runner: Runner = subprocess.run) -> int:
         return 0
 
     comments = fetch_comments(repo, pr_number, runner)
-    summaries = summaries_by_run_url(comments, run_url)
-    attribution = "run-url"
-    if not summaries:
-        # No summary carries our run URL. Either we posted nothing, or the
-        # sandbox dropped the footer §3e requires. Either way attribution is
-        # inexact from here on, so we report but never hide.
-        summaries = summaries_in_window(comments, since, head_sha) if since else []
-        attribution = "window-fallback" if summaries else "none"
-        if summaries:
-            print(
-                f"::warning::{len(summaries)} SDK review summary comment(s) fall in "
-                f"this run's window but none carries this run's URL ({run_url}); the "
-                "sandbox likely dropped the required **Run:** footer "
-                "(ORCHESTRATION.md §3e). Counting them for the soft-success rule but "
-                "minimizing nothing — without exact attribution a duplicate cannot be "
-                "told from another run's review."
-            )
+    summaries, attribution = attribute(comments, run_url, parse_ts(since), head_sha)
+    if attribution != BY_RUN_URL and summaries:
+        # No summary carries our run URL, so the sandbox dropped the footer §3e
+        # requires. We can say these are nobody else's, not that they are ours —
+        # report them for the soft-success rule, but hide nothing.
+        print(
+            f"::warning::{len(summaries)} SDK review summary comment(s) fall in this "
+            f"run's window but none carries this run's URL ({run_url}); the sandbox "
+            "likely dropped the required **Run:** footer (ORCHESTRATION.md §3e). "
+            "Counting them for the soft-success rule but minimizing nothing — without "
+            "exact attribution a duplicate cannot be told from another run's review."
+        )
 
     minimized = 0
 
-    if attribution == "run-url" and len(summaries) > 1:
+    if attribution == BY_RUN_URL and len(summaries) > 1:
         newest = summaries[-1]
         stale = summaries[:-1]
         print(

--- a/.github/scripts/sdk_review_dedupe_verdicts.py
+++ b/.github/scripts/sdk_review_dedupe_verdicts.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""Collapse duplicate `<!-- SDK_REVIEW -->` verdict comments from one run.
+
+A review run posts exactly one summary. On 2026-08-19 PR #3276 received the
+identical summary five times in 76 seconds (FND-636): a provider-level retry
+replays the assistant turn, and the tool call in that turn — `gh api …
+/comments -f body=…` — is not idempotent, so it posts again. The frequency of
+that is model-dependent; the vulnerability is not, which is why the fix is
+post-hoc and deterministic rather than another instruction in the prompt.
+
+So: after the sandbox stream closes, count the summaries this run posted. One
+is the normal case. More than one means a replay, and every copy but the newest
+is minimized as a duplicate (GraphQL `minimizeComment`) with a warning
+annotation. Bodies are never edited — the summary footer carries the run URL
+that the sandbox's own replay guard greps for (ORCHESTRATION.md Phase 0 §6b),
+and the newest copy stays visible so `last_reviewed_head()` and
+`sdk_review_approve.py` keep reading the verdict they read before.
+
+Minimizing rather than deleting is deliberate: the duplicates are evidence of a
+mothership-side replay, and a reader chasing "why did I get five emails" needs
+to be able to expand them.
+
+Also reports whether a verdict was posted at all, which is what the dispatch
+step's soft-success rule turns on — a run whose stream broke *after* the
+summary landed has delivered its review and must not fail the PR check.
+
+Environment:
+    REPO             owner/repo
+    PR_NUMBER        pull request number
+    SINCE            ISO8601 lower bound: only summaries created at or after
+                     this instant count as "this run's". Empty disables both
+                     the count and any minimizing (with no bound we cannot
+                     tell our own summary from a previous head's).
+    DEDUPE_OUTPUT    path to write `key=value` results to (optional; falls
+                     back to GITHUB_OUTPUT, then stdout)
+    DRY_RUN          "true" to report without minimizing
+    GH_TOKEN         consumed by `gh` for auth (not read here directly)
+
+Outputs:
+    verdict_posted        1 if this run posted at least one summary, else 0
+    verdict_count         how many summaries this run posted
+    minimized_count       how many were minimized
+
+Always exits 0. This runs between the sandbox finishing and the dispatch step
+deciding pass/fail; turning a tidy-up failure into a red review check would
+trade a cosmetic problem for a real one.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from collections.abc import Callable
+from datetime import datetime
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from sdk_review_gate import (  # noqa: E402  (needs the sys.path bootstrap)
+    SUMMARY_MARKER,
+    Runner,
+    fetch_comments,
+)
+
+MINIMIZE_MUTATION = (
+    "mutation($id: ID!) { minimizeComment(input: {subjectId: $id, "
+    "classifier: DUPLICATE}) { minimizedComment { isMinimized } } }"
+)
+
+Writer = Callable[[str, str], None]
+
+
+def _parsed(stamp: str) -> datetime | None:
+    """`2026-08-19T18:09:39Z` / `…39.123Z` as an aware datetime, or None."""
+    try:
+        return datetime.fromisoformat(stamp.strip().replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def created_at_or_after(stamp: str, bound: str) -> bool:
+    """Whether `stamp` is at or after `bound`.
+
+    Parsed rather than string-compared because the two sides are produced by
+    different writers with different precision: GitHub stamps comments to the
+    second (`…:39Z`) while the starter step records `new Date().toISOString()`
+    (`…:39.123Z`). Lexicographically "Z" > "." — so a comment created *before*
+    the bound, in the same second, sorts after it and would be counted as ours.
+    """
+    left, right = _parsed(stamp), _parsed(bound)
+    if left is None or right is None:
+        return stamp >= bound  # last resort; both shapes are ISO8601 in practice
+    return left >= right
+
+
+def this_runs_summaries(comments: list[dict], since: str) -> list[dict]:
+    """This run's summary comments, oldest first."""
+    mine = [
+        c
+        for c in comments
+        if SUMMARY_MARKER in (c.get("body") or "")
+        and created_at_or_after(str(c.get("created_at") or ""), since)
+    ]
+    # created_at has second precision, so same-second duplicates tie; comment
+    # ids increase monotonically and break the tie in posting order.
+    return sorted(
+        mine, key=lambda c: (str(c.get("created_at") or ""), c.get("id") or 0)
+    )
+
+
+def minimize(node_id: str, runner: Runner = subprocess.run) -> bool:
+    """Hide one comment as a duplicate. False if GitHub refused."""
+    result = runner(
+        [
+            "gh",
+            "api",
+            "graphql",
+            "-f",
+            f"query={MINIMIZE_MUTATION}",
+            "-f",
+            f"id={node_id}",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        print(
+            f"::warning::could not minimize duplicate verdict comment {node_id} "
+            f"(exit {result.returncode}): {(result.stderr or '').strip()[:200]}"
+        )
+        return False
+    return True
+
+
+def make_writer() -> Writer:
+    path = os.environ.get("DEDUPE_OUTPUT") or os.environ.get("GITHUB_OUTPUT")
+
+    def _write(key: str, value: str) -> None:
+        line = f"{key}={value}\n"
+        if path:
+            with open(path, "a") as handle:
+                handle.write(line)
+        else:
+            print(f"OUTPUT: {key}={value}")
+
+    return _write
+
+
+def main(runner: Runner = subprocess.run) -> int:
+    repo = os.environ.get("REPO", "")
+    pr_number = os.environ.get("PR_NUMBER", "")
+    since = os.environ.get("SINCE", "").strip()
+    dry_run = os.environ.get("DRY_RUN", "") == "true"
+    write = make_writer()
+
+    if not (repo and pr_number and since):
+        # No bound means no way to attribute a summary to this run. Report
+        # nothing found and touch nothing.
+        print(
+            "::notice::sdk-review verdict dedupe: skipped "
+            f"(repo={repo or 'unset'} pr={pr_number or 'unset'} "
+            f"since={since or 'unset'})"
+        )
+        write("verdict_posted", "0")
+        write("verdict_count", "0")
+        write("minimized_count", "0")
+        return 0
+
+    summaries = this_runs_summaries(fetch_comments(repo, pr_number, runner), since)
+    minimized = 0
+
+    if len(summaries) > 1:
+        newest = summaries[-1]
+        stale = summaries[:-1]
+        print(
+            f"::warning::This run posted {len(summaries)} SDK review summaries on "
+            f"PR #{pr_number}; one is expected. Keeping comment {newest.get('id')} "
+            f"and minimizing {len(stale)} duplicate(s) — the sandbox turn that posts "
+            "the summary was replayed (FND-636)."
+        )
+        for comment in stale:
+            node_id = comment.get("node_id") or ""
+            if not node_id:
+                print(
+                    f"::warning::duplicate verdict comment {comment.get('id')} has no "
+                    "node_id — cannot minimize it"
+                )
+                continue
+            if dry_run:
+                minimized += 1
+                continue
+            if minimize(node_id, runner):
+                minimized += 1
+
+    write("verdict_posted", "1" if summaries else "0")
+    write("verdict_count", str(len(summaries)))
+    write("minimized_count", str(minimized))
+    print(
+        f"::notice::sdk-review verdict dedupe: {len(summaries)} summary comment(s) "
+        f"from this run, {minimized} minimized."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/sdk_review_gate.py
+++ b/.github/scripts/sdk_review_gate.py
@@ -8,6 +8,27 @@ been reviewed. The PR then carries two summaries for the same sha, written by
 two runs, differing only in wording — indistinguishable to a reader from the
 duplicate a crashed-and-replayed run produces.
 
+Runs in two PHASEs against the same logic:
+
+    preflight  the cheap `gate` job, OUTSIDE the per-PR concurrency group.
+               An optimization: it turns away the common re-trigger before
+               a VPN connect and a sandbox are spent on it.
+    locked     the first step of `sdk-review-dispatch`, INSIDE the
+               `sdk-review-$PR` concurrency group. This one is the
+               authority: while it runs, no sibling run in the group can be
+               executing, so the comment state it reads is post-lock and
+               final. It adds the sibling-in-flight check on top of the
+               unchanged-HEAD check, which covers the one case the lock does
+               not — a sandbox that outlived its cancelled job (see
+               `sdk-review.yml`, "Cancelling this job does NOT stop the
+               sandbox") and is still going to post a verdict.
+
+Both phases share `decide()`, so the two callers cannot drift on what counts
+as a duplicate trigger. Before FND-636 the authoritative check lived in the
+sandbox prompt (ORCHESTRATION.md Phase 0 §6b): the model had to boot and
+reason before it could decline, so the run was paid for either way, and a
+degraded model skipped the check entirely.
+
 A human tagging `@sdk-review` always dispatches, even on an unchanged HEAD:
 re-reading the same diff is a legitimate thing to ask for, and second-guessing
 it would make the tag feel broken.
@@ -23,19 +44,24 @@ docs/standards/ci.md.
 Environment:
     REPO            owner/repo (e.g. atlanhq/application-sdk)
     PR_NUMBER       pull request number
-    HEAD_SHA        40-char sha this trigger would review (empty when
-                    HEAD_RESOLVED=false)
+    GATE_PHASE      preflight (default) | locked
+    HEAD_SHA        40-char sha this trigger would review. Optional: when
+                    empty the sha is resolved here, with retries.
     EVENT_NAME      issue_comment | workflow_dispatch
     TRIGGER_ACTOR   login of the commenter ("" for workflow_dispatch)
-    HEAD_RESOLVED   true (default) | false — set by the workflow when all
-                    head-resolution retries are exhausted
+    HEAD_RESOLVED   forces the fail-open path when set to "false". Normally
+                    left unset — head resolution happens here.
+    RUN_ID          this run's GITHUB_RUN_ID; a starter comment carrying it
+                    is our own, not a sibling's (locked phase only)
     GH_TOKEN        consumed by `gh` for auth (not read here directly)
     GITHUB_OUTPUT   path to the step-output file (optional; falls back to stdout)
 
 Outputs:
-    decision  proceed | skip
-    reason    machine-readable slug
-    message   one line suitable for a PR comment or a ::notice::
+    decision       proceed | skip
+    reason         machine-readable slug
+    message        one line suitable for a PR comment or a ::notice::
+    head_sha       the sha the decision was made against ("" if unresolved)
+    head_resolved  true | false
 """
 
 from __future__ import annotations
@@ -44,6 +70,7 @@ import json
 import os
 import re
 import subprocess
+import time
 from collections.abc import Callable
 
 # Logins the workflow's `if:` lets through besides OWNER/MEMBER/COLLABORATOR
@@ -53,7 +80,64 @@ BOT_TRIGGERS = frozenset({"mothership-ai[bot]", "atlan-ci"})
 SUMMARY_MARKER = "<!-- SDK_REVIEW -->"
 REVIEWED_HEAD_RE = re.compile(r"<!--\s*REVIEWED_HEAD:\s*([0-9a-f]{40})\s*-->")
 
+# The "review starting" comment the dispatch job posts before it hands off to
+# the sandbox, and the two stamps it carries so a later run can tell whose it
+# is and whether that run has finished.
+STARTER_MARKER = "<!-- SDK_REVIEW_STARTED -->"
+STARTER_HEAD_RE = re.compile(r"<!--\s*SDK_REVIEW_STARTED_HEAD:\s*([0-9a-f]{40})\s*-->")
+STARTER_RUN_RE = re.compile(r"<!--\s*SDK_REVIEW_STARTED_RUN:\s*([0-9]+)\s*-->")
+# Appended to the starter by the `Stamp cost + status onto starter comment`
+# step, which is `always()` — so its presence means that run reached its end,
+# cancelled or not. Kept byte-identical to the JS `includes('— status `')`
+# guard in sdk-review.yml; changing one without the other makes every finished
+# run look in-flight.
+STARTER_STAMP = "\u2014 status `"
+
+# Head resolution: 3 attempts, 5 s then 10 s backoff. Exhaustion is not fatal
+# — see the fail-open note in main().
+HEAD_ATTEMPTS = 3
+HEAD_BACKOFF_SECONDS = 5
+
 Runner = Callable[..., subprocess.CompletedProcess]
+Sleeper = Callable[[float], None]
+
+
+def resolve_head(
+    repo: str,
+    pr_number: str,
+    runner: Runner = subprocess.run,
+    sleeper: Sleeper = time.sleep,
+) -> tuple[str, bool]:
+    """The PR's current head sha, and whether we actually got it.
+
+    Retried because a transient 5xx here used to decide the review: the
+    caller had no sha, so the gate could not compare one, and the trigger was
+    either dropped or duplicated depending on which way the caller guessed.
+    On exhaustion we return ("", False) and main() proceeds fail-open.
+
+    Lives here rather than as a shell `for` loop in the workflow both because
+    docs/standards/ci.md forbids branching logic in YAML and because the
+    locked phase needs the identical resolution — two copies of a retry loop
+    is two things to keep in step.
+    """
+    for attempt in range(1, HEAD_ATTEMPTS + 1):
+        result = runner(
+            ["gh", "api", f"repos/{repo}/pulls/{pr_number}", "--jq", ".head.sha"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        sha = (result.stdout or "").strip()
+        if result.returncode == 0 and sha:
+            return sha, True
+        print(f"::warning::Head resolution attempt {attempt}/{HEAD_ATTEMPTS} failed")
+        if attempt < HEAD_ATTEMPTS:
+            sleeper(attempt * HEAD_BACKOFF_SECONDS)
+    print(
+        f"::warning::All {HEAD_ATTEMPTS} head-resolution attempts failed — "
+        "gate will proceed fail-open"
+    )
+    return "", False
 
 
 def fetch_comments(
@@ -111,13 +195,54 @@ def last_reviewed_head(comments: list[dict]) -> str | None:
     return None
 
 
+def inflight_sibling_run(
+    comments: list[dict], head_sha: str, self_run_id: str
+) -> str | None:
+    """Run id of another run that claimed this sha and has not finished.
+
+    A run claims a sha by posting the starter comment; the cost/status stamp
+    is appended when the run ends. An unstamped starter from a run that is not
+    us therefore means a review for this exact sha is still in flight.
+
+    Under the concurrency lock that should be impossible — except the sandbox
+    outlives a cancelled job, keeps working, and still posts its verdict with
+    its own token minutes after GitHub calls the run cancelled. That zombie is
+    what this catches; the lock covers everything else.
+
+    Starters written before FND-636 carry no head/run stamps and are ignored,
+    so rollout cannot skip a legitimate trigger on an in-flight PR.
+    """
+    if not head_sha:
+        return None
+    for comment in reversed(comments):
+        body = comment.get("body") or ""
+        if not body.startswith(STARTER_MARKER):
+            continue
+        head = STARTER_HEAD_RE.search(body)
+        if not head or head.group(1) != head_sha:
+            continue
+        run = STARTER_RUN_RE.search(body)
+        if not run or run.group(1) == self_run_id:
+            continue
+        if STARTER_STAMP in body:
+            continue  # that run reached its end
+        return run.group(1)
+    return None
+
+
 def decide(
     event_name: str,
     actor: str,
     head_sha: str,
     reviewed_head: str | None,
+    inflight_run: str | None = None,
 ) -> tuple[str, str, str]:
-    """Return (decision, reason, message)."""
+    """Return (decision, reason, message).
+
+    `inflight_run` is only ever populated in the locked phase — the preflight
+    gate runs outside the lock, where "a sibling is running" is the normal
+    state and not grounds to decline.
+    """
     if event_name != "issue_comment":
         return "proceed", "manual-dispatch", "Manual dispatch — reviewing."
     if actor not in BOT_TRIGGERS:
@@ -129,6 +254,13 @@ def decide(
             f"Skipping: `{head_sha[:7]}` already has an SDK review and this trigger came "
             f"from @{actor}, not a human. Push a commit, or tag `@sdk-review` yourself to "
             f"force a re-review.",
+        )
+    if inflight_run:
+        return (
+            "skip",
+            "sibling-run-in-flight",
+            f"Skipping: run {inflight_run} is already reviewing `{head_sha[:7]}` and this "
+            f"trigger came from @{actor}, not a human. Its verdict will land on this PR.",
         )
     return (
         "proceed",
@@ -147,19 +279,34 @@ def set_output(key: str, value: str) -> None:
         print(f"OUTPUT: {key}={value}")
 
 
-def main(runner: Runner = subprocess.run) -> int:
+def main(runner: Runner = subprocess.run, sleeper: Sleeper = time.sleep) -> int:
     repo = os.environ.get("REPO", "")
     pr_number = os.environ.get("PR_NUMBER", "")
-    head_sha = os.environ.get("HEAD_SHA", "")
     event_name = os.environ.get("EVENT_NAME", "issue_comment")
     actor = os.environ.get("TRIGGER_ACTOR", "")
-    head_resolved = os.environ.get("HEAD_RESOLVED", "true")
+    phase = os.environ.get("GATE_PHASE", "preflight")
+    self_run_id = os.environ.get("RUN_ID", "")
+
+    # HEAD_SHA is an override for callers that already hold the sha; when it is
+    # absent we resolve it (with retries) so both phases read the same value the
+    # same way. HEAD_RESOLVED=false forces the fail-open branch below.
+    head_sha = os.environ.get("HEAD_SHA", "")
+    forced = os.environ.get("HEAD_RESOLVED", "")
+    if forced == "false":
+        head_sha, head_resolved = "", False
+    elif head_sha:
+        head_resolved = True
+    else:
+        head_sha, head_resolved = resolve_head(repo, pr_number, runner, sleeper)
+
+    set_output("head_sha", head_sha)
+    set_output("head_resolved", "true" if head_resolved else "false")
 
     # If all head-resolution retries were exhausted, proceed fail-open.
     # A missing review is always worse than an extra review.
-    if head_resolved != "true":
+    if not head_resolved:
         message = (
-            "Head SHA could not be resolved after 3 attempts "
+            f"Head SHA could not be resolved after {HEAD_ATTEMPTS} attempts "
             "(transient GitHub API error). Proceeding fail-open — "
             "reviewing is the safe default."
         )
@@ -172,16 +319,22 @@ def main(runner: Runner = subprocess.run) -> int:
         return 0
 
     reviewed_head: str | None = None
+    inflight_run: str | None = None
     # Only a bot trigger can be gated, so skip the API call entirely otherwise.
     if event_name == "issue_comment" and actor in BOT_TRIGGERS and repo and pr_number:
-        reviewed_head = last_reviewed_head(fetch_comments(repo, pr_number, runner))
+        comments = fetch_comments(repo, pr_number, runner)
+        reviewed_head = last_reviewed_head(comments)
+        if phase == "locked":
+            inflight_run = inflight_sibling_run(comments, head_sha, self_run_id)
 
-    decision, reason, message = decide(event_name, actor, head_sha, reviewed_head)
+    decision, reason, message = decide(
+        event_name, actor, head_sha, reviewed_head, inflight_run
+    )
 
     set_output("decision", decision)
     set_output("reason", reason)
     set_output("message", message)
-    print(f"::notice::sdk-review gate: {decision} ({reason}) — {message}")
+    print(f"::notice::sdk-review gate [{phase}]: {decision} ({reason}) — {message}")
     return 0
 
 

--- a/.github/scripts/sdk_review_summaries.py
+++ b/.github/scripts/sdk_review_summaries.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Which `<!-- SDK_REVIEW -->` summary comments belong to THIS review run.
+
+Two steps in `sdk-review.yml` ask that question and act on opposite answers:
+
+    sdk_review_dedupe_verdicts.py   too many are ours  → minimize the extras
+    sdk_review_verdict_gate.py      none are ours       → fail the run
+
+A reader that says "ours" too readily lets another run's verdict vouch for a
+run that delivered nothing; one that says "ours" too rarely fails a review that
+did land. Getting those two wrong in opposite directions from two separate
+implementations is how a green check and a red check end up describing the same
+run, so the decision lives here once and both callers import it.
+
+Attribution is by run URL, not by a time window. ORCHESTRATION.md §3e makes
+`**Run:** …(<GHA_RUN_URL>)` mandatory on every summary, and the sandbox's own
+replay guard (§6b) already greps it, so the key is exact: a replayed assistant
+turn re-posts the same body and therefore the same URL, while another run's
+summary can never carry ours.
+
+A window cannot make that claim. The sandbox outlives a cancelled job and posts
+minutes later, and a human trigger always passes the locked dedupe gate — so a
+summary that is emphatically not ours can land between our starter comment and
+our stream closing.
+
+The window survives only as a fallback for summaries that name no run at all,
+i.e. written before the footer existed. Anything naming another run is that
+run's, whatever its timestamp.
+
+Because the run URL carries the exact case, the window is free to be strict:
+see `at_or_after`.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime, timezone
+
+# `sdk_review_approve.py` still accepts the legacy marker, and a gate that
+# failed a run the approver would have stamped is worse than no gate.
+SUMMARY_MARKERS = ("<!-- SDK_REVIEW -->", "<!-- TEST_SDK_REVIEW -->")
+
+REVIEWED_HEAD_RE = re.compile(r"<!--\s*REVIEWED_HEAD:\s*([0-9a-f]{40})\s*-->")
+
+# A GitHub Actions run URL, wherever it appears in a comment body. The trailing
+# digits end the match, so the `)` closing a markdown link is excluded.
+ACTIONS_RUN_URL_RE = re.compile(r"https://\S*?/actions/runs/\d+")
+
+# What `attribute()` reports about how it decided.
+BY_RUN_URL = "run-url"
+BY_WINDOW = "window-fallback"
+UNATTRIBUTED = "none"
+
+
+def parse_ts(value: str) -> datetime | None:
+    """A GitHub or JS ISO-8601 timestamp as an aware datetime, or None."""
+    text = (value or "").strip()
+    if not text:
+        return None
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def at_or_after(created_at: str, since: datetime) -> bool:
+    """Whether `created_at` is at or after `since`, compared as instants.
+
+    The two sides differ in precision — GitHub records `created_at` to the
+    second (`…:39Z`), the starter step stamps `new Date().toISOString()`
+    (`…:39.371Z`) — so they are parsed rather than string-compared:
+    lexicographically "Z" > ".", which would make `…:39Z >= …:39.371Z` true and
+    let a summary from *before* the bound vouch for this run.
+
+    Deliberately NOT floored to the second. Flooring would admit that
+    pre-window summary back, and the failure it would guard against — this run's
+    own verdict posted inside the starter's own second, stored a fraction
+    earlier than the bound — cannot happen: the bound is our starter comment,
+    and the sandbox has to boot and review before it can post. Nor would it
+    matter if it did, because our own verdict is found by run URL and never
+    reaches this comparison. Between a window that leans towards claiming
+    someone else's summary and one that leans away, lean away.
+    """
+    created = parse_ts(created_at)
+    if created is None:
+        return False
+    return created >= since
+
+
+def is_summary(comment: dict) -> bool:
+    body = comment.get("body") or ""
+    return any(marker in body for marker in SUMMARY_MARKERS)
+
+
+def claimed_run_urls(body: str) -> set[str]:
+    """Every Actions run URL a comment body claims.
+
+    Matched anywhere in the body rather than by parsing the `**Run:**` line,
+    because that footer is LLM-rendered: a reworded link label must not read as
+    "claims no run" and promote another run's summary into our fallback.
+    """
+    return set(ACTIONS_RUN_URL_RE.findall(body))
+
+
+def _oldest_first(comments: list[dict]) -> list[dict]:
+    # created_at is second-precision, so same-second duplicates tie; comment
+    # ids increase monotonically and break the tie in posting order.
+    return sorted(
+        comments, key=lambda c: (str(c.get("created_at") or ""), c.get("id") or 0)
+    )
+
+
+def attribute(
+    comments: list[dict],
+    run_url: str,
+    since: datetime | None = None,
+    head_sha: str = "",
+) -> tuple[list[dict], str]:
+    """This run's summary comments (oldest first) and how they were identified.
+
+    Returns `(summaries, BY_RUN_URL | BY_WINDOW | UNATTRIBUTED)`. Callers that
+    write to the PR must act only on `BY_RUN_URL`: under the fallback we know a
+    summary is not another run's, but not that it is ours.
+    """
+    summaries = [c for c in comments if is_summary(c)]
+
+    if run_url:
+        mine = [
+            c for c in summaries if run_url in claimed_run_urls(c.get("body") or "")
+        ]
+        if mine:
+            return _oldest_first(mine), BY_RUN_URL
+
+    if since is None:
+        return [], UNATTRIBUTED
+
+    kept = []
+    for comment in summaries:
+        body = comment.get("body") or ""
+        if claimed_run_urls(body):
+            continue  # another run's — ours would have matched by URL above
+        if not at_or_after(str(comment.get("created_at") or ""), since):
+            continue
+        stamped = REVIEWED_HEAD_RE.search(body)
+        if stamped and head_sha and stamped.group(1) != head_sha:
+            continue
+        kept.append(comment)
+    return (_oldest_first(kept), BY_WINDOW) if kept else ([], UNATTRIBUTED)

--- a/.github/scripts/sdk_review_verdict_gate.py
+++ b/.github/scripts/sdk_review_verdict_gate.py
@@ -50,14 +50,18 @@ from __future__ import annotations
 import json
 import os
 import subprocess
+import sys
 import time
 from collections.abc import Callable
-from datetime import datetime, timezone
+from datetime import datetime
+from pathlib import Path
 
-# Both markers count as a delivered verdict. `sdk_review_approve.py` accepts
-# the legacy `<!-- TEST_SDK_REVIEW -->` form too, and a gate that failed a run
-# the approver would have happily stamped would be worse than no gate.
-SUMMARY_MARKERS = ("<!-- SDK_REVIEW -->", "<!-- TEST_SDK_REVIEW -->")
+sys.path.insert(0, str(Path(__file__).parent))
+
+from sdk_review_summaries import (  # noqa: E402  (needs the sys.path bootstrap)
+    attribute,
+    parse_ts,
+)
 
 # Our own marker. Deliberately not a `<!-- SDK_REVIEW -->` prefix so this
 # comment can never be mistaken for a verdict by the counters above, by
@@ -76,25 +80,6 @@ RECHECK_DELAY_S = 10.0
 
 Runner = Callable[..., subprocess.CompletedProcess]
 Sleeper = Callable[[float], None]
-
-
-def parse_ts(value: str) -> datetime | None:
-    """Parse a GitHub/JS ISO-8601 timestamp, tolerating the `Z` suffix.
-
-    Compared as datetimes rather than strings because the two sides differ in
-    precision: `new Date().toISOString()` carries milliseconds
-    (`...:03.371Z`), the REST API's `created_at` does not (`...:03Z`).
-    """
-    text = (value or "").strip()
-    if not text:
-        return None
-    try:
-        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
-    except ValueError:
-        return None
-    if parsed.tzinfo is None:
-        parsed = parsed.replace(tzinfo=timezone.utc)
-    return parsed
 
 
 def fetch_comments(
@@ -150,22 +135,22 @@ def fetch_comments(
     return None
 
 
-def count_summaries(comments: list[dict], since: datetime) -> int:
-    """Summary comments created at or after `since`.
+def count_summaries(comments: list[dict], since: datetime, run_url: str = "") -> int:
+    """How many summary comments this run posted.
 
-    The lower bound is what stops a verdict from a *previous* trigger — same
-    PR, older head — from vouching for this run.
+    Delegates to `sdk_review_summaries.attribute()`, which the dedupe step also
+    uses, so "this run posted no verdict" and "this run posted too many" are
+    answered from one definition of ownership rather than two.
+
+    That matters here more than anywhere: this gate is the only one that exits
+    non-zero. Attributing by time window alone let another run's summary — a
+    zombie sandbox posting minutes after its job was cancelled, or a concurrent
+    human trigger — vouch for a run that delivered nothing, and comparing an
+    unfloored millisecond bound against GitHub's second-precision `created_at`
+    dropped this run's own verdict when both landed in the same second, failing
+    a review that had in fact been posted.
     """
-    count = 0
-    for comment in comments:
-        body = comment.get("body") or ""
-        if not any(marker in body for marker in SUMMARY_MARKERS):
-            continue
-        created = parse_ts(str(comment.get("created_at") or ""))
-        if created is None or created < since:
-            continue
-        count += 1
-    return count
+    return len(attribute(comments, run_url, since)[0])
 
 
 def no_verdict_body(pr_number: str, cost: str, run_url: str) -> str:
@@ -267,7 +252,7 @@ def main(runner: Runner = subprocess.run, sleeper: Sleeper = time.sleep) -> int:
         comments = fetch_comments(repo, pr_number, runner, sleeper)
         if comments is None:
             return _fail_open(f"could not list comments on PR #{pr_number}")
-        count = count_summaries(comments, since)
+        count = count_summaries(comments, since, run_url)
         if count > 0:
             break
         if attempt < RECHECK_ATTEMPTS:

--- a/.github/scripts/sdk_review_verdict_gate.py
+++ b/.github/scripts/sdk_review_verdict_gate.py
@@ -32,7 +32,10 @@ Environment:
     STARTER_STARTED_AT   ISO-8601 lower bound: the starter comment's timestamp,
                          set by this run's own starter step. Comments older
                          than this belong to a previous trigger.
-    GHA_RUN_URL          link to this workflow run (optional)
+    GHA_RUN_URL          link to this workflow run, and the ownership key
+                         `sdk_review_summaries.attribute()` matches on
+    HEAD_SHA             the sha this run was dispatched for, so a summary for
+                         a different head cannot vouch for this run
     GH_TOKEN             consumed by `gh` for auth (not read here directly)
     GITHUB_OUTPUT        path to the step-output file (optional)
 
@@ -135,7 +138,9 @@ def fetch_comments(
     return None
 
 
-def count_summaries(comments: list[dict], since: datetime, run_url: str = "") -> int:
+def count_summaries(
+    comments: list[dict], since: datetime, run_url: str = "", head_sha: str = ""
+) -> int:
     """How many summary comments this run posted.
 
     Delegates to `sdk_review_summaries.attribute()`, which the dedupe step also
@@ -143,14 +148,18 @@ def count_summaries(comments: list[dict], since: datetime, run_url: str = "") ->
     answered from one definition of ownership rather than two.
 
     That matters here more than anywhere: this gate is the only one that exits
-    non-zero. Attributing by time window alone let another run's summary — a
-    zombie sandbox posting minutes after its job was cancelled, or a concurrent
-    human trigger — vouch for a run that delivered nothing, and comparing an
-    unfloored millisecond bound against GitHub's second-precision `created_at`
-    dropped this run's own verdict when both landed in the same second, failing
-    a review that had in fact been posted.
+    non-zero, so its count has to be the stricter of the two. Attributing by
+    time window alone let another run's summary — a zombie sandbox posting
+    minutes after its job was cancelled, or a concurrent human trigger — vouch
+    for a run that delivered nothing.
+
+    Every narrowing `attribute()` offers is passed, `head_sha` included.
+    Dropping it left a footerless summary for a *different* reviewed head
+    counting here while the dedupe step, which passed it, called the same
+    comment nobody's — one shared decision returning two answers, which is the
+    thing this module exists to prevent.
     """
-    return len(attribute(comments, run_url, since)[0])
+    return len(attribute(comments, run_url, since, head_sha)[0])
 
 
 def no_verdict_body(pr_number: str, cost: str, run_url: str) -> str:
@@ -227,6 +236,7 @@ def main(runner: Runner = subprocess.run, sleeper: Sleeper = time.sleep) -> int:
     final_status = os.environ.get("FINAL_STATUS", "").strip()
     cost = os.environ.get("FINAL_COST", "").strip()
     run_url = os.environ.get("GHA_RUN_URL", "").strip()
+    head_sha = os.environ.get("HEAD_SHA", "").strip()
     since = parse_ts(os.environ.get("STARTER_STARTED_AT", ""))
 
     # Only a run that claims it finished cleanly is in scope. Every other
@@ -252,7 +262,7 @@ def main(runner: Runner = subprocess.run, sleeper: Sleeper = time.sleep) -> int:
         comments = fetch_comments(repo, pr_number, runner, sleeper)
         if comments is None:
             return _fail_open(f"could not list comments on PR #{pr_number}")
-        count = count_summaries(comments, since, run_url)
+        count = count_summaries(comments, since, run_url, head_sha)
         if count > 0:
             break
         if attempt < RECHECK_ATTEMPTS:

--- a/.github/scripts/tests/test_react_to_comment.py
+++ b/.github/scripts/tests/test_react_to_comment.py
@@ -428,6 +428,7 @@ def test_every_caller_can_actually_reach_the_script() -> None:
 EXPECTED_CALLERS = {
     ("sdk-review.yml", "react-on-skip", "React to skipped trigger"),
     ("sdk-review.yml", "sdk-review-dispatch", "React to comment"),
+    ("sdk-review.yml", "sdk-review-dispatch", "React to skipped re-trigger"),
     ("sdk-resolve.yml", "sdk-resolve-dispatch", "Acknowledge with a reaction"),
     ("auto-fix-vulnerabilities.yaml", "auto-fix", "React to comment"),
     ("capability-manifest-regen.yaml", "regen", "React to comment"),

--- a/.github/scripts/tests/test_sdk_review_dedupe_verdicts.py
+++ b/.github/scripts/tests/test_sdk_review_dedupe_verdicts.py
@@ -3,6 +3,10 @@
 The shape being defended against is PR #3276: one review run, five identical
 `<!-- SDK_REVIEW -->` summaries inside 76 seconds, because a provider-level
 retry replayed the assistant turn that posts the comment.
+
+The shape that must NOT be collapsed is someone else's summary landing in the
+same window — a zombie sandbox that outlived its cancelled job, or a concurrent
+human-triggered run. Attribution is by run URL for that reason.
 """
 
 from __future__ import annotations
@@ -23,19 +27,31 @@ assert SPEC.loader is not None
 SPEC.loader.exec_module(dedupe)
 
 SINCE = "2026-08-19T18:09:30.123Z"
+RUN_URL = "https://github.com/atlanhq/application-sdk/actions/runs/32286845311"
+OTHER_RUN_URL = "https://github.com/atlanhq/application-sdk/actions/runs/32286821875"
+HEAD = "4237280fd9dd1eb52c8b3a0eb44e4f4a3c2d1b0a"
+OTHER_HEAD = "51c160b06a2a350289c7d779f4ab887503f98685"
 
 
-def verdict(comment_id: int, created_at: str, node: str | None = None) -> dict:
+def verdict(
+    comment_id: int,
+    created_at: str,
+    run_url: str | None = RUN_URL,
+    head: str | None = HEAD,
+    node: str | None = None,
+) -> dict:
+    """A summary comment as ORCHESTRATION.md §3e specifies it."""
+    lines = ["<!-- SDK_REVIEW -->", "<!-- VERDICT: READY_TO_MERGE -->"]
+    if head is not None:
+        lines.append(f"<!-- REVIEWED_HEAD: {head} -->")
+    lines += ["## SDK Review (mothership)", "", "---", "**CI:** all passing"]
+    if run_url is not None:
+        lines.append(f"**Run:** [view workflow logs + cost]({run_url})")
     return {
         "id": comment_id,
         "node_id": node if node is not None else f"IC_kw{comment_id}",
         "created_at": created_at,
-        "body": (
-            "<!-- SDK_REVIEW -->\n"
-            "<!-- VERDICT: READY_TO_MERGE -->\n"
-            "<!-- REVIEWED_HEAD: 4237280fd9dd1eb52c8b3a0eb44e4f4a3c2d1b0a -->\n"
-            "## SDK Review (mothership)\n"
-        ),
+        "body": "\n".join(lines),
     }
 
 
@@ -76,6 +92,8 @@ def _env(monkeypatch: pytest.MonkeyPatch, out: Path, **extra: str) -> None:
     monkeypatch.setenv("REPO", "atlanhq/application-sdk")
     monkeypatch.setenv("PR_NUMBER", "3276")
     monkeypatch.setenv("SINCE", SINCE)
+    monkeypatch.setenv("GHA_RUN_URL", RUN_URL)
+    monkeypatch.setenv("HEAD_SHA", HEAD)
     monkeypatch.setenv("DEDUPE_OUTPUT", str(out))
     monkeypatch.delenv("DRY_RUN", raising=False)
     for key, value in extra.items():
@@ -85,12 +103,21 @@ def _env(monkeypatch: pytest.MonkeyPatch, out: Path, **extra: str) -> None:
 # --- created_at_or_after() -----------------------------------------------
 
 
-def test_bound_compares_instants_not_strings():
-    """`…:39Z` is BEFORE `…:39.123Z` even though "Z" > "." lexicographically."""
-    assert not dedupe.created_at_or_after(
-        "2026-08-19T18:09:39Z", "2026-08-19T18:09:39.123Z"
+def test_bound_ignores_sub_second_precision_in_both_directions():
+    """GitHub stores `created_at` to the second; the bound has milliseconds.
+
+    Unfloored, a verdict posted at …:39.950Z is stored as …:39Z, parses to
+    39.000, and falls *before* a …:39.900Z bound — so the verdict this run just
+    posted is excluded and a delivered review hard-fails.
+    """
+    assert dedupe.created_at_or_after(
+        "2026-08-19T18:09:39Z", "2026-08-19T18:09:39.900Z"
     )
-    assert "2026-08-19T18:09:39Z" >= "2026-08-19T18:09:39.123Z"  # the naive form
+    # …and the string form's opposite error: a comment from the second *before*
+    # the bound must still be excluded.
+    assert not dedupe.created_at_or_after(
+        "2026-08-19T18:09:38Z", "2026-08-19T18:09:39.900Z"
+    )
 
 
 def test_bound_is_inclusive():
@@ -105,17 +132,26 @@ def test_unparseable_timestamps_fall_back_to_string_order():
     assert dedupe.created_at_or_after("zzz", "aaa")
 
 
-# --- this_runs_summaries() ----------------------------------------------
+# --- summaries_by_run_url() ---------------------------------------------
 
 
-def test_only_this_runs_summaries_count():
-    """A summary from a previous head must not be attributed to this run."""
+def test_run_url_identifies_our_summaries_exactly():
     comments = [
-        verdict(1, "2026-08-19T17:33:00Z"),  # previous run
+        verdict(1, "2026-08-19T17:33:00Z", run_url=OTHER_RUN_URL),
         chatter(2, "2026-08-19T18:10:00Z"),
         verdict(3, "2026-08-19T18:14:35Z"),
     ]
-    assert [c["id"] for c in dedupe.this_runs_summaries(comments, SINCE)] == [3]
+    assert [c["id"] for c in dedupe.summaries_by_run_url(comments, RUN_URL)] == [3]
+
+
+def test_run_url_matching_ignores_the_time_window_entirely():
+    """A replay can post long after the starter; the URL still identifies it."""
+    comments = [verdict(1, "2026-08-19T02:00:00Z")]
+    assert [c["id"] for c in dedupe.summaries_by_run_url(comments, RUN_URL)] == [1]
+
+
+def test_no_run_url_matches_nothing():
+    assert dedupe.summaries_by_run_url([verdict(1, "2026-08-19T18:14:35Z")], "") == []
 
 
 def test_same_second_duplicates_are_ordered_by_comment_id():
@@ -125,11 +161,35 @@ def test_same_second_duplicates_are_ordered_by_comment_id():
         verdict(10, "2026-08-19T18:14:50Z"),
         verdict(20, "2026-08-19T18:14:50Z"),
     ]
-    assert [c["id"] for c in dedupe.this_runs_summaries(comments, SINCE)] == [
+    assert [c["id"] for c in dedupe.summaries_by_run_url(comments, RUN_URL)] == [
         10,
         20,
         30,
     ]
+
+
+# --- summaries_in_window() ----------------------------------------------
+
+
+def test_window_fallback_excludes_a_summary_for_another_head():
+    """A zombie sandbox posts inside our window for the sha it was reviewing."""
+    comments = [verdict(1, "2026-08-19T18:14:35Z", head=OTHER_HEAD)]
+    assert dedupe.summaries_in_window(comments, SINCE, HEAD) == []
+
+
+def test_window_fallback_keeps_our_head():
+    comments = [verdict(1, "2026-08-19T18:14:35Z")]
+    assert [c["id"] for c in dedupe.summaries_in_window(comments, SINCE, HEAD)] == [1]
+
+
+def test_window_fallback_admits_a_summary_predating_the_head_marker():
+    comments = [verdict(1, "2026-08-19T18:14:35Z", head=None)]
+    assert [c["id"] for c in dedupe.summaries_in_window(comments, SINCE, HEAD)] == [1]
+
+
+def test_window_fallback_excludes_summaries_before_the_bound():
+    comments = [verdict(1, "2026-08-19T17:33:00Z")]
+    assert dedupe.summaries_in_window(comments, SINCE, HEAD) == []
 
 
 # --- main(): the #3276 burst --------------------------------------------
@@ -159,7 +219,21 @@ def test_keeps_the_newest_and_minimizes_the_rest(
         "verdict_posted": "1",
         "verdict_count": "5",
         "minimized_count": "4",
+        "attribution": "run-url",
     }
+
+
+def test_a_verdict_posted_in_the_starters_own_second_still_counts(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+):
+    """The sub-second regression, end to end, on the fallback path."""
+    out = tmp_path / "out"
+    _env(monkeypatch, out, SINCE="2026-08-19T18:09:39.900Z")
+    # No run URL on the summary, so attribution falls back to the window.
+    runner = fake_runner([[verdict(1, "2026-08-19T18:09:39Z", run_url=None)]])
+
+    assert dedupe.main(runner) == 0
+    assert outputs(out)["verdict_posted"] == "1"
 
 
 def test_the_normal_single_summary_is_left_alone(
@@ -176,23 +250,110 @@ def test_the_normal_single_summary_is_left_alone(
         "verdict_posted": "1",
         "verdict_count": "1",
         "minimized_count": "0",
+        "attribution": "run-url",
+    }
+
+
+# --- main(): summaries that are not ours --------------------------------
+
+
+def test_a_zombie_sandboxs_summary_in_our_window_is_never_minimized(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+):
+    """Our own verdict must not be hidden as the DUPLICATE of someone else's."""
+    out = tmp_path / "out"
+    _env(monkeypatch, out)
+    comments = [
+        verdict(1, "2026-08-19T18:14:35Z"),  # ours
+        verdict(2, "2026-08-19T18:16:00Z", run_url=OTHER_RUN_URL),  # the zombie's
+    ]
+    runner = fake_runner([comments])
+
+    assert dedupe.main(runner) == 0
+
+    assert graphql_calls(runner) == []
+    assert outputs(out) == {
+        "verdict_posted": "1",
+        "verdict_count": "1",
+        "minimized_count": "0",
+        "attribution": "run-url",
+    }
+
+
+def test_another_runs_summary_alone_does_not_claim_a_delivered_review(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+):
+    """Soft-success must not fire when our sandbox posted nothing."""
+    out = tmp_path / "out"
+    _env(monkeypatch, out)
+    comments = [verdict(1, "2026-08-19T18:14:35Z", run_url=OTHER_RUN_URL)]
+
+    assert dedupe.main(fake_runner([comments])) == 0
+    assert outputs(out)["verdict_posted"] == "1"  # same head, so the fallback keeps it
+    assert outputs(out)["attribution"] == "window-fallback"
+    assert outputs(out)["minimized_count"] == "0"
+
+
+def test_another_head_in_our_window_is_not_a_delivered_review(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+):
+    out = tmp_path / "out"
+    _env(monkeypatch, out)
+    comments = [
+        verdict(1, "2026-08-19T18:14:35Z", run_url=OTHER_RUN_URL, head=OTHER_HEAD)
+    ]
+
+    assert dedupe.main(fake_runner([comments])) == 0
+    assert outputs(out) == {
+        "verdict_posted": "0",
+        "verdict_count": "0",
+        "minimized_count": "0",
+        "attribution": "none",
     }
 
 
 def test_a_previous_runs_duplicate_pair_is_not_touched(
     tmp_path, monkeypatch: pytest.MonkeyPatch
 ):
-    """Only this run's window is ours to tidy; older reviews stay visible."""
+    """Only what this run posted is ours to tidy; older reviews stay visible."""
     out = tmp_path / "out"
     _env(monkeypatch, out)
     runner = fake_runner(
-        [[verdict(1, "2026-08-19T17:33:00Z"), verdict(2, "2026-08-19T17:37:00Z")]]
+        [
+            [
+                verdict(1, "2026-08-19T17:33:00Z", run_url=OTHER_RUN_URL),
+                verdict(2, "2026-08-19T17:37:00Z", run_url=OTHER_RUN_URL),
+            ]
+        ]
     )
 
     assert dedupe.main(runner) == 0
 
     assert graphql_calls(runner) == []
     assert outputs(out)["verdict_posted"] == "0"
+
+
+def test_a_footerless_duplicate_pair_is_counted_but_not_hidden(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+):
+    """Without the run URL we cannot tell our duplicate from another review."""
+    out = tmp_path / "out"
+    _env(monkeypatch, out)
+    comments = [
+        verdict(1, "2026-08-19T18:14:35Z", run_url=None),
+        verdict(2, "2026-08-19T18:14:43Z", run_url=None),
+    ]
+    runner = fake_runner([comments])
+
+    assert dedupe.main(runner) == 0
+
+    assert graphql_calls(runner) == []
+    assert outputs(out) == {
+        "verdict_posted": "1",
+        "verdict_count": "2",
+        "minimized_count": "0",
+        "attribution": "window-fallback",
+    }
 
 
 def test_no_verdict_reports_zero_so_the_dispatch_step_still_hard_fails(
@@ -203,24 +364,39 @@ def test_no_verdict_reports_zero_so_the_dispatch_step_still_hard_fails(
 
     assert dedupe.main(fake_runner([[chatter(1, "2026-08-19T18:10:00Z")]])) == 0
     assert outputs(out)["verdict_posted"] == "0"
+    assert outputs(out)["attribution"] == "none"
 
 
-def test_an_empty_bound_reports_no_verdict_and_touches_nothing(
+def test_nothing_to_attribute_by_touches_nothing(
     tmp_path, monkeypatch: pytest.MonkeyPatch
 ):
-    """Without the starter timestamp we cannot tell our summary from anyone's."""
     out = tmp_path / "out"
-    _env(monkeypatch, out, SINCE="")
+    _env(monkeypatch, out, SINCE="", GHA_RUN_URL="")
 
     def _explode(*_a, **_kw):
-        raise AssertionError("queried GitHub with no lower bound")
+        raise AssertionError("queried GitHub with nothing to attribute by")
 
     assert dedupe.main(_explode) == 0
     assert outputs(out) == {
         "verdict_posted": "0",
         "verdict_count": "0",
         "minimized_count": "0",
+        "attribution": "none",
     }
+
+
+def test_a_run_url_alone_is_enough_to_attribute(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+):
+    """An empty starter timestamp no longer disables the collapse."""
+    out = tmp_path / "out"
+    _env(monkeypatch, out, SINCE="")
+    comments = [verdict(1, "2026-08-19T18:14:35Z"), verdict(2, "2026-08-19T18:14:43Z")]
+    runner = fake_runner([comments])
+
+    assert dedupe.main(runner) == 0
+    assert len(graphql_calls(runner)) == 1
+    assert outputs(out)["attribution"] == "run-url"
 
 
 def test_pages_are_flattened_before_counting(tmp_path, monkeypatch: pytest.MonkeyPatch):
@@ -267,6 +443,7 @@ def test_a_refused_minimize_is_reported_not_raised(
         "verdict_posted": "1",
         "verdict_count": "2",
         "minimized_count": "0",
+        "attribution": "run-url",
     }
 
 

--- a/.github/scripts/tests/test_sdk_review_dedupe_verdicts.py
+++ b/.github/scripts/tests/test_sdk_review_dedupe_verdicts.py
@@ -6,7 +6,9 @@ retry replayed the assistant turn that posts the comment.
 
 The shape that must NOT be collapsed is someone else's summary landing in the
 same window — a zombie sandbox that outlived its cancelled job, or a concurrent
-human-triggered run. Attribution is by run URL for that reason.
+human-triggered run. Attribution is by run URL for that reason; the attribution
+decision itself is tested in test_sdk_review_summaries.py, and what this module
+does with the answer is tested here.
 """
 
 from __future__ import annotations
@@ -100,98 +102,6 @@ def _env(monkeypatch: pytest.MonkeyPatch, out: Path, **extra: str) -> None:
         monkeypatch.setenv(key, value)
 
 
-# --- created_at_or_after() -----------------------------------------------
-
-
-def test_bound_ignores_sub_second_precision_in_both_directions():
-    """GitHub stores `created_at` to the second; the bound has milliseconds.
-
-    Unfloored, a verdict posted at …:39.950Z is stored as …:39Z, parses to
-    39.000, and falls *before* a …:39.900Z bound — so the verdict this run just
-    posted is excluded and a delivered review hard-fails.
-    """
-    assert dedupe.created_at_or_after(
-        "2026-08-19T18:09:39Z", "2026-08-19T18:09:39.900Z"
-    )
-    # …and the string form's opposite error: a comment from the second *before*
-    # the bound must still be excluded.
-    assert not dedupe.created_at_or_after(
-        "2026-08-19T18:09:38Z", "2026-08-19T18:09:39.900Z"
-    )
-
-
-def test_bound_is_inclusive():
-    assert dedupe.created_at_or_after(SINCE, SINCE)
-
-
-def test_bound_accepts_a_later_instant():
-    assert dedupe.created_at_or_after("2026-08-19T18:14:55Z", SINCE)
-
-
-def test_unparseable_timestamps_fall_back_to_string_order():
-    assert dedupe.created_at_or_after("zzz", "aaa")
-
-
-# --- summaries_by_run_url() ---------------------------------------------
-
-
-def test_run_url_identifies_our_summaries_exactly():
-    comments = [
-        verdict(1, "2026-08-19T17:33:00Z", run_url=OTHER_RUN_URL),
-        chatter(2, "2026-08-19T18:10:00Z"),
-        verdict(3, "2026-08-19T18:14:35Z"),
-    ]
-    assert [c["id"] for c in dedupe.summaries_by_run_url(comments, RUN_URL)] == [3]
-
-
-def test_run_url_matching_ignores_the_time_window_entirely():
-    """A replay can post long after the starter; the URL still identifies it."""
-    comments = [verdict(1, "2026-08-19T02:00:00Z")]
-    assert [c["id"] for c in dedupe.summaries_by_run_url(comments, RUN_URL)] == [1]
-
-
-def test_no_run_url_matches_nothing():
-    assert dedupe.summaries_by_run_url([verdict(1, "2026-08-19T18:14:35Z")], "") == []
-
-
-def test_same_second_duplicates_are_ordered_by_comment_id():
-    """created_at is second-precision; ids break the tie in posting order."""
-    comments = [
-        verdict(30, "2026-08-19T18:14:50Z"),
-        verdict(10, "2026-08-19T18:14:50Z"),
-        verdict(20, "2026-08-19T18:14:50Z"),
-    ]
-    assert [c["id"] for c in dedupe.summaries_by_run_url(comments, RUN_URL)] == [
-        10,
-        20,
-        30,
-    ]
-
-
-# --- summaries_in_window() ----------------------------------------------
-
-
-def test_window_fallback_excludes_a_summary_for_another_head():
-    """A zombie sandbox posts inside our window for the sha it was reviewing."""
-    comments = [verdict(1, "2026-08-19T18:14:35Z", head=OTHER_HEAD)]
-    assert dedupe.summaries_in_window(comments, SINCE, HEAD) == []
-
-
-def test_window_fallback_keeps_our_head():
-    comments = [verdict(1, "2026-08-19T18:14:35Z")]
-    assert [c["id"] for c in dedupe.summaries_in_window(comments, SINCE, HEAD)] == [1]
-
-
-def test_window_fallback_admits_a_summary_predating_the_head_marker():
-    comments = [verdict(1, "2026-08-19T18:14:35Z", head=None)]
-    assert [c["id"] for c in dedupe.summaries_in_window(comments, SINCE, HEAD)] == [1]
-
-
-def test_window_fallback_excludes_summaries_before_the_bound():
-    comments = [verdict(1, "2026-08-19T17:33:00Z")]
-    assert dedupe.summaries_in_window(comments, SINCE, HEAD) == []
-
-
 # --- main(): the #3276 burst --------------------------------------------
 
 
@@ -223,17 +133,22 @@ def test_keeps_the_newest_and_minimizes_the_rest(
     }
 
 
-def test_a_verdict_posted_in_the_starters_own_second_still_counts(
+def test_our_verdict_is_found_however_late_it_lands(
     tmp_path, monkeypatch: pytest.MonkeyPatch
 ):
-    """The sub-second regression, end to end, on the fallback path."""
+    """No window can drop our own verdict — the run URL is what finds it.
+
+    This is the case a lenient window was proposed to rescue: a summary whose
+    `created_at` sits outside the starter bound. Attribution never consults the
+    bound for our own summary, so the window stays strict and this still counts.
+    """
     out = tmp_path / "out"
     _env(monkeypatch, out, SINCE="2026-08-19T18:09:39.900Z")
-    # No run URL on the summary, so attribution falls back to the window.
-    runner = fake_runner([[verdict(1, "2026-08-19T18:09:39Z", run_url=None)]])
+    runner = fake_runner([[verdict(1, "2026-08-19T18:09:39Z")]])
 
     assert dedupe.main(runner) == 0
     assert outputs(out)["verdict_posted"] == "1"
+    assert outputs(out)["attribution"] == "run-url"
 
 
 def test_the_normal_single_summary_is_left_alone(
@@ -283,15 +198,24 @@ def test_a_zombie_sandboxs_summary_in_our_window_is_never_minimized(
 def test_another_runs_summary_alone_does_not_claim_a_delivered_review(
     tmp_path, monkeypatch: pytest.MonkeyPatch
 ):
-    """Soft-success must not fire when our sandbox posted nothing."""
+    """Soft-success must not fire when our sandbox posted nothing.
+
+    The summary is for our head and inside our window — the only thing that
+    says it is not ours is the run URL in its footer. Before that was the
+    ownership key this reported `verdict_posted=1`, so the dispatch step
+    soft-succeeded on a review this run never delivered.
+    """
     out = tmp_path / "out"
     _env(monkeypatch, out)
     comments = [verdict(1, "2026-08-19T18:14:35Z", run_url=OTHER_RUN_URL)]
 
     assert dedupe.main(fake_runner([comments])) == 0
-    assert outputs(out)["verdict_posted"] == "1"  # same head, so the fallback keeps it
-    assert outputs(out)["attribution"] == "window-fallback"
-    assert outputs(out)["minimized_count"] == "0"
+    assert outputs(out) == {
+        "verdict_posted": "0",
+        "verdict_count": "0",
+        "minimized_count": "0",
+        "attribution": "none",
+    }
 
 
 def test_another_head_in_our_window_is_not_a_delivered_review(

--- a/.github/scripts/tests/test_sdk_review_dedupe_verdicts.py
+++ b/.github/scripts/tests/test_sdk_review_dedupe_verdicts.py
@@ -1,0 +1,315 @@
+"""Tests for the duplicate-verdict collapse (FND-636).
+
+The shape being defended against is PR #3276: one review run, five identical
+`<!-- SDK_REVIEW -->` summaries inside 76 seconds, because a provider-level
+retry replayed the assistant turn that posts the comment.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location(
+    "sdk_review_dedupe_verdicts", SCRIPTS / "sdk_review_dedupe_verdicts.py"
+)
+dedupe = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(dedupe)
+
+SINCE = "2026-08-19T18:09:30.123Z"
+
+
+def verdict(comment_id: int, created_at: str, node: str | None = None) -> dict:
+    return {
+        "id": comment_id,
+        "node_id": node if node is not None else f"IC_kw{comment_id}",
+        "created_at": created_at,
+        "body": (
+            "<!-- SDK_REVIEW -->\n"
+            "<!-- VERDICT: READY_TO_MERGE -->\n"
+            "<!-- REVIEWED_HEAD: 4237280fd9dd1eb52c8b3a0eb44e4f4a3c2d1b0a -->\n"
+            "## SDK Review (mothership)\n"
+        ),
+    }
+
+
+def chatter(comment_id: int, created_at: str) -> dict:
+    return {
+        "id": comment_id,
+        "node_id": f"IC_kw{comment_id}",
+        "created_at": created_at,
+        "body": "@sdk-review",
+    }
+
+
+def fake_runner(pages, returncode: int = 0):
+    """Answers the comments read; records every `gh` invocation."""
+    calls: list[list[str]] = []
+
+    def _run(args, *_a, **_kw):
+        calls.append(args)
+        if args[:3] == ["gh", "api", "graphql"]:
+            return subprocess.CompletedProcess(args, 0, "{}", "")
+        return subprocess.CompletedProcess(args, returncode, json.dumps(pages), "")
+
+    _run.calls = calls  # type: ignore[attr-defined]
+    return _run
+
+
+def graphql_calls(runner) -> list[list[str]]:
+    return [c for c in runner.calls if c[:3] == ["gh", "api", "graphql"]]
+
+
+def outputs(path: Path) -> dict[str, str]:
+    return dict(
+        line.split("=", 1) for line in path.read_text().splitlines() if "=" in line
+    )
+
+
+def _env(monkeypatch: pytest.MonkeyPatch, out: Path, **extra: str) -> None:
+    monkeypatch.setenv("REPO", "atlanhq/application-sdk")
+    monkeypatch.setenv("PR_NUMBER", "3276")
+    monkeypatch.setenv("SINCE", SINCE)
+    monkeypatch.setenv("DEDUPE_OUTPUT", str(out))
+    monkeypatch.delenv("DRY_RUN", raising=False)
+    for key, value in extra.items():
+        monkeypatch.setenv(key, value)
+
+
+# --- created_at_or_after() -----------------------------------------------
+
+
+def test_bound_compares_instants_not_strings():
+    """`…:39Z` is BEFORE `…:39.123Z` even though "Z" > "." lexicographically."""
+    assert not dedupe.created_at_or_after(
+        "2026-08-19T18:09:39Z", "2026-08-19T18:09:39.123Z"
+    )
+    assert "2026-08-19T18:09:39Z" >= "2026-08-19T18:09:39.123Z"  # the naive form
+
+
+def test_bound_is_inclusive():
+    assert dedupe.created_at_or_after(SINCE, SINCE)
+
+
+def test_bound_accepts_a_later_instant():
+    assert dedupe.created_at_or_after("2026-08-19T18:14:55Z", SINCE)
+
+
+def test_unparseable_timestamps_fall_back_to_string_order():
+    assert dedupe.created_at_or_after("zzz", "aaa")
+
+
+# --- this_runs_summaries() ----------------------------------------------
+
+
+def test_only_this_runs_summaries_count():
+    """A summary from a previous head must not be attributed to this run."""
+    comments = [
+        verdict(1, "2026-08-19T17:33:00Z"),  # previous run
+        chatter(2, "2026-08-19T18:10:00Z"),
+        verdict(3, "2026-08-19T18:14:35Z"),
+    ]
+    assert [c["id"] for c in dedupe.this_runs_summaries(comments, SINCE)] == [3]
+
+
+def test_same_second_duplicates_are_ordered_by_comment_id():
+    """created_at is second-precision; ids break the tie in posting order."""
+    comments = [
+        verdict(30, "2026-08-19T18:14:50Z"),
+        verdict(10, "2026-08-19T18:14:50Z"),
+        verdict(20, "2026-08-19T18:14:50Z"),
+    ]
+    assert [c["id"] for c in dedupe.this_runs_summaries(comments, SINCE)] == [
+        10,
+        20,
+        30,
+    ]
+
+
+# --- main(): the #3276 burst --------------------------------------------
+
+
+def test_keeps_the_newest_and_minimizes_the_rest(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+):
+    out = tmp_path / "out"
+    _env(monkeypatch, out)
+    comments = [
+        verdict(1, "2026-08-19T18:09:39Z"),
+        verdict(2, "2026-08-19T18:14:35Z"),
+        verdict(3, "2026-08-19T18:14:43Z"),
+        verdict(4, "2026-08-19T18:14:50Z"),
+        verdict(5, "2026-08-19T18:14:55Z"),
+    ]
+    runner = fake_runner([comments])
+
+    assert dedupe.main(runner) == 0
+
+    minimized = graphql_calls(runner)
+    assert len(minimized) == 4
+    hidden = {arg for call in minimized for arg in call if arg.startswith("id=")}
+    assert hidden == {"id=IC_kw1", "id=IC_kw2", "id=IC_kw3", "id=IC_kw4"}
+    assert outputs(out) == {
+        "verdict_posted": "1",
+        "verdict_count": "5",
+        "minimized_count": "4",
+    }
+
+
+def test_the_normal_single_summary_is_left_alone(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+):
+    out = tmp_path / "out"
+    _env(monkeypatch, out)
+    runner = fake_runner([[verdict(1, "2026-08-19T18:14:35Z")]])
+
+    assert dedupe.main(runner) == 0
+
+    assert graphql_calls(runner) == []
+    assert outputs(out) == {
+        "verdict_posted": "1",
+        "verdict_count": "1",
+        "minimized_count": "0",
+    }
+
+
+def test_a_previous_runs_duplicate_pair_is_not_touched(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+):
+    """Only this run's window is ours to tidy; older reviews stay visible."""
+    out = tmp_path / "out"
+    _env(monkeypatch, out)
+    runner = fake_runner(
+        [[verdict(1, "2026-08-19T17:33:00Z"), verdict(2, "2026-08-19T17:37:00Z")]]
+    )
+
+    assert dedupe.main(runner) == 0
+
+    assert graphql_calls(runner) == []
+    assert outputs(out)["verdict_posted"] == "0"
+
+
+def test_no_verdict_reports_zero_so_the_dispatch_step_still_hard_fails(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+):
+    out = tmp_path / "out"
+    _env(monkeypatch, out)
+
+    assert dedupe.main(fake_runner([[chatter(1, "2026-08-19T18:10:00Z")]])) == 0
+    assert outputs(out)["verdict_posted"] == "0"
+
+
+def test_an_empty_bound_reports_no_verdict_and_touches_nothing(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+):
+    """Without the starter timestamp we cannot tell our summary from anyone's."""
+    out = tmp_path / "out"
+    _env(monkeypatch, out, SINCE="")
+
+    def _explode(*_a, **_kw):
+        raise AssertionError("queried GitHub with no lower bound")
+
+    assert dedupe.main(_explode) == 0
+    assert outputs(out) == {
+        "verdict_posted": "0",
+        "verdict_count": "0",
+        "minimized_count": "0",
+    }
+
+
+def test_pages_are_flattened_before_counting(tmp_path, monkeypatch: pytest.MonkeyPatch):
+    """--paginate --slurp returns one array per page; duplicates can straddle."""
+    out = tmp_path / "out"
+    _env(monkeypatch, out)
+    runner = fake_runner(
+        [[verdict(1, "2026-08-19T18:14:35Z")], [verdict(2, "2026-08-19T18:14:43Z")]]
+    )
+
+    assert dedupe.main(runner) == 0
+    assert outputs(out)["verdict_count"] == "2"
+    assert len(graphql_calls(runner)) == 1
+
+
+# --- failure handling ----------------------------------------------------
+
+
+def test_a_failed_comments_read_reports_no_verdict_without_raising(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+):
+    out = tmp_path / "out"
+    _env(monkeypatch, out)
+
+    assert dedupe.main(fake_runner([], returncode=1)) == 0
+    assert outputs(out)["verdict_posted"] == "0"
+
+
+def test_a_refused_minimize_is_reported_not_raised(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+):
+    """GitHub refusing to hide a comment must not red-check a landed review."""
+    out = tmp_path / "out"
+    _env(monkeypatch, out)
+    comments = [verdict(1, "2026-08-19T18:09:39Z"), verdict(2, "2026-08-19T18:14:35Z")]
+
+    def _run(args, *_a, **_kw):
+        if args[:3] == ["gh", "api", "graphql"]:
+            return subprocess.CompletedProcess(args, 1, "", "403 Forbidden")
+        return subprocess.CompletedProcess(args, 0, json.dumps([comments]), "")
+
+    assert dedupe.main(_run) == 0
+    assert outputs(out) == {
+        "verdict_posted": "1",
+        "verdict_count": "2",
+        "minimized_count": "0",
+    }
+
+
+def test_a_duplicate_with_no_node_id_is_skipped_not_fatal(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+):
+    out = tmp_path / "out"
+    _env(monkeypatch, out)
+    comments = [
+        verdict(1, "2026-08-19T18:09:39Z", node=""),
+        verdict(2, "2026-08-19T18:14:35Z"),
+    ]
+    runner = fake_runner([comments])
+
+    assert dedupe.main(runner) == 0
+    assert graphql_calls(runner) == []
+    assert outputs(out)["minimized_count"] == "0"
+
+
+def test_dry_run_counts_without_calling_graphql(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+):
+    out = tmp_path / "out"
+    _env(monkeypatch, out, DRY_RUN="true")
+    comments = [verdict(1, "2026-08-19T18:09:39Z"), verdict(2, "2026-08-19T18:14:35Z")]
+    runner = fake_runner([comments])
+
+    assert dedupe.main(runner) == 0
+    assert graphql_calls(runner) == []
+    assert outputs(out)["minimized_count"] == "1"
+
+
+# --- the mutation itself -------------------------------------------------
+
+
+def test_the_mutation_hides_the_comment_as_a_duplicate():
+    assert "minimizeComment" in dedupe.MINIMIZE_MUTATION
+    assert "classifier: DUPLICATE" in dedupe.MINIMIZE_MUTATION
+
+
+def test_minimize_passes_the_node_id_as_a_graphql_variable():
+    runner = fake_runner([])
+    assert dedupe.minimize("IC_kwABC", runner) is True
+    (call,) = graphql_calls(runner)
+    assert f"query={dedupe.MINIMIZE_MUTATION}" in call
+    assert "id=IC_kwABC" in call

--- a/.github/scripts/tests/test_sdk_review_dedupe_workflow.py
+++ b/.github/scripts/tests/test_sdk_review_dedupe_workflow.py
@@ -1,0 +1,168 @@
+"""Workflow-side premises the dedupe logic in sdk_review_gate.py depends on.
+
+The Python is only as correct as the YAML that feeds it: the locked phase reads
+stamps that `sdk-review.yml` has to write, and its `skip` decision is only
+cheap if every downstream step is actually guarded on it. Both are one careless
+edit away from silently regressing, so they are asserted here rather than left
+to review.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+WORKFLOW = REPO_ROOT / ".github/workflows/sdk-review.yml"
+
+SPEC = importlib.util.spec_from_file_location(
+    "sdk_review_gate", REPO_ROOT / ".github/scripts/sdk_review_gate.py"
+)
+gate = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(gate)
+
+GUARD = "steps.lock_gate.outputs.decision != 'skip'"
+
+# Steps that are inert on a skip without naming the guard, and why. Anything
+# outside this set must carry GUARD.
+INERT_ON_SKIP = {
+    # Run before the check, and feed it.
+    "Checkout repo (for local globalprotect-connect action)": "runs before the check",
+    "Parse comment intent": "runs before the check",
+    "Dedupe check (authoritative — inside the concurrency lock)": "is the check",
+    # The check's own skip path.
+    "React to skipped re-trigger": "only fires on skip",
+    # Chained off a guarded step's outcome, so a skip propagates.
+    "Connect to VPN (attempt 2/3)": "chained off vpn1.outcome",
+    "Connect to VPN (attempt 3/3)": "chained off vpn2.outcome",
+    "Notify PR if VPN failed after 3 attempts": "chained off vpn3.outcome",
+    "Fail workflow after VPN failure notification": "chained off vpn3.outcome",
+    # Gated on an output a guarded step never produced.
+    "Terminate mothership sandbox on cancel": "needs session.outputs.session_id",
+    "Stamp cost + status onto starter comment": "needs starter.outputs.comment_id",
+    "Set sdk-review status to failure (only on workflow failure)": (
+        "needs pr.outputs.head_sha"
+    ),
+}
+
+
+def workflow() -> dict:
+    return yaml.safe_load(WORKFLOW.read_text())
+
+
+def dispatch_steps() -> list[dict]:
+    return workflow()["jobs"]["sdk-review-dispatch"]["steps"]
+
+
+def step(name: str) -> dict:
+    for candidate in dispatch_steps():
+        if candidate.get("name") == name:
+            return candidate
+    raise AssertionError(f"no step named {name!r} in sdk-review-dispatch")
+
+
+def starter_script() -> str:
+    return step("Post 'review starting' notice to PR")["with"]["script"]
+
+
+# --- the check runs under the lock, ahead of every side effect ------------
+
+
+def test_the_check_is_in_the_locked_job():
+    job = workflow()["jobs"]["sdk-review-dispatch"]
+    assert "sdk-review-" in job["concurrency"]["group"]
+    assert job["concurrency"]["cancel-in-progress"] is False
+    assert any(s.get("id") == "lock_gate" for s in job["steps"])
+
+
+def test_the_check_runs_in_the_locked_phase_and_knows_its_own_run_id():
+    check = step("Dedupe check (authoritative — inside the concurrency lock)")
+    assert check["env"]["GATE_PHASE"] == "locked"
+    assert check["env"]["RUN_ID"] == "${{ github.run_id }}"
+
+
+def test_a_crashed_check_reviews_rather_than_dropping_the_trigger():
+    """No decision output means "not skip", so the guards below let it run."""
+    check = step("Dedupe check (authoritative — inside the concurrency lock)")
+    assert check["continue-on-error"] is True
+
+
+def test_the_preflight_gate_declares_its_phase():
+    assert workflow()["jobs"]["gate"]["steps"][1]["env"]["GATE_PHASE"] == "preflight"
+
+
+def test_the_check_precedes_every_side_effect():
+    names = [s.get("name") for s in dispatch_steps()]
+    check = names.index("Dedupe check (authoritative — inside the concurrency lock)")
+    for effect in (
+        "React to comment",
+        "Ensure labels exist",
+        "Post 'review starting' notice to PR",
+        "Set sdk-review status to pending",
+        "Dispatch to mothership Rover Direct API",
+    ):
+        assert names.index(effect) > check, f"{effect} runs before the dedupe check"
+
+
+def test_every_step_is_either_guarded_or_provably_inert():
+    unguarded = [
+        s.get("name")
+        for s in dispatch_steps()
+        if GUARD not in str(s.get("if", "")) and s.get("name") not in INERT_ON_SKIP
+    ]
+    assert unguarded == [], (
+        "new step(s) in sdk-review-dispatch neither carry the lock_gate guard nor "
+        f"are listed as inert on skip: {unguarded}"
+    )
+
+
+# --- the starter comment writes what the locked phase reads ---------------
+
+
+def test_the_starter_stamps_the_head_and_run_the_check_looks_for():
+    script = starter_script()
+    assert "<!-- SDK_REVIEW_STARTED_HEAD: ${process.env.HEAD_SHA} -->" in script
+    assert "<!-- SDK_REVIEW_STARTED_RUN: ${process.env.RUN_ID} -->" in script
+    assert "headStamp," in script and "runStamp," in script
+
+
+def test_the_starter_is_given_the_head_and_run_id():
+    env = step("Post 'review starting' notice to PR")["env"]
+    assert env["HEAD_SHA"] == "${{ steps.pr.outputs.head_sha }}"
+    assert env["RUN_ID"] == "${{ github.run_id }}"
+
+
+def test_the_marker_stays_on_the_first_line_so_folding_still_matches():
+    """The fold logic keys off `body.startsWith(marker)`; stamps go after it."""
+    script = starter_script()
+    body = script.split("const body = [", 1)[1]
+    assert body.lstrip().startswith("marker,")
+
+
+def test_the_stamp_the_check_treats_as_finished_is_the_one_the_stamper_writes():
+    """`STARTER_STAMP` and the stamper's idempotence guard must not drift.
+
+    If the JS footer changes shape, every finished run starts looking in-flight
+    and bot re-triggers get skipped forever.
+    """
+    stamper = step("Stamp cost + status onto starter comment")["with"]["script"]
+    assert f"includes('{gate.STARTER_STAMP}')" in stamper
+    assert f"{gate.STARTER_STAMP}" + "${finalStatus}" in stamper.replace("\\`", "`")
+
+
+def test_the_stamper_runs_even_on_a_cancel():
+    """The check reads "no stamp" as "still running", so this must be always()."""
+    assert step("Stamp cost + status onto starter comment")["if"].startswith("always()")
+
+
+# --- the verdict-side collapse is wired into the dispatch step ------------
+
+
+def test_the_dispatch_step_collapses_duplicate_verdicts():
+    run = step("Dispatch to mothership Rover Direct API")["run"]
+    assert "sdk_review_dedupe_verdicts.py" in run
+    assert 'SINCE="${STARTER_STARTED_AT:-}"' in run
+    assert "verdict_posted" in run

--- a/.github/scripts/tests/test_sdk_review_dedupe_workflow.py
+++ b/.github/scripts/tests/test_sdk_review_dedupe_workflow.py
@@ -185,6 +185,23 @@ def test_the_delivery_gate_shares_the_ownership_key():
     env = step("Verify the review delivered a verdict")["env"]
     assert env["GHA_RUN_URL"].endswith("/actions/runs/${{ github.run_id }}")
     assert env["STARTER_STARTED_AT"] == "${{ steps.starter.outputs.started_at }}"
+    # Every narrowing attribute() offers, or the two steps answer differently
+    # for the same comment — and this is the one that exits non-zero.
+    assert env["HEAD_SHA"] == "${{ steps.pr.outputs.head_sha }}"
+
+
+def test_both_attribution_callers_are_given_the_same_inputs():
+    """A shared decision only agrees if both callers feed it the same thing.
+
+    The dedupe step reads these from its own env; the gate step from its. A
+    narrowing wired into one and not the other is how the shared module ends up
+    returning two answers for one comment.
+    """
+    shared = ("GHA_RUN_URL", "HEAD_SHA")
+    dispatch = step("Dispatch to mothership Rover Direct API")["env"]
+    verdict = step("Verify the review delivered a verdict")["env"]
+    for key in shared:
+        assert dispatch[key] == verdict[key], f"{key} differs between the two callers"
 
 
 def test_the_summary_template_still_carries_the_run_url():

--- a/.github/scripts/tests/test_sdk_review_dedupe_workflow.py
+++ b/.github/scripts/tests/test_sdk_review_dedupe_workflow.py
@@ -166,3 +166,22 @@ def test_the_dispatch_step_collapses_duplicate_verdicts():
     assert "sdk_review_dedupe_verdicts.py" in run
     assert 'SINCE="${STARTER_STARTED_AT:-}"' in run
     assert "verdict_posted" in run
+
+
+def test_the_dispatch_step_supplies_the_ownership_key():
+    """Attribution is by run URL; HEAD_SHA and SINCE only feed the fallback."""
+    env = step("Dispatch to mothership Rover Direct API")["env"]
+    assert env["GHA_RUN_URL"].endswith("/actions/runs/${{ github.run_id }}")
+    assert env["HEAD_SHA"] == "${{ steps.pr.outputs.head_sha }}"
+    assert env["STARTER_STARTED_AT"] == "${{ steps.starter.outputs.started_at }}"
+
+
+def test_the_summary_template_still_carries_the_run_url():
+    """The ownership key only works because §3e mandates this footer line.
+
+    If the template ever drops it, every run falls back to window attribution
+    and stops collapsing duplicates — silently. Fail here instead.
+    """
+    orchestration = (REPO_ROOT / ".mothership/pr-review/ORCHESTRATION.md").read_text()
+    assert "**Run:** [view workflow logs + cost](<GHA_RUN_URL>)" in orchestration
+    assert "The trailing **Run:** line is required on every summary." in orchestration

--- a/.github/scripts/tests/test_sdk_review_dedupe_workflow.py
+++ b/.github/scripts/tests/test_sdk_review_dedupe_workflow.py
@@ -176,6 +176,17 @@ def test_the_dispatch_step_supplies_the_ownership_key():
     assert env["STARTER_STARTED_AT"] == "${{ steps.starter.outputs.started_at }}"
 
 
+def test_the_delivery_gate_shares_the_ownership_key():
+    """The gate that reds a run and the step that hides duplicates must agree.
+
+    Both read `sdk_review_summaries.attribute()`; the gate can only reach the
+    exact tier if the workflow hands it the same run URL.
+    """
+    env = step("Verify the review delivered a verdict")["env"]
+    assert env["GHA_RUN_URL"].endswith("/actions/runs/${{ github.run_id }}")
+    assert env["STARTER_STARTED_AT"] == "${{ steps.starter.outputs.started_at }}"
+
+
 def test_the_summary_template_still_carries_the_run_url():
     """The ownership key only works because §3e mandates this footer line.
 

--- a/.github/scripts/tests/test_sdk_review_gate.py
+++ b/.github/scripts/tests/test_sdk_review_gate.py
@@ -249,3 +249,281 @@ def test_head_resolved_true_uses_normal_flow(tmp_path, monkeypatch: pytest.Monke
     written = out.read_text()
     assert "decision=skip" in written
     assert "reason=unchanged-head-bot-retrigger" in written
+
+
+# --- resolve_head() ------------------------------------------------------
+
+
+def sha_runner(*results):
+    """A runner that returns each (stdout, returncode) in turn."""
+    queue = list(results)
+    calls: list[list[str]] = []
+
+    def _run(args, *_a, **_kw):
+        calls.append(args)
+        stdout, code = queue.pop(0)
+        return subprocess.CompletedProcess(
+            args=args, returncode=code, stdout=stdout, stderr=""
+        )
+
+    _run.calls = calls  # type: ignore[attr-defined]
+    return _run
+
+
+def test_resolve_head_returns_the_sha_on_the_first_attempt():
+    runner = sha_runner((f"{HEAD}\n", 0))
+    slept: list[float] = []
+    assert gate.resolve_head("o/r", "1", runner, slept.append) == (HEAD, True)
+    assert slept == []
+
+
+def test_resolve_head_retries_a_transient_failure():
+    runner = sha_runner(("", 1), ("", 1), (f"{HEAD}\n", 0))
+    slept: list[float] = []
+    assert gate.resolve_head("o/r", "1", runner, slept.append) == (HEAD, True)
+    assert slept == [5, 10]
+
+
+def test_resolve_head_treats_empty_stdout_as_a_failure():
+    """A 0 exit with no sha is not a resolution — `gh` does that on some 5xx."""
+    runner = sha_runner(("\n", 0), (f"{HEAD}\n", 0))
+    assert gate.resolve_head("o/r", "1", runner, lambda _s: None) == (HEAD, True)
+
+
+def test_resolve_head_gives_up_after_three_attempts():
+    runner = sha_runner(("", 1), ("", 1), ("", 1))
+    assert gate.resolve_head("o/r", "1", runner, lambda _s: None) == ("", False)
+    assert len(runner.calls) == gate.HEAD_ATTEMPTS
+
+
+# --- inflight_sibling_run() ----------------------------------------------
+
+
+def starter(
+    head: str, run_id: str, stamped: bool = False, folded: bool = False
+) -> dict:
+    """A `review starting` comment as the dispatch job writes it."""
+    lines = [
+        gate.STARTER_MARKER,
+        f"<!-- SDK_REVIEW_STARTED_HEAD: {head} -->",
+        f"<!-- SDK_REVIEW_STARTED_RUN: {run_id} -->",
+        "🔍 **SDK Review (mothership)** triggered by @someone at 2026-08-19T18:20:48Z.",
+    ]
+    if folded:
+        # The starter step folds earlier starters by dropping line 1 and
+        # re-emitting the rest inside a <details> block — the head/run stamps
+        # survive that, which is what keeps a folded-but-live claim visible.
+        lines = [
+            gate.STARTER_MARKER,
+            "<!-- SDK_REVIEW_STARTED_FOLDED -->",
+            "<details><summary>Earlier @sdk-review trigger</summary>",
+            "",
+            *lines[1:],
+            "</details>",
+        ]
+    if stamped:
+        lines += [
+            "",
+            "---",
+            "✅ **Completed** — status `completed`, cost `$1.20`, duration 8m 3s.",
+        ]
+    return {"body": "\n".join(lines)}
+
+
+def test_inflight_detects_an_unstamped_starter_from_another_run():
+    comments = [starter(HEAD, "32286821875")]
+    assert gate.inflight_sibling_run(comments, HEAD, "32286845311") == "32286821875"
+
+
+def test_inflight_ignores_our_own_starter():
+    comments = [starter(HEAD, "32286845311")]
+    assert gate.inflight_sibling_run(comments, HEAD, "32286845311") is None
+
+
+def test_inflight_ignores_a_finished_run():
+    """The cost stamp is `always()`, so its presence means that run ended."""
+    comments = [starter(HEAD, "32286821875", stamped=True)]
+    assert gate.inflight_sibling_run(comments, HEAD, "32286845311") is None
+
+
+def test_inflight_ignores_a_claim_on_a_different_head():
+    comments = [starter(OTHER, "32286821875")]
+    assert gate.inflight_sibling_run(comments, HEAD, "32286845311") is None
+
+
+def test_inflight_sees_a_folded_but_unfinished_claim():
+    """A newer trigger folds the older starter; the older run is still live."""
+    comments = [starter(HEAD, "32286821875", folded=True)]
+    assert gate.inflight_sibling_run(comments, HEAD, "32286845311") == "32286821875"
+
+
+def test_inflight_ignores_starters_written_before_the_stamps_existed():
+    """Rollout safety: a legacy starter must not skip a legitimate trigger."""
+    legacy = {
+        "body": f"{gate.STARTER_MARKER}\n🔍 **SDK Review (mothership)** triggered."
+    }
+    assert gate.inflight_sibling_run([legacy], HEAD, "32286845311") is None
+
+
+def test_inflight_ignores_the_verdict_comment():
+    assert gate.inflight_sibling_run([summary(HEAD)], HEAD, "1") is None
+
+
+def test_inflight_needs_a_head_to_compare():
+    comments = [starter(HEAD, "32286821875")]
+    assert gate.inflight_sibling_run(comments, "", "32286845311") is None
+
+
+def test_inflight_returns_the_newest_matching_claim():
+    comments = [starter(HEAD, "111"), starter(HEAD, "222")]
+    assert gate.inflight_sibling_run(comments, HEAD, "333") == "222"
+
+
+# --- decide() with a sibling in flight -----------------------------------
+
+
+def test_bot_skips_while_a_sibling_run_is_in_flight():
+    decision, reason, message = gate.decide(
+        "issue_comment", "mothership-ai[bot]", HEAD, None, "32286821875"
+    )
+    assert decision == "skip"
+    assert reason == "sibling-run-in-flight"
+    assert "32286821875" in message
+
+
+def test_human_proceeds_even_while_a_sibling_run_is_in_flight():
+    decision, reason, _ = gate.decide(
+        "issue_comment", "vaibhavatlan", HEAD, None, "32286821875"
+    )
+    assert decision == "proceed"
+    assert reason == "human-trigger"
+
+
+def test_already_reviewed_wins_over_sibling_in_flight():
+    """Both are skips; the reviewed-head reason is the more useful one."""
+    _, reason, _ = gate.decide("issue_comment", "atlan-ci", HEAD, HEAD, "32286821875")
+    assert reason == "unchanged-head-bot-retrigger"
+
+
+def test_no_sibling_in_flight_still_proceeds_on_a_new_head():
+    decision, reason, _ = gate.decide("issue_comment", "atlan-ci", HEAD, OTHER, None)
+    assert decision == "proceed"
+    assert reason == "bot-trigger-new-head"
+
+
+# --- main(): phases ------------------------------------------------------
+
+
+def _bot_env(monkeypatch: pytest.MonkeyPatch, out_path, **extra: str) -> None:
+    monkeypatch.setenv("GITHUB_OUTPUT", str(out_path))
+    monkeypatch.setenv("REPO", "atlanhq/application-sdk")
+    monkeypatch.setenv("PR_NUMBER", "3285")
+    monkeypatch.setenv("HEAD_SHA", HEAD)
+    monkeypatch.setenv("EVENT_NAME", "issue_comment")
+    monkeypatch.setenv("TRIGGER_ACTOR", "mothership-ai[bot]")
+    monkeypatch.delenv("HEAD_RESOLVED", raising=False)
+    for key, value in extra.items():
+        monkeypatch.setenv(key, value)
+
+
+def test_locked_phase_skips_a_burst_trigger_while_the_first_run_is_live(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+):
+    """The #3285 shape: five bot triggers, only the first earns a run."""
+    out = tmp_path / "gh_output"
+    _bot_env(monkeypatch, out, GATE_PHASE="locked", RUN_ID="32286845311")
+
+    assert gate.main(fake_runner([[starter(HEAD, "32286821875")]])) == 0
+
+    written = out.read_text()
+    assert "decision=skip" in written
+    assert "reason=sibling-run-in-flight" in written
+
+
+def test_preflight_phase_does_not_gate_on_a_sibling_run(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+):
+    """Outside the lock a live sibling is the normal state, not a duplicate."""
+    out = tmp_path / "gh_output"
+    _bot_env(monkeypatch, out, GATE_PHASE="preflight", RUN_ID="32286845311")
+
+    assert gate.main(fake_runner([[starter(HEAD, "32286821875")]])) == 0
+
+    written = out.read_text()
+    assert "decision=proceed" in written
+    assert "reason=bot-trigger-new-head" in written
+
+
+def test_phase_defaults_to_preflight(tmp_path, monkeypatch: pytest.MonkeyPatch):
+    out = tmp_path / "gh_output"
+    _bot_env(monkeypatch, out, RUN_ID="32286845311")
+    monkeypatch.delenv("GATE_PHASE", raising=False)
+
+    assert gate.main(fake_runner([[starter(HEAD, "32286821875")]])) == 0
+    assert "decision=proceed" in out.read_text()
+
+
+def test_locked_phase_still_skips_an_already_reviewed_head(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+):
+    out = tmp_path / "gh_output"
+    _bot_env(monkeypatch, out, GATE_PHASE="locked", RUN_ID="32286845311")
+
+    assert gate.main(fake_runner([[summary(HEAD)]])) == 0
+
+    written = out.read_text()
+    assert "decision=skip" in written
+    assert "reason=unchanged-head-bot-retrigger" in written
+
+
+# --- main(): head resolution now lives here ------------------------------
+
+
+def test_main_resolves_head_when_the_caller_supplies_none(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+):
+    out = tmp_path / "gh_output"
+    _bot_env(monkeypatch, out, GATE_PHASE="locked", RUN_ID="1")
+    monkeypatch.setenv("HEAD_SHA", "")
+
+    def _run(args, *_a, **_kw):
+        if "pulls/3285" in " ".join(args):
+            return subprocess.CompletedProcess(args, 0, f"{HEAD}\n", "")
+        return subprocess.CompletedProcess(args, 0, json.dumps([[summary(HEAD)]]), "")
+
+    assert gate.main(_run, lambda _s: None) == 0
+
+    written = out.read_text()
+    assert f"head_sha={HEAD}" in written
+    assert "head_resolved=true" in written
+    assert "reason=unchanged-head-bot-retrigger" in written
+
+
+def test_main_fails_open_when_it_cannot_resolve_head_itself(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+):
+    """No HEAD_RESOLVED env needed any more — exhaustion is seen in-script."""
+    out = tmp_path / "gh_output"
+    _bot_env(monkeypatch, out, GATE_PHASE="locked", RUN_ID="1")
+    monkeypatch.setenv("HEAD_SHA", "")
+
+    def _run(args, *_a, **_kw):
+        assert "pulls/3285" in " ".join(args), "must not read comments without a head"
+        return subprocess.CompletedProcess(args, 1, "", "boom")
+
+    assert gate.main(_run, lambda _s: None) == 0
+
+    written = out.read_text()
+    assert "decision=proceed" in written
+    assert "reason=head-resolution-failed" in written
+    assert "head_resolved=false" in written
+
+
+def test_main_exports_the_head_it_decided_against(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+):
+    out = tmp_path / "gh_output"
+    _bot_env(monkeypatch, out, GATE_PHASE="preflight", RUN_ID="1")
+
+    assert gate.main(fake_runner([[]])) == 0
+    assert f"head_sha={HEAD}" in out.read_text()

--- a/.github/scripts/tests/test_sdk_review_summaries.py
+++ b/.github/scripts/tests/test_sdk_review_summaries.py
@@ -1,0 +1,208 @@
+"""Tests for shared summary attribution — whose review comment is whose.
+
+Two steps read this and act on opposite answers: the dedupe step minimizes the
+extras when too many are ours, the delivery gate fails the run when none are.
+Both failure directions are covered here because they are the same defect seen
+from two sides.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+SPEC = importlib.util.spec_from_file_location(
+    "sdk_review_summaries",
+    Path(__file__).resolve().parents[1] / "sdk_review_summaries.py",
+)
+summaries = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(summaries)
+
+RUN_URL = "https://github.com/atlanhq/application-sdk/actions/runs/32286845311"
+OTHER_RUN_URL = "https://github.com/atlanhq/application-sdk/actions/runs/32286821875"
+HEAD = "4237280fd9dd1eb52c8b3a0eb44e4f4a3c2d1b0a"
+OTHER_HEAD = "51c160b06a2a350289c7d779f4ab887503f98685"
+
+# The starter step stamps `new Date().toISOString()`; GitHub's created_at has
+# no sub-second part. Keeping the milliseconds here is the point.
+SINCE = summaries.parse_ts("2026-08-19T18:09:39.371Z")
+assert SINCE is not None
+
+
+def verdict(
+    comment_id: int,
+    created_at: str,
+    run_url: str | None = RUN_URL,
+    head: str | None = HEAD,
+    marker: str = "<!-- SDK_REVIEW -->",
+) -> dict:
+    """A summary comment as ORCHESTRATION.md §3e specifies it."""
+    lines = [marker, "<!-- VERDICT: READY_TO_MERGE -->"]
+    if head is not None:
+        lines.append(f"<!-- REVIEWED_HEAD: {head} -->")
+    lines += ["## SDK Review (mothership)", "", "---", "**CI:** all passing"]
+    if run_url is not None:
+        lines.append(f"**Run:** [view workflow logs + cost]({run_url})")
+    return {"id": comment_id, "created_at": created_at, "body": "\n".join(lines)}
+
+
+def ids(result: tuple[list[dict], str]) -> list[int]:
+    return [c["id"] for c in result[0]]
+
+
+# --- at_or_after() -------------------------------------------------------
+
+
+def test_the_bounds_own_second_is_not_widened_into_the_window():
+    """The window leans away from claiming a summary, not towards it.
+
+    `…:39Z` parses to 39.000, before a `…:39.371Z` bound, so it stays out. A
+    summary landing in the starter's own second is a *previous* run's — ours
+    cannot exist yet, because the sandbox has not booted. And when ours does
+    land, the run URL identifies it without consulting this window at all.
+    """
+    assert not summaries.at_or_after("2026-08-19T18:09:39Z", SINCE)
+
+
+def test_string_comparison_would_have_admitted_it():
+    """Pinning why this is parsed: as text, "Z" > "." and the guard inverts."""
+    assert "2026-08-19T18:09:39Z" >= "2026-08-19T18:09:39.371Z"
+
+
+def test_the_second_before_the_bound_is_excluded():
+    assert not summaries.at_or_after("2026-08-19T18:09:38Z", SINCE)
+
+
+def test_the_bound_is_inclusive():
+    assert summaries.at_or_after("2026-08-19T18:09:39.371Z", SINCE)
+
+
+def test_an_unparseable_timestamp_is_not_in_the_window():
+    assert not summaries.at_or_after("not a timestamp", SINCE)
+
+
+# --- claimed_run_urls() --------------------------------------------------
+
+
+def test_the_footer_url_is_read_out_of_the_markdown_link():
+    body = f"**Run:** [view workflow logs + cost]({RUN_URL})"
+    assert summaries.claimed_run_urls(body) == {RUN_URL}
+
+
+def test_the_closing_paren_is_not_part_of_the_url():
+    assert RUN_URL in summaries.claimed_run_urls(f"[x]({RUN_URL})")
+
+
+def test_a_body_naming_no_run_claims_nothing():
+    assert summaries.claimed_run_urls("<!-- SDK_REVIEW -->\n## SDK Review") == set()
+
+
+# --- attribute(): the exact tier ----------------------------------------
+
+
+def test_our_run_url_identifies_our_summaries():
+    comments = [
+        verdict(1, "2026-08-19T17:33:00Z", run_url=OTHER_RUN_URL),
+        {"id": 2, "created_at": "2026-08-19T18:10:00Z", "body": "@sdk-review"},
+        verdict(3, "2026-08-19T18:14:35Z"),
+    ]
+    result = summaries.attribute(comments, RUN_URL, SINCE, HEAD)
+    assert ids(result) == [3]
+    assert result[1] == summaries.BY_RUN_URL
+
+
+def test_the_exact_tier_ignores_the_window():
+    """A replayed turn can post long after the starter; the URL still binds."""
+    result = summaries.attribute([verdict(1, "2026-08-19T02:00:00Z")], RUN_URL, SINCE)
+    assert ids(result) == [1]
+    assert result[1] == summaries.BY_RUN_URL
+
+
+def test_the_exact_tier_ignores_a_head_the_review_moved_to():
+    """§6c lets a review update the branch, so REVIEWED_HEAD may not be ours."""
+    comments = [verdict(1, "2026-08-19T18:14:35Z", head=OTHER_HEAD)]
+    result = summaries.attribute(comments, RUN_URL, SINCE, HEAD)
+    assert ids(result) == [1]
+
+
+def test_same_second_duplicates_come_back_in_posting_order():
+    comments = [
+        verdict(30, "2026-08-19T18:14:50Z"),
+        verdict(10, "2026-08-19T18:14:50Z"),
+        verdict(20, "2026-08-19T18:14:50Z"),
+    ]
+    assert ids(summaries.attribute(comments, RUN_URL, SINCE)) == [10, 20, 30]
+
+
+def test_the_legacy_marker_counts_as_a_summary():
+    """`sdk_review_approve.py` accepts it, so refusing it here would red a
+    run the approver would have stamped."""
+    comments = [verdict(1, "2026-08-19T18:14:35Z", marker="<!-- TEST_SDK_REVIEW -->")]
+    assert ids(summaries.attribute(comments, RUN_URL, SINCE)) == [1]
+
+
+# --- attribute(): the fallback tier -------------------------------------
+
+
+def test_another_runs_summary_is_never_ours():
+    """The false-green: a zombie sandbox's verdict vouching for our silence.
+
+    Its summary names another run, so no timestamp or head can make it ours.
+    """
+    comments = [verdict(1, "2026-08-19T18:14:35Z", run_url=OTHER_RUN_URL)]
+    result = summaries.attribute(comments, RUN_URL, SINCE, HEAD)
+    assert result == ([], summaries.UNATTRIBUTED)
+
+
+def test_a_footerless_summary_in_our_window_for_our_head_is_admitted():
+    comments = [verdict(1, "2026-08-19T18:14:35Z", run_url=None)]
+    result = summaries.attribute(comments, RUN_URL, SINCE, HEAD)
+    assert ids(result) == [1]
+    assert result[1] == summaries.BY_WINDOW
+
+
+def test_the_fallback_excludes_another_head():
+    comments = [verdict(1, "2026-08-19T18:14:35Z", run_url=None, head=OTHER_HEAD)]
+    assert summaries.attribute(comments, RUN_URL, SINCE, HEAD) == (
+        [],
+        summaries.UNATTRIBUTED,
+    )
+
+
+def test_the_fallback_admits_a_summary_predating_the_head_marker():
+    comments = [verdict(1, "2026-08-19T18:14:35Z", run_url=None, head=None)]
+    assert ids(summaries.attribute(comments, RUN_URL, SINCE, HEAD)) == [1]
+
+
+def test_the_fallback_excludes_summaries_before_the_bound():
+    comments = [verdict(1, "2026-08-19T17:33:00Z", run_url=None)]
+    assert summaries.attribute(comments, RUN_URL, SINCE, HEAD) == (
+        [],
+        summaries.UNATTRIBUTED,
+    )
+
+
+def test_no_bound_and_no_url_match_attributes_nothing():
+    comments = [verdict(1, "2026-08-19T18:14:35Z", run_url=None)]
+    assert summaries.attribute(comments, RUN_URL, None) == ([], summaries.UNATTRIBUTED)
+
+
+def test_no_run_url_at_all_falls_straight_through_to_the_window():
+    """The delivery gate's older callers pass no URL; they must still work."""
+    comments = [verdict(1, "2026-08-19T18:14:35Z", run_url=None)]
+    result = summaries.attribute(comments, "", SINCE)
+    assert ids(result) == [1]
+    assert result[1] == summaries.BY_WINDOW
+
+
+def test_non_summary_comments_are_never_attributed():
+    comments = [
+        {"id": 1, "created_at": "2026-08-19T18:14:35Z", "body": "lgtm"},
+        {
+            "id": 2,
+            "created_at": "2026-08-19T18:14:36Z",
+            "body": f"<!-- SDK_REVIEW_STARTED -->\n[run]({RUN_URL})",
+        },
+    ]
+    assert summaries.attribute(comments, RUN_URL, SINCE) == ([], summaries.UNATTRIBUTED)

--- a/.github/scripts/tests/test_sdk_review_verdict_gate.py
+++ b/.github/scripts/tests/test_sdk_review_verdict_gate.py
@@ -36,13 +36,21 @@ BEFORE = "2026-08-19T17:10:00Z"
 AFTER = "2026-08-19T19:04:11Z"
 
 
-def summary_comment(created_at: str, marker: str = "<!-- SDK_REVIEW -->") -> dict:
+HEAD = "0cab6b6e4eff94f28f249e1319ab74d55e1f7abc"
+OTHER_HEAD = "51c160b06a2a350289c7d779f4ab887503f98685"
+
+
+def summary_comment(
+    created_at: str,
+    marker: str = "<!-- SDK_REVIEW -->",
+    head: str = HEAD,
+) -> dict:
     return {
         "created_at": created_at,
         "body": (
             f"{marker}\n"
             "<!-- VERDICT: READY_TO_MERGE -->\n"
-            "<!-- REVIEWED_HEAD: 0cab6b6e4eff94f28f249e1319ab74d55e1f7abc -->\n"
+            f"<!-- REVIEWED_HEAD: {head} -->\n"
             "## SDK Review (mothership)\n"
         ),
     }
@@ -96,6 +104,7 @@ def env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
         "FINAL_STATUS": "completed",
         "FINAL_COST": "7.98",
         "STARTER_STARTED_AT": STARTED_AT,
+        "HEAD_SHA": HEAD,
         "GHA_RUN_URL": "https://github.com/atlanhq/application-sdk/actions/runs/32285618316",
         "GITHUB_OUTPUT": str(output),
     }.items():
@@ -183,6 +192,29 @@ def test_mixed_precision_timestamps_are_compared_as_instants(env: Path):
 
     gh = FakeGh(comments=[summary_comment("2026-08-19T18:56:04Z")])
     assert verdict_gate.main(gh, lambda _s: None) == 0
+
+
+def test_a_summary_for_another_head_does_not_vouch_for_this_run(env: Path):
+    """The narrowing this gate was dropping.
+
+    A footerless summary inside our window, for a head this run was not
+    dispatched for — a zombie sandbox still posting for the sha it was
+    reviewing. It counted here while the dedupe step, passing the same
+    `head_sha` to the same shared decision, called it nobody's. The gate is the
+    one that exits non-zero, so it has to be at least as strict.
+    """
+    gh = FakeGh(comments=[summary_comment(AFTER, head=OTHER_HEAD)])
+
+    assert verdict_gate.main(gh, lambda _s: None) == 1
+    assert outputs(env)["verdict_delivered"] == "false"
+
+
+def test_our_own_head_in_the_window_still_vouches(env: Path):
+    """The inverse, so the narrowing cannot be over-tightened unnoticed."""
+    gh = FakeGh(comments=[summary_comment(AFTER)])
+
+    assert verdict_gate.main(gh, lambda _s: None) == 0
+    assert outputs(env)["verdict_delivered"] == "true"
 
 
 def test_legacy_test_marker_counts_as_delivered(env: Path):

--- a/.github/workflows/sdk-review.yml
+++ b/.github/workflows/sdk-review.yml
@@ -85,10 +85,16 @@ jobs:
   #
   # NOTE — this job is an OPTIMIZATION, not the authority. It runs outside
   # the per-PR concurrency group (sdk-review-$PR), so two concurrent bot
-  # triggers can both pass it ("no review yet") and both reach the sandbox.
-  # The authoritative dedupe check lives inside the sandbox (ORCHESTRATION.md
-  # Phase 0 §6b bot-trigger dedupe guard), which runs under the concurrency
-  # lock and sees true post-lock comment state.
+  # triggers can both pass it ("no review yet") and both reach the dispatch
+  # job. The authority is the `Dedupe check` step at the top of
+  # `sdk-review-dispatch`: it runs under the concurrency lock, so no sibling
+  # run in the group can be executing while it reads comment state, and it
+  # re-resolves HEAD rather than trusting this job's answer.
+  #
+  # It used to be the sandbox (ORCHESTRATION.md Phase 0 §6b), which meant the
+  # dedupe was only as reliable as the model: the sandbox had to boot and
+  # reason before it could decline — so five duplicate triggers on #3285 cost
+  # five runs — and a degraded model skipped the check outright (FND-636).
   gate:
     if: >-
       github.event_name == 'workflow_dispatch'
@@ -112,38 +118,17 @@ jobs:
       - name: Checkout repo (for the gate script)
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Resolve PR head
-        id: head
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.issue.number || inputs.pr_number }}
-        run: |
-          # 3 attempts, 5 s / 10 s backoff. On exhaustion emit head_resolved=false
-          # rather than failing the job — the gate script then proceeds fail-open
-          # (reviewing is the safe default; a missing review is the harmful outcome).
-          for attempt in 1 2 3; do
-            if SHA=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.head.sha' 2>/dev/null) \
-               && [ -n "$SHA" ]; then
-              echo "head_sha=${SHA}" >> "$GITHUB_OUTPUT"
-              echo "head_resolved=true" >> "$GITHUB_OUTPUT"
-              exit 0
-            fi
-            echo "::warning::Head resolution attempt ${attempt}/3 failed"
-            [ "$attempt" -lt 3 ] && sleep $((attempt * 5))
-          done
-          echo "::warning::All 3 head-resolution attempts failed — gate will proceed fail-open"
-          echo "head_sha=" >> "$GITHUB_OUTPUT"
-          echo "head_resolved=false" >> "$GITHUB_OUTPUT"
-
+      # Head resolution (3 attempts, 5 s / 10 s backoff) happens inside the
+      # script, not in a shell loop here: docs/standards/ci.md keeps branching
+      # logic out of YAML, and the locked phase below needs the identical
+      # resolution — one implementation, two callers.
       - name: Decide whether to review
         id: gate
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.issue.number || inputs.pr_number }}
-          HEAD_SHA: ${{ steps.head.outputs.head_sha }}
-          HEAD_RESOLVED: ${{ steps.head.outputs.head_resolved }}
+          GATE_PHASE: preflight
           EVENT_NAME: ${{ github.event_name }}
           TRIGGER_ACTOR: ${{ github.event.comment.user.login }}
         run: python3 .github/scripts/sdk_review_gate.py
@@ -275,12 +260,63 @@ jobs:
             core.setOutput('pr_number', prNumber);
             core.setOutput('commenter_intent', intent);
 
+      # THE authoritative dedupe check. Everything below it is guarded on its
+      # decision (`steps.lock_gate.outputs.decision != 'skip'`), so a skip
+      # costs one runner minute and leaves no trace on the PR beyond a 😕
+      # reaction — no starter comment, no pending commit status, no sandbox.
+      #
+      # It has to be HERE, not in the `gate` job: this job holds
+      # `sdk-review-$PR`, so while this step runs no sibling run in the group
+      # can be executing, and the comment state it reads is post-lock and
+      # final. The `gate` job cannot make that claim, which is how five
+      # `@sdk-review` comments 11–16 s apart on #3285 became five review runs
+      # (FND-636) — every one of them passed a gate that had read pre-lock
+      # state.
+      #
+      # Same script as the gate, one phase apart. `locked` adds the
+      # sibling-in-flight check for the one case the lock does not cover: a
+      # sandbox that outlived its cancelled job and is still going to post.
+      #
+      # Human triggers are never skipped here — see the carve-out in
+      # sdk_review_gate.py. Tagging `@sdk-review` yourself always reviews.
+      #
+      # continue-on-error: a crash here leaves `decision` empty, every guard
+      # below reads that as "not skip", and the review runs. Dropping a review
+      # is the harmful outcome; an extra one is not — same fail-open doctrine
+      # the script applies when it cannot resolve HEAD.
+      - name: Dedupe check (authoritative — inside the concurrency lock)
+        id: lock_gate
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ steps.parse.outputs.pr_number }}
+          GATE_PHASE: locked
+          EVENT_NAME: ${{ github.event_name }}
+          TRIGGER_ACTOR: ${{ github.event.comment.user.login }}
+          RUN_ID: ${{ github.run_id }}
+        run: python3 .github/scripts/sdk_review_gate.py
+
+      # Same 😕 the `react-on-skip` job leaves for a gate-level skip, for the
+      # same reason: without it a declined trigger is indistinguishable from a
+      # dead reviewer, and the resolver re-tags. No comment — that would be
+      # noise the resolver may re-read as pending work.
+      - name: React to skipped re-trigger
+        if: steps.lock_gate.outputs.decision == 'skip' && steps.parse.outputs.comment_id != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          COMMENT_ID: ${{ steps.parse.outputs.comment_id }}
+          REACTION: confused
+        run: python3 .github/scripts/react_to_comment.py
+
       # Best-effort, never fatal. This used to be the opening lines of the
       # step below, unguarded — and a transient HTTP 503 from the reactions
       # API killed the whole dispatch job before it reached the mothership
       # call, losing the review request entirely. The script always exits 0.
       # `COMMENT_ID` is blank on workflow_dispatch, which the script no-ops on.
       - name: React to comment
+        if: steps.lock_gate.outputs.decision != 'skip'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
@@ -289,6 +325,7 @@ jobs:
         run: python3 .github/scripts/react_to_comment.py
 
       - name: Ensure labels exist
+        if: steps.lock_gate.outputs.decision != 'skip'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
@@ -309,6 +346,7 @@ jobs:
 
       - name: Fetch PR head metadata
         id: pr
+        if: steps.lock_gate.outputs.decision != 'skip'
         env:
           PR_NUMBER: ${{ steps.parse.outputs.pr_number }}
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
@@ -352,6 +390,7 @@ jobs:
       # session failure the RUN_ID addition fixed for multi-trigger cases.
       - name: Compute mothership session id
         id: session
+        if: steps.lock_gate.outputs.decision != 'skip'
         env:
           PR_NUMBER: ${{ steps.parse.outputs.pr_number }}
           HEAD_SHA_SHORT: ${{ steps.pr.outputs.head_sha_short }}
@@ -364,9 +403,12 @@ jobs:
 
       - name: Post 'review starting' notice to PR
         id: starter
+        if: steps.lock_gate.outputs.decision != 'skip'
         env:
           PR_NUMBER: ${{ steps.parse.outputs.pr_number }}
           COMMENTER: ${{ steps.parse.outputs.commenter }}
+          HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
+          RUN_ID: ${{ github.run_id }}
           GHA_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
@@ -393,6 +435,14 @@ jobs:
             const runUrl = process.env.GHA_RUN_URL;
             const prNumber = parseInt(process.env.PR_NUMBER, 10);
             const startedAt = new Date().toISOString();
+            // The starter doubles as this run's claim on a sha: `locked`-phase
+            // sdk_review_gate.py reads these two stamps, plus the absence of
+            // the '— status `' footer the cost stamper appends, to recognise a
+            // sibling run that is still mid-review. Without the sha it could
+            // not tell a claim on THIS head from one on a previous head, and
+            // without the run id it would read its own claim as a sibling's.
+            const headStamp = `<!-- SDK_REVIEW_STARTED_HEAD: ${process.env.HEAD_SHA} -->`;
+            const runStamp = `<!-- SDK_REVIEW_STARTED_RUN: ${process.env.RUN_ID} -->`;
 
             // Fold any previous (unfolded) starter comments on this PR.
             const existing = await github.rest.issues.listComments({
@@ -427,6 +477,8 @@ jobs:
 
             const body = [
               marker,
+              headStamp,
+              runStamp,
               `🔍 **SDK Review (mothership)** triggered by @${commenter} at ${startedAt}.`,
               ``,
               `[Watch the workflow run live](${runUrl}) — the review summary will appear as a separate comment when complete (typical: 5–30 min, hard cap 2h).`,
@@ -443,6 +495,7 @@ jobs:
             console.log(`Posted new 'starting' comment id=${result.data.id}`);
 
       - name: Set sdk-review status to pending
+        if: steps.lock_gate.outputs.decision != 'skip'
         env:
           HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
@@ -470,6 +523,7 @@ jobs:
       # guarantee the step terminates and the next attempt fires.
       - name: Connect to VPN (attempt 1/3)
         id: vpn1
+        if: steps.lock_gate.outputs.decision != 'skip'
         uses: ./.github/actions/globalprotect-connect
         continue-on-error: true
         timeout-minutes: 5
@@ -556,6 +610,7 @@ jobs:
 
       - name: Dispatch to mothership Rover Direct API
         id: dispatch
+        if: steps.lock_gate.outputs.decision != 'skip'
         env:
           MOTHERSHIP_URL: ${{ vars.MOTHERSHIP_URL }}
           HARNESS_TOKEN: ${{ secrets.HARNESS_TOKEN }}
@@ -936,27 +991,25 @@ jobs:
           # github.run_started_at because it is deterministically populated by
           # a step in this run. The previous code keyed this bound off
           # github.run_started_at, which evaluated to empty here (seen in the
-          # run's env dump); the empty value made the `[ -n ... ]` guard below
-          # false, so this whole soft-success block was skipped and every
-          # delivered-then-dropped review hard-failed.
-          VERDICT_POSTED=0
-          RUN_STARTED_AT="${STARTER_STARTED_AT:-}"
-          if [ -n "${PR_NUMBER}" ] && [ -n "${RUN_STARTED_AT}" ]; then
-            # --slurp collapses all pages into one array so the jq filter emits a
-            # SINGLE count. NOTE: `gh api` rejects `--slurp` together with `--jq`
-            # ("the --slurp option is not supported with --jq"), so the slurped
-            # array is piped into a standalone `jq`. The prior `--slurp --jq` form
-            # errored, was swallowed by `2>/dev/null`, and `|| echo 0` forced a
-            # false "no verdict" -> every delivered-then-dropped review hard-failed
-            # (see RCA for run 29001242204).
-            SUMMARY_COUNT=$(gh api "repos/${REPO_FULL_NAME}/issues/${PR_NUMBER}/comments" \
-              --paginate --slurp 2>/dev/null \
-              | jq "[.[][] | select(.body | contains(\"<!-- SDK_REVIEW -->\")) | select(.created_at >= \"${RUN_STARTED_AT}\")] | length" \
-              2>/dev/null || echo "0")
-            if [ "${SUMMARY_COUNT:-0}" -gt 0 ]; then
-              VERDICT_POSTED=1
-            fi
-          fi
+          # run's env dump); the empty value made the then-inline `[ -n ... ]`
+          # guard false, so this whole soft-success block was skipped and every
+          # delivered-then-dropped review hard-failed. An empty SINCE now
+          # reports "no verdict" from one place, in the script.
+          #
+          # Counting this run's summaries and collapsing duplicates are the
+          # same read, so one script does both (FND-636): it reports
+          # verdict_posted for the soft-success rule below, and minimizes
+          # every copy but the newest when a replayed sandbox turn posted the
+          # summary more than once. It always exits 0 — a tidy-up failure must
+          # not turn a delivered review into a red check.
+          DEDUPE_OUT="$(mktemp)"
+          SINCE="${STARTER_STARTED_AT:-}" DEDUPE_OUTPUT="$DEDUPE_OUT" \
+            REPO="${REPO_FULL_NAME}" \
+            python3 .github/scripts/sdk_review_dedupe_verdicts.py
+          # sed, not grep: an unexpectedly empty file must not trip `set -e`
+          # here and lose the outcome of a review that already landed.
+          VERDICT_POSTED="$(sed -n 's/^verdict_posted=//p' "$DEDUPE_OUT" | head -1)"
+          VERDICT_POSTED="${VERDICT_POSTED:-0}"
 
           # Export the run summary fields BEFORE the failure checks below
           # call `fail_or_warn`, which can `exit 1`. If we exported after,
@@ -1149,7 +1202,7 @@ jobs:
         # quota ORG_PAT_GITHUB draws on. Needs `issues: write` as well as
         # `pull_requests: write` — labels are an Issues-scope resource.
         id: app-token
-        if: success() && steps.parse.outputs.pr_number != ''
+        if: success() && steps.parse.outputs.pr_number != '' && steps.lock_gate.outputs.decision != 'skip'
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           app-id: ${{ secrets.FLEET_APP_ID }}
@@ -1181,7 +1234,7 @@ jobs:
       # bot-signature approval, so whichever gets there first wins and the
       # other no-ops.
       - name: Approve PR as atlan-ci (counts as code-owner)
-        if: success() && steps.parse.outputs.pr_number != ''
+        if: success() && steps.parse.outputs.pr_number != '' && steps.lock_gate.outputs.decision != 'skip'
         env:
           # Everything except the APPROVE call. Keeping the reads, label writes
           # and dismissals off the `atlan-ci` PAT is what stops the one call

--- a/.github/workflows/sdk-review.yml
+++ b/.github/workflows/sdk-review.yml
@@ -1002,6 +1002,13 @@ jobs:
           # every copy but the newest when a replayed sandbox turn posted the
           # summary more than once. It always exits 0 — a tidy-up failure must
           # not turn a delivered review into a red check.
+          #
+          # GHA_RUN_URL is the ownership key, not the timestamp: every summary
+          # carries it (ORCHESTRATION.md §3e), so it distinguishes our replayed
+          # duplicate from a zombie sandbox's or a concurrent human-triggered
+          # run's summary landing in the same window. SINCE and HEAD_SHA only
+          # feed the fallback used when no summary carries our URL. All three
+          # are already in this step's env.
           DEDUPE_OUT="$(mktemp)"
           SINCE="${STARTER_STARTED_AT:-}" DEDUPE_OUTPUT="$DEDUPE_OUT" \
             REPO="${REPO_FULL_NAME}" \

--- a/.github/workflows/sdk-review.yml
+++ b/.github/workflows/sdk-review.yml
@@ -1110,6 +1110,7 @@ jobs:
           FINAL_STATUS: ${{ steps.dispatch.outputs.final_status }}
           FINAL_COST: ${{ steps.dispatch.outputs.final_cost }}
           STARTER_STARTED_AT: ${{ steps.starter.outputs.started_at }}
+          HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
           GHA_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: python3 .github/scripts/sdk_review_verdict_gate.py
 

--- a/.github/workflows/sdk-review.yml
+++ b/.github/workflows/sdk-review.yml
@@ -1095,9 +1095,14 @@ jobs:
       # fails open whenever it cannot establish the count — a false red on a
       # delivered review is the failure mode the run-29001242204 RCA was
       # written about.
+      # Guarded like the other post-review steps: a re-trigger the locked
+      # dedupe check declined never dispatched a sandbox, so there is no
+      # verdict for it to be missing. (`final_status` would be empty and the
+      # gate would bow out on its own, but a check that reds a run must not
+      # depend on that indirection.)
       - name: Verify the review delivered a verdict
         id: verdict
-        if: success() && steps.parse.outputs.pr_number != ''
+        if: success() && steps.parse.outputs.pr_number != '' && steps.lock_gate.outputs.decision != 'skip'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}

--- a/.mothership/pr-review/ORCHESTRATION.md
+++ b/.mothership/pr-review/ORCHESTRATION.md
@@ -231,12 +231,24 @@ BUDGET
     re-trigger against an unchanged HEAD comes from a *different* run and
     must still produce a review.
 
+    This guard only catches a replay that re-enters the prompt from the top.
+    A provider-level retry that replays a single assistant *turn* re-executes
+    the `gh api … /comments -f body=…` call directly, with no prompt to
+    re-read — that is how #3276 collected the identical summary five times.
+    Nothing you can write here prevents it, so the workflow cleans up after
+    it: `sdk_review_dedupe_verdicts.py` runs once the stream closes, keeps the
+    newest summary this run posted and minimizes the rest (FND-636).
+
     **Bot-trigger dedupe guard — run immediately after the replay guard.**
-    The `gate` job in `sdk-review.yml` is an *optimization*, not the
-    authority: it runs outside the per-PR concurrency group, so two
-    automated triggers can both pass it concurrently ("no review for this
-    HEAD yet") and both reach the sandbox. The sandbox runs inside the
-    concurrency lock and is the only place that sees true comment state.
+    This is now a *backstop*, not the authority. Since FND-636 the
+    authoritative check is the `Dedupe check` step at the top of
+    `sdk-review-dispatch`, which runs under the per-PR concurrency lock and
+    declines before a sandbox is booted at all — deciding it here meant the
+    sandbox had to start and reason before it could decline, so the run was
+    paid for either way, and a degraded model skipped the check entirely
+    (five duplicate triggers on #3285 became five runs). Keep this guard: it
+    costs one API call, and it still catches the case where the comment
+    landed between the workflow's read and the sandbox's start.
 
     Check: if `COMMENTER` is an automated trigger (`mothership-ai[bot]`
     or `atlan-ci`) **and** the newest summary's `<!-- REVIEWED_HEAD -->`
@@ -254,7 +266,7 @@ BUDGET
       NEWEST_REVIEWED_HEAD=$(grep -oE '<!-- REVIEWED_HEAD: [0-9a-f]{40} -->' /tmp/PRIOR_REVIEW.md \
         | grep -oE '[0-9a-f]{40}' || true)
       if [ -n "$NEWEST_REVIEWED_HEAD" ] && [ "$NEWEST_REVIEWED_HEAD" = "$HEAD_SHA" ]; then
-        echo "SKIP: bot-trigger dedupe — @${COMMENTER} re-triggered on HEAD ${HEAD_SHA} which the newest summary already reviewed. Gate was not authoritative (runs outside the concurrency lock). Stopping without posting."
+        echo "SKIP: bot-trigger dedupe — @${COMMENTER} re-triggered on HEAD ${HEAD_SHA} which the newest summary already reviewed. Backstop for the workflow's locked dedupe check. Stopping without posting."
         # S4: Restore the commit status so the dispatch run's pending state
         # does not linger after this no-op. The dispatch run always sets
         # sdk-review to "pending" before the sandbox starts. If the sandbox

--- a/.mothership/pr-review/ORCHESTRATION.md
+++ b/.mothership/pr-review/ORCHESTRATION.md
@@ -237,7 +237,10 @@ BUDGET
     re-read — that is how #3276 collected the identical summary five times.
     Nothing you can write here prevents it, so the workflow cleans up after
     it: `sdk_review_dedupe_verdicts.py` runs once the stream closes, keeps the
-    newest summary this run posted and minimizes the rest (FND-636).
+    newest summary this run posted and minimizes the rest (FND-636). It
+    identifies "this run's" summaries by the `<GHA_RUN_URL>` in the §3e
+    footer, the same key this guard greps — which is another reason that line
+    is not optional. Drop it and the collapse silently stops working.
 
     **Bot-trigger dedupe guard — run immediately after the replay guard.**
     This is now a *backstop*, not the authority. Since FND-636 the


### PR DESCRIPTION
Closes FND-636.

Two symptoms on 2026-08-19, one root pattern. PR #3276 received the identical
`<!-- SDK_REVIEW -->` verdict five times from a single run. PR #3285 received
five `@sdk-review` comments from `mothership-ai[bot]` in 51 seconds and spawned
five review runs. Both come from a provider-level retry replaying an assistant
turn whose tool call — `gh api … /comments -f body=…` — is not idempotent. The
frequency of that is model-dependent; the vulnerability is not, so both fixes
here are deterministic and outside the model.

## Trigger side — the dedupe decision moves under the lock

The authoritative check used to live in the sandbox prompt (ORCHESTRATION.md
Phase 0 §6b). That meant the sandbox had to boot and reason before it could
decline — so the run was paid for either way — and a degraded model skipped the
check outright. All five #3285 runs booted.

It now runs as a `Dedupe check` step at the top of `sdk-review-dispatch`, which
holds `sdk-review-$PR`. While that step runs, no sibling run in the group can
be executing, so the comment state it reads is post-lock and final. The `gate`
job cannot make that claim, which is why every one of the five #3285 triggers
passed it.

Implemented as a second *phase* of `sdk_review_gate.py`
(`GATE_PHASE=preflight|locked`) rather than a second script, so the gate and the
authority cannot drift on what counts as a duplicate trigger. The human carve-out
is untouched: a human tagging `@sdk-review` always dispatches, unchanged HEAD or
not.

The locked phase also declines while a sibling run is still mid-review for the
same sha — the one case the concurrency lock does not cover, because the sandbox
outlives a cancelled job and still posts its verdict minutes later. It reads that
off the starter comment, which now stamps `SDK_REVIEW_STARTED_HEAD` and
`SDK_REVIEW_STARTED_RUN`; an unstamped starter for this sha from another run
means a review is in flight. Starters written before this PR carry no stamps and
are ignored, so rollout cannot skip a legitimate trigger on an in-flight PR.

## Verdict side — duplicates get collapsed after the fact

New `sdk_review_dedupe_verdicts.py` runs once the sandbox stream closes: it keeps
the newest summary this run posted and minimizes the rest as duplicates
(`minimizeComment(classifier: DUPLICATE)`). Minimized rather than deleted — the
duplicates are the evidence of the replay, and the newest stays visible so
`last_reviewed_head()` and `sdk_review_approve.py` read the same verdict they
read before. It also reports `verdict_posted`, replacing the inline jq the
soft-success rule used to run.

## Decisions worth flagging for review

- **One job, not a preflight job in the same concurrency group.** A separate
  locked job releases the group before the dispatch job acquires it, so a sibling
  can take the lock and still read pre-verdict state — it would not have stopped
  the #3285 burst. The cost is that ~11 downstream steps carry
  `if: steps.lock_gate.outputs.decision != 'skip'`.
  `test_sdk_review_dedupe_workflow.py` enumerates the steps that are provably
  inert on a skip and fails on any new step that is neither guarded nor listed,
  so a future step cannot quietly escape the guard.
- **`continue-on-error: true` on the check.** A crash leaves `decision` empty,
  every guard reads that as "not skip", and the review runs. Dropping a review is
  the harmful outcome; an extra one is not.
- **A locked skip writes no commit status.** It never sets `sdk-review` to
  pending, so there is nothing to restore — unlike the sandbox-side guard, which
  had to re-derive and re-apply the prior verdict's status.
- **§6b stays as a backstop**, relabelled from "the authority". One API call, and
  it still catches a comment landing between the workflow's read and the
  sandbox's start.
- **Timestamps compared as instants, not strings.** GitHub stamps comments to the
  second (`…:39Z`); the starter records `…:39.123Z`. `"Z" > "."`, so the previous
  lexicographic form could attribute a summary posted *before* our starter to
  this run.
- **Head resolution moved into the script**, deleting a `for`/`if` shell loop from
  the workflow (`docs/standards/ci.md`) that the locked phase would otherwise have
  had to duplicate.
- **Cancellations deliberately untouched.** `cancel-in-progress` stays `false`
  after a human tag destroyed a 28-minute run on #2989. The queue eviction is the
  mitigation working, not the bug.

## Testing

`.github/scripts/tests/` is green (2638 tests). New coverage:

- `test_sdk_review_gate.py` — head-resolution retries, the sibling-in-flight
  detector (own starter, finished run, other sha, folded-but-live, legacy
  starter), the `locked` vs `preflight` split, and the #3285 burst shape.
- `test_sdk_review_dedupe_verdicts.py` — the #3276 five-summary shape,
  same-second ordering, previous-run summaries left alone, a refused minimize,
  the instant-vs-string bound.
- `test_sdk_review_dedupe_workflow.py` — pins the YAML premises the Python
  depends on: the starter stamps, the ``— status ` `` literal shared with the JS
  stamper, that the stamper is `always()`, and full guard coverage.

Not verifiable locally: behaviour under a real trigger burst. After merge, the
first bot re-trigger on an already-reviewed HEAD should get a 😕 reaction and a
`reason=unchanged-head-bot-retrigger` notice in the run log, with no starter
comment and no pending status.

## Security-relevant changes

`.github/workflows/sdk-review.yml` is a CI control-plane file. No permission,
token, or trigger-surface changes: the same `permissions:` block, the same
`secrets.GITHUB_TOKEN` for the new step, the same `if:` on the `gate` job. The
net effect is strictly fewer dispatches, never more — every new path either
skips or falls through to existing behaviour.
