### PR TITLE
fix(e2e): wire the agent_json() hook on SQLAppE2ETest (FND-843)

### DIFF
--- a/application_sdk/testing/e2e/sql_app.py
+++ b/application_sdk/testing/e2e/sql_app.py
@@ -5,6 +5,8 @@ capturing the boilerplate every SQL connector needs:
 
 * SQL-specific class attrs (include/exclude filters, task queues, QI knobs).
 * :meth:`agent_spec` — derives a unique-per-run agent name.
+* :meth:`agent_json` — the one derivation of the agent-mode routing
+  block, feeding both the mustache blob and the flat AE routing rows.
 * :meth:`connection_spec` — resolves the tenant's ``$admin`` role GUID.
 * :meth:`_mustache_substitutions` — builds :class:`SQLMustacheSubstitutions`
   from ``database_spec()`` + ``agent_spec()``.
@@ -148,6 +150,22 @@ class SQLAppE2ETest(BaseE2ETest):
             )
         )
 
+    def agent_json(self) -> dict[str, Any] | None:
+        """Agent-mode routing block, derived once from the DB + agent specs.
+
+        Wiring this hook (rather than building the block inline in
+        :meth:`_mustache_substitutions`) is what lets ``build_ae_payload``
+        emit the flat ``agent-json.*`` / ``credential-guid.*`` routing rows.
+        Without it the base hook returns None, the agent branch never runs,
+        and every SQL connector has to override ``_build_ae_payload`` to
+        re-derive the same rows by hand — five copies of one derivation that
+        can drift from the blob. Returns None in DIRECT mode (no agent).
+        """
+        agent = self.agent_spec()
+        if agent is None:
+            return None
+        return build_agent_json(self.database_spec(), agent, self.connector_short_name)
+
     def connection_spec(self) -> ConnectionSpec:
         """Connection identity with ``$admin`` role on the admin ACL."""
         if not hasattr(self, "_admin_role_guid"):
@@ -187,20 +205,11 @@ class SQLAppE2ETest(BaseE2ETest):
         connection_ref = ConnectionRef.model_validate(
             {"typeName": "Connection", "attributes": spec.attributes()}
         )
-        agent = self.agent_spec()
-        database = self.database_spec()
-
-        agent_json: dict[str, Any] | None = (
-            build_agent_json(database, agent, self.connector_short_name)
-            if agent is not None
-            else None
-        )
-
         return self.substitutions_class.model_validate(
             {
                 "connection": connection_ref,
                 "extraction_method": self.mode.value,
-                "agent_json": agent_json,
+                "agent_json": self.agent_json(),
                 "include_filter": self.include_filter,
                 "exclude_filter": self.exclude_filter,
                 "exclude_table_regex": "",

--- a/tests/unit/testing/e2e/test_sql_app_e2e.py
+++ b/tests/unit/testing/e2e/test_sql_app_e2e.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+
 import pytest
 
 from application_sdk.testing.e2e.base import FullDAGOutcome
@@ -271,6 +273,21 @@ class _ConcreteSQLTest(SQLAppE2ETest):
     @staticmethod
     def _resolve_admin_role_guid() -> str:
         return "role-guid-123"
+
+
+@pytest.fixture(autouse=True)
+def _restore_class_mode() -> Iterator[None]:
+    """Put ``_ConcreteSQLTest.mode`` back after a test rebinds the ClassVar.
+
+    ``_make_test`` sets the mode on the *class*, not the instance, so without
+    this every test leaks its mode into the shared class default and a later
+    reader of that default becomes order-dependent.
+    """
+    original = _ConcreteSQLTest.mode
+    try:
+        yield
+    finally:
+        _ConcreteSQLTest.mode = original
 
 
 class TestSQLAppE2ETestHooks:

--- a/tests/unit/testing/e2e/test_sql_app_e2e.py
+++ b/tests/unit/testing/e2e/test_sql_app_e2e.py
@@ -376,3 +376,97 @@ class TestSQLAppE2ETestHooks:
         t = self._make_test()
         dag = t._build_legacy_seed_dag("atlan-mysql-ci-agent-1")
         assert dag["extract"]["inputs"]["task_queue"] == "atlan-mysql-ci-agent-1"
+
+
+# ---------------------------------------------------------------------------
+# SQLAppE2ETest.agent_json — the hook that feeds build_ae_payload's agent branch
+# ---------------------------------------------------------------------------
+
+
+def _submit_params(payload: dict) -> dict[str, object]:
+    tasks = payload["spec"]["templates"][0]["dag"]["tasks"]
+    return {p["name"]: p["value"] for p in tasks[0]["arguments"]["parameters"]}
+
+
+class TestSQLAppAgentJsonHook:
+    """One derivation: the mustache blob and the flat AE rows share a source.
+
+    Before the hook was wired, ``BaseE2ETest.agent_json()`` returned None for
+    every SQL connector, ``build_ae_payload`` skipped its whole agent branch,
+    and each connector overrode ``_build_ae_payload`` to re-append the routing
+    rows by hand — a second derivation that could drift from the blob.
+    """
+
+    def _make_test(self, mode: RunMode = RunMode.AGENT) -> _ConcreteSQLTest:
+        t = _ConcreteSQLTest()
+        t.run_id = 1
+        t.connection_qualified_name = "default/mysql/1"
+        t.connection_display_name = "mysql-1"
+        t._admin_role_guid = "role-guid-123"
+        t.__class__.mode = mode
+        return t
+
+    def test_returns_none_in_direct_mode(self) -> None:
+        assert self._make_test(RunMode.DIRECT).agent_json() is None
+
+    def test_matches_build_agent_json(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("ATLAN_APPLICATION_NAME", raising=False)
+        monkeypatch.delenv("ATLAN_DEPLOYMENT_NAME", raising=False)
+        t = self._make_test(RunMode.AGENT)
+        agent = t.agent_spec()
+        assert agent is not None
+        assert t.agent_json() == build_agent_json(_DATABASE, agent, "mysql")
+
+    def test_mustache_blob_comes_from_the_same_hook(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("ATLAN_APPLICATION_NAME", raising=False)
+        monkeypatch.delenv("ATLAN_DEPLOYMENT_NAME", raising=False)
+        t = self._make_test(RunMode.AGENT)
+        subs = t._mustache_substitutions()
+        assert subs.model_dump(by_alias=True)["{{agent-json}}"] == t.agent_json()
+
+    def test_subclass_emits_routing_rows_with_no_payload_override(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The point of the issue: no ``_build_ae_payload`` override needed."""
+        monkeypatch.delenv("ATLAN_APPLICATION_NAME", raising=False)
+        monkeypatch.delenv("ATLAN_DEPLOYMENT_NAME", raising=False)
+        assert "_build_ae_payload" not in vars(_ConcreteSQLTest)
+        t = self._make_test(RunMode.AGENT)
+        agent = t.agent_spec()
+        assert agent is not None
+
+        params = _submit_params(t._build_ae_payload("mysql-slug"))
+
+        assert params["agent-json.host"] == _DATABASE.host
+        assert params["agent-json.port"] == _DATABASE.port
+        assert params["agent-json.auth-type"] == _DATABASE.auth_type
+        assert params["agent-json.agent-name"] == agent.agent_name
+        assert params["agent-json.agent-type"] == agent.agent_type
+        assert params["agent-json.key-type"] == agent.key_type
+        assert params["agent-json.aws-auth-method"] == agent.aws_auth_method
+        assert params["agent-json.azure-auth-method"] == agent.azure_auth_method
+        assert params["credential-guid.auth-type"] == _DATABASE.auth_type
+        assert params["credential-guid.credential-type"] == "atlan-connectors-mysql"
+
+    def test_blob_and_flat_rows_agree(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Same source, so the JSON blob cannot disagree with the flat rows."""
+        import orjson
+
+        monkeypatch.delenv("ATLAN_APPLICATION_NAME", raising=False)
+        monkeypatch.delenv("ATLAN_DEPLOYMENT_NAME", raising=False)
+        t = self._make_test(RunMode.AGENT)
+        params = _submit_params(t._build_ae_payload("mysql-slug"))
+        blob = orjson.loads(params["agent-json"])
+        assert blob == t.agent_json()
+        for key, value in blob.items():
+            flat = f"agent-json.{key}"
+            if flat in params:
+                assert params[flat] == value
+
+    def test_direct_mode_emits_no_routing_rows(self) -> None:
+        t = self._make_test(RunMode.DIRECT)
+        params = _submit_params(t._build_ae_payload("mysql-slug"))
+        assert not [k for k in params if k.startswith("agent-json.")]
+        assert not [k for k in params if k.startswith("credential-guid.")]


### PR DESCRIPTION
## Problem

`BaseE2ETest._build_ae_payload` documents its contract plainly:

> Subclasses never override this method — they override the two typed hooks above.

Every SQL connector violates it, because the hook it needs was never wired up.

`SQLAppE2ETest._mustache_substitutions()` already computed the agent block inline — but `SQLAppE2ETest` did not override the `agent_json()` hook. So `BaseE2ETest.agent_json()` returned `None`, `build_ae_payload` skipped its entire agent branch, and no flat `agent-json.*` / `credential-guid.*` rows were emitted. Every SQL connector that wants the UI-shaped submit therefore overrides `_build_ae_payload` and re-derives the same rows by hand — four hand-rolled copies today (`atlan-mysql-app`, `atlan-metabase-app`, `atlan-dremio-app`, `atlan-cloudsql-postgres-app`), each free to drift from the blob.

## Change

`application_sdk/testing/e2e/sql_app.py`:

- Add `SQLAppE2ETest.agent_json()` — `None` in DIRECT mode, otherwise `build_agent_json(self.database_spec(), agent, self.connector_short_name)`.
- `_mustache_substitutions()` now reads `self.agent_json()` instead of building the block inline. The local `agent` / `database` vars are gone; they existed only to feed that build.
- Module docstring's hook list updated.

One derivation in one place, so the blob and the flat rows cannot disagree.

## Deliberately not in scope: widening the flattening loop

FND-843 notes that if #3411 lands first, its flattening loop should widen from `key.startswith("basic.")` to `"." in key`. **#3411 is still open**, so that loop does not exist on `main` yet and editing it here would collide with that PR.

Consequence, relevant to the follow-ups: with this change alone a `SQLAppE2ETest` subclass emits **11** of mysql's 13 hand-rolled rows. The 3 still missing — `credential-guid.port`, `agent-json.basic.username`, `agent-json.basic.password` — are exactly #3411's payload. FND-845 (delete mysql's override) should land after #3411 if byte-parity with the override it removes is wanted.

## Scope note

The flat rows are a UI form-state artefact, not a backend requirement: on the AE-native path Heracles flattens every parameter row into `allParams` and only substitutes `{{<name>}}` placeholders in the manifest DAG, and agent routing reads the parsed blob (`extractAgentJSON`). This PR is about **one derivation instead of five**, not about the rows being load-bearing.

## Verification

- `uv run pytest tests/unit/testing/e2e/` — **511 passed**.
- New `TestSQLAppAgentJsonHook` (6 tests): `None` in DIRECT mode; equals `build_agent_json(...)`; the mustache blob comes from the same hook; a subclass with **no** `_build_ae_payload` override (asserted via `vars()`) still emits the full routing row set; blob and flat rows agree key-for-key; DIRECT mode emits zero routing rows.
- pre-commit (ruff, ruff-format, isort, pyright) clean on both files.
- Live: `atlan-mysql-app` `Tests` with `run_e2e=true` pinned to this SDK ref — the `mysql-*-{aws,azure,gcp}` legs must stay green. Not yet run.

Closes FND-843.
