### PR TITLE
fix(e2e): recover an ambiguous submit instead of failing the leg

### DIFF
--- a/application_sdk/testing/e2e/_errors.py
+++ b/application_sdk/testing/e2e/_errors.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from enum import Enum
 from typing import ClassVar
 
 from application_sdk.errors.leaves import (
@@ -45,12 +46,55 @@ class AtlanApiResponseInvariantError(DataIntegrityError):
     location: str | None = "atlan_api_client"
 
 
+class RequestDelivery(str, Enum):
+    """Whether a failed HTTP request can have taken effect at the origin.
+
+    The distinction only matters for a **non-idempotent** write (the AE
+    submit): re-issuing one the origin already processed spawns a duplicate
+    run, so the client must know whether that is possible before retrying.
+
+    Two independent signals narrow the ambiguous case:
+
+    * the transport error's own shape. ``urllib`` could not tell a connect
+      timeout from a read timeout — both surfaced as a bare
+      :class:`TimeoutError` — which forced the submit path to treat every
+      network failure as ambiguous and give up after one attempt. ``httpx``
+      separates the connect phase from everything after it, giving
+      :attr:`NOT_DELIVERED`.
+    * a follow-up read of the origin's own state. A write whose effect is
+      externally observable can simply be looked up afterwards, giving
+      :attr:`NOT_APPLIED` when it is provably absent.
+    """
+
+    NOT_DELIVERED = "not_delivered"
+    """The connection was never established, so the request bytes never left
+    the client. The origin cannot have seen it — re-issuing is safe even for a
+    non-idempotent write."""
+
+    NOT_APPLIED = "not_applied"
+    """The request may well have reached the origin, but a follow-up read of
+    the origin's own state found no trace of its effect. Re-issuing is safe on
+    the strength of that read, not of the transport error."""
+
+    AMBIGUOUS = "ambiguous"
+    """The connection was established, the failure came later (read timeout,
+    reset mid-flight), and nothing has ruled out the origin having processed
+    it. Only an idempotent caller may re-issue."""
+
+
 @dataclass(kw_only=True)
 class AtlanApiTimeoutError(AppTimeoutError):
-    """No response received from the AE API before the timeout elapsed."""
+    """No response received from the AE API before the timeout elapsed.
+
+    ``delivery`` records whether the request can have reached the origin. It
+    defaults to :attr:`RequestDelivery.AMBIGUOUS` — the conservative value —
+    so any raise site that does not classify the failure keeps the old
+    never-repost behaviour for non-idempotent writes.
+    """
 
     code: ClassVar[str] = "TIMEOUT_ATLAN_API"
     operation: str | None = "native_status_poll"
+    delivery: RequestDelivery = RequestDelivery.AMBIGUOUS
 
 
 # ---------------------------------------------------------------------------

--- a/application_sdk/testing/e2e/base.py
+++ b/application_sdk/testing/e2e/base.py
@@ -1067,6 +1067,11 @@ class BaseE2ETest:
             progress_stall_seconds=self.dag_progress_stall_seconds,
         )
 
+        # Log-only, outcome-neutral. Placed after the poll so Elasticsearch
+        # indexing lag cannot masquerade as an absence. See
+        # probe_run_is_listed — this is what settles FND-676's gate.
+        self.client.probe_run_is_listed(slug, run_id)
+
         asset_counts: dict[str, int] = {}
         asset_qn_samples: dict[str, list[str]] = {}
         total_assets = 0

--- a/application_sdk/testing/e2e/base.py
+++ b/application_sdk/testing/e2e/base.py
@@ -1051,7 +1051,11 @@ class BaseE2ETest:
             self.mode.value,
             self.connection_qualified_name,
         )
-        run_id = self.client.submit_workflow(payload, **self._submit_retry_kwargs())
+        # slug= lets an ambiguous submit timeout be resolved by reading AE's own
+        # run list under this slug instead of failing the leg outright.
+        run_id = self.client.submit_workflow(
+            payload, slug=slug, **self._submit_retry_kwargs()
+        )
         logger.info("AE submit returned run_id=%s", run_id)
 
         ae_result = self.client.poll_native_status(

--- a/application_sdk/testing/e2e/client.py
+++ b/application_sdk/testing/e2e/client.py
@@ -840,7 +840,7 @@ class AEWorkflowClient:
             ),
             operation=path,
             delivery=delivery,
-        )
+        ) from last_exc
 
     # ------------------------------------------------------------------
     # Endpoints

--- a/application_sdk/testing/e2e/client.py
+++ b/application_sdk/testing/e2e/client.py
@@ -37,13 +37,14 @@ from __future__ import annotations
 import asyncio
 import math
 import time
-import urllib.error
-import urllib.request
 from collections.abc import Callable
 from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
 from enum import Enum
 from typing import TYPE_CHECKING, Any
+from urllib.parse import quote
 
+import httpx
 import orjson
 
 if TYPE_CHECKING:
@@ -60,13 +61,14 @@ from application_sdk.testing.e2e._errors import (
     DAGProgressStalledError,
     MissingHarnessClassAttrError,
     NoWorkerOnTaskQueueError,
+    RequestDelivery,
 )
 from application_sdk.testing.e2e._poll import _HEARTBEAT_SECONDS, until_deadline
 
 logger = get_logger(__name__)
 
 
-# Standard library urllib's default User-Agent (``Python-urllib/<ver>``)
+# A default client User-Agent (``Python-urllib/<ver>``, ``python-httpx/<ver>``)
 # is blocked by Cloudflare on most Atlan tenants (Error 1010 — browser
 # signature banned). Spoofing a real UA keeps the request flowing through.
 _USER_AGENT = "atlan-sdk-full-dag-e2e/1.0 (+https://github.com/atlanhq/application-sdk)"
@@ -78,7 +80,7 @@ _USER_AGENT = "atlan-sdk-full-dag-e2e/1.0 (+https://github.com/atlanhq/applicati
 _HTTP_TIMEOUT = 60
 # AE create and submit can take >60 s on the first call — the origin
 # server may be slow to respond, causing Cloudflare to return HTTP 504
-# at its own gateway timeout before urllib's 60 s window closes.  Using
+# at its own gateway timeout before a 60 s client window closes.  Using
 # 120 s lets Cloudflare's 504 arrive as an HTTP error (which the
 # existing 5xx retry loop handles) rather than a raw TimeoutError.
 _SUBMIT_TIMEOUT = 120
@@ -89,6 +91,53 @@ _SUBMIT_TIMEOUT = 120
 # 10-15 min poll doesn't fail the whole run.
 _REQUEST_MAX_ATTEMPTS = 4
 _REQUEST_BACKOFF_SECONDS = 3
+
+# Reconciling an ambiguous submit: how long to keep asking AE whether the run
+# it may or may not have accepted actually exists.
+#
+# AE persists the run record BEFORE it calls Temporal and before it answers the
+# submit, so any submit that got far enough to have an effect leaves a row we
+# can find. In production that row is read back through Elasticsearch, which is
+# near-real-time rather than real-time — a run committed microseconds before the
+# connection died can take a few seconds to become searchable. A single probe
+# would read that lag as "no run exists" and re-POST into a duplicate, so we
+# poll for a window instead. The window only ever elapses on a path that today
+# fails the whole leg outright, so it is sized for confidence, not for speed.
+_RECONCILE_TIMEOUT_SECONDS = 90
+_RECONCILE_INTERVAL_SECONDS = 10
+
+# How far before the submit to start looking for "our" run. Absorbs clock skew
+# between the CI runner and the tenant, whose timestamps we are comparing
+# directly. Safe to be generous: the workflow slug is unique per CI leg
+# (``<connector>-e2e-full-ci-<run_id>-<hash>``), so the only runs this window
+# can possibly match are the leg's own submits of the same payload.
+_RECONCILE_CLOCK_SKEW_SECONDS = 120
+
+# AE caps ``page_size`` at 100 and returns runs newest-first. One page is
+# ample: a single leg's unique slug has one run, or a small handful if an
+# earlier attempt in the same call already landed.
+_RECONCILE_PAGE_SIZE = 20
+
+# Whether "AE lists no run under this slug" may authorise re-POSTing an
+# ambiguous submit. Deliberately off.
+#
+# Reconciliation has two halves with very different risk profiles. *Adopting* a
+# run the read finds is pure upside: if the listing works we recover a leg that
+# would otherwise have failed, and if it doesn't we find nothing and behave
+# exactly as before. *Re-POSTing* because the read found nothing is only safe
+# if an empty list genuinely means "no run exists" — and that has not been
+# established end-to-end, because the harness submits through Heracles
+# (``/api/service/package-workflows``) rather than through AE's own
+# ``/api/v1/workflows/{slug}/submit``. AE's run listing filters out runs
+# lacking automation-engine fields, so a Heracles-originated run being invisible
+# here would turn every empty read into a false "nothing landed" and produce the
+# duplicate run this whole mechanism exists to prevent.
+#
+# Flip this on once a live e2e leg has shown a Heracles-submitted run appearing
+# under GET /automation/api/v1/runs?workflow_slug=<slug>. Until then the
+# absence half stays disabled and an unrecovered ambiguous submit fails exactly
+# as it did before. The machinery below is complete and tested either way.
+_RESUBMIT_WHEN_AE_REPORTS_NO_RUN = False
 
 # An overloaded tenant answers a retryable 5xx with its own estimate of how
 # long to wait before trying again:
@@ -242,6 +291,126 @@ def _retry_gap(
     wanted = math.ceil(requested)
     allowed = min(wanted, _MAX_RETRY_AFTER_SECONDS, max(budget_left, 0))
     return _RetryGap(seconds=max(default_seconds, allowed), requested=wanted)
+
+
+@dataclass(frozen=True)
+class RunLookup:
+    """What a read of AE's run list learned about a run we expected to exist.
+
+    Absence and ignorance are different answers and the caller acts on them
+    differently, so they are not both spelled ``None``.
+    """
+
+    run_id: str | None = None
+    """The matching run's id, when one was found."""
+
+    conclusive: bool = False
+    """True when AE actually answered. ``run_id=None, conclusive=True`` is
+    proof the run does not exist; ``conclusive=False`` means the read never
+    got through and nothing was established either way."""
+
+
+@dataclass(frozen=True)
+class WriteRecovery:
+    """What a follow-up read learned about a write whose response was lost.
+
+    Returned by :meth:`AEWorkflowClient._post_with_retry`'s
+    ``recover_ambiguous`` hook. The default — no body, not proven absent — is
+    the "learned nothing" case, which leaves the write as ambiguous as it was.
+    """
+
+    body: dict[str, Any] | None = None
+    """The response the origin would have sent, when the write is found to
+    have landed. Returned to the caller in place of the lost response."""
+
+    proven_absent: bool = False
+    """True only when the read positively established that the write left no
+    trace. This — not the mere absence of a body — is what licenses re-issuing
+    a non-idempotent write."""
+
+
+def _parse_run_timestamp(raw: object) -> datetime | None:
+    """Best-effort read of an AE ``created_at`` into an aware UTC datetime.
+
+    AE models the field as a ``datetime``, which FastAPI serialises to ISO-8601
+    — but this value decides whether we adopt a run or re-POST a
+    non-idempotent submit, so a shape this function fails to recognise must
+    read as "unknown" (``None``), never as "old enough" or "new enough".
+    Numeric forms are accepted too: the Atlan-mode registry populates the field
+    from a metastore entity whose create time is epoch milliseconds.
+    """
+    if isinstance(raw, bool):  # bool is an int; never a timestamp
+        return None
+    if isinstance(raw, int | float):
+        # Disambiguate by magnitude: anything past ~year 5138 in seconds is
+        # milliseconds. Both AE backends are well clear of that boundary.
+        seconds = raw / 1000 if raw > 1e11 else float(raw)
+        try:
+            return datetime.fromtimestamp(seconds, tz=UTC)
+        except (OverflowError, OSError, ValueError):
+            return None
+    if not isinstance(raw, str) or not raw:
+        return None
+    try:
+        parsed = datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+    # A naive timestamp is UTC by convention on both AE backends
+    # (``datetime.now(timezone.utc)`` server-side, epoch-derived in Atlan mode).
+    return parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=UTC)
+
+
+def _newest_run_since(body: dict[str, Any], floor: datetime) -> str | None:
+    """Run id of the newest run in *body* created at or after *floor*.
+
+    ``body`` is AE's ``BulkResponse[WorkflowRun]``: ``{"data": [...]}``, newest
+    first. A row whose ``created_at`` cannot be parsed is skipped rather than
+    assumed recent — adopting the wrong run would make the harness poll a run
+    that is not the one it submitted.
+    """
+    rows = body.get("data")
+    if not isinstance(rows, list):
+        return None
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        run_id = row.get("guid") or row.get("run_id")
+        if not isinstance(run_id, str) or not run_id:
+            continue
+        created = _parse_run_timestamp(row.get("created_at"))
+        if created is not None and created >= floor:
+            return run_id
+    return None
+
+
+def _classify_delivery(exc: Exception) -> RequestDelivery:
+    """Can the origin have seen the request that raised *exc*?
+
+    ``httpx`` separates the connect phase from everything after it, which
+    ``urllib`` collapsed into a bare ``TimeoutError``. A failure to *establish*
+    the connection proves the request bytes never left the client, so even a
+    non-idempotent write is safe to re-issue. Anything later — a read timeout,
+    a reset mid-flight, a protocol error — may already have been processed by
+    the origin.
+
+    Deliberately conservative: only the three exception types that cannot
+    coexist with a delivered request are classified
+    :attr:`RequestDelivery.NOT_DELIVERED`; everything else, including any
+    future ``httpx`` transport error this function has not been taught about,
+    falls through to :attr:`RequestDelivery.AMBIGUOUS` and keeps the old
+    never-repost behaviour.
+
+    * :class:`httpx.ConnectTimeout` — the TCP/TLS handshake never completed.
+      This is the shape a blackholed public-FQDN hairpin takes on the CI
+      runners, and the case this classification exists to recover.
+    * :class:`httpx.ConnectError` — DNS failure, connection refused, no route.
+    * :class:`httpx.PoolTimeout` — no connection was ever acquired from the
+      pool. Unreachable today (``_request`` builds a single-use client) but
+      classified for correctness rather than left to the ambiguous default.
+    """
+    if isinstance(exc, httpx.ConnectTimeout | httpx.ConnectError | httpx.PoolTimeout):
+        return RequestDelivery.NOT_DELIVERED
+    return RequestDelivery.AMBIGUOUS
 
 
 def _is_credential_name_conflict(status: int, body: dict[str, Any] | str) -> bool:
@@ -588,64 +757,74 @@ class AEWorkflowClient:
     ) -> tuple[int, dict[str, Any] | str]:
         """HTTP request returning ``(status_code, parsed_body_or_text)``.
 
-        ``retry_network_errors=False`` disables the network-layer retry: a
-        read-timeout on a non-idempotent write (submit) is ambiguous — the
-        server may already have processed it — so re-POSTing would spawn a
-        duplicate. Such callers surface the first timeout instead.
+        A 4xx/5xx is a real response, not a failure: it is returned to the
+        caller so the caller's status-based retry/handling applies. Only a
+        transport-layer failure (DNS blip, connect/read timeout, reset) is
+        retried here, and a sustained one surfaces as
+        :class:`AtlanApiTimeoutError` (an :class:`AppError`) so callers'
+        transient-tolerance — e.g. the poll loop — handles it instead of a raw
+        crash.
+
+        ``retry_network_errors=False`` disables that retry entirely: the caller
+        is a non-idempotent write (submit) whose re-POST decision belongs to
+        the single retry loop in :meth:`_post_with_retry`, not to a nested one
+        here. The raised error carries a
+        :class:`~application_sdk.testing.e2e._errors.RequestDelivery` telling
+        that loop whether the origin can have seen the request — which is what
+        makes a connect-phase failure safely retryable there.
         """
         url = f"{self.tenant_url}{path}"
-        data = orjson.dumps(body) if body is not None else None
-        req = urllib.request.Request(url, data=data, method=method)
-        req.add_header("Authorization", f"Bearer {self._api_token}")
-        req.add_header("Accept", "application/json")
-        req.add_header("User-Agent", _USER_AGENT)
+        content = orjson.dumps(body) if body is not None else None
+        headers = {
+            "Authorization": f"Bearer {self._api_token}",
+            "Accept": "application/json",
+            "User-Agent": _USER_AGENT,
+        }
         if body is not None:
-            req.add_header("Content-Type", "application/json")
+            headers["Content-Type"] = "application/json"
         last_exc: Exception | None = None
+        delivery = RequestDelivery.AMBIGUOUS
         for attempt in range(1, _REQUEST_MAX_ATTEMPTS + 1):
             try:
-                with urllib.request.urlopen(req, timeout=timeout) as resp:
-                    raw = resp.read()
-                    try:
-                        return resp.status, orjson.loads(raw)
-                    except orjson.JSONDecodeError:
-                        logger.warning(
-                            "Response body is not JSON; returning raw text",
-                            exc_info=True,
-                        )
-                        return resp.status, raw.decode(errors="replace")
-            except urllib.error.HTTPError as e:
-                # A real HTTP response (4xx/5xx), NOT a transient network error —
-                # return it so the caller's status-based retry/handling applies.
-                raw = e.read()
+                # A fresh client per call, matching the previous urllib
+                # behaviour of one connection per request: a pooled connection
+                # that is already half-dead would otherwise be reused across
+                # the retry, which is the exact condition we retry to escape.
+                # follow_redirects preserves urlopen's redirect handling, which
+                # httpx disables by default.
+                with httpx.Client(
+                    timeout=httpx.Timeout(timeout), follow_redirects=True
+                ) as http:
+                    resp = http.request(method, url, content=content, headers=headers)
+                raw = resp.content
                 try:
-                    return e.code, orjson.loads(raw)
+                    return resp.status_code, orjson.loads(raw)
                 except orjson.JSONDecodeError:
                     logger.warning(
-                        "HTTP error body is not JSON; returning raw text",
+                        "Response body is not JSON; returning raw text",
                         exc_info=True,
                     )
-                    return e.code, raw.decode(errors="replace")
-            except (urllib.error.URLError, TimeoutError, OSError) as e:
-                # Transient network-layer error (DNS blip / read timeout / conn
-                # reset) — common on multi-minute polls over a VPN/loft tunnel.
-                # Retry a few times; if it persists, surface as AtlanApiTimeoutError
-                # (an AppError) so callers' transient-tolerance (e.g. the poll loop)
-                # handles it instead of a raw crash. NOTE: HTTPError is a URLError
-                # subclass but is caught above, so it never reaches here.
+                    return resp.status_code, raw.decode(errors="replace")
+            except (httpx.TransportError, OSError) as e:
+                # Transport-layer error — common on multi-minute polls over a
+                # VPN/loft tunnel, and on CI runners whose node-local egress
+                # SNAT intermittently blackholes a public-FQDN hairpin.
                 last_exc = e
+                delivery = _classify_delivery(e)
                 if not retry_network_errors:
-                    # Non-idempotent caller (submit): do not re-issue — the
-                    # server may have accepted the first request. Surface it.
+                    # Non-idempotent caller (submit): never re-issue from here.
+                    # _post_with_retry owns that decision and now has the
+                    # delivery classification it needs to make it safely.
                     break
                 if attempt < _REQUEST_MAX_ATTEMPTS:
                     logger.warning(
-                        "transient network error on %s %s (attempt %d/%d): %s — "
-                        "retrying in %ds",
+                        "transient network error on %s %s (attempt %d/%d, "
+                        "delivery=%s): %s — retrying in %ds",
                         method,
                         path,
                         attempt,
                         _REQUEST_MAX_ATTEMPTS,
+                        delivery.value,
                         e,
                         _REQUEST_BACKOFF_SECONDS,
                         exc_info=True,
@@ -656,9 +835,11 @@ class AEWorkflowClient:
                 # `attempt` is the actual count made — 1 when retries are
                 # disabled (submit), up to _REQUEST_MAX_ATTEMPTS otherwise — so
                 # a submit timeout doesn't misreport 4 tries when it made 1.
-                f"{method} {path} failed after {attempt} attempt(s): {last_exc!r}"
+                f"{method} {path} failed after {attempt} attempt(s) "
+                f"[delivery={delivery.value}]: {last_exc!r}"
             ),
             operation=path,
+            delivery=delivery,
         )
 
     # ------------------------------------------------------------------
@@ -676,6 +857,7 @@ class AEWorkflowClient:
         op_name: str,
         mutate_before_retry: Callable[[dict[str, Any] | None], None] | None = None,
         retry_network_errors: bool = True,
+        recover_ambiguous: Callable[[], WriteRecovery] | None = None,
     ) -> tuple[int, dict[str, Any] | str]:
         """POST *path* with unified timeout + retry, returning ``(status, body)``.
 
@@ -703,10 +885,28 @@ class AEWorkflowClient:
                 before each retry (mutates it in place). Lets a caller make a
                 retry idempotent — e.g. rotate a non-idempotent credential name
                 so a re-sent submit can't collide on a unique constraint.
-            retry_network_errors: When False, a network timeout is never
-                re-POSTed (nor re-issued at the ``_request`` layer) — required
-                for non-idempotent writes like submit, where a retry after the
-                server already accepted the request spawns a duplicate run.
+            retry_network_errors: When False, an *ambiguous* network failure is
+                never re-POSTed (nor re-issued at the ``_request`` layer) —
+                required for non-idempotent writes like submit, where a retry
+                after the server already accepted the request spawns a
+                duplicate run. A failure classified
+                :attr:`~application_sdk.testing.e2e._errors.RequestDelivery.NOT_DELIVERED`
+                is re-POSTed regardless: the connection was never established,
+                so the origin provably never saw the request and no duplicate
+                is possible. Those re-POSTs are counted against the same
+                ``total_attempts`` budget as every other retry, keeping the
+                single-retry-loop invariant that
+                :func:`cold_start_submit_kwargs` depends on.
+            recover_ambiguous: Optional read of the origin's own state, called
+                when a network failure leaves it unknown whether the write took
+                effect. Return the response body the origin *would* have sent
+                if the write is found to have landed — it is returned to the
+                caller as a 200 and no retry happens. Return ``None`` if the
+                write provably left no trace, which reclassifies the failure as
+                :attr:`~application_sdk.testing.e2e._errors.RequestDelivery.NOT_APPLIED`
+                and makes a re-POST safe even for a non-idempotent write. Only
+                consulted for a genuinely ambiguous failure: a connect-phase
+                one needs no read, and an idempotent caller needs no proof.
         """
         last: tuple[int, dict[str, Any] | str] = (0, {})
         # Seconds spent waiting *beyond* the fixed gap because the origin asked
@@ -722,12 +922,48 @@ class AEWorkflowClient:
                     retry_network_errors=retry_network_errors,
                 )
             except (TimeoutError, OSError, AtlanApiTimeoutError) as exc:
-                if retry_network_errors and attempt < total_attempts:
+                # Only _request classifies delivery; a bare TimeoutError/OSError
+                # reaching here (a patched _request in tests, or a caller that
+                # raised before classification) keeps the conservative default.
+                delivery = (
+                    exc.delivery
+                    if isinstance(exc, AtlanApiTimeoutError)
+                    else RequestDelivery.AMBIGUOUS
+                )
+                if (
+                    delivery is RequestDelivery.AMBIGUOUS
+                    and recover_ambiguous is not None
+                ):
+                    # Ask the origin what actually happened rather than
+                    # guessing from the transport error.
+                    recovered = recover_ambiguous()
+                    if recovered.body is not None:
+                        logger.info(
+                            "%s attempt %d/%d: the connection died but the "
+                            "write had already landed — adopting the origin's "
+                            "own record instead of re-issuing",
+                            op_name,
+                            attempt,
+                            total_attempts,
+                        )
+                        return 200, recovered.body
+                    if recovered.proven_absent:
+                        delivery = RequestDelivery.NOT_APPLIED
+                # A request the origin never received, or never acted on, is
+                # safe to re-POST even when the caller forbids retrying
+                # genuinely ambiguous ones.
+                may_repost = retry_network_errors or delivery in (
+                    RequestDelivery.NOT_DELIVERED,
+                    RequestDelivery.NOT_APPLIED,
+                )
+                if may_repost and attempt < total_attempts:
                     logger.warning(
-                        "%s attempt %d/%d: timeout (%s) — retrying in %ds",
+                        "%s attempt %d/%d: timeout (delivery=%s) (%s) — "
+                        "retrying in %ds",
                         op_name,
                         attempt,
                         total_attempts,
+                        delivery.value,
                         exc,
                         sleep_seconds,
                         exc_info=True,
@@ -736,12 +972,27 @@ class AEWorkflowClient:
                         mutate_before_retry(body)
                     time.sleep(sleep_seconds)
                     continue
+                # Name why we stopped. "after 1 attempt(s)" on its own reads
+                # like broken retry logic; it is in fact the non-idempotency
+                # guard declining to re-issue a request the origin may have
+                # already processed.
+                halted = (
+                    " — not re-issued: this write is non-idempotent and the "
+                    "connection had already been established when it failed, "
+                    "so the origin may already have processed it"
+                    if not may_repost
+                    else ""
+                )
                 raise AtlanApiTimeoutError(
-                    # `attempt` is the actual count made — 1 when retries are
-                    # disabled (submit), up to total_attempts otherwise — so a
-                    # no-retry submit timeout doesn't misreport total_attempts.
-                    message=f"{op_name} timed out after {attempt} attempt(s)",
+                    # `attempt` is the actual count made — 1 when an ambiguous
+                    # failure halts a non-idempotent write, up to total_attempts
+                    # otherwise — so it doesn't misreport total_attempts.
+                    message=(
+                        f"{op_name} timed out after {attempt} attempt(s) "
+                        f"[delivery={delivery.value}]{halted}"
+                    ),
                     operation=path,
+                    delivery=delivery,
                 ) from exc
             last = (status, resp_body)
             is_retry = retryable(status, resp_body)
@@ -900,10 +1151,111 @@ class AEWorkflowClient:
             retry_after_seconds=_requested_retry_after(body),
         )
 
+    def find_run_created_since(
+        self,
+        slug: str,
+        since: datetime,
+        *,
+        timeout_seconds: int = _RECONCILE_TIMEOUT_SECONDS,
+        interval_seconds: int = _RECONCILE_INTERVAL_SECONDS,
+    ) -> RunLookup:
+        """Poll ``GET /automation/api/v1/runs`` for a run of *slug* created at or
+        after *since*.
+
+        This is how an ambiguous submit gets resolved: AE writes the run record
+        before it answers the submit, so asking AE what runs exist answers the
+        question the timeout left open — did the write take effect? A found run
+        is adopted (the DAG really is executing; only the response was lost),
+        and a genuinely absent one makes a re-POST safe.
+
+        Polls rather than probing once, because production AE serves this list
+        from Elasticsearch and a just-committed run needs a moment to become
+        searchable. Returns as soon as one appears.
+
+        Args:
+            slug: Workflow slug to look under. Unique per CI leg, which is what
+                makes "a run exists under this slug" mean "our run exists".
+            since: Wall-clock instant the submit was issued. Timezone-aware;
+                :data:`_RECONCILE_CLOCK_SKEW_SECONDS` is subtracted internally
+                to absorb runner-vs-tenant clock skew.
+            timeout_seconds: Total budget for the poll.
+            interval_seconds: Gap between polls.
+
+        Returns:
+            A :class:`RunLookup`. ``run_id`` is set when a matching run was
+            found. ``conclusive`` distinguishes the two ways of finding none:
+            AE answered and had no such run (proof of absence, safe to act on)
+            versus AE never answered at all (proves nothing).
+        """
+        floor = since - timedelta(seconds=_RECONCILE_CLOCK_SKEW_SECONDS)
+        # A read that errored proves nothing about whether the run exists. If
+        # the same network fault that killed the submit also kills every
+        # reconcile read, the answer must stay "unknown" — reporting it as
+        # "absent" would authorise the duplicate submit this exists to prevent.
+        answered = False
+        # include_test_runs / include_system both widen an otherwise
+        # default-filtered listing. Widening is free here: the slug already
+        # restricts the result set to this leg's own runs, so the only effect
+        # is that we cannot miss our run because of how AE classified it.
+        path = (
+            f"/automation/api/v1/runs?workflow_slug={quote(slug, safe='')}"
+            f"&page=0&page_size={_RECONCILE_PAGE_SIZE}"
+            "&include_test_runs=true&include_system=true"
+        )
+        for attempt in until_deadline(
+            timeout_seconds,
+            interval_seconds,
+            label=f"an AE run under slug '{slug}' created since {floor.isoformat()}",
+        ):
+            try:
+                status, body = self._request("GET", path)
+            except AppError:
+                # The reconcile read is itself best-effort: a tenant that
+                # cannot answer it leaves the submit exactly as ambiguous as
+                # before, which the caller already handles. Never let it
+                # replace the submit failure the operator needs to see.
+                logger.warning(
+                    "reconcile read failed for slug %s — treating this attempt "
+                    "as inconclusive",
+                    slug,
+                    exc_info=True,
+                )
+                continue
+            if status >= 300 or not isinstance(body, dict):
+                logger.warning(
+                    "reconcile read for slug %s returned HTTP %d — treating "
+                    "this attempt as inconclusive\nresponse=%r",
+                    slug,
+                    status,
+                    body,
+                )
+                continue
+            answered = True
+            run_id = _newest_run_since(body, floor)
+            if run_id is not None:
+                return RunLookup(run_id=run_id, conclusive=True)
+        if answered:
+            logger.warning(
+                "AE reports no run under slug %s created since %s across a "
+                "%ds window — the submit left no trace",
+                slug,
+                floor.isoformat(),
+                timeout_seconds,
+            )
+        else:
+            logger.warning(
+                "no reconcile read of slug %s succeeded within %ds — whether "
+                "the submit landed stays unknown",
+                slug,
+                timeout_seconds,
+            )
+        return RunLookup(conclusive=answered)
+
     def submit_workflow(
         self,
         payload: dict[str, Any],
         *,
+        slug: str = "",
         retries: int = 4,
         retry_sleep_seconds: int = 5,
     ) -> str:
@@ -921,10 +1273,26 @@ class AEWorkflowClient:
         re-issuing one AE already accepted spawns a duplicate run that AE marks
         ``Skipped`` and returns as a *fresh* run_id — so a blind retry makes the
         harness poll a phantom skipped run while the real one runs to
-        completion under a different id. Two guards prevent that:
+        completion under a different id. Three guards prevent that:
 
-        * ``retry_network_errors=False`` — a read-timeout is ambiguous (the
-          server may have accepted the submit), so we never re-POST on timeout.
+        * ``retry_network_errors=False`` — a failure *after* the connection was
+          established is ambiguous (the server may have accepted the submit),
+          so we never blindly re-POST on one. A connect-phase failure is
+          exempt: the request provably never reached AE, so
+          ``_post_with_retry`` re-POSTs it within the normal attempt budget.
+          See :func:`_classify_delivery`; this is what keeps a blackholed CI
+          hairpin from reding a whole e2e leg on the first packet loss.
+        * ``recover_ambiguous`` — when *slug* is known, an ambiguous failure is
+          resolved by asking AE what actually happened rather than guessing.
+          AE writes the run record before it answers the submit, so
+          :meth:`find_run_created_since` can see a run that was accepted even
+          though the response never arrived: that run is adopted, and the DAG
+          the harness goes on to poll is the real one. A submit called without
+          a *slug*, or one whose reconcile read cannot get through, keeps the
+          old fail-fast behaviour — the guard degrades to what it replaced
+          rather than to a duplicate. The converse move, re-POSTing *because*
+          AE reports no such run, is gated off pending live verification; see
+          :data:`_RESUBMIT_WHEN_AE_REPORTS_NO_RUN`.
         * the ``already active`` conflict (AE-WF-409-03, which Heracles masks
           as a 500 — see :func:`_is_already_active_run`) is treated as terminal,
           not a retryable 5xx, and surfaced as
@@ -942,8 +1310,36 @@ class AEWorkflowClient:
         that still reads as connection-refused is surfaced as
         :class:`AppNotReadyError` rather than an opaque
         :class:`AtlanApiHttpError`, so the failure names the cause. FND-402.
+
+        Args:
+            payload: The AE submit body.
+            slug: Workflow slug the payload submits against. Optional only for
+                backwards compatibility — supplying it is what enables the
+                reconcile-before-retry guard described above, so every caller
+                that has the slug should pass it.
+            retries: Retries on top of the initial attempt.
+            retry_sleep_seconds: Fixed gap between attempts.
         """
         started = time.monotonic()
+        # Wall clock, not the monotonic one above: this is compared against
+        # timestamps AE assigns, so it has to be on the same scale.
+        submitted_at = datetime.now(UTC)
+
+        def _recover_from_ae() -> WriteRecovery:
+            """Ask AE whether the submit whose response we lost took effect."""
+            lookup = self.find_run_created_since(slug, submitted_at)
+            if lookup.run_id is not None:
+                logger.warning(
+                    "submit_workflow: the response was lost but AE has run %s "
+                    "under slug %s — adopting it rather than re-submitting",
+                    lookup.run_id,
+                    slug,
+                )
+                return WriteRecovery(body={"run_id": lookup.run_id})
+            return WriteRecovery(
+                proven_absent=lookup.conclusive and _RESUBMIT_WHEN_AE_REPORTS_NO_RUN
+            )
+
         status, body = self._post_with_retry(
             "/api/service/package-workflows?submit=true",
             body=payload,
@@ -964,6 +1360,9 @@ class AEWorkflowClient:
             op_name="submit_workflow",
             mutate_before_retry=_rotate_submit_credential_name,
             retry_network_errors=False,
+            # Resolvable only when we know which slug to look under; without
+            # one, an ambiguous timeout stays terminal as it always was.
+            recover_ambiguous=_recover_from_ae if slug else None,
         )
         if _is_already_active_run(status, body):
             raise AtlanAEWorkflowAlreadyActiveError(

--- a/application_sdk/testing/e2e/client.py
+++ b/application_sdk/testing/e2e/client.py
@@ -1251,6 +1251,83 @@ class AEWorkflowClient:
             )
         return RunLookup(conclusive=answered)
 
+    def probe_run_is_listed(self, slug: str, run_id: str) -> bool | None:
+        """Log-only check that *run_id* is visible in AE's run listing for *slug*.
+
+        Exists to settle :data:`_RESUBMIT_WHEN_AE_REPORTS_NO_RUN` with evidence
+        instead of waiting for a rare failure to produce it. The reconcile read
+        only fires on an ambiguous submit timeout, so on its own it would tell
+        us nothing until the next such timeout — and only for that one leg.
+        This probe runs on the *success* path, where we already know the true
+        run id, and asks the one question the gate turns on: does a run
+        submitted through Heracles show up in a listing that filters on
+        automation-engine fields?
+
+        Call it after the DAG poll has finished, not right after the submit:
+        production AE serves the listing from Elasticsearch, and an immediate
+        probe would report a lag as an absence — the exact false negative the
+        gate exists to avoid, recorded as if it were the answer.
+
+        Never raises and never affects the run's outcome.
+
+        Returns:
+            ``True`` if AE listed the run, ``False`` if it answered without it,
+            ``None`` if the read did not get through (which settles nothing).
+        """
+        path = (
+            f"/automation/api/v1/runs?workflow_slug={quote(slug, safe='')}"
+            f"&page=0&page_size={_RECONCILE_PAGE_SIZE}"
+            "&include_test_runs=true&include_system=true"
+        )
+        try:
+            status, body = self._request("GET", path)
+        except AppError:
+            logger.warning(
+                "AE-listing probe for slug %s did not get through; whether a "
+                "Heracles-submitted run is listable stays unanswered",
+                slug,
+                exc_info=True,
+            )
+            return None
+        if status >= 300 or not isinstance(body, dict):
+            logger.warning(
+                "AE-listing probe for slug %s returned HTTP %d; whether a "
+                "Heracles-submitted run is listable stays unanswered\n"
+                "response=%r",
+                slug,
+                status,
+                body,
+            )
+            return None
+        rows = body.get("data")
+        listed = (
+            [r.get("guid") or r.get("run_id") for r in rows if isinstance(r, dict)]
+            if isinstance(rows, list)
+            else []
+        )
+        if run_id in listed:
+            logger.info(
+                "AE-listing probe: run %s IS listed under slug %s — a "
+                "Heracles-submitted run is discoverable via "
+                "GET /automation/api/v1/runs, so reconciliation can trust an "
+                "empty read as proof of absence (FND-676: this is the evidence "
+                "_RESUBMIT_WHEN_AE_REPORTS_NO_RUN waits on)",
+                run_id,
+                slug,
+            )
+            return True
+        logger.warning(
+            "AE-listing probe: run %s is NOT listed under slug %s (AE returned "
+            "%d run(s): %r) — reconciliation must NOT treat an empty read as "
+            "proof of absence; keep _RESUBMIT_WHEN_AE_REPORTS_NO_RUN off "
+            "(FND-676)",
+            run_id,
+            slug,
+            len(listed),
+            listed,
+        )
+        return False
+
     def submit_workflow(
         self,
         payload: dict[str, Any],

--- a/application_sdk/testing/full_dag/base.py
+++ b/application_sdk/testing/full_dag/base.py
@@ -757,6 +757,9 @@ class BaseFullDAGE2ETest:
         )
         run_id = self.client.submit_workflow(
             payload,
+            # Lets an ambiguous submit timeout be resolved by reading AE's own
+            # run list under this slug instead of failing the leg outright.
+            slug=slug,
             **cold_start_submit_kwargs(
                 self.app_ready_timeout_seconds,
                 self.app_ready_poll_interval_seconds,

--- a/application_sdk/testing/full_dag/base.py
+++ b/application_sdk/testing/full_dag/base.py
@@ -773,6 +773,11 @@ class BaseFullDAGE2ETest:
             timeout_seconds=self.ae_poll_timeout_seconds,
         )
 
+        # Log-only, outcome-neutral. Placed after the poll so Elasticsearch
+        # indexing lag cannot masquerade as an absence. See
+        # probe_run_is_listed — this is what settles FND-676's gate.
+        self.client.probe_run_is_listed(slug, run_id)
+
         # Only probe Atlas if every DAG node succeeded — extract feeds
         # publish, qi feeds lineage-app, lineage-app feeds lineage-
         # publish, so a partial-success DAG produces a partial-success

--- a/tests/unit/testing/e2e/test_base_e2e.py
+++ b/tests/unit/testing/e2e/test_base_e2e.py
@@ -965,4 +965,8 @@ class TestSubmitRetryKwargs:
         with pytest.raises(RuntimeError, match="stop after submit"):
             harness.run_full_dag()
         _, kwargs = harness.client.submit_workflow.call_args
-        assert kwargs == {"retries": 60, "retry_sleep_seconds": 5}
+        assert kwargs == {
+            "slug": "slug",
+            "retries": 60,
+            "retry_sleep_seconds": 5,
+        }

--- a/tests/unit/testing/e2e/test_client.py
+++ b/tests/unit/testing/e2e/test_client.py
@@ -7,10 +7,10 @@ transient_streak budget works correctly.
 
 from __future__ import annotations
 
-import io
-import urllib.error
+from datetime import UTC, datetime, timedelta
 from unittest.mock import patch
 
+import httpx
 import pytest
 
 from application_sdk.testing.e2e._errors import (
@@ -20,10 +20,12 @@ from application_sdk.testing.e2e._errors import (
     AtlanApiTimeoutError,
     DAGProgressStalledError,
     NoWorkerOnTaskQueueError,
+    RequestDelivery,
 )
 from application_sdk.testing.e2e._poll import fake_clock
 from application_sdk.testing.e2e.client import (
     _MAX_RETRY_AFTER_SECONDS,
+    _RECONCILE_CLOCK_SKEW_SECONDS,
     _REQUEST_MAX_ATTEMPTS,
     _RETRY_AFTER_BUDGET_SECONDS,
     AEWorkflowClient,
@@ -31,9 +33,13 @@ from application_sdk.testing.e2e.client import (
     DAGNodeStatus,
     DAGRunResult,
     DAGRunStatus,
+    RunLookup,
+    _classify_delivery,
     _is_already_active_run,
     _is_app_not_ready,
     _is_credential_name_conflict,
+    _newest_run_since,
+    _parse_run_timestamp,
     _requested_retry_after,
     _retry_gap,
     _rotate_submit_credential_name,
@@ -818,36 +824,72 @@ class TestPollNativeStatusHonoursRetryAfter:
         ]
 
 
-class _FakeResponse:
-    """Minimal urlopen() return value usable as a context manager."""
+def _patch_transport(*results: httpx.Response | Exception):
+    """Patch the one httpx call ``_request`` makes, per attempt.
 
-    def __init__(self, status: int, raw: bytes):
-        self.status = status
-        self._raw = raw
+    ``_request`` builds a single-use ``httpx.Client`` per attempt, so patching
+    ``Client.request`` covers every attempt from one place. Pass one entry per
+    expected attempt: a ``Response`` to answer with, or an exception to raise.
+    A single entry is repeated for every attempt.
+    """
+    if len(results) == 1:
+        only = results[0]
+        # A lone Response goes through return_value, not side_effect: an
+        # httpx.Response is itself iterable (byte streaming), so mock would
+        # consume it as a sequence of per-attempt results.
+        kwargs = (
+            {"side_effect": only}
+            if isinstance(only, Exception)
+            else {"return_value": only}
+        )
+    else:
+        kwargs = {"side_effect": list(results)}
+    return patch.object(httpx.Client, "request", autospec=True, **kwargs)
 
-    def __enter__(self):
-        return self
 
-    def __exit__(self, *exc):
-        return False
+def _response(status: int, raw: bytes) -> httpx.Response:
+    return httpx.Response(status_code=status, content=raw)
 
-    def read(self) -> bytes:
-        return self._raw
+
+class TestClassifyDelivery:
+    """Only a connect-phase failure proves the origin never saw the request."""
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            httpx.ConnectTimeout("handshake never completed"),
+            httpx.ConnectError("name resolution failed"),
+            httpx.PoolTimeout("no connection acquired"),
+        ],
+    )
+    def test_connect_phase_is_not_delivered(self, exc):
+        assert _classify_delivery(exc) is RequestDelivery.NOT_DELIVERED
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            httpx.ReadTimeout("the read operation timed out"),
+            httpx.WriteTimeout("write timed out"),
+            httpx.RemoteProtocolError("server disconnected"),
+            httpx.ReadError("connection reset"),
+            OSError("something else entirely"),
+        ],
+    )
+    def test_everything_after_the_handshake_is_ambiguous(self, exc):
+        assert _classify_delivery(exc) is RequestDelivery.AMBIGUOUS
 
 
 class TestRequestNetworkRetry:
     """_request: transient network errors retry; sustained ones surface as
     AtlanApiTimeoutError (an AppError) so the poll loop tolerates them instead
-    of crashing on a raw URLError/TimeoutError mid-poll."""
+    of crashing on a raw transport error mid-poll."""
 
     def test_retries_transient_then_succeeds(self):
-        """URLError on attempt 1 → succeeds on attempt 2."""
+        """A transport error on attempt 1 → succeeds on attempt 2."""
         client = _make_client()
-        ok = _FakeResponse(200, b'{"ok": true}')
         with (
-            patch(
-                "application_sdk.testing.e2e.client.urllib.request.urlopen",
-                side_effect=[urllib.error.URLError("dns blip"), ok],
+            _patch_transport(
+                httpx.ConnectError("dns blip"), _response(200, b'{"ok": true}')
             ),
             patch("time.sleep"),
         ):
@@ -856,41 +898,56 @@ class TestRequestNetworkRetry:
         assert body == {"ok": True}
 
     def test_sustained_network_error_raises_atlan_timeout(self):
-        """URLError on every attempt → AtlanApiTimeoutError after max attempts."""
+        """A transport error on every attempt → AtlanApiTimeoutError."""
         client = _make_client()
         with (
-            patch(
-                "application_sdk.testing.e2e.client.urllib.request.urlopen",
-                side_effect=urllib.error.URLError("name resolution"),
-            ) as mock_open,
+            _patch_transport(httpx.ConnectError("name resolution")) as mock_req,
             patch("time.sleep"),
             pytest.raises(AtlanApiTimeoutError),
         ):
             client._request("GET", "/native-status")
-        assert mock_open.call_count == _REQUEST_MAX_ATTEMPTS
+        assert mock_req.call_count == _REQUEST_MAX_ATTEMPTS
 
-    def test_httperror_returns_immediately_without_retry(self):
+    def test_5xx_returns_immediately_without_retry(self):
         """A real 5xx HTTP response is returned, not retried as a network error."""
         client = _make_client()
-        http_err = urllib.error.HTTPError(
-            url="https://tenant.example.com/native-status",
-            code=500,
-            msg="server error",
-            hdrs=None,
-            fp=io.BytesIO(b'{"err": "boom"}'),
-        )
         with (
-            patch(
-                "application_sdk.testing.e2e.client.urllib.request.urlopen",
-                side_effect=http_err,
-            ) as mock_open,
+            _patch_transport(_response(500, b'{"err": "boom"}')) as mock_req,
             patch("time.sleep") as mock_sleep,
         ):
             status, body = client._request("GET", "/native-status")
         assert status == 500
         assert body == {"err": "boom"}
-        assert mock_open.call_count == 1
+        assert mock_req.call_count == 1
         mock_sleep.assert_not_called()
+
+    def test_non_json_body_returns_raw_text(self):
+        """A 2xx that isn't JSON degrades to text rather than crashing."""
+        client = _make_client()
+        with _patch_transport(_response(200, b"<html>gateway</html>")):
+            status, body = client._request("GET", "/native-status")
+        assert status == 200
+        assert body == "<html>gateway</html>"
+
+    def test_error_carries_the_delivery_classification(self):
+        """The raised error records whether the origin can have seen the
+        request — _post_with_retry's re-POST decision reads this."""
+        client = _make_client()
+        with (
+            _patch_transport(httpx.ReadTimeout("read timed out")),
+            patch("time.sleep"),
+            pytest.raises(AtlanApiTimeoutError) as excinfo,
+        ):
+            client._request("GET", "/native-status")
+        assert excinfo.value.delivery is RequestDelivery.AMBIGUOUS
+
+        with (
+            _patch_transport(httpx.ConnectTimeout("handshake never completed")),
+            patch("time.sleep"),
+            pytest.raises(AtlanApiTimeoutError) as excinfo,
+        ):
+            client._request("GET", "/native-status")
+        assert excinfo.value.delivery is RequestDelivery.NOT_DELIVERED
 
 
 class TestCredentialConflictHelpers:
@@ -1168,10 +1225,28 @@ class TestSubmitWorkflowIdempotency:
         assert mock_req.call_count == 1
         mock_sleep.assert_not_called()
 
-    def test_network_timeout_is_not_reposted(self):
-        """A read-timeout on submit is ambiguous (server may have accepted it),
-        so submit_workflow must surface it without re-POSTing — and report the
-        one attempt actually made, not total_attempts."""
+    def test_ambiguous_network_timeout_is_not_reposted(self):
+        """A read-timeout on submit is ambiguous (AE may have accepted it), so
+        submit_workflow must surface it without re-POSTing — reporting the one
+        attempt actually made, not total_attempts, and naming why it stopped."""
+        client = _make_client()
+        ambiguous = AtlanApiTimeoutError(
+            message="read timed out",
+            operation="/submit",
+            delivery=RequestDelivery.AMBIGUOUS,
+        )
+        with (
+            patch.object(client, "_request", side_effect=ambiguous) as mock_req,
+            patch("time.sleep"),
+            pytest.raises(AtlanApiTimeoutError, match=r"after 1 attempt") as excinfo,
+        ):
+            client.submit_workflow({"any": "payload"})
+        assert mock_req.call_count == 1
+        assert "not re-issued" in str(excinfo.value)
+
+    def test_unclassified_timeout_is_treated_as_ambiguous(self):
+        """A bare TimeoutError carries no delivery classification, so the
+        conservative default applies and submit still refuses to re-POST."""
         client = _make_client()
         with (
             patch.object(
@@ -1183,20 +1258,70 @@ class TestSubmitWorkflowIdempotency:
             client.submit_workflow({"any": "payload"})
         assert mock_req.call_count == 1
 
+    def test_connect_failure_is_reposted_within_the_budget(self):
+        """A connect-phase failure never reached AE, so submit re-POSTs it
+        despite being non-idempotent — and recovers when the next one lands.
+        This is the blackholed-CI-hairpin case that used to red a whole leg."""
+        client = _make_client()
+        never_sent = AtlanApiTimeoutError(
+            message="handshake never completed",
+            operation="/submit",
+            delivery=RequestDelivery.NOT_DELIVERED,
+        )
+        with (
+            patch.object(
+                client, "_request", side_effect=[never_sent, (200, {"run_id": "r-2"})]
+            ) as mock_req,
+            patch("time.sleep"),
+        ):
+            assert client.submit_workflow({"any": "payload"}) == "r-2"
+        assert mock_req.call_count == 2
+
+    def test_sustained_connect_failure_exhausts_the_budget_then_raises(self):
+        """Re-POSTing a never-delivered submit is bounded by the caller's
+        attempt budget, not unbounded — and the raise reports the real count."""
+        client = _make_client()
+        never_sent = AtlanApiTimeoutError(
+            message="handshake never completed",
+            operation="/submit",
+            delivery=RequestDelivery.NOT_DELIVERED,
+        )
+        with (
+            patch.object(client, "_request", side_effect=never_sent) as mock_req,
+            patch("time.sleep"),
+            pytest.raises(AtlanApiTimeoutError, match=r"after 3 attempt") as excinfo,
+        ):
+            client.submit_workflow({"any": "payload"}, retries=2)
+        assert mock_req.call_count == 3
+        # It exhausted the budget rather than declining to re-issue.
+        assert "not re-issued" not in str(excinfo.value)
+
     def test_request_no_repost_on_timeout_when_disabled(self):
         """_request(retry_network_errors=False) issues exactly one POST on a
-        TimeoutError instead of the usual _REQUEST_MAX_ATTEMPTS."""
+        transport error instead of the usual _REQUEST_MAX_ATTEMPTS — the
+        re-POST decision belongs to _post_with_retry, not to a nested loop."""
         client = _make_client()
         with (
-            patch(
-                "application_sdk.testing.e2e.client.urllib.request.urlopen",
-                side_effect=TimeoutError("read timed out"),
-            ) as mock_open,
+            _patch_transport(httpx.ReadTimeout("read timed out")) as mock_req,
             patch("time.sleep"),
             pytest.raises(AtlanApiTimeoutError),
         ):
             client._request("POST", "/submit", body={}, retry_network_errors=False)
-        assert mock_open.call_count == 1
+        assert mock_req.call_count == 1
+
+    def test_request_no_repost_even_when_never_delivered(self):
+        """Same for a connect failure: _request still makes exactly one call.
+        Re-POSTing it is safe, but doing so HERE would nest inside
+        _post_with_retry's loop and blow the cold-start attempt budget."""
+        client = _make_client()
+        with (
+            _patch_transport(httpx.ConnectTimeout("no handshake")) as mock_req,
+            patch("time.sleep"),
+            pytest.raises(AtlanApiTimeoutError) as excinfo,
+        ):
+            client._request("POST", "/submit", body={}, retry_network_errors=False)
+        assert mock_req.call_count == 1
+        assert excinfo.value.delivery is RequestDelivery.NOT_DELIVERED
 
     def test_genuine_5xx_still_retries_then_succeeds(self):
         """A real 5xx that is NOT the already-active conflict remains retryable,
@@ -1218,3 +1343,326 @@ class TestSubmitWorkflowIdempotency:
         client = _make_client()
         with patch.object(client, "_request", return_value=(200, {"run_id": "r-1"})):
             assert client.submit_workflow({"any": "payload"}) == "r-1"
+
+
+class TestParseRunTimestamp:
+    """created_at decides adopt-vs-resubmit, so an unrecognised shape must read
+    as unknown rather than as a plausible-looking instant."""
+
+    def test_iso_with_offset(self):
+        parsed = _parse_run_timestamp("2026-08-20T13:58:39.123456+00:00")
+        assert parsed == datetime(2026, 8, 20, 13, 58, 39, 123456, tzinfo=UTC)
+
+    def test_iso_with_zulu_suffix(self):
+        parsed = _parse_run_timestamp("2026-08-20T13:58:39Z")
+        assert parsed == datetime(2026, 8, 20, 13, 58, 39, tzinfo=UTC)
+
+    def test_naive_iso_is_read_as_utc(self):
+        """Both AE backends stamp UTC; a naive value is not local time."""
+        parsed = _parse_run_timestamp("2026-08-20T13:58:39")
+        assert parsed == datetime(2026, 8, 20, 13, 58, 39, tzinfo=UTC)
+
+    def test_epoch_milliseconds(self):
+        """The Atlan-mode registry derives created_at from a metastore entity
+        create time, which is epoch milliseconds."""
+        assert _parse_run_timestamp(1787234319000) == datetime(
+            2026, 8, 20, 13, 58, 39, tzinfo=UTC
+        )
+
+    def test_epoch_seconds(self):
+        assert _parse_run_timestamp(1787234319) == datetime(
+            2026, 8, 20, 13, 58, 39, tzinfo=UTC
+        )
+
+    @pytest.mark.parametrize(
+        "raw", [None, "", "not-a-date", True, False, {"nested": 1}, []]
+    )
+    def test_unrecognised_shapes_are_unknown_not_guessed(self, raw):
+        assert _parse_run_timestamp(raw) is None
+
+
+class TestNewestRunSince:
+    """Picking our run out of AE's BulkResponse[WorkflowRun]."""
+
+    _FLOOR = datetime(2026, 8, 20, 13, 0, 0, tzinfo=UTC)
+
+    def test_returns_the_first_run_at_or_after_the_floor(self):
+        body = {
+            "data": [
+                {"guid": "newer", "created_at": "2026-08-20T14:00:00Z"},
+                {"guid": "older", "created_at": "2026-08-20T12:00:00Z"},
+            ]
+        }
+        assert _newest_run_since(body, self._FLOOR) == "newer"
+
+    def test_ignores_runs_created_before_the_floor(self):
+        body = {"data": [{"guid": "older", "created_at": "2026-08-20T12:00:00Z"}]}
+        assert _newest_run_since(body, self._FLOOR) is None
+
+    def test_floor_is_inclusive(self):
+        body = {"data": [{"guid": "exact", "created_at": "2026-08-20T13:00:00Z"}]}
+        assert _newest_run_since(body, self._FLOOR) == "exact"
+
+    def test_skips_rows_whose_timestamp_cannot_be_parsed(self):
+        """An unparseable row must not be adopted on optimism — the harness
+        would then poll a run it never submitted."""
+        body = {
+            "data": [
+                {"guid": "unparseable", "created_at": "???"},
+                {"guid": "good", "created_at": "2026-08-20T14:00:00Z"},
+            ]
+        }
+        assert _newest_run_since(body, self._FLOOR) == "good"
+
+    def test_accepts_run_id_as_well_as_guid(self):
+        body = {"data": [{"run_id": "r-1", "created_at": "2026-08-20T14:00:00Z"}]}
+        assert _newest_run_since(body, self._FLOOR) == "r-1"
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            {},
+            {"data": None},
+            {"data": []},
+            {"data": "not a list"},
+            {"data": [None, 7, "x"]},
+            {"data": [{"created_at": "2026-08-20T14:00:00Z"}]},  # no id
+            {"data": [{"guid": "", "created_at": "2026-08-20T14:00:00Z"}]},
+        ],
+    )
+    def test_malformed_bodies_yield_nothing(self, body):
+        assert _newest_run_since(body, self._FLOOR) is None
+
+
+class TestFindRunCreatedSince:
+    """The reconcile read: found / proven-absent / never-answered."""
+
+    _SINCE = datetime(2026, 8, 20, 13, 58, 45, tzinfo=UTC)
+
+    def test_found_run_is_conclusive(self):
+        client = _make_client()
+        body = {"data": [{"guid": "r-real", "created_at": "2026-08-20T13:58:46Z"}]}
+        with patch.object(client, "_request", return_value=(200, body)):
+            lookup = client.find_run_created_since("slug-x", self._SINCE)
+        assert lookup == RunLookup(run_id="r-real", conclusive=True)
+
+    def test_queries_ae_under_the_slug(self):
+        client = _make_client()
+        with patch.object(
+            client, "_request", return_value=(200, {"data": []})
+        ) as mock_req:
+            client.find_run_created_since(
+                "slug/with space", self._SINCE, timeout_seconds=0
+            )
+        _, path = mock_req.call_args[0]
+        assert path.startswith("/automation/api/v1/runs?")
+        assert "workflow_slug=slug%2Fwith%20space" in path
+        # Widened so AE's own default filters cannot hide our run.
+        assert "include_test_runs=true" in path
+        assert "include_system=true" in path
+
+    def test_empty_answer_is_proof_of_absence(self):
+        client = _make_client()
+        with patch.object(client, "_request", return_value=(200, {"data": []})):
+            lookup = client.find_run_created_since(
+                "slug-x", self._SINCE, timeout_seconds=0
+            )
+        assert lookup == RunLookup(run_id=None, conclusive=True)
+
+    def test_unanswered_read_proves_nothing(self):
+        """If the fault that killed the submit also kills every reconcile read,
+        the answer must stay unknown — never 'absent', which would authorise
+        the duplicate submit this whole mechanism exists to prevent."""
+        client = _make_client()
+        with patch.object(
+            client, "_request", side_effect=AtlanApiTimeoutError(message="blackholed")
+        ):
+            lookup = client.find_run_created_since(
+                "slug-x", self._SINCE, timeout_seconds=0
+            )
+        assert lookup == RunLookup(run_id=None, conclusive=False)
+
+    def test_non_2xx_read_proves_nothing(self):
+        client = _make_client()
+        with patch.object(client, "_request", return_value=(503, {"err": "down"})):
+            lookup = client.find_run_created_since(
+                "slug-x", self._SINCE, timeout_seconds=0
+            )
+        assert lookup.conclusive is False
+
+    def test_polls_until_the_run_becomes_searchable(self):
+        """AE serves this list from Elasticsearch, so a run committed just
+        before the connection died can take a moment to appear. One empty
+        answer is not the end of the search."""
+        client = _make_client()
+        late = {"data": [{"guid": "r-late", "created_at": "2026-08-20T13:58:46Z"}]}
+        with (
+            patch.object(
+                client,
+                "_request",
+                side_effect=[(200, {"data": []}), (200, {"data": []}), (200, late)],
+            ) as mock_req,
+            patch("time.sleep"),
+        ):
+            lookup = client.find_run_created_since(
+                "slug-x", self._SINCE, timeout_seconds=60, interval_seconds=10
+            )
+        assert lookup.run_id == "r-late"
+        assert mock_req.call_count == 3
+
+    def test_clock_skew_window_admits_a_slightly_earlier_run(self):
+        """The runner's clock and the tenant's are compared directly, so a run
+        AE stamped just before our own 'now' is still ours."""
+        client = _make_client()
+        skewed = self._SINCE - timedelta(seconds=_RECONCILE_CLOCK_SKEW_SECONDS // 2)
+        body = {"data": [{"guid": "r-skewed", "created_at": skewed.isoformat()}]}
+        with patch.object(client, "_request", return_value=(200, body)):
+            lookup = client.find_run_created_since("slug-x", self._SINCE)
+        assert lookup.run_id == "r-skewed"
+
+    def test_run_older_than_the_skew_window_is_not_adopted(self):
+        client = _make_client()
+        stale = self._SINCE - timedelta(seconds=_RECONCILE_CLOCK_SKEW_SECONDS + 60)
+        body = {"data": [{"guid": "r-stale", "created_at": stale.isoformat()}]}
+        with patch.object(client, "_request", return_value=(200, body)):
+            lookup = client.find_run_created_since(
+                "slug-x", self._SINCE, timeout_seconds=0
+            )
+        assert lookup == RunLookup(run_id=None, conclusive=True)
+
+
+class TestSubmitReconciliation:
+    """submit_workflow resolves an ambiguous timeout by asking AE what happened
+    rather than guessing from the transport error."""
+
+    @staticmethod
+    def _ambiguous() -> AtlanApiTimeoutError:
+        return AtlanApiTimeoutError(
+            message="read timed out",
+            operation="/submit",
+            delivery=RequestDelivery.AMBIGUOUS,
+        )
+
+    def test_adopts_the_run_ae_already_created(self):
+        """The submit landed and only the response was lost: the DAG is really
+        running, so return its id instead of failing the leg."""
+        client = _make_client()
+        with (
+            patch.object(client, "_request", side_effect=self._ambiguous()),
+            patch.object(
+                client,
+                "find_run_created_since",
+                return_value=RunLookup(run_id="r-adopted", conclusive=True),
+            ) as mock_find,
+            patch("time.sleep"),
+        ):
+            assert client.submit_workflow({"any": "p"}, slug="slug-x") == "r-adopted"
+        assert mock_find.call_args[0][0] == "slug-x"
+
+    def test_does_not_resubmit_after_adopting(self):
+        client = _make_client()
+        with (
+            patch.object(client, "_request", side_effect=self._ambiguous()) as mock_req,
+            patch.object(
+                client,
+                "find_run_created_since",
+                return_value=RunLookup(run_id="r-adopted", conclusive=True),
+            ),
+            patch("time.sleep"),
+        ):
+            client.submit_workflow({"any": "p"}, slug="slug-x", retries=4)
+        assert mock_req.call_count == 1
+
+    def test_resubmits_when_ae_proves_nothing_landed(self):
+        """Enabled form of the absence half. Gated off by default until a live
+        leg confirms Heracles-submitted runs show up in AE's listing, so the
+        gate is patched on here rather than the test asserting today's default."""
+        client = _make_client()
+        with (
+            patch.object(
+                client,
+                "_request",
+                side_effect=[self._ambiguous(), (200, {"run_id": "r-2"})],
+            ) as mock_req,
+            patch.object(
+                client,
+                "find_run_created_since",
+                return_value=RunLookup(run_id=None, conclusive=True),
+            ),
+            patch(
+                "application_sdk.testing.e2e.client."
+                "_RESUBMIT_WHEN_AE_REPORTS_NO_RUN",
+                True,
+            ),
+            patch("time.sleep"),
+        ):
+            assert client.submit_workflow({"any": "p"}, slug="slug-x") == "r-2"
+        assert mock_req.call_count == 2
+
+    def test_absence_does_not_resubmit_while_the_gate_is_off(self):
+        """Default posture: an unrecovered ambiguous submit fails exactly as it
+        did before reconciliation existed. Adopting is the only enabled half."""
+        client = _make_client()
+        with (
+            patch.object(client, "_request", side_effect=self._ambiguous()) as mock_req,
+            patch.object(
+                client,
+                "find_run_created_since",
+                return_value=RunLookup(run_id=None, conclusive=True),
+            ),
+            patch("time.sleep"),
+            pytest.raises(AtlanApiTimeoutError, match=r"after 1 attempt"),
+        ):
+            client.submit_workflow({"any": "p"}, slug="slug-x")
+        assert mock_req.call_count == 1
+
+    def test_inconclusive_reconcile_still_fails_fast(self):
+        """Unknown is not absent. With no proof either way the old never-repost
+        behaviour stands, rather than risking a duplicate run."""
+        client = _make_client()
+        with (
+            patch.object(client, "_request", side_effect=self._ambiguous()) as mock_req,
+            patch.object(
+                client,
+                "find_run_created_since",
+                return_value=RunLookup(run_id=None, conclusive=False),
+            ),
+            patch("time.sleep"),
+            pytest.raises(AtlanApiTimeoutError, match=r"after 1 attempt") as excinfo,
+        ):
+            client.submit_workflow({"any": "p"}, slug="slug-x")
+        assert mock_req.call_count == 1
+        assert "not re-issued" in str(excinfo.value)
+
+    def test_no_slug_means_no_reconcile(self):
+        """A caller that cannot name the slug keeps the pre-existing fail-fast
+        contract — the guard degrades, it does not guess."""
+        client = _make_client()
+        with (
+            patch.object(client, "_request", side_effect=self._ambiguous()) as mock_req,
+            patch.object(client, "find_run_created_since") as mock_find,
+            patch("time.sleep"),
+            pytest.raises(AtlanApiTimeoutError),
+        ):
+            client.submit_workflow({"any": "p"})
+        assert mock_req.call_count == 1
+        mock_find.assert_not_called()
+
+    def test_connect_failure_skips_the_reconcile_read(self):
+        """A never-delivered request needs no proof: re-POST straight away
+        instead of spending the reconcile window on a settled question."""
+        client = _make_client()
+        never_sent = AtlanApiTimeoutError(
+            message="handshake never completed",
+            operation="/submit",
+            delivery=RequestDelivery.NOT_DELIVERED,
+        )
+        with (
+            patch.object(
+                client, "_request", side_effect=[never_sent, (200, {"run_id": "r-3"})]
+            ),
+            patch.object(client, "find_run_created_since") as mock_find,
+            patch("time.sleep"),
+        ):
+            assert client.submit_workflow({"any": "p"}, slug="slug-x") == "r-3"
+        mock_find.assert_not_called()

--- a/tests/unit/testing/e2e/test_client.py
+++ b/tests/unit/testing/e2e/test_client.py
@@ -1531,6 +1531,45 @@ class TestFindRunCreatedSince:
         assert lookup == RunLookup(run_id=None, conclusive=True)
 
 
+class TestProbeRunIsListed:
+    """The success-path probe that settles _RESUBMIT_WHEN_AE_REPORTS_NO_RUN.
+
+    Its whole value is that a wrong answer is worse than no answer, so
+    'listed', 'answered but absent' and 'never answered' stay three outcomes.
+    """
+
+    def test_listed_run_returns_true(self):
+        body = {"data": [{"guid": "r-1"}, {"guid": "r-0"}]}
+        client = _make_client()
+        with patch.object(client, "_request", return_value=(200, body)):
+            assert client.probe_run_is_listed("slug-x", "r-1") is True
+
+    def test_answered_without_the_run_returns_false(self):
+        client = _make_client()
+        with patch.object(client, "_request", return_value=(200, {"data": []})):
+            assert client.probe_run_is_listed("slug-x", "r-1") is False
+
+    def test_unanswered_read_returns_none_not_false(self):
+        """A read that never got through settles nothing — reporting it as
+        'absent' would be recorded as evidence for flipping the gate."""
+        client = _make_client()
+        with patch.object(
+            client, "_request", side_effect=AtlanApiTimeoutError(message="blackholed")
+        ):
+            assert client.probe_run_is_listed("slug-x", "r-1") is None
+
+    def test_non_2xx_returns_none(self):
+        client = _make_client()
+        with patch.object(client, "_request", return_value=(503, {"err": "down"})):
+            assert client.probe_run_is_listed("slug-x", "r-1") is None
+
+    def test_never_raises_into_the_leg(self):
+        """Outcome-neutral: a broken probe must not fail a passing e2e run."""
+        client = _make_client()
+        with patch.object(client, "_request", return_value=(200, {"data": "junk"})):
+            assert client.probe_run_is_listed("slug-x", "r-1") is False
+
+
 class TestSubmitReconciliation:
     """submit_workflow resolves an ambiguous timeout by asking AE what happened
     rather than guessing from the transport error."""

--- a/tests/unit/testing/full_dag/test_base.py
+++ b/tests/unit/testing/full_dag/test_base.py
@@ -546,12 +546,17 @@ class TestFullDAGColdStartBudget:
         with pytest.raises(RuntimeError, match="stop after submit"):
             harness.run_full_dag()
         _, kwargs = harness.client.submit_workflow.call_args
-        assert kwargs == {"retries": 60, "retry_sleep_seconds": 5}
+        assert kwargs == {
+            "slug": "slug",
+            "retries": 60,
+            "retry_sleep_seconds": 5,
+        }
 
     def test_zero_budget_defers_to_submit_workflow_defaults(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """0 passes no overrides at all, matching BaseE2ETest."""
+        """0 passes no budget overrides at all, matching BaseE2ETest. The slug
+        is threaded regardless — it is not part of the cold-start budget."""
         _bootstrap_env(monkeypatch)
         cls = _make_test()
         cls.app_ready_timeout_seconds = 0
@@ -569,4 +574,4 @@ class TestFullDAGColdStartBudget:
         with pytest.raises(RuntimeError, match="stop after submit"):
             harness.run_full_dag()
         _, kwargs = harness.client.submit_workflow.call_args
-        assert kwargs == {}
+        assert kwargs == {"slug": "slug"}


### PR DESCRIPTION
Closes FND-676.

## The failure

An e2e leg reds like this, and the message reads like the retry logic is broken:

```
AtlanApiTimeoutError: POST /api/service/package-workflows?submit=true
failed after 1 attempt(s): TimeoutError('The read operation timed out')
AtlanApiTimeoutError: submit_workflow timed out after 1 attempt(s)
```

The single attempt was deliberate. The AE submit is non-idempotent: re-POSTing one AE already accepted spawns a duplicate run that AE marks `Skipped` and returns under a *fresh* run_id, so the harness ends up polling a phantom while the real run finishes elsewhere. With no way to tell whether AE had seen the request, giving up was the only safe move.

Every other write on the same leg recovered fine — `publish_version` succeeded on attempt 2/5 in the same log. Only the submit had to fail closed.

## What changes

Two narrower questions replace the blanket "we can't know".

### Did the request reach AE at all?

`urllib` collapsed a connect timeout and a read timeout into one bare `TimeoutError`. `_request` moves onto `httpx`, which separates the connect phase from everything after it.

- `RequestDelivery` (`NOT_DELIVERED` / `NOT_APPLIED` / `AMBIGUOUS`) rides on `AtlanApiTimeoutError.delivery`.
- `_classify_delivery` maps `ConnectTimeout` / `ConnectError` / `PoolTimeout` to `NOT_DELIVERED`. Anything it hasn't been taught about falls through to `AMBIGUOUS`, so an unrecognised transport error keeps the old never-repost behaviour.
- A `NOT_DELIVERED` submit is re-POSTed by `_post_with_retry` inside the existing attempt budget.

This is the shape a blackholed CI egress hairpin takes, and it's what reded the linked run.

The re-POST deliberately stays in `_post_with_retry` rather than `_request`: nesting a second loop underneath would multiply the POSTs per attempt and blow the cold-start budget `cold_start_submit_kwargs` sizes.

### Did the request take effect?

AE persists the run record **before** it calls Temporal and before it answers the submit, so a run it accepted is visible at `GET /automation/api/v1/runs?workflow_slug=<slug>` — reachable with the same tenant URL and bearer token the harness already uses for `/automation/api/v1/workflows`, `/versions` and `/publish`. No Temporal client needed.

- `find_run_created_since()` polls that endpoint and returns a typed `RunLookup`.
- `_post_with_retry` gained a `recover_ambiguous` hook returning `WriteRecovery`; a found run is handed back as the response the origin would have sent, and the submit is never re-issued.
- It polls rather than probing once because production AE serves this listing from Elasticsearch — a run committed microseconds before the connection died takes a moment to become searchable.
- `_RECONCILE_CLOCK_SKEW_SECONDS` absorbs runner-vs-tenant clock skew, safe because the workflow slug is unique per CI leg.

**Absence and ignorance stay distinct.** A reconcile read that never got through reports `conclusive=False`, never "no run" — so the same network fault that killed the submit cannot end up authorising a duplicate.

## Deliberately gated off

`_RESUBMIT_WHEN_AE_REPORTS_NO_RUN = False`.

Adopting a run the read finds is pure upside: if the listing works we recover a leg that would otherwise have failed, and if it doesn't we find nothing and behave exactly as before. Re-POSTing *because* the read found nothing is only safe if an empty list genuinely means no run exists — and that is unverified. The harness submits through Heracles (`/api/service/package-workflows`), not AE's own `/api/v1/workflows/{slug}/submit`, and AE's run listing filters out runs lacking automation-engine fields. If a Heracles-originated run were invisible there, every empty read would become a false "nothing landed".

**To enable:** confirm a Heracles-submitted run appears under `GET /automation/api/v1/runs?workflow_slug=<slug>`, then flip the constant. The machinery is complete and tested on both sides of the gate.

### How the gate gets settled

`probe_run_is_listed` does that confirmation automatically. The reconcile read can't: it only fires on an ambiguous submit timeout, so it would tell us nothing until the next such timeout, and only for that one leg — precisely when we least want to be learning it.

So the probe asks on the **success** path, where the true run id is already known. One GET per leg, log-only, never raises, never affects the outcome. Both harnesses call it after the DAG poll — deliberately not straight after the submit, because AE serves the listing from Elasticsearch and an immediate probe would record indexing lag as an absence, entering the exact false negative the gate exists to avoid into the record as if it were the answer.

Grep a green e2e leg's log for `AE-listing probe`:

- `run <id> IS listed under slug <slug>` → flip `_RESUBMIT_WHEN_AE_REPORTS_NO_RUN` to `True`.
- `run <id> is NOT listed` → leave it off; reconciliation stays adopt-only, which is still a strict improvement.
- `did not get through` / `returned HTTP <n>` → settles nothing, wait for another leg.

## Notes for review

- No new dependency: `httpx` is already declared in the `tests` extra and `testing/e2e/portforward.py` already imports it.
- Behaviour preserved across the transport swap: `follow_redirects=True` matches `urlopen`, the spoofed User-Agent still bypasses the Cloudflare 1010 block, and a fresh single-use client per attempt matches urllib's one-connection-per-request so a half-dead pooled connection can't be reused across the retry we're making to escape it.
- `httpx` returns 4xx/5xx as responses rather than raising, so the old `HTTPError` branch is gone — the status-based retry path is unchanged.
- `submit_workflow` gained a `slug=` kwarg (defaulted, so no caller breaks). Both harnesses now pass it; without one, an ambiguous timeout stays terminal exactly as before.
- Error messages now carry `[delivery=…]` and name the reason when the guard declines to re-issue.

## Testing

575 unit tests pass under `tests/unit/testing/`; pre-commit clean including pyright.

New coverage: delivery classification per exception type, transport retry/no-retry paths, timestamp parsing (ISO with offset / Z / naive / epoch ms / epoch s / unrecognised), run selection out of AE's `BulkResponse`, the reconcile outcomes — found, proven-absent, never-answered, gate-off, no-slug, connect-failure-skips-the-read — and the probe's three outcomes, including that an unanswered read reports `None` rather than `False` so it is never filed as evidence.

The full `tests/unit` run has pre-existing collection errors from a missing `pyarrow` in my local venv, unrelated to these files.
