### PR TITLE
ci(sdk-gate): run the conformance suite tests on SDK changes too (FND-921)

### DIFF
--- a/.github/workflows/sdk-gate.yaml
+++ b/.github/workflows/sdk-gate.yaml
@@ -292,10 +292,20 @@ jobs:
   # package's source OR its pyproject.toml / uv.lock (e.g. a Renovate dep bump)
   # re-runs its tests — closing the gap where these were only exercised on
   # merge/publish, never on PRs.
+  #
+  # ALSO gated on `sdk`, which looks like an unrelated area but is not: this
+  # package's tests include the deprecations-manifest drift guard
+  # (packages/conformance/tests/test_deprecations_manifest.py), whose *input* is
+  # a whole-tree scan of application_sdk/. Gating it on packages/conformance/**
+  # alone inverted the dependency — the guard only fired once you had already
+  # remembered to regenerate the manifest, so a PR that adds a @deprecated and
+  # forgets skipped it entirely on `pull_request` and was evicted from the merge
+  # queue instead (FND-921). The job is ~30s and runs parallel to the ~10min
+  # Windows unit-test legs, so covering every SDK PR costs no wall-clock.
   conformance-suite-tests:
     name: Conformance Suite Tests
     needs: changes
-    if: needs.changes.outputs.conformance_pkg == 'true' || needs.changes.outputs.force_conformance == 'true'
+    if: needs.changes.outputs.conformance_pkg == 'true' || needs.changes.outputs.sdk == 'true' || needs.changes.outputs.force_conformance == 'true'
     uses: ./.github/workflows/conformance-suite-tests-reusable.yaml
     secrets: inherit
 


### PR DESCRIPTION
## Problem

The `conformance-suite-tests` job in `sdk-gate.yaml` was gated on `conformance_pkg` (= `packages/conformance/**`) alone. But the tests it runs include the deprecations-manifest drift guard, `packages/conformance/tests/test_deprecations_manifest.py::test_committed_manifest_matches_fresh_scan`, whose **input** is a whole-tree scan of `application_sdk/`.

That inverts the dependency. The guard exists to catch "you added a `@deprecated` and forgot to regenerate the manifest" — but it only ran when the PR had *already* touched `packages/conformance/**`, which for that failure mode means the manifest was already regenerated. A PR that adds a deprecation and forgets skipped the guard entirely on `pull_request`, then got evicted from the merge queue when the merge-group build happened to run it.

Cost of that miss: a full merge-queue cycle (~15 minutes) plus a re-enqueue, per occurrence.

Observed on a recent PR:

| Head | PR file set | `Suite unit tests` |
|---|---|---|
| pre-fix (`pull_request`) | `application_sdk/**`, `tests/**`, `pyproject.toml`, `uv.lock` | **job did not exist** |
| merge-group build | + queue siblings | ran, **failed in 29s** |
| post-fix (`pull_request`) | + `conformance/data/deprecated_symbols.json` | ran, green, 32s |

## Change

One clause on the job's `if:`:

```yaml
if: needs.changes.outputs.conformance_pkg == 'true' || needs.changes.outputs.sdk == 'true' || needs.changes.outputs.force_conformance == 'true'
```

Plus a comment recording why an SDK-area output gates a conformance-package job, so the next reader does not "simplify" it back out.

### Why OR the `sdk` output rather than widen the `conformance_pkg` filter

- The two areas keep their separate meanings; `conformance_pkg` stays "the package's own source changed".
- `sdk` already passes through the `sdk-refine` step, so a markdown-only change to `application_sdk/**` still skips. Widening the raw filter would lose that.
- `sdk` covers `.github/workflows/sdk-gate.yaml` itself, so this PR self-tests the new clause.

## Cost

Measured, not estimated:

- The drift test alone: **0.42s** (3 tests in the file).
- The whole job — checkout + `uv sync --all-extras --all-groups` + 3093 tests: **29–35s** in CI.
- It runs parallel to `SDK Tests / Unit Tests (3.11, windows-latest)` at **9m33s**.

So covering every SDK PR adds no wall-clock to the gate, against ~15 minutes of wasted queue cycle each time drift reaches the merge group.

## Verification

- `yaml.safe_load` parses; `conformance_pkg`, `sdk`, and `force_conformance` all confirmed as declared outputs of the `changes` job (a typo there would silently make the job never run, and `skipped` counts as pass at the gate).
- `uv run pre-commit run --files .github/workflows/sdk-gate.yaml` — clean.
- This PR's own CI is the functional test: it touches `sdk-gate.yaml`, so `sdk` is true and `Conformance Suite Tests / Suite unit tests` must appear in the checks. If it does not, the clause is wrong.

Refs FND-921.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
