### PR TITLE
feat(testing): implement the harness's bounded-wait primitives (FND-227)

### DIFF
--- a/application_sdk/testing/e2e/base.py
+++ b/application_sdk/testing/e2e/base.py
@@ -71,7 +71,6 @@ from application_sdk.testing.e2e._manifest_identity import (
     compare_node_identities,
     node_identities,
 )
-from application_sdk.testing.e2e._poll import until_deadline
 from application_sdk.testing.e2e.client import (
     AEWorkflowClient,
     DAGNodeResult,
@@ -88,6 +87,7 @@ from application_sdk.testing.e2e.payload import (
     build_ae_payload,
 )
 from application_sdk.testing.e2e.substitutions import MustacheSubstitutions
+from application_sdk.testing.harness._poll import until_deadline
 
 logger = get_logger(__name__)
 

--- a/application_sdk/testing/e2e/client.py
+++ b/application_sdk/testing/e2e/client.py
@@ -65,7 +65,7 @@ from application_sdk.testing.e2e._errors import (
     NoWorkerOnTaskQueueError,
     RequestDelivery,
 )
-from application_sdk.testing.e2e._poll import _HEARTBEAT_SECONDS, until_deadline
+from application_sdk.testing.harness._poll import _HEARTBEAT_SECONDS, until_deadline
 
 logger = get_logger(__name__)
 

--- a/application_sdk/testing/e2e/pods.py
+++ b/application_sdk/testing/e2e/pods.py
@@ -6,7 +6,7 @@ import json
 import orjson
 
 from application_sdk.observability.logger_adaptor import get_logger
-from application_sdk.testing.e2e._poll import until_deadline_async
+from application_sdk.testing.harness._poll import until_deadline_async
 
 logger = get_logger(__name__)
 

--- a/application_sdk/testing/e2e/portforward.py
+++ b/application_sdk/testing/e2e/portforward.py
@@ -7,7 +7,7 @@ from typing import Any
 import httpx
 
 from application_sdk.observability.logger_adaptor import get_logger
-from application_sdk.testing.e2e._poll import until_deadline_async
+from application_sdk.testing.harness._poll import until_deadline_async
 
 logger = get_logger(__name__)
 

--- a/application_sdk/testing/e2e/workflows.py
+++ b/application_sdk/testing/e2e/workflows.py
@@ -3,8 +3,8 @@
 from typing import Any
 
 from application_sdk.observability.logger_adaptor import get_logger
-from application_sdk.testing.e2e._poll import until_deadline_async
 from application_sdk.testing.e2e.portforward import kube_http_call
+from application_sdk.testing.harness._poll import until_deadline_async
 
 logger = get_logger(__name__)
 

--- a/application_sdk/testing/harness/__init__.py
+++ b/application_sdk/testing/harness/__init__.py
@@ -25,10 +25,15 @@ Module map:
 
 ``bridge``
     The one sync/async bridge. One reused event loop per thread.
+``_poll``
+    The deadline arithmetic both bounded-wait shapes and ``testing/e2e``'s
+    twelve loops run on. Private; moved here from ``testing/e2e`` in child C.
 ``waiting``
     ``poll_until`` and ``hold_stable`` — the only two bounded-wait shapes.
 ``outcome``
-    What a wait returns: settled, never-started, stalled, expired, indeterminate.
+    What a wait returns: settled, never-started, stalled, expired, indeterminate
+    — plus ``grade``, the precondition gate that reduces a scenario's whole pile
+    of outcomes and findings to one verdict.
 ``budgets``
     One typed ``Budget`` per wait, and named per-tier profiles.
 ``identity``
@@ -52,12 +57,13 @@ Module map:
 ``teardown``
     Purge mechanics, including the batching that is a correctness bound.
 
-``bridge``, ``outcome``'s vocabulary, ``spec``, ``budgets``, ``expectations`` and
-``identity`` are real; the rest are typed stubs, each naming the child issue that
-fills it in. Nothing outside this package consumes any of it yet — ``testing/e2e``
-is re-expressed over it in child H, and until then the extracted modules are
-pinned against the code they were lifted from by their unit tests rather than by
-being called from it.
+``bridge``, ``waiting``, ``outcome``, ``spec``, ``budgets``, ``expectations``
+and ``identity`` are real; the rest are typed stubs, each naming the child issue
+that fills it in. Nothing outside this package consumes any of it yet —
+``testing/e2e`` is re-expressed over it in child H, and until then the extracted
+modules are pinned against the code they were lifted from by their unit tests
+rather than by being called from it. For ``waiting`` that pin is a differential
+test against ``poll_native_status`` itself, on identical scripted readings.
 
 The optional ``harness`` extra carries the typed Kubernetes backend for
 ``cluster`` (``pip install 'atlan-application-sdk[harness]'``). It is
@@ -69,6 +75,10 @@ from application_sdk.testing.harness._errors import (
     HarnessNotBuiltError,
     MissingTenantEnvError,
     SyncBridgeInAsyncContextError,
+    WaitExpiredError,
+    WaitIndeterminateError,
+    WaitNeverStartedError,
+    WaitStalledError,
 )
 from application_sdk.testing.harness.bridge import close_loop, run_sync
 from application_sdk.testing.harness.budgets import (
@@ -86,10 +96,17 @@ from application_sdk.testing.harness.outcome import (
     Outcome,
     Settled,
     Stalled,
+    Verdict,
     assert_settled,
+    grade,
 )
 from application_sdk.testing.harness.spec import AppUnderTest
-from application_sdk.testing.harness.waiting import Probe, hold_stable, poll_until
+from application_sdk.testing.harness.waiting import (
+    Classifier,
+    Probe,
+    hold_stable,
+    poll_until,
+)
 
 __all__ = [
     # The sync bridge — test-harness only
@@ -102,17 +119,24 @@ __all__ = [
     "close_loop",
     "run_sync",
     # Bounded waits
+    "Classifier",
     "Probe",
     "hold_stable",
     "poll_until",
-    # Outcomes
+    # Outcomes, and the leaves assert_settled raises for the failing four
     "Expired",
     "Indeterminate",
     "NeverStarted",
     "Outcome",
     "Settled",
     "Stalled",
+    "Verdict",
+    "WaitExpiredError",
+    "WaitIndeterminateError",
+    "WaitNeverStartedError",
+    "WaitStalledError",
     "assert_settled",
+    "grade",
     # Budgets
     "CONNECTOR_CI",
     "Budget",

--- a/application_sdk/testing/harness/_errors.py
+++ b/application_sdk/testing/harness/_errors.py
@@ -11,6 +11,8 @@ from dataclasses import dataclass
 from typing import ClassVar
 
 from application_sdk.errors.leaves import (
+    AppTimeoutError,
+    DependencyUnavailableError,
     InvalidInputError,
     PreconditionError,
     UnimplementedError,
@@ -20,6 +22,10 @@ __all__ = [
     "HarnessNotBuiltError",
     "MissingTenantEnvError",
     "SyncBridgeInAsyncContextError",
+    "WaitExpiredError",
+    "WaitIndeterminateError",
+    "WaitNeverStartedError",
+    "WaitStalledError",
 ]
 
 
@@ -77,3 +83,130 @@ class MissingTenantEnvError(InvalidInputError):
 
     code: ClassVar[str] = "INVALID_INPUT_HARNESS_TENANT_ENV"
     field: str | None = "ATLAN_BASE_URL,ATLAN_API_KEY"
+
+
+# ---------------------------------------------------------------------------
+# The four failing verdicts, as the leaves ``assert_settled`` raises
+# ---------------------------------------------------------------------------
+#
+# One leaf per non-settled :mod:`application_sdk.testing.harness.outcome`
+# variant, carrying that variant's fields rather than stringifying them into a
+# message: the whole reason the primitive returns a structured verdict is that a
+# report can group and count without re-parsing prose, and an adapter that
+# raises must not throw that away on the way out.
+#
+# These are the *generic* leaves. ``testing/e2e``'s own
+# ``NoWorkerOnTaskQueueError`` / ``AutomationEngineNotDispatchingError`` /
+# ``DAGProgressStalledError`` stay exactly as they are, because their value is
+# the connector remediation advice in their messages — which queue to check,
+# which agent name resolves to it — and that advice is precisely what could not
+# come along into a shared primitive. A caller that wants it matches on the
+# outcome variant and raises its own leaf; a caller that just wants the wait to
+# fail calls
+# :func:`~application_sdk.testing.harness.outcome.assert_settled` and gets these.
+
+
+@dataclass(kw_only=True)
+class WaitNeverStartedError(PreconditionError):
+    """A bounded wait's start-grace window closed with nothing having started.
+
+    ``PreconditionError`` rather than a timeout, matching the two e2e leaves
+    that guard the same moment: the budget did not run out, the state that had
+    to exist before the work could begin never did (no poller on the task queue,
+    a queue-name mismatch, a worker scaled to zero). Retrying the same call
+    without changing that state is not expected to help, which is the
+    category's own litmus test.
+
+    Attributes:
+        label: What was being waited on, verbatim from the outcome.
+        grace_seconds: The start-grace window that closed without a start.
+        attempts: How many times the probe ran.
+        elapsed_seconds: Wall-clock time the wait consumed.
+    """
+
+    code: ClassVar[str] = "PRECONDITION_WAIT_NEVER_STARTED"
+    component: str | None = "harness_waiting"
+    label: str | None = None
+    grace_seconds: float | None = None
+    attempts: int | None = None
+    elapsed_seconds: float | None = None
+
+
+@dataclass(kw_only=True)
+class WaitStalledError(AppTimeoutError):
+    """Work started, then stopped making observable progress.
+
+    A ``TIMEOUT``-category leaf, following :class:`TaskStalledError`'s reasoning
+    (ADR-0018): a stall *is* a bounded wait that elapsed, just a wait for the
+    next change rather than for the end. ``testing/e2e``'s
+    ``DAGProgressStalledError`` calls the same condition a ``PRECONDITION``; it
+    predates the ADR and keeps its category so no existing consumer sees a
+    reclassification. Normalising the pair is listed on FND-240.
+
+    Attributes:
+        label: What was being waited on, verbatim from the outcome.
+        fingerprint: The progress fingerprint that stopped changing — the single
+            most useful field, because it says *what* froze.
+        stall_window_seconds: How long the fingerprint went unchanged before the
+            watchdog fired.
+        attempts: How many times the probe ran.
+    """
+
+    code: ClassVar[str] = "TIMEOUT_WAIT_STALLED"
+    component: str | None = "harness_waiting"
+    label: str | None = None
+    fingerprint: str | None = None
+    stall_window_seconds: float | None = None
+    attempts: int | None = None
+
+
+@dataclass(kw_only=True)
+class WaitExpiredError(AppTimeoutError):
+    """A bounded wait spent its whole budget while work was still progressing.
+
+    The plain timeout, and the only one of the four that says nothing about
+    *why*: the work was moving, it was simply not finished. ``timeout_seconds``
+    and ``elapsed_seconds`` come from :class:`AppTimeoutError`.
+
+    Attributes:
+        label: What was being waited on, verbatim from the outcome.
+        attempts: How many times the probe ran.
+    """
+
+    code: ClassVar[str] = "TIMEOUT_WAIT_EXPIRED"
+    component: str | None = "harness_waiting"
+    label: str | None = None
+    attempts: int | None = None
+
+
+@dataclass(kw_only=True)
+class WaitIndeterminateError(DependencyUnavailableError):
+    """The wait reached no verdict, because the probe itself could not be read.
+
+    ``DEPENDENCY_UNAVAILABLE`` is the load-bearing choice here, not a category
+    of convenience: an expired vcluster token, a dropped tunnel or a 503 from
+    Atlas is neither a pass nor a regression in the thing under test, and this
+    is the category whose own definition is "the same call would work once the
+    dependency recovers". A caller grading a suite can therefore separate
+    "could not tell" from "told, and it was bad" on the category alone. See
+    :mod:`application_sdk.testing.harness.outcome` for why the verdict exists
+    at all.
+
+    The cause is preserved as ``__cause__`` (``raise ... from``) as well as
+    summarised in the message, so a caller can still classify which backend and
+    which transport failed.
+
+    Attributes:
+        label: What was being waited on, verbatim from the outcome.
+        attempts: How many times the probe ran.
+        elapsed_seconds: Wall-clock time the wait consumed.
+        transient_failures: How many probe errors were absorbed before the wait
+            gave up.
+    """
+
+    code: ClassVar[str] = "DEPENDENCY_UNAVAILABLE_WAIT_INDETERMINATE"
+    component: str | None = "harness_waiting"
+    label: str | None = None
+    attempts: int | None = None
+    elapsed_seconds: float | None = None
+    transient_failures: int | None = None

--- a/application_sdk/testing/harness/_poll.py
+++ b/application_sdk/testing/harness/_poll.py
@@ -1,8 +1,8 @@
-"""One bounded-poll primitive for the e2e harness's deadline loops.
+"""The deadline arithmetic every bounded loop in the harness runs on.
 
-Every "probe until it's ready or the budget runs out" loop in this package
-routes through :func:`until_deadline` (sync) or :func:`until_deadline_async`
-(async). Before this module each of them hand-rolled the same three lines::
+Every "probe until it's ready or the budget runs out" loop routes through
+:func:`until_deadline` (sync) or :func:`until_deadline_async` (async). Before
+this module each of them hand-rolled the same three lines::
 
     deadline = time.monotonic() + timeout
     while True:
@@ -36,6 +36,15 @@ Testing: pass ``clock``/``sleep`` explicitly, or wrap the code under test in
 :func:`fake_clock`. Neither touches :func:`time.monotonic` itself — the asyncio
 event loop reads that for its own timers, and fast-forwarding it globally makes
 async tests flake.
+
+Private, and it lives here rather than in ``testing/e2e/`` because the harness
+cannot import from the package it is about to be the foundation of: child H
+re-expresses ``testing/e2e`` *over*
+:mod:`application_sdk.testing.harness.waiting`, and a
+``harness -> e2e -> harness`` cycle is what keeping the deadline loop on the e2e
+side would have produced. Both sides read it from here today; the five
+``testing/e2e`` call sites keep their behaviour byte for byte and only their
+import line moved (child C on FND-224).
 """
 
 from __future__ import annotations

--- a/application_sdk/testing/harness/budgets.py
+++ b/application_sdk/testing/harness/budgets.py
@@ -36,7 +36,7 @@ mode preserving the ``elapsed += interval_seconds`` accumulator — a bug that
 never charged HTTP round-trip time to the budget, so ``ae_poll_timeout_seconds
 = 600`` bounded 600s of *sleeps* plus N round trips at up to 60s each. That
 accumulator no longer exists: every deadline loop in ``testing/e2e/`` now runs
-through :mod:`application_sdk.testing.e2e._poll`, which is monotonic and
+through :mod:`application_sdk.testing.harness._poll`, which is monotonic and
 re-clamps each gap against the clock read *after* the probe. So there is no
 current behaviour to preserve, and no ``clock`` field here — shipping one would
 be reintroducing the bug as a supported mode. See the D3 note on FND-224.
@@ -111,13 +111,34 @@ class Budget:
             work *has* started, after which the wait returns
             :class:`~application_sdk.testing.harness.outcome.Stalled`. ``None``
             disables the watchdog.
-        max_transient_failures: How many probe errors to absorb before giving up
-            with :class:`~application_sdk.testing.harness.outcome.Indeterminate`.
-            ``0`` means the first probe error ends the wait.
+        max_transient_failures: Length of the *consecutive* probe-error streak
+            that ends the wait with
+            :class:`~application_sdk.testing.harness.outcome.Indeterminate`. The
+            Nth consecutive error is the one that gives up, so ``5`` absorbs
+            four and stops on the fifth — the boundary
+            ``poll_native_status`` has today, pinned by
+            ``test_gives_up_at_max_transient_failures``, and preserved here
+            rather than corrected because a drift would change every connector's
+            tolerance the moment child D rewires the loop. ``0`` and ``1`` are
+            therefore the same instruction: end on the first error. Normalising
+            that degenerate pair is listed on FND-240.
+
+            A streak, not a total: any successful probe resets it, so a wait
+            spanning a twenty-minute VPN tunnel is not bounded by the *sum* of
+            the blips it survived. Set per backend — a kubectl read over a
+            tunnel and an in-process HTTP call have different normal failure
+            rates (FND-227's 2026-08-17 amendment).
         retry_after_budget: Ceiling on the *extra* waiting an origin may request
             via ``Retry-After`` across the whole wait, on top of the fixed gaps.
             Without it a slow origin can stretch the real wall-clock bound well
             past :attr:`timeout`. ``None`` means honour no origin backoff.
+        max_retry_after: Ceiling on any *single* origin-requested wait, so one
+            pathological value cannot hang a CI leg inside its own backoff.
+            Same field, same meaning, as
+            :attr:`RequestBudget.max_retry_after`: a wait that honours origin
+            backoff needs both bounds, and only one of them was here.
+            ``None`` honours whatever the origin asks for, up to
+            :attr:`retry_after_budget`.
         heartbeat: Cadence of the "still waiting" progress line. ``None``
             silences it, which is right when the call site logs its own richer
             per-poll progress and a second line would be duplicate noise.
@@ -129,6 +150,7 @@ class Budget:
     stall_timeout: timedelta | None = None
     max_transient_failures: int = 0
     retry_after_budget: timedelta | None = None
+    max_retry_after: timedelta | None = None
     heartbeat: timedelta | None = timedelta(seconds=30)
 
 
@@ -239,6 +261,10 @@ CONNECTOR_CI = BudgetProfile(
             stall_timeout=timedelta(seconds=300),
             max_transient_failures=5,
             retry_after_budget=timedelta(seconds=300),
+            # The same per-single-wait cap _retry_gap already applies inside
+            # this loop; it had no home on Budget until child C needed to
+            # honour origin backoff from inside the primitive.
+            max_retry_after=timedelta(seconds=120),
             # poll_native_status throttles its own richer progress line to the
             # heartbeat cadence and disables the generic one.
             heartbeat=None,

--- a/application_sdk/testing/harness/outcome.py
+++ b/application_sdk/testing/harness/outcome.py
@@ -19,21 +19,39 @@ what closes the fail-open reads catalogued as C4 on FND-224 — four count/sampl
 methods that return zeros on search error, so an Atlas outage currently reports
 *"asset floor not met"* and points the reader at the connector.
 
+**Two independent designs landed on the same narrowing.** The runtime scenario
+suite's ``crd_schema()`` caches "this CRD is not installed here" on a **404
+only**; a 403 from a restricted role, an expired token or a read timeout raises
+rather than caching a false negative. Same rule, arrived at separately: a
+failed read may not borrow the vocabulary of a successful one. That is the
+strongest evidence available that the rule is not a local preference, and it is
+why :class:`Indeterminate` is a variant here rather than a convention the
+caller is asked to remember (FND-227's 2026-08-17 amendment).
+
 :func:`assert_settled` converts back to the raise-on-failure style the connector
 suites already use, so ``BaseE2ETest``'s observable behaviour is unchanged by
-routing through this vocabulary.
-
-Finding accumulation and the precondition gate that sit on top of these types
-are FND-227 (child C) — this module scaffolds the vocabulary they return.
+routing through this vocabulary. :func:`grade` is the other direction — the
+precondition gate that turns a bag of accumulated outcomes and findings into the
+one verdict a scenario reports, with the ordering that keeps both halves of the
+C4 fix honest: a confirmed regression is never softened into "could not tell",
+and a pass is never claimed over a read that did not happen.
 """
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import timedelta
-from typing import Generic, TypeAlias, TypeVar, Union
+from enum import StrEnum
+from typing import Any, Generic, TypeAlias, TypeVar, Union
 
-from application_sdk.testing.harness._errors import HarnessNotBuiltError
+from application_sdk.testing.harness._errors import (
+    WaitExpiredError,
+    WaitIndeterminateError,
+    WaitNeverStartedError,
+    WaitStalledError,
+)
+from application_sdk.testing.harness.expectations import UNREADABLE, Finding
 
 __all__ = [
     "Expired",
@@ -42,7 +60,9 @@ __all__ = [
     "Outcome",
     "Settled",
     "Stalled",
+    "Verdict",
     "assert_settled",
+    "grade",
 ]
 
 T = TypeVar("T")
@@ -97,12 +117,24 @@ class NeverStarted(_Waited[T]):
 class Stalled(_Waited[T]):
     """Work started, then stopped making observable progress.
 
+    Also the verdict
+    :func:`~application_sdk.testing.harness.waiting.hold_stable` returns when an
+    invariant breaks. Not a reuse of convenience: both are "it stopped being
+    what it should be", both are diagnosed from the same two facts — how long it
+    was fine for, and what it looked like when it wasn't — and giving the
+    negative assertion its own variant would make every consumer handle a sixth
+    case to say the same thing.
+
     Attributes:
         stall_window: How long the fingerprint went unchanged before the
-            watchdog fired.
+            watchdog fired. From ``hold_stable``, how long the invariant held
+            before it broke.
         fingerprint: The progress fingerprint that stopped changing — the
             single most useful line in the report, because it says *what* froze.
-        last: The last probe reading.
+            From ``hold_stable``, where there is no progress string to freeze,
+            a short rendering of the reading that broke the invariant: same job,
+            the one line that says what went wrong.
+        last: The last probe reading. From ``hold_stable``, the violating one.
     """
 
     stall_window: timedelta
@@ -163,17 +195,139 @@ def assert_settled(outcome: Outcome[T]) -> T:
     Args:
         outcome: The verdict to unwrap.
 
+    One leaf per failing variant, each carrying that variant's fields rather
+    than a rendered sentence — see
+    :mod:`application_sdk.testing.harness._errors`. These are the *generic*
+    leaves; a caller that wants ``testing/e2e``'s connector remediation advice
+    matches on the variant itself and raises its own.
+
+    Args:
+        outcome: The verdict to unwrap.
+
     Returns:
         :attr:`Settled.value`.
 
     Raises:
-        HarnessNotBuiltError: Always — the leaf mapping lands with
-            :mod:`application_sdk.testing.harness.waiting` in FND-227 (child C).
+        WaitNeverStartedError: The start-grace window closed with no start.
+        WaitStalledError: Progress froze, or a ``hold_stable`` invariant broke.
+        WaitExpiredError: The budget ran out with work still moving.
+        WaitIndeterminateError: The probe could not be read, chained from the
+            cause so the original transport error stays reachable.
     """
-    raise HarnessNotBuiltError(
-        message="assert_settled is not implemented yet",
-        operation="assert_settled",
-        reason="lands with waiting.poll_until, child C on FND-224 (= FND-227)",
-        issue="FND-227",
-        component="harness_outcome",
-    )
+    seconds = outcome.elapsed.total_seconds()
+    if isinstance(outcome, Settled):
+        return outcome.value
+    if isinstance(outcome, NeverStarted):
+        grace = outcome.grace.total_seconds()
+        raise WaitNeverStartedError(
+            message=(
+                f"nothing started on {outcome.label} within {grace:.0f}s "
+                f"({outcome.attempts} probe(s) over {seconds:.0f}s). Work that "
+                "never starts points at dispatch, not at the work being slow."
+            ),
+            label=outcome.label,
+            grace_seconds=grace,
+            attempts=outcome.attempts,
+            elapsed_seconds=seconds,
+        )
+    if isinstance(outcome, Stalled):
+        window = outcome.stall_window.total_seconds()
+        raise WaitStalledError(
+            message=(
+                f"{outcome.label} stopped changing for {window:.0f}s after "
+                f"{seconds:.0f}s; last fingerprint {outcome.fingerprint!r}"
+            ),
+            label=outcome.label,
+            fingerprint=outcome.fingerprint,
+            stall_window_seconds=window,
+            attempts=outcome.attempts,
+            elapsed_seconds=seconds,
+        )
+    if isinstance(outcome, Expired):
+        budget = outcome.budget.total_seconds()
+        raise WaitExpiredError(
+            message=(
+                f"{outcome.label} did not settle within {budget:.0f}s "
+                f"({outcome.attempts} probe(s), still progressing when the "
+                "budget ran out)"
+            ),
+            label=outcome.label,
+            attempts=outcome.attempts,
+            timeout_seconds=budget,
+            elapsed_seconds=seconds,
+        )
+    raise WaitIndeterminateError(
+        message=(
+            f"could not read {outcome.label} — no verdict on the thing under "
+            f"test. {outcome.transient_failures} probe error(s) absorbed over "
+            f"{outcome.attempts} probe(s) in {seconds:.0f}s: {outcome.cause!r}"
+        ),
+        label=outcome.label,
+        attempts=outcome.attempts,
+        elapsed_seconds=seconds,
+        transient_failures=outcome.transient_failures,
+    ) from outcome.cause
+
+
+class Verdict(StrEnum):
+    """How a whole scenario graded, once everything it observed is in.
+
+    Three values rather than a boolean, for the reason
+    :class:`Indeterminate` exists: a suite that can only say pass or fail has to
+    spell an unreadable dependency as one of them, and both spellings are wrong.
+    """
+
+    #: Everything that was checked was readable, and met its expectation.
+    PASSED = "passed"
+    #: At least one readable observation did not meet its expectation.
+    FAILED = "failed"
+    #: Nothing was found wrong, but something could not be read, so "nothing
+    #: wrong" is not the same claim as "right".
+    INDETERMINATE = "indeterminate"
+
+
+def grade(
+    *,
+    outcomes: Iterable[Outcome[Any]] = (),
+    findings: Iterable[Finding] = (),
+) -> Verdict:
+    """Reduce everything a scenario accumulated to its one verdict.
+
+    The precondition gate. Both halves of the C4 fix are orderings, and this is
+    where they are enforced:
+
+    * **A pass is never claimed over a read that did not happen.**
+      :class:`Indeterminate`, and any :class:`~...expectations.Finding` carrying
+      :data:`~application_sdk.testing.harness.expectations.UNREADABLE`, block
+      :attr:`Verdict.PASSED`. Silence from a search that errored is not
+      evidence.
+    * **A confirmed regression is never softened into "could not tell."**
+      :attr:`Verdict.FAILED` outranks :attr:`Verdict.INDETERMINATE`, so one
+      unrelated dropped tunnel cannot bury a real finding that a *successful*
+      read produced. The gate exists to stop a failed read being graded, not to
+      discard evidence that was actually gathered.
+
+    Args:
+        outcomes: Every bounded wait the scenario performed, in any order.
+        findings: Every finding the evaluators produced, in any order.
+
+    Returns:
+        ``FAILED`` if anything readable was wrong; else ``INDETERMINATE`` if
+        anything could not be read; else ``PASSED``.
+    """
+    unreadable = False
+    for finding in findings:
+        if finding.expectation == UNREADABLE:
+            unreadable = True
+        else:
+            # A finding from a read that succeeded is evidence, and evidence
+            # settles the verdict — no later Indeterminate can downgrade it.
+            return Verdict.FAILED
+    for outcome in outcomes:
+        if isinstance(outcome, Settled):
+            continue
+        if isinstance(outcome, Indeterminate):
+            unreadable = True
+            continue
+        return Verdict.FAILED
+    return Verdict.INDETERMINATE if unreadable else Verdict.PASSED

--- a/application_sdk/testing/harness/waiting.py
+++ b/application_sdk/testing/harness/waiting.py
@@ -11,11 +11,26 @@ error streak with a retry-after budget.* Only the fingerprint and the predicates
 are instance-specific, and they are passed in — which is why no fixed shared
 verb is needed and why ``ClusterReader`` never has to grow everyone's states.
 
-The clock, the sleeping and the off-by-one already live in
-:mod:`application_sdk.testing.e2e._poll` (``until_deadline`` /
+The clock, the sleeping and the off-by-one live in
+:mod:`application_sdk.testing.harness._poll` (``until_deadline`` /
 ``until_deadline_async``, monotonic, with the gap re-clamped against the clock
 read *after* the probe). :func:`poll_until` is built on that rather than on a
-second deadline implementation; the private module moves here as part of child C.
+second deadline implementation; that private module moved here from
+``testing/e2e/`` as part of child C, because the harness cannot import from the
+package child H is about to re-express over it.
+
+**Nothing in ``testing/e2e`` calls this yet.** Re-expressing its twelve bounded
+loops is child D (FND-240), and the client those loops live on is synchronous
+until child F converts it — routing a sync method through an async primitive on
+the loop bridge in the meantime would be a workaround built to be deleted. What
+stands in for that proof today is
+``tests/unit/testing/harness/test_waiting_equivalence.py``: it drives
+:func:`poll_until` with the AE-shaped probe, predicates, fingerprint and
+retry-after classifier over the *same* scripted readings ``poll_native_status``
+sees, and asserts both produce the same verdict, the same attempt count and the
+same sleep sequence. A differential test against the live loop is stronger
+evidence than "the 58 existing tests still pass", and it costs the connector
+path no diff at all.
 
 :func:`hold_stable` is **new**. All twelve bounded loops in ``testing/e2e/``
 today are "wait until"; not one is "assert stays". The negative assertion is
@@ -24,7 +39,11 @@ what the runtime scaling scenarios turn on — "a busy pod is never scaled away"
 steady-state group — because most scaling bugs are wrong *actions* rather than
 wrong states.
 
-Implementation is FND-227 (child C).
+**Neither primitive raises on a failed wait.** Both return an
+:mod:`~application_sdk.testing.harness.outcome` variant; see that module for
+why, and :func:`~application_sdk.testing.harness.outcome.assert_settled` for the
+raise-on-failure adapter the connector suites keep. The one exception is an
+*unclassified* probe exception, which propagates — see ``transient`` below.
 """
 
 from __future__ import annotations
@@ -33,17 +52,99 @@ from collections.abc import Awaitable, Callable
 from datetime import timedelta
 from typing import TypeAlias, TypeVar
 
-from application_sdk.testing.harness._errors import HarnessNotBuiltError
+from application_sdk.observability.logger_adaptor import get_logger
+from application_sdk.testing.harness._poll import until_deadline_async
 from application_sdk.testing.harness.budgets import Budget
-from application_sdk.testing.harness.outcome import Outcome
+from application_sdk.testing.harness.outcome import (
+    Expired,
+    Indeterminate,
+    NeverStarted,
+    Outcome,
+    Settled,
+    Stalled,
+)
 
-__all__ = ["Probe", "hold_stable", "poll_until"]
+logger = get_logger(__name__)
+
+__all__ = ["Classifier", "Probe", "hold_stable", "poll_until"]
 
 T = TypeVar("T")
 
 #: One reading of whatever is being waited on. Async by construction (decision
 #: D1): there is no synchronous probe anywhere in the harness.
 Probe: TypeAlias = Callable[[], Awaitable[T]]
+
+#: Turns a probe exception into the backoff to honour before retrying, or
+#: ``None`` for "not transient — this one is terminal". Per backend, never
+#: fixed at the primitive: a kubectl read over a tunnel and an in-process HTTP
+#: call have different normal failure rates.
+Classifier: TypeAlias = Callable[[BaseException], "timedelta | None"]
+
+#: Cap on the rendered reading a :func:`hold_stable` violation carries as its
+#: fingerprint. A violating pod list is a report line, not a payload dump.
+_RENDER_LIMIT = 120
+
+
+def _seconds(value: timedelta | None) -> float | None:
+    """Return *value* in seconds, or ``None``."""
+    return None if value is None else value.total_seconds()
+
+
+def _render(value: object) -> str:
+    """Summarise a reading for a report line, bounded so it stays one line."""
+    text = repr(value)
+    if len(text) <= _RENDER_LIMIT:
+        return text
+    return f"{text[: _RENDER_LIMIT - 1]}…"
+
+
+def _honoured_gap(
+    requested: timedelta,
+    *,
+    floor: float,
+    cap: float | None,
+    budget_left: float,
+) -> float:
+    """Pick the gap before the next probe, honouring the origin's request.
+
+    Mirrors ``testing/e2e/client.py``'s ``_retry_gap``, with the two bounds that
+    were module constants there now read off the :class:`Budget`:
+
+    * ``cap`` (:attr:`Budget.max_retry_after`) bounds any *single* wait, so one
+      pathological ``Retry-After`` cannot hang a CI leg inside its own backoff;
+    * ``budget_left`` (what is left of :attr:`Budget.retry_after_budget`) bounds
+      the *total* above-the-floor waiting across the whole wait.
+
+    Never returns less than ``floor``: honouring a hint may lengthen the gap the
+    loop already guaranteed, never shorten it. A wait with no
+    :attr:`Budget.retry_after_budget` therefore degrades cleanly to the fixed
+    interval, which is exactly what "honour no origin backoff" should do — one
+    rule, not a second branch.
+
+    Unlike ``_retry_gap`` this does **not** round the request up to a whole
+    second. There the input was an HTTP ``Retry-After`` header, integer seconds
+    by definition; here it is a ``timedelta`` the classifier chose, and
+    quantising someone else's duration is not the primitive's call. A classifier
+    reading that header rounds on the way in.
+
+    Args:
+        requested: What the origin asked for. Non-positive means "nothing
+            usable", and the floor stands.
+        floor: The loop's own fixed gap.
+        cap: Ceiling on this single wait, or ``None`` for no ceiling.
+        budget_left: Above-the-floor seconds still permitted in this wait.
+
+    Returns:
+        The gap to take, before :meth:`Attempt.sleep_next` clamps it again
+        against the residual deadline.
+    """
+    wanted = requested.total_seconds()
+    if wanted <= 0:
+        return floor
+    allowed = min(wanted, max(budget_left, 0.0))
+    if cap is not None:
+        allowed = min(allowed, cap)
+    return max(floor, allowed)
 
 
 async def poll_until(
@@ -52,7 +153,7 @@ async def poll_until(
     settled: Callable[[T], bool],
     started: Callable[[T], bool] | None = None,
     fingerprint: Callable[[T], str] | None = None,
-    transient: Callable[[BaseException], timedelta | None] | None = None,
+    transient: Classifier | None = None,
     budget: Budget,
     label: str,
 ) -> Outcome[T]:
@@ -67,17 +168,24 @@ async def poll_until(
             :class:`~application_sdk.testing.harness.outcome.NeverStarted`
             rather than a generic timeout — dispatch failures and slow work are
             different diagnoses. ``None`` means "started on the first reading".
+            A latch, not a level: work that starts and finishes between two
+            polls still counts as started.
         fingerprint: Reduces a reading to a comparable progress string. When it
             stops changing for ``budget.stall_timeout`` the wait returns
             :class:`~application_sdk.testing.harness.outcome.Stalled` carrying
             the frozen fingerprint. ``None`` disables the watchdog regardless of
             the budget, because there is nothing to compare.
         transient: Classifies a probe exception. Returns a backoff to honour
-            (bounded by ``budget.retry_after_budget``) to absorb it as
-            transient, or ``None`` to treat it as terminal. An unclassified
-            exception propagates: a deterministic bug in the probe itself — a
-            wrong call signature, a bad config value — raises the same exception
-            on every attempt, so waiting out the budget only delays the failure.
+            (bounded by ``budget.max_retry_after`` and
+            ``budget.retry_after_budget``) to absorb it as transient, or
+            ``None`` to treat it as terminal. An unclassified exception
+            propagates: a deterministic bug in the probe itself — a wrong call
+            signature, a bad config value — raises the same exception on every
+            attempt, so waiting out the budget only delays the failure. Passing
+            no classifier at all therefore means "every probe error is a bug in
+            the probe", which is right for an in-process read and wrong for a
+            kubectl read over a tunnel — hence per backend, not fixed at the
+            primitive (FND-227's 2026-08-17 amendment).
         budget: The wait's whole allowance. See
             :class:`~application_sdk.testing.harness.budgets.Budget`.
         label: Noun phrase naming the concrete target, for the report and the
@@ -89,15 +197,162 @@ async def poll_until(
         :func:`~application_sdk.testing.harness.outcome.assert_settled` for the
         raise-on-failure adapter.
 
+        A budget that expires without one successful reading returns
+        :class:`~application_sdk.testing.harness.outcome.Indeterminate`, not
+        :class:`~application_sdk.testing.harness.outcome.Expired`: "it did not
+        finish in time" is a claim about the thing under test, and a wait that
+        never read it is not entitled to make one.
+
     Raises:
-        HarnessNotBuiltError: Always — implementation is FND-227 (child C).
+        BaseException: Whatever ``probe`` raised, when ``transient`` does not
+            classify it as worth absorbing.
     """
-    raise HarnessNotBuiltError(
-        message="poll_until is not implemented yet",
-        operation="poll_until",
-        reason="child C on FND-224 (= FND-227)",
-        issue="FND-227",
-        component="harness_waiting",
+    interval_seconds = budget.poll_interval.total_seconds()
+    grace_seconds = _seconds(budget.start_grace)
+    # A watchdog with nothing to compare is not a watchdog. The fingerprint
+    # decides whether the budget's window is armed, not the other way round.
+    stall_seconds = _seconds(budget.stall_timeout) if fingerprint else None
+    retry_after_left = (budget.retry_after_budget or timedelta(0)).total_seconds()
+    max_retry_after = _seconds(budget.max_retry_after)
+
+    # ``started=None`` is "started on the first reading", which is the same
+    # latch already closed — so the grace window can never fire, and there is no
+    # separate no-predicate branch below.
+    has_started = started is None
+    streak = 0
+    attempts = 0
+    elapsed = 0.0
+    last_value: T | None = None
+    last_error: BaseException | None = None
+    last_fingerprint: str | None = None
+    last_progress = 0.0
+
+    async for attempt in until_deadline_async(
+        budget.timeout.total_seconds(),
+        interval_seconds,
+        label=label,
+        heartbeat_seconds=(budget.heartbeat or timedelta(0)).total_seconds(),
+    ):
+        attempts = attempt.number
+        elapsed = attempt.elapsed
+        try:
+            value = await probe()
+        # Exception, not BaseException: a cancelled test is not a failed read,
+        # and asyncio.CancelledError must reach the task that sent it.
+        except Exception as error:
+            backoff = transient(error) if transient is not None else None
+            if backoff is None:
+                raise
+            last_error = error
+            streak += 1
+            if streak >= budget.max_transient_failures:
+                # WARNING, not ERROR: an unreadable dependency is explicitly not
+                # a verdict on the thing under test, and the caller is handed
+                # the cause to grade. Reporting it as an error here would red a
+                # dashboard for something this function declines to call a
+                # failure.
+                logger.warning(
+                    "giving up on %s after %d consecutive probe error(s) in "
+                    "%.0fs — no verdict, the read itself failed",
+                    label,
+                    streak,
+                    elapsed,
+                    exc_info=True,
+                )
+                return Indeterminate(
+                    label=label,
+                    attempts=attempts,
+                    elapsed=timedelta(seconds=elapsed),
+                    cause=error,
+                    transient_failures=streak,
+                    last=last_value,
+                )
+            # Back off for as long as the origin asked when it said so, rather
+            # than for the poll cadence: an overloaded origin answering
+            # "retry_after: 120" would otherwise burn the whole streak inside
+            # its own wait window. ``sleep_next`` clamps to the residual budget
+            # and reports the gap actually taken.
+            gap = _honoured_gap(
+                backoff,
+                floor=interval_seconds,
+                cap=max_retry_after,
+                budget_left=retry_after_left,
+            )
+            retry_after_left -= gap - interval_seconds
+            slept = attempt.sleep_next(gap)
+            # conformance: ignore[L006] fires only on an absorbed probe error, not per iteration; a streak that ends in a returned Indeterminate leaves no other record of how long the origin was asked to be waited for
+            logger.warning(
+                "transient error probing %s (streak %d/%d) — sleeping %.0fs "
+                "and retrying",
+                label,
+                streak,
+                budget.max_transient_failures,
+                slept,
+                exc_info=True,
+            )
+            continue
+
+        streak = 0
+        last_value = value
+        if not has_started and started is not None and started(value):
+            has_started = True
+        if fingerprint is not None:
+            mark = fingerprint(value)
+            if mark != last_fingerprint:
+                last_fingerprint = mark
+                last_progress = elapsed
+        if settled(value):
+            return Settled(
+                label=label,
+                attempts=attempts,
+                elapsed=timedelta(seconds=elapsed),
+                value=value,
+            )
+        # Fail fast when nothing has started inside the grace window. Checked
+        # only after a reading that succeeded: a probe that could not be read
+        # has not shown that nothing started, it has shown nothing at all.
+        if not has_started and grace_seconds is not None and elapsed >= grace_seconds:
+            return NeverStarted(
+                label=label,
+                attempts=attempts,
+                elapsed=timedelta(seconds=elapsed),
+                grace=timedelta(seconds=grace_seconds),
+                last=value,
+            )
+        # Progress watchdog: something started, then the fingerprint froze for
+        # the whole window. Turns an indefinite hang into a self-terminating
+        # failure that names what stopped moving.
+        if (
+            has_started
+            and stall_seconds is not None
+            and (elapsed - last_progress) >= stall_seconds
+        ):
+            return Stalled(
+                label=label,
+                attempts=attempts,
+                elapsed=timedelta(seconds=elapsed),
+                # The observed quiet gap, not the configured window: they differ
+                # whenever a probe overran its own interval, and the observed one
+                # is the number that answers "how long has it been frozen?".
+                stall_window=timedelta(seconds=elapsed - last_progress),
+                fingerprint=last_fingerprint or "",
+                last=value,
+            )
+
+    if last_value is None and last_error is not None:
+        return Indeterminate(
+            label=label,
+            attempts=attempts,
+            elapsed=timedelta(seconds=elapsed),
+            cause=last_error,
+            transient_failures=streak,
+        )
+    return Expired(
+        label=label,
+        attempts=attempts,
+        elapsed=timedelta(seconds=elapsed),
+        budget=budget.timeout,
+        last=last_value,
     )
 
 
@@ -105,6 +360,7 @@ async def hold_stable(
     probe: Probe[T],
     *,
     invariant: Callable[[T], bool],
+    transient: Classifier | None = None,
     budget: Budget,
     label: str,
 ) -> Outcome[T]:
@@ -118,6 +374,14 @@ async def hold_stable(
         probe: Takes one reading. Called once per poll.
         invariant: True while the reading is still acceptable. The first False
             ends the hold.
+        transient: Classifies a probe exception, exactly as in
+            :func:`poll_until`. Not on the signature the scaffold sketched, and
+            added because the scenarios this exists for run out-of-cluster over
+            a VPN plus a vcluster tunnel, where a reset connection mid-hold is
+            routine: with no classifier the first blip ends a twenty-minute hold
+            as :class:`~application_sdk.testing.harness.outcome.Indeterminate`.
+            ``budget.max_transient_failures`` bounds the streak, as it does
+            there.
         budget: The hold's allowance. ``start_grace`` and ``stall_timeout`` are
             not consulted: there is no start to wait for and no progress to
             watch.
@@ -131,15 +395,97 @@ async def hold_stable(
         "stopped being what it should be" shape — carrying the violating
         reading when it did not; or
         :class:`~application_sdk.testing.harness.outcome.Indeterminate` when the
-        probe itself could not be read.
+        probe itself could not be read. A hold cannot pass over a window it
+        never observed: "nothing went wrong" and "I did not look" are the same
+        silence, which is the whole reason that third verdict exists.
 
     Raises:
-        HarnessNotBuiltError: Always — implementation is FND-227 (child C).
+        BaseException: Whatever ``probe`` raised, when ``transient`` does not
+            classify it as worth absorbing.
     """
-    raise HarnessNotBuiltError(
-        message="hold_stable is not implemented yet",
-        operation="hold_stable",
-        reason="child C on FND-224 (= FND-227); new work, not an extraction",
-        issue="FND-227",
-        component="harness_waiting",
+    interval_seconds = budget.poll_interval.total_seconds()
+    retry_after_left = (budget.retry_after_budget or timedelta(0)).total_seconds()
+    max_retry_after = _seconds(budget.max_retry_after)
+
+    streak = 0
+    attempts = 0
+    elapsed = 0.0
+    last_value: T | None = None
+    last_error: BaseException | None = None
+
+    async for attempt in until_deadline_async(
+        budget.timeout.total_seconds(),
+        interval_seconds,
+        label=label,
+        heartbeat_seconds=(budget.heartbeat or timedelta(0)).total_seconds(),
+    ):
+        attempts = attempt.number
+        elapsed = attempt.elapsed
+        try:
+            value = await probe()
+        except Exception as error:
+            backoff = transient(error) if transient is not None else None
+            if backoff is None:
+                raise
+            last_error = error
+            streak += 1
+            if streak >= budget.max_transient_failures:
+                logger.warning(
+                    "giving up on the %s hold after %d consecutive probe "
+                    "error(s) in %.0fs — the window went unobserved, so the "
+                    "invariant is unproven rather than held",
+                    label,
+                    streak,
+                    elapsed,
+                    exc_info=True,
+                )
+                return Indeterminate(
+                    label=label,
+                    attempts=attempts,
+                    elapsed=timedelta(seconds=elapsed),
+                    cause=error,
+                    transient_failures=streak,
+                    last=last_value,
+                )
+            gap = _honoured_gap(
+                backoff,
+                floor=interval_seconds,
+                cap=max_retry_after,
+                budget_left=retry_after_left,
+            )
+            retry_after_left -= gap - interval_seconds
+            attempt.sleep_next(gap)
+            continue
+
+        streak = 0
+        last_value = value
+        if not invariant(value):
+            return Stalled(
+                label=label,
+                attempts=attempts,
+                elapsed=timedelta(seconds=elapsed),
+                # How long it held before it broke — the other half of the
+                # report line, and the reason a flap at 2s and a flap at 19m do
+                # not read the same.
+                stall_window=timedelta(seconds=elapsed),
+                fingerprint=_render(value),
+                last=value,
+            )
+
+    if last_value is None:
+        # Never read once across the whole hold. There is no reading to call
+        # settled, and calling the invariant held would be a claim about a
+        # window nothing observed.
+        return Indeterminate(
+            label=label,
+            attempts=attempts,
+            elapsed=timedelta(seconds=elapsed),
+            cause=last_error or RuntimeError(f"the {label} hold took no reading"),
+            transient_failures=streak,
+        )
+    return Settled(
+        label=label,
+        attempts=attempts,
+        elapsed=timedelta(seconds=elapsed),
+        value=last_value,
     )

--- a/application_sdk/testing/harness/waiting.py
+++ b/application_sdk/testing/harness/waiting.py
@@ -49,8 +49,9 @@ raise-on-failure adapter the connector suites keep. The one exception is an
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
 from datetime import timedelta
-from typing import TypeAlias, TypeVar
+from typing import Generic, TypeAlias, TypeVar
 
 from application_sdk.observability.logger_adaptor import get_logger
 from application_sdk.testing.harness._poll import until_deadline_async
@@ -83,6 +84,42 @@ Classifier: TypeAlias = Callable[[BaseException], "timedelta | None"]
 #: Cap on the rendered reading a :func:`hold_stable` violation carries as its
 #: fingerprint. A violating pod list is a report line, not a payload dump.
 _RENDER_LIMIT = 120
+
+
+@dataclass(frozen=True, slots=True)
+class _Observation(Generic[T]):
+    """A reading that was actually taken, wrapped so its absence has a spelling.
+
+    Both primitives have to answer "did any probe ever succeed?", and neither may
+    answer it with ``last_value is None``: ``Probe[T]`` puts no bound on ``T``, so
+    ``None`` is a perfectly good reading — a ``ClusterReader`` returning "no such
+    deployment", a status field that is legitimately null. Deciding on ``is None``
+    turns a successful ``None`` into "never observed", which reports a hold that
+    held as :class:`~application_sdk.testing.harness.outcome.Indeterminate` and a
+    poll that read its target as never having read it.
+
+    So the holder is the sentinel: ``None`` here means *no observation object*,
+    which the probe cannot produce, while ``_Observation(None)`` is a reading of
+    ``None``. Same reasoning, and the same shape, as
+    :class:`~application_sdk.testing.harness.expectations.Unreadable` — a failed
+    read may not borrow the vocabulary of a successful one.
+
+    Attributes:
+        value: The reading, whatever ``T`` is.
+    """
+
+    value: T
+
+
+def _last(observation: _Observation[T] | None) -> T | None:
+    """Unwrap an observation for an outcome's ``last`` field.
+
+    ``Outcome.last`` is typed ``T | None`` and so cannot itself distinguish a
+    reading of ``None`` from no reading at all. That conflation is confined to
+    the report: no *decision* in this module is taken on it — see
+    :class:`_Observation`.
+    """
+    return None if observation is None else observation.value
 
 
 def _seconds(value: timedelta | None) -> float | None:
@@ -222,7 +259,7 @@ async def poll_until(
     streak = 0
     attempts = 0
     elapsed = 0.0
-    last_value: T | None = None
+    observation: _Observation[T] | None = None
     last_error: BaseException | None = None
     last_fingerprint: str | None = None
     last_progress = 0.0
@@ -265,7 +302,7 @@ async def poll_until(
                     elapsed=timedelta(seconds=elapsed),
                     cause=error,
                     transient_failures=streak,
-                    last=last_value,
+                    last=_last(observation),
                 )
             # Back off for as long as the origin asked when it said so, rather
             # than for the poll cadence: an overloaded origin answering
@@ -293,7 +330,7 @@ async def poll_until(
             continue
 
         streak = 0
-        last_value = value
+        observation = _Observation(value)
         if not has_started and started is not None and started(value):
             has_started = True
         if fingerprint is not None:
@@ -339,7 +376,10 @@ async def poll_until(
                 last=value,
             )
 
-    if last_value is None and last_error is not None:
+    # Never *observed*, not "the last reading happened to be None" — a wait that
+    # read its target and one that never could are different claims, and a
+    # `Probe[None]` makes them identical to an `is None` test.
+    if observation is None and last_error is not None:
         return Indeterminate(
             label=label,
             attempts=attempts,
@@ -352,7 +392,7 @@ async def poll_until(
         attempts=attempts,
         elapsed=timedelta(seconds=elapsed),
         budget=budget.timeout,
-        last=last_value,
+        last=_last(observation),
     )
 
 
@@ -410,7 +450,7 @@ async def hold_stable(
     streak = 0
     attempts = 0
     elapsed = 0.0
-    last_value: T | None = None
+    observation: _Observation[T] | None = None
     last_error: BaseException | None = None
 
     async for attempt in until_deadline_async(
@@ -445,7 +485,7 @@ async def hold_stable(
                     elapsed=timedelta(seconds=elapsed),
                     cause=error,
                     transient_failures=streak,
-                    last=last_value,
+                    last=_last(observation),
                 )
             gap = _honoured_gap(
                 backoff,
@@ -458,7 +498,7 @@ async def hold_stable(
             continue
 
         streak = 0
-        last_value = value
+        observation = _Observation(value)
         if not invariant(value):
             return Stalled(
                 label=label,
@@ -472,10 +512,15 @@ async def hold_stable(
                 last=value,
             )
 
-    if last_value is None:
-        # Never read once across the whole hold. There is no reading to call
-        # settled, and calling the invariant held would be a claim about a
-        # window nothing observed.
+    if observation is None:
+        # Never read once across the whole hold — the *holder* is absent, which
+        # a probe cannot produce. A hold over a `Probe[None]` whose every reading
+        # was a legitimate `None` observed its window perfectly well, and tested
+        # for with `is None` it would have been reported as unobservable.
+        #
+        # `observation is None` implies a classified error was absorbed: the loop
+        # always yields one attempt, and an attempt either produced a reading or
+        # raised. The fallback keeps `cause` typed rather than covering a path.
         return Indeterminate(
             label=label,
             attempts=attempts,
@@ -487,5 +532,5 @@ async def hold_stable(
         label=label,
         attempts=attempts,
         elapsed=timedelta(seconds=elapsed),
-        value=last_value,
+        value=observation.value,
     )

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -1,8 +1,8 @@
 <!--
 generated-by:  capability-manifest skill (.claude/skills/capability-manifest)
 sdk-version:   3.29.0
-source-sha:    e0f655b27da8254a167264e8bc101b1e445247ed
-source-date:   2026-08-26T18:29:50+01:00
+source-sha:    9a2afbd6d898717f72a1059eb0c19baacf54550f
+source-date:   2026-08-26T22:41:32+01:00
 do-not-edit:   re-run the skill instead of hand-editing
 -->
 
@@ -34,7 +34,7 @@ do-not-edit:   re-run the skill instead of hand-editing
 | `application_sdk.server` | FastAPI server, MCP integration, middleware, health endpoint | 4 |
 | `application_sdk.storage` | Object-store abstraction — factory, formats, batch, transfer, cloud bindings | 42 |
 | `application_sdk.templates` | SQL metadata extractor templates and their contracts | 6 |
-| `application_sdk.testing` | Test infrastructure — mocks, fixtures, hypothesis strategies, integration helpers | 163 |
+| `application_sdk.testing` | Test infrastructure — mocks, fixtures, hypothesis strategies, integration helpers | 170 |
 | `application_sdk.validation` | Offline artifact & asset validation — format-agnostic wrapper (ADR-0020) plus pyatlan_v9 .validate() wrappers, no network call | 78 |
 
 ## Subpackage Details
@@ -3600,6 +3600,14 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Summary:** A reading that could not be taken.
 - **Defined in:** `application_sdk/testing/harness/expectations.py`
 
+#### `Verdict`
+
+- **Import:** `from application_sdk.testing.harness import Verdict`
+- **Also importable from:** `application_sdk.testing.harness.outcome`
+- **Signature:** `class Verdict`
+- **Summary:** How a whole scenario graded, once everything it observed is in.
+- **Defined in:** `application_sdk/testing/harness/outcome.py`
+
 #### `Wait`
 
 - **Import:** `from application_sdk.testing.harness import Wait`
@@ -3607,6 +3615,34 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Signature:** `class Wait`
 - **Summary:** The bounded waits a connector run performs, as profile keys.
 - **Defined in:** `application_sdk/testing/harness/budgets.py`
+
+#### `WaitExpiredError`
+
+- **Import:** `from application_sdk.testing.harness import WaitExpiredError`
+- **Signature:** `class WaitExpiredError(*, ...)`
+- **Summary:** A bounded wait spent its whole budget while work was still progressing.
+- **Defined in:** `application_sdk/testing/harness/_errors.py`
+
+#### `WaitIndeterminateError`
+
+- **Import:** `from application_sdk.testing.harness import WaitIndeterminateError`
+- **Signature:** `class WaitIndeterminateError(*, ...)`
+- **Summary:** The wait reached no verdict, because the probe itself could not be read.
+- **Defined in:** `application_sdk/testing/harness/_errors.py`
+
+#### `WaitNeverStartedError`
+
+- **Import:** `from application_sdk.testing.harness import WaitNeverStartedError`
+- **Signature:** `class WaitNeverStartedError(*, ...)`
+- **Summary:** A bounded wait's start-grace window closed with nothing having started.
+- **Defined in:** `application_sdk/testing/harness/_errors.py`
+
+#### `WaitStalledError`
+
+- **Import:** `from application_sdk.testing.harness import WaitStalledError`
+- **Signature:** `class WaitStalledError(*, ...)`
+- **Summary:** Work started, then stopped making observable progress.
+- **Defined in:** `application_sdk/testing/harness/_errors.py`
 
 #### `WorkflowExecutionStatus`
 
@@ -3836,6 +3872,14 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Summary:** Find all pandera YAML schema files in the given directory.
 - **Defined in:** `application_sdk/testing/integration/validation.py`
 
+#### `grade`
+
+- **Import:** `from application_sdk.testing.harness import grade`
+- **Also importable from:** `application_sdk.testing.harness.outcome`
+- **Signature:** `grade(*, outcomes: Iterable[Outcome[Any]] = (), findings: Iterable[Finding] = ())`
+- **Summary:** Reduce everything a scenario accumulated to its one verdict.
+- **Defined in:** `application_sdk/testing/harness/outcome.py`
+
 #### `greater_than`
 
 - **Import:** `from application_sdk.testing.integration import greater_than`
@@ -3861,7 +3905,7 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 
 - **Import:** `from application_sdk.testing.harness import hold_stable`
 - **Also importable from:** `application_sdk.testing.harness.waiting`
-- **Signature:** `hold_stable(probe: Probe[T], *, invariant: Callable[[T], bool], budget: Budget, label: str)`
+- **Signature:** `hold_stable(probe: Probe[T], *, ...)`
 - **Summary:** Assert *invariant* holds for every reading across the whole budget.
 - **Defined in:** `application_sdk/testing/harness/waiting.py`
 
@@ -4197,6 +4241,14 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Defined in:** `application_sdk/testing/e2e/workflows.py`
 
 ### Constants and Enums
+
+#### `Classifier`
+
+- **Import:** `from application_sdk.testing.harness import Classifier`
+- **Also importable from:** `application_sdk.testing.harness.waiting`
+- **Signature:** `Classifier: TypeAlias`
+- **Summary:** _(no docstring)_
+- **Defined in:** `application_sdk/testing/harness/waiting.py`
 
 #### `CONNECTOR_CI`
 

--- a/tests/unit/testing/e2e/test_client.py
+++ b/tests/unit/testing/e2e/test_client.py
@@ -23,7 +23,6 @@ from application_sdk.testing.e2e._errors import (
     NoWorkerOnTaskQueueError,
     RequestDelivery,
 )
-from application_sdk.testing.e2e._poll import fake_clock
 from application_sdk.testing.e2e.client import (
     _MAX_RETRY_AFTER_SECONDS,
     _RECONCILE_CLOCK_SKEW_SECONDS,
@@ -47,6 +46,7 @@ from application_sdk.testing.e2e.client import (
     _safe_node_status,
     _safe_run_status,
 )
+from application_sdk.testing.harness._poll import fake_clock
 
 _RUN_ID = "test-run-123"
 

--- a/tests/unit/testing/full_dag/test_client.py
+++ b/tests/unit/testing/full_dag/test_client.py
@@ -10,7 +10,6 @@ from typing import Any
 
 import pytest
 
-from application_sdk.testing.e2e._poll import fake_clock
 from application_sdk.testing.full_dag._errors import (
     AtlanApiHttpError,
     AtlanApiResponseInvariantError,
@@ -20,6 +19,7 @@ from application_sdk.testing.full_dag.client import (
     DAGNodeStatus,
     DAGRunStatus,
 )
+from application_sdk.testing.harness._poll import fake_clock
 
 
 def _make_client(monkeypatch: pytest.MonkeyPatch, responses: list[tuple[int, Any]]):

--- a/tests/unit/testing/harness/test_budgets.py
+++ b/tests/unit/testing/harness/test_budgets.py
@@ -56,6 +56,7 @@ def test_budget_defaults_leave_every_guard_off_except_the_heartbeat() -> None:
     assert budget.stall_timeout is None
     assert budget.max_transient_failures == 0
     assert budget.retry_after_budget is None
+    assert budget.max_retry_after is None
     assert budget.heartbeat == timedelta(seconds=30)
 
 
@@ -232,3 +233,13 @@ def test_the_waits_that_honour_origin_backoff_carry_the_same_ceiling(
     a slow origin cannot stretch either past what that constant allows."""
     budget = CONNECTOR_CI.budgets[wait]
     assert _seconds(budget.retry_after_budget) == _RETRY_AFTER_BUDGET_SECONDS
+
+
+def test_the_ae_run_carries_the_per_wait_ceiling_its_loop_already_applies() -> None:
+    """``_retry_gap`` clamps every single honoured wait inside ``poll_native_status``
+    at ``_MAX_RETRY_AFTER_SECONDS``. That bound had no home on ``Budget`` until
+    child C needed to honour origin backoff from inside the primitive, so it is
+    the one number in this profile that arrived after the original lift — read
+    back off the same constant as the rest."""
+    budget = CONNECTOR_CI.budgets[Wait.AE_RUN]
+    assert _seconds(budget.max_retry_after) == _MAX_RETRY_AFTER_SECONDS

--- a/tests/unit/testing/harness/test_outcome.py
+++ b/tests/unit/testing/harness/test_outcome.py
@@ -1,0 +1,238 @@
+"""Unit tests for the two adapters on the outcome vocabulary.
+
+``assert_settled`` converts a verdict back to the raise-on-failure style the
+connector suites already use; ``grade`` converts a pile of verdicts and findings
+forward into the one answer a scenario reports. The vocabulary's own dataclasses
+are covered in ``test_scaffold.py`` — what is pinned here is the two mappings,
+because both encode a decision that is easy to get subtly wrong: which category
+a failing wait belongs to, and which of two bad answers outranks the other.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+import pytest
+
+from application_sdk.errors.categories import FailureCategory
+from application_sdk.testing.harness import (
+    Expired,
+    Indeterminate,
+    NeverStarted,
+    Settled,
+    Stalled,
+    Verdict,
+    WaitExpiredError,
+    WaitIndeterminateError,
+    WaitNeverStartedError,
+    WaitStalledError,
+    assert_settled,
+    grade,
+)
+from application_sdk.testing.harness.expectations import UNREADABLE, Finding
+
+_LABEL = "AE run 8412 native status"
+_ATTEMPTS = 7
+
+
+def _finding(expectation: str) -> Finding:
+    return Finding(
+        subject="Table", detail="expected >= 1, saw 0", expectation=expectation
+    )
+
+
+# ---------------------------------------------------------------------------
+# assert_settled
+# ---------------------------------------------------------------------------
+
+
+def test_a_settled_wait_unwraps_to_its_value() -> None:
+    outcome = Settled(
+        label=_LABEL,
+        attempts=_ATTEMPTS,
+        elapsed=timedelta(seconds=12),
+        value={"extract": "ok"},
+    )
+    assert assert_settled(outcome) == {"extract": "ok"}
+
+
+def test_never_started_raises_a_precondition_not_a_timeout() -> None:
+    """The budget did not run out — the state that had to exist first never did,
+    which is the category's own litmus test and what both e2e leaves guarding
+    this moment already choose."""
+    outcome = NeverStarted(
+        label=_LABEL,
+        attempts=_ATTEMPTS,
+        elapsed=timedelta(seconds=180),
+        grace=timedelta(seconds=180),
+    )
+    with pytest.raises(WaitNeverStartedError) as caught:
+        assert_settled(outcome)
+    error = caught.value
+    assert error.category is FailureCategory.PRECONDITION
+    assert error.code == "PRECONDITION_WAIT_NEVER_STARTED"
+    assert error.grace_seconds == 180.0
+    assert error.attempts == _ATTEMPTS
+    assert error.label == _LABEL
+    assert "AE run 8412 native status" in error.message
+
+
+def test_stalled_raises_carrying_the_fingerprint_that_froze() -> None:
+    """The single most useful field in the report, because it says *what* froze —
+    so it is a field, not a substring of a rendered sentence."""
+    outcome = Stalled(
+        label=_LABEL,
+        attempts=_ATTEMPTS,
+        elapsed=timedelta(seconds=420),
+        stall_window=timedelta(seconds=300),
+        fingerprint="✓✓·-",
+    )
+    with pytest.raises(WaitStalledError) as caught:
+        assert_settled(outcome)
+    error = caught.value
+    assert error.category is FailureCategory.TIMEOUT
+    assert error.code == "TIMEOUT_WAIT_STALLED"
+    assert error.fingerprint == "✓✓·-"
+    assert error.stall_window_seconds == 300.0
+    assert error.elapsed_seconds == 420.0
+
+
+def test_expired_raises_the_plain_timeout_with_both_durations() -> None:
+    outcome = Expired(
+        label=_LABEL,
+        attempts=_ATTEMPTS,
+        elapsed=timedelta(seconds=600),
+        budget=timedelta(seconds=600),
+    )
+    with pytest.raises(WaitExpiredError) as caught:
+        assert_settled(outcome)
+    error = caught.value
+    assert error.code == "TIMEOUT_WAIT_EXPIRED"
+    assert error.timeout_seconds == 600.0
+    assert error.elapsed_seconds == 600.0
+
+
+def test_indeterminate_raises_a_dependency_failure_chained_from_its_cause() -> None:
+    """Load-bearing, not a category of convenience: a caller grading a suite has
+    to be able to separate "could not tell" from "told, and it was bad" without
+    parsing a message, and an expired vcluster token must not read as a
+    regression in the thing under test."""
+    cause = ConnectionResetError("tunnel died")
+    outcome = Indeterminate(
+        label=_LABEL,
+        attempts=_ATTEMPTS,
+        elapsed=timedelta(seconds=95),
+        cause=cause,
+        transient_failures=5,
+    )
+    with pytest.raises(WaitIndeterminateError) as caught:
+        assert_settled(outcome)
+    error = caught.value
+    assert error.category is FailureCategory.DEPENDENCY_UNAVAILABLE
+    assert error.code == "DEPENDENCY_UNAVAILABLE_WAIT_INDETERMINATE"
+    assert error.transient_failures == 5
+    assert error.__cause__ is cause, "the original transport error stays reachable"
+
+
+def test_every_failing_verdict_maps_to_a_distinct_code() -> None:
+    """Four verdicts collapsing to three codes would make one of them
+    untriageable from the code column alone."""
+    codes = {
+        WaitNeverStartedError.code,
+        WaitStalledError.code,
+        WaitExpiredError.code,
+        WaitIndeterminateError.code,
+    }
+    assert len(codes) == 4
+
+
+# ---------------------------------------------------------------------------
+# grade — the precondition gate
+# ---------------------------------------------------------------------------
+
+
+def _settled() -> Settled[str]:
+    return Settled(
+        label=_LABEL, attempts=_ATTEMPTS, elapsed=timedelta(seconds=1), value="ok"
+    )
+
+
+def _indeterminate() -> Indeterminate[str]:
+    return Indeterminate(
+        label=_LABEL,
+        attempts=_ATTEMPTS,
+        elapsed=timedelta(seconds=1),
+        cause=ConnectionResetError("x"),
+    )
+
+
+def _expired() -> Expired[str]:
+    return Expired(
+        label=_LABEL,
+        attempts=_ATTEMPTS,
+        elapsed=timedelta(seconds=1),
+        budget=timedelta(seconds=1),
+    )
+
+
+def test_nothing_observed_grades_as_passed() -> None:
+    """A scenario that declared no expectations and performed no waits has
+    nothing to be indeterminate about."""
+    assert grade() is Verdict.PASSED
+
+
+def test_everything_settled_and_no_findings_grades_as_passed() -> None:
+    assert grade(outcomes=[_settled(), _settled()]) is Verdict.PASSED
+
+
+def test_a_finding_from_a_read_that_worked_grades_as_failed() -> None:
+    assert grade(findings=[_finding("floor")]) is Verdict.FAILED
+
+
+def test_a_wait_that_did_not_settle_grades_as_failed() -> None:
+    assert grade(outcomes=[_settled(), _expired()]) is Verdict.FAILED
+
+
+def test_an_unreadable_finding_blocks_a_pass_without_claiming_a_failure() -> None:
+    """Silence from a search that errored is not evidence, in either direction —
+    the C4 fix's consumer side."""
+    assert grade(findings=[_finding(UNREADABLE)]) is Verdict.INDETERMINATE
+
+
+def test_an_indeterminate_wait_blocks_a_pass_the_same_way() -> None:
+    assert grade(outcomes=[_settled(), _indeterminate()]) is Verdict.INDETERMINATE
+
+
+@pytest.mark.parametrize(
+    "findings",
+    [
+        [_finding(UNREADABLE), _finding("floor")],
+        [_finding("floor"), _finding(UNREADABLE)],
+    ],
+    ids=["unreadable-first", "finding-first"],
+)
+def test_a_confirmed_regression_outranks_an_unrelated_unreadable(
+    findings: list[Finding],
+) -> None:
+    """Order-independently. The gate exists to stop a *failed read* being
+    graded, not to discard evidence that was actually gathered — one dropped
+    tunnel elsewhere must not bury a real finding."""
+    assert grade(findings=findings) is Verdict.FAILED
+
+
+def test_a_failed_wait_outranks_an_indeterminate_one() -> None:
+    assert grade(outcomes=[_indeterminate(), _expired()]) is Verdict.FAILED
+
+
+def test_a_real_finding_outranks_an_indeterminate_wait() -> None:
+    """The two halves are graded against each other, not each in its own silo."""
+    assert (
+        grade(outcomes=[_indeterminate()], findings=[_finding("exact")])
+        is Verdict.FAILED
+    )
+
+
+def test_the_verdict_reads_as_a_plain_string() -> None:
+    """A scenario suite writes this into a report file it did not import an enum
+    to read back."""
+    assert Verdict.INDETERMINATE == "indeterminate"

--- a/tests/unit/testing/harness/test_poll.py
+++ b/tests/unit/testing/harness/test_poll.py
@@ -14,8 +14,8 @@ from unittest.mock import patch
 
 import pytest
 
-from application_sdk.testing.e2e import _poll
-from application_sdk.testing.e2e._poll import (
+from application_sdk.testing.harness import _poll
+from application_sdk.testing.harness._poll import (
     Attempt,
     FakeClock,
     fake_clock,

--- a/tests/unit/testing/harness/test_scaffold.py
+++ b/tests/unit/testing/harness/test_scaffold.py
@@ -29,6 +29,7 @@ from application_sdk.testing.harness import (
     hold_stable,
     poll_until,
 )
+from application_sdk.testing.harness._poll import fake_clock
 from application_sdk.testing.harness.cluster import (
     ClusterReader,
     CustomResourceReader,
@@ -329,28 +330,23 @@ def test_the_stub_leaf_is_also_a_notimplementederror() -> None:
     assert error.issue == "FND-224"
 
 
-async def test_poll_until_is_an_unimplemented_stub() -> None:
+async def test_the_three_child_c_stubs_are_gone() -> None:
+    """``poll_until`` / ``hold_stable`` / ``assert_settled`` were the scaffold's
+    FND-227 stubs. They are implemented now, and their own tests live in
+    ``test_waiting.py`` / ``test_outcome.py``; what belongs *here* is the proof
+    that the scaffold no longer holds a stub under those names, so a revert
+    cannot quietly restore one."""
+
     async def _probe() -> int:
         return 1
 
-    with pytest.raises(HarnessNotBuiltError) as caught:
-        await poll_until(_probe, settled=bool, budget=_budget(), label="x")
-    assert caught.value.issue == "FND-227"
-
-
-async def test_hold_stable_is_an_unimplemented_stub() -> None:
-    async def _probe() -> int:
-        return 1
-
-    with pytest.raises(HarnessNotBuiltError) as caught:
-        await hold_stable(_probe, invariant=bool, budget=_budget(), label="x")
-    assert caught.value.issue == "FND-227"
-
-
-def test_assert_settled_is_an_unimplemented_stub() -> None:
-    with pytest.raises(HarnessNotBuiltError) as caught:
-        assert_settled(Settled(label="x", attempts=1, elapsed=timedelta(0), value=1))
-    assert caught.value.issue == "FND-227"
+    with fake_clock():
+        settled = await poll_until(_probe, settled=bool, budget=_budget(), label="x")
+        # A hold always spends its whole budget on the happy path, so it needs
+        # the fake clock even here: the real one would sleep the full minute.
+        held = await hold_stable(_probe, invariant=bool, budget=_budget(), label="x")
+    assert assert_settled(settled) == 1
+    assert isinstance(held, Settled)
 
 
 async def test_every_remaining_stub_names_its_child_issue() -> None:

--- a/tests/unit/testing/harness/test_waiting.py
+++ b/tests/unit/testing/harness/test_waiting.py
@@ -1,0 +1,732 @@
+"""Unit tests for the two bounded-wait primitives.
+
+Tenant-free and clock-free: every wait here runs under
+:func:`~application_sdk.testing.harness._poll.fake_clock`, which fast-forwards
+the poll helper's own sleeps without touching :func:`time.monotonic` — patching
+that process-wide hands the asyncio loop a mock for its own timers and produces
+spurious ``StopIteration`` flakes.
+
+What these pin is the primitive's *contract*. That it is a faithful extraction
+of ``poll_native_status``'s interleaved guards is a separate claim, pinned
+separately and differentially in ``test_waiting_equivalence.py``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import timedelta
+from unittest.mock import patch
+
+import pytest
+
+from application_sdk.testing.harness import (
+    Budget,
+    Expired,
+    Indeterminate,
+    NeverStarted,
+    Settled,
+    Stalled,
+    hold_stable,
+    poll_until,
+)
+from application_sdk.testing.harness._poll import FakeClock, fake_clock
+
+# ---------------------------------------------------------------------------
+# Scripting a probe
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class Reading:
+    """One scripted probe reading.
+
+    A typed reading rather than a bare string or dict, so a test that means
+    "started but not finished" says so in the type it constructs.
+
+    Attributes:
+        phase: What the reading says the work is doing.
+        mark: The progress fingerprint this reading would produce. Two readings
+            with the same mark are indistinguishable to the watchdog.
+    """
+
+    phase: str
+    mark: str = "-"
+
+
+class Blip(Exception):
+    """A probe failure a classifier can absorb, optionally with a backoff.
+
+    Attributes:
+        retry_after: What the origin asked for, or ``None`` for "no request",
+            mirroring an HTTP ``Retry-After`` that was absent.
+    """
+
+    def __init__(self, retry_after: timedelta | None = None) -> None:
+        super().__init__(f"blip (retry_after={retry_after})")
+        self.retry_after = retry_after
+
+
+class Bug(Exception):
+    """A probe failure no classifier absorbs — a deterministic bug in the probe."""
+
+
+@dataclass
+class Script:
+    """A probe that replays scripted items, repeating the last one forever.
+
+    Repeating rather than exhausting is deliberate: a wait that outlives its
+    script should hit its *budget*, not a ``StopIteration`` that would surface
+    as an unrelated ``RuntimeError`` from inside the coroutine.
+
+    Attributes:
+        items: Readings to return, and exceptions to raise, in order.
+        calls: How many times the probe was called.
+    """
+
+    items: list[Reading | Exception]
+    calls: int = field(default=0)
+
+    async def __call__(self) -> Reading:
+        item = self.items[min(self.calls, len(self.items) - 1)]
+        self.calls += 1
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+
+def _budget(**overrides: object) -> Budget:
+    """A 60s/5s budget — twelve polls — with the named fields overridden."""
+    fields: dict[str, object] = {
+        "timeout": timedelta(seconds=60),
+        "poll_interval": timedelta(seconds=5),
+        "heartbeat": None,
+    }
+    fields.update(overrides)
+    return Budget(**fields)  # pyright: ignore[reportArgumentType]
+
+
+def _settled(phase: str) -> object:
+    return lambda reading: reading.phase == phase
+
+
+def _absorb_all(exc: BaseException) -> timedelta | None:
+    """Classify every :class:`Blip` as transient, honouring its request."""
+    return exc.retry_after or timedelta(0) if isinstance(exc, Blip) else None
+
+
+_MARK = lambda reading: reading.mark  # noqa: E731 — one expression, named once
+
+
+# ---------------------------------------------------------------------------
+# poll_until — settling
+# ---------------------------------------------------------------------------
+
+
+async def test_a_reading_that_is_already_settled_costs_one_probe() -> None:
+    script = Script([Reading("done")])
+    with fake_clock() as clock:
+        outcome = await poll_until(
+            script, settled=_settled("done"), budget=_budget(), label="the run"
+        )
+    assert isinstance(outcome, Settled)
+    assert outcome.value == Reading("done")
+    assert outcome.attempts == 1
+    assert outcome.label == "the run"
+    assert clock.slept == []
+
+
+async def test_settling_late_reports_the_attempts_and_the_elapsed_it_took() -> None:
+    script = Script([Reading("run"), Reading("run"), Reading("done")])
+    with fake_clock():
+        outcome = await poll_until(
+            script, settled=_settled("done"), budget=_budget(), label="the run"
+        )
+    assert isinstance(outcome, Settled)
+    assert outcome.attempts == 3
+    # Two gaps of the 5s interval separate three probes.
+    assert outcome.elapsed == timedelta(seconds=10)
+
+
+async def test_a_wait_that_never_settles_expires_with_the_last_reading() -> None:
+    script = Script([Reading("run")])
+    with fake_clock() as clock:
+        outcome = await poll_until(
+            script, settled=_settled("done"), budget=_budget(), label="the run"
+        )
+    assert isinstance(outcome, Expired)
+    assert outcome.budget == timedelta(seconds=60)
+    assert outcome.last == Reading("run")
+    assert sum(clock.slept) <= 60, "a bounded wait may not sleep past its own budget"
+
+
+# ---------------------------------------------------------------------------
+# poll_until — the start-grace latch
+# ---------------------------------------------------------------------------
+
+
+async def test_nothing_starting_inside_the_grace_window_is_never_started() -> None:
+    """The diagnosis that separates dispatch failures from slow work."""
+    script = Script([Reading("pending")])
+    with fake_clock():
+        outcome = await poll_until(
+            script,
+            settled=_settled("done"),
+            started=_settled("running"),
+            budget=_budget(start_grace=timedelta(seconds=20)),
+            label="the run",
+        )
+    assert isinstance(outcome, NeverStarted)
+    assert outcome.grace == timedelta(seconds=20)
+    assert outcome.elapsed == timedelta(seconds=20)
+    assert outcome.last == Reading("pending")
+
+
+async def test_no_started_predicate_means_started_so_the_grace_cannot_fire() -> None:
+    script = Script([Reading("pending")])
+    with fake_clock():
+        outcome = await poll_until(
+            script,
+            settled=_settled("done"),
+            budget=_budget(start_grace=timedelta(seconds=20)),
+            label="the run",
+        )
+    assert isinstance(outcome, Expired)
+
+
+async def test_started_is_a_latch_not_a_level() -> None:
+    """Work that starts and finishes between two polls still counts as started.
+
+    Without the latch a node that ran to completion inside one interval would
+    read as "never started" and be reported as a dispatch failure — the exact
+    misdiagnosis the variant exists to prevent.
+    """
+    script = Script(
+        [Reading("pending"), Reading("running"), Reading("pending"), Reading("done")]
+    )
+    with fake_clock():
+        outcome = await poll_until(
+            script,
+            settled=_settled("done"),
+            started=_settled("running"),
+            budget=_budget(start_grace=timedelta(seconds=5)),
+            label="the run",
+        )
+    assert isinstance(outcome, Settled)
+
+
+async def test_the_grace_is_checked_only_after_a_reading_that_succeeded() -> None:
+    """A probe that could not be read has not shown that nothing started."""
+    script = Script([Blip(), Blip(), Reading("running"), Reading("done")])
+    with fake_clock():
+        outcome = await poll_until(
+            script,
+            settled=_settled("done"),
+            started=_settled("running"),
+            transient=_absorb_all,
+            budget=_budget(start_grace=timedelta(seconds=5), max_transient_failures=5),
+            label="the run",
+        )
+    assert isinstance(outcome, Settled)
+
+
+# ---------------------------------------------------------------------------
+# poll_until — the progress watchdog
+# ---------------------------------------------------------------------------
+
+
+async def test_a_frozen_fingerprint_stalls_and_carries_what_froze() -> None:
+    script = Script([Reading("running", mark="✓·")])
+    with fake_clock():
+        outcome = await poll_until(
+            script,
+            settled=_settled("done"),
+            fingerprint=_MARK,
+            budget=_budget(stall_timeout=timedelta(seconds=20)),
+            label="the run",
+        )
+    assert isinstance(outcome, Stalled)
+    assert outcome.fingerprint == "✓·"
+    assert outcome.stall_window == timedelta(seconds=20)
+    assert outcome.elapsed == timedelta(seconds=20)
+
+
+async def test_the_stall_window_is_the_quiet_gap_not_the_whole_wait() -> None:
+    """Six polls of real progress, then it freezes.
+
+    The two numbers are only the same when the fingerprint never moved at all,
+    which is what makes this the one shape that tells them apart: reporting the
+    total elapsed would say a run that worked for 20s and then wedged had been
+    frozen from the start.
+    """
+    script = Script(
+        [Reading("running", mark=f"m{n}") for n in range(5)]
+        + [Reading("running", mark="frozen")]
+    )
+    with fake_clock():
+        outcome = await poll_until(
+            script,
+            settled=_settled("done"),
+            fingerprint=_MARK,
+            budget=_budget(
+                timeout=timedelta(seconds=120), stall_timeout=timedelta(seconds=20)
+            ),
+            label="the run",
+        )
+    assert isinstance(outcome, Stalled)
+    assert outcome.fingerprint == "frozen"
+    # Six distinct marks over the first 25s — the last one arrives at 25s and is
+    # the one that then freezes — so the window closes at 45s.
+    assert outcome.elapsed == timedelta(seconds=45)
+    assert outcome.stall_window == timedelta(seconds=20)
+
+
+async def test_a_changing_fingerprint_resets_the_watchdog() -> None:
+    """Every poll moves the mark on, so a 20s window never closes inside 60s."""
+    script = Script([Reading("running", mark=f"m{n}") for n in range(20)])
+    with fake_clock():
+        outcome = await poll_until(
+            script,
+            settled=_settled("done"),
+            fingerprint=_MARK,
+            budget=_budget(stall_timeout=timedelta(seconds=20)),
+            label="the run",
+        )
+    assert isinstance(outcome, Expired)
+
+
+async def test_no_fingerprint_disables_the_watchdog_whatever_the_budget_says() -> None:
+    """There is nothing to compare, so the window cannot mean anything."""
+    script = Script([Reading("running")])
+    with fake_clock():
+        outcome = await poll_until(
+            script,
+            settled=_settled("done"),
+            budget=_budget(stall_timeout=timedelta(seconds=20)),
+            label="the run",
+        )
+    assert isinstance(outcome, Expired)
+
+
+async def test_the_watchdog_waits_for_something_to_have_started() -> None:
+    """A run that has not started yet is the grace window's business, not the
+    watchdog's — otherwise a slow dispatch is reported as a wedged node."""
+    script = Script([Reading("pending", mark="··")])
+    with fake_clock():
+        outcome = await poll_until(
+            script,
+            settled=_settled("done"),
+            started=_settled("running"),
+            fingerprint=_MARK,
+            budget=_budget(stall_timeout=timedelta(seconds=20)),
+            label="the run",
+        )
+    assert isinstance(outcome, Expired), "no start, so no stall verdict"
+
+
+# ---------------------------------------------------------------------------
+# poll_until — transient probe errors
+# ---------------------------------------------------------------------------
+
+
+async def test_an_unclassified_probe_error_propagates() -> None:
+    """A deterministic bug raises the same exception on every attempt, so
+    waiting out the budget only delays the failure."""
+    script = Script([Bug()])
+    with fake_clock():
+        with pytest.raises(Bug):
+            await poll_until(
+                script,
+                settled=_settled("done"),
+                transient=_absorb_all,
+                budget=_budget(max_transient_failures=5),
+                label="the run",
+            )
+    assert script.calls == 1
+
+
+async def test_with_no_classifier_at_all_every_probe_error_propagates() -> None:
+    script = Script([Blip()])
+    with fake_clock():
+        with pytest.raises(Blip):
+            await poll_until(
+                script,
+                settled=_settled("done"),
+                budget=_budget(max_transient_failures=5),
+                label="the run",
+            )
+
+
+async def test_blips_below_the_streak_are_absorbed() -> None:
+    script = Script([Blip(), Blip(), Reading("done")])
+    with fake_clock():
+        outcome = await poll_until(
+            script,
+            settled=_settled("done"),
+            transient=_absorb_all,
+            budget=_budget(max_transient_failures=5),
+            label="the run",
+        )
+    assert isinstance(outcome, Settled)
+    assert outcome.attempts == 3
+
+
+async def test_the_streak_gives_up_on_the_nth_consecutive_error() -> None:
+    """``max_transient_failures=N`` stops on error N, absorbing N-1.
+
+    The boundary ``poll_native_status`` has today and
+    ``test_gives_up_at_max_transient_failures`` pins. Preserved rather than
+    corrected: drifting it here would change every connector's tolerance the
+    moment child D rewires the loop, invisibly. Normalising it is on FND-240.
+    """
+    script = Script([Blip()])
+    with fake_clock():
+        outcome = await poll_until(
+            script,
+            settled=_settled("done"),
+            transient=_absorb_all,
+            budget=_budget(max_transient_failures=3),
+            label="the run",
+        )
+    assert isinstance(outcome, Indeterminate)
+    assert isinstance(outcome.cause, Blip)
+    assert outcome.transient_failures == 3
+    assert script.calls == 3
+
+
+async def test_a_success_resets_the_streak() -> None:
+    """A streak, not a total: a twenty-minute wait is not bounded by the sum of
+    the blips it survived."""
+    script = Script(
+        [Blip(), Blip(), Reading("running"), Blip(), Blip(), Reading("done")]
+    )
+    with fake_clock():
+        outcome = await poll_until(
+            script,
+            settled=_settled("done"),
+            transient=_absorb_all,
+            budget=_budget(max_transient_failures=3),
+            label="the run",
+        )
+    assert isinstance(outcome, Settled)
+
+
+async def test_zero_tolerance_ends_the_wait_on_the_first_error() -> None:
+    script = Script([Blip()])
+    with fake_clock():
+        outcome = await poll_until(
+            script,
+            settled=_settled("done"),
+            transient=_absorb_all,
+            budget=_budget(max_transient_failures=0),
+            label="the run",
+        )
+    assert isinstance(outcome, Indeterminate)
+    assert script.calls == 1
+
+
+async def test_a_budget_spent_without_one_reading_is_indeterminate() -> None:
+    """ "It did not finish in time" is a claim about the thing under test, and a
+    wait that never read it is not entitled to make one."""
+    script = Script([Blip()])
+    with fake_clock():
+        outcome = await poll_until(
+            script,
+            settled=_settled("done"),
+            transient=_absorb_all,
+            budget=_budget(max_transient_failures=999),
+            label="the run",
+        )
+    assert isinstance(outcome, Indeterminate)
+    assert isinstance(outcome.cause, Blip)
+
+
+async def test_an_indeterminate_still_carries_the_last_good_reading() -> None:
+    script = Script([Reading("running"), Blip()])
+    with fake_clock():
+        outcome = await poll_until(
+            script,
+            settled=_settled("done"),
+            transient=_absorb_all,
+            budget=_budget(max_transient_failures=2),
+            label="the run",
+        )
+    assert isinstance(outcome, Indeterminate)
+    assert outcome.last == Reading("running")
+
+
+async def test_a_cancellation_is_not_a_failed_read() -> None:
+    """``CancelledError`` must reach the task that sent it, even under a
+    classifier that would absorb anything it was offered."""
+
+    async def cancelling() -> Reading:
+        raise KeyboardInterrupt
+
+    with fake_clock():
+        with pytest.raises(KeyboardInterrupt):
+            await poll_until(
+                cancelling,
+                settled=_settled("done"),
+                transient=lambda _exc: timedelta(0),
+                budget=_budget(max_transient_failures=5),
+                label="the run",
+            )
+
+
+# ---------------------------------------------------------------------------
+# poll_until — honouring origin backoff
+# ---------------------------------------------------------------------------
+
+
+async def _blip_wait(clock_holder: list[FakeClock], **budget_kwargs: object) -> None:
+    script = Script([Blip(timedelta(seconds=30)), Reading("done")])
+    with fake_clock() as clock:
+        clock_holder.append(clock)
+        await poll_until(
+            script,
+            settled=_settled("done"),
+            transient=_absorb_all,
+            budget=_budget(max_transient_failures=5, **budget_kwargs),
+            label="the run",
+        )
+
+
+async def test_an_origin_backoff_replaces_the_poll_interval() -> None:
+    """An overloaded origin answering "retry_after: 30" must not burn the whole
+    failure streak inside its own wait window."""
+    clocks: list[FakeClock] = []
+    await _blip_wait(clocks, retry_after_budget=timedelta(seconds=300))
+    assert clocks[0].slept == [30.0]
+
+
+async def test_origin_backoff_is_ignored_without_a_retry_after_budget() -> None:
+    """``retry_after_budget=None`` is "honour no origin backoff" — one rule, so
+    it degrades to the fixed interval rather than needing a second branch."""
+    clocks: list[FakeClock] = []
+    await _blip_wait(clocks)
+    assert clocks[0].slept == [5.0]
+
+
+async def test_a_single_pathological_backoff_is_capped() -> None:
+    clocks: list[FakeClock] = []
+    script = Script([Blip(timedelta(seconds=900)), Reading("done")])
+    with fake_clock() as clock:
+        clocks.append(clock)
+        await poll_until(
+            script,
+            settled=_settled("done"),
+            transient=_absorb_all,
+            budget=_budget(
+                timeout=timedelta(seconds=600),
+                max_transient_failures=5,
+                retry_after_budget=timedelta(seconds=300),
+                max_retry_after=timedelta(seconds=120),
+            ),
+            label="the run",
+        )
+    assert clocks[0].slept == [120.0]
+
+
+async def test_the_retry_after_budget_bounds_the_total_honoured_waiting() -> None:
+    """Three 60s requests against a 100s above-the-interval allowance.
+
+    Only the *above-the-interval* part is charged, so a 60s gap spends 55: the
+    first request is honoured whole, the second is clamped to the 45 left, and
+    by the third there are 5 — exactly the fixed interval — so the honouring
+    degrades to the gap the loop already guaranteed rather than to nothing.
+    """
+    script = Script(
+        [
+            Blip(timedelta(seconds=60)),
+            Blip(timedelta(seconds=60)),
+            Blip(timedelta(seconds=60)),
+            Reading("done"),
+        ]
+    )
+    with fake_clock() as clock:
+        await poll_until(
+            script,
+            settled=_settled("done"),
+            transient=_absorb_all,
+            budget=_budget(
+                timeout=timedelta(seconds=600),
+                max_transient_failures=5,
+                retry_after_budget=timedelta(seconds=100),
+            ),
+            label="the run",
+        )
+    assert clock.slept == [60.0, 45.0, 5.0]
+
+
+async def test_honouring_a_backoff_can_only_lengthen_the_gap() -> None:
+    """A 1s request against a 5s interval keeps the 5s the loop guaranteed."""
+    script = Script([Blip(timedelta(seconds=1)), Reading("done")])
+    with fake_clock() as clock:
+        await poll_until(
+            script,
+            settled=_settled("done"),
+            transient=_absorb_all,
+            budget=_budget(
+                max_transient_failures=5, retry_after_budget=timedelta(seconds=300)
+            ),
+            label="the run",
+        )
+    assert clock.slept == [5.0]
+
+
+async def test_an_honoured_backoff_is_still_clamped_to_the_deadline() -> None:
+    """A 120s request against a 30s residual budget may not block for 120s."""
+    script = Script([Blip(timedelta(seconds=120))])
+    with fake_clock() as clock:
+        await poll_until(
+            script,
+            settled=_settled("done"),
+            transient=_absorb_all,
+            budget=_budget(
+                timeout=timedelta(seconds=30),
+                max_transient_failures=99,
+                retry_after_budget=timedelta(seconds=300),
+            ),
+            label="the run",
+        )
+    assert sum(clock.slept) <= 30
+
+
+# ---------------------------------------------------------------------------
+# poll_until — the heartbeat
+# ---------------------------------------------------------------------------
+
+
+async def test_the_heartbeat_is_silent_when_the_budget_silences_it() -> None:
+    script = Script([Reading("running")])
+    with (
+        patch("application_sdk.testing.harness._poll._log_heartbeat") as beat,
+        fake_clock(),
+    ):
+        await poll_until(
+            script, settled=_settled("done"), budget=_budget(), label="the run"
+        )
+    beat.assert_not_called()
+
+
+async def test_the_heartbeat_narrates_a_wait_that_says_nothing_else() -> None:
+    script = Script([Reading("running")])
+    with (
+        patch("application_sdk.testing.harness._poll._log_heartbeat") as beat,
+        fake_clock(),
+    ):
+        await poll_until(
+            script,
+            settled=_settled("done"),
+            budget=_budget(
+                timeout=timedelta(seconds=120), heartbeat=timedelta(seconds=30)
+            ),
+            label="the run",
+        )
+    # 120s of waiting at a 30s cadence, and the first poll is at zero elapsed so
+    # it does not count as one: 30s, 60s, 90s.
+    assert beat.call_count == 3
+    assert [call.args[0] for call in beat.call_args_list] == ["the run"] * 3
+
+
+# ---------------------------------------------------------------------------
+# hold_stable
+# ---------------------------------------------------------------------------
+
+
+async def test_a_hold_that_is_never_violated_spends_its_whole_budget() -> None:
+    """Success *is* the budget expiring with nothing having gone wrong."""
+    script = Script([Reading("two replicas")])
+    with fake_clock() as clock:
+        outcome = await hold_stable(
+            script,
+            invariant=lambda reading: reading.phase == "two replicas",
+            budget=_budget(),
+            label="worker replicas while the extract activity runs",
+        )
+    assert isinstance(outcome, Settled)
+    assert outcome.value == Reading("two replicas")
+    assert sum(clock.slept) == 55.0, "twelve probes, eleven gaps, inside 60s"
+
+
+async def test_the_first_violation_ends_the_hold_and_names_the_reading() -> None:
+    script = Script(
+        [Reading("two replicas"), Reading("two replicas"), Reading("scaled away")]
+    )
+    with fake_clock():
+        outcome = await hold_stable(
+            script,
+            invariant=lambda reading: reading.phase == "two replicas",
+            budget=_budget(),
+            label="worker replicas",
+        )
+    assert isinstance(outcome, Stalled)
+    assert outcome.last == Reading("scaled away")
+    assert "scaled away" in outcome.fingerprint
+    # How long it held before it broke — a flap at 10s and a flap at 19m are
+    # not the same report.
+    assert outcome.stall_window == timedelta(seconds=10)
+
+
+async def test_a_violating_reading_is_rendered_as_one_line() -> None:
+    script = Script([Reading("x" * 400)])
+    with fake_clock():
+        outcome = await hold_stable(
+            script, invariant=lambda _r: False, budget=_budget(), label="replicas"
+        )
+    assert isinstance(outcome, Stalled)
+    assert len(outcome.fingerprint) <= 120
+    assert outcome.fingerprint.endswith("…")
+
+
+async def test_an_unclassified_error_ends_a_hold_by_propagating() -> None:
+    script = Script([Bug()])
+    with fake_clock():
+        with pytest.raises(Bug):
+            await hold_stable(
+                script, invariant=lambda _r: True, budget=_budget(), label="replicas"
+            )
+
+
+async def test_a_hold_absorbs_blips_the_way_a_poll_does() -> None:
+    """The scenarios this exists for run over a VPN plus a vcluster tunnel,
+    where a reset connection mid-hold is routine."""
+    script = Script([Blip(), Blip(), Reading("steady")])
+    with fake_clock():
+        outcome = await hold_stable(
+            script,
+            invariant=lambda reading: reading.phase == "steady",
+            transient=_absorb_all,
+            budget=_budget(max_transient_failures=5),
+            label="replicas",
+        )
+    assert isinstance(outcome, Settled)
+
+
+async def test_a_hold_nobody_could_observe_is_not_a_hold_that_passed() -> None:
+    """ "Nothing went wrong" and "I did not look" are the same silence."""
+    script = Script([Blip()])
+    with fake_clock():
+        outcome = await hold_stable(
+            script,
+            invariant=lambda _r: True,
+            transient=_absorb_all,
+            budget=_budget(max_transient_failures=3),
+            label="replicas",
+        )
+    assert isinstance(outcome, Indeterminate)
+    assert outcome.transient_failures == 3
+
+
+async def test_a_hold_whose_every_probe_blipped_never_reports_settled() -> None:
+    """Tolerance high enough to absorb every blip must still not manufacture a
+    pass out of a window in which nothing was ever read."""
+    script = Script([Blip()])
+    with fake_clock():
+        outcome = await hold_stable(
+            script,
+            invariant=lambda _r: True,
+            transient=_absorb_all,
+            budget=_budget(max_transient_failures=999),
+            label="replicas",
+        )
+    assert isinstance(outcome, Indeterminate)

--- a/tests/unit/testing/harness/test_waiting.py
+++ b/tests/unit/testing/harness/test_waiting.py
@@ -94,6 +94,31 @@ class Script:
         return item
 
 
+@dataclass
+class NoneScript:
+    """A ``Probe[None]``: its *successful* reading is ``None``.
+
+    ``Probe[T]`` puts no bound on ``T``, so this is an ordinary probe, not a
+    pathological one — a cluster read answering "no such deployment", a status
+    field that is legitimately null. It exists here because it is the only shape
+    that can tell "I read a value" apart from "I never read one": under a
+    ``last_value is None`` test the two are identical.
+
+    Attributes:
+        readings: How many successful ``None`` readings before it starts failing.
+        calls: How many times the probe was called.
+    """
+
+    readings: int
+    calls: int = field(default=0)
+
+    async def __call__(self) -> None:
+        self.calls += 1
+        if self.calls > self.readings:
+            raise Blip()
+        return None
+
+
 def _budget(**overrides: object) -> Budget:
     """A 60s/5s budget — twelve polls — with the named fields overridden."""
     fields: dict[str, object] = {
@@ -440,6 +465,43 @@ async def test_a_budget_spent_without_one_reading_is_indeterminate() -> None:
     assert isinstance(outcome.cause, Blip)
 
 
+async def test_a_read_none_is_not_the_same_as_never_having_read() -> None:
+    """One successful ``None`` reading, then absorbed blips to the ceiling.
+
+    The wait *did* read its target, so the budget running out is ``Expired`` —
+    a claim about the thing under test that the wait has earned. Deciding on
+    ``last_value is None`` would report ``Indeterminate`` instead, disowning a
+    reading it actually took, because a legitimate ``None`` is spelled exactly
+    like "nothing was ever observed".
+    """
+    script = NoneScript(readings=1)
+    with fake_clock():
+        outcome = await poll_until(
+            script,
+            settled=lambda _reading: False,
+            transient=_absorb_all,
+            budget=_budget(max_transient_failures=999),
+            label="the run",
+        )
+    assert isinstance(outcome, Expired)
+    assert script.calls > 1, "the blips after the reading are what trip the bug"
+
+
+async def test_a_probe_that_never_read_is_still_indeterminate() -> None:
+    """The other half of the pair: zero readings keeps the verdict honest, so the
+    fix above cannot have been "always report Expired"."""
+    script = NoneScript(readings=0)
+    with fake_clock():
+        outcome = await poll_until(
+            script,
+            settled=lambda _reading: False,
+            transient=_absorb_all,
+            budget=_budget(max_transient_failures=999),
+            label="the run",
+        )
+    assert isinstance(outcome, Indeterminate)
+
+
 async def test_an_indeterminate_still_carries_the_last_good_reading() -> None:
     script = Script([Reading("running"), Blip()])
     with fake_clock():
@@ -715,6 +777,43 @@ async def test_a_hold_nobody_could_observe_is_not_a_hold_that_passed() -> None:
         )
     assert isinstance(outcome, Indeterminate)
     assert outcome.transient_failures == 3
+
+
+async def test_a_hold_over_none_readings_holds() -> None:
+    """Every reading is a legitimate ``None`` and the invariant accepts it.
+
+    So the hold held, for the whole budget, and the verdict is ``Settled`` with
+    ``None`` as its value. Deciding observation on ``last_value is None`` would
+    call this window unobservable and attach a synthetic ``RuntimeError`` to a
+    hold in which every single probe succeeded.
+    """
+    script = NoneScript(readings=1_000)
+    with fake_clock():
+        outcome = await hold_stable(
+            script,
+            invariant=lambda reading: reading is None,
+            budget=_budget(),
+            label="no deployment while the app is uninstalled",
+        )
+    assert isinstance(outcome, Settled)
+    assert outcome.value is None
+    assert outcome.attempts == 12, "it spent the whole budget rather than bailing"
+
+
+async def test_a_hold_over_none_readings_still_catches_a_violation() -> None:
+    """The pair to the above: an invariant that rejects ``None`` still stalls, so
+    the fix cannot have been "treat a None reading as always acceptable"."""
+    script = NoneScript(readings=1_000)
+    with fake_clock():
+        outcome = await hold_stable(
+            script,
+            invariant=lambda reading: reading is not None,
+            budget=_budget(),
+            label="a deployment exists",
+        )
+    assert isinstance(outcome, Stalled)
+    assert outcome.last is None
+    assert outcome.fingerprint == "None"
 
 
 async def test_a_hold_whose_every_probe_blipped_never_reports_settled() -> None:

--- a/tests/unit/testing/harness/test_waiting_equivalence.py
+++ b/tests/unit/testing/harness/test_waiting_equivalence.py
@@ -1,0 +1,375 @@
+"""``poll_until`` against ``poll_native_status``, on identical scripted readings.
+
+FND-227 is an *extraction*: the start-grace latch, the progress watchdog and the
+transient streak with its retry-after budget all already work — as interleaved
+statements inside ``AEWorkflowClient.poll_native_status``, coupled to the AE
+``native-status`` wire shape, the ``DAGNodeStatus`` vocabulary and a node-glyph
+summary string. Claiming the generic primitive preserves them needs evidence,
+and "the 58 existing client tests still pass" is not that evidence: those tests
+exercise the live loop, which this PR does not touch.
+
+So the evidence is differential. Each scenario below is one script — a list of
+readings and errors — fed to *both* loops:
+
+* the live one, through a patched ``get_native_status``;
+* :func:`~application_sdk.testing.harness.waiting.poll_until`, with the AE shape
+  supplied as the four callables the primitive takes in.
+
+Both run under :func:`~application_sdk.testing.harness._poll.fake_clock`, so the
+comparison covers three observable things and not just the answer: **which
+verdict, after how many probes, having slept exactly which gaps.** The sleep
+sequence is the load-bearing one — it is what catches a retry-after clamp, an
+off-by-one in the budget accounting or a lost interval floor, none of which
+change the verdict.
+
+The budget both sides run on is ``CONNECTOR_CI[Wait.AE_RUN]``, converted back to
+the live loop's keyword arguments. That makes this a check on the profile too: if
+child B's lift of those numbers were wrong, the two loops would diverge here.
+
+Re-expressing the live loop *on* the primitive is child D (FND-240) — its client
+is synchronous until child F converts it, and bridging a sync method onto an
+async primitive in the meantime would be a workaround built to be deleted. This
+file is what stands in for that proof until then, and it costs the connector path
+no diff at all.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from datetime import timedelta
+from unittest.mock import patch
+
+import pytest
+
+from application_sdk.errors import AppError
+from application_sdk.testing.e2e._errors import (
+    AtlanApiHttpError,
+    AtlanApiTimeoutError,
+    AutomationEngineNotDispatchingError,
+    DAGProgressStalledError,
+    NoWorkerOnTaskQueueError,
+)
+from application_sdk.testing.e2e.client import (
+    AEWorkflowClient,
+    DAGNodeResult,
+    DAGNodeStatus,
+    DAGRunResult,
+    DAGRunStatus,
+    _node_glyph,
+)
+from application_sdk.testing.harness._poll import fake_clock
+from application_sdk.testing.harness.budgets import CONNECTOR_CI, Wait
+from application_sdk.testing.harness.waiting import poll_until
+
+_RUN_ID = "test-run-123"
+_AE = CONNECTOR_CI.budgets[Wait.AE_RUN]
+
+#: The two vocabularies, side by side. Every live outcome — a returned result or
+#: a raised leaf — has exactly one harness verdict, and the mapping is the
+#: extraction's actual claim: four connector-specific leaves collapse to the
+#: three generic verdicts that carry the *diagnosis*, while the remediation
+#: advice those leaves exist for stays with them.
+_SAME_VERDICT = {
+    "terminal": "Settled",
+    "timed_out": "Expired",
+    NoWorkerOnTaskQueueError.__name__: "NeverStarted",
+    AutomationEngineNotDispatchingError.__name__: "NeverStarted",
+    DAGProgressStalledError.__name__: "Stalled",
+    # The streak gave up. The live loop re-raises the origin's own error; the
+    # primitive declines to call an unreadable dependency a verdict on the run.
+    AtlanApiHttpError.__name__: "Indeterminate",
+    # The budget expired without one usable response.
+    AtlanApiTimeoutError.__name__: "Indeterminate",
+}
+
+
+# ---------------------------------------------------------------------------
+# Building readings
+# ---------------------------------------------------------------------------
+
+
+def _result(run_status: DAGRunStatus, *node_statuses: DAGNodeStatus) -> DAGRunResult:
+    """One ``native-status`` reading with one node per given status."""
+    return DAGRunResult(
+        run_id=_RUN_ID,
+        workflow_slug="slug",
+        status=run_status,
+        nodes=[
+            DAGNodeResult(
+                name=f"node{index}",
+                status=status,
+                started_at_ms=None,
+                completed_at_ms=None,
+                error_message=None,
+            )
+            for index, status in enumerate(node_statuses)
+        ],
+    )
+
+
+def _blip(retry_after: float | None = None) -> AtlanApiHttpError:
+    """The 500 AE returns for a few seconds when the tenant's Temporal blips."""
+    return AtlanApiHttpError(
+        message="AE-COMMON-500-01: An unexpected error occurred",
+        target="GET /api/service/package-workflows/native-status HTTP 500",
+        retry_after_seconds=retry_after,
+    )
+
+
+Script = list[DAGRunResult | Exception]
+
+
+# ---------------------------------------------------------------------------
+# The AE shape, as the four callables the primitive takes in
+# ---------------------------------------------------------------------------
+
+
+def _ae_settled(result: DAGRunResult) -> bool:
+    return result.status.is_terminal
+
+
+def _ae_started(result: DAGRunResult) -> bool:
+    """A node has started once it leaves the not-started set.
+
+    The check is on node-level start, not the run status: the parent AE workflow
+    runs on the always-on automation-engine queue, so the run flips to
+    ``Running`` even when the connector's ``extract`` node is stuck because
+    nothing polls its task queue.
+    """
+    return any(not node.status.is_not_started for node in result.nodes)
+
+
+def _ae_fingerprint(result: DAGRunResult) -> str:
+    """The node-glyph summary the live loop already uses as its progress mark."""
+    return " ".join(_node_glyph(node) for node in result.nodes)
+
+
+def _ae_transient(exc: BaseException) -> timedelta | None:
+    """Absorb any ``AppError``, honouring an origin ``Retry-After``.
+
+    Rounding up is the classifier's job, not the primitive's: the live
+    ``_retry_gap`` takes ``math.ceil`` because its input is an HTTP header in
+    whole seconds, whereas the primitive is handed a ``timedelta`` and has no
+    business quantising it. Doing it here is what keeps the two gap sequences
+    identical.
+    """
+    if not isinstance(exc, AppError):
+        return None
+    requested = exc.retry_after_seconds if isinstance(exc, AtlanApiHttpError) else None
+    if requested is None or requested <= 0:
+        return timedelta(0)
+    return timedelta(seconds=math.ceil(requested))
+
+
+# ---------------------------------------------------------------------------
+# Running one script through both loops
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class Observed:
+    """What one loop did with a script — the whole comparable surface.
+
+    Attributes:
+        verdict: The harness verdict name, live outcomes mapped through
+            :data:`_SAME_VERDICT`.
+        attempts: How many times the loop probed.
+        slept: Every gap it slept, in order.
+    """
+
+    verdict: str
+    attempts: int
+    slept: tuple[float, ...]
+
+
+@dataclass
+class _Replay:
+    """Serves a script in order, repeating its last item forever."""
+
+    script: Script
+    calls: int = field(default=0)
+
+    def next(self) -> DAGRunResult:
+        item = self.script[min(self.calls, len(self.script) - 1)]
+        self.calls += 1
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+
+def _live(script: Script) -> Observed:
+    """Run the script through ``poll_native_status``."""
+    client = AEWorkflowClient(
+        tenant_url="https://tenant.example.com", api_token="tok-test"
+    )
+    replay = _Replay(script)
+    grace = _AE.start_grace
+    stall = _AE.stall_timeout
+    assert grace is not None and stall is not None, "the AE_RUN profile arms both"
+
+    with patch.object(
+        client, "get_native_status", side_effect=lambda _id: replay.next()
+    ):
+        with fake_clock() as clock:
+            try:
+                result = client.poll_native_status(
+                    _RUN_ID,
+                    interval_seconds=int(_AE.poll_interval.total_seconds()),
+                    timeout_seconds=int(_AE.timeout.total_seconds()),
+                    max_transient_failures=_AE.max_transient_failures,
+                    stall_grace_seconds=int(grace.total_seconds()),
+                    progress_stall_seconds=int(stall.total_seconds()),
+                    stall_task_queue="atlan-openapi-e2e-full-ci",
+                )
+            except AppError as error:
+                raised = type(error).__name__
+                return Observed(
+                    verdict=_SAME_VERDICT[raised],
+                    attempts=replay.calls,
+                    slept=tuple(clock.slept),
+                )
+            returned = "timed_out" if result.timed_out else "terminal"
+            return Observed(
+                verdict=_SAME_VERDICT[returned],
+                attempts=replay.calls,
+                slept=tuple(clock.slept),
+            )
+
+
+async def _harness(script: Script) -> Observed:
+    """Run the same script through ``poll_until``, AE shape passed in."""
+    replay = _Replay(script)
+
+    async def probe() -> DAGRunResult:
+        return replay.next()
+
+    with fake_clock() as clock:
+        outcome = await poll_until(
+            probe,
+            settled=_ae_settled,
+            started=_ae_started,
+            fingerprint=_ae_fingerprint,
+            transient=_ae_transient,
+            budget=_AE,
+            label=f"AE run {_RUN_ID}",
+        )
+    return Observed(
+        verdict=type(outcome).__name__,
+        attempts=outcome.attempts,
+        slept=tuple(clock.slept),
+    )
+
+
+# ---------------------------------------------------------------------------
+# The scripts
+# ---------------------------------------------------------------------------
+
+_RUNNING_NODE = _result(DAGRunStatus.RUNNING, DAGNodeStatus.RUNNING)
+_PENDING_NODE = _result(DAGRunStatus.RUNNING, DAGNodeStatus.PENDING)
+_NOT_DISPATCHED = _result(DAGRunStatus.PENDING, DAGNodeStatus.PENDING)
+_SUCCEEDED = _result(DAGRunStatus.SUCCEEDED, DAGNodeStatus.SUCCEEDED)
+_FAILED = _result(DAGRunStatus.FAILED, DAGNodeStatus.FAILED)
+
+#: Alternates its glyph summary every poll, so the watchdog never closes and the
+#: run reaches its ceiling still visibly progressing.
+_PROGRESSING: Script = [
+    _result(DAGRunStatus.RUNNING, DAGNodeStatus.RUNNING, status)
+    for _ in range(40)
+    for status in (DAGNodeStatus.PENDING, DAGNodeStatus.RUNNING)
+]
+
+_SCENARIOS: dict[str, Script] = {
+    "settles-immediately": [_SUCCEEDED],
+    "settles-after-progress": [_RUNNING_NODE, _RUNNING_NODE, _SUCCEEDED],
+    "settles-on-a-failed-run": [_RUNNING_NODE, _FAILED],
+    "no-node-ever-starts": [_PENDING_NODE],
+    "the-run-is-never-dispatched": [_NOT_DISPATCHED],
+    "started-then-frozen": [_RUNNING_NODE],
+    "progressing-past-the-ceiling": _PROGRESSING,
+    "blips-below-the-streak": [_blip(), _blip(), _blip(), _blip(), _SUCCEEDED],
+    "the-streak-gives-up": [_blip()],
+    "a-blip-that-asks-for-a-backoff": [_blip(retry_after=30), _SUCCEEDED],
+    "a-backoff-request-below-the-interval": [_blip(retry_after=2), _SUCCEEDED],
+    "a-pathological-backoff-request": [_blip(retry_after=900), _SUCCEEDED],
+    "a-fractional-backoff-request": [_blip(retry_after=30.4), _SUCCEEDED],
+    "blips-that-each-ask-for-a-backoff": [
+        _blip(retry_after=120),
+        _blip(retry_after=120),
+        _blip(retry_after=120),
+        _SUCCEEDED,
+    ],
+    "a-blip-then-progress-then-more-blips": [
+        _blip(),
+        _blip(),
+        _RUNNING_NODE,
+        _blip(),
+        _blip(),
+        _SUCCEEDED,
+    ],
+}
+
+
+@pytest.mark.parametrize("name", sorted(_SCENARIOS))
+async def test_the_primitive_and_the_live_loop_agree(name: str) -> None:
+    """Same script, same verdict, same probe count, same sleep sequence."""
+    script = _SCENARIOS[name]
+    assert await _harness(script) == _live(script)
+
+
+# ---------------------------------------------------------------------------
+# What the comparison would miss on its own
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("name", "verdict"),
+    [
+        ("settles-immediately", "Settled"),
+        ("no-node-ever-starts", "NeverStarted"),
+        ("the-run-is-never-dispatched", "NeverStarted"),
+        ("started-then-frozen", "Stalled"),
+        ("progressing-past-the-ceiling", "Expired"),
+        ("the-streak-gives-up", "Indeterminate"),
+    ],
+)
+async def test_each_verdict_is_actually_reached(name: str, verdict: str) -> None:
+    """Two loops agreeing on the wrong answer is still agreement.
+
+    Pinning the verdict each script is *supposed* to produce is what stops the
+    parametrised comparison above degenerating into "both returned ``Expired``,
+    because neither guard fired at all".
+    """
+    assert (await _harness(_SCENARIOS[name])).verdict == verdict
+
+
+async def test_a_non_apperror_propagates_from_both_loops() -> None:
+    """The classifier absorbs ``AppError`` and nothing else, matching the live
+    ``except AppError``: a deterministic bug in the probe must not be waited out.
+    """
+    with pytest.raises(ValueError):
+        await _harness([ValueError("a bug in the probe, not a blip")])
+    with pytest.raises(ValueError):
+        _live([ValueError("a bug in the probe, not a blip")])
+
+
+async def test_the_stall_verdict_names_the_summary_that_froze() -> None:
+    """The one field the connector leaf carried as prose and the verdict carries
+    as data — the reason ``Stalled`` is worth having at all."""
+    replay = _Replay([_RUNNING_NODE])
+
+    async def probe() -> DAGRunResult:
+        return replay.next()
+
+    with fake_clock():
+        outcome = await poll_until(
+            probe,
+            settled=_ae_settled,
+            started=_ae_started,
+            fingerprint=_ae_fingerprint,
+            transient=_ae_transient,
+            budget=_AE,
+            label=f"AE run {_RUN_ID}",
+        )
+    assert outcome.fingerprint == _ae_fingerprint(_RUNNING_NODE)  # type: ignore[union-attr]
+    assert outcome.stall_window == _AE.stall_timeout  # type: ignore[union-attr]


### PR DESCRIPTION
Child C of [FND-224](https://linear.app/atlan-epd/issue/FND-224). Closes [FND-227](https://linear.app/atlan-epd/issue/FND-227). Was stacked on #3435 (child B) and #3433 (child A); both are now merged, so this is rebased straight onto `main` and the diff is exactly its own: `waiting.py`, `outcome.py`'s two adapters, and the `_poll` move.

Three of the scaffold's stubs stop raising `HarnessNotBuiltError`: `poll_until`, `hold_stable`, `assert_settled`.

## `poll_until` — an extraction, and the proof it is one

Both guards already work. They are interleaved statements inside `poll_native_status`, coupled to the AE `native-status` wire shape, the `DAGNodeStatus` vocabulary, and a node-glyph summary *string* used as the progress fingerprint. The generic primitive underneath is *bounded poll + caller-supplied fingerprint + started/settled predicates + start-grace latch + no-change watchdog + transient streak with a retry-after budget*, and only the fingerprint and the predicates are instance-specific — so they are passed in.

**Nothing in `testing/e2e` calls it.** FND-240's description assigns "re-express `poll_native_status` on it" to this child, and it is deliberately not here: `AEWorkflowClient` is synchronous until child F converts it, so routing a sync method through an async primitive today means the `run_sync` bridge in a poll loop — a workaround built to be deleted, against D1 and against "delete v3-prep workarounds, don't preserve them as patterns". Consolidating the loops is child D, on an async client.

So the proof is differential instead, in `test_waiting_equivalence.py`. Fifteen scripts — readings and errors — are fed to **both** loops: the live one through a patched `get_native_status`, and `poll_until` with the AE shape supplied as its four callables. Both run under `fake_clock`, and the comparison is three things, not one:

**which verdict, after how many probes, having slept exactly which gaps.**

The sleep sequence is the load-bearing one — it catches a lost retry-after clamp, an off-by-one in the budget accounting or a dropped interval floor, none of which change the verdict. The budget both sides run on is `CONNECTOR_CI[Wait.AE_RUN]`, converted back into the live loop's keyword arguments, so this checks child B's lift of those numbers too.

That is stronger evidence than "the 58 existing client tests still pass" — those exercise the live loop, which this PR does not touch — and it costs the connector path no diff at all. A second parametrised test pins which verdict each script is *supposed* to reach, because two loops agreeing on the wrong answer is still agreement.

Verdicts reached, live and harness identical: `Settled` (3 probes), `NeverStarted` (19, at 180s), `Stalled` (31, at 300s), `Expired` (60, at 590s), `Indeterminate` (5).

### One behaviour deliberately preserved, warts included

`max_transient_failures=N` gives up on error **N**, absorbing N−1 — so `0` and `1` are the same instruction. That is `poll_native_status`'s boundary, pinned by `test_gives_up_at_max_transient_failures`. The field's scaffold docstring implied the cleaner "absorb N, fail on N+1"; correcting it here would change every connector's tolerance the moment child D rewires the loop, invisibly. Preserved, documented precisely, and added to FND-240's normalisation list.

### `Budget.max_retry_after`

`_retry_gap` clamps every single honoured wait at `_MAX_RETRY_AFTER_SECONDS = 120` inside the AE loop. `Budget` carried only the *total* (`retry_after_budget`) — `RequestBudget` had both. Adding the missing half keeps the guard where it cannot be forgotten rather than asking two classifiers to re-implement it, and `test_budgets.py` reads it back off the same constant as the rest of the profile.

The primitive does **not** round a requested backoff up to a whole second. `_retry_gap` does, because its input is an HTTP header; here it is a `timedelta` the classifier chose, and quantising someone else's duration is not the primitive's call. The AE classifier in the equivalence test does the `math.ceil`, which is what keeps the two gap sequences identical.

## `hold_stable` — new, and the one thing twelve loops cannot do

All twelve bounded loops in `testing/e2e/` are "wait until"; not one is "assert stays". Success is the budget expiring with nothing having gone wrong, so `budget.timeout` is a hold *duration*, not a deadline to race.

It returns `Stalled` on a violation — same "stopped being what it should be" shape, with `stall_window` as *how long it held before it broke*, because a flap at 10s and a flap at 19m are not the same report.

**Added to the sketched signature: `transient`.** These scenarios run out-of-cluster over a VPN plus a vcluster tunnel, where a reset connection mid-hold is routine; with no classifier the first blip ends a twenty-minute hold as `Indeterminate`. A hold that could not read its window still never reports `Settled` — "nothing went wrong" and "I did not look" are the same silence.

## The 2026-08-17 amendment

* **Transient classification is per backend.** It already is, structurally: the classifier is an argument, and `max_transient_failures` / `retry_after_budget` / `max_retry_after` are `Budget` fields. What this PR adds is the consequence — passing *no* classifier means "every probe error is a bug in the probe", right for an in-process read and wrong for a kubectl read over a tunnel — spelled out on the parameter rather than left implicit.
* **A failed read is `Indeterminate`.** `outcome.py` now cites the runtime suite's `crd_schema()` narrowing on **404 only** — a 403, an expired token or a timeout raises rather than caching a false negative — as the independent design that reached the same rule. Two designs landing on it separately is the strongest available evidence it is not a local preference.

Also: a budget that expires without one successful reading returns `Indeterminate`, not `Expired`. "It did not finish in time" is a claim about the thing under test, and a wait that never read it is not entitled to make one.

## `assert_settled` and `grade`

`assert_settled` maps each failing verdict to a typed leaf carrying that verdict's *fields*, not a rendered sentence. The category choices are the content: `NeverStarted` → `PRECONDITION` (matching both e2e leaves guarding that moment), `Indeterminate` → `DEPENDENCY_UNAVAILABLE` so a caller can separate "could not tell" from "told, and it was bad" on the category alone. `Stalled` → `TIMEOUT`, following `TaskStalledError`/ADR-0018; `DAGProgressStalledError` calls the same condition a `PRECONDITION` and keeps it, so no existing consumer sees a reclassification — that pair is on FND-240 too.

These are the *generic* leaves. `NoWorkerOnTaskQueueError` and friends stay exactly as they are: their value is the connector remediation advice in their messages, which is precisely what could not come along into a shared primitive.

`grade` is the precondition gate `outcome.py` assigned to this child. Two orderings, both load-bearing:

* a pass is never claimed over a read that did not happen — `Indeterminate`, and any `Finding` carrying `UNREADABLE`, block `PASSED`;
* a confirmed regression is never softened into "could not tell" — `FAILED` outranks `INDETERMINATE`, so one dropped tunnel elsewhere cannot bury a finding a *successful* read produced.

## `_poll` moved into the harness

`testing/e2e/_poll.py` → `harness/_poll.py`, which the scaffold's `waiting.py` docstring already assigned to this child. It has to move: child H re-expresses `testing/e2e` over the harness, and leaving the deadline loop on the e2e side would make that a `harness → e2e → harness` cycle. Private module, five in-repo call sites, import line only — no behaviour change, and its 33 tests pass unmoved.

## Verification

* **32 single-edit mutations, 31 caught.** Streak boundary off by one, streak never resetting, an unclassified error absorbed, cancellation swallowed as a failed read, the interval floor dropped, the single-wait cap ignored, the allowance charged wrongly in both directions, the latch turned into a level, the grace checked before a reading succeeded, the watchdog armed without a fingerprint, progress not resetting it, the stall window reporting total elapsed, the hold's invariant inverted, an unobserved hold reporting settled, and every `grade` precedence flip.
  * The one survivor is a **provably equivalent** mutant: `wanted <= 0` → `wanted < 0` in `_honoured_gap`. For `wanted == 0`, `max(floor, min(0, budget_left))` is already `floor`; for a negative, so is `max(floor, negative)`. The early return is a readability shortcut, not load-bearing.
  * The stall-window mutation survived the first run and is why `test_the_stall_window_is_the_quiet_gap_not_the_whole_wait` exists — every earlier stall test froze from the first reading, where the two numbers coincide.
* `uv run pre-commit run --files ...` — clean (ruff, ruff-format, isort, pyright)
* Full unit suite — **8,281 passed, 9 skipped**, +75 net over #3435, exactly the new tests minus the three retired stub assertions
* `harness/**` coverage **100%**, unchanged from #3435 — including all 114 statements in `waiting.py`
* `atlan-application-sdk-conformance detect` — **zero findings** in any file this PR touches
* `docs/agents/sdk-capabilities.md` regenerated via `uv run poe regen-capabilities` (pinned `griffe==2.1.0`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

