### PR TITLE
ci(renovate): bound the npm lock on the refresh lane (FND-380)

### DIFF
--- a/.github/scripts/bound_lock_branch.py
+++ b/.github/scripts/bound_lock_branch.py
@@ -48,6 +48,14 @@ shape:
    non-fast-forward rejection. That workflow skips this branch and hands the file
    over here, keeping a single writer per branch.
 
+5. **The npm lock is bounded too, by a different driver.** The lane rewrites a
+   fourth file, ``packages/conformance/conformance/package-lock.json``, and npm
+   can express none of the per-package retention ceilings the uv bound depends
+   on — so ``renovate_npm_lock_bounded`` gates the whole file instead: take the
+   bounded resolve, or restore the base branch's lock verbatim. FND-380. It rides
+   in the same commit for the same reason the two uv locks do.
+
+
 Fail-closed, like the driver it wraps. If any project's bound cannot be applied,
 this exits non-zero having committed nothing — a red check on the PR, which the
 auto-approve gate then declines to approve. A control whose failure mode is a log
@@ -64,6 +72,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
 
+import renovate_npm_lock_bounded as npm_bounded
 import renovate_uv_lock_bounded as bounded
 
 COMMIT_MESSAGE = "chore(deps): bound the refreshed locks to the release-age window"
@@ -100,6 +109,12 @@ PROJECTS: tuple[Project, ...] = (
     ),
 )
 
+# The one npm project the refresh lane rewrites: dev-only devDependencies for the
+# remediation programs, never bundled in the published wheel. Its bound is a
+# different mechanism from the uv projects' (see renovate_npm_lock_bounded), so it
+# is declared separately rather than squeezed into Project.
+NPM_PROJECT = "packages/conformance/conformance"
+
 # Regenerated from the ROOT lock. Flags match dependabot-requirements-sync.yaml
 # byte for byte so the file this produces is the same file that workflow produces
 # — deliberately not --all-extras, which would widen what the export pins.
@@ -126,6 +141,26 @@ def bound_project(project: Project, window: str, baseline_ref: str, root: Path) 
     for name in project.exempt:
         argv += ["--exempt", name]
     return bounded.main(argv)
+
+
+def bound_npm(window: str, baseline_ref: str, root: Path) -> int:
+    """Run the npm driver over the one npm project. Returns its exit code.
+
+    Same window as the uv projects deliberately — see the driver's docstring for
+    what that leaves on the table against the org checker's own threshold, and why
+    closing that gap is the checker's change to make rather than a second window
+    here.
+    """
+    return npm_bounded.main(
+        [
+            "--window",
+            window,
+            "--baseline-ref",
+            baseline_ref,
+            "--project-dir",
+            str(root / NPM_PROJECT),
+        ]
+    )
 
 
 def export_requirements(root: Path) -> None:
@@ -217,6 +252,15 @@ def main(argv: list[str] | None = None) -> int:
             )
             return code
 
+    code = bound_npm(args.window, args.baseline_ref, root)
+    if code != 0:
+        print(
+            f"npm bound failed for {NPM_PROJECT!r}; committing nothing so the "
+            "unbounded locks cannot merge.",
+            file=sys.stderr,
+        )
+        return code
+
     try:
         export_requirements(root)
     except RuntimeError as error:
@@ -224,6 +268,7 @@ def main(argv: list[str] | None = None) -> int:
         return 1
 
     paths = [f"{p.directory}/uv.lock".removeprefix("./") for p in PROJECTS]
+    paths.append(f"{NPM_PROJECT}/{npm_bounded.LOCKFILE}")
     paths.append(REQUIREMENTS_PATH)
     stage_and_commit(root, paths)
     return 0

--- a/.github/scripts/renovate_npm_lock_bounded.py
+++ b/.github/scripts/renovate_npm_lock_bounded.py
@@ -1,0 +1,483 @@
+#!/usr/bin/env python3
+"""Apply the release-age bound to ``package-lock.json`` on the refresh lane.
+
+FND-376 bounded the three Python files ``renovate/lock-file-maintenance``
+rewrites in this repo. It left the fourth — ``packages/conformance/conformance/
+package-lock.json`` — unbounded, which was the whole of the remaining
+``checks/dep-cooldown`` failure on that lane (measured on #3355: the branch's
+entire net diff was that one file, and the check named ``fast-uri@3.1.6``,
+published the same day). FND-380 closes it.
+
+Why this is not the uv driver with a different command
+-----------------------------------------------------
+``renovate_uv_lock_bounded`` gives every package a *retention ceiling* —
+``--exclude-newer-package <name>=<upload-time of the version main pins>`` — so a
+bounded resolve can decline to adopt something new without ever rolling anything
+back. **npm has no per-package equivalent, and there is no forward-only mode at
+all.** Measured against this project on npm 11.19.0, with ``X`` a 7-day cutoff:
+
+===========================================================  ======================
+command                                                      versus ``main``
+===========================================================  ======================
+``npm install --package-lock-only`` (lock present)           byte-identical, no-op
+``npm install --package-lock-only --before=X`` (lock present) **no-op** — npm keeps
+                                                             a lock that already
+                                                             satisfies the ranges
+``npm install --package-lock-only --before=X`` (no lock)      4 rolled BACK
+``npm update --package-lock-only --before=X`` (lock present)  the same 4 rolled BACK
+===========================================================  ======================
+
+The rollbacks were ``fast-uri 3.1.6 -> 3.1.5``, ``hono 4.13.4 -> 4.13.2``,
+``jose 6.2.10 -> 6.2.9`` and ``negotiator 1.1.0 -> 1.0.0`` — all four adopted by
+``main`` before this bound existed, so all four are inside a 7-day window. At the
+``P3D`` this lane actually runs, three of them still are (``negotiator`` has since
+aged out and ``hono`` resolves to 4.13.3). Either way it is the mass-rollback
+failure FND-359 corrected before merge, and reverting a version adopted because it
+fixed something is worse than adopting a fix late.
+
+Note the second row especially: it is the silent one. Leaving the committed lock
+in place and adding ``--before`` produces a *clean exit and no change whatsoever*,
+so a bound written that way would report success, bound nothing, and look
+identical to a lane with nothing to do. The lock must be removed first for the
+date bound to mean anything.
+
+So the bound here is all-or-nothing on the whole file
+----------------------------------------------------
+1. Re-resolve from ``package.json`` alone, with ``--before`` set to the window.
+2. Compare the result against the lock ``main`` ships. Any package whose newest
+   locked version went *down* is a regression.
+3. On any regression, restore ``main``'s lock **verbatim** and take nothing.
+   Otherwise take the bounded resolve.
+
+The fallback is byte-for-byte what ``main`` already ships, so this can never roll
+a version back — not as a policy that holds if the comparison is right, but
+structurally, because the only two things it can ever write are a resolve that
+regressed nothing and the file it is comparing against. And it can never adopt
+something fresh, because npm did the date filtering and the whole refresh is
+declined when any part of it regresses.
+
+What that costs, and why a decline is not a failure
+---------------------------------------------------
+The coupling is real: one package that ``main`` adopted inside the window holds
+the entire npm lock until it ages out. Today that is three of them, so this
+declines and the lane's npm diff is empty. It is not a permanent stall — under
+this bound ``main`` only ever takes versions that were already ``--window`` old,
+so once the pre-bound adoptions age past the window a bounded resolve stops
+regressing and the file starts moving again.
+
+A decline is therefore an ordinary outcome, reported and exit 0, not an error. It
+has to be: nothing in CI installs this lock (no ``npm ci`` anywhere in the repo),
+so unlike the uv side there is no required check whose failure could hold the
+branch, and there is nothing for a red to protect. What a decline produces is
+exactly the state the branch would be in if the file were in ``ignorePaths`` —
+which is the safe state. Errors that are *not* safe — npm unavailable, the
+registry unreachable, a lock that cannot be parsed, a manifest that has moved out
+from under the baseline — return non-zero and the caller commits nothing, the
+same fail-closed-not-fail-partial rule ``bound_lock_branch`` applies to the uv
+projects.
+
+Window
+------
+``P3D``, passed by the caller to match the uv lane rather than the checker. Note
+what that means: ``checks/dep-cooldown`` (the ``atlan-security`` App, not a
+workflow in this repo) still enforces **7 days** — measured 2026-08-24 on #3365,
+which it failed on a 3-day-old release. So an adoption aged between 3 and 7 days
+is bounded correctly by policy and still reported by the check. That residual gap
+is deliberate and recorded in ``docs/standards/ci.md``; closing it means aligning
+the App's threshold to the fleet's 3-day policy (FND-761), not widening the bound
+here.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+import renovate_uv_lock_bounded as uv_bounded
+
+LOCKFILE = "package-lock.json"
+MANIFEST = "package.json"
+
+# `npm install` resolving nothing but the tree. `--ignore-scripts` is belt and
+# braces — `--package-lock-only` installs nothing, so there is no lifecycle script
+# to run — and the other two only quieten output that would otherwise bury the
+# resolve's own errors.
+NPM_RESOLVE = [
+    "npm",
+    "install",
+    "--package-lock-only",
+    "--ignore-scripts",
+    "--no-audit",
+    "--no-fund",
+]
+
+_SEMVER_RE = re.compile(
+    r"^v?(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$"
+)
+
+
+def semver_key(version: str) -> tuple | None:
+    """Semver precedence as a sortable tuple, or None when it does not parse.
+
+    Deliberately not ``packaging.Version``, which the uv driver's ``_version_key``
+    uses. PEP 440 gets many semver strings right, and two categories dangerously
+    wrong. Both measured against packaging 26.3:
+
+    * **Inverted.** ``1.0.0-1`` normalises to ``1.0.0.post1``, which compares
+      *greater* than ``1.0.0`` — so a rollback from ``1.0.0`` to the prerelease
+      ``1.0.0-1`` would read as an upgrade and pass the gate.
+    * **Unparseable.** ``7.0.0-next.5``, ``1.0.0-alpha.beta`` and ``1.2.3-0.3.7``
+      are all valid semver and all raise ``InvalidVersion``. ``-next.N`` is an
+      ordinary npm release channel, so this is not an exotic case, and the uv
+      driver treats "cannot parse" as a regression — which would wedge this file
+      into declining every run for as long as one such version was in the tree.
+
+    The ordering implemented here is semver.org §11: release triple first, then a
+    release outranking any prerelease of itself, then prerelease identifiers
+    compared one by one with numeric ones ordering below alphanumeric ones, and a
+    shorter run of identifiers ordering below a longer one that shares its prefix.
+    Build metadata is ignored, as semver requires — PEP 440 would read it as a
+    local version and rank ``1.0.0+build.1`` above ``1.0.0``.
+
+    Returns None rather than guessing, so the caller can report an unparseable
+    version instead of silently dropping the comparison — the same choice
+    ``renovate_uv_lock_bounded._version_key`` makes, for the same reason: the
+    version nobody can order is the one most worth a human look.
+    """
+    match = _SEMVER_RE.match(version.strip())
+    if not match:
+        return None
+    major, minor, patch, prerelease = match.groups()
+    release = (int(major), int(minor), int(patch))
+    if prerelease is None:
+        # No prerelease outranks every prerelease of the same release, hence the 1.
+        return (release, 1, ())
+    identifiers: list[tuple[int, int | str]] = []
+    for part in prerelease.split("."):
+        # Numeric identifiers compare numerically and rank below alphanumeric
+        # ones, so the leading 0/1 carries that class distinction into the tuple.
+        identifiers.append((0, int(part)) if part.isdigit() else (1, part))
+    return (release, 0, tuple(identifiers))
+
+
+def package_name(path: str, entry: dict) -> str | None:
+    """The package name for one ``packages`` entry, or None for the project root.
+
+    npm keys ``packages`` by *install path* — ``node_modules/@openprose/reactor``,
+    ``node_modules/negotiator/node_modules/content-type`` — and only the root
+    entry (key ``""``) carries an explicit ``name``. The name is whatever follows
+    the last ``node_modules/``, which keeps the ``@scope/`` prefix intact.
+    """
+    if not path:
+        return None
+    name = entry.get("name")
+    if isinstance(name, str) and name:
+        return name
+    marker = "node_modules/"
+    index = path.rfind(marker)
+    return path[index + len(marker) :] if index != -1 else path
+
+
+def lock_versions(lock_text: str) -> dict[str, set[str]]:
+    """``{package name: every version the lock pins it at}``.
+
+    Keyed by NAME and not by install path, because the install path is a resolver
+    detail: a package that moves between a hoisted and a nested position changes
+    its key without changing its version, and comparing paths would read that as
+    one entry vanishing and another appearing. Observed in this project — a
+    ``negotiator`` downgrade takes its nested ``content-type`` copy with it, so
+    the path set differs between the two resolves while the versions that matter
+    are still directly comparable. A name can legitimately appear at several
+    versions at once (three separate ``content-type`` copies here), hence a set
+    rather than a single version.
+
+    An empty or unparseable document raises, so a truncated lock cannot read as
+    "no packages" — which would make every comparison against it vacuous.
+    """
+    document = json.loads(lock_text)
+    packages = document.get("packages")
+    if not isinstance(packages, dict):
+        raise ValueError(
+            "lockfile has no `packages` table, so nothing can be compared; "
+            "expected npm lockfileVersion 2 or 3"
+        )
+    versions: dict[str, set[str]] = {}
+    for path, entry in packages.items():
+        if not isinstance(entry, dict):
+            continue
+        name = package_name(path, entry)
+        version = entry.get("version")
+        if name and isinstance(version, str) and version:
+            versions.setdefault(name, set()).add(version)
+    return versions
+
+
+def regressions(
+    before: dict[str, set[str]], after: dict[str, set[str]]
+) -> dict[str, tuple[str, str]]:
+    """``{name: (baseline newest, resolved newest)}`` for anything that went down.
+
+    Compares the NEWEST version each name is pinned at on either side. That is
+    the question the gate is actually asking — "does this resolve take away a
+    release ``main`` already has?" — and it is the formulation that survives a
+    tree reshuffle, where the same versions sit at different install paths.
+
+    A name that disappears entirely is not a regression: it means nothing depends
+    on it in the bounded solution any more. Whatever *caused* it to drop out is
+    itself a version move, and shows up here under its own name.
+
+    A version that does not parse is reported rather than skipped — an unorderable
+    version is exactly the case worth declining over — but only when the name's
+    version set actually *moved*. A non-semver pin that both sides share (a git or
+    file dependency, say) would otherwise decline every run forever, which is a
+    wedge, not a control.
+    """
+    found: dict[str, tuple[str, str]] = {}
+    for name, baseline_versions in before.items():
+        resolved_versions = after.get(name)
+        if not resolved_versions or baseline_versions == resolved_versions:
+            continue
+        newest_before = newest(baseline_versions)
+        newest_after = newest(resolved_versions)
+        if newest_before is None or newest_after is None:
+            found[name] = (
+                ", ".join(sorted(baseline_versions)),
+                ", ".join(sorted(resolved_versions)),
+            )
+        elif semver_key(newest_after) < semver_key(newest_before):  # type: ignore[operator]
+            found[name] = (newest_before, newest_after)
+    return found
+
+
+def newest(versions: set[str]) -> str | None:
+    """The highest version by semver precedence, or None if any does not parse.
+
+    All-or-nothing on purpose: a set containing one unorderable string has no
+    well-defined maximum, and picking the highest of the rest would quietly
+    compare against a version that may not be the real ceiling.
+    """
+    keys = {version: semver_key(version) for version in versions}
+    if not keys or any(key is None for key in keys.values()):
+        return None
+    return max(keys, key=lambda version: keys[version])  # type: ignore[arg-type,return-value]
+
+
+def committed_text(project_dir: Path, ref: str, filename: str) -> str | None:
+    """One file as COMMITTED at ``ref``, or None when it is verifiably absent.
+
+    Absence is established with ``git ls-tree`` rather than inferred from a failed
+    ``git show``, because ``git show`` exits non-zero for both "path absent" and
+    "blob unreadable" and cannot tell them apart — treating the second as the
+    first would silently compare against nothing. Same reasoning, and the same
+    ``<rev>:./<path>`` form, as ``renovate_uv_lock_bounded.baseline_lock_text``:
+    a bare ``<rev>:<path>`` resolves from the repo root wherever it runs, so
+    without the ``./`` this would read the wrong file for a nested project.
+    """
+    listing = subprocess.run(
+        ["git", "ls-tree", "-r", "--name-only", ref, "--", filename],
+        cwd=project_dir,
+        capture_output=True,
+        text=True,
+    )
+    if listing.returncode != 0:
+        raise RuntimeError(
+            f"cannot inspect {ref}'s tree in {project_dir}: {listing.stderr.strip()}"
+        )
+    if filename not in listing.stdout.splitlines():
+        return None
+    show = subprocess.run(
+        ["git", "show", f"{ref}:./{filename}"],
+        cwd=project_dir,
+        capture_output=True,
+        text=True,
+    )
+    if show.returncode != 0:
+        raise RuntimeError(
+            f"{filename} exists in {ref} but cannot be read in {project_dir}: "
+            f"{show.stderr.strip()}"
+        )
+    return show.stdout
+
+
+def bounded_resolve(
+    project_dir: Path, cutoff: dt.datetime
+) -> subprocess.CompletedProcess[str]:
+    """Re-resolve the tree with nothing published after ``cutoff`` visible.
+
+    The lock is removed first by the caller, and that is load-bearing rather than
+    tidy: with a lock in place that already satisfies ``package.json``, npm has
+    nothing to do and ``--before`` changes nothing at all (measured — see the
+    module docstring). Resolving from the manifest alone is the only way the date
+    bound reaches the tree.
+    """
+    command = [*NPM_RESOLVE, f"--before={cutoff.strftime('%Y-%m-%dT%H:%M:%SZ')}"]
+    return subprocess.run(command, cwd=project_dir, capture_output=True, text=True)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--window",
+        required=True,
+        help="Release-age bound as an ISO 8601 duration, e.g. P3D. Match the uv "
+        "lane's: a second window in the same workflow needs its own "
+        "justification, and the fleet's policy is one number.",
+    )
+    parser.add_argument(
+        "--baseline-ref",
+        required=True,
+        help="Git ref whose package-lock.json is the baseline for the rollback "
+        "gate AND the content restored when the gate declines — the PR's base "
+        "branch, e.g. origin/main. Required rather than defaulted to HEAD: HEAD "
+        "on this lane is Renovate's unbounded refresh, so comparing against it "
+        "would report a regression for every version the bound correctly holds "
+        "back, and restoring it would ship the refresh this exists to bound.",
+    )
+    parser.add_argument("--project-dir", default=".")
+    args = parser.parse_args(argv)
+
+    project_dir = Path(args.project_dir).resolve()
+    lock_path = project_dir / LOCKFILE
+    manifest_path = project_dir / MANIFEST
+
+    if not lock_path.exists() or not manifest_path.exists():
+        print(
+            f"No {LOCKFILE}/{MANIFEST} pair in {project_dir} — nothing to bound.",
+            file=sys.stderr,
+        )
+        return 0
+
+    try:
+        window = uv_bounded.parse_window(args.window)
+    except ValueError as error:
+        print(str(error), file=sys.stderr)
+        return 1
+
+    try:
+        baseline_lock = committed_text(project_dir, args.baseline_ref, LOCKFILE)
+        baseline_manifest = committed_text(project_dir, args.baseline_ref, MANIFEST)
+    except RuntimeError as error:
+        print(str(error), file=sys.stderr)
+        return 1
+
+    if baseline_lock is None:
+        # A lock added in this very branch. There is nothing to compare against
+        # and nothing to fall back to, so the gate cannot run — and a bounded
+        # resolve with no gate behind it is the mass-rollback shape this exists to
+        # avoid. Leave the file alone and say so.
+        print(
+            f"No {LOCKFILE} committed at {args.baseline_ref}, so there is no "
+            "baseline to compare against and nothing to restore if the resolve "
+            "regresses. Leaving the lock untouched.",
+            file=sys.stderr,
+        )
+        return 0
+
+    # The decline path writes the baseline lock back. That is only a coherent
+    # thing to do while the manifest it was resolved from is still the manifest on
+    # the branch — otherwise the restore produces a lock that does not satisfy
+    # `package.json`, which `npm ci` rejects. lockFileMaintenance never edits a
+    # manifest, so this should not fire; it is here because the failure it guards
+    # is silent, and cheap to make impossible.
+    if baseline_manifest is not None and baseline_manifest != manifest_path.read_text():
+        print(
+            f"{MANIFEST} differs from {args.baseline_ref}, so the baseline lock is "
+            "no longer a valid fallback for this branch and the bound has no safe "
+            "outcome to fall back to. Refusing rather than restoring a lock the "
+            "manifest does not match.",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        before = lock_versions(baseline_lock)
+    except (ValueError, json.JSONDecodeError) as error:
+        print(
+            f"cannot read {LOCKFILE} at {args.baseline_ref}: {error}", file=sys.stderr
+        )
+        return 1
+
+    refreshed = lock_path.read_text()
+    cutoff = dt.datetime.now(dt.timezone.utc) - window
+
+    # Removed, not overwritten: `--before` against a lock that already satisfies
+    # the manifest is a silent no-op. Restored on every path out of here.
+    lock_path.unlink()
+    result = bounded_resolve(project_dir, cutoff)
+    if result.returncode != 0 or not lock_path.exists():
+        lock_path.write_text(baseline_lock)
+        print(
+            f"Bounded npm resolve failed, so {LOCKFILE} has been restored to what "
+            f"{args.baseline_ref} ships and this run bounds nothing. Refusing to "
+            "fall back to Renovate's unbounded lock.\n" + result.stderr,
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        after = lock_versions(lock_path.read_text())
+    except (ValueError, json.JSONDecodeError) as error:
+        lock_path.write_text(baseline_lock)
+        print(
+            f"bounded resolve produced an unreadable {LOCKFILE} ({error}); "
+            f"restored {args.baseline_ref}'s copy.",
+            file=sys.stderr,
+        )
+        return 1
+
+    regressed = regressions(before, after)
+    if regressed:
+        lock_path.write_text(baseline_lock)
+        detail = ", ".join(
+            f"{name} {old} -> {new}" for name, (old, new) in sorted(regressed.items())
+        )
+        uv_bounded.summarise(
+            [
+                f"**npm bound declined** (`{args.window}`): the bounded resolve "
+                f"would move {len(regressed)} package(s) backwards.",
+                "",
+                f"- {detail}",
+                f"- `{LOCKFILE}` restored to `{args.baseline_ref}` verbatim, so "
+                "this lane's npm diff is empty rather than a rollback.",
+                "- npm has no per-package retention ceiling, so the refusal is "
+                "all-or-nothing on the whole file. Nothing needs fixing: these "
+                f"versions were adopted inside the window and the bound will stop "
+                f"declining once they are `{args.window}` old.",
+            ]
+        )
+        return 0
+
+    advanced = sorted(
+        name
+        for name, versions in after.items()
+        if name in before and before[name] != versions
+    )
+    added = sorted(name for name in after if name not in before)
+    dropped = sorted(name for name in before if name not in after)
+    unchanged = lock_path.read_text() == refreshed
+    uv_bounded.summarise(
+        [
+            f"**npm bound applied:** `{args.window}` to `{LOCKFILE}`",
+            "",
+            f"- {len(advanced)} package(s) moved, {len(added)} added, "
+            f"{len(dropped)} no longer required — none published inside the window",
+            "- no package moved backwards from what the base branch ships, checked "
+            "on the newest version each name is pinned at",
+            "- identical to Renovate's own refresh: nothing it took was inside the "
+            "window"
+            if unchanged
+            else "- differs from Renovate's refresh, which resolved unbounded",
+        ]
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/tests/test_bound_lock_branch.py
+++ b/.github/scripts/tests/test_bound_lock_branch.py
@@ -45,12 +45,17 @@ def git(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
 
 @pytest.fixture
 def repo(tmp_path: Path) -> Path:
-    """A repo shaped like application-sdk: two uv projects and a requirements.txt."""
+    """A repo shaped like application-sdk: two uv projects, one npm project, and a
+    requirements.txt. All four files the refresh lane rewrites."""
     (tmp_path / "uv.lock").write_text("root lock\n")
     (tmp_path / "requirements.txt").write_text("stale==1.0.0\n")
     sub = tmp_path / "packages" / "conformance"
     sub.mkdir(parents=True)
     (sub / "uv.lock").write_text("sub lock\n")
+    npm_project = tmp_path / orchestrator.NPM_PROJECT
+    npm_project.mkdir(parents=True, exist_ok=True)
+    (npm_project / "package.json").write_text('{"name": "remediation"}\n')
+    (npm_project / "package-lock.json").write_text('{"lockfileVersion": 3}\n')
     git(tmp_path, "init", "-q")
     git(tmp_path, "add", "-A")
     git(tmp_path, "commit", "-qm", "base")
@@ -198,12 +203,44 @@ class TestBoundProject:
             assert exempt == list(project.exempt)
 
 
+class TestBoundNpm:
+    """The fourth file the lane rewrites, bounded by a different mechanism."""
+
+    def test_the_npm_project_is_the_one_under_packages_conformance(self):
+        # Two levels of `conformance`, which is easy to get wrong by one: the uv
+        # project is packages/conformance, the npm project is one deeper.
+        assert orchestrator.NPM_PROJECT == "packages/conformance/conformance"
+
+    def test_the_npm_driver_gets_the_same_window_and_baseline_as_the_uv_bound(
+        self, monkeypatch, tmp_path
+    ):
+        """A second window in one workflow would need its own justification, and a
+        baseline other than the base branch is what makes "never roll back what
+        main ships" structural rather than a claim."""
+        calls: list[list[str]] = []
+        monkeypatch.setattr(
+            orchestrator.npm_bounded, "main", lambda argv: calls.append(argv) or 0
+        )
+        orchestrator.bound_npm("P3D", "origin/main", tmp_path)
+
+        (argv,) = calls
+        assert argv[argv.index("--window") + 1] == "P3D"
+        assert argv[argv.index("--baseline-ref") + 1] == "origin/main"
+        assert argv[argv.index("--project-dir") + 1] == str(
+            tmp_path / orchestrator.NPM_PROJECT
+        )
+        # The npm bound has no exempt set: exemptions exist to let a first-party
+        # package move ahead of the window, and none of these three dev-only
+        # devDependencies is Atlan-published.
+        assert "--exempt" not in argv
+
+
 class TestMain:
     """End to end with the bound stubbed. The invariant under test throughout is
     that nothing reaches a commit unless every project was bounded successfully."""
 
-    def _stub_bound(self, monkeypatch, *, rewrite: bool = True):
-        """Stand in for the driver. `rewrite=False` models an already-bound branch."""
+    def _stub_bound(self, monkeypatch, *, rewrite: bool = True, npm_code: int = 0):
+        """Stand in for both drivers. `rewrite=False` models an already-bound branch."""
 
         def fake_main(argv: list[str]) -> int:
             directory = Path(argv[argv.index("--project-dir") + 1])
@@ -211,12 +248,19 @@ class TestMain:
                 (directory / "uv.lock").write_text("bounded\n")
             return 0
 
-        monkeypatch.setattr(orchestrator.bounded, "main", fake_main)
+        def fake_npm_main(argv: list[str]) -> int:
+            directory = Path(argv[argv.index("--project-dir") + 1])
+            if rewrite and npm_code == 0:
+                (directory / "package-lock.json").write_text('{"bounded": true}\n')
+            return npm_code
 
-    def test_one_commit_carries_both_locks_and_the_requirements_export(
+        monkeypatch.setattr(orchestrator.bounded, "main", fake_main)
+        monkeypatch.setattr(orchestrator.npm_bounded, "main", fake_npm_main)
+
+    def test_one_commit_carries_every_lock_and_the_requirements_export(
         self, monkeypatch, in_repo
     ):
-        """One commit, not three: each push re-fires the PR's whole check suite."""
+        """One commit, not four: each push re-fires the PR's whole check suite."""
         self._stub_bound(monkeypatch)
         monkeypatch.setattr(
             orchestrator,
@@ -228,9 +272,29 @@ class TestMain:
         assert head_files(in_repo) == {
             "uv.lock",
             "packages/conformance/uv.lock",
+            f"{orchestrator.NPM_PROJECT}/package-lock.json",
             "requirements.txt",
         }
         assert head_subject(in_repo) == orchestrator.COMMIT_MESSAGE
+
+    def test_a_failed_npm_bound_commits_nothing_at_all(self, monkeypatch, in_repo):
+        """Same fail-closed-not-fail-partial rule the uv projects get.
+
+        A half-bounded branch still auto-merges and still looks like the control
+        worked. The npm driver reserves a non-zero exit for the cases where it
+        could not establish a safe outcome at all — a declined bound is exit 0,
+        precisely so an ordinary decline does not throw away the uv bounds that
+        did apply.
+        """
+        self._stub_bound(monkeypatch, npm_code=1)
+        exported: list[Path] = []
+        monkeypatch.setattr(
+            orchestrator, "export_requirements", lambda root: exported.append(root)
+        )
+
+        assert orchestrator.main(["--window", "P7D", "--baseline-ref", "HEAD"]) == 1
+        assert head_subject(in_repo) == "base"
+        assert exported == [], "the export must not run against a half-bound tree"
 
     def test_a_failed_bound_commits_nothing_at_all(self, monkeypatch, in_repo):
         """Fail-closed, and specifically not fail-partial.

--- a/.github/scripts/tests/test_renovate_npm_lock_bounded.py
+++ b/.github/scripts/tests/test_renovate_npm_lock_bounded.py
@@ -1,0 +1,458 @@
+"""Tests for .github/scripts/renovate_npm_lock_bounded.py.
+
+Pure-unit: npm is never invoked. The resolve is stubbed, because what needs cover
+is not "does npm work" but every way this can go wrong quietly —
+
+* a comparison that reads a downgrade as an upgrade (the PEP 440 trap),
+* a gate that fires on a tree reshuffle and so never lets the file move,
+* a decline that writes back something other than exactly what the base branch
+  ships, which is the one thing the mechanism promises it can never do,
+* and a resolve that runs with the old lock still in place, where ``--before`` is
+  a documented no-op and the whole bound silently evaporates.
+
+The last one is why the invariant is asserted from inside the stub.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import renovate_npm_lock_bounded as npm
+
+WORKFLOW = (
+    Path(__file__).parent.parent.parent / "workflows" / "renovate-lock-cooldown.yaml"
+)
+
+GIT_ENV = {
+    "GIT_AUTHOR_NAME": "t",
+    "GIT_AUTHOR_EMAIL": "t@t",
+    "GIT_COMMITTER_NAME": "t",
+    "GIT_COMMITTER_EMAIL": "t@t",
+    "GIT_CONFIG_GLOBAL": "/dev/null",
+    "GIT_CONFIG_SYSTEM": "/dev/null",
+    "PATH": __import__("os").environ.get("PATH", ""),
+}
+
+MANIFEST = {
+    "name": "remediation",
+    "version": "1.0.0",
+    "devDependencies": {"@openprose/reactor": "^0.3.1"},
+}
+
+
+def git(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args], cwd=cwd, check=True, env=GIT_ENV, capture_output=True, text=True
+    )
+
+
+def lock(**names: str) -> str:
+    """An npm lockfile pinning each name at a version, hoisted under node_modules.
+
+    Keyword form for the common case; `lock_at` takes explicit install paths for
+    the nested-copy and reshuffle cases.
+    """
+    return lock_at({f"node_modules/{name}": version for name, version in names.items()})
+
+
+def lock_at(paths: dict[str, str]) -> str:
+    """An npm lockfile pinning the given install paths at the given versions."""
+    packages: dict[str, dict] = {
+        "": {"name": "remediation", "version": "1.0.0", "devDependencies": {}}
+    }
+    for path, version in paths.items():
+        packages[path] = {"version": version, "dev": True}
+    return json.dumps(
+        {"name": "remediation", "lockfileVersion": 3, "packages": packages}, indent=2
+    )
+
+
+@pytest.fixture
+def project(tmp_path: Path) -> Path:
+    """A git repo whose HEAD is the baseline and whose worktree is the refresh.
+
+    Shaped like the real one: the npm project sits several directories down, which
+    is what makes the `<rev>:./<path>` form in committed_text load-bearing. A
+    decoy lock at the repo root catches a driver that reads the wrong file.
+    """
+    (tmp_path / "package-lock.json").write_text(lock(decoy="9.9.9"))
+    directory = tmp_path / "packages" / "conformance" / "conformance"
+    directory.mkdir(parents=True)
+    (directory / "package.json").write_text(json.dumps(MANIFEST, indent=2))
+    (directory / "package-lock.json").write_text(lock(hono="4.13.1", jose="6.2.8"))
+    git(tmp_path, "init", "-q")
+    git(tmp_path, "add", "-A")
+    git(tmp_path, "commit", "-qm", "baseline")
+    return directory
+
+
+def stub_resolve(monkeypatch, produced: str | None, *, returncode: int = 0):
+    """Stand in for npm. Asserts the lock was removed before the resolve ran."""
+    seen: dict[str, bool] = {}
+
+    def fake(project_dir: Path, cutoff) -> subprocess.CompletedProcess[str]:
+        lock_path = project_dir / npm.LOCKFILE
+        # THE invariant. `--before` against a lock that already satisfies
+        # package.json exits clean and changes nothing, so a resolve that runs
+        # with the old lock still there bounds nothing and reports success.
+        seen["removed"] = not lock_path.exists()
+        if produced is not None:
+            lock_path.write_text(produced)
+        return subprocess.CompletedProcess(["npm"], returncode, "", "boom")
+
+    monkeypatch.setattr(npm, "bounded_resolve", fake)
+    return seen
+
+
+def run(project_dir: Path, ref: str = "HEAD") -> int:
+    return npm.main(
+        ["--window", "P3D", "--baseline-ref", ref, "--project-dir", str(project_dir)]
+    )
+
+
+class TestSemverKey:
+    """Ordering, and specifically the cases PEP 440 gets wrong.
+
+    The uv driver compares with `packaging.Version`; reusing it here would be the
+    obvious economy and is the bug this class exists to prevent.
+    """
+
+    @pytest.mark.parametrize(
+        "lower, higher",
+        [
+            ("1.2.3", "1.2.4"),
+            ("1.2.3", "1.3.0"),
+            ("1.9.0", "1.10.0"),
+            ("4.13.2", "4.13.4"),
+            # A release outranks every prerelease of itself.
+            ("1.0.0-rc.1", "1.0.0"),
+            # Numeric identifiers compare numerically, not as strings.
+            ("1.0.0-beta.2", "1.0.0-beta.11"),
+            # A shorter run of identifiers ranks below a longer one sharing it.
+            ("1.0.0-alpha", "1.0.0-alpha.1"),
+            # Numeric identifiers rank below alphanumeric ones.
+            ("1.0.0-1", "1.0.0-alpha"),
+            ("1.0.0-alpha.1", "1.0.0-alpha.beta"),
+        ],
+    )
+    def test_ordering(self, lower: str, higher: str):
+        assert npm.semver_key(lower) < npm.semver_key(higher)
+
+    def test_a_numeric_prerelease_ranks_below_its_release(self):
+        """PEP 440 reads `1.0.0-1` as `1.0.0.post1` and ranks it ABOVE `1.0.0`.
+
+        Measured on packaging 26.3. Comparing that way turns a rollback from a
+        release to one of its prereleases into an apparent upgrade, which the gate
+        would then wave through — the single most consequential difference between
+        the two schemes for this driver's purpose.
+        """
+        assert npm.semver_key("1.0.0-1") < npm.semver_key("1.0.0")
+
+    @pytest.mark.parametrize(
+        "version", ["7.0.0-next.5", "1.0.0-alpha.beta", "1.2.3-0.3.7"]
+    )
+    def test_prerelease_channels_pep440_rejects_still_parse(self, version: str):
+        """All three raise InvalidVersion under packaging, and `-next.N` is an
+        ordinary npm channel. Under the uv driver's key these would read as
+        "cannot compare", which `regressions` reports — wedging the file into
+        declining every single run for as long as one was in the tree."""
+        assert npm.semver_key(version) is not None
+
+    def test_build_metadata_is_ignored_as_semver_requires(self):
+        # PEP 440 would read `+build.1` as a local version and rank it higher.
+        assert npm.semver_key("1.0.0+build.1") == npm.semver_key("1.0.0")
+
+    @pytest.mark.parametrize(
+        "version", ["", "latest", "1.2", "not-a-version", "1.2.3.4"]
+    )
+    def test_unparseable_returns_none_rather_than_guessing(self, version: str):
+        assert npm.semver_key(version) is None
+
+
+class TestPackageName:
+    def test_the_root_entry_has_no_package_name(self):
+        assert npm.package_name("", {"name": "remediation"}) is None
+
+    def test_a_scope_is_part_of_the_name(self):
+        assert (
+            npm.package_name("node_modules/@openprose/reactor", {})
+            == "@openprose/reactor"
+        )
+
+    def test_a_nested_copy_resolves_to_the_same_name_as_a_hoisted_one(self):
+        """Which is the whole point: three `content-type` copies at three depths
+        are one package for comparison purposes."""
+        nested = npm.package_name(
+            "node_modules/negotiator/node_modules/content-type", {}
+        )
+        assert nested == npm.package_name("node_modules/content-type", {})
+        assert nested == "content-type"
+
+
+class TestLockVersions:
+    def test_every_version_of_a_name_is_collected(self):
+        versions = npm.lock_versions(
+            lock_at(
+                {
+                    "node_modules/content-type": "2.1.0",
+                    "node_modules/negotiator/node_modules/content-type": "2.0.0",
+                }
+            )
+        )
+        assert versions["content-type"] == {"2.1.0", "2.0.0"}
+
+    def test_a_lockfile_with_no_packages_table_raises(self):
+        """Rather than reading as "no packages", which would make every
+        comparison against it vacuous and every resolve look clean."""
+        with pytest.raises(ValueError, match="no `packages` table"):
+            npm.lock_versions(json.dumps({"lockfileVersion": 1}))
+
+
+class TestRegressions:
+    def test_a_downgrade_is_caught(self):
+        found = npm.regressions({"jose": {"6.2.10"}}, {"jose": {"6.2.9"}})
+        assert found == {"jose": ("6.2.10", "6.2.9")}
+
+    def test_an_upgrade_is_not(self):
+        assert npm.regressions({"jose": {"6.2.8"}}, {"jose": {"6.2.10"}}) == {}
+
+    def test_a_tree_reshuffle_at_the_same_versions_is_not_a_regression(self):
+        """The versions are identical; only the install paths moved. Comparing by
+        path would report one entry vanishing and another appearing, and this gate
+        would decline the file forever on nothing at all."""
+        before = npm.lock_versions(lock_at({"node_modules/content-type": "2.1.0"}))
+        after = npm.lock_versions(
+            lock_at({"node_modules/body-parser/node_modules/content-type": "2.1.0"})
+        )
+        assert npm.regressions(before, after) == {}
+
+    def test_a_package_that_drops_out_entirely_is_not_a_regression(self):
+        """Nothing depends on it in the bounded solution. Whatever caused it to
+        drop out is itself a version move, and is reported under its own name."""
+        assert npm.regressions({"gone": {"1.0.0"}}, {}) == {}
+
+    def test_a_second_older_copy_appearing_is_not_a_regression(self):
+        # main has one copy at 2.1.0; the resolve has 2.1.0 plus a nested 2.0.0.
+        # Nothing was taken away, so nothing regressed.
+        assert npm.regressions({"c": {"2.1.0"}}, {"c": {"2.1.0", "2.0.0"}}) == {}
+
+    def test_losing_the_newest_of_several_copies_is_a_regression(self):
+        assert npm.regressions({"c": {"2.1.0", "2.0.0"}}, {"c": {"2.0.0"}}) == {
+            "c": ("2.1.0", "2.0.0")
+        }
+
+    def test_an_unparseable_version_is_reported_rather_than_skipped(self):
+        found = npm.regressions({"weird": {"1.0.0"}}, {"weird": {"file:../local"}})
+        assert "weird" in found
+
+    def test_an_unparseable_version_both_sides_share_is_not_a_regression(self):
+        """A git or file dependency pinned identically on both sides has not moved.
+        Reporting it would decline every run forever — a wedge, not a control."""
+        pinned = {"weird": {"file:../local"}}
+        assert npm.regressions(pinned, pinned) == {}
+
+    def test_a_set_with_one_unorderable_member_has_no_newest(self):
+        # Picking the highest of the rest would compare against a version that may
+        # not be the real ceiling.
+        assert npm.newest({"1.0.0", "not-a-version"}) is None
+        assert npm.newest({"1.0.0", "1.10.0", "1.9.0"}) == "1.10.0"
+
+
+class TestDecline:
+    def test_a_regressing_resolve_restores_the_baseline_byte_for_byte(
+        self, project: Path, monkeypatch
+    ):
+        """The mechanism's whole promise. Not "restores equivalent versions" —
+        restores the exact bytes the base branch ships, so the lane's diff for
+        this file is empty and no rollback is possible even in principle.
+        """
+        baseline = npm.committed_text(project, "HEAD", npm.LOCKFILE)
+        # What Renovate left on the branch: the unbounded refresh.
+        (project / npm.LOCKFILE).write_text(lock(hono="4.13.4", jose="6.2.10"))
+        # What a bounded resolve produces today — older than main on both, because
+        # main adopted both inside the window before the bound existed.
+        stub_resolve(
+            monkeypatch,
+            lock(hono="4.13.0", jose="6.2.7"),
+        )
+
+        assert run(project) == 0
+        assert (project / npm.LOCKFILE).read_text() == baseline
+
+    def test_a_decline_exits_zero(self, project: Path, monkeypatch):
+        """A decline is an ordinary outcome, not an error: nothing in CI installs
+        this lock, so there is no required check for a red to hold, and the state
+        it leaves is exactly the safe one. Exiting non-zero here would stop
+        bound_lock_branch committing the uv bounds that DID apply."""
+        stub_resolve(monkeypatch, lock(hono="4.13.0"))
+        assert run(project) == 0
+
+
+class TestAdopt:
+    def test_a_clean_resolve_is_kept(self, project: Path, monkeypatch):
+        produced = lock(hono="4.13.2", jose="6.2.9")
+        stub_resolve(monkeypatch, produced)
+        assert run(project) == 0
+        assert (project / npm.LOCKFILE).read_text() == produced
+
+    def test_the_resolve_runs_against_no_lock_at_all(self, project: Path, monkeypatch):
+        seen = stub_resolve(monkeypatch, lock(hono="4.13.2"))
+        assert run(project) == 0
+        assert seen["removed"], (
+            "npm was handed the old lock, and `--before` against a lock that "
+            "already satisfies package.json is a silent no-op"
+        )
+
+    def test_a_dropped_package_does_not_block_adoption(
+        self, project: Path, monkeypatch
+    ):
+        stub_resolve(monkeypatch, lock(hono="4.13.2"))
+        assert run(project) == 0
+        assert "jose" not in (project / npm.LOCKFILE).read_text()
+
+
+class TestFailClosed:
+    def test_a_failed_resolve_restores_the_baseline_and_reports(
+        self, project: Path, monkeypatch
+    ):
+        """Never Renovate's unbounded lock, which is what the worktree holds when
+        this starts."""
+        baseline = (project / npm.LOCKFILE).read_text()
+        (project / npm.LOCKFILE).write_text(lock(hono="4.13.4"))
+        stub_resolve(monkeypatch, None, returncode=1)
+
+        assert run(project) == 1
+        assert (project / npm.LOCKFILE).read_text() == baseline
+
+    def test_an_unreadable_resolve_output_restores_the_baseline(
+        self, project: Path, monkeypatch
+    ):
+        baseline = (project / npm.LOCKFILE).read_text()
+        stub_resolve(monkeypatch, "{ this is not json")
+        assert run(project) == 1
+        assert (project / npm.LOCKFILE).read_text() == baseline
+
+    def test_a_manifest_that_moved_refuses_rather_than_restoring(
+        self, project: Path, monkeypatch
+    ):
+        """A restore is only coherent while the manifest the baseline was resolved
+        from is still the manifest on the branch — otherwise it writes a lock that
+        `npm ci` rejects. lockFileMaintenance never edits a manifest, so this
+        should not fire; the guard is here because the corruption would be silent.
+        """
+        refreshed = lock(hono="4.13.4")
+        (project / npm.LOCKFILE).write_text(refreshed)
+        (project / "package.json").write_text(
+            json.dumps(
+                {**MANIFEST, "devDependencies": {"@openprose/reactor": "^0.4.0"}}
+            )
+        )
+        called: list[bool] = []
+        monkeypatch.setattr(
+            npm, "bounded_resolve", lambda *a, **k: called.append(True) or None
+        )
+
+        assert run(project) == 1
+        assert called == [], "the resolve must not run when there is no safe fallback"
+        assert (project / npm.LOCKFILE).read_text() == refreshed
+
+    def test_an_unparseable_window_fails_before_touching_anything(
+        self, project: Path, monkeypatch
+    ):
+        baseline = (project / npm.LOCKFILE).read_text()
+        monkeypatch.setattr(
+            npm, "bounded_resolve", lambda *a, **k: pytest.fail("should not resolve")
+        )
+        assert (
+            npm.main(
+                [
+                    "--window",
+                    "7 days",
+                    "--baseline-ref",
+                    "HEAD",
+                    "--project-dir",
+                    str(project),
+                ]
+            )
+            == 1
+        )
+        assert (project / npm.LOCKFILE).read_text() == baseline
+
+
+class TestNoBaseline:
+    def test_a_lock_added_in_this_branch_is_left_alone(
+        self, project: Path, monkeypatch
+    ):
+        """No baseline means no gate and nothing to fall back to, and a bounded
+        resolve with no gate behind it is the mass-rollback shape this exists to
+        avoid."""
+        git(project, "rm", "-q", "--cached", npm.LOCKFILE)
+        git(project, "commit", "-qm", "drop the lock")
+        added = lock(hono="4.13.4")
+        (project / npm.LOCKFILE).write_text(added)
+        monkeypatch.setattr(
+            npm, "bounded_resolve", lambda *a, **k: pytest.fail("should not resolve")
+        )
+
+        assert run(project) == 0
+        assert (project / npm.LOCKFILE).read_text() == added
+
+    def test_a_project_without_the_pair_is_a_clean_no_op(self, tmp_path: Path):
+        assert run(tmp_path) == 0
+
+
+class TestCommittedText:
+    def test_a_nested_project_reads_its_own_lock_and_not_the_repo_roots(
+        self, project: Path
+    ):
+        """`git show <rev>:<path>` is repo-root-relative wherever it runs, so
+        without the `./` prefix this returns the ROOT lock as the nested project's
+        baseline — a comparison against a completely unrelated file."""
+        text = npm.committed_text(project, "HEAD", npm.LOCKFILE)
+        assert text is not None
+        assert "decoy" not in text
+        assert "hono" in text
+
+    def test_an_absent_path_is_none_and_a_broken_ref_raises(self, project: Path):
+        assert npm.committed_text(project, "HEAD", "no-such-file.json") is None
+        with pytest.raises(RuntimeError):
+            npm.committed_text(project, "refs/heads/nope", npm.LOCKFILE)
+
+
+class TestWorkflowWiring:
+    """The npm lock has to be in the trigger's `paths:`, and node has to be on the
+    runner. Both fail by the job not running or the step not finding npm, and
+    neither is red anywhere that matters — the check is not required."""
+
+    @property
+    def job(self) -> dict:
+        return yaml.safe_load(WORKFLOW.read_text())["jobs"]["bound"]
+
+    def test_the_npm_lock_triggers_the_lane(self):
+        # Measured on #3355: the branch's entire net diff after the uv bound was
+        # this one file, so a push carrying only it must still run the job.
+        triggers = yaml.safe_load(WORKFLOW.read_text())[True]
+        assert (
+            "packages/conformance/conformance/package-lock.json"
+            in triggers["push"]["paths"]
+        )
+
+    def test_node_is_pinned_rather_than_taken_from_the_runner_image(self):
+        # npm's major decides the lockfileVersion it writes; a runner rolling
+        # forward to one that writes a different version would turn every bounded
+        # resolve into a whole-file rewrite.
+        setup = next(
+            step
+            for step in self.job["steps"]
+            if str(step.get("uses", "")).startswith("actions/setup-node@")
+        )
+        assert setup["uses"].split("@")[1].split()[0], "setup-node must be SHA-pinned"
+        assert setup["with"]["node-version"] == "24"

--- a/.github/workflows/renovate-lock-cooldown.yaml
+++ b/.github/workflows/renovate-lock-cooldown.yaml
@@ -23,6 +23,12 @@ name: Bound the Renovate lock refresh
 # that is first-party and explicitly chosen — the cooldown has no business
 # delaying a deliberate pick, only the unattended upgrade-everything refresh.
 #
+# The lane rewrites four lock files, and the npm one is bounded by a different
+# mechanism from the three Python ones (FND-380): npm can express none of the
+# per-package retention ceilings the uv bound relies on, so that file is gated
+# whole — take the bounded resolve, or restore the base branch's lock verbatim.
+# See renovate_npm_lock_bounded's docstring for the measurements behind that.
+#
 # All logic lives in the tested driver .github/scripts/bound_lock_branch.py; this
 # workflow provides the toolchain, the baseline ref, and the push.
 
@@ -33,6 +39,10 @@ on:
     paths:
       - "uv.lock"
       - "packages/conformance/uv.lock"
+      # The npm lock moves on its own: measured on #3355, whose entire net diff
+      # after the uv bound was this one file. Without it here that push runs no
+      # job at all and the file merges unbounded.
+      - "packages/conformance/conformance/package-lock.json"
 
 permissions:
   contents: read
@@ -46,7 +56,7 @@ concurrency:
 
 jobs:
   bound:
-    name: Re-resolve uv.lock under the release-age window
+    name: Re-resolve the refreshed locks under the release-age window
     runs-on: ubuntu-latest
     timeout-minutes: 20
     # Two guards, for two unrelated reasons.
@@ -130,6 +140,17 @@ jobs:
       - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           version: "0.12.5"
+
+      # For the npm half of the bound. Pinned to the same major as renovate.yaml
+      # rather than taking whatever the runner image ships: npm's major decides
+      # the lockfileVersion it writes, and a runner rolling forward to a major
+      # that writes a different one would turn every bounded resolve into a
+      # whole-file rewrite. Verified on npm 11.x: an unbounded
+      # `npm install --package-lock-only` reproduces the committed lock
+      # byte for byte, so the lane's diffs stay reviewable.
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "24"
 
       # P3D matches the fleet. A shorter window here would put application-sdk's
       # CI on a different dependency set from the connectors again, which is half

--- a/docs/standards/ci.md
+++ b/docs/standards/ci.md
@@ -329,15 +329,77 @@ branch, which the gate then withholds on. Measured: the lane read `success` on
 Clearing the commands removes a signal that can only ever be false here; the
 bound itself is not lost, because the workflow above applies it instead.
 
-**Not covered:** `packages/conformance/conformance/package-lock.json`. npm has no
-per-package equivalent of `--exclude-newer-package`, so the retention ceilings
-that stop the uv bound rolling versions backwards cannot be expressed there — a
-plain `npm install --before` is the mass-rollback failure FND-359 corrected before
-merge. The `checks/dep-cooldown` check run can therefore still fail on that one
-file. Note that it comes from the org security platform, not from a workflow in
-this repo: `dep-cooldown.yml` was removed in FND-373 because a public repo cannot
+### The npm lock is bounded differently: all-or-nothing on the whole file
+
+The lane rewrites a fourth file, `packages/conformance/conformance/package-lock.json`
+— dev-only devDependencies for the remediation programs, never bundled in the
+published wheel. It gets its own driver, `renovate_npm_lock_bounded` (FND-380),
+because **npm can express none of the per-package retention ceilings the uv bound
+depends on, and has no forward-only mode at all.** Measured on npm 11.19.0 against
+this project:
+
+| command | versus `main` |
+| --- | --- |
+| `npm install --package-lock-only` (lock present) | byte-identical, no-op |
+| `npm install --package-lock-only --before=X` (lock present) | **no-op** |
+| `npm install --package-lock-only --before=X` (no lock) | 4 rolled **back** |
+| `npm update --package-lock-only --before=X` (lock present) | the same 4 rolled **back** |
+
+Two of those rows are traps. The second is the silent one: leaving the committed
+lock in place and adding `--before` exits clean and changes nothing, so a bound
+written that way reports success, bounds nothing, and is indistinguishable from a
+lane with nothing to do. **The lock must be deleted before the resolve for the
+date bound to reach the tree at all.** The third and fourth are the mass-rollback
+failure FND-359 corrected before merge — the four were `fast-uri`, `hono`, `jose`
+and `negotiator`, all adopted by `main` before this bound existed.
+
+So the mechanism gates the file as a unit:
+
+1. re-resolve from `package.json` alone with `--before` set to the window,
+2. compare against the lock `main` ships, on the newest version each package
+   *name* is pinned at — by name and not by install path, so a package moving
+   between a hoisted and a nested position is not read as one entry vanishing and
+   another appearing,
+3. any name whose newest version went down, restore `main`'s lock **verbatim**;
+   otherwise take the bounded resolve.
+
+It cannot roll anything back, structurally rather than as a policy: the only two
+things it can ever write are a resolve that regressed nothing and the exact bytes
+it compared against. **A decline is exit 0, not an error.** Nothing in CI installs
+this lock — there is no `npm ci` anywhere in the repo — so unlike the uv side
+there is no required check a red could hold the branch on, and the state a decline
+leaves is the safe one. Non-zero is reserved for the cases with no safe outcome at
+all: npm unavailable, an unparseable lock, or a `package.json` that has moved away
+from the baseline the fallback was resolved against.
+
+The cost is the coupling, and it is real: one package `main` adopted inside the
+window holds the entire npm lock until it ages out. It is not permanent — under
+this bound `main` only ever takes versions that were already `--window` old, so
+the pre-bound adoptions age past the window and the file starts moving again.
+
+Do not reuse `packaging.Version` for the comparison, tempting as it is: PEP 440
+reads `1.0.0-1` as `1.0.0.post1` and ranks it **above** `1.0.0`, so a rollback
+from a release to one of its own prereleases would read as an upgrade, and it
+rejects `7.0.0-next.5` outright — an ordinary npm channel — which the uv driver
+treats as "cannot compare" and therefore as a regression, wedging the file into
+declining every run.
+
+### What `checks/dep-cooldown` still reports, and why that is not a bug here
+
+The bound runs at `P3D` on both halves, matching the fleet's policy. The
+`checks/dep-cooldown` check run enforces **7 days** — measured 2026-08-24 on
+\#3365, which it failed on a 3-day-old release. So an adoption aged between 3 and 7
+days is bounded correctly by policy and still reported by the check. Measured
+exposure on one sampled refresh: 2 of the 6 versions the P3D bound adopted sat in
+that band.
+
+Closing that is the checker's threshold to change, not a second window here
+(FND-761).
+Note where the check comes from: the `atlan-security` App, **not** a workflow in
+this repo. `dep-cooldown.yml` was removed in FND-373 because a public repo cannot
 call the private reusable it wired up, so it had never produced a check run at
-all. The platform's check run is a separate thing and was never affected.
+all — and the App offers no `lockfile-globs` equivalent to scope, only a `security`
+label bypass. The App's check run is a separate thing and was never affected.
 
 ## Reusing scripts from a reusable workflow
 


### PR DESCRIPTION
Closes FND-380.

The `renovate/lock-file-maintenance` lane rewrites four lock files. FND-376 bounded the three Python ones and left `packages/conformance/conformance/package-lock.json` — which was the whole of the remaining `checks/dep-cooldown` failure. Measured on #3355: after the uv bound, the branch's entire net diff was that one file, and the check named `fast-uri@3.1.6`, published the same day.

## Why the npm half needs a different mechanism

`renovate_uv_lock_bounded` relies on per-package retention ceilings (`--exclude-newer-package <name>=<upload-time main pins>`) so a bounded resolve can decline to adopt something new without rolling anything back. **npm has no equivalent, and no forward-only mode at all.** Measured on npm 11.19.0 against this project, with a 7-day cutoff:

| command | versus `main` |
| --- | --- |
| `npm install --package-lock-only` (lock present) | byte-identical, no-op |
| `npm install --package-lock-only --before=X` (lock present) | **no-op** |
| `npm install --package-lock-only --before=X` (no lock) | 4 rolled **back** |
| `npm update --package-lock-only --before=X` (lock present) | the same 4 rolled **back** |

Two of those rows are traps worth knowing about beyond this PR:

- **Row 2 is silent.** Leaving the committed lock in place and adding `--before` exits clean and changes *nothing*. A cooldown written that way reports success, bounds nothing, and is indistinguishable from a lane with nothing to do. **The lock has to be deleted before the resolve** for the date bound to reach the tree.
- **Rows 3 and 4** are the mass-rollback failure FND-359 corrected before merge. The four were `fast-uri 3.1.6→3.1.5`, `hono 4.13.4→4.13.2`, `jose 6.2.10→6.2.9`, `negotiator 1.1.0→1.0.0` — all adopted by `main` before this bound existed.

## What this does

`renovate_npm_lock_bounded` gates the file as a unit:

1. re-resolve from `package.json` alone with `--before` set to the window,
2. compare against the lock `main` ships, on the newest version each package **name** is pinned at — by name and not install path, so a package moving between a hoisted and a nested position isn't read as one entry vanishing and another appearing,
3. any name whose newest version went down → restore `main`'s lock **verbatim**; otherwise take the bounded resolve.

It cannot roll anything back structurally rather than by policy: the only two things it can ever write are a resolve that regressed nothing and the exact bytes it compared against.

**A decline is exit 0, not an error.** Nothing in CI installs this lock — no `npm ci` anywhere in the repo — so unlike the uv side there is no required check a red could hold the branch on, and the state a decline leaves is the safe one. Failing would also throw away the uv bounds that *did* apply in the same run. Non-zero is reserved for cases with no safe outcome at all: npm unavailable, an unparseable lock, or a `package.json` that has moved away from the baseline the fallback was resolved against.

It rides in the same commit as the uv bounds, for the reason already recorded in `bound_lock_branch`: each push re-fires the PR's entire required-check suite.

### The cost, stated plainly

One package `main` adopted inside the window holds the entire npm lock until it ages out — today, three of them, so it currently declines and the lane's npm diff is empty. Not a permanent stall: under this bound `main` only ever takes versions that were already `--window` old, so the pre-bound adoptions age past the window and the file starts moving again.

### Don't reuse `packaging.Version` here

PEP 440 reads `1.0.0-1` as `1.0.0.post1` and ranks it **above** `1.0.0`, so a rollback from a release to its own prerelease would read as an upgrade and pass the gate. It also rejects `7.0.0-next.5`, `1.0.0-alpha.beta` and `1.2.3-0.3.7` outright — `-next.N` is an ordinary npm channel — and the uv driver treats "cannot parse" as a regression, which would wedge this file into declining every run. A semver.org §11 comparator is used instead, with the divergences pinned by test.

## Window: P3D, with the residual gap recorded rather than papered over

P3D matches the uv lane and the fleet's policy. The `checks/dep-cooldown` check run comes from the **`atlan-security` App** — not a workflow in this repo; `dep-cooldown.yml` was removed in FND-373 because a public repo cannot call the private reusable, and it had never produced a check run at all — and that App still enforces **7 days** (measured 2026-08-24 on #3365, which it failed on a 3-day-old release).

So an adoption aged 3–7 days is bounded correctly by policy and still reported. Quantified on one sampled refresh: **2 of the 6 versions the P3D bound adopted** sat in that band. The App exposes no `lockfile-globs` or `min-age-days` knob to a caller, only an audited `security` label, so closing this is the App's threshold to align — raised as FND-761. `docs/standards/ci.md` records the gap beside the uv bound.

## Verification

End-to-end with real npm against the real registry, in a throwaway repo shaped like the lane (baseline commit + Renovate's unbounded refresh commit):

| baseline | window | outcome |
| --- | --- | --- |
| today's `main` | P3D | **declined**, lock restored byte-identical to `main` |
| an older commit | P3D | **adopted** a bounded resolve — 7 packages forward, 0 backward |
| an older commit | PT1M | **adopted**, identical to Renovate's own unbounded refresh |

Also verified: an *unbounded* from-scratch `npm install --package-lock-only` reproduces the committed lock byte for byte, so re-resolving from the manifest adds no formatting churn to the lane's diffs.

`pytest .github/scripts/tests`: **3267 passed**. Pre-commit clean.

## Review notes

- `.github/workflows/renovate-lock-cooldown.yaml` is a security-relevant control-plane file. The changes are: the npm lock added to the trigger's `paths:` (without it, an npm-only push runs no job at all), a SHA-pinned `actions/setup-node` at Node 24, and the job renamed since it no longer bounds only `uv.lock`. The `if:` actor guard, the App-token scope, the push, and the `renovate/artifacts` carry-forward are untouched.
- No new dependencies. The semver comparator is stdlib `re`; npm and Node come from the runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
