### PR TITLE
ci(sdk-review): re-dispatch sdk-review on a model swap when the sandbox dies (FND-643)

### DIFF
--- a/.github/scripts/mothership_terminate_session.py
+++ b/.github/scripts/mothership_terminate_session.py
@@ -20,10 +20,18 @@ nobody. Every branch is reported as an annotation instead.
 Branching logic lives here (a tested script) rather than inlined in the
 workflow YAML, per docs/standards/ci.md.
 
+A run can boot more than one sandbox: `sdk_review_dispatch.py` re-dispatches
+once on a different model when the first sandbox dies on a hard error, and each
+attempt gets its OWN session id (mothership reads a reused id as a follow-up and
+tries to resume the dead conversation). The workflow cannot know which attempt
+was live when the cancel landed, so this stops every id the dispatcher could
+have used — the ids are derived from the same helper, and an id that never
+existed comes back 404, which is already handled as "nothing to stop".
+
 Environment:
     MOTHERSHIP_URL   base URL, e.g. https://mothership.atlan.dev
     HARNESS_TOKEN    bearer token for the sandbox API
-    SESSION_ID       session to stop, from the workflow's `session` step
+    SESSION_ID       base session id, from the workflow's `session` step
 """
 
 from __future__ import annotations
@@ -32,7 +40,15 @@ import os
 import sys
 import urllib.error
 import urllib.request
+from pathlib import Path
 from typing import Callable
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from sdk_review_dispatch import (  # noqa: E402  (needs the sys.path bootstrap)
+    MAX_DISPATCH_ATTEMPTS,
+    attempt_session_id,
+)
 
 TIMEOUT_SECONDS = 30
 BODY_PREVIEW_CHARS = 500
@@ -114,8 +130,10 @@ def main(argv: list[str] | None = None) -> int:
         )
         return 0
 
-    print(f"Job cancelled — asking mothership to stop session {session_id}.")
-    print(terminate(base_url, token, session_id))
+    for attempt in range(1, MAX_DISPATCH_ATTEMPTS + 1):
+        sid = attempt_session_id(session_id, attempt)
+        print(f"Job cancelled — asking mothership to stop session {sid}.")
+        print(terminate(base_url, token, sid))
     return 0
 
 

--- a/.github/scripts/sdk_review_dispatch.py
+++ b/.github/scripts/sdk_review_dispatch.py
@@ -30,6 +30,13 @@ have, because the review lane needs them:
     its summary to the PR, the review WAS delivered, so a later stream
     breakage is a mothership-side finalize glitch and must not red the check.
 
+One re-dispatch is allowed when the sandbox dies on a hard error that a
+different model could survive — see MAX_DISPATCH_ATTEMPTS and retry_decision().
+The retry fires only after the verdict check has come back empty, which is the
+single point where the sandbox is provably dead AND nothing was delivered;
+every other stream ending stays fail-fast, because a second reviewer would post
+a second summary on the same PR.
+
 Environment (all supplied by the `Dispatch to mothership Rover Direct API`
 step in `.github/workflows/sdk-review.yml`):
     MOTHERSHIP_URL       base URL (e.g. https://mothership.atlan.dev)
@@ -59,9 +66,9 @@ import tempfile
 import time
 import urllib.error
 import urllib.request
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Sequence
 from pathlib import Path
-from typing import Any
+from typing import Any, NamedTuple
 
 sys.path.insert(0, str(Path(__file__).parent))
 
@@ -101,6 +108,73 @@ IDLE_WARN_SECONDS = 300
 MAIN_MODEL = "kimi-k3"
 FAST_MODEL = "gpt-5.6-luna"
 IDLE_TIMEOUT_SECONDS = 1800
+
+# --- Re-dispatch when the sandbox dies on a hard error ----------------------
+# One retry, on a DIFFERENT main model — the port of the resolve lane's
+# FND-641. Mothership's intra-group provider fallback already exists and fires
+# on a 429, but every provider in the `kimi-k3` group serves the SAME model, so
+# a same-model re-dispatch just re-hits the same model-level fault (observed on
+# resolve: the 429 fell through to Moonshot AI, which returned 400 "the message
+# at position 21 with role 'assistant' must not be empty" — same model, same
+# bug). Swapping the model is the whole point of the retry.
+MAX_DISPATCH_ATTEMPTS = 2
+# Attempt 2's main model: mothership's own DEFAULT_CLAUDE_MODEL, named
+# explicitly rather than by omitting `model` from the payload, so a test can
+# assert the two attempts actually differ and the retry does not silently
+# follow a mothership config change. `small_fast_model` and
+# CLAUDE_CODE_SUBAGENT_MODEL stay pinned to FAST_MODEL — mothership's
+# model_routing_env does `fast = small_fast_model or model`, so changing only
+# `model` must not drag the background lane along.
+RETRY_MAIN_MODEL = "claude-opus-5"
+# Retry only a fault a different model can plausibly survive. This is an
+# allowlist, not a denylist: a wrong retry burns a second sandbox boot — up to
+# an hour of the job's 130-min budget plus a real bill — so an unrecognised
+# cause stays fail-fast. A recognised code decides on its own; the message is
+# consulted ONLY when the code carries no information at all.
+RETRYABLE_ERR_CODES = frozenset(
+    {
+        "400",
+        "429",
+        "500",
+        "502",
+        "503",
+        "504",
+        "api_error",
+        "overloaded_error",
+        "provider_error",
+        "rate_limit_error",
+        "sandbox_error",
+    }
+)
+# Message substrings that identify a model/provider fault. These are a fallback
+# for one specific case: a `complete` event flattens an absent error code to
+# `none`, and a standalone `error` event defaults it to `unknown`, while both
+# still forward the provider's own text. They must NEVER override a code that
+# does carry information — "401 upstream auth failed" mentions upstream and is
+# nonetheless a permanent fault that would fail identically on any model.
+RETRYABLE_ERR_PATTERNS = (
+    "must not be empty",  # the kimi-k3 empty-assistant-turn fault
+    "rate-limited",
+    "rate limited",
+    "overloaded",
+    "temporarily unavailable",
+    "upstream",
+)
+UNINFORMATIVE_ERR_CODES = frozenset({"", "none", "unknown"})
+# Fails identically on any model, so never spend a second sandbox on it: the
+# sandbox wants interactive input, which GHA can never give.
+NEVER_RETRY_ERR_CODES = frozenset({"elicitation"})
+# The job caps at 130 min (`timeout-minutes: 130`) and the VPN steps eat a few
+# of those before dispatch starts, so budget this step at 110 min from its own
+# start. A retry is only worth booting with enough of that left to finish a
+# review; below the floor, fail fast rather than burn a sandbox the runner will
+# kill mid-flight. Cancelling the job does NOT stop the sandbox, so the retry's
+# own `max_timeout_seconds` is clamped to what remains — otherwise a killed
+# runner leaves it billing for up to 2h unattended.
+DISPATCH_BUDGET_SECONDS = 6600
+# A review typically lands in 5–30 min. Half an hour is the floor at which a
+# second attempt can realistically deliver a verdict.
+RETRY_MIN_REMAINING_SECONDS = 1800
 
 # Log-line preview caps, carried over from the jq programs in the shell.
 TEXT_PREVIEW_CHARS = 160
@@ -155,6 +229,28 @@ COMMENTER_INTENT — there are no commands to interpret. See
 ORCHESTRATION.md Phase 0 step 7."""
 
 
+def attempt_model(attempt: int) -> str:
+    """Main model for this attempt — the swap that makes a retry worth booting."""
+    return MAIN_MODEL if attempt <= 1 else RETRY_MAIN_MODEL
+
+
+def attempt_suffix(attempt: int) -> str:
+    return "" if attempt <= 1 else f"-retry{attempt - 1}"
+
+
+def attempt_session_id(session_id: str, attempt: int) -> str:
+    """A retry MUST NOT reuse the session id.
+
+    Mothership reads a supplied `session_id` as a follow-up
+    (`is_follow_up = request.session_id is not None`), so a second dispatch on
+    the same id tries to RESUME a conversation that has just died — the "No
+    conversation found with session" failure on #2987 and the zero-SSE death on
+    #2989. `mothership_terminate_session.py` derives the same ids so a cancel
+    still stops whichever attempt is live.
+    """
+    return f"{session_id}{attempt_suffix(attempt)}"
+
+
 def build_payload(
     *,
     session_id: str,
@@ -168,24 +264,30 @@ def build_payload(
     commenter_intent: str,
     comment_id: str,
     gha_run_url: str,
+    attempt: int = 1,
     max_timeout_seconds: int = STREAM_TIMEOUT_SECONDS,
 ) -> dict[str, Any]:
     """The /api/sandbox/execute body.
 
     `base_branch` is the PR's HEAD ref, not `main`: the sandbox clones the repo
     at the ref it is given, and a review has to read the code under review.
+
+    `attempt` > 1 is a re-dispatch after the previous sandbox died on a hard
+    error: same prompt (review is stateless — the orchestration re-reads live
+    PR state, and a prior review on the PR is handled by its delta logic),
+    different main model, and a fresh session id.
     """
     return {
         "mode": "direct",
         "stream": True,
         "source": "github-pr-review",
-        "source_id": f"{repo}#{pr_number}",
-        "session_id": session_id,
+        "source_id": f"{repo}#{pr_number}{attempt_suffix(attempt)}",
+        "session_id": attempt_session_id(session_id, attempt),
         "repositories": ["atlanhq/application-sdk"],
         "base_branch": head_ref,
         "snapshot": "_base",
         "ai_gateway_key_name": "sdk_review",
-        "model": MAIN_MODEL,
+        "model": attempt_model(attempt),
         "small_fast_model": FAST_MODEL,
         "env_vars": {"CLAUDE_CODE_SUBAGENT_MODEL": FAST_MODEL},
         "prompt": build_prompt(
@@ -211,6 +313,7 @@ def build_payload(
             "commenter": commenter,
             "commenter_intent": commenter_intent,
             "comment_id": comment_id,
+            "attempt": attempt,
         },
     }
 
@@ -511,19 +614,161 @@ def process_stream(
     return st
 
 
+# --- re-dispatch decision --------------------------------------------------
+
+
+class Attempt(NamedTuple):
+    """One dispatch of the run: which model it ran, and how it ended."""
+
+    number: int
+    model: str
+    state: SSEState
+
+
+def sandbox_terminated_abnormally(st: SSEState) -> bool:
+    """True when the sandbox itself died, as opposed to our stream being cut.
+
+    The distinction is what makes re-dispatching safe: a dead sandbox will post
+    nothing more, while a live one behind a cut stream is still reviewing — and
+    a second reviewer would post a second summary on the same PR.
+    """
+    return st.errored or (st.completed and st.status != "completed")
+
+
+def is_retryable_fault(st: SSEState) -> bool:
+    """True when the cause looks like a model/provider fault, not a fixed one.
+
+    The code decides whenever it carries information: a recognised retryable
+    one retries, and anything else — 401, 403, a prompt fault — does not. The
+    message patterns are consulted only for a code of `none`/`unknown`/empty,
+    which is the flattened-code case they exist for. Letting them speak for a
+    known code would classify "401 upstream auth failed" as retryable and buy a
+    second sandbox that fails identically.
+    """
+    if st.err_code in NEVER_RETRY_ERR_CODES:
+        return False
+    if st.err_code in RETRYABLE_ERR_CODES:
+        return True
+    if st.err_code not in UNINFORMATIVE_ERR_CODES:
+        return False
+    return any(p in st.err_msg.lower() for p in RETRYABLE_ERR_PATTERNS)
+
+
+def retry_decision(st: SSEState, attempt: int, seconds_left: float) -> tuple[bool, str]:
+    """Whether to re-dispatch after this attempt, and the reason either way.
+
+    Called only once the verdict check has come back empty, so "the sandbox is
+    dead and delivered nothing" is already established. The reason is logged
+    verbatim so a run that did NOT retry says why — the part that is otherwise
+    invisible.
+    """
+    if attempt >= MAX_DISPATCH_ATTEMPTS:
+        return False, f"already used all {MAX_DISPATCH_ATTEMPTS} attempts"
+    if st.stream_error:
+        return False, (
+            "our stream died rather than the sandbox — it is probably still "
+            "reviewing, and a re-dispatch would post a second summary"
+        )
+    if not sandbox_terminated_abnormally(st):
+        return False, (
+            "the stream ended without a hard error — the sandbox may still be "
+            "running, and a re-dispatch would double-review the PR"
+        )
+    if not is_retryable_fault(st):
+        return False, (
+            f"code={st.err_code or 'none'} is not a known model/provider fault, "
+            "so a different model would fail the same way"
+        )
+    if seconds_left < RETRY_MIN_REMAINING_SECONDS:
+        return False, (
+            f"only {int(seconds_left)}s of the job budget remain, below the "
+            f"{RETRY_MIN_REMAINING_SECONDS}s a retry needs to deliver a review"
+        )
+    return True, (
+        f"code={st.err_code or 'none'} looks like a model/provider fault — "
+        f"re-dispatching on {RETRY_MAIN_MODEL} (attempt {attempt + 1} of "
+        f"{MAX_DISPATCH_ATTEMPTS})"
+    )
+
+
+def total_cost(attempts: Sequence[Attempt]) -> str:
+    """Summed `cost_usd` across attempts, or "" when none reported one.
+
+    Mothership's cost telemetry is already unreliable (runs that streamed
+    hundreds of responses have reported an empty or zero cost), so an
+    unparseable value is skipped rather than treated as zero — and the caller
+    renders the per-attempt breakdown alongside this total so a retry ladder
+    cannot hide its spend behind one number.
+    """
+    total = 0.0
+    seen = False
+    for a in attempts:
+        try:
+            total += float(a.state.cost)
+        except (TypeError, ValueError):
+            continue
+        seen = True
+    if not seen:
+        return ""
+    return f"{total:.4f}".rstrip("0").rstrip(".")
+
+
+def _md_cell(text: str) -> str:
+    """Flatten arbitrary error text into one Markdown table cell."""
+    # Truncate BEFORE escaping: the other order can cut mid-escape and leave a
+    # trailing backslash that swallows the cell delimiter.
+    return " ".join(text.split())[:200].replace("|", "\\|")
+
+
+def render_attempt_trail(attempts: Sequence[Attempt]) -> list[str]:
+    """Per-attempt model/status/cost rows; empty unless a retry actually ran."""
+    if len(attempts) < 2:
+        return []
+    lines = [
+        "",
+        "### Attempts",
+        "",
+        "| # | Model | Status | Cost (USD) | Error |",
+        "|---|---|---|---|---|",
+    ]
+    missing_cost = False
+    for a in attempts:
+        st = a.state
+        status = st.status or ("error" if st.errored else "no `complete` event")
+        err = f"`{st.err_code}` {st.err_msg}".strip() if st.err_code else ""
+        if not st.cost:
+            missing_cost = True
+        lines.append(
+            f"| {a.number} | `{a.model}` | {status} | {st.cost or 'n/a'} | "
+            f"{_md_cell(err)} |"
+        )
+    if missing_cost:
+        lines += [
+            "",
+            "> One or more attempts reported no `cost_usd` — the total above "
+            "is a lower bound.",
+        ]
+    return lines
+
+
 # --- outcome ---------------------------------------------------------------
 
 
-def render_outputs(st: SSEState) -> dict[str, str]:
+def render_outputs(st: SSEState, attempts: Sequence[Attempt] = ()) -> dict[str, str]:
     """The four `$GITHUB_OUTPUT` keys, exactly as the shell computed them.
 
     `final_err_msg` is flattened because a multi-line value would break the
     `key=value` contract. `final_status` falls back to the error code so a
     sandbox that died before emitting `complete` still names its cause.
+
+    `final_cost` becomes the SUM once a retry has run: the starter-comment
+    stamper renders it as the run's cost, and reporting only the last attempt's
+    bill would understate a retry ladder. A single attempt is unchanged.
     """
+    cost = total_cost(attempts) if len(attempts) > 1 else st.cost
     return {
         "final_status": st.status or st.err_code or "unknown",
-        "final_cost": st.cost or "unknown",
+        "final_cost": cost or "unknown",
         "final_err_code": st.err_code,
         "final_err_msg": st.err_msg.replace("\n", " "),
     }
@@ -594,9 +839,18 @@ def decide_exit(
 
 
 def render_step_summary(
-    st: SSEState, pr_number: str, gha_run_url: str, verdict_posted: bool
+    st: SSEState,
+    pr_number: str,
+    gha_run_url: str,
+    verdict_posted: bool,
+    attempts: Sequence[Attempt] = (),
 ) -> str:
-    """Markdown written to GITHUB_STEP_SUMMARY — always renders."""
+    """Markdown written to GITHUB_STEP_SUMMARY — always renders.
+
+    `attempts` carries every dispatch this run made. With a single attempt it
+    changes nothing; with a retry it adds the per-attempt cost trail and makes
+    the headline cost the sum, so the retry's spend is never invisible.
+    """
     ok = st.completed and st.status == "completed" and not st.errored
     if ok:
         outcome = "✅ review completed"
@@ -607,11 +861,15 @@ def render_step_summary(
         )
     else:
         outcome = "❌ review failed"
+    cost = total_cost(attempts) if len(attempts) > 1 else st.cost
+    cost_line = f"**Cost:** {cost or 'n/a'} USD"
+    if len(attempts) > 1:
+        cost_line += f" across {len(attempts)} attempts"
     lines = [
         f"# SDK Review — PR #{pr_number}",
         "",
         f"**Outcome:** {outcome}  ",
-        f"**Cost:** {st.cost or 'n/a'} USD  ",
+        f"{cost_line}  ",
         f"**Final status:** `{st.status or 'none'}`  ",
     ]
     if gha_run_url:
@@ -622,6 +880,7 @@ def render_step_summary(
         )
     if st.stream_error:
         lines.append(f"**Stream:** {_squash(st.stream_error)[:200]}  ")
+    lines += render_attempt_trail(attempts)
     return "\n".join(lines) + "\n"
 
 
@@ -787,33 +1046,75 @@ def main() -> int:
         print("::error::Cannot reach mothership after 5 attempts. VPN may have failed.")
         return 1
 
-    payload = build_payload(
-        session_id=os.environ["SESSION_ID"],
-        pr_number=pr_number,
-        pr_url=os.environ.get("PR_URL", ""),
-        repo=repo,
-        head_sha=os.environ.get("HEAD_SHA", ""),
-        head_ref=os.environ.get("HEAD_REF", ""),
-        base_ref=os.environ.get("BASE_REF", ""),
-        commenter=os.environ.get("COMMENTER", ""),
-        commenter_intent=os.environ.get("COMMENTER_INTENT", ""),
-        comment_id=os.environ.get("COMMENT_ID", ""),
-        gha_run_url=gha_run_url,
-    )
-    st = dispatch_once(base_url, token, payload, pr_number, gha_run_url)
+    since = os.environ.get("STARTER_STARTED_AT", "")
+    run_start = time.monotonic()
+    attempts: list[Attempt] = []
+    attempt = 1
+    while True:
+        # Clamp the sandbox's own cap to what is left of this step's budget.
+        # Cancelling the job does not stop the sandbox, so an unclamped retry
+        # started late would keep billing for up to 2h after the runner dies.
+        seconds_left = DISPATCH_BUDGET_SECONDS - (time.monotonic() - run_start)
+        payload = build_payload(
+            session_id=os.environ["SESSION_ID"],
+            pr_number=pr_number,
+            pr_url=os.environ.get("PR_URL", ""),
+            repo=repo,
+            head_sha=os.environ.get("HEAD_SHA", ""),
+            head_ref=os.environ.get("HEAD_REF", ""),
+            base_ref=os.environ.get("BASE_REF", ""),
+            commenter=os.environ.get("COMMENTER", ""),
+            commenter_intent=os.environ.get("COMMENTER_INTENT", ""),
+            comment_id=os.environ.get("COMMENT_ID", ""),
+            gha_run_url=gha_run_url,
+            attempt=attempt,
+            max_timeout_seconds=max(1, min(STREAM_TIMEOUT_SECONDS, int(seconds_left))),
+        )
+        model = attempt_model(attempt)
+        print(f"[attempt {attempt}/{MAX_DISPATCH_ATTEMPTS}] dispatching on {model}")
+        st = dispatch_once(base_url, token, payload, pr_number, gha_run_url)
+        attempts.append(Attempt(attempt, model, st))
+        # Per-attempt cost, logged separately so a retry ladder cannot hide its
+        # spend behind a single total.
+        print(
+            f"[attempt {attempt}/{MAX_DISPATCH_ATTEMPTS}] model={model} "
+            f"status={st.status or 'none'} cost_usd={st.cost or 'n/a'} "
+            f"code={st.err_code or 'none'}"
+        )
 
-    # Stream ended. Establish whether the verdict landed BEFORE deciding the
-    # exit, and export the outputs before the decision can return non-zero —
-    # otherwise the very failure paths we want to surface would never write
-    # `final_err_code` / `final_err_msg`, and the starter-comment stamper would
-    # have nothing to render.
-    verdict_posted = check_verdict_posted(
-        os.environ.get("STARTER_STARTED_AT", ""), repo
-    )
-    write_outputs(render_outputs(st))
-    write_step_summary(render_step_summary(st, pr_number, gha_run_url, verdict_posted))
+        # Stream ended. Establish whether the verdict landed before anything
+        # else: a delivered review is a soft-success, and re-dispatching over
+        # one would post a second summary on the same PR. This is the review
+        # lane's equivalent of the resolve lane's out-of-band poll — cheaper,
+        # because the reviewer's hand-off IS a PR comment we already read.
+        verdict_posted = check_verdict_posted(since, repo)
+        code, messages = decide_exit(st, verdict_posted, pr_number)
+        if code == 0:
+            break
 
-    code, messages = decide_exit(st, verdict_posted, pr_number)
+        should_retry, reason = retry_decision(
+            st, attempt, DISPATCH_BUDGET_SECONDS - (time.monotonic() - run_start)
+        )
+        if not should_retry:
+            print(f"::warning::Not re-dispatching: {reason}")
+            break
+        print(f"::warning::Re-dispatching after a dead sandbox: {reason}")
+        attempt += 1
+
+    if code != 0 and len(attempts) > 1:
+        messages[-1] += (
+            f" (retried on {attempt_model(len(attempts))} after "
+            f"{attempt_model(1)} died; both attempts failed)"
+        )
+
+    # Export the outputs before printing the decision — the failure paths we
+    # want to surface must still write `final_err_code` / `final_err_msg`, or
+    # the starter-comment stamper has nothing to render.
+    write_outputs(render_outputs(st, attempts))
+    write_step_summary(
+        render_step_summary(st, pr_number, gha_run_url, verdict_posted, attempts)
+    )
+
     for message in messages:
         print(message)
     return code

--- a/.github/scripts/tests/test_sdk_review_dispatch.py
+++ b/.github/scripts/tests/test_sdk_review_dispatch.py
@@ -25,6 +25,7 @@ import yaml
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
+import mothership_terminate_session as mts  # noqa: E402  (sys.path bootstrap)
 import sdk_review_dispatch as sd  # noqa: E402  (needs the sys.path bootstrap)
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -738,3 +739,356 @@ def test_the_session_id_comes_from_the_step_the_terminator_also_reads():
         == terminator["env"]["SESSION_ID"]
         == "${{ steps.session.outputs.session_id }}"
     )
+
+
+# ---------------------------------------------------------------------------
+# re-dispatch on a model swap (the FND-641 port)
+# ---------------------------------------------------------------------------
+
+
+def _errored(code: str = "429", msg: str = "rate limited") -> sd.SSEState:
+    return _stream(*_event("error", {"code": code, "message": msg}))
+
+
+def test_the_retry_runs_a_different_main_model():
+    """A same-model re-dispatch re-hits the same model-level fault.
+
+    Every provider in the `kimi-k3` group serves the same model, so mothership's
+    own intra-group fallback cannot help. Swapping the model is the whole point.
+    """
+    assert sd.attempt_model(1) == sd.MAIN_MODEL
+    assert sd.attempt_model(2) == sd.RETRY_MAIN_MODEL
+    assert sd.MAIN_MODEL != sd.RETRY_MAIN_MODEL
+    assert _payload(attempt=1)["model"] == sd.MAIN_MODEL
+    assert _payload(attempt=2)["model"] == sd.RETRY_MAIN_MODEL
+
+
+def test_the_retry_leaves_the_background_lanes_alone():
+    """`fast = small_fast_model or model`, so changing `model` must not drag it."""
+    p = _payload(attempt=2)
+    assert p["small_fast_model"] == sd.FAST_MODEL
+    assert p["env_vars"]["CLAUDE_CODE_SUBAGENT_MODEL"] == sd.FAST_MODEL
+
+
+def test_the_retry_gets_a_fresh_session_id():
+    """Reusing it makes mothership try to RESUME the conversation that just died.
+
+    `is_follow_up = request.session_id is not None` — that is the "No
+    conversation found with session" failure on #2987 and the zero-SSE death on
+    #2989.
+    """
+    first = _payload(attempt=1, session_id="sdk-review-x-42-abc-99-1")["session_id"]
+    second = _payload(attempt=2, session_id="sdk-review-x-42-abc-99-1")["session_id"]
+    assert first == "sdk-review-x-42-abc-99-1"
+    assert second == "sdk-review-x-42-abc-99-1-retry1"
+    assert first != second
+
+
+def test_the_retry_gets_its_own_source_id_and_records_the_attempt():
+    assert _payload(attempt=2)["source_id"].endswith("-retry1")
+    assert _payload(attempt=1)["metadata"]["attempt"] == 1
+    assert _payload(attempt=2)["metadata"]["attempt"] == 2
+
+
+def test_the_retry_clamps_the_sandbox_cap_to_the_remaining_budget():
+    """Cancelling the job does not stop the sandbox — an unclamped retry bills on."""
+    assert _payload(max_timeout_seconds=900)["max_timeout_seconds"] == 900
+
+
+@pytest.mark.parametrize(
+    "code,msg",
+    [
+        ("429", ""),
+        ("500", ""),
+        ("sandbox_error", ""),
+        ("none", "the message at position 21 must not be empty"),
+        ("unknown", "provider temporarily unavailable"),
+        ("", "upstream returned garbage"),
+    ],
+)
+def test_model_and_provider_faults_are_retryable(code, msg):
+    assert sd.is_retryable_fault(_errored(code, msg)) is True
+
+
+@pytest.mark.parametrize(
+    "code,msg",
+    [
+        ("401", "upstream auth failed"),  # a known code always beats the patterns
+        ("403", "forbidden"),
+        ("elicitation", "needs input"),
+        ("prompt_too_long", "reduce the prompt"),
+        ("none", "the review found 3 blocking issues"),
+    ],
+)
+def test_permanent_faults_are_never_retried(code, msg):
+    """A wrong retry burns a second sandbox boot and a real bill."""
+    assert sd.is_retryable_fault(_errored(code, msg)) is False
+
+
+def test_a_known_code_is_never_overridden_by_the_message_patterns():
+    """`401 upstream auth failed` mentions `upstream` and is still permanent."""
+    assert sd.is_retryable_fault(_errored("401", "upstream auth failed")) is False
+
+
+def test_retry_fires_on_a_dead_sandbox_with_a_retryable_code():
+    should, reason = sd.retry_decision(_errored("429"), 1, 6000)
+    assert should is True
+    assert sd.RETRY_MAIN_MODEL in reason and "attempt 2 of 2" in reason
+
+
+def test_retry_fires_when_complete_carries_status_error():
+    st = _stream(
+        *_event(
+            "complete", {"status": "error", "error": {"code": "500", "message": ""}}
+        )
+    )
+    assert sd.sandbox_terminated_abnormally(st) is True
+    assert sd.retry_decision(st, 1, 6000)[0] is True
+
+
+def test_only_one_retry_is_ever_spent():
+    should, reason = sd.retry_decision(_errored("429"), 2, 6000)
+    assert should is False and "all 2 attempts" in reason
+    assert sd.MAX_DISPATCH_ATTEMPTS == 2
+
+
+def test_a_cut_stream_never_retries_because_the_reviewer_may_still_be_working():
+    """A second reviewer would post a second summary on the same PR."""
+    st = _stream(*_event("started", {"session_id": "s"}))
+    st.stream_error = "read timed out"
+    should, reason = sd.retry_decision(st, 1, 6000)
+    assert should is False and "post a second summary" in reason
+
+
+def test_a_clean_eof_without_complete_never_retries():
+    st = _stream(*_event("started", {"session_id": "s"}))
+    should, reason = sd.retry_decision(st, 1, 6000)
+    assert should is False and "may still be running" in reason
+
+
+def test_an_unrecognised_cause_stays_fail_fast():
+    should, reason = sd.retry_decision(_errored("401", "auth"), 1, 6000)
+    assert should is False and "not a known model/provider fault" in reason
+
+
+def test_a_retry_is_refused_below_the_wall_clock_floor():
+    """Below the floor a second sandbox would be killed mid-review."""
+    should, reason = sd.retry_decision(_errored("429"), 1, 600)
+    assert should is False and "600s of the job budget remain" in reason
+    assert sd.retry_decision(_errored("429"), 1, sd.RETRY_MIN_REMAINING_SECONDS)[0]
+
+
+def test_every_refusal_says_why():
+    """A run that did NOT retry is otherwise silent about the decision."""
+    for st, attempt, left in (
+        (_errored("429"), 2, 6000),
+        (_errored("401"), 1, 6000),
+        (_errored("429"), 1, 10),
+        (_stream(*_event("started", {})), 1, 6000),
+    ):
+        should, reason = sd.retry_decision(st, attempt, left)
+        assert should is False and reason.strip()
+
+
+# --- the cost trail --------------------------------------------------------
+
+
+def _attempts(*costs: str) -> list[sd.Attempt]:
+    out = []
+    for i, cost in enumerate(costs, start=1):
+        st = sd.SSEState()
+        st.cost = cost
+        st.completed = True
+        st.status = "completed"
+        out.append(sd.Attempt(i, sd.attempt_model(i), st))
+    return out
+
+
+def test_a_retry_ladder_reports_the_summed_cost():
+    ladder = _attempts("0.85", "2.40")
+    assert sd.total_cost(ladder) == "3.25"
+    assert sd.render_outputs(ladder[-1].state, ladder)["final_cost"] == "3.25"
+
+
+def test_a_single_attempt_reports_its_own_cost_unchanged():
+    """The `$GITHUB_OUTPUT` contract must not move for the common case."""
+    st = _stream(*_event("complete", {"status": "completed", "cost_usd": "0.83"}))
+    one = [sd.Attempt(1, sd.MAIN_MODEL, st)]
+    expected = {
+        "final_status": "completed",
+        "final_cost": "0.83",
+        "final_err_code": "",
+        "final_err_msg": "",
+    }
+    assert sd.render_outputs(st, one) == expected
+    assert sd.render_outputs(st) == expected
+
+
+def test_unparseable_costs_are_skipped_not_counted_as_zero():
+    """Mothership's cost telemetry is unreliable; a lower bound beats a lie."""
+    assert sd.total_cost(_attempts("", "2.40")) == "2.4"
+    blank = _attempts("", "")
+    assert sd.total_cost(blank) == ""
+    assert sd.render_outputs(blank[-1].state, blank)["final_cost"] == "unknown"
+
+
+def test_the_attempt_trail_only_renders_when_a_retry_actually_ran():
+    assert sd.render_attempt_trail(_attempts("0.83")) == []
+    trail = "\n".join(sd.render_attempt_trail(_attempts("0.85", "2.40")))
+    assert f"`{sd.MAIN_MODEL}`" in trail and f"`{sd.RETRY_MAIN_MODEL}`" in trail
+    assert "| 1 |" in trail and "| 2 |" in trail
+
+
+def test_the_trail_flags_a_missing_cost_as_a_lower_bound():
+    assert "lower bound" in "\n".join(sd.render_attempt_trail(_attempts("", "2.40")))
+
+
+def test_the_trail_cannot_be_broken_by_a_pipe_in_an_error_message():
+    st = _errored("400", "bad | input\nsecond line")
+    ladder = [sd.Attempt(1, sd.MAIN_MODEL, st), sd.Attempt(2, sd.RETRY_MAIN_MODEL, st)]
+    row = next(r for r in sd.render_attempt_trail(ladder) if r.startswith("| 1 |"))
+    # 5 columns → 6 unescaped delimiters. The pipe inside the message is
+    # escaped, so it does not open a seventh cell.
+    assert row.replace("\\|", "").count("|") == 6
+    assert "\\|" in row and "\n" not in row
+
+
+def test_the_step_summary_carries_the_trail_and_the_summed_cost():
+    ladder = _attempts("0.85", "2.40")
+    body = sd.render_step_summary(ladder[-1].state, "42", "u", False, ladder)
+    assert "3.25 USD across 2 attempts" in body
+    assert "### Attempts" in body
+
+
+# --- the loop in main() ----------------------------------------------------
+
+
+@pytest.fixture
+def dispatch_env(tmp_path, monkeypatch):
+    """Enough env for `main()`, with health and the dedupe pass neutralised."""
+    monkeypatch.setenv("MOTHERSHIP_URL", "http://m")
+    monkeypatch.setenv("HARNESS_TOKEN", "tok")
+    monkeypatch.setenv("PR_NUMBER", "42")
+    monkeypatch.setenv("SESSION_ID", "base-id")
+    monkeypatch.setenv("REPO_FULL_NAME", "atlanhq/application-sdk")
+    monkeypatch.setenv("HEAD_REF", "feature-branch")
+    monkeypatch.setenv("GITHUB_OUTPUT", str(tmp_path / "out"))
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(tmp_path / "summary"))
+    monkeypatch.setattr(sd, "check_health", lambda *_a, **_k: True)
+    return tmp_path
+
+
+def _outputs(tmp_path) -> dict[str, str]:
+    return dict(
+        line.split("=", 1)
+        for line in (tmp_path / "out").read_text().splitlines()
+        if "=" in line
+    )
+
+
+def _record_dispatches(monkeypatch, states, verdicts):
+    """Stub the transport with one canned SSEState per attempt."""
+    seen: list[dict] = []
+
+    def fake_dispatch(base_url, token, payload, pr_number, gha_run_url, *_a, **_k):
+        seen.append(payload)
+        return states[len(seen) - 1]
+
+    monkeypatch.setattr(sd, "dispatch_once", fake_dispatch)
+    monkeypatch.setattr(
+        sd, "check_verdict_posted", lambda *_a, **_k: verdicts[len(seen) - 1]
+    )
+    return seen
+
+
+def _completed(cost: str) -> sd.SSEState:
+    return _stream(*_event("complete", {"status": "completed", "cost_usd": cost}))
+
+
+def test_main_re_dispatches_once_on_a_dead_sandbox(dispatch_env, monkeypatch, capsys):
+    seen = _record_dispatches(
+        monkeypatch, [_errored("429"), _completed("2.40")], [False, False]
+    )
+
+    assert sd.main() == 0
+    assert [p["model"] for p in seen] == [sd.MAIN_MODEL, sd.RETRY_MAIN_MODEL]
+    assert [p["session_id"] for p in seen] == ["base-id", "base-id-retry1"]
+    out = _outputs(dispatch_env)
+    assert out["final_status"] == "completed"
+    assert out["final_cost"] == "2.4"  # attempt 1 reported none
+    assert "### Attempts" in (dispatch_env / "summary").read_text()
+    assert "Re-dispatching after a dead sandbox" in capsys.readouterr().out
+
+
+def test_main_does_not_retry_once_the_verdict_is_on_the_pr(dispatch_env, monkeypatch):
+    """A delivered review is a soft-success; a retry would post a second one."""
+    seen = _record_dispatches(monkeypatch, [_errored("429")], [True])
+
+    assert sd.main() == 0
+    assert len(seen) == 1
+    assert _outputs(dispatch_env)["final_err_code"] == "429"
+
+
+def test_main_reports_both_models_when_the_retry_also_fails(
+    dispatch_env, monkeypatch, capsys
+):
+    _record_dispatches(monkeypatch, [_errored("429"), _errored("500")], [False, False])
+
+    assert sd.main() == 1
+    printed = capsys.readouterr().out
+    assert f"retried on {sd.RETRY_MAIN_MODEL} after {sd.MAIN_MODEL} died" in printed
+    assert _outputs(dispatch_env)["final_status"] == "500"
+
+
+def test_main_stays_single_attempt_on_a_permanent_fault(
+    dispatch_env, monkeypatch, capsys
+):
+    seen = _record_dispatches(monkeypatch, [_errored("401", "auth")], [False])
+
+    assert sd.main() == 1
+    assert len(seen) == 1
+    assert "Not re-dispatching:" in capsys.readouterr().out
+
+
+def test_main_clamps_the_retry_sandbox_to_the_remaining_budget(
+    dispatch_env, monkeypatch
+):
+    """A killed runner must not leave the second sandbox billing for 2h."""
+    states = [_errored("429"), _completed("1.0")]  # built before the clock is frozen
+    seen = _record_dispatches(monkeypatch, states, [False, False])
+    # Attempt 1 burned all but 3000s of the step's budget.
+    elapsed = [0.0, sd.DISPATCH_BUDGET_SECONDS - 3000]
+    monkeypatch.setattr(sd.time, "monotonic", lambda: elapsed[min(len(seen), 1)])
+
+    sd.main()
+    assert len(seen) == 2
+    assert seen[1]["max_timeout_seconds"] <= 3000
+
+
+# --- the terminator derives the same ids -----------------------------------
+
+
+def test_the_terminator_stops_every_session_the_dispatcher_could_have_booted():
+    """A cancel during the retry must not leave the second sandbox billing.
+
+    The workflow cannot know which attempt was live, so the terminator walks the
+    same `attempt_session_id` ladder; an id that never existed 404s, which it
+    already treats as "nothing to stop".
+    """
+    stopped: list[str] = []
+    monkey = os.environ.copy()
+    monkey.update(MOTHERSHIP_URL="http://m", HARNESS_TOKEN="tok", SESSION_ID="base-id")
+    original_requester = mts._default_requester
+    original_env = dict(os.environ)
+    mts._default_requester = lambda url, token: (stopped.append(url), (200, ""))[1]
+    os.environ.update(monkey)
+    try:
+        assert mts.main() == 0
+    finally:
+        mts._default_requester = original_requester
+        os.environ.clear()
+        os.environ.update(original_env)
+
+    assert len(stopped) == sd.MAX_DISPATCH_ATTEMPTS
+    assert stopped[0].endswith("/api/sandbox/session/base-id?destroy=true")
+    assert stopped[1].endswith("/api/sandbox/session/base-id-retry1?destroy=true")

--- a/.github/workflows/sdk-review.yml
+++ b/.github/workflows/sdk-review.yml
@@ -627,6 +627,11 @@ jobs:
       # The step's outputs (`final_status`, `final_cost`, `final_err_code`,
       # `final_err_msg`) are a contract: `sdk_review_verdict_gate.py`, the
       # starter-comment stamper and `sdk_review_approve.py` all read them.
+      #
+      # The step can boot TWO sandboxes: it re-dispatches once on a different
+      # main model when the first dies on a hard error a model swap could
+      # survive (FND-641, ported in FND-643). `final_cost` is then the sum, and
+      # the step summary carries the per-attempt trail.
       - name: Dispatch to mothership Rover Direct API
         id: dispatch
         if: steps.lock_gate.outputs.decision != 'skip'
@@ -702,6 +707,11 @@ jobs:
       # nothing left to stop. Never fail the job from here: this is
       # best-effort cleanup running inside the cancellation grace period,
       # and masking the real outcome with a teardown error helps nobody.
+      #
+      # SESSION_ID is the BASE id. A run can boot more than one sandbox (the
+      # dispatcher re-dispatches once on a different model when the first dies),
+      # and each attempt gets its own derived id, so the script walks the same
+      # ladder rather than trusting an id this step cannot know.
       - name: Terminate mothership sandbox on cancel
         if: cancelled() && steps.session.outputs.session_id != ''
         env:


### PR DESCRIPTION
> **Stacked on #3301** — review that one first. This branch contains its commit; the diff to read is the second commit only, or set the base to `chrishehim/fnd-643-extract` in the Files tab.

### Changelog

- Re-dispatch an SDK review once, on a different main model, when the sandbox dies on a hard error a model swap could survive — the port of [FND-641](https://linear.app/atlan-epd/issue/FND-641/re-dispatch-with-a-model-swap-when-the-sandbox-dies-on-a-hard-error) from the resolve lane.
- Give each attempt its own mothership session id, and teach `mothership_terminate_session.py` to walk the same ladder on cancel.
- Sum `final_cost` across attempts and render a per-attempt model/status/cost trail into the step summary.

### Additional context (e.g. screenshots, logs, links)

- [FND-643](https://linear.app/atlan-epd/issue/FND-643/extract-sdk-reviews-inline-sse-dispatch-to-a-tested-script-then-give) step 4 of 4. Depends on #3301, which created the tested seam this hooks into.

**Why a model swap and not just a retry**

Mothership's intra-group provider fallback already exists and already fires on a 429 — but every provider in the `kimi-k3` group serves the *same* model, so a same-model re-dispatch re-hits the same model-level fault. Observed on the resolve lane: the 429 fell through to Moonshot AI, which returned `400 "the message at position 21 with role 'assistant' must not be empty"` — same model, same bug. Swapping to `claude-opus-5` is the whole point; without it the second sandbox boot fails identically.

**What has to be true before a second sandbox is booted**

A wrong retry costs a second sandbox boot — up to an hour of the job's 130-minute budget, plus a real bill — so the gate is an allowlist and every refusal logs its reason. A run that did *not* retry currently says nothing about the decision, which is the part that is invisible today.

1. **The verdict check comes back empty.** This is the hook point the ticket specifies: the review lane's equivalent of resolve's out-of-band poll, and cheaper, because the reviewer's hand-off *is* a PR comment we already read for the soft-success rule. A review already on the PR is a soft-success, and re-dispatching over one posts a second summary.
2. **The sandbox terminated abnormally.** A cut stream never retries — the reviewer is probably still working, and a second reviewer double-reviews the PR.
3. **The cause is on the retryable allowlist.** A recognised code decides on its own; the message patterns are consulted only for `none` / `unknown` / empty, which is the flattened-code case they exist for. So `401 upstream auth failed` stays permanent despite mentioning `upstream`.
4. **At least 30 minutes of the step's 110-minute budget remain.** Below that a second sandbox gets killed mid-review. The retry's own `max_timeout_seconds` is clamped to what is left, because cancelling the job does *not* stop the sandbox.

**Two things the resolve port does not carry over, and why they matter here**

- **The retry gets a fresh session id (`…-retry1`).** Mothership reads a supplied `session_id` as a follow-up (`is_follow_up = request.session_id is not None`), so reusing it would try to *resume* the conversation that just died. That is the "No conversation found with session" failure on #2987 and the zero-SSE death on #2989 — the same class of bug the `GITHUB_RUN_ID` suffix in the `session` step was added to fix. Without this the retry would be dead on arrival.
- **`mothership_terminate_session.py` now walks the same ladder.** A cancel cannot know which attempt was live, and an unstopped second sandbox keeps billing for up to two hours. The ids come from the same `attempt_session_id` helper so the two cannot drift, and an id that never existed comes back 404 — already handled there as "nothing to stop".

**Cost visibility**

`final_cost` becomes the sum once a retry has run (the starter-comment stamper renders it as the run's cost, and reporting only the last attempt's bill would understate the ladder), and the step summary gains the per-attempt breakdown. An unparseable `cost_usd` is skipped rather than counted as zero, and the trail says so — mothership's cost telemetry is already unreliable, and a flagged lower bound beats a confident wrong number.

### Checklist

- [x] Additional tests added
- [ ] All CI checks passed
- [x] Relevant documentation updated

Full `.github/scripts/tests` suite: 2878 passed. `pre-commit` clean on every changed file.

---

### Copyleft License Compliance

- [ ] Have you used any code that is subject to a Copyleft license (e.g., GPL, AGPL, LGPL)?
- [ ] If yes, have you modified the code in the context of this project? please share additional details.
