### PR TITLE
ci(e2e): retry the marketplace publish through an upstream outage (FND-760)

### DIFF
--- a/.github/actions/e2e-tenant-lease/action.yaml
+++ b/.github/actions/e2e-tenant-lease/action.yaml
@@ -118,8 +118,13 @@ inputs:
       tenant, which is the race the lease exists to close, whereas breaking one
       late costs a blocked tenant that a waiter is already reporting loudly.
       0 disables the backstop.
+
+      Raised from 14400 when prepare-tenant's ceiling went to 48 min to fit the
+      publish retry (FND-760). That is the sizing test doing its job, not a
+      margin being spent: the hold this must clear is now 48+120 min, and a TTL
+      that no longer cleared it by 1.5x would start breaking live holders.
     required: false
-    default: "14400"
+    default: "16200"
   on-timeout:
     description: |
       "fail" (default) — go red naming the holding run. "warn" — proceed

--- a/.github/scripts/e2e_tenant_app.py
+++ b/.github/scripts/e2e_tenant_app.py
@@ -61,6 +61,31 @@ had its install miss, so waiting on GM's release status is not sufficient.
 Hence ``--install-retry-seconds`` (default 600): the install itself is retried
 while LM catches up. ``--scan-wait-seconds`` stays at 0 — waiting on the scan
 would not have helped, and a base-image CVE must not red an unrelated PR.
+
+The marketplace service is not always there
+-------------------------------------------
+Every call this script makes goes through Heracles to the marketplace service,
+and that service is a **shared** dependency: the e2e fan-out sends every
+connector's run at the same three tenants, and the tenant lease cannot space
+them out (it is keyed ``(app, cloud)`` and its ref lives in each app's *own*
+repo, so two different apps never contend). When it degrades it degrades for
+everyone at once.
+
+On 2026-08-24 it did, for about eight minutes, and took five connector PRs with
+it (FND-760). One fault, four different-looking symptoms:
+
+* ``POST /marketplace/publish`` → HTTP 400 ``code 1000`` "Please check your
+  request parameters", message ``error getting response from marketplace
+  service`` — a *validation* shape for something that is not a validation
+  failure. Four apps across all three clouds, two of them in the same second.
+* the same publish → a 60s client-side read timeout. Hanging, not rejecting.
+* ``POST .../install`` → ``status_code=500`` inside an HTTP 200 envelope.
+* ``GET .../deployments/{id}`` → the same HTTP 400, nine times running.
+
+Only the last of those survived, because ``_poll_deployment`` is the one caller
+that already retried a bad read. So ``--publish-retry-seconds`` (default 240)
+gives ``_publish`` the same tolerance: see :func:`_publish` for which half of
+the failure space is retried and why the other half must stay fatal.
 """
 
 from __future__ import annotations
@@ -68,6 +93,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import random
 import re
 import sys
 import time
@@ -106,12 +132,31 @@ _SCAN_POLL_SECONDS = 10
 #: Gap between install retries while LM's catalog snapshot catches up.
 _INSTALL_RETRY_POLL_SECONDS = 20
 
-#: The two waits this script can spend, as module constants rather than argparse
-#: literals, because a caller's job `timeout-minutes` has to stay above their sum:
-#: if the runner's timeout fires first, a slow LM sync reports as "job cancelled"
-#: and the actionable error this script was about to print is never written. The
-#: workflows' guards assert their timeouts against these, so raising one here
-#: fails the guard rather than silently making a job timeout reachable.
+#: Base gap between publish retries, and the band of jitter added to it.
+#:
+#: Jittered rather than fixed — the only place in this file that is. The other
+#: two retries wait on something tenant-local (LM's own catalog sync, one
+#: deployment reconciling), so their spacing affects nobody else. This one waits
+#: on the *shared* marketplace service, which fails for the whole fan-out at
+#: once (see the module docstring), and nothing upstream spaces those runs out.
+#: A fixed interval would put every connector that just failed onto the same
+#: retry beat and re-apply, in lockstep, the load the service was already
+#: failing under.
+_PUBLISH_RETRY_POLL_SECONDS = 15
+_PUBLISH_RETRY_JITTER_SECONDS = 10
+
+#: The three waits this script can spend, as module constants rather than
+#: argparse literals, because a caller's job `timeout-minutes` has to stay above
+#: their sum: if the runner's timeout fires first, a slow LM sync reports as "job
+#: cancelled" and the actionable error this script was about to print is never
+#: written. The workflows' guards assert their timeouts against these, so raising
+#: one here fails the guard rather than silently making a job timeout reachable.
+#:
+#: 240 for the publish because the outage it exists for is measured in minutes,
+#: not seconds: on 2026-08-24 the failures ran 09:00:27 → 09:02:25 and the next
+#: success was 09:03:50, so anything under ~3 min would have bought nothing on
+#: the one event there is real evidence from.
+DEFAULT_PUBLISH_RETRY_SECONDS = 240
 DEFAULT_INSTALL_RETRY_SECONDS = 600
 DEFAULT_DEPLOYMENT_TIMEOUT_SECONDS = 600
 
@@ -683,6 +728,64 @@ def _looks_like_cicd_managed(response: Response) -> bool:
     return "managed by ci/cd" in rendered or "cicd_managed" in rendered
 
 
+#: Heracles' wording when its own call to the marketplace service did not come
+#: back. It arrives as HTTP 400 with ``code 1000`` / "Please check your request
+#: parameters" — i.e. Heracles reports an upstream that never answered *as if*
+#: the caller had sent a bad payload — so neither the status nor the top-level
+#: ``error`` distinguishes it from a real rejection. This message is the only
+#: field that does.
+_UPSTREAM_UNREACHABLE_MARKER = "error getting response from marketplace service"
+
+
+def _looks_like_upstream_unreachable(response: Response) -> bool:
+    """True when Heracles is saying the marketplace service did not answer *it*.
+
+    Matched on the message text and deliberately not on the status. The status is
+    400, indistinguishable from a genuine payload rejection, and treating every
+    publish 400 as transient would make a real bad request wait out the whole
+    retry budget before failing with the same error.
+
+    Fails closed: if Heracles rewords this, the match stops firing and a publish
+    is fatal on its first response again — today's behaviour, not a new one. That
+    is the right direction to fail in, and the reason this is not widened to
+    something loose like "marketplace" or "not reach".
+    """
+    rendered = json.dumps(response.body).lower() if response.body else ""
+    return _UPSTREAM_UNREACHABLE_MARKER in rendered
+
+
+def _publish_is_retryable(response: Response) -> bool:
+    """True when a failed publish is worth sending again.
+
+    The split is between "the marketplace service could not answer" and "the
+    marketplace service answered, and the answer was no". Only the first
+    self-heals; retrying the second just delays a failure that was already
+    correct — and on the credential and provenance rejections it delays the one
+    error a human actually needs to read.
+    """
+    # Credentials do not come good on a retry, and 401/403 already carries the
+    # which-of-two-credentials hint. Checked before the marker so a reworded
+    # upstream can never drag an auth failure into the retry loop.
+    if response.status in (401, 403):
+        return False
+    if response.status == 429 or response.status >= 500:
+        return True
+    return _looks_like_upstream_unreachable(response)
+
+
+def _wait_before_publish_retry(attempt: int, deadline: float, why: str) -> None:
+    """Sleep out one publish-retry gap, never past ``deadline``."""
+    jitter = random.uniform(0, _PUBLISH_RETRY_JITTER_SECONDS)  # noqa: S311 — spacing retries across a fan-out, not a security decision
+    remaining = deadline - time.monotonic()
+    gap = max(0.0, min(_PUBLISH_RETRY_POLL_SECONDS + jitter, remaining))
+    print(
+        f"::warning::marketplace publish attempt {attempt} failed ({why}); the "
+        f"marketplace service is a shared dependency and this is its transient "
+        f"shape — retrying in {gap:.0f}s, {max(0.0, remaining):.0f}s of budget left"
+    )
+    time.sleep(gap)
+
+
 def _looks_like_scan_gate_text(text: str) -> bool:
     """Scan-gate detection over a plain message string.
 
@@ -746,15 +849,71 @@ def _wait_for_scan(
     return status
 
 
-def _publish(client: TenantClient, request: PublishRequest) -> tuple[str, str]:
-    """Register the version. Returns ``(version_id, release_id)``."""
+def _publish(
+    client: TenantClient,
+    request: PublishRequest,
+    *,
+    retry_seconds: int = 0,
+) -> tuple[str, str]:
+    """Register the version. Returns ``(version_id, release_id)``.
+
+    Retries only the half of the failure space that self-heals — see
+    :func:`_publish_is_retryable` for the split, and the module docstring for the
+    outage that made it necessary. A transport-level failure (the read timeout
+    Heracles produces when the marketplace service hangs rather than answers) is
+    retried on the same budget: it is the client-side view of the same fault.
+
+    On re-sending after an ambiguous failure
+    ----------------------------------------
+    A retry cannot know whether the attempt it is replacing reached GM, so this
+    can re-register a version GM already has. That is a deliberate trade rather
+    than an oversight, and it is cheap here for two specific reasons:
+
+    * The version string is the image tag, so a retry re-registers *the same*
+      version rather than a second, differently-named one.
+    * The registration is ``allowed_tenants``-scoped to one e2e tenant, so the
+      worst case is a duplicate row GM will never surface to a real tenant.
+
+    Weighed against a fault that redded four connector PRs inside eight minutes,
+    a duplicate row on a test tenant is the cheaper failure. If a retry does come
+    back rejected because the version already exists, the error below says which
+    attempt it was on, so that reads as what it is rather than as a mystery.
+    """
     try:
         body = build(request)
     except PublishBodyError as exc:
         raise TenantAppError(str(exc)) from exc
 
-    response = client.post(PUBLISH_PATH, body=body)
-    if not response.ok:
+    deadline = time.monotonic() + max(retry_seconds, 0)
+    attempt = 0
+    while True:
+        attempt += 1
+        try:
+            response = client.post(PUBLISH_PATH, body=body)
+        except TenantApiError as exc:
+            # Transport-level, so there is no status to branch on and
+            # _publish_is_retryable never sees it. Retried anyway: the tenant
+            # resolved and was reachable minutes ago in this same job, so a
+            # timeout here is the service hanging, not a misconfigured base URL.
+            if time.monotonic() >= deadline:
+                raise TenantAppError(
+                    f"marketplace publish never completed — {attempt} attempt(s) "
+                    f"over a {retry_seconds}s budget, none of which got a response. "
+                    f"Last: {exc}"
+                ) from exc
+            _wait_before_publish_retry(attempt, deadline, str(exc))
+            continue
+
+        if response.ok:
+            break
+        if _publish_is_retryable(response) and time.monotonic() < deadline:
+            _wait_before_publish_retry(
+                attempt,
+                deadline,
+                f"HTTP {response.status} {_render_body(response.body)}",
+            )
+            continue
+
         # 401/403 here is the credential question: publish authorises on the
         # OAuth client, so name that explicitly rather than leaving an operator
         # to guess which of two credentials was rejected.
@@ -777,6 +936,25 @@ def _publish(client: TenantClient, request: PublishRequest) -> tuple[str, str]:
                 "/marketplace/apps/<id>/info did not expose it — check that read, "
                 "or pass --repo-url with the APP'S OWN repo (not the repo whose "
                 "CI is running: GM would repoint the app's provenance to it)."
+            )
+        elif _looks_like_upstream_unreachable(response):
+            # Retryable in shape, so getting here means the budget ran out. Say
+            # that, because the body claims a bad request and an operator who
+            # takes it at face value goes looking at the payload for a fault that
+            # is not in it.
+            hint = (
+                f" The body says 'check your request parameters', but this is "
+                f"Heracles reporting that the marketplace service did not answer "
+                f"IT — the payload is not the problem. Retried for {retry_seconds}s "
+                "and it stayed down, so this is an outage to raise rather than a "
+                "run to re-trigger."
+            )
+        elif attempt > 1:
+            hint = (
+                f" This was attempt {attempt}; an earlier attempt may have reached "
+                "GM before its response was lost, so a rejection naming an "
+                "existing version means the registration landed and only the "
+                "answer went missing."
             )
         raise TenantAppError(
             f"marketplace publish failed with HTTP {response.status}.{hint}\n"
@@ -1272,7 +1450,9 @@ def install(args: argparse.Namespace) -> InstallOutcome:
         release_model=args.release_model,
         created_by=args.created_by,
     )
-    version_id, release_id = _publish(publish_client, request)
+    version_id, release_id = _publish(
+        publish_client, request, retry_seconds=args.publish_retry_seconds
+    )
     print(f"registered version_id={version_id} release_id={release_id}")
 
     if args.scan_wait_seconds > 0:
@@ -1473,6 +1653,18 @@ def main(argv: list[str] | None = None) -> int:
             "Seconds to wait for GM's release scan before installing. 0 (the "
             "default) does not wait: a base-image CVE must not red an unrelated "
             "PR's e2e. Raise only if GM refuses to install an unscanned release."
+        ),
+    )
+    p_install.add_argument(
+        "--publish-retry-seconds",
+        type=int,
+        default=DEFAULT_PUBLISH_RETRY_SECONDS,
+        help=(
+            "How long to keep retrying the version-create while the marketplace "
+            "service is not answering. Covers Heracles' HTTP 400 'error getting "
+            "response from marketplace service', its 5xx, and the client-side "
+            "read timeout — not a real rejection, which stays fatal on the first "
+            "response. 0 disables the retry."
         ),
     )
     p_install.add_argument(

--- a/.github/scripts/tests/test_e2e_tenant_app.py
+++ b/.github/scripts/tests/test_e2e_tenant_app.py
@@ -134,6 +134,12 @@ def _install_args(**overrides: object) -> argparse.Namespace:
         "release_model": "",
         "created_by": "",
         "scan_wait_seconds": 0,
+        # Both retry budgets default to 0 here, and every test that wants a retry
+        # opts in. `time.sleep` is stubbed but `time.monotonic` is not, so a
+        # nonzero budget against a transport that never succeeds is a hot loop
+        # for that many real seconds — a test must either script a success or
+        # keep the budget at 0.
+        "publish_retry_seconds": 0,
         "install_retry_seconds": 0,
         "timeout_seconds": 600,
     }
@@ -348,6 +354,184 @@ def test_publish_without_a_version_id_fails_rather_than_installing_nothing(
     )
     with pytest.raises(app.TenantAppError, match="version_id"):
         app.install(_install_args())
+
+
+# ── The marketplace service is a shared dependency (FND-760) ─────────────────
+# Heracles reports "the marketplace service did not answer me" as HTTP 400
+# `code 1000` "Please check your request parameters" — a validation shape for
+# something that is not a validation failure. On 2026-08-24 that took four
+# connector PRs down in eight minutes across all three clouds. The publish is
+# retried through it; a real rejection still fails on the first response.
+
+
+def _upstream_down(status: int = 400) -> Response:
+    """Heracles' body when its own call to the marketplace service did not return.
+
+    Verbatim from the atlan-db2-app / atlan-databricks-app / cloudsql legs, minus
+    the requestId — the point of the fixture is that the retryable signal lives in
+    `message` and nowhere else.
+    """
+    return Response(
+        status=status,
+        body={
+            "code": 1000,
+            "error": "Please check your request parameters",
+            "info": None,
+            "message": "error getting response from marketplace service",
+        },
+    )
+
+
+def _publish_after(*failures: Response) -> StubTransport:
+    """Transport whose publish fails with each of ``failures``, then succeeds."""
+    return StubTransport(
+        routes=[
+            StubRoute("GET", "/info", _ok({})),
+            *[StubRoute("POST", "/marketplace/publish", f) for f in failures],
+            StubRoute("POST", "/marketplace/publish", _ok({"version_id": "v1"})),
+            StubRoute("POST", "/install", _ok({"deployment_id": "d1"})),
+            StubRoute("GET", "/deployments/", _ok({"deployment_status": "SUCCEEDED"})),
+            StubRoute("GET", "/info", _ok(_lm_info(_VERSION))),
+        ],
+        sticky=[StubRoute("GET", "/releases/", Response(status=404, body={}))],
+    )
+
+
+def test_publish_retries_through_the_marketplace_being_unreachable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    transport = _wire(
+        monkeypatch,
+        _publish_after(_upstream_down(), _upstream_down(), _upstream_down()),
+    )
+    outcome = app.install(_install_args(publish_retry_seconds=240))
+    assert outcome.deployment_id == "d1"
+    assert len([p for p in transport.paths("POST") if "/publish" in p]) == 4
+
+
+@pytest.mark.parametrize("status", [429, 500, 502, 503, 504])
+def test_publish_retries_the_transient_statuses(
+    monkeypatch: pytest.MonkeyPatch, status: int
+) -> None:
+    """A body-less 5xx/429 is retried on the status alone — no marker needed."""
+    transport = _wire(monkeypatch, _publish_after(Response(status=status, body={})))
+    app.install(_install_args(publish_retry_seconds=240))
+    assert len([p for p in transport.paths("POST") if "/publish" in p]) == 2
+
+
+def test_a_real_rejection_is_not_retried(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The bug this guards: retrying every publish 400.
+
+    Heracles' upstream-failure body IS a 400, so the temptation is to retry the
+    status. That would make a genuinely malformed request — and the CI/CD-managed
+    provenance guard, which arrives as a 400 too — spend the whole budget before
+    reporting the error a human has to read. Only the message discriminates.
+    """
+    transport = _wire(
+        monkeypatch,
+        StubTransport(
+            routes=[
+                StubRoute("GET", "/info", Response(status=404, body={})),
+                StubRoute(
+                    "POST",
+                    "/marketplace/publish",
+                    Response(
+                        status=400, body={"message": "version is managed by ci/cd"}
+                    ),
+                ),
+            ]
+        ),
+    )
+    with pytest.raises(app.TenantAppError, match="source_repo"):
+        app.install(_install_args(publish_retry_seconds=240))
+    assert len([p for p in transport.paths("POST") if "/publish" in p]) == 1
+
+
+def test_a_credential_rejection_is_never_retried(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Even carrying the retryable marker. Credentials do not come good on a retry.
+
+    The marker is upstream text, so a reworded or proxied 401 could carry it;
+    the status is checked first precisely so that cannot drag an auth failure
+    into a four-minute loop and bury the which-credential hint behind it.
+    """
+    transport = _wire(
+        monkeypatch,
+        StubTransport(
+            routes=[
+                StubRoute("GET", "/info", Response(status=404, body={})),
+                StubRoute("POST", "/marketplace/publish", _upstream_down(status=401)),
+            ]
+        ),
+    )
+    with pytest.raises(app.TenantAppError, match="E2E_OAUTH_CLIENT_ID"):
+        app.install(_install_args(publish_retry_seconds=240))
+    assert len([p for p in transport.paths("POST") if "/publish" in p]) == 1
+
+
+@dataclass
+class _PublishTimesOutThen:
+    """Raises a transport-level error on the first ``failures`` publishes.
+
+    A StubRoute can only carry a Response, and this fault has none: TenantClient
+    RAISES on DNS / connect / read-timeout rather than returning a status. So this
+    is the only way to reach `_publish`'s `except TenantApiError` arm — the arm
+    that covers the anaplan leg, where the marketplace service hung for the full
+    60s client timeout instead of answering.
+    """
+
+    inner: StubTransport
+    failures: int
+    seen: int = 0
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        *,
+        body: dict[str, object] | None = None,
+        timeout: int = 60,
+    ) -> Response:
+        if method == "POST" and "/marketplace/publish" in path:
+            self.seen += 1
+            if self.seen <= self.failures:
+                raise TenantApiError(
+                    f"POST {path} could not reach {_TENANT}: "
+                    "The read operation timed out"
+                )
+        return self.inner.request(method, path, body=body, timeout=timeout)
+
+
+def test_publish_retries_a_transport_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    transport = _PublishTimesOutThen(inner=_publish_after(), failures=2)
+    monkeypatch.setattr(TenantClient, "request", transport.request)
+    outcome = app.install(_install_args(publish_retry_seconds=240))
+    assert outcome.deployment_id == "d1"
+    assert transport.seen == 3
+
+
+def test_publish_budget_exhaustion_says_outage_not_bad_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Reaching here means the service stayed down, so the body is misleading.
+
+    Taking "check your request parameters" at face value sends the next person to
+    read the publish body for a fault that is not in it — which is exactly the
+    hour this failure mode has already cost.
+    """
+    _wire(
+        monkeypatch,
+        StubTransport(
+            routes=[StubRoute("GET", "/info", Response(status=404, body={}))],
+            sticky=[StubRoute("POST", "/marketplace/publish", _upstream_down())],
+        ),
+    )
+    with pytest.raises(app.TenantAppError) as excinfo:
+        app.install(_install_args(publish_retry_seconds=0))
+    message = str(excinfo.value)
+    assert "the payload is not the problem" in message
+    assert "outage to raise rather than a run to re-trigger" in message
 
 
 # ── Reconciliation ───────────────────────────────────────────────────────────

--- a/.github/scripts/tests/test_prepare_tenant_wiring.py
+++ b/.github/scripts/tests/test_prepare_tenant_wiring.py
@@ -973,16 +973,20 @@ def test_a_failed_discovery_skips_the_image_builds(
 def test_job_timeout_stays_above_the_scripts_own_waits(jobs: dict) -> None:  # type: ignore[type-arg]
     """The runner's timeout must not be able to fire before the script's.
 
-    The install retries while LM's catalog snapshot catches up, then polls the
-    deployment — both bounded by the script's defaults, since the step overrides
-    neither. If the job budget is under their sum, a slow sync reports as a bare
+    The publish retries while the marketplace service is not answering, then the
+    install retries while LM's catalog snapshot catches up, then the deployment
+    is polled — all three bounded by the script's defaults, since the step
+    overrides none of them. They are sequential in the worst case, so the budget
+    is their sum. If the job budget is under it, a slow sync reports as a bare
     "job cancelled after Nm" and the actionable error the script was about to
     print is never written: the diagnosis-hostile failure this whole job exists to
     avoid. Derived from the script's constants, so raising one of those fails here
     rather than silently making a job timeout reachable.
     """
     waits = (
-        app.DEFAULT_INSTALL_RETRY_SECONDS + app.DEFAULT_DEPLOYMENT_TIMEOUT_SECONDS
+        app.DEFAULT_PUBLISH_RETRY_SECONDS
+        + app.DEFAULT_INSTALL_RETRY_SECONDS
+        + app.DEFAULT_DEPLOYMENT_TIMEOUT_SECONDS
     ) // 60
     required = round(waits / _MAX_WAIT_SHARE)
     actual = jobs["prepare-tenant"]["timeout-minutes"]
@@ -997,7 +1001,11 @@ def test_job_timeout_stays_above_the_scripts_own_waits(jobs: dict) -> None:  # t
         for s in jobs["prepare-tenant"]["steps"]
         if str(s.get("name", "")) == "Install the app under test"
     ][0]
-    for flag in ("--install-retry-seconds", "--timeout-seconds"):
+    for flag in (
+        "--publish-retry-seconds",
+        "--install-retry-seconds",
+        "--timeout-seconds",
+    ):
         assert flag not in install["run"], (
             f"the step now passes {flag}, so the budget above is no longer the "
             "script's default — compute the timeout from the passed value instead"

--- a/.github/workflows/tests-reusable.yaml
+++ b/.github/workflows/tests-reusable.yaml
@@ -1624,12 +1624,17 @@ jobs:
       # tenant resolver take its single-tenant path.
       matrix: ${{ fromJson(needs.discover-e2e.outputs.cloud-count != '0' && needs.discover-e2e.outputs.cloud-matrix || '{"include":[{"cloud":""}]}') }}
     runs-on: ubuntu-latest
-    # Twice the script's own waits, not a shade over them: the install retries for
-    # up to ~600s while LM's catalog snapshot catches up, then polls the deployment
-    # for up to ~600s. At 30 the runner's timeout can fire first on a slow sync,
-    # and a bare "job cancelled after 30m" replaces the actionable error the script
-    # was about to print — the diagnosis-hostile failure this job exists to avoid.
-    timeout-minutes: 40
+    # Twice the script's own waits, not a shade over them: the publish retries for
+    # up to ~240s while the marketplace service is not answering, the install
+    # retries for up to ~600s while LM's catalog snapshot catches up, then the
+    # deployment is polled for up to ~600s. Set too tight, the runner's timeout
+    # fires first on a slow sync and a bare "job cancelled after Nm" replaces the
+    # actionable error the script was about to print — the diagnosis-hostile
+    # failure this job exists to avoid. This is a ceiling, not a spend: the job
+    # finishes in a handful of minutes whenever the tenants are healthy.
+    # test_job_timeout_stays_above_the_scripts_own_waits derives the floor from
+    # the script's constants, so this cannot drift below them unnoticed.
+    timeout-minutes: 48
     concurrency:
       # Run-unique, i.e. deliberately NOT a serialising group. Tenant exclusion
       # is the lease's job now (lease-tenant above), and the lease is strictly


### PR DESCRIPTION
## Why

On 2026-08-24 the marketplace service degraded for about eight minutes and took five connector e2e runs down with it — across **all three clouds**, so this is not the azure-tenant problem the earlier thread was tracking.

| Time (UTC) | App / cloud | Symptom |
|---|---|---|
| 08:57:05 | alloydb / azure | install → HTTP 200 body `status_code=500 'Internal server error'` |
| 09:00:27 | anaplan / azure | `POST .../marketplace/publish could not reach ***: read operation timed out` |
| 09:01:21 | db2 / azure | publish HTTP 400 `code 1000` |
| 09:01:21 | databricks / azure | publish HTTP 400 `code 1000` (same second) |
| 09:02:23–25 | cloudsql / aws + gcp | publish HTTP 400 `code 1000` |
| 09:05:13 | databricks / gcp | deployment FAILED + 9× status-read HTTP 400 |

One fault, four different-looking symptoms. Every publish failure carried the byte-identical Heracles envelope across four apps and three clouds:

```
{'code': 1000, 'error': 'Please check your request parameters',
 'message': 'error getting response from marketplace service'}
```

Transient, too — cloudsql re-ran at 12:20 and Prepare tenant passed on all three clouds with the same code and the same payload.

Only one of those symptoms survived, because `_poll_deployment` is the one caller that already retried a bad read — it rode through nine consecutive 400s. `_publish` retried nothing, so a blip became a red PR directly.

## What changed

`_publish` now retries the half of the failure space that self-heals, on a 240s budget sized from the observed outage (failures ran 09:00:27→09:02:25, next success 09:03:50 — anything under ~3 min would have bought nothing).

Retried: Heracles' 400 upstream-unreachable marker, 429/5xx, and the raised transport timeout.
Fatal on the first response: a genuine 400 such as the `cicd_managed` provenance guard, and 401/403 — checked *before* the marker so a reworded upstream can never drag a credential failure into a four-minute loop and bury the which-credential hint behind it.

Backoff is jittered, and is the only jittered wait in the file. The other two retries wait on something tenant-local; this one waits on the *shared* marketplace service, which fails for the whole fan-out at once, and the tenant lease cannot space those runs out — it is keyed `(app, cloud)` and its ref lives in each app's own repo, so two different apps never contend.

## Two things worth a reviewer's attention

**1. The retry matches on prose, not on a status.** That is deliberate and it is not something this PR can fix. Heracles reports *every* marketplace server fault as HTTP 400 `code 1000` "Please check your request parameters" — both by throwing `atlan.BAD_REQUEST` on a transport error, and by capping LM's real 5xx to 400 on the way out so Cloudflare does not replace the JSON body. So no marketplace 5xx exists at the API boundary and no client can branch on status. Filed as **DISTR-924**. `_looks_like_upstream_unreachable` is written to fail closed: reworded, it stops firing and the publish is fatal on its first response again — today's behaviour, not a new one.

**2. The install retry is deliberately not widened.** LM's `install_app` returns HTTP 200 for every failure with the cause discarded (blanket `except Exception`, constant "Internal server error"), so a 500 there is currently indistinguishable from a permanent LM bug — retrying it would delay a real failure rather than absorb a blip. Filed as **DISTR-925**; fixing it is what makes `_install` safely retryable.

## The two config raises are forced, not chosen

`test_job_timeout_stays_above_the_scripts_own_waits` derives `prepare-tenant`'s ceiling from the script's constants, and `test_the_lease_ttl_cannot_fire_on_a_healthy_holder` derives `ttl-seconds` from that ceiling. The ceiling was sitting exactly on its floor (40 = 20/0.5), so *any* publish budget above zero moves both. Both guards were updated to take the new constant rather than worked around — leaving it out of the sum is the silent regression they exist to catch.

`timeout-minutes` is a ceiling, not a spend: the job finishes in a handful of minutes whenever the tenants are healthy.

## Out of scope

`databricks / gcp` is the one failure in that batch **not** explained by the marketplace blip — the on-demand worker pod never scheduled (`NotTriggerScaleUp: 20 node(s) didn't match Pod's node affinity/selector, 2 max node group size reached`). Tenant capacity, separate owner.

## Testing

8 new cases: retry through the 400 marker, through 429/500/502/503/504, and through a transport timeout; a real 400 and a 401 are each asserted to make exactly one call; budget exhaustion is asserted to say *outage*, not bad payload.

`217 passed` across `test_e2e_tenant_app.py` + `test_prepare_tenant_wiring.py`; pre-commit clean (ruff, ruff-format, pyright, check-yaml).

## Security-relevant changes for review

Touches two control-plane files. Neither weakens a control:
- `.github/workflows/tests-reusable.yaml` — `timeout-minutes` 40 → 48 on `prepare-tenant`.
- `.github/actions/e2e-tenant-lease/action.yaml` — `ttl-seconds` 14400 → 16200, keeping the ≥1.5× margin over the longest legitimate hold so the TTL cannot break a live holder and put a second installer on a tenant.

Closes FND-760.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
