### PR TITLE
ci(e2e): one connector dispatch per commit, however many events fire (FND-646)

### DIFF
--- a/.github/actions/e2e-apps/action.yaml
+++ b/.github/actions/e2e-apps/action.yaml
@@ -162,9 +162,67 @@ runs:
           exit 1
         fi
 
+    # ── One live dispatch per (dispatching SHA, app) ─────────────────────────
+    # GitHub can emit several pull_request events for one head SHA — observed as
+    # `opened` plus `labeled e2e` TWICE, one second apart, which spawned three
+    # full PR Checks runs that each dispatched every connector and then fought
+    # over the same cloud tenants (FND-646). Nothing in a workflow `if:` can tell
+    # two identical `labeled` events apart, so the duplication is killed here
+    # instead: an atomic ref CAS on refs/e2e-dispatch/<app>/<sha>, the same
+    # primitive as the tenant lease.
+    #
+    # Deliberately NOT `concurrency: cancel-in-progress`. The dispatch below is
+    # fire-and-forget, so cancelling this run does not cancel the connector run
+    # it already started — and a queueing group holds exactly ONE pending run,
+    # so a third arrival is evicted with no log at all (FND-218).
+    #
+    # Callback mode only, and that is a correctness constraint rather than
+    # scope: in poll mode THIS job's conclusion is the verdict, so a skipped
+    # dispatch would be a vacuous green that can mask the winner's real result on
+    # the same SHA. In callback mode the verdict is the check run on the SHA —
+    # created once, completed by the connector, and polled by every duplicate
+    # run's own connector gate, which is why skipping loses nothing. Poll mode's
+    # only caller also dispatches into a hermetic kind cluster, so it has no
+    # tenant to contend for.
+    #
+    # continue-on-error plus `!= 'false'` below: every guard failure must leave
+    # the dispatch happening. A PR whose e2e silently never ran is far worse than
+    # one that pays for a duplicate — which is exactly the pre-existing
+    # behaviour. Needs contents:write (the claim ref), checks:read (has this SHA
+    # already been dispatched?) and pull-requests:read (the stale-claim prune).
+    - name: Claim the dispatch slot for this SHA
+      id: dispatch_guard
+      if: inputs.wait-mode == 'callback'
+      continue-on-error: true
+      shell: bash
+      env:
+        # The calling job's own token, scoped to THIS repo — the claim refs live
+        # here, next to the SHA they key on. Not checks-app-token: that exists
+        # so the check run is owned by the App the connector's callback uses,
+        # which has nothing to do with ref writes.
+        GH_TOKEN: ${{ github.token }}
+        REPO: ${{ github.repository }}
+        SHA: ${{ inputs.check-sha }}
+        APP: ${{ inputs.repo-name }}
+        NAME: ${{ inputs.check-run-name }}
+      run: |
+        set -euo pipefail
+        python3 .github/scripts/e2e_dispatch_guard.py \
+          --repo "$REPO" \
+          --sha "$SHA" \
+          --app "$APP" \
+          --check-run-name "$NAME" \
+          --run-id "$GITHUB_RUN_ID" \
+          --run-attempt "$GITHUB_RUN_ATTEMPT"
+
+    # Gated on the guard, so a duplicate run creates NO second check run on the
+    # SHA: the winner's check is the one the connector completes and the one
+    # every duplicate run's connector gate polls. A second in_progress check with
+    # the same name would have nothing to complete it and would hang until the
+    # watchdog swept it.
     - name: Create pending check run
       id: create_check
-      if: inputs.wait-mode == 'callback'
+      if: inputs.wait-mode == 'callback' && steps.dispatch_guard.outputs.claimed != 'false'
       shell: bash
       env:
         # Fleet App token (this repo), NOT github.token — the connector's
@@ -198,7 +256,7 @@ runs:
     # the gate/watchdog timeout rather than an immediate job failure.
     - name: Dispatch connector workflow
       id: return_dispatch_callback
-      if: inputs.wait-mode == 'callback'
+      if: inputs.wait-mode == 'callback' && steps.dispatch_guard.outputs.claimed != 'false'
       continue-on-error: true
       uses: codex-/return-dispatch@85e564d60eaec3cc4aca885373d510cfe4bd5b19 # v4.0.1
       with:

--- a/.github/actions/e2e-apps/action.yaml
+++ b/.github/actions/e2e-apps/action.yaml
@@ -188,7 +188,9 @@ runs:
     # continue-on-error plus `!= 'false'` below: every guard failure must leave
     # the dispatch happening. A PR whose e2e silently never ran is far worse than
     # one that pays for a duplicate — which is exactly the pre-existing
-    # behaviour. Needs contents:write (the claim ref), checks:read (has this SHA
+    # behaviour. Needs contents:write (the claim ref), actions:read (is a
+    # claimant that has not dispatched yet still alive, or did it die?),
+    # checks:read (has this SHA
     # already been dispatched?) and pull-requests:read (the stale-claim prune).
     - name: Claim the dispatch slot for this SHA
       id: dispatch_guard

--- a/.github/scripts/e2e_dispatch_guard.py
+++ b/.github/scripts/e2e_dispatch_guard.py
@@ -1,0 +1,842 @@
+#!/usr/bin/env python3
+"""At most one LIVE connector e2e dispatch per ``(dispatching SHA, app)``.
+
+Why this exists
+---------------
+GitHub can emit several ``pull_request`` events for one head SHA. Observed on
+PR #3306 (FND-646): ``opened`` at 01:17:18, then ``labeled e2e`` at 01:17:19 and
+again at 01:17:20 — three events, one commit. Each spawned a full ``PR Checks``
+run, each satisfied the connector gate independently, and each dispatched every
+connector repo. One commit produced three ``Tests`` runs in
+``atlan-openapi-app``, and those three runs then fought over the same three
+cloud tenants: the winner ran the suite in ten minutes, and the two losers split
+the freed leases between them and blocked on each other for the full 90-minute
+wait budget.
+
+The amplification is what this module removes, at source. The duplicate ``PR
+Checks`` runs still happen — GitHub creates them and nothing in a workflow's
+``if:`` can tell two identical ``labeled`` events apart — but only the first one
+to get here reaches a tenant.
+
+Why not ``concurrency:``
+-----------------------
+``cancel-in-progress`` was considered and rejected. The dispatch is
+fire-and-forget (``e2e-apps`` in ``wait-mode: callback`` creates the check run,
+dispatches, and exits), so cancelling the SDK-side run does not cancel the
+connector run it already started — it only orphans it, and the tenant contention
+is unchanged. And a queueing group is worse than useless here: GitHub holds
+exactly ONE pending run per group, so a third arrival cancels the waiter with no
+log output at all. That is FND-218, the failure the tenant lease exists to
+replace; re-adding it in front of the dispatch would reintroduce it.
+
+Cancellation is also unsafe as a steady-state mechanism, which is worth stating
+because it is the obvious first idea: ``prepare-tenant`` carries ``if:
+always()``, so a cancelled connector run still finishes installing the app onto
+the tenants it had already leased on its way out. Cancelling is an acceptable
+manual escape hatch. It is not a design.
+
+The protocol
+------------
+One ref per ``(app, sha)``, with a FIXED name::
+
+    refs/e2e-dispatch/<app>/<sha>
+
+``POST /git/refs`` on a name that already exists returns 422, and that 422 is an
+atomic test-and-set evaluated by GitHub: of N simultaneous callers exactly one
+sees 201, whatever the order. Same primitive as the ``(app, cloud)`` tenant
+lease (``.github/actions/e2e-tenant-lease``), deliberately — the precedent and
+the failure modes are already understood, and the alternative (probe the SHA for
+an existing ``Connector E2E run / <app>`` check and skip if present) is
+read-then-act with no atomicity. The observed gap between the duplicate dispatch
+steps was 12 seconds, so a probe would have held here; it is simply not the
+thing to build when a CAS is available.
+
+The ref points at a **blob** recording who claimed it. A ref can target a blob,
+which is what lets one atomic creation both take the slot and say who took it.
+
+"At most one LIVE dispatch", not "one ever"
+------------------------------------------
+A claim that never expires would be a footgun: re-running the dispatch job (the
+normal way to retry a transient dispatch failure) would silently no-op, and e2e
+for that commit could never be re-run at all. So an existing claim is not
+automatically final. A contender that finds the slot taken resolves it as:
+
+* claimed by **this run** (any attempt) — proceed. This is a job re-run, and the
+  operator asking for a re-run is asking for a re-dispatch.
+* claimed by another run, and a ``Connector E2E run / <app>`` check run exists on
+  this SHA — **skip**. The dispatch happened; its verdict is that check, and the
+  connector gate on every one of the duplicate runs polls the same check and
+  reports the same answer. Nothing is lost by not dispatching again.
+* claimed by another run with no such check, and that run is **still live** —
+  skip. A peer is between its claim and its check creation, a window of one API
+  call.
+* claimed by another run with no such check, and that run is **over** — reap the
+  claim and take it. The claimer died before dispatching, so without this the
+  slot would stay taken by a run that will never dispatch, and this SHA would
+  have no e2e at all.
+
+The check run is the "did it dispatch" evidence rather than a second field in the
+blob because it already exists, is created immediately before the dispatch by the
+claimer, and is already swept when abandoned (``e2e-callback-watchdog.yml``).
+Reusing it keeps the claim a single write.
+
+Failure posture: fail OPEN
+--------------------------
+Every failure to operate the guard — no ref-write permission, a rate limit, an
+unparseable answer — proceeds with the dispatch and prints a ``::warning::``.
+That direction is deliberate and it is the opposite of the tenant lease's:
+
+* The lease protects a shared mutable tenant, so proceeding unserialised risks
+  two installers on one tenant. It fails open only on permissions, and never on
+  a rate limit.
+* This guard protects only against *duplicate* dispatches. Failing closed would
+  drop the single dispatch that was supposed to happen, and a PR whose e2e
+  silently never ran is far worse than a PR that pays for two e2e runs — which
+  is, in any case, exactly the pre-existing behaviour.
+
+So the worst case for a broken guard is the status quo.
+
+Pruning
+-------
+Claim refs are per-SHA, so the namespace would otherwise grow without bound (the
+merge queue dispatches on every SDK merge). On the claiming path only, this
+prunes its own app's claims: a claim is deletable when its SHA is not the head of
+any open PR *and* that SHA's ``Connector E2E run / <app>`` check is completed or
+absent — i.e. when no dispatch for it can still be live. Bounded pages, a bounded
+number of deletes per invocation, and every failure is a warning: pruning is
+housekeeping and must never be able to fail a dispatch.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+
+# Outside refs/heads and refs/tags on purpose: a branch would fire `push` events
+# and show up in the branch list, a tag would pollute the release surface. A
+# custom namespace is inert — nothing watches it.
+REF_NAMESPACE = "e2e-dispatch"
+
+# The only GitHub run status that means "over". Everything else — queued,
+# in_progress, requested, waiting, pending — is treated as live, so an
+# unfamiliar future status errs towards leaving a peer's claim alone.
+_COMPLETED = "completed"
+
+# Transport-level retries (curl could not complete the request, or GitHub
+# answered 5xx). Few and short: this runs once per dispatch, not in a poll loop,
+# and every failure path here fails open anyway.
+_TRANSPORT_ATTEMPTS = 3
+_TRANSPORT_BACKOFF_SECONDS = 2
+
+# Pruning budget. Five pages of 100 covers ~500 claims for one app, which is far
+# past the steady state the prune itself maintains; the delete cap bounds the
+# API cost of the first invocation after a long gap without it.
+_PRUNE_MAX_PAGES = 5
+_PRUNE_MAX_DELETES = 25
+_OPEN_PR_MAX_PAGES = 5
+
+_SAFE_SLUG_CHARS = frozenset("abcdefghijklmnopqrstuvwxyz0123456789._-")
+_SHA_RE = re.compile(r"\A[0-9a-f]{7,64}\Z")
+
+
+def slug(value: str, *, default: str = "app") -> str:
+    """Reduce a free-text key to one safe git ref path component.
+
+    Deliberately narrower than git's own rules: the app name comes from a
+    workflow input, and a ref name is the one place where "mostly valid" turns
+    into a 422 nobody expected — and here a 422 *means something else*.
+    """
+    cleaned = "".join(
+        char if char in _SAFE_SLUG_CHARS else "-" for char in value.strip().lower()
+    )
+    while ".." in cleaned:
+        cleaned = cleaned.replace("..", "-")
+    cleaned = cleaned.strip("-._")
+    while cleaned.endswith(".lock"):
+        cleaned = cleaned[: -len(".lock")].strip("-._")
+    return cleaned or default
+
+
+def claim_ref(app: str, sha: str) -> str:
+    """The single ref every contender for one ``(app, sha)`` dispatch races for.
+
+    App first, SHA second, so ``git/matching-refs/e2e-dispatch/<app>`` lists one
+    app's claims and the prune never has to walk the whole namespace.
+    """
+    return f"refs/{REF_NAMESPACE}/{slug(app)}/{sha}"
+
+
+def sha_of(ref: str) -> str:
+    """The SHA component of a claim ref, or "" if it does not look like one."""
+    tail = ref.rsplit("/", 1)[-1].strip().lower()
+    return tail if _SHA_RE.match(tail) else ""
+
+
+@dataclass(frozen=True)
+class Claimant:
+    """Who claimed a dispatch slot, read back from the blob the ref points at."""
+
+    run_id: int
+    attempt: int
+    claimed_at: float | None
+
+    def run_url(self, repo: str) -> str:
+        return f"https://github.com/{repo}/actions/runs/{self.run_id}"
+
+    def is_my_run(self, run_id: int) -> bool:
+        """Same RUN, any attempt.
+
+        Attempt is recorded for the log, not for the decision: a re-run of the
+        dispatch job bumps the attempt and must be allowed to dispatch again,
+        which is the whole reason this compares run ids only.
+        """
+        return self.run_id == run_id
+
+
+@dataclass(frozen=True)
+class Response:
+    """One API answer. Headers are carried because rate-limit detection needs
+    them."""
+
+    status: int
+    headers: dict[str, str]
+    body: object | None
+
+    @property
+    def message(self) -> str:
+        return self.body.get("message", "") if isinstance(self.body, dict) else ""
+
+
+class GuardUnavailable(Exception):
+    """The guard could not be operated, so the dispatch proceeds unguarded.
+
+    An exception rather than a return value so no call site can forget that the
+    failure direction here is "dispatch anyway" — see the module docstring.
+    """
+
+
+def run(cmd: list[str], **kwargs) -> subprocess.CompletedProcess:
+    """Single seam so tests can stub the HTTP client."""
+    return subprocess.run(cmd, **kwargs)
+
+
+def _parse_http(raw: str, label: str) -> Response:
+    """Split a ``curl -i`` response into status, headers and parsed body."""
+    text = raw.replace("\r\n", "\n")
+    if "\n\n" not in text:
+        raise GuardUnavailable(f"unexpected response for {label}: {text[:300]!r}")
+    header_block, _, body = text.partition("\n\n")
+    lines = header_block.splitlines()
+    try:
+        status_code = int(lines[0].split()[1])
+    except (IndexError, ValueError):
+        raise GuardUnavailable(
+            f"could not parse the HTTP status line for {label}: "
+            f"{(lines[0] if lines else '')!r}"
+        ) from None
+    headers: dict[str, str] = {}
+    for line in lines[1:]:
+        name, sep, value = line.partition(":")
+        if sep:
+            headers[name.strip().lower()] = value.strip()
+
+    if not body.strip():
+        return Response(status_code, headers, None)
+    try:
+        return Response(status_code, headers, json.loads(body))
+    except json.JSONDecodeError:
+        # A non-JSON body (an HTML error page from a proxy) must not crash the
+        # caller before it can report the status code, which is the part that
+        # decides what happens next.
+        return Response(status_code, headers, None)
+
+
+def gh_request(
+    method: str,
+    path: str,
+    payload: dict | None = None,
+    *,
+    sleep=time.sleep,
+) -> Response:
+    """Call the GitHub API, returning the status rather than raising on 4xx.
+
+    curl, not ``gh api``, for the same reason ``e2e_tenant_lease.py`` and
+    ``poll_check_runs_gate.py`` use it: ``gh api`` treats every non-2xx as a
+    command failure and prints its own diagnostic instead of the response. Here
+    the non-2xx codes are the entire mechanism — 422 on ref creation IS the slot
+    being taken.
+    """
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    if not token:
+        raise GuardUnavailable("GH_TOKEN (or GITHUB_TOKEN) is not set")
+
+    cmd = [
+        "curl",
+        "-sS",
+        "-i",
+        "--max-time",
+        "30",
+        "-X",
+        method,
+        # Authorization read from stdin (-K -) rather than -H so the token never
+        # appears in curl's argv, where anything else on the runner could read it
+        # from /proc/<pid>/cmdline. Re-supplied per attempt below because stdin
+        # is consumed per process — a retry reusing only the argv would send an
+        # unauthenticated request and read the 401 as a permission denial.
+        "-K",
+        "-",
+        "-H",
+        "Accept: application/vnd.github+json",
+        "-H",
+        "X-GitHub-Api-Version: 2022-11-28",
+    ]
+    config = f'header = "Authorization: Bearer {token}"\n'
+    if payload is not None:
+        cmd += ["-H", "Content-Type: application/json", "-d", json.dumps(payload)]
+    cmd.append(f"https://api.github.com/{path}")
+
+    label = f"{method} {path}"
+    for attempt in range(1, _TRANSPORT_ATTEMPTS + 1):
+        result = run(cmd, input=config, capture_output=True, text=True, check=False)
+        last = attempt == _TRANSPORT_ATTEMPTS
+
+        if result.returncode != 0:
+            if last:
+                raise GuardUnavailable(
+                    f"curl failed for {label} after {_TRANSPORT_ATTEMPTS} "
+                    f"attempts: {result.stderr.strip()}"
+                )
+        else:
+            response = _parse_http(result.stdout, label)
+            if response.status < 500 or last:
+                return response
+
+        sleep(_TRANSPORT_BACKOFF_SECONDS * 2 ** (attempt - 1))
+
+    raise GuardUnavailable(f"exhausted transport attempts for {label}")
+
+
+def _rate_limited(response: Response) -> bool:
+    """Is this a rate limit rather than a permission problem?
+
+    Both arrive as 403. The distinction changes only the wording of the warning
+    here — both fail open — but conflating them makes a rate-limited hour look
+    like a misconfigured permission, which is a diagnosis-hostile lie.
+    """
+    if response.status == 429:
+        return True
+    if response.status != 403:
+        return False
+    if response.headers.get("x-ratelimit-remaining") == "0":
+        return True
+    if "retry-after" in response.headers:
+        return True
+    message = response.message.lower()
+    return "rate limit" in message or "abuse detection" in message
+
+
+def _denied(response: Response) -> bool:
+    """A genuine permission answer. GitHub 404s resources it will not admit
+    exist, so 404 counts, but a rate limit explicitly does not."""
+    return response.status in (401, 403, 404) and not _rate_limited(response)
+
+
+def create_claim_blob(repo: str, run_id: int, attempt: int, now: float) -> str:
+    """Write the claim record the ref will point at. Returns the blob sha."""
+    payload = {"run_id": run_id, "attempt": attempt, "claimed_at": now}
+    response = gh_request(
+        "POST",
+        f"repos/{repo}/git/blobs",
+        {"content": json.dumps(payload), "encoding": "utf-8"},
+    )
+    if (
+        response.status in (200, 201)
+        and isinstance(response.body, dict)
+        and response.body.get("sha")
+    ):
+        return str(response.body["sha"])
+    raise GuardUnavailable(
+        f"could not write the dispatch claim record in {repo}: "
+        f"HTTP {response.status} {response.message!r}"
+        + (" (rate-limited)" if _rate_limited(response) else "")
+    )
+
+
+def try_claim(repo: str, ref: str, blob_sha: str) -> str:
+    """One atomic attempt. Returns "claimed" or "taken"; raises otherwise.
+
+    The 422 is not an error path bolted on — it is the lock.
+    """
+    response = gh_request(
+        "POST", f"repos/{repo}/git/refs", {"ref": ref, "sha": blob_sha}
+    )
+    if response.status in (200, 201):
+        return "claimed"
+    if response.status == 422 and "already exists" in response.message.lower():
+        return "taken"
+    raise GuardUnavailable(
+        f"could not create the dispatch claim {ref} in {repo}: "
+        f"HTTP {response.status} {response.message!r}"
+        + (" (rate-limited)" if _rate_limited(response) else "")
+    )
+
+
+def read_claim_target(repo: str, ref: str) -> str | None:
+    """The sha the claim ref points at, or None if it does not exist."""
+    response = gh_request("GET", f"repos/{repo}/git/ref/{ref.removeprefix('refs/')}")
+    if response.status == 404:
+        return None
+    if response.status >= 400 or not isinstance(response.body, dict):
+        raise GuardUnavailable(
+            f"could not read the dispatch claim {ref}: HTTP {response.status}"
+        )
+    target = response.body.get("object") or {}
+    sha = target.get("sha") if isinstance(target, dict) else None
+    return str(sha) if sha else None
+
+
+def read_claimant(repo: str, blob_sha: str) -> Claimant | None:
+    """Decode the claim record a ref points at, or None if it is unreadable."""
+    response = gh_request("GET", f"repos/{repo}/git/blobs/{blob_sha}")
+    if response.status >= 400 or not isinstance(response.body, dict):
+        print(
+            f"::warning::a dispatch claim record ({blob_sha}) is unreadable "
+            f"(HTTP {response.status})."
+        )
+        return None
+    content = response.body.get("content")
+    if not isinstance(content, str):
+        return None
+    try:
+        record = json.loads(base64.b64decode(content))
+    except (ValueError, TypeError):
+        print("::warning::a dispatch claim record is not valid JSON.")
+        return None
+    if not isinstance(record, dict):
+        return None
+    try:
+        run_id = int(record["run_id"])
+        attempt = int(record["attempt"])
+    except (KeyError, TypeError, ValueError):
+        print("::warning::a dispatch claim record names no run.")
+        return None
+    claimed_at = record.get("claimed_at")
+    return Claimant(
+        run_id=run_id,
+        attempt=attempt,
+        claimed_at=float(claimed_at) if isinstance(claimed_at, (int, float)) else None,
+    )
+
+
+def delete_ref(repo: str, ref: str) -> bool:
+    """Delete a claim ref. False ⇒ already gone, which is not a fault."""
+    response = gh_request(
+        "DELETE", f"repos/{repo}/git/refs/{ref.removeprefix('refs/')}"
+    )
+    return response.status in (200, 204)
+
+
+def dispatch_exists(repo: str, sha: str, check_run_name: str) -> bool | None:
+    """Did the claimer get as far as creating its check run on ``sha``?
+
+    True/False, or None when the answer is unreadable. The check run is created
+    immediately before the dispatch, so its presence is the evidence that a
+    dispatch either happened or is one API call away from happening.
+    """
+    state = checks_state(repo, sha, check_run_name)
+    return None if state is None else state != "absent"
+
+
+def checks_state(repo: str, sha: str, check_run_name: str) -> str | None:
+    """ "absent", "running" or "done" for ``check_run_name`` on ``sha``.
+
+    None when the answer is unreadable. Three states rather than a boolean
+    because "absent" and "done" mean opposite things to the prune: a claim whose
+    check was never created may still be about to dispatch, while one whose check
+    has concluded cannot.
+    """
+    response = gh_request(
+        "GET",
+        f"repos/{repo}/commits/{sha}/check-runs?per_page=100",
+    )
+    if response.status >= 400 or not isinstance(response.body, dict):
+        print(
+            f"::warning::could not read the check runs on {sha} "
+            f"(HTTP {response.status})."
+        )
+        return None
+    runs = response.body.get("check_runs")
+    if not isinstance(runs, list):
+        return None
+    mine = [
+        entry
+        for entry in runs
+        if isinstance(entry, dict) and entry.get("name") == check_run_name
+    ]
+    if not mine:
+        return "absent"
+    return "done" if all(e.get("status") == _COMPLETED for e in mine) else "running"
+
+
+def claim_is_settled(repo: str, ref: str, sha: str, check_run_name: str) -> bool | None:
+    """Can nothing that depends on this claim still be live?
+
+    The prune's safety condition. A concluded check settles it outright. A check
+    that is still running does not. A claim with NO check has to fall back to the
+    claimant's run: a peer between its claim and its check creation is a window
+    of one API call, and pruning inside that window would let a duplicate event
+    for the same SHA dispatch a second time.
+    """
+    state = checks_state(repo, sha, check_run_name)
+    if state is None:
+        return None
+    if state == "running":
+        return False
+    if state == "done":
+        return True
+
+    target = read_claim_target(repo, ref)
+    if target is None:
+        return False
+    claimant = read_claimant(repo, target)
+    if claimant is None:
+        return None
+    return not run_is_live(repo, claimant.run_id)
+
+
+def run_is_live(repo: str, run_id: int) -> bool:
+    """Is the claiming run still going?
+
+    Errs towards True. Reading a transient API failure as "over" would reap a
+    live peer's claim and produce the duplicate dispatch this exists to prevent,
+    whereas erring towards "live" only skips a dispatch whose verdict is already
+    on its way.
+    """
+    response = gh_request("GET", f"repos/{repo}/actions/runs/{run_id}")
+    if response.status == 404:
+        # Deleted, or never existed. Nothing will ever dispatch for this claim.
+        return False
+    if response.status >= 400 or not isinstance(response.body, dict):
+        print(
+            f"::warning::could not read run {run_id} in {repo} "
+            f"(HTTP {response.status}); treating it as still live."
+        )
+        return True
+    return response.body.get("status") != _COMPLETED
+
+
+def open_pr_heads(repo: str) -> set[str] | None:
+    """Head SHAs of every open PR, or None if the list could not be read.
+
+    None is not an empty set: an unreadable list must not license pruning every
+    claim in the namespace.
+    """
+    heads: set[str] = set()
+    for page in range(1, _OPEN_PR_MAX_PAGES + 1):
+        response = gh_request(
+            "GET", f"repos/{repo}/pulls?state=open&per_page=100&page={page}"
+        )
+        if response.status >= 400 or not isinstance(response.body, list):
+            print(
+                "::warning::could not list open pull requests "
+                f"(HTTP {response.status}); skipping the dispatch-claim prune."
+            )
+            return None
+        for entry in response.body:
+            if isinstance(entry, dict):
+                head = entry.get("head")
+                if isinstance(head, dict) and isinstance(head.get("sha"), str):
+                    heads.add(head["sha"].lower())
+        if len(response.body) < 100:
+            break
+    return heads
+
+
+def list_claims(repo: str, app: str) -> list[str] | None:
+    """Every claim ref for one app, or None if the listing failed."""
+    prefix = f"{REF_NAMESPACE}/{slug(app)}"
+    refs: list[str] = []
+    seen: set[str] = set()
+    for page in range(1, _PRUNE_MAX_PAGES + 1):
+        response = gh_request(
+            "GET", f"repos/{repo}/git/matching-refs/{prefix}?per_page=100&page={page}"
+        )
+        if response.status == 404:
+            # No claims for this app yet. matching-refs is documented to answer
+            # with an empty array, but the older single-ref endpoint 404s and the
+            # two have been confused before, so both are accepted as "none".
+            return refs
+        if response.status >= 400 or not isinstance(response.body, list):
+            print(
+                f"::warning::could not list dispatch claims for {app} "
+                f"(HTTP {response.status}); skipping the prune."
+            )
+            return None
+        fresh = 0
+        for entry in response.body:
+            if isinstance(entry, dict) and isinstance(entry.get("ref"), str):
+                ref = entry["ref"]
+                if ref not in seen:
+                    seen.add(ref)
+                    refs.append(ref)
+                    fresh += 1
+        # Two stop conditions, because matching-refs does not document `page`:
+        # a short page means the end, and a page that adds nothing new means the
+        # parameter was ignored and we are re-reading page one.
+        if len(response.body) < 100 or fresh == 0:
+            break
+    return refs
+
+
+def prune(repo: str, app: str, keep_sha: str, check_run_name: str) -> int:
+    """Delete claims that no live dispatch can still depend on.
+
+    Deletable means: not the SHA being claimed now, not the head of an open PR,
+    and that SHA's check run is finished or was never created. Merge-queue SHAs
+    are never open PR heads, which is what keeps the namespace from growing with
+    every merge — and they are safe to forget, because no second dispatch event
+    can arrive for a merge-queue SHA once its run is over.
+
+    Best-effort throughout: every failure returns early with a warning. Pruning
+    is housekeeping and must never fail a dispatch.
+    """
+    refs = list_claims(repo, app)
+    if not refs:
+        return 0
+    heads = open_pr_heads(repo)
+    if heads is None:
+        return 0
+
+    deleted = 0
+    for ref in refs:
+        if deleted >= _PRUNE_MAX_DELETES:
+            print(
+                f"Reached the per-dispatch prune cap of {_PRUNE_MAX_DELETES} "
+                f"stale dispatch claims for {app}; the rest go next time."
+            )
+            break
+        sha = sha_of(ref)
+        if not sha or sha == keep_sha.lower() or sha in heads:
+            continue
+        if claim_is_settled(repo, ref, sha, check_run_name) is not True:
+            continue
+        if delete_ref(repo, ref):
+            deleted += 1
+    if deleted:
+        print(f"Pruned {deleted} stale dispatch claim(s) for {app}.")
+    return deleted
+
+
+def resolve(
+    repo: str,
+    ref: str,
+    *,
+    app: str,
+    sha: str,
+    check_run_name: str,
+    run_id: int,
+    attempt: int,
+    clock=time.time,
+) -> tuple[str, Claimant | None]:
+    """Decide whether this run should dispatch.
+
+    Returns ("claimed" | "reclaimed" | "duplicate", the blocking claimant or
+    None). Raises ``GuardUnavailable`` when the guard cannot be operated, which
+    the caller turns into "dispatch anyway".
+    """
+    target = read_claim_target(repo, ref)
+    if target is None:
+        blob = create_claim_blob(repo, run_id, attempt, clock())
+        if try_claim(repo, ref, blob) == "claimed":
+            return "claimed", None
+        # Somebody won the race between the read and the CAS. The CAS was the
+        # authority, as intended; re-read and judge the winner below.
+        target = read_claim_target(repo, ref)
+        if target is None:
+            # Taken and then released inside one round trip. Nothing sane does
+            # that, so rather than loop, fail open — a duplicate dispatch is the
+            # status quo and an unexplained state is not worth guessing at.
+            raise GuardUnavailable(
+                f"{ref} was taken and gone again within one round trip"
+            )
+
+    claimant = read_claimant(repo, target)
+    if claimant is None:
+        # An unreadable record cannot be attributed, and attributing it wrongly
+        # in either direction is worse than the status quo.
+        raise GuardUnavailable(f"the claim record behind {ref} is unreadable")
+
+    if claimant.is_my_run(run_id):
+        print(
+            f"This run already claimed the dispatch slot {ref} "
+            f"(attempt {claimant.attempt}); re-dispatching."
+        )
+        return "claimed", None
+
+    dispatched = dispatch_exists(repo, sha, check_run_name)
+    if dispatched is None:
+        raise GuardUnavailable(f"could not tell whether {sha} was already dispatched")
+    if dispatched:
+        print(
+            f"Run {claimant.run_id} ({claimant.run_url(repo)}) already dispatched "
+            f"{app} for {sha}; skipping this duplicate dispatch. Its "
+            f"'{check_run_name}' check on this commit carries the verdict, and "
+            "this run's connector gate reads that same check."
+        )
+        return "duplicate", claimant
+
+    if run_is_live(repo, claimant.run_id):
+        print(
+            f"Run {claimant.run_id} ({claimant.run_url(repo)}) is claiming the "
+            f"{app} dispatch for {sha} right now; skipping this duplicate."
+        )
+        return "duplicate", claimant
+
+    print(
+        f"::warning::run {claimant.run_id} claimed the {app} dispatch for {sha} "
+        "and finished without dispatching; reclaiming the slot."
+    )
+    delete_ref(repo, ref)
+    blob = create_claim_blob(repo, run_id, attempt, clock())
+    if try_claim(repo, ref, blob) == "claimed":
+        return "reclaimed", None
+    # Another contender reclaimed it first. It will dispatch; this one must not.
+    print(f"Another run reclaimed {ref} first; skipping this duplicate dispatch.")
+    return "duplicate", claimant
+
+
+def write_outputs(outputs: dict[str, str], path: str | None) -> None:
+    if not path:
+        for key, value in outputs.items():
+            print(f"{key}={value}")
+        return
+    with open(path, "a", encoding="utf-8") as handle:
+        for key, value in outputs.items():
+            handle.write(f"{key}={value}\n")
+
+
+def summarise(line: str) -> None:
+    path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not path:
+        return
+    try:
+        with open(path, "a", encoding="utf-8") as handle:
+            handle.write(line + "\n")
+    except OSError:
+        pass
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Claim the (dispatching SHA, app) connector e2e dispatch slot."
+    )
+    parser.add_argument(
+        "--repo", required=True, help="owner/repo the claim ref lives in."
+    )
+    parser.add_argument(
+        "--sha", required=True, help="The dispatching SHA (this repo's PR head)."
+    )
+    parser.add_argument("--app", required=True, help="Target connector repo name.")
+    parser.add_argument(
+        "--check-run-name",
+        required=True,
+        help="The check run the claimer creates before dispatching, e.g. "
+        "'Connector E2E run / atlan-mysql-app'. Its presence on --sha is the "
+        "evidence that a dispatch already happened.",
+    )
+    parser.add_argument("--run-id", required=True, type=int, help="github.run_id")
+    parser.add_argument(
+        "--run-attempt", required=True, type=int, help="github.run_attempt"
+    )
+    parser.add_argument(
+        "--no-prune",
+        action="store_true",
+        help="Skip the stale-claim prune. The prune is best-effort housekeeping; "
+        "this exists so a caller can drop its API cost entirely.",
+    )
+    args = parser.parse_args(sys.argv[1:] if argv is None else argv)
+
+    sha = args.sha.strip().lower()
+    if not _SHA_RE.match(sha):
+        # Fail open, like every other guard failure: a malformed SHA is a caller
+        # bug, and blocking the dispatch would hide it behind a missing e2e run
+        # rather than surfacing it.
+        print(
+            f"::warning::--sha {args.sha!r} is not a commit sha, so the duplicate "
+            "dispatch guard cannot key on it; dispatching unguarded."
+        )
+        write_outputs(
+            {
+                "claimed": "true",
+                "state": "disabled",
+                "claim-ref": "",
+                "holder-run-id": "",
+            },
+            os.environ.get("GITHUB_OUTPUT"),
+        )
+        return 0
+
+    ref = claim_ref(args.app, sha)
+    try:
+        state, blocker = resolve(
+            args.repo,
+            ref,
+            app=args.app,
+            sha=sha,
+            check_run_name=args.check_run_name,
+            run_id=args.run_id,
+            attempt=args.run_attempt,
+        )
+    except GuardUnavailable as unavailable:
+        print(
+            f"::warning::the duplicate-dispatch guard is not working ({unavailable}), "
+            "so this run is dispatching unguarded. Worst case is the pre-existing "
+            "behaviour: a duplicate connector run. Grant this job 'contents: write' "
+            "(claim refs), 'checks: read' and 'pull-requests: read' if that is what "
+            "is missing."
+        )
+        write_outputs(
+            {
+                "claimed": "true",
+                "state": "disabled",
+                "claim-ref": ref,
+                "holder-run-id": "",
+            },
+            os.environ.get("GITHUB_OUTPUT"),
+        )
+        return 0
+
+    if state != "duplicate" and not args.no_prune:
+        try:
+            prune(args.repo, args.app, sha, args.check_run_name)
+        except GuardUnavailable as unavailable:
+            print(f"::warning::the dispatch-claim prune stopped early: {unavailable}")
+
+    if state == "duplicate" and blocker is not None:
+        summarise(
+            f"- **{args.app}**: duplicate dispatch skipped — "
+            f"[run {blocker.run_id}]({blocker.run_url(args.repo)}) already "
+            f"dispatched `{sha[:8]}`."
+        )
+
+    write_outputs(
+        {
+            "claimed": "false" if state == "duplicate" else "true",
+            "state": state,
+            "claim-ref": ref,
+            "holder-run-id": str(blocker.run_id) if blocker else "",
+        },
+        os.environ.get("GITHUB_OUTPUT"),
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/e2e_dispatch_guard.py
+++ b/.github/scripts/e2e_dispatch_guard.py
@@ -142,6 +142,12 @@ _PRUNE_MAX_PAGES = 5
 _PRUNE_MAX_DELETES = 25
 _OPEN_PR_MAX_PAGES = 5
 
+# Pages of check runs on ONE commit. Ten (1000 checks) is far past what any SHA
+# here carries; the cap exists so a pathological commit cannot spin, and hitting
+# it is reported as "unreadable" rather than "no dispatch found" — the direction
+# that fails open.
+_CHECKS_MAX_PAGES = 10
+
 _SAFE_SLUG_CHARS = frozenset("abcdefghijklmnopqrstuvwxyz0123456789._-")
 _SHA_RE = re.compile(r"\A[0-9a-f]{7,64}\Z")
 
@@ -461,28 +467,64 @@ def checks_state(repo: str, sha: str, check_run_name: str) -> str | None:
     because "absent" and "done" mean opposite things to the prune: a claim whose
     check was never created may still be about to dispatch, while one whose check
     has concluded cannot.
+
+    Paginated, and "absent" is only returned once every page has been read. A
+    single ``per_page=100`` GET would report a named check living past page one as
+    "never dispatched", which is the one wrong answer that costs a tenant: the
+    reclaim path would then fire a second connector run. This repo's SHAs already
+    carry enough checks for that to be reachable, which is why
+    ``poll_check_runs_gate.py`` paginates the same endpoint.
+
+    Anything that prevents full coverage — a failed page, a missing page, more
+    pages than the cap — is "unreadable" rather than "absent", so the callers
+    fall open instead of acting on a partial list.
     """
-    response = gh_request(
-        "GET",
-        f"repos/{repo}/commits/{sha}/check-runs?per_page=100",
-    )
-    if response.status >= 400 or not isinstance(response.body, dict):
+    matches: list[dict] = []
+    seen = 0
+    for page in range(1, _CHECKS_MAX_PAGES + 1):
+        response = gh_request(
+            "GET",
+            f"repos/{repo}/commits/{sha}/check-runs?per_page=100&page={page}",
+        )
+        if response.status >= 400 or not isinstance(response.body, dict):
+            print(
+                f"::warning::could not read the check runs on {sha} "
+                f"(HTTP {response.status})."
+            )
+            return None
+        runs = response.body.get("check_runs")
+        if not isinstance(runs, list):
+            return None
+        matches.extend(
+            entry
+            for entry in runs
+            if isinstance(entry, dict) and entry.get("name") == check_run_name
+        )
+        seen += len(runs)
+
+        total = response.body.get("total_count")
+        # total_count makes coverage decidable; without it a short page is the
+        # only end-of-list signal left.
+        if seen >= total if isinstance(total, int) else len(runs) < 100:
+            break
+        if not runs:
+            # A page that adds nothing while the count says there is more: the
+            # listing cannot be completed, so it is unreadable, not empty.
+            print(
+                f"::warning::the check-run listing for {sha} stopped short of "
+                f"its own total_count ({seen}/{total})."
+            )
+            return None
+    else:
         print(
-            f"::warning::could not read the check runs on {sha} "
-            f"(HTTP {response.status})."
+            f"::warning::{sha} carries more than {_CHECKS_MAX_PAGES} pages of "
+            "check runs, so this could not be read in full."
         )
         return None
-    runs = response.body.get("check_runs")
-    if not isinstance(runs, list):
-        return None
-    mine = [
-        entry
-        for entry in runs
-        if isinstance(entry, dict) and entry.get("name") == check_run_name
-    ]
-    if not mine:
+
+    if not matches:
         return "absent"
-    return "done" if all(e.get("status") == _COMPLETED for e in mine) else "running"
+    return "done" if all(e.get("status") == _COMPLETED for e in matches) else "running"
 
 
 def claim_is_settled(repo: str, ref: str, sha: str, check_run_name: str) -> bool | None:
@@ -799,7 +841,8 @@ def main(argv: list[str] | None = None) -> int:
             f"::warning::the duplicate-dispatch guard is not working ({unavailable}), "
             "so this run is dispatching unguarded. Worst case is the pre-existing "
             "behaviour: a duplicate connector run. Grant this job 'contents: write' "
-            "(claim refs), 'checks: read' and 'pull-requests: read' if that is what "
+            "(claim refs), 'checks: read', 'actions: read' and "
+            "'pull-requests: read' if that is what "
             "is missing."
         )
         write_outputs(

--- a/.github/scripts/tests/test_e2e_dispatch_guard.py
+++ b/.github/scripts/tests/test_e2e_dispatch_guard.py
@@ -28,8 +28,10 @@ import yaml
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from e2e_dispatch_guard import (  # noqa: E402
+    _CHECKS_MAX_PAGES,
     Claimant,
     GuardUnavailable,
+    checks_state,
     claim_is_settled,
     claim_ref,
     dispatch_exists,
@@ -641,6 +643,125 @@ def test_a_5xx_is_retried_before_giving_up(http: FakeHTTP, monkeypatch) -> None:
     assert http.count("GET", "/actions/runs/7") == 2
 
 
+# --- the check-run listing is paginated ------------------------------------
+#
+# A single per_page=100 GET reports a named check living past page one as "never
+# dispatched" — the one wrong answer that costs a tenant, because the reclaim
+# path then fires a second connector run. This repo's SHAs already carry enough
+# checks for that to be reachable, which is why poll_check_runs_gate.py
+# paginates the same endpoint.
+
+
+def _filler(count: int, name: str = "SDK Gate"):
+    return [{"name": name, "status": "completed"} for _ in range(count)]
+
+
+def test_a_named_check_past_page_one_is_found(http: FakeHTTP) -> None:
+    http.route(
+        "GET",
+        "/check-runs",
+        (200, {"total_count": 101, "check_runs": _filler(100)}),
+        (
+            200,
+            {
+                "total_count": 101,
+                "check_runs": [{"name": CHECK, "status": "in_progress"}],
+            },
+        ),
+    )
+    assert checks_state(REPO, SHA, CHECK) == "running"
+    assert http.count("GET", "/check-runs") == 2
+
+
+def test_a_dispatch_recorded_past_page_one_is_not_reclaimed(http: FakeHTTP) -> None:
+    """The failure this pagination exists to stop: a claim held by a dead run
+    whose check lives on page two used to read as "never dispatched", and the
+    reclaim path would dispatch a second connector run onto the same tenants."""
+    _stub_taken(http, 999)
+    http.route(
+        "GET",
+        "/check-runs",
+        (200, {"total_count": 101, "check_runs": _filler(100)}),
+        (
+            200,
+            {
+                "total_count": 101,
+                "check_runs": [{"name": CHECK, "status": "completed"}],
+            },
+        ),
+    )
+
+    state, blocker = _resolve(run_id=1)
+
+    assert state == "duplicate"
+    assert blocker is not None and blocker.run_id == 999
+    # No reclaim: no ref deletion, no second CAS.
+    assert http.count("DELETE", "/git/refs/") == 0
+    assert http.count("POST", "/git/refs") == 0
+
+
+def test_a_failed_later_page_is_unreadable_not_absent(http: FakeHTTP) -> None:
+    # "absent" licenses a reclaim, so it may only be returned from a listing
+    # that was read in full.
+    http.route(
+        "GET",
+        "/check-runs",
+        (200, {"total_count": 200, "check_runs": _filler(100)}),
+        (500, {"message": "boom"}),
+    )
+    assert checks_state(REPO, SHA, CHECK) is None
+
+
+def test_more_pages_than_the_cap_is_unreadable(http: FakeHTTP) -> None:
+    http.route(
+        "GET",
+        "/check-runs",
+        *[
+            (200, {"total_count": 10_000, "check_runs": _filler(100)})
+            for _ in range(11)
+        ],
+    )
+    assert checks_state(REPO, SHA, CHECK) is None
+    # Bounded: it stops at the cap rather than walking a pathological commit.
+    assert http.count("GET", "/check-runs") == _CHECKS_MAX_PAGES
+
+
+def test_a_listing_short_of_its_own_total_is_unreadable(http: FakeHTTP) -> None:
+    http.route(
+        "GET",
+        "/check-runs",
+        (200, {"total_count": 200, "check_runs": _filler(100)}),
+        (200, {"total_count": 200, "check_runs": []}),
+    )
+    assert checks_state(REPO, SHA, CHECK) is None
+
+
+def test_a_single_short_page_is_one_call(http: FakeHTTP) -> None:
+    # The normal case must not pay for pagination it does not need.
+    http.route("GET", "/check-runs", (200, _checks((CHECK, "completed"))))
+    assert checks_state(REPO, SHA, CHECK) == "done"
+    assert http.count("GET", "/check-runs") == 1
+
+
+def test_a_listing_without_a_total_count_still_terminates(http: FakeHTTP) -> None:
+    # total_count is not load-bearing: a short page is the fallback end-of-list
+    # signal, so a response shape change cannot make this spin.
+    http.route("GET", "/check-runs", (200, {"check_runs": _filler(3)}))
+    assert checks_state(REPO, SHA, CHECK) == "absent"
+    assert http.count("GET", "/check-runs") == 1
+
+
+def test_several_named_checks_are_only_done_when_all_are(http: FakeHTTP) -> None:
+    """Duplicate dispatches are exactly what put two same-named checks on one
+    SHA, so the prune's "settled" question is about the whole set."""
+    http.route(
+        "GET",
+        "/check-runs",
+        (200, _checks((CHECK, "completed"), (CHECK, "in_progress"))),
+    )
+    assert checks_state(REPO, SHA, CHECK) == "running"
+
+
 # --- wiring: the action and its caller -------------------------------------
 
 
@@ -721,6 +842,13 @@ def test_the_caller_grants_what_the_guard_needs() -> None:
     assert permissions["contents"] == "write", "claim refs are created and deleted"
     assert permissions["checks"] == "read", "has this SHA already been dispatched?"
     assert permissions["pull-requests"] == "read", "the stale-claim prune"
+    # Without this, GET /actions/runs/<id> 404s the way a deleted run does — so a
+    # LIVE claimant reads as dead, its claim is reclaimed, and a second connector
+    # run lands on the same tenants. The sibling lease-tenant job grants it too.
+    assert permissions["actions"] == "read", (
+        "run liveness decides whether a claimant that has not dispatched yet is "
+        "mid-dispatch or dead; a permission-shaped 404 reads as dead"
+    )
 
 
 def test_the_guard_keys_on_the_same_sha_as_the_check_run() -> None:

--- a/.github/scripts/tests/test_e2e_dispatch_guard.py
+++ b/.github/scripts/tests/test_e2e_dispatch_guard.py
@@ -1,0 +1,744 @@
+"""Tests for .github/scripts/e2e_dispatch_guard.py (FND-646).
+
+The HTTP client is stubbed at the ``run()`` seam with a fake that speaks real
+curl-shaped responses, so status-code handling — 422 "already exists" (which IS
+the lock), 403 permission, 403 rate limit, 500 transient — is exercised through
+the same parser production uses rather than around it.
+
+Two properties get the most attention here, because both are the kind that pass
+a happy-path test and then cost a tenant:
+
+* the CAS decides, not the pre-read. The tests drive the sequence a second
+  contender really sees (free, then taken) rather than a tidy snapshot.
+* every failure direction is OPEN. A guard that cannot be operated must still
+  dispatch, because a PR whose e2e silently never ran is worse than one that
+  pays for a duplicate — which is the pre-existing behaviour anyway.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from e2e_dispatch_guard import (  # noqa: E402
+    Claimant,
+    GuardUnavailable,
+    claim_is_settled,
+    claim_ref,
+    dispatch_exists,
+    main,
+    open_pr_heads,
+    prune,
+    resolve,
+    run_is_live,
+    sha_of,
+    slug,
+    try_claim,
+)
+
+REPO = "atlanhq/application-sdk"
+APP = "atlan-openapi-app"
+SHA = "c5597b22" + "0" * 32
+CHECK = f"Connector E2E run / {APP}"
+REF = f"refs/e2e-dispatch/{APP}/{SHA}"
+BLOB = "b" * 40
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_ACTION = _REPO_ROOT / ".github/actions/e2e-apps/action.yaml"
+_PR_WORKFLOW = _REPO_ROOT / ".github/workflows/pull_request.yaml"
+
+
+# --- fake HTTP client ------------------------------------------------------
+
+
+class FakeHTTP:
+    """Records requests and replays queued curl-shaped responses.
+
+    Keyed by (method, path-fragment) so a test only describes the calls it cares
+    about; anything unmatched raises rather than silently answering 200, which is
+    what keeps a test from passing because production stopped making a call it
+    was supposed to make.
+
+    A route with several responses pops one per call, so a test can express
+    "free, then taken" — the sequence, not just the snapshot.
+    """
+
+    def __init__(self) -> None:
+        self.routes: dict[tuple[str, str], list[tuple]] = {}
+        self.calls: list[tuple[str, str]] = []
+        self.payloads: list[dict] = []
+        self.cmds: list[list[str]] = []
+        self.inputs: list[str | None] = []
+
+    def route(self, method: str, contains: str, *responses: tuple) -> None:
+        self.routes[(method, contains)] = list(responses)
+
+    def __call__(self, cmd: list[str], **kwargs):
+        method = cmd[cmd.index("-X") + 1]
+        url = cmd[-1]
+        self.calls.append((method, url))
+        self.cmds.append(list(cmd))
+        self.inputs.append(kwargs.get("input"))
+        if "-d" in cmd:
+            self.payloads.append(json.loads(cmd[cmd.index("-d") + 1]))
+        for (route_method, contains), responses in self.routes.items():
+            if route_method != method or contains not in url:
+                continue
+            entry = responses[0] if len(responses) == 1 else responses.pop(0)
+            status, body = entry[0], entry[1]
+            headers = entry[2] if len(entry) > 2 else {}
+            payload = "" if body is None else json.dumps(body)
+            header_lines = "".join(f"\r\n{k}: {v}" for k, v in headers.items())
+            return _completed(f"HTTP/2 {status}{header_lines}\r\n\r\n{payload}")
+        raise AssertionError(f"unstubbed request: {method} {url}")
+
+    def count(self, method: str, contains: str) -> int:
+        return len([c for c in self.calls if c[0] == method and contains in c[1]])
+
+
+class _completed:
+    def __init__(self, stdout: str, returncode: int = 0, stderr: str = "") -> None:
+        self.stdout = stdout
+        self.returncode = returncode
+        self.stderr = stderr
+
+
+@pytest.fixture
+def http(monkeypatch: pytest.MonkeyPatch) -> FakeHTTP:
+    monkeypatch.setenv("GH_TOKEN", "x")
+    fake = FakeHTTP()
+    monkeypatch.setattr("e2e_dispatch_guard.run", fake)
+    return fake
+
+
+def _claim_blob(run_id: int, attempt: int = 1, claimed_at: float | None = 1000.0):
+    record: dict[str, object] = {"run_id": run_id, "attempt": attempt}
+    if claimed_at is not None:
+        record["claimed_at"] = claimed_at
+    encoded = base64.b64encode(json.dumps(record).encode()).decode()
+    return {"content": encoded, "encoding": "base64"}
+
+
+def _checks(*entries: tuple[str, str]):
+    return {
+        "check_runs": [{"name": name, "status": status} for name, status in entries]
+    }
+
+
+_RATE_LIMIT = (
+    403,
+    {"message": "API rate limit exceeded for installation"},
+    {"x-ratelimit-remaining": "0"},
+)
+_PERMISSION_DENIED = (403, {"message": "Resource not accessible by integration"})
+
+
+def _resolve(**kwargs):
+    defaults = dict(
+        app=APP,
+        sha=SHA,
+        check_run_name=CHECK,
+        run_id=1,
+        attempt=1,
+        clock=lambda: 1000.0,
+    )
+    defaults.update(kwargs)
+    return resolve(REPO, REF, **defaults)  # type: ignore[arg-type]
+
+
+# --- keying ----------------------------------------------------------------
+
+
+def test_the_claim_ref_puts_the_app_before_the_sha() -> None:
+    """App first so ``matching-refs/e2e-dispatch/<app>`` lists one app's claims;
+    the prune must never have to walk the whole namespace."""
+    assert claim_ref(APP, SHA) == f"refs/e2e-dispatch/{APP}/{SHA}"
+
+
+def test_the_claim_ref_is_fixed_for_a_given_sha_and_app() -> None:
+    # The whole mechanism is collision: a name only one run could guess is a
+    # name that cannot collide, and collision is the signal.
+    assert claim_ref(APP, SHA) == claim_ref(APP.upper(), SHA)
+
+
+def test_the_app_slug_cannot_produce_a_ref_git_rejects() -> None:
+    assert slug("My App/Name") == "my-app-name"
+    assert ".." not in slug("a..b")
+    assert not slug("thing.lock").endswith(".lock")
+    assert slug("///") == "app"
+
+
+def test_sha_of_reads_the_last_component() -> None:
+    assert sha_of(REF) == SHA
+
+
+def test_sha_of_rejects_a_non_sha_tail() -> None:
+    # Guards the prune: a ref whose tail is not a commit sha must never be
+    # matched against the open-PR head set and deleted on a miss.
+    assert sha_of("refs/e2e-dispatch/app/not-a-sha") == ""
+
+
+# --- the CAS ---------------------------------------------------------------
+
+
+def test_a_422_already_exists_is_the_slot_being_taken(http: FakeHTTP) -> None:
+    http.route("POST", "/git/refs", (422, {"message": "Reference already exists"}))
+    assert try_claim(REPO, REF, BLOB) == "taken"
+
+
+def test_a_201_is_the_slot_being_claimed(http: FakeHTTP) -> None:
+    http.route("POST", "/git/refs", (201, {"ref": REF}))
+    assert try_claim(REPO, REF, BLOB) == "claimed"
+
+
+@pytest.mark.parametrize("answer", [_PERMISSION_DENIED, _RATE_LIMIT])
+def test_a_403_on_the_cas_makes_the_guard_unavailable(http: FakeHTTP, answer) -> None:
+    """Both directions fail open at the caller. They are told apart only so the
+    warning names the real cause — a rate-limited hour reported as a permissions
+    problem is a diagnosis-hostile lie."""
+    http.route("POST", "/git/refs", answer)
+    with pytest.raises(GuardUnavailable):
+        try_claim(REPO, REF, BLOB)
+
+
+def test_an_unheld_slot_is_claimed(http: FakeHTTP) -> None:
+    http.route("GET", "/git/ref/", (404, {"message": "Not Found"}))
+    http.route("POST", "/git/blobs", (201, {"sha": BLOB}))
+    http.route("POST", "/git/refs", (201, {"ref": REF}))
+
+    assert _resolve() == ("claimed", None)
+
+
+def test_the_claim_record_names_this_run(http: FakeHTTP) -> None:
+    http.route("GET", "/git/ref/", (404, {"message": "Not Found"}))
+    http.route("POST", "/git/blobs", (201, {"sha": BLOB}))
+    http.route("POST", "/git/refs", (201, {"ref": REF}))
+
+    _resolve(run_id=4242, attempt=3)
+
+    record = json.loads(http.payloads[0]["content"])
+    assert record["run_id"] == 4242
+    assert record["attempt"] == 3
+    assert record["claimed_at"] == 1000.0
+
+
+def test_losing_the_race_after_the_pre_read_is_not_a_claim(http: FakeHTTP) -> None:
+    """THE case that has to work. The pre-read is an optimisation; the CAS is the
+    authority, and a contender that read "free" and then lost the CAS must fall
+    through to judging the winner — not proceed as if it had won."""
+    http.route(
+        "GET",
+        "/git/ref/",
+        (404, {"message": "Not Found"}),
+        (200, {"object": {"sha": BLOB, "type": "blob"}}),
+    )
+    http.route("POST", "/git/blobs", (201, {"sha": BLOB}))
+    http.route("POST", "/git/refs", (422, {"message": "Reference already exists"}))
+    http.route("GET", "/git/blobs/", (200, _claim_blob(999)))
+    http.route("GET", "/check-runs", (200, _checks((CHECK, "in_progress"))))
+
+    state, blocker = _resolve(run_id=1)
+
+    assert state == "duplicate"
+    assert blocker is not None and blocker.run_id == 999
+
+
+# --- resolving an existing claim -------------------------------------------
+
+
+def _stub_taken(http: FakeHTTP, run_id: int, attempt: int = 1) -> None:
+    http.route("GET", "/git/ref/", (200, {"object": {"sha": BLOB, "type": "blob"}}))
+    http.route("GET", "/git/blobs/", (200, _claim_blob(run_id, attempt)))
+
+
+def test_a_dispatch_already_made_for_this_sha_is_skipped(http: FakeHTTP) -> None:
+    _stub_taken(http, 999)
+    http.route("GET", "/check-runs", (200, _checks((CHECK, "in_progress"))))
+
+    state, blocker = _resolve(run_id=1)
+
+    assert state == "duplicate"
+    assert blocker is not None and blocker.run_id == 999
+
+
+def test_a_completed_dispatch_for_this_sha_is_still_skipped(http: FakeHTTP) -> None:
+    """Same commit, same code, already tested. The verdict is that check run, and
+    every duplicate run's own connector gate polls it — re-dispatching would buy
+    a second answer to a question already answered, at the price of a tenant."""
+    _stub_taken(http, 999)
+    http.route("GET", "/check-runs", (200, _checks((CHECK, "completed"))))
+
+    assert _resolve(run_id=1)[0] == "duplicate"
+
+
+def test_this_runs_own_claim_permits_a_re_dispatch(http: FakeHTTP) -> None:
+    """Attempt is recorded for the log, not the decision: re-running the dispatch
+    job is how an operator retries a transient dispatch failure, and a claim that
+    blocked its own run's re-run would make that impossible."""
+    _stub_taken(http, 555, attempt=1)
+
+    state, blocker = _resolve(run_id=555, attempt=2)
+
+    assert state == "claimed"
+    assert blocker is None
+    # No check-run probe and no re-write: it is already ours.
+    assert http.count("GET", "/check-runs") == 0
+    assert http.count("POST", "/git/refs") == 0
+
+
+def test_a_live_claimer_that_has_not_dispatched_yet_still_blocks(
+    http: FakeHTTP,
+) -> None:
+    # The window between a peer's claim and its check creation is one API call.
+    # Reclaiming inside it is how one SHA gets two connector runs.
+    _stub_taken(http, 999)
+    http.route("GET", "/check-runs", (200, _checks(("Some other check", "completed"))))
+    http.route("GET", "/actions/runs/999", (200, {"status": "in_progress"}))
+
+    assert _resolve(run_id=1)[0] == "duplicate"
+
+
+def test_a_dead_claimer_that_never_dispatched_is_reclaimed(http: FakeHTTP) -> None:
+    """Otherwise the slot stays taken by a run that will never dispatch, and this
+    commit has no e2e at all — a silent loss of coverage, which is the failure
+    mode this whole area exists to avoid."""
+    _stub_taken(http, 999)
+    http.route("GET", "/check-runs", (200, _checks()))
+    http.route("GET", "/actions/runs/999", (200, {"status": "completed"}))
+    http.route("DELETE", "/git/refs/", (204, None))
+    http.route("POST", "/git/blobs", (201, {"sha": BLOB}))
+    http.route("POST", "/git/refs", (201, {"ref": REF}))
+
+    assert _resolve(run_id=1) == ("reclaimed", None)
+
+
+def test_losing_the_reclaim_race_does_not_dispatch(http: FakeHTTP) -> None:
+    # Two contenders can both see a dead claimer. Exactly one may take over.
+    _stub_taken(http, 999)
+    http.route("GET", "/check-runs", (200, _checks()))
+    http.route("GET", "/actions/runs/999", (200, {"status": "completed"}))
+    http.route("DELETE", "/git/refs/", (204, None))
+    http.route("POST", "/git/blobs", (201, {"sha": BLOB}))
+    http.route("POST", "/git/refs", (422, {"message": "Reference already exists"}))
+
+    assert _resolve(run_id=1)[0] == "duplicate"
+
+
+def test_an_unreadable_claim_record_fails_open(http: FakeHTTP) -> None:
+    # Attributing an unreadable claim in either direction is worse than the
+    # status quo, so it is not attributed at all.
+    http.route("GET", "/git/ref/", (200, {"object": {"sha": BLOB, "type": "blob"}}))
+    http.route("GET", "/git/blobs/", (200, {"content": "not base64 json"}))
+
+    with pytest.raises(GuardUnavailable):
+        _resolve(run_id=1)
+
+
+def test_an_unreadable_check_list_fails_open(http: FakeHTTP) -> None:
+    _stub_taken(http, 999)
+    http.route("GET", "/check-runs", (500, {"message": "boom"}))
+
+    with pytest.raises(GuardUnavailable):
+        _resolve(run_id=1)
+
+
+# --- liveness --------------------------------------------------------------
+
+
+def test_a_missing_run_is_not_live(http: FakeHTTP) -> None:
+    http.route("GET", "/actions/runs/7", (404, {"message": "Not Found"}))
+    assert run_is_live(REPO, 7) is False
+
+
+def test_an_unreadable_run_is_treated_as_live(http: FakeHTTP) -> None:
+    """Errs towards live. Reading a transient failure as "over" reaps a live
+    peer's claim and produces the duplicate this module exists to prevent."""
+    http.route("GET", "/actions/runs/7", (500, {"message": "boom"}))
+    assert run_is_live(REPO, 7) is True
+
+
+@pytest.mark.parametrize("status", ["queued", "in_progress", "waiting", "pending"])
+def test_every_non_completed_status_is_live(http: FakeHTTP, status: str) -> None:
+    # An unfamiliar future status must err towards leaving a peer alone.
+    http.route("GET", "/actions/runs/7", (200, {"status": status}))
+    assert run_is_live(REPO, 7) is True
+
+
+def test_dispatch_exists_ignores_other_checks_on_the_sha(http: FakeHTTP) -> None:
+    http.route(
+        "GET",
+        "/check-runs",
+        (200, _checks(("SDK Gate", "completed"), ("Trivy", "completed"))),
+    )
+    assert dispatch_exists(REPO, SHA, CHECK) is False
+
+
+# --- pruning ---------------------------------------------------------------
+
+
+def test_an_open_pr_head_is_never_pruned(http: FakeHTTP) -> None:
+    other = "a" * 40
+    http.route(
+        "GET",
+        "/matching-refs/",
+        (200, [{"ref": f"refs/e2e-dispatch/{APP}/{other}"}]),
+    )
+    http.route("GET", "/pulls?", (200, [{"head": {"sha": other}}]))
+
+    assert prune(REPO, APP, SHA, CHECK) == 0
+
+
+def test_the_sha_being_claimed_now_is_never_pruned(http: FakeHTTP) -> None:
+    http.route("GET", "/matching-refs/", (200, [{"ref": REF}]))
+    http.route("GET", "/pulls?", (200, []))
+
+    assert prune(REPO, APP, SHA, CHECK) == 0
+
+
+def test_a_settled_merge_queue_claim_is_pruned(http: FakeHTTP) -> None:
+    """A merge-queue SHA is never an open PR head, which is what would otherwise
+    make the namespace grow with every merge. Safe to forget once its check has
+    concluded: no second dispatch event can arrive for it."""
+    stale = "a" * 40
+    http.route(
+        "GET",
+        "/matching-refs/",
+        (200, [{"ref": f"refs/e2e-dispatch/{APP}/{stale}"}]),
+    )
+    http.route("GET", "/pulls?", (200, []))
+    http.route("GET", "/check-runs", (200, _checks((CHECK, "completed"))))
+    http.route("DELETE", "/git/refs/", (204, None))
+
+    assert prune(REPO, APP, SHA, CHECK) == 1
+
+
+def test_a_claim_whose_dispatch_is_still_running_is_not_pruned(
+    http: FakeHTTP,
+) -> None:
+    stale = "a" * 40
+    http.route(
+        "GET",
+        "/matching-refs/",
+        (200, [{"ref": f"refs/e2e-dispatch/{APP}/{stale}"}]),
+    )
+    http.route("GET", "/pulls?", (200, []))
+    http.route("GET", "/check-runs", (200, _checks((CHECK, "in_progress"))))
+
+    assert prune(REPO, APP, SHA, CHECK) == 0
+
+
+def test_a_check_less_claim_is_pruned_only_when_its_run_is_over(
+    http: FakeHTTP,
+) -> None:
+    """The one case where "no check" must NOT mean "nothing is happening": a peer
+    between its claim and its check creation. Pruning there would let a duplicate
+    event for the same SHA dispatch a second time."""
+    stale = "a" * 40
+    ref = f"refs/e2e-dispatch/{APP}/{stale}"
+    http.route("GET", "/matching-refs/", (200, [{"ref": ref}]))
+    http.route("GET", "/pulls?", (200, []))
+    http.route("GET", "/check-runs", (200, _checks()))
+    http.route("GET", "/git/ref/", (200, {"object": {"sha": BLOB, "type": "blob"}}))
+    http.route("GET", "/git/blobs/", (200, _claim_blob(999)))
+    http.route("GET", "/actions/runs/999", (200, {"status": "in_progress"}))
+
+    assert prune(REPO, APP, SHA, CHECK) == 0
+
+
+def test_an_unreadable_pr_list_prunes_nothing(http: FakeHTTP) -> None:
+    """None is not an empty set: an unreadable list must not license deleting
+    every claim in the namespace."""
+    http.route(
+        "GET",
+        "/matching-refs/",
+        (200, [{"ref": f"refs/e2e-dispatch/{APP}/{'a' * 40}"}]),
+    )
+    http.route("GET", "/pulls?", (500, {"message": "boom"}))
+
+    assert open_pr_heads(REPO) is None
+    assert prune(REPO, APP, SHA, CHECK) == 0
+
+
+def test_no_claims_for_this_app_is_not_an_error(http: FakeHTTP) -> None:
+    # matching-refs is documented to answer with an empty array, but the older
+    # single-ref endpoint 404s and the two have been confused before.
+    http.route("GET", "/matching-refs/", (404, {"message": "Not Found"}))
+    assert prune(REPO, APP, SHA, CHECK) == 0
+
+
+def test_claim_is_settled_is_unknown_when_the_checks_are_unreadable(
+    http: FakeHTTP,
+) -> None:
+    http.route("GET", "/check-runs", (500, {"message": "boom"}))
+    assert claim_is_settled(REPO, REF, SHA, CHECK) is None
+
+
+# --- the CLI: every failure direction is open ------------------------------
+
+
+def _outputs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    path = tmp_path / "outputs"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(path))
+    return path
+
+
+def _argv(**overrides) -> list[str]:
+    args = {
+        "--repo": REPO,
+        "--sha": SHA,
+        "--app": APP,
+        "--check-run-name": CHECK,
+        "--run-id": "1",
+        "--run-attempt": "1",
+    }
+    args.update(overrides)
+    return [item for pair in args.items() for item in pair]
+
+
+def _read(path: Path) -> dict[str, str]:
+    return dict(
+        line.split("=", 1) for line in path.read_text().splitlines() if "=" in line
+    )
+
+
+def test_a_claimed_slot_reports_claimed(
+    http: FakeHTTP, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    out = _outputs(tmp_path, monkeypatch)
+    http.route("GET", "/git/ref/", (404, {"message": "Not Found"}))
+    http.route("POST", "/git/blobs", (201, {"sha": BLOB}))
+    http.route("POST", "/git/refs", (201, {"ref": REF}))
+    http.route("GET", "/matching-refs/", (200, [{"ref": REF}]))
+    http.route("GET", "/pulls?", (200, []))
+
+    assert main(_argv()) == 0
+
+    outputs = _read(out)
+    assert outputs["claimed"] == "true"
+    assert outputs["state"] == "claimed"
+    assert outputs["claim-ref"] == REF
+
+
+def test_a_duplicate_reports_not_claimed_and_names_the_holder(
+    http: FakeHTTP, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    out = _outputs(tmp_path, monkeypatch)
+    _stub_taken(http, 999)
+    http.route("GET", "/check-runs", (200, _checks((CHECK, "in_progress"))))
+
+    assert main(_argv()) == 0
+
+    outputs = _read(out)
+    assert outputs["claimed"] == "false"
+    assert outputs["state"] == "duplicate"
+    assert outputs["holder-run-id"] == "999"
+
+
+def test_a_duplicate_never_prunes(
+    http: FakeHTTP, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Housekeeping is the claimer's job. A run that is standing down should not
+    also be deleting refs — and the unstubbed-request guard in FakeHTTP is what
+    proves it does not."""
+    _outputs(tmp_path, monkeypatch)
+    _stub_taken(http, 999)
+    http.route("GET", "/check-runs", (200, _checks((CHECK, "in_progress"))))
+
+    assert main(_argv()) == 0
+    assert http.count("GET", "/matching-refs/") == 0
+
+
+@pytest.mark.parametrize(
+    "failure",
+    [
+        _PERMISSION_DENIED,
+        _RATE_LIMIT,
+        (500, {"message": "boom"}),
+    ],
+)
+def test_every_guard_failure_still_dispatches(
+    http: FakeHTTP, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, failure
+) -> None:
+    """The load-bearing property. A guard that cannot be operated must not be
+    able to withhold the one dispatch that was supposed to happen — the worst
+    case for a broken guard is the pre-existing duplicate."""
+    out = _outputs(tmp_path, monkeypatch)
+    http.route("GET", "/git/ref/", failure)
+
+    assert main(_argv()) == 0
+
+    outputs = _read(out)
+    assert outputs["claimed"] == "true"
+    assert outputs["state"] == "disabled"
+
+
+def test_a_transport_failure_still_dispatches(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("GH_TOKEN", "x")
+    monkeypatch.setattr("time.sleep", lambda *_a, **_k: None)
+    monkeypatch.setattr(
+        "e2e_dispatch_guard.run",
+        lambda *_a, **_k: _completed("", returncode=60, stderr="SSL problem"),
+    )
+    out = _outputs(tmp_path, monkeypatch)
+
+    assert main(_argv()) == 0
+    assert _read(out)["claimed"] == "true"
+
+
+def test_a_missing_token_still_dispatches(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    out = _outputs(tmp_path, monkeypatch)
+
+    assert main(_argv()) == 0
+    assert _read(out)["claimed"] == "true"
+
+
+def test_a_malformed_sha_still_dispatches(
+    http: FakeHTTP, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A caller bug. Blocking the dispatch would hide it behind a missing e2e run
+    # rather than surfacing it.
+    out = _outputs(tmp_path, monkeypatch)
+
+    assert main(_argv(**{"--sha": "refs/heads/main"})) == 0
+    assert _read(out)["claimed"] == "true"
+    assert http.calls == []
+
+
+def test_the_token_never_reaches_curls_command_line(http: FakeHTTP) -> None:
+    """Anything else on the runner can read /proc/<pid>/cmdline while a request
+    is in flight, so the credential goes through stdin (-K -) instead."""
+    http.route("GET", "/actions/runs/7", (200, {"status": "completed"}))
+    run_is_live(REPO, 7)
+
+    assert not any("x" == arg for arg in http.cmds[0])
+    assert not any("Authorization" in arg for arg in http.cmds[0])
+    assert http.inputs[0] is not None and "Authorization" in http.inputs[0]
+
+
+def test_a_5xx_is_retried_before_giving_up(http: FakeHTTP, monkeypatch) -> None:
+    monkeypatch.setattr("time.sleep", lambda *_a, **_k: None)
+    http.route(
+        "GET",
+        "/actions/runs/7",
+        (500, {"message": "boom"}),
+        (200, {"status": "completed"}),
+    )
+
+    assert run_is_live(REPO, 7) is False
+    assert http.count("GET", "/actions/runs/7") == 2
+
+
+# --- wiring: the action and its caller -------------------------------------
+
+
+@pytest.fixture(scope="module")
+def action() -> dict:  # type: ignore[type-arg]
+    return yaml.safe_load(_ACTION.read_text(encoding="utf-8"))
+
+
+def _step(action: dict, name_fragment: str) -> dict:  # type: ignore[type-arg]
+    for step in action["runs"]["steps"]:
+        if name_fragment in str(step.get("name", "")):
+            return step
+    raise AssertionError(f"e2e-apps has no step matching {name_fragment!r}")
+
+
+def test_the_guard_runs_before_the_check_run_is_created(action: dict) -> None:  # type: ignore[type-arg]
+    """Order is the point. A duplicate run that created its own in_progress
+    check on the SHA would leave a check nothing completes — the connector's
+    callback completes the winner's — and it would hang until the watchdog."""
+    names = [str(step.get("name", "")) for step in action["runs"]["steps"]]
+    guard = next(i for i, n in enumerate(names) if "Claim the dispatch slot" in n)
+    create = next(i for i, n in enumerate(names) if "Create pending check run" in n)
+    dispatch = next(
+        i for i, n in enumerate(names) if n == "Dispatch connector workflow"
+    )
+    assert guard < create < dispatch
+
+
+def test_the_guard_invokes_the_script_at_a_real_path(action: dict) -> None:  # type: ignore[type-arg]
+    step = _step(action, "Claim the dispatch slot")
+    assert "e2e_dispatch_guard.py" in step["run"]
+    assert (_REPO_ROOT / ".github/scripts/e2e_dispatch_guard.py").is_file()
+
+
+def test_the_guard_cannot_fail_the_dispatch(action: dict) -> None:  # type: ignore[type-arg]
+    """Both halves of failing open. `continue-on-error` keeps a crashed guard
+    from ending the job before the dispatch, and `!= 'false'` keeps the empty
+    output a crashed step leaves behind from reading as "somebody else has it"."""
+    guard = _step(action, "Claim the dispatch slot")
+    assert guard["continue-on-error"] is True
+
+    for name in ("Create pending check run", "Dispatch connector workflow"):
+        condition = _step(action, name)["if"]
+        assert "steps.dispatch_guard.outputs.claimed != 'false'" in condition, (
+            f"{name} must proceed unless the guard positively reported a "
+            "duplicate; anything else fails closed and silently drops e2e"
+        )
+
+
+def test_the_guard_is_callback_mode_only(action: dict) -> None:  # type: ignore[type-arg]
+    """Not a scope decision. In poll mode THIS job's conclusion is the verdict,
+    so a skipped dispatch would be a vacuous green that can mask the winner's
+    real result on the same SHA. In callback mode the verdict is the check run,
+    which the duplicate run's own connector gate reads."""
+    assert (
+        "inputs.wait-mode == 'callback'"
+        in _step(action, "Claim the dispatch slot")["if"]
+    )
+
+
+def test_the_guard_uses_this_repos_own_token(action: dict) -> None:  # type: ignore[type-arg]
+    # The claim refs live in THIS repo, next to the SHA they key on. The fleet
+    # App tokens are scoped for other jobs: github-token to the connector,
+    # checks-app-token to check ownership.
+    env = _step(action, "Claim the dispatch slot")["env"]
+    assert env["GH_TOKEN"] == "${{ github.token }}"
+    assert env["REPO"] == "${{ github.repository }}"
+    assert env["SHA"] == "${{ inputs.check-sha }}"
+    assert env["NAME"] == "${{ inputs.check-run-name }}"
+
+
+def test_the_caller_grants_what_the_guard_needs() -> None:
+    """A job-level permissions block REPLACES the workflow default rather than
+    merging with it, so a missing grant here does not fail loudly — the guard
+    just fails open and every duplicate dispatches again, which is invisible."""
+    jobs = yaml.safe_load(_PR_WORKFLOW.read_text(encoding="utf-8"))["jobs"]
+    permissions = jobs["connector-tests"]["permissions"]
+    assert permissions["contents"] == "write", "claim refs are created and deleted"
+    assert permissions["checks"] == "read", "has this SHA already been dispatched?"
+    assert permissions["pull-requests"] == "read", "the stale-claim prune"
+
+
+def test_the_guard_keys_on_the_same_sha_as_the_check_run() -> None:
+    """The claim, the check run and the connector gate's poll must all name one
+    SHA. If the claim keyed on anything else, the "already dispatched" evidence
+    would be looked for on a commit that never had it."""
+    jobs = yaml.safe_load(_PR_WORKFLOW.read_text(encoding="utf-8"))["jobs"]
+    step = next(
+        s for s in jobs["connector-tests"]["steps"] if "e2e-apps" in str(s.get("uses"))
+    )
+    assert step["with"]["check-sha"] == (
+        "${{ github.event_name == 'merge_group' && github.sha "
+        "|| github.event.pull_request.head.sha }}"
+    )
+
+
+def test_the_claimant_dataclass_ignores_the_attempt_for_ownership() -> None:
+    # Spelled out because the opposite reading is tempting and would break the
+    # only supported way to retry a dispatch.
+    assert Claimant(run_id=7, attempt=1, claimed_at=None).is_my_run(7)
+    assert not Claimant(run_id=7, attempt=1, claimed_at=None).is_my_run(8)

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -469,8 +469,23 @@ jobs:
     # wait-mode != 'callback' and never runs here. A job-level permissions block
     # replaces rather than merges with the workflow defaults, so contents:read
     # is spelled out explicitly.
+    #
+    # The three grants beyond that all belong to e2e-apps' duplicate-dispatch
+    # guard (FND-646), which runs on github.token because the claim refs live in
+    # THIS repo:
+    #   contents: write     — create/delete refs/e2e-dispatch/<app>/<sha>, the
+    #                         atomic CAS that decides which of several runs on one
+    #                         SHA reaches a tenant. Same capability, same reason,
+    #                         and the same "only in a job that runs no test code"
+    #                         scoping as tests-reusable's lease-tenant job.
+    #   checks: read        — has this SHA already been dispatched? The
+    #                         'Connector E2E run / <app>' check is the evidence.
+    #   pull-requests: read — the stale-claim prune keeps a claim only while its
+    #                         SHA is still an open PR head.
     permissions:
-      contents: read
+      contents: write
+      checks: read
+      pull-requests: read
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.matrix-builder.outputs.matrix) }}

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -480,11 +480,19 @@ jobs:
     #                         scoping as tests-reusable's lease-tenant job.
     #   checks: read        — has this SHA already been dispatched? The
     #                         'Connector E2E run / <app>' check is the evidence.
+    #   actions: read       — tell a claimant that died before dispatching from
+    #                         one that is mid-dispatch. Without it the run read
+    #                         404s, a LIVE claimant reads as dead, and its claim
+    #                         is reclaimed — a second connector run onto the same
+    #                         tenants, i.e. the bug the guard exists to prevent.
+    #                         The sibling lease-tenant job grants this for the
+    #                         same reason.
     #   pull-requests: read — the stale-claim prune keeps a claim only while its
     #                         SHA is still an open PR head.
     permissions:
       contents: write
       checks: read
+      actions: read
       pull-requests: read
     strategy:
       fail-fast: false

--- a/docs/standards/connector-ci-e2e.md
+++ b/docs/standards/connector-ci-e2e.md
@@ -53,6 +53,46 @@ than cancelling it (`cancel-in-progress: false`). That is deliberate —
 cancelling mid-run abandons a live Automation Engine run and leaves tenant state
 behind — and it is a separate decision from the gating above.
 
+### One dispatch per commit, however many events GitHub sends
+
+GitHub can emit several `pull_request` events for one head SHA. Observed on
+PR #3306: `opened`, then `labeled e2e` **twice**, one second apart — three
+events, one commit, three full `PR Checks` runs, and three independent
+dispatches into the same connector. Those three connector runs then fought over
+the same three cloud tenants: one ran the suite in ten minutes, the other two
+split the freed leases between them and blocked on each other for the whole
+90-minute wait budget (FND-646).
+
+No workflow `if:` can tell two identical `labeled` events apart, so `e2e-apps`
+(`wait-mode: callback`) claims a dispatch slot before it dispatches:
+
+* One ref per commit and app — `refs/e2e-dispatch/<app>/<sha>`, created by an
+  atomic CAS. `POST /git/refs` returns 422 when the ref exists, and exactly one
+  of N simultaneous callers sees 201. Same primitive as the `(app, cloud)`
+  tenant lease.
+* A run that loses creates **no check run** and dispatches nothing. It stays
+  green: the verdict for that commit is the single `Connector E2E run / <app>`
+  check the winner created, and every duplicate run's own Connector Tests Gate
+  polls that same check and reports the same answer.
+* **Re-running the dispatch job still re-dispatches.** The claim is owned by a
+  *run*, not a run attempt, so a re-run of the run that claimed it proceeds.
+* A claim whose run died before dispatching is reclaimed by the next contender,
+  so a crashed dispatcher cannot leave a commit with no e2e.
+* Every failure of the guard itself — no permission, a rate limit, an
+  unreadable answer — **dispatches anyway** with a warning. A commit whose e2e
+  silently never ran is far worse than a duplicate, which is only the
+  pre-existing behaviour.
+
+Duplicate `PR Checks` runs still appear, and each still pays for its base-image
+build. That is accepted: it is cheap and it never reaches a tenant.
+
+Explicitly rejected: `concurrency: cancel-in-progress` on the dispatching
+workflow. The dispatch is fire-and-forget, so cancelling the SDK-side run
+orphans the connector run it already started rather than stopping it — and a
+cancelled connector run is not even safe, because `prepare-tenant` carries
+`if: always()` and finishes installing onto the tenants it had already leased on
+its way out.
+
 ## SDR composite action inputs
 
 ```yaml


### PR DESCRIPTION
Linear: [FND-646](https://linear.app/atlan-epd/issue/FND-646/e2e-tenant-leases-one-label-spawns-duplicate-runs-and-cross-run-lease) — **Fix A** of three. This is the base of a stack: #3309 adds the ordered-lease driver, #3310 flips the workflow onto it.

## What broke

GitHub emitted **three** `pull_request` events for one head SHA on PR #3306: `opened` at 01:17:18, then `labeled e2e` at 01:17:19 **and again** at 01:17:20. Each spawned a full `PR Checks` run, each satisfied the `connector-tests` gate independently, and each dispatched every connector repo. One commit produced three `Tests` runs in `atlan-openapi-app`:

| SDK run | dispatch step | connector run |
| -- | -- | -- |
| 32320469314 | 01:19:25 | 32320599606 |
| 32320470344 | 01:19:37 | 32320612381 |
| 32320469975 | 01:24:42 | 32320919397 |

Those three runs then fought over the same three cloud tenants — the winner ran the suite in ten minutes, the two losers split the freed leases between them and blocked on each other for the full 90-minute wait budget.

Nothing in a workflow `if:` can tell two identical `labeled` events apart, so the amplification is killed at the dispatch.

## What this does

`e2e-apps` (`wait-mode: callback`) claims `refs/e2e-dispatch/<app>/<sha>` by atomic CAS before it dispatches — the same primitive the tenant lease uses, where GitHub's 422 on creating an existing ref *is* the lock. A run that loses creates **no check run** and dispatches nothing.

Skipping loses nothing: the verdict for that commit is the single `Connector E2E run / <app>` check the winner created, and every duplicate run's own Connector Tests Gate polls that same check by SHA and reports the same answer.

**At most one *live* dispatch, not one ever.** A permanent claim would be a footgun, so an existing claim resolves as:

| claim state | outcome |
| -- | -- |
| held by **this run** (any attempt) | proceed — a job re-run is a request to re-dispatch |
| held by another run, check exists on the SHA | skip — the dispatch happened |
| held by another run, no check, that run still live | skip — a peer is mid-dispatch |
| held by another run, no check, that run is over | reclaim — the claimer died before dispatching |

**Every failure fails OPEN** — no permission, a rate limit, an unreadable answer, a crashed step — with a `::warning::`. That is the opposite of the tenant lease's posture and deliberate: this guards against a *duplicate* dispatch, not against two installers on one tenant, so a broken guard's worst case is the pre-existing behaviour. A commit whose e2e silently never ran would be far worse.

**Callback mode only**, and that is correctness rather than scope: in poll mode the dispatching job's own conclusion *is* the verdict, so a skipped dispatch would be a vacuous green that can mask the winner's real result on the same SHA. Poll mode's one caller also dispatches into a hermetic kind cluster and has no tenant to contend for.

**Pruning.** Claims are per-SHA, so the namespace would otherwise grow with every merge-queue dispatch. On the claiming path only, a claim is deleted when its SHA is neither the one being claimed now nor an open PR head, *and* no dispatch for it can still be live. Bounded pages, capped deletes, every failure a warning.

## Explicitly rejected

`concurrency: cancel-in-progress` on `pull_request.yaml`. The dispatch is fire-and-forget, so cancelling the SDK-side run orphans the connector run it already started rather than stopping it — and a cancelled connector run is not even safe: `prepare-tenant` carries `if: always()`, so it finishes installing onto the tenants it had already leased on its way out (observed: two `Prepare tenant` legs succeeded *after* the cancel). A queueing group is worse still — GitHub holds one pending run per group, so a third arrival is evicted with no log at all (FND-218).

## Permissions

`connector-tests` gains `contents: write` (the claim refs), `checks: read` (has this SHA been dispatched?) and `pull-requests: read` (the prune). Same "only in a job that runs no test code" scoping as `tests-reusable`'s `lease-tenant`.

## Tests

54 new tests in `.github/scripts/tests/test_e2e_dispatch_guard.py`, run by `CI script tests`. The load-bearing ones: the CAS decides rather than the pre-read (a contender that read "free" then lost must fall through to judging the winner), every failure direction dispatches anyway, the guard runs before the check run is created, and the prune never deletes a claim whose dispatch may still be live.

Full suite: 2985 passed.
