### PR TITLE
refactor(testing): consolidate the e2e harness's deadline poll loops

### DIFF
--- a/application_sdk/testing/e2e/_poll.py
+++ b/application_sdk/testing/e2e/_poll.py
@@ -27,7 +27,8 @@ own ``try``/``except`` and raises its own typed error leaf on exhaustion::
                 attempts=attempt.number, elapsed_seconds=attempt.elapsed
             )
 
-What the loop owns: the clock, the sleeping, the off-by-one, and a throttled
+What the loop owns: the clock, the sleeping, the off-by-one (including the gap
+after a probe that overran its own interval), and a throttled
 heartbeat log so a multi-minute wait doesn't look wedged in CI output. What the
 call site owns: the probe, the success condition, and the failure.
 
@@ -96,9 +97,11 @@ class Attempt:
             seconds: The gap the origin asked for.
 
         Returns:
-            The gap the loop will actually wait — clamped to :attr:`remaining`,
-            so a 120s request against a 50s residual budget cannot push the loop
-            past its own deadline. Log this, not the requested value.
+            The gap the loop will wait — clamped to :attr:`remaining`, so a 120s
+            request against a 50s residual budget cannot push the loop past its
+            own deadline. Log this, not the requested value. Measured against the
+            budget as of *this* attempt; a probe that then overruns its own
+            interval shortens the real gap further (see :func:`_next_gap`).
 
         Note:
             A no-op on an :attr:`is_last` attempt: the loop stops rather than
@@ -146,6 +149,28 @@ def _next_attempt(
     )
 
 
+def _next_gap(
+    attempt: Attempt,
+    start: float,
+    timeout_seconds: float,
+    interval_seconds: float,
+    now: float,
+) -> float:
+    """How long to wait before the next poll, given the clock after the probe.
+
+    ``attempt.remaining`` was measured *before* the probe ran. A probe that
+    outlasts its own interval has already eaten into the budget, so sleeping the
+    full gap on top of it would carry the loop past the deadline — the exact
+    overshoot ``is_last`` exists to prevent, arriving by a different route. Read
+    the clock again and clamp.
+
+    Clamping to zero costs the call site nothing: the next iteration still yields
+    a final attempt with ``is_last=True``, so its exhaustion branch always fires.
+    """
+    requested = attempt._gap if attempt._gap is not None else interval_seconds
+    return min(requested, max(timeout_seconds - (now - start), 0.0))
+
+
 def until_deadline(
     timeout_seconds: float,
     interval_seconds: float,
@@ -157,10 +182,20 @@ def until_deadline(
 ) -> Iterator[Attempt]:
     """Yield one :class:`Attempt` per poll until the budget expires, sleeping between.
 
-    At least one attempt is always yielded — a zero or negative budget still gets
-    a single probe, and that probe carries ``is_last=True``. The final attempt is
-    the last one for which a further ``interval_seconds`` still fits inside
-    ``timeout_seconds``, so the loop never sleeps beyond its own deadline.
+    The final attempt is the last one for which a further ``interval_seconds``
+    still fits inside ``timeout_seconds``, and each gap is re-clamped against the
+    clock read *after* the probe returns, so the loop never sleeps beyond its own
+    deadline — not even when a probe outlasts its own interval.
+
+    At least one attempt is always yielded: a zero or negative budget still gets a
+    single probe, carrying ``is_last=True``. This is a deliberate contract change
+    from the hand-rolled ``while clock() < deadline`` loops this replaced, which
+    probed zero times on a non-positive budget. Exhaustion branches key on
+    ``is_last``, so a loop that yields nothing raises nothing — the failure would
+    vanish silently instead of surfacing as a typed error. No call site passes a
+    non-positive budget today (every one reads a positive ``ClassVar`` default),
+    so the change is contract-only; a caller that genuinely wants
+    zero-budget-means-no-work must check that before entering the loop.
 
     Args:
         timeout_seconds: Total wall-clock budget for the whole loop.
@@ -195,7 +230,9 @@ def until_deadline(
         yield attempt
         if attempt.is_last:
             return
-        do_sleep(attempt._gap if attempt._gap is not None else interval_seconds)
+        do_sleep(
+            _next_gap(attempt, start, timeout_seconds, interval_seconds, read_clock())
+        )
 
 
 async def until_deadline_async(
@@ -243,7 +280,9 @@ async def until_deadline_async(
         yield attempt
         if attempt.is_last:
             return
-        await do_sleep(attempt._gap if attempt._gap is not None else interval_seconds)
+        await do_sleep(
+            _next_gap(attempt, start, timeout_seconds, interval_seconds, read_clock())
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/application_sdk/testing/e2e/_poll.py
+++ b/application_sdk/testing/e2e/_poll.py
@@ -1,0 +1,309 @@
+"""One bounded-poll primitive for the e2e harness's deadline loops.
+
+Every "probe until it's ready or the budget runs out" loop in this package
+routes through :func:`until_deadline` (sync) or :func:`until_deadline_async`
+(async). Before this module each of them hand-rolled the same three lines::
+
+    deadline = time.monotonic() + timeout
+    while True:
+        ...work...
+        if time.monotonic() >= deadline:
+            raise ...
+        time.sleep(interval)
+
+which is wrong in a way that is easy to miss: the budget check sits *after* the
+work, so the loop sleeps one whole interval past its stated timeout before
+noticing. :attr:`Attempt.is_last` moves that decision to before the sleep — the
+call site is told "this is your last look" and the loop stops there.
+
+The primitive is a **generator, not a callback**, so each call site keeps its
+own ``try``/``except`` and raises its own typed error leaf on exhaustion::
+
+    for attempt in until_deadline(timeout_s, interval_s, label="worker health"):
+        if probe_ok(url):
+            return
+        if attempt.is_last:
+            raise WorkerNotHealthyError(
+                attempts=attempt.number, elapsed_seconds=attempt.elapsed
+            )
+
+What the loop owns: the clock, the sleeping, the off-by-one, and a throttled
+heartbeat log so a multi-minute wait doesn't look wedged in CI output. What the
+call site owns: the probe, the success condition, and the failure.
+
+Testing: pass ``clock``/``sleep`` explicitly, or wrap the code under test in
+:func:`fake_clock`. Neither touches :func:`time.monotonic` itself — the asyncio
+event loop reads that for its own timers, and fast-forwarding it globally makes
+async tests flake.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import AsyncIterator, Awaitable, Callable, Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+
+from application_sdk.observability.logger_adaptor import get_logger
+
+logger = get_logger(__name__)
+
+# Cadence for the "still waiting" heartbeat line. Long enough not to drown the
+# log on a fast happy-path run, short enough that an operator watching a CI leg
+# can tell "still polling" from "harness wedged". Also reused by
+# ``client.poll_native_status``, which throttles its own richer progress line to
+# the same cadence.
+_HEARTBEAT_SECONDS = 30.0
+
+# Module-level indirection for the defaults, so :func:`fake_clock` can swap them
+# without reassigning ``time.monotonic`` / ``time.sleep`` process-wide. Read at
+# call time, never captured as a default argument value.
+_monotonic: Callable[[], float] = time.monotonic
+_sleep: Callable[[float], None] = time.sleep
+_async_sleep: Callable[[float], Awaitable[None]] = asyncio.sleep
+
+
+@dataclass
+class Attempt:
+    """One poll of a bounded-deadline loop.
+
+    Attributes:
+        number: 1-based attempt count. Feeds an ``attempts=`` error field
+            directly instead of being re-derived at the call site.
+        elapsed: Seconds since the loop started, as measured by the loop's own
+            clock. Feeds an ``elapsed_seconds=`` error field.
+        remaining: Seconds left in the budget (never negative).
+        is_last: ``True`` on the final attempt the loop will yield — there is
+            not enough budget left for another interval. A call site that has
+            not succeeded by now must raise here; the loop will not come back.
+    """
+
+    number: int
+    elapsed: float
+    remaining: float
+    is_last: bool
+    # Set by ``sleep_next``; read by the loop after the yield resumes.
+    _gap: float | None = field(default=None, repr=False, compare=False)
+
+    def sleep_next(self, seconds: float) -> float:
+        """Wait ``seconds`` before the next poll instead of the fixed interval.
+
+        For call sites that honour an origin-supplied backoff (an HTTP
+        ``retry_after``) in place of their own cadence.
+
+        Args:
+            seconds: The gap the origin asked for.
+
+        Returns:
+            The gap the loop will actually wait — clamped to :attr:`remaining`,
+            so a 120s request against a 50s residual budget cannot push the loop
+            past its own deadline. Log this, not the requested value.
+
+        Note:
+            A no-op on an :attr:`is_last` attempt: the loop stops rather than
+            sleeping, so there is no next poll to delay.
+        """
+        gap = min(max(seconds, 0.0), self.remaining)
+        self._gap = gap
+        return gap
+
+
+def _log_heartbeat(label: str, attempt: Attempt, timeout_seconds: float) -> None:
+    """Emit the throttled "still waiting" progress line.
+
+    Deliberately a function rather than an inline statement: the log is throttled
+    to ``heartbeat_seconds`` by its caller, so it is not per-iteration volume and
+    should not read as an in-loop INFO.
+    """
+    logger.info(
+        "Still waiting on %s: attempt %d, %.0fs of %.0fs elapsed (%.0fs left)",
+        label,
+        attempt.number,
+        attempt.elapsed,
+        timeout_seconds,
+        attempt.remaining,
+    )
+
+
+def _next_attempt(
+    number: int,
+    start: float,
+    timeout_seconds: float,
+    interval_seconds: float,
+    now: float,
+) -> Attempt:
+    """Build the attempt for the current clock reading."""
+    elapsed = now - start
+    remaining = max(timeout_seconds - elapsed, 0.0)
+    return Attempt(
+        number=number,
+        elapsed=elapsed,
+        remaining=remaining,
+        # No room for another interval means no further attempt: stop here
+        # rather than sleeping past the stated budget to find out.
+        is_last=remaining <= interval_seconds,
+    )
+
+
+def until_deadline(
+    timeout_seconds: float,
+    interval_seconds: float,
+    *,
+    label: str,
+    heartbeat_seconds: float = _HEARTBEAT_SECONDS,
+    clock: Callable[[], float] | None = None,
+    sleep: Callable[[float], None] | None = None,
+) -> Iterator[Attempt]:
+    """Yield one :class:`Attempt` per poll until the budget expires, sleeping between.
+
+    At least one attempt is always yielded — a zero or negative budget still gets
+    a single probe, and that probe carries ``is_last=True``. The final attempt is
+    the last one for which a further ``interval_seconds`` still fits inside
+    ``timeout_seconds``, so the loop never sleeps beyond its own deadline.
+
+    Args:
+        timeout_seconds: Total wall-clock budget for the whole loop.
+        interval_seconds: Gap between polls. Pass ``0`` to spin.
+        label: What is being waited on, for the heartbeat line. A noun phrase
+            naming the concrete target ("worker health at <url>"), not a verb.
+        heartbeat_seconds: Cadence of the "still waiting" INFO line. ``0``
+            disables it — use that when the call site logs its own per-poll
+            progress and a second line would be duplicate noise.
+        clock: Monotonic time source. Defaults to :func:`time.monotonic`.
+        sleep: Blocking sleep. Defaults to :func:`time.sleep`.
+
+    Yields:
+        One :class:`Attempt` per poll, in order.
+    """
+    read_clock = clock or _monotonic
+    do_sleep = sleep or _sleep
+    start = read_clock()
+    number = 0
+    last_heartbeat = 0.0
+    while True:
+        number += 1
+        attempt = _next_attempt(
+            number, start, timeout_seconds, interval_seconds, read_clock()
+        )
+        if (
+            heartbeat_seconds > 0
+            and (attempt.elapsed - last_heartbeat) >= heartbeat_seconds
+        ):
+            last_heartbeat = attempt.elapsed
+            _log_heartbeat(label, attempt, timeout_seconds)
+        yield attempt
+        if attempt.is_last:
+            return
+        do_sleep(attempt._gap if attempt._gap is not None else interval_seconds)
+
+
+async def until_deadline_async(
+    timeout_seconds: float,
+    interval_seconds: float,
+    *,
+    label: str,
+    heartbeat_seconds: float = _HEARTBEAT_SECONDS,
+    clock: Callable[[], float] | None = None,
+    sleep: Callable[[float], Awaitable[None]] | None = None,
+) -> AsyncIterator[Attempt]:
+    """Async twin of :func:`until_deadline` — identical semantics, awaits the sleep.
+
+    A single generator cannot straddle both worlds: ``async for`` needs an async
+    generator, and awaiting inside a sync one is not possible. The attempt
+    arithmetic is shared via :func:`_next_attempt` so the two cannot drift.
+
+    Args:
+        timeout_seconds: Total wall-clock budget for the whole loop.
+        interval_seconds: Gap between polls.
+        label: What is being waited on, for the heartbeat line.
+        heartbeat_seconds: Cadence of the "still waiting" INFO line; ``0`` off.
+        clock: Monotonic time source. Defaults to :func:`time.monotonic`.
+        sleep: Awaitable sleep. Defaults to :func:`asyncio.sleep`.
+
+    Yields:
+        One :class:`Attempt` per poll, in order.
+    """
+    read_clock = clock or _monotonic
+    do_sleep = sleep or _async_sleep
+    start = read_clock()
+    number = 0
+    last_heartbeat = 0.0
+    while True:
+        number += 1
+        attempt = _next_attempt(
+            number, start, timeout_seconds, interval_seconds, read_clock()
+        )
+        if (
+            heartbeat_seconds > 0
+            and (attempt.elapsed - last_heartbeat) >= heartbeat_seconds
+        ):
+            last_heartbeat = attempt.elapsed
+            _log_heartbeat(label, attempt, timeout_seconds)
+        yield attempt
+        if attempt.is_last:
+            return
+        await do_sleep(attempt._gap if attempt._gap is not None else interval_seconds)
+
+
+# ---------------------------------------------------------------------------
+# Test seam
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FakeClock:
+    """Deterministic stand-in for ``time.monotonic`` + the sleeps.
+
+    :meth:`sleep` advances :attr:`now` instead of blocking, so a poll loop under
+    this clock runs its whole budget instantly and in a fixed, assertable number
+    of iterations.
+
+    Attributes:
+        now: Current monotonic reading, advanced by every sleep.
+        slept: Every gap slept, in order — the assertion target for "did the
+            loop honour the backoff and clamp it to the remaining budget?".
+    """
+
+    now: float = 0.0
+    slept: list[float] = field(default_factory=list)
+
+    def monotonic(self) -> float:
+        """Return the current reading without advancing it."""
+        return self.now
+
+    def sleep(self, seconds: float) -> None:
+        """Record the gap and fast-forward :attr:`now` by it."""
+        self.slept.append(seconds)
+        self.now += seconds
+
+    async def async_sleep(self, seconds: float) -> None:
+        """Awaitable :meth:`sleep`, for :func:`until_deadline_async`."""
+        self.sleep(seconds)
+
+
+@contextmanager
+def fake_clock(start: float = 0.0) -> Iterator[FakeClock]:
+    """Swap the poll helpers' default clock and sleeps for a deterministic fake.
+
+    For testing code that polls but does not expose ``clock``/``sleep`` on its
+    own signature. Only this module's defaults are swapped — ``time.monotonic``
+    and ``time.sleep`` are untouched, so nothing else in the process sees a
+    fast-forwarded clock. That matters for the asyncio event loop, which reads
+    ``time.monotonic`` for its own timers: patching it globally makes async tests
+    flake with spurious ``StopIteration``.
+
+    Args:
+        start: Initial monotonic reading.
+
+    Yields:
+        The :class:`FakeClock` in force for the duration of the block.
+    """
+    global _monotonic, _sleep, _async_sleep  # noqa: PLW0603 — the swap is the point
+    fake = FakeClock(now=start)
+    saved = (_monotonic, _sleep, _async_sleep)
+    _monotonic, _sleep, _async_sleep = fake.monotonic, fake.sleep, fake.async_sleep
+    try:
+        yield fake
+    finally:
+        _monotonic, _sleep, _async_sleep = saved

--- a/application_sdk/testing/e2e/base.py
+++ b/application_sdk/testing/e2e/base.py
@@ -59,6 +59,7 @@ from application_sdk.testing.e2e._errors import (
     MissingHarnessClassAttrError,
     MissingHarnessEnvError,
 )
+from application_sdk.testing.e2e._poll import until_deadline
 from application_sdk.testing.e2e.client import (
     AEWorkflowClient,
     DAGNodeStatus,
@@ -1035,8 +1036,14 @@ class BaseE2ETest:
                     # consistent but assets appear within seconds if publish
                     # succeeded. Use a short dedicated timeout rather than the
                     # full atlas_poll_timeout_seconds used for the connection.
-                    deadline = time.monotonic() + self.atlas_asset_poll_timeout_seconds
-                    while True:
+                    for _attempt in until_deadline(
+                        self.atlas_asset_poll_timeout_seconds,
+                        self.atlas_asset_poll_interval_seconds,
+                        label=f"Atlas asset counts under {self.connection_qualified_name}",
+                        # The per-poll inventory line below already reports
+                        # progress every iteration; a heartbeat would duplicate it.
+                        heartbeat_seconds=0,
+                    ):
                         asset_counts = self.client.count_assets_under_connection(
                             self.connection_qualified_name,
                             type_names=probe_types,
@@ -1051,16 +1058,14 @@ class BaseE2ETest:
                         # same evaluator as the final assertion, so the two can
                         # never drift to different definitions of "met".
                         met = not self._evaluate_asset_expectations(asset_counts)
-                        if time.monotonic() >= deadline:
-                            break
                         # Floors/non-empty can exit as soon as they're satisfied.
                         # Exact-count parity must NOT: ES indexing is eventually
                         # consistent, so a transient match could end polling
                         # before late-arriving over-extracted assets land. Keep
-                        # polling to the deadline so over-extraction surfaces.
+                        # polling to the deadline so over-extraction surfaces —
+                        # `until_deadline` ends the loop on its own last attempt.
                         if met and not self.expected_exact_counts:
                             break
-                        time.sleep(self.atlas_asset_poll_interval_seconds)
                 # True total across ALL asset types (not just the probed ones).
                 # The non-empty backstop uses this so it also protects connectors
                 # that declare no per-type expectations — precisely the ones most
@@ -1244,27 +1249,30 @@ class BaseE2ETest:
         """
         url = os.environ.get("E2E_WORKER_HEALTH_URL", self.worker_health_url)
         logger.info("Worker-up-only tier: probing %s", url)
-        deadline = time.monotonic() + self.worker_health_timeout_seconds
         last_error = ""
-        while True:
-            # conformance: ignore[L006] short, bounded readiness poll (worker_health_timeout_seconds) with a modest interval, not a hot loop; the worker is already health-gated by the sdr-e2e action so this converges on the first attempt in CI
+        for attempt in until_deadline(
+            self.worker_health_timeout_seconds,
+            self.worker_health_poll_interval_seconds,
+            label=f"{self.connector_short_name} worker health at {url}",
+        ):
             try:
                 with urllib.request.urlopen(url, timeout=10) as resp:  # noqa: S310 — fixed health URL, not user input
                     status = resp.status
                 if 200 <= status < 300:
+                    # conformance: ignore[L006] fires at most once per call — the immediately-following return exits the loop on first success; not per-iteration log volume
                     logger.info("App worker healthy: %s -> HTTP %s", url, status)
                     return
                 last_error = f"HTTP {status}"
             except (urllib.error.URLError, OSError) as exc:
                 last_error = str(exc)
-            if time.monotonic() >= deadline:
+            if attempt.is_last:
                 raise AssertionError(
                     f"App worker for {self.connector_short_name} did not become "
                     f"healthy at {url} within {self.worker_health_timeout_seconds}s "
-                    f"(last: {last_error}). No source is provisioned, so this run "
+                    f"({attempt.number} attempts, {attempt.elapsed:.0f}s elapsed; "
+                    f"last: {last_error}). No source is provisioned, so this run "
                     "only checks that the worker deploys and serves /server/health."
                 )
-            time.sleep(self.worker_health_poll_interval_seconds)
 
     # ------------------------------------------------------------------
     # Default test method

--- a/application_sdk/testing/e2e/client.py
+++ b/application_sdk/testing/e2e/client.py
@@ -59,6 +59,7 @@ from application_sdk.testing.e2e._errors import (
     DAGProgressStalledError,
     NoWorkerOnTaskQueueError,
 )
+from application_sdk.testing.e2e._poll import _HEARTBEAT_SECONDS, until_deadline
 
 logger = get_logger(__name__)
 
@@ -108,12 +109,12 @@ _REQUEST_BACKOFF_SECONDS = 3
 _MAX_RETRY_AFTER_SECONDS = 120
 _RETRY_AFTER_BUDGET_SECONDS = 300
 
-# Cadence for "still polling" heartbeat log lines in
-# ``poll_native_status`` — lineage stages take 2-5 min on small
-# datasets and the status string doesn't change during that time, so
-# the loop would otherwise look wedged in CI output. Long enough that
-# we don't drown the log on a fast happy-path run.
-_HEARTBEAT_SECONDS = 30
+# ``_HEARTBEAT_SECONDS`` (imported from ``_poll``) is the cadence for "still
+# polling" heartbeat log lines in ``poll_native_status`` — lineage stages take
+# 2-5 min on small datasets and the status string doesn't change during that
+# time, so the loop would otherwise look wedged in CI output. That loop throttles
+# its own richer progress line to the same cadence and disables the generic
+# heartbeat, rather than emitting two "still waiting" lines.
 
 # Per-status glyphs for the poll-loop log line — gives the operator a
 # quick visual scan of "what's done / what's running" without parsing
@@ -970,20 +971,27 @@ class AEWorkflowClient:
         it exists to turn an indefinite hang into a fast, self-terminating
         failure with the last-seen node states, instead of a manual cancel.
         """
-        elapsed = 0
         last_summary: str | None = None
         last_result: DAGRunResult | None = None
         transient_streak = 0
         # Seconds spent waiting *beyond* the poll interval because the origin
         # asked for longer — same accounting ``_post_with_retry`` keeps, so
         # both retry loops bound honoured backoff at _RETRY_AFTER_BUDGET_SECONDS.
-        honoured_seconds = 0
-        last_log_elapsed = 0  # seconds since the last info log fired
+        honoured_seconds = 0.0
+        last_log_elapsed = 0.0  # seconds since the last info log fired
         any_node_started = False  # any node reached Running/terminal (stall guard)
         last_progress_elapsed = (
-            0  # elapsed at the last node-state transition (progress watchdog)
+            0.0  # elapsed at the last node-state transition (progress watchdog)
         )
-        while elapsed < timeout_seconds:
+        for attempt in until_deadline(
+            timeout_seconds,
+            interval_seconds,
+            label=f"AE run {run_id}",
+            # This loop emits its own richer progress line (per node-state change
+            # plus a heartbeat at the same cadence); the generic one would double it.
+            heartbeat_seconds=0,
+        ):
+            elapsed = attempt.elapsed
             try:
                 result = self.get_native_status(run_id)
             except AppError as e:
@@ -1001,18 +1009,19 @@ class AEWorkflowClient:
                 # rather than the poll cadence: an overloaded tenant answering
                 # "retry_after: 120" would otherwise burn the whole
                 # max_transient_failures streak inside its own wait window.
-                # ``elapsed`` advances by the real wait, so timeout_seconds
-                # still bounds the loop.
+                # The loop's own clock advances by the real wait, so
+                # timeout_seconds still bounds it.
                 gap = _retry_gap(
                     e.retry_after_seconds if isinstance(e, AtlanApiHttpError) else None,
                     default_seconds=interval_seconds,
                     budget_left=_RETRY_AFTER_BUDGET_SECONDS - honoured_seconds,
                 )
                 honoured_seconds += gap.seconds - interval_seconds
-                # Never sleep past the deadline: a 120s honoured wait against
-                # a 50s remaining budget must not block the full 120s before
-                # the timeout is re-checked.
-                sleep_for = min(gap.seconds, max(timeout_seconds - elapsed, 0))
+                # ``sleep_next`` clamps to the residual budget, so a 120s
+                # honoured wait against a 50s remaining budget does not block
+                # the full 120s before the timeout is re-checked — and it
+                # reports back the gap actually taken, for the log below.
+                sleep_for = attempt.sleep_next(gap.seconds)
                 logger.warning(
                     "native-status transient error (streak %d/%d): %s — sleeping %ds%s and retrying",
                     transient_streak,
@@ -1022,8 +1031,6 @@ class AEWorkflowClient:
                     gap.origin_note,
                     exc_info=True,
                 )
-                time.sleep(sleep_for)
-                elapsed += sleep_for
                 continue
             transient_streak = 0
             last_result = result
@@ -1055,7 +1062,7 @@ class AEWorkflowClient:
                 logger.info(
                     "%s AE run [%3ds] %s — %s",
                     run_glyph,
-                    elapsed,
+                    int(elapsed),
                     result.status.value,
                     summary,
                 )
@@ -1114,8 +1121,6 @@ class AEWorkflowClient:
                         f"{timeout_seconds}s."
                     ),
                 )
-            time.sleep(interval_seconds)
-            elapsed += interval_seconds
         # Timeout: return the last observation so callers can include
         # node-level state in the failure message rather than just
         # "timed out after Xs".
@@ -1219,24 +1224,30 @@ class AEWorkflowClient:
         """
         if max_not_found_attempts_override is not None:
             max_not_found_attempts = max_not_found_attempts_override
-        elapsed = 0
-        not_found_streak = 0
         # `max_forbidden_attempts` kept on the signature for back-compat
         # but unused now that the search path doesn't surface 403.
         del max_forbidden_attempts
-        while elapsed < timeout_seconds:
+        for attempt in until_deadline(
+            timeout_seconds,
+            interval_seconds,
+            label=f"Atlas Connection {qualified_name}",
+            # The per-poll probe line below already reports progress every
+            # iteration; a heartbeat would duplicate it.
+            heartbeat_seconds=0,
+        ):
             found = self.connection_exists_in_atlas_via_search(qualified_name)
             # conformance: ignore[L006] short, bounded poll (timeout_seconds) with modest iteration count, not a hot loop; the per-iteration probe result is the primary diagnostic signal when an E2E run fails to converge
             logger.info(
                 "Atlas Connection probe [%ds] qn=%s exists=%s",
-                elapsed,
+                int(attempt.elapsed),
                 qualified_name,
                 found,
             )
             if found:
                 return True
-            not_found_streak += 1
-            if not_found_streak >= max_not_found_attempts:
+            # A found probe returns immediately, so every attempt reached here is
+            # an empty search and the attempt number *is* the consecutive streak.
+            if attempt.number >= max_not_found_attempts:
                 logger.error(
                     "Atlas Connection probe found nothing %d times in a row "
                     "(%ds elapsed) — stopping early. The Connection never "
@@ -1244,12 +1255,10 @@ class AEWorkflowClient:
                     "but the entities did not reach the asset server. Check "
                     "publish metrics vs the storage bucket the worker wrote "
                     "to and the one publish reads from.",
-                    not_found_streak,
-                    elapsed,
+                    attempt.number,
+                    int(attempt.elapsed),
                 )
                 return False
-            time.sleep(interval_seconds)
-            elapsed += interval_seconds
         return False
 
     def count_assets_under_connection(

--- a/application_sdk/testing/e2e/pods.py
+++ b/application_sdk/testing/e2e/pods.py
@@ -2,11 +2,11 @@
 
 import asyncio
 import json
-import time
 
 import orjson
 
 from application_sdk.observability.logger_adaptor import get_logger
+from application_sdk.testing.e2e._poll import until_deadline_async
 
 logger = get_logger(__name__)
 
@@ -48,8 +48,11 @@ async def wait_for_pods_ready(
     poll_interval: float = 5.0,
 ) -> None:
     """Wait until all matching pods have all containers Ready."""
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
+    async for attempt in until_deadline_async(
+        timeout,
+        poll_interval,
+        label=f"pods '{label_selector}' in namespace '{namespace}'",
+    ):
         pods = await get_pods(namespace, label_selector)
         if pods:
             all_ready = all(
@@ -61,11 +64,12 @@ async def wait_for_pods_ready(
             )
             if all_ready:
                 return
-        await asyncio.sleep(poll_interval)
-    raise TimeoutError(
-        f"Pods with selector '{label_selector}' in namespace '{namespace}' "
-        f"did not become ready within {timeout}s"
-    )
+        if attempt.is_last:
+            raise TimeoutError(
+                f"Pods with selector '{label_selector}' in namespace '{namespace}' "
+                f"did not become ready within {timeout}s ({attempt.number} attempts, "
+                f"{attempt.elapsed:.0f}s elapsed; {len(pods)} pod(s) matched)"
+            )
 
 
 async def get_pod_logs(namespace: str, pod_name: str, container: str = "") -> str:

--- a/application_sdk/testing/e2e/portforward.py
+++ b/application_sdk/testing/e2e/portforward.py
@@ -7,8 +7,13 @@ from typing import Any
 import httpx
 
 from application_sdk.observability.logger_adaptor import get_logger
+from application_sdk.testing.e2e._poll import until_deadline_async
 
 logger = get_logger(__name__)
+
+# Tight cadence: the port opens within a few hundred ms once kubectl's tunnel is
+# up, and every attempt already carries its own 1s connect timeout.
+_PORT_POLL_INTERVAL_SECONDS = 0.1
 
 
 def _find_free_port() -> int:
@@ -22,10 +27,14 @@ async def _wait_for_port(
     port: int, host: str = "127.0.0.1", timeout: float = 10.0
 ) -> None:
     """Poll until TCP port accepts connections or timeout."""
-    import time  # noqa: PLC0415 — stdlib time; lazy use only
-
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
+    async for attempt in until_deadline_async(
+        timeout,
+        _PORT_POLL_INTERVAL_SECONDS,
+        label=f"tcp://{host}:{port}",
+        # A 10s budget never reaches the 30s heartbeat cadence, and the caller
+        # already logs the port-forward it is waiting on.
+        heartbeat_seconds=0,
+    ):
         try:
             _reader, writer = await asyncio.wait_for(
                 asyncio.open_connection(host, port), timeout=1.0
@@ -33,9 +42,12 @@ async def _wait_for_port(
             writer.close()
             await writer.wait_closed()
             return
-        except (ConnectionRefusedError, OSError, asyncio.TimeoutError):
-            await asyncio.sleep(0.1)
-    raise TimeoutError(f"Port {port} did not become ready within {timeout}s")
+        except (ConnectionRefusedError, OSError, asyncio.TimeoutError) as exc:
+            if attempt.is_last:
+                raise TimeoutError(
+                    f"Port {port} did not become ready within {timeout}s "
+                    f"({attempt.number} attempts)"
+                ) from exc
 
 
 async def kube_http_call(

--- a/application_sdk/testing/e2e/workflows.py
+++ b/application_sdk/testing/e2e/workflows.py
@@ -1,9 +1,9 @@
 """Workflow trigger and status helpers for K8s e2e tests."""
 
-import asyncio
 from typing import Any
 
 from application_sdk.observability.logger_adaptor import get_logger
+from application_sdk.testing.e2e._poll import until_deadline_async
 from application_sdk.testing.e2e.portforward import kube_http_call
 
 logger = get_logger(__name__)
@@ -69,10 +69,9 @@ async def wait_for_workflow(
     Raises:
         TimeoutError: If the workflow does not complete within ``timeout``.
     """
-    import time  # noqa: PLC0415 — stdlib time; lazy use only
-
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
+    async for attempt in until_deadline_async(
+        timeout, poll_interval, label=f"workflow {workflow_id}"
+    ):
         response = await kube_http_call(
             namespace=namespace,
             service=service,
@@ -86,8 +85,13 @@ async def wait_for_workflow(
         logger.debug("Workflow %s status: %s", workflow_id, status)
         if status in _TERMINAL_STATES:
             return data
-        await asyncio.sleep(poll_interval)
+        if attempt.is_last:
+            raise TimeoutError(
+                f"Workflow {workflow_id} did not reach a terminal state within "
+                f"{timeout}s ({attempt.number} attempts, {attempt.elapsed:.0f}s "
+                f"elapsed; last status={status or 'unknown'})"
+            )
 
-    raise TimeoutError(
-        f"Workflow {workflow_id} did not reach a terminal state within {timeout}s"
+    raise AssertionError(  # pragma: no cover — the is_last branch always fires first
+        f"poll loop for workflow {workflow_id} ended without a final attempt"
     )

--- a/tests/unit/testing/e2e/test_client.py
+++ b/tests/unit/testing/e2e/test_client.py
@@ -20,6 +20,7 @@ from application_sdk.testing.e2e._errors import (
     DAGProgressStalledError,
     NoWorkerOnTaskQueueError,
 )
+from application_sdk.testing.e2e._poll import fake_clock
 from application_sdk.testing.e2e.client import (
     _MAX_RETRY_AFTER_SECONDS,
     _REQUEST_MAX_ATTEMPTS,
@@ -100,7 +101,7 @@ class TestPollNativeStatusStallGuard:
         stuck = _result(DAGRunStatus.RUNNING, DAGNodeStatus.PENDING)
 
         with patch.object(client, "get_native_status", return_value=stuck):
-            with patch("time.sleep"):
+            with fake_clock():
                 with pytest.raises(NoWorkerOnTaskQueueError) as exc:
                     client.poll_native_status(
                         _RUN_ID,
@@ -121,7 +122,7 @@ class TestPollNativeStatusStallGuard:
         stuck = _result(DAGRunStatus.RUNNING, DAGNodeStatus.SCHEDULED)
 
         with patch.object(client, "get_native_status", return_value=stuck):
-            with patch("time.sleep"):
+            with fake_clock():
                 with pytest.raises(NoWorkerOnTaskQueueError):
                     client.poll_native_status(
                         _RUN_ID,
@@ -138,7 +139,7 @@ class TestPollNativeStatusStallGuard:
         stuck = _result(DAGRunStatus.RUNNING, DAGNodeStatus.PENDING)
 
         with patch.object(client, "get_native_status", return_value=stuck):
-            with patch("time.sleep"):
+            with fake_clock():
                 with pytest.raises(NoWorkerOnTaskQueueError) as exc:
                     client.poll_native_status(
                         _RUN_ID,
@@ -159,7 +160,7 @@ class TestPollNativeStatusStallGuard:
         side_effects = [running] * 6 + [done]
 
         with patch.object(client, "get_native_status", side_effect=side_effects):
-            with patch("time.sleep"):
+            with fake_clock():
                 result = client.poll_native_status(
                     _RUN_ID,
                     interval_seconds=10,
@@ -176,7 +177,7 @@ class TestPollNativeStatusStallGuard:
         stuck = _result(DAGRunStatus.RUNNING, DAGNodeStatus.PENDING)
 
         with patch.object(client, "get_native_status", return_value=stuck):
-            with patch("time.sleep"):
+            with fake_clock():
                 result = client.poll_native_status(
                     _RUN_ID,
                     interval_seconds=10,
@@ -192,7 +193,7 @@ class TestPollNativeStatusStallGuard:
         stuck = _result(DAGRunStatus.RUNNING, DAGNodeStatus.PENDING)
 
         with patch.object(client, "get_native_status", return_value=stuck):
-            with patch("time.sleep"):
+            with fake_clock():
                 result = client.poll_native_status(
                     _RUN_ID,
                     interval_seconds=10,
@@ -208,7 +209,7 @@ class TestPollNativeStatusStallGuard:
         stuck = _result(DAGRunStatus.RUNNING, DAGNodeStatus.PENDING)
 
         with patch.object(client, "get_native_status", return_value=stuck):
-            with patch("time.sleep"):
+            with fake_clock():
                 result = client.poll_native_status(
                     _RUN_ID,
                     interval_seconds=10,
@@ -231,7 +232,7 @@ class TestPollNativeStatusProgressWatchdog:
         stuck = _result(DAGRunStatus.RUNNING, DAGNodeStatus.RUNNING)
 
         with patch.object(client, "get_native_status", return_value=stuck):
-            with patch("time.sleep"):
+            with fake_clock():
                 with pytest.raises(DAGProgressStalledError) as exc:
                     client.poll_native_status(
                         _RUN_ID,
@@ -250,7 +251,7 @@ class TestPollNativeStatusProgressWatchdog:
         stuck = _result(DAGRunStatus.RUNNING, DAGNodeStatus.RUNNING)
 
         with patch.object(client, "get_native_status", return_value=stuck):
-            with patch("time.sleep"):
+            with fake_clock():
                 result = client.poll_native_status(
                     _RUN_ID,
                     interval_seconds=10,
@@ -270,7 +271,7 @@ class TestPollNativeStatusProgressWatchdog:
         with patch.object(
             client, "get_native_status", side_effect=[running, running, done]
         ):
-            with patch("time.sleep"):
+            with fake_clock():
                 result = client.poll_native_status(
                     _RUN_ID,
                     interval_seconds=10,
@@ -304,7 +305,7 @@ class TestSkippedStatus:
         skipped = _result(DAGRunStatus.SKIPPED, DAGNodeStatus.PENDING)
 
         with patch.object(client, "get_native_status", return_value=skipped):
-            with patch("time.sleep"):
+            with fake_clock():
                 result = client.poll_native_status(
                     _RUN_ID,
                     interval_seconds=10,
@@ -326,7 +327,7 @@ class TestPollNativeStatusTransientHandling:
         side_effects = [err, err, ok]
 
         with patch.object(client, "get_native_status", side_effect=side_effects):
-            with patch("time.sleep"):
+            with fake_clock():
                 result = client.poll_native_status(
                     _RUN_ID,
                     interval_seconds=1,
@@ -343,7 +344,7 @@ class TestPollNativeStatusTransientHandling:
         side_effects = [_http_error()] * max_failures
 
         with patch.object(client, "get_native_status", side_effect=side_effects):
-            with patch("time.sleep"):
+            with fake_clock():
                 with pytest.raises(AtlanApiHttpError):
                     client.poll_native_status(
                         _RUN_ID,
@@ -367,7 +368,7 @@ class TestPollNativeStatusTransientHandling:
         side_effects = [err, err, running, err, err, ok]
 
         with patch.object(client, "get_native_status", side_effect=side_effects):
-            with patch("time.sleep"):
+            with fake_clock():
                 result = client.poll_native_status(
                     _RUN_ID,
                     interval_seconds=1,
@@ -385,7 +386,7 @@ class TestPollNativeStatusTransientHandling:
             patch.object(
                 client, "get_native_status", side_effect=ValueError("unexpected")
             ),
-            patch("time.sleep"),
+            fake_clock(),
             pytest.raises(ValueError, match="unexpected"),
         ):
             client.poll_native_status(
@@ -704,7 +705,7 @@ class TestPollNativeStatusHonoursRetryAfter:
             patch.object(
                 client, "get_native_status", side_effect=[err, _succeeded_result()]
             ),
-            patch("time.sleep") as mock_sleep,
+            fake_clock() as clock,
         ):
             result = client.poll_native_status(
                 _RUN_ID,
@@ -713,7 +714,7 @@ class TestPollNativeStatusHonoursRetryAfter:
                 max_transient_failures=5,
             )
         assert result.status == DAGRunStatus.SUCCEEDED
-        mock_sleep.assert_called_once_with(120)
+        assert clock.slept == [120]
 
     def test_hintless_error_keeps_the_poll_cadence(self):
         client = _make_client()
@@ -723,7 +724,7 @@ class TestPollNativeStatusHonoursRetryAfter:
                 "get_native_status",
                 side_effect=[_http_error(), _succeeded_result()],
             ),
-            patch("time.sleep") as mock_sleep,
+            fake_clock() as clock,
         ):
             client.poll_native_status(
                 _RUN_ID,
@@ -731,7 +732,7 @@ class TestPollNativeStatusHonoursRetryAfter:
                 timeout_seconds=600,
                 max_transient_failures=5,
             )
-        mock_sleep.assert_called_once_with(10)
+        assert clock.slept == [10]
 
     def test_long_backoff_counts_against_the_poll_timeout(self):
         """Honouring a long wait must not let the loop outlive timeout_seconds."""
@@ -743,7 +744,7 @@ class TestPollNativeStatusHonoursRetryAfter:
         )
         with (
             patch.object(client, "get_native_status", side_effect=[err] * 10),
-            patch("time.sleep") as mock_sleep,
+            fake_clock() as clock,
             pytest.raises(AtlanApiTimeoutError),
         ):
             client.poll_native_status(
@@ -755,7 +756,7 @@ class TestPollNativeStatusHonoursRetryAfter:
         # Each honoured sleep is clamped to the remaining timeout budget:
         # 120s requested against a 200s deadline sleeps 120s, then only 80s,
         # so the loop exits exactly at the deadline rather than overshooting.
-        assert [call.args[0] for call in mock_sleep.call_args_list] == [120, 80]
+        assert clock.slept == [120, 80]
 
     def test_honoured_wait_is_clamped_to_the_remaining_timeout(self):
         """timeout_seconds < retry_after: the first sleep stops at the deadline."""
@@ -767,7 +768,7 @@ class TestPollNativeStatusHonoursRetryAfter:
         )
         with (
             patch.object(client, "get_native_status", side_effect=[err] * 10),
-            patch("time.sleep") as mock_sleep,
+            fake_clock() as clock,
             pytest.raises(AtlanApiTimeoutError),
         ):
             client.poll_native_status(
@@ -778,7 +779,7 @@ class TestPollNativeStatusHonoursRetryAfter:
             )
         # 50s remain and the origin asked for 120s: one clamped 50s sleep
         # reaches the deadline exactly; the loop never sleeps past it.
-        assert [call.args[0] for call in mock_sleep.call_args_list] == [50]
+        assert clock.slept == [50]
 
     def test_honoured_backoff_is_budgeted_across_the_poll_loop(self):
         """A tenant repeating retry_after: 120 exhausts the shared budget, then
@@ -792,7 +793,7 @@ class TestPollNativeStatusHonoursRetryAfter:
         )
         with (
             patch.object(client, "get_native_status", side_effect=[err] * 10),
-            patch("time.sleep") as mock_sleep,
+            fake_clock() as clock,
             pytest.raises(AtlanApiHttpError),
         ):
             client.poll_native_status(
@@ -807,7 +808,7 @@ class TestPollNativeStatusHonoursRetryAfter:
         # 110 + 110 + 80 = 300), then the fixed 10s cadence once the budget
         # is spent — no unbounded 120s waits. The fifth error hits the
         # transient-failure cap and re-raises.
-        assert [call.args[0] for call in mock_sleep.call_args_list] == [
+        assert clock.slept == [
             120,
             120,
             80,

--- a/tests/unit/testing/e2e/test_poll.py
+++ b/tests/unit/testing/e2e/test_poll.py
@@ -314,6 +314,20 @@ class TestAsyncTwin:
         assert clock.now == 10
         assert [a.is_last for a in seen] == [False, True]
 
+    async def test_a_probe_that_blows_the_budget_still_gets_a_final_attempt(self):
+        """Clamping the async gap to zero must not cost the call site its raise."""
+        clock = FakeClock()
+        seen: list[Attempt] = []
+        async for attempt in until_deadline_async(
+            10, 3, label="thing", clock=clock.monotonic, sleep=clock.async_sleep
+        ):
+            seen.append(attempt)
+            if attempt.number == 1:
+                clock.now += 50  # the probe alone outlasts the whole budget
+
+        assert clock.slept == [0]
+        assert [a.is_last for a in seen] == [False, True]
+
     async def test_honours_sleep_next(self):
         clock = FakeClock()
         async for attempt in until_deadline_async(

--- a/tests/unit/testing/e2e/test_poll.py
+++ b/tests/unit/testing/e2e/test_poll.py
@@ -104,6 +104,44 @@ class TestDeadlineIsRespected:
         assert attempts[0].remaining == 0
         assert clock.slept == []
 
+    def test_a_slow_probe_does_not_push_the_loop_past_the_deadline(self):
+        """A probe that outlasts its interval must shrink the next gap, not add to it.
+
+        timeout=10, interval=3, one 8s probe: sleeping a full 3s on top of it would
+        end the loop at 11s. The gap is re-clamped against the clock read after the
+        probe returns.
+        """
+        clock = FakeClock()
+        seen: list[Attempt] = []
+        for attempt in until_deadline(
+            10, 3, label="thing", clock=clock.monotonic, sleep=clock.sleep
+        ):
+            seen.append(attempt)
+            if attempt.number == 1:
+                clock.now += 8  # the probe itself takes 8s
+
+        assert clock.slept == [2]
+        assert clock.now == 10
+        assert [a.is_last for a in seen] == [False, True]
+
+    def test_a_probe_that_blows_the_budget_still_gets_a_final_attempt(self):
+        """Clamping the gap to zero must not cost the call site its raise.
+
+        The exhaustion branch keys on is_last, so a loop that returned silently
+        here would swallow the failure.
+        """
+        clock = FakeClock()
+        seen: list[Attempt] = []
+        for attempt in until_deadline(
+            10, 3, label="thing", clock=clock.monotonic, sleep=clock.sleep
+        ):
+            seen.append(attempt)
+            if attempt.number == 1:
+                clock.now += 50  # the probe alone outlasts the whole budget
+
+        assert clock.slept == [0]
+        assert [a.is_last for a in seen] == [False, True]
+
     def test_zero_interval_spins_to_the_deadline(self):
         """interval=0 is legal (the worker-health tier uses it) and terminates.
 
@@ -260,6 +298,21 @@ class TestAsyncTwin:
 
         assert async_attempts == sync_attempts
         assert async_clock.slept == sync_clock.slept
+
+    async def test_a_slow_probe_does_not_push_the_loop_past_the_deadline(self):
+        """The post-probe gap clamp must hold in the async twin too."""
+        clock = FakeClock()
+        seen: list[Attempt] = []
+        async for attempt in until_deadline_async(
+            10, 3, label="thing", clock=clock.monotonic, sleep=clock.async_sleep
+        ):
+            seen.append(attempt)
+            if attempt.number == 1:
+                clock.now += 8
+
+        assert clock.slept == [2]
+        assert clock.now == 10
+        assert [a.is_last for a in seen] == [False, True]
 
     async def test_honours_sleep_next(self):
         clock = FakeClock()

--- a/tests/unit/testing/e2e/test_poll.py
+++ b/tests/unit/testing/e2e/test_poll.py
@@ -1,0 +1,342 @@
+"""Unit tests for the shared bounded-poll helper.
+
+The defect this helper exists to remove: every hand-rolled loop it replaced
+checked its budget *after* the work and *before* the sleep, so it slept one full
+interval past its stated timeout. The ``is_last`` tests below pin the fix — a
+loop must never wait beyond ``timeout_seconds``, and the call site must always
+get exactly one attempt flagged as its last chance to raise.
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import patch
+
+import pytest
+
+from application_sdk.testing.e2e import _poll
+from application_sdk.testing.e2e._poll import (
+    Attempt,
+    FakeClock,
+    fake_clock,
+    until_deadline,
+    until_deadline_async,
+)
+
+
+def _drain(
+    timeout: float, interval: float, **kwargs
+) -> tuple[list[Attempt], FakeClock]:
+    """Run a sync loop to exhaustion under a fake clock, returning what it yielded."""
+    clock = FakeClock()
+    attempts = list(
+        until_deadline(
+            timeout,
+            interval,
+            label="thing",
+            clock=clock.monotonic,
+            sleep=clock.sleep,
+            **kwargs,
+        )
+    )
+    return attempts, clock
+
+
+async def _drain_async(
+    timeout: float, interval: float, **kwargs
+) -> tuple[list[Attempt], FakeClock]:
+    """Async twin of :func:`_drain`."""
+    clock = FakeClock()
+    attempts = [
+        attempt
+        async for attempt in until_deadline_async(
+            timeout,
+            interval,
+            label="thing",
+            clock=clock.monotonic,
+            sleep=clock.async_sleep,
+            **kwargs,
+        )
+    ]
+    return attempts, clock
+
+
+class TestDeadlineIsRespected:
+    """The loop must not sleep, or poll, past its own budget."""
+
+    def test_never_sleeps_past_the_deadline(self):
+        """The regression this helper exists for: total slept <= the budget.
+
+        The hand-rolled loops each checked the deadline after the work and before
+        the sleep, so a 10s budget at a 3s interval waited 12s.
+        """
+        attempts, clock = _drain(10, 3)
+
+        assert clock.now <= 10
+        assert sum(clock.slept) <= 10
+        assert [a.elapsed for a in attempts] == [0, 3, 6, 9]
+
+    def test_final_attempt_is_the_last_one_that_fits(self):
+        """Exactly one attempt carries is_last, and it is the final one."""
+        attempts, _ = _drain(10, 3)
+
+        assert [a.is_last for a in attempts] == [False, False, False, True]
+
+    def test_one_attempt_when_the_budget_is_a_single_interval(self):
+        """A budget with no room for a second poll gets one attempt, flagged last."""
+        attempts, clock = _drain(10, 10)
+
+        assert len(attempts) == 1
+        assert attempts[0].is_last is True
+        assert clock.slept == []
+
+    @pytest.mark.parametrize("timeout", [0, -5])
+    def test_zero_or_negative_budget_still_probes_once(self, timeout: float):
+        """A probe loop always looks at least once, rather than failing unchecked.
+
+        The call site's exhaustion branch is keyed on ``is_last``, so a loop that
+        yielded nothing would raise nothing — the failure would vanish.
+        """
+        attempts, clock = _drain(timeout, 5)
+
+        assert len(attempts) == 1
+        assert attempts[0].is_last is True
+        assert attempts[0].remaining == 0
+        assert clock.slept == []
+
+    def test_zero_interval_spins_to_the_deadline(self):
+        """interval=0 is legal (the worker-health tier uses it) and terminates.
+
+        Deliberately on the real clock: a spin advances only because wall time
+        does, so :class:`FakeClock` — which advances only on sleep — cannot model
+        it and would loop forever.
+        """
+        attempts = list(until_deadline(0.05, 0, label="thing", heartbeat_seconds=0))
+
+        assert len(attempts) >= 1
+        assert attempts[-1].is_last is True
+        assert attempts[-1].elapsed >= 0.05
+
+
+class TestAttemptFields:
+    """The typed fields exist so an error leaf never re-derives them by hand."""
+
+    def test_number_elapsed_and_remaining(self):
+        attempts, _ = _drain(10, 3)
+
+        assert [a.number for a in attempts] == [1, 2, 3, 4]
+        assert [a.remaining for a in attempts] == [10, 7, 4, 1]
+
+    def test_remaining_never_goes_negative(self):
+        """Budgets that don't divide by the interval must not report a debt."""
+        attempts, _ = _drain(10, 4)
+
+        assert all(a.remaining >= 0 for a in attempts)
+        assert attempts[-1].remaining == 2
+
+
+class TestEarlyExit:
+    """Breaking out of the loop must stop it dead, not sleep once more."""
+
+    def test_break_on_first_attempt_sleeps_nothing(self):
+        clock = FakeClock()
+        for _attempt in until_deadline(
+            100, 5, label="thing", clock=clock.monotonic, sleep=clock.sleep
+        ):
+            break
+
+        assert clock.slept == []
+        assert clock.now == 0
+
+    def test_break_partway_stops_the_clock(self):
+        clock = FakeClock()
+        for attempt in until_deadline(
+            100, 5, label="thing", clock=clock.monotonic, sleep=clock.sleep
+        ):
+            if attempt.number == 3:
+                break
+
+        assert clock.slept == [5, 5]
+
+
+class TestSleepNext:
+    """Call sites that honour an origin-supplied backoff replace one gap only."""
+
+    def test_honours_a_longer_requested_gap(self):
+        clock = FakeClock()
+        for attempt in until_deadline(
+            1000, 10, label="thing", clock=clock.monotonic, sleep=clock.sleep
+        ):
+            if attempt.number == 1:
+                attempt.sleep_next(120)
+            if attempt.number == 3:
+                break
+
+        # First gap honoured at 120s, then straight back to the poll cadence —
+        # the request applies to one sleep, not to the rest of the loop.
+        assert clock.slept == [120, 10]
+
+    def test_clamps_the_gap_to_the_remaining_budget(self):
+        """A 120s backoff against a 50s residual budget must not overshoot it."""
+        clock = FakeClock()
+        gaps: list[float] = []
+        for attempt in until_deadline(
+            50, 10, label="thing", clock=clock.monotonic, sleep=clock.sleep
+        ):
+            gaps.append(attempt.sleep_next(120))
+
+        assert gaps == [50, 0]  # second call lands on the last attempt: no-op
+        assert clock.slept == [50]
+        assert clock.now == 50
+
+    def test_returns_the_gap_actually_taken(self):
+        """The return value is what the call site should log, not the request."""
+        clock = FakeClock()
+        loop = until_deadline(
+            50, 10, label="thing", clock=clock.monotonic, sleep=clock.sleep
+        )
+        assert next(loop).sleep_next(30) == 30
+
+    def test_negative_request_floors_at_zero(self):
+        clock = FakeClock()
+        loop = until_deadline(
+            50, 10, label="thing", clock=clock.monotonic, sleep=clock.sleep
+        )
+        assert next(loop).sleep_next(-5) == 0
+
+
+class TestHeartbeat:
+    """One shared heartbeat instead of five loops that go silent for minutes."""
+
+    def _heartbeats(self, timeout: float, interval: float, **kwargs) -> list[str]:
+        """Drain a loop and return the rendered heartbeat lines it emitted."""
+        with patch.object(_poll, "logger") as mock_logger:
+            _drain(timeout, interval, **kwargs)
+        return [
+            call.args[0] % call.args[1:] for call in mock_logger.info.call_args_list
+        ]
+
+    def test_fires_at_the_configured_cadence(self):
+        # Attempts land at 0,10,...,90; the heartbeat fires at 30, 60 and 90.
+        assert len(self._heartbeats(100, 10, heartbeat_seconds=30)) == 3
+
+    def test_zero_disables_it(self):
+        assert self._heartbeats(100, 10, heartbeat_seconds=0) == []
+
+    def test_names_the_label_and_the_budget(self):
+        with patch.object(_poll, "logger") as mock_logger:
+            clock = FakeClock()
+            list(
+                until_deadline(
+                    100,
+                    40,
+                    label="worker health at http://localhost:8000/server/health",
+                    heartbeat_seconds=30,
+                    clock=clock.monotonic,
+                    sleep=clock.sleep,
+                )
+            )
+
+        call = mock_logger.info.call_args_list[0]
+        message = call.args[0] % call.args[1:]
+        assert "worker health at http://localhost:8000/server/health" in message
+        assert "attempt 2" in message
+        assert "40s of 100s elapsed" in message
+        assert "60s left" in message
+
+
+class TestAsyncTwin:
+    """The async generator must not drift from the sync one."""
+
+    @pytest.mark.parametrize(
+        ("timeout", "interval"),
+        [(10, 3), (10, 10), (0, 5), (50, 4), (7, 2)],
+    )
+    async def test_yields_the_same_attempts_as_the_sync_loop(
+        self, timeout: float, interval: float
+    ):
+        sync_attempts, sync_clock = _drain(timeout, interval)
+        async_attempts, async_clock = await _drain_async(timeout, interval)
+
+        assert async_attempts == sync_attempts
+        assert async_clock.slept == sync_clock.slept
+
+    async def test_honours_sleep_next(self):
+        clock = FakeClock()
+        async for attempt in until_deadline_async(
+            1000,
+            10,
+            label="thing",
+            clock=clock.monotonic,
+            sleep=clock.async_sleep,
+        ):
+            if attempt.number == 1:
+                attempt.sleep_next(120)
+            if attempt.number == 3:
+                break
+
+        assert clock.slept == [120, 10]
+
+    async def test_awaits_the_real_asyncio_sleep_by_default(self):
+        """No clock injected → real timers, and the budget still bounds the loop."""
+        started = time.monotonic()
+        attempts = [
+            attempt
+            async for attempt in until_deadline_async(
+                0.06, 0.02, label="thing", heartbeat_seconds=0
+            )
+        ]
+
+        assert len(attempts) >= 2
+        assert attempts[-1].is_last is True
+        # Bounded by the budget (plus scheduler slop), not by budget + one interval.
+        assert time.monotonic() - started < 0.5
+
+
+class TestFakeClock:
+    """The test seam itself: it must not disturb the process-wide clock."""
+
+    def test_leaves_time_monotonic_alone(self):
+        """A global clock patch breaks the asyncio loop's own timers."""
+        real_monotonic = time.monotonic
+        with fake_clock():
+            assert time.monotonic is real_monotonic
+            assert time.sleep is not None
+            before = time.monotonic()
+            assert time.monotonic() >= before
+
+    def test_swaps_the_poll_defaults_and_restores_them(self):
+        saved = (_poll._monotonic, _poll._sleep, _poll._async_sleep)
+        with fake_clock() as clock:
+            # `==`, not `is`: a bound method is a fresh object per attribute read.
+            assert _poll._monotonic == clock.monotonic
+            assert _poll._sleep == clock.sleep
+            assert _poll._async_sleep == clock.async_sleep
+        assert (_poll._monotonic, _poll._sleep, _poll._async_sleep) == saved
+
+    def test_restores_the_defaults_after_an_exception(self):
+        saved = (_poll._monotonic, _poll._sleep, _poll._async_sleep)
+        with pytest.raises(RuntimeError, match="boom"), fake_clock():
+            raise RuntimeError("boom")
+        assert (_poll._monotonic, _poll._sleep, _poll._async_sleep) == saved
+
+    def test_drives_a_loop_that_takes_no_clock_arguments(self):
+        """The point of the seam: poll code with no injectable clock still runs fast."""
+        with fake_clock() as clock:
+            attempts = list(until_deadline(600, 30, label="thing"))
+
+        assert len(attempts) == 20
+        assert clock.now == 570
+
+    async def test_drives_an_async_loop_without_touching_the_event_loop_clock(self):
+        started = time.monotonic()
+        with fake_clock() as clock:
+            attempts = [
+                attempt
+                async for attempt in until_deadline_async(600, 30, label="thing")
+            ]
+
+        assert len(attempts) == 20
+        assert clock.now == 570
+        # A 570s simulated wait that took no real time at all.
+        assert time.monotonic() - started < 1.0

--- a/tests/unit/testing/full_dag/test_client.py
+++ b/tests/unit/testing/full_dag/test_client.py
@@ -10,6 +10,7 @@ from typing import Any
 
 import pytest
 
+from application_sdk.testing.e2e._poll import fake_clock
 from application_sdk.testing.full_dag._errors import (
     AtlanApiHttpError,
     AtlanApiResponseInvariantError,
@@ -127,8 +128,6 @@ def test_unknown_status_strings_treated_as_pending(
 def test_poll_native_status_returns_on_terminal(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    # Avoid the real time.sleep — poll interval doesn't matter for the test.
-    monkeypatch.setattr("time.sleep", lambda _: None)
     client, queue = _make_client(
         monkeypatch,
         [
@@ -143,7 +142,10 @@ def test_poll_native_status_returns_on_terminal(
             ),
         ],
     )
-    result = client.poll_native_status("r", interval_seconds=1, timeout_seconds=60)
+    # fake_clock fast-forwards the poll loop's own clock and sleeps; the real
+    # time.monotonic (and so the asyncio loop's timers) stay untouched.
+    with fake_clock():
+        result = client.poll_native_status("r", interval_seconds=1, timeout_seconds=60)
     assert result.status is DAGRunStatus.SUCCEEDED
     assert queue == []  # all three responses consumed
 
@@ -151,7 +153,6 @@ def test_poll_native_status_returns_on_terminal(
 def test_poll_native_status_returns_last_observation_on_timeout(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr("time.sleep", lambda _: None)
     client, _ = _make_client(
         monkeypatch,
         # interval=1, timeout=3 → we'll fire 3 polls (elapsed=0,1,2) all Running
@@ -161,7 +162,8 @@ def test_poll_native_status_returns_last_observation_on_timeout(
             (200, {"status": "Running", "dag_nodes": {}}),
         ],
     )
-    result = client.poll_native_status("r", interval_seconds=1, timeout_seconds=3)
+    with fake_clock():
+        result = client.poll_native_status("r", interval_seconds=1, timeout_seconds=3)
     # Still Running but we got back the last observed state instead of
     # raising — caller can include node-level diagnostics in their error.
     assert result.status is DAGRunStatus.RUNNING
@@ -173,7 +175,6 @@ def test_poll_atlas_for_connection_succeeds_when_search_finds_it(
     """``poll_atlas_for_connection`` returns True as soon as the
     search-based existence check returns True (indexer may have lagged
     earlier polls)."""
-    monkeypatch.setattr("time.sleep", lambda _: None)
     client, _ = _make_client(monkeypatch, [])
 
     # Stub the search-based existence check directly — first two polls
@@ -185,12 +186,13 @@ def test_poll_atlas_for_connection_succeeds_when_search_finds_it(
         return calls["n"] >= 3
 
     monkeypatch.setattr(client, "connection_exists_in_atlas_via_search", fake_search)
-    assert (
-        client.poll_atlas_for_connection(
-            "default/mysql/test", interval_seconds=1, timeout_seconds=10
+    with fake_clock():
+        assert (
+            client.poll_atlas_for_connection(
+                "default/mysql/test", interval_seconds=1, timeout_seconds=10
+            )
+            is True
         )
-        is True
-    )
     assert calls["n"] == 3
 
 
@@ -198,17 +200,17 @@ def test_poll_atlas_for_connection_bails_after_not_found_streak(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """``max_not_found_attempts`` consecutive empty searches → False fast."""
-    monkeypatch.setattr("time.sleep", lambda _: None)
     client, _ = _make_client(monkeypatch, [])
     monkeypatch.setattr(
         client, "connection_exists_in_atlas_via_search", lambda _: False
     )
-    assert (
-        client.poll_atlas_for_connection(
-            "default/mysql/test",
-            interval_seconds=1,
-            timeout_seconds=1000,
-            max_not_found_attempts_override=3,
+    with fake_clock():
+        assert (
+            client.poll_atlas_for_connection(
+                "default/mysql/test",
+                interval_seconds=1,
+                timeout_seconds=1000,
+                max_not_found_attempts_override=3,
+            )
+            is False
         )
-        is False
-    )


### PR DESCRIPTION
Closes FND-626.

Six independently hand-rolled `deadline = time.monotonic() + …` poll loops in `application_sdk/testing/e2e/` now route through one bounded-poll primitive in a new private `_poll.py`: `until_deadline` (sync) and `until_deadline_async` (async twin — one generator cannot straddle both). Attempt arithmetic is shared by a single helper so the two cannot drift, and a parity test drives both under the same fake clock asserting identical `Attempt` sequences.

## The defect this removes

Every loop checked its budget *after* the work and *before* the sleep:

```python
deadline = time.monotonic() + timeout
while True:
    ...work...
    if time.monotonic() >= deadline:
        raise ...
    time.sleep(interval)
```

A 10s budget at a 3s interval waits 12s. `Attempt.is_last` moves that decision ahead of the sleep — the call site is told this is its last look, and the loop stops there.

The primitive is a generator, not a callback, so every call site keeps its own `try`/`except` and raises its own error leaf. `attempt.number` / `attempt.elapsed` feed those leaves directly instead of being re-derived by hand, so every exhaustion message now reports attempts and elapsed seconds.

## Also

* **Heartbeat logging.** Only `poll_native_status` had one; two of the other five went silent for minutes in CI output. Loops that already log per-iteration progress opt out with `heartbeat_seconds=0` rather than emitting a second "still waiting" line.
* **`Attempt.sleep_next(seconds) -> float`** lets `poll_native_status` honour an origin-supplied `retry_after` in place of its own cadence — clamped to the residual budget, returning the gap actually taken so the log reports the wait rather than the request. The existing sleep-sequence assertions (`[120, 80]`, `[50]`, `[120, 120, 80, 10]`) all hold unchanged.
* **`poll_atlas_for_connection`** drops its `not_found_streak` variable: a found probe returns immediately, so the streak was always `attempt.number`.

## Testing without patching the global clock

`fake_clock()` swaps only `_poll`'s clock/sleep defaults, leaving `time.monotonic` alone — patching that globally fast-forwards the asyncio event loop's own timers. The 20 `patch("time.sleep")` sites in the client poll tests move to it and assert against `clock.slept`.

This was required, not cosmetic: `poll_native_status` previously advanced a synthetic integer `elapsed`, so on a real clock with `time.sleep` patched every timeout-path test hangs.

`interval_seconds=0` (the worker-health tier) advances only because wall time does, so a fake clock cannot model it — documented on `FakeClock`, and that one case is tested against the real clock.

## Deviations from the issue

* **L006 directives went 1 → 3, not 6 → 1.** The heartbeat's `logger.info` lives outside any loop, so L006 doesn't fire on it. The three that remain sit on genuinely per-iteration diagnostic lines the call sites keep (Atlas inventory, Atlas Connection probe, AE run progress) — never the duplication this issue was about. Two of the five previously-unaudited loops turned out to have no in-loop INFO at all.

## Out of scope, unchanged

`_post_with_retry`'s `retry_after` honouring — attempt-count-based retry, not a deadline poll.

## Verification

* 7243 unit tests pass (9 skipped), including 29 new tests for the helper
* pre-commit clean: ruff, ruff-format, isort, pyright
* `conformance detect` adds no active findings in the touched files
* `e2e`-labelled so the harness legs run against real sources before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
