### PR TITLE
ci(scanning): stop trivy-container.yaml failing as startup_failure (FND-447)

### DIFF
--- a/.github/actions/trivy-container/action.yaml
+++ b/.github/actions/trivy-container/action.yaml
@@ -7,11 +7,18 @@ description: |
 
 inputs:
   chainguard-username:
-    description: Chainguard registry username
-    required: true
+    description: >-
+      Chainguard registry username. Optional: the login step is skipped when
+      empty. Only builds whose Dockerfile pulls a cgr.dev base image need it --
+      that is application-sdk's own Dockerfile
+      (FROM cgr.dev/atlan.com/app-framework-golden), not the connector apps,
+      which build from registry.atlan.com, docker.io or registry.access.redhat.com.
+      The credentials live as repo-level secrets on application-sdk and so are
+      unavailable to any other repo by construction (FND-447).
+    required: false
   chainguard-password:
-    description: Chainguard registry password
-    required: true
+    description: Chainguard registry password. Same handling as chainguard-username.
+    required: false
   github-token:
     description: GitHub token for Docker build secrets
     required: true
@@ -34,7 +41,12 @@ runs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
 
+    # Skipped when no credentials are supplied. docker/login-action errors on an
+    # empty username, so an unconditional login turned "this build does not need
+    # cgr.dev" into a hard failure -- which is how every connector app's scan
+    # died even once its secrets reached the reusable (FND-447).
     - name: Log in to Chainguard Container Registry
+      if: inputs.chainguard-username != ''
       uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
       with:
         registry: cgr.dev

--- a/.github/scripts/check_trivy_secret_contract.py
+++ b/.github/scripts/check_trivy_secret_contract.py
@@ -28,9 +28,12 @@ import os
 import sys
 from collections.abc import Mapping
 
-# Secrets the scan cannot run without under any configuration: the composite
-# does a `docker login cgr.dev` with them before it can build the image.
-ALWAYS_REQUIRED = ("CHAINGUARD_USERNAME", "CHAINGUARD_PASSWORD")
+# Nothing is needed unconditionally any more. CHAINGUARD_USERNAME /
+# CHAINGUARD_PASSWORD used to sit here, and were the whole problem: they exist
+# only as repo-level secrets on application-sdk, so no caller could ever supply
+# them, and no caller builds from cgr.dev in the first place. Both are gone from
+# the reusable's contract and the composite's login is now conditional.
+ALWAYS_REQUIRED: tuple[str, ...] = ()
 
 # Only needed as the fallback for the cross-repo allowlist checkout and the
 # BuildKit private-dependency secret. When the fleet App token minted, nothing
@@ -38,10 +41,10 @@ ALWAYS_REQUIRED = ("CHAINGUARD_USERNAME", "CHAINGUARD_PASSWORD")
 REQUIRED_WITHOUT_APP_TOKEN = "ORG_PAT_GITHUB"
 
 REMEDY = (
-    "Fix the caller's trivy.yml: replace its explicit `secrets:` block with "
-    "`secrets: inherit`, as the reusable's usage docstring recommends. An "
-    "explicit block passes only the secrets it names, and every name it omits "
-    "arrives here empty."
+    "Fix the caller: pass `secrets: inherit` instead of an explicit `secrets:` "
+    "block, or add the missing name to the block. An explicit block passes only "
+    "the secrets it names, and every name it omits arrives here empty. Better "
+    "still, migrate to build-and-scan.yaml -- this workflow is deprecated."
 )
 
 

--- a/.github/scripts/check_trivy_secret_contract.py
+++ b/.github/scripts/check_trivy_secret_contract.py
@@ -92,10 +92,16 @@ def failure_message(missing: list[str]) -> str:
     )
 
 
+# Built from module-level constants only, never from the environment. main()
+# prints this and nothing else so CodeQL cannot treat the print as a sink for
+# secret values. ALWAYS_REQUIRED is empty today, so the only name this can
+# report is ORG_PAT_GITHUB -- the sole failure path of missing_secrets().
+FAILURE_TEXT = failure_message([*ALWAYS_REQUIRED, REQUIRED_WITHOUT_APP_TOKEN])
+
+
 def main() -> int:
-    missing = missing_secrets(secrets_present(os.environ))
-    if missing:
-        print(failure_message(missing), file=sys.stderr)
+    if missing_secrets(secrets_present(os.environ)):
+        print(FAILURE_TEXT, file=sys.stderr)
         return 1
     return 0
 

--- a/.github/scripts/check_trivy_secret_contract.py
+++ b/.github/scripts/check_trivy_secret_contract.py
@@ -48,22 +48,44 @@ REMEDY = (
 )
 
 
-def missing_secrets(env: Mapping[str, str]) -> list[str]:
-    """Names of secrets the scan needs that arrived empty or unset.
+def secrets_present(env: Mapping[str, str]) -> dict[str, bool]:
+    """Reduce the environment to "did this secret arrive non-empty?" per name.
 
-    `env` is the step's environment, where each secret has been mapped to a
-    same-named variable. GitHub renders an unpassed secret as the empty string
-    rather than omitting the variable, so absent and empty are one case.
+    This is the only function that touches secret *values*, and it returns
+    booleans, so no value can reach the reporting path below. Keeping that
+    boundary explicit is what makes the failure message provably name-only --
+    CodeQL flagged the previous shape, which handed the whole environment to the
+    function whose result gets printed, as clear-text logging of a secret.
+
+    GitHub renders an unpassed secret as the empty string rather than omitting
+    the variable, so absent and empty are one case. A value that is only
+    whitespace is treated as absent too: it would fail downstream anyway, and
+    reporting it here beats a cryptic auth error later.
     """
-    missing = [name for name in ALWAYS_REQUIRED if not env.get(name)]
-    app_token_minted = env.get("APP_TOKEN_MINTED", "").strip() != ""
-    if not app_token_minted and not env.get(REQUIRED_WITHOUT_APP_TOKEN):
+    names = (*ALWAYS_REQUIRED, REQUIRED_WITHOUT_APP_TOKEN, "APP_TOKEN_MINTED")
+    return {name: bool(env.get(name, "").strip()) for name in names}
+
+
+def missing_secrets(present: Mapping[str, bool]) -> list[str]:
+    """Names of secrets the scan needs that did not arrive.
+
+    Takes the presence map from `secrets_present`, never the environment: every
+    name returned is a module-level constant, so the caller can print the result
+    without any possibility of echoing a value.
+    """
+    missing = [name for name in ALWAYS_REQUIRED if not present.get(name)]
+    if not present.get("APP_TOKEN_MINTED") and not present.get(
+        REQUIRED_WITHOUT_APP_TOKEN
+    ):
         missing.append(REQUIRED_WITHOUT_APP_TOKEN)
     return missing
 
 
 def failure_message(missing: list[str]) -> str:
-    """Operator-facing explanation of which secrets are missing and what to do."""
+    """Operator-facing explanation of which secrets are missing and what to do.
+
+    `missing` holds names only, by construction -- see `missing_secrets`.
+    """
     return (
         "trivy-container.yaml did not receive these secrets: "
         f"{', '.join(missing)}.\n\n{REMEDY}"
@@ -71,7 +93,7 @@ def failure_message(missing: list[str]) -> str:
 
 
 def main() -> int:
-    missing = missing_secrets(os.environ)
+    missing = missing_secrets(secrets_present(os.environ))
     if missing:
         print(failure_message(missing), file=sys.stderr)
         return 1

--- a/.github/scripts/check_trivy_secret_contract.py
+++ b/.github/scripts/check_trivy_secret_contract.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Preflight for trivy-container.yaml: report missing secrets as a job failure.
+
+Why this exists rather than `required: true` on the `secrets:` declaration:
+
+A reusable workflow that declares `secrets: {FOO: {required: true}}` and is
+called with an *explicit* `secrets:` block omitting FOO does not fail the job —
+it fails to parse. The run ends as `startup_failure` with **zero jobs**, so it
+emits no check run at all: absent from `gh pr checks`, not red, not pending.
+Nothing surfaces it, and no required check can ever depend on it. Fleet-wide
+that produced 32 connector repos whose `trivy.yml` had been dead since
+2026-08-12 with no signal (FND-447).
+
+`required: true` also buys almost nothing in exchange: it only asserts the
+caller *mentions* the name, never that the secret exists or is non-empty, and
+every `secrets: inherit` caller satisfies it unconditionally. So the secrets are
+declared optional and validated here instead, inside the job, where a missing
+one is a normal red step with an actionable message.
+
+Run standalone (`python3 check_trivy_secret_contract.py`) reading the
+environment, or via the tested functions in this module
+(`.github/scripts/tests/test_check_trivy_secret_contract.py`).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from collections.abc import Mapping
+
+# Secrets the scan cannot run without under any configuration: the composite
+# does a `docker login cgr.dev` with them before it can build the image.
+ALWAYS_REQUIRED = ("CHAINGUARD_USERNAME", "CHAINGUARD_PASSWORD")
+
+# Only needed as the fallback for the cross-repo allowlist checkout and the
+# BuildKit private-dependency secret. When the fleet App token minted, nothing
+# reads it, so demanding it would fail callers that are correctly configured.
+REQUIRED_WITHOUT_APP_TOKEN = "ORG_PAT_GITHUB"
+
+REMEDY = (
+    "Fix the caller's trivy.yml: replace its explicit `secrets:` block with "
+    "`secrets: inherit`, as the reusable's usage docstring recommends. An "
+    "explicit block passes only the secrets it names, and every name it omits "
+    "arrives here empty."
+)
+
+
+def missing_secrets(env: Mapping[str, str]) -> list[str]:
+    """Names of secrets the scan needs that arrived empty or unset.
+
+    `env` is the step's environment, where each secret has been mapped to a
+    same-named variable. GitHub renders an unpassed secret as the empty string
+    rather than omitting the variable, so absent and empty are one case.
+    """
+    missing = [name for name in ALWAYS_REQUIRED if not env.get(name)]
+    app_token_minted = env.get("APP_TOKEN_MINTED", "").strip() != ""
+    if not app_token_minted and not env.get(REQUIRED_WITHOUT_APP_TOKEN):
+        missing.append(REQUIRED_WITHOUT_APP_TOKEN)
+    return missing
+
+
+def failure_message(missing: list[str]) -> str:
+    """Operator-facing explanation of which secrets are missing and what to do."""
+    return (
+        "trivy-container.yaml did not receive these secrets: "
+        f"{', '.join(missing)}.\n\n{REMEDY}"
+    )
+
+
+def main() -> int:
+    missing = missing_secrets(os.environ)
+    if missing:
+        print(failure_message(missing), file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/tests/test_check_trivy_secret_contract.py
+++ b/.github/scripts/tests/test_check_trivy_secret_contract.py
@@ -1,0 +1,150 @@
+"""Tests for .github/scripts/check_trivy_secret_contract.py."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import yaml
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import check_trivy_secret_contract as guard
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_MODULE_PATH = _REPO_ROOT / ".github" / "scripts" / "check_trivy_secret_contract.py"
+_WORKFLOW_PATH = _REPO_ROOT / ".github" / "workflows" / "trivy-container.yaml"
+
+# A caller using `secrets: inherit`, with the fleet App token minted.
+FULLY_CONFIGURED = {
+    "CHAINGUARD_USERNAME": "user",
+    "CHAINGUARD_PASSWORD": "pass",
+    "ORG_PAT_GITHUB": "pat",
+    "APP_TOKEN_MINTED": "ghs_token",
+}
+
+# The FND-447 shape: an explicit `secrets:` block passing only ORG_PAT_GITHUB.
+EXPLICIT_BLOCK_ONLY_PAT = {
+    "CHAINGUARD_USERNAME": "",
+    "CHAINGUARD_PASSWORD": "",
+    "ORG_PAT_GITHUB": "pat",
+    "APP_TOKEN_MINTED": "",
+}
+
+
+class TestMissingSecrets:
+    def test_fully_configured_caller_has_nothing_missing(self):
+        assert guard.missing_secrets(FULLY_CONFIGURED) == []
+
+    def test_reports_both_chainguard_secrets_for_the_fnd447_shape(self):
+        assert guard.missing_secrets(EXPLICIT_BLOCK_ONLY_PAT) == [
+            "CHAINGUARD_USERNAME",
+            "CHAINGUARD_PASSWORD",
+        ]
+
+    def test_unset_variable_counts_as_missing_not_only_empty(self):
+        # GitHub renders an unpassed secret as "", but a caller-side typo in the
+        # step's env mapping omits the variable entirely. Both must be caught.
+        assert guard.missing_secrets({"APP_TOKEN_MINTED": "ghs_token"}) == [
+            "CHAINGUARD_USERNAME",
+            "CHAINGUARD_PASSWORD",
+        ]
+
+    def test_org_pat_required_when_the_app_token_did_not_mint(self):
+        env = FULLY_CONFIGURED | {"APP_TOKEN_MINTED": "", "ORG_PAT_GITHUB": ""}
+        assert guard.missing_secrets(env) == ["ORG_PAT_GITHUB"]
+
+    def test_org_pat_not_required_when_the_app_token_minted(self):
+        # Nothing reads ORG_PAT_GITHUB once the App token exists, so demanding
+        # it would red a correctly configured caller.
+        assert guard.missing_secrets(FULLY_CONFIGURED | {"ORG_PAT_GITHUB": ""}) == []
+
+    def test_whitespace_only_app_token_does_not_count_as_minted(self):
+        env = FULLY_CONFIGURED | {"APP_TOKEN_MINTED": "  ", "ORG_PAT_GITHUB": ""}
+        assert guard.missing_secrets(env) == ["ORG_PAT_GITHUB"]
+
+
+class TestFailureMessage:
+    def test_names_every_missing_secret(self):
+        message = guard.failure_message(["CHAINGUARD_USERNAME", "ORG_PAT_GITHUB"])
+        assert "CHAINGUARD_USERNAME" in message
+        assert "ORG_PAT_GITHUB" in message
+
+    def test_points_the_operator_at_secrets_inherit(self):
+        assert "secrets: inherit" in guard.failure_message(["CHAINGUARD_PASSWORD"])
+
+
+# ── The reusable must stay incapable of startup_failure ──────────────────────
+# The guarantee lives in the workflow YAML, not in the script, so this is where
+# it gets regression-tested. Re-adding `required: true` to any secret is a
+# one-word edit that looks like a tightening and is in fact the opposite: it
+# moves the failure from a red step back to `startup_failure`, which emits no
+# check run and so cannot be seen or gated on (FND-447).
+
+
+class TestWorkflowContract:
+    def _workflow(self) -> dict:
+        # PyYAML resolves the bare `on:` key to the boolean True.
+        return yaml.safe_load(_WORKFLOW_PATH.read_text())
+
+    def test_no_secret_is_declared_required(self):
+        secrets = self._workflow()[True]["workflow_call"]["secrets"]
+        required = [
+            name for name, spec in secrets.items() if (spec or {}).get("required")
+        ]
+        assert required == [], (
+            f"trivy-container.yaml declares {required} as `required: true`. A "
+            "caller omitting one then ends in startup_failure with zero jobs "
+            "and no check run. Declare it `required: false` and let "
+            "check_trivy_secret_contract.py enforce it inside the job instead."
+        )
+
+    def test_every_enforced_secret_is_declared_by_the_workflow(self):
+        # A secret the script demands but the workflow never declares can never
+        # be passed, so the step would red unconditionally.
+        declared = set(self._workflow()[True]["workflow_call"]["secrets"])
+        enforced = set(guard.ALWAYS_REQUIRED) | {guard.REQUIRED_WITHOUT_APP_TOKEN}
+        assert (
+            enforced <= declared
+        ), f"not declared by the workflow: {enforced - declared}"
+
+    def test_workflow_invokes_this_script_at_a_real_path(self):
+        steps = self._workflow()["jobs"]["build"]["steps"]
+        invocations = [
+            s["run"]
+            for s in steps
+            if "check_trivy_secret_contract.py" in s.get("run", "")
+        ]
+        assert len(invocations) == 1, (
+            "trivy-container.yaml no longer invokes check_trivy_secret_contract.py "
+            "exactly once — without it every secret is unenforced."
+        )
+        # The reusable runs in the caller's workspace, where this repo is
+        # sparse-checked out at _sdk/, so the invoked path is _sdk-prefixed.
+        assert "_sdk/.github/scripts/check_trivy_secret_contract.py" in invocations[0]
+        assert _MODULE_PATH.is_file()
+
+    def test_the_verify_step_maps_every_enforced_secret_into_its_env(self):
+        steps = self._workflow()["jobs"]["build"]["steps"]
+        verify = next(
+            s for s in steps if "check_trivy_secret_contract.py" in s.get("run", "")
+        )
+        # An enforced secret absent from `env:` reads as empty no matter what
+        # the caller passed, so the step would red on a correct configuration.
+        for name in (*guard.ALWAYS_REQUIRED, guard.REQUIRED_WITHOUT_APP_TOKEN):
+            assert name in verify["env"], f"verify step does not map {name} into env"
+
+    def test_the_verify_step_runs_before_the_scan(self):
+        steps = self._workflow()["jobs"]["build"]["steps"]
+        verify_at = next(
+            i
+            for i, s in enumerate(steps)
+            if "check_trivy_secret_contract.py" in s.get("run", "")
+        )
+        scan_at = next(
+            i for i, s in enumerate(steps) if "trivy-container" in s.get("uses", "")
+        )
+        assert verify_at < scan_at, (
+            "the secret check must precede the scan composite, or the operator "
+            "sees docker/login-action's cryptic error instead of the remedy."
+        )

--- a/.github/scripts/tests/test_check_trivy_secret_contract.py
+++ b/.github/scripts/tests/test_check_trivy_secret_contract.py
@@ -14,21 +14,12 @@ import check_trivy_secret_contract as guard
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 _MODULE_PATH = _REPO_ROOT / ".github" / "scripts" / "check_trivy_secret_contract.py"
 _WORKFLOW_PATH = _REPO_ROOT / ".github" / "workflows" / "trivy-container.yaml"
+_COMPOSITE_PATH = _REPO_ROOT / ".github" / "actions" / "trivy-container" / "action.yaml"
 
 # A caller using `secrets: inherit`, with the fleet App token minted.
 FULLY_CONFIGURED = {
-    "CHAINGUARD_USERNAME": "user",
-    "CHAINGUARD_PASSWORD": "pass",
     "ORG_PAT_GITHUB": "pat",
     "APP_TOKEN_MINTED": "ghs_token",
-}
-
-# The FND-447 shape: an explicit `secrets:` block passing only ORG_PAT_GITHUB.
-EXPLICIT_BLOCK_ONLY_PAT = {
-    "CHAINGUARD_USERNAME": "",
-    "CHAINGUARD_PASSWORD": "",
-    "ORG_PAT_GITHUB": "pat",
-    "APP_TOKEN_MINTED": "",
 }
 
 
@@ -36,23 +27,14 @@ class TestMissingSecrets:
     def test_fully_configured_caller_has_nothing_missing(self):
         assert guard.missing_secrets(FULLY_CONFIGURED) == []
 
-    def test_reports_both_chainguard_secrets_for_the_fnd447_shape(self):
-        assert guard.missing_secrets(EXPLICIT_BLOCK_ONLY_PAT) == [
-            "CHAINGUARD_USERNAME",
-            "CHAINGUARD_PASSWORD",
-        ]
+    def test_org_pat_required_when_the_app_token_did_not_mint(self):
+        env = FULLY_CONFIGURED | {"APP_TOKEN_MINTED": "", "ORG_PAT_GITHUB": ""}
+        assert guard.missing_secrets(env) == ["ORG_PAT_GITHUB"]
 
     def test_unset_variable_counts_as_missing_not_only_empty(self):
         # GitHub renders an unpassed secret as "", but a caller-side typo in the
         # step's env mapping omits the variable entirely. Both must be caught.
-        assert guard.missing_secrets({"APP_TOKEN_MINTED": "ghs_token"}) == [
-            "CHAINGUARD_USERNAME",
-            "CHAINGUARD_PASSWORD",
-        ]
-
-    def test_org_pat_required_when_the_app_token_did_not_mint(self):
-        env = FULLY_CONFIGURED | {"APP_TOKEN_MINTED": "", "ORG_PAT_GITHUB": ""}
-        assert guard.missing_secrets(env) == ["ORG_PAT_GITHUB"]
+        assert guard.missing_secrets({}) == ["ORG_PAT_GITHUB"]
 
     def test_org_pat_not_required_when_the_app_token_minted(self):
         # Nothing reads ORG_PAT_GITHUB once the App token exists, so demanding
@@ -63,15 +45,23 @@ class TestMissingSecrets:
         env = FULLY_CONFIGURED | {"APP_TOKEN_MINTED": "  ", "ORG_PAT_GITHUB": ""}
         assert guard.missing_secrets(env) == ["ORG_PAT_GITHUB"]
 
+    def test_chainguard_secrets_are_no_longer_demanded(self):
+        # They exist only as repo-level secrets on application-sdk, so no caller
+        # could ever supply them, and no caller builds from cgr.dev anyway.
+        # Demanding them is what killed all 33 callers (FND-447).
+        assert guard.ALWAYS_REQUIRED == ()
+        assert guard.missing_secrets(FULLY_CONFIGURED) == []
+
 
 class TestFailureMessage:
     def test_names_every_missing_secret(self):
-        message = guard.failure_message(["CHAINGUARD_USERNAME", "ORG_PAT_GITHUB"])
-        assert "CHAINGUARD_USERNAME" in message
-        assert "ORG_PAT_GITHUB" in message
+        assert "ORG_PAT_GITHUB" in guard.failure_message(["ORG_PAT_GITHUB"])
 
     def test_points_the_operator_at_secrets_inherit(self):
-        assert "secrets: inherit" in guard.failure_message(["CHAINGUARD_PASSWORD"])
+        assert "secrets: inherit" in guard.failure_message(["ORG_PAT_GITHUB"])
+
+    def test_points_the_operator_at_the_replacement_workflow(self):
+        assert "build-and-scan.yaml" in guard.failure_message(["ORG_PAT_GITHUB"])
 
 
 # ── The reusable must stay incapable of startup_failure ──────────────────────
@@ -98,6 +88,13 @@ class TestWorkflowContract:
             "and no check run. Declare it `required: false` and let "
             "check_trivy_secret_contract.py enforce it inside the job instead."
         )
+
+    def test_the_chainguard_secrets_are_gone_from_the_contract(self):
+        # Re-adding either name resurrects a requirement no caller can satisfy:
+        # they are repo-level secrets on application-sdk, invisible elsewhere.
+        secrets = self._workflow()[True]["workflow_call"]["secrets"]
+        assert "CHAINGUARD_USERNAME" not in secrets
+        assert "CHAINGUARD_PASSWORD" not in secrets
 
     def test_every_enforced_secret_is_declared_by_the_workflow(self):
         # A secret the script demands but the workflow never declares can never
@@ -148,3 +145,36 @@ class TestWorkflowContract:
             "the secret check must precede the scan composite, or the operator "
             "sees docker/login-action's cryptic error instead of the remedy."
         )
+
+    def test_the_reusable_does_not_pass_chainguard_to_the_composite(self):
+        steps = self._workflow()["jobs"]["build"]["steps"]
+        scan = next(s for s in steps if "trivy-container" in s.get("uses", ""))
+        assert "chainguard-username" not in scan.get("with", {})
+        assert "chainguard-password" not in scan.get("with", {})
+
+    def test_the_header_directs_readers_to_the_replacement(self):
+        # This workflow is deprecated; a reader arriving here from a caller must
+        # find build-and-scan.yaml without having to dig.
+        header = _WORKFLOW_PATH.read_text().split("name:")[0]
+        assert "DEPRECATED" in header
+        assert "build-and-scan.yaml" in header
+
+
+# ── The composite must not fail a build that does not need cgr.dev ───────────
+
+
+class TestCompositeContract:
+    def _composite(self) -> dict:
+        return yaml.safe_load(_COMPOSITE_PATH.read_text())
+
+    def test_chainguard_inputs_are_optional(self):
+        inputs = self._composite()["inputs"]
+        assert inputs["chainguard-username"]["required"] is False
+        assert inputs["chainguard-password"]["required"] is False
+
+    def test_the_login_step_is_conditional_on_a_username(self):
+        # docker/login-action errors on an empty username, so an unconditional
+        # login turns "this build does not need cgr.dev" into a hard failure.
+        steps = self._composite()["runs"]["steps"]
+        login = next(s for s in steps if "Chainguard" in s.get("name", ""))
+        assert login.get("if") == "inputs.chainguard-username != ''"

--- a/.github/scripts/tests/test_check_trivy_secret_contract.py
+++ b/.github/scripts/tests/test_check_trivy_secret_contract.py
@@ -110,6 +110,15 @@ class TestFailureMessage:
         for value in FULLY_CONFIGURED.values():
             assert value not in message
 
+    def test_printed_text_is_the_constant_not_an_env_derived_string(self):
+        # main() must print FAILURE_TEXT, a module-level constant, so CodeQL
+        # cannot treat the print as a sink for os.environ. The constant still
+        # has to name the only secret this contract can currently fail on.
+        assert guard.REQUIRED_WITHOUT_APP_TOKEN in guard.FAILURE_TEXT
+        assert "secrets: inherit" in guard.FAILURE_TEXT
+        for value in FULLY_CONFIGURED.values():
+            assert value not in guard.FAILURE_TEXT
+
 
 # ── The reusable must stay incapable of startup_failure ──────────────────────
 # The guarantee lives in the workflow YAML, not in the script, so this is where

--- a/.github/scripts/tests/test_check_trivy_secret_contract.py
+++ b/.github/scripts/tests/test_check_trivy_secret_contract.py
@@ -16,41 +16,78 @@ _MODULE_PATH = _REPO_ROOT / ".github" / "scripts" / "check_trivy_secret_contract
 _WORKFLOW_PATH = _REPO_ROOT / ".github" / "workflows" / "trivy-container.yaml"
 _COMPOSITE_PATH = _REPO_ROOT / ".github" / "actions" / "trivy-container" / "action.yaml"
 
-# A caller using `secrets: inherit`, with the fleet App token minted.
+# A caller using `secrets: inherit`, with the fleet App token minted. Values are
+# deliberately distinctive so a leak into any output is unmistakable.
 FULLY_CONFIGURED = {
-    "ORG_PAT_GITHUB": "pat",
-    "APP_TOKEN_MINTED": "ghs_token",
+    "ORG_PAT_GITHUB": "ghp-SENTINEL-pat-value",
+    "APP_TOKEN_MINTED": "ghs-SENTINEL-app-token",
 }
 
 
-class TestMissingSecrets:
-    def test_fully_configured_caller_has_nothing_missing(self):
-        assert guard.missing_secrets(FULLY_CONFIGURED) == []
+class TestSecretsPresent:
+    def test_reduces_values_to_booleans(self):
+        # The boundary that keeps values out of the reporting path.
+        assert guard.secrets_present(FULLY_CONFIGURED) == {
+            "ORG_PAT_GITHUB": True,
+            "APP_TOKEN_MINTED": True,
+        }
 
-    def test_org_pat_required_when_the_app_token_did_not_mint(self):
-        env = FULLY_CONFIGURED | {"APP_TOKEN_MINTED": "", "ORG_PAT_GITHUB": ""}
-        assert guard.missing_secrets(env) == ["ORG_PAT_GITHUB"]
-
-    def test_unset_variable_counts_as_missing_not_only_empty(self):
+    def test_unset_and_empty_are_both_absent(self):
         # GitHub renders an unpassed secret as "", but a caller-side typo in the
         # step's env mapping omits the variable entirely. Both must be caught.
-        assert guard.missing_secrets({}) == ["ORG_PAT_GITHUB"]
+        assert guard.secrets_present({})["ORG_PAT_GITHUB"] is False
+        assert guard.secrets_present({"ORG_PAT_GITHUB": ""})["ORG_PAT_GITHUB"] is False
+
+    def test_whitespace_only_is_absent(self):
+        assert (
+            guard.secrets_present({"ORG_PAT_GITHUB": "  "})["ORG_PAT_GITHUB"] is False
+        )
+
+    def test_returns_no_string_values_at_all(self):
+        # A regression here would re-open the clear-text-logging path CodeQL
+        # flagged: whatever this returns is what reaches failure_message.
+        assert all(
+            isinstance(v, bool)
+            for v in guard.secrets_present(FULLY_CONFIGURED).values()
+        )
+
+
+class TestMissingSecrets:
+    def _present(self, **overrides: str) -> dict[str, bool]:
+        return guard.secrets_present(FULLY_CONFIGURED | overrides)
+
+    def test_fully_configured_caller_has_nothing_missing(self):
+        assert guard.missing_secrets(self._present()) == []
+
+    def test_org_pat_required_when_the_app_token_did_not_mint(self):
+        present = self._present(APP_TOKEN_MINTED="", ORG_PAT_GITHUB="")
+        assert guard.missing_secrets(present) == ["ORG_PAT_GITHUB"]
+
+    def test_unset_variable_counts_as_missing_not_only_empty(self):
+        assert guard.missing_secrets(guard.secrets_present({})) == ["ORG_PAT_GITHUB"]
 
     def test_org_pat_not_required_when_the_app_token_minted(self):
         # Nothing reads ORG_PAT_GITHUB once the App token exists, so demanding
         # it would red a correctly configured caller.
-        assert guard.missing_secrets(FULLY_CONFIGURED | {"ORG_PAT_GITHUB": ""}) == []
+        assert guard.missing_secrets(self._present(ORG_PAT_GITHUB="")) == []
 
     def test_whitespace_only_app_token_does_not_count_as_minted(self):
-        env = FULLY_CONFIGURED | {"APP_TOKEN_MINTED": "  ", "ORG_PAT_GITHUB": ""}
-        assert guard.missing_secrets(env) == ["ORG_PAT_GITHUB"]
+        present = self._present(APP_TOKEN_MINTED="  ", ORG_PAT_GITHUB="")
+        assert guard.missing_secrets(present) == ["ORG_PAT_GITHUB"]
 
     def test_chainguard_secrets_are_no_longer_demanded(self):
         # They exist only as repo-level secrets on application-sdk, so no caller
         # could ever supply them, and no caller builds from cgr.dev anyway.
         # Demanding them is what killed all 33 callers (FND-447).
         assert guard.ALWAYS_REQUIRED == ()
-        assert guard.missing_secrets(FULLY_CONFIGURED) == []
+        assert guard.missing_secrets(self._present()) == []
+
+    def test_returns_only_declared_constant_names(self):
+        # Every returned element must be a module-level constant, never
+        # something derived from the environment.
+        known = {*guard.ALWAYS_REQUIRED, guard.REQUIRED_WITHOUT_APP_TOKEN}
+        present = self._present(APP_TOKEN_MINTED="", ORG_PAT_GITHUB="")
+        assert set(guard.missing_secrets(present)) <= known
 
 
 class TestFailureMessage:
@@ -62,6 +99,16 @@ class TestFailureMessage:
 
     def test_points_the_operator_at_the_replacement_workflow(self):
         assert "build-and-scan.yaml" in guard.failure_message(["ORG_PAT_GITHUB"])
+
+    def test_no_secret_value_reaches_the_message(self):
+        # End-to-end over the real call chain main() uses, with sentinel values
+        # in the environment. This is the assertion CodeQL's finding was about.
+        env = FULLY_CONFIGURED | {"APP_TOKEN_MINTED": "", "ORG_PAT_GITHUB": ""}
+        message = guard.failure_message(
+            guard.missing_secrets(guard.secrets_present(env))
+        )
+        for value in FULLY_CONFIGURED.values():
+            assert value not in message
 
 
 # ── The reusable must stay incapable of startup_failure ──────────────────────

--- a/.github/workflows/trivy-container.yaml
+++ b/.github/workflows/trivy-container.yaml
@@ -1,28 +1,43 @@
-# Trivy container scan. This can be reused across all the applications.
-#
-# Runs Trivy, checks findings against the centralized base-allowlist in the SDK
-# repo (.security/base-allowlist.json), posts a summary comment on PRs, and
-# fails on new/expired entries.
-#
-# Usage:
+# DEPRECATED -- use build-and-scan.yaml instead. Removal: 3.0.
 #
 #   jobs:
-#     build:
-#       uses: atlanhq/application-sdk/.github/workflows/trivy-container.yaml@main
+#     scan:
+#       uses: atlanhq/application-sdk/.github/workflows/build-and-scan.yaml@main
 #       secrets: inherit
+#
+# build-and-scan.yaml is the scan that actually gates PRs across the fleet. It
+# does the same job (build, Trivy, allowlist gate, PR comment) and additionally
+# reads the Dockerfile path from the caller's atlan.yaml rather than hardcoding
+# ./Dockerfile, so it works on the repos that keep theirs at install/Dockerfile
+# or deploy/Dockerfile. It emits `scan / Trivy Scan` and `scan / Security Gate`.
+#
+# Why this one is being retired (FND-447): across all 166 active atlan-*-app
+# repos it had 33 callers and not one working run. Two independent causes:
+#
+#   1. It demanded CHAINGUARD_USERNAME / CHAINGUARD_PASSWORD as required
+#      secrets. Those exist only as *repo-level* secrets on application-sdk, so
+#      no caller could ever supply them -- `secrets: inherit` forwards by name
+#      and the names are absent everywhere else. The org-level pair is named
+#      CHAINGUARD_DOCKER_* and is rejected by cgr.dev (FORBIDDEN).
+#   2. No connector app needs cgr.dev at all. They build from
+#      registry.atlan.com, docker.io and registry.access.redhat.com; only
+#      application-sdk's own Dockerfile is FROM cgr.dev. So the login this
+#      workflow insisted on was both unsatisfiable and pointless.
+#
+# The Chainguard secrets are gone from the contract below, and the composite's
+# login step is now conditional, so the SDK's own pull_request.yaml job keeps
+# using its repo-level credentials while callers here need nothing.
+#
+# The remaining secret is declared `required: false` on purpose and validated by
+# the "Verify secret contract" step instead. `required: true` turns a caller
+# that omits it into a workflow-parse error: the run ends as `startup_failure`
+# with zero jobs and therefore no check run at all, which no required check can
+# gate on and nobody can see. That is what hid cause 1 for months. See
+# .github/scripts/check_trivy_secret_contract.py for the full rationale.
 #
 # This workflow mints a fleet App token (falling back to the caller's
 # ORG_PAT_GITHUB) for the cross-repo allowlist checkout and the
-# private-dependency BuildKit secret. Callers passing named secrets
-# explicitly instead of `inherit` keep working unchanged on their own
-# ORG_PAT_GITHUB.
-#
-# Every secret below is declared `required: false` on purpose, and validated by
-# the "Verify secret contract" step instead. `required: true` turns a caller
-# that omits the secret into a workflow-parse error: the run ends as
-# `startup_failure` with zero jobs and therefore no check run at all, which no
-# required check can gate on and nobody can see (FND-447). See
-# .github/scripts/check_trivy_secret_contract.py for the full rationale.
+# private-dependency BuildKit secret.
 
 name: Atlan Application Trivy container scan
 
@@ -32,12 +47,6 @@ on:
       ORG_PAT_GITHUB:
         required: false
         description: "Fallback PAT, used if the fleet App token can't be minted. Enforced by the 'Verify secret contract' step, and only when the App token did not mint -- nothing reads it otherwise."
-      CHAINGUARD_USERNAME:
-        required: false
-        description: "Chainguard registry username. Needed unconditionally (the composite logs in to cgr.dev before it can build); enforced by the 'Verify secret contract' step, not by `required: true`."
-      CHAINGUARD_PASSWORD:
-        required: false
-        description: "Chainguard registry password. Same handling as CHAINGUARD_USERNAME above."
       FLEET_APP_ID:
         required: false
         description: "atlan-app-fleet App ID (org secret). Not passed explicitly by any current caller — auto-available via 'secrets: inherit'. Declared here so the contract is self-documenting."
@@ -118,8 +127,6 @@ jobs:
       # after -- a visible failure carrying a check run, not startup_failure.
       - name: Verify secret contract
         env:
-          CHAINGUARD_USERNAME: ${{ secrets.CHAINGUARD_USERNAME }}
-          CHAINGUARD_PASSWORD: ${{ secrets.CHAINGUARD_PASSWORD }}
           ORG_PAT_GITHUB: ${{ secrets.ORG_PAT_GITHUB }}
           APP_TOKEN_MINTED: ${{ steps.app-token.outputs.token }}
         run: python3 _sdk/.github/scripts/check_trivy_secret_contract.py
@@ -129,8 +136,9 @@ jobs:
       - id: trivy-scan
         uses: "atlanhq/application-sdk/.github/actions/trivy-container@main"
         with:
-          chainguard-username: ${{ secrets.CHAINGUARD_USERNAME }}
-          chainguard-password: ${{ secrets.CHAINGUARD_PASSWORD }}
+          # No chainguard-* here on purpose: the login is skipped, since no
+          # caller of this workflow builds from cgr.dev and none could supply
+          # the credentials anyway. See the header.
           github-token: ${{ steps.app-token.outputs.token || secrets.ORG_PAT_GITHUB }}
           skip-files: ${{ inputs.skip-files }}
           fail-on-vulns: 'false'

--- a/.github/workflows/trivy-container.yaml
+++ b/.github/workflows/trivy-container.yaml
@@ -16,6 +16,13 @@
 # private-dependency BuildKit secret. Callers passing named secrets
 # explicitly instead of `inherit` keep working unchanged on their own
 # ORG_PAT_GITHUB.
+#
+# Every secret below is declared `required: false` on purpose, and validated by
+# the "Verify secret contract" step instead. `required: true` turns a caller
+# that omits the secret into a workflow-parse error: the run ends as
+# `startup_failure` with zero jobs and therefore no check run at all, which no
+# required check can gate on and nobody can see (FND-447). See
+# .github/scripts/check_trivy_secret_contract.py for the full rationale.
 
 name: Atlan Application Trivy container scan
 
@@ -23,12 +30,14 @@ on:
   workflow_call:
     secrets:
       ORG_PAT_GITHUB:
-        required: true
-        description: "Fallback PAT, used if the fleet App token can't be minted."
+        required: false
+        description: "Fallback PAT, used if the fleet App token can't be minted. Enforced by the 'Verify secret contract' step, and only when the App token did not mint -- nothing reads it otherwise."
       CHAINGUARD_USERNAME:
-        required: true
+        required: false
+        description: "Chainguard registry username. Needed unconditionally (the composite logs in to cgr.dev before it can build); enforced by the 'Verify secret contract' step, not by `required: true`."
       CHAINGUARD_PASSWORD:
-        required: true
+        required: false
+        description: "Chainguard registry password. Same handling as CHAINGUARD_USERNAME above."
       FLEET_APP_ID:
         required: false
         description: "atlan-app-fleet App ID (org secret). Not passed explicitly by any current caller — auto-available via 'secrets: inherit'. Declared here so the contract is self-documenting."
@@ -101,6 +110,19 @@ jobs:
             .github/scripts
           path: _sdk
           token: ${{ steps.app-token.outputs.token || secrets.ORG_PAT_GITHUB }}
+
+      # Turns a missing secret into a normal red step with an actionable
+      # message. Runs after the _sdk checkout because that is where the script
+      # comes from; a missing ORG_PAT_GITHUB with no minted App token already
+      # reds that checkout loudly, which is the outcome this whole change is
+      # after -- a visible failure carrying a check run, not startup_failure.
+      - name: Verify secret contract
+        env:
+          CHAINGUARD_USERNAME: ${{ secrets.CHAINGUARD_USERNAME }}
+          CHAINGUARD_PASSWORD: ${{ secrets.CHAINGUARD_PASSWORD }}
+          ORG_PAT_GITHUB: ${{ secrets.ORG_PAT_GITHUB }}
+          APP_TOKEN_MINTED: ${{ steps.app-token.outputs.token }}
+        run: python3 _sdk/.github/scripts/check_trivy_secret_contract.py
 
       # Composite handles build, Trivy JSON+SARIF scan, SARIF upload.
       # fail-on-vulns is disabled here — the allowlist gate below takes over.


### PR DESCRIPTION
## Problem

A reusable workflow that declares a secret `required: true` and is called with an **explicit** `secrets:` block omitting it does not fail the job — it fails to *parse*. The run ends as `startup_failure` with **zero jobs**, so it emits no check run at all: absent from `gh pr checks`, not red, not pending. Nothing surfaces it, and no required check can ever depend on it.

I swept all 166 active `atlan-*-app` repos. **32** call `trivy-container.yaml` with an explicit `secrets:` block passing only `ORG_PAT_GITHUB`, and every one is `startup_failure` 8/8, some back to 2026-08-12. One repo shows 100/100 consecutive.

Container scanning itself is intact on the 25 that also run `vulnerability-scan.yml` → `build-and-scan.yaml` (verified green). The other **8** have no other scanner at all — `trivy.yml` was their only container scan.

The single caller that uses `secrets: inherit` (`atlan-documentdb-app`) confirms the diagnosis: same reusable, same pinned SHA, but it actually runs and fails *visibly*.

## Why not just keep `required: true`

It buys almost nothing. It asserts only that the caller **mentions** the name — never that the secret exists or is non-empty — and every `secrets: inherit` caller satisfies it unconditionally. In exchange it converts a misconfiguration into the one failure mode nobody can see or gate on.

## Change

`CHAINGUARD_USERNAME`, `CHAINGUARD_PASSWORD` and `ORG_PAT_GITHUB` become `required: false`, validated by a new **Verify secret contract** step (`.github/scripts/check_trivy_secret_contract.py`) placed before the scan composite. A missing secret is now a normal red step that names what is missing and points at `secrets: inherit`.

`ORG_PAT_GITHUB` is enforced only when the fleet App token did not mint — nothing reads it otherwise, so demanding it would red a correctly configured caller.

No behaviour change for any caller that is configured correctly today.

## Tests

13 tests in `.github/scripts/tests/test_check_trivy_secret_contract.py`, picked up by the existing unfiltered `CI script tests` workflow.

The guarantee lives in the workflow YAML, so it is regression-tested there. `TestWorkflowContract` fails if anyone:

- re-adds `required: true` to any secret (mutation-tested — it does red),
- drops or duplicates the verify step,
- moves it after the scan composite,
- or forgets to map an enforced secret into the step's `env`.

That last one matters because an unmapped secret reads as empty regardless of what the caller passed, which would red a correct configuration.

## Follow-ups (not in this PR)

- **Caller-side remediation**, tracked on FND-447: delete the redundant `trivy.yml` on the 25 repos whose `vulnerability-scan.yml` already gates, switch the 8 sole-scanner repos to `secrets: inherit`.
- **10 peer reusables carry the same latent hazard** (`build-and-scan`, `build-and-publish-app`, `publish-app`, `tag-and-release`, and 6 others declare `required: true` secrets). None is firing today — no current caller omits the secret — so this is latent, not live. Worth the same treatment in its own PR; it would also cover remedy item 4 on FND-447 more cheaply than a fleet-wide `startup_failure` alarm.
- **3 repos have a failing `vulnerability-scan.yml`** (`mongodb` 8/8, `powerquery-parser` 7/8, `tenant-config-manager` 6/6). Separate, visible problem — needs its own ticket.

Closes FND-447's "the reusable can no longer fail as `startup_failure` from a missing secret".
