### PR TITLE
ci(sdk-review): give a dropped sandbox RPC its own retry class (FND-647)

### DIFF
--- a/.github/scripts/sdk_resolve_dispatch.py
+++ b/.github/scripts/sdk_resolve_dispatch.py
@@ -18,6 +18,17 @@ The retry fires only after the out-of-band poll has come back empty, which is
 the single point where the sandbox is provably dead and nothing further will
 land; every other stream ending stays fail-fast.
 
+That is a strictly narrower rule than the review lane's, on purpose (FND-647).
+The reviewer also retries a fault it cannot prove killed the sandbox, because
+two reviewers only ever cost a duplicate comment that FND-636's dedupe
+collapses. A resolver PUSHES COMMITS: two live on one branch is what
+`sdk_resolve_push_guard.py` exists to prevent and nothing can undo afterwards.
+So on this lane an unproven death is never re-dispatched — a dropped RPC buys
+the LONG out-of-band poll instead (see `oob_poll_budget`), which is a recovery
+that cannot double-run anything. `retry_decision` has to say that explicitly:
+the fault otherwise reads as a no-op run to `resolved_nothing` and would be
+re-dispatched on the strength of it.
+
 Environment:
     MOTHERSHIP_URL      base URL (e.g. https://mothership.atlan.dev)
     HARNESS_TOKEN       bearer for /api/sandbox/execute
@@ -147,6 +158,19 @@ RETRYABLE_ERR_PATTERNS = (
     "upstream",
 )
 UNINFORMATIVE_ERR_CODES = frozenset({"", "none", "unknown"})
+# FND-647. A fault in mothership's own RPC to the sandbox, not in the model —
+# observed as `code=unknown` + "ReadableStream received over RPC disconnected
+# prematurely." on run 32309963717 (PR #3276), which threw away a healthy $0.69
+# run. Read only when the code carries no information, exactly like the
+# model-fault patterns above.
+#
+# On THIS lane the class never authorises a re-dispatch: the drop is in the pipe,
+# so it is no evidence the resolver died, and a second resolver pushing to one
+# branch is unrecoverable. What it selects is the long out-of-band poll (the
+# resolver may be many minutes from its Phase 4 hand-off) plus a refusal that
+# says so. The review lane keeps its own copy of this tuple and DOES retry on
+# it; the tuples are deliberately per-lane, because the entry conditions are.
+RETRYABLE_TRANSPORT_PATTERNS = ("disconnected prematurely",)
 # Causes that fail identically on any model — never spend a second sandbox:
 #   elicitation   the sandbox wants interactive input, which GHA can never give.
 #   stream_error  OUR urlopen died, not the sandbox. The resolver is probably
@@ -188,7 +212,9 @@ OOB_POLL_INTERVAL_SECONDS = 30
 OOB_POLL_SECONDS_STREAM_DROP = 2700
 # Abnormal sandbox termination (status=error / error event): the sandbox is dead
 # and will post nothing more — a couple of quick checks only catch a summary that
-# landed just before it died.
+# landed just before it died. NOT used for a transport fault, which reports a
+# terminal error without the sandbox being dead (FND-647): those take the
+# stream-drop budget above.
 OOB_POLL_SECONDS_HARD_ERROR = 120
 # Clock-skew margin subtracted from this run's start when matching a summary's
 # created_at, so a hand-off posted right at the boundary isn't missed. Small
@@ -808,14 +834,40 @@ def sandbox_terminated_abnormally(st: SSEState) -> bool:
     return st.status != "completed" or resolved_nothing(st)
 
 
+def is_transport_fault(st: SSEState) -> bool:
+    """True when the reported fault is the RPC to the sandbox, not the model.
+
+    Same code discipline as `is_retryable_fault`: an informative code decides on
+    its own and never falls through to the patterns, which exist for the
+    flattened `none`/`unknown`/empty case. `http_` codes are excluded outright —
+    a status on the POST itself means no sandbox was ever started, so there is no
+    RPC to a sandbox that could have dropped, and that codespace already decides
+    for itself.
+    """
+    if st.err_code.startswith("http_") or st.err_code not in UNINFORMATIVE_ERR_CODES:
+        return False
+    return any(p in st.err_msg.lower() for p in RETRYABLE_TRANSPORT_PATTERNS)
+
+
 def oob_poll_budget(st: SSEState) -> int:
     """Seconds to look for an out-of-band summary, given how the stream ended."""
     if not st.got_event:
         return 0  # never saw an event → sandbox likely never started; nothing to await
+    if is_transport_fault(st):
+        # FND-647. mothership reported a dropped RPC, which `errored` then makes
+        # look like a dead sandbox to the check below — so this ranks above it.
+        # The pipe dropping is no evidence the resolver stopped, and it can be
+        # many minutes from its Phase 4 hand-off, so give it the full window.
+        # Waiting is the ONLY recovery available here: a re-dispatch is off the
+        # table (see `retry_decision`), so the 120s this used to get is exactly
+        # how a healthy run gets thrown away (run 32309963717, $0.69).
+        return OOB_POLL_SECONDS_STREAM_DROP
     if sandbox_terminated_abnormally(st):
         # Sandbox terminated abnormally; only catch a summary posted just before.
         return OOB_POLL_SECONDS_HARD_ERROR
-    return OOB_POLL_SECONDS_STREAM_DROP  # transport drop; sandbox likely still working
+    # Our own stream was cut with no terminal event; the sandbox is likely
+    # still working.
+    return OOB_POLL_SECONDS_STREAM_DROP
 
 
 def is_retryable_fault(st: SSEState) -> bool:
@@ -849,10 +901,12 @@ def is_retryable_fault(st: SSEState) -> bool:
 def retry_decision(st: SSEState, attempt: int, seconds_left: float) -> tuple[bool, str]:
     """Whether to re-dispatch after this attempt, and the reason either way.
 
-    Called only once the out-of-band poll has come back empty, so "the sandbox
-    is dead and posted nothing" is already established for the abnormal-
-    termination branch. The reason is logged verbatim so a run that did NOT
-    retry says why, which is the part that is invisible today.
+    Called only once the out-of-band poll has come back empty, so "posted
+    nothing" is established for every branch, and "the sandbox is dead" for the
+    abnormal-termination branch — with one exception, which is why the transport
+    branch below exists: a dropped RPC reports a terminal fault without proving
+    the resolver stopped, and on this lane an unproven death is never retried.
+    The reason is logged verbatim so a run that did NOT retry says why.
     """
     if attempt >= MAX_DISPATCH_ATTEMPTS:
         return False, f"already used all {MAX_DISPATCH_ATTEMPTS} attempts"
@@ -860,6 +914,28 @@ def retry_decision(st: SSEState, attempt: int, seconds_left: float) -> tuple[boo
         return False, (
             "the stream ended without a hard error — the sandbox may still be "
             "running, and a re-dispatch would double-run the resolver"
+        )
+    if is_transport_fault(st):
+        # FND-647, and it must be ranked ABOVE `is_retryable_fault` rather than
+        # left to fall through it. An error event leaves `run_completed` False,
+        # so a clean `complete` plus a dropped RPC is indistinguishable from a
+        # no-op run — and FND-644's `resolved_nothing` branch answers True on
+        # that basis, buying a second resolver against a first of UNKNOWN
+        # liveness. That is the double-push `sdk_resolve_push_guard.py` exists to
+        # prevent, and no dedupe can undo it after the fact. (Before FND-644 the
+        # same fault fell out the other side, refused with "a different model
+        # would fail the same way" — true, and beside the point: the model never
+        # failed. Run 32309963717 was lost that way.)
+        #
+        # This lane therefore has NO transport retry class at all, by decision
+        # rather than by default: what the fault buys instead is the long
+        # out-of-band poll above, which recovers the run without ever risking a
+        # second resolver. If that poll came back empty, the run is spent.
+        return False, (
+            f"code={st.err_code or 'none'} reports a dropped RPC to the sandbox, "
+            "not a dead one — the resolver may still be pushing, and two "
+            "resolvers on one branch cannot be undone, so this lane waits for "
+            "the out-of-band hand-off instead of re-dispatching"
         )
     if not is_retryable_fault(st):
         return False, (

--- a/.github/scripts/sdk_review_dispatch.py
+++ b/.github/scripts/sdk_review_dispatch.py
@@ -30,19 +30,27 @@ have, because the review lane needs them:
     its summary to the PR, the review WAS delivered, so a later stream
     breakage is a mothership-side finalize glitch and must not red the check.
 
-One re-dispatch is allowed, in either of two classes — see
+One re-dispatch is allowed, in any of three classes — see
 MAX_DISPATCH_ATTEMPTS and retry_decision():
 
-  * the sandbox died on a hard error a DIFFERENT model could survive; and
+  * the sandbox died on a hard error a DIFFERENT model could survive;
   * the sandbox reached `status=completed` and posted no verdict, which is the
     turn ending early rather than the model failing, so attempt 2 runs the SAME
-    model.
+    model; and
+  * mothership reported a dropped RPC to the sandbox, which is a fault in the
+    pipe rather than in the model — so attempt 2 also runs the SAME model.
 
-Both fire only after the verdict check has come back empty — confirmed empty,
-sharing `sdk_review_verdict_gate`'s recheck, because the comments API is not
-read-after-write consistent. That is the single point where the sandbox is
-provably finished AND nothing was delivered; every other stream ending stays
-fail-fast, because a second reviewer would post a second summary on the same PR.
+All three fire only after the verdict check has come back empty — confirmed
+empty, sharing `sdk_review_verdict_gate`'s recheck, because the comments API is
+not read-after-write consistent. That is the single point where nothing was
+delivered; every other stream ending stays fail-fast, because a second reviewer
+would post a second summary on the same PR.
+
+The first two classes also have the sandbox provably finished. The third does
+not — a dropped pipe says nothing about the sandbox behind it — and is admitted
+anyway because this lane is self-repairing: both attempts carry the same
+`GHA_RUN_URL`, so FND-636's dedupe collapses a double post. The resolve lane
+gets no such class, for exactly that reason (FND-647).
 
 Environment (all supplied by the `Dispatch to mothership Rover Direct API`
 step in `.github/workflows/sdk-review.yml`):
@@ -217,6 +225,22 @@ RETRYABLE_ERR_PATTERNS = (
     "upstream",
 )
 UNINFORMATIVE_ERR_CODES = frozenset({"", "none", "unknown"})
+# FND-647. A fault in mothership's own RPC to the sandbox, not in the model.
+# Kept in its OWN tuple rather than added to RETRYABLE_ERR_PATTERNS above
+# because it moves a different axis: a model swap cannot fix something the model
+# never touched, so this class re-dispatches on the SAME model (with the fresh
+# session id every attempt already gets). Read only when the code carries no
+# information, exactly like the model-fault patterns.
+#
+# Deliberately narrow — one message shape, observed on resolver run
+# 32309963717, which threw away a healthy $0.69 run over it. Every entry admits
+# a re-dispatch against a sandbox of UNKNOWN liveness, affordable here only
+# because FND-636's dedupe collapses a double post: both attempts carry the same
+# GHA_RUN_URL, the key it attributes on. Do not add a pattern that has not been
+# seen in a real run. The resolve lane keeps its own copy of this tuple and uses
+# it to REFUSE — a second resolver pushes commits — so the two are deliberately
+# not shared: same signature, opposite policy.
+RETRYABLE_TRANSPORT_PATTERNS = ("disconnected prematurely",)
 # Fails identically on any model, so never spend a second sandbox on it: the
 # sandbox wants interactive input, which GHA can never give.
 NEVER_RETRY_ERR_CODES = frozenset({"elicitation"})
@@ -769,6 +793,20 @@ def is_retryable_fault(st: SSEState) -> bool:
     return any(p in st.err_msg.lower() for p in RETRYABLE_ERR_PATTERNS)
 
 
+def is_transport_fault(st: SSEState) -> bool:
+    """True when the reported fault is the RPC to the sandbox, not the model.
+
+    Same code discipline as `is_retryable_fault`: an informative code decides on
+    its own and never falls through to the patterns, which exist for the
+    flattened `none`/`unknown`/empty case. `http_` codes are excluded outright —
+    a status on the POST itself means no sandbox was ever started, so there is no
+    RPC to a sandbox that could have dropped.
+    """
+    if st.err_code.startswith("http_") or st.err_code not in UNINFORMATIVE_ERR_CODES:
+        return False
+    return any(p in st.err_msg.lower() for p in RETRYABLE_TRANSPORT_PATTERNS)
+
+
 def sandbox_completed_cleanly(st: SSEState) -> bool:
     """True when the sandbox reported the terminal `complete` event, happily.
 
@@ -812,6 +850,27 @@ def _retry_class(st: SSEState, attempt: int) -> RetryPlan:
             False,
             "the stream ended without a hard error — the sandbox may still be "
             "running, and a re-dispatch would double-review the PR",
+        )
+    if is_transport_fault(st):
+        # FND-647. mothership's RPC to the sandbox dropped. Nothing about the
+        # model failed, so the swap axis is the wrong one — attempt 2 re-runs
+        # the same model on a fresh session id.
+        #
+        # Ranked BELOW the two guards above rather than above them: reaching
+        # here means mothership itself reported a terminal fault, so this is not
+        # the "our socket died and the reviewer is probably still working" case,
+        # where a retry is usually two sandboxes for one review. It is still a
+        # sandbox of unknown liveness — the drop is in the pipe, not the sandbox
+        # — and that is affordable only because both attempts carry the same
+        # GHA_RUN_URL and FND-636's dedupe collapses a double post.
+        same = attempt_model(attempt)
+        return RetryPlan(
+            True,
+            f"code={st.err_code or 'none'} reports a dropped RPC to the sandbox "
+            f"({_squash(st.err_msg)[:80]}) — the model never failed, so "
+            f"re-dispatching on the same model ({same}) (attempt {attempt + 1} "
+            f"of {MAX_DISPATCH_ATTEMPTS})",
+            same,
         )
     if not is_retryable_fault(st):
         return RetryPlan(

--- a/.github/scripts/tests/test_sdk_resolve_dispatch.py
+++ b/.github/scripts/tests/test_sdk_resolve_dispatch.py
@@ -1079,3 +1079,119 @@ def test_main_skips_the_oob_poll_and_the_retry_when_the_budget_is_spent(
     assert polled == []
     assert len(payloads) == 1
     assert "job budget" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# a dropped RPC to the sandbox: long poll, never a re-dispatch (FND-647)
+# ---------------------------------------------------------------------------
+
+# Verbatim from run 32309963717 (PR #3276): the code is flattened to `unknown`
+# and the provider text arrives as a nested JSON blob, so the pattern has to
+# match inside it.
+_RPC_DROP = (
+    '{"type":"error","message":"ReadableStream received over RPC '
+    'disconnected prematurely."}'
+)
+
+
+def _error_event(code: str, message: str) -> list[str]:
+    return ["event: error", f"data: {json.dumps({'code': code, 'message': message})}"]
+
+
+def _rpc_dropped():
+    """That run's ending: a clean `complete`, then a dropped-RPC error event."""
+    return _stream(
+        "event: complete",
+        'data: {"status": "completed", "cost_usd": "0.686704"}',
+        "",
+        *_error_event("unknown", _RPC_DROP),
+    )
+
+
+def test_a_dropped_rpc_outranks_the_noop_classification():
+    """The live hazard this closes, and why the branch is ranked where it is.
+
+    An error event leaves `run_completed` False, so a clean `complete` plus a
+    dropped RPC is indistinguishable from a sandbox that stopped having done
+    nothing — and FND-644's no-op branch answers `is_retryable_fault` True on
+    that basis. Left alone it would spend a second resolver against a first one
+    of UNKNOWN liveness, which is the double-push this lane cannot undo. (The
+    run that motivated FND-647 predates that branch by a day, so its log shows
+    the older, opposite failure: no retry at all.)
+    """
+    st = _rpc_dropped()
+    assert sr.is_transport_fault(st) is True
+    assert sr.resolved_nothing(st) is True
+    assert sr.is_retryable_fault(st) is True  # would have re-dispatched
+    # `errored` also makes it look dead, which is what bought it the 120s poll.
+    assert sr.sandbox_terminated_abnormally(st) is True
+    assert sr.retry_decision(st, 1, sr.DISPATCH_BUDGET_SECONDS)[0] is False
+
+
+def test_a_dropped_rpc_gets_the_long_out_of_band_poll():
+    """The pipe dropped, not the resolver — it may be minutes from Phase 4."""
+    assert sr.oob_poll_budget(_rpc_dropped()) == sr.OOB_POLL_SECONDS_STREAM_DROP
+    assert sr.OOB_POLL_SECONDS_STREAM_DROP > sr.OOB_POLL_SECONDS_HARD_ERROR
+
+
+def test_a_dropped_rpc_is_never_re_dispatched_on_this_lane():
+    """A resolver pushes commits; two on one branch cannot be undone."""
+    ok, reason = sr.retry_decision(_rpc_dropped(), 1, sr.DISPATCH_BUDGET_SECONDS)
+    assert ok is False
+    assert "dropped RPC" in reason and "cannot be undone" in reason
+
+
+def test_a_known_code_is_never_overridden_by_the_transport_patterns():
+    """A code that carries information decides on its own, as everywhere else."""
+    st = _stream(*_error_event("401", _RPC_DROP))
+    assert sr.is_transport_fault(st) is False
+    assert sr.retry_decision(st, 1, sr.DISPATCH_BUDGET_SECONDS)[0] is False
+
+
+def test_a_dispatch_level_http_status_is_never_the_transport_class():
+    """No sandbox was ever started, so no RPC to one can have dropped."""
+    st = sr.SSEState()
+    st.got_event = st.errored = True
+    st.err_code, st.err_msg = "http_504", f"HTTP 504 on dispatch POST: {_RPC_DROP}"
+    assert sr.is_transport_fault(st) is False
+    # And it keeps the model swap the http_ codespace already earned it.
+    assert sr.retry_decision(st, 1, sr.DISPATCH_BUDGET_SECONDS)[0] is True
+
+
+def test_a_model_fault_still_swaps_the_model():
+    """No regression on FND-641: the model-swap class keeps its own axis."""
+    st = sr.SSEState()
+    st.got_event = st.completed = st.errored = True
+    st.status, st.err_code = "error", "429"
+    st.err_msg = "temporarily rate-limited upstream"
+    assert sr.is_transport_fault(st) is False
+    ok, reason = sr.retry_decision(st, 1, sr.DISPATCH_BUDGET_SECONDS)
+    assert ok is True and sr.RETRY_MAIN_MODEL in reason
+
+
+def test_main_waits_out_a_dropped_rpc_instead_of_re_dispatching(monkeypatch, capsys):
+    """End-to-end: the long poll finds the hand-off and the run is recovered."""
+    _main_env(monkeypatch)
+    budgets = []
+
+    def fake_poll(pr, token, since, budget, **_k):
+        budgets.append(budget)
+        return "http://handoff"
+
+    monkeypatch.setattr(sr, "poll_for_oob_summary", fake_poll)
+    payloads = _record_dispatches(monkeypatch, [_rpc_dropped()])
+
+    assert sr.main() == 0
+    assert len(payloads) == 1  # never a second resolver on the branch
+    assert budgets == [sr.OOB_POLL_SECONDS_STREAM_DROP]
+    assert "out-of-band" in capsys.readouterr().out
+
+
+def test_main_fails_a_dropped_rpc_whose_handoff_never_lands(monkeypatch, capsys):
+    """Nothing to show for it, but still no second resolver: the run is spent."""
+    _main_env(monkeypatch)
+    payloads = _record_dispatches(monkeypatch, [_rpc_dropped()])
+
+    assert sr.main() == 1
+    assert len(payloads) == 1
+    assert "Not re-dispatching" in capsys.readouterr().out

--- a/.github/scripts/tests/test_sdk_review_dispatch.py
+++ b/.github/scripts/tests/test_sdk_review_dispatch.py
@@ -1457,3 +1457,107 @@ def test_the_terminator_stops_every_session_the_dispatcher_could_have_booted():
     assert len(stopped) == sd.MAX_DISPATCH_ATTEMPTS
     assert stopped[0].endswith("/api/sandbox/session/base-id?destroy=true")
     assert stopped[1].endswith("/api/sandbox/session/base-id-retry1?destroy=true")
+
+
+# ---------------------------------------------------------------------------
+# re-dispatch on the SAME model when mothership's RPC to the sandbox drops
+# (FND-647)
+# ---------------------------------------------------------------------------
+
+# Verbatim from resolver run 32309963717 (PR #3276): the code is flattened to
+# `unknown` and the provider text arrives as a nested JSON blob, so the pattern
+# has to match inside it.
+_RPC_DROP = (
+    '{"type":"error","message":"ReadableStream received over RPC '
+    'disconnected prematurely."}'
+)
+
+
+def _rpc_dropped(cost: str = "0.686704") -> sd.SSEState:
+    """That run's ending: a clean `complete`, then a dropped-RPC error event."""
+    return _stream(
+        *_event("complete", {"status": "completed", "cost_usd": cost}),
+        *_event("error", {"code": "unknown", "message": _RPC_DROP}),
+    )
+
+
+def test_a_dropped_rpc_is_not_a_model_fault_and_used_to_fall_through():
+    """The regression anchor: the model-swap allowlist declines this, correctly.
+
+    Nothing about the model failed, so `is_retryable_fault` has no business
+    saying yes — which is exactly why the run was thrown away at $0.69 before
+    this class existed.
+    """
+    st = _rpc_dropped()
+    assert sd.is_retryable_fault(st) is False
+    assert sd.is_transport_fault(st) is True
+    assert sd.sandbox_completed_cleanly(st) is False  # the error event rules it out
+
+
+def test_a_dropped_rpc_retries_on_the_same_model():
+    plan = sd.retry_decision(_rpc_dropped(), 1, 6000)
+    assert plan.retry is True
+    assert plan.model == sd.MAIN_MODEL != sd.RETRY_MAIN_MODEL
+    assert "dropped RPC" in plan.reason and "same model" in plan.reason
+
+
+def test_a_dropped_rpc_without_a_terminal_complete_is_the_same_class():
+    """The other shape it arrives in: the error event and nothing after it."""
+    st = _stream(*_event("error", {"code": "unknown", "message": _RPC_DROP}))
+    assert st.completed is False and st.stream_error == ""
+    plan = sd.retry_decision(st, 1, 6000)
+    assert plan.retry is True and plan.model == sd.MAIN_MODEL
+
+
+def test_the_transport_retry_still_honours_the_shared_retry_bounds():
+    """Constraint: an extra entry condition only — the knobs do not move."""
+    st = _rpc_dropped()
+    assert sd.retry_decision(st, sd.MAX_DISPATCH_ATTEMPTS, 6000).retry is False
+    assert sd.retry_decision(st, 1, sd.RETRY_MIN_REMAINING_SECONDS - 1).retry is False
+    assert sd.retry_decision(st, 1, sd.RETRY_MIN_REMAINING_SECONDS).retry is True
+
+
+def test_a_known_code_is_never_overridden_by_the_transport_patterns():
+    """A code that carries information decides on its own, as everywhere else."""
+    st = _stream(*_event("error", {"code": "401", "message": _RPC_DROP}))
+    assert sd.is_transport_fault(st) is False
+    assert sd.retry_decision(st, 1, 6000).retry is False
+
+
+def test_a_dispatch_level_http_status_is_never_the_transport_class():
+    """No sandbox was ever started, so no RPC to one can have dropped."""
+    st = sd.SSEState(0.0)
+    st.errored = True
+    st.err_code, st.err_msg = "http_504", f"HTTP 504 on dispatch POST: {_RPC_DROP}"
+    assert sd.is_transport_fault(st) is False
+    # And it keeps the model swap the http_ codespace already earned it.
+    assert sd.retry_decision(st, 1, 6000).model == sd.RETRY_MAIN_MODEL
+
+
+def test_a_model_fault_still_swaps_the_model():
+    """No regression on FND-641/FND-643: the two classes stay on their own axes."""
+    assert sd.retry_decision(_errored("429"), 1, 6000).model == sd.RETRY_MAIN_MODEL
+
+
+def test_main_re_dispatches_a_dropped_rpc_on_the_same_model(
+    dispatch_env, monkeypatch, capsys
+):
+    """Fresh session id, same model, and the verdict lands on attempt 2."""
+    seen = _record_dispatches(
+        monkeypatch, [_rpc_dropped(), _completed("0.83")], [False, True]
+    )
+
+    assert sd.main() == 0
+    assert [p["model"] for p in seen] == [sd.MAIN_MODEL, sd.MAIN_MODEL]
+    assert [p["session_id"] for p in seen] == ["base-id", "base-id-retry1"]
+    assert f"Re-dispatching on {sd.MAIN_MODEL}" in capsys.readouterr().out
+
+
+def test_main_does_not_re_dispatch_a_dropped_rpc_that_delivered(
+    dispatch_env, monkeypatch
+):
+    """The verdict is on the PR: the drop was cosmetic, so no second sandbox."""
+    seen = _record_dispatches(monkeypatch, [_rpc_dropped()], [True])
+
+    assert sd.main() == 0
+    assert len(seen) == 1

--- a/.github/workflows/sdk-resolve.yml
+++ b/.github/workflows/sdk-resolve.yml
@@ -218,9 +218,13 @@ jobs:
       # The script dispatches ONCE, then re-dispatches at most once more on a
       # DIFFERENT main model when the sandbox died on a model/provider fault and
       # posted no out-of-band hand-off (FND-641). Both attempts' costs are logged
-      # separately and rendered in the step summary. Everything else — a
-      # transport drop, an auth or prompt fault, an elicitation — stays
-      # fail-fast; see MAX_DISPATCH_ATTEMPTS / retry_decision() in the script.
+      # separately and rendered in the step summary. Everything else — a cut
+      # stream, a dropped RPC to the sandbox, an auth or prompt fault, an
+      # elicitation — stays fail-fast: unlike the review lane, a second resolver
+      # would push to the same branch, so an unproven death is never retried
+      # here (FND-647). A dropped RPC instead buys the long out-of-band poll,
+      # which recovers the run without a second sandbox. See
+      # MAX_DISPATCH_ATTEMPTS / retry_decision() in the script.
       - name: Dispatch SDK Resolve to mothership Rover Direct API
         env:
           MOTHERSHIP_URL: ${{ vars.MOTHERSHIP_URL }}

--- a/.github/workflows/sdk-review.yml
+++ b/.github/workflows/sdk-review.yml
@@ -640,10 +640,13 @@ jobs:
       # `final_err_msg`) are a contract: `sdk_review_verdict_gate.py`, the
       # starter-comment stamper and `sdk_review_approve.py` all read them.
       #
-      # The step can boot TWO sandboxes: it re-dispatches once on a different
-      # main model when the first dies on a hard error a model swap could
-      # survive (FND-641, ported in FND-643). `final_cost` is then the sum, and
-      # the step summary carries the per-attempt trail.
+      # The step can boot TWO sandboxes. It re-dispatches once, on one of
+      # three classes: a hard error a model swap could survive (FND-641, ported
+      # in FND-643) goes to a DIFFERENT main model; a clean `status=completed`
+      # that delivered no verdict (FND-645) and a dropped RPC to the sandbox
+      # (FND-647) re-run the SAME one, because neither is a model fault. All
+      # three fire only on a confirmed-empty verdict read. `final_cost` is then
+      # the sum, and the step summary carries the per-attempt trail.
       - name: Dispatch to mothership Rover Direct API
         id: dispatch
         if: steps.lock_gate.outputs.decision != 'skip'
@@ -721,9 +724,10 @@ jobs:
       # and masking the real outcome with a teardown error helps nobody.
       #
       # SESSION_ID is the BASE id. A run can boot more than one sandbox (the
-      # dispatcher re-dispatches once on a different model when the first dies),
-      # and each attempt gets its own derived id, so the script walks the same
-      # ladder rather than trusting an id this step cannot know.
+      # dispatcher re-dispatches once when the first delivers nothing — on the
+      # same model or a different one, depending on the fault), and each attempt
+      # gets its own derived id, so the script walks the same ladder rather than
+      # trusting an id this step cannot know.
       - name: Terminate mothership sandbox on cancel
         if: cancelled() && steps.session.outputs.session_id != ''
         env:


### PR DESCRIPTION
A premature RPC disconnect between mothership and the sandbox is retryable on the **same** model — nothing about the model failed — but both dispatch lanes had exactly one retry axis (`RETRY_MAIN_MODEL`), so it fell through. Resolver run [32309963717](https://github.com/atlanhq/application-sdk/actions/runs/32309963717) threw away a healthy $0.69 run over it, refused with *"a different model would fail the same way"*: true, and beside the point.

Adds `RETRYABLE_TRANSPORT_PATTERNS` + `is_transport_fault()` to both lanes — one fault signature, deliberately opposite policies, because the blast radius of a wrong retry differs sharply.

## Review lane — retry, on the same model

New branch in `_retry_class`, ranked below the clean-completed (FND-645) and cut-stream guards, so reaching it means mothership itself reported a terminal fault. Returns `attempt_model(attempt)` — the same model, on the fresh session id every attempt already gets.

The drop says nothing about whether the sandbox is still alive. Admitting that unknown liveness is affordable here *only* because the lane is self-repairing: both attempts carry the same `GHA_RUN_URL`, so FND-636's dedupe collapses a double post. Entry stays gated on the confirmed-empty verdict read FND-645 landed — no new read.

## Resolve lane — never re-dispatch, plus the long poll

A resolver pushes commits, and two on one branch is what `sdk_resolve_push_guard.py` exists to prevent. Two findings shaped this half:

1. **The live bug here is the opposite of the ticket's.** FND-644 (#3299) merged 2026-08-20, a day after the run above. An `error` event leaves `run_completed()` False, so a clean `complete` + a dropped RPC is indistinguishable from a no-op run — and `resolved_nothing()` makes `is_retryable_fault()` answer **True**. On today's `main` that spends a second resolver against a first of unknown liveness. The new branch is ranked *above* `is_retryable_fault` precisely to close that.
2. **The 120 s poll was itself the bug.** `sandbox_terminated_abnormally()` is True for this fault (it is `errored`), so it drew `OOB_POLL_SECONDS_HARD_ERROR`. But the pipe dropping is no evidence the resolver stopped — it can be many minutes from its Phase 4 hand-off. `oob_poll_budget()` now returns the stream-drop budget (2700 s) for a transport fault. That recovers the run without ever risking a second resolver, which is why "leave it fail-fast and accept the lost run" was not the right answer either.

**On a liveness probe:** considered and rejected. The only endpoint we have is `DELETE /api/sandbox/session/{id}?destroy=true`, and by our own framing (`mothership_terminate_session.py`, and the PR footer in `sdk-review.yml`) a 2xx is "termination requested", not proof of death. Destroy-then-retry would be a guess dressed as proof.

## Tests

Per lane: transport pattern → same-model retry (review) / refusal + long poll (resolve); verdict already posted → no retry; an informative code and an `http_` dispatch status are never the transport class; a model fault still swaps the model (no FND-641/FND-643 regression); the `resolved_nothing` interaction pinned as a named test on resolve. 229 passing in the two dispatch suites.

## Also

Workflow comments in `sdk-review.yml` / `sdk-resolve.yml` updated — both still described a single "different model" retry, which FND-645 had already made incomplete. Comment-only; no steps, permissions or logic changed.

Closes FND-647.
