### PR TITLE
ci(e2e): teach the tenant lease to take several tenants in a fixed order (FND-646)

### DIFF
--- a/.github/actions/e2e-tenant-lease/action.yaml
+++ b/.github/actions/e2e-tenant-lease/action.yaml
@@ -58,6 +58,11 @@ inputs:
       function of the names: derive it from anything per-run and two contenders
       disagree about which lock comes first, which is the whole guarantee.
 
+      Names are canonicalised to the lease key before they are ordered, so
+      spelling cannot reorder the locks: `aws, gcp` and `aws,gcp` are one pair of
+      tenants taken in one order, and a difference in case or spacing between two
+      callers cannot invert them.
+
       Empty falls back to `cloud`, so a caller can pass both unconditionally —
       no branching shell — and the single-tenant path, where the resolved cloud
       list is legitimately empty, keeps leasing "default".

--- a/.github/actions/e2e-tenant-lease/action.yaml
+++ b/.github/actions/e2e-tenant-lease/action.yaml
@@ -37,6 +37,34 @@ inputs:
     description: |
       Cloud whose tenant this is; the other half of the lease key. Empty is
       valid and means the single-tenant fallback path, keyed as "default".
+
+      Mutually exclusive with `clouds`: passing both non-empty fails rather than
+      picking one, because silently preferring one would leave the other's tenant
+      unserialised while the job still went green.
+    required: false
+    default: ""
+  clouds:
+    description: |
+      Comma-separated clouds to lease as ONE ordered set. `acquire` takes them
+      in a fixed order (sorted by name) under a single total `wait-seconds`
+      budget, and hands back everything it took if it cannot get the whole set;
+      `release` gives the same set back.
+
+      This is what makes a cross-CSP run safe. The per-cloud matrix it replaces
+      acquired every cloud in parallel and held each while blocking on the rest
+      — hold-and-wait, which deadlocked as soon as two runs queued behind one
+      holder and split the freed set between them (FND-646). Ordering by name
+      makes a cycle structurally impossible, and the order MUST stay a pure
+      function of the names: derive it from anything per-run and two contenders
+      disagree about which lock comes first, which is the whole guarantee.
+
+      Empty falls back to `cloud`, so a caller can pass both unconditionally —
+      no branching shell — and the single-tenant path, where the resolved cloud
+      list is legitimately empty, keeps leasing "default".
+
+      NOT accepted by `verify`, deliberately: each install leg must confirm its
+      OWN tenant, and a set-shaped verify would invite it to check the aggregate
+      again — the approximation `verify` was added to replace.
     required: false
     default: ""
   wait-seconds:
@@ -105,8 +133,21 @@ outputs:
       the job green with only a warning.
     value: ${{ steps.lease.outputs.state }}
   lease-ref:
-    description: The tenant's lease ref this run raced for.
+    description: |
+      The lease ref the outcome hinged on: the tenant this run raced for in
+      single-cloud mode, and in `clouds` mode the last one taken when the whole
+      set was acquired or the one that blocked otherwise. One specific tenant to
+      name in an error, never a guess about which of the set it was.
     value: ${{ steps.lease.outputs.lease-ref }}
+  lease-refs:
+    description: |
+      Every lease ref this run now holds, comma-separated; empty unless
+      `acquired` is true. Acquisition is all-or-nothing, so this is either the
+      whole requested set or nothing — never a partial hold.
+    value: ${{ steps.lease.outputs.lease-refs }}
+  clouds:
+    description: The clouds this run leased, comma-separated and in acquisition order.
+    value: ${{ steps.lease.outputs.clouds }}
   holder-run-id:
     description: The run holding the lease when this one gave up waiting; else empty.
     value: ${{ steps.lease.outputs.holder-run-id }}
@@ -123,6 +164,7 @@ runs:
         MODE: ${{ inputs.mode }}
         APP: ${{ inputs.app }}
         CLOUD: ${{ inputs.cloud }}
+        CLOUDS: ${{ inputs.clouds }}
         WAIT_SECONDS: ${{ inputs.wait-seconds }}
         POLL_SECONDS: ${{ inputs.poll-seconds }}
         TTL_SECONDS: ${{ inputs.ttl-seconds }}
@@ -143,6 +185,7 @@ runs:
           --repo "$LEASE_REPO" \
           --app "$APP" \
           --cloud "$CLOUD" \
+          --clouds "$CLOUDS" \
           --run-id "$RUN_ID" \
           --run-attempt "$RUN_ATTEMPT" \
           --wait-seconds "$WAIT_SECONDS" \

--- a/.github/actions/e2e-tenant-lease/e2e_tenant_lease.py
+++ b/.github/actions/e2e-tenant-lease/e2e_tenant_lease.py
@@ -57,10 +57,32 @@ loudly and names the holder — a run that starves gets a red job saying the ten
 was busy, not silence. Correctness first; FIFO was the property that turned out
 to be unaffordable.
 
+One run, several tenants: ordered acquisition
+--------------------------------------------
+A cross-CSP run needs one tenant per cloud, and it needs all of them for its
+whole life. Taking them in PARALLEL and holding each while blocking on the rest
+is hold-and-wait, and it deadlocked in production the first time two runs queued
+behind one holder (FND-646): the holder released all three leases, the two
+waiters raced for the freed set and *split* it, and each then blocked on what the
+other held for the full wait budget. With ≥2 runs queued behind a holder that
+split is the expected outcome, not a rare interleaving.
+
+So a run that wants several tenants takes them one at a time, in a fixed order
+derived only from the cloud names (``acquire_ordered``, ``--clouds``). Resource
+ordering makes a cycle impossible, so the worst case degrades from mutual
+blocking to plain serialisation, and nothing is ever cancelled.
+
+Note what this is NOT: it is not the ordered ticket queue rejected above. That
+attempt replaced the CAS with an ordering and got fairness instead of exclusion.
+The CAS below is untouched and remains the only thing that grants a lease; the
+ordering governs only the sequence in which ONE run takes several of them.
+
 API budget
 ----------
 ``GITHUB_TOKEN`` allows 1000 requests/hour **per repository**, and every matrix
-leg of a run shares that one budget. A waiting poll therefore has to be cheap or
+leg of a run shares that one budget. Ordered acquisition helps here too: polling
+one lease at a time rather than three concurrently divides a waiting run's
+request rate by the number of clouds. A waiting poll therefore has to be cheap or
 the lease starves itself of API calls precisely when several legs are queueing —
 and a rate-limit 403 looks exactly like a permission 403, which used to fail the
 lease open. So:
@@ -719,6 +741,137 @@ def acquire(
     return ("rate-limited" if rate_limited else "timeout"), blocker
 
 
+@dataclass(frozen=True)
+class OrderedOutcome:
+    """The result of an ordered multi-cloud acquisition.
+
+    ``ref`` is the one the outcome hinged on — the last lease taken when the
+    whole set was acquired, the one that blocked otherwise — so a caller has one
+    specific tenant to name in an error instead of guessing which of the set it
+    was.
+    """
+
+    state: str
+    blocker: Holder | None
+    held: tuple[str, ...]
+    ref: str
+
+
+def acquire_ordered(
+    repo: str,
+    app: str,
+    clouds: list[str],
+    run_id: int,
+    attempt: int,
+    *,
+    wait_seconds: int,
+    poll_seconds: int,
+    ttl_seconds: int,
+    sleep=time.sleep,
+    clock=time.time,
+) -> OrderedOutcome:
+    """Take EVERY cloud's lease, in a fixed order, under one total budget.
+
+    ``state`` is "acquired" | "disabled" | "timeout" | "rate-limited", and
+    "acquired" is all-or-nothing: any other state hands back whatever was taken
+    on the way, so the caller either holds the whole set or nothing.
+
+    Why ordered, and why one job
+    ----------------------------
+    ``lease-tenant`` used to be a per-cloud matrix that acquired each cloud's
+    lease in PARALLEL and held it for the whole run, with the install gated on
+    the matrix aggregate. That is textbook hold-and-wait: a run that wins a
+    subset sits on those tenants while blocking on the rest. It deadlocked in
+    production the moment two runs queued behind one holder (FND-646) — the
+    holder released all three leases, the two waiters raced for the freed set
+    and *split* it (one took aws + azure, the other gcp), and each then blocked
+    on what the other held for the full wait budget.
+
+    That split is the EXPECTED outcome of a parallel matrix whenever ≥2 runs are
+    queued behind a holder, not a rare interleaving. Acquiring in a fixed global
+    order makes it structurally impossible: two runs can never hold locks the
+    other needs out of order, so the worst case degrades from mutual blocking to
+    plain serialisation. No run is ever cancelled — a queued run waits and then
+    proceeds.
+
+    The order is ``sorted()`` over the cloud names, and it MUST stay a pure
+    function of the names. Deriving it from anything per-run (run id, arrival
+    order, the caller's list order) is what breaks the guarantee, because two
+    contenders would then disagree about which lock comes first. Every contender
+    also computes it over its OWN resolved cloud list, which may be a subset —
+    that is fine and is why sorting works: any two runs still take their common
+    subset in the same relative order.
+
+    This is NOT the ordered ticket queue the module docstring rejects. That
+    attempt replaced the atomic CAS with a run_id ordering and got fairness
+    instead of exclusion. Here the CAS is untouched and still the only thing that
+    grants a lease; the ordering governs only the sequence in which ONE run takes
+    several of them.
+
+    ``wait_seconds`` is a TOTAL budget across the set, not per cloud, so the job
+    timeout still bounds the whole thing. It also cuts the API cost: polling one
+    lease at a time instead of three concurrently divides the per-run request
+    rate by the number of clouds, and that rate is the binding constraint (see
+    the module docstring's API budget section).
+    """
+    order = sorted(set(clouds))
+    held: list[str] = []
+    deadline = clock() + wait_seconds
+    ref = lease_ref(app, order[0])
+
+    for cloud in order:
+        ref = lease_ref(app, cloud)
+        remaining = int(deadline - clock())
+        if remaining <= 0:
+            print(
+                f"::error::the {wait_seconds}s tenant-lease budget ran out before "
+                f"{ref} could be taken."
+            )
+            release_all(repo, held, run_id, attempt)
+            return OrderedOutcome("timeout", None, (), ref)
+
+        state, blocker = acquire(
+            repo,
+            ref,
+            run_id,
+            attempt,
+            wait_seconds=remaining,
+            poll_seconds=poll_seconds,
+            ttl_seconds=ttl_seconds,
+            sleep=sleep,
+            clock=clock,
+        )
+        if state == "acquired":
+            held.append(ref)
+            continue
+
+        # Hand back everything taken on the way in. release-tenant would do it
+        # too, but only after this job's own failure has propagated — and holding
+        # tenants across that gap is the hold-and-wait this function exists to
+        # remove.
+        if held:
+            print(
+                f"Giving back {len(held)} lease(s) already held, because the "
+                f"whole set could not be taken: {', '.join(held)}"
+            )
+        release_all(repo, held, run_id, attempt)
+        return OrderedOutcome(state, blocker, (), ref)
+
+    print(f"All {len(held)} tenant lease(s) acquired in order: {', '.join(held)}")
+    return OrderedOutcome("acquired", None, tuple(held), ref)
+
+
+def release_all(repo: str, refs: list[str], run_id: int, attempt: int) -> None:
+    """Release several leases, ownership-checked one at a time.
+
+    Reverse order, so the lock taken last is given back first. It makes no
+    difference to correctness — releases cannot block — but it keeps the log
+    reading as the inverse of the acquisition.
+    """
+    for ref in reversed(refs):
+        release(repo, ref, run_id, attempt)
+
+
 def _sleep_for_rate_limit(sleep, poll_seconds: int, retry_after: int | None) -> None:
     """Back off after a rate limit, honouring Retry-After within reason.
 
@@ -847,6 +1000,17 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--cloud", default="", help="Cloud (lease key part); empty = single tenant."
     )
+    parser.add_argument(
+        "--clouds",
+        default="",
+        help="Comma-separated clouds to lease as ONE ordered set (acquire and "
+        "release only). Empty falls back to --cloud, so a caller that always "
+        "passes both needs no conditional shell and the single-tenant path — "
+        "where the resolved cloud list is legitimately empty — keeps working. "
+        "Acquisition is sorted by cloud name and --wait-seconds becomes a TOTAL "
+        "budget across the set; see acquire_ordered for why the order must be a "
+        "pure function of the names.",
+    )
     parser.add_argument("--run-id", required=True, type=int, help="github.run_id")
     parser.add_argument(
         "--run-attempt", required=True, type=int, help="github.run_attempt"
@@ -905,30 +1069,79 @@ def main(argv: list[str] | None = None) -> int:
             "(0 disables the TTL backstop)"
         )
 
+    clouds = [cloud for cloud in args.clouds.split(",") if cloud.strip()]
+    if clouds and args.cloud.strip():
+        # Silently preferring one would make the OTHER one's tenant unserialised
+        # while the job still went green.
+        raise SystemExit(
+            f"::error::--cloud {args.cloud!r} and --clouds {args.clouds!r} were "
+            "both given; pass one. --clouds leases an ordered set, --cloud leases "
+            "one tenant, and an empty --clouds falls back to --cloud."
+        )
+
     ref = lease_ref(args.app, args.cloud)
 
     if args.mode == "release":
-        release(args.repo, ref, args.run_id, args.run_attempt)
+        # Ordered acquisition means a single job may hold several leases, so the
+        # release side has to be able to give back the same set. Ownership is
+        # checked per ref, so a set this run only partly holds is safe.
+        release_all(
+            args.repo,
+            [lease_ref(args.app, cloud) for cloud in sorted(clouds)] or [ref],
+            args.run_id,
+            args.run_attempt,
+        )
         return 0
 
     if args.mode == "verify":
+        # Deliberately single-cloud only. Verify exists because a matrix job
+        # cannot depend on its own leg of an upstream matrix, so each install leg
+        # confirms ITS OWN tenant; a --clouds form here would invite the install
+        # to check the aggregate again, which is the exact approximation this mode
+        # was added to replace.
+        if clouds:
+            raise SystemExit(
+                "::error::--mode verify takes --cloud, not --clouds: each install "
+                "leg must confirm its own tenant rather than the set."
+            )
         held = verify_held(args.repo, ref, args.run_id, args.run_attempt)
         return 0 if held else 1
 
-    state, blocker = acquire(
-        args.repo,
-        ref,
-        args.run_id,
-        args.run_attempt,
-        wait_seconds=args.wait_seconds,
-        poll_seconds=args.poll_seconds,
-        ttl_seconds=args.ttl_seconds,
-    )
+    if clouds:
+        outcome = acquire_ordered(
+            args.repo,
+            args.app,
+            clouds,
+            args.run_id,
+            args.run_attempt,
+            wait_seconds=args.wait_seconds,
+            poll_seconds=args.poll_seconds,
+            ttl_seconds=args.ttl_seconds,
+        )
+        state, blocker, held_refs = outcome.state, outcome.blocker, list(outcome.held)
+        # The ref the outcome hinged on, so the errors below name one specific
+        # tenant. `lease-refs` carries the whole set.
+        ref = outcome.ref
+    else:
+        held_refs = []
+        state, blocker = acquire(
+            args.repo,
+            ref,
+            args.run_id,
+            args.run_attempt,
+            wait_seconds=args.wait_seconds,
+            poll_seconds=args.poll_seconds,
+            ttl_seconds=args.ttl_seconds,
+        )
+        if state == "acquired":
+            held_refs = [ref]
     write_outputs(
         {
             "acquired": "true" if state == "acquired" else "false",
             "state": state,
             "lease-ref": ref,
+            "lease-refs": ",".join(held_refs),
+            "clouds": ",".join(sorted(clouds)) if clouds else args.cloud,
             "holder-run-id": str(blocker.run_id) if blocker else "",
         },
         os.environ.get("GITHUB_OUTPUT"),

--- a/.github/actions/e2e-tenant-lease/e2e_tenant_lease.py
+++ b/.github/actions/e2e-tenant-lease/e2e_tenant_lease.py
@@ -797,7 +797,17 @@ def acquire_ordered(
     The order is ``sorted()`` over the cloud names, and it MUST stay a pure
     function of the names. Deriving it from anything per-run (run id, arrival
     order, the caller's list order) is what breaks the guarantee, because two
-    contenders would then disagree about which lock comes first. Every contender
+    contenders would then disagree about which lock comes first.
+
+    It sorts the ``slug()`` of each name — the same canonical form ``lease_ref``
+    keys the lease on — rather than the raw token, because the order has to be a
+    pure function of the *lock*, not of its spelling. Sorting raw tokens would let
+    ``"aws, gcp"`` and ``"aws,gcp"`` (or a difference in case) take the very same
+    pair of locks in opposite orders, which is exactly the disagreement that
+    reopens the FND-646 cycle. Canonicalizing first also makes the dedup real:
+    two spellings of one cloud collapse to the one lease they name.
+
+    Every contender
     also computes it over its OWN resolved cloud list, which may be a subset —
     that is fine and is why sorting works: any two runs still take their common
     subset in the same relative order.
@@ -814,7 +824,7 @@ def acquire_ordered(
     rate by the number of clouds, and that rate is the binding constraint (see
     the module docstring's API budget section).
     """
-    order = sorted(set(clouds))
+    order = sorted({slug(cloud) for cloud in clouds})
     held: list[str] = []
     deadline = clock() + wait_seconds
     ref = lease_ref(app, order[0])
@@ -867,9 +877,22 @@ def release_all(repo: str, refs: list[str], run_id: int, attempt: int) -> None:
     Reverse order, so the lock taken last is given back first. It makes no
     difference to correctness — releases cannot block — but it keeps the log
     reading as the inverse of the acquisition.
+
+    Every ref is attempted even if one release exhausts its transport retries and
+    raises: this is the unwind path for a partial hold, so abandoning the rest at
+    the first failure would leave earlier leases held until their TTL expires —
+    the hold-and-wait ``acquire_ordered`` exists to remove. The first failure is
+    re-raised once the whole set has been attempted, so the job still goes red.
     """
+    failure: SystemExit | None = None
     for ref in reversed(refs):
-        release(repo, ref, run_id, attempt)
+        try:
+            release(repo, ref, run_id, attempt)
+        except SystemExit as exc:
+            print(f"::warning::could not release {ref}; continuing with the rest.")
+            failure = failure or exc
+    if failure is not None:
+        raise failure
 
 
 def _sleep_for_rate_limit(sleep, poll_seconds: int, retry_after: int | None) -> None:
@@ -1069,7 +1092,12 @@ def main(argv: list[str] | None = None) -> int:
             "(0 disables the TTL backstop)"
         )
 
-    clouds = [cloud for cloud in args.clouds.split(",") if cloud.strip()]
+    # Canonicalize to the same form `lease_ref` keys the lease on, so the
+    # acquisition order is a function of the lock rather than of its spelling:
+    # "aws, gcp" and "aws,gcp" name one pair of locks and must take them in one
+    # order. Blank tokens are dropped on the raw text first, because `slug("")`
+    # is the single-tenant "default" rather than nothing.
+    clouds = [slug(cloud) for cloud in args.clouds.split(",") if cloud.strip()]
     if clouds and args.cloud.strip():
         # Silently preferring one would make the OTHER one's tenant unserialised
         # while the job still went green.

--- a/.github/scripts/tests/test_e2e_tenant_lease.py
+++ b/.github/scripts/tests/test_e2e_tenant_lease.py
@@ -1367,6 +1367,30 @@ def test_ordered_acquisition_deduplicates_clouds(http: FakeHTTP) -> None:
     assert list(outcome.held) == [_ref_for("aws")]
 
 
+@pytest.mark.parametrize("spelling", ["aws,gcp", "aws, gcp", " GCP ,aws", "AWS,gcp"])
+def test_ordered_acquisition_orders_by_the_lease_key_not_the_spelling(
+    spelling: str, http: FakeHTTP
+) -> None:
+    """Every spelling of one set names the same pair of LOCKS, so every spelling
+    has to take them in the same order. Sorting the raw tokens does not: " gcp"
+    sorts before "aws" on its leading space, so `"aws, gcp"` and `"aws,gcp"` would
+    take one pair of locks in opposite orders — two contenders disagreeing about
+    which lock comes first, which is exactly the FND-646 cycle. So the sort key is
+    the `slug()` the lease is keyed on, not the text the caller typed."""
+    _stub_free_and_claimable(http, ["aws", "gcp"])
+    _ordered(spelling.split(","))
+    assert _claimed_refs(http) == [_ref_for("aws"), _ref_for("gcp")]
+
+
+def test_ordered_acquisition_deduplicates_across_spellings(http: FakeHTTP) -> None:
+    # Same lease named twice. Canonicalizing before the dedup is what collapses
+    # it to one entry; two raw spellings would CAS the one ref twice, and the
+    # second attempt reads this run's own lease as somebody else's occupancy.
+    _stub_free_and_claimable(http, ["aws"])
+    outcome = _ordered(["aws", " AWS "])
+    assert list(outcome.held) == [_ref_for("aws")]
+
+
 def test_a_blocked_cloud_gives_back_what_was_already_held(http: FakeHTTP) -> None:
     """The whole point. Holding aws while blocking on azure is hold-and-wait —
     exactly the shape that deadlocked when two runs split a freed set — so a run
@@ -1433,6 +1457,31 @@ def test_release_all_gives_every_lease_back(http: FakeHTTP) -> None:
 def test_release_all_of_nothing_makes_no_calls(http: FakeHTTP) -> None:
     release_all(REPO, [], 100, 1)
     assert http.calls == []
+
+
+def test_release_all_attempts_every_ref_even_when_one_release_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """This is the unwind path for a partial hold, so it must not abandon the rest
+    of the set at the first transport failure: the leases it skipped would stay
+    held until their TTL expired, which is the hold-and-wait that ordered
+    acquisition exists to remove. Every ref is attempted, then the first failure
+    is re-raised so the job still goes red."""
+    attempted: list[str] = []
+
+    def failing_release(repo: str, ref: str, run_id: int, attempt: int) -> bool:
+        attempted.append(ref)
+        if ref == _ref_for("gcp"):
+            raise SystemExit("::error::curl retries exhausted")
+        return True
+
+    monkeypatch.setattr("e2e_tenant_lease.release", failing_release)
+
+    with pytest.raises(SystemExit, match="retries exhausted"):
+        release_all(REPO, [_ref_for("aws"), _ref_for("gcp")], 100, 1)
+
+    # Reverse order, so gcp is the one that fails — and aws is still given back.
+    assert attempted == [_ref_for("gcp"), _ref_for("aws")]
 
 
 # --- the ordered CLI -------------------------------------------------------

--- a/.github/scripts/tests/test_e2e_tenant_lease.py
+++ b/.github/scripts/tests/test_e2e_tenant_lease.py
@@ -38,6 +38,7 @@ from e2e_tenant_lease import (  # noqa: E402
     _denied,
     _rate_limited,
     acquire,
+    acquire_ordered,
     create_identity_blob,
     gh_request,
     holder_is_live,
@@ -45,6 +46,7 @@ from e2e_tenant_lease import (  # noqa: E402
     main,
     read_holder,
     release,
+    release_all,
     release_ref,
     slug,
     try_acquire,
@@ -1282,3 +1284,233 @@ def test_main_validates_before_touching_the_api(
     monkeypatch.delenv("GITHUB_TOKEN", raising=False)
     with pytest.raises(SystemExit, match="poll-seconds"):
         main(_argv("acquire", "--poll-seconds", "0"))
+
+
+# --- ordered multi-cloud acquisition (FND-646) ------------------------------
+#
+# The property under test is the absence of a deadlock, which no single-run test
+# can observe directly. What CAN be pinned is the mechanism that rules it out:
+# one run takes its tenants one at a time, in an order that is a pure function of
+# the cloud names, and gives back everything if it cannot get the whole set. Get
+# any of those three wrong and hold-and-wait is back.
+
+
+def _ref_for(cloud: str) -> str:
+    return f"refs/e2e-tenant-lease/example/{cloud}/holder"
+
+
+def _path_of(ref: str) -> str:
+    """The URL fragment FakeHTTP routes on for a given lease ref."""
+    return "/git/ref/" + ref.removeprefix("refs/")
+
+
+def _ordered(clouds: list[str], **kwargs):
+    defaults = dict(
+        wait_seconds=60,
+        poll_seconds=30,
+        ttl_seconds=0,
+        sleep=lambda _s: None,
+        clock=lambda: 1000.0,
+    )
+    defaults.update(kwargs)
+    return acquire_ordered(REPO, "example", clouds, 100, 1, **defaults)
+
+
+def _claimed_refs(http: FakeHTTP) -> list[str]:
+    """The refs this run put through the CAS, in the order it tried them.
+
+    Read from the payloads rather than the URLs because every ref creation POSTs
+    to the same endpoint — the ref name only exists in the body.
+    """
+    return [p["ref"] for p in http.payloads if "ref" in p]
+
+
+def _stub_free_and_claimable(http: FakeHTTP, clouds: list[str]) -> None:
+    for cloud in clouds:
+        http.route("GET", _path_of(_ref_for(cloud)), (404, {"message": "Not Found"}))
+    _stub_blob_write(http)
+    http.route("POST", "/git/refs", *[(201, {"ref": ""}) for _ in clouds])
+
+
+def test_ordered_acquisition_takes_every_cloud(http: FakeHTTP) -> None:
+    _stub_free_and_claimable(http, ["aws", "azure", "gcp"])
+    outcome = _ordered(["aws", "azure", "gcp"])
+    assert outcome.state == "acquired"
+    assert list(outcome.held) == [_ref_for(c) for c in ("aws", "azure", "gcp")]
+
+
+def test_ordered_acquisition_sorts_by_cloud_name(http: FakeHTTP) -> None:
+    """THE guarantee. Resource ordering only excludes a cycle if every contender
+    agrees on the order, so it must come from the names and nothing else — not
+    the caller's list order, not run id, not arrival order."""
+    _stub_free_and_claimable(http, ["aws", "azure", "gcp"])
+    _ordered(["gcp", "aws", "azure"])
+    assert _claimed_refs(http) == [_ref_for(c) for c in ("aws", "azure", "gcp")]
+
+
+def test_ordered_acquisition_of_a_subset_keeps_the_same_relative_order(
+    http: FakeHTTP,
+) -> None:
+    """A repo whose tenant matrix carries only some clouds locks only those. That
+    is safe precisely because sorting a subset preserves the relative order of
+    the locks it shares with any other contender."""
+    _stub_free_and_claimable(http, ["aws", "gcp"])
+    _ordered(["gcp", "aws"])
+    assert _claimed_refs(http) == [_ref_for("aws"), _ref_for("gcp")]
+
+
+def test_ordered_acquisition_deduplicates_clouds(http: FakeHTTP) -> None:
+    # A duplicate would CAS the same ref twice, and the second attempt reads its
+    # own lease as somebody else's occupancy.
+    _stub_free_and_claimable(http, ["aws"])
+    outcome = _ordered(["aws", "aws"])
+    assert list(outcome.held) == [_ref_for("aws")]
+
+
+def test_a_blocked_cloud_gives_back_what_was_already_held(http: FakeHTTP) -> None:
+    """The whole point. Holding aws while blocking on azure is hold-and-wait —
+    exactly the shape that deadlocked when two runs split a freed set — so a run
+    that cannot get the whole set must hold none of it."""
+    theirs = "c" * 40
+    http.route(
+        "GET",
+        _path_of(_ref_for("aws")),
+        # Free on the way in, ours on the way back out.
+        (404, {"message": "Not Found"}),
+        (200, {"ref": _ref_for("aws"), "object": {"sha": BLOB, "type": "blob"}}),
+        (200, {"ref": _ref_for("aws"), "object": {"sha": BLOB, "type": "blob"}}),
+    )
+    http.route(
+        "GET",
+        _path_of(_ref_for("azure")),
+        (200, {"ref": _ref_for("azure"), "object": {"sha": theirs, "type": "blob"}}),
+    )
+    _stub_blob_write(http)
+    http.route("POST", "/git/refs", (201, {"ref": _ref_for("aws")}))
+    http.route("GET", f"/git/blobs/{BLOB}", (200, _holder_blob(100, 1)))
+    http.route("GET", f"/git/blobs/{theirs}", (200, _holder_blob(555)))
+    http.route("GET", "/actions/runs/", _live())
+    http.route("DELETE", "/git/refs/", (204, None))
+
+    outcome = _ordered(["aws", "azure"], wait_seconds=1, poll_seconds=1)
+
+    assert outcome.state == "timeout"
+    assert outcome.held == ()
+    assert outcome.blocker is not None and outcome.blocker.run_id == 555
+    # The error names the tenant that actually blocked, not the first of the set.
+    assert outcome.ref == _ref_for("azure")
+    assert http.count("DELETE", "/git/refs/") == 1
+
+
+def test_the_wait_budget_is_total_across_the_set(http: FakeHTTP) -> None:
+    """`wait-seconds` becomes a budget for the whole ordered set, not a fresh one
+    per cloud — otherwise N clouds could outlast the job timeout by N times over
+    and the runner's "cancelled after Nm" would replace the actionable error."""
+    ticks = iter([1000.0, 1000.0, 1000.0, 9999.0, 9999.0, 9999.0])
+    http.route("GET", _path_of(_ref_for("aws")), (404, {"message": "Not Found"}))
+    _stub_blob_write(http)
+    http.route("POST", "/git/refs", (201, {"ref": _ref_for("aws")}))
+    http.route("GET", f"/git/blobs/{BLOB}", (200, _holder_blob(100, 1)))
+    http.route("DELETE", "/git/refs/", (204, None))
+
+    outcome = _ordered(["aws", "azure"], wait_seconds=60, clock=lambda: next(ticks))
+
+    assert outcome.state == "timeout"
+    # azure was never even attempted: the budget was gone.
+    assert _claimed_refs(http) == [_ref_for("aws")]
+    assert outcome.ref == _ref_for("azure")
+    assert outcome.held == ()
+
+
+def test_release_all_gives_every_lease_back(http: FakeHTTP) -> None:
+    http.route("GET", "/git/ref/", (200, _ref_body()))
+    http.route("GET", "/git/blobs/", (200, _holder_blob(100, 1)))
+    http.route("DELETE", "/git/refs/", (204, None), (204, None))
+    release_all(REPO, [_ref_for("aws"), _ref_for("azure")], 100, 1)
+    assert http.count("DELETE", "/git/refs/") == 2
+
+
+def test_release_all_of_nothing_makes_no_calls(http: FakeHTTP) -> None:
+    release_all(REPO, [], 100, 1)
+    assert http.calls == []
+
+
+# --- the ordered CLI -------------------------------------------------------
+
+
+def _argv_clouds(mode: str, clouds: str, *extra: str) -> list[str]:
+    return [
+        "--mode",
+        mode,
+        "--repo",
+        REPO,
+        "--app",
+        "example",
+        "--clouds",
+        clouds,
+        "--run-id",
+        "100",
+        "--run-attempt",
+        "1",
+        *extra,
+    ]
+
+
+def test_main_acquire_reports_the_whole_set_it_holds(
+    http: FakeHTTP, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    out = tmp_path / "out"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(out))
+    _stub_free_and_claimable(http, ["aws", "gcp"])
+
+    assert main(_argv_clouds("acquire", "gcp,aws")) == 0
+
+    written = out.read_text()
+    assert "acquired=true" in written
+    assert f"lease-refs={_ref_for('aws')},{_ref_for('gcp')}" in written
+    assert "clouds=aws,gcp" in written
+
+
+def test_main_acquire_with_an_empty_cloud_list_falls_back_to_one_tenant(
+    http: FakeHTTP, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The single-tenant path resolves an EMPTY cloud list, so an empty --clouds
+    has to mean "use --cloud" rather than "lease nothing". That is what lets the
+    action pass both unconditionally instead of branching in shell."""
+    out = tmp_path / "out"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(out))
+    _stub_unheld(http)
+    _stub_blob_write(http)
+    http.route("POST", "/git/refs", (201, {"ref": REF}))
+
+    assert main(_argv("acquire", "--clouds", "")) == 0
+    assert f"lease-refs={REF}" in out.read_text()
+
+
+def test_main_rejects_both_cloud_and_clouds(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Preferring one silently would leave the other's tenant unserialised while
+    # the job still went green.
+    monkeypatch.setenv("GH_TOKEN", "x")
+    with pytest.raises(SystemExit, match="both given"):
+        main(_argv("acquire", "--clouds", "aws,gcp"))
+
+
+def test_main_verify_refuses_a_cloud_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    """verify exists so each install leg confirms ITS OWN tenant. A set-shaped
+    verify would invite the install to check the aggregate again, which is the
+    approximation this mode replaced."""
+    monkeypatch.setenv("GH_TOKEN", "x")
+    with pytest.raises(SystemExit, match="verify takes --cloud"):
+        main(_argv_clouds("verify", "aws,gcp"))
+
+
+def test_main_release_gives_back_the_whole_set(
+    http: FakeHTTP, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+    http.route("GET", "/git/ref/", (200, _ref_body()), (200, _ref_body()))
+    http.route("GET", "/git/blobs/", (200, _holder_blob(100, 1)))
+    http.route("DELETE", "/git/refs/", (204, None), (204, None))
+
+    assert main(_argv_clouds("release", "aws,gcp")) == 0
+    assert http.count("DELETE", "/git/refs/") == 2


### PR DESCRIPTION
Linear: [FND-646](https://linear.app/atlan-epd/issue/FND-646/e2e-tenant-leases-one-label-spawns-duplicate-runs-and-cross-run-lease) — **Fix B**, driver half. Stacked on #3308; the workflow flip that uses it is the next PR in the stack.

## What broke

`lease-tenant` is a `fail-fast: false` matrix that acquires each cloud's lease **in parallel**, holds each for the whole run, and gates the install on the matrix aggregate. A run that wins a subset sits on those tenants while blocking on the rest — hold-and-wait.

It deadlocked at the **handoff**, which is what makes it routine rather than rare:

* 01:19:34 — run 32320599606 won all three leases, ran the full e2e, released at 01:29:22 (10 min end to end).
* ~01:29 — the two waiters raced for the freed set and **split** it: 32320612381 took aws + azure, 32320919397 took gcp.
* Each then blocked on what the other held, for the full 5400s budget.

Any time two or more runs are queued behind one holder, the parallel matrix makes that split the *expected* outcome.

## What this does

Adds `acquire_ordered` / `--clouds` to the lease driver: a set of tenants taken **one at a time**, in an order that is a pure function of the cloud names (`sorted()`), under **one total** `wait-seconds` budget, handing back everything it took if it cannot get the whole set.

Resource ordering makes a cycle structurally impossible, so the worst case degrades from mutual blocking to plain serialisation. **No run is ever cancelled** — a queued run waits and then proceeds. That matters, because cancelling is not a safe alternative: `prepare-tenant` carries `if: always()`, so a cancelled run finishes installing onto the tenants it had already leased on its way out.

Each contender computes the order over its *own* resolved cloud list, which may be a subset. That is fine and is why sorting works: any two runs still take their common subset in the same relative order.

## This is not the ordered ticket queue the module docstring rejects

That earlier attempt replaced the atomic CAS with a `run_id` ordering, and got fairness instead of exclusion — both contenders acquired and both installed onto the same tenant. Here the CAS is **untouched** and remains the only thing that grants a lease; the ordering governs only the sequence in which *one* run takes several of them.

## Notes

* **Inert until a caller passes `clouds:`.** Landed separately on purpose: the action is pinned `@main` by every contender (they all have to agree on the ref layout), so the workflow flip must not race the action it calls. `uses:` cannot take an expression, so a single PR would have had `main`'s copy — without `--clouds` — running the new invocation.
* **`verify` deliberately refuses a set.** That mode exists because a matrix job cannot depend on its own leg of an upstream matrix, so each install leg must confirm *its own* tenant. A set-shaped verify would invite the install to check the aggregate again, which is the approximation `verify` was added to replace.
* **Empty `--clouds` falls back to `--cloud`.** The single-tenant path resolves a legitimately empty cloud list, so the action can pass both unconditionally — no branching shell in a `run:` block (docs/standards/ci.md).
* **API budget improves.** Polling one lease at a time rather than three concurrently divides a waiting run's request rate by the number of clouds, which the action's own `poll-seconds` docstring flags as the binding constraint.
* New outputs: `lease-refs` (the whole held set — all-or-nothing, never partial) and `clouds`. `lease-ref` now means "the ref the outcome hinged on", so an error names one specific tenant rather than guessing which of the set it was.

## Tests

19 new tests. The load-bearing ones: the order comes from the names and nothing else (asserted against a deliberately unsorted caller list, and against a subset), a blocked cloud gives back what was already held, and the wait budget is total across the set rather than per cloud.

Full suite: 2998 passed.
