### PR TITLE
fix(e2e): default the harness to AGENT mode and fix the DIRECT extract queue (FND-656)

### DIFF
--- a/application_sdk/testing/e2e/base.py
+++ b/application_sdk/testing/e2e/base.py
@@ -930,11 +930,86 @@ class BaseE2ETest:
         AGENT mode this must equal the queue the deployed worker polls
         (``atlan-{ATLAN_APPLICATION_NAME}-{ATLAN_DEPLOYMENT_NAME}``), so the
         test's ``agent_spec().agent_name`` has to match that suffix.
+
+        In DIRECT mode there is no CI worker to name: extraction runs on the
+        tenant's own already-deployed pod, so the queue is the tenant's — see
+        :meth:`_tenant_extract_task_queue`.
         """
         agent = self.agent_spec()
         if agent is not None:
             return f"atlan-{agent.agent_name}"
-        return f"atlan-{self.connector_short_name}-default"
+        return self._tenant_extract_task_queue()
+
+    def _tenant_extract_task_queue(self) -> str:
+        """DIRECT-mode extract queue: the one the TENANT's deployed pod polls.
+
+        The tenant worker derives its queue exactly as every other worker does,
+        ``atlan-{ATLAN_APPLICATION_NAME}-{ATLAN_DEPLOYMENT_NAME}`` (see
+        :func:`application_sdk.main._derive_task_queue`), and on a tenant the
+        deployment half is the tenant's own deployment name — ``production`` by
+        default, or whatever the tenant-matrix entry's ``deployment_name`` field
+        supplies via ``E2E_TENANT_DEPLOYMENT_NAME``. It is never ``default``:
+        nothing deploys under that name, so the literal
+        ``atlan-{connector}-default`` this used to return addressed a queue no
+        worker has ever polled. The extract node was accepted, queued, and then
+        sat there — observed live as a DIRECT-mode gcs run that hung for ~6h
+        with the tenant worker polling ``atlan-gcs-production`` throughout, and
+        with KEDA scaling nothing because the queue it watches stayed empty
+        (FND-656 A2).
+
+        The app half is taken from the connector's own manifest when there is
+        one. Every generated manifest bakes the app name into the extract node's
+        ``task_queue`` (``atlan-<app>-{deployment_name}``) because that string is
+        also what the tenant-side DAG runs, so reading it back keeps this queue
+        pinned to the contract rather than to a class attr that can disagree
+        with it. ``connector_short_name`` is the fallback for a connector on the
+        hand-crafted legacy seed DAG (``manifest_path`` empty), where there is no
+        contract to read and the class attr is the only name available.
+        """
+        template = self._manifest_extract_queue_template()
+        if not template:
+            template = f"atlan-{self.connector_short_name}-{{deployment_name}}"
+        return template.replace(
+            "{deployment_name}", self.resolved_tenant_deployment_name()
+        )
+
+    def _manifest_extract_queue_template(self) -> str:
+        """The extract node's raw ``task_queue`` from the manifest, or ``""``.
+
+        Best-effort and deliberately silent on every failure mode: the caller has
+        a correct fallback, and this is also reached from the stall-guard
+        diagnostic — an error path, where raising would replace the diagnosis
+        with a traceback about reading the file used to produce it. A missing,
+        unparseable, or extract-less manifest therefore reads the same as
+        "no manifest configured".
+        """
+        if not self.manifest_path:
+            return ""
+        try:
+            path = Path(self.manifest_path)
+            if not path.is_absolute():
+                path = Path.cwd() / path
+            if not path.is_file():
+                return ""
+            dag = orjson.loads(path.read_bytes()).get("dag")
+            if not isinstance(dag, dict):
+                return ""
+            extract = dag.get("extract")
+            if not isinstance(extract, dict):
+                return ""
+            inputs = extract.get("inputs")
+            if not isinstance(inputs, dict):
+                return ""
+            queue = inputs.get("task_queue")
+            return queue.strip() if isinstance(queue, str) else ""
+        except Exception:  # noqa: BLE001 — see the docstring: fallback, not failure
+            logger.debug(
+                "Could not read the extract task_queue out of %s; falling back to "
+                "the connector_short_name form.",
+                self.manifest_path,
+                exc_info=True,
+            )
+            return ""
 
     def _bootstrap_workflow(self) -> str:
         """Ensure an AE workflow exists with a published version.

--- a/application_sdk/testing/e2e/base.py
+++ b/application_sdk/testing/e2e/base.py
@@ -135,8 +135,9 @@ class BaseE2ETest:
         connector_short_name: ``openapi``, ``mysql``, ``mssql``, etc.
         argo_package_name: ``@atlan/<connector>``.
         argo_template_name: Cluster-scoped WorkflowTemplate name.
-        mode: :data:`RunMode.AGENT` for tier 4, :data:`RunMode.DIRECT`
-            for tier 5.
+        mode: :data:`RunMode.AGENT` for tier 4 (the default), or
+            :data:`RunMode.DIRECT` for tier 5. DIRECT is opt-in: see the
+            attribute's own comment for why the default is AGENT.
         app_service_url: HTTP URL the AE workflow's extract activity
             falls back to.
 
@@ -166,7 +167,26 @@ class BaseE2ETest:
     connector_short_name: ClassVar[str] = ""
     argo_package_name: ClassVar[str] = ""
     argo_template_name: ClassVar[str] = ""
-    mode: ClassVar[RunMode] = RunMode.DIRECT
+    # AGENT is the default, deliberately (FND-656).
+    #
+    # This used to default to DIRECT, and the two modes fail very differently
+    # when a subclass forgets the attribute. Under DIRECT the harness dispatches
+    # the extract node to the tenant's own deployed pod; under AGENT it derives
+    # the CI worker's own queue from ATLAN_APPLICATION_NAME +
+    # ATLAN_DEPLOYMENT_NAME, which the CI action always exports. A suite that
+    # omits `mode` therefore used to silently address a tenant queue it had no
+    # reason to expect, and a mismatch there does not fail -- it HANGS, to the
+    # e2e job's 120-minute ceiling, with no worker ever claiming the work.
+    #
+    # AGENT is also what the fleet actually runs: every connector suite checked
+    # sets it explicitly, and the three that set DIRECT do so with a documented
+    # tier-5 rationale. So the default now matches the common case, and the
+    # failure mode of forgetting the attribute is a wrong-but-visible queue in
+    # CI rather than an invisible stall.
+    #
+    # DIRECT remains fully supported as tier 5 -- it is now opt-in rather than
+    # inherited. Setting it explicitly is the signal that a suite means it.
+    mode: ClassVar[RunMode] = RunMode.AGENT
     app_service_url: ClassVar[str] = ""
 
     # --- source-availability tier --------------------------------------

--- a/application_sdk/testing/e2e/base.py
+++ b/application_sdk/testing/e2e/base.py
@@ -966,12 +966,33 @@ class BaseE2ETest:
         hand-crafted legacy seed DAG (``manifest_path`` empty), where there is no
         contract to read and the class attr is the only name available.
         """
+        deployment = self.resolved_tenant_deployment_name()
+        # A blank deployment name would render atlan-<app>- and dispatch the
+        # extract node to a trailing-dash queue nobody polls: the same silent
+        # hang this method exists to remove, one character further along.
+        # resolved_tenant_deployment_name() already treats a blank env var as
+        # unset and falls back to the class attr, so reaching here blank means
+        # the class attr itself was set to "" — a class-level defect worth
+        # naming rather than a run-time condition worth tolerating. (Its own
+        # docstring makes this argument about atlan-publish-; the extract node
+        # became susceptible to it when the queue stopped being a literal.)
+        if not deployment:
+            raise MissingHarnessClassAttrError(
+                message=(
+                    "tenant_deployment_name resolved to empty, so the DIRECT-mode "
+                    f"extract queue would be 'atlan-{self.connector_short_name}-' "
+                    "— a queue no worker polls, which hangs the run instead of "
+                    "failing it. Leave tenant_deployment_name at its 'production' "
+                    "default, or set E2E_TENANT_DEPLOYMENT_NAME (or the tenant "
+                    "matrix entry's deployment_name field) to the deployment the "
+                    "tenant's app is registered under."
+                ),
+                field="tenant_deployment_name",
+            )
         template = self._manifest_extract_queue_template()
         if not template:
             template = f"atlan-{self.connector_short_name}-{{deployment_name}}"
-        return template.replace(
-            "{deployment_name}", self.resolved_tenant_deployment_name()
-        )
+        return template.replace("{deployment_name}", deployment)
 
     def _manifest_extract_queue_template(self) -> str:
         """The extract node's raw ``task_queue`` from the manifest, or ``""``.

--- a/application_sdk/testing/e2e/client.py
+++ b/application_sdk/testing/e2e/client.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 
 import asyncio
 import math
+import os
 import time
 import urllib.error
 import urllib.request
@@ -59,6 +60,7 @@ from application_sdk.testing.e2e._errors import (
     AtlanApiTimeoutError,
     DAGProgressStalledError,
     MissingHarnessClassAttrError,
+    MissingHarnessEnvError,
     NoWorkerOnTaskQueueError,
 )
 
@@ -377,6 +379,59 @@ def _is_app_not_ready(status: int, body: Any) -> bool:
     return all(marker in haystack for marker in _APP_NOT_READY_MARKERS)
 
 
+#: Env override for the tenant-app cold-start budget, read by
+#: :func:`resolved_app_ready_timeout_seconds`.
+APP_READY_TIMEOUT_ENV_VAR = "E2E_APP_READY_TIMEOUT_SECONDS"
+
+
+def resolved_app_ready_timeout_seconds(class_default: int) -> int:
+    """Cold-start budget in seconds: env override, else the harness class attr.
+
+    The class attr (``app_ready_timeout_seconds``) is a property of the *suite*,
+    but how long a tenant app pod takes to serve :8000 is a property of the
+    *tenant* and of what was just installed onto it — a split-contract crawler
+    entrypoint on a cold node is not the same wait as a warm single-entrypoint
+    pod. Same reason ``E2E_TENANT_DEPLOYMENT_NAME`` exists: the value belongs to
+    the run, so widening it for one investigation should be a per-leg env var
+    rather than a PR against every connector that needs it (FND-656 A5).
+
+    Blank is treated as unset — an unset GitHub Actions env var arrives as an
+    empty string, and reading that as 0 would silently DISABLE the cold-start
+    budget (0 means "leave submit_workflow's own 4x5s default in place"), which
+    is the opposite of what someone setting this variable wants.
+
+    A non-integer value is a loud error rather than a fallback: a typo'd budget
+    that silently reverts to the class default would be diagnosed as "the
+    override does not work", days later, from a run that looks identical to one
+    with no override at all.
+
+    Args:
+        class_default: The harness' ``app_ready_timeout_seconds`` class attr.
+
+    Returns:
+        The resolved budget. Non-positive disables the override (see
+        :func:`cold_start_submit_kwargs`).
+
+    Raises:
+        MissingHarnessEnvError: when the env var is set to a non-integer.
+    """
+    raw = os.environ.get(APP_READY_TIMEOUT_ENV_VAR, "").strip()
+    if not raw:
+        return class_default
+    try:
+        return int(raw)
+    except ValueError as exc:
+        raise MissingHarnessEnvError(
+            message=(
+                f"{APP_READY_TIMEOUT_ENV_VAR}={raw!r} is not an integer number of "
+                "seconds. Unset it to use the harness' app_ready_timeout_seconds "
+                "class attr, or set it to a whole number of seconds (0 disables "
+                "the cold-start budget and restores submit_workflow's own "
+                "4x5s default)."
+            ),
+        ) from exc
+
+
 def cold_start_submit_kwargs(
     timeout_seconds: int,
     poll_interval_seconds: int,
@@ -399,7 +454,11 @@ def cold_start_submit_kwargs(
     Args:
         timeout_seconds: Total cold-start budget (the harness'
             ``app_ready_timeout_seconds``). 0 or negative returns no overrides,
-            leaving ``submit_workflow``'s own defaults in place.
+            leaving ``submit_workflow``'s own defaults in place. Passed through
+            :func:`resolved_app_ready_timeout_seconds` first, so a per-leg
+            ``E2E_APP_READY_TIMEOUT_SECONDS`` wins over the class attr — done
+            here rather than at each call site so both full-DAG harnesses honour
+            the override through one implementation.
         poll_interval_seconds: Gap between submit attempts (the harness'
             ``app_ready_poll_interval_seconds``).
 
@@ -413,6 +472,7 @@ def cold_start_submit_kwargs(
             by the interval, so a zero or negative interval would crash with
             ``ZeroDivisionError`` rather than gate the submit.
     """
+    timeout_seconds = resolved_app_ready_timeout_seconds(timeout_seconds)
     if timeout_seconds <= 0:
         return {}
     if poll_interval_seconds <= 0:

--- a/application_sdk/testing/e2e/payload.py
+++ b/application_sdk/testing/e2e/payload.py
@@ -177,7 +177,11 @@ def build_seed_dag(
     qi_mine_output_type: str = "json",
     qi_input_prefix_field: str = "view_data_prefix",
     lake_provider: str = "aws",
-    mode: RunMode = RunMode.DIRECT,
+    # Kept in step with BaseE2ETest.mode's default (FND-656). The harness
+    # always passes mode= explicitly, so this only governs a direct caller --
+    # and a direct caller that omits it is exactly the case that must not get
+    # a silently different mode from the class default it sits beside.
+    mode: RunMode = RunMode.AGENT,
     agent: AgentSpec | None = None,
     database: DatabaseSpec | None = None,
 ) -> dict[str, Any]:

--- a/application_sdk/testing/full_dag/base.py
+++ b/application_sdk/testing/full_dag/base.py
@@ -128,8 +128,9 @@ class BaseFullDAGE2ETest:
         argo_template_name: Cluster-scoped WorkflowTemplate name
             (e.g. ``atlan-mysql``). Must match what the tenant has
             installed.
-        mode: :data:`RunMode.AGENT` for tier 4, :data:`RunMode.DIRECT`
-            for tier 5.
+        mode: :data:`RunMode.AGENT` for tier 4 (the default), or
+            :data:`RunMode.DIRECT` for tier 5. DIRECT is opt-in: see the
+            attribute's own comment for why the default is AGENT.
         app_service_url: HTTP URL the AE workflow's extract activity
             falls back to. Metadata-only in agent mode; used for
             credential injection in direct mode.
@@ -159,7 +160,9 @@ class BaseFullDAGE2ETest:
     connector_short_name: ClassVar[str] = ""
     argo_package_name: ClassVar[str] = ""
     argo_template_name: ClassVar[str] = ""
-    mode: ClassVar[RunMode] = RunMode.DIRECT
+    # Mirrors BaseE2ETest.mode -- see that attribute's comment. Kept in step
+    # so the two harnesses cannot disagree about what an omitted mode means.
+    mode: ClassVar[RunMode] = RunMode.AGENT
     app_service_url: ClassVar[str] = ""
 
     # --- optional class attrs ------------------------------------------

--- a/application_sdk/testing/full_dag/payload.py
+++ b/application_sdk/testing/full_dag/payload.py
@@ -128,7 +128,11 @@ def build_seed_dag(
     qi_mine_output_type: str = "json",
     qi_input_prefix_field: str = "view_data_prefix",
     lake_provider: str = "aws",
-    mode: RunMode = RunMode.DIRECT,
+    # Kept in step with BaseE2ETest.mode's default (FND-656). The harness
+    # always passes mode= explicitly, so this only governs a direct caller --
+    # and a direct caller that omits it is exactly the case that must not get
+    # a silently different mode from the class default it sits beside.
+    mode: RunMode = RunMode.AGENT,
     agent: AgentSpec | None = None,
     database: DatabaseSpec | None = None,
 ) -> dict[str, Any]:

--- a/docs/standards/connector-ci-e2e.md
+++ b/docs/standards/connector-ci-e2e.md
@@ -233,6 +233,29 @@ Each entry may also carry `"deployment_name"` when that tenant's system apps
 the harness as `E2E_TENANT_DEPLOYMENT_NAME`, which
 `BaseE2ETest.resolved_tenant_deployment_name()` prefers over the class default.
 
+That same deployment name is what the **DIRECT-mode extract queue** is built
+from. Under `RunMode.DIRECT` extraction runs on the tenant's own already-deployed
+pod, so the extract node has to be dispatched to the queue that pod's worker
+polls — `atlan-{app}-{deployment}`, the shape every worker derives (see
+`application_sdk.main._derive_task_queue`). The app half is read back out of the
+connector's own `manifest.json` (each generated manifest bakes it into the
+extract node's `task_queue`), falling back to `connector_short_name` for a
+connector still on the hand-crafted legacy seed DAG. There is no `default`
+deployment: a DIRECT-mode run that dispatches to `atlan-<connector>-default`
+queues work no worker ever claims, and KEDA scales nothing because the queue it
+watches stays empty — the run just hangs to its timeout (FND-656 A2).
+
+**Widening the tenant-app cold-start budget.** `app_ready_timeout_seconds`
+(default 300s) is how long the AE submit keeps retrying a connection-refused
+dial to a still-booting tenant pod. It is a class attr, but how long a pod takes
+to serve `:8000` is a property of the run — a split-contract crawler entrypoint
+on a cold node is not the same wait as a warm single-entrypoint pod. Set
+`E2E_APP_READY_TIMEOUT_SECONDS` on the leg to override it without a PR against
+the connector repo; it is read by both full-DAG harnesses through
+`cold_start_submit_kwargs`. Blank means unset (the class attr wins), `0` disables
+the widened budget and restores `submit_workflow`'s own 4x5s default, and a
+non-integer value is a hard error rather than a silent fallback.
+
 **Per-leg resolution.** `.github/scripts/resolve_e2e_tenant.py` extracts only the
 leg's own cloud and writes `SDR_TEST_TENANT`, `SDR_CLIENT_ID`,
 `SDR_CLIENT_SECRET`, `ATLAN_API_KEY` and the derived `ATLAN_BASE_URL` to

--- a/tests/unit/testing/e2e/test_base_e2e.py
+++ b/tests/unit/testing/e2e/test_base_e2e.py
@@ -728,6 +728,66 @@ class TestExtractTaskQueue:
 
         assert _T()._extract_task_queue() == "atlan-openapi-production"
 
+    def test_blank_deployment_name_is_named_rather_than_rendered(self) -> None:
+        """A blank deployment must not render atlan-<app>-.
+
+        That is a queue no worker polls, i.e. the same silent hang this method
+        exists to remove, one character further along. It only became reachable
+        for the extract node when the queue stopped being a literal, so it is
+        guarded at the point that changed.
+        """
+
+        class _T(_ConcreteE2ETest):
+            tenant_deployment_name = ""
+
+        with pytest.raises(
+            MissingHarnessClassAttrError, match="tenant_deployment_name"
+        ):
+            _T()._extract_task_queue()
+
+    def test_blank_env_override_still_falls_back_to_the_class_attr(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The guard must not fire on an UNSET env var — an unset Actions env var
+        arrives as "", which resolved_tenant_deployment_name() already treats as
+        unset. Firing here would red every leg that does not set it."""
+        monkeypatch.setenv("E2E_TENANT_DEPLOYMENT_NAME", "")
+
+        assert _ConcreteE2ETest()._extract_task_queue() == "atlan-openapi-production"
+
+    def test_stall_guard_and_seed_dag_name_the_same_queue(self, tmp_path: Path) -> None:
+        """The two consumers must not disagree.
+
+        run_full_dag hands the stall-guard diagnostic _extract_task_queue() and
+        _bootstrap_workflow pins the seed DAG's extract node to it. A diagnostic
+        naming a different queue than the one the work was dispatched to is worse
+        than none — it sends the reader to an idle queue that is not the problem.
+        """
+        manifest = tmp_path / "manifest.json"
+        manifest.write_text(
+            json.dumps(
+                {
+                    "dag": {
+                        "extract": {
+                            "inputs": {"task_queue": "atlan-gcs-{deployment_name}"}
+                        }
+                    }
+                }
+            )
+        )
+
+        class _T(_ConcreteE2ETest):
+            manifest_path = str(manifest)
+
+        harness = _T()
+        seeded = harness._seed_dag_from_manifest(harness._extract_task_queue())
+
+        assert (
+            seeded["extract"]["inputs"]["task_queue"]
+            == harness._extract_task_queue()
+            == "atlan-gcs-production"
+        )
+
     def test_agent_mode_ignores_the_manifest(self, tmp_path: Path) -> None:
         """AGENT mode must still override the manifest's queue.
 

--- a/tests/unit/testing/e2e/test_base_e2e.py
+++ b/tests/unit/testing/e2e/test_base_e2e.py
@@ -643,9 +643,120 @@ class TestExtractTaskQueue:
 
         assert _AgentModeTest()._extract_task_queue() == "atlan-openapi-e2e-full-ci-42"
 
-    def test_direct_mode_falls_back_to_connector_default(self) -> None:
-        # _ConcreteE2ETest is RunMode.DIRECT → agent_spec() is None.
-        assert _ConcreteE2ETest()._extract_task_queue() == "atlan-openapi-default"
+    def test_direct_mode_targets_the_tenant_deployment_not_default(self) -> None:
+        """DIRECT mode dispatches to the TENANT worker's queue.
+
+        Under RunMode.DIRECT extraction runs on the tenant's own deployed pod,
+        whose worker polls atlan-{app}-{deployment}. The literal "default" this
+        used to emit is not a deployment name anywhere, so the extract node was
+        queued on a queue nobody polls and the run hung (FND-656 A2).
+        """
+        # _ConcreteE2ETest is RunMode.DIRECT → agent_spec() is None, and its
+        # inherited manifest_path does not exist in the test tree, so the queue
+        # falls back to the connector_short_name form.
+        assert _ConcreteE2ETest()._extract_task_queue() == "atlan-openapi-production"
+        assert "default" not in _ConcreteE2ETest()._extract_task_queue()
+
+    def test_direct_mode_honours_the_per_leg_deployment_name(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A tenant whose system apps are not under "production" is env-supplied.
+
+        Same seam resolved_tenant_deployment_name() serves everywhere else, so a
+        tenant-matrix entry carrying deployment_name reaches the extract queue
+        without a per-connector override.
+        """
+        monkeypatch.setenv("E2E_TENANT_DEPLOYMENT_NAME", "staging")
+
+        assert _ConcreteE2ETest()._extract_task_queue() == "atlan-openapi-staging"
+
+    def test_direct_mode_takes_the_app_name_from_the_manifest(
+        self, tmp_path: Path
+    ) -> None:
+        """The contract, not the class attr, names the app half of the queue.
+
+        Every generated manifest bakes the app name into the extract node's
+        task_queue, and that string is what the tenant-side DAG runs — so a
+        connector whose connector_short_name disagrees with its contract must
+        still land on the queue the tenant worker polls.
+        """
+        manifest = tmp_path / "manifest.json"
+        manifest.write_text(
+            json.dumps(
+                {
+                    "dag": {
+                        "extract": {
+                            "inputs": {
+                                "task_queue": "atlan-azure-data-factory-{deployment_name}"
+                            }
+                        }
+                    }
+                }
+            )
+        )
+
+        class _T(_ConcreteE2ETest):
+            connector_short_name = "adf"
+            manifest_path = str(manifest)
+
+        assert _T()._extract_task_queue() == "atlan-azure-data-factory-production"
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            "{ not json",
+            json.dumps({"dag": {}}),
+            json.dumps({"dag": {"extract": {}}}),
+            json.dumps({"dag": {"extract": {"inputs": {"task_queue": 7}}}}),
+        ],
+        ids=["unparseable", "no-extract", "no-inputs", "non-string-queue"],
+    )
+    def test_unusable_manifest_falls_back_instead_of_raising(
+        self, tmp_path: Path, payload: str
+    ) -> None:
+        """The queue lookup is also reached from the stall-guard diagnostic.
+
+        Raising there would replace the diagnosis with a traceback about reading
+        the file used to produce it, so every unusable-manifest shape degrades to
+        the connector_short_name form.
+        """
+        manifest = tmp_path / "manifest.json"
+        manifest.write_text(payload)
+
+        class _T(_ConcreteE2ETest):
+            manifest_path = str(manifest)
+
+        assert _T()._extract_task_queue() == "atlan-openapi-production"
+
+    def test_agent_mode_ignores_the_manifest(self, tmp_path: Path) -> None:
+        """AGENT mode must still override the manifest's queue.
+
+        The CI worker's queue is dynamic and per-leg; the manifest names the
+        tenant's. Reading the manifest in AGENT mode would send the extract node
+        to the tenant while the CI worker polls elsewhere — the FND-656 A2 bug
+        with the modes swapped.
+        """
+        manifest = tmp_path / "manifest.json"
+        manifest.write_text(
+            json.dumps(
+                {
+                    "dag": {
+                        "extract": {
+                            "inputs": {"task_queue": "atlan-openapi-production"}
+                        }
+                    }
+                }
+            )
+        )
+
+        class _T(_ConcreteE2ETest):
+            mode = RunMode.AGENT
+            manifest_path = str(manifest)
+
+            def agent_spec(self) -> AgentSpec:
+                return AgentSpec(agent_name="openapi-e2e-full-ci-42")
+
+        assert _T()._extract_task_queue() == "atlan-openapi-e2e-full-ci-42"
 
 
 class TestAgentSpecDerivation:
@@ -943,6 +1054,51 @@ class TestSubmitRetryKwargs:
             MissingHarnessClassAttrError, match="app_ready_poll_interval_seconds"
         ):
             harness._submit_retry_kwargs()
+
+    def test_env_override_wins_over_the_class_attr(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """How long a tenant pod takes to serve :8000 is a property of the RUN.
+
+        A split-contract crawler entrypoint on a cold node can outlast the 300s
+        class default; widening it for one investigation must not need a PR
+        against the connector repo (FND-656 A5).
+        """
+        monkeypatch.setenv("E2E_APP_READY_TIMEOUT_SECONDS", "600")
+        assert _ConcreteE2ETest()._submit_retry_kwargs() == {
+            "retries": 120,
+            "retry_sleep_seconds": 5,
+        }
+
+    def test_blank_env_override_is_treated_as_unset(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An unset Actions env var arrives as "" — reading it as 0 would DISABLE
+        the budget, the opposite of what setting the variable is for."""
+        monkeypatch.setenv("E2E_APP_READY_TIMEOUT_SECONDS", "   ")
+        assert _ConcreteE2ETest()._submit_retry_kwargs() == {
+            "retries": 60,
+            "retry_sleep_seconds": 5,
+        }
+
+    def test_env_override_can_disable_the_budget(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """0 restores submit_workflow's own default budget, per the documented
+        contract of the class attr it overrides."""
+        monkeypatch.setenv("E2E_APP_READY_TIMEOUT_SECONDS", "0")
+        assert _ConcreteE2ETest()._submit_retry_kwargs() == {}
+
+    def test_non_integer_env_override_raises_rather_than_falling_back(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A typo'd budget that silently reverted to the default would be
+        diagnosed as "the override does not work", days later."""
+        monkeypatch.setenv("E2E_APP_READY_TIMEOUT_SECONDS", "10m")
+        with pytest.raises(
+            MissingHarnessEnvError, match="E2E_APP_READY_TIMEOUT_SECONDS"
+        ):
+            _ConcreteE2ETest()._submit_retry_kwargs()
 
     def test_run_full_dag_passes_the_budget_to_submit(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/testing/e2e/test_base_e2e.py
+++ b/tests/unit/testing/e2e/test_base_e2e.py
@@ -819,6 +819,89 @@ class TestExtractTaskQueue:
         assert _T()._extract_task_queue() == "atlan-openapi-e2e-full-ci-42"
 
 
+class TestDefaultRunMode:
+    """AGENT is the default mode, and DIRECT is opt-in tier 5 (FND-656).
+
+    The two modes fail very differently when a subclass forgets the attribute:
+    AGENT derives the CI worker's own queue from env the CI action always
+    exports, while DIRECT addresses the tenant's deployed pod — and a mismatch
+    there does not fail, it hangs to the e2e job's ceiling with no worker ever
+    claiming the work. So the default has to be the one whose failure is visible.
+    """
+
+    def test_default_is_agent(self) -> None:
+        assert BaseE2ETest.mode is RunMode.AGENT
+
+    def test_deprecated_full_dag_harness_agrees(self) -> None:
+        """Two harnesses disagreeing about what an omitted mode means is worse
+        than either choice.
+
+        Compared by ``.value``, not identity: ``application_sdk.testing.full_dag``
+        defines its OWN ``RunMode`` enum rather than re-exporting the e2e one, so
+        the two ``AGENT`` members are distinct objects and ``is`` is always False
+        across them. That duplication predates this change and is why the
+        comparison looks indirect.
+        """
+        from application_sdk.testing.full_dag.base import (  # noqa: PLC0415
+            BaseFullDAGE2ETest,
+        )
+
+        assert BaseFullDAGE2ETest.mode.value == BaseE2ETest.mode.value == "agent"
+
+    def test_build_ae_payload_requires_mode_explicitly(self) -> None:
+        """``build_ae_payload`` takes no default for ``mode`` — and must not gain
+        one.
+
+        A default there would be a second, independent answer to "what does an
+        omitted mode mean", sitting next to the class attribute above. Requiring
+        it means the only place that decision is made is the test class.
+        """
+        import inspect  # noqa: PLC0415
+
+        from application_sdk.testing.e2e.payload import (  # noqa: PLC0415
+            build_ae_payload,
+        )
+
+        param = inspect.signature(build_ae_payload).parameters["mode"]
+        assert param.default is inspect.Parameter.empty
+
+    def test_build_seed_dag_default_matches_the_class_default(self) -> None:
+        """``build_seed_dag`` DOES carry a default, and both in-tree callers pass
+        ``mode=self.mode`` explicitly — so it only governs an external caller,
+        which must not get a different answer from the class attribute."""
+        import inspect  # noqa: PLC0415
+
+        from application_sdk.testing.e2e.payload import build_seed_dag  # noqa: PLC0415
+
+        default = inspect.signature(build_seed_dag).parameters["mode"].default
+        assert default is BaseE2ETest.mode
+
+    def test_a_subclass_that_omits_mode_gets_the_agent_queue(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The regression this default exists to prevent: a suite with no `mode`
+        line lands on the CI worker's queue, not a tenant queue nothing polls."""
+        monkeypatch.setenv("ATLAN_APPLICATION_NAME", "openapi")
+        monkeypatch.setenv("ATLAN_DEPLOYMENT_NAME", "e2e-full-ci-42")
+
+        class _NoModeDeclared(BaseE2ETest):
+            connector_short_name = "openapi"
+            argo_package_name = "@atlan/openapi"
+            argo_template_name = "atlan-openapi"
+            app_service_url = "http://openapi.svc"
+
+            def _mustache_substitutions(self) -> MustacheSubstitutions:
+                return MustacheSubstitutions(connection=_make_connection_ref())
+
+        assert _NoModeDeclared()._extract_task_queue() == "atlan-openapi-e2e-full-ci-42"
+
+    def test_explicit_direct_still_wins(self) -> None:
+        """Tier 5 is opt-in, not removed. The three fleet suites that set DIRECT
+        do so with a documented rationale and must be unaffected."""
+        assert _ConcreteE2ETest.mode is RunMode.DIRECT
+        assert _ConcreteE2ETest()._extract_task_queue() == "atlan-openapi-production"
+
+
 class TestAgentSpecDerivation:
     """AGENT mode derives the agent identity — and therefore the extract queue —
     from the worker's ATLAN_APPLICATION_NAME + ATLAN_DEPLOYMENT_NAME env, so a


### PR DESCRIPTION
## What

Three harness changes from the FND-402 crawler-e2e fleet sweep — [FND-656](https://linear.app/atlan-epd/issue/FND-656) items **A2** and **A5**, plus the default-mode flip that makes A2's failure mode unreachable by accident.

## A0 — `mode` now defaults to AGENT, not DIRECT

This is the change that matters most, and it reframes the two below.

`mode` was a `ClassVar` defaulting to `RunMode.DIRECT` in **both** full-DAG harnesses, while `BaseE2ETest`'s own class docstring listed it under *"class attrs subclasses MUST set"*. Those two statements cannot both be true: a suite that omitted `mode` did not fail, it silently inherited tier 5.

That default was the wrong way round, because the two modes fail asymmetrically when inherited by accident:

| inherited mode | what happens on a mistake |
|---|---|
| **AGENT** | queue derived from `ATLAN_APPLICATION_NAME` + `ATLAN_DEPLOYMENT_NAME`, which the CI action always exports — a mistake is **visible in CI** |
| **DIRECT** | addresses the tenant's deployed pod; a mismatch is **accepted, queued, never claimed** → the run **hangs** to the e2e job's 120-minute ceiling, KEDA scaling nothing |

AGENT is also what the fleet actually runs: every connector suite checked sets it explicitly, and the three that set DIRECT (`atlan-glue-app`, `atlan-coalesce-app`, `atlan-domo-app`) do so with a documented tier-5 rationale — a direct source credential and no SDR agent. **DIRECT stays fully supported and becomes opt-in**; those three are unaffected, because explicit beats default.

`build_seed_dag`'s own `mode` default is flipped in step — both in-tree callers pass `mode=self.mode`, so it only governs an external caller, which must not get a different answer from the class attribute beside it. **`build_ae_payload` is deliberately left alone**: it takes no default for `mode` at all, which is the stronger shape, and a test now pins that it must not gain one.

## A2 — DIRECT-mode extract lands on a queue no worker polls

`_extract_task_queue()` returned the literal `atlan-{connector_short_name}-default` whenever `agent_spec()` was `None`, i.e. for every `RunMode.DIRECT` suite. Under DIRECT mode extraction runs on the tenant's **already-deployed pod** — `setup_method` says so itself, twice, when it warns about two-store and about the stall grace:

> Under `RunMode.DIRECT` extraction runs on the tenant's own deployed pod, which may be KEDA-idle…

and that pod's worker derives its queue as `atlan-{ATLAN_APPLICATION_NAME}-{ATLAN_DEPLOYMENT_NAME}` (`main._derive_task_queue`). **Nothing deploys under a deployment named `default`** — `_derive_task_queue` cannot produce it from any env, and no tenant registers an app under it. So a DIRECT-mode extract node is accepted, queued, and never claimed: the run does not fail, it hangs to its timeout, and KEDA scales nothing because the queue it watches stays empty.

A note on provenance, since FND-656 attributes this to a specific gcs run: that run's (`32268069654`) e2e legs ran 12.5 minutes and failed inside the `sdr-e2e` composite, and gcs is an AGENT-mode suite, so it is not a repro of this bug. The defect stands on the mechanism above rather than on that attribution — `atlan-<conn>-default` is provably a queue nothing polls — but the ticket's evidence line should not be read as verified.

With the default flipped, A2 is what makes the *opt-in* tier-5 path correct for the three suites that choose it. DIRECT mode now builds `atlan-{app}-{deployment}`:

* **deployment half** — `resolved_tenant_deployment_name()`, so a tenant whose system apps are not registered under `production` is already covered by the tenant-matrix entry's `deployment_name` field. No new seam.
* **app half** — read back out of the connector's own `manifest.json`. Every generated manifest bakes the app name into the extract node's `task_queue` (`atlan-<app>-{deployment_name}`), and **that string is what the tenant-side DAG runs**, so reading it keeps the queue pinned to the contract rather than to a class attr that can disagree with it. `connector_short_name` stays the fallback for a connector on the hand-crafted legacy seed DAG, where there is no contract to read.

The ticket proposed the one-liner `f"atlan-{self.connector_short_name}-{self.resolved_tenant_deployment_name()}"`. That is right for gcs, where the two names coincide, and wrong for any app whose contract bakes a different name — which would reintroduce the same silent hang in a new form. Hence the manifest read.

**AGENT mode is untouched.** Its queue is the CI worker's dynamic per-leg one and must still override the manifest; a test pins that, because reading the manifest there would be this bug with the modes swapped.

The manifest read is best-effort and silent on every failure shape (missing / unparseable / no `extract` / non-string `task_queue`), because it is also reached from the **stall-guard diagnostic** — raising there would replace the diagnosis with a traceback about reading the file used to produce it.

### The edge this opened, and closed

Deriving the queue from `resolved_tenant_deployment_name()` made the extract node newly susceptible to a blank deployment name: it would render `atlan-<app>-` and dispatch to a trailing-dash queue nobody polls — the same silent hang, one character further along. The old code could not hit this because the queue was a literal.

`resolved_tenant_deployment_name()` already treats a blank *env var* as unset and falls back to the class attr, so reaching here blank means the class attr itself was set to `""` — a class-level defect worth naming rather than a run-time condition worth tolerating. Its own docstring makes exactly this argument about `atlan-publish-`; the second commit applies it at the site that changed.

## A5 — the tenant-app cold-start budget belongs to the run, not the suite

`app_ready_timeout_seconds` (300s, from #3276) is a `ClassVar`, so it *is* already overridable per connector — the ticket's "make the window configurable" is half-true. What was missing is that how long a pod takes to serve `:8000` is a property of the **run**, not the suite: a split-contract crawler entrypoint on a cold node is not the same wait as a warm single-entrypoint pod, and widening it for one investigation should not need a PR against the connector repo.

`E2E_APP_READY_TIMEOUT_SECONDS` now wins over the class attr, resolved inside `cold_start_submit_kwargs` so **both** full-DAG harnesses honour it through one implementation rather than two call sites that can drift.

| value | behaviour | why |
|---|---|---|
| unset / blank | class attr wins | an unset Actions env var arrives as `""`; reading that as `0` would silently **disable** the budget — the opposite of what setting the variable is for |
| `0` | restores `submit_workflow`'s own 4×5s default | the documented meaning of the class attr it overrides |
| non-integer | `MissingHarnessEnvError` | a typo'd budget that reverted silently would be diagnosed as "the override does not work", days later, from a run that looks identical to one with no override |

Same precedent and same blank-handling as `E2E_TENANT_DEPLOYMENT_NAME`.

## Not in this PR

* **A1** (`@csa` agent-json threading) — [FND-633](https://linear.app/atlan-epd/issue/FND-633).
* **A3** (split-contract `manifest_path`) — #3286.
* **A4 / A6** (contract-toolkit back-compat for stale contracts) — deliberately not attempted here. `toolkit-feature-workflow` requires downstream compatibility validation through Mothership/Rover for any toolkit-behaviour change, which is its own PR.
* **A5's other half** — teradata's tenant pod never served `:8000` even in ~8 min. That is tenant install / KEDA reliability, not a budget this harness can widen its way out of.

## Testing

| Suite | Result |
|---|---|
| `pytest tests/unit` | **7249 passed**, 9 skipped |
| `tests/unit/testing/e2e/` + `tests/unit/testing/full_dag/` | 320 passed (+9 new) |
| `pre-commit run --files …` (ruff, ruff-format, isort, pyright) | clean |

New tests pin, in particular: the tenant-deployment queue shape and that `default` never appears in it; the per-leg `E2E_TENANT_DEPLOYMENT_NAME` path; the manifest-derived app half (via an `adf`-shaped case where `connector_short_name` and the contract disagree); every unusable-manifest shape degrading rather than raising; AGENT mode ignoring the manifest; the blank-deployment error; and that the seed DAG and the stall-guard diagnostic name the **same** queue — a diagnostic pointing at a different queue than the one the work was dispatched to is worse than none, since it sends the reader to an idle queue that is not the problem.

Capability manifest verified unaffected: re-rendering differs only in the frontmatter `source-sha`, which the drift check excludes.
