### PR TITLE
ci(sdk-review): pin both AI lanes to Grok 4.6 (FND-660)

### DIFF
--- a/.github/scripts/sdk_resolve_dispatch.py
+++ b/.github/scripts/sdk_resolve_dispatch.py
@@ -59,21 +59,34 @@ READ_IDLE_TIMEOUT_SECONDS = 1900
 # keeping the last N bytes always preserves it.
 BUFFER_CAP_BYTES = 65536
 DEFAULT_MAX_ROUNDS = 8
-# Models this lane runs on, mirroring sdk-review.yml. Chosen on cost per TASK,
-# not per token: kimi-k3 (index 57.2, ~$0.85/task) vs claude-opus-5 (60.5,
-# ~$2.40) and gpt-5.6-luna (51.2, $0.20/Mtok in) vs claude-haiku-4-5 (29.6,
-# $1.00/Mtok) — better and cheaper on the fast lane. Reverting is a one-liner.
-MAIN_MODEL = "kimi-k3"
+# Models this lane runs on, mirroring the review lane. The main lane is pinned
+# to Grok 4.6 by operator request, replacing kimi-k3 (chosen on cost per TASK,
+# not per token: index 57.2, ~$0.85/task vs claude-opus-5 at 60.5, ~$2.40).
+# Both proxy sides have to allow it or every dispatch dies on turn one, and the
+# code says which: 404 means `x-ai/grok-4.6` is not in the llmproxy.atlan.dev
+# catalog, 403 means the gateway key does not allowlist it. This lane declares
+# no `ai_gateway_key_name`, so that key is mothership's LITELLM_KEY_DEFAULT —
+# not the review lane's scoped `sdk_review` key.
+#
+# KNOWN RISK, carried deliberately: xAI does NOT prompt-cache on the Anthropic
+# `/v1/messages` route Claude Code uses (verified in the LiteLLM ledger when
+# mothership pinned its PR reviewer to x-ai/grok-4.5 in Jul 2026, and the reason
+# it reverted), so a multi-turn agentic lane re-bills its full context every
+# turn — and resolve runs up to DEFAULT_MAX_ROUNDS rounds per PR.
+#
+# The fast lane stays on gpt-5.6-luna. Reverting is a one-liner.
+MAIN_MODEL = "x-ai/grok-4.6"
 FAST_MODEL = "gpt-5.6-luna"
 
 # --- Re-dispatch when the sandbox dies on a hard error ----------------------
 # One retry, on a DIFFERENT main model. Mothership's intra-group provider
-# fallback already exists and already fires on a 429 — but every provider in the
-# `kimi-k3` group serves the SAME model, so a same-model re-dispatch just
-# re-hits the same model-level fault (observed: the 429 fell through to Moonshot
-# AI, which returned 400 "the message at position 21 with role 'assistant' must
-# not be empty" — same model, same bug). Swapping the model is the whole point
-# of the retry; without it the second sandbox boot fails identically.
+# fallback already exists and already fires on a 429 — but every provider in a
+# model's group serves the SAME model, so a same-model re-dispatch just re-hits
+# the same model-level fault (observed while this lane was on kimi-k3: the 429
+# fell through to Moonshot AI, which returned 400 "the message at position 21
+# with role 'assistant' must not be empty" — same model, same bug). Swapping the
+# model is the whole point of the retry; without it the second sandbox boot
+# fails identically.
 MAX_DISPATCH_ATTEMPTS = 2
 # Attempt 2's main model. This is mothership's own DEFAULT_CLAUDE_MODEL, named
 # explicitly rather than by omitting `model` from the payload: an explicit
@@ -110,7 +123,7 @@ RETRYABLE_ERR_CODES = frozenset(
 # does carry information — "401 upstream auth failed" mentions upstream and is
 # nonetheless a permanent fault that would fail identically on any model.
 RETRYABLE_ERR_PATTERNS = (
-    "must not be empty",  # the kimi-k3 empty-assistant-turn fault
+    "must not be empty",  # the empty-assistant-turn fault (first seen on kimi-k3)
     "rate-limited",
     "rate limited",
     "overloaded",
@@ -276,7 +289,7 @@ def build_payload(
         # claude-sonnet-5, so Task/Explore legwork bills Claude rates whatever
         # the main lane runs. `small_fast_model` must be pinned explicitly:
         # mothership's model_routing_env does `fast = small_fast_model or model`,
-        # so pinning `model` alone would put the background lane on kimi-k3.
+        # so pinning `model` alone would put the background lane on MAIN_MODEL.
         "model": attempt_model(attempt),
         "small_fast_model": FAST_MODEL,
         "env_vars": {"CLAUDE_CODE_SUBAGENT_MODEL": FAST_MODEL},

--- a/.github/scripts/sdk_review_dispatch.py
+++ b/.github/scripts/sdk_review_dispatch.py
@@ -99,24 +99,39 @@ STREAM_TRANSPORT_ERRORS = (
 # the sandbox looks stalled. Re-armed by every content-bearing event.
 IDLE_WARN_SECONDS = 300
 
-# Models this lane runs on. Chosen on cost per TASK, not per token: kimi-k3
-# (index 57.2, ~$0.85/task) vs claude-opus-5 (60.5, ~$2.40) and gpt-5.6-luna
-# (51.2, $0.20/Mtok in) vs claude-haiku-4-5 (29.6, $1.00/Mtok) — better and
-# cheaper on the fast lane. `small_fast_model` must be pinned explicitly:
-# mothership's model_routing_env does `fast = small_fast_model or model`, so
-# pinning `model` alone would put the background lane on kimi-k3 too.
-MAIN_MODEL = "kimi-k3"
+# Models this lane runs on. The main lane is pinned to Grok 4.6 by operator
+# request, replacing kimi-k3 (which was itself chosen on cost per TASK, not per
+# token: index 57.2, ~$0.85/task vs claude-opus-5 at 60.5, ~$2.40). Two things
+# have to hold on the proxy side or every dispatch dies on turn one, and the
+# codes tell you which: 404 means `x-ai/grok-4.6` is not in the
+# llmproxy.atlan.dev catalog, 403 means the `sdk_review` gateway key does not
+# allowlist it.
+#
+# KNOWN RISK, carried deliberately: xAI does NOT prompt-cache on the
+# Anthropic `/v1/messages` route Claude Code uses (verified in the LiteLLM
+# ledger when mothership pinned its PR reviewer to x-ai/grok-4.5 in Jul 2026 —
+# Cache Hit False even with Claude Code sending cache_control), so a multi-turn
+# agentic reviewer re-bills its full context every turn. That is why mothership
+# reverted its own grok pin. This lane has the same shape, so watch the
+# per-review cost before treating the switch as settled.
+#
+# The fast lane stays on gpt-5.6-luna. `small_fast_model` must be pinned
+# explicitly: mothership's model_routing_env does `fast = small_fast_model or
+# model`, so pinning `model` alone would drag the background lane onto the main
+# model too.
+MAIN_MODEL = "x-ai/grok-4.6"
 FAST_MODEL = "gpt-5.6-luna"
 IDLE_TIMEOUT_SECONDS = 1800
 
 # --- Re-dispatch when the sandbox dies on a hard error ----------------------
 # One retry, on a DIFFERENT main model — the port of the resolve lane's
 # FND-641. Mothership's intra-group provider fallback already exists and fires
-# on a 429, but every provider in the `kimi-k3` group serves the SAME model, so
-# a same-model re-dispatch just re-hits the same model-level fault (observed on
-# resolve: the 429 fell through to Moonshot AI, which returned 400 "the message
-# at position 21 with role 'assistant' must not be empty" — same model, same
-# bug). Swapping the model is the whole point of the retry.
+# on a 429, but every provider in a model's group serves the SAME model, so a
+# same-model re-dispatch just re-hits the same model-level fault (observed on
+# resolve while the main lane was kimi-k3: the 429 fell through to Moonshot AI,
+# which returned 400 "the message at position 21 with role 'assistant' must not
+# be empty" — same model, same bug). Swapping the model is the whole point of
+# the retry.
 MAX_DISPATCH_ATTEMPTS = 2
 # Attempt 2's main model: mothership's own DEFAULT_CLAUDE_MODEL, named
 # explicitly rather than by omitting `model` from the payload, so a test can
@@ -153,7 +168,7 @@ RETRYABLE_ERR_CODES = frozenset(
 # does carry information — "401 upstream auth failed" mentions upstream and is
 # nonetheless a permanent fault that would fail identically on any model.
 RETRYABLE_ERR_PATTERNS = (
-    "must not be empty",  # the kimi-k3 empty-assistant-turn fault
+    "must not be empty",  # the empty-assistant-turn fault (first seen on kimi-k3)
     "rate-limited",
     "rate limited",
     "overloaded",

--- a/.github/scripts/tests/test_sdk_resolve_dispatch.py
+++ b/.github/scripts/tests/test_sdk_resolve_dispatch.py
@@ -58,7 +58,7 @@ def test_payload_pins_all_three_model_lanes():
     # mothership's Claude defaults (main -> claude-opus-5, sub-agent ->
     # claude-sonnet-5), and `small_fast_model` unset resolves to `model`.
     p = sr.build_payload("1", "u", 8, "2026-07-08", "reviewer-one", "requester-login")
-    assert p["model"] == "kimi-k3"
+    assert p["model"] == "x-ai/grok-4.6"
     assert p["small_fast_model"] == "gpt-5.6-luna"
     assert p["env_vars"]["CLAUDE_CODE_SUBAGENT_MODEL"] == "gpt-5.6-luna"
     # Every pinned value must survive JSON encoding as a non-blank string —

--- a/.github/scripts/tests/test_sdk_review_dispatch.py
+++ b/.github/scripts/tests/test_sdk_review_dispatch.py
@@ -93,7 +93,7 @@ def test_payload_pins_all_three_model_lanes():
     # Leaving any lane unset silently falls back to mothership's Claude
     # defaults, and `small_fast_model` unset resolves to `model`.
     p = _payload()
-    assert p["model"] == "kimi-k3"
+    assert p["model"] == "x-ai/grok-4.6"
     assert p["small_fast_model"] == "gpt-5.6-luna"
     assert p["env_vars"]["CLAUDE_CODE_SUBAGENT_MODEL"] == "gpt-5.6-luna"
     encoded = json.loads(json.dumps(p))
@@ -753,7 +753,7 @@ def _errored(code: str = "429", msg: str = "rate limited") -> sd.SSEState:
 def test_the_retry_runs_a_different_main_model():
     """A same-model re-dispatch re-hits the same model-level fault.
 
-    Every provider in the `kimi-k3` group serves the same model, so mothership's
+    Every provider in a model's group serves the same model, so mothership's
     own intra-group fallback cannot help. Swapping the model is the whole point.
     """
     assert sd.attempt_model(1) == sd.MAIN_MODEL


### PR DESCRIPTION
## What

Switch the main model of both AI CI lanes from `kimi-k3` to Grok 4.6 (`x-ai/grok-4.6`), by operator request.

- `.github/scripts/sdk_review_dispatch.py` — `MAIN_MODEL`
- `.github/scripts/sdk_resolve_dispatch.py` — `MAIN_MODEL`

**Main lane only.** `FAST_MODEL` stays `gpt-5.6-luna`: mothership's `model_routing_env` does `fast = small_fast_model or model`, so holding it is what keeps the background / sub-agent lane off the main model. `RETRY_MAIN_MODEL` stays `claude-opus-5`, so the FND-641 re-dispatch is still a genuine model swap rather than a same-model retry.

The comments that named `kimi-k3` as the live main model are re-anchored rather than deleted — the empty-assistant-turn incident is the recorded justification for `MAX_DISPATCH_ATTEMPTS = 2`, so it stays as history.

## Slug form

`x-ai/grok-4.6`, not bare `grok-4.6`. Mothership's own grok pin used `x-ai/grok-4.5` as the request-side value; the `xai/…` and `openrouter/x-ai/…` spellings that show up in cost dashboards are *reported* route ids, a different layer. Prefixed aliases are the documented form (`z-ai/glm-5.2` in `docs/reference/rover-model-override.md`, "pass it verbatim").

## Before merge — one unverified precondition

The model pin is two-sided; I could not check the proxy side (no gateway key locally). Please confirm `x-ai/grok-4.6` is served:

```
curl -s -H "Authorization: Bearer $LLM_API_KEY" \
  https://llmproxy.atlan.dev/v1/models | jq -r '.data[].id' | grep -i grok
```

Failure is loud on the first turn and the code says which side is missing:

- **404** — the alias is not in the `llmproxy.atlan.dev` catalog.
- **403** — the gateway key does not allowlist it. sdk-review declares `ai_gateway_key_name: sdk_review`; sdk-resolve declares none, so it resolves to mothership's `LITELLM_KEY_DEFAULT`.

Both splits are now recorded in the constant blocks so the next person debugging a dead dispatch does not have to re-derive them.

## Known risk, carried deliberately

Mothership pinned its own PR reviewer to `x-ai/grok-4.5` in Jul 2026 and reverted it: xAI does **not** prompt-cache on the Anthropic `/v1/messages` route Claude Code uses (LiteLLM ledger showed Cache Hit False even with Claude Code sending `cache_control`), so every turn re-bills the full context and the lower per-token price is negated on a multi-turn agentic run. Both lanes here have that shape — review is a 5–30 min agentic reviewer, resolve runs up to `DEFAULT_MAX_ROUNDS` rounds per PR. This does not block the switch, but it is the number to watch after merge; reverting is a one-liner.

## Verification

- `.github/scripts/tests/test_sdk_review_dispatch.py` + `test_sdk_resolve_dispatch.py`: 170 passed (literal model assertions updated).
- Full `.github/scripts/tests` suite: 2931 passed locally (14m — the cross-file guards are the slow part).
- pre-commit clean on all four files, pyright included.
- No other file imports `MAIN_MODEL` / `FAST_MODEL` / `attempt_model`.

Ticket: FND-660 — https://linear.app/atlan-epd/issue/FND-660/pin-the-sdk-review-and-sdk-resolve-lanes-to-grok-46

🤖 Generated with [Claude Code](https://claude.com/claude-code)
