### PR TITLE
feat(e2e): assert the executed DAG is the app under test's (FND-129)

### DIFF
--- a/application_sdk/testing/e2e/_errors.py
+++ b/application_sdk/testing/e2e/_errors.py
@@ -138,6 +138,36 @@ class ManifestDagMissingError(DataIntegrityError):
 
 
 @dataclass(kw_only=True)
+class DeployedManifestMismatchError(DataIntegrityError):
+    """The DAG AE published at submit is not the DAG the app under test declares.
+
+    The version check upstream of this one asserts the right *image* is
+    installed. This asserts the right *graph* ran, which is a different claim:
+    at submit, Heracles re-fetches the manifest from the tenant-deployed pod and
+    calls ``CreateVersion`` + ``PublishVersion`` on the harness's own slug,
+    superseding the seed version. So the graph that executes is the pod's, and
+    until this check nothing named the difference — a leg whose assertions all
+    pass could have been exercising a graph the repo never built.
+
+    Raised only on a positive finding: the read got through, AE's published
+    version provably superseded the harness's seed, and the node identities
+    still disagree. Every unanswerable outcome (an unreadable response, a
+    version that never superseded, a connector with no manifest to compare)
+    logs and continues — see
+    :meth:`~application_sdk.testing.e2e.base.BaseE2ETest._assert_deployed_manifest_matches`.
+
+    ``observed`` carries the rendered node-set / per-node diff
+    (:meth:`~application_sdk.testing.e2e._manifest_identity.ManifestIdentityDiff.render`)
+    so the failure names which nodes diverged rather than only that some did.
+    """
+
+    code: ClassVar[str] = "DATA_INTEGRITY_DEPLOYED_MANIFEST_MISMATCH"
+    expectation: str | None = (
+        "the published DAG's node identities match the local manifest's"
+    )
+
+
+@dataclass(kw_only=True)
 class AdminRoleNotResolvedError(PreconditionError):
     """The pyatlan role cache could not resolve the ``$admin`` role GUID."""
 

--- a/application_sdk/testing/e2e/_manifest_identity.py
+++ b/application_sdk/testing/e2e/_manifest_identity.py
@@ -1,0 +1,214 @@
+"""Node-identity comparison between the app's manifest and the DAG AE published.
+
+Verifying the installed *version* says "the right image is on the tenant". This
+module answers the stronger question: **is the graph that ran the graph we
+built?**
+
+The two are not the same check. At AE submit, Heracles re-fetches the manifest
+from the tenant-deployed pod and calls ``CreateVersion`` + ``PublishVersion`` on
+the same slug the harness seeded, superseding the harness's own seed version. So
+what executes is the pod's DAG, not the one the harness uploaded — and nothing
+downstream ever names the difference.
+
+Why *identity* and not the DAG blob: template variables are substituted on the
+way through (Heracles' ``substituteTemplateVars``, and the harness's own
+``{deployment_name}`` / mustache fills before that), so a byte comparison of the
+two DAGs fails on every run. What survives substitution is each node's identity
+— its name, the app that runs it, and the workflow type dispatched — which is
+exactly what "the same graph" turns on.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+APP_NAME_PLACEHOLDER = "{app_name}"
+"""Manifest placeholder for the connector's own app name.
+
+Both sides of the comparison resolve it against the connector short name, so a
+manifest that still ships the placeholder and a copy whose placeholder was
+already substituted compare equal rather than reading as a changed node.
+"""
+
+
+@dataclass(frozen=True)
+class DagNodeIdentity:
+    """What a DAG node is, stripped of everything substitution can rewrite.
+
+    Attributes:
+        name: The node's key in the DAG object (``extract``, ``publish``, ...).
+        app_name: App the node is dispatched to. Empty when the node declares
+            none — absence is not treated as a mismatch, see
+            :func:`compare_node_identities`.
+        workflow_type: Temporal workflow type the node runs
+            (``inputs.workflow_type``). Empty when the node declares none.
+    """
+
+    name: str
+    app_name: str = ""
+    workflow_type: str = ""
+
+    def describe(self) -> str:
+        """``extract (app=mysql, workflow_type=MySQLWorkflow)`` — fields it has."""
+        parts = [f"app={self.app_name}" if self.app_name else "app=?"]
+        parts.append(
+            f"workflow_type={self.workflow_type}"
+            if self.workflow_type
+            else "workflow_type=?"
+        )
+        return f"{self.name} ({', '.join(parts)})"
+
+
+@dataclass(frozen=True)
+class NodeIdentityChange:
+    """One node present on both sides whose identity fields disagree."""
+
+    name: str
+    expected: DagNodeIdentity
+    actual: DagNodeIdentity
+
+
+@dataclass(frozen=True)
+class ManifestIdentityDiff:
+    """Node-set + per-node-identity difference between two DAGs.
+
+    Attributes:
+        missing: Nodes the local manifest declares that the published DAG has
+            no node for.
+        unexpected: Nodes the published DAG carries that the local manifest
+            does not declare.
+        changed: Nodes on both sides whose ``app_name`` or ``workflow_type``
+            conflict.
+    """
+
+    missing: tuple[DagNodeIdentity, ...] = ()
+    unexpected: tuple[DagNodeIdentity, ...] = ()
+    changed: tuple[NodeIdentityChange, ...] = ()
+
+    @property
+    def matches(self) -> bool:
+        """True iff the two DAGs describe the same nodes doing the same work."""
+        return not (self.missing or self.unexpected or self.changed)
+
+    def render(self) -> str:
+        """Multi-line diff, one finding per line, ordered most-structural first.
+
+        Node-set differences come before field changes because they are the
+        stronger signal: a missing node means the deployed app does not run a
+        step this test asserts on, whereas a changed ``workflow_type`` means it
+        runs a different build of one.
+        """
+        if self.matches:
+            return "no difference"
+        lines: list[str] = []
+        for node in self.missing:
+            lines.append(
+                f"  - declared locally but absent from the published DAG: "
+                f"{node.describe()}"
+            )
+        for node in self.unexpected:
+            lines.append(
+                f"  + present in the published DAG but not declared locally: "
+                f"{node.describe()}"
+            )
+        for change in self.changed:
+            lines.append(
+                f"  ~ {change.name}: local {change.expected.describe()} "
+                f"vs published {change.actual.describe()}"
+            )
+        return "\n".join(lines)
+
+
+def _resolved(raw: object, app_name: str) -> str:
+    """A manifest string field as a comparable value.
+
+    Non-strings (a node that carries a number or ``null`` where a name belongs)
+    resolve to ``""`` — treated as "not declared", never as a mismatch, because
+    the shape is the manifest's problem, not this check's finding.
+    """
+    if not isinstance(raw, str):
+        return ""
+    value = raw.strip()
+    if app_name:
+        value = value.replace(APP_NAME_PLACEHOLDER, app_name)
+    return value
+
+
+def node_identities(
+    dag: Mapping[str, Any], *, app_name: str = ""
+) -> dict[str, DagNodeIdentity]:
+    """Reduce a DAG object to ``{node name: identity}``.
+
+    ``app_name`` is read from the node level first and from ``inputs`` second:
+    the manifest declares both and they agree, but only one may survive a given
+    producer's rewriting, so either alone is enough to identify the node.
+
+    Args:
+        dag: A manifest-shaped ``dag`` object — ``{node name: node}``.
+        app_name: Connector short name used to resolve
+            :data:`APP_NAME_PLACEHOLDER`. Pass it on both sides of a comparison
+            or on neither; passing it on one side only makes a placeholder read
+            as a change.
+
+    Returns:
+        One :class:`DagNodeIdentity` per node whose key is a string. Nodes that
+        are not objects still yield an identity (name only), so a malformed
+        node cannot silently disappear from the node set.
+    """
+    identities: dict[str, DagNodeIdentity] = {}
+    for name, node in dag.items():
+        if not isinstance(name, str):
+            continue
+        if not isinstance(node, dict):
+            identities[name] = DagNodeIdentity(name=name)
+            continue
+        inputs = node.get("inputs")
+        inputs = inputs if isinstance(inputs, dict) else {}
+        resolved_app = _resolved(node.get("app_name"), app_name) or _resolved(
+            inputs.get("app_name"), app_name
+        )
+        identities[name] = DagNodeIdentity(
+            name=name,
+            app_name=resolved_app,
+            workflow_type=_resolved(inputs.get("workflow_type"), app_name),
+        )
+    return identities
+
+
+def _conflicts(expected: str, actual: str) -> bool:
+    """True only when both sides declared a value and the values differ.
+
+    A field one side omits is not a finding. The published DAG's shape is
+    Heracles' to change, and reporting an omission as a mismatch would red every
+    leg on the day it stops echoing a field — a false failure about the harness,
+    dressed up as a claim about the app under test. The node *set* stays strict;
+    this tolerance applies only to the fields inside a node both sides agree
+    exists.
+    """
+    return bool(expected) and bool(actual) and expected != actual
+
+
+def compare_node_identities(
+    expected: Mapping[str, DagNodeIdentity],
+    actual: Mapping[str, DagNodeIdentity],
+) -> ManifestIdentityDiff:
+    """Diff two identity maps built by :func:`node_identities`.
+
+    Args:
+        expected: Identities from the local manifest (the app under test).
+        actual: Identities from the DAG AE published at submit.
+
+    Returns:
+        A :class:`ManifestIdentityDiff`; check :attr:`~ManifestIdentityDiff.matches`.
+    """
+    missing = tuple(expected[name] for name in sorted(set(expected) - set(actual)))
+    unexpected = tuple(actual[name] for name in sorted(set(actual) - set(expected)))
+    changed = tuple(
+        NodeIdentityChange(name=name, expected=expected[name], actual=actual[name])
+        for name in sorted(set(expected) & set(actual))
+        if _conflicts(expected[name].app_name, actual[name].app_name)
+        or _conflicts(expected[name].workflow_type, actual[name].workflow_type)
+    )
+    return ManifestIdentityDiff(missing=missing, unexpected=unexpected, changed=changed)

--- a/application_sdk/testing/e2e/base.py
+++ b/application_sdk/testing/e2e/base.py
@@ -138,6 +138,31 @@ def _derive_progress_stall_seconds(timeout_seconds: int) -> int:
     return min(window, timeout_seconds // 2)
 
 
+def _supersedes(published: int | None, seed: int | None) -> bool:
+    """Whether *published* provably replaced the harness's *seed* version.
+
+    Provably is the whole point. AE's version number is optional on the wire
+    (``_safe_int`` yields ``None`` for a missing or non-numeric one), and
+    ``None != seed`` is true — so an inequality test alone reads an unknown
+    version as a supersede and goes on to compare a DAG it cannot attribute to
+    the tenant. An absent number cannot prove anything, so it answers False.
+
+    ``seed is None`` is the one case where no proof is needed: the harness
+    published no seed version, so there is nothing for AE to have superseded
+    and whatever it serves is not the harness's own DAG echoed back.
+
+    Args:
+        published: Version number AE reports for the published version.
+        seed: Version number the harness published, if it published one.
+
+    Returns:
+        True only when the comparison that follows is meaningful.
+    """
+    if seed is None:
+        return True
+    return published is not None and published != seed
+
+
 @dataclass(frozen=True)
 class NodeDispatch:
     """Where the seed DAG asked AE to dispatch one node.
@@ -1404,7 +1429,7 @@ class BaseE2ETest:
             read = self.client.get_published_version(slug)
             if read is not None:
                 published = read
-                if read.dag and (seed is None or read.version != seed):
+                if read.dag and _supersedes(read.version, seed):
                     return read
             if attempt.is_last:
                 break
@@ -1420,10 +1445,12 @@ class BaseE2ETest:
             return None
         logger.warning(
             "Deployed-manifest identity check skipped for slug %s: after %ds AE "
-            "still serves version %r (the harness's own seed version is %r) with "
-            "%d node(s), so Heracles' re-fetch of the tenant pod's manifest was "
-            "not observed. Comparing the seed DAG against itself would report a "
-            "match regardless of what the tenant runs, so nothing is asserted",
+            "serves version %r (the harness's own seed version is %r) with %d "
+            "node(s), which does not prove Heracles' re-fetch of the tenant "
+            "pod's manifest superseded the seed — an absent version number "
+            "cannot, and an equal one says it did not. Comparing the seed DAG "
+            "against itself would report a match regardless of what the tenant "
+            "runs, so nothing is asserted",
             slug,
             self.deployed_manifest_timeout_seconds,
             published.version,

--- a/application_sdk/testing/e2e/base.py
+++ b/application_sdk/testing/e2e/base.py
@@ -54,6 +54,7 @@ from application_sdk.contracts.types import ConnectionRef
 from application_sdk.observability.logger_adaptor import get_logger
 from application_sdk.testing.e2e._errors import (
     DAGProgressStalledError,
+    DeployedManifestMismatchError,
     HarnessMethodNotImplementedError,
     ManifestDagMissingError,
     ManifestFileNotFoundError,
@@ -61,12 +62,18 @@ from application_sdk.testing.e2e._errors import (
     MissingHarnessEnvError,
     ProgressWatchdogUnreachableError,
 )
+from application_sdk.testing.e2e._manifest_identity import (
+    DagNodeIdentity,
+    compare_node_identities,
+    node_identities,
+)
 from application_sdk.testing.e2e._poll import until_deadline
 from application_sdk.testing.e2e.client import (
     AEWorkflowClient,
     DAGNodeResult,
     DAGNodeStatus,
     DAGRunResult,
+    PublishedVersion,
     cold_start_submit_kwargs,
 )
 from application_sdk.testing.e2e.credential import CredentialBody
@@ -257,6 +264,20 @@ class BaseE2ETest:
     # never mutated in place, so the class-level empty default is not shared
     # state.
     _node_dispatch: dict[str, NodeDispatch] = {}
+    # Node name -> the identity the app under test declares for that node,
+    # captured from the manifest-derived seed DAG in _bootstrap_workflow and
+    # read only by _assert_deployed_manifest_matches. Empty means there is
+    # nothing to compare against (a hand-crafted legacy seed DAG, or a suite
+    # reusing a pre-existing ae_workflow_slug), and the check self-skips. Plain
+    # instance field, same reason as source_available above.
+    _expected_node_identities: dict[str, DagNodeIdentity] = {}
+    # AE's version number for the seed version this harness published, or None
+    # when the harness published none. _assert_deployed_manifest_matches waits
+    # for the published version to differ from this before comparing: while AE
+    # still serves the seed, the only DAG on offer is the harness's own, and
+    # comparing it to itself would report a match no matter what the tenant
+    # runs. Plain instance field, same reason as source_available above.
+    _seed_version: int | None = None
     # Health endpoint the worker-up tier probes. The CI worker container
     # serves it on localhost:8000 (the sdr-e2e action gates on the same URL
     # before pytest). Override via E2E_WORKER_HEALTH_URL for other topologies.
@@ -307,6 +328,32 @@ class BaseE2ETest:
     # the 5 min headline.
     app_ready_timeout_seconds: ClassVar[int] = 300
     app_ready_poll_interval_seconds: ClassVar[int] = 5
+
+    # --- deployed-manifest identity check (FND-129) --------------------
+    # Whether to assert, right after submit, that the DAG AE published is the
+    # DAG this repo's manifest declares. Verifying the installed *version*
+    # (which CI does, via the sdr-e2e action's `expected-app-version`) says the
+    # right image is on the tenant; this says the graph that ran is the graph we
+    # built — a different claim, because at submit Heracles re-fetches the
+    # manifest from the tenant-deployed pod and supersedes the harness's seed
+    # version with it.
+    #
+    # On by default, but it only ever *fails* a leg on a positive finding: an
+    # unreadable response, a published version that never superseded the seed,
+    # or a connector with no manifest to compare all log and continue. So an
+    # unonboarded caller is untouched without opting out, the same way the CI
+    # version check self-skips on an empty `expected-app-version`. Set False on
+    # a connector whose deployed DAG legitimately diverges from its committed
+    # manifest — and say why in the override, because the default position is
+    # that such a divergence is the bug this check exists to find.
+    assert_deployed_manifest: ClassVar[bool] = True
+    # Budget for the published version to supersede the harness's seed. This is
+    # AE's own create+publish, server-side and already done by the time submit
+    # answers, so the wait is for read-after-write visibility rather than for
+    # work: seconds, not minutes. Exhausting it is not a failure — the check
+    # reports the supersede as unobserved and the run continues to the poll.
+    deployed_manifest_timeout_seconds: ClassVar[int] = 60
+    deployed_manifest_poll_interval_seconds: ClassVar[int] = 5
 
     # --- optional class attrs ------------------------------------------
     connection_type: ClassVar[str] = ""
@@ -469,6 +516,8 @@ class BaseE2ETest:
                 )
 
         self._node_dispatch = {}
+        self._expected_node_identities = {}
+        self._seed_version = None
 
         # A pinned progress-stall window that is not strictly below the poll
         # ceiling is a disabled watchdog (see ProgressWatchdogUnreachableError).
@@ -1082,6 +1131,30 @@ class BaseE2ETest:
             )
         self._node_dispatch = dispatch
 
+    def _capture_expected_node_identities(self, seed_dag: dict[str, Any]) -> None:
+        """Record the node identities the app under test declares.
+
+        Read back only by :meth:`_assert_deployed_manifest_matches`.
+
+        Captured from the seed DAG rather than by re-reading the file: the seed
+        DAG *is* the manifest's ``dag``, already carrying this harness's
+        ``{app_name}`` substitution, so the two sides of the later comparison
+        are normalised the same way. A connector with no ``manifest_path`` built
+        its seed DAG by hand (``_build_legacy_seed_dag``) — that is an
+        approximation of the app's graph, not a copy of it, so there is nothing
+        to compare and the identities stay empty.
+        """
+        if not self.manifest_path:
+            logger.info(
+                "manifest_path empty — the deployed-manifest identity check has "
+                "no committed DAG to compare against and will self-skip"
+            )
+            self._expected_node_identities = {}
+            return
+        self._expected_node_identities = node_identities(
+            seed_dag, app_name=self.connector_short_name
+        )
+
     def _bootstrap_workflow(self) -> str:
         """Ensure an AE workflow exists with a published version.
 
@@ -1113,6 +1186,7 @@ class BaseE2ETest:
             seed_dag = self._build_legacy_seed_dag(extract_queue)
 
         self._capture_node_dispatch(seed_dag)
+        self._capture_expected_node_identities(seed_dag)
 
         version = self.client.create_version(
             slug,
@@ -1120,6 +1194,7 @@ class BaseE2ETest:
         )
         logger.info("Created seed version %d under slug %s", version, slug)
         self.client.publish_version(slug, version)
+        self._seed_version = version
         return slug
 
     # ------------------------------------------------------------------
@@ -1299,6 +1374,133 @@ class BaseE2ETest:
             self.app_ready_poll_interval_seconds,
         )
 
+    # ------------------------------------------------------------------
+    # Deployed-manifest identity check
+    # ------------------------------------------------------------------
+
+    def _read_superseding_published_version(self, slug: str) -> PublishedVersion | None:
+        """Wait briefly for AE to serve a published version past the seed.
+
+        Args:
+            slug: The AE workflow slug the harness submitted against.
+
+        Returns:
+            The published version once it carries a DAG and provably superseded
+            the harness's seed, else ``None`` — the honest answer for both an
+            unreadable response and a supersede that never showed up inside the
+            budget. ``None`` is never a mismatch.
+        """
+        seed = self._seed_version
+        # The last read that came back at all, not the last read: a transient
+        # blip after a good read must not make the diagnostic claim AE was never
+        # readable, which is a different (and wronger) thing to tell an operator.
+        published: PublishedVersion | None = None
+        for attempt in until_deadline(
+            self.deployed_manifest_timeout_seconds,
+            self.deployed_manifest_poll_interval_seconds,
+            label=f"the DAG AE published for slug {slug}",
+            heartbeat_seconds=0,
+        ):
+            read = self.client.get_published_version(slug)
+            if read is not None:
+                published = read
+                if read.dag and (seed is None or read.version != seed):
+                    return read
+            if attempt.is_last:
+                break
+        if published is None:
+            # get_published_version already logged why each read failed.
+            logger.warning(
+                "Deployed-manifest identity check skipped for slug %s: AE's "
+                "published version was never readable within %ds, so whether "
+                "the executed DAG is this repo's DAG stays unverified",
+                slug,
+                self.deployed_manifest_timeout_seconds,
+            )
+            return None
+        logger.warning(
+            "Deployed-manifest identity check skipped for slug %s: after %ds AE "
+            "still serves version %r (the harness's own seed version is %r) with "
+            "%d node(s), so Heracles' re-fetch of the tenant pod's manifest was "
+            "not observed. Comparing the seed DAG against itself would report a "
+            "match regardless of what the tenant runs, so nothing is asserted",
+            slug,
+            self.deployed_manifest_timeout_seconds,
+            published.version,
+            seed,
+            len(published.dag),
+        )
+        return None
+
+    def _assert_deployed_manifest_matches(self, slug: str) -> None:
+        """Assert the DAG AE published is the DAG this repo's manifest declares.
+
+        Runs immediately after submit and before the poll loop. Post-submit is
+        the one thing lost versus the preflight this replaces (which AE does not
+        offer — see
+        :meth:`~application_sdk.testing.e2e.client.AEWorkflowClient.get_published_version`),
+        but it still fails within seconds of submit and long before any
+        assertion, with a node-level diff instead of a confusing downstream
+        failure.
+
+        Compares node identity, not the DAG blob: template variables are
+        substituted at submit, so a byte comparison would fail on every run.
+
+        Raises:
+            DeployedManifestMismatchError: The read got through, AE's published
+                version provably superseded the harness's seed, and the node
+                identities still disagree.
+        """
+        if not self.assert_deployed_manifest:
+            logger.info(
+                "assert_deployed_manifest is off for %s — not checking whether "
+                "the executed DAG is this repo's DAG",
+                type(self).__name__,
+            )
+            return
+        expected = self._expected_node_identities
+        if not expected:
+            logger.info(
+                "Deployed-manifest identity check skipped for slug %s: this "
+                "suite has no manifest-derived seed DAG to compare against",
+                slug,
+            )
+            return
+        published = self._read_superseding_published_version(slug)
+        if published is None:
+            return
+        actual = node_identities(published.dag, app_name=self.connector_short_name)
+        diff = compare_node_identities(expected, actual)
+        if diff.matches:
+            logger.info(
+                "Deployed-manifest identity check passed: AE published version "
+                "%r for slug %s runs the %d node(s) this repo's manifest "
+                "declares (%s), so the executed DAG is the app under test's",
+                published.version,
+                slug,
+                len(expected),
+                ", ".join(sorted(expected)),
+            )
+            return
+        raise DeployedManifestMismatchError(
+            message=(
+                f"The DAG AE published at submit is not the DAG "
+                f"{type(self).__name__} built from {self.manifest_path}.\n"
+                f"At submit, Heracles re-fetches the manifest from the "
+                f"tenant-deployed pod and publishes it over the harness's seed "
+                f"version, so this is the graph that will actually run — and it "
+                f"is not this repo's. The tenant is very likely running a "
+                f"different build of the app than the one under test.\n"
+                f"slug={slug} published_version={published.version!r} "
+                f"seed_version={self._seed_version!r}\n"
+                f"local nodes:     {', '.join(sorted(expected)) or '(none)'}\n"
+                f"published nodes: {', '.join(sorted(actual)) or '(none)'}\n"
+                f"differences:\n{diff.render()}"
+            ),
+            observed=diff.render(),
+            location=f"AE workflow slug {slug}",
+        )
+
     def run_full_dag(self) -> FullDAGOutcome:
         """Submit, poll AE, poll Atlas, return the combined outcome."""
         slug = self._bootstrap_workflow()
@@ -1327,6 +1529,12 @@ class BaseE2ETest:
             payload, slug=slug, **self._submit_retry_kwargs()
         )
         logger.info("AE submit returned run_id=%s", run_id)
+
+        # Before the poll: submit is what makes Heracles fetch the tenant pod's
+        # manifest and publish it over our seed, so this is the earliest point
+        # the executed graph is knowable — and still seconds in, long before any
+        # assertion could pass against the wrong app.
+        self._assert_deployed_manifest_matches(slug)
 
         try:
             ae_result = self.client.poll_native_status(

--- a/application_sdk/testing/e2e/client.py
+++ b/application_sdk/testing/e2e/client.py
@@ -782,6 +782,59 @@ class DAGRunResult:
         return [n for n in self.nodes if n.status.is_not_started]
 
 
+@dataclass(frozen=True)
+class PublishedVersion:
+    """The workflow version AE currently serves as published, and its DAG.
+
+    Read back after submit to see what Heracles published over the harness's
+    seed version — the graph that actually executes. ``version`` is opaque
+    beyond ``!=``: it exists so a caller can tell "AE superseded my seed" from
+    "AE is still serving my seed", which is the difference between a real
+    comparison and comparing the harness's own DAG to itself.
+
+    Attributes:
+        version: AE's version number, or ``None`` when the response omitted it
+            (which makes the supersede question unanswerable, not answered no).
+        dag: The version's ``dag`` object, ``{}`` when absent.
+    """
+
+    version: int | None
+    dag: dict[str, Any]
+
+
+def _first_version_row(body: Any) -> dict[str, Any] | None:
+    """First version record in a ``/versions`` listing response, if any.
+
+    The listing's envelope is not contractual — observed and plausible shapes
+    put the rows under ``data`` directly, under a nested ``records`` /
+    ``versions`` / ``items`` key, or return a bare single object for a
+    ``page_size=1`` read. Accepting all of them keeps a shape change from
+    reading as "the DAG does not match"; an envelope this function cannot parse
+    returns ``None``, which callers treat as unanswerable rather than as a
+    finding.
+    """
+    if isinstance(body, list):
+        rows: Any = body
+    elif isinstance(body, dict):
+        rows = body.get("data", body)
+        if isinstance(rows, dict):
+            for key in ("records", "versions", "items"):
+                nested = rows.get(key)
+                if isinstance(nested, list):
+                    rows = nested
+                    break
+    else:
+        return None
+    if isinstance(rows, dict):
+        # A page_size=1 read that answered with the record itself.
+        return rows if ("dag" in rows or "version" in rows) else None
+    if isinstance(rows, list):
+        for row in rows:
+            if isinstance(row, dict):
+                return row
+    return None
+
+
 class AEWorkflowClient:
     """Thin wrapper over the three Atlan endpoints used by full-DAG tests.
 
@@ -1223,6 +1276,69 @@ class AEWorkflowClient:
             message=f"publish_version failed after {retries} attempts: {body!r}",
             target="POST /automation/api/v1/workflows/.../versions/.../publish",
             retry_after_seconds=_requested_retry_after(body),
+        )
+
+    def get_published_version(self, slug: str) -> PublishedVersion | None:
+        """GET the published version of *slug* — the DAG that actually runs.
+
+        ``GET /automation/api/v1/workflows/<slug>/versions?is_published=true
+        &page=0&page_size=1`` — the same read Heracles itself uses
+        (``GetLatestPublishedVersion``). Read-only, and on a route family the
+        harness already authenticates against for create / publish.
+
+        There is deliberately no preflight equivalent of this: the originally
+        planned ``?submit=false`` does not exist (``processCreateWorkflow``
+        routes native execution to ``processAutomationEngineWorkflow`` without
+        forwarding query params, and that function ends in an unconditional
+        submit), and there is no ``GET /package-workflows/{name}``. So callers
+        read this *after* submit.
+
+        Never raises. Returns ``None`` when the read did not get through — a
+        transport failure, a non-2xx, or an envelope
+        :func:`_first_version_row` could not parse. ``None`` means "no answer",
+        which is not the same as "no match", and callers must not treat it as
+        one.
+
+        Returns:
+            The published version and its DAG, or ``None`` if unreadable.
+        """
+        path = (
+            f"/automation/api/v1/workflows/{quote(slug, safe='')}/versions"
+            "?is_published=true&page=0&page_size=1"
+        )
+        try:
+            status, body = self._request("GET", path)
+        except AppError:
+            logger.warning(
+                "published-version read for slug %s did not get through; which "
+                "DAG AE published stays unknown",
+                slug,
+                exc_info=True,
+            )
+            return None
+        if status >= 300:
+            logger.warning(
+                "published-version read for slug %s returned HTTP %d; which DAG "
+                "AE published stays unknown\nresponse=%r",
+                slug,
+                status,
+                body,
+            )
+            return None
+        row = _first_version_row(body)
+        if row is None:
+            logger.warning(
+                "published-version read for slug %s returned no parseable "
+                "version record; which DAG AE published stays unknown\n"
+                "response=%r",
+                slug,
+                body,
+            )
+            return None
+        dag = row.get("dag")
+        return PublishedVersion(
+            version=_safe_int(row.get("version")),
+            dag=dag if isinstance(dag, dict) else {},
         )
 
     def find_run_created_since(

--- a/docs/standards/connector-ci-e2e.md
+++ b/docs/standards/connector-ci-e2e.md
@@ -615,6 +615,52 @@ side benefit.
 > tenant. With `install-app-to-tenant: false`, that is whatever was last
 > hand-deployed there.
 
+### Asserting the executed DAG, not just the installed version (FND-129)
+
+The install path verifies the **version** on the tenant (`expected-app-version`,
+self-skipping when empty). That is a proxy. What actually executes is the DAG
+Heracles fetches from the tenant-deployed pod at submit — `CreateVersion(slug,
+dag)` + `PublishVersion` on the same slug the harness seeded, superseding the
+seed version. So the version check says *the right image is installed*; the
+harness also asserts *the graph that ran is the graph we built*.
+
+Right after submit and before the poll loop, `BaseE2ETest` reads back the
+published version:
+
+```
+GET /automation/api/v1/workflows/{slug}/versions?is_published=true&page=0&page_size=1
+```
+
+and compares its DAG's **node identity** — node set, plus each node's `app_name`
+and `inputs.workflow_type` — against the identities of the manifest-derived seed
+DAG. A divergence raises `DeployedManifestMismatchError` with the node-level
+diff. Post-submit is the one thing lost versus a preflight: the originally
+planned `?submit=false` does not exist (`processCreateWorkflow` routes native
+execution to `processAutomationEngineWorkflow` without forwarding query params,
+and that function ends in an unconditional submit), and there is no
+`GET /package-workflows/{name}`. It still fails within seconds of submit and
+long before any assertion, with a precise diff instead of a confusing
+downstream failure.
+
+**Identity, not the DAG blob.** Template variables are substituted at submit
+(`substituteTemplateVars`), so a byte comparison would fail on every run. Node
+name, owning app and workflow type survive substitution; the `{app_name}`
+placeholder is resolved on both sides before comparing.
+
+**It only ever reds a leg on a positive finding.** Three outcomes are
+*unanswerable*, and each logs and continues rather than failing:
+
+| Outcome | Why nothing is asserted |
+|---|---|
+| The read did not get through (transport error, non-2xx, unparseable envelope) | No answer is not a mismatch |
+| AE still serves the harness's own seed version after `deployed_manifest_timeout_seconds` (60s) | Comparing the seed DAG to itself would pass whatever the tenant runs |
+| The suite has no `manifest_path` (a hand-crafted legacy seed DAG) | The seed is an approximation of the app's graph, not a copy of it |
+
+So an unonboarded caller is untouched without opting out — the same self-skip
+posture as the CI version check. `assert_deployed_manifest = False` on the test
+class turns it off outright, but the default position is that a divergence is
+the bug this check exists to find.
+
 ### Adoption: on by default (FND-128)
 
 `install-app-to-tenant` defaults to **true**. No app repo has to opt in, and none

--- a/tests/unit/testing/e2e/test_deployed_manifest_identity.py
+++ b/tests/unit/testing/e2e/test_deployed_manifest_identity.py
@@ -1,0 +1,454 @@
+"""Tests for the post-submit deployed-manifest identity check (FND-129).
+
+Three layers, all tenant-free:
+
+* :mod:`application_sdk.testing.e2e._manifest_identity` — pure identity
+  reduction and diffing.
+* ``AEWorkflowClient.get_published_version`` — envelope tolerance, and the
+  contract that an unreadable read answers ``None`` rather than raising.
+* ``BaseE2ETest._assert_deployed_manifest_matches`` — which outcomes fail the
+  leg (exactly one: a positive finding) and which only log.
+
+The last group is the point of the ticket: a leg that asserts against the wrong
+app must go red, and every *unanswerable* outcome must not.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from application_sdk.errors.base import AppError
+from application_sdk.testing.e2e import BaseE2ETest
+from application_sdk.testing.e2e._errors import DeployedManifestMismatchError
+from application_sdk.testing.e2e._manifest_identity import (
+    DagNodeIdentity,
+    compare_node_identities,
+    node_identities,
+)
+from application_sdk.testing.e2e.client import (
+    AEWorkflowClient,
+    PublishedVersion,
+    _first_version_row,
+)
+
+
+def _node(app_name: str, workflow_type: str) -> dict[str, Any]:
+    """A manifest-shaped node declaring both identity fields, as the real ones do."""
+    return {
+        "app_name": app_name,
+        "inputs": {"app_name": app_name, "workflow_type": workflow_type},
+    }
+
+
+_LOCAL_DAG: dict[str, Any] = {
+    "extract": _node("{app_name}", "MySQLWorkflow"),
+    "publish": _node("publish", "PublishWorkflow"),
+}
+
+
+def _make_client() -> AEWorkflowClient:
+    return AEWorkflowClient(
+        tenant_url="https://tenant.example.invalid",
+        api_token="tok-test",
+    )
+
+
+class _Harness(BaseE2ETest):
+    connector_short_name = "mysql"
+    argo_package_name = "@atlan/mysql"
+    argo_template_name = "atlan-mysql"
+
+
+def _harness(**overrides: Any) -> _Harness:
+    """A harness with the check's inputs set directly, bypassing bootstrap.
+
+    ``_bootstrap_workflow`` needs a tenant; the check under test only needs the
+    two pieces of state bootstrap leaves behind.
+    """
+    harness = _Harness()
+    harness.client = _make_client()
+    harness._expected_node_identities = node_identities(_LOCAL_DAG, app_name="mysql")
+    harness._seed_version = 1000
+    for key, value in overrides.items():
+        setattr(harness, key, value)
+    return harness
+
+
+# ---------------------------------------------------------------------------
+# node_identities
+# ---------------------------------------------------------------------------
+
+
+class TestNodeIdentities:
+    def test_reduces_a_manifest_dag_to_name_app_and_workflow_type(self) -> None:
+        ids = node_identities(_LOCAL_DAG, app_name="mysql")
+        assert ids["extract"] == DagNodeIdentity(
+            name="extract", app_name="mysql", workflow_type="MySQLWorkflow"
+        )
+        assert ids["publish"] == DagNodeIdentity(
+            name="publish", app_name="publish", workflow_type="PublishWorkflow"
+        )
+
+    def test_app_name_placeholder_resolves_to_the_connector(self) -> None:
+        """The whole point of ``app_name=``: a placeholder and its substituted
+        form must compare equal, or every leg reports a changed extract node."""
+        raw = node_identities({"extract": _node("{app_name}", "W")}, app_name="mysql")
+        substituted = node_identities(
+            {"extract": _node("mysql", "W")}, app_name="mysql"
+        )
+        assert compare_node_identities(raw, substituted).matches
+
+    def test_node_level_app_name_wins_over_inputs(self) -> None:
+        dag = {
+            "extract": {
+                "app_name": "outer",
+                "inputs": {"app_name": "inner", "workflow_type": "W"},
+            }
+        }
+        assert node_identities(dag)["extract"].app_name == "outer"
+
+    def test_inputs_app_name_is_the_fallback(self) -> None:
+        dag = {"extract": {"inputs": {"app_name": "inner", "workflow_type": "W"}}}
+        assert node_identities(dag)["extract"].app_name == "inner"
+
+    def test_a_node_that_is_not_an_object_still_appears_in_the_node_set(self) -> None:
+        """A malformed node must not silently vanish — its absence from the set
+        would read as a node-set match that isn't one."""
+        ids = node_identities({"extract": "not-an-object"})
+        assert ids["extract"] == DagNodeIdentity(name="extract")
+
+    def test_non_string_identity_fields_read_as_undeclared(self) -> None:
+        dag = {"extract": {"app_name": 7, "inputs": {"workflow_type": None}}}
+        assert node_identities(dag)["extract"] == DagNodeIdentity(name="extract")
+
+    def test_empty_dag_yields_no_identities(self) -> None:
+        assert node_identities({}) == {}
+
+
+# ---------------------------------------------------------------------------
+# compare_node_identities
+# ---------------------------------------------------------------------------
+
+
+class TestCompareNodeIdentities:
+    def test_identical_dags_match(self) -> None:
+        ids = node_identities(_LOCAL_DAG, app_name="mysql")
+        assert compare_node_identities(ids, ids).matches
+
+    def test_a_node_the_published_dag_lacks_is_reported_missing(self) -> None:
+        expected = node_identities(_LOCAL_DAG, app_name="mysql")
+        actual = node_identities({"extract": _node("mysql", "MySQLWorkflow")})
+        diff = compare_node_identities(expected, actual)
+        assert not diff.matches
+        assert [n.name for n in diff.missing] == ["publish"]
+        assert diff.unexpected == ()
+        assert "declared locally but absent" in diff.render()
+
+    def test_an_extra_published_node_is_reported_unexpected(self) -> None:
+        expected = node_identities({"extract": _node("mysql", "MySQLWorkflow")})
+        actual = node_identities(_LOCAL_DAG, app_name="mysql")
+        diff = compare_node_identities(expected, actual)
+        assert [n.name for n in diff.unexpected] == ["publish"]
+        assert "present in the published DAG" in diff.render()
+
+    def test_a_changed_workflow_type_is_a_mismatch(self) -> None:
+        expected = node_identities(_LOCAL_DAG, app_name="mysql")
+        actual = node_identities(
+            {**_LOCAL_DAG, "extract": _node("mysql", "OldMySQLWorkflow")},
+            app_name="mysql",
+        )
+        diff = compare_node_identities(expected, actual)
+        assert [c.name for c in diff.changed] == ["extract"]
+        assert "OldMySQLWorkflow" in diff.render()
+
+    def test_a_changed_app_name_is_a_mismatch(self) -> None:
+        expected = node_identities(_LOCAL_DAG, app_name="mysql")
+        actual = node_identities(
+            {**_LOCAL_DAG, "publish": _node("some-other-app", "PublishWorkflow")},
+            app_name="mysql",
+        )
+        assert [c.name for c in compare_node_identities(expected, actual).changed] == [
+            "publish"
+        ]
+
+    def test_a_field_the_published_dag_omits_is_not_a_mismatch(self) -> None:
+        """Tolerance is deliberate: the published envelope is Heracles' to
+        change, and an omission is not evidence about the app under test."""
+        expected = node_identities(_LOCAL_DAG, app_name="mysql")
+        actual = node_identities(
+            {"extract": {"app_name": "mysql"}, "publish": {"app_name": "publish"}}
+        )
+        assert compare_node_identities(expected, actual).matches
+
+    def test_render_of_a_match_says_so(self) -> None:
+        ids = node_identities(_LOCAL_DAG, app_name="mysql")
+        assert compare_node_identities(ids, ids).render() == "no difference"
+
+
+# ---------------------------------------------------------------------------
+# _first_version_row
+# ---------------------------------------------------------------------------
+
+
+class TestFirstVersionRow:
+    _ROW = {"version": 7, "dag": {"extract": {}}}
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            pytest.param({"data": [_ROW]}, id="data-list"),
+            pytest.param({"data": {"records": [_ROW]}}, id="data-records"),
+            pytest.param({"data": {"versions": [_ROW]}}, id="data-versions"),
+            pytest.param({"data": {"items": [_ROW]}}, id="data-items"),
+            pytest.param({"data": _ROW}, id="data-object"),
+            pytest.param([_ROW], id="bare-list"),
+            pytest.param(_ROW, id="bare-object"),
+        ],
+    )
+    def test_accepts_every_plausible_envelope(self, body: Any) -> None:
+        assert _first_version_row(body) == self._ROW
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            pytest.param({"data": []}, id="empty-list"),
+            pytest.param({"data": {"total": 0}}, id="no-rows-and-no-record"),
+            pytest.param("not json", id="text"),
+            pytest.param(None, id="none"),
+        ],
+    )
+    def test_returns_none_when_no_record_is_present(self, body: Any) -> None:
+        assert _first_version_row(body) is None
+
+
+# ---------------------------------------------------------------------------
+# AEWorkflowClient.get_published_version
+# ---------------------------------------------------------------------------
+
+
+class TestGetPublishedVersion:
+    def test_reads_the_published_version_and_its_dag(self) -> None:
+        client = _make_client()
+        body = {"data": [{"version": 42, "dag": _LOCAL_DAG}]}
+        with patch.object(client, "_request", return_value=(200, body)) as request:
+            published = client.get_published_version("mysql-abc")
+        assert published == PublishedVersion(version=42, dag=_LOCAL_DAG)
+        _, path = request.call_args.args
+        assert path == (
+            "/automation/api/v1/workflows/mysql-abc/versions"
+            "?is_published=true&page=0&page_size=1"
+        )
+
+    def test_the_slug_is_url_encoded(self) -> None:
+        client = _make_client()
+        with patch.object(client, "_request", return_value=(200, {"data": []})) as req:
+            client.get_published_version("a/b?c")
+        assert "workflows/a%2Fb%3Fc/versions" in req.call_args.args[1]
+
+    def test_a_version_row_without_a_dag_yields_an_empty_dag(self) -> None:
+        client = _make_client()
+        with patch.object(client, "_request", return_value=(200, {"data": [{}]})):
+            published = client.get_published_version("s")
+        assert published == PublishedVersion(version=None, dag={})
+
+    @pytest.mark.parametrize("status", [404, 500, 503])
+    def test_a_non_2xx_answers_none_rather_than_raising(self, status: int) -> None:
+        client = _make_client()
+        with patch.object(client, "_request", return_value=(status, {"err": "x"})):
+            assert client.get_published_version("s") is None
+
+    def test_a_transport_failure_answers_none_rather_than_raising(self) -> None:
+        """The check is an enhancement on top of the run; a read that cannot get
+        through must never be the thing that fails the leg."""
+        client = _make_client()
+        with patch.object(client, "_request", side_effect=AppError(message="down")):
+            assert client.get_published_version("s") is None
+
+    def test_an_unparseable_envelope_answers_none(self) -> None:
+        client = _make_client()
+        with patch.object(client, "_request", return_value=(200, "not json")):
+            assert client.get_published_version("s") is None
+
+
+# ---------------------------------------------------------------------------
+# BaseE2ETest._assert_deployed_manifest_matches
+# ---------------------------------------------------------------------------
+
+
+def _published(dag: dict[str, Any], version: int = 2000) -> PublishedVersion:
+    return PublishedVersion(version=version, dag=dag)
+
+
+class TestAssertDeployedManifestMatches:
+    def test_a_matching_published_dag_passes(self) -> None:
+        harness = _harness()
+        with patch.object(
+            harness.client, "get_published_version", return_value=_published(_LOCAL_DAG)
+        ):
+            harness._assert_deployed_manifest_matches("mysql-abc")
+
+    def test_a_diverging_published_dag_fails_the_leg(self) -> None:
+        harness = _harness()
+        deployed = {"extract": _node("mysql", "OldMySQLWorkflow")}
+        with (
+            patch.object(
+                harness.client,
+                "get_published_version",
+                return_value=_published(deployed),
+            ),
+            pytest.raises(DeployedManifestMismatchError) as exc,
+        ):
+            harness._assert_deployed_manifest_matches("mysql-abc")
+        # The diff has to name the nodes, not merely report a mismatch.
+        assert "OldMySQLWorkflow" in exc.value.message
+        assert "publish" in exc.value.message
+        assert exc.value.observed is not None
+        assert "publish" in exc.value.observed
+
+    def test_the_check_is_skippable_per_connector(self) -> None:
+        harness = _harness()
+        with (
+            patch.object(type(harness), "assert_deployed_manifest", False),
+            patch.object(harness.client, "get_published_version") as read,
+        ):
+            harness._assert_deployed_manifest_matches("mysql-abc")
+        read.assert_not_called()
+
+    def test_a_suite_with_no_manifest_derived_dag_skips_without_reading(self) -> None:
+        harness = _harness()
+        harness._expected_node_identities = {}
+        with patch.object(harness.client, "get_published_version") as read:
+            harness._assert_deployed_manifest_matches("mysql-abc")
+        read.assert_not_called()
+
+    def test_a_published_version_that_never_supersedes_the_seed_asserts_nothing(
+        self,
+    ) -> None:
+        """AE still serving the harness's own seed means the only DAG on offer is
+        the one the harness uploaded. Comparing it to itself would pass whatever
+        the tenant runs, so the honest outcome is to assert nothing — even when
+        the DAG differs, as it does here."""
+        harness = _harness(
+            deployed_manifest_timeout_seconds=1,
+            deployed_manifest_poll_interval_seconds=1,
+        )
+        seed_echo = _published({"extract": _node("mysql", "Divergent")}, version=1000)
+        with (
+            patch.object(
+                harness.client, "get_published_version", return_value=seed_echo
+            ),
+            patch("time.sleep"),
+        ):
+            harness._assert_deployed_manifest_matches("mysql-abc")
+
+    def test_an_unreadable_published_version_asserts_nothing(self) -> None:
+        harness = _harness(
+            deployed_manifest_timeout_seconds=1,
+            deployed_manifest_poll_interval_seconds=1,
+        )
+        with (
+            patch.object(harness.client, "get_published_version", return_value=None),
+            patch("time.sleep"),
+        ):
+            harness._assert_deployed_manifest_matches("mysql-abc")
+
+    def test_an_empty_published_dag_asserts_nothing(self) -> None:
+        harness = _harness(
+            deployed_manifest_timeout_seconds=1,
+            deployed_manifest_poll_interval_seconds=1,
+        )
+        with (
+            patch.object(
+                harness.client, "get_published_version", return_value=_published({})
+            ),
+            patch("time.sleep"),
+        ):
+            harness._assert_deployed_manifest_matches("mysql-abc")
+
+    def test_a_late_supersede_is_waited_for(self) -> None:
+        """AE's version listing is read-after-write: the first read can still be
+        the seed. One retry inside the budget must be enough to see the real DAG."""
+        harness = _harness(
+            deployed_manifest_timeout_seconds=30,
+            deployed_manifest_poll_interval_seconds=1,
+        )
+        reads = [
+            _published(_LOCAL_DAG, version=1000),  # still the seed
+            None,  # a blip
+            _published({"extract": _node("mysql", "Divergent")}),
+        ]
+        with (
+            patch.object(harness.client, "get_published_version", side_effect=reads),
+            patch("time.sleep"),
+            pytest.raises(DeployedManifestMismatchError),
+        ):
+            harness._assert_deployed_manifest_matches("mysql-abc")
+
+    def test_a_readable_read_survives_a_later_blip(self) -> None:
+        """A blip after a good read must not make the diagnostic claim AE was
+        never readable — that is a different, and wronger, thing to report."""
+        harness = _harness(
+            deployed_manifest_timeout_seconds=2,
+            deployed_manifest_poll_interval_seconds=1,
+        )
+        reads = [_published({}, version=1000), None]
+        with (
+            patch.object(harness.client, "get_published_version", side_effect=reads),
+            patch("time.sleep"),
+        ):
+            harness._assert_deployed_manifest_matches("mysql-abc")
+
+    def test_an_empty_first_read_does_not_end_the_wait(self) -> None:
+        harness = _harness(
+            deployed_manifest_timeout_seconds=30,
+            deployed_manifest_poll_interval_seconds=1,
+        )
+        reads = [
+            _published({}),
+            _published({"extract": _node("mysql", "Divergent")}),
+        ]
+        with (
+            patch.object(harness.client, "get_published_version", side_effect=reads),
+            patch("time.sleep"),
+            pytest.raises(DeployedManifestMismatchError),
+        ):
+            harness._assert_deployed_manifest_matches("mysql-abc")
+
+    def test_a_harness_with_no_seed_version_compares_the_first_readable_dag(
+        self,
+    ) -> None:
+        """No seed of our own (a pre-seeded slug) means there is nothing for AE
+        to supersede, so the supersede gate cannot apply and the published DAG
+        is compared as read."""
+        harness = _harness()
+        harness._seed_version = None
+        with (
+            patch.object(
+                harness.client,
+                "get_published_version",
+                return_value=_published({"extract": _node("mysql", "Divergent")}),
+            ),
+            pytest.raises(DeployedManifestMismatchError),
+        ):
+            harness._assert_deployed_manifest_matches("mysql-abc")
+
+
+class TestCaptureExpectedNodeIdentities:
+    def test_a_manifest_derived_seed_dag_is_captured(self) -> None:
+        harness = _Harness()
+        harness._capture_expected_node_identities(dict(_LOCAL_DAG))
+        assert set(harness._expected_node_identities) == {"extract", "publish"}
+        # {app_name} resolved against the connector, so the later comparison is
+        # normalised on both sides.
+        assert harness._expected_node_identities["extract"].app_name == "mysql"
+
+    def test_a_hand_crafted_legacy_seed_dag_is_not_captured(self) -> None:
+        """``manifest_path == ''`` means the seed DAG is the harness's own
+        approximation of the app's graph, not a copy of it — nothing to compare."""
+        harness = _Harness()
+        with patch.object(type(harness), "manifest_path", ""):
+            harness._capture_expected_node_identities(dict(_LOCAL_DAG))
+        assert harness._expected_node_identities == {}

--- a/tests/unit/testing/e2e/test_deployed_manifest_identity.py
+++ b/tests/unit/testing/e2e/test_deployed_manifest_identity.py
@@ -28,6 +28,7 @@ from application_sdk.testing.e2e._manifest_identity import (
     compare_node_identities,
     node_identities,
 )
+from application_sdk.testing.e2e.base import _supersedes
 from application_sdk.testing.e2e.client import (
     AEWorkflowClient,
     PublishedVersion,
@@ -278,7 +279,7 @@ class TestGetPublishedVersion:
 # ---------------------------------------------------------------------------
 
 
-def _published(dag: dict[str, Any], version: int = 2000) -> PublishedVersion:
+def _published(dag: dict[str, Any], version: int | None = 2000) -> PublishedVersion:
     return PublishedVersion(version=version, dag=dag)
 
 
@@ -387,6 +388,42 @@ class TestAssertDeployedManifestMatches:
         ):
             harness._assert_deployed_manifest_matches("mysql-abc")
 
+    def test_a_published_version_with_no_version_number_asserts_nothing(self) -> None:
+        """AE's version number is optional on the wire, so ``_safe_int`` can
+        yield None — and ``None != seed`` is true. Comparing on inequality alone
+        would treat an unattributable record as superseding the seed and diff a
+        DAG it cannot prove came from the tenant."""
+        harness = _harness(
+            deployed_manifest_timeout_seconds=1,
+            deployed_manifest_poll_interval_seconds=1,
+        )
+        unnumbered = _published({"extract": _node("mysql", "Divergent")}, version=None)
+        with (
+            patch.object(
+                harness.client, "get_published_version", return_value=unnumbered
+            ),
+            patch("time.sleep"),
+        ):
+            harness._assert_deployed_manifest_matches("mysql-abc")
+
+    def test_an_unnumbered_read_does_not_end_the_wait(self) -> None:
+        """It is unprovable, not terminal: a numbered supersede later in the
+        budget must still be found and compared."""
+        harness = _harness(
+            deployed_manifest_timeout_seconds=30,
+            deployed_manifest_poll_interval_seconds=1,
+        )
+        reads = [
+            _published({"extract": _node("mysql", "Divergent")}, version=None),
+            _published({"extract": _node("mysql", "Divergent")}, version=2000),
+        ]
+        with (
+            patch.object(harness.client, "get_published_version", side_effect=reads),
+            patch("time.sleep"),
+            pytest.raises(DeployedManifestMismatchError),
+        ):
+            harness._assert_deployed_manifest_matches("mysql-abc")
+
     def test_a_readable_read_survives_a_later_blip(self) -> None:
         """A blip after a good read must not make the diagnostic claim AE was
         never readable — that is a different, and wronger, thing to report."""
@@ -434,6 +471,25 @@ class TestAssertDeployedManifestMatches:
             pytest.raises(DeployedManifestMismatchError),
         ):
             harness._assert_deployed_manifest_matches("mysql-abc")
+
+
+class TestSupersedes:
+    """The predicate that decides whether the comparison is meaningful at all."""
+
+    @pytest.mark.parametrize(
+        ("published", "seed", "expected"),
+        [
+            pytest.param(2000, 1000, True, id="a-different-number-supersedes"),
+            pytest.param(1000, 1000, False, id="the-same-number-does-not"),
+            pytest.param(None, 1000, False, id="an-absent-number-proves-nothing"),
+            pytest.param(2000, None, True, id="no-seed-needs-no-proof"),
+            pytest.param(None, None, True, id="no-seed-even-without-a-number"),
+        ],
+    )
+    def test_only_a_provable_replacement_counts(
+        self, published: int | None, seed: int | None, expected: bool
+    ) -> None:
+        assert _supersedes(published, seed) is expected
 
 
 class TestCaptureExpectedNodeIdentities:


### PR DESCRIPTION
Closes FND-129.

## The gap

Verifying the installed **version** says the right image is on the tenant. What actually *executes* is the DAG Heracles fetches from the tenant-deployed pod at submit — `CreateVersion(slug, dag)` + `PublishVersion` on the harness's own slug, superseding the seed version. So a leg whose assertions all pass could have been exercising a graph this repo never built, and nothing downstream named the difference.

## What this does

Right after submit and before the poll loop, the harness reads back the published version:

```
GET /automation/api/v1/workflows/{slug}/versions?is_published=true&page=0&page_size=1
```

(the same read Heracles itself uses — `GetLatestPublishedVersion`) and compares **node identity**: the node set, plus each node's `app_name` and `inputs.workflow_type`. A divergence raises `DeployedManifestMismatchError` carrying the node-level diff:

```
  - declared locally but absent from the published DAG: publish (app=publish, workflow_type=PublishWorkflow)
  ~ extract: local extract (app=mysql, workflow_type=MySQLWorkflow) vs published extract (app=mysql, workflow_type=OldMySQLWorkflow)
```

**Why post-submit.** The originally planned `?submit=false` preflight does not exist — `processCreateWorkflow` routes native execution to `processAutomationEngineWorkflow` without forwarding query params, and that function ends in an unconditional submit — and there is no `GET /package-workflows/{name}`. Post-submit is the one thing lost versus a preflight, but it still fails within seconds of submit and long before any assertion, with a precise diff instead of a confusing downstream failure.

**Why identity, not the DAG blob.** Template variables are substituted at submit (`substituteTemplateVars`), so a byte comparison would fail on every run. Node name, owning app and workflow type survive substitution; `{app_name}` is resolved on both sides before comparing.

## Exactly one outcome reds a leg

Three outcomes are *unanswerable*, and each logs and continues rather than failing:

| Outcome | Why nothing is asserted |
|---|---|
| The read did not get through (transport error, non-2xx, unparseable envelope) | No answer is not a mismatch |
| AE still serves the harness's own seed version after 60s | Comparing the seed DAG to itself would pass whatever the tenant runs |
| The suite has no `manifest_path` (hand-crafted legacy seed DAG) | The seed is an approximation of the app's graph, not a copy of it |

So an unonboarded caller is untouched without opting out — the same self-skip posture as the CI version check — and `assert_deployed_manifest` can default to `True`. Set it `False` on a connector whose deployed DAG legitimately diverges from its committed manifest.

## Reviewer attention

**This arms fleet-wide on the next SDK bump.** That is deliberate: a silently-wrong pass is worse than a red leg, and only a real node-set / field divergence can produce one. If you disagree, the alternative is defaulting to `False` and flipping it per-connector.

**The per-node field comparison is tolerant on purpose.** A field one side omits is *not* reported as a change — only both-present-and-different is. I have no VPN-side observation of the real published envelope from this branch, and reporting an omission as a mismatch would red every leg on the day Heracles stops echoing a field: a false claim about the app under test. The node *set* stays strict, which is the primary signal, and the passing INFO line logs the full identity table so the first live runs give us what is needed to tighten this. Recorded as a follow-up on the ticket.

## Files

- `application_sdk/testing/e2e/_manifest_identity.py` (new) — `DagNodeIdentity`, `node_identities()`, `compare_node_identities()`, `ManifestIdentityDiff.render()`
- `client.py` — `AEWorkflowClient.get_published_version()`, `PublishedVersion`, `_first_version_row` (envelope tolerance)
- `_errors.py` — `DeployedManifestMismatchError`, a `DataIntegrityError` carrying the diff in the existing `observed` field
- `base.py` — `_assert_deployed_manifest_matches()`, `_read_superseding_published_version()`, `_capture_expected_node_identities()`, and the three new class attrs
- `docs/standards/connector-ci-e2e.md` — section under "Building the image once"
- `tests/unit/testing/e2e/test_deployed_manifest_identity.py` — 46 tests

Not applied to `application_sdk/testing/full_dag/`, the deprecated twin removed in v4.0.

## Verification

- 46 new unit tests pass; full unit suite **7432 passed / 9 skipped**
- `uv run pre-commit run --files <changed>` clean (ruff, ruff-format, isort, pyright)
- `atlan-application-sdk-conformance detect` — zero findings in the new code (the 15 hits in these files are all pre-existing lines)
- Capability manifest regen produced a header-only diff, so it is not stale

🤖 Generated with [Claude Code](https://claude.com/claude-code)
