### PR TITLE
fix(e2e): chunk the teardown asset purge (FND-779)

### DIFF
--- a/application_sdk/testing/e2e/base.py
+++ b/application_sdk/testing/e2e/base.py
@@ -102,6 +102,15 @@ _PROGRESS_STALL_MIN_SECONDS = 300
 # DAG is frozen.
 _PROGRESS_STALL_MAX_SECONDS = 1800
 
+# Teardown purges assets in batches of this size. pyatlan's purge_by_guid puts
+# one ``guid=`` query param per asset into a single DELETE, and httpx refuses to
+# build a URL whose query exceeds MAX_URL_LENGTH (65536) — at ~42 bytes per GUID
+# that is a hard ceiling near 1,550 assets, raised client-side so *nothing* is
+# deleted. A crawl routinely produces more than that, so the list has to be
+# chunked. Kept well under the ceiling: purge is expensive server-side, and a
+# smaller batch means a single failing chunk orphans less.
+_PURGE_BATCH_SIZE = 50
+
 
 def _derive_progress_stall_seconds(timeout_seconds: int) -> int:
     """Progress-watchdog window to use when a suite pins no explicit value.
@@ -661,10 +670,58 @@ class BaseE2ETest:
         if not conn_qn:
             return
 
+        client = self._teardown_client()
+        if client is None:
+            return
+
+        # Two independently-guarded phases. Sharing one guard is what let a
+        # single child-purge failure orphan the connection as well: the raise
+        # jumped past the connection purge entirely, and the teardown warning
+        # is post-verdict, so the leg still went green while leaking everything.
+        self._purge_child_assets(client, conn_qn)
+        self._purge_connection(client, conn_qn)
+
+    @staticmethod
+    def _teardown_client() -> Any | None:
+        """Sync pyatlan client for teardown, or ``None`` when unavailable.
+
+        Returns:
+            An ``AtlanClient``, or ``None`` if the harness env isn't configured
+            (nothing to clean up) or the client couldn't be built.
+        """
+        tenant_url = os.environ.get("ATLAN_BASE_URL", "")
+        api_token = os.environ.get("ATLAN_API_KEY", "")
+        if not tenant_url or not api_token:
+            return None
         try:
             from pyatlan.client.atlan import (  # noqa: PLC0415; type: ignore[import]
                 AtlanClient,
             )
+
+            # conformance: ignore[P024] e2e harness asset lookup runs outside the async execution path; sync pyatlan is intentional
+            return AtlanClient(base_url=tenant_url, api_key=api_token)
+        except Exception:
+            logger.warning(
+                "e2e cleanup: could not build a tenant client — manual purge "
+                "may be needed",
+                exc_info=True,
+            )
+            return None
+
+    @staticmethod
+    def _purge_child_assets(client: Any, conn_qn: str) -> None:
+        """Purge every descendant of ``conn_qn`` in bounded batches.
+
+        Every GUID is collected *before* the first delete on purpose. pyatlan's
+        default search pagination is offset-based (``from``/``size``), so
+        purging between pages shifts the result window and silently skips
+        assets; a list of 36-char strings is cheap even at six figures.
+
+        Args:
+            client: Sync pyatlan client.
+            conn_qn: Qualified name of the connection being torn down.
+        """
+        try:
             from pyatlan.model.assets import (  # noqa: PLC0415; type: ignore[import]
                 Asset,
             )
@@ -672,35 +729,86 @@ class BaseE2ETest:
                 FluentSearch,
             )
 
-            tenant_url = os.environ.get("ATLAN_BASE_URL", "")
-            api_token = os.environ.get("ATLAN_API_KEY", "")
-            if not tenant_url or not api_token:
-                return
-
-            # conformance: ignore[P024] e2e harness asset lookup runs outside the async execution path; sync pyatlan is intentional
-            client = AtlanClient(base_url=tenant_url, api_key=api_token)
-
-            # Collect GUIDs for all descendant assets.
-            child_guids: list[str] = []
             child_request = (
                 FluentSearch()
                 .where(Asset.QUALIFIED_NAME.startswith(conn_qn + "/"))
                 .include_on_results(Asset.GUID)
             ).to_request()
             child_request.dsl.size = 200
-            for asset in client.asset.search(child_request):
-                if asset.guid:
-                    child_guids.append(asset.guid)
+            child_guids: list[str] = [
+                asset.guid for asset in client.asset.search(child_request) if asset.guid
+            ]
+        except Exception:
+            logger.warning(
+                "e2e cleanup: could not list child assets under %s — manual "
+                "purge may be needed",
+                conn_qn,
+                exc_info=True,
+            )
+            return
 
-            if child_guids:
-                client.asset.purge_by_guid(child_guids)
-                logger.info(
-                    "e2e cleanup: purged %d child assets under %s",
-                    len(child_guids),
-                    conn_qn,
+        if not child_guids:
+            return
+
+        # Batch failures are counted and reported once after the loop rather
+        # than logged per batch: a large crawl is hundreds of batches, and a
+        # tenant-wide outage would otherwise emit one warning per batch.
+        purged = 0
+        failed_batches = 0
+        last_error: Exception | None = None
+        for offset in range(0, len(child_guids), _PURGE_BATCH_SIZE):
+            batch = child_guids[offset : offset + _PURGE_BATCH_SIZE]
+            try:
+                client.asset.purge_by_guid(batch)
+            # conformance: ignore[E004] teardown boundary — a batch failure must never propagate and mask the test verdict; the aggregate is logged at WARNING with exc_info below
+            except Exception as exc:
+                # DEBUG per batch, WARNING for the summary below: a tenant-wide
+                # outage is hundreds of failing batches, and one line each would
+                # bury the count that actually says how much leaked.
+                logger.debug(
+                    "e2e cleanup: purge batch at offset %d failed",
+                    offset,
+                    exc_info=True,
                 )
+                failed_batches += 1
+                last_error = exc
+            else:
+                purged += len(batch)
 
-            # Purge the connection itself.
+        if last_error is not None:
+            logger.warning(
+                "e2e cleanup: purged %d of %d child assets under %s; %d batch(es) "
+                "of %d failed — manual purge may be needed",
+                purged,
+                len(child_guids),
+                conn_qn,
+                failed_batches,
+                _PURGE_BATCH_SIZE,
+                exc_info=last_error,
+            )
+        else:
+            logger.info(
+                "e2e cleanup: purged %d child assets under %s",
+                purged,
+                conn_qn,
+            )
+
+    @staticmethod
+    def _purge_connection(client: Any, conn_qn: str) -> None:
+        """Purge the connection asset itself.
+
+        Args:
+            client: Sync pyatlan client.
+            conn_qn: Qualified name of the connection being torn down.
+        """
+        try:
+            from pyatlan.model.assets import (  # noqa: PLC0415; type: ignore[import]
+                Asset,
+            )
+            from pyatlan.model.fluent_search import (  # noqa: PLC0415; type: ignore[import]
+                FluentSearch,
+            )
+
             conn_request = (
                 FluentSearch()
                 .where(Asset.QUALIFIED_NAME.eq(conn_qn))
@@ -713,7 +821,6 @@ class BaseE2ETest:
                     client.asset.purge_by_guid(asset.guid)
                     # conformance: ignore[L006] loop bounded to a single result via dsl.size=1; one purge event per connection
                     logger.info("e2e cleanup: purged connection %s", conn_qn)
-
         except Exception:
             logger.warning(
                 "e2e cleanup failed for connection %s — manual purge may be needed",

--- a/tests/unit/testing/e2e/test_base_e2e.py
+++ b/tests/unit/testing/e2e/test_base_e2e.py
@@ -1735,8 +1735,16 @@ class TestTeardownPurgeBatching:
         assert asset_client.purge_batches == [["conn-guid"]]
 
     def test_unconfigured_env_is_a_no_op(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """No tenant client means nothing to clean up — and nothing to raise."""
+        """No tenant creds means nothing to clean up — and nothing to raise.
+
+        The real ``_teardown_client`` runs here: stubbing it out would skip the
+        very env branch this covers, and building an AtlanClient against an
+        empty base URL is what would raise.
+        """
+        monkeypatch.delenv("ATLAN_BASE_URL", raising=False)
+        monkeypatch.delenv("ATLAN_API_KEY", raising=False)
+        assert BaseE2ETest._teardown_client() is None
+
         harness = _ConcreteE2ETest()
         harness.connection_qualified_name = "default/openapi/1787587123106596"
-        monkeypatch.setattr(BaseE2ETest, "_teardown_client", staticmethod(lambda: None))
         harness.teardown_method(method=None)  # should not raise

--- a/tests/unit/testing/e2e/test_base_e2e.py
+++ b/tests/unit/testing/e2e/test_base_e2e.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import urllib.error
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock
@@ -26,6 +27,7 @@ from application_sdk.testing.e2e._errors import (
     ProgressWatchdogUnreachableError,
 )
 from application_sdk.testing.e2e.base import (
+    _PURGE_BATCH_SIZE,
     BaseE2ETest,
     FullDAGOutcome,
     NodeDispatch,
@@ -1575,3 +1577,166 @@ class TestProgressStallDiagnostics:
         with pytest.raises(DAGProgressStalledError) as exc:
             harness.run_full_dag()
         assert exc.value is original
+
+
+# ---------------------------------------------------------------------------
+# teardown_method — batched purge (FND-779)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _StubAsset:
+    """Minimal stand-in for a pyatlan search hit."""
+
+    guid: str | None
+
+
+class _StubAssetClient:
+    """Records purge batches and replays canned search results.
+
+    ``search`` answers the child query first and the connection query second,
+    matching the order ``teardown_method`` issues them.
+    """
+
+    def __init__(
+        self,
+        children: list[_StubAsset],
+        connection: list[_StubAsset] | None = None,
+        failing_batches: frozenset[int] = frozenset(),
+        search_error: Exception | None = None,
+    ) -> None:
+        self._children = children
+        self._connection = (
+            connection if connection is not None else [_StubAsset("conn-guid")]
+        )
+        self._failing_batches = failing_batches
+        self._search_error = search_error
+        self.search_count = 0
+        self.purge_batches: list[list[str]] = []
+
+    def search(self, request: object) -> list[_StubAsset]:
+        self.search_count += 1
+        if self.search_count == 1:
+            if self._search_error is not None:
+                raise self._search_error
+            return self._children
+        return self._connection
+
+    def purge_by_guid(self, guid: str | list[str]) -> None:
+        batch = [guid] if isinstance(guid, str) else list(guid)
+        self.purge_batches.append(batch)
+        if len(self.purge_batches) in self._failing_batches:
+            raise RuntimeError("simulated purge failure")
+
+
+class _StubTenantClient:
+    def __init__(self, asset: _StubAssetClient) -> None:
+        self.asset = asset
+
+
+class TestTeardownPurgeBatching:
+    """A crawl's full GUID list must never go out as one oversized request.
+
+    pyatlan puts one ``guid=`` query param per asset into a single DELETE, and
+    httpx refuses to build a URL whose query exceeds 65536 bytes — raised
+    client-side, so an unbatched purge deletes nothing at all.
+    """
+
+    HTTPX_MAX_URL_LENGTH = 65536
+
+    def _harness(
+        self, monkeypatch: pytest.MonkeyPatch, asset_client: _StubAssetClient
+    ) -> _ConcreteE2ETest:
+        harness = _ConcreteE2ETest()
+        harness.connection_qualified_name = "default/openapi/1787587123106596"
+        monkeypatch.setattr(
+            BaseE2ETest,
+            "_teardown_client",
+            staticmethod(lambda: _StubTenantClient(asset_client)),
+        )
+        return harness
+
+    def test_large_child_set_is_purged_in_bounded_batches(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        children = [_StubAsset(f"guid-{i:04d}") for i in range(2000)]
+        asset_client = _StubAssetClient(children)
+        self._harness(monkeypatch, asset_client).teardown_method(method=None)
+
+        child_batches = asset_client.purge_batches[:-1]
+        assert len(child_batches) == 2000 // _PURGE_BATCH_SIZE
+        assert all(len(batch) <= _PURGE_BATCH_SIZE for batch in child_batches)
+        # Every GUID goes out exactly once — batching must not drop or duplicate.
+        assert [guid for batch in child_batches for guid in batch] == [
+            f"guid-{i:04d}" for i in range(2000)
+        ]
+
+    def test_a_full_batch_stays_under_the_httpx_url_cap(self) -> None:
+        """The batch size is what keeps the built URL constructible at all."""
+        guid_len = len("0004b475-1234-4abc-8def-0123456789ab")
+        query_len = len("deleteType=PURGE") + _PURGE_BATCH_SIZE * (
+            len("&guid=") + guid_len
+        )
+        assert query_len < self.HTTPX_MAX_URL_LENGTH
+
+    def test_ragged_final_batch_is_still_purged(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        children = [_StubAsset(f"guid-{i}") for i in range(_PURGE_BATCH_SIZE + 3)]
+        asset_client = _StubAssetClient(children)
+        self._harness(monkeypatch, asset_client).teardown_method(method=None)
+
+        child_batches = asset_client.purge_batches[:-1]
+        assert [len(batch) for batch in child_batches] == [_PURGE_BATCH_SIZE, 3]
+
+    def test_a_failing_batch_does_not_abort_the_remaining_batches(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        children = [_StubAsset(f"guid-{i}") for i in range(_PURGE_BATCH_SIZE * 3)]
+        asset_client = _StubAssetClient(children, failing_batches=frozenset({2}))
+        self._harness(monkeypatch, asset_client).teardown_method(method=None)
+
+        # 3 child batches attempted (the failing one included) + the connection.
+        assert len(asset_client.purge_batches) == 4
+
+    def test_child_purge_failure_still_purges_the_connection(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The regression: one guard for both phases orphaned the connection."""
+        children = [_StubAsset("guid-0")]
+        asset_client = _StubAssetClient(children, failing_batches=frozenset({1}))
+        self._harness(monkeypatch, asset_client).teardown_method(method=None)
+
+        assert asset_client.purge_batches[-1] == ["conn-guid"]
+
+    def test_child_search_failure_still_purges_the_connection(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        asset_client = _StubAssetClient([], search_error=RuntimeError("search down"))
+        self._harness(monkeypatch, asset_client).teardown_method(method=None)
+
+        assert asset_client.purge_batches == [["conn-guid"]]
+
+    def test_assets_without_a_guid_are_skipped(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        children = [_StubAsset("guid-0"), _StubAsset(None), _StubAsset("guid-1")]
+        asset_client = _StubAssetClient(children)
+        self._harness(monkeypatch, asset_client).teardown_method(method=None)
+
+        assert asset_client.purge_batches[0] == ["guid-0", "guid-1"]
+
+    def test_no_children_purges_only_the_connection(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        asset_client = _StubAssetClient([])
+        self._harness(monkeypatch, asset_client).teardown_method(method=None)
+
+        assert asset_client.purge_batches == [["conn-guid"]]
+
+    def test_unconfigured_env_is_a_no_op(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """No tenant client means nothing to clean up — and nothing to raise."""
+        harness = _ConcreteE2ETest()
+        harness.connection_qualified_name = "default/openapi/1787587123106596"
+        monkeypatch.setattr(BaseE2ETest, "_teardown_client", staticmethod(lambda: None))
+        harness.teardown_method(method=None)  # should not raise


### PR DESCRIPTION
## Problem

`BaseE2ETest.teardown_method` accumulated **every** descendant GUID across all search pages and passed the whole list to `client.asset.purge_by_guid()` in one call.

pyatlan does no chunking — `purge_by_guid` puts one `guid=` query param per asset into a single `DELETE /entity/bulk/guid`. httpx refuses to build a URL whose query exceeds `MAX_URL_LENGTH` (65536). At `&guid=` + 36 chars ≈ 42 bytes per GUID that is a hard ceiling near **1,550 assets**, and the `InvalidURL` is raised client-side — so nothing is deleted at all, not even partially:

```
[WARNING] application_sdk.testing.e2e.base - e2e cleanup failed for connection
          default/<connector>/<ts> — manual purge may be needed
httpx.InvalidURL: URL component 'query' too long
```

**The blast radius was wider than the child assets.** The child purge and the connection purge sat inside the same `try`, so the raise jumped straight to the outer `except` and the connection was orphaned too. Teardown failures log as a post-verdict WARNING, so no test went red — the leak was silent, and it accumulated across every leg (aws/gcp/azure) on the shared e2e tenants.

Observed on a Power BI e2e run and reported for several other connectors.

Not a test-correctness problem: connections are isolated by qualifiedName timestamp, so runs don't collide. It's junk piling up on shared tenants, which degrades tenant search over time.

## Fix

1. **Batch the purge** — `_PURGE_BATCH_SIZE = 50`, well under the URL ceiling. Purge is expensive server-side, and a smaller batch means a failing chunk orphans less.
2. **Split teardown into three independently-guarded phases** (`_teardown_client` / `_purge_child_assets` / `_purge_connection`), so a child-purge failure can no longer skip the connection purge.
3. **Collect all GUIDs before the first delete.** pyatlan's default `client.asset.search` pagination is offset-based (`from`/`size`), so purging between pages would shift the result window and silently skip assets. A list of 36-char strings is cheap even at six figures.
4. **Report batch failures once**, at WARNING after the loop (per-batch detail at DEBUG). A tenant-wide outage is hundreds of failing batches; one warning each would bury the count that actually says how much leaked.

## Testing

9 new tests in `tests/unit/testing/e2e/test_base_e2e.py::TestTeardownPurgeBatching`:

- 2,000 GUIDs → 40 batches, each within the cap, every GUID sent exactly once
- a full batch's built query length stays under httpx's 65536 cap
- ragged final batch is still purged
- a failing batch does not abort the remaining batches
- **regression:** a child-purge failure still purges the connection
- a child-*search* failure still purges the connection
- assets without a GUID are skipped; no children purges only the connection; unconfigured env is a no-op

Verified locally:
- `tests/unit/testing/e2e/` — 415 passed
- `pre-commit` on both files — clean
- `conformance detect --scope sdk` — no new unsuppressed findings

Closes FND-779.
