### PR TITLE
feat(validation): artifact-validation wrapper skeleton + shared event-name registry (FND-684)

### DIFF
--- a/.claude/skills/capability-manifest/references/subpackage-purposes.yaml
+++ b/.claude/skills/capability-manifest/references/subpackage-purposes.yaml
@@ -19,5 +19,5 @@ server: FastAPI server, MCP integration, middleware, health endpoint
 storage: Object-store abstraction — factory, formats, batch, transfer, cloud bindings
 templates: SQL metadata extractor templates and their contracts
 testing: Test infrastructure — mocks, fixtures, hypothesis strategies, integration helpers
-validation: Offline asset validation — pyatlan_v9 .validate() wrappers, no network call
+validation: Offline artifact & asset validation — format-agnostic wrapper (ADR-0020) plus pyatlan_v9 .validate() wrappers, no network call
 transformers: "Legacy daft+YAML transformer stack (back-compat only — migrate to pyatlan record mappers; see upgrade-guide-v3.md). No __all__; deep-import only."

--- a/application_sdk/app/base.py
+++ b/application_sdk/app/base.py
@@ -80,6 +80,17 @@ from application_sdk.errors import (
 from application_sdk.errors.base import AppError as _NewAppError
 from application_sdk.errors.leaves import InternalError as _InternalError
 from application_sdk.errors.leaves import InvalidInputError as _InvalidInputError
+
+# Fixed event name for the structured, queryable transformed-asset validation
+# outcome. Emitted on every upload from inside the upload activity, so the
+# Temporal activity context (workflow_id/run_id/app_name) is auto-stamped and the
+# row joins to the workflow outcome in ClickHouse — mirrors the preflight gate's
+# outcome event. Scalar counts land as top-level LogAttributes; the per-failure
+# drill-down rides in the ``asset_validation_matrix`` JSON attribute. The name now
+# lives in the shared event-name registry alongside the preflight gate's two and
+# the generic artifact-validation one; its value is **unchanged** by that move,
+# because shipped dashboards and alert rules key off the exact string.
+from application_sdk.observability.events import ASSET_VALIDATION_EVENT
 from application_sdk.observability.logger_adaptor import (
     ASSET_VALIDATION_MATRIX_KEY,
     get_logger,
@@ -96,17 +107,6 @@ try:
     _FRAMEWORK_VERSION = importlib.metadata.version("application-sdk")
 except importlib.metadata.PackageNotFoundError:  # conformance: ignore[E009] package not installed (e.g. editable dev install); "unknown" sentinel is benign
     _FRAMEWORK_VERSION = "unknown"
-
-# Fixed event name for the structured, queryable transformed-asset validation
-# outcome. Emitted on every upload from inside the upload activity, so the
-# Temporal activity context (workflow_id/run_id/app_name) is auto-stamped and the
-# row joins to the workflow outcome in ClickHouse — mirrors the preflight gate's
-# outcome event. Scalar counts land as top-level LogAttributes; the per-failure
-# drill-down rides in the ``asset_validation_matrix`` JSON attribute.
-# Peer of ``PREFLIGHT_OUTCOME_EVENT`` (execution/_temporal/preflight_gate.py):
-# same outcome-event pattern. No shared registry for these names yet — worth
-# adding only once a third such event exists.
-ASSET_VALIDATION_EVENT = "Transformed-asset validation outcome"
 
 # Cap on how many failure/orphan rows the matrix carries, aliased from the single
 # source of truth in ``constants`` so the structured matrix and the human-readable

--- a/application_sdk/constants.py
+++ b/application_sdk/constants.py
@@ -570,14 +570,22 @@ VALIDATE_ASSETS_ON_UPLOAD: bool = (
 VALIDATE_ASSETS_TIMEOUT_SECONDS: float = float(
     os.getenv("ATLAN_VALIDATE_ASSETS_TIMEOUT_SECONDS", "600")
 )
-#: The single "rows per axis" cap for transformed-asset validation output —
-#: shared by both surfaces so they can never drift: the human-readable
-#: ``AssetValidationReport.format_report(max_items=...)`` listing and the
-#: structured ``asset_validation_matrix`` telemetry the upload activity emits.
-#: The event's scalar counts always reflect the full batch; only these
-#: drill-down samples are bounded (so a pathological batch cannot produce an
-#: unbounded WARNING body or ``LogAttributes`` value).
-ASSET_VALIDATION_MAX_ITEMS_PER_AXIS: int = 25
+#: The single "rows per axis" cap for every validation drill-down surface —
+#: one number, so the human-readable ``format_report(max_items=...)`` listing and
+#: the structured matrix telemetry can never drift apart.
+#:
+#: Bounding is two-tier and deliberately asymmetric: the **scan** is unbounded
+#: (every record is examined, so the event's scalar counts always reflect the full
+#: batch) and only the two *output* surfaces are capped, so a pathological batch
+#: cannot produce an unbounded WARNING body or ``LogAttributes`` value.
+ARTIFACT_VALIDATION_MAX_ITEMS_PER_AXIS: int = 25
+
+#: The transformed-asset validator's cap. An alias rather than its own literal:
+#: asset validation is one format x source cell of the artifact wrapper
+#: (ADR-0020), and two independently-editable 25s is exactly the drift the single
+#: shared cap exists to prevent. The name survives because it is the pinned
+#: identifier the shipped asset surface imports.
+ASSET_VALIDATION_MAX_ITEMS_PER_AXIS: int = ARTIFACT_VALIDATION_MAX_ITEMS_PER_AXIS
 
 # Dapr Client Configuration
 #: Maximum gRPC message length in bytes for Dapr client.

--- a/application_sdk/execution/_temporal/preflight_gate.py
+++ b/application_sdk/execution/_temporal/preflight_gate.py
@@ -61,6 +61,20 @@ with workflow.unsafe.imports_passed_through():
         PreflightStatus,
     )
     from application_sdk.infrastructure.context import get_infrastructure
+
+    # Stable log bodies for the gate's two events — the contract connector-pulse
+    # queries on. They live in the shared event-name registry and their values are
+    # **unchanged** by the move there, so every dashboard string keeps working.
+    # The outcome event is the gate's per-run verdict row; the posture event fires
+    # once per gate-registered app at worker build and is the *denominator* the
+    # outcome events cannot supply — an app that never reaches a verdict emits no
+    # outcome row carrying ``gate_mode``, so "which apps believe they are gated" is
+    # unanswerable from outcomes alone, and that is exactly the app whose broken
+    # guarantee we most need to find.
+    from application_sdk.observability.events import (
+        PREFLIGHT_OUTCOME_EVENT,
+        PREFLIGHT_POSTURE_EVENT,
+    )
     from application_sdk.observability.logger_adaptor import (
         CHECK_MATRIX_KEY,
         GATE_ATTEMPTS_KEY,
@@ -74,18 +88,6 @@ with workflow.unsafe.imports_passed_through():
 logger = get_logger(__name__)
 
 PREFLIGHT_FAILED_ERROR_TYPE = "PreflightFailed"
-
-# Stable log body for the gate outcome event — the contract connector-pulse queries
-# on. Pinned here so the string can't drift across the emission sites.
-PREFLIGHT_OUTCOME_EVENT = "Preflight gate outcome"
-
-# Stable log body for the boot-time posture event, emitted once per gate-registered
-# app at worker build. This is the *denominator* the outcome events cannot supply:
-# an app that never reaches a verdict emits no outcome row carrying ``gate_mode``,
-# so "which apps believe they are gated" is unanswerable from outcomes alone —
-# which is exactly the app whose broken guarantee we most need to find. Pinned
-# alongside the outcome event for the same reason.
-PREFLIGHT_POSTURE_EVENT = "Preflight gate posture"
 
 # Contract sentinel stamped as the primary FailureDetails.code on a fallback block
 # (a handler that returned NOT_READY without a typed check error). It replaces the

--- a/application_sdk/observability/events.py
+++ b/application_sdk/observability/events.py
@@ -1,0 +1,75 @@
+"""Pinned log-message bodies for the SDK's structured outcome events.
+
+An *outcome event* is a log line whose **message body is a contract**: dashboards,
+alert rules and connector-pulse queries match on the exact string, so rewording one
+silently empties every panel keyed off it. This module is the single place those
+strings are written down.
+
+Emitting a queryable event is a three-part contract, and all three edits are
+required or the fields silently never reach OTLP:
+
+1. a pinned name constant — **here**, and it is the log message body;
+2. an attribute-key constant in
+   :mod:`application_sdk.observability.logger_adaptor`, shared with the emitter so
+   a rename is one edit;
+3. entries in that module's ``_KNOWN_EXTRA_KEYS`` allowlist, which is what gates
+   kwargs into the emitted ``LogRecord``'s attributes.
+
+Why a separate module rather than ``logger_adaptor``: importing ``logger_adaptor``
+pulls loguru and the OTLP exporter stack, and a caller that only needs to *name* an
+event (a test, a validator, a conformance rule) should not pay for that. This file
+imports nothing.
+
+Nothing here may ever be reworded. A new event is a new constant; a renamed event
+is a new constant plus a migration for every consumer of the old string.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+# ── Preflight gate (execution/_temporal/preflight_gate.py) ──────────────────
+
+#: The gate's per-run verdict row. Re-exported unchanged from
+#: ``preflight_gate.PREFLIGHT_OUTCOME_EVENT``.
+PREFLIGHT_OUTCOME_EVENT: Final = "Preflight gate outcome"
+
+#: The boot-time posture row, emitted once per gate-registered app at worker
+#: build — the denominator the outcome events cannot supply. Re-exported
+#: unchanged from ``preflight_gate.PREFLIGHT_POSTURE_EVENT``.
+PREFLIGHT_POSTURE_EVENT: Final = "Preflight gate posture"
+
+# ── Validation (validation/, app/base.py) ───────────────────────────────────
+
+#: Transformed-asset (NDJSON x pyatlan_v9 model) validation outcome, emitted from
+#: the upload activity. Re-exported unchanged from
+#: ``app.base.ASSET_VALIDATION_EVENT``. ADR-0020 folds this check into the
+#: artifact wrapper as one format x source cell; the name is preserved verbatim
+#: through that move because shipped dashboards key off it.
+ASSET_VALIDATION_EVENT: Final = "Transformed-asset validation outcome"
+
+#: Generic artifact validation outcome (ADR-0020): one row per artifact hand-off,
+#: whatever its format and whichever schema source declared it. Emitted for every
+#: hand-off including the negative outcomes — a check that reports nothing is
+#: indistinguishable from a check that passed.
+ARTIFACT_VALIDATION_EVENT: Final = "Artifact validation outcome"
+
+
+#: Every pinned event body, for tests and introspection. Membership here is the
+#: definition of "this string is a contract".
+OUTCOME_EVENT_NAMES: Final[frozenset[str]] = frozenset(
+    {
+        PREFLIGHT_OUTCOME_EVENT,
+        PREFLIGHT_POSTURE_EVENT,
+        ASSET_VALIDATION_EVENT,
+        ARTIFACT_VALIDATION_EVENT,
+    }
+)
+
+__all__ = [
+    "ARTIFACT_VALIDATION_EVENT",
+    "ASSET_VALIDATION_EVENT",
+    "OUTCOME_EVENT_NAMES",
+    "PREFLIGHT_OUTCOME_EVENT",
+    "PREFLIGHT_POSTURE_EVENT",
+]

--- a/application_sdk/observability/logger_adaptor.py
+++ b/application_sdk/observability/logger_adaptor.py
@@ -81,6 +81,36 @@ GATE_ATTEMPTS_KEY = "gate_attempt"
 # attributes.
 ASSET_VALIDATION_MATRIX_KEY = "asset_validation_matrix"
 
+# Generic artifact-validation outcome-event keys (ADR-0020), shared with the
+# emitter (``application_sdk.validation.artifacts``) so a rename is a single edit
+# that keeps the emit call-site and the allowlist below in sync. One row is
+# emitted per artifact hand-off, whatever the format and whichever schema source
+# declared it — including the negative outcomes, because a check that reports
+# nothing is indistinguishable from a check that passed.
+#
+# ``artifact_unit`` names what ``artifact_total``/``passed``/``failed`` count, so
+# the same four scalars carry both a streaming NDJSON record scan and a parquet
+# footer column diff without a consumer having to infer the unit from the format.
+# The bounded per-failure drill-down rides in ``artifact_validation_matrix`` as
+# one JSON string (JSONExtract-able), exactly as the asset matrix does, and is
+# always present — even as ``"[]"`` — so consumers never branch on its presence.
+ARTIFACT_VALIDATION_MATRIX_KEY = "artifact_validation_matrix"
+ARTIFACT_FORMAT_KEY = "artifact_format"
+ARTIFACT_SCHEMA_SOURCE_KEY = "artifact_schema_source"
+ARTIFACT_FIELD_KEY = "artifact_field"
+ARTIFACT_UNIT_KEY = "artifact_unit"
+ARTIFACT_TOTAL_KEY = "artifact_total"
+ARTIFACT_PASSED_KEY = "artifact_passed"
+ARTIFACT_FAILED_KEY = "artifact_failed"
+ARTIFACT_UNDECODABLE_KEY = "artifact_undecodable"
+ARTIFACT_FIELDS_DECLARED_KEY = "artifact_fields_declared"
+
+# Whether the undeclared artifact sat on an entrypoint's public boundary
+# (a finding) or on an app-internal ``@task`` contract (informational). Both emit;
+# neither is silent. Deliberately unprefixed, matching the equally generic
+# ``outcome``/``reason``/``checks`` keys this allowlist already carries.
+ARTIFACT_BOUNDARY_KEY = "boundary"
+
 # SDK-side allowlist that gates which kwargs reach OTLP.  When a logger is called
 # with structured kwargs (e.g. ``_log().info("Downloaded", storage_path=key)``),
 # loguru places the kwargs on ``record["extra"]`` rather than in the message
@@ -145,6 +175,18 @@ _KNOWN_EXTRA_KEYS = frozenset(
         "assets_invalid",
         "assets_orphaned",
         "assets_undeserializable",
+        # ── Generic artifact validation outcome event (ADR-0020) ─────────
+        ARTIFACT_VALIDATION_MATRIX_KEY,
+        ARTIFACT_FORMAT_KEY,
+        ARTIFACT_SCHEMA_SOURCE_KEY,
+        ARTIFACT_FIELD_KEY,
+        ARTIFACT_UNIT_KEY,
+        ARTIFACT_TOTAL_KEY,
+        ARTIFACT_PASSED_KEY,
+        ARTIFACT_FAILED_KEY,
+        ARTIFACT_UNDECODABLE_KEY,
+        ARTIFACT_FIELDS_DECLARED_KEY,
+        ARTIFACT_BOUNDARY_KEY,
         # ── Misc SDK ─────────────────────────────────────────────────────
         "log_type",
         "app_name",

--- a/application_sdk/validation/__init__.py
+++ b/application_sdk/validation/__init__.py
@@ -1,13 +1,24 @@
-"""Offline, reusable data validation for Atlan asset writes.
+"""Offline, reusable data validation for Atlan artifacts and asset writes.
 
-This package is the SDK's *principle-based* validation scaffold (BLDX-1555). It
-builds on the per-asset ``.validate()`` backbone that ``pyatlan_v9`` exposes on
-every asset class — a purely local, dry-run check (required fields, qualified-name
-format, and create-time hierarchy fields) that needs **no network call**. Pushing
-validation this deep in the stack means the same check applies whether an asset is
-produced via the app SDK, low-level ``pyatlan``, or MCP.
+Two layers live here.
 
-Two things live here:
+**Artifact validation** (ADR-0020) is the generic one: a thin, format-agnostic
+wrapper that takes an app-owned declaration, dispatches on format, and owns only
+the shared outcome — one report shape, one outcome event, one bounded drill-down
+payload. Byte integrity (``storage/integrity.py``) attests that the bytes read are
+the bytes written and is explicit that this proves nothing about the artifact being
+semantically complete; this is that missing third leg. Its two orthogonal plug-in
+seams — *where the declaration comes from* and *how a format is checked* — are
+:mod:`application_sdk.validation.protocols`; the shared outcome surface is
+:mod:`application_sdk.validation.artifacts`.
+
+**Asset validation** (BLDX-1555) is the concrete NDJSON x typed-model check that
+predates the wrapper, built on the per-asset ``.validate()`` backbone that
+``pyatlan_v9`` exposes on every asset class — a purely local, dry-run check
+(required fields, qualified-name format, and create-time hierarchy fields) that
+needs **no network call**. Pushing validation this deep in the stack means the same
+check applies whether an asset is produced via the app SDK, low-level ``pyatlan``,
+or MCP. It offers:
 
 * :func:`validate_asset` — run pyatlan_v9's ``.validate()`` on a single asset and
   return the error messages (never raises).
@@ -20,8 +31,30 @@ Two things live here:
 
 The referential-integrity pass is intentionally an SDK concern, not a pyatlan one:
 it is a cross-record check that a single asset's ``.validate()`` cannot make.
+
+ADR-0020 folds asset validation into the wrapper as its NDJSON x ``ModelSource``
+cell, preserving its event name and attribute keys verbatim — a refactor behind a
+stable event surface, not a rename.
+
+**Standing dependency floor for this whole package**: no ``pyarrow``, ``pandas`` or
+``pandera`` import anywhere in it. A JSON-only caller must never pay for a parquet
+reader, and pandera stays test-only.
 """
 
+from application_sdk.validation.artifacts import (
+    ArtifactDeclaration,
+    ArtifactFailureKind,
+    ArtifactFieldType,
+    ArtifactFieldTypeExtended,
+    ArtifactValidationFailure,
+    ArtifactValidationOutcome,
+    ArtifactValidationReport,
+    DeclaredField,
+    FieldMapDeclaration,
+    ModelDeclaration,
+    artifact_validation_event_fields,
+    artifact_validation_matrix_json,
+)
 from application_sdk.validation.assets import (
     AssetValidationFailure,
     AssetValidationReport,
@@ -29,8 +62,25 @@ from application_sdk.validation.assets import (
     validate_asset,
     validate_transformed_dir,
 )
+from application_sdk.validation.protocols import FormatValidator, SchemaSource
 
 __all__ = [
+    # Artifact validation (ADR-0020)
+    "ArtifactDeclaration",
+    "ArtifactFailureKind",
+    "ArtifactFieldType",
+    "ArtifactFieldTypeExtended",
+    "ArtifactValidationFailure",
+    "ArtifactValidationOutcome",
+    "ArtifactValidationReport",
+    "DeclaredField",
+    "FieldMapDeclaration",
+    "FormatValidator",
+    "ModelDeclaration",
+    "SchemaSource",
+    "artifact_validation_event_fields",
+    "artifact_validation_matrix_json",
+    # Asset validation (BLDX-1555)
     "AssetValidationFailure",
     "AssetValidationReport",
     "ReferentialFailure",

--- a/application_sdk/validation/artifacts.py
+++ b/application_sdk/validation/artifacts.py
@@ -1,0 +1,559 @@
+"""Format-agnostic artifact validation: the shared outcome surface (ADR-0020).
+
+Data crosses app boundaries as files, and at every hand-off the producer's idea of
+the artifact's shape and the consumer's idea of it are independent beliefs that
+nothing checks. ``storage/integrity.py`` attests that the bytes read are the bytes
+written and is explicit that this proves nothing about the artifact being
+*semantically* complete; this is the missing third leg.
+
+This module is the wrapper's **shared** half — the part that is identical no matter
+what format the artifact is in or where its declaration came from:
+
+* the logical-type vocabulary declarations are written against;
+* the typed declaration a schema source resolves to;
+* the outcome vocabulary;
+* :class:`ArtifactValidationReport`, the one report shape;
+* the bounded drill-down matrix and the outcome-event attribute map.
+
+The two plug-in seams that vary — *where the declaration comes from* and *how a
+format is checked* — are :mod:`application_sdk.validation.protocols`. Keeping them
+separate is load-bearing: conflating them forces either a dataframe dependency or a
+hand-authored field list for the 500-type asset case.
+
+**Dependency floor.** Nothing in this module tree may import ``pyarrow``,
+``pandas`` or ``pandera``. A JSON-only caller must never pay for a parquet reader,
+and pandera stays test-only (ADR-0020, Option 2) — this is a standing constraint,
+not a temporary state. ``tests/unit/validation/test_artifact_dependency_floor.py``
+enforces it statically.
+
+**Sync by design.** Nothing here is a coroutine. Validators are plain synchronous
+scans so the one caller that needs to stay off the event loop — the activity
+interceptor — owns the offload decision (``run_in_thread`` / an isolated child
+process) rather than every validator re-deciding it.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from dataclasses import dataclass
+from typing import Final, Literal, Union
+
+import orjson
+
+from application_sdk.constants import ARTIFACT_VALIDATION_MAX_ITEMS_PER_AXIS
+from application_sdk.observability.events import ARTIFACT_VALIDATION_EVENT
+from application_sdk.observability.logger_adaptor import (
+    ARTIFACT_BOUNDARY_KEY,
+    ARTIFACT_FAILED_KEY,
+    ARTIFACT_FIELD_KEY,
+    ARTIFACT_FIELDS_DECLARED_KEY,
+    ARTIFACT_FORMAT_KEY,
+    ARTIFACT_PASSED_KEY,
+    ARTIFACT_SCHEMA_SOURCE_KEY,
+    ARTIFACT_TOTAL_KEY,
+    ARTIFACT_UNDECODABLE_KEY,
+    ARTIFACT_UNIT_KEY,
+    ARTIFACT_VALIDATION_MATRIX_KEY,
+)
+
+__all__ = [
+    "ARTIFACT_FIELD_TYPES",
+    "ARTIFACT_FIELD_TYPES_EXTENDED",
+    "ARTIFACT_VALIDATION_EVENT",
+    "ARTIFACT_VALIDATION_OUTCOMES",
+    "OUTCOME_ABSENT",
+    "OUTCOME_CLEAN",
+    "OUTCOME_FLAGGED",
+    "OUTCOME_NOT_DECLARED",
+    "OUTCOME_UNSUPPORTED",
+    "UNIT_COLUMN",
+    "UNIT_RECORD",
+    "ArtifactDeclaration",
+    "ArtifactFailureKind",
+    "ArtifactFieldType",
+    "ArtifactFieldTypeExtended",
+    "ArtifactValidationFailure",
+    "ArtifactValidationOutcome",
+    "ArtifactValidationReport",
+    "DeclaredField",
+    "FieldMapDeclaration",
+    "ModelDeclaration",
+    "artifact_validation_event_fields",
+    "artifact_validation_matrix_json",
+]
+
+
+# ---------------------------------------------------------------------------
+# The logical-type vocabulary
+# ---------------------------------------------------------------------------
+#
+# The SDK owns the vocabulary; every field that uses it is the app's. Two tiers,
+# the second layering additively on the first, mirroring the ``ArtifactFieldType``
+# / ``ArtifactFieldTypeExtended`` typealiases the contract toolkit emits: the base
+# is a floor every validator must map for every format, while an extension member
+# may resolve to "unsupported for this format" without widening that floor.
+#
+# Each member earns its place against a specific observed failure rather than
+# mirroring arrow wholesale. The load-bearing pair is ``string`` vs ``timestamp``:
+# a production RCA traced a 73-day frozen lineage marker to one column that had
+# become a string where the consumer expected a timestamp, with every workflow in
+# the chain reporting success throughout. That single distinction is why this
+# capability exists.
+
+ArtifactFieldType = Literal[
+    "string",
+    "int",
+    "float",
+    "bool",
+    "timestamp",
+    "date",
+    "json",
+    "any",
+]
+"""The stable floor: types every validator must map, for every format."""
+
+ArtifactFieldTypeExtended = Union[
+    ArtifactFieldType,
+    Literal["decimal", "binary", "time", "array", "struct", "map"],
+]
+"""Additive extension. Declarations use this, so a member can be declared before
+every validator supports it — resolving to ``unsupported`` for a format rather
+than widening the floor above."""
+
+ARTIFACT_FIELD_TYPES: Final[frozenset[str]] = frozenset(
+    {"string", "int", "float", "bool", "timestamp", "date", "json", "any"}
+)
+"""Runtime membership test for :data:`ArtifactFieldType`."""
+
+ARTIFACT_FIELD_TYPES_EXTENDED: Final[frozenset[str]] = ARTIFACT_FIELD_TYPES | frozenset(
+    {"decimal", "binary", "time", "array", "struct", "map"}
+)
+"""Runtime membership test for :data:`ArtifactFieldTypeExtended`."""
+
+
+# ---------------------------------------------------------------------------
+# What a schema source resolves to
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class DeclaredField:
+    """One field an app declares it requires of an artifact.
+
+    Nested payloads are addressed by **dotted path plus a container type**, not by
+    a recursive type grammar: ``payload.rows`` typed ``array`` rather than a nested
+    schema literal. The deeply-nested case never needs the grammar because it
+    delegates to an executable model (see :class:`ModelDeclaration`).
+    """
+
+    path: str
+    """Field name, or dotted path for a nested field (e.g. ``payload.rows``)."""
+    type: ArtifactFieldTypeExtended = "any"
+    """Declared logical type. ``any`` means "must be present, type not asserted" —
+    so a thin declaration can assert presence without anyone inventing a wrong type
+    to satisfy the vocabulary."""
+    required: bool = True
+    """When False the field is type-checked only if present."""
+
+
+@dataclass(frozen=True)
+class FieldMapDeclaration:
+    """A declaration resolved to an explicit field map — the ``ContractSource`` shape.
+
+    Checked by diffing: declared names and logical types against what the artifact
+    actually carries.
+    """
+
+    fields: tuple[DeclaredField, ...] = ()
+
+    @property
+    def field_count(self) -> int:
+        """How many fields the declaration names."""
+        return len(self.fields)
+
+
+@dataclass(frozen=True)
+class ModelDeclaration:
+    """A declaration resolved to an executable typed model — the ``ModelSource`` shape.
+
+    Nothing is authored: the model *is* the declaration, which is what makes the
+    500-type / 4000-property asset case tractable. Checked by delegation to the
+    model's own validation, never by diffing — a model carries no column mapping,
+    which is why the parquet x model cell is genuinely ``unsupported`` and says so
+    rather than guessing.
+    """
+
+    model: type
+
+    @property
+    def field_count(self) -> int:
+        """Always 0: a model declares no enumerable field list at this layer."""
+        return 0
+
+
+ArtifactDeclaration = Union[FieldMapDeclaration, ModelDeclaration]
+"""Tagged union of what a :class:`~application_sdk.validation.protocols.SchemaSource`
+resolves to. A union rather than one struct with optional halves, so a validator
+cannot silently treat "declared no fields" and "delegate to a model" as the same
+thing."""
+
+
+# ---------------------------------------------------------------------------
+# The outcome vocabulary
+# ---------------------------------------------------------------------------
+
+OUTCOME_CLEAN: Final = "clean"
+"""Checked against a declaration; nothing failed."""
+
+OUTCOME_FLAGGED: Final = "flagged"
+"""Checked against a declaration; at least one unit failed."""
+
+OUTCOME_NOT_DECLARED: Final = "not_declared"
+"""No declaration exists for this artifact. Carries ``boundary``: a finding on an
+entrypoint's public interface, informational on an internal ``@task``."""
+
+OUTCOME_UNSUPPORTED: Final = "unsupported"
+"""A declaration exists but this (format x source) cell cannot check it — e.g.
+parquet x model. Never silence."""
+
+OUTCOME_ABSENT: Final = "absent"
+"""The artifact itself was not readable: missing, empty, or a malformed declaration
+artifact that degraded to a warning rather than an exception into the caller."""
+
+ArtifactValidationOutcome = Literal[
+    "clean", "flagged", "not_declared", "unsupported", "absent"
+]
+"""Every artifact hand-off emits exactly one of these — the negatives included.
+A check that reports nothing is indistinguishable from a check that passed, and
+that ambiguity is itself a defect: the earlier upload-time hook returned early and
+emitted nothing when its path gate did not match, so an app could look adopted
+while validating zero records."""
+
+ARTIFACT_VALIDATION_OUTCOMES: Final[frozenset[str]] = frozenset(
+    {
+        OUTCOME_CLEAN,
+        OUTCOME_FLAGGED,
+        OUTCOME_NOT_DECLARED,
+        OUTCOME_UNSUPPORTED,
+        OUTCOME_ABSENT,
+    }
+)
+"""Runtime membership test for :data:`ArtifactValidationOutcome`."""
+
+
+ArtifactFailureKind = Literal["missing", "type_mismatch", "undecodable", "invalid"]
+"""Why one unit failed. ``missing``/``type_mismatch`` come from a field-map diff,
+``undecodable`` from a unit that could not be parsed at all, ``invalid`` from a
+model delegating its own validation messages back."""
+
+UNIT_RECORD: Final = "record"
+"""Unit for the streaming per-record formats (NDJSON)."""
+
+UNIT_COLUMN: Final = "column"
+"""Unit for the metadata-only formats, where the footer schema is diffed and no row
+is ever read (parquet)."""
+
+
+# ---------------------------------------------------------------------------
+# The report
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ArtifactValidationFailure:
+    """One failing unit — a record that broke, or a column that disagreed."""
+
+    kind: ArtifactFailureKind
+    """Why it failed."""
+    field: str = ""
+    """Declared field path involved, or "" when the whole unit failed."""
+    expected: str = ""
+    """Declared logical type ("" when not a type question)."""
+    actual: str = ""
+    """Observed type ("" when not a type question, or unknown)."""
+    file: str = ""
+    """Artifact file the unit came from ("" when validated in-memory)."""
+    line: int = 0
+    """1-based record line within ``file``; 0 for column units and in-memory checks."""
+    # ``dataclasses.field`` qualified: this class has a member named ``field``,
+    # which shadows a bare ``field`` import inside the class body.
+    errors: list[str] = dataclasses.field(default_factory=list)
+    """Human-readable messages. A list, mirroring ``AssetValidationFailure.errors``,
+    because a delegating model returns several at once."""
+
+
+@dataclass
+class ArtifactValidationReport:
+    """Aggregate outcome of validating one artifact against one declaration.
+
+    Mirrors :class:`~application_sdk.validation.assets.AssetValidationReport`:
+    scalar counts, a bounded failure list, ``ok``/``failed``, and a
+    ``format_report(*, max_items=...)`` renderer that shares its cap with the
+    telemetry matrix.
+
+    ``total``/``passed`` count **units**, named by :attr:`unit` — records for a
+    streaming scan, columns for a footer diff — so the same four scalars describe
+    both without a consumer inferring the unit from the format.
+
+    The three non-scan outcomes have no counts to report and are built through
+    :meth:`not_declared`, :meth:`unsupported` and :meth:`absent`, which pin
+    :attr:`verdict`. Everything else derives its outcome from the failure list, so
+    "reported clean" and "found nothing wrong" cannot come apart.
+    """
+
+    artifact_format: str = ""
+    """``ndjson`` / ``parquet`` — "" when nothing was read."""
+    schema_source: str = ""
+    """``contract`` / ``model`` — "" when no declaration was resolved."""
+    unit: str = ""
+    """What ``total``/``passed`` count: :data:`UNIT_RECORD` or :data:`UNIT_COLUMN`."""
+    fields_declared: int = 0
+    """How many fields the declaration named (0 for a model declaration)."""
+    total: int = 0
+    """Units examined. Always the whole artifact — the scan is never sampled."""
+    passed: int = 0
+    """Units with no failure."""
+    failures: list[ArtifactValidationFailure] = dataclasses.field(default_factory=list)
+    """Every failing unit. Unbounded: only the *output* surfaces are capped."""
+    boundary: bool = False
+    """Whether this hand-off sits on an entrypoint's public interface."""
+    reason: str = ""
+    """Short explanation, chiefly for the non-scan outcomes."""
+    verdict: ArtifactValidationOutcome | None = None
+    """Pinned non-scan outcome. ``None`` means "a scan ran; derive it"."""
+
+    # -- derived ---------------------------------------------------------
+
+    @property
+    def outcome(self) -> ArtifactValidationOutcome:
+        """The single value the outcome event reports."""
+        if self.verdict is not None:
+            return self.verdict
+        return OUTCOME_CLEAN if self.ok else OUTCOME_FLAGGED
+
+    @property
+    def ok(self) -> bool:
+        """True when nothing failed.
+
+        The non-scan outcomes are ``ok`` too: they are honest reports that no check
+        ran, not verdicts against the artifact.
+        """
+        return not self.failures
+
+    @property
+    def failed(self) -> int:
+        """Units that failed — ``total - passed``, never a row count.
+
+        A record can break on several fields at once, so ``len(failures)`` is a
+        problem-row count and can exceed this.
+        """
+        return self.total - self.passed
+
+    @property
+    def undecodable(self) -> int:
+        """Units that could not be parsed at all.
+
+        Derived from the failure list rather than tracked alongside it, so the two
+        cannot disagree.
+        """
+        return sum(1 for f in self.failures if f.kind == "undecodable")
+
+    # -- non-scan constructors -------------------------------------------
+
+    @classmethod
+    def not_declared(
+        cls, *, boundary: bool, reason: str = "no artifact schema declared"
+    ) -> "ArtifactValidationReport":
+        """No declaration exists. A finding on the boundary, informational inside."""
+        return cls(verdict=OUTCOME_NOT_DECLARED, boundary=boundary, reason=reason)
+
+    @classmethod
+    def unsupported(
+        cls,
+        *,
+        artifact_format: str,
+        schema_source: str,
+        reason: str,
+        boundary: bool = False,
+    ) -> "ArtifactValidationReport":
+        """This (format x source) cell cannot check the declaration it was given."""
+        return cls(
+            verdict=OUTCOME_UNSUPPORTED,
+            artifact_format=artifact_format,
+            schema_source=schema_source,
+            reason=reason,
+            boundary=boundary,
+        )
+
+    @classmethod
+    def absent(
+        cls,
+        *,
+        reason: str,
+        artifact_format: str = "",
+        schema_source: str = "",
+        boundary: bool = False,
+    ) -> "ArtifactValidationReport":
+        """The artifact or its declaration could not be read at all."""
+        return cls(
+            verdict=OUTCOME_ABSENT,
+            artifact_format=artifact_format,
+            schema_source=schema_source,
+            reason=reason,
+            boundary=boundary,
+        )
+
+    # -- rendering -------------------------------------------------------
+
+    def format_report(
+        self, *, max_items: int = ARTIFACT_VALIDATION_MAX_ITEMS_PER_AXIS
+    ) -> str:
+        """Render a human-readable summary.
+
+        ``max_items`` caps how many failures are *listed*, never how many are
+        examined — the headline counts always reflect the whole artifact. Defaults
+        to :data:`~application_sdk.constants.ARTIFACT_VALIDATION_MAX_ITEMS_PER_AXIS`,
+        the same cap :func:`artifact_validation_matrix_json` applies to the
+        structured telemetry, so the two surfaces stay in lockstep.
+        """
+        if self.verdict is not None:
+            head = f"Artifact validation: {self.outcome}"
+            if self.verdict == OUTCOME_NOT_DECLARED:
+                head += " (boundary)" if self.boundary else " (internal)"
+            return f"{head} — {self.reason}" if self.reason else head
+
+        cell = f"{self.artifact_format or '?'} x {self.schema_source or '?'}"
+        unit = self.unit or "unit"
+        lines = [
+            f"Artifact validation [{cell}]: {self.outcome} — "
+            f"{self.passed}/{self.total} {unit}s passed, {self.failed} failed, "
+            f"{self.undecodable} undecodable, {self.fields_declared} field(s) declared"
+        ]
+        lines.extend(f"  {_failure_line(f)}" for f in self.failures[:max_items])
+        # Split the overflow by kind so a tail of undecodable records is never
+        # miscounted as type mismatches — matching the disjoint headline.
+        remaining = self.failures[max_items:]
+        for kind in sorted({f.kind for f in remaining}):
+            count = sum(1 for f in remaining if f.kind == kind)
+            lines.append(f"  ... and {count} more {kind}")
+        return "\n".join(lines)
+
+
+def _failure_line(failure: ArtifactValidationFailure) -> str:
+    """Render one failure row for :meth:`ArtifactValidationReport.format_report`."""
+    label = failure.field or "<record>"
+    loc = _location(failure.file, failure.line)
+    detail = "; ".join(failure.errors)
+    if failure.expected or failure.actual:
+        types = f" (declared {failure.expected or '?'}, found {failure.actual or '?'})"
+    else:
+        types = ""
+    suffix = f": {detail}" if detail else ""
+    return f"{failure.kind.upper()} {label}{types}{loc}{suffix}"
+
+
+def _location(file: str, line: int) -> str:
+    if file and line:
+        return f" ({file}:{line})"
+    if file:
+        return f" ({file})"
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# Telemetry
+# ---------------------------------------------------------------------------
+
+_MATRIX_ERROR_MAXLEN: Final = 300
+"""Per-row message cap (chars). A delegating model's messages can be long, so
+truncate: a single row must not be able to bloat the ClickHouse attribute."""
+
+
+def artifact_validation_matrix_json(
+    report: ArtifactValidationReport,
+    *,
+    max_items: int = ARTIFACT_VALIDATION_MAX_ITEMS_PER_AXIS,
+) -> str:
+    """Compact per-failure drill-down for the outcome event, as one JSON string.
+
+    Lands as a single ``LogAttributes`` value in ClickHouse so a consumer can
+    ``JSONExtract`` the per-failure detail against workflow outcomes with no schema
+    change (mirrors the preflight gate's ``check_matrix`` and the asset validator's
+    ``asset_validation_matrix``). Small fixed fields only, bounded to ``max_items``
+    rows by the same constant :meth:`ArtifactValidationReport.format_report` uses,
+    so the human report and the telemetry can never drift.
+
+    **Always returns a value — ``"[]"`` when there is nothing to show** — so
+    consumers parse it unconditionally instead of branching on presence. A branch
+    mishandled in the dropping direction is how a hand-off that never reached a
+    verdict vanishes from the numerator it belongs in.
+    """
+    rows = [
+        {
+            "kind": f.kind,
+            "field": f.field,
+            "expected": f.expected,
+            "actual": f.actual,
+            "error": ("; ".join(f.errors))[:_MATRIX_ERROR_MAXLEN],
+            "file": f.file,
+            "line": f.line,
+        }
+        for f in report.failures[:max_items]
+    ]
+    return orjson.dumps(rows).decode()
+
+
+def artifact_validation_event_fields(
+    report: ArtifactValidationReport,
+    *,
+    artifact_field: str = "",
+    max_items: int = ARTIFACT_VALIDATION_MAX_ITEMS_PER_AXIS,
+) -> dict[str, str | int | bool]:
+    """Build the outcome event's attribute map from a report.
+
+    The single mapping site from report to telemetry, so the emitter cannot drift
+    from the allowlist. Every key returned here is in
+    ``logger_adaptor._KNOWN_EXTRA_KEYS``; anything absent from that allowlist is
+    dropped by ``_build_extra_dict`` and silently never reaches OTLP, which is why
+    ``tests/unit/validation/test_artifact_event_fields.py`` asserts this map against
+    the allowlist rather than against an emit call.
+
+    Every field is present on **every** outcome, negatives included — the matrix as
+    ``"[]"``. Emit with::
+
+        logger.info(
+            ARTIFACT_VALIDATION_EVENT,
+            app_name=...,
+            entrypoint=...,
+            **artifact_validation_event_fields(report, artifact_field=...),
+        )
+
+    Args:
+        report: The report to project.
+        artifact_field: Output-contract field name the artifact came from.
+            Declarations are keyed by ``(entrypoint, field)``, so this plus the
+            already-allowlisted ``entrypoint`` identifies the declaration exactly.
+            Nothing is inferred from path shape — path-shape inference is precisely
+            what made the earlier upload-time hook silently validate nothing.
+        max_items: Row cap for the matrix; shared with ``format_report``.
+
+    Returns:
+        Keyword arguments for the ``ARTIFACT_VALIDATION_EVENT`` log call.
+    """
+    return {
+        "outcome": report.outcome,
+        "reason": report.reason,
+        ARTIFACT_FORMAT_KEY: report.artifact_format,
+        ARTIFACT_SCHEMA_SOURCE_KEY: report.schema_source,
+        ARTIFACT_FIELD_KEY: artifact_field,
+        ARTIFACT_UNIT_KEY: report.unit,
+        ARTIFACT_TOTAL_KEY: report.total,
+        ARTIFACT_PASSED_KEY: report.passed,
+        ARTIFACT_FAILED_KEY: report.failed,
+        ARTIFACT_UNDECODABLE_KEY: report.undecodable,
+        ARTIFACT_FIELDS_DECLARED_KEY: report.fields_declared,
+        ARTIFACT_BOUNDARY_KEY: report.boundary,
+        ARTIFACT_VALIDATION_MATRIX_KEY: artifact_validation_matrix_json(
+            report, max_items=max_items
+        ),
+    }

--- a/application_sdk/validation/protocols.py
+++ b/application_sdk/validation/protocols.py
@@ -1,0 +1,155 @@
+"""The two plug-in seams of artifact validation (ADR-0020).
+
+The wrapper is thin on purpose: it takes an app-owned declaration, dispatches on
+format, and owns only the shared outcome (:mod:`application_sdk.validation.artifacts`).
+Everything that varies sits behind one of exactly two protocols, and **keeping them
+orthogonal is the load-bearing choice** — conflating "where does the declaration
+come from" with "how is this format checked" forces either a dataframe dependency
+or a hand-authored field list for the 500-type asset case:
+
+===================  ============================================  ==========================
+Seam                 Question                                      Plug-ins
+===================  ============================================  ==========================
+:class:`SchemaSource`   where does the declaration come from?      ``ModelSource``, ``ContractSource``
+:class:`FormatValidator` how is it checked for this format?        NDJSON (streaming), parquet (footer)
+===================  ============================================  ==========================
+
+The cross product is not uniformly implementable, and that is stated rather than
+guessed at: parquet x model is genuinely ``unsupported`` because a model carries no
+column mapping. :meth:`FormatValidator.supports` is where a cell says so, and the
+wrapper turns a ``False`` into an ``unsupported`` outcome — never into silence.
+
+``Protocol`` rather than an ABC so a plug-in is structurally typed: an app can
+supply its own source or validator without importing an SDK base class, and the
+SDK never has to enumerate implementations. Both are ``runtime_checkable`` so the
+wrapper can reject a mis-shaped plug-in at registration with a clear error instead
+of an ``AttributeError`` mid-scan; note that ``isinstance`` against a runtime
+protocol checks member *presence*, not signatures, so it is a guardrail rather than
+a type check.
+
+Everything here is synchronous. Validators are plain scans, so the one caller that
+must stay off the event loop — the activity interceptor — owns the offload decision
+(``run_in_thread``, or an isolated child process for the model path) rather than
+every validator re-deciding it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+
+from application_sdk.validation.artifacts import (
+    ArtifactDeclaration,
+    ArtifactValidationReport,
+)
+
+__all__ = ["FormatValidator", "SchemaSource"]
+
+
+@runtime_checkable
+class SchemaSource(Protocol):
+    """Where an artifact's declaration comes from.
+
+    Two implementations ship (FND-686): ``ContractSource`` loads the app's
+    generated ``app/generated/artifact_schemas.json`` — versioned, pinned,
+    statically diffable, readable by non-Python consumers — and ``ModelSource``
+    resolves to an executable typed model, so nothing is authored at all.
+
+    **There is no inline source**, and there will not be one: no literal field map,
+    no dict escape hatch, not even for a three-field artifact. Every declaration is
+    version-controlled. The contracts found in the field were prose comments spread
+    across each app's source — load-bearing, well written, and exactly the trap,
+    because a comment can faithfully document a workaround, so drift gets recorded
+    *as the spec*. A "just this once" inline map is how that state is reached.
+
+    An app whose storage facade bypasses the framework still calls the public
+    ``validate_artifact(...)`` entry point — it just passes a ``ContractSource``.
+    The escape hatch is about *where the call happens*, never about *where the
+    declaration lives*.
+    """
+
+    @property
+    def kind(self) -> str:
+        """Short stable identifier for telemetry: ``contract`` or ``model``.
+
+        Lands on the outcome event as ``artifact_schema_source``, so it is a
+        queryable value and must not be reworded once shipped.
+        """
+        ...
+
+    def resolve(self) -> ArtifactDeclaration | None:
+        """Load the declaration, or ``None`` when this artifact has none.
+
+        ``None`` is a first-class answer, not an error: it becomes the
+        ``not_declared`` outcome, a finding on an entrypoint's public boundary and
+        informational on an internal ``@task``. Either way it emits.
+
+        A *malformed or absent* declaration artifact must also degrade — to a
+        warning and an ``absent`` outcome — rather than raise into the caller. The
+        validation scaffold is defense in depth; it may never break a real hand-off.
+        """
+        ...
+
+
+@runtime_checkable
+class FormatValidator(Protocol):
+    """How one artifact format is checked against a resolved declaration.
+
+    Each format brings its own dependency floor, and the wrapper's whole point is
+    that the expensive mechanism is never on the cheap path:
+
+    * **NDJSON** streams line by line — one pass, constant memory, no dataframe,
+      stdlib and ``orjson`` only, so **zero new dependencies**.
+    * **parquet** reads the schema from the file footer and diffs it — *metadata
+      only, no rows read*. ``pyarrow`` is an extra, so it is imported lazily and
+      degrades to skip-with-warning when absent.
+
+    Answering "is ``START_TIME`` a timestamp?" by loading rows into a dataframe
+    pays a dataframe to do a metadata lookup and drags pandas into the runtime path
+    of callers that only ever see JSON. That is why this seam exists.
+    """
+
+    @property
+    def artifact_format(self) -> str:
+        """Short stable identifier for telemetry: ``ndjson``, ``parquet``.
+
+        Lands on the outcome event as ``artifact_format``.
+        """
+        ...
+
+    @property
+    def unit(self) -> str:
+        """What this validator counts — :data:`~application_sdk.validation.artifacts.UNIT_RECORD`
+        or :data:`~application_sdk.validation.artifacts.UNIT_COLUMN`.
+
+        Reported alongside the scalar counts so a consumer never has to infer the
+        unit from the format.
+        """
+        ...
+
+    def supports(self, declaration: ArtifactDeclaration) -> bool:
+        """Whether this format can check *this kind* of declaration.
+
+        The one cell that answers ``False`` today is parquet x model: a model
+        carries no column mapping, so a footer diff has nothing to diff against.
+        The wrapper turns ``False`` into an ``unsupported`` outcome — the cell says
+        so out loud rather than guessing or going quiet.
+        """
+        ...
+
+    def validate(
+        self, path: Path, declaration: ArtifactDeclaration
+    ) -> ArtifactValidationReport:
+        """Check the artifact at ``path`` and return the shared report shape.
+
+        Called only when :meth:`supports` returned True. **Every unit is examined**
+        — bounding applies to the report's two output surfaces, never to the scan,
+        so the scalar counts always describe the whole artifact.
+
+        A missing or unreadable artifact is an ``absent`` report
+        (:meth:`~application_sdk.validation.artifacts.ArtifactValidationReport.absent`),
+        not an exception: a validator that raises into a hand-off has broken the
+        very thing it was added to protect. A raise here is the wrapper's
+        "our validator broke" axis, which always fails open regardless of posture.
+        """
+        ...

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -1,8 +1,8 @@
 <!--
 generated-by:  capability-manifest skill (.claude/skills/capability-manifest)
-sdk-version:   3.28.2
-source-sha:    7f8e7fcfd8c4d0e3bdca99297c515e42606f3d72
-source-date:   2026-08-21T13:45:40+01:00
+sdk-version:   3.28.3
+source-sha:    fc4b272b8ccd28c598abc514cb57c30b4959a4c6
+source-date:   2026-08-24T20:25:58Z
 do-not-edit:   re-run the skill instead of hand-editing
 -->
 
@@ -29,13 +29,13 @@ do-not-edit:   re-run the skill instead of hand-editing
 | `application_sdk.handler` | HTTP handler framework — Handler ABC, DefaultHandler, preflight, auth, service factory | 22 |
 | `application_sdk.infrastructure` | Protocol-based infrastructure (StateStore, SecretStore, PubSub, Bindings, CapacityPool) | 38 |
 | `application_sdk.main` | Dev entry point — run_dev_combined() and AppConfig for local execution and container startup | 2 |
-| `application_sdk.observability` | Logging context — ExecutionContext, CorrelationContext, request/correlation helpers | 22 |
+| `application_sdk.observability` | Logging context — ExecutionContext, CorrelationContext, request/correlation helpers | 27 |
 | `application_sdk.outputs` | Output collectors and record models for Automation Engine | 4 |
 | `application_sdk.server` | FastAPI server, MCP integration, middleware, health endpoint | 4 |
 | `application_sdk.storage` | Object-store abstraction — factory, formats, batch, transfer, cloud bindings | 42 |
 | `application_sdk.templates` | SQL metadata extractor templates and their contracts | 6 |
 | `application_sdk.testing` | Test infrastructure — mocks, fixtures, hypothesis strategies, integration helpers | 97 |
-| `application_sdk.validation` | Offline asset validation — pyatlan_v9 .validate() wrappers, no network call | 5 |
+| `application_sdk.validation` | Offline artifact & asset validation — format-agnostic wrapper (ADR-0020) plus pyatlan_v9 .validate() wrappers, no network call | 30 |
 
 ## Subpackage Details
 
@@ -2586,12 +2586,47 @@ Logging context — ExecutionContext, CorrelationContext, request/correlation he
 
 ### Constants and Enums
 
+#### `ARTIFACT_VALIDATION_EVENT`
+
+- **Import:** `from application_sdk.observability.events import ARTIFACT_VALIDATION_EVENT`
+- **Signature:** `ARTIFACT_VALIDATION_EVENT: Final`
+- **Summary:** _(no docstring)_
+- **Defined in:** `application_sdk/observability/events.py`
+
+#### `ASSET_VALIDATION_EVENT`
+
+- **Import:** `from application_sdk.observability.events import ASSET_VALIDATION_EVENT`
+- **Signature:** `ASSET_VALIDATION_EVENT: Final`
+- **Summary:** _(no docstring)_
+- **Defined in:** `application_sdk/observability/events.py`
+
 #### `correlation_context`
 
 - **Import:** `from application_sdk.observability import correlation_context`
 - **Signature:** `correlation_context: ContextVar[dict[str, Any] | None]`
 - **Summary:** _(no docstring)_
 - **Defined in:** `application_sdk/observability/context.py`
+
+#### `OUTCOME_EVENT_NAMES`
+
+- **Import:** `from application_sdk.observability.events import OUTCOME_EVENT_NAMES`
+- **Signature:** `OUTCOME_EVENT_NAMES: Final[frozenset[str]]`
+- **Summary:** _(no docstring)_
+- **Defined in:** `application_sdk/observability/events.py`
+
+#### `PREFLIGHT_OUTCOME_EVENT`
+
+- **Import:** `from application_sdk.observability.events import PREFLIGHT_OUTCOME_EVENT`
+- **Signature:** `PREFLIGHT_OUTCOME_EVENT: Final`
+- **Summary:** _(no docstring)_
+- **Defined in:** `application_sdk/observability/events.py`
+
+#### `PREFLIGHT_POSTURE_EVENT`
+
+- **Import:** `from application_sdk.observability.events import PREFLIGHT_POSTURE_EVENT`
+- **Signature:** `PREFLIGHT_POSTURE_EVENT: Final`
+- **Summary:** _(no docstring)_
+- **Defined in:** `application_sdk/observability/events.py`
 
 #### `request_context`
 
@@ -3719,9 +3754,25 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 
 ## `application_sdk.validation`
 
-Offline asset validation — pyatlan_v9 .validate() wrappers, no network call
+Offline artifact & asset validation — format-agnostic wrapper (ADR-0020) plus pyatlan_v9 .validate() wrappers, no network call
 
 ### Classes
+
+#### `ArtifactValidationFailure`
+
+- **Import:** `from application_sdk.validation import ArtifactValidationFailure`
+- **Also importable from:** `application_sdk.validation.artifacts`
+- **Signature:** `class ArtifactValidationFailure(kind: ArtifactFailureKind, ...)`
+- **Summary:** One failing unit — a record that broke, or a column that disagreed.
+- **Defined in:** `application_sdk/validation/artifacts.py`
+
+#### `ArtifactValidationReport`
+
+- **Import:** `from application_sdk.validation import ArtifactValidationReport`
+- **Also importable from:** `application_sdk.validation.artifacts`
+- **Signature:** `class ArtifactValidationReport(artifact_format: str = '', ...)`
+- **Summary:** Aggregate outcome of validating one artifact against one declaration.
+- **Defined in:** `application_sdk/validation/artifacts.py`
 
 #### `AssetValidationFailure`
 
@@ -3737,6 +3788,38 @@ Offline asset validation — pyatlan_v9 .validate() wrappers, no network call
 - **Summary:** Aggregate outcome of validating a batch of transformed assets.
 - **Defined in:** `application_sdk/validation/assets.py`
 
+#### `DeclaredField`
+
+- **Import:** `from application_sdk.validation import DeclaredField`
+- **Also importable from:** `application_sdk.validation.artifacts`
+- **Signature:** `class DeclaredField(path: str, type: ArtifactFieldTypeExtended = 'any', required: bool = True)`
+- **Summary:** One field an app declares it requires of an artifact.
+- **Defined in:** `application_sdk/validation/artifacts.py`
+
+#### `FieldMapDeclaration`
+
+- **Import:** `from application_sdk.validation import FieldMapDeclaration`
+- **Also importable from:** `application_sdk.validation.artifacts`
+- **Signature:** `class FieldMapDeclaration(fields: tuple[DeclaredField, ...] = ())`
+- **Summary:** A declaration resolved to an explicit field map — the ``ContractSource`` shape.
+- **Defined in:** `application_sdk/validation/artifacts.py`
+
+#### `FormatValidator`
+
+- **Import:** `from application_sdk.validation import FormatValidator`
+- **Also importable from:** `application_sdk.validation.protocols`
+- **Signature:** `class FormatValidator`
+- **Summary:** How one artifact format is checked against a resolved declaration.
+- **Defined in:** `application_sdk/validation/protocols.py`
+
+#### `ModelDeclaration`
+
+- **Import:** `from application_sdk.validation import ModelDeclaration`
+- **Also importable from:** `application_sdk.validation.artifacts`
+- **Signature:** `class ModelDeclaration(model: type)`
+- **Summary:** A declaration resolved to an executable typed model — the ``ModelSource`` shape.
+- **Defined in:** `application_sdk/validation/artifacts.py`
+
 #### `ReferentialFailure`
 
 - **Import:** `from application_sdk.validation import ReferentialFailure`
@@ -3744,7 +3827,31 @@ Offline asset validation — pyatlan_v9 .validate() wrappers, no network call
 - **Summary:** A relationship reference whose target asset is absent from the batch.
 - **Defined in:** `application_sdk/validation/assets.py`
 
+#### `SchemaSource`
+
+- **Import:** `from application_sdk.validation import SchemaSource`
+- **Also importable from:** `application_sdk.validation.protocols`
+- **Signature:** `class SchemaSource`
+- **Summary:** Where an artifact's declaration comes from.
+- **Defined in:** `application_sdk/validation/protocols.py`
+
 ### Functions
+
+#### `artifact_validation_event_fields`
+
+- **Import:** `from application_sdk.validation import artifact_validation_event_fields`
+- **Also importable from:** `application_sdk.validation.artifacts`
+- **Signature:** `artifact_validation_event_fields(report: ArtifactValidationReport, *, ...)`
+- **Summary:** Build the outcome event's attribute map from a report.
+- **Defined in:** `application_sdk/validation/artifacts.py`
+
+#### `artifact_validation_matrix_json`
+
+- **Import:** `from application_sdk.validation import artifact_validation_matrix_json`
+- **Also importable from:** `application_sdk.validation.artifacts`
+- **Signature:** `artifact_validation_matrix_json(report: ArtifactValidationReport, *, ...)`
+- **Summary:** Compact per-failure drill-down for the outcome event, as one JSON string.
+- **Defined in:** `application_sdk/validation/artifacts.py`
 
 #### `validate_asset`
 
@@ -3759,6 +3866,125 @@ Offline asset validation — pyatlan_v9 .validate() wrappers, no network call
 - **Signature:** `validate_transformed_dir(path: str | Path, *, for_creation: bool = True, check_referential_integrity: bool = True)`
 - **Summary:** Validate every transformed-output asset under ``path``.
 - **Defined in:** `application_sdk/validation/assets.py`
+
+### Constants and Enums
+
+#### `ARTIFACT_FIELD_TYPES`
+
+- **Import:** `from application_sdk.validation.artifacts import ARTIFACT_FIELD_TYPES`
+- **Signature:** `ARTIFACT_FIELD_TYPES: Final[frozenset[str]]`
+- **Summary:** Runtime membership test for :data:`ArtifactFieldType`.
+- **Defined in:** `application_sdk/validation/artifacts.py`
+
+#### `ARTIFACT_FIELD_TYPES_EXTENDED`
+
+- **Import:** `from application_sdk.validation.artifacts import ARTIFACT_FIELD_TYPES_EXTENDED`
+- **Signature:** `ARTIFACT_FIELD_TYPES_EXTENDED: Final[frozenset[str]]`
+- **Summary:** Runtime membership test for :data:`ArtifactFieldTypeExtended`.
+- **Defined in:** `application_sdk/validation/artifacts.py`
+
+#### `ARTIFACT_VALIDATION_EVENT`
+
+- **Import:** `from application_sdk.validation.artifacts import ARTIFACT_VALIDATION_EVENT`
+- **Signature:** `ARTIFACT_VALIDATION_EVENT: Final`
+- **Summary:** _(no docstring)_
+- **Defined in:** `application_sdk/observability/events.py`
+
+#### `ARTIFACT_VALIDATION_OUTCOMES`
+
+- **Import:** `from application_sdk.validation.artifacts import ARTIFACT_VALIDATION_OUTCOMES`
+- **Signature:** `ARTIFACT_VALIDATION_OUTCOMES: Final[frozenset[str]]`
+- **Summary:** Runtime membership test for :data:`ArtifactValidationOutcome`.
+- **Defined in:** `application_sdk/validation/artifacts.py`
+
+#### `ArtifactDeclaration`
+
+- **Import:** `from application_sdk.validation import ArtifactDeclaration`
+- **Also importable from:** `application_sdk.validation.artifacts`
+- **Signature:** `ArtifactDeclaration`
+- **Summary:** Tagged union of what a :class:`~application_sdk.validation.protocols.SchemaSource`
+- **Defined in:** `application_sdk/validation/artifacts.py`
+
+#### `ArtifactFailureKind`
+
+- **Import:** `from application_sdk.validation import ArtifactFailureKind`
+- **Also importable from:** `application_sdk.validation.artifacts`
+- **Signature:** `ArtifactFailureKind`
+- **Summary:** Why one unit failed. ``missing``/``type_mismatch`` come from a field-map diff,
+- **Defined in:** `application_sdk/validation/artifacts.py`
+
+#### `ArtifactFieldType`
+
+- **Import:** `from application_sdk.validation import ArtifactFieldType`
+- **Also importable from:** `application_sdk.validation.artifacts`
+- **Signature:** `ArtifactFieldType`
+- **Summary:** The stable floor: types every validator must map, for every format.
+- **Defined in:** `application_sdk/validation/artifacts.py`
+
+#### `ArtifactFieldTypeExtended`
+
+- **Import:** `from application_sdk.validation import ArtifactFieldTypeExtended`
+- **Also importable from:** `application_sdk.validation.artifacts`
+- **Signature:** `ArtifactFieldTypeExtended`
+- **Summary:** Additive extension. Declarations use this, so a member can be declared before
+- **Defined in:** `application_sdk/validation/artifacts.py`
+
+#### `ArtifactValidationOutcome`
+
+- **Import:** `from application_sdk.validation import ArtifactValidationOutcome`
+- **Also importable from:** `application_sdk.validation.artifacts`
+- **Signature:** `ArtifactValidationOutcome`
+- **Summary:** Every artifact hand-off emits exactly one of these — the negatives included.
+- **Defined in:** `application_sdk/validation/artifacts.py`
+
+#### `OUTCOME_ABSENT`
+
+- **Import:** `from application_sdk.validation.artifacts import OUTCOME_ABSENT`
+- **Signature:** `OUTCOME_ABSENT: Final`
+- **Summary:** The artifact itself was not readable: missing, empty, or a malformed declaration
+- **Defined in:** `application_sdk/validation/artifacts.py`
+
+#### `OUTCOME_CLEAN`
+
+- **Import:** `from application_sdk.validation.artifacts import OUTCOME_CLEAN`
+- **Signature:** `OUTCOME_CLEAN: Final`
+- **Summary:** Checked against a declaration; nothing failed.
+- **Defined in:** `application_sdk/validation/artifacts.py`
+
+#### `OUTCOME_FLAGGED`
+
+- **Import:** `from application_sdk.validation.artifacts import OUTCOME_FLAGGED`
+- **Signature:** `OUTCOME_FLAGGED: Final`
+- **Summary:** Checked against a declaration; at least one unit failed.
+- **Defined in:** `application_sdk/validation/artifacts.py`
+
+#### `OUTCOME_NOT_DECLARED`
+
+- **Import:** `from application_sdk.validation.artifacts import OUTCOME_NOT_DECLARED`
+- **Signature:** `OUTCOME_NOT_DECLARED: Final`
+- **Summary:** No declaration exists for this artifact. Carries ``boundary``: a finding on an
+- **Defined in:** `application_sdk/validation/artifacts.py`
+
+#### `OUTCOME_UNSUPPORTED`
+
+- **Import:** `from application_sdk.validation.artifacts import OUTCOME_UNSUPPORTED`
+- **Signature:** `OUTCOME_UNSUPPORTED: Final`
+- **Summary:** A declaration exists but this (format x source) cell cannot check it — e.g.
+- **Defined in:** `application_sdk/validation/artifacts.py`
+
+#### `UNIT_COLUMN`
+
+- **Import:** `from application_sdk.validation.artifacts import UNIT_COLUMN`
+- **Signature:** `UNIT_COLUMN: Final`
+- **Summary:** Unit for the metadata-only formats, where the footer schema is diffed and no row
+- **Defined in:** `application_sdk/validation/artifacts.py`
+
+#### `UNIT_RECORD`
+
+- **Import:** `from application_sdk.validation.artifacts import UNIT_RECORD`
+- **Signature:** `UNIT_RECORD: Final`
+- **Summary:** Unit for the streaming per-record formats (NDJSON).
+- **Defined in:** `application_sdk/validation/artifacts.py`
 
 ## Contracts
 

--- a/docs/concepts/monitoring.md
+++ b/docs/concepts/monitoring.md
@@ -426,6 +426,44 @@ Emitting `outcome="clean"` too gives a denominator, so a dashboard can rank conn
 flag-rate rather than only seeing failures. Uploads with nothing to validate (validation disabled, or
 a non-`transformed/` path) emit no event.
 
+### Artifact-validation outcome event
+
+The generic artifact-validation wrapper ([ADR-0020](../adr/0020-artifact-validation.md)) emits
+`"Artifact validation outcome"` — one row per artifact hand-off, whatever the format and whichever
+schema source declared it.
+
+!!! note "Not yet emitted"
+
+    The attribute contract below ships ahead of its emitter: the wrapper's report, matrix and event
+    fields exist, but nothing calls them until the `FileReference` interceptor wiring lands. The
+    table is the reference for what the allowlist admits, not a description of rows you will find in
+    ClickHouse today.
+
+| Attribute | Meaning |
+|-----------|---------|
+| `outcome` | `clean`, `flagged`, `not_declared`, `unsupported` or `absent` |
+| `reason` | short explanation, chiefly for the three non-scan outcomes |
+| `artifact_format` | `ndjson`, `parquet` — empty when nothing was read |
+| `artifact_schema_source` | `contract` or `model` |
+| `artifact_field` | output-contract field the artifact came from; with `entrypoint` this keys the declaration |
+| `artifact_unit` | what the counts count: `record` (streaming scan) or `column` (footer diff) |
+| `artifact_total` | units examined — always the whole artifact, never a sample |
+| `artifact_passed` | units with no failure |
+| `artifact_failed` | units that failed |
+| `artifact_undecodable` | units that could not be parsed at all |
+| `artifact_fields_declared` | fields the declaration named (0 for a model declaration) |
+| `boundary` | whether the hand-off sits on an entrypoint's public interface |
+| `artifact_validation_matrix` | compact JSON array of per-failure detail (bounded rows), `JSONExtract`-able |
+
+Two properties are worth relying on. **Every hand-off emits**, the negative outcomes included — a
+check that reports nothing is indistinguishable from a check that passed, so `not_declared`,
+`unsupported` and `absent` are rows, not silence. And **every attribute is present on every
+outcome**, the matrix as `"[]"` when there is nothing to show, so a consumer parses it
+unconditionally instead of branching on presence.
+
+The event body and its attribute keys are a pinned contract, like the two preflight-gate events and
+the asset-validation one; all four names live in `application_sdk/observability/events.py`.
+
 ### Replay suppression
 
 `self.logger` suppresses log output during Temporal workflow replay by default, matching the behaviour of Temporal's native `workflow.logger`. This prevents duplicate bare lines (missing `workflow_id`/`run_id`) that would otherwise appear in Grafana when a worker replays history after a sticky-cache eviction.

--- a/tests/unit/observability/test_event_registry.py
+++ b/tests/unit/observability/test_event_registry.py
@@ -1,0 +1,81 @@
+"""The shared outcome-event name registry.
+
+These strings are the message *body* of a log line, and dashboards, alert rules and
+connector-pulse queries match on them exactly. Moving them into one module was the
+point of the registry; the risk the move introduces is that one of them gets
+"tidied" in transit, which no consumer would notice until a panel silently emptied.
+
+So the values are asserted literally here, and each emitting module is asserted to
+still expose the name it always exposed — a shipped consumer importing
+``preflight_gate.PREFLIGHT_OUTCOME_EVENT`` must keep working.
+"""
+
+from __future__ import annotations
+
+from application_sdk.observability import events
+
+
+def test_existing_names_moved_unchanged() -> None:
+    """The registry is a move, not a rename. Nothing here may ever be reworded."""
+    assert events.PREFLIGHT_OUTCOME_EVENT == "Preflight gate outcome"
+    assert events.PREFLIGHT_POSTURE_EVENT == "Preflight gate posture"
+    assert events.ASSET_VALIDATION_EVENT == "Transformed-asset validation outcome"
+
+
+def test_the_new_name_is_the_fourth() -> None:
+    assert events.ARTIFACT_VALIDATION_EVENT == "Artifact validation outcome"
+    assert len(events.OUTCOME_EVENT_NAMES) == 4
+
+
+def test_names_are_distinct() -> None:
+    """Two events sharing a body are indistinguishable downstream."""
+    names = [
+        events.PREFLIGHT_OUTCOME_EVENT,
+        events.PREFLIGHT_POSTURE_EVENT,
+        events.ASSET_VALIDATION_EVENT,
+        events.ARTIFACT_VALIDATION_EVENT,
+    ]
+    assert len(set(names)) == len(names)
+    assert all(name.strip() for name in names)
+
+
+def test_registry_is_the_full_set() -> None:
+    assert events.OUTCOME_EVENT_NAMES == {
+        events.PREFLIGHT_OUTCOME_EVENT,
+        events.PREFLIGHT_POSTURE_EVENT,
+        events.ASSET_VALIDATION_EVENT,
+        events.ARTIFACT_VALIDATION_EVENT,
+    }
+
+
+def test_emitting_modules_still_export_their_names() -> None:
+    """v3 has shipped: an existing import site must not break on the move."""
+    from application_sdk.app.base import ASSET_VALIDATION_EVENT
+    from application_sdk.execution._temporal.preflight_gate import (
+        PREFLIGHT_OUTCOME_EVENT,
+        PREFLIGHT_POSTURE_EVENT,
+    )
+
+    assert PREFLIGHT_OUTCOME_EVENT == events.PREFLIGHT_OUTCOME_EVENT
+    assert PREFLIGHT_POSTURE_EVENT == events.PREFLIGHT_POSTURE_EVENT
+    assert ASSET_VALIDATION_EVENT == events.ASSET_VALIDATION_EVENT
+
+
+def test_the_registry_imports_nothing_from_the_sdk() -> None:
+    """A caller that only needs to *name* an event must not pay for the exporter
+    stack ``logger_adaptor`` pulls in."""
+    import ast
+    from pathlib import Path
+
+    tree = ast.parse(Path(events.__file__).read_text())
+    imported = {
+        node.module.split(".")[0]
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom) and node.module
+    } | {
+        alias.name.split(".")[0]
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Import)
+        for alias in node.names
+    }
+    assert imported <= {"typing", "__future__"}

--- a/tests/unit/validation/test_artifact_dependency_floor.py
+++ b/tests/unit/validation/test_artifact_dependency_floor.py
@@ -1,0 +1,54 @@
+"""The validation package's standing dependency floor (ADR-0020).
+
+No ``pyarrow``, ``pandas`` or ``pandera`` anywhere in ``application_sdk/validation``.
+Two reasons, and neither expires:
+
+* **Cost must match the question.** "Is ``START_TIME`` a timestamp?" is answered by
+  one parquet footer read. Answering it with a dataframe pays a dataframe to do a
+  metadata lookup and drags pandas into the runtime path of callers that only ever
+  see JSON — wrong memory profile, wrong CVE footprint. When the parquet validator
+  lands it imports ``pyarrow`` **lazily, inside the function**, so a JSON-only
+  caller never pays for it; a module-level import would defeat that and is what
+  this test catches.
+* **pandera stays test-only.** Value ranges, record counts and statistical checks
+  are exactly right there and wrong on the runtime path.
+
+Checked statically over the source, so the result does not depend on what an
+earlier test in the session happened to import.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+import application_sdk.validation as validation_pkg
+
+FORBIDDEN = {"pyarrow", "pandas", "pandera"}
+
+_PACKAGE_ROOT = Path(validation_pkg.__file__).parent
+_MODULES = sorted(_PACKAGE_ROOT.rglob("*.py"))
+
+
+def _imported_roots(tree: ast.AST) -> set[str]:
+    """Every top-level package name this module imports, at any nesting depth."""
+    roots: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            roots.update(alias.name.split(".")[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module and node.level == 0:
+            roots.add(node.module.split(".")[0])
+    return roots
+
+
+def test_the_package_has_modules_to_check() -> None:
+    """Guard against the glob silently matching nothing and the suite passing."""
+    assert len(_MODULES) >= 4
+
+
+@pytest.mark.parametrize("module", _MODULES, ids=lambda p: p.name)
+def test_no_dataframe_dependency(module: Path) -> None:
+    found = _imported_roots(ast.parse(module.read_text())) & FORBIDDEN
+    assert not found, f"{module.name} imports {sorted(found)} — see ADR-0020"

--- a/tests/unit/validation/test_artifact_event_fields.py
+++ b/tests/unit/validation/test_artifact_event_fields.py
@@ -1,0 +1,145 @@
+"""The artifact-validation outcome event must actually reach OTLP.
+
+Emitting a queryable event is a three-part contract — a pinned name constant, an
+attribute-key constant, and entries in ``_KNOWN_EXTRA_KEYS`` — and getting two of
+the three right fails *silently*: loguru accepts the kwargs, the log line looks
+correct locally, and ``_build_extra_dict`` drops the unlisted keys on the floor
+before the exporter ever sees them.
+
+So these tests assert against the allowlist and against ``_build_extra_dict``
+itself, not against a mocked emit call. A mock records whatever it is handed; only
+the filter can tell you the field survives.
+"""
+
+from __future__ import annotations
+
+import orjson
+
+from application_sdk.observability.events import (
+    ARTIFACT_VALIDATION_EVENT,
+    OUTCOME_EVENT_NAMES,
+)
+from application_sdk.observability.logger_adaptor import (
+    _KNOWN_EXTRA_KEYS,
+    _build_extra_dict,
+)
+from application_sdk.validation.artifacts import (
+    ArtifactValidationFailure,
+    ArtifactValidationReport,
+    artifact_validation_event_fields,
+)
+
+
+def _flagged() -> ArtifactValidationReport:
+    return ArtifactValidationReport(
+        artifact_format="ndjson",
+        schema_source="contract",
+        unit="record",
+        fields_declared=4,
+        total=1000,
+        passed=999,
+        boundary=True,
+        failures=[
+            ArtifactValidationFailure(
+                kind="type_mismatch",
+                field="START_TIME",
+                expected="timestamp",
+                actual="string",
+                file="query_history.ndjson",
+                line=41,
+                errors=["declared timestamp, found string"],
+            )
+        ],
+    )
+
+
+_REPORTS: dict[str, ArtifactValidationReport] = {
+    "flagged": _flagged(),
+    "clean": ArtifactValidationReport(
+        artifact_format="ndjson",
+        schema_source="contract",
+        unit="record",
+        fields_declared=4,
+        total=1000,
+        passed=1000,
+    ),
+    "not_declared": ArtifactValidationReport.not_declared(boundary=True),
+    "unsupported": ArtifactValidationReport.unsupported(
+        artifact_format="parquet",
+        schema_source="model",
+        reason="a model carries no column mapping",
+    ),
+    "absent": ArtifactValidationReport.absent(reason="artifact not found"),
+}
+
+
+def test_every_event_key_is_on_the_allowlist() -> None:
+    for outcome, report in _REPORTS.items():
+        fields = artifact_validation_event_fields(
+            report, artifact_field="query_history"
+        )
+        unlisted = set(fields) - _KNOWN_EXTRA_KEYS
+        assert not unlisted, f"{outcome}: keys dropped before OTLP: {sorted(unlisted)}"
+
+
+def test_every_event_field_survives_build_extra_dict() -> None:
+    """The real filter, not a mock: this is what runs between loguru and the exporter."""
+    for outcome, report in _REPORTS.items():
+        fields = artifact_validation_event_fields(
+            report, artifact_field="query_history"
+        )
+        survived = _build_extra_dict(dict(fields))
+        assert survived == fields, f"{outcome}: {set(fields) - set(survived)} dropped"
+
+
+def test_the_attribute_set_is_identical_across_outcomes() -> None:
+    """Including the negatives — a consumer never branches on which keys exist."""
+    shapes = {
+        outcome: sorted(artifact_validation_event_fields(report))
+        for outcome, report in _REPORTS.items()
+    }
+    assert len(set(map(tuple, shapes.values()))) == 1, shapes
+
+
+def test_matrix_is_present_on_every_outcome() -> None:
+    for outcome, report in _REPORTS.items():
+        fields = artifact_validation_event_fields(report)
+        matrix = fields["artifact_validation_matrix"]
+        assert isinstance(matrix, str)
+        assert isinstance(orjson.loads(matrix), list), outcome
+    assert (
+        artifact_validation_event_fields(_REPORTS["clean"])[
+            "artifact_validation_matrix"
+        ]
+        == "[]"
+    )
+
+
+def test_fields_project_the_report_faithfully() -> None:
+    fields = artifact_validation_event_fields(
+        _flagged(), artifact_field="query_history"
+    )
+    assert fields["outcome"] == "flagged"
+    assert fields["artifact_format"] == "ndjson"
+    assert fields["artifact_schema_source"] == "contract"
+    assert fields["artifact_field"] == "query_history"
+    assert fields["artifact_unit"] == "record"
+    assert fields["artifact_total"] == 1000
+    assert fields["artifact_passed"] == 999
+    assert fields["artifact_failed"] == 1
+    assert fields["artifact_undecodable"] == 0
+    assert fields["artifact_fields_declared"] == 4
+    assert fields["boundary"] is True
+
+
+def test_boundary_is_reported_on_every_outcome_not_just_not_declared() -> None:
+    internal = artifact_validation_event_fields(
+        ArtifactValidationReport.not_declared(boundary=False)
+    )
+    assert internal["boundary"] is False
+    assert "boundary" in artifact_validation_event_fields(_REPORTS["clean"])
+
+
+def test_event_name_is_pinned_in_the_registry() -> None:
+    assert ARTIFACT_VALIDATION_EVENT == "Artifact validation outcome"
+    assert ARTIFACT_VALIDATION_EVENT in OUTCOME_EVENT_NAMES

--- a/tests/unit/validation/test_artifact_report.py
+++ b/tests/unit/validation/test_artifact_report.py
@@ -1,0 +1,369 @@
+"""Tests for the shared artifact-validation outcome surface (ADR-0020).
+
+The two properties worth defending here are the ones a later change would break
+quietly:
+
+* **Two-tier bounding.** The scan is unbounded — every unit is examined and the
+  scalar counts always describe the whole artifact — while the two *output*
+  surfaces are capped by one shared constant, so the human report and the telemetry
+  matrix can never drift apart.
+* **No silent no-op.** Every hand-off resolves to exactly one outcome from the
+  fixed vocabulary, the negatives included, and the matrix attribute is present
+  even when empty so consumers never branch on its presence.
+"""
+
+from __future__ import annotations
+
+import orjson
+import pytest
+
+from application_sdk.constants import (
+    ARTIFACT_VALIDATION_MAX_ITEMS_PER_AXIS,
+    ASSET_VALIDATION_MAX_ITEMS_PER_AXIS,
+)
+from application_sdk.validation.artifacts import (
+    ARTIFACT_FIELD_TYPES,
+    ARTIFACT_FIELD_TYPES_EXTENDED,
+    ARTIFACT_VALIDATION_OUTCOMES,
+    OUTCOME_ABSENT,
+    OUTCOME_CLEAN,
+    OUTCOME_FLAGGED,
+    OUTCOME_NOT_DECLARED,
+    OUTCOME_UNSUPPORTED,
+    UNIT_COLUMN,
+    UNIT_RECORD,
+    ArtifactValidationFailure,
+    ArtifactValidationReport,
+    DeclaredField,
+    FieldMapDeclaration,
+    ModelDeclaration,
+    artifact_validation_matrix_json,
+)
+
+CAP = ARTIFACT_VALIDATION_MAX_ITEMS_PER_AXIS
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _mismatch(index: int) -> ArtifactValidationFailure:
+    """A type-mismatch row — the failure the capability exists to catch."""
+    return ArtifactValidationFailure(
+        kind="type_mismatch",
+        field="START_TIME",
+        expected="timestamp",
+        actual="string",
+        file="query_history.ndjson",
+        line=index,
+        errors=["declared timestamp, found string"],
+    )
+
+
+def _undecodable(index: int) -> ArtifactValidationFailure:
+    return ArtifactValidationFailure(
+        kind="undecodable",
+        file="query_history.ndjson",
+        line=index,
+        errors=["not valid JSON"],
+    )
+
+
+def _scanned(
+    *, failures: list[ArtifactValidationFailure], total: int
+) -> ArtifactValidationReport:
+    """A report from a scan that examined ``total`` records."""
+    failing_lines = {f.line for f in failures}
+    return ArtifactValidationReport(
+        artifact_format="ndjson",
+        schema_source="contract",
+        unit=UNIT_RECORD,
+        fields_declared=4,
+        total=total,
+        passed=total - len(failing_lines),
+        failures=failures,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Outcome derivation
+# ---------------------------------------------------------------------------
+
+
+def test_clean_scan_is_clean_and_ok() -> None:
+    report = _scanned(failures=[], total=1000)
+    assert report.outcome == OUTCOME_CLEAN
+    assert report.ok
+    assert report.failed == 0
+    assert report.undecodable == 0
+
+
+def test_any_failure_flags_the_report() -> None:
+    report = _scanned(failures=[_mismatch(7)], total=1000)
+    assert report.outcome == OUTCOME_FLAGGED
+    assert not report.ok
+    assert report.failed == 1
+
+
+def test_outcome_is_derived_not_stored_for_a_scan() -> None:
+    """A derived outcome cannot disagree with the failure list it summarises."""
+    report = _scanned(failures=[], total=10)
+    assert report.outcome == OUTCOME_CLEAN
+    report.failures.append(_mismatch(3))
+    assert report.outcome == OUTCOME_FLAGGED
+
+
+def test_not_declared_carries_the_boundary_axis() -> None:
+    finding = ArtifactValidationReport.not_declared(boundary=True)
+    informational = ArtifactValidationReport.not_declared(boundary=False)
+    assert finding.outcome == informational.outcome == OUTCOME_NOT_DECLARED
+    assert finding.boundary is True
+    assert informational.boundary is False
+    # Both emit; neither is silent.
+    assert finding.ok and informational.ok
+
+
+def test_unsupported_names_the_cell_that_cannot_check() -> None:
+    report = ArtifactValidationReport.unsupported(
+        artifact_format="parquet",
+        schema_source="model",
+        reason="a model carries no column mapping",
+    )
+    assert report.outcome == OUTCOME_UNSUPPORTED
+    assert report.artifact_format == "parquet"
+    assert report.schema_source == "model"
+
+
+def test_absent_is_a_reported_outcome_not_an_exception() -> None:
+    report = ArtifactValidationReport.absent(reason="artifact not found")
+    assert report.outcome == OUTCOME_ABSENT
+    assert report.reason == "artifact not found"
+
+
+@pytest.mark.parametrize(
+    "report",
+    [
+        _scanned(failures=[], total=1),
+        _scanned(failures=[_mismatch(1)], total=1),
+        ArtifactValidationReport.not_declared(boundary=True),
+        ArtifactValidationReport.unsupported(
+            artifact_format="parquet", schema_source="model", reason="r"
+        ),
+        ArtifactValidationReport.absent(reason="r"),
+    ],
+)
+def test_every_report_resolves_to_a_vocabulary_outcome(
+    report: ArtifactValidationReport,
+) -> None:
+    assert report.outcome in ARTIFACT_VALIDATION_OUTCOMES
+
+
+def test_outcome_vocabulary_is_exactly_the_five_adr_values() -> None:
+    assert ARTIFACT_VALIDATION_OUTCOMES == {
+        "clean",
+        "flagged",
+        "not_declared",
+        "unsupported",
+        "absent",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Counts
+# ---------------------------------------------------------------------------
+
+
+def test_failed_counts_units_not_failure_rows() -> None:
+    """One record breaking on two fields is one failed record, two matrix rows."""
+    two_fields_one_record = [
+        ArtifactValidationFailure(
+            kind="type_mismatch", field="START_TIME", line=4, expected="timestamp"
+        ),
+        ArtifactValidationFailure(
+            kind="missing", field="END_TIME", line=4, expected="timestamp"
+        ),
+    ]
+    report = _scanned(failures=two_fields_one_record, total=10)
+    assert report.failed == 1
+    assert len(report.failures) == 2
+    assert report.passed + report.failed == report.total
+
+
+def test_undecodable_is_derived_from_the_failure_list() -> None:
+    report = _scanned(
+        failures=[_mismatch(1), _undecodable(2), _undecodable(3)], total=9
+    )
+    assert report.undecodable == 2
+
+
+def test_the_scan_is_never_sampled() -> None:
+    """Bounding is an output concern: the counts describe the whole artifact."""
+    failures = [_mismatch(i) for i in range(1, CAP * 4 + 1)]
+    report = _scanned(failures=failures, total=100_000)
+    assert report.total == 100_000
+    assert report.failed == CAP * 4
+    assert len(report.failures) == CAP * 4
+
+
+# ---------------------------------------------------------------------------
+# Bounding — the human report
+# ---------------------------------------------------------------------------
+
+
+def test_format_report_lists_at_most_max_items() -> None:
+    report = _scanned(failures=[_mismatch(i) for i in range(1, 101)], total=1000)
+    listed = [
+        line for line in report.format_report().splitlines() if "TYPE_MISMATCH" in line
+    ]
+    assert len(listed) == CAP
+
+
+def test_format_report_headline_reflects_the_full_batch() -> None:
+    report = _scanned(failures=[_mismatch(i) for i in range(1, 101)], total=1000)
+    headline = report.format_report().splitlines()[0]
+    assert "900/1000 records passed" in headline
+    assert "100 failed" in headline
+
+
+def test_overflow_is_split_by_kind() -> None:
+    """A tail of undecodable records must not be miscounted as type mismatches."""
+    failures = [_mismatch(i) for i in range(1, CAP + 6)]
+    failures += [_undecodable(i) for i in range(CAP + 6, CAP + 11)]
+    report = _scanned(failures=failures, total=1000)
+    overflow = [
+        line for line in report.format_report().splitlines() if "... and" in line
+    ]
+    assert overflow == [
+        "  ... and 5 more type_mismatch",
+        "  ... and 5 more undecodable",
+    ]
+
+
+def test_no_overflow_line_when_everything_fits() -> None:
+    report = _scanned(failures=[_mismatch(1)], total=10)
+    assert "... and" not in report.format_report()
+
+
+def test_format_report_renders_the_declared_and_found_types() -> None:
+    report = _scanned(failures=[_mismatch(7)], total=10)
+    body = report.format_report()
+    assert "START_TIME" in body
+    assert "declared timestamp, found string" in body
+    assert "(query_history.ndjson:7)" in body
+
+
+def test_non_scan_outcomes_render_a_single_line() -> None:
+    boundary = ArtifactValidationReport.not_declared(boundary=True).format_report()
+    internal = ArtifactValidationReport.not_declared(boundary=False).format_report()
+    assert boundary.splitlines() == [
+        "Artifact validation: not_declared (boundary) — no artifact schema declared"
+    ]
+    assert "(internal)" in internal
+
+
+# ---------------------------------------------------------------------------
+# Bounding — the telemetry matrix
+# ---------------------------------------------------------------------------
+
+
+def test_matrix_is_always_present_even_when_empty() -> None:
+    """Consumers parse it unconditionally rather than branching on presence."""
+    assert artifact_validation_matrix_json(_scanned(failures=[], total=10)) == "[]"
+    assert (
+        artifact_validation_matrix_json(
+            ArtifactValidationReport.not_declared(boundary=True)
+        )
+        == "[]"
+    )
+    assert (
+        artifact_validation_matrix_json(ArtifactValidationReport.absent(reason="r"))
+        == "[]"
+    )
+
+
+def test_matrix_row_shape_is_fixed() -> None:
+    rows = orjson.loads(
+        artifact_validation_matrix_json(_scanned(failures=[_mismatch(7)], total=10))
+    )
+    assert rows == [
+        {
+            "kind": "type_mismatch",
+            "field": "START_TIME",
+            "expected": "timestamp",
+            "actual": "string",
+            "error": "declared timestamp, found string",
+            "file": "query_history.ndjson",
+            "line": 7,
+        }
+    ]
+
+
+def test_matrix_is_bounded_to_max_items() -> None:
+    report = _scanned(failures=[_mismatch(i) for i in range(1, 501)], total=10_000)
+    assert len(orjson.loads(artifact_validation_matrix_json(report))) == CAP
+
+
+def test_matrix_truncates_a_pathological_message() -> None:
+    report = _scanned(
+        failures=[
+            ArtifactValidationFailure(kind="invalid", errors=["x" * 5000], line=1)
+        ],
+        total=1,
+    )
+    (row,) = orjson.loads(artifact_validation_matrix_json(report))
+    assert len(row["error"]) == 300
+
+
+def test_report_and_matrix_share_one_cap() -> None:
+    """The whole point of the shared constant: these two can never drift."""
+    report = _scanned(failures=[_mismatch(i) for i in range(1, 501)], total=10_000)
+    listed = sum(
+        1 for line in report.format_report().splitlines() if "TYPE_MISMATCH" in line
+    )
+    assert listed == len(orjson.loads(artifact_validation_matrix_json(report)))
+
+
+def test_asset_cap_is_the_same_number_by_construction() -> None:
+    """Asset validation is one cell of the wrapper; two editable 25s would drift."""
+    assert ASSET_VALIDATION_MAX_ITEMS_PER_AXIS == ARTIFACT_VALIDATION_MAX_ITEMS_PER_AXIS
+
+
+# ---------------------------------------------------------------------------
+# Declarations and the type vocabulary
+# ---------------------------------------------------------------------------
+
+
+def test_field_map_declaration_counts_its_fields() -> None:
+    declaration = FieldMapDeclaration(
+        fields=(
+            DeclaredField(path="START_TIME", type="timestamp"),
+            DeclaredField(path="CREDITS", type="decimal"),
+            DeclaredField(path="payload.rows", type="array", required=False),
+        )
+    )
+    assert declaration.field_count == 3
+    assert declaration.fields[2].required is False
+
+
+def test_declared_field_defaults_to_presence_only() -> None:
+    """``any`` lets a thin declaration assert presence without inventing a type."""
+    assert DeclaredField(path="ID").type == "any"
+    assert DeclaredField(path="ID").required is True
+
+
+def test_model_declaration_enumerates_nothing() -> None:
+    declaration = ModelDeclaration(model=dict)
+    assert declaration.field_count == 0
+    assert declaration.model is dict
+
+
+def test_extended_vocabulary_layers_additively_on_the_floor() -> None:
+    assert ARTIFACT_FIELD_TYPES < ARTIFACT_FIELD_TYPES_EXTENDED
+    assert {"string", "timestamp", "any"} <= ARTIFACT_FIELD_TYPES
+    assert "decimal" in ARTIFACT_FIELD_TYPES_EXTENDED
+    assert "decimal" not in ARTIFACT_FIELD_TYPES
+
+
+def test_unit_vocabulary() -> None:
+    assert (UNIT_RECORD, UNIT_COLUMN) == ("record", "column")


### PR DESCRIPTION
Step 1 of the [ADR-0020](https://github.com/atlanhq/application-sdk/blob/main/docs/adr/0020-artifact-validation.md) sequence ([FND-684](https://linear.app/atlan-epd/issue/FND-684)). Pure addition — no schema sources, no format validators, no interceptor hook, **zero behaviour change**. Nothing emits the new event yet.

## What lands

**The two plug-in seams** — `SchemaSource` and `FormatValidator` (`validation/protocols.py`). Deliberately orthogonal: conflating "where does the declaration come from" with "how is this format checked" is what forces either a dataframe dependency or a hand-authored field list for the 500-type asset case. `FormatValidator.supports()` is where the parquet × model cell says `unsupported` out loud instead of guessing.

**One report shape** — `ArtifactValidationReport`, mirroring `AssetValidationReport`: scalar counts, a bounded failure list, `ok`/`failed`, `format_report(*, max_items=...)`. For a scan the outcome is *derived* from the failure list, so "reported clean" and "found nothing wrong" cannot come apart; the three non-scan outcomes are built through named constructors that pin the verdict.

**Two-tier bounding, one constant.** The scan stays unbounded — every unit examined, counts always describe the whole artifact — and only the two *output* surfaces are capped. The cap is now `ARTIFACT_VALIDATION_MAX_ITEMS_PER_AXIS`, with `ASSET_VALIDATION_MAX_ITEMS_PER_AXIS` **aliased onto it**: asset validation is one format × source cell of this wrapper, and two independently editable `25`s is exactly the drift a single shared cap exists to prevent. The matrix is always present, `"[]"` included, so consumers never branch on presence.

**The outcome event's three-part contract** — pinned name, attribute-key constants, `_KNOWN_EXTRA_KEYS` entries. Getting two of the three right fails *silently*: loguru accepts the kwargs, the line looks right locally, and `_build_extra_dict` drops the unlisted keys before the exporter sees them. So the test asserts the field map against the allowlist **and through `_build_extra_dict` itself**, not against a mocked emit call.

**The shared event-name registry.** `app/base.py` said it was worth adding "only once a third such event exists" — there are three, and this is the fourth. The existing names move into `observability/events.py` **unchanged**, and every emitting module still exports the identifier it always did (asserted in tests): dashboards and alert rules key off the exact strings, and v3 has shipped consumers. `events.py` imports nothing — a caller that only needs to *name* an event should not pay for the OTLP exporter stack `logger_adaptor` pulls in.

## Outcome vocabulary

`clean` · `flagged` · `not_declared` (with `boundary: true|false`) · `unsupported` · `absent`. Every one of them emits, and every attribute is present on every outcome. A check that reports nothing is indistinguishable from a check that passed — that ambiguity is what let the earlier upload-time hook look adopted while validating zero records.

## Design calls worth a look

- **`failed` counts units, not failure rows.** A record can break on several fields at once, so `failed == total - passed` and `len(failures)` is the (larger) problem-row count. `undecodable` is derived from the failure list rather than tracked beside it, so the two cannot disagree.
- **`boundary` is emitted on every outcome, not only `not_declared`.** Same reasoning as the always-present matrix: presence-branching is the failure mode.
- **The logical-type vocabulary is included** (`ArtifactFieldType` / `ArtifactFieldTypeExtended` + runtime frozensets). Slightly beyond the ticket's literal bullet list, but `DeclaredField.type` needs a real type and a bare `str` would have been the loose-typing escape hatch. FND-685 mirrors these in pkl.
- **Everything is synchronous.** Validators are plain scans so the one caller that must stay off the event loop — the activity interceptor — owns the offload decision, rather than every validator re-deciding it.

## Testing

- `tests/unit/validation/test_artifact_report.py` — outcome derivation, unit-vs-row counting, report bounding **including the overflow split by kind**, matrix shape/truncation, and an assertion that the report listing and the matrix bound to the same number.
- `tests/unit/validation/test_artifact_event_fields.py` — allowlist survival through the real filter, plus an identical-attribute-set-across-outcomes check.
- `tests/unit/validation/test_artifact_dependency_floor.py` — static AST scan: no `pyarrow` / `pandas` / `pandera` anywhere in `application_sdk/validation`. Static rather than `sys.modules`-based so the result does not depend on what an earlier test imported.
- `tests/unit/observability/test_event_registry.py` — the moved names are byte-identical, distinct, and still importable from their original modules.

`tests/unit`: 7538 passed. `uv run pre-commit run --all-files` clean. Conformance (`detect --scope sdk`) reports nothing on the new files.

## Not in scope

No conceptual doc under `docs/concepts/` yet — there is no public `validate_artifact(...)` to document until FND-686/FND-691. `docs/concepts/monitoring.md` does gain the event's attribute table, explicitly labelled as shipping ahead of its emitter.
