### PR TITLE
ci(sdk-review): retry on the same model when a clean sandbox posts no verdict (FND-645)

### DIFF
--- a/.github/scripts/sdk_review_dispatch.py
+++ b/.github/scripts/sdk_review_dispatch.py
@@ -30,12 +30,19 @@ have, because the review lane needs them:
     its summary to the PR, the review WAS delivered, so a later stream
     breakage is a mothership-side finalize glitch and must not red the check.
 
-One re-dispatch is allowed when the sandbox dies on a hard error that a
-different model could survive — see MAX_DISPATCH_ATTEMPTS and retry_decision().
-The retry fires only after the verdict check has come back empty, which is the
-single point where the sandbox is provably dead AND nothing was delivered;
-every other stream ending stays fail-fast, because a second reviewer would post
-a second summary on the same PR.
+One re-dispatch is allowed, in either of two classes — see
+MAX_DISPATCH_ATTEMPTS and retry_decision():
+
+  * the sandbox died on a hard error a DIFFERENT model could survive; and
+  * the sandbox reached `status=completed` and posted no verdict, which is the
+    turn ending early rather than the model failing, so attempt 2 runs the SAME
+    model.
+
+Both fire only after the verdict check has come back empty — confirmed empty,
+sharing `sdk_review_verdict_gate`'s recheck, because the comments API is not
+read-after-write consistent. That is the single point where the sandbox is
+provably finished AND nothing was delivered; every other stream ending stays
+fail-fast, because a second reviewer would post a second summary on the same PR.
 
 Environment (all supplied by the `Dispatch to mothership Rover Direct API`
 step in `.github/workflows/sdk-review.yml`):
@@ -73,6 +80,10 @@ from typing import Any, NamedTuple
 sys.path.insert(0, str(Path(__file__).parent))
 
 import sdk_review_dedupe_verdicts  # noqa: E402  (needs the sys.path bootstrap)
+from sdk_review_verdict_gate import (  # noqa: E402  (same bootstrap)
+    RECHECK_ATTEMPTS,
+    RECHECK_DELAY_S,
+)
 
 HEALTH_RETRIES = 5
 HEALTH_BACKOFF_SECONDS = 5
@@ -230,7 +241,13 @@ ORCHESTRATION.md Phase 0 step 7."""
 
 
 def attempt_model(attempt: int) -> str:
-    """Main model for this attempt — the swap that makes a retry worth booting."""
+    """Default main model for this attempt — the swap the hard-error retry needs.
+
+    Only a default: `retry_decision()` names the model for the attempt it
+    authorises, because the two retry classes differ on exactly this axis. A
+    same-model re-dispatch (the sandbox finished cleanly and said nothing) must
+    NOT be dragged onto RETRY_MAIN_MODEL — nothing about the model failed.
+    """
     return MAIN_MODEL if attempt <= 1 else RETRY_MAIN_MODEL
 
 
@@ -265,6 +282,7 @@ def build_payload(
     comment_id: str,
     gha_run_url: str,
     attempt: int = 1,
+    model: str | None = None,
     max_timeout_seconds: int = STREAM_TIMEOUT_SECONDS,
 ) -> dict[str, Any]:
     """The /api/sandbox/execute body.
@@ -272,10 +290,11 @@ def build_payload(
     `base_branch` is the PR's HEAD ref, not `main`: the sandbox clones the repo
     at the ref it is given, and a review has to read the code under review.
 
-    `attempt` > 1 is a re-dispatch after the previous sandbox died on a hard
-    error: same prompt (review is stateless — the orchestration re-reads live
-    PR state, and a prior review on the PR is handled by its delta logic),
-    different main model, and a fresh session id.
+    `attempt` > 1 is a re-dispatch: same prompt (review is stateless — the
+    orchestration re-reads live PR state, and a prior review on the PR is
+    handled by its delta logic) and a fresh session id. `model` defaults to
+    `attempt_model(attempt)`; the caller passes it explicitly so the same-model
+    retry class can keep attempt 2 on MAIN_MODEL.
     """
     return {
         "mode": "direct",
@@ -287,7 +306,7 @@ def build_payload(
         "base_branch": head_ref,
         "snapshot": "_base",
         "ai_gateway_key_name": "sdk_review",
-        "model": attempt_model(attempt),
+        "model": model or attempt_model(attempt),
         "small_fast_model": FAST_MODEL,
         "env_vars": {"CLAUDE_CODE_SUBAGENT_MODEL": FAST_MODEL},
         "prompt": build_prompt(
@@ -625,6 +644,19 @@ class Attempt(NamedTuple):
     state: SSEState
 
 
+class RetryPlan(NamedTuple):
+    """Whether to re-dispatch, why, and which main model attempt N+1 runs.
+
+    `model` is empty when `retry` is False. It cannot be derived from the
+    attempt number alone: the two retry classes differ on exactly that axis — a
+    dead sandbox needs a DIFFERENT model, a silent one needs the SAME one.
+    """
+
+    retry: bool
+    reason: str
+    model: str = ""
+
+
 def sandbox_terminated_abnormally(st: SSEState) -> bool:
     """True when the sandbox itself died, as opposed to our stream being cut.
 
@@ -654,41 +686,84 @@ def is_retryable_fault(st: SSEState) -> bool:
     return any(p in st.err_msg.lower() for p in RETRYABLE_ERR_PATTERNS)
 
 
-def retry_decision(st: SSEState, attempt: int, seconds_left: float) -> tuple[bool, str]:
-    """Whether to re-dispatch after this attempt, and the reason either way.
+def sandbox_completed_cleanly(st: SSEState) -> bool:
+    """True when the sandbox reported the terminal `complete` event, happily.
 
-    Called only once the verdict check has come back empty, so "the sandbox is
-    dead and delivered nothing" is already established. The reason is logged
-    verbatim so a run that did NOT retry says why — the part that is otherwise
-    invisible.
+    Paired with a confirmed-empty verdict this is the silent-review defect: a
+    full review streams to the log, bills a real cost, ends
+    `[complete] status=completed`, and nothing reaches the PR (run
+    32310634558 on #3276). `sdk_review_verdict_gate.py` reds it correctly one
+    step later, but nothing retried it, so the review was simply lost.
     """
-    if attempt >= MAX_DISPATCH_ATTEMPTS:
-        return False, f"already used all {MAX_DISPATCH_ATTEMPTS} attempts"
+    return st.completed and st.status == "completed" and not st.errored
+
+
+def _retry_class(st: SSEState, attempt: int) -> RetryPlan:
+    """Which retry class this ending falls into, if either, and on which model.
+
+    Called only once the verdict check has come back CONFIRMED empty, so
+    "nothing was delivered" is already established for every branch below.
+    """
+    if sandbox_completed_cleanly(st):
+        # Ranked above the cut-stream guard deliberately: `complete` IS the
+        # terminal event, so the sandbox is provably finished and will post
+        # nothing further even if our socket then died on the way out. And
+        # nothing about the MODEL failed here — the turn ended early — so the
+        # swap axis is irrelevant and attempt 2 re-runs the same one.
+        same = attempt_model(attempt)
+        return RetryPlan(
+            True,
+            "the sandbox reached status=completed and posted no verdict — the "
+            f"turn ended early, so re-dispatching on the same model ({same}) "
+            f"(attempt {attempt + 1} of {MAX_DISPATCH_ATTEMPTS})",
+            same,
+        )
     if st.stream_error:
-        return False, (
+        return RetryPlan(
+            False,
             "our stream died rather than the sandbox — it is probably still "
-            "reviewing, and a re-dispatch would post a second summary"
+            "reviewing, and a re-dispatch would post a second summary",
         )
     if not sandbox_terminated_abnormally(st):
-        return False, (
+        return RetryPlan(
+            False,
             "the stream ended without a hard error — the sandbox may still be "
-            "running, and a re-dispatch would double-review the PR"
+            "running, and a re-dispatch would double-review the PR",
         )
     if not is_retryable_fault(st):
-        return False, (
+        return RetryPlan(
+            False,
             f"code={st.err_code or 'none'} is not a known model/provider fault, "
-            "so a different model would fail the same way"
+            "so a different model would fail the same way",
         )
-    if seconds_left < RETRY_MIN_REMAINING_SECONDS:
-        return False, (
-            f"only {int(seconds_left)}s of the job budget remain, below the "
-            f"{RETRY_MIN_REMAINING_SECONDS}s a retry needs to deliver a review"
-        )
-    return True, (
+    return RetryPlan(
+        True,
         f"code={st.err_code or 'none'} looks like a model/provider fault — "
         f"re-dispatching on {RETRY_MAIN_MODEL} (attempt {attempt + 1} of "
-        f"{MAX_DISPATCH_ATTEMPTS})"
+        f"{MAX_DISPATCH_ATTEMPTS})",
+        RETRY_MAIN_MODEL,
     )
+
+
+def retry_decision(st: SSEState, attempt: int, seconds_left: float) -> RetryPlan:
+    """Whether to re-dispatch after this attempt, on what, and why either way.
+
+    The reason is logged verbatim so a run that did NOT retry says why — the
+    part that is otherwise invisible. The attempt cap and the wall-clock floor
+    bound BOTH classes; only the classification in `_retry_class` differs.
+    """
+    if attempt >= MAX_DISPATCH_ATTEMPTS:
+        return RetryPlan(False, f"already used all {MAX_DISPATCH_ATTEMPTS} attempts")
+    plan = _retry_class(st, attempt)
+    if not plan.retry:
+        return plan
+    if seconds_left < RETRY_MIN_REMAINING_SECONDS:
+        return RetryPlan(
+            False,
+            f"only {int(seconds_left)}s of the job budget remain, below the "
+            f"{RETRY_MIN_REMAINING_SECONDS}s a retry needs to deliver a review",
+        )
+    return plan
 
 
 def total_cost(attempts: Sequence[Attempt]) -> str:
@@ -947,6 +1022,41 @@ def check_verdict_posted(
     return False
 
 
+def check_verdict_posted_confirmed(
+    since: str,
+    repo: str,
+    dedupe: Callable[[], int] = _dedupe_main,
+    sleeper: Callable[[float], None] = time.sleep,
+) -> bool:
+    """`check_verdict_posted`, with a zero re-read before it is believed.
+
+    The comment listing is not read-after-write consistent — a summary written
+    seconds ago can be missing from the next GET — and a single unconfirmed
+    zero is now load-bearing twice over: it authorises a re-dispatch (which on
+    a PR whose verdict DID land would post a second summary) as well as the
+    hard-failure path.
+
+    `RECHECK_ATTEMPTS` / `RECHECK_DELAY_S` are imported from
+    `sdk_review_verdict_gate`, which reads the same comments one step later for
+    the same reason. Two copies of the threshold would drift, and this step
+    deciding "empty" while the gate decides "delivered" is precisely the
+    contradiction the shared constant prevents. The 20s is spent only on a run
+    that is already failing or about to retry.
+    """
+    for attempt in range(1, RECHECK_ATTEMPTS + 1):
+        if check_verdict_posted(since, repo, dedupe):
+            return True
+        if attempt < RECHECK_ATTEMPTS:
+            print(
+                f"No SDK_REVIEW summary attributed to this run (attempt "
+                f"{attempt}/{RECHECK_ATTEMPTS}) — re-reading in "
+                f"{RECHECK_DELAY_S:.0f}s in case the listing has not caught up.",
+                flush=True,
+            )
+            sleeper(RECHECK_DELAY_S)
+    return False
+
+
 # --- transport -------------------------------------------------------------
 
 
@@ -1050,11 +1160,15 @@ def main() -> int:
     run_start = time.monotonic()
     attempts: list[Attempt] = []
     attempt = 1
+    # Named by the previous attempt's RetryPlan; empty on the first pass. The
+    # model is NOT a function of the attempt number — see RetryPlan.
+    next_model = ""
     while True:
         # Clamp the sandbox's own cap to what is left of this step's budget.
         # Cancelling the job does not stop the sandbox, so an unclamped retry
         # started late would keep billing for up to 2h after the runner dies.
         seconds_left = DISPATCH_BUDGET_SECONDS - (time.monotonic() - run_start)
+        model = next_model or attempt_model(attempt)
         payload = build_payload(
             session_id=os.environ["SESSION_ID"],
             pr_number=pr_number,
@@ -1068,9 +1182,9 @@ def main() -> int:
             comment_id=os.environ.get("COMMENT_ID", ""),
             gha_run_url=gha_run_url,
             attempt=attempt,
+            model=model,
             max_timeout_seconds=max(1, min(STREAM_TIMEOUT_SECONDS, int(seconds_left))),
         )
-        model = attempt_model(attempt)
         print(f"[attempt {attempt}/{MAX_DISPATCH_ATTEMPTS}] dispatching on {model}")
         st = dispatch_once(base_url, token, payload, pr_number, gha_run_url)
         attempts.append(Attempt(attempt, model, st))
@@ -1087,24 +1201,30 @@ def main() -> int:
         # one would post a second summary on the same PR. This is the review
         # lane's equivalent of the resolve lane's out-of-band poll — cheaper,
         # because the reviewer's hand-off IS a PR comment we already read.
-        verdict_posted = check_verdict_posted(since, repo)
+        verdict_posted = check_verdict_posted_confirmed(since, repo)
         code, messages = decide_exit(st, verdict_posted, pr_number)
-        if code == 0:
+        if code == 0 and verdict_posted:
             break
 
-        should_retry, reason = retry_decision(
+        # A clean `complete` with no verdict exits 0 here — `decide_exit` has
+        # nothing to fault — so the retry decision has to be reached on the
+        # green path too, or the silent-review class could never fire. When it
+        # declines, the outcome is exactly what it was before: exit 0, and
+        # `sdk_review_verdict_gate.py` reds the run one step later.
+        plan = retry_decision(
             st, attempt, DISPATCH_BUDGET_SECONDS - (time.monotonic() - run_start)
         )
-        if not should_retry:
-            print(f"::warning::Not re-dispatching: {reason}")
+        if not plan.retry:
+            print(f"::warning::Not re-dispatching: {plan.reason}")
             break
-        print(f"::warning::Re-dispatching after a dead sandbox: {reason}")
+        print(f"::warning::Re-dispatching on {plan.model}: {plan.reason}")
+        next_model = plan.model
         attempt += 1
 
     if code != 0 and len(attempts) > 1:
         messages[-1] += (
-            f" (retried on {attempt_model(len(attempts))} after "
-            f"{attempt_model(1)} died; both attempts failed)"
+            f" (retried on {attempts[-1].model} after {attempts[0].model}; "
+            "both attempts failed)"
         )
 
     # Export the outputs before printing the decision — the failure paths we

--- a/.github/scripts/tests/test_sdk_review_dispatch.py
+++ b/.github/scripts/tests/test_sdk_review_dispatch.py
@@ -27,6 +27,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 import mothership_terminate_session as mts  # noqa: E402  (sys.path bootstrap)
 import sdk_review_dispatch as sd  # noqa: E402  (needs the sys.path bootstrap)
+import sdk_review_verdict_gate as vg  # noqa: E402  (sys.path bootstrap)
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 WORKFLOW = REPO_ROOT / ".github/workflows/sdk-review.yml"
@@ -831,9 +832,10 @@ def test_a_known_code_is_never_overridden_by_the_message_patterns():
 
 
 def test_retry_fires_on_a_dead_sandbox_with_a_retryable_code():
-    should, reason = sd.retry_decision(_errored("429"), 1, 6000)
-    assert should is True
-    assert sd.RETRY_MAIN_MODEL in reason and "attempt 2 of 2" in reason
+    plan = sd.retry_decision(_errored("429"), 1, 6000)
+    assert plan.retry is True
+    assert plan.model == sd.RETRY_MAIN_MODEL
+    assert sd.RETRY_MAIN_MODEL in plan.reason and "attempt 2 of 2" in plan.reason
 
 
 def test_retry_fires_when_complete_carries_status_error():
@@ -843,12 +845,12 @@ def test_retry_fires_when_complete_carries_status_error():
         )
     )
     assert sd.sandbox_terminated_abnormally(st) is True
-    assert sd.retry_decision(st, 1, 6000)[0] is True
+    assert sd.retry_decision(st, 1, 6000).retry is True
 
 
 def test_only_one_retry_is_ever_spent():
-    should, reason = sd.retry_decision(_errored("429"), 2, 6000)
-    assert should is False and "all 2 attempts" in reason
+    plan = sd.retry_decision(_errored("429"), 2, 6000)
+    assert plan.retry is False and "all 2 attempts" in plan.reason
     assert sd.MAX_DISPATCH_ATTEMPTS == 2
 
 
@@ -856,26 +858,26 @@ def test_a_cut_stream_never_retries_because_the_reviewer_may_still_be_working():
     """A second reviewer would post a second summary on the same PR."""
     st = _stream(*_event("started", {"session_id": "s"}))
     st.stream_error = "read timed out"
-    should, reason = sd.retry_decision(st, 1, 6000)
-    assert should is False and "post a second summary" in reason
+    plan = sd.retry_decision(st, 1, 6000)
+    assert plan.retry is False and "post a second summary" in plan.reason
 
 
 def test_a_clean_eof_without_complete_never_retries():
     st = _stream(*_event("started", {"session_id": "s"}))
-    should, reason = sd.retry_decision(st, 1, 6000)
-    assert should is False and "may still be running" in reason
+    plan = sd.retry_decision(st, 1, 6000)
+    assert plan.retry is False and "may still be running" in plan.reason
 
 
 def test_an_unrecognised_cause_stays_fail_fast():
-    should, reason = sd.retry_decision(_errored("401", "auth"), 1, 6000)
-    assert should is False and "not a known model/provider fault" in reason
+    plan = sd.retry_decision(_errored("401", "auth"), 1, 6000)
+    assert plan.retry is False and "not a known model/provider fault" in plan.reason
 
 
 def test_a_retry_is_refused_below_the_wall_clock_floor():
     """Below the floor a second sandbox would be killed mid-review."""
-    should, reason = sd.retry_decision(_errored("429"), 1, 600)
-    assert should is False and "600s of the job budget remain" in reason
-    assert sd.retry_decision(_errored("429"), 1, sd.RETRY_MIN_REMAINING_SECONDS)[0]
+    plan = sd.retry_decision(_errored("429"), 1, 600)
+    assert plan.retry is False and "600s of the job budget remain" in plan.reason
+    assert sd.retry_decision(_errored("429"), 1, sd.RETRY_MIN_REMAINING_SECONDS).retry
 
 
 def test_every_refusal_says_why():
@@ -885,9 +887,157 @@ def test_every_refusal_says_why():
         (_errored("401"), 1, 6000),
         (_errored("429"), 1, 10),
         (_stream(*_event("started", {})), 1, 6000),
+        (_completed("0.83"), 2, 6000),
+        (_completed("0.83"), 1, 10),
     ):
-        should, reason = sd.retry_decision(st, attempt, left)
-        assert should is False and reason.strip()
+        plan = sd.retry_decision(st, attempt, left)
+        assert plan.retry is False and plan.reason.strip()
+
+
+# ---------------------------------------------------------------------------
+# re-dispatch on the SAME model when a clean sandbox delivers no verdict
+# (FND-645)
+# ---------------------------------------------------------------------------
+
+
+def test_a_clean_completed_sandbox_that_said_nothing_retries_on_the_same_model():
+    """`complete` IS the terminal event, so the sandbox is provably finished.
+
+    Nothing about the model failed — the turn ended early — so dragging in
+    RETRY_MAIN_MODEL would spend the expensive lane on a fault it cannot fix.
+    """
+    st = _completed("3.307718")
+    assert sd.sandbox_completed_cleanly(st) is True
+    assert sd.sandbox_terminated_abnormally(st) is False  # why it never retried
+
+    plan = sd.retry_decision(st, 1, 6000)
+    assert plan.retry is True
+    assert plan.model == sd.MAIN_MODEL != sd.RETRY_MAIN_MODEL
+    assert "posted no verdict" in plan.reason and "same model" in plan.reason
+
+
+def test_the_same_model_retry_still_honours_the_shared_retry_bounds():
+    """Constraint: an extra entry condition only — the knobs do not move."""
+    st = _completed("1.0")
+    assert sd.retry_decision(st, sd.MAX_DISPATCH_ATTEMPTS, 6000).retry is False
+    assert sd.retry_decision(st, 1, sd.RETRY_MIN_REMAINING_SECONDS - 1).retry is False
+    assert sd.retry_decision(st, 1, sd.RETRY_MIN_REMAINING_SECONDS).retry is True
+
+
+def test_a_complete_carrying_a_non_completed_status_is_not_the_clean_class():
+    """That is a dead sandbox — the model-swap class owns it."""
+    st = _stream(
+        *_event(
+            "complete", {"status": "error", "error": {"code": "500", "message": ""}}
+        )
+    )
+    assert sd.sandbox_completed_cleanly(st) is False
+    assert sd.retry_decision(st, 1, 6000).model == sd.RETRY_MAIN_MODEL
+
+
+def test_a_terminal_complete_outranks_a_socket_death_on_the_way_out():
+    """The sandbox already said it was finished; a late transport error cannot
+    make it live again, so this is still the silent-review class."""
+    st = _completed("0.83")
+    st.stream_error = "connection reset by peer"
+    plan = sd.retry_decision(st, 1, 6000)
+    assert plan.retry is True and plan.model == sd.MAIN_MODEL
+
+
+def test_the_same_model_retry_keeps_every_other_dispatch_axis(
+    dispatch_env, monkeypatch
+):
+    """Fresh session id, own source_id, recorded attempt — only the model differs."""
+    seen = _record_dispatches(
+        monkeypatch, [_completed("3.30"), _completed("0.83")], [False, True]
+    )
+
+    assert sd.main() == 0
+    assert [p["model"] for p in seen] == [sd.MAIN_MODEL, sd.MAIN_MODEL]
+    assert [p["session_id"] for p in seen] == ["base-id", "base-id-retry1"]
+    assert seen[1]["source_id"].endswith("-retry1")
+    assert seen[1]["metadata"]["attempt"] == 2
+    assert seen[1]["small_fast_model"] == sd.FAST_MODEL
+
+
+def test_main_does_not_retry_a_clean_run_that_did_deliver(dispatch_env, monkeypatch):
+    """The regression this class could most easily cause: a double review."""
+    seen = _record_dispatches(monkeypatch, [_completed("0.83")], [True])
+
+    assert sd.main() == 0
+    assert len(seen) == 1
+    assert _outputs(dispatch_env)["final_status"] == "completed"
+
+
+def test_main_exits_green_when_the_silent_retry_is_also_silent(
+    dispatch_env, monkeypatch, capsys
+):
+    """Unchanged outcome once the attempts are spent — `sdk_review_verdict_gate`
+    still owns turning that silence into a red check one step later."""
+    seen = _record_dispatches(
+        monkeypatch, [_completed("3.30"), _completed("2.10")], [False, False]
+    )
+
+    assert sd.main() == 0
+    assert len(seen) == 2
+    assert "Not re-dispatching: already used all 2 attempts" in capsys.readouterr().out
+    assert _outputs(dispatch_env)["final_cost"] == "5.4"
+
+
+def test_a_cut_stream_with_no_verdict_still_never_retries(dispatch_env, monkeypatch):
+    """The double-review guard must not regress: no `complete`, so the reviewer
+    may still be working, and a second one would post a second summary."""
+    cut = _stream(*_event("started", {"session_id": "s"}))
+    cut.stream_error = "read timed out"
+    seen = _record_dispatches(monkeypatch, [cut], [False])
+
+    assert sd.main() == 1
+    assert len(seen) == 1
+
+
+# --- the confirmed-empty verdict read --------------------------------------
+
+
+def test_an_empty_verdict_is_re_read_before_it_is_believed(monkeypatch):
+    """The comments API is not read-after-write consistent, and this zero now
+    authorises a re-dispatch as well as the failure path."""
+    reads = []
+    slept = []
+    monkeypatch.setattr(
+        sd, "check_verdict_posted", lambda *_a, **_k: (reads.append(1), False)[1]
+    )
+
+    assert sd.check_verdict_posted_confirmed("s", "o/r", sleeper=slept.append) is False
+    assert len(reads) == sd.RECHECK_ATTEMPTS
+    assert slept == [sd.RECHECK_DELAY_S] * (sd.RECHECK_ATTEMPTS - 1)
+
+
+def test_a_verdict_found_on_the_first_read_costs_no_delay(monkeypatch):
+    reads = []
+    slept = []
+    monkeypatch.setattr(
+        sd, "check_verdict_posted", lambda *_a, **_k: (reads.append(1), True)[1]
+    )
+
+    assert sd.check_verdict_posted_confirmed("s", "o/r", sleeper=slept.append) is True
+    assert len(reads) == 1 and slept == []
+
+
+def test_a_late_landing_verdict_is_caught_by_the_recheck(monkeypatch):
+    """The read-after-write lag this exists for: retrying here would double-review."""
+    answers = [False, True]
+    monkeypatch.setattr(sd, "check_verdict_posted", lambda *_a, **_k: answers.pop(0))
+
+    assert (
+        sd.check_verdict_posted_confirmed("s", "o/r", sleeper=lambda _s: None) is True
+    )
+
+
+def test_the_recheck_threshold_is_the_gate_s_own_not_a_second_copy():
+    """Two copies would drift, and this step deciding `empty` while the gate
+    decides `delivered` is the contradiction sharing them prevents."""
+    assert sd.RECHECK_ATTEMPTS is vg.RECHECK_ATTEMPTS
+    assert sd.RECHECK_DELAY_S is vg.RECHECK_DELAY_S
 
 
 # --- the cost trail --------------------------------------------------------
@@ -996,7 +1146,7 @@ def _record_dispatches(monkeypatch, states, verdicts):
 
     monkeypatch.setattr(sd, "dispatch_once", fake_dispatch)
     monkeypatch.setattr(
-        sd, "check_verdict_posted", lambda *_a, **_k: verdicts[len(seen) - 1]
+        sd, "check_verdict_posted_confirmed", lambda *_a, **_k: verdicts[len(seen) - 1]
     )
     return seen
 
@@ -1017,7 +1167,7 @@ def test_main_re_dispatches_once_on_a_dead_sandbox(dispatch_env, monkeypatch, ca
     assert out["final_status"] == "completed"
     assert out["final_cost"] == "2.4"  # attempt 1 reported none
     assert "### Attempts" in (dispatch_env / "summary").read_text()
-    assert "Re-dispatching after a dead sandbox" in capsys.readouterr().out
+    assert f"Re-dispatching on {sd.RETRY_MAIN_MODEL}" in capsys.readouterr().out
 
 
 def test_main_does_not_retry_once_the_verdict_is_on_the_pr(dispatch_env, monkeypatch):
@@ -1036,7 +1186,7 @@ def test_main_reports_both_models_when_the_retry_also_fails(
 
     assert sd.main() == 1
     printed = capsys.readouterr().out
-    assert f"retried on {sd.RETRY_MAIN_MODEL} after {sd.MAIN_MODEL} died" in printed
+    assert f"retried on {sd.RETRY_MAIN_MODEL} after {sd.MAIN_MODEL}" in printed
     assert _outputs(dispatch_env)["final_status"] == "500"
 
 


### PR DESCRIPTION
Closes FND-645.

## The defect

`sdk_review_dispatch.py` gated every retry on `sandbox_terminated_abnormally()`:

```python
def sandbox_terminated_abnormally(st: SSEState) -> bool:
    return st.errored or (st.completed and st.status != "completed")
```

A sandbox that reaches `status=completed` and posts no verdict returns `False`, so `retry_decision()` declined it with *"the sandbox may still be running, and a re-dispatch would double-review the PR"*.

That reasoning holds for a cut stream. It does not hold here: `complete` **is** the terminal event, so the sandbox is provably finished and will post nothing further.

Observed on PR #3276 — a full delta re-review streamed to the log, ending "All guardrails clean", then `[complete] status=completed cost_usd=3.307718` with no summary comment. `sdk_review_verdict_gate.py` redded the run correctly, but nothing retried it, so the review was lost and a human had to re-tag.

FND-643's model-swap re-dispatch closed the three hard-sandbox-death failures observed the same day; this was the fourth and last.

## The fix

A second retry class, on the **same** model. Nothing about the model failed — the turn ended early — so `RETRY_MAIN_MODEL` must not be dragged in.

**`retry_decision()` now returns a `RetryPlan(retry, reason, model)`** instead of `(bool, str)`. The model had to leave `attempt_model(attempt)` because the two classes differ on exactly that axis: a dead sandbox needs a *different* model, a silent one needs the *same* one. `build_payload()` takes `model=` explicitly; `attempt_model()` remains the default for the hard-error class.

Classification moved into `_retry_class()`, with the attempt cap and the `RETRY_MIN_REMAINING_SECONDS` floor applied once in `retry_decision()` so they bound both classes and cannot drift apart.

**Ordering worth a second look:** the clean-completed check is ranked *above* the `stream_error` guard, not below it. If `complete status=completed` arrived and our socket then died on the way out, the sandbox has already said it is finished — a late transport error cannot make it live again — so that is still the silent-review class. Covered by `test_a_terminal_complete_outranks_a_socket_death_on_the_way_out`.

## Gated on a confirmed-empty verdict

`check_verdict_posted()` is a single read, and the comment listing is not read-after-write consistent. That zero is now load-bearing twice over: it authorises a re-dispatch (which on a PR whose verdict *did* land would post a second summary) as well as the hard-failure path.

New `check_verdict_posted_confirmed()` re-reads a zero before believing it, importing `RECHECK_ATTEMPTS` / `RECHECK_DELAY_S` from `sdk_review_verdict_gate` — which reads the same comments one step later for the same reason — rather than restating the threshold. A test asserts identity (`is`) against the gate's constants so a second copy cannot creep back in; this step deciding "empty" while the gate decides "delivered" is the contradiction sharing them prevents.

`check_verdict_posted()` itself is untouched and still a single read. The 20s lands only on a run that is already failing or about to retry — the happy path returns on the first read.

## The `main()` loop

The break condition moved from `if code == 0` to `if code == 0 and verdict_posted`. A clean `complete` with no verdict exits 0 from `decide_exit()` — it has nothing to fault — so the retry decision had to become reachable on the green path, or this class could never fire. `code != 0` implies `verdict_posted is False` (that is what `fail_or_warn` does), so the two conditions are equivalent everywhere except the case this PR is about.

**When the retry declines, the outcome is exactly what it was before:** exit 0, and `sdk_review_verdict_gate.py` reds the run one step later.

## Deliberately unchanged

An extra entry condition only. `RETRY_MIN_REMAINING_SECONDS`, `MAX_DISPATCH_ATTEMPTS`, `attempt_session_id`'s `-retry1` suffix, the per-attempt cost trail and the four `$GITHUB_OUTPUT` keys all stay as they were. `mothership_terminate_session.py` still walks the same session-id ladder, so a cancel mid-retry still stops whichever attempt is live.

## Tests

13 new cases in `.github/scripts/tests/test_sdk_review_dispatch.py`, including the three the issue names:

- clean-completed + no verdict → retry on the **same** model;
- clean-completed + verdict posted → no retry (the double review this class could most easily cause);
- cut stream + no verdict → **still** no retry — the existing double-review guard must not regress.

Plus: the shared bounds hold for the new class, a `complete` carrying a non-`completed` status still routes to the model-swap class, the recheck stops early on a late-landing verdict, and the threshold is the gate's own object.

`112 passed` in that file; `656 passed` across the review/resolve/terminate script tests. Pre-commit clean (ruff, ruff-format, isort, pyright).

## Out of scope

The premature RPC disconnect (`ReadableStream received over RPC disconnected prematurely`) still fails both lanes unretried. Unlike this one, the sandbox may still be alive behind the dropped RPC, so it needs a bounded out-of-band verdict poll rather than a new pattern here — its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
