### PR TITLE
fix(testing): make DatabaseSpec.connector_config_name a warned fallback

### DIFF
--- a/application_sdk/testing/e2e/base.py
+++ b/application_sdk/testing/e2e/base.py
@@ -37,6 +37,7 @@ import secrets
 import time
 import urllib.error
 import urllib.request
+import warnings
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -89,6 +90,12 @@ from application_sdk.testing.e2e.payload import (
 from application_sdk.testing.e2e.substitutions import MustacheSubstitutions
 
 logger = get_logger(__name__)
+
+# Version that drops the deprecated ``DatabaseSpec.connector_config_name``
+# fallback in :meth:`BaseE2ETest.resolved_connector_config_name`. Every
+# deprecation in this SDK names its removal version; this is the one for that
+# field.
+DATABASE_SPEC_CREDENTIAL_TYPE_REMOVAL_VERSION = "4.0"
 
 # Node statuses that are a genuine failure and are never tolerated by the
 # skip-tolerant DAG gate (see BaseE2ETest._core_dag_ok). Pending/Scheduled are
@@ -433,8 +440,14 @@ class BaseE2ETest:
     tenant_deployment_name: ClassVar[str] = "production"
     extract_workflow_type: ClassVar[str] = ""
     # Credential-config name for the ``credential-guid.credential-type`` routing
-    # row + the credential body's ``connectorConfigName`` backfill. Empty =>
-    # build_ae_payload defaults it to ``f"atlan-connectors-{connector_short_name}"``.
+    # row + the credential body's ``connectorConfigName`` backfill. THE place to
+    # declare it — it is what the contract toolkit emits into a bundle's
+    # generated ``_e2e_base.py``, so a value set here is the generated identity.
+    # Read via :meth:`resolved_connector_config_name`, never directly: that
+    # method is the single resolution point, and it also honours (with a
+    # deprecation warning) the legacy ``DatabaseSpec.connector_config_name``
+    # field for suites that set only that one. Both empty =>
+    # build_ae_payload defaults to ``f"atlan-connectors-{connector_short_name}"``.
     connector_config_name: ClassVar[str] = ""
     # Typed substitutions model the harness instantiates for the seed DAG's
     # ``{{...}}`` fills. A connector that declares extra manifest mustache keys
@@ -1320,6 +1333,118 @@ class BaseE2ETest:
                 return parts[0]
         return ""
 
+    def _database_spec_connector_config_name(self) -> str:
+        """The legacy ``DatabaseSpec.connector_config_name``, or ``""``.
+
+        Duck-typed on purpose. ``database_spec()`` is a
+        :class:`~application_sdk.testing.e2e.sql_app.SQLAppE2ETest` hook, but
+        non-SQL suites define it ad hoc on a plain :class:`BaseE2ETest`
+        subclass — and those are exactly the suites that set the deprecated
+        field, so a ``SQLAppE2ETest``-only lookup would miss them.
+
+        Returns ``""`` for a suite with no hook at all and for a
+        ``SQLAppE2ETest`` subclass that has not overridden the default (which
+        raises :class:`HarnessMethodNotImplementedError`); any other exception
+        from the hook propagates, because the caller decides whether this
+        lookup was load-bearing.
+        """
+        hook = getattr(self, "database_spec", None)
+        if not callable(hook):
+            return ""
+        try:
+            spec = hook()
+        except HarnessMethodNotImplementedError:
+            return ""
+        return getattr(spec, "connector_config_name", "") or ""
+
+    def _warn_legacy_connector_config_name(self, disposition: str) -> None:
+        """Emit the ``DatabaseSpec.connector_config_name`` deprecation notice.
+
+        Paired ``DeprecationWarning`` + ``warning`` log line, the same shape
+        every other 4.0 deprecation in this SDK uses: the warning so ``-W
+        error`` and ``filterwarnings`` can make it fatal ahead of the removal,
+        the log line so it is visible in a CI job's captured output where
+        nobody is reading Python's warning filter.
+        """
+        message = (
+            f"{type(self).__name__}: DatabaseSpec.connector_config_name is "
+            f"deprecated and is removed in "
+            f"v{DATABASE_SPEC_CREDENTIAL_TYPE_REMOVAL_VERSION}. {disposition} "
+            f"Declare the credential-config name once, on the "
+            f"`connector_config_name` ClassVar of the test class (a bundle "
+            f"gets it generated into app/generated/<entrypoint>/_e2e_base.py), "
+            f"and drop it from database_spec()."
+        )
+        warnings.warn(message, DeprecationWarning, stacklevel=3)
+        logger.warning("%s", message)
+
+    def resolved_connector_config_name(self) -> str:
+        """The connector's credential-config name — the one resolution point.
+
+        Precedence:
+
+        1. The :attr:`connector_config_name` ClassVar. The supported place to
+           declare it, and what the contract toolkit generates into a bundle's
+           ``_e2e_base.py``.
+        2. ``DatabaseSpec.connector_config_name``, honoured only when the
+           ClassVar is empty.
+
+           .. deprecated:: 3.30.0
+              Removed in v4.0 — set the ClassVar instead.
+        3. ``""``, leaving :func:`~application_sdk.testing.e2e.payload.build_ae_payload`
+           to derive ``f"atlan-connectors-{connector_short_name}"``.
+
+        The deprecated field never outranks the ClassVar: it is hand-written
+        per suite while the ClassVar can be generated, so letting the
+        hand-written copy win would silently override a generated identity —
+        the same trap this precedence exists to close, only mirrored.
+
+        Setting the field warns either way, naming what actually happened to
+        the value: honoured (the ClassVar was empty), ignored (the ClassVar
+        disagreed), or redundant (both agreed). A suite that declares it is
+        told which, instead of having to guess whether it is wired.
+        """
+        declared = self.connector_config_name
+        if declared:
+            # The ClassVar already answered; this lookup only decides which
+            # deprecation notice to emit, so a hook that cannot be built must
+            # not take the payload down with it. A suite that genuinely needs
+            # database_spec() calls it again in _credential_body() /
+            # _mustache_substitutions(), where the failure carries its own cause.
+            try:
+                legacy = self._database_spec_connector_config_name()
+            except Exception:
+                logger.warning(
+                    "%s: could not read database_spec() while checking for a "
+                    "deprecated connector_config_name; using the "
+                    "connector_config_name ClassVar (%s).",
+                    type(self).__name__,
+                    declared,
+                    exc_info=True,
+                )
+                return declared
+            if legacy and legacy != declared:
+                self._warn_legacy_connector_config_name(
+                    f"It is set to {legacy!r} and was IGNORED — the "
+                    f"`connector_config_name` ClassVar ({declared!r}) is "
+                    f"authoritative and is what this run submits."
+                )
+            elif legacy:
+                self._warn_legacy_connector_config_name(
+                    f"It restates the `connector_config_name` ClassVar "
+                    f"({declared!r}) and has no effect."
+                )
+            return declared
+
+        legacy = self._database_spec_connector_config_name()
+        if legacy:
+            self._warn_legacy_connector_config_name(
+                f"It is set to {legacy!r} and the `connector_config_name` "
+                f"ClassVar is empty, so this run is submitting the field's "
+                f"value."
+            )
+        return legacy
+
     def _build_ae_payload(self, slug: str) -> dict[str, Any]:
         """Compose the AE submit payload from typed hook results.
 
@@ -1339,7 +1464,7 @@ class BaseE2ETest:
             ae_workflow_slug=slug,
             entrypoint=self._resolved_entrypoint(),
             agent_json=self.agent_json(),
-            credential_type=self.connector_config_name,
+            credential_type=self.resolved_connector_config_name(),
         )
 
     def _build_legacy_seed_dag(self, extract_queue: str) -> dict[str, Any]:

--- a/application_sdk/testing/e2e/payload.py
+++ b/application_sdk/testing/e2e/payload.py
@@ -110,7 +110,22 @@ class DatabaseSpec:
     password: str
     auth_type: str = "basic"
     extra: dict[str, Any] = field(default_factory=dict)
-    connector_config_name: str = ""  # e.g. atlan-connectors-mysql
+    # e.g. atlan-connectors-mysql.
+    #
+    # .. deprecated:: 3.30.0
+    #    Set the ``connector_config_name`` ClassVar on the test class instead
+    #    (:attr:`application_sdk.testing.e2e.base.BaseE2ETest.connector_config_name`)
+    #    — that is the one the toolkit generates into a bundle's
+    #    ``_e2e_base.py``. This field is removed in v4.0.
+    #
+    # Until then it is a *fallback*, resolved by
+    # :meth:`~application_sdk.testing.e2e.base.BaseE2ETest.resolved_connector_config_name`:
+    # honoured when the ClassVar is empty, ignored (with a warning) when the
+    # ClassVar is set. It is never silently inert, and it never outranks the
+    # ClassVar. Note the separate, NOT-deprecated ``connector_config_name``
+    # field on the codegen'd ``<Connector>AgentCredentialBody`` — that one is a
+    # wire field on the credential body and is unrelated to this.
+    connector_config_name: str = ""
 
 
 @dataclass(frozen=True)

--- a/application_sdk/testing/e2e/sql_app.py
+++ b/application_sdk/testing/e2e/sql_app.py
@@ -63,6 +63,8 @@ class SQLAppE2ETest(BaseE2ETest):
             argo_template_name = "atlan-mysql"
             mode = RunMode.AGENT
             app_service_url = "http://mysql.mysql-app.svc.cluster.local"
+            # The credential-config name lives here, not on DatabaseSpec.
+            connector_config_name = "atlan-connectors-mysql"
 
             include_filter = r"^def\\.e2e_main$"
             qi_input_prefix_field = "transformed_data_prefix"
@@ -74,7 +76,6 @@ class SQLAppE2ETest(BaseE2ETest):
                 return DatabaseSpec(
                     host="mysql", port=3306,
                     username="e2e_user", password="e2e_pass",
-                    connector_config_name="atlan-connectors-mysql",
                 )
 
             def _credential_body(self):

--- a/tests/unit/testing/e2e/test_base_e2e.py
+++ b/tests/unit/testing/e2e/test_base_e2e.py
@@ -20,6 +20,7 @@ import pytest
 from application_sdk.contracts.types import ConnectionRef
 from application_sdk.testing.e2e._errors import (
     DAGProgressStalledError,
+    HarnessMethodNotImplementedError,
     ManifestDagMissingError,
     ManifestFileNotFoundError,
     MissingHarnessClassAttrError,
@@ -39,7 +40,8 @@ from application_sdk.testing.e2e.client import (
     DAGRunResult,
     DAGRunStatus,
 )
-from application_sdk.testing.e2e.payload import AgentSpec, RunMode
+from application_sdk.testing.e2e.credential import CredentialBody
+from application_sdk.testing.e2e.payload import AgentSpec, DatabaseSpec, RunMode
 from application_sdk.testing.e2e.substitutions import MustacheSubstitutions
 
 
@@ -1748,3 +1750,153 @@ class TestTeardownPurgeBatching:
         harness = _ConcreteE2ETest()
         harness.connection_qualified_name = "default/openapi/1787587123106596"
         harness.teardown_method(method=None)  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# resolved_connector_config_name — FND-857
+# ---------------------------------------------------------------------------
+
+
+class _NoDatabaseSpecTest(_ConcreteE2ETest):
+    """A suite with no ``database_spec()`` hook at all (the common non-SQL shape)."""
+
+
+class _LegacyFieldOnlyTest(_ConcreteE2ETest):
+    """Declares the credential-config name only on the deprecated spec field.
+
+    This is the metabase shape: a plain ``BaseE2ETest`` subclass that defines
+    ``database_spec()`` ad hoc (there is no such hook on the base) and sets
+    ``connector_config_name`` on the returned :class:`DatabaseSpec`.
+    """
+
+    def database_spec(self) -> DatabaseSpec:
+        return DatabaseSpec(
+            host="metabase",
+            port=3000,
+            username="u",
+            password="p",
+            connector_config_name="atlan-connectors-legacy",
+        )
+
+
+class _BothAgreeTest(_LegacyFieldOnlyTest):
+    """The mysql shape: ClassVar pinned, spec field restating it."""
+
+    connector_config_name = "atlan-connectors-legacy"
+
+
+class _BothDisagreeTest(_LegacyFieldOnlyTest):
+    """ClassVar and spec field give different answers — the field loses."""
+
+    connector_config_name = "atlan-connectors-classvar"
+
+
+class _BrokenSpecWithClassVarTest(_ConcreteE2ETest):
+    """ClassVar answers; ``database_spec()`` blows up on an unrelated cause."""
+
+    connector_config_name = "atlan-connectors-classvar"
+
+    def database_spec(self) -> DatabaseSpec:
+        raise RuntimeError("credentials env not set")
+
+
+class TestResolvedConnectorConfigName:
+    def test_classvar_is_used_when_set(self) -> None:
+        class _T(_ConcreteE2ETest):
+            connector_config_name = "atlan-connectors-classvar"
+
+        assert _T().resolved_connector_config_name() == "atlan-connectors-classvar"
+
+    def test_empty_when_nothing_declared(self) -> None:
+        """Both empty leaves build_ae_payload to derive the conventional name."""
+        assert _NoDatabaseSpecTest().resolved_connector_config_name() == ""
+
+    def test_sql_default_hook_is_not_an_error(self) -> None:
+        """An unoverridden ``SQLAppE2ETest.database_spec()`` raises; that is a
+        "no legacy value here", not a harness failure."""
+
+        class _T(_ConcreteE2ETest):
+            def database_spec(self) -> DatabaseSpec:
+                raise HarnessMethodNotImplementedError(
+                    message="subclass must override database_spec()",
+                    operation="database_spec",
+                )
+
+        assert _T().resolved_connector_config_name() == ""
+
+    def test_legacy_field_is_honoured_when_classvar_empty(self) -> None:
+        """The point of the ticket: the field consumers populate is not inert."""
+        harness = _LegacyFieldOnlyTest()
+        with pytest.warns(DeprecationWarning, match="DatabaseSpec"):
+            assert harness.resolved_connector_config_name() == "atlan-connectors-legacy"
+
+    def test_honoured_warning_says_the_value_is_being_submitted(self) -> None:
+        with pytest.warns(DeprecationWarning) as record:
+            _LegacyFieldOnlyTest().resolved_connector_config_name()
+        message = str(record[0].message)
+        assert "atlan-connectors-legacy" in message
+        assert "submitting" in message
+        assert "removed in v4.0" in message
+        assert "connector_config_name` ClassVar" in message
+
+    def test_classvar_wins_over_a_disagreeing_legacy_field(self) -> None:
+        """Never let the hand-written copy override a generated identity."""
+        harness = _BothDisagreeTest()
+        with pytest.warns(DeprecationWarning, match="IGNORED"):
+            assert (
+                harness.resolved_connector_config_name() == "atlan-connectors-classvar"
+            )
+
+    def test_ignored_warning_names_both_values(self) -> None:
+        with pytest.warns(DeprecationWarning) as record:
+            _BothDisagreeTest().resolved_connector_config_name()
+        message = str(record[0].message)
+        assert "atlan-connectors-legacy" in message
+        assert "atlan-connectors-classvar" in message
+
+    def test_agreeing_legacy_field_still_warns_as_redundant(self) -> None:
+        """Agreement today is luck, not wiring — the line still has to go."""
+        harness = _BothAgreeTest()
+        with pytest.warns(DeprecationWarning, match="no effect"):
+            assert harness.resolved_connector_config_name() == "atlan-connectors-legacy"
+
+    def test_broken_database_spec_does_not_break_a_declared_classvar(self) -> None:
+        """The lookup is advisory once the ClassVar has answered, so a hook that
+        cannot be built must not take the payload down with it."""
+        harness = _BrokenSpecWithClassVarTest()
+        assert harness.resolved_connector_config_name() == "atlan-connectors-classvar"
+
+    def test_broken_database_spec_propagates_when_it_is_load_bearing(self) -> None:
+        """With no ClassVar the hook is the only source, so swallowing here
+        would silently fall back to the conventional name — the original trap."""
+
+        class _T(_ConcreteE2ETest):
+            def database_spec(self) -> DatabaseSpec:
+                raise RuntimeError("credentials env not set")
+
+        with pytest.raises(RuntimeError, match="credentials env not set"):
+            _T().resolved_connector_config_name()
+
+    def test_build_ae_payload_submits_the_legacy_value(self) -> None:
+        """End to end: the field reaches the wire, not just the resolver.
+
+        ``connectorConfigName`` is backfilled onto the credential body from the
+        resolved credential type, so a body that does not set one is what shows
+        whether the resolution reached the submit.
+        """
+
+        class _T(_LegacyFieldOnlyTest):
+            def _credential_body(self) -> CredentialBody:
+                return CredentialBody()
+
+        harness = _T()
+        harness.run_id = 1
+        harness.connection_qualified_name = "default/openapi/1"
+        harness.connection_display_name = "openapi-1"
+        harness._admin_role_guid = "role-guid-123"
+
+        with pytest.warns(DeprecationWarning):
+            payload = harness._build_ae_payload("openapi-slug")
+
+        body = payload["payload"][0]["body"]
+        assert body["connectorConfigName"] == "atlan-connectors-legacy"

--- a/tests/unit/testing/e2e/test_sql_app_e2e.py
+++ b/tests/unit/testing/e2e/test_sql_app_e2e.py
@@ -36,7 +36,6 @@ _DATABASE = DatabaseSpec(
     port=3306,
     username="user",
     password="pass",
-    connector_config_name="atlan-connectors-mysql",
 )
 
 _AGENT = AgentSpec(agent_name="mysql-e2e-ci-1")
@@ -263,6 +262,7 @@ class _ConcreteSQLTest(SQLAppE2ETest):
     argo_template_name = "atlan-mysql"
     mode = RunMode.AGENT
     app_service_url = "http://mysql.svc"
+    connector_config_name = "atlan-connectors-mysql"
 
     def database_spec(self) -> DatabaseSpec:
         return _DATABASE


### PR DESCRIPTION
### Changelog

- `DatabaseSpec.connector_config_name` (`application_sdk/testing/e2e/payload.py`) was declared and read by **nothing** in `application_sdk/testing/e2e/`. The live value came from the `BaseE2ETest.connector_config_name` ClassVar. Connector authors set the spec field, saw no error, and reasonably believed the credential type was wired — a suite that set only the field and left the ClassVar empty fell back to `atlan-connectors-{connector_short_name}` and silently diverged from what it declared.
- Collapse the two readers into one resolution point, `BaseE2ETest.resolved_connector_config_name()`:
  1. the `connector_config_name` ClassVar, if set;
  2. else `DatabaseSpec.connector_config_name` — **honoured**, with a `DeprecationWarning` + `logger.warning` naming the ClassVar as the replacement and v4.0 as the removal;
  3. else empty, leaving `build_ae_payload` to derive the conventional name exactly as before.
- The deprecated field never outranks the ClassVar, and it is never silently ignored. Setting it warns either way and names what actually happened to the value: **honoured** (ClassVar empty, this run submits the field's value), **IGNORED** (ClassVar set and disagreed — quotes both values), or **redundant** (both agreed, so the line has no effect).
- Fix the `SQLAppE2ETest` class docstring, which had been propagating the trap by setting the field on `DatabaseSpec` in its worked example.
- Add `TestResolvedConnectorConfigName` (11 tests) in `tests/unit/testing/e2e/test_base_e2e.py`.

### Additional context (e.g. screenshots, logs, links)

- Linear: [FND-857](https://linear.app/atlan-epd/issue/FND-857/databasespecconnector-config-name-is-a-trap-consumers-populate-it)
- **Why the ClassVar wins, and not the field.** `contract-toolkit/src/App.pkl` generates `connector_config_name = "..."` into a bundle's `app/generated/<entrypoint>/_e2e_base.py`. Making the spec field authoritative would let a hand-written `database_spec()` silently override a *generated* identity — the same trap, mirrored. A deprecated, hand-written surface must not beat the supported, generatable one.
- **The deprecated `full_dag` package is untouched.** `application_sdk/testing/full_dag/payload.py` declares its **own** independent `DatabaseSpec`; it does not import the `e2e` one, so nothing here reaches it.
- **No consumer change is required, and none is breaking.**
  - An app that declares the name only on its `DatabaseSpec` becomes correct-by-declaration with zero edits — the value it declared is now the value submitted, where previously it was dropped and the conventional fallback used instead. It emits the *honoured* warning until the declaration moves to the ClassVar.
  - An app that sets both (`connector_config_name=self.connector_config_name`) emits the *redundant* warning; the fix is deleting that one kwarg from `database_spec()`.
- `stacklevel=3` points the warning at the caller of `resolved_connector_config_name()`. There is no `filterwarnings = error` in `pyproject.toml`, so this warns rather than breaking any suite today.
- The advisory-vs-load-bearing split on a `database_spec()` that raises is deliberate and covered by tests: the exception **propagates** when the hook is the only source of the value (swallowing there would silently re-open the original trap), and is **swallowed and logged** once the ClassVar has already answered (a suite that genuinely needs the hook calls it again in `_credential_body()` / `_mustache_substitutions()`, where the failure carries its own cause).
- Local verification: `tests/unit/testing/` — 765 passed, 4 skipped. Pre-commit (ruff, ruff-format, isort, pyright) clean.

### Checklist

- [x] Additional tests added
- [ ] All CI checks passed
- [x] Relevant documentation updated

<!-- Docs: the ClassVar comment, the DatabaseSpec field's deprecation note, and the SQLAppE2ETest docstring example are the documentation for this surface; no file under docs/ references connector_config_name. -->

---

### Copyleft License Compliance

- [ ] Have you used any code that is subject to a Copyleft license (e.g., GPL, AGPL, LGPL)?
- [ ] If yes, have you modified the code in the context of this project? please share additional details.
