### PR TITLE
ci(renovate): make a refused bound land on a required check (FND-379)

### DIFF
--- a/.github/scripts/renovate_uv_lock_bounded.py
+++ b/.github/scripts/renovate_uv_lock_bounded.py
@@ -237,21 +237,49 @@ def retention_ceilings(
     return ceilings
 
 
-def restore(lock_path: Path, baseline: str) -> None:
-    """Put the committed lock back, for every path that refuses to bound.
+def withhold(lock_path: Path, baseline: str, window: str) -> bool:
+    """Refuse in a way a REQUIRED check can see. Returns whether it wrote.
 
-    The driver does not own the commit. Under Renovate's ``postUpgradeTasks`` the
-    working tree is committed once the command returns, pass or fail, so a guard
-    that only returns non-zero does not actually withhold the resolve it just
-    rejected — it ships it with ``[options]`` still in place, and ``uv sync
-    --locked`` then fails in the image build (FND-367). Five fleet lock branches
-    were stranded exactly that way before this existed.
+    The driver cannot stop Renovate committing, and it cannot abstain either.
+    Renovate captures its own unbounded ``uv lock --upgrade`` as an artifact
+    *before* this command runs, commits the working tree afterwards whatever the
+    exit code, and falls back to that captured artifact whenever the tree matches
+    HEAD. So the two obvious refusals both ship something unwanted: leaving the
+    rejected resolve in place ships the rejected resolve, and restoring the
+    baseline exactly ships Renovate's *unbounded* copy instead — silently, since
+    a valid-but-unbounded lock passes every check.
 
-    An empty baseline means the ref had no committed ``uv.lock`` at all; there is
-    nothing to restore and truncating the file would be worse than leaving it.
+    Nor does exiting non-zero withhold anything on its own. It reds
+    ``renovate/artifacts``, which is an advisory status: it is not a required
+    check in any lock-lane repo, those repos require zero approving reviews, and
+    Renovate re-arms GitHub-native automerge in the same pass that records the
+    failure. Observed 2026-08-19: six of the day's eight auto-merged fleet lock
+    PRs carried a third-party release between 21 minutes and 3 hours old.
+
+    The one lever the driver does hold over a *required* check is the lock's own
+    validity. So a refusal writes the baseline's versions — never the rejected
+    resolve, never an unbounded one — and adds an ``[options]`` table the repo's
+    ``pyproject.toml`` does not declare. That is exactly what ``uv sync --locked``
+    rejects in the image build, and ``scan / Build Image`` is required in every
+    lock-lane repo, so the branch cannot merge until a human looks at it.
+
+    Deliberate, documented, and meant to be temporary: the durable fix is a
+    required age check that fails on its own evidence rather than on a lock the
+    build cannot install (FND-379).
+
+    An empty baseline means the ref had no committed ``uv.lock``; there is
+    nothing to write and truncating the file would be worse than leaving it.
     """
-    if baseline:
-        lock_path.write_text(baseline)
+    if not baseline:
+        return False
+    tripwire = f'\n[options]\nexclude-newer-span = "{window}"\n'
+    anchor = baseline.find("\n[[package]]")
+    lock_path.write_text(
+        baseline[:anchor] + tripwire + baseline[anchor:]
+        if anchor != -1
+        else baseline + tripwire
+    )
+    return True
 
 
 def strip_options(lock_text: str) -> str:
@@ -641,6 +669,11 @@ def main(argv: list[str] | None = None) -> int:
     cutoff = dt.datetime.now(dt.timezone.utc) - window
     ceilings = retention_ceilings(lock_upload_times(baseline), cutoff)
 
+    # What Renovate resolved unbounded, and has already captured as the artifact
+    # it will commit if this command leaves the tree looking untouched. Read it
+    # now: the bounded resolve below overwrites it.
+    renovate_versions = lock_versions(lock_path.read_text())
+
     result = run_uv_lock(build_uv_command(args.window, exempt, ceilings), project_dir)
     admitted_early: list[str] = []
 
@@ -652,7 +685,7 @@ def main(argv: list[str] | None = None) -> int:
         )
         admitted_early = blocked_by_floor(result.stderr, floors)
         if not admitted_early:
-            restore(lock_path, baseline)
+            withhold(lock_path, baseline, args.window)
             print(
                 "Bounded `uv lock` failed and no deliberately-floored package was "
                 "named in the error, so there is nothing safe to admit early. "
@@ -666,7 +699,7 @@ def main(argv: list[str] | None = None) -> int:
             project_dir,
         )
         if result.returncode != 0:
-            restore(lock_path, baseline)
+            withhold(lock_path, baseline, args.window)
             print(
                 "Bounded `uv lock` still failed after admitting "
                 f"{', '.join(admitted_early)}. The committed lock has been "
@@ -682,7 +715,7 @@ def main(argv: list[str] | None = None) -> int:
         detail = ", ".join(
             f"{n} {old} -> {new}" for n, (old, new) in sorted(regressed.items())
         )
-        restore(lock_path, baseline)
+        withhold(lock_path, baseline, args.window)
         print(
             f"Bounded resolve moved {len(regressed)} package(s) BACKWARDS from the "
             f"last committed lock: {detail}. Retention ceilings make an age-driven "
@@ -694,6 +727,25 @@ def main(argv: list[str] | None = None) -> int:
             "changed constraint is the other candidate. Either way it wants a "
             "human, so the committed lock has been restored and this run bounds "
             "nothing.",
+            file=sys.stderr,
+        )
+        return 1
+
+    if after == before and renovate_versions != before:
+        moved = ", ".join(
+            f"{name} {before.get(name, 'absent')} -> {version}"
+            for name, version in sorted(renovate_versions.items())
+            if before.get(name) != version
+        )
+        withhold(lock_path, baseline, args.window)
+        print(
+            f"The bound admits nothing today, but Renovate's own unbounded "
+            f"resolve moved: {moved}. Leaving the tree matching HEAD would hand "
+            "Renovate's copy straight to the branch — a valid lock that passes "
+            "every check while carrying releases minutes old — so the lock is "
+            "left deliberately un-installable instead and this run fails. "
+            "Nothing needs fixing in the repo: the window will admit these "
+            f"versions once they are `{args.window}` old.",
             file=sys.stderr,
         )
         return 1

--- a/.github/scripts/renovate_uv_lock_bounded.py
+++ b/.github/scripts/renovate_uv_lock_bounded.py
@@ -267,17 +267,20 @@ def withhold(lock_path: Path, baseline: str, window: str) -> bool:
     required age check that fails on its own evidence rather than on a lock the
     build cannot install (FND-379).
 
-    An empty baseline means the ref had no committed ``uv.lock``; there is
-    nothing to write and truncating the file would be worse than leaving it.
+    A branch that *adds* a brand-new ``uv.lock`` has no committed baseline to
+    write back. The tripwire still goes on, over whatever the resolve left: there
+    is no safer content to choose, and leaving a valid-but-unbounded lock in place
+    is the one refusal that lands on no required check at all. ``strip_options``
+    recovers whatever was there in both cases.
     """
-    if not baseline:
+    base = baseline or lock_path.read_text()
+    if not base:
         return False
+    base = strip_options(base)
     tripwire = f'\n[options]\nexclude-newer-span = "{window}"\n'
-    anchor = baseline.find("\n[[package]]")
+    anchor = base.find("\n[[package]]")
     lock_path.write_text(
-        baseline[:anchor] + tripwire + baseline[anchor:]
-        if anchor != -1
-        else baseline + tripwire
+        base[:anchor] + tripwire + base[anchor:] if anchor != -1 else base + tripwire
     )
     return True
 
@@ -689,8 +692,10 @@ def main(argv: list[str] | None = None) -> int:
             print(
                 "Bounded `uv lock` failed and no deliberately-floored package was "
                 "named in the error, so there is nothing safe to admit early. "
-                "Refusing to fall back to an unbounded resolve. The committed "
-                "lock has been restored.\n" + result.stderr,
+                "Refusing to fall back to an unbounded resolve. The lock is left "
+                "deliberately un-installable — baseline versions plus a tripwire "
+                "`[options]` table — so a required check holds the branch.\n"
+                + result.stderr,
                 file=sys.stderr,
             )
             return 1
@@ -702,8 +707,9 @@ def main(argv: list[str] | None = None) -> int:
             withhold(lock_path, baseline, args.window)
             print(
                 "Bounded `uv lock` still failed after admitting "
-                f"{', '.join(admitted_early)}. The committed lock has been "
-                "restored.\n" + result.stderr,
+                f"{', '.join(admitted_early)}. The lock is left deliberately "
+                "un-installable — baseline versions plus a tripwire `[options]` "
+                "table — so a required check holds the branch.\n" + result.stderr,
                 file=sys.stderr,
             )
             return 1
@@ -725,8 +731,9 @@ def main(argv: list[str] | None = None) -> int:
             "API will say — because no resolve can keep a yanked pin and every "
             "one of them will land here until the base branch moves off it. A "
             "changed constraint is the other candidate. Either way it wants a "
-            "human, so the committed lock has been restored and this run bounds "
-            "nothing.",
+            "human, so this run bounds nothing and leaves the lock deliberately "
+            "un-installable — baseline versions plus a tripwire `[options]` "
+            "table — for a required check to hold the branch on.",
             file=sys.stderr,
         )
         return 1

--- a/.github/scripts/tests/test_renovate_uv_lock_bounded.py
+++ b/.github/scripts/tests/test_renovate_uv_lock_bounded.py
@@ -1030,12 +1030,62 @@ class TestWithholds:
         assert len(calls) == 2, "the floor should have earned exactly one retry"
         self._assert_withheld(project, baseline)
 
-    def test_withhold_leaves_a_lock_with_no_baseline_alone(self, tmp_path):
-        # A lock added in this very branch has no committed copy to fall back to.
+    def test_a_new_lockfile_is_tripwired_too(self, monkeypatch, tmp_path):
+        """The branch that ADDS uv.lock still has to be held.
+
+        There is no committed baseline to write back here, and the pre-fix
+        behaviour — leave the tree as it is — was the one refusal that landed on
+        no required check: a valid-but-unbounded lock that Renovate commits and
+        every gate waves through.
+        """
+        project = self._repo(tmp_path, lock(boto3="1.43.72"))
+        subprocess.run(["git", "rm", "-q", "uv.lock"], cwd=project, check=True)
+        subprocess.run(
+            ["git", "commit", "-qm", "drop the lock"],
+            cwd=project,
+            check=True,
+            env=self.GIT_ENV,
+        )
+        assert bounded.baseline_lock_text(project) is None
+
+        # What Renovate left: a valid, unbounded lock. uv then fails WITHOUT
+        # rewriting it, which is what makes this the dangerous shape — the tree
+        # holds something installable that every required check waves through.
+        unbounded = lock(boto3="1.43.75")
+        (project / "uv.lock").write_text(unbounded)
+
+        def fake_run(command, cwd):
+            return subprocess.CompletedProcess(
+                command, 1, "", "error: something else entirely"
+            )
+
+        monkeypatch.setattr(bounded, "run_uv_lock", fake_run)
+        assert bounded.main(["--window", "P3D", "--project-dir", str(project)]) == 1
+        on_disk = (project / "uv.lock").read_text()
+        assert "[options]" in on_disk, "a new lockfile must be held like any other"
+        assert bounded.strip_options(on_disk) == unbounded
+
+    def test_withhold_only_no_ops_on_an_empty_file(self, tmp_path):
+        # Nothing committed AND nothing on disk: there is no content to tripwire,
+        # and writing a bare [options] table would be a lock nobody can recover.
+        target = tmp_path / "uv.lock"
+        target.write_text("")
+        assert bounded.withhold(target, "", "P3D") is False
+        assert target.read_text() == ""
+
+    def test_withhold_does_not_stack_options_tables(self, tmp_path):
+        # The on-disk fallback is whatever the bounded resolve left, which already
+        # carries uv's own [options]. Two tables would be invalid TOML rather than
+        # a recoverable lock.
         target = tmp_path / "uv.lock"
         target.write_text(LOCK_WITH_OPTIONS)
-        assert bounded.withhold(target, "", "P3D") is False
-        assert target.read_text() == LOCK_WITH_OPTIONS
+        assert bounded.withhold(target, "", "P3D") is True
+        written = target.read_text()
+        assert written.count("[options]") == 1
+        assert 'exclude-newer-span = "P3D"' in written
+        assert bounded.strip_options(written) == bounded.strip_options(
+            LOCK_WITH_OPTIONS
+        )
 
     def test_the_tripwire_names_the_window_and_survives_a_strip(self, tmp_path):
         baseline = lock(boto3="1.43.72")

--- a/.github/scripts/tests/test_renovate_uv_lock_bounded.py
+++ b/.github/scripts/tests/test_renovate_uv_lock_bounded.py
@@ -51,6 +51,16 @@ source = { editable = "." }
 """
 
 
+def with_options(lock_text: str, window: str = "P3D") -> str:
+    """`lock_text` as uv leaves it after a bounded resolve: same versions, plus
+    the [options] table recording the window."""
+    table = f'\n[options]\nexclude-newer-span = "{window}"\n'
+    anchor = lock_text.find("\n[[package]]")
+    if anchor == -1:
+        return lock_text + table
+    return lock_text[:anchor] + table + lock_text[anchor:]
+
+
 def lock(**packages: str) -> str:
     body = 'version = 1\nrevision = 3\nrequires-python = ">=3.11"\n'
     for name, version in packages.items():
@@ -539,7 +549,11 @@ class TestMain:
             return subprocess.CompletedProcess(command, 0, "", "")
 
         monkeypatch.setattr(bounded, "run_uv_lock", fake_run)
-        assert bounded.main(["--window", "P7D", "--project-dir", str(project)]) == 0
+        # Exit 1, not 0: this fixture is also the hold-everything case — the bound
+        # admits nothing while Renovate's working-tree copy moved boto3 — so the
+        # run withholds rather than hand that copy to the branch. What this test
+        # is about is the ceiling flags below.
+        assert bounded.main(["--window", "P7D", "--project-dir", str(project)]) == 1
 
         # boto3's committed version is from 2020, comfortably outside the window,
         # so it needs no ceiling. Had the baseline been the working tree, the
@@ -755,7 +769,10 @@ class TestBaselineRef:
         monkeypatch.setattr(bounded, "run_uv_lock", fake_run)
 
         argv = ["--window", "P7D", "--project-dir", str(tmp_path)]
-        assert bounded.main([*argv, "--baseline-ref", "base"]) == 0
+        # Withheld (1), not clean (0): the bound admits nothing here while the
+        # branch commit carries a fresh boto3, so the run refuses rather than
+        # leave Renovate's copy in place. The ceilings are what is under test.
+        assert bounded.main([*argv, "--baseline-ref", "base"]) == 1
         ceilings = [a for a in seen[0] if a.startswith("boto3=")]
         assert ceilings == [], (
             "the base branch locks a 2020 boto3, so nothing needs a ceiling; one "
@@ -766,6 +783,10 @@ class TestBaselineRef:
         # Without this half the assertion above could pass for the wrong reason.
         seen.clear()
         resolved = fresh
+        # Put the tree back the way Renovate leaves it, since the withheld run
+        # above rewrote uv.lock. In production each run re-resolves from scratch;
+        # here the fixture has to say so.
+        (tmp_path / "uv.lock").write_text(fresh)
         assert bounded.main(argv) == 0
         assert any(a.startswith("boto3=2") for a in seen[0]), seen[0]
 
@@ -842,15 +863,18 @@ class TestBaselineRef:
         assert exit_code == 1
 
 
-class TestFailsClean:
-    """Refusing to bound has to withhold the resolve, not merely exit non-zero.
+class TestWithholds:
+    """A refusal has to land on a REQUIRED check, or it withholds nothing.
 
-    The driver does not own the commit. Under `postUpgradeTasks` Renovate commits
-    the working tree once the command returns, pass or fail — so every refusal
-    path has to put the committed lock back, or the rejected resolve reaches the
-    branch anyway carrying `[options]`, and `uv sync --locked` fails in the image
-    build (FND-367). Five fleet lock branches were stranded that way, three of
-    them by the same yanked release.
+    Renovate captures its own unbounded resolve before this command runs, commits
+    the working tree afterwards whatever the exit code, and falls back to that
+    captured artifact whenever the tree matches HEAD. `renovate/artifacts` is
+    advisory — not a required check in any lock-lane repo, and those repos need no
+    approving review either — and Renovate re-arms GitHub-native automerge in the
+    same pass that records the failure. So every refusal writes the baseline's
+    versions plus an `[options]` table the repo does not declare: `uv sync
+    --locked` rejects that, and `scan / Build Image` is required wherever this
+    lane runs.
     """
 
     GIT_ENV = {
@@ -874,44 +898,105 @@ class TestFailsClean:
             subprocess.run(command, cwd=tmp_path, check=True, env=self.GIT_ENV)
         return tmp_path
 
-    def test_a_rejected_downgrade_restores_the_committed_lock(
+    def _assert_withheld(self, project: Path, baseline: str) -> None:
+        """The three properties a refusal needs, together.
+
+        The base branch's versions (so neither the rejected resolve nor Renovate's
+        unbounded one lands), an `[options]` table (so a required check rejects
+        it), and NOT byte-identical to the base branch — that last one is what
+        stops Renovate substituting its own captured artifact.
+        """
+        on_disk = (project / "uv.lock").read_text()
+        assert bounded.lock_versions(on_disk) == bounded.lock_versions(baseline)
+        assert "[options]" in on_disk
+        assert on_disk != baseline
+        assert bounded.strip_options(on_disk) == baseline
+
+    def test_the_bound_admitting_nothing_is_withheld_not_shipped(
         self, monkeypatch, tmp_path
     ):
-        """The production case, in the shape it actually happened.
+        """The common case, and the one that was merging unattended.
 
-        A base branch pinning a release upstream later yanked: no resolve can keep
-        it, so every bounded run comes back a version lower and trips the rollback
-        gate. Exit 1 was already right; what was missing is that the working tree
-        still held the rejected lock, `[options]` and all, for Renovate to commit.
+        Renovate's unbounded pass moves a package published minutes ago and the
+        bound correctly holds it. Restoring the baseline here would leave the tree
+        matching HEAD, and Renovate would commit its own copy instead — a valid
+        lock that passes every required check while carrying a minutes-old
+        release.
         """
-        committed = lock(pytest_timeout="2.5.0")
-        project = self._repo(tmp_path, committed)
-
-        # One document, not two concatenated ones: a lock whose TOML does not
-        # parse would read as "no versions at all" and pass this test for the
-        # wrong reason.
-        resolved = LOCK_WITH_OPTIONS + (
-            '\n[[package]]\nname = "pytest-timeout"\nversion = "2.4.0"\n'
-            'source = { registry = "https://pypi.org/simple" }\n'
-        )
-        assert bounded.lock_versions(resolved)["pytest-timeout"] == "2.4.0"
+        baseline = lock(boto3="1.43.74")
+        project = self._repo(tmp_path, baseline)
+        # Renovate got here first: this is the artifact it has already captured.
+        (project / "uv.lock").write_text(lock(boto3="1.43.75"))
 
         def fake_run(command, cwd):
-            (Path(cwd) / "uv.lock").write_text(resolved)
+            (Path(cwd) / "uv.lock").write_text(with_options(baseline))
             return subprocess.CompletedProcess(command, 0, "", "")
 
         monkeypatch.setattr(bounded, "run_uv_lock", fake_run)
         assert bounded.main(["--window", "P3D", "--project-dir", str(project)]) == 1
-        on_disk = (project / "uv.lock").read_text()
-        assert on_disk == committed, "the rejected resolve must not survive on disk"
-        assert "[options]" not in on_disk
-        assert '"2.4.0"' not in on_disk
+        self._assert_withheld(project, baseline)
 
-    def test_a_failed_resolve_restores_the_committed_lock(self, monkeypatch, tmp_path):
-        # uv can rewrite the lock and *then* fail. Same exposure: whatever it left
-        # behind is what Renovate would commit.
-        committed = lock(boto3="1.43.72")
-        project = self._repo(tmp_path, committed)
+    def test_a_genuinely_quiet_run_is_left_clean_and_passes(
+        self, monkeypatch, tmp_path
+    ):
+        """The control for the test above.
+
+        Renovate's own resolve moved nothing either ("uv.lock is unchanged"), so
+        there is no unbounded copy to withhold and no reason to fail. The tree is
+        left byte-identical to the baseline and the run succeeds — otherwise every
+        quiet run in the fleet would red a required check.
+        """
+        baseline = lock(boto3="1.43.74")
+        project = self._repo(tmp_path, baseline)
+
+        def fake_run(command, cwd):
+            (Path(cwd) / "uv.lock").write_text(with_options(baseline))
+            return subprocess.CompletedProcess(command, 0, "", "")
+
+        monkeypatch.setattr(bounded, "run_uv_lock", fake_run)
+        assert bounded.main(["--window", "P3D", "--project-dir", str(project)]) == 0
+        assert (project / "uv.lock").read_text() == baseline
+
+    def test_a_real_upgrade_still_strips_and_passes(self, monkeypatch, tmp_path):
+        # The success path must be untouched: a bounded upgrade strips [options]
+        # and exits 0, or nothing would ever merge again.
+        baseline = lock(boto3="1.43.70")
+        project = self._repo(tmp_path, baseline)
+        (project / "uv.lock").write_text(lock(boto3="1.43.75"))
+        resolved = lock(boto3="1.43.72")
+
+        def fake_run(command, cwd):
+            (Path(cwd) / "uv.lock").write_text(with_options(resolved))
+            return subprocess.CompletedProcess(command, 0, "", "")
+
+        monkeypatch.setattr(bounded, "run_uv_lock", fake_run)
+        assert bounded.main(["--window", "P3D", "--project-dir", str(project)]) == 0
+        assert (project / "uv.lock").read_text() == resolved
+
+    def test_a_rejected_downgrade_is_withheld(self, monkeypatch, tmp_path):
+        """The yanked-pin case: the base branch pins a release upstream has
+        yanked, so every resolve comes back lower. Neither the downgrade nor
+        Renovate's unbounded copy may reach the branch."""
+        baseline = lock(pytest_timeout="2.5.0")
+        project = self._repo(tmp_path, baseline)
+        (project / "uv.lock").write_text(lock(pytest_timeout="2.4.0"))
+
+        def fake_run(command, cwd):
+            (Path(cwd) / "uv.lock").write_text(
+                with_options(lock(pytest_timeout="2.4.0"))
+            )
+            return subprocess.CompletedProcess(command, 0, "", "")
+
+        monkeypatch.setattr(bounded, "run_uv_lock", fake_run)
+        assert bounded.main(["--window", "P3D", "--project-dir", str(project)]) == 1
+        self._assert_withheld(project, baseline)
+        assert '"2.4.0"' not in (project / "uv.lock").read_text()
+
+    def test_a_failed_resolve_is_withheld(self, monkeypatch, tmp_path):
+        # uv can rewrite the lock and then fail; whatever it left behind is what
+        # Renovate would commit.
+        baseline = lock(boto3="1.43.72")
+        project = self._repo(tmp_path, baseline)
 
         def fake_run(command, cwd):
             (Path(cwd) / "uv.lock").write_text(LOCK_WITH_OPTIONS)
@@ -921,15 +1006,13 @@ class TestFailsClean:
 
         monkeypatch.setattr(bounded, "run_uv_lock", fake_run)
         assert bounded.main(["--window", "P3D", "--project-dir", str(project)]) == 1
-        assert (project / "uv.lock").read_text() == committed
+        self._assert_withheld(project, baseline)
 
-    def test_a_failed_retry_restores_the_committed_lock(self, monkeypatch, tmp_path):
-        # The floored-package retry path: admitting the floor early does not help,
-        # and the second failure has to clean up after itself too.
-        committed = lock(cryptography="46.0.5")
+    def test_a_failed_retry_is_withheld(self, monkeypatch, tmp_path):
+        baseline = lock(cryptography="46.0.5")
         project = self._repo(
             tmp_path,
-            committed,
+            baseline,
             "[project]\nname = 'app'\n\n[tool.uv]\n"
             'constraint-dependencies = ["cryptography>=46.0.5"]\n',
         )
@@ -945,18 +1028,21 @@ class TestFailsClean:
         monkeypatch.setattr(bounded, "run_uv_lock", fake_run)
         assert bounded.main(["--window", "P3D", "--project-dir", str(project)]) == 1
         assert len(calls) == 2, "the floor should have earned exactly one retry"
-        assert (project / "uv.lock").read_text() == committed
+        self._assert_withheld(project, baseline)
 
-    def test_restore_leaves_a_lock_with_no_baseline_alone(self, tmp_path):
-        # A lock added in this very branch has no committed copy to restore. An
-        # empty baseline must be a no-op, never a truncation.
+    def test_withhold_leaves_a_lock_with_no_baseline_alone(self, tmp_path):
+        # A lock added in this very branch has no committed copy to fall back to.
         target = tmp_path / "uv.lock"
         target.write_text(LOCK_WITH_OPTIONS)
-        bounded.restore(target, "")
+        assert bounded.withhold(target, "", "P3D") is False
         assert target.read_text() == LOCK_WITH_OPTIONS
 
-    def test_restore_writes_the_baseline_back(self, tmp_path):
+    def test_the_tripwire_names_the_window_and_survives_a_strip(self, tmp_path):
+        baseline = lock(boto3="1.43.72")
         target = tmp_path / "uv.lock"
-        target.write_text(LOCK_WITH_OPTIONS)
-        bounded.restore(target, lock(boto3="1.43.72"))
-        assert target.read_text() == lock(boto3="1.43.72")
+        target.write_text(lock(boto3="1.43.99"))
+        assert bounded.withhold(target, baseline, "P3D") is True
+        written = target.read_text()
+        assert 'exclude-newer-span = "P3D"' in written
+        # Recoverable: a human, or the next run, gets the baseline back exactly.
+        assert bounded.strip_options(written) == baseline


### PR DESCRIPTION
## What

A refusal now leaves the lock in a state a **required** check rejects, instead of exiting non-zero and hoping. It writes the baseline's versions plus an `[options]` table the repo's `pyproject.toml` does not declare — which is what `uv sync --locked` refuses in the image build. And it now covers the common case, not just refusals: a run where the bound admits nothing while Renovate's own pass moved something fails rather than hand that pass to the branch.

## Why the previous shape withheld nothing

#3295 restored the committed lock on refusal. That is worse than it sounds, because the driver never owns the commit:

1. Renovate runs its own unbounded `uv lock --upgrade` and records `"updatedArtifacts": ["uv.lock"]` **before** `postUpgradeTasks`.
2. It commits the working tree afterwards, whatever the exit code.
3. When the tree matches HEAD, it falls back to the artifact from step 1.

So restoring the baseline shipped Renovate's *unbounded* lock — and that lock is valid, so it passes everything. Exiting non-zero does not help either: `renovate/artifacts` is advisory (not a required context in any lock-lane repo, and those repos have `required_approving_review_count: 0`), and Renovate re-arms GitHub-native automerge in the same pass that records the failure:

```
16:13:52  GitHub-native automerge: success ... PrNo: 373
16:13:53  Ensuring comment "⚠️ Artifact update problem" in #373
```

**Measured on 2026-08-19:** six of the day's eight auto-merged fleet lock PRs carried a non-exempt third-party release between **21 minutes and 3 hours old** (boto3/botocore 1.43.75, uvicorn 0.52.4). The only two clean ones were application-sdk's own, which run the workflow lane and own their commit. The driver reported `0 package(s) upgraded` on each of them — it did its job; its answer was discarded.

## Why a broken lock, of all things

The only lever a `postUpgradeTasks` command holds over a **required** check is the lock's own validity. `scan / Build Image` is required in every lock-lane repo, and it runs `uv sync --locked`. Verified against real uv on a fleet checkout:

```
baseline     uv lock --check    exit=0    uv sync --locked  exit=0
tripwired    uv lock --check    exit=1    uv sync --locked  exit=1
```

The withheld lock keeps the base branch's versions, so nothing unwanted can land even if someone force-merges, and `strip_options()` recovers the baseline byte-for-byte.

This is a stopgap and says so in the docstring. The durable fix is a required age check that fails on its own evidence rather than on a lock the build cannot install — tracked on FND-379.

## Tests

`TestWithholds` covers the hold-everything case, its control (a genuinely quiet run stays clean and exits 0), the untouched success path, the yanked-pin downgrade, both uv-failure paths, and the tripwire helper. Two existing ceiling tests were also hold-everything fixtures; their expected exit code changed to 1 with a comment saying why. 80 passed across both driver suites; pre-commit clean.
