### PR TITLE
fix(conformance): make the vendored bootstrap scaffold lint-clean in any caller (FND-445)

### DIFF
--- a/.github/scripts/build_conformance_args.py
+++ b/.github/scripts/build_conformance_args.py
@@ -1,14 +1,30 @@
-"""Build the `detect` argument list for atlan-application-sdk-conformance.
+r"""Build the `detect` argument list for atlan-application-sdk-conformance.
 
-Reads EXCLUDE_PATHS and EXIT_ZERO from the environment (set by GitHub Actions
-``env:`` blocks) and prints one argument per line to stdout.  Callers do:
+Reads EXCLUDE_PATHS and EXIT_ZERO from the environment (set by GitHub
+Actions ``env:`` blocks) and prints one argument per line to stdout.
+Callers do::
 
-    mapfile -t detect_args < <(python .github/scripts/build_conformance_args.py \\
-      --series C --slug ci)
+    mapfile -t detect_args < <(python \
+      .github/scripts/build_conformance_args.py --series C --slug ci)
     uvx atlan-application-sdk-conformance detect "${detect_args[@]}"
 
-This keeps all conditional argument-building logic in a tested Python script
-rather than inlined in YAML (per docs/standards/ci.md).
+This keeps all conditional argument-building logic in a tested Python
+script rather than inlined in YAML (per docs/standards/ci.md).
+
+``bootstrap`` vendors this file into every consumer repo and overwrites
+it on every run, so a consumer cannot fix it locally — the next
+bootstrap reverts the fix. It therefore has to be lint-clean under the
+strictest ruff config in the fleet, not just this repo's (FND-445):
+
+- docstrings on the module and every public function, and a raw
+  docstring here (the ``r`` prefix) because the shell example below
+  contains a backslash (pydocstyle ``D``);
+- every line inside 88 columns and every exploded call/signature closed
+  by a magic trailing comma, so ``ruff format`` is a no-op at any
+  configured line length rather than re-joining at a wider one.
+
+``tests/test_bootstrap_scaffold_lint.py`` in the conformance package
+enforces both.
 """
 
 from __future__ import annotations
@@ -25,7 +41,20 @@ def build_args(
     exclude: str = "",
     exit_zero: bool = False,
 ) -> list[str]:
-    result = ["--repo", ".", "--series", series, "--output", f"{slug}.sarif"]
+    """Return the ``detect`` arguments for one conformance series.
+
+    ``exclude`` renders as ``--exclude`` when non-empty, and
+    ``exit_zero`` appends ``--exit-zero`` for soft-enforcement runs
+    where violations are reported but do not fail the job.
+    """
+    result = [
+        "--repo",
+        ".",
+        "--series",
+        series,
+        "--output",
+        f"{slug}.sarif",
+    ]
     if exclude:
         result += ["--exclude", exclude]
     if exit_zero:
@@ -34,21 +63,34 @@ def build_args(
 
 
 def main(argv: list[str] | None = None) -> int:
+    """Print one detect argument per line to stdout; return the exit code."""
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--series", required=True, help="Conformance series letter(s)")
-    parser.add_argument("--slug", required=True, help="Series slug for SARIF filename")
+    parser.add_argument(
+        "--series",
+        required=True,
+        help="Conformance series letter(s)",
+    )
+    parser.add_argument(
+        "--slug",
+        required=True,
+        help="Series slug for SARIF filename",
+    )
     args = parser.parse_args(argv)
 
     exclude = os.environ.get("EXCLUDE_PATHS", "")
     exit_zero = os.environ.get("EXIT_ZERO", "").lower() == "true"
 
     detect_args = build_args(
-        args.series, args.slug, exclude=exclude, exit_zero=exit_zero
+        args.series,
+        args.slug,
+        exclude=exclude,
+        exit_zero=exit_zero,
     )
-    # This print is the script's actual output mechanism — the calling composite
-    # action reads stdout via `mapfile`, not application logging — so callers
-    # that enable ruff's T201 (no bare prints) don't need a per-repo pyproject.toml
-    # ignore for this bootstrap-managed file.
+    # This print is the script's actual output mechanism — the calling
+    # composite action reads stdout via `mapfile`, not application
+    # logging — so callers that enable ruff's T201 (no bare prints) do
+    # not need a per-repo pyproject.toml ignore for this
+    # bootstrap-managed file.
     print("\n".join(detect_args))  # noqa: T201
     return 0
 

--- a/packages/conformance/conformance/bootstrap/render.py
+++ b/packages/conformance/conformance/bootstrap/render.py
@@ -82,6 +82,16 @@ RETIRED_WORKFLOWS: tuple[str, ...] = ("docstring-coverage.yaml",)
 # whose changed-files filter matches) legs fail with "Can't find action.yml"
 # the first time they actually run. Static templates (no per-repo params),
 # always-overwrite like MANAGED_WORKFLOWS.
+#
+# Because these are always-overwrite, they have to satisfy the *caller's*
+# linters, not just this repo's: a consumer whose pre-commit rejects one of
+# them cannot fix it, since the next bootstrap run reverts the fix. FND-445
+# was exactly that — the vendored Python script failed pydocstyle ``D`` and
+# got re-wrapped by ``ruff format`` at a 100-column line length, leaving a
+# connector with a permanently red pre-commit and ``checks.yml``.
+# ``tests/test_bootstrap_scaffold_lint.py`` lints every force-written
+# artifact under a config stricter than this repo's; keep new templates
+# inside it.
 MANAGED_ACTION_FILES: tuple[tuple[str, str], ...] = (
     (
         ".github/actions/run-conformance-detect/action.yaml",

--- a/packages/conformance/conformance/bootstrap/render.py
+++ b/packages/conformance/conformance/bootstrap/render.py
@@ -89,9 +89,12 @@ RETIRED_WORKFLOWS: tuple[str, ...] = ("docstring-coverage.yaml",)
 # was exactly that — the vendored Python script failed pydocstyle ``D`` and
 # got re-wrapped by ``ruff format`` at a 100-column line length, leaving a
 # connector with a permanently red pre-commit and ``checks.yml``.
-# ``tests/test_bootstrap_scaffold_lint.py`` lints every force-written
-# artifact under a config stricter than this repo's; keep new templates
-# inside it.
+# ``tests/test_bootstrap_scaffold_lint.py`` holds that line for every
+# force-written artifact: the template-rendered ones (these two plus the
+# MANAGED_WORKFLOWS shims and the remediate SKILL.md) under a config
+# stricter than this repo's, and ``.github/ci-system-deps.txt``, whose
+# bytes come from the ``--system-deps`` flag rather than a template,
+# separately. Keep new templates inside it.
 MANAGED_ACTION_FILES: tuple[tuple[str, str], ...] = (
     (
         ".github/actions/run-conformance-detect/action.yaml",

--- a/packages/conformance/conformance/bootstrap/templates/build_conformance_args.py
+++ b/packages/conformance/conformance/bootstrap/templates/build_conformance_args.py
@@ -1,14 +1,30 @@
-"""Build the `detect` argument list for atlan-application-sdk-conformance.
+r"""Build the `detect` argument list for atlan-application-sdk-conformance.
 
-Reads EXCLUDE_PATHS and EXIT_ZERO from the environment (set by GitHub Actions
-``env:`` blocks) and prints one argument per line to stdout.  Callers do:
+Reads EXCLUDE_PATHS and EXIT_ZERO from the environment (set by GitHub
+Actions ``env:`` blocks) and prints one argument per line to stdout.
+Callers do::
 
-    mapfile -t detect_args < <(python .github/scripts/build_conformance_args.py \\
-      --series C --slug ci)
+    mapfile -t detect_args < <(python \
+      .github/scripts/build_conformance_args.py --series C --slug ci)
     uvx atlan-application-sdk-conformance detect "${detect_args[@]}"
 
-This keeps all conditional argument-building logic in a tested Python script
-rather than inlined in YAML (per docs/standards/ci.md).
+This keeps all conditional argument-building logic in a tested Python
+script rather than inlined in YAML (per docs/standards/ci.md).
+
+``bootstrap`` vendors this file into every consumer repo and overwrites
+it on every run, so a consumer cannot fix it locally — the next
+bootstrap reverts the fix. It therefore has to be lint-clean under the
+strictest ruff config in the fleet, not just this repo's (FND-445):
+
+- docstrings on the module and every public function, and a raw
+  docstring here (the ``r`` prefix) because the shell example below
+  contains a backslash (pydocstyle ``D``);
+- every line inside 88 columns and every exploded call/signature closed
+  by a magic trailing comma, so ``ruff format`` is a no-op at any
+  configured line length rather than re-joining at a wider one.
+
+``tests/test_bootstrap_scaffold_lint.py`` in the conformance package
+enforces both.
 """
 
 from __future__ import annotations
@@ -25,7 +41,20 @@ def build_args(
     exclude: str = "",
     exit_zero: bool = False,
 ) -> list[str]:
-    result = ["--repo", ".", "--series", series, "--output", f"{slug}.sarif"]
+    """Return the ``detect`` arguments for one conformance series.
+
+    ``exclude`` renders as ``--exclude`` when non-empty, and
+    ``exit_zero`` appends ``--exit-zero`` for soft-enforcement runs
+    where violations are reported but do not fail the job.
+    """
+    result = [
+        "--repo",
+        ".",
+        "--series",
+        series,
+        "--output",
+        f"{slug}.sarif",
+    ]
     if exclude:
         result += ["--exclude", exclude]
     if exit_zero:
@@ -34,21 +63,34 @@ def build_args(
 
 
 def main(argv: list[str] | None = None) -> int:
+    """Print one detect argument per line to stdout; return the exit code."""
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--series", required=True, help="Conformance series letter(s)")
-    parser.add_argument("--slug", required=True, help="Series slug for SARIF filename")
+    parser.add_argument(
+        "--series",
+        required=True,
+        help="Conformance series letter(s)",
+    )
+    parser.add_argument(
+        "--slug",
+        required=True,
+        help="Series slug for SARIF filename",
+    )
     args = parser.parse_args(argv)
 
     exclude = os.environ.get("EXCLUDE_PATHS", "")
     exit_zero = os.environ.get("EXIT_ZERO", "").lower() == "true"
 
     detect_args = build_args(
-        args.series, args.slug, exclude=exclude, exit_zero=exit_zero
+        args.series,
+        args.slug,
+        exclude=exclude,
+        exit_zero=exit_zero,
     )
-    # This print is the script's actual output mechanism — the calling composite
-    # action reads stdout via `mapfile`, not application logging — so callers
-    # that enable ruff's T201 (no bare prints) don't need a per-repo pyproject.toml
-    # ignore for this bootstrap-managed file.
+    # This print is the script's actual output mechanism — the calling
+    # composite action reads stdout via `mapfile`, not application
+    # logging — so callers that enable ruff's T201 (no bare prints) do
+    # not need a per-repo pyproject.toml ignore for this
+    # bootstrap-managed file.
     print("\n".join(detect_args))  # noqa: T201
     return 0
 

--- a/packages/conformance/pyproject.toml
+++ b/packages/conformance/pyproject.toml
@@ -58,6 +58,15 @@ packages = ["conformance"]
 asyncio_mode = "auto"
 testpaths = ["tests"]
 
+# Dev tooling. ruff is a genuine test dependency here, not only a
+# pre-commit hook: tests/test_bootstrap_scaffold_lint.py runs it over the
+# scaffolds bootstrap force-writes into consumer repos (FND-445), which
+# have to stay lint-clean under configs stricter than this repo's.
+# Pinned exactly — an unpinned linter makes that guard's verdict a
+# function of cache age rather than of the files it checks.
+[dependency-groups]
+dev = ["ruff==0.16.3"]
+
 [tool.ruff.format]
 exclude = ["conformance/bootstrap/templates/renovate.json"]
 

--- a/packages/conformance/tests/test_bootstrap_scaffold_lint.py
+++ b/packages/conformance/tests/test_bootstrap_scaffold_lint.py
@@ -1,0 +1,206 @@
+"""Lint guards for the scaffolds bootstrap force-writes into consumer repos.
+
+FND-445: ``bootstrap`` vendors ``MANAGED_ACTION_FILES`` (currently
+``.github/scripts/build_conformance_args.py`` and
+``.github/actions/run-conformance-detect/action.yaml``) plus every
+``MANAGED_WORKFLOWS`` shim into each consumer repo, and overwrites them
+on every run — "re-running eradicates drift". A consumer whose linters
+reject one of those files therefore cannot fix it: the next bootstrap
+reverts the fix.
+
+That happened. One connector repo selects pydocstyle ``D`` and sets
+``line-length = 100``; the shipped ``build_conformance_args.py`` had no
+function docstrings, a backslash in a non-raw module docstring, and a
+call split at 88 columns that ``ruff format`` re-joined at 100. Result:
+five consecutive red ``checks.yml`` runs on ``main``, a permanently red
+pre-commit, and an otherwise-clean remediation PR held in draft — all
+from a file the repo does not own.
+
+So the rule these tests hold: **anything bootstrap force-writes has to
+satisfy the strictest linter config in the fleet, not just this repo's.**
+"""
+
+from __future__ import annotations
+
+import pathlib
+import shutil
+import subprocess
+import sys
+
+import pytest
+from conformance.bootstrap.render import MANAGED_ACTION_FILES, MANAGED_WORKFLOWS, render
+
+# The strictest ruff lint selection seen in the fleet, plus "I" (import
+# order), because fleet repos also run isort. A repo tightening its config
+# further is exactly how FND-445 surfaced, so widen this list when it does.
+_STRICT_SELECT = "E,F,W,I,D,G,T201,LOG,BLE,S110,S112,TRY400,TRY401"
+
+# Every line length a caller plausibly configures. Both check (E501) and
+# format (re-wrapping) run at each: a scaffold formatted for one width is
+# not automatically a format no-op at another, which is half of what made
+# the affected repo red.
+_LINE_LENGTHS = (88, 100, 120)
+
+# The tightest wrap in _LINE_LENGTHS. Keeping every physical line inside
+# it, and closing every exploded call/signature with a magic trailing
+# comma, is what makes `ruff format` a no-op at all of them.
+_TIGHTEST_WRAP = min(_LINE_LENGTHS)
+
+_PY_SCAFFOLDS = tuple(
+    (dest, template) for dest, template in MANAGED_ACTION_FILES if dest.endswith(".py")
+)
+
+# Every always-overwrite artifact, as (repo-relative dest, template name).
+# renovate.json and .gitignore are excluded on purpose: those are
+# write-if-absent, so a consumer can edit them and keep the edit.
+_FORCE_WRITTEN = (
+    *MANAGED_ACTION_FILES,
+    *((f".github/workflows/{name}", name) for name in MANAGED_WORKFLOWS),
+    (".claude/skills/remediate/SKILL.md", "remediate.md"),
+)
+
+
+def _ruff_cmd() -> list[str]:
+    """Return the argv prefix that runs ruff in this environment."""
+    exe = shutil.which("ruff")
+    return [exe] if exe else [sys.executable, "-m", "ruff"]
+
+
+def _write_scaffold(
+    tmp_path: pathlib.Path, dest_rel: str, template: str
+) -> pathlib.Path:
+    """Render *template* to a file named as the consumer repo sees it."""
+    path = tmp_path / pathlib.Path(dest_rel).name
+    path.write_text(render(template), encoding="utf-8")
+    return path
+
+
+def test_ruff_is_installed() -> None:
+    """Fail loudly rather than let the guards below vanish into a skip."""
+    proc = subprocess.run([*_ruff_cmd(), "--version"], capture_output=True, text=True)
+    assert proc.returncode == 0, (
+        "ruff is not runnable here, so the scaffold lint guards cannot run. It "
+        "is a pinned dev-group dependency of this package — `uv sync "
+        "--all-extras --all-groups`, which is what CI does."
+    )
+
+
+def test_there_is_a_python_scaffold_to_lint() -> None:
+    """Guard the guard: an empty parametrize list would pass silently."""
+    assert _PY_SCAFFOLDS, (
+        "MANAGED_ACTION_FILES has no .py entry — if the vendored script was "
+        "renamed or retired, update _PY_SCAFFOLDS; if it moved to a new "
+        "extension, add the equivalent lint guard for it."
+    )
+
+
+@pytest.mark.parametrize("line_length", _LINE_LENGTHS)
+@pytest.mark.parametrize("dest_rel,template", _PY_SCAFFOLDS)
+def test_python_scaffold_passes_strict_ruff_check(
+    dest_rel: str,
+    template: str,
+    line_length: int,
+    tmp_path: pathlib.Path,
+) -> None:
+    path = _write_scaffold(tmp_path, dest_rel, template)
+    proc = subprocess.run(
+        [
+            *_ruff_cmd(),
+            "check",
+            # --isolated: judge the file as a foreign repo's linter would,
+            # not through this repo's pyproject.toml (which selects neither
+            # D nor a non-default line length — why this stayed latent).
+            "--isolated",
+            "--line-length",
+            str(line_length),
+            "--select",
+            _STRICT_SELECT,
+            str(path),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, (
+        f"{dest_rel} fails `ruff check --select {_STRICT_SELECT}` at "
+        f"line-length {line_length}. Consumer repos cannot fix this — "
+        f"bootstrap force-writes the file — so fix the template:\n"
+        f"{proc.stdout}{proc.stderr}"
+    )
+
+
+@pytest.mark.parametrize("line_length", _LINE_LENGTHS)
+@pytest.mark.parametrize("dest_rel,template", _PY_SCAFFOLDS)
+def test_python_scaffold_is_a_ruff_format_no_op(
+    dest_rel: str,
+    template: str,
+    line_length: int,
+    tmp_path: pathlib.Path,
+) -> None:
+    path = _write_scaffold(tmp_path, dest_rel, template)
+    proc = subprocess.run(
+        [
+            *_ruff_cmd(),
+            "format",
+            "--isolated",
+            "--line-length",
+            str(line_length),
+            "--check",
+            "--diff",
+            str(path),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, (
+        f"{dest_rel} is not `ruff format`-clean at line-length "
+        f"{line_length}, so a consumer's ruff-format hook rewrites it and "
+        f"reds their pre-commit on every run. Close exploded calls with a "
+        f"magic trailing comma so the shape holds at every width:\n"
+        f"{proc.stdout}{proc.stderr}"
+    )
+
+
+@pytest.mark.parametrize("dest_rel,template", _PY_SCAFFOLDS)
+def test_python_scaffold_lines_fit_the_tightest_wrap(
+    dest_rel: str, template: str
+) -> None:
+    """Keep every physical line inside the tightest configured wrap.
+
+    E501 at the tightest width would catch this too; asserting it
+    directly names the actual invariant, so the failure says "shorten
+    line 42" rather than pointing at a formatter disagreement.
+    """
+    long_lines = [
+        (num, len(line))
+        for num, line in enumerate(render(template).splitlines(), start=1)
+        if len(line) > _TIGHTEST_WRAP
+    ]
+    assert not long_lines, (
+        f"{dest_rel} has lines longer than {_TIGHTEST_WRAP} columns "
+        f"(line, length): {long_lines}. A caller wrapping at "
+        f"{_TIGHTEST_WRAP} would both flag E501 and re-wrap the file."
+    )
+
+
+@pytest.mark.parametrize("dest_rel,template", _FORCE_WRITTEN)
+def test_force_written_scaffold_is_whitespace_clean(
+    dest_rel: str, template: str
+) -> None:
+    """Hold the pre-commit-hooks staples for every force-written file.
+
+    trailing-whitespace, end-of-file-fixer and mixed-line-ending are the
+    hooks fleet repos run alongside ruff; a file bootstrap keeps
+    rewriting has to satisfy them too, whatever its type — YAML and
+    Markdown included, not just the vendored Python.
+    """
+    content = render(template)
+    assert "\r" not in content, f"{dest_rel} contains a CR (mixed line endings)"
+    assert "\t" not in content, f"{dest_rel} contains a tab"
+    assert content.endswith("\n"), f"{dest_rel} does not end with a newline"
+    assert not content.endswith("\n\n"), f"{dest_rel} ends with a blank line"
+    trailing = [
+        num
+        for num, line in enumerate(content.splitlines(), start=1)
+        if line != line.rstrip()
+    ]
+    assert not trailing, f"{dest_rel} has trailing whitespace on lines {trailing}"

--- a/packages/conformance/tests/test_bootstrap_scaffold_lint.py
+++ b/packages/conformance/tests/test_bootstrap_scaffold_lint.py
@@ -26,9 +26,11 @@ import pathlib
 import shutil
 import subprocess
 import sys
+import tomllib
 
 import pytest
 from conformance.bootstrap.render import MANAGED_ACTION_FILES, MANAGED_WORKFLOWS, render
+from conformance.cli import _cmd_bootstrap
 
 # The strictest ruff lint selection seen in the fleet, plus "I" (import
 # order), because fleet repos also run isort. A repo tightening its config
@@ -50,13 +52,45 @@ _PY_SCAFFOLDS = tuple(
     (dest, template) for dest, template in MANAGED_ACTION_FILES if dest.endswith(".py")
 )
 
-# Every always-overwrite artifact, as (repo-relative dest, template name).
-# renovate.json and .gitignore are excluded on purpose: those are
-# write-if-absent, so a consumer can edit them and keep the edit.
-_FORCE_WRITTEN = (
+# Every always-overwrite artifact that comes from a template, as
+# (repo-relative dest, template name).
+#
+# renovate.json, .gitignore and contract_schema.lock.json are excluded on
+# purpose: those are write-if-absent, so a consumer can edit them and keep
+# the edit. `.github/ci-system-deps.txt` is force-written but has no
+# template — its bytes are the `--system-deps` flag value — so it is
+# covered separately, by
+# test_force_written_system_deps_file_is_whitespace_clean below.
+_TEMPLATE_RENDERED_FORCE_WRITTEN = (
     *MANAGED_ACTION_FILES,
     *((f".github/workflows/{name}", name) for name in MANAGED_WORKFLOWS),
     (".claude/skills/remediate/SKILL.md", "remediate.md"),
+)
+
+# Per-repo render parameters to check the templates under, beyond the
+# defaults. bootstrap renders these with **kwargs, so a conditional block
+# only taken by an opted-in repo is a shape the default render never
+# exercises — and a whitespace defect inside one would reach exactly the
+# repos that opted in, and no others.
+#
+# Only the parameters that reach an always-overwrite template are listed:
+# `system_deps` (checks.yml), `use_ghcr_base` (build-and-publish.yaml),
+# `exit_zero` (conformance.yaml) and the app naming. tests.yaml's and
+# renovate.json's parameters are absent because those files are not in
+# _TEMPLATE_RENDERED_FORCE_WRITTEN — they are write-if-absent, so a
+# consumer's edit survives.
+_RENDER_PARAMS: tuple[tuple[str, dict[str, str]], ...] = (
+    ("defaults", {}),
+    (
+        "every-opt-in",
+        {
+            "app_name": "widget",
+            "app_image_name": "atlan-widget-app",
+            "system_deps": "libkrb5-dev gcc",
+            "use_ghcr_base": "true",
+            "exit_zero": "true",
+        },
+    ),
 )
 
 
@@ -64,6 +98,17 @@ def _ruff_cmd() -> list[str]:
     """Return the argv prefix that runs ruff in this environment."""
     exe = shutil.which("ruff")
     return [exe] if exe else [sys.executable, "-m", "ruff"]
+
+
+def _pinned_ruff_version() -> str:
+    """Return the ruff version this package's dev group pins."""
+    pyproject = pathlib.Path(__file__).resolve().parents[1] / "pyproject.toml"
+    dev = tomllib.loads(pyproject.read_text(encoding="utf-8"))["dependency-groups"][
+        "dev"
+    ]
+    pins = [spec.split("==", 1)[1] for spec in dev if spec.startswith("ruff==")]
+    assert len(pins) == 1, f"expected exactly one exact ruff pin, got {pins}"
+    return pins[0]
 
 
 def _write_scaffold(
@@ -75,13 +120,27 @@ def _write_scaffold(
     return path
 
 
-def test_ruff_is_installed() -> None:
-    """Fail loudly rather than let the guards below vanish into a skip."""
+def test_ruff_is_the_pinned_version() -> None:
+    """Resolve ruff and prove it is the pinned one, not whatever is on PATH.
+
+    Two failure modes in one assertion. Missing ruff would otherwise turn
+    every guard below into a silent skip; an *ambient* ruff earlier on PATH
+    than the synced venv's would make the verdict a function of whatever the
+    machine happens to have installed — the exact thing the exact pin exists
+    to prevent. Under `uv run` the venv wins, so this holds in CI.
+    """
     proc = subprocess.run([*_ruff_cmd(), "--version"], capture_output=True, text=True)
     assert proc.returncode == 0, (
         "ruff is not runnable here, so the scaffold lint guards cannot run. It "
         "is a pinned dev-group dependency of this package — `uv sync "
-        "--all-extras --all-groups`, which is what CI does."
+        f"--all-extras --all-groups`, which is what CI does. {proc.stderr}"
+    )
+    pin = _pinned_ruff_version()
+    assert proc.stdout.split() == ["ruff", pin], (
+        f"resolved ruff is {proc.stdout.strip()!r}, but this package pins "
+        f"ruff=={pin}. The scaffold guards would report a verdict from a "
+        f"binary the pin never selected. Run under `uv run` in "
+        f"packages/conformance so the synced venv's ruff comes first on PATH."
     )
 
 
@@ -182,18 +241,14 @@ def test_python_scaffold_lines_fit_the_tightest_wrap(
     )
 
 
-@pytest.mark.parametrize("dest_rel,template", _FORCE_WRITTEN)
-def test_force_written_scaffold_is_whitespace_clean(
-    dest_rel: str, template: str
-) -> None:
-    """Hold the pre-commit-hooks staples for every force-written file.
+def _assert_whitespace_clean(dest_rel: str, content: str) -> None:
+    """Hold the pre-commit-hooks staples for one force-written file.
 
     trailing-whitespace, end-of-file-fixer and mixed-line-ending are the
-    hooks fleet repos run alongside ruff; a file bootstrap keeps
-    rewriting has to satisfy them too, whatever its type — YAML and
-    Markdown included, not just the vendored Python.
+    hooks fleet repos run alongside ruff; a file bootstrap keeps rewriting
+    has to satisfy them too, whatever its type — YAML and Markdown
+    included, not just the vendored Python.
     """
-    content = render(template)
     assert "\r" not in content, f"{dest_rel} contains a CR (mixed line endings)"
     assert "\t" not in content, f"{dest_rel} contains a tab"
     assert content.endswith("\n"), f"{dest_rel} does not end with a newline"
@@ -204,3 +259,33 @@ def test_force_written_scaffold_is_whitespace_clean(
         if line != line.rstrip()
     ]
     assert not trailing, f"{dest_rel} has trailing whitespace on lines {trailing}"
+
+
+@pytest.mark.parametrize("params_id,params", _RENDER_PARAMS, ids=lambda v: v)
+@pytest.mark.parametrize("dest_rel,template", _TEMPLATE_RENDERED_FORCE_WRITTEN)
+def test_force_written_scaffold_is_whitespace_clean(
+    dest_rel: str,
+    template: str,
+    params_id: str,
+    params: dict[str, str],
+) -> None:
+    _assert_whitespace_clean(f"{dest_rel} [{params_id}]", render(template, **params))
+
+
+def test_force_written_system_deps_file_is_whitespace_clean(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Cover the one force-written artifact with no template.
+
+    `.github/ci-system-deps.txt` is written from the `--system-deps` flag,
+    so its bytes are the operator's, not a template's. Every producer
+    normalises (the arg parser re-joins on single spaces; both autodetect
+    readers go through `sanitize_package_list`) — this pins that premise at
+    the file, driving the messiest spelling the CLI accepts through the real
+    bootstrap path.
+    """
+    monkeypatch.chdir(tmp_path)
+    _cmd_bootstrap(["--system-deps=  libkrb5-dev   gcc\n"])
+    dest = tmp_path / ".github" / "ci-system-deps.txt"
+    assert dest.exists(), "bootstrap wrote no ci-system-deps.txt for a non-empty flag"
+    _assert_whitespace_clean(".github/ci-system-deps.txt", dest.read_text())

--- a/packages/conformance/uv.lock
+++ b/packages/conformance/uv.lock
@@ -245,6 +245,11 @@ test = [
     { name = "pytest-asyncio" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "ruff" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "atlan-application-sdk", extras = ["sql"], marker = "extra == 'test'" },
@@ -256,6 +261,9 @@ requires-dist = [
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=1.4.0,<2.0.0" },
 ]
 provides-extras = ["test"]
+
+[package.metadata.requires-dev]
+dev = [{ name = "ruff", specifier = "==0.16.3" }]
 
 [[package]]
 name = "attrs"
@@ -3093,6 +3101,31 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/9c/97/0043896fdd7828ce09a1d9a8b06433714d0960fc4ff3fc4aa72b666b764e/rpds_py-2026.6.3-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:2bfd04c19ddbd6640de0b51894d764bd2758854d5b75bd102d2ef10cb9c293a9", size = 558118, upload-time = "2026-06-30T07:17:47.759Z" },
     { url = "https://files.pythonhosted.org/packages/f6/40/02355f0e134f783a8f9814c4680a1bd311d37671577a5964ea838573ff37/rpds_py-2026.6.3-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:ca6546b66be9dc4738b1b043d5ebd5488c66c578c5ff0fd0e8065313fe3afb76", size = 623138, upload-time = "2026-06-30T07:17:49.355Z" },
     { url = "https://files.pythonhosted.org/packages/10/85/48f0abdcef5cce4e034c7a5b0ceeceba0b01bf0d942824f4bb720afe2dec/rpds_py-2026.6.3-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:8e65860d238379ed982fd9ba690579b5e95af2f4840f99c772816dbe573cb826", size = 586486, upload-time = "2026-06-30T07:17:51.141Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.16.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/61/b3/3213589383f8f1b3938781bd1278713f6d18621a14992b3e81fefb8a5ef9/ruff-0.16.3.tar.gz", hash = "sha256:e76d33a347661a84b5be6d043d0347fdc745dfdcf825a8f4fed64b5e26eebdf2", size = 4891904, upload-time = "2026-08-13T15:17:13.381Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/96/493770daebd68c0a67f1549fdf519f53be51fc435186c0585bcc272fd76c/ruff-0.16.3-py3-none-linux_armv6l.whl", hash = "sha256:0c5710e247a58a4521e66e124ba9a74655b414f61ba3a2e9e3811e11098f48f7", size = 10902799, upload-time = "2026-08-13T15:16:27.382Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/e6/2becf3942fddc29a29b8df47691d456fb1085391a694f74d84513251418c/ruff-0.16.3-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:fe155130631a2471fd2e14a7a664a4dfbd7194b8229c3d7b2a40b21178639081", size = 11135539, upload-time = "2026-08-13T15:16:30.87Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/1e/4b8b72f0d006dbf19326aa99f9ca0ee2ff374187c4d301cf529a51aa06fe/ruff-0.16.3-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e2ed719e14aa64d895c2ee922594a90a43c861a93f0575a95ff8c47cdbd13eb9", size = 10475095, upload-time = "2026-08-13T15:16:33.259Z" },
+    { url = "https://files.pythonhosted.org/packages/92/32/2201fa49ba1f6c101ee321e83f051ac7a4b8d07b0ef6b4d3f2772b302275/ruff-0.16.3-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9e0b1da805eb043654645d74d5de1e5ce2edc686e40790d2b86f56d71cc06a84", size = 10668771, upload-time = "2026-08-13T15:16:35.65Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/66/4afc5c8363bd04d45effce1b7c8713ca037d7a6740b7451a2403a6e3a972/ruff-0.16.3-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a37bdea0bbe21780f590bf437d6412c8c4e1b6cd010f91a65c2c40c5e5f5f870", size = 10699568, upload-time = "2026-08-13T15:16:38.195Z" },
+    { url = "https://files.pythonhosted.org/packages/53/fd/c67d246bf36bf1698551c56de39e95cd07f70e64433e0098e6267d77061b/ruff-0.16.3-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:09571e6d1288ed9be475207a3ac04ada404f1cd898104be0f6ab8d7df438575b", size = 11499365, upload-time = "2026-08-13T15:16:40.623Z" },
+    { url = "https://files.pythonhosted.org/packages/67/0b/00ecbceb99a263af7b12f6f05ac3c92bc47b905e91adc3f207a836e3bc01/ruff-0.16.3-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2c18c5a101eb540010638cc1ff3c84944d3adb3df62b8d98ca8f22ba484d3413", size = 12311728, upload-time = "2026-08-13T15:16:43.564Z" },
+    { url = "https://files.pythonhosted.org/packages/54/b2/b7b3bb54f4d3f7db504e476ad4ab8de530dceebe2c061384b2757ee419e8/ruff-0.16.3-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8457c44f15033c85ddbb77b15d451df9e24e4bd03b628396dd3610cedc3b8f82", size = 11699896, upload-time = "2026-08-13T15:16:46.209Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/30/4c468429ac195addc5ee1b717b6ab1b66632786737ca3b2ed3443fb0c26a/ruff-0.16.3-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:294b95c4ae0cda9388525c2047778aa758d6b8d4bb876fd4e9eaa3ebc92343eb", size = 11058736, upload-time = "2026-08-13T15:16:48.823Z" },
+    { url = "https://files.pythonhosted.org/packages/43/67/7a113cdaddf24b64d7f75b1242a99d04c82fcef4f6921fdbb832beaffb5f/ruff-0.16.3-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:3d0c7c40c87c2a820509c31ba007968da6e1306468c067b2d82fbfdbcd0e8474", size = 11586911, upload-time = "2026-08-13T15:16:51.913Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/c1/2e66f24c0f3ead25a5e660111778685e505e5da353c82802bf49f0cbe7b9/ruff-0.16.3-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:9f738c0fdfa8eed0b2ce7fb27ee7258208a92a68d7949e62aa15164bc7b389da", size = 10954265, upload-time = "2026-08-13T15:16:54.763Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/ba/4cee23bf52cba9a058d3726de623624daf50ef9638868edd86f4126157f6/ruff-0.16.3-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:fb785f0be25abe69d320415cd4f833b59e17ba7613d9ba6a958023b6bceb0a50", size = 10709886, upload-time = "2026-08-13T15:16:57.339Z" },
+    { url = "https://files.pythonhosted.org/packages/82/df/7da7194fa5d9dc0a285f7e6fa5a4722e7c63faac0b45b614ded9314363a1/ruff-0.16.3-py3-none-musllinux_1_2_i686.whl", hash = "sha256:c5536e3acfbf9563085aa2be7b13c629c3077e902afc5b941ac44024dbb9f506", size = 11210392, upload-time = "2026-08-13T15:17:00.171Z" },
+    { url = "https://files.pythonhosted.org/packages/35/85/7795f6e817af050e7517bf3e7aa9b061cce70ef33d280aad902c956c1ecf/ruff-0.16.3-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a2d85c02f9b8e165d85e6779184d38c4132de12603dab59c51c28e22584f9e4d", size = 11626910, upload-time = "2026-08-13T15:17:03.299Z" },
+    { url = "https://files.pythonhosted.org/packages/78/9b/475b927cf27a5cbbda3c7bafb69ed6ff77e1d7923d5d85f17c2749d7ae32/ruff-0.16.3-py3-none-win32.whl", hash = "sha256:388cdf2166642bd9b13d52b5932d3170f34f8abed7e8d9a855f1d84b83645a0a", size = 10931415, upload-time = "2026-08-13T15:17:05.726Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/99/e2a2bfc4fbf0a1e8a916bc9ebe6fe6c58cc34c28e0ffc6ce281d572d1c2e/ruff-0.16.3-py3-none-win_amd64.whl", hash = "sha256:e80a7d69ca2a6d1c4d352ec91458cdca6e56c83cdbcabd93e4abe1e53591d948", size = 11445993, upload-time = "2026-08-13T15:17:08.353Z" },
+    { url = "https://files.pythonhosted.org/packages/69/3e/4132e539aed78c148854d4997a2685b0ed4dc4e87110b59ce528564e184e/ruff-0.16.3-py3-none-win_arm64.whl", hash = "sha256:b8ca152da82c1acc1fa8d5874b15951935f0eef46f10e6954c83859011b6178a", size = 11399302, upload-time = "2026-08-13T15:17:10.908Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -463,6 +463,9 @@ requires-dist = [
 ]
 provides-extras = ["test"]
 
+[package.metadata.requires-dev]
+dev = [{ name = "ruff", specifier = "==0.16.3" }]
+
 [[package]]
 name = "attrs"
 version = "26.1.0"


### PR DESCRIPTION
## Problem

`bootstrap` force-writes `.github/scripts/build_conformance_args.py` into every consumer repo and overwrites it on every run ("re-running eradicates drift"). A consumer whose linters reject that file therefore **cannot fix it** — the next bootstrap reverts the fix.

The shipped file had:

- no docstrings on its public functions (`D103` ×2) and a backslash in a non-raw module docstring (`D301`);
- a call split at 88 columns that `ruff format` **re-joins** at a wider line length.

A connector selecting pydocstyle `D` with `line-length = 100` had a permanently red pre-commit and `checks.yml` from this, plus an otherwise-clean remediation PR stuck in draft — all from a file it does not own. Latent elsewhere only because most repos do not select `D`; it surfaces as repos tighten their lint config.

## Fix

**`build_conformance_args.py`** — template and the monorepo's canonical copy, kept byte-identical for the existing sync guard:

- module and function docstrings; the module docstring is raw (`r` prefix) so the shell example's backslash is legal;
- every exploded call/signature closed by a magic trailing comma, longest line 77 columns. The trailing comma is the actual mechanism — without it ruff re-joins the split call at 100/120, whatever the source width.

Verified: `ruff check --isolated --select E,F,W,I,D,G,T201,LOG,BLE,S110,S112,TRY400,TRY401` and `ruff format --check` clean at line-length **79/88/100/120**, against ruff **0.6.4** (this repo's pre-commit rev), **0.11.2** and **0.16.3**. Behaviour unchanged — the 9 existing `.github/scripts` tests pass and the script's stdout is identical.

**Regression guard** — `packages/conformance/tests/test_bootstrap_scaffold_lint.py`, running in the package's existing CI job (`conformance-suite-tests-reusable.yaml`), no workflow change:

- renders each force-written artifact and runs `ruff check` / `ruff format --check` `--isolated` at 88/100/120 for the `.py` scaffolds. `--isolated` is the point: this repo's own config selects neither `D` nor a non-default line length, which is exactly why the defect was invisible here;
- asserts the ≤88-column invariant directly, so a failure says "shorten line N" rather than "the formatter disagrees";
- whitespace / EOF / tab hygiene — the pre-commit-hooks staples — for **every** always-overwritten artifact, the 14 workflow shims and the `remediate` SKILL.md included, not just the Python;
- two meta-guards: ruff must be runnable (fails loudly rather than skipping) and the `.py` scaffold list must be non-empty.

Falsified before trusting it: reverted the template to the pre-fix version and the guard reported exactly the failures observed downstream — `D301`, two `D103`, format rewrite at 100 and 120 (5 failed / 21 passed). Restored → 26 passed; full package suite 2886 passed.

`ruff==0.16.3` pinned exactly in the package's new `[dependency-groups] dev` (dev group, so not published metadata). Exact pin, not a range: an unpinned linter makes the guard's verdict a function of cache age rather than of the files it checks. 0.16.3 rather than 0.16.4 — the latter is inside the 7-day release-age cooldown.

`render.py` now records the rule next to `MANAGED_ACTION_FILES`: anything bootstrap force-writes has to satisfy the *caller's* linters, because the caller has no way to opt out.

## Known residual — deliberately out of scope

The force-written YAML shims and the `remediate` SKILL.md carry lines well past 80 columns (the vendored action manifest peaks at 156, 18 lines over 80; SKILL.md at 454). A caller running **yamllint** or **markdownlint** over `.github/**` falls into the identical trap, and unlike the Python case that cannot be fixed by re-wrapping alone — long `${{ }}` expressions do not wrap. Flagged rather than silently widening this PR; worth its own ticket if any consumer actually runs those hooks.

No conformance version bump here — that happens in the separate `chore(conformance): release vX` lane. Consumers pick the fix up on their next `bootstrap` after a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
