### PR TITLE
ci(e2e): make retrying a failed connector leg on the same commit work

### DIFF
--- a/.github/scripts/e2e_dispatch_guard.py
+++ b/.github/scripts/e2e_dispatch_guard.py
@@ -73,9 +73,21 @@ automatically final. A contender that finds the slot taken resolves it as:
 * claimed by **this run** (any attempt) — proceed. This is a job re-run, and the
   operator asking for a re-run is asking for a re-dispatch.
 * claimed by another run, and a ``Connector E2E run / <app>`` check run exists on
-  this SHA — **skip**. The dispatch happened; its verdict is that check, and the
-  connector gate on every one of the duplicate runs polls the same check and
-  reports the same answer. Nothing is lost by not dispatching again.
+  this SHA that has **not concluded**, or whose newest attempt concluded as a
+  PASS — **skip**. Either the dispatch is still being answered or it has been
+  answered; its verdict is that check, and the connector gate on every one of the
+  duplicate runs polls the same check and reports the same answer.
+* claimed by another run, every check under that name has concluded, the NEWEST
+  concluded non-passing, and the claiming run is **over** — reap the claim and
+  re-dispatch. A failed leg is the one already-dispatched state with a question
+  still worth asking, and re-adding the ``e2e`` label is how people ask it.
+  Newest rather than any, because a SHA retried once keeps the old attempt's
+  failed check and any-failure would re-trigger forever; every attempt concluded
+  rather than just the newest, because an older one still running means its
+  connector run is still at the tenant.
+* same, but the claiming run is **still live** — skip. It may be mid-re-run of
+  its own dispatch job (see the first case), and that plus a reclaim here is two
+  dispatches contending for one tenant.
 * claimed by another run with no such check, and that run is **still live** —
   skip. A peer is between its claim and its check creation, a window of one API
   call.
@@ -185,6 +197,13 @@ _OPEN_PR_MAX_PAGES = 5
 # it is reported as "unreadable" rather than "no dispatch found" — the direction
 # that fails open.
 _CHECKS_MAX_PAGES = 10
+
+# Conclusions that mean "this leg has an answer, do not re-dispatch it". Kept
+# identical to poll_check_runs_gate.PASSING_CONCLUSIONS: the gate calls these a
+# pass, so treating any of them as retryable here would re-run a leg the required
+# check is already green on. Everything else — failure, cancelled, timed_out,
+# action_required, stale — is a question still worth re-asking.
+_PASSING_CONCLUSIONS = frozenset({"success", "neutral", "skipped"})
 
 _SAFE_SLUG_CHARS = frozenset("abcdefghijklmnopqrstuvwxyz0123456789._-")
 _SHA_RE = re.compile(r"\A[0-9a-f]{7,64}\Z")
@@ -508,15 +527,73 @@ def delete_ref(repo: str, ref: str) -> bool:
     return response.status in (200, 204)
 
 
-def dispatch_exists(repo: str, sha: str, check_run_name: str) -> bool | None:
-    """Did the claimer get as far as creating its check run on ``sha``?
+def check_run_age_key(check_run: dict) -> tuple[str, int]:
+    """Sort key that orders same-named check runs oldest-first.
 
-    True/False, or None when the answer is unreadable. The check run is created
-    immediately before the dispatch, so its presence is the evidence that a
-    dispatch either happened or is one API call away from happening.
+    Deliberately a copy of ``poll_check_runs_gate.check_run_age_key`` rather than
+    an import: nothing in .github/scripts imports a sibling script (every one is
+    a self-contained stdlib-only entry point), and the two must agree or the
+    guard would judge a retry against a different attempt than the gate reports.
+    ``test_the_guard_and_the_gate_order_check_runs_identically`` imports both and
+    holds them to the same table.
     """
-    state = checks_state(repo, sha, check_run_name)
-    return None if state is None else state != "absent"
+    started_at = check_run.get("started_at")
+    check_id = check_run.get("id")
+    return (
+        started_at if isinstance(started_at, str) else "",
+        check_id if isinstance(check_id, int) else 0,
+    )
+
+
+@dataclass(frozen=True)
+class DispatchState:
+    """What the check runs on a SHA say about one app's dispatch."""
+
+    #: Any check at all under this name, i.e. a dispatch happened (or is one API
+    #: call away from happening).
+    dispatched: bool
+    #: EVERY check under this name has concluded. Not just the newest: an older
+    #: attempt still in flight means its connector run is still at the tenant,
+    #: and re-dispatching on top of that is the contention this module prevents.
+    settled: bool
+    #: Conclusion of the newest attempt, None if it has not concluded or carries
+    #: no conclusion. Newest, not folded: a retried SHA keeps the old attempt's
+    #: check, so any-failure would re-trigger a leg that has since passed on
+    #: every subsequent event, forever.
+    newest_conclusion: str | None
+
+    @property
+    def retryable(self) -> bool:
+        """Is there a failed answer here that is worth asking again?"""
+        return (
+            self.dispatched
+            and self.settled
+            and self.newest_conclusion is not None
+            and self.newest_conclusion not in _PASSING_CONCLUSIONS
+        )
+
+
+def read_dispatch_state(
+    repo: str, sha: str, check_run_name: str
+) -> DispatchState | None:
+    """One listing, both answers. None when the listing is unreadable.
+
+    Deliberately not two calls (``dispatch_exists`` plus a conclusion read):
+    they would be two separate listings of the same endpoint that could disagree
+    across the gap, and the second would be pure cost.
+    """
+    matches = named_check_runs(repo, sha, check_run_name)
+    if matches is None:
+        return None
+    if not matches:
+        return DispatchState(dispatched=False, settled=False, newest_conclusion=None)
+    newest = max(matches, key=check_run_age_key)
+    conclusion = newest.get("conclusion")
+    return DispatchState(
+        dispatched=True,
+        settled=all(entry.get("status") == _COMPLETED for entry in matches),
+        newest_conclusion=conclusion if isinstance(conclusion, str) else None,
+    )
 
 
 def checks_state(repo: str, sha: str, check_run_name: str) -> str | None:
@@ -537,6 +614,25 @@ def checks_state(repo: str, sha: str, check_run_name: str) -> str | None:
     Anything that prevents full coverage — a failed page, a missing page, more
     pages than the cap — is "unreadable" rather than "absent", so the callers
     fall open instead of acting on a partial list.
+    """
+    matches = named_check_runs(repo, sha, check_run_name)
+    if matches is None:
+        return None
+    if not matches:
+        return "absent"
+    return "done" if all(e.get("status") == _COMPLETED for e in matches) else "running"
+
+
+def named_check_runs(repo: str, sha: str, check_run_name: str) -> list[dict] | None:
+    """Every check run on ``sha`` called ``check_run_name``; None if unreadable.
+
+    A list rather than a verdict because a retried SHA legitimately carries more
+    than one: ``create_check_run.py`` POSTs a fresh check per dispatch instead of
+    PATCHing the previous attempt's. Callers decide what to do with several —
+    ``checks_state`` folds them (any still running ⇒ running), while
+    ``newest_conclusion`` picks the latest.
+
+    See ``checks_state`` for why this paginates and why partial coverage is None.
     """
     matches: list[dict] = []
     seen = 0
@@ -581,9 +677,7 @@ def checks_state(repo: str, sha: str, check_run_name: str) -> str | None:
         )
         return None
 
-    if not matches:
-        return "absent"
-    return "done" if all(e.get("status") == _COMPLETED for e in matches) else "running"
+    return matches
 
 
 def claim_is_settled(repo: str, ref: str, sha: str, check_run_name: str) -> bool | None:
@@ -806,30 +900,65 @@ def resolve(
         )
         return "claimed", None
 
-    dispatched = dispatch_exists(repo, sha, check_run_name)
-    if dispatched is None:
+    state = read_dispatch_state(repo, sha, check_run_name)
+    if state is None:
         raise GuardUnavailable(f"could not tell whether {sha} was already dispatched")
-    if dispatched:
+    if state.dispatched:
+        # A leg that has already been dispatched is normally settled: the check
+        # run is the verdict and every duplicate run's gate reads it. The one
+        # exception is a leg that dispatched and FAILED, because then there is a
+        # question still worth asking — and re-adding the `e2e` label is what
+        # people reach for to ask it. Before this, that re-label spent a full run
+        # (both native base-image builds, Trivy, SDR K8s E2E) dispatching nothing
+        # and re-reading the same red check.
+        #
+        # Three conditions, and every one of them is load-bearing:
+        #
+        # * NEWEST conclusion, not "any failure" — a SHA retried once keeps the
+        #   old attempt's check, so any-failure would re-trigger a leg that has
+        #   since passed, on every subsequent event, forever.
+        # * A PASSING newest conclusion stays deduped. Re-testing a green leg
+        #   costs a tenant to re-answer an answered question.
+        # * The claimant run must be dead. A live claimant may be mid-re-run of
+        #   its own dispatch job (``is_my_run`` lets it through), and that plus a
+        #   reclaim here is two dispatches contending for one tenant — the exact
+        #   harm this module exists to prevent.
+        if state.retryable and not run_is_live(repo, claimant.run_id):
+            print(
+                f"Run {claimant.run_id} ({claimant.run_url(repo)}) dispatched "
+                f"{app} for {sha} and its newest '{check_run_name}' concluded "
+                f"{state.newest_conclusion!r}; that run is over, so this one "
+                "reclaims the slot and re-dispatches."
+            )
+            return _reclaim(
+                repo,
+                ref,
+                run_id=run_id,
+                attempt=attempt,
+                pr_number=pr_number,
+                claimant=claimant,
+                clock=clock,
+            )
         print(
             f"Run {claimant.run_id} ({claimant.run_url(repo)}) already dispatched "
             f"{app} for {sha}; skipping this duplicate dispatch. Its "
             f"'{check_run_name}' check on this commit carries the verdict, and "
             "this run's connector gate reads that same check."
         )
-        # Without this the message reads as "nothing to do here", and the only
-        # re-trigger people find is a fresh commit. There IS one on this commit:
-        # the claiming run may dispatch again (``is_my_run`` compares run ids
-        # only, so a re-run of it bumps the attempt and is allowed through),
-        # while any OTHER run lands here and skips. The whole run, not
-        # ``--failed``: a leg that dispatched fine and then failed downstream
-        # leaves this job green, so ``--failed`` re-runs the gate alone and it
-        # re-reads the very check that is already red.
-        print(
-            f"::notice::to re-run {app} e2e on {sha[:8]} without a new commit, "
-            f"re-run the claiming run itself: gh run rerun {claimant.run_id} "
-            "(the whole run — not --failed). Only that run is allowed to "
-            "re-dispatch this commit."
-        )
+        # Only the live-claimant case is left with something retryable in it, and
+        # there the answer is that run, not this one: re-running IT is allowed
+        # (``is_my_run`` compares run ids only, so a re-run bumps the attempt and
+        # goes through). The whole run, not ``--failed``: a leg that dispatched
+        # fine and then failed downstream leaves the dispatch job green, so
+        # ``--failed`` re-runs the gate alone and it re-reads the same red check.
+        if state.retryable:
+            print(
+                f"::notice::{app} e2e concluded {state.newest_conclusion!r} on "
+                f"{sha[:8]} but run {claimant.run_id} is still going, so this run "
+                f"cannot take the slot. To retry now: gh run rerun "
+                f"{claimant.run_id} (the whole run — not --failed). Otherwise "
+                "re-add the `e2e` label once that run finishes."
+            )
         return "duplicate", claimant
 
     if run_is_live(repo, claimant.run_id):
@@ -843,6 +972,35 @@ def resolve(
         f"::warning::run {claimant.run_id} claimed the {app} dispatch for {sha} "
         "and finished without dispatching; reclaiming the slot."
     )
+    return _reclaim(
+        repo,
+        ref,
+        run_id=run_id,
+        attempt=attempt,
+        pr_number=pr_number,
+        claimant=claimant,
+        clock=clock,
+    )
+
+
+def _reclaim(
+    repo: str,
+    ref: str,
+    *,
+    run_id: int,
+    attempt: int,
+    pr_number: int | None,
+    claimant: Claimant,
+    clock,
+) -> tuple[str, Claimant | None]:
+    """Take the slot from a finished claimant, or lose the race and stand down.
+
+    Shared by both reclaim reasons (a claimant that never dispatched, and one
+    whose dispatch failed) so there is one CAS, not two. Delete-then-create is
+    what makes it safe with several contenders: the create is the compare-and-set,
+    so exactly one wins and every other reads back "duplicate" rather than
+    dispatching a second run at the same tenant.
+    """
     delete_ref(repo, ref)
     blob = create_claim_blob(repo, run_id, attempt, clock(), pr_number)
     if try_claim(repo, ref, blob) == "claimed":

--- a/.github/scripts/e2e_dispatch_guard.py
+++ b/.github/scripts/e2e_dispatch_guard.py
@@ -816,6 +816,20 @@ def resolve(
             f"'{check_run_name}' check on this commit carries the verdict, and "
             "this run's connector gate reads that same check."
         )
+        # Without this the message reads as "nothing to do here", and the only
+        # re-trigger people find is a fresh commit. There IS one on this commit:
+        # the claiming run may dispatch again (``is_my_run`` compares run ids
+        # only, so a re-run of it bumps the attempt and is allowed through),
+        # while any OTHER run lands here and skips. The whole run, not
+        # ``--failed``: a leg that dispatched fine and then failed downstream
+        # leaves this job green, so ``--failed`` re-runs the gate alone and it
+        # re-reads the very check that is already red.
+        print(
+            f"::notice::to re-run {app} e2e on {sha[:8]} without a new commit, "
+            f"re-run the claiming run itself: gh run rerun {claimant.run_id} "
+            "(the whole run — not --failed). Only that run is allowed to "
+            "re-dispatch this commit."
+        )
         return "duplicate", claimant
 
     if run_is_live(repo, claimant.run_id):

--- a/.github/scripts/poll_check_runs_gate.py
+++ b/.github/scripts/poll_check_runs_gate.py
@@ -180,6 +180,46 @@ def gh_api_conditional(path: str, *, etag: str | None = None):
     return status_code, new_etag, body_json
 
 
+def check_run_age_key(check_run: dict) -> tuple[str, int]:
+    """Sort key that orders same-named check runs oldest-first.
+
+    ``started_at`` is the semantic answer and GitHub renders it as a Zulu
+    ISO-8601 stamp, which sorts correctly as a plain string. It is the primary
+    key rather than ``id`` because it is the field that means "when this attempt
+    began"; ``id`` only breaks ties (same-second creations, or a missing
+    ``started_at``), where its monotonicity is what makes it usable at all.
+    """
+    started_at = check_run.get("started_at")
+    check_id = check_run.get("id")
+    return (
+        started_at if isinstance(started_at, str) else "",
+        check_id if isinstance(check_id, int) else 0,
+    )
+
+
+def remember_newest(latest: dict[str, dict], check_run: dict) -> None:
+    """Keep only the newest check run per name in ``latest``.
+
+    A SHA can carry SEVERAL check runs under one name: create_check_run.py POSTs
+    a new one per dispatch rather than PATCHing the old one, so every re-dispatch
+    for the same commit — the supported way to retry a failed connector leg, see
+    e2e_dispatch_guard.py's ``is_my_run`` — leaves the previous attempt's check
+    behind alongside the new one.
+
+    This used to be a bare ``latest[name] = check_run``, i.e. whichever entry the
+    API happened to list last. The listing order of that endpoint is not
+    documented, so on a retried SHA the gate could resolve to the SUPERSEDED
+    attempt and report the old failure against a leg that had since passed (or
+    the reverse). Newest wins, explicitly.
+    """
+    name = check_run["name"]
+    incumbent = latest.get(name)
+    if incumbent is None or check_run_age_key(check_run) >= check_run_age_key(
+        incumbent
+    ):
+        latest[name] = check_run
+
+
 def list_all_check_runs(repo: str, sha: str) -> list[dict]:
     """Full, uncached fetch of every check run on `sha` across all pages.
 
@@ -246,7 +286,7 @@ def wait_for_checks(
             check_runs = list_all_check_runs(repo, sha)
             for check_run in check_runs:
                 if check_run.get("name") in expected_names:
-                    latest[check_run["name"]] = check_run
+                    remember_newest(latest, check_run)
         else:
             status_code, etag, body = gh_api_conditional(path, etag=etag)
             if status_code == 200 and body is not None:
@@ -267,7 +307,7 @@ def wait_for_checks(
                     check_runs = list_all_check_runs(repo, sha)
                 for check_run in check_runs:
                     if check_run.get("name") in expected_names:
-                        latest[check_run["name"]] = check_run
+                        remember_newest(latest, check_run)
             elif status_code != 304:
                 raise SystemExit(
                     f"::error::unexpected status {status_code} polling {path}"

--- a/.github/scripts/tests/test_e2e_dispatch_guard.py
+++ b/.github/scripts/tests/test_e2e_dispatch_guard.py
@@ -27,17 +27,22 @@ import yaml
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
+# The gate is imported only so the drift test can hold its copy of
+# check_run_age_key against the guard's; production never imports across scripts.
+import poll_check_runs_gate as gate  # noqa: E402
 from e2e_dispatch_guard import (  # noqa: E402
     _CHECKS_MAX_PAGES,
+    _PASSING_CONCLUSIONS,
     Claimant,
     GuardUnavailable,
+    check_run_age_key,
     checks_state,
     claim_is_settled,
     claim_ref,
-    dispatch_exists,
     main,
     open_pr_heads,
     prune,
+    read_dispatch_state,
     resolve,
     run_is_live,
     sha_of,
@@ -132,6 +137,34 @@ def _checks(*entries: tuple[str, str]):
     return {
         "check_runs": [{"name": name, "status": status} for name, status in entries]
     }
+
+
+def _attempt(
+    conclusion: str | None, *, at: str, check_id: int, name: str | None = None
+):
+    """One concluded (or running) attempt's check run, with an age.
+
+    Separate from ``_checks`` because the reclaim decision reads fields that
+    helper does not carry — a conclusion, and enough ordering information to say
+    which of several same-named checks is the newest.
+    """
+    entry = {
+        "name": name or CHECK,
+        "status": "completed" if conclusion else "in_progress",
+        "started_at": at,
+        "id": check_id,
+    }
+    if conclusion:
+        entry["conclusion"] = conclusion
+    return entry
+
+
+def _attempts(*entries: dict):
+    return {"total_count": len(entries), "check_runs": list(entries)}
+
+
+OLD_FAIL = _attempt("failure", at="2026-08-21T00:53:41Z", check_id=100)
+NEW_PASS = _attempt("success", at="2026-08-21T01:41:00Z", check_id=200)
 
 
 _RATE_LIMIT = (
@@ -280,29 +313,185 @@ def test_a_completed_dispatch_for_this_sha_is_still_skipped(http: FakeHTTP) -> N
     assert _resolve(run_id=1)[0] == "duplicate"
 
 
-def test_the_skip_names_the_re_run_that_can_actually_re_dispatch(
+# --- retrying a leg that dispatched and failed -----------------------------
+#
+# Re-adding the `e2e` label is what people reach for to retry a failed leg, and
+# it used to spend a whole run (both native base-image builds, Trivy, SDR K8s
+# E2E) dispatching nothing and re-reading the same red check. A new run may now
+# take the slot — but only when the failure is genuinely settled, because every
+# loosening here is paid for in tenant contention.
+
+
+def _stub_reclaim_writes(http: FakeHTTP, *, wins_the_race: bool = True) -> None:
+    http.route("DELETE", "/git/refs/", (204, None))
+    http.route("POST", "/git/blobs", (201, {"sha": BLOB}))
+    http.route(
+        "POST",
+        "/git/refs",
+        (201, {"ref": REF}) if wins_the_race else (422, {"message": "already exists"}),
+    )
+
+
+def test_a_settled_failure_is_reclaimed_by_a_new_run(http: FakeHTTP) -> None:
+    _stub_taken(http, 999)
+    http.route("GET", "/check-runs", (200, _attempts(OLD_FAIL)))
+    http.route("GET", "/actions/runs/999", (200, {"status": "completed"}))
+    _stub_reclaim_writes(http)
+
+    assert _resolve(run_id=1) == ("reclaimed", None)
+
+
+def test_a_passing_leg_is_never_reclaimed(http: FakeHTTP) -> None:
+    """Re-testing a green leg spends a tenant to re-answer an answered question,
+    and the required check is already satisfied by it."""
+    _stub_taken(http, 999)
+    http.route("GET", "/check-runs", (200, _attempts(NEW_PASS)))
+
+    assert _resolve(run_id=1)[0] == "duplicate"
+
+
+@pytest.mark.parametrize("passing", ["success", "neutral", "skipped"])
+def test_every_conclusion_the_gate_calls_a_pass_is_not_retryable(
+    http: FakeHTTP, passing
+) -> None:
+    """These three are exactly poll_check_runs_gate.PASSING_CONCLUSIONS. Treating
+    any of them as retryable would re-dispatch a leg the gate is green on."""
+    _stub_taken(http, 999)
+    http.route(
+        "GET",
+        "/check-runs",
+        (200, _attempts(_attempt(passing, at="2026-08-21T01:00:00Z", check_id=1))),
+    )
+
+    assert _resolve(run_id=1)[0] == "duplicate"
+
+
+@pytest.mark.parametrize("failing", ["failure", "cancelled", "timed_out", "stale"])
+def test_the_non_passing_conclusions_are_retryable(http: FakeHTTP, failing) -> None:
+    _stub_taken(http, 999)
+    http.route(
+        "GET",
+        "/check-runs",
+        (200, _attempts(_attempt(failing, at="2026-08-21T01:00:00Z", check_id=1))),
+    )
+    http.route("GET", "/actions/runs/999", (200, {"status": "completed"}))
+    _stub_reclaim_writes(http)
+
+    assert _resolve(run_id=1) == ("reclaimed", None)
+
+
+def test_a_leg_still_in_flight_is_never_reclaimed(http: FakeHTTP) -> None:
+    """Its connector run is at the tenant right now; a second dispatch is the
+    contention this module exists to prevent."""
+    _stub_taken(http, 999)
+    http.route(
+        "GET",
+        "/check-runs",
+        (200, _attempts(_attempt(None, at="2026-08-21T01:00:00Z", check_id=1))),
+    )
+
+    assert _resolve(run_id=1)[0] == "duplicate"
+
+
+def test_an_older_attempt_still_running_blocks_the_reclaim(http: FakeHTTP) -> None:
+    """`settled` is every attempt, not just the newest. A newer attempt can
+    conclude while an older one is still going, and that older connector run is
+    still holding the tenant."""
+    still_going = _attempt(None, at="2026-08-21T00:10:00Z", check_id=50)
+    http_stub = _attempts(still_going, OLD_FAIL)
+    _stub_taken(http, 999)
+    http.route("GET", "/check-runs", (200, http_stub))
+
+    assert _resolve(run_id=1)[0] == "duplicate"
+
+
+@pytest.mark.parametrize(
+    "newest_first", [False, True], ids=["oldest-first", "newest-first"]
+)
+def test_the_newest_conclusion_decides_not_any_failure(
+    http: FakeHTTP, newest_first
+) -> None:
+    """A SHA retried once keeps the old attempt's failed check. Folding the two
+    together — any-failure, or last-in-listing-order — would re-trigger a leg
+    that has since passed, on every subsequent event, forever."""
+    listing = [NEW_PASS, OLD_FAIL] if newest_first else [OLD_FAIL, NEW_PASS]
+    _stub_taken(http, 999)
+    http.route("GET", "/check-runs", (200, _attempts(*listing)))
+
+    assert _resolve(run_id=1)[0] == "duplicate"
+
+
+def test_a_settled_failure_is_not_reclaimed_while_the_claimant_is_live(
     http: FakeHTTP, capsys
 ) -> None:
-    """The skip used to end at "its check carries the verdict", which reads as
-    "nothing to do" — so the only retry anyone found was pushing a throwaway
-    commit. There IS one on this commit, but only for the CLAIMING run
-    (``is_my_run`` compares run ids), and nothing said so.
+    """A live claimant may be mid-re-run of its own dispatch job — ``is_my_run``
+    lets that through — and that plus a reclaim here is two dispatches at one
+    tenant. The notice hands the operator the one lever that IS safe."""
+    _stub_taken(http, 999)
+    http.route("GET", "/check-runs", (200, _attempts(OLD_FAIL)))
+    http.route("GET", "/actions/runs/999", (200, {"status": "in_progress"}))
 
-    The whole run, not ``--failed``: a leg that dispatched fine and then failed
-    downstream leaves this job green, so ``--failed`` re-runs the gate alone and
-    it re-reads the same red check.
-    """
+    assert _resolve(run_id=1)[0] == "duplicate"
+
+    printed = capsys.readouterr().out
+    assert "gh run rerun 999" in printed
+    assert "not --failed" in printed, (
+        "a leg that dispatched fine and failed downstream leaves the dispatch job "
+        "green, so --failed re-runs the gate alone and it re-reads the red check"
+    )
+
+
+def test_losing_the_race_to_reclaim_a_failure_does_not_dispatch(
+    http: FakeHTTP,
+) -> None:
+    """Two duplicate runs can both see the same settled failure. The create is
+    the compare-and-set, so exactly one may dispatch."""
+    _stub_taken(http, 999)
+    http.route("GET", "/check-runs", (200, _attempts(OLD_FAIL)))
+    http.route("GET", "/actions/runs/999", (200, {"status": "completed"}))
+    _stub_reclaim_writes(http, wins_the_race=False)
+
+    assert _resolve(run_id=1)[0] == "duplicate"
+
+
+def test_a_concluded_check_with_no_conclusion_field_is_not_reclaimed(
+    http: FakeHTTP,
+) -> None:
+    """Unreadable is not "failed". Reclaiming on a missing conclusion would make
+    every malformed check run a re-dispatch."""
     _stub_taken(http, 999)
     http.route("GET", "/check-runs", (200, _checks((CHECK, "completed"))))
 
     assert _resolve(run_id=1)[0] == "duplicate"
 
-    printed = capsys.readouterr().out
-    assert "gh run rerun 999" in printed, (
-        "the skip must name the claiming run's id — that run is the only one the "
-        "guard lets re-dispatch this SHA"
-    )
-    assert "not --failed" in printed
+
+def test_an_unreadable_listing_never_reclaims(http: FakeHTTP) -> None:
+    _stub_taken(http, 999)
+    http.route("GET", "/check-runs", (500, {"message": "server error"}))
+
+    with pytest.raises(GuardUnavailable):
+        _resolve(run_id=1)
+
+
+def test_the_guard_and_the_gate_order_check_runs_identically() -> None:
+    """The two copies of check_run_age_key must agree, or the guard would judge a
+    retry against a different attempt than the gate reports. Copies rather than a
+    shared import because nothing in .github/scripts imports a sibling script;
+    this is what stops them drifting."""
+    table = [
+        {"started_at": "2026-08-21T00:53:41Z", "id": 100},
+        {"started_at": "2026-08-21T01:41:00Z", "id": 200},
+        {"started_at": "2026-08-21T01:41:00Z", "id": 201},
+        {"id": 5},
+        {},
+        {"started_at": None, "id": None},
+    ]
+    assert [check_run_age_key(e) for e in table] == [
+        gate.check_run_age_key(e) for e in table
+    ]
+    assert _PASSING_CONCLUSIONS == set(
+        gate.PASSING_CONCLUSIONS
+    ), "the guard must not call retryable a conclusion the gate calls a pass"
 
 
 def test_this_runs_own_claim_permits_a_re_dispatch(http: FakeHTTP) -> None:
@@ -398,13 +587,14 @@ def test_every_non_completed_status_is_live(http: FakeHTTP, status: str) -> None
     assert run_is_live(REPO, 7) is True
 
 
-def test_dispatch_exists_ignores_other_checks_on_the_sha(http: FakeHTTP) -> None:
+def test_the_dispatch_state_ignores_other_checks_on_the_sha(http: FakeHTTP) -> None:
     http.route(
         "GET",
         "/check-runs",
         (200, _checks(("SDK Gate", "completed"), ("Trivy", "completed"))),
     )
-    assert dispatch_exists(REPO, SHA, CHECK) is False
+    state = read_dispatch_state(REPO, SHA, CHECK)
+    assert state is not None and state.dispatched is False
 
 
 # --- pruning ---------------------------------------------------------------

--- a/.github/scripts/tests/test_e2e_dispatch_guard.py
+++ b/.github/scripts/tests/test_e2e_dispatch_guard.py
@@ -280,6 +280,31 @@ def test_a_completed_dispatch_for_this_sha_is_still_skipped(http: FakeHTTP) -> N
     assert _resolve(run_id=1)[0] == "duplicate"
 
 
+def test_the_skip_names_the_re_run_that_can_actually_re_dispatch(
+    http: FakeHTTP, capsys
+) -> None:
+    """The skip used to end at "its check carries the verdict", which reads as
+    "nothing to do" — so the only retry anyone found was pushing a throwaway
+    commit. There IS one on this commit, but only for the CLAIMING run
+    (``is_my_run`` compares run ids), and nothing said so.
+
+    The whole run, not ``--failed``: a leg that dispatched fine and then failed
+    downstream leaves this job green, so ``--failed`` re-runs the gate alone and
+    it re-reads the same red check.
+    """
+    _stub_taken(http, 999)
+    http.route("GET", "/check-runs", (200, _checks((CHECK, "completed"))))
+
+    assert _resolve(run_id=1)[0] == "duplicate"
+
+    printed = capsys.readouterr().out
+    assert "gh run rerun 999" in printed, (
+        "the skip must name the claiming run's id — that run is the only one the "
+        "guard lets re-dispatch this SHA"
+    )
+    assert "not --failed" in printed
+
+
 def test_this_runs_own_claim_permits_a_re_dispatch(http: FakeHTTP) -> None:
     """Attempt is recorded for the log, not the decision: re-running the dispatch
     job is how an operator retries a transient dispatch failure, and a claim that

--- a/.github/scripts/tests/test_poll_check_runs_gate.py
+++ b/.github/scripts/tests/test_poll_check_runs_gate.py
@@ -670,3 +670,146 @@ def test_the_gate_may_read_the_pull_request() -> None:
     merging with it, so dropping this does not fail loudly — the read 403s, the
     poll warns, and it waits the full budget exactly as it used to."""
     assert _connector_gate()["permissions"]["pull-requests"] == "read"
+
+
+# --- newest-wins among same-named check runs ------------------------------
+#
+# A retried commit carries MORE THAN ONE check run per name: create_check_run.py
+# POSTs a fresh one per dispatch instead of PATCHing the previous attempt, so
+# re-running the claiming run (the supported same-commit retry — see
+# e2e_dispatch_guard.py's is_my_run) leaves the old attempt's check alongside the
+# new one. The gate used to keep whichever the API listed LAST, and that
+# endpoint's ordering is undocumented, so the verdict it reported was a coin
+# flip between the two attempts. Both listing orders are pinned below, because
+# either one alone passes with the broken implementation half the time.
+
+STALE_FAIL = {
+    "name": NAMES[0],
+    "status": "completed",
+    "conclusion": "failure",
+    "started_at": "2026-08-21T00:53:41Z",
+    "id": 100,
+}
+FRESH_PASS = {
+    "name": NAMES[0],
+    "status": "completed",
+    "conclusion": "success",
+    "started_at": "2026-08-21T01:41:00Z",
+    "id": 200,
+}
+OTHER_LEG_PASS = {
+    "name": NAMES[1],
+    "status": "completed",
+    "conclusion": "success",
+    "started_at": "2026-08-21T01:41:00Z",
+    "id": 201,
+}
+
+
+@pytest.mark.parametrize(
+    "newest_first", [False, True], ids=["oldest-first", "newest-first"]
+)
+def test_wait_for_checks_keeps_the_newest_of_two_same_named_checks(
+    monkeypatch, newest_first
+):
+    listing = [FRESH_PASS, STALE_FAIL] if newest_first else [STALE_FAIL, FRESH_PASS]
+    monkeypatch.setattr(
+        mod,
+        "run",
+        lambda cmd, **kw: _http_response(
+            200, '"v1"', _check_runs_body([*listing, OTHER_LEG_PASS])
+        ),
+    )
+
+    assert (
+        mod.wait_for_checks(REPO, SHA, NAMES, sleep=lambda s: None) is True
+    ), "the superseded attempt's failure was reported over the retry that passed"
+
+
+@pytest.mark.parametrize(
+    "newest_first", [False, True], ids=["oldest-first", "newest-first"]
+)
+def test_wait_for_checks_does_not_let_a_stale_pass_mask_a_fresh_failure(
+    monkeypatch, newest_first
+):
+    """The other direction, which matters more: newest-wins must not have been
+    implemented as "prefer the passing one"."""
+    stale_pass = {**STALE_FAIL, "conclusion": "success"}
+    fresh_fail = {**FRESH_PASS, "conclusion": "failure"}
+    listing = [fresh_fail, stale_pass] if newest_first else [stale_pass, fresh_fail]
+    monkeypatch.setattr(
+        mod,
+        "run",
+        lambda cmd, **kw: _http_response(
+            200, '"v1"', _check_runs_body([*listing, OTHER_LEG_PASS])
+        ),
+    )
+
+    assert (
+        mod.wait_for_checks(REPO, SHA, NAMES, sleep=lambda s: None) is False
+    ), "a superseded pass masked the retry's failure"
+
+
+def test_wait_for_checks_waits_when_the_newest_attempt_is_still_running(monkeypatch):
+    """A concluded older attempt must not satisfy the gate while the retry that
+    superseded it is still in flight — that declares a verdict from a run nobody
+    is waiting on any more.
+
+    The stale attempt is the PASSING one and is listed last, so the old
+    last-wins code returns True here immediately. Making it the failing one
+    instead would give False either way and prove nothing.
+    """
+    stale_pass = {**STALE_FAIL, "conclusion": "success"}
+    running_retry = {
+        "name": NAMES[0],
+        "status": "in_progress",
+        "started_at": "2026-08-21T01:41:00Z",
+        "id": 200,
+    }
+    monkeypatch.setattr(
+        mod,
+        "run",
+        lambda cmd, **kw: _http_response(
+            200, '"v1"', _check_runs_body([running_retry, stale_pass, OTHER_LEG_PASS])
+        ),
+    )
+
+    assert (
+        mod.wait_for_checks(
+            REPO,
+            SHA,
+            NAMES,
+            interval_seconds=1,
+            timeout_seconds=2,
+            sleep=lambda s: None,
+        )
+        is False
+    ), "a superseded pass satisfied the gate while the retry was still running"
+
+
+def test_check_run_age_key_breaks_ties_on_id_and_tolerates_no_timestamp():
+    same_second_old = {"name": NAMES[0], "started_at": "2026-08-21T01:41:00Z", "id": 1}
+    same_second_new = {"name": NAMES[0], "started_at": "2026-08-21T01:41:00Z", "id": 2}
+    assert mod.check_run_age_key(same_second_new) > mod.check_run_age_key(
+        same_second_old
+    )
+    # A check run with no started_at must still be orderable rather than blow up
+    # the whole poll on a TypeError comparing None to str.
+    assert mod.check_run_age_key({"name": NAMES[0], "id": 5}) == ("", 5)
+    assert mod.check_run_age_key({"name": NAMES[0]}) == ("", 0)
+
+
+def test_remember_newest_is_the_only_way_latest_is_populated():
+    """Guards the fix itself. Every behavioural test above still passes if only
+    ONE of the two assignment sites is converted, so a future edit that
+    re-introduces a bare ``latest[name] = check_run`` in either branch would
+    silently restore the coin flip."""
+    source = (Path(__file__).parent.parent / "poll_check_runs_gate.py").read_text()
+    poll_body = source.split("def wait_for_checks(", 1)[1]
+    assert "latest[check_run[" not in poll_body, (
+        "wait_for_checks assigns into `latest` directly again — route it through "
+        "remember_newest() so same-named check runs stay newest-wins"
+    )
+    assert (
+        poll_body.count("remember_newest(latest, check_run)") == 2
+    ), "both the conditional-GET and the full-pagination branch must dedupe"


### PR DESCRIPTION
### Changelog

Retrying a connector e2e leg on the same commit now works, and reports the right verdict when it does.

- **`e2e_dispatch_guard.py` — a new run can retry a leg that dispatched and failed.** Previously only the *claiming* run could re-dispatch a commit (`is_my_run` compares run ids), so re-adding the `e2e` label spent a whole run — both native base-image builds, Trivy, SDR K8s E2E — dispatching nothing and re-reading the same red check. A new run may now reclaim the slot when the failure is settled.
- **`poll_check_runs_gate.py` — the gate resolves the newest check run** when a commit carries several under one name, keyed on `started_at` with `id` as the tie-break. Both assignment sites (conditional-GET and full-pagination) go through `remember_newest`.
- Both reclaim reasons share one `_reclaim`, so there is one CAS rather than two. `read_dispatch_state` replaces `dispatch_exists` (now removed as dead) and answers both questions from a single listing.

### Additional context (e.g. screenshots, logs, links)

- **Why the gate change is a bug fix, not a nicety.** `create_check_run.py` POSTs a fresh check run per dispatch rather than PATCHing the previous attempt's, so a retried SHA carries two checks under one name. The gate kept whichever the listing returned last (`latest[check_run["name"]] = check_run`), and that endpoint's ordering is not documented — so the verdict was a coin flip between attempts. It could report a superseded failure against a leg that had since passed, or a superseded pass over the retry's failure. Retrying was not safe to *use* until this was fixed, which is why both halves are one PR.
- **The three conditions on the reclaim are each load-bearing**, and each has a test that fails without it:
  - *Newest* conclusion, not any-failure — a retried SHA keeps the old failed check, so any-failure would re-trigger a passed leg on every subsequent event, forever.
  - A passing newest conclusion still dedupes — re-testing a green leg spends a tenant to re-answer an answered question.
  - Every attempt concluded **and** the claiming run dead — an older attempt still running means its connector run is still at the tenant, and a live claimant may be mid-re-run of its own dispatch job. Either plus a reclaim is two dispatches at one tenant.
- **The skip notice is narrowed** to the only case it is still right for: a settled failure whose claimant is still live, where re-running that run is the one safe lever. It spells out "the whole run, not `--failed`", because a leg that dispatched fine and then failed downstream leaves the dispatch job green, so `--failed` re-runs the gate alone and it re-reads the same red check.
- `check_run_age_key` is a deliberate **copy** of the gate's rather than a cross-script import — nothing in `.github/scripts` imports a sibling (every script is a self-contained stdlib-only entry point). A test imports both modules and holds the two copies to one table, and the two passing-conclusion sets to each other.
- The module docstring's decision table is updated; it documented the old four cases and would otherwise now be wrong.
- **Found while investigating** three `Prepare tenant (azure)` failures whose root cause was unrelated (a full Atlas Cassandra volume on the e2e tenant). Diagnosing them is what surfaced that a failed leg could not be retried without a throwaway commit.

### Checklist

- [x] Additional tests added
- [ ] All CI checks passed
- [x] Relevant documentation updated

Tests: `test_e2e_dispatch_guard.py` + `test_poll_check_runs_gate.py` = 138 passed; full `.github/scripts/tests/` suite green. Every new behavioural test was verified against the *old* behaviour: neutering `retryable` fails 6, making `settled` read only the newest attempt fails the older-attempt-still-running test, replacing newest-wins with last-in-listing fails the `newest-first` parametrisation, and reverting the gate fix fails 4. The gate tests are parametrised over listing order because with last-wins each order passes half the time on its own, and a meta-test pins both gate call sites since every behavioural test still passes when only one is converted.

---

### Copyleft License Compliance

- [ ] Have you used any code that is subject to a Copyleft license (e.g., GPL, AGPL, LGPL)?
- [ ] If yes, have you modified the code in the context of this project? please share additional details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
