### PR TITLE
ci(reviewer): re-request a review when the head moves past the verdict (FND-638)

### DIFF
--- a/.github/scripts/sdk_review_approve.py
+++ b/.github/scripts/sdk_review_approve.py
@@ -31,6 +31,17 @@ bot is done" while the merge gate is still blocked. If the approval cannot be
 posted the status is left as the dispatcher set it (pending) and the run fails
 loudly.
 
+A stale head is re-reviewed, not dropped
+---------------------------------------
+A verdict describes the sha stamped in its `REVIEWED_HEAD` marker. If the PR's
+head has moved since, no stamp is applied — that guard is correct and must stay.
+What was wrong was what happened next: nothing. The run exited green, the review
+evaporated, and the loop sat waiting for a human who had no idea anything had
+happened. So that one refusal now posts a single `@sdk-review` comment for the
+current head (`request_rereview`), guarded once-per-sha so a fix->review->fix
+chain cannot feed itself. The neighbouring refusals — no `REVIEWED_HEAD`, and an
+unresolvable head — establish no sha to review and keep failing closed.
+
 Labels
 ------
 Written through the REST labels API rather than `gh pr edit`. Labels are an
@@ -87,7 +98,10 @@ Environment:
                                 unless `sdk-review-approved` was already on the
                                 PR when this run started
     GH_TOKEN                    App installation token — every call but APPROVE
-    APPROVER_TOKEN              `atlan-ci` PAT — the APPROVE call only
+    APPROVER_TOKEN              `atlan-ci` PAT — the APPROVE call, and the
+                                `@sdk-review` re-review request on a stale head
+                                (the reviewer's `if:` admits no other identity
+                                we hold). Absent, both are skipped.
     APPROVE_MAX_ATTEMPTS        default 3
     APPROVE_MAX_WAIT_SECONDS    total sleep budget across retries, default 120
 
@@ -104,9 +118,21 @@ import json
 import os
 import re
 import subprocess
+import sys
 import time
 from collections.abc import Callable
 from dataclasses import dataclass
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+# The in-flight check the review gate already owns. Importing it rather than
+# re-deriving it keeps one definition of "a run has claimed this sha and has
+# not finished" — the two would otherwise drift, and a drifted copy either
+# double-dispatches or never dispatches.
+from sdk_review_gate import (  # noqa: E402  (needs the sys.path bootstrap)
+    inflight_sibling_run,
+)
 
 Runner = Callable[..., subprocess.CompletedProcess]
 Sleeper = Callable[[float], None]
@@ -206,6 +232,85 @@ def extract_reviewed_head(body: str) -> str | None:
     """The sha the verdict was computed against, if the comment stamps one."""
     match = REVIEWED_HEAD_RE.search(body)
     return match.group(1) if match else None
+
+
+# --- re-review request on a stale head -----------------------------------
+#
+# When the head has moved past the verdict, every stamp is refused — correctly:
+# the verdict describes `reviewed_head`, and stamping the new head would bless
+# code the reviewer never saw. Before FND-638 that was the end of it. The run
+# exited green, the review evaporated, and the loop sat waiting for a human who
+# had no idea anything had happened; six of sixteen completed runs on one day
+# lost their verdict that way, at roughly $45 of review work.
+#
+# So the refusal now asks for one fresh review of the head that actually exists.
+# The request has to be a comment because that is the only surface
+# `sdk-review.yml` listens on, and its body has to START with `@sdk-review`
+# because that workflow's job-level `if:` uses `startsWith`. The markers
+# therefore sit at the bottom of the body, not the top.
+RETRIGGER_MARKER = "<!-- SDK_REVIEW_RETRIGGER -->"
+RETRIGGER_HEAD_RE = re.compile(
+    r"<!--\s*SDK_REVIEW_RETRIGGER_HEAD:\s*([0-9a-f]{40})\s*-->"
+)
+
+# What `request_rereview` did, in words, for the ::warning:: it annotates. The
+# slugs themselves are what `StampOutcome.detail` carries.
+RETRIGGER_REASONS = {
+    "posted": "requested a fresh review of the current head",
+    "already-requested": "a re-review was already requested for this head",
+    "already-reviewed": "the current head already has a verdict",
+    "run-in-flight": "a review of the current head is already running",
+    "comments-unreadable": "the PR comments could not be read to check",
+    "no-approver-token": "no APPROVER_TOKEN to post the trigger with",
+    "post-failed": "the trigger comment could not be posted",
+}
+
+
+def retrigger_body(stale_head: str, head_sha: str) -> str:
+    """The `@sdk-review` comment that asks for a review of the current head."""
+    return (
+        "@sdk-review\n"
+        "\n"
+        f"The last review's verdict was computed for `{stale_head[:7]}`, but this "
+        f"PR's head has since moved to `{head_sha[:7]}`, so that verdict cannot be "
+        "stamped onto code it never saw. Requesting one fresh review of the "
+        "current head.\n"
+        "\n"
+        f"{RETRIGGER_MARKER}\n"
+        f"<!-- SDK_REVIEW_RETRIGGER_HEAD: {head_sha} -->\n"
+    )
+
+
+def retrigger_posted_for(comments: list[dict], head_sha: str) -> bool:
+    """Whether a re-review has already been requested for `head_sha`.
+
+    Keyed on the sha rather than counted, so a fix->review->fix->review chain
+    gets one request per distinct head and cannot feed itself: a second request
+    for a sha that already has one is the loop, and this is where it stops.
+    """
+    for comment in comments:
+        body = comment.get("body") or ""
+        if RETRIGGER_MARKER not in body:
+            continue
+        match = RETRIGGER_HEAD_RE.search(body)
+        if match and match.group(1) == head_sha:
+            return True
+    return False
+
+
+def reviewed_at(comments: list[dict], head_sha: str) -> bool:
+    """Whether some verdict comment on this PR already reviewed `head_sha`.
+
+    The fast path is driven by an `issue_comment` event, so the body it was
+    handed can be an older verdict while a newer one covering the live head
+    already sits on the PR. Asking for a review of a head that has one would be
+    pure waste.
+    """
+    return any(
+        _is_verdict_comment(comment)
+        and extract_reviewed_head(comment.get("body") or "") == head_sha
+        for comment in comments
+    )
 
 
 def label_plan(verdict: str, current: set[str]) -> tuple[set[str], set[str]]:
@@ -319,6 +424,37 @@ class Client:
             elif isinstance(page, dict):
                 items.append(page)
         return items
+
+    def all_comments(self) -> list[dict] | None:
+        """Every issue comment on the PR, or None if the listing could not be read.
+
+        Unfiltered, unlike `_summary_comments()`: the re-review guards have to
+        see the starter comments and the retrigger markers too, and those are
+        written by other identities.
+
+        None is preserved rather than collapsed to `[]` for the same reason it
+        is on the reviews listing — "the API did not answer" must not read as
+        "nothing is there" when the emptiness is the precondition for a write.
+        """
+        return self._paginated(f"issues/{self.pr_number}/comments")
+
+    def post_comment(self, body: str, token: str) -> bool:
+        """Post `body` as a PR comment under `token`; True on success."""
+        result = self.run(
+            [
+                "api",
+                f"repos/{self.repo}/issues/{self.pr_number}/comments",
+                "-X",
+                "POST",
+                "-f",
+                f"body={body}",
+            ],
+            token=token,
+        )
+        if result.returncode != 0:
+            print(f"::warning::could not post comment: {result.stderr.strip()}")
+            return False
+        return True
 
     def _summary_comments(self) -> list[dict]:
         """Verdict comments only: reviewer-bot-authored AND carrying a marker.
@@ -517,6 +653,47 @@ class Client:
         )
 
 
+def request_rereview(client: Client, stale_head: str, head_sha: str) -> str:
+    """Ask for one review of `head_sha`; return the machine-readable outcome.
+
+    Every guard fails CLOSED: an unreadable listing means we cannot prove a
+    request is absent, and a duplicate `@sdk-review` costs a full sandbox run.
+    A lost request is recoverable by a human tagging `@sdk-review`; a
+    self-feeding trigger loop is not.
+
+    Deliberately scoped to the stale-head refusal alone. The two neighbouring
+    refusals — a verdict with no `REVIEWED_HEAD`, and an unresolvable head — are
+    different faults: neither establishes a sha to review, so both keep failing
+    closed rather than guessing one.
+    """
+    # Posted as `atlan-ci` rather than under GH_TOKEN. Two hard requirements,
+    # not a preference: `sdk-review.yml`'s job-level `if:` admits `atlan-ci`,
+    # `mothership-ai[bot]` and human collaborators and nothing else, and
+    # `sdk-review-dismiss-on-human.yml` excludes `atlan-ci` by name — a trigger
+    # from any other identity would either be ignored by the reviewer or read as
+    # human activity and dismiss the very approval the loop is chasing. It costs
+    # one request against that quota, and only on this branch.
+    approver_token = os.environ.get("APPROVER_TOKEN", "")
+    if not approver_token:
+        return "no-approver-token"
+
+    comments = client.all_comments()
+    if comments is None:
+        return "comments-unreadable"
+    if reviewed_at(comments, head_sha):
+        return "already-reviewed"
+    if retrigger_posted_for(comments, head_sha):
+        return "already-requested"
+    # `self_run_id=""` because this is not a review run: no starter comment on
+    # the PR can be ours, so every unfinished one for this sha counts.
+    if inflight_sibling_run(comments, head_sha, ""):
+        return "run-in-flight"
+
+    if not client.post_comment(retrigger_body(stale_head, head_sha), approver_token):
+        return "post-failed"
+    return "posted"
+
+
 def post_approval_with_retry(
     client: Client,
     sha: str,
@@ -635,12 +812,19 @@ def stamp_verdict(
 
     # The verdict was computed for reviewed_head. A push since then means the
     # current head is unreviewed, and stamping it would bless unreviewed code.
+    #
+    # Refusing to stamp is not enough on its own, though: dropping the verdict
+    # here and exiting green is how a review evaporates while the loop waits on
+    # a human who was never told. So the refusal also asks for one fresh review
+    # of the head that does exist — see `request_rereview`.
     if reviewed_head != head_sha:
+        outcome = request_rereview(client, reviewed_head, head_sha)
         print(
             f"::warning::PR #{pr_number}: verdict was computed for {reviewed_head} "
-            f"but current head is {head_sha} — skipping all stamps."
+            f"but current head is {head_sha} — skipping all stamps; "
+            f"{RETRIGGER_REASONS.get(outcome, outcome)}."
         )
-        return StampOutcome(SKIPPED, 0, "head moved past the verdict")
+        return StampOutcome(SKIPPED, 0, f"head moved past the verdict ({outcome})")
 
     # Belt-and-suspenders for the slow path: the review can take 10–30 minutes,
     # and the sandbox could in principle have reviewed a sha other than the one

--- a/.github/scripts/sdk_review_approve.py
+++ b/.github/scripts/sdk_review_approve.py
@@ -281,14 +281,29 @@ def retrigger_body(stale_head: str, head_sha: str) -> str:
     )
 
 
+# The re-review trigger is posted as `atlan-ci` (see `request_rereview`), so a
+# marker from any other author is not a request this loop made. Trusting one
+# would let a forged marker for the current head — anyone can comment on a
+# public-repo PR — read as `already-requested` and silently suppress the fresh
+# review the stale-head refusal exists to ask for. Same fail-closed authorship
+# rule `reviewed_at()` applies to verdicts.
+RETRIGGER_AUTHOR = "atlan-ci"
+
+
 def retrigger_posted_for(comments: list[dict], head_sha: str) -> bool:
     """Whether a re-review has already been requested for `head_sha`.
 
     Keyed on the sha rather than counted, so a fix->review->fix->review chain
     gets one request per distinct head and cannot feed itself: a second request
     for a sha that already has one is the loop, and this is where it stops.
+
+    Only an `atlan-ci` marker counts: the request is only ever posted under
+    that identity, so any other author's marker is either a human quoting one
+    or a forgery, and neither proves the loop already asked.
     """
     for comment in comments:
+        if (comment.get("user") or {}).get("login") != RETRIGGER_AUTHOR:
+            continue
         body = comment.get("body") or ""
         if RETRIGGER_MARKER not in body:
             continue
@@ -665,6 +680,19 @@ def request_rereview(client: Client, stale_head: str, head_sha: str) -> str:
     refusals — a verdict with no `REVIEWED_HEAD`, and an unresolvable head — are
     different faults: neither establishes a sha to review, so both keep failing
     closed rather than guessing one.
+
+    The check-then-post below is not atomic across the two concurrency groups
+    this can race with: the fast path (`sdk-review-approve-on-verdict.yml`,
+    group `sdk-review-approve-<PR>`) and the slow path (`sdk-review.yml`, group
+    `sdk-review-<PR>`) hold different per-PR locks, so two runs could both see
+    no marker and both post `@sdk-review` for the same head. That is accepted,
+    dedupe-covered behavior: the authoritative `Dedupe check` inside the
+    dispatch lock re-resolves HEAD and declines the second trigger, so the
+    residue is one duplicate comment plus a self-declining run — never a
+    duplicate review. Closing the race outright would mean serializing every
+    `stamp_verdict` caller under one per-PR group, which would make a 10–30 min
+    review hold the lock while approval runs queue behind it; that cost is not
+    worth eliminating a comment the dispatcher already drops.
     """
     # Posted as `atlan-ci` rather than under GH_TOKEN. Two hard requirements,
     # not a preference: `sdk-review.yml`'s job-level `if:` admits `atlan-ci`,

--- a/.github/scripts/tests/test_sdk_review_approve.py
+++ b/.github/scripts/tests/test_sdk_review_approve.py
@@ -160,11 +160,11 @@ def starter_comment(
     return {"id": 4, "body": body, "user": {"login": "atlan-ci"}}
 
 
-def retrigger_comment(head: str = HEAD) -> dict:
+def retrigger_comment(head: str = HEAD, login: str = "atlan-ci") -> dict:
     return {
         "id": 6,
         "body": approve.retrigger_body(OTHER, head),
-        "user": {"login": "atlan-ci"},
+        "user": {"login": login},
     }
 
 
@@ -523,6 +523,27 @@ def test_the_review_request_is_posted_once_per_sha(monkeypatch):
     )
     assert run_main(gh, monkeypatch, **stale_head_env()) == 0
     assert gh.called(is_comment_post) == []
+
+
+def test_a_forged_retrigger_marker_does_not_suppress_the_request(monkeypatch):
+    """A marker from a non-`atlan-ci` author is not a request this loop made.
+
+    Anyone can comment on a public-repo PR. Without the author check, a forged
+    `SDK_REVIEW_RETRIGGER` marker for the current head would read as
+    `already-requested` and silently suppress the fresh review the stale-head
+    refusal exists to ask for — the exact failure FND-638 was fixing.
+    """
+    gh = base_gh()
+    gh.on(
+        lambda a: a[2] == f"repos/{REPO}/issues/{PR}/comments",
+        ok(
+            comments(
+                summary_comment(5), retrigger_comment(head=HEAD, login="evil-doer")
+            )
+        ),
+    )
+    assert run_main(gh, monkeypatch, **stale_head_env()) == 0
+    assert f"<!-- SDK_REVIEW_RETRIGGER_HEAD: {HEAD} -->" in posted_comment_body(gh)
 
 
 def test_a_request_for_a_different_sha_does_not_block_this_one(monkeypatch):

--- a/.github/scripts/tests/test_sdk_review_approve.py
+++ b/.github/scripts/tests/test_sdk_review_approve.py
@@ -127,6 +127,51 @@ def is_rate_limit_probe(argv) -> bool:
     return argv[1] == "api" and argv[2] == "rate_limit"
 
 
+def is_comment_post(argv) -> bool:
+    return (
+        argv[1] == "api"
+        and argv[2] == f"repos/{REPO}/issues/{PR}/comments"
+        and "POST" in argv
+    )
+
+
+def posted_comment_body(gh: FakeGH) -> str:
+    """The body of the single comment POST `gh` recorded."""
+    (argv,) = gh.called(is_comment_post)
+    return next(arg[len("body=") :] for arg in argv if arg.startswith("body="))
+
+
+def starter_comment(
+    head: str = HEAD, run_id: str = "99", finished: bool = False
+) -> dict:
+    """The "review starting" comment `sdk-review.yml` posts, as the API returns it.
+
+    Kept in the shape `sdk_review_gate.inflight_sibling_run` parses, since that
+    is the function the stale-head re-review defers to.
+    """
+    body = (
+        "<!-- SDK_REVIEW_STARTED -->\n"
+        f"<!-- SDK_REVIEW_STARTED_HEAD: {head} -->\n"
+        f"<!-- SDK_REVIEW_STARTED_RUN: {run_id} -->\n"
+        "SDK review starting."
+    )
+    if finished:
+        body += "\n\n\u2014 status `success`"
+    return {"id": 4, "body": body, "user": {"login": "atlan-ci"}}
+
+
+def retrigger_comment(head: str = HEAD) -> dict:
+    return {
+        "id": 6,
+        "body": approve.retrigger_body(OTHER, head),
+        "user": {"login": "atlan-ci"},
+    }
+
+
+def comments(*bodies: dict) -> str:
+    return json.dumps([list(bodies)])
+
+
 def base_gh(
     labels: list[str] | None = None, reviews: list[dict] | None = None
 ) -> FakeGH:
@@ -423,12 +468,153 @@ def test_superseded_ready_verdict_dismisses_the_stale_bot_approval(monkeypatch):
     assert gh.called(lambda a: "dismissals" in a[2])
 
 
+# --- the stale-head branch (FND-638) -------------------------------------
+#
+# The refusal to stamp is correct and pinned below; what these add is that the
+# refusal no longer ends the story. Six of sixteen completed runs on one day had
+# their verdict discarded here with only a warning, and the loop then waited on
+# a human who was never told.
+
+
+def stale_head_env() -> dict:
+    """Env for a run whose verdict describes OTHER while the live head is HEAD."""
+    return {"COMMENT_BODY": verdict_comment(head=OTHER)}
+
+
 def test_head_moved_since_review_skips_every_stamp(monkeypatch):
     gh = base_gh()
-    assert run_main(gh, monkeypatch, COMMENT_BODY=verdict_comment(head=OTHER)) == 0
+    assert run_main(gh, monkeypatch, **stale_head_env()) == 0
     assert gh.called(is_approve) == []
     assert gh.called(is_status) == []
     assert gh.called(is_label_add) == []
+
+
+def test_head_moved_requests_a_review_of_the_current_head(monkeypatch):
+    gh = base_gh()
+    assert run_main(gh, monkeypatch, **stale_head_env()) == 0
+    body = posted_comment_body(gh)
+    # `sdk-review.yml`'s job-level `if:` is a startsWith, so the mention has to
+    # be the first thing in the body — markers go at the bottom.
+    assert body.startswith("@sdk-review")
+    assert approve.RETRIGGER_MARKER in body
+    assert f"<!-- SDK_REVIEW_RETRIGGER_HEAD: {HEAD} -->" in body
+
+
+def test_the_review_request_is_posted_as_atlan_ci(monkeypatch):
+    """Not under GH_TOKEN: the reviewer's `if:` admits no identity we hold.
+
+    `sdk-review.yml` accepts `atlan-ci`, `mothership-ai[bot]` and human
+    collaborators; a trigger from the fleet App would be silently ignored. And
+    `sdk-review-dismiss-on-human.yml` excludes `atlan-ci` by name, so this
+    comment cannot be mistaken for the human activity that dismisses approvals.
+    """
+    gh = base_gh()
+    assert run_main(gh, monkeypatch, **stale_head_env()) == 0
+    index = gh.calls.index(gh.called(is_comment_post)[0])
+    assert gh.tokens[index] == "pat-atlan-ci"
+
+
+def test_the_review_request_is_posted_once_per_sha(monkeypatch):
+    """The once-per-sha key is what stops fix->review->fix becoming a loop."""
+    gh = base_gh()
+    gh.on(
+        lambda a: a[2] == f"repos/{REPO}/issues/{PR}/comments",
+        ok(comments(summary_comment(5), retrigger_comment(head=HEAD))),
+    )
+    assert run_main(gh, monkeypatch, **stale_head_env()) == 0
+    assert gh.called(is_comment_post) == []
+
+
+def test_a_request_for_a_different_sha_does_not_block_this_one(monkeypatch):
+    """Keyed on the head, not on "a request was made once on this PR"."""
+    gh = base_gh()
+    gh.on(
+        lambda a: a[2] == f"repos/{REPO}/issues/{PR}/comments",
+        ok(comments(summary_comment(5), retrigger_comment(head=OTHER))),
+    )
+    assert run_main(gh, monkeypatch, **stale_head_env()) == 0
+    assert f"<!-- SDK_REVIEW_RETRIGGER_HEAD: {HEAD} -->" in posted_comment_body(gh)
+
+
+def test_no_request_while_a_run_is_already_reviewing_that_head(monkeypatch):
+    gh = base_gh()
+    gh.on(
+        lambda a: a[2] == f"repos/{REPO}/issues/{PR}/comments",
+        ok(comments(summary_comment(5), starter_comment(head=HEAD))),
+    )
+    assert run_main(gh, monkeypatch, **stale_head_env()) == 0
+    assert gh.called(is_comment_post) == []
+
+
+def test_a_finished_run_on_that_head_does_not_count_as_in_flight(monkeypatch):
+    """A stamped starter means that run reached its end — it will post nothing more."""
+    gh = base_gh()
+    gh.on(
+        lambda a: a[2] == f"repos/{REPO}/issues/{PR}/comments",
+        ok(comments(summary_comment(5), starter_comment(head=HEAD, finished=True))),
+    )
+    assert run_main(gh, monkeypatch, **stale_head_env()) == 0
+    assert gh.called(is_comment_post) != []
+
+
+def test_no_request_when_the_current_head_already_has_a_verdict(monkeypatch):
+    """The fast path can be driven by an older verdict than the PR's newest."""
+    gh = base_gh()
+    gh.on(
+        lambda a: a[2] == f"repos/{REPO}/issues/{PR}/comments",
+        ok(comments(summary_comment(9, body=verdict_comment(head=HEAD)))),
+    )
+    assert run_main(gh, monkeypatch, **stale_head_env()) == 0
+    assert gh.called(is_comment_post) == []
+
+
+def test_no_request_when_the_comment_listing_cannot_be_read(monkeypatch):
+    """Fails closed: an unreadable listing cannot prove a request is absent.
+
+    A duplicate `@sdk-review` costs a full sandbox run; a lost one costs a human
+    typing the mention.
+    """
+    gh = base_gh()
+    gh.on(
+        lambda a: a[2] == f"repos/{REPO}/issues/{PR}/comments",
+        fail("gh: Bad gateway (HTTP 502)"),
+    )
+    assert run_main(gh, monkeypatch, **stale_head_env()) == 0
+    assert gh.called(is_comment_post) == []
+
+
+def test_no_request_without_an_approver_token(monkeypatch):
+    gh = base_gh()
+    assert run_main(gh, monkeypatch, APPROVER_TOKEN="", **stale_head_env()) == 0
+    assert gh.called(is_comment_post) == []
+
+
+def test_a_verdict_without_a_reviewed_head_marker_requests_nothing(monkeypatch):
+    """A different fault: no sha is established, so there is none to review."""
+    gh = base_gh()
+    body = "<!-- SDK_REVIEW -->\n<!-- VERDICT: READY_TO_MERGE -->\n"
+    assert run_main(gh, monkeypatch, COMMENT_BODY=body) == 0
+    assert gh.called(is_comment_post) == []
+
+
+def test_an_unresolvable_head_requests_nothing(monkeypatch):
+    """Also a different fault — and the sha to review is exactly what is missing."""
+    gh = base_gh()
+    gh.on(is_head_lookup, fail("gh: Bad gateway (HTTP 502)"))
+    assert run_main(gh, monkeypatch, **stale_head_env()) == 0
+    assert gh.called(is_comment_post) == []
+
+
+# --- request helpers in isolation ----------------------------------------
+
+
+def test_retrigger_posted_for_ignores_a_marker_without_a_head_stamp():
+    assert not approve.retrigger_posted_for([{"body": approve.RETRIGGER_MARKER}], HEAD)
+
+
+def test_reviewed_at_ignores_a_forged_verdict_from_another_author():
+    forged = summary_comment(11, login="attacker", body=verdict_comment(head=HEAD))
+    assert not approve.reviewed_at([forged], HEAD)
 
 
 def test_newer_verdict_comment_supersedes_this_run(monkeypatch):


### PR DESCRIPTION
Closes [FND-638](https://linear.app/atlan-epd/issue/FND-638/a-stale-head-verdict-is-discarded-instead-of-re-run).

## The defect

A verdict describes the sha in its `REVIEWED_HEAD` marker. When the PR's head has moved since, `sdk_review_approve.py` refuses every stamp. That guard is correct and stays — stamping the live head would bless code the reviewer never saw.

What was wrong is what happened *after* the refusal, which was nothing. The run exited green, the review evaporated, and the loop then sat waiting for a human who had no idea anything had happened. On 2026-08-19 that discarded six of sixteen completed runs.

## The fix

On the `head moved past the verdict` branch specifically, request one fresh review of the head that does exist, by posting a single `@sdk-review` comment.

Four guards, all failing **closed** — a duplicate trigger costs a full sandbox run, while a lost one costs a human typing the mention:

| Guard | Why |
| --- | --- |
| Once per sha, keyed on the new head | A fix→review→fix chain gets one request per distinct head and cannot feed itself |
| No request while a run has claimed that sha and not finished | Reuses `sdk_review_gate.inflight_sibling_run` rather than a second copy of it |
| No request if some verdict on the PR already covers the live head | The fast path can be driven by an event carrying an older comment than the PR's newest |
| No request if the comment listing is unreadable | An unreadable listing cannot prove a request is absent |

**Only the stale-head branch.** The two neighbouring refusals — a verdict with no `REVIEWED_HEAD`, and an unresolvable head — establish no sha to review, so they keep failing closed.

## Why `atlan-ci` posts the trigger

A requirement, not a preference. `sdk-review.yml`'s job-level `if:` admits `atlan-ci`, `mothership-ai[bot]` and human collaborators and nothing else; and `sdk-review-dismiss-on-human.yml` excludes `atlan-ci` by name. From any other identity — the fleet App token included — the comment would either be ignored by the reviewer or read as human activity and dismiss the very approval the loop is chasing. It costs one request against that quota, and only on this branch.

## Scope

- `sdk_review_reconcile.py` pre-filters stale heads before it ever reaches `stamp_verdict`, so the cron sweep does not re-request. Left as is.
- No workflow YAML changes: the trigger surface, the gate and the dedupe primitive all already exist.

## Testing

- 15 new tests in `.github/scripts/tests/test_sdk_review_approve.py`, pinning both directions of every guard (a finished starter comment does *not* count as in-flight; a request for a different sha does *not* block this one). The existing stale-head test is unchanged and still pins "no stamp is applied".
- `uv run --extra workflows --with pytest python -m pytest .github/scripts/tests -q` → **2792 passed**.
- `uv run pre-commit run --files …` clean, pyright included.

## Sequencing

FND-638 is blocked-by FND-636 (merged as b0a28075b, whose `inflight_sibling_run` this reuses) and FND-639. Lane serialisation removes most occurrences of this; this covers the residue — a human pushing while a review is in flight, which serialisation cannot prevent.
