### PR TITLE
ci(sdk-resolve): retry a mothership sandbox-api fault on the same model (FND-764)

### DIFF
--- a/.github/scripts/sdk_resolve_dispatch.py
+++ b/.github/scripts/sdk_resolve_dispatch.py
@@ -207,6 +207,12 @@ NEVER_RETRY_ERR_CODES = frozenset({"elicitation", "stream_error"})
 # the class rot into a denylist.
 SANDBOX_API_ERR_CODE = "internal"
 SANDBOX_API_ERR_PREFIX = "[sandbox-api/"
+# Long enough to survive the clone-timeout shape, which is ~150 chars and buries
+# its actual cause ("Command timeout after 60000ms") at the very end, behind the
+# JSON envelope. That is the ONE variant of this class whose message carries a
+# recoverable cause, so truncating it at the 80 the other classes use would
+# discard the only thing worth reading in the line a human triages from.
+SANDBOX_API_ERR_PREVIEW_CHARS = 200
 # Dispatch-level HTTP statuses live in their own `http_` codespace, kept apart
 # from the stream's provider codes on purpose: a provider 400 carried inside the
 # stream is worth a different model, while a 400 on the POST itself is a
@@ -1018,7 +1024,8 @@ def _retry_class(st: SSEState, attempt: int) -> RetryPlan:
         return RetryPlan(
             True,
             f"code={st.err_code} is a fault in mothership's own sandbox-api "
-            f"wrapper ({_squash(st.err_msg)[:80]}), not in the model or the "
+            f"wrapper ({_squash(st.err_msg)[:SANDBOX_API_ERR_PREVIEW_CHARS]}), "
+            f"not in the model or the "
             f"resolver — re-dispatching on the same model ({same}) "
             f"(attempt {attempt + 1} of {MAX_DISPATCH_ATTEMPTS})",
             same,

--- a/.github/scripts/sdk_resolve_dispatch.py
+++ b/.github/scripts/sdk_resolve_dispatch.py
@@ -12,11 +12,14 @@ Dispatch + SSE parsing + GITHUB_STEP_SUMMARY rendering live here (tested) rather
 than in inline workflow shell, per docs/standards/ci.md. Parses the
 `=== SDK RESOLVE SUMMARY ===` block the resolver emits (ORCHESTRATION Phase 4).
 
-One re-dispatch is allowed when the sandbox dies on a hard error that a
-different model could survive — see MAX_DISPATCH_ATTEMPTS and retry_decision().
-The retry fires only after the out-of-band poll has come back empty, which is
-the single point where the sandbox is provably dead and nothing further will
-land; every other stream ending stays fail-fast.
+One re-dispatch is allowed when the sandbox dies on a hard error a second
+attempt could survive — see MAX_DISPATCH_ATTEMPTS and retry_decision(). Two
+classes qualify, and they differ on which model attempt 2 runs: a model/provider
+fault swaps the model (FND-641), while a fault in mothership's own sandbox-api
+wrapper keeps it (FND-764), because nothing about the model failed there. The
+retry fires only after the out-of-band poll has come back empty, which is the
+single point where the sandbox is provably dead and nothing further will land;
+every other stream ending stays fail-fast.
 
 That is a strictly narrower rule than the review lane's, on purpose (FND-647).
 The reviewer also retries a fault it cannot prove killed the sandbox, because
@@ -179,6 +182,31 @@ RETRYABLE_TRANSPORT_PATTERNS = ("disconnected prematurely",)
 # Auth/permission and prompt faults are excluded by the allowlist above rather
 # than named here: they will fail the same way on any model, forever.
 NEVER_RETRY_ERR_CODES = frozenset({"elicitation", "stream_error"})
+# FND-764. mothership's own sandbox-api codespace: `code=internal` carries a
+# message stamped with the wrapper that reported it (`_err_msg(e,
+# "sandbox-api/_execute_sync")` in its `sandbox_api.py`). Every observed
+# instance is plumbing on mothership's side of the API, never the model:
+#
+#   [sandbox-api/_execute_sync] generator didn't stop after throw()     (x8)
+#   [sandbox-api/_execute_sync] Failed to clone repository: ...         (x1)
+#                               Command timeout after 60000ms
+#
+# Those two do NOT share a cause — the clone timeout is legible and plainly
+# transient, while `generator didn't stop after throw()` is mothership's
+# `langfuse_lifecycle_span` swallowing the real exception and yielding a second
+# time (FND-765), so the actual fault is destroyed before it reaches us. What
+# they share is what licenses the retry: nothing was delivered and nothing was
+# billed. Both arrive with an empty `cost_usd` while other failures on this lane
+# report real spend ($0.48 / $2.26 / $6.58 / $28.34), so no model produced a
+# token, and all 9 affected PRs were checked for a resolver push or Phase-4
+# hand-off — there were none.
+#
+# Matched on the code AND the message prefix, not the code alone: `internal` is
+# a generic label and a future non-plumbing use of it must not inherit a retry
+# it was never argued for. The prefix keeps this an allowlist instead of letting
+# the class rot into a denylist.
+SANDBOX_API_ERR_CODE = "internal"
+SANDBOX_API_ERR_PREFIX = "[sandbox-api/"
 # Dispatch-level HTTP statuses live in their own `http_` codespace, kept apart
 # from the stream's provider codes on purpose: a provider 400 carried inside the
 # stream is worth a different model, while a 400 on the POST itself is a
@@ -317,6 +345,7 @@ def build_payload(
     requester: str,
     *,
     attempt: int = 1,
+    model: str = "",
     max_timeout_seconds: int = STREAM_TIMEOUT_SECONDS,
 ) -> dict[str, Any]:
     # `attempt` > 1 is a re-dispatch after the previous sandbox died on a hard
@@ -340,7 +369,10 @@ def build_payload(
         # the main lane runs. `small_fast_model` must be pinned explicitly:
         # mothership's model_routing_env does `fast = small_fast_model or model`,
         # so pinning `model` alone would put the background lane on MAIN_MODEL.
-        "model": attempt_model(attempt),
+        # `model` is passed explicitly by the caller because it is NOT a
+        # function of the attempt number — a sandbox-api plumbing fault retries
+        # on the SAME model where a model fault swaps it (see RetryPlan).
+        "model": model or attempt_model(attempt),
         "small_fast_model": FAST_MODEL,
         "env_vars": {"CLAUDE_CODE_SUBAGENT_MODEL": FAST_MODEL},
         "prompt": build_prompt(
@@ -548,6 +580,21 @@ def _rounds_completed(summary: dict[str, str]) -> int | None:
         return int(summary["rounds"].strip())
     except (KeyError, ValueError, AttributeError):
         return None
+
+
+class RetryPlan(NamedTuple):
+    """Whether to re-dispatch, why, and which main model attempt N+1 runs.
+
+    `model` is empty when `retry` is False. It cannot be derived from the
+    attempt number alone: the retry classes differ on exactly that axis — a
+    dead sandbox needs a DIFFERENT model, a sandbox-api plumbing fault needs
+    the SAME one. Ported from the review lane, which already had to make this
+    distinction (FND-645 / FND-647).
+    """
+
+    retry: bool
+    reason: str
+    model: str = ""
 
 
 class Attempt(NamedTuple):
@@ -870,6 +917,24 @@ def oob_poll_budget(st: SSEState) -> int:
     return OOB_POLL_SECONDS_STREAM_DROP
 
 
+def _squash(text: str) -> str:
+    r"""Collapse whitespace runs so a multi-line fault fits one log line."""
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def is_sandbox_api_fault(st: SSEState) -> bool:
+    """True when mothership's sandbox-api reported a fault in its own plumbing.
+
+    Self-deciding on the code, like every other classifier here: `internal` is
+    informative, so this never consults RETRYABLE_ERR_PATTERNS. The message
+    prefix is part of the discriminator rather than a fallback — see
+    SANDBOX_API_ERR_CODE for why the code alone is not enough.
+    """
+    if st.err_code != SANDBOX_API_ERR_CODE:
+        return False
+    return st.err_msg.lstrip().startswith(SANDBOX_API_ERR_PREFIX)
+
+
 def is_retryable_fault(st: SSEState) -> bool:
     """True when the cause looks like a model/provider fault, not a fixed one.
 
@@ -898,22 +963,20 @@ def is_retryable_fault(st: SSEState) -> bool:
     return any(p in st.err_msg.lower() for p in RETRYABLE_ERR_PATTERNS)
 
 
-def retry_decision(st: SSEState, attempt: int, seconds_left: float) -> tuple[bool, str]:
-    """Whether to re-dispatch after this attempt, and the reason either way.
+def _retry_class(st: SSEState, attempt: int) -> RetryPlan:
+    """Which retry class this ending falls into, if any, and on which model.
 
     Called only once the out-of-band poll has come back empty, so "posted
     nothing" is established for every branch, and "the sandbox is dead" for the
     abnormal-termination branch — with one exception, which is why the transport
     branch below exists: a dropped RPC reports a terminal fault without proving
     the resolver stopped, and on this lane an unproven death is never retried.
-    The reason is logged verbatim so a run that did NOT retry says why.
     """
-    if attempt >= MAX_DISPATCH_ATTEMPTS:
-        return False, f"already used all {MAX_DISPATCH_ATTEMPTS} attempts"
     if not sandbox_terminated_abnormally(st):
-        return False, (
+        return RetryPlan(
+            False,
             "the stream ended without a hard error — the sandbox may still be "
-            "running, and a re-dispatch would double-run the resolver"
+            "running, and a re-dispatch would double-run the resolver",
         )
     if is_transport_fault(st):
         # FND-647, and it must be ranked ABOVE `is_retryable_fault` rather than
@@ -931,31 +994,73 @@ def retry_decision(st: SSEState, attempt: int, seconds_left: float) -> tuple[boo
         # rather than by default: what the fault buys instead is the long
         # out-of-band poll above, which recovers the run without ever risking a
         # second resolver. If that poll came back empty, the run is spent.
-        return False, (
+        return RetryPlan(
+            False,
             f"code={st.err_code or 'none'} reports a dropped RPC to the sandbox, "
             "not a dead one — the resolver may still be pushing, and two "
             "resolvers on one branch cannot be undone, so this lane waits for "
-            "the out-of-band hand-off instead of re-dispatching"
+            "the out-of-band hand-off instead of re-dispatching",
+        )
+    if is_sandbox_api_fault(st):
+        # FND-764. Ranked below the transport branch and above the model one,
+        # because it is neither: mothership reported a fault in its OWN wrapper
+        # around the run, so nothing about the model failed and the swap axis is
+        # the wrong one — attempt 2 re-runs the same model on a fresh sandbox.
+        #
+        # Unlike the transport case just above, this one is safe on this lane.
+        # The distinction is where the fault is: a dropped RPC leaves a sandbox
+        # of unknown liveness behind the broken pipe, while a sandbox-api fault
+        # is mothership saying its own execution wrapper never delivered a run
+        # at all — empty `cost_usd`, no first token, and (checked across all 9
+        # occurrences) not one resolver push or Phase-4 hand-off. There is no
+        # first resolver for a second to race.
+        same = attempt_model(attempt)
+        return RetryPlan(
+            True,
+            f"code={st.err_code} is a fault in mothership's own sandbox-api "
+            f"wrapper ({_squash(st.err_msg)[:80]}), not in the model or the "
+            f"resolver — re-dispatching on the same model ({same}) "
+            f"(attempt {attempt + 1} of {MAX_DISPATCH_ATTEMPTS})",
+            same,
         )
     if not is_retryable_fault(st):
-        return False, (
+        return RetryPlan(
+            False,
             f"code={st.err_code or 'none'} is not a known model/provider fault, "
-            "so a different model would fail the same way"
-        )
-    if seconds_left < RETRY_MIN_REMAINING_SECONDS:
-        return False, (
-            f"only {int(seconds_left)}s of the job budget remain, below the "
-            f"{RETRY_MIN_REMAINING_SECONDS}s a retry needs to finish a round"
+            "so a different model would fail the same way",
         )
     cause = (
         "the sandbox reported success but emitted no Phase 4 summary (no-op run)"
         if resolved_nothing(st)
         else f"code={st.err_code or 'none'} looks like a model/provider fault"
     )
-    return True, (
+    return RetryPlan(
+        True,
         f"{cause} — re-dispatching on {RETRY_MAIN_MODEL} (attempt {attempt + 1} "
-        f"of {MAX_DISPATCH_ATTEMPTS})"
+        f"of {MAX_DISPATCH_ATTEMPTS})",
+        RETRY_MAIN_MODEL,
     )
+
+
+def retry_decision(st: SSEState, attempt: int, seconds_left: float) -> RetryPlan:
+    """Whether to re-dispatch after this attempt, on what, and why either way.
+
+    The reason is logged verbatim so a run that did NOT retry says why — the
+    part that is otherwise invisible. The attempt cap and the wall-clock floor
+    bound EVERY class; only the classification in `_retry_class` differs.
+    """
+    if attempt >= MAX_DISPATCH_ATTEMPTS:
+        return RetryPlan(False, f"already used all {MAX_DISPATCH_ATTEMPTS} attempts")
+    plan = _retry_class(st, attempt)
+    if not plan.retry:
+        return plan
+    if seconds_left < RETRY_MIN_REMAINING_SECONDS:
+        return RetryPlan(
+            False,
+            f"only {int(seconds_left)}s of the job budget remain, below the "
+            f"{RETRY_MIN_REMAINING_SECONDS}s a retry needs to finish a round",
+        )
+    return plan
 
 
 def poll_for_oob_summary(
@@ -1120,8 +1225,11 @@ def main() -> int:
     attempts: list[Attempt] = []
     oob_url: str | None = None
     attempt = 1
+    # Named by the previous attempt's RetryPlan; empty on the first pass. The
+    # model is NOT a function of the attempt number — see RetryPlan.
+    next_model = ""
     while True:
-        model = attempt_model(attempt)
+        model = next_model or attempt_model(attempt)
         # Clamp the sandbox's own cap to what is left of this step's budget.
         # Cancelling the job does not stop the sandbox, so an unclamped retry
         # started late would keep billing for up to 2h after the runner dies.
@@ -1134,6 +1242,7 @@ def main() -> int:
             reviewers,
             requester,
             attempt=attempt,
+            model=model,
             max_timeout_seconds=max(1, min(STREAM_TIMEOUT_SECONDS, int(seconds_left))),
         )
         print(f"[attempt {attempt}/{MAX_DISPATCH_ATTEMPTS}] dispatching on {model}")
@@ -1184,19 +1293,20 @@ def main() -> int:
         # a resolver that is still working, or one that finished just before it
         # died. Phase 0 re-reads live PR state, so a second sandbox resumes
         # rather than restarts.
-        should_retry, reason = retry_decision(
+        plan = retry_decision(
             st, attempt, DISPATCH_BUDGET_SECONDS - (time.time() - run_start_epoch)
         )
-        if not should_retry:
-            print(f"::warning::Not re-dispatching: {reason}")
+        if not plan.retry:
+            print(f"::warning::Not re-dispatching: {plan.reason}")
             break
-        print(f"::warning::Re-dispatching on a fresh sandbox: {reason}")
+        print(f"::warning::Re-dispatching on a fresh sandbox: {plan.reason}")
+        next_model = plan.model
         attempt += 1
 
     if code != 0 and len(attempts) > 1:
         message += (
-            f" (retried on {attempt_model(len(attempts))} after "
-            f"{attempt_model(1)} failed; both attempts failed)"
+            f" (retried on {attempts[-1].model} after {attempts[0].model} "
+            "failed; both attempts failed)"
         )
 
     write_step_summary(

--- a/.github/scripts/sdk_resolve_dispatch.py
+++ b/.github/scripts/sdk_resolve_dispatch.py
@@ -21,6 +21,13 @@ retry fires only after the out-of-band poll has come back empty, which is the
 single point where the sandbox is provably dead and nothing further will land;
 every other stream ending stays fail-fast.
 
+That poll establishes "nothing was DELIVERED", not "nothing was PUSHED" — it
+only looks for the Phase-4 hand-off, so a resolver that pushed in earlier rounds
+and died before Phase 4 leaves it empty too. Each retry class therefore has to
+carry its own evidence that no first resolver exists: the model-fault class
+because the sandbox died on its own first turn, and the sandbox-api class
+because it additionally requires an empty `cost_usd` (see `billed_nothing`).
+
 That is a strictly narrower rule than the review lane's, on purpose (FND-647).
 The reviewer also retries a fault it cannot prove killed the sandbox, because
 two reviewers only ever cost a duplicate comment that FND-636's dedupe
@@ -201,12 +208,33 @@ NEVER_RETRY_ERR_CODES = frozenset({"elicitation", "stream_error"})
 # token, and all 9 affected PRs were checked for a resolver push or Phase-4
 # hand-off — there were none.
 #
-# Matched on the code AND the message prefix, not the code alone: `internal` is
-# a generic label and a future non-plumbing use of it must not inherit a retry
-# it was never argued for. The prefix keeps this an allowlist instead of letting
-# the class rot into a denylist.
+# That empty `cost_usd` is CHECKED, not merely observed — see `billed_nothing`.
+# It has to be, because it is the whole safety argument on a lane that pushes
+# commits, and it does not follow from anything else the classifier sees. The
+# masked shape is `langfuse_lifecycle_span` destroying the real exception, so
+# the wrapper fault can originate anywhere inside `_execute_sync` — including
+# AFTER a run did work — and such an occurrence would be byte-identical to the
+# 9 pre-first-token ones. The out-of-band poll does not cover the gap either:
+# it runs for OOB_POLL_SECONDS_HARD_ERROR and looks only for the Phase-4
+# hand-off, so a resolver that pushed in rounds 1..N without reaching Phase 4
+# leaves it empty. "The poll came back empty" is not "nothing was pushed".
+#
+# This conjunct is the ONE place this class deliberately diverges from the
+# review lane's copy, for the same reason RETRYABLE_TRANSPORT_PATTERNS diverges:
+# the entry conditions are per-lane. A second reviewer costs a duplicate comment
+# that FND-636's dedupe collapses; a second resolver pushes to a branch and
+# cannot be undone.
+#
+# Matched on the code AND the message, not the code alone: `internal` is a
+# generic label and a future non-plumbing use of it must not inherit a retry
+# it was never argued for. The message test keeps this an allowlist instead of
+# letting the class rot into a denylist. It is a substring rather than a prefix
+# test because mothership does not consistently deliver the message bare: the
+# transport class on this same lane exists because the provider text arrived
+# wrapped in a nested JSON blob, and `[sandbox-api/` is specific enough that
+# matching it anywhere in the message keeps the allowlist just as tight.
 SANDBOX_API_ERR_CODE = "internal"
-SANDBOX_API_ERR_PREFIX = "[sandbox-api/"
+SANDBOX_API_ERR_MARKER = "[sandbox-api/"
 # Long enough to survive the clone-timeout shape, which is ~150 chars and buries
 # its actual cause ("Command timeout after 60000ms") at the very end, behind the
 # JSON envelope. That is the ONE variant of this class whose message carries a
@@ -338,7 +366,14 @@ def _reviewer_handles(reviewers: str, requester: str) -> list[str]:
 
 
 def attempt_model(attempt: int) -> str:
-    """Main model for this attempt — the swap that makes a retry worth booting."""
+    """Default main model for this attempt — the swap a model-fault retry needs.
+
+    Only a default, and only ever right for attempt 1: `retry_decision()` names
+    the model for the attempt it authorises, because the retry classes differ on
+    exactly this axis. A same-model re-dispatch (mothership's own sandbox-api
+    wrapper faulted, FND-764) must NOT be dragged onto RETRY_MAIN_MODEL —
+    nothing about the model failed.
+    """
     return MAIN_MODEL if attempt <= 1 else RETRY_MAIN_MODEL
 
 
@@ -350,15 +385,17 @@ def build_payload(
     reviewers: str,
     requester: str,
     *,
+    model: str,
     attempt: int = 1,
-    model: str = "",
     max_timeout_seconds: int = STREAM_TIMEOUT_SECONDS,
 ) -> dict[str, Any]:
     # `attempt` > 1 is a re-dispatch after the previous sandbox died on a hard
     # error: same prompt (the resolver re-reads live PR state in Phase 0, so the
-    # second sandbox resumes wherever the first stopped), different main model.
-    # The source_id is suffixed so the two runs are distinguishable on the
-    # mothership side rather than colliding on one id.
+    # second sandbox resumes wherever the first stopped), on whichever main
+    # model the caller's RetryPlan named — a model fault swaps it, a fault in
+    # mothership's own wrapper keeps it. The source_id is suffixed so the two
+    # runs are distinguishable on the mothership side rather than colliding on
+    # one id.
     suffix = "" if attempt <= 1 else f"-retry{attempt - 1}"
     return {
         "mode": "direct",
@@ -375,10 +412,12 @@ def build_payload(
         # the main lane runs. `small_fast_model` must be pinned explicitly:
         # mothership's model_routing_env does `fast = small_fast_model or model`,
         # so pinning `model` alone would put the background lane on MAIN_MODEL.
-        # `model` is passed explicitly by the caller because it is NOT a
-        # function of the attempt number — a sandbox-api plumbing fault retries
-        # on the SAME model where a model fault swaps it (see RetryPlan).
-        "model": model or attempt_model(attempt),
+        # `model` is required from the caller because it is NOT a function of
+        # the attempt number — a sandbox-api plumbing fault retries on the SAME
+        # model where a model fault swaps it (see RetryPlan). Deliberately no
+        # `or attempt_model(attempt)` fallback: that would let a caller that
+        # forgot the argument silently get the swap back.
+        "model": model,
         "small_fast_model": FAST_MODEL,
         "env_vars": {"CLAUDE_CODE_SUBAGENT_MODEL": FAST_MODEL},
         "prompt": build_prompt(
@@ -928,6 +967,27 @@ def _squash(text: str) -> str:
     return re.sub(r"\s+", " ", text).strip()
 
 
+def billed_nothing(st: SSEState) -> bool:
+    """True when the run reported no spend, i.e. no model ever produced a token.
+
+    This is the evidence that licenses a re-dispatch on THIS lane, so it is
+    checked rather than assumed. All 9 observed FND-764 occurrences reported an
+    empty `cost_usd` while other failures on this lane reported real spend
+    ($0.48 / $2.26 / $6.58 / $28.34).
+
+    Deliberately fails OPEN on a cost it cannot read. `total_cost` above
+    documents mothership's cost telemetry as unreliable, and that unreliability
+    is false-EMPTY — runs that streamed hundreds of responses have reported no
+    cost. So an unreadable value can only ever return this to the behaviour
+    that shipped without the guard, never to something stricter than the
+    evidence supports.
+    """
+    try:
+        return float(st.cost) == 0.0
+    except (TypeError, ValueError):
+        return True  # absent or unparseable — no positive evidence of spend
+
+
 def is_sandbox_api_fault(st: SSEState) -> bool:
     """True when mothership's sandbox-api reported a fault in its own plumbing.
 
@@ -935,10 +995,16 @@ def is_sandbox_api_fault(st: SSEState) -> bool:
     informative, so this never consults RETRYABLE_ERR_PATTERNS. The message
     prefix is part of the discriminator rather than a fallback — see
     SANDBOX_API_ERR_CODE for why the code alone is not enough.
+
+    The empty-cost conjunct is what makes this safe ON THIS LANE, and it is why
+    this predicate is NOT byte-identical to the review lane's copy — see
+    SANDBOX_API_ERR_CODE.
     """
     if st.err_code != SANDBOX_API_ERR_CODE:
         return False
-    return st.err_msg.lstrip().startswith(SANDBOX_API_ERR_PREFIX)
+    if not billed_nothing(st):
+        return False
+    return SANDBOX_API_ERR_MARKER in st.err_msg
 
 
 def is_retryable_fault(st: SSEState) -> bool:
@@ -969,8 +1035,13 @@ def is_retryable_fault(st: SSEState) -> bool:
     return any(p in st.err_msg.lower() for p in RETRYABLE_ERR_PATTERNS)
 
 
-def _retry_class(st: SSEState, attempt: int) -> RetryPlan:
+def _retry_class(st: SSEState, attempt: int, current_model: str) -> RetryPlan:
     """Which retry class this ending falls into, if any, and on which model.
+
+    `current_model` is the model THIS attempt actually ran, threaded down from
+    `main()`. The same-model classes must not re-derive it from `attempt`:
+    `attempt_model` answers "what attempt N would have run by default", which
+    stops being the same answer the moment a same-model retry has happened.
 
     Called only once the out-of-band poll has come back empty, so "posted
     nothing" is established for every branch, and "the sandbox is dead" for the
@@ -1020,7 +1091,7 @@ def _retry_class(st: SSEState, attempt: int) -> RetryPlan:
         # at all — empty `cost_usd`, no first token, and (checked across all 9
         # occurrences) not one resolver push or Phase-4 hand-off. There is no
         # first resolver for a second to race.
-        same = attempt_model(attempt)
+        same = current_model
         return RetryPlan(
             True,
             f"code={st.err_code} is a fault in mothership's own sandbox-api "
@@ -1049,16 +1120,22 @@ def _retry_class(st: SSEState, attempt: int) -> RetryPlan:
     )
 
 
-def retry_decision(st: SSEState, attempt: int, seconds_left: float) -> RetryPlan:
+def retry_decision(
+    st: SSEState, attempt: int, seconds_left: float, current_model: str
+) -> RetryPlan:
     """Whether to re-dispatch after this attempt, on what, and why either way.
 
     The reason is logged verbatim so a run that did NOT retry says why — the
     part that is otherwise invisible. The attempt cap and the wall-clock floor
     bound EVERY class; only the classification in `_retry_class` differs.
+
+    `current_model` is required rather than defaulted: a caller that omitted it
+    would silently reintroduce the attempt-number derivation this signature
+    exists to remove. See `_retry_class`.
     """
     if attempt >= MAX_DISPATCH_ATTEMPTS:
         return RetryPlan(False, f"already used all {MAX_DISPATCH_ATTEMPTS} attempts")
-    plan = _retry_class(st, attempt)
+    plan = _retry_class(st, attempt, current_model)
     if not plan.retry:
         return plan
     if seconds_left < RETRY_MIN_REMAINING_SECONDS:
@@ -1301,7 +1378,10 @@ def main() -> int:
         # died. Phase 0 re-reads live PR state, so a second sandbox resumes
         # rather than restarts.
         plan = retry_decision(
-            st, attempt, DISPATCH_BUDGET_SECONDS - (time.time() - run_start_epoch)
+            st,
+            attempt,
+            DISPATCH_BUDGET_SECONDS - (time.time() - run_start_epoch),
+            model,
         )
         if not plan.retry:
             print(f"::warning::Not re-dispatching: {plan.reason}")

--- a/.github/scripts/sdk_review_dispatch.py
+++ b/.github/scripts/sdk_review_dispatch.py
@@ -244,6 +244,17 @@ RETRYABLE_TRANSPORT_PATTERNS = ("disconnected prematurely",)
 # Fails identically on any model, so never spend a second sandbox on it: the
 # sandbox wants interactive input, which GHA can never give.
 NEVER_RETRY_ERR_CODES = frozenset({"elicitation"})
+# FND-764. mothership's own sandbox-api codespace — a fault in its execution
+# wrapper rather than in the model. Precautionary on THIS lane: all 9 observed
+# occurrences were on the resolve lane and none here, but the two lanes POST the
+# same `mode: "direct"` endpoint and reach the same five unguarded
+# `langfuse_lifecycle_span` blocks in mothership's `_execute_direct`, so the
+# review lane is exposed to it identically. Matched on the code AND the message
+# prefix so a future non-plumbing `internal` cannot inherit a retry that was
+# never argued for. Kept as its own per-lane copy, like RETRYABLE_TRANSPORT_
+# PATTERNS above, because the entry conditions are per-lane.
+SANDBOX_API_ERR_CODE = "internal"
+SANDBOX_API_ERR_PREFIX = "[sandbox-api/"
 # Dispatch-level HTTP statuses live in their own `http_` codespace, kept apart
 # from the stream's provider codes on purpose: a provider 400 carried inside the
 # stream is worth a different model, while a 400 on the POST itself is a
@@ -793,6 +804,19 @@ def is_retryable_fault(st: SSEState) -> bool:
     return any(p in st.err_msg.lower() for p in RETRYABLE_ERR_PATTERNS)
 
 
+def is_sandbox_api_fault(st: SSEState) -> bool:
+    """True when mothership's sandbox-api reported a fault in its own plumbing.
+
+    Self-deciding on the code, like `is_retryable_fault`: `internal` is
+    informative, so this never consults the message-pattern ladder. The prefix
+    is part of the discriminator rather than a fallback — see
+    SANDBOX_API_ERR_CODE.
+    """
+    if st.err_code != SANDBOX_API_ERR_CODE:
+        return False
+    return st.err_msg.lstrip().startswith(SANDBOX_API_ERR_PREFIX)
+
+
 def is_transport_fault(st: SSEState) -> bool:
     """True when the reported fault is the RPC to the sandbox, not the model.
 
@@ -868,6 +892,22 @@ def _retry_class(st: SSEState, attempt: int) -> RetryPlan:
             True,
             f"code={st.err_code or 'none'} reports a dropped RPC to the sandbox "
             f"({_squash(st.err_msg)[:80]}) — the model never failed, so "
+            f"re-dispatching on the same model ({same}) (attempt {attempt + 1} "
+            f"of {MAX_DISPATCH_ATTEMPTS})",
+            same,
+        )
+    if is_sandbox_api_fault(st):
+        # FND-764. mothership reported a fault in its OWN wrapper around the run
+        # (`sandbox-api/...`), not in the model — so, like the transport class
+        # above, the swap axis is the wrong one and attempt 2 re-runs the same
+        # model on a fresh session id. Ranked above `is_retryable_fault` because
+        # `internal` is an informative code and would otherwise fall out of it
+        # as "not a known model/provider fault" — true, and beside the point.
+        same = attempt_model(attempt)
+        return RetryPlan(
+            True,
+            f"code={st.err_code} is a fault in mothership's own sandbox-api "
+            f"wrapper ({_squash(st.err_msg)[:80]}), not in the model — "
             f"re-dispatching on the same model ({same}) (attempt {attempt + 1} "
             f"of {MAX_DISPATCH_ATTEMPTS})",
             same,

--- a/.github/scripts/sdk_review_dispatch.py
+++ b/.github/scripts/sdk_review_dispatch.py
@@ -30,27 +30,34 @@ have, because the review lane needs them:
     its summary to the PR, the review WAS delivered, so a later stream
     breakage is a mothership-side finalize glitch and must not red the check.
 
-One re-dispatch is allowed, in any of three classes — see
+One re-dispatch is allowed, in any of four classes — see
 MAX_DISPATCH_ATTEMPTS and retry_decision():
 
   * the sandbox died on a hard error a DIFFERENT model could survive;
   * the sandbox reached `status=completed` and posted no verdict, which is the
     turn ending early rather than the model failing, so attempt 2 runs the SAME
-    model; and
+    model;
   * mothership reported a dropped RPC to the sandbox, which is a fault in the
-    pipe rather than in the model — so attempt 2 also runs the SAME model.
+    pipe rather than in the model — so attempt 2 also runs the SAME model; and
+  * mothership reported a fault in its OWN sandbox-api wrapper (FND-764), which
+    is again not the model, so attempt 2 runs the SAME model. Precautionary
+    here: all 9 observed occurrences were on the resolve lane.
 
-All three fire only after the verdict check has come back empty — confirmed
+All four fire only after the verdict check has come back empty — confirmed
 empty, sharing `sdk_review_verdict_gate`'s recheck, because the comments API is
 not read-after-write consistent. That is the single point where nothing was
 delivered; every other stream ending stays fail-fast, because a second reviewer
 would post a second summary on the same PR.
 
-The first two classes also have the sandbox provably finished. The third does
-not — a dropped pipe says nothing about the sandbox behind it — and is admitted
-anyway because this lane is self-repairing: both attempts carry the same
-`GHA_RUN_URL`, so FND-636's dedupe collapses a double post. The resolve lane
-gets no such class, for exactly that reason (FND-647).
+Three of the four also have the sandbox provably finished: the clean `complete`
+is terminal, and a sandbox-api fault is mothership reporting that its own
+execution wrapper never delivered a run. The dropped RPC does not — a dropped
+pipe says nothing about the sandbox behind it — and is admitted anyway because
+this lane is self-repairing: both attempts carry the same `GHA_RUN_URL`, so
+FND-636's dedupe collapses a double post. The resolve lane gets no dropped-RPC
+class, for exactly that reason (FND-647); it does take the sandbox-api class,
+with an extra empty-`cost_usd` conjunct to prove nothing ran before it
+re-dispatches a lane that pushes commits.
 
 Environment (all supplied by the `Dispatch to mothership Rover Direct API`
 step in `.github/workflows/sdk-review.yml`):
@@ -250,11 +257,21 @@ NEVER_RETRY_ERR_CODES = frozenset({"elicitation"})
 # same `mode: "direct"` endpoint and reach the same five unguarded
 # `langfuse_lifecycle_span` blocks in mothership's `_execute_direct`, so the
 # review lane is exposed to it identically. Matched on the code AND the message
-# prefix so a future non-plumbing `internal` cannot inherit a retry that was
-# never argued for. Kept as its own per-lane copy, like RETRYABLE_TRANSPORT_
-# PATTERNS above, because the entry conditions are per-lane.
+# so a future non-plumbing `internal` cannot inherit a retry that was never
+# argued for. The message test is a substring rather than a prefix because
+# mothership does not consistently deliver the message bare — the transport
+# class above exists because the provider text arrived wrapped in a nested JSON
+# blob — and `[sandbox-api/` is specific enough that matching it anywhere keeps
+# the allowlist just as tight.
+#
+# Kept as its own per-lane copy, like RETRYABLE_TRANSPORT_PATTERNS above,
+# because the entry conditions are per-lane. The resolve lane's copy carries an
+# extra empty-`cost_usd` conjunct that this one deliberately omits: a second
+# reviewer costs a duplicate comment that FND-636's dedupe collapses, so this
+# lane does not need to prove nothing ran before re-dispatching, while a second
+# resolver pushes to a branch and cannot be undone.
 SANDBOX_API_ERR_CODE = "internal"
-SANDBOX_API_ERR_PREFIX = "[sandbox-api/"
+SANDBOX_API_ERR_MARKER = "[sandbox-api/"
 # Wider than the 80 the other classes use: the clone-timeout variant of this
 # class is ~150 chars and buries its actual cause at the very end, behind a JSON
 # envelope, so the usual cap would discard the only readable part.
@@ -335,9 +352,10 @@ ORCHESTRATION.md Phase 0 step 7."""
 def attempt_model(attempt: int) -> str:
     """Default main model for this attempt — the swap the hard-error retry needs.
 
-    Only a default: `retry_decision()` names the model for the attempt it
-    authorises, because the two retry classes differ on exactly this axis. A
-    same-model re-dispatch (the sandbox finished cleanly and said nothing) must
+    Only a default, and only ever right for attempt 1: `retry_decision()` names
+    the model for the attempt it authorises, because the retry classes differ on
+    exactly this axis. A same-model re-dispatch (the sandbox finished cleanly
+    and said nothing; the RPC dropped; mothership's own wrapper faulted) must
     NOT be dragged onto RETRY_MAIN_MODEL — nothing about the model failed.
     """
     return MAIN_MODEL if attempt <= 1 else RETRY_MAIN_MODEL
@@ -766,8 +784,9 @@ class RetryPlan(NamedTuple):
     """Whether to re-dispatch, why, and which main model attempt N+1 runs.
 
     `model` is empty when `retry` is False. It cannot be derived from the
-    attempt number alone: the two retry classes differ on exactly that axis — a
-    dead sandbox needs a DIFFERENT model, a silent one needs the SAME one.
+    attempt number alone: the retry classes differ on exactly that axis — a
+    dead sandbox needs a DIFFERENT model, while a silent one, a dropped RPC and
+    a sandbox-api plumbing fault all need the SAME one.
     """
 
     retry: bool
@@ -812,13 +831,14 @@ def is_sandbox_api_fault(st: SSEState) -> bool:
     """True when mothership's sandbox-api reported a fault in its own plumbing.
 
     Self-deciding on the code, like `is_retryable_fault`: `internal` is
-    informative, so this never consults the message-pattern ladder. The prefix
-    is part of the discriminator rather than a fallback — see
-    SANDBOX_API_ERR_CODE.
+    informative, so this never consults the message-pattern ladder. The message
+    test is part of the discriminator rather than a fallback — see
+    SANDBOX_API_ERR_CODE, which also explains why this lane's copy carries no
+    empty-`cost_usd` conjunct where the resolve lane's does.
     """
     if st.err_code != SANDBOX_API_ERR_CODE:
         return False
-    return st.err_msg.lstrip().startswith(SANDBOX_API_ERR_PREFIX)
+    return SANDBOX_API_ERR_MARKER in st.err_msg
 
 
 def is_transport_fault(st: SSEState) -> bool:
@@ -847,11 +867,16 @@ def sandbox_completed_cleanly(st: SSEState) -> bool:
     return st.completed and st.status == "completed" and not st.errored
 
 
-def _retry_class(st: SSEState, attempt: int) -> RetryPlan:
-    """Which retry class this ending falls into, if either, and on which model.
+def _retry_class(st: SSEState, attempt: int, current_model: str) -> RetryPlan:
+    """Which retry class this ending falls into, if any, and on which model.
 
     Called only once the verdict check has come back CONFIRMED empty, so
     "nothing was delivered" is already established for every branch below.
+
+    `current_model` is the model THIS attempt actually ran, threaded down from
+    `main()`. The same-model classes must not re-derive it from `attempt`:
+    `attempt_model` answers "what attempt N would have run by default", which
+    stops being the same answer the moment a same-model retry has happened.
     """
     if sandbox_completed_cleanly(st):
         # Ranked above the cut-stream guard deliberately: `complete` IS the
@@ -859,7 +884,7 @@ def _retry_class(st: SSEState, attempt: int) -> RetryPlan:
         # nothing further even if our socket then died on the way out. And
         # nothing about the MODEL failed here — the turn ended early — so the
         # swap axis is irrelevant and attempt 2 re-runs the same one.
-        same = attempt_model(attempt)
+        same = current_model
         return RetryPlan(
             True,
             "the sandbox reached status=completed and posted no verdict — the "
@@ -891,7 +916,7 @@ def _retry_class(st: SSEState, attempt: int) -> RetryPlan:
         # sandbox of unknown liveness — the drop is in the pipe, not the sandbox
         # — and that is affordable only because both attempts carry the same
         # GHA_RUN_URL and FND-636's dedupe collapses a double post.
-        same = attempt_model(attempt)
+        same = current_model
         return RetryPlan(
             True,
             f"code={st.err_code or 'none'} reports a dropped RPC to the sandbox "
@@ -907,7 +932,7 @@ def _retry_class(st: SSEState, attempt: int) -> RetryPlan:
         # model on a fresh session id. Ranked above `is_retryable_fault` because
         # `internal` is an informative code and would otherwise fall out of it
         # as "not a known model/provider fault" — true, and beside the point.
-        same = attempt_model(attempt)
+        same = current_model
         return RetryPlan(
             True,
             f"code={st.err_code} is a fault in mothership's own sandbox-api "
@@ -932,16 +957,22 @@ def _retry_class(st: SSEState, attempt: int) -> RetryPlan:
     )
 
 
-def retry_decision(st: SSEState, attempt: int, seconds_left: float) -> RetryPlan:
+def retry_decision(
+    st: SSEState, attempt: int, seconds_left: float, current_model: str
+) -> RetryPlan:
     """Whether to re-dispatch after this attempt, on what, and why either way.
 
     The reason is logged verbatim so a run that did NOT retry says why — the
     part that is otherwise invisible. The attempt cap and the wall-clock floor
-    bound BOTH classes; only the classification in `_retry_class` differs.
+    bound EVERY class; only the classification in `_retry_class` differs.
+
+    `current_model` is required rather than defaulted: a caller that omitted it
+    would silently reintroduce the attempt-number derivation this signature
+    exists to remove. See `_retry_class`.
     """
     if attempt >= MAX_DISPATCH_ATTEMPTS:
         return RetryPlan(False, f"already used all {MAX_DISPATCH_ATTEMPTS} attempts")
-    plan = _retry_class(st, attempt)
+    plan = _retry_class(st, attempt, current_model)
     if not plan.retry:
         return plan
     if seconds_left < RETRY_MIN_REMAINING_SECONDS:
@@ -1425,7 +1456,10 @@ def main() -> int:
         # declines, the outcome is exactly what it was before: exit 0, and
         # `sdk_review_verdict_gate.py` reds the run one step later.
         plan = retry_decision(
-            st, attempt, DISPATCH_BUDGET_SECONDS - (time.monotonic() - run_start)
+            st,
+            attempt,
+            DISPATCH_BUDGET_SECONDS - (time.monotonic() - run_start),
+            model,
         )
         if not plan.retry:
             print(f"::warning::Not re-dispatching: {plan.reason}")

--- a/.github/scripts/sdk_review_dispatch.py
+++ b/.github/scripts/sdk_review_dispatch.py
@@ -255,6 +255,10 @@ NEVER_RETRY_ERR_CODES = frozenset({"elicitation"})
 # PATTERNS above, because the entry conditions are per-lane.
 SANDBOX_API_ERR_CODE = "internal"
 SANDBOX_API_ERR_PREFIX = "[sandbox-api/"
+# Wider than the 80 the other classes use: the clone-timeout variant of this
+# class is ~150 chars and buries its actual cause at the very end, behind a JSON
+# envelope, so the usual cap would discard the only readable part.
+SANDBOX_API_ERR_PREVIEW_CHARS = 200
 # Dispatch-level HTTP statuses live in their own `http_` codespace, kept apart
 # from the stream's provider codes on purpose: a provider 400 carried inside the
 # stream is worth a different model, while a 400 on the POST itself is a
@@ -907,7 +911,8 @@ def _retry_class(st: SSEState, attempt: int) -> RetryPlan:
         return RetryPlan(
             True,
             f"code={st.err_code} is a fault in mothership's own sandbox-api "
-            f"wrapper ({_squash(st.err_msg)[:80]}), not in the model — "
+            f"wrapper ({_squash(st.err_msg)[:SANDBOX_API_ERR_PREVIEW_CHARS]}), "
+            f"not in the model — "
             f"re-dispatching on the same model ({same}) (attempt {attempt + 1} "
             f"of {MAX_DISPATCH_ATTEMPTS})",
             same,

--- a/.github/scripts/tests/test_sdk_resolve_dispatch.py
+++ b/.github/scripts/tests/test_sdk_resolve_dispatch.py
@@ -7,6 +7,8 @@ import sys
 import urllib.error
 from pathlib import Path
 
+import pytest
+
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 import sdk_resolve_dispatch as sr
@@ -44,6 +46,7 @@ def test_payload_shape():
         "2026-07-08",
         "reviewer-one,reviewer-two",
         "requester-login",
+        model=sr.MAIN_MODEL,
     )
     assert p["mode"] == "direct" and p["stream"] is True
     assert p["source_id"] == "sdk-resolve-1234-2026-07-08"
@@ -58,7 +61,15 @@ def test_payload_pins_all_three_model_lanes():
     # All three lanes must be pinned: leaving any unset silently falls back to
     # mothership's Claude defaults (main -> claude-opus-5, sub-agent ->
     # claude-sonnet-5), and `small_fast_model` unset resolves to `model`.
-    p = sr.build_payload("1", "u", 8, "2026-07-08", "reviewer-one", "requester-login")
+    p = sr.build_payload(
+        "1",
+        "u",
+        8,
+        "2026-07-08",
+        "reviewer-one",
+        "requester-login",
+        model=sr.MAIN_MODEL,
+    )
     assert p["model"] == "xai/grok-4.6"
     assert p["small_fast_model"] == "gpt-5.6-luna"
     assert p["env_vars"]["CLAUDE_CODE_SUBAGENT_MODEL"] == "gpt-5.6-luna"
@@ -203,7 +214,7 @@ def test_noop_run_is_retryable_and_names_itself_in_the_reason():
     st = _stream("event: complete", 'data: {"status": "completed"}')
     assert st.err_code == ""
     assert sr.is_retryable_fault(st) is True
-    _plan = sr.retry_decision(st, 1, sr.DISPATCH_BUDGET_SECONDS)
+    _plan = sr.retry_decision(st, 1, sr.DISPATCH_BUDGET_SECONDS, sr.MAIN_MODEL)
     ok, reason = _plan.retry, _plan.reason
     assert ok is True
     assert "no-op run" in reason
@@ -626,8 +637,14 @@ def test_retry_payload_swaps_only_the_main_model():
     # provider fallback already covers a different provider for the same model,
     # and that is what failed. The two fast lanes must NOT move with it —
     # model_routing_env does `fast = small_fast_model or model`.
-    first = sr.build_payload("1", "u", 8, "2026-08-19", "rev", "req", attempt=1)
-    retry = sr.build_payload("1", "u", 8, "2026-08-19", "rev", "req", attempt=2)
+    # The model is the caller's to name now (FND-764), so the swap this asserts
+    # is `attempt_model`'s default ladder — the one a model-fault retry uses.
+    first = sr.build_payload(
+        "1", "u", 8, "2026-08-19", "rev", "req", attempt=1, model=sr.attempt_model(1)
+    )
+    retry = sr.build_payload(
+        "1", "u", 8, "2026-08-19", "rev", "req", attempt=2, model=sr.attempt_model(2)
+    )
     assert first["model"] == sr.MAIN_MODEL
     assert retry["model"] == sr.RETRY_MAIN_MODEL
     assert retry["model"] != first["model"]
@@ -648,11 +665,21 @@ def test_retry_payload_clamps_the_sandbox_timeout():
     # Cancelling the job does not stop the sandbox, so a late retry must not be
     # left billing for the full 2h after the runner dies.
     p = sr.build_payload(
-        "1", "u", 8, "2026-08-19", "rev", "req", attempt=2, max_timeout_seconds=900
+        "1",
+        "u",
+        8,
+        "2026-08-19",
+        "rev",
+        "req",
+        attempt=2,
+        model=sr.RETRY_MAIN_MODEL,
+        max_timeout_seconds=900,
     )
     assert p["max_timeout_seconds"] == 900
     assert (
-        sr.build_payload("1", "u", 8, "d", "rev", "req")["max_timeout_seconds"]
+        sr.build_payload("1", "u", 8, "d", "rev", "req", model=sr.MAIN_MODEL)[
+            "max_timeout_seconds"
+        ]
         == sr.STREAM_TIMEOUT_SECONDS
     )
 
@@ -711,7 +738,7 @@ def test_retry_decision_fires_on_a_dead_sandbox_with_a_provider_fault():
     st = sr.SSEState()
     st.got_event = st.completed = st.errored = True
     st.status, st.err_code = "error", "429"
-    _plan = sr.retry_decision(st, 1, sr.DISPATCH_BUDGET_SECONDS)
+    _plan = sr.retry_decision(st, 1, sr.DISPATCH_BUDGET_SECONDS, sr.MAIN_MODEL)
     ok, reason = _plan.retry, _plan.reason
     assert ok is True
     assert sr.RETRY_MAIN_MODEL in reason
@@ -721,7 +748,7 @@ def test_retry_decision_refuses_a_second_retry():
     st = sr.SSEState()
     st.got_event = st.completed = st.errored = True
     st.status, st.err_code = "error", "429"
-    _plan = sr.retry_decision(st, sr.MAX_DISPATCH_ATTEMPTS, 6000)
+    _plan = sr.retry_decision(st, sr.MAX_DISPATCH_ATTEMPTS, 6000, sr.MAIN_MODEL)
     ok, reason = _plan.retry, _plan.reason
     assert ok is False and "attempts" in reason
 
@@ -730,7 +757,7 @@ def test_retry_decision_refuses_a_transport_drop():
     # The sandbox may still be working — a re-dispatch would double-run it.
     st = _stream("event: started", 'data: {"session_id": "s1"}')
     assert sr.sandbox_terminated_abnormally(st) is False
-    _plan = sr.retry_decision(st, 1, 6000)
+    _plan = sr.retry_decision(st, 1, 6000, sr.MAIN_MODEL)
     ok, reason = _plan.retry, _plan.reason
     assert ok is False and "double-run" in reason
 
@@ -739,7 +766,7 @@ def test_retry_decision_refuses_when_the_job_budget_is_nearly_gone():
     st = sr.SSEState()
     st.got_event = st.completed = st.errored = True
     st.status, st.err_code = "error", "429"
-    _plan = sr.retry_decision(st, 1, sr.RETRY_MIN_REMAINING_SECONDS - 1)
+    _plan = sr.retry_decision(st, 1, sr.RETRY_MIN_REMAINING_SECONDS - 1, sr.MAIN_MODEL)
     ok, reason = _plan.retry, _plan.reason
     assert ok is False and "job budget" in reason
 
@@ -772,7 +799,7 @@ def test_an_http_status_on_the_post_is_not_a_stream_error():
     st = sr.dispatch_once("http://m", "tok", {}, opener=_raising_opener(exc))
     assert st.err_code == "http_504"
     assert st.errored is True
-    _plan = sr.retry_decision(st, 1, sr.DISPATCH_BUDGET_SECONDS)
+    _plan = sr.retry_decision(st, 1, sr.DISPATCH_BUDGET_SECONDS, sr.MAIN_MODEL)
     ok, reason = _plan.retry, _plan.reason
     assert ok is True
     assert sr.RETRY_MAIN_MODEL in reason
@@ -1131,7 +1158,9 @@ def test_a_dropped_rpc_outranks_the_noop_classification():
     assert sr.is_retryable_fault(st) is True  # would have re-dispatched
     # `errored` also makes it look dead, which is what bought it the 120s poll.
     assert sr.sandbox_terminated_abnormally(st) is True
-    assert sr.retry_decision(st, 1, sr.DISPATCH_BUDGET_SECONDS)[0] is False
+    assert (
+        sr.retry_decision(st, 1, sr.DISPATCH_BUDGET_SECONDS, sr.MAIN_MODEL)[0] is False
+    )
 
 
 def test_a_dropped_rpc_gets_the_long_out_of_band_poll():
@@ -1142,7 +1171,9 @@ def test_a_dropped_rpc_gets_the_long_out_of_band_poll():
 
 def test_a_dropped_rpc_is_never_re_dispatched_on_this_lane():
     """A resolver pushes commits; two on one branch cannot be undone."""
-    _plan = sr.retry_decision(_rpc_dropped(), 1, sr.DISPATCH_BUDGET_SECONDS)
+    _plan = sr.retry_decision(
+        _rpc_dropped(), 1, sr.DISPATCH_BUDGET_SECONDS, sr.MAIN_MODEL
+    )
     ok, reason = _plan.retry, _plan.reason
     assert ok is False
     assert "dropped RPC" in reason and "cannot be undone" in reason
@@ -1152,7 +1183,9 @@ def test_a_known_code_is_never_overridden_by_the_transport_patterns():
     """A code that carries information decides on its own, as everywhere else."""
     st = _stream(*_error_event("401", _RPC_DROP))
     assert sr.is_transport_fault(st) is False
-    assert sr.retry_decision(st, 1, sr.DISPATCH_BUDGET_SECONDS)[0] is False
+    assert (
+        sr.retry_decision(st, 1, sr.DISPATCH_BUDGET_SECONDS, sr.MAIN_MODEL)[0] is False
+    )
 
 
 def test_a_dispatch_level_http_status_is_never_the_transport_class():
@@ -1162,7 +1195,9 @@ def test_a_dispatch_level_http_status_is_never_the_transport_class():
     st.err_code, st.err_msg = "http_504", f"HTTP 504 on dispatch POST: {_RPC_DROP}"
     assert sr.is_transport_fault(st) is False
     # And it keeps the model swap the http_ codespace already earned it.
-    assert sr.retry_decision(st, 1, sr.DISPATCH_BUDGET_SECONDS)[0] is True
+    assert (
+        sr.retry_decision(st, 1, sr.DISPATCH_BUDGET_SECONDS, sr.MAIN_MODEL)[0] is True
+    )
 
 
 def test_a_model_fault_still_swaps_the_model():
@@ -1172,7 +1207,7 @@ def test_a_model_fault_still_swaps_the_model():
     st.status, st.err_code = "error", "429"
     st.err_msg = "temporarily rate-limited upstream"
     assert sr.is_transport_fault(st) is False
-    _plan = sr.retry_decision(st, 1, sr.DISPATCH_BUDGET_SECONDS)
+    _plan = sr.retry_decision(st, 1, sr.DISPATCH_BUDGET_SECONDS, sr.MAIN_MODEL)
     ok, reason = _plan.retry, _plan.reason
     assert ok is True and sr.RETRY_MAIN_MODEL in reason
 
@@ -1249,7 +1284,7 @@ def test_a_sandbox_api_fault_retries_on_the_SAME_model():
     """
     st = _sandbox_api_dead()
     assert sr.is_transport_fault(st) is False
-    plan = sr.retry_decision(st, 1, sr.DISPATCH_BUDGET_SECONDS)
+    plan = sr.retry_decision(st, 1, sr.DISPATCH_BUDGET_SECONDS, sr.MAIN_MODEL)
     assert plan.retry is True
     assert plan.model == sr.MAIN_MODEL != sr.RETRY_MAIN_MODEL
     assert "sandbox-api" in plan.reason
@@ -1263,21 +1298,26 @@ def test_an_internal_code_without_the_prefix_still_refuses_to_retry():
     """
     st = _sandbox_api_dead("upstream model rejected the request")
     assert sr.is_sandbox_api_fault(st) is False
-    plan = sr.retry_decision(st, 1, sr.DISPATCH_BUDGET_SECONDS)
+    plan = sr.retry_decision(st, 1, sr.DISPATCH_BUDGET_SECONDS, sr.MAIN_MODEL)
     assert plan.retry is False
     assert plan.model == ""
     assert "not a known model/provider fault" in plan.reason
 
 
 def test_the_budget_floor_still_bounds_the_sandbox_api_class():
-    plan = sr.retry_decision(_sandbox_api_dead(), 1, sr.RETRY_MIN_REMAINING_SECONDS - 1)
+    plan = sr.retry_decision(
+        _sandbox_api_dead(), 1, sr.RETRY_MIN_REMAINING_SECONDS - 1, sr.MAIN_MODEL
+    )
     assert plan.retry is False
     assert "job budget" in plan.reason
 
 
 def test_the_attempt_cap_still_bounds_the_sandbox_api_class():
     plan = sr.retry_decision(
-        _sandbox_api_dead(), sr.MAX_DISPATCH_ATTEMPTS, sr.DISPATCH_BUDGET_SECONDS
+        _sandbox_api_dead(),
+        sr.MAX_DISPATCH_ATTEMPTS,
+        sr.DISPATCH_BUDGET_SECONDS,
+        sr.MAIN_MODEL,
     )
     assert plan.retry is False
 
@@ -1322,7 +1362,97 @@ def test_the_clone_timeout_variant_keeps_its_cause_in_the_reason():
     from.
     """
     plan = sr.retry_decision(
-        _sandbox_api_dead(_SANDBOX_API_CLONE), 1, sr.DISPATCH_BUDGET_SECONDS
+        _sandbox_api_dead(_SANDBOX_API_CLONE),
+        1,
+        sr.DISPATCH_BUDGET_SECONDS,
+        sr.MAIN_MODEL,
     )
     assert plan.retry is True
     assert "Command timeout after 60000ms" in plan.reason
+
+
+def _sandbox_api_billed(cost: str, message: str = _SANDBOX_API_MASKED):
+    """The same fault, but with real spend reported — so something DID run."""
+    return _stream(
+        "event: complete",
+        f'data: {{"status": "error", "cost_usd": "{cost}"}}',
+        "",
+        *_error_event("internal", message),
+    )
+
+
+def test_a_sandbox_api_fault_that_billed_is_never_retried():
+    """The conjunct that makes this class safe on a lane that pushes commits.
+
+    The empty `cost_usd` is the whole safety argument — it is what establishes
+    that no model produced a token and therefore that no resolver can have
+    pushed. Real spend means the wrapper faulted AFTER a run started, and a
+    second resolver on one branch cannot be undone.
+    """
+    st = _sandbox_api_billed("12.34")
+    assert sr.billed_nothing(st) is False
+    assert sr.is_sandbox_api_fault(st) is False
+    plan = sr.retry_decision(st, 1, sr.DISPATCH_BUDGET_SECONDS, sr.MAIN_MODEL)
+    assert plan.retry is False
+    assert plan.model == ""
+    assert "not a known model/provider fault" in plan.reason
+
+
+def test_a_zero_cost_still_counts_as_nothing_billed():
+    for cost in ("", "0", "0.0", "0.0000"):
+        assert sr.billed_nothing(_sandbox_api_billed(cost)) is True
+        assert sr.is_sandbox_api_fault(_sandbox_api_billed(cost)) is True
+
+
+def test_an_unreadable_cost_fails_open_to_the_pre_guard_behaviour():
+    """`total_cost` documents mothership's cost telemetry as unreliable.
+
+    That unreliability is false-EMPTY, so an unparseable value must not be read
+    as evidence of spend — it can only ever return this to the behaviour that
+    shipped before the guard, never to something stricter than the evidence.
+    """
+    st = _sandbox_api_billed("n/a")
+    assert sr.billed_nothing(st) is True
+    assert sr.is_sandbox_api_fault(st) is True
+
+
+def test_a_sandbox_api_fault_is_matched_anywhere_in_the_message():
+    """mothership does not deliver the message bare consistently.
+
+    The transport class on this lane exists because the provider text arrived
+    wrapped in a nested JSON blob (see `_RPC_DROP`), so anchoring this class to
+    a prefix would silently miss the same fault in the same envelope — failing
+    closed, and failing to do the one job the class was added for.
+    """
+    wrapped = (
+        '{"type":"error","message":"[sandbox-api/_execute_sync] generator '
+        "didn't stop after throw()\"}"
+    )
+    st = _sandbox_api_dead(wrapped)
+    assert sr.is_sandbox_api_fault(st) is True
+    assert sr.retry_decision(st, 1, sr.DISPATCH_BUDGET_SECONDS, sr.MAIN_MODEL).retry
+
+
+def test_the_same_model_is_the_one_that_RAN_not_the_one_attempt_n_implies():
+    """The invariant the RetryPlan port exists to hold.
+
+    `attempt_model(attempt)` answers "what attempt N would have run by default",
+    which stops being the same answer the moment a same-model retry has
+    happened. Passing a model that is neither MAIN_MODEL nor RETRY_MAIN_MODEL
+    proves the plan reports what actually ran rather than re-deriving it.
+    """
+    ran = "some/other-model"
+    plan = sr.retry_decision(_sandbox_api_dead(), 1, sr.DISPATCH_BUDGET_SECONDS, ran)
+    assert plan.retry is True
+    assert plan.model == ran
+    assert f"same model ({ran})" in plan.reason
+
+
+def test_build_payload_requires_the_model_rather_than_deriving_it():
+    """No `or attempt_model(attempt)` fallback: forgetting it must be an error.
+
+    A silent fallback would put a same-model retry back on RETRY_MAIN_MODEL —
+    the exact bug the explicit `model` argument removes.
+    """
+    with pytest.raises(TypeError):
+        sr.build_payload("1", "u", 8, "d", "rev", "req", attempt=2)  # type: ignore[call-arg]

--- a/.github/scripts/tests/test_sdk_resolve_dispatch.py
+++ b/.github/scripts/tests/test_sdk_resolve_dispatch.py
@@ -1312,4 +1312,17 @@ def test_main_names_both_models_when_a_same_model_retry_also_fails(monkeypatch, 
     assert len(payloads) == 2
     out = capsys.readouterr().out
     assert f"retried on {sr.MAIN_MODEL} after {sr.MAIN_MODEL} failed" in out
-    assert sr.RETRY_MAIN_MODEL not in out
+
+
+def test_the_clone_timeout_variant_keeps_its_cause_in_the_reason():
+    """The one shape of this class whose message is worth reading.
+
+    Its cause sits at the very end, behind a JSON envelope, so the 80-char cap
+    the other classes use would truncate it away in the line a human triages
+    from.
+    """
+    plan = sr.retry_decision(
+        _sandbox_api_dead(_SANDBOX_API_CLONE), 1, sr.DISPATCH_BUDGET_SECONDS
+    )
+    assert plan.retry is True
+    assert "Command timeout after 60000ms" in plan.reason

--- a/.github/scripts/tests/test_sdk_resolve_dispatch.py
+++ b/.github/scripts/tests/test_sdk_resolve_dispatch.py
@@ -203,7 +203,8 @@ def test_noop_run_is_retryable_and_names_itself_in_the_reason():
     st = _stream("event: complete", 'data: {"status": "completed"}')
     assert st.err_code == ""
     assert sr.is_retryable_fault(st) is True
-    ok, reason = sr.retry_decision(st, 1, sr.DISPATCH_BUDGET_SECONDS)
+    _plan = sr.retry_decision(st, 1, sr.DISPATCH_BUDGET_SECONDS)
+    ok, reason = _plan.retry, _plan.reason
     assert ok is True
     assert "no-op run" in reason
     assert sr.RETRY_MAIN_MODEL in reason
@@ -710,7 +711,8 @@ def test_retry_decision_fires_on_a_dead_sandbox_with_a_provider_fault():
     st = sr.SSEState()
     st.got_event = st.completed = st.errored = True
     st.status, st.err_code = "error", "429"
-    ok, reason = sr.retry_decision(st, 1, sr.DISPATCH_BUDGET_SECONDS)
+    _plan = sr.retry_decision(st, 1, sr.DISPATCH_BUDGET_SECONDS)
+    ok, reason = _plan.retry, _plan.reason
     assert ok is True
     assert sr.RETRY_MAIN_MODEL in reason
 
@@ -719,7 +721,8 @@ def test_retry_decision_refuses_a_second_retry():
     st = sr.SSEState()
     st.got_event = st.completed = st.errored = True
     st.status, st.err_code = "error", "429"
-    ok, reason = sr.retry_decision(st, sr.MAX_DISPATCH_ATTEMPTS, 6000)
+    _plan = sr.retry_decision(st, sr.MAX_DISPATCH_ATTEMPTS, 6000)
+    ok, reason = _plan.retry, _plan.reason
     assert ok is False and "attempts" in reason
 
 
@@ -727,7 +730,8 @@ def test_retry_decision_refuses_a_transport_drop():
     # The sandbox may still be working — a re-dispatch would double-run it.
     st = _stream("event: started", 'data: {"session_id": "s1"}')
     assert sr.sandbox_terminated_abnormally(st) is False
-    ok, reason = sr.retry_decision(st, 1, 6000)
+    _plan = sr.retry_decision(st, 1, 6000)
+    ok, reason = _plan.retry, _plan.reason
     assert ok is False and "double-run" in reason
 
 
@@ -735,7 +739,8 @@ def test_retry_decision_refuses_when_the_job_budget_is_nearly_gone():
     st = sr.SSEState()
     st.got_event = st.completed = st.errored = True
     st.status, st.err_code = "error", "429"
-    ok, reason = sr.retry_decision(st, 1, sr.RETRY_MIN_REMAINING_SECONDS - 1)
+    _plan = sr.retry_decision(st, 1, sr.RETRY_MIN_REMAINING_SECONDS - 1)
+    ok, reason = _plan.retry, _plan.reason
     assert ok is False and "job budget" in reason
 
 
@@ -767,7 +772,8 @@ def test_an_http_status_on_the_post_is_not_a_stream_error():
     st = sr.dispatch_once("http://m", "tok", {}, opener=_raising_opener(exc))
     assert st.err_code == "http_504"
     assert st.errored is True
-    ok, reason = sr.retry_decision(st, 1, sr.DISPATCH_BUDGET_SECONDS)
+    _plan = sr.retry_decision(st, 1, sr.DISPATCH_BUDGET_SECONDS)
+    ok, reason = _plan.retry, _plan.reason
     assert ok is True
     assert sr.RETRY_MAIN_MODEL in reason
 
@@ -1136,7 +1142,8 @@ def test_a_dropped_rpc_gets_the_long_out_of_band_poll():
 
 def test_a_dropped_rpc_is_never_re_dispatched_on_this_lane():
     """A resolver pushes commits; two on one branch cannot be undone."""
-    ok, reason = sr.retry_decision(_rpc_dropped(), 1, sr.DISPATCH_BUDGET_SECONDS)
+    _plan = sr.retry_decision(_rpc_dropped(), 1, sr.DISPATCH_BUDGET_SECONDS)
+    ok, reason = _plan.retry, _plan.reason
     assert ok is False
     assert "dropped RPC" in reason and "cannot be undone" in reason
 
@@ -1165,7 +1172,8 @@ def test_a_model_fault_still_swaps_the_model():
     st.status, st.err_code = "error", "429"
     st.err_msg = "temporarily rate-limited upstream"
     assert sr.is_transport_fault(st) is False
-    ok, reason = sr.retry_decision(st, 1, sr.DISPATCH_BUDGET_SECONDS)
+    _plan = sr.retry_decision(st, 1, sr.DISPATCH_BUDGET_SECONDS)
+    ok, reason = _plan.retry, _plan.reason
     assert ok is True and sr.RETRY_MAIN_MODEL in reason
 
 
@@ -1195,3 +1203,113 @@ def test_main_fails_a_dropped_rpc_whose_handoff_never_lands(monkeypatch, capsys)
     assert sr.main() == 1
     assert len(payloads) == 1
     assert "Not re-dispatching" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# a fault in mothership's own sandbox-api wrapper: same-model retry (FND-764)
+# ---------------------------------------------------------------------------
+
+# Verbatim from the 9 consecutive resolve failures on 2026-08-24 (runs
+# 32712863922 .. 32739465231). mothership's `langfuse_lifecycle_span` swallowed
+# the real exception and yielded a second time, so `contextlib` raised this in
+# its place and the actual cause never reached us (FND-765).
+_SANDBOX_API_MASKED = "[sandbox-api/_execute_sync] generator didn't stop after throw()"
+# The other observed shape, from run 32494993256 — legible, and plainly
+# transient. A different cause from the one above; the same retryability.
+_SANDBOX_API_CLONE = (
+    "[sandbox-api/_execute_sync] Failed to clone repository: "
+    '{"error":"CommandError: ... Command timeout after 60000ms"}'
+)
+
+
+def _sandbox_api_dead(message: str = _SANDBOX_API_MASKED):
+    """How those runs ended: `complete` with status=error, no cost, then the code.
+
+    `cost_usd` is empty on purpose — it is empty on every observed occurrence,
+    which is the evidence that no model produced a token.
+    """
+    return _stream(
+        "event: complete",
+        'data: {"status": "error", "cost_usd": ""}',
+        "",
+        *_error_event("internal", message),
+    )
+
+
+def test_a_sandbox_api_fault_is_recognised_by_code_and_prefix():
+    for msg in (_SANDBOX_API_MASKED, _SANDBOX_API_CLONE):
+        assert sr.is_sandbox_api_fault(_sandbox_api_dead(msg)) is True
+
+
+def test_a_sandbox_api_fault_retries_on_the_SAME_model():
+    """The whole point of the class: the model never failed, so don't swap it.
+
+    Before FND-764 this fell out of `is_retryable_fault` as "not a known
+    model/provider fault" — true, and beside the point.
+    """
+    st = _sandbox_api_dead()
+    assert sr.is_transport_fault(st) is False
+    plan = sr.retry_decision(st, 1, sr.DISPATCH_BUDGET_SECONDS)
+    assert plan.retry is True
+    assert plan.model == sr.MAIN_MODEL != sr.RETRY_MAIN_MODEL
+    assert "sandbox-api" in plan.reason
+
+
+def test_an_internal_code_without_the_prefix_still_refuses_to_retry():
+    """The guard that keeps this an allowlist rather than a denylist.
+
+    `internal` is a generic label. A future non-plumbing use of it must not
+    inherit a retry that was only ever argued for the sandbox-api codespace.
+    """
+    st = _sandbox_api_dead("upstream model rejected the request")
+    assert sr.is_sandbox_api_fault(st) is False
+    plan = sr.retry_decision(st, 1, sr.DISPATCH_BUDGET_SECONDS)
+    assert plan.retry is False
+    assert plan.model == ""
+    assert "not a known model/provider fault" in plan.reason
+
+
+def test_the_budget_floor_still_bounds_the_sandbox_api_class():
+    plan = sr.retry_decision(_sandbox_api_dead(), 1, sr.RETRY_MIN_REMAINING_SECONDS - 1)
+    assert plan.retry is False
+    assert "job budget" in plan.reason
+
+
+def test_the_attempt_cap_still_bounds_the_sandbox_api_class():
+    plan = sr.retry_decision(
+        _sandbox_api_dead(), sr.MAX_DISPATCH_ATTEMPTS, sr.DISPATCH_BUDGET_SECONDS
+    )
+    assert plan.retry is False
+
+
+def test_main_redispatches_a_sandbox_api_fault_on_the_same_model(monkeypatch, capsys):
+    """End-to-end: two dispatches, both on MAIN_MODEL, and the run recovers."""
+    _main_env(monkeypatch)
+    payloads = _record_dispatches(
+        monkeypatch, [_sandbox_api_dead(), _completed_stream("2.10")]
+    )
+
+    assert sr.main() == 0
+    assert [p["model"] for p in payloads] == [sr.MAIN_MODEL, sr.MAIN_MODEL]
+    # A retry MUST NOT collide with attempt 1's source_id on the mothership side.
+    assert payloads[0]["source_id"] != payloads[1]["source_id"]
+    assert "Re-dispatching" in capsys.readouterr().out
+
+
+def test_main_names_both_models_when_a_same_model_retry_also_fails(monkeypatch, capsys):
+    """The failure suffix must report what actually ran, not attempt_model().
+
+    With the model no longer a function of the attempt number, deriving the
+    suffix from `attempt_model(...)` would claim a swap to RETRY_MAIN_MODEL that
+    never happened.
+    """
+    _main_env(monkeypatch)
+    payloads = _record_dispatches(
+        monkeypatch, [_sandbox_api_dead(), _sandbox_api_dead()]
+    )
+
+    assert sr.main() == 1
+    assert len(payloads) == 2
+    out = capsys.readouterr().out
+    assert f"retried on {sr.MAIN_MODEL} after {sr.MAIN_MODEL} failed" in out
+    assert sr.RETRY_MAIN_MODEL not in out

--- a/.github/scripts/tests/test_sdk_review_dispatch.py
+++ b/.github/scripts/tests/test_sdk_review_dispatch.py
@@ -640,7 +640,7 @@ def test_an_http_status_on_the_post_is_not_a_stream_error():
     assert st.err_code == "http_504"
     assert st.errored is True
     assert st.stream_error == ""
-    plan = sd._retry_class(st, 1)
+    plan = sd._retry_class(st, 1, sd.MAIN_MODEL)
     assert plan.retry is True
 
 
@@ -669,7 +669,7 @@ def test_a_genuine_transport_drop_is_still_never_retried():
     )
     assert st.stream_error
     assert st.errored is False
-    plan = sd._retry_class(st, 1)
+    plan = sd._retry_class(st, 1, sd.MAIN_MODEL)
     assert plan.retry is False
 
 
@@ -1047,7 +1047,7 @@ def test_a_known_code_is_never_overridden_by_the_message_patterns():
 
 
 def test_retry_fires_on_a_dead_sandbox_with_a_retryable_code():
-    plan = sd.retry_decision(_errored("429"), 1, 6000)
+    plan = sd.retry_decision(_errored("429"), 1, 6000, sd.MAIN_MODEL)
     assert plan.retry is True
     assert plan.model == sd.RETRY_MAIN_MODEL
     assert sd.RETRY_MAIN_MODEL in plan.reason and "attempt 2 of 2" in plan.reason
@@ -1060,11 +1060,11 @@ def test_retry_fires_when_complete_carries_status_error():
         )
     )
     assert sd.sandbox_terminated_abnormally(st) is True
-    assert sd.retry_decision(st, 1, 6000).retry is True
+    assert sd.retry_decision(st, 1, 6000, sd.MAIN_MODEL).retry is True
 
 
 def test_only_one_retry_is_ever_spent():
-    plan = sd.retry_decision(_errored("429"), 2, 6000)
+    plan = sd.retry_decision(_errored("429"), 2, 6000, sd.MAIN_MODEL)
     assert plan.retry is False and "all 2 attempts" in plan.reason
     assert sd.MAX_DISPATCH_ATTEMPTS == 2
 
@@ -1073,26 +1073,28 @@ def test_a_cut_stream_never_retries_because_the_reviewer_may_still_be_working():
     """A second reviewer would post a second summary on the same PR."""
     st = _stream(*_event("started", {"session_id": "s"}))
     st.stream_error = "read timed out"
-    plan = sd.retry_decision(st, 1, 6000)
+    plan = sd.retry_decision(st, 1, 6000, sd.MAIN_MODEL)
     assert plan.retry is False and "post a second summary" in plan.reason
 
 
 def test_a_clean_eof_without_complete_never_retries():
     st = _stream(*_event("started", {"session_id": "s"}))
-    plan = sd.retry_decision(st, 1, 6000)
+    plan = sd.retry_decision(st, 1, 6000, sd.MAIN_MODEL)
     assert plan.retry is False and "may still be running" in plan.reason
 
 
 def test_an_unrecognised_cause_stays_fail_fast():
-    plan = sd.retry_decision(_errored("401", "auth"), 1, 6000)
+    plan = sd.retry_decision(_errored("401", "auth"), 1, 6000, sd.MAIN_MODEL)
     assert plan.retry is False and "not a known model/provider fault" in plan.reason
 
 
 def test_a_retry_is_refused_below_the_wall_clock_floor():
     """Below the floor a second sandbox would be killed mid-review."""
-    plan = sd.retry_decision(_errored("429"), 1, 600)
+    plan = sd.retry_decision(_errored("429"), 1, 600, sd.MAIN_MODEL)
     assert plan.retry is False and "600s of the job budget remain" in plan.reason
-    assert sd.retry_decision(_errored("429"), 1, sd.RETRY_MIN_REMAINING_SECONDS).retry
+    assert sd.retry_decision(
+        _errored("429"), 1, sd.RETRY_MIN_REMAINING_SECONDS, sd.MAIN_MODEL
+    ).retry
 
 
 def test_every_refusal_says_why():
@@ -1105,7 +1107,7 @@ def test_every_refusal_says_why():
         (_completed("0.83"), 2, 6000),
         (_completed("0.83"), 1, 10),
     ):
-        plan = sd.retry_decision(st, attempt, left)
+        plan = sd.retry_decision(st, attempt, left, sd.attempt_model(attempt))
         assert plan.retry is False and plan.reason.strip()
 
 
@@ -1125,7 +1127,7 @@ def test_a_clean_completed_sandbox_that_said_nothing_retries_on_the_same_model()
     assert sd.sandbox_completed_cleanly(st) is True
     assert sd.sandbox_terminated_abnormally(st) is False  # why it never retried
 
-    plan = sd.retry_decision(st, 1, 6000)
+    plan = sd.retry_decision(st, 1, 6000, sd.MAIN_MODEL)
     assert plan.retry is True
     assert plan.model == sd.MAIN_MODEL != sd.RETRY_MAIN_MODEL
     assert "posted no verdict" in plan.reason and "same model" in plan.reason
@@ -1134,9 +1136,20 @@ def test_a_clean_completed_sandbox_that_said_nothing_retries_on_the_same_model()
 def test_the_same_model_retry_still_honours_the_shared_retry_bounds():
     """Constraint: an extra entry condition only — the knobs do not move."""
     st = _completed("1.0")
-    assert sd.retry_decision(st, sd.MAX_DISPATCH_ATTEMPTS, 6000).retry is False
-    assert sd.retry_decision(st, 1, sd.RETRY_MIN_REMAINING_SECONDS - 1).retry is False
-    assert sd.retry_decision(st, 1, sd.RETRY_MIN_REMAINING_SECONDS).retry is True
+    assert (
+        sd.retry_decision(st, sd.MAX_DISPATCH_ATTEMPTS, 6000, sd.MAIN_MODEL).retry
+        is False
+    )
+    assert (
+        sd.retry_decision(
+            st, 1, sd.RETRY_MIN_REMAINING_SECONDS - 1, sd.MAIN_MODEL
+        ).retry
+        is False
+    )
+    assert (
+        sd.retry_decision(st, 1, sd.RETRY_MIN_REMAINING_SECONDS, sd.MAIN_MODEL).retry
+        is True
+    )
 
 
 def test_a_complete_carrying_a_non_completed_status_is_not_the_clean_class():
@@ -1147,7 +1160,7 @@ def test_a_complete_carrying_a_non_completed_status_is_not_the_clean_class():
         )
     )
     assert sd.sandbox_completed_cleanly(st) is False
-    assert sd.retry_decision(st, 1, 6000).model == sd.RETRY_MAIN_MODEL
+    assert sd.retry_decision(st, 1, 6000, sd.MAIN_MODEL).model == sd.RETRY_MAIN_MODEL
 
 
 def test_a_terminal_complete_outranks_a_socket_death_on_the_way_out():
@@ -1155,7 +1168,7 @@ def test_a_terminal_complete_outranks_a_socket_death_on_the_way_out():
     make it live again, so this is still the silent-review class."""
     st = _completed("0.83")
     st.stream_error = "connection reset by peer"
-    plan = sd.retry_decision(st, 1, 6000)
+    plan = sd.retry_decision(st, 1, 6000, sd.MAIN_MODEL)
     assert plan.retry is True and plan.model == sd.MAIN_MODEL
 
 
@@ -1495,7 +1508,7 @@ def test_a_dropped_rpc_is_not_a_model_fault_and_used_to_fall_through():
 
 
 def test_a_dropped_rpc_retries_on_the_same_model():
-    plan = sd.retry_decision(_rpc_dropped(), 1, 6000)
+    plan = sd.retry_decision(_rpc_dropped(), 1, 6000, sd.MAIN_MODEL)
     assert plan.retry is True
     assert plan.model == sd.MAIN_MODEL != sd.RETRY_MAIN_MODEL
     assert "dropped RPC" in plan.reason and "same model" in plan.reason
@@ -1505,23 +1518,34 @@ def test_a_dropped_rpc_without_a_terminal_complete_is_the_same_class():
     """The other shape it arrives in: the error event and nothing after it."""
     st = _stream(*_event("error", {"code": "unknown", "message": _RPC_DROP}))
     assert st.completed is False and st.stream_error == ""
-    plan = sd.retry_decision(st, 1, 6000)
+    plan = sd.retry_decision(st, 1, 6000, sd.MAIN_MODEL)
     assert plan.retry is True and plan.model == sd.MAIN_MODEL
 
 
 def test_the_transport_retry_still_honours_the_shared_retry_bounds():
     """Constraint: an extra entry condition only — the knobs do not move."""
     st = _rpc_dropped()
-    assert sd.retry_decision(st, sd.MAX_DISPATCH_ATTEMPTS, 6000).retry is False
-    assert sd.retry_decision(st, 1, sd.RETRY_MIN_REMAINING_SECONDS - 1).retry is False
-    assert sd.retry_decision(st, 1, sd.RETRY_MIN_REMAINING_SECONDS).retry is True
+    assert (
+        sd.retry_decision(st, sd.MAX_DISPATCH_ATTEMPTS, 6000, sd.MAIN_MODEL).retry
+        is False
+    )
+    assert (
+        sd.retry_decision(
+            st, 1, sd.RETRY_MIN_REMAINING_SECONDS - 1, sd.MAIN_MODEL
+        ).retry
+        is False
+    )
+    assert (
+        sd.retry_decision(st, 1, sd.RETRY_MIN_REMAINING_SECONDS, sd.MAIN_MODEL).retry
+        is True
+    )
 
 
 def test_a_known_code_is_never_overridden_by_the_transport_patterns():
     """A code that carries information decides on its own, as everywhere else."""
     st = _stream(*_event("error", {"code": "401", "message": _RPC_DROP}))
     assert sd.is_transport_fault(st) is False
-    assert sd.retry_decision(st, 1, 6000).retry is False
+    assert sd.retry_decision(st, 1, 6000, sd.MAIN_MODEL).retry is False
 
 
 def test_a_dispatch_level_http_status_is_never_the_transport_class():
@@ -1531,12 +1555,15 @@ def test_a_dispatch_level_http_status_is_never_the_transport_class():
     st.err_code, st.err_msg = "http_504", f"HTTP 504 on dispatch POST: {_RPC_DROP}"
     assert sd.is_transport_fault(st) is False
     # And it keeps the model swap the http_ codespace already earned it.
-    assert sd.retry_decision(st, 1, 6000).model == sd.RETRY_MAIN_MODEL
+    assert sd.retry_decision(st, 1, 6000, sd.MAIN_MODEL).model == sd.RETRY_MAIN_MODEL
 
 
 def test_a_model_fault_still_swaps_the_model():
     """No regression on FND-641/FND-643: the two classes stay on their own axes."""
-    assert sd.retry_decision(_errored("429"), 1, 6000).model == sd.RETRY_MAIN_MODEL
+    assert (
+        sd.retry_decision(_errored("429"), 1, 6000, sd.MAIN_MODEL).model
+        == sd.RETRY_MAIN_MODEL
+    )
 
 
 def test_main_re_dispatches_a_dropped_rpc_on_the_same_model(
@@ -1594,7 +1621,7 @@ def test_a_sandbox_api_fault_is_not_a_model_fault_and_would_fall_through():
 
 
 def test_a_sandbox_api_fault_retries_on_the_same_model():
-    plan = sd.retry_decision(_sandbox_api_dead(), 1, 6000)
+    plan = sd.retry_decision(_sandbox_api_dead(), 1, 6000, sd.MAIN_MODEL)
     assert plan.retry is True
     assert plan.model == sd.MAIN_MODEL != sd.RETRY_MAIN_MODEL
     assert "sandbox-api" in plan.reason and "same model" in plan.reason
@@ -1604,13 +1631,74 @@ def test_an_internal_code_without_the_prefix_still_refuses_to_retry():
     """Keeps the class an allowlist: `internal` alone buys nothing."""
     st = _sandbox_api_dead("upstream model rejected the request")
     assert sd.is_sandbox_api_fault(st) is False
-    plan = sd.retry_decision(st, 1, 6000)
+    plan = sd.retry_decision(st, 1, 6000, sd.MAIN_MODEL)
     assert plan.retry is False and plan.model == ""
 
 
 def test_the_sandbox_api_retry_still_honours_the_shared_retry_bounds():
     """Constraint: an extra entry condition only — the knobs do not move."""
     st = _sandbox_api_dead()
-    assert sd.retry_decision(st, sd.MAX_DISPATCH_ATTEMPTS, 6000).retry is False
-    assert sd.retry_decision(st, 1, sd.RETRY_MIN_REMAINING_SECONDS - 1).retry is False
-    assert sd.retry_decision(st, 1, sd.RETRY_MIN_REMAINING_SECONDS).retry is True
+    assert (
+        sd.retry_decision(st, sd.MAX_DISPATCH_ATTEMPTS, 6000, sd.MAIN_MODEL).retry
+        is False
+    )
+    assert (
+        sd.retry_decision(
+            st, 1, sd.RETRY_MIN_REMAINING_SECONDS - 1, sd.MAIN_MODEL
+        ).retry
+        is False
+    )
+    assert (
+        sd.retry_decision(st, 1, sd.RETRY_MIN_REMAINING_SECONDS, sd.MAIN_MODEL).retry
+        is True
+    )
+
+
+def test_a_sandbox_api_fault_is_matched_anywhere_in_the_message():
+    """mothership does not deliver the message bare consistently.
+
+    The transport class on this lane exists because the provider text arrived
+    wrapped in a nested JSON blob, so anchoring this class to a prefix would
+    silently miss the same fault in the same envelope.
+    """
+    wrapped = (
+        '{"type":"error","message":"[sandbox-api/_execute_sync] generator '
+        "didn't stop after throw()\"}"
+    )
+    st = _sandbox_api_dead(wrapped)
+    assert sd.is_sandbox_api_fault(st) is True
+    assert sd.retry_decision(st, 1, 6000, sd.MAIN_MODEL).retry is True
+
+
+def test_this_lane_retries_a_sandbox_api_fault_that_billed():
+    """The deliberate divergence from the resolve lane's copy.
+
+    A second reviewer costs a duplicate comment that FND-636's dedupe collapses,
+    so this lane does not have to prove nothing ran before re-dispatching. The
+    resolve lane does, because a second resolver pushes commits.
+    """
+    st = _stream(
+        *_event("complete", {"status": "error", "cost_usd": "12.34"}),
+        *_event("error", {"code": "internal", "message": _SANDBOX_API_MASKED}),
+    )
+    assert sd.is_sandbox_api_fault(st) is True
+    assert sd.retry_decision(st, 1, 6000, sd.MAIN_MODEL).retry is True
+
+
+def test_the_same_model_is_the_one_that_RAN_not_the_one_attempt_n_implies():
+    """The invariant `RetryPlan` exists to hold, pinned on every same-model class.
+
+    `attempt_model(attempt)` answers "what attempt N would have run by default",
+    which stops being the same answer the moment a same-model retry has
+    happened. A model that is neither MAIN_MODEL nor RETRY_MAIN_MODEL proves the
+    plan reports what actually ran rather than re-deriving it.
+    """
+    ran = "some/other-model"
+    for st in (
+        _sandbox_api_dead(),
+        _rpc_dropped(),
+        _completed("0.83"),
+    ):
+        plan = sd.retry_decision(st, 1, 6000, ran)
+        assert plan.retry is True
+        assert plan.model == ran, plan.reason

--- a/.github/scripts/tests/test_sdk_review_dispatch.py
+++ b/.github/scripts/tests/test_sdk_review_dispatch.py
@@ -1561,3 +1561,56 @@ def test_main_does_not_re_dispatch_a_dropped_rpc_that_delivered(
 
     assert sd.main() == 0
     assert len(seen) == 1
+
+
+# ---------------------------------------------------------------------------
+# a fault in mothership's own sandbox-api wrapper: same-model retry (FND-764)
+# ---------------------------------------------------------------------------
+
+# Verbatim from the resolve lane's 9 consecutive failures on 2026-08-24. This
+# lane saw none of them, but both POST the same `mode: "direct"` endpoint and
+# reach the same unguarded lifecycle-span blocks on mothership's side, so the
+# exposure is identical — the class is precautionary here, not observed.
+_SANDBOX_API_MASKED = "[sandbox-api/_execute_sync] generator didn't stop after throw()"
+
+
+def _sandbox_api_dead(message: str = _SANDBOX_API_MASKED) -> sd.SSEState:
+    return _stream(
+        *_event("complete", {"status": "error", "cost_usd": ""}),
+        *_event("error", {"code": "internal", "message": message}),
+    )
+
+
+def test_a_sandbox_api_fault_is_not_a_model_fault_and_would_fall_through():
+    """The regression anchor: the model-swap allowlist declines `internal`.
+
+    Correctly — nothing about the model failed. Before this class that refusal
+    was the end of the run.
+    """
+    st = _sandbox_api_dead()
+    assert sd.is_retryable_fault(st) is False
+    assert sd.is_transport_fault(st) is False  # informative code, not a pipe drop
+    assert sd.is_sandbox_api_fault(st) is True
+
+
+def test_a_sandbox_api_fault_retries_on_the_same_model():
+    plan = sd.retry_decision(_sandbox_api_dead(), 1, 6000)
+    assert plan.retry is True
+    assert plan.model == sd.MAIN_MODEL != sd.RETRY_MAIN_MODEL
+    assert "sandbox-api" in plan.reason and "same model" in plan.reason
+
+
+def test_an_internal_code_without_the_prefix_still_refuses_to_retry():
+    """Keeps the class an allowlist: `internal` alone buys nothing."""
+    st = _sandbox_api_dead("upstream model rejected the request")
+    assert sd.is_sandbox_api_fault(st) is False
+    plan = sd.retry_decision(st, 1, 6000)
+    assert plan.retry is False and plan.model == ""
+
+
+def test_the_sandbox_api_retry_still_honours_the_shared_retry_bounds():
+    """Constraint: an extra entry condition only — the knobs do not move."""
+    st = _sandbox_api_dead()
+    assert sd.retry_decision(st, sd.MAX_DISPATCH_ATTEMPTS, 6000).retry is False
+    assert sd.retry_decision(st, 1, sd.RETRY_MIN_REMAINING_SECONDS - 1).retry is False
+    assert sd.retry_decision(st, 1, sd.RETRY_MIN_REMAINING_SECONDS).retry is True

--- a/uv.lock
+++ b/uv.lock
@@ -464,7 +464,7 @@ requires-dist = [
 provides-extras = ["test"]
 
 [package.metadata.requires-dev]
-dev = [{ name = "ruff", specifier = "==0.16.4" }]
+dev = [{ name = "ruff", specifier = "==0.16.3" }]
 
 [[package]]
 name = "attrs"

--- a/uv.lock
+++ b/uv.lock
@@ -464,7 +464,7 @@ requires-dist = [
 provides-extras = ["test"]
 
 [package.metadata.requires-dev]
-dev = [{ name = "ruff", specifier = "==0.16.3" }]
+dev = [{ name = "ruff", specifier = "==0.16.4" }]
 
 [[package]]
 name = "attrs"


### PR DESCRIPTION
Closes FND-764.

## Why

Every `@sdk-resolve` invocation on 2026-08-24 failed — **9 consecutive**, over 5 hours, all on the identical wire fault:

```
[complete]  status=error cost_usd=
[attempt 1/2] model=xai/grok-4.6 status=error cost_usd=n/a code=internal
##[warning]Not re-dispatching: code=internal is not a known model/provider fault,
           so a different model would fail the same way
##[error]Sandbox error: code=internal
         message=[sandbox-api/_execute_sync] generator didn't stop after throw()
```

`code=internal` had no retry class. `is_retryable_fault()` sees an informative code — so the message-pattern ladder is skipped, by design — that is absent from `RETRYABLE_ERR_CODES`, and refuses with *"a different model would fail the same way"*. True, and beside the point: the model never ran.

That code is mothership's own **sandbox-api** codespace, stamped by the wrapper that reported it (`_err_msg(e, "sandbox-api/_execute_sync")`). Two shapes are on record, and they do **not** share a cause:

| message | seen | cause |
|---|---|---|
| `generator didn't stop after throw()` | ×8 | masked — mothership's `langfuse_lifecycle_span` swallows the real exception and yields a second time |
| `Failed to clone repository: … Command timeout after 60000ms` | ×1 | legible, and plainly transient |

What they *do* share is what licenses a retry: **nothing was delivered and nothing was billed.** `cost_usd` is empty on all 9 while other failures on this lane report real spend ($0.48 / $2.26 / $6.58 / $28.34), so no model produced a token — and all 9 affected PRs were checked for a resolver push or Phase-4 hand-off. There were none. On a lane where two resolvers on one branch cannot be undone, that is the bar: there is no first resolver for a second to race.

This is the **opposite** of FND-647's dropped RPC, which leaves a sandbox of unknown liveness behind a broken pipe. That one is still refused here, and the new branch is ranked below it deliberately.

## What changed

- **New retry class** on both lanes, discriminated on `code=internal` **and** a `[sandbox-api/` message prefix. Matching the code alone would let a future non-plumbing `internal` inherit a retry nobody argued for — this stays an allowlist, not a denylist.
- **Retries on the same model.** Nothing about the model failed, so the swap axis is wrong and opus prices are unwarranted. Follows the FND-645 / FND-647 same-model precedent.
- **`RetryPlan(retry, reason, model)` ported into the resolve lane** from the review lane. This is the enabling change: `retry_decision` returned a 2-tuple and the caller derived the model from the attempt number, so "same model" was literally inexpressible — a retry would have silently landed on `claude-opus-5`. `build_payload` now takes an explicit `model`, and the *"retried on X after Y"* suffix names the models actually run for the same reason.
- **Out-of-band poll untouched.** `retry_decision`'s contract is that it runs only after that poll came back empty, which is what establishes "delivered nothing" before any retry is considered. 120s of a 6600s budget is what buys the safety argument above.
- **Mirrored into `sdk_review_dispatch.py`** — labelled precautionary in the comment, because 0 of the 9 hits were on the review lane. Both lanes POST the same `mode: "direct"` endpoint and reach the same unguarded lifecycle-span blocks, so the exposure is identical.
- Second commit widens the log preview for this class only: the clone-timeout shape is ~150 chars and buries its cause behind a JSON envelope, so the 80-char cap the other classes use truncated away the one readable thing in the line a human triages from.

## Honest scope — this does not restore the lane

The fault is **sustained, not transient**: the lane was still failing identically at 14:33 UTC. A retry authorised by this change will very likely hit the same broken path. This earns its keep against the *isolated* occurrence — the 08-21 clone timeout, where resolve was healthy either side of it.

Recovering the actual cause needs mothership's server log (`sandbox_api.py:412` logs the traceback with `exc_info=True`), keyed by the 9 session IDs in FND-764. Two companion pieces of work:

- **FND-765** — the mothership fix that stops the exception being destroyed in the first place. PR: atlanhq/mothership#2621
- **FND-767** — the log dig that identifies what is actually throwing.

## Tests

225 pass across both dispatch suites (resolve 83 → 90, review 130 → 134). Beyond the happy paths:

- **the negative case** — an `internal` code *without* the `[sandbox-api/` prefix still refuses to retry, which is what keeps the class from rotting into a denylist;
- the same-model assertion, and that it differs from `RETRY_MAIN_MODEL`;
- attempt cap and wall-clock floor still bound the new class;
- a retry gets a fresh `source_id` rather than colliding with attempt 1 on the mothership side;
- the *"retried on X after Y"* suffix names what actually ran — deriving it from `attempt_model()` would have claimed a model swap that never happened;
- the clone-timeout variant keeps `Command timeout after 60000ms` in its reason.

`pre-commit` clean on all four files (ruff, ruff-format, isort, pyright).
