### PR TITLE
fix(conformance): fail the tenant lease where the missing grant can be named (FND-702)

### DIFF
--- a/.github/actions/e2e-tenant-lease/action.yaml
+++ b/.github/actions/e2e-tenant-lease/action.yaml
@@ -12,11 +12,15 @@ description: |
   first and does not work.
 
   Requires `contents: write` (to create and delete the ticket ref) and
-  `actions: read` (to tell a live holder from a dead one). Without them the
-  action warns and disables the lease rather than failing — each e2e leg
-  re-asserts the installed version independently (FND-31), so the lease reduces
-  contention rather than being the thing that makes a wrong-version run
-  detectable.
+  `actions: read` (to tell a live holder from a dead one). Without them `acquire`
+  FAILS, naming the missing grant.
+
+  It used to warn and proceed lease-less instead. That fail-open was never real:
+  `prepare-tenant` verifies its own tenant's lease before installing, finds none,
+  and reds every install leg two jobs later with an error that cannot be acted on
+  (FND-702). Note that a caller's `permissions:` block is exhaustive rather than
+  additive, so a caller that declares one must declare every scope the reusable
+  workflow's jobs use — declaring less is what CAUSES this failure.
 
 inputs:
   mode:
@@ -129,13 +133,10 @@ outputs:
     value: ${{ steps.lease.outputs.acquired }}
   state:
     description: |
-      "acquired"; "disabled" (no ref-write permission — the run proceeds
-      unserialised); "timeout" (the tenant stayed busy); or "rate-limited" (the
-      API never cleared, which fails rather than proceeding unserialised).
-
-      Worth asserting in anger rather than trusting a green job: "disabled" is a
-      deliberate fail-open, so a lease that is not working at all still leaves
-      the job green with only a warning.
+      "acquired"; "denied" (no ref-write permission in the calling workflow);
+      "timeout" (the tenant stayed busy); or "rate-limited" (the API never
+      cleared). Only "acquired" exits 0 — every other state fails the step, so a
+      green lease job means a lease was genuinely taken.
     value: ${{ steps.lease.outputs.state }}
   lease-ref:
     description: |

--- a/.github/actions/e2e-tenant-lease/e2e_tenant_lease.py
+++ b/.github/actions/e2e-tenant-lease/e2e_tenant_lease.py
@@ -116,18 +116,30 @@ sizing is load-bearing for release safety as well as for acquisition: see
 
 Failure posture
 ---------------
-* **No permission to write refs** is a ``::warning::`` and the run proceeds
-  *without* a lease. The lease reduces contention; it is not what keeps a
-  wrong-version run from passing — every leg re-asserts the installed version
-  itself (FND-31). Making an ungrantable lease fail the run would turn a safety
-  improvement into a new way for e2e to go red fleet-wide.
+* **No permission to write refs** fails the acquire, naming the grant that is
+  missing.
 
-  Note the limit of that backstop, which is easy to overstate: the version assert
-  catches a *wrong-version* run, not two runs installing the *same* version and
-  fighting over one tenant. Two dispatches of one commit do exactly that, and it
-  surfaces as a worker/task-queue failure rather than a version mismatch. So
-  fail-open is a real reduction in protection, not a no-op — which is why a rate
-  limit must never be allowed to trigger it.
+  This used to be a ``::warning::`` that returned ``disabled`` and exited 0, on
+  the reasoning that "making an ungrantable lease fail the run would turn a
+  safety improvement into a new way for e2e to go red fleet-wide". That
+  fail-open never existed (FND-702). ``prepare-tenant``'s first step runs this
+  same driver in ``--mode verify``, which needs only ``contents: read``, finds
+  no lease ref, and exits 1 under ``set -euo pipefail`` — so every
+  ``Prepare tenant`` leg failed, the e2e legs were skipped, and the gate went
+  red anyway. The choice was not being made; it was being *reversed* two jobs
+  later, at the cost of an error that said "re-run this job" when re-running
+  could not possibly help.
+
+  So the posture is now the one the code always had, said where it can be
+  explained: a lease that cannot be taken at all is a configuration error in the
+  caller's ``permissions:`` block, and it is reported at the acquire, by name.
+
+  Proceeding unserialised was the alternative and was rejected on its merits,
+  not merely because it was more work. The FND-31 version assert catches a
+  *wrong-version* run, not two runs installing the *same* version and fighting
+  over one tenant — two dispatches of one commit do exactly that, and it
+  surfaces as a worker/task-queue failure rather than a version mismatch. That
+  is also why a rate limit must never be allowed to reach this path.
 * **Not acquired within the wait budget** fails loudly, naming the holding run.
 
 Co-located with the composite action, and pinned ``@main`` by every consumer on
@@ -378,8 +390,10 @@ def _rate_limited(response: Response) -> bool:
 
     Both arrive as 403, and conflating them is how the lease used to switch
     itself OFF exactly when it was needed: several legs queueing for tenants is
-    also when the shared per-repository budget runs out, and the fail-open path
-    then let every waiting run proceed onto the tenant unserialised.
+    also when the shared per-repository budget runs out, and the (then
+    nominally fail-open) denial path let every waiting run give up on the lease.
+    The denial path fails the job now (FND-702), so the same conflation would
+    turn a busy hour into a red run blaming a permission the caller has.
 
     Detected from the headers first (``x-ratelimit-remaining: 0``, or a
     ``retry-after`` on a secondary limit) and the message second, so it does not
@@ -418,7 +432,7 @@ class RateLimited(Exception):
 
     An exception rather than a return value so every call site cannot forget to
     distinguish it from a permission denial — which is the mistake that made the
-    lease fail open under contention.
+    lease abandon itself under contention.
     """
 
     def __init__(self, retry_after: int | None = None) -> None:
@@ -431,8 +445,9 @@ def create_identity_blob(
 ) -> str | None:
     """Write the holder record the lease ref will point at.
 
-    Returns the blob sha, or None if ref writes are not permitted. Raises
-    ``RateLimited`` when the API is merely busy.
+    Returns the blob sha, or None if writes are not permitted — which the caller
+    turns into a red job naming the missing grant, not into a lease-less run.
+    Raises ``RateLimited`` when the API is merely busy.
 
     Written immediately before the CAS, not once per acquire, because the record
     carries the acquisition timestamp: a blob minted when the run first started
@@ -647,14 +662,23 @@ def _timestamp(value: object) -> float | None:
     return stamp.timestamp()
 
 
-_DISABLED_WARNING = (
-    "::warning::this repository will not let the run write git refs, so the "
-    "(app, cloud) tenant lease is disabled for this run and e2e proceeds "
-    "unserialised. Grant the lease job 'contents: write' to enable it. Each e2e "
-    "leg still asserts the installed version independently (FND-31), so a "
-    "WRONG-version run cannot pass silently — but two runs installing the SAME "
-    "version will still fight over the tenant, so this is a real loss of "
-    "protection, not a no-op."
+# Printed at the ONE place that can explain the failure. Reaching the install
+# without a lease is not survivable — `prepare-tenant` verifies its own tenant's
+# lease before installing and fails when there is none — so the choice here is
+# not "red or green", it is "red here with the fix, or red two jobs later with
+# 'Re-run this job'" (FND-702).
+_DENIED_ERROR = (
+    "::error::this run may not write git refs, so the (app, cloud) tenant lease "
+    "cannot be taken. This is a permissions problem in the CALLING workflow, not "
+    "a problem with the change under test, and re-running will not fix it: give "
+    "the job that calls tests-reusable.yaml `contents: write` and `actions: "
+    "read`. A `permissions:` block is exhaustive, not additive — every scope it "
+    "omits becomes `none` — so a caller that declares one must declare the whole "
+    "set the reusable's jobs use (see the block in the scaffolded tests.yaml). A "
+    "caller with NO block at all gets this only where the repository default is "
+    "read-only. Proceeding without the lease is not the fallback: two runs "
+    "installing the SAME version onto one tenant surface as a worker/task-queue "
+    "failure, which the FND-31 per-leg version assert does not catch."
 )
 
 
@@ -672,7 +696,7 @@ def acquire(
 ) -> tuple[str, Holder | None]:
     """Take the lease, or report why not.
 
-    Returns ("acquired" | "disabled" | "timeout" | "rate-limited",
+    Returns ("acquired" | "denied" | "timeout" | "rate-limited",
     blocking_holder_or_None).
 
     Each waiting pass costs two API calls: read the ref, and check the holding
@@ -700,8 +724,8 @@ def acquire(
             try:
                 blob_sha = create_identity_blob(repo, run_id, attempt, clock())
                 if blob_sha is None:
-                    print(_DISABLED_WARNING)
-                    return "disabled", None
+                    print(_DENIED_ERROR)
+                    return "denied", None
                 outcome = try_acquire(repo, ref, blob_sha)
             except RateLimited as limited:
                 rate_limited = True
@@ -713,8 +737,8 @@ def acquire(
                 print(f"Tenant lease acquired: {ref}")
                 return "acquired", None
             if outcome == "denied":
-                print(_DISABLED_WARNING)
-                return "disabled", None
+                print(_DENIED_ERROR)
+                return "denied", None
             # "occupied": somebody won the race between our read and our CAS.
             # Re-read next pass; the CAS was the authority, as intended.
             print("Lost the race for the tenant lease; it is held again.")
@@ -787,7 +811,7 @@ def acquire_ordered(
 ) -> OrderedOutcome:
     """Take EVERY cloud's lease, in a fixed order, under one total budget.
 
-    ``state`` is "acquired" | "disabled" | "timeout" | "rate-limited", and
+    ``state`` is "acquired" | "denied" | "timeout" | "rate-limited", and
     "acquired" is all-or-nothing: any other state hands back whatever was taken
     on the way, so the caller either holds the whole set or nothing.
 
@@ -913,17 +937,18 @@ def release_all(repo: str, refs: list[str], run_id: int, attempt: int) -> None:
 def _sleep_for_rate_limit(sleep, poll_seconds: int, retry_after: int | None) -> None:
     """Back off after a rate limit, honouring Retry-After within reason.
 
-    Never returns "disabled" to the caller: a rate limit is a reason to wait, not
-    evidence that the lease cannot be taken. Switching the lease off here would
-    do it precisely when several legs are contending, which is both when the
-    budget runs out and when the lease matters most.
+    Never returns "denied" to the caller: a rate limit is a reason to wait, not
+    evidence that the caller lacks the grant. Reporting it as a denial would do
+    so precisely when several legs are contending — which is both when the budget
+    runs out and when the lease matters most — and would send whoever read the
+    log to fix a `permissions:` block that was already correct.
     """
     delay = poll_seconds
     if retry_after is not None:
         delay = max(poll_seconds, min(retry_after, _MAX_RETRY_AFTER))
     print(
         "::warning::rate-limited by the GitHub API while taking the tenant lease; "
-        f"backing off {delay}s and retrying. The lease is NOT being disabled — "
+        f"backing off {delay}s and retrying. This is NOT a permission problem — "
         "the per-repository budget is shared by every matrix leg, so this is "
         "expected under contention."
     )
@@ -1004,7 +1029,9 @@ def verify_held(repo: str, ref: str, run_id: int, attempt: int) -> bool:
         print(
             f"::error::this run does not hold the tenant lease {ref} — it is "
             "unheld or its holder record is unreadable, so installing now could "
-            "race another run. Re-run this job."
+            "race another run. Read the 'Tenant lease' job's log before "
+            "re-running: if the acquire itself failed, its error says why and "
+            "re-running this job cannot help."
         )
         return False
     if not holder.is_me(run_id, attempt):
@@ -1191,8 +1218,15 @@ def main(argv: list[str] | None = None) -> int:
         os.environ.get("GITHUB_OUTPUT"),
     )
 
-    if state in ("acquired", "disabled"):
+    if state == "acquired":
         return 0
+
+    if state == "denied":
+        # The message was printed at the point of denial, where the specific call
+        # that was refused is still in hand. Exiting non-zero here is the whole of
+        # FND-702: the run cannot install without a lease either way, so this
+        # moves the red to the one job that can say what to grant.
+        return 1
 
     if state == "rate-limited":
         # Deliberately NOT fail-open: proceeding unserialised because the API was

--- a/.github/scripts/tests/test_e2e_tenant_lease.py
+++ b/.github/scripts/tests/test_e2e_tenant_lease.py
@@ -678,19 +678,33 @@ def test_acquire_retries_when_the_holder_is_unreadable(http: FakeHTTP) -> None:
     assert http.count("DELETE", "/git/refs/") == 0
 
 
-def test_acquire_disables_itself_without_blob_write(http: FakeHTTP) -> None:
-    # Fail-open: the lease reduces contention, it is not what makes a
-    # wrong-version run detectable (each leg re-asserts the version, FND-31).
+def test_acquire_is_denied_without_blob_write(http: FakeHTTP) -> None:
+    # NOT fail-open (FND-702). The predecessor returned "disabled" and exited 0
+    # on the theory that the run proceeded unserialised; it never did — the
+    # install's own verify step reds every Prepare tenant leg two jobs later.
     _stub_unheld(http)
     http.route("POST", "/git/blobs", _PERMISSION_DENIED)
-    assert _acquire() == ("disabled", None)
+    assert _acquire() == ("denied", None)
 
 
-def test_acquire_disables_itself_without_ref_write(http: FakeHTTP) -> None:
+def test_acquire_is_denied_without_ref_write(http: FakeHTTP) -> None:
     _stub_unheld(http)
     _stub_blob_write(http)
     http.route("POST", "/git/refs", _PERMISSION_DENIED)
-    assert _acquire() == ("disabled", None)
+    assert _acquire() == ("denied", None)
+
+
+@pytest.mark.parametrize("refused", ["/git/blobs", "/git/refs"])
+def test_a_denial_does_not_keep_retrying(http: FakeHTTP, refused: str) -> None:
+    # A denial is a fact about the token, not about timing, so it must answer on
+    # the first pass rather than burning the whole wait budget re-learning it.
+    _stub_unheld(http)
+    _stub_blob_write(http)
+    http.route("POST", refused, _PERMISSION_DENIED)
+    slept: list[int] = []
+    state, _ = _acquire(wait_seconds=300, poll_seconds=1, sleep=slept.append)
+    assert state == "denied"
+    assert slept == []
 
 
 def test_acquire_respects_the_wait_budget(http: FakeHTTP) -> None:
@@ -1135,13 +1149,41 @@ def test_main_acquire_can_warn_instead_of_failing(
     assert "::warning::" in capsys.readouterr().out
 
 
-def test_main_acquire_exits_zero_when_the_lease_is_disabled(
-    http: FakeHTTP, monkeypatch: pytest.MonkeyPatch
+def test_main_acquire_fails_when_the_lease_cannot_be_taken(
+    http: FakeHTTP, capsys, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    # FND-702: the documented fail-open was fail-closed. `prepare-tenant` runs
+    # this same driver in --mode verify, which needs only `contents: read`,
+    # finds no lease and exits 1 under `set -euo pipefail` — so exiting 0 here
+    # bought nothing except a red two jobs later saying "Re-run this job", which
+    # cannot help. Exit non-zero at the one place that can name the grant.
     monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
     _stub_unheld(http)
     http.route("POST", "/git/blobs", _PERMISSION_DENIED)
-    assert main(_argv("acquire")) == 0
+    assert main(_argv("acquire")) == 1
+    printed = capsys.readouterr().out
+    assert "::error::" in printed
+    # Names the grant, the workflow to grant it in, and that retrying is futile.
+    assert "contents: write" in printed
+    assert "actions: read" in printed
+    assert "re-running will not fix it" in printed
+    assert "::warning::" not in printed
+
+
+def test_main_acquire_reports_denied_in_its_outputs(
+    http: FakeHTTP, tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A caller that reads `state` must see the denial, not a value that reads as
+    # a benign posture. `acquired` stays false, so no consumer can mistake it.
+    output = tmp_path / "outputs"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(output))
+    _stub_unheld(http)
+    http.route("POST", "/git/blobs", _PERMISSION_DENIED)
+    assert main(_argv("acquire")) == 1
+    written = output.read_text()
+    assert "state=denied" in written
+    assert "acquired=false" in written
+    assert "lease-refs=\n" in written
 
 
 def test_main_acquire_fails_on_a_persistent_rate_limit(
@@ -1393,6 +1435,27 @@ def test_ordered_acquisition_deduplicates_across_spellings(http: FakeHTTP) -> No
     assert list(outcome.held) == [_ref_for("aws")]
 
 
+def test_ordered_acquisition_reports_a_denial_on_the_first_cloud(
+    http: FakeHTTP,
+) -> None:
+    # A denial is repo-wide, so it answers on the FIRST lease of the set rather
+    # than being rediscovered per cloud. It must reach the caller as "denied" and
+    # not as the timeout it would look like if the state were swallowed — the
+    # two have opposite remedies ("grant the token" vs "wait for the tenant").
+    for cloud in ("aws", "azure", "gcp"):
+        http.route("GET", _path_of(_ref_for(cloud)), (404, {"message": "Not Found"}))
+    http.route("POST", "/git/blobs", _PERMISSION_DENIED)
+
+    outcome = _ordered(["aws", "azure", "gcp"])
+
+    assert outcome.state == "denied"
+    assert outcome.held == ()
+    assert outcome.ref == _ref_for("aws")
+    # Nothing was taken, so nothing is given back — and in particular the unwind
+    # does not issue a DELETE the same token cannot make either.
+    assert http.count("DELETE", "/git/refs/") == 0
+
+
 def test_a_blocked_cloud_gives_back_what_was_already_held(http: FakeHTTP) -> None:
     """The whole point. Holding aws while blocking on azure is hold-and-wait —
     exactly the shape that deadlocked when two runs split a freed set — so a run
@@ -1520,6 +1583,21 @@ def test_main_acquire_reports_the_whole_set_it_holds(
     assert "acquired=true" in written
     assert f"lease-refs={_ref_for('aws')},{_ref_for('gcp')}" in written
     assert "clouds=aws,gcp" in written
+
+
+def test_main_acquire_fails_when_the_whole_set_is_denied(
+    http: FakeHTTP, capsys, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The path lease-tenant actually takes — it always passes --clouds — so the
+    # FND-702 exit code has to hold on the ordered branch too, not only on the
+    # single-tenant one.
+    monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+    for cloud in ("aws", "azure", "gcp"):
+        http.route("GET", _path_of(_ref_for(cloud)), (404, {"message": "Not Found"}))
+    http.route("POST", "/git/blobs", _PERMISSION_DENIED)
+
+    assert main(_argv_clouds("acquire", "aws,azure,gcp")) == 1
+    assert "::error::" in capsys.readouterr().out
 
 
 def test_main_acquire_with_an_empty_cloud_list_falls_back_to_one_tenant(

--- a/.github/workflows/tests-reusable.yaml
+++ b/.github/workflows/tests-reusable.yaml
@@ -1530,6 +1530,14 @@ jobs:
       # Ref writes create and delete the lease ticket. Scoped to THIS job on
       # purpose: the long-running e2e legs below keep read-only contents, so the
       # write capability lives only in a job that runs no test code.
+      #
+      # A called workflow's permissions can only EQUAL or NARROW the caller's, so
+      # this declaration is a ceiling and not a grant: if the calling repo's
+      # `tests:` job has no `contents: write` — because it declares a narrower
+      # `permissions:` block, or because the repo default is read-only — the
+      # acquire below fails, by design and with an error naming the grant
+      # (FND-702). The canonical scaffolded tests.yaml declares the whole set for
+      # exactly this reason.
       contents: write
       # Tell a live holder from a dead one, which is what makes a cancelled run's
       # abandoned ticket self-healing.

--- a/docs/standards/ci.md
+++ b/docs/standards/ci.md
@@ -524,8 +524,37 @@ Three further consequences to design for:
   failure.
 * Ref writes need `contents: write`, so put acquire/release in their own small
   jobs and leave the jobs that execute test code read-only.
-* If the lease fails open when it cannot be taken (the right default when a
-  separate assertion already catches the underlying hazard), then a broken lease
-  looks exactly like a working one — green, with a warning. **Assert the acquire
-  step's `state` output in anger** when verifying, rather than concluding from an
-  absence of red.
+* **A fail-open is only a fail-open if every consumer downstream agrees.** This
+  lease used to warn and return `disabled` when it could not write refs, on the
+  reasoning that failing an ungrantable lease would turn a safety improvement
+  into a fleet-wide red. It did not proceed: the install job verifies its own
+  tenant's lease before installing, needs only `contents: read` to do it, finds
+  nothing, and reds — so the run went red anyway, two jobs later, with an error
+  saying "re-run this job" when re-running could not help (FND-702). The posture
+  was not being chosen; it was being *reversed* by a consumer, at the cost of the
+  one message that could have explained it. Before writing a fail-open, walk
+  every consumer of the thing you are failing open on and check that it tolerates
+  the degraded value; if any one of them does not, the fail-open is fiction, and
+  the honest version is to fail where the cause is still in hand.
+
+### Declare the permissions a reusable workflow needs, in the caller
+
+A called workflow's `permissions` can only **equal or narrow** its caller's, so a
+job in the reusable declaring `contents: write` is a ceiling, never a grant. A
+caller with no block at all satisfies it purely from the repository's
+`default_workflow_permissions` — which means tightening that setting, an ordinary
+hardening step, silently strips the grant from every adopted repo at once, with
+nothing in the resulting failure pointing at the cause.
+
+So the canonical scaffolded `tests.yaml` declares the set explicitly. Two things
+make that edit easy to get wrong:
+
+* **A `permissions:` block is exhaustive, not additive.** Every scope it omits
+  becomes `none`. A well-meaning `permissions: {contents: read}` on the caller is
+  strictly *worse* than declaring nothing, because it clamps a job whose
+  repository default would have carried it.
+* **Derive the set from the reusable, in a test.** `test_tests_yaml_permissions`
+  reads every `permissions:` block in `tests-reusable.yaml`, takes the strongest
+  level each scope is used at, and asserts the scaffolded caller declares exactly
+  that — so adding a scope to a job of the reusable fails there rather than
+  silently arriving as `none` in every connector.

--- a/packages/conformance/conformance/bootstrap/templates/tests.yaml
+++ b/packages/conformance/conformance/bootstrap/templates/tests.yaml
@@ -95,6 +95,38 @@ on:
 
 jobs:
   tests:
+    # Declared rather than inherited from the repository default, because a
+    # called workflow's permissions can only EQUAL or NARROW its caller's. Every
+    # scope below is one the reusable workflow's own jobs declare; leaving this
+    # block out makes the whole set depend on `default_workflow_permissions`
+    # being `write`, so tightening that setting — an ordinary hardening step —
+    # would silently strip `contents: write` from the tenant lease and red the
+    # e2e install in every adopted connector at once (FND-702).
+    #
+    # A `permissions:` block is EXHAUSTIVE, not additive: every scope it omits
+    # becomes `none`. So this cannot be trimmed to "the ones this repo looks like
+    # it needs" — narrowing any line here clamps the reusable's job that uses it.
+    # If you are tempted to cut one, cut the job that needs it in
+    # application-sdk instead.
+    permissions:
+      # The (app, cloud) tenant lease: creates and deletes the lease ref that
+      # serialises e2e runs against a shared tenant. Held only by application-
+      # sdk's lease/release jobs, never by a job that runs connector test code.
+      contents: write
+      # Tells a live lease holder from a dead one, so a cancelled run's
+      # abandoned lease is self-healing rather than blocking the tenant.
+      actions: read
+      # Pushes and pulls the per-run e2e image from GHCR.
+      packages: write
+      # The unit tier's coverage-delta comment and the e2e tier's PR reporting.
+      pull-requests: write
+      # The e2e tier's commit status on the SDK commit that dispatched it.
+      statuses: write
+      # Mints the run's OIDC token for the dataforge source-credential exchange
+      # (no stored dataforge secret). Never granted by a repository default at
+      # any setting, so it only works when declared here. Inert — the fetch
+      # chain self-skips — in a repo that does not use dataforge.
+      id-token: write
     uses: atlanhq/application-sdk/.github/workflows/tests-reusable.yaml@main
     with:
 <% if unit_coverage_fail_under %>      unit-coverage-fail-under: "<< unit_coverage_fail_under >>"

--- a/packages/conformance/tests/test_tests_yaml_permissions.py
+++ b/packages/conformance/tests/test_tests_yaml_permissions.py
@@ -1,0 +1,149 @@
+"""The scaffolded ``tests.yaml`` must declare the token the reusable needs (FND-702).
+
+A called workflow's ``permissions`` can only EQUAL or NARROW its caller's, so a
+caller with no block at all satisfies ``tests-reusable.yaml``'s ``contents:
+write`` purely from ``default_workflow_permissions`` being ``write``. Tightening
+that repository setting — an ordinary hardening step, and one that could
+plausibly be applied org-wide — would then strip the tenant lease's ref-write
+grant in every adopted connector at once.
+
+Two things are pinned here, and the second is the one that keeps working after
+this change is forgotten:
+
+* the block exists and carries the lease's own two grants, by name; and
+* its scope set is derived from ``tests-reusable.yaml`` rather than restated, so
+  a new scope added to any job of the reusable fails HERE, at the one place a
+  caller could otherwise silently clamp it to ``none``.
+
+That second property is why a caller's block is dangerous to add carelessly: a
+``permissions:`` block is exhaustive, not additive. Declaring
+``permissions: {contents: read}`` on the caller is strictly worse than declaring
+nothing, because it clamps the lease job whose default would have carried it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+from conformance.bootstrap.extract import (
+    declared_keys,
+    unpreserved_tests_yaml_declarations,
+)
+from conformance.bootstrap.render import render
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_REUSABLE = _REPO_ROOT / ".github/workflows/tests-reusable.yaml"
+
+#: GitHub's permission levels, weakest first. Used to take the maximum a scope is
+#: declared at across the reusable's jobs — a caller has ONE block covering every
+#: job it calls, so it must carry each scope at the strongest level any job uses.
+_LEVELS = ("none", "read", "write")
+
+
+def _caller_job() -> dict:  # type: ignore[type-arg]
+    """The `tests:` job of the canonical scaffolded caller, as GitHub reads it."""
+    rendered = yaml.safe_load(render("tests.yaml", app_name="example"))
+    return rendered["jobs"]["tests"]
+
+
+def _required_scopes() -> dict[str, str]:
+    """Every scope the reusable's jobs declare, at the strongest level used.
+
+    Read from the workflow rather than listed, so this file cannot fall out of
+    date with it: adding `checks: write` to one job of the reusable makes the
+    assertions below fail until the scaffolded caller carries it too.
+    """
+    workflow = yaml.safe_load(_REUSABLE.read_text(encoding="utf-8"))
+    required: dict[str, str] = {}
+    for job in workflow["jobs"].values():
+        for scope, level in (job.get("permissions") or {}).items():
+            if _LEVELS.index(level) > _LEVELS.index(required.get(scope, "none")):
+                required[scope] = level
+    return required
+
+
+def test_the_scaffolded_caller_declares_a_permissions_block() -> None:
+    assert "permissions" in _caller_job(), (
+        "without a block the whole fleet's e2e install depends on "
+        "default_workflow_permissions being `write` (FND-702)"
+    )
+
+
+def test_the_scaffolded_caller_grants_the_tenant_lease_its_two_permissions() -> None:
+    # Named explicitly as well as derived below, because these two are the ones
+    # whose absence produces the FND-702 failure: the acquire is denied, and
+    # every `Prepare tenant` leg then reds on a lease that was never taken.
+    permissions = _caller_job()["permissions"]
+    assert permissions["contents"] == "write"  # create/delete the lease ref
+    assert permissions["actions"] == "read"  # tell a live holder from a dead one
+
+
+def test_the_scaffolded_caller_declares_every_scope_the_reusable_uses() -> None:
+    # The wiring assertion. A caller's block is exhaustive rather than additive,
+    # so any scope missing here is `none` for every job of the reusable —
+    # regardless of what that job declares for itself.
+    permissions = _caller_job()["permissions"]
+    for scope, level in _required_scopes().items():
+        assert scope in permissions, (
+            f"tests-reusable.yaml declares `{scope}: {level}` on one of its jobs, "
+            f"but the scaffolded caller omits it — which clamps it to `none`. Add "
+            f"it to conformance/bootstrap/templates/tests.yaml."
+        )
+        assert _LEVELS.index(permissions[scope]) >= _LEVELS.index(level), (
+            f"the scaffolded caller declares `{scope}: {permissions[scope]}` but "
+            f"the reusable needs `{level}`; a caller can only narrow."
+        )
+
+
+def test_the_scaffolded_caller_grants_nothing_the_reusable_does_not_use() -> None:
+    # Least privilege in the other direction: the block is a ceiling for every
+    # job of the reusable, so an extra scope is a standing grant to code that
+    # never asked for it. Failing here means either delete the line, or the job
+    # that needs it belongs in the reusable where it is reviewable.
+    extra = set(_caller_job()["permissions"]) - set(_required_scopes())
+    assert not extra, f"the scaffolded caller grants unused scopes: {sorted(extra)}"
+
+
+# ── The rollout has to survive --resync (FND-604) ────────────────────────────
+
+
+def _existing_without_permissions() -> str:
+    """A repo's tests.yaml as it stands today: the canonical, block removed."""
+    rendered = render("tests.yaml", app_name="example")
+    lines = rendered.splitlines(keepends=True)
+    start = next(i for i, line in enumerate(lines) if line.strip() == "permissions:")
+    end = next(
+        i for i in range(start + 1, len(lines)) if lines[i].lstrip().startswith("uses:")
+    )
+    stripped = "".join(lines[:start] + lines[end:])
+    # By the same structural reading `unpreserved_declarations` uses, so the
+    # surrounding comment block — which says the word — cannot make this vacuous.
+    assert "permissions" not in declared_keys(stripped)
+    return stripped
+
+
+def test_resync_onto_a_caller_that_predates_the_block_drops_nothing() -> None:
+    # FND-604 makes --resync REFUSE when the re-render would delete a declaration
+    # the file carries. Adding a block only ever adds keys, so every already-
+    # adopted repo can take this update with a plain `bootstrap --resync`.
+    dropped = unpreserved_tests_yaml_declarations(
+        _existing_without_permissions(), render("tests.yaml", app_name="example")
+    )
+    assert dropped == []
+
+
+def test_resync_onto_a_caller_that_hand_rolled_its_own_block_drops_nothing() -> None:
+    # The dangerous edit this change exists to pre-empt — a well-meaning
+    # `permissions: contents: read` — is a key present on BOTH sides, so the
+    # resync proceeds and overwrites it with the correct set rather than
+    # refusing and leaving the clamp in place.
+    hand_rolled = _existing_without_permissions().replace(
+        "  tests:\n",
+        "  tests:\n    permissions:\n      contents: read\n",
+        1,
+    )
+    dropped = unpreserved_tests_yaml_declarations(
+        hand_rolled, render("tests.yaml", app_name="example")
+    )
+    assert dropped == []


### PR DESCRIPTION
Stacked on #3339 (which is stacked on #3336) — review those first; this PR's diff against `main` includes them.

## Two defects, one code path

Neither is live today. `default_workflow_permissions` is `write` in application-sdk, atlan-openapi-app, atlan-mysql-app and atlan-metabase-app, and the lease acquires in 8–11s across all three apps. This is a landmine with a specific, plausible trigger.

### 1. The documented fail-open is fail-closed

`e2e_tenant_lease.py` treated "cannot write refs" as a deliberate fail-open — `create_identity_blob` returns `None`, `acquire` returns `disabled`, `main` exits **0** with:

> this repository will not let the run write git refs … so the (app, cloud) tenant lease is disabled for this run and **e2e proceeds unserialised**.

It does not proceed. `prepare-tenant`'s first step runs the same driver in `--mode verify`, which reads the lease ref (only needs `contents: read`, which that job has), finds nothing, and exits 1:

> this run does not hold the tenant lease … Re-run this job.

The step carries `set -euo pipefail`, so every `Prepare tenant (<cloud>)` leg fails, the e2e legs are skipped, and the gate goes red — with an error that says "re-run this job" when re-running cannot possibly help.

The module docstring's own justification for failing open was that *"making an ungrantable lease fail the run would turn a safety improvement into a new way for e2e to go red fleet-wide"*. That is exactly what happened. The choice was not being made; it was being **reversed two jobs later**, at the cost of the one message that could have explained it.

**Fixed by taking the posture the code already had, and saying it where it can be explained.** `acquire` returns `denied`, `main` exits 1, and the error names `contents: write`, `actions: read`, the workflow to grant them in, and that re-running will not help.

Proceeding unserialised was the alternative, and is rejected on its merits rather than for being more work: the FND-31 per-leg version assert catches a *wrong-version* run, not two runs installing the *same* version onto one tenant — that surfaces as a worker/task-queue failure, which nothing in the run asserts on. Making `verify` tolerant is the one edit that converts this loud red into a silent unserialised install on every tenant; the docstring now says so, in case someone reaches for it while working FND-696's isolation TODO.

`verify`'s own message gains a pointer to the lease job, so the reader is sent to the log that has the cause rather than to a re-run button.

### 2. No connector declares the permission the lease needs

`atlan-openapi-app`'s `tests.yaml` (bootstrap-scaffolded, drift-tracked at WARN by C002) has **no** `permissions:` block at all — not workflow-level, not on the `tests:` job. A called workflow's `permissions` can only equal or narrow its caller's, so `lease-tenant`'s `contents: write` was satisfied purely by the repo's permissive default. Tightening `default_workflow_permissions` to `read` — a normal hardening step, and one that could plausibly be applied org-wide — would have reded the e2e install in **every** adopted connector at once, via defect 1, with nothing pointing at the cause.

The canonical `tests.yaml` now declares the block.

**It declares every scope the reusable uses, not just the lease's two, and that is the part worth reviewing.** A `permissions:` block is **exhaustive, not additive** — every scope it omits becomes `none`. So the tempting minimal edit, `permissions: {contents: write, actions: read}`, would silently strip `packages: write` (the GHCR push), `pull-requests: write` (the coverage comment), `statuses: write` (the commit status on the dispatching SDK commit) and `id-token: write` (the dataforge OIDC exchange) from the reusable's jobs. A `permissions: {contents: read}` would be worse than declaring nothing at all.

One of the six is a genuine new grant rather than a re-declaration: `id-token` is `none` under a repository default at *any* setting, so the reusable's `id-token: write` on the integration and e2e jobs has never been effective in a scaffolded caller. The dataforge fetch chain self-skips where the inputs are unset, so this is inert in a repo that does not use dataforge.

## What keeps this correct after it is forgotten

The set is **derived from `tests-reusable.yaml`, not restated**. `test_tests_yaml_permissions` reads every job's `permissions:` block, takes the strongest level each scope is used at, and asserts the scaffolded caller declares exactly that — in both directions:

- a scope the reusable uses and the template omits fails there, rather than arriving as `none` in every connector;
- a scope the template grants and no job uses fails too, so the block cannot quietly accumulate standing grants.

## Rollout survives `--resync` (FND-604)

`--resync` refuses when the re-render would delete a declaration the file carries. Adding a block only ever *adds* keys, so no already-adopted repo is blocked. Pinned from both ends:

- a caller that predates the block (the canonical with the block removed) drops nothing;
- a caller that hand-rolled `permissions: contents: read` also drops nothing — `permissions` is present on both sides, so the resync proceeds and **overwrites** the clamp rather than refusing and leaving it in place. That is the right outcome for the one edit most likely to be made by hand.

The fleet rollout itself (`bootstrap --resync` in each adopted connector) is not in this PR.

## Testing

`.github/scripts/tests/test_e2e_tenant_lease.py` — the three tests that pinned the old exit-0 posture are rewritten, not deleted, and five are added:

- a denial answers on the **first** pass rather than burning the wait budget (parametrised over the blob write and the ref write), since a denial is a fact about the token and not about timing;
- `main` exits 1, prints `::error::` and no `::warning::`, and the message names both grants and says retrying is futile;
- the outputs carry `state=denied` with `acquired=false`, so a consumer reading `state` cannot mistake it for a benign posture;
- `acquire_ordered` propagates `denied` from the first cloud, holds nothing, and issues **no** `DELETE` — an unwind must not attempt a write the same token cannot make either;
- the `--clouds` branch `main` actually takes (lease-tenant always passes `--clouds`) exits 1 too.

`packages/conformance/tests/test_tests_yaml_permissions.py` — 6 tests, covering the block's existence, the lease's two grants by name, both directions of the derived set, and the two resync shapes above.

Mutation-checked: deleting `packages: write` from the template fails the derived wiring test with a message naming the scope and the file to edit.

`.github/scripts/tests/`: **3149 passed**. `packages/conformance/tests/`: **2859 passed**. `pre-commit` clean on all changed files.

Security-relevant note for review: this PR *widens* the token in scaffolded connector callers by one scope (`id-token: write`, discussed above) and pins the other five at the level the reusable already declared. It narrows nothing, and adds no permission to any application-sdk job.
