### PR TITLE
ci: stop passing the org PAT as a Docker build-arg (FND-697)

### DIFF
--- a/.github/workflows/build-and-publish-app.yaml
+++ b/.github/workflows/build-and-publish-app.yaml
@@ -1248,13 +1248,18 @@ jobs:
           labels: |
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
-          build-args: |
-            ACCESS_TOKEN_USR=${{ github.actor }}
-            ACCESS_TOKEN_PWD=${{ secrets.ORG_PAT_GITHUB }}
-          # This job already logs into GHCR with the PAT above, so there's no
-          # benefit to minting a separate App token just for this BuildKit
-          # secret (Dockerfiles cloning a private git dependency, e.g.
-          # atlan-query-redaction) -- the PAT is already in play either way.
+          # The org PAT reaches the build ONLY as a BuildKit secret, never as a
+          # build arg. Build args are recorded in image config and are readable
+          # via `docker history` by anyone who can pull the image, so the
+          # `ACCESS_TOKEN_USR`/`ACCESS_TOKEN_PWD` args this step used to pass
+          # published the credential rather than merely using it (FND-697). A
+          # `--mount=type=secret` is never written to a layer or to history.
+          #
+          # Dockerfiles cloning a private git dependency (e.g. atlan-query-redaction)
+          # read it via `--mount=type=secret,id=git_token`. This job already logs
+          # into GHCR with the PAT above, so there's no benefit to minting a
+          # separate App token just for this -- the PAT is already in play either
+          # way.
           secrets: |
             git_token=${{ secrets.ORG_PAT_GITHUB }}
 

--- a/.github/workflows/build-and-scan.yaml
+++ b/.github/workflows/build-and-scan.yaml
@@ -105,16 +105,20 @@ jobs:
           cache-from: type=gha,scope=scan
           cache-to: type=gha,mode=max,scope=scan
           provenance: false
-          build-args: |
-            ACCESS_TOKEN_USR=${{ github.actor }}
-            ACCESS_TOKEN_PWD=${{ secrets.ORG_PAT_GITHUB }}
-          # Forward the org PAT as a BuildKit secret too, so Dockerfiles that clone a
-          # private git dependency via `--mount=type=secret,id=git_token` (e.g. apps
-          # pulling atlan-query-redaction) can authenticate during the scan build.
-          # Ignored by Dockerfiles that don't mount it, so it's a no-op for every other
-          # app. Mirrors the token the deploy/publish workflow already provides. This
-          # job already logs into GHCR with the PAT above, so there's no benefit to
-          # minting a separate App token just for this -- the PAT is already in play.
+          # The org PAT reaches the build ONLY as a BuildKit secret, never as a
+          # build arg. Build args are recorded in image config and are readable
+          # via `docker history` by anyone who can pull the image, so the
+          # `ACCESS_TOKEN_USR`/`ACCESS_TOKEN_PWD` args this step used to pass
+          # published the credential rather than merely using it (FND-697). A
+          # `--mount=type=secret` is never written to a layer or to history.
+          #
+          # Dockerfiles that clone a private git dependency (e.g. apps pulling
+          # atlan-query-redaction) read it via `--mount=type=secret,id=git_token`.
+          # Ignored by Dockerfiles that don't mount it, so it's a no-op for every
+          # other app. Mirrors the token the deploy/publish workflow provides.
+          # This job already logs into GHCR with the PAT above, so there's no
+          # benefit to minting a separate App token just for this -- the PAT is
+          # already in play.
           secrets: |
             git_token=${{ secrets.ORG_PAT_GITHUB }}
 

--- a/.github/workflows/build-apps-image.yaml
+++ b/.github/workflows/build-apps-image.yaml
@@ -213,9 +213,21 @@ jobs:
           labels: |
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
-          build-args: |
-            ACCESS_TOKEN_USR=${{ github.actor }}
-            ACCESS_TOKEN_PWD=${{ secrets.ORG_PAT_GITHUB }}
+          # The org PAT reaches the build ONLY as a BuildKit secret, never as a
+          # build arg. Build args are recorded in image config and are readable
+          # via `docker history` by anyone who can pull the image, so the
+          # `ACCESS_TOKEN_USR`/`ACCESS_TOKEN_PWD` args this step used to pass
+          # published the credential rather than merely using it (FND-697). A
+          # `--mount=type=secret` is never written to a layer or to history.
+          #
+          # Dockerfiles cloning a private git dependency (e.g. atlan-query-redaction)
+          # read it via `--mount=type=secret,id=git_token`; this is the same id
+          # build-and-publish-app.yaml and build-and-scan.yaml already provide, so
+          # an app builds identically down either path. Ignored by Dockerfiles that
+          # don't mount it. This job already logs into GHCR with the PAT above, so
+          # there's no benefit to minting a separate App token just for this.
+          secrets: |
+            git_token=${{ secrets.ORG_PAT_GITHUB }}
 
   # ── Job 3: Merge arch digests into a single multi-arch manifest ───────────────
   merge:

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -85,12 +85,17 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
 
+      # GHCR for a package owned by this same repo needs nothing beyond the
+      # job's own GITHUB_TOKEN plus `packages: write` (declared at the top of
+      # this file) -- the org PAT was strictly more privilege than the push
+      # requires. This workflow is not reusable and has no external callers, so
+      # the token is always application-sdk's own.
       - name: Login to GitHub Registry
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.ORG_PAT_GITHUB }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Log in to Chainguard Container Registry
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
@@ -119,13 +124,14 @@ jobs:
           # Arch-suffixed — merged into the real tag by merge-ghcr below.
           tags: |
             ghcr.io/atlanhq/app-runtime-base-${{ needs.prepare.outputs.lowercase_branch }}:sha-${{ needs.prepare.outputs.sha }}-${{ matrix.arch }}
-          build-args: |
-            ACCESS_TOKEN_USR=$GITHUB_ACTOR
-            ACCESS_TOKEN_PWD=${{ secrets.ORG_PAT_GITHUB }}
-          # This job already logs into GHCR with ORG_PAT_GITHUB above, so
-          # there's no benefit to minting a separate App token just for this
-          # generic GHA-cache-API auth -- the PAT is already in play either way.
-          github-token: ${{ secrets.ORG_PAT_GITHUB }}
+          # No `build-args` here on purpose. Build args are recorded in image
+          # config and are readable via `docker history` by anyone who can pull
+          # the image, so a credential passed that way is published, not just
+          # used (FND-697). This Dockerfile is a single `FROM` and needs no
+          # credential at all; a Dockerfile that does should mount one with
+          # `RUN --mount=type=secret`, which BuildKit keeps out of every layer,
+          # and be fed via the `secrets:` input rather than `build-args`.
+          github-token: ${{ secrets.GITHUB_TOKEN }}
         env:
           DOCKER_CLIENT_TIMEOUT: 600
           COMPOSE_HTTP_TIMEOUT: 600
@@ -142,12 +148,13 @@ jobs:
       - name: Set up Buildx
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
 
+      # Same-repo GHCR push -- see the note on the push-to-ghcr login above.
       - name: Login to GitHub Registry
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.ORG_PAT_GITHUB }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create and push multi-arch manifest
         env:

--- a/docs/standards/ci.md
+++ b/docs/standards/ci.md
@@ -168,6 +168,54 @@ it, or kept out of that file in the first place.
 `export_extra_env.py` and `test_export_extra_env.py` are the worked example,
 including a static check that every call site masks before it writes.
 
+## Never pass a credential as a Docker `build-arg`
+
+**Rule:** a step that builds an image must not put a token, password, or key in
+`build-args:`. Feed it through `secrets:` instead, and have the Dockerfile read
+it with `RUN --mount=type=secret`.
+
+```yaml
+# WRONG — publishes the credential with the image
+build-args: |
+  ACCESS_TOKEN_PWD=${{ secrets.ORG_PAT_GITHUB }}
+
+# RIGHT — the value is available during the RUN and nowhere after it
+secrets: |
+  git_token=${{ secrets.ORG_PAT_GITHUB }}
+```
+
+```dockerfile
+RUN --mount=type=secret,id=git_token,uid=1000 \
+    UV_GIT_TOKEN="$(cat /run/secrets/git_token)" \
+    uv sync --frozen --no-dev
+```
+
+**Why:** a build arg is not a build-time-only variable. BuildKit records the
+`ARG` name *and its value* in the image config, so `docker history <image>`
+prints it back to anyone who can pull the image — no repo access, no Actions
+log access, no runner access needed. The credential is published as part of the
+artifact, and it stays published in every tag ever built that way; deleting the
+workflow line does not retract the images. `::add-mask::` does not help here for
+the same reason it does not help with artifacts: it rewrites the log stream, not
+bytes written elsewhere.
+
+A `--mount=type=secret` is exposed as a tmpfs file for the duration of one `RUN`
+and is not part of that layer, the image config, or the history. It is also the
+only form that survives layer caching correctly: a build arg changes the cache
+key, so rotating the credential invalidates every layer after the `ARG`.
+
+**Migrating a consumer:** `build-args` and `secrets` are not interchangeable at
+the Dockerfile end, so the two sides have to move together. Land the Dockerfile
+change first — a Dockerfile that mounts `git_token` ignores an
+`ACCESS_TOKEN_PWD` build arg it no longer reads, so it builds green under both
+the old and the new workflow — then drop the build arg from the workflow. Doing
+it the other way round leaves the build with an empty credential, and `uv sync`
+against a private git dependency fails on the next build rather than at merge.
+
+**Scope note:** this covers credentials only. Non-secret build inputs — a
+version string, a target arch, a base-image reference — are what `build-args`
+are for, and recording those in image history is a feature.
+
 ## Renovate post-upgrade commands
 
 Two run today, both installed as bare PATH commands by `.github/workflows/renovate.yaml`


### PR DESCRIPTION
Four build workflows passed a credential to `docker/build-push-action` as
`build-args: ACCESS_TOKEN_USR/ACCESS_TOKEN_PWD`. BuildKit records an ARG's name
*and value* in the image config, so `docker history` prints it back to anyone who
can pull the image — no repo access, no Actions log access needed. That published
the credential as part of every image these workflows built, and it stays
published in every tag already built that way.

Tracked as FND-697.

## What changed

| Workflow | External callers | Change |
|---|---|---|
| `build-and-scan.yaml` | 123 | args dropped — already fed `secrets: git_token=` |
| `build-and-publish-app.yaml` | 210 | args dropped — already fed `secrets: git_token=` |
| `build-apps-image.yaml` | 2 | args dropped, **added** `secrets: git_token=` |
| `build-image.yaml` | 0 | args dropped outright; GHCR logins + GHA-cache token → `GITHUB_TOKEN` |

Two of the four already carried the same token through `secrets: git_token=`,
which BuildKit exposes as a tmpfs file for the duration of one `RUN` and never
writes to a layer or to history. For those the build args were pure redundancy —
the credential was already reaching the build by the safe path, and removing the
unsafe one changes nothing about what builds.

`build-apps-image.yaml` had no `secrets:` block, so it gains the same `git_token`
id the other two publish paths use. An app now builds identically down either
path.

`build-image.yaml` builds this repo's own Dockerfile, which is a single
`FROM cgr.dev/atlan.com/app-framework-golden:3.13` and needs no credential at
all, so its args are dropped rather than converted.

## Why `GITHUB_TOKEN` only in `build-image.yaml`

That file is not a reusable workflow and has no callers outside this repo, it
already declares `packages: write`, and its target is a package owned by this
same repo — so the org PAT was strictly more privilege than the push requires.

The three fleet-wide workflows keep the PAT for registry login on purpose. In a
reusable workflow `secrets.GITHUB_TOKEN` is the *caller's* token, capped by the
caller's `permissions:` block; any of the ~100 callers sitting on the default
would start failing at publish time. That swap needs a per-caller permission
audit and a per-package GHCR linkage check, so it gets its own ticket and a
canary. It is also a least-privilege improvement rather than a leak fix — a
registry login credential is not recorded in the image.

## Consumer impact

`atlan-snowflake-app` and `atlan-bigquery-app` already read the credential via
`--mount=type=secret,id=git_token` and only mention `ACCESS_TOKEN_PWD` in a
comment, so they are unaffected.

`atlan-auth-app` still has `ARG ACCESS_TOKEN_PWD` feeding `UV_GIT_TOKEN`, and
calls both `build-and-publish-app.yaml` and `build-and-scan.yaml`. It needs
atlanhq/atlan-auth-app#63 to land first — that change is green
under both the old and the new workflow, so it can merge independently and in
either order relative to this.

No other consumer Dockerfile in the org reads these args: of the 7 that do,
4 (`hagrid`, `heimdall`, `heracles`, `atlan-admission-controller`) are platform
repos with their own CI and are untouched by this.

## Blast radius

`atlanhq` has 1012 GHCR container packages, of which exactly 2 are public, and
neither is built by these workflows. Every app package checked is private and
linked to its own repo. No anonymously-public `atlanhq/<app>` Docker Hub
repository was found. So the exposure on the paths this repo owns is
org-wide-pull rather than internet-wide — which lowers the urgency of the
rotation without changing that the credential should be treated as compromised.

## Docs

Adds a `docs/standards/ci.md` section stating the rule, why a build arg is not a
build-time-only variable, and the migration ordering that keeps a consumer green
across the change (Dockerfile first, then the workflow — a Dockerfile that mounts
`git_token` ignores a build arg it no longer reads).

## Verification

- Repo-wide grep for `ACCESS_TOKEN_PWD` returns only the new explanatory comments.
- All four workflows parse.
- `pre-commit run --files <changed>` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
