### PR TITLE
ci(e2e): stop the pod-health FAILED verdict reading benign pod churn as an install failure

### DIFF
--- a/.github/scripts/e2e_tenant_app.py
+++ b/.github/scripts/e2e_tenant_app.py
@@ -361,11 +361,24 @@ _BENIGN_WAITING_REASONS = frozenset({"", "podinitializing", "containercreating"}
 _CLEAN_TERMINATION_REASONS = frozenset({"completed"})
 
 #: Container-state reasons that are never the app image's fault: the kubelet
-#: could not ASSEMBLE the container, so the image was never run. The observed one
-#: is a Vault secret whose name encodes the namespace and had not synced yet.
-_NON_APP_CONTAINER_REASONS = frozenset(
-    {"createcontainerconfigerror", "createcontainererror"}
-)
+#: could not BUILD THE CONFIG for the container, so the image was never
+#: instantiated. The observed one is a Vault secret whose name encodes the
+#: namespace and had not synced yet.
+#:
+#: Exactly one member, and ``CreateContainerError`` is deliberately NOT it. The
+#: two look interchangeable and are not: the kubelet sets ``…ConfigError`` while
+#: *generating* the config (a missing Secret/ConfigMap or key), and plain
+#: ``CreateContainerError`` afterwards, when the CRI ``CreateContainer`` call
+#: fails — a bad security context, a volume or device the app's chart asked for,
+#: an image that cannot be instantiated. Those are app faults, and they are
+#: precisely what this hatch exists to keep fatal.
+#:
+#: The rest of the hatch fails closed; widening this set on a guess is the one
+#: way to reopen it, because a one-shot reason ages out of the settle window and
+#: the version read-back confirms what was INSTALLED rather than that it runs.
+#: So: add a member only with a fixture taken from a real ``describe`` showing
+#: that reason on a container the app cannot have broken.
+_NON_APP_CONTAINER_REASONS = frozenset({"createcontainerconfigerror"})
 
 #: Pod-level ``Reason:`` values that mean the NODE took the pod away. All are
 #: written by the kubelet or the scheduler, never by anything the app controls.

--- a/.github/scripts/e2e_tenant_app.py
+++ b/.github/scripts/e2e_tenant_app.py
@@ -180,7 +180,18 @@ DEFAULT_DEPLOYMENT_TIMEOUT_SECONDS = 600
 #: diagnostics name only benign pod churn (FND-831). 90s because the observed
 #: window was ~14s of secret-sync lag plus a scale-down: everything that recovers
 #: on its own has recovered well inside it, and anything still warning after it is
-#: not churn. Included in the job-budget sum asserted by
+#: not churn.
+#:
+#: 90 also sits 30s clear of a formatting cliff that is kubectl's, not ours:
+#: ``duration.HumanDuration`` branches on ``seconds < 60*2``, so ``LAST SEEN``
+#: stays in the seconds form (``91s``) all the way to 120s and only then becomes
+#: ``XmYs``. Raising this past 120 makes the minutes form the common case rather
+#: than an edge case — :func:`ongoing_failures` parses both and its fixtures
+#: cover both, so nothing breaks, but the resolution the window compares at
+#: coarsens to whole seconds-within-minutes. Worth knowing before raising it,
+#: rather than rediscovering it.
+#:
+#: Included in the job-budget sum asserted by
 #: ``test_job_timeout_stays_above_the_scripts_own_waits``, so raising it forces
 #: prepare-tenant's ceiling up rather than silently making a runner timeout
 #: reachable. 0 disables the tolerance entirely: without a settle there is no

--- a/.github/scripts/e2e_tenant_app.py
+++ b/.github/scripts/e2e_tenant_app.py
@@ -86,6 +86,22 @@ Only the last of those survived, because ``_poll_deployment`` is the one caller
 that already retried a bad read. So ``--publish-retry-seconds`` (default 240)
 gives ``_publish`` the same tolerance: see :func:`_publish` for which half of
 the failure space is retried and why the other half must stay fatal.
+
+A FAILED verdict is not always about the app
+--------------------------------------------
+LM's deployment health check is namespace-scoped AND its verdict is an instant:
+any pod unhealthy at the moment it looks reds the install, including a pod the
+platform itself just deleted on purpose. Two tolerances handle that, both
+narrow, both falling through to the installed-version read-back rather than
+passing on their own:
+
+* :func:`foreign_failure` — every image failing to PULL belongs to a different
+  version, so the verdict is about an orphan from an earlier install (FND-31).
+* :func:`benign_pod_failure` plus :func:`_settle` — the unhealthy container is
+  not the one running the image under test, or its failure is one the app image
+  cannot cause, AND the namespace stops failing while we watch (FND-831).
+
+Anything else stays fatal. The default is not to second-guess LM.
 """
 
 from __future__ import annotations
@@ -97,7 +113,7 @@ import random
 import re
 import sys
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 
 from e2e_tenant_api import (
@@ -159,6 +175,17 @@ _PUBLISH_RETRY_JITTER_SECONDS = 10
 DEFAULT_PUBLISH_RETRY_SECONDS = 240
 DEFAULT_INSTALL_RETRY_SECONDS = 600
 DEFAULT_DEPLOYMENT_TIMEOUT_SECONDS = 600
+
+#: How long to let the namespace settle before honouring a FAILED verdict whose
+#: diagnostics name only benign pod churn (FND-831). 90s because the observed
+#: window was ~14s of secret-sync lag plus a scale-down: everything that recovers
+#: on its own has recovered well inside it, and anything still warning after it is
+#: not churn. Included in the job-budget sum asserted by
+#: ``test_job_timeout_stays_above_the_scripts_own_waits``, so raising it forces
+#: prepare-tenant's ceiling up rather than silently making a runner timeout
+#: reachable. 0 disables the tolerance entirely: without a settle there is no
+#: evidence the churn stopped, so every FAILED verdict is honoured.
+DEFAULT_SETTLE_SECONDS = 90
 
 #: Keys an install/info response may carry the installed version under. LM has
 #: not committed to one name across versions, so check the plausible set rather
@@ -273,6 +300,116 @@ _QUOTED_IMAGE_RE = re.compile(r'"([^"\s]+/[^"\s]+)"')
 #: A pinned image reference is the same reference with ``@sha256:…`` in place of
 #: the tag: `repo:tag@sha256:…`. Kubelet can report a pull failure in that form.
 _PINNED_IMAGE_RE = re.compile(r"@sha256:[0-9a-f]{64}$")
+
+# ── Reading `kubectl describe pod` (FND-831) ─────────────────────────────────
+#
+# LM's ``pod_describe`` is concatenated `kubectl describe pod` output, one block
+# per pod. Its indentation is the schema: the pod's own fields sit at column 0,
+# ``Init Containers:`` / ``Containers:`` head a section, each container is a
+# 2-space-indented header, its fields sit at 4 and their sub-fields at 6::
+#
+#     Name:    metabase-server-6b9f7d4c8-x7d2k
+#     Status:  Failed
+#     Reason:  Evicted
+#     Init Containers:
+#       atlan-env-seeder:
+#         Image:       ghcr.io/atlanhq/atlan-env-seeder:1.2.3
+#         State:       Terminated
+#           Reason:    Error
+#           Exit Code: 137
+#         Ready:       False
+#
+# This is parsed rather than substring-matched because the whole point is WHICH
+# container failed: the reason lines alone cannot tell a platform-injected init
+# container apart from the app image under test.
+
+#: A pod block opens on a column-0 ``Name:``.
+_DESCRIBE_NAME_RE = re.compile(r"^Name:\s+(\S+)")
+#: The pod-level ``Reason:`` — ``Evicted`` and friends live here, not on a
+#: container. Column 0, so it cannot collide with a container's own reason.
+_DESCRIBE_POD_REASON_RE = re.compile(r"^Reason:\s+(\S+)")
+#: Section headers. ``Ephemeral Containers`` counts as an init-like section only
+#: in that it is never the app: debug containers are attached by a human.
+_DESCRIBE_SECTION_RE = re.compile(
+    r"^(Init Containers|Containers|Ephemeral Containers):\s*$"
+)
+#: A container header: exactly two spaces, then a name, then a bare colon.
+_DESCRIBE_CONTAINER_RE = re.compile(r"^ {2}(\S[^:]*):\s*$")
+#: A container field (4 spaces) and its sub-field (6 spaces). ``Image:`` must not
+#: also match ``Image ID:`` — hence the colon immediately after the key.
+_DESCRIBE_FIELD_RE = re.compile(r"^ {4}(\S[^:]*):\s*(.*)$")
+_DESCRIBE_SUBFIELD_RE = re.compile(r"^ {6}(\S[^:]*):\s*(.*)$")
+
+#: ``State: Waiting`` reasons that mean "not started YET", which is not a
+#: failure. Reading these as unhealthy would put the app container of every
+#: init-blocked pod into the unhealthy set, and rule (1) below only holds when
+#: the unhealthy set is the container that actually broke.
+_BENIGN_WAITING_REASONS = frozenset({"", "podinitializing", "containercreating"})
+
+#: A terminated container that exited cleanly.
+_CLEAN_TERMINATION_REASONS = frozenset({"completed"})
+
+#: Container-state reasons that are never the app image's fault: the kubelet
+#: could not ASSEMBLE the container, so the image was never run. The observed one
+#: is a Vault secret whose name encodes the namespace and had not synced yet.
+_NON_APP_CONTAINER_REASONS = frozenset(
+    {"createcontainerconfigerror", "createcontainererror"}
+)
+
+#: Pod-level ``Reason:`` values that mean the NODE took the pod away. All are
+#: written by the kubelet or the scheduler, never by anything the app controls.
+_NODE_PRESSURE_POD_REASONS = frozenset(
+    {
+        "evicted",
+        "shutdown",
+        "nodeshutdown",
+        "terminationbykubelet",
+        "preempting",
+        "disruptiontarget",
+    }
+)
+
+#: SIGKILL. Ambiguous on its own — a scale-down and an OOM kill both land here —
+#: which is why the classifier demands positive evidence naming the deletion, and
+#: why ``OOMKilled`` in the (last) state keeps it fatal.
+_SIGKILL_EXIT_CODE = "137"
+_OOM_REASON = "oomkilled"
+
+#: KEDA's own event for "this ScaledObject just scaled its target to zero".
+_KEDA_DEACTIVATED_MARKER = "kedascaletargetdeactivated"
+#: Events that name a pod's deletion explicitly — the ReplicaSet's
+#: ``Deleted pod: <name>`` and the kubelet's ``Killing``. Matched against the
+#: pod's own name, so this is causal evidence rather than a timestamp
+#: correlation with whatever else the namespace was doing.
+_POD_DELETED_MARKERS = ("successfuldelete", "killing")
+
+#: Event-line markers that mean "something in this namespace is still not well".
+#: ``warning`` is the TYPE column, so any Warning event counts: the settle errs
+#: toward honouring LM's verdict, which is the safe direction — a namespace that
+#: is still warning has not settled.
+_UNHEALTHY_EVENT_MARKERS = (
+    "warning",
+    "failed",
+    "backoff",
+    "unhealthy",
+    "evicted",
+    "crashloop",
+    "oomkill",
+)
+
+#: kubectl's relative ``LAST SEEN`` column: ``9s``, ``2m``, ``5m1s``, ``3h59m``,
+#: ``2d``. ``<unknown>`` and the header's ``LAST`` match nothing, which is how an
+#: unaged line is told apart from a young one.
+_EVENT_AGE_RE = re.compile(r"(?:(\d+)d)?(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?")
+
+#: Per-pod budget for the ``pod_describe`` render, and how many pods to print.
+#: One budget across the whole concatenation is what hid the failing pod in
+#: FND-831: it printed as "tail 200 of 542 lines" and the only pod that failed
+#: the install was in the dropped head, leaving two healthy workers as the
+#: entire visible evidence. ``head`` per pod because a describe block opens with
+#: the pod's status and its container states and ends in volumes and tolerations.
+_DESCRIBE_POD_MAX_LINES = 120
+_DESCRIBE_MAX_PODS = 6
 
 
 class TenantAppError(RuntimeError):
@@ -1256,6 +1393,23 @@ def _image_tag(reference: str) -> str:
     return tag if sep and head else ""
 
 
+def _is_our_image(reference: str, ours: str) -> bool:
+    """Is *reference* the image under test, as far as can be proven?
+
+    Deliberately biased toward YES. Kubelet and the pod spec can each name the
+    same image in a different resolution — ``repo:tag``, ``repo@sha256:…``,
+    ``repo:tag@sha256:…`` — and every caller of this uses "not ours" to excuse
+    something. So a reference counts as ours whenever it shares our repository
+    and its tag is ours, a digest, or absent; only a different repository, or a
+    resolvably different tag of ours, is somebody else's.
+    """
+    if _image_repository(reference) != _image_repository(ours):
+        return False
+    reference_tag = _image_tag(reference)
+    ours_tag = _image_tag(ours)
+    return not reference_tag or not ours_tag or reference_tag == ours_tag
+
+
 def foreign_failure(diagnostics: str, image: str) -> list[str]:
     """Return failing images that are NOT *image*, or [] if ours is among them.
 
@@ -1276,15 +1430,378 @@ def foreign_failure(diagnostics: str, image: str) -> list[str]:
     if not failing:
         return []
     ours = image.strip()
-    ours_repo = _image_repository(ours)
-    ours_tag = _image_tag(ours)
-    for ref in failing:
-        if _image_repository(ref) != ours_repo:
-            continue  # a different repository: provably somebody else's pod
-        ref_tag = _image_tag(ref)
-        if not ref_tag or not ours_tag or ref_tag == ours_tag:
-            return []  # same repository and tag, digest-pinned, or untagged
+    if any(_is_our_image(ref, ours) for ref in failing):
+        return []  # same repository and tag, digest-pinned, or untagged
     return failing
+
+
+@dataclass
+class PodContainer:
+    """One container's state, as ``kubectl describe pod`` reports it."""
+
+    name: str
+    init: bool
+    image: str = ""
+    state: str = ""
+    reason: str = ""
+    exit_code: str = ""
+    last_state: str = ""
+    last_reason: str = ""
+    last_exit_code: str = ""
+    ready: bool = False
+
+
+@dataclass
+class PodStatus:
+    """One pod block from ``pod_describe``.
+
+    ``lines`` is the block's own text, kept so the diagnostics can be re-rendered
+    per pod instead of under one budget shared across every pod in the namespace.
+    """
+
+    name: str
+    reason: str = ""
+    phase: str = ""
+    containers: list[PodContainer] = field(default_factory=list)
+    lines: list[str] = field(default_factory=list)
+
+
+def parse_pod_describe(text: str) -> list[PodStatus]:
+    """Split ``pod_describe`` into pods and their containers.
+
+    Tolerant by construction: it is handed the whole diagnostics blob, most of
+    which is events and logs, so anything that does not match the indentation
+    schema is simply not a container. Lines before the first pod block are
+    returned as a nameless leading ``PodStatus`` rather than dropped — the
+    renderer prints everything it is given or the truncation this replaces is
+    just moved somewhere else.
+    """
+    pods: list[PodStatus] = []
+    pod: PodStatus | None = None
+    init_section: bool | None = None
+    container: PodContainer | None = None
+    # Which of ``State:`` / ``Last State:`` the 6-space sub-fields belong to.
+    in_last_state = False
+
+    for line in text.splitlines():
+        name = _DESCRIBE_NAME_RE.match(line)
+        if name:
+            pod = PodStatus(name=name.group(1))
+            pods.append(pod)
+            init_section, container, in_last_state = None, None, False
+            pod.lines.append(line)
+            continue
+
+        if pod is None:
+            # A preamble. Keep it under a nameless pod so nothing is lost.
+            pod = PodStatus(name="")
+            pods.append(pod)
+        pod.lines.append(line)
+
+        section = _DESCRIBE_SECTION_RE.match(line)
+        if section:
+            init_section = section.group(1) != "Containers"
+            container, in_last_state = None, False
+            continue
+
+        if line[:1].strip():  # column 0: a pod-level field closes any container
+            pod_reason = _DESCRIBE_POD_REASON_RE.match(line)
+            if pod_reason:
+                pod.reason = pod_reason.group(1)
+            elif line.startswith("Status:"):
+                pod.phase = line.partition(":")[2].strip()
+            init_section, container, in_last_state = None, None, False
+            continue
+
+        if init_section is not None:
+            header = _DESCRIBE_CONTAINER_RE.match(line)
+            if header:
+                container = PodContainer(name=header.group(1), init=init_section)
+                pod.containers.append(container)
+                in_last_state = False
+                continue
+
+        if container is None:
+            continue
+
+        field_match = _DESCRIBE_FIELD_RE.match(line)
+        if field_match:
+            key, value = field_match.group(1), field_match.group(2).strip()
+            if key == "Image":
+                container.image = value
+            elif key == "State":
+                container.state, in_last_state = value, False
+            elif key == "Last State":
+                container.last_state, in_last_state = value, True
+            elif key == "Ready":
+                container.ready = value == "True"
+            continue
+
+        sub = _DESCRIBE_SUBFIELD_RE.match(line)
+        if sub:
+            key, value = sub.group(1), sub.group(2).strip()
+            if key == "Reason":
+                if in_last_state:
+                    container.last_reason = value
+                else:
+                    container.reason = value
+            elif key == "Exit Code":
+                if in_last_state:
+                    container.last_exit_code = value
+                else:
+                    container.exit_code = value
+
+    return [p for p in pods if p.name or p.containers or any(p.lines)]
+
+
+def _container_is_unhealthy(container: PodContainer) -> bool:
+    """Is this container broken, as opposed to merely not started yet?
+
+    ``Ready: False`` is deliberately not the test. With KEDA scale-to-zero an
+    app's steady state is no pods at all, and an init container that has done its
+    job is terminated — both read as not-ready while nothing is wrong.
+    """
+    state = container.state.lower()
+    if state == "terminated":
+        return (
+            container.reason.lower() not in _CLEAN_TERMINATION_REASONS
+            or container.exit_code not in ("", "0")
+        )
+    if state == "waiting":
+        return container.reason.lower() not in _BENIGN_WAITING_REASONS
+    # Running, or no state parsed at all: nothing here is evidence of a failure.
+    return False
+
+
+def _pod_is_unhealthy(pod: PodStatus) -> bool:
+    return any(_container_is_unhealthy(c) for c in pod.containers)
+
+
+def _deletion_is_named(diagnostics: str, pod: str) -> bool:
+    """Do the events positively tie *pod*'s deletion to a KEDA scale-down?
+
+    Both halves are required, and the second must name the pod. A
+    ``KEDAScaleTargetDeactivated`` event on its own is only a timestamp
+    correlation with whatever else the namespace was doing; the ReplicaSet's
+    ``Deleted pod: <name>`` is what makes it causal.
+    """
+    if not pod:
+        return False
+    if _KEDA_DEACTIVATED_MARKER not in diagnostics.lower():
+        return False
+    needle = pod.lower()
+    return any(
+        marker in lowered and needle in lowered
+        for lowered in (line.lower() for line in diagnostics.splitlines())
+        for marker in _POD_DELETED_MARKERS
+    )
+
+
+def _excuse_for(
+    pod: PodStatus, container: PodContainer, diagnostics: str, image: str
+) -> str:
+    """Why this unhealthy container is not evidence about the app under test.
+
+    Returns "" when it IS evidence, or when nothing recognisable excuses it —
+    which keeps LM's verdict authoritative by default. Every clause below has to
+    name something positively; "it does not look that bad" is not a clause.
+    """
+    # (1) Container ownership, the primary rule. The container under test is the
+    # one running the image we published; every other container in the pod was
+    # injected by the platform's pod template, so it can be neither broken by the
+    # app nor fixed by it. Inverted rather than an allowlist of platform names, so
+    # the platform can rename or add init containers without this going stale.
+    # An UNREADABLE image falls through instead of being excused: the direction a
+    # misread must never take is "not ours, so ignore it".
+    if container.image and not _is_our_image(container.image, image.strip()):
+        kind = "init" if container.init else "sidecar"
+        return (
+            f"the failing container is the platform-injected {kind} container "
+            f"{container.name!r} running {container.image}, not the image under "
+            "test"
+        )
+
+    # (3) Reason classifier, for the app's own container. Each of these is a
+    # failure the app image cannot cause.
+    reasons = {container.reason.lower(), container.last_reason.lower()}
+    config = reasons & _NON_APP_CONTAINER_REASONS
+    if config:
+        return (
+            f"{container.name} never started: {sorted(config)[0]} means the "
+            "kubelet could not assemble the container from its secret/config, so "
+            "the image was never run"
+        )
+
+    if pod.reason.lower() in _NODE_PRESSURE_POD_REASONS:
+        return (
+            f"the node took the pod away ({pod.reason}), which is a scheduling "
+            "and capacity outcome, not an app fault"
+        )
+
+    if _SIGKILL_EXIT_CODE in {container.exit_code, container.last_exit_code}:
+        if _OOM_REASON in reasons:
+            # A genuine OOM exits 137 too, and says so. Stays fatal.
+            return ""
+        if _deletion_is_named(diagnostics, pod.name):
+            return (
+                f"{container.name} was SIGKILLed (exit "
+                f"{_SIGKILL_EXIT_CODE}) because the events name this pod's own "
+                "deletion after a KEDA scale-down — the platform deleted a pod "
+                "that was still initialising"
+            )
+
+    return ""
+
+
+def benign_pod_failure(diagnostics: str, image: str) -> str:
+    """Explain why a FAILED verdict is not about the app, or return "".
+
+    LM's health check is namespace-scoped and its verdict is a snapshot: any pod
+    in the namespace that is unhealthy at that instant reds the install, including
+    pods the platform itself deleted on purpose. ``foreign_failure`` already
+    handles one shape of that (an orphan stuck pulling a different version); this
+    handles the rest, by asking whose container broke and why.
+
+    Fatal by default in both directions that matter. An empty string is returned
+    when nothing unhealthy could be PARSED — unreadable diagnostics are not
+    evidence of health — and as soon as one unhealthy container has no recognised
+    excuse, because a real broken app usually sits alongside benign churn rather
+    than instead of it.
+    """
+    unhealthy = [
+        (pod, container)
+        for pod in parse_pod_describe(diagnostics)
+        for container in pod.containers
+        if _container_is_unhealthy(container)
+    ]
+    if not unhealthy:
+        return ""
+
+    excuses: list[str] = []
+    for pod, container in unhealthy:
+        excuse = _excuse_for(pod, container, diagnostics, image)
+        if not excuse:
+            return ""
+        excuses.append(f"{pod.name or '<unnamed pod>'}: {excuse}")
+    # dict.fromkeys rather than a set: the order is the order the pods appear in,
+    # which is the order a reader will find them in the dump above.
+    return "; ".join(dict.fromkeys(excuses))
+
+
+def _event_age_seconds(token: str) -> int | None:
+    """Seconds behind ``token``, kubectl's relative ``LAST SEEN`` column.
+
+    ``None`` for anything that is not an age — the header row's ``LAST``, an
+    ``<unknown>``, a message that happens to start a line. A None is never read
+    as young: an unaged line cannot say the namespace is still failing.
+    """
+    match = _EVENT_AGE_RE.fullmatch(token.strip())
+    if not match or not any(match.groups()):
+        return None
+    days, hours, minutes, seconds = (int(g or 0) for g in match.groups())
+    return days * 86400 + hours * 3600 + minutes * 60 + seconds
+
+
+def ongoing_failures(events: str, window_seconds: int) -> list[str]:
+    """Event lines that say the namespace is STILL unhealthy, newest-first order.
+
+    "Still" is what the age column buys: the events behind the original verdict
+    age past ``window_seconds`` while we wait, so anything left inside the window
+    fired during the settle. A repeating warning keeps its ``LAST SEEN`` young,
+    which is exactly the case that must stay fatal — a platform container that
+    never recovers.
+    """
+    lines: list[str] = []
+    for line in events.splitlines():
+        head = line.split(maxsplit=1)
+        if not head:
+            continue
+        age = _event_age_seconds(head[0])
+        if age is None or age >= window_seconds:
+            continue
+        lowered = line.lower()
+        if any(marker in lowered for marker in _UNHEALTHY_EVENT_MARKERS):
+            lines.append(line.strip())
+    return lines
+
+
+def _print_pod_describe(text: str) -> None:
+    """Render ``pod_describe`` per pod, unhealthy pods first.
+
+    One budget across the whole concatenation is what made FND-831's own item (1)
+    unverifiable from its CI log: ``pod_describe`` printed as "tail 200 of 542
+    lines" and the only pod that failed the install was in the dropped head, so
+    the visible evidence was two healthy workers. A per-pod budget cannot let one
+    pod crowd out another, and unhealthy-first means the budget on the number of
+    pods spends itself on the ones that failed.
+    """
+    pods = parse_pod_describe(text)
+    if not any(pod.name for pod in pods):
+        # Nothing recognisable as a pod block: print it as it came rather than
+        # under a per-pod title that would misdescribe it.
+        _print_block("pod_describe", text, _DESCRIBE_POD_MAX_LINES * 2, "tail")
+        return
+    # Stable, so pods keep their original order within each group.
+    ordered = sorted(pods, key=lambda pod: not _pod_is_unhealthy(pod))
+    for pod in ordered[:_DESCRIBE_MAX_PODS]:
+        state = " — UNHEALTHY" if _pod_is_unhealthy(pod) else ""
+        title = f"pod_describe: {pod.name or 'before the first pod'}{state}"
+        _print_block(title, "\n".join(pod.lines), _DESCRIBE_POD_MAX_LINES, "head")
+    dropped = ordered[_DESCRIBE_MAX_PODS:]
+    if dropped:
+        print(
+            f"--- pod_describe: {len(dropped)} further pod(s) not printed: "
+            f"{', '.join(pod.name or '<unnamed>' for pod in dropped)} ---"
+        )
+
+
+def _live_events(client: TenantClient, app_id: str, title: str) -> str | None:
+    """Print and return live ``kubectl get events`` for the app's namespace.
+
+    ``None`` — distinct from ``""`` — when the read did not succeed. A caller that
+    is asking "has the namespace settled?" must not read an unreadable answer as
+    a healthy one.
+    """
+    try:
+        response = client.get(APP_EVENTS_PATH.format(app_id=path_segment(app_id)))
+    except TenantApiError as exc:
+        print(f"::warning::could not fetch live events: {exc}")
+        return None
+    if not response.ok:
+        print(f"::warning::live events read returned HTTP {response.status}")
+        return None
+    body = response.body if isinstance(response.body, dict) else {}
+    text = str(body.get("events") or "")
+    _print_block(title, text, _EVENTS_MAX_LINES)
+    return text
+
+
+def _settle(client: TenantClient, app_id: str, seconds: int) -> list[str]:
+    """Wait, re-read the live events, and report what is still failing.
+
+    What makes the tolerance above safe: a platform container that genuinely
+    never recovers keeps warning, and those warnings are what this returns.
+
+    The re-read is of the EVENTS, not the deployment status. LM's
+    ``deployment_status`` is a terminal record — it never flips back to
+    SUCCEEDED — and its failure snapshot is frozen at the moment of failure, so
+    neither can say whether the namespace is well now. The live events can.
+    """
+    print(
+        f"::notice::the FAILED verdict names only benign pod churn. Waiting "
+        f"{seconds}s and re-reading the live events before honouring it: churn "
+        "has stopped by then, and anything still warning after it is not churn."
+    )
+    time.sleep(seconds)
+    events = _live_events(
+        client, app_id, title=f"live namespace events after settling {seconds}s"
+    )
+    if events is None:
+        return [
+            "the live-events read failed, so recovery could not be confirmed — "
+            "honouring LM's verdict rather than guessing"
+        ]
+    return ongoing_failures(events, seconds)
 
 
 def _dump_failure(client: TenantClient, app_id: str) -> str:
@@ -1331,10 +1848,15 @@ def _dump_failure(client: TenantClient, app_id: str) -> str:
                 f"(HTTP {response.status}); falling back to live events"
             )
 
-    for field, max_lines, keep in _FAILURE_SECTIONS:
-        text = str(snapshot.pop(field, "") or "")
+    for name, max_lines, keep in _FAILURE_SECTIONS:
+        text = str(snapshot.pop(name, "") or "")
         diagnostics.append(text)
-        _print_block(field, text, max_lines, keep)
+        if name == "pod_describe":
+            # Per pod, unhealthy first: see _print_pod_describe for why one
+            # shared budget is not good enough here.
+            _print_pod_describe(text)
+        else:
+            _print_block(name, text, max_lines, keep)
 
     # Whatever is left, so a new snapshot field is visible the day it ships
     # instead of being silently dropped by the list above.
@@ -1350,24 +1872,62 @@ def _dump_failure(client: TenantClient, app_id: str) -> str:
     # Live events. Fetched even when the snapshot had its own copy: the snapshot
     # is from the moment of failure and these are from now, and on the timeout
     # path they are the only events there are.
-    try:
-        events = client.get(APP_EVENTS_PATH.format(app_id=path_segment(app_id)))
-    except TenantApiError as exc:
-        print(f"::warning::could not fetch live events: {exc}")
-    else:
-        if events.ok:
-            body = events.body if isinstance(events.body, dict) else {}
-            text = str(body.get("events") or "")
-            diagnostics.append(text)
-            _print_block("live namespace events", text, _EVENTS_MAX_LINES)
-        else:
-            print(f"::warning::live events read returned HTTP {events.status}")
+    events = _live_events(client, app_id, title="live namespace events")
+    if events is not None:
+        diagnostics.append(events)
 
     collected = "\n".join(diagnostics)
     _hint_platform_mismatch(collected)
     # Returned so the caller can work out WHOSE pod failed without a second
     # round of API calls: everything needed is already in this text.
     return collected
+
+
+def _tolerate_pod_churn(
+    client: TenantClient,
+    app_id: str,
+    failure: DeploymentFailed,
+    diagnostics: str,
+    image: str,
+    settle_seconds: int,
+) -> str:
+    """Downgrade a FAILED verdict caused by benign pod churn, or re-raise it.
+
+    Two conditions, both required (FND-831). The diagnostics have to NAME why the
+    unhealthy container is not the app under test, and the namespace then has to
+    be seen to stop failing. Naming alone is not enough — a platform container
+    that never recovers names the same reason forever — and settling alone is not
+    enough either, since an app that crash-loops slower than the window would
+    look calm.
+
+    Returns the reason, for the log lines and for the read-back's failure message.
+    Never returns "": everything that is not tolerated leaves by ``raise``.
+    """
+    reason = benign_pod_failure(diagnostics, image)
+    if not reason:
+        raise failure
+    if settle_seconds <= 0:
+        print(
+            f"::warning::the diagnostics name only benign pod churn ({reason}), "
+            "but --settle-seconds is 0, so the verdict stands: without a settle "
+            "there is no evidence the churn stopped."
+        )
+        raise failure
+    ongoing = _settle(client, app_id, settle_seconds)
+    if ongoing:
+        raise DeploymentFailed(
+            f"{failure} The diagnostics named benign pod churn ({reason}), but "
+            f"the namespace was still failing {settle_seconds}s later, so the "
+            "verdict stands: " + " | ".join(ongoing[:5])
+        ) from failure
+    print(
+        f"::warning::{failure} — but {reason}, and nothing in the namespace was "
+        f"still failing {settle_seconds}s later. LM's health check is "
+        "namespace-scoped and its verdict is an instant, so pod churn the "
+        "platform caused reds an install that is fine. Falling through to the "
+        "installed-version read-back, which decides."
+    )
+    return reason
 
 
 def install(args: argparse.Namespace) -> InstallOutcome:
@@ -1479,6 +2039,7 @@ def install(args: argparse.Namespace) -> InstallOutcome:
     # below is then the only thing that decides success — which is the right
     # authority anyway.
     foreign: list[str] = []
+    churn = ""
     if deployment_id:
         print(f"install accepted, deployment_id={deployment_id}")
         try:
@@ -1486,24 +2047,37 @@ def install(args: argparse.Namespace) -> InstallOutcome:
         except DeploymentFailed as exc:
             diagnostics = _dump_failure(read_client, app_id)
             foreign = foreign_failure(diagnostics, args.image)
-            if not foreign:
-                raise
-            # LM's health check is namespace-scoped, so its FAILED verdict can be
-            # about a pod this install never touched — an orphan from an earlier
-            # version, which fails every subsequent install to that tenant until
-            # someone deletes it. Every failing image here belongs to a different
-            # version, so the verdict is not evidence about ours.
-            #
-            # NOT a pass on its own: the read-back below has to confirm the tenant
-            # actually serves the version we installed. Downgrading the verdict
-            # only moves the decision to direct evidence — it does not skip it.
-            print(
-                f"::warning::{exc} — but the failing pod(s) want "
-                f"{', '.join(foreign)}, not {args.image}. LM's health check is "
-                "namespace-scoped, so an orphaned pod from an earlier version "
-                "fails this check for every later install. Falling through to the "
-                "installed-version read-back, which decides."
-            )
+            if foreign:
+                # LM's health check is namespace-scoped, so its FAILED verdict can
+                # be about a pod this install never touched — an orphan from an
+                # earlier version, which fails every subsequent install to that
+                # tenant until someone deletes it. Every failing image here belongs
+                # to a different version, so the verdict is not evidence about
+                # ours.
+                #
+                # NOT a pass on its own: the read-back below has to confirm the
+                # tenant actually serves the version we installed. Downgrading the
+                # verdict only moves the decision to direct evidence — it does not
+                # skip it.
+                print(
+                    f"::warning::{exc} — but the failing pod(s) want "
+                    f"{', '.join(foreign)}, not {args.image}. LM's health check is "
+                    "namespace-scoped, so an orphaned pod from an earlier version "
+                    "fails this check for every later install. Falling through to "
+                    "the installed-version read-back, which decides."
+                )
+            else:
+                # The same namespace-scoping, one layer out: not an orphan pulling
+                # a different version, but pod churn the platform itself caused.
+                # Raises unless it can name the reason AND watch it stop.
+                churn = _tolerate_pod_churn(
+                    read_client,
+                    app_id,
+                    exc,
+                    diagnostics,
+                    args.image,
+                    args.settle_seconds,
+                )
         except TenantAppError:
             # Timeout, or an unrelated failure. Nobody else's fault; fatal.
             _dump_failure(read_client, app_id)
@@ -1528,6 +2102,13 @@ def install(args: argparse.Namespace) -> InstallOutcome:
             if foreign
             else ""
         )
+        tolerated = (
+            f" The FAILED verdict was tolerated as benign pod churn ({churn}); "
+            "with the read-back disagreeing, treat that as one thing that went "
+            "wrong rather than the whole story."
+            if churn
+            else ""
+        )
         unverifiable = (
             " The tenant reported no usable version: see the info dump above. "
             "That is not the same as running the wrong one — LM's version_text "
@@ -1541,7 +2122,15 @@ def install(args: argparse.Namespace) -> InstallOutcome:
             f"{args.version}, so this install cannot be confirmed. Heracles "
             "fetches the DAG from the deployed pod at AE submit, so letting the "
             "legs run now would test an unverified version."
-            f"{unverifiable}{orphans}"
+            f"{unverifiable}{orphans}{tolerated}"
+        )
+    if churn:
+        print(
+            f"::notice::tenant serves {installed}; the FAILED verdict was benign "
+            f"pod churn ({churn}) and the namespace settled. Nothing to clean up "
+            "on the tenant, but the churn itself is worth removing at the "
+            "platform: KEDA's initialCooldownPeriod would stop a scale-down "
+            "racing a still-initialising pod."
         )
     if foreign:
         print(
@@ -1684,6 +2273,19 @@ def main(argv: list[str] | None = None) -> int:
         type=int,
         default=DEFAULT_DEPLOYMENT_TIMEOUT_SECONDS,
         help="Budget for the deployment to reconcile. A timeout fails.",
+    )
+    p_install.add_argument(
+        "--settle-seconds",
+        type=int,
+        default=DEFAULT_SETTLE_SECONDS,
+        help=(
+            "How long to let the namespace settle before honouring a FAILED "
+            "verdict whose diagnostics name only benign pod churn — a "
+            "platform-injected init container, a config/secret that had not "
+            "synced, a node eviction, or a pod KEDA deleted mid-init. 0 disables "
+            "the tolerance: without a settle there is no evidence the churn "
+            "stopped, so every FAILED verdict is honoured."
+        ),
     )
 
     p_verify = sub.add_parser("verify", help="assert the installed version")

--- a/.github/scripts/e2e_tenant_app.py
+++ b/.github/scripts/e2e_tenant_app.py
@@ -398,8 +398,13 @@ _UNHEALTHY_EVENT_MARKERS = (
 )
 
 #: kubectl's relative ``LAST SEEN`` column: ``9s``, ``2m``, ``5m1s``, ``3h59m``,
-#: ``2d``. ``<unknown>`` and the header's ``LAST`` match nothing, which is how an
-#: unaged line is told apart from a young one.
+#: ``2d``. Both regimes have to parse, because kubectl switches units at two
+#: minutes — seconds below it (``95s``), minutes and seconds above (``2m13s``) —
+#: and the settle window sits near that flip.
+#:
+#: ``<unknown>`` matches nothing, and so does ``LAST``: the header's first column
+#: is the TWO words ``LAST SEEN``, so its leading token is a word, not an age.
+#: That is what tells an unaged line apart from a young one.
 _EVENT_AGE_RE = re.compile(r"(?:(\d+)d)?(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?")
 
 #: Per-pod budget for the ``pod_describe`` render, and how many pods to print.
@@ -1703,13 +1708,26 @@ def _event_age_seconds(token: str) -> int | None:
 
 
 def ongoing_failures(events: str, window_seconds: int) -> list[str]:
-    """Event lines that say the namespace is STILL unhealthy, newest-first order.
+    """Event lines showing something failed again inside the last *window_seconds*.
 
-    "Still" is what the age column buys: the events behind the original verdict
-    age past ``window_seconds`` while we wait, so anything left inside the window
-    fired during the settle. A repeating warning keeps its ``LAST SEEN`` young,
-    which is exactly the case that must stay fatal — a platform container that
-    never recovers.
+    The age column is what buys "again": the events behind the original verdict
+    age past the window while we wait, so anything left inside it fired during
+    the settle. A repeating warning keeps its ``LAST SEEN`` young, which is
+    exactly the case that must stay fatal — a platform container that never
+    recovers.
+
+    Read the empty list precisely. It means "nothing failed again recently",
+    NOT "the namespace is healthy": a ONE-SHOT warning on a still-wedged pod
+    ages out of the window and takes the window quiet with it, and the incident's
+    own ``secret not found`` lines fired once per pod. That gap is why nothing
+    downstream may treat this as proof of health — the installed-version
+    read-back is the authority, it is unconditional, and a wrongly quiet window
+    only reaches it sooner.
+
+    The boundary is exclusive: an age of exactly ``window_seconds`` counts as
+    outside. kubectl also switches from seconds to minutes at two minutes, so
+    around a 90s window the same instant can arrive as ``95s`` or ``2m1s``;
+    both parse, and erring outside is the direction the read-back covers.
     """
     lines: list[str] = []
     for line in events.splitlines():
@@ -1777,15 +1795,24 @@ def _live_events(client: TenantClient, app_id: str, title: str) -> str | None:
 
 
 def _settle(client: TenantClient, app_id: str, seconds: int) -> list[str]:
-    """Wait, re-read the live events, and report what is still failing.
+    """Wait, re-read the live events, and report what failed again while we did.
 
     What makes the tolerance above safe: a platform container that genuinely
     never recovers keeps warning, and those warnings are what this returns.
 
-    The re-read is of the EVENTS, not the deployment status. LM's
+    The re-read is of the LIVE EVENTS, and of nothing else. LM's
     ``deployment_status`` is a terminal record — it never flips back to
-    SUCCEEDED — and its failure snapshot is frozen at the moment of failure, so
-    neither can say whether the namespace is well now. The live events can.
+    SUCCEEDED. Its failure snapshot cannot help either, and the reason is
+    stronger than "it does not change": the snapshot is **failure-triggered**, so
+    it can only ever depict a failure. Even a snapshot overwritten by a later
+    flap would depict that flap, never a recovery.
+
+    The snapshot's ``pod_events`` must also never reach :func:`ongoing_failures`.
+    Its ages are relative to its own capture moment, not to now — measured 8s
+    behind the live read on the FND-831 run, and unbounded in general — so the
+    same lines would read as young forever. The two sections have identical
+    shape, which makes that a one-line mistake; hence one function that reads
+    live events and one caller.
     """
     print(
         f"::notice::the FAILED verdict names only benign pod churn. Waiting "
@@ -1798,8 +1825,8 @@ def _settle(client: TenantClient, app_id: str, seconds: int) -> list[str]:
     )
     if events is None:
         return [
-            "the live-events read failed, so recovery could not be confirmed — "
-            "honouring LM's verdict rather than guessing"
+            "the live-events read failed, so nothing could be established either "
+            "way — honouring LM's verdict rather than guessing"
         ]
     return ongoing_failures(events, seconds)
 
@@ -1894,11 +1921,16 @@ def _tolerate_pod_churn(
     """Downgrade a FAILED verdict caused by benign pod churn, or re-raise it.
 
     Two conditions, both required (FND-831). The diagnostics have to NAME why the
-    unhealthy container is not the app under test, and the namespace then has to
-    be seen to stop failing. Naming alone is not enough — a platform container
-    that never recovers names the same reason forever — and settling alone is not
-    enough either, since an app that crash-loops slower than the window would
-    look calm.
+    unhealthy container is not the app under test, and nothing may then be seen
+    to fail again while we wait. Naming alone is not enough — a platform
+    container that never recovers names the same reason forever — and a quiet
+    window alone is not enough either, since an app that crash-loops slower than
+    the window, or fails once and stays wedged, would look calm.
+
+    Neither condition proves the app is healthy, and this function does not
+    claim it. It only establishes that LM's verdict is not evidence EITHER way,
+    which hands the decision to the installed-version read-back — unconditional,
+    direct, and the only positive evidence in the flow.
 
     Returns the reason, for the log lines and for the read-back's failure message.
     Never returns "": everything that is not tolerated leaves by ``raise``.
@@ -1910,21 +1942,22 @@ def _tolerate_pod_churn(
         print(
             f"::warning::the diagnostics name only benign pod churn ({reason}), "
             "but --settle-seconds is 0, so the verdict stands: without a settle "
-            "there is no evidence the churn stopped."
+            "there is nothing to say the churn stopped."
         )
         raise failure
     ongoing = _settle(client, app_id, settle_seconds)
     if ongoing:
         raise DeploymentFailed(
             f"{failure} The diagnostics named benign pod churn ({reason}), but "
-            f"the namespace was still failing {settle_seconds}s later, so the "
-            "verdict stands: " + " | ".join(ongoing[:5])
+            f"something failed again within {settle_seconds}s, so the verdict "
+            "stands: " + " | ".join(ongoing[:5])
         ) from failure
     print(
-        f"::warning::{failure} — but {reason}, and nothing in the namespace was "
-        f"still failing {settle_seconds}s later. LM's health check is "
+        f"::warning::{failure} — but {reason}, and nothing in the namespace "
+        f"failed again in the {settle_seconds}s after. LM's health check is "
         "namespace-scoped and its verdict is an instant, so pod churn the "
-        "platform caused reds an install that is fine. Falling through to the "
+        "platform caused reds an install that is fine. That is not a clean bill "
+        "of health, only the absence of a repeat: falling through to the "
         "installed-version read-back, which decides."
     )
     return reason
@@ -2127,7 +2160,7 @@ def install(args: argparse.Namespace) -> InstallOutcome:
     if churn:
         print(
             f"::notice::tenant serves {installed}; the FAILED verdict was benign "
-            f"pod churn ({churn}) and the namespace settled. Nothing to clean up "
+            f"pod churn ({churn}) that did not repeat. Nothing to clean up "
             "on the tenant, but the churn itself is worth removing at the "
             "platform: KEDA's initialCooldownPeriod would stop a scale-down "
             "racing a still-initialising pod."

--- a/.github/scripts/tests/test_e2e_tenant_app.py
+++ b/.github/scripts/tests/test_e2e_tenant_app.py
@@ -142,6 +142,10 @@ def _install_args(**overrides: object) -> argparse.Namespace:
         "publish_retry_seconds": 0,
         "install_retry_seconds": 0,
         "timeout_seconds": 600,
+        # The real default, not 0: `time.sleep` is stubbed above, so the settle
+        # costs nothing here, and 0 would disable the pod-churn tolerance
+        # altogether — every test of it would then be testing the wrong branch.
+        "settle_seconds": app.DEFAULT_SETTLE_SECONDS,
     }
     values.update(overrides)
     return argparse.Namespace(**values)
@@ -1815,6 +1819,822 @@ def test_a_timeout_is_never_downgraded(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_deployment_failed_is_a_tenant_app_error() -> None:
     # Callers catching TenantAppError (main(), the workflows) must keep working.
     assert issubclass(app.DeploymentFailed, app.TenantAppError)
+
+
+# ── Benign pod churn is not an install failure (FND-831) ─────────────────────
+# LM's health check is namespace-scoped AND its verdict is an instant: any pod
+# unhealthy at that moment reds the install, including one the platform itself
+# deleted on purpose. The first install onto a fresh GCP tenant failed in 45s
+# exactly that way — KEDA scaled the server deployment to zero while the
+# platform's `atlan-env-seeder` init container was still blocked on a Vault
+# secret whose name encodes the namespace and had not synced yet, so the pod was
+# SIGKILLed mid-init and left phase Failed. The workers recovered; the app was
+# fine.
+#
+# `foreign_failure` could not catch it: it reads pull-failure lines only, and
+# this run had none (`Normal Pulled`). So the tolerance below is by container
+# ownership and reason, and every clause has to name something positively — LM's
+# verdict stays authoritative by default in both directions that matter.
+
+
+@dataclass(frozen=True)
+class _Container:
+    """One container block of `kubectl describe pod`, rendered at real indents.
+
+    The indentation IS the schema the parser reads — container names at two
+    spaces, fields at four, sub-fields at six — so the fixtures render it rather
+    than hand the parser a shape kubectl never emits.
+    """
+
+    name: str
+    image: str
+    state: str = "Running"
+    reason: str = ""
+    exit_code: str = ""
+    last_state: str = ""
+    last_reason: str = ""
+    last_exit_code: str = ""
+    ready: bool = True
+
+    def render(self) -> str:
+        lines = [
+            f"  {self.name}:",
+            "    Container ID:   containerd://c0ffee",
+            f"    Image:          {self.image}",
+            # Present in real output and a trap: `Image ID:` must not be read as
+            # `Image:`, or every container looks digest-pinned.
+            f"    Image ID:       {self.image}@sha256:{'ab' * 32}",
+            f"    State:          {self.state}",
+        ]
+        if self.reason:
+            lines.append(f"      Reason:       {self.reason}")
+        if self.exit_code:
+            lines.append(f"      Exit Code:    {self.exit_code}")
+        if self.last_state:
+            lines.append(f"    Last State:     {self.last_state}")
+            if self.last_reason:
+                lines.append(f"      Reason:       {self.last_reason}")
+            if self.last_exit_code:
+                lines.append(f"      Exit Code:    {self.last_exit_code}")
+        lines.append(f"    Ready:          {self.ready}")
+        lines.append("    Restart Count:  0")
+        return "\n".join(lines)
+
+
+def _describe_pod(
+    name: str,
+    *,
+    status: str = "Running",
+    reason: str = "",
+    init: tuple[_Container, ...] = (),
+    containers: tuple[_Container, ...] = (),
+    padding: int = 0,
+) -> str:
+    """One `kubectl describe pod` block, optionally padded with tail detail.
+
+    `padding` stands in for the volumes/tolerations/events bulk a real block ends
+    with — the reason a budget shared across pods drops whichever pod comes
+    first.
+    """
+    lines = [
+        f"Name:             {name}",
+        "Namespace:        openapi-app",
+        f"Status:           {status}",
+    ]
+    if reason:
+        lines.append(f"Reason:           {reason}")
+    if init:
+        lines.append("Init Containers:")
+        lines.extend(c.render() for c in init)
+    if containers:
+        lines.append("Containers:")
+        lines.extend(c.render() for c in containers)
+    lines.extend(["Conditions:", "  Type           Status", "  Initialized    False"])
+    lines.extend(f"  volume detail {i}" for i in range(padding))
+    lines.extend(["Events:", "  <none>"])
+    return "\n".join(lines) + "\n"
+
+
+#: The platform's own init container. Its image is not ours, which is the whole
+#: discriminator — no allowlist of platform container names to keep current.
+_SEEDER_IMAGE = "ghcr.io/atlanhq/atlan-env-seeder:1.4.2"
+_FAILED_POD = "openapi-server-6b9f7d4c8-x7d2k"
+_HEALTHY_POD = "openapi-worker-7d5c9-aaaaa"
+
+_KILLED_SEEDER = _Container(
+    name="atlan-env-seeder",
+    image=_SEEDER_IMAGE,
+    state="Terminated",
+    reason="Error",
+    exit_code="137",
+    ready=False,
+)
+_DONE_SEEDER = _Container(
+    name="atlan-env-seeder",
+    image=_SEEDER_IMAGE,
+    state="Terminated",
+    reason="Completed",
+    exit_code="0",
+)
+_INITIALISING_APP = _Container(
+    name="openapi-server",
+    image=_IMAGE,
+    state="Waiting",
+    reason="PodInitializing",
+    ready=False,
+)
+_RUNNING_APP = _Container(name="openapi-worker", image=_IMAGE)
+
+#: The incident: a server pod SIGKILLed mid-init beside a worker that recovered.
+_CHURN_DESCRIBE = _describe_pod(
+    _FAILED_POD,
+    status="Failed",
+    init=(_KILLED_SEEDER,),
+    containers=(_INITIALISING_APP,),
+) + _describe_pod(_HEALTHY_POD, init=(_DONE_SEEDER,), containers=(_RUNNING_APP,))
+
+
+def _churn_events(age: str = "21s", deleted: str = _FAILED_POD) -> str:
+    """The events behind the incident, at a settable age.
+
+    `age` is what the settle turns on: the same lines read again after the wait
+    carry a bigger age, and anything still inside the window fired during it.
+    """
+    return (
+        "LAST SEEN   TYPE      REASON     OBJECT   MESSAGE\n"
+        f"{age}   Warning   Failed   pod/{_FAILED_POD}   "
+        'Error: secret "vault-app-creds-x" not found\n'
+        f"{age}   Normal    KEDAScaleTargetDeactivated   "
+        "scaledobject/openapi-server-scale   Deactivated apps/v1.Deployment "
+        "openapi-app/openapi-server\n"
+        f"{age}   Normal    SuccessfulDelete   "
+        f"replicaset/openapi-server-6b9f7d4c8   Deleted pod: {deleted}\n"
+    )
+
+
+# ── Reading `kubectl describe pod` ───────────────────────────────────────────
+
+
+def test_describe_is_parsed_into_pods_and_containers() -> None:
+    pods = app.parse_pod_describe(_CHURN_DESCRIBE)
+    assert [p.name for p in pods] == [_FAILED_POD, _HEALTHY_POD]
+
+    failed, healthy = pods
+    assert failed.phase == "Failed"
+    assert [(c.name, c.init) for c in failed.containers] == [
+        ("atlan-env-seeder", True),
+        ("openapi-server", False),
+    ]
+    seeder, server = failed.containers
+    # The whole point of parsing: which container, running which image.
+    assert seeder.image == _SEEDER_IMAGE
+    assert (seeder.state, seeder.reason, seeder.exit_code) == (
+        "Terminated",
+        "Error",
+        "137",
+    )
+    assert server.image == _IMAGE, (
+        "`Image ID:` must not be read as `Image:` — every container would look "
+        "digest-pinned and the ownership compare would stop discriminating"
+    )
+    assert app._pod_is_unhealthy(failed) and not app._pod_is_unhealthy(healthy)
+
+
+def test_a_pod_level_reason_is_not_read_as_a_containers() -> None:
+    """`Reason: Evicted` sits at column 0; a container's sits at six spaces."""
+    pods = app.parse_pod_describe(
+        _describe_pod(
+            _FAILED_POD,
+            status="Failed",
+            reason="Evicted",
+            containers=(
+                _Container(
+                    name="openapi-server",
+                    image=_IMAGE,
+                    state="Terminated",
+                    reason="Error",
+                    exit_code="1",
+                    ready=False,
+                ),
+            ),
+        )
+    )
+    assert pods[0].reason == "Evicted"
+    assert pods[0].containers[0].reason == "Error"
+
+
+def test_last_state_subfields_are_not_attributed_to_the_current_state() -> None:
+    """A restarted container carries two reasons and two exit codes.
+
+    Merging them loses the OOM guard: a container Waiting in CrashLoopBackOff
+    whose LAST state was OOMKilled must keep its 137 fatal.
+    """
+    container = _Container(
+        name="openapi-server",
+        image=_IMAGE,
+        state="Waiting",
+        reason="CrashLoopBackOff",
+        last_state="Terminated",
+        last_reason="OOMKilled",
+        last_exit_code="137",
+        ready=False,
+    )
+    parsed = app.parse_pod_describe(
+        _describe_pod(_FAILED_POD, status="Failed", containers=(container,))
+    )[0].containers[0]
+    assert (parsed.state, parsed.reason, parsed.exit_code) == (
+        "Waiting",
+        "CrashLoopBackOff",
+        "",
+    )
+    assert (parsed.last_state, parsed.last_reason, parsed.last_exit_code) == (
+        "Terminated",
+        "OOMKilled",
+        "137",
+    )
+
+
+def test_text_before_the_first_pod_is_kept_not_dropped() -> None:
+    """The renderer prints what it parses, so nothing may be lost in parsing."""
+    pods = app.parse_pod_describe(
+        "kubectl: warning about something\n" + _CHURN_DESCRIBE
+    )
+    assert [p.name for p in pods] == ["", _FAILED_POD, _HEALTHY_POD]
+    assert "kubectl: warning" in "\n".join(pods[0].lines)
+    assert not app._pod_is_unhealthy(pods[0])
+
+
+def test_events_text_yields_no_containers() -> None:
+    """The classifier is handed the WHOLE diagnostics blob, most of it events.
+
+    Kept as an unnamed block rather than dropped — a section that vanishes from
+    the dump is the failure mode this parser also exists to fix — but it must
+    contribute no containers, or event text would start excusing things.
+    """
+    pods = app.parse_pod_describe(_churn_events())
+    assert [p.name for p in pods] == [""]
+    assert pods[0].containers == []
+
+
+@pytest.mark.parametrize(
+    "container,unhealthy",
+    [
+        (_RUNNING_APP, False),
+        (_DONE_SEEDER, False),
+        (_INITIALISING_APP, False),
+        (_KILLED_SEEDER, True),
+        (
+            _Container(
+                name="c",
+                image=_IMAGE,
+                state="Waiting",
+                reason="ContainerCreating",
+                ready=False,
+            ),
+            False,
+        ),
+        (
+            _Container(
+                name="c",
+                image=_IMAGE,
+                state="Waiting",
+                reason="CreateContainerConfigError",
+                ready=False,
+            ),
+            True,
+        ),
+        (
+            _Container(
+                name="c",
+                image=_IMAGE,
+                state="Terminated",
+                reason="Completed",
+                exit_code="1",
+                ready=False,
+            ),
+            True,
+        ),
+        # Not-ready on its own is not a failure: with KEDA scale-to-zero an app's
+        # steady state is no pods at all, and a finished init container is
+        # terminated. A Ready assertion would be wrong at least as often as it
+        # helped, which is why it is not the test.
+        (_Container(name="c", image=_IMAGE, state="Running", ready=False), False),
+    ],
+)
+def test_container_health(container: _Container, unhealthy: bool) -> None:
+    parsed = app.parse_pod_describe(_describe_pod("p", containers=(container,)))[
+        0
+    ].containers[0]
+    assert app._container_is_unhealthy(parsed) is unhealthy
+
+
+# ── (1) Container ownership ──────────────────────────────────────────────────
+
+
+def test_a_platform_injected_container_is_not_evidence_about_the_app() -> None:
+    """The incident. The failing container is not running the image under test.
+
+    Inverted rather than an allowlist of platform container names: the container
+    under test is the one running the image we published, and every other
+    container in the pod came from the platform's pod template. Nothing to keep
+    current when the platform renames or adds one.
+    """
+    reason = app.benign_pod_failure(_CHURN_DESCRIBE + _churn_events(), _IMAGE)
+    assert "atlan-env-seeder" in reason
+    assert _SEEDER_IMAGE in reason
+    assert app.foreign_failure(_CHURN_DESCRIBE + _churn_events(), _IMAGE) == [], (
+        "no pull failure here (`Normal Pulled`), which is why the existing "
+        "escape hatch could not catch this and this one had to exist"
+    )
+
+
+def test_an_unreadable_container_image_is_not_excused() -> None:
+    """The misread that must never happen: "not ours, so ignore it".
+
+    An absent `Image:` is not evidence the container belongs to the platform, so
+    it falls through to the reason classifier instead of being waved past.
+    """
+    describe = _describe_pod(
+        _FAILED_POD,
+        status="Failed",
+        containers=(
+            _Container(
+                name="openapi-server",
+                image="",
+                state="Terminated",
+                reason="Error",
+                exit_code="1",
+                ready=False,
+            ),
+        ),
+    )
+    assert app.parse_pod_describe(describe)[0].containers[0].image == ""
+    assert app.benign_pod_failure(describe, _IMAGE) == ""
+
+
+def test_our_own_container_failing_is_never_benign() -> None:
+    """A crash-looping app container is exactly what this check exists to catch."""
+    describe = _describe_pod(
+        _FAILED_POD,
+        status="Failed",
+        init=(_DONE_SEEDER,),
+        containers=(
+            _Container(
+                name="openapi-server",
+                image=_IMAGE,
+                state="Waiting",
+                reason="CrashLoopBackOff",
+                last_state="Terminated",
+                last_reason="Error",
+                last_exit_code="1",
+                ready=False,
+            ),
+        ),
+    )
+    assert app.benign_pod_failure(describe + _churn_events(), _IMAGE) == ""
+
+
+def test_one_unexcused_container_makes_the_whole_verdict_fatal() -> None:
+    """A real breakage usually sits ALONGSIDE benign churn, not instead of it."""
+    broken = _describe_pod(
+        "openapi-worker-broken",
+        status="Failed",
+        containers=(
+            _Container(
+                name="openapi-worker",
+                image=_IMAGE,
+                state="Waiting",
+                reason="CrashLoopBackOff",
+                ready=False,
+            ),
+        ),
+    )
+    assert (
+        app.benign_pod_failure(_CHURN_DESCRIBE + broken + _churn_events(), _IMAGE) == ""
+    )
+
+
+def test_a_digest_pinned_app_container_is_still_ours() -> None:
+    """The pod spec can name the image at a different resolution than --image.
+
+    Reading that as a platform container would excuse a genuinely broken app —
+    so the ownership test reuses the deliberately ours-biased image compare.
+    """
+    digest = f"{_IMAGE.rpartition(':')[0]}@sha256:{'a1' * 32}"
+    describe = _describe_pod(
+        _FAILED_POD,
+        status="Failed",
+        containers=(
+            _Container(
+                name="openapi-server",
+                image=digest,
+                state="Waiting",
+                reason="CrashLoopBackOff",
+                ready=False,
+            ),
+        ),
+    )
+    assert app._is_our_image(digest, _IMAGE)
+    assert app.benign_pod_failure(describe, _IMAGE) == ""
+
+
+# ── (3) The reason classifier ────────────────────────────────────────────────
+
+
+def test_a_config_error_on_our_own_container_is_excused() -> None:
+    """The kubelet could not assemble the container, so the image never ran.
+
+    Same slow secret sync as the incident, landing on the app's own container
+    rather than the platform's init container — the shape the window reopens in
+    on the first install of each new app to a tenant.
+    """
+    describe = _describe_pod(
+        _FAILED_POD,
+        status="Failed",
+        containers=(
+            _Container(
+                name="openapi-server",
+                image=_IMAGE,
+                state="Waiting",
+                reason="CreateContainerConfigError",
+                ready=False,
+            ),
+        ),
+    )
+    reason = app.benign_pod_failure(describe, _IMAGE)
+    assert "createcontainerconfigerror" in reason.lower()
+
+
+def test_an_evicted_pod_is_excused() -> None:
+    describe = _describe_pod(
+        _FAILED_POD,
+        status="Failed",
+        reason="Evicted",
+        containers=(
+            _Container(
+                name="openapi-server",
+                image=_IMAGE,
+                state="Terminated",
+                reason="Error",
+                exit_code="1",
+                ready=False,
+            ),
+        ),
+    )
+    assert "Evicted" in app.benign_pod_failure(describe, _IMAGE)
+
+
+def test_a_scale_down_kill_of_our_own_container_needs_the_events_to_name_it() -> None:
+    """Exit 137 is ambiguous, so the excuse rests on named causal evidence.
+
+    Both halves required: KEDA deactivating the ScaledObject, AND a delete event
+    naming THIS pod. The second is what makes it causal rather than a timestamp
+    correlation with whatever else the namespace was doing.
+    """
+    describe = _describe_pod(
+        _FAILED_POD,
+        status="Failed",
+        containers=(
+            _Container(
+                name="openapi-server",
+                image=_IMAGE,
+                state="Terminated",
+                reason="Error",
+                exit_code="137",
+                ready=False,
+            ),
+        ),
+    )
+    assert "SIGKILL" in app.benign_pod_failure(describe + _churn_events(), _IMAGE)
+    # The delete names a DIFFERENT pod: no evidence about this one.
+    assert (
+        app.benign_pod_failure(
+            describe + _churn_events(deleted="openapi-server-older-zzzzz"), _IMAGE
+        )
+        == ""
+    )
+    # KEDA never deactivated anything: a 137 with no scale-down behind it.
+    assert app.benign_pod_failure(describe, _IMAGE) == ""
+
+
+def test_an_oom_kill_stays_fatal_even_with_a_scale_down_in_the_events() -> None:
+    """A genuine OOM exits 137 too, and says so.
+
+    Excusing it would hide the one app-image failure this exit code is most
+    likely to mean.
+    """
+    describe = _describe_pod(
+        _FAILED_POD,
+        status="Failed",
+        containers=(
+            _Container(
+                name="openapi-server",
+                image=_IMAGE,
+                state="Waiting",
+                reason="CrashLoopBackOff",
+                last_state="Terminated",
+                last_reason="OOMKilled",
+                last_exit_code="137",
+                ready=False,
+            ),
+        ),
+    )
+    assert app.benign_pod_failure(describe + _churn_events(), _IMAGE) == ""
+
+
+def test_unreadable_diagnostics_are_never_benign() -> None:
+    """No parsed unhealthy container is NOT evidence of health.
+
+    The dangerous inversion: a 404 on the snapshot leaves the classifier with
+    nothing to read, and "nothing unhealthy found" would then make every FAILED
+    verdict tolerable.
+    """
+    for text in ("", "deployment failed", "Pods failed in namespace openapi-app"):
+        assert app.benign_pod_failure(text, _IMAGE) == ""
+    # A healthy-looking describe with no unhealthy container is the same case:
+    # LM saw something we cannot, so its verdict stands.
+    assert (
+        app.benign_pod_failure(
+            _describe_pod(
+                _HEALTHY_POD, init=(_DONE_SEEDER,), containers=(_RUNNING_APP,)
+            ),
+            _IMAGE,
+        )
+        == ""
+    )
+
+
+# ── (2) Settling before honouring the verdict ────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "token,seconds",
+    [
+        ("9s", 9),
+        ("2m", 120),
+        ("5m1s", 301),
+        ("3h59m", 14340),
+        ("2d", 172800),
+        ("LAST", None),
+        ("<unknown>", None),
+        ("", None),
+        ("pod/openapi-0", None),
+    ],
+)
+def test_event_age_parsing(token: str, seconds: int | None) -> None:
+    assert app._event_age_seconds(token) == seconds
+
+
+def test_the_settle_window_is_what_tells_churn_from_a_stuck_platform() -> None:
+    """The same lines, read twice: young means still failing, old means settled."""
+    assert app.ongoing_failures(_churn_events(age="21s"), 90) != []
+    assert app.ongoing_failures(_churn_events(age="2m21s"), 90) == []
+    # The header row carries no age and must never read as young.
+    assert (
+        app.ongoing_failures("LAST SEEN   TYPE      REASON   OBJECT   MESSAGE\n", 90)
+        == []
+    )
+    # A Normal event inside the window is not a failure.
+    assert (
+        app.ongoing_failures(
+            "3s   Normal   Pulled   pod/openapi-0   Successfully pulled image\n", 90
+        )
+        == []
+    )
+
+
+def test_a_repeating_warning_keeps_the_verdict(monkeypatch: pytest.MonkeyPatch) -> None:
+    """What makes the tolerance safe: a platform container that never recovers.
+
+    Its `LAST SEEN` stays young because the event keeps re-firing, so the settle
+    sees it and the verdict stands.
+    """
+    transport = _wire(
+        monkeypatch,
+        StubTransport(
+            routes=[
+                StubRoute("GET", "/events", _ok({"events": _churn_events(age="4s")}))
+            ]
+        ),
+    )
+    still = app._settle(TenantClient(base_url=_TENANT, bearer="t"), _APP_ID, 90)
+    assert still and "vault-app-creds" in still[0]
+    assert transport.paths("GET") == [app.APP_EVENTS_PATH.format(app_id=_APP_ID)], (
+        "the settle must re-read the EVENTS: LM's deployment_status is a terminal "
+        "record and its failure snapshot is frozen, so neither can say the "
+        "namespace is well now"
+    )
+
+
+def test_an_unreadable_settle_read_honours_the_verdict(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A read that failed is not a namespace that recovered."""
+    _wire(
+        monkeypatch,
+        StubTransport(routes=[StubRoute("GET", "/events", Response(503, {}))]),
+    )
+    still = app._settle(TenantClient(base_url=_TENANT, bearer="t"), _APP_ID, 90)
+    assert still and "could not be confirmed" in still[0]
+
+
+# ── End to end through install() ─────────────────────────────────────────────
+
+
+def _churn_routes(
+    *,
+    settled_events: str,
+    installed: str = _VERSION,
+    describe: str = _CHURN_DESCRIBE,
+) -> StubTransport:
+    return StubTransport(
+        routes=[
+            StubRoute("GET", "/info", Response(404, {})),
+            StubRoute("POST", "/marketplace/publish", _ok({"version_id": "v1"})),
+            StubRoute("POST", "/install", _ok({"deployment_id": "d1"})),
+            StubRoute(
+                "GET",
+                "/deployments/",
+                _ok(
+                    {
+                        "deployment_status": "FAILED",
+                        "message": (
+                            f"Pods failed in namespace openapi-app: {_FAILED_POD}"
+                        ),
+                    }
+                ),
+            ),
+            StubRoute(
+                "GET",
+                "/failure",
+                _snapshot_response(
+                    failure_reason="HelmRelease not ready",
+                    pod_events=_churn_events(),
+                    pod_describe=describe,
+                ),
+            ),
+            # The live read inside _dump_failure, then the settle's re-read.
+            StubRoute("GET", "/events", _ok({"events": _churn_events()})),
+            StubRoute("GET", "/events", _ok({"events": settled_events})),
+            StubRoute("GET", "/info", _ok({"version": installed})),
+        ],
+        sticky=[StubRoute("GET", "/releases/", Response(404, {}))],
+    )
+
+
+def test_benign_churn_passes_once_the_namespace_settles(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The FND-831 run, end to end: 45s red becomes a warning and a green leg."""
+    _wire(monkeypatch, _churn_routes(settled_events=_churn_events(age="4m")))
+    outcome = app.install(_install_args())
+    assert outcome.installed_version == _VERSION
+    out = capsys.readouterr().out
+    # On the ::warning:: line itself: `atlan-env-seeder` also appears in the
+    # echoed describe, so a whole-output check would pass on a silent downgrade.
+    assert any(
+        "::warning::" in line and "atlan-env-seeder" in line
+        for line in out.splitlines()
+    )
+    assert "settled" in out
+
+
+def test_churn_that_never_settles_still_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The platform container that genuinely never recovers.
+
+    Same diagnostics, same excuse — and the verdict stands anyway, because the
+    namespace is still warning after the wait. This is what makes rule (1) safe
+    rather than a blanket "ignore init containers".
+    """
+    _wire(monkeypatch, _churn_routes(settled_events=_churn_events(age="6s")))
+    with pytest.raises(app.DeploymentFailed, match="still failing"):
+        app.install(_install_args())
+
+
+def test_settling_does_not_replace_the_version_readback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Downgrading the verdict moves the decision to direct evidence, not past it."""
+    _wire(
+        monkeypatch,
+        _churn_routes(settled_events=_churn_events(age="4m"), installed="older"),
+    )
+    with pytest.raises(app.TenantAppError, match="cannot be confirmed") as caught:
+        app.install(_install_args())
+    assert "benign pod churn" in str(caught.value), (
+        "the read-back failure has to say the verdict was downgraded, or the "
+        "reader chases a version mismatch with no idea a pod also died"
+    )
+
+
+def test_settle_seconds_zero_honours_every_verdict(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The off switch is safe by construction: no settle, no tolerance."""
+    _wire(monkeypatch, _churn_routes(settled_events=_churn_events(age="4m")))
+    with pytest.raises(app.DeploymentFailed):
+        app.install(_install_args(settle_seconds=0))
+    assert "--settle-seconds is 0" in capsys.readouterr().out
+
+
+def test_the_orphan_path_is_unchanged_by_the_churn_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A pull failure on a foreign image must not be routed through the settle.
+
+    `foreign_failure` has positive evidence already and costs no wait, so it
+    keeps precedence — and the churn path must not consume the settle's stubbed
+    events read, which is what a wrong ordering would show up as.
+    """
+    transport = _wire(
+        monkeypatch,
+        StubTransport(
+            routes=[
+                StubRoute("GET", "/info", Response(404, {})),
+                StubRoute("POST", "/marketplace/publish", _ok({"version_id": "v1"})),
+                StubRoute("POST", "/install", _ok({"deployment_id": "d1"})),
+                StubRoute("GET", "/deployments/", _ok({"deployment_status": "FAILED"})),
+                StubRoute("GET", "/failure", Response(404, {})),
+                StubRoute("GET", "/events", _ok({"events": _ORPHAN_EVENTS})),
+                StubRoute("GET", "/info", _ok({"version": _VERSION})),
+            ],
+            sticky=[StubRoute("GET", "/releases/", Response(404, {}))],
+        ),
+    )
+    assert app.install(_install_args()).installed_version == _VERSION
+    assert (
+        sum("/events" in p for p in transport.paths("GET")) == 1
+    ), "the orphan path must not settle: it has its own positive evidence"
+
+
+# ── The failing pod has to survive the print budget ──────────────────────────
+
+
+def test_the_failing_pod_survives_a_healthy_pods_bulk(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """What made FND-831's own item (1) unverifiable from its CI log.
+
+    `pod_describe` printed as "tail 200 of 542 lines" and the only pod that
+    failed the install was in the dropped head, so the visible evidence was two
+    healthy workers. A budget per pod cannot let one pod crowd out another, and
+    unhealthy-first spends the pod budget on the pods that failed.
+    """
+    describe = _describe_pod(
+        _FAILED_POD,
+        status="Failed",
+        init=(_KILLED_SEEDER,),
+        containers=(_INITIALISING_APP,),
+    ) + _describe_pod(
+        _HEALTHY_POD, init=(_DONE_SEEDER,), containers=(_RUNNING_APP,), padding=400
+    )
+    _dump(
+        monkeypatch,
+        StubRoute("GET", "/failure", _snapshot_response(pod_describe=describe)),
+        StubRoute("GET", "/events", _ok({"events": ""})),
+    )
+    out = capsys.readouterr().out
+    assert f"pod_describe: {_FAILED_POD} — UNHEALTHY" in out
+    assert "Exit Code:    137" in out, (
+        "the failing container's own state is the evidence rule (1) turns on; "
+        "printing 400 lines of a healthy pod instead is how it got lost"
+    )
+    assert out.index(_FAILED_POD) < out.index(
+        _HEALTHY_POD
+    ), "unhealthy pods first, or the pod budget spends itself on healthy ones"
+
+
+def test_an_unparseable_describe_is_still_printed_whole(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Never silently drop a section the parser did not recognise."""
+    _dump(
+        monkeypatch,
+        StubRoute(
+            "GET", "/failure", _snapshot_response(pod_describe="something unexpected")
+        ),
+        StubRoute("GET", "/events", _ok({"events": ""})),
+    )
+    out = capsys.readouterr().out
+    assert "--- pod_describe" in out and "something unexpected" in out
+
+
+def test_only_so_many_pods_are_printed_and_the_rest_are_named(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A budget that drops pods silently reads as "that was all of them"."""
+    describe = "".join(
+        _describe_pod(f"openapi-worker-{i}", containers=(_RUNNING_APP,))
+        for i in range(app._DESCRIBE_MAX_PODS + 2)
+    )
+    _dump(
+        monkeypatch,
+        StubRoute("GET", "/failure", _snapshot_response(pod_describe=describe)),
+        StubRoute("GET", "/events", _ok({"events": ""})),
+    )
+    out = capsys.readouterr().out
+    assert "2 further pod(s) not printed" in out
+    assert "openapi-worker-7" in out
 
 
 # ── "unknown" is not a version ───────────────────────────────────────────────

--- a/.github/scripts/tests/test_e2e_tenant_app.py
+++ b/.github/scripts/tests/test_e2e_tenant_app.py
@@ -2420,10 +2420,17 @@ def test_the_window_boundary_is_exclusive_across_the_unit_flip(
 ) -> None:
     """Which side of a 90s window each rendering falls on, pinned deliberately.
 
-    kubectl prints seconds below two minutes and minutes above, so the same
-    instant can arrive either way near this boundary. Exactly-at-the-window
-    counts as outside: erring that way hands the decision to the version
-    read-back, which is unconditional, rather than reding a leg on a rounding.
+    Exactly-at-the-window counts as outside. That leniency is safe because the
+    settle only ever gates a DOWNGRADE — an unrecognised reason never reaches
+    this comparison at all — so erring outside hands the decision to the
+    unconditional version read-back, while erring inside would red a healthy leg
+    on a rounding.
+
+    Both renderings are covered because kubectl's `duration.HumanDuration`
+    branches on `seconds < 60*2`: the seconds form holds to 120s, so at the
+    current 90s window `2m` and `2m1s` are outside-the-window cases rather than
+    boundary ones. A settle raised past 120 makes them the common case; see
+    `DEFAULT_SETTLE_SECONDS` for why that is worth knowing first.
     """
     events = f"{age}   Warning   Failed   pod/openapi-0   Error: something\n"
     assert bool(app.ongoing_failures(events, 90)) is inside

--- a/.github/scripts/tests/test_e2e_tenant_app.py
+++ b/.github/scripts/tests/test_e2e_tenant_app.py
@@ -2371,11 +2371,19 @@ def test_unreadable_diagnostics_are_never_benign() -> None:
     "token,seconds",
     [
         ("9s", 9),
+        # kubectl switches units at two minutes: seconds below it, minutes above.
+        # The settle window sits near that flip, so both regimes have to parse or
+        # the boundary silently loses resolution.
+        ("95s", 95),
         ("2m", 120),
+        ("2m1s", 121),
         ("5m1s", 301),
         ("3h59m", 14340),
         ("2d", 172800),
+        # The header's first column is the TWO words `LAST SEEN`, so its leading
+        # token is a word. Neither it nor an unaged row may read as young.
         ("LAST", None),
+        ("SEEN", None),
         ("<unknown>", None),
         ("", None),
         ("pod/openapi-0", None),
@@ -2386,10 +2394,10 @@ def test_event_age_parsing(token: str, seconds: int | None) -> None:
 
 
 def test_the_settle_window_is_what_tells_churn_from_a_stuck_platform() -> None:
-    """The same lines, read twice: young means still failing, old means settled."""
+    """The same lines, read twice: young means it failed again, old means quiet."""
     assert app.ongoing_failures(_churn_events(age="21s"), 90) != []
     assert app.ongoing_failures(_churn_events(age="2m21s"), 90) == []
-    # The header row carries no age and must never read as young.
+    # The two-word header row carries no age and must never read as young.
     assert (
         app.ongoing_failures("LAST SEEN   TYPE      REASON   OBJECT   MESSAGE\n", 90)
         == []
@@ -2401,6 +2409,24 @@ def test_the_settle_window_is_what_tells_churn_from_a_stuck_platform() -> None:
         )
         == []
     )
+
+
+@pytest.mark.parametrize(
+    "age,inside",
+    [("89s", True), ("90s", False), ("91s", False), ("2m", False), ("2m1s", False)],
+)
+def test_the_window_boundary_is_exclusive_across_the_unit_flip(
+    age: str, inside: bool
+) -> None:
+    """Which side of a 90s window each rendering falls on, pinned deliberately.
+
+    kubectl prints seconds below two minutes and minutes above, so the same
+    instant can arrive either way near this boundary. Exactly-at-the-window
+    counts as outside: erring that way hands the decision to the version
+    read-back, which is unconditional, rather than reding a leg on a rounding.
+    """
+    events = f"{age}   Warning   Failed   pod/openapi-0   Error: something\n"
+    assert bool(app.ongoing_failures(events, 90)) is inside
 
 
 def test_a_repeating_warning_keeps_the_verdict(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -2435,7 +2461,7 @@ def test_an_unreadable_settle_read_honours_the_verdict(
         StubTransport(routes=[StubRoute("GET", "/events", Response(503, {}))]),
     )
     still = app._settle(TenantClient(base_url=_TENANT, bearer="t"), _APP_ID, 90)
-    assert still and "could not be confirmed" in still[0]
+    assert still and "nothing could be established" in still[0]
 
 
 # ── End to end through install() ─────────────────────────────────────────────
@@ -2446,6 +2472,8 @@ def _churn_routes(
     settled_events: str,
     installed: str = _VERSION,
     describe: str = _CHURN_DESCRIBE,
+    snapshot_events: str | None = None,
+    live_events: str | None = None,
 ) -> StubTransport:
     return StubTransport(
         routes=[
@@ -2469,12 +2497,20 @@ def _churn_routes(
                 "/failure",
                 _snapshot_response(
                     failure_reason="HelmRelease not ready",
-                    pod_events=_churn_events(),
+                    pod_events=(
+                        _churn_events() if snapshot_events is None else snapshot_events
+                    ),
                     pod_describe=describe,
                 ),
             ),
             # The live read inside _dump_failure, then the settle's re-read.
-            StubRoute("GET", "/events", _ok({"events": _churn_events()})),
+            StubRoute(
+                "GET",
+                "/events",
+                _ok(
+                    {"events": _churn_events() if live_events is None else live_events}
+                ),
+            ),
             StubRoute("GET", "/events", _ok({"events": settled_events})),
             StubRoute("GET", "/info", _ok({"version": installed})),
         ],
@@ -2496,7 +2532,36 @@ def test_benign_churn_passes_once_the_namespace_settles(
         "::warning::" in line and "atlan-env-seeder" in line
         for line in out.splitlines()
     )
-    assert "settled" in out
+    assert "not a clean bill of health" in out, (
+        "the tolerance establishes that LM's verdict is not evidence either way, "
+        "not that the app is well — a one-shot warning on a wedged pod ages out "
+        "of the window too. Promise the stronger thing and the next change will "
+        "be built on it"
+    )
+
+
+def test_only_the_settles_own_read_reaches_the_age_window(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The snapshot's `pod_events` must never be measured against the window.
+
+    Its ages are relative to its own capture moment, not to now — measured 8s
+    behind the live read on the FND-831 run, and unbounded in general — so the
+    same lines would read as young forever and no install could ever settle.
+    The two sections have identical shape, which makes that a one-line mistake.
+
+    Here both the snapshot and the at-failure live read are 1s old while the
+    settle's own re-read is quiet: only a leak from either could red this.
+    """
+    _wire(
+        monkeypatch,
+        _churn_routes(
+            snapshot_events=_churn_events(age="1s"),
+            live_events=_churn_events(age="1s"),
+            settled_events=_churn_events(age="4m"),
+        ),
+    )
+    assert app.install(_install_args()).installed_version == _VERSION
 
 
 def test_churn_that_never_settles_still_fails(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -2507,7 +2572,7 @@ def test_churn_that_never_settles_still_fails(monkeypatch: pytest.MonkeyPatch) -
     rather than a blanket "ignore init containers".
     """
     _wire(monkeypatch, _churn_routes(settled_events=_churn_events(age="6s")))
-    with pytest.raises(app.DeploymentFailed, match="still failing"):
+    with pytest.raises(app.DeploymentFailed, match="failed again within 90s"):
         app.install(_install_args())
 
 

--- a/.github/scripts/tests/test_e2e_tenant_app.py
+++ b/.github/scripts/tests/test_e2e_tenant_app.py
@@ -2265,6 +2265,84 @@ def test_a_config_error_on_our_own_container_is_excused() -> None:
     assert "createcontainerconfigerror" in reason.lower()
 
 
+def _config_error_describe(reason: str, image: str = _IMAGE) -> str:
+    return _describe_pod(
+        _FAILED_POD,
+        status="Failed",
+        containers=(
+            _Container(
+                name="openapi-server",
+                image=image,
+                state="Waiting",
+                reason=reason,
+                ready=False,
+            ),
+        ),
+    )
+
+
+def test_plain_create_container_error_on_our_image_stays_fatal() -> None:
+    """`CreateContainerError` is NOT `CreateContainerConfigError`.
+
+    The kubelet sets `…ConfigError` while *generating* the config — a missing
+    Secret or ConfigMap, the FND-831 shape — and plain `CreateContainerError`
+    afterwards, when the CRI `CreateContainer` call fails: a bad security
+    context, a volume or device the app's chart asked for, an image that cannot
+    be instantiated. Those are app faults.
+
+    Excusing it would reopen the hatch through the one gap the rest of it closes:
+    a one-shot reason ages out of the settle window, and the version read-back
+    confirms what was INSTALLED rather than that it runs (LM records the install,
+    and with scale-to-zero "no running pod" looks normal), so prepare-tenant
+    would go green on an app image that cannot start.
+    """
+    assert (
+        app.benign_pod_failure(_config_error_describe("CreateContainerError"), _IMAGE)
+        == ""
+    )
+    # The narrowing must not have cost us the reason it exists for.
+    assert app.benign_pod_failure(
+        _config_error_describe("CreateContainerConfigError"), _IMAGE
+    )
+
+
+def test_create_container_error_on_a_platform_container_is_still_excused() -> None:
+    """The narrowing is about OUR container only.
+
+    Rule (1) decides ownership before any reason is consulted, so a platform
+    container failing this way is excused for the same reason it always was — the
+    app can neither cause nor fix it. Over-correcting into "this reason is always
+    fatal" would red a leg on a platform fault.
+    """
+    assert app.benign_pod_failure(
+        _config_error_describe("CreateContainerError", image=_SEEDER_IMAGE), _IMAGE
+    )
+
+
+def test_an_unexcused_reason_stays_fatal_through_install(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End to end, because the unit answer is only half the guard.
+
+    `benign_pod_failure` returning "" has to reach a raise rather than a quiet
+    fall-through, and it must do so BEFORE the settle — an unrecognised reason
+    never gets a window to age out of.
+    """
+    transport = _wire(
+        monkeypatch,
+        _churn_routes(
+            describe=_config_error_describe("CreateContainerError"),
+            settled_events=_churn_events(age="4m"),
+        ),
+    )
+    with pytest.raises(app.DeploymentFailed):
+        app.install(_install_args())
+    assert sum("/events" in p for p in transport.paths("GET")) == 1, (
+        "an unrecognised reason must not reach the settle: it is fatal either "
+        "way, and a window it can age out of is a window it can pass through"
+    )
+
+
 def test_an_evicted_pod_is_excused() -> None:
     describe = _describe_pod(
         _FAILED_POD,

--- a/.github/scripts/tests/test_prepare_tenant_wiring.py
+++ b/.github/scripts/tests/test_prepare_tenant_wiring.py
@@ -974,10 +974,11 @@ def test_job_timeout_stays_above_the_scripts_own_waits(jobs: dict) -> None:  # t
     """The runner's timeout must not be able to fire before the script's.
 
     The publish retries while the marketplace service is not answering, then the
-    install retries while LM's catalog snapshot catches up, then the deployment
-    is polled — all three bounded by the script's defaults, since the step
-    overrides none of them. They are sequential in the worst case, so the budget
-    is their sum. If the job budget is under it, a slow sync reports as a bare
+    install retries while LM's catalog snapshot catches up, the deployment is
+    polled, and a FAILED verdict that names only benign pod churn then settles —
+    all four bounded by the script's defaults, since the step overrides none of
+    them. They are sequential in the worst case, so the budget is their sum. If
+    the job budget is under it, a slow sync reports as a bare
     "job cancelled after Nm" and the actionable error the script was about to
     print is never written: the diagnosis-hostile failure this whole job exists to
     avoid. Derived from the script's constants, so raising one of those fails here
@@ -987,6 +988,7 @@ def test_job_timeout_stays_above_the_scripts_own_waits(jobs: dict) -> None:  # t
         app.DEFAULT_PUBLISH_RETRY_SECONDS
         + app.DEFAULT_INSTALL_RETRY_SECONDS
         + app.DEFAULT_DEPLOYMENT_TIMEOUT_SECONDS
+        + app.DEFAULT_SETTLE_SECONDS
     ) // 60
     required = round(waits / _MAX_WAIT_SHARE)
     actual = jobs["prepare-tenant"]["timeout-minutes"]
@@ -1005,6 +1007,7 @@ def test_job_timeout_stays_above_the_scripts_own_waits(jobs: dict) -> None:  # t
         "--publish-retry-seconds",
         "--install-retry-seconds",
         "--timeout-seconds",
+        "--settle-seconds",
     ):
         assert flag not in install["run"], (
             f"the step now passes {flag}, so the budget above is no longer the "

--- a/.github/workflows/tests-reusable.yaml
+++ b/.github/workflows/tests-reusable.yaml
@@ -1626,15 +1626,20 @@ jobs:
     runs-on: ubuntu-latest
     # Twice the script's own waits, not a shade over them: the publish retries for
     # up to ~240s while the marketplace service is not answering, the install
-    # retries for up to ~600s while LM's catalog snapshot catches up, then the
-    # deployment is polled for up to ~600s. Set too tight, the runner's timeout
+    # retries for up to ~600s while LM's catalog snapshot catches up, the
+    # deployment is polled for up to ~600s, and a FAILED verdict that names only
+    # benign pod churn then settles for ~90s. Set too tight, the runner's timeout
     # fires first on a slow sync and a bare "job cancelled after Nm" replaces the
     # actionable error the script was about to print — the diagnosis-hostile
     # failure this job exists to avoid. This is a ceiling, not a spend: the job
     # finishes in a handful of minutes whenever the tenants are healthy.
     # test_job_timeout_stays_above_the_scripts_own_waits derives the floor from
     # the script's constants, so this cannot drift below them unnoticed.
-    timeout-minutes: 48
+    #
+    # 48 → 50 for the FND-831 settle. The lease TTL still clears the hold this
+    # is half of (1.5 × (50 + 120) min < 16200s), so it needs no change; at 60
+    # it would.
+    timeout-minutes: 50
     concurrency:
       # Run-unique, i.e. deliberately NOT a serialising group. Tenant exclusion
       # is the lease's job now (lease-tenant above), and the lease is strictly

--- a/docs/standards/connector-ci-e2e.md
+++ b/docs/standards/connector-ci-e2e.md
@@ -417,17 +417,24 @@ The pull-failure reading above cannot catch that — there was no pull failure
   shutdown, or exit 137 where the events *name this pod's* deletion
   (`KEDAScaleTargetDeactivated` **and** `Deleted pod: <name>`). `OOMKilled` exits
   137 too and stays fatal. Anything unrecognised stays fatal.
-- **Then it has to stop.** The verdict is only downgraded if the namespace goes
-  quiet: `--settle-seconds` (90 by default) later the live events are re-read,
-  and any unhealthy event still inside that window keeps the verdict. A platform
-  container that never recovers keeps warning, so it still fails us. The re-read
-  is of the **events**: LM's `deployment_status` is a terminal record and its
-  failure snapshot is frozen at the moment of failure, so neither can say the
-  namespace is well now. `--settle-seconds 0` disables the tolerance entirely.
+- **Then it must not happen again.** `--settle-seconds` (90 by default) later the
+  live events are re-read, and any unhealthy event still inside that window keeps
+  the verdict. A platform container that never recovers keeps warning, so it
+  still fails us. The re-read is of the **live events** and nothing else: LM's
+  `deployment_status` is a terminal record, and its failure snapshot is
+  *failure-triggered*, so it can only ever depict a failure — never a recovery.
+  The snapshot's `pod_events` must never reach the age comparison either: its
+  ages are relative to its own capture moment (8s behind the live read on the run
+  above, unbounded in general), so the same lines would read as young forever.
+  `--settle-seconds 0` disables the tolerance entirely.
 
-As with the foreign-pod path, the installed-version read-back still decides, and
-its failure message says the verdict was downgraded so the mismatch is not read
-in isolation.
+None of this proves the app is healthy, and nothing downstream should read it
+that way — a one-shot warning on a still-wedged pod ages out of the window and
+takes the window quiet with it. What the two conditions establish is that LM's
+verdict is not evidence **either way**, which hands the decision to the
+installed-version read-back: unconditional, direct, and the only positive
+evidence in the flow. Its failure message says when a verdict was downgraded, so
+a version mismatch is never read in isolation.
 
 Two platform-side fixes would remove the churn rather than tolerate it — KEDA
 `initialCooldownPeriod` on the server ScaledObject, and LM not counting a pod it

--- a/docs/standards/connector-ci-e2e.md
+++ b/docs/standards/connector-ci-e2e.md
@@ -413,10 +413,16 @@ The pull-failure reading above cannot catch that — there was no pull failure
   same repository-identity compare as above (an unreadable `Image:` counts as
   ours), so there is no list of platform container names to keep current.
 - **Why, for our own container.** `CreateContainerConfigError` (the kubelet could
-  not assemble the container, so the image never ran), a node eviction or
+  not *generate* the container's config — a missing Secret or ConfigMap — so the
+  image was never instantiated), a node eviction or
   shutdown, or exit 137 where the events *name this pod's* deletion
   (`KEDAScaleTargetDeactivated` **and** `Deleted pod: <name>`). `OOMKilled` exits
-  137 too and stays fatal. Anything unrecognised stays fatal.
+  137 too and stays fatal. Anything unrecognised stays fatal — including plain
+  `CreateContainerError`, which the kubelet sets *after* config generation when
+  the CRI `CreateContainer` call fails (a bad security context, a volume the
+  chart asked for, an image that cannot be instantiated). Those are app faults
+  and are what this tolerance exists to keep fatal, so the reason list is not to
+  be widened without a fixture from a real `describe`.
 - **Then it must not happen again.** `--settle-seconds` (90 by default) later the
   live events are re-read, and any unhealthy event still inside that window keeps
   the verdict. A platform container that never recovers keeps warning, so it

--- a/docs/standards/connector-ci-e2e.md
+++ b/docs/standards/connector-ci-e2e.md
@@ -392,6 +392,52 @@ A timeout is never downgraded this way — an accepted-but-unreconciled deploy i
 nobody else's fault, and it is the silent wrong-version failure this whole
 mechanism exists to remove.
 
+### When the FAILED verdict is about pod churn the platform caused
+
+The verdict is also an **instant**, not just a namespace: any pod unhealthy at
+the moment LM looks reds the install, including a pod the platform itself just
+deleted on purpose. The first install onto a new tenant failed in 45s that way —
+KEDA scaled the server deployment to zero while the platform-injected
+`atlan-env-seeder` init container was still blocked on a Vault secret whose name
+encodes the namespace and had not synced yet, so the pod was SIGKILLed mid-init
+and left phase `Failed`. The workers recovered, the app was fine, and the two
+warm namespaces on the other clouds passed the same run.
+
+The pull-failure reading above cannot catch that — there was no pull failure
+(`Normal Pulled`) — so a second, narrower tolerance sits behind it. It needs
+**both** halves, and the failing container has to be named:
+
+- **Whose container broke.** The container under test is the one running the
+  image we published; every other container in the pod came from the platform's
+  pod template, so it can be neither broken nor fixed by the app. Decided by the
+  same repository-identity compare as above (an unreadable `Image:` counts as
+  ours), so there is no list of platform container names to keep current.
+- **Why, for our own container.** `CreateContainerConfigError` (the kubelet could
+  not assemble the container, so the image never ran), a node eviction or
+  shutdown, or exit 137 where the events *name this pod's* deletion
+  (`KEDAScaleTargetDeactivated` **and** `Deleted pod: <name>`). `OOMKilled` exits
+  137 too and stays fatal. Anything unrecognised stays fatal.
+- **Then it has to stop.** The verdict is only downgraded if the namespace goes
+  quiet: `--settle-seconds` (90 by default) later the live events are re-read,
+  and any unhealthy event still inside that window keeps the verdict. A platform
+  container that never recovers keeps warning, so it still fails us. The re-read
+  is of the **events**: LM's `deployment_status` is a terminal record and its
+  failure snapshot is frozen at the moment of failure, so neither can say the
+  namespace is well now. `--settle-seconds 0` disables the tolerance entirely.
+
+As with the foreign-pod path, the installed-version read-back still decides, and
+its failure message says the verdict was downgraded so the mismatch is not read
+in isolation.
+
+Two platform-side fixes would remove the churn rather than tolerate it — KEDA
+`initialCooldownPeriod` on the server ScaledObject, and LM not counting a pod it
+deleted itself — but both live outside this repo.
+
+`pod_describe` is printed **per pod, unhealthy first**, for the same reason: under
+one shared budget it printed as "tail 200 of 542 lines" and the only pod that
+failed the install was in the dropped head, leaving two healthy workers as the
+entire visible evidence.
+
 Each entry may also carry `"deployment_name"` when that tenant's system apps
 (publish / quality / lineage) are not registered under `production`. It reaches
 the harness as `E2E_TENANT_DEPLOYMENT_NAME`, which


### PR DESCRIPTION
Closes FND-831.

## The problem

LM's deployment health check is namespace-scoped **and** its verdict is an instant, so any pod unhealthy at the moment it looks reds the install — including a pod the platform itself just deleted on purpose.

The first install onto a new e2e tenant failed in 45s that way. KEDA scaled the server deployment to zero while the platform-injected `atlan-env-seeder` init container was still blocked on a Vault secret whose name encodes the namespace and had not synced yet, so the pod was SIGKILLed mid-init and left phase `Failed`. The workers recovered, the app was fine, and the two warm namespaces on the other clouds passed the same run.

`foreign_failure` could not catch it: it reads pull-failure lines only, and this run had none (`Normal Pulled`). So `_poll_deployment`'s `DeploymentFailed` raised before the installed-version read-back ever ran, and we never found out whether the tenant served the version under test. The existing hatch isn't too strict — it's the wrong *shape*, built for exactly one failure mode.

## The fix

A second, narrower tolerance behind it. Three conditions, all required:

**1. Container ownership.** The container under test is the one running the image we published; every other container in the pod came from the platform's pod template, so it can be neither broken nor fixed by the app. Keyed on the container's **image**, not its name — no allowlist of platform container names to keep current when the platform renames or adds one. Reuses the existing repository-identity compare (extracted as `_is_our_image`, which `foreign_failure` now shares) rather than a second comparison with the opposite bias; its "err toward treating too much as ours" direction is the safe one here too, since *ours* means **not** excused. An unreadable `Image:` therefore counts as ours.

This needed a real parse of `pod_describe` (`parse_pod_describe` → `PodStatus` / `PodContainer`): the indentation is the only thing that says which container a `Reason:` belongs to, and `Last State:` sub-fields must not be merged into the current state or the `OOMKilled` guard below is lost.

**2. A reason classifier**, for the app's own container: `CreateContainerConfigError` (the kubelet could not assemble the container, so the image never ran), node eviction/shutdown, and exit 137 only where the events name *this pod's* deletion — both `KEDAScaleTargetDeactivated` **and** a `Deleted pod: <name>` naming it, so the excuse rests on causal evidence rather than a timestamp correlation. `OOMKilled` exits 137 too and stays fatal. Anything unrecognised stays fatal.

**3. A settle.** `--settle-seconds` (90) later the live events are re-read, and any unhealthy event still inside that window keeps the verdict — so a platform container that genuinely never recovers still fails us. Read off kubectl's relative `LAST SEEN` column: the events behind the original verdict age past the window while we wait, so anything left inside it fired during the settle, and a repeating warning stays young.

The re-read is of the **live events** and nothing else. `deployment_status` is a terminal record, and the failure snapshot is *failure-triggered* — it can only ever depict a failure, never a recovery. The snapshot's `pod_events` must not reach the age comparison either: its ages are relative to its own capture moment (measured 8s behind the live read on this run, unbounded in general), so the same lines would read as young forever. Both sections have identical shape, so there's a test that neither can leak in.

`--settle-seconds 0` disables the tolerance rather than auto-granting it.

## What this deliberately does *not* claim

None of the above proves the app is healthy, and the code says so — a one-shot warning on a still-wedged pod ages out of the window and takes the window quiet with it, and this incident's own `secret not found` lines fired once per pod. What the conditions establish is that LM's verdict is not evidence **either way**, which hands the decision to the installed-version read-back: unconditional, direct, and the only positive evidence in the flow. Its failure message now says when a verdict was downgraded, so a version mismatch is never read in isolation. A test pins that weaker wording, because it's the sentence a future reader would otherwise strengthen back by accident.

Two rejected alternatives, for the record: asserting a pod is `Ready` (with scale-to-zero, zero pods is the correct steady state, so it would be wrong at least as often as it helps — hence `_container_is_unhealthy` not testing `Ready`), and weakening the version read-back (it is the only positive evidence there is).

## Also: the failing pod has to survive the print budget

`pod_describe` is now printed **per pod, unhealthy first** (120 lines head each, at most 6 pods with the remainder named rather than silently dropped).

Under one shared budget it printed as "tail 200 of 542 lines" on the run this fixes, and the only pod that failed the install was in the dropped head — leaving two healthy workers as the entire visible evidence. `_dump_failure` returns the *full* text, so the classifier was never affected, but item 1 above would have been unverifiable from a CI log by anyone debugging it later.

## Budget cascade

`DEFAULT_SETTLE_SECONDS` joins the sum in `test_job_timeout_stays_above_the_scripts_own_waits` — leaving it out is the silent regression that guard exists to catch — which takes `prepare-tenant`'s ceiling 48 → 50 min. The lease TTL needs no change: 1.5 × (50+120) min = 15300s ≤ 16200s. It would at 60. `--settle-seconds` also joins that test's forbidden-flag list, so passing it from the step can't silently invalidate the budget.

`DEFAULT_SETTLE_SECONDS` documents the one non-obvious constraint on its own value: `duration.HumanDuration` branches on `seconds < 60*2`, so `LAST SEEN` stays in the seconds form to 120s. 90 sits 30s clear; raising the settle past 120 makes `XmYs` the common case (parsed and fixtured either way, but the comparison coarsens).

## Out of scope

Two platform-side fixes would remove the churn rather than tolerate it — KEDA `initialCooldownPeriod` on the server ScaledObject, and LM not counting a pod it deleted itself — but both live outside this repo.

## Testing

~45 new cases in `.github/scripts/tests/test_e2e_tenant_app.py`, with fixtures rendering `kubectl describe pod` at real indentation (including the `Image ID:` vs `Image:` trap) and the incident's exact event sequence end to end. Coverage is deliberately weighted toward the *safe* direction: our own container failing, an unreadable image, one unexcused container beside benign churn, an OOM kill with a scale-down in the events, unreadable diagnostics, and churn that never settles all stay fatal.

Whole CI-script suite: 3320 passed. Pre-commit clean.

## Note for reviewers

Touches `tests-reusable.yaml` in one place only (a `timeout-minutes` value and its comment), which overlaps textually — not semantically — with #3346. Does not touch the lease action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
