### PR TITLE
refactor(validation): absorb asset validation into the wrapper as NDJSON × ModelSource (FND-690)

### DIFF
--- a/application_sdk/app/base.py
+++ b/application_sdk/app/base.py
@@ -29,7 +29,6 @@ from typing import (
 from uuid import UUID
 
 import obstore as obs
-import orjson
 from temporalio import activity, workflow
 from temporalio.exceptions import FailureError
 
@@ -97,15 +96,11 @@ from application_sdk.errors.leaves import InvalidInputError as _InvalidInputErro
 # the generic artifact-validation one; its value is **unchanged** by that move,
 # because shipped dashboards and alert rules key off the exact string.
 from application_sdk.observability.events import ASSET_VALIDATION_EVENT
-from application_sdk.observability.logger_adaptor import (
-    ASSET_VALIDATION_MATRIX_KEY,
-    get_logger,
-)
+from application_sdk.observability.logger_adaptor import get_logger
 from application_sdk.observability.observability import AtlanObservability
 
 if TYPE_CHECKING:
     from application_sdk.execution.progress import ProgressWatchdogMode
-    from application_sdk.validation import AssetValidationReport
 
 _task_logger = get_logger(__name__)
 
@@ -114,60 +109,18 @@ try:
 except importlib.metadata.PackageNotFoundError:  # conformance: ignore[E009] package not installed (e.g. editable dev install); "unknown" sentinel is benign
     _FRAMEWORK_VERSION = "unknown"
 
-# Cap on how many failure/orphan rows the matrix carries, aliased from the single
-# source of truth in ``constants`` so the structured matrix and the human-readable
-# ``format_report()`` listing (which defaults to the same constant) can never
-# drift. The event's scalar counts always reflect the full batch; the matrix is a
-# bounded drill-down sample so a pathological batch can't produce an unbounded
-# LogAttributes value. Passed explicitly to ``format_report(max_items=...)`` below
-# to make the shared cap obvious at the call site.
+# Cap on how many failure/orphan rows the event's drill-down matrix carries, and how
+# many the human-readable ``format_report()`` lists, from the single source of truth
+# in ``constants`` so the two can never drift. The event's scalar counts always
+# reflect the full batch; the matrix is a bounded drill-down sample so a pathological
+# batch can't produce an unbounded LogAttributes value. Passed explicitly to
+# ``format_report(max_items=...)`` below to make the shared cap obvious at the call
+# site.
+#
+# The matrix builder itself, and the whole event attribute map, moved to
+# ``validation.assets`` with the fold-in (FND-690): the event and the check that
+# feeds it now live in one module. The emitted row is unchanged by that move.
 _VALIDATION_MATRIX_MAX_ROWS = ASSET_VALIDATION_MAX_ITEMS_PER_AXIS
-
-# Per-row error message cap (chars). pyatlan_v9 ``.validate()`` messages can be
-# long; truncate so a single row can't bloat the ClickHouse attribute.
-_VALIDATION_MATRIX_ERROR_MAXLEN = 300
-
-
-def _validation_matrix_json(report: "AssetValidationReport") -> str:
-    """Compact per-failure matrix for the outcome event, as one JSON string.
-
-    Lands as a single ``LogAttributes`` value in ClickHouse so connector-pulse can
-    ``JSONExtract`` the per-failure detail against workflow outcomes with no schema
-    change (mirrors the preflight gate's ``check_matrix``). Small fixed fields
-    only, bounded to :data:`_VALIDATION_MATRIX_MAX_ROWS` rows per axis — the
-    headline counts on the event carry the full totals, and the human-readable
-    ``format_report()`` still rides in the WARNING body for flagged runs. Not
-    internally guarded (``orjson.dumps`` can raise): the sole caller,
-    :func:`_warn_on_invalid_transformed_assets`, wraps the whole emit in
-    ``try/except``, so a raise here is caught there and never blocks the upload.
-    """
-    rows: list[dict[str, Any]] = []
-    for f in report.failures[:_VALIDATION_MATRIX_MAX_ROWS]:
-        rows.append(
-            {
-                "kind": "undeserializable" if f.deserialize_error else "invalid",
-                "type_name": f.type_name,
-                "qualified_name": f.qualified_name,
-                "error": (f.errors[0] if f.errors else "")[
-                    :_VALIDATION_MATRIX_ERROR_MAXLEN
-                ],
-                "file": f.file,
-                "line": f.line,
-            }
-        )
-    for o in report.orphans[:_VALIDATION_MATRIX_MAX_ROWS]:
-        rows.append(
-            {
-                "kind": "orphan",
-                "type_name": o.missing_type_name,
-                "qualified_name": o.missing_qualified_name,
-                "relationship": o.relationship,
-                "reference_count": o.reference_count,
-                "file": o.file,
-                "line": o.line,
-            }
-        )
-    return orjson.dumps(rows).decode()
 
 
 def _resolve_transformed_target(local_path: str) -> "Path | None":
@@ -209,6 +162,24 @@ async def _warn_on_invalid_transformed_assets(local_path: str, app_name: str) ->
     the scaffold must not break a real handoff — and it scans every record (no
     sampling) so the summary is accurate.
 
+    **The check is reached through the generic wrapper** (ADR-0020, FND-690):
+    ``validate_artifact(target, ModelSource(model=Asset))`` is the NDJSON x
+    ``ModelSource`` cell, and that cell *is*
+    :func:`~application_sdk.validation.assets.validate_transformed_dir` — same walk,
+    same decode, same referential pass. What the wrapper adds is a second, generic
+    outcome vocabulary over the same findings, and a guarantee this hook used to
+    provide itself: every path through it resolves to a report rather than an
+    exception.
+
+    ``ASSET_VALIDATION_EVENT`` is emitted exactly as before. Its name and every
+    attribute key are a shipped contract — dashboards, the
+    ``asset_validation_matrix`` attribute and alert rules key off those exact
+    strings — so the row is built by
+    :func:`~application_sdk.validation.assets.asset_validation_event_fields` from the
+    asset-vocabulary report the cell carries, i.e. from the same object this hook
+    emitted from before the fold-in. This hook does **not** additionally emit
+    ``ARTIFACT_VALIDATION_EVENT``: one hand-off, one row.
+
     The scan runs via
     :func:`application_sdk._runtime.offload.run_best_effort`, for two reasons.
     It keeps the event loop and the activity's auto-heartbeat free while a large
@@ -219,7 +190,8 @@ async def _warn_on_invalid_transformed_assets(local_path: str, app_name: str) ->
     CNCT-85). ``run_best_effort`` isolates the scan in a child process, so a
     crash kills only the child; it then logs the warning and the handoff
     proceeds. The timeout bounds the scan for the same reason — a hung
-    validation must not stall an upload forever.
+    validation must not stall an upload forever. The wrapper is synchronous by
+    design precisely so this caller owns that decision.
 
     Referential (orphan) integrity runs by default on this hook: extracts and
     transforms are full by design by default, so every referenced parent is
@@ -239,16 +211,24 @@ async def _warn_on_invalid_transformed_assets(local_path: str, app_name: str) ->
     if target is None:
         return
 
+    from pyatlan_v9.model.assets import (  # noqa: PLC0415 — deferred: pyatlan_v9 stays off the import path of an app that never uploads transformed assets
+        Asset,
+    )
+
     from application_sdk.validation import (  # noqa: PLC0415 — deferred: only load the validator on the upload path
-        validate_transformed_dir,
+        AssetArtifactReport,
+        ModelSource,
+        asset_validation_event_fields,
+        validate_artifact,
     )
 
     # Best-effort: run_best_effort isolates the scan in a child process and, on
     # any native crash / timeout / error, logs a warning and returns None — the
     # upload is never blocked, failed, or crashed by the validation scaffold.
     report = await run_best_effort(
-        validate_transformed_dir,
+        validate_artifact,
         str(target),
+        ModelSource(model=Asset),
         label="Transformed-asset validation",
         logger=_task_logger,
         timeout=VALIDATE_ASSETS_TIMEOUT_SECONDS,
@@ -261,30 +241,38 @@ async def _warn_on_invalid_transformed_assets(local_path: str, app_name: str) ->
         # None means the scan itself failed — no counts to emit.
         return
 
+    if not isinstance(report, AssetArtifactReport):
+        # The wrapper resolved to an outcome without running the cell — it never
+        # raises, so a broken plug-in or an unreadable artifact arrives as a plain
+        # report instead of an exception. There are no asset-vocabulary counts to
+        # project, and inventing zeros would put a fabricated denominator on the
+        # board. The wrapper has already logged the cause with a traceback; name the
+        # skip so the gap in the event stream is explicable.
+        _task_logger.warning(
+            "Transformed-asset validation produced no counts (%s: %s); "
+            "handoff continues",
+            report.outcome,
+            report.reason or "no reason recorded",
+        )
+        return
+
     # Emit the structured outcome on every validated upload (clean + flagged) so
     # the row is queryable and gives a denominator. Wrapped: a defect in the
     # emit path (e.g. matrix encoding) must never break a real handoff.
     try:
-        flagged = not report.ok
+        assets = report.assets
+        flagged = not assets.ok
         _task_logger.info(
             ASSET_VALIDATION_EVENT,
-            outcome="flagged" if flagged else "clean",
-            app_name=app_name,
-            assets_total=report.total,
-            assets_passed=report.passed,
-            # ``failed`` counts undeserializable records too; report "invalid"
-            # (per-asset .validate() failures) disjointly, matching the headline
-            # in format_report().
-            assets_invalid=report.failed - report.undeserializable,
-            assets_orphaned=len(report.orphans),
-            assets_undeserializable=report.undeserializable,
-            **{ASSET_VALIDATION_MATRIX_KEY: _validation_matrix_json(report)},
+            **asset_validation_event_fields(
+                assets, app_name=app_name, max_items=_VALIDATION_MATRIX_MAX_ROWS
+            ),
         )
         if flagged:
             _task_logger.warning(
                 "Transformed-asset validation flagged issues before upload "
                 "(handoff continues): %s",
-                report.format_report(max_items=_VALIDATION_MATRIX_MAX_ROWS),
+                assets.format_report(max_items=_VALIDATION_MATRIX_MAX_ROWS),
             )
     except Exception:  # noqa: BLE001 — defense-in-depth must never break the upload
         _task_logger.warning(

--- a/application_sdk/validation/__init__.py
+++ b/application_sdk/validation/__init__.py
@@ -39,8 +39,12 @@ The referential-integrity pass is intentionally an SDK concern, not a pyatlan on
 it is a cross-record check that a single asset's ``.validate()`` cannot make.
 
 ADR-0020 folds asset validation into the wrapper as its NDJSON x ``ModelSource``
-cell, preserving its event name and attribute keys verbatim — a refactor behind a
-stable event surface, not a rename.
+cell, and FND-690 did it: ``NdjsonValidator`` dispatches a model declaration to
+:func:`validate_assets_as_artifact`, which is :func:`validate_transformed_dir`
+reported in the shared shape. The scan, its process isolation and its outcome event
+are unchanged — the event's name and every attribute key are preserved verbatim,
+because dashboards and alert rules key off those exact strings and v3 has shipped
+consumers. A refactor behind a stable event surface, not a rename.
 
 **Standing dependency floor for this whole package**: no ``pyarrow``, ``pandas`` or
 ``pandera`` import anywhere in it. A JSON-only caller must never pay for a parquet
@@ -66,10 +70,15 @@ from application_sdk.validation.artifacts import (
     artifact_validation_matrix_json,
 )
 from application_sdk.validation.assets import (
+    AssetArtifactReport,
     AssetValidationFailure,
     AssetValidationReport,
     ReferentialFailure,
+    asset_validation_event_fields,
+    asset_validation_matrix_json,
+    supports_asset_model,
     validate_asset,
+    validate_assets_as_artifact,
     validate_transformed_dir,
 )
 from application_sdk.validation.ndjson import NdjsonValidator, iter_ndjson_lines
@@ -115,10 +124,15 @@ __all__ = [
     "declared_artifact_fields",
     "iter_ndjson_lines",
     "validate_artifact",
-    # Asset validation (BLDX-1555)
+    # Asset validation (BLDX-1555) — the NDJSON x ModelSource cell (FND-690)
+    "AssetArtifactReport",
     "AssetValidationFailure",
     "AssetValidationReport",
     "ReferentialFailure",
+    "asset_validation_event_fields",
+    "asset_validation_matrix_json",
+    "supports_asset_model",
     "validate_asset",
+    "validate_assets_as_artifact",
     "validate_transformed_dir",
 ]

--- a/application_sdk/validation/assets.py
+++ b/application_sdk/validation/assets.py
@@ -4,6 +4,14 @@ See :mod:`application_sdk.validation` for the why. This module holds the typed
 result models, the single-asset check, and the transformed-output directory
 walk (per-asset validation + referential-integrity second pass).
 
+Since FND-690 it is also **the artifact wrapper's NDJSON x ``ModelSource`` cell** —
+same walk, reached through :func:`~application_sdk.validation.wrapper.validate_artifact`
+and reported in the shared :class:`~application_sdk.validation.artifacts.ArtifactValidationReport`
+shape by :func:`validate_assets_as_artifact`. Nothing above that fold-in line changed:
+the fold-in is a projection over the findings this walk already produced, plus the
+shipped ``ASSET_VALIDATION_EVENT`` attribute map moved here from ``app.base`` so the
+event and the check that feeds it live together.
+
 Design constraints worth preserving if you edit this file:
 
 * **Decode through ``from_atlas_json``, not ``<ConcreteType>.from_json``.**
@@ -43,16 +51,26 @@ import functools
 import typing
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Iterator
+from typing import Final, Iterator
 
 import msgspec
+import orjson
 from pyatlan_v9.model.assets import Asset
 from pyatlan_v9.model.assets.referenceable import RelatedReferenceable
 from pyatlan_v9.model.transform import from_atlas_json
 
 from application_sdk.common.spillable_dict import SpillableDict
 from application_sdk.constants import ASSET_VALIDATION_MAX_ITEMS_PER_AXIS
-from application_sdk.observability.logger_adaptor import get_logger
+from application_sdk.observability.logger_adaptor import (
+    ASSET_VALIDATION_MATRIX_KEY,
+    get_logger,
+)
+from application_sdk.validation.artifacts import (
+    OUTCOME_ABSENT,
+    ArtifactValidationFailure,
+    ArtifactValidationReport,
+    ModelDeclaration,
+)
 from application_sdk.validation.ndjson import iter_ndjson_lines
 
 logger = get_logger(__name__)
@@ -495,3 +513,300 @@ def validate_transformed_dir(
             present.close()
 
     return report
+
+
+# ---------------------------------------------------------------------------
+# The wrapper cell: NDJSON x ModelSource (ADR-0020, FND-690)
+# ---------------------------------------------------------------------------
+#
+# Everything above predates the wrapper and is unchanged. Everything below is the
+# same check reached through the generic seam: ``validate_transformed_dir`` *is* the
+# NDJSON x ``ModelSource`` cell, so this is a projection, not a second scan. One
+# walk, one set of findings, two report vocabularies over it.
+#
+# Why two vocabularies rather than one: the shared ``ArtifactValidationReport``
+# speaks in units, declared fields and failure kinds, while ``ASSET_VALIDATION_EVENT``
+# shipped speaking in assets, orphans and undeserializable records. That event's
+# name and every attribute key are a contract — dashboards and alert rules key off
+# the exact strings and v3 has shipped consumers — so the asset vocabulary is kept
+# verbatim and carried *alongside* the shared shape rather than translated into it.
+
+
+def supports_asset_model(model: object) -> bool:
+    """True when ``model`` is a class this cell can decode NDJSON records into.
+
+    The cell delegates to ``pyatlan_v9``'s per-asset ``.validate()`` and decodes
+    through ``from_atlas_json``, both specific to the asset model — so an arbitrary
+    class exposing a callable ``validate`` is **not** something this cell can check,
+    however well-shaped it looks to
+    :class:`~application_sdk.validation.sources.ModelSource`.
+
+    Answering ``False`` there is what turns "we cannot check this" into a reported
+    ``unsupported`` outcome naming the cell. The alternative is worse in a specific
+    way: decoding every record with the wrong decoder would report a whole artifact
+    as ``undecodable``, which reads as a data defect and blames the app for the
+    SDK's inability to delegate.
+    """
+    return isinstance(model, type) and issubclass(model, Asset)
+
+
+@dataclass
+class AssetArtifactReport(ArtifactValidationReport):
+    """The NDJSON x ``ModelSource`` cell's report: the shared shape plus asset detail.
+
+    An :class:`~application_sdk.validation.artifacts.ArtifactValidationReport`, so
+    the wrapper stamps it and every generic consumer reads it unchanged — with the
+    scan's own :class:`AssetValidationReport` carried on :attr:`assets` for the two
+    surfaces that speak the asset vocabulary: the shipped ``ASSET_VALIDATION_EVENT``
+    attribute map and its human-readable ``format_report()`` body.
+
+    The detail is *carried*, not re-derived, which is what makes the event
+    byte-identical across the fold-in by construction:
+    :func:`asset_validation_event_fields` is handed the very object the pre-wrapper
+    hook emitted from.
+
+    The shared counts and :attr:`assets` are populated together in
+    :func:`validate_assets_as_artifact`, off one walk — they cannot disagree.
+    """
+
+    assets: AssetValidationReport = field(default_factory=AssetValidationReport)
+    """The scan's findings in the asset vocabulary (per-asset failures + orphans)."""
+
+
+def _as_record_failure(failure: AssetValidationFailure) -> ArtifactValidationFailure:
+    """Project one per-asset finding onto the shared failure shape.
+
+    ``deserialize_error`` becomes ``undecodable`` and everything else becomes
+    ``invalid`` — the same split the matrix makes, so the shared report's derived
+    ``undecodable`` count *equals* ``AssetValidationReport.undeserializable`` rather
+    than approximating it.
+
+    ``field`` stays "" and the messages are carried verbatim. The shared vocabulary
+    addresses a unit positionally (``file:line``) and has no room for an asset's
+    ``(typeName, qualifiedName)``; rewriting the model's own ``.validate()``
+    messages to smuggle it in would make the two surfaces disagree about what the
+    model said. The identity is on :attr:`AssetArtifactReport.assets` instead.
+    """
+    return ArtifactValidationFailure(
+        kind="undecodable" if failure.deserialize_error else "invalid",
+        file=failure.file,
+        line=failure.line,
+        errors=list(failure.errors),
+    )
+
+
+def _as_reference_failure(orphan: ReferentialFailure) -> ArtifactValidationFailure:
+    """Project one orphan onto the shared failure shape.
+
+    ``missing`` is the shared vocabulary's word for it, and ``field`` carries the
+    relationship attribute the reference came through — a relationship *is* a field
+    of the referencing record, so this is the same "which field" question the
+    field-map cell answers, asked of a reference.
+
+    An orphan does not move ``passed``: a record can be perfectly valid on its own
+    terms and still point at a parent nobody emitted, which is exactly why the
+    referential pass is a second axis. So this lands in ``failures`` (a problem
+    count) without changing ``failed`` (a unit count) — the divergence the shared
+    report already documents.
+    """
+    return ArtifactValidationFailure(
+        kind="missing",
+        field=orphan.relationship,
+        file=orphan.file,
+        line=orphan.line,
+        errors=[
+            f"[{orphan.missing_type_name}] {orphan.missing_qualified_name} is "
+            f"referenced through '{orphan.relationship}' by "
+            f"{orphan.reference_count} asset(s) in this batch but is not itself "
+            f"present"
+        ],
+    )
+
+
+def validate_assets_as_artifact(
+    path: str | Path,
+    declaration: ModelDeclaration | None = None,
+    *,
+    for_creation: bool = True,
+    check_referential_integrity: bool = True,
+) -> AssetArtifactReport:
+    """The NDJSON x ``ModelSource`` cell: :func:`validate_transformed_dir`, reported
+    in the shared shape.
+
+    Reached through :func:`~application_sdk.validation.wrapper.validate_artifact`
+    with a :class:`~application_sdk.validation.sources.ModelSource`; the
+    :class:`~application_sdk.validation.ndjson.NdjsonValidator` dispatches a model
+    declaration here. Callable directly too, which is how the projection is tested
+    without standing up the wrapper.
+
+    Args:
+        path: A transformed-output directory (e.g. ``.../transformed``) or file.
+        declaration: The resolved model declaration. Accepted for the
+            :class:`~application_sdk.validation.protocols.FormatValidator` shape and
+            for the model check; ``None`` skips that check, for a direct caller with
+            no declaration to hand.
+        for_creation: Passed through to each asset's ``.validate()``.
+        check_referential_integrity: Run the referential (orphan) second pass.
+            Defaults on, as the upload hook has always run it: extracts and
+            transforms are full by design, so the batch is complete and the pass is
+            accurate.
+
+    Returns:
+        An :class:`AssetArtifactReport`. ``absent`` when the scan found no records at
+        all — the same answer the field-map arm gives, because "zero records checked"
+        reported as ``clean`` is the exact failure this capability exists to remove.
+        :func:`asset_validation_event_fields` still projects that to ``clean`` on the
+        legacy event, whose outcome vocabulary shipped as clean/flagged only.
+    """
+    if declaration is not None and not supports_asset_model(declaration.model):
+        # Unreachable through the wrapper, which honours ``supports``. Guarded for
+        # the direct caller: decoding with the wrong decoder would report the whole
+        # artifact as a data defect.
+        name = getattr(declaration.model, "__name__", type(declaration.model).__name__)
+        return AssetArtifactReport(
+            verdict=OUTCOME_ABSENT,
+            reason=(
+                f"the ndjson x model cell delegates to pyatlan_v9 assets; "
+                f"{name} is not one"
+            ),
+        )
+
+    assets = validate_transformed_dir(
+        path,
+        for_creation=for_creation,
+        check_referential_integrity=check_referential_integrity,
+    )
+
+    if assets.total == 0:
+        return AssetArtifactReport(
+            verdict=OUTCOME_ABSENT,
+            reason=f"no ndjson records found at {path}",
+            assets=assets,
+        )
+
+    return AssetArtifactReport(
+        total=assets.total,
+        passed=assets.passed,
+        failures=(
+            [_as_record_failure(f) for f in assets.failures]
+            + [_as_reference_failure(o) for o in assets.orphans]
+        ),
+        assets=assets,
+    )
+
+
+# ---------------------------------------------------------------------------
+# The shipped ASSET_VALIDATION_EVENT projection
+# ---------------------------------------------------------------------------
+#
+# Moved here verbatim from ``app.base`` by FND-690, so the event and the check that
+# feeds it live in one module. **Nothing about the emitted row changed in that
+# move** — same event name, same attribute keys, same row keys and key order inside
+# the matrix, same caps. ``tests/unit/validation/test_asset_event.py`` pins all of
+# it against a golden payload precisely so a later refactor cannot quietly reword a
+# string a dashboard matches on.
+
+ASSET_VALIDATION_MATRIX_ERROR_MAXLEN: Final = 300
+"""Per-row error message cap (chars). pyatlan_v9 ``.validate()`` messages can be
+long; truncate so a single row cannot bloat the ClickHouse attribute."""
+
+
+def asset_validation_matrix_json(
+    report: AssetValidationReport,
+    *,
+    max_items: int = ASSET_VALIDATION_MAX_ITEMS_PER_AXIS,
+) -> str:
+    """Compact per-failure matrix for the outcome event, as one JSON string.
+
+    Lands as a single ``LogAttributes`` value in ClickHouse so connector-pulse can
+    ``JSONExtract`` the per-failure detail against workflow outcomes with no schema
+    change (mirrors the preflight gate's ``check_matrix``). Small fixed fields only,
+    bounded to ``max_items`` rows **per axis** — the headline counts on the event
+    carry the full totals, and the human-readable ``format_report()`` still rides in
+    the WARNING body for flagged runs.
+
+    Not internally guarded (``orjson.dumps`` can raise): the emitting hook wraps the
+    whole emit in ``try/except``, so a raise here is caught there and never blocks
+    the handoff.
+    """
+    rows: list[dict[str, object]] = []
+    for f in report.failures[:max_items]:
+        rows.append(
+            {
+                "kind": "undeserializable" if f.deserialize_error else "invalid",
+                "type_name": f.type_name,
+                "qualified_name": f.qualified_name,
+                "error": (f.errors[0] if f.errors else "")[
+                    :ASSET_VALIDATION_MATRIX_ERROR_MAXLEN
+                ],
+                "file": f.file,
+                "line": f.line,
+            }
+        )
+    for o in report.orphans[:max_items]:
+        rows.append(
+            {
+                "kind": "orphan",
+                "type_name": o.missing_type_name,
+                "qualified_name": o.missing_qualified_name,
+                "relationship": o.relationship,
+                "reference_count": o.reference_count,
+                "file": o.file,
+                "line": o.line,
+            }
+        )
+    return orjson.dumps(rows).decode()
+
+
+def asset_validation_event_fields(
+    report: AssetValidationReport,
+    *,
+    app_name: str,
+    max_items: int = ASSET_VALIDATION_MAX_ITEMS_PER_AXIS,
+) -> dict[str, str | int]:
+    """Build ``ASSET_VALIDATION_EVENT``'s attribute map from an asset report.
+
+    The single mapping site from report to telemetry, so the emitter cannot drift
+    from the allowlist — every key returned here is in
+    ``logger_adaptor._KNOWN_EXTRA_KEYS``, and a key absent from that allowlist is
+    dropped by ``_build_extra_dict`` and silently never reaches OTLP.
+
+    **Every string here is a shipped contract.** The keys, the two ``outcome``
+    values and the matrix's own row keys are matched verbatim by dashboards and
+    alert rules, so this map is pinned against a golden payload in
+    ``tests/unit/validation/test_asset_event.py`` rather than merely exercised.
+
+    Two details are load-bearing and deliberately preserved from the pre-wrapper
+    emitter:
+
+    * ``assets_invalid`` is reported **disjointly** from
+      ``assets_undeserializable``. ``AssetValidationReport.failed`` counts the
+      undeserializable records too, so they are subtracted out — matching the
+      headline in ``format_report()``.
+    * ``outcome`` is ``clean``/``flagged`` and nothing else. The shared artifact
+      report has five outcomes, but this event shipped with two, and widening the
+      vocabulary of a field dashboards group by is a breaking change dressed as an
+      improvement. A scan that found nothing to read reports ``clean`` here and
+      ``absent`` on the shared report.
+
+    Args:
+        report: The scan's findings in the asset vocabulary — i.e.
+            :attr:`AssetArtifactReport.assets`.
+        app_name: Emitting app, carried as the already-allowlisted ``app_name``.
+        max_items: Row cap per axis for the matrix; shared with ``format_report``.
+
+    Returns:
+        Keyword arguments for the ``ASSET_VALIDATION_EVENT`` log call.
+    """
+    return {
+        "outcome": "clean" if report.ok else "flagged",
+        "app_name": app_name,
+        "assets_total": report.total,
+        "assets_passed": report.passed,
+        "assets_invalid": report.failed - report.undeserializable,
+        "assets_orphaned": len(report.orphans),
+        "assets_undeserializable": report.undeserializable,
+        ASSET_VALIDATION_MATRIX_KEY: asset_validation_matrix_json(
+            report, max_items=max_items
+        ),
+    }

--- a/application_sdk/validation/ndjson.py
+++ b/application_sdk/validation/ndjson.py
@@ -31,13 +31,20 @@ now imports it, because it was already format-generic — it yields
 blanks. A second walk would be a second set of decisions about blank lines, file
 ordering and directory recursion to keep in sync.
 
-**Which cell this is.** NDJSON x ``ContractSource`` — a per-record declared-key
-presence and JSON type check. The NDJSON x ``ModelSource`` cell (per-record decode
-plus the model's own ``.validate()``) is
-:func:`~application_sdk.validation.assets.validate_transformed_dir` today and is
-folded into this validator by FND-690; until then :meth:`NdjsonValidator.supports`
-answers ``False`` for a model declaration and the wrapper reports ``unsupported``,
-which is the honest interim state rather than silence.
+**Which cells this is.** Both NDJSON cells, because the wrapper dispatches on
+*format*: it picks the validator claiming ``ndjson`` and then asks it which kinds of
+declaration it can check, so a second ndjson-claiming validator would never be
+reached. :meth:`NdjsonValidator.validate` splits them.
+
+* NDJSON x ``ContractSource`` — a per-record declared-key presence and JSON type
+  check, the code in this module.
+* NDJSON x ``ModelSource`` — per-record decode plus the model's own ``.validate()``,
+  which is :func:`~application_sdk.validation.assets.validate_transformed_dir`. It
+  predates the wrapper and FND-690 folded it in behind this seam rather than
+  reimplementing it, so the check, its isolation posture and its shipped outcome
+  event are all unchanged — only the way it is reached is new. The delegation is a
+  deferred import: that module pulls ``pyatlan_v9``, which must stay off the import
+  path of a caller that only ever diffs a field map.
 """
 
 from __future__ import annotations
@@ -60,6 +67,7 @@ from application_sdk.validation.artifacts import (
     ArtifactValidationReport,
     DeclaredField,
     FieldMapDeclaration,
+    ModelDeclaration,
 )
 
 logger = get_logger(__name__)
@@ -400,28 +408,52 @@ class NdjsonValidator:
         return UNIT_RECORD
 
     def supports(self, declaration: ArtifactDeclaration) -> bool:
-        """True for a field-map declaration.
+        """True for a field-map declaration, and for a delegatable model.
 
-        A model declaration answers ``False`` **for now**: the NDJSON x
-        ``ModelSource`` cell is real and implemented — it is
-        :func:`~application_sdk.validation.assets.validate_transformed_dir` — but it
-        has not been folded in behind this seam yet (FND-690). Until it is, the
-        wrapper reports ``unsupported`` naming the cell, which is the honest interim
-        state; the alternative is a validator quietly returning ``clean`` for an
-        artifact it never looked at.
+        Both NDJSON cells live behind this one validator, because dispatch is by
+        *format*: the wrapper picks the validator whose ``artifact_format`` matches
+        and then asks it which kinds of declaration it can check. A second
+        ndjson-claiming validator would never be reached.
+
+        A model declaration answers True only when the model is one this cell can
+        actually decode into — see
+        :func:`~application_sdk.validation.assets.supports_asset_model`. A model that
+        merely *looks* delegatable to
+        :class:`~application_sdk.validation.sources.ModelSource` (any class with a
+        callable ``validate``) gets a reported ``unsupported``, not a scan that
+        reports every record as undecodable.
         """
-        return isinstance(declaration, FieldMapDeclaration)
+        if isinstance(declaration, FieldMapDeclaration):
+            return True
+        if isinstance(declaration, ModelDeclaration):
+            from application_sdk.validation.assets import (  # noqa: PLC0415 — deferred on purpose: assets.py imports pyatlan_v9, and a module-level import here would put it on the import path of every field-map caller (and would be circular — assets.py imports this module's walk)
+                supports_asset_model,
+            )
+
+            return supports_asset_model(declaration.model)
+        return False
 
     def validate(
         self, path: Path, declaration: ArtifactDeclaration
     ) -> ArtifactValidationReport:
         """Scan every record under ``path`` against ``declaration``.
 
+        Dispatches on which kind of declaration it was handed — the two NDJSON cells
+        are the same walk asking a different question of each record, so they share a
+        validator and split here:
+
+        * a field map is **diffed** — declared key presence plus JSON type, below;
+        * a model is **delegated to** — decode the record into the model and let it
+          validate itself, in
+          :func:`~application_sdk.validation.assets.validate_assets_as_artifact`.
+
         Args:
             path: A single NDJSON file, or a directory of ``*.json`` parts.
-            declaration: The field map to check against. Called only after
-                :meth:`supports` said yes, so this is a
-                :class:`~application_sdk.validation.artifacts.FieldMapDeclaration`.
+            declaration: What to check against. Called only after :meth:`supports`
+                said yes, so this is a
+                :class:`~application_sdk.validation.artifacts.FieldMapDeclaration` or
+                a delegatable
+                :class:`~application_sdk.validation.artifacts.ModelDeclaration`.
 
         Returns:
             A report whose scalar counts describe the whole artifact. ``absent``
@@ -430,14 +462,21 @@ class NdjsonValidator:
             this capability was built to remove: zero records checked, and a pass
             on the board.
         """
+        if isinstance(declaration, ModelDeclaration):
+            from application_sdk.validation.assets import (  # noqa: PLC0415 — deferred for the same two reasons as in supports(): pyatlan_v9 stays off the field-map path, and a module-level import would be circular
+                validate_assets_as_artifact,
+            )
+
+            return validate_assets_as_artifact(path, declaration)
+
         if not isinstance(declaration, FieldMapDeclaration):
             # Unreachable via the wrapper, which honours ``supports``. Guarded
             # anyway: an app may call a validator directly, and reading ``.fields``
-            # off a model declaration would raise into that caller.
+            # off something that is neither declaration would raise into that caller.
             return ArtifactValidationReport.absent(
                 reason=(
                     f"the ndjson validator was handed a "
-                    f"{type(declaration).__name__}, not a field map"
+                    f"{type(declaration).__name__}, not a field map or a model"
                 ),
             )
 

--- a/application_sdk/validation/ndjson.py
+++ b/application_sdk/validation/ndjson.py
@@ -43,8 +43,12 @@ reached. :meth:`NdjsonValidator.validate` splits them.
   predates the wrapper and FND-690 folded it in behind this seam rather than
   reimplementing it, so the check, its isolation posture and its shipped outcome
   event are all unchanged — only the way it is reached is new. The delegation is a
-  deferred import: that module pulls ``pyatlan_v9``, which must stay off the import
-  path of a caller that only ever diffs a field map.
+  **deferred import, and only circularity requires it**: ``assets.py`` imports
+  :func:`iter_ndjson_lines` from this module at module scope, so a module-level
+  import back would cycle (measured: ``ImportError``, partially initialized
+  module). It buys no dependency-floor benefit — this package's ``__init__``
+  imports ``assets`` at module scope, so ``pyatlan_v9`` is already loaded by the
+  time anything can import this module.
 """
 
 from __future__ import annotations
@@ -426,7 +430,7 @@ class NdjsonValidator:
         if isinstance(declaration, FieldMapDeclaration):
             return True
         if isinstance(declaration, ModelDeclaration):
-            from application_sdk.validation.assets import (  # noqa: PLC0415 — deferred on purpose: assets.py imports pyatlan_v9, and a module-level import here would put it on the import path of every field-map caller (and would be circular — assets.py imports this module's walk)
+            from application_sdk.validation.assets import (  # noqa: PLC0415 — deferred because a module-level import would cycle: assets.py imports this module's iter_ndjson_lines at module scope
                 supports_asset_model,
             )
 
@@ -463,7 +467,7 @@ class NdjsonValidator:
             on the board.
         """
         if isinstance(declaration, ModelDeclaration):
-            from application_sdk.validation.assets import (  # noqa: PLC0415 — deferred for the same two reasons as in supports(): pyatlan_v9 stays off the field-map path, and a module-level import would be circular
+            from application_sdk.validation.assets import (  # noqa: PLC0415 — deferred for the same reason as in supports(): a module-level import would cycle
                 validate_assets_as_artifact,
             )
 

--- a/application_sdk/validation/wrapper.py
+++ b/application_sdk/validation/wrapper.py
@@ -64,10 +64,13 @@ def builtin_format_validators() -> tuple[FormatValidator, ...]:
     caller — exactly the cost coupling the two-seam design exists to prevent
     (``tests/unit/validation/test_artifact_dependency_floor.py`` enforces it).
 
-    NDJSON ships (FND-688); parquet lands in FND-689. Until it does, a declared
-    parquet artifact resolves to ``unsupported`` naming the format that had no
-    validator — which is the honest report, and is visible in the outcome events
-    rather than looking like a pass.
+    NDJSON ships (FND-688), covering **both** its cells — the field-map diff and the
+    model delegation folded in from the asset validator (FND-690) — because dispatch
+    is by format, so one validator claims ``ndjson`` and decides per declaration
+    kind. Parquet lands in FND-689; until it does, a declared parquet artifact
+    resolves to ``unsupported`` naming the format that had no validator — which is
+    the honest report, and is visible in the outcome events rather than looking like
+    a pass.
     """
     from application_sdk.validation.ndjson import (  # noqa: PLC0415 — deferred on purpose: FND-689's parquet validator imports pyarrow, an extra, and a module-level import here would put it on every JSON-only caller's path
         NdjsonValidator,

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -1,8 +1,8 @@
 <!--
 generated-by:  capability-manifest skill (.claude/skills/capability-manifest)
 sdk-version:   3.28.3
-source-sha:    d9608448f11e6d6f4b39f4ae1f8b4061d751090e
-source-date:   2026-08-25T03:31:37+01:00
+source-sha:    bd903916a890bec12323cc3a618d58f59fe86843
+source-date:   2026-08-25T09:53:37Z
 do-not-edit:   re-run the skill instead of hand-editing
 -->
 
@@ -35,7 +35,7 @@ do-not-edit:   re-run the skill instead of hand-editing
 | `application_sdk.storage` | Object-store abstraction — factory, formats, batch, transfer, cloud bindings | 42 |
 | `application_sdk.templates` | SQL metadata extractor templates and their contracts | 6 |
 | `application_sdk.testing` | Test infrastructure — mocks, fixtures, hypothesis strategies, integration helpers | 97 |
-| `application_sdk.validation` | Offline artifact & asset validation — format-agnostic wrapper (ADR-0020) plus pyatlan_v9 .validate() wrappers, no network call | 45 |
+| `application_sdk.validation` | Offline artifact & asset validation — format-agnostic wrapper (ADR-0020) plus pyatlan_v9 .validate() wrappers, no network call | 50 |
 
 ## Subpackage Details
 
@@ -3789,6 +3789,13 @@ Offline artifact & asset validation — format-agnostic wrapper (ADR-0020) plus 
 - **Summary:** Aggregate outcome of validating one artifact against one declaration.
 - **Defined in:** `application_sdk/validation/artifacts.py`
 
+#### `AssetArtifactReport`
+
+- **Import:** `from application_sdk.validation import AssetArtifactReport`
+- **Signature:** `class AssetArtifactReport(artifact_format: str = '', ...)`
+- **Summary:** The NDJSON x ``ModelSource`` cell's report: the shared shape plus asset detail.
+- **Defined in:** `application_sdk/validation/assets.py`
+
 #### `AssetValidationFailure`
 
 - **Import:** `from application_sdk.validation import AssetValidationFailure`
@@ -3900,6 +3907,20 @@ Offline artifact & asset validation — format-agnostic wrapper (ADR-0020) plus 
 - **Summary:** Compact per-failure drill-down for the outcome event, as one JSON string.
 - **Defined in:** `application_sdk/validation/artifacts.py`
 
+#### `asset_validation_event_fields`
+
+- **Import:** `from application_sdk.validation import asset_validation_event_fields`
+- **Signature:** `asset_validation_event_fields(report: AssetValidationReport, *, ...)`
+- **Summary:** Build ``ASSET_VALIDATION_EVENT``'s attribute map from an asset report.
+- **Defined in:** `application_sdk/validation/assets.py`
+
+#### `asset_validation_matrix_json`
+
+- **Import:** `from application_sdk.validation import asset_validation_matrix_json`
+- **Signature:** `asset_validation_matrix_json(report: AssetValidationReport, *, max_items: int = ASSET_VALIDATION_MAX_ITEMS_PER_AXIS)`
+- **Summary:** Compact per-failure matrix for the outcome event, as one JSON string.
+- **Defined in:** `application_sdk/validation/assets.py`
+
 #### `builtin_format_validators`
 
 - **Import:** `from application_sdk.validation import builtin_format_validators`
@@ -3924,6 +3945,13 @@ Offline artifact & asset validation — format-agnostic wrapper (ADR-0020) plus 
 - **Summary:** Yield ``(file, 1-based line number, raw bytes)`` for every non-blank line.
 - **Defined in:** `application_sdk/validation/ndjson.py`
 
+#### `supports_asset_model`
+
+- **Import:** `from application_sdk.validation import supports_asset_model`
+- **Signature:** `supports_asset_model(model: object)`
+- **Summary:** True when ``model`` is a class this cell can decode NDJSON records into.
+- **Defined in:** `application_sdk/validation/assets.py`
+
 #### `validate_artifact`
 
 - **Import:** `from application_sdk.validation import validate_artifact`
@@ -3937,6 +3965,13 @@ Offline artifact & asset validation — format-agnostic wrapper (ADR-0020) plus 
 - **Import:** `from application_sdk.validation import validate_asset`
 - **Signature:** `validate_asset(asset: Asset, *, for_creation: bool = True)`
 - **Summary:** Run pyatlan_v9's ``.validate()`` and return its error messages.
+- **Defined in:** `application_sdk/validation/assets.py`
+
+#### `validate_assets_as_artifact`
+
+- **Import:** `from application_sdk.validation import validate_assets_as_artifact`
+- **Signature:** `validate_assets_as_artifact(path: str | Path, *, ...)`
+- **Summary:** The NDJSON x ``ModelSource`` cell: :func:`validate_transformed_dir`, reported
 - **Defined in:** `application_sdk/validation/assets.py`
 
 #### `validate_transformed_dir`

--- a/docs/concepts/apps.md
+++ b/docs/concepts/apps.md
@@ -528,6 +528,14 @@ or when the path is not a `transformed/` subtree (e.g. a raw upload), no outcome
 See [Monitoring](monitoring.md#asset-validation-outcome-event) for the attribute list as it reaches
 OTLP.
 
+> **One check, reached through the wrapper.** This check *is* the generic artifact wrapper's
+> NDJSON × `ModelSource` cell ([ADR-0020](../adr/0020-artifact-validation.md)) — the hook calls
+> `validate_artifact(target, ModelSource(model=Asset))`, and the model the declaration delegates to is
+> pyatlan_v9's `Asset`. Nothing about the check, its process isolation or its event changed in that
+> move: the event name and every attribute key above are a shipped contract that dashboards and alert
+> rules match verbatim. One hand-off emits one row, so this hook does **not** also emit the generic
+> `"Artifact validation outcome"`.
+
 > **On by default (CNCT-85).** The scan runs in an isolated child process
 > (process-isolation fix [#2769](https://github.com/atlanhq/application-sdk/pull/2769)), so a native
 > fault in the decode path is contained and downgraded to a best-effort skip rather than killing the

--- a/docs/concepts/monitoring.md
+++ b/docs/concepts/monitoring.md
@@ -426,6 +426,13 @@ Emitting `outcome="clean"` too gives a denominator, so a dashboard can rank conn
 flag-rate rather than only seeing failures. Uploads with nothing to validate (validation disabled, or
 a non-`transformed/` path) emit no event.
 
+Since [ADR-0020](../adr/0020-artifact-validation.md) this check is the artifact wrapper's
+NDJSON × `ModelSource` cell, reached as `validate_artifact(target, ModelSource(model=Asset))`. **The
+event above is unchanged by that** — name, keys, `outcome` vocabulary and matrix row keys are all a
+shipped contract, and the fold-in was a refactor behind it. One hand-off emits one row, so this
+upload does not additionally emit `"Artifact validation outcome"`; the two events are two
+vocabularies, not two checks.
+
 ### Artifact-validation outcome event
 
 The generic artifact-validation wrapper ([ADR-0020](../adr/0020-artifact-validation.md)) emits
@@ -436,10 +443,12 @@ schema source declared it.
 
     The attribute contract below ships ahead of its emitter. The wrapper's report, matrix and event
     fields exist, both schema sources (`ContractSource`, `ModelSource`) are callable, and
-    `validate_artifact(...)` really does check an NDJSON artifact against a contract declaration —
-    but a parquet declaration still resolves to `unsupported`, and nothing calls the wrapper
-    automatically until the `FileReference` interceptor wiring lands. The table is the reference for
-    what the allowlist admits, not a description of rows you will find in ClickHouse today.
+    `validate_artifact(...)` really does check an NDJSON artifact — against a contract declaration,
+    and against a model declaration via the asset cell the upload hook calls. But a parquet
+    declaration still resolves to `unsupported`, and nothing calls the wrapper automatically until
+    the `FileReference` interceptor wiring lands. The only rows in ClickHouse today are the asset
+    hook's, and those carry the *asset* event's attributes, not these. The table is the reference for
+    what the allowlist admits, not a description of rows you will find there.
 
 | Attribute | Meaning |
 |-----------|---------|

--- a/tests/unit/app/test_upload_asset_validation.py
+++ b/tests/unit/app/test_upload_asset_validation.py
@@ -9,13 +9,20 @@ The scan function is pickled by reference into a spawn child, so test doubles
 for it must be module-level functions in this file — mocks and closures cannot
 cross the process boundary.
 
+Since FND-690 the check is reached through the generic artifact wrapper —
+``validate_artifact(target, ModelSource(model=Asset))``, the NDJSON x ``ModelSource``
+cell — so that is what the offloaded scan doubles below patch. The cell *is*
+``validate_transformed_dir``, so every assertion here is about the same walk it
+always was.
+
 On every *validated* upload the helper emits a structured
 ``ASSET_VALIDATION_EVENT`` (INFO) carrying per-axis counts and a compact
 ``asset_validation_matrix`` JSON attribute — allowlisted so it reaches OTLP /
-ClickHouse. The human-readable WARNING (full ``format_report()``) is additionally
-logged only when the batch is flagged. Uploads with nothing to validate (flag
-off / not a ``transformed/`` subtree) — and scans that crash/time out — emit
-neither.
+ClickHouse. Its name and every attribute key are a shipped contract, pinned
+byte-for-byte in ``tests/unit/validation/test_asset_event.py``. The human-readable
+WARNING (full ``format_report()``) is additionally logged only when the batch is
+flagged. Uploads with nothing to validate (flag off / not a ``transformed/``
+subtree) — and scans that crash/time out — emit neither.
 """
 
 from __future__ import annotations
@@ -43,7 +50,6 @@ _HAS_ROCKSDICT = importlib.util.find_spec("rocksdict") is not None
 APP = "test-app"
 CONN = "default/snow/123"
 SCHEMA_QN = f"{CONN}/DB/SCHEMA"
-TABLE_QN = f"{SCHEMA_QN}/T1"
 
 
 def _write_transformed(base: Path, entity: str, assets: list) -> None:
@@ -58,19 +64,26 @@ def _write_transformed(base: Path, entity: str, assets: list) -> None:
 # Module-level scan doubles: run_best_effort pickles the scan function by
 # reference into a spawn child, so a failing double must be an importable
 # module-level function (a MagicMock cannot cross the process boundary).
-def _raise_runtime_error(path, **kwargs):
+def _raise_runtime_error(path, source, **kwargs):
     raise RuntimeError("boom")
 
 
-def _segfault(path, **kwargs):
+def _segfault(path, source, **kwargs):
     # Not ctypes.string_at(0): on Windows ctypes converts the access violation
     # to OSError instead of dying. faulthandler's test hook faults for real on
     # every platform.
     faulthandler._sigsegv()
 
 
-def _hang(path, **kwargs):
+def _hang(path, source, **kwargs):
     time.sleep(3600)
+
+
+def _absent_report(path, source, **kwargs):
+    # What the wrapper returns when a plug-in seam breaks: a report, never a raise.
+    from application_sdk.validation import ArtifactValidationReport
+
+    return ArtifactValidationReport.absent(reason="validator raised: RuntimeError")
 
 
 def _invalid_table() -> Table:
@@ -280,7 +293,7 @@ class TestWarnOnInvalidTransformedAssets:
         _valid_hierarchy(tmp_path)
         with patch.object(base_module, "_task_logger") as logger:
             with patch(
-                "application_sdk.validation.validate_transformed_dir",
+                "application_sdk.validation.validate_artifact",
                 _raise_runtime_error,
             ):
                 # Must not propagate the RuntimeError (raised in the child,
@@ -292,21 +305,40 @@ class TestWarnOnInvalidTransformedAssets:
 
     async def test_emit_failure_is_swallowed(self, tmp_path: Path) -> None:
         # A defect in the emit path (e.g. matrix encoding) must never break the
-        # upload: it is caught and downgraded to a warning, no raise.
+        # upload: it is caught and downgraded to a warning, no raise. The hook
+        # resolves the projection lazily at call time, so patching it on the
+        # validation package is what the hook actually looks up.
         _valid_hierarchy(tmp_path)
         with patch.object(base_module, "_task_logger") as logger:
-            with patch.object(
-                base_module,
-                "_validation_matrix_json",
+            with patch(
+                "application_sdk.validation.asset_validation_event_fields",
                 side_effect=RuntimeError("encode boom"),
             ):
                 await _warn_on_invalid_transformed_assets(str(tmp_path), APP)
             logger.warning.assert_called_once()
             assert logger.warning.call_args.kwargs.get("exc_info") is True
-            # The matrix is built as an eager arg to _task_logger.info(...), so a
-            # raise there is hit before .info() is called — no partial outcome
+            # The attribute map is built as an eager arg to _task_logger.info(...),
+            # so a raise there is hit before .info() is called — no partial outcome
             # event is emitted (mirrors test_unexpected_scan_error_is_swallowed).
             logger.info.assert_not_called()
+
+    async def test_a_wrapper_outcome_without_counts_emits_no_event(
+        self, tmp_path: Path
+    ) -> None:
+        # The wrapper never raises, so a validator that blows up arrives as a plain
+        # `absent` report rather than as an exception — and a plain report carries no
+        # asset-vocabulary counts. Emitting zeros there would put a fabricated
+        # denominator on the board, so the hook names the skip and emits nothing.
+        _valid_hierarchy(tmp_path)
+        with patch.object(base_module, "_task_logger") as logger:
+            with patch(
+                "application_sdk.validation.validate_artifact",
+                _absent_report,
+            ):
+                await _warn_on_invalid_transformed_assets(str(tmp_path), APP)
+            logger.info.assert_not_called()
+            logger.warning.assert_called_once()
+            assert "produced no counts" in logger.warning.call_args.args[0]
 
     async def test_native_crash_warns_and_continues(self, tmp_path: Path) -> None:
         # CNCT-85: a segfault in the decode path (e.g. a native msgspec bug) is
@@ -315,9 +347,7 @@ class TestWarnOnInvalidTransformedAssets:
         # produced no report, so no outcome event is emitted.
         _valid_hierarchy(tmp_path)
         with patch.object(base_module, "_task_logger") as logger:
-            with patch(
-                "application_sdk.validation.validate_transformed_dir", _segfault
-            ):
+            with patch("application_sdk.validation.validate_artifact", _segfault):
                 await _warn_on_invalid_transformed_assets(str(tmp_path), APP)
             logger.warning.assert_called_once()
             assert "subprocess died" in logger.warning.call_args.args[0]
@@ -331,7 +361,7 @@ class TestWarnOnInvalidTransformedAssets:
         _valid_hierarchy(tmp_path)
         with patch.object(base_module, "_task_logger") as logger:
             with (
-                patch("application_sdk.validation.validate_transformed_dir", _hang),
+                patch("application_sdk.validation.validate_artifact", _hang),
                 patch("application_sdk.constants.VALIDATE_ASSETS_TIMEOUT_SECONDS", 1.0),
             ):
                 await _warn_on_invalid_transformed_assets(str(tmp_path), APP)
@@ -355,7 +385,7 @@ class TestWarnOnInvalidTransformedAssets:
             _valid_hierarchy(base)
         with patch.object(base_module, "_task_logger") as logger:
             with (
-                patch("application_sdk.validation.validate_transformed_dir", _hang),
+                patch("application_sdk.validation.validate_artifact", _hang),
                 patch("application_sdk.constants.VALIDATE_ASSETS_TIMEOUT_SECONDS", 1.0),
             ):
                 results = await asyncio.gather(
@@ -423,114 +453,3 @@ class TestWarnOnInvalidTransformedAssets:
         with patch.object(base_module, "_task_logger") as logger_after:
             await _warn_on_invalid_transformed_assets(str(dirs[0]), APP)
             logger_after.warning.assert_not_called()
-
-
-def _failure(i: int, *, deserialize_error: bool = False, error: str | None = None):
-    from application_sdk.validation.assets import AssetValidationFailure
-
-    return AssetValidationFailure(
-        file="entities.json",
-        line=i,
-        type_name="Table",
-        qualified_name=f"{TABLE_QN}_{i}",
-        errors=[error if error is not None else f"bad {i}"],
-        deserialize_error=deserialize_error,
-    )
-
-
-def _orphan(i: int):
-    from application_sdk.validation.assets import ReferentialFailure
-
-    return ReferentialFailure(
-        missing_type_name="Table",
-        missing_qualified_name=f"{SCHEMA_QN}/T_MISSING_{i}",
-        reference_count=1,
-        file="entities.json",
-        line=i,
-        type_name="Column",
-        qualified_name=f"{SCHEMA_QN}/T_MISSING_{i}/C1",
-        relationship="table",
-    )
-
-
-def test_matrix_is_bounded_to_max_rows_per_axis() -> None:
-    """The matrix caps at ``_VALIDATION_MATRIX_MAX_ROWS`` rows *per axis*, so a
-    pathological batch cannot produce an unbounded LogAttributes value. The report
-    still carries the true totals — only the drill-down sample is bounded."""
-    from application_sdk.validation.assets import AssetValidationReport
-
-    cap = base_module._VALIDATION_MATRIX_MAX_ROWS
-    n = cap + 5
-    report = AssetValidationReport(
-        total=2 * n,
-        passed=0,
-        failures=[_failure(i) for i in range(n)],
-        orphans=[_orphan(i) for i in range(n)],
-    )
-
-    matrix = json.loads(base_module._validation_matrix_json(report))
-    invalid_rows = [r for r in matrix if r["kind"] == "invalid"]
-    orphan_rows = [r for r in matrix if r["kind"] == "orphan"]
-    assert len(invalid_rows) == cap
-    assert len(orphan_rows) == cap
-    assert len(matrix) == 2 * cap
-    # Scalar totals are unbounded (full batch), only the matrix is sampled.
-    assert report.failed == n
-    assert len(report.orphans) == n
-
-
-def test_matrix_marks_undeserializable_rows() -> None:
-    """A failure carrying ``deserialize_error=True`` must surface in the matrix as
-    ``kind="undeserializable"`` (the branch the emitter splits on), never
-    ``"invalid"`` — so a dashboard can tell decode failures from per-asset
-    ``.validate()`` failures. The scalar tests only assert the ``0`` count, so
-    without this the matrix branch is unexercised."""
-    from application_sdk.validation.assets import AssetValidationReport
-
-    report = AssetValidationReport(
-        total=1,
-        passed=0,
-        failures=[_failure(0, deserialize_error=True)],
-        orphans=[],
-    )
-
-    matrix = json.loads(base_module._validation_matrix_json(report))
-    assert [r["kind"] for r in matrix] == ["undeserializable"]
-
-
-def test_matrix_truncates_long_error_to_maxlen() -> None:
-    """Per-row error text is clipped to ``_VALIDATION_MATRIX_ERROR_MAXLEN`` so a
-    single pathological ``.validate()`` message cannot bloat the ClickHouse
-    attribute. Pin the length so a future refactor of the slice can't silently
-    drop the guard."""
-    from application_sdk.validation.assets import AssetValidationReport
-
-    maxlen = base_module._VALIDATION_MATRIX_ERROR_MAXLEN
-    report = AssetValidationReport(
-        total=1,
-        passed=0,
-        failures=[_failure(0, error="x" * (maxlen + 50))],
-        orphans=[],
-    )
-
-    matrix = json.loads(base_module._validation_matrix_json(report))
-    assert len(matrix[0]["error"]) == maxlen
-
-
-def test_asset_validation_outcome_keys_in_allowlist() -> None:
-    """The PR's core promise — the structured outcome attributes reach OTLP /
-    ClickHouse — holds only while these keys stay allowlisted. Pin the six new
-    validation-outcome keys the emitter relies on (mirrors the storage-op and
-    file_ref allowlist guards in tests/unit/observability/test_logger_adaptor.py)."""
-    from application_sdk.observability.logger_adaptor import _KNOWN_EXTRA_KEYS
-
-    required = {
-        ASSET_VALIDATION_MATRIX_KEY,
-        "assets_total",
-        "assets_passed",
-        "assets_invalid",
-        "assets_orphaned",
-        "assets_undeserializable",
-    }
-    missing = required - _KNOWN_EXTRA_KEYS
-    assert not missing, f"_KNOWN_EXTRA_KEYS missing validation keys: {missing}"

--- a/tests/unit/validation/test_asset_cell.py
+++ b/tests/unit/validation/test_asset_cell.py
@@ -7,8 +7,11 @@ rather than behaviours — the behaviour of the walk itself is ``test_assets.py`
 subject and is deliberately not re-asserted.
 
 * The wrapper path and the direct path produce an **identical event payload** for the
-  same input. That is the acceptance criterion "byte-identical event output, before
-  vs after" made executable: the direct path is the pre-fold-in path.
+  same input, which proves the wrapper *carries* the scan's own report rather than
+  re-deriving one. Note what this does and does not pin: both sides call the same
+  post-refactor projection, so it is wrapper == direct, not before == after. The
+  before/after guarantee is the frozen literal in ``test_asset_event.py`` — that is
+  where a reworded key or a changed value fails.
 * The shared report's derived counts agree with the asset report's own, so a generic
   consumer and a dashboard cannot disagree about the same batch.
 * Every outcome resolves through the wrapper — including the negatives — because a
@@ -95,13 +98,19 @@ def _through_the_wrapper(path: Path) -> AssetArtifactReport:
 
 
 @pytest.mark.parametrize("flawed", [False, True], ids=["clean", "flagged"])
-def test_the_wrapper_path_emits_the_identical_event_payload(
-    tmp_path: Path, flawed: bool
-) -> None:
-    """The acceptance criterion, executable: the direct path *is* the pre-fold-in
-    path, so an identical payload for the same input is what "byte-identical event
-    output, before vs after" means. Run over both outcomes, because the clean row is
-    the denominator and is emitted just as unconditionally as the flagged one."""
+def test_the_wrapper_path_matches_the_direct_path(tmp_path: Path, flawed: bool) -> None:
+    """Reaching the scan through the wrapper changes nothing about what is emitted.
+
+    This is the invariant that makes ``AssetArtifactReport`` carrying ``.assets``
+    worth the subclass: the wrapper hands the projection the scan's own report, so
+    the two call paths cannot drift. Run over both outcomes, because the clean row is
+    the denominator and is emitted just as unconditionally as the flagged one.
+
+    **What this does not prove.** Both sides call the same post-refactor
+    :func:`asset_validation_event_fields`, so a rename applied consistently would
+    keep them equal. Before-vs-after is pinned separately, by the frozen literal in
+    ``test_asset_event.py`` — the two tests are complements, not duplicates.
+    """
     _valid_hierarchy(tmp_path)
     if flawed:
         _write(tmp_path, "Extra", [_invalid_table()])

--- a/tests/unit/validation/test_asset_cell.py
+++ b/tests/unit/validation/test_asset_cell.py
@@ -1,0 +1,273 @@
+"""The NDJSON x ``ModelSource`` cell: asset validation reached through the wrapper.
+
+FND-690 folded ``validate_transformed_dir`` into the artifact wrapper. The claim
+being tested is narrow and specific: **the same walk, reached a new way, reporting
+the same findings in two vocabularies.** So the tests here are mostly equivalences
+rather than behaviours — the behaviour of the walk itself is ``test_assets.py``'s
+subject and is deliberately not re-asserted.
+
+* The wrapper path and the direct path produce an **identical event payload** for the
+  same input. That is the acceptance criterion "byte-identical event output, before
+  vs after" made executable: the direct path is the pre-fold-in path.
+* The shared report's derived counts agree with the asset report's own, so a generic
+  consumer and a dashboard cannot disagree about the same batch.
+* Every outcome resolves through the wrapper — including the negatives — because a
+  check that reports nothing is indistinguishable from a check that passed.
+
+Fixtures are real pyatlan_v9 assets serialized with ``to_nested_bytes()``, the wire
+shape connectors actually write, so the decode path is the production one.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+from pyatlan_v9.model.assets import Asset, Column, Database, Schema, Table
+
+from application_sdk.validation import (
+    FORMAT_NDJSON,
+    FORMAT_PARQUET,
+    AssetArtifactReport,
+    ModelSource,
+    asset_validation_event_fields,
+    validate_artifact,
+    validate_assets_as_artifact,
+    validate_transformed_dir,
+)
+from application_sdk.validation.artifacts import (
+    OUTCOME_ABSENT,
+    OUTCOME_CLEAN,
+    OUTCOME_FLAGGED,
+    OUTCOME_UNSUPPORTED,
+    UNIT_RECORD,
+    ModelDeclaration,
+)
+
+_HAS_ROCKSDICT = importlib.util.find_spec("rocksdict") is not None
+requires_rocksdict = pytest.mark.skipif(
+    not _HAS_ROCKSDICT,
+    reason="referential-integrity pass needs rocksdict (the [storage] extra)",
+)
+
+APP = "test-app"
+CONN = "default/snow/123"
+DB_QN = f"{CONN}/DB"
+SCHEMA_QN = f"{CONN}/DB/SCHEMA"
+TABLE_QN = f"{SCHEMA_QN}/T1"
+
+
+def _write(base: Path, entity: str, assets: list) -> None:
+    out_dir = base / "transformed" / entity
+    out_dir.mkdir(parents=True, exist_ok=True)
+    with open(out_dir / "entities.json", "wb") as handle:
+        for asset in assets:
+            handle.write(asset.to_nested_bytes())
+            handle.write(b"\n")
+
+
+def _valid_hierarchy(base: Path) -> None:
+    _write(
+        base, "Database", [Database.creator(name="DB", connection_qualified_name=CONN)]
+    )
+    _write(
+        base, "Schema", [Schema.creator(name="SCHEMA", database_qualified_name=DB_QN)]
+    )
+    _write(base, "Table", [Table.creator(name="T1", schema_qualified_name=SCHEMA_QN)])
+
+
+def _invalid_table() -> Table:
+    table = Table.creator(name="T1", schema_qualified_name=SCHEMA_QN)
+    table.qualified_name = None
+    return table
+
+
+def _through_the_wrapper(path: Path) -> AssetArtifactReport:
+    report = validate_artifact(path, ModelSource(model=Asset))
+    assert isinstance(report, AssetArtifactReport), report
+    return report
+
+
+# ---------------------------------------------------------------------------
+# The equivalence that makes this a refactor
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("flawed", [False, True], ids=["clean", "flagged"])
+def test_the_wrapper_path_emits_the_identical_event_payload(
+    tmp_path: Path, flawed: bool
+) -> None:
+    """The acceptance criterion, executable: the direct path *is* the pre-fold-in
+    path, so an identical payload for the same input is what "byte-identical event
+    output, before vs after" means. Run over both outcomes, because the clean row is
+    the denominator and is emitted just as unconditionally as the flagged one."""
+    _valid_hierarchy(tmp_path)
+    if flawed:
+        _write(tmp_path, "Extra", [_invalid_table()])
+
+    before = asset_validation_event_fields(
+        validate_transformed_dir(tmp_path / "transformed"), app_name=APP
+    )
+    after = asset_validation_event_fields(
+        _through_the_wrapper(tmp_path / "transformed").assets, app_name=APP
+    )
+
+    assert after == before
+    assert after["outcome"] == ("flagged" if flawed else "clean")
+
+
+def test_the_shared_counts_agree_with_the_asset_counts(tmp_path: Path) -> None:
+    """One walk populates both vocabularies, so they cannot disagree about a batch.
+
+    ``undecodable`` is the load-bearing one: the shared report *derives* it from the
+    failure list rather than tracking it, so this pins that the projection's
+    ``invalid``/``undecodable`` split lands on the same records the asset report
+    counted as undeserializable.
+    """
+    _valid_hierarchy(tmp_path)
+    _write(tmp_path, "Extra", [_invalid_table()])
+
+    report = _through_the_wrapper(tmp_path / "transformed")
+
+    assert report.total == report.assets.total == 4
+    assert report.passed == report.assets.passed == 3
+    assert report.undecodable == report.assets.undeserializable == 0
+    # ``failed`` is a unit count: invalid + undecodable, and never the orphans.
+    assert report.failed == 1
+
+
+def test_an_undeserializable_record_lands_as_undecodable(tmp_path: Path) -> None:
+    """The shared vocabulary's word for it, on the same records."""
+    out_dir = tmp_path / "transformed" / "Junk"
+    out_dir.mkdir(parents=True)
+    (out_dir / "entities.json").write_bytes(b'{"not":"an asset"\n')
+
+    report = _through_the_wrapper(tmp_path / "transformed")
+
+    assert report.assets.undeserializable == 1
+    assert report.undecodable == 1
+    assert [f.kind for f in report.failures] == ["undecodable"]
+
+
+@requires_rocksdict
+def test_an_orphan_lands_as_a_missing_reference(tmp_path: Path) -> None:
+    """An orphan is a ``missing`` failure naming the relationship it came through —
+    and it does **not** move ``passed``. A record can be valid on its own terms and
+    still point at a parent nobody emitted, which is why the referential pass is a
+    second axis rather than a per-record verdict."""
+    _valid_hierarchy(tmp_path)
+    _write(
+        tmp_path,
+        "Column",
+        [
+            Column.creator(
+                name="C1",
+                parent_type=Table,
+                parent_qualified_name=f"{SCHEMA_QN}/T_MISSING",
+                order=1,
+            )
+        ],
+    )
+
+    report = _through_the_wrapper(tmp_path / "transformed")
+
+    assert report.outcome == OUTCOME_FLAGGED
+    assert report.total == report.passed == 4
+    # Every unit passed its own check; the batch is still flagged.
+    assert report.failed == 0
+    orphans = [f for f in report.failures if f.kind == "missing"]
+    assert len(orphans) == 1
+    assert orphans[0].field == "table"
+    assert "T_MISSING" in orphans[0].errors[0]
+
+
+# ---------------------------------------------------------------------------
+# Every path resolves to an outcome
+# ---------------------------------------------------------------------------
+
+
+def test_a_valid_batch_is_clean_and_names_its_cell(tmp_path: Path) -> None:
+    """The wrapper stamps the cell, not the validator — so a dashboard reading the
+    generic event knows which (format x source) produced the row."""
+    _valid_hierarchy(tmp_path)
+
+    report = _through_the_wrapper(tmp_path / "transformed")
+
+    assert report.outcome == OUTCOME_CLEAN
+    assert report.artifact_format == FORMAT_NDJSON
+    assert report.schema_source == "model"
+    assert report.unit == UNIT_RECORD
+    # A model declares no enumerable field list at this layer.
+    assert report.fields_declared == 0
+
+
+def test_an_empty_batch_is_absent_not_clean(tmp_path: Path) -> None:
+    """Zero records checked reported as ``clean`` is the exact failure this
+    capability exists to remove. The legacy event still says ``clean``, because its
+    outcome vocabulary shipped two-valued — both surfaces are honest, in their own
+    vocabulary."""
+    (tmp_path / "transformed").mkdir()
+
+    report = _through_the_wrapper(tmp_path / "transformed")
+
+    assert report.outcome == OUTCOME_ABSENT
+    assert "no ndjson records" in report.reason
+    assert asset_validation_event_fields(report.assets, app_name=APP)["outcome"] == (
+        "clean"
+    )
+
+
+def test_parquet_times_model_is_still_unsupported(tmp_path: Path) -> None:
+    """Folding in the NDJSON cell does not quietly claim the parquet one. A model
+    carries no column mapping, so a footer diff has nothing to diff against."""
+    report = validate_artifact(
+        tmp_path, ModelSource(model=Asset, artifact_format=FORMAT_PARQUET)
+    )
+
+    assert report.outcome == OUTCOME_UNSUPPORTED
+    assert not isinstance(report, AssetArtifactReport)
+
+
+def test_an_undelegatable_model_is_unsupported(tmp_path: Path) -> None:
+    """``ModelSource`` accepts any class with a callable ``validate``; this cell
+    decodes through pyatlan_v9, so anything else is reported ``unsupported`` rather
+    than scanned with the wrong decoder."""
+
+    class _Whatever:
+        def validate(self) -> None: ...
+
+    report = validate_artifact(tmp_path, ModelSource(model=_Whatever))
+
+    assert report.outcome == OUTCOME_UNSUPPORTED
+
+
+def test_a_direct_caller_with_an_undelegatable_model_gets_a_report(
+    tmp_path: Path,
+) -> None:
+    """Unreachable through the wrapper, which honours ``supports`` — guarded for the
+    app that calls the cell itself, where a wrong-decoder scan would report a whole
+    artifact as a data defect."""
+    report = validate_assets_as_artifact(tmp_path, ModelDeclaration(model=dict))
+
+    assert report.outcome == OUTCOME_ABSENT
+    assert "delegates to pyatlan_v9 assets" in report.reason
+    assert report.assets.total == 0
+
+
+def test_the_referential_pass_can_be_turned_off_by_a_direct_caller(
+    tmp_path: Path,
+) -> None:
+    """The wrapper path always runs it — extracts and transforms are full by design,
+    so the batch is complete — but the knob survives for a caller validating a
+    deliberately partial batch."""
+    _write(
+        tmp_path, "Table", [Table.creator(name="T1", schema_qualified_name=SCHEMA_QN)]
+    )
+
+    report = validate_assets_as_artifact(
+        tmp_path / "transformed", check_referential_integrity=False
+    )
+
+    assert report.outcome == OUTCOME_CLEAN
+    assert report.assets.orphans == []

--- a/tests/unit/validation/test_asset_event.py
+++ b/tests/unit/validation/test_asset_event.py
@@ -1,0 +1,254 @@
+"""The shipped ``ASSET_VALIDATION_EVENT`` surface, pinned (FND-690).
+
+FND-690 folded asset validation into the artifact wrapper as its NDJSON x
+``ModelSource`` cell. That is a refactor behind a **stable event surface**: the
+event's name and every one of its attribute keys are matched verbatim by dashboards,
+the ``asset_validation_matrix`` drill-down and alert rules, and v3 has shipped
+consumers of all of it.
+
+So this file does not merely exercise the projection — it pins it, in the two ways
+that catch the two ways it can break:
+
+* **A golden payload.** The full attribute map for a known batch is compared against
+  a literal, so a reworded key, a dropped key, a renamed matrix row key or a changed
+  ``outcome`` value fails loudly rather than silently emptying a panel.
+* **The allowlist.** Every key the projection emits must be in
+  ``logger_adaptor._KNOWN_EXTRA_KEYS``, or ``_build_extra_dict`` drops it and the
+  attribute never reaches OTLP at all. A test that asserted only the returned dict
+  would pass while the row arrived empty in ClickHouse.
+
+The cell's own behaviour — that it is the same walk, reported in the shared shape —
+is in ``test_assets.py`` (the walk) and ``test_ndjson_validator.py`` (the dispatch).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from application_sdk.constants import ASSET_VALIDATION_MAX_ITEMS_PER_AXIS
+from application_sdk.observability.events import ASSET_VALIDATION_EVENT
+from application_sdk.observability.logger_adaptor import (
+    _KNOWN_EXTRA_KEYS,
+    ASSET_VALIDATION_MATRIX_KEY,
+)
+from application_sdk.validation.assets import (
+    ASSET_VALIDATION_MATRIX_ERROR_MAXLEN,
+    AssetValidationFailure,
+    AssetValidationReport,
+    ReferentialFailure,
+    asset_validation_event_fields,
+    asset_validation_matrix_json,
+)
+
+APP = "test-app"
+CONN = "default/snow/123"
+SCHEMA_QN = f"{CONN}/DB/SCHEMA"
+TABLE_QN = f"{SCHEMA_QN}/T1"
+
+
+def _failure(
+    i: int, *, deserialize_error: bool = False, error: str | None = None
+) -> AssetValidationFailure:
+    return AssetValidationFailure(
+        file="entities.json",
+        line=i,
+        type_name="Table",
+        qualified_name=f"{TABLE_QN}_{i}",
+        errors=[error if error is not None else f"bad {i}"],
+        deserialize_error=deserialize_error,
+    )
+
+
+def _orphan(i: int) -> ReferentialFailure:
+    return ReferentialFailure(
+        missing_type_name="Table",
+        missing_qualified_name=f"{SCHEMA_QN}/T_MISSING_{i}",
+        reference_count=1,
+        file="entities.json",
+        line=i,
+        type_name="Column",
+        qualified_name=f"{SCHEMA_QN}/T_MISSING_{i}/C1",
+        relationship="table",
+    )
+
+
+# ---------------------------------------------------------------------------
+# The event surface, pinned
+# ---------------------------------------------------------------------------
+
+
+def test_the_event_name_is_unchanged() -> None:
+    """The log message body *is* the event name, and it is matched verbatim.
+
+    Pinned as a literal rather than compared to the constant: comparing a constant
+    to itself would pass through any rename, which is the whole failure this guards.
+    """
+    assert ASSET_VALIDATION_EVENT == "Transformed-asset validation outcome"
+
+
+def test_the_full_attribute_map_is_byte_identical_for_a_known_batch() -> None:
+    """The golden payload: every key, every value, and the matrix as an exact string.
+
+    One invalid record, one undeserializable record, one orphan, over a batch of
+    four. The literal below is what the pre-wrapper emitter produced for this input,
+    so a diff here is a change to a shipped surface.
+    """
+    report = AssetValidationReport(
+        total=4,
+        passed=2,
+        undeserializable=1,
+        failures=[
+            _failure(3, error="qualified_name is required"),
+            _failure(4, deserialize_error=True, error="could not deserialize"),
+        ],
+        orphans=[_orphan(2)],
+    )
+
+    fields = asset_validation_event_fields(report, app_name=APP)
+
+    assert fields == {
+        "outcome": "flagged",
+        "app_name": "test-app",
+        "assets_total": 4,
+        "assets_passed": 2,
+        "assets_invalid": 1,
+        "assets_orphaned": 1,
+        "assets_undeserializable": 1,
+        "asset_validation_matrix": (
+            '[{"kind":"invalid","type_name":"Table",'
+            '"qualified_name":"default/snow/123/DB/SCHEMA/T1_3",'
+            '"error":"qualified_name is required","file":"entities.json","line":3},'
+            '{"kind":"undeserializable","type_name":"Table",'
+            '"qualified_name":"default/snow/123/DB/SCHEMA/T1_4",'
+            '"error":"could not deserialize","file":"entities.json","line":4},'
+            '{"kind":"orphan","type_name":"Table",'
+            '"qualified_name":"default/snow/123/DB/SCHEMA/T_MISSING_2",'
+            '"relationship":"table","reference_count":1,'
+            '"file":"entities.json","line":2}]'
+        ),
+    }
+
+
+def test_a_clean_batch_emits_a_denominator_with_an_empty_matrix() -> None:
+    """The clean row exists so flag-rate has a denominator, and the matrix is
+    always present — ``"[]"`` rather than absent, so consumers never branch on it."""
+    fields = asset_validation_event_fields(
+        AssetValidationReport(total=3, passed=3), app_name=APP
+    )
+
+    assert fields["outcome"] == "clean"
+    assert fields[ASSET_VALIDATION_MATRIX_KEY] == "[]"
+
+
+def test_the_outcome_vocabulary_stays_two_valued() -> None:
+    """This event shipped with ``clean``/``flagged`` and nothing else.
+
+    The shared artifact report has five outcomes, and a scan with nothing to read is
+    ``absent`` there — but widening the vocabulary of a field dashboards group by is
+    a breaking change dressed as an improvement, so a zero-record batch reports
+    ``clean`` here.
+    """
+    empty = asset_validation_event_fields(AssetValidationReport(), app_name=APP)
+
+    assert empty["outcome"] == "clean"
+
+
+def test_every_emitted_key_is_allowlisted_for_otlp() -> None:
+    """The projection's core promise — these attributes reach ClickHouse — holds only
+    while every key stays in ``_KNOWN_EXTRA_KEYS``. A key absent from it is dropped
+    by ``_build_extra_dict`` and silently never reaches the exporter, so asserting
+    the returned dict alone would pass while the row arrived empty."""
+    emitted = set(asset_validation_event_fields(AssetValidationReport(), app_name=APP))
+
+    assert not emitted - _KNOWN_EXTRA_KEYS
+
+
+def test_invalid_and_undeserializable_are_reported_disjointly() -> None:
+    """``AssetValidationReport.failed`` counts undeserializable records too, so the
+    event subtracts them out — matching the headline in ``format_report()``. Without
+    this, a batch of pure decode failures would be double-counted as invalid assets
+    as well."""
+    report = AssetValidationReport(
+        total=2,
+        passed=0,
+        undeserializable=2,
+        failures=[_failure(i, deserialize_error=True) for i in range(2)],
+    )
+
+    fields = asset_validation_event_fields(report, app_name=APP)
+
+    assert fields["assets_invalid"] == 0
+    assert fields["assets_undeserializable"] == 2
+
+
+# ---------------------------------------------------------------------------
+# The bounded drill-down matrix
+# ---------------------------------------------------------------------------
+
+
+def test_matrix_is_bounded_to_max_rows_per_axis() -> None:
+    """The matrix caps at the shared constant **per axis**, so a pathological batch
+    cannot produce an unbounded LogAttributes value. The report still carries the
+    true totals — only the drill-down sample is bounded."""
+    cap = ASSET_VALIDATION_MAX_ITEMS_PER_AXIS
+    n = cap + 5
+    report = AssetValidationReport(
+        total=2 * n,
+        passed=0,
+        failures=[_failure(i) for i in range(n)],
+        orphans=[_orphan(i) for i in range(n)],
+    )
+
+    matrix = json.loads(asset_validation_matrix_json(report))
+
+    assert len([r for r in matrix if r["kind"] == "invalid"]) == cap
+    assert len([r for r in matrix if r["kind"] == "orphan"]) == cap
+    assert len(matrix) == 2 * cap
+    # Scalar totals are unbounded (full batch), only the matrix is sampled.
+    assert report.failed == n
+    assert len(report.orphans) == n
+
+
+def test_matrix_marks_undeserializable_rows() -> None:
+    """A failure carrying ``deserialize_error=True`` surfaces as
+    ``kind="undeserializable"``, never ``"invalid"`` — so a dashboard can tell decode
+    failures from per-asset ``.validate()`` failures."""
+    report = AssetValidationReport(
+        total=1, passed=0, failures=[_failure(0, deserialize_error=True)]
+    )
+
+    matrix = json.loads(asset_validation_matrix_json(report))
+
+    assert [r["kind"] for r in matrix] == ["undeserializable"]
+
+
+def test_matrix_truncates_long_error_to_maxlen() -> None:
+    """Per-row error text is clipped so a single pathological ``.validate()`` message
+    cannot bloat the ClickHouse attribute. Pin the length so a future refactor of the
+    slice can't silently drop the guard."""
+    maxlen = ASSET_VALIDATION_MATRIX_ERROR_MAXLEN
+    report = AssetValidationReport(
+        total=1, passed=0, failures=[_failure(0, error="x" * (maxlen + 50))]
+    )
+
+    matrix = json.loads(asset_validation_matrix_json(report))
+
+    assert len(matrix[0]["error"]) == maxlen
+
+
+@pytest.mark.parametrize("max_items", [0, 1, 3])
+def test_the_matrix_cap_is_honoured_per_axis(max_items: int) -> None:
+    """``max_items`` is passed through by the event projection, so the human report
+    and the telemetry can be held to the same cap at one call site."""
+    report = AssetValidationReport(
+        total=10,
+        passed=0,
+        failures=[_failure(i) for i in range(5)],
+        orphans=[_orphan(i) for i in range(5)],
+    )
+
+    fields = asset_validation_event_fields(report, app_name=APP, max_items=max_items)
+
+    assert len(json.loads(fields[ASSET_VALIDATION_MATRIX_KEY])) == 2 * max_items

--- a/tests/unit/validation/test_asset_event.py
+++ b/tests/unit/validation/test_asset_event.py
@@ -92,8 +92,13 @@ def test_the_full_attribute_map_is_byte_identical_for_a_known_batch() -> None:
     """The golden payload: every key, every value, and the matrix as an exact string.
 
     One invalid record, one undeserializable record, one orphan, over a batch of
-    four. The literal below is what the pre-wrapper emitter produced for this input,
-    so a diff here is a change to a shipped surface.
+    four. The literal below is frozen from what the **pre-wrapper** emitter produced
+    for this input, so a diff here is a change to a shipped surface.
+
+    This is the before-vs-after anchor for the whole fold-in. Its sibling in
+    ``test_asset_cell.py`` pins that the wrapper path equals the direct path, which
+    is a different property: that comparison runs both sides through this same
+    projection, so only a frozen literal can catch the projection itself changing.
     """
     report = AssetValidationReport(
         total=4,

--- a/tests/unit/validation/test_ndjson_validator.py
+++ b/tests/unit/validation/test_ndjson_validator.py
@@ -102,23 +102,46 @@ def test_it_ships_as_a_builtin() -> None:
     assert builtin_format_validators() == (NdjsonValidator(),)
 
 
-def test_a_model_declaration_is_unsupported_not_silently_clean() -> None:
-    """NDJSON x ModelSource is real but not folded in yet (FND-690).
+def test_a_delegatable_model_declaration_is_claimed() -> None:
+    """Both NDJSON cells live behind this one validator (FND-690).
 
-    The failure mode being excluded is a validator that returns ``clean`` for an
-    artifact it never looked at. ``unsupported`` is the honest interim answer.
+    Dispatch is by *format*, so a second ndjson-claiming validator would never be
+    reached; the model cell is claimed here and split inside ``validate``.
+    """
+    from pyatlan_v9.model.assets import Asset
+
+    assert NdjsonValidator().supports(ModelDeclaration(model=Asset)) is True
+
+
+def test_an_undelegatable_model_is_unsupported_not_silently_clean() -> None:
+    """The failure mode excluded is a validator that returns ``clean`` — or a whole
+    artifact reported ``undecodable`` — for a model it cannot actually decode into.
+
+    ``ModelSource`` accepts any class exposing a callable ``validate``; this cell
+    decodes through pyatlan_v9's ``from_atlas_json``, so anything else gets a
+    reported ``unsupported`` naming the cell.
     """
     assert NdjsonValidator().supports(ModelDeclaration(model=dict)) is False
 
 
-def test_a_model_declaration_handed_here_directly_does_not_raise(
+def test_an_undelegatable_model_handed_here_directly_does_not_raise(
     tmp_path: Path,
 ) -> None:
     """The wrapper honours ``supports``; an app calling the validator may not."""
-    report = _validate(tmp_path, ModelDeclaration(model=dict))  # type: ignore[arg-type]
+    report = _validate(tmp_path, ModelDeclaration(model=dict))
 
     assert report.outcome == OUTCOME_ABSENT
-    assert "not a field map" in report.reason
+    assert "delegates to pyatlan_v9 assets" in report.reason
+
+
+def test_a_non_declaration_handed_here_directly_does_not_raise(
+    tmp_path: Path,
+) -> None:
+    """Neither a field map nor a model: still a report, never a raise."""
+    report = _validate(tmp_path, object())  # type: ignore[arg-type]
+
+    assert report.outcome == OUTCOME_ABSENT
+    assert "not a field map or a model" in report.reason
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Step 5 of the [ADR-0020](docs/adr/0020-artifact-validation.md) sequence, closing [FND-690](https://linear.app/atlan-epd/issue/FND-690/absorb-asset-validation-into-the-wrapper-as-ndjson-modelsource).

`validate_transformed_dir` becomes the artifact wrapper's **NDJSON × `ModelSource`** cell, and `App.upload()`'s hook is re-pointed at `validate_artifact(target, ModelSource(model=Asset))`. One report shape, one event, one registry entry — instead of two hooks doing the same job at the same seam.

**The check itself is untouched**: same walk, same `from_atlas_json` decode, same referential pass, same `run_best_effort` child-process isolation (CNCT-85). Only the way it is reached is new.

## The design call

Dispatch in the wrapper is by *format*, so a second ndjson-claiming validator would never be reached. `NdjsonValidator.supports` therefore claims both declaration kinds and `validate` splits: a field map is **diffed**, a model is **delegated to** `validate_assets_as_artifact`. The delegation is a deferred import in both methods, and **circularity is the only reason** — `assets.py` imports `iter_ndjson_lines` from `ndjson.py` at module scope, so importing back at module scope raises `ImportError` on a partially initialized module (measured). It buys no dependency-floor benefit: this package's `__init__` imports `assets` at module scope, so `pyatlan_v9` is already loaded before anything can import `ndjson`. An earlier revision of this PR claimed otherwise in two `noqa` comments and the module docstring; corrected.

**The event's vocabulary is carried, not translated.** `AssetValidationReport` speaks in assets, orphans and undeserializable records; `ArtifactValidationReport` speaks in units, declared fields and failure kinds. Translating one into the other would have forced either several asset-specific fields onto the shared failure dataclass or a dict escape hatch. Instead `AssetArtifactReport` subclasses `ArtifactValidationReport` and carries the scan's own report on `.assets`, so `asset_validation_event_fields` is handed *the very object the pre-wrapper hook emitted from*.

That is what makes `ASSET_VALIDATION_EVENT` byte-identical **by construction** rather than by careful re-derivation. Its name and every attribute key are a shipped contract that dashboards, the `asset_validation_matrix` attribute and alert rules match verbatim, and v3 has shipped consumers.

## Two deliberate divergences between the surfaces

Both documented at the code, not just here.

* **A zero-record batch is `absent` on the shared report and `clean` on the legacy event.** `absent` is the honest generic answer and is exactly what the field-map arm already returns — "zero records checked, reported as a pass" is the failure this capability exists to remove. But that event shipped with a two-valued `outcome`, and widening the vocabulary of a field dashboards group by is a breaking change dressed as an improvement.
* **An orphan lands as `kind="missing"` with `field=<relationship>` and does not move `passed`.** A record can be valid on its own terms and still point at a parent nobody emitted, which is why the referential pass is a second axis: it adds to `failures` (a problem count) without changing `failed` (a unit count).

## An undelegatable model is `unsupported`, not scanned

`ModelSource` accepts any class exposing a callable `validate`; this cell decodes through `pyatlan_v9`. Scanning with the wrong decoder would report a whole artifact as `undecodable` — which reads as a data defect and blames the app for the SDK's inability to delegate. `supports_asset_model` gates it.

## Moves

The matrix builder and the whole event attribute map move from `app/base.py` (−75 lines) to `validation/assets.py` as `asset_validation_matrix_json` / `asset_validation_event_fields`, so the event and the check that feeds it live in one module. `_VALIDATION_MATRIX_ERROR_MAXLEN` goes with them as `ASSET_VALIDATION_MATRIX_ERROR_MAXLEN`.

The upload hook does **not** additionally emit `ARTIFACT_VALIDATION_EVENT`: one hand-off, one row.

## Acceptance

| Criterion | Where |
|---|---|
| Event name + full attribute-key set pinned against current values | `tests/unit/validation/test_asset_event.py` |
| Byte-identical event output for a known input, before vs after | `test_asset_event.py::test_the_full_attribute_map_is_byte_identical_for_a_known_batch` — a literal frozen from the pre-wrapper emitter |
| Wrapper path ≡ direct path (the wrapper carries the scan's report rather than re-deriving it) | `test_asset_cell.py::test_the_wrapper_path_matches_the_direct_path` |
| `validate_asset` / `validate_transformed_dir` still importable from `application_sdk.validation` | unchanged in signature and behaviour |
| Existing asset-validation tests pass unmodified | `tests/unit/validation/test_assets.py` untouched |

The attribute-key test also checks every emitted key against `_KNOWN_EXTRA_KEYS`: a key absent from that allowlist is dropped by `_build_extra_dict` and silently never reaches OTLP, so asserting the returned dict alone would pass while the row arrived empty in ClickHouse.

The two payload tests are complements, not duplicates. The cell test runs both sides through the *same* post-refactor projection, so it cannot catch that projection changing — only the frozen literal can. Splitting the acceptance row this way was a review finding.

## Verification

* Full unit suite: **7820 passed, 9 skipped**.
* Pre-commit clean (ruff, ruff-format, isort, pyright).
* Conformance C / E / L series: no new findings (the three pre-existing WARN-tier `assets.py` findings are unmoved code at shifted line numbers; this PR adds no `try`/`except`).
* Capability manifest regenerated via `uv run poe regen-capabilities`.

## Docs

`docs/concepts/apps.md` and `docs/concepts/monitoring.md` updated. The monitoring "not yet emitted" note was also corrected — it claimed `validate_artifact` only checked NDJSON against a *contract* declaration, which is no longer the whole story.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

