### PR TITLE
test(e2e): make a teardown leak visible, and opt-in fatal

### DIFF
--- a/application_sdk/testing/e2e/base.py
+++ b/application_sdk/testing/e2e/base.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 
 import os
 import secrets
+import sys
 import time
 import urllib.error
 import urllib.request
@@ -444,6 +445,15 @@ class BaseE2ETest:
     # so no ``_mustache_substitutions()`` override is needed just to add params.
     substitutions_class: ClassVar[type[MustacheSubstitutions]] = MustacheSubstitutions
 
+    # Teardown that fails is teardown that leaked: the ephemeral connection and
+    # its descendants stay on the tenant forever. Left False so this stays a
+    # behaviour a repo opts into — flipping the default would redden every
+    # connector whose tenant cannot currently purge, all at once, for a
+    # condition none of them introduced. Set True in a suite (or fleet-wide,
+    # once cleanup is healthy everywhere) to make a leak fail the leg instead of
+    # passing green with a warning nobody reads.
+    fail_on_cleanup_error: ClassVar[bool] = False
+
     ae_poll_interval_seconds: ClassVar[int] = 10
     ae_poll_timeout_seconds: ClassVar[int] = 600
     # Fail-fast stall guard (test-harness only — this module is never imported
@@ -783,8 +793,17 @@ class BaseE2ETest:
         ephemeral connections and their descendants don't accumulate on the
         tenant and degrade search performance over time.
 
-        Failures here are logged as warnings, not re-raised, so they never
-        mask the real test result.
+        Failures here are logged as warnings and, by default, not re-raised, so
+        they never mask the real test result. They are ALSO emitted as a GitHub
+        ``::error::`` annotation, because a warning inside a green leg is a
+        leak nobody sees: the run is green, the log line is thousands of lines
+        down, and the assets stay on the tenant. Set
+        :attr:`fail_on_cleanup_error` to turn a leak into a failed leg.
+
+        Raises:
+            AssertionError: If cleanup leaked and ``fail_on_cleanup_error`` is
+                set. Raised only AFTER both purge phases have run, so opting in
+                never reduces how much gets cleaned up.
         """
         conn_qn = getattr(self, "connection_qualified_name", None)
         if not conn_qn:
@@ -798,8 +817,27 @@ class BaseE2ETest:
         # single child-purge failure orphan the connection as well: the raise
         # jumped past the connection purge entirely, and the teardown warning
         # is post-verdict, so the leg still went green while leaking everything.
-        self._purge_child_assets(client, conn_qn)
-        self._purge_connection(client, conn_qn)
+        #
+        # Both run unconditionally and the verdict is taken afterwards, for the
+        # same reason: short-circuiting on the first leak would orphan whatever
+        # the second phase would have cleaned.
+        children_ok = self._purge_child_assets(client, conn_qn)
+        connection_ok = self._purge_connection(client, conn_qn)
+        if children_ok and connection_ok:
+            return
+
+        leaked = "child assets" if not children_ok else ""
+        if not connection_ok:
+            leaked = f"{leaked} and the connection" if leaked else "the connection"
+        detail = (
+            f"e2e cleanup leaked {leaked} under {conn_qn} — these stay on the "
+            "tenant until purged manually"
+        )
+        # Annotation, not just a log line: this surfaces in the run summary even
+        # when the leg is green, which is the whole point.
+        print(f"::error::{detail}", file=sys.stderr)  # noqa: T201
+        if self.fail_on_cleanup_error:
+            raise AssertionError(detail)
 
     @staticmethod
     def _teardown_client() -> Any | None:
@@ -829,7 +867,7 @@ class BaseE2ETest:
             return None
 
     @staticmethod
-    def _purge_child_assets(client: Any, conn_qn: str) -> None:
+    def _purge_child_assets(client: Any, conn_qn: str) -> bool:
         """Purge every descendant of ``conn_qn`` in bounded batches.
 
         Every GUID is collected *before* the first delete on purpose. pyatlan's
@@ -840,6 +878,10 @@ class BaseE2ETest:
         Args:
             client: Sync pyatlan client.
             conn_qn: Qualified name of the connection being torn down.
+
+        Returns:
+            ``True`` when every descendant was purged (including the vacuous
+            "there were none" case), ``False`` when anything leaked.
         """
         try:
             from pyatlan.model.assets import (  # noqa: PLC0415; type: ignore[import]
@@ -865,10 +907,10 @@ class BaseE2ETest:
                 conn_qn,
                 exc_info=True,
             )
-            return
+            return False
 
         if not child_guids:
-            return
+            return True
 
         # Batch failures are counted and reported once after the loop rather
         # than logged per batch: a large crawl is hundreds of batches, and a
@@ -906,20 +948,26 @@ class BaseE2ETest:
                 _PURGE_BATCH_SIZE,
                 exc_info=last_error,
             )
-        else:
-            logger.info(
-                "e2e cleanup: purged %d child assets under %s",
-                purged,
-                conn_qn,
-            )
+            return False
+
+        logger.info(
+            "e2e cleanup: purged %d child assets under %s",
+            purged,
+            conn_qn,
+        )
+        return True
 
     @staticmethod
-    def _purge_connection(client: Any, conn_qn: str) -> None:
+    def _purge_connection(client: Any, conn_qn: str) -> bool:
         """Purge the connection asset itself.
 
         Args:
             client: Sync pyatlan client.
             conn_qn: Qualified name of the connection being torn down.
+
+        Returns:
+            ``True`` when the connection was purged (or was already gone),
+            ``False`` when it leaked.
         """
         try:
             from pyatlan.model.assets import (  # noqa: PLC0415; type: ignore[import]
@@ -947,6 +995,8 @@ class BaseE2ETest:
                 conn_qn,
                 exc_info=True,
             )
+            return False
+        return True
 
     # ------------------------------------------------------------------
     # Pre-run seeding

--- a/tests/unit/testing/e2e/test_base_e2e.py
+++ b/tests/unit/testing/e2e/test_base_e2e.py
@@ -1748,3 +1748,80 @@ class TestTeardownPurgeBatching:
         harness = _ConcreteE2ETest()
         harness.connection_qualified_name = "default/openapi/1787587123106596"
         harness.teardown_method(method=None)  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# teardown_method — cleanup leak reporting
+# ---------------------------------------------------------------------------
+
+
+class _StrictCleanupTest(_ConcreteE2ETest):
+    """Opts in to failing the leg when teardown leaks."""
+
+    fail_on_cleanup_error = True
+
+
+class TestTeardownLeakReporting:
+    """A leak must be visible, and opt-in fatal, without ever cleaning less.
+
+    The regression these pin: a tenant that denies the purge (e.g. Atlas
+    ATLAS-403-00-001 on ``delete entity``) left the connection and every
+    descendant on the tenant while the leg still reported green, because the
+    only signal was a ``logger.warning`` thousands of lines into a passing job.
+    """
+
+    def _run_teardown(self, cls, monkeypatch, *, children_ok, connection_ok):
+        test = cls()
+        test.connection_qualified_name = "default/openapi/test-123"
+        monkeypatch.setattr(cls, "_teardown_client", staticmethod(lambda: object()))
+        calls = []
+
+        def _children(client, conn_qn):
+            calls.append("children")
+            return children_ok
+
+        def _connection(client, conn_qn):
+            calls.append("connection")
+            return connection_ok
+
+        monkeypatch.setattr(cls, "_purge_child_assets", staticmethod(_children))
+        monkeypatch.setattr(cls, "_purge_connection", staticmethod(_connection))
+        return test, calls
+
+    def test_clean_teardown_is_silent(self, monkeypatch, capsys):
+        test, calls = self._run_teardown(
+            _ConcreteE2ETest, monkeypatch, children_ok=True, connection_ok=True
+        )
+        test.teardown_method(None)
+        assert calls == ["children", "connection"]
+        assert "::error::" not in capsys.readouterr().err
+
+    def test_leak_emits_annotation_but_does_not_raise_by_default(
+        self, monkeypatch, capsys
+    ):
+        test, _ = self._run_teardown(
+            _ConcreteE2ETest, monkeypatch, children_ok=False, connection_ok=True
+        )
+        test.teardown_method(None)
+        err = capsys.readouterr().err
+        assert "::error::" in err
+        assert "child assets" in err
+
+    def test_leak_raises_when_opted_in(self, monkeypatch):
+        test, _ = self._run_teardown(
+            _StrictCleanupTest, monkeypatch, children_ok=False, connection_ok=True
+        )
+        with pytest.raises(AssertionError, match="child assets"):
+            test.teardown_method(None)
+
+    def test_both_phases_run_before_the_verdict(self, monkeypatch):
+        """Opting in must not short-circuit and orphan MORE than the default."""
+        test, calls = self._run_teardown(
+            _StrictCleanupTest, monkeypatch, children_ok=False, connection_ok=False
+        )
+        with pytest.raises(AssertionError, match="connection"):
+            test.teardown_method(None)
+        assert calls == ["children", "connection"]
+
+    def test_default_is_opt_in(self):
+        assert BaseE2ETest.fail_on_cleanup_error is False


### PR DESCRIPTION
## Problem

A tenant that denies the e2e teardown purge leaves the ephemeral connection **and every descendant** on the tenant — and the leg still reports **green**. The only signal is a `logger.warning` thousands of lines into a passing job, so nobody sees it and assets accumulate run after run.

Found on [atlanhq/atlan-databricks-app#402](https://github.com/atlanhq/atlan-databricks-app/pull/402): **four of six legs** hit

```
ATLAS-403-00-001: service-account-apikey-… is not authorized to
perform delete entity: guid=0124fcbc-…   (at client.asset.purge_by_guid)
```

every leg passed, and the leak was only found by reading the logs of a green run. That is the failure mode this PR closes: not the 403 itself, but the fact that a leak is invisible.

## Change

Two narrow changes:

- **`_purge_child_assets` / `_purge_connection` now return whether they cleaned up.** They already had per-phase error handling — they just discarded the verdict. `teardown_method` aggregates the two.
- **A leak emits a `::error::` annotation**, so it surfaces in the run summary of an otherwise-green leg, and a new ClassVar **`fail_on_cleanup_error` (default `False`)** turns a leak into a failed leg for suites that opt in.

```python
class TestMyConnectorE2E(SQLAppE2ETest):
    fail_on_cleanup_error = True   # a leak now fails the leg
```

## Why the default stays `False`

Flipping it would redden every connector whose tenant cannot currently purge — all at once, for a condition none of them introduced. The annotation gives the visibility without the blast radius. Once fleet cleanup is healthy, the default is a one-line change.

## Ordering guarantee

Both purge phases still run unconditionally and the verdict is taken afterwards, so **opting in never cleans up less than the default**. Short-circuiting on the first leak would orphan whatever the second phase would have cleaned — the same bug the "two independently-guarded phases" comment already warns about. Pinned by `test_both_phases_run_before_the_verdict`.

## Tests

5 new tests in `tests/unit/testing/e2e/test_base_e2e.py::TestTeardownLeakReporting` — clean teardown stays silent, a leak annotates but does not raise by default, a leak raises when opted in, both phases run before the verdict, and the default is opt-in. Full module: **507 passed**. `ruff check` / `ruff format --check` clean.

## Root cause of the 403 (confirmed on the tenant)

Inspected the azure e2e tenant's Atlas index directly. It is **connection ownership**, not a role gap and not an undeletable entity type:

```
qualifiedName = default/databricks/1787592838173740   (337 entities, all ACTIVE, still leaked)
__createdBy   = service-account-atlan-argo
adminUsers    = ["service-account-atlan-argo"]        ← not the e2e API key
```

…while the harness logged `Resolved current user for connection adminUsers: service-account-apikey-1af390ea-…` for that same leg. The harness resolves the right admin into the connection spec, but the Connection that materialises in Atlas is created by the **publish path under argo's identity**, with itself as sole admin. The e2e key is then not an admin of the connection, so Atlas denies `delete entity` on every asset beneath it and the bulk purge 403s on the first GUID evaluated.

Across all 49 databricks connections on that tenant: 5 argo-owned (the leaks), 44 `playwright` leftovers, and **zero** owned by an `apikey` — because every connection the harness did own was purged cleanly.

Two notes for reviewers of this PR:

- **This PR does not fix that.** It is detection: it makes the leak visible in a green run and opt-in fatal. The ownership fix belongs where the connection is created — the harness creating the Connection before submit, or publish honouring the payload's `adminUsers`/`adminRoles`.
- Because the denial covers *every* entity under the connection, the batched purge on `main` does not rescue these runs either: every batch fails. Batching bounds damage only when a denial is genuinely entity-specific.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
