### PR TITLE
fix(e2e): emit the 3 agent-mode routing rows connectors hand-append (FND-829)

### DIFF
--- a/application_sdk/testing/e2e/payload.py
+++ b/application_sdk/testing/e2e/payload.py
@@ -395,10 +395,13 @@ def build_ae_payload(
             ``extra`` ref-keys, or the dotted ``basic.*`` / ``keypair.*`` shape
             from :func:`build_agent_json`). When supplied, the ``agent-json``
             JSON-blob parameter is (re)written from it and the flat
-            ``agent-json.<key>`` routing rows (:data:`_AGENT_JSON_ROUTING_KEYS`)
-            plus the ``credential-guid.*`` rows the shared cluster template reads
-            are emitted — so agent-mode connectors no longer hand-roll a
-            ``_build_ae_payload`` override to append them. Absent (default None)
+            ``agent-json.<key>`` routing rows (:data:`_AGENT_JSON_ROUTING_KEYS`),
+            the dotted ``agent-json.basic.*`` ref-key rows, plus the
+            ``credential-guid.*`` rows (``credential-type`` / ``auth-type`` /
+            ``port``) the shared cluster template reads are emitted — so
+            agent-mode connectors no longer hand-roll a ``_build_ae_payload``
+            override to append them. The emitted row set matches the legacy
+            ``testing/full_dag`` builder's agent branch. Absent (default None)
             => no flat rows and no blob rewrite (backward-compatible: the blob,
             if any, comes from ``mustache_subs``'s ``{{agent-json}}`` field).
         credential_type: The connector's credential-config name (e.g.
@@ -473,11 +476,30 @@ def build_ae_payload(
             parameters.append(
                 {"name": "credential-guid.auth-type", "value": agent_json["auth-type"]}
             )
+        # The legacy full_dag builder also emits credential-guid.port in agent
+        # mode, and every agent-mode connector (mysql / metabase / mode) was
+        # hand-appending it back after calling this function. Emit it here so the
+        # row set matches what the cluster template has always been sent.
+        if "port" in agent_json:
+            parameters.append(
+                {"name": "credential-guid.port", "value": agent_json["port"]}
+            )
         for key in _AGENT_JSON_ROUTING_KEYS:
             if key in agent_json:
                 parameters.append(
                     {"name": f"agent-json.{key}", "value": agent_json[key]}
                 )
+        # Dotted credential-material keys from :func:`build_agent_json`
+        # (``basic.username`` / ``basic.password``, and any future ``basic.*``).
+        # These are secret-store KEY NAMES, never values, so flattening them
+        # leaks nothing — and the cluster template reads the flat rows separately
+        # even though it could unpack the blob, so omitting them was the third
+        # row each connector had to append by hand. Distinct from the
+        # single-bundle shape's bare ``username`` / ``password`` keys, which stay
+        # in the blob only (they are not in _AGENT_JSON_ROUTING_KEYS).
+        for key, value in agent_json.items():
+            if key.startswith("basic."):
+                parameters.append({"name": f"agent-json.{key}", "value": value})
 
     # Flat connection.* parameter rows (UI sends both the nested JSON
     # and these for the orchestrator's convenience).

--- a/tests/unit/testing/e2e/test_harness_payload.py
+++ b/tests/unit/testing/e2e/test_harness_payload.py
@@ -429,6 +429,79 @@ class TestAgentJsonInjection:
         )
         assert params["credential-guid.auth-type"] == "basic"
 
+    def test_port_row_emitted(self) -> None:
+        # The legacy testing/full_dag builder emits credential-guid.port in its
+        # agent branch; mysql / metabase / mode all hand-appended it back after
+        # this builder dropped it.
+        params = _params(self._build(agent_json=_BUNDLE_AGENT_JSON))
+        assert params["credential-guid.port"] == 443
+
+    def test_no_port_row_when_agent_json_has_no_port(self) -> None:
+        bundle = {k: v for k, v in _BUNDLE_AGENT_JSON.items() if k != "port"}
+        params = _params(self._build(agent_json=bundle))
+        assert "credential-guid.port" not in params
+
+    def test_dotted_basic_ref_keys_flattened(self) -> None:
+        # build_agent_json's shape: basic.username / basic.password carry
+        # secret-store KEY NAMES, and the cluster template reads the flat rows.
+        params = _params(
+            self._build(
+                agent_json={
+                    **_BUNDLE_AGENT_JSON,
+                    "basic.username": "SDR_SALESFORCE_USERNAME",
+                    "basic.password": "SDR_SALESFORCE_PASSWORD",
+                }
+            )
+        )
+        assert params["agent-json.basic.username"] == "SDR_SALESFORCE_USERNAME"
+        assert params["agent-json.basic.password"] == "SDR_SALESFORCE_PASSWORD"
+
+    def test_bare_username_password_still_not_flattened(self) -> None:
+        # Only the dotted basic.* shape is flattened. The single-bundle shape's
+        # bare username / password keys stay in the blob (they are not routing
+        # keys), so this change does not widen what leaves the harness.
+        params = _params(
+            self._build(
+                agent_json={
+                    **_BUNDLE_AGENT_JSON,
+                    "basic.username": "SDR_SALESFORCE_USERNAME",
+                }
+            )
+        )
+        assert "agent-json.username" not in params
+        assert "agent-json.password" not in params
+
+    def test_build_agent_json_row_set_matches_legacy_agent_branch(self) -> None:
+        # Regression lock: the full row set an agent-mode connector needs, so no
+        # connector has to append any of it in a _build_ae_payload override.
+        db = DatabaseSpec(
+            host="db.example.com",
+            port=3306,
+            username="u",
+            password="p",
+            connector_config_name="atlan-connectors-mysql",
+        )
+        agent = AgentSpec(agent_name="mysql-e2e-ci-1234")
+        params = _params(self._build(agent_json=build_agent_json(db, agent, "mysql")))
+        for name in (
+            "credential-guid.credential-type",
+            "credential-guid.auth-type",
+            "credential-guid.port",
+            "agent-json.host",
+            "agent-json.port",
+            "agent-json.auth-type",
+            "agent-json.agent-name",
+            "agent-json.agent-type",
+            "agent-json.key-type",
+            "agent-json.aws-auth-method",
+            "agent-json.azure-auth-method",
+            "agent-json.basic.username",
+            "agent-json.basic.password",
+        ):
+            assert name in params, f"missing routing row {name}"
+        assert params["agent-json.basic.username"] == "SDR_MYSQL_USERNAME"
+        assert params["credential-guid.port"] == 3306
+
     def test_credential_type_override(self) -> None:
         params = _params(
             self._build(


### PR DESCRIPTION
## Problem

`application_sdk/testing/e2e/payload.py::build_ae_payload` emits a **smaller** agent-mode parameter row set than the legacy `application_sdk/testing/full_dag/payload.py` builder it replaced. Three rows are missing:

- `credential-guid.port`
- `agent-json.basic.username`
- `agent-json.basic.password`

`basic.username` / `basic.password` are not in `_AGENT_JSON_ROUTING_KEYS`, so today they only ride inside the `agent-json` blob. The Argo cluster template reads the flat rows separately — the legacy builder says so in its own comment:

> Agent mode duplicates a subset under `agent-json.*` — the Argo cluster template reads these flat parameters separately even though it could also unpack agent-json JSON. Reproducing the exact UI shape avoids subtle service-side validation drift.

So every agent-mode connector re-adds exactly these three in a `_build_ae_payload` override: [`atlan-mysql-app`](https://github.com/atlanhq/atlan-mysql-app/blob/main/tests/e2e/test_mysql_full_dag.py), [`atlan-metabase-app`](https://github.com/atlanhq/atlan-metabase-app/blob/main/tests/e2e/test_metabase_e2e.py), and now `atlan-mode-app`. Three copies of one list — and the `agent_json` docstring already advertises that connectors "no longer hand-roll a `_build_ae_payload` override to append them", which wasn't true for these.

## Change

Inside the existing `if agent_json is not None:` branch:

- emit `credential-guid.port` when the block carries a `port`
- emit a flat `agent-json.<key>` row for every dotted `basic.*` key

The emitted row set now matches the legacy builder's agent branch.

**No secret exposure:** `basic.username` / `basic.password` hold secret-store **key names** (`SDR_<CONN>_USERNAME`), never credential values — that's the whole point of the agent-mode indirection. Flattening them leaks nothing new.

## Backward compatibility

- `mysql` and `metabase` call `build_ae_payload()` **without** `agent_json=`, so this branch never executes for them — unaffected.
- Only callers that pass `agent_json` gain the rows.
- The single-bundle shape's bare `username` / `password` keys stay blob-only (they aren't routing keys and aren't dotted `basic.*`). `test_bare_username_password_still_not_flattened` locks that in.
- One caller both passes `agent_json` and hand-appends these three today: `atlan-mode-app` (atlanhq/atlan-mode-app#112). Its append is being made absence-conditional so it emits no duplicates before or after this release.

## Tests

5 added to `tests/unit/testing/e2e/test_harness_payload.py::TestAgentJsonInjection`:

| test | asserts |
|---|---|
| `test_port_row_emitted` | `credential-guid.port` present |
| `test_no_port_row_when_agent_json_has_no_port` | absent when the block has no port |
| `test_dotted_basic_ref_keys_flattened` | `agent-json.basic.username/password` carry the ref-key names |
| `test_bare_username_password_still_not_flattened` | bare `username`/`password` stay blob-only |
| `test_build_agent_json_row_set_matches_legacy_agent_branch` | regression lock on the full 13-row set from a `build_agent_json` block |

`757 passed` in `tests/unit/testing`. `ruff 0.6.4` format+check and `pyright 1.1.410` clean (repo pins).

## Origin

Surfaced by FND-402 while fixing the mode crawler e2e. That suite ran `RunMode.AGENT` but submitted a DIRECT-shape payload, so the orchestrator skipped credential creation and shipped a literal `{{credentialGuid}}` to the worker (`[AAF-CRD-005] Invalid credential GUID — must match [a-zA-Z0-9_-]+`). Porting the mysql/metabase AGENT shape meant copying this three-row append for the third time.

Linear: [FND-829](https://linear.app/atlan-epd/issue/FND-829). Related: FND-402, FND-778.

🤖 Generated with [Claude Code](https://claude.com/claude-code)