### PR TITLE
ci(sdk-review): Send an attributed AI Gateway key alias from the SDK resolve dispatch lane

### DIFF
--- a/.github/scripts/sdk_resolve_dispatch.py
+++ b/.github/scripts/sdk_resolve_dispatch.py
@@ -88,8 +88,9 @@ DEFAULT_MAX_ROUNDS = 8
 # code says which: 400 means the pinned name is not one the
 # llmproxy.atlan.dev catalog recognises (its own message is "Invalid model
 # name passed in model=..."), 403 means the gateway key does not allowlist it.
-# This lane declares no `ai_gateway_key_name`, so that key is mothership's
-# LITELLM_KEY_DEFAULT - not the review lane's scoped `sdk_review` key.
+# This lane sends the `sdk_review` alias, so its spend is billed to the
+# shared SDK-lane key LITELLM_KEY_SDK_REVIEW, and resolve runs therefore
+# share the review lane's budget.
 #
 # Mothership itself does not validate the name at all: `_validate_model_ids`
 # in `harness/api/models/sandbox.py` only rejects blank/whitespace/control-char
@@ -405,6 +406,7 @@ def build_payload(
         "repositories": ["atlanhq/application-sdk"],
         "base_branch": "main",
         "snapshot": "_base",
+        "ai_gateway_key_name": "sdk_review",
         # Model pinning, same three lanes as sdk-review.yml (PR #2985). Without
         # these the lane inherits mothership's DEFAULT_CLAUDE_MODEL
         # (claude-opus-5) and `_base` leaves CLAUDE_CODE_SUBAGENT_MODEL on

--- a/.github/scripts/tests/test_sdk_resolve_dispatch.py
+++ b/.github/scripts/tests/test_sdk_resolve_dispatch.py
@@ -73,6 +73,7 @@ def test_payload_declares_attributed_gateway_key():
     )
     assert p["ai_gateway_key_name"] == "sdk_review"
 
+
 def test_payload_pins_all_three_model_lanes():
     # All three lanes must be pinned: leaving any unset silently falls back to
     # mothership's Claude defaults (main -> claude-opus-5, sub-agent ->

--- a/.github/scripts/tests/test_sdk_resolve_dispatch.py
+++ b/.github/scripts/tests/test_sdk_resolve_dispatch.py
@@ -57,6 +57,22 @@ def test_payload_shape():
     assert p["metadata"]["requester"] == "requester-login"
 
 
+def test_payload_declares_attributed_gateway_key():
+    # Without this, mothership's sandbox API has neither a request-level
+    # ai_gateway_key_name nor a snapshot-declared alias to bill against, and
+    # fails closed: "No attributed AI Gateway key for this run ... Refusing
+    # to fall back to a shared, un-attributed key."
+    p = sr.build_payload(
+        "1234",
+        "http://run",
+        8,
+        "2026-07-08",
+        "reviewer-one,reviewer-two",
+        "requester-login",
+        model=sr.MAIN_MODEL,
+    )
+    assert p["ai_gateway_key_name"] == "sdk_review"
+
 def test_payload_pins_all_three_model_lanes():
     # All three lanes must be pinned: leaving any unset silently falls back to
     # mothership's Claude defaults (main -> claude-opus-5, sub-agent ->


### PR DESCRIPTION
The SDK Resolve (mothership) workflow fails in CI with this error from mothership's sandbox API:

```
[sandbox-api/_execute_sync] No attributed AI Gateway key for this run (channel=None, snapshot=None). Refusing to fall back to a shared, un-attributed key.
```

## Why it started

Mothership resolves a billing key from either the request's `ai_gateway_key_name` field or the dispatched snapshot's own declared alias. `sdk_resolve_dispatch.py` sets neither - it dispatches with `snapshot: "_base"`, and `_base` declares no alias. Until recently that fell through to a shared default key. Mothership commit `deafa0136` (2026-08-20) made that fall-through raise instead of silently billing the shared `LITELLM_KEY_DEFAULT` key. That change is correct - it closes an un-attributed spend gap - so the fix belongs on the caller side, here.

## The fix

Send `ai_gateway_key_name: "sdk_review"` in the resolve lane's dispatch payload, matching what the sibling `sdk_review_dispatch.py` already sends. That alias is already provisioned and already mounted as `LITELLM_KEY_SDK_REVIEW` on both beta and prod, so no new infra is needed.

Also corrected the comment above the model-pinning block in `sdk_resolve_dispatch.py`, which previously said this lane declares no alias and therefore bills the shared default key - no longer true.

Added a payload test (`test_payload_declares_attributed_gateway_key`) asserting `build_payload(...)["ai_gateway_key_name"] == "sdk_review"`, so the alias can't silently drop out of the payload again.

## Known trade-off

Resolve spend is now billed to the review lane's `sdk_review` / `LITELLM_KEY_SDK_REVIEW` key, so the two lanes share one budget instead of having independent visibility into spend. A dedicated `sdk_resolve` alias with its own key is the cleaner long-term fix; this PR deliberately reuses the existing, already-provisioned alias to unblock CI without adding new infra.
