### PR TITLE
ci(e2e): stop dispatching e2e for a superseded commit (FND-696)

### DIFF
--- a/.github/actions/e2e-apps/action.yaml
+++ b/.github/actions/e2e-apps/action.yaml
@@ -171,6 +171,13 @@ runs:
     # instead: an atomic ref CAS on refs/e2e-dispatch/<app>/<sha>, the same
     # primitive as the tenant lease.
     #
+    # The same step also drops the dispatch when `check-sha` is no longer the
+    # head of the PR it came from. That is the OTHER duplication and the CAS
+    # cannot see it: two head SHAs on one PR are two legitimate claims, so both
+    # fan out, and the connector-side lease then makes the head commit queue
+    # behind the obsolete commit's whole run — 3m38s, 10m12s and 12m of lease
+    # wait across three connectors on PR #3322 (FND-696).
+    #
     # Deliberately NOT `concurrency: cancel-in-progress`. The dispatch below is
     # fire-and-forget, so cancelling this run does not cancel the connector run
     # it already started — and a queueing group holds exactly ONE pending run,
@@ -207,6 +214,12 @@ runs:
         SHA: ${{ inputs.check-sha }}
         APP: ${{ inputs.repo-name }}
         NAME: ${{ inputs.check-run-name }}
+        # Empty on the merge_group path, which is what disables the stale-head
+        # check there: a queue entry's SHA is not any PR's head and never
+        # becomes stale. Taken from the event rather than an input so a caller
+        # cannot get it wrong — the guard keys on `check-sha`, and a PR number
+        # that did not come from the same event could name a different PR.
+        PR_NUMBER: ${{ github.event.pull_request.number }}
       run: |
         set -euo pipefail
         python3 .github/scripts/e2e_dispatch_guard.py \
@@ -214,6 +227,7 @@ runs:
           --sha "$SHA" \
           --app "$APP" \
           --check-run-name "$NAME" \
+          --pr-number "$PR_NUMBER" \
           --run-id "$GITHUB_RUN_ID" \
           --run-attempt "$GITHUB_RUN_ATTEMPT"
 

--- a/.github/actions/e2e-apps/action.yaml
+++ b/.github/actions/e2e-apps/action.yaml
@@ -178,10 +178,16 @@ runs:
     # behind the obsolete commit's whole run — 3m38s, 10m12s and 12m of lease
     # wait across three connectors on PR #3322 (FND-696).
     #
-    # Deliberately NOT `concurrency: cancel-in-progress`. The dispatch below is
-    # fire-and-forget, so cancelling this run does not cancel the connector run
-    # it already started — and a queueing group holds exactly ONE pending run,
-    # so a third arrival is evicted with no log at all (FND-218).
+    # Deliberately NOT `concurrency: cancel-in-progress`, but NOT because it
+    # would achieve nothing: that claim (FND-646) only holds once the dispatch
+    # below has fired, since cancelling this run cannot cancel a connector run it
+    # already started. Before then there is an ~8-minute base-image window in
+    # which cancellation WOULD have stopped the stale run — the case the head
+    # check above exists for. The reasons it is still not the lever to reach for:
+    # a run cancelled between creating its check run and dispatching leaves a
+    # check nothing will ever complete, and a queueing group holds exactly ONE
+    # pending run, so a third arrival is evicted with no log at all (FND-218).
+    # The head check gets the same tenant-side benefit without either.
     #
     # Callback mode only, and that is a correctness constraint rather than
     # scope: in poll mode THIS job's conclusion is the verdict, so a skipped

--- a/.github/actions/e2e-tenant-lease/e2e_tenant_lease.py
+++ b/.github/actions/e2e-tenant-lease/e2e_tenant_lease.py
@@ -148,6 +148,21 @@ import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
 
+# A waiting lease is the longest-running step in the whole e2e run, and its only
+# outward sign of life is the per-attempt "waiting for ..." line. Python
+# block-buffers stdout when it is a pipe, which an Actions log always is, so
+# without this NOTHING appears until the process exits: a run that queued for ten
+# minutes showed a blank step for ten minutes and then printed all ten minutes of
+# progress at once. That is indistinguishable from a wedged step to anyone
+# watching, and it is why the queue got read as a deadlock (FND-696).
+#
+# hasattr rather than a bare call: this runs at import, and a stdout that some
+# other harness has replaced with a plain writable object would otherwise make
+# the whole lease unimportable — trading an invisible wait for an unserialised
+# tenant, which is the failure this module exists to prevent.
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(line_buffering=True)
+
 # The lease ref lives outside refs/heads and refs/tags on purpose: a branch would
 # fire `push` events (and show up in the branch list), a tag would pollute the
 # release surface. A custom namespace is inert — nothing watches it.

--- a/.github/scripts/e2e_dispatch_guard.py
+++ b/.github/scripts/e2e_dispatch_guard.py
@@ -21,14 +21,22 @@ to get here reaches a tenant.
 
 Why not ``concurrency:``
 -----------------------
-``cancel-in-progress`` was considered and rejected. The dispatch is
-fire-and-forget (``e2e-apps`` in ``wait-mode: callback`` creates the check run,
-dispatches, and exits), so cancelling the SDK-side run does not cancel the
-connector run it already started — it only orphans it, and the tenant contention
-is unchanged. And a queueing group is worse than useless here: GitHub holds
-exactly ONE pending run per group, so a third arrival cancels the waiter with no
-log output at all. That is FND-218, the failure the tenant lease exists to
-replace; re-adding it in front of the dispatch would reintroduce it.
+``cancel-in-progress`` was considered and rejected. *Once the dispatch has
+fired* it changes nothing: the dispatch is fire-and-forget (``e2e-apps`` in
+``wait-mode: callback`` creates the check run, dispatches, and exits), so
+cancelling the SDK-side run does not cancel the connector run it already started
+— it only orphans it, and the tenant contention is unchanged.
+
+That is not the same as "cancellation could never have helped", and the
+stale-head section below is the counter-example: a run spends ~8 minutes
+building the base image before it reaches the dispatch, and a cancel landing in
+that window would have stopped the fan-out outright. Two things still rule it
+out. A run cancelled between creating its check run and dispatching leaves a
+check that nothing will ever complete. And a queueing group is worse than
+useless here: GitHub holds exactly ONE pending run per group, so a third arrival
+cancels the waiter with no log output at all — FND-218, the failure the tenant
+lease exists to replace, reintroduced in front of the dispatch. The head check
+below buys the same tenant time with neither hazard.
 
 Cancellation is also unsafe as a steady-state mechanism, which is worth stating
 because it is the obvious first idea: ``prepare-tenant`` carries ``if:
@@ -117,9 +125,14 @@ reason above. Unreadable answers dispatch, in keeping with the fail-open posture
 a stale run costs tenant time, a wrongly-skipped head commit costs the PR its
 e2e.
 
-It does not close the window where the stale run dispatched first (a push more
-than ~2min behind the previous one). That case is a live connector run holding a
-lease it legitimately took, and the queue is the right answer to it.
+It closes the window up to the dispatch and nothing past it. A push landing
+later leaves a connector run already in flight, which is two cases, not one. If
+that run has ACQUIRED a lease, there is nothing to do — cancelling it is unsafe
+for the ``prepare-tenant`` reason above, so the queue is the right answer. If it
+has dispatched but NOT yet leased — still building, unit-testing and
+integration-testing, 2m30s on the openapi leg of PR #3322 — it holds nothing and
+could stand down for free. That second case needs a check on the connector side,
+immediately before the lease, and is tracked as FND-701.
 
 Pruning
 -------

--- a/.github/scripts/e2e_dispatch_guard.py
+++ b/.github/scripts/e2e_dispatch_guard.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
-"""At most one LIVE connector e2e dispatch per ``(dispatching SHA, app)``.
+"""At most one LIVE connector e2e dispatch per ``(dispatching SHA, app)``, and
+none at all for a SHA the PR has already moved past.
 
 Why this exists
 ---------------
@@ -95,6 +96,30 @@ That direction is deliberate and it is the opposite of the tenant lease's:
   is, in any case, exactly the pre-existing behaviour.
 
 So the worst case for a broken guard is the status quo.
+
+The other duplication: one PR, two head SHAs
+--------------------------------------------
+The CAS keys on the SHA, so it is blind by construction to the *sequential*
+duplicate: commit A's ``PR Checks`` run is still working its way towards the
+dispatch when commit B lands, and both then dispatch — two different SHAs, two
+uncontested claims, two full fan-outs. Nothing is duplicated in the CAS's terms
+and everything is duplicated in the tenants' terms. The connector-side lease
+behaves correctly and that is precisely the problem: it QUEUES, so commit B waits
+out commit A's entire install-plus-legs cycle before touching a tenant. On PR
+#3322 that cost 3m38s, 10m12s and 12m of pure lease wait across three connectors,
+all of it spent behind a commit that was already history (FND-696).
+
+The fix is one API call on the ``pull_request`` path: if ``--sha`` is no longer
+the head of ``--pr-number``, skip. Not cancellation — the stale run has not
+dispatched yet when this runs, so there is nothing to cancel, and cancelling a
+connector run that HAS started is unsafe anyway for the ``prepare-tenant``
+reason above. Unreadable answers dispatch, in keeping with the fail-open posture:
+a stale run costs tenant time, a wrongly-skipped head commit costs the PR its
+e2e.
+
+It does not close the window where the stale run dispatched first (a push more
+than ~2min behind the previous one). That case is a live connector run holding a
+lease it legitimately took, and the queue is the right answer to it.
 
 Pruning
 -------
@@ -574,6 +599,30 @@ def run_is_live(repo: str, run_id: int) -> bool:
     return response.body.get("status") != _COMPLETED
 
 
+def pr_head_sha(repo: str, number: int) -> str | None:
+    """The head SHA the PR currently points at, or None if it could not be read.
+
+    None is "unknown", never "no head": every caller treats an unreadable answer
+    as "not superseded" and dispatches, because the only thing worse than paying
+    for a stale e2e run is a PR head whose e2e silently never ran.
+    """
+    response = gh_request("GET", f"repos/{repo}/pulls/{number}")
+    if response.status >= 400 or not isinstance(response.body, dict):
+        print(
+            f"::warning::could not read pull request #{number} "
+            f"(HTTP {response.status}); dispatching without the stale-head check."
+        )
+        return None
+    head = response.body.get("head")
+    if not isinstance(head, dict) or not isinstance(head.get("sha"), str):
+        print(
+            f"::warning::pull request #{number} reported no head sha; "
+            "dispatching without the stale-head check."
+        )
+        return None
+    return head["sha"].strip().lower()
+
+
 def open_pr_heads(repo: str) -> set[str] | None:
     """Head SHAs of every open PR, or None if the list could not be read.
 
@@ -787,6 +836,13 @@ def main(argv: list[str] | None = None) -> int:
     )
     parser.add_argument("--app", required=True, help="Target connector repo name.")
     parser.add_argument(
+        "--pr-number",
+        default="",
+        help="Number of the pull request whose head --sha is, on the "
+        "pull_request path. Empty (the merge_group path) disables the "
+        "stale-head check: a queue entry has no PR head to fall behind.",
+    )
+    parser.add_argument(
         "--check-run-name",
         required=True,
         help="The check run the claimer creates before dispatching, e.g. "
@@ -824,6 +880,52 @@ def main(argv: list[str] | None = None) -> int:
             os.environ.get("GITHUB_OUTPUT"),
         )
         return 0
+
+    # ── Is this SHA still the thing under review? ────────────────────────────
+    # The CAS below is keyed on (app, SHA), so it cannot see the OTHER shape of
+    # duplication: one PR, two live head SHAs. A push that lands while the
+    # previous commit's PR Checks run is still on its way to this step leaves two
+    # runs dispatching two full fan-outs, and the connector-side tenant lease
+    # then does exactly what it promises — it queues the current SHA behind the
+    # obsolete one's whole install-plus-legs cycle. Measured on PR #3322: 3m38s
+    # of lease wait in one connector, 10m12s in another, 12m in a third, every
+    # second of it spent waiting for a commit nobody was going to merge
+    # (FND-696).
+    #
+    # So: if this run's SHA is no longer the PR's head, the dispatch is dropped
+    # here rather than serialised there. Cheaper than cancellation, and it needs
+    # no write permission — at this point the stale run has not dispatched yet,
+    # so there is nothing to cancel. (Once it HAS dispatched, this check cannot
+    # help; the connector run is live and the lease queue is the right answer.)
+    #
+    # One API call, and unreadable means "not superseded": the failure that
+    # matters is skipping the head commit's only dispatch, so every doubt
+    # resolves towards dispatching.
+    pr_number = args.pr_number.strip()
+    if pr_number.isdigit():
+        head = pr_head_sha(args.repo, int(pr_number))
+        if head is not None and head != sha:
+            print(
+                f"::notice::skipping the {args.app} dispatch: {sha[:8]} is no "
+                f"longer the head of PR #{pr_number} ({head[:8]} is). The tenant "
+                "belongs to the head commit's run."
+            )
+            summarise(
+                f"- **{args.app}**: stale dispatch skipped — `{sha[:8]}` was "
+                f"superseded by `{head[:8]}` on PR #{pr_number}."
+            )
+            write_outputs(
+                {
+                    "claimed": "false",
+                    "state": "superseded",
+                    # Empty on purpose: no claim was taken, and naming a ref this
+                    # run never wrote would read as one it holds.
+                    "claim-ref": "",
+                    "holder-run-id": "",
+                },
+                os.environ.get("GITHUB_OUTPUT"),
+            )
+            return 0
 
     ref = claim_ref(args.app, sha)
     try:

--- a/.github/scripts/poll_check_runs_gate.py
+++ b/.github/scripts/poll_check_runs_gate.py
@@ -17,6 +17,23 @@ does so cheaply:
 
 Exits 0 once every name in --name is 'completed' with a passing conclusion,
 1 if any concludes non-passing, 1 on timeout.
+
+Stopping early when the SHA stops mattering
+-------------------------------------------
+A check run that never appears is waited out in full — 130 minutes, by design,
+because a connector can legitimately take two hours to report. There is one case
+where that wait is knowably pointless: this run's SHA is no longer the head of
+its PR, and the dispatch guard therefore declined to dispatch for it at all
+(``e2e_dispatch_guard.py``, FND-696). Nothing will ever create the checks, so
+with ``--pr-number`` this stops as soon as it can see that, and exits 0.
+
+Zero, not one, and the reason is worth stating because "green without a verdict"
+is normally the bug: this is a green on a commit that is no longer under review,
+where no verdict is required from anyone. A red there would be a false alarm on
+an abandoned run — recurring, since a second push in quick succession is routine,
+and read by automation that treats a red gate as a real failure. The head
+commit's own run is entirely unaffected, and it is the only one whose gate can
+satisfy a required check.
 """
 
 from __future__ import annotations
@@ -30,6 +47,61 @@ import sys
 import time
 
 PASSING_CONCLUSIONS = {"success", "neutral", "skipped"}
+
+# This poll runs for up to 130 minutes and its only sign of life is the
+# per-attempt "waiting on checks" line. Python block-buffers stdout when it is a
+# pipe, which an Actions log always is, so without this the step shows nothing at
+# all until it finishes and then prints the whole history at once — a live gate
+# and a wedged one look identical (FND-696).
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(line_buffering=True)
+
+
+class Superseded(Exception):
+    """The SHA being polled is no longer the head of its PR.
+
+    Raised rather than returned so it cannot be confused with a verdict: there is
+    no pass or fail for a commit nobody is going to merge, and the caller has to
+    handle it deliberately.
+    """
+
+    def __init__(self, head: str) -> None:
+        super().__init__(head)
+        self.head = head
+
+
+def pr_head_sha(repo: str, number: int) -> str | None:
+    """The head SHA the PR currently points at, or None if it could not be read.
+
+    None is "unknown", never "no head": an unreadable answer must leave the poll
+    exactly as it was, because the cost of being wrong here is abandoning the
+    wait for checks that were genuinely on their way.
+
+    Hence the SystemExit catch, which is the whole reason this is not a two-line
+    function. ``gh_api_conditional`` raises on any >=400 — correct for the poll
+    it was written for, where an unreadable check listing is a real failure, and
+    exactly wrong here: this read is an optimisation, so a missing
+    ``pull-requests: read`` grant would otherwise turn "stop waiting sooner" into
+    "kill the gate the first time it looks".
+    """
+    try:
+        status_code, _etag, body = gh_api_conditional(f"repos/{repo}/pulls/{number}")
+    except SystemExit as unreadable:
+        print(
+            f"::warning::could not read pull request #{number} ({unreadable}); "
+            "continuing to wait."
+        )
+        return None
+    if status_code != 200 or not isinstance(body, dict):
+        print(
+            f"::warning::could not read pull request #{number} "
+            f"(HTTP {status_code}); continuing to wait."
+        )
+        return None
+    head = body.get("head")
+    if not isinstance(head, dict) or not isinstance(head.get("sha"), str):
+        return None
+    return head["sha"].strip().lower()
 
 
 def run(cmd: list[str], **kwargs) -> subprocess.CompletedProcess:
@@ -145,10 +217,15 @@ def wait_for_checks(
     *,
     interval_seconds: int = 30,
     timeout_seconds: int = 7800,
+    pr_number: int | None = None,
     sleep=time.sleep,
 ) -> bool:
     """Poll until every name in `expected_names` has a 'completed' check run
-    on `sha`, or the timeout elapses. Returns True iff all conclusions pass."""
+    on `sha`, or the timeout elapses. Returns True iff all conclusions pass.
+
+    Raises `Superseded` when `pr_number` is given and `sha` has stopped being
+    that PR's head while checks are still missing — nothing will create them.
+    """
     path = f"repos/{repo}/commits/{sha}/check-runs?per_page=100"
     etag: str | None = None
     latest: dict[str, dict] = {}
@@ -202,6 +279,19 @@ def wait_for_checks(
         ]
         if not missing and not pending:
             break
+
+        # Only ever asked about a check that is MISSING, never one that is merely
+        # pending: a pending check has a connector run behind it that will report,
+        # and abandoning that wait would throw away a real verdict.
+        #
+        # Attempt 1 is where this normally fires — the checks are created by the
+        # dispatch job this one `needs`, so on the head commit they already exist
+        # by the first poll. The periodic re-ask afterwards covers the push that
+        # lands mid-wait, at one call per five minutes rather than one per poll.
+        if missing and pr_number and (attempt == 1 or attempt % 10 == 0):
+            head = pr_head_sha(repo, pr_number)
+            if head is not None and head != sha.strip().lower():
+                raise Superseded(head)
 
         print(
             f"[{attempt}/{max_attempts}] waiting on checks — missing={missing} pending={pending}"
@@ -280,6 +370,15 @@ def main(argv: list[str] | None = None) -> int:
         default=7800,
         help="Overall poll budget (default 7800s = 130min, safely above the 120min connector job ceiling).",
     )
+    parser.add_argument(
+        "--pr-number",
+        default="",
+        help="The PR whose head --sha is, on the pull_request path. Given, a "
+        "poll for checks that will never exist because this SHA was superseded "
+        "stops early instead of waiting out the whole budget. Empty (the "
+        "merge_group path) keeps the previous behaviour: a queue entry's SHA is "
+        "not any PR's head, so there is nothing for it to fall behind.",
+    )
     args = parser.parse_args(argv)
 
     if args.names_json is not None:
@@ -292,13 +391,24 @@ def main(argv: list[str] | None = None) -> int:
     else:
         names = args.names
 
-    ok = wait_for_checks(
-        args.repo,
-        args.sha,
-        names,
-        interval_seconds=args.interval_seconds,
-        timeout_seconds=args.timeout_seconds,
-    )
+    pr_number = args.pr_number.strip()
+    try:
+        ok = wait_for_checks(
+            args.repo,
+            args.sha,
+            names,
+            interval_seconds=args.interval_seconds,
+            timeout_seconds=args.timeout_seconds,
+            pr_number=int(pr_number) if pr_number.isdigit() else None,
+        )
+    except Superseded as superseded:
+        print(
+            f"::notice::not waiting for connector checks on {args.sha[:8]}: it is "
+            f"no longer the head of PR #{pr_number} ({superseded.head[:8]} is), so "
+            "no dispatch was made for it and no check will ever appear. The head "
+            "commit's own run carries the verdict."
+        )
+        return 0
     return 0 if ok else 1
 
 

--- a/.github/scripts/poll_check_runs_gate.py
+++ b/.github/scripts/poll_check_runs_gate.py
@@ -82,11 +82,13 @@ def pr_head_sha(repo: str, number: int) -> str | None:
     it was written for, where an unreadable check listing is a real failure, and
     exactly wrong here: this read is an optimisation, so a missing
     ``pull-requests: read`` grant would otherwise turn "stop waiting sooner" into
-    "kill the gate the first time it looks".
+    "kill the gate the first time it looks". A 200 whose body is not JSON raises
+    ``json.JSONDecodeError`` from the same parser; swallow that too, matching the
+    dispatch-side fail-open, so a proxy HTML page cannot fail the required gate.
     """
     try:
         status_code, _etag, body = gh_api_conditional(f"repos/{repo}/pulls/{number}")
-    except SystemExit as unreadable:
+    except (SystemExit, json.JSONDecodeError) as unreadable:
         print(
             f"::warning::could not read pull request #{number} ({unreadable}); "
             "continuing to wait."

--- a/.github/scripts/tests/test_e2e_dispatch_guard.py
+++ b/.github/scripts/tests/test_e2e_dispatch_guard.py
@@ -619,6 +619,136 @@ def test_a_malformed_sha_still_dispatches(
     assert http.calls == []
 
 
+# --- the other duplication: one PR, two head SHAs --------------------------
+#
+# The CAS is keyed on the SHA, so two live commits on one PR are two legitimate
+# claims and both fan out. Nothing is duplicated in the CAS's terms; the cost
+# lands a repo away, where the tenant lease queues the head commit behind the
+# obsolete commit's entire install-plus-legs cycle (FND-696). These tests pin
+# both directions: a superseded SHA must not reach a tenant, and every doubt
+# about whether it IS superseded must still dispatch.
+
+_HEAD = "d47789e0" + "1" * 32
+
+
+def test_a_superseded_sha_does_not_dispatch(
+    http: FakeHTTP, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    out = _outputs(tmp_path, monkeypatch)
+    http.route("GET", "/pulls/3322", (200, {"head": {"sha": _HEAD}}))
+
+    assert main(_argv(**{"--pr-number": "3322"})) == 0
+
+    outputs = _read(out)
+    assert outputs["claimed"] == "false"
+    assert outputs["state"] == "superseded"
+    # No claim was taken, so naming one would read as a ref this run holds.
+    assert outputs["claim-ref"] == ""
+    # And it stands down completely: no CAS, no prune, no check-run read. The
+    # unstubbed-request guard in FakeHTTP is what proves it — one call, total.
+    assert len(http.calls) == 1
+
+
+def test_the_head_sha_dispatches(
+    http: FakeHTTP, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    out = _outputs(tmp_path, monkeypatch)
+    http.route("GET", "/pulls/3322", (200, {"head": {"sha": SHA}}))
+    http.route("GET", "/git/ref/", (404, {"message": "Not Found"}))
+    http.route("POST", "/git/blobs", (201, {"sha": BLOB}))
+    http.route("POST", "/git/refs", (201, {"ref": REF}))
+    http.route("GET", "/matching-refs/", (200, [{"ref": REF}]))
+    http.route("GET", "/pulls?", (200, []))
+
+    assert main(_argv(**{"--pr-number": "3322"})) == 0
+
+    assert _read(out)["state"] == "claimed"
+
+
+def test_a_head_sha_in_a_different_case_is_not_superseded(
+    http: FakeHTTP, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """One SHA in two spellings must not read as two commits — that would skip
+    the head commit's own dispatch, the one failure worse than a stale run."""
+    out = _outputs(tmp_path, monkeypatch)
+    http.route("GET", "/pulls/3322", (200, {"head": {"sha": SHA.upper()}}))
+    http.route("GET", "/git/ref/", (404, {"message": "Not Found"}))
+    http.route("POST", "/git/blobs", (201, {"sha": BLOB}))
+    http.route("POST", "/git/refs", (201, {"ref": REF}))
+    http.route("GET", "/matching-refs/", (200, [{"ref": REF}]))
+    http.route("GET", "/pulls?", (200, []))
+
+    assert main(_argv(**{"--pr-number": "3322"})) == 0
+
+    assert _read(out)["state"] == "claimed"
+
+
+@pytest.mark.parametrize(
+    "answer",
+    [
+        (404, {"message": "Not Found"}),
+        (500, {"message": "boom"}),
+        _PERMISSION_DENIED,
+        _RATE_LIMIT,
+        # Shape change: a 200 that says nothing about the head.
+        (200, {"number": 3322}),
+        (200, {"head": {"ref": "bump-version-main"}}),
+    ],
+)
+def test_an_unreadable_pr_head_still_dispatches(
+    http: FakeHTTP, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, answer
+) -> None:
+    """Unknown is not stale. Every doubt resolves towards dispatching, because a
+    stale run costs tenant time and a wrongly-skipped head commit costs the PR
+    its e2e outright."""
+    out = _outputs(tmp_path, monkeypatch)
+    http.route("GET", "/pulls/3322", answer)
+    http.route("GET", "/git/ref/", (404, {"message": "Not Found"}))
+    http.route("POST", "/git/blobs", (201, {"sha": BLOB}))
+    http.route("POST", "/git/refs", (201, {"ref": REF}))
+    http.route("GET", "/matching-refs/", (200, [{"ref": REF}]))
+    http.route("GET", "/pulls?", (200, []))
+
+    assert main(_argv(**{"--pr-number": "3322"})) == 0
+
+    assert _read(out)["claimed"] == "true"
+
+
+@pytest.mark.parametrize("number", ["", "  ", "not-a-number"])
+def test_no_pr_number_skips_the_check_entirely(
+    http: FakeHTTP, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, number
+) -> None:
+    """The merge_group path. A queue entry's SHA is not any PR's head, so there
+    is nothing for it to fall behind — and asking would spend an API call to
+    learn that a 404 means "carry on"."""
+    out = _outputs(tmp_path, monkeypatch)
+    http.route("GET", "/git/ref/", (404, {"message": "Not Found"}))
+    http.route("POST", "/git/blobs", (201, {"sha": BLOB}))
+    http.route("POST", "/git/refs", (201, {"ref": REF}))
+    http.route("GET", "/matching-refs/", (200, [{"ref": REF}]))
+    http.route("GET", "/pulls?", (200, []))
+
+    assert main(_argv(**{"--pr-number": number})) == 0
+
+    assert _read(out)["state"] == "claimed"
+    assert http.count("GET", "/pulls/3322") == 0
+
+
+def test_the_stale_head_check_runs_before_the_claim(
+    http: FakeHTTP, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Order, not preference. Claiming first and standing down after would leave
+    a claim ref behind that no run will ever dispatch for, and the next
+    contender on that SHA would have to reap it."""
+    _outputs(tmp_path, monkeypatch)
+    http.route("GET", "/pulls/3322", (200, {"head": {"sha": _HEAD}}))
+
+    assert main(_argv(**{"--pr-number": "3322"})) == 0
+
+    assert http.count("POST", "/git/refs") == 0
+    assert http.count("POST", "/git/blobs") == 0
+
+
 def test_the_token_never_reaches_curls_command_line(http: FakeHTTP) -> None:
     """Anything else on the runner can read /proc/<pid>/cmdline while a request
     is in flight, so the credential goes through stdin (-K -) instead."""
@@ -831,6 +961,20 @@ def test_the_guard_uses_this_repos_own_token(action: dict) -> None:  # type: ign
     assert env["REPO"] == "${{ github.repository }}"
     assert env["SHA"] == "${{ inputs.check-sha }}"
     assert env["NAME"] == "${{ inputs.check-run-name }}"
+
+
+def test_the_pr_number_comes_from_the_event(action: dict) -> None:  # type: ignore[type-arg]
+    """Two properties in one expression. It must come from the EVENT, not an
+    input, or a caller could name a PR whose head has nothing to do with
+    `check-sha` — and the guard would then skip against a stranger's commit. And
+    it is empty on the merge_group path, which is exactly what disables the
+    stale-head check for a queue entry that has no PR head to fall behind."""
+    step = _step(action, "Claim the dispatch slot")
+    assert step["env"]["PR_NUMBER"] == "${{ github.event.pull_request.number }}"
+    assert "--pr-number" in step["run"], (
+        "the env var alone does nothing; without the flag the stale-head check "
+        "is silently off and every superseded commit fans out again"
+    )
 
 
 def test_the_caller_grants_what_the_guard_needs() -> None:

--- a/.github/scripts/tests/test_e2e_tenant_lease.py
+++ b/.github/scripts/tests/test_e2e_tenant_lease.py
@@ -22,6 +22,8 @@ from __future__ import annotations
 
 import base64
 import json
+import select
+import subprocess
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -1563,3 +1565,54 @@ def test_main_release_gives_back_the_whole_set(
 
     assert main(_argv_clouds("release", "aws,gcp")) == 0
     assert http.count("DELETE", "/git/refs/") == 2
+
+
+# --- the wait has to be visible while it is waiting ------------------------
+
+
+_LEASE_SCRIPT = (
+    Path(__file__).parent.parent.parent
+    / "actions"
+    / "e2e-tenant-lease"
+    / "e2e_tenant_lease.py"
+)
+
+
+def test_the_wait_log_streams_rather_than_arriving_at_exit() -> None:
+    """Python block-buffers stdout when it is a pipe, and an Actions log is
+    always a pipe. Without the import-time line-buffering this module sets, a run
+    that queued for ten minutes showed an EMPTY step for ten minutes and then
+    printed all ten minutes of "waiting for ..." at once — indistinguishable from
+    a wedged step, and duly read as a deadlock (FND-696).
+
+    Asserted through a real pipe rather than by reading the source: the property
+    is "the line arrives before the process does", and only a subprocess can say
+    that.
+    """
+    program = (
+        "import sys, time\n"
+        f"sys.path.insert(0, {str(_LEASE_SCRIPT.parent)!r})\n"
+        # Importing is the whole point: the buffering is configured at import,
+        # so nothing here may print before it.
+        "import e2e_tenant_lease  # noqa: F401\n"
+        "print('[1/180] waiting for the tenant')\n"
+        # Long enough that an exit flush cannot be what delivered the line.
+        "time.sleep(120)\n"
+    )
+    proc = subprocess.Popen(
+        [sys.executable, "-c", program],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        ready, _, _ = select.select([proc.stdout], [], [], 30)
+        assert ready, (
+            "nothing reached the log while the process was still running, so a "
+            "waiting lease is invisible for as long as it waits"
+        )
+        assert proc.stdout is not None
+        assert "waiting for the tenant" in proc.stdout.readline()
+    finally:
+        proc.kill()
+        proc.wait(timeout=30)

--- a/.github/scripts/tests/test_poll_check_runs_gate.py
+++ b/.github/scripts/tests/test_poll_check_runs_gate.py
@@ -557,6 +557,7 @@ def test_the_head_sha_keeps_waiting(monkeypatch):
         _http_response(403, None, {"message": "Resource not accessible"}),
         _http_response(500, None, {"message": "boom"}),
         _http_response(200, None, {"number": 3322}),
+        _completed_raw(200, "<html>proxy error</html>"),
     ],
 )
 def test_an_unreadable_pr_head_keeps_waiting(monkeypatch, pr_answer):

--- a/.github/scripts/tests/test_poll_check_runs_gate.py
+++ b/.github/scripts/tests/test_poll_check_runs_gate.py
@@ -8,6 +8,7 @@ import sys
 from pathlib import Path
 
 import pytest
+import yaml
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
@@ -463,3 +464,208 @@ def test_main_rejects_both_name_and_names_json(monkeypatch):
         assert False, "expected SystemExit (argparse mutually exclusive)"
     except SystemExit:
         pass
+
+
+# --- stopping early when the SHA stops mattering ---------------------------
+#
+# A missing check is waited out for the full 130min, because a connector can
+# legitimately take two hours to report. The one case where that wait is
+# knowably pointless: the dispatch guard declined to dispatch because this SHA
+# is no longer the PR's head, so nothing will ever create the checks (FND-696).
+# These tests pin the boundary — the wait ends only for a MISSING check on a
+# superseded SHA, and never on a doubt.
+
+_HEAD = "d47789e0"
+
+
+def _route(monkeypatch, *, pr_answer, check_runs):
+    """Answer the PR read and the check-run listing separately."""
+    seen = {"pulls": 0}
+
+    def fake_run(cmd, **kwargs):
+        url = cmd[-1]
+        if "/pulls/" in url:
+            seen["pulls"] += 1
+            return pr_answer
+        return _http_response(200, '"v1"', _check_runs_body(check_runs))
+
+    monkeypatch.setattr(mod, "run", fake_run)
+    return seen
+
+
+def test_a_superseded_sha_stops_waiting(monkeypatch):
+    _route(
+        monkeypatch,
+        pr_answer=_http_response(200, None, {"head": {"sha": _HEAD}}),
+        check_runs=[],
+    )
+    with pytest.raises(mod.Superseded) as raised:
+        mod.wait_for_checks(
+            REPO, SHA, NAMES, pr_number=3322, timeout_seconds=7800, sleep=lambda s: None
+        )
+    assert raised.value.head == _HEAD
+
+
+def test_a_superseded_sha_exits_zero_rather_than_failing(monkeypatch):
+    """Green without a verdict is normally the bug; here the commit is no longer
+    under review, so no verdict is required — and a red on an abandoned run is a
+    false alarm that automation reads as a real failure."""
+    _route(
+        monkeypatch,
+        pr_answer=_http_response(200, None, {"head": {"sha": _HEAD}}),
+        check_runs=[],
+    )
+    assert (
+        mod.main(
+            [
+                "--repo",
+                REPO,
+                "--sha",
+                SHA,
+                "--names-json",
+                json.dumps(NAMES),
+                "--pr-number",
+                "3322",
+            ]
+        )
+        == 0
+    )
+
+
+def test_the_head_sha_keeps_waiting(monkeypatch):
+    _route(
+        monkeypatch,
+        pr_answer=_http_response(200, None, {"head": {"sha": SHA}}),
+        check_runs=[],
+    )
+    ok = mod.wait_for_checks(
+        REPO,
+        SHA,
+        NAMES,
+        pr_number=3322,
+        interval_seconds=1,
+        timeout_seconds=2,
+        sleep=lambda s: None,
+    )
+    assert ok is False
+
+
+@pytest.mark.parametrize(
+    "pr_answer",
+    [
+        _http_response(404, None, {"message": "Not Found"}),
+        _http_response(403, None, {"message": "Resource not accessible"}),
+        _http_response(500, None, {"message": "boom"}),
+        _http_response(200, None, {"number": 3322}),
+    ],
+)
+def test_an_unreadable_pr_head_keeps_waiting(monkeypatch, pr_answer):
+    """Unknown is not superseded. Being wrong here abandons the wait for checks
+    that were genuinely on their way, which loses a real verdict."""
+    _route(monkeypatch, pr_answer=pr_answer, check_runs=[])
+    ok = mod.wait_for_checks(
+        REPO,
+        SHA,
+        NAMES,
+        pr_number=3322,
+        interval_seconds=1,
+        timeout_seconds=2,
+        sleep=lambda s: None,
+    )
+    assert ok is False
+
+
+def test_a_pending_check_is_never_abandoned(monkeypatch):
+    """The distinction that matters. A check that EXISTS has a connector run
+    behind it that will report; only a check that was never created can be known
+    to be never coming. A superseded SHA whose checks are all present must still
+    be waited out, or a real verdict is thrown away."""
+    seen = _route(
+        monkeypatch,
+        pr_answer=_http_response(200, None, {"head": {"sha": _HEAD}}),
+        check_runs=[{"name": n, "status": "in_progress"} for n in NAMES],
+    )
+    ok = mod.wait_for_checks(
+        REPO,
+        SHA,
+        NAMES,
+        pr_number=3322,
+        interval_seconds=1,
+        timeout_seconds=2,
+        sleep=lambda s: None,
+    )
+    assert ok is False
+    assert seen["pulls"] == 0, "a pending check must not even ask about the head"
+
+
+def test_no_pr_number_never_asks(monkeypatch):
+    """The merge_group path, unchanged: a queue entry's SHA is not any PR's head,
+    so asking would spend a call to learn that a 404 means "carry on"."""
+    seen = _route(
+        monkeypatch,
+        pr_answer=_http_response(200, None, {"head": {"sha": _HEAD}}),
+        check_runs=[],
+    )
+    ok = mod.wait_for_checks(
+        REPO, SHA, NAMES, interval_seconds=1, timeout_seconds=2, sleep=lambda s: None
+    )
+    assert ok is False
+    assert seen["pulls"] == 0
+
+
+def test_the_head_is_re_checked_periodically_not_every_poll(monkeypatch):
+    """A push can land mid-wait, so the question is asked again — but at one call
+    per five minutes, not one per poll: this token's budget is 1000 requests an
+    hour for the whole repository."""
+    seen = _route(
+        monkeypatch,
+        pr_answer=_http_response(200, None, {"head": {"sha": SHA}}),
+        check_runs=[],
+    )
+    mod.wait_for_checks(
+        REPO,
+        SHA,
+        NAMES,
+        pr_number=3322,
+        interval_seconds=1,
+        timeout_seconds=25,
+        sleep=lambda s: None,
+    )
+    # Attempt 1, then every tenth: 1, 10, 20 out of 25 attempts.
+    assert seen["pulls"] == 3
+
+
+# --- wiring: the caller has to pass it, and be allowed to ------------------
+
+
+def _connector_gate() -> dict:
+    workflow = Path(__file__).resolve().parents[2] / "workflows" / "pull_request.yaml"
+    return yaml.safe_load(workflow.read_text(encoding="utf-8"))["jobs"][
+        "connector-gate"
+    ]
+
+
+def _poll_step(job: dict) -> dict:
+    for step in job["steps"]:
+        if "poll_check_runs_gate.py" in str(step.get("run", "")):
+            return step
+    raise AssertionError("connector-gate no longer polls check runs")
+
+
+def test_the_gate_passes_the_pr_number_from_the_event() -> None:
+    """From the event, not an input: the number has to belong to the same PR as
+    the SHA being polled, or the early exit would fire against a stranger's
+    commit. Empty on merge_group, which is what leaves that path unchanged."""
+    step = _poll_step(_connector_gate())
+    assert step["env"]["PR_NUMBER"] == "${{ github.event.pull_request.number }}"
+    assert "--pr-number" in step["run"], (
+        "without the flag the early exit is silently off and a superseded run "
+        "waits out the full 130min for checks nobody will ever create"
+    )
+
+
+def test_the_gate_may_read_the_pull_request() -> None:
+    """A job-level permissions block REPLACES the workflow default rather than
+    merging with it, so dropping this does not fail loudly — the read 403s, the
+    poll warns, and it waits the full budget exactly as it used to."""
+    assert _connector_gate()["permissions"]["pull-requests"] == "read"

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -656,6 +656,11 @@ jobs:
     permissions:
       contents: read
       checks: read
+      # Reading this PR's current head, so a poll for checks that will never
+      # exist stops early. Missing, the read 403s, the poll warns and waits the
+      # full budget — the old behaviour, which is why this is easy to drop and
+      # never notice.
+      pull-requests: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -694,13 +699,19 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           MATRIX_JSON: ${{ needs.matrix-builder.outputs.matrix }}
           SHA: ${{ github.event_name == 'merge_group' && github.sha || github.event.pull_request.head.sha }}
+          # Lets this stop early instead of waiting out the full 130min for
+          # checks that will never exist: when SHA is no longer this PR's head,
+          # the dispatch guard declined to dispatch for it (FND-696). Empty on
+          # the merge_group path, which keeps the previous behaviour there.
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
           NAMES_JSON=$(jq -c '[.include[] | "Connector E2E run / " + .repo_name]' <<< "$MATRIX_JSON")
           python3 .github/scripts/poll_check_runs_gate.py \
             --repo "${{ github.repository }}" \
             --sha "$SHA" \
-            --names-json "$NAMES_JSON"
+            --names-json "$NAMES_JSON" \
+            --pr-number "$PR_NUMBER"
 
   # Real-cloud storage integration tests (S3 / Azure / GCS) — exercise
   # create_store_from_binding + CloudStore against real buckets/vaults using the

--- a/docs/standards/connector-ci-e2e.md
+++ b/docs/standards/connector-ci-e2e.md
@@ -87,11 +87,20 @@ Duplicate `PR Checks` runs still appear, and each still pays for its base-image
 build. That is accepted: it is cheap and it never reaches a tenant.
 
 Explicitly rejected: `concurrency: cancel-in-progress` on the dispatching
-workflow. The dispatch is fire-and-forget, so cancelling the SDK-side run
-orphans the connector run it already started rather than stopping it — and a
-cancelled connector run is not even safe, because `prepare-tenant` carries
-`if: always()` and finishes installing onto the tenants it had already leased on
-its way out.
+workflow. Once the dispatch has fired it achieves nothing — the dispatch is
+fire-and-forget, so cancelling the SDK-side run orphans the connector run it
+already started rather than stopping it, and a cancelled connector run is not
+even safe, because `prepare-tenant` carries `if: always()` and finishes
+installing onto the tenants it had already leased on its way out.
+
+That is not an argument that cancellation *never* helps, and the section below
+is the counter-example: for the ~8 minutes a run spends building the base image
+before it dispatches, cancelling it would have stopped the fan-out outright. It
+is still not the lever to reach for there — a run cancelled between creating its
+check run and dispatching leaves a check nothing will ever complete, and a
+queueing group holds exactly ONE pending run, so a third arrival is evicted with
+no log at all (FND-218). The head check below buys the same tenant time without
+either hazard.
 
 ### No dispatch for a commit the PR has moved past
 
@@ -124,10 +133,20 @@ from, and skips if it is not:
   automation reads as a real failure. Only the head commit's gate can satisfy a
   required check.
 
-It does **not** close the window where the stale run dispatched first — a push
-landing more than a couple of minutes behind the previous one. That case is a
-live connector run holding a lease it legitimately took, and the queue is the
-right answer to it.
+This closes the window up to the dispatch, and nothing after it. A push landing
+later leaves a connector run already in flight, and that run splits into two
+cases that want opposite answers:
+
+* It has **acquired a lease**. Nothing to be done: cancelling is unsafe for the
+  `prepare-tenant` reason above, so the queue is the right answer and the head
+  commit waits.
+* It has **dispatched but not leased yet** — it is still building, unit-testing
+  and integration-testing, which was 2m30s on the openapi leg of PR #3322
+  (dispatched 21:07:38, leased 21:10:10). It holds nothing, so it can stand down
+  for free, and the head commit takes the tenant instead.
+
+The second case is a connector-side check made immediately before the lease is
+taken, and it is tracked as FND-701.
 
 ## SDR composite action inputs
 

--- a/docs/standards/connector-ci-e2e.md
+++ b/docs/standards/connector-ci-e2e.md
@@ -93,6 +93,42 @@ cancelled connector run is not even safe, because `prepare-tenant` carries
 `if: always()` and finishes installing onto the tenants it had already leased on
 its way out.
 
+### No dispatch for a commit the PR has moved past
+
+The claim above keys on the SHA, which makes it blind by construction to the
+*sequential* duplicate: commit A's `PR Checks` run is still working its way
+towards the dispatch when commit B lands. Two SHAs, two uncontested claims, two
+full fan-outs — nothing duplicated in the CAS's terms, everything duplicated in
+the tenants'. The lease then behaves exactly as advertised and **queues**, so the
+head commit waits out the obsolete commit's entire install-plus-legs cycle. On
+PR #3322 that was 3m38s, 10m12s and 12m of pure lease wait across three
+connectors, all of it behind a commit already superseded by a bot push 59
+seconds later (FND-696).
+
+So the guard also asks whether `check-sha` is still the head of the PR it came
+from, and skips if it is not:
+
+* **One API call, on the `pull_request` path only.** A merge-queue entry's SHA is
+  not any PR's head and cannot fall behind, so `--pr-number` is empty there and
+  the check does not run.
+* **Skip, not cancel.** At that point the stale run has not dispatched yet, so
+  there is nothing to cancel — and cancelling a connector run that *has* started
+  is unsafe for the `prepare-tenant` reason above.
+* **Unreadable means "not superseded".** A stale run costs tenant time; a
+  wrongly-skipped head commit costs the PR its e2e outright.
+* The stale run's own `Connector Tests Gate` would otherwise wait 130 minutes for
+  a check nobody is going to create, so `poll_check_runs_gate.py` takes the same
+  `--pr-number` and stops as soon as it can see that its SHA is no longer the
+  head. It exits **0**: no verdict is required from a commit that is no longer
+  under review, and a red there is a false alarm on an abandoned run that
+  automation reads as a real failure. Only the head commit's gate can satisfy a
+  required check.
+
+It does **not** close the window where the stale run dispatched first — a push
+landing more than a couple of minutes behind the previous one. That case is a
+live connector run holding a lease it legitimately took, and the queue is the
+right answer to it.
+
 ## SDR composite action inputs
 
 ```yaml


### PR DESCRIPTION
## The tenant lease was working, and that was the problem

Reported as "the lease is deadlocked". It was not. It queued, FIFO, behind a legitimately-live holder — and the holder should never have existed.

On PR #3322 two `PR Checks` runs were live on two different head SHAs, 59 seconds apart:

| run | SHA | created |
|---|---|---|
| 32417548486 | `be82fad` | 21:04:59 |
| 32417635861 | `d47789e` | 21:05:58 (bot push) |

`PR Checks` has no workflow-level concurrency, so the older run was never cancelled. It reached its dispatch step at 21:07:53 — about two minutes *after* it was already obsolete — and fanned out to every connector repo anyway. The head commit's run dispatched 36 seconds behind it, and in each repo the two then serialised on the `(app, cloud)` lease:

| connector | lease wait | waiting on |
|---|---|---|
| openapi | 3m38s | stale run 32417801517 (its azure prepare failed, so it let go early) |
| mysql | 10m12s | stale run 32417800478 (ran its full e2e legs) |
| metabase | ~12m | stale run 32417796816 (ran its full e2e legs) |

Every holder released cleanly — mysql acquired all three leases at 21:20:51, metabase at ~21:22:30. Pure queueing, all of it behind a commit nobody was going to merge.

`e2e_dispatch_guard.py` could not see this. Its CAS keys on `(app, SHA)`, so two SHAs on one PR are two *uncontested* claims. It was built for the **simultaneous** duplicate — `opened` plus two `labeled e2e` events, one commit, FND-646 — and is blind by construction to the **sequential** one.

## Changes

**1. The guard skips a superseded SHA** (`e2e_dispatch_guard.py`, `e2e-apps/action.yaml`)

One extra API call on the `pull_request` path: if `check-sha` is no longer the head of the PR it came from, don't dispatch.

- **Skip, not cancel.** At that point the stale run has not dispatched yet, so there is nothing to cancel — and cancelling a connector run that *has* started is unsafe for the reason already documented here: `prepare-tenant` carries `if: always()` and finishes installing onto the tenants it had leased on its way out.
- **Unreadable means "not superseded".** A stale run costs tenant time; a wrongly-skipped head commit costs the PR its e2e outright. Every doubt resolves towards dispatching, matching the module's existing fail-open posture.
- Empty `--pr-number` on the `merge_group` path disables the check: a queue entry's SHA is not any PR's head and cannot fall behind.
- Runs *before* the CAS, so a run standing down leaves no claim ref for the next contender to reap.

**2. The gate stops waiting for checks that will never appear** (`poll_check_runs_gate.py`)

Skipping alone would have traded a 10-minute lease wait for a 2-hour zombie: the stale run's `Connector Tests Gate` would poll the full 130 minutes for a check nobody was going to create. It now takes the same `--pr-number` and stops as soon as it can see its SHA is superseded.

- **Exits 0.** "Green without a verdict" is normally the bug; here the commit is no longer under review, so no verdict is required from anyone. A red on an abandoned run is a recurring false alarm (a second push in quick succession is routine) that automation reads as a real failure. Only the head commit's gate can satisfy a required check.
- **Only ever asked about a MISSING check**, never a pending one — a check that exists has a connector run behind it that will report, and abandoning that wait throws away a real verdict.
- Re-asked at attempt 1 then every tenth (≈5 min), not every poll: this token's budget is 1000 requests/hour for the whole repository.
- `pull-requests: read` added to `connector-gate`. Without it the read 403s, the poll warns and waits the full budget — i.e. exactly the old behaviour, which is why a wiring test pins the grant.
- The `SystemExit` catch in `pr_head_sha` is load-bearing: `gh_api_conditional` raises on any ≥400, which is right for the check listing it was written for and exactly wrong for an optional optimisation. Without it a missing permission would kill the gate the first time it looked.

**3. The wait is visible while it is waiting** (`e2e_tenant_lease.py`, `poll_check_runs_gate.py`)

Neither poll loop flushed stdout. Python block-buffers stdout to a pipe, and an Actions log is always a pipe, so all seven `[n/180] waiting…` lines arrived with one identical timestamp when the process exited. A ten-minute queue showed a *blank step* for ten minutes and then dumped ten minutes of history at once — indistinguishable from a wedged step, which is precisely why this was read as a deadlock. Both now line-buffer at import, guarded with `hasattr` so a harness that replaced `sys.stdout` cannot make the lease unimportable (that would trade an invisible wait for an unserialised tenant).

## Not fixed, deliberately

The window where the stale run dispatched *before* the newer push landed — a push more than a couple of minutes behind the previous one. That case is a live connector run holding a lease it legitimately took, and the queue is the right answer to it.

Also considered and not done: `concurrency: cancel-in-progress` on `PR Checks`. It would have killed the stale run ~2 min before it dispatched and saved its base-image build too, but it introduces a narrow interleaving where a run cancelled between creating its check run and dispatching leaves a check nothing will ever complete. Worth its own change, not a rider on this one.

## Follow-up

FND-700 — one cloud's `Prepare tenant` failure still collapses every other cloud's legs. In the openapi run above, aws and gcp were installed and ready; azure's install failed and the entire `End-to-end` matrix was skipped, because the `e2e` job gates on the **aggregate** `needs.prepare-tenant.result`. Out of scope here.

## Testing

- `.github/scripts/tests/test_e2e_dispatch_guard.py` — superseded skips (and touches nothing else: one API call, total); the head SHA dispatches; a differently-cased head is not two commits; six unreadable shapes all dispatch; no PR number never asks; the check runs before the claim. Plus wiring: the number comes from the *event*, not an input, so a caller cannot make the guard skip against a stranger's commit.
- `.github/scripts/tests/test_poll_check_runs_gate.py` — superseded stops and exits 0; the head SHA keeps waiting; four unreadable shapes keep waiting; **a pending check is never abandoned, and does not even ask**; the head is re-checked periodically, not every poll. Plus the two wiring asserts.
- `.github/scripts/tests/test_e2e_tenant_lease.py` — the streaming test spawns a subprocess through a real pipe and `select`s on it, rather than reading the source: verified to fail (`assert []`) with the line-buffering removed, and pass with it.
- Full `.github/scripts/tests/` suite: 3095 passed. `pre-commit` clean on all changed files.

Security-relevant note for review: this touches `.github/workflows/pull_request.yaml` (one new `pull-requests: read` grant on `connector-gate`, one new env var + flag) and `.github/actions/e2e-apps/action.yaml`. No new permissions with write scope, no secret handling changed.
