### PR TITLE
ci(renovate): declare the version parser the bound gate needs (FND-379)

### DIFF
--- a/.github/scripts/renovate_uv_lock_bounded.py
+++ b/.github/scripts/renovate_uv_lock_bounded.py
@@ -680,6 +680,23 @@ def main(argv: list[str] | None = None) -> int:
         )
         baseline = ""
 
+    if Version is None:
+        # `packaging` is imported defensively at the top of this module, and every
+        # version comparison here degrades to "cannot compare" without it. The
+        # rollback gate reports what it cannot compare, so a run in that state
+        # accuses every ordinary upgrade of moving backwards — a wedged lane whose
+        # message blames the dependency data. Say the true cause instead, and say
+        # it before uv spends a minute resolving.
+        withhold(lock_path, baseline, args.window)
+        print(
+            "`packaging` is not importable, so no version can be compared and the "
+            "rollback gate cannot do its job. Refusing rather than bounding "
+            "blind: install packaging for the interpreter running this command "
+            "(the workflow pins it) and re-run.",
+            file=sys.stderr,
+        )
+        return 1
+
     before = lock_versions(baseline)
     cutoff = dt.datetime.now(dt.timezone.utc) - window
     ceilings = retention_ceilings(lock_upload_times(baseline), cutoff)
@@ -742,7 +759,9 @@ def main(argv: list[str] | None = None) -> int:
             "been YANKED upstream — `pip index versions <name>` or the PyPI JSON "
             "API will say — because no resolve can keep a yanked pin and every "
             "one of them will land here until the base branch moves off it. A "
-            "changed constraint is the other candidate. Either way it wants a "
+            "changed constraint is the other candidate, as is a version string "
+            "that is not valid PEP 440 — those are reported here too rather than "
+            "silently skipped. Either way it wants a "
             "human, so this run bounds nothing and leaves the lock deliberately "
             "un-installable — baseline versions plus a tripwire `[options]` "
             "table — for a required check to hold the branch on.",

--- a/.github/scripts/tests/test_bound_lock_branch.py
+++ b/.github/scripts/tests/test_bound_lock_branch.py
@@ -122,6 +122,24 @@ class TestWorkflowGuards:
         )
         assert "chore(deps): bound the refreshed locks" in self.job["if"]
 
+    def test_the_bound_step_pins_the_version_parser_it_needs(self):
+        """The runner image is not a promise.
+
+        The driver's rollback gate needs PEP 440 parsing, and `python3` on a bare
+        runner is not guaranteed to have `packaging` importable. Without it the
+        gate reports every upgrade as a regression, so the dependency is declared
+        at the call site rather than assumed — pinned, and `--no-project` so the
+        bound never waits on a full dev sync.
+        """
+        steps = self.job["steps"]
+        bound_step = next(
+            s for s in steps if s.get("name") == "Bound the refreshed locks"
+        )
+        run = bound_step["run"]
+        assert "bound_lock_branch.py" in run
+        assert "--with 'packaging==" in run, run
+        assert "--no-project" in run, run
+
     def test_the_lane_is_scoped_to_the_lock_refresh_branch(self):
         # Widening this to `renovate/**` would put the bound on the single-package
         # lanes, where a deliberately chosen first-party version has no business

--- a/.github/scripts/tests/test_renovate_uv_lock_bounded.py
+++ b/.github/scripts/tests/test_renovate_uv_lock_bounded.py
@@ -936,6 +936,27 @@ class TestWithholds:
         assert bounded.main(["--window", "P3D", "--project-dir", str(project)]) == 1
         self._assert_withheld(project, baseline)
 
+    def test_a_missing_version_parser_fails_before_uv_runs(self, monkeypatch, tmp_path):
+        """`packaging` absent must read as `packaging` absent.
+
+        Every comparison in this module degrades to "cannot compare" without it,
+        and the rollback gate reports what it cannot compare — so a run in that
+        state accuses every ordinary upgrade of moving backwards. Observed while
+        probing the driver under an interpreter without it: six forward moves
+        reported as regressions. Fail on the real cause, before uv spends a
+        minute resolving, and hold the branch while doing it.
+        """
+        baseline = lock(boto3="1.43.72")
+        project = self._repo(tmp_path, baseline)
+
+        def fail_if_called(command, cwd):
+            raise AssertionError("uv must not run when versions cannot be compared")
+
+        monkeypatch.setattr(bounded, "Version", None)
+        monkeypatch.setattr(bounded, "run_uv_lock", fail_if_called)
+        assert bounded.main(["--window", "P3D", "--project-dir", str(project)]) == 1
+        self._assert_withheld(project, baseline)
+
     def test_a_hold_is_an_ordinary_no_op_when_the_caller_owns_the_commit(
         self, monkeypatch, tmp_path, capsys
     ):

--- a/.github/workflows/renovate-lock-cooldown.yaml
+++ b/.github/workflows/renovate-lock-cooldown.yaml
@@ -137,8 +137,14 @@ jobs:
       - name: Bound the refreshed locks
         env:
           BASE_BRANCH: ${{ github.event.repository.default_branch }}
+        # `--with packaging`, pinned: the driver's rollback gate needs PEP 440
+        # parsing, and the runner image shipping `packaging` for the system
+        # interpreter is not a promise GitHub makes. Without it every ordinary
+        # upgrade reads as a regression. `--no-project` keeps this off the repo's
+        # own environment — the bound must not depend on a full dev sync.
         run: |
-          python3 .github/scripts/bound_lock_branch.py \
+          uv run --no-project --with 'packaging==26.3' \
+            python .github/scripts/bound_lock_branch.py \
             --window P3D \
             --baseline-ref "origin/$BASE_BRANCH"
 


### PR DESCRIPTION
## What

The bound step declares the version parser it depends on — `uv run --no-project --with 'packaging==26.3'` — and the driver refuses with the real reason when that parser is missing, instead of blaming the dependency data.

## Why

`renovate-lock-cooldown.yaml` ran the driver on the runner's system `python3` with no dependency install, so `packaging` being importable was an unstated assumption. Every version comparison in the driver degrades to "cannot compare" without it, and the rollback gate deliberately reports what it cannot compare — the docstring's "an unparseable version is the case most worth a human look". Put those together and a run without `packaging` accuses **every ordinary upgrade** of moving backwards:

```
Bounded resolve moved 6 package(s) BACKWARDS from the last committed lock:
  charset-normalizer 3.5.0 -> 3.5.1, griffelib 2.1.0 -> 2.2.0,
  hypothesis 6.165.8 -> 6.165.10, pygments 2.20.0 -> 2.21.0, ...
```

Every one of those is a forward move. That output came from running the driver under an interpreter without `packaging` while probing the lane after #3326 — so the message is now known to be reachable, and it points at the wrong thing. Post-#3297 the consequence is a held branch nobody can explain; before it, a silently skipped bound.

`packaging` **is** present on the runner today: yesterday's bounding commit on #3279 compared real forward moves and exited 0, which it could not have done otherwise. So this closes a trap rather than a live failure — but the trap is a runner-image detail we do not control, and the failure mode it produces looks like a dependency problem rather than a missing dependency.

## Changes

- The step pins `packaging==26.3` — the version already in this repo's `uv.lock`, so no new dependency — and passes `--no-project` so the bound never waits on a full dev sync.
- The driver checks `Version` once, up front: if it is unavailable it withholds the branch, says `packaging` is not importable, and returns **before** uv spends a minute resolving.
- The rollback message now names an unparseable version as one of the things it reports, alongside a yank and a changed constraint.

## Tests

- `test_a_missing_version_parser_fails_before_uv_runs` — monkeypatches `Version` to None, asserts exit 1, asserts the branch is withheld, and asserts uv is never invoked. Verified red without the guard (`AssertionError: uv must not run when versions cannot be compared`).
- `test_the_bound_step_pins_the_version_parser_it_needs` — a drift test on the workflow's own call site, so the `--with` and `--no-project` cannot quietly go away.

88 passed across both driver suites; pre-commit clean.
