### PR TITLE
fix(conformance): report Release Gate on merge-queue branches (FND-851)

### DIFF
--- a/packages/conformance/conformance/bootstrap/templates/release-gate.yaml
+++ b/packages/conformance/conformance/bootstrap/templates/release-gate.yaml
@@ -27,6 +27,14 @@ on:
   pull_request:
     types: [opened, synchronize, labeled, unlabeled, reopened]
     branches: [main]
+  # A merge queue evaluates required contexts against the `merge_group` event
+  # on the gh-readonly-queue/<base>/pr-N-<sha> ref, not against the pull
+  # request. Without this trigger no "Release Gate" check-run is ever created
+  # for the merge group, so the required context sits at "Expected — waiting
+  # for status to be reported" forever and the queue never drains (FND-851).
+  # Same shape as release-files-guard.yaml and sdk-gate.yaml in
+  # application-sdk, which are the two in-repo guards of this kind.
+  merge_group:
 
 permissions:
   contents: read
@@ -39,6 +47,13 @@ jobs:
     timeout-minutes: 2
     steps:
       - name: Verify release readiness
+        # `github.event.pull_request` does not exist on `merge_group`, so the
+        # label lookup can only run on the pull_request event. A skipped step
+        # still leaves the job successful, and that success is what reports
+        # the green context to the queue. Nothing is lost by passing here: a
+        # release PR missing `e2e` fails this gate on the PR itself and so
+        # never becomes eligible to enter the queue.
+        if: github.event_name == 'pull_request'
         env:
           LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
         run: |


### PR DESCRIPTION
Closes FND-851.

## Problem

`Release Gate` is now a required status check on app repos. In `atlan-metabase-app` every merge-queue entry sits at:

> Release Gate — Expected — Waiting for status to be reported

with all six other required contexts green. The queue never drains. Any app repo that bootstrapped this template **and** made the check required stalls identically.

## Cause

The scaffolded `release-gate.yaml` triggers only on `pull_request`. A merge queue evaluates required contexts against the `merge_group` event on the `gh-readonly-queue/<base>/pr-N-<sha>` ref, not against the pull request — so no `Release Gate` check-run is ever created for the merge group, and a required context that matches no check waits forever.

Not drift: `atlan-metabase-app`'s copy was byte-identical to this template.

## Fix

1. `merge_group:` added to `on:`.
2. `if: github.event_name == 'pull_request'` on the `Verify release readiness` step — `github.event.pull_request` is null on `merge_group`. A skipped step leaves the job successful, and that success is what reports the green context to the queue.

Passing in the queue is sound rather than vacuous: a release PR missing `e2e` fails this gate on the PR itself, so it never becomes eligible to enter the queue.

## Why this survived

This repo's own guards of the same shape already do exactly this — `release-files-guard.yaml:30,55` and `sdk-gate.yaml:34`. `release-gate.yaml` is template-only; `grep -rn "name: Release Gate" .github/workflows/` returns nothing, so no run in this repo ever exercised it. Every other bootstrap template that produces a required context (`tests.yaml`, `conformance.yaml`, `checks.yml`, `vulnerability-scan.yml`, `commits.yaml`) already carries `merge_group:`. This was the only one missing it.

That is a dogfooding gap as much as a code gap: a bootstrap template that produces a *required* context has no in-repo run to catch a trigger mistake, and enforcement state is not a file, so the drift detector cannot see it either. FND-851 tracks a follow-up conformance validator asserting that every workflow producing a required context also subscribes to `merge_group`.

## After merge

Resync the template across the fleet. Repos already stalled need `Release Gate` temporarily dropped from their required contexts so the fix PR can get through the queue it is fixing, then re-added.

Companion PR: atlanhq/atlan-metabase-app#361

🤖 Generated with [Claude Code](https://claude.com/claude-code)
