### PR TITLE
feat(validation): wire artifact validation into the FileReference interceptor, both sides, warn-only (FND-691)

### DIFF
--- a/application_sdk/constants.py
+++ b/application_sdk/constants.py
@@ -570,6 +570,19 @@ VALIDATE_ASSETS_ON_UPLOAD: bool = (
 VALIDATE_ASSETS_TIMEOUT_SECONDS: float = float(
     os.getenv("ATLAN_VALIDATE_ASSETS_TIMEOUT_SECONDS", "600")
 )
+#: ADR-0020 step 7: when True, the activity interceptor validates every
+#: ``FileReference`` artifact against its declared artifact schema on both sides
+#: of a task — at ingest (after materialise) and at hand-off (before persist).
+#: Warn-only: an outcome event is emitted for every artifact, including the
+#: negative outcomes, and nothing is ever blocked or raised.
+#:
+#: Defaulted ON. This is a deployment-level kill switch, not a posture knob —
+#: whether a verdict blocks is the app's artifact-validation posture (FND-692),
+#: and turning this off stops the outcome events too, which is exactly why it is
+#: a switch an operator flips deliberately rather than a per-app default.
+VALIDATE_ARTIFACTS: bool = (
+    os.getenv("ATLAN_VALIDATE_ARTIFACTS", "true").lower() == "true"
+)
 #: The single "rows per axis" cap for every validation drill-down surface —
 #: one number, so the human-readable ``format_report(max_items=...)`` listing and
 #: the structured matrix telemetry can never drift apart.

--- a/application_sdk/execution/_temporal/activities.py
+++ b/application_sdk/execution/_temporal/activities.py
@@ -248,6 +248,24 @@ def create_activity_from_task(
     input_type = task_metadata.input_type
     output_type = task_metadata.output_type
 
+    # ADR-0020 step 7. Both facts artifact validation needs about *this app* are
+    # constant for the worker's lifetime, so they are resolved once here and baked
+    # into the closure below — the same shape the preflight gate's posture uses —
+    # rather than costing a registry lookup on every artifact hand-off. Neither
+    # call raises: an app that is not registered yields empty values, and the hook
+    # then reports every hand-off as non-boundary against the flat generated
+    # declaration file.
+    from application_sdk.validation.interceptor import (  # noqa: PLC0415 — deferred to worker build: importing any `validation` submodule loads the package __init__, which pulls pyatlan_v9 in via `assets`. A module-scope import here would put that on the import path of every process that touches `execution` — the handler and server processes included, neither of which ever runs an activity.
+        ARTIFACT_SIDE_HANDOFF,
+        ARTIFACT_SIDE_INGEST,
+        boundary_contract_types,
+        entrypoint_index,
+        validate_artifacts,
+    )
+
+    boundary_contracts = boundary_contract_types(task_metadata.app_name)
+    entrypoint_by_workflow_type = entrypoint_index(task_metadata.app_name)
+
     async def activity_fn(context: TaskContext, input_data: Input) -> Output:
         """Execute the task as a Temporal activity."""
         from application_sdk.app.context import (  # noqa: PLC0415 — circular: execution/__init__.py loads sibling modules + app.base imports execution
@@ -466,11 +484,47 @@ def create_activity_from_task(
                 # Resolve the store once for both FileReference hooks.
                 store = infra.storage if infra is not None else None
 
+                # ADR-0020 step 7: both artifact-validation enforcement points ride
+                # this seam, and both sit *outside* the `store is not None` guards
+                # below — a hand-off that moves no bytes still hands an artifact
+                # over, and a check that goes quiet on some paths is
+                # indistinguishable from one that passed (FND-401).
+                #
+                # Declarations are keyed by (entrypoint, contract field name). The
+                # field name comes off the walk; the entry point comes off the run's
+                # own workflow type, through the index baked in at worker build.
+                entrypoint_name = entrypoint_by_workflow_type.get(
+                    _current_workflow_type(), ""
+                )
+
                 # Materialise any durable FileReferences in the input before the task runs.
                 if store is not None and has_refs_to_materialize(input_data):
                     input_data = await materialize_file_refs(store, input_data)
 
+                # Consumer side, after materialise: the bytes this task is about to
+                # read are on local disk now, so re-validate them on read. This is
+                # the point that stays on permanently — it is the only cover for
+                # producers that are not our code and for artifacts already written.
+                await validate_artifacts(
+                    input_data,
+                    side=ARTIFACT_SIDE_INGEST,
+                    app_name=context.app_name,
+                    entrypoint=entrypoint_name,
+                    boundary_contracts=boundary_contracts,
+                )
+
                 result = await task_method(input_data)
+
+                # Producer side, BEFORE persist: the bytes are still local and the
+                # producing activity is still on the stack, so a flag blames whoever
+                # wrote the artifact rather than whoever reads it three hops later.
+                await validate_artifacts(
+                    result,
+                    side=ARTIFACT_SIDE_HANDOFF,
+                    app_name=context.app_name,
+                    entrypoint=entrypoint_name,
+                    boundary_contracts=boundary_contracts,
+                )
 
                 # Persist any ephemeral FileReferences in the output after the task completes.
                 if store is not None and has_refs_to_persist(result):

--- a/application_sdk/observability/logger_adaptor.py
+++ b/application_sdk/observability/logger_adaptor.py
@@ -105,6 +105,14 @@ ARTIFACT_FAILED_KEY = "artifact_failed"
 ARTIFACT_UNDECODABLE_KEY = "artifact_undecodable"
 ARTIFACT_FIELDS_DECLARED_KEY = "artifact_fields_declared"
 
+# Which of the two enforcement points emitted the row: ``ingest`` (consumer side,
+# re-validated on read, after materialise) or ``handoff`` (producer side, checked
+# before persist while the bytes are still local so blame lands on the producer).
+# Both come off one declaration at one site, and without this key the two are
+# indistinguishable in ClickHouse — a producer-side flag and the consumer-side
+# re-read of the same artifact would collapse into one number.
+ARTIFACT_SIDE_KEY = "artifact_side"
+
 # Whether the undeclared artifact sat on an entrypoint's public boundary
 # (a finding) or on an app-internal ``@task`` contract (informational). Both emit;
 # neither is silent. Deliberately unprefixed, matching the equally generic
@@ -186,6 +194,7 @@ _KNOWN_EXTRA_KEYS = frozenset(
         ARTIFACT_FAILED_KEY,
         ARTIFACT_UNDECODABLE_KEY,
         ARTIFACT_FIELDS_DECLARED_KEY,
+        ARTIFACT_SIDE_KEY,
         ARTIFACT_BOUNDARY_KEY,
         # ── Misc SDK ─────────────────────────────────────────────────────
         "log_type",

--- a/application_sdk/storage/file_ref_sync.py
+++ b/application_sdk/storage/file_ref_sync.py
@@ -35,7 +35,8 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
-from collections.abc import Callable, Coroutine
+from collections.abc import Callable, Coroutine, Iterator
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -51,21 +52,72 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 
-def _find_file_refs(data: Any) -> list[FileReference]:
-    """Recursively find all FileReference instances in a BaseModel/dataclass tree."""
+@dataclass(frozen=True)
+class NamedFileRef:
+    """One ``FileReference`` found in a contract tree, with where it was found.
+
+    The *where* is what artifact validation needs and the bare ref cannot
+    supply. Declarations are keyed by ``(entrypoint, contract field name)``, and
+    whether a hand-off sits on an app's public boundary is a fact about the class
+    that owns the field — neither is recoverable from a ``FileReference``, which
+    carries only paths.
+    """
+
+    ref: FileReference
+    """The reference itself."""
+
+    field: str = ""
+    """Name of the contract field it was reached through, or "" for a bare ref
+    handed in at the top level."""
+
+    owner: type | None = None
+    """The model class declaring :attr:`field`, or ``None`` for a bare ref.
+
+    For a ref inside a container (``list[FileReference]``,
+    ``dict[str, FileReference]``) this is the model declaring the *container*
+    field, so every element shares the one declaration keyed by that field name —
+    which is how the declaration is keyed.
+    """
+
+
+def iter_named_file_refs(
+    data: Any, *, field: str = "", owner: type | None = None
+) -> Iterator[NamedFileRef]:
+    """Walk a contract tree yielding every ``FileReference`` with its field name.
+
+    The same traversal :func:`_find_file_refs` does — that function is written in
+    terms of this one, so the two cannot drift into disagreeing about which refs
+    a tree contains. Containers pass the enclosing ``(owner, field)`` down
+    unchanged; a nested model re-keys to its own fields, so a ref on an inner
+    model reports that inner model as its owner and is therefore never counted as
+    a boundary hand-off.
+
+    Args:
+        data: Model, container or scalar to walk.
+        field: Field name the recursion arrived through — internal.
+        owner: Model class declaring ``field`` — internal.
+
+    Yields:
+        One :class:`NamedFileRef` per reference, in the tree's own field order.
+    """
     if isinstance(data, FileReference):
-        return [data]
-    refs: list[FileReference] = []
-    if isinstance(data, BaseModel):
+        yield NamedFileRef(ref=data, field=field, owner=owner)
+    elif isinstance(data, BaseModel):
         for name in type(data).model_fields:
-            refs.extend(_find_file_refs(getattr(data, name)))
+            yield from iter_named_file_refs(
+                getattr(data, name), field=name, owner=type(data)
+            )
     elif isinstance(data, (list, tuple)):
         for item in data:
-            refs.extend(_find_file_refs(item))
+            yield from iter_named_file_refs(item, field=field, owner=owner)
     elif isinstance(data, dict):
-        for v in data.values():
-            refs.extend(_find_file_refs(v))
-    return refs
+        for value in data.values():
+            yield from iter_named_file_refs(value, field=field, owner=owner)
+
+
+def _find_file_refs(data: Any) -> list[FileReference]:
+    """Recursively find all FileReference instances in a BaseModel/dataclass tree."""
+    return [named.ref for named in iter_named_file_refs(data)]
 
 
 def _local_sidecar_ok(local_path: str) -> bool:

--- a/application_sdk/validation/__init__.py
+++ b/application_sdk/validation/__init__.py
@@ -16,7 +16,11 @@ there is no inline source), the format validator that ships is
 :mod:`application_sdk.validation.ndjson` (``NdjsonValidator`` — a streaming,
 constant-memory, per-record check, plus ``iter_ndjson_lines``, the one NDJSON walk
 in the tree), and the public entry point is ``validate_artifact`` in
-:mod:`application_sdk.validation.wrapper`.
+:mod:`application_sdk.validation.wrapper`. Both enforcement points — consumer-side
+at ingest and producer-side before persist — are wired to the activity
+interceptor's one ``FileReference`` seam by
+:mod:`application_sdk.validation.interceptor`, warn-only, with every artifact
+emitting an outcome.
 
 **Asset validation** (BLDX-1555) is the concrete NDJSON x typed-model check that
 predates the wrapper, built on the per-asset ``.validate()`` backbone that
@@ -72,6 +76,14 @@ from application_sdk.validation.assets import (
     validate_asset,
     validate_transformed_dir,
 )
+from application_sdk.validation.interceptor import (
+    ARTIFACT_SIDE_HANDOFF,
+    ARTIFACT_SIDE_INGEST,
+    ARTIFACT_SIDES,
+    boundary_contract_types,
+    entrypoint_index,
+    validate_artifacts,
+)
 from application_sdk.validation.ndjson import NdjsonValidator, iter_ndjson_lines
 from application_sdk.validation.protocols import FormatValidator, SchemaSource
 from application_sdk.validation.sources import (
@@ -89,6 +101,9 @@ from application_sdk.validation.wrapper import (
 __all__ = [
     # Artifact validation (ADR-0020)
     "ARTIFACT_FORMATS",
+    "ARTIFACT_SIDES",
+    "ARTIFACT_SIDE_HANDOFF",
+    "ARTIFACT_SIDE_INGEST",
     "FORMAT_NDJSON",
     "FORMAT_PARQUET",
     "ArtifactDeclaration",
@@ -111,10 +126,13 @@ __all__ = [
     "artifact_schema_paths",
     "artifact_validation_event_fields",
     "artifact_validation_matrix_json",
+    "boundary_contract_types",
     "builtin_format_validators",
     "declared_artifact_fields",
+    "entrypoint_index",
     "iter_ndjson_lines",
     "validate_artifact",
+    "validate_artifacts",
     # Asset validation (BLDX-1555)
     "AssetValidationFailure",
     "AssetValidationReport",

--- a/application_sdk/validation/artifacts.py
+++ b/application_sdk/validation/artifacts.py
@@ -50,6 +50,7 @@ from application_sdk.observability.logger_adaptor import (
     ARTIFACT_FORMAT_KEY,
     ARTIFACT_PASSED_KEY,
     ARTIFACT_SCHEMA_SOURCE_KEY,
+    ARTIFACT_SIDE_KEY,
     ARTIFACT_TOTAL_KEY,
     ARTIFACT_UNDECODABLE_KEY,
     ARTIFACT_UNIT_KEY,
@@ -567,6 +568,7 @@ def artifact_validation_event_fields(
     report: ArtifactValidationReport,
     *,
     artifact_field: str = "",
+    side: str = "",
     max_items: int = ARTIFACT_VALIDATION_MAX_ITEMS_PER_AXIS,
 ) -> dict[str, str | int | bool]:
     """Build the outcome event's attribute map from a report.
@@ -595,6 +597,13 @@ def artifact_validation_event_fields(
             already-allowlisted ``entrypoint`` identifies the declaration exactly.
             Nothing is inferred from path shape — path-shape inference is precisely
             what made the earlier upload-time hook silently validate nothing.
+        side: Which enforcement point emitted this row —
+            :data:`~application_sdk.validation.interceptor.ARTIFACT_SIDE_INGEST`
+            or
+            :data:`~application_sdk.validation.interceptor.ARTIFACT_SIDE_HANDOFF`.
+            "" for a caller outside the interceptor, which is the honest answer
+            rather than picking a side on its behalf. Always emitted, so a
+            consumer never branches on its presence.
         max_items: Row cap for the matrix; shared with ``format_report``.
 
     Returns:
@@ -606,6 +615,7 @@ def artifact_validation_event_fields(
         ARTIFACT_FORMAT_KEY: report.artifact_format,
         ARTIFACT_SCHEMA_SOURCE_KEY: report.schema_source,
         ARTIFACT_FIELD_KEY: artifact_field,
+        ARTIFACT_SIDE_KEY: side,
         ARTIFACT_UNIT_KEY: report.unit,
         ARTIFACT_TOTAL_KEY: report.total,
         ARTIFACT_PASSED_KEY: report.passed,

--- a/application_sdk/validation/interceptor.py
+++ b/application_sdk/validation/interceptor.py
@@ -1,0 +1,420 @@
+"""Both artifact-validation enforcement points, wired to the one seam (ADR-0020).
+
+``FileReference`` is the universal hand-off token and the activity interceptor is
+the one place every ``@task`` in every app funnels through, so both enforcement
+points come off one declaration at one site::
+
+      materialize_file_refs(...)     # durable -> local
+    + validate(ingest)               <- consumer side, re-validate on read
+      result = await task_method(input_data)
+    + validate(handoff)              <- producer side, BEFORE persist: the bytes
+      persist_file_refs(...)            are still local, so blame lands on the
+                                        producer rather than on whoever reads it
+                                        three hops later
+
+The declaration is read off the contract field the reference was reached through,
+exactly as the ``Lazy()`` marker is read inside the persist/materialise walk —
+:func:`~application_sdk.storage.file_ref_sync.iter_named_file_refs` is that same
+walk, and ``_find_file_refs`` is written in terms of it, so nothing here can drift
+into disagreeing with the interceptor about which references a tree holds.
+
+**No silent no-op — this is the point.** The earlier upload-time hook's path gate
+returned ``None`` and emitted *nothing* when it did not match, so an app could look
+adopted while validating zero records (FND-401). Here **every** reference on both
+sides emits exactly one outcome event, negatives included: ``not_declared`` (with
+its ``boundary`` attribute), ``unsupported``, and ``absent``. A check that reports
+nothing is indistinguishable from a check that passed, and that ambiguity is itself
+the defect.
+
+**Warn-only, and it never raises into the task.**
+:func:`~application_sdk.validation.wrapper.validate_artifact` already refuses to
+raise across either plug-in seam; this module adds the outer belt so that a defect
+in the *wiring* — the walk, the offload, the emit — cannot break a hand-off either.
+Nothing here fails an activity, and nothing here blocks a persist. Whether a
+verdict may block is a separate axis (the app's artifact-validation posture,
+FND-692) that does not exist yet.
+
+**Off the event loop.** Validators are plain synchronous scans, so per ADR-0020 the
+interceptor — not each validator — owns the offload decision. A contract-sourced
+scan is pure Python plus ``orjson``, so it rides
+:func:`~application_sdk._runtime.offload.run_in_thread`; the model-sourced path,
+whose decode enters third-party C extensions, needs the isolated child process and
+is not reachable from here (the NDJSON validator answers ``supports() -> False`` for
+a model declaration until FND-690 folds it in).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Final, Iterable, Iterator, Mapping
+
+from application_sdk.observability.events import ARTIFACT_VALIDATION_EVENT
+from application_sdk.observability.logger_adaptor import get_logger
+from application_sdk.validation.artifacts import (
+    ArtifactValidationReport,
+    artifact_validation_event_fields,
+)
+from application_sdk.validation.sources import ArtifactDeclarationError, ContractSource
+
+if TYPE_CHECKING:
+    from application_sdk.app.registry import AppMetadata
+    from application_sdk.storage.file_ref_sync import NamedFileRef
+
+logger = get_logger(__name__)
+
+__all__ = [
+    "ARTIFACT_SIDES",
+    "ARTIFACT_SIDE_HANDOFF",
+    "ARTIFACT_SIDE_INGEST",
+    "boundary_contract_types",
+    "entrypoint_index",
+    "validate_artifacts",
+]
+
+
+ARTIFACT_SIDE_INGEST: Final = "ingest"
+"""Consumer side: the artifact was just materialised and is about to be read.
+
+Stays on permanently once graduated — it is the only cover for producers that are
+not our code, and for artifacts that were already written."""
+
+ARTIFACT_SIDE_HANDOFF: Final = "handoff"
+"""Producer side: the task has returned and the bytes are still local.
+
+Checked *before* persist on purpose. The producing activity is still on the stack,
+so a flag blames the app that wrote the artifact instead of the app that reads it
+several hops later."""
+
+ARTIFACT_SIDES: Final[frozenset[str]] = frozenset(
+    {ARTIFACT_SIDE_INGEST, ARTIFACT_SIDE_HANDOFF}
+)
+"""Runtime membership test for the two enforcement points."""
+
+
+# ---------------------------------------------------------------------------
+# Worker-build resolution
+# ---------------------------------------------------------------------------
+
+
+def _app_metadata(app_name: str) -> "AppMetadata | None":
+    """The registered app's metadata, or ``None`` when it cannot be looked up.
+
+    One guarded lookup for both build-time resolvers below, so they cannot come to
+    disagree about what an unresolvable app means.
+
+    ``None`` is not an error here. ``create_activity_from_task`` is called directly
+    by plenty of tests with nothing registered, and in a real worker the registry is
+    populated long before ``create_worker`` runs — so a miss is either a harmless
+    test path or an already-fatal boot problem that a warning from an advisory
+    validation hook would only add noise to. DEBUG, with the traceback, so a third
+    case nobody predicted is still recoverable from a log.
+
+    Args:
+        app_name: The registered app name, from the task's metadata.
+
+    Returns:
+        The app's metadata, or ``None``.
+    """
+    try:
+        from application_sdk.app.registry import (  # noqa: PLC0415 — circular: execution/__init__.py loads sibling modules + app.base imports validation
+            AppRegistry,
+        )
+
+        return AppRegistry.get_instance().get(app_name)
+    except Exception:  # noqa: BLE001 — advisory wiring must never break worker build
+        logger.debug(
+            "Artifact validation: no registered app '%s' at worker build; hand-offs "
+            "will report boundary=False and read the flat declaration file",
+            app_name,
+            exc_info=True,
+        )
+        return None
+
+
+def boundary_contract_types(app_name: str) -> frozenset[type]:
+    """Every contract class that sits on one of ``app_name``'s public boundaries.
+
+    An entry point's ``input_type`` and ``output_type`` and nothing else — the same
+    line :mod:`application_sdk.app._artifact_schema_guard` draws at registration,
+    and for the same reason: an entry point's contracts are read by another app or
+    by the DAG, while an internal ``@task`` contract is the app's own business. The
+    default ``run()`` is registered as an *implicit* entry point carrying the same
+    metadata, so "every entry point" already means "every public boundary" with no
+    special case to drift.
+
+    Resolved **once at worker build** and baked into the activity's closure, the
+    same shape the preflight gate's posture uses, so ``boundary`` is accurate
+    without a registry lookup on every hand-off.
+
+    Membership is by exact class identity rather than ``issubclass``: a subclass of
+    a boundary contract is a *different* contract, whose own declaration is keyed
+    by its own entry point, and treating it as public would report a finding
+    against an app for a field nobody outside it can see.
+
+    Never raises. An app that is not registered — the case every direct
+    ``create_activity_from_task`` call in a test hits — resolves to the empty set,
+    so every hand-off reports ``boundary=False``. That is the conservative
+    direction: it under-reports findings rather than inventing them.
+
+    Args:
+        app_name: The registered app name, from the task's metadata.
+
+    Returns:
+        The boundary contract classes, or an empty set when they cannot be
+        resolved.
+    """
+    metadata = _app_metadata(app_name)
+    if metadata is None:
+        return frozenset()
+    types: set[type] = set()
+    for entry_point in metadata.entry_points.values():
+        types.add(entry_point.input_type)
+        types.add(entry_point.output_type)
+    return frozenset(types)
+
+
+def entrypoint_index(app_name: str) -> Mapping[str, str]:
+    """Map every Temporal workflow type ``app_name`` registers to its entry point.
+
+    Declarations are keyed by ``(entrypoint, contract field name)``, and the
+    entry-point half decides *which file* is read: a bundle's declarations live at
+    ``app/generated/<entry-point>/artifact_schemas.json``, a single-entry-point
+    app's at the flat ``app/generated/artifact_schemas.json``. Without this,
+    every bundle would miss its own declarations and report ``not_declared``
+    fleet-wide — a silent no-op wearing an outcome event's clothes.
+
+    Built from ``AppMetadata.workflow_types``, which is the same index the worker
+    registers workflow classes from, so a run's ``activity.info().workflow_type``
+    is always a key here. Legacy inbound aliases resolve to the same entry point as
+    the canonical type.
+
+    Resolved once at worker build for the same reason as
+    :func:`boundary_contract_types`, and equally never raises: an unresolvable app
+    yields an empty mapping, and every hand-off then reads the flat file, which is
+    the correct answer for the single-entry-point majority.
+
+    Args:
+        app_name: The registered app name, from the task's metadata.
+
+    Returns:
+        ``{workflow type: entry-point name}``, possibly empty.
+    """
+    metadata = _app_metadata(app_name)
+    if metadata is None:
+        return {}
+    return {
+        workflow_type: entry_point.name
+        for workflow_type, entry_point in metadata.workflow_types.items()
+    }
+
+
+# ---------------------------------------------------------------------------
+# The hook
+# ---------------------------------------------------------------------------
+
+
+async def validate_artifacts(
+    data: Any,
+    *,
+    side: str,
+    app_name: str = "",
+    entrypoint: str = "",
+    boundary_contracts: frozenset[type] = frozenset(),
+) -> None:
+    """Validate every ``FileReference`` in ``data`` and emit one outcome each.
+
+    Called twice per task — once with the materialised input, once with the
+    returned output before it is persisted. Warn-only and total: every reference
+    reachable in the tree produces exactly one
+    :data:`~application_sdk.observability.events.ARTIFACT_VALIDATION_EVENT`,
+    including the references that turn out to have no declaration, no supported
+    validator, or no readable artifact.
+
+    References are de-duplicated on ``(owner, field, local_path)``. Two elements of
+    one ``list[FileReference]`` pointing at the same file share one declaration and
+    would emit byte-identical rows, so scanning the file twice would only inflate
+    the denominator FND-694's graduation review reads.
+
+    Never raises, never blocks, and never fails the activity — including when the
+    walk, the offload or the emit is what broke. A check that breaks the hand-off it
+    was added to protect is worse than no check at all.
+
+    Args:
+        data: The task's input (at ingest) or output (at hand-off).
+        side: :data:`ARTIFACT_SIDE_INGEST` or :data:`ARTIFACT_SIDE_HANDOFF`.
+        app_name: Registered app name, carried onto the event.
+        entrypoint: Entry-point name for this run, from :func:`entrypoint_index`.
+            "" reads the flat generated declaration file.
+        boundary_contracts: From :func:`boundary_contract_types`, resolved at
+            worker build.
+    """
+    from application_sdk.constants import (  # noqa: PLC0415 — deferred so a deployment can flip the switch under test, mirroring VALIDATE_ASSETS_ON_UPLOAD
+        VALIDATE_ARTIFACTS,
+    )
+
+    if not VALIDATE_ARTIFACTS:
+        return
+
+    try:
+        named = list(_unique(_walk(data)))
+    except Exception:  # noqa: BLE001 — the scaffold may not break the hand-off
+        logger.warning(
+            "Artifact validation: could not walk the %s payload; skipping it "
+            "(the hand-off continues)",
+            side,
+            exc_info=True,
+        )
+        return
+
+    for item in named:
+        boundary = item.owner is not None and item.owner in boundary_contracts
+        try:
+            report = await _report_for(item, entrypoint=entrypoint, boundary=boundary)
+        except Exception:  # noqa: BLE001 — the scaffold may not break the hand-off
+            logger.warning(
+                "Artifact validation: the %s check for field '%s' raised; "
+                "reporting it as absent (the hand-off continues)",
+                side,
+                item.field,
+                exc_info=True,
+            )
+            report = ArtifactValidationReport.absent(
+                reason="the artifact-validation hook raised",
+                boundary=boundary,
+            )
+        _emit(
+            report,
+            side=side,
+            app_name=app_name,
+            entrypoint=entrypoint,
+            artifact_field=item.field,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+def _walk(data: Any) -> Iterator["NamedFileRef"]:
+    """The persist/materialise walk, re-used rather than re-implemented."""
+    from application_sdk.storage.file_ref_sync import (  # noqa: PLC0415 — circular: storage/__init__.py loads sibling modules
+        iter_named_file_refs,
+    )
+
+    return iter_named_file_refs(data)
+
+
+def _unique(named: Iterable["NamedFileRef"]) -> Iterator["NamedFileRef"]:
+    """Drop references that would emit an identical row for an identical scan."""
+    seen: set[tuple[type | None, str, str | None]] = set()
+    for item in named:
+        key = (item.owner, item.field, item.ref.local_path)
+        if key in seen:
+            continue
+        seen.add(key)
+        yield item
+
+
+async def _report_for(
+    item: "NamedFileRef", *, entrypoint: str, boundary: bool
+) -> ArtifactValidationReport:
+    """Resolve one reference to exactly one report.
+
+    Nothing is inferred from the shape of the storage path — path-shape inference is
+    precisely what made the earlier upload-time hook match nothing. The contract
+    field the reference was reached through is what the declaration is keyed on, and
+    the walk already knows it.
+    """
+    from application_sdk._runtime.offload import (  # noqa: PLC0415 — circular: _runtime loads observability which loads constants
+        run_in_thread,
+    )
+    from application_sdk.validation.wrapper import (  # noqa: PLC0415 — keeps the parquet validator's pyarrow floor off a JSON-only caller's import path
+        validate_artifact,
+    )
+
+    source = ContractSource(field=item.field, entrypoint=entrypoint)
+    local_path = item.ref.local_path
+    if not local_path:
+        return _no_local_artifact(source, boundary=boundary)
+    # Synchronous by design (ADR-0020): the scan is a plain streaming read, so the
+    # interceptor owns the offload rather than every validator re-deciding it.
+    return await run_in_thread(
+        validate_artifact, Path(local_path), source, boundary=boundary
+    )
+
+
+def _no_local_artifact(
+    source: ContractSource, *, boundary: bool
+) -> ArtifactValidationReport:
+    """The outcome for a reference carrying no local artifact to scan.
+
+    A lazy field the interceptor deliberately did not download, a durable reference
+    that was never materialised, an output field left unset. There is nothing to
+    read, but silence is the one answer that is not allowed, so the declaration is
+    resolved anyway to keep the two facts apart: "this artifact has no declaration"
+    is ``not_declared`` and is a finding only on a boundary, while "it is declared
+    and we could not read it" is ``absent``. Collapsing them would report an app
+    that declared its artifact correctly as having declared nothing.
+    """
+    try:
+        declaration = source.resolve()
+    except ArtifactDeclarationError as exc:
+        logger.warning(
+            "Artifact validation: declaration unreadable — %s", exc, exc_info=True
+        )
+        return ArtifactValidationReport.absent(
+            reason=f"declaration unreadable: {exc}",
+            schema_source=source.kind,
+            boundary=boundary,
+        )
+    if declaration is None:
+        return ArtifactValidationReport.not_declared(boundary=boundary)
+    return ArtifactValidationReport.absent(
+        reason="the reference carries no local artifact to check",
+        artifact_format=declaration.artifact_format,
+        schema_source=source.kind,
+        boundary=boundary,
+    )
+
+
+def _emit(
+    report: ArtifactValidationReport,
+    *,
+    side: str,
+    app_name: str,
+    entrypoint: str,
+    artifact_field: str,
+) -> None:
+    """Emit the one queryable row, plus a readable WARNING when it is flagged.
+
+    Wrapped end to end: a defect in the emit path — a matrix that will not encode,
+    an adapter that rejects a kwarg — must not be able to break the hand-off the
+    row was describing.
+    """
+    try:
+        # conformance: ignore[L018] app_name/entrypoint are in _KNOWN_EXTRA_KEYS; _build_extra_dict promotes them to indexed OTLP attributes — %-style would lose the promotion, and a pinned outcome event exists precisely so its attributes are queryable columns
+        logger.info(
+            ARTIFACT_VALIDATION_EVENT,
+            app_name=app_name,
+            entrypoint=entrypoint,
+            **artifact_validation_event_fields(
+                report, artifact_field=artifact_field, side=side
+            ),
+        )
+        if not report.ok:
+            logger.warning(
+                "Artifact validation flagged the %s hand-off of '%s' "
+                "(the hand-off continues): %s",
+                side,
+                artifact_field or "<unnamed reference>",
+                report.format_report(),
+            )
+    except Exception:  # noqa: BLE001 — the scaffold may not break the hand-off
+        logger.warning(
+            "Artifact validation: could not emit the %s outcome for field '%s' "
+            "(the hand-off continues)",
+            side,
+            artifact_field,
+            exc_info=True,
+        )

--- a/application_sdk/validation/interceptor.py
+++ b/application_sdk/validation/interceptor.py
@@ -309,10 +309,26 @@ def _walk(data: Any) -> Iterator["NamedFileRef"]:
 
 
 def _unique(named: Iterable["NamedFileRef"]) -> Iterator["NamedFileRef"]:
-    """Drop references that would emit an identical row for an identical scan."""
-    seen: set[tuple[type | None, str, str | None]] = set()
+    """Drop references that would emit an identical row for an identical scan.
+
+    Identity is ``(owner, field, artifact)``, where the artifact is the local path
+    if there is one, the storage path otherwise, and — when a reference names
+    neither — the reference object itself.
+
+    **The fallback to object identity is what keeps the denominator honest.** A
+    durable, lazy or freshly-constructed reference has no ``local_path`` at all, so
+    keying on it alone would collapse every such reference under one field into a
+    single row: a ``list[FileReference]`` of ten distinct durable artifacts would
+    report once, understating the denominator FND-694's graduation review reads and
+    hiding nine hand-offs that emitted nothing. Deduplicating is only ever allowed
+    to drop a row that is genuinely a repeat of one already emitted; anything it
+    cannot prove is a repeat has to be its own row.
+    """
+    seen: set[tuple[type | None, str, str | int]] = set()
     for item in named:
-        key = (item.owner, item.field, item.ref.local_path)
+        ref = item.ref
+        artifact = ref.local_path or ref.storage_path or id(ref)
+        key = (item.owner, item.field, artifact)
         if key in seen:
             continue
         seen.add(key)

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -1,8 +1,8 @@
 <!--
 generated-by:  capability-manifest skill (.claude/skills/capability-manifest)
 sdk-version:   3.28.3
-source-sha:    d9608448f11e6d6f4b39f4ae1f8b4061d751090e
-source-date:   2026-08-25T03:31:37+01:00
+source-sha:    bd903916a890bec12323cc3a618d58f59fe86843
+source-date:   2026-08-25T09:53:37Z
 do-not-edit:   re-run the skill instead of hand-editing
 -->
 
@@ -35,7 +35,7 @@ do-not-edit:   re-run the skill instead of hand-editing
 | `application_sdk.storage` | Object-store abstraction — factory, formats, batch, transfer, cloud bindings | 42 |
 | `application_sdk.templates` | SQL metadata extractor templates and their contracts | 6 |
 | `application_sdk.testing` | Test infrastructure — mocks, fixtures, hypothesis strategies, integration helpers | 97 |
-| `application_sdk.validation` | Offline artifact & asset validation — format-agnostic wrapper (ADR-0020) plus pyatlan_v9 .validate() wrappers, no network call | 45 |
+| `application_sdk.validation` | Offline artifact & asset validation — format-agnostic wrapper (ADR-0020) plus pyatlan_v9 .validate() wrappers, no network call | 51 |
 
 ## Subpackage Details
 
@@ -3900,6 +3900,14 @@ Offline artifact & asset validation — format-agnostic wrapper (ADR-0020) plus 
 - **Summary:** Compact per-failure drill-down for the outcome event, as one JSON string.
 - **Defined in:** `application_sdk/validation/artifacts.py`
 
+#### `boundary_contract_types`
+
+- **Import:** `from application_sdk.validation import boundary_contract_types`
+- **Also importable from:** `application_sdk.validation.interceptor`
+- **Signature:** `boundary_contract_types(app_name: str)`
+- **Summary:** Every contract class that sits on one of ``app_name``'s public boundaries.
+- **Defined in:** `application_sdk/validation/interceptor.py`
+
 #### `builtin_format_validators`
 
 - **Import:** `from application_sdk.validation import builtin_format_validators`
@@ -3916,6 +3924,14 @@ Offline artifact & asset validation — format-agnostic wrapper (ADR-0020) plus 
 - **Summary:** Every contract field name declared for one entrypoint.
 - **Defined in:** `application_sdk/validation/sources.py`
 
+#### `entrypoint_index`
+
+- **Import:** `from application_sdk.validation import entrypoint_index`
+- **Also importable from:** `application_sdk.validation.interceptor`
+- **Signature:** `entrypoint_index(app_name: str)`
+- **Summary:** Map every Temporal workflow type ``app_name`` registers to its entry point.
+- **Defined in:** `application_sdk/validation/interceptor.py`
+
 #### `iter_ndjson_lines`
 
 - **Import:** `from application_sdk.validation import iter_ndjson_lines`
@@ -3931,6 +3947,14 @@ Offline artifact & asset validation — format-agnostic wrapper (ADR-0020) plus 
 - **Signature:** `validate_artifact(path: Path | str, *, ...)`
 - **Summary:** Validate one artifact against the declaration its source resolves to.
 - **Defined in:** `application_sdk/validation/wrapper.py`
+
+#### `validate_artifacts`
+
+- **Import:** `from application_sdk.validation import validate_artifacts`
+- **Also importable from:** `application_sdk.validation.interceptor`
+- **Signature:** `validate_artifacts(data: Any, *, ...)`
+- **Summary:** Validate every ``FileReference`` in ``data`` and emit one outcome each.
+- **Defined in:** `application_sdk/validation/interceptor.py`
 
 #### `validate_asset`
 
@@ -3983,6 +4007,30 @@ Offline artifact & asset validation — format-agnostic wrapper (ADR-0020) plus 
 - **Signature:** `ARTIFACT_SCHEMAS_FILENAME: Final`
 - **Summary:** Name of the generated declaration artifact, as the contract toolkit emits it.
 - **Defined in:** `application_sdk/validation/sources.py`
+
+#### `ARTIFACT_SIDE_HANDOFF`
+
+- **Import:** `from application_sdk.validation import ARTIFACT_SIDE_HANDOFF`
+- **Also importable from:** `application_sdk.validation.interceptor`
+- **Signature:** `ARTIFACT_SIDE_HANDOFF: Final`
+- **Summary:** Producer side: the task has returned and the bytes are still local.
+- **Defined in:** `application_sdk/validation/interceptor.py`
+
+#### `ARTIFACT_SIDE_INGEST`
+
+- **Import:** `from application_sdk.validation import ARTIFACT_SIDE_INGEST`
+- **Also importable from:** `application_sdk.validation.interceptor`
+- **Signature:** `ARTIFACT_SIDE_INGEST: Final`
+- **Summary:** Consumer side: the artifact was just materialised and is about to be read.
+- **Defined in:** `application_sdk/validation/interceptor.py`
+
+#### `ARTIFACT_SIDES`
+
+- **Import:** `from application_sdk.validation import ARTIFACT_SIDES`
+- **Also importable from:** `application_sdk.validation.interceptor`
+- **Signature:** `ARTIFACT_SIDES: Final[frozenset[str]]`
+- **Summary:** Runtime membership test for the two enforcement points.
+- **Defined in:** `application_sdk/validation/interceptor.py`
 
 #### `ARTIFACT_VALIDATION_EVENT`
 

--- a/docs/concepts/apps.md
+++ b/docs/concepts/apps.md
@@ -632,6 +632,19 @@ A *malformed* `artifact_schemas.json` is not treated as "declares nothing" — t
 skipped with a log line saying why, so one bad JSON blob cannot produce a warning on every boundary
 field.
 
+#### What a declaration buys you at runtime
+
+The activity interceptor validates every `FileReference` artifact against its declaration on both
+sides of every task — at ingest (right after the file is materialised, before your code reads it)
+and at hand-off (right after your task returns, while the bytes are still local so a flag blames the
+producer). It is warn-only: a mismatch is logged and counted, never blocked.
+
+Every artifact emits one `"Artifact validation outcome"` row either way, including the negatives —
+`not_declared`, `unsupported`, `absent` — because a check that reports nothing is indistinguishable
+from a check that passed. So a boundary field you never declared is visible in ClickHouse as
+`outcome=not_declared, boundary=true` rather than as an app that quietly validates zero records. See
+[Monitoring — Artifact-validation outcome event](monitoring.md#artifact-validation-outcome-event).
+
 See [FileReference & App.upload()](file-reference.md) for what a `FileReference` is and how it moves,
 and the contract toolkit's `examples/artifact-schemas/` for a full worked contract.
 

--- a/docs/concepts/file-reference.md
+++ b/docs/concepts/file-reference.md
@@ -117,6 +117,11 @@ fills them in during persist and materialize.
 > contract. Omitting it warns at worker build today and is an error in v4.0. A `FileReference` on an
 > internal `@task` contract is exempt. See
 > [Apps — Declaring artifact schemas](apps.md#declaring-artifact-schemas).
+>
+> Declared or not, every `FileReference` the interceptor sees emits one warn-only
+> [artifact-validation outcome](monitoring.md#artifact-validation-outcome-event) on each side of the
+> task — at ingest after materialize and at hand-off before persist. A declared artifact is scanned
+> against its declaration; an undeclared one reports `not_declared` rather than nothing at all.
 
 ### Constructing a FileReference
 

--- a/docs/concepts/monitoring.md
+++ b/docs/concepts/monitoring.md
@@ -432,14 +432,24 @@ The generic artifact-validation wrapper ([ADR-0020](../adr/0020-artifact-validat
 `"Artifact validation outcome"` — one row per artifact hand-off, whatever the format and whichever
 schema source declared it.
 
-!!! note "Not yet emitted"
+Rows are emitted automatically by the activity interceptor. Every `@task` in every app funnels
+through one seam, and both enforcement points come off the one declaration there:
 
-    The attribute contract below ships ahead of its emitter. The wrapper's report, matrix and event
-    fields exist, both schema sources (`ContractSource`, `ModelSource`) are callable, and
-    `validate_artifact(...)` really does check an NDJSON artifact against a contract declaration —
-    but a parquet declaration still resolves to `unsupported`, and nothing calls the wrapper
-    automatically until the `FileReference` interceptor wiring lands. The table is the reference for
-    what the allowlist admits, not a description of rows you will find in ClickHouse today.
+```
+  materialize_file_refs(...)   # durable -> local
++ validate(ingest)             <- consumer side, re-validate on read
+  result = await task_method(input_data)
++ validate(handoff)            <- producer side, BEFORE persist, while the bytes are still local
+  persist_file_refs(...)          so a flag blames the producer, not whoever reads it three hops on
+```
+
+Everything is **warn-only**: a flagged artifact is logged and counted, never blocked, and a defect in
+the validation scaffold itself can neither fail an activity nor skip a persist. Set
+`ATLAN_VALIDATE_ARTIFACTS=false` to turn the whole hook off for a deployment — note this stops the
+outcome events too, so an app then has no denominator at all.
+
+A declared **parquet** artifact still resolves to `unsupported` until the parquet validator ships;
+that is a row, not silence.
 
 | Attribute | Meaning |
 |-----------|---------|
@@ -448,6 +458,7 @@ schema source declared it.
 | `artifact_format` | `ndjson`, `parquet` — empty when nothing was read |
 | `artifact_schema_source` | `contract` or `model` |
 | `artifact_field` | output-contract field the artifact came from; with `entrypoint` this keys the declaration |
+| `artifact_side` | `ingest` (consumer side, after materialise) or `handoff` (producer side, before persist) |
 | `artifact_unit` | what the counts count: `record` (streaming scan) or `column` (footer diff) |
 | `artifact_total` | units examined — always the whole artifact, never a sample |
 | `artifact_passed` | units with no failure |
@@ -462,6 +473,11 @@ check that reports nothing is indistinguishable from a check that passed, so `no
 `unsupported` and `absent` are rows, not silence. And **every attribute is present on every
 outcome**, the matrix as `"[]"` when there is nothing to show, so a consumer parses it
 unconditionally instead of branching on presence.
+
+`boundary` is what makes `not_declared` actionable. An entry point's `input_type`/`output_type` are a
+public interface, so a missing declaration there is a finding against the app; the same gap on an
+internal `@task` contract is informational. The set of boundary contract classes is resolved once at
+worker build, so the attribute costs nothing per hand-off.
 
 The event body and its attribute keys are a pinned contract, like the two preflight-gate events and
 the asset-validation one; all four names live in `application_sdk/observability/events.py`.

--- a/tests/unit/execution/test_activity_artifact_validation.py
+++ b/tests/unit/execution/test_activity_artifact_validation.py
@@ -1,0 +1,241 @@
+"""Both artifact-validation hooks fire from the real interceptor (FND-691).
+
+:mod:`tests.unit.validation.test_interceptor` exercises the hook directly. This
+module asserts the *wiring*: that a real activity built by
+``create_activity_from_task`` runs the consumer-side check after materialise and
+the producer-side check before persist, that the boundary set resolved at worker
+build reaches both, and that a validator blowing up neither fails the activity nor
+skips the rest of the hand-off.
+
+The App classes are defined inside each test rather than at module scope because
+``tests/unit/execution/conftest.py`` resets both registries around every test — a
+module-level App would be registered once at import and gone by the first
+``create_activity_from_task``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, cast
+from unittest.mock import patch
+
+import orjson
+import pytest
+
+from application_sdk.app.base import App
+from application_sdk.app.registry import TaskRegistry
+from application_sdk.app.task import task
+from application_sdk.contracts.base import Input, Output
+from application_sdk.contracts.types import FileReference
+from application_sdk.execution._temporal.activities import (
+    TaskContext,
+    create_activity_from_task,
+)
+from application_sdk.observability.events import ARTIFACT_VALIDATION_EVENT
+from application_sdk.validation import interceptor as interceptor_module
+
+
+class _EchoIn(Input, allow_unbounded_fields=True):
+    raw_queries: FileReference | None = None
+
+
+class _EchoOut(Output, allow_unbounded_fields=True):
+    queries: FileReference | None = None
+
+
+class _ScratchIn(Input, allow_unbounded_fields=True):
+    scratch_in: FileReference | None = None
+
+
+class _ScratchOut(Output, allow_unbounded_fields=True):
+    scratch_out: FileReference | None = None
+
+
+_DECLARATIONS = {
+    "raw_queries": {
+        "format": "ndjson",
+        "fields": [{"name": "QUERY_ID", "type": "string", "description": "id"}],
+    },
+    "queries": {
+        "format": "ndjson",
+        "fields": [
+            {"name": "QUERY_ID", "type": "string", "description": "id"},
+            {"name": "START_TIME", "type": "timestamp", "description": "when"},
+        ],
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Harness
+# ---------------------------------------------------------------------------
+
+
+def _boundary_activity(output_path: str) -> Any:
+    """An app whose ``@task`` contracts *are* its entry point's contracts."""
+
+    class ArtifactBoundaryApp(App):
+        @task(timeout_seconds=60)
+        async def echo(self, input: _EchoIn) -> _EchoOut:
+            return _EchoOut(queries=FileReference(local_path=output_path))
+
+        async def run(self, input: _EchoIn) -> _EchoOut:
+            return await self.echo(input)
+
+    return _activity_for("artifact-boundary-app", "echo")
+
+
+def _internal_activity(output_path: str) -> Any:
+    """An app whose ``@task`` contracts are app-internal; only ``run()``'s are public."""
+
+    class ArtifactInternalApp(App):
+        @task(timeout_seconds=60)
+        async def crunch(self, input: _ScratchIn) -> _ScratchOut:
+            return _ScratchOut(scratch_out=FileReference(local_path=output_path))
+
+        async def run(self, input: _EchoIn) -> _EchoOut:
+            return _EchoOut()
+
+    return _activity_for("artifact-internal-app", "crunch")
+
+
+def _activity_for(app_name: str, task_name: str) -> Any:
+    tasks = TaskRegistry.get_instance().get_tasks_for_app(app_name)
+    return create_activity_from_task(next(t for t in tasks if t.name == task_name))
+
+
+def _task_context(app_name: str, task_name: str) -> TaskContext:
+    return TaskContext(
+        app_name=app_name,
+        task_name=task_name,
+        run_id="run-fnd691",
+        heartbeat_timeout_seconds=None,
+        auto_heartbeat_seconds=None,
+    )
+
+
+def _events(logger: Any) -> list[dict[str, Any]]:
+    return [
+        call.kwargs
+        for call in logger.info.call_args_list
+        if call.args and call.args[0] == ARTIFACT_VALIDATION_EVENT
+    ]
+
+
+def _ndjson(path: Path, records: list[dict[str, Any]]) -> str:
+    path.write_bytes(b"\n".join(orjson.dumps(r) for r in records) + b"\n")
+    return str(path)
+
+
+@pytest.fixture
+def generated_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A per-test generated tree holding the two declarations above."""
+    generated = tmp_path / "generated"
+    generated.mkdir()
+    (generated / "artifact_schemas.json").write_bytes(
+        orjson.dumps({"version": 1, "schemas": _DECLARATIONS})
+    )
+    monkeypatch.setattr(
+        "application_sdk.validation.sources.CONTRACT_GENERATED_DIR", str(generated)
+    )
+    return generated
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_both_hooks_fire_on_a_declared_contract(
+    tmp_path: Path, generated_dir: Path
+) -> None:
+    """One declaration at one site, checked on both sides of the task."""
+    output = _ndjson(
+        tmp_path / "out.json",
+        [{"QUERY_ID": "q1", "START_TIME": "2026-08-25T00:00:00Z"}],
+    )
+    incoming = _ndjson(tmp_path / "in.json", [{"QUERY_ID": "q0"}])
+    activity_fn = _boundary_activity(output)
+
+    with patch.object(interceptor_module, "logger") as logger:
+        result = await activity_fn(
+            _task_context("artifact-boundary-app", "echo"),
+            _EchoIn(raw_queries=FileReference(local_path=incoming)),
+        )
+        events = _events(logger)
+
+    assert cast(_EchoOut, result).queries is not None
+    by_side = {e["artifact_side"]: e for e in events}
+    assert set(by_side) == {"ingest", "handoff"}
+    assert by_side["ingest"]["artifact_field"] == "raw_queries"
+    assert by_side["ingest"]["outcome"] == "clean"
+    assert by_side["handoff"]["artifact_field"] == "queries"
+    assert by_side["handoff"]["outcome"] == "clean"
+
+
+@pytest.mark.asyncio
+async def test_boundary_is_true_for_an_entrypoint_contract(
+    tmp_path: Path, generated_dir: Path
+) -> None:
+    """No declaration on a public interface is a finding, and says which one."""
+    (generated_dir / "artifact_schemas.json").unlink()
+    activity_fn = _boundary_activity(str(tmp_path / "absent.json"))
+
+    with patch.object(interceptor_module, "logger") as logger:
+        await activity_fn(
+            _task_context("artifact-boundary-app", "echo"),
+            _EchoIn(raw_queries=FileReference(local_path=str(tmp_path / "in.json"))),
+        )
+        events = _events(logger)
+
+    assert [e["outcome"] for e in events] == ["not_declared", "not_declared"]
+    assert all(e["boundary"] is True for e in events)
+
+
+@pytest.mark.asyncio
+async def test_boundary_is_false_for_an_internal_task_contract(
+    tmp_path: Path, generated_dir: Path
+) -> None:
+    """The same missing declaration is informational inside the app."""
+    (generated_dir / "artifact_schemas.json").unlink()
+    activity_fn = _internal_activity(str(tmp_path / "scratch-out.json"))
+
+    with patch.object(interceptor_module, "logger") as logger:
+        await activity_fn(
+            _task_context("artifact-internal-app", "crunch"),
+            _ScratchIn(scratch_in=FileReference(local_path=str(tmp_path / "s.json"))),
+        )
+        events = _events(logger)
+
+    assert [e["outcome"] for e in events] == ["not_declared", "not_declared"]
+    assert all(e["boundary"] is False for e in events)
+
+
+@pytest.mark.asyncio
+async def test_a_raising_validator_never_reaches_the_task(
+    tmp_path: Path, generated_dir: Path
+) -> None:
+    """The activity still returns its result; the failure lands as ``absent``."""
+
+    def _boom(*args: Any, **kwargs: Any) -> Any:
+        raise RuntimeError("validator exploded")
+
+    activity_fn = _boundary_activity(
+        _ndjson(tmp_path / "out.json", [{"QUERY_ID": "q"}])
+    )
+
+    with patch("application_sdk.validation.wrapper.validate_artifact", _boom):
+        with patch.object(interceptor_module, "logger") as logger:
+            result = await activity_fn(
+                _task_context("artifact-boundary-app", "echo"),
+                _EchoIn(
+                    raw_queries=FileReference(
+                        local_path=_ndjson(tmp_path / "in.json", [{"QUERY_ID": "q0"}])
+                    )
+                ),
+            )
+            events = _events(logger)
+
+    assert cast(_EchoOut, result).queries is not None
+    assert [e["outcome"] for e in events] == ["absent", "absent"]

--- a/tests/unit/execution/test_activity_artifact_validation.py
+++ b/tests/unit/execution/test_activity_artifact_validation.py
@@ -17,16 +17,18 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Any, cast
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import orjson
 import pytest
 
 from application_sdk.app.base import App
+from application_sdk.app.entrypoint import entrypoint
 from application_sdk.app.registry import TaskRegistry
 from application_sdk.app.task import task
 from application_sdk.contracts.base import Input, Output
 from application_sdk.contracts.types import FileReference
+from application_sdk.execution._temporal import activities as activities_module
 from application_sdk.execution._temporal.activities import (
     TaskContext,
     create_activity_from_task,
@@ -97,6 +99,27 @@ def _internal_activity(output_path: str) -> Any:
             return _EchoOut()
 
     return _activity_for("artifact-internal-app", "crunch")
+
+
+def _bundle_activity(output_path: str) -> Any:
+    """A bundle: two entry points, one legacy inbound alias, one shared @task."""
+
+    class ArtifactBundleApp(App):
+        legacy_workflow_types = {"legacy-extract": "extract"}
+
+        @task(timeout_seconds=60)
+        async def echo(self, input: _EchoIn) -> _EchoOut:
+            return _EchoOut(queries=FileReference(local_path=output_path))
+
+        @entrypoint(name="extract", default=True)
+        async def extract(self, input: _EchoIn) -> _EchoOut:
+            return await self.echo(input)
+
+        @entrypoint(name="enrich")
+        async def enrich(self, input: _EchoIn) -> _EchoOut:
+            return _EchoOut()
+
+    return _activity_for("artifact-bundle-app", "echo")
 
 
 def _activity_for(app_name: str, task_name: str) -> Any:
@@ -239,3 +262,122 @@ async def test_a_raising_validator_never_reaches_the_task(
 
     assert cast(_EchoOut, result).queries is not None
     assert [e["outcome"] for e in events] == ["absent", "absent"]
+
+
+# ---------------------------------------------------------------------------
+# A bundle reads its own entry point's declarations
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def bundle_generated_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A bundle tree whose two declaration files disagree on purpose.
+
+    ``app/generated/extract/artifact_schemas.json`` declares what the artifact
+    actually carries; the flat ``app/generated/artifact_schemas.json`` declares a
+    field it does not. The nested file is tried first and the first file that
+    exists answers, so a ``clean`` outcome can only mean the per-entry-point file
+    was the one read — and a ``flagged`` one would mean the entry point never
+    reached the resolver and the run fell through to the flat file.
+    """
+    generated = tmp_path / "generated"
+    (generated / "extract").mkdir(parents=True)
+    (generated / "extract" / "artifact_schemas.json").write_bytes(
+        orjson.dumps(
+            {
+                "version": 1,
+                "schemas": {
+                    "queries": {
+                        "format": "ndjson",
+                        "fields": [
+                            {"name": "QUERY_ID", "type": "string", "description": "id"}
+                        ],
+                    }
+                },
+            }
+        )
+    )
+    (generated / "artifact_schemas.json").write_bytes(
+        orjson.dumps(
+            {
+                "version": 1,
+                "schemas": {
+                    "queries": {
+                        "format": "ndjson",
+                        "fields": [
+                            {
+                                "name": "NOT_IN_THE_ARTIFACT",
+                                "type": "string",
+                                "description": "only the flat file asks for this",
+                            }
+                        ],
+                    }
+                },
+            }
+        )
+    )
+    monkeypatch.setattr(
+        "application_sdk.validation.sources.CONTRACT_GENERATED_DIR", str(generated)
+    )
+    return generated
+
+
+@pytest.mark.parametrize(
+    "workflow_type",
+    [
+        pytest.param("artifact-bundle-app:extract", id="canonical-type"),
+        pytest.param("legacy-extract", id="legacy-alias"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_the_runs_entry_point_selects_the_declaration_file(
+    tmp_path: Path, bundle_generated_dir: Path, workflow_type: str
+) -> None:
+    """The workflow type the run arrives on picks which declarations apply.
+
+    Stubbed at the Temporal boundary rather than at ``_current_workflow_type``, so
+    the key this asserts on is the one Temporal actually hands the activity — the
+    index is built from ``AppMetadata.workflow_types``, and a legacy inbound alias
+    has to resolve to the same entry point as the canonical type.
+    """
+    output = _ndjson(tmp_path / "out.json", [{"QUERY_ID": "q1"}])
+    activity_fn = _bundle_activity(output)
+
+    with patch.object(
+        activities_module.activity,
+        "info",
+        return_value=MagicMock(workflow_type=workflow_type),
+    ):
+        with patch.object(interceptor_module, "logger") as logger:
+            await activity_fn(_task_context("artifact-bundle-app", "echo"), _EchoIn())
+            events = _events(logger)
+
+    handoff = next(e for e in events if e["artifact_side"] == "handoff")
+    assert handoff["entrypoint"] == "extract"
+    assert handoff["outcome"] == "clean", (
+        "flagged means the flat file answered — the entry point never reached "
+        "ContractSource"
+    )
+
+
+@pytest.mark.asyncio
+async def test_an_unregistered_workflow_type_falls_back_to_the_flat_file(
+    tmp_path: Path, bundle_generated_dir: Path
+) -> None:
+    """The conservative direction: read the flat file, never guess an entry point."""
+    output = _ndjson(tmp_path / "out.json", [{"QUERY_ID": "q1"}])
+    activity_fn = _bundle_activity(output)
+
+    with patch.object(
+        activities_module.activity,
+        "info",
+        return_value=MagicMock(workflow_type="some-type-nobody-registered"),
+    ):
+        with patch.object(interceptor_module, "logger") as logger:
+            await activity_fn(_task_context("artifact-bundle-app", "echo"), _EchoIn())
+            events = _events(logger)
+
+    handoff = next(e for e in events if e["artifact_side"] == "handoff")
+    assert handoff["entrypoint"] == ""
+    # The flat file asks for a field the artifact does not carry.
+    assert handoff["outcome"] == "flagged"

--- a/tests/unit/validation/test_interceptor.py
+++ b/tests/unit/validation/test_interceptor.py
@@ -439,6 +439,53 @@ class TestBookkeeping:
         assert len(events) == 2
 
     @pytest.mark.asyncio
+    async def test_distinct_durable_refs_under_one_field_each_emit(
+        self, generated_dir: Path
+    ) -> None:
+        """Nothing is materialised yet, so ``local_path`` cannot tell them apart.
+
+        Deduplicating on the local path alone would collapse a whole
+        ``list[FileReference]`` of durable artifacts into one row — understating
+        the denominator and hiding every hand-off but the first.
+        """
+        events = await _run(
+            _ParentOut(
+                parts=[
+                    FileReference(storage_path="artifacts/a", is_durable=True),
+                    FileReference(storage_path="artifacts/b", is_durable=True),
+                ]
+            )
+        )
+        assert len(events) == 2
+
+    @pytest.mark.asyncio
+    async def test_the_same_durable_artifact_twice_is_scanned_once(
+        self, generated_dir: Path
+    ) -> None:
+        """Two references, one storage path: a genuine repeat, so one row."""
+        events = await _run(
+            _ParentOut(
+                parts=[
+                    FileReference(storage_path="artifacts/a", is_durable=True),
+                    FileReference(storage_path="artifacts/a", is_durable=True),
+                ]
+            )
+        )
+        assert len(events) == 1
+
+    @pytest.mark.asyncio
+    async def test_refs_naming_no_artifact_at_all_each_emit(
+        self, generated_dir: Path
+    ) -> None:
+        """Neither path is set, so nothing proves these are the same hand-off.
+
+        Dedup may only ever drop a row it can prove is a repeat; two references
+        that name nothing fall back to object identity rather than collapsing.
+        """
+        events = await _run(_ParentOut(parts=[FileReference(), FileReference()]))
+        assert len(events) == 2
+
+    @pytest.mark.asyncio
     async def test_the_kill_switch_stops_the_hook_entirely(
         self, generated_dir: Path
     ) -> None:

--- a/tests/unit/validation/test_interceptor.py
+++ b/tests/unit/validation/test_interceptor.py
@@ -1,0 +1,440 @@
+"""Artifact validation wired to the FileReference interceptor (FND-691, ADR-0020).
+
+The property under test throughout is **no silent no-op**. The hook this replaces
+returned early and emitted nothing whenever its path gate did not match, so an app
+could look adopted while validating zero records (FND-401) — which is why almost
+every test here asserts on what was *emitted*, negatives included, rather than on
+whether a scan happened to run.
+
+Events are captured by patching the module's own logger. That is enough here
+because :mod:`tests.unit.validation.test_artifact_event_fields` already asserts the
+attribute map against the real ``_build_extra_dict`` filter — a mock records
+whatever it is handed, so only that test can prove the fields reach OTLP.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import orjson
+import pytest
+
+from application_sdk.contracts.base import Input, Output
+from application_sdk.contracts.types import FileReference
+from application_sdk.observability.events import ARTIFACT_VALIDATION_EVENT
+from application_sdk.storage.file_ref_sync import _find_file_refs, iter_named_file_refs
+from application_sdk.validation import interceptor as interceptor_module
+from application_sdk.validation.interceptor import (
+    ARTIFACT_SIDE_HANDOFF,
+    ARTIFACT_SIDE_INGEST,
+    boundary_contract_types,
+    entrypoint_index,
+    validate_artifacts,
+)
+
+# ---------------------------------------------------------------------------
+# Contracts under test
+# ---------------------------------------------------------------------------
+
+
+class _BoundaryIn(Input, allow_unbounded_fields=True):
+    """Stands in for an entry point's public input contract."""
+
+    raw_queries: FileReference | None = None
+
+
+class _BoundaryOut(Output, allow_unbounded_fields=True):
+    """Stands in for an entry point's public output contract."""
+
+    queries: FileReference | None = None
+
+
+class _InternalOut(Output, allow_unbounded_fields=True):
+    """An internal ``@task`` contract — never an entry point's boundary."""
+
+    scratch: FileReference | None = None
+
+
+class _Nested(Output, allow_unbounded_fields=True):
+    inner: FileReference | None = None
+
+
+class _ParentOut(Output, allow_unbounded_fields=True):
+    child: _Nested | None = None
+    parts: list[FileReference] = []
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_declarations(generated: Path, schemas: dict[str, Any]) -> None:
+    generated.mkdir(parents=True, exist_ok=True)
+    (generated / "artifact_schemas.json").write_bytes(
+        orjson.dumps({"version": 1, "schemas": schemas})
+    )
+
+
+_NDJSON_QUERIES = {
+    "queries": {
+        "format": "ndjson",
+        "fields": [
+            {"name": "QUERY_ID", "type": "string", "description": "the query id"},
+            {"name": "START_TIME", "type": "timestamp", "description": "when it ran"},
+        ],
+    }
+}
+
+
+@pytest.fixture
+def generated_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point the contract source at a per-test generated tree.
+
+    ``sources`` binds ``CONTRACT_GENERATED_DIR`` at import, and the loader caches
+    per path — a fresh ``tmp_path`` per test keeps both honest.
+    """
+    generated = tmp_path / "generated"
+    generated.mkdir()
+    monkeypatch.setattr(
+        "application_sdk.validation.sources.CONTRACT_GENERATED_DIR", str(generated)
+    )
+    return generated
+
+
+def _ndjson(tmp_path: Path, name: str, records: list[dict[str, Any]]) -> str:
+    path = tmp_path / name
+    path.write_bytes(b"\n".join(orjson.dumps(r) for r in records) + b"\n")
+    return str(path)
+
+
+def _events(logger: Any) -> list[dict[str, Any]]:
+    """Every artifact-validation outcome row the hook emitted, in order."""
+    return [
+        call.kwargs
+        for call in logger.info.call_args_list
+        if call.args and call.args[0] == ARTIFACT_VALIDATION_EVENT
+    ]
+
+
+async def _run(data: Any, **kwargs: Any) -> list[dict[str, Any]]:
+    """Run the hook with a captured logger and return the emitted rows."""
+    kwargs.setdefault("side", ARTIFACT_SIDE_HANDOFF)
+    with patch.object(interceptor_module, "logger") as logger:
+        await validate_artifacts(data, **kwargs)
+        return _events(logger)
+
+
+# ---------------------------------------------------------------------------
+# The walk
+# ---------------------------------------------------------------------------
+
+
+class TestNamedWalk:
+    """``iter_named_file_refs`` is the one walk; ``_find_file_refs`` rides it."""
+
+    def test_names_the_contract_field_the_ref_was_reached_through(self) -> None:
+        out = _BoundaryOut(queries=FileReference(local_path="/tmp/q.json"))
+        named = list(iter_named_file_refs(out))
+        assert [(n.field, n.owner) for n in named] == [("queries", _BoundaryOut)]
+
+    def test_container_elements_share_the_container_field(self) -> None:
+        parent = _ParentOut(
+            parts=[
+                FileReference(local_path="/tmp/a.json"),
+                FileReference(local_path="/tmp/b.json"),
+            ]
+        )
+        named = list(iter_named_file_refs(parent))
+        assert [(n.field, n.owner) for n in named] == [
+            ("parts", _ParentOut),
+            ("parts", _ParentOut),
+        ]
+
+    def test_a_nested_model_owns_its_own_field(self) -> None:
+        """So a ref on an inner model is never counted as a boundary hand-off."""
+        parent = _ParentOut(child=_Nested(inner=FileReference(local_path="/tmp/i")))
+        named = list(iter_named_file_refs(parent))
+        assert [(n.field, n.owner) for n in named] == [("inner", _Nested)]
+
+    def test_a_bare_ref_has_no_field_and_no_owner(self) -> None:
+        named = list(iter_named_file_refs(FileReference(local_path="/tmp/x")))
+        assert (named[0].field, named[0].owner) == ("", None)
+
+    def test_find_file_refs_still_agrees_with_the_named_walk(self) -> None:
+        parent = _ParentOut(
+            child=_Nested(inner=FileReference(local_path="/tmp/i")),
+            parts=[FileReference(local_path="/tmp/a"), FileReference()],
+        )
+        assert _find_file_refs(parent) == [n.ref for n in iter_named_file_refs(parent)]
+
+
+# ---------------------------------------------------------------------------
+# Worker-build resolution
+# ---------------------------------------------------------------------------
+
+
+class TestWorkerBuildResolution:
+    def test_unregistered_app_resolves_to_empty_and_never_raises(self) -> None:
+        assert boundary_contract_types("no-such-app-fnd691") == frozenset()
+        assert entrypoint_index("no-such-app-fnd691") == {}
+
+    def test_boundary_set_is_the_entry_points_contracts(self) -> None:
+        from application_sdk.app.base import App
+        from application_sdk.app.task import task
+
+        class BoundaryProbeApp(App):
+            @task(timeout_seconds=60)
+            async def crunch(self, input: Input) -> _InternalOut:  # noqa: D102
+                return _InternalOut()
+
+            async def run(self, input: _BoundaryIn) -> _BoundaryOut:  # noqa: D102
+                return _BoundaryOut()
+
+        assert boundary_contract_types("boundary-probe-app") == frozenset(
+            {_BoundaryIn, _BoundaryOut}
+        )
+        # The internal @task contract is excluded by construction, not by a filter.
+        assert _InternalOut not in boundary_contract_types("boundary-probe-app")
+        # Every registered workflow type resolves to its entry point, so a bundle
+        # reads its own declaration file rather than missing it silently.
+        assert entrypoint_index("boundary-probe-app") == {"boundary-probe-app": "run"}
+
+
+# ---------------------------------------------------------------------------
+# Every artifact emits exactly one outcome
+# ---------------------------------------------------------------------------
+
+
+class TestEveryArtifactEmits:
+    @pytest.mark.asyncio
+    async def test_a_declared_clean_artifact_reports_clean(
+        self, tmp_path: Path, generated_dir: Path
+    ) -> None:
+        _write_declarations(generated_dir, _NDJSON_QUERIES)
+        local = _ndjson(
+            tmp_path,
+            "queries.json",
+            [{"QUERY_ID": "q1", "START_TIME": "2026-08-25T10:00:00Z"}],
+        )
+        events = await _run(_BoundaryOut(queries=FileReference(local_path=local)))
+        assert len(events) == 1
+        assert events[0]["outcome"] == "clean"
+        assert events[0]["artifact_format"] == "ndjson"
+        assert events[0]["artifact_schema_source"] == "contract"
+        assert events[0]["artifact_field"] == "queries"
+        assert events[0]["artifact_total"] == 1
+        assert events[0]["artifact_side"] == ARTIFACT_SIDE_HANDOFF
+
+    @pytest.mark.asyncio
+    async def test_a_declared_broken_artifact_reports_flagged(
+        self, tmp_path: Path, generated_dir: Path
+    ) -> None:
+        """The 73-day RCA in miniature: a timestamp that became a string."""
+        _write_declarations(generated_dir, _NDJSON_QUERIES)
+        local = _ndjson(
+            tmp_path,
+            "queries.json",
+            [{"QUERY_ID": "q1", "START_TIME": "last Tuesday"}],
+        )
+        with patch.object(interceptor_module, "logger") as logger:
+            await validate_artifacts(
+                _BoundaryOut(queries=FileReference(local_path=local)),
+                side=ARTIFACT_SIDE_HANDOFF,
+            )
+            events = _events(logger)
+            # The human-readable report rides a WARNING only when flagged.
+            assert logger.warning.called
+        assert events[0]["outcome"] == "flagged"
+        assert events[0]["artifact_failed"] == 1
+        matrix = orjson.loads(events[0]["artifact_validation_matrix"])
+        assert matrix[0]["field"] == "START_TIME"
+        assert matrix[0]["expected"] == "timestamp"
+
+    @pytest.mark.asyncio
+    async def test_an_undeclared_ref_reports_not_declared(
+        self, tmp_path: Path, generated_dir: Path
+    ) -> None:
+        local = _ndjson(tmp_path, "scratch.json", [{"anything": 1}])
+        events = await _run(_InternalOut(scratch=FileReference(local_path=local)))
+        assert [e["outcome"] for e in events] == ["not_declared"]
+
+    @pytest.mark.asyncio
+    async def test_an_unsupported_cell_says_so_rather_than_going_quiet(
+        self, tmp_path: Path, generated_dir: Path
+    ) -> None:
+        """A declared parquet artifact has no validator yet (FND-689)."""
+        _write_declarations(
+            generated_dir,
+            {
+                "queries": {
+                    "format": "parquet",
+                    "fields": [{"name": "QUERY_ID", "type": "string"}],
+                }
+            },
+        )
+        local = _ndjson(tmp_path, "queries.json", [{"QUERY_ID": "q1"}])
+        events = await _run(_BoundaryOut(queries=FileReference(local_path=local)))
+        assert events[0]["outcome"] == "unsupported"
+        assert events[0]["artifact_format"] == "parquet"
+
+    @pytest.mark.asyncio
+    async def test_a_missing_artifact_reports_absent(
+        self, tmp_path: Path, generated_dir: Path
+    ) -> None:
+        _write_declarations(generated_dir, _NDJSON_QUERIES)
+        events = await _run(
+            _BoundaryOut(
+                queries=FileReference(local_path=str(tmp_path / "never-written.json"))
+            )
+        )
+        assert events[0]["outcome"] == "absent"
+
+    @pytest.mark.asyncio
+    async def test_a_ref_with_no_local_artifact_still_emits(
+        self, generated_dir: Path
+    ) -> None:
+        """A lazy or unmaterialised ref: declared, so ``absent``, never silence."""
+        _write_declarations(generated_dir, _NDJSON_QUERIES)
+        events = await _run(
+            _BoundaryOut(
+                queries=FileReference(storage_path="artifacts/q", is_durable=True)
+            )
+        )
+        assert events[0]["outcome"] == "absent"
+        assert events[0]["artifact_schema_source"] == "contract"
+
+    @pytest.mark.asyncio
+    async def test_no_local_artifact_and_no_declaration_is_not_declared(
+        self, generated_dir: Path
+    ) -> None:
+        """ "You declared nothing" must not be mislabelled "we could not read it"."""
+        events = await _run(_BoundaryOut(queries=FileReference()))
+        assert events[0]["outcome"] == "not_declared"
+
+    @pytest.mark.asyncio
+    async def test_nothing_is_emitted_for_a_payload_holding_no_refs(self) -> None:
+        assert await _run(_BoundaryOut()) == []
+
+
+# ---------------------------------------------------------------------------
+# boundary
+# ---------------------------------------------------------------------------
+
+
+class TestBoundaryAttribution:
+    @pytest.mark.asyncio
+    async def test_entrypoint_contract_reports_boundary_true(
+        self, generated_dir: Path
+    ) -> None:
+        events = await _run(
+            _BoundaryOut(queries=FileReference()),
+            boundary_contracts=frozenset({_BoundaryIn, _BoundaryOut}),
+        )
+        assert events[0]["outcome"] == "not_declared"
+        assert events[0]["boundary"] is True
+
+    @pytest.mark.asyncio
+    async def test_internal_task_contract_reports_boundary_false(
+        self, generated_dir: Path
+    ) -> None:
+        events = await _run(
+            _InternalOut(scratch=FileReference()),
+            boundary_contracts=frozenset({_BoundaryIn, _BoundaryOut}),
+        )
+        assert events[0]["outcome"] == "not_declared"
+        assert events[0]["boundary"] is False
+
+    @pytest.mark.asyncio
+    async def test_a_ref_on_a_nested_model_is_not_a_boundary_handoff(
+        self, generated_dir: Path
+    ) -> None:
+        events = await _run(
+            _ParentOut(child=_Nested(inner=FileReference())),
+            boundary_contracts=frozenset({_ParentOut}),
+        )
+        assert events[0]["boundary"] is False
+
+
+# ---------------------------------------------------------------------------
+# The scaffold may never break the hand-off
+# ---------------------------------------------------------------------------
+
+
+def _boom(*args: Any, **kwargs: Any) -> Any:
+    raise RuntimeError("validator exploded")
+
+
+class TestNeverBreaksTheHandoff:
+    @pytest.mark.asyncio
+    async def test_a_raising_validator_becomes_an_absent_row(
+        self, tmp_path: Path, generated_dir: Path
+    ) -> None:
+        _write_declarations(generated_dir, _NDJSON_QUERIES)
+        local = _ndjson(tmp_path, "queries.json", [{"QUERY_ID": "q1"}])
+        with patch("application_sdk.validation.wrapper.validate_artifact", _boom):
+            events = await _run(
+                _BoundaryOut(queries=FileReference(local_path=local)),
+                boundary_contracts=frozenset({_BoundaryOut}),
+            )
+        assert events[0]["outcome"] == "absent"
+        # The boundary fact survives the failure — it is the wiring's, not the
+        # validator's, so a broken validator cannot erase a finding's audience.
+        assert events[0]["boundary"] is True
+
+    @pytest.mark.asyncio
+    async def test_a_broken_walk_is_swallowed(self, generated_dir: Path) -> None:
+        with patch.object(interceptor_module, "_walk", _boom):
+            assert await _run(_BoundaryOut(queries=FileReference())) == []
+
+    @pytest.mark.asyncio
+    async def test_a_broken_emit_is_swallowed(self, generated_dir: Path) -> None:
+        with patch.object(
+            interceptor_module, "artifact_validation_event_fields", _boom
+        ):
+            with patch.object(interceptor_module, "logger") as logger:
+                # Returning at all is half the assertion: a raise here would have
+                # propagated straight into the task the hook wraps.
+                await validate_artifacts(
+                    _BoundaryOut(queries=FileReference()), side=ARTIFACT_SIDE_INGEST
+                )
+                assert _events(logger) == []
+                assert logger.warning.called
+
+
+# ---------------------------------------------------------------------------
+# Bookkeeping
+# ---------------------------------------------------------------------------
+
+
+class TestBookkeeping:
+    @pytest.mark.asyncio
+    async def test_identical_refs_are_scanned_once(
+        self, tmp_path: Path, generated_dir: Path
+    ) -> None:
+        ref = FileReference(local_path=_ndjson(tmp_path, "a.json", [{"x": 1}]))
+        events = await _run(_ParentOut(parts=[ref, ref]))
+        assert len(events) == 1
+
+    @pytest.mark.asyncio
+    async def test_distinct_artifacts_under_one_field_each_emit(
+        self, tmp_path: Path, generated_dir: Path
+    ) -> None:
+        events = await _run(
+            _ParentOut(
+                parts=[
+                    FileReference(local_path=_ndjson(tmp_path, "a.json", [{"x": 1}])),
+                    FileReference(local_path=_ndjson(tmp_path, "b.json", [{"x": 2}])),
+                ]
+            )
+        )
+        assert len(events) == 2
+
+    @pytest.mark.asyncio
+    async def test_the_kill_switch_stops_the_hook_entirely(
+        self, generated_dir: Path
+    ) -> None:
+        with patch("application_sdk.constants.VALIDATE_ARTIFACTS", False):
+            assert await _run(_BoundaryOut(queries=FileReference())) == []


### PR DESCRIPTION
Step 7 of the [ADR-0020](docs/adr/0020-artifact-validation.md) sequence. Closes [FND-691](https://linear.app/atlan-epd/issue/FND-691/wire-artifact-validation-into-the-filereference-interceptor-both-sides), and closes FND-401's coverage gap.

## What

`FileReference` is the universal hand-off token and the activity interceptor is the one place every `@task` in every app funnels through, so both enforcement points come off one declaration at one site:

```
materialize_file_refs(...)              if store & refs
validate_artifacts(input,  "ingest")    <- consumer side, re-validate on read
result = await task_method(input_data)
validate_artifacts(result, "handoff")   <- producer side, BEFORE persist: the
persist_file_refs(...)                     bytes are still local, so blame lands
                                           on the producer
```

Both hooks sit **outside** the `store is not None` guards on purpose. A hand-off that moves no bytes still hands an artifact over, and a check that goes quiet on some paths is indistinguishable from one that passed — that ambiguity *is* FND-401, and removing it is the point of the step. Every reference emits exactly one outcome, the negatives included: `not_declared` (carrying `boundary`), `unsupported`, `absent`.

Everything is warn-only. Nothing here fails an activity or blocks a persist; whether a verdict may block stays FND-692's axis.

## How

**The walk is the existing one, not a second one.** `storage/file_ref_sync.py` gains `NamedFileRef` + `iter_named_file_refs`, which yield each reference with the contract field it was reached through and the model class declaring it. `_find_file_refs` is now written in terms of it, so the two cannot drift into disagreeing about what a tree holds. Containers pass `(owner, field)` down unchanged, so every element of a `list[FileReference]` shares the one declaration keyed by that field; a nested model re-keys to its own fields, so an inner reference is never counted as a boundary hand-off.

**Two facts resolved once at worker build**, baked into the activity's closure — the shape the preflight gate's posture already uses:

- `boundary_contract_types()` — every entry point's `input_type`/`output_type`, exact class identity. The same line `_artifact_schema_guard` draws at registration, so the runtime attribute and the registration warning cannot disagree about what "public" means.
- `entrypoint_index()` — every registered workflow type mapped to its entry point.

Neither raises: an unregistered app yields empty values, which reports `boundary=False` against the flat declaration file. That is the conservative direction — it under-reports findings rather than inventing them.

## Two decisions beyond the ticket

**1. `entrypoint_index` is load-bearing, not incidental.** Declarations are keyed by `(entrypoint, field)` and the entrypoint half decides *which generated file is read*. Without a workflow-type → entry-point map, every bundle app would miss its own `app/generated/<ep>/artifact_schemas.json` and report `not_declared` fleet-wide — a silent no-op wearing an outcome event's clothes, i.e. exactly the failure this step exists to remove. Resolved at build alongside the boundary set; one dict lookup per call on `activity.info().workflow_type`.

**2. One new event attribute: `artifact_side` (`ingest` | `handoff`).** Without it the two enforcement points are indistinguishable in ClickHouse — a producer-side flag and the consumer-side re-read of the same artifact collapse into one number, and FND-694's false-positive measurement cannot separate them. Added as the full three-part contract (key constant, `_KNOWN_EXTRA_KEYS` entry, and a `side=` kwarg on `artifact_validation_event_fields`, which stays the single report→telemetry mapping site). Present on every outcome; `""` for callers outside the interceptor.

## Acceptance

| Criterion | Where |
|---|---|
| Both hooks fire on a task whose contract declares a schema | `test_activity_artifact_validation.py::test_both_hooks_fire_on_a_declared_contract` — one `clean` per side, correct `artifact_field` on each |
| `not_declared` with the right `boundary`, for an entry-point contract **and** an internal `@task` contract | the two `test_boundary_is_*` tests, driven through the real `create_activity_from_task` |
| `unsupported` for an artifact the validator cannot handle; `absent` for a missing one; no path returns without emitting | `test_interceptor.py` — including a reference with no local artifact at all, where the declaration is resolved anyway so "you declared nothing" is never mislabelled as "we could not read it" |
| A validator exception never propagates into the task or the persist step | asserted at the hook and end-to-end through the activity (result still returned, two `absent` rows). The wiring is belted too: a broken walk, offload or emit is swallowed |

## Notes

- **Offload**: `run_in_thread`, per ADR-0020 — contract × NDJSON is pure Python plus `orjson`, and the interceptor owns the offload decision so validators stay synchronous. The model path (isolated child process) is unreachable from here; NDJSON still answers `supports() -> False` for a `ModelDeclaration` until FND-690.
- **Cost is opt-in by declaration.** An undeclared reference resolves to `not_declared` without ever reading the artifact.
- **Kill switch**: `ATLAN_VALIDATE_ARTIFACTS` (default `true`). It stops the outcome events too, which is why it is deliberately an operator switch and not a per-app default.
- Two conformance findings on the new module are suppressed with justifications: `E004` on the guarded registry lookup (advisory wiring must not break worker build) and `L018` on the emit (`app_name`/`entrypoint` are allowlisted keys promoted to indexed OTLP attributes — the promotion is the whole point of a pinned outcome event).

## Verification

- `uv run pytest tests/unit` — 7828 passed, 9 skipped
- `uv run pre-commit run --all-files` — clean (pyright included)
- `atlan-application-sdk-conformance detect` — no unsuppressed findings on the changed files
- Docs updated: `monitoring.md` (the "Not yet emitted" note is gone, `artifact_side` documented), `apps.md`, `file-reference.md`; capability manifest regenerated via `uv run poe regen-capabilities`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
