### PR TITLE
feat(testing): scaffold application_sdk/testing/harness/ (FND-238)

### DIFF
--- a/application_sdk/testing/e2e/__init__.py
+++ b/application_sdk/testing/e2e/__init__.py
@@ -4,8 +4,8 @@ Two sub-surfaces live here:
 
 K8s utilities (existing)::
 
+    from application_sdk.testing.harness import AppUnderTest
     from application_sdk.testing.e2e import (
-        AppConfig,
         LogCollector,
         kube_http_call,
         run_workflow,
@@ -30,6 +30,8 @@ from application_sdk.testing.e2e.workflows import run_workflow, wait_for_workflo
 
 __all__ = [
     # K8s utilities
+    # Deprecated (removed in v4.0) — use
+    # application_sdk.testing.harness.AppUnderTest
     "AppConfig",
     "LogCollector",
     "kube_http_call",

--- a/application_sdk/testing/e2e/config.py
+++ b/application_sdk/testing/e2e/config.py
@@ -1,26 +1,67 @@
-"""AppConfig dataclass for K8s e2e test deployments."""
+"""Deprecated home of ``AppConfig``. Use ``harness.AppUnderTest``.
 
+``AppConfig`` here collided by name with :class:`application_sdk.main.AppConfig`,
+which is the authoritative *runtime* config object every app is configured
+through. Two unrelated types sharing a name was tolerable while this one was
+unexported plumbing; it stopped being tolerable at the point the name was about
+to become shared vocabulary across the harness, the runtime scenario suite and
+the connector suites.
+
+The replacement is :class:`application_sdk.testing.harness.AppUnderTest`.
+"""
+
+from __future__ import annotations
+
+import warnings
 from dataclasses import dataclass
 
+from application_sdk.testing.harness.spec import AppUnderTest
 
-@dataclass
-class AppConfig:
-    """Configuration for an app under K8s e2e testing.
+__all__ = ["AppConfig"]
 
-    Args:
-        app_name: K8s resource prefix.
-        app_module: Python module path, e.g. ``"my_app.main:App"``.
-        namespace: K8s namespace to deploy into.
-        image: Full image reference, e.g. ``"ghcr.io/org/my-app:v1.0.0"``.
-        handler_port: Port the handler service listens on.
-        worker_health_port: Port the worker health server listens on.
-        timeout: Deploy timeout in seconds.
+#: Version that removes :class:`AppConfig`. Every deprecation in this SDK names
+#: its removal version; this is the one for that class.
+APP_CONFIG_REMOVAL_VERSION = "4.0"
+
+
+@dataclass(frozen=True, slots=True)
+class AppConfig(AppUnderTest):
+    """Deprecated (removed in v4.0) — use :class:`AppUnderTest`.
+
+    Kept so an existing ``AppConfig(...)`` call site keeps working. The four
+    fields below were never read by anything — not by this package, not by
+    ``tests/e2e/conftest.py``'s fixtures, not by any consumer repo — so they are
+    accepted and ignored rather than carried into
+    :class:`~application_sdk.testing.harness.AppUnderTest`.
+
+    ``AppUnderTest`` also reorders the fields (``app_name``, ``namespace``,
+    ``handler_port``), so construct this by keyword. Both known call sites
+    already do.
+
+    Attributes:
+        app_module: Ignored. Nothing ever read it; a deployer that would have
+            used it was never shipped.
+        image: Ignored, same reason.
+        worker_health_port: Ignored. The worker health probe reads
+            ``BaseE2ETest.worker_health_url``, which carries its own port.
+        timeout: Ignored. Waits take a
+            :class:`~application_sdk.testing.harness.Budget`.
     """
 
-    app_name: str
-    app_module: str
-    namespace: str
-    image: str
-    handler_port: int = 8000
+    app_module: str = ""
+    image: str = ""
     worker_health_port: int = 8081
     timeout: int = 300
+
+    def __post_init__(self) -> None:
+        """Warn that this class is deprecated, naming its replacement."""
+        warnings.warn(
+            "application_sdk.testing.e2e.AppConfig is deprecated and will be "
+            f"removed in v{APP_CONFIG_REMOVAL_VERSION}; use "
+            "application_sdk.testing.harness.AppUnderTest instead. It collides "
+            "by name with application_sdk.main.AppConfig, the runtime config "
+            "object. app_module, image, worker_health_port and timeout are not "
+            "carried over — nothing ever read them.",
+            DeprecationWarning,
+            stacklevel=2,
+        )

--- a/application_sdk/testing/e2e/config.py
+++ b/application_sdk/testing/e2e/config.py
@@ -13,7 +13,6 @@ The replacement is :class:`application_sdk.testing.harness.AppUnderTest`.
 from __future__ import annotations
 
 import warnings
-from dataclasses import dataclass
 
 from application_sdk.testing.harness.spec import AppUnderTest
 
@@ -21,43 +20,80 @@ __all__ = ["AppConfig"]
 
 #: Version that removes :class:`AppConfig`. Every deprecation in this SDK names
 #: its removal version; this is the one for that class.
+#:
+#: The warning text below spells "v4.0" literally rather than interpolating this
+#: constant. Conformance rule B002 reads the notice as written in the source, so
+#: an f-string placeholder makes a compliant deprecation look like one that never
+#: named its removal version. ``test_deprecation_names_a_removal_version`` pins
+#: the two together so they cannot drift.
 APP_CONFIG_REMOVAL_VERSION = "4.0"
 
 
-@dataclass(frozen=True, slots=True)
 class AppConfig(AppUnderTest):
     """Deprecated (removed in v4.0) — use :class:`AppUnderTest`.
 
-    Kept so an existing ``AppConfig(...)`` call site keeps working. The four
-    fields below were never read by anything — not by this package, not by
-    ``tests/e2e/conftest.py``'s fixtures, not by any consumer repo — so they are
-    accepted and ignored rather than carried into
-    :class:`~application_sdk.testing.harness.AppUnderTest`.
+    A subclass, so a downstream fixture already annotated ``-> AppUnderTest``
+    accepts an ``AppConfig`` unchanged for the whole migration window.
 
-    ``AppUnderTest`` also reorders the fields (``app_name``, ``namespace``,
-    ``handler_port``), so construct this by keyword. Both known call sites
-    already do.
+    **The positional signature is preserved exactly**, which is why this declares
+    an explicit ``__init__`` instead of inheriting a generated one. Field order
+    on :class:`AppUnderTest` is ``(app_name, namespace, handler_port)``, so a
+    dataclass-generated subclass ``__init__`` would have bound
+    ``AppConfig("app", "module", "ns", "image")`` as ``namespace="module"`` and
+    ``handler_port="ns"`` — accepted silently, wrong at every read. A shim that
+    mis-binds its arguments is a silent break, not a deprecation.
 
-    Attributes:
-        app_module: Ignored. Nothing ever read it; a deployer that would have
+    Four of the seven fields were never read by anything — not by this package,
+    not by ``tests/e2e/conftest.py``'s fixtures, not by any consumer repo — so
+    they are accepted and stored but carry no meaning. They are absent from
+    :class:`AppUnderTest`.
+
+    Two other compatibility details, both deliberate:
+
+    * **Mutability is preserved.** :class:`AppUnderTest` is frozen; the original
+      ``AppConfig`` was a plain mutable dataclass, so ``cfg.timeout = 600``
+      worked. Freezing it here would be a second silent break in the same shim,
+      so ``__setattr__`` and ``__delattr__`` are restored.
+    * ``__eq__`` and ``__repr__`` come from :class:`AppUnderTest` and therefore
+      consider only the three live fields. Two ``AppConfig`` instances differing
+      only in ``image`` compare equal — correct, given ``image`` has no effect on
+      anything.
+
+    Args:
+        app_name: Kubernetes resource prefix.
+        app_module: Ignored. Nothing ever read it; the deployer that would have
             used it was never shipped.
-        image: Ignored, same reason.
+        namespace: Kubernetes namespace the app is deployed into.
+        image: Ignored, same reason as ``app_module``.
+        handler_port: Port the handler Service listens on.
         worker_health_port: Ignored. The worker health probe reads
             ``BaseE2ETest.worker_health_url``, which carries its own port.
         timeout: Ignored. Waits take a
             :class:`~application_sdk.testing.harness.Budget`.
     """
 
-    app_module: str = ""
-    image: str = ""
-    worker_health_port: int = 8081
-    timeout: int = 300
+    __slots__ = ("app_module", "image", "timeout", "worker_health_port")
 
-    def __post_init__(self) -> None:
-        """Warn that this class is deprecated, naming its replacement."""
+    def __init__(
+        self,
+        app_name: str = "",
+        app_module: str = "",
+        namespace: str = "",
+        image: str = "",
+        handler_port: int = 8000,
+        worker_health_port: int = 8081,
+        timeout: int = 300,
+    ) -> None:
+        """Construct the shim, warning that it is deprecated.
+
+        Positional order is the original's, verbatim. The four originally
+        required fields now default to empty rather than raising, because a
+        deprecation shim should accept everything the old signature accepted and
+        a little more — never less.
+        """
         warnings.warn(
             "application_sdk.testing.e2e.AppConfig is deprecated and will be "
-            f"removed in v{APP_CONFIG_REMOVAL_VERSION}; use "
+            "removed in v4.0; use "
             "application_sdk.testing.harness.AppUnderTest instead. It collides "
             "by name with application_sdk.main.AppConfig, the runtime config "
             "object. app_module, image, worker_health_port and timeout are not "
@@ -65,3 +101,19 @@ class AppConfig(AppUnderTest):
             DeprecationWarning,
             stacklevel=2,
         )
+        # AppUnderTest is frozen, so its generated __init__ is the only way in.
+        super().__init__(
+            app_name=app_name, namespace=namespace, handler_port=handler_port
+        )
+        object.__setattr__(self, "app_module", app_module)
+        object.__setattr__(self, "image", image)
+        object.__setattr__(self, "worker_health_port", worker_health_port)
+        object.__setattr__(self, "timeout", timeout)
+
+    def __setattr__(self, name: str, value: object) -> None:
+        """Restore the original's mutability — see the class docstring."""
+        object.__setattr__(self, name, value)
+
+    def __delattr__(self, name: str) -> None:
+        """Restore the original's mutability — see the class docstring."""
+        object.__delattr__(self, name)

--- a/application_sdk/testing/harness/__init__.py
+++ b/application_sdk/testing/harness/__init__.py
@@ -61,7 +61,10 @@ deliberately *not* folded into ``[tests]``: a connector installing test extras
 should not pull a Kubernetes client.
 """
 
-from application_sdk.testing.harness._errors import SyncBridgeInAsyncContextError
+from application_sdk.testing.harness._errors import (
+    HarnessNotBuiltError,
+    SyncBridgeInAsyncContextError,
+)
 from application_sdk.testing.harness.bridge import close_loop, run_sync
 from application_sdk.testing.harness.budgets import Budget, BudgetProfile
 from application_sdk.testing.harness.outcome import (
@@ -79,6 +82,9 @@ from application_sdk.testing.harness.waiting import Probe, hold_stable, poll_unt
 __all__ = [
     # The sync bridge — test-harness only
     "SyncBridgeInAsyncContextError",
+    # Raised by every not-yet-implemented scaffold function; also a
+    # NotImplementedError, so `except NotImplementedError` still catches it.
+    "HarnessNotBuiltError",
     "close_loop",
     "run_sync",
     # Bounded waits

--- a/application_sdk/testing/harness/__init__.py
+++ b/application_sdk/testing/harness/__init__.py
@@ -1,0 +1,101 @@
+"""Shared test-harness plumbing: bounded waits, outcomes, budgets, readers, starters.
+
+Not ``testing.e2e``, because this surface serves runtime scaling scenarios,
+cluster reads and chaos injection as well as end-to-end connector runs — none of
+which are end-to-end connector runs. ``testing.e2e`` keeps its name, its import
+paths and its public surface; it is re-expressed *over* this package in place
+(child H on FND-224), so no connector, no generated ``_e2e_base.py`` and no
+conformance rule sees a diff.
+
+Three consumers, one core:
+
+* **connector suites** — ``BaseE2ETest`` / ``SQLAppE2ETest``, unchanged names and
+  behaviour, expressed over these functions.
+* **the runtime scenario suite** (``atlanhq/app-runtime-test-suite``) — Python,
+  out-of-cluster, driving these readers and waits from its own scenario format.
+* **composers** — anything that wants the setup/teardown steps as async fixtures
+  rather than as a base class to inherit.
+
+Everything below the pytest boundary is ``async`` (decision D1). The one bridge
+back to blocking code is :func:`~application_sdk.testing.harness.bridge.run_sync`,
+exported here and documented as test-harness-only — see that module for why it
+does not live in ``application_sdk.common``.
+
+Module map:
+
+``bridge``
+    The one sync/async bridge. One reused event loop per thread.
+``waiting``
+    ``poll_until`` and ``hold_stable`` — the only two bounded-wait shapes.
+``outcome``
+    What a wait returns: settled, never-started, stalled, expired, indeterminate.
+``budgets``
+    One typed ``Budget`` per wait, and named per-tier profiles.
+``identity``
+    Run-id and unique-name minting, behind a clock seam.
+``expectations``
+    The two pure evaluators — asset counts and qualified-name locations.
+``evidence``
+    Evidence bundle collection, and redaction at the boundary that ships it.
+``spec``
+    ``AppUnderTest`` — where to find the app under test in a cluster.
+``cluster``
+    Read-only Kubernetes Protocols and the states they return.
+``temporal``
+    Read-only Temporal Protocol — pollers and workflow status.
+``atlas``
+    Atlas reads, split out of ``testing/e2e/client.py``.
+``automation_engine``
+    AE reads and the non-idempotent submit's retry, from the same split.
+``starters``
+    Three ways to start a workflow; deliberately no shared signature.
+``teardown``
+    Purge mechanics, including the batching that is a correctness bound.
+
+Most of it is typed stubs at this point: this package is the scaffold from
+FND-238, and each module names the child issue that fills it in.
+
+The optional ``harness`` extra carries the typed Kubernetes backend for
+``cluster`` (``pip install 'atlan-application-sdk[harness]'``). It is
+deliberately *not* folded into ``[tests]``: a connector installing test extras
+should not pull a Kubernetes client.
+"""
+
+from application_sdk.testing.harness._errors import SyncBridgeInAsyncContextError
+from application_sdk.testing.harness.bridge import close_loop, run_sync
+from application_sdk.testing.harness.budgets import Budget, BudgetProfile
+from application_sdk.testing.harness.outcome import (
+    Expired,
+    Indeterminate,
+    NeverStarted,
+    Outcome,
+    Settled,
+    Stalled,
+    assert_settled,
+)
+from application_sdk.testing.harness.spec import AppUnderTest
+from application_sdk.testing.harness.waiting import Probe, hold_stable, poll_until
+
+__all__ = [
+    # The sync bridge — test-harness only
+    "SyncBridgeInAsyncContextError",
+    "close_loop",
+    "run_sync",
+    # Bounded waits
+    "Probe",
+    "hold_stable",
+    "poll_until",
+    # Outcomes
+    "Expired",
+    "Indeterminate",
+    "NeverStarted",
+    "Outcome",
+    "Settled",
+    "Stalled",
+    "assert_settled",
+    # Budgets
+    "Budget",
+    "BudgetProfile",
+    # App under test
+    "AppUnderTest",
+]

--- a/application_sdk/testing/harness/_errors.py
+++ b/application_sdk/testing/harness/_errors.py
@@ -1,0 +1,29 @@
+"""Typed error leaves for the shared test harness.
+
+Private module: leaves that are public surface are re-exported from
+:mod:`application_sdk.testing.harness`. Mirrors
+:mod:`application_sdk.testing.e2e._errors`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import ClassVar
+
+from application_sdk.errors.leaves import PreconditionError
+
+__all__ = ["SyncBridgeInAsyncContextError"]
+
+
+@dataclass(kw_only=True)
+class SyncBridgeInAsyncContextError(PreconditionError):
+    """:func:`~application_sdk.testing.harness.run_sync` was called from a running loop.
+
+    The bridge owns its thread's event loop, so it cannot be re-entered from
+    inside one: ``run_until_complete`` on a running loop raises, and standing up
+    a second loop on the same thread would fragment every client the harness
+    caches per loop. The caller wants the ``_async`` twin of whatever it called.
+    """
+
+    code: ClassVar[str] = "PRECONDITION_SYNC_BRIDGE_IN_ASYNC_CONTEXT"
+    component: str | None = "harness_sync_bridge"

--- a/application_sdk/testing/harness/_errors.py
+++ b/application_sdk/testing/harness/_errors.py
@@ -10,9 +10,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import ClassVar
 
-from application_sdk.errors.leaves import PreconditionError
+from application_sdk.errors.leaves import PreconditionError, UnimplementedError
 
-__all__ = ["SyncBridgeInAsyncContextError"]
+__all__ = ["HarnessNotBuiltError", "SyncBridgeInAsyncContextError"]
 
 
 @dataclass(kw_only=True)
@@ -27,3 +27,27 @@ class SyncBridgeInAsyncContextError(PreconditionError):
 
     code: ClassVar[str] = "PRECONDITION_SYNC_BRIDGE_IN_ASYNC_CONTEXT"
     component: str | None = "harness_sync_bridge"
+
+
+@dataclass(kw_only=True)
+class HarnessNotBuiltError(UnimplementedError, NotImplementedError):
+    """A scaffolded harness function whose implementation has not landed yet.
+
+    Inherits :class:`NotImplementedError` alongside the SDK's
+    :class:`~application_sdk.errors.leaves.UnimplementedError` leaf so both hold:
+    it is a typed leaf carrying a category and an audience, *and* it is still
+    what Python's convention — and any reader's ``except`` — expects from a
+    function that has not been written.
+
+    :attr:`issue` names the child issue that fills the function in, as a field
+    rather than as a substring of the message, so an audit of what is left in the
+    scaffold can enumerate it instead of grepping prose.
+
+    Attributes:
+        issue: Identifier of the issue that lands the implementation.
+        component: Which part of the harness the gap is in.
+    """
+
+    code: ClassVar[str] = "UNIMPLEMENTED_HARNESS_NOT_BUILT"
+    issue: str | None = None
+    component: str | None = "test_harness"

--- a/application_sdk/testing/harness/atlas/__init__.py
+++ b/application_sdk/testing/harness/atlas/__init__.py
@@ -1,0 +1,83 @@
+"""Atlas reads, lifted out of ``testing/e2e/client.py``.
+
+``client.py`` is 2,475 lines carrying two unrelated concerns: talking to the
+Automation Engine, and searching Atlas. Splitting it here and in
+:mod:`application_sdk.testing.harness.automation_engine` is child F on FND-224.
+
+Two things change on the way across, and neither is cosmetic:
+
+**Async only.** Five ``asyncio.run`` bridges survive in ``client.py``
+(``_connection_search_async``, ``_search_counts_async``, ``_count_total_async``,
+the sample paths) — each stands up a fresh event loop and a fresh
+``AsyncAtlanClient``, and therefore a fresh TLS handshake, per call. The
+``_async`` implementations already exist; what lifts here is the async twin, and
+the sync entry points become one-liners over
+:func:`~application_sdk.testing.harness.bridge.run_sync` (decision D1).
+
+**No fail-open counts.** All four count and sample methods currently return zeros
+or ``[]`` on a search error. The visible symptom is not a silent pass but a
+*misleading diagnosis*: the run reports "asset floor not met" and points the
+reader at the connector when the real fault was Atlas. These readers return
+:class:`~application_sdk.testing.harness.outcome.Indeterminate` instead, so an
+unreadable count can no longer be graded as a low count.
+
+``packages/conformance``'s ``rules/client_seam.py`` names
+``application_sdk/testing/e2e/client.py`` as *the* sanctioned low-level Atlan
+path, so it needs updating when these reads move — child F, not this issue.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+
+from application_sdk.testing.harness.outcome import Outcome
+
+__all__ = ["count_assets", "sample_qualified_names"]
+
+
+async def count_assets(
+    connection_qualified_name: str, type_names: Sequence[str]
+) -> Outcome[Mapping[str, int]]:
+    """Count assets of each named type under a connection.
+
+    Args:
+        connection_qualified_name: Connection prefix to count under.
+        type_names: Atlan type names to count. Empty counts nothing and returns
+            an empty mapping — not the total.
+
+    Returns:
+        :class:`~application_sdk.testing.harness.outcome.Settled` carrying type
+        name -> count, or
+        :class:`~application_sdk.testing.harness.outcome.Indeterminate` when the
+        search could not be read. A type with no assets is a ``0`` in a settled
+        result; it is never the same value as an unreadable search.
+
+    Raises:
+        NotImplementedError: Always — implementation is child F on FND-224.
+    """
+    raise NotImplementedError("count_assets is child F on FND-224")
+
+
+async def sample_qualified_names(
+    connection_qualified_name: str,
+    type_names: Sequence[str],
+    *,
+    per_type: int,
+) -> Outcome[Mapping[str, Sequence[str]]]:
+    """Sample qualified names of each named type under a connection.
+
+    Args:
+        connection_qualified_name: Connection prefix to sample under.
+        type_names: Atlan type names to sample.
+        per_type: How many names to sample per type.
+
+    Returns:
+        :class:`~application_sdk.testing.harness.outcome.Settled` carrying type
+        name -> sampled qualified names, or
+        :class:`~application_sdk.testing.harness.outcome.Indeterminate` when the
+        search could not be read.
+
+    Raises:
+        NotImplementedError: Always — implementation is child F on FND-224.
+    """
+    raise NotImplementedError("sample_qualified_names is child F on FND-224")

--- a/application_sdk/testing/harness/atlas/__init__.py
+++ b/application_sdk/testing/harness/atlas/__init__.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 
+from application_sdk.testing.harness._errors import HarnessNotBuiltError
 from application_sdk.testing.harness.outcome import Outcome
 
 __all__ = ["count_assets", "sample_qualified_names"]
@@ -53,9 +54,15 @@ async def count_assets(
         result; it is never the same value as an unreadable search.
 
     Raises:
-        NotImplementedError: Always — implementation is child F on FND-224.
+        HarnessNotBuiltError: Always — implementation is child F on FND-224.
     """
-    raise NotImplementedError("count_assets is child F on FND-224")
+    raise HarnessNotBuiltError(
+        message="count_assets is not implemented yet",
+        operation="count_assets",
+        reason="child F on FND-224",
+        issue="FND-224",
+        component="harness_atlas",
+    )
 
 
 async def sample_qualified_names(
@@ -78,6 +85,12 @@ async def sample_qualified_names(
         search could not be read.
 
     Raises:
-        NotImplementedError: Always — implementation is child F on FND-224.
+        HarnessNotBuiltError: Always — implementation is child F on FND-224.
     """
-    raise NotImplementedError("sample_qualified_names is child F on FND-224")
+    raise HarnessNotBuiltError(
+        message="sample_qualified_names is not implemented yet",
+        operation="sample_qualified_names",
+        reason="child F on FND-224",
+        issue="FND-224",
+        component="harness_atlas",
+    )

--- a/application_sdk/testing/harness/automation_engine/__init__.py
+++ b/application_sdk/testing/harness/automation_engine/__init__.py
@@ -1,0 +1,103 @@
+"""Automation Engine reads and write retries, lifted out of ``testing/e2e/client.py``.
+
+The other half of the ``client.py`` split (child F on FND-224); see
+:mod:`application_sdk.testing.harness.atlas` for the reasoning shared by both.
+
+What is specific to this half is the **submit**, which is the one non-idempotent
+write in the harness. Re-issuing a submit the origin already processed spawns a
+duplicate run, so the retry logic cannot simply count attempts — it has to know
+whether a failed request can have taken effect. ``testing/e2e/_errors.py``'s
+``RequestDelivery`` already encodes that (a connect-phase failure never left the
+client; a follow-up read that finds no trace proves it was not applied), and it
+lifts across with the submit rather than being re-derived.
+
+The retry budget here is also the widest in the harness and for a
+counter-intuitive reason: an AE submit is the *only* tenant-facing probe of the
+installed app pod on the connector CI path, because the runner has no kubectl
+route into the tenant vcluster. A pod that is minutes from serving arrives as a
+generic 5xx on submit, so the submit's own retry has to be sized for a cold
+start rather than for transient AE overload.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+from application_sdk.testing.harness.budgets import Budget
+from application_sdk.testing.harness.outcome import Outcome
+
+__all__ = ["AERunHandle", "NativeStatus", "poll_native_status", "submit_run"]
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class AERunHandle:
+    """What a successful submit returns.
+
+    Attributes:
+        workflow_slug: AE's slug for the workflow the run belongs to.
+        run_id: AE's identifier for this run.
+    """
+
+    workflow_slug: str
+    run_id: str
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class NativeStatus:
+    """One reading of a run's ``native-status``.
+
+    Attributes:
+        node_states: DAG node name -> state, as AE reports it.
+        finished: Whether AE considers the run terminal.
+        fingerprint: The node-state summary used as the progress fingerprint by
+            :func:`~application_sdk.testing.harness.waiting.poll_until`. Carried
+            on the reading rather than recomputed by the caller so the value the
+            watchdog compares and the value the report prints cannot drift.
+    """
+
+    node_states: Mapping[str, str]
+    finished: bool
+    fingerprint: str
+
+
+async def submit_run(
+    payload: Mapping[str, object], *, budget: Budget
+) -> Outcome[AERunHandle]:
+    """Submit a run to the Automation Engine, retrying only where it is safe to.
+
+    Args:
+        payload: The AE submit body.
+        budget: Retry allowance. Sized for a tenant app pod's cold start, not for
+            transient AE overload — see the module docstring.
+
+    Returns:
+        :class:`~application_sdk.testing.harness.outcome.Settled` carrying the
+        handle, or a verdict describing why no run was started.
+
+    Raises:
+        NotImplementedError: Always — implementation is child F on FND-224.
+    """
+    raise NotImplementedError("submit_run is child F on FND-224")
+
+
+async def poll_native_status(
+    handle: AERunHandle, *, budget: Budget
+) -> Outcome[NativeStatus]:
+    """Poll a run's native status until it settles, stalls or runs out of budget.
+
+    Re-expressed over :func:`~application_sdk.testing.harness.waiting.poll_until`
+    rather than re-implemented: the start-grace latch and the no-change watchdog
+    this function needs are exactly what that primitive was extracted from.
+
+    Args:
+        handle: The run to poll.
+        budget: The poll's allowance.
+
+    Returns:
+        The verdict, carrying the last :class:`NativeStatus` read.
+
+    Raises:
+        NotImplementedError: Always — implementation is child F on FND-224.
+    """
+    raise NotImplementedError("poll_native_status is child F on FND-224")

--- a/application_sdk/testing/harness/automation_engine/__init__.py
+++ b/application_sdk/testing/harness/automation_engine/__init__.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from dataclasses import dataclass
 
+from application_sdk.testing.harness._errors import HarnessNotBuiltError
 from application_sdk.testing.harness.budgets import Budget
 from application_sdk.testing.harness.outcome import Outcome
 
@@ -76,9 +77,15 @@ async def submit_run(
         handle, or a verdict describing why no run was started.
 
     Raises:
-        NotImplementedError: Always — implementation is child F on FND-224.
+        HarnessNotBuiltError: Always — implementation is child F on FND-224.
     """
-    raise NotImplementedError("submit_run is child F on FND-224")
+    raise HarnessNotBuiltError(
+        message="submit_run is not implemented yet",
+        operation="submit_run",
+        reason="child F on FND-224",
+        issue="FND-224",
+        component="harness_automation_engine",
+    )
 
 
 async def poll_native_status(
@@ -98,6 +105,12 @@ async def poll_native_status(
         The verdict, carrying the last :class:`NativeStatus` read.
 
     Raises:
-        NotImplementedError: Always — implementation is child F on FND-224.
+        HarnessNotBuiltError: Always — implementation is child F on FND-224.
     """
-    raise NotImplementedError("poll_native_status is child F on FND-224")
+    raise HarnessNotBuiltError(
+        message="poll_native_status is not implemented yet",
+        operation="poll_native_status",
+        reason="child F on FND-224",
+        issue="FND-224",
+        component="harness_automation_engine",
+    )

--- a/application_sdk/testing/harness/bridge.py
+++ b/application_sdk/testing/harness/bridge.py
@@ -82,6 +82,21 @@ def _loop_for_this_thread() -> asyncio.AbstractEventLoop:
     return loop
 
 
+def _loop_is_running() -> bool:
+    """Whether this thread already has a running event loop.
+
+    :func:`asyncio.get_running_loop` is the only way to ask, and it answers "no"
+    by raising, so the ``except`` here is the negative answer rather than a
+    swallowed failure — there is nothing to log and nothing to recover from.
+    """
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        # conformance: ignore[E007] the RuntimeError IS the answer "no loop is running" — asyncio offers no non-raising query, so there is no error here to log
+        return False
+    return True
+
+
 def run_sync(coro: Coroutine[Any, Any, T]) -> T:
     """Run *coro* to completion on this thread's bridge loop and return its result.
 
@@ -106,11 +121,7 @@ def run_sync(coro: Coroutine[Any, Any, T]) -> T:
             def run_full_dag(self) -> FullDAGOutcome:                   # one line
                 return run_sync(self.run_full_dag_async())
     """
-    try:
-        asyncio.get_running_loop()
-    except RuntimeError:
-        pass  # no running loop — the expected case, carry on
-    else:
+    if _loop_is_running():
         # Close the coroutine explicitly: a never-awaited coroutine that is
         # merely garbage-collected emits a "coroutine was never awaited"
         # RuntimeWarning, which lands in the traceback next to the real error

--- a/application_sdk/testing/harness/bridge.py
+++ b/application_sdk/testing/harness/bridge.py
@@ -1,0 +1,147 @@
+"""The harness's one sync/async bridge.
+
+Everything below the pytest boundary is ``async`` (decision D1 on FND-224):
+:class:`~pyatlan.client.aio.AsyncAtlanClient` rather than the sync
+``AtlanClient``, :class:`httpx.AsyncClient` rather than ``urllib.request``,
+:func:`asyncio.sleep` rather than :func:`time.sleep`. Exactly one place in the
+harness turns a coroutine back into a blocking call, and this is it.
+
+**Why a bridge exists at all.** ``setup_method`` / ``teardown_method`` are
+pytest xunit hooks: pytest calls them, and it never awaits them. A sync
+composer — a plain ``def`` test, or a helper called from one — is the same
+shape. So the harness publishes three entry shapes over one async core:
+
+* the xunit shims on ``BaseE2ETest``, each a one-liner over its ``_async`` twin,
+* async fixtures for composers that already run under ``asyncio_mode = auto``,
+* this bridge, for a sync composer that has no loop of its own.
+
+**Why it is public.** A third consumer shape asked for it (FND-244): the
+runtime scenario suite drives harness reads from sync scenario code. Publishing
+it here, rather than in ``application_sdk.common``, is deliberate — a sync
+bridge in the core SDK reads as the SDK sanctioning sync bridges in *app* code,
+against the async-only stance conformance rules P024 and P031 encode. This one
+is test-harness-only, and its import path says so.
+
+**One loop per thread, reused.** The loop is created lazily on first use and
+kept for the life of the thread. Standing up a fresh loop per call is what the
+five ad-hoc ``asyncio.run`` sites in ``testing/e2e/client.py`` do today, and it
+is the bug D1 found: a new loop plus a new ``AsyncAtlanClient`` plus a new TLS
+handshake on *every* poll iteration — up to ~50 handshakes for one boolean. The
+runtime suite drives this in a loop against a real tenant, so per-call loop
+creation is not an abstract cost.
+
+Threads get their own loop rather than sharing one because an event loop is not
+thread-safe, and pytest plugins (``pytest-xdist``, ``pytest-timeout``) do run
+harness code off the main thread.
+
+**Teardown is the caller's.** Call :func:`close_loop` from the fixture or
+process teardown that owns the thread. Not calling it leaks one loop per thread
+until the process exits, which is survivable in a test process and is why this
+is not a hard requirement — but a long-lived driver that spawns threads should
+close them.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from collections.abc import Coroutine
+from typing import Any, TypeVar
+
+from application_sdk.observability.logger_adaptor import get_logger
+from application_sdk.testing.harness._errors import SyncBridgeInAsyncContextError
+
+logger = get_logger(__name__)
+
+__all__ = ["close_loop", "run_sync"]
+
+T = TypeVar("T")
+
+# One slot per thread. A module-level dict keyed by thread ident would leak
+# entries for dead threads; threading.local is collected with the thread.
+_state = threading.local()
+
+
+def _loop_for_this_thread() -> asyncio.AbstractEventLoop:
+    """Return this thread's bridge loop, creating it on first use.
+
+    A loop that was closed out from under us (a caller that called
+    :func:`close_loop` and then :func:`run_sync` again) is replaced rather than
+    reused, so the second call works instead of raising a confusing
+    ``RuntimeError: Event loop is closed`` from deep inside asyncio.
+    """
+    loop: asyncio.AbstractEventLoop | None = getattr(_state, "loop", None)
+    if loop is not None and not loop.is_closed():
+        return loop
+    loop = asyncio.new_event_loop()
+    _state.loop = loop
+    logger.debug(
+        "Harness sync bridge created an event loop for thread %s",
+        threading.current_thread().name,
+    )
+    return loop
+
+
+def run_sync(coro: Coroutine[Any, Any, T]) -> T:
+    """Run *coro* to completion on this thread's bridge loop and return its result.
+
+    Args:
+        coro: The coroutine to drive. Typically a call to an ``_async`` twin.
+
+    Returns:
+        Whatever the coroutine returns.
+
+    Raises:
+        SyncBridgeInAsyncContextError: A loop is already running on this thread.
+            Await the ``_async`` twin instead — the message names it.
+        BaseException: Anything the coroutine raises propagates unchanged. The
+            bridge adds no wrapping, so a connector's ``except`` clauses keep
+            matching the leaves they matched before.
+
+    Example:
+        .. code-block:: python
+
+            async def run_full_dag_async(self) -> FullDAGOutcome: ...   # the real one
+
+            def run_full_dag(self) -> FullDAGOutcome:                   # one line
+                return run_sync(self.run_full_dag_async())
+    """
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        pass  # no running loop — the expected case, carry on
+    else:
+        # Close the coroutine explicitly: a never-awaited coroutine that is
+        # merely garbage-collected emits a "coroutine was never awaited"
+        # RuntimeWarning, which lands in the traceback next to the real error
+        # and reads as a second, unrelated bug.
+        coro.close()
+        raise SyncBridgeInAsyncContextError(
+            message=(
+                "run_sync() was called from inside a running event loop. "
+                "Await the coroutine directly, or call the _async twin of the "
+                "method you called (e.g. run_full_dag_async() instead of "
+                "run_full_dag())."
+            ),
+        )
+    return _loop_for_this_thread().run_until_complete(coro)
+
+
+def close_loop() -> None:
+    """Close this thread's bridge loop, if it has one. Idempotent.
+
+    Call from the fixture or process teardown that owns the thread. A later
+    :func:`run_sync` on the same thread creates a fresh loop rather than
+    failing, so closing early is safe.
+    """
+    loop: asyncio.AbstractEventLoop | None = getattr(_state, "loop", None)
+    _state.loop = None
+    if loop is None or loop.is_closed():
+        return
+    try:
+        loop.close()
+    finally:
+        logger.debug(
+            "Harness sync bridge closed the event loop for thread %s",
+            threading.current_thread().name,
+        )

--- a/application_sdk/testing/harness/budgets.py
+++ b/application_sdk/testing/harness/budgets.py
@@ -1,0 +1,96 @@
+"""One typed budget for every bounded wait in the harness.
+
+Today "budget" is not one layer. It is ten class attributes and six budgets on
+``BaseE2ETest``, plus seven more knobs hard-coded in ``testing/e2e/client.py``
+and never exposed (``_HTTP_TIMEOUT``, ``_SUBMIT_TIMEOUT``,
+``_REQUEST_MAX_ATTEMPTS``, ``_REQUEST_BACKOFF_SECONDS``,
+``_MAX_RETRY_AFTER_SECONDS``, ``_RETRY_AFTER_BUDGET_SECONDS``,
+``_HEARTBEAT_SECONDS``), plus ``max_forbidden_attempts`` and
+``max_not_found_attempts``. :class:`Budget` absorbs all of it into one value a
+call site can pass, and :class:`BudgetProfile` names a per-tier set of them —
+which is what a scenario suite needs when the same wait has different timings
+against ``kind`` than against a tenant.
+
+Populating the named profiles from today's ``ClassVar`` defaults, verbatim, is
+child B. This module scaffolds the types they are expressed in.
+
+``timedelta`` rather than bare seconds throughout: an ``int`` named
+``..._seconds`` is a unit convention that a call site can silently violate, and
+this vocabulary is about to be shared across three repos.
+
+**On the clock (D3).** The FND-224 decomposition asked for a ``Budget.clock``
+mode preserving the ``elapsed += interval_seconds`` accumulator — a bug that
+never charged HTTP round-trip time to the budget, so ``ae_poll_timeout_seconds
+= 600`` bounded 600s of *sleeps* plus N round trips at up to 60s each. That
+accumulator no longer exists: every deadline loop in ``testing/e2e/`` now runs
+through :mod:`application_sdk.testing.e2e._poll`, which is monotonic and
+re-clamps each gap against the clock read *after* the probe. So there is no
+current behaviour to preserve, and no ``clock`` field here — shipping one would
+be reintroducing the bug as a supported mode. See the D3 note on FND-224.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import timedelta
+
+__all__ = ["Budget", "BudgetProfile"]
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class Budget:
+    """Everything a single bounded wait is allowed to spend.
+
+    Attributes:
+        timeout: Total wall-clock bound for the whole wait, on a monotonic
+            clock. Includes probe time, not just the gaps between probes.
+        poll_interval: Nominal gap between probes. The real gap is clamped
+            against the remaining budget, so a probe that outlasts its own
+            interval shortens the next gap rather than overshooting the timeout.
+        start_grace: How long to allow before *anything* has started, after
+            which the wait returns
+            :class:`~application_sdk.testing.harness.outcome.NeverStarted`.
+            ``None`` disables the latch — correct for a wait against shared or
+            autoscaled infrastructure, where legitimate pickup can outlast any
+            fixed grace.
+        stall_timeout: How long the progress fingerprint may go unchanged once
+            work *has* started, after which the wait returns
+            :class:`~application_sdk.testing.harness.outcome.Stalled`. ``None``
+            disables the watchdog.
+        max_transient_failures: How many probe errors to absorb before giving up
+            with :class:`~application_sdk.testing.harness.outcome.Indeterminate`.
+            ``0`` means the first probe error ends the wait.
+        retry_after_budget: Ceiling on the *extra* waiting an origin may request
+            via ``Retry-After`` across the whole wait, on top of the fixed gaps.
+            Without it a slow origin can stretch the real wall-clock bound well
+            past :attr:`timeout`. ``None`` means honour no origin backoff.
+        heartbeat: Cadence of the "still waiting" progress line. ``None``
+            silences it, which is right when the call site logs its own richer
+            per-poll progress and a second line would be duplicate noise.
+    """
+
+    timeout: timedelta
+    poll_interval: timedelta
+    start_grace: timedelta | None = None
+    stall_timeout: timedelta | None = None
+    max_transient_failures: int = 0
+    retry_after_budget: timedelta | None = None
+    heartbeat: timedelta | None = timedelta(seconds=30)
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class BudgetProfile:
+    """A named set of budgets for one execution tier.
+
+    The same wait wants different timings against a local ``kind`` cluster, a
+    docker-compose worker in connector CI, and a shared tenant. Naming the set
+    means a suite selects a tier rather than re-deriving nine numbers.
+
+    Attributes:
+        name: Tier identifier, for reports and for the selecting env var.
+        budgets: Wait label -> budget. Keys are the ``label`` values the waits
+            pass, so a report can say which profile governed a given wait.
+    """
+
+    name: str
+    budgets: dict[str, Budget]

--- a/application_sdk/testing/harness/cluster/__init__.py
+++ b/application_sdk/testing/harness/cluster/__init__.py
@@ -1,0 +1,313 @@
+"""Read-only Protocols over a Kubernetes cluster, plus the states they return.
+
+**Read-only by decision, not by omission.** The runtime scenario suite mutates —
+patching a TWD to compress timings, suspending and resuming a Flux HelmRelease
+so the patch survives, rendering and server-side-applying charts, installing a
+fixture app. All of that stays on the suite side (agreed on FND-224, 2026-08-17):
+the SDK has no app-functional need for it, so abstracting it now would be
+inventing a shared surface for one consumer. Every Protocol here is a reader.
+
+**Two Protocols, not one union.** :class:`ClusterReader` covers the built-in
+kinds the harness itself needs. Custom resources go on
+:class:`CustomResourceReader`, parameterised by :class:`ResourceRef` rather than
+by an enum of kinds plus a plurals map — an enum would mean every new consumer's
+kind becomes a change in *this* repo, which is precisely the widening FND-224
+exists to remove.
+
+**Why a Protocol from day one.** ``kubectl`` is explicitly not the end state
+(HOR-818 for Horizon, plus the agent-infrastructure gateway). Each of those
+arrives as a backend rather than as a rewrite of every caller.
+
+The typed ``kubeconfig`` backend, which retires the ``kubectl``-shelling reads in
+``testing/e2e/{pods,logs}.py``, is FND-241 (child E) and lands behind the
+optional ``harness`` extra. ``kubectl port-forward`` survives as *transport*
+only: it is what reaches the app handler Service, and ``kubernetes.stream``'s
+port-forward is not a drop-in for it.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Mapping, Sequence
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from enum import Enum
+from typing import Any, Protocol, runtime_checkable
+
+__all__ = [
+    "ClusterReader",
+    "CustomResourceReader",
+    "DeploymentState",
+    "HttpRequest",
+    "HttpResponse",
+    "LogLine",
+    "PodPhase",
+    "PodState",
+    "ResourceRef",
+    "ServiceTarget",
+]
+
+
+class PodPhase(str, Enum):
+    """Kubernetes pod phase, as the API server reports it."""
+
+    PENDING = "Pending"
+    RUNNING = "Running"
+    SUCCEEDED = "Succeeded"
+    FAILED = "Failed"
+    UNKNOWN = "Unknown"
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class PodState:
+    """One pod, reduced to what a harness assertion reads.
+
+    Attributes:
+        name: Pod name.
+        namespace: Namespace the pod is in.
+        phase: Reported phase.
+        ready: Whether every container passes its readiness probe. Not derivable
+            from :attr:`phase` — a ``Running`` pod with a failing readiness probe
+            is the exact shape a "worker is up" assertion must not accept.
+        restarts: Total container restarts. A worker that is up but restarting is
+            a different failure from a worker that never came up.
+        node: Node the pod is scheduled on, or ``None`` while unscheduled.
+        labels: Pod labels, for a caller narrowing further than its selector did.
+    """
+
+    name: str
+    namespace: str
+    phase: PodPhase
+    ready: bool
+    restarts: int
+    node: str | None = None
+    labels: Mapping[str, str] | None = None
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class DeploymentState:
+    """One Deployment's replica counts.
+
+    Attributes:
+        name: Deployment name.
+        namespace: Namespace the Deployment is in.
+        desired_replicas: ``.spec.replicas`` — the *intent*. This is the scaling
+            metric, deliberately: ``.status.readyReplicas`` lags, so asserting on
+            it turns a scaling assertion into a race against pod startup.
+        ready_replicas: ``.status.readyReplicas`` — still exposed, because "did
+            the scale-up actually land" is a real and different question.
+        updated_replicas: ``.status.updatedReplicas``, for telling a rollout in
+            progress from a settled one.
+    """
+
+    name: str
+    namespace: str
+    desired_replicas: int
+    ready_replicas: int
+    updated_replicas: int
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class LogLine:
+    """One line of container output.
+
+    Attributes:
+        pod: Pod the line came from. A selector matches many pods, and which one
+            logged a line is usually the point.
+        container: Container within that pod.
+        message: The line itself, newline stripped.
+        timestamp: Server-side timestamp, when the backend supplies one.
+    """
+
+    pod: str
+    container: str
+    message: str
+    timestamp: datetime | None = None
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class ServiceTarget:
+    """A Service and port to reach, however the backend chooses to reach it.
+
+    Attributes:
+        namespace: Namespace the Service is in.
+        service: Service name.
+        port: Service port.
+    """
+
+    namespace: str
+    service: str
+    port: int
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class HttpRequest:
+    """An HTTP call to make against a :class:`ServiceTarget`.
+
+    Attributes:
+        method: HTTP method.
+        path: Path including any query string, leading slash included.
+        body: JSON body to send, or ``None`` for no body.
+        headers: Extra headers.
+        timeout: Per-request bound. Distinct from the enclosing wait's budget:
+            one hung request must not consume the whole budget silently.
+    """
+
+    method: str
+    path: str
+    body: Mapping[str, Any] | None = None
+    headers: Mapping[str, str] | None = None
+    timeout: timedelta = timedelta(seconds=30)
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class HttpResponse:
+    """What came back.
+
+    Attributes:
+        status: HTTP status code.
+        body: Decoded JSON body, or ``None`` when the body was empty or not JSON.
+        text: Raw body text. Retained alongside :attr:`body` because a non-JSON
+            error page is the most useful thing to report when a call fails.
+    """
+
+    status: int
+    body: Any | None = None
+    text: str = ""
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class ResourceRef:
+    """Identifies a custom-resource kind by its API coordinates.
+
+    Parameterised rather than enumerated on purpose: a ``Kind`` enum plus a
+    ``_PLURALS`` map means every consumer's new kind is a change in this repo,
+    for a need only that consumer has. With a ref, the calling suite keeps its
+    own kind vocabulary and resolves it to these three strings at the call.
+
+    Attributes:
+        group: API group, e.g. ``"helm.toolkit.fluxcd.io"``.
+        version: API version, e.g. ``"v2"``.
+        plural: Plural resource name as the API server routes it, e.g.
+            ``"helmreleases"``. The plural, not the kind: it is what the URL path
+            needs, and deriving it from the kind is the map this avoids.
+    """
+
+    group: str
+    version: str
+    plural: str
+
+
+@runtime_checkable
+class ClusterReader(Protocol):
+    """Read built-in Kubernetes state. No mutation, by decision.
+
+    Every method is ``async`` (decision D1). A backend over a synchronous client
+    offloads it — that is the backend's problem, not the caller's.
+    """
+
+    async def deployments(
+        self, namespace: str, selector: str
+    ) -> Sequence[DeploymentState]:
+        """Return the Deployments matching *selector* in *namespace*.
+
+        Args:
+            namespace: Namespace to read.
+            selector: Label selector, in ``kubectl -l`` syntax.
+
+        Returns:
+            One :class:`DeploymentState` per match, possibly empty.
+        """
+        ...
+
+    async def pods(self, namespace: str, selector: str) -> Sequence[PodState]:
+        """Return the pods matching *selector* in *namespace*.
+
+        Args:
+            namespace: Namespace to read.
+            selector: Label selector, in ``kubectl -l`` syntax.
+
+        Returns:
+            One :class:`PodState` per match, possibly empty.
+        """
+        ...
+
+    def logs(
+        self, namespace: str, selector: str, *, since: timedelta | None = None
+    ) -> AsyncIterator[LogLine]:
+        """Stream container output from the pods matching *selector*.
+
+        Not ``async def``: an async generator's caller wants ``async for``, and
+        declaring this ``async def`` would make the call return a coroutine that
+        has to be awaited before there is an iterator to iterate.
+
+        Args:
+            namespace: Namespace to read.
+            selector: Label selector, in ``kubectl -l`` syntax.
+            since: Only lines newer than this. ``None`` means from the start of
+                the container's retained output.
+
+        Yields:
+            One :class:`LogLine` per line, interleaved across matching pods.
+        """
+        ...
+
+    async def http(self, target: ServiceTarget, request: HttpRequest) -> HttpResponse:
+        """Make an HTTP call against an in-cluster Service.
+
+        How the call reaches the Service is the backend's business — an ephemeral
+        ``kubectl port-forward`` from outside, or a direct call from a driver
+        that already sits inside the cluster.
+
+        Args:
+            target: Service and port to reach.
+            request: The call to make.
+
+        Returns:
+            The response, whatever its status. A non-2xx is a value here, not an
+            exception: the caller's predicate decides what counts as failure.
+        """
+        ...
+
+
+@runtime_checkable
+class CustomResourceReader(Protocol):
+    """Read custom resources, parameterised by :class:`ResourceRef`.
+
+    Separate from :class:`ClusterReader` so that Protocol never becomes the union
+    of every consumer's needs.
+    """
+
+    async def custom_resources(
+        self, ref: ResourceRef, namespace: str, *, selector: str | None = None
+    ) -> Sequence[Mapping[str, Any]]:
+        """Return the custom resources of *ref* in *namespace*.
+
+        Args:
+            ref: API coordinates of the kind to read.
+            namespace: Namespace to read.
+            selector: Optional label selector.
+
+        Returns:
+            The raw resource bodies. Untyped by design: the harness has no schema
+            for another repo's CRDs, and inventing one here would be the same
+            widening :class:`ResourceRef` avoids.
+        """
+        ...
+
+    async def crd_schema(self, ref: ResourceRef) -> Mapping[str, Any] | None:
+        """Return the CRD's OpenAPI schema, or ``None`` when it is not installed.
+
+        Args:
+            ref: API coordinates of the kind to look up.
+
+        Returns:
+            The schema body, or ``None`` when the CRD is genuinely absent.
+
+        Raises:
+            Exception: On any error that is *not* a clean 404. A 403, an expired
+                token or a timeout must raise rather than be cached as "not
+                installed" — the same rule as
+                :class:`~application_sdk.testing.harness.outcome.Indeterminate`:
+                a read that failed is neither a pass nor a component fault.
+        """
+        ...

--- a/application_sdk/testing/harness/evidence.py
+++ b/application_sdk/testing/harness/evidence.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 
+from application_sdk.testing.harness._errors import HarnessNotBuiltError
 from application_sdk.testing.harness.expectations import Finding
 
 __all__ = ["EvidenceBundle", "redact"]
@@ -61,6 +62,12 @@ def redact(bundle: EvidenceBundle) -> EvidenceBundle:
         the local copy useless.
 
     Raises:
-        NotImplementedError: Always — implementation is child G on FND-224.
+        HarnessNotBuiltError: Always — implementation is child G on FND-224.
     """
-    raise NotImplementedError("redact is child G on FND-224")
+    raise HarnessNotBuiltError(
+        message="redact is not implemented yet",
+        operation="redact",
+        reason="child G on FND-224",
+        issue="FND-224",
+        component="harness_evidence",
+    )

--- a/application_sdk/testing/harness/evidence.py
+++ b/application_sdk/testing/harness/evidence.py
@@ -1,0 +1,66 @@
+"""Collecting what a failed run left behind, and redacting it before it ships.
+
+A red CI leg is only useful if the evidence for it survives the pod that
+produced it. This module collects that evidence into one bundle — pod logs,
+the DAG node table, the counts that were read, the findings — and redacts it on
+the way out.
+
+Redaction is not optional and not a caller's responsibility. The harness handles
+credential bodies (a connector's source credentials, an Atlan API key, a
+tenant hostname) and evidence is the one thing here that is *designed* to leave
+the process. Redaction therefore happens at this boundary, not by withholding
+fields from the types upstream: withholding makes the domain objects harder to
+debug locally while still leaking anything a future field forgets to withhold.
+
+Implementation, and wiring it into the connector failure path, is child G on
+FND-224.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+
+from application_sdk.testing.harness.expectations import Finding
+
+__all__ = ["EvidenceBundle", "redact"]
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class EvidenceBundle:
+    """Everything worth keeping about one harness run.
+
+    Attributes:
+        label: What the run was — the suite and entrypoint, for the report title.
+        findings: Every unmet expectation, accumulated rather than truncated at
+            the first.
+        logs: Source name -> captured lines. Source is a pod name, a container,
+            or a synthetic name for a non-pod source.
+        readings: Named observations the run made — asset counts, node states,
+            poller identities. Kept as a mapping rather than typed per kind so a
+            new observation does not need a new field here.
+        artifacts: Relative path -> file contents to write alongside the report.
+    """
+
+    label: str
+    findings: Sequence[Finding] = field(default_factory=tuple)
+    logs: Mapping[str, Sequence[str]] = field(default_factory=dict)
+    readings: Mapping[str, object] = field(default_factory=dict)
+    artifacts: Mapping[str, str] = field(default_factory=dict)
+
+
+def redact(bundle: EvidenceBundle) -> EvidenceBundle:
+    """Return *bundle* with credential-shaped values replaced by placeholders.
+
+    Args:
+        bundle: The bundle to sanitise.
+
+    Returns:
+        A new bundle. Never mutates the input: a caller that logs locally and
+        uploads remotely must be able to hold both, and an in-place scrub makes
+        the local copy useless.
+
+    Raises:
+        NotImplementedError: Always — implementation is child G on FND-224.
+    """
+    raise NotImplementedError("redact is child G on FND-224")

--- a/application_sdk/testing/harness/expectations.py
+++ b/application_sdk/testing/harness/expectations.py
@@ -1,0 +1,133 @@
+"""The two pure evaluators, generalised off the connector class attributes.
+
+Both already exist on ``BaseE2ETest`` as pure functions of their input plus a
+dozen ``ClassVar``\\s: ``_evaluate_asset_expectations`` (floors, exact parity,
+and the "completed but extracted nothing" backstop) and
+``_validate_asset_locations`` (sampled qualified names nested under the
+connection at the declared depth). They are the two pieces of the harness that
+already need no tenant to test — which is exactly why they lift first (child B
+on FND-224).
+
+Generalising means taking the declarations as an argument instead of reading
+``self``. That is the whole change: a composer that is not a ``BaseE2ETest``
+subclass can then evaluate the same expectations, and the connector's class
+attributes become one way of *supplying* :class:`AssetExpectations` rather than
+the only place it can live.
+
+Both return findings rather than raising, for the accumulation reason in
+:mod:`application_sdk.testing.harness.outcome`: a run reports every unmet
+expectation, not the first one.
+
+One behaviour is deliberately **not** preserved. ``_validate_asset_locations``
+fails open today — the sampling read returns ``[]`` on any search error, which
+arrives as "no samples, skip", so an auth fault reads as a pass. That is finding
+C4 on FND-224, and the fix is structural: a caller that could not read passes
+:class:`~application_sdk.testing.harness.outcome.Indeterminate` rather than an
+empty sample set, so "unreadable" can no longer be spelled the same way as
+"nothing to check".
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+
+__all__ = ["AssetExpectations", "Finding", "evaluate_counts", "evaluate_locations"]
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class Finding:
+    """One unmet expectation, in a form a report can render without re-parsing.
+
+    A string was enough while the only consumer was a pytest failure message.
+    It is not enough for the evidence bundle, which groups findings by what they
+    are about.
+
+    Attributes:
+        subject: What the finding is about — an asset type name, a node name.
+        detail: Human-readable statement of what was expected and what was seen.
+            Written for whoever reads a red CI leg.
+        expectation: Which declared expectation was not met, e.g. ``"floor"``,
+            ``"exact"``, ``"nonempty"``, ``"depth"``.
+    """
+
+    subject: str
+    detail: str
+    expectation: str
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class AssetExpectations:
+    """What a run is expected to have landed in Atlas.
+
+    Attributes:
+        floors: Asset type -> minimum count (``>=``).
+        exacts: Asset type -> exact count (``==``), against a committed baseline
+            from a direct (non-agent) run. Catches over-extraction as well as
+            under-extraction, which a floor cannot.
+        depths: Asset type -> number of qualified-name segments expected below
+            the connection prefix. Catches assets that landed at the wrong
+            hierarchy level — mis-parented, flattened, a dropped path segment —
+            even when the count is right.
+        require_nonempty: Whether a run that completes and lands zero assets
+            fails. Defaults on, and it fires even for a connector that declares
+            nothing else — those are the ones most likely to regress silently.
+        connection_qualified_name: Prefix every sampled qualified name must sit
+            under. Empty means the nesting half of the location check is skipped.
+    """
+
+    floors: Mapping[str, int] = field(default_factory=dict)
+    exacts: Mapping[str, int] = field(default_factory=dict)
+    depths: Mapping[str, int] = field(default_factory=dict)
+    require_nonempty: bool = True
+    connection_qualified_name: str = ""
+
+
+def evaluate_counts(
+    counts: Mapping[str, int],
+    expectations: AssetExpectations,
+    *,
+    total_assets: int | None = None,
+) -> Sequence[Finding]:
+    """Evaluate per-type counts against the declared floors, exacts and backstop.
+
+    Args:
+        counts: Asset type -> count observed in Atlas.
+        expectations: What was declared.
+        total_assets: True count across *all* asset types, which is not
+            ``sum(counts.values())`` when only some types were counted. The
+            non-empty backstop reads this so it fires for a connector that
+            declared no per-type expectations at all. ``None`` falls back to the
+            sum, which is what lets the evaluator be driven from a unit test.
+
+    Returns:
+        One :class:`Finding` per unmet expectation; empty when all were met.
+
+    Raises:
+        NotImplementedError: Always — implementation is child B on FND-224.
+    """
+    raise NotImplementedError("evaluate_counts is child B on FND-224")
+
+
+def evaluate_locations(
+    samples: Mapping[str, Sequence[str]],
+    expectations: AssetExpectations,
+) -> Sequence[Finding]:
+    """Evaluate sampled qualified names against the declared hierarchy depths.
+
+    Args:
+        samples: Asset type -> sampled qualified names. A type with no samples is
+            skipped: "too few or none" is already covered by the count floors and
+            the non-empty backstop, so this check is only about the *shape* of
+            assets that did land. Callers must not spell "I could not read" as an
+            empty mapping — see the module docstring.
+        expectations: What was declared.
+
+    Returns:
+        One :class:`Finding` per sampled name that is not nested under the
+        connection, or is nested at the wrong depth; empty when all were fine.
+
+    Raises:
+        NotImplementedError: Always — implementation is child B on FND-224.
+    """
+    raise NotImplementedError("evaluate_locations is child B on FND-224")

--- a/application_sdk/testing/harness/expectations.py
+++ b/application_sdk/testing/harness/expectations.py
@@ -32,6 +32,8 @@ from __future__ import annotations
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 
+from application_sdk.testing.harness._errors import HarnessNotBuiltError
+
 __all__ = ["AssetExpectations", "Finding", "evaluate_counts", "evaluate_locations"]
 
 
@@ -104,9 +106,15 @@ def evaluate_counts(
         One :class:`Finding` per unmet expectation; empty when all were met.
 
     Raises:
-        NotImplementedError: Always — implementation is child B on FND-224.
+        HarnessNotBuiltError: Always — implementation is child B on FND-224.
     """
-    raise NotImplementedError("evaluate_counts is child B on FND-224")
+    raise HarnessNotBuiltError(
+        message="evaluate_counts is not implemented yet",
+        operation="evaluate_counts",
+        reason="child B on FND-224",
+        issue="FND-224",
+        component="harness_expectations",
+    )
 
 
 def evaluate_locations(
@@ -128,6 +136,12 @@ def evaluate_locations(
         connection, or is nested at the wrong depth; empty when all were fine.
 
     Raises:
-        NotImplementedError: Always — implementation is child B on FND-224.
+        HarnessNotBuiltError: Always — implementation is child B on FND-224.
     """
-    raise NotImplementedError("evaluate_locations is child B on FND-224")
+    raise HarnessNotBuiltError(
+        message="evaluate_locations is not implemented yet",
+        operation="evaluate_locations",
+        reason="child B on FND-224",
+        issue="FND-224",
+        component="harness_expectations",
+    )

--- a/application_sdk/testing/harness/identity.py
+++ b/application_sdk/testing/harness/identity.py
@@ -1,0 +1,73 @@
+"""Run-id and unique-name minting, behind a clock seam.
+
+Today ``BaseE2ETest`` mints these inline in ``setup_method``: a run id from
+``GITHUB_RUN_ID`` falling back to ``int(time.time())``, and a unique connection
+suffix from ``int(time.time())`` plus six random digits. Both read the wall clock
+directly, which is why the names they produce cannot be asserted on — the only
+available test is "it looks roughly right".
+
+Putting the clock behind a seam makes the minted names a *function of inputs*, so
+a test can pin the exact qualified name a run will produce. That matters more
+than it sounds: the ephemeral qualified name is what ``teardown.py`` purges, and
+a name the test cannot predict is a purge the test cannot verify.
+
+Implementation is child B on FND-224.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+__all__ = ["Minter"]
+
+
+class Minter:
+    """Mints the per-run identifiers a harness run needs.
+
+    Args:
+        clock: Wall-clock source, in whole seconds. Injected rather than read
+            from :func:`time.time` so minted names are assertable. Note this is
+            deliberately *not* the monotonic clock the wait budgets use: these
+            identifiers want a value that is stable across processes and
+            recognisable in a tenant's asset list.
+        randbelow: Source of the random suffix, matching
+            :func:`secrets.randbelow`'s signature.
+        run_id_env: Ambient run identifier (a CI run id) to prefer over the
+            clock, or ``None`` to always mint from the clock.
+    """
+
+    def __init__(
+        self,
+        *,
+        clock: Callable[[], int],
+        randbelow: Callable[[int], int],
+        run_id_env: str | None = None,
+    ) -> None:
+        self._clock = clock
+        self._randbelow = randbelow
+        self._run_id_env = run_id_env
+
+    def run_id(self) -> int:
+        """Return the identifier for this run.
+
+        Returns:
+            The ambient CI run id when there is one and it is numeric, else a
+            clock reading.
+
+        Raises:
+            NotImplementedError: Always — implementation is child B on FND-224.
+        """
+        raise NotImplementedError("Minter.run_id is child B on FND-224")
+
+    def unique_suffix(self) -> str:
+        """Return a suffix that makes a name unique within a tenant.
+
+        Returns:
+            A clock reading concatenated with a zero-padded random component.
+            Two runs starting in the same second must not collide, because a
+            collision means one run purges the other's assets.
+
+        Raises:
+            NotImplementedError: Always — implementation is child B on FND-224.
+        """
+        raise NotImplementedError("Minter.unique_suffix is child B on FND-224")

--- a/application_sdk/testing/harness/identity.py
+++ b/application_sdk/testing/harness/identity.py
@@ -18,6 +18,8 @@ from __future__ import annotations
 
 from collections.abc import Callable
 
+from application_sdk.testing.harness._errors import HarnessNotBuiltError
+
 __all__ = ["Minter"]
 
 
@@ -55,9 +57,15 @@ class Minter:
             clock reading.
 
         Raises:
-            NotImplementedError: Always — implementation is child B on FND-224.
+            HarnessNotBuiltError: Always — implementation is child B on FND-224.
         """
-        raise NotImplementedError("Minter.run_id is child B on FND-224")
+        raise HarnessNotBuiltError(
+            message="Minter.run_id is not implemented yet",
+            operation="Minter.run_id",
+            reason="child B on FND-224",
+            issue="FND-224",
+            component="harness_identity",
+        )
 
     def unique_suffix(self) -> str:
         """Return a suffix that makes a name unique within a tenant.
@@ -68,6 +76,12 @@ class Minter:
             collision means one run purges the other's assets.
 
         Raises:
-            NotImplementedError: Always — implementation is child B on FND-224.
+            HarnessNotBuiltError: Always — implementation is child B on FND-224.
         """
-        raise NotImplementedError("Minter.unique_suffix is child B on FND-224")
+        raise HarnessNotBuiltError(
+            message="Minter.unique_suffix is not implemented yet",
+            operation="Minter.unique_suffix",
+            reason="child B on FND-224",
+            issue="FND-224",
+            component="harness_identity",
+        )

--- a/application_sdk/testing/harness/outcome.py
+++ b/application_sdk/testing/harness/outcome.py
@@ -1,0 +1,173 @@
+"""What a bounded wait produced — returned, not raised.
+
+Three requirements force a structured return rather than an exception:
+
+**Accumulation.** A scenario reports everything wrong with a run, not just the
+first thing. An exception aborts at the first failing step; a value can be
+collected alongside the others.
+
+**Naming the step.** "The run failed" is not actionable; "the ``publish`` node
+stopped changing state after 4m12s, last fingerprint ``✓✓·-``" is.
+:class:`Stalled` carries the label and the fingerprint that stopped changing.
+
+**Infrastructure failure is not assertion failure.** An expired vcluster token,
+a dropped tunnel or a 503 from Atlas is neither a pass nor a component
+regression, and grading it as either is worse than reporting it as neither.
+:class:`Indeterminate` is that third answer. It is the same rule as "a path
+matching no rule is reported as no coverage, not treated as passing", and it is
+what closes the fail-open reads catalogued as C4 on FND-224 — four count/sample
+methods that return zeros on search error, so an Atlas outage currently reports
+*"asset floor not met"* and points the reader at the connector.
+
+:func:`assert_settled` converts back to the raise-on-failure style the connector
+suites already use, so ``BaseE2ETest``'s observable behaviour is unchanged by
+routing through this vocabulary.
+
+Finding accumulation and the precondition gate that sit on top of these types
+are FND-227 (child C) — this module scaffolds the vocabulary they return.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import timedelta
+from typing import Generic, TypeAlias, TypeVar, Union
+
+__all__ = [
+    "Expired",
+    "Indeterminate",
+    "NeverStarted",
+    "Outcome",
+    "Settled",
+    "Stalled",
+    "assert_settled",
+]
+
+T = TypeVar("T")
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class _Waited(Generic[T]):
+    """Fields every outcome carries, whatever the verdict.
+
+    Attributes:
+        label: What was being waited on, as a noun phrase naming the concrete
+            target ("AE run 8412 native status"). Goes straight into the report,
+            so it is written for whoever reads a red CI leg.
+        attempts: How many times the probe ran, 1-based.
+        elapsed: Wall-clock time the wait consumed, on a monotonic clock.
+    """
+
+    label: str
+    attempts: int
+    elapsed: timedelta
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class Settled(_Waited[T]):
+    """The probe reached the settled state inside its budget.
+
+    Attributes:
+        value: The final probe reading.
+    """
+
+    value: T
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class NeverStarted(_Waited[T]):
+    """Nothing ever started, so the budget was spent waiting for work to begin.
+
+    Distinct from :class:`Expired` because the diagnosis is different: work that
+    never starts points at dispatch (a queue-name mismatch, no poller on the
+    task queue, a worker scaled to zero), not at the work being slow.
+
+    Attributes:
+        grace: The start-grace window that closed without a start.
+        last: The last probe reading, when there was one.
+    """
+
+    grace: timedelta
+    last: T | None = None
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class Stalled(_Waited[T]):
+    """Work started, then stopped making observable progress.
+
+    Attributes:
+        stall_window: How long the fingerprint went unchanged before the
+            watchdog fired.
+        fingerprint: The progress fingerprint that stopped changing — the
+            single most useful line in the report, because it says *what* froze.
+        last: The last probe reading.
+    """
+
+    stall_window: timedelta
+    fingerprint: str
+    last: T | None = None
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class Expired(_Waited[T]):
+    """The budget ran out while work was still progressing.
+
+    Attributes:
+        budget: The total budget the wait was given.
+        last: The last probe reading.
+    """
+
+    budget: timedelta
+    last: T | None = None
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class Indeterminate(_Waited[T]):
+    """The wait could not reach a verdict — the probe itself failed.
+
+    Never graded as a pass and never as a component failure. An expired
+    vcluster token must not read as a regression in the thing under test.
+
+    Attributes:
+        cause: The exception that made the reading unavailable. Retained rather
+            than stringified so a caller can classify it (which backend, which
+            transport) without re-parsing a message.
+        transient_failures: How many probe errors were absorbed before the wait
+            gave up.
+    """
+
+    cause: BaseException
+    transient_failures: int = 0
+    last: T | None = None
+
+
+#: Every verdict a bounded wait can return.
+#:
+#: ``Union`` rather than ``|`` because this alias is generic: ``Outcome[T]`` has
+#: to stay subscriptable at runtime, and ``types.UnionType`` is not on 3.11.
+Outcome: TypeAlias = Union[
+    Settled[T], NeverStarted[T], Stalled[T], Expired[T], Indeterminate[T]
+]
+
+
+def assert_settled(outcome: Outcome[T]) -> T:
+    """Return the settled value, or raise the typed leaf for the verdict.
+
+    The adapter between the outcome vocabulary and the raise-on-failure style
+    the connector suites already expect: ``BaseE2ETest`` methods keep raising, so
+    re-expressing them over :func:`~application_sdk.testing.harness.waiting.poll_until`
+    is not observable to a connector.
+
+    Args:
+        outcome: The verdict to unwrap.
+
+    Returns:
+        :attr:`Settled.value`.
+
+    Raises:
+        NotImplementedError: Always — the leaf mapping lands with
+            :mod:`application_sdk.testing.harness.waiting` in FND-227 (child C).
+    """
+    raise NotImplementedError(
+        "assert_settled lands with waiting.poll_until in FND-227 (child C)"
+    )

--- a/application_sdk/testing/harness/outcome.py
+++ b/application_sdk/testing/harness/outcome.py
@@ -33,6 +33,8 @@ from dataclasses import dataclass
 from datetime import timedelta
 from typing import Generic, TypeAlias, TypeVar, Union
 
+from application_sdk.testing.harness._errors import HarnessNotBuiltError
+
 __all__ = [
     "Expired",
     "Indeterminate",
@@ -165,9 +167,13 @@ def assert_settled(outcome: Outcome[T]) -> T:
         :attr:`Settled.value`.
 
     Raises:
-        NotImplementedError: Always — the leaf mapping lands with
+        HarnessNotBuiltError: Always — the leaf mapping lands with
             :mod:`application_sdk.testing.harness.waiting` in FND-227 (child C).
     """
-    raise NotImplementedError(
-        "assert_settled lands with waiting.poll_until in FND-227 (child C)"
+    raise HarnessNotBuiltError(
+        message="assert_settled is not implemented yet",
+        operation="assert_settled",
+        reason="lands with waiting.poll_until, child C on FND-224 (= FND-227)",
+        issue="FND-227",
+        component="harness_outcome",
     )

--- a/application_sdk/testing/harness/spec.py
+++ b/application_sdk/testing/harness/spec.py
@@ -1,0 +1,38 @@
+"""Identity of the app a harness run targets in a cluster.
+
+Renamed from ``application_sdk.testing.e2e.config.AppConfig``, which collided by
+name with the production :class:`application_sdk.main.AppConfig` — the
+authoritative runtime config object. Two unrelated types with one name is
+tolerable while one of them is unexported plumbing; it stops being tolerable the
+moment the name becomes shared vocabulary across the harness, the runtime
+scenario suite and the connector suites.
+
+Four of the original seven fields (``app_module``, ``image``,
+``worker_health_port``, ``timeout``) were never read by anything — not by the
+harness, not by ``tests/e2e/conftest.py``'s helpers, not by any consumer repo —
+so they are dropped here rather than carried into the shared vocabulary. The
+deprecated :class:`~application_sdk.testing.e2e.config.AppConfig` alias still
+accepts them so an existing ``AppConfig(...)`` call site keeps working.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+__all__ = ["AppUnderTest"]
+
+
+@dataclass(frozen=True, slots=True)
+class AppUnderTest:
+    """Where to find the app under test inside a cluster.
+
+    Attributes:
+        app_name: Kubernetes resource prefix. The handler Service is
+            ``{app_name}-handler``; the worker Deployment is ``{app_name}-worker``.
+        namespace: Kubernetes namespace the app is deployed into.
+        handler_port: Port the handler Service listens on.
+    """
+
+    app_name: str
+    namespace: str
+    handler_port: int = 8000

--- a/application_sdk/testing/harness/starters/__init__.py
+++ b/application_sdk/testing/harness/starters/__init__.py
@@ -1,0 +1,161 @@
+"""Three ways to start a workflow. Deliberately no shared signature.
+
+Different inputs, different handles, no common verb — this is the point, not an
+oversight. A shared ``start(spec) -> handle`` would have to accept the union of
+three unrelated specs and return the union of three unrelated handles, and every
+new way to start work would widen both. As three functions, a base class simply
+calls the one it wants, and a fourth way to start work (a cluster mutation, a
+chaos injection) is a fourth function with nothing in the middle to widen.
+
+**Only one of the three exists today.** ``testing/e2e/workflows.run_workflow`` is
+:func:`start_via_app_handler`: an HTTP ``POST /api/v1/workflows`` to the app's
+*handler Service* through an ephemeral ``kubectl port-forward``. It never touches
+a Temporal task queue. :func:`start_via_automation_engine` is the AE submit,
+lifting from ``testing/e2e/client.py``. :func:`start_on_task_queue` is **new work
+on both sides** — nothing in either repo starts a workflow by dispatching
+directly to a queue — and it is the runtime suite's *first* scenario, because
+everything else depends on it working.
+
+:func:`start_via_automation_engine` lands in child G on FND-224.
+:func:`start_via_app_handler` moves with the cluster reader in child E.
+:func:`start_on_task_queue` is a separate issue, outside FND-224.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+
+from application_sdk.testing.harness.automation_engine import AERunHandle
+from application_sdk.testing.harness.cluster import ClusterReader, ServiceTarget
+
+__all__ = [
+    "HttpRunHandle",
+    "HttpWorkflowSpec",
+    "QueueWorkflowSpec",
+    "WorkflowRunHandle",
+    "start_on_task_queue",
+    "start_via_app_handler",
+    "start_via_automation_engine",
+]
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class QueueWorkflowSpec:
+    """A workflow to dispatch straight onto a Temporal task queue.
+
+    Attributes:
+        workflow_type: Registered workflow type name.
+        task_queue: Queue to dispatch on. Not derived here: the derivation is
+            :func:`application_sdk.common.task_queue.derive_task_queue`, and
+            re-deriving it in the harness would add a sixth independent
+            derivation of the seam this project is trying to collapse.
+        workflow_id: Explicit workflow ID. ``None`` mints one.
+        argument: The workflow's single input argument.
+    """
+
+    workflow_type: str
+    task_queue: str
+    workflow_id: str | None = None
+    argument: Mapping[str, object] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class HttpWorkflowSpec:
+    """A workflow to start by calling the app's own handler Service.
+
+    Attributes:
+        target: Handler Service and port to POST to.
+        workflow_name: Workflow name the handler routes on.
+        body: Request body.
+    """
+
+    target: ServiceTarget
+    workflow_name: str
+    body: Mapping[str, object] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class WorkflowRunHandle:
+    """A run started directly on a task queue.
+
+    Attributes:
+        workflow_id: The workflow ID that was started.
+        run_id: Temporal's run ID for this execution.
+        task_queue: Queue it was dispatched on, echoed back so a caller can
+            assert the queue it *meant* to use is the queue it got.
+    """
+
+    workflow_id: str
+    run_id: str
+    task_queue: str
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class HttpRunHandle:
+    """A run started through the app's handler Service.
+
+    Attributes:
+        workflow_id: The workflow ID the handler reports. The handler's response
+            is the only identifier available on this path — there is no run ID
+            until the workflow is looked up in Temporal.
+    """
+
+    workflow_id: str
+
+
+async def start_via_automation_engine(spec: Mapping[str, object]) -> AERunHandle:
+    """Start a run through the Automation Engine.
+
+    Args:
+        spec: The AE submit payload, as
+            :func:`application_sdk.testing.e2e.payload.build_ae_payload` builds it.
+
+    Returns:
+        The AE run handle.
+
+    Raises:
+        NotImplementedError: Always — implementation is child G on FND-224.
+    """
+    raise NotImplementedError("start_via_automation_engine is child G on FND-224")
+
+
+async def start_on_task_queue(spec: QueueWorkflowSpec) -> WorkflowRunHandle:
+    """Start a workflow by dispatching it directly onto a Temporal task queue.
+
+    Args:
+        spec: What to start, and where.
+
+    Returns:
+        The run handle.
+
+    Raises:
+        NotImplementedError: Always — new work, tracked as a separate issue
+            outside FND-224. Nothing in the SDK or the runtime suite starts a
+            workflow this way today.
+    """
+    raise NotImplementedError(
+        "start_on_task_queue is new work, tracked outside FND-224"
+    )
+
+
+async def start_via_app_handler(
+    spec: HttpWorkflowSpec, *, reader: ClusterReader
+) -> HttpRunHandle:
+    """Start a workflow by POSTing to the app's own handler Service.
+
+    Args:
+        spec: What to start, and which Service to call.
+        reader: Supplies the HTTP transport into the cluster. Taken as an
+            argument rather than constructed here so the same call works from a
+            driver outside the cluster (port-forward) and one inside it.
+
+    Returns:
+        The run handle.
+
+    Raises:
+        NotImplementedError: Always — this lifts from
+            ``application_sdk.testing.e2e.workflows.run_workflow`` with the
+            cluster reader in child E on FND-224.
+    """
+    raise NotImplementedError("start_via_app_handler is child E on FND-224")

--- a/application_sdk/testing/harness/starters/__init__.py
+++ b/application_sdk/testing/harness/starters/__init__.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 
+from application_sdk.testing.harness._errors import HarnessNotBuiltError
 from application_sdk.testing.harness.automation_engine import AERunHandle
 from application_sdk.testing.harness.cluster import ClusterReader, ServiceTarget
 
@@ -115,9 +116,15 @@ async def start_via_automation_engine(spec: Mapping[str, object]) -> AERunHandle
         The AE run handle.
 
     Raises:
-        NotImplementedError: Always — implementation is child G on FND-224.
+        HarnessNotBuiltError: Always — implementation is child G on FND-224.
     """
-    raise NotImplementedError("start_via_automation_engine is child G on FND-224")
+    raise HarnessNotBuiltError(
+        message="start_via_automation_engine is not implemented yet",
+        operation="start_via_automation_engine",
+        reason="child G on FND-224",
+        issue="FND-224",
+        component="harness_starters",
+    )
 
 
 async def start_on_task_queue(spec: QueueWorkflowSpec) -> WorkflowRunHandle:
@@ -130,12 +137,16 @@ async def start_on_task_queue(spec: QueueWorkflowSpec) -> WorkflowRunHandle:
         The run handle.
 
     Raises:
-        NotImplementedError: Always — new work, tracked as a separate issue
+        HarnessNotBuiltError: Always — new work, tracked as a separate issue
             outside FND-224. Nothing in the SDK or the runtime suite starts a
             workflow this way today.
     """
-    raise NotImplementedError(
-        "start_on_task_queue is new work, tracked outside FND-224"
+    raise HarnessNotBuiltError(
+        message="start_on_task_queue is not implemented yet",
+        operation="start_on_task_queue",
+        reason="new work on both sides, tracked as a separate issue outside FND-224",
+        issue="FND-224",
+        component="harness_starters",
     )
 
 
@@ -154,8 +165,14 @@ async def start_via_app_handler(
         The run handle.
 
     Raises:
-        NotImplementedError: Always — this lifts from
+        HarnessNotBuiltError: Always — this lifts from
             ``application_sdk.testing.e2e.workflows.run_workflow`` with the
             cluster reader in child E on FND-224.
     """
-    raise NotImplementedError("start_via_app_handler is child E on FND-224")
+    raise HarnessNotBuiltError(
+        message="start_via_app_handler is not implemented yet",
+        operation="start_via_app_handler",
+        reason="child E on FND-224, with the cluster reader",
+        issue="FND-224",
+        component="harness_starters",
+    )

--- a/application_sdk/testing/harness/teardown.py
+++ b/application_sdk/testing/harness/teardown.py
@@ -28,6 +28,8 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 
+from application_sdk.testing.harness._errors import HarnessNotBuiltError
+
 __all__ = ["PURGE_BATCH_SIZE", "PurgeReport", "purge_connection"]
 
 #: Assets per DELETE. See the module docstring for why this is a correctness
@@ -65,6 +67,12 @@ async def purge_connection(connection_qualified_name: str) -> PurgeReport:
         module docstring.
 
     Raises:
-        NotImplementedError: Always — implementation is child G on FND-224.
+        HarnessNotBuiltError: Always — implementation is child G on FND-224.
     """
-    raise NotImplementedError("purge_connection is child G on FND-224")
+    raise HarnessNotBuiltError(
+        message="purge_connection is not implemented yet",
+        operation="purge_connection",
+        reason="child G on FND-224",
+        issue="FND-224",
+        component="harness_teardown",
+    )

--- a/application_sdk/testing/harness/teardown.py
+++ b/application_sdk/testing/harness/teardown.py
@@ -1,0 +1,70 @@
+"""Purging what a harness run created.
+
+Lifted from ``BaseE2ETest.teardown_method``, whose purge path is the part of the
+harness with the least test coverage and the most consequence: assets a failed
+run leaves behind accumulate in a shared tenant, and a leftover half-set-up
+connection is exactly what greens a later run that should have failed.
+
+Two mechanics have to survive the lift, both non-obvious:
+
+**Batching is a hard requirement, not a tuning knob.** ``pyatlan``'s
+``purge_by_guid`` puts one ``guid=`` query parameter per asset into a single
+DELETE, and ``httpx`` refuses to build a URL whose query exceeds its
+``MAX_URL_LENGTH``. At roughly 42 bytes per GUID that is a ceiling near 1,550
+assets, raised client-side — so an unbatched purge of a normal crawl's output
+deletes *nothing*. The batch stays well under the ceiling for a second reason:
+purge is expensive server-side, and a smaller batch means a failing chunk
+orphans less.
+
+**A failed purge is reported, never raised.** Teardown runs after the assertions
+have already decided the verdict. Raising here replaces a real failure with a
+cleanup error and loses the diagnosis.
+
+Implementation is child G on FND-224.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+
+__all__ = ["PURGE_BATCH_SIZE", "PurgeReport", "purge_connection"]
+
+#: Assets per DELETE. See the module docstring for why this is a correctness
+#: bound rather than a performance choice.
+PURGE_BATCH_SIZE = 50
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class PurgeReport:
+    """What a purge managed to delete, and what it did not.
+
+    Attributes:
+        purged: Count of assets successfully deleted.
+        orphaned: Qualified names of assets the purge could not delete. Named
+            individually rather than counted: an operator cleaning up by hand
+            needs the list, and a count tells them only that they have a problem.
+        errors: One line per failed batch, in order.
+    """
+
+    purged: int = 0
+    orphaned: Sequence[str] = field(default_factory=tuple)
+    errors: Sequence[str] = field(default_factory=tuple)
+
+
+async def purge_connection(connection_qualified_name: str) -> PurgeReport:
+    """Delete every asset under *connection_qualified_name*, then the connection.
+
+    Args:
+        connection_qualified_name: The ephemeral connection this run created.
+            Must be a name the run minted itself — never a long-lived shared
+            connection, whose assets are not this run's to delete.
+
+    Returns:
+        A :class:`PurgeReport`. Failures are reported here, not raised: see the
+        module docstring.
+
+    Raises:
+        NotImplementedError: Always — implementation is child G on FND-224.
+    """
+    raise NotImplementedError("purge_connection is child G on FND-224")

--- a/application_sdk/testing/harness/temporal/__init__.py
+++ b/application_sdk/testing/harness/temporal/__init__.py
@@ -1,0 +1,124 @@
+"""Read-only Protocol over Temporal, plus the states it returns.
+
+Neither reader exists in ``testing/e2e/`` today, and the gap is load-bearing:
+:class:`~application_sdk.testing.e2e._errors.NoWorkerOnTaskQueueError` is
+currently *inferred* — "no DAG node started inside the grace window, so probably
+nothing is polling the queue". A real poller read makes it **observed**, which
+turns the single most common harness wedge (a suite whose ``agent_spec()``
+queue does not match the deployed worker's) from a 180-second guess into a fact.
+
+Read-only, like :mod:`application_sdk.testing.harness.cluster`, and for the same
+reason: scenario-side mutation stays scenario-side.
+
+Implementation lands as a separate issue outside FND-224, per the decomposition —
+this module scaffolds the vocabulary its callers are written against.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+from typing import Protocol, runtime_checkable
+
+__all__ = [
+    "PollerInfo",
+    "TemporalReader",
+    "WorkflowExecutionStatus",
+    "WorkflowStatus",
+]
+
+
+class WorkflowExecutionStatus(str, Enum):
+    """Terminal and non-terminal states a workflow execution can report.
+
+    Mirrors Temporal's own ``WorkflowExecutionStatus`` rather than inventing a
+    parallel vocabulary — the harness's job is to report what Temporal says.
+    """
+
+    RUNNING = "Running"
+    COMPLETED = "Completed"
+    FAILED = "Failed"
+    CANCELED = "Canceled"
+    TERMINATED = "Terminated"
+    CONTINUED_AS_NEW = "ContinuedAsNew"
+    TIMED_OUT = "TimedOut"
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class PollerInfo:
+    """One worker seen polling a task queue.
+
+    Attributes:
+        identity: The worker's self-reported identity, usually
+            ``{pid}@{hostname}``. This is what tells "the wrong worker is
+            polling" from "nothing is polling".
+        last_access: When Temporal last saw this poller.
+        build_id: Worker build identifier, when versioning is in use. Names the
+            specific build holding the queue — the shape behind an older build
+            keeping the pollers while the current one sits at zero.
+    """
+
+    identity: str
+    last_access: datetime
+    build_id: str | None = None
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class WorkflowStatus:
+    """One workflow execution's state.
+
+    Attributes:
+        workflow_id: The workflow ID asked about.
+        run_id: The specific run this status describes.
+        status: Execution status as Temporal reports it.
+        task_queue: Queue the execution is dispatched on. Exposed because the
+            queue-name seam — ``atlan-{application}-{deployment}``, derived
+            independently in several places — is checkable here without a pod
+            exec.
+        started_at: When the execution started.
+        closed_at: When it reached a terminal state, or ``None`` while running.
+    """
+
+    workflow_id: str
+    run_id: str
+    status: WorkflowExecutionStatus
+    task_queue: str
+    started_at: datetime | None = None
+    closed_at: datetime | None = None
+
+
+@runtime_checkable
+class TemporalReader(Protocol):
+    """Read Temporal state. No mutation, by decision."""
+
+    async def task_queue_pollers(
+        self, queue: str, *, namespace: str
+    ) -> Sequence[PollerInfo]:
+        """Return the workers Temporal currently sees polling *queue*.
+
+        Args:
+            queue: Task-queue name.
+            namespace: Temporal namespace.
+
+        Returns:
+            One :class:`PollerInfo` per poller. **Empty is a real answer** — it
+            is the observed form of "no worker on this task queue", and the
+            caller should report it as such rather than retrying into a timeout.
+        """
+        ...
+
+    async def workflow_status(
+        self, workflow_id: str, *, run_id: str | None = None
+    ) -> WorkflowStatus:
+        """Return the state of one workflow execution.
+
+        Args:
+            workflow_id: Workflow ID to describe.
+            run_id: Specific run, or ``None`` for the latest run of that ID.
+
+        Returns:
+            The execution's :class:`WorkflowStatus`.
+        """
+        ...

--- a/application_sdk/testing/harness/waiting.py
+++ b/application_sdk/testing/harness/waiting.py
@@ -1,0 +1,132 @@
+"""The two bounded-wait primitives every harness loop is expressed over.
+
+**This is an extraction, not an invention.** Both guards :func:`poll_until`
+needs already work — they are interleaved statements inside
+``testing/e2e/client.py``'s ``poll_native_status``, coupled to the Automation
+Engine ``native-status`` wire shape, the ``DAGNodeStatus`` vocabulary, and a
+node-glyph summary *string* used as the progress fingerprint. The generic
+primitive underneath is: *bounded poll + caller-supplied progress fingerprint +
+started/settled predicates + start-grace latch + no-change watchdog + transient-
+error streak with a retry-after budget.* Only the fingerprint and the predicates
+are instance-specific, and they are passed in — which is why no fixed shared
+verb is needed and why ``ClusterReader`` never has to grow everyone's states.
+
+The clock, the sleeping and the off-by-one already live in
+:mod:`application_sdk.testing.e2e._poll` (``until_deadline`` /
+``until_deadline_async``, monotonic, with the gap re-clamped against the clock
+read *after* the probe). :func:`poll_until` is built on that rather than on a
+second deadline implementation; the private module moves here as part of child C.
+
+:func:`hold_stable` is **new**. All twelve bounded loops in ``testing/e2e/``
+today are "wait until"; not one is "assert stays". The negative assertion is
+what the runtime scaling scenarios turn on — "a busy pod is never scaled away",
+"it must not scale down while a long activity is still running", and the whole
+steady-state group — because most scaling bugs are wrong *actions* rather than
+wrong states.
+
+Implementation is FND-227 (child C).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from datetime import timedelta
+from typing import TypeAlias, TypeVar
+
+from application_sdk.testing.harness.budgets import Budget
+from application_sdk.testing.harness.outcome import Outcome
+
+__all__ = ["Probe", "hold_stable", "poll_until"]
+
+T = TypeVar("T")
+
+#: One reading of whatever is being waited on. Async by construction (decision
+#: D1): there is no synchronous probe anywhere in the harness.
+Probe: TypeAlias = Callable[[], Awaitable[T]]
+
+
+async def poll_until(
+    probe: Probe[T],
+    *,
+    settled: Callable[[T], bool],
+    started: Callable[[T], bool] | None = None,
+    fingerprint: Callable[[T], str] | None = None,
+    transient: Callable[[BaseException], timedelta | None] | None = None,
+    budget: Budget,
+    label: str,
+) -> Outcome[T]:
+    """Poll until *settled*, or until the budget, grace or watchdog says stop.
+
+    Args:
+        probe: Takes one reading. Called once per poll.
+        settled: True when the reading is the terminal state being waited for.
+            Returns :class:`~application_sdk.testing.harness.outcome.Settled`.
+        started: True once work has demonstrably begun. Until it returns True
+            the start-grace latch applies, and its expiry gives
+            :class:`~application_sdk.testing.harness.outcome.NeverStarted`
+            rather than a generic timeout — dispatch failures and slow work are
+            different diagnoses. ``None`` means "started on the first reading".
+        fingerprint: Reduces a reading to a comparable progress string. When it
+            stops changing for ``budget.stall_timeout`` the wait returns
+            :class:`~application_sdk.testing.harness.outcome.Stalled` carrying
+            the frozen fingerprint. ``None`` disables the watchdog regardless of
+            the budget, because there is nothing to compare.
+        transient: Classifies a probe exception. Returns a backoff to honour
+            (bounded by ``budget.retry_after_budget``) to absorb it as
+            transient, or ``None`` to treat it as terminal. An unclassified
+            exception propagates: a deterministic bug in the probe itself — a
+            wrong call signature, a bad config value — raises the same exception
+            on every attempt, so waiting out the budget only delays the failure.
+        budget: The wait's whole allowance. See
+            :class:`~application_sdk.testing.harness.budgets.Budget`.
+        label: Noun phrase naming the concrete target, for the report and the
+            heartbeat line. Written for whoever reads a red CI leg.
+
+    Returns:
+        The verdict. Never raises on a failed wait — see
+        :mod:`application_sdk.testing.harness.outcome` for why, and
+        :func:`~application_sdk.testing.harness.outcome.assert_settled` for the
+        raise-on-failure adapter.
+
+    Raises:
+        NotImplementedError: Always — implementation is FND-227 (child C).
+    """
+    raise NotImplementedError("poll_until is FND-227 (child C)")
+
+
+async def hold_stable(
+    probe: Probe[T],
+    *,
+    invariant: Callable[[T], bool],
+    budget: Budget,
+    label: str,
+) -> Outcome[T]:
+    """Assert *invariant* holds for every reading across the whole budget.
+
+    The negative assertion: success is the budget expiring with nothing having
+    gone wrong. ``budget.timeout`` is therefore the hold *duration*, not a
+    deadline to race — this function always spends it in full on the happy path.
+
+    Args:
+        probe: Takes one reading. Called once per poll.
+        invariant: True while the reading is still acceptable. The first False
+            ends the hold.
+        budget: The hold's allowance. ``start_grace`` and ``stall_timeout`` are
+            not consulted: there is no start to wait for and no progress to
+            watch.
+        label: Noun phrase naming what must stay true ("worker replicas while
+            the extract activity runs").
+
+    Returns:
+        :class:`~application_sdk.testing.harness.outcome.Settled` with the last
+        reading when the invariant held throughout;
+        :class:`~application_sdk.testing.harness.outcome.Stalled` — same
+        "stopped being what it should be" shape — carrying the violating
+        reading when it did not; or
+        :class:`~application_sdk.testing.harness.outcome.Indeterminate` when the
+        probe itself could not be read.
+
+    Raises:
+        NotImplementedError: Always — implementation is FND-227 (child C).
+    """
+    raise NotImplementedError("hold_stable is FND-227 (child C)")

--- a/application_sdk/testing/harness/waiting.py
+++ b/application_sdk/testing/harness/waiting.py
@@ -33,6 +33,7 @@ from collections.abc import Awaitable, Callable
 from datetime import timedelta
 from typing import TypeAlias, TypeVar
 
+from application_sdk.testing.harness._errors import HarnessNotBuiltError
 from application_sdk.testing.harness.budgets import Budget
 from application_sdk.testing.harness.outcome import Outcome
 
@@ -89,9 +90,15 @@ async def poll_until(
         raise-on-failure adapter.
 
     Raises:
-        NotImplementedError: Always — implementation is FND-227 (child C).
+        HarnessNotBuiltError: Always — implementation is FND-227 (child C).
     """
-    raise NotImplementedError("poll_until is FND-227 (child C)")
+    raise HarnessNotBuiltError(
+        message="poll_until is not implemented yet",
+        operation="poll_until",
+        reason="child C on FND-224 (= FND-227)",
+        issue="FND-227",
+        component="harness_waiting",
+    )
 
 
 async def hold_stable(
@@ -127,6 +134,12 @@ async def hold_stable(
         probe itself could not be read.
 
     Raises:
-        NotImplementedError: Always — implementation is FND-227 (child C).
+        HarnessNotBuiltError: Always — implementation is FND-227 (child C).
     """
-    raise NotImplementedError("hold_stable is FND-227 (child C)")
+    raise HarnessNotBuiltError(
+        message="hold_stable is not implemented yet",
+        operation="hold_stable",
+        reason="child C on FND-224 (= FND-227); new work, not an extraction",
+        issue="FND-227",
+        component="harness_waiting",
+    )

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -1,8 +1,8 @@
 <!--
 generated-by:  capability-manifest skill (.claude/skills/capability-manifest)
 sdk-version:   3.29.0
-source-sha:    61913873f10221724cab19322cf060b6b50c3c8b
-source-date:   2026-08-26T02:59:49+01:00
+source-sha:    4d71641e9416d228dceda7a5335da0c36a0b4a46
+source-date:   2026-08-26T08:20:57+01:00
 do-not-edit:   re-run the skill instead of hand-editing
 -->
 
@@ -3106,7 +3106,7 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 
 - **Import:** `from application_sdk.testing.e2e import AppConfig`
 - **Also importable from:** `application_sdk.testing.e2e.config`
-- **Signature:** `class AppConfig(app_name: str, ...)`
+- **Signature:** `class AppConfig(app_name: str = '', ...)`
 - **Summary:** Deprecated (removed in v4.0) — use :class:`AppUnderTest`.
 - **Defined in:** `application_sdk/testing/e2e/config.py`
 

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -1,8 +1,8 @@
 <!--
 generated-by:  capability-manifest skill (.claude/skills/capability-manifest)
-sdk-version:   3.28.3
-source-sha:    552d36d15f0be66f01885adcc7b51c20e9406128
-source-date:   2026-08-25T22:34:28+01:00
+sdk-version:   3.29.0
+source-sha:    9f5b89e6251980fca5a1ecb6f500823ac351fe51
+source-date:   2026-08-26T01:19:46Z
 do-not-edit:   re-run the skill instead of hand-editing
 -->
 
@@ -34,7 +34,7 @@ do-not-edit:   re-run the skill instead of hand-editing
 | `application_sdk.server` | FastAPI server, MCP integration, middleware, health endpoint | 4 |
 | `application_sdk.storage` | Object-store abstraction — factory, formats, batch, transfer, cloud bindings | 42 |
 | `application_sdk.templates` | SQL metadata extractor templates and their contracts | 6 |
-| `application_sdk.testing` | Test infrastructure — mocks, fixtures, hypothesis strategies, integration helpers | 97 |
+| `application_sdk.testing` | Test infrastructure — mocks, fixtures, hypothesis strategies, integration helpers | 150 |
 | `application_sdk.validation` | Offline artifact & asset validation — format-agnostic wrapper (ADR-0020) plus pyatlan_v9 .validate() wrappers, no network call | 78 |
 
 ## Subpackage Details
@@ -3080,6 +3080,13 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 
 ### Classes
 
+#### `AERunHandle`
+
+- **Import:** `from application_sdk.testing.harness.automation_engine import AERunHandle`
+- **Signature:** `class AERunHandle(*, workflow_slug: str, run_id: str) -> None`
+- **Summary:** What a successful submit returns.
+- **Defined in:** `application_sdk/testing/harness/automation_engine/__init__.py`
+
 #### `AEWorkflowClient`
 
 - **Import:** `from application_sdk.testing.full_dag import AEWorkflowClient`
@@ -3098,9 +3105,18 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 #### `AppConfig`
 
 - **Import:** `from application_sdk.testing.e2e import AppConfig`
+- **Also importable from:** `application_sdk.testing.e2e.config`
 - **Signature:** `class AppConfig(app_name: str, ...)`
-- **Summary:** Configuration for an app under K8s e2e testing.
+- **Summary:** Deprecated (removed in v4.0) — use :class:`AppUnderTest`.
 - **Defined in:** `application_sdk/testing/e2e/config.py`
+
+#### `AppUnderTest`
+
+- **Import:** `from application_sdk.testing.harness import AppUnderTest`
+- **Also importable from:** `application_sdk.testing.harness.spec`
+- **Signature:** `class AppUnderTest(app_name: str, namespace: str, handler_port: int = 8000)`
+- **Summary:** Where to find the app under test inside a cluster.
+- **Defined in:** `application_sdk/testing/harness/spec.py`
 
 #### `AssetDiff`
 
@@ -3109,6 +3125,13 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Signature:** `class AssetDiff(asset_type: str, ...)`
 - **Summary:** A single difference found between expected and actual metadata.
 - **Defined in:** `application_sdk/testing/integration/comparison.py`
+
+#### `AssetExpectations`
+
+- **Import:** `from application_sdk.testing.harness.expectations import AssetExpectations`
+- **Signature:** `class AssetExpectations(*, ...)`
+- **Summary:** What a run is expected to have landed in Atlas.
+- **Defined in:** `application_sdk/testing/harness/expectations.py`
 
 #### `AssetValidationFailure`
 
@@ -3152,12 +3175,42 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Summary:** Deprecated: use ``application_sdk.testing.e2e.BaseE2ETest`` with
 - **Defined in:** `application_sdk/testing/sdr/base.py`
 
+#### `Budget`
+
+- **Import:** `from application_sdk.testing.harness import Budget`
+- **Also importable from:** `application_sdk.testing.harness.budgets`
+- **Signature:** `class Budget(*, ...)`
+- **Summary:** Everything a single bounded wait is allowed to spend.
+- **Defined in:** `application_sdk/testing/harness/budgets.py`
+
+#### `BudgetProfile`
+
+- **Import:** `from application_sdk.testing.harness import BudgetProfile`
+- **Also importable from:** `application_sdk.testing.harness.budgets`
+- **Signature:** `class BudgetProfile(*, name: str, budgets: dict[str, Budget])`
+- **Summary:** A named set of budgets for one execution tier.
+- **Defined in:** `application_sdk/testing/harness/budgets.py`
+
 #### `CategoryResult`
 
 - **Import:** `from application_sdk.testing.parity import CategoryResult`
 - **Signature:** `class CategoryResult(category: str, ...)`
 - **Summary:** Comparison result for a single category (e.g., table, column).
 - **Defined in:** `application_sdk/testing/parity/models.py`
+
+#### `ClusterReader`
+
+- **Import:** `from application_sdk.testing.harness.cluster import ClusterReader`
+- **Signature:** `class ClusterReader`
+- **Summary:** Read built-in Kubernetes state. No mutation, by decision.
+- **Defined in:** `application_sdk/testing/harness/cluster/__init__.py`
+
+#### `CustomResourceReader`
+
+- **Import:** `from application_sdk.testing.harness.cluster import CustomResourceReader`
+- **Signature:** `class CustomResourceReader`
+- **Summary:** Read custom resources, parameterised by :class:`ResourceRef`.
+- **Defined in:** `application_sdk/testing/harness/cluster/__init__.py`
 
 #### `DAGNodeResult`
 
@@ -3196,12 +3249,41 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Summary:** The integration source's credential fields, read uniformly from env.
 - **Defined in:** `application_sdk/testing/integration/source.py`
 
+#### `DeploymentState`
+
+- **Import:** `from application_sdk.testing.harness.cluster import DeploymentState`
+- **Signature:** `class DeploymentState(*, ...)`
+- **Summary:** One Deployment's replica counts.
+- **Defined in:** `application_sdk/testing/harness/cluster/__init__.py`
+
+#### `EvidenceBundle`
+
+- **Import:** `from application_sdk.testing.harness.evidence import EvidenceBundle`
+- **Signature:** `class EvidenceBundle(*, ...)`
+- **Summary:** Everything worth keeping about one harness run.
+- **Defined in:** `application_sdk/testing/harness/evidence.py`
+
+#### `Expired`
+
+- **Import:** `from application_sdk.testing.harness import Expired`
+- **Also importable from:** `application_sdk.testing.harness.outcome`
+- **Signature:** `class Expired(*, label: str, attempts: int, elapsed: timedelta, budget: timedelta, last: T | None = None)`
+- **Summary:** The budget ran out while work was still progressing.
+- **Defined in:** `application_sdk/testing/harness/outcome.py`
+
 #### `FieldDiff`
 
 - **Import:** `from application_sdk.testing.parity import FieldDiff`
 - **Signature:** `class FieldDiff(field_path: str, baseline_value: Any, candidate_value: Any)`
 - **Summary:** A single field-level difference between baseline and candidate.
 - **Defined in:** `application_sdk/testing/parity/models.py`
+
+#### `Finding`
+
+- **Import:** `from application_sdk.testing.harness.expectations import Finding`
+- **Signature:** `class Finding(*, subject: str, detail: str, expectation: str) -> None`
+- **Summary:** One unmet expectation, in a form a report can render without re-parsing.
+- **Defined in:** `application_sdk/testing/harness/expectations.py`
 
 #### `FullDAGOutcome`
 
@@ -3216,6 +3298,42 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Signature:** `class GapReport(diffs: list[AssetDiff] = list(), summary: dict[str, int] = dict(), expected_file: str | None = None)`
 - **Summary:** Summary of all differences between expected and actual metadata.
 - **Defined in:** `application_sdk/testing/integration/comparison.py`
+
+#### `HttpRequest`
+
+- **Import:** `from application_sdk.testing.harness.cluster import HttpRequest`
+- **Signature:** `class HttpRequest(*, ...)`
+- **Summary:** An HTTP call to make against a :class:`ServiceTarget`.
+- **Defined in:** `application_sdk/testing/harness/cluster/__init__.py`
+
+#### `HttpResponse`
+
+- **Import:** `from application_sdk.testing.harness.cluster import HttpResponse`
+- **Signature:** `class HttpResponse(*, status: int, body: Any | None = None, text: str = '') -> None`
+- **Summary:** What came back.
+- **Defined in:** `application_sdk/testing/harness/cluster/__init__.py`
+
+#### `HttpRunHandle`
+
+- **Import:** `from application_sdk.testing.harness.starters import HttpRunHandle`
+- **Signature:** `class HttpRunHandle(*, workflow_id: str) -> None`
+- **Summary:** A run started through the app's handler Service.
+- **Defined in:** `application_sdk/testing/harness/starters/__init__.py`
+
+#### `HttpWorkflowSpec`
+
+- **Import:** `from application_sdk.testing.harness.starters import HttpWorkflowSpec`
+- **Signature:** `class HttpWorkflowSpec(*, target: ServiceTarget, workflow_name: str, body: Mapping[str, object] = dict()) -> None`
+- **Summary:** A workflow to start by calling the app's own handler Service.
+- **Defined in:** `application_sdk/testing/harness/starters/__init__.py`
+
+#### `Indeterminate`
+
+- **Import:** `from application_sdk.testing.harness import Indeterminate`
+- **Also importable from:** `application_sdk.testing.harness.outcome`
+- **Signature:** `class Indeterminate(*, ...)`
+- **Summary:** The wait could not reach a verdict — the probe itself failed.
+- **Defined in:** `application_sdk/testing/harness/outcome.py`
 
 #### `IntegrationTestClient`
 
@@ -3237,6 +3355,20 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Signature:** `class LogCollector(namespace: str, output_dir: Path)`
 - **Summary:** Collect kubectl logs, pod descriptions, and events from a namespace.
 - **Defined in:** `application_sdk/testing/e2e/logs.py`
+
+#### `LogLine`
+
+- **Import:** `from application_sdk.testing.harness.cluster import LogLine`
+- **Signature:** `class LogLine(*, pod: str, container: str, message: str, timestamp: datetime | None = None) -> None`
+- **Summary:** One line of container output.
+- **Defined in:** `application_sdk/testing/harness/cluster/__init__.py`
+
+#### `Minter`
+
+- **Import:** `from application_sdk.testing.harness.identity import Minter`
+- **Signature:** `class Minter(*, clock: Callable[[], int], randbelow: Callable[[int], int], run_id_env: str | None = None) -> None`
+- **Summary:** Mints the per-run identifiers a harness run needs.
+- **Defined in:** `application_sdk/testing/harness/identity.py`
 
 #### `MockBinding`
 
@@ -3280,12 +3412,69 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Summary:** In-memory state store with call-tracking for unit tests.
 - **Defined in:** `application_sdk/testing/mocks.py`
 
+#### `NativeStatus`
+
+- **Import:** `from application_sdk.testing.harness.automation_engine import NativeStatus`
+- **Signature:** `class NativeStatus(*, node_states: Mapping[str, str], finished: bool, fingerprint: str) -> None`
+- **Summary:** One reading of a run's ``native-status``.
+- **Defined in:** `application_sdk/testing/harness/automation_engine/__init__.py`
+
+#### `NeverStarted`
+
+- **Import:** `from application_sdk.testing.harness import NeverStarted`
+- **Also importable from:** `application_sdk.testing.harness.outcome`
+- **Signature:** `class NeverStarted(*, label: str, attempts: int, elapsed: timedelta, grace: timedelta, last: T | None = None)`
+- **Summary:** Nothing ever started, so the budget was spent waiting for work to begin.
+- **Defined in:** `application_sdk/testing/harness/outcome.py`
+
+#### `PodPhase`
+
+- **Import:** `from application_sdk.testing.harness.cluster import PodPhase`
+- **Signature:** `class PodPhase`
+- **Summary:** Kubernetes pod phase, as the API server reports it.
+- **Defined in:** `application_sdk/testing/harness/cluster/__init__.py`
+
+#### `PodState`
+
+- **Import:** `from application_sdk.testing.harness.cluster import PodState`
+- **Signature:** `class PodState(*, ...)`
+- **Summary:** One pod, reduced to what a harness assertion reads.
+- **Defined in:** `application_sdk/testing/harness/cluster/__init__.py`
+
+#### `PollerInfo`
+
+- **Import:** `from application_sdk.testing.harness.temporal import PollerInfo`
+- **Signature:** `class PollerInfo(*, identity: str, last_access: datetime, build_id: str | None = None) -> None`
+- **Summary:** One worker seen polling a task queue.
+- **Defined in:** `application_sdk/testing/harness/temporal/__init__.py`
+
+#### `PurgeReport`
+
+- **Import:** `from application_sdk.testing.harness.teardown import PurgeReport`
+- **Signature:** `class PurgeReport(*, purged: int = 0, orphaned: Sequence[str] = tuple(), errors: Sequence[str] = tuple()) -> None`
+- **Summary:** What a purge managed to delete, and what it did not.
+- **Defined in:** `application_sdk/testing/harness/teardown.py`
+
+#### `QueueWorkflowSpec`
+
+- **Import:** `from application_sdk.testing.harness.starters import QueueWorkflowSpec`
+- **Signature:** `class QueueWorkflowSpec(*, ...)`
+- **Summary:** A workflow to dispatch straight onto a Temporal task queue.
+- **Defined in:** `application_sdk/testing/harness/starters/__init__.py`
+
 #### `ReferentialFailure`
 
 - **Import:** `from application_sdk.testing.integration import ReferentialFailure`
 - **Signature:** `class ReferentialFailure(missing_type_name: str, ...)`
 - **Summary:** A relationship reference whose target asset is absent from the batch.
 - **Defined in:** `application_sdk/validation/assets.py`
+
+#### `ResourceRef`
+
+- **Import:** `from application_sdk.testing.harness.cluster import ResourceRef`
+- **Signature:** `class ResourceRef(*, group: str, version: str, plural: str) -> None`
+- **Summary:** Identifies a custom-resource kind by its API coordinates.
+- **Defined in:** `application_sdk/testing/harness/cluster/__init__.py`
 
 #### `RunMode`
 
@@ -3309,6 +3498,21 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Summary:** Result of executing a single scenario.
 - **Defined in:** `application_sdk/testing/integration/models.py`
 
+#### `ServiceTarget`
+
+- **Import:** `from application_sdk.testing.harness.cluster import ServiceTarget`
+- **Signature:** `class ServiceTarget(*, namespace: str, service: str, port: int) -> None`
+- **Summary:** A Service and port to reach, however the backend chooses to reach it.
+- **Defined in:** `application_sdk/testing/harness/cluster/__init__.py`
+
+#### `Settled`
+
+- **Import:** `from application_sdk.testing.harness import Settled`
+- **Also importable from:** `application_sdk.testing.harness.outcome`
+- **Signature:** `class Settled(*, label: str, attempts: int, elapsed: timedelta, value: T)`
+- **Summary:** The probe reached the settled state inside its budget.
+- **Defined in:** `application_sdk/testing/harness/outcome.py`
+
 #### `SQLAppE2EFullTest`
 
 - **Import:** `from application_sdk.testing.full_dag import SQLAppE2EFullTest`
@@ -3322,6 +3526,49 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Signature:** `class SQLAppE2ETest`
 - **Summary:** Full-DAG e2e harness pre-wired for SQL connectors.
 - **Defined in:** `application_sdk/testing/e2e/sql_app.py`
+
+#### `Stalled`
+
+- **Import:** `from application_sdk.testing.harness import Stalled`
+- **Also importable from:** `application_sdk.testing.harness.outcome`
+- **Signature:** `class Stalled(*, ...)`
+- **Summary:** Work started, then stopped making observable progress.
+- **Defined in:** `application_sdk/testing/harness/outcome.py`
+
+#### `SyncBridgeInAsyncContextError`
+
+- **Import:** `from application_sdk.testing.harness import SyncBridgeInAsyncContextError`
+- **Signature:** `class SyncBridgeInAsyncContextError(*, ...)`
+- **Summary:** :func:`~application_sdk.testing.harness.run_sync` was called from a running loop.
+- **Defined in:** `application_sdk/testing/harness/_errors.py`
+
+#### `TemporalReader`
+
+- **Import:** `from application_sdk.testing.harness.temporal import TemporalReader`
+- **Signature:** `class TemporalReader`
+- **Summary:** Read Temporal state. No mutation, by decision.
+- **Defined in:** `application_sdk/testing/harness/temporal/__init__.py`
+
+#### `WorkflowExecutionStatus`
+
+- **Import:** `from application_sdk.testing.harness.temporal import WorkflowExecutionStatus`
+- **Signature:** `class WorkflowExecutionStatus`
+- **Summary:** Terminal and non-terminal states a workflow execution can report.
+- **Defined in:** `application_sdk/testing/harness/temporal/__init__.py`
+
+#### `WorkflowRunHandle`
+
+- **Import:** `from application_sdk.testing.harness.starters import WorkflowRunHandle`
+- **Signature:** `class WorkflowRunHandle(*, workflow_id: str, run_id: str, task_queue: str) -> None`
+- **Summary:** A run started directly on a task queue.
+- **Defined in:** `application_sdk/testing/harness/starters/__init__.py`
+
+#### `WorkflowStatus`
+
+- **Import:** `from application_sdk.testing.harness.temporal import WorkflowStatus`
+- **Signature:** `class WorkflowStatus(*, ...)`
+- **Summary:** One workflow execution's state.
+- **Defined in:** `application_sdk/testing/harness/temporal/__init__.py`
 
 ### Functions
 
@@ -3345,6 +3592,14 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Signature:** `app_context(mock_state_store: MockStateStore, mock_secret_store: MockSecretStore)`
 - **Summary:** AppContext wired with MockStateStore and MockSecretStore.
 - **Defined in:** `application_sdk/testing/fixtures.py`
+
+#### `assert_settled`
+
+- **Import:** `from application_sdk.testing.harness import assert_settled`
+- **Also importable from:** `application_sdk.testing.harness.outcome`
+- **Signature:** `assert_settled(outcome: Outcome[T])`
+- **Summary:** Return the settled value, or raise the typed leaf for the verdict.
+- **Defined in:** `application_sdk/testing/harness/outcome.py`
 
 #### `between`
 
@@ -3381,6 +3636,14 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Summary:** TaskRegistry reset before and after each test.
 - **Defined in:** `application_sdk/testing/fixtures.py`
 
+#### `close_loop`
+
+- **Import:** `from application_sdk.testing.harness import close_loop`
+- **Also importable from:** `application_sdk.testing.harness.bridge`
+- **Signature:** `close_loop()`
+- **Summary:** Close this thread's bridge loop, if it has one. Idempotent.
+- **Defined in:** `application_sdk/testing/harness/bridge.py`
+
 #### `cold_start_submit_kwargs`
 
 - **Import:** `from application_sdk.testing.full_dag.client import cold_start_submit_kwargs`
@@ -3408,6 +3671,13 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Signature:** `contains(item: Any, *, description: str | None = None)`
 - **Summary:** Assert that the actual value contains the given item.
 - **Defined in:** `application_sdk/testing/integration/assertions.py`
+
+#### `count_assets`
+
+- **Import:** `from application_sdk.testing.harness.atlas import count_assets`
+- **Signature:** `count_assets(connection_qualified_name: str, type_names: Sequence[str]) -> Outcome[Mapping[str, int]]`
+- **Summary:** Count assets of each named type under a connection.
+- **Defined in:** `application_sdk/testing/harness/atlas/__init__.py`
 
 #### `custom`
 
@@ -3437,12 +3707,26 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Summary:** Assert that the actual value equals the expected value.
 - **Defined in:** `application_sdk/testing/integration/assertions.py`
 
+#### `evaluate_counts`
+
+- **Import:** `from application_sdk.testing.harness.expectations import evaluate_counts`
+- **Signature:** `evaluate_counts(counts: Mapping[str, *, ...)`
+- **Summary:** Evaluate per-type counts against the declared floors, exacts and backstop.
+- **Defined in:** `application_sdk/testing/harness/expectations.py`
+
 #### `evaluate_if_lazy`
 
 - **Import:** `from application_sdk.testing.integration import evaluate_if_lazy`
 - **Signature:** `evaluate_if_lazy(value: T)`
 - **Summary:** Evaluate a value if it's lazy, otherwise return as-is.
 - **Defined in:** `application_sdk/testing/integration/lazy.py`
+
+#### `evaluate_locations`
+
+- **Import:** `from application_sdk.testing.harness.expectations import evaluate_locations`
+- **Signature:** `evaluate_locations(samples: Mapping[str, Sequence[str]], expectations: AssetExpectations) -> Sequence[Finding]`
+- **Summary:** Evaluate sampled qualified names against the declared hierarchy depths.
+- **Defined in:** `application_sdk/testing/harness/expectations.py`
 
 #### `exists`
 
@@ -3513,6 +3797,14 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Signature:** `has_length(expected_length: int, *, description: str | None = None)`
 - **Summary:** Assert that the actual value has the expected length.
 - **Defined in:** `application_sdk/testing/integration/assertions.py`
+
+#### `hold_stable`
+
+- **Import:** `from application_sdk.testing.harness import hold_stable`
+- **Also importable from:** `application_sdk.testing.harness.waiting`
+- **Signature:** `hold_stable(probe: Probe[T], *, invariant: Callable[[T], bool], budget: Budget, label: str)`
+- **Summary:** Assert *invariant* holds for every reading across the whole budget.
+- **Defined in:** `application_sdk/testing/harness/waiting.py`
 
 #### `is_dict`
 
@@ -3717,12 +4009,49 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Summary:** Create a pytest parametrize decorator for scenarios.
 - **Defined in:** `application_sdk/testing/integration/runner.py`
 
+#### `poll_native_status`
+
+- **Import:** `from application_sdk.testing.harness.automation_engine import poll_native_status`
+- **Signature:** `poll_native_status(handle: AERunHandle, *, budget: Budget) -> Outcome[NativeStatus]`
+- **Summary:** Poll a run's native status until it settles, stalls or runs out of budget.
+- **Defined in:** `application_sdk/testing/harness/automation_engine/__init__.py`
+
+#### `poll_until`
+
+- **Import:** `from application_sdk.testing.harness import poll_until`
+- **Also importable from:** `application_sdk.testing.harness.waiting`
+- **Signature:** `poll_until(probe: Probe[T], *, ...)`
+- **Summary:** Poll until *settled*, or until the budget, grace or watchdog says stop.
+- **Defined in:** `application_sdk/testing/harness/waiting.py`
+
+#### `purge_connection`
+
+- **Import:** `from application_sdk.testing.harness.teardown import purge_connection`
+- **Signature:** `purge_connection(connection_qualified_name: str) -> PurgeReport`
+- **Summary:** Delete every asset under *connection_qualified_name*, then the connection.
+- **Defined in:** `application_sdk/testing/harness/teardown.py`
+
+#### `redact`
+
+- **Import:** `from application_sdk.testing.harness.evidence import redact`
+- **Signature:** `redact(bundle: EvidenceBundle) -> EvidenceBundle`
+- **Summary:** Return *bundle* with credential-shaped values replaced by placeholders.
+- **Defined in:** `application_sdk/testing/harness/evidence.py`
+
 #### `run_comparison`
 
 - **Import:** `from application_sdk.testing.parity import run_comparison`
 - **Signature:** `run_comparison(baseline_dir: Path, candidate_dir: Path)`
 - **Summary:** Run full parity comparison across all categories.
 - **Defined in:** `application_sdk/testing/parity/comparator.py`
+
+#### `run_sync`
+
+- **Import:** `from application_sdk.testing.harness import run_sync`
+- **Also importable from:** `application_sdk.testing.harness.bridge`
+- **Signature:** `run_sync(coro: Coroutine[Any, Any, T])`
+- **Summary:** Run *coro* to completion on this thread's bridge loop and return its result.
+- **Defined in:** `application_sdk/testing/harness/bridge.py`
 
 #### `run_workflow`
 
@@ -3731,12 +4060,47 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Summary:** POST to the handler's workflow endpoint and return the workflow ID.
 - **Defined in:** `application_sdk/testing/e2e/workflows.py`
 
+#### `sample_qualified_names`
+
+- **Import:** `from application_sdk.testing.harness.atlas import sample_qualified_names`
+- **Signature:** `sample_qualified_names(connection_qualified_name: str, *, ...)`
+- **Summary:** Sample qualified names of each named type under a connection.
+- **Defined in:** `application_sdk/testing/harness/atlas/__init__.py`
+
+#### `start_on_task_queue`
+
+- **Import:** `from application_sdk.testing.harness.starters import start_on_task_queue`
+- **Signature:** `start_on_task_queue(spec: QueueWorkflowSpec) -> WorkflowRunHandle`
+- **Summary:** Start a workflow by dispatching it directly onto a Temporal task queue.
+- **Defined in:** `application_sdk/testing/harness/starters/__init__.py`
+
+#### `start_via_app_handler`
+
+- **Import:** `from application_sdk.testing.harness.starters import start_via_app_handler`
+- **Signature:** `start_via_app_handler(spec: HttpWorkflowSpec, *, reader: ClusterReader) -> HttpRunHandle`
+- **Summary:** Start a workflow by POSTing to the app's own handler Service.
+- **Defined in:** `application_sdk/testing/harness/starters/__init__.py`
+
+#### `start_via_automation_engine`
+
+- **Import:** `from application_sdk.testing.harness.starters import start_via_automation_engine`
+- **Signature:** `start_via_automation_engine(spec: Mapping[str, object]) -> AERunHandle`
+- **Summary:** Start a run through the Automation Engine.
+- **Defined in:** `application_sdk/testing/harness/starters/__init__.py`
+
 #### `starts_with`
 
 - **Import:** `from application_sdk.testing.integration import starts_with`
 - **Signature:** `starts_with(prefix: str, *, description: str | None = None)`
 - **Summary:** Assert that the actual value starts with the given prefix.
 - **Defined in:** `application_sdk/testing/integration/assertions.py`
+
+#### `submit_run`
+
+- **Import:** `from application_sdk.testing.harness.automation_engine import submit_run`
+- **Signature:** `submit_run(payload: Mapping[str, object], *, budget: Budget) -> Outcome[AERunHandle]`
+- **Summary:** Submit a run to the Automation Engine, retrying only where it is safe to.
+- **Defined in:** `application_sdk/testing/harness/automation_engine/__init__.py`
 
 #### `validate_asset`
 
@@ -3765,6 +4129,31 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Signature:** `wait_for_workflow(namespace: str, ...)`
 - **Summary:** Poll GET /api/v1/workflows/{id} until the workflow reaches a terminal state.
 - **Defined in:** `application_sdk/testing/e2e/workflows.py`
+
+### Constants and Enums
+
+#### `Outcome`
+
+- **Import:** `from application_sdk.testing.harness import Outcome`
+- **Also importable from:** `application_sdk.testing.harness.outcome`
+- **Signature:** `Outcome: TypeAlias`
+- **Summary:** _(no docstring)_
+- **Defined in:** `application_sdk/testing/harness/outcome.py`
+
+#### `Probe`
+
+- **Import:** `from application_sdk.testing.harness import Probe`
+- **Also importable from:** `application_sdk.testing.harness.waiting`
+- **Signature:** `Probe: TypeAlias`
+- **Summary:** _(no docstring)_
+- **Defined in:** `application_sdk/testing/harness/waiting.py`
+
+#### `PURGE_BATCH_SIZE`
+
+- **Import:** `from application_sdk.testing.harness.teardown import PURGE_BATCH_SIZE`
+- **Signature:** `PURGE_BATCH_SIZE`
+- **Summary:** _(no docstring)_
+- **Defined in:** `application_sdk/testing/harness/teardown.py`
 
 ## `application_sdk.validation`
 

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -1,8 +1,8 @@
 <!--
 generated-by:  capability-manifest skill (.claude/skills/capability-manifest)
 sdk-version:   3.29.0
-source-sha:    9f5b89e6251980fca5a1ecb6f500823ac351fe51
-source-date:   2026-08-26T01:19:46Z
+source-sha:    61913873f10221724cab19322cf060b6b50c3c8b
+source-date:   2026-08-26T02:59:49+01:00
 do-not-edit:   re-run the skill instead of hand-editing
 -->
 
@@ -34,7 +34,7 @@ do-not-edit:   re-run the skill instead of hand-editing
 | `application_sdk.server` | FastAPI server, MCP integration, middleware, health endpoint | 4 |
 | `application_sdk.storage` | Object-store abstraction — factory, formats, batch, transfer, cloud bindings | 42 |
 | `application_sdk.templates` | SQL metadata extractor templates and their contracts | 6 |
-| `application_sdk.testing` | Test infrastructure — mocks, fixtures, hypothesis strategies, integration helpers | 150 |
+| `application_sdk.testing` | Test infrastructure — mocks, fixtures, hypothesis strategies, integration helpers | 151 |
 | `application_sdk.validation` | Offline artifact & asset validation — format-agnostic wrapper (ADR-0020) plus pyatlan_v9 .validate() wrappers, no network call | 78 |
 
 ## Subpackage Details
@@ -3298,6 +3298,13 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Signature:** `class GapReport(diffs: list[AssetDiff] = list(), summary: dict[str, int] = dict(), expected_file: str | None = None)`
 - **Summary:** Summary of all differences between expected and actual metadata.
 - **Defined in:** `application_sdk/testing/integration/comparison.py`
+
+#### `HarnessNotBuiltError`
+
+- **Import:** `from application_sdk.testing.harness import HarnessNotBuiltError`
+- **Signature:** `class HarnessNotBuiltError(*, ...)`
+- **Summary:** A scaffolded harness function whose implementation has not landed yet.
+- **Defined in:** `application_sdk/testing/harness/_errors.py`
 
 #### `HttpRequest`
 

--- a/packages/conformance/conformance/data/deprecated_symbols.json
+++ b/packages/conformance/conformance/data/deprecated_symbols.json
@@ -219,6 +219,15 @@
     {
       "kind": "class",
       "marker_via": "warn",
+      "message": "application_sdk.testing.e2e.AppConfig is deprecated and will be removed in v4.0; use application_sdk.testing.harness.AppUnderTest instead. It collides by name with application_sdk.main.AppConfig, the runtime config object. app_module, image, worker_health_port and timeout are not carried over \u2014 nothing ever read them.",
+      "migration_target": true,
+      "module": "application_sdk.testing.e2e.config",
+      "removal_version": "4.0",
+      "symbol": "AppConfig"
+    },
+    {
+      "kind": "class",
+      "marker_via": "warn",
       "message": "application_sdk.testing.sdr.BaseSDRIntegrationTest is deprecated; use application_sdk.testing.e2e.BaseE2ETest with RunMode.AGENT \u2014 will be removed in v4.0",
       "migration_target": true,
       "module": "application_sdk.testing.sdr.base",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,6 +132,21 @@ tests = [
     "pandera[io]>=0.32.0,<0.33.0",
     "httpx>=0.27.0,<0.29.0",
 ]
+# Typed Kubernetes backend for application_sdk.testing.harness.cluster — the
+# in-process client that replaces the `kubectl`-shelling reads in
+# testing/e2e/{pods,logs}.py (FND-241).
+#
+# Deliberately NOT folded into [tests]: a connector installing test extras
+# should not pull a Kubernetes client. Verified safe to keep separate —
+# connectors pin atlan-application-sdk[iam-auth,sql,workflows,pandas] and carry
+# their own `test` extra, so no connector's production closure changes either
+# way. Keeping it apart is what keeps the reason legible.
+#
+# Only the harness imports this, and only under the e2e/scenario markers, so it
+# is never on a production code path.
+harness = [
+    "kubernetes>=36.0.3,<37.0.0",
+]
 scale_data_generator = [
     "faker>=40.37.0,<40.38.0",
     "numpy>=1.23.5,<3.0.0",
@@ -320,6 +335,13 @@ markers = [
 # under unit tests. Including them in unit coverage drags the percentage down
 # without representing product-code quality. Keep `mocks.py` and `fixtures.py`
 # in scope since downstream apps consume them as a public testing API.
+#
+# `application_sdk/testing/harness/**` is deliberately ABSENT from this list.
+# It is new code with a tenant-free unit surface — bounded waits, outcome
+# vocabulary, budgets, pure evaluators, the sync bridge — so it counts toward
+# the 85% gate like any other module. The `testing/e2e/**` exemption below is
+# about code that only runs against a live tenant; inheriting it here by
+# proximity would exempt the one part of this surface that is unit-testable.
 omit = [
     "tests/**",
     "application_sdk/test_utils/**",
@@ -340,6 +362,10 @@ exclude_lines = [
     "if __name__ == .__main__.:",
     "pass",
     "raise ImportError",
+    # An ellipsis-only body is a Protocol method or a typing stub: a signature
+    # declaration, never a statement that runs. Anchored to a line that is
+    # nothing but `...` so it cannot swallow a real statement.
+    "^\\s*\\.\\.\\.$",
 ]
 fail_under = 85
 show_missing = true

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -6,12 +6,10 @@ a specific app. Utility fixtures provide log collection and HTTP helpers.
 Example downstream conftest::
 
     @pytest.fixture(scope="session")
-    def app_config() -> AppConfig:
-        return AppConfig(
+    def app_config() -> AppUnderTest:
+        return AppUnderTest(
             app_name="my-app",
-            app_module="my_app.main:App",
             namespace="app-my-app",
-            image="ghcr.io/my-org/my-app:latest",
         )
 """
 
@@ -21,27 +19,25 @@ from typing import Any
 
 import pytest
 
-from application_sdk.testing.e2e import AppConfig, kube_http_call
+from application_sdk.testing.e2e import kube_http_call
+from application_sdk.testing.harness import AppUnderTest
 
 
 @pytest.fixture(scope="session")
-def app_config() -> AppConfig:
-    """Return AppConfig for the app under test.
+def app_config() -> AppUnderTest:
+    """Return the app under test.
 
     Override this fixture in your repo's conftest.py. By default, reads
     from environment variables so CI can inject values without code changes.
     """
-    return AppConfig(
+    return AppUnderTest(
         app_name=os.environ["E2E_APP_NAME"],
-        app_module=os.environ["E2E_APP_MODULE"],
         namespace=os.environ.get("E2E_NAMESPACE", f"app-{os.environ['E2E_APP_NAME']}"),
-        image=os.environ["E2E_IMAGE"],
-        timeout=int(os.environ.get("E2E_TIMEOUT", "300")),
     )
 
 
 @pytest.fixture
-def handler_call(app_config: AppConfig) -> Callable[..., Any]:
+def handler_call(app_config: AppUnderTest) -> Callable[..., Any]:
     """Return an async callable that routes requests to the handler via port-forward."""
 
     async def _call(

--- a/tests/unit/testing/harness/test_bridge.py
+++ b/tests/unit/testing/harness/test_bridge.py
@@ -1,0 +1,127 @@
+"""Unit tests for the harness's one sync/async bridge.
+
+The two properties that matter are the ones D1 was about: **one loop per thread,
+reused across calls** (not a fresh loop per call, which is the bug the five
+``asyncio.run`` sites in ``testing/e2e/client.py`` have), and **a clear error
+rather than an opaque RuntimeError** when a loop is already running.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+
+import pytest
+
+from application_sdk.testing.harness import (
+    SyncBridgeInAsyncContextError,
+    bridge,
+    close_loop,
+    run_sync,
+)
+
+
+@pytest.fixture(autouse=True)
+def _close_bridge_loop():
+    """Leave no loop behind, so one test's loop cannot serve the next one."""
+    yield
+    close_loop()
+
+
+async def _answer() -> int:
+    return 42
+
+
+def test_run_sync_returns_the_coroutine_result() -> None:
+    assert run_sync(_answer()) == 42
+
+
+def test_run_sync_propagates_exceptions_unwrapped() -> None:
+    """The bridge adds no wrapping: existing `except` clauses keep matching."""
+
+    class Sentinel(ValueError):
+        pass
+
+    async def _boom() -> None:
+        raise Sentinel("from the coroutine")
+
+    with pytest.raises(Sentinel, match="from the coroutine"):
+        run_sync(_boom())
+
+
+def test_the_loop_is_reused_across_calls() -> None:
+    """The whole point of D1's amendment: no new loop (and no new TLS handshake) per call."""
+
+    async def _current_loop() -> asyncio.AbstractEventLoop:
+        return asyncio.get_running_loop()
+
+    first = run_sync(_current_loop())
+    second = run_sync(_current_loop())
+    assert first is second
+
+
+def test_each_thread_gets_its_own_loop() -> None:
+    """An event loop is not thread-safe, and pytest plugins do run code off-main."""
+
+    async def _current_loop() -> asyncio.AbstractEventLoop:
+        return asyncio.get_running_loop()
+
+    main_loop = run_sync(_current_loop())
+    seen: list[asyncio.AbstractEventLoop] = []
+
+    def _worker() -> None:
+        try:
+            seen.append(run_sync(_current_loop()))
+        finally:
+            close_loop()
+
+    thread = threading.Thread(target=_worker)
+    thread.start()
+    thread.join()
+
+    assert len(seen) == 1
+    assert seen[0] is not main_loop
+
+
+def test_calling_from_a_running_loop_raises_and_names_the_twin() -> None:
+    async def _reenter() -> None:
+        run_sync(_answer())
+
+    with pytest.raises(SyncBridgeInAsyncContextError) as caught:
+        asyncio.run(_reenter())
+    assert "_async" in str(caught.value)
+
+
+def test_the_rejected_coroutine_is_closed_not_leaked() -> None:
+    """A never-awaited coroutine that is merely GC'd emits a RuntimeWarning that
+    lands next to the real error and reads as a second, unrelated bug."""
+    coro = _answer()
+
+    async def _reenter() -> None:
+        with pytest.raises(SyncBridgeInAsyncContextError):
+            run_sync(coro)
+
+    asyncio.run(_reenter())
+    # cr_frame is None once a coroutine has been closed.
+    assert coro.cr_frame is None
+
+
+def test_close_loop_is_idempotent() -> None:
+    run_sync(_answer())
+    close_loop()
+    close_loop()
+    assert getattr(bridge._state, "loop", None) is None
+
+
+def test_run_sync_after_close_creates_a_fresh_loop() -> None:
+    """Closing early must not poison the thread — the alternative is a
+    `RuntimeError: Event loop is closed` from deep inside asyncio."""
+
+    async def _current_loop() -> asyncio.AbstractEventLoop:
+        return asyncio.get_running_loop()
+
+    first = run_sync(_current_loop())
+    close_loop()
+    second = run_sync(_current_loop())
+    assert second is not first
+    assert first.is_closed()

--- a/tests/unit/testing/harness/test_scaffold.py
+++ b/tests/unit/testing/harness/test_scaffold.py
@@ -1,0 +1,353 @@
+"""Unit tests for the harness scaffold's concrete surface.
+
+Covers what FND-238 actually lands: the outcome vocabulary, the ``Budget`` type,
+the ``AppConfig`` -> ``AppUnderTest`` rename with its deprecation, and the
+wiring claims the issue makes about coverage and the capability manifest.
+
+Every stub is asserted to raise ``NotImplementedError`` naming its child issue,
+so a later child cannot quietly ship a half-implementation that returns ``None``.
+"""
+
+from __future__ import annotations
+
+import warnings
+from datetime import timedelta
+
+import pytest
+
+from application_sdk.testing.harness import (
+    AppUnderTest,
+    Budget,
+    BudgetProfile,
+    Expired,
+    Indeterminate,
+    NeverStarted,
+    Settled,
+    Stalled,
+    assert_settled,
+    hold_stable,
+    poll_until,
+)
+from application_sdk.testing.harness.cluster import (
+    ClusterReader,
+    CustomResourceReader,
+    DeploymentState,
+    PodPhase,
+    PodState,
+    ResourceRef,
+)
+from application_sdk.testing.harness.temporal import (
+    TemporalReader,
+    WorkflowExecutionStatus,
+)
+
+# ---------------------------------------------------------------------------
+# Outcome vocabulary
+# ---------------------------------------------------------------------------
+
+
+def _budget() -> Budget:
+    return Budget(timeout=timedelta(seconds=60), poll_interval=timedelta(seconds=5))
+
+
+def test_settled_carries_the_value_and_the_wait_shape() -> None:
+    outcome = Settled(
+        label="AE run native status",
+        attempts=3,
+        elapsed=timedelta(seconds=12),
+        value={"extract": "Succeeded"},
+    )
+    assert outcome.value == {"extract": "Succeeded"}
+    assert outcome.label == "AE run native status"
+
+
+def test_stalled_carries_the_fingerprint_that_froze() -> None:
+    """The single most useful line in the report: what stopped changing."""
+    outcome = Stalled(
+        label="AE run native status",
+        attempts=40,
+        elapsed=timedelta(minutes=7),
+        stall_window=timedelta(minutes=5),
+        fingerprint="OK OK RUN -",
+        last={"publish": "Running"},
+    )
+    assert outcome.fingerprint == "OK OK RUN -"
+
+
+def test_never_started_is_distinct_from_expired() -> None:
+    """Different diagnoses: dispatch failed, versus work was slow."""
+    never = NeverStarted(
+        label="AE run",
+        attempts=18,
+        elapsed=timedelta(minutes=3),
+        grace=timedelta(minutes=3),
+    )
+    expired = Expired(
+        label="AE run",
+        attempts=60,
+        elapsed=timedelta(minutes=10),
+        budget=timedelta(minutes=10),
+    )
+    assert type(never) is not type(expired)
+
+
+def test_indeterminate_retains_the_cause_object() -> None:
+    """Retained rather than stringified so a caller can classify it without
+    re-parsing a message."""
+    cause = TimeoutError("vcluster token expired")
+    outcome = Indeterminate(
+        label="cluster deployments",
+        attempts=4,
+        elapsed=timedelta(seconds=20),
+        cause=cause,
+        transient_failures=3,
+    )
+    assert outcome.cause is cause
+    assert outcome.transient_failures == 3
+
+
+def test_outcomes_are_immutable() -> None:
+    outcome = Settled(label="x", attempts=1, elapsed=timedelta(0), value=1)
+    with pytest.raises((AttributeError, TypeError)):
+        outcome.value = 2  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Budgets
+# ---------------------------------------------------------------------------
+
+
+def test_budget_defaults_leave_every_guard_off_except_the_heartbeat() -> None:
+    """A guard that is on by default is a guard a caller did not ask for."""
+    budget = _budget()
+    assert budget.start_grace is None
+    assert budget.stall_timeout is None
+    assert budget.max_transient_failures == 0
+    assert budget.retry_after_budget is None
+    assert budget.heartbeat == timedelta(seconds=30)
+
+
+def test_budget_has_no_clock_mode() -> None:
+    """D3: the `elapsed += interval` accumulator is already gone from the tree,
+    so there is no behaviour to preserve and no mode to select. Shipping one
+    would be reintroducing the bug as a supported option."""
+    assert not hasattr(_budget(), "clock")
+
+
+def test_budget_profile_names_a_tier() -> None:
+    profile = BudgetProfile(name="connector_ci", budgets={"ae_poll": _budget()})
+    assert profile.budgets["ae_poll"].timeout == timedelta(seconds=60)
+
+
+# ---------------------------------------------------------------------------
+# The app-under-test rename
+# ---------------------------------------------------------------------------
+
+
+def test_app_under_test_keeps_only_the_fields_anything_reads() -> None:
+    app = AppUnderTest(app_name="my-app", namespace="app-my-app")
+    assert app.handler_port == 8000
+    assert not hasattr(app, "app_module")
+    assert not hasattr(app, "image")
+    assert not hasattr(app, "timeout")
+    assert not hasattr(app, "worker_health_port")
+
+
+def test_deprecated_app_config_still_accepts_the_dropped_fields() -> None:
+    """An existing AppConfig(...) call site keeps working."""
+    from application_sdk.testing.e2e import AppConfig
+
+    with pytest.warns(DeprecationWarning, match="AppUnderTest"):
+        config = AppConfig(
+            app_name="my-app",
+            namespace="default",
+            app_module="my_app.main:App",
+            image="ghcr.io/org/my-app:latest",
+            timeout=600,
+        )
+    assert config.app_name == "my-app"
+    assert config.handler_port == 8000
+    assert isinstance(config, AppUnderTest)
+
+
+def test_deprecation_names_a_removal_version() -> None:
+    from application_sdk.testing.e2e.config import APP_CONFIG_REMOVAL_VERSION, AppConfig
+
+    with pytest.warns(DeprecationWarning) as caught:
+        AppConfig(app_name="a", namespace="b")
+    assert f"v{APP_CONFIG_REMOVAL_VERSION}" in str(caught[0].message)
+
+
+def test_app_under_test_itself_warns_about_nothing() -> None:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        AppUnderTest(app_name="a", namespace="b")  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# Protocols and value types
+# ---------------------------------------------------------------------------
+
+
+def test_deployment_state_exposes_intent_and_actual_separately() -> None:
+    """`.spec.replicas` is the scaling metric; `.status.readyReplicas` lags, so
+    asserting on it turns a scaling assertion into a startup race."""
+    state = DeploymentState(
+        name="my-app-worker",
+        namespace="app-my-app",
+        desired_replicas=3,
+        ready_replicas=1,
+        updated_replicas=3,
+    )
+    assert state.desired_replicas != state.ready_replicas
+
+
+def test_pod_state_separates_running_from_ready() -> None:
+    """A Running pod with a failing readiness probe is exactly what a
+    "worker is up" assertion must not accept."""
+    pod = PodState(
+        name="my-app-worker-abc",
+        namespace="app-my-app",
+        phase=PodPhase.RUNNING,
+        ready=False,
+        restarts=2,
+    )
+    assert pod.phase is PodPhase.RUNNING
+    assert pod.ready is False
+
+
+def test_resource_ref_takes_the_plural_not_the_kind() -> None:
+    """The plural is what the API path needs; deriving it from a Kind is the
+    map that ResourceRef exists to avoid."""
+    ref = ResourceRef(
+        group="helm.toolkit.fluxcd.io", version="v2", plural="helmreleases"
+    )
+    assert ref.plural == "helmreleases"
+
+
+def test_the_reader_protocols_are_structural() -> None:
+    """No consumer has to inherit from these to satisfy them."""
+    for protocol in (ClusterReader, CustomResourceReader, TemporalReader):
+        assert getattr(protocol, "_is_protocol", False)
+        assert getattr(protocol, "_is_runtime_protocol", False)
+
+
+def test_a_plain_object_satisfies_cluster_reader_by_shape() -> None:
+    class Fake:
+        async def deployments(self, namespace, selector): ...
+        async def pods(self, namespace, selector): ...
+        def logs(self, namespace, selector, *, since=None): ...
+        async def http(self, target, request): ...
+
+    assert isinstance(Fake(), ClusterReader)
+
+
+def test_workflow_status_vocabulary_mirrors_temporal() -> None:
+    assert WorkflowExecutionStatus.RUNNING.value == "Running"
+    assert WorkflowExecutionStatus.TIMED_OUT.value == "TimedOut"
+
+
+# ---------------------------------------------------------------------------
+# Stubs: every one names its child issue and refuses to half-work
+# ---------------------------------------------------------------------------
+
+
+async def test_poll_until_is_an_unimplemented_stub() -> None:
+    async def _probe() -> int:
+        return 1
+
+    with pytest.raises(NotImplementedError, match="FND-227"):
+        await poll_until(_probe, settled=bool, budget=_budget(), label="x")
+
+
+async def test_hold_stable_is_an_unimplemented_stub() -> None:
+    async def _probe() -> int:
+        return 1
+
+    with pytest.raises(NotImplementedError, match="FND-227"):
+        await hold_stable(_probe, invariant=bool, budget=_budget(), label="x")
+
+
+def test_assert_settled_is_an_unimplemented_stub() -> None:
+    with pytest.raises(NotImplementedError, match="FND-227"):
+        assert_settled(Settled(label="x", attempts=1, elapsed=timedelta(0), value=1))
+
+
+async def test_every_remaining_stub_names_its_child_issue() -> None:
+    from application_sdk.testing.harness import atlas, automation_engine, starters
+    from application_sdk.testing.harness.evidence import EvidenceBundle, redact
+    from application_sdk.testing.harness.expectations import (
+        AssetExpectations,
+        evaluate_counts,
+        evaluate_locations,
+    )
+    from application_sdk.testing.harness.identity import Minter
+    from application_sdk.testing.harness.teardown import purge_connection
+
+    expectations = AssetExpectations()
+    minter = Minter(clock=lambda: 0, randbelow=lambda _n: 0)
+
+    for call in (
+        lambda: evaluate_counts({}, expectations),
+        lambda: evaluate_locations({}, expectations),
+        minter.run_id,
+        minter.unique_suffix,
+        lambda: redact(EvidenceBundle(label="x")),
+    ):
+        with pytest.raises(NotImplementedError, match="FND-224"):
+            call()
+
+    for coro in (
+        atlas.count_assets("default/x/1", ["Table"]),
+        atlas.sample_qualified_names("default/x/1", ["Table"], per_type=3),
+        automation_engine.submit_run({}, budget=_budget()),
+        purge_connection("default/x/1"),
+        starters.start_via_automation_engine({}),
+        starters.start_on_task_queue(
+            starters.QueueWorkflowSpec(workflow_type="w", task_queue="q")
+        ),
+    ):
+        with pytest.raises(NotImplementedError, match="FND-224"):
+            await coro
+
+
+# ---------------------------------------------------------------------------
+# Wiring claims the issue makes
+# ---------------------------------------------------------------------------
+
+
+def test_harness_is_not_omitted_from_unit_coverage() -> None:
+    """FND-238: harness/** is new code with a tenant-free unit surface, so it
+    counts toward the 85% gate. testing/e2e/** keeps its exemption."""
+    import tomllib
+    from pathlib import Path
+
+    pyproject = Path(__file__).resolve().parents[4] / "pyproject.toml"
+    with pyproject.open("rb") as handle:
+        omit = tomllib.load(handle)["tool"]["coverage"]["run"]["omit"]
+
+    assert "application_sdk/testing/e2e/**" in omit
+    assert not [entry for entry in omit if "testing/harness" in entry]
+
+
+def test_the_harness_extra_is_separate_from_tests() -> None:
+    """A connector installing test extras must not pull a Kubernetes client."""
+    import tomllib
+    from pathlib import Path
+
+    pyproject = Path(__file__).resolve().parents[4] / "pyproject.toml"
+    with pyproject.open("rb") as handle:
+        extras = tomllib.load(handle)["project"]["optional-dependencies"]
+
+    assert any(dep.startswith("kubernetes") for dep in extras["harness"])
+    assert not any("kubernetes" in dep for dep in extras["tests"])
+
+
+def test_the_package_declares_all_so_the_manifest_extractor_finds_it() -> None:
+    """The capability-manifest extractor discovers every public module that
+    declares __all__ (it walks the tree since FND-439), so no extractor change
+    is needed for a nested testing.* subpackage — only a regeneration."""
+    import application_sdk.testing.harness as harness
+
+    assert "run_sync" in harness.__all__
+    assert all(hasattr(harness, name) for name in harness.__all__)

--- a/tests/unit/testing/harness/test_scaffold.py
+++ b/tests/unit/testing/harness/test_scaffold.py
@@ -20,6 +20,7 @@ from application_sdk.testing.harness import (
     Budget,
     BudgetProfile,
     Expired,
+    HarnessNotBuiltError,
     Indeterminate,
     NeverStarted,
     Settled,
@@ -252,25 +253,37 @@ def test_workflow_status_vocabulary_mirrors_temporal() -> None:
 # ---------------------------------------------------------------------------
 
 
+def test_the_stub_leaf_is_also_a_notimplementederror() -> None:
+    """It is a typed SDK leaf with a category and an audience, and it is still
+    what Python's convention — and any reader's `except` — expects."""
+    error = HarnessNotBuiltError(message="x", issue="FND-224")
+    assert isinstance(error, NotImplementedError)
+    assert error.code == "UNIMPLEMENTED_HARNESS_NOT_BUILT"
+    assert error.issue == "FND-224"
+
+
 async def test_poll_until_is_an_unimplemented_stub() -> None:
     async def _probe() -> int:
         return 1
 
-    with pytest.raises(NotImplementedError, match="FND-227"):
+    with pytest.raises(HarnessNotBuiltError) as caught:
         await poll_until(_probe, settled=bool, budget=_budget(), label="x")
+    assert caught.value.issue == "FND-227"
 
 
 async def test_hold_stable_is_an_unimplemented_stub() -> None:
     async def _probe() -> int:
         return 1
 
-    with pytest.raises(NotImplementedError, match="FND-227"):
+    with pytest.raises(HarnessNotBuiltError) as caught:
         await hold_stable(_probe, invariant=bool, budget=_budget(), label="x")
+    assert caught.value.issue == "FND-227"
 
 
 def test_assert_settled_is_an_unimplemented_stub() -> None:
-    with pytest.raises(NotImplementedError, match="FND-227"):
+    with pytest.raises(HarnessNotBuiltError) as caught:
         assert_settled(Settled(label="x", attempts=1, elapsed=timedelta(0), value=1))
+    assert caught.value.issue == "FND-227"
 
 
 async def test_every_remaining_stub_names_its_child_issue() -> None:
@@ -294,8 +307,10 @@ async def test_every_remaining_stub_names_its_child_issue() -> None:
         minter.unique_suffix,
         lambda: redact(EvidenceBundle(label="x")),
     ):
-        with pytest.raises(NotImplementedError, match="FND-224"):
+        with pytest.raises(HarnessNotBuiltError) as caught:
             call()
+        assert caught.value.issue == "FND-224"
+        assert caught.value.operation
 
     for coro in (
         atlas.count_assets("default/x/1", ["Table"]),
@@ -307,8 +322,10 @@ async def test_every_remaining_stub_names_its_child_issue() -> None:
             starters.QueueWorkflowSpec(workflow_type="w", task_queue="q")
         ),
     ):
-        with pytest.raises(NotImplementedError, match="FND-224"):
+        with pytest.raises(HarnessNotBuiltError) as caught:
             await coro
+        assert caught.value.issue == "FND-224"
+        assert caught.value.operation
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/testing/harness/test_scaffold.py
+++ b/tests/unit/testing/harness/test_scaffold.py
@@ -156,7 +156,7 @@ def test_app_under_test_keeps_only_the_fields_anything_reads() -> None:
 
 
 def test_deprecated_app_config_still_accepts_the_dropped_fields() -> None:
-    """An existing AppConfig(...) call site keeps working."""
+    """An existing keyword AppConfig(...) call site keeps working."""
     from application_sdk.testing.e2e import AppConfig
 
     with pytest.warns(DeprecationWarning, match="AppUnderTest"):
@@ -168,8 +168,74 @@ def test_deprecated_app_config_still_accepts_the_dropped_fields() -> None:
             timeout=600,
         )
     assert config.app_name == "my-app"
+    assert config.namespace == "default"
     assert config.handler_port == 8000
+    assert config.app_module == "my_app.main:App"
+    assert config.timeout == 600
     assert isinstance(config, AppUnderTest)
+
+
+def test_deprecated_app_config_preserves_the_original_positional_order() -> None:
+    """The whole reason AppConfig declares an explicit __init__.
+
+    AppUnderTest's field order is (app_name, namespace, handler_port), so a
+    dataclass-generated subclass __init__ would bind these four positionals as
+    namespace="my_app.main:App" and handler_port="default" — accepted silently,
+    wrong at every read. A shim that mis-binds is a silent break.
+    """
+    from application_sdk.testing.e2e import AppConfig
+
+    with pytest.warns(DeprecationWarning):
+        config = AppConfig(
+            "my-app",
+            "my_app.main:App",
+            "default",
+            "ghcr.io/org/my-app:latest",
+        )
+    assert config.app_name == "my-app"
+    assert config.app_module == "my_app.main:App"
+    assert config.namespace == "default"
+    assert config.image == "ghcr.io/org/my-app:latest"
+    assert config.handler_port == 8000
+
+
+def test_deprecated_app_config_accepts_all_seven_positionally() -> None:
+    from application_sdk.testing.e2e import AppConfig
+
+    with pytest.warns(DeprecationWarning):
+        config = AppConfig("a", "m", "ns", "img", 9000, 9001, 600)
+    assert (config.app_name, config.namespace, config.handler_port) == ("a", "ns", 9000)
+    assert (config.worker_health_port, config.timeout) == (9001, 600)
+
+
+def test_deprecated_app_config_stays_mutable() -> None:
+    """AppUnderTest is frozen; the original AppConfig was not. Freezing the shim
+    would be a second silent break in the same class."""
+    from application_sdk.testing.e2e import AppConfig
+
+    with pytest.warns(DeprecationWarning):
+        config = AppConfig(app_name="a", namespace="b")
+    config.timeout = 600
+    config.namespace = "c"
+    assert config.timeout == 600
+    assert config.namespace == "c"
+
+
+def test_app_under_test_stays_frozen() -> None:
+    """The shim's mutability must not leak onto the replacement."""
+    app = AppUnderTest(app_name="a", namespace="b")
+    with pytest.raises((AttributeError, TypeError)):
+        app.namespace = "c"  # type: ignore[misc]
+
+
+def test_deprecated_app_config_carries_no_instance_dict() -> None:
+    """Both classes declare __slots__, so a typo'd field is a failure rather
+    than a silently-ignored attribute."""
+    from application_sdk.testing.e2e import AppConfig
+
+    with pytest.warns(DeprecationWarning):
+        config = AppConfig(app_name="a", namespace="b")
+    assert not hasattr(config, "__dict__")
 
 
 def test_deprecation_names_a_removal_version() -> None:

--- a/tests/unit/testing/harness/test_scaffold.py
+++ b/tests/unit/testing/harness/test_scaffold.py
@@ -36,6 +36,7 @@ from application_sdk.testing.harness.cluster import (
     PodPhase,
     PodState,
     ResourceRef,
+    ServiceTarget,
 )
 from application_sdk.testing.harness.temporal import (
     TemporalReader,
@@ -288,6 +289,7 @@ def test_assert_settled_is_an_unimplemented_stub() -> None:
 
 async def test_every_remaining_stub_names_its_child_issue() -> None:
     from application_sdk.testing.harness import atlas, automation_engine, starters
+    from application_sdk.testing.harness.cluster import HttpRequest, HttpResponse
     from application_sdk.testing.harness.evidence import EvidenceBundle, redact
     from application_sdk.testing.harness.expectations import (
         AssetExpectations,
@@ -299,6 +301,21 @@ async def test_every_remaining_stub_names_its_child_issue() -> None:
 
     expectations = AssetExpectations()
     minter = Minter(clock=lambda: 0, randbelow=lambda _n: 0)
+
+    class _Reader:
+        """Shaped like a ClusterReader so the call is typed, not bypassed."""
+
+        async def deployments(self, namespace: str, selector: str):
+            return ()
+
+        async def pods(self, namespace: str, selector: str):
+            return ()
+
+        def logs(self, namespace: str, selector: str, *, since=None):
+            raise AssertionError("the stub must raise before reading logs")
+
+        async def http(self, target, request: HttpRequest) -> HttpResponse:
+            raise AssertionError("the stub must raise before calling out")
 
     for call in (
         lambda: evaluate_counts({}, expectations),
@@ -320,6 +337,17 @@ async def test_every_remaining_stub_names_its_child_issue() -> None:
         starters.start_via_automation_engine({}),
         starters.start_on_task_queue(
             starters.QueueWorkflowSpec(workflow_type="w", task_queue="q")
+        ),
+        starters.start_via_app_handler(
+            starters.HttpWorkflowSpec(
+                target=ServiceTarget(namespace="ns", service="svc", port=8000),
+                workflow_name="metadata_extraction",
+            ),
+            reader=_Reader(),
+        ),
+        automation_engine.poll_native_status(
+            automation_engine.AERunHandle(workflow_slug="w", run_id="1"),
+            budget=_budget(),
         ),
     ):
         with pytest.raises(HarnessNotBuiltError) as caught:

--- a/tools/migrate_v3/MIGRATION_PROMPT.md
+++ b/tools/migrate_v3/MIGRATION_PROMPT.md
@@ -754,18 +754,17 @@ class TestMyConnector(BaseTest):
 ```python
 # TODO(upgrade-v3): human must validate this test is equivalent to the original
 import pytest
-from application_sdk.testing.e2e import AppConfig, run_workflow, wait_for_workflow
+from application_sdk.testing.e2e import run_workflow, wait_for_workflow
+from application_sdk.testing.harness import AppUnderTest
 
 @pytest.fixture(scope="session")
-def app_config() -> AppConfig:
-    return AppConfig(
+def app_config() -> AppUnderTest:
+    return AppUnderTest(
         app_name="my-connector",
-        app_module="my_connector.main:MyExtractor",
         namespace="default",
-        image="ghcr.io/atlanhq/my-connector:latest",
     )
 
-async def test_metadata_extraction(app_config: AppConfig) -> None:
+async def test_metadata_extraction(app_config: AppUnderTest) -> None:
     workflow_id = await run_workflow(
         namespace=app_config.namespace,
         service=app_config.app_name,
@@ -787,7 +786,7 @@ async def test_metadata_extraction(app_config: AppConfig) -> None:
 
 | v2 | v3 |
 |----|----|
-| `BaseTest` class | `AppConfig` fixtures |
+| `BaseTest` class | `AppUnderTest` fixtures |
 | `self.run_workflow(name, payload)` | `run_workflow(namespace, service, port, name, payload)` |
 | Built-in wait/poll | `wait_for_workflow(namespace, service, port, workflow_id, timeout)` |
 | `self.default_payload()` | Explicit `payload` dict — extract values from the v2 method body |

--- a/uv.lock
+++ b/uv.lock
@@ -272,6 +272,9 @@ daft = [
 distributed-lock = [
     { name = "redis", extra = ["hiredis"] },
 ]
+harness = [
+    { name = "kubernetes" },
+]
 iam-auth = [
     { name = "boto3" },
 ]
@@ -374,6 +377,7 @@ requires-dist = [
     { name = "google-auth", specifier = ">=2.0.0,<3.0.0" },
     { name = "httpx", marker = "extra == 'tests'", specifier = ">=0.27.0,<0.29.0" },
     { name = "httpx-retries", specifier = ">=0.6.0,<0.7.0" },
+    { name = "kubernetes", marker = "extra == 'harness'", specifier = ">=36.0.3,<37.0.0" },
     { name = "loguru", specifier = ">=0.7.3,<0.8.0" },
     { name = "numpy", marker = "extra == 'scale-data-generator'", specifier = ">=1.23.5,<3.0.0" },
     { name = "obstore", specifier = ">=0.11.0,<0.12.0" },
@@ -405,7 +409,7 @@ requires-dist = [
     { name = "temporalio", marker = "extra == 'workflows'", specifier = ">=1.25.0,<2.0.0" },
     { name = "uvloop", marker = "sys_platform != 'win32'", specifier = ">=0.21.0,<0.23.0" },
 ]
-provides-extras = ["workflows", "sql", "daft", "storage", "incremental", "iam-auth", "azure", "distributed-lock", "mcp", "tests", "scale-data-generator", "sqlalchemy", "pandas"]
+provides-extras = ["workflows", "sql", "daft", "storage", "incremental", "iam-auth", "azure", "distributed-lock", "mcp", "tests", "harness", "scale-data-generator", "sqlalchemy", "pandas"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1291,6 +1295,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/89/d5/c0d8d0a4ca3ffea92266f33d92a375e2794820ad89f9be97cf0c9a9697d0/duckdb_engine-0.17.0.tar.gz", hash = "sha256:396b23869754e536aa80881a92622b8b488015cf711c5a40032d05d2cf08f3cf", size = 48054, upload-time = "2025-03-29T09:49:17.663Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/a2/e90242f53f7ae41554419b1695b4820b364df87c8350aa420b60b20cab92/duckdb_engine-0.17.0-py3-none-any.whl", hash = "sha256:3aa72085e536b43faab635f487baf77ddc5750069c16a2f8d9c6c3cb6083e979", size = 49676, upload-time = "2025-03-29T09:49:15.564Z" },
+]
+
+[[package]]
+name = "durationpy"
+version = "0.10"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/a4/e44218c2b394e31a6dd0d6b095c4e1f32d0be54c2a4b250032d717647bab/durationpy-0.10.tar.gz", hash = "sha256:1fa6893409a6e739c9c72334fc65cca1f355dbdd93405d30f726deb5bde42fba", size = 3335, upload-time = "2025-05-17T13:52:37.26Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/0d/9feae160378a3553fa9a339b0e9c1a048e147a4127210e286ef18b730f03/durationpy-0.10-py3-none-any.whl", hash = "sha256:3b41e1b601234296b4fb368338fdcd3e13e0b4fb5b67345948f4f2bf9868b286", size = 3922, upload-time = "2025-05-17T13:52:36.463Z" },
 ]
 
 [[package]]
@@ -2375,6 +2388,27 @@ wheels = [
 ]
 
 [[package]]
+name = "kubernetes"
+version = "36.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "certifi" },
+    { name = "durationpy" },
+    { name = "python-dateutil" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "requests-oauthlib" },
+    { name = "six" },
+    { name = "urllib3" },
+    { name = "websocket-client" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ca/57/b07b96353f902aa1bdbe00e878e3a12a137977d03a962479785576aa8ec9/kubernetes-36.0.3.tar.gz", hash = "sha256:36993ed25ce59b789c9341473a228fcf268504a2fec7c2b2b1531d73072e5ce7", size = 2337528, upload-time = "2026-07-13T20:38:12.128Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/30/a96d47df739689ac0001ade0afefc16e3b477fc2fb426b568515fdc8afce/kubernetes-36.0.3-py2.py3-none-any.whl", hash = "sha256:8fde9241c4b298e6374a069dcf728359b4e72c2fb29489a975ba4e1c047cf10f", size = 4618066, upload-time = "2026-07-13T20:38:10.172Z" },
+]
+
+[[package]]
 name = "lazy-loader"
 version = "0.5"
 source = { registry = "https://pypi.org/simple" }
@@ -3162,6 +3196,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/42/06/6e11443f7b64ee376c860506091103bf68f92d2cab9e8d96d4501babf07c/numpy-2.5.2-cp315-cp315t-win32.whl", hash = "sha256:7354826bc6f8f69402e9b7fe28d15fcd34feebd74f856f111585c5b0c9fb0251", size = 6269775, upload-time = "2026-08-09T13:48:17.543Z" },
     { url = "https://files.pythonhosted.org/packages/f1/18/195d6b86cd72dbbc501edfa778005fa6b87afd34c153e46028cd3a0938f4/numpy-2.5.2-cp315-cp315t-win_amd64.whl", hash = "sha256:e5651f3f87add730ee6608d915009e19c911fba0cb000c7e3ea994b7d768eb12", size = 12782559, upload-time = "2026-08-09T13:48:21.023Z" },
     { url = "https://files.pythonhosted.org/packages/b4/07/458c344f0f0c178f4481dad5cca790626ffe4c34eabf9467069d06ee4999/numpy-2.5.2-cp315-cp315t-win_arm64.whl", hash = "sha256:5f8e00be2ec6f45f4e8a41a527f68d44a7d96fee92a650e4d8b1326f77f61e6e", size = 10748103, upload-time = "2026-08-09T13:48:24.21Z" },
+]
+
+[[package]]
+name = "oauthlib"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/5f/19930f824ffeb0ad4372da4812c50edbd1434f678c90c2733e1188edfc63/oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9", size = 185918, upload-time = "2025-06-19T22:48:08.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df838baa98fa71844d84283302f7604ed565dafe5a6b5041a/oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1", size = 160065, upload-time = "2025-06-19T22:48:06.508Z" },
 ]
 
 [[package]]
@@ -4557,6 +4600,19 @@ wheels = [
 ]
 
 [[package]]
+name = "requests-oauthlib"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "oauthlib" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9", size = 55650, upload-time = "2024-03-22T20:32:29.939Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36", size = 24179, upload-time = "2024-03-22T20:32:28.055Z" },
+]
+
+[[package]]
 name = "rich"
 version = "15.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -5501,6 +5557,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/27/0b/a54103cfd732bb703c7a749222011a0483ef3705948dae3b203158601119/watchfiles-1.2.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:094b9b70103d4e963499bdea001ee3c2697b144cd9ae6218a62c0f89ec9e31db", size = 396629, upload-time = "2026-05-18T04:32:03.268Z" },
     { url = "https://files.pythonhosted.org/packages/5e/2c/73f31a3b893886206c3f54d73e8ad8dee58cdb2f69ad2622e0a8a9e07f4e/watchfiles-1.2.0-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b0ef001f8c25ad0fa9529f914c1600647ecd0f542d11c19b7894768c67b6acb7", size = 457318, upload-time = "2026-05-18T04:31:01.932Z" },
     { url = "https://files.pythonhosted.org/packages/e9/f9/45d021e4a5cc7b9dd567f7cbb06d3b75f751a690063fb6cc7ec60f4e46b7/watchfiles-1.2.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a88fc94e647bc4eec523f1caa540258eb71d14278b9daf72fa1e2658a98df0f0", size = 457771, upload-time = "2026-05-18T04:30:56.331Z" },
+]
+
+[[package]]
+name = "websocket-client"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/41/aa4bf9664e4cda14c3b39865b12251e8e7d239f4cd0e3cc1b6c2ccde25c1/websocket_client-1.9.0.tar.gz", hash = "sha256:9e813624b6eb619999a97dc7958469217c3176312b3a16a4bd1bc7e08a46ec98", size = 70576, upload-time = "2025-10-07T21:16:36.495Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl", hash = "sha256:af248a825037ef591efbf6ed20cc5faa03d3b47b9e5a2230a529eeee1c1fc3ef", size = 82616, upload-time = "2025-10-07T21:16:34.951Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Child A of [FND-224](https://linear.app/atlan-epd/issue/FND-224). Closes [FND-238](https://linear.app/atlan-epd/issue/FND-238/child-a-settle-harness-decisions-and-scaffold-application).

Stands up `application_sdk/testing/harness/` — the package the other children of FND-224 fill in — and settles the three decisions that had to be made before any extraction, because all three change signatures.

Nothing imports the new package yet. `testing/e2e/` is untouched apart from the `AppConfig` rename below, so no connector, no generated `_e2e_base.py` and no conformance rule sees a diff.

## What is real code

The decisions fully determine four modules, so those ship working rather than stubbed:

- **`bridge.run_sync`** — the harness's one sync/async bridge, public and harness-scoped. One lazily-created event loop **per thread**, reused across calls, replaced rather than reused if closed; `SyncBridgeInAsyncContextError` when a loop is already running, with a message that names the `_async` twin. The rejected coroutine is explicitly `.close()`d, because a never-awaited coroutine that is merely GC'd emits a `RuntimeWarning` that lands next to the real error and reads as a second, unrelated bug.

  Deliberately **not** in `application_sdk.common`: a public sync bridge in core reads as the SDK sanctioning sync bridges in app code, against the async-only stance that conformance rules P024 and P031 encode. The import path is the documentation.

- **`outcome`** — `Settled | NeverStarted | Stalled | Expired | Indeterminate`, returned rather than raised. Three reasons, all from the FND-224 discussion: findings accumulate instead of aborting at the first; `Stalled` names the step and carries the fingerprint that stopped changing; and `Indeterminate` is the third answer for a read that failed, so an expired vcluster token can never be graded as a component regression.

- **`budgets.Budget`** — one typed allowance per bounded wait, absorbing the ten class attrs on `BaseE2ETest` plus the seven knobs hard-coded in `client.py` and never exposed. `timedelta` throughout rather than `..._seconds: int`, since this vocabulary is about to be shared across three repos.

- **`cluster` / `temporal`** — the reader Protocols and their state types. Read-only by decision, not by omission: scenario-side mutation stays scenario-side (agreed on FND-224, 2026-08-17). Custom resources sit on a separate `CustomResourceReader` parameterised by `ResourceRef(group, version, plural)`, so `ClusterReader` never becomes the union of every consumer's kinds.

Everything else — `waiting`, `identity`, `expectations`, `evidence`, `teardown`, `atlas`, `automation_engine`, `starters` — is a typed stub whose `NotImplementedError` names the child issue that implements it, with a test asserting each one raises. A later child cannot quietly ship a half-implementation that returns `None`.

## Two of the issue's own instructions were stale

Both were true when written. Following them now would have done unnecessary work, and in one case actively harmful work.

### D3's `Budget.clock` mode is not deferred — it is void

The issue asked to preserve the `elapsed += interval_seconds` accumulator behind an explicit clock mode. **That accumulator no longer exists anywhere in `testing/e2e/`.** Every deadline loop now routes through `application_sdk/testing/e2e/_poll.py` (`until_deadline` / `until_deadline_async`), which is monotonic, yields `is_last` *before* the sleep, and re-clamps each gap against the clock read *after* the probe — so a probe that outlasts its own interval shortens the next gap rather than overshooting. `poll_native_status` and both Atlas polls are on it.

So shipping `Budget.clock = ELAPSED_ACCUMULATOR` would not preserve current behaviour. It would **reintroduce a fixed bug as a supported option**, and any connector selecting the "faithful" profile would silently get an unbounded timeout back. `Budget` has no `clock` field, and `test_budget_has_no_clock_mode` pins that with the reasoning in its docstring.

Two knock-ons, both recorded on FND-224: the separate "flip the default to monotonic" issue has nothing left to do, and child C's `waiting.py` is a thinner extraction than scoped — `poll_until` is the grace latch + watchdog + transient streak *on top of* `_poll`, and `_poll.py` moves into `harness/` rather than being reimplemented. `hold_stable` is still genuinely new.

### The capability-manifest extractor needs no change

The issue says adding `testing.harness` needs an extractor edit because the extractor "lists `testing` but no nested subpackage and only reads top-level `__all__`". FND-439 already rewrote `discover_public_modules()` to walk `application_sdk/**.py` and index every public module declaring `__all__` — precisely because a hand-maintained list is what made `application_sdk.execution.heartbeat` invisible. `testing.e2e.AppConfig` was already in the manifest on `main`, which is the evidence the claim was stale.

Verified rather than reasoned: a plain `uv run poe regen-capabilities` picked up `run_sync`, `AppUnderTest`, `Budget`, the outcome types and the nested `harness.cluster` / `harness.temporal` / `harness.starters` symbols with no extractor edit.

One real consequence of *how* the walk works did need handling: it treats the shortest import path as canonical and breaks ties **alphabetically**. Re-exporting `AppUnderTest` from `testing/e2e/__init__.py` published `from application_sdk.testing.e2e import AppUnderTest` as its canonical path, because `e2e` < `harness`. The re-export was removed; the harness is the home.

## Wiring, explicit rather than inherited

- **Coverage.** `harness/**` is **absent** from `[tool.coverage.run] omit`, with a comment at that list saying so and why, plus `test_harness_is_not_omitted_from_unit_coverage`. The failure mode is a future reader adding it by proximity to the `testing/e2e/**` exemption, which is about code that only runs against a live tenant. The package currently sits at **100%**.

  One `exclude_lines` entry was needed: `^\s*\.\.\.$`, anchored so it can only match an ellipsis-only line. Protocol method bodies are signature declarations, and twenty-odd of them would otherwise read as uncovered statements.

- **New optional extra.** `harness = ["kubernetes>=36.0.3,<37.0.0"]`, for the typed cluster backend landing in FND-241. Never folded into `[tests]`: a connector installing test extras should not pull a Kubernetes client. 36.0.3 is from 2026-07-13, well clear of the release-age cooldown.

## `AppConfig` → `AppUnderTest`

`application_sdk.testing.harness.AppUnderTest`, frozen, three fields: `app_name`, `namespace`, `handler_port`. The other four (`app_module`, `image`, `worker_health_port`, `timeout`) are dropped — confirmed unread by this package, by `tests/e2e/conftest.py`'s fixtures, and by every consumer repo.

`testing.e2e.AppConfig` survives as a deprecated subclass, removal named for **v4.0**, warning on construction, still accepting all seven kwargs. It needed to: `atlan-alloydb-postgres-app` constructs it in two e2e modules. Both sit inside a `try/except ImportError → pytest.skip` for an `AppDeployer` the SDK never shipped, so they skip at import today regardless — but the alias costs nothing, and the field order changed, so a hard removal would have been a gratuitous break.

Also updated: `tests/e2e/conftest.py`, which drops its now-unread `E2E_APP_MODULE` / `E2E_IMAGE` / `E2E_TIMEOUT` reads (nothing in CI sets them and they are fixture-local, so no `_REMOVED_ENV_VARS` entry is owed), and `tools/migrate_v3/MIGRATION_PROMPT.md`.

## Review notes

- **New direct dependency.** `kubernetes` behind the `harness` extra. Lock diff is additive-only — `kubernetes`, `durationpy`, `oauthlib`, `requests-oauthlib`, `websocket-client`, `six`, all extra-gated. `requirements.txt` is unchanged, since the export is not `--all-extras`.
- **No behaviour change to any shipped path.** The only edits outside the new package are the `AppConfig` alias, the two docs/fixture call sites, and the pyproject wiring.

## Verification

- `uv run pre-commit run --all-files` — clean (ruff, ruff-format, isort, pyright)
- Full unit suite — **8,120 passed, 9 skipped**; 33 of those are new
- `harness/**` coverage **100%**, counting toward the 85% gate; repo total 92.85%
- `atlan-application-sdk-conformance detect --series T` — gate passed, **zero findings in the new code**
- `docs/agents/sdk-capabilities.md` regenerated on the pinned `griffe==2.1.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
