### PR TITLE
ci(e2e): give each matrix leg its own GlobalProtect identity (FND-279)

### DIFF
--- a/.github/actions/globalprotect-connect/action.yml
+++ b/.github/actions/globalprotect-connect/action.yml
@@ -21,6 +21,16 @@ inputs:
     description: "Maximum number of connection attempts"
     required: false
     default: "3"
+  client-suffix:
+    description: >
+      Extra discriminator folded into --local-hostname. The default identity is
+      run id + GITHUB_JOB + attempt, which is unique ACROSS workflows but NOT
+      across the legs of a matrix job: GITHUB_JOB is the job id from the
+      workflow file, identical for every matrix instance. Concurrent legs then
+      present the same "computer" to GlobalProtect and evict each other's
+      sessions. Any matrix caller must pass a per-leg value (e.g. matrix.name).
+    required: false
+    default: ""
 
 outputs:
   vpn-connected:
@@ -33,6 +43,10 @@ runs:
     - name: Connect via OpenConnect
       uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
       id: openconnect-connection
+      # Passed as env rather than interpolated into `command:` — the value is
+      # caller-supplied and must not be able to reach the shell as source text.
+      env:
+        GP_CLIENT_SUFFIX: ${{ inputs.client-suffix }}
       with:
         max_attempts: ${{ fromJSON(inputs.max-attempts) }}
         # Per-attempt budget. With --max-time 60 on the curl test below, a
@@ -89,7 +103,24 @@ runs:
           # --local-hostname two concurrent VPN jobs sharing these GLOBALPROTECT_*
           # creds (this reviewer plus any other workflow) silently displace each
           # other's tunnels. Derive it from the run id / job / attempt.
-          LOCAL_HOSTNAME="gha-${GITHUB_RUN_ID:-0}-${GITHUB_JOB:-job}-${GITHUB_RUN_ATTEMPT:-1}"
+          #
+          # run id + job + attempt separates WORKFLOWS but not the legs of one
+          # MATRIX job: GITHUB_JOB is the job id from the workflow file, so every
+          # matrix instance reports the same value and the three of them collapse
+          # onto one identity. Observed on atlan-teradata-app run 32928987368,
+          # where the aws/gcp/azure e2e legs connected at 04:12:44, 04:13:22 and
+          # 04:14:47 and only the last one still had a tunnel at crawl time — the
+          # other two failed the crawl with a 10s TCP connect timeout to the
+          # source, surfaced as "Preflight failed: Could not authenticate".
+          # GP_CLIENT_SUFFIX is how a matrix caller keeps its legs distinct.
+          # Keep the suffix's TAIL, not its head. The 63-char cap below cuts
+          # from the end, which is exactly where the discriminating part of a
+          # leg name lives ("...-e2e-aws" vs "...-e2e-gcp") — a long suite name
+          # would truncate the cloud off and silently recreate the collision
+          # this input exists to prevent. Budget 40 chars so the fixed prefix
+          # (gha- + a 11-digit run id + job + attempt) always fits alongside it.
+          GP_CLIENT_SUFFIX=$(printf '%s' "${GP_CLIENT_SUFFIX:-}" | tr -cd 'a-zA-Z0-9-' | rev | cut -c1-40 | rev)
+          LOCAL_HOSTNAME="gha-${GITHUB_RUN_ID:-0}-${GITHUB_JOB:-job}-${GITHUB_RUN_ATTEMPT:-1}${GP_CLIENT_SUFFIX:+-${GP_CLIENT_SUFFIX}}"
           LOCAL_HOSTNAME=$(echo "$LOCAL_HOSTNAME" | tr -cd 'a-zA-Z0-9-' | cut -c1-63)
           echo "Using --local-hostname: ${LOCAL_HOSTNAME}"
 

--- a/.github/workflows/tests-reusable.yaml
+++ b/.github/workflows/tests-reusable.yaml
@@ -2111,6 +2111,12 @@ jobs:
           username: ${{ secrets.GLOBALPROTECT_USERNAME }}
           password: ${{ secrets.GLOBALPROTECT_PASSWORD }}
           mothership-url: https://api.dataforge.atlan.dev
+          # This is a MATRIX job, so the action's default identity (run id +
+          # GITHUB_JOB + attempt) is the same string for every leg and the legs
+          # evict each other's VPN sessions — last connect wins, the rest fail
+          # the crawl on an unreachable source. matrix.name is the per-leg
+          # discriminator (suite x cloud), so each leg is its own "computer".
+          client-suffix: ${{ matrix.name }}
 
       # Dataforge-sourced connector credentials. The fetch's stdout is
       # captured into a shell variable — values never reach the log — and


### PR DESCRIPTION
## What

Adds an optional `client-suffix` input to `globalprotect-connect`, folded into `--local-hostname`, and passes `matrix.name` from the e2e job in `tests-reusable.yaml`.

## Why

The action builds its client identity as:

```bash
LOCAL_HOSTNAME="gha-${GITHUB_RUN_ID}-${GITHUB_JOB}-${GITHUB_RUN_ATTEMPT}"
```

That separates concurrent *workflows*, which is what it was added for. It does **not** separate the legs of a *matrix* job: `GITHUB_JOB` is the job id from the workflow file, identical for every matrix instance. So the aws/gcp/azure e2e legs all present the same identity, GlobalProtect treats "same user + same computer" as a session replacement, and each leg evicts the previous one's tunnel. Last connect wins; the others keep running with no route.

Observed on `atlan-teradata-app` [run 32928987368](https://github.com/atlanhq/atlan-teradata-app/actions/runs/32928987368):

| leg | VPN connected | outcome |
|---|---|---|
| gcp | 04:12:44 | tunnel evicted → crawl failed |
| aws | 04:13:22 | tunnel evicted → crawl failed |
| **azure** | **04:14:47** (last) | kept the tunnel, crawled, published |

The two losers fail with a 10s TCP connect timeout to the source:

```
[Error 446] Teradata connection attempt to socket:<host>:<port> with timeout 10000 ms took 10000 ms and failed
```

which the SDK reports as `Preflight failed: Could not authenticate to the Teradata source.` — an auth message for a routing failure, which is why this reads as bad credentials and gets chased in the wrong direction. FND-279 already records the symptom ("recrawl needed a solo rerun after GP session contention") as environmental. It isn't; it's deterministic, and it means **every connector using a dataforge source across the cloud matrix has had at most one leg per run able to reach its source.**

## Scope

Only the e2e job passes a suffix — it is the only matrix caller of this action. The `integration` job is a single instance and keeps the default, and an empty suffix produces the exact hostname it produces today, so this is a no-op for every existing caller.

## Two details

- The value is passed via `env:` (`GP_CLIENT_SUFFIX`), not `${{ }}` interpolation into `command:`, so caller-supplied text never reaches the shell as source.
- The suffix is truncated from its **head**, keeping the tail. The existing 63-char cap cuts from the end — exactly where leg names differ (`...-e2e-aws` vs `...-e2e-gcp`) — so truncating the other way would silently recreate this collision for a connector with a long suite name.

## Verification

Hostname derivation simulated across cases:

```
suffix=[]                  -> gha-32928987368-e2e-1                     (unchanged)
suffix=[teradata-e2e-aws]  -> gha-32928987368-e2e-1-teradata-e2e-aws
suffix=[teradata-e2e-gcp]  -> gha-32928987368-e2e-1-teradata-e2e-gcp
suffix=[priority-metadata-propagator-app-full-dag-e2e-azure]
                           -> gha-32928987368-e2e-1-tadata-propagator-app-full-dag-e2e-azure
                              (62 chars, cloud preserved)
```

Both files pass the repo's pre-commit hooks, including `check-yaml (GitHub composite-action manifests)`.

The real proof is a teradata e2e run with all three legs reaching the source; that needs this merged, since the VPN step lives inside the reusable and no connector can override it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
