### PR TITLE
fix(validation): validate transformed output as upsert, not creation

### DIFF
--- a/application_sdk/validation/assets.py
+++ b/application_sdk/validation/assets.py
@@ -380,6 +380,20 @@ def validate_transformed_dir(
     and the check it enabled was the single largest source of false ``invalid``
     findings on the fleet (FND-803).
 
+    Note what this restores: **pyatlan's own signature is
+    ``validate(self, for_creation: bool = False)``**, and its docstring names
+    this exact caller — "only by explicit user invocation (e.g., validating
+    JSONL before sending to Atlan)". This SDK was overriding that default. So
+    this is not a loosened check; it is the library's intended default for the
+    JSONL case, restored.
+
+    Fixing it in pyatlan instead would be a regression. Under
+    ``for_creation=True`` the requirement is *correct*: ``GCSObject.creator()``
+    takes ``gcs_bucket_name`` as a required keyword argument (the
+    qualifiedName derives from the bucket), so the check faithfully mirrors the
+    contract it guards. Dropping it there would make ``for_creation=True`` pass
+    objects ``creator()`` cannot construct.
+
     ``for_creation=True`` enforces pyatlan's ``creator()`` contract — the
     parent-hierarchy fields a caller must supply when *constructing* an asset
     from scratch. Transformed output is not that. It is an **upsert** payload

--- a/application_sdk/validation/assets.py
+++ b/application_sdk/validation/assets.py
@@ -321,10 +321,12 @@ def validate_asset(asset: Asset, *, for_creation: bool = True) -> list[str]:
 
     Args:
         asset: A concrete pyatlan_v9 asset instance.
-        for_creation: When True (default), also enforce the create-time hierarchy
-            checks. Connector runs currently assume a first-time run against a
-            source, so everything they emit as transformed output is for initial
-            creation.
+        for_creation: When True (default), also enforce pyatlan's create-time
+            hierarchy checks. This is the strict primitive and keeps the strict
+            default; :func:`validate_transformed_dir` deliberately defaults the
+            other way, because transformed output is an **upsert** payload
+            rather than a ``creator()`` call. See FND-803 and that function's
+            docstring for the measurement behind the asymmetry.
     """
     try:
         asset.validate(for_creation=for_creation)
@@ -357,7 +359,7 @@ def _iter_ndjson_lines(path: str | Path) -> Iterator[tuple[str, int, bytes]]:
 def validate_transformed_dir(
     path: str | Path,
     *,
-    for_creation: bool = True,
+    for_creation: bool = False,
     check_referential_integrity: bool = True,
 ) -> AssetValidationReport:
     """Validate every transformed-output asset under ``path``.
@@ -372,9 +374,38 @@ def validate_transformed_dir(
     from the data, not a hard-coded list. **Every line is always scanned** — the
     report reflects the full batch, not a sample.
 
+    **Why ``for_creation`` defaults to False.** It used to default True, on the
+    premise that "connector runs assume a first-time run against a source, so
+    everything they emit is for initial creation". That premise does not hold,
+    and the check it enabled was the single largest source of false ``invalid``
+    findings on the fleet (FND-803).
+
+    ``for_creation=True`` enforces pyatlan's ``creator()`` contract — the
+    parent-hierarchy fields a caller must supply when *constructing* an asset
+    from scratch. Transformed output is not that. It is an **upsert** payload
+    for assets whose parents already exist in Atlas, so the fields the contract
+    demands are legitimately absent, and Atlas accepts the payload regardless.
+    Measured: a well-formed ``Column`` carrying name, qualifiedName and
+    connectionQualifiedName **fails** under ``for_creation=True``. On one day
+    the flag alone accounted for ~2.0M fivetran, ~330k thoughtspot and ~55k gcs
+    assets reported invalid, every message ending "is required for creation".
+    A connector team independently confirmed the finding was wrong: GCSObject
+    assets ingest successfully without ``gcsBucketName``, and many already had.
+
+    Turning it off does **not** hollow out the check. Still caught, verified by
+    test: a ``qualifiedName`` that does not match its type's expected pattern
+    (this is what found a real defect — an empty path segment producing
+    ``.../afvc//cum/cuguid``), a missing ``qualifiedName``, and a structurally
+    wrong payload. What stops being reported is precisely the class Atlas never
+    required.
+
+    Callers who genuinely are creating assets — a pre-create gate rather than a
+    post-transform observation — pass ``for_creation=True`` explicitly.
+
     Args:
         path: A transformed-output directory (e.g. ``.../transformed``) or file.
-        for_creation: Passed through to each asset's ``.validate()``.
+        for_creation: Passed through to each asset's ``.validate()``. Defaults
+            to False — see "Why ``for_creation`` defaults to False" above.
         check_referential_integrity: Run the referential second pass.
 
     Returns:

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -1,8 +1,8 @@
 <!--
 generated-by:  capability-manifest skill (.claude/skills/capability-manifest)
 sdk-version:   3.28.3
-source-sha:    816d6fd930c6524ddcf2bcba0f433b094ee46473
-source-date:   2026-08-25T02:45:24+01:00
+source-sha:    d977b106745bfeb35c138ba08b01535f03affefd
+source-date:   2026-08-25T13:32:41+05:30
 do-not-edit:   re-run the skill instead of hand-editing
 -->
 
@@ -3734,7 +3734,7 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 #### `validate_transformed_dir`
 
 - **Import:** `from application_sdk.testing.integration import validate_transformed_dir`
-- **Signature:** `validate_transformed_dir(path: str | Path, *, for_creation: bool = True, check_referential_integrity: bool = True)`
+- **Signature:** `validate_transformed_dir(path: str | Path, *, for_creation: bool = False, check_referential_integrity: bool = True)`
 - **Summary:** Validate every transformed-output asset under ``path``.
 - **Defined in:** `application_sdk/validation/assets.py`
 
@@ -3919,7 +3919,7 @@ Offline artifact & asset validation — format-agnostic wrapper (ADR-0020) plus 
 #### `validate_transformed_dir`
 
 - **Import:** `from application_sdk.validation import validate_transformed_dir`
-- **Signature:** `validate_transformed_dir(path: str | Path, *, for_creation: bool = True, check_referential_integrity: bool = True)`
+- **Signature:** `validate_transformed_dir(path: str | Path, *, for_creation: bool = False, check_referential_integrity: bool = True)`
 - **Summary:** Validate every transformed-output asset under ``path``.
 - **Defined in:** `application_sdk/validation/assets.py`
 

--- a/tests/unit/validation/test_assets.py
+++ b/tests/unit/validation/test_assets.py
@@ -660,3 +660,107 @@ def test_scalar_gaps_are_not_claimed_to_be_fixed():
     # ...but the missing scalars are still correctly reported.
     assert any("schema_name is required" in e for e in errors), errors
     assert any("database_name is required" in e for e in errors), errors
+
+
+# ---------------------------------------------------------------------------
+# FND-803 — for_creation=True was the largest source of false `invalid`.
+#
+# It enforces pyatlan's creator() contract (the parent-hierarchy fields a
+# caller supplies when CONSTRUCTING an asset). Transformed output is an upsert
+# payload whose parents already exist in Atlas, so those fields are
+# legitimately absent and Atlas accepts the record. A connector team confirmed
+# it independently: GCSObject ingests fine without gcsBucketName.
+# ---------------------------------------------------------------------------
+
+
+def _raw(type_name: str, **attributes) -> bytes:
+    import json
+
+    return json.dumps(
+        {"typeName": type_name, "status": "ACTIVE", "attributes": attributes}
+    ).encode()
+
+
+_GOOD_COLUMN = dict(
+    name="c",
+    qualifiedName="default/snow/1/DB/SCH/T/c",
+    connectionQualifiedName="default/snow/1",
+)
+
+
+def test_well_formed_column_fails_only_under_for_creation():
+    """The headline: for_creation=True rejects an asset with nothing wrong."""
+    asset = assets_module._deserialize(_raw("Column", **_GOOD_COLUMN))
+
+    assert validate_asset(asset, for_creation=True) != []
+    assert validate_asset(asset, for_creation=False) == []
+
+
+def test_gcs_object_without_bucket_name_is_not_a_finding():
+    """The connector team's report, as a test. Every message on this axis ended
+    "is required for creation", and this was the one confirmed from the
+    ingestion side: these assets land in Atlas without the attribute."""
+    asset = assets_module._deserialize(
+        _raw(
+            "GCSObject",
+            name="chunk-0-part0.json",
+            qualifiedName="default/gcs/1787291630/ip_snapshot_prod/obj",
+            connectionQualifiedName="default/gcs/1787291630",
+        )
+    )
+
+    creation_errors = validate_asset(asset, for_creation=True)
+    assert "gcs_bucket_name is required for creation" in creation_errors[0]
+    assert validate_asset(asset, for_creation=False) == []
+
+
+@pytest.mark.parametrize(
+    "raw,expected_fragment",
+    [
+        # The real defect this found in production: an empty path segment.
+        pytest.param(
+            _raw(
+                "Column",
+                name="cuguid",
+                qualifiedName="default/athena/1/AwsDataCatalog/db/afvc//cum/cuguid",
+                connectionQualifiedName="default/athena/1",
+            ),
+            "does not match expected pattern",
+            id="empty-path-segment",
+        ),
+        pytest.param(
+            _raw("Column", name="c", qualifiedName="not-a-qualified-name"),
+            "does not match expected pattern",
+            id="garbage-qualified-name",
+        ),
+        pytest.param(
+            _raw("Column", name="c", connectionQualifiedName="default/snow/1"),
+            "qualified_name is required",
+            id="missing-qualified-name",
+        ),
+    ],
+)
+def test_real_defects_are_still_caught_without_for_creation(raw, expected_fragment):
+    """Turning the flag off must not hollow out the check."""
+    asset = assets_module._deserialize(raw)
+
+    errors = validate_asset(asset, for_creation=False)
+
+    assert errors, "a real defect must still be reported"
+    assert expected_fragment in errors[0]
+
+
+def test_validate_transformed_dir_defaults_to_upsert_semantics(tmp_path):
+    """The batch walker's default is what the upload hook gets, so pin it."""
+    transformed = tmp_path / "transformed"
+    transformed.mkdir()
+    (transformed / "entities.json").write_bytes(_raw("Column", **_GOOD_COLUMN) + b"\n")
+
+    default = validate_transformed_dir(transformed, check_referential_integrity=False)
+    strict = validate_transformed_dir(
+        transformed, for_creation=True, check_referential_integrity=False
+    )
+
+    assert default.passed == 1 and default.failed == 0
+    # The flag is still honoured for callers who genuinely are creating.
+    assert strict.failed == 1


### PR DESCRIPTION
Closes FND-803. Sibling of #3401 — that PR fixes the **decode** axis, this one fixes the **`.validate()`** axis. Independent changes, deliberately separate so they can be reviewed and rolled back on their own.

## Problem

`validate_transformed_dir` hardcoded `for_creation=True`. That enforces pyatlan's `creator()` contract — the parent-hierarchy fields a caller must supply when **constructing** an asset from scratch.

Transformed output is not that. It is an **upsert** payload for assets whose parents already exist in Atlas, so the fields the contract demands are legitimately absent, and Atlas accepts the payload regardless.

**A well-formed Column fails.** Carrying `name`, `qualifiedName` and `connectionQualifiedName`:

```
for_creation=True   ['schema_name is required for creation',
                     'schema_qualified_name is required for creation',
                     'database_name is required for creation', ...]
for_creation=False  []
```

## Scale

Every message on this axis ends **"is required for creation"**. From the real error strings in `asset_validation_matrix`, one day:

| Connector | Assets reported invalid | Error |
|---|---|---|
| fivetran | 2,014,594 | `Column`: `schema_name` / `database_name`; also `Table`, `SalesforceField`, `SalesforceObject` |
| thoughtspot | 330,120 | `ThoughtspotColumn`: `thoughtspot_table is required for creation` |
| gcs | 54,738 | `GCSObject`: `gcs_bucket_name is required for creation` |
| bridge | 1 | `Tag`: `mapped_classification_name is required for creation` |

**Independently confirmed by a connector team.** On the GCS case the owning engineer reported that `gcsBucketName` is *not* required for GCSObject ingestion, and that their tenant already holds many successfully-ingested GCSObject assets without it. The run showed `8/194045 passed, 194037 invalid` — ~100%, entirely from that one rule. Their concern was that the warning misleads users, since the run's real failure was an unrelated publish timeout.

That is the strongest possible evidence for a false positive: the ingestion side says the field was never required.

## This does not hollow out the check

Verified by test — still caught with `for_creation=False`:

| Case | Still reported |
|---|---|
| `qualifiedName` not matching its type's pattern | ✅ |
| missing `qualifiedName` | ✅ |
| structurally wrong payload | ✅ |
| well-formed asset | correctly passes |

The pattern check is not hypothetical — it is what found the **one real `invalid` finding on the whole board**: an empty path segment producing `.../afvc//cum/cuguid` on athena, 456 assets. That survives this change.

What stops being reported is precisely the class Atlas never required.

## Fix

Default `validate_transformed_dir(for_creation=False)`. The parameter stays, so a caller who genuinely is creating assets — a pre-create gate rather than a post-transform observation — passes `for_creation=True` explicitly.

`validate_asset` keeps its strict default: it is the low-level primitive, and a direct caller asking for creation semantics should get them. The asymmetry is documented on both sides.

Both real callers (`App.upload()`'s hook and the integration test runner) call it bare, so both pick up upsert semantics.

## Expected effect

The `invalid` axis should fall from ~2.4M assets/day to athena's 456 — the finding that is real.

## Tests

- A well-formed Column passes under the new default and fails under the old one.
- The GCSObject case the connector team reported, asserting the exact `gcs_bucket_name is required for creation` message under the old behaviour and clean under the new.
- Parametrized proof that real defects are still caught: bad QN pattern (including the athena empty-segment string), garbage QN, missing QN.
- A test pinning the batch walker's default, since that is what the upload hook silently inherits, and asserting the flag is still honoured when passed.

447 tests pass across `tests/unit/validation/`, `tests/unit/app/test_upload_asset_validation.py`, `tests/unit/testing/integration/`, and `tests/unit/transformers/`. Pre-commit clean.

## Known gap

An empty `name` passes under both settings. Not a regression from this change, but worth a look — noted on the ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
