### PR TITLE
ci(sdk-resolve): stop pushing under a review in flight

### DIFF
--- a/.github/scripts/sdk_resolve_push_guard.py
+++ b/.github/scripts/sdk_resolve_push_guard.py
@@ -25,18 +25,45 @@ push, which is what this script does.
 What counts as "in flight"
 --------------------------
 Comment state on the PR, read fresh from the API. A review is in flight when the
-newest `@sdk-review` trigger comment is *unanswered*:
+newest `@sdk-review` **round** is unanswered and still plausibly alive:
 
-* no `<!-- SDK_REVIEW -->` verdict comment from the reviewer bot has been posted
-  since that trigger, and
-* the trigger carries no `confused` reaction — `sdk-review.yml`'s gate job
-  reacts 😕 to a trigger it consciously declines (an unchanged-HEAD bot
-  re-trigger), and deliberately posts no comment. Without reading that reaction
-  a declined trigger would look unanswered forever, and
-* the trigger is younger than `--max-inflight-seconds`. A reviewer sandbox that
-  died mid-run must not wedge the resolver; the default matches the resolver's
-  own Phase 3b wait, so this guard can never block longer than the wait the
-  resolver already tolerates.
+* the round carries no `confused` reaction — `sdk-review.yml`'s gate job reacts
+  😕 to a trigger it consciously declines (an unchanged-HEAD bot re-trigger), and
+  deliberately posts no comment. Without reading that reaction a declined
+  trigger would look unanswered forever, and
+* no verdict comment *answers* it (below), and
+* it is younger than `--max-inflight-seconds`. A reviewer sandbox that died
+  mid-run must not wedge the resolver; the default matches the resolver's own
+  Phase 3b wait, so this guard can never block longer than the wait the resolver
+  already tolerates.
+
+A **round** is one or more trigger comments posted within
+`--burst-window-seconds` of each other, collapsed. Duplicate `@sdk-review` bursts
+seconds apart are one logical request, and the reviewer's own dedupe guard
+answers such a burst with a single verdict — counting them as two rounds would
+leave one permanently unanswered and hold every later push for the full stale
+window.
+
+Answered, and why a timestamp alone cannot decide it
+----------------------------------------------------
+"A verdict landed after the trigger" is not sufficient. A reviewer sandbox runs
+for up to 2h while the resolver's per-round wait is 40 min, and a human can
+re-tag mid-review — so two reviews can be outstanding at once. The older one's
+verdict then lands *after* the newer trigger, and a timestamp rule reads it as
+the newer round's answer: the guard clears, the push lands, and the review that
+is still running has its verdict stranded as stale. That is the same bug this
+script exists to prevent, one round further along.
+
+So the reviewer echoes the trigger it is answering as
+`<!-- ANSWERS_TRIGGER: <comment id> -->` (`.mothership/pr-review/ORCHESTRATION.md`
+§3e), and a round counts as answered when a verdict either:
+
+* echoes one of that round's trigger comment ids — precise, or
+* carries no `ANSWERS_TRIGGER` stamp at all and is newer than the round —
+  the timestamp fallback, for verdicts predating the stamp, `workflow_dispatch`
+  reviews that have no trigger comment, and the case where the reviewer simply
+  omits the marker. Degrading to the old rule exactly where correlation is
+  missing keeps a missing stamp from turning into a 40-minute false hold.
 
 Fail-open, deliberately
 -----------------------
@@ -74,6 +101,7 @@ import re
 import subprocess
 import time
 from collections.abc import Callable
+from dataclasses import dataclass
 from datetime import datetime, timezone
 
 DEFAULT_REPO = "atlanhq/application-sdk"
@@ -95,6 +123,16 @@ TRIGGER_RE = re.compile(r"^\s*@sdk-review\b", re.IGNORECASE)
 
 # The reaction `sdk-review.yml`'s gate leaves on a trigger it declined.
 DECLINED_REACTION = "confused"
+
+# The reviewer's echo of the trigger comment id its verdict answers. Written by
+# .mothership/pr-review/ORCHESTRATION.md §3e; absent on verdicts that predate it
+# and on workflow_dispatch reviews, which have no trigger comment.
+ANSWERS_TRIGGER_RE = re.compile(r"<!--\s*ANSWERS_TRIGGER:\s*(\d+)\s*-->")
+
+# Triggers this close together are one logical request, not two rounds. The
+# duplicate bursts seen in practice land ~11s apart; the reviewer answers such a
+# burst once, so treating them as two rounds would leave one unanswerable.
+DEFAULT_BURST_WINDOW_SECONDS = 120
 
 # Slightly past the reviewer's typical 5–15 min, and equal to the resolver's own
 # Phase 3b per-round wait: a review that has not answered in this long is not
@@ -206,42 +244,113 @@ def was_declined(comment: dict) -> bool:
         return False
 
 
-def _newest(comments: list[dict], predicate: Callable[[dict], bool]) -> dict | None:
-    """The last comment satisfying `predicate`, by created_at.
+def extract_answers_trigger(body: str) -> str | None:
+    """The trigger comment id a verdict says it answers, if it stamps one."""
+    match = ANSWERS_TRIGGER_RE.search(body)
+    return match.group(1) if match else None
+
+
+def _dated(
+    comments: list[dict], predicate: Callable[[dict], bool]
+) -> list[tuple[datetime, dict]]:
+    """Matching comments as (timestamp, comment), oldest first.
 
     The API returns comments oldest-first, but sorting on the timestamp rather
     than trusting the order keeps this correct if that ever changes — and a
-    comment with an unparseable timestamp is skipped rather than silently
+    comment whose timestamp will not parse is dropped rather than silently
     sorting to the front.
     """
-    dated = [
-        (stamp, comment)
-        for comment in comments
-        if predicate(comment)
-        and (stamp := parse_timestamp(comment.get("created_at"))) is not None
-    ]
-    if not dated:
-        return None
-    return max(dated, key=lambda pair: pair[0])[1]
+    dated: list[tuple[datetime, dict]] = []
+    for comment in comments:
+        if not predicate(comment):
+            continue
+        stamp = parse_timestamp(comment.get("created_at"))
+        if stamp is not None:
+            dated.append((stamp, comment))
+    dated.sort(key=lambda pair: pair[0])
+    return dated
+
+
+@dataclass(frozen=True)
+class Round:
+    """One logical `@sdk-review` request: a burst of triggers, collapsed."""
+
+    ids: frozenset[str]
+    first_at: datetime
+    last_at: datetime
+    declined: bool
+
+
+def logical_rounds(
+    comments: list[dict],
+    burst_window_seconds: float = DEFAULT_BURST_WINDOW_SECONDS,
+) -> list[Round]:
+    """Trigger comments grouped into rounds, oldest round first.
+
+    A round is declined only when *every* trigger in it was declined: if the gate
+    let any of them through, a review ran.
+    """
+    rounds: list[Round] = []
+    group: list[tuple[datetime, dict]] = []
+
+    def flush() -> None:
+        if not group:
+            return
+        rounds.append(
+            Round(
+                ids=frozenset(
+                    str(comment["id"]) for _, comment in group if comment.get("id")
+                ),
+                first_at=group[0][0],
+                last_at=group[-1][0],
+                declined=all(was_declined(comment) for _, comment in group),
+            )
+        )
+        group.clear()
+
+    for stamp, comment in _dated(comments, is_trigger):
+        if group and (stamp - group[-1][0]).total_seconds() > burst_window_seconds:
+            flush()
+        group.append((stamp, comment))
+    flush()
+    return rounds
+
+
+def answering_verdict(
+    round_: Round, verdicts: list[tuple[datetime, dict]]
+) -> tuple[datetime, dict] | None:
+    """The verdict that answers `round_`, or None.
+
+    Newest first, so a correlated answer wins over an older fallback match.
+    """
+    for stamp, comment in reversed(verdicts):
+        echoed = extract_answers_trigger(comment.get("body") or "")
+        if echoed is not None:
+            # Stamped verdicts are self-describing: one that names a different
+            # round is NOT this round's answer, however recent it is. That is the
+            # whole point — an earlier round's late verdict must not clear a
+            # review that is still running.
+            if echoed in round_.ids:
+                return stamp, comment
+            continue
+        if stamp > round_.last_at:
+            return stamp, comment
+    return None
 
 
 def assess(
     comments: list[dict],
     now: datetime,
     max_inflight_seconds: float = DEFAULT_MAX_INFLIGHT_SECONDS,
+    burst_window_seconds: float = DEFAULT_BURST_WINDOW_SECONDS,
 ) -> tuple[bool, str, str]:
     """Return (in_flight, reason, message) for the PR's comment state."""
-    trigger = _newest(comments, is_trigger)
-    if trigger is None:
+    rounds = logical_rounds(comments, burst_window_seconds)
+    if not rounds:
         return False, "no-trigger", "No `@sdk-review` trigger on this PR."
 
-    trigger_at = parse_timestamp(trigger.get("created_at"))
-    # _newest only returns comments whose timestamp parsed, so this holds; the
-    # assert-free re-check keeps the type checker honest without a cast.
-    if trigger_at is None:  # pragma: no cover - unreachable via _newest
-        return False, "trigger-undated", "Newest trigger has no usable timestamp."
-
-    if was_declined(trigger):
+    current = rounds[-1]
+    if current.declined:
         return (
             False,
             "trigger-declined",
@@ -249,32 +358,33 @@ def assess(
             "(😕) — no review is running for it.",
         )
 
-    verdict = _newest(comments, is_verdict)
-    verdict_at = parse_timestamp(verdict.get("created_at")) if verdict else None
-    if verdict_at is not None and verdict_at > trigger_at:
+    answer = answering_verdict(current, _dated(comments, is_verdict))
+    if answer is not None:
+        stamp, comment = answer
+        correlated = extract_answers_trigger(comment.get("body") or "") is not None
         return (
             False,
             "verdict-answered",
-            f"The newest `@sdk-review` trigger was answered at "
-            f"{verdict_at.isoformat()} — clear to push.",
+            f"The newest `@sdk-review` round was answered at {stamp.isoformat()} "
+            f"({'correlated' if correlated else 'by timestamp'}) — clear to push.",
         )
 
-    waited = (now - trigger_at).total_seconds()
+    waited = (now - current.last_at).total_seconds()
     if waited >= max_inflight_seconds:
         return (
             False,
             "trigger-stale",
-            f"The newest `@sdk-review` trigger is {int(waited)}s old with no "
-            f"verdict (cap {int(max_inflight_seconds)}s) — treating the review "
-            f"as dead rather than holding the push further.",
+            f"The newest `@sdk-review` round is {int(waited)}s old with no "
+            f"verdict of its own (cap {int(max_inflight_seconds)}s) — treating "
+            f"the review as dead rather than holding the push further.",
         )
 
     return (
         True,
         "review-in-flight",
         f"An `@sdk-review` review has been in flight for {int(waited)}s with no "
-        f"verdict yet. Pushing now would move HEAD out from under it and the "
-        f"verdict would be discarded as stale.",
+        f"verdict of its own yet. Pushing now would move HEAD out from under it "
+        f"and the verdict would be discarded as stale.",
     )
 
 
@@ -284,12 +394,13 @@ def check(
     runner: Runner = subprocess.run,
     now: Clock = _utcnow,
     max_inflight_seconds: float = DEFAULT_MAX_INFLIGHT_SECONDS,
+    burst_window_seconds: float = DEFAULT_BURST_WINDOW_SECONDS,
 ) -> tuple[bool, str, str]:
     """One assessment against live comment state. Fails open."""
     comments = fetch_comments(repo, pr_number, runner)
     if comments is None:
         return False, "state-unreadable", "Could not read PR comments — failing open."
-    return assess(comments, now(), max_inflight_seconds)
+    return assess(comments, now(), max_inflight_seconds, burst_window_seconds)
 
 
 def wait_until_clear(
@@ -301,6 +412,7 @@ def wait_until_clear(
     max_inflight_seconds: float = DEFAULT_MAX_INFLIGHT_SECONDS,
     deadline_seconds: float = DEFAULT_DEADLINE_SECONDS,
     interval_seconds: float = DEFAULT_INTERVAL_SECONDS,
+    burst_window_seconds: float = DEFAULT_BURST_WINDOW_SECONDS,
 ) -> tuple[bool, str, str]:
     """Poll until no review is in flight, or the deadline elapses.
 
@@ -322,7 +434,7 @@ def wait_until_clear(
     )
     while True:
         in_flight, reason, message = check(
-            repo, pr_number, runner, now, max_inflight_seconds
+            repo, pr_number, runner, now, max_inflight_seconds, burst_window_seconds
         )
         if not in_flight:
             return in_flight, reason, message
@@ -376,6 +488,15 @@ def build_parser() -> argparse.ArgumentParser:
             f"(default {DEFAULT_MAX_INFLIGHT_SECONDS})"
         ),
     )
+    parser.add_argument(
+        "--burst-window-seconds",
+        type=float,
+        default=DEFAULT_BURST_WINDOW_SECONDS,
+        help=(
+            "triggers this close together count as one round "
+            f"(default {DEFAULT_BURST_WINDOW_SECONDS})"
+        ),
+    )
     return parser
 
 
@@ -398,10 +519,16 @@ def main(
             args.max_inflight_seconds,
             args.deadline_seconds,
             args.interval_seconds,
+            args.burst_window_seconds,
         )
     else:
         in_flight, reason, message = check(
-            repo, args.pr, runner, now, args.max_inflight_seconds
+            repo,
+            args.pr,
+            runner,
+            now,
+            args.max_inflight_seconds,
+            args.burst_window_seconds,
         )
 
     if in_flight:

--- a/.github/scripts/sdk_resolve_push_guard.py
+++ b/.github/scripts/sdk_resolve_push_guard.py
@@ -1,0 +1,415 @@
+#!/usr/bin/env python3
+"""Refuse an SDK-resolve push while an `@sdk-review` review is still in flight.
+
+The problem
+-----------
+`@sdk-review` (read-only) and `@sdk-resolve` (the only writer) run in separate
+mothership sandboxes, and the resolver *triggers* the reviewer then blocks for
+its reply (`.mothership/pr-resolve/ORCHESTRATION.md` Phase 3a -> 3b). The two
+lanes are therefore concurrent by design, and neither has a notion of a shared
+round. When the resolver pushes inside the trigger -> verdict window, the review
+in flight is reviewing a sha that no longer exists as HEAD:
+
+* the verdict lands stamped `REVIEWED_HEAD: <old sha>`;
+* `sdk_review_approve.py` compares that stamp against the live head, sees the
+  mismatch, and declines every stamp ("head moved past the verdict");
+* the round produced nothing, and the resolver spends another of its
+  `MAX_ROUNDS` re-asking for the same review.
+
+A shared GitHub Actions concurrency group across `sdk-review.yml` and
+`sdk-resolve.yml` cannot fix this: the resolve job holds the group for the whole
+loop while blocking on a review that would queue behind it, so every run would
+end at `stopped_reason: review-timeout`. The invariant has to be enforced at the
+push, which is what this script does.
+
+What counts as "in flight"
+--------------------------
+Comment state on the PR, read fresh from the API. A review is in flight when the
+newest `@sdk-review` trigger comment is *unanswered*:
+
+* no `<!-- SDK_REVIEW -->` verdict comment from the reviewer bot has been posted
+  since that trigger, and
+* the trigger carries no `confused` reaction — `sdk-review.yml`'s gate job
+  reacts 😕 to a trigger it consciously declines (an unchanged-HEAD bot
+  re-trigger), and deliberately posts no comment. Without reading that reaction
+  a declined trigger would look unanswered forever, and
+* the trigger is younger than `--max-inflight-seconds`. A reviewer sandbox that
+  died mid-run must not wedge the resolver; the default matches the resolver's
+  own Phase 3b wait, so this guard can never block longer than the wait the
+  resolver already tolerates.
+
+Fail-open, deliberately
+-----------------------
+Any failure to read comment state — `gh` non-zero, unparseable JSON, an
+unparseable timestamp — reports "clear to push" with a `::warning::`. A guard
+that cannot see the state must not be the thing that stops the resolver from
+making progress; the consequence of a missed hold is one wasted round, while the
+consequence of a false hold is a resolver that can never push at all. This
+matches `sdk_review_gate.py`'s stance for the same reason.
+
+Usage (from the resolver sandbox, cwd = the cloned repo)::
+
+    # block until the in-flight review answers, then push
+    python3 .github/scripts/sdk_resolve_push_guard.py --pr "$PR_NUMBER" --wait
+    git push
+
+    # or ask once and decide for yourself
+    python3 .github/scripts/sdk_resolve_push_guard.py --pr "$PR_NUMBER"
+
+Environment:
+    REPO        owner/repo; defaults to atlanhq/application-sdk
+    GH_TOKEN    consumed by `gh` for auth (not read here directly)
+
+Exit status:
+    0   clear to push (no review in flight, or the wait cleared it)
+    10  a review is in flight (`--wait`: still in flight at the deadline)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import time
+from collections.abc import Callable
+from datetime import datetime, timezone
+
+DEFAULT_REPO = "atlanhq/application-sdk"
+
+SUMMARY_MARKER = "<!-- SDK_REVIEW -->"
+# Accepted alongside the current marker for PRs that predate the promotion out
+# of the `test-sdk-review-*` prefix; kept in sync with sdk_review_approve.py.
+LEGACY_SUMMARY_MARKER = "<!-- TEST_SDK_REVIEW -->"
+SUMMARY_MARKERS = (SUMMARY_MARKER, LEGACY_SUMMARY_MARKER)
+
+VERDICT_AUTHOR = "mothership-ai[bot]"
+
+# A trigger comment *starts with* the mention — the same test `sdk-review.yml`'s
+# job-level `if:` applies (`startsWith(github.event.comment.body, '@sdk-review')`).
+# Anchoring here rather than searching anywhere in the body keeps prose that
+# merely names the reviewer (a resolve status comment, a human explaining the
+# loop) from being mistaken for a trigger.
+TRIGGER_RE = re.compile(r"^\s*@sdk-review\b", re.IGNORECASE)
+
+# The reaction `sdk-review.yml`'s gate leaves on a trigger it declined.
+DECLINED_REACTION = "confused"
+
+# Slightly past the reviewer's typical 5–15 min, and equal to the resolver's own
+# Phase 3b per-round wait: a review that has not answered in this long is not
+# coming back, and holding the push any longer only burns the resolver's budget.
+DEFAULT_MAX_INFLIGHT_SECONDS = 2400
+DEFAULT_DEADLINE_SECONDS = 1800
+DEFAULT_INTERVAL_SECONDS = 30
+
+EXIT_CLEAR = 0
+EXIT_IN_FLIGHT = 10
+
+Runner = Callable[..., subprocess.CompletedProcess]
+Clock = Callable[[], datetime]
+Sleeper = Callable[[float], None]
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def fetch_comments(
+    repo: str, pr_number: str, runner: Runner = subprocess.run
+) -> list[dict] | None:
+    """Every comment on the PR, or None when the state could not be read.
+
+    None and [] are different answers and the caller treats them differently: []
+    is "read it, there are no comments" (clear to push), None is "could not read
+    it" (fail open, but say so). Collapsing them would make an API outage
+    indistinguishable from a quiet PR.
+
+    `--slurp` returns one array per page rather than a flat stream, and is used
+    instead of `--jq` deliberately: the naive `--jq '.[] | .body'` form collapses
+    a multiline body to its first line, which for a verdict comment is the HTML
+    marker alone.
+    """
+    result = runner(
+        [
+            "gh",
+            "api",
+            f"repos/{repo}/issues/{pr_number}/comments",
+            "--paginate",
+            "--slurp",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        print(
+            f"::warning::sdk-resolve push guard: could not list PR comments "
+            f"(exit {result.returncode}) — not holding the push."
+        )
+        return None
+    try:
+        pages = json.loads(result.stdout or "[]")
+    except json.JSONDecodeError as e:
+        print(
+            f"::warning::sdk-resolve push guard: could not parse PR comments "
+            f"({e}) — not holding the push."
+        )
+        return None
+    comments: list[dict] = []
+    for page in pages:
+        # A single un-paginated response is a bare array; --slurp wraps it in one
+        # more level. Tolerate both shapes.
+        if isinstance(page, list):
+            comments.extend(c for c in page if isinstance(c, dict))
+        elif isinstance(page, dict):
+            comments.append(page)
+    return comments
+
+
+def parse_timestamp(raw: str | None) -> datetime | None:
+    """An ISO-8601 GitHub timestamp as an aware datetime, or None."""
+    if not raw:
+        return None
+    try:
+        parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    # A naive value would raise on every later comparison; treat it as UTC,
+    # which is what the API documents it to be.
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def is_trigger(comment: dict) -> bool:
+    """A comment that would fire `sdk-review.yml`."""
+    return bool(TRIGGER_RE.match(comment.get("body") or ""))
+
+
+def is_verdict(comment: dict) -> bool:
+    """A review summary posted by the reviewer bot."""
+    if (comment.get("user") or {}).get("login") != VERDICT_AUTHOR:
+        return False
+    body = comment.get("body") or ""
+    return any(marker in body for marker in SUMMARY_MARKERS)
+
+
+def was_declined(comment: dict) -> bool:
+    """True when `sdk-review.yml`'s gate reacted 😕 — seen and declined."""
+    reactions = comment.get("reactions")
+    if not isinstance(reactions, dict):
+        return False
+    try:
+        return int(reactions.get(DECLINED_REACTION) or 0) > 0
+    except (TypeError, ValueError):
+        return False
+
+
+def _newest(comments: list[dict], predicate: Callable[[dict], bool]) -> dict | None:
+    """The last comment satisfying `predicate`, by created_at.
+
+    The API returns comments oldest-first, but sorting on the timestamp rather
+    than trusting the order keeps this correct if that ever changes — and a
+    comment with an unparseable timestamp is skipped rather than silently
+    sorting to the front.
+    """
+    dated = [
+        (stamp, comment)
+        for comment in comments
+        if predicate(comment)
+        and (stamp := parse_timestamp(comment.get("created_at"))) is not None
+    ]
+    if not dated:
+        return None
+    return max(dated, key=lambda pair: pair[0])[1]
+
+
+def assess(
+    comments: list[dict],
+    now: datetime,
+    max_inflight_seconds: float = DEFAULT_MAX_INFLIGHT_SECONDS,
+) -> tuple[bool, str, str]:
+    """Return (in_flight, reason, message) for the PR's comment state."""
+    trigger = _newest(comments, is_trigger)
+    if trigger is None:
+        return False, "no-trigger", "No `@sdk-review` trigger on this PR."
+
+    trigger_at = parse_timestamp(trigger.get("created_at"))
+    # _newest only returns comments whose timestamp parsed, so this holds; the
+    # assert-free re-check keeps the type checker honest without a cast.
+    if trigger_at is None:  # pragma: no cover - unreachable via _newest
+        return False, "trigger-undated", "Newest trigger has no usable timestamp."
+
+    if was_declined(trigger):
+        return (
+            False,
+            "trigger-declined",
+            "The newest `@sdk-review` trigger was declined by the review gate "
+            "(😕) — no review is running for it.",
+        )
+
+    verdict = _newest(comments, is_verdict)
+    verdict_at = parse_timestamp(verdict.get("created_at")) if verdict else None
+    if verdict_at is not None and verdict_at > trigger_at:
+        return (
+            False,
+            "verdict-answered",
+            f"The newest `@sdk-review` trigger was answered at "
+            f"{verdict_at.isoformat()} — clear to push.",
+        )
+
+    waited = (now - trigger_at).total_seconds()
+    if waited >= max_inflight_seconds:
+        return (
+            False,
+            "trigger-stale",
+            f"The newest `@sdk-review` trigger is {int(waited)}s old with no "
+            f"verdict (cap {int(max_inflight_seconds)}s) — treating the review "
+            f"as dead rather than holding the push further.",
+        )
+
+    return (
+        True,
+        "review-in-flight",
+        f"An `@sdk-review` review has been in flight for {int(waited)}s with no "
+        f"verdict yet. Pushing now would move HEAD out from under it and the "
+        f"verdict would be discarded as stale.",
+    )
+
+
+def check(
+    repo: str,
+    pr_number: str,
+    runner: Runner = subprocess.run,
+    now: Clock = _utcnow,
+    max_inflight_seconds: float = DEFAULT_MAX_INFLIGHT_SECONDS,
+) -> tuple[bool, str, str]:
+    """One assessment against live comment state. Fails open."""
+    comments = fetch_comments(repo, pr_number, runner)
+    if comments is None:
+        return False, "state-unreadable", "Could not read PR comments — failing open."
+    return assess(comments, now(), max_inflight_seconds)
+
+
+def wait_until_clear(
+    repo: str,
+    pr_number: str,
+    runner: Runner = subprocess.run,
+    now: Clock = _utcnow,
+    sleeper: Sleeper = time.sleep,
+    max_inflight_seconds: float = DEFAULT_MAX_INFLIGHT_SECONDS,
+    deadline_seconds: float = DEFAULT_DEADLINE_SECONDS,
+    interval_seconds: float = DEFAULT_INTERVAL_SECONDS,
+) -> tuple[bool, str, str]:
+    """Poll until no review is in flight, or the deadline elapses.
+
+    A heartbeat line per iteration keeps bytes flowing on the sandbox's stream so
+    neither mothership's idle timeout nor the dispatch read watchdog fires while
+    this blocks — the same reason ORCHESTRATION Phase 3b prints one.
+
+    Bounded two ways on purpose. The wall clock is the real budget, but a clock
+    that does not advance — a frozen fake in a test, a sandbox whose clock is
+    stepped by its host — would make the elapsed check unfalsifiable and spin
+    this loop forever, which for a guard whose whole job is "let the resolver
+    push eventually" is the worst available failure. The poll count is the
+    backstop that cannot stall.
+    """
+    started = now()
+    polls = 0
+    max_polls = (
+        max(1, int(deadline_seconds // interval_seconds)) if interval_seconds > 0 else 1
+    )
+    while True:
+        in_flight, reason, message = check(
+            repo, pr_number, runner, now, max_inflight_seconds
+        )
+        if not in_flight:
+            return in_flight, reason, message
+
+        elapsed = (now() - started).total_seconds()
+        polls += 1
+        if elapsed + interval_seconds > deadline_seconds or polls > max_polls:
+            return (
+                True,
+                "wait-deadline",
+                f"Still in flight after {int(elapsed)}s / {polls} polls "
+                f"(deadline {int(deadline_seconds)}s): {message}",
+            )
+        print(
+            f"[push-guard] review in flight, waiting … "
+            f"{int(elapsed)}s/{int(deadline_seconds)}s elapsed"
+        )
+        sleeper(interval_seconds)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Refuse an SDK-resolve push while an @sdk-review review is in flight."
+        )
+    )
+    parser.add_argument("--pr", required=True, help="pull request number")
+    parser.add_argument(
+        "--wait",
+        action="store_true",
+        help="block until the in-flight review answers instead of reporting once",
+    )
+    parser.add_argument(
+        "--deadline-seconds",
+        type=float,
+        default=DEFAULT_DEADLINE_SECONDS,
+        help=f"--wait budget (default {DEFAULT_DEADLINE_SECONDS})",
+    )
+    parser.add_argument(
+        "--interval-seconds",
+        type=float,
+        default=DEFAULT_INTERVAL_SECONDS,
+        help=f"--wait poll interval (default {DEFAULT_INTERVAL_SECONDS})",
+    )
+    parser.add_argument(
+        "--max-inflight-seconds",
+        type=float,
+        default=DEFAULT_MAX_INFLIGHT_SECONDS,
+        help=(
+            "age at which an unanswered trigger is treated as a dead review "
+            f"(default {DEFAULT_MAX_INFLIGHT_SECONDS})"
+        ),
+    )
+    return parser
+
+
+def main(
+    argv: list[str] | None = None,
+    runner: Runner = subprocess.run,
+    now: Clock = _utcnow,
+    sleeper: Sleeper = time.sleep,
+) -> int:
+    args = build_parser().parse_args(argv)
+    repo = os.environ.get("REPO") or DEFAULT_REPO
+
+    if args.wait:
+        in_flight, reason, message = wait_until_clear(
+            repo,
+            args.pr,
+            runner,
+            now,
+            sleeper,
+            args.max_inflight_seconds,
+            args.deadline_seconds,
+            args.interval_seconds,
+        )
+    else:
+        in_flight, reason, message = check(
+            repo, args.pr, runner, now, args.max_inflight_seconds
+        )
+
+    if in_flight:
+        print(f"::warning::sdk-resolve push guard: HOLD ({reason}) — {message}")
+        return EXIT_IN_FLIGHT
+    print(f"::notice::sdk-resolve push guard: clear ({reason}) — {message}")
+    return EXIT_CLEAR
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/tests/test_sdk_resolve_push_guard.py
+++ b/.github/scripts/tests/test_sdk_resolve_push_guard.py
@@ -1,0 +1,460 @@
+"""Tests for the SDK-resolve push guard.
+
+The regression these pin: the resolver pushing inside the `@sdk-review`
+trigger -> verdict window, which moves HEAD out from under the review in flight
+so `sdk_review_approve.py` discards the verdict as stale ("head moved past the
+verdict") and the round produces nothing.
+
+Both directions matter and both are covered. A guard that holds too little
+lets the race back in; a guard that holds too much (a declined trigger, a dead
+reviewer sandbox, an unreadable API) leaves the resolver unable to push at all,
+which is the worse failure — so every fail-open path has a case.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+SPEC = importlib.util.spec_from_file_location(
+    "sdk_resolve_push_guard",
+    Path(__file__).resolve().parents[1] / "sdk_resolve_push_guard.py",
+)
+guard = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules["sdk_resolve_push_guard"] = guard
+SPEC.loader.exec_module(guard)
+
+
+REPO = "atlanhq/application-sdk"
+PR = "3276"
+
+NOW = datetime(2026, 8, 19, 18, 0, 0, tzinfo=timezone.utc)
+
+
+def at(**delta: float) -> str:
+    """An API timestamp offset from NOW, e.g. `at(minutes=-5)`."""
+    return (NOW + timedelta(**delta)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def clock() -> datetime:
+    """A frozen clock. Fine for `check`, which reads the clock exactly once."""
+    return NOW
+
+
+class FakeTime:
+    """A clock that advances only when something sleeps.
+
+    Stepping per clock *read* would be wrong: `wait_until_clear` reads the clock
+    more than once per poll, so a per-read step blows the whole budget on the
+    first iteration and the loop never sleeps at all. Advancing on sleep is both
+    realistic and the thing the loop's budget arithmetic is actually about.
+    """
+
+    def __init__(self) -> None:
+        self.now = NOW
+        self.slept: list[float] = []
+
+    def clock(self) -> datetime:
+        return self.now
+
+    def sleep(self, seconds: float) -> None:
+        self.slept.append(seconds)
+        self.now += timedelta(seconds=seconds)
+
+
+def trigger(
+    created_at: str, *, declined: bool = False, login: str = "atlan-ci"
+) -> dict:
+    return {
+        "body": "@sdk-review",
+        "created_at": created_at,
+        "user": {"login": login},
+        "reactions": {"eyes": 1, "confused": 1 if declined else 0},
+    }
+
+
+def verdict(
+    created_at: str,
+    *,
+    login: str = "mothership-ai[bot]",
+    marker: str = "<!-- SDK_REVIEW -->",
+) -> dict:
+    return {
+        "body": f"{marker}\n<!-- VERDICT: READY_TO_MERGE -->\n## SDK Review\n",
+        "created_at": created_at,
+        "user": {"login": login},
+        "reactions": {},
+    }
+
+
+def ok(payload: object) -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(
+        args=[], returncode=0, stdout=json.dumps(payload), stderr=""
+    )
+
+
+def runner_for(payload: object) -> guard.Runner:
+    def run(*_args: object, **_kwargs: object) -> subprocess.CompletedProcess:
+        return ok(payload)
+
+    return run
+
+
+# --- assess: holds --------------------------------------------------------
+
+
+def test_unanswered_trigger_holds_the_push():
+    in_flight, reason, _ = guard.assess([trigger(at(minutes=-5))], NOW)
+    assert in_flight
+    assert reason == "review-in-flight"
+
+
+def test_verdict_older_than_the_trigger_still_holds():
+    """The exact shape of the race: a prior round's verdict, a fresh trigger."""
+    comments = [verdict(at(minutes=-30)), trigger(at(minutes=-4))]
+    in_flight, reason, _ = guard.assess(comments, NOW)
+    assert in_flight
+    assert reason == "review-in-flight"
+
+
+def test_hold_message_names_the_stale_verdict_consequence():
+    _, _, message = guard.assess([trigger(at(minutes=-5))], NOW)
+    assert "300s" in message
+    assert "stale" in message
+
+
+# --- assess: clears -------------------------------------------------------
+
+
+def test_no_trigger_is_clear():
+    in_flight, reason, _ = guard.assess([], NOW)
+    assert not in_flight
+    assert reason == "no-trigger"
+
+
+def test_answered_trigger_is_clear():
+    comments = [trigger(at(minutes=-20)), verdict(at(minutes=-1))]
+    in_flight, reason, _ = guard.assess(comments, NOW)
+    assert not in_flight
+    assert reason == "verdict-answered"
+
+
+def test_legacy_marker_counts_as_an_answer():
+    comments = [
+        trigger(at(minutes=-20)),
+        verdict(at(minutes=-1), marker="<!-- TEST_SDK_REVIEW -->"),
+    ]
+    in_flight, reason, _ = guard.assess(comments, NOW)
+    assert not in_flight
+    assert reason == "verdict-answered"
+
+
+def test_declined_trigger_is_clear():
+    """The gate reacts 😕 and posts nothing; without reading it this wedges."""
+    in_flight, reason, _ = guard.assess([trigger(at(minutes=-5), declined=True)], NOW)
+    assert not in_flight
+    assert reason == "trigger-declined"
+
+
+def test_stale_trigger_is_clear():
+    """A reviewer sandbox that died must not hold the push indefinitely."""
+    in_flight, reason, _ = guard.assess([trigger(at(minutes=-41))], NOW)
+    assert not in_flight
+    assert reason == "trigger-stale"
+
+
+def test_stale_cap_is_configurable():
+    comments = [trigger(at(minutes=-5))]
+    assert guard.assess(comments, NOW, max_inflight_seconds=60)[1] == "trigger-stale"
+    assert (
+        guard.assess(comments, NOW, max_inflight_seconds=600)[1] == "review-in-flight"
+    )
+
+
+# --- comment classification ----------------------------------------------
+
+
+def test_only_a_leading_mention_is_a_trigger():
+    """Prose that merely names the reviewer is not a trigger.
+
+    The resolver's own `<!-- SDK_RESOLVE_STATUS -->` comment says it will
+    "re-run `@sdk-review`" mid-sentence; treating that as a trigger would make
+    the resolver hold its own push against a review nobody asked for.
+    """
+    status = {
+        "body": "🤖 SDK Resolve — round 2. Fixing, then I'll re-run `@sdk-review`.",
+        "created_at": at(minutes=-1),
+        "user": {"login": "mothership-ai[bot]"},
+        "reactions": {},
+    }
+    assert not guard.is_trigger(status)
+    in_flight, reason, _ = guard.assess([status], NOW)
+    assert not in_flight
+    assert reason == "no-trigger"
+
+
+def test_trigger_with_trailing_text_still_counts():
+    comment = trigger(at(minutes=-2))
+    comment["body"] = "@sdk-review please look at the retry path"
+    assert guard.is_trigger(comment)
+
+
+def test_verdict_from_a_non_reviewer_login_is_not_an_answer():
+    """A human pasting the marker must not clear the hold."""
+    comments = [trigger(at(minutes=-5)), verdict(at(minutes=-1), login="someone")]
+    in_flight, reason, _ = guard.assess(comments, NOW)
+    assert in_flight
+    assert reason == "review-in-flight"
+
+
+def test_newest_trigger_wins_over_an_older_answered_one():
+    comments = [
+        trigger(at(minutes=-40)),
+        verdict(at(minutes=-25)),
+        trigger(at(minutes=-3)),
+    ]
+    in_flight, reason, _ = guard.assess(comments, NOW)
+    assert in_flight
+    assert reason == "review-in-flight"
+
+
+def test_out_of_order_listing_is_sorted_by_timestamp():
+    """Correct even if the API stops returning comments oldest-first."""
+    comments = [trigger(at(minutes=-3)), trigger(at(minutes=-40))]
+    in_flight, reason, _ = guard.assess(comments, NOW)
+    assert in_flight
+    assert reason == "review-in-flight"
+
+
+def test_undated_comments_are_skipped_not_sorted_first():
+    undated = trigger(at(minutes=-3))
+    undated["created_at"] = "not-a-timestamp"
+    comments = [undated, trigger(at(minutes=-41))]
+    in_flight, reason, _ = guard.assess(comments, NOW)
+    assert not in_flight
+    assert reason == "trigger-stale"
+
+
+def test_malformed_reactions_do_not_crash_or_decline():
+    comment = trigger(at(minutes=-5))
+    comment["reactions"] = "not-a-dict"
+    assert not guard.was_declined(comment)
+    assert guard.assess([comment], NOW)[0]
+
+
+def test_non_numeric_reaction_count_is_not_a_decline():
+    comment = trigger(at(minutes=-5))
+    comment["reactions"] = {"confused": "many"}
+    assert not guard.was_declined(comment)
+
+
+def test_naive_timestamps_are_treated_as_utc():
+    parsed = guard.parse_timestamp("2026-08-19T17:55:00")
+    assert parsed is not None
+    assert parsed.tzinfo is timezone.utc
+
+
+# --- fetch + fail-open ----------------------------------------------------
+
+
+def test_fetch_unwraps_slurped_pages():
+    payload = [[trigger(at(minutes=-5))], [verdict(at(minutes=-1))]]
+    comments = guard.fetch_comments(REPO, PR, runner_for(payload))
+    assert comments is not None
+    assert len(comments) == 2
+
+
+def test_fetch_tolerates_an_unwrapped_array():
+    payload = [trigger(at(minutes=-5))]
+    comments = guard.fetch_comments(REPO, PR, runner_for(payload))
+    assert comments is not None
+    assert len(comments) == 1
+
+
+def test_fetch_uses_paginate_and_slurp_not_jq(capsys: pytest.CaptureFixture[str]):
+    """`--jq` would truncate a multiline verdict body to its marker line."""
+    seen: list[list[str]] = []
+
+    def run(argv: list[str], **_kwargs: object) -> subprocess.CompletedProcess:
+        seen.append(argv)
+        return ok([])
+
+    guard.fetch_comments(REPO, PR, run)
+    assert "--paginate" in seen[0]
+    assert "--slurp" in seen[0]
+    assert "--jq" not in seen[0]
+
+
+def test_gh_failure_fails_open(capsys: pytest.CaptureFixture[str]):
+    def run(*_args: object, **_kwargs: object) -> subprocess.CompletedProcess:
+        return subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="")
+
+    in_flight, reason, _ = guard.check(REPO, PR, run, clock)
+    assert not in_flight
+    assert reason == "state-unreadable"
+    assert "::warning::" in capsys.readouterr().out
+
+
+def test_unparseable_json_fails_open():
+    def run(*_args: object, **_kwargs: object) -> subprocess.CompletedProcess:
+        return subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="{not json", stderr=""
+        )
+
+    in_flight, reason, _ = guard.check(REPO, PR, run, clock)
+    assert not in_flight
+    assert reason == "state-unreadable"
+
+
+def test_empty_listing_is_distinct_from_unreadable():
+    in_flight, reason, _ = guard.check(REPO, PR, runner_for([[]]), clock)
+    assert not in_flight
+    assert reason == "no-trigger"
+
+
+# --- wait mode ------------------------------------------------------------
+
+
+def test_wait_returns_as_soon_as_the_verdict_lands():
+    answered = [[trigger(at(minutes=-5)), verdict(at(minutes=-1))]]
+    pending = [[trigger(at(minutes=-5))]]
+    fake = FakeTime()
+
+    def run(*_args: object, **_kwargs: object) -> subprocess.CompletedProcess:
+        # Answered on the third poll; the first two still see the bare trigger.
+        return ok(answered if len(fake.slept) >= 2 else pending)
+
+    in_flight, reason, _ = guard.wait_until_clear(
+        REPO, PR, run, fake.clock, fake.sleep, interval_seconds=30
+    )
+    assert not in_flight
+    assert reason == "verdict-answered"
+    assert fake.slept == [30, 30]
+
+
+def test_wait_gives_up_at_the_deadline():
+    fake = FakeTime()
+    in_flight, reason, message = guard.wait_until_clear(
+        REPO,
+        PR,
+        runner_for([[trigger(at(minutes=-5))]]),
+        fake.clock,
+        fake.sleep,
+        deadline_seconds=90,
+        interval_seconds=30,
+    )
+    assert in_flight
+    assert reason == "wait-deadline"
+    assert "deadline 90s" in message
+    # Sleeps to exactly the budget, then stops rather than overrunning it.
+    assert fake.slept == [30, 30, 30]
+
+
+def test_wait_terminates_under_a_stalled_clock():
+    """The poll-count backstop, pinned.
+
+    Without it a clock that never advances makes the elapsed check
+    unfalsifiable and the loop spins forever — a guard that never returns is
+    strictly worse than one that lets the push through.
+    """
+    slept: list[float] = []
+    in_flight, reason, _ = guard.wait_until_clear(
+        REPO,
+        PR,
+        runner_for([[trigger(at(minutes=-5))]]),
+        clock,
+        slept.append,
+        deadline_seconds=90,
+        interval_seconds=30,
+    )
+    assert in_flight
+    assert reason == "wait-deadline"
+    assert slept == [30, 30, 30]
+
+
+def test_wait_does_not_sleep_when_already_clear():
+    slept: list[float] = []
+    in_flight, _, _ = guard.wait_until_clear(
+        REPO, PR, runner_for([[]]), clock, slept.append
+    )
+    assert not in_flight
+    assert slept == []
+
+
+def test_wait_prints_a_heartbeat(capsys: pytest.CaptureFixture[str]):
+    """Keeps bytes flowing so the sandbox stream watchdogs don't fire."""
+    guard.wait_until_clear(
+        REPO,
+        PR,
+        runner_for([[trigger(at(minutes=-5))]]),
+        FakeTime().clock,
+        FakeTime().sleep,
+        deadline_seconds=60,
+        interval_seconds=30,
+    )
+    assert "[push-guard] review in flight" in capsys.readouterr().out
+
+
+# --- CLI ------------------------------------------------------------------
+
+
+def test_main_exits_10_when_in_flight(capsys: pytest.CaptureFixture[str]):
+    code = guard.main(
+        ["--pr", PR], runner_for([[trigger(at(minutes=-5))]]), clock, lambda _s: None
+    )
+    assert code == guard.EXIT_IN_FLIGHT
+    assert "HOLD (review-in-flight)" in capsys.readouterr().out
+
+
+def test_main_exits_0_when_clear(capsys: pytest.CaptureFixture[str]):
+    code = guard.main(["--pr", PR], runner_for([[]]), clock, lambda _s: None)
+    assert code == guard.EXIT_CLEAR
+    assert "clear (no-trigger)" in capsys.readouterr().out
+
+
+def test_main_wait_mode_polls():
+    fake = FakeTime()
+    code = guard.main(
+        ["--pr", PR, "--wait", "--deadline-seconds", "60", "--interval-seconds", "30"],
+        runner_for([[trigger(at(minutes=-5))]]),
+        fake.clock,
+        fake.sleep,
+    )
+    assert code == guard.EXIT_IN_FLIGHT
+    assert fake.slept == [30, 30]
+
+
+def test_main_reads_repo_from_env(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("REPO", "atlanhq/somewhere-else")
+    seen: list[list[str]] = []
+
+    def run(argv: list[str], **_kwargs: object) -> subprocess.CompletedProcess:
+        seen.append(argv)
+        return ok([[]])
+
+    guard.main(["--pr", PR], run, clock, lambda _s: None)
+    assert "repos/atlanhq/somewhere-else/issues/3276/comments" in seen[0]
+
+
+def test_main_defaults_repo_to_application_sdk(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("REPO", raising=False)
+    seen: list[list[str]] = []
+
+    def run(argv: list[str], **_kwargs: object) -> subprocess.CompletedProcess:
+        seen.append(argv)
+        return ok([[]])
+
+    guard.main(["--pr", PR], run, clock, lambda _s: None)
+    assert f"repos/{REPO}/issues/3276/comments" in seen[0]
+
+
+def test_pr_argument_is_required():
+    with pytest.raises(SystemExit):
+        guard.build_parser().parse_args([])

--- a/.github/scripts/tests/test_sdk_resolve_push_guard.py
+++ b/.github/scripts/tests/test_sdk_resolve_push_guard.py
@@ -70,9 +70,14 @@ class FakeTime:
 
 
 def trigger(
-    created_at: str, *, declined: bool = False, login: str = "atlan-ci"
+    created_at: str,
+    *,
+    declined: bool = False,
+    login: str = "atlan-ci",
+    comment_id: int = 1,
 ) -> dict:
     return {
+        "id": comment_id,
         "body": "@sdk-review",
         "created_at": created_at,
         "user": {"login": login},
@@ -85,9 +90,13 @@ def verdict(
     *,
     login: str = "mothership-ai[bot]",
     marker: str = "<!-- SDK_REVIEW -->",
+    answers: int | None = None,
 ) -> dict:
+    """A verdict comment. `answers` stamps the trigger id it correlates to."""
+    stamp = f"<!-- ANSWERS_TRIGGER: {answers} -->\n" if answers is not None else ""
     return {
-        "body": f"{marker}\n<!-- VERDICT: READY_TO_MERGE -->\n## SDK Review\n",
+        "id": 900 + (answers or 0),
+        "body": f"{marker}\n<!-- VERDICT: READY_TO_MERGE -->\n{stamp}## SDK Review\n",
         "created_at": created_at,
         "user": {"login": login},
         "reactions": {},
@@ -178,6 +187,176 @@ def test_stale_cap_is_configurable():
     )
 
 
+# --- round correlation ----------------------------------------------------
+
+
+def test_older_rounds_late_verdict_does_not_clear_the_new_round():
+    """The regression this correlation exists for.
+
+    Round 1 triggers, the resolver's 40-min wait elapses, a new round triggers
+    (a human re-tag, or a reviewer sandbox that outlived the wait — it runs up
+    to 2h). Round 1's verdict then lands AFTER round 2's trigger. By timestamp
+    alone it reads as round 2's answer, the guard clears, the push lands, and
+    the review still running has its verdict stranded as stale — the exact bug
+    this script exists to prevent, one round further along.
+    """
+    comments = [
+        trigger(at(minutes=-50), comment_id=1),
+        trigger(at(minutes=-5), comment_id=2),
+        verdict(at(minutes=-1), answers=1),
+    ]
+    in_flight, reason, _ = guard.assess(comments, NOW)
+    assert in_flight
+    assert reason == "review-in-flight"
+
+
+def test_correlated_verdict_for_the_current_round_clears():
+    comments = [
+        trigger(at(minutes=-50), comment_id=1),
+        trigger(at(minutes=-5), comment_id=2),
+        verdict(at(minutes=-30), answers=1),
+        verdict(at(minutes=-1), answers=2),
+    ]
+    in_flight, reason, message = guard.assess(comments, NOW)
+    assert not in_flight
+    assert reason == "verdict-answered"
+    assert "correlated" in message
+
+
+def test_unstamped_verdict_still_answers_by_timestamp():
+    """Verdicts predating the marker, and workflow_dispatch reviews, keep working.
+
+    A missing stamp must degrade to the old rule, not to a 40-minute false hold.
+    """
+    comments = [trigger(at(minutes=-20), comment_id=7), verdict(at(minutes=-1))]
+    in_flight, reason, message = guard.assess(comments, NOW)
+    assert not in_flight
+    assert reason == "verdict-answered"
+    assert "by timestamp" in message
+
+
+def test_a_stamped_verdict_for_another_round_does_not_block_an_unstamped_answer():
+    """Mixed state: the reviewer stamped one round and omitted it on the next."""
+    comments = [
+        trigger(at(minutes=-50), comment_id=1),
+        trigger(at(minutes=-5), comment_id=2),
+        verdict(at(minutes=-30), answers=1),
+        verdict(at(minutes=-1)),
+    ]
+    in_flight, reason, _ = guard.assess(comments, NOW)
+    assert not in_flight
+    assert reason == "verdict-answered"
+
+
+def test_stamped_verdict_older_than_the_round_it_names_still_answers_it():
+    """Correlation beats ordering: the id match is authoritative, not the clock."""
+    comments = [
+        trigger(at(minutes=-5), comment_id=2),
+        verdict(at(minutes=-4), answers=2),
+    ]
+    in_flight, reason, _ = guard.assess(comments, NOW)
+    assert not in_flight
+    assert reason == "verdict-answered"
+
+
+def test_answers_trigger_is_extracted():
+    body = "<!-- SDK_REVIEW -->\n<!-- ANSWERS_TRIGGER: 3312445566 -->\n"
+    assert guard.extract_answers_trigger(body) == "3312445566"
+
+
+def test_missing_answers_trigger_returns_none():
+    assert guard.extract_answers_trigger("<!-- SDK_REVIEW -->") is None
+
+
+def test_empty_answers_trigger_is_not_a_correlation():
+    """The reviewer's sed deletes an empty marker; if one slips through, ignore it.
+
+    Reading `ANSWERS_TRIGGER:` with no digits as "names a round, not yours" would
+    hold every push for the full stale window on a marker that says nothing.
+    """
+    assert guard.extract_answers_trigger("<!-- ANSWERS_TRIGGER:  -->") is None
+    comments = [trigger(at(minutes=-20), comment_id=7)]
+    comments.append(verdict(at(minutes=-1)))
+    comments[-1]["body"] = "<!-- SDK_REVIEW -->\n<!-- ANSWERS_TRIGGER:  -->\n"
+    in_flight, reason, _ = guard.assess(comments, NOW)
+    assert not in_flight
+    assert reason == "verdict-answered"
+
+
+# --- burst collapsing -----------------------------------------------------
+
+
+def test_a_duplicate_burst_is_one_round():
+    """Two triggers seconds apart get ONE verdict; two rounds would never clear.
+
+    The reviewer's dedupe guard answers a burst once, stamping whichever comment
+    id won. Counting the burst as two rounds would leave one permanently
+    unanswered and hold every later push for the full stale window.
+    """
+    comments = [
+        trigger(at(minutes=-20), comment_id=1),
+        trigger(at(minutes=-20, seconds=11), comment_id=2),
+        verdict(at(minutes=-1), answers=1),
+    ]
+    assert len(guard.logical_rounds(comments)) == 1
+    in_flight, reason, _ = guard.assess(comments, NOW)
+    assert not in_flight
+    assert reason == "verdict-answered"
+
+
+def test_triggers_beyond_the_burst_window_are_separate_rounds():
+    comments = [
+        trigger(at(minutes=-20), comment_id=1),
+        trigger(at(minutes=-5), comment_id=2),
+    ]
+    assert len(guard.logical_rounds(comments)) == 2
+
+
+def test_burst_window_is_configurable():
+    comments = [
+        trigger(at(minutes=-20), comment_id=1),
+        trigger(at(minutes=-19), comment_id=2),
+    ]
+    assert len(guard.logical_rounds(comments, burst_window_seconds=30)) == 2
+    assert len(guard.logical_rounds(comments, burst_window_seconds=120)) == 1
+
+
+def test_a_burst_is_declined_only_when_every_trigger_was():
+    """One accepted trigger in the burst means a review ran."""
+    mixed = [
+        trigger(at(minutes=-5), comment_id=1, declined=True),
+        trigger(at(minutes=-5, seconds=11), comment_id=2),
+    ]
+    assert not guard.logical_rounds(mixed)[0].declined
+    assert guard.assess(mixed, NOW)[0]
+
+    both = [
+        trigger(at(minutes=-5), comment_id=1, declined=True),
+        trigger(at(minutes=-5, seconds=11), comment_id=2, declined=True),
+    ]
+    assert guard.logical_rounds(both)[0].declined
+    assert guard.assess(both, NOW)[1] == "trigger-declined"
+
+
+def test_round_age_is_measured_from_its_last_trigger():
+    comments = [
+        trigger(at(minutes=-41), comment_id=1),
+        trigger(at(minutes=-40, seconds=-30), comment_id=2),
+    ]
+    # One round (30s apart); its last trigger is 2430s old, past the 2400 cap.
+    assert len(guard.logical_rounds(comments)) == 1
+    assert guard.assess(comments, NOW)[1] == "trigger-stale"
+
+
+def test_a_trigger_without_an_id_does_not_break_the_round():
+    """Defensive: a comment payload missing `id` still forms a usable round."""
+    comment = trigger(at(minutes=-5))
+    del comment["id"]
+    rounds = guard.logical_rounds([comment])
+    assert rounds[0].ids == frozenset()
+    assert guard.assess([comment], NOW)[0]
+
+
 # --- comment classification ----------------------------------------------
 
 
@@ -216,9 +395,9 @@ def test_verdict_from_a_non_reviewer_login_is_not_an_answer():
 
 def test_newest_trigger_wins_over_an_older_answered_one():
     comments = [
-        trigger(at(minutes=-40)),
-        verdict(at(minutes=-25)),
-        trigger(at(minutes=-3)),
+        trigger(at(minutes=-40), comment_id=1),
+        verdict(at(minutes=-25), answers=1),
+        trigger(at(minutes=-3), comment_id=2),
     ]
     in_flight, reason, _ = guard.assess(comments, NOW)
     assert in_flight
@@ -227,16 +406,19 @@ def test_newest_trigger_wins_over_an_older_answered_one():
 
 def test_out_of_order_listing_is_sorted_by_timestamp():
     """Correct even if the API stops returning comments oldest-first."""
-    comments = [trigger(at(minutes=-3)), trigger(at(minutes=-40))]
+    comments = [
+        trigger(at(minutes=-3), comment_id=2),
+        trigger(at(minutes=-40), comment_id=1),
+    ]
     in_flight, reason, _ = guard.assess(comments, NOW)
     assert in_flight
     assert reason == "review-in-flight"
 
 
 def test_undated_comments_are_skipped_not_sorted_first():
-    undated = trigger(at(minutes=-3))
+    undated = trigger(at(minutes=-3), comment_id=2)
     undated["created_at"] = "not-a-timestamp"
-    comments = [undated, trigger(at(minutes=-41))]
+    comments = [undated, trigger(at(minutes=-41), comment_id=1)]
     in_flight, reason, _ = guard.assess(comments, NOW)
     assert not in_flight
     assert reason == "trigger-stale"

--- a/.mothership/pr-resolve/CLAUDE.md
+++ b/.mothership/pr-resolve/CLAUDE.md
@@ -38,6 +38,16 @@ auto-merge loop is what the SDK-evolution rebuild was undoing).
 > the same turn you posted the trigger or before you have consumed a review reply
 > this run. (This is the exact failure to never repeat: trigger the review, then
 > exit before it answers — leaving every finding unaddressed.)
+>
+> **And that window is a no-push window.** The reviewer works from the HEAD it saw
+> when it started. Push between your trigger and its verdict and the verdict
+> arrives stamped for a sha that is no longer HEAD; `sdk_review_approve.py`
+> compares the two, declines every stamp (no labels, no approval, no status), and
+> the round is spent for nothing. Gate **every** push on
+> `python3 .github/scripts/sdk_resolve_push_guard.py --pr "$PR_NUMBER" --wait` —
+> exit 10 means hold the change for the next round. One push per round, and land
+> any CI fix you already know about *before* you trigger, never after the verdict
+> comes back. Details: ORCHESTRATION **Commit + push rules**.
 
 1. **Minimal, targeted fixes only** — address the finding; no drive-by refactor.
 2. **Prove-false is allowed; a re-raised dismissal ends the run** — a finding you
@@ -50,7 +60,8 @@ auto-merge loop is what the SDK-evolution rebuild was undoing).
 3. **Expect the reset churn** — every push fires `reset-on-push` (strips
    `sdk-review-*` labels, resets the `sdk-review` status) and re-runs CI. That
    is normal. Key your loop off the *reviewer's findings + CI*, never off the
-   labels/status you just reset.
+   labels/status you just reset. What is NOT normal is churning a review you have
+   in flight — see the no-push window above.
 4. **CI never gates the review** — greening CI is best-effort and only a
    head start / round-saver, NOT an entry condition. If CI won't go green, still
    run `@sdk-review` (the review is valuable on red CI and often explains the

--- a/.mothership/pr-resolve/ORCHESTRATION.md
+++ b/.mothership/pr-resolve/ORCHESTRATION.md
@@ -37,7 +37,9 @@ git push
 ```
 
 `--wait` blocks (printing a heartbeat) until the in-flight review answers, then
-exits 0. Exit **10** means it gave up: either the trigger has gone 40 min
+exits 0. "Answers" means the same thing it means in 3b — the reviewer's
+`ANSWERS_TRIGGER` echo of *your* trigger, not merely a verdict with a later
+timestamp. Exit **10** means it gave up: either the trigger has gone 40 min
 unanswered (reviewer sandbox died) or the 30-min wait budget elapsed. On exit 10
 do **not** push — carry the change into the next round and push it once the
 verdict has been consumed. Never `git push` without the guard in front of it,
@@ -167,15 +169,32 @@ REPLY=""
 deadline=$(( $(date +%s) + 2400 ))
 while [ "$(date +%s)" -lt "$deadline" ]; do
   REPLY=$(gh pr view "$PR_NUMBER" --json comments --jq \
-    "[.comments[] | select(.createdAt > \"$TRIGGER_TIME\")
+    "[.comments[]
        | select(.author.login | test(\"mothership\"))
-       | select(.body | contains(\"<!-- SDK_REVIEW -->\"))] | last | .url // empty")
+       | select(.body | contains(\"<!-- SDK_REVIEW -->\"))
+       | select(
+           (.body | contains(\"<!-- ANSWERS_TRIGGER: $TRIGGER_ID -->\"))
+           or ((.body | test(\"<!-- ANSWERS_TRIGGER: [0-9]+ -->\") | not)
+               and (.createdAt > \"$TRIGGER_TIME\"))
+         )] | last | .url // empty")
   [ -n "$REPLY" ] && break
   echo "[3b] waiting for @sdk-review reply … $(date -u +%H:%M:%S)"
   sleep 30
 done
 [ -z "$REPLY" ] && echo "[3b] no reply after 40 min — stopped_reason=review-timeout"
 ```
+
+**Why the filter is not just `createdAt > TRIGGER_TIME`.** Two reviews can be
+outstanding on one PR at once — the reviewer's sandbox runs up to 2h while this
+wait is 40 min, and a human can tag `@sdk-review` mid-review. An earlier round's
+verdict then lands *after* your trigger, and a timestamp-only filter latches it:
+you act on a verdict computed for a HEAD that is no longer current, and the
+review actually running has its verdict stranded. So match on the reviewer's
+`<!-- ANSWERS_TRIGGER: <comment id> -->` echo of the trigger it answers
+(`.mothership/pr-review/ORCHESTRATION.md` §3e), and fall back to the timestamp
+only for a verdict that carries no such stamp — a `workflow_dispatch` review, or
+one predating the marker. `sdk_resolve_push_guard.py` applies the same rule; keep
+the two in step.
 
 Take the **last** matching comment (never a CI comment, a human comment, the
 `@sdk-review` trigger you just posted, or an older review). If the wait elapses

--- a/.mothership/pr-resolve/ORCHESTRATION.md
+++ b/.mothership/pr-resolve/ORCHESTRATION.md
@@ -14,6 +14,56 @@ Never fabricate a CI result or a reviewer comment. Always read real state from
 
 ---
 
+## Commit + push rules
+
+Referenced by every phase that writes. Two invariants, then the mechanics.
+
+### 1. Never push while a review is in flight
+
+`@sdk-review` runs in its **own sandbox** against the HEAD it saw when it
+started. Pushing between your trigger (3a) and its verdict (3b) moves HEAD out
+from under it: the verdict lands stamped `REVIEWED_HEAD: <the sha you just
+replaced>`, `sdk_review_approve.py` compares that stamp against the live head,
+and declines *every* stamp — no labels, no approval, no commit status. The round
+produced nothing and you have one fewer left. The two lanes have no shared
+notion of a round, so this window is yours to respect.
+
+The trigger→verdict window is a **no-push window**, and it is not a judgement
+call. Run the guard before every `git push`, in every phase:
+
+```bash
+python3 .github/scripts/sdk_resolve_push_guard.py --pr "$PR_NUMBER" --wait
+git push
+```
+
+`--wait` blocks (printing a heartbeat) until the in-flight review answers, then
+exits 0. Exit **10** means it gave up: either the trigger has gone 40 min
+unanswered (reviewer sandbox died) or the 30-min wait budget elapsed. On exit 10
+do **not** push — carry the change into the next round and push it once the
+verdict has been consumed. Never `git push` without the guard in front of it,
+and never route around a hold by amending or force-pushing.
+
+### 2. One push per round
+
+Batch the round's work — CI fixes *and* review-finding fixes — into a single
+push, then re-trigger. Every push fires `reset-on-push` (strips the
+`sdk-review-*` labels, resets the `sdk-review` status) and restarts CI, so two
+pushes per round buys two CI waves and two label resets for one review.
+
+The corollary binds Phase 1 and Phase 3e: **finish the head before you trigger
+on it.** If you already know CI on the current HEAD needs a fix you can make,
+make it and push it *before* posting `@sdk-review` — not after the verdict comes
+back. A review triggered on a head you are about to change is a review you have
+chosen to throw away, and it takes an earned approval with it. (Guardrail 4 is
+unchanged: red CI you *cannot* fix never blocks the review — trigger anyway.)
+
+### 3. Mechanics
+
+Conventional Commits. Commit specific files; never `git add -A`, `--amend`,
+`--no-verify`, or force-push. Never touch `CHANGELOG.md`. No Co-Authored-By.
+
+---
+
 ## Phase 0: Preflight
 
 ```bash
@@ -43,8 +93,9 @@ then:
   the diff) → do NOT touch; note it and move on.
 
 If you changed files: `uv run pre-commit run --files <changed>`, run the relevant
-tests, then commit + push (see Commit rules). Re-watch and repeat. Cap: **5 fix
-attempts**.
+tests, then commit + push (see **Commit + push rules** — the push guard applies
+here too, even though no review has been triggered yet: a *human* may have tagged
+`@sdk-review` before you started). Re-watch and repeat. Cap: **5 fix attempts**.
 
 **Best-effort, NON-blocking — never skip the review over red CI.** This phase
 is a quick head start on the obvious failures, not a gate. If CI is still red
@@ -64,7 +115,8 @@ Fetch unresolved, non-outdated review threads whose first comment author login
 contains `copilot` (GraphQL — see the `automate-pr` skill for the exact query).
 For each: read the code, **fix** or **dismiss as false-positive with a
 rationale**, always reply on the thread, then resolve the thread via
-`resolveReviewThread`. Push any fixes. Cap: **3 rounds**, then move on.
+`resolveReviewThread`. Push any fixes (through the guard — see **Commit + push
+rules**). Cap: **3 rounds**, then move on.
 
 Print: `[Phase 2 complete] copilot=<N fixed>/<M dismissed>`
 
@@ -75,6 +127,12 @@ Print: `[Phase 2 complete] copilot=<N fixed>/<M dismissed>`
 Repeat up to `MAX_ROUNDS`:
 
 ### 3a. Trigger the reviewer (its own sandbox)
+
+**Before you post the trigger:** the HEAD you trigger on is the HEAD you are
+committing to leave standing until the verdict lands. Land any CI fix you
+already know you are going to make *first* (**Commit + push rules** §2) — from
+the moment this comment posts until 3c consumes the reply, you must not push.
+
 ```bash
 TRIGGER_URL=$(gh pr comment "$PR_NUMBER" --body "@sdk-review") || TRIGGER_URL=""
 # Validate the comment actually landed — a swallowed gh failure here would make
@@ -199,13 +257,19 @@ For each bullet, incl. every nit:
 
 ### 3e. Commit, push, re-green CI (best-effort)
 `uv run pre-commit run --files <changed>` → relevant tests → commit specific
-files → push. The push resets the reviewer labels/status (expected). Then make a
-best-effort pass at greening CI on the new HEAD before re-triggering, so you
-don't waste a round on a failure you just introduced — but if CI stays red for a
-reason you can't fix, still re-trigger the review (same rule as Phase 1: red CI
-never blocks the review). Looping back to 3a posts a fresh `@sdk-review` comment
-on the PR — that comment is the visible "re-running the review now" signal the
-3c′ acknowledgement promised, so the handoff is observable end to end.
+files → **run the push guard** → push. You are past 3c here, so the guard
+normally clears immediately; run it anyway — a human may have tagged
+`@sdk-review` while you were fixing, and that review is as real as yours.
+
+The push resets the reviewer labels/status (expected). Then make a best-effort
+pass at greening CI on the new HEAD **before** re-triggering, so you don't waste
+a round on a failure you just introduced, and fold any fix it needs into this
+same round rather than pushing again after the next verdict (**Commit + push
+rules** §2) — but if CI stays red for a reason you can't fix, still re-trigger
+the review (same rule as Phase 1: red CI never blocks the review). Looping back
+to 3a posts a fresh `@sdk-review` comment on the PR — that comment is the visible
+"re-running the review now" signal the 3c′ acknowledgement promised, so the
+handoff is observable end to end.
 
 ### 3f. Repeat → 3a.
 
@@ -267,6 +331,9 @@ Print: `[Phase 4 complete] merge_ready=<yes|no>`
   `READY_TO_MERGE`, then hand back to a human.
 - **The reviewer stays read-only.** You are the only writer; it runs in its own
   sandbox and you consume its comment output.
+- **Never push under a review in flight.** The trigger→verdict window is a
+  no-push window; `sdk_resolve_push_guard.py --wait` gates every push. A push
+  inside it discards the verdict as stale and burns the round.
 - **A round isn't done until the review answers.** Posting `@sdk-review` only
   triggers the reviewer's separate sandbox — block for its reply (Phase 3b)
   before ending the run or emitting the summary. Never exit the same turn you

--- a/.mothership/pr-review/CLAUDE.md
+++ b/.mothership/pr-review/CLAUDE.md
@@ -128,6 +128,7 @@ Don't just say "this is wrong." Say what the right path forward is.
 - Read-only on cloned repos. NEVER `git commit` or `git push` to the PR branch.
 - Post reviews via `gh pr comment` / `gh pr review` / `gh api` from inside the sandbox (see ORCHESTRATION 3f). No mothership-side review handler exists.
 - After posting the review: do NOT apply SDK labels yourself — the GHA layer parses the structured `<!-- VERDICT: X -->` marker and owns labels, the `sdk-review` commit status, and the atlan-ci approval. See ORCHESTRATION 3c.
+- Keep the `<!-- ANSWERS_TRIGGER: <comment id> -->` marker on every verdict you post from a comment trigger (`COMMENT_ID` from the prompt header, raw digits; omit the line on `workflow_dispatch`). It is how the resolver's push guard tells your verdict from an earlier round's — drop it and a push can land mid-review and strand the verdict you just wrote. See ORCHESTRATION 3e.
 - After posting on APPROVE: resolve bot inline threads via GraphQL (see ORCHESTRATION 3d).
 - PATCH scope findings: include exact fix code in suggested_fix (for the human to apply — the review never applies fixes itself).
 - DESIGN_CHANGE scope: flag for human decision.

--- a/.mothership/pr-review/ORCHESTRATION.md
+++ b/.mothership/pr-review/ORCHESTRATION.md
@@ -1275,7 +1275,19 @@ SHA from the prompt header — write the raw hex characters, never the
 literal placeholder text `<HEAD_SHA>`.** The §3f submit step adds a
 shell-level safety net (`sed`) in case the LLM writes the placeholder,
 but the correct value must come from the reviewed HEAD, not a live
-re-fetch. For toolkit scopes, the fourth marker
+re-fetch. The fourth marker `<!-- ANSWERS_TRIGGER: <comment id> -->`
+records **which** `@sdk-review` comment this verdict answers — write
+`COMMENT_ID` from the prompt header verbatim, raw digits only. On a
+`workflow_dispatch` run `COMMENT_ID` is blank; **omit the whole line**
+rather than writing an empty or placeholder value. Two reviews can be
+outstanding on one PR at once (this sandbox runs up to 2h while the
+resolver's per-round wait is 40 min, and a human can re-tag mid-review),
+so a verdict's timestamp alone cannot say which request it answers. The
+resolver's push guard reads this marker to tell "the round I am waiting
+on has answered" from "an earlier round's verdict landed late"; without
+it, it falls back to comparing timestamps and can clear a push while
+this review is still running — stranding the verdict you are about to
+post. For toolkit scopes, the fifth marker
 `<!-- TOOLKIT_ARTIFACT_HASH: <sha256> -->` records the PR-generated
 artifact hash from Phase 1b-toolkit so the next round can carry
 consumer validation forward; omit the line entirely for non-toolkit
@@ -1285,6 +1297,7 @@ scopes.
 <!-- SDK_REVIEW -->
 <!-- VERDICT: READY_TO_MERGE | NEEDS_FIXES | BLOCKED | NEEDS_HUMAN | NEEDS_REBASE -->
 <!-- REVIEWED_HEAD: <HEAD_SHA> -->
+<!-- ANSWERS_TRIGGER: <COMMENT_ID> -->            <!-- omit on workflow_dispatch -->
 <!-- TOOLKIT_ARTIFACT_HASH: <ARTIFACT_HASH> -->   <!-- toolkit scopes only -->
 ## SDK <Review | Re-review> (mothership): PR #<number> — <title>
 <!-- For review_scope=contract-toolkit, write this heading as:
@@ -1444,6 +1457,16 @@ gh api "repos/$REPO/statuses/$HEAD_SHA" \
 # pattern finds no match and the file is unchanged.
 HEAD_SHA_STAMPED=$(jq -r '.headRefOid' /tmp/PR.json)
 sed -i "s|<!-- REVIEWED_HEAD: <HEAD_SHA> -->|<!-- REVIEWED_HEAD: ${HEAD_SHA_STAMPED} -->|" /tmp/review-summary.md
+
+# Same safety net for ANSWERS_TRIGGER. COMMENT_ID is from the prompt
+# header (set it as a shell var, as Phase 0 step 6b does) and is blank
+# on workflow_dispatch — so stamp it, then delete the line outright if
+# the value came out empty. An empty marker is worse than none: the
+# push guard would read it as "this verdict names a round, and it is not
+# yours" and hold the resolver's push for the full stale window.
+# Both seds are idempotent — a correctly-written line matches neither.
+sed -i "s|<!-- ANSWERS_TRIGGER: <COMMENT_ID> -->|<!-- ANSWERS_TRIGGER: ${COMMENT_ID} -->|" /tmp/review-summary.md
+sed -i '/<!-- ANSWERS_TRIGGER: *-->/d' /tmp/review-summary.md
 
 # Summary comment (the body built in 3a, including the
 # <!-- SDK_REVIEW --> marker and the <!-- REVIEW_DATA --> JSON) — LAST:


### PR DESCRIPTION
## Problem

`@sdk-review` (read-only) and `@sdk-resolve` (the only writer) run in separate sandboxes, and the resolver *triggers* the reviewer then blocks for its reply (`ORCHESTRATION.md` Phase 3a → 3b). Both lanes are live at once by design, and neither had a shared notion of a round.

A push inside the trigger → verdict window moves HEAD out from under the review in flight. The verdict then lands stamped `REVIEWED_HEAD: <the sha that was replaced>`, `sdk_review_approve.py` compares it against the live head and declines *every* stamp — no labels, no approval, no commit status. The round produced nothing and the resolver has one fewer left.

## Why not a shared concurrency group

The obvious fix — one per-PR concurrency group across `sdk-review.yml` and `sdk-resolve.yml` — deadlocks:

1. resolve acquires the group, posts `@sdk-review`, blocks for up to 40 min
2. `sdk-review-dispatch` queues behind it (`cancel-in-progress: false`, which is load-bearing for an unrelated reason — a `true` there once killed a review 28 minutes in)
3. resolve's wait elapses → `stopped_reason: review-timeout` → `NEEDS_HUMAN`

Every run, not an edge case. Flipping the review's `cancel-in-progress` to `true` is worse: the review cancels the resolver mid-loop. The invariant has to be enforced at the push.

## What this does

**1. `sdk_resolve_push_guard.py` — the invariant, at the push.** Run before every `git push`, in every phase. A review is in flight when the newest `@sdk-review` trigger comment is unanswered:

- no reviewer-bot verdict comment since it, **and**
- no `confused` reaction on it — `sdk-review.yml`'s gate reacts 😕 to a trigger it consciously declines and deliberately posts no comment, so without reading that reaction a declined trigger looks unanswered forever, **and**
- younger than `--max-inflight-seconds` (default 2400, matching the resolver's own Phase 3b wait) so a reviewer sandbox that died mid-run cannot wedge the resolver

`--wait` blocks with a heartbeat until it clears, then exits 0. Exit 10 means hold the change for the next round.

It **fails open** on every unreadable-state path (`gh` non-zero, unparseable JSON, unparseable timestamp), same stance as `sdk_review_gate.py` and for the same reason: a missed hold costs one round, a false hold costs *every* push. The wait loop is bounded by poll count as well as by wall clock — a clock that does not advance would otherwise make the elapsed check unfalsifiable and spin the loop forever.

**2. The ordering rule.** New `Commit + push rules` section in the playbook, which also fills in the dangling `(see Commit rules)` reference Phase 1 has always had:

- one push per round — batch CI fixes and review-finding fixes together
- **land a CI fix you already know about *before* you trigger**, not after the verdict comes back

That second rule is the one that matters for the case in FND-639: a review triggered on a head you are about to change is a review, and an earned approval, you have chosen to throw away. Guardrail 4 is unchanged — red CI you *cannot* fix still never blocks the review.

## Already in place

The round token itself needed no work. The reviewer already stamps `<!-- REVIEWED_HEAD: <sha> -->` and `sdk_review_approve.py` already declines on a mismatch — that guard is why this race shows up as "nothing happened" rather than as an approval on unreviewed code. This change is its resolve-side counterpart.

## Files

| File | Change |
| --- | --- |
| `.github/scripts/sdk_resolve_push_guard.py` | new — the guard |
| `.github/scripts/tests/test_sdk_resolve_push_guard.py` | new — 35 tests |
| `.mothership/pr-resolve/ORCHESTRATION.md` | `Commit + push rules`; wired into Phases 1, 2, 3a, 3e and Principles |
| `.mothership/pr-resolve/CLAUDE.md` | no-push window folded into the paramount blockquote |

No workflow YAML changes.

## Testing

- 35 new tests, covering both directions: every hold path, and every fail-open path (declined trigger, dead reviewer, unreadable API, stalled clock)
- full `.github/scripts/tests` suite green — 2621 passed
- `pre-commit` clean (ruff, ruff-format, isort, pyright)

Refs [FND-639](https://linear.app/atlan-epd/issue/FND-639/sdk-resolve-and-sdk-review-race-each-other-on-the-same-pr)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
