### PR TITLE
feat(e2e): name an AE submit that leaves {{credentialGuid}} unresolved (FND-656)

### DIFF
--- a/application_sdk/testing/e2e/client.py
+++ b/application_sdk/testing/e2e/client.py
@@ -1623,6 +1623,19 @@ class AEWorkflowClient:
         to attribute the fault; hardening this into an invariant is a follow-up
         for once the logged shape is known. FND-402 / FND-656.
         """
+        # Unconditional, because the shape is the unknown. AE's submit response
+        # is undocumented; a detector that only reports when it fires can never
+        # tell us WHY it did not (verified against a real tenant: the response
+        # carries no Argo parameter block at all, so the scan below is inert
+        # there). Top-level keys only — never values, which can carry a source
+        # credential. This is what makes the next run diagnostic instead of
+        # silent.
+        logger.info(
+            "submit_workflow: AE accepted run %s; response keys=%s data keys=%s",
+            run_id,
+            sorted(body.keys()),
+            sorted(body["data"].keys()) if isinstance(body.get("data"), dict) else None,
+        )
         leftover = _unsubstituted_parameter_tokens(body)
         if not leftover:
             return
@@ -1632,13 +1645,12 @@ class AEWorkflowClient:
             "them the run WILL fail on the extract node with [AAF-CRD-005] "
             "Invalid credential GUID — AE did not turn the submit's payload[] "
             "credential block into a GUID. That is a tenant/AE control-plane "
-            "fault, not a connector defect; response keys=%s",
+            "fault, not a connector defect.",
             run_id,
             len(leftover),
             ", ".join(
                 f"{name} -> {{{{{token}}}}}" for name, token in sorted(leftover.items())
             ),
-            sorted(body.keys()),
         )
 
     def get_native_status(self, run_id: str) -> DAGRunResult:

--- a/application_sdk/testing/e2e/client.py
+++ b/application_sdk/testing/e2e/client.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 
 import asyncio
 import math
+import re
 import time
 from collections.abc import Callable
 from dataclasses import dataclass, replace
@@ -459,6 +460,49 @@ def _rotate_submit_credential_name(body: dict[str, Any] | None) -> None:
     base, _, tail = str(name).rpartition("-retry")
     n = int(tail) + 1 if base and tail.isdigit() else 1
     cred["body"]["name"] = f"{base or name}-retry{n}"
+
+
+# One mustache token, e.g. ``{{credentialGuid}}``, capturing the name. Applied
+# with fullmatch below, so the brace-free inner class is what keeps a value like
+# ``{{a}}{{b}}`` from reading as a single token.
+_MUSTACHE_TOKEN_RE = re.compile(r"\{\{([^{}]+)\}\}")
+
+
+def _unsubstituted_parameter_tokens(body: Any) -> dict[str, str]:
+    """Map ``parameter name -> mustache token`` for values AE left unresolved.
+
+    The harness submits ``{{credentialGuid}}`` as a *deliberate* literal: the
+    ``payload[]`` block asks AE to create a credential and substitute the token
+    in the request's own Argo parameters (see :func:`build_ae_payload`). When
+    that substitution silently does not happen, AE still answers 2xx with a
+    run_id, so the harness polls happily and the literal only surfaces ~2min
+    later as a worker-side ``[AAF-CRD-005] Invalid credential GUID`` on the
+    extract node — a connector-looking error for a control-plane fault. This
+    reads the submit response so the fault can be named where it happens.
+
+    Returns parameter names and token names only, never values: an Argo
+    parameter value can carry a source credential, and this feeds a log line.
+
+    Only reports when a value is EXACTLY one token. A value that merely embeds
+    braces (a JSON blob, a regex) is not evidence of failed substitution.
+    """
+    found: dict[str, str] = {}
+
+    def _walk(node: Any) -> None:
+        if isinstance(node, dict):
+            name, value = node.get("name"), node.get("value")
+            if isinstance(name, str) and isinstance(value, str):
+                m = _MUSTACHE_TOKEN_RE.fullmatch(value.strip())
+                if m:
+                    found[name] = m.group(1)
+            for v in node.values():
+                _walk(v)
+        elif isinstance(node, list):
+            for v in node:
+                _walk(v)
+
+    _walk(body)
+    return found
 
 
 def _node_glyph(node) -> str:
@@ -1532,6 +1576,7 @@ class AEWorkflowClient:
             data = body.get("data") if isinstance(body.get("data"), dict) else body
             run_id = data.get("run_id") if isinstance(data, dict) else None
             if run_id:
+                self._warn_on_unsubstituted_parameters(body, run_id)
                 return run_id
             raise AtlanApiResponseInvariantError(
                 message=f"AE submit returned no run_id\nresponse={body!r}",
@@ -1556,6 +1601,44 @@ class AEWorkflowClient:
             message=f"AE submit failed: HTTP {status}\nresponse={body!r}",
             target=f"POST /api/service/package-workflows?submit=true HTTP {status}",
             retry_after_seconds=_requested_retry_after(body),
+        )
+
+    def _warn_on_unsubstituted_parameters(
+        self, body: dict[str, Any], run_id: str
+    ) -> None:
+        """Log the parameters AE accepted but left as literal mustache tokens.
+
+        A 2xx submit with a run_id is currently the harness's only success
+        signal, so an AE that creates the run without resolving ``payload[]``
+        into the request's Argo parameters produces a run that cannot work and
+        a harness that does not know it. The extract activity then dies on the
+        literal (``[AAF-CRD-005] Invalid credential GUID — must match
+        [a-zA-Z0-9_-]+: '{{credentialGuid}}'``) one poll interval later, which
+        reads as a connector bug rather than a control-plane one.
+
+        Warn rather than raise, deliberately. AE's submit response shape is
+        undocumented (see this method's caller) and may legitimately echo the
+        request unmodified, which would make a hard assertion fail every
+        connector's green run. A warning is safe on every tenant and is enough
+        to attribute the fault; hardening this into an invariant is a follow-up
+        for once the logged shape is known. FND-402 / FND-656.
+        """
+        leftover = _unsubstituted_parameter_tokens(body)
+        if not leftover:
+            return
+        logger.warning(
+            "submit_workflow: AE accepted run %s but left %d parameter(s) as "
+            "unresolved mustache literals: %s. If 'credential-guid' is among "
+            "them the run WILL fail on the extract node with [AAF-CRD-005] "
+            "Invalid credential GUID — AE did not turn the submit's payload[] "
+            "credential block into a GUID. That is a tenant/AE control-plane "
+            "fault, not a connector defect; response keys=%s",
+            run_id,
+            len(leftover),
+            ", ".join(
+                f"{name} -> {{{{{token}}}}}" for name, token in sorted(leftover.items())
+            ),
+            sorted(body.keys()),
         )
 
     def get_native_status(self, run_id: str) -> DAGRunResult:

--- a/tests/unit/testing/e2e/test_unsubstituted_parameters.py
+++ b/tests/unit/testing/e2e/test_unsubstituted_parameters.py
@@ -1,0 +1,196 @@
+"""Unit tests for the unresolved-mustache detector on the AE submit path.
+
+The harness submits ``{{credentialGuid}}`` as a deliberate literal and relies
+on AE turning the request's ``payload[]`` credential block into a real GUID. If
+AE answers 2xx with a run_id but skips that substitution, nothing in the
+harness notices: the run is polled normally and the literal only surfaces a
+poll interval later as a worker-side ``[AAF-CRD-005] Invalid credential GUID``
+on the extract node, which reads as a connector defect rather than a
+control-plane one. These tests pin the detector that names it at submit time.
+
+See FND-402 / FND-656.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from application_sdk.testing.e2e.client import (
+    AEWorkflowClient,
+    _unsubstituted_parameter_tokens,
+)
+
+
+def _make_client() -> AEWorkflowClient:
+    return AEWorkflowClient(
+        tenant_url="https://tenant.example.com",
+        api_token="tok-test",
+    )
+
+
+def _submit_response(*parameters: dict) -> dict:
+    """An AE submit response echoing the Argo parameter block."""
+    return {
+        "data": {"run_id": "run-xyz"},
+        "spec": {
+            "templates": [
+                {
+                    "name": "main",
+                    "dag": {
+                        "tasks": [
+                            {
+                                "name": "run",
+                                "arguments": {"parameters": list(parameters)},
+                            }
+                        ]
+                    },
+                }
+            ]
+        },
+    }
+
+
+class TestUnsubstitutedParameterTokens:
+    def test_finds_unresolved_credential_guid(self):
+        found = _unsubstituted_parameter_tokens(
+            _submit_response({"name": "credential-guid", "value": "{{credentialGuid}}"})
+        )
+        assert found == {"credential-guid": "credentialGuid"}
+
+    def test_resolved_guid_is_not_reported(self):
+        found = _unsubstituted_parameter_tokens(
+            _submit_response(
+                {
+                    "name": "credential-guid",
+                    "value": "a1b2c3d4-dead-beef-0000-111122223333",
+                }
+            )
+        )
+        assert found == {}
+
+    def test_reports_every_unresolved_parameter(self):
+        found = _unsubstituted_parameter_tokens(
+            _submit_response(
+                {"name": "credential-guid", "value": "{{credentialGuid}}"},
+                {"name": "include-filter", "value": '{"^dev$": ["^public$"]}'},
+                {"name": "temp-table-regex", "value": "{{temp-table-regex}}"},
+            )
+        )
+        assert found == {
+            "credential-guid": "credentialGuid",
+            "temp-table-regex": "temp-table-regex",
+        }
+
+    def test_json_blob_value_is_not_a_false_positive(self):
+        """A value that merely contains braces is not failed substitution."""
+        found = _unsubstituted_parameter_tokens(
+            _submit_response(
+                # the redshift crawler's real include_filter shape
+                {
+                    "name": "include-filter",
+                    "value": '{"^dev$": ["^public$", "^workflows$"]}',
+                },
+                {"name": "connection", "value": '{"typeName": "Connection"}'},
+                {"name": "exclude-filter", "value": "{}"},
+            )
+        )
+        assert found == {}
+
+    def test_embedded_token_is_not_reported(self):
+        """Only a value that is EXACTLY one token counts as unresolved."""
+        found = _unsubstituted_parameter_tokens(
+            _submit_response(
+                {"name": "compiled-url", "value": "redshift://host/{{db}}?ssl=true"}
+            )
+        )
+        assert found == {}
+
+    def test_surrounding_whitespace_still_matches(self):
+        found = _unsubstituted_parameter_tokens(
+            _submit_response(
+                {"name": "credential-guid", "value": " {{credentialGuid}} "}
+            )
+        )
+        assert found == {"credential-guid": "credentialGuid"}
+
+    def test_tolerates_unexpected_shapes(self):
+        """The response shape is undocumented — the walker must never raise."""
+        for body in (
+            {},
+            {"data": None},
+            {"spec": []},
+            {"a": [1, "x", None, {"b": {}}]},
+        ):
+            assert _unsubstituted_parameter_tokens(body) == {}
+
+    def test_ignores_non_parameter_name_value_pairs(self):
+        """A name/value dict whose value is not a bare token is skipped."""
+        found = _unsubstituted_parameter_tokens(
+            {"name": "some-node", "value": {"nested": "dict"}}
+        )
+        assert found == {}
+
+
+class TestSubmitWarnsOnUnsubstituted:
+    def _payload(self) -> dict:
+        return {
+            "payload": [
+                {
+                    "parameter": "credentialGuid",
+                    "type": "credential",
+                    "body": {"name": "default-redshift-1234-1"},
+                }
+            ]
+        }
+
+    @staticmethod
+    def _rendered(warn_mock) -> str:
+        """The warning as it reaches the log, args interpolated."""
+        assert warn_mock.called, "expected a warning about unresolved parameters"
+        fmt, *args = warn_mock.call_args.args
+        return fmt % tuple(args)
+
+    def test_submit_warns_but_still_returns_run_id(self):
+        """The detector is diagnostic only — it must not change the outcome."""
+        client = _make_client()
+        resp = _submit_response(
+            {"name": "credential-guid", "value": "{{credentialGuid}}"}
+        )
+        with (
+            patch.object(client, "_request", return_value=(200, resp)),
+            patch("application_sdk.testing.e2e.client.logger") as log,
+        ):
+            run_id = client.submit_workflow(self._payload(), retries=0)
+        assert run_id == "run-xyz"
+        rendered = self._rendered(log.warning)
+        assert "AAF-CRD-005" in rendered
+        assert "credential-guid" in rendered
+        # names the fault's owner, so the reader does not chase the connector
+        assert "control-plane" in rendered
+
+    def test_no_warning_on_a_fully_resolved_submit(self):
+        client = _make_client()
+        resp = _submit_response(
+            {"name": "credential-guid", "value": "a1b2c3d4-dead-beef-0000-111122223333"}
+        )
+        with (
+            patch.object(client, "_request", return_value=(200, resp)),
+            patch("application_sdk.testing.e2e.client.logger") as log,
+        ):
+            run_id = client.submit_workflow(self._payload(), retries=0)
+        assert run_id == "run-xyz"
+        assert not log.warning.called
+
+    def test_warning_never_prints_parameter_values(self):
+        """Argo parameter values can carry source credentials — names only."""
+        client = _make_client()
+        resp = _submit_response(
+            {"name": "credential-guid", "value": "{{credentialGuid}}"},
+            {"name": "agent-json", "value": "s3cr3t-should-never-be-logged"},
+        )
+        with (
+            patch.object(client, "_request", return_value=(200, resp)),
+            patch("application_sdk.testing.e2e.client.logger") as log,
+        ):
+            client.submit_workflow(self._payload(), retries=0)
+        assert "s3cr3t-should-never-be-logged" not in self._rendered(log.warning)

--- a/tests/unit/testing/e2e/test_unsubstituted_parameters.py
+++ b/tests/unit/testing/e2e/test_unsubstituted_parameters.py
@@ -194,3 +194,39 @@ class TestSubmitWarnsOnUnsubstituted:
         ):
             client.submit_workflow(self._payload(), retries=0)
         assert "s3cr3t-should-never-be-logged" not in self._rendered(log.warning)
+
+    def test_logs_response_shape_even_when_nothing_is_unresolved(self):
+        """The shape is the unknown — it must be logged on EVERY accepted submit.
+
+        Regression guard: the first cut logged the shape only inside the
+        warning, so a real tenant whose submit response carries no parameter
+        block at all produced total silence and no way to learn why.
+        """
+        client = _make_client()
+        resp = _submit_response(
+            {"name": "credential-guid", "value": "a1b2c3d4-dead-beef-0000-111122223333"}
+        )
+        with (
+            patch.object(client, "_request", return_value=(200, resp)),
+            patch("application_sdk.testing.e2e.client.logger") as log,
+        ):
+            client.submit_workflow(self._payload(), retries=0)
+        assert not log.warning.called
+        fmt, *args = log.info.call_args.args
+        rendered = fmt % tuple(args)
+        assert "response keys=" in rendered
+        assert "'data'" in rendered and "'spec'" in rendered
+
+    def test_response_shape_log_never_prints_values(self):
+        client = _make_client()
+        resp = {"data": {"run_id": "run-xyz", "token": "s3cr3t-value"}}
+        with (
+            patch.object(client, "_request", return_value=(200, resp)),
+            patch("application_sdk.testing.e2e.client.logger") as log,
+        ):
+            client.submit_workflow(self._payload(), retries=0)
+        fmt, *args = log.info.call_args.args
+        rendered = fmt % tuple(args)
+        assert "s3cr3t-value" not in rendered
+        # the KEY is fine to name; only the value must not appear
+        assert "token" in rendered


### PR DESCRIPTION
## What

Make an AE submit that fails to resolve `{{credentialGuid}}` **self-reporting**, instead of surfacing two minutes later as a connector error.

Two things on every accepted submit:
1. Log the response shape (top-level + `data` keys) — unconditionally.
2. Warn if any Argo parameter came back as a literal mustache token, naming the parameters and pointing at the tenant/AE control plane.

## Why

`build_ae_payload` sends `{{credentialGuid}}` as a **deliberate** literal, paired with a `payload[]` block asking AE to create the credential and substitute the token. Both halves travel in one submit.

When AE skips that substitution it still answers `2xx` with a `run_id`. `submit_workflow` validates exactly one thing —

```python
run_id = data.get("run_id")
if run_id: return run_id
```

— so the harness polls a run that cannot work. The literal surfaces up to 60s later, on the worker:

```
[AAF-CRD-005] Invalid credential GUID — must match [a-zA-Z0-9_-]+: '{{credentialGuid}}'
```

A control-plane fault wearing a connector error's clothes. The success-path response body was never logged either (`_post_with_retry` logs bodies only on `warning`), so it couldn't be diagnosed after the fact.

The only existing credential-failure detector on this path is `_is_credential_name_conflict` — a substring match for `credentials_name_key` that fires solely on `status >= 400`, and whose own docstring warns it will "silently stop firing" if AE renames the constraint. A 2xx that failed to create the credential is invisible to it.

## How this was found

Triaging the redshift crawler e2e (FND-402, [atlan-redshift-app#382](https://github.com/atlanhq/atlan-redshift-app/pull/382)). aws has now failed **7/7 runs across 4 days** on `AAF-CRD-005`, while azure and gcp pass **4/6 each on the same commit, image and SDK** — green legs landing an identical Atlas inventory (1 Database / 2 Schema / 126 Table / 22 View / 1906 Column) and passing the qualifiedName-depth assertions. The suite is correct; the runs were spent proving the connector innocent because the one component that could see the real fault discarded the evidence.

## Validated against a real tenant — and the first cut was wrong

I pinned redshift's e2e to this branch ([run 32754174934](https://github.com/atlanhq/atlan-redshift-app/actions/runs/32754174934), SDK built from `55b9e04`) to check it actually fires. **It did not.** AE's submit response carries no Argo parameter block at all, so the scan had nothing to inspect and the check was inert.

That is why the shape logging is now unconditional. Logging it only from inside the warning was backwards: silence could mean "AE substituted fine" *or* "the detector cannot see anything", with no way to tell them apart. The next run now reports which is true, and where the parameters actually live — which is the input needed either to point the check at the right endpoint or to close this off as unreachable from the client.

Second commit carries that fix plus its regression test.

## Design notes

**Keys only, never values.** A submit response can carry a source credential and this feeds a log line, so both the shape log and the warning emit names only. Two tests pin it — one asserting a secret-shaped *value* never appears while its *key* still does.

**Warns, does not raise** — deliberately. AE's response shape is undocumented, so a hard assertion could red every connector's green run. A warning is safe on every tenant and still attributes the fault; hardening into an invariant is a follow-up once the logged shape is known.

**Exact-match only.** A value counts as unresolved only when it is *exactly* one token, so real brace-carrying values aren't false positives — redshift's `include_filter` `{"^dev$": ["^public$"]}`, `exclude_filter` `{}`, JSON connection blobs, an embedded `{{db}}` in a URL. Each has a test.

## Testing

- `tests/unit/testing/e2e/test_unsubstituted_parameters.py` — 13 tests: detection, the resolved-GUID negative, multi-parameter reporting, four false-positive shapes, malformed/undocumented bodies (must never raise), the unconditional-shape-log regression guard, and two no-values-in-logs guarantees.
- `tests/unit/testing/e2e/` → **419 passed**; `tests/unit/testing/` → **644 passed, 4 skipped**. No regressions.
- `ruff check` → 6 findings, all **pre-existing on `main`** (verified identical count against the unmodified baseline; `logging-exc-info` ×5 + one `quoted-annotation`, none in this diff). `ruff format` clean. No dependency or lockfile change.

No behaviour change on any currently-passing run: one `logger.info`, plus a `logger.warning` behind a detector that returns empty for a resolved submit.

## Note for reviewers

This does **not** fix the underlying tenant fault — it makes it visible. Tracking under FND-656; the redshift-side story is FND-402.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
