### PR TITLE
ci(stale): move the starter workflow off the org PAT (FND-698)

### DIFF
--- a/.github/workflow-templates/stale.yml
+++ b/.github/workflow-templates/stale.yml
@@ -18,9 +18,15 @@ jobs:
       pull-requests: write
 
     steps:
+    # No repo-token: actions/stale defaults to the job's GITHUB_TOKEN, which is
+    # all this needs -- every API call it makes is against the current repo. On
+    # Enterprise Cloud that token draws on a 15,000/hr per-repo budget, whereas
+    # an org PAT draws on one shared 5,000/hr budget for every repo using it.
+    # A stale bot enumerates every open issue and PR on each scheduled run, so
+    # it is one of the hungriest things to point at a shared budget. The
+    # `permissions:` block above grants the writes it needs to label and comment.
     - uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93 # v11
       with:
-        repo-token: ${{ secrets.ORG_PAT_GITHUB }}
         stale-issue-message: 'Stale issue'
         stale-pr-message: 'Stale pull request'
         stale-issue-label: 'Stale'


### PR DESCRIPTION
## What

`.github/workflow-templates/stale.yml` passed `secrets.ORG_PAT_GITHUB` as
`actions/stale`'s `repo-token`. Dropped — the action's default is the job's own
`GITHUB_TOKEN`, which is what this needed all along, since every API call it
makes is against the current repo.

The job already declares `issues: write` / `pull-requests: write`, so no
`permissions:` change is required. Added a comment recording why the line must
not come back.

## Why this one

The org PAT draws on one shared **5,000/hr** budget across every repo using it;
`GITHUB_TOKEN` gets **15,000/hr per repo** on Enterprise Cloud. A stale bot
enumerates every open issue and PR on each scheduled run, making it one of the
hungriest things to point at a shared budget — and the job is entirely
repo-local, so the PAT bought nothing.

This file is the GitHub *starter-workflow* surface (the Actions "New workflow"
UI), so the fix also stops newly scaffolded repos inheriting the PAT.

## Fleet copies

Full inventory at untruncated search depth: 36 files across `atlanhq` reference
`actions/stale`. Three still carried `ORG_PAT_GITHUB`, each now has a PR:

- atlanhq/atlan-frontend#30967
- atlanhq/atlan-publish-app#957
- atlanhq/atlan-docs#1460 (hand-rolled `actions/github-script` loop rather than
  `actions/stale`, same PAT, same fix)

The remaining 30 already route through this repo's reusable
`.github/workflows/stale.yml` (fleet App token, `GITHUB_TOKEN` fallback) or pass
`GITHUB_TOKEN` directly.

Out of scope, flagged for follow-up: `atlanhq/atlan` and
`atlanhq/marketplace-packages` pass *personal* PATs (`my_pat`,
`AMIT_GH_PAT_TOKEN`) to their stale jobs — same class of problem, different
secret.

## Verification

Search depth was checked against the cap per FND-698's own warning: 36 results
against a limit of 100, so the inventory is not truncated. Template YAML parses;
pre-commit clean.

Closes FND-698.
