### PR TITLE
ci(hygiene): clear the e2e tenant version pin instead of leaving it behind (FND-709)

### DIFF
--- a/.github/actions/e2e-tenant-lease/action.yaml
+++ b/.github/actions/e2e-tenant-lease/action.yaml
@@ -111,15 +111,16 @@ inputs:
       the pre-lease span (discovery, image build, manifest merge, runner queue
       time) counts against it.
 
-      Must exceed the longest legitimate hold: the install plus the leg ceiling.
-      Sized against the workflow's own job timeouts by a test, so raising either
-      forces this up rather than silently eating the margin. Errs long on
-      purpose — breaking a live holder's lease puts a second installer on the
-      tenant, which is the race the lease exists to close, whereas breaking one
-      late costs a blocked tenant that a waiter is already reporting loudly.
-      0 disables the backstop.
+      Must exceed the longest legitimate hold: the install, the leg ceiling, and
+      since FND-709 the uninstall that clears the run's version pin before the
+      lease is handed back. Sized against the workflow's own job timeouts by a
+      test, so raising any of them forces this up rather than silently eating the
+      margin. Errs long on purpose — breaking a live holder's lease puts a second
+      installer on the tenant, which is the race the lease exists to close,
+      whereas breaking one late costs a blocked tenant that a waiter is already
+      reporting loudly. 0 disables the backstop.
     required: false
-    default: "14400"
+    default: "18000"
   on-timeout:
     description: |
       "fail" (default) — go red naming the holding run. "warn" — proceed

--- a/.github/actions/e2e-tenant-lease/e2e_tenant_lease.py
+++ b/.github/actions/e2e-tenant-lease/e2e_tenant_lease.py
@@ -1099,13 +1099,15 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--ttl-seconds",
         type=int,
-        default=14400,
+        default=18000,
         help="How long a holder may HOLD the lease (measured from the acquisition "
         "time it recorded, not from run age) before a waiter treats it as wedged "
-        "and breaks it. Must exceed the longest legitimate hold — the install plus "
-        "the leg ceiling — because breaking a live holder's lease puts a second "
-        "installer on the tenant, and because release safety depends on it too. "
-        "Default 4h against a 40min+120min hold. 0 disables the backstop.",
+        "and breaks it. Must exceed the longest legitimate hold — the install, the "
+        "leg ceiling, and the uninstall that clears the run's version pin before "
+        "the lease goes back (FND-709) — because breaking a live holder's lease "
+        "puts a second installer on the tenant, and because release safety depends "
+        "on it too. Default 5h against a 40min+120min+15min hold. 0 disables the "
+        "backstop.",
     )
     parser.add_argument(
         "--on-timeout",

--- a/.github/scripts/e2e_tenant_api.py
+++ b/.github/scripts/e2e_tenant_api.py
@@ -69,6 +69,21 @@ _SERVICE_PREFIX = "/api/service"
 #: :func:`path_segment` means a formatted-in value cannot either.
 PUBLISH_PATH = f"{_SERVICE_PREFIX}/marketplace/publish"
 INSTALL_PATH = f"{_SERVICE_PREFIX}/marketplace/tenant/default/apps/{{app_id}}/install"
+#: The sibling of INSTALL_PATH, and deliberately written next to it: the two are
+#: one pair, so a change to the tenant scoping of one has to be made to the other.
+#: `POST .../uninstall` in local-marketplace (`marketplace_api/v1/router.py`),
+#: proxied by Heracles as `uninstallTenantApp` in `api/marketplace.json`.
+#:
+#: Three refusals are baked into the route rather than into this constant, and the
+#: caller has to know them: a non-`default` deployment name is a 400 (customer
+#: infra / SDR uninstall is not implemented in LM yet), a system app is a 409
+#: (`is_system_app`, so this route can never clear a `publish-app`-style pin —
+#: those are reconciler-owned), and an app that is not installed is a 404. Only
+#: the `default` deployment is reachable here, which is what the e2e install path
+#: already targets.
+UNINSTALL_PATH = (
+    f"{_SERVICE_PREFIX}/marketplace/tenant/default/apps/{{app_id}}/uninstall"
+)
 APP_INFO_PATH = f"{_SERVICE_PREFIX}/marketplace/apps/{{app_id}}/info"
 DEPLOYMENT_PATH = f"{_SERVICE_PREFIX}/marketplace/apps/deployments/{{deployment_id}}"
 APP_EVENTS_PATH = f"{_SERVICE_PREFIX}/marketplace/apps/{{app_id}}/events"

--- a/.github/scripts/e2e_tenant_app.py
+++ b/.github/scripts/e2e_tenant_app.py
@@ -184,6 +184,16 @@ _VERSION_KEYS = (
 #: envelope; the others are tolerated aliases.
 _VERSION_NESTS = ("installed", "install", "installation", "deployment", "data")
 
+#: The subset of :data:`_VERSION_NESTS` whose PRESENCE means the tenant still holds
+#: an install record, used by :func:`_confirm_uninstalled` to answer "is the record
+#: gone?" when no version string can be read out of it.
+#:
+#: Deliberately not the whole tuple. ``deployment`` describes a reconcile that may
+#: well be the uninstall's own, and ``data`` is just Heracles' envelope wrapper
+#: (already unwrapped by ``Response.data()``) — treating either as an install
+#: record would report residue on a tenant that is genuinely clean.
+_INSTALL_STATE_NESTS = ("installed", "install", "installation")
+
 #: Placeholders LM emits in place of a version. NOT versions, and treating them as
 #: one is worse than reading nothing: it turns "this tenant cannot tell us what it
 #: runs" into "this tenant runs something called 'unknown'", which reads like a
@@ -1583,6 +1593,87 @@ def verify(args: argparse.Namespace) -> str:
     return installed
 
 
+def _confirm_uninstalled(client: TenantClient, app_id: str) -> str:
+    """Return "" when the tenant CONFIRMS the app is gone, else why it did not.
+
+    Fail-closed, and deliberately not :func:`_installed_version`. That helper folds
+    every non-2xx, every unreadable body and every placeholder version into ``""``
+    because its callers read ``""`` as "install it", where a wrong empty costs one
+    redundant install. Here ``""`` is the assertion that the version pin is gone,
+    so the same fold would report a version it never managed to read as a cleared
+    tenant — and with ``continue-on-error`` on the ``release-tenant`` step, that is
+    silent: the pin stays, and the next repo's install is what pays for it.
+
+    That is the same false-green class this subcommand already closes on the POST
+    side, where Heracles' router ``400 Path was not found`` is its own
+    ``route-missing`` outcome rather than a benign "nothing to remove"
+    (:attr:`_MarketplaceReply.route_missing`). The read-back needs the same
+    posture, so only two answers count as evidence of removal:
+
+    * a genuine ``404`` — LM has no install record for this app, and
+    * a ``200`` carrying neither a readable version nor an install-state record.
+
+    Everything else is a read that proves nothing — a 5xx, an expired credential,
+    a body that is not JSON, a transport error, or an ``installed`` block whose
+    version is unreadable — and the caller reports it as residue rather than
+    claiming the tenant is clean.
+    """
+    try:
+        response = client.get(APP_INFO_PATH.format(app_id=path_segment(app_id)))
+    except TenantApiError as exc:
+        # The GET is inside the try for the same reason the POST is: _uninstall_one
+        # promises never to raise, and one app's transport error must not abandon
+        # the rest of the sweep.
+        return f"could not read the app's info back to confirm removal: {exc}"
+
+    if response.status == 404:
+        return ""
+    if not response.ok:
+        return (
+            f"app info answered HTTP {response.status} rather than the 404 that "
+            "would show the install record is gone, so this tenant is unread, not "
+            "confirmed clean, and the pin may still be there"
+        )
+    if not isinstance(response.body, dict):
+        return (
+            f"app info answered HTTP {response.status} with a non-JSON body, which "
+            "confirms nothing about the install record, so the pin may still be there"
+        )
+
+    data = response.data()
+    version = _extract_version(data) or resolve_version_via_catalog(data)
+    if version:
+        return (
+            f"the tenant still reports {version} installed after the uninstall "
+            "completed, so the HelmRelease — and the releaseChannel/releaseId "
+            "pin in its values — may still be there"
+        )
+    record = next(
+        (
+            nest
+            for nest in _INSTALL_STATE_NESTS
+            if isinstance(data.get(nest), dict) and data.get(nest)
+        ),
+        "",
+    )
+    if record:
+        # The confusing case, so print what the payload actually held rather than
+        # leaving whoever reads the residue report to guess — same diagnostic
+        # _installed_version prints when it cannot read a version.
+        _print_block(
+            "app info (install record still present, no version could be read)",
+            "\n".join(describe_info(data)) or "<no identifying fields present>",
+            _INFO_DIAGNOSTIC_MAX_LINES,
+            "head",
+        )
+        return (
+            f"the tenant still carries an {record!r} record for this app after the "
+            "uninstall completed, with no readable version in it, so the pin may "
+            "still be there"
+        )
+    return ""
+
+
 def _uninstall_one(
     post_client: TenantClient,
     read_client: TenantClient,
@@ -1667,21 +1758,18 @@ def _uninstall_one(
             "relying on the read-back below"
         )
 
-    # Direct evidence, mirroring what install() does with its version read-back.
-    # LM's third uninstall step deletes the `AtlanAppInstalled` record, so a
-    # tenant that still reports a version for this app has not finished — and an
-    # empty read is meaningful HERE in a way it is not on the install path,
-    # because "not installed" is precisely the state being asserted.
-    still = _installed_version(read_client, app_id)
-    if still:
-        return UninstallOutcome(
-            app_id,
-            "unreachable",
-            f"the tenant still reports {still} installed after the uninstall "
-            "completed, so the HelmRelease — and the releaseChannel/releaseId "
-            "pin in its values — may still be there",
-            reply.deployment_id,
-        )
+    # Direct evidence, and the thing that actually decides — LM's own verdict is
+    # namespace-scoped (DISTR-901), so it can be about somebody else's pod. LM's
+    # third uninstall step deletes the `AtlanAppInstalled` record, so a tenant that
+    # still reports this app has not finished.
+    #
+    # Read back through _confirm_uninstalled rather than _installed_version: "not
+    # installed" is precisely the state being asserted here, so a failed READ must
+    # not be able to answer it. Only a real 404, or a 200 with no install record,
+    # clears the app; every other answer is residue.
+    residue = _confirm_uninstalled(read_client, app_id)
+    if residue:
+        return UninstallOutcome(app_id, "unreachable", residue, reply.deployment_id)
     return UninstallOutcome(
         app_id, "removed", "install record and HelmRelease gone", reply.deployment_id
     )

--- a/.github/scripts/e2e_tenant_app.py
+++ b/.github/scripts/e2e_tenant_app.py
@@ -323,10 +323,15 @@ class InstallOutcome:
 #: pin for the app afterwards, which is the whole point of the subcommand; the
 #: rest mean it might, and the caller reports them as residue.
 #:
-#: ``refused`` and ``unreachable`` are kept apart because they need different
-#: humans: ``refused`` is LM declining (a wrong deployment name, a 4xx it will
-#: keep giving), ``unreachable`` is the call or the reconcile not completing (a
-#: transient the next run's cleanup will retry for free).
+#: The three residue outcomes are kept apart because they need different humans,
+#: and none of them is a retry of another:
+#:
+#: * ``refused`` — LM declining (a system app, a non-``default`` deployment); a
+#:   4xx it will keep giving, so a different route or a different ticket.
+#: * ``unreachable`` — the call or the reconcile not completing; a transient the
+#:   next run's cleanup retries for free.
+#: * ``route-missing`` — the tenant's Heracles does not proxy uninstall at all.
+#:   Nothing about the app or the request will change it; the tenant has to move.
 _CLEARED_OUTCOMES = frozenset({"removed", "not-installed"})
 
 
@@ -951,7 +956,13 @@ class _MarketplaceReply:
 
     @property
     def not_found(self) -> bool:
-        """The release is not resolvable in LM's tenant-catalog snapshot yet."""
+        """The release is not resolvable in LM's tenant-catalog snapshot yet.
+
+        The message match is deliberately loose, and safe here for one reason
+        only: this drives a RETRY, so a false positive costs one more attempt.
+        Do not reuse it anywhere a false positive is terminal — see
+        :attr:`not_installed`, which needs the same idea and cannot use this.
+        """
         return self.status_code == 404 or "not found" in self.message.lower()
 
     @property
@@ -959,17 +970,43 @@ class _MarketplaceReply:
         return not self.failed and "already installed" in self.message.lower()
 
     @property
+    def route_missing(self) -> bool:
+        """Heracles does not proxy this path on this tenant.
+
+        Verified live, and it is NOT a variant of :attr:`not_installed`: the
+        router answers ``HTTP 400`` with ``"Path was not found"``, byte-identical
+        to what a path invented on the spot returns, while a route that IS
+        proxied hands back LM's own envelope (``HTTP 200`` carrying an in-body
+        ``status_code``). So this means "the tenant cannot do this at all", and
+        for an uninstall that means the version pin is still there.
+
+        It has to be checked BEFORE :attr:`not_installed`, and be its own outcome
+        rather than folded into ``refused``: the fix is a Heracles version on the
+        tenant, not anything about the app or the request.
+        """
+        return self.status_code == 400 and "path was not found" in self.message.lower()
+
+    @property
     def not_installed(self) -> bool:
         """Uninstall's benign 404: there is no install record left to remove.
 
-        The same status code as install's :attr:`not_found`, read oppositely, and
-        the difference is load-bearing. On install a 404 means "LM's
-        tenant-catalog snapshot has not caught up with a fresh publish" and the
-        right response is to retry for minutes; on uninstall it means the tenant
-        is already in the state being asked for, and retrying would burn the
-        whole budget waiting for something that has already happened.
+        Keyed on the STATUS CODE alone, deliberately, and not on
+        :attr:`not_found` — which is the same idea one layer looser, and whose
+        looseness is safe only on the install path.
+
+        There, a false positive costs a retry. Here it is a terminal success, so
+        a false positive silently reports "nothing to remove" and leaves the pin
+        exactly where it was — the failure mode this whole subcommand exists to
+        remove. A live probe found precisely that: Heracles' router 400 says
+        ``"Path was not found"``, whose substring ``not found`` made an unproxied
+        route read as an already-clean tenant, on every run, forever.
+
+        LM's real answer is unambiguous and does not need the message: an
+        enveloped ``status_code: 404`` with ``status: "error"`` (``HTTP 200``
+        over the wire), or a genuine ``404``, which the parse folds to the same
+        value.
         """
-        return self.not_found
+        return self.status_code == 404
 
     @property
     def system_app(self) -> bool:
@@ -1566,6 +1603,20 @@ def _uninstall_one(
     except TenantApiError as exc:
         return UninstallOutcome(app_id, "unreachable", f"uninstall call failed: {exc}")
 
+    if reply.route_missing:
+        # Checked first: the router 400 carries "not found" in its text, and this
+        # is the tenant saying it cannot do this at all rather than that there is
+        # nothing to do. Residue, and residue whose fix is on the tenant.
+        return UninstallOutcome(
+            app_id,
+            "route-missing",
+            "this tenant's Heracles does not proxy the uninstall route "
+            f"({reply.message!r}, HTTP {reply.http_status} — the same answer an "
+            "invented path returns), so the version pin is still there. The "
+            "proxy landed in heracles' api/marketplace.json as "
+            "`uninstallTenantApp`; a tenant predating it cannot be cleaned up "
+            "over the API at all.",
+        )
     if reply.not_installed:
         # The tenant is already in the state being asked for. Terminal success,
         # not a retryable miss — see _MarketplaceReply.not_installed.
@@ -1813,7 +1864,10 @@ def main(argv: list[str] | None = None) -> int:
                 "out of the registry cache, and LM's health check is "
                 "namespace-scoped — so it will fail EVERY future install to this "
                 "tenant, for any repo. Clear it with the E2E Tenant Uninstall "
-                "workflow.",
+                "workflow — EXCEPT a `route-missing`, which that workflow cannot "
+                "fix either: it means this tenant's Heracles does not proxy the "
+                "uninstall route, so nothing clears the pin over the API until "
+                "the tenant moves forward.",
                 file=sys.stderr,
             )
             return 1

--- a/.github/scripts/e2e_tenant_app.py
+++ b/.github/scripts/e2e_tenant_app.py
@@ -12,7 +12,7 @@ runs (``processAutomationEngineWorkflow``). The harness's local seed DAG
 establishes the workflow record, not the graph. So the DAG contract a full-DAG
 e2e exercises is whatever is installed on that tenant.
 
-Two subcommands:
+Three subcommands:
 
 ``install``
     Register a tenant-targeted GM version for the PR image, install it, wait for
@@ -28,6 +28,35 @@ Two subcommands:
     can replace it between the install and the assertions. There is no
     cross-job lease in GitHub Actions that closes that window, so the drift is
     turned into a loud failure instead of a silent wrong-version pass.
+
+``uninstall``
+    Give the tenant back. FND-709: ``install`` writes ``releaseChannel:
+    "specific"`` plus a ``releaseId`` into the app's HelmRelease values, and
+    nothing ever removed it — so every connector that ran e2e left a permanent
+    per-connector version pin on every tenant it touched (30 of them on one
+    cloud's tenant, one per connector, accumulated over three days). That is a
+    hazard rather than clutter: LM's deployment health check is namespace-scoped
+    (DISTR-901), so a single stale ``sdr-test-*`` pod that has aged out of the
+    registry cache fails EVERY future install to that tenant, for repos that had
+    nothing to do with the run that created it.
+
+    Deleting the HelmRelease is what clears the pin — ``releaseChannel``,
+    ``releaseId`` and ``image.tag`` all live in its values, so they go with it.
+    That is step one of LM's ``AppDeploymentWorkflow(operation=UNINSTALL)``;
+    steps two and three wait for the workload to be gone and delete the
+    ``AtlanAppInstalled`` record.
+
+    Residue always exits non-zero: this reports honestly on what it left behind,
+    and the one caller that must not go red on it — the e2e cleanup, in a job
+    whose whole purpose is handing the tenant back — tolerates it with
+    ``continue-on-error`` at the call site instead.
+
+    Two things it deliberately cannot do. It cannot touch a **system** app (LM
+    answers 409; those are reconciler-owned — FND-438), and it does not delete
+    the app's **namespace** (which carries ``helm.sh/resource-policy: keep`` and
+    would need cluster-wide RBAC). Neither weakens the point: ``helm uninstall``
+    removes the Deployments and pods, and a bare namespace with no unhealthy pods
+    in it does not fail anybody's install.
 
 Credentials
 -----------
@@ -82,6 +111,7 @@ from e2e_tenant_api import (
     INSTALL_PATH,
     PUBLISH_PATH,
     RELEASE_SCAN_PATH,
+    UNINSTALL_PATH,
     Response,
     TenantApiError,
     TenantClient,
@@ -114,6 +144,16 @@ _INSTALL_RETRY_POLL_SECONDS = 20
 #: fails the guard rather than silently making a job timeout reachable.
 DEFAULT_INSTALL_RETRY_SECONDS = 600
 DEFAULT_DEPLOYMENT_TIMEOUT_SECONDS = 600
+
+#: Budget for the UNINSTALL deployment to reconcile, and much smaller than the
+#: install's on purpose. It is a Flux HelmRelease delete plus a wait for the
+#: workload to go, with no image pull, no registry, and no catalog-snapshot lag to
+#: sit behind — so the install's 600s would only ever be spent by a wedged
+#: uninstall, and this wait is spent while the tenant LEASE IS STILL HELD (the
+#: cleanup has to finish before the tenant is handed to the next run, or that
+#: run's fresh install is what gets deleted). Long enough for the normal case,
+#: short enough that a wedged one hands the tenant back rather than sitting on it.
+DEFAULT_UNINSTALL_TIMEOUT_SECONDS = 300
 
 #: Keys an install/info response may carry the installed version under. LM has
 #: not committed to one name across versions, so check the plausible set rather
@@ -279,6 +319,38 @@ class InstallOutcome:
         }
 
 
+#: What an uninstall attempt settled to. Two of these mean the tenant carries no
+#: pin for the app afterwards, which is the whole point of the subcommand; the
+#: rest mean it might, and the caller reports them as residue.
+#:
+#: ``refused`` and ``unreachable`` are kept apart because they need different
+#: humans: ``refused`` is LM declining (a wrong deployment name, a 4xx it will
+#: keep giving), ``unreachable`` is the call or the reconcile not completing (a
+#: transient the next run's cleanup will retry for free).
+_CLEARED_OUTCOMES = frozenset({"removed", "not-installed"})
+
+
+@dataclass(frozen=True)
+class UninstallOutcome:
+    """What one app's uninstall attempt did, per app rather than per run.
+
+    One of these per app id because the sweep path takes a list, and a single
+    aggregated verdict would hide exactly the case worth seeing: 29 pins cleared
+    and one refused reads as a failure, and the one that needs a human is the one
+    named in ``detail``.
+    """
+
+    app_id: str
+    outcome: str
+    detail: str = ""
+    deployment_id: str = ""
+
+    @property
+    def cleared(self) -> bool:
+        """True when the tenant carries no version pin for this app afterwards."""
+        return self.outcome in _CLEARED_OUTCOMES
+
+
 def _env(*names: str) -> str:
     """Return the first non-empty value among ``names``.
 
@@ -358,6 +430,33 @@ def resolve_app_id(explicit: str) -> str:
             "marketplace yet, so there is nothing to install or verify against."
         )
     return str(app_id).strip()
+
+
+def resolve_app_ids(value: str) -> list[str]:
+    """Parse a comma- or space-separated app-id list, or fall back to atlan.yaml.
+
+    One flag rather than a ``--app-id`` / ``--app-ids`` pair, because the two call
+    sites want opposite defaults and a pair would let a caller pass both and have
+    one silently win. The e2e cleanup runs in the app repo and passes nothing, so
+    the id comes from ``atlan.yaml`` exactly as the install's did — the two cannot
+    disagree about which app was installed. The manual sweep runs in
+    application-sdk, where there is no ``atlan.yaml`` to read, and names the apps
+    explicitly.
+
+    Duplicates are dropped in first-seen order: the sweep list is hand-written, a
+    repeated id would uninstall twice, and the second attempt's benign 404 would
+    read in the report as though the app had never been installed.
+    """
+    tokens = [token.strip() for token in value.replace(",", " ").split()]
+    supplied = [token for token in tokens if token]
+    if not supplied:
+        supplied = [resolve_app_id("")]
+    ordered: list[str] = []
+    for app_id in supplied:
+        validated = validate_app_id(app_id)
+        if validated not in ordered:
+            ordered.append(validated)
+    return ordered
 
 
 def _clients(base_url: str) -> tuple[TenantClient, TenantClient]:
@@ -794,8 +893,8 @@ def _publish(client: TenantClient, request: PublishRequest) -> tuple[str, str]:
 
 
 @dataclass(frozen=True)
-class _InstallReply:
-    """LM's install response, whose HTTP status is not the whole story.
+class _MarketplaceReply:
+    """LM's install/uninstall response, whose HTTP status is not the whole story.
 
     ``POST /tenant/default/apps/{id}/install`` answers **HTTP 200 with an
     error-shaped envelope** for its two non-deploying outcomes
@@ -806,6 +905,15 @@ class _InstallReply:
 
     So ``response.ok`` alone would read a 404 as a success. The in-body
     ``status_code`` is authoritative and is what this parses.
+
+    ONE reader for both routes on purpose. ``/uninstall`` is the same handler
+    family and answers in the same envelope (202 plus a ``deployment_id`` on the
+    happy path), so a second parser would be a second place for the "trust
+    ``status_code``, not ``response.ok``" rule to be forgotten. What differs
+    between the two routes is only *which* of the outcome properties below is the
+    benign one, and that is the caller's decision rather than this class's — see
+    :attr:`not_installed`, where install and uninstall read the same 404
+    oppositely.
     """
 
     http_status: int
@@ -816,7 +924,7 @@ class _InstallReply:
     rendered_body: str
 
     @classmethod
-    def parse(cls, response: Response) -> _InstallReply:
+    def parse(cls, response: Response) -> _MarketplaceReply:
         data = response.data() if isinstance(response.body, dict) else {}
         raw_code = data.get("status_code")
         # `message` is LM's 200-envelope field; `detail` is what Heracles/FastAPI
@@ -850,6 +958,31 @@ class _InstallReply:
     def already_installed(self) -> bool:
         return not self.failed and "already installed" in self.message.lower()
 
+    @property
+    def not_installed(self) -> bool:
+        """Uninstall's benign 404: there is no install record left to remove.
+
+        The same status code as install's :attr:`not_found`, read oppositely, and
+        the difference is load-bearing. On install a 404 means "LM's
+        tenant-catalog snapshot has not caught up with a fresh publish" and the
+        right response is to retry for minutes; on uninstall it means the tenant
+        is already in the state being asked for, and retrying would burn the
+        whole budget waiting for something that has already happened.
+        """
+        return self.not_found
+
+    @property
+    def system_app(self) -> bool:
+        """LM refuses to uninstall a system app (``is_system_app``) with a 409.
+
+        Permanent and by design rather than transient: system apps are
+        reconciler-owned and would be re-installed if removed, so this route can
+        never clear one. Reported, never retried — and the reason a system-app
+        version pin belongs to FND-438 rather than to this path. It cannot arise
+        for a connector, which is every app this driver installs.
+        """
+        return self.status_code == 409
+
 
 def _install(
     client: TenantClient,
@@ -880,7 +1013,7 @@ def _install(
     attempt = 0
     while True:
         attempt += 1
-        reply = _InstallReply.parse(
+        reply = _MarketplaceReply.parse(
             client.post(
                 INSTALL_PATH.format(app_id=path_segment(app_id)),
                 body={"version_id": version_id, "force_install": True},
@@ -1413,6 +1546,134 @@ def verify(args: argparse.Namespace) -> str:
     return installed
 
 
+def _uninstall_one(
+    post_client: TenantClient,
+    read_client: TenantClient,
+    app_id: str,
+    *,
+    timeout_seconds: int,
+) -> UninstallOutcome:
+    """Remove one app's installation from the tenant, and say what happened.
+
+    Never raises: every path returns an :class:`UninstallOutcome`. The caller is
+    a cleanup step, so "what is left behind" is the answer it needs about EVERY
+    app in the list — one app's transport error must not abandon the rest.
+    """
+    try:
+        reply = _MarketplaceReply.parse(
+            post_client.post(UNINSTALL_PATH.format(app_id=path_segment(app_id)))
+        )
+    except TenantApiError as exc:
+        return UninstallOutcome(app_id, "unreachable", f"uninstall call failed: {exc}")
+
+    if reply.not_installed:
+        # The tenant is already in the state being asked for. Terminal success,
+        # not a retryable miss — see _MarketplaceReply.not_installed.
+        return UninstallOutcome(
+            app_id, "not-installed", reply.message or "no install record on the tenant"
+        )
+    if reply.system_app:
+        return UninstallOutcome(
+            app_id,
+            "refused",
+            "LM refuses to uninstall a system app (409). System apps are "
+            "reconciler-owned, so this route can never clear their version pin — "
+            f"that is FND-438's territory. message={reply.message!r}",
+        )
+    if reply.failed:
+        return UninstallOutcome(
+            app_id,
+            "refused",
+            f"status={reply.status!r} status_code={reply.status_code} "
+            f"message={reply.message!r} (HTTP {reply.http_status}). A 400 here is "
+            "LM rejecting a non-`default` deployment name — customer-infra / SDR "
+            "uninstall is not implemented in LM yet, and only the `default` "
+            f"deployment is reachable. response={reply.rendered_body}",
+        )
+
+    if reply.deployment_id:
+        print(f"uninstall accepted, deployment_id={reply.deployment_id}")
+        try:
+            _poll_deployment(read_client, reply.deployment_id, timeout_seconds)
+        except (TenantAppError, TenantApiError) as exc:
+            # DeploymentFailed and a timeout are the same answer here, unlike on
+            # the install side. There the distinction mattered because LM's
+            # namespace-scoped verdict could be about somebody else's pod and the
+            # version read-back could overrule it; here there is no version to
+            # read back that would prove the HelmRelease is gone, so either way
+            # the honest report is "a pin may remain".
+            return UninstallOutcome(
+                app_id,
+                "unreachable",
+                f"uninstall deployment did not confirm: {exc}",
+                reply.deployment_id,
+            )
+    else:
+        # LM answered success without starting a deployment. Not treated as done:
+        # the read-back below is the only direct evidence either way.
+        print(
+            "::notice::uninstall reported success but started no deployment; "
+            "relying on the read-back below"
+        )
+
+    # Direct evidence, mirroring what install() does with its version read-back.
+    # LM's third uninstall step deletes the `AtlanAppInstalled` record, so a
+    # tenant that still reports a version for this app has not finished — and an
+    # empty read is meaningful HERE in a way it is not on the install path,
+    # because "not installed" is precisely the state being asserted.
+    still = _installed_version(read_client, app_id)
+    if still:
+        return UninstallOutcome(
+            app_id,
+            "unreachable",
+            f"the tenant still reports {still} installed after the uninstall "
+            "completed, so the HelmRelease — and the releaseChannel/releaseId "
+            "pin in its values — may still be there",
+            reply.deployment_id,
+        )
+    return UninstallOutcome(
+        app_id, "removed", "install record and HelmRelease gone", reply.deployment_id
+    )
+
+
+def uninstall(args: argparse.Namespace) -> list[UninstallOutcome]:
+    """Clear this run's version pin from the tenant. Returns one outcome per app.
+
+    Ordering, not just cleanup: the caller must run this while it STILL HOLDS the
+    tenant lease and before it releases it. Handing the tenant over first means
+    the next run's install can land between the HelmRelease delete and the record
+    delete, and LM's reinstall suppression is explicitly not a second backstop —
+    ``trigger_uninstall`` and ``_trigger_install`` share one ``is_app_uninstalled``
+    lookup that fails open, so neither blocks the other on a bad read.
+    """
+    base_url = validate_tenant_base_url(args.base_url)
+    app_ids = resolve_app_ids(args.app_ids)
+    post_client, read_client = _clients(base_url)
+
+    outcomes: list[UninstallOutcome] = []
+    for app_id in app_ids:
+        print(f"--- uninstalling {app_id} ---")
+        outcome = _uninstall_one(
+            post_client, read_client, app_id, timeout_seconds=args.timeout_seconds
+        )
+        level = "notice" if outcome.cleared else "warning"
+        print(f"::{level}::{app_id}: {outcome.outcome} — {outcome.detail}")
+        outcomes.append(outcome)
+    return outcomes
+
+
+def _uninstall_outputs(outcomes: list[UninstallOutcome]) -> dict[str, str]:
+    """Render the per-app outcomes for ``$GITHUB_OUTPUT`` and the step summary."""
+    return {
+        "cleared": ",".join(o.app_id for o in outcomes if o.cleared),
+        "residual": ",".join(o.app_id for o in outcomes if not o.cleared),
+        "deployment_ids": ",".join(
+            o.deployment_id for o in outcomes if o.deployment_id
+        ),
+        "outcomes": ";".join(f"{o.app_id}={o.outcome}" for o in outcomes),
+    }
+
+
 def _write_outputs(outputs: dict[str, str]) -> None:
     """Append to ``$GITHUB_OUTPUT``, or print when running outside Actions.
 
@@ -1498,12 +1759,64 @@ def main(argv: list[str] | None = None) -> int:
     _add_common(p_verify)
     p_verify.add_argument("--expected", required=True)
 
+    p_uninstall = sub.add_parser(
+        "uninstall", help="remove the installation, clearing the version pin"
+    )
+    # NOT _add_common: this subcommand takes a LIST where the others take one id,
+    # and offering both would let a caller pass both and have one silently win.
+    p_uninstall.add_argument("--base-url", required=True, help="https://<tenant>")
+    p_uninstall.add_argument(
+        "--app-ids",
+        default="",
+        help=(
+            "GM app UUIDs, comma- or space-separated. Omit to read the single "
+            "app_id from atlan.yaml in the cwd, which is what the e2e cleanup "
+            "does so its id has the same source as the install's."
+        ),
+    )
+    p_uninstall.add_argument(
+        "--timeout-seconds",
+        type=int,
+        default=DEFAULT_UNINSTALL_TIMEOUT_SECONDS,
+        help=(
+            "Budget for the uninstall deployment to reconcile. Spent while the "
+            "tenant lease is still held, so it is deliberately much shorter than "
+            "the install's."
+        ),
+    )
+    # No --best-effort flag. Residue always exits non-zero here, and the ONE
+    # caller that must not go red — the e2e cleanup, which runs in a job whose
+    # whole purpose is handing the tenant back and must never red a run whose
+    # tests passed — says so with `continue-on-error: true` at its call site.
+    # Keeping the tolerance in the workflow rather than in a flag means it is
+    # visible to whoever reads the step, it covers the failure paths a residue
+    # flag would not (an unreachable tenant, a rotated credential), and this
+    # script stays honest about what it left behind.
+
     args = parser.parse_args(argv)
 
     try:
         if args.command == "install":
             outcome = install(args)
             _write_outputs(outcome.as_outputs())
+        elif args.command == "uninstall":
+            outcomes = uninstall(args)
+            _write_outputs(_uninstall_outputs(outcomes))
+            residual = [o for o in outcomes if not o.cleared]
+            if not residual:
+                return 0
+            print(
+                f"::error::{len(residual)} of {len(outcomes)} app(s) may still "
+                "carry a version pin on this tenant: "
+                + ", ".join(f"{o.app_id} ({o.outcome})" for o in residual)
+                + ". Each one is a candidate ImagePullBackOff once its image ages "
+                "out of the registry cache, and LM's health check is "
+                "namespace-scoped — so it will fail EVERY future install to this "
+                "tenant, for any repo. Clear it with the E2E Tenant Uninstall "
+                "workflow.",
+                file=sys.stderr,
+            )
+            return 1
         else:
             _write_outputs({"installed_version": verify(args)})
     except (TenantAppError, TenantApiError) as exc:

--- a/.github/scripts/tests/test_e2e_tenant_app.py
+++ b/.github/scripts/tests/test_e2e_tenant_app.py
@@ -1009,7 +1009,7 @@ def test_success_without_a_deployment_id_still_fails(
     ],
 )
 def test_not_found_detection(code: int, message: str, expected_not_found: bool) -> None:
-    reply = app._InstallReply.parse(_install_reply("error", code, message))
+    reply = app._MarketplaceReply.parse(_install_reply("error", code, message))
     assert reply.not_found is expected_not_found
 
 

--- a/.github/scripts/tests/test_e2e_tenant_uninstall.py
+++ b/.github/scripts/tests/test_e2e_tenant_uninstall.py
@@ -1,0 +1,415 @@
+"""Tests for the `uninstall` subcommand of .github/scripts/e2e_tenant_app.py.
+
+FND-709. The gap this closes was invisible for months precisely because nothing
+asserted it: `install` wrote a `releaseChannel: specific` pin into the app's
+HelmRelease values and no code path removed it, so the residue accumulated one
+pin per connector per tenant and only surfaced when a stale image aged out of the
+registry cache and started failing OTHER repos' installs (LM's health check is
+namespace-scoped — DISTR-901).
+
+So these assertions are shaped around "what is left on the tenant afterwards",
+not around "did the call return 200". Every route LM can answer with is scripted:
+the happy path, the two benign non-deployments, the two permanent refusals, and
+the two ways a reconcile can leave a pin behind.
+
+The HTTP seam is stubbed at ``TenantClient.request``, reusing the transport stub
+from test_e2e_tenant_app.py rather than a second copy — one stub means one place
+where "a fragment match on ``/install`` also matches ``/uninstall``" has to be
+remembered.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+sys.path.insert(0, str(Path(__file__).parent))
+
+import e2e_tenant_api as api  # noqa: E402
+import e2e_tenant_app as app  # noqa: E402
+from e2e_tenant_api import Response, TenantApiError, TenantClient  # noqa: E402
+from test_e2e_tenant_app import StubRoute, StubTransport, _ok, _wire  # noqa: E402
+
+_TENANT = "https://example-tenant.atlan.test"
+_APP_ID = "019d1f6b-6fea-7db3-96d8-e61e159d0351"
+_OTHER_APP_ID = "019d1f6b-6fea-7db3-96d8-e61e159d0352"
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(app.time, "sleep", lambda _s: None)
+
+
+@pytest.fixture(autouse=True)
+def _creds(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("E2E_OAUTH_CLIENT_ID", "client-id")
+    monkeypatch.setenv("E2E_OAUTH_CLIENT_SECRET", "client-secret")
+    monkeypatch.delenv("ATLAN_API_KEY", raising=False)
+    monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+    monkeypatch.setattr(app, "mint_oauth_token", lambda *_a, **_k: "stub.jwt.token")
+
+
+def _args(**overrides: object) -> argparse.Namespace:
+    values: dict[str, object] = {
+        "base_url": _TENANT,
+        "app_ids": _APP_ID,
+        "timeout_seconds": 300,
+    }
+    values.update(overrides)
+    return argparse.Namespace(**values)
+
+
+def _reply(status: str, code: int, message: str = "", **extra: object) -> Response:
+    """LM's envelope: HTTP 200 carrying its own authoritative ``status_code``."""
+    return Response(
+        status=200,
+        body={"status": status, "status_code": code, "message": message, **extra},
+    )
+
+
+# ── The route itself ─────────────────────────────────────────────────────────
+
+
+def test_uninstall_path_is_the_tenant_scoped_sibling_of_install() -> None:
+    """The two are one pair: uninstall must target the same tenant scope install
+    does, or a run would install onto `default` and try to clean up elsewhere.
+
+    Asserted as a derivation rather than a second literal, so the paths cannot
+    drift apart without this failing.
+    """
+    assert api.UNINSTALL_PATH == api.INSTALL_PATH.replace("/install", "/uninstall")
+    assert "/tenant/default/apps/" in api.UNINSTALL_PATH
+
+
+# ── The happy path: the pin is gone ──────────────────────────────────────────
+
+
+def test_a_completed_uninstall_reports_removed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    transport = _wire(
+        monkeypatch,
+        StubTransport(
+            routes=[
+                StubRoute(
+                    "POST", "/uninstall", _reply("success", 202, deployment_id="d1")
+                ),
+                StubRoute(
+                    "GET", "/deployments/", _ok({"deployment_status": "SUCCEEDED"})
+                ),
+                # LM's third step deletes the AtlanAppInstalled record, so info no
+                # longer reports a version.
+                StubRoute("GET", "/info", Response(status=404, body={})),
+            ]
+        ),
+    )
+    outcomes = app.uninstall(_args())
+
+    assert [o.outcome for o in outcomes] == ["removed"]
+    assert outcomes[0].cleared is True
+    assert outcomes[0].deployment_id == "d1"
+    assert transport.paths("POST") == [
+        api.UNINSTALL_PATH.format(app_id=_APP_ID)
+    ], "the app id must reach the path through the module's own constant"
+
+
+def test_the_read_back_is_what_decides_and_not_the_202(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A SUCCEEDED uninstall deployment whose install record is still there is
+    residue, not success. Same rule as install()'s version read-back: LM's own
+    verdict is namespace-scoped, so direct evidence about THIS app decides."""
+    _wire(
+        monkeypatch,
+        StubTransport(
+            routes=[
+                StubRoute(
+                    "POST", "/uninstall", _reply("success", 202, deployment_id="d1")
+                ),
+                StubRoute(
+                    "GET", "/deployments/", _ok({"deployment_status": "SUCCEEDED"})
+                ),
+                StubRoute("GET", "/info", _ok({"version_text": "sdr-test-abc12345"})),
+            ]
+        ),
+    )
+    outcomes = app.uninstall(_args())
+
+    assert outcomes[0].cleared is False
+    assert outcomes[0].outcome == "unreachable"
+    assert "sdr-test-abc12345" in outcomes[0].detail
+
+
+# ── Benign non-deployments ───────────────────────────────────────────────────
+
+
+def test_a_404_is_terminal_success_not_a_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The SAME status code install retries for minutes. On uninstall the tenant
+    is already in the state being asked for, so retrying would burn the whole
+    budget waiting for something that has already happened."""
+    transport = _wire(
+        monkeypatch,
+        StubTransport(
+            routes=[
+                StubRoute(
+                    "POST",
+                    "/uninstall",
+                    _reply("error", 404, "App with ID '…' not found"),
+                )
+            ]
+        ),
+    )
+    outcomes = app.uninstall(_args())
+
+    assert outcomes[0].outcome == "not-installed"
+    assert outcomes[0].cleared is True
+    assert len(transport.paths("POST")) == 1, "a 404 must not be retried"
+    assert (
+        transport.paths("GET") == []
+    ), "nothing to poll and nothing to read back: there is no install record"
+
+
+def test_success_without_a_deployment_still_reads_back(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # LM answering success with no deployment_id is not evidence the pin is gone.
+    _wire(
+        monkeypatch,
+        StubTransport(
+            routes=[
+                StubRoute("POST", "/uninstall", _reply("success", 200, "done")),
+                StubRoute("GET", "/info", Response(status=404, body={})),
+            ]
+        ),
+    )
+    assert app.uninstall(_args())[0].outcome == "removed"
+
+
+# ── Permanent refusals ───────────────────────────────────────────────────────
+
+
+def test_a_system_app_is_refused_and_named_as_such(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """409 is permanent, so it must not read as a transient. It is also the one
+    outcome that needs a DIFFERENT fix (FND-438: system apps are reconciler-owned
+    and this route can never clear their pin), so the detail has to say so."""
+    _wire(
+        monkeypatch,
+        StubTransport(
+            routes=[
+                StubRoute(
+                    "POST", "/uninstall", _reply("error", 409, "app is a system app")
+                )
+            ]
+        ),
+    )
+    outcome = app.uninstall(_args())[0]
+
+    assert outcome.outcome == "refused"
+    assert outcome.cleared is False
+    assert "system app" in outcome.detail
+    assert "FND-438" in outcome.detail
+
+
+def test_a_non_default_deployment_is_refused_with_the_reason(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _wire(
+        monkeypatch,
+        StubTransport(
+            routes=[
+                StubRoute(
+                    "POST",
+                    "/uninstall",
+                    _reply("error", 400, "only the default deployment is supported"),
+                )
+            ]
+        ),
+    )
+    outcome = app.uninstall(_args())[0]
+
+    assert outcome.outcome == "refused"
+    assert "default" in outcome.detail
+
+
+# ── The two ways a reconcile leaves a pin behind ─────────────────────────────
+
+
+@pytest.mark.parametrize("terminal", ["FAILED", "STILL_RUNNING"])
+def test_an_unconfirmed_deployment_is_residue(
+    monkeypatch: pytest.MonkeyPatch, terminal: str
+) -> None:
+    """A FAILED uninstall and one that never reaches a terminal state are the
+    SAME answer here, unlike on the install side. There, a namespace-scoped FAILED
+    verdict could be about somebody else's pod and the version read-back could
+    overrule it; here there is no read-back that can prove the HelmRelease is
+    gone, so both mean "a pin may remain"."""
+    _wire(
+        monkeypatch,
+        StubTransport(
+            routes=[
+                StubRoute(
+                    "POST", "/uninstall", _reply("success", 202, deployment_id="d1")
+                ),
+            ],
+            sticky=[
+                StubRoute("GET", "/deployments/", _ok({"deployment_status": terminal})),
+            ],
+        ),
+    )
+    outcome = app.uninstall(_args(timeout_seconds=0))[0]
+
+    assert outcome.outcome == "unreachable"
+    assert outcome.cleared is False
+
+
+def test_a_transport_error_on_one_app_does_not_abandon_the_rest(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The sweep's whole value is telling a human what is LEFT on the tenant, so
+    one unreachable app must not cost the answer about the other 29."""
+
+    def _explode(
+        _self: object,
+        method: str,
+        path: str,
+        **_kwargs: object,
+    ) -> Response:
+        if _APP_ID in path:
+            raise TenantApiError(f"{method} {path} could not reach the tenant")
+        if method == "POST":
+            return _reply("error", 404, "not found")
+        raise AssertionError(f"unexpected {method} {path}")
+
+    monkeypatch.setattr(TenantClient, "request", _explode)
+    outcomes = app.uninstall(_args(app_ids=f"{_APP_ID},{_OTHER_APP_ID}"))
+
+    assert [(o.app_id, o.outcome) for o in outcomes] == [
+        (_APP_ID, "unreachable"),
+        (_OTHER_APP_ID, "not-installed"),
+    ]
+
+
+# ── The app-id list ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        f"{_APP_ID},{_OTHER_APP_ID}",
+        f"{_APP_ID} {_OTHER_APP_ID}",
+        f" {_APP_ID}, {_OTHER_APP_ID} ",
+        f"{_APP_ID},{_OTHER_APP_ID},{_APP_ID}",
+    ],
+)
+def test_the_app_id_list_is_parsed_and_deduped(raw: str) -> None:
+    # A repeated id would uninstall twice, and the second attempt's benign 404
+    # would read in the report as though the app had never been installed.
+    assert app.resolve_app_ids(raw) == [_APP_ID, _OTHER_APP_ID]
+
+
+def test_a_non_uuid_app_id_is_rejected_before_any_call() -> None:
+    # The ids land in a request path. `str.format` does no escaping, so a value
+    # carrying a slash would rewrite the path on a live tenant.
+    with pytest.raises(TenantApiError, match="invalid app_id"):
+        app.resolve_app_ids(f"{_APP_ID},../../etc/passwd")
+
+
+def test_an_empty_list_falls_back_to_atlan_yaml(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The e2e cleanup passes no ids on purpose: reading atlan.yaml is what makes
+    the uninstall's app the SAME app the install's came from."""
+    (tmp_path / "atlan.yaml").write_text(f"app_id: {_APP_ID}\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    assert app.resolve_app_ids("") == [_APP_ID]
+
+
+# ── Exit code and outputs ────────────────────────────────────────────────────
+
+
+def test_main_exits_zero_when_every_pin_is_cleared(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    output = tmp_path / "gh-output"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(output))
+    _wire(
+        monkeypatch,
+        StubTransport(routes=[StubRoute("POST", "/uninstall", _reply("error", 404))]),
+    )
+
+    code = app.main(["uninstall", "--base-url", _TENANT, "--app-ids", _APP_ID])
+
+    assert code == 0
+    written = dict(
+        line.split("=", 1) for line in output.read_text().splitlines() if line
+    )
+    assert written["cleared"] == _APP_ID
+    assert written["residual"] == ""
+    assert written["outcomes"] == f"{_APP_ID}=not-installed"
+
+
+def test_main_exits_nonzero_on_residue(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Residue is a non-zero exit, always. The one caller that must not go red on
+    it — the e2e cleanup, in a job whose whole purpose is handing the tenant back
+    — says so with `continue-on-error` at its call site, which keeps that
+    tolerance visible in the workflow instead of hidden behind a flag here."""
+    _wire(
+        monkeypatch,
+        StubTransport(
+            routes=[
+                StubRoute("POST", "/uninstall", _reply("error", 409, "system app")),
+            ]
+        ),
+    )
+
+    code = app.main(["uninstall", "--base-url", _TENANT, "--app-ids", _APP_ID])
+
+    assert code == 1
+    err = capsys.readouterr().err
+    assert "may still carry a version pin" in err
+    # The consequence, not just the fact: a pin nobody understands the cost of
+    # does not get cleared.
+    assert "namespace-scoped" in err
+
+
+def test_the_residue_report_names_every_residual_app(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _wire(
+        monkeypatch,
+        StubTransport(
+            routes=[],
+            sticky=[
+                StubRoute("POST", "/uninstall", _reply("error", 409, "system app"))
+            ],
+        ),
+    )
+
+    app.main(
+        ["uninstall", "--base-url", _TENANT, "--app-ids", f"{_APP_ID},{_OTHER_APP_ID}"]
+    )
+
+    err = capsys.readouterr().err
+    assert "2 of 2" in err
+    assert _APP_ID in err
+    assert _OTHER_APP_ID in err
+
+
+def test_the_uninstall_wait_is_shorter_than_the_installs() -> None:
+    """It is spent while the tenant LEASE IS STILL HELD, so it is not free the way
+    the install's wait is: every second here is a second the next run queues for a
+    tenant nobody is using."""
+    assert (
+        app.DEFAULT_UNINSTALL_TIMEOUT_SECONDS < app.DEFAULT_DEPLOYMENT_TIMEOUT_SECONDS
+    )

--- a/.github/scripts/tests/test_e2e_tenant_uninstall.py
+++ b/.github/scripts/tests/test_e2e_tenant_uninstall.py
@@ -144,6 +144,74 @@ def test_the_read_back_is_what_decides_and_not_the_202(
     assert "sdr-test-abc12345" in outcomes[0].detail
 
 
+# ── The router 400 that nearly read as "already clean" ───────────────────────
+#
+# Found by probing a live tenant, not by reading code, and it is the sharpest
+# regression risk in this subcommand: the first implementation keyed
+# `not_installed` on install's loose `"not found" in message` match, and Heracles'
+# router 400 says "Path was not found". A tenant that does not proxy the route
+# therefore reported "not-installed / cleared", green, on every run, forever —
+# leaving the pin exactly where it was. The failure mode FND-709 exists to remove,
+# reintroduced inside the fix for it.
+
+
+def _router_400() -> Response:
+    """Heracles' verbatim answer for a path it does not proxy.
+
+    Captured live against a real tenant, alongside a control: an invented path
+    returns this byte-for-byte, while a route that IS proxied returns LM's
+    envelope (HTTP 200, in-body `status_code`, `status: "error"`). So the shape
+    below is the router, not LM, and not the app.
+    """
+    return Response(
+        status=400, body={"status_code": 400, "message": "Path was not found"}
+    )
+
+
+def test_an_unproxied_route_is_residue_and_not_a_clean_tenant(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _wire(
+        monkeypatch,
+        StubTransport(routes=[StubRoute("POST", "/uninstall", _router_400())]),
+    )
+    outcome = app.uninstall(_args())[0]
+
+    assert outcome.outcome == "route-missing"
+    assert (
+        outcome.cleared is False
+    ), "a tenant that cannot uninstall at all must never report its pin cleared"
+    # And the detail has to point at the tenant, not at the app or the request:
+    # nothing about either will ever change this answer.
+    assert "Heracles" in outcome.detail
+
+
+def test_not_installed_ignores_the_message_and_keys_on_the_code() -> None:
+    """The predicate, directly, because this is where the false green came from.
+
+    LM's real 404 is an enveloped `status_code`, which needs no message match. A
+    message-based match cannot tell it from the router's 400.
+    """
+    router = app._MarketplaceReply.parse(_router_400())
+    assert router.route_missing is True
+    assert router.not_installed is False
+
+    lm = app._MarketplaceReply.parse(_reply("error", 404, "App with ID '…' not found"))
+    assert lm.not_installed is True
+    assert lm.route_missing is False
+
+    # A 404 whose message says nothing useful is still a 404.
+    assert app._MarketplaceReply.parse(_reply("error", 404, "")).not_installed is True
+
+    # And the loose predicate install retries on must NOT be what drives this:
+    # it matches the router 400, which is exactly the bug.
+    assert router.not_found is True, (
+        "install's not_found is deliberately loose (a false positive costs one "
+        "retry). This assertion documents that looseness so nobody re-points "
+        "not_installed at it."
+    )
+
+
 # ── Benign non-deployments ───────────────────────────────────────────────────
 
 

--- a/.github/scripts/tests/test_e2e_tenant_uninstall.py
+++ b/.github/scripts/tests/test_e2e_tenant_uninstall.py
@@ -144,6 +144,169 @@ def test_the_read_back_is_what_decides_and_not_the_202(
     assert "sdr-test-abc12345" in outcomes[0].detail
 
 
+# ── The read-back must fail CLOSED ───────────────────────────────────────────
+#
+# Same class of bug as the router 400 below, one layer further in: `install`'s
+# `_installed_version` folds every non-2xx, every unreadable body and every
+# placeholder version into "", because ITS caller reads "" as "install it" and a
+# wrong empty costs one redundant install. Reusing it to assert "the pin is gone"
+# inverts that: a 500, an expired credential or a dropped connection reads as a
+# clean tenant. With `continue-on-error` on the `release-tenant` step, that is
+# silent — the pin survives and the next repo's install pays for it.
+#
+# So only a real 404, or a 200 with no install record, may report `removed`.
+
+
+@pytest.mark.parametrize("status", [401, 403, 500, 502, 504])
+def test_a_failed_read_back_is_residue_and_not_a_clean_tenant(
+    monkeypatch: pytest.MonkeyPatch, status: int
+) -> None:
+    """Any non-404 failure on the info GET proves nothing about the install
+    record, so it is residue. A 404 is the only failure that IS evidence."""
+    _wire(
+        monkeypatch,
+        StubTransport(
+            routes=[
+                StubRoute(
+                    "POST", "/uninstall", _reply("success", 202, deployment_id="d1")
+                ),
+                StubRoute(
+                    "GET", "/deployments/", _ok({"deployment_status": "SUCCEEDED"})
+                ),
+                StubRoute("GET", "/info", Response(status=status, body={})),
+            ]
+        ),
+    )
+    outcome = app.uninstall(_args())[0]
+
+    assert outcome.outcome == "unreachable"
+    assert outcome.cleared is False
+    assert str(status) in outcome.detail
+
+
+def test_a_transport_error_on_the_read_back_is_residue_not_removed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The GET is wrapped in the same try/except as the POST: _uninstall_one
+    promises never to raise, and a dropped connection while confirming must not
+    escape as an exception NOR report the pin cleared."""
+
+    def _explode(
+        _self: object,
+        method: str,
+        path: str,
+        **_kwargs: object,
+    ) -> Response:
+        if method == "POST":
+            return _reply("success", 202, deployment_id="d1")
+        if "/deployments/" in path:
+            return _ok({"deployment_status": "SUCCEEDED"})
+        raise TenantApiError(f"{method} {path} could not reach the tenant")
+
+    monkeypatch.setattr(TenantClient, "request", _explode)
+    outcome = app.uninstall(_args())[0]
+
+    assert outcome.outcome == "unreachable"
+    assert outcome.cleared is False
+    assert "could not read the app's info back" in outcome.detail
+
+
+def test_an_install_record_with_no_readable_version_is_residue(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`version_text: unknown` is a placeholder, not a version — so the version
+    read comes back empty while the install record is plainly still there. The
+    record's PRESENCE decides, not whether a version could be read out of it."""
+    _wire(
+        monkeypatch,
+        StubTransport(
+            routes=[
+                StubRoute(
+                    "POST", "/uninstall", _reply("success", 202, deployment_id="d1")
+                ),
+                StubRoute(
+                    "GET", "/deployments/", _ok({"deployment_status": "SUCCEEDED"})
+                ),
+                StubRoute(
+                    "GET", "/info", _ok({"installed": {"version_text": "unknown"}})
+                ),
+            ]
+        ),
+    )
+    outcome = app.uninstall(_args())[0]
+
+    assert outcome.outcome == "unreachable"
+    assert outcome.cleared is False
+    assert "'installed'" in outcome.detail
+
+
+def test_a_non_json_read_back_is_residue(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An HTML error page from a proxy is a 200 whose body is not an object. It
+    confirms nothing, so it cannot report the pin cleared."""
+    _wire(
+        monkeypatch,
+        StubTransport(
+            routes=[
+                StubRoute(
+                    "POST", "/uninstall", _reply("success", 202, deployment_id="d1")
+                ),
+                StubRoute(
+                    "GET", "/deployments/", _ok({"deployment_status": "SUCCEEDED"})
+                ),
+                StubRoute(
+                    "GET", "/info", Response(status=200, body="<html>502</html>")
+                ),
+            ]
+        ),
+    )
+    outcome = app.uninstall(_args())[0]
+
+    assert outcome.outcome == "unreachable"
+    assert outcome.cleared is False
+    assert "non-JSON" in outcome.detail
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {},
+        {"catalog": {"app_version": {"version": "sdr-test-abc12345"}}},
+        {"installed": {}},
+        {"deployment": {"deployment_status": "SUCCEEDED"}},
+    ],
+    ids=["empty", "catalog-only", "empty-record", "deployment-only"],
+)
+def test_a_200_with_no_install_record_is_removed(
+    monkeypatch: pytest.MonkeyPatch, payload: dict[str, object]
+) -> None:
+    """The other side of failing closed: these must NOT be reported as residue.
+
+    `catalog` describes the app in general and is present whether or not it is
+    installed (`resolve_version_via_catalog` only reads it when an `installed`
+    UUID matches), `deployment` may be the uninstall's own reconcile, and an empty
+    record carries no install. Reporting any of them as residue would red every
+    clean uninstall and train whoever reads the report to ignore it.
+    """
+    _wire(
+        monkeypatch,
+        StubTransport(
+            routes=[
+                StubRoute(
+                    "POST", "/uninstall", _reply("success", 202, deployment_id="d1")
+                ),
+                StubRoute(
+                    "GET", "/deployments/", _ok({"deployment_status": "SUCCEEDED"})
+                ),
+                StubRoute("GET", "/info", _ok(payload)),
+            ]
+        ),
+    )
+    outcome = app.uninstall(_args())[0]
+
+    assert outcome.outcome == "removed"
+    assert outcome.cleared is True
+
+
 # ── The router 400 that nearly read as "already clean" ───────────────────────
 #
 # Found by probing a live tenant, not by reading code, and it is the sharpest

--- a/.github/scripts/tests/test_e2e_tenant_uninstall_workflow.py
+++ b/.github/scripts/tests/test_e2e_tenant_uninstall_workflow.py
@@ -1,0 +1,154 @@
+"""Guards for .github/workflows/e2e-tenant-uninstall.yaml.
+
+FND-709's sweep half: the manual workflow that clears the version pins already
+sitting on the e2e tenants, and the standing escape hatch for one the automatic
+cleanup could not clear.
+
+Same two properties the install workflow's guards protect, for the same reasons.
+It takes free-text `workflow_dispatch` inputs and REMOVES apps from a live
+tenant, so (a) no input may be interpolated into a `run:` block, where it would be
+spliced into the script before bash sees a quote, and (b) it must not be able to
+run without an explicit confirmation.
+
+Plus one this workflow needs and the install one does not: the `clouds` fan-out is
+built in the expression layer so the `run:` blocks stay straight-line
+(docs/standards/ci.md), and an expression that renders wrong is a sweep pointed at
+the wrong tenants — so it is evaluated here rather than trusted.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from _gha_expr import evaluate_operand  # noqa: E402
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_WORKFLOW = _REPO_ROOT / ".github/workflows/e2e-tenant-uninstall.yaml"
+
+#: Any `${{ inputs.* }}` reference, which is what must not appear inside `run:`.
+_INPUT_REF = re.compile(r"\$\{\{\s*inputs\.[A-Za-z0-9_-]+\s*\}\}")
+
+
+@pytest.fixture(scope="module")
+def workflow() -> dict:  # type: ignore[type-arg]
+    return yaml.safe_load(_WORKFLOW.read_text(encoding="utf-8"))
+
+
+def _steps(workflow: dict) -> list[dict]:  # type: ignore[type-arg]
+    steps: list[dict] = []  # type: ignore[type-arg]
+    for job in workflow["jobs"].values():
+        steps.extend(job.get("steps") or [])
+    return steps
+
+
+def _dispatch_inputs(workflow: dict) -> dict:  # type: ignore[type-arg]
+    # `workflow[True]`: YAML 1.1 resolves the bare key `on` to the boolean true.
+    triggers = workflow.get("on", workflow.get(True))
+    return triggers["workflow_dispatch"]["inputs"]
+
+
+def test_no_dispatch_input_is_interpolated_into_a_run_block(workflow: dict) -> None:  # type: ignore[type-arg]
+    offenders: list[str] = []
+    for step in _steps(workflow):
+        script = step.get("run")
+        if not isinstance(script, str):
+            continue
+        for match in _INPUT_REF.findall(script):
+            offenders.append(f"{step.get('name', '?')}: {match}")
+    assert not offenders, (
+        "these run: blocks interpolate a workflow_dispatch input directly, which "
+        "splices attacker-influenced text into the shell. `app_ids` is a list of "
+        "ids that reach a request path, so this is the one input where a crafted "
+        f'value is worth real effort. Pass it via env: as a quoted "$VAR". '
+        f"Offenders: {offenders}"
+    )
+
+
+def test_the_app_id_list_arrives_through_env(workflow: dict) -> None:  # type: ignore[type-arg]
+    by_name = {str(s.get("name", "")): s for s in _steps(workflow)}
+    step = by_name.get("Uninstall the apps")
+    assert step is not None, "the uninstall step is gone; update this guard"
+    env = set(step.get("env") or {})
+    assert {"APP_IDS", "TIMEOUT_SECONDS"} <= env
+    # The credentials are NOT re-exported here: the resolver already wrote them to
+    # $GITHUB_ENV, and every hop a secret takes is a hop it can be mishandled on.
+    assert not {"SDR_CLIENT_ID", "SDR_CLIENT_SECRET", "ATLAN_API_KEY"} & env
+
+
+def test_uninstall_requires_explicit_confirmation(workflow: dict) -> None:  # type: ignore[type-arg]
+    """Removing an app from a tenant is a deployment; it must not run by default."""
+    confirm = _dispatch_inputs(workflow)["confirm"]
+    assert confirm["default"] == "no"
+    assert set(confirm["options"]) == {"no", "yes"}
+    assert workflow["jobs"]["uninstall"]["if"] == "inputs.confirm == 'yes'", (
+        "the confirmation gate must be a job-level if:, so an unconfirmed run is "
+        "visibly skipped rather than green-but-did-nothing"
+    )
+
+
+@pytest.mark.parametrize(
+    ("selection", "expected"),
+    [
+        ("all", ["aws", "azure", "gcp"]),
+        ("aws", ["aws"]),
+        ("azure", ["azure"]),
+        ("gcp", ["gcp"]),
+    ],
+)
+def test_the_cloud_fan_out_renders_for_every_option(
+    workflow: dict,  # type: ignore[type-arg]
+    selection: str,
+    expected: list[str],
+) -> None:
+    """A matrix expression that renders wrong points the sweep at the wrong
+    tenants — or at none, which is a green run that did nothing. Evaluated for
+    every option the `choice` offers rather than spot-checked, because "all" and
+    the single-cloud form take different arms of the `&&`/`||`.
+    """
+    matrix = workflow["jobs"]["uninstall"]["strategy"]["matrix"]["cloud"]
+    inner = matrix.strip()
+    assert inner.startswith("${{ fromJson(") and inner.endswith(") }}")
+    # fromJson is not modelled by the evaluator, so the argument is evaluated and
+    # parsed here — which is exactly what fromJson does.
+    argument = inner[len("${{ fromJson(") : -len(") }}")]
+    rendered = evaluate_operand(argument, {"inputs": {"clouds": selection}})
+    assert json.loads(rendered) == expected
+
+    # And the option list and the fan-out must not drift apart: a cloud added to
+    # the choice but not to the "all" arm would be silently skipped by every sweep.
+    options = set(_dispatch_inputs(workflow)["clouds"]["options"]) - {"all"}
+    all_arm = json.loads(evaluate_operand(argument, {"inputs": {"clouds": "all"}}))
+    assert set(all_arm) == options
+
+
+def test_one_wedged_tenant_does_not_stop_the_others(workflow: dict) -> None:  # type: ignore[type-arg]
+    """The pins accumulated on all three tenants, so a sweep that abandons two
+    clouds because the third is wedged leaves most of the hazard in place."""
+    assert workflow["jobs"]["uninstall"]["strategy"]["fail-fast"] is False
+
+
+def test_concurrency_is_per_cloud_selection_and_does_not_cancel(workflow: dict) -> None:  # type: ignore[type-arg]
+    concurrency = workflow["concurrency"]
+    assert "inputs.clouds" in concurrency["group"]
+    # Cancelling mid-uninstall leaves the tenant with the HelmRelease gone and the
+    # install record still there.
+    assert concurrency["cancel-in-progress"] is False
+
+
+def test_residue_reds_this_run(workflow: dict) -> None:  # type: ignore[type-arg]
+    """The opposite of the automatic cleanup's contract, deliberately.
+
+    A pin that would not clear is precisely what this run was fired to fix, so it
+    has to be a red run rather than a warning in a log nobody opens — which means
+    NOT carrying the `continue-on-error` the e2e cleanup step does.
+    """
+    by_name = {str(s.get("name", "")): s for s in _steps(workflow)}
+    assert "continue-on-error" not in by_name["Uninstall the apps"]

--- a/.github/scripts/tests/test_export_extra_env.py
+++ b/.github/scripts/tests/test_export_extra_env.py
@@ -580,6 +580,10 @@ _PROSE_ONLY_FILES = {
     # invokes it. The "no live mention" assertion below is what keeps that true:
     # if it ever starts invoking the script, it stops being excluded.
     ".github/workflows/e2e-tenant-install.yaml",
+    # FND-709, and for exactly the same reason as its install twin above: the
+    # version-pin sweep resolves a tenant in two passes and cites this script as
+    # the explanation, in a comment.
+    ".github/workflows/e2e-tenant-uninstall.yaml",
 }
 
 # The script and its own tests are the implementation, not callers of it. Both

--- a/.github/scripts/tests/test_prepare_tenant_wiring.py
+++ b/.github/scripts/tests/test_prepare_tenant_wiring.py
@@ -503,10 +503,19 @@ def test_the_lease_wait_fits_inside_the_job_timeout(jobs: dict) -> None:  # type
 
 
 #: The jobs a lease is actually HELD across: acquired before the install, released
-#: after the last leg. The TTL is measured from the acquisition time the holder
-#: records for itself, so only this span counts — none of the pre-lease work
+#: at the end of release-tenant. The TTL is measured from the acquisition time the
+#: holder records for itself, so only this span counts — none of the pre-lease work
 #: (discovery, image build, manifest merge, runner queue time) does.
-_LEASE_HELD_ACROSS = ("prepare-tenant", "e2e")
+#:
+#: release-tenant is in the span since FND-709 and has to be. It no longer only
+#: releases: it uninstalls the app first, clearing the `releaseChannel: specific`
+#: pin the install wrote, and that has to happen UNDER the lease — hand the tenant
+#: over first and the next run's install can land between LM's HelmRelease delete
+#: and its record delete, with LM's fail-open `is_app_uninstalled` lookup shared
+#: between the two paths so neither blocks the other. Raising release-tenant's
+#: timeout therefore forces the TTL up here, rather than silently eating its
+#: margin.
+_LEASE_HELD_ACROSS = ("prepare-tenant", "e2e", "release-tenant")
 
 
 def test_the_lease_ttl_cannot_fire_on_a_healthy_holder(jobs: dict) -> None:  # type: ignore[type-arg]
@@ -1002,6 +1011,154 @@ def test_job_timeout_stays_above_the_scripts_own_waits(jobs: dict) -> None:  # t
             f"the step now passes {flag}, so the budget above is no longer the "
             "script's default — compute the timeout from the passed value instead"
         )
+
+
+# ── FND-709: the run clears its own version pin before it lets the tenant go ─
+#
+# Every assertion below protects something whose failure mode is silent residue
+# rather than a red build — a `releaseChannel: specific` pin left on a shared
+# tenant, which surfaces weeks later as an ImagePullBackOff that fails somebody
+# ELSE's install (LM's health check is namespace-scoped, DISTR-901). That is
+# exactly how the gap this closes went unnoticed for months, so the regression
+# has to be catchable here.
+
+#: The step names the guards below key on. Kept as constants because the
+#: assertions are about their ORDER and their gates, and a rename that only
+#: touched one of two literals would silently stop testing anything.
+_HOLD_STEP = "Confirm this run still holds the tenant lease"
+_UNINSTALL_STEP = "Clear this run's version pin from the tenant"
+_RELEASE_STEP = "Release the tenant lease"
+
+
+def _release_tenant_steps(jobs: dict) -> list[dict]:  # type: ignore[type-arg]
+    return list(jobs["release-tenant"]["steps"])
+
+
+def _step_index(jobs: dict, name: str) -> int:  # type: ignore[type-arg]
+    for index, step in enumerate(_release_tenant_steps(jobs)):
+        if str(step.get("name", "")) == name:
+            return index
+    raise AssertionError(
+        f"release-tenant has no step named {name!r}; the FND-709 cleanup guards "
+        "below key on it"
+    )
+
+
+def test_the_pin_is_cleared_before_the_lease_goes_back(jobs: dict) -> None:  # type: ignore[type-arg]
+    """The order IS the safety property.
+
+    Release first and the next run's install can land between LM's HelmRelease
+    delete and its record delete — and LM's reinstall suppression is explicitly
+    not a second backstop: `trigger_uninstall` and `_trigger_install` share one
+    `is_app_uninstalled` lookup that fails open, so on a bad read neither blocks
+    the other. The lease is the only thing that closes that window.
+    """
+    assert _step_index(jobs, _UNINSTALL_STEP) < _step_index(jobs, _RELEASE_STEP), (
+        "the uninstall must run while this run still holds the lease; releasing "
+        "first lets the next run's install race LM's delete"
+    )
+
+
+def test_the_uninstall_only_runs_for_a_cloud_this_run_actually_holds(
+    jobs: dict,
+) -> None:  # type: ignore[type-arg]
+    """release-tenant's `if:` is deliberately wide — it runs for clouds this run
+    never leased, so a leg that holds nothing can still hand back what it does.
+
+    The RELEASE is safe under that widening on its own (the driver re-checks
+    ownership per ref before deleting). An UNINSTALL is not: run for a cloud this
+    run never held, it deletes whatever the actual holder just installed. So it
+    has to be gated on the per-cloud lease check, and that check has to be
+    non-fatal or it reds the one job that must always be able to release.
+    """
+    steps = _release_tenant_steps(jobs)
+    hold = steps[_step_index(jobs, _HOLD_STEP)]
+    uninstall = steps[_step_index(jobs, _UNINSTALL_STEP)]
+
+    assert (
+        hold["continue-on-error"] is True
+    ), "a not-held verdict must not red the job that hands the tenant back"
+    assert "--mode verify" in hold["run"]
+    assert _step_index(jobs, _HOLD_STEP) < _step_index(jobs, _UNINSTALL_STEP)
+    assert f"steps.{hold['id']}.outcome == 'success'" in uninstall["if"], (
+        "the uninstall is not gated on this run holding THIS cloud's lease, so it "
+        "can delete another run's install"
+    )
+
+
+def test_the_uninstall_cannot_red_a_run_whose_tests_passed(jobs: dict) -> None:  # type: ignore[type-arg]
+    """A pin left behind is a slow hazard; a job that goes red over it blocks a
+    merge now. The tolerance lives here rather than in a driver flag so it is
+    visible to whoever reads the step — and so it also covers the failure paths a
+    residue flag would not (an unreachable tenant, a rotated credential)."""
+    steps = _release_tenant_steps(jobs)
+    for name in (_HOLD_STEP, "Resolve e2e tenant for this cloud", _UNINSTALL_STEP):
+        assert (
+            steps[_step_index(jobs, name)]["continue-on-error"] is True
+        ), f"{name!r} can fail, and release-tenant must never fail"
+    # And the tenant still goes back whatever the cleanup did.
+    assert steps[_step_index(jobs, _RELEASE_STEP)]["if"] == "always()"
+
+
+def test_the_uninstall_reads_app_id_from_the_apps_own_atlan_yaml(jobs: dict) -> None:  # type: ignore[type-arg]
+    """One source for the app id, shared with the install.
+
+    Threading it in would give the uninstall a second source that can disagree
+    with the install's — and a disagreement here means uninstalling the wrong app
+    from a live tenant while looking entirely successful.
+    """
+    steps = _release_tenant_steps(jobs)
+    uninstall = steps[_step_index(jobs, _UNINSTALL_STEP)]
+    assert "--app-ids" not in uninstall["run"]
+    assert "e2e_tenant_app.py uninstall" in uninstall["run"]
+    # Which needs the caller's repo checked out, or atlan.yaml is not there to read.
+    assert any(
+        "actions/checkout" in str(step.get("uses", ""))
+        and "path" not in step.get("with", {})
+        for step in steps
+    ), "the caller's repo must be checked out for its atlan.yaml"
+
+
+def test_release_tenant_timeout_stays_above_the_uninstalls_own_wait(jobs: dict) -> None:  # type: ignore[type-arg]
+    """Same rule as prepare-tenant's, and it now has a second job: this timeout
+    feeds the lease TTL guard, because release-tenant is time the lease is HELD.
+    Raising the script's budget forces both up rather than silently making a job
+    timeout — or a TTL break on a live holder — reachable."""
+    waits = app.DEFAULT_UNINSTALL_TIMEOUT_SECONDS // 60
+    required = round(waits / _MAX_WAIT_SHARE)
+    actual = jobs["release-tenant"]["timeout-minutes"]
+    assert actual >= required, (
+        f"release-tenant allows {actual} min but the uninstall can spend {waits} "
+        f"min of it waiting. Raise it to at least {required} — and re-check the "
+        "lease TTL, which is derived from this."
+    )
+
+    uninstall = _release_tenant_steps(jobs)[_step_index(jobs, _UNINSTALL_STEP)]
+    assert "--timeout-seconds" not in uninstall["run"], (
+        "the step now passes --timeout-seconds, so the budget above is no longer "
+        "the script's default — compute the timeout from the passed value instead"
+    )
+
+
+def test_the_cleanup_and_the_install_resolve_the_same_tenant(jobs: dict) -> None:  # type: ignore[type-arg]
+    """A cleanup pointed at a different tenant than the install would leave the
+    pin exactly where it was and delete an app from somewhere else. Pinned by
+    construction: both legs run the same resolver over the same matrix secret and
+    the same `matrix.cloud`."""
+    assert (
+        jobs["release-tenant"]["env"]["E2E_CLOUD"]
+        == jobs["prepare-tenant"]["env"]["E2E_CLOUD"]
+    )
+    assert (
+        jobs["release-tenant"]["env"]["E2E_TENANT_MATRIX_JSON"]
+        == jobs["prepare-tenant"]["env"]["E2E_TENANT_MATRIX_JSON"]
+    )
+    # The two-pass mask-then-write protocol for this step is NOT re-asserted here.
+    # The per-leg tenant resolver's own test module already audits every
+    # invocation in this workflow (`test_every_env_write_call_site_masks_first`),
+    # and it FINDS them by scanning .github for that script's name — so much as
+    # naming it here would register this file as one of its call sites and break
+    # the audit that matters. Deliberately worded to stay outside that net.
 
 
 def test_install_step_does_not_thread_app_id(jobs: dict) -> None:  # type: ignore[type-arg]

--- a/.github/scripts/tests/test_resolve_e2e_tenant.py
+++ b/.github/scripts/tests/test_resolve_e2e_tenant.py
@@ -385,6 +385,10 @@ def test_call_sites_are_the_expected_files() -> None:
         # that tenant the same way a leg does. Audited: it runs the two-pass
         # --mask-only-then-write protocol, which the ordering guard below checks.
         ".github/workflows/e2e-tenant-install.yaml",
+        # FND-709: the version-pin sweep, install's mirror image. It removes an
+        # app from one e2e tenant, so it resolves that tenant the same way — and
+        # is audited the same way, by the ordering guard below.
+        ".github/workflows/e2e-tenant-uninstall.yaml",
         ".github/workflows/tests-reusable.yaml",
     }
 

--- a/.github/workflows/e2e-tenant-uninstall.yaml
+++ b/.github/workflows/e2e-tenant-uninstall.yaml
@@ -1,0 +1,221 @@
+# Manually clear app version pins from the e2e tenants.
+#
+# FND-709. `Prepare tenant` installs the app under test through LM, which writes
+# `releaseChannel: "specific"` plus a `releaseId` into the app's HelmRelease
+# values. Nothing ever removed it, so every connector that ran e2e left a
+# permanent per-connector pin behind: 46 of 106 HelmReleases on one cloud's e2e
+# tenant were on `releaseChannel: specific`, and 30 of those carried
+# `sdr-test-<hash>` tags — the deterministic e2e test-image tag — accumulated one
+# per connector over three days.
+#
+# tests-reusable.yaml's `release-tenant` job now clears its own run's pin before
+# handing the lease back, so the accumulation stops at source. This workflow is
+# the other half: the sweep that clears what is ALREADY there, and the standing
+# escape hatch for a pin that survives the automatic cleanup (an uninstall that
+# could not reach the tenant, a run that was cancelled before `release-tenant`
+# started — GitHub cancels queued jobs rather than running them, so `always()`
+# does not save that case).
+#
+# WHY THIS MATTERS MORE THAN TIDINESS: LM's deployment health check is
+# namespace-scoped (DISTR-901), so ANY unhealthy pod in `<app>-app` fails EVERY
+# install to that tenant. Each stale `sdr-test-*` pin is a candidate
+# ImagePullBackOff the moment its image ages out of the registry cache — a future
+# install-blocker for a repo that had nothing to do with the run that created it.
+# FND-131 spent several runs diagnosing exactly that shape.
+#
+# WHY THIS IS workflow_dispatch AND NOT AUTOMATIC: removing an app from a tenant
+# is a deployment. The manual trigger IS the human authorisation and the `confirm`
+# input makes firing it at the wrong tenant a deliberate act. The automatic path
+# is scoped to the one app a run installed and is in tests-reusable.yaml; this one
+# takes an arbitrary list, so it stays manual.
+#
+# WHAT IT CANNOT DO, by design:
+#
+#   * System apps. LM answers 409 (`is_system_app`) because those are
+#     reconciler-owned and would be reinstalled if removed. The other population
+#     of `specific` pins — system apps on feature-branch builds — is FND-438's
+#     territory and is unreachable from here.
+#   * Non-`default` deployments. LM rejects those 400; customer-infra / SDR
+#     uninstall is not implemented there yet. The e2e install path only ever
+#     targets `default`, so everything this sweep needs to reach is reachable.
+#   * Deleting the namespace. It carries `helm.sh/resource-policy: keep` and
+#     removing it would need cluster-wide RBAC. Not a gap: `helm uninstall` takes
+#     the Deployments and pods with it, and a bare namespace with no unhealthy
+#     pods in it does not fail anybody's install.
+#   * `app_configs` ConfigMaps and install-hook credential Secrets survive — LM
+#     applies them out-of-band with `kubectl apply`, so `helm uninstall` leaves
+#     them. LM's own position is that they are harmless and overwritten on
+#     reinstall; sweeping them is an LM follow-up, not this workflow's job.
+#
+# NO TENANT LEASE, and it is worth being explicit about why. Lease tickets are
+# refs in the repository a run belongs to, and every contender for a connector's
+# tenant runs in the connector's repo — this workflow runs in application-sdk, so
+# it cannot see them. Keying the lease centrally would need a cross-repo PAT with
+# ref-write on every app repo. Same trade-off, and the same residual gap, as the
+# E2E Tenant Install workflow: a sweep can land underneath a live e2e run, whose
+# per-leg version check would then fail LOUDLY rather than pass on the wrong
+# version. Tracked on FND-250.
+#
+# Credentials never leave CI. `resolve_e2e_tenant.py` writes the tenant and its
+# credentials into $GITHUB_ENV behind the two-pass mask protocol, and
+# `e2e_tenant_app.py` reads them from the environment rather than argv (argv is
+# visible in process listings and in `set -x` output). Nothing prints a token.
+name: E2E Tenant Uninstall
+
+on:
+  workflow_dispatch:
+    inputs:
+      clouds:
+        description: >-
+          Which cloud's e2e tenant to sweep. "all" fans out over every cloud as a
+          matrix — the pins accumulated on all three, so that is the normal
+          choice for the FND-709 backfill.
+        required: true
+        type: choice
+        options: [all, aws, azure, gcp]
+        default: all
+      confirm:
+        description: "This REMOVES apps from a live tenant. Select yes to proceed."
+        required: true
+        type: choice
+        options: ["no", "yes"]
+        default: "no"
+      app_ids:
+        description: >-
+          GM app UUIDs to uninstall, comma- or space-separated (the `app_id` field
+          in each app repo's atlan.yaml). An app that is not installed on a given
+          tenant reports "not-installed" and costs one call, so the same list can
+          be fired at every cloud.
+        required: true
+        type: string
+      timeout_seconds:
+        description: >-
+          Budget for each app's uninstall deployment to reconcile before it is
+          reported as residue. A HelmRelease delete plus a wait for the workload
+          to go, so much shorter than an install's.
+        required: false
+        type: string
+        default: "300"
+
+permissions:
+  contents: read
+
+concurrency:
+  # One sweep at a time per cloud, and NOT cancel-in-progress: cancelling
+  # mid-uninstall leaves the tenant in whatever state LM reached, with the
+  # HelmRelease gone and the install record still there. Cloud-keyed rather than
+  # app-keyed because the list is per-run, so there is no single app to key on.
+  #
+  # Deliberately the SAME group shape as e2e-tenant-install.yaml's but a different
+  # name, so an install and a sweep can run concurrently on one cloud. Serialising
+  # them against each other would be better; it is not possible from here for the
+  # same reason the lease is not (see the header), and a sweep that removes the
+  # app an install just placed surfaces as that workflow's own read-back failing,
+  # loudly.
+  group: e2e-tenant-uninstall-${{ inputs.clouds }}
+  cancel-in-progress: false
+
+jobs:
+  uninstall:
+    name: Clear pins on ${{ matrix.cloud }}
+    # A job-level `if:` rather than a shell test, so an unconfirmed dispatch is
+    # visibly skipped instead of green-but-did-nothing.
+    if: inputs.confirm == 'yes'
+    strategy:
+      # One wedged tenant must not stop the other two being cleaned.
+      fail-fast: false
+      matrix:
+        # Expression-layer branching, so the `run:` blocks below stay
+        # straight-line (docs/standards/ci.md). `format` rather than string
+        # concatenation because GHA expressions have no `+` for strings.
+        cloud: ${{ fromJson(inputs.clouds == 'all' && '["aws","azure","gcp"]' || format('["{0}"]', inputs.clouds)) }}
+    runs-on: ubuntu-latest
+    # Comfortably above the script's own budget even for a long list: the sweep is
+    # sequential over app_ids, so the worst case is timeout_seconds per app. Sized
+    # for the FND-709 backfill (~30 apps) reaching its per-app budget only rarely
+    # — the normal case is a few seconds each. A run that does hit this reports the
+    # apps it had already cleared in its step log.
+    timeout-minutes: 120
+    permissions:
+      contents: read
+    env:
+      E2E_TENANT_MATRIX_JSON: ${{ secrets.E2E_TENANT_MATRIX_JSON }}
+      E2E_CLOUD: ${{ matrix.cloud }}
+      FALLBACK_SDR_TEST_TENANT: ${{ secrets.SDR_TEST_TENANT }}
+      FALLBACK_SDR_CLIENT_ID: ${{ secrets.SDR_CLIENT_ID }}
+      FALLBACK_SDR_CLIENT_SECRET: ${{ secrets.SDR_CLIENT_SECRET }}
+      FALLBACK_ATLAN_API_KEY: ${{ secrets.ATLAN_API_KEY }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # Two invocations: the mask pass must reach the log BEFORE the write pass
+      # redirects stdout into $GITHUB_ENV, because registering the matrix blob as
+      # a secret does not redact the values inside it. Same protocol as
+      # tests-reusable.yaml and e2e-tenant-install.yaml — see
+      # .github/scripts/export_extra_env.py for why the two passes are separate.
+      - name: Resolve the target tenant
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/resolve_e2e_tenant.py \
+            --matrix-json "$E2E_TENANT_MATRIX_JSON" \
+            --cloud "$E2E_CLOUD" \
+            --fallback-tenant "$FALLBACK_SDR_TEST_TENANT" \
+            --fallback-client-id "$FALLBACK_SDR_CLIENT_ID" \
+            --fallback-client-secret "$FALLBACK_SDR_CLIENT_SECRET" \
+            --fallback-api-key "$FALLBACK_ATLAN_API_KEY" \
+            --mask-only
+          python3 .github/scripts/resolve_e2e_tenant.py \
+            --matrix-json "$E2E_TENANT_MATRIX_JSON" \
+            --cloud "$E2E_CLOUD" \
+            --fallback-tenant "$FALLBACK_SDR_TEST_TENANT" \
+            --fallback-client-id "$FALLBACK_SDR_CLIENT_ID" \
+            --fallback-client-secret "$FALLBACK_SDR_CLIENT_SECRET" \
+            --fallback-api-key "$FALLBACK_ATLAN_API_KEY" \
+            >> "$GITHUB_ENV"
+
+      # Every dispatch input reaches the shell through env:, never through
+      # `${{ }}` inside run:. A workflow_dispatch input is attacker-influenced
+      # free text, and direct interpolation splices it into the script before bash
+      # sees a quote — so a crafted `app_ids` would execute rather than be parsed.
+      # Via env:, bash receives it as data, and the driver validates every id
+      # against the GM UUID shape before it reaches a request path.
+      #
+      # No env: block re-exporting the credentials: the script reads
+      # SDR_CLIENT_ID / SDR_CLIENT_SECRET straight out of the environment the
+      # resolver wrote, so the secret is not interpolated through a GitHub
+      # expression again just to be renamed.
+      #
+      # Residue exits non-zero here, unlike in the automatic cleanup: a pin that
+      # would not clear IS what this run was fired to fix, so it must be a red run
+      # and not a warning in a log nobody opens.
+      - name: Uninstall the apps
+        id: uninstall
+        env:
+          APP_IDS: ${{ inputs.app_ids }}
+          TIMEOUT_SECONDS: ${{ inputs.timeout_seconds }}
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/e2e_tenant_app.py uninstall \
+            --base-url "$ATLAN_BASE_URL" \
+            --app-ids "$APP_IDS" \
+            --timeout-seconds "$TIMEOUT_SECONDS"
+
+      - name: Summarise
+        if: always()
+        env:
+          CLOUD: ${{ matrix.cloud }}
+          CLEARED: ${{ steps.uninstall.outputs.cleared }}
+          RESIDUAL: ${{ steps.uninstall.outputs.residual }}
+          OUTCOMES: ${{ steps.uninstall.outputs.outcomes }}
+        run: |
+          {
+            echo "### E2E tenant uninstall — ${CLOUD}"
+            echo ""
+            echo "| Field | Value |"
+            echo "|---|---|"
+            echo "| Pin cleared | \`${CLEARED:-none}\` |"
+            echo "| Pin possibly left behind | \`${RESIDUAL:-none}\` |"
+            echo "| Per-app outcome | \`${OUTCOMES:-not attempted}\` |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/tests-reusable.yaml
+++ b/.github/workflows/tests-reusable.yaml
@@ -2237,7 +2237,37 @@ jobs:
           # Dockerfile that declares no such secret mount simply ignores it.
           git-token: ${{ secrets.ORG_PAT_GITHUB }}
 
-  # ── Hand the tenant to whoever is next in the queue ──────────────────────
+  # ── Give the tenant back: clear this run's pin, then release the lease ───
+  # Two things, in that order, and the order is the safety property (FND-709).
+  #
+  # `Prepare tenant` installs via LM, which writes `releaseChannel: "specific"`
+  # plus a `releaseId` into the app's HelmRelease values. Nothing ever removed it,
+  # so every connector that ran e2e left a PERMANENT per-connector version pin on
+  # every tenant it touched — 30 of them on one cloud's tenant, one per connector,
+  # accumulated over three days. That is a hazard rather than clutter: LM's
+  # deployment health check is namespace-scoped (DISTR-901), so one stale
+  # `sdr-test-*` pod whose image has aged out of the registry cache fails EVERY
+  # future install to that tenant, including for repos that had nothing to do with
+  # the run that created it. FND-131 spent several runs diagnosing exactly that
+  # shape before the cause was found.
+  #
+  # The uninstall runs BEFORE the release and while the lease is still held. The
+  # other order looks harmless and is not: handing the tenant over first lets the
+  # next run's install land between LM's HelmRelease delete and its record delete,
+  # and LM's reinstall suppression is explicitly NOT a second backstop —
+  # `trigger_uninstall` and `_trigger_install` share one `is_app_uninstalled`
+  # lookup that fails open, so on a bad read neither blocks the other. The lease
+  # is the only thing that closes that window, which is why this job is now part
+  # of the span the lease TTL has to clear (see test_e2e_tenant_lease's
+  # _LEASE_HELD_ACROSS).
+  #
+  # Deliberate consequence: `Prepare tenant` can no longer short-circuit on
+  # "tenant already runs <version> — nothing to do", so every run pays a full
+  # install, including a re-run of the same commit (the `sdr-test-<hash>` tag is
+  # deterministic, so that no-op used to fire). Accepted, and it cuts both ways —
+  # that short-circuit is precisely why FND-281 found a dirty tenant could never
+  # be detected: a run that installs nothing observes nothing.
+  #
   # Prompt release, not the mechanism that makes the lease safe. GitHub cancels
   # queued jobs rather than running them, so on a cancelled run this job never
   # starts at all and `if: always()` does not help — which is why liveness is
@@ -2245,10 +2275,12 @@ jobs:
   # ticket whose run is over. This job just means the next run waits seconds
   # rather than one poll interval.
   #
-  # It never fails the workflow: the driver returns 0 whether or not a ticket was
-  # there to delete, so a release hiccup cannot redden a run whose tests passed.
+  # It never fails the workflow: the release driver returns 0 whether or not a
+  # ticket was there to delete, every step that CAN fail carries
+  # `continue-on-error`, and no job needs this one — so neither a release hiccup
+  # nor a pin that would not clear can redden a run whose tests passed.
   release-tenant:
-    name: Release tenant lease (${{ matrix.cloud || 'default' }})
+    name: Give the tenant back (${{ matrix.cloud || 'default' }})
     needs: [discover-e2e, lease-tenant, prepare-tenant, e2e]
     # Still a per-cloud MATRIX while the acquire is one ordered job (FND-646), and
     # deliberately so: release cannot block, is ownership-checked, and is
@@ -2272,17 +2304,161 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(needs.discover-e2e.outputs.cloud-count != '0' && needs.discover-e2e.outputs.cloud-matrix || '{"include":[{"cloud":""}]}') }}
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    # Above the uninstall's own reconcile budget with room for the two checkouts,
+    # the lease check, the tenant resolve and the release — asserted against
+    # e2e_tenant_app.DEFAULT_UNINSTALL_TIMEOUT_SECONDS by a test, so raising that
+    # constant fails the guard rather than quietly making a job timeout reachable.
+    # It also feeds the lease TTL guard, because this is now time the lease is
+    # HELD: raising it forces the TTL up rather than eating the TTL's margin.
+    timeout-minutes: 15
     permissions:
       contents: write
       actions: read
+    env:
+      E2E_TENANT_MATRIX_JSON: ${{ secrets.E2E_TENANT_MATRIX_JSON }}
+      E2E_CLOUD: ${{ matrix.cloud }}
+      FALLBACK_SDR_TEST_TENANT: ${{ secrets.SDR_TEST_TENANT }}
+      FALLBACK_SDR_CLIENT_ID: ${{ secrets.SDR_CLIENT_ID }}
+      FALLBACK_SDR_CLIENT_SECRET: ${{ secrets.SDR_CLIENT_SECRET }}
+      FALLBACK_ATLAN_API_KEY: ${{ secrets.ATLAN_API_KEY }}
     steps:
+      # The caller's repo, for its atlan.yaml: the uninstall reads app_id from the
+      # same file the install did, so the two cannot disagree about which app this
+      # run put on the tenant.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # Same sparse fetch and same `job.workflow_sha` pin as prepare-tenant's, for
+      # the same reason: a PR editing these drivers must exercise its own version,
+      # and `uses:` cannot take an expression so an action reference could only
+      # ever be @main.
+      - name: Fetch SDK CI scripts
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: atlanhq/application-sdk
+          ref: ${{ job.workflow_sha }}
+          sparse-checkout: |
+            .github/scripts
+            .github/actions/e2e-tenant-lease
+          sparse-checkout-cone-mode: false
+          path: application-sdk-scripts
+          persist-credentials: false
+
+      # Ownership check, and the whole reason the uninstall below is safe. This
+      # job's `if:` is deliberately wide — it runs for every cloud in the matrix,
+      # including clouds this run never leased (a partial acquire, a lease job that
+      # died) — because a leg that holds nothing must still be able to give back
+      # whatever it does hold. The RELEASE is safe under that widening on its own,
+      # since the release driver re-checks ownership per ref before deleting. An
+      # UNINSTALL is not: run for a cloud this run never held, it would delete
+      # whatever the actual holder had just installed.
+      #
+      # `continue-on-error` plus reading `.outcome` keeps the branch in the
+      # expression layer instead of a shell `if` (docs/standards/ci.md), and keeps
+      # a not-held verdict from reddening a job that must never fail.
+      - name: Confirm this run still holds the tenant lease
+        id: hold
+        continue-on-error: true
+        env:
+          APP: ${{ inputs.app-name }}
+          CLOUD: ${{ matrix.cloud }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          python3 application-sdk-scripts/.github/actions/e2e-tenant-lease/e2e_tenant_lease.py \
+            --mode verify \
+            --repo "$GITHUB_REPOSITORY" \
+            --app "$APP" \
+            --cloud "$CLOUD" \
+            --run-id "$GITHUB_RUN_ID" \
+            --run-attempt "$GITHUB_RUN_ATTEMPT"
+
+      # Two invocations, mask pass first — see prepare-tenant's equivalent step for
+      # why registering the matrix blob as a secret does not redact the values
+      # inside it.
+      # `continue-on-error` for the same reason the uninstall has it, and it is not
+      # redundant with the guard below: an unshared tenant-matrix secret makes the
+      # resolver EXIT non-zero, which would red this job outright — the one job
+      # that must always be able to hand the tenant back. The `ATLAN_BASE_URL`
+      # guard below then skips the uninstall rather than running it with no tenant.
+      - name: Resolve e2e tenant for this cloud
+        id: resolve
+        if: steps.hold.outcome == 'success'
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          python3 application-sdk-scripts/.github/scripts/resolve_e2e_tenant.py \
+            --matrix-json "$E2E_TENANT_MATRIX_JSON" \
+            --cloud "$E2E_CLOUD" \
+            --fallback-tenant "$FALLBACK_SDR_TEST_TENANT" \
+            --fallback-client-id "$FALLBACK_SDR_CLIENT_ID" \
+            --fallback-client-secret "$FALLBACK_SDR_CLIENT_SECRET" \
+            --fallback-api-key "$FALLBACK_ATLAN_API_KEY" \
+            --mask-only
+          python3 application-sdk-scripts/.github/scripts/resolve_e2e_tenant.py \
+            --matrix-json "$E2E_TENANT_MATRIX_JSON" \
+            --cloud "$E2E_CLOUD" \
+            --fallback-tenant "$FALLBACK_SDR_TEST_TENANT" \
+            --fallback-client-id "$FALLBACK_SDR_CLIENT_ID" \
+            --fallback-client-secret "$FALLBACK_SDR_CLIENT_SECRET" \
+            --fallback-api-key "$FALLBACK_ATLAN_API_KEY" \
+            >> "$GITHUB_ENV"
+
+      # `continue-on-error` rather than a flag in the driver. This job exists to
+      # hand the tenant back and must never red a run whose tests passed, but the
+      # residue still has to be VISIBLE — so the script reports it as an
+      # ::error:: annotation and exits non-zero, the step shows as failed-but-
+      # continued, and the job stays green. The next run's cleanup retries for
+      # free; a pin that survives repeatedly is cleared with the E2E Tenant
+      # Uninstall workflow.
+      #
+      # Not gated on prepare-tenant's result, on purpose. A prepare-tenant that
+      # failed AFTER LM accepted the install (a deployment that never reconciled,
+      # say) has already written the pin, which is exactly the case worth cleaning
+      # up — and where nothing was installed the uninstall reads LM's 404 and
+      # reports "not-installed", which costs one call.
+      #
+      # `--app-ids` is deliberately omitted so the driver reads app_id from the
+      # caller's atlan.yaml, the same source the install used.
+      - name: Clear this run's version pin from the tenant
+        id: uninstall
+        if: steps.hold.outcome == 'success' && env.ATLAN_BASE_URL != ''
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          python3 application-sdk-scripts/.github/scripts/e2e_tenant_app.py uninstall \
+            --base-url "$ATLAN_BASE_URL"
+
+      # `always()`: the tenant goes back whatever the uninstall did. A pin left
+      # behind is a slow hazard; a lease left behind blocks the next run now.
       - name: Release the tenant lease
+        if: always()
         uses: atlanhq/application-sdk/.github/actions/e2e-tenant-lease@main
         with:
           mode: release
           app: ${{ inputs.app-name }}
           cloud: ${{ matrix.cloud }}
+
+      - name: Summarise
+        if: always()
+        env:
+          CLOUD: ${{ matrix.cloud || 'default' }}
+          HELD: ${{ steps.hold.outcome }}
+          CLEARED: ${{ steps.uninstall.outputs.cleared }}
+          RESIDUAL: ${{ steps.uninstall.outputs.residual }}
+          OUTCOMES: ${{ steps.uninstall.outputs.outcomes }}
+        run: |
+          {
+            echo "### Tenant given back — ${CLOUD}"
+            echo ""
+            echo "| Field | Value |"
+            echo "|---|---|"
+            echo "| Lease held by this run | \`${HELD}\` |"
+            echo "| Version pin cleared | \`${CLEARED:-none}\` |"
+            echo "| Version pin possibly left behind | \`${RESIDUAL:-none}\` |"
+            echo "| Per-app outcome | \`${OUTCOMES:-not attempted}\` |"
+          } >> "$GITHUB_STEP_SUMMARY"
 
   # ── Callback: report the result back to the application-sdk PR/commit ────
   # that dispatched this run. application-sdk's e2e-apps composite

--- a/docs/standards/connector-ci-e2e.md
+++ b/docs/standards/connector-ci-e2e.md
@@ -450,6 +450,22 @@ workflow it is manual because removing an app from a tenant is a deployment, and
 it holds no lease, for the same reason: lease tickets are refs in the repo a run
 belongs to, and this one runs in application-sdk (FND-250).
 
+**One precondition, and it is per tenant.** Heracles has to *proxy* the uninstall
+route (`uninstallTenantApp` in its `api/marketplace.json`). A tenant predating that
+answers the router's `HTTP 400 "Path was not found"` — byte-identical to what an
+invented path returns — and the driver reports `route-missing`: residue, whose fix
+is the tenant's Heracles version and not anything about the app, the request, or
+the sweep workflow.
+
+Worth stating because it nearly shipped as a silent false green. The router's
+message contains the substring `not found`, and the first implementation reused
+install's deliberately-loose `not_found` match, so an unproxied tenant reported
+*"nothing to remove, cleared"* on every run and left the pin in place forever.
+`not_installed` therefore keys on the enveloped `status_code: 404` and never on the
+message. Install's loose match stays loose on purpose — there a false positive
+costs one retry, not a permanent miss — which is exactly why the two predicates are
+now separate.
+
 Three things neither path can do, and none of them is a gap:
 
 | Not done | Why | Whose problem |

--- a/docs/standards/connector-ci-e2e.md
+++ b/docs/standards/connector-ci-e2e.md
@@ -392,6 +392,77 @@ A timeout is never downgraded this way — an accepted-but-unreconciled deploy i
 nobody else's fault, and it is the silent wrong-version failure this whole
 mechanism exists to remove.
 
+### Giving the tenant back: clearing the version pin (FND-709)
+
+The orphaned pod above is not bad luck; the install path was **manufacturing**
+one per connector per tenant.
+
+`Prepare tenant` installs through LM, which writes `releaseChannel: "specific"`
+plus a `releaseId` into the app's HelmRelease values. Nothing removed it, so the
+pin was permanent and per connector. Measured on one cloud's e2e tenant: 46 of 106
+HelmReleases on `releaseChannel: specific`, **30 of them carrying `sdr-test-*`
+tags** — the deterministic e2e test-image tag — accumulated one per connector over
+three days.
+
+Each one is a future `ImagePullBackOff` the moment its image ages out of the
+registry cache, and by the rule in the section above that fails **every** install
+to that tenant, for repos that had nothing to do with the run that created it.
+That is the shape FND-131 spent several runs diagnosing.
+
+**`release-tenant` now clears its own run's pin before it releases the lease.** It
+runs `e2e_tenant_app.py uninstall`, which POSTs LM's uninstall route — the sibling
+of the install one, over the same plain HTTPS — and LM's
+`AppDeploymentWorkflow(operation=UNINSTALL)` deletes the Flux HelmRelease, waits
+for the workload to be gone, and deletes the `AtlanAppInstalled` record. Deleting
+the HelmRelease is what clears the pin: `releaseChannel`, `releaseId` and
+`image.tag` all live in its values.
+
+Four properties of that job, each load-bearing:
+
+- **Uninstall first, release second.** Handing the tenant over first lets the next
+  run's install land between LM's HelmRelease delete and its record delete, and
+  LM's reinstall suppression is explicitly *not* a second backstop —
+  `trigger_uninstall` and `_trigger_install` share one `is_app_uninstalled` lookup
+  that fails open, so on a bad read neither blocks the other. The lease is the only
+  thing that closes that window, which is why `release-tenant` is now part of the
+  span the lease TTL has to clear.
+- **Gated on this run holding *this cloud's* lease.** `release-tenant`'s `if:` is
+  deliberately wide — it runs for clouds this run never leased, so a leg holding
+  nothing can still hand back what it does hold. The release is safe under that
+  widening on its own (the driver re-checks ownership per ref). An uninstall is
+  not: run for a cloud this run never held, it deletes whatever the actual holder
+  just installed.
+- **It cannot red a run whose tests passed.** Every step that can fail carries
+  `continue-on-error`, and no job needs `release-tenant`. The residue is still
+  visible: the driver reports it as an `::error::` annotation, exits non-zero, and
+  the step shows as failed-but-continued.
+- **The version no-op is gone, on purpose.** `Prepare tenant` can no longer
+  short-circuit on *"tenant already runs `<version>` — nothing to do"*, so every
+  run pays a full install, including a re-run of the same commit (the
+  `sdr-test-<hash>` tag is deterministic, so that no-op used to fire). Accepted,
+  and it cuts both ways: that short-circuit is exactly why FND-281 found a dirty
+  tenant could never be detected — a run that installs nothing observes nothing.
+
+**Clearing what is already there, or a pin the automatic path could not.** The
+`E2E Tenant Uninstall` workflow (`workflow_dispatch`, in application-sdk) takes a
+list of `app_id`s and a cloud — or `all` — and sweeps them. Like the install
+workflow it is manual because removing an app from a tenant is a deployment, and
+it holds no lease, for the same reason: lease tickets are refs in the repo a run
+belongs to, and this one runs in application-sdk (FND-250).
+
+Three things neither path can do, and none of them is a gap:
+
+| Not done | Why | Whose problem |
+|---|---|---|
+| System apps | LM answers 409 (`is_system_app`) — they are reconciler-owned and would be reinstalled | FND-438 |
+| Non-`default` deployments | LM rejects 400; customer-infra / SDR uninstall is unimplemented there. The e2e install path only ever targets `default` | — |
+| Deleting the namespace | It carries `helm.sh/resource-policy: keep`, and removing it needs cluster-wide RBAC. `helm uninstall` takes the Deployments and pods, and a bare namespace with no unhealthy pods fails nobody's install | — |
+
+`app_configs` ConfigMaps and install-hook credential Secrets also survive — LM
+applies them out-of-band with `kubectl apply`, so `helm uninstall` leaves them.
+LM's position is that they are harmless and overwritten on reinstall; sweeping
+them is an LM follow-up.
+
 Each entry may also carry `"deployment_name"` when that tenant's system apps
 (publish / quality / lineage) are not registered under `production`. It reaches
 the harness as `E2E_TENANT_DEPLOYMENT_NAME`, which
@@ -846,6 +917,9 @@ pass/fail already blocks publish while the 85% threshold only annotates.
 - SDR composite action: [`.github/actions/sdr-e2e/action.yaml`](../../.github/actions/sdr-e2e/action.yaml)
 - Full-DAG reusable workflow: [`.github/workflows/e2e-full-reusable.yaml`](../../.github/workflows/e2e-full-reusable.yaml)
 - Cross-repo dispatcher action: [`.github/actions/e2e-apps/action.yaml`](../../.github/actions/e2e-apps/action.yaml)
+- Tenant install / uninstall driver: [`.github/scripts/e2e_tenant_app.py`](../../.github/scripts/e2e_tenant_app.py)
+- Manual install escape hatch: [`.github/workflows/e2e-tenant-install.yaml`](../../.github/workflows/e2e-tenant-install.yaml)
+- Version-pin sweep: [`.github/workflows/e2e-tenant-uninstall.yaml`](../../.github/workflows/e2e-tenant-uninstall.yaml)
 - Test harness: [`application_sdk/testing/full_dag/`](../../application_sdk/testing/full_dag/)
 - Series of merged PRs that built this:
   - [#1669](https://github.com/atlanhq/application-sdk/pull/1669) — SDR composite + pytest base


### PR DESCRIPTION
Closes FND-709.

## The problem

`Prepare tenant` installs the app under test through local-marketplace, which writes `releaseChannel: "specific"` plus a `releaseId` into the app's HelmRelease values. **Nothing ever removed it**, so the pin was permanent and per connector.

Measured on one cloud's e2e tenant: 46 of 106 HelmReleases on `releaseChannel: specific`, **30 of them carrying the deterministic `sdr-test-*` e2e image tag**, accumulated one per connector over three days.

That is a hazard rather than clutter. LM's deployment health check is namespace-scoped (DISTR-901), so a single stale pod whose image has aged out of the registry cache fails *every* future install to that tenant — including for repos that had nothing to do with the run that created it. That is the shape FND-131 spent several runs diagnosing before the cause was found.

## The fix

`e2e_tenant_app.py` grows an `uninstall` subcommand over LM's uninstall route (the sibling of the install one, over the same plain HTTPS the install already uses), and `release-tenant` runs it before it hands the lease back. Deleting the HelmRelease is what clears the pin: `releaseChannel`, `releaseId` and `image.tag` all live in its values.

Four properties, each load-bearing:

* **Uninstall first, release second.** Releasing first lets the next run's install land between LM's HelmRelease delete and its record delete, and LM's reinstall suppression is explicitly not a second backstop — `trigger_uninstall` and `_trigger_install` share one fail-open `is_app_uninstalled` lookup, so on a bad read neither blocks the other. The lease is the only thing that closes that window, so `release-tenant` joins the span the lease TTL must clear (**TTL default 4h → 5h**, derived by the existing `_LEASE_HELD_ACROSS` guard rather than hand-set).
* **Gated on this run holding *this cloud's* lease.** `release-tenant`'s `if:` is deliberately wide — it runs for clouds this run never leased. The release is safe under that because the driver re-checks ownership per ref; an uninstall is not, so it is gated on the per-cloud lease `verify`, made non-fatal with `continue-on-error` + `steps.hold.outcome` so the branch stays in the expression layer (`docs/standards/ci.md`).
* **It cannot red a run whose tests passed.** Every fallible step carries `continue-on-error` and no job needs `release-tenant`. The residue stays visible: the driver reports it as an `::error::` annotation and exits non-zero, so the step shows as failed-but-continued.
* **`Prepare tenant`'s version no-op is now unreachable, on purpose.** Every run pays a full install, including a re-run of the same commit (the `sdr-test-<hash>` tag is deterministic, so that short-circuit used to fire). Accepted, and it cuts both ways: that short-circuit is precisely why FND-281 found a dirty tenant could never be detected — a run that installs nothing observes nothing.

## Clearing what is already there

New `E2E Tenant Uninstall` workflow (`workflow_dispatch`): a comma/space-separated list of app ids, and a cloud choice including `all` which fans out as a matrix. Manual because removing an app from a tenant is a deployment, and the `confirm` input makes firing it at the wrong tenant a deliberate act. Residue **reds** the run there, unlike the automatic cleanup — a pin that would not clear is what that run was fired to fix.

It holds no lease, for the same reason the manual install workflow does not: lease tickets are refs in the repo a run belongs to, and this one runs in `application-sdk` (FND-250). A sweep landing under a live e2e run surfaces as that run's own per-leg version check failing, loudly.

## What neither path can do — none of it a gap

| Not done | Why | Whose problem |
|---|---|---|
| System apps | LM answers 409 (`is_system_app`) — reconciler-owned, would be reinstalled | FND-438 |
| Non-`default` deployments | LM answers 400; customer-infra / SDR uninstall is unimplemented there. The e2e install path only ever targets `default` | — |
| Deleting the namespace | `helm.sh/resource-policy: keep`, and removal needs cluster-wide RBAC. `helm uninstall` already takes the Deployments and pods, which is what the hazard is about | — |

`app_configs` ConfigMaps and install-hook credential Secrets also survive — LM applies them out-of-band with `kubectl apply`. LM's position is that they are harmless and overwritten on reinstall; sweeping them is an LM follow-up.

## Tests

The gap went unnoticed for months precisely because nothing asserted it, so the guards are shaped around *what is left on the tenant afterwards* rather than *did the call return 200*.

* `test_e2e_tenant_uninstall.py` (20) — every reply LM can give: happy path, the benign 404 (the **same** status code install retries for minutes, read oppositely here, and asserted as such), 409 system app, 400 wrong deployment, FAILED and timed-out reconciles, a read-back that still reports a version, one app's transport error not abandoning the other 29, and app-id list parsing / de-dupe / UUID validation.
* `test_e2e_tenant_uninstall_workflow.py` (10) — no dispatch input reaches a `run:` block, confirmation is a job-level gate, and the `clouds` matrix expression is **evaluated** for every option the choice offers (plus a drift check between the option list and the `all` arm).
* Six new guards in `test_prepare_tenant_wiring.py` — the uninstall-before-release ordering, the per-cloud lease gate, the `continue-on-error` contract, the app-id source, and the timeout ↔ TTL derivation.

Full `.github/scripts/tests` suite: **3228 passed**. Pre-commit clean.

## Follow-up

Merging this stops the accumulation. Clearing the 30 pins already on the tenants is one dispatch of `E2E Tenant Uninstall` (`clouds: all`) once this is on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
