### PR TITLE
ci(e2e): collapse the tenant lease into one ordered job (FND-646)

### DIFF
--- a/.github/actions/e2e-tenant-lease/e2e_tenant_lease.py
+++ b/.github/actions/e2e-tenant-lease/e2e_tenant_lease.py
@@ -996,9 +996,10 @@ def verify_held(repo: str, ref: str, run_id: int, attempt: int) -> bool:
         print(
             f"::error::this run does not hold the tenant lease {ref}: it is held "
             f"by run {holder.run_id} ({holder.run_url(repo)}), attempt "
-            f"{holder.attempt}. Installing now would race that run. This usually "
-            "means this cloud's acquire failed while another cloud's succeeded. "
-            "Re-run this job."
+            f"{holder.attempt}. Installing now would race that run. Acquisition "
+            "is all-or-nothing across the cloud set, so this normally means the "
+            "lease was broken by its TTL, or reaped after this run was misread "
+            "as finished. Re-run this job."
         )
         return False
     print(f"Tenant lease confirmed held by this run: {ref}")

--- a/.github/scripts/tests/test_prepare_tenant_wiring.py
+++ b/.github/scripts/tests/test_prepare_tenant_wiring.py
@@ -235,13 +235,35 @@ def test_the_lease_jobs_use_the_shared_action_at_main(
     assert step["with"]["mode"] == mode
 
 
-@pytest.mark.parametrize("job", ["lease-tenant", "release-tenant"])
-def test_the_lease_jobs_key_on_app_and_cloud(jobs: dict, job: str) -> None:  # type: ignore[type-arg]
-    """Acquire and release must name the same tenant, or every run leaks its
+def test_the_release_keys_on_app_and_cloud(jobs: dict) -> None:  # type: ignore[type-arg]
+    """Acquire and release must name the same tenants, or every run leaks its
     ticket and the next contender waits for a holder that has already gone."""
-    with_ = _lease_step(jobs, job)["with"]
+    with_ = _lease_step(jobs, "release-tenant")["with"]
     assert with_["app"] == "${{ inputs.app-name }}"
     assert with_["cloud"] == "${{ matrix.cloud }}"
+
+
+def test_the_acquire_is_one_job_over_an_ordered_cloud_set(jobs: dict) -> None:  # type: ignore[type-arg]
+    """The deadlock fix, asserted as shape (FND-646).
+
+    A per-cloud matrix acquires in PARALLEL and holds each lease while blocking
+    on the rest — hold-and-wait. It deadlocked the first time two runs queued
+    behind one holder: they raced for the freed set, split it, and each blocked on
+    what the other held for the whole wait budget. With two or more runs queued
+    that split is the expected outcome, so the parallel shape must not come back.
+    """
+    lease = jobs["lease-tenant"]
+    assert "strategy" not in lease, (
+        "lease-tenant must acquire every cloud in ONE job, in order; a matrix "
+        "acquires them in parallel and reintroduces hold-and-wait (FND-646)"
+    )
+    with_ = _lease_step(jobs, "lease-tenant")["with"]
+    assert with_["app"] == "${{ inputs.app-name }}"
+    assert with_["clouds"] == "${{ needs.discover-e2e.outputs.cloud-list }}"
+    assert "cloud" not in with_, (
+        "passing both cloud and clouds fails the driver rather than silently "
+        "preferring one; the acquire takes the set"
+    )
 
 
 @pytest.mark.parametrize("job", ["lease-tenant", "release-tenant"])
@@ -533,15 +555,57 @@ def test_the_lease_wait_budget_is_the_operator_facing_signal(jobs: dict) -> None
 
 
 def test_the_lease_and_install_fan_out_over_the_same_clouds(jobs: dict) -> None:  # type: ignore[type-arg]
-    # A lease leg that missed a cloud the install then ran against is an
+    # A cloud the lease missed and the install then ran against is an
     # unserialised install, not a visible failure.
-    assert (
-        jobs["lease-tenant"]["strategy"]["matrix"]
-        == (jobs["prepare-tenant"]["strategy"]["matrix"])
-    )
     assert (
         jobs["release-tenant"]["strategy"]["matrix"]
         == (jobs["prepare-tenant"]["strategy"]["matrix"])
+    )
+
+
+def test_the_lease_set_and_the_install_matrix_come_from_one_discovery(
+    jobs: dict,  # type: ignore[type-arg]
+) -> None:
+    """The acquire takes a LIST and the install fans out over a MATRIX, so they
+    can no longer be compared string-for-string. They are pinned to the same
+    discovery STEP instead — `discover-clouds`, the clouds-only call — because
+    that removes the possibility of disagreement rather than testing for it.
+    """
+    outputs = yaml.safe_load(_WORKFLOW.read_text(encoding="utf-8"))["jobs"][
+        "discover-e2e"
+    ]["outputs"]
+    assert outputs["cloud-list"] == "${{ steps.discover-clouds.outputs.clouds }}"
+    assert outputs["cloud-matrix"] == "${{ steps.discover-clouds.outputs.matrix }}"
+
+    assert (
+        _lease_step(jobs, "lease-tenant")["with"]["clouds"]
+        == "${{ needs.discover-e2e.outputs.cloud-list }}"
+    )
+    assert "cloud-matrix" in jobs["prepare-tenant"]["strategy"]["matrix"]
+
+
+def test_a_failed_lease_fails_the_install_rather_than_skipping_it(jobs: dict) -> None:  # type: ignore[type-arg]
+    """Load-bearing in the opposite direction to how it reads.
+
+    Acquisition is all-or-nothing, so a failed lease means the run holds nothing
+    — and tightening prepare-tenant's gate to `== 'success'` would SKIP the
+    install. The e2e legs deliberately tolerate a skipped prepare-tenant, so they
+    would then run against whatever version the tenant happens to serve (FND-31).
+    Letting the install run and fail on its own lease check is what stops them.
+    """
+    assert (
+        evaluate(
+            _load_gate("prepare-tenant"),
+            {
+                "inputs": {"install-app-to-tenant": True},
+                "needs": {
+                    "discover-e2e": {"result": "success"},
+                    "merge-e2e-image": {"result": "success"},
+                    "lease-tenant": {"result": "failure"},
+                },
+            },
+        )
+        is True
     )
 
 

--- a/.github/workflows/tests-reusable.yaml
+++ b/.github/workflows/tests-reusable.yaml
@@ -1036,6 +1036,16 @@ jobs:
       # e2e-full-reusable.yaml's plan-clouds has always guarded on the count for
       # exactly this reason.
       cloud-count: ${{ steps.discover-clouds.outputs.count }}
+      # The same cloud dimension as a flat list, for lease-tenant — which is ONE
+      # job that takes every cloud's lease in order rather than a matrix leg per
+      # cloud (FND-646), so it needs the list and not a matrix.
+      #
+      # Emitted from the SAME action call as `cloud-matrix` above, not from the
+      # suite fan-out's `clouds` below. The two calls resolve identically today
+      # and a test pins that, but a lease set that missed a cloud the install
+      # then ran against would be an unserialised install rather than a visible
+      # failure — so this takes the distinction out of play entirely.
+      cloud-list: ${{ steps.discover-clouds.outputs.clouds }}
       # The resolved cloud list as a flat string, for the scorecard's descriptive
       # `observed` field (FND-34). Taken from the SAME action call that emitted
       # the matrix, so "what we recorded as covered" and "what actually ran"
@@ -1416,21 +1426,37 @@ jobs:
   # the order runs reach this job, and a total order gives fairness rather than
   # exclusion. Exclusion needs an atomic primitive — see the module docstring.
   #
-  # Same gate and same cloud matrix as prepare-tenant: no install, no contention
-  # worth serialising — the legs of a non-installing run cannot lose a version
-  # race because nothing changes the version under them.
+  # ONE job for every cloud, not a matrix leg per cloud — and that is the fix for
+  # a deadlock, not a tidy-up (FND-646). The matrix acquired each cloud's lease in
+  # PARALLEL and held it for the whole run while blocking on the rest, which is
+  # hold-and-wait. It deadlocked the first time two runs queued behind one holder:
+  # the holder released all three leases at once, the two waiters raced for the
+  # freed set and SPLIT it (one took aws + azure, the other gcp), and each then
+  # blocked on what the other held for the full 90-minute budget. Any time two or
+  # more runs are queued behind a holder, a parallel matrix makes that split the
+  # EXPECTED outcome.
+  #
+  # So this job takes them one at a time, in an order that is a pure function of
+  # the cloud names, and gives back everything it took if it cannot get the whole
+  # set (see acquire_ordered). Resource ordering makes a cycle impossible, so the
+  # worst case degrades from mutual blocking to plain serialisation. Nothing is
+  # ever cancelled: a queued run waits and then proceeds. That matters because
+  # cancelling is not a safe alternative here — prepare-tenant carries
+  # `if: always()`, so a cancelled run finishes installing onto the tenants it
+  # had already leased on its way out.
+  #
+  # Same gate as prepare-tenant: no install, no contention worth serialising —
+  # the legs of a non-installing run cannot lose a version race because nothing
+  # changes the version under them.
   lease-tenant:
-    name: Tenant lease (${{ matrix.cloud || 'default' }})
+    name: Tenant lease
     needs: [discover-e2e, merge-e2e-image]
     if: inputs.install-app-to-tenant && needs.merge-e2e-image.result == 'success'
-    strategy:
-      # One cloud's queue being stuck must not cancel the others.
-      fail-fast: false
-      matrix: ${{ fromJson(needs.discover-e2e.outputs.cloud-count != '0' && needs.discover-e2e.outputs.cloud-matrix || '{"include":[{"cloud":""}]}') }}
     runs-on: ubuntu-latest
-    # Above the action's own 90-minute wait budget, so a run that queues for the
-    # full budget still reaches the script's own error — which names the holding
-    # run — instead of being replaced by a bare "job cancelled after Nm".
+    # Above the action's own 90-minute wait budget, which is now a budget for the
+    # WHOLE ordered set rather than per cloud — so this still bounds the job, and
+    # a run that queues for the full budget still reaches the script's own error
+    # (which names the holding run) instead of a bare "job cancelled after Nm".
     timeout-minutes: 100
     permissions:
       # Ref writes create and delete the lease ticket. Scoped to THIS job on
@@ -1441,12 +1467,16 @@ jobs:
       # abandoned ticket self-healing.
       actions: read
     steps:
-      - name: Acquire the tenant lease
+      - name: Acquire the tenant leases
         uses: atlanhq/application-sdk/.github/actions/e2e-tenant-lease@main
         with:
           mode: acquire
           app: ${{ inputs.app-name }}
-          cloud: ${{ matrix.cloud }}
+          # The clouds prepare-tenant will install onto, from the same discovery
+          # call that built its matrix. Empty is the single-tenant fallback path
+          # and the action leases "default" for it, which is what prepare-tenant's
+          # own fallback leg (`cloud: ""`) verifies.
+          clouds: ${{ needs.discover-e2e.outputs.cloud-list }}
 
   # ── Install the app under test onto each cloud's tenant ──────────────────
   # One leg per CLOUD, not per suite × cloud: the installation is tenant-scoped
@@ -1462,18 +1492,32 @@ jobs:
     # Gated on lease-tenant having RUN, not on it having succeeded, and then each
     # leg confirms its OWN cloud's lease in its first step.
     #
-    # `needs.lease-tenant.result` is the matrix AGGREGATE, so `== 'success'` means
-    # "some cloud's lease succeeded", never "this leg's did". Observed live: one
-    # cloud's acquire failed on a transient TLS error and the aggregate then
-    # skipped the install for the two clouds whose leases HAD been taken — a run
-    # holding two tenants that installed onto neither.
+    # Since lease-tenant became a single ordered job (FND-646) its `.result` is
+    # exact rather than a matrix aggregate — but `!= 'skipped'` still has to
+    # stay, and now for a sharper reason than the one it was written for.
+    # Acquisition is all-or-nothing, so a FAILED lease means this run holds
+    # nothing; tightening this to `== 'success'` would SKIP the install, and the
+    # e2e legs deliberately tolerate a skipped prepare-tenant (see
+    # test_e2e_tolerates_skipped_but_not_failed_prepare). They would then run
+    # against whatever version the tenant happens to serve — the exact FND-31
+    # failure. Letting the install run and FAIL on its own lease check is what
+    # stops the legs.
+    #
+    # It was originally widened because `.result` was the matrix aggregate:
+    # `== 'success'` meant "some cloud's lease succeeded", never "this leg's
+    # did". Observed live — one cloud's acquire failed on a transient TLS error
+    # and the aggregate then skipped the install for the two clouds whose leases
+    # HAD been taken, a run holding two tenants that installed onto neither.
+    # Ordered acquisition removes that failure mode at source; the per-cloud
+    # verify step below stays anyway, because it is the only thing that makes the
+    # install's precondition true per TENANT rather than per job.
     #
     # `always()` is what makes the widening actually do anything, and it is easy
     # to omit: without a status-check function GitHub applies an implicit
     # success() over every `needs` entry and skips the job BEFORE this `if:` is
-    # consulted, so a failed lease leg would still skip the install everywhere
-    # and the per-cloud verify step below would never run. Same shape and same
-    # reason as the e2e legs' gate — see test_e2e_tolerates_skipped_but_not_failed_prepare.
+    # consulted, so a failed lease would still skip the install and the per-cloud
+    # verify step below would never run. Same shape and same reason as the e2e
+    # legs' gate.
     #
     # Because always() lifts that implicit success(), discover-e2e and
     # merge-e2e-image have to be named explicitly here; they were previously
@@ -2115,17 +2159,23 @@ jobs:
   release-tenant:
     name: Release tenant lease (${{ matrix.cloud || 'default' }})
     needs: [discover-e2e, lease-tenant, prepare-tenant, e2e]
-    # Gated on lease-tenant having RUN, not on it having succeeded. `.result` on a
-    # matrix job is the aggregate, so `== 'success'` meant one cloud's acquire
-    # timing out skipped the release for EVERY cloud — including the legs that did
-    # acquire, whose leases would then wait for the next contender's reaper
-    # instead of being handed back. That directly contradicts this job's own
-    # reason for existing.
+    # Still a per-cloud MATRIX while the acquire is one ordered job (FND-646), and
+    # deliberately so: release cannot block, is ownership-checked, and is
+    # idempotent, so there is no hold-and-wait to remove here — and one leg per
+    # cloud keeps a single wedged DELETE from holding the others' tenants.
+    #
+    # Gated on lease-tenant having RUN, not on it having succeeded. When acquire
+    # was a matrix, `== 'success'` meant one cloud's acquire timing out skipped
+    # the release for EVERY cloud, including those that had acquired — their
+    # leases then waited for the next contender's reaper instead of being handed
+    # back. The ordered acquire hands its own leases back on the way out of a
+    # failure, so this is now a backstop rather than the primary path, but it must
+    # stay one: a lease job that dies outright releases nothing.
     #
     # Safe to widen because the release driver checks ownership before deleting:
-    # a leg that never acquired reads a lease that is not its own (or none at all)
-    # and no-ops. Not gated on the legs' outcome either — a failed leg must still
-    # give the tenant back.
+    # a leg for a cloud this run never held reads a lease that is not its own (or
+    # none at all) and no-ops. Not gated on the legs' outcome either — a failed
+    # leg must still give the tenant back.
     if: always() && needs.lease-tenant.result != 'skipped'
     strategy:
       fail-fast: false

--- a/docs/standards/ci.md
+++ b/docs/standards/ci.md
@@ -438,7 +438,38 @@ any contender decides, and nothing enforces that. Use an atomic primitive and
 derive nothing from ids. The cost is fairness — acquisition becomes a scramble,
 so bound starvation with the wait budget below rather than with a queue position.
 
-Three consequences to design for:
+**But when one run needs SEVERAL of these locks, it must take them in a fixed
+order — and that is a different rule, not a contradiction of the one above.**
+The lease job used to be a per-cloud matrix that acquired every cloud's lease in
+parallel and held each for the whole run while blocking on the rest. That is
+textbook hold-and-wait, and it deadlocked the first time two runs queued behind
+one holder (FND-646): the holder released all three leases at once, the two
+waiters raced for the freed set and **split** it — one took aws + azure, the
+other gcp — and each then blocked on what the other held for the whole 90-minute
+wait budget. Any time two or more runs are queued behind a holder, a parallel
+matrix makes that split the *expected* outcome, not a rare interleaving.
+
+The fix is resource ordering: one job takes every lock it needs, one at a time,
+in an order that is a **pure function of the resource names** (`sorted()`). Two
+runs can then never hold locks the other needs out of order, so the worst case
+degrades from mutual blocking to plain serialisation. Note what is and is not
+being ordered — the CAS still grants every lease, and the order governs only the
+sequence in which *one* run takes several of them. That is why this does not
+re-open the rejected-ordering trap above.
+
+Consequences worth spelling out:
+
+* The wait budget becomes a **total** across the set, not per resource, or N
+  locks can outlast the job timeout by N times over and the runner's bare
+  "cancelled after Nm" replaces the actionable error.
+* Acquisition has to be **all-or-nothing**: a run that cannot get the whole set
+  hands back what it took, immediately, rather than waiting for its cleanup job.
+* Derive the order from the names only. Run id, arrival order, or the caller's
+  list order all make two contenders disagree about which lock comes first,
+  which is the entire guarantee.
+* Release can stay parallel. It cannot block, so there is no wait to order.
+
+Three further consequences to design for:
 
 * A waiting run occupies a runner, so give the wait a budget and fail loudly past
   it, **naming the holder**. A contention outcome must never be phrased as a test


### PR DESCRIPTION
Linear: [FND-646](https://linear.app/atlan-epd/issue/FND-646/e2e-tenant-leases-one-label-spawns-duplicate-runs-and-cross-run-lease) — **Fix B**, workflow half. Stacked on #3309 (which adds the driver support this uses) and #3308.

## What this does

Collapses `lease-tenant` from a per-cloud matrix into **one job** that acquires every cloud's lease in a fixed order. See #3309 for why: the parallel matrix was hold-and-wait, and two runs queued behind one holder reliably split the freed set and blocked on each other for the whole wait budget.

```diff
   lease-tenant:
-    name: Tenant lease (${{ matrix.cloud || 'default' }})
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJson(... cloud-matrix ...) }}
+    name: Tenant lease
     steps:
-      - name: Acquire the tenant lease
+      - name: Acquire the tenant leases
         uses: atlanhq/application-sdk/.github/actions/e2e-tenant-lease@main
         with:
           mode: acquire
           app: ${{ inputs.app-name }}
-          cloud: ${{ matrix.cloud }}
+          clouds: ${{ needs.discover-e2e.outputs.cloud-list }}
```

`timeout-minutes: 100` stays above the (now total) 5400s budget, so a run that queues for the whole budget still reaches the script's own error — the one place the holding run is named — instead of a bare "job cancelled after Nm".

## Three decisions worth reviewing

**The lease set and the install matrix come from the same discovery call.** New `cloud-list` job output, emitted from the *same* `discover-clouds` step as `cloud-matrix` rather than from the suite fan-out's `clouds`. The two calls resolve identically today and a test pins that — but a lease set that missed a cloud the install then ran against would be an unserialised install rather than a visible failure, so this takes the distinction out of play instead of testing for it.

**`release-tenant` stays a matrix.** Release cannot block, is ownership-checked and idempotent, so there is no hold-and-wait to remove — and one leg per cloud keeps a single wedged `DELETE` from holding the others' tenants. It also stays gated on the lease job having *run* rather than succeeded: the ordered acquire hands its own leases back on the way out of a failure, so that gate is now a backstop rather than the primary path, but a lease job that dies outright still releases nothing.

**`prepare-tenant` keeps `needs.lease-tenant.result != 'skipped'`, and the reason has changed.** It was widened because `.result` was a matrix aggregate. With one job it is exact — but tightening it to `== 'success'` would now be a live FND-31 hazard: acquisition is all-or-nothing, so a failed lease means the run holds nothing, `== 'success'` would **skip** the install, and the e2e legs deliberately tolerate a skipped `prepare-tenant` (see `test_e2e_tolerates_skipped_but_not_failed_prepare`). They would then run against whatever version the tenant happens to serve. Letting the install run and **fail** its own lease check is what stops them. Now pinned by `test_a_failed_lease_fails_the_install_rather_than_skipping_it`.

## Docs

`docs/standards/ci.md` gains the general rule: several locks in one run must be taken in a fixed order derived only from the resource names, with a total wait budget and all-or-nothing acquisition. Written next to — and explicitly distinguished from — the existing "do not build exclusion out of an ordering rule" paragraphs, because the two read like a contradiction and are not: the CAS still grants every lease; the ordering only governs the sequence in which one run takes several.

Also corrects the `verify` failure message, which told the reader the likely cause was "this cloud's acquire failed while another cloud's succeeded" — no longer possible once acquisition is all-or-nothing.

## Not exercised pre-merge

Connector repos call `tests-reusable.yaml@main`, so this workflow's change is not run by this PR's own e2e dispatch. The wiring tests (`test_prepare_tenant_wiring.py`, 61 passing) are the guard, including a new assertion that `lease-tenant` has **no** `strategy` — the parallel shape must not come back.

Full suite: 3000 passed.
