### PR TITLE
feat(contract-toolkit): declare artifact schemas for data hand-offs (FND-685)

### DIFF
--- a/contract-toolkit/CLAUDE.md
+++ b/contract-toolkit/CLAUDE.md
@@ -63,7 +63,7 @@ demonstrates distinct feature surface, verified by `tests/*.pkl`.
 - `connection-ref`: `ConnectionRefInput` widget, `pipeline.publish = null`.
 - `publish-controls`: publish toggles, `includeInputFields`, `errorHandling`.
 - `fanin`: multi-parent fan-in via `dependsOn`, explicit `DependencyCondition`.
-- `artifact-schemas`: `artifactSchemas` data hand-off declarations — parquet + NDJSON, dotted nested paths, an input artifact.
+- `artifact-schemas`: `artifactSchemas` data hand-off declarations — parquet + NDJSON, nested paths, arrays of structs (`[]` element step), an input artifact.
 
 ## Editing Rules
 

--- a/contract-toolkit/CLAUDE.md
+++ b/contract-toolkit/CLAUDE.md
@@ -19,6 +19,7 @@ Contracts generate — from one `pkl eval -m . contract/app.pkl` at repo root:
 - `app/generated/atlan-connectors-{name}.json` — credential config
 - `app/generated/manifest.json` — Automation Engine DAG
 - `app/generated/_input.py` — typed SDK input model
+- `app/generated/artifact_schemas.json` — data hand-off declarations (only when `artifactSchemas` is non-empty)
 
 ## Main Files
 
@@ -62,6 +63,7 @@ demonstrates distinct feature surface, verified by `tests/*.pkl`.
 - `connection-ref`: `ConnectionRefInput` widget, `pipeline.publish = null`.
 - `publish-controls`: publish toggles, `includeInputFields`, `errorHandling`.
 - `fanin`: multi-parent fan-in via `dependsOn`, explicit `DependencyCondition`.
+- `artifact-schemas`: `artifactSchemas` data hand-off declarations — parquet + NDJSON, dotted nested paths, an input artifact.
 
 ## Editing Rules
 

--- a/contract-toolkit/README.md
+++ b/contract-toolkit/README.md
@@ -106,7 +106,7 @@ The `examples/` directory contains executable contracts that teach stable toolki
 - [`examples/fanin/`](examples/fanin/) — multi-parent fan-in via `dependsOn`, explicit `DependencyCondition`.
 - [`examples/agent-e2e/`](examples/agent-e2e/) — agent/SDR e2e codegen: `_e2e_credential.py` emits both `<Name>CredentialBody` (direct) and `<Name>AgentCredentialBody` (lightweight), plus an `extraction-method` ConditionalInput whose `overrideEnum` widens the substitutions `Literal` to `["direct", "agent"]`.
 - [`examples/scheduled/`](examples/scheduled/) — cron background job via `schedules`; renders `triggers.schedules` into `manifest.json` (multiple schedules, non-UTC timezone, a `PAUSED` one). See [Schedules](docs/reference.md#schedules-background-jobs).
-- [`examples/artifact-schemas/`](examples/artifact-schemas/) — data hand-off declarations via `artifactSchemas`; renders `app/generated/artifact_schemas.json` (parquet + NDJSON, dotted nested paths, an input artifact). See [Artifact Schemas](docs/reference.md#artifact-schemas-data-hand-off-declarations).
+- [`examples/artifact-schemas/`](examples/artifact-schemas/) — data hand-off declarations via `artifactSchemas`; renders `app/generated/artifact_schemas.json` (parquet + NDJSON, nested paths, arrays of structs via the `[]` element step, an input artifact). See [Artifact Schemas](docs/reference.md#artifact-schemas-data-hand-off-declarations).
 
 ## What Gets Generated
 
@@ -190,8 +190,12 @@ string where the consumer expects a timestamp is reported instead of flowing on.
 The toolkit is transport, not owner: it fixes the logical type vocabulary
 (`string`/`int`/`float`/`bool`/`timestamp`/`date`/`json`/`any`, plus the additive
 `decimal`/`binary`/`time`/`array`/`struct`/`map`) and the file shape; every field is
-authored by the app. Nested payloads are dotted paths plus a container type, not a
-recursive grammar.
+authored by the app. Nested payloads are paths plus a container type, not a recursive
+grammar: `.name` descends into a container's named member and `[]` descends into an
+array's element, so an array of structs is `columns` (`array`) → `columns[]` (`struct`)
+→ `columns[].name` (`string`). Every path prefix must be declared, with a type that can
+hold what the path descends into — otherwise a producer that flattened the container
+away would still pass on the leaf assertion alone.
 
 Every field must carry a non-empty `description`. A declaration is read by whoever is
 debugging the hand-off that just failed, and a bare `name` + `type` pair states the

--- a/contract-toolkit/README.md
+++ b/contract-toolkit/README.md
@@ -106,6 +106,7 @@ The `examples/` directory contains executable contracts that teach stable toolki
 - [`examples/fanin/`](examples/fanin/) — multi-parent fan-in via `dependsOn`, explicit `DependencyCondition`.
 - [`examples/agent-e2e/`](examples/agent-e2e/) — agent/SDR e2e codegen: `_e2e_credential.py` emits both `<Name>CredentialBody` (direct) and `<Name>AgentCredentialBody` (lightweight), plus an `extraction-method` ConditionalInput whose `overrideEnum` widens the substitutions `Literal` to `["direct", "agent"]`.
 - [`examples/scheduled/`](examples/scheduled/) — cron background job via `schedules`; renders `triggers.schedules` into `manifest.json` (multiple schedules, non-UTC timezone, a `PAUSED` one). See [Schedules](docs/reference.md#schedules-background-jobs).
+- [`examples/artifact-schemas/`](examples/artifact-schemas/) — data hand-off declarations via `artifactSchemas`; renders `app/generated/artifact_schemas.json` (parquet + NDJSON, dotted nested paths, an input artifact). See [Artifact Schemas](docs/reference.md#artifact-schemas-data-hand-off-declarations).
 
 ## What Gets Generated
 
@@ -178,6 +179,26 @@ Typed Python `AppInputContract` dataclass. SDK-owned fields inherited from `Extr
 Framework-populated fields (`workflow_id`, `correlation_id`, `app_name`) are declared by
 the SDK's base `Input` and are never regenerated from a `uiConfig` property — redeclaring
 one would shadow the base field with the author's type and fail only at workflow dispatch.
+
+### Artifact Schemas (`app/generated/artifact_schemas.json`)
+
+Declared shapes for the files this app hands off, keyed by the contract `FileReference`
+field the runtime materialises — never by a storage path. The SDK checks the real
+artifact against the declaration at the hand-off, so a column that has quietly become a
+string where the consumer expects a timestamp is reported instead of flowing on.
+
+The toolkit is transport, not owner: it fixes the logical type vocabulary
+(`string`/`int`/`float`/`bool`/`timestamp`/`date`/`json`/`any`, plus the additive
+`decimal`/`binary`/`time`/`array`/`struct`/`map`) and the file shape; every field is
+authored by the app. Nested payloads are dotted paths plus a container type, not a
+recursive grammar.
+
+**Opt-in and emitted only when declared.** An app with no `artifactSchemas` block
+generates byte-identical output to before the block existed — no new file. Unlike the
+workflow config and manifest, this file does not depend on `uiConfig`. Multi-entrypoint
+apps declare it per entrypoint and each copy lands under
+`app/generated/{entrypoint}/`. See
+[`docs/reference.md`](docs/reference.md#artifact-schemas-data-hand-off-declarations).
 
 ## Modules
 

--- a/contract-toolkit/README.md
+++ b/contract-toolkit/README.md
@@ -193,6 +193,10 @@ The toolkit is transport, not owner: it fixes the logical type vocabulary
 authored by the app. Nested payloads are dotted paths plus a container type, not a
 recursive grammar.
 
+Every field must carry a non-empty `description`. A declaration is read by whoever is
+debugging the hand-off that just failed, and a bare `name` + `type` pair states the
+assertion without stating why it holds.
+
 **Opt-in and emitted only when declared.** An app with no `artifactSchemas` block
 generates byte-identical output to before the block existed — no new file. Unlike the
 workflow config and manifest, this file does not depend on `uiConfig`. Multi-entrypoint

--- a/contract-toolkit/docs/reference.md
+++ b/contract-toolkit/docs/reference.md
@@ -212,7 +212,7 @@ with the consumer.
 
 | Field | Type | Default | Description |
 |---|---|---|---|
-| `name` | `ArtifactFieldPath` | — | Dotted path to the field within a record: `"a"`, `"a.b"`, `"a.b.c"`. Empty segments (`".a"`, `"a."`, `"a..b"`) fail generation. |
+| `name` | `ArtifactFieldPath` | — | Path to the field within a record, built from two step kinds: `.name` descends into a container's named member (`"a.b"`), `[]` descends into an array's element (`"tags[]"`, `"columns[].name"`). Empty segments (`".a"`, `"a."`, `"a..b"`) and malformed brackets (`"[]"`, `"a["`, `"a[0]"`) fail generation. |
 | `type` | `ArtifactFieldTypeExtended` | `"any"` | Logical type asserted for this field. |
 | `required` | Boolean | `true` | Whether the field must be present in every record / in the parquet schema. Always rendered. |
 | `description` | String (non-empty) | — | **Required.** What the field carries and what the consumer expects of it. Never asserted at runtime — it is documentation, enforced at authoring time, and always present in the output. |
@@ -276,10 +276,43 @@ not asserted" — declare it rather than inventing a wrong type to satisfy the e
 
 #### Nesting
 
-Nested payloads are declared as **dotted field paths plus a container type**, not a
-recursive type grammar: declare `attributes` as `struct` and `attributes.name` as
-`string`. Deeply-nested cases with thousands of properties are not declared here at
-all — the SDK's model-backed schema source delegates to the executable model instead.
+Nested payloads are declared as **paths plus a container type**, not a recursive type
+grammar. There are two step kinds:
+
+| Step | Means | Example |
+|---|---|---|
+| `.name` | descend into a container's named member | `attributes` (`struct`) → `attributes.name` (`string`) |
+| `[]` | descend into an array's **element** | `columns` (`array`) → `columns[]` (`struct`) → `columns[].name` (`string`) |
+
+An array of scalars carries a leaf type on the element step instead of a struct:
+`tags` as `array`, `tags[]` as `string`.
+
+`[]` is the explicit "descend into the list" step precisely because the physical
+encoding is not. Parquet spells the same leaf `columns.list.element.name` under the
+3-level list encoding and `columns.bag.array.name` under the legacy 2-level one, so a
+declaration written in physical terms would be pinned to an encoding the producer can
+change without telling anyone. `[]` says what is *meant*; each validator resolves it
+for its own format.
+
+On an element path, **`required` reads per element**: `columns[].name` required means
+every element must carry `name`, and an empty array satisfies it vacuously. Declaring
+the array itself `required = false` is the separate statement that the array may be
+absent entirely.
+
+**Every path prefix must itself be declared, with a container type that can hold what
+the path descends into.** Declaring `attributes.name` while leaving `attributes`
+undeclared fails generation — it would drop exactly the check that catches a producer
+which flattened the struct away, since the leaf assertion can still pass against a
+flattened record. Declaring `attributes` as `string` alongside `attributes.name` fails
+too: that is a contradiction the validator would otherwise have to resolve by guessing.
+A `.name` step needs its container declared `struct`/`map`/`json`/`any`; an `[]` step
+needs `array`/`any`.
+
+Index selection (`columns[0]`) is rejected by the grammar: a schema describes every
+element, not one of them.
+
+Deeply-nested cases with thousands of properties are not declared here at all — the
+SDK's model-backed schema source delegates to the executable model instead.
 
 ```pkl
 artifactSchemas {
@@ -323,6 +356,22 @@ artifactSchemas {
         type = "string"
         description = "Stable identity of the entity. Publish upserts on it."
       }
+      new ArtifactField {
+        name = "attributes.columns"
+        type = "array"
+        required = false
+        description = "Child columns carried inline. Absent for types that have none."
+      }
+      new ArtifactField {
+        name = "attributes.columns[]"
+        type = "struct"
+        description = "One column."
+      }
+      new ArtifactField {
+        name = "attributes.columns[].name"
+        type = "string"
+        description = "Column name as it appears in the source."
+      }
     }
   }
 }
@@ -344,9 +393,12 @@ artifactSchemas {
     "transformed_entities": {
       "format": "ndjson",
       "fields": [
-        { "name": "typeName",                 "type": "string", "required": true, "description": "Atlan type this record instantiates. Publish routes on it." },
-        { "name": "attributes",               "type": "struct", "required": true, "description": "Container for the entity's attributes." },
-        { "name": "attributes.qualifiedName", "type": "string", "required": true, "description": "Stable identity of the entity. Publish upserts on it." }
+        { "name": "typeName",                 "type": "string", "required": true,  "description": "Atlan type this record instantiates. Publish routes on it." },
+        { "name": "attributes",               "type": "struct", "required": true,  "description": "Container for the entity's attributes." },
+        { "name": "attributes.qualifiedName", "type": "string", "required": true,  "description": "Stable identity of the entity. Publish upserts on it." },
+        { "name": "attributes.columns",       "type": "array",  "required": false, "description": "Child columns carried inline. Absent for types that have none." },
+        { "name": "attributes.columns[]",     "type": "struct", "required": true,  "description": "One column." },
+        { "name": "attributes.columns[].name","type": "string", "required": true,  "description": "Column name as it appears in the source." }
       ]
     }
   }

--- a/contract-toolkit/docs/reference.md
+++ b/contract-toolkit/docs/reference.md
@@ -164,6 +164,182 @@ entrypoint renders its own manifest.
 See [`examples/scheduled/`](../examples/scheduled/) for a full worked example.
 (Same field/behaviour exists on the legacy `NativeApp.pkl`.)
 
+### Artifact Schemas (data hand-off declarations)
+
+Data crosses app boundaries as files: a connector writes NDJSON entities the publish
+app reads, a miner writes partitioned parquet a parser reads. At each hand-off the
+producer's idea of the artifact's shape and the consumer's idea of it are independent
+beliefs, and nothing checks that they agree. A production RCA traced a 73-day frozen
+lineage marker to one column that had become a string where the consumer expected a
+timestamp — every workflow in the chain reported success throughout.
+
+`artifactSchemas` is where an app declares those shapes. The toolkit renders them to
+`app/generated/artifact_schemas.json`; the SDK checks the real artifact against the
+declaration at the hand-off (see ADR-0020 in the SDK repo).
+
+**The toolkit is transport, not owner.** Every field is authored by the app, the SDK
+ships no field list, and the artifact is per-app. What the toolkit owns is the *type
+vocabulary* and the file shape — nothing in `src/` names a column.
+
+Default is empty, and an app that declares nothing generates **byte-identical** output
+to before this block existed, so adoption is per-app and per-entrypoint.
+
+| Property | Type | Default | Description |
+|---|---|---|---|
+| `artifactSchemas` | `Mapping<ContractFieldName, ArtifactSchema>` | `new Mapping {}` | Declared shapes for this entrypoint's artifacts, keyed by contract field name. Rendered to `app/generated/artifact_schemas.json` when non-empty; no file at all when empty. |
+
+**Keys are contract field names, never paths.** A key is the name of a `FileReference`
+field on this entrypoint's input or output contract model — a Python identifier,
+validated at eval time. The runtime resolves a declaration from the contract field it
+is materialising, so nothing is inferred from the shape of a storage path. (Path-shape
+inference is what let an earlier upload-time hook match nothing and silently validate
+zero records; a key like `"artifacts/raw/*.parquet"` fails generation.)
+
+**Inputs are declarable too.** For a cross-app hand-off the **consumer** declares what
+it requires of its input, and the producer references the consumer's published
+declaration by pinned version rather than re-authoring the field list. Ownership stays
+with the consumer.
+
+**`ArtifactSchema`:**
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `format` | `ArtifactFormat` | — | `"ndjson"` or `"parquet"`. No default: each format has its own validator with its own cost and dependency floor, and the answer is not derivable from the contract field. This is the *content* format — SDK NDJSON artifacts conventionally carry a `.json` suffix and are still `"ndjson"`. |
+| `fields` | `Listing<ArtifactField>` | — | Declared fields. Must be **non-empty** and names must be **distinct**, both enforced at eval time. A zero-field schema reports as declared while asserting nothing; a duplicate name would silently collapse to one assertion. |
+| `description` | String? | null | Free-form note for humans reading the generated artifact. Never asserted; omitted from the output when unset. |
+
+**`ArtifactField`:**
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `name` | `ArtifactFieldPath` | — | Dotted path to the field within a record: `"a"`, `"a.b"`, `"a.b.c"`. Empty segments (`".a"`, `"a."`, `"a..b"`) fail generation. |
+| `type` | `ArtifactFieldTypeExtended` | `"any"` | Logical type asserted for this field. |
+| `required` | Boolean | `true` | Whether the field must be present in every record / in the parquet schema. Always rendered. |
+| `description` | String? | null | Free-form note. Never asserted; omitted when unset. |
+
+#### The logical-type vocabulary
+
+Two typealiases, the second layering additively on the first, so the base stays a
+guaranteed floor while extension members can be declared before every validator
+supports them:
+
+```pkl
+/// Types every validator must map, for every format. The stable floor.
+typealias ArtifactFieldType =
+  "string"|"int"|"float"|"bool"|"timestamp"|"date"|"json"|"any"
+
+/// Additive extension. A member here may resolve to "unsupported for this
+/// format" without widening the floor above.
+typealias ArtifactFieldTypeExtended =
+  ArtifactFieldType|"decimal"|"binary"|"time"|"array"|"struct"|"map"
+```
+
+Field declarations use `ArtifactFieldTypeExtended`. The vocabulary is *logical*, not
+physical — one member covers several physical encodings.
+
+| Logical | parquet / arrow | NDJSON / JSON |
+|---|---|---|
+| `string` | `string`, `large_string` | JSON string |
+| `int` | any `int*` / `uint*` | JSON number, integral |
+| `float` | `float*`, `double` | JSON number |
+| `decimal` | `decimal128`, `decimal256` | JSON number **or** string (both lossless carriers) |
+| `bool` | `bool` | JSON `true`/`false` |
+| `timestamp` | `timestamp[*]` — **any unit, tz-aware or not** | ISO-8601 string or epoch number |
+| `date` | `date32`, `date64` | ISO-8601 date string |
+| `time` | `time32`, `time64` | ISO-8601 time string |
+| `binary` | `binary`, `large_binary`, `fixed_size_binary` | base64 string |
+| `json` | `string` whose content parses as JSON | nested object/array, or a JSON-in-string |
+| `array` | `list`, `large_list`, `fixed_size_list` | JSON array |
+| `struct` | `struct` | JSON object |
+| `map` | `map` | JSON object |
+| `any` | any type | any type |
+
+The load-bearing row is `timestamp`: arrow `timestamp[*]` satisfies it at any unit,
+tz-aware or not, and arrow `string` does **not**. That single asymmetry is the check
+the RCA above needed. `json` exists so a parquet column that is physically a string
+but semantically a JSON blob keeps its own check. `any` means "must be present, type
+not asserted" — declare it rather than inventing a wrong type to satisfy the enum.
+
+#### Nesting
+
+Nested payloads are declared as **dotted field paths plus a container type**, not a
+recursive type grammar: declare `attributes` as `struct` and `attributes.name` as
+`string`. Deeply-nested cases with thousands of properties are not declared here at
+all — the SDK's model-backed schema source delegates to the executable model instead.
+
+```pkl
+artifactSchemas {
+  ["raw_queries"] = new ArtifactSchema {
+    format = "parquet"
+    description = "Query-history rows written for the downstream parser."
+    fields {
+      new ArtifactField { name = "QUERY_ID"; type = "string" }
+      new ArtifactField { name = "START_TIME"; type = "timestamp" }
+      new ArtifactField { name = "CREDITS_USED"; type = "float"; required = false }
+    }
+  }
+  ["transformed_entities"] = new ArtifactSchema {
+    format = "ndjson"
+    fields {
+      new ArtifactField { name = "typeName"; type = "string" }
+      new ArtifactField { name = "attributes"; type = "struct" }
+      new ArtifactField { name = "attributes.qualifiedName"; type = "string" }
+    }
+  }
+}
+```
+→ generated `app/generated/artifact_schemas.json`:
+```jsonc
+{
+  "version": 1,
+  "schemas": {
+    "raw_queries": {
+      "format": "parquet",
+      "description": "Query-history rows written for the downstream parser.",
+      "fields": [
+        { "name": "QUERY_ID",     "type": "string",    "required": true  },
+        { "name": "START_TIME",   "type": "timestamp", "required": true  },
+        { "name": "CREDITS_USED", "type": "float",     "required": false }
+      ]
+    },
+    "transformed_entities": {
+      "format": "ndjson",
+      "fields": [
+        { "name": "typeName",                 "type": "string", "required": true },
+        { "name": "attributes",               "type": "struct", "required": true },
+        { "name": "attributes.qualifiedName", "type": "string", "required": true }
+      ]
+    }
+  }
+}
+```
+
+`version` is the envelope version of the file shape, read by the SDK loader. It is
+bumped only on a breaking change to the file's structure — not when an app edits its
+own declarations.
+
+**Placement:** `artifactSchemas` is a per-entrypoint property, exactly like `pipeline` /
+`uiConfig` / `schedules`. A single-entrypoint app declares it at the top level and the
+file lands at `app/generated/artifact_schemas.json`. A **multi-entrypoint** app declares
+it on each [entrypoint's `contract`](#multi-entrypoint-apps), and each entrypoint's file
+is re-exported to `app/generated/{entrypoint}/artifact_schemas.json` by the standard
+re-export path — no bundle-specific wiring. The entrypoint dimension is therefore the
+file's *location*, and the keys inside the file stay contract field names, so nothing
+has to be re-keyed on relocation.
+
+Declaring `artifactSchemas` on a **bundle root** is a generation error. The root has no
+contract model of its own, so a key there could not name a real `FileReference` field,
+and the shared file it would emit could be picked up as a fallback for an entrypoint
+that declares nothing — checking the wrong declarations silently. Two entrypoints that
+genuinely share an artifact assign one shared `ArtifactSchema` value into both contracts.
+
+Unlike the workflow config and manifest, this file does **not** depend on `uiConfig`: a
+declaration describes data hand-offs, which an app has whether or not it renders a setup
+form.
+
+See [`examples/artifact-schemas/`](../examples/artifact-schemas/) for a full worked
+example. Not available on the legacy `NativeApp.pkl`.
+
 ### E2E Test Harness
 
 These fields are emitted into `app/generated/_e2e_base.py` and are required by `BaseE2ETest` / `SQLAppE2ETest`. The defaults are derived from `name`; 95% of connectors never need to override them.
@@ -2900,6 +3076,42 @@ class AppInputContract(ExtractionInput):
   `{"catalog": {"db": {}}}` to the existing filter map shape
   `{"catalog": ["db"]}` before validation.
 - Publish fields simplified: `publish_dry_run` replaces the loader-specific fields
+
+---
+
+### Artifact Schemas (`app/generated/artifact_schemas.json`)
+
+Emitted **only** when the contract declares a non-empty `artifactSchemas` block — an
+app that declares nothing produces no such file. Independent of `uiConfig`. In a
+multi-entrypoint app each entrypoint's copy lands at
+`app/generated/{entrypoint}/artifact_schemas.json`.
+
+```json
+{
+  "version": 1,
+  "schemas": {
+    "raw_queries": {
+      "format": "parquet",
+      "description": "Query-history rows written for the downstream parser.",
+      "fields": [
+        { "name": "QUERY_ID", "type": "string", "required": true },
+        { "name": "START_TIME", "type": "timestamp", "required": true },
+        { "name": "CREDITS_USED", "type": "float", "required": false }
+      ]
+    }
+  }
+}
+```
+
+- `version` — envelope version of the file shape, read by the SDK loader. Bumped only
+  on a breaking structural change, never when an app edits its own declarations.
+- `schemas` keys — contract field names (a `FileReference` field on the entrypoint's
+  input/output model), never storage paths.
+- `description` — omitted entirely when unset, on both the schema and the field.
+- `required` — always emitted, defaulting to `true`.
+
+See [Artifact Schemas (data hand-off declarations)](#artifact-schemas-data-hand-off-declarations)
+for the type vocabulary and the per-format mapping.
 
 ---
 

--- a/contract-toolkit/docs/reference.md
+++ b/contract-toolkit/docs/reference.md
@@ -206,7 +206,7 @@ with the consumer.
 |---|---|---|---|
 | `format` | `ArtifactFormat` | — | `"ndjson"` or `"parquet"`. No default: each format has its own validator with its own cost and dependency floor, and the answer is not derivable from the contract field. This is the *content* format — SDK NDJSON artifacts conventionally carry a `.json` suffix and are still `"ndjson"`. |
 | `fields` | `Listing<ArtifactField>` | — | Declared fields. Must be **non-empty** and names must be **distinct**, both enforced at eval time. A zero-field schema reports as declared while asserting nothing; a duplicate name would silently collapse to one assertion. |
-| `description` | String? | null | Free-form note for humans reading the generated artifact. Never asserted; omitted from the output when unset. |
+| `description` | String? | null | What this artifact is. Free-form, never asserted; omitted from the output when unset. |
 
 **`ArtifactField`:**
 
@@ -215,7 +215,7 @@ with the consumer.
 | `name` | `ArtifactFieldPath` | — | Dotted path to the field within a record: `"a"`, `"a.b"`, `"a.b.c"`. Empty segments (`".a"`, `"a."`, `"a..b"`) fail generation. |
 | `type` | `ArtifactFieldTypeExtended` | `"any"` | Logical type asserted for this field. |
 | `required` | Boolean | `true` | Whether the field must be present in every record / in the parquet schema. Always rendered. |
-| `description` | String? | null | Free-form note. Never asserted; omitted when unset. |
+| `description` | String (non-empty) | — | **Required.** What the field carries and what the consumer expects of it. Never asserted at runtime — it is documentation, enforced at authoring time, and always present in the output. |
 
 #### The logical-type vocabulary
 
@@ -254,6 +254,20 @@ physical — one member covers several physical encodings.
 | `map` | `map` | JSON object |
 | `any` | any type | any type |
 
+#### Why `description` is required on every field
+
+A declaration is read by whoever is debugging the hand-off that just failed. A bare
+`name` + `type` pair states the assertion but not why it holds — and there are two
+cases where the pair states almost nothing on its own: a `type = "any"` field, whose
+description is the only place it can say what it carries, and a `required = false`
+field, whose description is the only place it can say *when* it appears. A field with
+no description also cannot be reviewed: a reviewer sees `"YEAR": "int"` and has no way
+to tell a considered assertion from a guess.
+
+Generation refuses a missing or empty description, naming the field. `description` is
+therefore always present in the generated artifact, so a consumer never branches on it.
+The schema-level `description` stays optional.
+
 The load-bearing row is `timestamp`: arrow `timestamp[*]` satisfies it at any unit,
 tz-aware or not, and arrow `string` does **not**. That single asymmetry is the check
 the RCA above needed. `json` exists so a parquet column that is physically a string
@@ -273,17 +287,42 @@ artifactSchemas {
     format = "parquet"
     description = "Query-history rows written for the downstream parser."
     fields {
-      new ArtifactField { name = "QUERY_ID"; type = "string" }
-      new ArtifactField { name = "START_TIME"; type = "timestamp" }
-      new ArtifactField { name = "CREDITS_USED"; type = "float"; required = false }
+      new ArtifactField {
+        name = "QUERY_ID"
+        type = "string"
+        description = "Warehouse-assigned query id. The parser's join key."
+      }
+      new ArtifactField {
+        name = "START_TIME"
+        type = "timestamp"
+        description = "When the query began executing."
+      }
+      new ArtifactField {
+        name = "CREDITS_USED"
+        type = "float"
+        required = false
+        description = "Compute credits billed. Absent on warehouses that do not meter per query."
+      }
     }
   }
   ["transformed_entities"] = new ArtifactSchema {
     format = "ndjson"
     fields {
-      new ArtifactField { name = "typeName"; type = "string" }
-      new ArtifactField { name = "attributes"; type = "struct" }
-      new ArtifactField { name = "attributes.qualifiedName"; type = "string" }
+      new ArtifactField {
+        name = "typeName"
+        type = "string"
+        description = "Atlan type this record instantiates. Publish routes on it."
+      }
+      new ArtifactField {
+        name = "attributes"
+        type = "struct"
+        description = "Container for the entity's attributes."
+      }
+      new ArtifactField {
+        name = "attributes.qualifiedName"
+        type = "string"
+        description = "Stable identity of the entity. Publish upserts on it."
+      }
     }
   }
 }
@@ -297,17 +336,17 @@ artifactSchemas {
       "format": "parquet",
       "description": "Query-history rows written for the downstream parser.",
       "fields": [
-        { "name": "QUERY_ID",     "type": "string",    "required": true  },
-        { "name": "START_TIME",   "type": "timestamp", "required": true  },
-        { "name": "CREDITS_USED", "type": "float",     "required": false }
+        { "name": "QUERY_ID",     "type": "string",    "required": true,  "description": "Warehouse-assigned query id. The parser's join key." },
+        { "name": "START_TIME",   "type": "timestamp", "required": true,  "description": "When the query began executing." },
+        { "name": "CREDITS_USED", "type": "float",     "required": false, "description": "Compute credits billed. Absent on warehouses that do not meter per query." }
       ]
     },
     "transformed_entities": {
       "format": "ndjson",
       "fields": [
-        { "name": "typeName",                 "type": "string", "required": true },
-        { "name": "attributes",               "type": "struct", "required": true },
-        { "name": "attributes.qualifiedName", "type": "string", "required": true }
+        { "name": "typeName",                 "type": "string", "required": true, "description": "Atlan type this record instantiates. Publish routes on it." },
+        { "name": "attributes",               "type": "struct", "required": true, "description": "Container for the entity's attributes." },
+        { "name": "attributes.qualifiedName", "type": "string", "required": true, "description": "Stable identity of the entity. Publish upserts on it." }
       ]
     }
   }
@@ -3094,9 +3133,9 @@ multi-entrypoint app each entrypoint's copy lands at
       "format": "parquet",
       "description": "Query-history rows written for the downstream parser.",
       "fields": [
-        { "name": "QUERY_ID", "type": "string", "required": true },
-        { "name": "START_TIME", "type": "timestamp", "required": true },
-        { "name": "CREDITS_USED", "type": "float", "required": false }
+        { "name": "QUERY_ID", "type": "string", "required": true, "description": "Warehouse-assigned query id. The parser's join key." },
+        { "name": "START_TIME", "type": "timestamp", "required": true, "description": "When the query began executing." },
+        { "name": "CREDITS_USED", "type": "float", "required": false, "description": "Compute credits billed. Absent on warehouses that do not meter per query." }
       ]
     }
   }
@@ -3107,7 +3146,8 @@ multi-entrypoint app each entrypoint's copy lands at
   on a breaking structural change, never when an app edits its own declarations.
 - `schemas` keys — contract field names (a `FileReference` field on the entrypoint's
   input/output model), never storage paths.
-- `description` — omitted entirely when unset, on both the schema and the field.
+- `description` — required and non-empty on every field, so always present. The
+  schema-level `description` is optional and omitted when unset.
 - `required` — always emitted, defaulting to `true`.
 
 See [Artifact Schemas (data hand-off declarations)](#artifact-schemas-data-hand-off-declarations)

--- a/contract-toolkit/examples/artifact-schemas/app.pkl
+++ b/contract-toolkit/examples/artifact-schemas/app.pkl
@@ -15,9 +15,10 @@
 ///   - a **parquet** hand-off whose `START_TIME` is declared `timestamp`. Arrow
 ///     `timestamp[*]` satisfies that at any unit; arrow `string` does not. That
 ///     one asymmetry is the check a 73-day frozen-lineage RCA needed.
-///   - an **NDJSON** hand-off with nested fields declared as dotted paths plus a
-///     container type (`attributes` is `struct`, `attributes.name` is `string`)
-///     — no recursive type grammar.
+///   - an **NDJSON** hand-off with nested fields declared as paths plus a container
+///     type — `attributes` is `struct` and `attributes.name` is `string`; an array
+///     of structs is `attributes.columns` (`array`), `attributes.columns[]`
+///     (`struct`), `attributes.columns[].name` (`string`). No recursive grammar.
 ///   - an artifact declared on the app's **input**: the consumer owns the
 ///     declaration, so a consuming app states what it requires of what it reads.
 ///
@@ -128,6 +129,41 @@ artifactSchemas {
         type = "timestamp"
         required = false
         description = "When this entity was last written by a run. Absent on the first sync, set on every later one."
+      }
+      new ArtifactField {
+        name = "attributes.columns"
+        type = "array"
+        required = false
+        description = "Child columns carried inline on a table entity. Absent for entity types that have none."
+      }
+      new ArtifactField {
+        // The array's ELEMENT, addressed with the `[]` step. Declaring it as a struct
+        // is what lets the two leaf paths below mean anything.
+        name = "attributes.columns[]"
+        type = "struct"
+        description = "One column. `required` on the paths below reads per element, so an empty columns array satisfies them vacuously."
+      }
+      new ArtifactField {
+        name = "attributes.columns[].name"
+        type = "string"
+        description = "Column name as it appears in the source."
+      }
+      new ArtifactField {
+        name = "attributes.columns[].order"
+        type = "int"
+        description = "Ordinal position of the column within the table, 1-based."
+      }
+      new ArtifactField {
+        // A scalar array: the element step carries a leaf type rather than a struct.
+        name = "attributes.tags"
+        type = "array"
+        required = false
+        description = "Source-side tags on the entity. Absent when the source has no tagging."
+      }
+      new ArtifactField {
+        name = "attributes.tags[]"
+        type = "string"
+        description = "One tag. Elements are plain strings, not objects."
       }
       new ArtifactField {
         // Present-but-unasserted: a thin contract states presence without anyone

--- a/contract-toolkit/examples/artifact-schemas/app.pkl
+++ b/contract-toolkit/examples/artifact-schemas/app.pkl
@@ -1,0 +1,151 @@
+/// Artifact-schemas example — demonstrates declaring the shape of the files an
+/// app hands off (ADR-0020).
+///
+/// `artifactSchemas` is keyed by the name of a `FileReference` field on this
+/// entrypoint's input/output contract model, never by a storage path. Each entry
+/// declares a format and a non-empty list of fields; the toolkit renders them to
+/// `app/generated/artifact_schemas.json` and the SDK checks the real artifact
+/// against the declaration at the hand-off.
+///
+/// The three cases worth seeing here:
+///   - a **parquet** hand-off whose `START_TIME` is declared `timestamp`. Arrow
+///     `timestamp[*]` satisfies that at any unit; arrow `string` does not. That
+///     one asymmetry is the check a 73-day frozen-lineage RCA needed.
+///   - an **NDJSON** hand-off with nested fields declared as dotted paths plus a
+///     container type (`attributes` is `struct`, `attributes.name` is `string`)
+///     — no recursive type grammar.
+///   - an artifact declared on the app's **input**: the consumer owns the
+///     declaration, so a consuming app states what it requires of what it reads.
+///
+/// Generated layout:
+///   atlan.yaml
+///   app.yaml
+///   app/generated/artifact-schemas-example.json  ← workflow setup config
+///   app/generated/artifact_schemas.json          ← the declarations
+///   app/generated/manifest.json
+///   app/generated/_input.py
+amends "../../src/App.pkl"
+
+name = "artifact-schemas-example"
+displayName = "Artifact Schemas Example"
+icon = "https://assets.atlan.com/assets/fullscreen-exit.svg"
+hasCredentialConfig = false
+
+pipeline {
+  publish = null
+}
+
+uiConfig = new UIConfig {
+  tasks {
+    ["Configuration"] {
+      inputs {
+        ["lookback-days"] = new NumericInput {
+          title = "Query lookback (days)"
+          helpText = "How much query history to read."
+          default = 30
+          width = 4
+        }
+      }
+    }
+  }
+}
+
+artifactSchemas {
+  // Output hand-off: partitioned parquet this app writes for a downstream parser.
+  ["raw_queries"] = new ArtifactSchema {
+    format = "parquet"
+    description = "Query-history rows written for the downstream parser."
+    fields {
+      new ArtifactField {
+        name = "QUERY_ID"
+        type = "string"
+      }
+      new ArtifactField {
+        name = "START_TIME"
+        type = "timestamp"
+        description = "Must be a real timestamp column. A stringified timestamp here is the defect this declaration exists to catch."
+      }
+      new ArtifactField {
+        name = "CREDITS_USED"
+        type = "float"
+        required = false
+      }
+      new ArtifactField {
+        // Snowflake NUMBER lands as parquet decimal128; asserting float would
+        // either mis-flag the column or lose precision.
+        name = "ROWS_PRODUCED"
+        type = "decimal"
+        required = false
+      }
+      new ArtifactField {
+        name = "YEAR"
+        type = "int"
+        description = "Partition column."
+      }
+      new ArtifactField {
+        name = "SESSION_PARAMS"
+        type = "json"
+        required = false
+        description = "Physically a string column; semantically a JSON blob. Collapsing the two would defeat this hop's check."
+      }
+    }
+  }
+
+  // Output hand-off: NDJSON entities, nested fields as dotted paths.
+  ["transformed_entities"] = new ArtifactSchema {
+    format = "ndjson"
+    description = "Transformed entities streamed to the publish step."
+    fields {
+      new ArtifactField {
+        name = "typeName"
+        type = "string"
+      }
+      new ArtifactField {
+        name = "attributes"
+        type = "struct"
+      }
+      new ArtifactField {
+        name = "attributes.qualifiedName"
+        type = "string"
+      }
+      new ArtifactField {
+        name = "attributes.name"
+        type = "string"
+      }
+      new ArtifactField {
+        name = "attributes.lastSyncRunAt"
+        type = "timestamp"
+        required = false
+      }
+      new ArtifactField {
+        // Present-but-unasserted: a thin contract states presence without anyone
+        // inventing a wrong type to satisfy the enum.
+        name = "customAttributes"
+        type = "any"
+        required = false
+      }
+    }
+  }
+
+  // Input hand-off: what this app requires of an artifact another app produced.
+  // The consumer owns the declaration; the producer references it rather than
+  // re-authoring the field list.
+  ["upstream_lineage"] = new ArtifactSchema {
+    format = "ndjson"
+    description = "Lineage edges this app reads from an upstream producer."
+    fields {
+      new ArtifactField {
+        name = "source_qualified_name"
+        type = "string"
+      }
+      new ArtifactField {
+        name = "target_qualified_name"
+        type = "string"
+      }
+      new ArtifactField {
+        name = "process_id"
+        type = "string"
+      }
+    }
+  }
+}

--- a/contract-toolkit/examples/artifact-schemas/app.pkl
+++ b/contract-toolkit/examples/artifact-schemas/app.pkl
@@ -7,6 +7,10 @@
 /// `app/generated/artifact_schemas.json` and the SDK checks the real artifact
 /// against the declaration at the hand-off.
 ///
+/// Every field carries a `description`. It is required: a declaration is read by
+/// whoever is debugging the hand-off that just failed, and `name` + `type` alone
+/// state the assertion without stating why it holds.
+///
 /// The three cases worth seeing here:
 ///   - a **parquet** hand-off whose `START_TIME` is declared `timestamp`. Arrow
 ///     `timestamp[*]` satisfies that at any unit; arrow `string` does not. That
@@ -59,16 +63,18 @@ artifactSchemas {
       new ArtifactField {
         name = "QUERY_ID"
         type = "string"
+        description = "Warehouse-assigned query id, unique within the account. The parser's join key."
       }
       new ArtifactField {
         name = "START_TIME"
         type = "timestamp"
-        description = "Must be a real timestamp column. A stringified timestamp here is the defect this declaration exists to catch."
+        description = "When the query began executing. Must be a real timestamp column — a stringified timestamp here is the defect this declaration exists to catch."
       }
       new ArtifactField {
         name = "CREDITS_USED"
         type = "float"
         required = false
+        description = "Compute credits billed for the query. Absent on warehouses that do not meter per query."
       }
       new ArtifactField {
         // Snowflake NUMBER lands as parquet decimal128; asserting float would
@@ -76,17 +82,18 @@ artifactSchemas {
         name = "ROWS_PRODUCED"
         type = "decimal"
         required = false
+        description = "Row count the query returned. Declared decimal because a Snowflake NUMBER lands as parquet decimal128; asserting float would mis-flag it or lose precision."
       }
       new ArtifactField {
         name = "YEAR"
         type = "int"
-        description = "Partition column."
+        description = "Partition column derived from START_TIME. The parser prunes on it, so a string here silently disables partition pruning."
       }
       new ArtifactField {
         name = "SESSION_PARAMS"
         type = "json"
         required = false
-        description = "Physically a string column; semantically a JSON blob. Collapsing the two would defeat this hop's check."
+        description = "Session settings in force for the query. Physically a string column, semantically a JSON blob — collapsing the two would defeat this hop's check."
       }
     }
   }
@@ -99,23 +106,28 @@ artifactSchemas {
       new ArtifactField {
         name = "typeName"
         type = "string"
+        description = "Atlan type this record instantiates, e.g. Table. Publish routes on it."
       }
       new ArtifactField {
         name = "attributes"
         type = "struct"
+        description = "Container for the entity's attributes. Declared so a record that flattened them to top level is caught before publish reads it."
       }
       new ArtifactField {
         name = "attributes.qualifiedName"
         type = "string"
+        description = "Stable identity of the entity. Publish upserts on it, so a missing or non-string value creates duplicates rather than failing."
       }
       new ArtifactField {
         name = "attributes.name"
         type = "string"
+        description = "Display name shown in the UI."
       }
       new ArtifactField {
         name = "attributes.lastSyncRunAt"
         type = "timestamp"
         required = false
+        description = "When this entity was last written by a run. Absent on the first sync, set on every later one."
       }
       new ArtifactField {
         // Present-but-unasserted: a thin contract states presence without anyone
@@ -123,6 +135,7 @@ artifactSchemas {
         name = "customAttributes"
         type = "any"
         required = false
+        description = "Source-specific extras passed through untouched. Type deliberately unasserted — the shape is the source's, not ours."
       }
     }
   }
@@ -137,14 +150,17 @@ artifactSchemas {
       new ArtifactField {
         name = "source_qualified_name"
         type = "string"
+        description = "Qualified name of the upstream asset the edge starts at."
       }
       new ArtifactField {
         name = "target_qualified_name"
         type = "string"
+        description = "Qualified name of the downstream asset the edge ends at."
       }
       new ArtifactField {
         name = "process_id"
         type = "string"
+        description = "Id of the process that produced the edge. Groups edges into one lineage process on read."
       }
     }
   }

--- a/contract-toolkit/examples/artifact-schemas/app.yaml
+++ b/contract-toolkit/examples/artifact-schemas/app.yaml
@@ -1,0 +1,5 @@
+# AUTO-GENERATED from contract/app.pkl — DO NOT EDIT MANUALLY.
+# To regenerate: pkl eval -m . contract/app.pkl
+app_name: artifact-schemas-example
+app_image: ${APP_IMAGE}
+app_port: 8000

--- a/contract-toolkit/examples/artifact-schemas/app/generated/_e2e_base.py
+++ b/contract-toolkit/examples/artifact-schemas/app/generated/_e2e_base.py
@@ -1,0 +1,12 @@
+# Generated from contract/app.pkl via contract-toolkit. DO NOT EDIT.
+# Regenerate with: pkl eval -m . contract/app.pkl
+from application_sdk.testing.e2e import BaseE2ETest
+
+
+class ArtifactSchemasExampleGeneratedE2EBase(BaseE2ETest):
+    connector_short_name = "artifact-schemas-example"
+    argo_package_name = "@atlan/artifact-schemas-example"
+    argo_template_name = "atlan-artifact-schemas-example"
+    app_service_url = (
+        "http://artifact-schemas-example.artifact-schemas-example-app.svc.cluster.local"
+    )

--- a/contract-toolkit/examples/artifact-schemas/app/generated/_e2e_substitutions.py
+++ b/contract-toolkit/examples/artifact-schemas/app/generated/_e2e_substitutions.py
@@ -1,0 +1,11 @@
+# Generated from contract/app.pkl via contract-toolkit. DO NOT EDIT.
+# Regenerate with: pkl eval -m . contract/app.pkl
+from __future__ import annotations
+
+from pydantic import Field
+
+from application_sdk.testing.e2e.substitutions import MustacheSubstitutions
+
+
+class ArtifactSchemasExampleMustacheSubstitutions(MustacheSubstitutions):
+    lookback_days: int = Field(default=30, alias="{{lookback-days}}")

--- a/contract-toolkit/examples/artifact-schemas/app/generated/_input.py
+++ b/contract-toolkit/examples/artifact-schemas/app/generated/_input.py
@@ -1,0 +1,10 @@
+# AUTO-GENERATED from contract/app.pkl — DO NOT EDIT MANUALLY.
+# To regenerate: pkl eval -m . contract/app.pkl
+from __future__ import annotations
+
+from application_sdk.templates.contracts import ExtractionInput
+
+
+class AppInputContract(ExtractionInput):
+    lookback_days: int = 30
+    """How much query history to read."""

--- a/contract-toolkit/examples/artifact-schemas/app/generated/artifact-schemas-example.json
+++ b/contract-toolkit/examples/artifact-schemas/app/generated/artifact-schemas-example.json
@@ -1,0 +1,31 @@
+{
+  "id": "artifact-schemas-example",
+  "name": "Artifact Schemas Example",
+  "logo": "https://assets.atlan.com/assets/fullscreen-exit.svg",
+  "config": {
+    "properties": {
+      "lookback-days": {
+        "type": "number",
+        "required": false,
+        "ui": {
+          "widget": "inputNumber",
+          "label": "Query lookback (days)",
+          "hidden": false,
+          "help": "How much query history to read.",
+          "grid": 4
+        },
+        "default": 30
+      }
+    },
+    "steps": [
+      {
+        "title": "Configuration",
+        "description": "",
+        "id": "configuration",
+        "properties": [
+          "lookback-days"
+        ]
+      }
+    ]
+  }
+}

--- a/contract-toolkit/examples/artifact-schemas/app/generated/artifact_schemas.json
+++ b/contract-toolkit/examples/artifact-schemas/app/generated/artifact_schemas.json
@@ -1,0 +1,101 @@
+{
+  "version": 1,
+  "schemas": {
+    "raw_queries": {
+      "format": "parquet",
+      "description": "Query-history rows written for the downstream parser.",
+      "fields": [
+        {
+          "name": "QUERY_ID",
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "START_TIME",
+          "type": "timestamp",
+          "required": true,
+          "description": "Must be a real timestamp column. A stringified timestamp here is the defect this declaration exists to catch."
+        },
+        {
+          "name": "CREDITS_USED",
+          "type": "float",
+          "required": false
+        },
+        {
+          "name": "ROWS_PRODUCED",
+          "type": "decimal",
+          "required": false
+        },
+        {
+          "name": "YEAR",
+          "type": "int",
+          "required": true,
+          "description": "Partition column."
+        },
+        {
+          "name": "SESSION_PARAMS",
+          "type": "json",
+          "required": false,
+          "description": "Physically a string column; semantically a JSON blob. Collapsing the two would defeat this hop's check."
+        }
+      ]
+    },
+    "transformed_entities": {
+      "format": "ndjson",
+      "description": "Transformed entities streamed to the publish step.",
+      "fields": [
+        {
+          "name": "typeName",
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "attributes",
+          "type": "struct",
+          "required": true
+        },
+        {
+          "name": "attributes.qualifiedName",
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "attributes.name",
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "attributes.lastSyncRunAt",
+          "type": "timestamp",
+          "required": false
+        },
+        {
+          "name": "customAttributes",
+          "type": "any",
+          "required": false
+        }
+      ]
+    },
+    "upstream_lineage": {
+      "format": "ndjson",
+      "description": "Lineage edges this app reads from an upstream producer.",
+      "fields": [
+        {
+          "name": "source_qualified_name",
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "target_qualified_name",
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "process_id",
+          "type": "string",
+          "required": true
+        }
+      ]
+    }
+  }
+}

--- a/contract-toolkit/examples/artifact-schemas/app/generated/artifact_schemas.json
+++ b/contract-toolkit/examples/artifact-schemas/app/generated/artifact_schemas.json
@@ -78,6 +78,42 @@
           "description": "When this entity was last written by a run. Absent on the first sync, set on every later one."
         },
         {
+          "name": "attributes.columns",
+          "type": "array",
+          "required": false,
+          "description": "Child columns carried inline on a table entity. Absent for entity types that have none."
+        },
+        {
+          "name": "attributes.columns[]",
+          "type": "struct",
+          "required": true,
+          "description": "One column. `required` on the paths below reads per element, so an empty columns array satisfies them vacuously."
+        },
+        {
+          "name": "attributes.columns[].name",
+          "type": "string",
+          "required": true,
+          "description": "Column name as it appears in the source."
+        },
+        {
+          "name": "attributes.columns[].order",
+          "type": "int",
+          "required": true,
+          "description": "Ordinal position of the column within the table, 1-based."
+        },
+        {
+          "name": "attributes.tags",
+          "type": "array",
+          "required": false,
+          "description": "Source-side tags on the entity. Absent when the source has no tagging."
+        },
+        {
+          "name": "attributes.tags[]",
+          "type": "string",
+          "required": true,
+          "description": "One tag. Elements are plain strings, not objects."
+        },
+        {
           "name": "customAttributes",
           "type": "any",
           "required": false,

--- a/contract-toolkit/examples/artifact-schemas/app/generated/artifact_schemas.json
+++ b/contract-toolkit/examples/artifact-schemas/app/generated/artifact_schemas.json
@@ -8,35 +8,38 @@
         {
           "name": "QUERY_ID",
           "type": "string",
-          "required": true
+          "required": true,
+          "description": "Warehouse-assigned query id, unique within the account. The parser's join key."
         },
         {
           "name": "START_TIME",
           "type": "timestamp",
           "required": true,
-          "description": "Must be a real timestamp column. A stringified timestamp here is the defect this declaration exists to catch."
+          "description": "When the query began executing. Must be a real timestamp column — a stringified timestamp here is the defect this declaration exists to catch."
         },
         {
           "name": "CREDITS_USED",
           "type": "float",
-          "required": false
+          "required": false,
+          "description": "Compute credits billed for the query. Absent on warehouses that do not meter per query."
         },
         {
           "name": "ROWS_PRODUCED",
           "type": "decimal",
-          "required": false
+          "required": false,
+          "description": "Row count the query returned. Declared decimal because a Snowflake NUMBER lands as parquet decimal128; asserting float would mis-flag it or lose precision."
         },
         {
           "name": "YEAR",
           "type": "int",
           "required": true,
-          "description": "Partition column."
+          "description": "Partition column derived from START_TIME. The parser prunes on it, so a string here silently disables partition pruning."
         },
         {
           "name": "SESSION_PARAMS",
           "type": "json",
           "required": false,
-          "description": "Physically a string column; semantically a JSON blob. Collapsing the two would defeat this hop's check."
+          "description": "Session settings in force for the query. Physically a string column, semantically a JSON blob — collapsing the two would defeat this hop's check."
         }
       ]
     },
@@ -47,32 +50,38 @@
         {
           "name": "typeName",
           "type": "string",
-          "required": true
+          "required": true,
+          "description": "Atlan type this record instantiates, e.g. Table. Publish routes on it."
         },
         {
           "name": "attributes",
           "type": "struct",
-          "required": true
+          "required": true,
+          "description": "Container for the entity's attributes. Declared so a record that flattened them to top level is caught before publish reads it."
         },
         {
           "name": "attributes.qualifiedName",
           "type": "string",
-          "required": true
+          "required": true,
+          "description": "Stable identity of the entity. Publish upserts on it, so a missing or non-string value creates duplicates rather than failing."
         },
         {
           "name": "attributes.name",
           "type": "string",
-          "required": true
+          "required": true,
+          "description": "Display name shown in the UI."
         },
         {
           "name": "attributes.lastSyncRunAt",
           "type": "timestamp",
-          "required": false
+          "required": false,
+          "description": "When this entity was last written by a run. Absent on the first sync, set on every later one."
         },
         {
           "name": "customAttributes",
           "type": "any",
-          "required": false
+          "required": false,
+          "description": "Source-specific extras passed through untouched. Type deliberately unasserted — the shape is the source's, not ours."
         }
       ]
     },
@@ -83,17 +92,20 @@
         {
           "name": "source_qualified_name",
           "type": "string",
-          "required": true
+          "required": true,
+          "description": "Qualified name of the upstream asset the edge starts at."
         },
         {
           "name": "target_qualified_name",
           "type": "string",
-          "required": true
+          "required": true,
+          "description": "Qualified name of the downstream asset the edge ends at."
         },
         {
           "name": "process_id",
           "type": "string",
-          "required": true
+          "required": true,
+          "description": "Id of the process that produced the edge. Groups edges into one lineage process on read."
         }
       ]
     }

--- a/contract-toolkit/examples/artifact-schemas/app/generated/manifest.json
+++ b/contract-toolkit/examples/artifact-schemas/app/generated/manifest.json
@@ -1,0 +1,26 @@
+{
+  "execution_mode": "automation-engine",
+  "dag": {
+    "extract": {
+      "activity_name": "execute_workflow",
+      "activity_display_name": "Extract Artifact Schemas Example Metadata",
+      "app_name": "artifact-schemas-example",
+      "inputs": {
+        "workflow_type": "artifact-schemas-example",
+        "app_name": "artifact-schemas-example",
+        "app_id": "",
+        "argo_workflow_slug": "",
+        "task_queue": "atlan-artifact-schemas-example-{deployment_name}",
+        "args": {
+          "app_name": "artifact-schemas-example",
+          "credential": "{{credential}}",
+          "agent_json": "{{agent-json}}",
+          "lookback_days": "{{lookback-days}}"
+        }
+      },
+      "error_handling": {
+        "start_to_close_timeout_seconds": 86400
+      }
+    }
+  }
+}

--- a/contract-toolkit/examples/artifact-schemas/atlan.yaml
+++ b/contract-toolkit/examples/artifact-schemas/atlan.yaml
@@ -1,0 +1,17 @@
+# AUTO-GENERATED from contract/app.pkl — DO NOT EDIT MANUALLY.
+# To regenerate: pkl eval -m . contract/app.pkl
+name: artifact-schemas-example
+display_name: Artifact Schemas Example
+type: connector
+execution_mode: native
+icon_url: https://assets.atlan.com/assets/fullscreen-exit.svg
+visibility: public
+build_tag: v1
+self_deployed_runtime: true
+entrypoints:
+- name: artifact-schemas-example
+  display_name: Artifact Schemas Example
+  icon_url: https://assets.atlan.com/assets/fullscreen-exit.svg
+  type: connector
+  package_id: '@atlan/artifact-schemas-example'
+  marketplace_card: true

--- a/contract-toolkit/scripts/check-invariants.sh
+++ b/contract-toolkit/scripts/check-invariants.sh
@@ -319,7 +319,7 @@ check_artifact_schemas() {
 
 check_artifact_schemas "path-shaped key" 'A-Za-z_' "$(artifact_schemas_body '  ["artifacts/raw/*.parquet"] = new ArtifactSchema {
     format = "parquet"
-    fields { new ArtifactField { name = "QUERY_ID"; type = "string" } }
+    fields { new ArtifactField { name = "QUERY_ID"; type = "string"; description = "d" } }
   }')"
 
 check_artifact_schemas "empty fields" 'isEmpty' "$(artifact_schemas_body '  ["raw_queries"] = new ArtifactSchema {
@@ -330,8 +330,8 @@ check_artifact_schemas "empty fields" 'isEmpty' "$(artifact_schemas_body '  ["ra
 check_artifact_schemas "duplicate field names" 'isDistinct' "$(artifact_schemas_body '  ["raw_queries"] = new ArtifactSchema {
     format = "parquet"
     fields {
-      new ArtifactField { name = "QUERY_ID"; type = "string" }
-      new ArtifactField { name = "QUERY_ID"; type = "int" }
+      new ArtifactField { name = "QUERY_ID"; type = "string"; description = "d" }
+      new ArtifactField { name = "QUERY_ID"; type = "int"; description = "d" }
     }
   }')"
 
@@ -343,7 +343,7 @@ AS_CTRL_CONTRACT="$(mktemp "$REPO_ROOT/test-artifact-schemas-ctrl-XXXXXX.pkl")"
 AS_CTRL_OUT="$(mktemp -d "$REPO_ROOT/test-artifact-schemas-ctrl-out-XXXXXX")"
 artifact_schemas_body '  ["raw_queries"] = new ArtifactSchema {
     format = "parquet"
-    fields { new ArtifactField { name = "START_TIME"; type = "timestamp" } }
+    fields { new ArtifactField { name = "START_TIME"; type = "timestamp"; description = "d" } }
   }' > "$AS_CTRL_CONTRACT"
 AS_CTRL_ERR="$(pkl eval -m "$AS_CTRL_OUT" "$AS_CTRL_CONTRACT" 2>&1 || true)"
 if echo "$AS_CTRL_ERR" | grep -q "Pkl Error"; then
@@ -356,6 +356,16 @@ elif [ ! -f "$AS_CTRL_OUT/app/generated/artifact_schemas.json" ]; then
 fi
 rm -f "$AS_CTRL_CONTRACT"
 rm -rf "$AS_CTRL_OUT"
+
+check_artifact_schemas "missing field description" '`description` is required' "$(artifact_schemas_body '  ["raw_queries"] = new ArtifactSchema {
+    format = "parquet"
+    fields { new ArtifactField { name = "START_TIME"; type = "timestamp" } }
+  }')"
+
+check_artifact_schemas "empty field description" 'isEmpty' "$(artifact_schemas_body '  ["raw_queries"] = new ArtifactSchema {
+    format = "parquet"
+    fields { new ArtifactField { name = "START_TIME"; type = "timestamp"; description = "" } }
+  }')"
 
 # A bundle root has no contract model, so a key there could not name a real
 # FileReference field, and the file it would emit could be picked up as a fallback
@@ -380,7 +390,7 @@ entrypoints {
 artifactSchemas {
   ["raw_queries"] = new ArtifactSchema {
     format = "parquet"
-    fields { new ArtifactField { name = "START_TIME"; type = "timestamp" } }
+    fields { new ArtifactField { name = "START_TIME"; type = "timestamp"; description = "d" } }
   }
 }
 PKLEOF

--- a/contract-toolkit/scripts/check-invariants.sh
+++ b/contract-toolkit/scripts/check-invariants.sh
@@ -260,6 +260,171 @@ uiConfig = new Config.UIConfig {
 }'
 
 # --------------------------------------------------------------------------
+# 9. artifactSchemas (ADR-0020): the three declarations that must fail to
+#    generate rather than render a declaration that checks nothing.
+#
+#    - A path/prefix/glob key. Declarations are keyed by the contract field the
+#      runtime is materialising; path-shape inference is what let the earlier
+#      upload-time hook match nothing and validate zero records.
+#    - An empty `fields` listing. Reports as declared, asserts nothing — the
+#      "looks adopted, validates nothing" state the capability exists to remove.
+#    - Duplicate field names within a schema, which would silently collapse to
+#      one assertion.
+#
+#    Asserted here rather than in pkl test because facts cannot express
+#    "eval fails".
+# --------------------------------------------------------------------------
+echo ":: Checking artifactSchemas invariants..."
+
+# $1 = artifactSchemas block body
+artifact_schemas_body() {
+  cat <<PKLEOF
+amends "src/App.pkl"
+
+name = "artifact-schemas-invariant-app"
+displayName = "Artifact Schemas Invariant App"
+icon = "https://example.com/icon.svg"
+hasCredentialConfig = false
+pipeline { publish = null }
+
+uiConfig = new UIConfig {
+  tasks {
+    ["Configuration"] {
+      inputs { ["target"] = new TextInput { title = "Target"; placeholderText = "x" } }
+    }
+  }
+}
+
+artifactSchemas {
+$1
+}
+PKLEOF
+}
+
+check_artifact_schemas() {
+  local label="$1" expected="$2" body="$3"
+  local contract out_dir err
+  contract="$(mktemp "$REPO_ROOT/test-artifact-schemas-XXXXXX.pkl")"
+  out_dir="$(mktemp -d "$REPO_ROOT/test-artifact-schemas-out-XXXXXX")"
+  printf '%s\n' "$body" > "$contract"
+  err="$(pkl eval -m "$out_dir" "$contract" 2>&1 || true)"
+  rm -f "$contract"
+  rm -rf "$out_dir"
+  if ! echo "$err" | grep -q "$expected"; then
+    echo "FAIL: artifactSchemas invariant did not fire for $label"
+    echo "  Got: $err"
+    fail=1
+  fi
+}
+
+check_artifact_schemas "path-shaped key" 'A-Za-z_' "$(artifact_schemas_body '  ["artifacts/raw/*.parquet"] = new ArtifactSchema {
+    format = "parquet"
+    fields { new ArtifactField { name = "QUERY_ID"; type = "string" } }
+  }')"
+
+check_artifact_schemas "empty fields" 'isEmpty' "$(artifact_schemas_body '  ["raw_queries"] = new ArtifactSchema {
+    format = "parquet"
+    fields {}
+  }')"
+
+check_artifact_schemas "duplicate field names" 'isDistinct' "$(artifact_schemas_body '  ["raw_queries"] = new ArtifactSchema {
+    format = "parquet"
+    fields {
+      new ArtifactField { name = "QUERY_ID"; type = "string" }
+      new ArtifactField { name = "QUERY_ID"; type = "int" }
+    }
+  }')"
+
+# Control: the same contract with a valid declaration must generate cleanly, and
+# must actually emit the artifact. Without this, a check that always errors (for
+# any reason) would pass the three assertions above and prove nothing.
+echo ":: Checking a valid artifactSchemas declaration still generates (control)..."
+AS_CTRL_CONTRACT="$(mktemp "$REPO_ROOT/test-artifact-schemas-ctrl-XXXXXX.pkl")"
+AS_CTRL_OUT="$(mktemp -d "$REPO_ROOT/test-artifact-schemas-ctrl-out-XXXXXX")"
+artifact_schemas_body '  ["raw_queries"] = new ArtifactSchema {
+    format = "parquet"
+    fields { new ArtifactField { name = "START_TIME"; type = "timestamp" } }
+  }' > "$AS_CTRL_CONTRACT"
+AS_CTRL_ERR="$(pkl eval -m "$AS_CTRL_OUT" "$AS_CTRL_CONTRACT" 2>&1 || true)"
+if echo "$AS_CTRL_ERR" | grep -q "Pkl Error"; then
+  echo "FAIL: control contract with a valid artifactSchemas declaration failed to generate"
+  echo "  Got: $AS_CTRL_ERR"
+  fail=1
+elif [ ! -f "$AS_CTRL_OUT/app/generated/artifact_schemas.json" ]; then
+  echo "FAIL: control contract generated no app/generated/artifact_schemas.json"
+  fail=1
+fi
+rm -f "$AS_CTRL_CONTRACT"
+rm -rf "$AS_CTRL_OUT"
+
+# A bundle root has no contract model, so a key there could not name a real
+# FileReference field, and the file it would emit could be picked up as a fallback
+# for an entrypoint that declares nothing. Generation must refuse.
+echo ":: Checking artifactSchemas on a bundle root is refused..."
+AS_BUNDLE_CONTRACT="$(mktemp "$REPO_ROOT/test-artifact-schemas-bundle-XXXXXX.pkl")"
+AS_BUNDLE_OUT="$(mktemp -d "$REPO_ROOT/test-artifact-schemas-bundle-out-XXXXXX")"
+cat > "$AS_BUNDLE_CONTRACT" << 'PKLEOF'
+amends "src/App.pkl"
+
+import "examples/artifact-schemas/app.pkl" as Sub
+
+name = "artifact-schemas-bundle"
+displayName = "Artifact Schemas Bundle"
+icon = "https://example.com/icon.svg"
+hasCredentialConfig = false
+
+entrypoints {
+  new Entrypoint { name = "sub"; displayName = "Sub"; contract = Sub }
+}
+
+artifactSchemas {
+  ["raw_queries"] = new ArtifactSchema {
+    format = "parquet"
+    fields { new ArtifactField { name = "START_TIME"; type = "timestamp" } }
+  }
+}
+PKLEOF
+AS_BUNDLE_ERR="$(pkl eval -m "$AS_BUNDLE_OUT" "$AS_BUNDLE_CONTRACT" 2>&1 || true)"
+rm -f "$AS_BUNDLE_CONTRACT"
+rm -rf "$AS_BUNDLE_OUT"
+if ! echo "$AS_BUNDLE_ERR" | grep -q "multi-entrypoint bundle root"; then
+  echo "FAIL: artifactSchemas on a bundle root was not refused"
+  echo "  Got: $AS_BUNDLE_ERR"
+  fail=1
+fi
+
+# Control: a contract declaring NO artifactSchemas must not emit the artifact.
+# This is the fleet-wide byte-identical requirement — every existing consumer
+# repo regenerates against this toolkit and must see no new file.
+echo ":: Checking an app with no artifactSchemas emits no artifact (control)..."
+AS_NONE_CONTRACT="$(mktemp "$REPO_ROOT/test-artifact-schemas-none-XXXXXX.pkl")"
+AS_NONE_OUT="$(mktemp -d "$REPO_ROOT/test-artifact-schemas-none-out-XXXXXX")"
+cat > "$AS_NONE_CONTRACT" << 'PKLEOF'
+amends "src/App.pkl"
+
+name = "artifact-schemas-absent-app"
+displayName = "Artifact Schemas Absent App"
+icon = "https://example.com/icon.svg"
+hasCredentialConfig = false
+pipeline { publish = null }
+
+uiConfig = new UIConfig {
+  tasks {
+    ["Configuration"] {
+      inputs { ["target"] = new TextInput { title = "Target"; placeholderText = "x" } }
+    }
+  }
+}
+PKLEOF
+pkl eval -m "$AS_NONE_OUT" "$AS_NONE_CONTRACT" > /dev/null 2>&1 || true
+if [ -f "$AS_NONE_OUT/app/generated/artifact_schemas.json" ]; then
+  echo "FAIL: an app declaring no artifactSchemas still emitted artifact_schemas.json"
+  fail=1
+fi
+rm -f "$AS_NONE_CONTRACT"
+rm -rf "$AS_NONE_OUT"
+
+# --------------------------------------------------------------------------
 # Done
 # --------------------------------------------------------------------------
 if [ "$fail" -ne 0 ]; then

--- a/contract-toolkit/scripts/check-invariants.sh
+++ b/contract-toolkit/scripts/check-invariants.sh
@@ -367,6 +367,71 @@ check_artifact_schemas "empty field description" 'isEmpty' "$(artifact_schemas_b
     fields { new ArtifactField { name = "START_TIME"; type = "timestamp"; description = "" } }
   }')"
 
+# A nested path whose container is undeclared drops exactly the check that catches a
+# producer which flattened the container away — the leaf assertion can still pass
+# against a flattened record. And a container declared with a scalar type is a
+# contradiction the validator would have to resolve by guessing.
+check_artifact_schemas "nested path with undeclared container" 'without their container' "$(artifact_schemas_body '  ["raw_queries"] = new ArtifactSchema {
+    format = "ndjson"
+    fields { new ArtifactField { name = "attributes.name"; type = "string"; description = "d" } }
+  }')"
+
+check_artifact_schemas "element path with undeclared element" 'without their container' "$(artifact_schemas_body '  ["raw_queries"] = new ArtifactSchema {
+    format = "ndjson"
+    fields {
+      new ArtifactField { name = "columns"; type = "array"; description = "d" }
+      new ArtifactField { name = "columns[].name"; type = "string"; description = "d" }
+    }
+  }')"
+
+check_artifact_schemas "named-member step into a scalar container" 'descends into' "$(artifact_schemas_body '  ["raw_queries"] = new ArtifactSchema {
+    format = "ndjson"
+    fields {
+      new ArtifactField { name = "attributes"; type = "string"; description = "d" }
+      new ArtifactField { name = "attributes.name"; type = "string"; description = "d" }
+    }
+  }')"
+
+check_artifact_schemas "[] step into a non-array container" 'descends into' "$(artifact_schemas_body '  ["raw_queries"] = new ArtifactSchema {
+    format = "ndjson"
+    fields {
+      new ArtifactField { name = "columns"; type = "struct"; description = "d" }
+      new ArtifactField { name = "columns[]"; type = "struct"; description = "d" }
+    }
+  }')"
+
+# Index selection is not a declaration — a schema describes every element, not one of
+# them — so `columns[0]` must fail the path grammar rather than be read as `columns[]`.
+check_artifact_schemas "index selection in a path" 'Type constraint' "$(artifact_schemas_body '  ["raw_queries"] = new ArtifactSchema {
+    format = "ndjson"
+    fields { new ArtifactField { name = "columns[0]"; type = "struct"; description = "d" } }
+  }')"
+
+# Control: a fully-declared array of structs must generate cleanly. Without this, the
+# four refusals above would pass even if every element path were rejected outright.
+echo ":: Checking a fully-declared array of structs still generates (control)..."
+AS_ARR_CONTRACT="$(mktemp "$REPO_ROOT/test-artifact-schemas-arr-XXXXXX.pkl")"
+AS_ARR_OUT="$(mktemp -d "$REPO_ROOT/test-artifact-schemas-arr-out-XXXXXX")"
+artifact_schemas_body '  ["transformed_entities"] = new ArtifactSchema {
+    format = "ndjson"
+    fields {
+      new ArtifactField { name = "columns"; type = "array"; description = "d" }
+      new ArtifactField { name = "columns[]"; type = "struct"; description = "d" }
+      new ArtifactField { name = "columns[].name"; type = "string"; description = "d" }
+    }
+  }' > "$AS_ARR_CONTRACT"
+AS_ARR_ERR="$(pkl eval -m "$AS_ARR_OUT" "$AS_ARR_CONTRACT" 2>&1 || true)"
+if echo "$AS_ARR_ERR" | grep -q "Pkl Error"; then
+  echo "FAIL: control contract with a fully-declared array of structs failed to generate"
+  echo "  Got: $AS_ARR_ERR"
+  fail=1
+elif ! grep -q '"columns\[\].name"' "$AS_ARR_OUT/app/generated/artifact_schemas.json"; then
+  echo "FAIL: control contract did not render the element path columns[].name"
+  fail=1
+fi
+rm -f "$AS_ARR_CONTRACT"
+rm -rf "$AS_ARR_OUT"
+
 # A bundle root has no contract model, so a key there could not name a real
 # FileReference field, and the file it would emit could be picked up as a fallback
 # for an entrypoint that declares nothing. Generation must refuse.

--- a/contract-toolkit/src/App.pkl
+++ b/contract-toolkit/src/App.pkl
@@ -411,6 +411,46 @@ manifestTopLevelArgs: Mapping<String, String> = new Mapping {
 /// ```
 pipeline: Pipeline = new Pipeline {}
 
+// ── ARTIFACT SCHEMAS ─────────────────────────────────────────────────────────
+
+/// Per-artifact field declarations, rendered to `app/generated/artifact_schemas.json`.
+///
+/// Default: empty — an app that declares nothing generates **byte-identical**
+/// output to before this block existed, so adopting it is opt-in per app.
+///
+/// Each key is the name of a `FileReference` field on this entrypoint's input or
+/// output contract model (`ContractFieldName`) — never a path, prefix, or glob.
+/// Keying by contract field is the whole point: the runtime knows which field it
+/// is materialising, so nothing is inferred from the shape of a storage path.
+///
+/// The toolkit is transport, not owner. Every field below is authored by the app
+/// that *consumes* the artifact; the SDK ships no field list. For a cross-app
+/// hand-off the consumer declares what it requires of its input, and the producer
+/// references the consumer's published declaration rather than re-authoring it.
+///
+/// Multi-entrypoint apps declare `artifactSchemas` on each entrypoint contract;
+/// the bundle re-exports them to `app/generated/{entrypoint}/artifact_schemas.json`
+/// like every other per-entrypoint artifact, so the entrypoint dimension is the
+/// file's location and the key inside the file stays the contract field name.
+/// Declaring it on a bundle **root** is a generation error: the root has no contract
+/// model, so a key there could not name a real field, and the file it would emit
+/// could be picked up as a fallback for an entrypoint that declares nothing.
+///
+/// ```pkl
+/// artifactSchemas {
+///   ["raw_queries"] = new ArtifactSchema {
+///     format = "parquet"
+///     description = "Query-history rows the parser reads."
+///     fields {
+///       new ArtifactField { name = "QUERY_ID"; type = "string" }
+///       new ArtifactField { name = "START_TIME"; type = "timestamp" }
+///       new ArtifactField { name = "CREDITS_USED"; type = "float"; required = false }
+///     }
+///   }
+/// }
+/// ```
+artifactSchemas: Mapping<ContractFieldName, ArtifactSchema> = new Mapping {}
+
 // ── DEPLOY CONFIG ─────────────────────────────────────────────────────────────
 
 /// Deployment configuration. Leave unset (null, the default) to let Heracles
@@ -3773,6 +3813,147 @@ local appYamlOutput: FileOutput = new FileOutput {
   text = generatedYamlHeader + renderer.renderDocument(value)
 }
 
+// ── Artifact schema declarations (ADR-0020) ──────────────────────────────────
+//
+// Apps declare the shape of the files they hand off, and the SDK checks the real
+// artifact against that declaration at the hand-off. The toolkit's whole job here
+// is transport: it owns the *type vocabulary* and the file format; every field is
+// the app's. Nothing in `src/` names a column.
+
+/// Logical field types every validator must map, for every format. The stable floor.
+///
+/// This is a *logical* vocabulary, not a physical one — one member can cover several
+/// physical encodings (`int` matches any arrow width and signedness; `timestamp`
+/// matches `timestamp[*]` at any unit, tz-aware or not). The load-bearing member is
+/// `timestamp`: an arrow `string` does **not** satisfy it, which is the single
+/// asymmetry the capability exists to assert.
+///
+/// `any` means "must be present, type not asserted" — declare it rather than
+/// inventing a wrong type to satisfy the enum.
+typealias ArtifactFieldType =
+  "string"|"int"|"float"|"bool"|"timestamp"|"date"|"json"|"any"
+
+/// Additive extension of `ArtifactFieldType`. A member here may resolve to
+/// "unsupported for this format" in a given validator without widening the floor
+/// above, so a contract can declare it before every validator supports it.
+///
+/// `decimal` exists because a Snowflake `NUMBER` lands as parquet `decimal128` and
+/// asserting `float` would either mis-flag it or lose precision. `binary`, `time`,
+/// `array`, `struct` and `map` are real in warehouse sources but on no current hop.
+typealias ArtifactFieldTypeExtended =
+  ArtifactFieldType|"decimal"|"binary"|"time"|"array"|"struct"|"map"
+
+/// Physical container format of a declared artifact. Each format has its own
+/// validator with its own dependency floor — NDJSON streams line by line on the
+/// stdlib, parquet reads only the file footer and needs pyarrow.
+///
+/// Content format, not file extension: SDK NDJSON artifacts are conventionally
+/// written with a `.json` suffix and are still `"ndjson"` here.
+typealias ArtifactFormat = "ndjson"|"parquet"
+
+/// Name of a `FileReference` field on an entrypoint's input/output contract model:
+/// a Python identifier.
+///
+/// Deliberately **not** a path, prefix, or glob. The runtime resolves a declaration
+/// from the contract field it is materialising, never from the shape of a storage
+/// path — path-shape inference is what let the earlier upload-time hook match
+/// nothing and silently validate zero records.
+typealias ContractFieldName = String(matches(Regex("[A-Za-z_][A-Za-z0-9_]*")))
+
+/// Dotted path to a field inside an artifact record: `"a"`, `"a.b"`, `"a.b.c"`.
+///
+/// Nested payloads are declared as dotted paths plus a container type — declare
+/// `attributes` as `struct` and `attributes.name` as `string` — rather than a
+/// recursive type grammar. Empty segments (`""`, `".a"`, `"a."`, `"a..b"`) are
+/// rejected at eval time.
+typealias ArtifactFieldPath = String(matches(Regex("[^.]+(\\.[^.]+)*")))
+
+/// One declared field within an artifact.
+class ArtifactField {
+  /// Dotted path to the field within a record. See `ArtifactFieldPath`.
+  name: ArtifactFieldPath
+
+  /// Logical type asserted for this field. Use `"any"` to assert presence only.
+  type: ArtifactFieldTypeExtended = "any"
+
+  /// Whether the field must be present in every record / in the parquet schema.
+  /// Default `true` — a declared field is expected to be there. Set `false` for a
+  /// field that is genuinely optional but must carry `type` when it does appear.
+  required: Boolean = true
+
+  /// Free-form note for humans reading the generated artifact. Never asserted.
+  description: String?
+}
+
+/// The declared shape of one artifact handed off through a contract `FileReference`.
+///
+/// `fields` must be non-empty: a schema declaring zero fields checks nothing while
+/// reporting as declared, which is exactly the "looks adopted, validates nothing"
+/// state this capability exists to remove. Field names must be distinct — a
+/// duplicate would silently collapse to one assertion.
+class ArtifactSchema {
+  /// Physical format of the artifact. No default: the app must say which validator
+  /// applies, because the answer is not derivable from the contract field.
+  format: ArtifactFormat
+
+  /// Declared fields. Non-empty, names distinct.
+  fields: Listing<ArtifactField>(!isEmpty, this.toList().map((f) -> f.name).isDistinct)
+
+  /// Free-form note for humans reading the generated artifact. Never asserted.
+  description: String?
+}
+
+local function renderArtifactField(f: ArtifactField): Mapping<String, Any> = new Mapping {
+  ["name"] = f.name
+  ["type"] = f.type
+  ["required"] = f.required
+  when (f.description != null) { ["description"] = f.description }
+}
+
+local function renderArtifactSchema(s: ArtifactSchema): Mapping<String, Any> = new Mapping {
+  ["format"] = s.format
+  when (s.description != null) { ["description"] = s.description }
+  ["fields"] = new Listing {
+    for (f in s.fields) {
+      renderArtifactField(f)
+    }
+  }
+}
+
+/// Envelope version of `artifact_schemas.json`. Bump only on a breaking change to
+/// the file's shape; the SDK loader reads it to decide how to parse.
+local artifactSchemasVersion: Int = 1
+
+local artifactSchemasData: Mapping<String, Any> = new Mapping {
+  ["version"] = artifactSchemasVersion
+  ["schemas"] = new Mapping {
+    for (fieldName, schema in artifactSchemas) {
+      [fieldName] = renderArtifactSchema(schema)
+    }
+  }
+}
+
+local artifactSchemasOutput: FileOutput = new FileOutput {
+  value = artifactSchemasData
+  renderer = new JsonRenderer {}
+}
+
+// A bundle root has no contract model of its own, so a key here could never name a
+// real `FileReference` field. Emitting it anyway would put a shared
+// `app/generated/artifact_schemas.json` next to the per-entrypoint ones, where a
+// loader looking up an entrypoint that declares nothing could fall back onto it and
+// check the wrong declarations — the silent-wrong-answer failure mode this whole
+// capability exists to remove. Refuse instead. Two entrypoints that genuinely share
+// an artifact assign one shared `ArtifactSchema` value into both contracts.
+hidden _bundleArtifactSchemaCheck: Any =
+  if (!entrypoints.isEmpty && !artifactSchemas.isEmpty)
+    throw("App.pkl: `artifactSchemas` is declared on a multi-entrypoint bundle root, "
+      + "which has no contract model of its own. Declarations are keyed by a FileReference "
+      + "field on an entrypoint's input/output contract, so move them onto each "
+      + "entrypoint's `contract`. Entrypoints that share an artifact can assign one "
+      + "shared ArtifactSchema value into both.")
+  else null
+
 // ── Multi-entrypoint credential dedup (from NativeAppBundle.pkl) ──────────────
 
 class ContractFile {
@@ -3839,6 +4020,10 @@ output =
   // is a supported opt-out, and a lazily-evaluated check inside that node would
   // let a reserved-name collision through for exactly those contracts.
   let (_reservedUiCheck = reservedUiFieldInvariant)
+  // Forced for the same reason: the single-entrypoint emission below is the only
+  // reader of `artifactSchemas`, so a bundle root's declaration would otherwise
+  // never be evaluated and would vanish without a word.
+  let (_bundleSchemaCheck = _bundleArtifactSchemaCheck)
   let (_e2eCredOutput = generateE2ECredentialPy())
   let (_e2eSubsOutput = generateE2ESubstitutionsPy())
   new ModuleOutput {
@@ -3871,6 +4056,15 @@ output =
         }
         when (_e2eSubsOutput != null) {
           ["app/generated/_e2e_substitutions.py"] = _e2eSubsOutput!!
+        }
+        // artifact schema declarations (ADR-0020) — also independent of uiConfig:
+        // a declaration describes data hand-offs, which an app has whether or not
+        // it renders a setup form. Gated on non-empty so an app that declares
+        // nothing generates byte-identical output to before this block existed.
+        // Multi-entrypoint apps declare these on each entrypoint's contract; the
+        // re-export loop below relocates each one to `app/generated/{entrypoint}/`.
+        when (!artifactSchemas.isEmpty) {
+          ["app/generated/artifact_schemas.json"] = artifactSchemasOutput
         }
       }
 

--- a/contract-toolkit/src/App.pkl
+++ b/contract-toolkit/src/App.pkl
@@ -3867,13 +3867,48 @@ typealias ArtifactFormat = "ndjson"|"parquet"
 /// nothing and silently validate zero records.
 typealias ContractFieldName = String(matches(Regex("[A-Za-z_][A-Za-z0-9_]*")))
 
-/// Dotted path to a field inside an artifact record: `"a"`, `"a.b"`, `"a.b.c"`.
+/// Path to a field inside an artifact record, built from two step kinds:
 ///
-/// Nested payloads are declared as dotted paths plus a container type — declare
-/// `attributes` as `struct` and `attributes.name` as `string` — rather than a
-/// recursive type grammar. Empty segments (`""`, `".a"`, `"a."`, `"a..b"`) are
-/// rejected at eval time.
-typealias ArtifactFieldPath = String(matches(Regex("[^.]+(\\.[^.]+)*")))
+///   - `.name` — descend into a container's named member: `"a"`, `"a.b"`, `"a.b.c"`
+///   - `[]` — descend into an array's **element**: `"tags[]"`, `"columns[].name"`
+///
+/// Nested payloads are declared as paths plus a container type — declare
+/// `attributes` as `struct` and `attributes.name` as `string`; declare `columns` as
+/// `array`, `columns[]` as `struct`, and `columns[].name` as `string` — rather than
+/// a recursive type grammar. The flat form is what parquet already uses to address
+/// nested leaves, and it lets a static diff compare two *sets* of paths instead of
+/// two trees.
+///
+/// `[]` is the explicit "descend into the list" step precisely because the physical
+/// encoding is not: parquet spells the same leaf `columns.list.element.name` under a
+/// 3-level encoding and `columns.bag.array.name` under the legacy 2-level one, so a
+/// declaration written in physical terms would be pinned to an encoding the producer
+/// can change. `[]` says what is meant; the validator resolves it per format.
+///
+/// On an element path, `required` reads per element — `columns[].name` required means
+/// every element must carry `name`, and an empty array satisfies it vacuously.
+///
+/// Rejected at eval time: empty segments (`""`, `".a"`, `"a."`, `"a..b"`) and
+/// malformed brackets (`"[]"`, `"a["`, `"a]"`, `"a[0]"` — index selection is not a
+/// declaration, since a schema describes every element, not one of them).
+typealias ArtifactFieldPath =
+  String(matches(Regex("[^.\\[\\]]+(\\[\\])*(\\.[^.\\[\\]]+(\\[\\])*)*")))
+
+/// The path one step up from `p`, or `null` when `p` is already top level.
+/// `"a.b"` → `"a"`, `"a[]"` → `"a"`, `"a[].b"` → `"a[]"`.
+const local function artifactFieldParentPath(p: String): String? =
+  if (p.endsWith("[]")) p.dropLast(2)
+  else
+    let (i = p.lastIndexOfOrNull("."))
+    if (i == null) null else p.take(i)
+
+/// Types that can carry a named member (`parent.child`). `json` qualifies because a
+/// JSON blob in a string column is descended into; `any` qualifies because "type not
+/// asserted" must not also mean "cannot be nested into".
+const local artifactNamedMemberContainers: List<String> = List("struct", "map", "json", "any")
+
+/// Types that can carry an element (`parent[]`).
+const local artifactElementContainers: List<String> = List("array", "any")
 
 /// One declared field within an artifact.
 class ArtifactField {
@@ -3920,6 +3955,45 @@ class ArtifactSchema {
 
   /// Free-form note for humans reading the generated artifact. Never asserted.
   description: String?
+
+  /// Every nested path must have its container declared, and that container must be
+  /// a type that can actually hold what the path descends into.
+  ///
+  /// Declaring `attributes.name` while leaving `attributes` undeclared drops exactly
+  /// the check that catches a producer which flattened the struct away — the leaf
+  /// assertion still passes against a flattened record in some readers. And
+  /// declaring `attributes` as `string` while also declaring `attributes.name` is a
+  /// contradiction the validator would have to resolve by guessing. Both fail here.
+  hidden _nestingCheck: Any =
+    let (byName = fields.toList().toMap((f) -> f.name, (f) -> f))
+    let (orphans = fields.toList().filter((f) ->
+      let (parent = artifactFieldParentPath(f.name))
+      parent != null && !byName.containsKey(parent)
+    ))
+    if (!orphans.isEmpty)
+      throw("ArtifactSchema: nested path(s) \(orphans.map((f) -> "'\(f.name)' (declare '\(artifactFieldParentPath(f.name))')").join(", ")) "
+        + "declared without their container. Declare every path prefix with its "
+        + "container type — `columns` as `array`, `columns[]` as `struct`, then "
+        + "`columns[].name` — so a producer that flattened the container away is "
+        + "caught rather than passing on the leaf assertion alone.")
+    else
+      let (mismatches = fields.toList().filter((f) ->
+        let (parent = artifactFieldParentPath(f.name))
+        if (parent == null) false
+        else if (f.name.endsWith("[]"))
+          !artifactElementContainers.contains(byName[parent].type)
+        else
+          !artifactNamedMemberContainers.contains(byName[parent].type)
+      ))
+      if (!mismatches.isEmpty)
+        throw("ArtifactSchema: \(mismatches.map((f) ->
+            let (parent = artifactFieldParentPath(f.name)!!)
+            "'\(f.name)' descends into '\(parent)', declared `\(byName[parent].type)`"
+          ).join("; ")). "
+          + "A path with a named-member step needs its container declared as one of "
+          + "\(artifactNamedMemberContainers.join("/")); a path with an `[]` step needs "
+          + "\(artifactElementContainers.join("/")).")
+      else null
 }
 
 local function renderArtifactField(f: ArtifactField): Mapping<String, Any> = new Mapping {
@@ -3931,7 +4005,11 @@ local function renderArtifactField(f: ArtifactField): Mapping<String, Any> = new
   ["description"] = f.description
 }
 
-local function renderArtifactSchema(s: ArtifactSchema): Mapping<String, Any> = new Mapping {
+local function renderArtifactSchema(s: ArtifactSchema): Mapping<String, Any> =
+  // Hidden properties are lazy — reference the validator so its `throw` fires at eval
+  // time rather than silently rendering a declaration with an undeclared container.
+  let (_nesting = s._nestingCheck)
+  new Mapping {
   ["format"] = s.format
   when (s.description != null) { ["description"] = s.description }
   ["fields"] = new Listing {

--- a/contract-toolkit/src/App.pkl
+++ b/contract-toolkit/src/App.pkl
@@ -442,9 +442,16 @@ pipeline: Pipeline = new Pipeline {}
 ///     format = "parquet"
 ///     description = "Query-history rows the parser reads."
 ///     fields {
-///       new ArtifactField { name = "QUERY_ID"; type = "string" }
-///       new ArtifactField { name = "START_TIME"; type = "timestamp" }
-///       new ArtifactField { name = "CREDITS_USED"; type = "float"; required = false }
+///       new ArtifactField {
+///         name = "QUERY_ID"
+///         type = "string"
+///         description = "Warehouse-assigned id, unique within the account."
+///       }
+///       new ArtifactField {
+///         name = "START_TIME"
+///         type = "timestamp"
+///         description = "When the query began. A stringified timestamp here is the defect this catches."
+///       }
 ///     }
 ///   }
 /// }
@@ -3881,8 +3888,20 @@ class ArtifactField {
   /// field that is genuinely optional but must carry `type` when it does appear.
   required: Boolean = true
 
-  /// Free-form note for humans reading the generated artifact. Never asserted.
-  description: String?
+  /// What this field carries and what the consumer expects of it. **Required and
+  /// non-empty** — a declaration is read by whoever is debugging the hand-off that
+  /// just failed, and a bare `name`/`type` pair tells them the assertion but not
+  /// why it holds. It is also the only place a `type = "any"` field can say what it
+  /// is, and the only place a `required = false` field can say when it appears.
+  /// Never asserted at runtime; it is documentation, enforced at authoring time.
+  ///
+  /// The default `throw` is how a required property gets an actionable error: Pkl's
+  /// own "value is undefined" message names neither the field nor the reason.
+  description: String(!isEmpty) =
+    throw("ArtifactField '\(name)': `description` is required — say what the field "
+      + "carries and what the consumer expects of it. A name and a type state the "
+      + "assertion but not why it holds, and a declaration is read by whoever is "
+      + "debugging the hand-off that just failed.")
 }
 
 /// The declared shape of one artifact handed off through a contract `FileReference`.
@@ -3907,7 +3926,9 @@ local function renderArtifactField(f: ArtifactField): Mapping<String, Any> = new
   ["name"] = f.name
   ["type"] = f.type
   ["required"] = f.required
-  when (f.description != null) { ["description"] = f.description }
+  // Always present — `description` is required on `ArtifactField`, so a consumer
+  // never has to branch on it.
+  ["description"] = f.description
 }
 
 local function renderArtifactSchema(s: ArtifactSchema): Mapping<String, Any> = new Mapping {

--- a/contract-toolkit/tests/artifact_schemas_test.pkl
+++ b/contract-toolkit/tests/artifact_schemas_test.pkl
@@ -8,6 +8,10 @@
 //   - an app that declares nothing emits NO `artifact_schemas.json`, so adopting
 //     the block is opt-in and existing consumer repos see no spurious diff.
 //   - declarations are keyed by contract field name, never by path shape.
+//   - nesting stays flat: a container declaration plus leaf paths, with `[]` as the
+//     "descend into the list" step, so arrays of structs are expressible without a
+//     recursive type grammar. (The refusals for an undeclared or wrongly-typed
+//     container live in scripts/check-invariants.sh.)
 //   - a bundle relocates each entrypoint's declarations under
 //     `app/generated/{entrypoint}/` with no bundle-specific wiring.
 
@@ -200,6 +204,62 @@ local extendedSchemas = parser.parse(
   extendedApp.output.files["app/generated/artifact_schemas.json"].text
 )
 
+// ── Element paths: arrays of structs, and scalar arrays ───────────────────────
+
+local arraysApp = (App) {
+  name = "arrays-app"
+  displayName = "Arrays App"
+  icon = "https://example.com/icon.svg"
+  hasCredentialConfig = false
+  pipeline { publish = null }
+  uiConfig = bundleUiConfig
+
+  artifactSchemas {
+    ["entities"] = new App.ArtifactSchema {
+      format = "ndjson"
+      fields {
+        new App.ArtifactField {
+          name = "columns"
+          type = "array"
+          description = "Child columns carried inline."
+        }
+        new App.ArtifactField {
+          name = "columns[]"
+          type = "struct"
+          description = "One column."
+        }
+        new App.ArtifactField {
+          name = "columns[].name"
+          type = "string"
+          description = "Column name."
+        }
+        new App.ArtifactField {
+          name = "columns[].order"
+          type = "int"
+          required = false
+          description = "Ordinal position, when the source exposes one."
+        }
+        new App.ArtifactField {
+          name = "tags"
+          type = "array"
+          description = "Source-side tags."
+        }
+        new App.ArtifactField {
+          name = "tags[]"
+          type = "string"
+          description = "One tag. Elements are plain strings."
+        }
+      }
+    }
+  }
+}
+
+local arraysSchemas = parser.parse(
+  arraysApp.output.files["app/generated/artifact_schemas.json"].text
+)
+
+local arraysFields = arraysSchemas["schemas"]["entities"]["fields"]
+
 facts {
   // ── Opt-in: no declaration, no artifact ────────────────────────────────────
   ["an app that declares nothing emits no artifact_schemas.json"] {
@@ -288,6 +348,41 @@ facts {
   ["extension types are declarable without widening the floor"] {
     extendedSchemas["schemas"]["wide"]["fields"].toList().map((f) -> f["type"]) ==
       List("decimal", "binary", "time", "array", "struct", "map")
+  }
+
+  // ── Element paths ──────────────────────────────────────────────────────────
+  // An array of structs is three declarations, not a recursive grammar: the array,
+  // its element, and each leaf under the element.
+  ["an array of structs is declared as array + element + leaves"] {
+    arraysFields.toList().map((f) -> f["name"]) == List(
+      "columns", "columns[]", "columns[].name", "columns[].order", "tags", "tags[]"
+    )
+    arraysFields[0]["type"] == "array"
+    arraysFields[1]["type"] == "struct"
+    arraysFields[2]["type"] == "string"
+  }
+
+  // A scalar array carries a leaf type on the element step rather than a struct —
+  // the case an `elementType` property would have handled, expressed with the same
+  // mechanism as everything else.
+  ["a scalar array carries its element type on the [] step"] {
+    arraysFields[4]["name"] == "tags"
+    arraysFields[4]["type"] == "array"
+    arraysFields[5]["name"] == "tags[]"
+    arraysFields[5]["type"] == "string"
+  }
+
+  // `required` is per element on an element path, so it renders exactly as declared
+  // and the validator (not the toolkit) owns the vacuous-on-empty-array reading.
+  ["required renders per element on an element path"] {
+    arraysFields[2]["required"] == true
+    arraysFields[3]["required"] == false
+  }
+
+  // The committed example carries the same shape, so step 3's fixture exercises it.
+  ["the example fixture declares an array of structs"] {
+    exampleSchemas["schemas"]["transformed_entities"]["fields"].toList()
+      .map((f) -> f["name"]).contains("attributes.columns[].name")
   }
 
   // ── Bundle relocation ──────────────────────────────────────────────────────

--- a/contract-toolkit/tests/artifact_schemas_test.pkl
+++ b/contract-toolkit/tests/artifact_schemas_test.pkl
@@ -48,7 +48,12 @@ local defaultsApp = (App) {
     ["bare"] = new App.ArtifactSchema {
       format = "ndjson"
       fields {
-        new App.ArtifactField { name = "only_field" }
+        // `description` is the only property with no default — everything else
+        // here is exercising the defaults.
+        new App.ArtifactField {
+          name = "only_field"
+          description = "The one field, declared with nothing but a name."
+        }
       }
     }
   }
@@ -102,7 +107,7 @@ local bundleCrawlerContract = (App) {
     ["transformed_entities"] = new App.ArtifactSchema {
       format = "ndjson"
       fields {
-        new App.ArtifactField { name = "typeName"; type = "string" }
+        new App.ArtifactField { name = "typeName"; type = "string"; description = "Atlan type this record instantiates." }
       }
     }
   }
@@ -120,7 +125,7 @@ local bundleMinerContract = (App) {
     ["raw_queries"] = new App.ArtifactSchema {
       format = "parquet"
       fields {
-        new App.ArtifactField { name = "START_TIME"; type = "timestamp" }
+        new App.ArtifactField { name = "START_TIME"; type = "timestamp"; description = "When the query began executing." }
       }
     }
   }
@@ -180,12 +185,12 @@ local extendedApp = (App) {
     ["wide"] = new App.ArtifactSchema {
       format = "parquet"
       fields {
-        new App.ArtifactField { name = "amount"; type = "decimal" }
-        new App.ArtifactField { name = "payload"; type = "binary" }
-        new App.ArtifactField { name = "run_at"; type = "time" }
-        new App.ArtifactField { name = "tags"; type = "array" }
-        new App.ArtifactField { name = "attributes"; type = "struct" }
-        new App.ArtifactField { name = "labels"; type = "map" }
+        new App.ArtifactField { name = "amount"; type = "decimal"; description = "An extension-typed decimal field." }
+        new App.ArtifactField { name = "payload"; type = "binary"; description = "An extension-typed binary field." }
+        new App.ArtifactField { name = "run_at"; type = "time"; description = "An extension-typed time field." }
+        new App.ArtifactField { name = "tags"; type = "array"; description = "An extension-typed array field." }
+        new App.ArtifactField { name = "attributes"; type = "struct"; description = "An extension-typed struct field." }
+        new App.ArtifactField { name = "labels"; type = "map"; description = "An extension-typed map field." }
       }
     }
   }
@@ -250,10 +255,19 @@ facts {
     defaultsSchemas["schemas"]["bare"]["fields"][0]["type"] == "any"
   }
 
-  ["description is omitted when unset, on both the schema and the field"] {
+  // Schema-level description stays optional and is omitted when unset. Field-level
+  // description is REQUIRED and non-empty, so it is always present — a consumer
+  // reading the artifact never has to branch on it, and a field can never state an
+  // assertion without stating why it holds. (The refusals for a missing or empty
+  // field description live in scripts/check-invariants.sh, since facts cannot
+  // express "eval fails".)
+  ["schema description is omitted when unset; field description is always present"] {
     !defaultsSchemas["schemas"]["bare"].containsKey("description")
-    !defaultsSchemas["schemas"]["bare"]["fields"][0].containsKey("description")
-    exampleSchemas["schemas"]["raw_queries"]["fields"][1].containsKey("description")
+    defaultsSchemas["schemas"]["bare"]["fields"][0]["description"] ==
+      "The one field, declared with nothing but a name."
+    exampleSchemas["schemas"]["raw_queries"]["fields"].toList().every((f) ->
+      !(f["description"] as String).isEmpty
+    )
   }
 
   // ── Nesting: dotted paths plus a container type, no recursive grammar ──────

--- a/contract-toolkit/tests/artifact_schemas_test.pkl
+++ b/contract-toolkit/tests/artifact_schemas_test.pkl
@@ -1,0 +1,298 @@
+// Tests for artifact schema declarations (ADR-0020, FND-685).
+//
+// `artifactSchemas` is the declaration home for the shape of the files an app
+// hands off. The toolkit is transport, not owner: it fixes the type vocabulary
+// and the file shape, and every field is authored by the app.
+//
+// The load-bearing behaviours asserted here:
+//   - an app that declares nothing emits NO `artifact_schemas.json`, so adopting
+//     the block is opt-in and existing consumer repos see no spurious diff.
+//   - declarations are keyed by contract field name, never by path shape.
+//   - a bundle relocates each entrypoint's declarations under
+//     `app/generated/{entrypoint}/` with no bundle-specific wiring.
+
+amends "pkl:test"
+
+import "pkl:json"
+import "../examples/artifact-schemas/app.pkl" as artifactSchemasApp
+import "../examples/minimal/app.pkl" as minimalApp
+import "../src/App.pkl" as App
+
+local parser = new json.Parser { useMapping = true }
+
+local exampleFiles = artifactSchemasApp.output.files
+local exampleSchemas = parser.parse(
+  exampleFiles["app/generated/artifact_schemas.json"].text
+)
+
+// ── Defaults: a field declared with nothing but a name ────────────────────────
+
+local defaultsApp = (App) {
+  name = "defaults-app"
+  displayName = "Defaults App"
+  icon = "https://example.com/icon.svg"
+  hasCredentialConfig = false
+  pipeline { publish = null }
+
+  uiConfig = new App.UIConfig {
+    tasks {
+      ["Configuration"] {
+        inputs {
+          ["target"] = new App.TextInput { title = "Target"; placeholderText = "x" }
+        }
+      }
+    }
+  }
+
+  artifactSchemas {
+    ["bare"] = new App.ArtifactSchema {
+      format = "ndjson"
+      fields {
+        new App.ArtifactField { name = "only_field" }
+      }
+    }
+  }
+}
+
+local defaultsSchemas = parser.parse(
+  defaultsApp.output.files["app/generated/artifact_schemas.json"].text
+)
+
+// ── An app with no declarations (the byte-identical guarantee) ─────────────────
+
+local noSchemasApp = (App) {
+  name = "no-schemas-app"
+  displayName = "No Schemas App"
+  icon = "https://example.com/icon.svg"
+  hasCredentialConfig = false
+  pipeline { publish = null }
+
+  uiConfig = new App.UIConfig {
+    tasks {
+      ["Configuration"] {
+        inputs {
+          ["target"] = new App.TextInput { title = "Target"; placeholderText = "x" }
+        }
+      }
+    }
+  }
+}
+
+// ── Bundle mode: per-entrypoint relocation, plus a bundle-level declaration ────
+
+local bundleUiConfig = new App.UIConfig {
+  tasks {
+    ["Configuration"] {
+      inputs {
+        ["target"] = new App.TextInput { title = "Target"; placeholderText = "x" }
+      }
+    }
+  }
+}
+
+local bundleCrawlerContract = (App) {
+  name = "crawler"
+  displayName = "Crawler"
+  icon = "https://example.com/icon.svg"
+  hasCredentialConfig = false
+  uiConfig = bundleUiConfig
+  pipeline { publish = null }
+
+  artifactSchemas {
+    ["transformed_entities"] = new App.ArtifactSchema {
+      format = "ndjson"
+      fields {
+        new App.ArtifactField { name = "typeName"; type = "string" }
+      }
+    }
+  }
+}
+
+local bundleMinerContract = (App) {
+  name = "miner"
+  displayName = "Query Miner"
+  icon = "https://example.com/icon.svg"
+  hasCredentialConfig = false
+  uiConfig = bundleUiConfig
+  pipeline { publish = null }
+
+  artifactSchemas {
+    ["raw_queries"] = new App.ArtifactSchema {
+      format = "parquet"
+      fields {
+        new App.ArtifactField { name = "START_TIME"; type = "timestamp" }
+      }
+    }
+  }
+}
+
+local bundleApp = (App) {
+  name = "schema-bundle"
+  displayName = "Schema Bundle"
+  icon = "https://example.com/icon.svg"
+  hasCredentialConfig = false
+  entrypoints {
+    new App.Entrypoint {
+      name = "crawler"
+      displayName = "Crawler"
+      contract = bundleCrawlerContract
+    }
+    new App.Entrypoint {
+      name = "miner"
+      displayName = "Query Miner"
+      contract = bundleMinerContract
+    }
+  }
+}
+
+local bundleFiles = bundleApp.output.files
+
+local bundleMinerSchemas = parser.parse(
+  bundleFiles["app/generated/miner/artifact_schemas.json"].text
+)
+
+// A bundle whose entrypoints declare nothing must not gain the artifact either.
+local bareBundleApp = (App) {
+  name = "bare-bundle"
+  displayName = "Bare Bundle"
+  icon = "https://example.com/icon.svg"
+  hasCredentialConfig = false
+  entrypoints {
+    new App.Entrypoint {
+      name = "crawler"
+      displayName = "Crawler"
+      contract = (bundleCrawlerContract) { artifactSchemas = new Mapping {} }
+    }
+  }
+}
+
+// ── Extension types: declarable before every validator supports them ──────────
+
+local extendedApp = (App) {
+  name = "extended-app"
+  displayName = "Extended App"
+  icon = "https://example.com/icon.svg"
+  hasCredentialConfig = false
+  pipeline { publish = null }
+  uiConfig = bundleUiConfig
+
+  artifactSchemas {
+    ["wide"] = new App.ArtifactSchema {
+      format = "parquet"
+      fields {
+        new App.ArtifactField { name = "amount"; type = "decimal" }
+        new App.ArtifactField { name = "payload"; type = "binary" }
+        new App.ArtifactField { name = "run_at"; type = "time" }
+        new App.ArtifactField { name = "tags"; type = "array" }
+        new App.ArtifactField { name = "attributes"; type = "struct" }
+        new App.ArtifactField { name = "labels"; type = "map" }
+      }
+    }
+  }
+}
+
+local extendedSchemas = parser.parse(
+  extendedApp.output.files["app/generated/artifact_schemas.json"].text
+)
+
+facts {
+  // ── Opt-in: no declaration, no artifact ────────────────────────────────────
+  ["an app that declares nothing emits no artifact_schemas.json"] {
+    !noSchemasApp.output.files.containsKey("app/generated/artifact_schemas.json")
+  }
+
+  // The committed `minimal` example is the regression guard for the fleet-wide
+  // byte-identical requirement: every existing example predates this block.
+  ["the minimal example is unchanged by the block existing"] {
+    !minimalApp.output.files.containsKey("app/generated/artifact_schemas.json")
+  }
+
+  ["a bundle whose entrypoints declare nothing emits no artifact_schemas.json"] {
+    !bareBundleApp.output.files.containsKey("app/generated/artifact_schemas.json")
+    !bareBundleApp.output.files.containsKey("app/generated/crawler/artifact_schemas.json")
+  }
+
+  // ── Envelope ───────────────────────────────────────────────────────────────
+  ["the artifact carries a version envelope and a schemas map"] {
+    exampleSchemas["version"] == 1
+    exampleSchemas.containsKey("schemas")
+  }
+
+  // ── Keying: contract field names, never path shapes ────────────────────────
+  ["declarations are keyed by output-contract field name"] {
+    exampleSchemas["schemas"].keys == Set("raw_queries", "transformed_entities", "upstream_lineage")
+  }
+
+  // ── Field rendering ────────────────────────────────────────────────────────
+  ["a parquet declaration renders format, description and ordered fields"] {
+    exampleSchemas["schemas"]["raw_queries"]["format"] == "parquet"
+    exampleSchemas["schemas"]["raw_queries"]["description"] ==
+      "Query-history rows written for the downstream parser."
+    exampleSchemas["schemas"]["raw_queries"]["fields"].length == 6
+    exampleSchemas["schemas"]["raw_queries"]["fields"][0]["name"] == "QUERY_ID"
+    exampleSchemas["schemas"]["raw_queries"]["fields"][0]["type"] == "string"
+  }
+
+  // The one asymmetry the capability exists to assert: a timestamp column must
+  // survive the declaration as `timestamp`, never collapse to `string`.
+  ["a timestamp field is declared as timestamp, not string"] {
+    exampleSchemas["schemas"]["raw_queries"]["fields"][1]["name"] == "START_TIME"
+    exampleSchemas["schemas"]["raw_queries"]["fields"][1]["type"] == "timestamp"
+  }
+
+  ["required defaults to true and is always rendered"] {
+    exampleSchemas["schemas"]["raw_queries"]["fields"][0]["required"] == true
+    exampleSchemas["schemas"]["raw_queries"]["fields"][2]["required"] == false
+    defaultsSchemas["schemas"]["bare"]["fields"][0]["required"] == true
+  }
+
+  ["type defaults to any — presence asserted, type not"] {
+    defaultsSchemas["schemas"]["bare"]["fields"][0]["type"] == "any"
+  }
+
+  ["description is omitted when unset, on both the schema and the field"] {
+    !defaultsSchemas["schemas"]["bare"].containsKey("description")
+    !defaultsSchemas["schemas"]["bare"]["fields"][0].containsKey("description")
+    exampleSchemas["schemas"]["raw_queries"]["fields"][1].containsKey("description")
+  }
+
+  // ── Nesting: dotted paths plus a container type, no recursive grammar ──────
+  ["nested payloads render as dotted paths alongside a container type"] {
+    exampleSchemas["schemas"]["transformed_entities"]["fields"][1]["name"] == "attributes"
+    exampleSchemas["schemas"]["transformed_entities"]["fields"][1]["type"] == "struct"
+    exampleSchemas["schemas"]["transformed_entities"]["fields"][2]["name"] == "attributes.qualifiedName"
+    exampleSchemas["schemas"]["transformed_entities"]["fields"][2]["type"] == "string"
+  }
+
+  // ── The consumer owns the declaration, so inputs are declarable too ────────
+  ["an input artifact is declared the same way as an output"] {
+    exampleSchemas["schemas"]["upstream_lineage"]["format"] == "ndjson"
+    exampleSchemas["schemas"]["upstream_lineage"]["fields"].length == 3
+  }
+
+  // ── Extension vocabulary ───────────────────────────────────────────────────
+  ["extension types are declarable without widening the floor"] {
+    extendedSchemas["schemas"]["wide"]["fields"].toList().map((f) -> f["type"]) ==
+      List("decimal", "binary", "time", "array", "struct", "map")
+  }
+
+  // ── Bundle relocation ──────────────────────────────────────────────────────
+  ["a bundle relocates each entrypoint's declarations under its own subfolder"] {
+    bundleFiles.containsKey("app/generated/crawler/artifact_schemas.json")
+    bundleFiles.containsKey("app/generated/miner/artifact_schemas.json")
+  }
+
+  // The entrypoint dimension is the file's location; the key inside the file
+  // stays the contract field name, so nothing has to re-key on relocation.
+  ["relocated declarations keep contract-field keys, not entrypoint keys"] {
+    bundleMinerSchemas["schemas"].keys == Set("raw_queries")
+    bundleMinerSchemas["schemas"]["raw_queries"]["fields"][0]["type"] == "timestamp"
+  }
+
+  // A bundle root emits no shared file that could shadow the per-entrypoint ones.
+  // (Declaring `artifactSchemas` on a bundle root is a generation error — asserted
+  // in scripts/check-invariants.sh, since facts cannot express "eval fails".)
+  ["a bundle root emits no shared artifact_schemas.json"] {
+    !bundleFiles.containsKey("app/generated/artifact_schemas.json")
+  }
+}


### PR DESCRIPTION
### Changelog

Step 2 of the ADR-0020 sequence ([FND-685](https://linear.app/atlan-epd/issue/FND-685)): the declaration home for artifact validation. Nothing consumes it yet.

- **New `artifactSchemas` block on `App.pkl`**, rendering to `app/generated/artifact_schemas.json`. Apps declare the shape of the files they hand off; the SDK will check the real artifact against the declaration at the hand-off.
- **Logical type vocabulary**: `ArtifactFieldType` (`string`/`int`/`float`/`bool`/`timestamp`/`date`/`json`/`any`) as the stable floor, `ArtifactFieldTypeExtended` layering `decimal`/`binary`/`time`/`array`/`struct`/`map` additively so a member can resolve to "unsupported for this format" without widening the floor. The load-bearing member is `timestamp`: arrow `timestamp[*]` satisfies it at any unit, arrow `string` does not.
- **The toolkit is transport, not owner.** It fixes the type vocabulary and the file shape; every field is authored by the app and nothing in `src/` names a column.
- **Declarations are keyed by contract field name, never by path shape** — `ContractFieldName` is a Python identifier, so a path/prefix/glob key fails generation. Path-shape inference is what let an earlier upload-time hook match nothing and validate zero records.
- **Every field must carry a non-empty `description`.** A declaration is read by whoever is debugging the hand-off that just failed, and a bare `name` + `type` pair states the assertion without stating why it holds — least of all for a `type = "any"` field or a `required = false` one, where the description is the only place it can say what it carries or when it appears. Generation refuses a missing or empty description, naming the field.
- **Nesting is paths plus a container type**, not a recursive type grammar. Two step kinds: `.name` descends into a container's named member (`attributes` as `struct` → `attributes.name` as `string`), and `[]` descends into an array's element (`columns` as `array` → `columns[]` as `struct` → `columns[].name` as `string`). A scalar array carries its leaf type on the element step: `tags` as `array`, `tags[]` as `string`.
- **Every path prefix must be declared, with a type that can hold what the path descends into.** Declaring `attributes.name` while leaving `attributes` undeclared drops exactly the check that catches a producer which flattened the struct away — the leaf assertion can still pass against a flattened record. Declaring `attributes` as `string` alongside `attributes.name` is a contradiction the validator would otherwise resolve by guessing. Both fail generation.
- **Nine things fail generation** rather than render a declaration that checks nothing: a path-shaped key; an empty `fields` listing; duplicate field names within a schema; a missing or empty field `description`; a path whose container is undeclared; a container declared with a type that cannot hold what the path descends into; index selection in a path (`columns[0]` — a schema describes every element, not one of them); a malformed bracket; and `artifactSchemas` on a multi-entrypoint bundle root (which has no contract model, and whose shared file could be picked up as a fallback for an entrypoint that declares nothing).
- **New example** `contract-toolkit/examples/artifact-schemas/` — parquet + NDJSON hand-offs, nested paths, an array of structs and a scalar array, and an artifact declared on the app's *input* (the consumer owns the declaration). This becomes the committed fixture for step 3.
- **20 new pkl tests**, 9 new `check-invariants.sh` refusals plus 3 controls, and docs across `README.md`, `docs/reference.md` and `CLAUDE.md`.

**The block is optional and emitted only when non-empty**, so every existing example regenerates byte-identical and no consumer repo sees a spurious diff. Multi-entrypoint apps declare it per entrypoint and each copy is relocated to `app/generated/{entrypoint}/` by the existing re-export path — no bundle-specific wiring, and no re-keying, because the entrypoint dimension is the file's *location*.

**Known limit, accepted:** a field whose *name* contains a literal dot is indistinguishable from a nested path. Not on any current hop; the additive fix if it ever turns up is an escape in `ArtifactFieldPath`, which breaks no existing declaration.

<details>
<summary>Generated shape</summary>

```json
{
  "version": 1,
  "schemas": {
    "raw_queries": {
      "format": "parquet",
      "description": "Query-history rows written for the downstream parser.",
      "fields": [
        { "name": "QUERY_ID", "type": "string", "required": true, "description": "Warehouse-assigned query id. The parser's join key." },
        { "name": "START_TIME", "type": "timestamp", "required": true, "description": "When the query began executing." },
        { "name": "CREDITS_USED", "type": "float", "required": false, "description": "Compute credits billed. Absent on warehouses that do not meter per query." }
      ]
    },
    "transformed_entities": {
      "format": "ndjson",
      "fields": [
        { "name": "attributes", "type": "struct", "required": true, "description": "Container for the entity's attributes." },
        { "name": "attributes.columns", "type": "array", "required": false, "description": "Child columns carried inline. Absent for types that have none." },
        { "name": "attributes.columns[]", "type": "struct", "required": true, "description": "One column." },
        { "name": "attributes.columns[].name", "type": "string", "required": true, "description": "Column name as it appears in the source." }
      ]
    }
  }
}
```

`description` is required and non-empty on every field, so it is always present and a consumer never branches on it; the schema-level `description` is optional and omitted when unset. `required` is always emitted, defaulting to `true`. `version` is the envelope version of the file shape, bumped only on a breaking structural change — never when an app edits its own declarations.

</details>

### Additional context

**Why this exists.** Data crosses app boundaries as files, and at every hand-off the producer's idea of the artifact's shape and the consumer's idea of it are independent beliefs that nothing checks. A production RCA traced a 73-day frozen lineage marker to a single column that had become a string where the consumer expected a timestamp — every workflow in the chain reported success throughout, because every workflow was individually doing exactly what it was told.

**Design decisions not spelled out in the ticket:**

- *The entrypoint dimension is the file's location, not a key inside it.* In a bundle, a sub-contract renders believing it is a standalone app, so its own `name` need not match the bundle's `Entrypoint.name` — that mismatch is exactly why `_e2e_base.py` is regenerated bundle-scoped rather than relocated. Embedding an entrypoint identity inside `artifact_schemas.json` would inherit the same bug, so the file relocates unchanged and the keys inside stay contract field names, the same way `manifest.json` and `_input.py` already work.
- *`ArtifactFormat` is `"ndjson"|"parquet"` with no default on `ArtifactSchema.format`.* Content format, not file extension — SDK NDJSON artifacts conventionally carry a `.json` suffix and are still `"ndjson"`. No default because the answer is not derivable from the contract field, and each format has its own validator with its own dependency floor. Kept to exactly the formats ADR-0020 designs validators for; adding a member later is additive.
- *`[]` rather than an `elementType` property.* An `elementType` would have covered `array<string>` and stopped at `array<struct>`, which is the case that actually matters. The path step composes instead, and it is the explicit "descend into the list" marker precisely because the physical encoding is not: parquet spells the same leaf `columns.list.element.name` under the 3-level list encoding and `columns.bag.array.name` under the legacy 2-level one, so a declaration written in physical terms would be pinned to an encoding the producer can change. `[]` says what is meant; each validator resolves it for its own format. On an element path `required` reads per element, and an empty array satisfies it vacuously.
- *`ArtifactField.description` defaults to a `throw`.* That is how a required Pkl property gets an actionable error — Pkl's own "value is undefined" message names neither the field nor the reason.
- *Not added to `NativeApp.pkl`* — legacy modules are frozen reference material.
- The example app is `name = "artifact-schemas-example"`, so its workflow-config file is `artifact-schemas-example.json` rather than sitting next to `artifact_schemas.json` differing only by a hyphen.

**Byte-identical requirement — verified three ways:** `regenerate-all.sh` produces zero diff against every existing committed example (the only new files in the tree are the new example); a pkl fact on the committed `minimal` example; and a `check-invariants.sh` control asserting the file is absent when nothing is declared.

**Local acceptance (all green):**

| Check | Result |
|---|---|
| `contract-toolkit/scripts/regenerate-all.sh` | clean, no drift on existing examples |
| `contract-toolkit/scripts/check-invariants.sh` | passed |
| `pkl test tests/*.pkl` | 343 tests / 828 asserts, 100% |
| `uv run --extra workflows python contract-toolkit/scripts/test-sdk-import.py` | 41 files imported |
| `git diff --check` | clean |
| `uv run pre-commit run --all-files` | clean |

- ADR: `docs/adr/0020-artifact-validation.md`
- Linear: [FND-685](https://linear.app/atlan-epd/issue/FND-685) · design in [FND-399](https://linear.app/atlan-epd/issue/FND-399)
- Blocks FND-686 (`ContractSource` loader), FND-687 (registration warning + K016), FND-693 (K015)

### Checklist
- [x] Additional tests added
- [ ] All CI checks passed
- [x] Relevant documentation updated

---

### Copyleft License Compliance

- [ ] Have you used any code that is subject to a Copyleft license (e.g., GPL, AGPL, LGPL)?
- [ ] If yes, have you modified the code in the context of this project? please share additional details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
