### PR TITLE
ci(renovate): restore the committed lock when the bound refuses (FND-379)

### DIFF
--- a/.github/scripts/renovate_uv_lock_bounded.py
+++ b/.github/scripts/renovate_uv_lock_bounded.py
@@ -237,6 +237,23 @@ def retention_ceilings(
     return ceilings
 
 
+def restore(lock_path: Path, baseline: str) -> None:
+    """Put the committed lock back, for every path that refuses to bound.
+
+    The driver does not own the commit. Under Renovate's ``postUpgradeTasks`` the
+    working tree is committed once the command returns, pass or fail, so a guard
+    that only returns non-zero does not actually withhold the resolve it just
+    rejected — it ships it with ``[options]`` still in place, and ``uv sync
+    --locked`` then fails in the image build (FND-367). Five fleet lock branches
+    were stranded exactly that way before this existed.
+
+    An empty baseline means the ref had no committed ``uv.lock`` at all; there is
+    nothing to restore and truncating the file would be worse than leaving it.
+    """
+    if baseline:
+        lock_path.write_text(baseline)
+
+
 def strip_options(lock_text: str) -> str:
     """Remove the ``[options]`` table and any ``[options.*]`` subtable.
 
@@ -635,10 +652,12 @@ def main(argv: list[str] | None = None) -> int:
         )
         admitted_early = blocked_by_floor(result.stderr, floors)
         if not admitted_early:
+            restore(lock_path, baseline)
             print(
                 "Bounded `uv lock` failed and no deliberately-floored package was "
                 "named in the error, so there is nothing safe to admit early. "
-                "Refusing to fall back to an unbounded resolve.\n" + result.stderr,
+                "Refusing to fall back to an unbounded resolve. The committed "
+                "lock has been restored.\n" + result.stderr,
                 file=sys.stderr,
             )
             return 1
@@ -647,9 +666,11 @@ def main(argv: list[str] | None = None) -> int:
             project_dir,
         )
         if result.returncode != 0:
+            restore(lock_path, baseline)
             print(
                 "Bounded `uv lock` still failed after admitting "
-                f"{', '.join(admitted_early)}.\n" + result.stderr,
+                f"{', '.join(admitted_early)}. The committed lock has been "
+                "restored.\n" + result.stderr,
                 file=sys.stderr,
             )
             return 1
@@ -661,13 +682,18 @@ def main(argv: list[str] | None = None) -> int:
         detail = ", ".join(
             f"{n} {old} -> {new}" for n, (old, new) in sorted(regressed.items())
         )
+        restore(lock_path, baseline)
         print(
             f"Bounded resolve moved {len(regressed)} package(s) BACKWARDS from the "
-            f"last committed lock: {detail}. Retention ceilings should make an "
-            "age-driven downgrade impossible, so this means something else forced "
-            "a different solution — most often a yanked release, sometimes a "
-            "changed constraint. Both are worth a human and neither is worth "
-            "auto-merging, so nothing is committed.",
+            f"last committed lock: {detail}. Retention ceilings make an age-driven "
+            "downgrade impossible, so something else forced a different solution. "
+            "Check first whether the base branch pins a release that has since "
+            "been YANKED upstream — `pip index versions <name>` or the PyPI JSON "
+            "API will say — because no resolve can keep a yanked pin and every "
+            "one of them will land here until the base branch moves off it. A "
+            "changed constraint is the other candidate. Either way it wants a "
+            "human, so the committed lock has been restored and this run bounds "
+            "nothing.",
             file=sys.stderr,
         )
         return 1

--- a/.github/scripts/tests/test_renovate_uv_lock_bounded.py
+++ b/.github/scripts/tests/test_renovate_uv_lock_bounded.py
@@ -840,3 +840,123 @@ class TestBaselineRef:
             ]
         )
         assert exit_code == 1
+
+
+class TestFailsClean:
+    """Refusing to bound has to withhold the resolve, not merely exit non-zero.
+
+    The driver does not own the commit. Under `postUpgradeTasks` Renovate commits
+    the working tree once the command returns, pass or fail — so every refusal
+    path has to put the committed lock back, or the rejected resolve reaches the
+    branch anyway carrying `[options]`, and `uv sync --locked` fails in the image
+    build (FND-367). Five fleet lock branches were stranded that way, three of
+    them by the same yanked release.
+    """
+
+    GIT_ENV = {
+        "GIT_AUTHOR_NAME": "t",
+        "GIT_AUTHOR_EMAIL": "t@t",
+        "GIT_COMMITTER_NAME": "t",
+        "GIT_COMMITTER_EMAIL": "t@t",
+        "PATH": os.environ.get("PATH", ""),
+    }
+
+    def _repo(self, tmp_path: Path, lock_text: str, pyproject: str = "") -> Path:
+        (tmp_path / "uv.lock").write_text(lock_text)
+        (tmp_path / "pyproject.toml").write_text(
+            pyproject or "[project]\nname = 'app'\n"
+        )
+        for command in (
+            ["git", "init", "-q"],
+            ["git", "add", "-A"],
+            ["git", "commit", "-qm", "baseline"],
+        ):
+            subprocess.run(command, cwd=tmp_path, check=True, env=self.GIT_ENV)
+        return tmp_path
+
+    def test_a_rejected_downgrade_restores_the_committed_lock(
+        self, monkeypatch, tmp_path
+    ):
+        """The production case, in the shape it actually happened.
+
+        A base branch pinning a release upstream later yanked: no resolve can keep
+        it, so every bounded run comes back a version lower and trips the rollback
+        gate. Exit 1 was already right; what was missing is that the working tree
+        still held the rejected lock, `[options]` and all, for Renovate to commit.
+        """
+        committed = lock(pytest_timeout="2.5.0")
+        project = self._repo(tmp_path, committed)
+
+        # One document, not two concatenated ones: a lock whose TOML does not
+        # parse would read as "no versions at all" and pass this test for the
+        # wrong reason.
+        resolved = LOCK_WITH_OPTIONS + (
+            '\n[[package]]\nname = "pytest-timeout"\nversion = "2.4.0"\n'
+            'source = { registry = "https://pypi.org/simple" }\n'
+        )
+        assert bounded.lock_versions(resolved)["pytest-timeout"] == "2.4.0"
+
+        def fake_run(command, cwd):
+            (Path(cwd) / "uv.lock").write_text(resolved)
+            return subprocess.CompletedProcess(command, 0, "", "")
+
+        monkeypatch.setattr(bounded, "run_uv_lock", fake_run)
+        assert bounded.main(["--window", "P3D", "--project-dir", str(project)]) == 1
+        on_disk = (project / "uv.lock").read_text()
+        assert on_disk == committed, "the rejected resolve must not survive on disk"
+        assert "[options]" not in on_disk
+        assert '"2.4.0"' not in on_disk
+
+    def test_a_failed_resolve_restores_the_committed_lock(self, monkeypatch, tmp_path):
+        # uv can rewrite the lock and *then* fail. Same exposure: whatever it left
+        # behind is what Renovate would commit.
+        committed = lock(boto3="1.43.72")
+        project = self._repo(tmp_path, committed)
+
+        def fake_run(command, cwd):
+            (Path(cwd) / "uv.lock").write_text(LOCK_WITH_OPTIONS)
+            return subprocess.CompletedProcess(
+                command, 1, "", "error: something else entirely"
+            )
+
+        monkeypatch.setattr(bounded, "run_uv_lock", fake_run)
+        assert bounded.main(["--window", "P3D", "--project-dir", str(project)]) == 1
+        assert (project / "uv.lock").read_text() == committed
+
+    def test_a_failed_retry_restores_the_committed_lock(self, monkeypatch, tmp_path):
+        # The floored-package retry path: admitting the floor early does not help,
+        # and the second failure has to clean up after itself too.
+        committed = lock(cryptography="46.0.5")
+        project = self._repo(
+            tmp_path,
+            committed,
+            "[project]\nname = 'app'\n\n[tool.uv]\n"
+            'constraint-dependencies = ["cryptography>=46.0.5"]\n',
+        )
+        calls: list[list[str]] = []
+
+        def fake_run(command, cwd):
+            calls.append(command)
+            (Path(cwd) / "uv.lock").write_text(LOCK_WITH_OPTIONS)
+            return subprocess.CompletedProcess(
+                command, 1, "", "error: No solution found ... cryptography>=46.0.5 ..."
+            )
+
+        monkeypatch.setattr(bounded, "run_uv_lock", fake_run)
+        assert bounded.main(["--window", "P3D", "--project-dir", str(project)]) == 1
+        assert len(calls) == 2, "the floor should have earned exactly one retry"
+        assert (project / "uv.lock").read_text() == committed
+
+    def test_restore_leaves_a_lock_with_no_baseline_alone(self, tmp_path):
+        # A lock added in this very branch has no committed copy to restore. An
+        # empty baseline must be a no-op, never a truncation.
+        target = tmp_path / "uv.lock"
+        target.write_text(LOCK_WITH_OPTIONS)
+        bounded.restore(target, "")
+        assert target.read_text() == LOCK_WITH_OPTIONS
+
+    def test_restore_writes_the_baseline_back(self, tmp_path):
+        target = tmp_path / "uv.lock"
+        target.write_text(LOCK_WITH_OPTIONS)
+        bounded.restore(target, lock(boto3="1.43.72"))
+        assert target.read_text() == lock(boto3="1.43.72")


### PR DESCRIPTION
## What

Every path in `renovate_uv_lock_bounded.py` that refuses to bound now restores the committed `uv.lock` before returning non-zero, and the rollback message names a yanked upstream release as the first thing to check.

## Why

The driver does not own the commit. Under Renovate's `postUpgradeTasks` the working tree is committed once the command returns — pass or fail — so a guard that only exits non-zero does not actually withhold the resolve it just rejected. It ships it, with `[options]` still in place, and `uv sync --locked` then fails in the image build. That is FND-367's failure, reached from a direction the strip cannot cover:

```
#13 0.990 error: The lockfile at `uv.lock` needs to be updated, but `--locked` was provided.
```

Five fleet lock-maintenance branches are currently stranded this way (`[options]` present on the branch, `renovate/artifacts` + `scan / Build Image` + `scan / Security Gate` red). Four carry `exclude-newer-span = "P7D"`, so this has been happening since the 7-day rollout; it is not new to the 3-day cut.

Three of the five are wedged by the same upstream event: their base branch pins `pytest-timeout 2.5.0`, which PyPI has since **yanked** ("accidental breaking change (probably)"). No resolve can keep a yanked pin, so every bounded run comes back at 2.4.0, trips the rollback gate, and — before this change — left the rejected lock on the branch. Unpinning those three repos is handled separately; this PR is the mechanism fix, so a future yank strands nothing.

`bound_lock_branch.py` (application-sdk's own lane, FND-376) was never exposed: it owns its commit and returns before staging. The restore is harmless there and leaves a clean tree.

## Tests

`TestFailsClean` covers all three refusal paths plus the `restore` helper itself. Verified red before the fix (5 failed, including the assertion that `[options]` survived on disk) and green after (77 passed across both driver suites).
