### PR TITLE
ci(renovate): only fail a hold where Renovate owns the commit (FND-379)

### DIFF
--- a/.github/scripts/bound_lock_branch.py
+++ b/.github/scripts/bound_lock_branch.py
@@ -117,9 +117,10 @@ def bound_project(project: Project, window: str, baseline_ref: str, root: Path) 
         "--project-dir",
         str(root / project.directory),
         # This script owns the commit, so a bound that admits nothing is a
-        # net-empty PR here, not the silent substitution it would be under
-        # postUpgradeTasks. Without this the driver fails, nothing is pushed, and
-        # Renovate's unbounded lock stays on the branch — observed on #3290.
+        # net-empty PR in the usual case (byte-identical to the baseline), not
+        # the silent substitution it would be under postUpgradeTasks. Without
+        # this the driver fails, nothing is pushed, and Renovate's unbounded
+        # lock stays on the branch — observed on #3290.
         "--caller-owns-commit",
     ]
     for name in project.exempt:

--- a/.github/scripts/bound_lock_branch.py
+++ b/.github/scripts/bound_lock_branch.py
@@ -116,6 +116,11 @@ def bound_project(project: Project, window: str, baseline_ref: str, root: Path) 
         baseline_ref,
         "--project-dir",
         str(root / project.directory),
+        # This script owns the commit, so a bound that admits nothing is a
+        # net-empty PR here, not the silent substitution it would be under
+        # postUpgradeTasks. Without this the driver fails, nothing is pushed, and
+        # Renovate's unbounded lock stays on the branch — observed on #3290.
+        "--caller-owns-commit",
     ]
     for name in project.exempt:
         argv += ["--exempt", name]

--- a/.github/scripts/renovate_uv_lock_bounded.py
+++ b/.github/scripts/renovate_uv_lock_bounded.py
@@ -608,6 +608,17 @@ def main(argv: list[str] | None = None) -> int:
     )
     parser.add_argument("--project-dir", default=".")
     parser.add_argument(
+        "--caller-owns-commit",
+        action="store_true",
+        help="The caller controls what gets committed, so a bound that admits "
+        "nothing is an ordinary no-op: write the baseline back and exit 0, and "
+        "let the caller commit that. Set by bound_lock_branch.py (FND-376), whose "
+        "workflow owns the push. Leave it off under Renovate's postUpgradeTasks, "
+        "where Renovate commits the working tree itself and substitutes its own "
+        "unbounded artifact whenever this command leaves the tree matching HEAD — "
+        "there, admitting nothing has to fail visibly instead.",
+    )
+    parser.add_argument(
         "--baseline-ref",
         default="HEAD",
         help="Git ref whose uv.lock is the PRE-refresh baseline for retention "
@@ -738,7 +749,7 @@ def main(argv: list[str] | None = None) -> int:
         )
         return 1
 
-    if after == before and renovate_versions != before:
+    if after == before and renovate_versions != before and not args.caller_owns_commit:
         moved = ", ".join(
             f"{name} {before.get(name, 'absent')} -> {version}"
             for name, version in sorted(renovate_versions.items())

--- a/.github/scripts/renovate_uv_lock_bounded.py
+++ b/.github/scripts/renovate_uv_lock_bounded.py
@@ -611,12 +611,13 @@ def main(argv: list[str] | None = None) -> int:
         "--caller-owns-commit",
         action="store_true",
         help="The caller controls what gets committed, so a bound that admits "
-        "nothing is an ordinary no-op: write the baseline back and exit 0, and "
-        "let the caller commit that. Set by bound_lock_branch.py (FND-376), whose "
-        "workflow owns the push. Leave it off under Renovate's postUpgradeTasks, "
-        "where Renovate commits the working tree itself and substitutes its own "
-        "unbounded artifact whenever this command leaves the tree matching HEAD — "
-        "there, admitting nothing has to fail visibly instead.",
+        "nothing is an ordinary no-op: write back the bounded resolve, whose "
+        "versions match the baseline, and exit 0, and let the caller commit "
+        "that. Set by bound_lock_branch.py (FND-376), whose workflow owns the "
+        "push. Leave it off under Renovate's postUpgradeTasks, where Renovate "
+        "commits the working tree itself and substitutes its own unbounded "
+        "artifact whenever this command leaves the tree matching HEAD — there, "
+        "admitting nothing has to fail visibly instead.",
     )
     parser.add_argument(
         "--baseline-ref",
@@ -749,24 +750,35 @@ def main(argv: list[str] | None = None) -> int:
         )
         return 1
 
-    if after == before and renovate_versions != before and not args.caller_owns_commit:
+    if after == before and renovate_versions != before:
         moved = ", ".join(
             f"{name} {before.get(name, 'absent')} -> {version}"
             for name, version in sorted(renovate_versions.items())
             if before.get(name) != version
         )
-        withhold(lock_path, baseline, args.window)
-        print(
-            f"The bound admits nothing today, but Renovate's own unbounded "
-            f"resolve moved: {moved}. Leaving the tree matching HEAD would hand "
-            "Renovate's copy straight to the branch — a valid lock that passes "
-            "every check while carrying releases minutes old — so the lock is "
-            "left deliberately un-installable instead and this run fails. "
-            "Nothing needs fixing in the repo: the window will admit these "
-            f"versions once they are `{args.window}` old.",
-            file=sys.stderr,
-        )
-        return 1
+        if args.caller_owns_commit:
+            # Informational only: this lane commits whatever we write, so a hold
+            # is a no-op rather than a refusal. Keep the window's contents in
+            # the log so a net-empty PR still explains itself.
+            print(
+                f"The bound admits nothing today; Renovate's unbounded resolve "
+                f"moved: {moved}. The caller owns the commit, so this is an "
+                "ordinary no-op rather than a hold.",
+                file=sys.stderr,
+            )
+        else:
+            withhold(lock_path, baseline, args.window)
+            print(
+                f"The bound admits nothing today, but Renovate's own unbounded "
+                f"resolve moved: {moved}. Leaving the tree matching HEAD would "
+                "hand Renovate's copy straight to the branch — a valid lock "
+                "that passes every check while carrying releases minutes old — "
+                "so the lock is left deliberately un-installable instead and "
+                "this run fails. Nothing needs fixing in the repo: the window "
+                f"will admit these versions once they are `{args.window}` old.",
+                file=sys.stderr,
+            )
+            return 1
 
     lock_path.write_text(strip_options(lock_path.read_text()))
 

--- a/.github/scripts/tests/test_bound_lock_branch.py
+++ b/.github/scripts/tests/test_bound_lock_branch.py
@@ -320,3 +320,25 @@ class TestExportRequirements:
         )
         orchestrator.export_requirements(repo)
         assert (repo / "requirements.txt").read_text() == "bounded==2.0.0\n"
+
+
+class TestOwnsItsCommit:
+    """This script pushes its own commit, and the driver has to be told so.
+
+    Without `--caller-owns-commit` the driver treats "the bound admits nothing" as
+    the postUpgradeTasks substitution risk and exits non-zero, so this script
+    pushes nothing and Renovate's unbounded commit stays on the branch. That is
+    how #3290 merged a 4-hour-old boto3.
+    """
+
+    def test_the_driver_is_told_that_this_script_owns_the_commit(self, monkeypatch):
+        seen: list[list[str]] = []
+
+        def fake_main(argv):
+            seen.append(argv)
+            return 0
+
+        monkeypatch.setattr(orchestrator.bounded, "main", fake_main)
+        project = orchestrator.PROJECTS[0]
+        assert orchestrator.bound_project(project, "P3D", "origin/main", Path(".")) == 0
+        assert "--caller-owns-commit" in seen[0], seen[0]

--- a/.github/scripts/tests/test_renovate_uv_lock_bounded.py
+++ b/.github/scripts/tests/test_renovate_uv_lock_bounded.py
@@ -937,7 +937,7 @@ class TestWithholds:
         self._assert_withheld(project, baseline)
 
     def test_a_hold_is_an_ordinary_no_op_when_the_caller_owns_the_commit(
-        self, monkeypatch, tmp_path
+        self, monkeypatch, tmp_path, capsys
     ):
         """The lane distinction, asserted against the case above.
 
@@ -966,9 +966,49 @@ class TestWithholds:
             ]
         )
         assert exit_code == 0
-        # The baseline, stripped: what the caller commits to revert the unbounded
-        # refresh, leaving a net-empty PR rather than a held branch.
+        # The bounded resolve, stripped: versions match the baseline so the
+        # caller commits a net-empty PR rather than a held branch.
         assert (project / "uv.lock").read_text() == baseline
+        # The window's contents still belong in the log even though this lane
+        # does not fail on them — otherwise a daily no-op PR is silent about
+        # what Renovate wanted.
+        assert "boto3 1.43.74 -> 1.43.75" in capsys.readouterr().err
+
+    def test_caller_owns_commit_keeps_bounded_bytes_when_versions_match(
+        self, monkeypatch, tmp_path
+    ):
+        """Versions matching the baseline is not the same as writing the baseline.
+
+        The bounded resolve can carry extra metadata the committed lock does not.
+        The caller-owns path writes that resolve (stripped of [options]), not the
+        baseline text — writing the baseline would risk a lock that no longer
+        satisfies the current pyproject.toml.
+        """
+        baseline = lock(boto3="1.43.74")
+        project = self._repo(tmp_path, baseline)
+        (project / "uv.lock").write_text(lock(boto3="1.43.75"))
+        # Same versions as the baseline, plus a metadata line strip_options keeps.
+        bounded_resolve = lock(boto3="1.43.74") + "# resolver-metadata: extra\n"
+
+        def fake_run(command, cwd):
+            (Path(cwd) / "uv.lock").write_text(with_options(bounded_resolve))
+            return subprocess.CompletedProcess(command, 0, "", "")
+
+        monkeypatch.setattr(bounded, "run_uv_lock", fake_run)
+        exit_code = bounded.main(
+            [
+                "--window",
+                "P3D",
+                "--project-dir",
+                str(project),
+                "--caller-owns-commit",
+            ]
+        )
+        assert exit_code == 0
+        final = (project / "uv.lock").read_text()
+        assert bounded.lock_versions(final) == bounded.lock_versions(baseline)
+        assert final != baseline
+        assert "# resolver-metadata: extra" in final
 
     def test_a_rejected_downgrade_still_fails_when_the_caller_owns_the_commit(
         self, monkeypatch, tmp_path

--- a/.github/scripts/tests/test_renovate_uv_lock_bounded.py
+++ b/.github/scripts/tests/test_renovate_uv_lock_bounded.py
@@ -936,6 +936,68 @@ class TestWithholds:
         assert bounded.main(["--window", "P3D", "--project-dir", str(project)]) == 1
         self._assert_withheld(project, baseline)
 
+    def test_a_hold_is_an_ordinary_no_op_when_the_caller_owns_the_commit(
+        self, monkeypatch, tmp_path
+    ):
+        """The lane distinction, asserted against the case above.
+
+        application-sdk's own lane runs from a workflow that owns the push, so a
+        bound admitting nothing means "commit the baseline and let the PR go
+        net-empty". Failing there pushes nothing and leaves Renovate's unbounded
+        commit standing on the branch — which is how a 4-hour-old boto3 reached
+        main on 2026-08-20.
+        """
+        baseline = lock(boto3="1.43.74")
+        project = self._repo(tmp_path, baseline)
+        (project / "uv.lock").write_text(lock(boto3="1.43.75"))
+
+        def fake_run(command, cwd):
+            (Path(cwd) / "uv.lock").write_text(with_options(baseline))
+            return subprocess.CompletedProcess(command, 0, "", "")
+
+        monkeypatch.setattr(bounded, "run_uv_lock", fake_run)
+        exit_code = bounded.main(
+            [
+                "--window",
+                "P3D",
+                "--project-dir",
+                str(project),
+                "--caller-owns-commit",
+            ]
+        )
+        assert exit_code == 0
+        # The baseline, stripped: what the caller commits to revert the unbounded
+        # refresh, leaving a net-empty PR rather than a held branch.
+        assert (project / "uv.lock").read_text() == baseline
+
+    def test_a_rejected_downgrade_still_fails_when_the_caller_owns_the_commit(
+        self, monkeypatch, tmp_path
+    ):
+        # The flag narrows the hold-everything case only. A genuine refusal still
+        # refuses in either lane.
+        baseline = lock(pytest_timeout="2.5.0")
+        project = self._repo(tmp_path, baseline)
+
+        def fake_run(command, cwd):
+            (Path(cwd) / "uv.lock").write_text(
+                with_options(lock(pytest_timeout="2.4.0"))
+            )
+            return subprocess.CompletedProcess(command, 0, "", "")
+
+        monkeypatch.setattr(bounded, "run_uv_lock", fake_run)
+        assert (
+            bounded.main(
+                [
+                    "--window",
+                    "P3D",
+                    "--project-dir",
+                    str(project),
+                    "--caller-owns-commit",
+                ]
+            )
+            == 1
+        )
+
     def test_a_genuinely_quiet_run_is_left_clean_and_passes(
         self, monkeypatch, tmp_path
     ):


### PR DESCRIPTION
## What

`bound_lock_branch.py` now passes `--caller-owns-commit`, and the driver only treats "the bound admits nothing" as a failure when it does *not* own the commit.

## Why — this repo's lock lane has been red since #3297 merged

#3297 made "the bound admits nothing while Renovate's own pass moved things" exit non-zero. That is correct under `postUpgradeTasks`, where Renovate commits the working tree itself and substitutes its captured unbounded artifact whenever the tree matches HEAD.

It is wrong in this repo's own lane. There `bound_lock_branch.py` owns the push, so a hold means *commit the baseline lock and let the PR go net-empty*. Failing instead pushes nothing — and Renovate's unbounded commit stays on the branch:

```
23:40:56Z  #3297 merged
23:43:09Z  bound run for 77e8470a fails:
           "The bound admits nothing today, but Renovate's own unbounded resolve
            moved: boto3 1.43.72 -> 1.43.75, botocore ..., idna 3.18 -> 3.19 ..."
           "Bound failed for 'packages/conformance'; committing nothing"
00:02:54Z  #3290 merges — Renovate's unbounded lock, one commit, no bounding commit
```

Every run of `renovate-lock-cooldown.yaml` since has failed the same way (6 of them). What reached `main` in #3290: **boto3/botocore 1.43.75 at four hours old**, plus `idna 3.19`, `pygments 2.21.0`, `uvicorn 0.52.4`, `pytest-socket 0.8.1`, `fastar 0.12.0`, `hypothesis 6.165.10`.

It also explains #3313, which looks like it is bumping nine packages it never touched: `main`'s `requirements.txt` still describes the pre-#3290 lock, so the next sync catches up on all of them at once. Its own bump — `pytest-rerunfailures` 16.5 → 16.6 — is properly 3d-bounded.

Genuine refusals (failed resolve, rollback gate) still refuse in both lanes; the flag narrows the hold-everything case only.

## Tests

- `test_a_hold_is_an_ordinary_no_op_when_the_caller_owns_the_commit` — exit 0, tree left at the stripped baseline for the caller to commit. Verified red without the fix (`assert 1 == 0`).
- `test_a_rejected_downgrade_still_fails_when_the_caller_owns_the_commit` — the flag does not weaken real refusals.
- `TestOwnsItsCommit` in the caller's suite pins that `bound_lock_branch.py` actually passes the flag.

85 passed across both driver suites; pre-commit clean.

## Follow-ups, not in this PR

1. `main`'s `requirements.txt` needs re-syncing to the current lock, and #3290's unbounded versions want a decision: leave them (they age out of the window today) or roll back.
2. The bound workflow's own job is **not a required check** on `main`, which is why a red bound could not stop #3290 merging. That gap is the reason a refusal has to reach a required check at all — tracked on FND-379.
