### PR TITLE
ci(sdk-resolve): fail a run that reports success with no Phase 4 summary (FND-644)

### DIFF
--- a/.github/scripts/sdk_resolve_dispatch.py
+++ b/.github/scripts/sdk_resolve_dispatch.py
@@ -455,6 +455,15 @@ def run_completed(st: SSEState) -> bool:
     """
     if st.errored:
         return False
+    if st.completed and st.status != "completed":
+        # A terminal status the sandbox itself calls a failure. `process_line`
+        # leaves `errored` False for a `complete` carrying status=error with an
+        # empty error object, so the check above does not cover this — and
+        # without it a run that streamed its Phase 4 summary and *then* died
+        # would render as merge-ready in the step summary while `decide_exit`
+        # returned 1. Terminal status and proof of work are both consulted, so
+        # the two never diverge.
+        return False
     summary = mine_summary(st)
     return any(k in summary for k in TERMINAL_SUMMARY_KEYS)
 

--- a/.github/scripts/sdk_resolve_dispatch.py
+++ b/.github/scripts/sdk_resolve_dispatch.py
@@ -160,6 +160,9 @@ OOB_SINCE_SKEW_SECONDS = 120
 
 SUMMARY_START = "=== SDK RESOLVE SUMMARY ==="
 SUMMARY_END = "=== END SUMMARY ==="
+# Summary rows only a run that reached Phase 4 can carry. Any one of them is
+# proof of work; their absence is proof the resolver never got there.
+TERMINAL_SUMMARY_KEYS = ("final_verdict", "merge_ready", "stopped_reason")
 # Rows rendered into the GitHub step summary, in order.
 SUMMARY_ROWS = (
     "rounds",
@@ -438,20 +441,33 @@ def mine_summary(st: SSEState) -> dict[str, str]:
 def run_completed(st: SSEState) -> bool:
     """True when the resolver actually finished its work.
 
-    The transport `complete` event is the normal success signal, but mothership
-    sometimes ends the resolve stream cleanly (EOF) without it. The resolver
-    emits its Phase 4 `=== SDK RESOLVE SUMMARY ===` block as its very last action
-    (ORCHESTRATION Phase 4), so a mined summary carrying a terminal key is
-    end-of-run evidence independent of the sentinel — treat that as completed. A
-    stream truncated mid-work carries no summary block and is still a failure, so
-    this never masks a genuinely incomplete run.
+    Proof of work is the Phase 4 `=== SDK RESOLVE SUMMARY ===` block, which the
+    resolver emits as its very last action (ORCHESTRATION Phase 4) — never the
+    transport `complete` sentinel. The sentinel reports only that the sandbox
+    stopped, and a sandbox can stop having done nothing at all: two dispatches
+    ended `status=completed` after 3-5 min having posted no `@sdk-review`
+    trigger, no status comment and no report, and pushed nothing, yet both runs
+    went green because the sentinel alone decided the exit code. Conversely,
+    mothership sometimes ends a fully successful stream cleanly (EOF) with no
+    sentinel at all. So the summary decides in both directions; the sentinel
+    decides only whether the sandbox is still alive, which is
+    `sandbox_terminated_abnormally`'s job.
     """
     if st.errored:
         return False
-    if st.completed:
-        return st.status == "completed"
     summary = mine_summary(st)
-    return any(k in summary for k in ("final_verdict", "merge_ready", "stopped_reason"))
+    return any(k in summary for k in TERMINAL_SUMMARY_KEYS)
+
+
+def resolved_nothing(st: SSEState) -> bool:
+    """True for a no-op run: the sandbox reported success but did no work.
+
+    Distinct from every other failure shape in that nothing went wrong at the
+    transport or provider layer — the model simply ended its turn before
+    working through the ORCHESTRATION. Nothing was pushed and nothing was
+    posted, so re-dispatching is both safe and the only way forward.
+    """
+    return st.completed and st.status == "completed" and not run_completed(st)
 
 
 def _rounds_completed(summary: dict[str, str]) -> int | None:
@@ -561,6 +577,11 @@ def render_step_summary(
             "✅ completed out-of-band — our stream dropped, but the resolver's "
             "Phase-4 hand-off comment was found on the PR"
         )
+    elif resolved_nothing(st):
+        outcome = (
+            "❌ no-op run — the sandbox reported success but did no work (no "
+            "Phase-4 summary, nothing pushed); safe to re-run `@sdk-resolve`"
+        )
     elif not ok:
         outcome = "❌ run failed"
     elif merge_ready:
@@ -653,6 +674,18 @@ def decide_exit(st: SSEState) -> tuple[int, str]:
         return 1, "::error::Stream ended without a 'complete' event"
     if st.status != "completed":
         return 1, f"::error::Sandbox final status={st.status} (expected 'completed')"
+    if resolved_nothing(st):
+        # The sentinel says the sandbox exited happily; the missing Phase 4
+        # summary says it never did the work. Fail, so the retry ladder below
+        # gets a chance on a different model instead of the run going green
+        # over a resolve that pushed nothing and posted nothing.
+        return (
+            1,
+            "::error::Sandbox reported status=completed but emitted no Phase 4 "
+            "summary — the resolver ended its turn without working through the "
+            "ORCHESTRATION (no @sdk-review trigger, no report, nothing pushed). "
+            "Treating as a failed run.",
+        )
     return 0, f"SDK Resolve completed (cost={st.cost})."
 
 
@@ -717,8 +750,16 @@ def sandbox_terminated_abnormally(st: SSEState) -> bool:
     hand-off, and whether re-dispatching is safe. A dead sandbox will post
     nothing more; a live one behind a cut stream is still working, and
     re-dispatching against it would double-run the resolver.
+
+    A no-op run (`resolved_nothing`) belongs on the dead side: the sentinel
+    proves the sandbox has stopped, so it will post nothing more and a
+    re-dispatch cannot double-run it.
     """
-    return st.errored or (st.completed and st.status != "completed")
+    if st.errored:
+        return True
+    if not st.completed:
+        return False  # no sentinel — our stream was cut, the sandbox may live on
+    return st.status != "completed" or resolved_nothing(st)
 
 
 def oob_poll_budget(st: SSEState) -> int:
@@ -743,6 +784,11 @@ def is_retryable_fault(st: SSEState) -> bool:
     """
     if st.err_code in NEVER_RETRY_ERR_CODES:
         return False
+    if resolved_nothing(st):
+        # A no-op run carries no error code at all, so the code ladder below
+        # cannot see it. The fault is the model ending its turn early, which is
+        # precisely the kind a different model can plausibly survive.
+        return True
     if st.err_code in RETRYABLE_ERR_CODES:
         return True
     if st.err_code not in UNINFORMATIVE_ERR_CODES:
@@ -775,10 +821,14 @@ def retry_decision(st: SSEState, attempt: int, seconds_left: float) -> tuple[boo
             f"only {int(seconds_left)}s of the job budget remain, below the "
             f"{RETRY_MIN_REMAINING_SECONDS}s a retry needs to finish a round"
         )
+    cause = (
+        "the sandbox reported success but emitted no Phase 4 summary (no-op run)"
+        if resolved_nothing(st)
+        else f"code={st.err_code or 'none'} looks like a model/provider fault"
+    )
     return True, (
-        f"code={st.err_code or 'none'} looks like a model/provider fault — "
-        f"re-dispatching on {RETRY_MAIN_MODEL} (attempt {attempt + 1} of "
-        f"{MAX_DISPATCH_ATTEMPTS})"
+        f"{cause} — re-dispatching on {RETRY_MAIN_MODEL} (attempt {attempt + 1} "
+        f"of {MAX_DISPATCH_ATTEMPTS})"
     )
 
 
@@ -985,13 +1035,13 @@ def main() -> int:
         if not should_retry:
             print(f"::warning::Not re-dispatching: {reason}")
             break
-        print(f"::warning::Re-dispatching after a dead sandbox: {reason}")
+        print(f"::warning::Re-dispatching on a fresh sandbox: {reason}")
         attempt += 1
 
     if code != 0 and len(attempts) > 1:
         message += (
             f" (retried on {attempt_model(len(attempts))} after "
-            f"{attempt_model(1)} died; both attempts failed)"
+            f"{attempt_model(1)} failed; both attempts failed)"
         )
 
     write_step_summary(

--- a/.github/scripts/tests/test_sdk_resolve_dispatch.py
+++ b/.github/scripts/tests/test_sdk_resolve_dispatch.py
@@ -164,6 +164,30 @@ def test_resolved_nothing_is_false_for_every_other_stream_shape():
     assert sr.resolved_nothing(_completed_stream()) is False
 
 
+def test_a_summary_does_not_outrank_a_failed_terminal_status():
+    # `process_line` leaves `errored` False for a `complete` carrying
+    # status=error with an empty error object. Without consulting the terminal
+    # status, a run that streamed its Phase 4 summary and *then* died would
+    # render as merge-ready while `decide_exit` returned 1 — the exit code and
+    # the step summary must never disagree.
+    st = _stream(
+        "event: response",
+        f"data: {json.dumps({'text': _SUMMARY_BLOCK})}",
+        "",
+        "event: complete",
+        'data: {"status": "error"}',
+    )
+    assert st.errored is False and st.status == "error"
+    assert sr.run_completed(st) is False
+    assert sr.decide_exit(st)[0] == 1
+    out = sr.render_step_summary(st, "1234", "http://run")
+    assert "merge-ready" not in out
+    assert "run failed" in out
+    # Still not a no-op: the sandbox reported a failure, so it keeps the
+    # error-code retry path rather than the no-op one.
+    assert sr.resolved_nothing(st) is False
+
+
 def test_noop_run_is_a_stopped_sandbox_with_a_short_poll():
     # The sentinel proves the sandbox stopped, so it will post nothing more:
     # poll briefly for a hand-off that landed just before, then move on. The

--- a/.github/scripts/tests/test_sdk_resolve_dispatch.py
+++ b/.github/scripts/tests/test_sdk_resolve_dispatch.py
@@ -15,6 +15,21 @@ def _stream(*lines: str):
     return sr.process_stream(list(lines))
 
 
+def _completed_stream(cost: str = "7.50"):
+    """A stream that both ends on the sentinel AND carries the Phase 4 summary.
+
+    Success needs both halves now: the sentinel alone is what a no-op run also
+    emits (see `test_complete_without_a_summary_is_a_noop_failure`).
+    """
+    return _stream(
+        "event: response",
+        f"data: {json.dumps({'text': _SUMMARY_BLOCK})}",
+        "",
+        "event: complete",
+        f'data: {{"status": "completed", "cost_usd": "{cost}"}}',
+    )
+
+
 # ---------------------------------------------------------------------------
 # payload / prompt
 # ---------------------------------------------------------------------------
@@ -109,15 +124,72 @@ def test_reviewer_handles_dedupe_and_strip():
 
 
 def test_successful_complete_stream():
+    st = _completed_stream("7.50")
+    assert st.completed and st.status == "completed" and st.cost == "7.50"
+    assert sr.decide_exit(st) == (0, "SDK Resolve completed (cost=7.50).")
+    assert sr.resolved_nothing(st) is False
+
+
+def test_complete_without_a_summary_is_a_noop_failure():
+    # Regression (FND-644): two dispatches on PR #3297 ended `status=completed`
+    # after 3-5 min having posted no @sdk-review trigger, no report, and pushed
+    # nothing — and both runs went green, because the sentinel alone decided the
+    # exit code. Proof of work is the Phase 4 summary, so a sentinel without one
+    # is a failed run.
     st = _stream(
         "event: started",
         'data: {"session_id": "s1", "sandbox_id": "b1"}',
         "",
+        "event: response",
+        'data: {"text": "Let me look at the PR."}',
+        "",
         "event: complete",
-        'data: {"status": "completed", "cost_usd": "7.50"}',
+        'data: {"status": "completed", "cost_usd": "1.457863"}',
     )
-    assert st.completed and st.status == "completed" and st.cost == "7.50"
-    assert sr.decide_exit(st) == (0, "SDK Resolve completed (cost=7.50).")
+    assert sr.resolved_nothing(st) is True
+    code, msg = sr.decide_exit(st)
+    assert code == 1
+    assert "no Phase 4 summary" in msg
+    assert "nothing pushed" in msg
+
+
+def test_resolved_nothing_is_false_for_every_other_stream_shape():
+    # Only a happy sentinel with no summary is a no-op. A hard error, a
+    # transport drop and a real success must each stay off this path, or they
+    # would inherit the no-op's short poll and its re-dispatch.
+    err = _stream("event: complete", 'data: {"status": "error"}')
+    drop = _stream("event: response", 'data: {"text": "working..."}')
+    assert sr.resolved_nothing(err) is False
+    assert sr.resolved_nothing(drop) is False
+    assert sr.resolved_nothing(_completed_stream()) is False
+
+
+def test_noop_run_is_a_stopped_sandbox_with_a_short_poll():
+    # The sentinel proves the sandbox stopped, so it will post nothing more:
+    # poll briefly for a hand-off that landed just before, then move on. The
+    # 45-min stream-drop budget would strand the run for nothing.
+    st = _stream("event: complete", 'data: {"status": "completed"}')
+    assert sr.sandbox_terminated_abnormally(st) is True
+    assert sr.oob_poll_budget(st) == sr.OOB_POLL_SECONDS_HARD_ERROR
+
+
+def test_noop_run_is_retryable_and_names_itself_in_the_reason():
+    # It carries no error code at all, so the code ladder cannot classify it.
+    st = _stream("event: complete", 'data: {"status": "completed"}')
+    assert st.err_code == ""
+    assert sr.is_retryable_fault(st) is True
+    ok, reason = sr.retry_decision(st, 1, sr.DISPATCH_BUDGET_SECONDS)
+    assert ok is True
+    assert "no-op run" in reason
+    assert sr.RETRY_MAIN_MODEL in reason
+
+
+def test_render_noop_run_is_distinct_from_a_hard_failure():
+    st = _stream("event: complete", 'data: {"status": "completed", "cost_usd": "1.45"}')
+    out = sr.render_step_summary(st, "3297", "http://run")
+    assert "no-op run" in out
+    assert "run failed" not in out
+    assert "No summary block was emitted" in out
 
 
 def test_error_event_fails():
@@ -750,9 +822,7 @@ def test_main_redispatches_on_a_model_fault_and_recovers(monkeypatch, capsys):
     dead.got_event = dead.completed = dead.errored = True
     dead.status, dead.cost, dead.err_code = "error", "1.75", "429"
     dead.err_msg = "moonshotai/kimi-k3 is temporarily rate-limited upstream"
-    good = _stream(
-        "event: complete", 'data: {"status": "completed", "cost_usd": "2.10"}'
-    )
+    good = _completed_stream("2.10")
     payloads = _record_dispatches(monkeypatch, [dead, good])
 
     assert sr.main() == 0
@@ -760,9 +830,39 @@ def test_main_redispatches_on_a_model_fault_and_recovers(monkeypatch, capsys):
     # The background lanes stay put across the swap.
     assert {p["small_fast_model"] for p in payloads} == {sr.FAST_MODEL}
     out = capsys.readouterr().out
-    assert "Re-dispatching after a dead sandbox" in out
+    assert "Re-dispatching on a fresh sandbox" in out
     # Both attempts' costs are logged separately.
     assert "cost_usd=1.75" in out and "cost_usd=2.10" in out
+
+
+def test_main_redispatches_a_noop_run_on_the_other_model(monkeypatch, capsys):
+    # End-to-end of the FND-644 path: attempt 1 reports success having done
+    # nothing, so the run must NOT go green on it — it re-dispatches on the
+    # other main model and succeeds there.
+    _main_env(monkeypatch)
+    noop = _stream(
+        "event: complete", 'data: {"status": "completed", "cost_usd": "1.45"}'
+    )
+    payloads = _record_dispatches(monkeypatch, [noop, _completed_stream("2.10")])
+
+    assert sr.main() == 0
+    assert [p["model"] for p in payloads] == [sr.MAIN_MODEL, sr.RETRY_MAIN_MODEL]
+    out = capsys.readouterr().out
+    assert "no-op run" in out
+    # The no-op attempt's spend stays visible rather than hiding behind the
+    # recovered attempt's success.
+    assert "cost_usd=1.45" in out
+
+
+def test_main_fails_when_both_attempts_are_noop_runs(monkeypatch, capsys):
+    # No silent green when the swap does not help either.
+    _main_env(monkeypatch)
+    noop = _stream("event: complete", 'data: {"status": "completed"}')
+    payloads = _record_dispatches(monkeypatch, [noop, noop])
+
+    assert sr.main() == 1
+    assert len(payloads) == 2
+    assert "both attempts failed" in capsys.readouterr().out
 
 
 def test_main_does_not_redispatch_an_elicitation(monkeypatch, capsys):
@@ -832,9 +932,7 @@ def test_main_writes_the_attempt_trail_to_the_step_summary(monkeypatch, tmp_path
     dead = sr.SSEState()
     dead.got_event = dead.completed = dead.errored = True
     dead.status, dead.cost, dead.err_code = "error", "1.75", "429"
-    good = _stream(
-        "event: complete", 'data: {"status": "completed", "cost_usd": "2.10"}'
-    )
+    good = _completed_stream("2.10")
     _record_dispatches(monkeypatch, [dead, good])
 
     assert sr.main() == 0


### PR DESCRIPTION
## Why

`@sdk-resolve` on #3297 was dispatched twice. Both runs booted a sandbox, streamed ~90 responses, billed $0.74 and $1.46, and **did nothing** — no `@sdk-review` trigger, no status comment, no Phase-4 report, nothing pushed. Both went **green**.

| run | model | duration | cost | side effects |
| -- | -- | -- | -- | -- |
| [32309907777](https://github.com/atlanhq/application-sdk/actions/runs/32309907777) | kimi-k3 | ~3 min | $0.74 | none |
| [32311800491](https://github.com/atlanhq/application-sdk/actions/runs/32311800491) | kimi-k3 | ~5.5 min | $1.46 | none |

Infra was healthy throughout: VPN on the first attempt, mothership reachable, then `[complete] status=completed`.

The cause is in `decide_exit`, which exited 0 on the transport sentinel alone:

```python
if st.status != "completed":
    return 1, f"::error::Sandbox final status={st.status} (expected 'completed')"
return 0, f"SDK Resolve completed (cost={st.cost})."
```

The sentinel reports only that the sandbox *stopped*. A sandbox that ends its turn after three minutes having done nothing emits exactly the same sentinel as one that worked through the whole ORCHESTRATION. The branch directly above it — the no-sentinel path — already demanded the Phase-4 `=== SDK RESOLVE SUMMARY ===` block as proof of work via `run_completed()`. The sentinel path demanded nothing.

That asymmetry also disabled the FND-641 retry: `retry_decision()` is only reached on an unhappy stream, so the `claude-opus-5` re-dispatch could never fire for this shape.

## What this changes

Proof of work is the Phase-4 summary, in both directions. The sentinel now decides only whether the sandbox is still alive — which is `sandbox_terminated_abnormally`'s job.

A no-op run (`resolved_nothing`: happy sentinel, no summary) is now:

- **a failure** in `decide_exit`, with an error naming what did not happen;
- **a stopped sandbox** in `sandbox_terminated_abnormally`, so it gets the short 120s hand-off poll rather than the 45-minute stream-drop budget, and a re-dispatch cannot double-run a resolver that is still working;
- **a retryable fault** in `is_retryable_fault`. It carries no error code at all, so the code ladder was blind to it; the fault is the model ending its turn early, which is exactly what the FND-641 model swap exists for;
- **a distinct outcome** in the step summary, not a generic "run failed".

`run_completed` collapses to one rule for both stream shapes, and `TERMINAL_SUMMARY_KEYS` names the keys once instead of inline.

## Tests

`pytest .github/scripts/tests` — **2786 passed** (was 2776).

Ten new tests, including the two `main()`-level ones that pin the behaviour end to end:

- `test_complete_without_a_summary_is_a_noop_failure` — the regression itself
- `test_resolved_nothing_is_false_for_every_other_stream_shape` — a hard error, a transport drop and a real success each stay off the new path
- `test_noop_run_is_a_stopped_sandbox_with_a_short_poll`
- `test_noop_run_is_retryable_and_names_itself_in_the_reason`
- `test_main_redispatches_a_noop_run_on_the_other_model` — attempt 1 no-ops, attempt 2 on `claude-opus-5` recovers, exit 0
- `test_main_fails_when_both_attempts_are_noop_runs` — no silent green when the swap does not help

Three existing tests encoded the old "bare sentinel = success" assumption and were updated to carry a summary block; `_completed_stream()` is the shared helper.

## Not in scope

This makes the no-op visible and buys one retry on a different model. It does not stop `kimi-k3` (`MAIN_MODEL`) from ending its turn early — that is a separate call about the model pin.

Closes FND-644.
