### PR TITLE
fix(handler): preflight envelope success reflects check pass/fail (FND-391)

### DIFF
--- a/application_sdk/handler/service.py
+++ b/application_sdk/handler/service.py
@@ -77,6 +77,7 @@ from application_sdk.handler.contracts import (
     PreflightCheck,
     PreflightInput,
     PreflightOutput,
+    PreflightStatus,
     SubscriptionConfig,
 )
 from application_sdk.handler.contracts import (
@@ -2878,22 +2879,25 @@ def create_app_handler_service(
                         "successMessage": msg if check.passed else "",
                         "failureMessage": "" if check.passed else msg,
                     }
-                # Envelope ``success`` reports whether preflight executed at
-                # all, not whether every check passed — per-check pass/fail
-                # belongs in ``data.<check>.success``. The SageV2 widget at
-                # SageV2.vue:249 short-circuits on ``!response.success`` and
-                # skips the per-check render loop entirely, so collapsing
-                # envelope success to ``status == READY`` (the previous
-                # behaviour) made every PARTIAL/NOT_READY response surface
-                # as "Check failed" with a blank "Hide details" panel
-                # (DBBI-665). Tying envelope success to "any check ran"
-                # keeps it false when a handler produced no checks and lets
-                # the widget render per-check rows otherwise. The canonical
-                # status is exposed separately under ``preflight``.
+                # Envelope ``success`` reflects the preflight VERDICT: it is
+                # false only when a blocking check failed, i.e. the gate
+                # returned ``NOT_READY``. ``READY`` and ``PARTIAL`` (advisory-
+                # only failures that still let the run proceed) are successes.
+                # Per-check pass/fail remains in ``data.<check>.success`` and
+                # the canonical status in ``preflight.status``.
+                #
+                # A prior revision tied ``success`` to ``len(result.checks) > 0``
+                # ("did any check run") to work around SageV2.vue:249 skipping
+                # the per-check render loop on ``!response.success`` (DBBI-665).
+                # That made the envelope report success even for wrong creds /
+                # an unreachable host, so callers could not trust the top-level
+                # flag (FND-391). The correct blast-radius fix is on the widget
+                # (render per-check detail even when ``success`` is false); the
+                # envelope now tells the truth.
                 response = _wrap_response(
                     v2_data,
                     message=result.message or f"Preflight check {result.status.value}",
-                    success=len(result.checks) > 0,
+                    success=result.status != PreflightStatus.NOT_READY,
                 )
                 response["preflight"] = _preflight_runtime_summary(result)
                 return JSONResponse(content=response)

--- a/tests/unit/handler/test_service.py
+++ b/tests/unit/handler/test_service.py
@@ -394,11 +394,10 @@ class TestPreflightEndpoint:
         )
         assert response.status_code == 200
         body = response.json()
-        # _TestHandler returns no checks, so envelope success is false
-        # (envelope success now means "preflight produced checks" — a handler
-        # that returns zero checks is treated as a preflight-system failure
-        # so the widget falls back to the top-level "Check failed" path).
-        assert body["success"] is False
+        # _TestHandler returns status READY (no blocking failure), so the
+        # envelope reports success — envelope success reflects the verdict
+        # (``status != NOT_READY``), not the check count (FND-391).
+        assert body["success"] is True
         # v2 format: data is a dict of check results keyed by camelCase name.
         assert body["data"] == {}
         assert body["message"] == "ready"
@@ -415,9 +414,9 @@ class TestPreflightEndpoint:
 
         assert response.status_code == 200
         body = response.json()
-        # No checks emitted, so the SageV2 envelope is success=False (same as
-        # any zero-check handler).
-        assert body["success"] is False
+        # DefaultHandler returns status READY, so the envelope reports success
+        # (verdict-based, not check-count-based — FND-391).
+        assert body["success"] is True
         assert body["data"] == {}
         assert body["message"] == "No preflight handler registered"
         assert body["preflight"]["status"] == "ready"
@@ -638,7 +637,8 @@ class TestPreflightEndpoint:
         client = _make_client(handler=_OneCheck())
         body = client.post("/workflows/v1/check", json={"credentials": []}).json()
 
-        assert body["success"] is True
+        # NOT_READY is a blocking failure → envelope success false (FND-391).
+        assert body["success"] is False
         assert list(body["data"]) == ["loginCheck"]
         assert body["data"]["loginCheck"]["success"] is False
         assert "should_block" not in body["preflight"]
@@ -714,15 +714,16 @@ class TestPreflightEndpoint:
         assert entry["failureMessage"] == ""
 
     # ------------------------------------------------------------------
-    # Envelope ``success`` reports preflight execution, not per-check pass
-    # (DBBI-665 root cause).
+    # Envelope ``success`` reflects the preflight VERDICT (FND-391):
+    # false only when a blocking check failed (status ``NOT_READY``);
+    # ``READY`` and ``PARTIAL`` are successes.
     # ------------------------------------------------------------------
     #
-    # The previous behaviour ``success = (status == READY)`` made every
-    # PARTIAL/NOT_READY response surface as a blank "Check failed" panel
-    # because SageV2.vue:249 short-circuits on ``!response.success`` and
-    # never iterates the per-check data. These tests pin the new contract:
-    # envelope success is true as long as preflight produced any checks.
+    # An earlier revision tied ``success`` to "any check ran"
+    # (``len(checks) > 0``) to dodge SageV2.vue:249 skipping the per-check
+    # render loop on ``!response.success`` (DBBI-665). That reported success
+    # even for wrong creds / unreachable hosts. The envelope now tells the
+    # truth; the widget-render concern is a separate frontend fix.
 
     def test_preflight_envelope_success_true_when_all_checks_pass(self) -> None:
         """Status READY → envelope success true (regression guard)."""
@@ -745,13 +746,14 @@ class TestPreflightEndpoint:
         )
         assert body["success"] is True
 
-    def test_preflight_envelope_success_true_when_a_check_fails(self) -> None:
-        """Status NOT_READY → envelope success TRUE so SageV2 still renders per-check rows.
+    def test_preflight_envelope_success_false_when_a_blocking_check_fails(
+        self,
+    ) -> None:
+        """Status NOT_READY → envelope success FALSE (blocking failure — FND-391).
 
-        This is the DBBI-665 case: previously a failed check forced envelope
-        success=false, which made the widget skip the per-check loop entirely
-        and show a blank "Hide details" panel. Pinning envelope success=true
-        whenever checks ran lets the per-check rows render.
+        A failed blocking check (wrong creds / unreachable host) must make the
+        top-level ``success`` false so callers can trust it. The per-check
+        detail stays on the wire so the widget can still render the failure.
         """
 
         class _OneCheck(_TestHandler):
@@ -774,7 +776,7 @@ class TestPreflightEndpoint:
             .post("/workflows/v1/check", json={"credentials": []})
             .json()
         )
-        assert body["success"] is True
+        assert body["success"] is False
         # Per-check detail is still on the wire so the widget can render it.
         assert body["data"]["apiVersion"]["success"] is False
         assert body["data"]["apiVersion"]["failureMessage"] == (
@@ -6770,10 +6772,9 @@ class TestPerEntrypointHandlerHook:
         )
         assert response.status_code == 200
         body = response.json()
-        # Envelope success reports that preflight ran (a check was produced), not
-        # that every check passed — per DBBI-665. The failing check surfaces in
-        # data.recipientCheck.
-        assert body["success"] is True
+        # NOT_READY is a blocking failure → envelope success false (FND-391).
+        # The failing check still surfaces in data.recipientCheck.
+        assert body["success"] is False
         assert body["data"]["recipientCheck"] == {
             "success": False,
             "message": "recipient missing",


### PR DESCRIPTION
## The bug

`POST /workflows/v1/check` (preflight) built its response envelope as:

```python
response = _wrap_response(
    v2_data,
    message=result.message or f"Preflight check {result.status.value}",
    success=len(result.checks) > 0,
)
```

`success` was derived from **"at least one check ran"**, not **"the checks passed"**. Handlers always append ≥1 check before returning, so the top-level `success` was `True` even for wrong credentials or an unreachable host — while the nested `data.<check>.success` and `preflight.status` correctly reported the failure. Callers could not trust the envelope flag. (FND-391)

## The fix

Derive `success` from the verdict:

```python
success=result.status != PreflightStatus.NOT_READY,
```

- `NOT_READY` (a blocking failure — the gate's "blocked / would_block" verdict) → `success=False`.
- `READY` and `PARTIAL` (advisory-only failures that still let the run proceed) → `success=True`.

`PreflightStatus` is now imported in `service.py`. Per-check pass/fail remains under `data.<check>.success`; the canonical status remains under `preflight.status`.

## SDK tests

Updated the unit tests in `tests/unit/handler/test_service.py` that had **pinned the buggy value**:
- READY / zero-check handlers now assert `success is True` (verdict-based, not check-count-based).
- NOT_READY handlers now assert `success is False`.

`uv run pytest tests/unit/handler/ tests/unit/app/test_preflight_gate.py` → **460 passed**. Pre-commit (ruff, isort, pyright) clean.

## Fleet blast radius — flagged for maintainer review

This envelope is shared by **every** connector's preflight, so the semantics change is fleet-wide:

- **atlan-presto-app** — the reason for this change. Its integration preflight scenarios (bad creds / unreachable host) want `success == False` and were previously xfail'd to hide the bug; that xfail is being removed in the companion presto PR.
- **atlan-adls-app** — `tests/integration/scenarios/preflight.py` has two scenarios (`preflight_not_ready_on_missing_storage_account`, `preflight_not_ready_when_auth_fails`) that assert envelope `success == True` while `preflight.status == "not_ready"`. These encode the old buggy value and **will need companion updates to assert `False`**. (They run unconditionally, no live creds required.)
- domo / dbt / snowflake / cognos / kafka / anaplan preflight tests were checked: their failure paths only assert per-check `data.<check>.success` (or are positive-only / already-skipped / already expect `False`), so they are **not** broken by this change.

### Frontend caveat (SageV2 widget)

The prior "any check ran" behavior was introduced to work around `SageV2.vue:249`, which short-circuits on `!response.success` and skips the per-check render loop — so on a NOT_READY response the widget shows a top-level "Check failed" with a blank detail panel (referenced as DBBI-665 in the old code comments). The correct long-term fix is on the frontend (render per-check detail even when `success` is false); the envelope should not lie to compensate. **Flagging this for maintainer review before merge.**

## Status

**Draft — do not merge.** Blast radius flagged above for maintainer sign-off; the adls companion test updates and the frontend widget behavior should be coordinated with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)