### PR TITLE
fix(conformance): remove obsolete P041 rule

### DIFF
--- a/packages/conformance/conformance/docs/rules/prescriptions.md
+++ b/packages/conformance/conformance/docs/rules/prescriptions.md
@@ -5,7 +5,7 @@
 
 # Prescription Rules (P-series)
 
-**45 rules** · Checker: `suite.checks.prescriptions` (P001–P003, P008–P015), `suite.checks.orchestration` (P004–P007, scans test files too), `suite.checks.entrypoint_alignment` (P016), `suite.checks.entrypoint` (P017–P018, scans test files too), `suite.checks.client_seam` (P019), `suite.checks.error_seam` (P043/P045, scans test files too), `suite.checks.determinism` (P020–P024, P031), `suite.checks.app_name_alignment` (P025), `suite.checks.sdr` (P029/P030, P037/P038/P039, P041), `suite.checks.transform_templates` (P040, scans template YAML) (all AST-based / cross-artifact)
+**44 rules** · Checker: `suite.checks.prescriptions` (P001–P003, P008–P015), `suite.checks.orchestration` (P004–P007, scans test files too), `suite.checks.entrypoint_alignment` (P016), `suite.checks.entrypoint` (P017–P018, scans test files too), `suite.checks.client_seam` (P019), `suite.checks.error_seam` (P043/P045, scans test files too), `suite.checks.determinism` (P020–P024, P031), `suite.checks.app_name_alignment` (P025), `suite.checks.sdr` (P029/P030, P037/P038/P039, P042), `suite.checks.transform_templates` (P040, scans template YAML) (all AST-based / cross-artifact)
 
 Suppress a finding on the violating line or the line directly above it:
 
@@ -63,7 +63,6 @@ reassigned.
 | [P038](#p038) | `SdrArtifactMisrooted` | `block` | `app` | `sdr-readiness` | — | 0.16.0 |
 | [P039](#p039) | `SdrAgentJsonDroppedByInputContract` | `block` | `app` | `sdr-readiness` | — | 0.16.0 |
 | [P040](#p040) | `TransformTemplateReservedKeyword` | `warn` | `app` | `transform-templates` | — | 0.18.0 |
-| [P041](#p041) | `SdrHardPreflightGate` | `warn` | `app` | `sdr-readiness` | — | 0.18.0 |
 | [P042](#p042) | `SdrHandRolledUploadBridge` | `warn` | `app` | `sdr-readiness` | — | 0.18.0 |
 | [P043](#p043) | `NonPublicErrorControlFlow` | `warn` | `app` | `error-seam` | — | 0.21.0 |
 | [P044](#p044) | `DirectStoragePrefixTransfer` | `warn` | `app` | `storage-seam` | — | 0.21.0 |
@@ -1566,85 +1565,6 @@ value was the interim advice and it is worse than it looks on an unfixed SDK: be
 found nothing, and dropped the attribute from published output — a silent missing
 attribute in place of a loud `ParserException`. From 3.28.0 both spellings resolve and
 render identically, so the upgrade is the fix and the template edit is unnecessary.
-
----
-
-## P041 — `SdrHardPreflightGate` {#p041}
-
-**Tier:** `warn` · **Scope:** `app` · **Category:** `sdr-readiness` · **Autofixable:** — · **Since:** 0.18.0
-
-> SDR app hard-codes preflight_gate_mode = 'hard' — non-secret-config preflight failures abort agent-mode workflows
-
-**Rationale:** In SDR (agent) mode the app resolves its configuration through the customer's secret
-store, and customers rightly mirror only *secrets* into it — non-sensitive values
-(database names, schema filters) are often absent. Preflight checks that depend on such
-non-secret config then report NOT_READY even though the run would succeed. Most
-connectors run the preflight gate non-fatally, but an app that hard-codes
-preflight_gate_mode = 'hard' aborts the entire workflow on that spurious verdict
-(observed for a query-engine connector in fleet testing). Until the SDK differentiates
-gate enforcement by run mode, the interim app-side posture is to soften the gate for
-self-deployed runs — e.g. preflight_gate_mode = 'soft' if ENABLE_ATLAN_UPLOAD else
-'hard' — keeping it env-overridable via ATLAN_PREFLIGHT_GATE_MODE.
-
-For apps declaring `self_deployed_runtime: true` in `atlan.yaml`, an unconditional
-`preflight_gate_mode = "hard"` assignment is flagged.
-
-The SDK's preflight gate (`App.preflight_gate_mode`) defaults to `"soft"` — a NOT_READY
-verdict is logged (`would_block`) but the run proceeds.  An app opts into `"hard"` when
-its checks are trusted to gate real runs.  That trust assumption breaks in SDR (agent)
-mode: configuration is resolved through the *customer's* secret store, and customers
-rightly mirror only secrets into it — non-sensitive values (a database name for a
-schema-existence check, for example) are commonly absent.  The preflight check then
-fails for a reason unrelated to the run's actual viability, and a hard gate aborts the
-whole workflow (observed for a query-engine connector in fleet testing; connectors with
-soft gates ran the same checks non-fatally and succeeded).
-
-This is suggest-only (WARN): a hard gate is a legitimate posture for cloud-hosted runs,
-and the right long-term fix is SDK-side — gate enforcement differentiated by run mode,
-so the same app can be hard in cloud mode and soft in agent mode.  Until then:
-
-**Remediation (interim app-side posture):** derive the gate mode from the run mode
-instead of hard-coding it, e.g.:
-
-```python
-preflight_gate_mode = "soft" if ENABLE_ATLAN_UPLOAD else "hard"
-```
-
-and keep it env-overridable (the SDK's `ATLAN_PREFLIGHT_GATE_MODE` env var takes
-precedence over the class attribute, so operators can restore the hard gate per
-deployment).
-
-**What is and is not flagged.**  The exemption is semantic, not structural: `"hard"` is
-safe only on the *else* path.
-
-Silent on:
-
-* `preflight_gate_mode = "soft" if ENABLE_ATLAN_UPLOAD else "hard"`   and its
-`if`/`else` statement spelling (an ordinary style   choice once the branches grow past
-one line); * `os.environ.get("ATLAN_PREFLIGHT_GATE_MODE", <that ternary>)` —   the same
-posture spelled through the override.
-
-Still flagged:
-
-* a plain `preflight_gate_mode = "hard"`; * the inverted ternary `"hard" if
-ENABLE_ATLAN_UPLOAD else "soft"`   — hard exactly when upload is on, the reverse of the
-intent; * a both-arms-hard ternary (unconditional in a conditional's   clothing); *
-`os.environ.get("ATLAN_PREFLIGHT_GATE_MODE", "hard")` and
-`os.environ.get("ATLAN_PREFLIGHT_GATE_MODE") or "hard"` — hard on   every deployment
-that leaves the variable unset.  Only the known   env-lookup callees (`os.environ.get` /
-`os.getenv` /   `os.environ.setdefault`) have their default read this way; an
-arbitrary helper call (`resolve_gate(env, default='hard')`) is   opaque to a static
-check — its constant default says nothing about   the value it returns, so it is *not*
-flagged; * one hop of constant indirection (`MODE = "hard"` /   `preflight_gate_mode =
-MODE`), at module level **or** in the   same class body — `preflight_gate_mode` is
-conventionally a   class attribute, so the class-body form is at least as common.   The
-name resolves when every straight-line assignment to it in   that body is a string
-literal; the last one wins (so   `MODE = "soft"` followed by `MODE = "hard"` still
-fires). A   name ever assigned a computed value is not resolved at all.
-
-Known limit: a condition written with inverted polarity (`"hard" if not
-ENABLE_ATLAN_UPLOAD else "soft"`) reads as the true-arm shape and is flagged — suppress
-it inline with the reason.
 
 ---
 

--- a/packages/conformance/conformance/programs/areas/prescriptions.prose.md
+++ b/packages/conformance/conformance/programs/areas/prescriptions.prose.md
@@ -458,7 +458,7 @@ drafting.
   — route to residue with the proposed shape; do not mechanically rename the
   class.  Leave `AsyncAtlanClient` usage untouched.
 
-**SDR-readiness rules (P029/P030, P037/P038/P039, P041, P042)** — all suggest-only,
+**SDR-readiness rules (P029/P030, P037/P038/P039, P042)** — all suggest-only,
 scope=app; `classification` is always `"judgment"`.  All gate on
 `self_deployed_runtime: true` in `atlan.yaml`.  Suggest-only is about *how the
 loop treats them* — never auto-edit an SDR finding, always draft and route to
@@ -592,31 +592,6 @@ say so.
   Pkl-layer change: declare `agent_json` on the extract-input contract in
   `contract/app.pkl` (or set `allow_unbounded_fields=True`) and regenerate; do
   not hand-edit the generated `_input.py`.  Route to residue for confirmation.
-
-- **P041 SdrHardPreflightGate** (WARN) — the app unconditionally sets
-  `preflight_gate_mode = "hard"`.  In SDR (agent) mode config resolves through
-  the customer's secret store, and customers rightly mirror only *secrets*
-  into it — a preflight check depending on non-secret config (e.g. a
-  database/schema existence check) then fails spuriously and the hard gate
-  aborts the whole workflow, while connectors with soft gates run the same
-  checks non-fatally and succeed.  Draft a proposal for the interim
-  run-mode-differentiated posture — `preflight_gate_mode = "soft" if
-  ENABLE_ATLAN_UPLOAD else "hard"` — noting the `ATLAN_PREFLIGHT_GATE_MODE`
-  env override as the per-deployment escape hatch; the intended long-term fix
-  is SDK-side (gate enforcement differentiated by run mode), so route to
-  residue for confirmation rather than auto-applying.
-
-  The exemption is **semantic, not structural**: `"hard"` is safe only in the
-  *else* arm.  Silent on `"soft" if ENABLE_ATLAN_UPLOAD else "hard"` and on its
-  `if`/`else` statement spelling (an ordinary style choice once the branches
-  grow), and on `os.environ.get("ATLAN_PREFLIGHT_GATE_MODE", <that ternary>)`.
-  Still fires on the inverted ternary (`"hard" if ENABLE_ATLAN_UPLOAD else
-  "soft"` — hard exactly when upload is on), on a both-arms-hard ternary, and
-  on `os.environ.get("ATLAN_PREFLIGHT_GATE_MODE", "hard")`, which is hard on
-  every deployment that does not set the variable.  Known limit: a condition
-  written with inverted polarity (`"hard" if not ENABLE_ATLAN_UPLOAD else
-  "soft"`) reads as the true-arm shape and is flagged — suppress it inline with
-  the reason.
 
 **Transform-template rule (P040)** — suggest-only, scope=app,
 `classification = "judgment"`; backed by `suite.checks.transform_templates`,

--- a/packages/conformance/conformance/suite/checks/sdr.py
+++ b/packages/conformance/conformance/suite/checks/sdr.py
@@ -1,7 +1,7 @@
-"""P-series SDR-readiness checks (P029, P030, P037, P038, P039, P041, P042).
+"""P-series SDR-readiness checks (P029, P030, P037, P038, P039, P042).
 
 Cross-artifact checks that gate on ``self_deployed_runtime: true`` in
-``atlan.yaml`` and verify seven structural invariants:
+``atlan.yaml`` and verify six structural invariants:
 
 * ``P029`` — an agent extraction manifest under ``app/generated/`` must surface
   ``agent_json`` AND ``extraction_method`` at the TOP LEVEL of
@@ -66,14 +66,6 @@ Cross-artifact checks that gate on ``self_deployed_runtime: true`` in
   ``*ExtractionInput`` family (which declares ``agent_json``) or set
   ``allow_unbounded_fields=True`` / ``extra="allow"`` are exempt.  WARN.
 
-* ``P041`` — an SDR app that unconditionally sets
-  ``preflight_gate_mode = "hard"``.  In agent mode, preflight checks that
-  depend on non-secret config (a database name for a schema-existence check)
-  fail spuriously because customers rightly mirror only secrets into the
-  secret store — a hard gate then aborts the whole workflow (observed for a
-  query-engine connector in fleet testing).  A run-mode-differentiated
-  conditional (``"soft" if ENABLE_ATLAN_UPLOAD else "hard"``) is not
-  flagged.  WARN (suggest-only).
 
 P026–P028 are reserved by a concurrent PR (GetattrOnTypedContractField,
 AppStateAsCrossTaskChannel, ManualQualifiedNameFString — PR #2417).
@@ -102,7 +94,6 @@ RULE_P030 = "P030"
 RULE_P037 = "P037"
 RULE_P038 = "P038"
 RULE_P039 = "P039"
-RULE_P041 = "P041"
 RULE_P042 = "P042"
 
 _SDR_FLAG_RE = re.compile(
@@ -1214,246 +1205,13 @@ def _check_p039(manifests: list[Path], root: Path) -> list[Finding]:
     return findings
 
 
-# ── P041: hard preflight gate in an SDR app ──────────────────────────────────
-
-#: The SDK ``App`` class attribute that opts preflight verdicts into aborting
-#: the run (``"hard"``) instead of logging-and-proceeding (``"soft"``).
-_PREFLIGHT_GATE_MODE_ATTR = "preflight_gate_mode"
-
-
-def _is_env_lookup_call(node: ast.Call) -> bool:
-    """Whether *node* calls a known environment-variable lookup.
-
-    Matches ``os.environ.get(...)``, ``os.getenv(...)``, and
-    ``os.environ.setdefault(...)`` — the shapes through which a deployment can
-    override the gate mode, per the rule's documentation.  Anything else
-    (``resolve_gate(...)``, ``config.get(...)``, …) returns a value this check
-    cannot see, so its arguments are not evidence of the runtime mode.
-    """
-    func = node.func
-    if isinstance(func, ast.Attribute):
-        if func.attr == "getenv" and isinstance(func.value, ast.Name):
-            return func.value.id == "os"
-        if (
-            func.attr in {"get", "setdefault"}
-            and isinstance(func.value, ast.Attribute)
-            and func.value.attr == "environ"
-            and isinstance(func.value.value, ast.Name)
-        ):
-            return func.value.value.id == "os"
-    return False
-
-
-def _is_unconditional_hard(
-    value: ast.AST, constants: dict[str, object] | None = None
-) -> bool:
-    """Whether *value* yields ``"hard"`` on the always-on / default path.
-
-    Semantic rather than structural: exempting every non-``Constant`` node lets
-    an *inverted* ternary (``"hard" if ENABLE_ATLAN_UPLOAD else "soft"`` — hard
-    exactly when upload is on), a both-arms-hard ternary, and an env default of
-    ``"hard"`` all escape, which are the very postures the rule audits.
-
-    Safe is ``"hard"`` in the *else* arm only — the documented run-mode split
-    ``"soft" if ENABLE_ATLAN_UPLOAD else "hard"``.  A nested conditional in an
-    env-var default (``os.environ.get(VAR, "soft" if ... else "hard")``) is the
-    same posture spelled through the override and stays silent too.
-    """
-    if isinstance(value, ast.Constant):
-        return value.value == "hard"
-    if isinstance(value, ast.IfExp):
-        # Hard in the true arm (or in both) is unconditional-in-effect; hard
-        # only in the else arm is the recommended run-mode-differentiated split.
-        return _is_unconditional_hard(value.body, constants)
-    if isinstance(value, ast.Call):
-        # An env-var override: `os.environ.get("ATLAN_PREFLIGHT_GATE_MODE",
-        # "hard")` is hard on every deployment that does not set the var.
-        # Only the known env-lookup callees are read this way — for any other
-        # call the returned value is opaque to a static check, so a constant
-        # argument (a helper's `default="hard"`, say) proves nothing about the
-        # mode the app actually runs with.
-        if not _is_env_lookup_call(value):
-            return False
-        return any(
-            _is_unconditional_hard(arg, constants)
-            for arg in [*value.args[1:], *(kw.value for kw in value.keywords)]
-        )
-    if isinstance(value, ast.Name) and constants is not None:
-        # A module-level `MODE = "hard"` indirection is still always hard;
-        # only an unambiguous single binding is resolved (no flow analysis).
-        return constants.get(value.id) == "hard"
-    if isinstance(value, ast.BoolOp) and isinstance(value.op, ast.Or):
-        # `os.environ.get(VAR) or "hard"` — the or-default idiom, semantically
-        # identical to the `.get(VAR, "hard")` form above.
-        return _is_unconditional_hard(value.values[-1], constants)
-    return False
-
-
-def _string_constants(body: list[ast.stmt]) -> dict[str, object]:
-    """``NAME = "literal"`` bindings among the straight-line statements of *body*.
-
-    Used for module bodies AND class bodies: ``preflight_gate_mode`` is
-    conventionally a class attribute, so ``class C: MODE = "hard"`` followed by
-    ``preflight_gate_mode = MODE`` in the same body is at least as natural as
-    the module-level form.
-
-    Deliberately not constant propagation — only direct children of *body* are
-    considered, so control flow is straight-line and the last write wins. A name
-    ever assigned a computed value is dropped rather than guessed at.
-    """
-    seen: dict[str, object] = {}
-    poisoned: set[str] = set()
-    for stmt in body:
-        if isinstance(stmt, ast.Assign) and len(stmt.targets) == 1:
-            target = stmt.targets[0]
-        elif isinstance(stmt, ast.AnnAssign) and stmt.value is not None:
-            target = stmt.target  # `MODE: str = "hard"`
-        else:
-            continue
-        if not isinstance(target, ast.Name):
-            continue
-        name = target.id
-        if isinstance(stmt.value, ast.Constant):
-            # Straight-line statements only, so the last write wins:
-            # `MODE = "soft"` then `MODE = "hard"` is deterministically hard.
-            seen[name] = stmt.value.value
-        else:
-            poisoned.add(name)  # a computed value — do not guess at it
-    return {k: v for k, v in seen.items() if k not in poisoned}
-
-
-def _gate_target_names(targets: list[ast.expr]) -> list[str]:
-    return [t.id for t in targets if isinstance(t, ast.Name)] + [
-        t.attr for t in targets if isinstance(t, ast.Attribute)
-    ]
-
-
-def _gate_assignments(stmts: list[ast.stmt]) -> list[tuple[ast.stmt, ast.expr]]:
-    """``(node, value)`` for each ``preflight_gate_mode`` assignment in *stmts*."""
-    out: list[tuple[ast.stmt, ast.expr]] = []
-    for stmt in stmts:
-        for node in ast.walk(stmt):
-            if isinstance(node, ast.Assign):
-                targets, value = list(node.targets), node.value
-            elif isinstance(node, ast.AnnAssign):
-                targets, value = [node.target], node.value
-            else:
-                continue
-            if value is None:
-                continue
-            if _PREFLIGHT_GATE_MODE_ATTR in _gate_target_names(targets):
-                out.append((node, value))
-    return out
-
-
-def _run_mode_split_exempt(
-    tree: ast.Module, constants: dict[str, object] | None = None
-) -> set[int]:
-    """ids of gate assigns that are the ``else`` arm of an if/else run-mode split.
-
-    ``if ENABLE_ATLAN_UPLOAD: ... = "soft"`` / ``else: ... = "hard"`` is the
-    documented posture spelled across two statements instead of as a ternary —
-    an ordinary style choice once the branches grow past one line — and must not
-    be flagged.  The polarity check mirrors the ternary's: ``"hard"`` on the
-    *true* arm is the inverted posture and still fires, as does both-arms-hard.
-    """
-    exempt: set[int] = set()
-    for node in ast.walk(tree):
-        if not isinstance(node, ast.If) or not node.orelse:
-            continue
-        body = _gate_assignments(node.body)
-        orelse = _gate_assignments(node.orelse)
-        if not body or not orelse:
-            continue
-        if any(_is_unconditional_hard(value, constants) for _n, value in body):
-            continue  # hard on the true arm — inverted/both-hard, keep firing
-        for assign, value in orelse:
-            if _is_unconditional_hard(value, constants):
-                exempt.add(id(assign))
-    return exempt
-
-
-def _check_p041(paths: list[Path], root: Path) -> list[Finding]:
-    """P041: an SDR app must not hard-code ``preflight_gate_mode = "hard"``.
-
-    Flags an assignment to ``preflight_gate_mode`` (plain or annotated) whose
-    value is ``"hard"`` on the always-on or default path — see
-    :func:`_is_unconditional_hard`.  The documented run-mode-differentiated
-    posture (``"soft" if ENABLE_ATLAN_UPLOAD else "hard"``, env-overridable via
-    ``ATLAN_PREFLIGHT_GATE_MODE``) is never flagged, in either its ternary or
-    its ``if``/``else`` spelling.
-    """
-    findings: list[Finding] = []
-    for path in paths:
-        try:
-            tree = ast.parse(path.read_text(encoding="utf-8"))
-        except (OSError, SyntaxError, ValueError):
-            continue
-        try:
-            rel = str(path.relative_to(root))
-        except ValueError:
-            rel = str(path)
-        module_constants = _string_constants(tree.body)
-        # `preflight_gate_mode` is conventionally a class attribute, so a
-        # same-class `MODE = "hard"` shadows the module-level one.
-        class_constants: dict[int, dict[str, object]] = {}
-        for cls in ast.walk(tree):
-            if not isinstance(cls, ast.ClassDef):
-                continue
-            merged = {**module_constants, **_string_constants(cls.body)}
-            for item in ast.walk(cls):
-                class_constants[id(item)] = merged
-        split_exempt = _run_mode_split_exempt(tree, module_constants)
-        for node in ast.walk(tree):
-            if isinstance(node, ast.Assign):
-                targets = list(node.targets)
-                value = node.value
-            elif isinstance(node, ast.AnnAssign):
-                targets = [node.target]
-                value = node.value
-            else:
-                continue
-            if value is None:
-                continue
-            if _PREFLIGHT_GATE_MODE_ATTR not in _gate_target_names(targets):
-                continue
-            if id(node) in split_exempt:
-                continue
-            if _is_unconditional_hard(
-                value, class_constants.get(id(node), module_constants)
-            ):
-                findings.append(
-                    Finding(
-                        rule_id=RULE_P041,
-                        file=rel,
-                        line=node.lineno,
-                        column=1,
-                        message=(
-                            f"{rel}:{node.lineno}: preflight_gate_mode is "
-                            "unconditionally 'hard' in an SDR app. In agent mode the "
-                            "app resolves config through the customer's secret "
-                            "store, and non-secret values (e.g. a database name for "
-                            "a schema-existence check) are rightly not mirrored "
-                            "there — the preflight check then fails spuriously and "
-                            "the hard gate aborts the whole workflow. Derive the "
-                            "gate from the run mode instead (e.g. "
-                            "preflight_gate_mode = 'soft' if ENABLE_ATLAN_UPLOAD "
-                            "else 'hard') and keep it env-overridable via "
-                            "ATLAN_PREFLIGHT_GATE_MODE, until SDK-side run-mode-"
-                            "differentiated gate enforcement lands."
-                        ),
-                    )
-                )
-    return findings
-
-
 def scan_path(path: Path, root: Path) -> list[Finding]:  # noqa: ARG001
     """No-op: the SDR checks require cross-artifact analysis; use scan_all."""
     return []
 
 
 def scan_all(paths: list[Path], root: Path) -> list[Finding]:
-    """Check the SDR-readiness rules (P029, P030, P037–P039, P041, P042).
+    """Check the SDR-readiness rules (P029, P030, P037–P039, P042).
 
     Parameters
     ----------
@@ -1461,8 +1219,7 @@ def scan_all(paths: list[Path], root: Path) -> list[Finding]:
         Python source files to inspect (as returned by :func:`discover`).
         These are the files checked by P030/P042 for a ``self.upload(`` call /
         upload-bridge shape, by P037 for the credential-resolution shape, by
-        P038 for the object-store prefix rooting, and by P041 for the
-        preflight-gate posture.
+        P038 for the object-store prefix rooting.
     root:
         Repo root — used to locate ``atlan.yaml`` and ``app/generated/`` (P039
         also inspects the generated ``_input.py`` contract models).
@@ -1479,7 +1236,6 @@ def scan_all(paths: list[Path], root: Path) -> list[Finding]:
     findings.extend(_check_p037(paths, root))
     findings.extend(_check_p038(paths, root))
     findings.extend(_check_p039(manifests, root))
-    findings.extend(_check_p041(paths, root))
     return findings
 
 
@@ -1489,8 +1245,7 @@ main = make_cli_main(
         "SDR-readiness checks — manifest agent_json slot (P029), "
         "upload call presence / no-op bridge stubs (P030), agent-aware "
         "credential resolution (P037), object-store prefix rooting (P038), "
-        "agent_json input-contract consumption (P039), and preflight-gate "
-        "posture (P041)."
+        "and agent_json input-contract consumption (P039)."
     ),
 )
 

--- a/packages/conformance/conformance/suite/rules/sdr.py
+++ b/packages/conformance/conformance/suite/rules/sdr.py
@@ -1,7 +1,7 @@
-"""SDR-readiness rule definitions (P029, P030, P037, P038, P039, P041, P042).
+"""SDR-readiness rule definitions (P029, P030, P037, P038, P039, P042).
 
 Apps that declare ``self_deployed_runtime: true`` in ``atlan.yaml`` must satisfy
-seven structural invariants before they can be considered SDR-ready:
+six structural invariants before they can be considered SDR-ready:
 
 * ``P029`` — every ``manifest.json`` under ``app/generated/`` must include an
   ``agent_json`` key inside ``dag.extract.inputs.args``.  Missing this field
@@ -45,12 +45,6 @@ seven structural invariants before they can be considered SDR-ready:
   / 0 assets; observed for a BI connector in fleet testing).  Contracts that
   subclass the SDK ``*ExtractionInput`` family or allow extra fields are exempt.
 
-* ``P041`` — an SDR app that hard-codes ``preflight_gate_mode = "hard"``.  In
-  SDR (agent) mode, preflight checks that depend on *non-secret* config (e.g. a
-  database/schema existence check) can fail because customers rightly do not
-  mirror non-sensitive values into the secret store; a hard gate then aborts
-  the whole workflow (observed for a query-engine connector in fleet testing).
-  Suggest-only: prefer a run-mode-differentiated posture.
 
 * ``P042`` — an app whose custom ``upload_to_atlan`` bridge *does* transfer, with
   no ``self.upload()`` anywhere.  Split out of P030 because the failure is
@@ -520,110 +514,6 @@ RULES: tuple[RuleDefinition, ...] = (
         help_uri=(
             "https://github.com/atlanhq/application-sdk/blob/main/"
             "packages/conformance/conformance/docs/rules/prescriptions.md#p039"
-        ),
-    ),
-    RuleDefinition(
-        id="P041",
-        scope=RuleScope.APP,
-        name="SdrHardPreflightGate",
-        tier=EnforcementTier.WARN,
-        mechanism=RuleMechanism.STATIC,
-        category="sdr-readiness",
-        autofixable=False,
-        orthogonal_gate="tests",
-        since="0.18.0",
-        rationale=(
-            "In SDR (agent) mode the app resolves its configuration through the "
-            "customer's secret store, and customers rightly mirror only *secrets* "
-            "into it — non-sensitive values (database names, schema filters) are "
-            "often absent. Preflight checks that depend on such non-secret config "
-            "then report NOT_READY even though the run would succeed. Most "
-            "connectors run the preflight gate non-fatally, but an app that "
-            "hard-codes preflight_gate_mode = 'hard' aborts the entire workflow on "
-            "that spurious verdict (observed for a query-engine connector in fleet "
-            "testing). Until the SDK differentiates gate enforcement by run mode, "
-            "the interim app-side posture is to soften the gate for self-deployed "
-            "runs — e.g. preflight_gate_mode = 'soft' if ENABLE_ATLAN_UPLOAD else "
-            "'hard' — keeping it env-overridable via ATLAN_PREFLIGHT_GATE_MODE."
-        ),
-        short_description=(
-            "SDR app hard-codes preflight_gate_mode = 'hard' — non-secret-config "
-            "preflight failures abort agent-mode workflows"
-        ),
-        full_description=(
-            "For apps declaring ``self_deployed_runtime: true`` in ``atlan.yaml``,\n"
-            'an unconditional ``preflight_gate_mode = "hard"`` assignment is\n'
-            "flagged.\n"
-            "\n"
-            "The SDK's preflight gate (``App.preflight_gate_mode``) defaults to\n"
-            '``"soft"`` — a NOT_READY verdict is logged (``would_block``) but the\n'
-            'run proceeds.  An app opts into ``"hard"`` when its checks are\n'
-            "trusted to gate real runs.  That trust assumption breaks in SDR\n"
-            "(agent) mode: configuration is resolved through the *customer's*\n"
-            "secret store, and customers rightly mirror only secrets into it —\n"
-            "non-sensitive values (a database name for a schema-existence check,\n"
-            "for example) are commonly absent.  The preflight check then fails for\n"
-            "a reason unrelated to the run's actual viability, and a hard gate\n"
-            "aborts the whole workflow (observed for a query-engine connector in\n"
-            "fleet testing; connectors with soft gates ran the same checks\n"
-            "non-fatally and succeeded).\n"
-            "\n"
-            "This is suggest-only (WARN): a hard gate is a legitimate posture for\n"
-            "cloud-hosted runs, and the right long-term fix is SDK-side — gate\n"
-            "enforcement differentiated by run mode, so the same app can be hard\n"
-            "in cloud mode and soft in agent mode.  Until then:\n"
-            "\n"
-            "**Remediation (interim app-side posture):** derive the gate mode from\n"
-            "the run mode instead of hard-coding it, e.g.::\n"
-            "\n"
-            '    preflight_gate_mode = "soft" if ENABLE_ATLAN_UPLOAD else "hard"\n'
-            "\n"
-            "and keep it env-overridable (the SDK's ``ATLAN_PREFLIGHT_GATE_MODE``\n"
-            "env var takes precedence over the class attribute, so operators can\n"
-            "restore the hard gate per deployment).\n"
-            "\n"
-            "**What is and is not flagged.**  The exemption is semantic, not\n"
-            'structural: ``"hard"`` is safe only on the *else* path.\n'
-            "\n"
-            "Silent on:\n"
-            "\n"
-            '* ``preflight_gate_mode = "soft" if ENABLE_ATLAN_UPLOAD else "hard"``\n'
-            "  and its ``if``/``else`` statement spelling (an ordinary style\n"
-            "  choice once the branches grow past one line);\n"
-            '* ``os.environ.get("ATLAN_PREFLIGHT_GATE_MODE", <that ternary>)`` —\n'
-            "  the same posture spelled through the override.\n"
-            "\n"
-            "Still flagged:\n"
-            "\n"
-            '* a plain ``preflight_gate_mode = "hard"``;\n'
-            '* the inverted ternary ``"hard" if ENABLE_ATLAN_UPLOAD else "soft"``\n'
-            "  — hard exactly when upload is on, the reverse of the intent;\n"
-            "* a both-arms-hard ternary (unconditional in a conditional's\n"
-            "  clothing);\n"
-            '* ``os.environ.get("ATLAN_PREFLIGHT_GATE_MODE", "hard")`` and\n'
-            '  ``os.environ.get("ATLAN_PREFLIGHT_GATE_MODE") or "hard"`` — hard on\n'
-            "  every deployment that leaves the variable unset.  Only the known\n"
-            "  env-lookup callees (``os.environ.get`` / ``os.getenv`` /\n"
-            "  ``os.environ.setdefault``) have their default read this way; an\n"
-            "  arbitrary helper call (``resolve_gate(env, default='hard')``) is\n"
-            "  opaque to a static check — its constant default says nothing about\n"
-            "  the value it returns, so it is *not* flagged;\n"
-            '* one hop of constant indirection (``MODE = "hard"`` /\n'
-            "  ``preflight_gate_mode = MODE``), at module level **or** in the\n"
-            "  same class body — ``preflight_gate_mode`` is conventionally a\n"
-            "  class attribute, so the class-body form is at least as common.\n"
-            "  The name resolves when every straight-line assignment to it in\n"
-            "  that body is a string literal; the last one wins (so\n"
-            '  ``MODE = "soft"`` followed by ``MODE = "hard"`` still fires). A\n'
-            "  name ever assigned a computed value is not resolved at all.\n"
-            "\n"
-            "Known limit: a condition written with inverted polarity\n"
-            '(``"hard" if not ENABLE_ATLAN_UPLOAD else "soft"``) reads as the\n'
-            "true-arm shape and is flagged — suppress it inline with the reason.\n"
-        ),
-        help_uri=(
-            "https://github.com/atlanhq/application-sdk/blob/main/"
-            "packages/conformance/conformance/docs/rules/prescriptions.md#p041"
         ),
     ),
     RuleDefinition(

--- a/packages/conformance/conformance/tools/generate_rule_docs.py
+++ b/packages/conformance/conformance/tools/generate_rule_docs.py
@@ -160,7 +160,7 @@ _SERIES_META: list[SeriesMeta] = [
             "`suite.checks.error_seam` (P043/P045, scans test files too), "
             "`suite.checks.determinism` (P020–P024, P031), "
             "`suite.checks.app_name_alignment` (P025), "
-            "`suite.checks.sdr` (P029/P030, P037/P038/P039, P041), "
+            "`suite.checks.sdr` (P029/P030, P037/P038/P039, P042), "
             "`suite.checks.transform_templates` (P040, scans template YAML) "
             "(all AST-based / cross-artifact)"
         ),

--- a/packages/conformance/tests/test_catalog.py
+++ b/packages/conformance/tests/test_catalog.py
@@ -319,8 +319,6 @@ def test_catalog_app_scoped_rules_are_the_expected_set() -> None:
     # duckdb; the SDK is the publisher of the [sql]/[incremental] extras.
     # P040: transform-template reserved keywords — only connector apps ship
     # transform YAML templates consumed by the query transformer.
-    # P041: hard preflight gate in an SDR app — gated on self_deployed_runtime,
-    # which the SDK never declares (fleet SDR sweep).
     # P042: hand-rolled upload_to_atlan bridge in an SDR app — same gating as
     # P030, which it was split out of.
     # P043/P045: error-seam — apps must build control flow on the SDK's public
@@ -333,7 +331,6 @@ def test_catalog_app_scoped_rules_are_the_expected_set() -> None:
         "B007",
         "D010",
         "P040",
-        "P041",
         "P042",
         "P043",
         "P044",
@@ -561,9 +558,6 @@ def test_catalog_p_series_present() -> None:
     P040 is TransformTemplateReservedKeyword — an unquoted DuckDB reserved
     keyword used as an identifier in a transform SQL template (ParserException
     at runtime on the daft-less SDK >= 3.22 runtime; fleet SDR sweep).
-    P041 is SdrHardPreflightGate — an SDR app that unconditionally sets
-    preflight_gate_mode = "hard", aborting agent-mode workflows on
-    non-secret-config preflight failures (fleet SDR sweep).
     P042 is SdrHandRolledUploadBridge — a working custom upload_to_atlan
     standing in for App.upload(), split out of P030 so the "bytes move but the
     SDK contract is reimplemented" shape carries its own severity, its own
@@ -619,7 +613,6 @@ def test_catalog_p_series_present() -> None:
         "P038",
         "P039",
         "P040",
-        "P041",
         "P042",
         "P043",
         "P044",

--- a/packages/conformance/tests/test_sdr.py
+++ b/packages/conformance/tests/test_sdr.py
@@ -1257,99 +1257,6 @@ def test_p030_absence_message_covers_sqlapp_run_delegation(tmp_path: Path) -> No
     assert "full-DAG e2e" in p030[0].message
 
 
-# ── P041: hard preflight gate in an SDR app ──────────────────────────────────
-
-
-def test_p041_rule_metadata() -> None:
-    rule = get_rule("P041")
-    assert rule.name == "SdrHardPreflightGate"
-    assert rule.tier == EnforcementTier.WARN
-    assert rule.scope == RuleScope.APP
-    assert rule.autofixable is False
-    assert rule.rationale.strip()
-    assert rule.since == "0.18.0"
-    assert rule.category == "sdr-readiness"
-
-
-_APP_WITH_UPLOAD = (
-    "class Connector:\n    async def run(self):\n        await self.upload('o')\n"
-)
-
-
-def test_p041_fires_on_unconditional_hard_gate(tmp_path: Path) -> None:
-    _write(
-        tmp_path,
-        {
-            "atlan.yaml": _SDR_ATLAN_YAML,
-            "app/connector.py": _APP_WITH_UPLOAD,
-            "app/main.py": ("class MyApp(App):\n" '    preflight_gate_mode = "hard"\n'),
-        },
-    )
-    p041 = [f for f in _run(tmp_path) if f.rule_id == "P041"]
-    assert len(p041) == 1
-    assert p041[0].file == "app/main.py"
-    assert p041[0].line == 2
-    assert "ATLAN_PREFLIGHT_GATE_MODE" in p041[0].message
-
-
-def test_p041_fires_on_annotated_assignment(tmp_path: Path) -> None:
-    _write(
-        tmp_path,
-        {
-            "atlan.yaml": _SDR_ATLAN_YAML,
-            "app/connector.py": _APP_WITH_UPLOAD,
-            "app/main.py": (
-                "class MyApp(App):\n" '    preflight_gate_mode: str = "hard"\n'
-            ),
-        },
-    )
-    assert any(f.rule_id == "P041" for f in _run(tmp_path))
-
-
-def test_p041_silent_on_soft_gate(tmp_path: Path) -> None:
-    _write(
-        tmp_path,
-        {
-            "atlan.yaml": _SDR_ATLAN_YAML,
-            "app/connector.py": _APP_WITH_UPLOAD,
-            "app/main.py": ("class MyApp(App):\n" '    preflight_gate_mode = "soft"\n'),
-        },
-    )
-    assert not any(f.rule_id == "P041" for f in _run(tmp_path))
-
-
-def test_p041_silent_on_run_mode_conditional(tmp_path: Path) -> None:
-    """The recommended interim posture — a run-mode conditional — never fires."""
-    _write(
-        tmp_path,
-        {
-            "atlan.yaml": _SDR_ATLAN_YAML,
-            "app/connector.py": _APP_WITH_UPLOAD,
-            "app/main.py": (
-                "class MyApp(App):\n"
-                "    preflight_gate_mode = (\n"
-                '        "soft" if ENABLE_ATLAN_UPLOAD else "hard"\n'
-                "    )\n"
-            ),
-        },
-    )
-    assert not any(f.rule_id == "P041" for f in _run(tmp_path))
-
-
-def test_p041_silent_on_non_sdr_app(tmp_path: Path) -> None:
-    _write(
-        tmp_path,
-        {
-            "atlan.yaml": _NON_SDR_ATLAN_YAML,
-            "app/main.py": ("class MyApp(App):\n" '    preflight_gate_mode = "hard"\n'),
-        },
-    )
-    assert not any(f.rule_id == "P041" for f in _run(tmp_path))
-
-
-# ── Regression: evidence must come from the scope being graded ───────────────
-
-
 def test_p030_absence_not_cleared_by_a_comment_mentioning_self_upload(
     tmp_path: Path,
 ) -> None:
@@ -1509,75 +1416,8 @@ def test_p030_real_fleet_bridge_shapes_are_not_flagged(tmp_path: Path) -> None:
         assert not any(f.rule_id == "P030" for f in _run(root)), body
 
 
-def test_p041_silent_on_if_else_run_mode_split(tmp_path: Path) -> None:
-    """The if/else spelling of the posture the rule's own remediation recommends.
-
-    Semantically identical to the documented ternary — an ordinary style choice
-    once the branches grow past one line.
-    """
-    _write(
-        tmp_path,
-        {
-            "atlan.yaml": _SDR_ATLAN_YAML,
-            "app/connector.py": (
-                "class Connector:\n"
-                "    def configure(self):\n"
-                "        if ENABLE_ATLAN_UPLOAD:\n"
-                "            self.preflight_gate_mode = 'soft'\n"
-                "        else:\n"
-                "            self.preflight_gate_mode = 'hard'\n"
-            ),
-        },
-    )
-    assert not any(f.rule_id == "P041" for f in _run(tmp_path))
-
-
-def test_p041_fires_on_inverted_and_both_hard_and_env_default(
-    tmp_path: Path,
-) -> None:
-    """Structural exemption of every non-Constant let these three escape."""
-    cases = {
-        "inverted": "'hard' if ENABLE_ATLAN_UPLOAD else 'soft'",
-        "both_hard": "'hard' if FLAG else 'hard'",
-        "env_default": "os.environ.get('ATLAN_PREFLIGHT_GATE_MODE', 'hard')",
-    }
-    for label, expr in cases.items():
-        root = tmp_path / label
-        _write(
-            root,
-            {
-                "atlan.yaml": _SDR_ATLAN_YAML,
-                "app/connector.py": (
-                    "class Connector:\n    preflight_gate_mode = " + expr + "\n"
-                ),
-            },
-        )
-        assert any(f.rule_id == "P041" for f in _run(root)), label
-
-
-def test_p041_silent_on_env_override_of_the_run_mode_split(tmp_path: Path) -> None:
-    """The full documented posture: env-overridable, defaulting to the split."""
-    _write(
-        tmp_path,
-        {
-            "atlan.yaml": _SDR_ATLAN_YAML,
-            "app/connector.py": (
-                "class Connector:\n"
-                "    preflight_gate_mode = os.environ.get(\n"
-                "        'ATLAN_PREFLIGHT_GATE_MODE',\n"
-                "        'soft' if ENABLE_ATLAN_UPLOAD else 'hard',\n"
-                "    )\n"
-            ),
-        },
-    )
-    assert not any(f.rule_id == "P041" for f in _run(tmp_path))
-
-
-# ── Round-2 regressions ──────────────────────────────────────────────────────
-
-
 def test_sdr_scan_survives_non_utf8_files(tmp_path: Path) -> None:
-    """_is_sdr_app gates P030 and P041 — one bad byte must not take them out."""
+    """_is_sdr_app gates the SDR rules — one bad byte must not take them out."""
     _write(
         tmp_path,
         {
@@ -1664,69 +1504,6 @@ def test_p030_two_hop_same_class_delegation_is_not_a_stub(tmp_path: Path) -> Non
     assert not any(f.rule_id == "P030" for f in _run(tmp_path))
 
 
-def test_p041_fires_on_or_default_and_name_indirection(tmp_path: Path) -> None:
-    """The or-default env idiom and one hop of module-level indirection."""
-    cases = {
-        "or_default": (
-            "import os\n"
-            "class Connector:\n"
-            "    preflight_gate_mode = os.environ.get('ATLAN_PREFLIGHT_GATE_MODE')"
-            " or 'hard'\n"
-        ),
-        "name_indirection": (
-            "MODE = 'hard'\nclass Connector:\n    preflight_gate_mode = MODE\n"
-        ),
-    }
-    for label, src in cases.items():
-        root = tmp_path / label
-        _write(root, {"atlan.yaml": _SDR_ATLAN_YAML, "app/connector.py": src})
-        assert any(f.rule_id == "P041" for f in _run(root)), label
-
-
-def test_p041_silent_on_or_default_soft(tmp_path: Path) -> None:
-    _write(
-        tmp_path,
-        {
-            "atlan.yaml": _SDR_ATLAN_YAML,
-            "app/connector.py": (
-                "import os\n"
-                "class Connector:\n"
-                "    preflight_gate_mode = os.environ.get('ATLAN_PREFLIGHT_GATE_MODE')"
-                " or 'soft'\n"
-            ),
-        },
-    )
-    assert not any(f.rule_id == "P041" for f in _run(tmp_path))
-
-
-def test_p041_silent_on_helper_call_with_hard_default(tmp_path: Path) -> None:
-    """An arbitrary helper call is opaque — its `default="hard"` proves nothing.
-
-    Only the documented env-lookup callees (`os.environ.get` / `os.getenv`)
-    have their default read as the deployment mode; for any other callable the
-    returned value is invisible to a static check, so a constant keyword must
-    not fire the rule.
-    """
-    cases = {
-        "helper_kw_default": (
-            "class Connector:\n"
-            "    preflight_gate_mode = resolve_gate(env_mode, default='hard')\n"
-        ),
-        "helper_positional_default": (
-            "class Connector:\n"
-            "    preflight_gate_mode = resolve_gate(env_mode, 'hard')\n"
-        ),
-        "config_getter": (
-            "class Connector:\n"
-            "    preflight_gate_mode = self.config.get('gate_mode', 'hard')\n"
-        ),
-    }
-    for label, src in cases.items():
-        root = tmp_path / label
-        _write(root, {"atlan.yaml": _SDR_ATLAN_YAML, "app/connector.py": src})
-        assert not any(f.rule_id == "P041" for f in _run(root)), label
-
-
 def test_p030_compound_upload_names_still_need_a_store(tmp_path: Path) -> None:
     """`upload` as one token of a compound name proves nothing on its own.
 
@@ -1789,39 +1566,6 @@ def test_p030_bare_sdk_storage_helpers_are_transfers(tmp_path: Path) -> None:
         assert not any(f.rule_id == "P030" for f in _run(root)), body
 
 
-def test_p041_fires_on_class_body_constant_indirection(tmp_path: Path) -> None:
-    """`preflight_gate_mode` is conventionally a class attribute."""
-    _write(
-        tmp_path,
-        {
-            "atlan.yaml": _SDR_ATLAN_YAML,
-            "app/connector.py": (
-                "class Connector:\n"
-                "    MODE = 'hard'\n"
-                "    preflight_gate_mode = MODE\n"
-            ),
-        },
-    )
-    assert any(f.rule_id == "P041" for f in _run(tmp_path))
-
-
-def test_p041_fires_on_deterministic_reassigned_constant(tmp_path: Path) -> None:
-    """Two straight-line module assignments have a deterministic final value."""
-    _write(
-        tmp_path,
-        {
-            "atlan.yaml": _SDR_ATLAN_YAML,
-            "app/connector.py": (
-                "MODE = 'soft'\n"
-                "MODE = 'hard'\n"
-                "class Connector:\n"
-                "    preflight_gate_mode = MODE\n"
-            ),
-        },
-    )
-    assert any(f.rule_id == "P041" for f in _run(tmp_path))
-
-
 def test_p030_positional_store_argument_is_a_transfer(tmp_path: Path) -> None:
     """The SDK's own callers pass the store positionally."""
     _write(
@@ -1836,19 +1580,3 @@ def test_p030_positional_store_argument_is_a_transfer(tmp_path: Path) -> None:
         },
     )
     assert not any(f.rule_id == "P030" for f in _run(tmp_path))
-
-
-def test_p041_fires_on_annotated_constant_indirection(tmp_path: Path) -> None:
-    """`MODE: str = "hard"` is the annotated spelling of a resolved constant."""
-    _write(
-        tmp_path,
-        {
-            "atlan.yaml": _SDR_ATLAN_YAML,
-            "app/connector.py": (
-                "MODE: str = 'hard'\n"
-                "class Connector:\n"
-                "    preflight_gate_mode = MODE\n"
-            ),
-        },
-    )
-    assert any(f.rule_id == "P041" for f in _run(tmp_path))


### PR DESCRIPTION
## Summary

- remove the P041 `SdrHardPreflightGate` conformance rule and checker
- remove its tests and catalog registration
- update conformance guidance and regenerate rule documentation

## Why

P041 assumed SDR preflight checks could fail because non-secret configuration was unavailable from the customer secret store. Secret access in the preflight activity has since been optimized, so hard preflight mode no longer needs this SDR-specific conformance restriction.

## Verification

- `pytest packages/conformance/tests/test_catalog.py packages/conformance/tests/test_sdr.py packages/conformance/tests/test_generate_rule_docs.py -q` (145 passed)
- pre-commit on all changed files
- generated rule docs `--check`
- `git diff --check`