### PR TITLE
feat(testing): land the Temporal readers for pollers and workflow status (FND-247)

### DIFF
--- a/application_sdk/testing/harness/__init__.py
+++ b/application_sdk/testing/harness/__init__.py
@@ -50,7 +50,18 @@ Module map:
     rather than wrapping it. ``kubectl`` survives there only as transport, for
     the port-forward that reaches an app handler Service.
 ``temporal``
-    Read-only Temporal Protocol — pollers and workflow status.
+    Read-only Temporal Protocol — pollers and workflow status — and the
+    ``temporalio`` backend behind it. The poller read makes an *observation*
+    available where ``NoWorkerOnTaskQueueError`` currently reasons from three
+    minutes of silence; it does not yet replace it. Nothing in ``testing/e2e``
+    calls this module, and it was not lifted from code in this repo — the poller
+    half re-expresses ``suite/ports/temporal.py`` in
+    ``atlanhq/app-runtime-test-suite``, so its unit tests are a golden table for
+    the plain reason that there is no local original to run a differential
+    against. Not the only module here whose pin is a captured table, and not a
+    claim that it is: see the provenance paragraph below. Adopting it in
+    ``poll_native_status`` is child H's, with the rest of the re-expression.
+    No extra to install: ``temporalio`` has been a core dependency since v3.1.
 ``atlas``
     Atlas reads, split out of ``testing/e2e/client.py`` — async, one client per
     batch, and an unreadable search reported as a verdict rather than as zero.
@@ -63,8 +74,8 @@ Module map:
     Purge mechanics, including the batching that is a correctness bound.
 
 ``bridge``, ``waiting``, ``outcome``, ``spec``, ``budgets``, ``expectations``,
-``identity``, ``atlas``, ``automation_engine`` and ``cluster`` are real; the rest
-are typed stubs, each naming the child issue that fills it in.
+``identity``, ``atlas``, ``automation_engine``, ``cluster`` and ``temporal`` are
+real; the rest are typed stubs, each naming the child issue that fills it in.
 
 ``atlas`` and ``automation_engine`` are the first two that ``testing/e2e``
 actually calls: since child F, ``AEWorkflowClient`` is a set of one-line

--- a/application_sdk/testing/harness/cluster/_portforward.py
+++ b/application_sdk/testing/harness/cluster/_portforward.py
@@ -55,16 +55,37 @@ _PORT_READY_TIMEOUT_SECONDS = 10.0
 #: Grace given to ``kubectl`` to exit after ``terminate()`` before it is killed.
 _TERMINATE_GRACE_SECONDS = 5.0
 
+#: Local end of every tunnel. ``kubectl port-forward`` binds loopback by
+#: default, and the address is handed to callers verbatim, so it is named once
+#: rather than formatted in two places that could disagree.
+_LOCAL_HOST = "127.0.0.1"
+
 
 def _find_free_port() -> int:  # pragma: no cover — binds a real socket
-    """Bind to port 0 to let the OS pick a free port, return it.
+    """Bind port 0 on loopback to let the OS pick a free port, and return it.
+
+    Loopback rather than every interface because that is the interface whose port
+    actually has to be free: ``kubectl port-forward`` binds its local end to
+    loopback, which is what :func:`_wait_for_port` and the client's ``base_url``
+    both already assume. Probing ``""`` asked a broader question than the tunnel
+    needs, and tripped CodeQL's all-interfaces bind rule on a socket that is
+    never listened on.
+
+    What this is **not** is a correctness fix, and the distinction is worth
+    keeping because the plausible version of it is wrong. ``("", 0)`` could not
+    hand back a port that loopback then refused: a TCP bind conflicts
+    symmetrically in both directions — a loopback-held port refuses an
+    all-interfaces bind and an all-interfaces-held port refuses a loopback one
+    (checked on macOS, ``errno 48`` each way) — so the kernel's ephemeral choice avoided
+    conflicts whichever address it was given. The change buys a truthful
+    expression of the constraint and a quiet scanner, not a fixed bug.
 
     Exempt from unit coverage rather than untested: the unit suite runs with
     ``--disable-socket``, so the only place this can execute is
     ``tests/integration/testing/test_portforward.py``, which does.
     """
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind(("", 0))  # noqa: S104 — intentional: OS picks free port on all interfaces
+        s.bind((_LOCAL_HOST, 0))
         return s.getsockname()[1]
 
 
@@ -100,7 +121,9 @@ class PortForward:
 
     Obtained from :func:`port_forward`, which owns its lifetime. Not constructed
     directly: a tunnel that nothing closes leaks a ``kubectl`` process for the
-    rest of the test session.
+    rest of the test session. The one exception is a caller that needs the
+    tunnel's address to outlive any ``with`` block — see :meth:`address` — and
+    owning it in that case means calling :meth:`aclose`.
 
     Args:
         namespace: Namespace the Service is in.
@@ -132,11 +155,19 @@ class PortForward:
         self.kube_context = kube_context
         self._proc: asyncio.subprocess.Process | None = None
         self._client: httpx.AsyncClient | None = None
-        # Guards the lazy open: `_opened` is check-then-act, so two concurrent
-        # `request()` calls on one session could each spawn a `kubectl` and only
-        # one would be recorded — leaking the other for the rest of the session.
-        # Normal use is sequential (one tunnel per `port_forward()`/`http()`),
-        # but a leaked subprocess is not the kind of thing to leave to usage.
+        self._local_port: int | None = None
+        # Guards the lazy open, which is check-then-act: two concurrent callers
+        # could each spawn a `kubectl` and only one would be recorded — leaking
+        # the other for the rest of the session. Normal use is sequential (one
+        # tunnel per `port_forward()`/`http()`), but a leaked subprocess is not
+        # the kind of thing to leave to usage.
+        #
+        # One lock, two lazy-open entry points since FND-247: `_opened` for the
+        # HTTP client and `address` for the raw target. Each takes this lock for
+        # its whole job rather than sharing a helper that takes it — a guard on
+        # `_opened` alone would let `address()` race `request()` into two
+        # processes, and routing `_opened` through `_tunnel` would need two
+        # acquisitions and reopen the window between them.
         self._opening = asyncio.Lock()
 
     async def request(
@@ -199,21 +230,49 @@ class PortForward:
         await self.aclose()
         return await _send()
 
-    async def _opened(self) -> httpx.AsyncClient:
-        """Return the tunnel's client, opening the tunnel if it is not up.
+    async def address(self) -> str:
+        """Return the tunnel's local ``host:port``, opening the tunnel if needed.
 
-        The double check around the lock is deliberate: the common path is a
-        tunnel that is already up, and taking a lock to discover that would put
-        every request through a serialisation point it does not need.
+        For a client this class cannot make the call for. ``temporalio`` speaks
+        gRPC and takes a bare ``host:port`` target
+        (:mod:`application_sdk.testing.harness.temporal`), so the Temporal reader
+        needs the tunnel's near end rather than an HTTP session over it — and a
+        second implementation of "shell out, find a free port, wait for it to
+        accept" is exactly the divergence this module was consolidated to end.
+
+        The caller owns the tunnel's lifetime in that case, which is the one
+        exception to "obtained from :func:`port_forward`": whatever holds the
+        address has to call :meth:`aclose` when it is finished, because the
+        address outlives any ``with`` block that produced it.
+
+        Returns:
+            ``127.0.0.1:{port}``, where the port is the OS-assigned local end.
+
+        Raises:
+            TimeoutError: If the tunnel's local port never accepted connections.
         """
-        if self._client is not None:
-            return self._client
-        async with self._opening:
-            if self._client is not None:
-                return self._client
-            return await self._open()
+        return f"{_LOCAL_HOST}:{await self._tunnel()}"
 
-    async def _open(self) -> httpx.AsyncClient:
+    async def _tunnel(self) -> int:
+        """Return the local port, spawning the tunnel if it is not up.
+
+        The raw-target entry point, for :meth:`address`. :meth:`_opened` does not
+        route through here — it holds the lock across its own spawn, for the
+        reason given there — so both entry points serialise on the same lock and
+        each completes its whole job inside one critical section.
+
+        The double check is deliberate: the common path is a tunnel that is
+        already up, and taking a lock to discover that would put every call
+        through a serialisation point it does not need.
+        """
+        if self._local_port is not None:
+            return self._local_port
+        async with self._opening:
+            if self._local_port is not None:
+                return self._local_port
+            return await self._spawn()
+
+    async def _spawn(self) -> int:
         """Spawn the tunnel and wait for its local port. Callers hold the lock."""
         local_port = _find_free_port()
         self._proc = await asyncio.create_subprocess_exec(
@@ -235,19 +294,76 @@ class PortForward:
         except BaseException:
             # The process is already running; leaving it behind on a failed
             # readiness wait is the leak this except exists to prevent.
+            #
+            # This call is also why `aclose` must never take `self._opening`:
+            # we are holding it right now. See the warning on `aclose`.
             await self.aclose()
             raise
-        self._client = httpx.AsyncClient(
-            base_url=f"http://127.0.0.1:{local_port}", timeout=self.timeout
-        )
-        return self._client
+        self._local_port = local_port
+        return local_port
+
+    async def _opened(self) -> httpx.AsyncClient:
+        """Return the tunnel's client, opening the tunnel if it is not up.
+
+        Spawns the tunnel and builds the client inside **one** acquisition, by
+        calling :meth:`_spawn` directly rather than going through
+        :meth:`_tunnel`. Two acquisitions would be the obvious composition and it
+        is wrong: :class:`asyncio.Lock` is not reentrant, so the lock cannot be
+        held across a call that takes it, and the handoff between them leaves a
+        window where an :meth:`aclose` can terminate the ``kubectl`` this client
+        is about to be pointed at. One critical section closes *that* window, at
+        the cost of repeating the port check.
+
+        It does **not** make open-vs-close atomic: :meth:`aclose` takes no lock,
+        so a close concurrent with this critical section can still strand a fresh
+        client on a terminated process. That residue is deliberate, and the
+        tempting fix for it deadlocks — see the warning on :meth:`aclose`, which
+        is where someone would go to make the mistake.
+
+        The client is guarded as well as the process for the smaller version of
+        the same reason: a dropped :class:`httpx.AsyncClient` leaks a connection
+        pool.
+        """
+        if self._client is not None:
+            return self._client
+        async with self._opening:
+            if self._client is not None:
+                return self._client
+            local_port = self._local_port
+            if local_port is None:
+                local_port = await self._spawn()
+            self._client = httpx.AsyncClient(
+                base_url=f"http://{_LOCAL_HOST}:{local_port}", timeout=self.timeout
+            )
+            return self._client
 
     async def aclose(self) -> None:
         """Close the HTTP client and terminate the ``kubectl`` process.
 
         Idempotent, and safe to call on a tunnel that never opened.
+
+        .. warning::
+            **Do not guard this with** :attr:`_opening`. It is the obvious way to
+            close the residual open-vs-close race — a concurrent ``aclose`` can
+            still land mid-open — and it **deadlocks**: :meth:`_spawn` runs with
+            the lock held and calls this from its readiness-failure path, so a
+            lock here would wait on one the same task already owns
+            (:class:`asyncio.Lock` is not reentrant).
+
+            The failure mode is what earns this a warning rather than a comment:
+            every happy-path test passes, and the hang arrives the first time a
+            port never comes up — the unhappy path, in production, on a day
+            something else is already wrong.
+
+            The residue is left open deliberately. A caller closing a session
+            while another task is still using it is doing something odd, and the
+            transport retry in :meth:`request` rebuilds a tunnel closed
+            underneath it. Closing it properly needs a locked public ``aclose``
+            over an unlocked internal one — more machinery than a self-healing
+            race is worth.
         """
         client, self._client = self._client, None
+        self._local_port = None
         if client is not None:
             await client.aclose()
         proc, self._proc = self._proc, None

--- a/application_sdk/testing/harness/temporal/__init__.py
+++ b/application_sdk/testing/harness/temporal/__init__.py
@@ -1,124 +1,98 @@
-"""Read-only Protocol over Temporal, plus the states it returns.
+"""Read-only Protocol over Temporal, the states it returns, and its backend.
 
-Neither reader exists in ``testing/e2e/`` today, and the gap is load-bearing:
-:class:`~application_sdk.testing.e2e._errors.NoWorkerOnTaskQueueError` is
-currently *inferred* — "no DAG node started inside the grace window, so probably
-nothing is polling the queue". A real poller read makes it **observed**, which
-turns the single most common harness wedge (a suite whose ``agent_spec()``
-queue does not match the deployed worker's) from a 180-second guess into a fact.
+Neither reader existed in ``testing/e2e/`` before FND-247, and the gap is
+load-bearing: ``testing.e2e``'s ``NoWorkerOnTaskQueueError`` is currently
+*inferred* — "no DAG node started inside the grace window, so probably nothing is
+polling the queue". A real poller read makes that **observable**, which is what
+downgrades the single most common harness wedge (a suite whose ``agent_spec()``
+queue does not match the deployed worker's) from a 180-second guess to a fact
+available on the first probe. The largest regression class it catches has no
+other detector at all: a queue name that is well formed and refers to nothing,
+where every string comparison passes and the queue simply does not exist.
+
+**Available, not yet adopted.** ``poll_native_status`` still infers, and nothing
+in ``testing/e2e`` calls this module — swapping the inference for the read is
+child H's, with the rest of the re-expression. The distinction is worth keeping
+straight in both directions: claiming the upgrade here would misreport the state
+of the tree, and describing this module as merely optional would understate why
+the read has to exist before that swap can happen.
 
 Read-only, like :mod:`application_sdk.testing.harness.cluster`, and for the same
-reason: scenario-side mutation stays scenario-side.
+reason: scenario-side mutation stays scenario-side. Starting work already has a
+home in :mod:`application_sdk.testing.harness.starters`, and a reader that could
+also terminate would be the one surface where a probe inside a bounded wait could
+change the thing it is measuring.
 
-Implementation lands as a separate issue outside FND-224, per the decomposition —
-this module scaffolds the vocabulary its callers are written against.
+**Two answers, three leaves.** Both reads refuse the fail-open shape, and the
+poller read refuses it hardest: an empty poller list is the finding, so a failure
+that answered empty would fabricate a diagnosis rather than merely lose one.
+Every failure raises — ``DEPENDENCY_UNAVAILABLE`` for a frontend that could not
+be reached or could not answer, which a bounded wait's transient classifier turns
+into :class:`~application_sdk.testing.harness.outcome.Indeterminate`, and
+``NOT_FOUND`` for a workflow id that does not exist, which is deliberately *not*
+retryable so a wait fails on a typo at once instead of spending its budget on it.
+
+**No extra to declare, and nothing to import-guard.** FND-247's amendment
+expected ``temporalio`` to be optional behind ``[workflows]`` and these readers
+to be guarded accordingly. It is a *core* dependency since v3.1 and
+``[workflows]`` is a backwards-compatibility alias resolving to it, so unlike
+``cluster``'s ``harness`` extra there is nothing to guard — and no cost to defer
+either, since ``application_sdk.testing``'s own package ``__init__`` already
+imports the client and its protos before any harness module is reached.
+
+Module map:
+
+``_states``
+    :class:`PollerInfo`, :class:`WorkflowStatus`,
+    :class:`WorkflowExecutionStatus`, :class:`TaskQueueType`, and the one pure
+    predicate over them, :func:`stale_version_pollers`.
+``_protocols``
+    :class:`TemporalReader`.
+``client``
+    :class:`TemporalServiceReader` and the two connection factories,
+    :func:`frontend_connection` and :func:`port_forwarded_connection`.
+``_errors``
+    The three leaves a read can raise before there is a verdict.
 """
 
-from __future__ import annotations
-
-from collections.abc import Sequence
-from dataclasses import dataclass
-from datetime import datetime
-from enum import Enum
-from typing import Protocol, runtime_checkable
+from application_sdk.testing.harness.temporal._errors import (
+    TemporalConnectFailedError,
+    TemporalReaderLoopMismatchError,
+    TemporalReadFailedError,
+    WorkflowNotFoundError,
+)
+from application_sdk.testing.harness.temporal._protocols import TemporalReader
+from application_sdk.testing.harness.temporal._states import (
+    PollerInfo,
+    TaskQueueType,
+    WorkflowExecutionStatus,
+    WorkflowStatus,
+    stale_version_pollers,
+)
+from application_sdk.testing.harness.temporal.client import (
+    TemporalConnection,
+    TemporalServiceReader,
+    frontend_connection,
+    port_forwarded_connection,
+)
 
 __all__ = [
-    "PollerInfo",
+    # Protocol
     "TemporalReader",
+    # States, and the one predicate over them
+    "PollerInfo",
+    "TaskQueueType",
     "WorkflowExecutionStatus",
     "WorkflowStatus",
+    "stale_version_pollers",
+    # The backend, and where its credentials come from
+    "TemporalConnection",
+    "TemporalServiceReader",
+    "frontend_connection",
+    "port_forwarded_connection",
+    # Leaves
+    "TemporalConnectFailedError",
+    "TemporalReadFailedError",
+    "TemporalReaderLoopMismatchError",
+    "WorkflowNotFoundError",
 ]
-
-
-class WorkflowExecutionStatus(str, Enum):
-    """Terminal and non-terminal states a workflow execution can report.
-
-    Mirrors Temporal's own ``WorkflowExecutionStatus`` rather than inventing a
-    parallel vocabulary — the harness's job is to report what Temporal says.
-    """
-
-    RUNNING = "Running"
-    COMPLETED = "Completed"
-    FAILED = "Failed"
-    CANCELED = "Canceled"
-    TERMINATED = "Terminated"
-    CONTINUED_AS_NEW = "ContinuedAsNew"
-    TIMED_OUT = "TimedOut"
-
-
-@dataclass(frozen=True, slots=True, kw_only=True)
-class PollerInfo:
-    """One worker seen polling a task queue.
-
-    Attributes:
-        identity: The worker's self-reported identity, usually
-            ``{pid}@{hostname}``. This is what tells "the wrong worker is
-            polling" from "nothing is polling".
-        last_access: When Temporal last saw this poller.
-        build_id: Worker build identifier, when versioning is in use. Names the
-            specific build holding the queue — the shape behind an older build
-            keeping the pollers while the current one sits at zero.
-    """
-
-    identity: str
-    last_access: datetime
-    build_id: str | None = None
-
-
-@dataclass(frozen=True, slots=True, kw_only=True)
-class WorkflowStatus:
-    """One workflow execution's state.
-
-    Attributes:
-        workflow_id: The workflow ID asked about.
-        run_id: The specific run this status describes.
-        status: Execution status as Temporal reports it.
-        task_queue: Queue the execution is dispatched on. Exposed because the
-            queue-name seam — ``atlan-{application}-{deployment}``, derived
-            independently in several places — is checkable here without a pod
-            exec.
-        started_at: When the execution started.
-        closed_at: When it reached a terminal state, or ``None`` while running.
-    """
-
-    workflow_id: str
-    run_id: str
-    status: WorkflowExecutionStatus
-    task_queue: str
-    started_at: datetime | None = None
-    closed_at: datetime | None = None
-
-
-@runtime_checkable
-class TemporalReader(Protocol):
-    """Read Temporal state. No mutation, by decision."""
-
-    async def task_queue_pollers(
-        self, queue: str, *, namespace: str
-    ) -> Sequence[PollerInfo]:
-        """Return the workers Temporal currently sees polling *queue*.
-
-        Args:
-            queue: Task-queue name.
-            namespace: Temporal namespace.
-
-        Returns:
-            One :class:`PollerInfo` per poller. **Empty is a real answer** — it
-            is the observed form of "no worker on this task queue", and the
-            caller should report it as such rather than retrying into a timeout.
-        """
-        ...
-
-    async def workflow_status(
-        self, workflow_id: str, *, run_id: str | None = None
-    ) -> WorkflowStatus:
-        """Return the state of one workflow execution.
-
-        Args:
-            workflow_id: Workflow ID to describe.
-            run_id: Specific run, or ``None`` for the latest run of that ID.
-
-        Returns:
-            The execution's :class:`WorkflowStatus`.
-        """
-        ...

--- a/application_sdk/testing/harness/temporal/_errors.py
+++ b/application_sdk/testing/harness/temporal/_errors.py
@@ -1,0 +1,167 @@
+"""Typed error leaves for the Temporal reader.
+
+Private module: the leaves that are public surface are re-exported from
+:mod:`application_sdk.testing.harness.temporal`. Mirrors
+:mod:`application_sdk.testing.harness.cluster._errors`.
+
+Three leaves, and the split between them is the whole design:
+
+* the frontend could not be reached at all
+  (:class:`TemporalConnectFailedError`),
+* it was reached and answered, but not with an answer
+  (:class:`TemporalReadFailedError`),
+* it answered, and the answer is that there is no such execution
+  (:class:`WorkflowNotFoundError`).
+
+The first two are ``DEPENDENCY_UNAVAILABLE``, so a bounded wait's transient
+classifier absorbs them and the wait reports
+:class:`~application_sdk.testing.harness.outcome.Indeterminate` — "could not
+look" rather than "looked and it was bad". The third is ``NOT_FOUND`` and
+deliberately *not* retryable: a workflow id that does not exist is a wrong id, a
+wrong namespace or a purged run, and none of those changes while a wait sleeps.
+Folding it into the first two would spend a whole 25-minute budget on a typo and
+then report it as a Temporal outage.
+
+What none of the three may become is an empty poller list. That is the fail-open
+shape this package exists to remove, and it is worse here than in the cluster
+readers: an empty list is exactly the finding
+:meth:`~application_sdk.testing.harness.temporal.TemporalReader.task_queue_pollers`
+exists to deliver, so a failure answering empty would not just lose information —
+it would fabricate the diagnosis.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import ClassVar
+
+from application_sdk.errors.leaves import (
+    DependencyUnavailableError,
+    NotFoundError,
+    PreconditionError,
+)
+
+__all__ = [
+    "TemporalConnectFailedError",
+    "TemporalReadFailedError",
+    "TemporalReaderLoopMismatchError",
+    "WorkflowNotFoundError",
+]
+
+
+@dataclass(kw_only=True)
+class TemporalConnectFailedError(DependencyUnavailableError):
+    """Could not establish a client against the Temporal frontend.
+
+    Distinct from :class:`TemporalReadFailedError` because the fix is different:
+    nothing was read, and nothing about the namespace is known — including
+    whether the address is even the right one. The address is carried as a field
+    so a run pointed at the wrong frontend says so in the failure rather than
+    leaving it to be inferred from a gRPC message.
+
+    Attributes:
+        address: ``host:port`` the connection was attempted against.
+        temporal_namespace: Namespace the client was being bound to. Named for
+            Temporal explicitly: a harness failure mentioning an unqualified
+            "namespace" next to a Kubernetes reader is a genuine ambiguity.
+    """
+
+    code: ClassVar[str] = "DEPENDENCY_UNAVAILABLE_TEMPORAL_CONNECT_FAILED"
+    component: str | None = "harness_temporal"
+    service: str | None = "temporal"
+    address: str | None = None
+    temporal_namespace: str | None = None
+
+
+@dataclass(kw_only=True)
+class TemporalReadFailedError(DependencyUnavailableError):
+    """A Temporal read reached the frontend and did not come back with data.
+
+    ``DEPENDENCY_UNAVAILABLE`` for the reason
+    :class:`~application_sdk.testing.harness.cluster.ClusterReadFailedError` is:
+    an ``UNAVAILABLE`` from a restarting frontend, a ``DEADLINE_EXCEEDED`` over a
+    VPN or an expired token is neither a pass nor a regression in the thing under
+    test, and this is the category whose definition is "the same call would work
+    once the dependency recovers".
+
+    Attributes:
+        rpc_status: gRPC status name the frontend returned, e.g.
+            ``"UNAVAILABLE"``. A name rather than a number because it is what the
+            reader of a report recognises, and ``None`` when the call failed
+            before any status came back.
+        address: ``host:port`` the read went through, so a run against the wrong
+            frontend is visible in the failure.
+        temporal_namespace: Namespace the read was scoped to.
+    """
+
+    code: ClassVar[str] = "DEPENDENCY_UNAVAILABLE_TEMPORAL_READ_FAILED"
+    component: str | None = "harness_temporal"
+    service: str | None = "temporal"
+    rpc_status: str | None = None
+    address: str | None = None
+    temporal_namespace: str | None = None
+
+
+@dataclass(kw_only=True)
+class WorkflowNotFoundError(NotFoundError):
+    """Temporal has no execution under this workflow ID.
+
+    ``NOT_FOUND`` rather than ``DEPENDENCY_UNAVAILABLE``, and that is the
+    load-bearing choice: ``NotFoundError`` is ``default_retryable = False``, so a
+    transient classifier keyed on retryability leaves it alone and the wait fails
+    at once instead of burning its budget. A wrong workflow id, a wrong namespace
+    and a run past its retention window are all states that must change before
+    the call can succeed, which is the litmus test.
+
+    A caller that is *waiting for* an execution to appear should not be catching
+    this at all — it wants the nullable read
+    (:meth:`~application_sdk.testing.harness.temporal.TemporalServiceReader.find_workflow_status`),
+    where absence is a value its predicate can test.
+
+    Attributes:
+        workflow_id: The workflow ID that had no execution.
+        run_id: The specific run asked for, or ``None`` when the latest run of
+            that ID was asked for.
+        temporal_namespace: Namespace that was searched. Carried because the
+            single most common cause of this leaf is a client bound to the wrong
+            namespace, and the message cannot be read as a queue-name problem
+            once the namespace is on the record.
+    """
+
+    code: ClassVar[str] = "NOT_FOUND_TEMPORAL_WORKFLOW"
+    component: str | None = "harness_temporal"
+    resource_type: str | None = "workflow_execution"
+    workflow_id: str | None = None
+    run_id: str | None = None
+    temporal_namespace: str | None = None
+
+
+@dataclass(kw_only=True)
+class TemporalReaderLoopMismatchError(PreconditionError):
+    """A connected reader was used from a different event loop than it opened on.
+
+    ``PRECONDITION`` on its own litmus test: retrying the same call changes
+    nothing, and the state that has to change first is that the existing
+    connection be closed. Raised rather than handled silently because the silent
+    handling leaks — a ``temporalio`` client is bound to its creating loop, so a
+    reader that rebound would drop the previous connection *without* awaiting its
+    close, and for a port-forwarded connection that close is what reaps a
+    ``kubectl`` child process.
+
+    Only raised when there is something to lose. A reader that has never
+    connected, or whose connection has already been closed, rebinds to the new
+    loop without complaint: there is no leak, so there is nothing to report.
+
+    The fix is almost never to close and reopen — it is to stop sharing one
+    reader across loops. :func:`~application_sdk.testing.harness.bridge.run_sync`
+    owns exactly one loop per thread, so a suite that reaches the reader only
+    through it never sees this.
+
+    Attributes:
+        address: ``host:port`` the existing connection is pointed at, so the
+            message names what would have been dropped.
+    """
+
+    code: ClassVar[str] = "PRECONDITION_TEMPORAL_READER_LOOP_MISMATCH"
+    component: str | None = "harness_temporal"
+    address: str | None = None

--- a/application_sdk/testing/harness/temporal/_protocols.py
+++ b/application_sdk/testing/harness/temporal/_protocols.py
@@ -1,0 +1,83 @@
+"""The read-only Temporal Protocol.
+
+Split out of the package ``__init__`` alongside :mod:`._states` when the backend
+landed (FND-247), for the reason
+:mod:`application_sdk.testing.harness.cluster._protocols` was: the backend
+imports this to declare what it satisfies. The name is re-exported from
+:mod:`application_sdk.testing.harness.temporal`, which stays the import path.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Protocol, runtime_checkable
+
+from application_sdk.testing.harness.temporal._states import PollerInfo, WorkflowStatus
+
+__all__ = ["TemporalReader"]
+
+
+@runtime_checkable
+class TemporalReader(Protocol):
+    """Read Temporal state. No mutation, by decision.
+
+    Read-only for the reason
+    :class:`~application_sdk.testing.harness.cluster.ClusterReader` is: the
+    scenario suite's mutations — starting work, terminating a leftover run — stay
+    scenario-side, and
+    :mod:`application_sdk.testing.harness.starters` already owns starting. A
+    reader that could also terminate would be the one surface where a probe
+    inside a bounded wait could change the thing it is measuring.
+
+    Every method is ``async`` (decision D1), which here costs nothing: unlike the
+    Kubernetes client, ``temporalio`` is asyncio-native, so the backend has no
+    offload to pay.
+    """
+
+    async def task_queue_pollers(
+        self, queue: str, *, namespace: str
+    ) -> Sequence[PollerInfo]:
+        """Return the workers Temporal currently sees polling *queue*.
+
+        Args:
+            queue: Task-queue name.
+            namespace: Temporal namespace. On the request rather than on the
+                connection because ``DescribeTaskQueue`` takes it there — see
+                :meth:`workflow_status`, which cannot offer the same parameter.
+
+        Returns:
+            One :class:`PollerInfo` per poller. **Empty is a real answer** — it
+            is the observed form of "no worker on this task queue", and the
+            caller should report it as such rather than retrying into a timeout.
+
+        Raises:
+            Exception: If the read failed. An unreadable frontend is never an
+                empty poller list — that fail-open shape is what FND-224's C4 is
+                about, and it matters more here than anywhere else in the
+                harness: empty is *the* diagnosis this read exists to deliver, so
+                a failure that answered empty would not merely be unhelpful, it
+                would manufacture the exact finding.
+        """
+        ...
+
+    async def workflow_status(
+        self, workflow_id: str, *, run_id: str | None = None
+    ) -> WorkflowStatus:
+        """Return the state of one workflow execution.
+
+        Args:
+            workflow_id: Workflow ID to describe.
+            run_id: Specific run, or ``None`` for the latest run of that ID.
+
+        Returns:
+            The execution's :class:`WorkflowStatus`.
+
+        Raises:
+            Exception: If there is no such execution, or if the read failed. The
+                two are distinguishable by type, and a backend must not collapse
+                them: "no such workflow" does not get better on retry, so a
+                bounded wait that absorbed it as transient would spend its whole
+                budget on a typo. A caller that is *waiting for* an execution to
+                appear wants a nullable read instead — the backend offers one.
+        """
+        ...

--- a/application_sdk/testing/harness/temporal/_states.py
+++ b/application_sdk/testing/harness/temporal/_states.py
@@ -1,0 +1,167 @@
+"""The typed states the Temporal reader returns, and the one predicate over them.
+
+Split out of the package ``__init__`` when the backend landed (FND-247), for the
+same reason :mod:`application_sdk.testing.harness.cluster._states` was: the
+backend module has to import these, and a package whose ``__init__`` both defines
+them *and* imports the backend is a cycle. Every name here is re-exported from
+:mod:`application_sdk.testing.harness.temporal`, which stays the import path.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+
+__all__ = [
+    "PollerInfo",
+    "TaskQueueType",
+    "WorkflowExecutionStatus",
+    "WorkflowStatus",
+    "stale_version_pollers",
+]
+
+
+class TaskQueueType(str, Enum):
+    """Which half of a task queue a poller is holding.
+
+    A Temporal task queue name addresses *two* queues — one for workflow tasks
+    and one for activity tasks — and a worker polls both. They are separate
+    ``DescribeTaskQueue`` reads, so "how many pollers does this queue have" has
+    no single answer, and collapsing the two into one count is what makes the
+    half-polling state invisible: a worker process whose workflow poll loop has
+    died while its activity poll loop is alive still answers "1 poller" to a
+    union count, which is exactly the zombie shape a harness exists to catch.
+    Every :class:`PollerInfo` therefore says which queue it was seen on.
+    """
+
+    WORKFLOW = "Workflow"
+    ACTIVITY = "Activity"
+    NEXUS = "Nexus"
+
+
+class WorkflowExecutionStatus(str, Enum):
+    """Terminal and non-terminal states a workflow execution can report.
+
+    Mirrors Temporal's own ``WorkflowExecutionStatus`` rather than inventing a
+    parallel vocabulary — the harness's job is to report what Temporal says.
+
+    :attr:`UNKNOWN` is the one member Temporal's Python enum has no counterpart
+    for: it models the proto's ``UNSPECIFIED``, which ``temporalio`` surfaces as
+    ``None``. It is here for the reason
+    :attr:`~application_sdk.testing.harness.cluster.PodPhase.UNKNOWN` is: a
+    status this SDK has never heard of is precisely what "unknown" means, and
+    raising on it would turn a new upstream status name into a harness crash.
+    """
+
+    RUNNING = "Running"
+    COMPLETED = "Completed"
+    FAILED = "Failed"
+    CANCELED = "Canceled"
+    TERMINATED = "Terminated"
+    CONTINUED_AS_NEW = "ContinuedAsNew"
+    TIMED_OUT = "TimedOut"
+    UNKNOWN = "Unknown"
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class PollerInfo:
+    """One worker seen polling a task queue.
+
+    Attributes:
+        identity: The worker's self-reported identity, usually
+            ``{pid}@{hostname}``. This is what tells "the wrong worker is
+            polling" from "nothing is polling".
+        last_access: When Temporal last saw this poller. An unset timestamp reads
+            as the Unix epoch, which is the safe direction for a staleness check:
+            a poller whose last access cannot be read must not read as fresh.
+        task_queue_type: Which half of the queue this poller was seen on — see
+            :class:`TaskQueueType` for why every poller carries it.
+        build_id: Worker build identifier, when versioning is in use. Names the
+            specific build holding the queue — the shape behind an older build
+            keeping the pollers while the current one sits at zero. ``None`` for
+            an unversioned worker, which :func:`stale_version_pollers` treats as
+            stale rather than as "no opinion".
+        deployment_name: Worker Deployment the build belongs to, when versioning
+            is in use. Carried alongside :attr:`build_id` because that is the
+            pair a Worker Deployment version is: this SDK's worker sets both
+            (``ATLAN_APP_DEPLOYMENT_NAME`` / ``ATLAN_APP_BUILD_ID``), so a build
+            id on its own cannot be matched against the deployment a
+            ``TemporalWorkerDeployment`` names.
+    """
+
+    identity: str
+    last_access: datetime
+    task_queue_type: TaskQueueType = TaskQueueType.WORKFLOW
+    build_id: str | None = None
+    deployment_name: str | None = None
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class WorkflowStatus:
+    """One workflow execution's state.
+
+    Attributes:
+        workflow_id: The workflow ID asked about.
+        run_id: The specific run this status describes.
+        status: Execution status as Temporal reports it.
+        task_queue: Queue the execution is dispatched on. Exposed because the
+            queue-name seam — ``atlan-{application}-{deployment}``, derived
+            independently in several places — is checkable here without a pod
+            exec.
+        history_length: Events in the execution's history so far. This is the
+            *progress* signal, and it is the reason the field exists: a wait on
+            :attr:`status` alone has nothing that changes between "running" and
+            "finished", so
+            :func:`~application_sdk.testing.harness.waiting.poll_until` could
+            only ever report that wait as ``Expired``. A history length that
+            stops growing is what makes ``Stalled`` — "it started and then
+            stopped moving" — available as a verdict at all.
+        started_at: When the execution started.
+        closed_at: When it reached a terminal state, or ``None`` while running.
+    """
+
+    workflow_id: str
+    run_id: str
+    status: WorkflowExecutionStatus
+    task_queue: str
+    history_length: int = 0
+    started_at: datetime | None = None
+    closed_at: datetime | None = None
+
+
+def stale_version_pollers(
+    pollers: Iterable[PollerInfo], *, current_build_id: str | None
+) -> Sequence[PollerInfo]:
+    """Return the pollers that are *not* on *current_build_id*.
+
+    The second half of the runtime suite's precondition gate — "the intended
+    version is Current, **and no stale-version workers are still polling**". The
+    first half is a
+    :meth:`~application_sdk.testing.harness.cluster.CustomResourceReader.custom_resources`
+    read of the ``TemporalWorkerDeployment`` that names the intended version, so
+    it needs nothing from this module.
+
+    Lifted from the Go harness's ``hasUnversionedPoller`` rather than left to the
+    call site, because the obvious one-liner gets the unversioned case wrong in
+    the quiet direction: a worker with **no** build id is stale — it is a build
+    that predates versioning, or one whose deployment config did not take — and
+    ``poller.build_id and poller.build_id != current`` skips exactly those. A
+    gate that passes because it could not see the offending worker is the
+    fail-open shape this package exists to remove.
+
+    Args:
+        pollers: Pollers read from a task queue.
+        current_build_id: The build id the deployment intends to be serving.
+            ``None`` means "versioning is not in use here", in which case no
+            poller can be stale and the result is empty — the alternative,
+            reporting every poller as stale, would red every unversioned
+            deployment.
+
+    Returns:
+        The stale pollers, in the order given. Empty is the passing state.
+    """
+    if current_build_id is None:
+        return ()
+    return tuple(poller for poller in pollers if poller.build_id != current_build_id)

--- a/application_sdk/testing/harness/temporal/client.py
+++ b/application_sdk/testing/harness/temporal/client.py
@@ -1,0 +1,908 @@
+"""The ``temporalio`` backend behind :class:`TemporalReader`, and how it connects.
+
+Neither read existed in this SDK before FND-247. The poller read is a lift from
+``suite/ports/temporal.py`` in ``atlanhq/app-runtime-test-suite``, whose
+``pollers()`` already worked against ``DescribeTaskQueue``; the re-expression on
+the way across is what the rest of this docstring is about.
+
+**Async, with no bridge inside it.** The lifted implementation runs its own event
+loop on a dedicated thread and hands every call to it with
+``run_coroutine_threadsafe``, because its scenario authors never write ``async``.
+Under this SDK's async-everywhere rule (D1) that inverts: the reader is plain
+``async`` and the sync composer reaches it through the one public bridge,
+:func:`~application_sdk.testing.harness.bridge.run_sync` — which owns exactly one
+loop per thread, so a suite that also reads Atlas or a cluster shares it instead
+of standing up a second one. Unlike
+:class:`~application_sdk.testing.harness.cluster.KubernetesReader` there is no
+:func:`~application_sdk._runtime.offload.run_in_thread` here at all:
+``temporalio`` is asyncio-native, so ``async`` is free rather than paid for.
+
+**No extra to declare, and no lazy import either.** FND-247's amendment expected
+``temporalio`` to be optional behind ``[workflows]``, with these readers
+import-guarded accordingly. Both halves turn out not to apply. ``temporalio`` was
+promoted to a *core* dependency in v3.1 and ``[workflows]`` is a
+backwards-compatibility alias resolving to it, so there is no extra to name —
+unlike the ``harness`` extra the cluster backend genuinely needs. And guarding it
+lazily the way that backend guards ``kubernetes`` would buy nothing measurable:
+``application_sdk.testing``'s own package ``__init__`` already imports
+``temporalio.client``, ``temporalio.service`` and the ``temporalio.api`` protos
+before any harness module is reached. So these imports are plain and at the top,
+which is what lets the conversions below take the client's real types instead of
+``Any``.
+
+**A poller count is two reads, not one.** A task-queue name addresses a workflow
+queue and an activity queue, they are separate ``DescribeTaskQueue`` calls, and a
+worker polls both. :meth:`TemporalServiceReader.task_queue_pollers` reads both by
+default and tags every poller with which one it came from
+(:class:`~application_sdk.testing.harness.temporal.TaskQueueType`). The lifted
+implementation read only the workflow queue and returned a bare count; both
+choices lose the state worth catching, because a union count and a workflow-only
+count disagree exactly when a worker process is half-polling — the poll loop that
+died while the process stayed alive, which is invisible to both Temporal's own
+"is there a worker" question and to Kubernetes' "is the pod ready" one.
+
+**One connection per loop, rebuilt once on a dropped transport.** A
+``temporalio`` ``Client`` is bound to the loop that created it, so the connection
+is cached against the running loop — the same affinity
+:class:`~application_sdk.testing.harness.cluster.KubernetesReader` honours per
+*thread* for its own non-thread-safe client, for the same reason. And when the
+connection is a ``kubectl port-forward`` tunnel, a tunnel that has died is
+permanent: the client's own reconnect loop retries an address nothing is
+listening on any more. So an ``UNAVAILABLE`` discards the cached connection and
+the read is re-attempted once against a fresh one — the trade
+:class:`~application_sdk.testing.harness.cluster.PortForward` already makes for
+HTTP calls, and child F made for the AE pool: pooled on the happy path, fresh on
+the retry.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from collections.abc import Awaitable, Callable, Iterable, Sequence
+from dataclasses import dataclass, field
+from datetime import timedelta, timezone
+from types import TracebackType
+from typing import TypeVar
+
+# P006 asks that ``temporalio`` stay behind ``execution/_temporal/`` so a future
+# orchestration change lands in one place. That contract is about the *worker*
+# adapter: the engine's workflow and activity API, on a production code path.
+# These imports are neither. They are an out-of-cluster read of Temporal's
+# control plane from test infrastructure — ``DescribeTaskQueue`` and
+# ``DescribeWorkflowExecution`` — which the adapter does not offer and should not
+# grow: putting a describe-a-task-queue client on a production path to satisfy a
+# lint rule is a worse coupling than the one the rule prevents. Each import
+# therefore carries the directive the rule prescribes for a deliberate exception.
+#
+# Two things about the layout are load-bearing rather than preference, and both
+# were arrived at by watching the tidier version fail.
+#
+# The directives sit ABOVE each import, not trailing it. Trailing is the obvious
+# way to write six near-identical comments, and it does not survive: appending
+# one takes these lines past 88 characters, ``ruff-format`` then wraps the
+# statement, and the directive lands on the wrapped *name* line instead of the
+# statement's own — which the checker matches on. Two of the six came back as
+# findings that way.
+#
+# ``isort`` is off across the block for the mirror-image reason: a directive
+# binds to the line below it, and a re-sort that lifts an import out from under
+# its own comment silently un-suppresses one line while stacking two directives
+# over another. Sorted by hand here, in the order isort would have chosen anyway
+# — it is only the comment handling being overridden, not isort's opinion.
+# isort: off
+# conformance: ignore[P006] harness control-plane read — see the note above
+from temporalio.api.enums.v1 import TaskQueueType as WireTaskQueueType
+
+# conformance: ignore[P006] harness control-plane read — see the note above
+from temporalio.api.taskqueue.v1 import PollerInfo as WirePollerInfo
+
+# conformance: ignore[P006] harness control-plane read — see the note above
+from temporalio.api.taskqueue.v1 import TaskQueue
+
+# conformance: ignore[P006] harness control-plane read — see the note above
+from temporalio.api.workflowservice.v1 import DescribeTaskQueueRequest
+
+# conformance: ignore[P006] harness control-plane read — see the note above
+from temporalio.client import Client, WorkflowExecutionDescription
+
+# conformance: ignore[P006] harness control-plane read — see the note above
+from temporalio.service import RPCError
+# isort: on
+
+from application_sdk.observability.logger_adaptor import get_logger
+from application_sdk.testing.harness.cluster._portforward import PortForward
+from application_sdk.testing.harness.cluster._states import ServiceTarget
+from application_sdk.testing.harness.temporal._errors import (
+    TemporalConnectFailedError,
+    TemporalReaderLoopMismatchError,
+    TemporalReadFailedError,
+    WorkflowNotFoundError,
+)
+from application_sdk.testing.harness.temporal._states import (
+    PollerInfo,
+    TaskQueueType,
+    WorkflowExecutionStatus,
+    WorkflowStatus,
+)
+
+logger = get_logger(__name__)
+
+T = TypeVar("T")
+
+__all__ = [
+    "TemporalConnection",
+    "TemporalServiceReader",
+    "frontend_connection",
+    "port_forwarded_connection",
+]
+
+#: Default per-call bound on a Temporal read. Distinct from any enclosing wait's
+#: budget, for the reason the cluster backend's is: one hung RPC must not
+#: silently consume the whole window a poll was given.
+_DEFAULT_REQUEST_TIMEOUT = timedelta(seconds=30)
+
+#: Which halves of a task queue a poller read covers when the caller does not
+#: say. Both of the two an SDK worker polls, and not ``NEXUS``: no app in this
+#: fleet registers a Nexus handler, so reading it would be a third RPC per probe
+#: that always answers empty — and an empty answer nobody asked for is one more
+#: way for a report to read as a finding.
+_DEFAULT_TASK_QUEUE_TYPES: tuple[TaskQueueType, ...] = (
+    TaskQueueType.WORKFLOW,
+    TaskQueueType.ACTIVITY,
+)
+
+#: The harness's queue-half vocabulary, as the wire's. Declared as a mapping
+#: rather than derived from the member names so a rename on either side is a
+#: type error here instead of a silent read of the wrong queue.
+_WIRE_QUEUE_TYPES: dict[TaskQueueType, WireTaskQueueType.ValueType] = {
+    TaskQueueType.WORKFLOW: WireTaskQueueType.TASK_QUEUE_TYPE_WORKFLOW,
+    TaskQueueType.ACTIVITY: WireTaskQueueType.TASK_QUEUE_TYPE_ACTIVITY,
+    TaskQueueType.NEXUS: WireTaskQueueType.TASK_QUEUE_TYPE_NEXUS,
+}
+
+#: gRPC statuses that mean "the transport is gone", as opposed to "the frontend
+#: said no". These are the ones a rebuilt connection can plausibly fix, which is
+#: what makes them the retry-once set rather than the retryable set.
+_TRANSPORT_LOST = frozenset({"UNAVAILABLE", "UNKNOWN"})
+
+
+# ---------------------------------------------------------------------------
+# Connections
+# ---------------------------------------------------------------------------
+
+
+async def _noop() -> None:
+    """Release nothing. The closer for a connection that owns no transport."""
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class TemporalConnection:
+    """One loop's client, plus whatever transport is holding it up.
+
+    Built by a factory — :func:`frontend_connection` or
+    :func:`port_forwarded_connection` — so that *how the frontend is reached* is
+    a parameter of :class:`TemporalServiceReader` rather than a subclass of it.
+    Mirrors :class:`~application_sdk.testing.harness.cluster.KubernetesApis`, and
+    for the same payoff: a driver that already runs inside the cluster is a third
+    factory here, not a second reader.
+
+    Attributes:
+        client: The connected ``temporalio`` client.
+        namespace: Temporal namespace the client is bound to. Handles are scoped
+            to it, so it is the namespace
+            :meth:`TemporalServiceReader.workflow_status` reads even though that
+            method takes no namespace argument.
+        address: ``host:port`` the client is pointed at, for a failure to name.
+        close: Releases the transport behind the client — a ``kubectl
+            port-forward`` tunnel, or nothing at all for a direct address.
+            Awaited by :meth:`TemporalServiceReader.aclose`.
+    """
+
+    client: Client
+    namespace: str
+    address: str
+    close: Callable[[], Awaitable[None]] = field(default=_noop)
+
+
+async def frontend_connection(
+    *,
+    address: str,
+    namespace: str,
+    api_key: str | None = None,
+    tls: bool = False,
+) -> TemporalConnection:
+    """Connect to a Temporal frontend at a known address.
+
+    Args:
+        address: ``host:port`` of the frontend.
+        namespace: Temporal namespace to bind the client to.
+        api_key: Bearer token, when the frontend expects one. Handed to the
+            client, never logged and never carried on a failure — the address and
+            the namespace are what a report needs, and a token in an error field
+            would travel wherever that report does.
+        tls: Whether to negotiate TLS.
+
+    Returns:
+        The connection. Its :attr:`~TemporalConnection.close` releases nothing:
+        the caller supplied the address, so the caller owns whatever provides it.
+
+    Raises:
+        TemporalConnectFailedError: If the client could not be established.
+    """
+    try:
+        client = await Client.connect(
+            address, namespace=namespace, api_key=api_key, tls=tls
+        )
+    # conformance: ignore[E004] re-raised immediately as a typed leaf naming the address and namespace; logging here would report the same failure twice
+    except Exception as error:
+        raise TemporalConnectFailedError(
+            message=(
+                f"Could not connect to the Temporal frontend at {address} "
+                f"for namespace {namespace!r}"
+            ),
+            target=address,
+            address=address,
+            temporal_namespace=namespace,
+            cause=error,
+        ) from error
+    return TemporalConnection(client=client, namespace=namespace, address=address)
+
+
+async def port_forwarded_connection(
+    *,
+    target: ServiceTarget,
+    namespace: str,
+    kube_context: str | None = None,
+    timeout: timedelta = _DEFAULT_REQUEST_TIMEOUT,
+) -> TemporalConnection:
+    """Connect to an in-cluster Temporal frontend Service through a tunnel.
+
+    How an out-of-cluster driver reaches the frontend at all. The tunnel is
+    :class:`~application_sdk.testing.harness.cluster.PortForward` — the same one
+    :meth:`~application_sdk.testing.harness.cluster.ClusterReader.http` uses,
+    reached through its
+    :meth:`~application_sdk.testing.harness.cluster.PortForward.address`
+    accessor because ``temporalio`` speaks gRPC and needs the tunnel's near end
+    rather than an HTTP session over it. Sharing it is the point: a second
+    "shell out, pick a free port, wait for it to accept" is the divergence
+    FND-224 exists to remove, and this one already kills the child by handle
+    rather than by pattern, which is what keeps concurrent runs on one host from
+    tearing down each other's tunnels.
+
+    Args:
+        target: The frontend ``Service`` and its gRPC port. No default: which
+            Service serves a tenant's frontend is deployment configuration, and a
+            wrong guess baked in here would surface as a connect timeout rather
+            than as a missing setting.
+        namespace: Temporal namespace to bind the client to.
+        kube_context: Kubeconfig context to tunnel through. Pass the same one the
+            cluster reader was built with whenever that is a named context:
+            without it ``kubectl`` uses whichever context the kubeconfig marks
+            current, so a suite reading pods from ``e2e-gcp`` would read *its*
+            Temporal from whatever is current instead — both calls succeeding,
+            nothing logged, and the only symptom a set of readings that cannot be
+            reconciled with each other. ``None`` is right only when the reader
+            did not name a context either.
+        timeout: Bound on the tunnel's local port becoming reachable.
+
+    Returns:
+        The connection. Its :attr:`~TemporalConnection.close` terminates the
+        tunnel, so :meth:`TemporalServiceReader.aclose` is not optional here —
+        an unclosed tunnel leaks a ``kubectl`` process for the rest of the
+        session.
+
+    Raises:
+        TemporalConnectFailedError: If the tunnel never opened, or the client
+            could not be established over it.
+    """
+    session = PortForward(
+        target.namespace,
+        target.service,
+        target.port,
+        timeout=timeout.total_seconds(),
+        kube_context=kube_context,
+    )
+    where = f"{target.namespace}/{target.service}:{target.port}" + (
+        f" (context {kube_context})" if kube_context else ""
+    )
+    try:
+        address = await session.address()
+    # conformance: ignore[E004] re-raised immediately as a typed leaf naming the Service; logging here would report the same failure twice
+    except Exception as error:
+        await session.aclose()
+        raise TemporalConnectFailedError(
+            message=f"Could not open a tunnel to the Temporal frontend at {where}",
+            target=where,
+            temporal_namespace=namespace,
+            cause=error,
+        ) from error
+
+    logger.debug(
+        "tunnelled to the Temporal frontend at %s via %s for namespace %s",
+        where,
+        address,
+        namespace,
+    )
+    try:
+        connected = await frontend_connection(address=address, namespace=namespace)
+    except BaseException:
+        # The tunnel is already up; leaving it behind on a failed connect is the
+        # leak this except exists to prevent.
+        await session.aclose()
+        raise
+    return TemporalConnection(
+        client=connected.client,
+        namespace=namespace,
+        address=address,
+        close=session.aclose,
+    )
+
+
+@dataclass(slots=True)
+class _Bound:
+    """One event loop's connection, and the lock that builds it exactly once.
+
+    The lock lives here rather than on the reader because an
+    :class:`asyncio.Lock` binds to the loop it is first awaited on, so a reader
+    reused across two loops needs two locks — the same reason the connection
+    itself is per-loop.
+    """
+
+    loop: asyncio.AbstractEventLoop
+    lock: asyncio.Lock
+    connection: TemporalConnection | None = None
+    #: Set while a connect is in flight, and the reason it exists: for the whole
+    #: duration of ``await connect()`` the connection is still ``None``, so a
+    #: fail-close that only tested :attr:`connection` would let another loop
+    #: replace this bound mid-connect — after which this loop stores its client
+    #: on a bound nothing references any more, leaking the client and, on the
+    #: tunnelled path, a ``kubectl`` child. Claimed before the await, cleared in
+    #: a ``finally`` so a *failed* connect releases the bound rather than
+    #: poisoning the reader for every other loop.
+    connecting: bool = False
+
+    @property
+    def in_use(self) -> bool:
+        """Whether another loop taking this reader would strand something."""
+        return self.connection is not None or self.connecting
+
+
+class TemporalServiceReader:
+    """Read Temporal state through the ``temporalio`` client.
+
+    Satisfies :class:`~application_sdk.testing.harness.temporal.TemporalReader`,
+    and offers two reads beyond it: :meth:`find_workflow_status`, where a missing
+    execution is a value rather than a raise, and :meth:`task_queue_pollers`'
+    ``task_queue_types`` narrowing.
+
+    Args:
+        connect: Factory building a connection. The seam that keeps "how is the
+            frontend reached" out of the reader: an in-cluster driver is another
+            factory, not a second reader class.
+        request_timeout: Per-call bound on every read.
+
+    Use it as an async context manager. That is not a style preference: a
+    port-forwarded connection holds a ``kubectl`` child process, so a reader that
+    is never closed leaks one for the rest of the session, and ``async with``
+    makes the release a property of the block rather than of the caller
+    remembering. :meth:`aclose` remains public for callers whose lifetime does
+    not fit a block.
+
+    Example:
+        >>> async with TemporalServiceReader(  # doctest: +SKIP
+        ...     connect=functools.partial(
+        ...         frontend_connection, address="127.0.0.1:7233", namespace="default"
+        ...     )
+        ... ) as reader:
+        ...     pollers = await reader.task_queue_pollers(
+        ...         "atlan-hello-world-default", namespace="default"
+        ...     )
+    """
+
+    def __init__(
+        self,
+        *,
+        connect: Callable[[], Awaitable[TemporalConnection]],
+        request_timeout: timedelta = _DEFAULT_REQUEST_TIMEOUT,
+    ) -> None:
+        self._connect = connect
+        self._request_timeout = request_timeout
+        self._bound: _Bound | None = None
+        # Guards the read-modify-write of `_bound`. A `threading.Lock`, not an
+        # `asyncio.Lock`, and that is forced rather than chosen: the whole point
+        # of `_bound` is that two *event loops* are in play, and separate loops
+        # run on separate threads — so an asyncio primitive cannot serialise
+        # them, and two threads could each pass the in-use check and each
+        # install a fresh bound. Held across no awaits, so it cannot deadlock.
+        self._swap = threading.Lock()
+
+    # -- the connection, per loop -------------------------------------------
+
+    async def _connection(self) -> TemporalConnection:
+        """This loop's connection, built on first use.
+
+        A ``temporalio`` ``Client`` is bound to the loop that created it, so a
+        reader handed between loops — a sync composer's
+        :func:`~application_sdk.testing.harness.bridge.run_sync` loop and a
+        native-async scenario's, say — must not share one. Honoured the way
+        :class:`~application_sdk.testing.harness.cluster.KubernetesReader`
+        honours thread affinity for its own non-shareable client.
+        """
+        bound = self._loop_bound()
+        if bound.connection is not None:
+            return bound.connection
+        async with bound.lock:
+            # Re-checked under the lock: two probes racing the first read on this
+            # loop would otherwise open two connections, and the loser's would be
+            # dropped without being closed — a leaked tunnel and a leaked client.
+            if bound.connection is None:
+                try:
+                    bound.connection = await self._connect()
+                finally:
+                    # Cleared whether the connect succeeded or raised. On failure
+                    # the bound goes back to idle and another loop may take the
+                    # reader; leaving the claim set would poison it for every
+                    # loop after one bad connect.
+                    with self._swap:
+                        bound.connecting = False
+            return bound.connection
+
+    def _loop_bound(self) -> _Bound:
+        """Claim this loop's bound, or refuse if another loop holds a live one.
+
+        Atomic across threads, which is the part that makes the refusal sound
+        rather than probable. Two event loops mean two threads, so the
+        read-modify-write of :attr:`_bound` is a genuine data race and no asyncio
+        primitive can serialise it: without :attr:`_swap`, two threads could each
+        find the bound idle and each install a fresh one, and the loser would go
+        on to connect onto a bound nothing references.
+
+        A **fresh** bound is claimed as ``connecting`` here, before it is
+        published and therefore before any await. That closes the window the
+        marker exists for: from this point no other loop can replace it, so the
+        connect that follows cannot be stranded halfway.
+
+        Rebinds freely while there is nothing to lose, and refuses once there is.
+        A reader that has never connected, or that has been closed, rebinds
+        without complaint — there is no leak in either case, and raising would
+        only punish a legitimate handoff of an idle reader.
+
+        Raises:
+            TemporalReaderLoopMismatchError: If another loop holds a connection
+                or is in the middle of opening one. Close it there, or — better —
+                stop sharing one reader across loops;
+                :func:`~application_sdk.testing.harness.bridge.run_sync` owns one
+                loop per thread, so a suite reaching the reader through it never
+                sees this.
+        """
+        running = asyncio.get_running_loop()
+        with self._swap:
+            bound = self._bound
+            if bound is not None and bound.loop is running:
+                return bound
+            if bound is not None and bound.in_use:
+                raise TemporalReaderLoopMismatchError(
+                    message=(
+                        "This Temporal reader is "
+                        + (
+                            f"already connected to {bound.connection.address}"
+                            if bound.connection is not None
+                            else "in the middle of connecting"
+                        )
+                        + " on a different event loop. Rebinding would strand "
+                        "that connection with nothing to close it, leaking the "
+                        "kubectl child behind a port-forwarded tunnel — await "
+                        "aclose() on the loop that opened it, or use one reader "
+                        "per loop"
+                    ),
+                    address=(
+                        bound.connection.address
+                        if bound.connection is not None
+                        else None
+                    ),
+                )
+            if bound is not None:
+                logger.debug(
+                    "rebinding an idle Temporal reader to a new event loop — "
+                    "nothing to close, so nothing is lost"
+                )
+            # Published already claimed, so the connect below cannot be displaced.
+            fresh = _Bound(loop=running, lock=asyncio.Lock(), connecting=True)
+            self._bound = fresh
+            return fresh
+
+    async def __aenter__(self) -> TemporalServiceReader:
+        """Enter the block. Opens nothing.
+
+        Deliberately not an eager connect: the reader's laziness is a property
+        other code relies on (a fixture can build one for a scenario that then
+        decides not to reach Temporal), and connecting here would turn
+        ``async with`` into a network call for a block that may never read.
+        """
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        """Close on the way out, however the block ended.
+
+        Returns ``None`` rather than a truthy value, so an exception raised
+        inside the block propagates — teardown is not a reason to swallow the
+        failure that triggered it.
+
+        This is the structural half of the leak guard, and it is worth being
+        precise about what it does and does not cover: it removes *forgetting* to
+        close, which is the common case. It does not close the residue described
+        on :meth:`aclose` — a read still running in another task can still
+        resurrect a connection after the block exits — because that is a property
+        of the read outliving the reader, not of who calls the close.
+        """
+        await self.aclose()
+
+    async def aclose(self) -> None:
+        """Release this loop's connection and whatever transport holds it up.
+
+        Idempotent, and safe on a reader that never connected. Not optional for a
+        port-forwarded connection: the tunnel is a ``kubectl`` child process —
+        prefer ``async with`` on the reader, which makes that structural rather
+        than remembered, and keep this for lifetimes that do not fit a block.
+
+        **Waits for an in-flight connect rather than returning past it.** Testing
+        ``connection is None`` and returning was wrong for the same reason the
+        loop guard's version of that test was: the connection is ``None`` for the
+        whole duration of ``await connect()``, so a teardown racing a first read
+        — two tasks on one loop, which is exactly a fixture closing while a
+        probe is still opening — returned "closed" and then had a client
+        installed behind it, with nothing left to close it.
+
+        :meth:`_connection` holds ``bound.lock`` across the connect, so acquiring
+        it here means one of two things has already happened: the connect
+        finished and there is a connection to close, or it failed and there is
+        not. So the postcondition is "everything this reader had open is closed",
+        rather than the weaker "nothing was open when I looked". Sequential use
+        pays nothing: an uncontended :class:`asyncio.Lock` acquires without
+        yielding.
+
+        It is **not** "and nothing will be open afterwards", and the difference is
+        deliberate rather than overlooked. A read already in flight holds its
+        connection as a local — :meth:`_connection` hands it out before this
+        method takes it away — so that read continues, fails against the closed
+        client, and :meth:`_read`'s rebuild opens a *fresh* connection after
+        teardown returned. Closing that residue needs ``aclose`` to be terminal
+        (a flag that makes :meth:`_connection` refuse), which would also forbid
+        the reuse-after-close that the rebuild itself depends on — a contract
+        change, not a fix, and one for whoever decides whether a reader is
+        single-use. Until then: do not tear a reader down while a read is still
+        running on it. Sequential ``read`` then ``aclose`` has no residue at all.
+
+        No deadlock, and it is worth saying why rather than leaving it to be
+        rechecked: nothing on the connect path calls back into this method. The
+        tunnelled factory closes its own
+        :class:`~application_sdk.testing.harness.cluster.PortForward`, not the
+        reader, and :meth:`_read`'s rebuild calls this only after
+        :meth:`_connection` has returned and released the lock. That is the
+        distinction from ``PortForward.aclose``, which genuinely cannot take its
+        own open lock because ``_spawn`` calls it while holding one.
+
+        Close on the loop that opened the connection. Awaiting a *contended*
+        lock from another loop is not sound, which is the same constraint
+        :meth:`_loop_bound` already enforces from the other side.
+        """
+        with self._swap:
+            bound = self._bound
+        if bound is None:
+            return
+        async with bound.lock:
+            connection, bound.connection = bound.connection, None
+            if connection is not None:
+                await connection.close()
+
+    # -- TemporalReader -----------------------------------------------------
+
+    async def task_queue_pollers(
+        self,
+        queue: str,
+        *,
+        namespace: str,
+        task_queue_types: Iterable[TaskQueueType] | None = None,
+    ) -> Sequence[PollerInfo]:
+        """Return the workers Temporal currently sees polling *queue*.
+
+        One ``DescribeTaskQueue`` per requested type, in the order requested, so
+        the returned sequence groups by type deterministically — a report and an
+        assertion both read better for it, and it costs nothing that concurrency
+        would buy back at this size.
+
+        Args:
+            queue: Task-queue name.
+            namespace: Temporal namespace. Taken per-call rather than from the
+                connection because ``DescribeTaskQueue`` carries it in the
+                request, so one connection can read across namespaces.
+            task_queue_types: Which halves of the queue to read. ``None`` selects
+                the default — the workflow and activity queues, the two an SDK
+                worker polls. An **empty** sequence is honoured as itself: it
+                reads nothing and makes no RPC, rather than being taken for
+                "unspecified".
+
+        Returns:
+            One :class:`PollerInfo` per poller per queue half. **Empty is a real
+            answer**, and the one this read exists to deliver: it is the observed
+            form of "no worker on this task queue", which ``testing.e2e``'s
+            ``NoWorkerOnTaskQueueError`` currently infers from three minutes of
+            silence.
+
+        Raises:
+            TemporalReadFailedError: If the read did not come back with data.
+                Never an empty sequence for an unreadable frontend — see
+                :mod:`application_sdk.testing.harness.temporal._errors` for why
+                that matters more here than anywhere else in the harness.
+        """
+        pollers: list[PollerInfo] = []
+        # `is None` rather than falsiness: an explicitly empty sequence means
+        # "read no queue halves", and `or` would silently promote it to both.
+        # A caller narrowing types from a config that happens to resolve empty
+        # would then get the opposite of what it asked for, and get it quietly.
+        wanted = (
+            _DEFAULT_TASK_QUEUE_TYPES if task_queue_types is None else task_queue_types
+        )
+        for queue_type in tuple(wanted):
+            request = DescribeTaskQueueRequest(
+                namespace=namespace,
+                task_queue=TaskQueue(name=queue),
+                task_queue_type=_WIRE_QUEUE_TYPES[queue_type],
+            )
+            response = await self._read(
+                lambda connection, request=request: (
+                    connection.client.workflow_service.describe_task_queue(
+                        request, timeout=self._request_timeout
+                    )
+                ),
+                target=f"pollers on {queue_type.value.lower()} queue {queue}",
+                namespace=namespace,
+            )
+            pollers.extend(
+                _poller_info(entry, queue_type) for entry in response.pollers
+            )
+        return pollers
+
+    async def workflow_status(
+        self, workflow_id: str, *, run_id: str | None = None
+    ) -> WorkflowStatus:
+        """Return the state of one workflow execution.
+
+        Args:
+            workflow_id: Workflow ID to describe.
+            run_id: Specific run, or ``None`` for the latest run of that ID.
+
+        Returns:
+            The execution's :class:`WorkflowStatus`.
+
+        Raises:
+            WorkflowNotFoundError: If there is no such execution. Not folded into
+                the read failure: a wrong id does not recover, so a wait must
+                fail on it at once rather than absorb it as a blip.
+            TemporalReadFailedError: If the read did not come back with data.
+        """
+        found = await self.find_workflow_status(workflow_id, run_id=run_id)
+        if found is None:
+            connection = await self._connection()
+            raise WorkflowNotFoundError(
+                message=(
+                    f"Temporal has no execution {workflow_id!r}"
+                    + (f" run {run_id!r}" if run_id else "")
+                    + f" in namespace {connection.namespace!r} — check the id and "
+                    "the namespace the client is bound to before the worker"
+                ),
+                resource_identifier=workflow_id,
+                workflow_id=workflow_id,
+                run_id=run_id,
+                temporal_namespace=connection.namespace,
+            )
+        return found
+
+    # -- beyond the Protocol ------------------------------------------------
+
+    async def find_workflow_status(
+        self, workflow_id: str, *, run_id: str | None = None
+    ) -> WorkflowStatus | None:
+        """Return one execution's state, or ``None`` when there is no such execution.
+
+        The nullable twin of :meth:`workflow_status`, and not merely a
+        convenience: a wait for work that something *else* dispatches — the
+        Automation Engine, in every connector run — starts before the execution
+        exists, so "not there yet" is a reading its predicate has to be able to
+        test. Raising through that window would make the wait's own
+        ``NeverStarted`` verdict unreachable, since the first probe would end the
+        wait.
+
+        The same 404-is-an-answer narrowing as
+        :meth:`~application_sdk.testing.harness.cluster.CustomResourceReader.crd_schema`,
+        and drawn in the same place: only ``NOT_FOUND`` answers ``None``. A
+        ``PERMISSION_DENIED`` from a narrowed token or a ``DEADLINE_EXCEEDED``
+        over a VPN raises, because a false "it never started" cached from one of
+        those is the negative no later read corrects.
+
+        Args:
+            workflow_id: Workflow ID to describe.
+            run_id: Specific run, or ``None`` for the latest run of that ID.
+
+        Returns:
+            The execution's :class:`WorkflowStatus`, or ``None`` if Temporal has
+            no execution under that ID.
+
+        Raises:
+            TemporalReadFailedError: On any failure that is not a clean
+                ``NOT_FOUND``.
+        """
+        target = f"workflow {workflow_id}" + (f" run {run_id}" if run_id else "")
+        try:
+            description = await self._read(
+                lambda connection: connection.client.get_workflow_handle(
+                    workflow_id, run_id=run_id
+                ).describe(rpc_timeout=self._request_timeout),
+                target=target,
+                namespace=None,
+            )
+        except TemporalReadFailedError as error:
+            if error.rpc_status != "NOT_FOUND":
+                raise
+            logger.debug("%s does not exist in this namespace (NOT_FOUND)", target)
+            return None
+        return _workflow_status(description, workflow_id)
+
+    # -- the read, with its one rebuild ------------------------------------
+
+    async def _read(
+        self,
+        call: Callable[[TemporalConnection], Awaitable[T]],
+        *,
+        target: str,
+        namespace: str | None,
+    ) -> T:
+        """Run one read, rebuilding the connection once if the transport is gone.
+
+        Args:
+            call: The read, given this loop's connection. Takes the connection
+                rather than closing over it so the retry runs against the *new*
+                one — a closure over the dead client would retry the same corpse.
+            target: What was being read, as a noun phrase for the report.
+            namespace: Namespace the read was scoped to, or ``None`` when the
+                connection's own namespace is the answer.
+
+        Returns:
+            Whatever the read returned.
+
+        Raises:
+            TemporalReadFailedError: If the read failed, and a rebuilt connection
+                did not fix it. Two consecutive transport failures are a frontend
+                that is genuinely unreachable, not a stale tunnel.
+        """
+        connection = await self._connection()
+        try:
+            return await self._attempt(connection, call, target, namespace)
+        except TemporalReadFailedError as error:
+            if error.rpc_status not in _TRANSPORT_LOST:
+                raise
+            logger.warning(
+                "the Temporal connection to %s dropped mid-read (%s) while "
+                "reading %s — rebuilding it and re-attempting once",
+                connection.address,
+                error.rpc_status,
+                target,
+                exc_info=True,
+            )
+        await self.aclose()
+        return await self._attempt(await self._connection(), call, target, namespace)
+
+    async def _attempt(
+        self,
+        connection: TemporalConnection,
+        call: Callable[[TemporalConnection], Awaitable[T]],
+        target: str,
+        namespace: str | None,
+    ) -> T:
+        """One read against one connection, with its errors typed.
+
+        Only ``temporalio``'s own ``RPCError`` is converted. A ``TypeError`` from
+        a wiring bug is a bug, and dressing it as ``DEPENDENCY_UNAVAILABLE``
+        would let a bounded wait absorb it as a transient blip and spend its
+        whole budget on it — the fail-open shape, one level up. ``RPCError``
+        rather than ``Exception`` plus an ``isinstance`` makes that a property of
+        the syntax rather than of a branch that can rot.
+        """
+        try:
+            return await call(connection)
+        except RPCError as error:
+            status = error.status.name
+            raise TemporalReadFailedError(
+                message=f"Could not read {target} ({status})",
+                target=target,
+                rpc_status=status,
+                address=connection.address,
+                temporal_namespace=namespace or connection.namespace,
+                cause=error,
+            ) from error
+
+
+# ---------------------------------------------------------------------------
+# Wire objects -> typed states
+# ---------------------------------------------------------------------------
+
+
+def _poller_info(entry: WirePollerInfo, queue_type: TaskQueueType) -> PollerInfo:
+    """One wire ``PollerInfo`` as the harness's own.
+
+    The build id is read from ``deployment_options`` first and
+    ``worker_version_capabilities`` second, because those are the new and old
+    shapes of the same fact and this SDK's worker sets the new one
+    (``WorkerDeploymentConfig``, from ``ATLAN_APP_DEPLOYMENT_NAME`` and
+    ``ATLAN_APP_BUILD_ID``). Reading only the legacy field would report every
+    versioned Atlan worker as unversioned, which
+    :func:`~application_sdk.testing.harness.temporal.stale_version_pollers`
+    would then read as *every* poller being stale.
+    """
+    build_id = _non_empty(entry.deployment_options.build_id) or _non_empty(
+        entry.worker_version_capabilities.build_id
+    )
+    return PollerInfo(
+        identity=entry.identity,
+        last_access=entry.last_access_time.ToDatetime(tzinfo=timezone.utc),
+        task_queue_type=queue_type,
+        build_id=build_id,
+        deployment_name=_non_empty(entry.deployment_options.deployment_name),
+    )
+
+
+def _workflow_status(
+    description: WorkflowExecutionDescription, workflow_id: str
+) -> WorkflowStatus:
+    """One ``WorkflowExecutionDescription`` as a :class:`WorkflowStatus`."""
+    return WorkflowStatus(
+        workflow_id=description.id or workflow_id,
+        run_id=description.run_id,
+        status=_execution_status(description.status),
+        task_queue=description.task_queue,
+        history_length=description.history_length,
+        started_at=description.start_time,
+        closed_at=description.close_time,
+    )
+
+
+def _execution_status(value: object) -> WorkflowExecutionStatus:
+    """A reported status as a :class:`WorkflowExecutionStatus`.
+
+    ``temporalio`` surfaces the proto's ``UNSPECIFIED`` as ``None``, and a status
+    this SDK has never heard of would arrive as an enum member with an unfamiliar
+    name. Both read as
+    :attr:`~application_sdk.testing.harness.temporal.WorkflowExecutionStatus.UNKNOWN`,
+    the way an unrecognised pod phase reads as ``Unknown``: a classification, not
+    a failure, so raising on it would turn a new upstream status into a harness
+    crash.
+    """
+    name = getattr(value, "name", None)
+    if isinstance(name, str):
+        member = WorkflowExecutionStatus.__members__.get(name)
+        if member is not None:
+            return member
+    if value is not None:
+        logger.warning(
+            "Unrecognised workflow execution status %r — reading it as %s",
+            value,
+            WorkflowExecutionStatus.UNKNOWN,
+        )
+    return WorkflowExecutionStatus.UNKNOWN
+
+
+def _non_empty(value: str) -> str | None:
+    """A protobuf string field, with its empty default read as absent.
+
+    Protobuf has no null for a scalar, so an unset ``build_id`` arrives as
+    ``""``. Carrying that through would make ``build_id == ""`` a build id, and
+    an unversioned poller would compare unequal to every real build while
+    claiming to have one.
+    """
+    return value or None

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -1,8 +1,8 @@
 <!--
 generated-by:  capability-manifest skill (.claude/skills/capability-manifest)
 sdk-version:   3.29.0
-source-sha:    87901cf1141d4a0ebad578030a5e4347111e7adf
-source-date:   2026-08-27T01:30:51+01:00
+source-sha:    faf9b47620aa53af11cf7d017255c8cb5e92ae55
+source-date:   2026-08-27T02:55:32+01:00
 do-not-edit:   re-run the skill instead of hand-editing
 -->
 
@@ -34,7 +34,7 @@ do-not-edit:   re-run the skill instead of hand-editing
 | `application_sdk.server` | FastAPI server, MCP integration, middleware, health endpoint | 4 |
 | `application_sdk.storage` | Object-store abstraction — factory, formats, batch, transfer, cloud bindings | 42 |
 | `application_sdk.templates` | SQL metadata extractor templates and their contracts | 6 |
-| `application_sdk.testing` | Test infrastructure — mocks, fixtures, hypothesis strategies, integration helpers | 199 |
+| `application_sdk.testing` | Test infrastructure — mocks, fixtures, hypothesis strategies, integration helpers | 209 |
 | `application_sdk.validation` | Offline artifact & asset validation — format-agnostic wrapper (ADR-0020) plus pyatlan_v9 .validate() wrappers, no network call | 78 |
 
 ## Subpackage Details
@@ -3597,9 +3597,9 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 #### `PollerInfo`
 
 - **Import:** `from application_sdk.testing.harness.temporal import PollerInfo`
-- **Signature:** `class PollerInfo(*, identity: str, last_access: datetime, build_id: str | None = None) -> None`
+- **Signature:** `class PollerInfo(*, ...)`
 - **Summary:** One worker seen polling a task queue.
-- **Defined in:** `application_sdk/testing/harness/temporal/__init__.py`
+- **Defined in:** `application_sdk/testing/harness/temporal/_states.py`
 
 #### `PortForward`
 
@@ -3734,12 +3734,56 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Summary:** :func:`~application_sdk.testing.harness.run_sync` was called from a running loop.
 - **Defined in:** `application_sdk/testing/harness/_errors.py`
 
+#### `TaskQueueType`
+
+- **Import:** `from application_sdk.testing.harness.temporal import TaskQueueType`
+- **Signature:** `class TaskQueueType`
+- **Summary:** Which half of a task queue a poller is holding.
+- **Defined in:** `application_sdk/testing/harness/temporal/_states.py`
+
+#### `TemporalConnectFailedError`
+
+- **Import:** `from application_sdk.testing.harness.temporal import TemporalConnectFailedError`
+- **Signature:** `class TemporalConnectFailedError(*, ...)`
+- **Summary:** Could not establish a client against the Temporal frontend.
+- **Defined in:** `application_sdk/testing/harness/temporal/_errors.py`
+
+#### `TemporalConnection`
+
+- **Import:** `from application_sdk.testing.harness.temporal import TemporalConnection`
+- **Also importable from:** `application_sdk.testing.harness.temporal.client`
+- **Signature:** `class TemporalConnection(*, client: Client, namespace: str, address: str, close: Callable[[], Awaitable[None]] = _noop)`
+- **Summary:** One loop's client, plus whatever transport is holding it up.
+- **Defined in:** `application_sdk/testing/harness/temporal/client.py`
+
 #### `TemporalReader`
 
 - **Import:** `from application_sdk.testing.harness.temporal import TemporalReader`
 - **Signature:** `class TemporalReader`
 - **Summary:** Read Temporal state. No mutation, by decision.
-- **Defined in:** `application_sdk/testing/harness/temporal/__init__.py`
+- **Defined in:** `application_sdk/testing/harness/temporal/_protocols.py`
+
+#### `TemporalReaderLoopMismatchError`
+
+- **Import:** `from application_sdk.testing.harness.temporal import TemporalReaderLoopMismatchError`
+- **Signature:** `class TemporalReaderLoopMismatchError(*, ...)`
+- **Summary:** A connected reader was used from a different event loop than it opened on.
+- **Defined in:** `application_sdk/testing/harness/temporal/_errors.py`
+
+#### `TemporalReadFailedError`
+
+- **Import:** `from application_sdk.testing.harness.temporal import TemporalReadFailedError`
+- **Signature:** `class TemporalReadFailedError(*, ...)`
+- **Summary:** A Temporal read reached the frontend and did not come back with data.
+- **Defined in:** `application_sdk/testing/harness/temporal/_errors.py`
+
+#### `TemporalServiceReader`
+
+- **Import:** `from application_sdk.testing.harness.temporal import TemporalServiceReader`
+- **Also importable from:** `application_sdk.testing.harness.temporal.client`
+- **Signature:** `class TemporalServiceReader(*, ...)`
+- **Summary:** Read Temporal state through the ``temporalio`` client.
+- **Defined in:** `application_sdk/testing/harness/temporal/client.py`
 
 #### `TenantAuth`
 
@@ -3804,7 +3848,14 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Import:** `from application_sdk.testing.harness.temporal import WorkflowExecutionStatus`
 - **Signature:** `class WorkflowExecutionStatus`
 - **Summary:** Terminal and non-terminal states a workflow execution can report.
-- **Defined in:** `application_sdk/testing/harness/temporal/__init__.py`
+- **Defined in:** `application_sdk/testing/harness/temporal/_states.py`
+
+#### `WorkflowNotFoundError`
+
+- **Import:** `from application_sdk.testing.harness.temporal import WorkflowNotFoundError`
+- **Signature:** `class WorkflowNotFoundError(*, ...)`
+- **Summary:** Temporal has no execution under this workflow ID.
+- **Defined in:** `application_sdk/testing/harness/temporal/_errors.py`
 
 #### `WorkflowRunHandle`
 
@@ -3818,7 +3869,7 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Import:** `from application_sdk.testing.harness.temporal import WorkflowStatus`
 - **Signature:** `class WorkflowStatus(*, ...)`
 - **Summary:** One workflow execution's state.
-- **Defined in:** `application_sdk/testing/harness/temporal/__init__.py`
+- **Defined in:** `application_sdk/testing/harness/temporal/_states.py`
 
 #### `WriteRecovery`
 
@@ -4028,6 +4079,14 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Signature:** `format_validation_report(results: list[dict[str, Any]])`
 - **Summary:** Format pandera validation results into a human-readable report.
 - **Defined in:** `application_sdk/testing/integration/validation.py`
+
+#### `frontend_connection`
+
+- **Import:** `from application_sdk.testing.harness.temporal import frontend_connection`
+- **Also importable from:** `application_sdk.testing.harness.temporal.client`
+- **Signature:** `frontend_connection(*, address: str, namespace: str, api_key: str | None = None, tls: bool = False)`
+- **Summary:** Connect to a Temporal frontend at a known address.
+- **Defined in:** `application_sdk/testing/harness/temporal/client.py`
 
 #### `generate_json_report`
 
@@ -4336,6 +4395,14 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Summary:** Hold one tunnel to a Service for a batch of calls.
 - **Defined in:** `application_sdk/testing/harness/cluster/_portforward.py`
 
+#### `port_forwarded_connection`
+
+- **Import:** `from application_sdk.testing.harness.temporal import port_forwarded_connection`
+- **Also importable from:** `application_sdk.testing.harness.temporal.client`
+- **Signature:** `port_forwarded_connection(*, *, ...)`
+- **Summary:** Connect to an in-cluster Temporal frontend Service through a tunnel.
+- **Defined in:** `application_sdk/testing/harness/temporal/client.py`
+
 #### `purge_connection`
 
 - **Import:** `from application_sdk.testing.harness.teardown import purge_connection`
@@ -4385,6 +4452,13 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Signature:** `sample_qualified_names(client: AsyncAtlanClient, *, ...)`
 - **Summary:** Sample up to *per_type* qualified names per type under the connection.
 - **Defined in:** `application_sdk/testing/harness/atlas/__init__.py`
+
+#### `stale_version_pollers`
+
+- **Import:** `from application_sdk.testing.harness.temporal import stale_version_pollers`
+- **Signature:** `stale_version_pollers(pollers: Iterable[PollerInfo], *, current_build_id: str | None)`
+- **Summary:** Return the pollers that are *not* on *current_build_id*.
+- **Defined in:** `application_sdk/testing/harness/temporal/_states.py`
 
 #### `start_on_task_queue`
 

--- a/tests/e2e/test_temporal_reader_live.py
+++ b/tests/e2e/test_temporal_reader_live.py
@@ -1,0 +1,185 @@
+"""Live-frontend smoke test for the Temporal reader.
+
+FND-247's acceptance criterion is that both readers work, and unit tests with a
+scripted client cannot establish it. What they cannot check is that a real
+frontend is reachable through a ``kubectl port-forward`` tunnel at all, that the
+wire fields this backend reads are the ones a real frontend populates — a poller
+with a ``deployment_options.build_id`` only exists where Worker Deployment
+versioning is actually in use — and that a queue name referring to nothing
+answers **empty** while an unreachable frontend **raises**. Those two answering
+differently is the entire point of the read, and it is only observable here.
+
+So it lives as an explicit, opt-in check rather than as prose in a PR
+description. Requires VPN plus a logged-in ``kubectl`` context, which is why it
+is ``e2e``-marked and skipped without a queue to point at::
+
+    E2E_TEMPORAL_QUEUE=atlan-hello-world-default \\
+    E2E_TEMPORAL_FRONTEND_NAMESPACE=temporal \\
+        uv run pytest tests/e2e/test_temporal_reader_live.py -m e2e -v
+
+``E2E_TEMPORAL_FRONTEND_SERVICE`` and ``E2E_TEMPORAL_FRONTEND_PORT`` override the
+Service the tunnel targets; ``E2E_TEMPORAL_NAMESPACE`` overrides the Temporal
+namespace (not the Kubernetes one — they are different things and the variables
+are named apart for that reason). Point ``E2E_TEMPORAL_ADDRESS`` at a frontend
+directly to skip the tunnel entirely, which is what a driver already inside the
+cluster would do.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import AsyncIterator
+
+import pytest
+
+from application_sdk.testing.harness.cluster import ServiceTarget
+from application_sdk.testing.harness.temporal import (
+    PollerInfo,
+    TaskQueueType,
+    TemporalReadFailedError,
+    TemporalServiceReader,
+    WorkflowNotFoundError,
+    frontend_connection,
+    port_forwarded_connection,
+    stale_version_pollers,
+)
+
+pytestmark = pytest.mark.e2e
+
+_QUEUE_ENV = "E2E_TEMPORAL_QUEUE"
+
+
+@pytest.fixture(scope="module")
+def queue() -> str:
+    value = os.environ.get(_QUEUE_ENV)
+    if not value:
+        pytest.skip(f"set {_QUEUE_ENV} to a task queue a worker is polling")
+    return value
+
+
+@pytest.fixture(scope="module")
+def temporal_namespace() -> str:
+    return os.environ.get("E2E_TEMPORAL_NAMESPACE", "default")
+
+
+@pytest.fixture
+async def reader(temporal_namespace: str) -> AsyncIterator[TemporalServiceReader]:
+    """A reader over whichever connection the environment describes.
+
+    Both factories are exercised by this one fixture on purpose: which one a run
+    uses is the only difference between an out-of-cluster driver and an in-cluster
+    one, and that is exactly the seam FND-248 arrives through.
+    """
+    address = os.environ.get("E2E_TEMPORAL_ADDRESS")
+
+    async def _connect():
+        if address:
+            return await frontend_connection(
+                address=address, namespace=temporal_namespace
+            )
+        return await port_forwarded_connection(
+            target=ServiceTarget(
+                namespace=os.environ.get("E2E_TEMPORAL_FRONTEND_NAMESPACE", "temporal"),
+                service=os.environ.get(
+                    "E2E_TEMPORAL_FRONTEND_SERVICE", "temporal-frontend"
+                ),
+                port=int(os.environ.get("E2E_TEMPORAL_FRONTEND_PORT", "7233")),
+            ),
+            namespace=temporal_namespace,
+        )
+
+    built = TemporalServiceReader(connect=_connect)
+    try:
+        yield built
+    finally:
+        await built.aclose()
+
+
+async def test_a_real_worker_is_polling_both_halves_of_its_queue(
+    reader: TemporalServiceReader, queue: str, temporal_namespace: str
+) -> None:
+    """Every field the backend claims to read is present on a real poller."""
+    pollers = await reader.task_queue_pollers(queue, namespace=temporal_namespace)
+
+    assert pollers, f"nothing is polling {queue} — point at a queue that has a worker"
+    for entry in pollers:
+        assert isinstance(entry, PollerInfo)
+        assert entry.identity, "a real poller always reports an identity"
+        assert entry.last_access.tzinfo is not None
+        # A versioned worker reports its Worker Deployment, not just a build id:
+        # the pair is what a TemporalWorkerDeployment's intended version can be
+        # matched against.
+        if entry.build_id is not None:
+            assert entry.deployment_name is not None
+
+    # Both halves, which is what makes a half-polling worker visible.
+    seen = {entry.task_queue_type for entry in pollers}
+    assert TaskQueueType.WORKFLOW in seen, (
+        "no workflow-task poller: the queue has an activity poller only, which is "
+        "the half-polling shape this read exists to surface"
+    )
+
+
+async def test_the_intended_version_is_the_one_holding_the_queue(
+    reader: TemporalServiceReader, queue: str, temporal_namespace: str
+) -> None:
+    """The precondition gate's second half, against a real frontend.
+
+    The intended version comes from the ``TemporalWorkerDeployment`` in a real
+    scenario; here the majority build id stands in for it, which still exercises
+    the predicate against real poller shapes and still fails if two builds are
+    both holding the queue.
+    """
+    pollers = await reader.task_queue_pollers(queue, namespace=temporal_namespace)
+    build_ids = {entry.build_id for entry in pollers}
+    if build_ids == {None}:
+        pytest.skip("this deployment does not use Worker Deployment versioning")
+
+    current = max(
+        (b for b in build_ids if b is not None),
+        key=lambda b: sum(1 for entry in pollers if entry.build_id == b),
+    )
+    stale = stale_version_pollers(pollers, current_build_id=current)
+
+    assert not stale, (
+        "more than one build is polling this queue: "
+        f"{sorted({entry.build_id for entry in stale}, key=str)} alongside {current}"
+    )
+
+
+async def test_a_queue_name_that_refers_to_nothing_answers_empty(
+    reader: TemporalServiceReader, temporal_namespace: str
+) -> None:
+    """The largest uncaught regression class, and the only read that catches it:
+    a well-formed queue name that nothing polls."""
+    pollers = await reader.task_queue_pollers(
+        "fnd247-no-such-queue", namespace=temporal_namespace
+    )
+
+    assert pollers == []
+
+
+async def test_a_namespace_nobody_has_raises_rather_than_answering_empty(
+    reader: TemporalServiceReader, queue: str
+) -> None:
+    """The other side of the same line, and the one that matters: empty is the
+    finding this read delivers, so an unreadable frontend must not produce it."""
+    with pytest.raises(TemporalReadFailedError) as raised:
+        await reader.task_queue_pollers(queue, namespace="fnd247-no-such-namespace")
+
+    assert raised.value.rpc_status in ("NOT_FOUND", "PERMISSION_DENIED")
+
+
+async def test_a_workflow_nobody_started_is_absent_rather_than_an_error(
+    reader: TemporalServiceReader,
+) -> None:
+    """The nullable read, so a wait for AE-dispatched work has a value to test."""
+    assert await reader.find_workflow_status("fnd247-no-such-workflow") is None
+
+
+async def test_the_strict_read_raises_not_found_for_the_same_workflow(
+    reader: TemporalServiceReader,
+) -> None:
+    """And the strict twin fails at once rather than being absorbed by a wait."""
+    with pytest.raises(WorkflowNotFoundError):
+        await reader.workflow_status("fnd247-no-such-workflow")

--- a/tests/integration/testing/test_portforward.py
+++ b/tests/integration/testing/test_portforward.py
@@ -9,6 +9,9 @@ cluster backend (FND-241); this imports the private helper from where it now
 lives, since ``testing/e2e/portforward`` re-exports only the public surface.
 """
 
+import socket
+from unittest.mock import patch
+
 import pytest
 
 from application_sdk.testing.harness.cluster._portforward import _find_free_port
@@ -18,4 +21,35 @@ from application_sdk.testing.harness.cluster._portforward import _find_free_port
 def test_find_free_port_returns_integer():
     port = _find_free_port()
     assert isinstance(port, int)
+    assert 1024 <= port <= 65535
+
+
+@pytest.mark.integration
+def test_find_free_port_binds_loopback_only():
+    """The probe binds loopback, not every interface.
+
+    Asserted on the address the socket is actually bound to rather than on the
+    returned port, because ``""`` and ``"127.0.0.1"`` both return a plausible
+    port and the difference is invisible in the return value — the same reason
+    the ``kube_context`` and ``--context`` pins assert on what was constructed.
+
+    It is the more accurate question to ask: ``kubectl port-forward`` binds its
+    local end to loopback, so "free on ``0.0.0.0``" is not the claim this
+    function needs to make. It is *not* a fix for a port ``kubectl`` could then
+    fail to take — a TCP bind conflicts symmetrically, so the kernel's ephemeral
+    choice avoided conflicts under either address. See the docstring on
+    :func:`_find_free_port` for that distinction, which matters because the
+    plausible mechanism is the wrong one.
+    """
+    bound: list[tuple[str, int]] = []
+    real_bind = socket.socket.bind
+
+    def _record(self: socket.socket, address: tuple[str, int]) -> None:
+        bound.append(address)
+        return real_bind(self, address)
+
+    with patch.object(socket.socket, "bind", _record):
+        port = _find_free_port()
+
+    assert bound == [("127.0.0.1", 0)]
     assert 1024 <= port <= 65535

--- a/tests/unit/testing/_temporal_fakes.py
+++ b/tests/unit/testing/_temporal_fakes.py
@@ -1,0 +1,310 @@
+"""Test doubles for the ``temporalio`` Temporal reader (FND-247).
+
+The doubles hand back **real protobuf messages and a real
+``WorkflowExecutionDescription``**, for the reason
+:mod:`tests.unit.testing._cluster_fakes` hands back real sanitized dicts: the
+conversion under test is the production one, not a mock-shaped variant of it.
+Every field-name assumption in ``client.py`` — ``deployment_options.build_id``
+versus ``worker_version_capabilities.build_id``, ``last_access_time``,
+``history_length`` — is therefore checked against the wire's own definitions
+rather than against a stub that would agree with any spelling.
+
+The narrowing needs a *real* ``RPCError`` for the same reason: the backend
+converts only ``temporalio``'s error type and lets everything else through, so a
+stub exception would let a test pass against a narrowing that had stopped
+working.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable, Sequence
+from datetime import datetime
+from typing import Any
+
+from temporalio.api.common.v1 import WorkerVersionCapabilities
+from temporalio.api.common.v1 import WorkflowExecution as WireWorkflowExecution
+from temporalio.api.common.v1 import WorkflowType
+from temporalio.api.deployment.v1 import WorkerDeploymentOptions
+from temporalio.api.enums.v1 import WorkflowExecutionStatus as WireStatus
+from temporalio.api.taskqueue.v1 import PollerInfo as WirePollerInfo
+from temporalio.api.workflow.v1 import WorkflowExecutionInfo
+from temporalio.api.workflowservice.v1 import (
+    DescribeTaskQueueRequest,
+    DescribeTaskQueueResponse,
+    DescribeWorkflowExecutionResponse,
+)
+from temporalio.client import WorkflowExecutionDescription
+from temporalio.converter import DataConverter
+from temporalio.service import RPCError, RPCStatusCode
+
+from application_sdk.testing.harness.temporal import (
+    TemporalConnection,
+    TemporalServiceReader,
+)
+
+__all__ = [
+    "FakeTemporal",
+    "RPCError",
+    "RPCStatusCode",
+    "describe_response",
+    "on_a_fresh_loop",
+    "poller",
+    "reader_over",
+    "rpc_error",
+    "workflow_description",
+]
+
+#: A ``BaseException`` in a fake's script means "the frontend answered with this".
+Answer = object | BaseException
+
+
+def _answer(value: Answer) -> Any:
+    if isinstance(value, BaseException):
+        raise value
+    return value
+
+
+def rpc_error(status: RPCStatusCode, message: str = "boom") -> RPCError:
+    """A real ``RPCError`` carrying *status*.
+
+    ``raw_grpc_status`` is empty because nothing under test reads it; the status
+    is what the backend narrows on.
+    """
+    return RPCError(message, status, b"")
+
+
+def poller(
+    identity: str,
+    *,
+    build_id: str | None = None,
+    deployment_name: str | None = None,
+    legacy_build_id: str | None = None,
+    last_access: datetime | None = None,
+) -> WirePollerInfo:
+    """One wire poller.
+
+    Args:
+        identity: The worker's self-reported identity.
+        build_id: Build id on ``deployment_options`` — the Worker Deployment
+            shape this SDK's worker actually sets.
+        deployment_name: Deployment name on ``deployment_options``.
+        legacy_build_id: Build id on ``worker_version_capabilities`` — the older
+            shape, present so the fallback can be exercised without the new one.
+        last_access: When Temporal last saw the poller. Left unset to exercise
+            the epoch the wire renders for an absent timestamp.
+    """
+    entry = WirePollerInfo(identity=identity)
+    if build_id is not None or deployment_name is not None:
+        entry.deployment_options.CopyFrom(
+            WorkerDeploymentOptions(
+                build_id=build_id or "", deployment_name=deployment_name or ""
+            )
+        )
+    if legacy_build_id is not None:
+        entry.worker_version_capabilities.CopyFrom(
+            WorkerVersionCapabilities(build_id=legacy_build_id, use_versioning=True)
+        )
+    if last_access is not None:
+        entry.last_access_time.FromDatetime(last_access)
+    return entry
+
+
+def describe_response(*pollers: WirePollerInfo) -> DescribeTaskQueueResponse:
+    """A ``DescribeTaskQueue`` answer carrying *pollers*."""
+    return DescribeTaskQueueResponse(pollers=list(pollers))
+
+
+async def workflow_description(
+    *,
+    workflow_id: str = "wf-1",
+    run_id: str = "run-1",
+    status: WireStatus.ValueType = WireStatus.WORKFLOW_EXECUTION_STATUS_RUNNING,
+    task_queue: str = "atlan-hello-world-default",
+    history_length: int = 42,
+    started_at: datetime | None = None,
+    closed_at: datetime | None = None,
+    workflow_type: str = "MetadataExtraction",
+) -> WorkflowExecutionDescription:
+    """A real ``WorkflowExecutionDescription``, built from a real wire response.
+
+    ``temporalio``'s own conversion runs, so the field names the backend reads
+    are the ones the client actually publishes rather than the ones a stub was
+    written to expose.
+    """
+    info = WorkflowExecutionInfo(
+        execution=WireWorkflowExecution(workflow_id=workflow_id, run_id=run_id),
+        type=WorkflowType(name=workflow_type),
+        task_queue=task_queue,
+        status=status,
+        history_length=history_length,
+    )
+    if started_at is not None:
+        info.start_time.FromDatetime(started_at)
+    if closed_at is not None:
+        info.close_time.FromDatetime(closed_at)
+    return await WorkflowExecutionDescription._from_raw_description(
+        DescribeWorkflowExecutionResponse(workflow_execution_info=info),
+        "default",
+        DataConverter.default,
+    )
+
+
+class _FakeWorkflowService:
+    """The one ``workflow_service`` verb the poller read calls."""
+
+    def __init__(self, fake: FakeTemporal) -> None:
+        self._fake = fake
+
+    async def describe_task_queue(
+        self, req: DescribeTaskQueueRequest, **kwargs: Any
+    ) -> DescribeTaskQueueResponse:
+        self._fake.calls.append(("describe_task_queue", req, kwargs))
+        return _answer(self._fake.next_pollers())
+
+
+class _FakeHandle:
+    """The one handle verb the status read calls."""
+
+    def __init__(
+        self, fake: FakeTemporal, workflow_id: str, run_id: str | None
+    ) -> None:
+        self._fake = fake
+        self._workflow_id = workflow_id
+        self._run_id = run_id
+
+    async def describe(self, **kwargs: Any) -> WorkflowExecutionDescription:
+        self._fake.calls.append(("describe", (self._workflow_id, self._run_id), kwargs))
+        return _answer(self._fake.next_description())
+
+
+class _FakeClient:
+    """Shaped like the parts of ``temporalio.client.Client`` a read touches."""
+
+    def __init__(self, fake: FakeTemporal) -> None:
+        self.workflow_service = _FakeWorkflowService(fake)
+        self._fake = fake
+
+    def get_workflow_handle(
+        self, workflow_id: str, *, run_id: str | None = None, **_: Any
+    ) -> _FakeHandle:
+        return _FakeHandle(self._fake, workflow_id, run_id)
+
+
+class FakeTemporal:
+    """Scripted answers for one reader, plus a record of what was asked.
+
+    Both scripts are *sequences* consumed one entry per call, so a test can say
+    "the first read drops the connection, the second succeeds" — the shape the
+    rebuild-once path needs — and the last entry repeats once the script runs out,
+    so the common case stays a single value.
+
+    Args:
+        pollers: What each ``describe_task_queue`` answers with, in order. A
+            ``BaseException`` is raised instead of returned.
+        descriptions: What each ``describe`` answers with, in order.
+    """
+
+    def __init__(
+        self,
+        *,
+        pollers: Sequence[Answer] = (),
+        descriptions: Sequence[Answer] = (),
+    ) -> None:
+        self.calls: list[tuple[str, Any, dict[str, Any]]] = []
+        self.connects: list[str] = []
+        self.closes = 0
+        self._pollers = list(pollers) or [describe_response()]
+        self._descriptions = list(descriptions)
+        self._poller_index = 0
+        self._description_index = 0
+
+    # -- the connection factory --------------------------------------------
+
+    def connect(
+        self, address: str = "127.0.0.1:7233"
+    ) -> Callable[[], Awaitable[TemporalConnection]]:
+        """A ``connect`` factory that records every build and every close.
+
+        The ``sleep(0)`` is load-bearing and must not be tidied away. Without a
+        real suspension point inside the connect, an ``asyncio.gather`` over
+        several first reads runs each one start-to-finish and no interleaving
+        occurs — so a concurrency test built on this fake passes with the
+        reader's lock *removed*, asserting only that a sequential program opens
+        one connection. Verified by removal: with the yield, dropping the lock
+        gives 5 connections; without it, 1 either way.
+
+        It also has to precede the append, not follow it: the guard reads the
+        state this records, so a yield after it proves nothing.
+        """
+
+        async def _build() -> TemporalConnection:
+            await asyncio.sleep(0)
+            self.connects.append(address)
+            return TemporalConnection(
+                client=_FakeClient(self),  # type: ignore[arg-type]
+                namespace="default",
+                address=address,
+                close=self._close,
+            )
+
+        return _build
+
+    async def _close(self) -> None:
+        self.closes += 1
+
+    # -- the scripts --------------------------------------------------------
+
+    def next_pollers(self) -> Answer:
+        value = self._pollers[min(self._poller_index, len(self._pollers) - 1)]
+        self._poller_index += 1
+        return value
+
+    def next_description(self) -> Answer:
+        if not self._descriptions:
+            raise AssertionError("no `descriptions` were scripted for this fake")
+        value = self._descriptions[
+            min(self._description_index, len(self._descriptions) - 1)
+        ]
+        self._description_index += 1
+        return value
+
+    # -- what was asked -----------------------------------------------------
+
+    def verbs(self) -> list[str]:
+        """Every call made, in order."""
+        return [name for name, _payload, _kwargs in self.calls]
+
+    def requests(self) -> list[DescribeTaskQueueRequest]:
+        """Every ``DescribeTaskQueue`` request, in order."""
+        return [
+            payload
+            for name, payload, _kwargs in self.calls
+            if name == "describe_task_queue"
+        ]
+
+    def kwargs_for(self, verb: str) -> dict[str, Any]:
+        """The keyword arguments the reader passed to *verb*, first call."""
+        for name, _payload, kwargs in self.calls:
+            if name == verb:
+                return kwargs
+        raise AssertionError(f"{verb} was never called; saw {self.verbs()}")
+
+
+def reader_over(fake: FakeTemporal, **kwargs: Any) -> TemporalServiceReader:
+    """A reader wired to *fake* instead of to a real frontend."""
+    return TemporalServiceReader(connect=fake.connect(), **kwargs)
+
+
+def on_a_fresh_loop(work: Callable[[], Awaitable[Any]]) -> Any:
+    """Run *work* on a loop of its own, then close it.
+
+    For the loop-affinity tests, which need two genuinely different loops. The
+    loop is closed in a ``finally`` so a failing assertion does not leave one
+    behind for the next test to trip over.
+    """
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(work())
+    finally:
+        loop.close()

--- a/tests/unit/testing/harness/cluster/test_portforward.py
+++ b/tests/unit/testing/harness/cluster/test_portforward.py
@@ -15,6 +15,7 @@ import httpx
 import pytest
 
 from application_sdk.testing.harness.cluster._portforward import (
+    PortForward,
     _wait_for_port,
     kube_http_call,
     port_forward,
@@ -416,3 +417,157 @@ async def test_no_override_leaves_the_sessions_own_timeout_in_place():
     assert request.await_args is not None
     assert "timeout" not in request.await_args.kwargs
     assert session.timeout == 11.0
+
+
+# ---------------------------------------------------------------------------
+# The tunnel's address, for a client this module cannot make the call for
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_address_opens_the_tunnel_and_names_its_near_end():
+    """``temporalio`` speaks gRPC and takes a bare ``host:port``, so the Temporal
+    reader needs the tunnel's near end rather than an HTTP session over it."""
+    pf_proc = _kubectl_proc()
+
+    with (
+        patch(_STUB_PORT, return_value=54321),
+        patch("asyncio.create_subprocess_exec", return_value=pf_proc) as mock_exec,
+        patch(_STUB_WAIT, new=AsyncMock()),
+    ):
+        async with port_forward("ns", "svc", 7233) as session:
+            assert await session.address() == "127.0.0.1:54321"
+
+    assert mock_exec.call_count == 1
+    pf_proc.terminate.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_the_address_and_a_request_share_one_tunnel():
+    """The reason ``address`` is on this class rather than a second
+    implementation elsewhere: a session that is asked for both opens one
+    ``kubectl`` process, not two."""
+    pf_proc = _kubectl_proc()
+    mock_response = MagicMock(spec=httpx.Response)
+
+    with (
+        patch(_STUB_PORT, return_value=54321),
+        patch("asyncio.create_subprocess_exec", return_value=pf_proc) as mock_exec,
+        patch(_STUB_WAIT, new=AsyncMock()),
+        patch("httpx.AsyncClient.request", new=AsyncMock(return_value=mock_response)),
+    ):
+        async with port_forward("ns", "svc", 7233) as session:
+            address = await session.address()
+            await session.request("GET", "/status")
+            assert await session.address() == address
+
+    assert mock_exec.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_a_closed_session_reopens_on_the_next_address_call():
+    """``aclose`` clears the port as well as the client, so a reused session does
+    not hand out the address of a tunnel it has already terminated."""
+    procs = [_kubectl_proc(), _kubectl_proc()]
+
+    with (
+        patch(_STUB_PORT, side_effect=[54321, 54322]),
+        patch("asyncio.create_subprocess_exec", side_effect=procs),
+        patch(_STUB_WAIT, new=AsyncMock()),
+    ):
+        async with port_forward("ns", "svc", 7233) as session:
+            assert await session.address() == "127.0.0.1:54321"
+            await session.aclose()
+            assert await session.address() == "127.0.0.1:54322"
+
+
+@pytest.mark.asyncio
+async def test_an_address_on_a_tunnel_that_never_opens_does_not_leak_the_process():
+    """Same leak the HTTP path guards: the ``kubectl`` child is already running by
+    the time the readiness wait gives up."""
+    pf_proc = _kubectl_proc()
+
+    with (
+        patch(_STUB_PORT, return_value=54321),
+        patch("asyncio.create_subprocess_exec", return_value=pf_proc),
+        patch(_STUB_WAIT, new=AsyncMock(side_effect=TimeoutError("never ready"))),
+        pytest.raises(TimeoutError),
+    ):
+        async with port_forward("ns", "svc", 7233) as session:
+            await session.address()
+
+    pf_proc.terminate.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_first_calls_spawn_exactly_one_tunnel():
+    """Both lazy-open entry points serialise on the same lock.
+
+    `address()` and `request()` are two separate doors onto one spawn, so a guard
+    covering only the HTTP one lets them race into two `kubectl` processes and
+    leak the unreferenced one — the leak FND-241 closed, reopened by FND-247
+    adding the second door.
+
+    `_wait_for_port` is replaced with a function that actually yields, and that
+    is the whole test. Patched with a bare `AsyncMock` it completes without ever
+    returning to the event loop, so `gather` runs each task start-to-finish and
+    the interleaving this exists to catch cannot occur — the test passes with the
+    lock removed. Verified by removing it: one real suspension point is the
+    difference between a regression test and a green line.
+    """
+    procs = [_kubectl_proc(), _kubectl_proc(), _kubectl_proc(), _kubectl_proc()]
+    mock_response = MagicMock(spec=httpx.Response)
+
+    async def _yielding_wait(*_args: Any, **_kwargs: Any) -> None:
+        await asyncio.sleep(0)
+
+    with (
+        patch(_STUB_PORT, side_effect=[54321, 54322, 54323, 54324]),
+        patch("asyncio.create_subprocess_exec", side_effect=procs) as mock_exec,
+        patch(_STUB_WAIT, new=_yielding_wait),
+        patch("httpx.AsyncClient.request", new=AsyncMock(return_value=mock_response)),
+    ):
+        async with port_forward("ns", "svc", 7233) as session:
+            await asyncio.gather(
+                session.address(),
+                session.request("GET", "/status"),
+                session.address(),
+                session.request("GET", "/status"),
+            )
+
+    assert mock_exec.call_count == 1, (
+        f"{mock_exec.call_count} kubectl processes spawned for one tunnel; "
+        "all but one are leaked"
+    )
+
+
+@pytest.mark.asyncio
+async def test_aclose_clears_both_fields_so_the_next_open_rebuilds():
+    """`aclose` has to clear the port as well as the client.
+
+    Deliberately NOT a claim that the spawn/client window is closed — this is
+    sequential, and a sequential test cannot demonstrate a race. What it pins is
+    the invariant the window fix relies on: after `aclose`, neither `_client` nor
+    `_local_port` survives, so nothing can point a fresh client at a terminated
+    process by reading a stale port.
+    """
+    procs = [_kubectl_proc(), _kubectl_proc()]
+
+    with (
+        patch(_STUB_PORT, side_effect=[54321, 54322]),
+        patch("asyncio.create_subprocess_exec", side_effect=procs),
+        patch(_STUB_WAIT, new=AsyncMock()),
+    ):
+        session = PortForward("ns", "svc", 7233)
+        client = await session._opened()
+        assert str(client.base_url) == "http://127.0.0.1:54321"
+        assert session._local_port == 54321
+
+        await session.aclose()
+        assert session._client is None
+        assert session._local_port is None
+
+        rebuilt = await session._opened()
+        assert str(rebuilt.base_url) == "http://127.0.0.1:54322"
+        assert session._local_port == 54322
+        await session.aclose()

--- a/tests/unit/testing/harness/temporal/__init__.py
+++ b/tests/unit/testing/harness/temporal/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for the Temporal reader (FND-247)."""

--- a/tests/unit/testing/harness/temporal/test_temporal_reads.py
+++ b/tests/unit/testing/harness/temporal/test_temporal_reads.py
@@ -1,0 +1,1222 @@
+"""Unit tests for the ``temporalio`` Temporal reader.
+
+Two claims get most of the attention, because they are the two the issue is
+about. The first is that an unreadable frontend never answers "no pollers": that
+is the finding this read exists to deliver, so a failure that returned an empty
+list would not lose a diagnosis, it would invent one. The second is that "no such
+workflow" and "could not read" stay distinguishable by type, since a bounded wait
+absorbs one and must fail at once on the other.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import itertools
+import threading
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from temporalio.client import Client
+
+from application_sdk.testing.harness.temporal import (
+    PollerInfo,
+    TaskQueueType,
+    TemporalConnectFailedError,
+    TemporalConnection,
+    TemporalReader,
+    TemporalReaderLoopMismatchError,
+    TemporalReadFailedError,
+    TemporalServiceReader,
+    WorkflowExecutionStatus,
+    WorkflowNotFoundError,
+    stale_version_pollers,
+)
+from application_sdk.testing.harness.temporal.client import frontend_connection
+from tests.unit.testing._temporal_fakes import (
+    FakeTemporal,
+    RPCStatusCode,
+    _FakeClient,
+    describe_response,
+    on_a_fresh_loop,
+    poller,
+    reader_over,
+    rpc_error,
+    workflow_description,
+)
+
+_QUEUE = "atlan-hello-world-default"
+
+
+# ---------------------------------------------------------------------------
+# Protocol conformance
+# ---------------------------------------------------------------------------
+
+
+def test_the_reader_satisfies_the_protocol():
+    assert isinstance(reader_over(FakeTemporal()), TemporalReader)
+
+
+def test_the_reader_satisfies_the_protocol_statically_too():
+    """``isinstance`` on a ``runtime_checkable`` Protocol only checks that the
+    methods exist, so it would pass a backend whose *signatures* had drifted. The
+    annotation is what pyright checks — and the drift worth catching is the
+    ``task_queue_types`` keyword the backend adds beyond the Protocol, which is
+    only compatible while it stays optional."""
+    reader: TemporalReader = reader_over(FakeTemporal())
+
+    assert reader is not None
+
+
+def test_a_plain_object_satisfies_the_protocol_by_shape():
+    """No consumer has to inherit from it — the runtime suite's own reader will
+    not."""
+
+    class Fake:
+        async def task_queue_pollers(self, queue, *, namespace): ...
+        async def workflow_status(self, workflow_id, *, run_id=None): ...
+
+    assert isinstance(Fake(), TemporalReader)
+
+
+# ---------------------------------------------------------------------------
+# The poller read
+# ---------------------------------------------------------------------------
+
+
+async def test_no_pollers_is_a_value_not_a_wait():
+    """The whole point: zero pollers is an answer available on the first probe,
+    where ``NoWorkerOnTaskQueueError`` currently infers it from three minutes of
+    silence."""
+    fake = FakeTemporal(pollers=[describe_response()])
+
+    assert await reader_over(fake).task_queue_pollers(_QUEUE, namespace="default") == []
+
+
+async def test_both_queue_halves_are_read_and_tagged():
+    """A task-queue name addresses two queues and a worker polls both, so a
+    single read answers a narrower question than "is anything polling"."""
+    fake = FakeTemporal(pollers=[describe_response(poller("1@host"))])
+
+    pollers = await reader_over(fake).task_queue_pollers(_QUEUE, namespace="default")
+
+    assert [p.task_queue_type for p in pollers] == [
+        TaskQueueType.WORKFLOW,
+        TaskQueueType.ACTIVITY,
+    ]
+    assert len(fake.requests()) == 2
+
+
+async def test_a_half_polling_worker_is_visible_rather_than_collapsed():
+    """The zombie shape: the workflow poll loop died while the process — and its
+    activity poll loop — stayed alive. A union count reports one poller and hides
+    it; per-half tagging is what makes it a finding."""
+    fake = FakeTemporal(
+        pollers=[describe_response(), describe_response(poller("1@host"))]
+    )
+
+    pollers = await reader_over(fake).task_queue_pollers(_QUEUE, namespace="default")
+
+    assert [p.task_queue_type for p in pollers] == [TaskQueueType.ACTIVITY]
+
+
+async def test_a_caller_can_narrow_to_one_half():
+    fake = FakeTemporal(pollers=[describe_response(poller("1@host"))])
+
+    pollers = await reader_over(fake).task_queue_pollers(
+        _QUEUE, namespace="default", task_queue_types=[TaskQueueType.WORKFLOW]
+    )
+
+    assert [p.task_queue_type for p in pollers] == [TaskQueueType.WORKFLOW]
+    assert len(fake.requests()) == 1
+
+
+async def test_an_empty_task_queue_types_reads_nothing_and_makes_no_rpc():
+    """``[]`` is honoured as itself, not taken for "unspecified".
+
+    ``tuple(task_queue_types or _DEFAULT_TASK_QUEUE_TYPES)`` promoted an empty
+    sequence to *both* halves — the exact opposite of what was asked, silently.
+    A caller narrowing types from a config that happens to resolve empty would
+    get two RPCs and a poller list it did not ask for, and nothing would say so.
+    """
+    fake = FakeTemporal()
+
+    pollers = await reader_over(fake).task_queue_pollers(
+        _QUEUE, namespace="default", task_queue_types=[]
+    )
+
+    assert pollers == []
+    assert fake.requests() == []
+    # No read means no reason to connect either.
+    assert fake.connects == []
+
+
+async def test_the_request_carries_the_queue_and_the_namespace_asked_for():
+    """``DescribeTaskQueue`` takes the namespace in the request, so one
+    connection reads across namespaces — and a wrong namespace has to be visible
+    in what was sent."""
+    fake = FakeTemporal()
+
+    await reader_over(fake).task_queue_pollers(_QUEUE, namespace="other-ns")
+
+    request = fake.requests()[0]
+    assert request.namespace == "other-ns"
+    assert request.task_queue.name == _QUEUE
+
+
+async def test_the_deployment_build_id_is_preferred_over_the_legacy_field():
+    """This SDK's worker sets ``deployment_options``; reading only the legacy
+    field would report every versioned Atlan worker as unversioned."""
+    fake = FakeTemporal(
+        pollers=[
+            describe_response(
+                poller(
+                    "1@host",
+                    build_id="sha-new",
+                    deployment_name="hello-world",
+                    legacy_build_id="sha-old",
+                )
+            )
+        ]
+    )
+
+    pollers = await reader_over(fake).task_queue_pollers(
+        _QUEUE, namespace="default", task_queue_types=[TaskQueueType.WORKFLOW]
+    )
+
+    assert pollers[0].build_id == "sha-new"
+    assert pollers[0].deployment_name == "hello-world"
+
+
+async def test_the_legacy_build_id_is_still_read_when_it_is_the_only_one():
+    fake = FakeTemporal(
+        pollers=[describe_response(poller("1@host", legacy_build_id="sha-old"))]
+    )
+
+    pollers = await reader_over(fake).task_queue_pollers(
+        _QUEUE, namespace="default", task_queue_types=[TaskQueueType.WORKFLOW]
+    )
+
+    assert pollers[0].build_id == "sha-old"
+
+
+async def test_an_unversioned_poller_reports_no_build_id_rather_than_an_empty_one():
+    """Protobuf has no null for a scalar, so an unset ``build_id`` arrives as
+    ``""`` — which would compare unequal to every real build while claiming to be
+    one."""
+    fake = FakeTemporal(pollers=[describe_response(poller("1@host"))])
+
+    pollers = await reader_over(fake).task_queue_pollers(
+        _QUEUE, namespace="default", task_queue_types=[TaskQueueType.WORKFLOW]
+    )
+
+    assert pollers[0].build_id is None
+    assert pollers[0].deployment_name is None
+
+
+async def test_last_access_comes_back_timezone_aware():
+    """A naive value compared against an aware ``now()`` raises at the call site,
+    hours from the conversion that produced it."""
+    seen = datetime(2026, 8, 26, 12, 30, tzinfo=timezone.utc)
+    fake = FakeTemporal(pollers=[describe_response(poller("1@host", last_access=seen))])
+
+    pollers = await reader_over(fake).task_queue_pollers(
+        _QUEUE, namespace="default", task_queue_types=[TaskQueueType.WORKFLOW]
+    )
+
+    assert pollers[0].last_access == seen
+    assert pollers[0].last_access.tzinfo is not None
+
+
+async def test_an_unreadable_frontend_raises_rather_than_reporting_no_pollers():
+    """The C4 fix, at the one read where a fail-open would *fabricate* the
+    finding rather than merely lose it."""
+    fake = FakeTemporal(pollers=[rpc_error(RPCStatusCode.PERMISSION_DENIED)])
+
+    with pytest.raises(TemporalReadFailedError) as raised:
+        await reader_over(fake).task_queue_pollers(_QUEUE, namespace="default")
+
+    assert raised.value.rpc_status == "PERMISSION_DENIED"
+    assert raised.value.address == "127.0.0.1:7233"
+    assert raised.value.temporal_namespace == "default"
+    assert raised.value.effective_retryable is True
+
+
+async def test_the_second_half_is_not_read_after_the_first_one_failed():
+    """A partial answer is worse than none: half a poller list looks exactly like
+    a half-polling worker, which is a real finding this must not manufacture."""
+    fake = FakeTemporal(pollers=[rpc_error(RPCStatusCode.PERMISSION_DENIED)])
+
+    with pytest.raises(TemporalReadFailedError):
+        await reader_over(fake).task_queue_pollers(_QUEUE, namespace="default")
+
+    assert len(fake.requests()) == 1
+
+
+async def test_a_wiring_bug_is_not_dressed_up_as_a_dependency_failure():
+    """A ``TypeError`` reported as ``DEPENDENCY_UNAVAILABLE`` would be absorbed by
+    a wait's transient budget and burn the window instead of failing at once."""
+    fake = FakeTemporal(pollers=[TypeError("bad signature")])
+
+    with pytest.raises(TypeError):
+        await reader_over(fake).task_queue_pollers(_QUEUE, namespace="default")
+
+
+async def test_the_per_call_timeout_is_handed_to_the_rpc():
+    """One hung call must not silently consume the whole budget a poll was
+    given."""
+    fake = FakeTemporal()
+
+    await reader_over(fake, request_timeout=timedelta(seconds=7)).task_queue_pollers(
+        _QUEUE, namespace="default"
+    )
+
+    assert fake.kwargs_for("describe_task_queue")["timeout"] == timedelta(seconds=7)
+
+
+# ---------------------------------------------------------------------------
+# The workflow status read
+# ---------------------------------------------------------------------------
+
+
+async def test_workflow_status_reports_what_temporal_says():
+    started = datetime(2026, 8, 26, 9, 0, tzinfo=timezone.utc)
+    fake = FakeTemporal(
+        descriptions=[await workflow_description(started_at=started, history_length=17)]
+    )
+
+    status = await reader_over(fake).workflow_status("wf-1")
+
+    assert status.workflow_id == "wf-1"
+    assert status.run_id == "run-1"
+    assert status.status is WorkflowExecutionStatus.RUNNING
+    assert status.task_queue == _QUEUE
+    assert status.history_length == 17
+    assert status.started_at == started
+    assert status.closed_at is None
+
+
+async def test_history_length_is_the_progress_signal():
+    """Status alone never changes between "running" and "finished", so a wait on
+    it could only ever report ``Expired``. A growing history is what makes
+    ``Stalled`` reachable."""
+    fake = FakeTemporal(
+        descriptions=[
+            await workflow_description(history_length=3),
+            await workflow_description(history_length=9),
+        ]
+    )
+    reader = reader_over(fake)
+
+    first = await reader.workflow_status("wf-1")
+    second = await reader.workflow_status("wf-1")
+
+    assert (first.history_length, second.history_length) == (3, 9)
+
+
+async def test_the_run_id_asked_for_reaches_the_handle():
+    fake = FakeTemporal(descriptions=[await workflow_description()])
+
+    await reader_over(fake).workflow_status("wf-1", run_id="run-9")
+
+    assert fake.calls[0][1] == ("wf-1", "run-9")
+
+
+async def test_a_missing_execution_raises_not_found_and_names_the_namespace():
+    """``NOT_FOUND`` and not ``DEPENDENCY_UNAVAILABLE``: a wrong id or a wrong
+    namespace does not recover while a wait sleeps, so the wait must fail on it
+    at once rather than spend its budget."""
+    fake = FakeTemporal(descriptions=[rpc_error(RPCStatusCode.NOT_FOUND)])
+
+    with pytest.raises(WorkflowNotFoundError) as raised:
+        await reader_over(fake).workflow_status("wf-typo")
+
+    assert raised.value.workflow_id == "wf-typo"
+    assert raised.value.temporal_namespace == "default"
+    assert raised.value.effective_retryable is False
+
+
+async def test_find_workflow_status_answers_none_for_a_missing_execution():
+    """The nullable twin. A wait for AE-dispatched work starts before the
+    execution exists, so "not there yet" has to be a value its predicate can
+    test."""
+    fake = FakeTemporal(descriptions=[rpc_error(RPCStatusCode.NOT_FOUND)])
+
+    assert await reader_over(fake).find_workflow_status("wf-1") is None
+
+
+@pytest.mark.parametrize(
+    "status",
+    [
+        RPCStatusCode.PERMISSION_DENIED,
+        RPCStatusCode.UNAUTHENTICATED,
+        RPCStatusCode.DEADLINE_EXCEEDED,
+        RPCStatusCode.INTERNAL,
+        RPCStatusCode.RESOURCE_EXHAUSTED,
+    ],
+)
+async def test_only_a_clean_not_found_reads_as_absent(status: RPCStatusCode):
+    """The narrowing, from the other side: a false "it never started" cached from
+    a 403 or a timeout is the negative no later read corrects."""
+    fake = FakeTemporal(descriptions=[rpc_error(status)])
+
+    with pytest.raises(TemporalReadFailedError):
+        await reader_over(fake).find_workflow_status("wf-1")
+
+
+async def test_an_unspecified_status_reads_as_unknown_rather_than_crashing():
+    """``temporalio`` surfaces the proto's ``UNSPECIFIED`` as ``None``; a new
+    upstream status name would arrive the same way. Neither is worth a harness
+    crash — the same call an unrecognised pod phase makes."""
+    from temporalio.api.enums.v1 import WorkflowExecutionStatus as WireStatus
+
+    fake = FakeTemporal(
+        descriptions=[
+            await workflow_description(
+                status=WireStatus.WORKFLOW_EXECUTION_STATUS_UNSPECIFIED
+            )
+        ]
+    )
+
+    status = await reader_over(fake).workflow_status("wf-1")
+
+    assert status.status is WorkflowExecutionStatus.UNKNOWN
+
+
+async def test_a_terminal_status_carries_its_close_time():
+    from temporalio.api.enums.v1 import WorkflowExecutionStatus as WireStatus
+
+    closed = datetime(2026, 8, 26, 10, 0, tzinfo=timezone.utc)
+    fake = FakeTemporal(
+        descriptions=[
+            await workflow_description(
+                status=WireStatus.WORKFLOW_EXECUTION_STATUS_COMPLETED, closed_at=closed
+            )
+        ]
+    )
+
+    status = await reader_over(fake).workflow_status("wf-1")
+
+    assert status.status is WorkflowExecutionStatus.COMPLETED
+    assert status.closed_at == closed
+
+
+# ---------------------------------------------------------------------------
+# The connection: pooled, per loop, rebuilt once
+# ---------------------------------------------------------------------------
+
+
+async def test_one_connection_serves_repeated_probes():
+    """The shape ``wait_for_workflow`` did *not* have before FND-241: a fresh
+    connection per probe is a handshake per probe.
+
+    Named for what it does — sequential probes — rather than "the whole wait".
+    There is no :func:`poll_until` here; the loop stands in for one, and a name
+    claiming a bounded wait would be describing a test that does not exercise it.
+    """
+    fake = FakeTemporal()
+    reader = reader_over(fake)
+
+    for _ in range(3):
+        await reader.task_queue_pollers(_QUEUE, namespace="default")
+
+    assert len(fake.connects) == 1
+
+
+async def test_a_dropped_transport_is_rebuilt_once_and_the_read_re_attempted():
+    """A ``kubectl port-forward`` tunnel that has died is permanent — the
+    client's own reconnect loop retries an address nothing is listening on."""
+    fake = FakeTemporal(
+        pollers=[
+            rpc_error(RPCStatusCode.UNAVAILABLE),
+            describe_response(poller("1@host")),
+        ]
+    )
+
+    pollers = await reader_over(fake).task_queue_pollers(
+        _QUEUE, namespace="default", task_queue_types=[TaskQueueType.WORKFLOW]
+    )
+
+    assert [p.identity for p in pollers] == ["1@host"]
+    assert len(fake.connects) == 2
+    assert fake.closes == 1
+
+
+async def test_two_consecutive_transport_failures_are_a_real_outage():
+    """One rebuild, not a retry loop: the budget belongs to the enclosing wait."""
+    fake = FakeTemporal(pollers=[rpc_error(RPCStatusCode.UNAVAILABLE)])
+
+    with pytest.raises(TemporalReadFailedError) as raised:
+        await reader_over(fake).task_queue_pollers(_QUEUE, namespace="default")
+
+    assert raised.value.rpc_status == "UNAVAILABLE"
+    assert len(fake.connects) == 2
+
+
+async def test_a_non_transport_failure_is_not_retried():
+    """A 403 does not get better with a new connection, and re-attempting it
+    doubles the time to a failure that was already certain."""
+    fake = FakeTemporal(pollers=[rpc_error(RPCStatusCode.PERMISSION_DENIED)])
+
+    with pytest.raises(TemporalReadFailedError):
+        await reader_over(fake).task_queue_pollers(_QUEUE, namespace="default")
+
+    assert len(fake.connects) == 1
+
+
+async def test_concurrent_first_reads_open_exactly_one_connection():
+    """Two probes racing the first read would otherwise leak the loser's
+    connection — and with it a ``kubectl`` child process.
+
+    This is only a concurrency test because ``FakeTemporal.connect`` yields
+    inside the connect. It did not, and this test passed with the reader's lock
+    removed — asserting that a sequential program opens one connection. Verified
+    by removal now: without the lock it reports 5.
+    """
+    fake = FakeTemporal()
+    reader = reader_over(fake)
+
+    await asyncio.gather(
+        *(reader.task_queue_pollers(_QUEUE, namespace="default") for _ in range(5))
+    )
+
+    assert len(fake.connects) == 1
+
+
+async def test_aclose_releases_the_transport_and_is_idempotent():
+    """Not optional for a tunnelled connection: it is a child process."""
+    fake = FakeTemporal()
+    reader = reader_over(fake)
+    await reader.task_queue_pollers(_QUEUE, namespace="default")
+
+    await reader.aclose()
+    await reader.aclose()
+
+    assert fake.closes == 1
+
+
+async def test_aclose_on_a_reader_that_never_connected_is_a_no_op():
+    fake = FakeTemporal()
+
+    await reader_over(fake).aclose()
+
+    assert fake.connects == []
+
+
+def test_a_connected_reader_used_on_a_second_loop_raises_rather_than_leaking():
+    """A ``temporalio`` client is bound to the loop that created it, so a reader
+    cannot follow one across loops.
+
+    It raises rather than rebinding, because rebinding drops the previous
+    connection *without* awaiting its close — and that close is what reaps the
+    ``kubectl`` child behind a port-forwarded connection. A leaked process is
+    worse than a loud refusal, and the new loop cannot do the closing either.
+    """
+    fake = FakeTemporal()
+    reader = reader_over(fake)
+
+    on_a_fresh_loop(lambda: reader.task_queue_pollers(_QUEUE, namespace="default"))
+
+    with pytest.raises(TemporalReaderLoopMismatchError) as raised:
+        on_a_fresh_loop(lambda: reader.task_queue_pollers(_QUEUE, namespace="default"))
+
+    assert raised.value.address == "127.0.0.1:7233"
+    assert raised.value.effective_retryable is False
+    # Not a silent rebuild: exactly one connection was ever made, and it is still
+    # the reader's — still closeable from the loop that owns it.
+    assert len(fake.connects) == 1
+    assert fake.closes == 0
+
+
+def test_an_unconnected_reader_rebinds_to_a_new_loop_without_complaint():
+    """Nothing to lose, so nothing to report.
+
+    Raising here would punish a legitimate handoff — a reader built by a fixture
+    on one loop and first used on another leaks nothing, because it never opened
+    anything.
+    """
+    fake = FakeTemporal()
+    reader = reader_over(fake)
+
+    on_a_fresh_loop(lambda: reader.task_queue_pollers(_QUEUE, namespace="default"))
+
+    assert len(fake.connects) == 1
+
+
+def test_a_closed_reader_may_be_reused_on_another_loop():
+    """`aclose()` on the owning loop is the documented way to hand a reader on."""
+    fake = FakeTemporal()
+    reader = reader_over(fake)
+
+    async def _use_then_close() -> None:
+        await reader.task_queue_pollers(_QUEUE, namespace="default")
+        await reader.aclose()
+
+    on_a_fresh_loop(_use_then_close)
+    on_a_fresh_loop(lambda: reader.task_queue_pollers(_QUEUE, namespace="default"))
+
+    assert len(fake.connects) == 2
+    assert fake.closes == 1
+
+
+# ---------------------------------------------------------------------------
+# Connecting
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def refusing_client(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, object]]:
+    """Patch the real ``Client.connect`` to refuse, recording what it was given.
+
+    Patched rather than pointed at an unroutable address: a unit test that
+    resolves a hostname is a unit test that can hang on someone else's DNS. The
+    patch is on ``temporalio.client.Client`` itself, which is the object this
+    backend imported, so the call being wrapped is still the real one.
+    """
+    calls: list[dict[str, object]] = []
+
+    async def _refuse(address: str, **kwargs: object) -> object:
+        calls.append({"address": address, **kwargs})
+        raise RuntimeError("failed to connect to all addresses")
+
+    monkeypatch.setattr(Client, "connect", _refuse)
+    return calls
+
+
+async def test_a_failed_connect_names_the_address_and_the_namespace(
+    refusing_client: list[dict[str, object]],
+):
+    """A run pointed at the wrong frontend has to say so, rather than leaving it
+    to be inferred from a gRPC message."""
+    with pytest.raises(TemporalConnectFailedError) as raised:
+        await frontend_connection(address="frontend:7233", namespace="default")
+
+    assert raised.value.address == "frontend:7233"
+    assert raised.value.temporal_namespace == "default"
+    assert raised.value.effective_retryable is True
+    assert refusing_client[0]["address"] == "frontend:7233"
+
+
+async def test_a_failed_connect_carries_no_credential(
+    refusing_client: list[dict[str, object]],
+):
+    """The address and the namespace are what a report needs; a token in an error
+    field travels wherever that report does."""
+    with pytest.raises(TemporalConnectFailedError) as raised:
+        await frontend_connection(
+            address="frontend:7233", namespace="default", api_key="s3cret-token"
+        )
+
+    # The token did reach the client — it is only absent from the failure.
+    assert refusing_client[0]["api_key"] == "s3cret-token"
+    assert "s3cret" not in str(raised.value)
+    assert not any("s3cret" in str(value) for value in vars(raised.value).values())
+
+
+async def test_a_successful_connect_owns_no_transport_to_release(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The caller supplied the address, so the caller owns whatever provides it —
+    and closing the connection must therefore be safe and do nothing."""
+
+    async def _accept(address: str, **kwargs: object) -> object:
+        return object()
+
+    monkeypatch.setattr(Client, "connect", _accept)
+
+    connection = await frontend_connection(address="frontend:7233", namespace="ns")
+
+    assert (connection.address, connection.namespace) == ("frontend:7233", "ns")
+    assert await connection.close() is None
+
+
+async def test_a_tunnel_that_never_opens_fails_as_a_connect_and_leaves_nothing_behind(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """An unclosed tunnel leaks a ``kubectl`` process for the rest of the
+    session, so the failure path has to release it."""
+    from application_sdk.testing.harness.cluster import ServiceTarget
+    from application_sdk.testing.harness.temporal.client import (
+        port_forwarded_connection,
+    )
+
+    closed: list[bool] = []
+
+    async def _never_opens(self) -> str:
+        raise TimeoutError("port 40000 did not become ready")
+
+    async def _record_close(self) -> None:
+        closed.append(True)
+
+    monkeypatch.setattr(
+        "application_sdk.testing.harness.cluster._portforward.PortForward.address",
+        _never_opens,
+    )
+    monkeypatch.setattr(
+        "application_sdk.testing.harness.cluster._portforward.PortForward.aclose",
+        _record_close,
+    )
+
+    with pytest.raises(TemporalConnectFailedError) as raised:
+        await port_forwarded_connection(
+            target=ServiceTarget(
+                namespace="temporal", service="temporal-frontend", port=7233
+            ),
+            namespace="default",
+        )
+
+    assert "temporal/temporal-frontend:7233" in str(raised.value)
+    assert closed == [True]
+
+
+async def test_a_tunnel_that_opens_but_cannot_connect_is_still_released(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The other half of the same leak: the tunnel is up by the time the client
+    fails."""
+    from application_sdk.testing.harness.cluster import ServiceTarget
+    from application_sdk.testing.harness.temporal.client import (
+        port_forwarded_connection,
+    )
+
+    closed: list[bool] = []
+
+    async def _opens(self) -> str:
+        return "127.0.0.1:40001"
+
+    async def _record_close(self) -> None:
+        closed.append(True)
+
+    monkeypatch.setattr(
+        "application_sdk.testing.harness.cluster._portforward.PortForward.address",
+        _opens,
+    )
+    monkeypatch.setattr(
+        "application_sdk.testing.harness.cluster._portforward.PortForward.aclose",
+        _record_close,
+    )
+
+    with pytest.raises(TemporalConnectFailedError):
+        await port_forwarded_connection(
+            target=ServiceTarget(
+                namespace="temporal", service="temporal-frontend", port=7233
+            ),
+            namespace="default",
+        )
+
+    assert closed == [True]
+
+
+async def test_a_tunnelled_connection_closes_the_tunnel_it_owns(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from application_sdk.testing.harness.cluster import ServiceTarget
+    from application_sdk.testing.harness.temporal import client as backend
+
+    closed: list[bool] = []
+
+    async def _opens(self) -> str:
+        return "127.0.0.1:40002"
+
+    async def _record_close(self) -> None:
+        closed.append(True)
+
+    async def _connect(*, address: str, namespace: str) -> object:
+        return backend.TemporalConnection(
+            client=object(),  # type: ignore[arg-type]
+            namespace=namespace,
+            address=address,
+        )
+
+    monkeypatch.setattr(
+        "application_sdk.testing.harness.cluster._portforward.PortForward.address",
+        _opens,
+    )
+    monkeypatch.setattr(
+        "application_sdk.testing.harness.cluster._portforward.PortForward.aclose",
+        _record_close,
+    )
+    monkeypatch.setattr(backend, "frontend_connection", _connect)
+
+    connection = await backend.port_forwarded_connection(
+        target=ServiceTarget(
+            namespace="temporal", service="temporal-frontend", port=7233
+        ),
+        namespace="default",
+    )
+    assert connection.address == "127.0.0.1:40002"
+
+    await connection.close()
+
+    assert closed == [True]
+
+
+def test_constructing_a_reader_does_not_connect():
+    """Nothing is opened until something is read, so a fixture can build one
+    against a frontend the test then decides not to reach."""
+    TemporalServiceReader(connect=_unused)  # should not raise
+
+
+def _unused():  # pragma: no cover — the constructor never calls its factory
+    raise AssertionError("the factory is not called until the first read")
+
+
+# ---------------------------------------------------------------------------
+# stale_version_pollers
+# ---------------------------------------------------------------------------
+
+
+def _p(build_id: str | None) -> PollerInfo:
+    return PollerInfo(
+        identity="1@host",
+        last_access=datetime(2026, 8, 26, tzinfo=timezone.utc),
+        build_id=build_id,
+    )
+
+
+def test_an_unversioned_poller_counts_as_stale():
+    """The ``hasUnversionedPoller`` trap: ``p.build_id and p.build_id != current``
+    skips exactly the workers whose deployment config did not take, so the gate
+    passes because it could not see the offender."""
+    assert stale_version_pollers([_p(None)], current_build_id="sha-new") == (_p(None),)
+
+
+def test_an_older_build_still_holding_the_queue_counts_as_stale():
+    stale = stale_version_pollers(
+        [_p("sha-old"), _p("sha-new")], current_build_id="sha-new"
+    )
+
+    assert [p.build_id for p in stale] == ["sha-old"]
+
+
+def test_the_passing_state_is_empty():
+    assert stale_version_pollers([_p("sha-new")], current_build_id="sha-new") == ()
+
+
+def test_no_current_build_means_versioning_is_not_in_use_here():
+    """Reporting every poller as stale would red every unversioned
+    deployment."""
+    assert stale_version_pollers([_p(None), _p("x")], current_build_id=None) == ()
+
+
+def test_a_status_name_this_sdk_has_never_heard_of_reads_as_unknown():
+    """Exercised against the classifier directly, because there is no wire value
+    for it: a status Temporal has not shipped yet cannot be put in a protobuf
+    enum. The point is that a *future* one is a classification rather than a
+    harness crash, which is only checkable this way."""
+    from enum import Enum
+
+    from application_sdk.testing.harness.temporal.client import _execution_status
+
+    class Later(Enum):
+        SOME_NEW_STATUS = 99
+
+    assert _execution_status(Later.SOME_NEW_STATUS) is WorkflowExecutionStatus.UNKNOWN
+
+
+async def test_the_kube_context_reaches_the_tunnel(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """FND-241 pinned the context onto ``kubectl port-forward`` because a reader
+    built for one cluster was tunnelling into another, both calls succeeding and
+    nothing logged. This factory builds its *own* ``PortForward``, so it has to
+    thread the context too or it reintroduces exactly that split — Temporal read
+    through whichever context is current while the pods came from a named one.
+
+    Asserted on what the tunnel was constructed with, not on a round trip: a
+    tunnel that reaches the right cluster because it also happens to be the
+    current context passes either way, which is the state the bug hides in.
+    """
+    from application_sdk.testing.harness.cluster import ServiceTarget
+    from application_sdk.testing.harness.cluster._portforward import PortForward
+    from application_sdk.testing.harness.temporal import client as backend
+
+    built: list[str | None] = []
+
+    async def _spawn(self: PortForward) -> int:
+        built.append(self.kube_context)
+        self._local_port = 40003
+        return 40003
+
+    async def _connect(*, address: str, namespace: str) -> object:
+        return backend.TemporalConnection(
+            client=object(),  # type: ignore[arg-type]
+            namespace=namespace,
+            address=address,
+        )
+
+    monkeypatch.setattr(PortForward, "_spawn", _spawn)
+    monkeypatch.setattr(backend, "frontend_connection", _connect)
+
+    connection = await backend.port_forwarded_connection(
+        target=ServiceTarget(
+            namespace="temporal", service="temporal-frontend", port=7233
+        ),
+        namespace="default",
+        kube_context="e2e-gcp",
+    )
+
+    assert built == ["e2e-gcp"]
+    # And the context is named in the failure surface, so a run against the
+    # wrong cluster says so rather than leaving it to be inferred.
+    assert connection.address == "127.0.0.1:40003"
+
+
+async def test_no_kube_context_leaves_the_argv_unpinned(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """``None`` must stay "whatever is current" rather than becoming a literal —
+    a `--context None` would fail every tunnel for a caller that never named
+    one."""
+    from application_sdk.testing.harness.cluster._portforward import kubectl_argv
+
+    assert "--context" not in kubectl_argv("port-forward", kube_context=None)
+
+
+def test_a_second_loop_is_refused_while_the_first_is_still_connecting():
+    """The in-flight window, which the `connection is not None` check missed.
+
+    For the whole duration of `await connect()` the connection is still `None`,
+    so a fail-close that tested only that field let a second loop replace
+    `_bound` mid-connect — after which the first loop stored its client on an
+    orphaned bound, leaking a `temporalio` client and, on the tunnelled path, a
+    `kubectl` child. Sequential reuse was already refused; this is the concurrent
+    first-connect hole.
+
+    Two real threads and two real loops, because that is the only way the race
+    exists: separate loops run on separate threads, so this is a genuine data
+    race that no asyncio primitive would serialise. Gated on `Event`s rather
+    than sleeps so it cannot pass by timing luck.
+    """
+    connect_entered = threading.Event()
+    release_connect = threading.Event()
+    fake = FakeTemporal()
+    inner = fake.connect()
+    attempts = itertools.count()
+
+    async def _slow_connect():
+        # Only the FIRST connect blocks. If the refusal is missing, the second
+        # loop therefore *succeeds* — so the failure is the leak itself (two
+        # connections, one stranded on an orphaned bound) rather than a hang,
+        # which would be both the wrong symptom and timing-dependent.
+        if next(attempts) == 0:
+            connect_entered.set()
+            # Threaded, not awaited, so the other loop runs while this one sits
+            # inside `await self._connect()`.
+            await asyncio.get_running_loop().run_in_executor(
+                None, release_connect.wait, 10
+            )
+        return await inner()
+
+    reader = TemporalServiceReader(connect=_slow_connect)
+    outcomes: dict[str, object] = {}
+
+    def _first() -> None:
+        try:
+            outcomes["first"] = on_a_fresh_loop(
+                lambda: reader.task_queue_pollers(_QUEUE, namespace="default")
+            )
+        except BaseException as exc:  # pragma: no cover - reported via outcomes
+            outcomes["first"] = exc
+
+    def _second() -> None:
+        try:
+            outcomes["second"] = on_a_fresh_loop(
+                lambda: reader.task_queue_pollers(_QUEUE, namespace="default")
+            )
+        except BaseException as exc:
+            outcomes["second"] = exc
+
+    first = threading.Thread(target=_first, name="loop-a")
+    first.start()
+    assert connect_entered.wait(10), "the first loop never entered connect()"
+
+    # The first loop is now inside `await connect()` with connection still None.
+    second = threading.Thread(target=_second, name="loop-b")
+    second.start()
+    second.join(10)
+    assert not second.is_alive(), "the second loop never returned"
+
+    release_connect.set()
+    first.join(10)
+    assert not first.is_alive(), "the first loop never finished"
+
+    # The leak assertion leads, because it is the defect: exactly one connection
+    # was ever opened, so nothing is stranded on a bound that lost its reference.
+    assert len(fake.connects) == 1, (
+        f"{len(fake.connects)} connections opened — the first loop's is stranded "
+        "on an orphaned bound and nothing will ever close it"
+    )
+    assert isinstance(outcomes["second"], TemporalReaderLoopMismatchError)
+    # The refusal names the state it found rather than a stale address.
+    assert "in the middle of connecting" in str(outcomes["second"])
+    assert outcomes["first"] == []
+    assert fake.closes == 0
+
+
+async def test_aclose_waits_for_an_in_flight_connect_rather_than_returning_past_it():
+    """Two tasks on one loop: a first read racing a fixture teardown.
+
+    `aclose` used to test `connection is None` and return — but the connection is
+    `None` for the whole duration of `await connect()`, so teardown reported
+    "closed" and the read then installed a client behind it with nothing left to
+    close it. Sequential read-then-close was always fine; this is the hole.
+
+    Asserted on both halves, because either alone is passable by accident: that
+    `aclose` does not complete while the connect is in flight (the ordering), and
+    that the connection is closed exactly once when it does (the leak).
+    """
+    started = asyncio.Event()
+    release = asyncio.Event()
+    fake = FakeTemporal()
+    inner = fake.connect()
+
+    async def _slow_connect():
+        started.set()
+        await release.wait()
+        return await inner()
+
+    reader = TemporalServiceReader(connect=_slow_connect)
+
+    read = asyncio.create_task(reader.task_queue_pollers(_QUEUE, namespace="default"))
+    await started.wait()
+
+    closing = asyncio.create_task(reader.aclose())
+    # Generous yielding: if `aclose` returns past the in-flight connect it needs
+    # only one scheduler turn to finish, so this cannot pass by not looking.
+    for _ in range(10):
+        await asyncio.sleep(0)
+    assert not closing.done(), (
+        "aclose() returned while a connect was still in flight — the client it "
+        "installs afterwards will never be closed"
+    )
+
+    release.set()
+    assert await read == []
+    await closing
+
+    assert len(fake.connects) == 1
+    assert fake.closes == 1, (
+        f"connection closed {fake.closes} times; the caller of aclose() believes "
+        "teardown completed"
+    )
+
+
+async def test_aclose_is_still_cheap_and_idempotent_when_nothing_is_in_flight():
+    """The waiting must not cost the ordinary path anything.
+
+    An uncontended `asyncio.Lock` acquires without yielding, so sequential
+    teardown is unchanged — and a second `aclose` still closes nothing twice.
+    """
+    fake = FakeTemporal()
+    reader = reader_over(fake)
+    await reader.task_queue_pollers(_QUEUE, namespace="default")
+
+    await reader.aclose()
+    await reader.aclose()
+
+    assert fake.closes == 1
+
+
+async def test_a_failed_connect_leaves_the_reader_usable_on_its_own_loop():
+    """A connect that raised must not wedge the reader it was opening on.
+
+    Renamed and re-scoped twice. It was `..._finds_nothing_to_close` and asserted
+    only that `aclose` returned — it survived a mutation to `aclose` untouched,
+    because absence-of-exception was the whole check.
+
+    My first rewrite claimed the reconnect proved the `connecting` claim had been
+    released. It does not: :meth:`_loop_bound` returns early on a loop match and
+    never consults the claim, so a same-loop reconnect succeeds whether or not
+    the claim was cleared. Mutating the releasing `finally` away leaves this test
+    green. The claim only gates *other* loops — which is what
+    `test_a_closed_reader_may_be_reused_on_another_loop` covers, and that one does
+    go red on the mutation.
+
+    So what this pins is the narrower true thing: a failed connect, followed by
+    teardown, leaves the reader working on its own loop. Worth having, and worth
+    not dressing up as more.
+    """
+    attempts = itertools.count()
+    connects: list[int] = []
+
+    async def _connect_failing_once() -> TemporalConnection:
+        n = next(attempts)
+        connects.append(n)
+        if n == 0:
+            raise RuntimeError("frontend unreachable")
+        return TemporalConnection(
+            client=_FakeClient(FakeTemporal()),  # type: ignore[arg-type]
+            namespace="default",
+            address="127.0.0.1:7233",
+        )
+
+    reader = TemporalServiceReader(connect=_connect_failing_once)
+
+    with pytest.raises(RuntimeError, match="frontend unreachable"):
+        await reader.task_queue_pollers(_QUEUE, namespace="default")
+    assert connects == [0]
+
+    # Teardown over a released claim: no work, no hang.
+    await reader.aclose()
+
+    await reader.task_queue_pollers(
+        _QUEUE, namespace="default", task_queue_types=[TaskQueueType.WORKFLOW]
+    )
+    assert connects == [0, 1], "a failed connect wedged the reader on its own loop"
+
+
+async def test_aclose_is_not_terminal_and_a_later_read_reconnects():
+    """The sequential reuse contract: closing does not retire the reader.
+
+    Load-bearing rather than incidental — `_read`'s transport-lost rebuild is
+    built on exactly this (`aclose` then reconnect), so making `aclose` terminal
+    would break the retry path. Anyone tempted to close the resurrection residue
+    that way has to break this test first, which is the point of pinning it
+    separately from the residue itself.
+    """
+    fake = FakeTemporal(pollers=[describe_response(poller("1@host"))])
+    reader = reader_over(fake)
+
+    await reader.task_queue_pollers(
+        _QUEUE, namespace="default", task_queue_types=[TaskQueueType.WORKFLOW]
+    )
+    await reader.aclose()
+    assert fake.closes == 1
+    connects_at_teardown = len(fake.connects)
+
+    await reader.task_queue_pollers(
+        _QUEUE, namespace="default", task_queue_types=[TaskQueueType.WORKFLOW]
+    )
+
+    assert len(fake.connects) == connects_at_teardown + 1
+
+
+async def test_a_read_in_flight_at_teardown_resurrects_a_connection_afterwards():
+    """The residue `aclose` does NOT close, with the read genuinely overlapping.
+
+    `_connection` hands the connection out as a local and releases `bound.lock`
+    before the RPC, so a read past that point is unprotected: `aclose` acquires
+    an uncontended lock, closes, and **returns** while the read is still running.
+    The read then fails against the closed client, and `_read`'s rebuild opens a
+    *fresh* connection after teardown reported success. On the tunnelled path
+    that is a `kubectl` child outliving the fixture that closed it.
+
+    Gated so the overlap is real rather than asserted: the first RPC parks on an
+    event until teardown has completed. A version that awaited a *finished* read
+    before closing would prove only that `aclose` is not terminal — which is a
+    different property, pinned separately above.
+
+    A record of current behaviour, not an endorsement. Closing it needs a
+    terminal `aclose`, which would break the sibling test and `_read`'s rebuild
+    with it — a contract change, not a fix.
+    """
+    in_flight = asyncio.Event()
+    release = asyncio.Event()
+    attempts = itertools.count()
+    connects: list[str] = []
+    closes: list[str] = []
+
+    class _Service:
+        async def describe_task_queue(self, req: object, **kwargs: object) -> object:
+            if next(attempts) == 0:
+                in_flight.set()
+                await release.wait()
+                # The closed client's RPC surfaces as a lost transport, which is
+                # what sends `_read` down its rebuild path.
+                raise rpc_error(RPCStatusCode.UNAVAILABLE)
+            return describe_response(poller("1@host"))
+
+    class _Client:
+        def __init__(self) -> None:
+            self.workflow_service = _Service()
+
+    async def _connect() -> TemporalConnection:
+        address = f"127.0.0.1:7233#{len(connects)}"
+        connects.append(address)
+
+        async def _close() -> None:
+            closes.append(address)
+
+        return TemporalConnection(
+            client=_Client(),  # type: ignore[arg-type]
+            namespace="default",
+            address=address,
+            close=_close,
+        )
+
+    reader = TemporalServiceReader(connect=_connect)
+    read = asyncio.create_task(
+        reader.task_queue_pollers(
+            _QUEUE, namespace="default", task_queue_types=[TaskQueueType.WORKFLOW]
+        )
+    )
+    await in_flight.wait()
+
+    # Teardown with the read genuinely past `_connection()` and mid-RPC.
+    await reader.aclose()
+    assert closes == [connects[0]], "teardown did not close the live connection"
+
+    release.set()
+    pollers = await read
+
+    # The read completed by opening a second connection — after aclose returned.
+    assert [p.identity for p in pollers] == ["1@host"]
+    assert len(connects) == 2, (
+        "the in-flight read did not reconnect; if aclose is now terminal, update "
+        "its docstring — it currently documents this residue as open"
+    )
+    assert closes == [connects[0]], (
+        f"connection {connects[1]} was opened after teardown and never closed — "
+        "this is the documented residue, not a new leak"
+    )
+
+
+async def test_async_with_closes_the_reader_on_block_exit():
+    """The structural half of the leak guard.
+
+    `PortForward` has never produced the never-closed leak across seven review
+    rounds because its acquire and release are one construct; `_connection` and
+    `aclose` are separate methods and produced it twice. This makes the caller's
+    side one construct too, so forgetting to close stops being possible rather
+    than being warned about.
+    """
+    fake = FakeTemporal()
+
+    async with TemporalServiceReader(connect=fake.connect()) as reader:
+        await reader.task_queue_pollers(_QUEUE, namespace="default")
+        assert fake.closes == 0
+
+    assert fake.closes == 1
+
+
+async def test_async_with_closes_on_an_exception_and_re_raises_it():
+    """Teardown must not swallow the failure that triggered it.
+
+    `__aexit__` returns `None`, not a truthy value — an exception inside the
+    block propagates while the connection is still released.
+    """
+    fake = FakeTemporal()
+
+    with pytest.raises(RuntimeError, match="scenario failed"):
+        async with TemporalServiceReader(connect=fake.connect()) as reader:
+            await reader.task_queue_pollers(_QUEUE, namespace="default")
+            raise RuntimeError("scenario failed")
+
+    assert fake.closes == 1
+
+
+async def test_entering_the_block_opens_nothing():
+    """`__aenter__` is not an eager connect.
+
+    A fixture may build a reader for a scenario that then decides not to reach
+    Temporal, and the laziness is pinned elsewhere as its own property — an
+    eager connect here would turn `async with` into a network call for a block
+    that never reads.
+    """
+    fake = FakeTemporal()
+
+    async with TemporalServiceReader(connect=fake.connect()):
+        assert fake.connects == []
+
+    assert fake.connects == []
+    assert fake.closes == 0

--- a/tests/unit/testing/harness/test_scaffold.py
+++ b/tests/unit/testing/harness/test_scaffold.py
@@ -432,6 +432,50 @@ def _unused():  # pragma: no cover — the factory is never called by these asse
     raise AssertionError("the protocol checks are structural, not behavioural")
 
 
+async def test_the_temporal_readers_are_real() -> None:
+    """FND-247 filled the ``temporal`` stub: the Protocol had no backend at all,
+    and ``NoWorkerOnTaskQueueError`` was inferred from three minutes of silence
+    rather than read.
+
+    Asserted here for the reason child E's deletion is: what belongs in the
+    scaffold's own test file is the proof that the package no longer holds a stub
+    under these names, so a revert cannot quietly restore one.
+    """
+    from application_sdk.testing.harness import temporal
+
+    assert isinstance(
+        temporal.TemporalServiceReader(connect=_unused), temporal.TemporalReader
+    )
+    for name in ("frontend_connection", "port_forwarded_connection"):
+        assert callable(getattr(temporal, name))
+
+    # The nullable twin is deliberately *not* on the Protocol: a caller waiting
+    # for an AE-dispatched execution to appear needs absence as a value, and a
+    # caller that already has an id wants the raise.
+    assert not hasattr(temporal.TemporalReader, "find_workflow_status")
+    assert callable(temporal.TemporalServiceReader.find_workflow_status)
+
+
+def test_the_temporal_readers_need_no_extra() -> None:
+    """FND-247's amendment expected ``temporalio`` behind the ``[workflows]``
+    extra, with the readers import-guarded. It is a *core* dependency since v3.1
+    and ``[workflows]`` is an alias resolving to it — so unlike ``cluster``'s
+    ``harness`` extra there is nothing to guard, and this pins the correction
+    rather than leaving it in a PR description."""
+    import tomllib
+    from pathlib import Path
+
+    pyproject = Path(__file__).resolve().parents[4] / "pyproject.toml"
+    with pyproject.open("rb") as handle:
+        project = tomllib.load(handle)["project"]
+
+    assert any(dep.startswith("temporalio") for dep in project["dependencies"])
+    assert any(
+        dep.startswith("temporalio")
+        for dep in project["optional-dependencies"]["workflows"]
+    )
+
+
 async def test_every_remaining_stub_names_its_child_issue() -> None:
     from application_sdk.testing.harness import starters
     from application_sdk.testing.harness.cluster import HttpRequest, HttpResponse


### PR DESCRIPTION
Child of [FND-224](https://linear.app/atlan-epd/issue/FND-224). Closes [FND-247](https://linear.app/atlan-epd/issue/FND-247). **#3439 has merged**, so this targets `main` directly and the diff is this change alone.

`TemporalReader` landed as a Protocol in #3433 with nothing behind it. `TemporalServiceReader` is the backend: the in-process `temporalio` client, satisfying it, plus the two connection factories that decide how the frontend is reached.

## What the poller read actually buys

`NoWorkerOnTaskQueueError` is currently **inferred** — "no DAG node started inside `ae_stall_grace_seconds`, so probably nothing is polling". That is a good heuristic and it is still a heuristic: a genuinely slow extract and an unpolled queue look identical for the first three minutes. Zero pollers is a **fact**, available on the first probe.

It is also the only detector for the class the issue calls its largest uncaught one: *"a queue name that is well formed and refers to nothing: every string matches, and the queue simply does not exist"*. Nothing else in the harness can see that — a manifest check compares strings and both sides agree.

## Three ways this departs from the reference it lifts

The amendment pointed at a working `pollers()` in `suite/ports/temporal.py`. It is a lift, and then:

**It is `async` with no loop-on-a-thread inside it.** The reference runs its own event loop on a dedicated thread and hands every call to it with `run_coroutine_threadsafe`, because its scenario authors never write `async`. Under D1 that inverts: the reader is plain `async` and the sync composer reaches it through the one public `run_sync` bridge, which already owns exactly one loop per thread — so a suite that also reads Atlas or a cluster shares it instead of standing up a second.

**A poller read is two `DescribeTaskQueue` calls, not one.** A task-queue name addresses a workflow queue *and* an activity queue, and a worker polls both. The reference read the workflow queue and returned a bare `int`; both choices lose the same state, because a union count and a workflow-only count disagree in exactly one situation — a worker process whose workflow poll loop has died while its activity poll loop is alive. That is the zombie shape (BLDX-1552/1553), and it is invisible to Temporal's own "is there a worker" question *and* to Kubernetes' "is the pod ready" one. So both halves are read and every `PollerInfo` carries which one it came from. `test_a_half_polling_worker_is_visible_rather_than_collapsed` pins it.

Two smaller consequences of the same decision are also tested: the second half is **not** read after the first one failed (`test_the_second_half_is_not_read_after_the_first_one_failed`), because half a poller list looks exactly like a half-polling worker and a partial answer here manufactures a real finding; and a caller that wants one half pays for one RPC.

**The build id comes from `deployment_options` before `worker_version_capabilities`.** Those are the new and old wire shapes of the same fact, and this SDK's worker sets the new one (`WorkerDeploymentConfig`, from `ATLAN_APP_DEPLOYMENT_NAME` / `ATLAN_APP_BUILD_ID`). Reading only the legacy field would report every versioned Atlan worker as unversioned — and `stale_version_pollers` would then call *every* poller stale. `deployment_name` is carried alongside the id for the same reason: a build id on its own cannot be matched against the deployment a `TemporalWorkerDeployment` names.

## `NOT_FOUND` is not folded into the read failure

`WorkflowNotFoundError` is a `NotFoundError`, so `default_retryable` is `False` and a transient classifier keyed on retryability leaves it alone. That is the load-bearing part: a wrong workflow id, a wrong namespace and a purged run are all states that must change first, so a wait has to fail on a typo at once rather than absorb it as a blip and spend a 25-minute budget before reporting it as a Temporal outage.

The nullable twin exists for the opposite case, and it is not a convenience. A wait for work that *something else* dispatches — the Automation Engine, in every connector run — starts before the execution exists, so "not there yet" has to be a value its predicate can test. Raising through that window would make the wait's own `NeverStarted` verdict unreachable, because the first probe would end the wait. So `find_workflow_status()` answers `None`, `workflow_status()` raises, and the narrowing between them is drawn in the same place as `crd_schema`'s: **only** a clean `NOT_FOUND` reads as absent. `PERMISSION_DENIED`, `UNAUTHENTICATED`, `DEADLINE_EXCEEDED`, `INTERNAL` and `RESOURCE_EXHAUSTED` are all parameterised as raising, because a false "it never started" cached from one of those is the negative no later read corrects.

`find_workflow_status` is deliberately **not** on the Protocol, and the scaffold test asserts that: a caller that already has an id wants the raise, and only a caller waiting for one to appear wants the nullable read.

## Two fields the scaffold did not have, and why

**`WorkflowStatus.history_length`.** Without it a wait on a workflow's status has no progress signal at all — `status` does not change between "running" and "finished" — so `poll_until` could only ever report that wait as `Expired`. A history length that stops growing is what makes `Stalled` reachable, which is the verdict that distinguishes "it started and then stopped moving" from "it was slow".

**`PollerInfo.task_queue_type`** — covered above.

Both are edits to unreleased types, as #3439's `custom_resources` signature change was.

## The `[workflows]` extra note is stale, and the correction is pinned by a test

FND-247's amendment expected `temporalio` to be optional behind `[workflows]`, with the readers import-guarded accordingly. Neither half applies: `temporalio` was promoted to a **core** dependency in v3.1 and `[workflows]` is a backwards-compatibility alias resolving to it. So there is no extra to name — unlike the `harness` extra the cluster backend genuinely needs.

There is also nothing to defer. Guarding the imports lazily the way `kube.py` guards `kubernetes` would buy nothing measurable, because `application_sdk.testing`'s own package `__init__` already imports `temporalio.client`, `temporalio.service` and the `temporalio.api` protos before any harness module is reached — I checked rather than assumed. So the imports are plain and at the top, which is what lets every conversion take the client's real types instead of `Any`. `test_the_temporal_readers_need_no_extra` holds the claim, so the correction is a test rather than a line in a PR description.

## `PortForward` grows `address()` rather than the reader growing a tunnel

`temporalio` speaks gRPC and takes a bare `host:port`, so the Temporal reader needs the tunnel's near end rather than an HTTP session over it. The reference shells out to `kubectl port-forward` itself; a second "shell out, pick a free port, wait for it to accept" is precisely the divergence FND-224 exists to remove, and the existing one already kills the child by handle rather than by pattern — which is what keeps concurrent runs on one host from tearing down each other's tunnels.

So `PortForward` exposes the address it already knows, and `_opened()` builds its `httpx` client over the same tunnel. `test_the_address_and_a_request_share_one_tunnel` asserts one `kubectl` process for both; `test_a_closed_session_reopens_on_the_next_address_call` pins the bug the split could have introduced, since `aclose()` now has to clear the port as well as the client or a reused session hands out the address of a tunnel it has already terminated.

`ServiceTarget` is reused from `cluster._states` rather than a parallel type being invented, and the frontend Service has **no default**: which Service serves a tenant's frontend is deployment configuration, and a wrong guess baked in here would surface as a connect timeout rather than as a missing setting.

## One connection per loop, rebuilt once on a dropped transport

A `temporalio` `Client` is bound to the loop that created it, so the connection is cached against the running loop — the same affinity `KubernetesReader` honours per *thread* for its own non-thread-safe client. A reader that moves loops rebuilds and says so at `WARNING`, because reconnecting on every call is a bug worth seeing rather than a mode worth supporting.

The rebuild-once is the trade `PortForward` already makes for HTTP and child F made for the AE pool: pooled on the happy path, fresh on the retry. It earns its place here specifically because a tunnel that has died is *permanent* — the client's own reconnect loop retries an address nothing is listening on any more. `UNAVAILABLE`/`UNKNOWN` discard and re-attempt once; `PERMISSION_DENIED` does not, because a 403 does not improve with a new connection and re-attempting doubles the time to a failure that was already certain.

The first-read race is closed under a lock, and the lock lives per-loop alongside the connection because an `asyncio.Lock` binds to the loop it is first awaited on. `test_concurrent_first_reads_open_exactly_one_connection` is why it is there: two probes racing would otherwise open two connections and drop the loser's without closing it — a leaked client and, on the tunnelled path, a leaked `kubectl` child.

## The narrowing is `except RPCError`, not `except Exception`

Same reason #3439 gives for `except _api_exception()`: it makes "anything that is not an RPC error propagates unchanged" a property of the syntax rather than of a branch that can rot. `test_a_wiring_bug_is_not_dressed_up_as_a_dependency_failure` is why it matters — a `TypeError` reported as `DEPENDENCY_UNAVAILABLE` would be absorbed by a wait's transient budget and burn the window instead of failing at once.

## `stale_version_pollers`, and the trap it exists to close

The issue names the Go harness's `hasUnversionedPoller` as prior art, and the second half of the precondition gate — *"the intended version is Current, and no stale-version workers are still polling"* — is what needs it. (The first half needs nothing from this module: the intended version is a `custom_resources` read of the `TemporalWorkerDeployment`, which #3439 already ships.)

It is a pure function rather than a one-liner at the call site because the obvious one-liner gets the unversioned case wrong in the quiet direction: `poller.build_id and poller.build_id != current` skips exactly the workers that have *no* build id — a build predating versioning, or one whose deployment config did not take. A gate that passes because it could not see the offending worker is the fail-open shape this package exists to remove. `current_build_id=None` answers empty rather than "everything is stale", so an unversioned deployment is not red by construction.

## The live-frontend criterion, as a test rather than as prose

No VPN or vcluster session was available here, so rather than assert "the readers work" in a PR description, `tests/e2e/test_temporal_reader_live.py` makes it executable — `e2e`-marked, skipped without a queue:

```
E2E_TEMPORAL_QUEUE=atlan-hello-world-default \
  uv run pytest tests/e2e/test_temporal_reader_live.py -m e2e -v
```

It checks the four things a scripted client cannot: that a real frontend is reachable through a tunnel at all; that a poller with a `deployment_options.build_id` exists where versioning is genuinely in use; that a queue name referring to nothing answers **empty**; and that an unreachable namespace **raises**. Those last two answering differently is the whole read. `E2E_TEMPORAL_ADDRESS` skips the tunnel, which is the shape an in-cluster driver takes — the fixture exercises both factories on purpose, because which one a run uses is the only difference FND-248 introduces. **This is the one item not verified in this PR.**

## One conformance suppression, and why it is a suppression

`P006` asks that `temporalio` stay behind `execution/_temporal/`. That contract is about the *worker* adapter — the engine's workflow and activity API, on a production code path — and these imports are an out-of-cluster read of the control plane from test infrastructure. Growing the adapter a describe-a-task-queue client to satisfy the rule would put test-only code on a production path, which is a worse coupling than the one the rule prevents. So each import carries the directive the rule itself prescribes for a deliberate exception, with the reason stated once above the block.

`isort` is off across that block, and that is load-bearing rather than tidiness: a directive binds to the line below it, and a re-sort that moves an import out from under its own comment silently un-suppresses one line while stacking two directives over another. I hit exactly that while writing it — the first attempt reported 2 of 6 findings back.

## Verification

Re-measured on the pushed commit rather than carried over from an earlier
rebase — the base moved four times while this sat.

* **Full unit suite — 8,688 passed, 9 skipped.** The figure before any of the
  rebases was 8,416; the delta is main's own new tests arriving with FND-242 and
  FND-241, not anything here. Re-measured on the rebased tree rather than carried
  forward — the number moved twice while this PR waited, and "it should not have
  changed" is not a measurement.
* **100% coverage on every new module** — `temporal/{__init__,_errors,_protocols,_states}.py`
  and `temporal/client.py`, 222 statements — and on
  `cluster/_portforward.py`, which this PR took from 29.89% to 100%.
* `uv run pre-commit run --all-files` — clean (ruff, ruff-format, isort, pyright).
* `docs/agents/sdk-capabilities.md` regenerated via `uv run poe regen-capabilities`.
* No dependency change: `pyproject.toml` and `uv.lock` untouched.

### Conformance: the live delta is zero

| | raw SARIF results | suppressed | **live findings** |
|---|---|---|---|
| `main` @ `11e99a4e7` | 560 | 301 | **259** |
| this PR | 566 | 307 | **259** |

**259 → 259.** This PR adds no live conformance findings.

Read the second column before concluding otherwise: suppressed findings stay in
the SARIF carrying `suppressions: [{kind: inSource, status: accepted}]` and keep
`kind: "fail"`, so a raw result count reads this PR as **+6**. Diffing
`(ruleId, file)` pairs shows the +6 is entirely `P006 × 6` in
`harness/temporal/client.py` — the `temporalio`-outside-the-adapter suppressions
described above, each carrying its justification. Filter with
`select((.suppressions // []) | length == 0)` to reproduce the 259.

Stating this explicitly because the two counts can move in opposite directions:
adding a directive to a previously-unwaived site lowers the live count while
raising the suppressed one, so a raw delta can tell a clean story assembled from
two unrelated movements. Here both counts move together, because all six
suppressed lines are lines that did not exist before this commit.

### Carried from FND-241, which could not land it

Three changes to `cluster/_portforward.py` originate in FND-241's review and
arrive here because #3439 was in the merge queue and frozen when they were
found. They are in this PR's diff because this PR already restructures that
file.

* **A CodeQL Medium** — "Binding a socket to all network interfaces" on
  `_find_free_port`'s `s.bind(("", 0))`. #3439 ships the finding; this closes
  it. The bind is now loopback, which is what `_wait_for_port` and the client's
  `base_url` already assume, and the `# noqa: S104 — intentional: OS picks free
  port on all interfaces` is deleted because it was **wrong rather than
  redundant**: it asserted all-interfaces was the intent when the intent is
  loopback. Pinned by `test_find_free_port_binds_loopback_only`, asserting the
  address the socket was bound to rather than the port it returned — `""` and
  `"127.0.0.1"` both return a plausible port.

  Recorded explicitly in the docstring: this is **not** a bug fix. The plausible
  story — that `("", 0)` could hand back a port `kubectl` then failed to take —
  is false. A TCP bind conflicts symmetrically (verified both directions, plus
  the `SO_REUSEPORT` case, `EADDRINUSE` each way), and on Linux all-interfaces
  is the *narrower* pool. It buys a truthful constraint and a quiet scanner.

* **A `.. warning::` on `aclose`** that guarding it with `_opening` deadlocks,
  because `_spawn` calls it from the readiness-failure path with the lock held.
  Every happy-path test passes and the hang arrives on the first port that never
  opens.

* **The concurrency guard moved to the shared spawn.** FND-241 put the lock on
  `_opened`, the only lazy-open entry point at the time; this PR adds a second
  (`address`), so a lock there alone lets the two race into two `kubectl`
  processes. Pinned by a test verified by removal: without the guard, 3 spawned
  and 2 leaked.

### Rebase note

Rebased onto the current base rather than merged, so the diff is this change
alone. `git range-diff` against the pre-rebase commit is 16 lines, all of it the
capability manifest's `source-sha` / `source-date` header — which
`capability-manifest-check.yaml` excludes by design, since the final squash SHA
does not exist while the PR is open. The manifest *body* is byte-identical.
