### PR TITLE
ci: attribute a tagged release to the human who merged it

### DIFF
--- a/.github/scripts/resolve_release_actor.py
+++ b/.github/scripts/resolve_release_actor.py
@@ -5,11 +5,11 @@ The Global Marketplace shows ``created_by`` in the Slack approval message for a
 release, so it needs to name the *human who owns the change* — not whatever
 identity happened to move the bits.
 
-For every event except ``push`` that is simply the triggering actor: a
-``workflow_dispatch``, ``release`` or ``schedule`` run was started deliberately
-by someone, and that someone is the answer.
+For ``workflow_dispatch`` and ``schedule`` that is simply the triggering actor:
+the run was started deliberately by someone, and that someone is the answer.
 
-``push`` (the merge-to-main auto-publish flow) is the hard case. Version-bump
+``push`` (merge-to-main auto-publish) and ``release`` (the tag flow) are the
+hard cases, and they share a fix. Version-bump
 PRs are opened by the Atlan Fleet App bot, so the PR *author* is a bot and the
 person who owns the release is the one who **merged** it. That name is only
 reachable in two hops:
@@ -56,6 +56,18 @@ import sys
 from typing import Callable
 
 PUSH_EVENT = "push"
+RELEASE_EVENT = "release"
+
+# Events whose triggering actor is not the person who owns the release, so the
+# human has to be recovered from the PR behind the SHA.
+#
+# ``push`` is the merge-to-main auto-publish flow. ``release`` is the tag flow:
+# the tag is cut by ``tag-and-release`` when a release-labelled PR merges, so
+# the GitHub Release is authored by the Fleet App bot and ``triggering_actor``
+# on the resulting ``release: published`` run is that bot — never a human. In
+# both cases GITHUB_SHA is the merge commit of the PR that caused the release,
+# so the same two-hop lookup recovers the person who merged it.
+_PR_DERIVED_EVENTS = (PUSH_EVENT, RELEASE_EVENT)
 
 
 def _run_gh(args: list) -> str:
@@ -129,13 +141,13 @@ def resolve_actor(
 ) -> str:
     """The login to attribute the release to."""
     run = run or _run_gh
-    if event_name != PUSH_EVENT:
+    if event_name not in _PR_DERIVED_EVENTS:
         return triggering_actor
     number = pr_number_for_sha(repo, sha, run)
     if number is None:
         print(
             f"::notice::no PR associated with {sha[:12]} — "
-            f"attributing to the pushing actor",
+            f"attributing to the triggering actor",
             file=sys.stderr,
         )
         return triggering_actor
@@ -143,7 +155,7 @@ def resolve_actor(
     if merger is None:
         print(
             f"::warning::PR #{number} for {sha[:12]} reports no merged_by — "
-            f"attributing to the pushing actor",
+            f"attributing to the triggering actor",
             file=sys.stderr,
         )
         return triggering_actor

--- a/.github/scripts/resolve_release_actor.py
+++ b/.github/scripts/resolve_release_actor.py
@@ -9,10 +9,9 @@ For ``workflow_dispatch`` and ``schedule`` that is simply the triggering actor:
 the run was started deliberately by someone, and that someone is the answer.
 
 ``push`` (merge-to-main auto-publish) and ``release`` (the tag flow) are the
-hard cases, and they share a fix. Version-bump
-PRs are opened by the Atlan Fleet App bot, so the PR *author* is a bot and the
-person who owns the release is the one who **merged** it. That name is only
-reachable in two hops:
+hard cases, and they share a fix. Version-bump PRs are opened by the Atlan
+Fleet App bot, so the PR *author* is a bot and the person who owns the release
+is the one who **merged** it. That name is only reachable in two hops:
 
 1. ``GET /repos/{repo}/commits/{sha}/pulls`` — the PR(s) the merge SHA belongs
    to. This list response carries ``user`` but **not** ``merged_by``: the field
@@ -28,6 +27,19 @@ triggering actor is the bot, while ``merged_by`` still names the human. When
 there is no associated PR at all (a direct push to main), the triggering actor
 *is* the person who pushed, and that is the fallback.
 
+Two independent signals mark a run as PR-derived, and either is enough: the
+event name, or a non-empty ``--release-tag``. The event name carries its own
+weight — inside a *called* reusable workflow ``GITHUB_EVENT_NAME`` is the event
+that triggered the **caller**, not ``workflow_call``. (Verified on a
+``pull_request`` caller run of ``tests-reusable.yaml``: its ``Detect merge
+queue`` job, gated ``if: github.event_name == 'pull_request'``, ran, while
+``Test-readiness scorecard``, gated on the negation, skipped. Both directions
+agree, and neither is possible if the callee saw ``workflow_call``.) The tag
+does not lean on that behaviour at all: every app caller sets ``release_tag``
+only for ``github.event_name == 'release'``, so a non-empty tag *is* a tagged
+release however the event arrives. The event gate stays because the
+deploy-on-merge apps publish on ``push``, which carries no tag.
+
 Finally, GM prefers an email address over a login, so the resolved actor's
 public email is looked up best-effort. Most accounts do not publish one; the
 login is the fallback, and every lookup failure degrades in that direction
@@ -37,7 +49,7 @@ Usage (from within a workflow step)::
 
     python3 .github/scripts/resolve_release_actor.py \
       --event-name push --repo owner/name --sha "$GITHUB_SHA" \
-      --triggering-actor someone >> "$GITHUB_OUTPUT"
+      --release-tag "$RELEASE_TAG" --triggering-actor someone >> "$GITHUB_OUTPUT"
 
 Writes ``created_by=<email-or-login>`` to stdout; diagnostics go to stderr.
 Requires ``GH_TOKEN`` in the environment for the ``gh`` calls.
@@ -68,6 +80,15 @@ RELEASE_EVENT = "release"
 # both cases GITHUB_SHA is the merge commit of the PR that caused the release,
 # so the same two-hop lookup recovers the person who merged it.
 _PR_DERIVED_EVENTS = (PUSH_EVENT, RELEASE_EVENT)
+
+
+def _is_pr_derived(event_name: str, release_tag: str) -> bool:
+    """Whether the triggering actor is the wrong person to attribute to.
+
+    Either signal alone is sufficient — see the module docstring for why both
+    exist and why neither subsumes the other.
+    """
+    return event_name in _PR_DERIVED_EVENTS or bool(release_tag.strip())
 
 
 def _run_gh(args: list) -> str:
@@ -138,10 +159,12 @@ def resolve_actor(
     sha: str,
     triggering_actor: str,
     run: Callable[[list], str] | None = None,
+    *,
+    release_tag: str = "",
 ) -> str:
     """The login to attribute the release to."""
     run = run or _run_gh
-    if event_name not in _PR_DERIVED_EVENTS:
+    if not _is_pr_derived(event_name, release_tag):
         return triggering_actor
     number = pr_number_for_sha(repo, sha, run)
     if number is None:
@@ -180,11 +203,15 @@ def resolve(
     sha: str,
     triggering_actor: str,
     run: Callable[[list], str] | None = None,
+    *,
+    release_tag: str = "",
 ) -> str:
     """The value GM stores as ``created_by`` — an email when one is public."""
     # Resolved per call, not bound as a default, so the ``_run_gh`` seam stays
     # stubbable from ``main`` down.
-    actor = resolve_actor(event_name, repo, sha, triggering_actor, run)
+    actor = resolve_actor(
+        event_name, repo, sha, triggering_actor, run, release_tag=release_tag
+    )
     return public_email(actor, run) or actor
 
 
@@ -196,13 +223,27 @@ def main(argv: list | None = None) -> int:
     parser.add_argument("--repo", required=True, help="owner/name")
     parser.add_argument("--sha", default="", help="github.sha (push events)")
     parser.add_argument(
+        "--release-tag",
+        default="",
+        help=(
+            "inputs.release_tag — non-empty only for a tagged release, which "
+            "marks the run PR-derived without consulting the event name."
+        ),
+    )
+    parser.add_argument(
         "--triggering-actor",
         required=True,
         help="github.triggering_actor — the fallback attribution.",
     )
     args = parser.parse_args(sys.argv[1:] if argv is None else argv)
 
-    created_by = resolve(args.event_name, args.repo, args.sha, args.triggering_actor)
+    created_by = resolve(
+        args.event_name,
+        args.repo,
+        args.sha,
+        args.triggering_actor,
+        release_tag=args.release_tag,
+    )
     # stdout is a strict contract: `created_by=<value>` and nothing else, since
     # the caller redirects it into $GITHUB_OUTPUT and the runner rejects any
     # line there without an `=`.

--- a/.github/scripts/tests/test_resolve_release_actor.py
+++ b/.github/scripts/tests/test_resolve_release_actor.py
@@ -144,10 +144,12 @@ class TestReleaseAttribution:
     """
 
     def test_attributes_to_the_merger_not_the_publishing_bot(self):
-        run = fake_gh({
-            f"repos/{REPO}/commits/{SHA}/pulls": COMMIT_PULLS_RESPONSE,
-            f"repos/{REPO}/pulls/3240": SINGLE_PULL_RESPONSE,
-        })
+        run = fake_gh(
+            {
+                f"repos/{REPO}/commits/{SHA}/pulls": COMMIT_PULLS_RESPONSE,
+                f"repos/{REPO}/pulls/3240": SINGLE_PULL_RESPONSE,
+            }
+        )
         assert (
             actor.resolve_actor("release", REPO, SHA, "atlan-app-fleet[bot]", run)
             == "a-human"

--- a/.github/scripts/tests/test_resolve_release_actor.py
+++ b/.github/scripts/tests/test_resolve_release_actor.py
@@ -121,7 +121,7 @@ class TestPushAttribution:
 
 
 class TestNonPushAttribution:
-    @pytest.mark.parametrize("event", ["workflow_dispatch", "release", "schedule"])
+    @pytest.mark.parametrize("event", ["workflow_dispatch", "schedule"])
     def test_attributes_to_whoever_triggered_the_run(self, event: str):
         """A deliberate trigger names its own owner — no lookup, no fallback."""
         calls: list = []
@@ -131,6 +131,35 @@ class TestNonPushAttribution:
             == "who-dispatched"
         )
         assert calls == []
+
+
+class TestReleaseAttribution:
+    """`release: published` is never triggered by a human.
+
+    The tag is cut by tag-and-release when a release-labelled PR merges, so the
+    Release is authored by the Fleet App bot and the publish run's triggering
+    actor is that bot. Trusting it attributed every tagged release to
+    `atlan-app-fleet`. GITHUB_SHA is the tagged commit — the merge commit of
+    that PR — so the same two hops recover the human who merged it.
+    """
+
+    def test_attributes_to_the_merger_not_the_publishing_bot(self):
+        run = fake_gh({
+            f"repos/{REPO}/commits/{SHA}/pulls": COMMIT_PULLS_RESPONSE,
+            f"repos/{REPO}/pulls/3240": SINGLE_PULL_RESPONSE,
+        })
+        assert (
+            actor.resolve_actor("release", REPO, SHA, "atlan-app-fleet[bot]", run)
+            == "a-human"
+        )
+
+    def test_falls_back_to_the_bot_rather_than_failing_the_publish(self):
+        """A tag pushed by hand has no PR. Degrading beats blocking a release."""
+        run = fake_gh({f"repos/{REPO}/commits/{SHA}/pulls": []})
+        assert (
+            actor.resolve_actor("release", REPO, SHA, "atlan-app-fleet[bot]", run)
+            == "atlan-app-fleet[bot]"
+        )
 
 
 class TestCreatedByValue:

--- a/.github/scripts/tests/test_resolve_release_actor.py
+++ b/.github/scripts/tests/test_resolve_release_actor.py
@@ -164,6 +164,61 @@ class TestReleaseAttribution:
         )
 
 
+class TestReleaseTagSignal:
+    """The tag identifies a tagged release without consulting the event name.
+
+    ``GITHUB_EVENT_NAME`` in a called reusable workflow is the caller's event
+    (``release``), not ``workflow_call`` — see the module docstring for the
+    reproducer. The tag is carried anyway so attribution does not rest on that
+    one behaviour: every caller sets ``release_tag`` only for a release event,
+    so a non-empty tag means the same thing on its own.
+    """
+
+    def test_a_tag_alone_reaches_the_merger(self):
+        run = fake_gh(
+            {
+                f"repos/{REPO}/commits/{SHA}/pulls": COMMIT_PULLS_RESPONSE,
+                f"repos/{REPO}/pulls/3240": SINGLE_PULL_RESPONSE,
+            }
+        )
+        assert (
+            actor.resolve_actor(
+                "workflow_call",
+                REPO,
+                SHA,
+                "atlan-app-fleet[bot]",
+                run,
+                release_tag="v0.3.2",
+            )
+            == "a-human"
+        )
+
+    def test_a_blank_tag_is_not_a_release(self):
+        """Whitespace is what an unset workflow input degrades to, not a tag."""
+        calls: list = []
+        run = fake_gh({}, calls)
+        assert (
+            actor.resolve_actor(
+                "workflow_dispatch", REPO, SHA, "who-dispatched", run, release_tag=" \n"
+            )
+            == "who-dispatched"
+        )
+        assert calls == []
+
+    def test_a_tagless_push_is_still_pr_derived(self):
+        """Deploy-on-merge apps publish on `push` and never set a tag."""
+        run = fake_gh(
+            {
+                f"repos/{REPO}/commits/{SHA}/pulls": COMMIT_PULLS_RESPONSE,
+                f"repos/{REPO}/pulls/3240": SINGLE_PULL_RESPONSE,
+            }
+        )
+        assert (
+            actor.resolve_actor("push", REPO, SHA, "who-pushed", run, release_tag="")
+            == "a-human"
+        )
+
+
 class TestCreatedByValue:
     def test_prefers_a_public_email_over_the_login(self):
         run = fake_gh(
@@ -253,6 +308,16 @@ class TestWorkflowWiring:
         assert publish["env"]["CREATED_BY"] == (
             "${{ steps." + resolver["id"] + ".outputs.created_by }}"
         )
+
+    def test_the_resolver_step_is_given_the_release_tag(self):
+        """Without this the tag signal is dead and only the event name is left.
+
+        Both halves are asserted: an env var carrying ``inputs.release_tag``,
+        and a command line that actually passes it.
+        """
+        step = self._step("Resolve release attribution")
+        assert step["env"]["RELEASE_TAG"] == "${{ inputs.release_tag }}"
+        assert '--release-tag "${RELEASE_TAG}"' in step["run"]
 
     def test_the_publish_step_no_longer_resolves_the_actor_inline(self):
         # The inline lookup this replaced was dead for two independent reasons

--- a/.github/workflows/build-and-publish-app.yaml
+++ b/.github/workflows/build-and-publish-app.yaml
@@ -1504,12 +1504,17 @@ jobs:
           # attribution collapses to the triggering actor with nothing red.
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TRIGGERING_ACTOR: ${{ github.triggering_actor }}
+          # A tagged release marks the run PR-derived on its own, so attribution
+          # holds even where the event name is unavailable. Callers set this
+          # only for `github.event_name == 'release'`.
+          RELEASE_TAG: ${{ inputs.release_tag }}
         run: |
           set -euo pipefail
           python3 .sdk-entrypoint/.github/scripts/resolve_release_actor.py \
             --event-name "${GITHUB_EVENT_NAME}" \
             --repo "${GITHUB_REPOSITORY}" \
             --sha "${GITHUB_SHA}" \
+            --release-tag "${RELEASE_TAG}" \
             --triggering-actor "${TRIGGERING_ACTOR}" >> "${GITHUB_OUTPUT}"
 
       - name: Publish version

--- a/.github/workflows/conformance-reusable.yaml
+++ b/.github/workflows/conformance-reusable.yaml
@@ -93,7 +93,13 @@ on:
         default: ""
         type: string
       event_name:
-        description: "Caller's github.event_name (push / pull_request / merge_group); reusable workflows always see 'workflow_call' internally"
+        description: >
+          Caller's github.event_name (push / pull_request / merge_group).
+          Taken as an input, not read from the context, so a caller can
+          declare push semantics deliberately — the SDK's sdk-gate.yaml
+          does exactly that. (A called reusable workflow does see the
+          caller's real event in github.event_name, not 'workflow_call';
+          the input is a choice, not a workaround.)
         required: false
         default: ""
         type: string


### PR DESCRIPTION
## Why

Every semver release in Global Marketplace is attributed to a bot.

[atlan-databricks-app v0.3.2](https://github.com/atlanhq/atlan-databricks-app/releases/tag/v0.3.2) shows **`Created by: atlan-app-fleet`** in its GM release thread. GM has a 256-entry GitHub→Slack map and would tag the person correctly — it just never receives a person.

## Root cause

`resolve_release_actor.py` runs its PR → `merged_by` lookup **only** on `push`, reasoning that any other event *"was started deliberately by someone, and that someone is the answer."*

That holds for `workflow_dispatch` and `schedule`. It does not hold for `release`:

1. `tag-and-publish.yaml` fires when a PR labelled `release` merges to main
2. it calls `tag-and-release`, which cuts the tag and publishes the GitHub Release **as the Fleet App bot**
3. `build-and-publish.yaml` listens on `release: [published]`
4. so `github.triggering_actor` on the publish run is `atlan-app-fleet[bot]` — never a human

## Fix

Four lines of logic. `GITHUB_SHA` on a `release` run is the tagged commit — which *is* the merge commit of the PR that caused the release — so the existing two hops already reach the right person. Only the event gate needed widening; no new API surface, no new permissions.

```diff
-if event_name != PUSH_EVENT:
+if event_name not in _PR_DERIVED_EVENTS:   # ("push", "release")
     return triggering_actor
```

`workflow_dispatch` and `schedule` keep the old path — those really are started by a human.

## Fallback behaviour

A tag pushed by hand has no PR behind it, so the lookup finds nothing and attribution degrades to the triggering actor exactly as it does today for a direct push to main. A release publishes rather than failing on attribution.

## Testing

16 pass. The parametrized non-push test lost `"release"` (it now asserts the opposite) and a `TestReleaseAttribution` class covers both the bot-merger case and the no-PR fallback.

Verified non-vacuous: reverting the one-line gate fails `test_attributes_to_the_merger_not_the_publishing_bot` and nothing else.

## Verified against live GitHub data

The patched script was run against real release runs — same inputs the workflow passes — and each result fed through GM's GitHub→Slack map:

| repo | tag | triggering_actor | resolved | GM tag |
|---|---|---|---|---|
| atlan-databricks-app | v0.3.2 | `atlan-app-fleet[bot]` | `omkargade04` | `<@U07ULMTBGER>` |
| atlan-databricks-app | v0.3.1 | `atlan-app-fleet[bot]` | `omkargade04` | `<@U07ULMTBGER>` |
| atlan-databricks-app | v0.3.0 | `atlan-app-fleet[bot]` | `fyzanshaik-atlan` | `<@U0A6N3CRK5L>` |
| atlan-databricks-app | v0.2.2 / v0.2.1 / v0.2.0 | `atlan-app-fleet[bot]` | `omkargade04` | `<@U07ULMTBGER>` |
| atlan-snowflake-app | v1.0.1 / v1.0.0 | `atlan-app-fleet[bot]` | `sharma-shreyas` | `<@U05LQHQSF0X>` |
| atlan-redshift-app | v1.0.0 | `atlan-app-fleet[bot]` | `fyzanshaik-atlan` | `<@U0A6N3CRK5L>` |
| atlan-thoughtspot-app | v1.1.1 | `atlan-app-fleet[bot]` | `prateek11rai` | `<@U06S4P9SAD8>` |
| atlan-thoughtspot-app | v1.1.0 | `atlan-app-fleet[bot]` | `zaman.ishtiyaq@atlan.com` | resolved via Slack email lookup |

`triggering_actor` was the bot on **every** sampled release run — the miss is systemic, not incidental.

Chain confirmed for v0.3.2: tag `v0.3.2` → commit `db46353d` (= the run's `head_sha`, i.e. `GITHUB_SHA`) → PR #409 *"Bump version to 0.3.2"* (opened by the bot, `merged_by` null in the list response as expected) → single-PR endpoint → `merged_by: omkargade04`.

Token permissions are inherited from the workflow-level block, which grants `pull-requests: write` — both hops are authorised.

## Blast radius

Attribution only — the value GM stores as `created_by`. No change to what gets built, tagged, or published. Every app repo using this reusable workflow picks it up on `@main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
