### PR TITLE
docs(testing): mark testing/full_dag deprecated where connector authors actually look

### DIFF
--- a/.claude/skills/capability-manifest/SKILL.md
+++ b/.claude/skills/capability-manifest/SKILL.md
@@ -15,7 +15,7 @@ optional_triggers:
   - "what does the SDK expose"
   - "list public methods of the SDK"
 owner: connector-platform-team
-last_updated: "2026-08-17"
+last_updated: "2026-08-25"
 staleness_days: 30
 inputs:
   - mode: "create | refresh | verify (auto-detected from existing state)"

--- a/application_sdk/testing/full_dag/__init__.py
+++ b/application_sdk/testing/full_dag/__init__.py
@@ -1,4 +1,19 @@
-"""Shared harness for tier-4 / tier-5 full-DAG end-to-end tests.
+""".. deprecated:: 3.24
+    Use :mod:`application_sdk.testing.e2e`. This module is removed in v4.0.
+
+    ``application_sdk.testing.e2e`` is the harness every scaffolded app gets:
+    :class:`~application_sdk.testing.e2e.BaseE2ETest` is what the codegen'd
+    ``app/generated/_e2e_base.py`` subclasses, SQL connectors get
+    :class:`~application_sdk.testing.e2e.SQLAppE2ETest` on top of it, and
+    :mod:`application_sdk.testing.e2e.client` / ``._errors`` are already the
+    canonical implementations this package re-exports.
+
+    ``BaseE2ETest`` is connector-agnostic — it is in production use on non-SQL
+    connectors (BI, API and object-store apps alike), so "my connector is not
+    SQL" is not a reason to stay here. The SQL-shaped parameter rows come from
+    ``SQLAppE2ETest``, not from the base.
+
+Shared harness for tier-4 / tier-5 full-DAG end-to-end tests.
 
 Tier 4 (e2e-sdr-full) and tier 5 (e2e-full) both validate connectors
 end-to-end against the *tenant's* system apps (publish, query-intelligence,

--- a/application_sdk/testing/full_dag/base.py
+++ b/application_sdk/testing/full_dag/base.py
@@ -118,7 +118,9 @@ class FullDAGOutcome:
 
 
 class BaseFullDAGE2ETest:
-    """Pytest base — subclass per connector, set class attrs.
+    """Deprecated (v4.0) — pytest base; use ``testing.e2e.BaseE2ETest``.
+
+    Pytest base — subclass per connector, set class attrs.
 
     Class attrs subclasses MUST set:
 

--- a/application_sdk/testing/full_dag/base.py
+++ b/application_sdk/testing/full_dag/base.py
@@ -118,7 +118,7 @@ class FullDAGOutcome:
 
 
 class BaseFullDAGE2ETest:
-    """Deprecated (v4.0) — pytest base; use ``testing.e2e.BaseE2ETest``.
+    """Deprecated (v4.0) — pytest base; use ``application_sdk.testing.e2e.BaseE2ETest``.
 
     Pytest base — subclass per connector, set class attrs.
 

--- a/application_sdk/testing/full_dag/payload.py
+++ b/application_sdk/testing/full_dag/payload.py
@@ -132,7 +132,9 @@ def build_seed_dag(
     agent: AgentSpec | None = None,
     database: DatabaseSpec | None = None,
 ) -> dict[str, Any]:
-    """Build a seed-version DAG matching the connector's manifest.json shape.
+    """Deprecated (v4.0) — seed-version DAG; use ``testing.e2e.payload``.
+
+    Build a seed-version DAG matching the connector's manifest.json shape.
 
     Workflows need at least one PUBLISHED version before package-
     workflows submit will accept them; the seed version is a no-op
@@ -353,7 +355,9 @@ def build_ae_payload(
     agent_json: dict[str, Any] | None = None,
     ae_workflow_slug: str = "",
 ) -> dict[str, Any]:
-    """Assemble the AE submit body.
+    """Deprecated (v4.0) — AE submit body; use ``testing.e2e.payload``.
+
+    Assemble the AE submit body.
 
     Args:
         run_id: Run identifier (typically ``int(time.time())`` or

--- a/application_sdk/testing/full_dag/payload.py
+++ b/application_sdk/testing/full_dag/payload.py
@@ -132,7 +132,7 @@ def build_seed_dag(
     agent: AgentSpec | None = None,
     database: DatabaseSpec | None = None,
 ) -> dict[str, Any]:
-    """Deprecated (v4.0) — seed-version DAG; use ``testing.e2e.payload``.
+    """Deprecated (v4.0) — seed-version DAG; use ``application_sdk.testing.e2e.payload``.
 
     Build a seed-version DAG matching the connector's manifest.json shape.
 
@@ -355,7 +355,7 @@ def build_ae_payload(
     agent_json: dict[str, Any] | None = None,
     ae_workflow_slug: str = "",
 ) -> dict[str, Any]:
-    """Deprecated (v4.0) — AE submit body; use ``testing.e2e.payload``.
+    """Deprecated (v4.0) — AE submit body; use ``application_sdk.testing.e2e.payload``.
 
     Assemble the AE submit body.
 

--- a/application_sdk/testing/full_dag/sql_app.py
+++ b/application_sdk/testing/full_dag/sql_app.py
@@ -36,7 +36,7 @@ from application_sdk.testing.full_dag.payload import AgentSpec, ConnectionSpec, 
 
 
 class SQLAppE2EFullTest(BaseFullDAGE2ETest):
-    """Deprecated (v4.0) — SQL full-DAG base; use ``testing.e2e.SQLAppE2ETest``.
+    """Deprecated (v4.0) — SQL full-DAG base; use ``application_sdk.testing.e2e.SQLAppE2ETest``.
 
     Full-DAG e2e harness pre-wired for SQL connectors.
 

--- a/application_sdk/testing/full_dag/sql_app.py
+++ b/application_sdk/testing/full_dag/sql_app.py
@@ -36,7 +36,9 @@ from application_sdk.testing.full_dag.payload import AgentSpec, ConnectionSpec, 
 
 
 class SQLAppE2EFullTest(BaseFullDAGE2ETest):
-    """Full-DAG e2e harness pre-wired for SQL connectors.
+    """Deprecated (v4.0) — SQL full-DAG base; use ``testing.e2e.SQLAppE2ETest``.
+
+    Full-DAG e2e harness pre-wired for SQL connectors.
 
     Most concrete connector tests end up looking like this:
 

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -1,8 +1,8 @@
 <!--
 generated-by:  capability-manifest skill (.claude/skills/capability-manifest)
 sdk-version:   3.28.3
-source-sha:    5b9baf3b85a68510603ee4c3468d435b86563fea
-source-date:   2026-08-25T22:26:47+01:00
+source-sha:    552d36d15f0be66f01885adcc7b51c20e9406128
+source-date:   2026-08-25T22:34:28+01:00
 do-not-edit:   re-run the skill instead of hand-editing
 -->
 
@@ -3135,7 +3135,7 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 
 - **Import:** `from application_sdk.testing.full_dag import BaseFullDAGE2ETest`
 - **Signature:** `class BaseFullDAGE2ETest`
-- **Summary:** Deprecated (removed in v4.0) — use ``application_sdk.testing.e2e.BaseE2ETest``.
+- **Summary:** Deprecated (v4.0) — pytest base; use ``testing.e2e.BaseE2ETest``.
 - **Defined in:** `application_sdk/testing/full_dag/base.py`
 
 #### `BaseIntegrationTest`
@@ -3313,7 +3313,7 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 
 - **Import:** `from application_sdk.testing.full_dag import SQLAppE2EFullTest`
 - **Signature:** `class SQLAppE2EFullTest`
-- **Summary:** Deprecated (removed in v4.0) — use ``application_sdk.testing.e2e.SQLAppE2ETest``.
+- **Summary:** Deprecated (v4.0) — SQL full-DAG base; use ``testing.e2e.SQLAppE2ETest``.
 - **Defined in:** `application_sdk/testing/full_dag/sql_app.py`
 
 #### `SQLAppE2ETest`
@@ -3357,14 +3357,14 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 
 - **Import:** `from application_sdk.testing.full_dag import build_ae_payload`
 - **Signature:** `build_ae_payload(*, *, ...)`
-- **Summary:** Deprecated (removed in v4.0) — use ``application_sdk.testing.e2e.payload``.
+- **Summary:** Deprecated (v4.0) — AE submit body; use ``testing.e2e.payload``.
 - **Defined in:** `application_sdk/testing/full_dag/payload.py`
 
 #### `build_seed_dag`
 
 - **Import:** `from application_sdk.testing.full_dag import build_seed_dag`
 - **Signature:** `build_seed_dag(*, *, ...)`
-- **Summary:** Deprecated (removed in v4.0) — use ``application_sdk.testing.e2e.payload``.
+- **Summary:** Deprecated (v4.0) — seed-version DAG; use ``testing.e2e.payload``.
 - **Defined in:** `application_sdk/testing/full_dag/payload.py`
 
 #### `clean_app_registry`

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -1,8 +1,8 @@
 <!--
 generated-by:  capability-manifest skill (.claude/skills/capability-manifest)
 sdk-version:   3.28.3
-source-sha:    2c3451b251449c2b97fafad7256613b9f804e528
-source-date:   2026-08-25T16:54:01Z
+source-sha:    5b9baf3b85a68510603ee4c3468d435b86563fea
+source-date:   2026-08-25T22:26:47+01:00
 do-not-edit:   re-run the skill instead of hand-editing
 -->
 
@@ -3135,7 +3135,7 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 
 - **Import:** `from application_sdk.testing.full_dag import BaseFullDAGE2ETest`
 - **Signature:** `class BaseFullDAGE2ETest`
-- **Summary:** Pytest base — subclass per connector, set class attrs.
+- **Summary:** Deprecated (removed in v4.0) — use ``application_sdk.testing.e2e.BaseE2ETest``.
 - **Defined in:** `application_sdk/testing/full_dag/base.py`
 
 #### `BaseIntegrationTest`
@@ -3313,7 +3313,7 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 
 - **Import:** `from application_sdk.testing.full_dag import SQLAppE2EFullTest`
 - **Signature:** `class SQLAppE2EFullTest`
-- **Summary:** Full-DAG e2e harness pre-wired for SQL connectors.
+- **Summary:** Deprecated (removed in v4.0) — use ``application_sdk.testing.e2e.SQLAppE2ETest``.
 - **Defined in:** `application_sdk/testing/full_dag/sql_app.py`
 
 #### `SQLAppE2ETest`
@@ -3357,14 +3357,14 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 
 - **Import:** `from application_sdk.testing.full_dag import build_ae_payload`
 - **Signature:** `build_ae_payload(*, *, ...)`
-- **Summary:** Assemble the AE submit body.
+- **Summary:** Deprecated (removed in v4.0) — use ``application_sdk.testing.e2e.payload``.
 - **Defined in:** `application_sdk/testing/full_dag/payload.py`
 
 #### `build_seed_dag`
 
 - **Import:** `from application_sdk.testing.full_dag import build_seed_dag`
 - **Signature:** `build_seed_dag(*, *, ...)`
-- **Summary:** Build a seed-version DAG matching the connector's manifest.json shape.
+- **Summary:** Deprecated (removed in v4.0) — use ``application_sdk.testing.e2e.payload``.
 - **Defined in:** `application_sdk/testing/full_dag/payload.py`
 
 #### `clean_app_registry`

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -3135,7 +3135,7 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 
 - **Import:** `from application_sdk.testing.full_dag import BaseFullDAGE2ETest`
 - **Signature:** `class BaseFullDAGE2ETest`
-- **Summary:** Deprecated (v4.0) — pytest base; use ``testing.e2e.BaseE2ETest``.
+- **Summary:** Deprecated (v4.0) — pytest base; use ``application_sdk.testing.e2e.BaseE2ETest``.
 - **Defined in:** `application_sdk/testing/full_dag/base.py`
 
 #### `BaseIntegrationTest`
@@ -3313,7 +3313,7 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 
 - **Import:** `from application_sdk.testing.full_dag import SQLAppE2EFullTest`
 - **Signature:** `class SQLAppE2EFullTest`
-- **Summary:** Deprecated (v4.0) — SQL full-DAG base; use ``testing.e2e.SQLAppE2ETest``.
+- **Summary:** Deprecated (v4.0) — SQL full-DAG base; use ``application_sdk.testing.e2e.SQLAppE2ETest``.
 - **Defined in:** `application_sdk/testing/full_dag/sql_app.py`
 
 #### `SQLAppE2ETest`
@@ -3357,14 +3357,14 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 
 - **Import:** `from application_sdk.testing.full_dag import build_ae_payload`
 - **Signature:** `build_ae_payload(*, *, ...)`
-- **Summary:** Deprecated (v4.0) — AE submit body; use ``testing.e2e.payload``.
+- **Summary:** Deprecated (v4.0) — AE submit body; use ``application_sdk.testing.e2e.payload``.
 - **Defined in:** `application_sdk/testing/full_dag/payload.py`
 
 #### `build_seed_dag`
 
 - **Import:** `from application_sdk.testing.full_dag import build_seed_dag`
 - **Signature:** `build_seed_dag(*, *, ...)`
-- **Summary:** Deprecated (v4.0) — seed-version DAG; use ``testing.e2e.payload``.
+- **Summary:** Deprecated (v4.0) — seed-version DAG; use ``application_sdk.testing.e2e.payload``.
 - **Defined in:** `application_sdk/testing/full_dag/payload.py`
 
 #### `clean_app_registry`

--- a/docs/standards/connector-ci-e2e.md
+++ b/docs/standards/connector-ci-e2e.md
@@ -14,7 +14,21 @@ This doc covers what the SDK ships — the composite action, the reusable workfl
 | `e2e-full-reusable.yaml` reusable workflow | `.github/workflows/e2e-full-reusable.yaml` | Boilerplate (120-min timeout, concurrency group, env wiring, agent-name resolution) for the full-DAG pipeline. Connector repos `uses:` it as a 5-line wrapper. |
 | `e2e-apps` cross-repo dispatcher | `.github/actions/e2e-apps/action.yaml` | Fires `workflow_dispatch` on the connector repo with the apps-sdk PR's head SHA. Polls for completion, surfaces a sticky status comment on the SDK PR. |
 | `BaseSDRIntegrationTest` | `application_sdk/testing/sdr/` | pytest base for the SDR pipeline. Connector test class declares `Scenario(...)` instances. |
-| `SQLAppE2EFullTest` / `BaseFullDAGE2ETest` | `application_sdk/testing/full_dag/` | pytest base for the full-DAG pipeline. Connector subclasses with `include_filter`, `expected_min_asset_counts`, `database_spec()`, etc. |
+| `BaseE2ETest` / `SQLAppE2ETest` | `application_sdk/testing/e2e/` | pytest base for the full-DAG pipeline. `BaseE2ETest` is connector-agnostic and is what the codegen'd `app/generated/_e2e_base.py` subclasses; SQL connectors use `SQLAppE2ETest` on top of it, subclassing with `include_filter`, `expected_min_asset_counts`, `database_spec()`, etc. |
+| ~~`SQLAppE2EFullTest` / `BaseFullDAGE2ETest`~~ | `application_sdk/testing/full_dag/` | **Deprecated, removed in v4.0.** The predecessor of the row above; it emits a `DeprecationWarning` on import and its client / error types are already re-exports of the `testing/e2e` ones. Do not start a new suite here — see [Which harness](#which-harness). |
+
+## Which harness
+
+New suites use `application_sdk.testing.e2e`. Nothing new should be written against `application_sdk.testing.full_dag`.
+
+| Your connector | Subclass |
+|---|---|
+| SQL | `application_sdk.testing.e2e.SQLAppE2ETest` |
+| Anything else (BI, API, object-store, agent apps) | the generated `app/generated/_e2e_base.py`, which subclasses `application_sdk.testing.e2e.BaseE2ETest` |
+
+`BaseE2ETest` is connector-agnostic and is already the base for every scaffolded app. The SQL-shaped parameter rows (`include-filter` / `exclude-filter`) come from `SQLAppE2ETest`, not from the base — so "my connector is not SQL, so I need the old harness" does not follow. If a non-SQL connector genuinely cannot express its manifest tokens through `BaseE2ETest`, that is an SDK gap worth filing, not a reason to start a `full_dag` suite.
+
+`application_sdk.testing.full_dag` is deprecated and removed in v4.0. It emits a `DeprecationWarning` on import, and its `client` / `_errors` modules are already thin re-exports of the `testing/e2e` ones. Suites still on it (domo, looker, saperp at time of writing) are pinned to released SDKs where it still works; they need migrating before a v4 repin, not preserving as a second supported path.
 
 ## The two pipelines
 
@@ -1001,7 +1015,7 @@ run that should have failed.
 1. **Action manifest**: `app.yaml` at repo root (3 lines).
 2. **Unified workflow**: copy `.github/workflows/tests.yaml` from mysql-app; swap connector references. This single file covers unit + integration tests (always) and full-DAG e2e (on the `e2e` label or `run_e2e=true` dispatch input).
 3. **Config dir**: create `.github/sdr-e2e/` (new) or `.github/e2e/` (legacy). Files: `docker-compose.ci.yml`, `e2e-full-docker-compose.yaml`, `e2e-full-components/`, `seed.sql`, `make-secrets.py`, `make-secrets-e2e-full.py`.
-4. **Tests**: unit + integration tests under `tests/unit/` and `tests/integration/`; full-DAG e2e under `tests/e2e/` (`SQLAppE2EFullTest` subclass). On a bundle app, one `tests/e2e/test_*.py` **per entrypoint** — see [Multi-entrypoint (bundle) apps](#multi-entrypoint-bundle-apps-one-suite-per-entrypoint).
+4. **Tests**: unit + integration tests under `tests/unit/` and `tests/integration/`; full-DAG e2e under `tests/e2e/` (`SQLAppE2ETest` subclass for SQL connectors, otherwise the generated `BaseE2ETest` subclass — see [Which harness](#which-harness)). On a bundle app, one `tests/e2e/test_*.py` **per entrypoint** — see [Multi-entrypoint (bundle) apps](#multi-entrypoint-bundle-apps-one-suite-per-entrypoint).
 5. **Repo secrets**: set the 7 entries from the table above.
 6. **SDK matrix**: add `<connector>-app` to the `DEFAULT_MATRIX` in apps-sdk's `matrix-builder` job (`pull_request.yaml`) so `connector-tests` fans out to your connector automatically.
 7. **Required check**: make `tests / Tests Gate` a required, unbypassable status check on the default branch, and remove any stale required checks left over from older workflows (`unit-tests`, `tests-passed`, …). Do this as soon as step 2 is merged — see below.
@@ -1050,7 +1064,7 @@ pass/fail already blocks publish while the 85% threshold only annotates.
 - SDR composite action: [`.github/actions/sdr-e2e/action.yaml`](../../.github/actions/sdr-e2e/action.yaml)
 - Full-DAG reusable workflow: [`.github/workflows/e2e-full-reusable.yaml`](../../.github/workflows/e2e-full-reusable.yaml)
 - Cross-repo dispatcher action: [`.github/actions/e2e-apps/action.yaml`](../../.github/actions/e2e-apps/action.yaml)
-- Test harness: [`application_sdk/testing/full_dag/`](../../application_sdk/testing/full_dag/)
+- Test harness: [`application_sdk/testing/e2e/`](../../application_sdk/testing/e2e/) (the deprecated predecessor, [`application_sdk/testing/full_dag/`](../../application_sdk/testing/full_dag/), is removed in v4.0)
 - Series of merged PRs that built this:
   - [#1669](https://github.com/atlanhq/application-sdk/pull/1669) — SDR composite + pytest base
   - [#1710](https://github.com/atlanhq/application-sdk/pull/1710) — Cross-repo dispatch + full-DAG harness + sticky comments


### PR DESCRIPTION
## Problem

`application_sdk.testing.full_dag` has emitted a `DeprecationWarning` naming v4.0 since #2877, and its `client` / `_errors` modules are already thin re-exports of the `testing/e2e` ones. But the doc a connector author actually reads never said so.

`docs/standards/connector-ci-e2e.md` had **zero** occurrences of "deprecat" while routing people straight to the old harness:

- the "What the SDK ships" table listed `SQLAppE2EFullTest` / `BaseFullDAGE2ETest` as *the* full-DAG pytest base
- the new-connector checklist said to subclass `SQLAppE2EFullTest`
- "Test harness:" in the references linked `application_sdk/testing/full_dag/`

...while the *body* of the same doc already describes `BaseE2ETest`. `docs/agents/sdk-capabilities.md` listed all eight full_dag symbols unmarked, and `full_dag/__init__.py` described itself as the canonical harness for 40 lines before its own `warnings.warn`.

That is how new suites keep getting started on a module that is removed in v4.0.

## The "non-SQL needs full_dag" belief

Two of the three remaining consumers justify staying by comparing against `SQLAppE2ETest` rather than `BaseE2ETest`:

> the `application_sdk.testing.e2e.SQLAppE2ETest` Argo-string parameter path does not fit — atlan-saperp-app

`BaseE2ETest` is connector-agnostic, and it is what the codegen'd `app/generated/_e2e_base.py` subclasses in **20 repos**, including plenty of non-SQL ones (anaplan, cognos, thoughtspot, mode, glean, fabric, gcs, soda, coalesce, powercenter, metabase, openapi). The SQL-shaped rows come from `SQLAppE2ETest`, not from the base. saperp also cites "the fleet runbook prescribes" full_dag for non-SQL connectors — and the runbook did, which is the doc this PR fixes.

## Change

- **New "Which harness" section** in `connector-ci-e2e.md`: SQL → `SQLAppE2ETest`; everything else → the generated `BaseE2ETest` subclass. States that a non-SQL connector that genuinely cannot express its manifest tokens through `BaseE2ETest` is an SDK gap worth filing, not a reason to start a `full_dag` suite.
- Corrected the components table (deprecated row kept, struck through, pointing at the replacement), the checklist and the references link.
- Deprecation banner on the `full_dag` module docstring, with the reasoning above.
- Each public `full_dag` docstring now leads with the deprecation, so the generated capability manifest carries it (regenerated; the only content drift is those four summaries).

Docs and docstrings only — no behaviour change. `DeprecationWarning` verified to still fire on submodule import.

## Remaining consumers

domo, looker, saperp — all pinned to released SDKs where the module still works. They need migrating before a v4 repin; this PR does not touch them.