### PR TITLE
fix(conformance): tell a stale bounded-lock refusal from a broken build (FND-782)

### DIFF
--- a/.github/scripts/renovate_fleet_scan.py
+++ b/.github/scripts/renovate_fleet_scan.py
@@ -9,6 +9,10 @@ size. Output is written in the exact per-repo JSON file layout that
 packages/conformance/conformance/renovate/scan.py `_parse_pr` / `_auto_merge_stats` for
 the consuming schema this script must match.
 
+One follow-up query per PR is issued after the search, and only for PRs that are red
+with a uv.lock-only diff: it reads that lock so the classifier can distinguish a stale
+bounded-lock refusal from an ordinary broken build (FND-782). See fetch_lock_texts.
+
 Environment:
     GH_TOKEN   bearer token (GitHub App installation token or PAT) for api.github.com
 
@@ -39,6 +43,12 @@ PAGE_SIZE = 100
 # far beyond any realistic fleet. Trips only if a query is unexpectedly unbounded.
 MAX_PAGES = 50
 
+# Ceiling on the follow-up uv.lock blob fetches (see fetch_lock_texts). Each one
+# pulls a few hundred KB, so this is a cost guard, not a correctness bound — the
+# pre-filter it backs up should leave a handful of candidates fleet-wide, and
+# anything over the cap is reported rather than silently dropped.
+MAX_LOCK_FETCHES = 25
+
 _OPEN_PR_FIELDS = """
 number
 url
@@ -57,6 +67,7 @@ files(first: 100) { nodes { path } }
 commits(last: 1) {
   nodes {
     commit {
+      committedDate
       statusCheckRollup {
         contexts(first: 100) {
           nodes {
@@ -208,6 +219,108 @@ def _status_rollup_to_list(pr: dict) -> list[dict]:
     return out
 
 
+# Conclusions/states that make a check red. Mirrors
+# conformance.renovate.scan._CHECKS_FAILING — duplicated rather than imported
+# because .github/scripts/ runs on a bare interpreter with no conformance package
+# installed. Only used as a fetch pre-filter here; the authoritative reduction
+# still happens in the classifier.
+_FAILING_CHECK_STATES = frozenset(
+    {"FAILURE", "ERROR", "TIMED_OUT", "CANCELLED", "ACTION_REQUIRED"}
+)
+
+_LOCK_BLOB_QUERY = """
+query($owner: String!, $name: String!, $expression: String!) {
+  repository(owner: $owner, name: $name) {
+    object(expression: $expression) {
+      ... on Blob { text }
+    }
+  }
+}
+"""
+
+
+def _head_committed_at(pr: dict) -> str:
+    commits = (pr.get("commits") or {}).get("nodes") or []
+    if not commits:
+        return ""
+    return ((commits[0] or {}).get("commit") or {}).get("committedDate") or ""
+
+
+def _has_failing_check(pr: dict) -> bool:
+    return any(
+        (c.get("state") or c.get("conclusion") or c.get("status") or "").upper()
+        in _FAILING_CHECK_STATES
+        for c in _status_rollup_to_list(pr)
+    )
+
+
+def lock_refusal_candidate(pr: dict) -> Optional[str]:
+    """Path of the uv.lock worth fetching for this PR, or None.
+
+    The bounded-lock refusal signal (FND-782) needs the branch's lock *contents*,
+    which no PR search field carries. Fetching one blob per open Renovate PR would
+    move hundreds of MB across the fleet for a condition that should be rare, so
+    narrow it first to the only shape that can possibly be a refusal: a red PR
+    whose entire diff is a single uv.lock. Both facts are already in hand from the
+    search response, and both are conditions the classifier independently requires
+    anyway — this is a pre-filter, not a second copy of the classification.
+    """
+    if not _has_failing_check(pr):
+        return None
+    paths = [f["path"] for f in (pr.get("files") or {}).get("nodes") or []]
+    if len(paths) != 1 or paths[0].rsplit("/", 1)[-1] != "uv.lock":
+        return None
+    return paths[0]
+
+
+def fetch_lock_texts(token: str, prs: list[dict], post: PostFn = _post_graphql) -> int:
+    """Attach ``uvLockText`` to every PR that could be carrying a lock refusal.
+
+    Mutates the nodes in place and returns how many were fetched. A blob that
+    cannot be read (deleted branch, permissions, an unexpected object type) is
+    warned about and skipped: the PR then classifies exactly as it did before this
+    signal existed, which is the safe direction to fail.
+    """
+    candidates = [(pr, path) for pr in prs if (path := lock_refusal_candidate(pr))]
+    if len(candidates) > MAX_LOCK_FETCHES:
+        skipped = [pr["url"] for pr, _ in candidates[MAX_LOCK_FETCHES:]]
+        print(
+            f"Warning: {len(candidates)} lock-refusal candidates exceeds the "
+            f"{MAX_LOCK_FETCHES}-fetch cap; not inspecting the lock for: "
+            f"{', '.join(skipped)}",
+            file=sys.stderr,
+        )
+        candidates = candidates[:MAX_LOCK_FETCHES]
+
+    fetched = 0
+    for pr, path in candidates:
+        owner, _, name = pr["repository"]["nameWithOwner"].partition("/")
+        payload = {
+            "query": _LOCK_BLOB_QUERY,
+            "variables": {
+                "owner": owner,
+                "name": name,
+                "expression": f"{pr.get('headRefName') or ''}:{path}",
+            },
+        }
+        try:
+            data = post(token, payload)
+            if "errors" in data:
+                raise RuntimeError(str(data["errors"]))
+            obj = ((data["data"] or {}).get("repository") or {}).get("object") or {}
+            text = obj.get("text")
+        except (RuntimeError, KeyError, TypeError) as exc:
+            print(
+                f"Warning: could not read {path} on {pr['url']}: {exc}",
+                file=sys.stderr,
+            )
+            continue
+        if text:
+            pr["uvLockText"] = text
+            fetched += 1
+    return fetched
+
+
 def normalize_open_pr(pr: dict) -> dict:
     """Map a GraphQL PullRequest node to the `gh pr list --json ...` shape renovate-scan expects."""
     return {
@@ -230,6 +343,12 @@ def normalize_open_pr(pr: dict) -> dict:
         "updatedAt": pr["updatedAt"],
         "isDraft": bool(pr.get("isDraft") or False),
         "body": pr.get("body") or "",
+        # Beyond the `gh pr list --json` schema, both read by
+        # conformance.renovate.scan._parse_pr and both optional there: the branch
+        # head's commit date (the clock a bounded-lock refusal expires against) and
+        # the head uv.lock, present only for the few PRs fetch_lock_texts picked.
+        "headCommittedAt": _head_committed_at(pr),
+        "uvLockText": pr.get("uvLockText") or "",
     }
 
 
@@ -292,6 +411,15 @@ def run(
         _MERGED_PR_FIELDS,
         post,
     )
+
+    # Second pass, deliberately narrow: only the red uv.lock-only PRs, and only
+    # then, get their lock contents pulled so the classifier can tell a stale
+    # bounded-lock refusal from an ordinary broken build (FND-782).
+    fetched = fetch_lock_texts(token, open_nodes, post)
+    if fetched:
+        print(
+            f"Fetched uv.lock for {fetched} lock-refusal candidate(s)", file=sys.stderr
+        )
 
     open_grouped = group_by_repo(open_nodes, normalize_open_pr)
     merged_grouped = group_by_repo(merged_nodes, normalize_merged_pr)

--- a/.github/scripts/renovate_fleet_scan.py
+++ b/.github/scripts/renovate_fleet_scan.py
@@ -153,6 +153,15 @@ def _post_graphql(token: str, payload: dict) -> dict:
         raise RuntimeError(
             f"GraphQL request failed: {exc.code} {exc.reason}: {body}"
         ) from exc
+    # Every transport failure leaves here as a RuntimeError, so a caller that
+    # wants to degrade on one — fetch_lock_texts skips the PR and lets it
+    # classify as an ordinary red build — can express that with one handler.
+    # HTTPError is a URLError subclass, hence the ordering; urlopen raises
+    # TimeoutError directly rather than wrapping it, hence both.
+    except (urllib.error.URLError, TimeoutError) as exc:
+        raise RuntimeError(f"GraphQL request failed: {exc}") from exc
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"GraphQL response was not JSON: {exc}") from exc
 
 
 def fetch_all_prs(
@@ -277,9 +286,13 @@ def fetch_lock_texts(token: str, prs: list[dict], post: PostFn = _post_graphql) 
     """Attach ``uvLockText`` to every PR that could be carrying a lock refusal.
 
     Mutates the nodes in place and returns how many were fetched. A blob that
-    cannot be read (deleted branch, permissions, an unexpected object type) is
-    warned about and skipped: the PR then classifies exactly as it did before this
-    signal existed, which is the safe direction to fail.
+    cannot be read — deleted branch, permissions, an unexpected object type, or a
+    timed-out request — is warned about and skipped: the PR then classifies
+    exactly as it did before this signal existed, which is the safe direction to
+    fail. This pass is an enrichment, so one flaky fetch must never abort the
+    whole dashboard update; ``_post_graphql`` normalises transport failures to
+    ``RuntimeError`` precisely so that is one handler rather than a list that
+    quietly falls behind ``urllib``.
     """
     candidates = [(pr, path) for pr in prs if (path := lock_refusal_candidate(pr))]
     if len(candidates) > MAX_LOCK_FETCHES:

--- a/.github/scripts/tests/test_renovate_fleet_scan.py
+++ b/.github/scripts/tests/test_renovate_fleet_scan.py
@@ -543,3 +543,45 @@ def test_open_pr_fields_request_the_head_commit_date():
     # The clock the refusal signal expires against rides on a selection the query
     # already makes; a rename upstream would silently disable the signal.
     assert "committedDate" in rfs._OPEN_PR_FIELDS
+
+
+def test_post_graphql_wraps_transport_errors_as_runtime_error(monkeypatch):
+    # urlopen raises URLError for DNS/connect failures. Left unwrapped it escapes
+    # fetch_lock_texts' handler and one flaky blob fetch aborts the whole
+    # dashboard update before any repo file is written.
+    def boom(req, timeout=None):
+        raise rfs.urllib.error.URLError("name resolution failed")
+
+    monkeypatch.setattr(rfs.urllib.request, "urlopen", boom)
+    try:
+        rfs._post_graphql("tok", {"query": "{}"})
+        assert False, "expected RuntimeError"
+    except RuntimeError as exc:
+        assert "name resolution failed" in str(exc)
+
+
+def test_post_graphql_wraps_timeouts_as_runtime_error(monkeypatch):
+    # urlopen raises TimeoutError directly rather than wrapping it in URLError,
+    # so it needs naming separately.
+    def boom(req, timeout=None):
+        raise TimeoutError("timed out")
+
+    monkeypatch.setattr(rfs.urllib.request, "urlopen", boom)
+    try:
+        rfs._post_graphql("tok", {"query": "{}"})
+        assert False, "expected RuntimeError"
+    except RuntimeError as exc:
+        assert "timed out" in str(exc)
+
+
+def test_fetch_lock_texts_survives_a_transport_failure(capsys):
+    # The whole point of the wrap: an enrichment pass degrades to "no signal for
+    # this PR", never to a dashboard that skipped every repo.
+    prs = [_candidate()]
+
+    def flaky_post(token, payload):
+        raise RuntimeError("GraphQL request failed: <urlopen error timed out>")
+
+    assert rfs.fetch_lock_texts("tok", prs, flaky_post) == 0
+    assert "uvLockText" not in prs[0]
+    assert "could not read uv.lock" in capsys.readouterr().err

--- a/.github/scripts/tests/test_renovate_fleet_scan.py
+++ b/.github/scripts/tests/test_renovate_fleet_scan.py
@@ -218,7 +218,16 @@ def test_normalize_open_pr_full_shape():
         "updatedAt": "2026-06-02T00:00:00Z",
         "isDraft": False,
         "body": "bumps foo",
-        "commits": {"nodes": [{"commit": {"statusCheckRollup": None}}]},
+        "commits": {
+            "nodes": [
+                {
+                    "commit": {
+                        "committedDate": "2026-06-02T00:00:00Z",
+                        "statusCheckRollup": None,
+                    }
+                }
+            ]
+        },
     }
     out = rfs.normalize_open_pr(pr)
     assert out == {
@@ -236,6 +245,8 @@ def test_normalize_open_pr_full_shape():
         "updatedAt": "2026-06-02T00:00:00Z",
         "isDraft": False,
         "body": "bumps foo",
+        "headCommittedAt": "2026-06-02T00:00:00Z",
+        "uvLockText": "",
     }
 
 
@@ -268,6 +279,8 @@ def test_normalize_open_pr_defaults_for_missing_optional_fields():
         "body",
         "statusCheckRollup",
         "autoMergeEnabled",
+        "headCommittedAt",
+        "uvLockText",
     ):
         assert out[key] is not None
 
@@ -393,3 +406,140 @@ def test_run_writes_open_and_merged_files(tmp_path):
     assert json.loads((open_dir / "atlanhq_b.json").read_text()) == []
     assert json.loads((merged_dir / "atlanhq_a.json").read_text()) == [{"reviews": []}]
     assert json.loads((merged_dir / "atlanhq_b.json").read_text()) == []
+
+
+# ---------------------------------------------------------------------------
+# Lock-refusal candidate pre-filter + blob fetch (FND-782)
+# ---------------------------------------------------------------------------
+
+
+def _candidate(
+    *,
+    conclusion="FAILURE",
+    paths=("uv.lock",),
+    url="https://github.com/atlanhq/atlan-mysql-app/pull/7",
+    branch="renovate/lock-file-maintenance",
+):
+    return {
+        "url": url,
+        "headRefName": branch,
+        "repository": {"nameWithOwner": "atlanhq/atlan-mysql-app"},
+        "files": {"nodes": [{"path": p} for p in paths]},
+        "commits": {
+            "nodes": [
+                {
+                    "commit": {
+                        "committedDate": "2026-08-20T00:00:00Z",
+                        "statusCheckRollup": {
+                            "contexts": {
+                                "nodes": [
+                                    {
+                                        "__typename": "CheckRun",
+                                        "conclusion": conclusion,
+                                        "status": "COMPLETED",
+                                    }
+                                ]
+                            }
+                        },
+                    }
+                }
+            ]
+        },
+    }
+
+
+def test_head_committed_at_read_from_last_commit():
+    assert rfs._head_committed_at(_candidate()) == "2026-08-20T00:00:00Z"
+
+
+def test_head_committed_at_empty_when_no_commits():
+    assert rfs._head_committed_at({"commits": {"nodes": []}}) == ""
+
+
+def test_lock_refusal_candidate_matches_red_lock_only_pr():
+    assert rfs.lock_refusal_candidate(_candidate()) == "uv.lock"
+
+
+def test_lock_refusal_candidate_matches_a_nested_lock():
+    assert rfs.lock_refusal_candidate(_candidate(paths=("apps/api/uv.lock",))) == (
+        "apps/api/uv.lock"
+    )
+
+
+def test_lock_refusal_candidate_skips_green_prs():
+    # The overwhelming majority of lock PRs. Fetching their locks would be the
+    # whole cost of this feature for none of the signal.
+    assert rfs.lock_refusal_candidate(_candidate(conclusion="SUCCESS")) is None
+
+
+def test_lock_refusal_candidate_skips_multi_file_diffs():
+    assert (
+        rfs.lock_refusal_candidate(_candidate(paths=("uv.lock", "pyproject.toml")))
+        is None
+    )
+
+
+def test_lock_refusal_candidate_skips_non_lock_diffs():
+    assert rfs.lock_refusal_candidate(_candidate(paths=("package-lock.json",))) is None
+
+
+def test_fetch_lock_texts_attaches_only_to_candidates():
+    prs = [_candidate(), _candidate(conclusion="SUCCESS", url="https://x/2")]
+    calls = []
+
+    def fake_post(token, payload):
+        calls.append(payload["variables"])
+        return {"data": {"repository": {"object": {"text": "[options]\n"}}}}
+
+    assert rfs.fetch_lock_texts("tok", prs, fake_post) == 1
+    assert calls == [
+        {
+            "owner": "atlanhq",
+            "name": "atlan-mysql-app",
+            "expression": "renovate/lock-file-maintenance:uv.lock",
+        }
+    ]
+    assert prs[0]["uvLockText"] == "[options]\n"
+    assert "uvLockText" not in prs[1]
+
+
+def test_fetch_lock_texts_survives_an_unreadable_blob(capsys):
+    # Deleted branch / permissions / an unexpected object type. The PR then
+    # classifies exactly as it did before this signal existed.
+    prs = [_candidate()]
+
+    def fake_post(token, payload):
+        return {"errors": [{"message": "Could not resolve to a Repository"}]}
+
+    assert rfs.fetch_lock_texts("tok", prs, fake_post) == 0
+    assert "uvLockText" not in prs[0]
+    assert "could not read uv.lock" in capsys.readouterr().err
+
+
+def test_fetch_lock_texts_skips_a_null_object():
+    prs = [_candidate()]
+
+    def fake_post(token, payload):
+        return {"data": {"repository": {"object": None}}}
+
+    assert rfs.fetch_lock_texts("tok", prs, fake_post) == 0
+    assert "uvLockText" not in prs[0]
+
+
+def test_fetch_lock_texts_caps_fetches_and_reports_what_it_skipped(monkeypatch, capsys):
+    monkeypatch.setattr(rfs, "MAX_LOCK_FETCHES", 2)
+    prs = [_candidate(url=f"https://x/{i}") for i in range(4)]
+
+    def fake_post(token, payload):
+        return {"data": {"repository": {"object": {"text": "x"}}}}
+
+    assert rfs.fetch_lock_texts("tok", prs, fake_post) == 2
+    err = capsys.readouterr().err
+    # No silent truncation: the ones that were dropped are named.
+    assert "https://x/2" in err and "https://x/3" in err
+
+
+def test_open_pr_fields_request_the_head_commit_date():
+    # The clock the refusal signal expires against rides on a selection the query
+    # already makes; a rename upstream would silently disable the signal.
+    assert "committedDate" in rfs._OPEN_PR_FIELDS

--- a/docs/standards/ci.md
+++ b/docs/standards/ci.md
@@ -251,6 +251,28 @@ Dockerfiles. That is what reddened `scan / Build Image` fleet-wide in #3212. The
 bounded driver strips the block; if you add another lock-writing command, check
 what it records.
 
+### A refused lock refresh is red on purpose, and nothing re-evaluates it
+
+`withhold()` in `renovate_uv_lock_bounded.py` refuses by writing the baseline
+versions plus a bare `[options]` table — the one lever the driver holds over a
+*required* check, since `uv sync --locked` then rejects the lock and
+`scan / Build Image` holds the branch. Two consequences follow, and both bite:
+
+**Nothing expires it.** The branch is not behind its base, so Renovate reuses it
+without re-running `postUpgradeTasks`, and the marker committed into `uv.lock`
+carries no clock. Observed 2026-08-24: five fleet lock PRs sat frozen for two to
+four days after the window that blocked them had opened. Recovery is to delete
+the branch and let the next pass rebuild it — `recreateClosed: true` in the shared
+preset is what makes that safe.
+
+**The fleet dashboard names it.** `conformance.renovate.classify` splits that
+shape out of `checks_failing` as `bounded_lock_refusal_expired` (FND-782) once
+four things hold: the PR is lock-maintenance, its diff is a `uv.lock` and nothing
+else, that lock carries a lone `exclude-newer-span` (uv's own `[options]` always
+records the absolute `exclude-newer` beside it, so a lone span is the driver's
+signature), and the branch head is at least as old as the window it names. It
+reports; it does not self-heal. A recurrence is meant to be visible, not absorbed.
+
 ## The release-age bound on application-sdk's own lock refresh
 
 `postUpgradeTasks` reaches every repo in the fleet except the one that publishes

--- a/packages/conformance/conformance/renovate/classify.py
+++ b/packages/conformance/conformance/renovate/classify.py
@@ -192,8 +192,14 @@ def bounded_lock_refusal_expired(
         # ordinary red-build reason rather than guessing from created_at, which
         # Renovate's in-place branch rewrites make unrelated to the refusal.
         return False
+    # Both sides get the same naive->UTC coercion classify() applies to
+    # created_at. Normalising only one of them makes a naive clock a TypeError on
+    # subtraction rather than a wrong-by-an-offset answer, which is a worse
+    # failure for a caller passing its own `now` in a test.
     if head.tzinfo is None:
         head = head.replace(tzinfo=timezone.utc)
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=timezone.utc)
     return now - head >= window
 
 

--- a/packages/conformance/conformance/renovate/classify.py
+++ b/packages/conformance/conformance/renovate/classify.py
@@ -23,6 +23,8 @@ Blocking-reason mirrors renovate-auto-approve-reusable.yml conditions:
 from __future__ import annotations
 
 import re
+from datetime import datetime, timedelta, timezone
+from typing import Optional
 
 from conformance.renovate.models import (
     BlockingReason,
@@ -72,8 +74,127 @@ _DEP_FILE_RE = re.compile(
 STALE_AFTER_DAYS = 1
 
 
+# ISO 8601 duration subset accepted for the tripwire window, mirroring
+# renovate_uv_lock_bounded.parse_window — that is the only writer, so anything it
+# cannot emit is not a window we should be interpreting. Calendar units are
+# rejected rather than approximated.
+_WINDOW_RE = re.compile(r"^P(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?)?$")
+
+
 def _non_dep_files(files: list[str]) -> list[str]:
     return [f for f in files if not _DEP_FILE_RE.match(f)]
+
+
+def parse_window(window: str) -> Optional[timedelta]:
+    """``P3D`` / ``PT12H`` -> timedelta; ``None`` for anything unrecognised."""
+    match = _WINDOW_RE.match(window.strip())
+    if not match or not any(match.groups()):
+        return None
+    days, hours, minutes = (int(g) if g else 0 for g in match.groups())
+    return timedelta(days=days, hours=hours, minutes=minutes)
+
+
+def lock_refusal_window(lock_text: str) -> str:
+    """The release-age window named by a bounded-lock *refusal* tripwire, or "".
+
+    ``withhold()`` in ``.github/scripts/renovate_uv_lock_bounded.py`` refuses a
+    lock refresh by writing the baseline versions plus a bare ``[options]`` table::
+
+        [options]
+        exclude-newer-span = "P3D"
+
+    That table is the refusal's only durable trace — nothing else on the PR
+    records it — and it is precisely what ``uv sync --locked`` rejects, which is
+    how a required check ends up red by design.
+
+    Distinguishing it from an ``[options]`` table uv wrote itself matters, because
+    four repos declare their own ``[tool.uv] exclude-newer`` and legitimately carry
+    one on every branch *and* on base. uv always records the absolute
+    ``exclude-newer`` key alongside the span (and an
+    ``[options.exclude-newer-package]`` subtable when per-package ceilings apply);
+    the tripwire writes the span alone. So a lone span is the driver's signature,
+    and reading only the head lock is enough — no second fetch of base to prove the
+    table was *added*.
+
+    Line-based rather than a ``tomllib`` round-trip for the same reason
+    ``strip_options`` is: the caller holds several hundred KB of lockfile per PR
+    and needs six lines of it.
+    """
+    span = ""
+    in_options = False
+    for raw in lock_text.splitlines():
+        line = raw.strip()
+        if line.startswith("[options."):
+            # uv's own per-package ceiling subtable. Never written by withhold().
+            return ""
+        if line.startswith("[options]"):
+            in_options = True
+            continue
+        if not in_options:
+            continue
+        if line.startswith("["):
+            in_options = False
+            continue
+        if not line or line.startswith("#"):
+            continue
+        key, _, value = line.partition("=")
+        if key.strip() == "exclude-newer":
+            # uv wrote this table, not the driver.
+            return ""
+        if key.strip() == "exclude-newer-span":
+            span = value.split("#")[0].strip().strip("\"'")
+    return span
+
+
+def _is_uv_lock_only(files: list[str]) -> bool:
+    """Exactly one changed file, and it is a ``uv.lock`` (at any depth)."""
+    return len(files) == 1 and files[0].rsplit("/", 1)[-1] == "uv.lock"
+
+
+def bounded_lock_refusal_expired(
+    pr: RenovatePR, category: Category, now: datetime
+) -> bool:
+    """Is this red PR a bounded-lock refusal whose window has already elapsed?
+
+    Four conditions, all machine-checkable and none heuristic:
+
+    1. it is a lock-maintenance PR,
+    2. the diff is a ``uv.lock`` and nothing else,
+    3. that lock carries the driver's refusal tripwire (see
+       :func:`lock_refusal_window`), and
+    4. the branch head is at least as old as the window the tripwire names.
+
+    (4) is what makes the refusal *expired* rather than merely present. A refusal
+    written at ``T`` was caused by content published inside ``(T - W, T]``; by
+    ``T + W`` every one of those releases is at least ``W`` old, so the same
+    resolve would now be admitted. ``head_committed_at`` is the right clock and
+    ``created_at`` is not: Renovate rewrites a lock branch in place, so a PR opened
+    a week ago may carry a refusal written an hour ago.
+
+    What this deliberately does not claim is *which* refusal path wrote the
+    tripwire — ``withhold()`` is also called for an unsatisfiable floor and for the
+    rollback gate, and those do not expire with the clock. The signal is honest
+    about that: it says the tripwire is on and the window it names has elapsed,
+    which is already strictly more than ``checks_failing`` conveys, and the first
+    triage step (look at the branch; delete it to force a fresh resolve) is the
+    same either way.
+    """
+    if category is not Category.LOCK_MAINTENANCE:
+        return False
+    if not _is_uv_lock_only(pr.files):
+        return False
+    window = parse_window(pr.lock_refusal_window)
+    if window is None:
+        return False
+    head = pr.head_committed_at
+    if head is None:
+        # No clock for the branch head — the input predates the field. Report the
+        # ordinary red-build reason rather than guessing from created_at, which
+        # Renovate's in-place branch rewrites make unrelated to the refusal.
+        return False
+    if head.tzinfo is None:
+        head = head.replace(tzinfo=timezone.utc)
+    return now - head >= window
 
 
 def categorize(pr: RenovatePR) -> Category:
@@ -257,17 +378,20 @@ def blocking_reason(
     category: Category,
     update_type: UpdateType,
     age_days: int = 0,
+    now: Optional[datetime] = None,
 ) -> BlockingReason:
     """
     Why has this open PR not merged?
 
     Mirrors the conditions in renovate-auto-approve-reusable.yml, then adds two
     signals for the silent-stuck case a green/approved/mergeable PR can fall into
-    when GitHub-native auto-merge is never armed (see PR #2828 postmortem).
+    when GitHub-native auto-merge is never armed (see PR #2828 postmortem), plus
+    one sub-case of a red build that no human owns (FND-782).
 
-    ``age_days`` is threaded in explicitly rather than read off ``pr`` because
-    classify() computes it after the model is first constructed.
+    ``age_days`` and ``now`` are threaded in explicitly rather than read off ``pr``
+    because classify() computes them after the model is first constructed.
     """
+    now = now or datetime.now(timezone.utc)
     if not auto_merge_expected(category, update_type):
         return BlockingReason.AWAITING_HUMAN_REVIEW
 
@@ -279,6 +403,12 @@ def blocking_reason(
         return BlockingReason.NON_DEP_FILES
 
     if pr.checks_state == ChecksState.FAILING:
+        # Red is ordinarily a human's problem and age adds nothing to it. One
+        # shape is different: a bounded-lock refusal is red by design and nothing
+        # will ever re-evaluate it, so once its window has elapsed it is frozen
+        # rather than broken. Separate it out so the dashboard can say which.
+        if bounded_lock_refusal_expired(pr, category, now):
+            return BlockingReason.BOUNDED_LOCK_REFUSAL_EXPIRED
         return BlockingReason.CHECKS_FAILING
     if pr.checks_state == ChecksState.PENDING:
         return BlockingReason.CHECKS_PENDING
@@ -316,8 +446,6 @@ def classify(pr: RenovatePR) -> RenovatePR:
     Return a new RenovatePR with category, update_type, auto_merge_expected,
     blocking_reason, and age_days populated.
     """
-    from datetime import datetime, timezone
-
     cat = categorize(pr)
     ut = derive_update_type(pr)
     ame = auto_merge_expected(cat, ut)
@@ -326,13 +454,11 @@ def classify(pr: RenovatePR) -> RenovatePR:
     # pr.created_at may be tz-aware or naive; normalise.
     created = pr.created_at
     if created.tzinfo is None:
-        from datetime import timezone as _tz
-
-        created = created.replace(tzinfo=_tz.utc)
+        created = created.replace(tzinfo=timezone.utc)
     age = max(0, (now - created).days)
 
     # age feeds the staleness backstop, so it must be computed before classifying.
-    br = blocking_reason(pr, cat, ut, age)
+    br = blocking_reason(pr, cat, ut, age, now)
 
     # dataclass is frozen=True; use replace pattern.
     import dataclasses

--- a/packages/conformance/conformance/renovate/models.py
+++ b/packages/conformance/conformance/renovate/models.py
@@ -39,6 +39,19 @@ class BlockingReason(str, Enum):
     )
     CHECKS_FAILING = "checks_failing"  # required CI checks red
     CHECKS_PENDING = "checks_pending"  # required CI checks still running
+    BOUNDED_LOCK_REFUSAL_EXPIRED = (
+        # A sub-case of CHECKS_FAILING, not an ordinary broken build. The
+        # release-age driver refused this lock refresh and left a deliberately
+        # un-installable uv.lock behind so a required check would hold the branch
+        # (see withhold() in .github/scripts/renovate_uv_lock_bounded.py) — but the
+        # window it named has since elapsed, so the thing that blocked it no longer
+        # would. Nothing re-evaluates it on its own: the branch is not behind base,
+        # so Renovate reuses it without re-running postUpgradeTasks, and the marker
+        # committed into uv.lock carries no clock. Recovery is to delete the branch
+        # and let the next Renovate pass rebuild it (recreateClosed: true in the
+        # shared preset makes that safe). FND-782; mechanism in FND-695.
+        "bounded_lock_refusal_expired"
+    )
     MERGE_CONFLICT = "merge_conflict"  # mergeable=CONFLICTING
     NON_DEP_FILES = "non_dep_files"  # changed files outside auto-approve allowlist
     AUTOMERGE_NOT_ARMED = (
@@ -107,6 +120,16 @@ class RenovatePR:
     # Defaulted so pre-existing RenovatePR constructions stay valid; scan._parse_pr
     # populates it from the fetched field.
     auto_merge_enabled: bool = False
+    # Raw: committedDate of the branch head. The clock the bounded-lock refusal
+    # signal expires against — created_at is wrong for it, because Renovate
+    # rewrites a lock branch in place across many pushes without reopening the PR.
+    # None when the input predates the field (a hand-rolled `gh pr list` dump, or a
+    # stored scan from before FND-782); the refusal signal then simply does not fire.
+    head_committed_at: Optional[datetime] = None
+    # Raw: the release-age window named by the tripwire `[options]` table in this
+    # branch's uv.lock ("P3D"), or "" when the lock has no tripwire. Parsed out by
+    # scan._parse_pr so the multi-hundred-KB lock text itself is never retained.
+    lock_refusal_window: str = ""
     # populated by classify()
     category: Category = Category.UNKNOWN
     update_type: UpdateType = UpdateType.UNKNOWN

--- a/packages/conformance/conformance/renovate/scan.py
+++ b/packages/conformance/conformance/renovate/scan.py
@@ -21,7 +21,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
-from conformance.renovate.classify import classify
+from conformance.renovate.classify import classify, lock_refusal_window
 from conformance.renovate.models import (
     AutoMergeStats,
     BlockingReason,
@@ -86,8 +86,32 @@ def _parse_checks_state(rollup: list[dict]) -> ChecksState:
     return ChecksState.GREEN
 
 
+def _parse_head_committed_at(raw: dict) -> Optional[datetime]:
+    """``headCommittedAt`` if the producer supplied one, else None.
+
+    Not a `gh pr list --json` field: renovate_fleet_scan.py augments each record
+    with it (the branch head's committedDate, one extra GraphQL selection on a
+    query it already runs). Absent input is not an error — it only means the
+    bounded-lock refusal signal has no clock to expire against.
+    """
+    value = raw.get("headCommittedAt")
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
 def _parse_pr(raw: dict) -> Optional[RenovatePR]:
-    """Parse a single item from `gh pr list --json` output."""
+    """Parse a single item from `gh pr list --json` output.
+
+    Two fields beyond that schema are read when present, both supplied by
+    renovate_fleet_scan.py: ``headCommittedAt`` and ``uvLockText`` (the branch
+    head's uv.lock, fetched only for the handful of PRs that could be carrying a
+    bounded-lock refusal). The text is reduced to its window here and dropped —
+    the model never holds the lockfile.
+    """
     try:
         created = datetime.fromisoformat(raw["createdAt"].replace("Z", "+00:00"))
         updated = datetime.fromisoformat(raw["updatedAt"].replace("Z", "+00:00"))
@@ -109,6 +133,8 @@ def _parse_pr(raw: dict) -> Optional[RenovatePR]:
             is_draft=raw.get("isDraft", False),
             body=raw.get("body") or "",
             auto_merge_enabled=bool(raw.get("autoMergeEnabled") or False),
+            head_committed_at=_parse_head_committed_at(raw),
+            lock_refusal_window=lock_refusal_window(raw.get("uvLockText") or ""),
         )
     except (KeyError, ValueError) as exc:
         print(f"Warning: skipping malformed PR record: {exc}", file=sys.stderr)
@@ -210,6 +236,14 @@ def _pr_to_dict(pr: RenovatePR) -> dict:
         "ageDays": pr.age_days,
         "createdAt": pr.created_at.isoformat(),
         "updatedAt": pr.updated_at.isoformat(),
+        # Bounded-lock refusal evidence, so a blockingReason of
+        # bounded_lock_refusal_expired can be rendered with the window it named
+        # and how long the branch has actually been frozen. Both null/empty on
+        # every PR that carries no tripwire, which is nearly all of them.
+        "headCommittedAt": pr.head_committed_at.isoformat()
+        if pr.head_committed_at
+        else None,
+        "lockRefusalWindow": pr.lock_refusal_window,
         # Which packages this PR delivers (parsed from body table / title) —
         # lets the fleet-freshness dashboard join "repo behind on tool X" to
         # the exact PR that fixes it. Empty for lock-maintenance PRs.

--- a/packages/conformance/tests/test_renovate_classify.py
+++ b/packages/conformance/tests/test_renovate_classify.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from datetime import datetime, timedelta, timezone
 
 from conformance.renovate.classify import STALE_AFTER_DAYS, classify
+from conformance.renovate.classify import lock_refusal_window as extract_refusal_window
+from conformance.renovate.classify import parse_window
 from conformance.renovate.models import (
     BlockingReason,
     Category,
@@ -38,6 +40,8 @@ def make_pr(
     is_draft: bool = False,
     body: str = "",
     auto_merge_enabled: bool = False,
+    head_committed_at: datetime | None = None,
+    lock_refusal_window: str = "",
 ) -> RenovatePR:
     """Construct an unclassified RenovatePR with sane defaults for one scenario."""
     return RenovatePR(
@@ -55,6 +59,8 @@ def make_pr(
         is_draft=is_draft,
         body=body,
         auto_merge_enabled=auto_merge_enabled,
+        head_committed_at=head_committed_at,
+        lock_refusal_window=lock_refusal_window,
     )
 
 
@@ -640,3 +646,181 @@ def test_extract_deps_title_fallback_action_form() -> None:
     assert [(d.name, d.from_version, d.to_version) for d in pr.deps] == [
         ("anthropics/claude-code-action", "", "1.0.190")
     ]
+
+
+# ── Bounded-lock refusal: expired vs. ordinary broken build (FND-782) ────────
+
+# The tripwire withhold() writes: baseline versions plus a bare [options] table.
+# The absence of an `exclude-newer` key is what separates it from an [options]
+# table uv wrote itself.
+_TRIPWIRE_LOCK = """\
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[options]
+exclude-newer-span = "P3D"
+
+[[package]]
+name = "boto3"
+version = "1.43.67"
+"""
+
+# What uv itself records when a repo declares its own [tool.uv] exclude-newer —
+# same span key, but always alongside the absolute timestamp and (when per-package
+# ceilings apply) the subtable. Four fleet repos carry this permanently, on base
+# as well as on every branch, and must never read as a refusal.
+_UV_OWN_OPTIONS_LOCK = """\
+version = 1
+revision = 3
+
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # no effect; back-compat for relative values
+exclude-newer-span = "P7D"
+
+[options.exclude-newer-package]
+pyatlan = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
+
+[[package]]
+name = "boto3"
+version = "1.43.67"
+"""
+
+_PLAIN_LOCK = """\
+version = 1
+revision = 3
+
+[[package]]
+name = "boto3"
+version = "1.43.67"
+"""
+
+
+def _refusal_pr(
+    *,
+    window: str = "P3D",
+    head_age: timedelta = timedelta(days=4),
+    files: list[str] | None = None,
+    labels: list[str] | None = None,
+    checks_state: ChecksState = ChecksState.FAILING,
+) -> RenovatePR:
+    """A red, uv.lock-only lock-maintenance PR carrying an expired tripwire."""
+    return make_pr(
+        labels=labels if labels is not None else ["update:lock-maintenance"],
+        title="Lock file maintenance",
+        branch="renovate/lock-file-maintenance",
+        checks_state=checks_state,
+        files=files if files is not None else ["uv.lock"],
+        created_at=_OLD,
+        head_committed_at=_NOW - head_age,
+        lock_refusal_window=window,
+    )
+
+
+def test_window_parses_days_and_hours() -> None:
+    assert parse_window("P3D") == timedelta(days=3)
+    assert parse_window("PT12H") == timedelta(hours=12)
+    assert parse_window(" P1DT6H ") == timedelta(days=1, hours=6)
+
+
+def test_window_rejects_calendar_units_and_junk() -> None:
+    # Mirrors the driver: months/years are refused rather than approximated.
+    assert parse_window("P1M") is None
+    assert parse_window("P") is None
+    assert parse_window("") is None
+    assert parse_window("3 days") is None
+
+
+def test_refusal_window_read_from_tripwire() -> None:
+    assert extract_refusal_window(_TRIPWIRE_LOCK) == "P3D"
+
+
+def test_refusal_window_empty_for_uv_written_options() -> None:
+    # The discriminator that keeps the four self-bounding repos out of the signal.
+    assert extract_refusal_window(_UV_OWN_OPTIONS_LOCK) == ""
+
+
+def test_refusal_window_empty_for_ordinary_lock() -> None:
+    assert extract_refusal_window(_PLAIN_LOCK) == ""
+
+
+def test_refusal_window_ignores_a_span_outside_the_options_table() -> None:
+    # A later table quoting the same key must not be read as the tripwire.
+    lock = _PLAIN_LOCK + '\n[tool.something]\nexclude-newer-span = "P7D"\n'
+    assert extract_refusal_window(lock) == ""
+
+
+def test_blocking_bounded_lock_refusal_expired() -> None:
+    # Red, lock-only, tripwire present, head older than the window it names.
+    pr = classify(_refusal_pr())
+    assert pr.blocking_reason is BlockingReason.BOUNDED_LOCK_REFUSAL_EXPIRED
+
+
+def test_blocking_bounded_lock_refusal_expired_at_the_window_boundary() -> None:
+    # Everything blocking a refusal written at T is >= W old at T + W, so the
+    # boundary itself counts as expired.
+    pr = classify(_refusal_pr(head_age=timedelta(days=3, seconds=1)))
+    assert pr.blocking_reason is BlockingReason.BOUNDED_LOCK_REFUSAL_EXPIRED
+
+
+def test_blocking_checks_failing_while_the_refusal_is_still_live() -> None:
+    # Held today, for a reason that still holds. Nothing to surface yet.
+    pr = classify(_refusal_pr(head_age=timedelta(hours=6)))
+    assert pr.blocking_reason is BlockingReason.CHECKS_FAILING
+
+
+def test_blocking_checks_failing_when_the_lock_has_no_tripwire() -> None:
+    # An ordinary broken lock-maintenance build — a human owns it.
+    pr = classify(_refusal_pr(window=""))
+    assert pr.blocking_reason is BlockingReason.CHECKS_FAILING
+
+
+def test_blocking_checks_failing_when_the_diff_is_more_than_the_lock() -> None:
+    pr = classify(_refusal_pr(files=["uv.lock", "pyproject.toml"]))
+    assert pr.blocking_reason is BlockingReason.CHECKS_FAILING
+
+
+def test_blocking_checks_failing_when_head_date_is_unknown() -> None:
+    # Input predating headCommittedAt: no clock, so no claim. created_at is not a
+    # substitute — Renovate rewrites a lock branch in place.
+    pr = classify(
+        make_pr(
+            labels=["update:lock-maintenance"],
+            checks_state=ChecksState.FAILING,
+            files=["uv.lock"],
+            created_at=_OLD,
+            head_committed_at=None,
+            lock_refusal_window="P3D",
+        )
+    )
+    assert pr.blocking_reason is BlockingReason.CHECKS_FAILING
+
+
+def test_blocking_refusal_signal_only_applies_to_lock_maintenance() -> None:
+    # Only the lock lane runs the bounded driver, so only it can be carrying a
+    # refusal. Assert the category guard rather than relying on the other three
+    # conditions to happen to exclude everything else.
+    pr = classify(_refusal_pr(labels=["conformance-package-update", "update:patch"]))
+    assert pr.blocking_reason is BlockingReason.CHECKS_FAILING
+
+
+def test_blocking_merge_conflict_still_wins_over_the_refusal_signal() -> None:
+    pr = classify(
+        make_pr(
+            labels=["update:lock-maintenance"],
+            checks_state=ChecksState.FAILING,
+            files=["uv.lock"],
+            mergeable="CONFLICTING",
+            head_committed_at=_NOW - timedelta(days=4),
+            lock_refusal_window="P3D",
+        )
+    )
+    assert pr.blocking_reason is BlockingReason.MERGE_CONFLICT
+
+
+def test_expired_refusal_counts_as_auto_merge_eligible_but_stuck() -> None:
+    # The dashboard's "stuck" count is derived from blocking_reason, so a new
+    # reason must not silently drop out of it.
+    pr = classify(_refusal_pr())
+    assert pr.auto_merge_expected is True
+    assert pr.blocking_reason is not BlockingReason.AWAITING_HUMAN_REVIEW

--- a/packages/conformance/tests/test_renovate_classify.py
+++ b/packages/conformance/tests/test_renovate_classify.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 
-from conformance.renovate.classify import STALE_AFTER_DAYS, classify
+from conformance.renovate.classify import (
+    STALE_AFTER_DAYS,
+    bounded_lock_refusal_expired,
+    classify,
+)
 from conformance.renovate.classify import lock_refusal_window as extract_refusal_window
 from conformance.renovate.classify import parse_window
 from conformance.renovate.models import (
@@ -824,3 +828,16 @@ def test_expired_refusal_counts_as_auto_merge_eligible_but_stuck() -> None:
     pr = classify(_refusal_pr())
     assert pr.auto_merge_expected is True
     assert pr.blocking_reason is not BlockingReason.AWAITING_HUMAN_REVIEW
+
+
+def test_refusal_expiry_tolerates_a_naive_clock_from_a_caller() -> None:
+    # blocking_reason() accepts a caller-supplied `now`. A naive one against an
+    # aware head_committed_at would raise on subtraction; both sides get the same
+    # UTC coercion classify() applies to created_at.
+    naive_now = _NOW.replace(tzinfo=None)
+    assert (
+        bounded_lock_refusal_expired(
+            _refusal_pr(), Category.LOCK_MAINTENANCE, naive_now
+        )
+        is True
+    )


### PR DESCRIPTION
Closes FND-782.

## The gap

A bounded-lock refusal is red **by design**. `withhold()` in `.github/scripts/renovate_uv_lock_bounded.py` writes the baseline versions plus a bare `[options]` table so `uv sync --locked` rejects the lock and `scan / Build Image` holds the branch — that is the one lever the driver has over a *required* check.

Nothing ever re-evaluates it. The branch is not behind its base, so Renovate reuses it without re-running `postUpgradeTasks`, and the marker committed into `uv.lock` carries no clock. Observed 2026-08-24: five fleet lock PRs sat frozen for two to four days after the window that blocked them had already opened. The dashboard classified all five as `checks_failing` — indistinguishable from a genuine build break that a human owns. Nothing surfaced them; they were found by hand.

The existing age backstop (`AUTOMERGE_STALE`) cannot help: it fires only inside the `checks_state == GREEN` branch, and a red PR terminates earlier at `CHECKS_FAILING` without ever acquiring an age dimension.

## The change

Split that shape out of `CHECKS_FAILING` as `BlockingReason.BOUNDED_LOCK_REFUSAL_EXPIRED`, on four machine-checkable conditions — no heuristics:

1. category is `LOCK_MAINTENANCE`,
2. the diff is a `uv.lock` and nothing else,
3. that lock carries a lone `exclude-newer-span` in `[options]`, and
4. the branch head is at least as old as the window the marker names.

(4) is what makes it *expired* rather than merely present: a refusal written at `T` was caused by content published inside `(T - W, T]`, so by `T + W` every one of those releases is at least `W` old and the same resolve would now be admitted.

## Two design calls worth reviewing

**Head-only lock read.** The ticket phrases condition (3) as the lock *adding* an `[options]` table, which naively needs both head and base. It does not: uv always records the absolute `exclude-newer` key alongside the span (and an `[options.exclude-newer-package]` subtable when per-package ceilings apply), whereas `withhold()` writes the span alone. A lone span is therefore the driver's signature, and the four self-bounding repos — glue, bw, thoughtspot, dbt, which carry a legitimate `[options]` on base *and* every branch — are excluded by that discriminator rather than by a second several-hundred-KB fetch. Tested against the real uv-written shape.

**`committedDate`, not `createdAt`.** Renovate rewrites a lock branch in place without reopening the PR, so a PR opened a week ago can carry a refusal written an hour ago; `createdAt` would over-report. The head commit date rides on a GraphQL selection `renovate_fleet_scan.py` already makes, so it costs nothing. When it is absent — input predating the field — the signal declines to fire rather than substituting `createdAt`.

## Fetch cost

The lock *contents* were the one input genuinely not in hand; no PR search field carries them. Fetching one blob per open Renovate PR would move hundreds of MB fleet-wide for a condition that should be rare, so a second pass fetches only for red, `uv.lock`-only PRs. Both are conditions the classifier independently requires, so this is a pre-filter rather than a duplicated classification. Capped at 25, with any PRs over the cap named in the log rather than silently dropped. Observed population: five.

## Honest limit

The tripwire does not record *which* refusal path wrote it — `withhold()` also fires for an unsatisfiable floor and for the rollback gate, and neither of those expires with the clock. So the new reason claims exactly what it can prove: the tripwire is on and the window it names has elapsed. That is still strictly more than `checks_failing` conveys, and the first triage step (look at the branch; delete it to force a fresh resolve) is the same either way. Documented in the docstring.

## Deliberately not doing

A janitor that self-heals the branch. It works — manual branch deletion recovered all five in one Renovate pass, and `recreateClosed: true` in the shared preset is what makes that safe — but it is machinery for a condition that should now be rare, and it would mask recurrences rather than report them. There is also no Renovate-config route to an expiry: `rebaseWhen` has no option that rebases a non-behind branch on a schedule.

## Files

| file | change |
| --- | --- |
| `renovate/models.py` | new `BlockingReason`; `head_committed_at` + `lock_refusal_window` on `RenovatePR` |
| `renovate/classify.py` | `lock_refusal_window()`, `parse_window()`, `bounded_lock_refusal_expired()`, wired into the `CHECKS_FAILING` branch |
| `renovate/scan.py` | reads the two new raw fields; emits `headCommittedAt` + `lockRefusalWindow` per PR |
| `renovate_fleet_scan.py` | `committedDate` on the existing commit selection; `fetch_lock_texts()` second pass |
| `docs/standards/ci.md` | subsection on why a refusal is red on purpose and what now names it |

No new workflow — `renovate-dashboard.yaml` already scans every fleet repo and runs this classifier.

## Verification

- 78 conformance classifier tests pass (20 new across the two suites).
- 3312 `.github/scripts` tests pass.
- `pre-commit` clean, pyright included.
- End-to-end through the real `renovate-scan` CLI on a synthetic red lock PR: emitted `bounded_lock_refusal_expired | P3D | 2026-08-20T20:35:54+00:00`, counted as 1 stuck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
