### PR TITLE
ci(sdk-review): keep every session id inside the 63-char sandbox name (FND-677)

### DIFF
--- a/.github/scripts/sdk_review_dispatch.py
+++ b/.github/scripts/sdk_review_dispatch.py
@@ -64,6 +64,7 @@ step in `.github/workflows/sdk-review.yml`):
 
 from __future__ import annotations
 
+import hashlib
 import http.client
 import json
 import os
@@ -159,6 +160,20 @@ IDLE_TIMEOUT_SECONDS = 1800
 # be empty" — same model, same bug). Swapping the model is the whole point of
 # the retry.
 MAX_DISPATCH_ATTEMPTS = 2
+# Mothership names the sandbox after the `session_id` it is handed, and that
+# name is a DNS label: `worker /sandbox/create` answers HTTP 500
+# {"error":"Sandbox ID must be 1-63 characters long."} for anything longer.
+# That killed the retry on #3326 and, by arithmetic, every retry this lane had
+# ever authorised (FND-677): the base id the workflow builds was 62 chars, so
+# attempt 1 booted and attempt 2 — base + `-retry1` — was 69 and could not
+# create a sandbox at all. Both retry classes derive their id here, so both
+# were dead on arrival. The base id is now short enough that the ladder fits
+# untouched; this cap is the invariant that keeps it that way.
+SANDBOX_ID_MAX_CHARS = 63
+# Chars of sha256 spent identifying an id that had to be squeezed. 10 hex chars
+# is ~40 bits — collision-proof enough for one repo's review ids, and short
+# enough to leave the human-readable head intact.
+SANDBOX_ID_DIGEST_CHARS = 10
 # Attempt 2's main model: mothership's own DEFAULT_CLAUDE_MODEL, named
 # explicitly rather than by omitting `model` from the payload, so a test can
 # assert the two attempts actually differ and the retry does not silently
@@ -293,6 +308,28 @@ def attempt_suffix(attempt: int) -> str:
     return "" if attempt <= 1 else f"-retry{attempt - 1}"
 
 
+def fit_sandbox_id(session_id: str) -> str:
+    """Squeeze `session_id` into mothership's sandbox-name budget.
+
+    Truncation alone would be a correctness bug, not a cosmetic one: every
+    part of the id that carries uniqueness (run id, run attempt, retry suffix)
+    sits at the END, and consecutive GitHub run ids share a long prefix — so a
+    head-truncated id could equal the previous run's, which is precisely the
+    resume-a-dead-conversation collision the attempt ladder exists to avoid.
+    Keep the legible head, and spend the last chars on a digest of the WHOLE
+    pre-truncation id so distinct inputs keep distinct outputs.
+
+    This is a backstop, not the fix: the workflow's base id leaves ~18 chars of
+    headroom under the cap, so a squeezed id means the format drifted (a test
+    asserts the real one still fits untouched).
+    """
+    if len(session_id) <= SANDBOX_ID_MAX_CHARS:
+        return session_id
+    digest = hashlib.sha256(session_id.encode()).hexdigest()[:SANDBOX_ID_DIGEST_CHARS]
+    head = session_id[: SANDBOX_ID_MAX_CHARS - SANDBOX_ID_DIGEST_CHARS - 1].rstrip("-")
+    return f"{head}-{digest}" if head else digest
+
+
 def attempt_session_id(session_id: str, attempt: int) -> str:
     """A retry MUST NOT reuse the session id.
 
@@ -302,8 +339,12 @@ def attempt_session_id(session_id: str, attempt: int) -> str:
     conversation found with session" failure on #2987 and the zero-SSE death on
     #2989. `mothership_terminate_session.py` derives the same ids so a cancel
     still stops whichever attempt is live.
+
+    Every id the lane can send goes through here, so the sandbox-name budget is
+    enforced in one place — the dispatcher and the terminator cannot disagree
+    about what was actually booted.
     """
-    return f"{session_id}{attempt_suffix(attempt)}"
+    return fit_sandbox_id(f"{session_id}{attempt_suffix(attempt)}")
 
 
 def build_payload(

--- a/.github/scripts/tests/test_mothership_terminate_session.py
+++ b/.github/scripts/tests/test_mothership_terminate_session.py
@@ -11,7 +11,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 import mothership_terminate_session as mts
 
-SESSION = "sdk-review-atlanhq-application-sdk-1234-deadbeef"
+SESSION = "sdk-review-1234-deadbeef-99-1"
 
 
 def _requester(status: int, body: str = ""):

--- a/.github/scripts/tests/test_sdk_review_dispatch.py
+++ b/.github/scripts/tests/test_sdk_review_dispatch.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import http.client
 import json
 import os
+import re
 import sys
 import urllib.error
 from pathlib import Path
@@ -54,7 +55,7 @@ def _frame(inner: dict) -> str:
 
 def _payload(**overrides):
     kwargs = dict(
-        session_id="sdk-review-atlanhq-application-sdk-42-0cab6b6e-99-1",
+        session_id="sdk-review-42-0cab6b6e-99-1",
         pr_number="42",
         pr_url="https://github.com/atlanhq/application-sdk/pull/42",
         repo="atlanhq/application-sdk",
@@ -844,6 +845,116 @@ def test_the_session_id_comes_from_the_step_the_terminator_also_reads():
         == terminator["env"]["SESSION_ID"]
         == "${{ steps.session.outputs.session_id }}"
     )
+
+
+# ---------------------------------------------------------------------------
+# the sandbox-name budget (FND-677)
+# ---------------------------------------------------------------------------
+
+# Worst case, deliberately past anything GitHub has handed this repo: 6-digit
+# PR numbers, a 13-digit run id (they are 11 today), and a 2-digit run attempt.
+# The budget has to survive growth, not just today's values.
+WORST_CASE_SESSION_VARS = {
+    "PR_NUMBER": "999999",
+    "HEAD_SHA_SHORT": "0cab6b6e",
+    "RUN_ID": "9999999999999",
+    "RUN_ATTEMPT": "99",
+}
+
+
+def session_step() -> dict:
+    steps = yaml.safe_load(WORKFLOW.read_text())["jobs"]["sdk-review-dispatch"]["steps"]
+    for step in steps:
+        if step.get("id") == "session":
+            return step
+    raise AssertionError("no `session` step in sdk-review-dispatch")
+
+
+def worst_case_base_session_id() -> str:
+    """The id the workflow would emit for the worst-case inputs.
+
+    Read out of the YAML rather than restated here: a test that hardcodes the
+    format cannot fail when the format is what drifts.
+    """
+    step = session_step()
+    template = re.search(r'session_id=(\S+)" >> "\$GITHUB_OUTPUT"', step["run"])
+    assert template, f"no session_id assignment in the `session` step: {step['run']!r}"
+    fmt = template.group(1)
+    referenced = set(re.findall(r"\$\{(\w+)", fmt))
+    assert referenced == set(WORST_CASE_SESSION_VARS), (
+        "the session id format changed which variables it interpolates — "
+        f"{referenced} vs {set(WORST_CASE_SESSION_VARS)}; re-check the budget "
+        "before updating this list"
+    )
+    for name, value in WORST_CASE_SESSION_VARS.items():
+        assert name in step["env"], f"session step no longer supplies {name}"
+        fmt = fmt.replace(f"${{{name}}}", value)
+    assert "$" not in fmt, f"unsubstituted shell in {fmt!r}"
+    return fmt
+
+
+def test_every_id_in_the_ladder_fits_the_sandbox_name_untruncated():
+    """The bug that made every re-dispatch unbootable, asserted at the source.
+
+    Mothership names the sandbox after the session id and rejects anything over
+    63 chars, so the base id has to leave room for the LONGEST suffix the ladder
+    can append — not merely fit on its own. It used to carry the repo name,
+    which put the base at 62 and `-retry1` at 69: attempt 1 booted and every
+    retry died on `/sandbox/create`.
+
+    Asserting equality, not just length, is the point: a `len() <= 63` check
+    would pass just as happily on an id `fit_sandbox_id()` had silently
+    replaced with a digest, which is a backstop and not a state to ship in.
+    """
+    base = worst_case_base_session_id()
+    for attempt in range(1, sd.MAX_DISPATCH_ATTEMPTS + 1):
+        expected = f"{base}{sd.attempt_suffix(attempt)}"
+        assert len(expected) <= sd.SANDBOX_ID_MAX_CHARS, (
+            f"attempt {attempt} id is {len(expected)} chars, over mothership's "
+            f"{sd.SANDBOX_ID_MAX_CHARS}-char sandbox name: {expected}"
+        )
+        assert sd.attempt_session_id(base, attempt) == expected
+
+
+def test_a_short_id_is_handed_through_unchanged():
+    """The cap must be invisible in the normal case — including to the
+    terminator, which reconstructs ids the dispatcher already sent."""
+    assert sd.fit_sandbox_id("sdk-review-42-0cab6b6e-99-1") == (
+        "sdk-review-42-0cab6b6e-99-1"
+    )
+    assert sd.attempt_session_id("base-id", 2) == "base-id-retry1"
+
+
+def test_a_squeezed_id_stays_inside_the_budget_and_keeps_its_head():
+    over = "sdk-review-" + "x" * 80
+    fitted = sd.fit_sandbox_id(over)
+    assert len(fitted) == sd.SANDBOX_ID_MAX_CHARS
+    assert fitted.startswith("sdk-review-")
+    # A DNS label: lowercase alphanumerics and dashes, starting and ending on a
+    # character mothership will accept.
+    assert re.fullmatch(r"[a-z0-9]([a-z0-9-]*[a-z0-9])?", fitted)
+
+
+def test_squeezing_keeps_the_uniqueness_that_lives_in_the_tail():
+    """Plain truncation would resurrect the collision the ladder exists to stop.
+
+    Consecutive GitHub run ids share a long prefix and the attempt/retry
+    markers sit at the very end, so an id cut to length would make two distinct
+    runs — and the two attempts of one run — ask mothership to RESUME the same
+    session. The digest is taken over the whole pre-truncation id, so the parts
+    that fall off still change the result.
+    """
+    long_base = "sdk-review-999999-0cab6b6e-" + "9" * 40
+    neighbours = [f"{long_base}1-1", f"{long_base}2-1", f"{long_base}1-2"]
+    fitted = [sd.fit_sandbox_id(n) for n in neighbours]
+    assert len(set(fitted)) == len(neighbours)
+
+    ladder = [
+        sd.attempt_session_id(f"{long_base}1-1", attempt)
+        for attempt in range(1, sd.MAX_DISPATCH_ATTEMPTS + 1)
+    ]
+    assert len(set(ladder)) == sd.MAX_DISPATCH_ATTEMPTS
+    assert all(len(sid) <= sd.SANDBOX_ID_MAX_CHARS for sid in ladder)
 
 
 # ---------------------------------------------------------------------------

--- a/.github/workflows/sdk-review.yml
+++ b/.github/workflows/sdk-review.yml
@@ -391,18 +391,30 @@ jobs:
       # failed SDK Review would dispatch the same session id into a sandbox that
       # mothership may still have in its DB — causing the same resume-of-a-dead-
       # session failure the RUN_ID addition fixed for multi-trigger cases.
+      #
+      # Kept SHORT on purpose. Mothership names the sandbox after this id, and
+      # that name is a DNS label — `/sandbox/create` rejects anything over 63
+      # chars. This used to carry `${REPO_FULL_NAME//\//-}`, which put the base
+      # at 62 and every `-retry1` id at 69: attempt 1 booted, and every
+      # re-dispatch the lane authorised died on sandbox create instead of
+      # reviewing (FND-677, seen on #3326). The repo name bought nothing the
+      # dispatch payload does not already carry — it sends
+      # `repositories: ["atlanhq/application-sdk"]` and a `source_id` of
+      # `<repo>#<pr>` — so it is gone, leaving ~18 chars of headroom for the
+      # retry suffix. `attempt_session_id()` enforces the 63-char cap as an
+      # invariant, and a test asserts this format still fits without it having
+      # to truncate. Do not lengthen this without re-reading that test.
       - name: Compute mothership session id
         id: session
         if: steps.lock_gate.outputs.decision != 'skip'
         env:
           PR_NUMBER: ${{ steps.parse.outputs.pr_number }}
           HEAD_SHA_SHORT: ${{ steps.pr.outputs.head_sha_short }}
-          REPO_FULL_NAME: ${{ github.repository }}
           RUN_ID: ${{ github.run_id }}
           RUN_ATTEMPT: ${{ github.run_attempt }}
         run: |
           set -euo pipefail
-          echo "session_id=sdk-review-${REPO_FULL_NAME//\//-}-${PR_NUMBER}-${HEAD_SHA_SHORT}-${RUN_ID}-${RUN_ATTEMPT}" >> "$GITHUB_OUTPUT"
+          echo "session_id=sdk-review-${PR_NUMBER}-${HEAD_SHA_SHORT}-${RUN_ID}-${RUN_ATTEMPT}" >> "$GITHUB_OUTPUT"
 
       - name: Post 'review starting' notice to PR
         id: starter


### PR DESCRIPTION
## What broke

Every `@sdk-review` re-dispatch dies on sandbox creation instead of running. Seen on #3326:

```
[attempt 1/2] model=xai/grok-4.6 status=error code=sandbox_error   # first-token watchdog
[attempt 2/2] dispatching on claude-opus-5
[complete]  status=error code=sandbox_error
message=Sandbox creation failed after 2 attempts (thread_id=sdk-review-<repo>-<pr>-<sha8>-<run-id>-1-retry1,
last_error=SandboxCreateError: worker /sandbox/create returned HTTP 500 after 4 attempt(s):
{"error":"Sandbox ID must be 1-63 characters long."})
```

The retry was authorised correctly and on the right model. It simply could never boot.

## Root cause

Mothership names the sandbox after the `session_id` it is handed, and that name is a DNS label — 63 chars max. The base id `sdk-review.yml` built,

```
sdk-review-${REPO_FULL_NAME//\//-}-${PR_NUMBER}-${HEAD_SHA_SHORT}-${RUN_ID}-${RUN_ATTEMPT}
```

is **62 chars** at a 4-digit PR number: one under the limit. `attempt_session_id()` then appends `-retry1`, so every attempt-2 id is **69 chars** and is rejected before a sandbox exists.

Both retry classes — the model swap on a hard error and the same-model re-dispatch when a clean sandbox posts no verdict — derive their id through that helper, so this was not a #3326 accident: no re-dispatch this lane has ever authorised could boot. The base id crossed the budget on 2026-08-06 when `RUN_ID`/`RUN_ATTEMPT` joined it (#3016), before either retry landed. Attempt 1 always fit, which is why the failure only shows up on the runs that most need a retry.

## Fix

**Shorten the base id** to `sdk-review-<pr>-<sha8>-<run-id>-<run-attempt>` — 38 chars, 45 with `-retry1`, ~18 clear of the cap. The `atlanhq-application-sdk-` segment cost 24 of the 69 and identified nothing new: the same payload already sends `repositories: ["atlanhq/application-sdk"]` and a `source_id` of `<repo>#<pr>`. Everything the id carries for uniqueness (PR, HEAD, run id, run attempt) is untouched.

**Make the budget an invariant** in `attempt_session_id()`, so a future format change cannot resurrect this. If an id ever exceeds 63 chars, keep the legible head and spend the last 11 on a digest of the whole pre-truncation id. Plain truncation would be a correctness bug rather than a cosmetic one: every part that carries uniqueness sits at the END, and consecutive GitHub run ids share a long prefix — a cut id could equal the previous run's, which is exactly the resume-a-dead-conversation collision the attempt ladder exists to prevent. `mothership_terminate_session.py` imports the same helper, so a cancel still derives precisely the ids that were dispatched.

## Tests

- `test_every_id_in_the_ladder_fits_the_sandbox_name_untruncated` reads the format **out of the YAML** (a test that restates the format cannot fail when the format is what drifts), substitutes worst-case inputs (6-digit PR, 13-digit run id, 2-digit attempt), and asserts every id in the ladder equals `base + suffix` — equality, not `len() <= 63`, so an id the cap had silently digested cannot pass. It also fails loudly if the format starts interpolating different variables, so the budget gets re-checked rather than assumed.
- `test_squeezing_keeps_the_uniqueness_that_lives_in_the_tail` pins the property that makes the digest fallback safe: neighbouring run ids, and the two attempts of one run, stay distinct after squeezing.
- Short ids pass through byte-identical (`test_a_short_id_is_handed_through_unchanged`), which is what keeps the terminator's derivation honest.

Mutation-checked both ways: restoring the old format fails the ladder test, and lengthening the literal prefix while keeping the same variables fails it on length (83 > 63).

## Out of scope

Attempt 1's own death on #3326 was `xai/grok-4.6` producing no content within 2m twice (`kill_reason: watchdog_first_token`). Main-lane model health is tracked separately (FND-663 / FND-660); this PR restores the recovery path that should have covered it.

Ticket: [FND-677](https://linear.app/atlan-epd/issue/FND-677/sdk-reviews-re-dispatch-can-never-boot-the-session-id-overruns)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
