### PR TITLE
ci(e2e): put the API token on the SQL connection ACL so teardown can purge

### DIFF
--- a/application_sdk/testing/e2e/sql_app.py
+++ b/application_sdk/testing/e2e/sql_app.py
@@ -152,6 +152,18 @@ class SQLAppE2ETest(BaseE2ETest):
         """Connection identity with ``$admin`` role on the admin ACL."""
         if not hasattr(self, "_admin_role_guid"):
             self._admin_role_guid = self._resolve_admin_role_guid()
+        # Same fallback the base spec applies (base.py): when a suite pins no
+        # explicit admin users, fall back to the current API token's username.
+        # Without it this spec goes out with an EMPTY adminUsers, the connection
+        # the publish path creates lists only its own service account as admin,
+        # and teardown_method — which runs as the API token — is then not an
+        # admin of the connection it must purge. Atlas denies the purge
+        # (ATLAS-403-00-001 "not authorized to perform delete entity") and the
+        # connection plus every descendant is orphaned on the tenant, while the
+        # leg still passes because teardown failures are only warnings.
+        admin_users = self.connection_admin_users or getattr(
+            self, "_auto_admin_users", ()
+        )
         return ConnectionSpec(
             name=self.connection_display_name,
             qualified_name=self.connection_qualified_name,
@@ -159,7 +171,7 @@ class SQLAppE2ETest(BaseE2ETest):
             source_logo=(
                 f"https://assets.atlan.com/assets/{self.connector_short_name}.png"
             ),
-            admin_users=self.connection_admin_users,
+            admin_users=admin_users,
             admin_groups=self.connection_admin_groups,
             admin_roles=(self._admin_role_guid,),
         )

--- a/tests/unit/testing/e2e/test_sql_app_e2e.py
+++ b/tests/unit/testing/e2e/test_sql_app_e2e.py
@@ -318,6 +318,39 @@ class TestSQLAppE2ETestHooks:
         spec = t.connection_spec()
         assert "role-guid-123" in spec.admin_roles
 
+    def test_connection_spec_falls_back_to_auto_admin_users(self) -> None:
+        """A suite that pins no admin users still gets the API token on the ACL.
+
+        Without this the spec ships an EMPTY adminUsers, the publish path
+        creates the connection with only its own service account as admin, and
+        teardown_method — running as the API token — cannot purge it. Atlas
+        answers ATLAS-403-00-001 and the connection plus every descendant is
+        orphaned while the leg still passes.
+        """
+        t = self._make_test()
+        assert not t.connection_admin_users  # suite pins none
+        t._auto_admin_users = ("service-account-apikey-abc",)
+        spec = t.connection_spec()
+        assert spec.admin_users == ("service-account-apikey-abc",)
+
+    def test_connection_spec_prefers_explicit_admin_users(self) -> None:
+        """An explicit class-level ACL still wins over the fallback."""
+        t = self._make_test()
+        t.__class__.connection_admin_users = ("explicit-user",)
+        try:
+            t._auto_admin_users = ("service-account-apikey-abc",)
+            spec = t.connection_spec()
+            assert spec.admin_users == ("explicit-user",)
+        finally:
+            t.__class__.connection_admin_users = ()
+
+    def test_connection_spec_survives_missing_auto_admin_users(self) -> None:
+        """No setup_method run (hence no _auto_admin_users) must not explode."""
+        t = self._make_test()
+        assert not hasattr(t, "_auto_admin_users")
+        spec = t.connection_spec()
+        assert spec.admin_users == ()
+
     def test_mustache_substitutions_returns_sql_type(self) -> None:
         from application_sdk.testing.e2e.substitutions import SQLMustacheSubstitutions
 


### PR DESCRIPTION
## The bug

`SQLAppE2ETest.connection_spec()` builds the connection ACL like this:

```python
admin_users=self.connection_admin_users,     # ← no fallback
```

`connection_admin_users` is a ClassVar defaulting to `()`. So **every SQL connector that doesn't pin an explicit ACL ships a connection spec with empty `adminUsers`.**

`BaseE2ETest`'s own spec already does it correctly, and its comment spells out why:

```python
# _auto_admin_users: the current API token's username (so teardown can purge)
admin_users = self.connection_admin_users or getattr(self, "_auto_admin_users", ())
```

The SQL override just dropped that line. This restores it.

## What it costs today

The publish path creates the connection with only its own service account on the ACL. `teardown_method` runs as the API token, which isn't on it, so Atlas refuses the purge:

```
ATLAS-403-00-001: service-account-apikey-… is not authorized to
perform delete entity: guid=…
```

The connection **and every descendant** are orphaned on the tenant — and the leg still passes, because teardown failures are only warnings. Each leaked run leaves ~337 assets behind.

## Evidence

Measured on one e2e tenant. Connections created by `service-account-atlan-argo`:

| connector | base class | outcome |
|---|---|---|
| databricks | `SQLAppE2ETest` | 4 leaked |
| mysql | `SQLAppE2ETest` | 12 leaked |
| postgres | `SQLAppE2ETest` | 5 leaked |
| mssql | `SQLAppE2ETest` | 3 leaked |
| **metabase** | **`BaseE2ETest`** | **10 purged cleanly, 0 leaked** |

Same tenant, same API key, same publish path. The only difference is whether the token is on the connection ACL — which is exactly what the missing fallback controls.

Confirmed against the tenant's audit index. A leaked databricks connection's create event:

```
adminUsers = ["service-account-atlan-argo"]
```

A metabase connection created by the **same** service account in the same period:

```
adminUsers = ["service-account-apikey-…", "service-account-atlan-argo"]
```

## Tests

Three added to `TestSQLAppE2ETestHooks`:

- falls back to `_auto_admin_users` when the suite pins none (the regression)
- an explicit class-level ACL still wins
- no `setup_method` (hence no `_auto_admin_users`) doesn't explode

`tests/unit/testing/e2e/`: **505 passed**. `ruff check` / `ruff format --check` clean at the repo's pinned 0.6.4.

## Scope

Not covered here: **Power BI also leaks**, but its connections already carry the token on the ACL, so that's a different defect and needs its own diagnosis — flagging rather than folding it in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
