### PR TITLE
fix: sandbox-safe pool resolution and e2e stall attribution

### DIFF
--- a/application_sdk/app/registry.py
+++ b/application_sdk/app/registry.py
@@ -1,5 +1,6 @@
 """App and Task discovery and registration."""
 
+import os
 import types
 import warnings
 from collections.abc import Mapping
@@ -504,11 +505,18 @@ def resolve_pool_queue(pool: str) -> str | None:
         pool: Validated lowercase kebab-case pool name
             (e.g. ``"heavy"``, ``"cold-tier"``).
 
+    Runs inside the Temporal workflow sandbox: ``_wrap_instance_tasks`` builds a
+    wrapper for every task at activation, and the wrapper factory resolves the
+    pool. ``os`` must therefore stay imported at module level. This module is a
+    sandbox passthrough, but passthrough is applied at import time — a deferred
+    ``import os`` inside this function runs while a workflow is executing and
+    resolves to the sandbox's restricted proxy, so ``os.environ.get`` raises
+    ``RestrictedWorkflowAccessError`` and every app declaring a ``@task(pool=...)``
+    fails its first workflow activation, whether or not that task is ever called.
+
     Returns:
         Resolved task-queue string, or ``None`` if unresolvable.
     """
-    import os  # noqa: PLC0415
-
     env_key = f"ATLAN_POOL_{pool.upper().replace('-', '_')}_QUEUE"
     explicit = os.environ.get(env_key)
     if explicit:

--- a/application_sdk/testing/e2e/_errors.py
+++ b/application_sdk/testing/e2e/_errors.py
@@ -175,20 +175,40 @@ class AppNotReadyError(PreconditionError):
 
 @dataclass(kw_only=True)
 class NoWorkerOnTaskQueueError(PreconditionError):
-    """No worker started any DAG node within the stall-grace window.
+    """No worker started any DAG node while the AE run was live.
 
-    The AE run's parent workflow runs on the always-on automation-engine
-    queue, so the top-level run flips to ``Running`` even when the connector's
-    own ``extract`` node is stuck ``Pending`` because no worker is polling its
-    task queue. Rather than let the harness hang for the full
-    ``ae_poll_timeout_seconds`` (often 30 min), we fail fast here. The usual
-    cause is an agent-name / task-queue mismatch: the test's
+    Raised only when the top-level run has left ``Pending`` — the parent
+    workflow runs on the always-on automation-engine queue, so a live parent
+    means AE dispatched and the connector's own node is the one stuck. That
+    points at the app: an agent-name / task-queue mismatch, where the test's
     ``agent_spec().agent_name`` must resolve to the same queue the deployed
     worker polls (``atlan-{ATLAN_APPLICATION_NAME}-{ATLAN_DEPLOYMENT_NAME}``).
+    Rather than hang for the full ``ae_poll_timeout_seconds`` (often 30 min),
+    the harness fails fast here.
+
+    A top-level run still sitting ``Pending`` is :class:`AutomationEngineNotDispatchingError`
+    instead — nothing reached the app, so the app's queue is not implicated.
     """
 
     code: ClassVar[str] = "PRECONDITION_NO_WORKER_ON_TASK_QUEUE"
     expected_state: str | None = "a worker polling the extract task queue"
+
+
+@dataclass(kw_only=True)
+class AutomationEngineNotDispatchingError(PreconditionError):
+    """The AE run never left ``Pending`` within the stall-grace window.
+
+    The top-level status is the Automation Engine's own state. While it is
+    ``Pending`` the run has not been dispatched at all, so no DAG node could
+    have started and nothing has yet been offered to the connector's task
+    queue. The app, its worker and its agent name are therefore not implicated
+    — attributing this to a missing worker sends triage to the wrong system.
+    The usual causes are tenant-side: AE contention on a shared e2e tenant, or
+    an AE worker that is not processing new runs.
+    """
+
+    code: ClassVar[str] = "PRECONDITION_AE_NOT_DISPATCHING"
+    expected_state: str | None = "the AE run leaving Pending"
 
 
 @dataclass(kw_only=True)

--- a/application_sdk/testing/e2e/client.py
+++ b/application_sdk/testing/e2e/client.py
@@ -58,6 +58,7 @@ from application_sdk.testing.e2e._errors import (
     AtlanApiHttpError,
     AtlanApiResponseInvariantError,
     AtlanApiTimeoutError,
+    AutomationEngineNotDispatchingError,
     DAGProgressStalledError,
     MissingHarnessClassAttrError,
     NoWorkerOnTaskQueueError,
@@ -1677,9 +1678,11 @@ class AEWorkflowClient:
                 last_log_elapsed = elapsed
             if result.status.is_terminal:
                 return result
-            # Fail fast when nothing has started within the grace window: the
-            # run is live (parent on the AE queue) but no node has begun, which
-            # almost always means no worker is polling the extract task queue.
+            # Fail fast when nothing has started within the grace window. Which
+            # system is at fault depends on the top-level status: a run still
+            # Pending was never dispatched by AE, so the app's queue cannot be
+            # the cause; a live parent means AE dispatched and the connector's
+            # own node is the one nothing picked up.
             if (
                 # only a positive grace arms the guard; None or any value <= 0
                 # disables it (a negative would otherwise fire on the first poll)
@@ -1688,6 +1691,18 @@ class AEWorkflowClient:
                 and not any_node_started
                 and elapsed >= stall_grace_seconds
             ):
+                if result.status is DAGRunStatus.PENDING:
+                    raise AutomationEngineNotDispatchingError(
+                        message=(
+                            f"AE run {run_id} was still Pending after "
+                            f"{stall_grace_seconds}s, so it was never dispatched and "
+                            "no DAG node could start. Nothing was offered to the "
+                            "app's task queue, so the app's worker and agent name "
+                            "are not implicated — check the tenant's automation "
+                            "engine (contention on a shared e2e tenant, or an AE "
+                            "worker not processing new runs)."
+                        ),
+                    )
                 queue_hint = (
                     f" task queue '{stall_task_queue}'"
                     if stall_task_queue
@@ -1696,8 +1711,9 @@ class AEWorkflowClient:
                 raise NoWorkerOnTaskQueueError(
                     message=(
                         f"No DAG node started within {stall_grace_seconds}s for run "
-                        f"{run_id} (top-level status={result.status.value}). This "
-                        f"almost always means no worker is polling{queue_hint}. "
+                        f"{run_id} (top-level status={result.status.value}), so AE "
+                        f"dispatched but nothing picked the node up. This almost "
+                        f"always means no worker is polling{queue_hint}. "
                         "Verify the test's agent_spec().agent_name resolves to the "
                         "queue the deployed worker polls "
                         "(atlan-{ATLAN_APPLICATION_NAME}-{ATLAN_DEPLOYMENT_NAME}); a "

--- a/tests/integration/test_task_pool_sandbox.py
+++ b/tests/integration/test_task_pool_sandbox.py
@@ -1,0 +1,88 @@
+"""P: Pooled-task sandbox integration test.
+
+Declaring ``@task(pool=...)`` makes the workflow resolve that pool to a task
+queue during activation: ``_wrap_instance_tasks`` (``app/base.py``) builds
+a wrapper for *every* task eagerly, and the wrapper factory calls
+``resolve_pool_queue``. That resolution therefore runs inside the Temporal
+sandbox, so anything it does at runtime must be sandbox-safe — including how
+it reaches ``os.environ``.
+
+The task is never invoked here on purpose. The failure is at activation, before
+any activity is scheduled, so a declared-but-uncalled pooled task is the
+smallest shape that reproduces it and needs no second worker on the pool queue.
+
+Requires a running Temporal dev server (see conftest.py).
+"""
+
+import asyncio
+
+import pytest
+
+from application_sdk.app.base import App
+from application_sdk.app.context import AppContext
+from application_sdk.app.entrypoint import entrypoint
+from application_sdk.app.task import task
+from application_sdk.contracts.base import Input, Output
+from application_sdk.execution.retry import NO_RETRY
+
+# ---------------------------------------------------------------------------
+# Module-level classes so Temporal's sandboxed runner can import them by path.
+# ---------------------------------------------------------------------------
+
+
+class PoolInput(Input):
+    value: str = ""
+
+
+class PoolOutput(Output):
+    length: int = 0
+
+
+class PooledTaskApp(App):
+    """Declares a pooled task the entry point never calls."""
+
+    name = "pooled-task-app"
+
+    @task(pool="heavy")
+    async def heavy_work(self, input: PoolInput) -> PoolOutput:  # pragma: no cover
+        # Never invoked — declaring it is enough to exercise pool resolution.
+        return PoolOutput(length=len(input.value))
+
+    @entrypoint
+    async def run_light(self, input: PoolInput) -> PoolOutput:
+        return PoolOutput(length=len(input.value))
+
+
+@pytest.mark.integration
+async def test_pooled_task_declaration_does_not_break_activation(
+    run_worker, executor, reregister_app
+):
+    """P1.1: a declared pooled task must not fail the workflow at activation.
+
+    Pool resolution runs inside the sandbox. If it is sandbox-unsafe, the app
+    fails before its entry point runs — and Temporal retries the failed
+    activation forever, so the run never reaches a terminal state. The
+    ``wait_for`` bound turns that wedge into a fast, attributable failure
+    instead of a hung suite.
+    """
+    reregister_app(PooledTaskApp)
+    async with run_worker():
+        context = AppContext(app_name=PooledTaskApp._app_name, app_version="1.0.0")
+        try:
+            result = await asyncio.wait_for(
+                executor.execute(
+                    PooledTaskApp,
+                    PoolInput(value="abcd"),
+                    context=context,
+                    retry_policy=NO_RETRY,
+                    entry_point="run-light",
+                ),
+                timeout=60,
+            )
+        except TimeoutError:
+            pytest.fail(
+                "Workflow never completed: activation is failing and Temporal is "
+                "retrying it forever. Pool resolution is sandbox-unsafe again — "
+                "check that resolve_pool_queue reaches os via a module-level import."
+            )
+    assert result.length == 4

--- a/tests/unit/testing/e2e/test_client.py
+++ b/tests/unit/testing/e2e/test_client.py
@@ -152,7 +152,7 @@ class TestPollNativeStatusStallGuard:
         never_dispatched = _result(DAGRunStatus.PENDING, DAGNodeStatus.PENDING)
 
         with patch.object(client, "get_native_status", return_value=never_dispatched):
-            with patch("time.sleep"):
+            with fake_clock():
                 with pytest.raises(AutomationEngineNotDispatchingError) as exc:
                     client.poll_native_status(
                         _RUN_ID,

--- a/tests/unit/testing/e2e/test_client.py
+++ b/tests/unit/testing/e2e/test_client.py
@@ -18,6 +18,7 @@ from application_sdk.testing.e2e._errors import (
     AtlanAEWorkflowAlreadyActiveError,
     AtlanApiHttpError,
     AtlanApiTimeoutError,
+    AutomationEngineNotDispatchingError,
     DAGProgressStalledError,
     NoWorkerOnTaskQueueError,
     RequestDelivery,
@@ -139,6 +140,31 @@ class TestPollNativeStatusStallGuard:
                         stall_grace_seconds=30,
                         stall_task_queue="atlan-openapi-e2e-full-ci-42",
                     )
+
+    def test_pending_run_is_attributed_to_ae_not_the_app(self):
+        """A top-level run still Pending was never dispatched by AE.
+
+        Nothing reached the app's task queue, so blaming a missing worker or a
+        wrong agent_name sends triage at the wrong system. Must raise the AE
+        error and must not name the app's queue.
+        """
+        client = _make_client()
+        never_dispatched = _result(DAGRunStatus.PENDING, DAGNodeStatus.PENDING)
+
+        with patch.object(client, "get_native_status", return_value=never_dispatched):
+            with patch("time.sleep"):
+                with pytest.raises(AutomationEngineNotDispatchingError) as exc:
+                    client.poll_native_status(
+                        _RUN_ID,
+                        interval_seconds=10,
+                        timeout_seconds=600,
+                        stall_grace_seconds=30,
+                        stall_task_queue="atlan-openapi-e2e-full-ci-42",
+                    )
+        message = str(exc.value)
+        assert "atlan-openapi-e2e-full-ci-42" not in message
+        assert "agent_spec()" not in message
+        assert "automation engine" in message.lower()
 
     def test_generic_queue_hint_when_stall_task_queue_empty(self):
         """With no stall_task_queue supplied, the error falls back to the


### PR DESCRIPTION
## TL;DR

Two standalone fixes split out of #3132 so they merge on their own merits instead of waiting on the design rework there.

## Sandbox-safe pool resolution

`resolve_pool_queue` imported `os` inside the function body. The registry module is a sandbox passthrough, but passthrough applies at import time — a deferred import runs while a workflow is executing and resolves to the sandbox's restricted proxy, so `os.environ.get` raises `RestrictedWorkflowAccessError`. Pool resolution runs at workflow activation (`_wrap_instance_tasks` builds a wrapper for every task eagerly), so any app declaring `@task(pool=...)` failed its first activation, whether or not the pooled task was ever called — and Temporal retries the failed workflow task forever, so the run sits open instead of failing.

Fix: module-level import. The new integration test reproduces the exact shape (declared-but-uncalled pooled task against a real Temporal server) and bounds the wait at 60s, so a regression fails fast with a message naming the mechanism instead of wedging the suite.

## E2E stall attribution

The stall guard raised `NoWorkerOnTaskQueueError` (check your agent name / task queue) for every run where no DAG node started in the grace window. When the top-level AE run is still `Pending`, AE never dispatched anything — nothing was offered to the app's queue, so that message sends triage to the wrong system. A still-Pending run now raises `AutomationEngineNotDispatchingError` pointing at the tenant's engine; a live parent with no node started keeps the existing error.