### PR TITLE
ci(sdk-resolve): re-dispatch on a different model when the sandbox dies (FND-641)

### DIFF
--- a/.github/scripts/sdk_resolve_dispatch.py
+++ b/.github/scripts/sdk_resolve_dispatch.py
@@ -86,9 +86,8 @@ RETRY_MAIN_MODEL = "claude-opus-5"
 # Retry only a fault a different model can plausibly survive. This is an
 # allowlist, not a denylist: a wrong retry burns a second sandbox boot — up to
 # an hour of the job's 130-min budget plus a real bill — so an unrecognised
-# cause stays fail-fast. Codes match exactly; patterns match as lowercase
-# substrings of "<code> <message>", because mothership passes provider text
-# through with the code sometimes flattened to `none`.
+# cause stays fail-fast. A recognised code decides on its own; the message is
+# consulted ONLY when the code carries no information at all.
 RETRYABLE_ERR_CODES = frozenset(
     {
         "400",
@@ -104,6 +103,12 @@ RETRYABLE_ERR_CODES = frozenset(
         "sandbox_error",
     }
 )
+# Message substrings that identify a model/provider fault. These are a fallback
+# for one specific case: a `complete` event flattens an absent error code to
+# `none`, and a standalone `error` event defaults it to `unknown`, while both
+# still forward the provider's own text. They must NEVER override a code that
+# does carry information — "401 upstream auth failed" mentions upstream and is
+# nonetheless a permanent fault that would fail identically on any model.
 RETRYABLE_ERR_PATTERNS = (
     "must not be empty",  # the kimi-k3 empty-assistant-turn fault
     "rate-limited",
@@ -112,6 +117,7 @@ RETRYABLE_ERR_PATTERNS = (
     "temporarily unavailable",
     "upstream",
 )
+UNINFORMATIVE_ERR_CODES = frozenset({"", "none", "unknown"})
 # Causes that fail identically on any model — never spend a second sandbox:
 #   elicitation   the sandbox wants interactive input, which GHA can never give.
 #   stream_error  OUR urlopen died, not the sandbox. The resolver is probably
@@ -728,16 +734,20 @@ def oob_poll_budget(st: SSEState) -> int:
 def is_retryable_fault(st: SSEState) -> bool:
     """True when the cause looks like a model/provider fault, not a fixed one.
 
-    Allowlist by code, then by substring of "<code> <message>" — mothership
-    forwards the provider's own text, and the code that carries it is not always
-    the numeric one (`complete` events flatten an absent code to `none`).
+    The code decides whenever it carries information: a recognised retryable one
+    retries, and anything else — 401, 403, a prompt fault — does not. The message
+    patterns are consulted only for a code of `none`/`unknown`/empty, which is
+    the flattened-code case they exist for. Letting them speak for a known code
+    would classify "401 upstream auth failed" as retryable and buy a second
+    sandbox that fails identically.
     """
     if st.err_code in NEVER_RETRY_ERR_CODES:
         return False
     if st.err_code in RETRYABLE_ERR_CODES:
         return True
-    blob = f"{st.err_code} {st.err_msg}".lower()
-    return any(pattern in blob for pattern in RETRYABLE_ERR_PATTERNS)
+    if st.err_code not in UNINFORMATIVE_ERR_CODES:
+        return False
+    return any(p in st.err_msg.lower() for p in RETRYABLE_ERR_PATTERNS)
 
 
 def retry_decision(st: SSEState, attempt: int, seconds_left: float) -> tuple[bool, str]:

--- a/.github/scripts/sdk_resolve_dispatch.py
+++ b/.github/scripts/sdk_resolve_dispatch.py
@@ -12,6 +12,12 @@ Dispatch + SSE parsing + GITHUB_STEP_SUMMARY rendering live here (tested) rather
 than in inline workflow shell, per docs/standards/ci.md. Parses the
 `=== SDK RESOLVE SUMMARY ===` block the resolver emits (ORCHESTRATION Phase 4).
 
+One re-dispatch is allowed when the sandbox dies on a hard error that a
+different model could survive — see MAX_DISPATCH_ATTEMPTS and retry_decision().
+The retry fires only after the out-of-band poll has come back empty, which is
+the single point where the sandbox is provably dead and nothing further will
+land; every other stream ending stays fail-fast.
+
 Environment:
     MOTHERSHIP_URL      base URL (e.g. https://mothership.atlan.dev)
     HARNESS_TOKEN       bearer for /api/sandbox/execute
@@ -36,9 +42,9 @@ import sys
 import time
 import urllib.error
 import urllib.request
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Sequence
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, NamedTuple
 
 HEALTH_RETRIES = 5
 HEALTH_BACKOFF_SECONDS = 5
@@ -59,6 +65,70 @@ DEFAULT_MAX_ROUNDS = 8
 # $1.00/Mtok) — better and cheaper on the fast lane. Reverting is a one-liner.
 MAIN_MODEL = "kimi-k3"
 FAST_MODEL = "gpt-5.6-luna"
+
+# --- Re-dispatch when the sandbox dies on a hard error ----------------------
+# One retry, on a DIFFERENT main model. Mothership's intra-group provider
+# fallback already exists and already fires on a 429 — but every provider in the
+# `kimi-k3` group serves the SAME model, so a same-model re-dispatch just
+# re-hits the same model-level fault (observed: the 429 fell through to Moonshot
+# AI, which returned 400 "the message at position 21 with role 'assistant' must
+# not be empty" — same model, same bug). Swapping the model is the whole point
+# of the retry; without it the second sandbox boot fails identically.
+MAX_DISPATCH_ATTEMPTS = 2
+# Attempt 2's main model. This is mothership's own DEFAULT_CLAUDE_MODEL, named
+# explicitly rather than by omitting `model` from the payload: an explicit
+# constant lets a test assert the two attempts actually differ, and keeps the
+# retry from silently following a mothership config change. `small_fast_model`
+# and CLAUDE_CODE_SUBAGENT_MODEL stay pinned to FAST_MODEL on the retry —
+# mothership's model_routing_env does `fast = small_fast_model or model`, so
+# changing only `model` must not be allowed to drag the background lane along.
+RETRY_MAIN_MODEL = "claude-opus-5"
+# Retry only a fault a different model can plausibly survive. This is an
+# allowlist, not a denylist: a wrong retry burns a second sandbox boot — up to
+# an hour of the job's 130-min budget plus a real bill — so an unrecognised
+# cause stays fail-fast. Codes match exactly; patterns match as lowercase
+# substrings of "<code> <message>", because mothership passes provider text
+# through with the code sometimes flattened to `none`.
+RETRYABLE_ERR_CODES = frozenset(
+    {
+        "400",
+        "429",
+        "500",
+        "502",
+        "503",
+        "504",
+        "api_error",
+        "overloaded_error",
+        "provider_error",
+        "rate_limit_error",
+        "sandbox_error",
+    }
+)
+RETRYABLE_ERR_PATTERNS = (
+    "must not be empty",  # the kimi-k3 empty-assistant-turn fault
+    "rate-limited",
+    "rate limited",
+    "overloaded",
+    "temporarily unavailable",
+    "upstream",
+)
+# Causes that fail identically on any model — never spend a second sandbox:
+#   elicitation   the sandbox wants interactive input, which GHA can never give.
+#   stream_error  OUR urlopen died, not the sandbox. The resolver is probably
+#                 still alive and working, so a re-dispatch would double-run it
+#                 — the exact thing the hook point below is chosen to avoid.
+# Auth/permission and prompt faults are excluded by the allowlist above rather
+# than named here: they will fail the same way on any model, forever.
+NEVER_RETRY_ERR_CODES = frozenset({"elicitation", "stream_error"})
+# The job caps at 130 min (`timeout-minutes: 130` in sdk-resolve.yml) and the VPN
+# steps eat a few of those before dispatch starts, so budget this step at 110 min
+# from its own start. A retry is only worth booting with enough of that left to
+# finish at least one review->fix round; below the floor, fail fast rather than
+# burn a sandbox the runner will kill mid-flight. Cancelling the job does NOT
+# stop the sandbox, so the retry's own `max_timeout_seconds` is clamped to what
+# remains — otherwise a killed runner leaves it billing for up to 2h unattended.
+DISPATCH_BUDGET_SECONDS = 6600
+RETRY_MIN_REMAINING_SECONDS = 1800
 
 # --- Out-of-band hand-off backstop -----------------------------------------
 # The resolver runs in its OWN mothership sandbox; our SSE stream only observes
@@ -161,6 +231,11 @@ def _reviewer_handles(reviewers: str, requester: str) -> list[str]:
     return handles
 
 
+def attempt_model(attempt: int) -> str:
+    """Main model for this attempt — the swap that makes a retry worth booting."""
+    return MAIN_MODEL if attempt <= 1 else RETRY_MAIN_MODEL
+
+
 def build_payload(
     pr_number: str,
     gha_run_url: str,
@@ -168,12 +243,21 @@ def build_payload(
     run_date: str,
     reviewers: str,
     requester: str,
+    *,
+    attempt: int = 1,
+    max_timeout_seconds: int = STREAM_TIMEOUT_SECONDS,
 ) -> dict[str, Any]:
+    # `attempt` > 1 is a re-dispatch after the previous sandbox died on a hard
+    # error: same prompt (the resolver re-reads live PR state in Phase 0, so the
+    # second sandbox resumes wherever the first stopped), different main model.
+    # The source_id is suffixed so the two runs are distinguishable on the
+    # mothership side rather than colliding on one id.
+    suffix = "" if attempt <= 1 else f"-retry{attempt - 1}"
     return {
         "mode": "direct",
         "stream": True,
         "source": "github-comment",
-        "source_id": f"sdk-resolve-{pr_number}-{run_date}",
+        "source_id": f"sdk-resolve-{pr_number}-{run_date}{suffix}",
         "repositories": ["atlanhq/application-sdk"],
         "base_branch": "main",
         "snapshot": "_base",
@@ -184,13 +268,13 @@ def build_payload(
         # the main lane runs. `small_fast_model` must be pinned explicitly:
         # mothership's model_routing_env does `fast = small_fast_model or model`,
         # so pinning `model` alone would put the background lane on kimi-k3.
-        "model": MAIN_MODEL,
+        "model": attempt_model(attempt),
         "small_fast_model": FAST_MODEL,
         "env_vars": {"CLAUDE_CODE_SUBAGENT_MODEL": FAST_MODEL},
         "prompt": build_prompt(
             pr_number, gha_run_url, max_rounds, reviewers, requester
         ),
-        "max_timeout_seconds": STREAM_TIMEOUT_SECONDS,
+        "max_timeout_seconds": max_timeout_seconds,
         "idle_timeout_seconds": 1800,
         "metadata": {
             "pr_number": pr_number,
@@ -198,6 +282,7 @@ def build_payload(
             "run_date": run_date,
             "reviewers": reviewers,
             "requester": requester,
+            "attempt": attempt,
         },
     }
 
@@ -371,14 +456,90 @@ def _rounds_completed(summary: dict[str, str]) -> int | None:
         return None
 
 
+class Attempt(NamedTuple):
+    """One dispatch of the run: which model it ran, and how it ended."""
+
+    number: int
+    model: str
+    state: SSEState
+
+
+def _md_cell(text: str) -> str:
+    """Flatten arbitrary error text into one Markdown table cell."""
+    # Truncate BEFORE escaping: the other order can cut mid-escape and leave a
+    # trailing backslash that swallows the cell delimiter.
+    return " ".join(text.split())[:200].replace("|", "\\|")
+
+
+def total_cost(attempts: Sequence[Attempt]) -> str:
+    """Summed `cost_usd` across attempts, or "" when none reported one.
+
+    Mothership's cost telemetry is already unreliable (runs that streamed
+    hundreds of responses have reported an empty or zero cost), so an
+    unparseable value is skipped rather than treated as zero — and the caller
+    renders the per-attempt breakdown alongside this total so a retry ladder
+    cannot hide its spend behind one number.
+    """
+    total = 0.0
+    seen = False
+    for a in attempts:
+        try:
+            total += float(a.state.cost)
+        except (TypeError, ValueError):
+            continue
+        seen = True
+    if not seen:
+        return ""
+    return f"{total:.4f}".rstrip("0").rstrip(".")
+
+
+def render_attempt_trail(attempts: Sequence[Attempt]) -> list[str]:
+    """Per-attempt model/status/cost rows; empty unless a retry actually ran."""
+    if len(attempts) < 2:
+        return []
+    lines = [
+        "",
+        "### Attempts",
+        "",
+        "| # | Model | Status | Cost (USD) | Error |",
+        "|---|---|---|---|---|",
+    ]
+    missing_cost = False
+    for a in attempts:
+        st = a.state
+        status = st.status or ("error" if st.errored else "no `complete` event")
+        err = f"`{st.err_code}` {st.err_msg}".strip() if st.errored else ""
+        if not st.cost:
+            missing_cost = True
+        lines.append(
+            f"| {a.number} | `{a.model}` | {status} | {st.cost or 'n/a'} | "
+            f"{_md_cell(err)} |"
+        )
+    if missing_cost:
+        lines += [
+            "",
+            "> One or more attempts reported no `cost_usd` — the total above "
+            "is a lower bound.",
+        ]
+    return lines
+
+
 def render_step_summary(
-    st: SSEState, pr_number: str, gha_run_url: str, oob_url: str | None = None
+    st: SSEState,
+    pr_number: str,
+    gha_run_url: str,
+    oob_url: str | None = None,
+    attempts: Sequence[Attempt] = (),
 ) -> str:
     """Build the Markdown written to GITHUB_STEP_SUMMARY — always renders.
 
     `oob_url`, when set, is the resolver's out-of-band Phase-4 hand-off comment
     found by polling after our stream was cut: the run completed even though the
     stream reported failure, so render it as a recovered success.
+
+    `attempts` carries every dispatch this run made. With a single attempt it
+    changes nothing; with a retry it adds the per-attempt cost trail and makes
+    the headline cost the sum, so the retry's spend is never invisible.
     """
     summary = mine_summary(st)
     ok = run_completed(st) or oob_url is not None
@@ -405,11 +566,15 @@ def render_step_summary(
         )
     else:
         outcome = "⚠️ stopped short — needs a human"
+    cost = total_cost(attempts) if len(attempts) > 1 else st.cost
+    cost_line = f"**Cost:** {cost or 'n/a'} USD"
+    if len(attempts) > 1:
+        cost_line += f" across {len(attempts)} attempts"
     lines = [
         f"# SDK Resolve — PR #{pr_number}",
         "",
         f"**Outcome:** {outcome}  ",
-        f"**Cost:** {st.cost or 'n/a'} USD  ",
+        f"{cost_line}  ",
     ]
     if gha_run_url:
         lines.append(f"**Run:** [logs + cost]({gha_run_url})  ")
@@ -430,6 +595,7 @@ def render_step_summary(
             "> No summary block was emitted by the run — see the workflow log "
             "for phase output.",
         ]
+    lines += render_attempt_trail(attempts)
     return "\n".join(lines) + "\n"
 
 
@@ -538,14 +704,72 @@ def _fetch_pr_comments(
     return data if isinstance(data, list) else []
 
 
+def sandbox_terminated_abnormally(st: SSEState) -> bool:
+    """True when the sandbox itself died, as opposed to our stream being cut.
+
+    The distinction drives two decisions: how long to wait for an out-of-band
+    hand-off, and whether re-dispatching is safe. A dead sandbox will post
+    nothing more; a live one behind a cut stream is still working, and
+    re-dispatching against it would double-run the resolver.
+    """
+    return st.errored or (st.completed and st.status != "completed")
+
+
 def oob_poll_budget(st: SSEState) -> int:
     """Seconds to look for an out-of-band summary, given how the stream ended."""
     if not st.got_event:
         return 0  # never saw an event → sandbox likely never started; nothing to await
-    if st.errored or (st.completed and st.status != "completed"):
+    if sandbox_terminated_abnormally(st):
         # Sandbox terminated abnormally; only catch a summary posted just before.
         return OOB_POLL_SECONDS_HARD_ERROR
     return OOB_POLL_SECONDS_STREAM_DROP  # transport drop; sandbox likely still working
+
+
+def is_retryable_fault(st: SSEState) -> bool:
+    """True when the cause looks like a model/provider fault, not a fixed one.
+
+    Allowlist by code, then by substring of "<code> <message>" — mothership
+    forwards the provider's own text, and the code that carries it is not always
+    the numeric one (`complete` events flatten an absent code to `none`).
+    """
+    if st.err_code in NEVER_RETRY_ERR_CODES:
+        return False
+    if st.err_code in RETRYABLE_ERR_CODES:
+        return True
+    blob = f"{st.err_code} {st.err_msg}".lower()
+    return any(pattern in blob for pattern in RETRYABLE_ERR_PATTERNS)
+
+
+def retry_decision(st: SSEState, attempt: int, seconds_left: float) -> tuple[bool, str]:
+    """Whether to re-dispatch after this attempt, and the reason either way.
+
+    Called only once the out-of-band poll has come back empty, so "the sandbox
+    is dead and posted nothing" is already established for the abnormal-
+    termination branch. The reason is logged verbatim so a run that did NOT
+    retry says why, which is the part that is invisible today.
+    """
+    if attempt >= MAX_DISPATCH_ATTEMPTS:
+        return False, f"already used all {MAX_DISPATCH_ATTEMPTS} attempts"
+    if not sandbox_terminated_abnormally(st):
+        return False, (
+            "the stream ended without a hard error — the sandbox may still be "
+            "running, and a re-dispatch would double-run the resolver"
+        )
+    if not is_retryable_fault(st):
+        return False, (
+            f"code={st.err_code or 'none'} is not a known model/provider fault, "
+            "so a different model would fail the same way"
+        )
+    if seconds_left < RETRY_MIN_REMAINING_SECONDS:
+        return False, (
+            f"only {int(seconds_left)}s of the job budget remain, below the "
+            f"{RETRY_MIN_REMAINING_SECONDS}s a retry needs to finish a round"
+        )
+    return True, (
+        f"code={st.err_code or 'none'} looks like a model/provider fault — "
+        f"re-dispatching on {RETRY_MAIN_MODEL} (attempt {attempt + 1} of "
+        f"{MAX_DISPATCH_ATTEMPTS})"
+    )
 
 
 def poll_for_oob_summary(
@@ -606,6 +830,39 @@ def _max_rounds() -> int:
         return DEFAULT_MAX_ROUNDS
 
 
+def dispatch_once(
+    base_url: str,
+    token: str,
+    payload: dict[str, Any],
+    opener: Callable[..., Any] = urllib.request.urlopen,
+) -> SSEState:
+    """POST one execution and drain its SSE stream into an SSEState."""
+    req = urllib.request.Request(
+        f"{base_url}/api/sandbox/execute",
+        data=json.dumps(payload).encode(),
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {token}",
+        },
+        method="POST",
+    )
+    try:
+        # timeout is the per-read socket idle watchdog (not a whole-request cap):
+        # a silent stall frees the runner in ~READ_IDLE_TIMEOUT_SECONDS instead
+        # of blocking the full 2h. TimeoutError/OSError surface here too.
+        with opener(req, timeout=READ_IDLE_TIMEOUT_SECONDS) as resp:
+            return process_stream(raw.decode("utf-8", "replace") for raw in resp)
+    except (urllib.error.URLError, TimeoutError, OSError) as e:
+        print(f"::error::Sandbox dispatch stream error/stall: {e}")
+        st = SSEState()
+        st.errored = True
+        # NOT retryable: this is OUR connection dying, not the sandbox. See
+        # NEVER_RETRY_ERR_CODES — the resolver is probably still working.
+        st.err_code = "stream_error"
+        st.err_msg = str(e)
+        return st
+
+
 def main() -> int:
     missing = [
         v
@@ -645,37 +902,47 @@ def main() -> int:
         print("::error::Cannot reach mothership after retries")
         return 1
 
-    payload = build_payload(
-        pr_number, gha_run_url, max_rounds, run_date, reviewers, requester
-    )
-    req = urllib.request.Request(
-        f"{base_url}/api/sandbox/execute",
-        data=json.dumps(payload).encode(),
-        headers={
-            "Content-Type": "application/json",
-            "Authorization": f"Bearer {token}",
-        },
-        method="POST",
-    )
-    try:
-        # timeout is the per-read socket idle watchdog (not a whole-request cap):
-        # a silent stall frees the runner in ~READ_IDLE_TIMEOUT_SECONDS instead
-        # of blocking the full 2h. TimeoutError/OSError surface here too.
-        with urllib.request.urlopen(req, timeout=READ_IDLE_TIMEOUT_SECONDS) as resp:
-            st = process_stream(raw.decode("utf-8", "replace") for raw in resp)
-    except (urllib.error.URLError, TimeoutError, OSError) as e:
-        print(f"::error::Sandbox dispatch stream error/stall: {e}")
-        st = SSEState()
-        st.errored = True
-        st.err_code = "stream_error"
-        st.err_msg = str(e)
-
-    code, message = decide_exit(st)
+    attempts: list[Attempt] = []
     oob_url: str | None = None
-    if code != 0:
+    attempt = 1
+    while True:
+        model = attempt_model(attempt)
+        # Clamp the sandbox's own cap to what is left of this step's budget.
+        # Cancelling the job does not stop the sandbox, so an unclamped retry
+        # started late would keep billing for up to 2h after the runner dies.
+        seconds_left = DISPATCH_BUDGET_SECONDS - (time.time() - run_start_epoch)
+        payload = build_payload(
+            pr_number,
+            gha_run_url,
+            max_rounds,
+            run_date,
+            reviewers,
+            requester,
+            attempt=attempt,
+            max_timeout_seconds=max(1, min(STREAM_TIMEOUT_SECONDS, int(seconds_left))),
+        )
+        print(f"[attempt {attempt}/{MAX_DISPATCH_ATTEMPTS}] dispatching on {model}")
+        st = dispatch_once(base_url, token, payload)
+        attempts.append(Attempt(attempt, model, st))
+        code, message = decide_exit(st)
+        # Per-attempt cost, logged separately so a retry ladder cannot hide its
+        # spend behind a single total.
+        print(
+            f"[attempt {attempt}/{MAX_DISPATCH_ATTEMPTS}] model={model} "
+            f"status={st.status or 'none'} cost_usd={st.cost or 'n/a'} "
+            f"code={st.err_code or 'none'}"
+        )
+        if code == 0:
+            break
+
         # Transport backstop: the resolver may have finished out-of-band after our
         # stream was cut. Look for its Phase-4 hand-off comment before failing.
-        budget = oob_poll_budget(st)
+        # Clamped to what is left of the step's budget: a 45-min stream-drop poll
+        # started late (most likely on a retry, which begins with attempt 1's time
+        # already spent) would otherwise let the runner's 130-min timeout kill the
+        # job before the step summary is ever written.
+        seconds_left = DISPATCH_BUDGET_SECONDS - (time.time() - run_start_epoch)
+        budget = min(oob_poll_budget(st), max(0, int(seconds_left)))
         if github_token and budget > 0:
             print(
                 f"::warning::Stream ended unhappily; polling PR #{pr_number} for up "
@@ -695,8 +962,31 @@ def main() -> int:
                 f"its Phase-4 hand-off out-of-band ({oob_url}) — the run completed. "
                 "Treating as success."
             )
+            break
 
-    write_step_summary(render_step_summary(st, pr_number, gha_run_url, oob_url))
+        # Only here is the sandbox provably dead with nothing further to land:
+        # the hard-error poll came back empty. Retrying earlier would double-run
+        # a resolver that is still working, or one that finished just before it
+        # died. Phase 0 re-reads live PR state, so a second sandbox resumes
+        # rather than restarts.
+        should_retry, reason = retry_decision(
+            st, attempt, DISPATCH_BUDGET_SECONDS - (time.time() - run_start_epoch)
+        )
+        if not should_retry:
+            print(f"::warning::Not re-dispatching: {reason}")
+            break
+        print(f"::warning::Re-dispatching after a dead sandbox: {reason}")
+        attempt += 1
+
+    if code != 0 and len(attempts) > 1:
+        message += (
+            f" (retried on {attempt_model(len(attempts))} after "
+            f"{attempt_model(1)} died; both attempts failed)"
+        )
+
+    write_step_summary(
+        render_step_summary(st, pr_number, gha_run_url, oob_url, attempts)
+    )
     print(message)
     return code
 

--- a/.github/scripts/tests/test_sdk_resolve_dispatch.py
+++ b/.github/scripts/tests/test_sdk_resolve_dispatch.py
@@ -516,3 +516,335 @@ def test_health_retries_then_fails():
 
     assert sr.check_health("http://m", opener=opener, sleeper=lambda _: None) is False
     assert calls["n"] == sr.HEALTH_RETRIES
+
+
+# ---------------------------------------------------------------------------
+# re-dispatch with a model swap (FND-641)
+# ---------------------------------------------------------------------------
+
+
+def test_retry_payload_swaps_only_the_main_model():
+    # The whole point of the retry: a different MODEL. Mothership's own
+    # provider fallback already covers a different provider for the same model,
+    # and that is what failed. The two fast lanes must NOT move with it —
+    # model_routing_env does `fast = small_fast_model or model`.
+    first = sr.build_payload("1", "u", 8, "2026-08-19", "rev", "req", attempt=1)
+    retry = sr.build_payload("1", "u", 8, "2026-08-19", "rev", "req", attempt=2)
+    assert first["model"] == sr.MAIN_MODEL
+    assert retry["model"] == sr.RETRY_MAIN_MODEL
+    assert retry["model"] != first["model"]
+    assert retry["small_fast_model"] == first["small_fast_model"] == sr.FAST_MODEL
+    assert (
+        retry["env_vars"]["CLAUDE_CODE_SUBAGENT_MODEL"]
+        == first["env_vars"]["CLAUDE_CODE_SUBAGENT_MODEL"]
+        == sr.FAST_MODEL
+    )
+    # Same prompt (Phase 0 re-reads live PR state, so the retry resumes), but a
+    # distinguishable source_id and a recorded attempt number.
+    assert retry["prompt"] == first["prompt"]
+    assert retry["source_id"] != first["source_id"]
+    assert retry["metadata"]["attempt"] == 2
+
+
+def test_retry_payload_clamps_the_sandbox_timeout():
+    # Cancelling the job does not stop the sandbox, so a late retry must not be
+    # left billing for the full 2h after the runner dies.
+    p = sr.build_payload(
+        "1", "u", 8, "2026-08-19", "rev", "req", attempt=2, max_timeout_seconds=900
+    )
+    assert p["max_timeout_seconds"] == 900
+    assert (
+        sr.build_payload("1", "u", 8, "d", "rev", "req")["max_timeout_seconds"]
+        == sr.STREAM_TIMEOUT_SECONDS
+    )
+
+
+def test_provider_faults_are_retryable():
+    for code, msg in (
+        ("429", "moonshotai/kimi-k3 is temporarily rate-limited upstream"),
+        ("400", "the message at position 21 with role 'assistant' must not be empty"),
+        ("sandbox_error", ""),
+        ("503", ""),
+    ):
+        st = sr.SSEState()
+        st.errored, st.err_code, st.err_msg = True, code, msg
+        assert sr.is_retryable_fault(st) is True, code
+
+
+def test_provider_text_is_matched_when_the_code_is_flattened():
+    # mothership flattens an absent `complete` error code to `none` while still
+    # forwarding the provider's text, so code alone is not enough.
+    st = sr.SSEState()
+    st.errored, st.err_code = True, "none"
+    st.err_msg = "upstream provider returned an unexpected payload"
+    assert sr.is_retryable_fault(st) is True
+
+
+def test_fixed_faults_are_not_retryable():
+    for code, msg in (
+        ("elicitation", "Sandbox requires interactive input; cannot answer from GHA"),
+        ("stream_error", "<urlopen error timed out>"),
+        ("401", "bad credentials"),
+        ("403", "resource not accessible"),
+        ("none", ""),
+    ):
+        st = sr.SSEState()
+        st.errored, st.err_code, st.err_msg = True, code, msg
+        assert sr.is_retryable_fault(st) is False, code
+
+
+def test_retry_decision_fires_on_a_dead_sandbox_with_a_provider_fault():
+    st = sr.SSEState()
+    st.got_event = st.completed = st.errored = True
+    st.status, st.err_code = "error", "429"
+    ok, reason = sr.retry_decision(st, 1, sr.DISPATCH_BUDGET_SECONDS)
+    assert ok is True
+    assert sr.RETRY_MAIN_MODEL in reason
+
+
+def test_retry_decision_refuses_a_second_retry():
+    st = sr.SSEState()
+    st.got_event = st.completed = st.errored = True
+    st.status, st.err_code = "error", "429"
+    ok, reason = sr.retry_decision(st, sr.MAX_DISPATCH_ATTEMPTS, 6000)
+    assert ok is False and "attempts" in reason
+
+
+def test_retry_decision_refuses_a_transport_drop():
+    # The sandbox may still be working — a re-dispatch would double-run it.
+    st = _stream("event: started", 'data: {"session_id": "s1"}')
+    assert sr.sandbox_terminated_abnormally(st) is False
+    ok, reason = sr.retry_decision(st, 1, 6000)
+    assert ok is False and "double-run" in reason
+
+
+def test_retry_decision_refuses_when_the_job_budget_is_nearly_gone():
+    st = sr.SSEState()
+    st.got_event = st.completed = st.errored = True
+    st.status, st.err_code = "error", "429"
+    ok, reason = sr.retry_decision(st, 1, sr.RETRY_MIN_REMAINING_SECONDS - 1)
+    assert ok is False and "job budget" in reason
+
+
+def test_attempt_model_swaps_on_the_second_attempt():
+    assert sr.attempt_model(1) == sr.MAIN_MODEL
+    assert sr.attempt_model(2) == sr.RETRY_MAIN_MODEL
+
+
+def test_total_cost_sums_attempts_and_skips_unreported_ones():
+    a = sr.SSEState()
+    a.cost = "1.75"
+    b = sr.SSEState()
+    b.cost = ""
+    c = sr.SSEState()
+    c.cost = "0.25"
+    assert sr.total_cost([sr.Attempt(1, "m", a), sr.Attempt(2, "n", c)]) == "2"
+    assert sr.total_cost([sr.Attempt(1, "m", a), sr.Attempt(2, "n", b)]) == "1.75"
+    assert sr.total_cost([sr.Attempt(1, "m", b)]) == ""
+
+
+def test_attempt_trail_renders_both_attempts_costs_separately():
+    first = sr.SSEState()
+    first.completed = first.errored = True
+    first.status, first.cost, first.err_code = "error", "1.75", "429"
+    first.err_msg = "rate-limited\nupstream | pipe"
+    second = _stream(
+        "event: complete", 'data: {"status": "completed", "cost_usd": "2.10"}'
+    )
+    attempts = [
+        sr.Attempt(1, sr.MAIN_MODEL, first),
+        sr.Attempt(2, sr.RETRY_MAIN_MODEL, second),
+    ]
+    out = sr.render_step_summary(second, "1234", "http://run", None, attempts)
+    assert "### Attempts" in out
+    assert "1.75" in out and "2.10" in out
+    assert f"`{sr.MAIN_MODEL}`" in out and f"`{sr.RETRY_MAIN_MODEL}`" in out
+    # Headline cost is the sum, and says so, so the retry's spend is not hidden.
+    assert "**Cost:** 3.85 USD across 2 attempts" in out
+    # Multi-line / pipe-bearing error text must not break the table.
+    assert "rate-limited upstream \\| pipe" in out
+
+
+def test_attempt_trail_flags_an_attempt_that_reported_no_cost():
+    first = sr.SSEState()
+    first.completed = first.errored = True
+    first.status, first.cost, first.err_code = "error", "", "429"
+    second = _stream(
+        "event: complete", 'data: {"status": "completed", "cost_usd": "2.10"}'
+    )
+    out = sr.render_step_summary(
+        second,
+        "1234",
+        "http://run",
+        None,
+        [
+            sr.Attempt(1, sr.MAIN_MODEL, first),
+            sr.Attempt(2, sr.RETRY_MAIN_MODEL, second),
+        ],
+    )
+    assert "lower bound" in out
+
+
+def test_single_attempt_renders_no_attempt_trail():
+    st = _stream("event: complete", 'data: {"status": "completed", "cost_usd": "7.50"}')
+    out = sr.render_step_summary(
+        st, "1234", "http://run", None, [sr.Attempt(1, "m", st)]
+    )
+    assert "### Attempts" not in out
+    assert "**Cost:** 7.50 USD  " in out
+
+
+# --- main() end-to-end over the retry loop ---------------------------------
+
+
+def _main_env(monkeypatch):
+    for k, v in {
+        "MOTHERSHIP_URL": "http://m",
+        "HARNESS_TOKEN": "t",
+        "PR_NUMBER": "1234",
+        "GITHUB_TOKEN": "gh",
+        "MAX_ROUNDS": "8",
+        "RUN_DATE": "2026-08-19",
+        "GHA_RUN_URL": "http://run",
+        "REVIEWERS": "rev",
+        "REQUESTER": "req",
+    }.items():
+        monkeypatch.setenv(k, v)
+    monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+    monkeypatch.setattr(sr, "check_health", lambda *a, **k: True)
+    # No out-of-band hand-off landed: the sandbox really is dead.
+    monkeypatch.setattr(sr, "poll_for_oob_summary", lambda *a, **k: None)
+
+
+def _record_dispatches(monkeypatch, states):
+    """Stub dispatch_once to return `states` in order; capture each payload."""
+    seen = []
+
+    def fake(base_url, token, payload, opener=None):
+        seen.append(payload)
+        return states[len(seen) - 1]
+
+    monkeypatch.setattr(sr, "dispatch_once", fake)
+    return seen
+
+
+def test_main_redispatches_on_a_model_fault_and_recovers(monkeypatch, capsys):
+    _main_env(monkeypatch)
+    dead = sr.SSEState()
+    dead.got_event = dead.completed = dead.errored = True
+    dead.status, dead.cost, dead.err_code = "error", "1.75", "429"
+    dead.err_msg = "moonshotai/kimi-k3 is temporarily rate-limited upstream"
+    good = _stream(
+        "event: complete", 'data: {"status": "completed", "cost_usd": "2.10"}'
+    )
+    payloads = _record_dispatches(monkeypatch, [dead, good])
+
+    assert sr.main() == 0
+    assert [p["model"] for p in payloads] == [sr.MAIN_MODEL, sr.RETRY_MAIN_MODEL]
+    # The background lanes stay put across the swap.
+    assert {p["small_fast_model"] for p in payloads} == {sr.FAST_MODEL}
+    out = capsys.readouterr().out
+    assert "Re-dispatching after a dead sandbox" in out
+    # Both attempts' costs are logged separately.
+    assert "cost_usd=1.75" in out and "cost_usd=2.10" in out
+
+
+def test_main_does_not_redispatch_an_elicitation(monkeypatch, capsys):
+    _main_env(monkeypatch)
+    st = _stream("event: elicitation", "data: {}")
+    payloads = _record_dispatches(monkeypatch, [st])
+
+    assert sr.main() == 1
+    assert len(payloads) == 1
+    assert "Not re-dispatching" in capsys.readouterr().out
+
+
+def test_main_does_not_redispatch_a_transport_drop(monkeypatch, capsys):
+    # Stream cut mid-work: the resolver is probably still running. Retrying here
+    # would double-run it, so this stays fail-fast even though it exits 1.
+    _main_env(monkeypatch)
+    st = _stream(
+        "event: started",
+        'data: {"session_id": "s1"}',
+        "",
+        "event: response",
+        'data: {"text": "working"}',
+    )
+    payloads = _record_dispatches(monkeypatch, [st])
+
+    assert sr.main() == 1
+    assert len(payloads) == 1
+    assert "double-run" in capsys.readouterr().out
+
+
+def test_main_stops_after_one_retry(monkeypatch, capsys):
+    _main_env(monkeypatch)
+
+    def dead():
+        st = sr.SSEState()
+        st.got_event = st.completed = st.errored = True
+        st.status, st.cost, st.err_code = "error", "1.75", "429"
+        return st
+
+    payloads = _record_dispatches(monkeypatch, [dead(), dead()])
+
+    assert sr.main() == 1
+    assert len(payloads) == sr.MAX_DISPATCH_ATTEMPTS
+    out = capsys.readouterr().out
+    assert "already used all" in out
+    assert "both attempts failed" in out
+
+
+def test_main_prefers_an_out_of_band_handoff_over_a_retry(monkeypatch):
+    # The dead sandbox had already posted its Phase-4 hand-off — the run is
+    # done, so spending a second sandbox on it would be pure waste.
+    _main_env(monkeypatch)
+    monkeypatch.setattr(sr, "poll_for_oob_summary", lambda *a, **k: "http://handoff")
+    dead = sr.SSEState()
+    dead.got_event = dead.completed = dead.errored = True
+    dead.status, dead.err_code = "error", "429"
+    payloads = _record_dispatches(monkeypatch, [dead])
+
+    assert sr.main() == 0
+    assert len(payloads) == 1
+
+
+def test_main_writes_the_attempt_trail_to_the_step_summary(monkeypatch, tmp_path):
+    _main_env(monkeypatch)
+    summary = tmp_path / "summary.md"
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary))
+    dead = sr.SSEState()
+    dead.got_event = dead.completed = dead.errored = True
+    dead.status, dead.cost, dead.err_code = "error", "1.75", "429"
+    good = _stream(
+        "event: complete", 'data: {"status": "completed", "cost_usd": "2.10"}'
+    )
+    _record_dispatches(monkeypatch, [dead, good])
+
+    assert sr.main() == 0
+    text = summary.read_text()
+    assert "### Attempts" in text
+    assert "**Cost:** 3.85 USD across 2 attempts" in text
+
+
+def test_main_skips_the_oob_poll_and_the_retry_when_the_budget_is_spent(
+    monkeypatch, capsys
+):
+    # With no job budget left there is time for neither a 120s hand-off poll nor
+    # a second sandbox — the runner's 130-min timeout would kill the job before
+    # either finished, and take the step summary with it.
+    _main_env(monkeypatch)
+    monkeypatch.setattr(sr, "DISPATCH_BUDGET_SECONDS", 0)
+    polled = []
+    monkeypatch.setattr(
+        sr, "poll_for_oob_summary", lambda *a, **k: polled.append(a) or None
+    )
+    dead = sr.SSEState()
+    dead.got_event = dead.completed = dead.errored = True
+    dead.status, dead.err_code = "error", "429"
+    payloads = _record_dispatches(monkeypatch, [dead])
+
+    assert sr.main() == 1
+    assert polled == []
+    assert len(payloads) == 1
+    assert "job budget" in capsys.readouterr().out

--- a/.github/scripts/tests/test_sdk_resolve_dispatch.py
+++ b/.github/scripts/tests/test_sdk_resolve_dispatch.py
@@ -572,12 +572,28 @@ def test_provider_faults_are_retryable():
 
 
 def test_provider_text_is_matched_when_the_code_is_flattened():
-    # mothership flattens an absent `complete` error code to `none` while still
-    # forwarding the provider's text, so code alone is not enough.
-    st = sr.SSEState()
-    st.errored, st.err_code = True, "none"
-    st.err_msg = "upstream provider returned an unexpected payload"
-    assert sr.is_retryable_fault(st) is True
+    # mothership flattens an absent `complete` error code to `none` (and a
+    # standalone `error` event defaults it to `unknown`) while still forwarding
+    # the provider's text, so code alone is not enough — for THOSE codes.
+    for code in ("none", "unknown", ""):
+        st = sr.SSEState()
+        st.errored, st.err_code = True, code
+        st.err_msg = "upstream provider returned an unexpected payload"
+        assert sr.is_retryable_fault(st) is True, code
+
+
+def test_message_patterns_never_override_an_informative_code():
+    # Regression: the pattern fallback used to match "<code> <message>" for ANY
+    # code, so a permanent fault whose text happened to mention "upstream" was
+    # classified retryable and bought a second sandbox that failed identically.
+    for code, msg in (
+        ("401", "upstream auth failed"),
+        ("403", "upstream permission denied"),
+        ("422", "prompt is overloaded with tokens"),
+    ):
+        st = sr.SSEState()
+        st.errored, st.err_code, st.err_msg = True, code, msg
+        assert sr.is_retryable_fault(st) is False, code
 
 
 def test_fixed_faults_are_not_retryable():

--- a/.github/workflows/sdk-resolve.yml
+++ b/.github/workflows/sdk-resolve.yml
@@ -215,6 +215,12 @@ jobs:
           echo "::error::All 3 VPN connection attempts failed. PR has been notified — see comment posted above."
           exit 1
 
+      # The script dispatches ONCE, then re-dispatches at most once more on a
+      # DIFFERENT main model when the sandbox died on a model/provider fault and
+      # posted no out-of-band hand-off (FND-641). Both attempts' costs are logged
+      # separately and rendered in the step summary. Everything else — a
+      # transport drop, an auth or prompt fault, an elicitation — stays
+      # fail-fast; see MAX_DISPATCH_ATTEMPTS / retry_decision() in the script.
       - name: Dispatch SDK Resolve to mothership Rover Direct API
         env:
           MOTHERSHIP_URL: ${{ vars.MOTHERSHIP_URL }}


### PR DESCRIPTION
Closes FND-641.

## Problem

`main()` in `.github/scripts/sdk_resolve_dispatch.py` POSTed to `/api/sandbox/execute` exactly once. On a terminal error it returned exit 1 and the invocation was over, so one bad upstream minute killed a whole `@sdk-resolve` and the requester re-tagged by hand. Against a *sustained* fault the manual re-tags mostly failed too.

## The retry has to swap the model

Mothership's intra-group provider fallback already exists and already fires on a 429 — but every provider in the `kimi-k3` group serves the same model, and it was the *model* emitting empty assistant turns. The observed fallback landed on the same bug and returned `400 "the message at position 21 with role 'assistant' must not be empty"`. A same-model re-dispatch would have burned a second sandbox boot to fail identically.

Attempt 2 therefore runs `RETRY_MAIN_MODEL` (`claude-opus-5`), named explicitly rather than by omitting `model` — an explicit constant lets a test assert the two attempts actually differ, and stops the retry silently following a mothership config change. `small_fast_model` and `CLAUDE_CODE_SUBAGENT_MODEL` stay pinned to `gpt-5.6-luna` on both attempts: `model_routing_env` does `fast = small_fast_model or model`, so changing only `model` must not drag the background lane along. A test asserts exactly this.

## Hook point

The abnormal-termination branch, and only *after* its 120s out-of-band poll comes back empty — the single point where the sandbox is provably dead and nothing further will land.

- Retrying on a **transport drop** would double-run a resolver that is still working.
- Retrying **before the poll** would double-run one that finished just before it died. If the Phase-4 hand-off comment is found, the run is reported as a recovered success and no second sandbox is spent.

Resumption is safe: Phase 0 of `.mothership/pr-resolve/ORCHESTRATION.md` does `gh pr checkout` + `gh pr view`, and the playbook's standing rule is "always read real state from `gh` before deciding the next action" — there is no local carry-over for a second sandbox to lose. The retry sends the same prompt with a suffixed `source_id` and `metadata.attempt`, so it resumes rather than restarts.

## Bounds

The failing sessions ran 29–64 minutes each, so an unbounded ladder would blow the job's 130-min timeout.

- **One retry** (`MAX_DISPATCH_ATTEMPTS = 2`), not one per model.
- **An allowlist of retryable causes, not a denylist.** A wrong retry costs a second sandbox boot plus a real bill, so an unrecognised code stays fail-fast. `RETRYABLE_ERR_CODES` covers 400/429/500/502/503/504, `sandbox_error`, `provider_error`, `rate_limit_error`, `overloaded_error`, `api_error`; `RETRYABLE_ERR_PATTERNS` matches provider text (`must not be empty`, `rate-limited`, `overloaded`, `upstream`) **only when the code carries no information** (`none`/`unknown`/empty) — a `complete` event flattens an absent code to `none` while still forwarding the message. A code that does carry information stands on the code lists alone, so `401 upstream auth failed` stays fail-fast despite mentioning upstream.
- **`NEVER_RETRY_ERR_CODES`** holds `elicitation` (GHA can never answer it) and `stream_error` (that is *our* urlopen dying, not the sandbox — the resolver is probably still working). Auth and prompt faults fail the allowlist by default.
- **A wall-clock floor.** `DISPATCH_BUDGET_SECONDS = 6600` (110 min, allowing for the VPN steps inside the job's 130-min cap) with `RETRY_MIN_REMAINING_SECONDS = 1800` — a retry with under 30 min left cannot finish a review round, so it is refused rather than booted.
- **Clamped timeouts.** Cancelling the job does not stop the sandbox, so the retry's own `max_timeout_seconds` is clamped to what remains — otherwise a killed runner leaves it billing for up to 2h unattended. The out-of-band poll is clamped the same way, so a 45-min stream-drop poll on the retry can't let the runner timeout kill the job before the step summary is written.

## Cost visibility

Cost telemetry is already unreliable (runs that streamed hundreds of responses have reported an empty or zero cost). Each attempt now logs its own `cost_usd` line, and the step summary gains an `### Attempts` table (attempt, model, status, cost, error). The headline cost is the sum, rendered as "across N attempts", and says the total is a lower bound when any attempt reported none — rather than passing off incomplete telemetry as complete.

## Scope

**Resolve lane only.** The ticket suggested landing review first because it is stateless, but the opposite is true of the code: resolve's dispatch is a tested Python script, while review's is ~460 lines of inlined shell (`sdk-review.yml:560-1036`). `docs/standards/ci.md` forbids adding conditional logic there, so the review lane needs its SSE loop extracted to a tested script first — filed as FND-643. Resolve was also 8 of the 10 failures that motivated this.

Unblocked by #3289, which sets `st.errored` for a `complete` carrying `status=error`; without it the retry could not tell a model fault from a prompt or auth fault.

## Testing

- 23 new tests in `.github/scripts/tests/test_sdk_resolve_dispatch.py`, including `main()` end-to-end over the retry loop: recovery on the second model, no retry on an elicitation, no retry on a transport drop, stop after one retry, out-of-band hand-off preferred over a retry, and the exhausted-budget path.
- `test_sdk_resolve_dispatch.py`: 62 passed. Full `.github/scripts/tests` suite: 2692 passed.
- `pre-commit` clean on all three files (ruff, ruff-format, isort, pyright).

## Security-relevant changes

None. No new dependencies, no credential handling, no network destinations beyond the existing mothership endpoint. The only behavioural change to outbound traffic is that one additional POST to the same already-approved `/api/sandbox/execute` endpoint may be made per run, under the caps described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
