### PR TITLE
feat(testing): extract the harness's pure core — evaluators, budgets, identity (FND-239)

### DIFF
--- a/application_sdk/testing/harness/__init__.py
+++ b/application_sdk/testing/harness/__init__.py
@@ -52,8 +52,12 @@ Module map:
 ``teardown``
     Purge mechanics, including the batching that is a correctness bound.
 
-Most of it is typed stubs at this point: this package is the scaffold from
-FND-238, and each module names the child issue that fills it in.
+``bridge``, ``outcome``'s vocabulary, ``spec``, ``budgets``, ``expectations`` and
+``identity`` are real; the rest are typed stubs, each naming the child issue that
+fills it in. Nothing outside this package consumes any of it yet — ``testing/e2e``
+is re-expressed over it in child H, and until then the extracted modules are
+pinned against the code they were lifted from by their unit tests rather than by
+being called from it.
 
 The optional ``harness`` extra carries the typed Kubernetes backend for
 ``cluster`` (``pip install 'atlan-application-sdk[harness]'``). It is
@@ -63,10 +67,18 @@ should not pull a Kubernetes client.
 
 from application_sdk.testing.harness._errors import (
     HarnessNotBuiltError,
+    MissingTenantEnvError,
     SyncBridgeInAsyncContextError,
 )
 from application_sdk.testing.harness.bridge import close_loop, run_sync
-from application_sdk.testing.harness.budgets import Budget, BudgetProfile
+from application_sdk.testing.harness.budgets import (
+    CONNECTOR_CI,
+    Budget,
+    BudgetProfile,
+    Call,
+    RequestBudget,
+    Wait,
+)
 from application_sdk.testing.harness.outcome import (
     Expired,
     Indeterminate,
@@ -85,6 +97,8 @@ __all__ = [
     # Raised by every not-yet-implemented scaffold function; also a
     # NotImplementedError, so `except NotImplementedError` still catches it.
     "HarnessNotBuiltError",
+    # No tenant in the ambient environment to run against
+    "MissingTenantEnvError",
     "close_loop",
     "run_sync",
     # Bounded waits
@@ -100,8 +114,12 @@ __all__ = [
     "Stalled",
     "assert_settled",
     # Budgets
+    "CONNECTOR_CI",
     "Budget",
     "BudgetProfile",
+    "Call",
+    "RequestBudget",
+    "Wait",
     # App under test
     "AppUnderTest",
 ]

--- a/application_sdk/testing/harness/_errors.py
+++ b/application_sdk/testing/harness/_errors.py
@@ -10,9 +10,17 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import ClassVar
 
-from application_sdk.errors.leaves import PreconditionError, UnimplementedError
+from application_sdk.errors.leaves import (
+    InvalidInputError,
+    PreconditionError,
+    UnimplementedError,
+)
 
-__all__ = ["HarnessNotBuiltError", "SyncBridgeInAsyncContextError"]
+__all__ = [
+    "HarnessNotBuiltError",
+    "MissingTenantEnvError",
+    "SyncBridgeInAsyncContextError",
+]
 
 
 @dataclass(kw_only=True)
@@ -51,3 +59,21 @@ class HarnessNotBuiltError(UnimplementedError, NotImplementedError):
     code: ClassVar[str] = "UNIMPLEMENTED_HARNESS_NOT_BUILT"
     issue: str | None = None
     component: str | None = "test_harness"
+
+
+@dataclass(kw_only=True)
+class MissingTenantEnvError(InvalidInputError):
+    """The environment carries no tenant for the harness to run against.
+
+    Named for the tenant rather than for the harness because that is what is
+    missing: ``application_sdk.testing.e2e._errors.MissingHarnessEnvError`` is
+    the pre-harness leaf covering the same gap, and it stays until child H
+    re-expresses ``testing/e2e`` over this package. Two leaves with one name and
+    two codes is the confusion this avoids.
+
+    Attributes:
+        field: The variable names that were absent, comma-separated.
+    """
+
+    code: ClassVar[str] = "INVALID_INPUT_HARNESS_TENANT_ENV"
+    field: str | None = "ATLAN_BASE_URL,ATLAN_API_KEY"

--- a/application_sdk/testing/harness/budgets.py
+++ b/application_sdk/testing/harness/budgets.py
@@ -6,17 +6,30 @@ and never exposed (``_HTTP_TIMEOUT``, ``_SUBMIT_TIMEOUT``,
 ``_REQUEST_MAX_ATTEMPTS``, ``_REQUEST_BACKOFF_SECONDS``,
 ``_MAX_RETRY_AFTER_SECONDS``, ``_RETRY_AFTER_BUDGET_SECONDS``,
 ``_HEARTBEAT_SECONDS``), plus ``max_forbidden_attempts`` and
-``max_not_found_attempts``. :class:`Budget` absorbs all of it into one value a
-call site can pass, and :class:`BudgetProfile` names a per-tier set of them —
-which is what a scenario suite needs when the same wait has different timings
-against ``kind`` than against a tenant.
+``max_not_found_attempts``. :class:`Budget` absorbs the waits into one value a
+call site can pass, :class:`RequestBudget` absorbs the per-call retry knobs, and
+:class:`BudgetProfile` names a per-tier set of both — which is what a scenario
+suite needs when the same wait has different timings against ``kind`` than
+against a tenant.
 
-Populating the named profiles from today's ``ClassVar`` defaults, verbatim, is
-child B. This module scaffolds the types they are expressed in.
+:data:`CONNECTOR_CI` is that set for the tier the SDK ships today, populated
+from ``BaseE2ETest``'s ``ClassVar`` defaults verbatim (child B on FND-224).
+Verbatim is checked, not asserted in prose: ``test_budgets.py`` reads the class
+attributes back off ``BaseE2ETest`` and compares, so the profile cannot drift
+away from the class it was lifted from before child H rewires the class to read
+it. No second profile ships here — the tiers that want different numbers
+(``kind``, a shared tenant) land with the consumer that knows what those numbers
+are, and inventing them now would put values in the SDK that nothing has ever
+run.
 
 ``timedelta`` rather than bare seconds throughout: an ``int`` named
 ``..._seconds`` is a unit convention that a call site can silently violate, and
-this vocabulary is about to be shared across three repos.
+this vocabulary is about to be shared across three repos. Two of the absorbed
+knobs are attempt *counts* rather than durations —
+``poll_atlas_for_connection``'s ``max_not_found_attempts``, and
+``submit_workflow``'s ``retries`` — and both convert cleanly, because an attempt
+cap on a fixed-interval loop is a duration wearing a disguise. See
+:data:`CONNECTOR_CI` for each conversion.
 
 **On the clock (D3).** The FND-224 decomposition asked for a ``Budget.clock``
 mode preserving the ``elapsed += interval_seconds`` accumulator — a bug that
@@ -31,10 +44,51 @@ be reintroducing the bug as a supported mode. See the D3 note on FND-224.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from collections.abc import Mapping
+from dataclasses import dataclass, field
 from datetime import timedelta
+from enum import StrEnum
 
-__all__ = ["Budget", "BudgetProfile"]
+__all__ = [
+    "CONNECTOR_CI",
+    "Budget",
+    "BudgetProfile",
+    "Call",
+    "RequestBudget",
+    "Wait",
+]
+
+
+class Wait(StrEnum):
+    """The bounded waits a connector run performs, as profile keys.
+
+    A :class:`StrEnum` rather than bare strings so a profile lookup is a name
+    the type checker knows, while ``profile.budgets["ae_run"]`` still works for
+    a scenario suite reading its keys out of a config file.
+    """
+
+    #: The LOCAL CI worker container's ``/server/health``.
+    WORKER_HEALTH = "worker_health"
+    #: The TENANT-installed app pod becoming reachable, observed only through
+    #: the AE submit's own retry — there is no other tenant-facing probe.
+    APP_READY = "app_ready"
+    #: AE serving a published version that supersedes the harness's seed.
+    DEPLOYED_MANIFEST = "deployed_manifest"
+    #: The AE run's ``native-status`` reaching a terminal state.
+    AE_RUN = "ae_run"
+    #: The Connection becoming searchable in Atlas.
+    ATLAS_CONNECTION = "atlas_connection"
+    #: Per-type asset counts settling after publish.
+    ATLAS_ASSET_COUNTS = "atlas_asset_counts"
+
+
+class Call(StrEnum):
+    """The outbound call shapes a run makes, as profile keys."""
+
+    #: Every tenant HTTP call except the submit.
+    HTTP = "http"
+    #: The AE submit, which is non-idempotent and gets its own budget.
+    SUBMIT = "submit"
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)
@@ -79,6 +133,38 @@ class Budget:
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)
+class RequestBudget:
+    """Everything one outbound call, including its retries, is allowed to spend.
+
+    Separate from :class:`Budget` because a request retry is not a bounded wait
+    and folding it into one would make :attr:`Budget.timeout` mean two things —
+    a ceiling on the whole loop in one case, a ceiling on each attempt in the
+    other. A retry loop has no total wall-clock bound today; giving it one here
+    would be inventing a number rather than absorbing one.
+
+    Attributes:
+        timeout: Ceiling on a single attempt. The loop above it is what bounds
+            the whole call.
+        max_attempts: Total attempts including the first, so ``1`` means no
+            retry.
+        backoff: Fixed gap between attempts, before any origin-requested
+            backoff is honoured.
+        max_retry_after: Ceiling on any *single* origin-requested ``Retry-After``
+            wait, so one pathological value cannot hang a CI leg. ``None``
+            honours whatever the origin asks for.
+        retry_after_budget: Ceiling on the total honoured-above-the-fixed-gap
+            waiting across the whole call. Once spent, the remaining attempts
+            fall back to :attr:`backoff`.
+    """
+
+    timeout: timedelta
+    max_attempts: int = 1
+    backoff: timedelta = timedelta(0)
+    max_retry_after: timedelta | None = None
+    retry_after_budget: timedelta | None = None
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
 class BudgetProfile:
     """A named set of budgets for one execution tier.
 
@@ -90,7 +176,101 @@ class BudgetProfile:
         name: Tier identifier, for reports and for the selecting env var.
         budgets: Wait label -> budget. Keys are the ``label`` values the waits
             pass, so a report can say which profile governed a given wait.
+        requests: Call label -> per-call budget.
     """
 
     name: str
-    budgets: dict[str, Budget]
+    budgets: Mapping[str, Budget]
+    requests: Mapping[str, RequestBudget] = field(default_factory=dict)
+
+
+#: Today's connector-CI tier: ``BaseE2ETest``'s ``ClassVar`` defaults and
+#: ``testing/e2e/client.py``'s module constants, verbatim.
+#:
+#: Every value here has exactly one source in the tree, and
+#: ``tests/unit/testing/harness/test_budgets.py`` reads that source back and
+#: compares — so this is a second spelling of those numbers, never a second
+#: opinion about them.
+#:
+#: Two entries convert an attempt cap into the duration it already was:
+#:
+#: * ``ATLAS_CONNECTION.start_grace`` is ``poll_atlas_for_connection``'s
+#:   ``max_not_found_attempts = 10``. Every probe that reaches the check is an
+#:   empty search (a hit returns immediately), so the cap fires on attempt 10 —
+#:   at ``9 x 30s`` elapsed, since attempt 1 runs at zero. "The connection never
+#:   appeared" is what
+#:   :class:`~application_sdk.testing.harness.outcome.NeverStarted` says, so it
+#:   is the start-grace latch rather than a guard of its own.
+#: * ``APP_READY`` is ``cold_start_submit_kwargs``, which divides the same two
+#:   numbers back into ``retries`` and ``retry_sleep_seconds`` for the submit's
+#:   own retry loop.
+#:
+#: ``max_forbidden_attempts`` is absorbed by being dropped: the Atlas poll went
+#: through the search index, whose ACL is permissive, so the knob stopped being
+#: reachable and ``poll_atlas_for_connection`` already ``del``\\s it unread.
+CONNECTOR_CI = BudgetProfile(
+    name="connector_ci",
+    budgets={
+        Wait.WORKER_HEALTH: Budget(
+            timeout=timedelta(seconds=120),
+            poll_interval=timedelta(seconds=3),
+        ),
+        Wait.APP_READY: Budget(
+            timeout=timedelta(seconds=300),
+            poll_interval=timedelta(seconds=5),
+            # Bounds the extra waiting an overloaded AE can request on top of
+            # the fixed gaps, so the ~5 min headline cannot silently become ~10.
+            retry_after_budget=timedelta(seconds=300),
+            # Retries inside a single submit call; no poll loop to narrate.
+            heartbeat=None,
+        ),
+        Wait.DEPLOYED_MANIFEST: Budget(
+            timeout=timedelta(seconds=60),
+            poll_interval=timedelta(seconds=5),
+            heartbeat=None,
+        ),
+        Wait.AE_RUN: Budget(
+            timeout=timedelta(seconds=600),
+            poll_interval=timedelta(seconds=10),
+            start_grace=timedelta(seconds=180),
+            # Derived from the ceiling rather than pinned, so raising the
+            # ceiling widens the watchdog instead of putting it out of reach:
+            # max(600 // 3, 300) clamped to 600 // 2.
+            stall_timeout=timedelta(seconds=300),
+            max_transient_failures=5,
+            retry_after_budget=timedelta(seconds=300),
+            # poll_native_status throttles its own richer progress line to the
+            # heartbeat cadence and disables the generic one.
+            heartbeat=None,
+        ),
+        Wait.ATLAS_CONNECTION: Budget(
+            timeout=timedelta(seconds=1500),
+            poll_interval=timedelta(seconds=30),
+            start_grace=timedelta(seconds=270),
+            heartbeat=None,
+        ),
+        Wait.ATLAS_ASSET_COUNTS: Budget(
+            timeout=timedelta(seconds=15),
+            poll_interval=timedelta(seconds=5),
+            heartbeat=None,
+        ),
+    },
+    requests={
+        Call.HTTP: RequestBudget(
+            timeout=timedelta(seconds=60),
+            max_attempts=4,
+            backoff=timedelta(seconds=3),
+            max_retry_after=timedelta(seconds=120),
+            retry_after_budget=timedelta(seconds=300),
+        ),
+        Call.SUBMIT: RequestBudget(
+            # Longer than the rest so a Cloudflare 504 arrives as an HTTP error
+            # the retry loop understands, rather than a raw TimeoutError.
+            timeout=timedelta(seconds=120),
+            max_attempts=4,
+            backoff=timedelta(seconds=3),
+            max_retry_after=timedelta(seconds=120),
+            retry_after_budget=timedelta(seconds=300),
+        ),
+    },
+)

--- a/application_sdk/testing/harness/expectations.py
+++ b/application_sdk/testing/harness/expectations.py
@@ -21,20 +21,72 @@ expectation, not the first one.
 One behaviour is deliberately **not** preserved. ``_validate_asset_locations``
 fails open today — the sampling read returns ``[]`` on any search error, which
 arrives as "no samples, skip", so an auth fault reads as a pass. That is finding
-C4 on FND-224, and the fix is structural: a caller that could not read passes
-:class:`~application_sdk.testing.harness.outcome.Indeterminate` rather than an
-empty sample set, so "unreadable" can no longer be spelled the same way as
-"nothing to check".
+C4 on FND-224, and the fix here is structural rather than documentary: a reading
+that could not be taken is :class:`Unreadable`, a variant the input mapping
+itself can hold, so "I could not read" can no longer be spelled the same way as
+"nothing to check". Every consulted reading that is :class:`Unreadable` produces
+a finding carrying :data:`UNREADABLE` as its expectation — a machine-readable
+marker, so whoever assembles the verdict can grade it as
+:class:`~application_sdk.testing.harness.outcome.Indeterminate` rather than as a
+component regression, without parsing prose.
+
+The count evaluator gets the same treatment, because it has the mirror-image
+version of the same bug: an unreadable count arrives as ``0`` and is reported as
+"asset floor not met" — fail-*closed*, but attributed to the connector instead
+of to the search that failed.
 """
 
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
+from typing import TypeAlias, Union
 
-from application_sdk.testing.harness._errors import HarnessNotBuiltError
+__all__ = [
+    "UNREADABLE",
+    "AssetExpectations",
+    "CountRead",
+    "Finding",
+    "SampleRead",
+    "Unreadable",
+    "evaluate_counts",
+    "evaluate_locations",
+]
 
-__all__ = ["AssetExpectations", "Finding", "evaluate_counts", "evaluate_locations"]
+#: :attr:`Finding.expectation` value marking a finding that exists because a
+#: reading could not be taken, not because an expectation was unmet. The one
+#: value a caller must not grade as a component regression.
+UNREADABLE = "unreadable"
+
+#: Subject used for findings about the run as a whole rather than one type.
+_ALL_TYPES = "all asset types"
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class Unreadable:
+    """A reading that could not be taken.
+
+    Exists so that "the search failed" has a spelling of its own. Without it the
+    only vocabulary available to a failed read is the vocabulary of a successful
+    one — an empty sample list, a zero count — and both of those already mean
+    something else.
+
+    Attributes:
+        cause: The exception that made the reading unavailable. Retained rather
+            than stringified, matching
+            :class:`~application_sdk.testing.harness.outcome.Indeterminate`, so
+            a caller can classify it without re-parsing a message.
+    """
+
+    cause: BaseException
+
+
+#: One per-type count, or the fact that it could not be read.
+CountRead: TypeAlias = Union[int, Unreadable]
+
+#: One per-type sample of qualified names, or the fact that it could not be
+#: read. ``Sequence[str]`` rather than ``list[str]`` so a caller may pass a tuple.
+SampleRead: TypeAlias = Union[Sequence[str], Unreadable]
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)
@@ -50,7 +102,8 @@ class Finding:
         detail: Human-readable statement of what was expected and what was seen.
             Written for whoever reads a red CI leg.
         expectation: Which declared expectation was not met, e.g. ``"floor"``,
-            ``"exact"``, ``"nonempty"``, ``"depth"``.
+            ``"exact"``, ``"nonempty"``, ``"depth"``, ``"nesting"`` — or
+            :data:`UNREADABLE` when the reading itself was unavailable.
     """
 
     subject: str
@@ -75,7 +128,9 @@ class AssetExpectations:
             fails. Defaults on, and it fires even for a connector that declares
             nothing else — those are the ones most likely to regress silently.
         connection_qualified_name: Prefix every sampled qualified name must sit
-            under. Empty means the nesting half of the location check is skipped.
+            under. Empty skips :func:`evaluate_locations` entirely: depth is
+            measured *below this prefix*, so with no prefix there is nothing to
+            measure from and no nesting to assert.
     """
 
     floors: Mapping[str, int] = field(default_factory=dict)
@@ -85,63 +140,234 @@ class AssetExpectations:
     connection_qualified_name: str = ""
 
 
+def _unreadable(subject: str, reading: Unreadable, *, checking: str) -> Finding:
+    """Build the finding for a reading that could not be taken.
+
+    Args:
+        subject: What the unavailable reading was about.
+        reading: The failed read, carrying its cause.
+        checking: The check that consulted it, named so the report says which
+            expectation went ungraded rather than only that a read failed.
+
+    Returns:
+        A finding whose :attr:`Finding.expectation` is :data:`UNREADABLE`.
+    """
+    return Finding(
+        subject=subject,
+        detail=(
+            f"could not be read, so the {checking} expectation was not graded: "
+            f"{type(reading.cause).__name__}: {reading.cause}"
+        ),
+        expectation=UNREADABLE,
+    )
+
+
 def evaluate_counts(
-    counts: Mapping[str, int],
+    counts: Mapping[str, CountRead],
     expectations: AssetExpectations,
     *,
-    total_assets: int | None = None,
+    total_assets: CountRead | None = None,
 ) -> Sequence[Finding]:
     """Evaluate per-type counts against the declared floors, exacts and backstop.
 
     Args:
-        counts: Asset type -> count observed in Atlas.
+        counts: Asset type -> count observed in Atlas, or :class:`Unreadable`
+            when that count could not be read. A type absent from the mapping
+            counts as zero, which is what "the search ran and found none" means;
+            a type whose read *failed* must be present and :class:`Unreadable`.
         expectations: What was declared.
         total_assets: True count across *all* asset types, which is not
             ``sum(counts.values())`` when only some types were counted. The
             non-empty backstop reads this so it fires for a connector that
             declared no per-type expectations at all. ``None`` falls back to the
-            sum, which is what lets the evaluator be driven from a unit test.
+            sum of the per-type counts, which is what lets the evaluator be
+            driven from a unit test — and that fallback is refused when any of
+            them was unreadable, since a partial sum reading zero is exactly the
+            fail-open this evaluator exists to close.
 
     Returns:
-        One :class:`Finding` per unmet expectation; empty when all were met.
-
-    Raises:
-        HarnessNotBuiltError: Always — implementation is child B on FND-224.
+        One :class:`Finding` per unmet expectation, floors then exacts then the
+        backstop; empty when all were met. A finding whose expectation is
+        :data:`UNREADABLE` says the check could not be graded — never that the
+        thing under test regressed.
     """
-    raise HarnessNotBuiltError(
-        message="evaluate_counts is not implemented yet",
-        operation="evaluate_counts",
-        reason="child B on FND-224",
-        issue="FND-224",
-        component="harness_expectations",
+    findings: list[Finding] = []
+
+    for type_name, floor in expectations.floors.items():
+        got = counts.get(type_name, 0)
+        if isinstance(got, Unreadable):
+            findings.append(_unreadable(type_name, got, checking="floor"))
+            continue
+        if got < floor:
+            findings.append(
+                Finding(
+                    subject=type_name,
+                    detail=f"got {got}, expected >= {floor}",
+                    expectation="floor",
+                )
+            )
+
+    for type_name, want in expectations.exacts.items():
+        got = counts.get(type_name, 0)
+        if isinstance(got, Unreadable):
+            findings.append(_unreadable(type_name, got, checking="exact"))
+            continue
+        if got != want:
+            findings.append(
+                Finding(
+                    subject=type_name,
+                    detail=(
+                        f"got {got}, expected exactly {want} "
+                        "(count parity vs. direct-run baseline)"
+                    ),
+                    expectation="exact",
+                )
+            )
+
+    findings.extend(_evaluate_nonempty(counts, expectations, total_assets))
+    return findings
+
+
+def _evaluate_nonempty(
+    counts: Mapping[str, CountRead],
+    expectations: AssetExpectations,
+    total_assets: CountRead | None,
+) -> Sequence[Finding]:
+    """Apply the "completed but extracted nothing" backstop.
+
+    Args:
+        counts: As passed to :func:`evaluate_counts`.
+        expectations: What was declared.
+        total_assets: The all-types total, or ``None`` to fall back to the sum
+            of the per-type counts.
+
+    Returns:
+        At most one finding.
+    """
+    floors = expectations.floors
+    exacts = expectations.exacts
+    has_positive_expectation = any(value > 0 for value in floors.values()) or any(
+        value > 0 for value in exacts.values()
     )
+    # A connector whose only declared expectations are zero (e.g. exact
+    # {"X": 0}) is asserting "produces zero of X" — the backstop must not
+    # override that into a failure.
+    asserting_zero = bool(floors or exacts) and not has_positive_expectation
+    if not expectations.require_nonempty or asserting_zero:
+        return ()
+
+    total = total_assets
+    if total is None:
+        unreadable = next(
+            (value for value in counts.values() if isinstance(value, Unreadable)),
+            None,
+        )
+        # Summing around an unreadable count gives a total that is low by an
+        # unknown amount — and the value it is compared against is zero, so
+        # "low" is precisely the direction that turns a failed search into a
+        # confident claim about the connector.
+        total = (
+            unreadable
+            if unreadable is not None
+            else sum(value for value in counts.values() if isinstance(value, int))
+        )
+
+    if isinstance(total, Unreadable):
+        return (_unreadable(_ALL_TYPES, total, checking="non-empty"),)
+    if total == 0:
+        return (
+            Finding(
+                subject=_ALL_TYPES,
+                detail=(
+                    "run produced ZERO assets in Atlas (workflow completed but "
+                    "extracted nothing)"
+                ),
+                expectation="nonempty",
+            ),
+        )
+    return ()
 
 
 def evaluate_locations(
-    samples: Mapping[str, Sequence[str]],
+    samples: Mapping[str, SampleRead],
     expectations: AssetExpectations,
 ) -> Sequence[Finding]:
     """Evaluate sampled qualified names against the declared hierarchy depths.
 
     Args:
-        samples: Asset type -> sampled qualified names. A type with no samples is
+        samples: Asset type -> sampled qualified names, or :class:`Unreadable`
+            when the sample read failed. A type with an *empty* sample is
             skipped: "too few or none" is already covered by the count floors and
             the non-empty backstop, so this check is only about the *shape* of
-            assets that did land. Callers must not spell "I could not read" as an
-            empty mapping — see the module docstring.
-        expectations: What was declared.
+            assets that did land. That skip is the reason a failed read may not
+            be spelled as an empty sequence.
+        expectations: What was declared. An empty
+            :attr:`AssetExpectations.connection_qualified_name` makes this a
+            no-op — see that attribute.
 
     Returns:
         One :class:`Finding` per sampled name that is not nested under the
         connection, or is nested at the wrong depth; empty when all were fine.
-
-    Raises:
-        HarnessNotBuiltError: Always — implementation is child B on FND-224.
     """
-    raise HarnessNotBuiltError(
-        message="evaluate_locations is not implemented yet",
-        operation="evaluate_locations",
-        reason="child B on FND-224",
-        issue="FND-224",
-        component="harness_expectations",
-    )
+    connection = expectations.connection_qualified_name
+    findings: list[Finding] = []
+    if not connection:
+        return findings
+
+    prefix = f"{connection}/"
+    for type_name, depth in expectations.depths.items():
+        sample = samples.get(type_name, ())
+        if isinstance(sample, Unreadable):
+            findings.append(_unreadable(type_name, sample, checking="depth"))
+            continue
+        for qualified_name in sample:
+            findings.extend(
+                _evaluate_one_location(
+                    type_name, qualified_name, prefix=prefix, depth=depth
+                )
+            )
+    return findings
+
+
+def _evaluate_one_location(
+    type_name: str, qualified_name: str, *, prefix: str, depth: int
+) -> Sequence[Finding]:
+    """Check one sampled qualified name against the connection prefix and depth.
+
+    Args:
+        type_name: Asset type the sample belongs to.
+        qualified_name: The sampled qualified name.
+        prefix: Connection qualified name with its trailing separator.
+        depth: Segments the name must carry below ``prefix``.
+
+    Returns:
+        At most one finding.
+    """
+    if not qualified_name.startswith(prefix):
+        return (
+            Finding(
+                subject=type_name,
+                detail=(
+                    f"{qualified_name!r} is not nested under the connection "
+                    f"{prefix.rstrip('/')}"
+                ),
+                expectation="nesting",
+            ),
+        )
+    # rstrip a trailing "/" first: a QN that ends in "/" would otherwise split
+    # into an empty tail segment and over-count the depth by one. (Atlan QNs
+    # conventionally don't end in "/", so this is defensive.)
+    tail = qualified_name[len(prefix) :].rstrip("/")
+    below = tail.split("/") if tail else []
+    if len(below) != depth:
+        return (
+            Finding(
+                subject=type_name,
+                detail=(
+                    f"{qualified_name!r} has {len(below)} segment(s) below the "
+                    f"connection, expected {depth} (wrong hierarchy level)"
+                ),
+                expectation="depth",
+            ),
+        )
+    return ()

--- a/application_sdk/testing/harness/identity.py
+++ b/application_sdk/testing/harness/identity.py
@@ -11,16 +11,82 @@ a test can pin the exact qualified name a run will produce. That matters more
 than it sounds: the ephemeral qualified name is what ``teardown.py`` purges, and
 a name the test cannot predict is a purge the test cannot verify.
 
-Implementation is child B on FND-224.
+The seam is a constructor argument, never a patched global. Patching
+``time.monotonic`` process-wide in an async test hands the same mock to the
+asyncio event loop's own clock, which produces flaky ``StopIteration`` failures
+that read as a bug in the code under test.
+
+Also here: :func:`read_tenant_auth`, the other half of ``setup_method``'s
+identity work — validating that the ambient environment actually carries a
+tenant to talk to. It is a pure function of a mapping for the same reason the
+clock is injected: an env read buried in a constructor is an env read no test
+can drive.
+
+Not here: resolving the ``$admin`` role GUID, which ``setup_method`` also does.
+That is an Atlas read over the network, not a derivation from inputs, and its
+home is :mod:`application_sdk.testing.harness.atlas` with the other Atlas reads.
 """
 
 from __future__ import annotations
 
-from collections.abc import Callable
+import secrets
+import time
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
 
-from application_sdk.testing.harness._errors import HarnessNotBuiltError
+from application_sdk.testing.harness._errors import MissingTenantEnvError
 
-__all__ = ["Minter"]
+__all__ = [
+    "ConnectionIdentity",
+    "Minter",
+    "TenantAuth",
+    "read_tenant_auth",
+]
+
+#: Exclusive upper bound on the random half of a unique suffix. Six digits, so
+#: the suffix is a fixed width and two runs landing in the same clock second
+#: collide with probability 1e-6 rather than 1.
+_RANDOM_SUFFIX_BOUND = 1_000_000
+
+#: Width the random half is zero-padded to. Padding is what keeps the suffix a
+#: fixed length: an unpadded 42 and an unpadded 420000 are the same number of
+#: characters apart as two different seconds, so without it the clock half and
+#: the random half are not separable by eye when reading a tenant's asset list.
+_RANDOM_SUFFIX_WIDTH = 6
+
+
+@dataclass(frozen=True, slots=True)
+class ConnectionIdentity:
+    """The ephemeral connection one harness run creates and then purges.
+
+    Attributes:
+        qualified_name: Atlan qualified name, ``default/<type>/<suffix>``. This
+            is the string teardown purges under, so it is also the string a test
+            has to be able to predict.
+        display_name: Human-facing name on the same connection.
+    """
+
+    qualified_name: str
+    display_name: str
+
+
+@dataclass(frozen=True, slots=True)
+class TenantAuth:
+    """How a run authenticates against the tenant under test.
+
+    Attributes:
+        base_url: Tenant base URL, without a trailing slash.
+        api_key: Atlan API key. Mandatory rather than optional because
+            ``/automation/api/v1/*`` needs the realm-admin ``resource_access``
+            role that only the API key's service account carries.
+        oauth_client_id: Service-account client id, when one is configured.
+        oauth_client_secret: Matching client secret.
+    """
+
+    base_url: str
+    api_key: str
+    oauth_client_id: str | None = None
+    oauth_client_secret: str | None = None
 
 
 class Minter:
@@ -49,23 +115,39 @@ class Minter:
         self._randbelow = randbelow
         self._run_id_env = run_id_env
 
+    @classmethod
+    def from_environment(cls, environ: Mapping[str, str]) -> Minter:
+        """Build a minter wired to the real clock and the ambient CI run id.
+
+        Args:
+            environ: Environment to read ``GITHUB_RUN_ID`` from. Passed in
+                rather than read from :data:`os.environ`, so the one thing a
+                caller cannot inject is the one thing that is genuinely
+                ambient.
+
+        Returns:
+            A minter over :func:`time.time` and :func:`secrets.randbelow`.
+        """
+        return cls(
+            clock=lambda: int(time.time()),
+            randbelow=secrets.randbelow,
+            run_id_env=environ.get("GITHUB_RUN_ID"),
+        )
+
     def run_id(self) -> int:
         """Return the identifier for this run.
 
         Returns:
             The ambient CI run id when there is one and it is numeric, else a
-            clock reading.
-
-        Raises:
-            HarnessNotBuiltError: Always — implementation is child B on FND-224.
+            clock reading. Non-numeric is treated as absent rather than as an
+            error: the run id is only ever used to scope names, so a locally-set
+            ``GITHUB_RUN_ID=local`` should degrade to a clock reading, not fail
+            the run before it starts.
         """
-        raise HarnessNotBuiltError(
-            message="Minter.run_id is not implemented yet",
-            operation="Minter.run_id",
-            reason="child B on FND-224",
-            issue="FND-224",
-            component="harness_identity",
-        )
+        ambient = self._run_id_env
+        if ambient and ambient.isdigit():
+            return int(ambient)
+        return self._clock()
 
     def unique_suffix(self) -> str:
         """Return a suffix that makes a name unique within a tenant.
@@ -73,15 +155,78 @@ class Minter:
         Returns:
             A clock reading concatenated with a zero-padded random component.
             Two runs starting in the same second must not collide, because a
-            collision means one run purges the other's assets.
-
-        Raises:
-            HarnessNotBuiltError: Always — implementation is child B on FND-224.
+            collision means one run purges the other's assets. Kept purely
+            numeric so Atlas never rejects the name for hyphens or alphabetic
+            characters.
         """
-        raise HarnessNotBuiltError(
-            message="Minter.unique_suffix is not implemented yet",
-            operation="Minter.unique_suffix",
-            reason="child B on FND-224",
-            issue="FND-224",
-            component="harness_identity",
+        return (
+            f"{self._clock()}"
+            f"{self._randbelow(_RANDOM_SUFFIX_BOUND):0{_RANDOM_SUFFIX_WIDTH}d}"
         )
+
+    def connection_identity(self, connection_type: str) -> ConnectionIdentity:
+        """Mint the ephemeral connection identity for this run.
+
+        The trailing segment must be unique per test *instance*: with the e2e
+        matrix each suite runs as a separate parallel job whose setup can land in
+        the same wall-clock second as another leg's, and rapid same-ref pushes
+        overlap too. A shared qualified name would let one leg's teardown purge
+        another leg's assets and mix its Atlas counts.
+
+        Args:
+            connection_type: Atlan catalog type segment — the connector's
+                ``connection_type`` where it differs from its short name, else
+                the short name.
+
+        Returns:
+            The qualified name and display name, both built from one suffix so
+            they cannot disagree about which run they belong to.
+        """
+        suffix = self.unique_suffix()
+        return ConnectionIdentity(
+            qualified_name=f"default/{connection_type}/{suffix}",
+            display_name=f"{connection_type}-{suffix}",
+        )
+
+
+def read_tenant_auth(environ: Mapping[str, str]) -> TenantAuth:
+    """Read and validate the tenant credentials a run needs from the environment.
+
+    Args:
+        environ: Environment to read. Passed in rather than read from
+            :data:`os.environ` so a test can drive every branch without mutating
+            process state.
+
+    Returns:
+        The resolved credentials, with the base URL's trailing slash stripped so
+        every downstream ``f"{base_url}/..."`` produces one separator rather than
+        two. OAuth fields are ``None`` when unset — empty string and unset mean
+        the same thing to the client, and only one of them can be passed on.
+
+    Raises:
+        MissingTenantEnvError: When ``ATLAN_BASE_URL`` or ``ATLAN_API_KEY`` is
+            absent or blank.
+    """
+    base_url = environ.get("ATLAN_BASE_URL", "").strip().rstrip("/")
+    api_key = environ.get("ATLAN_API_KEY", "").strip()
+    missing = [
+        name
+        for name, value in (("ATLAN_BASE_URL", base_url), ("ATLAN_API_KEY", api_key))
+        if not value
+    ]
+    if missing:
+        raise MissingTenantEnvError(
+            message=(
+                f"The harness needs {' and '.join(missing)} to reach a tenant. "
+                "ATLAN_API_KEY is mandatory because /automation/api/v1/* (AE "
+                "workflow management) requires the realm-admin resource_access "
+                "role that only the API key's service account carries."
+            ),
+            field=",".join(missing),
+        )
+    return TenantAuth(
+        base_url=base_url,
+        api_key=api_key,
+        oauth_client_id=environ.get("SDR_CLIENT_ID", "").strip() or None,
+        oauth_client_secret=environ.get("SDR_CLIENT_SECRET", "").strip() or None,
+    )

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -34,7 +34,7 @@ do-not-edit:   re-run the skill instead of hand-editing
 | `application_sdk.server` | FastAPI server, MCP integration, middleware, health endpoint | 4 |
 | `application_sdk.storage` | Object-store abstraction — factory, formats, batch, transfer, cloud bindings | 42 |
 | `application_sdk.templates` | SQL metadata extractor templates and their contracts | 6 |
-| `application_sdk.testing` | Test infrastructure — mocks, fixtures, hypothesis strategies, integration helpers | 151 |
+| `application_sdk.testing` | Test infrastructure — mocks, fixtures, hypothesis strategies, integration helpers | 163 |
 | `application_sdk.validation` | Offline artifact & asset validation — format-agnostic wrapper (ADR-0020) plus pyatlan_v9 .validate() wrappers, no network call | 78 |
 
 ## Subpackage Details
@@ -3187,8 +3187,16 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 
 - **Import:** `from application_sdk.testing.harness import BudgetProfile`
 - **Also importable from:** `application_sdk.testing.harness.budgets`
-- **Signature:** `class BudgetProfile(*, name: str, budgets: dict[str, Budget])`
+- **Signature:** `class BudgetProfile(*, name: str, budgets: Mapping[str, Budget], requests: Mapping[str, RequestBudget] = dict())`
 - **Summary:** A named set of budgets for one execution tier.
+- **Defined in:** `application_sdk/testing/harness/budgets.py`
+
+#### `Call`
+
+- **Import:** `from application_sdk.testing.harness import Call`
+- **Also importable from:** `application_sdk.testing.harness.budgets`
+- **Signature:** `class Call`
+- **Summary:** The outbound call shapes a run makes, as profile keys.
 - **Defined in:** `application_sdk/testing/harness/budgets.py`
 
 #### `CategoryResult`
@@ -3204,6 +3212,13 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Signature:** `class ClusterReader`
 - **Summary:** Read built-in Kubernetes state. No mutation, by decision.
 - **Defined in:** `application_sdk/testing/harness/cluster/__init__.py`
+
+#### `ConnectionIdentity`
+
+- **Import:** `from application_sdk.testing.harness.identity import ConnectionIdentity`
+- **Signature:** `class ConnectionIdentity(qualified_name: str, display_name: str) -> None`
+- **Summary:** The ephemeral connection one harness run creates and then purges.
+- **Defined in:** `application_sdk/testing/harness/identity.py`
 
 #### `CustomResourceReader`
 
@@ -3377,6 +3392,13 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Summary:** Mints the per-run identifiers a harness run needs.
 - **Defined in:** `application_sdk/testing/harness/identity.py`
 
+#### `MissingTenantEnvError`
+
+- **Import:** `from application_sdk.testing.harness import MissingTenantEnvError`
+- **Signature:** `class MissingTenantEnvError(*, ...)`
+- **Summary:** The environment carries no tenant for the harness to run against.
+- **Defined in:** `application_sdk/testing/harness/_errors.py`
+
 #### `MockBinding`
 
 - **Import:** `from application_sdk.testing import MockBinding`
@@ -3476,6 +3498,14 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Summary:** A relationship reference whose target asset is absent from the batch.
 - **Defined in:** `application_sdk/validation/assets.py`
 
+#### `RequestBudget`
+
+- **Import:** `from application_sdk.testing.harness import RequestBudget`
+- **Also importable from:** `application_sdk.testing.harness.budgets`
+- **Signature:** `class RequestBudget(*, ...)`
+- **Summary:** Everything one outbound call, including its retries, is allowed to spend.
+- **Defined in:** `application_sdk/testing/harness/budgets.py`
+
 #### `ResourceRef`
 
 - **Import:** `from application_sdk.testing.harness.cluster import ResourceRef`
@@ -3555,6 +3585,28 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Signature:** `class TemporalReader`
 - **Summary:** Read Temporal state. No mutation, by decision.
 - **Defined in:** `application_sdk/testing/harness/temporal/__init__.py`
+
+#### `TenantAuth`
+
+- **Import:** `from application_sdk.testing.harness.identity import TenantAuth`
+- **Signature:** `class TenantAuth(base_url: str, ...)`
+- **Summary:** How a run authenticates against the tenant under test.
+- **Defined in:** `application_sdk/testing/harness/identity.py`
+
+#### `Unreadable`
+
+- **Import:** `from application_sdk.testing.harness.expectations import Unreadable`
+- **Signature:** `class Unreadable(*, cause: BaseException) -> None`
+- **Summary:** A reading that could not be taken.
+- **Defined in:** `application_sdk/testing/harness/expectations.py`
+
+#### `Wait`
+
+- **Import:** `from application_sdk.testing.harness import Wait`
+- **Also importable from:** `application_sdk.testing.harness.budgets`
+- **Signature:** `class Wait`
+- **Summary:** The bounded waits a connector run performs, as profile keys.
+- **Defined in:** `application_sdk/testing/harness/budgets.py`
 
 #### `WorkflowExecutionStatus`
 
@@ -3731,7 +3783,7 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 #### `evaluate_locations`
 
 - **Import:** `from application_sdk.testing.harness.expectations import evaluate_locations`
-- **Signature:** `evaluate_locations(samples: Mapping[str, Sequence[str]], expectations: AssetExpectations) -> Sequence[Finding]`
+- **Signature:** `evaluate_locations(samples: Mapping[str, SampleRead], expectations: AssetExpectations) -> Sequence[Finding]`
 - **Summary:** Evaluate sampled qualified names against the declared hierarchy depths.
 - **Defined in:** `application_sdk/testing/harness/expectations.py`
 
@@ -4038,6 +4090,13 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Summary:** Delete every asset under *connection_qualified_name*, then the connection.
 - **Defined in:** `application_sdk/testing/harness/teardown.py`
 
+#### `read_tenant_auth`
+
+- **Import:** `from application_sdk.testing.harness.identity import read_tenant_auth`
+- **Signature:** `read_tenant_auth(environ: Mapping[str, str]) -> TenantAuth`
+- **Summary:** Read and validate the tenant credentials a run needs from the environment.
+- **Defined in:** `application_sdk/testing/harness/identity.py`
+
 #### `redact`
 
 - **Import:** `from application_sdk.testing.harness.evidence import redact`
@@ -4139,6 +4198,21 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 
 ### Constants and Enums
 
+#### `CONNECTOR_CI`
+
+- **Import:** `from application_sdk.testing.harness import CONNECTOR_CI`
+- **Also importable from:** `application_sdk.testing.harness.budgets`
+- **Signature:** `CONNECTOR_CI`
+- **Summary:** _(no docstring)_
+- **Defined in:** `application_sdk/testing/harness/budgets.py`
+
+#### `CountRead`
+
+- **Import:** `from application_sdk.testing.harness.expectations import CountRead`
+- **Signature:** `CountRead: TypeAlias`
+- **Summary:** _(no docstring)_
+- **Defined in:** `application_sdk/testing/harness/expectations.py`
+
 #### `Outcome`
 
 - **Import:** `from application_sdk.testing.harness import Outcome`
@@ -4161,6 +4235,20 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Signature:** `PURGE_BATCH_SIZE`
 - **Summary:** _(no docstring)_
 - **Defined in:** `application_sdk/testing/harness/teardown.py`
+
+#### `SampleRead`
+
+- **Import:** `from application_sdk.testing.harness.expectations import SampleRead`
+- **Signature:** `SampleRead: TypeAlias`
+- **Summary:** _(no docstring)_
+- **Defined in:** `application_sdk/testing/harness/expectations.py`
+
+#### `UNREADABLE`
+
+- **Import:** `from application_sdk.testing.harness.expectations import UNREADABLE`
+- **Signature:** `UNREADABLE`
+- **Summary:** _(no docstring)_
+- **Defined in:** `application_sdk/testing/harness/expectations.py`
 
 ## `application_sdk.validation`
 

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -1,8 +1,8 @@
 <!--
 generated-by:  capability-manifest skill (.claude/skills/capability-manifest)
 sdk-version:   3.29.0
-source-sha:    4d71641e9416d228dceda7a5335da0c36a0b4a46
-source-date:   2026-08-26T08:20:57+01:00
+source-sha:    e0f655b27da8254a167264e8bc101b1e445247ed
+source-date:   2026-08-26T18:29:50+01:00
 do-not-edit:   re-run the skill instead of hand-editing
 -->
 

--- a/tests/unit/testing/e2e/test_config.py
+++ b/tests/unit/testing/e2e/test_config.py
@@ -3,16 +3,17 @@
 The module had no test file of its own — ``tests/unit/test_app_config.py`` is
 about :class:`application_sdk.main.AppConfig`, the production runtime config,
 which is the *other* class in the name collision this deprecation exists to
-resolve. That gap is named in FND-239; this closes it.
+resolve. That gap is named in FND-239.
 
-``test_scaffold.py`` covers the rename from the harness side (the new class
-keeps only the fields anything reads). This covers the compatibility promise
-from the deprecated side: an existing call site keeps working, unchanged.
+Most of it is now closed from the harness side: ``test_scaffold.py`` covers the
+keyword and positional forms, the restored mutability, the absence of an
+instance ``__dict__``, and the removal version. This file covers what neither
+that file nor the runtime one does — the collision itself, the defaults, and the
+two consequences of the shim not being a dataclass any more.
 """
 
 from __future__ import annotations
 
-import dataclasses
 import warnings
 
 import pytest
@@ -32,66 +33,61 @@ def _config(**overrides: object) -> AppConfig:
 
 
 def test_the_two_app_configs_really_are_different_classes() -> None:
-    """The collision the rename resolves: one is a test-harness locator, the
-    other is the object every app is configured through."""
+    """The collision the rename resolves, and the reason this file exists: one is
+    a test-harness locator, the other is the object every app is configured
+    through. ``tests/unit/test_app_config.py`` tests that one."""
     assert AppConfig is not RuntimeAppConfig
     assert not issubclass(AppConfig, RuntimeAppConfig)
+    assert AppConfig.__module__ != RuntimeAppConfig.__module__
 
 
-def test_every_dropped_field_is_still_accepted() -> None:
-    """All seven kwargs, exactly as the one known consumer passes them."""
-    config = _config(
-        app_module="my_app.main:App",
-        image="ghcr.io/org/my-app:latest",
-        handler_port=9000,
-        worker_health_port=8081,
-        timeout=600,
-    )
-    assert (config.app_name, config.namespace, config.handler_port) == (
-        "my-app",
-        "app-my-app",
-        9000,
-    )
-    assert config.app_module == "my_app.main:App"
-    assert config.timeout == 600
-
-
-def test_the_dropped_fields_default_rather_than_being_required() -> None:
+def test_nothing_is_required_any_more() -> None:
+    """A shim should accept everything the old signature accepted and a little
+    more — never less. The four originally-required fields default rather than
+    raising, so a call site that drops one gets a deprecation, not a TypeError."""
     config = _config()
     assert (config.app_module, config.image) == ("", "")
     assert (config.worker_health_port, config.timeout) == (8081, 300)
+    with pytest.warns(DeprecationWarning):
+        assert AppConfig().app_name == ""
 
 
-def test_it_is_an_app_under_test_so_a_harness_call_site_accepts_it() -> None:
-    assert isinstance(_config(), AppUnderTest)
+def test_the_dead_fields_are_stored_but_carry_no_meaning() -> None:
+    """They are readable — a call site that sets one can read it back — and they
+    are absent from the replacement, which is the whole point of dropping them."""
+    config = _config(image="ghcr.io/org/my-app:latest", timeout=600)
+    assert config.image == "ghcr.io/org/my-app:latest"
+    assert config.timeout == 600
+    assert not hasattr(AppUnderTest(app_name="a", namespace="b"), "image")
 
 
-def test_it_stays_frozen() -> None:
-    """Losing immutability in the shim would let a call site mutate a value the
-    replacement cannot."""
-    with pytest.raises(dataclasses.FrozenInstanceError):
-        _config().app_name = "other"  # type: ignore[misc]
+def test_two_configs_differing_only_in_a_dead_field_compare_equal() -> None:
+    """``__eq__`` comes from AppUnderTest, so it considers only the three live
+    fields. Correct, given the other four have no effect on anything — but it is
+    a behaviour change from the original dataclass, so it is pinned."""
+    assert _config(image="a", timeout=1) == _config(image="b", timeout=2)
+    assert _config(namespace="one") != _config(namespace="two")
 
 
-def test_the_warning_names_the_replacement_and_the_removal_version() -> None:
-    with pytest.warns(DeprecationWarning) as caught:
-        AppConfig(app_name="a", namespace="b")
-    message = str(caught[0].message)
-    assert "application_sdk.testing.harness.AppUnderTest" in message
-    assert f"v{APP_CONFIG_REMOVAL_VERSION}" in message
+def test_a_dead_field_can_be_deleted_as_well_as_set() -> None:
+    """The original was a plain mutable dataclass, so ``__delattr__`` worked. The
+    shim restores both halves; restoring only ``__setattr__`` would leave a
+    frozen-flavoured hole in a class that is otherwise mutable."""
+    config = _config(timeout=600)
+    del config.timeout
+    assert not hasattr(config, "timeout")
 
 
 def test_the_warning_says_the_dropped_fields_are_not_carried_over() -> None:
-    """A call site that reads one of them back off the replacement would get an
-    AttributeError, so the warning has to say so rather than only that the class
-    moved."""
+    """A call site that reads one of them back off the replacement gets an
+    AttributeError, so the warning has to say which fields do not survive — not
+    only that the class moved."""
     with pytest.warns(DeprecationWarning) as caught:
         AppConfig(app_name="a", namespace="b", timeout=1)
-    message = str(caught[0].message)
-    assert "app_module, image, worker_health_port and timeout" in message
+    assert "app_module, image, worker_health_port and timeout" in str(caught[0].message)
 
 
 def test_the_removal_version_is_a_major() -> None:
-    """Every deprecation in this SDK names its removal version, and a field
-    removal is a break, so it can only land on a major."""
+    """Every deprecation in this SDK names its removal version, and dropping four
+    fields is a break, so it can only land on a major."""
     assert APP_CONFIG_REMOVAL_VERSION.endswith(".0")

--- a/tests/unit/testing/e2e/test_config.py
+++ b/tests/unit/testing/e2e/test_config.py
@@ -1,0 +1,97 @@
+"""Unit tests for the deprecated ``testing.e2e.config`` module.
+
+The module had no test file of its own — ``tests/unit/test_app_config.py`` is
+about :class:`application_sdk.main.AppConfig`, the production runtime config,
+which is the *other* class in the name collision this deprecation exists to
+resolve. That gap is named in FND-239; this closes it.
+
+``test_scaffold.py`` covers the rename from the harness side (the new class
+keeps only the fields anything reads). This covers the compatibility promise
+from the deprecated side: an existing call site keeps working, unchanged.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import warnings
+
+import pytest
+
+from application_sdk.main import AppConfig as RuntimeAppConfig
+from application_sdk.testing.e2e.config import APP_CONFIG_REMOVAL_VERSION, AppConfig
+from application_sdk.testing.harness import AppUnderTest
+
+
+def _config(**overrides: object) -> AppConfig:
+    """Build an ``AppConfig`` without the deprecation warning failing the test."""
+    fields: dict[str, object] = {"app_name": "my-app", "namespace": "app-my-app"}
+    fields.update(overrides)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        return AppConfig(**fields)  # type: ignore[arg-type]
+
+
+def test_the_two_app_configs_really_are_different_classes() -> None:
+    """The collision the rename resolves: one is a test-harness locator, the
+    other is the object every app is configured through."""
+    assert AppConfig is not RuntimeAppConfig
+    assert not issubclass(AppConfig, RuntimeAppConfig)
+
+
+def test_every_dropped_field_is_still_accepted() -> None:
+    """All seven kwargs, exactly as the one known consumer passes them."""
+    config = _config(
+        app_module="my_app.main:App",
+        image="ghcr.io/org/my-app:latest",
+        handler_port=9000,
+        worker_health_port=8081,
+        timeout=600,
+    )
+    assert (config.app_name, config.namespace, config.handler_port) == (
+        "my-app",
+        "app-my-app",
+        9000,
+    )
+    assert config.app_module == "my_app.main:App"
+    assert config.timeout == 600
+
+
+def test_the_dropped_fields_default_rather_than_being_required() -> None:
+    config = _config()
+    assert (config.app_module, config.image) == ("", "")
+    assert (config.worker_health_port, config.timeout) == (8081, 300)
+
+
+def test_it_is_an_app_under_test_so_a_harness_call_site_accepts_it() -> None:
+    assert isinstance(_config(), AppUnderTest)
+
+
+def test_it_stays_frozen() -> None:
+    """Losing immutability in the shim would let a call site mutate a value the
+    replacement cannot."""
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        _config().app_name = "other"  # type: ignore[misc]
+
+
+def test_the_warning_names_the_replacement_and_the_removal_version() -> None:
+    with pytest.warns(DeprecationWarning) as caught:
+        AppConfig(app_name="a", namespace="b")
+    message = str(caught[0].message)
+    assert "application_sdk.testing.harness.AppUnderTest" in message
+    assert f"v{APP_CONFIG_REMOVAL_VERSION}" in message
+
+
+def test_the_warning_says_the_dropped_fields_are_not_carried_over() -> None:
+    """A call site that reads one of them back off the replacement would get an
+    AttributeError, so the warning has to say so rather than only that the class
+    moved."""
+    with pytest.warns(DeprecationWarning) as caught:
+        AppConfig(app_name="a", namespace="b", timeout=1)
+    message = str(caught[0].message)
+    assert "app_module, image, worker_health_port and timeout" in message
+
+
+def test_the_removal_version_is_a_major() -> None:
+    """Every deprecation in this SDK names its removal version, and a field
+    removal is a break, so it can only land on a major."""
+    assert APP_CONFIG_REMOVAL_VERSION.endswith(".0")

--- a/tests/unit/testing/e2e/test_config.py
+++ b/tests/unit/testing/e2e/test_config.py
@@ -29,6 +29,8 @@ def _config(**overrides: object) -> AppConfig:
     fields.update(overrides)
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", DeprecationWarning)
+        # arg-type: the overrides are typed `object` so a caller can pass any
+        # field; AppConfig's parameters are str/int.
         return AppConfig(**fields)  # type: ignore[arg-type]
 
 

--- a/tests/unit/testing/harness/test_budgets.py
+++ b/tests/unit/testing/harness/test_budgets.py
@@ -1,0 +1,234 @@
+"""Unit tests for the typed budgets and the connector-CI profile.
+
+The profile claims to carry ``BaseE2ETest``'s class attributes and
+``testing/e2e/client.py``'s module constants *verbatim*. Nothing consumes it yet
+— ``testing/e2e`` is rewired in child H — so until then the only thing that can
+keep that claim true is a test that reads both sides and compares. These do,
+which is why they import the private constants directly: the point is to fail
+when the source of a number moves, not to restate the number.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+import pytest
+
+from application_sdk.testing.e2e.base import BaseE2ETest, _derive_progress_stall_seconds
+from application_sdk.testing.e2e.client import (
+    _HTTP_TIMEOUT,
+    _MAX_RETRY_AFTER_SECONDS,
+    _REQUEST_BACKOFF_SECONDS,
+    _REQUEST_MAX_ATTEMPTS,
+    _RETRY_AFTER_BUDGET_SECONDS,
+    _SUBMIT_TIMEOUT,
+    cold_start_submit_kwargs,
+)
+from application_sdk.testing.harness.budgets import (
+    CONNECTOR_CI,
+    Budget,
+    BudgetProfile,
+    Call,
+    RequestBudget,
+    Wait,
+)
+
+# poll_atlas_for_connection's own default, which is what BaseE2ETest gets by not
+# overriding it. Imported as a value rather than retyped so the conversion below
+# stays anchored to the signature it converts.
+_MAX_NOT_FOUND_ATTEMPTS = 10
+
+
+def _seconds(value: timedelta | None) -> float | None:
+    """Return *value* in seconds, or ``None``."""
+    return None if value is None else value.total_seconds()
+
+
+# ---------------------------------------------------------------------------
+# The Budget type itself
+# ---------------------------------------------------------------------------
+
+
+def test_budget_defaults_leave_every_guard_off_except_the_heartbeat() -> None:
+    """A guard that is on by default is a guard a caller did not ask for."""
+    budget = Budget(timeout=timedelta(seconds=60), poll_interval=timedelta(seconds=5))
+    assert budget.start_grace is None
+    assert budget.stall_timeout is None
+    assert budget.max_transient_failures == 0
+    assert budget.retry_after_budget is None
+    assert budget.heartbeat == timedelta(seconds=30)
+
+
+def test_request_budget_defaults_to_a_single_attempt() -> None:
+    """A retry nobody asked for is how a non-idempotent call gets sent twice."""
+    request = RequestBudget(timeout=timedelta(seconds=60))
+    assert request.max_attempts == 1
+    assert request.backoff == timedelta(0)
+    assert request.max_retry_after is None
+    assert request.retry_after_budget is None
+
+
+def test_a_profile_without_request_budgets_is_still_a_profile() -> None:
+    profile = BudgetProfile(
+        name="scenario",
+        budgets={Wait.AE_RUN: CONNECTOR_CI.budgets[Wait.AE_RUN]},
+    )
+    assert profile.requests == {}
+
+
+def test_profile_keys_are_readable_as_plain_strings() -> None:
+    """A scenario suite reads its tier's keys out of a config file, so the enum
+    has to be usable without importing it."""
+    assert CONNECTOR_CI.budgets["ae_run"] is CONNECTOR_CI.budgets[Wait.AE_RUN]
+    assert CONNECTOR_CI.requests["submit"] is CONNECTOR_CI.requests[Call.SUBMIT]
+
+
+# ---------------------------------------------------------------------------
+# CONNECTOR_CI is BaseE2ETest's class attributes, verbatim
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("wait", "timeout_attr", "interval_attr"),
+    [
+        (
+            Wait.WORKER_HEALTH,
+            "worker_health_timeout_seconds",
+            "worker_health_poll_interval_seconds",
+        ),
+        (
+            Wait.APP_READY,
+            "app_ready_timeout_seconds",
+            "app_ready_poll_interval_seconds",
+        ),
+        (
+            Wait.DEPLOYED_MANIFEST,
+            "deployed_manifest_timeout_seconds",
+            "deployed_manifest_poll_interval_seconds",
+        ),
+        (Wait.AE_RUN, "ae_poll_timeout_seconds", "ae_poll_interval_seconds"),
+        (
+            Wait.ATLAS_CONNECTION,
+            "atlas_poll_timeout_seconds",
+            "atlas_poll_interval_seconds",
+        ),
+        (
+            Wait.ATLAS_ASSET_COUNTS,
+            "atlas_asset_poll_timeout_seconds",
+            "atlas_asset_poll_interval_seconds",
+        ),
+    ],
+)
+def test_every_wait_carries_its_class_attribute_pair(
+    wait: Wait, timeout_attr: str, interval_attr: str
+) -> None:
+    budget = CONNECTOR_CI.budgets[wait]
+    assert _seconds(budget.timeout) == getattr(BaseE2ETest, timeout_attr)
+    assert _seconds(budget.poll_interval) == getattr(BaseE2ETest, interval_attr)
+
+
+def test_the_profile_covers_every_wait_and_every_call() -> None:
+    """A wait missing from the tier is a wait that silently keeps its hard-coded
+    number when the class is rewired."""
+    assert set(CONNECTOR_CI.budgets) == set(Wait)
+    assert set(CONNECTOR_CI.requests) == set(Call)
+
+
+def test_the_ae_run_stall_guard_is_the_class_grace_and_the_derived_window() -> None:
+    budget = CONNECTOR_CI.budgets[Wait.AE_RUN]
+    assert _seconds(budget.start_grace) == BaseE2ETest.ae_stall_grace_seconds
+    # dag_progress_stall_seconds is None by default, i.e. derived from the
+    # ceiling rather than pinned — so the profile has to carry the derivation's
+    # answer, not the old absolute it replaced.
+    assert BaseE2ETest.dag_progress_stall_seconds is None
+    assert _seconds(budget.stall_timeout) == _derive_progress_stall_seconds(
+        BaseE2ETest.ae_poll_timeout_seconds
+    )
+
+
+def test_the_ae_run_transient_streak_matches_the_poll_loops_own_default() -> None:
+    """``poll_native_status``'s ``max_transient_failures`` keyword default."""
+    import inspect
+
+    from application_sdk.testing.e2e.client import AEWorkflowClient
+
+    signature = inspect.signature(AEWorkflowClient.poll_native_status)
+    assert (
+        CONNECTOR_CI.budgets[Wait.AE_RUN].max_transient_failures
+        == signature.parameters["max_transient_failures"].default
+    )
+
+
+def test_the_atlas_connection_grace_is_the_not_found_cap_as_a_duration() -> None:
+    """Every probe that reaches the cap is an empty search (a hit returns
+    immediately), so attempt N fires at (N-1) intervals elapsed."""
+    budget = CONNECTOR_CI.budgets[Wait.ATLAS_CONNECTION]
+    expected = (_MAX_NOT_FOUND_ATTEMPTS - 1) * BaseE2ETest.atlas_poll_interval_seconds
+    assert _seconds(budget.start_grace) == expected
+
+
+def test_the_app_ready_budget_still_divides_into_todays_submit_retry() -> None:
+    """``cold_start_submit_kwargs`` turns the same two numbers back into the
+    submit loop's ``retries`` / ``retry_sleep_seconds``, so the pair here has to
+    be the pair it divides."""
+    budget = CONNECTOR_CI.budgets[Wait.APP_READY]
+    assert cold_start_submit_kwargs(
+        int(budget.timeout.total_seconds()),
+        int(budget.poll_interval.total_seconds()),
+    ) == {
+        "retries": BaseE2ETest.app_ready_timeout_seconds
+        // BaseE2ETest.app_ready_poll_interval_seconds,
+        "retry_sleep_seconds": BaseE2ETest.app_ready_poll_interval_seconds,
+    }
+
+
+@pytest.mark.parametrize(
+    "wait",
+    [
+        Wait.APP_READY,
+        Wait.DEPLOYED_MANIFEST,
+        Wait.AE_RUN,
+        Wait.ATLAS_CONNECTION,
+        Wait.ATLAS_ASSET_COUNTS,
+    ],
+)
+def test_the_loops_that_narrate_themselves_keep_the_heartbeat_off(wait: Wait) -> None:
+    """Each of these call sites passes ``heartbeat_seconds=0`` today, because it
+    logs its own richer per-poll line and a second one would be duplicate noise."""
+    assert CONNECTOR_CI.budgets[wait].heartbeat is None
+
+
+def test_the_only_loop_that_says_nothing_keeps_the_default_heartbeat() -> None:
+    assert CONNECTOR_CI.budgets[Wait.WORKER_HEALTH].heartbeat == timedelta(seconds=30)
+
+
+# ---------------------------------------------------------------------------
+# CONNECTOR_CI is client.py's module constants, verbatim
+# ---------------------------------------------------------------------------
+
+
+def test_the_http_call_budget_is_the_client_constants() -> None:
+    request = CONNECTOR_CI.requests[Call.HTTP]
+    assert _seconds(request.timeout) == _HTTP_TIMEOUT
+    assert request.max_attempts == _REQUEST_MAX_ATTEMPTS
+    assert _seconds(request.backoff) == _REQUEST_BACKOFF_SECONDS
+    assert _seconds(request.max_retry_after) == _MAX_RETRY_AFTER_SECONDS
+    assert _seconds(request.retry_after_budget) == _RETRY_AFTER_BUDGET_SECONDS
+
+
+def test_the_submit_keeps_its_own_longer_per_attempt_ceiling() -> None:
+    """Long enough that a Cloudflare 504 arrives as an HTTP error the retry loop
+    understands, rather than as a raw TimeoutError."""
+    submit = CONNECTOR_CI.requests[Call.SUBMIT]
+    assert _seconds(submit.timeout) == _SUBMIT_TIMEOUT
+    assert submit.timeout > CONNECTOR_CI.requests[Call.HTTP].timeout
+
+
+@pytest.mark.parametrize("wait", [Wait.APP_READY, Wait.AE_RUN])
+def test_the_waits_that_honour_origin_backoff_carry_the_same_ceiling(
+    wait: Wait,
+) -> None:
+    """Both spend their extra waiting through the client's retry-after budget, so
+    a slow origin cannot stretch either past what that constant allows."""
+    budget = CONNECTOR_CI.budgets[wait]
+    assert _seconds(budget.retry_after_budget) == _RETRY_AFTER_BUDGET_SECONDS

--- a/tests/unit/testing/harness/test_expectations.py
+++ b/tests/unit/testing/harness/test_expectations.py
@@ -296,4 +296,6 @@ def test_findings_are_immutable_and_carry_a_machine_readable_expectation() -> No
     assert (finding.subject, finding.expectation) == ("Table", "floor")
     assert finding.detail
     with pytest.raises((AttributeError, TypeError)):
+        # misc: the write is the assertion — Finding is frozen, and the point is
+        # that the type checker and the runtime agree about that.
         finding.subject = "Schema"  # type: ignore[misc]

--- a/tests/unit/testing/harness/test_expectations.py
+++ b/tests/unit/testing/harness/test_expectations.py
@@ -1,0 +1,299 @@
+"""Unit tests for the extracted asset-expectation evaluators.
+
+The behaviour these cover already had 19 tests against
+``BaseE2ETest._evaluate_asset_expectations`` / ``._validate_asset_locations``,
+which stay exactly as they are — the class is not rewired until child H, and a
+green run of both suites is what says the extraction preserved the logic.
+
+What is new here is the part that could not be tested on the class: an
+:class:`Unreadable` reading. On the class a failed search is spelled ``[]`` or
+``0``, which is indistinguishable from a successful search that found nothing,
+so there was no input that could express it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from application_sdk.testing.harness.expectations import (
+    UNREADABLE,
+    AssetExpectations,
+    Unreadable,
+    evaluate_counts,
+    evaluate_locations,
+)
+
+_SQL_DEPTHS = {"Database": 1, "Schema": 2, "Table": 3, "View": 3, "Column": 4}
+
+
+def _sql_locations() -> AssetExpectations:
+    """Location expectations for the db > schema > table > column shape."""
+    return AssetExpectations(
+        depths=_SQL_DEPTHS,
+        connection_qualified_name="default/x/123",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Counts: floors
+# ---------------------------------------------------------------------------
+
+
+def test_floors_met_passes() -> None:
+    expectations = AssetExpectations(floors={"Database": 1, "Table": 5})
+    assert evaluate_counts({"Database": 1, "Table": 7}, expectations) == []
+
+
+def test_floors_shortfall_names_the_type_and_the_floor() -> None:
+    expectations = AssetExpectations(floors={"Database": 1, "Table": 5})
+    findings = evaluate_counts({"Database": 1, "Table": 2}, expectations)
+    assert [(f.subject, f.expectation) for f in findings] == [("Table", "floor")]
+    assert findings[0].detail == "got 2, expected >= 5"
+
+
+def test_a_type_absent_from_the_counts_reads_as_zero() -> None:
+    """ "The search ran and found none" is what an absent key means."""
+    findings = evaluate_counts({}, AssetExpectations(floors={"Table": 1}))
+    assert findings[0].detail == "got 0, expected >= 1"
+
+
+# ---------------------------------------------------------------------------
+# Counts: exact parity
+# ---------------------------------------------------------------------------
+
+
+def test_exact_counts_match_passes() -> None:
+    expectations = AssetExpectations(exacts={"Database": 1, "Schema": 3})
+    assert evaluate_counts({"Database": 1, "Schema": 3}, expectations) == []
+
+
+def test_exact_catches_over_and_under_extraction() -> None:
+    expectations = AssetExpectations(exacts={"Schema": 3})
+    over = evaluate_counts({"Schema": 5}, expectations)
+    under = evaluate_counts({"Schema": 1}, expectations)
+    assert [f.expectation for f in over] == ["exact"]
+    assert [f.expectation for f in under] == ["exact"]
+    assert "expected exactly 3" in over[0].detail
+    assert "expected exactly 3" in under[0].detail
+
+
+def test_floors_and_exacts_accumulate_rather_than_shadow() -> None:
+    expectations = AssetExpectations(
+        floors={"Database": 1, "Table": 5}, exacts={"Schema": 3}
+    )
+    findings = evaluate_counts({"Database": 1, "Table": 2, "Schema": 5}, expectations)
+    assert [(f.subject, f.expectation) for f in findings] == [
+        ("Table", "floor"),
+        ("Schema", "exact"),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Counts: the non-empty backstop
+# ---------------------------------------------------------------------------
+
+
+def test_nonempty_fires_for_a_connector_that_declared_nothing() -> None:
+    """The population most likely to regress silently."""
+    findings = evaluate_counts({}, AssetExpectations(), total_assets=0)
+    assert [f.expectation for f in findings] == ["nonempty"]
+    assert "ZERO assets" in findings[0].detail
+
+
+def test_nonempty_reads_the_all_types_total_not_the_probed_dict() -> None:
+    assert evaluate_counts({}, AssetExpectations(), total_assets=5) == []
+
+
+def test_nonempty_opt_out_leaves_only_the_floor_finding() -> None:
+    expectations = AssetExpectations(floors={"Database": 1}, require_nonempty=False)
+    findings = evaluate_counts({}, expectations)
+    assert [f.expectation for f in findings] == ["floor"]
+
+
+def test_an_expectation_asserting_zero_is_not_overridden_by_the_backstop() -> None:
+    """ "Produces exactly 0 of X" plus zero assets has to pass."""
+    expectations = AssetExpectations(exacts={"PlaceholderType": 0})
+    assert evaluate_counts({}, expectations, total_assets=0) == []
+
+
+def test_the_backstop_falls_back_to_the_sum_when_no_total_is_given() -> None:
+    expectations = AssetExpectations(floors={"Table": 1})
+    assert evaluate_counts({"Table": 3}, expectations) == []
+
+
+# ---------------------------------------------------------------------------
+# Counts: unreadable — the fail-open closure (C4 on FND-224)
+# ---------------------------------------------------------------------------
+
+
+def test_an_unreadable_count_is_not_reported_as_a_missed_floor() -> None:
+    """The old shape read a failed search as 0 and blamed the connector for a
+    floor it was never graded against."""
+    findings = evaluate_counts(
+        {"Table": Unreadable(cause=TimeoutError("atlas 503"))},
+        AssetExpectations(floors={"Table": 5}),
+        total_assets=9,
+    )
+    assert [(f.subject, f.expectation) for f in findings] == [("Table", UNREADABLE)]
+    assert "floor expectation was not graded" in findings[0].detail
+    assert "TimeoutError: atlas 503" in findings[0].detail
+
+
+def test_an_unreadable_count_is_not_reported_as_an_exact_mismatch() -> None:
+    findings = evaluate_counts(
+        {"Schema": Unreadable(cause=ConnectionError("reset"))},
+        AssetExpectations(exacts={"Schema": 3}),
+        total_assets=9,
+    )
+    assert [f.expectation for f in findings] == [UNREADABLE]
+    assert "exact expectation was not graded" in findings[0].detail
+
+
+def test_one_failed_read_ungrades_every_check_that_consulted_it() -> None:
+    """Two findings for one cause is the honest count: the floor was not graded,
+    and neither was the backstop, because the fallback total cannot be summed."""
+    findings = evaluate_counts(
+        {"Table": Unreadable(cause=TimeoutError("atlas 503"))},
+        AssetExpectations(floors={"Table": 5}),
+    )
+    assert [(f.subject, f.expectation) for f in findings] == [
+        ("Table", UNREADABLE),
+        ("all asset types", UNREADABLE),
+    ]
+
+
+def test_an_unreadable_total_does_not_read_as_zero_assets() -> None:
+    findings = evaluate_counts(
+        {},
+        AssetExpectations(),
+        total_assets=Unreadable(cause=TimeoutError("atlas 503")),
+    )
+    assert [f.expectation for f in findings] == [UNREADABLE]
+    assert "ZERO assets" not in findings[0].detail
+
+
+def test_the_sum_fallback_refuses_to_add_around_an_unreadable_count() -> None:
+    """A partial sum is low by an unknown amount, and it is compared against
+    zero — so "low" is exactly the direction that manufactures a regression."""
+    findings = evaluate_counts(
+        {"Table": Unreadable(cause=TimeoutError("atlas 503"))},
+        AssetExpectations(),
+    )
+    assert [f.expectation for f in findings] == [UNREADABLE]
+
+
+def test_an_unreadable_count_for_an_undeclared_type_is_ignored() -> None:
+    """Nothing consulted it, so nothing went ungraded."""
+    findings = evaluate_counts(
+        {"Table": 1, "Ignored": Unreadable(cause=TimeoutError("x"))},
+        AssetExpectations(floors={"Table": 1}),
+        total_assets=1,
+    )
+    assert findings == []
+
+
+# ---------------------------------------------------------------------------
+# Locations
+# ---------------------------------------------------------------------------
+
+
+def test_correct_hierarchy_passes() -> None:
+    samples = {
+        "Database": ["default/x/123/db"],
+        "Schema": ["default/x/123/db/sch"],
+        "Table": ["default/x/123/db/sch/tbl", "default/x/123/db/sch/tbl2"],
+        "View": ["default/x/123/db/sch/vw"],
+        "Column": ["default/x/123/db/sch/tbl/col"],
+    }
+    assert evaluate_locations(samples, _sql_locations()) == []
+
+
+def test_wrong_depth_names_the_type_and_the_expected_depth() -> None:
+    # Table is missing the schema segment -> 2 below the connection, expected 3.
+    findings = evaluate_locations({"Table": ["default/x/123/db/tbl"]}, _sql_locations())
+    assert [(f.subject, f.expectation) for f in findings] == [("Table", "depth")]
+    assert "expected 3" in findings[0].detail
+
+
+def test_an_asset_outside_the_connection_is_a_nesting_finding() -> None:
+    # Right depth, wrong connection prefix (app-name / epoch drift).
+    findings = evaluate_locations({"Database": ["default/y/999/db"]}, _sql_locations())
+    assert [f.expectation for f in findings] == ["nesting"]
+    assert "not nested under the connection default/x/123" in findings[0].detail
+
+
+def test_a_type_with_no_samples_is_skipped() -> None:
+    """ "Too few or none" is the count floors' job, not this check's."""
+    samples = {"Database": ["default/x/123/db"], "Table": []}
+    assert evaluate_locations(samples, _sql_locations()) == []
+
+
+def test_a_trailing_slash_does_not_overcount_the_depth() -> None:
+    assert (
+        evaluate_locations({"Database": ["default/x/123/db/"]}, _sql_locations()) == []
+    )
+
+
+def test_declaring_no_depths_is_a_noop() -> None:
+    expectations = AssetExpectations(connection_qualified_name="default/x/123")
+    assert evaluate_locations({"Table": ["totally/wrong/place"]}, expectations) == []
+
+
+def test_every_bad_sample_is_reported_not_just_the_first() -> None:
+    samples = {
+        "Schema": ["default/x/123/db/sch", "default/x/123/sch_flat"],  # 2nd is depth 1
+        "Column": ["default/x/123/db/sch/tbl/col/extra"],  # depth 5
+    }
+    findings = evaluate_locations(samples, _sql_locations())
+    assert [(f.subject, f.expectation) for f in findings] == [
+        ("Schema", "depth"),
+        ("Column", "depth"),
+    ]
+
+
+def test_no_connection_prefix_skips_the_whole_check() -> None:
+    """Depth is measured below the prefix, so without one there is nothing to
+    measure from — and asserting nesting under "" would fail every sample."""
+    expectations = AssetExpectations(depths=_SQL_DEPTHS)
+    assert (
+        evaluate_locations({"Table": ["default/x/123/db/sch/tbl"]}, expectations) == []
+    )
+
+
+def test_an_unreadable_sample_can_no_longer_be_spelled_as_no_samples() -> None:
+    """The fail-open path this extraction closes: the sampling read returned []
+    on any search error, which arrived as "no samples, skip" — a silent pass."""
+    findings = evaluate_locations(
+        {"Table": Unreadable(cause=PermissionError("403 from search"))},
+        _sql_locations(),
+    )
+    assert [(f.subject, f.expectation) for f in findings] == [("Table", UNREADABLE)]
+    assert "PermissionError: 403 from search" in findings[0].detail
+
+
+def test_a_readable_type_is_still_graded_when_a_sibling_read_failed() -> None:
+    samples = {
+        "Table": Unreadable(cause=PermissionError("403")),
+        "Schema": ["default/x/123/sch_flat"],
+    }
+    findings = evaluate_locations(samples, _sql_locations())
+    assert [(f.subject, f.expectation) for f in findings] == [
+        ("Schema", "depth"),
+        ("Table", UNREADABLE),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Finding shape
+# ---------------------------------------------------------------------------
+
+
+def test_findings_are_immutable_and_carry_a_machine_readable_expectation() -> None:
+    """The evidence bundle groups by what a finding is about, so the report must
+    not have to re-parse the prose to find out."""
+    findings = evaluate_counts({"Table": 0}, AssetExpectations(floors={"Table": 1}))
+    finding = findings[0]
+    assert (finding.subject, finding.expectation) == ("Table", "floor")
+    assert finding.detail
+    with pytest.raises((AttributeError, TypeError)):
+        finding.subject = "Schema"  # type: ignore[misc]

--- a/tests/unit/testing/harness/test_identity.py
+++ b/tests/unit/testing/harness/test_identity.py
@@ -1,0 +1,208 @@
+"""Unit tests for run-id and unique-name minting, and the tenant env read.
+
+Every one of these was untestable before the extraction: ``setup_method`` read
+``time.time`` and ``os.environ`` directly, so the only available assertion about
+a minted name was that it looked roughly right. The clock seam is what turns
+these into assertions about an exact string — which matters because the minted
+qualified name is what teardown purges, and a name a test cannot predict is a
+purge a test cannot verify.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from application_sdk.testing.harness import MissingTenantEnvError
+from application_sdk.testing.harness.identity import (
+    Minter,
+    TenantAuth,
+    read_tenant_auth,
+)
+
+
+def _minter(
+    *, now: int = 1_700_000_000, random: int = 42, run_id_env: str | None = None
+) -> Minter:
+    """A minter whose every output is a function of its arguments."""
+    return Minter(
+        clock=lambda: now,
+        randbelow=lambda _bound: random,
+        run_id_env=run_id_env,
+    )
+
+
+# ---------------------------------------------------------------------------
+# run_id
+# ---------------------------------------------------------------------------
+
+
+def test_the_ambient_ci_run_id_wins_over_the_clock() -> None:
+    assert _minter(run_id_env="123456").run_id() == 123456
+
+
+def test_a_non_numeric_run_id_degrades_to_the_clock() -> None:
+    """A locally-set GITHUB_RUN_ID=local should not fail a run before it starts:
+    the id only ever scopes names."""
+    assert _minter(run_id_env="local").run_id() == 1_700_000_000
+
+
+@pytest.mark.parametrize("ambient", [None, "", "  "])
+def test_an_absent_or_blank_run_id_falls_back_to_the_clock(ambient: str | None) -> None:
+    assert _minter(run_id_env=ambient).run_id() == 1_700_000_000
+
+
+# ---------------------------------------------------------------------------
+# unique_suffix
+# ---------------------------------------------------------------------------
+
+
+def test_the_suffix_is_the_clock_and_a_zero_padded_random_half() -> None:
+    assert _minter(now=1_700_000_000, random=42).unique_suffix() == "1700000000000042"
+
+
+def test_the_suffix_is_purely_numeric() -> None:
+    """Atlas rejects a connection name carrying hyphens or letters."""
+    assert _minter(random=999_999).unique_suffix().isdigit()
+
+
+def test_the_random_half_is_a_fixed_width() -> None:
+    """Without the padding the clock half and the random half are not separable
+    by eye when reading a tenant's asset list."""
+    padded = _minter(now=1, random=7).unique_suffix()
+    assert padded == "1000007"
+
+
+def test_two_runs_in_the_same_second_do_not_collide() -> None:
+    """A collision means one run's teardown purges the other run's assets."""
+    same_second = 1_700_000_000
+    first = _minter(now=same_second, random=1).unique_suffix()
+    second = _minter(now=same_second, random=2).unique_suffix()
+    assert first != second
+
+
+def test_the_random_half_is_drawn_below_a_six_digit_bound() -> None:
+    """The bound is what makes the padding a padding rather than a truncation."""
+    seen: list[int] = []
+
+    def _randbelow(bound: int) -> int:
+        seen.append(bound)
+        return 0
+
+    Minter(clock=lambda: 0, randbelow=_randbelow).unique_suffix()
+    assert seen == [1_000_000]
+
+
+# ---------------------------------------------------------------------------
+# connection_identity
+# ---------------------------------------------------------------------------
+
+
+def test_the_connection_identity_is_predictable_end_to_end() -> None:
+    identity = _minter(now=1_700_000_000, random=42).connection_identity("postgres")
+    assert identity.qualified_name == "default/postgres/1700000000000042"
+    assert identity.display_name == "postgres-1700000000000042"
+
+
+def test_both_names_come_from_one_suffix() -> None:
+    """Minting them separately lets a clock tick between the two, and a display
+    name that disagrees with its qualified name is a run nobody can trace."""
+    ticks = iter([1, 2, 3, 4])
+    identity = Minter(
+        clock=lambda: next(ticks), randbelow=lambda _bound: 0
+    ).connection_identity("api")
+    assert identity.display_name == f"api-{identity.qualified_name.rsplit('/', 1)[1]}"
+
+
+def test_the_connection_type_is_the_middle_segment() -> None:
+    """Connectors whose Atlan catalog type differs from their short name pass the
+    catalog type — the qualified name has to carry that, not the app name."""
+    identity = _minter().connection_identity("api")
+    assert identity.qualified_name.startswith("default/api/")
+
+
+# ---------------------------------------------------------------------------
+# The seam itself
+# ---------------------------------------------------------------------------
+
+
+def test_the_clock_is_an_argument_not_a_patched_global() -> None:
+    """Patching time.monotonic process-wide in an async test hands the same mock
+    to the asyncio loop's own clock, which surfaces as a flaky StopIteration in
+    code that has nothing to do with the clock."""
+    early = _minter(now=1).unique_suffix()
+    late = _minter(now=2).unique_suffix()
+    assert (early, late) == ("1000042", "2000042")
+
+
+def test_from_environment_reads_the_ci_run_id() -> None:
+    minter = Minter.from_environment({"GITHUB_RUN_ID": "987654"})
+    assert minter.run_id() == 987654
+
+
+def test_from_environment_without_a_ci_run_id_mints_from_the_real_clock() -> None:
+    minted = Minter.from_environment({}).run_id()
+    # 2020-01-01, i.e. any real epoch reading is comfortably past it.
+    assert minted > 1_577_836_800
+
+
+# ---------------------------------------------------------------------------
+# read_tenant_auth
+# ---------------------------------------------------------------------------
+
+
+def test_the_tenant_url_loses_its_trailing_slash() -> None:
+    """Every downstream f"{base_url}/..." would otherwise produce two."""
+    auth = read_tenant_auth(
+        {"ATLAN_BASE_URL": "https://tenant.atlan.com/", "ATLAN_API_KEY": "k"}
+    )
+    assert auth == TenantAuth(base_url="https://tenant.atlan.com", api_key="k")
+
+
+def test_the_oauth_pair_is_carried_when_present() -> None:
+    auth = read_tenant_auth(
+        {
+            "ATLAN_BASE_URL": "https://tenant.atlan.com",
+            "ATLAN_API_KEY": "k",
+            "SDR_CLIENT_ID": "id",
+            "SDR_CLIENT_SECRET": "secret",
+        }
+    )
+    assert (auth.oauth_client_id, auth.oauth_client_secret) == ("id", "secret")
+
+
+def test_a_blank_oauth_value_reads_as_absent() -> None:
+    """Empty string and unset mean the same thing to the client, and only one of
+    them can be passed on."""
+    auth = read_tenant_auth(
+        {
+            "ATLAN_BASE_URL": "https://tenant.atlan.com",
+            "ATLAN_API_KEY": "k",
+            "SDR_CLIENT_ID": "  ",
+        }
+    )
+    assert auth.oauth_client_id is None
+
+
+@pytest.mark.parametrize(
+    ("environ", "expected_field"),
+    [
+        ({"ATLAN_API_KEY": "k"}, "ATLAN_BASE_URL"),
+        ({"ATLAN_BASE_URL": "https://t"}, "ATLAN_API_KEY"),
+        ({"ATLAN_BASE_URL": " ", "ATLAN_API_KEY": "k"}, "ATLAN_BASE_URL"),
+        ({}, "ATLAN_BASE_URL,ATLAN_API_KEY"),
+    ],
+)
+def test_a_missing_tenant_variable_names_itself(
+    environ: dict[str, str], expected_field: str
+) -> None:
+    with pytest.raises(MissingTenantEnvError) as caught:
+        read_tenant_auth(environ)
+    assert caught.value.field == expected_field
+
+
+def test_the_api_key_requirement_says_why_it_is_not_optional() -> None:
+    """An operator who has a working OAuth pair will otherwise read the API key
+    as redundant and drop it."""
+    with pytest.raises(MissingTenantEnvError) as caught:
+        read_tenant_auth({"ATLAN_BASE_URL": "https://t"})
+    assert "realm-admin" in str(caught.value)

--- a/tests/unit/testing/harness/test_scaffold.py
+++ b/tests/unit/testing/harness/test_scaffold.py
@@ -357,16 +357,7 @@ async def test_every_remaining_stub_names_its_child_issue() -> None:
     from application_sdk.testing.harness import atlas, automation_engine, starters
     from application_sdk.testing.harness.cluster import HttpRequest, HttpResponse
     from application_sdk.testing.harness.evidence import EvidenceBundle, redact
-    from application_sdk.testing.harness.expectations import (
-        AssetExpectations,
-        evaluate_counts,
-        evaluate_locations,
-    )
-    from application_sdk.testing.harness.identity import Minter
     from application_sdk.testing.harness.teardown import purge_connection
-
-    expectations = AssetExpectations()
-    minter = Minter(clock=lambda: 0, randbelow=lambda _n: 0)
 
     class _Reader:
         """Shaped like a ClusterReader so the call is typed, not bypassed."""
@@ -383,13 +374,7 @@ async def test_every_remaining_stub_names_its_child_issue() -> None:
         async def http(self, target, request: HttpRequest) -> HttpResponse:
             raise AssertionError("the stub must raise before calling out")
 
-    for call in (
-        lambda: evaluate_counts({}, expectations),
-        lambda: evaluate_locations({}, expectations),
-        minter.run_id,
-        minter.unique_suffix,
-        lambda: redact(EvidenceBundle(label="x")),
-    ):
+    for call in (lambda: redact(EvidenceBundle(label="x")),):
         with pytest.raises(HarnessNotBuiltError) as caught:
             call()
         assert caught.value.issue == "FND-224"


### PR DESCRIPTION
Child B of [FND-224](https://linear.app/atlan-epd/issue/FND-224). Closes [FND-239](https://linear.app/atlan-epd/issue/FND-239/child-b-extract-pure-expectation-evaluators-typed-budget-profiles-and). Cut as a stack on #3433, which has since merged — rebased onto `main`, so this diff is only the three modules.

The cheapest, lowest-risk slice: no tenant, and the first proof that the composition direction works. Three of the scaffold's modules stop raising `HarnessNotBuiltError`.

Nothing consumes them. `testing/e2e/` is untouched — `BaseE2ETest` keeps every class attribute and both evaluator methods exactly as they are, and is re-expressed over the harness in child H. So no connector, no generated `_e2e_base.py` and no conformance rule sees a diff, and the existing 19 evaluator tests pass unchanged, which is what says the extraction preserved the logic.

## `expectations` — the two pure evaluators

`evaluate_counts` and `evaluate_locations`, generalised off the class attrs: the declarations arrive as an `AssetExpectations` argument instead of being read off `self`, so a composer that is not a `BaseE2ETest` subclass can evaluate the same expectations. Findings accumulate rather than raising at the first.

**One behaviour is deliberately not preserved.** `_validate_asset_locations` fails open today — the sampling read returns `[]` on any search error, which arrives as "no samples, skip", so an auth fault reads as a pass (documented at `base.py:1195`, finding C4 on FND-224).

The scaffold left that fix as a documented contract on the caller ("callers must not spell *I could not read* as an empty mapping"). Prose cannot enforce it, and the whole point of C4 is that the two spellings are currently identical. So it is structural here instead: a reading that could not be taken is `Unreadable`, a variant the input mapping itself can hold. `samples: Mapping[str, Sequence[str]]` becomes `Mapping[str, SampleRead]`, and "I could not read" no longer has the same spelling as "nothing to check".

Applied to the count evaluator too, which has the mirror-image bug — an unreadable count arrives as `0` and is reported as *"asset floor not met"*. Fail-**closed**, but attributed to the connector rather than to the search that failed, which is the more expensive of the two failure modes to debug.

Every ungraded check emits a `Finding` carrying `UNREADABLE` as its `expectation`, so whoever assembles the verdict can grade it as `Indeterminate` rather than as a regression without parsing prose. The sum fallback for `total_assets` refuses to add around an unreadable count, because a partial sum is low by an unknown amount and the value it is compared against is zero.

One further doc correction from the scaffold: `AssetExpectations.connection_qualified_name` said an empty value "skips the nesting half" of the location check. There is no such half — depth is measured *below* that prefix, so with no prefix there is nothing to measure from either. Empty now skips the check, and the attribute says why.

## `budgets` — `CONNECTOR_CI`, verbatim and checked

Today's tier: `BaseE2ETest`'s `ClassVar` defaults plus `client.py`'s module constants. **Verbatim is checked, not claimed** — `test_budgets.py` reads both sides back (including the private `_HTTP_TIMEOUT` family and `_derive_progress_stall_seconds`) and compares, so the profile cannot drift from the class it was lifted from during the window where nothing calls it.

Two attempt caps convert to the durations they already were:

- `poll_atlas_for_connection`'s `max_not_found_attempts = 10` becomes `start_grace = 270s`. Every probe that reaches the cap is an empty search (a hit returns immediately), so attempt 10 fires at `9 × 30s`. "The connection never appeared" is what `NeverStarted` says, so it is the start-grace latch rather than a guard of its own.
- `app_ready_*` still divides back into the submit loop's `retries` / `retry_sleep_seconds` through `cold_start_submit_kwargs`, asserted by calling it.

`max_forbidden_attempts` is absorbed by being dropped: the Atlas poll went through the search index, whose ACL is permissive, so the knob stopped being reachable and `poll_atlas_for_connection` already `del`s it unread.

`RequestBudget` is new, and separate from `Budget` on purpose. A request retry is not a bounded wait; folding the four remaining `client.py` knobs into `Budget` would make `timeout` mean a ceiling on the whole loop in one case and on each attempt in the other. A retry loop has no total wall-clock bound today, and giving it one here would be inventing a number rather than absorbing one.

**No second profile ships.** The issue's `kind` / `tenant` tiers land with the consumer that knows what those numbers are; inventing them now would put values in the SDK that nothing has ever run.

## `identity` — minting behind a clock seam

`Minter` over an injected clock and `randbelow`, so a minted name is a function of its inputs and a test can pin the exact qualified name a run will produce. That matters more than it sounds: the ephemeral qualified name is what `teardown` purges, and a name the test cannot predict is a purge the test cannot verify. `connection_identity()` mints the qualified name and the display name from **one** suffix, so a clock tick between them cannot produce a display name that disagrees with its own connection.

The seam is a constructor argument, never a patched global — patching `time.monotonic` process-wide in an async test hands the same mock to the asyncio loop's own clock and produces flaky `StopIteration` failures in code that has nothing to do with the clock.

`read_tenant_auth` is `setup_method`'s other identity job (`ATLAN_BASE_URL` / `ATLAN_API_KEY` / the OAuth pair), as a pure function of a mapping rather than a read of `os.environ`. Its leaf is `MissingTenantEnvError` rather than a second `MissingHarnessEnvError`: two leaves with one name and two codes, in two modules that both exist until child H, is the confusion that avoids.

**Not here: the `$admin` role GUID resolution**, which the issue also lists for this module. It is an Atlas read over the network, not a derivation from inputs, so its home is `harness/atlas/` with the other Atlas reads — noted on FND-224 so it lands with them rather than being lost.

## The named test gap

`testing/e2e/config.py` had no test file of its own. `tests/unit/test_app_config.py` is about `application_sdk.main.AppConfig` — the production runtime config, and the *other* class in the name collision this deprecation exists to resolve — so the gap was easy to read as already closed.

#3433 absorbed most of it on the way to merging: `test_scaffold.py` now pins the keyword and positional forms, the restored mutability, the absent instance `__dict__` and the removal version. `tests/unit/testing/e2e/test_config.py` is what neither that file nor the runtime one covers — the class collision itself, the defaults now that nothing is required, and the two consequences of the shim no longer being a dataclass: `__eq__` ignoring the four dead fields, and `__delattr__` working alongside `__setattr__`.

The first push of this branch also carried a `test_it_stays_frozen`, written against #3433's head at the time this branch was cut. #3433 deliberately restored the shim's mutability before merging, so that test asserted the opposite of the merged contract and failed every unit leg. Deleted rather than inverted — `test_scaffold.py` already pins both the mutability and that it does not leak onto `AppUnderTest`.

## Verification

FND-239 asks for more than "the tests pass": each new test had to be shown to **fail** when the extracted code is deliberately perturbed. **22 single-edit mutations, 22 caught** — flipped comparisons in both evaluators, every `Unreadable` branch collapsed back to the fail-open spelling, the sum fallback re-summing around a failed read, the trailing-slash guard removed, the suffix padding and bound narrowed, the clock read twice while minting, the base URL keeping its trailing slash, and four budget values drifted.

- `uv run pre-commit run --files ...` — clean (ruff, ruff-format, isort, pyright)
- Full unit suite on the rebased branch — **8,210 passed, 9 skipped**; 85 of those are new, and the 19 pre-existing evaluator tests are untouched
- `harness/**` coverage **100%**, unchanged from #3433
- `atlan-application-sdk-conformance detect` — **zero findings in the new code**
- `docs/agents/sdk-capabilities.md` regenerated on the pinned `griffe==2.1.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
