### PR TITLE
ci(e2e): stand a superseded connector run down before it takes a tenant (FND-701)

### DIFF
--- a/.github/actions/e2e-dispatch-recheck/action.yaml
+++ b/.github/actions/e2e-dispatch-recheck/action.yaml
@@ -1,0 +1,78 @@
+name: E2E dispatch recheck
+description: |
+  Ask whether the application-sdk commit this connector run was dispatched for is
+  still the head of the pull request it came from, immediately before the run
+  queues for a tenant (FND-701).
+
+  The SDK-side guard (e2e_dispatch_guard.py, FND-696) drops a dispatch whose SHA
+  has already been superseded, but it can only see the window up to the dispatch.
+  This covers the window after it — the couple of minutes a dispatched connector
+  run spends building and testing before it reaches `lease-tenant`, holding
+  nothing. Standing down there hands the tenant straight to the live commit
+  instead of making it wait out a full install-plus-legs cycle.
+
+  Consumed at @main by every connector, deliberately and for the same reason the
+  tenant lease is: the claim-ref layout this reads has to match the one the
+  dispatching SDK run wrote, so the protocol must not vary with whichever ref a
+  caller happened to check out.
+
+  Needs no permissions beyond reading a public repository. `github.token` in a
+  connector repo can read application-sdk's refs, blobs and pull requests
+  because application-sdk is public; the check disables itself with a warning
+  rather than failing if that ever stops being true.
+
+inputs:
+  sdk-ref:
+    description: |
+      The `application_sdk_ref` this run was dispatched with. Anything that is
+      not a full 40-character commit sha disables the check — the connector's own
+      pull_request/push runs pass empty, and a branch name has no fixed head to
+      fall behind.
+    required: false
+    default: ""
+  app:
+    description: |
+      This connector's repository name (e.g. atlan-openapi-app). It is the `app`
+      component of the dispatch claim ref the SDK wrote, so it must be the REPO
+      name and not the short app-name — `github.repository` minus the owner is
+      the reliable source, since that is what the SDK's dispatch matrix keys on.
+    required: true
+  sdk-repo:
+    description: Repository holding the dispatch claim and the pull request.
+    required: false
+    default: atlanhq/application-sdk
+  github-token:
+    description: |
+      Token used for the reads. Defaults to the calling job's own
+      `github.token`, which is sufficient: every read is of public data in
+      another repository.
+    required: false
+    default: ""
+
+outputs:
+  superseded:
+    description: |
+      "true" only when the dispatching pull request has been positively shown to
+      point at a different head. Every other outcome — no claim record, an
+      unreadable answer, a ref that is not a commit sha — is "false", because
+      wrongly standing down denies a live commit its e2e outright while wrongly
+      carrying on merely costs the tenant time this was written to save.
+    value: ${{ steps.recheck.outputs.superseded }}
+
+runs:
+  using: composite
+  steps:
+    - name: Recheck the dispatched SDK ref
+      id: recheck
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token || github.token }}
+        SDK_REPO: ${{ inputs.sdk-repo }}
+        SDK_REF: ${{ inputs.sdk-ref }}
+        APP: ${{ inputs.app }}
+      run: |
+        set -euo pipefail
+        python3 "${{ github.action_path }}/e2e_dispatch_recheck.py" \
+          --sdk-repo "$SDK_REPO" \
+          --sdk-ref "$SDK_REF" \
+          --app "$APP"

--- a/.github/actions/e2e-dispatch-recheck/e2e_dispatch_recheck.py
+++ b/.github/actions/e2e-dispatch-recheck/e2e_dispatch_recheck.py
@@ -1,0 +1,312 @@
+"""Does the SDK commit this connector run was dispatched for still exist?
+
+Why this exists
+---------------
+``application-sdk``'s ``e2e_dispatch_guard.py`` drops a dispatch whose SHA is no
+longer the head of its PR (FND-696). It can only see the window up to the
+dispatch. A push landing after that leaves a connector run already in flight for
+a commit nobody is going to merge, and that run splits into two cases:
+
+* It has **acquired a tenant lease**. Nothing to be done. Cancelling it is unsafe
+  — ``prepare-tenant`` carries ``if: always()`` and finishes installing onto the
+  tenants it had leased on its way out — so the queue is the right answer and the
+  head commit waits.
+* It has **dispatched but not leased yet**: still building the image, running
+  unit and integration tests. On the openapi leg of application-sdk PR #3322 that
+  was 2m30s (dispatched 21:07:38, leased 21:10:10). It holds nothing, so it can
+  stand down for free, and the head commit takes the tenant instead of queueing
+  behind a full install-plus-legs cycle.
+
+This closes the second case. It runs immediately before ``lease-tenant`` and its
+answer gates the lease, the install and the legs (FND-701).
+
+How it identifies the PR
+------------------------
+The connector run is handed a SHA (``application_sdk_ref``) and nothing else. It
+is NOT told which application-sdk PR that SHA came from, and it cannot work it
+out from the SHA alone: ``GET /commits/{sha}/pulls`` returns an EMPTY list for a
+commit a force-push has moved past, which is precisely the case that matters.
+Verified against the incident SHA itself — ``be82fade`` on PR #3322 is associated
+with no pull request, while the head that replaced it resolves normally.
+
+So the PR number is read from the record that authorised the dispatch in the
+first place. ``e2e_dispatch_guard.py`` claims ``refs/e2e-dispatch/<app>/<sha>``
+before dispatching, pointed at a blob describing the claim; that blob now carries
+``pr_number``. Reading it back is a positive identification rather than an
+inference, and it costs nothing to keep alive: the guard's prune only deletes a
+claim once that SHA's ``Connector E2E run / <app>`` check has settled, which
+cannot happen while this run is the thing that has yet to complete it.
+
+A run with no claim ref is therefore not an SDK pull-request dispatch at all —
+someone pinning ``application_sdk_ref`` by hand to test a connector against a
+particular SDK commit — and is left alone. That is what keeps a manual run from
+being silently skipped for a commit that was never a PR head.
+
+Fail-open, in every direction
+-----------------------------
+Every unreadable answer means "not superseded". The two costs are wildly
+asymmetric: standing down wrongly denies a live commit its e2e outright, while
+failing to stand down costs the tenant time this was written to save — which is
+also exactly the pre-existing behaviour. So this exits 0 always, writes
+``superseded=false`` on any doubt, and never fails the job it runs in.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(line_buffering=True)
+
+_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+# Mirrors e2e_dispatch_guard.REF_NAMESPACE. Duplicated rather than imported: the
+# two live in different actions and only a connector repo consumes this one, so
+# an import would mean shipping the guard to every connector. A test pins the
+# pair equal so they cannot drift apart silently.
+REF_NAMESPACE = "e2e-dispatch"
+
+
+@dataclass(frozen=True)
+class Response:
+    status: int
+    body: object | None
+
+
+def run(cmd: list[str], **kwargs) -> subprocess.CompletedProcess:
+    """Single seam so tests can stub the HTTP client."""
+    return subprocess.run(cmd, **kwargs)
+
+
+def gh_request(path: str) -> Response:
+    """GET the GitHub API, returning the status rather than raising on 4xx.
+
+    curl rather than ``gh api`` for the same reason the lease uses it: ``gh api``
+    treats a non-2xx as a command failure and prints its own diagnostic instead
+    of the response, and here a 404 is a legitimate answer ("no claim record")
+    rather than an error.
+
+    No retry loop, unlike the lease's client. Every failure resolves to "carry on
+    as before", so a blip costs a saved lease rather than a run — and a retry
+    budget in front of the tenant queue would be paid on the happy path too.
+    """
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN") or ""
+    cmd = [
+        "curl",
+        "-sS",
+        "-i",
+        "--max-time",
+        "30",
+        # Authorization comes in through stdin (-K -) rather than argv, so the
+        # token is never visible in /proc/<pid>/cmdline to anything else sharing
+        # the runner. Same handling as the lease client.
+        "-K",
+        "-",
+        "-H",
+        "Accept: application/vnd.github+json",
+        "-H",
+        "X-GitHub-Api-Version: 2022-11-28",
+        f"https://api.github.com/{path}",
+    ]
+    config = f'header = "Authorization: Bearer {token}"\n' if token else ""
+    result = run(cmd, input=config, capture_output=True, text=True, check=False)
+    if result.returncode != 0:
+        print(f"::warning::curl failed for GET {path}: {result.stderr.strip()}")
+        return Response(0, None)
+
+    text = result.stdout.replace("\r\n", "\n")
+    header_block, _, body = text.partition("\n\n")
+    lines = header_block.splitlines()
+    try:
+        status = int(lines[0].split()[1])
+    except (IndexError, ValueError):
+        print(f"::warning::could not parse a status line for GET {path}")
+        return Response(0, None)
+    if not body.strip():
+        return Response(status, None)
+    try:
+        return Response(status, json.loads(body))
+    except json.JSONDecodeError:
+        # An HTML error page from a proxy must not crash the caller before it can
+        # see the status code, which is the part that decides what happens next.
+        return Response(status, None)
+
+
+def claim_ref(app: str, sha: str) -> str:
+    """The ref ``e2e_dispatch_guard.claim_ref`` wrote before dispatching this.
+
+    The guard runs the app through its own ``slug()`` before building the ref, and
+    this deliberately does not reimplement it. Every rule in that function —
+    unsafe-character mapping, ``..`` collapsing, ``.lock`` stripping — exists for
+    a free-text workflow input, and none of them can fire on a GitHub repository
+    name, whose own character set is already a subset of what slug() permits.
+    Copying the rules here would be dead code that could still drift; a test
+    instead asserts the two agree on every connector repo name in the fleet.
+
+    Case is the one thing that CAN differ (slug lowercases, a repo name need
+    not), so it is handled.
+    """
+    return f"refs/{REF_NAMESPACE}/{app.strip().lower()}/{sha}"
+
+
+def claim_blob_sha(repo: str, app: str, sha: str) -> str | None:
+    """The blob the dispatch claim for ``(app, sha)`` points at, or None.
+
+    None covers both "no claim exists" (a hand-pinned run, or a claim already
+    pruned) and "the claim could not be read". Neither is evidence of anything,
+    so both leave the run to proceed.
+    """
+    ref = claim_ref(app, sha)
+    response = gh_request(f"repos/{repo}/git/ref/{ref.removeprefix('refs/')}")
+    if response.status == 404:
+        print(
+            f"No dispatch claim at {ref}, so this run was not dispatched by an "
+            "application-sdk pull request. Proceeding."
+        )
+        return None
+    if response.status >= 400 or not isinstance(response.body, dict):
+        print(f"::warning::could not read {ref} (HTTP {response.status}). Proceeding.")
+        return None
+    target = response.body.get("object")
+    blob = target.get("sha") if isinstance(target, dict) else None
+    return blob if isinstance(blob, str) and blob else None
+
+
+def claim_pr_number(repo: str, blob_sha: str) -> int | None:
+    """The PR number recorded in a dispatch claim, or None if it has none.
+
+    A claim written before the guard started recording ``pr_number`` reads as
+    None and is left alone, which is what lets this ship without being in
+    lockstep with the guard change that writes the field.
+    """
+    response = gh_request(f"repos/{repo}/git/blobs/{blob_sha}")
+    if response.status >= 400 or not isinstance(response.body, dict):
+        print(
+            f"::warning::could not read the dispatch claim record {blob_sha} "
+            f"(HTTP {response.status}). Proceeding."
+        )
+        return None
+    content = response.body.get("content")
+    if not isinstance(content, str):
+        return None
+    try:
+        record = json.loads(base64.b64decode(content))
+    except (ValueError, json.JSONDecodeError):
+        print(f"::warning::the dispatch claim record {blob_sha} is not JSON.")
+        return None
+    number = record.get("pr_number") if isinstance(record, dict) else None
+    # bool is an int in Python, and `pr_number: true` must not read as PR #1.
+    if isinstance(number, bool) or not isinstance(number, int) or number <= 0:
+        return None
+    return number
+
+
+def pr_head_sha(repo: str, number: int) -> str | None:
+    """The head SHA that PR currently points at, or None if it is unreadable."""
+    response = gh_request(f"repos/{repo}/pulls/{number}")
+    if response.status >= 400 or not isinstance(response.body, dict):
+        print(
+            f"::warning::could not read {repo}#{number} (HTTP {response.status}). "
+            "Proceeding."
+        )
+        return None
+    head = response.body.get("head")
+    if not isinstance(head, dict) or not isinstance(head.get("sha"), str):
+        return None
+    return head["sha"].strip().lower()
+
+
+def is_superseded(repo: str, app: str, sha: str) -> bool:
+    """Has the PR that dispatched ``sha`` moved on to a different head?"""
+    blob = claim_blob_sha(repo, app, sha)
+    if blob is None:
+        return False
+    number = claim_pr_number(repo, blob)
+    if number is None:
+        print(
+            "The dispatch claim records no pull request, so this SHA cannot be "
+            "compared against a head. Proceeding."
+        )
+        return False
+    head = pr_head_sha(repo, number)
+    if head is None or head == sha:
+        return False
+    print(
+        f"::notice::{sha[:8]} is no longer the head of {repo}#{number} "
+        f"({head[:8]} is), so this run is testing a commit that has been "
+        "superseded. Standing down before the tenant lease rather than making "
+        "the live commit queue behind it."
+    )
+    return True
+
+
+def write_output(superseded: bool, path: str | None) -> None:
+    if not path:
+        return
+    with open(path, "a", encoding="utf-8") as handle:
+        handle.write(f"superseded={'true' if superseded else 'false'}\n")
+
+
+def summarise(line: str) -> None:
+    path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not path:
+        return
+    with open(path, "a", encoding="utf-8") as handle:
+        handle.write(line + "\n")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Recheck a dispatched SDK ref.")
+    parser.add_argument(
+        "--sdk-repo",
+        default="atlanhq/application-sdk",
+        help="The repository the dispatch claim and the pull request live in.",
+    )
+    parser.add_argument(
+        "--sdk-ref",
+        required=True,
+        help="The application_sdk_ref this run was dispatched with. Anything "
+        "that is not a full commit sha disables the check: a branch name has no "
+        "fixed head to fall behind.",
+    )
+    parser.add_argument(
+        "--app",
+        required=True,
+        help="This connector's repository name (e.g. atlan-openapi-app), which "
+        "is the app component of the dispatch claim ref.",
+    )
+    args = parser.parse_args(argv)
+
+    sha = args.sdk_ref.strip().lower()
+    app = args.app.strip()
+    superseded = False
+
+    if not _SHA_RE.match(sha):
+        # Empty on the connector's own pull_request/push runs, and a branch name
+        # when someone pins the SDK by branch. Neither names a commit that can be
+        # superseded, so there is nothing to ask.
+        print(f"--sdk-ref {args.sdk_ref!r} is not a commit sha; nothing to check.")
+    elif not app:
+        print("::warning::--app is empty, so the dispatch claim cannot be located.")
+    else:
+        superseded = is_superseded(args.sdk_repo, app, sha)
+
+    if superseded:
+        summarise(
+            f"- **e2e stood down**: `{sha[:8]}` is no longer the head of the "
+            f"`{args.sdk_repo}` pull request that dispatched this run, so the "
+            "tenant is left to the commit that is."
+        )
+    write_output(superseded, os.environ.get("GITHUB_OUTPUT"))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/.github/actions/verify-test-gate/action.yaml
+++ b/.github/actions/verify-test-gate/action.yaml
@@ -72,6 +72,24 @@ inputs:
   e2e-result:
     description: needs.e2e.result (matrix aggregate; skipped = not requested).
     required: true
+  superseded:
+    description: |
+      needs.sdk-head-recheck.outputs.superseded — "true" when the run stood its
+      e2e down because the application-sdk commit it was dispatched for is no
+      longer the head of the PR that dispatched it (FND-701).
+
+      That stand-down produces the exact shape of the "matrix skipped despite
+      discovered suites" anomaly: a successful discovery, a skipped matrix, and
+      no install-path failure to explain it. Without this input the gate reds and
+      `report-to-sdk` mirrors conclusion=failure onto the dispatching SDK commit
+      — "your change broke the connector" for a run that deliberately stood down,
+      which is the misattribution the cancelled/failure split exists to prevent.
+
+      Only the literal "true" explains the skip. Optional, defaulting to "false",
+      so callers pinned at @main that have not wired the recheck job keep the
+      previous behaviour — and so an unexplained skip stays an anomaly.
+    required: false
+    default: "false"
 
 outputs:
   passed:
@@ -122,6 +140,7 @@ runs:
         LEASE_TENANT_RESULT: ${{ inputs.lease-tenant-result }}
         PREPARE_TENANT_RESULT: ${{ inputs.prepare-tenant-result }}
         E2E_RESULT: ${{ inputs.e2e-result }}
+        SUPERSEDED: ${{ inputs.superseded }}
       run: |
         set -euo pipefail
         python3 "${{ github.action_path }}/verify_test_gate.py" \
@@ -134,4 +153,5 @@ runs:
           --merge-e2e-image "$MERGE_E2E_IMAGE_RESULT" \
           --lease-tenant "$LEASE_TENANT_RESULT" \
           --prepare-tenant "$PREPARE_TENANT_RESULT" \
-          --e2e "$E2E_RESULT" >> "$GITHUB_OUTPUT"
+          --e2e "$E2E_RESULT" \
+          --superseded "$SUPERSEDED" >> "$GITHUB_OUTPUT"

--- a/.github/actions/verify-test-gate/verify_test_gate.py
+++ b/.github/actions/verify-test-gate/verify_test_gate.py
@@ -131,6 +131,27 @@ def _install_path(
     ]
 
 
+def stood_down(superseded: str) -> bool:
+    """Did the run deliberately abandon e2e because its SDK commit is stale?
+
+    The connector-side recheck (``e2e-dispatch-recheck``, FND-701) skips
+    ``lease-tenant`` and the e2e legs when the application-sdk commit under test
+    is no longer the head of the PR that dispatched the run. That produces the
+    exact shape the matrix-skipped anomaly below exists to catch — a successful
+    discovery with a skipped matrix and no install-path failure to explain it —
+    so without an explanation the gate would red, and ``report-to-sdk`` would
+    mirror ``conclusion=failure`` onto the dispatching SDK commit: "your change
+    broke the connector" for a run that was deliberately stood down. Precisely
+    the misattribution the cancelled/failure split exists to prevent (FND-218).
+
+    Anything other than the literal "true" is False, and the anomaly still fires.
+    A stand-down has to be positively asserted by the job that decided it; an
+    absent, empty or unparseable value means the skip is still unexplained, which
+    is the state worth reddening.
+    """
+    return superseded.strip().lower() == "true"
+
+
 def evaluate(
     unit: str,
     integration: str,
@@ -142,6 +163,7 @@ def evaluate(
     merge_e2e_image: str = "skipped",
     prepare_tenant: str = "skipped",
     lease_tenant: str = "skipped",
+    superseded: str = "false",
 ) -> list[str]:
     """Return human-readable failure reasons (empty ⇒ the gate passes).
 
@@ -197,8 +219,14 @@ def evaluate(
     # Suppressed when an install-path job already failed: that IS the explanation
     # for the skip, and it is reported above with the failing job named. Firing
     # both would bury the cause under the symptom.
+    #
+    # Suppressed for the same reason by a stand-down (FND-701): the run skipped
+    # its own e2e because the SDK commit it was dispatched for is no longer the
+    # head of its PR. That is an explained skip, and it is asserted by the job
+    # that decided it rather than inferred from the shape of the results.
     if (
-        discover_e2e == "success"
+        not stood_down(superseded)
+        and discover_e2e == "success"
         and e2e == "skipped"
         and all(
             result in _OK_OPTIONAL
@@ -224,6 +252,7 @@ def cancelled_only(
     merge_e2e_image: str = "skipped",
     prepare_tenant: str = "skipped",
     lease_tenant: str = "skipped",
+    superseded: str = "false",
 ) -> bool:
     """True when at least one job was cancelled and nothing actually failed.
 
@@ -241,8 +270,13 @@ def cancelled_only(
     # gate error that is never cancellation-attributable, so its presence means
     # the block is not a pure cancellation — spell it "failure" and surface the
     # misconfiguration, never "just re-run".
+    #
+    # A stand-down is exempt for the same reason it is exempt above: it is not an
+    # anomaly at all, so it must not force the "never a pure cancellation" answer
+    # and relabel a genuinely cancelled run as a failure.
     if (
-        discover_e2e == "success"
+        not stood_down(superseded)
+        and discover_e2e == "success"
         and e2e == "skipped"
         and all(
             result in _OK_OPTIONAL
@@ -320,6 +354,7 @@ def _e2e_status(
     merge_e2e_image: str = "skipped",
     prepare_tenant: str = "skipped",
     lease_tenant: str = "skipped",
+    superseded: str = "false",
 ) -> str:
     if discover_e2e == "skipped":
         return "⊘ Skipped — add `e2e` label to trigger"
@@ -344,6 +379,12 @@ def _e2e_status(
             return f"❌ {row} failed"
     if e2e == "success":
         return "✅ Passed"
+    # Before the anomaly row, and mirroring the order in `evaluate`: a stand-down
+    # produces exactly the anomaly's shape, so whichever check runs first decides
+    # what the reader is told. "Matrix skipped despite discovered suites" would
+    # send them looking for a workflow misconfiguration that is not there.
+    if stood_down(superseded) and e2e == "skipped":
+        return "⊘ Stood down — superseded SDK commit"
     if discover_e2e == "success" and e2e == "skipped":
         return "❌ Matrix skipped despite discovered suites"
     if e2e == "skipped":
@@ -364,6 +405,7 @@ def render(
     merge_e2e_image: str = "skipped",
     prepare_tenant: str = "skipped",
     lease_tenant: str = "skipped",
+    superseded: str = "false",
 ) -> dict[str, str]:
     """Compute the gate's outputs: pass/fail + the display status strings.
 
@@ -394,6 +436,7 @@ def render(
         merge_e2e_image,
         prepare_tenant,
         lease_tenant,
+        superseded,
     )
     blocked_by_cancellation = errors and cancelled_only(
         unit,
@@ -406,6 +449,7 @@ def render(
         merge_e2e_image,
         prepare_tenant,
         lease_tenant,
+        superseded,
     )
     return {
         "passed": "true" if not errors else "false",
@@ -427,6 +471,7 @@ def render(
             merge_e2e_image,
             prepare_tenant,
             lease_tenant,
+            superseded,
         ),
         "overall-status": (
             "✅ All passed"
@@ -480,6 +525,15 @@ def main(argv: list[str] | None = None) -> int:
         help="needs.prepare-tenant.result",
     )
     parser.add_argument("--e2e", required=True, help="needs.e2e.result")
+    parser.add_argument(
+        "--superseded",
+        default="false",
+        help='needs.sdk-head-recheck.outputs.superseded. "true" explains a '
+        "skipped e2e matrix as a deliberate stand-down rather than the "
+        "misconfiguration the matrix-skipped anomaly exists to catch. Optional "
+        'and defaulting to "false" so callers pinned at @main that have not '
+        "wired the job keep the previous behaviour.",
+    )
     args = parser.parse_args(sys.argv[1:] if argv is None else argv)
 
     # Annotate each failure reason (shows on the gate step regardless of the
@@ -495,6 +549,7 @@ def main(argv: list[str] | None = None) -> int:
         args.merge_e2e_image,
         args.prepare_tenant,
         args.lease_tenant,
+        args.superseded,
     ):
         print(f"::error::{reason}", file=sys.stderr)
 
@@ -511,6 +566,7 @@ def main(argv: list[str] | None = None) -> int:
         args.merge_e2e_image,
         args.prepare_tenant,
         args.lease_tenant,
+        args.superseded,
     ):
         print(f"::error::{_CANCELLED_GUIDANCE}", file=sys.stderr)
 
@@ -525,6 +581,7 @@ def main(argv: list[str] | None = None) -> int:
         args.merge_e2e_image,
         args.prepare_tenant,
         args.lease_tenant,
+        args.superseded,
     ).items():
         print(f"{key}={value}")
     return 0

--- a/.github/scripts/e2e_dispatch_guard.py
+++ b/.github/scripts/e2e_dispatch_guard.py
@@ -392,9 +392,30 @@ def _denied(response: Response) -> bool:
     return response.status in (401, 403, 404) and not _rate_limited(response)
 
 
-def create_claim_blob(repo: str, run_id: int, attempt: int, now: float) -> str:
-    """Write the claim record the ref will point at. Returns the blob sha."""
-    payload = {"run_id": run_id, "attempt": attempt, "claimed_at": now}
+def create_claim_blob(
+    repo: str, run_id: int, attempt: int, now: float, pr_number: int | None = None
+) -> str:
+    """Write the claim record the ref will point at. Returns the blob sha.
+
+    ``pr_number`` is written for a reader a repo away. The connector run this
+    dispatch is about to start is handed only a SHA, and a SHA is not enough to
+    find its PR once the branch has moved: ``GET /commits/{sha}/pulls`` answers
+    with an empty list for a commit a force-push has passed, which is exactly the
+    case worth detecting. So the claim — the record that authorises the dispatch —
+    also carries the identity needed to retract it, and the connector's
+    pre-lease recheck reads it back (``e2e-dispatch-recheck``, FND-701).
+
+    Omitted rather than null when there is no PR (the merge_group path), so a
+    reader cannot tell "no PR" apart from "a claim written before this field
+    existed" — and does not need to: both mean "do not stand down".
+    """
+    payload: dict[str, object] = {
+        "run_id": run_id,
+        "attempt": attempt,
+        "claimed_at": now,
+    }
+    if pr_number is not None:
+        payload["pr_number"] = pr_number
     response = gh_request(
         "POST",
         f"repos/{repo}/git/blobs",
@@ -747,6 +768,7 @@ def resolve(
     check_run_name: str,
     run_id: int,
     attempt: int,
+    pr_number: int | None = None,
     clock=time.time,
 ) -> tuple[str, Claimant | None]:
     """Decide whether this run should dispatch.
@@ -757,7 +779,7 @@ def resolve(
     """
     target = read_claim_target(repo, ref)
     if target is None:
-        blob = create_claim_blob(repo, run_id, attempt, clock())
+        blob = create_claim_blob(repo, run_id, attempt, clock(), pr_number)
         if try_claim(repo, ref, blob) == "claimed":
             return "claimed", None
         # Somebody won the race between the read and the CAS. The CAS was the
@@ -808,7 +830,7 @@ def resolve(
         "and finished without dispatching; reclaiming the slot."
     )
     delete_ref(repo, ref)
-    blob = create_claim_blob(repo, run_id, attempt, clock())
+    blob = create_claim_blob(repo, run_id, attempt, clock(), pr_number)
     if try_claim(repo, ref, blob) == "claimed":
         return "reclaimed", None
     # Another contender reclaimed it first. It will dispatch; this one must not.
@@ -950,6 +972,12 @@ def main(argv: list[str] | None = None) -> int:
             check_run_name=args.check_run_name,
             run_id=args.run_id,
             attempt=args.run_attempt,
+            # Recorded in the claim so the connector run this is about to start
+            # can find its way back to the PR and recheck the head immediately
+            # before it queues for a tenant (FND-701). None on the merge_group
+            # path, where the same `--pr-number` is empty for the same reason:
+            # a queue entry's SHA is not any PR's head.
+            pr_number=int(pr_number) if pr_number.isdigit() else None,
         )
     except GuardUnavailable as unavailable:
         print(

--- a/.github/scripts/tests/test_build_callback_summary.py
+++ b/.github/scripts/tests/test_build_callback_summary.py
@@ -253,18 +253,24 @@ def test_the_callback_and_the_gate_judge_the_same_inputs(reusable) -> None:
 
 @pytest.mark.parametrize("job_name", ["report-to-sdk", "tests-passed"])
 def test_every_judged_job_is_also_needed(reusable, job_name: str) -> None:
-    """`needs.<job>.result` is empty for a job absent from `needs`.
+    """Any `needs.<job>.…` reference is empty for a job absent from `needs`.
 
     Empty is not one of the driver's pass states, so a missing `needs` entry
     would fail closed rather than green — but it would fail EVERY run, and the
     fix under pressure would be to drop the input rather than add the need. Pin
     both halves together.
+
+    Matched on the job name alone rather than on `.result`, because not every
+    judged value is a result: `superseded` reads `needs.<job>.outputs.…`, where
+    a missing need is WORSE than fail-closed. It renders empty, empty reads as
+    "the skip is unexplained", and the gate then reds every stood-down run with
+    the anomaly it was told to suppress (FND-701).
     """
     job = reusable["jobs"][job_name]
     needed = set(job["needs"])
     for value in _gate_step(job)["with"].values():
-        referenced = str(value).split("needs.")[1].split(".result")[0]
+        referenced = str(value).split("needs.")[1].split(".")[0]
         assert referenced in needed, (
             f"{job_name} judges `{referenced}` but does not need it, so its "
-            "result is always empty"
+            "value is always empty"
         )

--- a/.github/scripts/tests/test_e2e_dispatch_recheck.py
+++ b/.github/scripts/tests/test_e2e_dispatch_recheck.py
@@ -1,0 +1,480 @@
+"""Tests for .github/actions/e2e-dispatch-recheck/e2e_dispatch_recheck.py.
+
+Co-located module (checked out with the composite action in consumer repos); the
+test lives here with the other action-script tests.
+
+Two properties carry this file. The first is that a superseded SHA stands down
+BEFORE the tenant lease. The second, and the one worth more scrutiny, is that
+nothing else ever does: the script decides whether to abandon an e2e run, and a
+wrong "true" costs a live commit its only e2e. So every ambiguity below —
+unreadable ref, unreadable blob, a claim with no PR recorded, an unreadable PR, a
+ref that is not a commit sha — is pinned to "false", and the wiring tests pin the
+gates to read the OUTPUT rather than the job result so an outright job failure
+leases exactly as it did before.
+
+The HTTP client is stubbed at the ``run()`` seam with curl-shaped responses, so
+status handling goes through the same parser production uses. An unstubbed
+request raises rather than answering 200, which is what stops a test passing
+because the script quietly stopped making a call it was supposed to make.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+# The recheck ships inside a composite action, so it is not importable the way
+# the other scripts under test are. The guard is imported alongside it because
+# the pair share a cross-repo ref contract that only a test can hold together.
+sys.path.insert(0, str(Path(__file__).parent.parent))
+sys.path.insert(
+    0, str(Path(__file__).parent.parent.parent / "actions" / "e2e-dispatch-recheck")
+)
+
+import e2e_dispatch_guard  # noqa: E402
+from e2e_dispatch_recheck import (  # noqa: E402
+    REF_NAMESPACE,
+    claim_ref,
+    is_superseded,
+    main,
+)
+
+REPO = "atlanhq/application-sdk"
+APP = "atlan-openapi-app"
+# The real pair from application-sdk PR #3322: the bot force-pushed HEAD over
+# STALE 54 seconds after the label started the run that dispatched STALE.
+STALE = "be82fade2ad4a59a20be5f3709e57c1992c40fc3"
+HEAD = "d47789e09fc1a41e48fa9d8ce9a1062c3d6eac08"
+BLOB = "b" * 40
+PR = 3322
+
+
+# --- fake HTTP client ------------------------------------------------------
+
+
+class FakeHTTP:
+    def __init__(self) -> None:
+        self.routes: dict[str, tuple[int, object]] = {}
+        self.calls: list[str] = []
+        self.cmds: list[list[str]] = []
+        self.inputs: list[str | None] = []
+
+    def route(self, contains: str, response: tuple[int, object]) -> None:
+        self.routes[contains] = response
+
+    def __call__(self, cmd: list[str], **kwargs):
+        url = cmd[-1]
+        self.calls.append(url)
+        self.cmds.append(list(cmd))
+        self.inputs.append(kwargs.get("input"))
+        for contains, (status, body) in self.routes.items():
+            if contains not in url:
+                continue
+            payload = "" if body is None else json.dumps(body)
+            return _completed(f"HTTP/2 {status}\r\n\r\n{payload}")
+        raise AssertionError(f"unstubbed request: {url}")
+
+
+class _completed:
+    def __init__(self, stdout: str, returncode: int = 0, stderr: str = "") -> None:
+        self.stdout = stdout
+        self.returncode = returncode
+        self.stderr = stderr
+
+
+@pytest.fixture
+def http(monkeypatch: pytest.MonkeyPatch) -> FakeHTTP:
+    monkeypatch.setenv("GH_TOKEN", "x")
+    fake = FakeHTTP()
+    monkeypatch.setattr("e2e_dispatch_recheck.run", fake)
+    return fake
+
+
+def _claim(pr_number: int | None = PR) -> dict:
+    record: dict[str, object] = {"run_id": 32417548486, "attempt": 1}
+    if pr_number is not None:
+        record["pr_number"] = pr_number
+    return {"content": base64.b64encode(json.dumps(record).encode()).decode()}
+
+
+def _stub_claim(http: FakeHTTP, *, blob: dict | None = None) -> None:
+    http.route(f"/git/ref/{REF_NAMESPACE}/", (200, {"object": {"sha": BLOB}}))
+    http.route("/git/blobs/", (200, _claim() if blob is None else blob))
+
+
+def _outputs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    out = tmp_path / "outputs"
+    out.write_text("")
+    monkeypatch.setenv("GITHUB_OUTPUT", str(out))
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(tmp_path / "summary"))
+    return out
+
+
+def _read(out: Path) -> dict[str, str]:
+    return dict(
+        line.split("=", 1) for line in out.read_text().splitlines() if "=" in line
+    )
+
+
+# --- the case this exists for ----------------------------------------------
+
+
+def test_a_superseded_sha_stands_down(http: FakeHTTP) -> None:
+    _stub_claim(http)
+    http.route(f"/pulls/{PR}", (200, {"head": {"sha": HEAD}}))
+
+    assert is_superseded(REPO, APP, STALE) is True
+
+
+def test_the_head_sha_proceeds(http: FakeHTTP) -> None:
+    _stub_claim(http)
+    http.route(f"/pulls/{PR}", (200, {"head": {"sha": HEAD}}))
+
+    assert is_superseded(REPO, APP, HEAD) is False
+
+
+def test_a_head_in_a_different_case_is_not_a_different_commit(http: FakeHTTP) -> None:
+    """One SHA in two spellings must not read as two commits. That direction of
+    error abandons the live commit's e2e, which is the one outcome worse than
+    paying for a stale run."""
+    _stub_claim(http)
+    http.route(f"/pulls/{PR}", (200, {"head": {"sha": HEAD.upper()}}))
+
+    assert is_superseded(REPO, APP, HEAD) is False
+
+
+def test_it_reads_the_claim_the_dispatch_guard_wrote(http: FakeHTTP) -> None:
+    """The ref layout is a cross-repo contract with e2e_dispatch_guard.claim_ref:
+    the guard writes it in application-sdk, this reads it from a connector repo,
+    and nothing in either repo's tests would notice the two drifting apart."""
+    _stub_claim(http)
+    http.route(f"/pulls/{PR}", (200, {"head": {"sha": HEAD}}))
+
+    is_superseded(REPO, APP, STALE)
+
+    assert claim_ref(APP, STALE) == f"refs/e2e-dispatch/{APP}/{STALE}"
+    assert f"repos/{REPO}/git/ref/e2e-dispatch/{APP}/{STALE}" in http.calls[0]
+
+
+def test_the_guard_and_the_recheck_agree_on_the_namespace() -> None:
+    """Pins the duplicated constant. The two modules cannot import each other —
+    only this one ships to connector repos — so the pair is held together here
+    or not at all."""
+    assert REF_NAMESPACE == e2e_dispatch_guard.REF_NAMESPACE
+
+
+# Every connector repository the SDK's dispatch matrix can name. The claim ref
+# is built from this string on one side and parsed from it on the other, so the
+# fleet is the input set that actually matters.
+CONNECTOR_REPOS = [
+    "atlan-openapi-app",
+    "atlan-mysql-app",
+    "atlan-metabase-app",
+    "atlan-postgres-app",
+    "atlan-local-marketplace-app",
+]
+
+
+@pytest.mark.parametrize("repo_name", CONNECTOR_REPOS)
+def test_the_two_ref_builders_agree_on_every_connector_name(repo_name: str) -> None:
+    """The recheck does not reimplement the guard's slug(), on the grounds that
+    none of its rules can fire on a repository name. That is a claim about the
+    fleet, so it is asserted against the fleet rather than argued in a comment —
+    if a connector is ever added whose name slug() would rewrite, this fails
+    instead of the check silently looking for a ref that was never written."""
+    assert claim_ref(repo_name, STALE) == e2e_dispatch_guard.claim_ref(repo_name, STALE)
+
+
+def test_a_repo_name_in_a_different_case_still_finds_its_claim() -> None:
+    """slug() lowercases and a repository name need not be lowercase, which is
+    the one normalisation difference that can actually bite."""
+    assert claim_ref("Atlan-OpenAPI-App", STALE) == e2e_dispatch_guard.claim_ref(
+        "Atlan-OpenAPI-App", STALE
+    )
+
+
+def test_the_guard_records_the_pr_number_this_reads_back(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The other half of the same contract: the guard has to WRITE the field this
+    reads. A claim without it is inert here (see the test below), so the guard
+    silently dropping it would turn the recheck off with nothing going red."""
+    written: list[dict] = []
+
+    def fake_request(method, path, payload=None, **kwargs):
+        written.append(json.loads(payload["content"]))
+        return type("R", (), {"status": 201, "body": {"sha": BLOB}, "message": ""})()
+
+    monkeypatch.setattr(e2e_dispatch_guard, "gh_request", fake_request)
+    e2e_dispatch_guard.create_claim_blob(REPO, 1, 1, 1000.0, PR)
+
+    assert written[0]["pr_number"] == PR
+
+
+# --- every doubt resolves towards running the e2e --------------------------
+
+
+def test_no_claim_ref_proceeds(http: FakeHTTP) -> None:
+    """A hand-pinned application_sdk_ref, or a claim already pruned. Neither is
+    an SDK pull-request dispatch, and skipping a human's deliberate run against a
+    specific SDK commit would be a silent, baffling no-op."""
+    http.route(f"/git/ref/{REF_NAMESPACE}/", (404, {"message": "Not Found"}))
+
+    assert is_superseded(REPO, APP, STALE) is False
+
+
+def test_a_claim_without_a_pr_number_proceeds(http: FakeHTTP) -> None:
+    """Every claim written before the guard started recording the field, and
+    every merge_group claim, which has no PR by construction. This is what lets
+    the recheck ship without being in lockstep with the guard change."""
+    _stub_claim(http, blob=_claim(pr_number=None))
+
+    assert is_superseded(REPO, APP, STALE) is False
+
+
+@pytest.mark.parametrize(
+    "answer",
+    [
+        (403, {"message": "Resource not accessible by integration"}),
+        (403, {"message": "API rate limit exceeded"}),
+        (500, {"message": "boom"}),
+        (200, {"message": "no object here"}),
+        (200, None),
+    ],
+)
+def test_an_unreadable_claim_ref_proceeds(http: FakeHTTP, answer) -> None:
+    http.route(f"/git/ref/{REF_NAMESPACE}/", answer)
+
+    assert is_superseded(REPO, APP, STALE) is False
+
+
+@pytest.mark.parametrize(
+    "answer",
+    [
+        (404, {"message": "Not Found"}),
+        (403, {"message": "API rate limit exceeded"}),
+        (200, {"content": "not base64 json"}),
+        (200, {"content": base64.b64encode(b"[]").decode()}),
+        (200, {"encoding": "base64"}),
+    ],
+)
+def test_an_unreadable_claim_record_proceeds(http: FakeHTTP, answer) -> None:
+    http.route(f"/git/ref/{REF_NAMESPACE}/", (200, {"object": {"sha": BLOB}}))
+    http.route("/git/blobs/", answer)
+
+    assert is_superseded(REPO, APP, STALE) is False
+
+
+@pytest.mark.parametrize(
+    "answer",
+    [
+        (404, {"message": "Not Found"}),
+        (403, {"message": "API rate limit exceeded"}),
+        (500, {"message": "boom"}),
+        (200, {"number": PR}),
+        (200, {"head": {"ref": "bump-version-main"}}),
+    ],
+)
+def test_an_unreadable_pull_request_proceeds(http: FakeHTTP, answer) -> None:
+    _stub_claim(http)
+    http.route(f"/pulls/{PR}", answer)
+
+    assert is_superseded(REPO, APP, STALE) is False
+
+
+def test_a_pr_number_of_true_is_not_pull_request_one(http: FakeHTTP) -> None:
+    """bool is an int in Python, so a corrupted record carrying `true` would
+    otherwise be compared against whatever PR #1 happens to point at today."""
+    _stub_claim(http, blob=_claim(pr_number=True))  # type: ignore[arg-type]
+
+    assert is_superseded(REPO, APP, STALE) is False
+
+
+def test_a_transport_failure_proceeds(
+    http: FakeHTTP, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "e2e_dispatch_recheck.run",
+        lambda *a, **k: _completed(
+            "", returncode=6, stderr="curl: (6) could not resolve"
+        ),
+    )
+
+    assert is_superseded(REPO, APP, STALE) is False
+
+
+# --- the entry point --------------------------------------------------------
+
+
+def test_main_writes_true_for_a_superseded_ref(
+    http: FakeHTTP, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    out = _outputs(tmp_path, monkeypatch)
+    _stub_claim(http)
+    http.route(f"/pulls/{PR}", (200, {"head": {"sha": HEAD}}))
+
+    assert main(["--sdk-repo", REPO, "--sdk-ref", STALE, "--app", APP]) == 0
+
+    assert _read(out)["superseded"] == "true"
+
+
+def test_main_writes_false_for_the_head(
+    http: FakeHTTP, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    out = _outputs(tmp_path, monkeypatch)
+    _stub_claim(http)
+    http.route(f"/pulls/{PR}", (200, {"head": {"sha": HEAD}}))
+
+    assert main(["--sdk-repo", REPO, "--sdk-ref", HEAD, "--app", APP]) == 0
+
+    assert _read(out)["superseded"] == "false"
+
+
+@pytest.mark.parametrize(
+    "ref", ["", "   ", "main", "refs/heads/main", "be82fad", "z" * 40]
+)
+def test_a_ref_that_is_not_a_commit_sha_asks_nothing(
+    http: FakeHTTP, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, ref
+) -> None:
+    """The connector's own pull_request/push runs pass empty, and pinning the SDK
+    by branch is a supported way to run e2e. Neither names a commit that can be
+    superseded — and FakeHTTP raising on an unstubbed call is what proves no
+    request is made, rather than one being made and ignored."""
+    out = _outputs(tmp_path, monkeypatch)
+
+    assert main(["--sdk-repo", REPO, "--sdk-ref", ref, "--app", APP]) == 0
+
+    assert _read(out)["superseded"] == "false"
+    assert http.calls == []
+
+
+def test_main_never_fails_the_job(
+    http: FakeHTTP, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Exit 0 on the unhappy path too. This job sits in front of the tenant
+    lease; a non-zero exit here would take the e2e down with it, which is the
+    opposite of what a best-effort optimisation may do."""
+    _outputs(tmp_path, monkeypatch)
+    http.route(f"/git/ref/{REF_NAMESPACE}/", (500, {"message": "boom"}))
+
+    assert main(["--sdk-repo", REPO, "--sdk-ref", STALE, "--app", APP]) == 0
+
+
+def test_the_token_never_reaches_the_command_line(http: FakeHTTP) -> None:
+    """It goes in through stdin (-K -), so nothing else sharing the runner can
+    read it out of /proc/<pid>/cmdline while the request is in flight."""
+    _stub_claim(http)
+    http.route(f"/pulls/{PR}", (200, {"head": {"sha": HEAD}}))
+
+    is_superseded(REPO, APP, STALE)
+
+    assert not any("x" == arg or "Bearer x" in arg for arg in http.cmds[0])
+    assert http.inputs[0] is not None and "Bearer x" in http.inputs[0]
+
+
+# --- wiring -----------------------------------------------------------------
+
+
+def _workflow() -> dict:
+    path = Path(__file__).parent.parent.parent / "workflows" / "tests-reusable.yaml"
+    return yaml.safe_load(path.read_text())
+
+
+def _action() -> dict:
+    path = (
+        Path(__file__).parent.parent.parent
+        / "actions"
+        / "e2e-dispatch-recheck"
+        / "action.yaml"
+    )
+    return yaml.safe_load(path.read_text())
+
+
+def test_the_recheck_runs_before_the_lease_and_not_after() -> None:
+    """Asked as late as the DAG allows, because the answer is only worth as much
+    as its freshness — and strictly before anything takes a tenant."""
+    jobs = _workflow()["jobs"]
+
+    assert "sdk-head-recheck" in jobs["lease-tenant"]["needs"]
+    assert "lease-tenant" not in jobs["sdk-head-recheck"]["needs"]
+
+
+def test_the_lease_reads_the_output_not_the_job_result() -> None:
+    """The whole fail-open posture in one assertion. `needs.<job>.result` would
+    make an infrastructure failure of the recheck SKIP the lease — and a skipped
+    lease skips the install and greens the run vacuously. The output is empty
+    when the job did not answer, so `!= 'true'` leases exactly as before."""
+    gate = _workflow()["jobs"]["lease-tenant"]["if"]
+
+    assert "needs.sdk-head-recheck.outputs.superseded != 'true'" in gate
+    assert "needs.sdk-head-recheck.result" not in gate
+
+
+def test_the_lease_gate_lifts_the_implicit_success_check() -> None:
+    """`always()` is what lets the `if:` above be consulted at all. Without it
+    GitHub applies an implicit success() over every need and skips the job before
+    the gate is read, so a failed recheck would skip the lease — the exact
+    fail-CLOSED behaviour the output check exists to avoid. And because always()
+    lifts the check for the other needs too, they have to be named explicitly."""
+    gate = _workflow()["jobs"]["lease-tenant"]["if"]
+
+    assert "always()" in gate
+    assert "needs.discover-e2e.result == 'success'" in gate
+    assert "needs.merge-e2e-image.result == 'success'" in gate
+
+
+def test_the_legs_stand_down_with_the_lease() -> None:
+    """Gating the lease alone is not enough, and getting this wrong is worse than
+    not doing it: a SKIPPED lease-tenant is the benign value in the legs' own
+    clauses (it is the install-app-to-tenant:false path), so the legs would run
+    against a tenant nobody installed onto with expected-app-version empty — a
+    silently passing wrong-version run, which is the FND-31 failure the lease was
+    built to make impossible."""
+    e2e = _workflow()["jobs"]["e2e"]
+
+    assert "sdk-head-recheck" in e2e["needs"]
+    assert "needs.sdk-head-recheck.outputs.superseded != 'true'" in e2e["if"]
+
+
+def test_the_install_and_the_release_cascade_off_the_lease() -> None:
+    """Neither needs its own clause: both already gate on lease-tenant having
+    RUN, and a superseded run skips it. Pinned so that gating is not later
+    loosened to `always()` without noticing it carries the stand-down too."""
+    jobs = _workflow()["jobs"]
+
+    for name in ("prepare-tenant", "release-tenant"):
+        assert "needs.lease-tenant.result != 'skipped'" in jobs[name]["if"], name
+
+
+def test_the_recheck_is_keyed_on_the_repo_name_not_the_app_name() -> None:
+    """The claim ref the SDK writes is keyed on the connector REPOSITORY, which
+    is what its dispatch matrix iterates over. `inputs.app-name` is the short
+    form ("openapi", not "atlan-openapi-app") and would find no claim at all —
+    a check that silently never fires."""
+    step = _workflow()["jobs"]["sdk-head-recheck"]["steps"][0]
+
+    assert step["with"]["app"] == "${{ github.event.repository.name }}"
+    assert step["with"]["sdk-ref"] == "${{ inputs.application-sdk-ref }}"
+
+
+def test_the_recheck_is_consumed_at_main() -> None:
+    """Same reason the tenant lease is: this reads a ref layout the dispatching
+    SDK run wrote, so the protocol must not vary with whichever ref a connector
+    happened to check out."""
+    step = _workflow()["jobs"]["sdk-head-recheck"]["steps"][0]
+
+    assert step["uses"].endswith("/e2e-dispatch-recheck@main")
+
+
+def test_the_action_needs_no_write_permission() -> None:
+    """Every read is of public data in another repository, so the job runs on
+    contents:read. A check that quietly required more would fail open forever."""
+    job = _workflow()["jobs"]["sdk-head-recheck"]
+
+    assert job["permissions"] == {"contents": "read"}
+    assert _action()["runs"]["using"] == "composite"

--- a/.github/scripts/tests/test_e2e_dispatch_recheck.py
+++ b/.github/scripts/tests/test_e2e_dispatch_recheck.py
@@ -471,6 +471,49 @@ def test_the_recheck_is_consumed_at_main() -> None:
     assert step["uses"].endswith("/e2e-dispatch-recheck@main")
 
 
+def test_both_gate_evaluations_are_told_about_the_stand_down() -> None:
+    """Standing down produces the exact tuple the gate driver's matrix-skipped
+    anomaly exists to catch — discovery success, matrix skipped, no install-path
+    failure. Untold, `tests-passed` reds the required check AND `report-to-sdk`
+    mirrors conclusion=failure onto the dispatching SDK commit: "your change
+    broke the connector" for a run that deliberately stood down, which is the
+    FND-218 misattribution the cancelled/failure split exists to prevent.
+
+    Both call sites, because the two are meant to be one decision evaluated
+    twice: a gate told and a callback not told would disagree, which is the
+    drift the shared driver exists to remove."""
+    jobs = _workflow()["jobs"]
+
+    for name in ("tests-passed", "report-to-sdk"):
+        step = next(s for s in jobs[name]["steps"] if s.get("id") == "gate")
+        assert step["uses"].endswith("/verify-test-gate@main"), name
+        assert (
+            step["with"]["superseded"]
+            == "${{ needs.sdk-head-recheck.outputs.superseded }}"
+        ), name
+        # The expression above renders EMPTY unless the job declares the need,
+        # and empty reads as "unexplained" — the anomaly would fire silently.
+        assert "sdk-head-recheck" in jobs[name]["needs"], name
+
+
+def test_the_gate_input_is_optional_and_defaults_to_unexplained() -> None:
+    """The driver is consumed cross-repo at @main. A required input would break
+    every connector the instant it merged, and a default of "true" would let any
+    unexplained skipped matrix green the gate — the anomaly's whole purpose."""
+    gate_action = yaml.safe_load(
+        (
+            Path(__file__).parent.parent.parent
+            / "actions"
+            / "verify-test-gate"
+            / "action.yaml"
+        ).read_text()
+    )
+    superseded = gate_action["inputs"]["superseded"]
+
+    assert superseded["required"] is False
+    assert superseded["default"] == "false"
+
+
 def test_the_action_needs_no_write_permission() -> None:
     """Every read is of public data in another repository, so the job runs on
     contents:read. A check that quietly required more would fail open forever."""

--- a/.github/scripts/tests/test_verify_test_gate.py
+++ b/.github/scripts/tests/test_verify_test_gate.py
@@ -18,7 +18,13 @@ sys.path.insert(
     0, str(Path(__file__).parent.parent.parent / "actions" / "verify-test-gate")
 )
 
-from verify_test_gate import cancelled_only, evaluate, main, render  # noqa: E402
+from verify_test_gate import (  # noqa: E402
+    cancelled_only,
+    evaluate,
+    main,
+    render,
+    stood_down,
+)
 
 # --- passing states --------------------------------------------------------
 
@@ -104,6 +110,161 @@ def test_e2e_skipped_when_discovery_succeeded_is_failure() -> None:
     out = render("success", "success", "success", "success", "skipped")
     assert out["passed"] == "false"
     assert out["e2e-status"] == "❌ Matrix skipped despite discovered suites"
+
+
+# --- the stand-down: an EXPLAINED skipped matrix (FND-701) -----------------
+#
+# The connector-side recheck skips lease-tenant and the e2e legs when the
+# application-sdk commit under test is no longer the head of the PR that
+# dispatched the run. That produces the exact tuple the anomaly above exists to
+# catch — discovery success, matrix skipped, no install-path failure — so the
+# gate needs telling the difference. Getting it wrong in either direction is a
+# real cost: unsuppressed, every stand-down reds the gate AND mirrors
+# conclusion=failure onto the dispatching SDK commit ("your change broke the
+# connector", the FND-218 misattribution); over-suppressed, a future re-wiring of
+# the e2e `if` greens the gate by skipping it.
+
+_STOOD_DOWN = ("success", "success", "success", "success", "skipped")
+
+
+def test_a_stand_down_is_not_an_anomaly() -> None:
+    assert evaluate(*_STOOD_DOWN, superseded="true") == []
+
+
+def test_a_stand_down_greens_the_gate_and_says_why() -> None:
+    """`conclusion` is the part that travels: report-to-sdk feeds it straight
+    into the check run on the dispatching SDK commit."""
+    out = render(*_STOOD_DOWN, superseded="true")
+
+    assert out["passed"] == "true"
+    assert out["conclusion"] == "success"
+    assert out["e2e-status"] == "⊘ Stood down — superseded SDK commit"
+    assert out["overall-status"] == "✅ All passed"
+
+
+@pytest.mark.parametrize(
+    "superseded", ["", "false", "False", "no", "1", "yes", "TRUE "]
+)
+def test_only_a_positive_assertion_explains_the_skip(superseded: str) -> None:
+    """Everything except the literal "true" leaves the anomaly firing. An absent
+    or unparseable value means the recheck job did not answer — it skipped, or it
+    died — and an unanswered skip is still unexplained, which is the state worth
+    reddening. "TRUE " is included because it IS accepted: the value is trimmed
+    and lowercased, and a workflow expression that renders with whitespace must
+    not silently stop explaining."""
+    errors = evaluate(*_STOOD_DOWN, superseded=superseded)
+
+    if stood_down(superseded):
+        assert errors == []
+    else:
+        assert any("matrix was skipped" in error for error in errors)
+
+
+def test_the_anomaly_survives_for_an_unexplained_skip() -> None:
+    """The regression this pairing has to keep passing: the suppression is
+    conditional, not a removal."""
+    errors = evaluate(*_STOOD_DOWN)
+
+    assert len(errors) == 1
+    assert "matrix was skipped" in errors[0]
+
+
+def test_a_stand_down_does_not_excuse_a_real_failure() -> None:
+    """Standing e2e down says nothing about the unit tier. A superseded run whose
+    unit tests failed must still fail the gate — otherwise the stand-down becomes
+    a way to green anything."""
+    errors = evaluate(
+        "failure", "success", "success", "success", "skipped", superseded="true"
+    )
+
+    assert len(errors) == 1
+    assert "unit tests" in errors[0]
+
+
+def test_a_stand_down_leaves_a_cancellation_readable_as_one() -> None:
+    """cancelled_only short-circuits the anomaly tuple to False, on the grounds
+    that the anomaly is never cancellation-attributable. A stand-down is not the
+    anomaly, so it must not take that branch — or a genuinely cancelled unit job
+    would be relabelled "failure" and sent to the wrong reader."""
+    assert (
+        cancelled_only(
+            "cancelled", "success", "success", "success", "skipped", superseded="true"
+        )
+        is True
+    )
+    assert (
+        render(
+            "cancelled", "success", "success", "success", "skipped", superseded="true"
+        )["conclusion"]
+        == "cancelled"
+    )
+
+
+def test_an_install_path_failure_still_names_itself_under_a_stand_down() -> None:
+    """The stand-down suppresses the anomaly, never a named job. A lease that
+    actually failed has to keep saying so — "the tenant was busy" and "the commit
+    was superseded" call for opposite responses."""
+    errors = evaluate(
+        "success",
+        "success",
+        "success",
+        "success",
+        "skipped",
+        "skipped",
+        "success",
+        "success",
+        "skipped",
+        "failure",
+        "true",
+    )
+
+    assert len(errors) == 1
+    assert "the tenant lease" in errors[0]
+
+
+def test_the_flag_defaults_to_unexplained(capsys: pytest.CaptureFixture) -> None:
+    """A caller pinned at @main that has not wired the recheck job keeps the
+    previous behaviour exactly, which is what makes this deployable without
+    touching a single connector repo."""
+    main(
+        [
+            "--unit",
+            "success",
+            "--integration",
+            "success",
+            "--detect-integration",
+            "success",
+            "--discover-e2e",
+            "success",
+            "--e2e",
+            "skipped",
+        ]
+    )
+
+    assert "passed=false" in capsys.readouterr().out
+
+
+def test_the_flag_reaches_the_driver(capsys: pytest.CaptureFixture) -> None:
+    main(
+        [
+            "--unit",
+            "success",
+            "--integration",
+            "success",
+            "--detect-integration",
+            "success",
+            "--discover-e2e",
+            "success",
+            "--e2e",
+            "skipped",
+            "--superseded",
+            "true",
+        ]
+    )
+    out = capsys.readouterr().out
+
+    assert "passed=true" in out
+    assert "e2e-status=⊘ Stood down — superseded SDK commit" in out
 
 
 # --- render() (display strings shared with the summary table) --------------

--- a/.github/workflows/tests-reusable.yaml
+++ b/.github/workflows/tests-reusable.yaml
@@ -2301,6 +2301,7 @@ jobs:
         discover-e2e,
         build-e2e-image,
         merge-e2e-image,
+        sdk-head-recheck,
         lease-tenant,
         prepare-tenant,
         e2e,
@@ -2429,6 +2430,13 @@ jobs:
           lease-tenant-result: ${{ needs.lease-tenant.result }}
           prepare-tenant-result: ${{ needs.prepare-tenant.result }}
           e2e-result: ${{ needs.e2e.result }}
+          # Explains a skipped matrix as a deliberate stand-down rather than the
+          # misconfiguration the matrix-skipped anomaly exists to catch. Empty
+          # (the recheck job skipped, or it failed and wrote no answer) reads as
+          # "not explained", which is the correct default: the anomaly is what
+          # stops a future re-wiring of the e2e `if` from greening the gate by
+          # skipping it (FND-701).
+          superseded: ${{ needs.sdk-head-recheck.outputs.superseded }}
 
       # Body only — this step emits no verdict; the completion step below takes
       # the gate's. Its CLI stays frozen: this script is checked out from the
@@ -2729,6 +2737,7 @@ jobs:
         discover-e2e,
         build-e2e-image,
         merge-e2e-image,
+        sdk-head-recheck,
         lease-tenant,
         prepare-tenant,
         e2e,
@@ -2772,6 +2781,13 @@ jobs:
           lease-tenant-result: ${{ needs.lease-tenant.result }}
           prepare-tenant-result: ${{ needs.prepare-tenant.result }}
           e2e-result: ${{ needs.e2e.result }}
+          # Explains a skipped matrix as a deliberate stand-down rather than the
+          # misconfiguration the matrix-skipped anomaly exists to catch. Empty
+          # (the recheck job skipped, or it failed and wrote no answer) reads as
+          # "not explained", which is the correct default: the anomaly is what
+          # stops a future re-wiring of the e2e `if` from greening the gate by
+          # skipping it (FND-701).
+          superseded: ${{ needs.sdk-head-recheck.outputs.superseded }}
 
       - name: Post unified test-summary comment on PR
         if: always() && github.event_name == 'pull_request'

--- a/.github/workflows/tests-reusable.yaml
+++ b/.github/workflows/tests-reusable.yaml
@@ -1448,10 +1448,78 @@ jobs:
   # Same gate as prepare-tenant: no install, no contention worth serialising —
   # the legs of a non-installing run cannot lose a version race because nothing
   # changes the version under them.
+  # ── Is the SDK commit under test still the one under review? ─────────────
+  # The SDK-side dispatch guard drops a fan-out whose SHA has already been
+  # superseded (e2e_dispatch_guard.py, FND-696), but it can only see the window
+  # UP TO the dispatch. A push landing after it leaves this run already in
+  # flight for a commit nobody will merge, and the tenant lease below then does
+  # exactly what it promises — it QUEUES, so the live commit waits out this
+  # run's entire install-plus-legs cycle. On application-sdk PR #3322 that was
+  # 3m38s, 10m12s and 12m of pure lease wait across three connectors.
+  #
+  # This job is the second half of that fix (FND-701), and it is worth being
+  # precise about which half. A dispatched run that has ALREADY leased cannot be
+  # helped: cancelling it is unsafe, because prepare-tenant carries
+  # `if: always()` and finishes installing onto the tenants it holds on its way
+  # out — so for that run the queue is the right answer. A run that has
+  # dispatched but NOT yet leased is a different thing entirely. It is still
+  # building the image and running unit and integration tests — 2m30s on the
+  # openapi leg of #3322, dispatched 21:07:38 and leased 21:10:10 — and it holds
+  # nothing at all, so it can stand down for free.
+  #
+  # Placed here rather than earlier on purpose: the answer is only worth as much
+  # as its freshness, so it is asked as close to the lease as the DAG allows.
+  #
+  # It cannot fail this run. The script exits 0 on every path and answers
+  # "false" to every doubt, and the gates below read the OUTPUT rather than the
+  # job result, so even an outright job failure leaves the lease happening —
+  # which is the pre-existing behaviour.
+  sdk-head-recheck:
+    name: Recheck the dispatched SDK ref
+    needs: [merge-e2e-image]
+    if: inputs.install-app-to-tenant && needs.merge-e2e-image.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      # Nothing beyond the default. Every read is of public data in
+      # application-sdk — a ref, the blob it points at, and a pull request — and
+      # a connector's own github.token can already do that.
+      contents: read
+    outputs:
+      superseded: ${{ steps.recheck.outputs.superseded }}
+    steps:
+      - name: Recheck the dispatched SDK ref
+        id: recheck
+        uses: atlanhq/application-sdk/.github/actions/e2e-dispatch-recheck@main
+        with:
+          sdk-ref: ${{ inputs.application-sdk-ref }}
+          # The claim ref the SDK wrote is keyed on the connector REPOSITORY
+          # name, which is what its dispatch matrix iterates over — not the
+          # short app-name. Derived from github.repository so the two cannot
+          # disagree, and so a connector whose app-name and repo differ (every
+          # one of them: "openapi" vs "atlan-openapi-app") still finds its claim.
+          app: ${{ github.event.repository.name }}
+
   lease-tenant:
     name: Tenant lease
-    needs: [discover-e2e, merge-e2e-image]
-    if: inputs.install-app-to-tenant && needs.merge-e2e-image.result == 'success'
+    needs: [discover-e2e, merge-e2e-image, sdk-head-recheck]
+    # `always()` here is load-bearing and is what makes the recheck fail-open. A
+    # job's `needs` gate is evaluated separately from its `if:`, and without a
+    # status-check function GitHub applies an implicit success() over every need
+    # — so a recheck job that died on infrastructure would SKIP the lease, and a
+    # skipped lease skips the install and greens the run vacuously. Lifting the
+    # implicit check and reading the OUTPUT instead means an absent answer (job
+    # failed, job skipped, output never written) leases exactly as before.
+    #
+    # Because always() lifts that implicit check, discover-e2e and
+    # merge-e2e-image have to be named explicitly; they were previously carried
+    # by it. Same shape and same reason as prepare-tenant and the e2e legs below.
+    if: |
+      always() &&
+      inputs.install-app-to-tenant &&
+      needs.discover-e2e.result == 'success' &&
+      needs.merge-e2e-image.result == 'success' &&
+      needs.sdk-head-recheck.outputs.superseded != 'true'
     runs-on: ubuntu-latest
     # Above the action's own 90-minute wait budget, which is now a budget for the
     # WHOLE ordered set rather than per cloud — so this still bounds the job, and
@@ -1805,9 +1873,24 @@ jobs:
     # so the version check self-skips. A silently passing wrong-version run, from
     # the job added to make wrong-version runs impossible.
     needs:
-      [discover-e2e, build-e2e-image, merge-e2e-image, lease-tenant, prepare-tenant]
+      [
+        discover-e2e,
+        build-e2e-image,
+        merge-e2e-image,
+        sdk-head-recheck,
+        lease-tenant,
+        prepare-tenant,
+      ]
+    # The superseded clause is gated on the OUTPUT, never on the job result, and
+    # it has to be: a skipped lease-tenant is the benign value in the clauses
+    # below (it is the install-app-to-tenant:false path), so without this the
+    # legs would run against a tenant nobody installed onto with
+    # expected-app-version empty — a silently passing wrong-version run, the
+    # exact FND-31 failure. Reading the output also keeps a failed recheck
+    # fail-open: no answer means carry on (FND-701).
     if: |
       always() &&
+      needs.sdk-head-recheck.outputs.superseded != 'true' &&
       needs.discover-e2e.result == 'success' &&
       needs.discover-e2e.outputs.count != '0' &&
       (needs.lease-tenant.result == 'success' || needs.lease-tenant.result == 'skipped') &&

--- a/docs/standards/connector-ci-e2e.md
+++ b/docs/standards/connector-ci-e2e.md
@@ -145,8 +145,58 @@ cases that want opposite answers:
   (dispatched 21:07:38, leased 21:10:10). It holds nothing, so it can stand down
   for free, and the head commit takes the tenant instead.
 
-The second case is a connector-side check made immediately before the lease is
-taken, and it is tracked as FND-701.
+The second case is the connector-side recheck below.
+
+### Standing down before the lease
+
+`sdk-head-recheck` runs in `tests-reusable.yaml` immediately before
+`lease-tenant` and asks the same question the dispatch guard asked, at the last
+moment the answer can still save a tenant. When it says the SHA has been
+superseded, `lease-tenant` skips — and `prepare-tenant`, the `e2e` legs and
+`release-tenant` skip with it (FND-701).
+
+**Finding the pull request.** The connector run is handed `application_sdk_ref`
+and nothing else, and a SHA alone is not enough:
+`GET /commits/{sha}/pulls` answers with an **empty list** for a commit a
+force-push has moved past, which is precisely the case worth detecting. Verified
+against the incident itself — `be82fade` is associated with no pull request,
+while `d47789e0`, the head that replaced it, resolves normally.
+
+So the PR number comes from the record that authorised the dispatch. The guard
+already writes `refs/e2e-dispatch/<app>/<sha>` pointing at a blob describing the
+claim; that blob now carries `pr_number`, and the recheck reads it back. It is a
+positive identification rather than an inference, and the claim is guaranteed to
+outlive the run that needs it: the guard's prune only deletes a claim once that
+SHA's `Connector E2E run / <app>` check has settled, which cannot happen while
+this run is the thing that has yet to complete it.
+
+A run with **no** claim ref is therefore not an SDK pull-request dispatch —
+someone pinning `application_sdk_ref` by hand to test a connector against a
+particular SDK commit — and is left alone. Without that, a deliberate manual run
+would be skipped as a silent no-op.
+
+**Where the gates read from, and why it matters.** Both `lease-tenant` and the
+`e2e` legs gate on the job's `outputs.superseded`, never on its `result`:
+
+* A `needs.<job>.result` check would make an infrastructure failure of the
+  recheck **skip** the lease, and a skipped lease skips the install and greens
+  the run vacuously. Reading the output means an absent answer — job failed, job
+  skipped, output never written — leases exactly as before. The script exits 0
+  on every path for the same reason.
+* `lease-tenant` needs `always()` for that gate to be consulted at all: without
+  a status-check function GitHub applies an implicit `success()` over every
+  need and skips the job before the `if:` is read. That is also why
+  `discover-e2e` and `merge-e2e-image` are now named explicitly there.
+* The `e2e` legs need their **own** clause. A *skipped* `lease-tenant` is the
+  benign value in their existing gate — it is the `install-app-to-tenant: false`
+  path — so gating the lease alone would leave the legs running against a tenant
+  nobody installed onto with `expected-app-version` empty: a silently passing
+  wrong-version run, the exact FND-31 failure the lease exists to prevent.
+
+A stood-down run still reports to the dispatching SDK commit, and still reports
+green — the same vacuous green the SDK-side gate gives that commit, for the same
+reason: it is no longer the commit under review, and only the head commit's run
+can satisfy a required check.
 
 ## SDR composite action inputs
 

--- a/docs/standards/connector-ci-e2e.md
+++ b/docs/standards/connector-ci-e2e.md
@@ -193,10 +193,29 @@ would be skipped as a silent no-op.
   nobody installed onto with `expected-app-version` empty: a silently passing
   wrong-version run, the exact FND-31 failure the lease exists to prevent.
 
-A stood-down run still reports to the dispatching SDK commit, and still reports
-green — the same vacuous green the SDK-side gate gives that commit, for the same
-reason: it is no longer the commit under review, and only the head commit's run
-can satisfy a required check.
+**The Tests Gate has to be told.** A stand-down produces the exact tuple the gate
+driver's "matrix skipped despite discovered suites" anomaly exists to catch — a
+successful discovery, a skipped matrix, and no install-path failure to explain
+it. Left untold, `tests-passed` reds the required check *and* `report-to-sdk`
+mirrors `conclusion=failure` onto the dispatching SDK commit: "your change broke
+the connector" for a run that deliberately stood down, which is exactly the
+misattribution the cancelled/failure split exists to prevent (FND-218).
+
+So `verify-test-gate` takes a `superseded` input, and both call sites pass it —
+they are one decision evaluated twice, and a gate told while the callback is not
+would put them back in disagreement. Only the literal `"true"` explains the skip:
+an absent, empty or unparseable value means the recheck job never answered, and
+an unanswered skip is still unexplained. The input is optional and defaults to
+`"false"`, so a connector pinned at `@main` that has not wired the job keeps the
+previous behaviour, and a future re-wiring of the e2e `if` still cannot green the
+gate by skipping the matrix. The e2e row then reads
+`⊘ Stood down — superseded SDK commit` rather than pointing a reader at a
+workflow misconfiguration that is not there.
+
+A stood-down run therefore reports green to the dispatching SDK commit — the same
+vacuous green the SDK-side gate gives that commit, for the same reason: it is no
+longer the commit under review, and only the head commit's run can satisfy a
+required check.
 
 ## SDR composite action inputs
 


### PR DESCRIPTION
Stacked on #3336 — review that first; this PR's diff against `main` includes it.

## The half #3336 could not reach

#3336 stops application-sdk dispatching e2e for a commit the PR has moved past. That check runs before the dispatch, so it can only see the window before the dispatch. A push landing after it leaves a connector run already in flight, and that run is two cases rather than one:

| the in-flight run | can it stand down? |
|---|---|
| has **acquired a tenant lease** | No. Cancelling is unsafe — `prepare-tenant` carries `if: always()` and finishes installing onto the tenants it holds on its way out. The queue is the right answer. |
| has **dispatched but not leased** | Yes, for free. It is still building the image and running unit and integration tests, holding nothing. |

The second case was measured on the same incident: openapi's stale run dispatched at 21:07:38 and did not acquire its lease until **21:10:10**. For those 2m30s it held nothing while the live commit was queueing behind it.

#3336's prose called the whole residual window "a live connector run holding a lease it legitimately took". That is only true of the first row. Corrected in that PR's second commit; this PR closes the second row.

## Changes

**1. `sdk-head-recheck` (`tests-reusable.yaml`, new `e2e-dispatch-recheck` action)**

Runs immediately before `lease-tenant` — as late as the DAG allows, because the answer is only worth as much as its freshness — and its output gates the lease, the install and the legs.

**2. Finding the pull request, which is the part worth reviewing**

The connector run is handed `application_sdk_ref` and nothing else, and a SHA alone is not enough. The obvious call does not work, and I checked before building on it:

```
$ gh api repos/atlanhq/application-sdk/commits/be82fade.../pulls
[]
$ gh api repos/atlanhq/application-sdk/commits/d47789e0.../pulls
[{"number": 3322, "state": "open", "head": "d47789e0..."}]
```

`GET /commits/{sha}/pulls` returns an **empty list** for a commit a force-push has moved past — precisely the case worth detecting.

So the number comes from the record that authorised the dispatch. `e2e_dispatch_guard.py` already claims `refs/e2e-dispatch/<app>/<sha>` pointing at a blob describing the claim; that blob now carries `pr_number`, and the recheck reads it back. Two properties make this work rather than merely work today:

- **It is a positive identification, not an inference.** No guessing from event shape, actor, or which optional inputs happen to be set.
- **The claim outlives the run that needs it.** The guard's prune only deletes a claim once that SHA's `Connector E2E run / <app>` check has settled — which cannot happen while this run is the thing that has yet to complete it. Both incident SHAs' claim refs are still live in the repo today.

A run with **no** claim ref is therefore not an SDK pull-request dispatch — someone pinning `application_sdk_ref` by hand — and is left alone. Without that, a deliberate manual run against a specific SDK commit would be skipped as a silent no-op.

**3. Where the gates read from**

Both `lease-tenant` and the `e2e` legs gate on `outputs.superseded`, never on the job's `result`, and both halves of that are load-bearing:

- A `needs.<job>.result` check would let an infrastructure failure of the recheck **skip** the lease — and a skipped lease skips the install and greens the run vacuously. The output is empty when the job did not answer, so `!= 'true'` leases exactly as before. The script exits 0 on every path for the same reason.
- `lease-tenant` gains `always()`, or the gate is never consulted: without a status-check function GitHub applies an implicit `success()` over every need and skips the job before the `if:` is read. That is also why `discover-e2e` and `merge-e2e-image` are now named explicitly there.
- The legs need their **own** clause. A *skipped* `lease-tenant` is the benign value in their existing gate — it is the `install-app-to-tenant: false` path — so gating the lease alone would leave every leg running against a tenant nobody installed onto with `expected-app-version` empty: a silently passing wrong-version run, the exact FND-31 failure the lease exists to prevent.

A stood-down run still reports to the dispatching SDK commit, and still reports green — the same vacuous green #3336 gives that commit, for the same reason.

## Not done, deliberately

The first row of the table. A connector run that already holds a lease stays holding it, and the live commit queues. Cancelling it is unsafe and the queue is correct.

## Testing

`.github/scripts/tests/test_e2e_dispatch_recheck.py` — 49 tests, driven by the real SHA pair from PR #3322.

- The superseded SHA stands down; the head does not; a differently-cased head is not two commits.
- **Every ambiguity proceeds**: no claim ref, a claim with no `pr_number` (which is what lets this ship without being in lockstep with the guard change), five unreadable-ref shapes, five unreadable-record shapes, five unreadable-PR shapes, a transport failure, and `pr_number: true` (bool is an int in Python and must not read as PR #1). A ref that is not a commit sha asks **nothing** — proven by the fake raising on any unstubbed call.
- The cross-repo ref contract is pinned from both ends: the namespace constants match, the guard actually *writes* `pr_number`, and `claim_ref` agrees with the guard's `slug()`-based one for every connector repo name in the fleet plus a mixed-case name.
- Wiring: the recheck precedes the lease, both gates read the output and not the result, `lease-tenant` carries `always()` with its needs named explicitly, the legs carry their own clause, install and release cascade off the lease, the app is keyed on the repo name and not the short app-name, and it is consumed `@main`.

Mutation-checked: reverting the leg clause, swapping the lease gate to `needs.<job>.result`, and dropping `pr_number` from the guard each fail their test.

Full `.github/scripts/tests/` suite: **3144 passed**. `pre-commit` clean on all changed files.

Security-relevant note for review: no new permissions. `sdk-head-recheck` runs on `contents: read` and every read is of public data in application-sdk. The token goes to curl through stdin (`-K -`) rather than argv, matching the lease client, with a test asserting it never reaches the command line.
