### PR TITLE
refactor(testing): consolidate the remaining bounded wait loops onto the shared poll primitive (FND-240)

### DIFF
--- a/application_sdk/testing/e2e/_errors.py
+++ b/application_sdk/testing/e2e/_errors.py
@@ -57,6 +57,7 @@ __all__ = [
     "RequestDelivery",
     "SeededConnectionNotSearchableError",
     "UnknownConnectorTypeError",
+    "WorkerNotHealthyError",
 ]
 
 # ---------------------------------------------------------------------------
@@ -180,6 +181,47 @@ class SeededConnectionNotSearchableError(PreconditionError):
 
     code: ClassVar[str] = "PRECONDITION_SEEDED_CONNECTION_NOT_SEARCHABLE"
     expected_state: str | None = "seeded connection searchable in Atlas"
+
+
+@dataclass(kw_only=True)
+class WorkerNotHealthyError(PreconditionError, AssertionError):
+    """The app worker never served a 2xx from ``/server/health``.
+
+    The no-source tier's whole verdict. When a connector has no extraction source
+    in CI the full DAG cannot run, so
+    :meth:`~application_sdk.testing.e2e.base.BaseE2ETest.assert_worker_up` proves
+    the worker deployed instead — and an unhealthy worker must fail RED rather
+    than be reported as the skip that a *healthy* one earns.
+
+    ``PreconditionError`` for the reason
+    :class:`SeededConnectionNotSearchableError` is one: the budget did not run
+    out on work that was progressing, the state that had to exist before any work
+    could begin never did. Retrying without changing that state is not expected
+    to help.
+
+    **Also an** :class:`AssertionError`, deliberately. That is not a hedge and it
+    is not for pytest's benefit — pytest reds on any exception. It is because
+    ``assert_worker_up``'s docstring has promised an ``AssertionError`` since the
+    method existed, and out-of-repo connector suites are entitled to have written
+    ``except AssertionError`` against it. Typing the leaf is worth doing; taking a
+    documented ``except`` clause away from every connector in the fleet to do it
+    is not, and the two are not in tension — this raise satisfies both.
+
+    Attributes:
+        url: The health endpoint that never answered 2xx.
+        attempts: How many probes were made.
+        elapsed_seconds: Wall-clock time the wait consumed.
+        last_error: The last failure seen — an ``HTTP <code>`` or a transport
+            error's own message. The single most useful field: a refused
+            connection and a 503 point at different halves of a deployment.
+    """
+
+    code: ClassVar[str] = "PRECONDITION_WORKER_NOT_HEALTHY"
+    expected_state: str | None = "app worker serving 2xx from /server/health"
+    url: str | None = None
+    attempts: int | None = None
+    elapsed_seconds: float | None = None
+    last_error: str | None = None
 
 
 @dataclass(kw_only=True)

--- a/application_sdk/testing/e2e/base.py
+++ b/application_sdk/testing/e2e/base.py
@@ -1697,7 +1697,14 @@ class BaseE2ETest:
             description=f"Full-DAG e2e harness — {self.connector_short_name}",
         )
         logger.info("Created (or reused) AE workflow: name=%s slug=%s", name, slug)
-        time.sleep(3)
+        # AE has a brief indexing window before a fresh slug is queryable by
+        # /versions. This used to be an unconditional ``time.sleep(3)``, which is
+        # wrong in both directions — it charged every run three seconds it
+        # usually did not need, and was no help at all on the run where indexing
+        # took four. Now a real readiness read, advisory rather than a gate:
+        # ``create_version`` retries on 404 for exactly this reason, and that
+        # retry is what makes the sequence safe either way.
+        self.client.wait_for_slug(slug)
 
         extract_queue = self._extract_task_queue()
 

--- a/application_sdk/testing/e2e/base.py
+++ b/application_sdk/testing/e2e/base.py
@@ -1090,57 +1090,94 @@ class BaseE2ETest:
             )
 
         if probe is not None:
-            deadline = time.monotonic() + self.atlas_poll_timeout_seconds
-            attempts = 0
-            while True:
-                attempts += 1
-                try:
-                    probe()
-                except Exception as exc:
-                    if isinstance(exc, self._PROBE_NON_TRANSIENT_ERRORS):
-                        # A deterministic probe bug (a TypeError from a wrong
-                        # call signature, a config ValueError) will fail every
-                        # retry identically — burning the whole timeout before
-                        # surfacing. Re-raise immediately instead.
-                        logger.error(
-                            "e2e seed: probe write under %s raised %s, a "
-                            "non-transient error — failing fast rather than "
-                            "retrying until the %ds timeout",
-                            self.connection_qualified_name,
-                            type(exc).__name__,
-                            self.atlas_poll_timeout_seconds,
-                            exc_info=True,
-                        )
-                        raise
-                    if time.monotonic() >= deadline:
-                        logger.error(
-                            "e2e seed: probe write under %s still failing after "
-                            "%d attempt(s) / %ds — a fresh connection 403s child "
-                            "writes until its access policies go live, so this "
-                            "means provisioning never completed",
-                            self.connection_qualified_name,
-                            attempts,
-                            self.atlas_poll_timeout_seconds,
-                            exc_info=True,
-                        )
-                        raise
-                    logger.info(
-                        "e2e seed: probe write under %s not yet permitted "
-                        "(attempt %d) — connection policies not live; retrying",
-                        self.connection_qualified_name,
-                        attempts,
-                    )
-                    time.sleep(self.atlas_poll_interval_seconds)
-                else:
-                    logger.info(
-                        "e2e seed: probe write under %s succeeded after %d "
-                        "attempt(s) — connection policies are live",
-                        self.connection_qualified_name,
-                        attempts,
-                    )
-                    break
+            self._retry_seed_probe(probe)
 
         return self.connection_qualified_name
+
+    def _retry_seed_probe(self, probe: Callable[[], object]) -> None:
+        """Retry *probe* until it stops raising, or the Atlas budget runs out.
+
+        The loop is
+        :func:`~application_sdk.testing.harness._poll.until_deadline` (FND-240),
+        which is what removes the last hand-rolled ``time.monotonic() +
+        timeout`` deadline in this file — and with it the off-by-one every one of
+        them shared: the budget check sat *after* the probe, so the loop slept a
+        whole ``atlas_poll_interval_seconds`` past its stated timeout before
+        noticing. ``attempt.is_last`` makes that decision before the sleep.
+
+        Not :func:`~application_sdk.testing.harness.waiting.poll_until`, for one
+        reason: ``probe`` is a *synchronous* callable a connector suite supplies,
+        and the primitive is async by construction (decision D1). Reaching it
+        from here would mean either blocking the bridge's loop inside a
+        suite-supplied write or offloading it to a thread — both workarounds
+        built to be deleted when child H moves the sync boundary up to this
+        class's public methods. Its three sibling loops in this file take the
+        same shape for the same reason.
+
+        Args:
+            probe: The representative child write. Its return value is ignored;
+                only whether it raises matters.
+
+        Raises:
+            Exception: Whatever *probe* last raised — immediately for a
+                non-transient error, or on the final attempt otherwise.
+                Propagated rather than swallowed: a suite whose seed never
+                became writable must fail, not run against a connection it
+                cannot populate.
+        """
+        for attempt in until_deadline(
+            self.atlas_poll_timeout_seconds,
+            self.atlas_poll_interval_seconds,
+            label=f"a permitted child write under {self.connection_qualified_name}",
+            # The per-attempt line below already reports progress; a generic
+            # "still waiting" heartbeat would duplicate it.
+            heartbeat_seconds=0,
+        ):
+            try:
+                probe()
+            except Exception as exc:
+                if isinstance(exc, self._PROBE_NON_TRANSIENT_ERRORS):
+                    # A deterministic probe bug (a TypeError from a wrong
+                    # call signature, a config ValueError) will fail every
+                    # retry identically — burning the whole timeout before
+                    # surfacing. Re-raise immediately instead.
+                    logger.error(
+                        "e2e seed: probe write under %s raised %s, a "
+                        "non-transient error — failing fast rather than "
+                        "retrying until the %ds timeout",
+                        self.connection_qualified_name,
+                        type(exc).__name__,
+                        self.atlas_poll_timeout_seconds,
+                        exc_info=True,
+                    )
+                    raise
+                if attempt.is_last:
+                    logger.error(
+                        "e2e seed: probe write under %s still failing after "
+                        "%d attempt(s) / %ds — a fresh connection 403s child "
+                        "writes until its access policies go live, so this "
+                        "means provisioning never completed",
+                        self.connection_qualified_name,
+                        attempt.number,
+                        self.atlas_poll_timeout_seconds,
+                        exc_info=True,
+                    )
+                    raise
+                # conformance: ignore[L006] one line per poll of an atlas_poll_interval_seconds loop (30s by default), not a hot loop; a seed that never becomes writable is diagnosed from how many attempts were refused and for how long
+                logger.info(
+                    "e2e seed: probe write under %s not yet permitted "
+                    "(attempt %d) — connection policies not live; retrying",
+                    self.connection_qualified_name,
+                    attempt.number,
+                )
+                continue
+            logger.info(
+                "e2e seed: probe write under %s succeeded after %d "
+                "attempt(s) — connection policies are live",
+                self.connection_qualified_name,
+                attempt.number,
+            )
+            return
 
     # ------------------------------------------------------------------
     # Subclass hooks — override these

--- a/application_sdk/testing/e2e/base.py
+++ b/application_sdk/testing/e2e/base.py
@@ -65,6 +65,7 @@ from application_sdk.testing.e2e._errors import (
     ProgressWatchdogUnreachableError,
     SeededConnectionNotSearchableError,
     UnknownConnectorTypeError,
+    WorkerNotHealthyError,
 )
 from application_sdk.testing.e2e._manifest_identity import (
     DagNodeIdentity,
@@ -2352,13 +2353,22 @@ class BaseE2ETest:
         The no-source tier: when a connector has no extraction source in CI
         (``source_available`` False), the full-DAG e2e can't extract, so it
         proves the worker came up instead — a GET of ``/server/health`` returns
-        2xx. This is a hard assertion (raises ``AssertionError`` when the worker
-        never becomes healthy), so an unhealthy worker fails RED. The *caller*
-        (``test_full_dag_runs_end_to_end``) then raises ``pytest.skip`` so a
-        healthy worker reports SKIPPED, not a green pass — because the full DAG
-        was never exercised. The sdr-e2e CI action already gates on the same
+        2xx. This is a hard assertion, so an unhealthy worker fails RED. The
+        *caller* (``test_full_dag_runs_end_to_end``) then raises ``pytest.skip``
+        so a healthy worker reports SKIPPED, not a green pass — because the full
+        DAG was never exercised. The sdr-e2e CI action already gates on the same
         endpoint before pytest; re-asserting it here keeps a bare local
         ``pytest`` meaningful as a worker-deploy smoke check.
+
+        Raises:
+            WorkerNotHealthyError: The worker never answered 2xx inside
+                ``worker_health_timeout_seconds``. Typed since FND-240, which
+                names the bare ``AssertionError`` this used to raise: the last
+                failure seen is now a *field* rather than a fragment of a
+                sentence, and a refused connection and a 503 point at different
+                halves of a deployment. It **is** an ``AssertionError`` as well,
+                so a connector suite's existing ``except AssertionError`` — a
+                clause this method's own docstring invited — still catches it.
         """
         url = os.environ.get("E2E_WORKER_HEALTH_URL", self.worker_health_url)
         logger.info("Worker-up-only tier: probing %s", url)
@@ -2379,12 +2389,20 @@ class BaseE2ETest:
             except (urllib.error.URLError, OSError) as exc:
                 last_error = str(exc)
             if attempt.is_last:
-                raise AssertionError(
-                    f"App worker for {self.connector_short_name} did not become "
-                    f"healthy at {url} within {self.worker_health_timeout_seconds}s "
-                    f"({attempt.number} attempts, {attempt.elapsed:.0f}s elapsed; "
-                    f"last: {last_error}). No source is provisioned, so this run "
-                    "only checks that the worker deploys and serves /server/health."
+                raise WorkerNotHealthyError(
+                    message=(
+                        f"App worker for {self.connector_short_name} did not "
+                        f"become healthy at {url} within "
+                        f"{self.worker_health_timeout_seconds}s "
+                        f"({attempt.number} attempts, {attempt.elapsed:.0f}s "
+                        f"elapsed; last: {last_error}). No source is "
+                        "provisioned, so this run only checks that the worker "
+                        "deploys and serves /server/health."
+                    ),
+                    url=url,
+                    attempts=attempt.number,
+                    elapsed_seconds=attempt.elapsed,
+                    last_error=last_error,
                 )
 
     # ------------------------------------------------------------------

--- a/application_sdk/testing/e2e/client.py
+++ b/application_sdk/testing/e2e/client.py
@@ -35,6 +35,7 @@ rewrite:
 
 from __future__ import annotations
 
+import warnings
 from contextlib import AbstractAsyncContextManager
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any, TypeVar
@@ -82,6 +83,56 @@ T = TypeVar("T")
 #: Default types the per-type count and lineage reads cover, kept on this
 #: module's signatures as the tuple they have always been.
 _DEFAULT_TYPE_NAMES: tuple[str, ...] = atlas.DEFAULT_TYPE_NAMES
+
+
+#: Release that drops ``poll_atlas_for_connection``'s ``max_forbidden_attempts``.
+#: Named rather than left as prose: a deprecation without a removal version is a
+#: warning nobody has to act on.
+#:
+#: The notice below spells "v4.0" literally rather than interpolating this,
+#: for the reason ``AppConfig``'s does: conformance rule B002 reads the notice as
+#: written in the source, so an f-string placeholder makes a compliant
+#: deprecation look like one that never named its removal version.
+#: ``test_the_vestigial_knob_names_its_removal_version`` pins the two together.
+_FORBIDDEN_ATTEMPTS_REMOVAL_VERSION = "4.0"
+
+
+#: The log twin of the notice below, with the value the caller actually passed.
+#: %-style rather than an f-string so the value stays a log field.
+_FORBIDDEN_ATTEMPTS_LOG = (
+    "poll_atlas_for_connection(max_forbidden_attempts=%s) is deprecated, has no "
+    "effect, and will be removed in v4.0; use max_not_found_attempts instead. "
+    "This poll reads the search index, whose ACL is permissive, so a 403 never "
+    "surfaces and there is no 403 budget to bound."
+)
+
+
+def _warn_vestigial_forbidden_attempts(value: int) -> None:
+    """Say that ``max_forbidden_attempts`` does nothing, once per call that passes it.
+
+    Paired ``DeprecationWarning`` + ``warning`` log line, the same shape every
+    other 4.0 deprecation in this SDK uses: the warning so ``-W error`` and
+    ``filterwarnings`` can make it fatal ahead of the removal, the log line so it
+    is visible in a CI job's captured output where nobody is reading Python's
+    warning filter.
+
+    The notice is written **inline** rather than built into a local and passed by
+    name, which is not a style choice: conformance rule ``B002`` reads
+    ``warnings.warn``'s first argument statically, so a variable there reads as an
+    empty notice and a compliant deprecation is reported as one that named
+    neither a replacement nor a removal version. The log twin carries the value
+    the caller passed, which the notice does not need — the caller knows what
+    they wrote.
+    """
+    warnings.warn(
+        "poll_atlas_for_connection's max_forbidden_attempts is deprecated, has "
+        "no effect, and will be removed in v4.0; use max_not_found_attempts "
+        "instead. This poll reads the search index, whose ACL is permissive, so "
+        "a 403 never surfaces and there is no 403 budget to bound.",
+        DeprecationWarning,
+        stacklevel=3,
+    )
+    logger.warning(_FORBIDDEN_ATTEMPTS_LOG, value)
 
 
 def _settled_or_fail_open(outcome: Outcome[T], fallback: T) -> T:
@@ -345,7 +396,7 @@ class AEWorkflowClient:
         *,
         interval_seconds: int = 30,
         timeout_seconds: int = 1500,
-        max_forbidden_attempts: int = 5,
+        max_forbidden_attempts: int | None = None,
         max_not_found_attempts: int = 10,
         max_not_found_attempts_override: int | None = None,
     ) -> bool:
@@ -371,9 +422,15 @@ class AEWorkflowClient:
                 publish runs after the AE DAG completes and can take a while to
                 flush large connections. Callers with smaller datasets can
                 tighten this.
-            max_forbidden_attempts: Vestigial and unread. The poll goes through
-                the search index, whose ACL is permissive, so a 403 never
-                surfaces here. Kept on the signature for back-compat.
+            max_forbidden_attempts: **Deprecated, unread, and removed in
+                v4.0.** The poll goes through the
+                search index, whose ACL is permissive, so a 403 never surfaces
+                here and there is nothing for a 403 budget to bound. It was
+                ``del``'d unread rather than removed, which is the shape that
+                lets a caller keep passing a number and believe it does
+                something — so FND-240 makes it say so instead. Passing it warns;
+                omitting it is silent, which is why the default is now ``None``
+                rather than ``5``.
             max_not_found_attempts: Consecutive unproductive probes to tolerate.
             max_not_found_attempts_override: When set, replaces
                 ``max_not_found_attempts``.
@@ -384,7 +441,8 @@ class AEWorkflowClient:
         """
         if max_not_found_attempts_override is not None:
             max_not_found_attempts = max_not_found_attempts_override
-        del max_forbidden_attempts
+        if max_forbidden_attempts is not None:
+            _warn_vestigial_forbidden_attempts(max_forbidden_attempts)
         budget = Budget(
             timeout=timedelta(seconds=timeout_seconds),
             poll_interval=timedelta(seconds=interval_seconds),

--- a/application_sdk/testing/e2e/client.py
+++ b/application_sdk/testing/e2e/client.py
@@ -196,6 +196,16 @@ class AEWorkflowClient:
             )
         )
 
+    def wait_for_slug(self, slug: str) -> bool:
+        """Wait until AE resolves *slug*; see :meth:`AEClient.wait_for_slug`.
+
+        Advisory: the returned bool is for the caller's log, and an unresolved
+        slug is not an error — ``create_version``'s own 404 retry is what makes
+        the sequence safe. Replaces the unconditional ``time.sleep(3)`` both
+        full-DAG harnesses ran here (FND-240).
+        """
+        return run_sync(self._ae.wait_for_slug(slug))
+
     def create_version(
         self,
         slug: str,

--- a/application_sdk/testing/e2e/workflows.py
+++ b/application_sdk/testing/e2e/workflows.py
@@ -1,14 +1,55 @@
 """Workflow trigger and status helpers for K8s e2e tests."""
 
+from datetime import timedelta
 from typing import Any
 
+import httpx
+
 from application_sdk.observability.logger_adaptor import get_logger
-from application_sdk.testing.harness._poll import until_deadline_async
+from application_sdk.testing.harness.budgets import Budget
 from application_sdk.testing.harness.cluster import kube_http_call, port_forward
+from application_sdk.testing.harness.outcome import Expired, assert_settled
+from application_sdk.testing.harness.waiting import poll_until
 
 logger = get_logger(__name__)
 
 _TERMINAL_STATES = {"completed", "failed", "cancelled", "terminated"}
+
+#: Consecutive unreadable polls to absorb before the wait declares it has no
+#: verdict. Five at the 5-second default is ~25s of an unreachable handler,
+#: which is longer than a pod restart and shorter than any real wait — the same
+#: streak length the AE poll uses, for the same reason.
+_MAX_TRANSIENT_FAILURES = 5
+
+
+def _absorb_a_handler_blip(error: BaseException) -> timedelta | None:
+    """Is a failed status read worth another poll, or is it the answer?
+
+    The gap this closes: the loop this replaced called ``raise_for_status()``
+    with no policy around it, so one 502 from a handler pod mid-restart aborted
+    a 300-second wait — and aborted it as an ``httpx.HTTPStatusError``, which
+    reads as a test failure rather than as an unreadable dependency.
+
+    The narrowing is by *status class*, not by "any HTTP error":
+
+    * a transport error, or a 5xx / 429, is the handler being unreachable or
+      overloaded, and the next poll is entitled to a different answer;
+    * a 4xx is the handler answering. A 404 on a workflow id is a wrong id, and
+      no amount of waiting turns it into the right one — absorbing it would
+      spend the whole budget on a typo and then report a timeout.
+
+    Returns:
+        ``timedelta(0)`` — "absorb this, the loop's own interval is the gap" —
+        for a blip, or ``None`` for anything terminal. The handler serves no
+        ``Retry-After``, so there is no origin backoff to honour.
+    """
+    if isinstance(error, httpx.HTTPStatusError):
+        status = error.response.status_code
+        retryable = status >= 500 or status == httpx.codes.TOO_MANY_REQUESTS
+        return timedelta(0) if retryable else None
+    if isinstance(error, httpx.TransportError):
+        return timedelta(0)
+    return None
 
 
 async def run_workflow(
@@ -64,6 +105,20 @@ async def wait_for_workflow(
     :meth:`~application_sdk.testing.harness.cluster.PortForward.request`
     rebuilding once on a transport error.
 
+    The loop is :func:`~application_sdk.testing.harness.waiting.poll_until`
+    (FND-240), and that is what gives this wait a **transient-error policy** — it
+    had none. ``raise_for_status()`` sat bare inside the old loop, so a single
+    502 from a handler pod mid-restart ended a five-minute wait on its first
+    poll. :func:`_absorb_a_handler_blip` decides which failed reads are worth
+    another poll and which are the answer.
+
+    ``TimeoutError`` is kept for the expired case rather than becoming
+    :class:`~application_sdk.testing.harness._errors.WaitExpiredError`: this is a
+    public export with out-of-repo consumers, and their ``except TimeoutError``
+    is not something a refactor gets to invalidate. The unreadable case has no
+    such history — it used to surface as a raw ``httpx`` error — so it raises the
+    typed leaf.
+
     Args:
         namespace: K8s namespace where the handler service lives.
         service: Handler service name.
@@ -77,25 +132,59 @@ async def wait_for_workflow(
 
     Raises:
         TimeoutError: If the workflow does not complete within ``timeout``.
+        WaitIndeterminateError: If the handler could not be read for
+            :data:`_MAX_TRANSIENT_FAILURES` consecutive polls. Distinct from the
+            timeout on purpose: an unreachable handler is not evidence about the
+            workflow, and grading it as one would report a pod restart as a
+            workflow that never finished.
     """
+    # One session for the whole poll, opened outside the probe. Opening it
+    # *inside* would restore the per-probe ``kubectl`` process FND-241 removed —
+    # the probe is the loop body, and a context manager in a loop body is a
+    # tunnel per iteration.
     async with port_forward(namespace, service, port) as session:
-        async for attempt in until_deadline_async(
-            timeout, poll_interval, label=f"workflow {workflow_id}"
-        ):
+
+        async def probe() -> dict[str, Any]:
             response = await session.request("GET", f"/api/v1/workflows/{workflow_id}")
             response.raise_for_status()
             data: dict[str, Any] = response.json()
-            status = data.get("status", "").lower()
-            logger.debug("Workflow %s status: %s", workflow_id, status)
-            if status in _TERMINAL_STATES:
-                return data
-            if attempt.is_last:
-                raise TimeoutError(
-                    f"Workflow {workflow_id} did not reach a terminal state within "
-                    f"{timeout}s ({attempt.number} attempts, {attempt.elapsed:.0f}s "
-                    f"elapsed; last status={status or 'unknown'})"
-                )
+            logger.debug("Workflow %s status: %s", workflow_id, _status_of(data))
+            return data
 
-    raise AssertionError(  # pragma: no cover — the is_last branch always fires first
-        f"poll loop for workflow {workflow_id} ended without a final attempt"
-    )
+        outcome = await poll_until(
+            probe,
+            settled=lambda data: _status_of(data) in _TERMINAL_STATES,
+            transient=_absorb_a_handler_blip,
+            budget=Budget(
+                timeout=timedelta(seconds=timeout),
+                poll_interval=timedelta(seconds=poll_interval),
+                max_transient_failures=_MAX_TRANSIENT_FAILURES,
+            ),
+            label=f"workflow {workflow_id}",
+        )
+    if isinstance(outcome, Expired):
+        raise TimeoutError(
+            f"Workflow {workflow_id} did not reach a terminal state within "
+            f"{timeout}s ({outcome.attempts} attempts, "
+            f"{outcome.elapsed.total_seconds():.0f}s elapsed; last status="
+            f"{_status_of(outcome.last) or 'unknown'})"
+        )
+    # Indeterminate keeps its typed leaf; Settled unwraps. Neither NeverStarted
+    # nor Stalled is reachable — no ``started`` predicate and no ``fingerprint``
+    # is passed, so neither guard is armed — and ``assert_settled`` covers both
+    # anyway rather than this function growing a branch per unreachable verdict.
+    return assert_settled(outcome)
+
+
+def _status_of(data: dict[str, Any] | None) -> str:
+    """The handler's status string, lowercased; ``""`` when there is none.
+
+    Total on the input rather than assuming a dict with a string ``status``: the
+    settled predicate, the debug line and the timeout message all read it, and a
+    handler that answered ``{"status": null}`` must not crash the wait in the
+    predicate that was deciding whether to keep waiting.
+    """
+    if not isinstance(data, dict):
+        return ""
+    status = data.get("status", "")
+    return status.lower() if isinstance(status, str) else ""

--- a/application_sdk/testing/full_dag/base.py
+++ b/application_sdk/testing/full_dag/base.py
@@ -666,11 +666,11 @@ class BaseFullDAGE2ETest:
             description=f"Full-DAG e2e harness — {self.connector_short_name}",
         )
         logger.info("Created (or reused) AE workflow: name=%s slug=%s", name, slug)
-        # AE has a brief indexing window before the slug is queryable
-        # by /versions — sleep 3s here so the first create_version
-        # attempt usually succeeds. create_version also retries on
-        # 404, so this is belt-and-suspenders for cheap-and-fast.
-        time.sleep(3)
+        # AE has a brief indexing window before the slug is queryable by
+        # /versions. Was an unconditional ``time.sleep(3)``; now a real readiness
+        # read (FND-240), advisory rather than a gate — create_version retries on
+        # 404, and that retry is what makes the sequence safe either way.
+        self.client.wait_for_slug(slug)
 
         # Derive the extract task_queue from agent_name (tier-4) or
         # the connector's default tenant queue (tier-5). The Argo

--- a/application_sdk/testing/harness/__init__.py
+++ b/application_sdk/testing/harness/__init__.py
@@ -26,8 +26,10 @@ Module map:
 ``bridge``
     The one sync/async bridge. One reused event loop per thread.
 ``_poll``
-    The deadline arithmetic both bounded-wait shapes and ``testing/e2e``'s
-    twelve loops run on. Private; moved here from ``testing/e2e`` in child C.
+    The deadline arithmetic every bounded loop in the harness runs on — both
+    wait shapes, and the handful whose probe is synchronous and so reads it
+    directly. Private; moved here from ``testing/e2e`` in child C, and the sole
+    remaining clock since child D (FND-240).
 ``waiting``
     ``poll_until`` and ``hold_stable`` — the only two bounded-wait shapes.
 ``outcome``
@@ -79,11 +81,32 @@ real; the rest are typed stubs, each naming the child issue that fills it in.
 
 ``atlas`` and ``automation_engine`` are the first two that ``testing/e2e``
 actually calls: since child F, ``AEWorkflowClient`` is a set of one-line
-``run_sync`` shims over them and holds no logic of its own. The rest are still
-pinned against the code they were lifted from by their unit tests rather than by
-being called from it — ``testing/e2e`` is re-expressed over them in child H. For
-``waiting`` that pin is a differential test against ``poll_native_status``
-itself, on identical scripted readings.
+``run_sync`` shims over them and holds no logic of its own. ``waiting`` joined
+them in child D (FND-240) — ``poll_native_status``, ``atlas.poll_for_connection``,
+``workflows.wait_for_workflow`` and ``AEClient.wait_for_slug`` are all expressed
+over :func:`~application_sdk.testing.harness.waiting.poll_until`, and the loops
+whose probe is synchronous read ``_poll``'s deadline arithmetic directly. No
+bounded loop in the harness owns a deadline any more.
+
+The rest are pinned by their unit tests rather than by being called from
+``testing/e2e``, which is child H's change. What that pin *is* differs by
+provenance, and the difference is worth knowing before trusting one: a module
+lifted from code in this repo can be tested **differentially**, against the
+implementation it replaced on identical inputs, while one that was not has to be
+pinned against **captured numbers** instead. ``cluster`` is the first kind — it
+retired ``testing/e2e/pods.py``, so there was an original to compare against.
+``temporal`` is the second, and says so in its own entry above — so "pinned
+against the code they were lifted from" is not true of every module here.
+
+``waiting`` started as the first kind and became the second in child D, which is
+the case worth reading carefully because the change was not a choice: its pin
+*was* a differential against ``poll_native_status`` on identical scripted
+readings, and that stopped meaning anything the moment that function became a
+call to ``poll_until``. A loop compared against itself agrees by construction. So
+the numbers the hand-rolled loop produced — verdict, probe count and exact sleep
+sequence, for fifteen scripts — were captured before the conversion and frozen in
+``test_waiting_equivalence.py`` as a golden table. A differential that has
+quietly become circular is worse than no differential, because it still passes.
 
 The optional ``harness`` extra carries the typed Kubernetes backend for
 ``cluster`` (``pip install 'atlan-application-sdk[harness]'``). It is

--- a/application_sdk/testing/harness/_errors.py
+++ b/application_sdk/testing/harness/_errors.py
@@ -155,8 +155,9 @@ class WaitStalledError(AppTimeoutError):
     (ADR-0018): a stall *is* a bounded wait that elapsed, just a wait for the
     next change rather than for the end. ``testing/e2e``'s
     ``DAGProgressStalledError`` calls the same condition a ``PRECONDITION``; it
-    predates the ADR and keeps its category so no existing consumer sees a
-    reclassification. Normalising the pair is listed on FND-240.
+    predates the ADR and keeps its category, and FND-240 declined to normalise
+    the pair — see that class for why a ``code`` change is an error-contract
+    change rather than a refactor.
 
     Attributes:
         label: What was being waited on, verbatim from the outcome.

--- a/application_sdk/testing/harness/_poll.py
+++ b/application_sdk/testing/harness/_poll.py
@@ -121,6 +121,25 @@ class Attempt:
         return gap
 
 
+def monotonic() -> float:
+    """Read the clock the bounded-wait loops run on.
+
+    For code that keeps its own elapsed-time ledger *alongside* a loop rather
+    than inside one — a probe wrapper that logs progress, or one that has to
+    report how long a reading has been unchanged. Such a wrapper is called by
+    :func:`~application_sdk.testing.harness.waiting.poll_until`, which does not
+    hand it the :class:`Attempt`, so the only way for the two to agree on
+    "elapsed" is to read the same clock.
+
+    Reading it through this function rather than calling :func:`time.monotonic`
+    directly is what puts the wrapper under :func:`fake_clock` with the loop it
+    accompanies. A wrapper on the real clock inside a fake-clock test reports
+    zero elapsed for a wait the loop believes ran for ten minutes, which is
+    exactly the sort of disagreement a progress ledger exists to rule out.
+    """
+    return _monotonic()
+
+
 async def sleep_async(seconds: float) -> None:
     """Await *seconds* through this module's swappable sleep.
 

--- a/application_sdk/testing/harness/_poll.py
+++ b/application_sdk/testing/harness/_poll.py
@@ -42,9 +42,17 @@ cannot import from the package it is about to be the foundation of: child H
 re-expresses ``testing/e2e`` *over*
 :mod:`application_sdk.testing.harness.waiting`, and a
 ``harness -> e2e -> harness`` cycle is what keeping the deadline loop on the e2e
-side would have produced. Both sides read it from here today; the five
-``testing/e2e`` call sites keep their behaviour byte for byte and only their
-import line moved (child C on FND-224).
+side would have produced. Both sides read it from here today: child C moved it
+and rewired five ``testing/e2e`` call sites byte for byte, and child D (FND-240)
+brought the rest across — after which **no bounded loop in the harness owns a
+deadline**, and there is one clock rather than the monotonic-deadline /
+elapsed-accumulator / ``time.time()`` three that coexisted before.
+
+The remaining direct callers are the ones whose probe is *synchronous* — a
+connector-supplied write, a local test client — and so cannot reach
+:func:`~application_sdk.testing.harness.waiting.poll_until` without blocking the
+bridge's loop inside someone else's code. Everything async goes through the
+primitive instead, and gets the guards and the verdict vocabulary with it.
 """
 
 from __future__ import annotations

--- a/application_sdk/testing/harness/automation_engine/_errors.py
+++ b/application_sdk/testing/harness/automation_engine/_errors.py
@@ -253,9 +253,12 @@ class DAGProgressStalledError(PreconditionError):
 
     Categorised ``PRECONDITION`` where the generic
     :class:`~application_sdk.testing.harness._errors.WaitStalledError` is a
-    ``TIMEOUT`` (per ADR-0018). This one predates the ADR and keeps its category
-    so no existing consumer sees a reclassification; normalising the pair is
-    listed on FND-240.
+    ``TIMEOUT`` (per ADR-0018). FND-240 looked at normalising the pair and
+    **declined**: ``code`` is the field a structured failure envelope carries and
+    alert rules route on, so flipping this one's category silently re-routes
+    every consumer's stall alert. That is an error-contract change, and it
+    belongs at the next major with the rest of them — not folded into a refactor
+    whose whole constraint is that behaviour is preserved.
     """
 
     code: ClassVar[str] = "PRECONDITION_DAG_PROGRESS_STALLED"

--- a/application_sdk/testing/harness/automation_engine/client.py
+++ b/application_sdk/testing/harness/automation_engine/client.py
@@ -873,6 +873,16 @@ class AEClient:
         Retries on HTTP 404 (indexing lag — slug not yet queryable after
         create_workflow), HTTP 5xx (AE under load), and timeout.
 
+        ``retries`` means retries: this used to pass ``total_attempts=retries``,
+        so ``retries=5`` bought four of them while ``create_workflow``'s and
+        ``submit_workflow``'s identically-named parameter bought five. FND-240
+        normalised the four onto ``retries + 1``, the convention
+        :meth:`_post_with_retry` documents and the only one the parameter's name
+        is true under. The direction is deliberate: the other pair could have
+        been changed to match instead, but that shortens
+        ``cold_start_submit_kwargs``' budget, which divides a timeout by an
+        interval and needs the attempt count it asked for.
+
         Returns:
             The version number assigned by AE (typically a Unix
             timestamp, but treat as opaque int).
@@ -880,7 +890,7 @@ class AEClient:
         status, body = await self._post_with_retry(
             f"/automation/api/v1/workflows/{slug}/versions",
             body=version_payload,
-            total_attempts=retries,
+            total_attempts=retries + 1,
             sleep_seconds=retry_sleep_seconds,
             retryable=lambda s, b: s == 404 or s >= 500,
             op_name="create_version",
@@ -909,10 +919,13 @@ class AEClient:
         AE can lag a few seconds between version-create and version-
         publish — early calls return 404 (AE-WF-404-02 "version not
         found"). Retries on any non-success response and timeout.
+
+        ``retries`` means retries — see :meth:`create_version` for why the four
+        AE writes were normalised onto ``retries + 1`` (FND-240).
         """
         status, body = await self._post_with_retry(
             f"/automation/api/v1/workflows/{slug}/versions/{version}/publish",
-            total_attempts=retries,
+            total_attempts=retries + 1,
             sleep_seconds=retry_sleep_seconds,
             retryable=lambda s, b: (
                 s >= 300 or not (isinstance(b, dict) and b.get("status") == "success")
@@ -922,7 +935,9 @@ class AEClient:
         if status < 300 and isinstance(body, dict) and body.get("status") == "success":
             return
         raise AtlanApiHttpError(
-            message=f"publish_version failed after {retries} attempts: {body!r}",
+            message=(
+                f"publish_version failed after {retries + 1} attempt(s): {body!r}"
+            ),
             target="POST /automation/api/v1/workflows/.../versions/.../publish",
             retry_after_seconds=requested_retry_after(body),
         )

--- a/application_sdk/testing/harness/automation_engine/client.py
+++ b/application_sdk/testing/harness/automation_engine/client.py
@@ -31,6 +31,7 @@ the retry.
 
 from __future__ import annotations
 
+import math
 import time
 from collections.abc import Awaitable, Callable
 from dataclasses import replace
@@ -45,6 +46,7 @@ from application_sdk.errors.base import AppError
 from application_sdk.observability.logger_adaptor import get_logger
 from application_sdk.testing.harness._poll import (
     _HEARTBEAT_SECONDS,
+    monotonic,
     sleep_async,
     until_deadline_async,
 )
@@ -60,6 +62,7 @@ from application_sdk.testing.harness.automation_engine._errors import (
     RequestDelivery,
 )
 from application_sdk.testing.harness.automation_engine.retry import (
+    MAX_RETRY_AFTER_SECONDS,
     RETRY_AFTER_BUDGET_SECONDS,
     RunLookup,
     WriteRecovery,
@@ -84,6 +87,16 @@ from application_sdk.testing.harness.automation_engine.wire import (
     safe_node_status,
     safe_run_status,
 )
+from application_sdk.testing.harness.budgets import Budget
+from application_sdk.testing.harness.outcome import (
+    Expired,
+    Indeterminate,
+    NeverStarted,
+    Outcome,
+    Settled,
+    Stalled,
+)
+from application_sdk.testing.harness.waiting import poll_until
 
 logger = get_logger(__name__)
 
@@ -166,6 +179,140 @@ _RESUBMIT_WHEN_AE_REPORTS_NO_RUN = False
 # time, so the loop would otherwise look wedged in CI output. That loop throttles
 # its own richer progress line to the same cadence and disables the generic
 # heartbeat, rather than emitting two "still waiting" lines.
+
+
+# ---------------------------------------------------------------------------
+# The AE shape ``poll_until`` is given, as four callables plus a ledger
+# ---------------------------------------------------------------------------
+#
+# ``poll_native_status`` used to interleave these with the loop's own clock
+# arithmetic. FND-240 hands the loop to
+# :func:`~application_sdk.testing.harness.waiting.poll_until` and leaves the
+# AE-specific parts here, which is the whole of what child C extracted: the
+# start-grace latch, the progress watchdog and the transient streak are generic,
+# and only *what counts as started*, *what counts as progress* and *which
+# exception is a blip* are about the Automation Engine.
+
+
+def _armed(seconds: int | None) -> timedelta | None:
+    """Read a guard's window, or ``None`` when the caller disabled it.
+
+    ``poll_native_status`` spells "disabled" three ways — ``None``, ``0`` and any
+    negative — and :class:`~application_sdk.testing.harness.budgets.Budget`
+    spells it once, as ``None``. A negative is not folded in for tidiness: left
+    as a duration it would make ``elapsed >= grace`` true on the very first poll
+    and fire the guard before anything could possibly have started.
+    """
+    if seconds is None or seconds <= 0:
+        return None
+    return timedelta(seconds=seconds)
+
+
+def _any_node_started(result: DAGRunResult) -> bool:
+    """True once at least one DAG node has left the not-started set.
+
+    Node-level, not run-level, and that is the load-bearing part: the parent AE
+    workflow runs on the always-on automation-engine queue, so the top-level run
+    flips to ``Running`` even when the connector's own ``extract`` node is stuck
+    because nothing polls its task queue. Keying the start latch on the run
+    status would therefore report every unpolled queue as "started".
+    """
+    return any(not node.status.is_not_started for node in result.nodes)
+
+
+def _absorb_ae_blip(error: BaseException) -> timedelta | None:
+    """How long to back off after a probe error, or ``None`` if it is terminal.
+
+    Absorbs :class:`~application_sdk.errors.base.AppError` and nothing else,
+    which is the ``except AppError`` this replaced: the tenant's Temporal blips
+    during multi-minute runs and AE answers ``AE-COMMON-500-01`` for a few
+    seconds before recovering, whereas a ``TypeError`` from a wrong call
+    signature will raise identically on every attempt and waiting out the budget
+    only delays it.
+
+    Rounding up is the classifier's job rather than the primitive's:
+    :func:`~application_sdk.testing.harness.automation_engine.retry.retry_gap`
+    took ``math.ceil`` because its input is an HTTP body's integer seconds, and
+    :func:`~application_sdk.testing.harness.waiting._honoured_gap` is handed a
+    ``timedelta`` and has no business quantising someone else's duration. Doing
+    it here is what keeps the honoured gaps identical to the hand-rolled loop's.
+
+    Returns:
+        ``timedelta(0)`` for a blip the origin named no backoff for — "absorb
+        this, and the loop's own interval is the gap" — the requested backoff
+        when it did, or ``None`` for anything that is not an ``AppError``.
+    """
+    if not isinstance(error, AppError):
+        return None
+    requested = (
+        error.retry_after_seconds if isinstance(error, AtlanApiHttpError) else None
+    )
+    if requested is None or requested <= 0:
+        return timedelta(0)
+    return timedelta(seconds=math.ceil(requested))
+
+
+class _DAGProgress:
+    """The per-poll progress line, and the ledger behind it.
+
+    Two jobs the generic primitive deliberately does not do, both keyed on the
+    node-glyph summary:
+
+    * **the log.** One line per node-state change, plus a heartbeat at
+      :data:`~application_sdk.testing.harness._poll._HEARTBEAT_SECONDS` even
+      when nothing moved, because a lineage stage sits unchanged for 2-5 minutes
+      and an operator watching a CI leg cannot otherwise tell "still polling"
+      from "harness wedged". The ``L006`` waiver this carries forward is about
+      exactly that throttling, so the line moves here rather than being dropped.
+    * **the quiet gap.**
+      :attr:`~application_sdk.testing.harness.automation_engine.wire.DAGRunResult.seconds_since_last_progress`
+      is stamped onto the observation a *timed-out* poll returns, and
+      :class:`~application_sdk.testing.harness.outcome.Expired` does not carry
+      it — the watchdog's own window is on
+      :class:`~application_sdk.testing.harness.outcome.Stalled`, which is the
+      verdict where it fired. This sees every successful reading, so it can
+      answer the question in the one case the verdict cannot.
+
+    Elapsed comes from :func:`~application_sdk.testing.harness._poll.monotonic`
+    rather than a private clock, so it is the same reading the loop's own
+    ``Attempt.elapsed`` is measured against and a ``fake_clock`` test sees one
+    consistent timeline.
+    """
+
+    def __init__(self) -> None:
+        self._started = monotonic()
+        self._last_summary: str | None = None
+        self._last_logged = 0.0
+        #: Elapsed at the most recent successful reading.
+        self.last_elapsed = 0.0
+        #: Elapsed at the most recent *change* in the summary.
+        self.last_progress = 0.0
+
+    def observe(self, result: DAGRunResult) -> None:
+        """Record one successful reading and log it if it is worth a line."""
+        elapsed = monotonic() - self._started
+        self.last_elapsed = elapsed
+        summary = result.fingerprint
+        changed = summary != self._last_summary
+        if changed:
+            self.last_progress = elapsed
+        if not (changed or (elapsed - self._last_logged) >= _HEARTBEAT_SECONDS):
+            return
+        # conformance: ignore[L006] throttled to status-changes plus a heartbeat every _HEARTBEAT_SECONDS (see the class docstring), not per-iteration; demoting to DEBUG would hide long-running-stage progress in CI
+        logger.info(
+            "%s AE run [%3ds] %s — %s",
+            RUN_GLYPHS.get(result.status.value, "•"),
+            int(elapsed),
+            result.status.value,
+            summary,
+        )
+        self._last_summary = summary
+        self._last_logged = elapsed
+
+    @property
+    def quiet_seconds(self) -> float:
+        """How long the summary had been unchanged at the last reading."""
+        return max(0.0, self.last_elapsed - self.last_progress)
 
 
 class AEClient:
@@ -1141,50 +1288,62 @@ class AEClient:
     ) -> DAGRunResult:
         """Poll until the run reaches a terminal top-level status.
 
-        Logs a one-line summary per poll only when the status string
-        changes (i.e. progress moments), to avoid spamming logs during
-        long-running publish / lineage stages.
+        **The loop is
+        :func:`~application_sdk.testing.harness.waiting.poll_until`** (FND-240).
+        Child C extracted the start-grace latch, the progress watchdog and the
+        transient streak *from this function*; what is left here is the four
+        AE-specific callables (:func:`_any_node_started`, ``result.fingerprint``,
+        ``result.status.is_terminal``, :func:`_absorb_ae_blip`), the
+        :class:`~application_sdk.testing.harness.budgets.Budget` its keyword
+        arguments convert into, and :func:`_dag_run_verdict` — which turns the
+        generic verdict back into the AE leaf carrying this connector's
+        remediation advice.
 
-        Tolerates transient HTTP failures from :meth:`get_native_status`:
-        the tenant's Temporal occasionally blips during multi-minute
-        runs and AE then returns ``AE-COMMON-500-01: An unexpected
-        error occurred`` for a few seconds before recovering. We log
-        a warning and keep polling rather than failing the whole test
-        on a single bad response. After ``max_transient_failures``
-        consecutive errors we give up and re-raise — that's a
-        sustained outage, not a blip, and there's no point waiting.
-        When the failing response names a ``retry_after``, the next poll
-        waits that long instead of ``interval_seconds``, so an origin asking
-        for a 2-minute backoff doesn't consume the whole failure streak
-        inside its own wait window. Honoured waiting is capped per poll loop
-        at
-        :data:`~application_sdk.testing.harness.automation_engine.retry.RETRY_AFTER_BUDGET_SECONDS`
-        (same accounting as :meth:`_post_with_retry`) and each sleep is clamped
-        to the remaining ``timeout_seconds`` budget, so the loop never sleeps
-        past its own deadline.
+        Every observable behaviour is preserved and pinned rather than asserted:
+        ``test_waiting_equivalence.py`` fixes the verdict, the probe count and
+        the exact sleep sequence of fifteen scripted runs against the numbers the
+        hand-rolled loop produced. Two things did change, both log-only:
+
+        * the give-up-on-the-streak line is now the primitive's ``WARNING``
+          rather than this loop's ``ERROR``. The streak count it carried is
+          still on it, and the origin's error still propagates to the caller,
+          which is what makes the failure red.
+        * the per-poll progress line — throttled to node-state changes plus a
+          heartbeat, and the reason for the ``L006`` waiver — moved to
+          :class:`_DAGProgress`, which the probe wrapper calls. It is not
+          dropped: an operator watching a CI leg needs it to tell "still
+          polling" from "harness wedged", and a lineage stage sits unchanged for
+          minutes.
+
+        Tolerates transient HTTP failures from :meth:`get_native_status`: the
+        tenant's Temporal occasionally blips during multi-minute runs and AE then
+        returns ``AE-COMMON-500-01: An unexpected error occurred`` for a few
+        seconds before recovering. After ``max_transient_failures`` *consecutive*
+        errors the wait gives up and the origin's own error is re-raised — that
+        is a sustained outage, not a blip. When the failing response names a
+        ``retry_after`` the next poll waits that long instead of
+        ``interval_seconds``, so an origin asking for a 2-minute backoff doesn't
+        consume the whole failure streak inside its own wait window; honoured
+        waiting is capped per wait at
+        :data:`~application_sdk.testing.harness.automation_engine.retry.MAX_RETRY_AFTER_SECONDS`
+        and per loop at
+        :data:`~application_sdk.testing.harness.automation_engine.retry.RETRY_AFTER_BUDGET_SECONDS`,
+        and each sleep is clamped to the remaining budget.
 
         Fail-fast stall guard: when ``stall_grace_seconds`` is a positive int
-        (``None`` or any value ``<= 0`` disables it) and NO DAG node has left the
-        not-started set (``Pending`` / ``Scheduled``) within that window, raise
+        (``None`` or any value ``<= 0`` disables it — see :func:`_armed`) and NO
+        DAG node has left the not-started set within that window, raise
         :class:`~application_sdk.testing.harness.automation_engine._errors.NoWorkerOnTaskQueueError`
-        instead of hanging for the full ``timeout_seconds``. The parent AE
-        workflow runs on the always-on automation-engine queue, so the top-level
-        run flips to ``Running`` even when the connector's ``extract`` node is
-        stuck because no worker polls its task queue — hence the check is on
-        node-level start, not the run status. ``stall_task_queue`` is included in
-        the error message so the operator can see which queue had no worker.
+        instead of hanging for the full ``timeout_seconds``. ``stall_task_queue``
+        is named in the message so the operator can see which queue had no
+        worker.
 
-        Progress watchdog: when ``progress_stall_seconds`` is a positive int
-        (``None`` / ``<= 0`` disables it), the run fails fast if NO DAG node
-        changes state for that window *after* at least one node has started.
-        This catches a node that began but is wedged ``Running`` (e.g. an
-        extract stuck on a slow/failing upload) — the start-stall guard above
-        is a one-time latch and would miss it, so the harness would otherwise
-        poll the full ``timeout_seconds``. The window is deliberately wide
-        (well above a legitimately slow single node — lineage on deep queues
-        can sit ``Running`` for many minutes) so healthy runs never trip it;
-        it exists to turn an indefinite hang into a fast, self-terminating
-        failure with the last-seen node states, instead of a manual cancel.
+        Progress watchdog: when ``progress_stall_seconds`` is a positive int, the
+        run fails fast if the node-glyph summary does not change for that window
+        *after* at least one node has started. This catches a node that began but
+        is wedged ``Running`` — the start latch above is one-shot and would miss
+        it. The window is deliberately wide (lineage on deep queues legitimately
+        sits ``Running`` for many minutes) so healthy runs never trip it.
 
         On hitting ``timeout_seconds`` the last observation is returned rather
         than raised — but stamped with ``timed_out_after_seconds`` and
@@ -1194,208 +1353,221 @@ class AEClient:
         :attr:`~application_sdk.testing.harness.automation_engine.wire.DAGRunResult.timed_out`
         before treating the node states as a verdict.
 
-        Note:
-            Still a hand-rolled loop rather than a call to
-            :func:`~application_sdk.testing.harness.waiting.poll_until`, whose
-            start-grace latch and no-change watchdog were extracted from exactly
-            this function. Consolidating the two is child D (FND-240) and is
-            deliberately not folded into this move: the AE-specific leaves this
-            loop raises carry connector remediation advice
-            (:class:`~application_sdk.testing.harness.automation_engine._errors.NoWorkerOnTaskQueueError`
-            names the task queue to check) that
-            :func:`~application_sdk.testing.harness.outcome.assert_settled`'s
-            generic leaves do not, and re-deriving that mapping is a behaviour
-            change to review on its own rather than inside a 2,500-line move.
-            ``test_waiting_equivalence.py`` already pins the two loops as
-            equivalent on the parts that do transfer.
+        Args:
+            run_id: The AE run to watch.
+            interval_seconds: Nominal gap between polls.
+            timeout_seconds: Total wall-clock budget for the whole wait.
+            max_transient_failures: Length of the consecutive probe-error streak
+                that ends the wait. The Nth error is the one that gives up, so
+                ``5`` absorbs four; ``0`` and ``1`` both mean "end on the first".
+            stall_grace_seconds: Start-grace window, or ``None``/``<= 0`` to
+                disable the latch.
+            stall_task_queue: Task queue named in the no-worker message.
+            progress_stall_seconds: Progress-watchdog window, or ``None``/``<= 0``
+                to disable it.
+
+        Returns:
+            The terminal observation, or the last one seen when the budget ran
+            out (stamped, per above).
+
+        Raises:
+            AutomationEngineNotDispatchingError: Nothing started inside the grace
+                window and the run was still ``Pending`` — AE never dispatched
+                it, so the app's queue is not implicated.
+            NoWorkerOnTaskQueueError: Nothing started inside the grace window
+                while the run was live — AE dispatched and nothing picked it up.
+            DAGProgressStalledError: A node started, then the summary froze for
+                the whole watchdog window.
+            AtlanApiTimeoutError: The budget ran out without one usable reading.
+            AppError: The origin's own error, when the transient streak gave up.
         """
-        last_summary: str | None = None
-        last_result: DAGRunResult | None = None
-        transient_streak = 0
-        # Seconds spent waiting *beyond* the poll interval because the origin
-        # asked for longer — same accounting ``_post_with_retry`` keeps, so
-        # both retry loops bound honoured backoff at RETRY_AFTER_BUDGET_SECONDS.
-        honoured_seconds = 0.0
-        last_log_elapsed = 0.0  # seconds since the last info log fired
-        last_elapsed = 0.0  # elapsed at the last successful observation
-        any_node_started = False  # any node reached Running/terminal (stall guard)
-        last_progress_elapsed = (
-            0.0  # elapsed at the last node-state transition (progress watchdog)
+        budget = Budget(
+            timeout=timedelta(seconds=timeout_seconds),
+            poll_interval=timedelta(seconds=interval_seconds),
+            start_grace=_armed(stall_grace_seconds),
+            stall_timeout=_armed(progress_stall_seconds),
+            max_transient_failures=max_transient_failures,
+            retry_after_budget=timedelta(seconds=RETRY_AFTER_BUDGET_SECONDS),
+            max_retry_after=timedelta(seconds=MAX_RETRY_AFTER_SECONDS),
+            # _DAGProgress emits the richer per-poll line; the generic "still
+            # waiting" heartbeat would double it.
+            heartbeat=None,
         )
-        async for attempt in until_deadline_async(
-            timeout_seconds,
-            interval_seconds,
+        progress = _DAGProgress()
+
+        async def probe() -> DAGRunResult:
+            result = await self.get_native_status(run_id)
+            progress.observe(result)
+            return result
+
+        outcome = await poll_until(
+            probe,
+            settled=lambda result: result.status.is_terminal,
+            started=_any_node_started,
+            fingerprint=lambda result: result.fingerprint,
+            transient=_absorb_ae_blip,
+            budget=budget,
             label=f"AE run {run_id}",
-            # This loop emits its own richer progress line (per node-state change
-            # plus a heartbeat at the same cadence); the generic one would double it.
-            heartbeat_seconds=0,
-        ):
-            elapsed = attempt.elapsed
-            try:
-                result = await self.get_native_status(run_id)
-            except AppError as e:
-                transient_streak += 1
-                if transient_streak >= max_transient_failures:
-                    # conformance: ignore[L009] adds caller-invisible loop state (consecutive-failure streak count) not carried by the re-raised exception; not a duplicate of the raise site
-                    logger.error(
-                        "native-status failed %d times in a row — giving up: %s",
-                        transient_streak,
-                        e,
-                        exc_info=True,
-                    )
-                    raise
-                # Back off for as long as the origin asked when it said so,
-                # rather than the poll cadence: an overloaded tenant answering
-                # "retry_after: 120" would otherwise burn the whole
-                # max_transient_failures streak inside its own wait window.
-                # The loop's own clock advances by the real wait, so
-                # timeout_seconds still bounds it.
-                gap = retry_gap(
-                    e.retry_after_seconds if isinstance(e, AtlanApiHttpError) else None,
-                    default_seconds=interval_seconds,
-                    budget_left=RETRY_AFTER_BUDGET_SECONDS - honoured_seconds,
-                )
-                honoured_seconds += gap.seconds - interval_seconds
-                # ``sleep_next`` clamps to the residual budget, so a 120s
-                # honoured wait against a 50s remaining budget does not block
-                # the full 120s before the timeout is re-checked — and it
-                # reports back the gap actually taken, for the log below.
-                sleep_for = attempt.sleep_next(gap.seconds)
-                logger.warning(
-                    "native-status transient error (streak %d/%d): %s — sleeping %ds%s and retrying",
-                    transient_streak,
-                    max_transient_failures,
-                    e,
-                    sleep_for,
-                    gap.origin_note,
-                    exc_info=True,
-                )
-                continue
-            transient_streak = 0
-            last_result = result
-            last_elapsed = elapsed
-            # Stall guard: a node has "started" once it leaves the not-started
-            # set. Tracked as a latch so a node that starts and finishes between
-            # polls still counts.
-            if any(not n.status.is_not_started for n in result.nodes):
-                any_node_started = True
-            summary = result.fingerprint
-            run_glyph = RUN_GLYPHS.get(result.status.value, "•")
-            # Any change in the node-glyph summary means at least one node
-            # changed state = forward progress; reset the watchdog clock.
-            if summary != last_summary:
-                last_progress_elapsed = elapsed
-            # Log on every status change. Also emit a heartbeat every
-            # ``_HEARTBEAT_SECONDS`` even when the status hasn't moved,
-            # so long-running stages (lineage takes 2-5 min) don't look
-            # silent in CI logs. Without the heartbeat the operator
-            # can't distinguish "still polling" from "harness wedged".
-            should_log = (
-                summary != last_summary
-                or (elapsed - last_log_elapsed) >= _HEARTBEAT_SECONDS
-            )
-            if should_log:
-                # conformance: ignore[L006] throttled to status-changes plus a heartbeat every _HEARTBEAT_SECONDS (see comment above), not per-iteration; demoting to DEBUG would hide long-running-stage progress in CI
-                logger.info(
-                    "%s AE run [%3ds] %s — %s",
-                    run_glyph,
-                    int(elapsed),
-                    result.status.value,
-                    summary,
-                )
-                last_summary = summary
-                last_log_elapsed = elapsed
-            if result.status.is_terminal:
-                return result
-            # Fail fast when nothing has started within the grace window. Which
-            # system is at fault depends on the top-level status: a run still
-            # Pending was never dispatched by AE, so the app's queue cannot be
-            # the cause; a live parent means AE dispatched and the connector's
-            # own node is the one nothing picked up.
-            if (
-                # only a positive grace arms the guard; None or any value <= 0
-                # disables it (a negative would otherwise fire on the first poll)
-                stall_grace_seconds is not None
-                and stall_grace_seconds > 0
-                and not any_node_started
-                and elapsed >= stall_grace_seconds
-            ):
-                if result.status is DAGRunStatus.PENDING:
-                    raise AutomationEngineNotDispatchingError(
-                        message=(
-                            f"AE run {run_id} was still Pending after "
-                            f"{stall_grace_seconds}s, so it was never dispatched and "
-                            "no DAG node could start. Nothing was offered to the "
-                            "app's task queue, so the app's worker and agent name "
-                            "are not implicated — check the tenant's automation "
-                            "engine (contention on a shared e2e tenant, or an AE "
-                            "worker not processing new runs)."
-                        ),
-                    )
-                queue_hint = (
-                    f" task queue '{stall_task_queue}'"
-                    if stall_task_queue
-                    else " the extract task queue"
-                )
-                raise NoWorkerOnTaskQueueError(
-                    message=(
-                        f"No DAG node started within {stall_grace_seconds}s for run "
-                        f"{run_id} (top-level status={result.status.value}), so AE "
-                        f"dispatched but nothing picked the node up. This almost "
-                        f"always means no worker is polling{queue_hint}. "
-                        "Verify the test's agent_spec().agent_name resolves to the "
-                        "queue the deployed worker polls "
-                        "(atlan-{ATLAN_APPLICATION_NAME}-{ATLAN_DEPLOYMENT_NAME}); a "
-                        "common cause is a second e2e test class using a different "
-                        "agent_name than the single worker the CI job started."
-                    ),
-                )
-            # Progress watchdog: a node started but the DAG hasn't changed
-            # state for the whole window -> wedged. Fail fast with the last
-            # node states instead of polling the full timeout (see docstring).
-            if (
-                progress_stall_seconds is not None
-                and progress_stall_seconds > 0
-                and any_node_started
-                and (elapsed - last_progress_elapsed) >= progress_stall_seconds
-            ):
-                # Stamp the stall onto the observation and attach it, rather
-                # than rendering a ``name=status`` list here: naming the task
-                # queue and the child workflow needs the seed DAG's routing,
-                # which only the harness holds. One renderer, two entry points.
-                raise DAGProgressStalledError(
-                    message=(
-                        f"No DAG node changed state for {progress_stall_seconds}s for "
-                        f"run {run_id} (top-level status={result.status.value}). A node "
-                        "started but is not progressing — most often wedged on a "
-                        "slow/failing step (e.g. extract stuck on an object-store "
-                        "upload). Failing fast instead of polling the full "
-                        f"{timeout_seconds}s. Last-seen node states are attached as "
-                        "``result``."
-                    ),
-                    result=replace(
-                        result,
-                        progress_stalled_after_seconds=float(progress_stall_seconds),
-                        seconds_since_last_progress=max(
-                            0.0, elapsed - last_progress_elapsed
-                        ),
-                    ),
-                )
-        # Timeout: return the last observation so callers can include
-        # node-level state in the failure message rather than just
-        # "timed out after Xs". Stamp the ceiling onto it: returning the
-        # observation bare made every caller read the last-seen node states as
-        # a verdict, so a node that was never dispatched surfaced as a node
-        # failure with ``error=None``.
-        if last_result is not None:
-            return replace(
-                last_result,
-                timed_out_after_seconds=float(timeout_seconds),
-                seconds_since_last_progress=max(
-                    0.0, last_elapsed - last_progress_elapsed
+        )
+        return _dag_run_verdict(
+            outcome,
+            run_id=run_id,
+            progress=progress,
+            stall_grace_seconds=stall_grace_seconds,
+            stall_task_queue=stall_task_queue,
+            progress_stall_seconds=progress_stall_seconds,
+            timeout_seconds=timeout_seconds,
+            max_transient_failures=max_transient_failures,
+        )
+
+
+def _dag_run_verdict(
+    outcome: Outcome[DAGRunResult],
+    *,
+    run_id: str,
+    progress: _DAGProgress,
+    stall_grace_seconds: int | None,
+    stall_task_queue: str,
+    progress_stall_seconds: int | None,
+    timeout_seconds: int,
+    max_transient_failures: int,
+) -> DAGRunResult:
+    """Turn a generic wait verdict into the AE answer ``poll_native_status`` owes.
+
+    Deliberately **not**
+    :func:`~application_sdk.testing.harness.outcome.assert_settled`. That adapter
+    raises the generic leaves, and the four AE leaves this raises instead exist
+    for their remediation advice: ``NoWorkerOnTaskQueueError`` names the task
+    queue to check and the ``agent_spec()`` mismatch that usually causes it,
+    which a ``WaitNeverStartedError`` carrying a label cannot. Losing that would
+    be the behaviour change FND-227 declined to make inside a move.
+
+    Two verdicts are not raises at all, and that is the other reason this
+    function exists:
+
+    * :class:`~application_sdk.testing.harness.outcome.Expired` *returns* the
+      last observation, stamped, because a caller needs the node breakdown to
+      say which node was where when the harness stopped watching.
+    * :class:`~application_sdk.testing.harness.outcome.Indeterminate` splits in
+      two. A streak that gave up re-raises the origin's own error, so the
+      operator sees AE's message rather than a wrapper around it. A budget that
+      expired having never read anything raises
+      :class:`~application_sdk.testing.harness.automation_engine._errors.AtlanApiTimeoutError`,
+      because there is no observation to stamp and returning one would mean
+      inventing it. The two are told apart by the streak length: the wait only
+      gives up at ``max_transient_failures``, so any shorter streak is the
+      deadline having ended the loop.
+
+    Args:
+        outcome: What the wait returned.
+        run_id: The run, for the messages.
+        progress: The ledger that watched the same readings — the only thing
+            that can answer "how long had it been quiet?" on an
+            :class:`~application_sdk.testing.harness.outcome.Expired`.
+        stall_grace_seconds: The configured start grace, quoted in the message.
+        stall_task_queue: The queue to name, or empty for the generic hint.
+        progress_stall_seconds: The configured watchdog window.
+        timeout_seconds: The configured ceiling, stamped onto a timed-out result.
+        max_transient_failures: The streak length that would have given up.
+
+    Returns:
+        The settled observation, or the last one seen at the ceiling.
+
+    Raises:
+        AutomationEngineNotDispatchingError: See :meth:`AEClient.poll_native_status`.
+        NoWorkerOnTaskQueueError: See :meth:`AEClient.poll_native_status`.
+        DAGProgressStalledError: See :meth:`AEClient.poll_native_status`.
+        AtlanApiTimeoutError: See :meth:`AEClient.poll_native_status`.
+    """
+    if isinstance(outcome, Settled):
+        return outcome.value
+
+    if isinstance(outcome, NeverStarted):
+        # Which system is at fault depends on the top-level status: a run still
+        # Pending was never dispatched by AE, so the app's queue cannot be the
+        # cause; a live parent means AE dispatched and the connector's own node
+        # is the one nothing picked up.
+        if outcome.last is not None and outcome.last.status is DAGRunStatus.PENDING:
+            raise AutomationEngineNotDispatchingError(
+                message=(
+                    f"AE run {run_id} was still Pending after "
+                    f"{stall_grace_seconds}s, so it was never dispatched and "
+                    "no DAG node could start. Nothing was offered to the "
+                    "app's task queue, so the app's worker and agent name "
+                    "are not implicated — check the tenant's automation "
+                    "engine (contention on a shared e2e tenant, or an AE "
+                    "worker not processing new runs)."
                 ),
             )
-        raise AtlanApiTimeoutError(
-            message=f"native-status timed out after {timeout_seconds}s with no response",
-            timeout_seconds=float(timeout_seconds),
+        queue_hint = (
+            f" task queue '{stall_task_queue}'"
+            if stall_task_queue
+            else " the extract task queue"
         )
+        status = outcome.last.status.value if outcome.last is not None else "unknown"
+        raise NoWorkerOnTaskQueueError(
+            message=(
+                f"No DAG node started within {stall_grace_seconds}s for run "
+                f"{run_id} (top-level status={status}), so AE "
+                f"dispatched but nothing picked the node up. This almost "
+                f"always means no worker is polling{queue_hint}. "
+                "Verify the test's agent_spec().agent_name resolves to the "
+                "queue the deployed worker polls "
+                "(atlan-{ATLAN_APPLICATION_NAME}-{ATLAN_DEPLOYMENT_NAME}); a "
+                "common cause is a second e2e test class using a different "
+                "agent_name than the single worker the CI job started."
+            ),
+        )
+
+    if isinstance(outcome, Stalled) and outcome.last is not None:
+        # The configured window, falling back to the *observed* quiet gap rather
+        # than to zero. Unreachable today — ``_armed`` leaves
+        # ``budget.stall_timeout`` None for a non-positive window, so
+        # ``poll_until`` cannot return Stalled — but a fallback of 0 would stamp
+        # "the watchdog window was 0 seconds" onto a diagnostic, which is a lie
+        # that sends the reader hunting a phantom. The observed gap is true
+        # whatever the configuration was.
+        window = progress_stall_seconds or outcome.stall_window.total_seconds()
+        # Stamp the stall onto the observation and attach it, rather than
+        # rendering a ``name=status`` list here: naming the task queue and the
+        # child workflow needs the seed DAG's routing, which only the harness
+        # holds. One renderer, two entry points.
+        raise DAGProgressStalledError(
+            message=(
+                f"No DAG node changed state for {progress_stall_seconds}s for "
+                f"run {run_id} (top-level status={outcome.last.status.value}). A "
+                "node started but is not progressing — most often wedged on a "
+                "slow/failing step (e.g. extract stuck on an object-store "
+                "upload). Failing fast instead of polling the full "
+                f"{timeout_seconds}s. Last-seen node states are attached as "
+                "``result``."
+            ),
+            result=replace(
+                outcome.last,
+                progress_stalled_after_seconds=float(window),
+                seconds_since_last_progress=outcome.stall_window.total_seconds(),
+            ),
+        )
+
+    if isinstance(outcome, Expired) and outcome.last is not None:
+        # Returning the observation bare made every caller read the last-seen
+        # node states as a verdict, so a node that was never dispatched
+        # surfaced as a node failure with ``error=None``. Stamp the ceiling.
+        return replace(
+            outcome.last,
+            timed_out_after_seconds=float(timeout_seconds),
+            seconds_since_last_progress=progress.quiet_seconds,
+        )
+
+    if isinstance(outcome, Indeterminate) and outcome.transient_failures >= max(
+        1, max_transient_failures
+    ):
+        # The streak gave up. ``poll_until`` already logged the streak length at
+        # WARNING; re-raising the origin's own error is what makes the run red
+        # and puts AE's message in front of the operator.
+        raise outcome.cause
+
+    raise AtlanApiTimeoutError(
+        message=f"native-status timed out after {timeout_seconds}s with no response",
+        timeout_seconds=float(timeout_seconds),
+    )

--- a/application_sdk/testing/harness/automation_engine/client.py
+++ b/application_sdk/testing/harness/automation_engine/client.py
@@ -173,6 +173,17 @@ _RECONCILE_PAGE_SIZE = 20
 # as it did before. The machinery below is complete and tested either way.
 _RESUBMIT_WHEN_AE_REPORTS_NO_RUN = False
 
+# Waiting for AE to index a freshly created workflow slug. Replaces an
+# unconditional ``time.sleep(3)`` both full-DAG harnesses ran here (FND-240).
+#
+# The timeout is generous relative to the 3s it replaces because it costs nothing
+# when the answer is already yes: the first probe is at t=0, so an
+# already-indexed slug pays one HTTP call and no sleep at all, where the fixed
+# sleep charged every run three seconds. And unlike the sleep, the budget is what
+# a slower-than-usual index actually gets to use.
+_SLUG_INDEX_TIMEOUT_SECONDS = 30
+_SLUG_INDEX_INTERVAL_SECONDS = 1
+
 # ``_HEARTBEAT_SECONDS`` (imported from ``_poll``) is the cadence for "still
 # polling" heartbeat log lines in ``poll_native_status`` — lineage stages take
 # 2-5 min on small datasets and the status string doesn't change during that
@@ -708,6 +719,141 @@ class AEClient:
             target=f"POST /automation/api/v1/workflows HTTP {status}",
             retry_after_seconds=requested_retry_after(body),
         )
+
+    async def slug_resolves(self, slug: str) -> bool | None:
+        """Does AE resolve *slug* yet? ``None`` when the read did not settle it.
+
+        ``GET /automation/api/v1/workflows/<slug>/versions?page=0&page_size=1``.
+        The route family is the one :meth:`get_published_version` already reads,
+        so it exists and this client already authenticates against it; dropping
+        the ``is_published`` filter is what makes it answerable for a workflow
+        that has no published version yet, which is every workflow at this point
+        in a run.
+
+        The claim is narrow on purpose: a 2xx means AE resolved the slug, and a
+        404 is the same "Workflow with slug 'X' not found" that
+        :meth:`create_version` retries on. Nothing else is interpreted —
+        a 5xx, a transport failure or a 403 all answer ``None``, because none of
+        them says anything about whether the slug is indexed and treating an
+        overloaded AE as "not indexed" would poll out a budget over a fact it
+        never learned.
+
+        Absorbs every failure :meth:`_request` classifies — a transport error,
+        a timeout, any status — and answers ``None`` for it. It does **not**
+        absorb what ``_request`` itself lets through, and that set is not empty:
+        ``httpx.TooManyRedirects`` and ``httpx.DecodingError`` are
+        ``RequestError`` but *not* ``TransportError``, so ``_request``'s
+        ``except (httpx.TransportError, OSError)`` misses them, and the
+        transport is built with ``follow_redirects=True`` — which makes a
+        redirect loop on a misconfigured tenant proxy a real way for this to
+        raise. Stated rather than written as "never raises": the two sibling
+        reads on this route family say that, inherit the same hole, and a caller
+        who believes it writes no ``except`` at all. Widening ``_request``'s
+        narrowing is the actual fix and belongs with whoever owns it, not in a
+        bounded-wait change.
+
+        Returns:
+            ``True`` if AE resolved the slug, ``False`` if it answered that it
+            does not exist, ``None`` if the read settled nothing.
+        """
+        path = (
+            f"/automation/api/v1/workflows/{quote(slug, safe='')}"
+            "/versions?page=0&page_size=1"
+        )
+        try:
+            status, body = await self._request("GET", path)
+        except AppError:
+            logger.warning(
+                "slug-resolution read for %s did not get through; whether AE "
+                "has indexed it stays unknown",
+                slug,
+                exc_info=True,
+            )
+            return None
+        if status < 300:
+            return True
+        if status == 404:
+            return False
+        logger.warning(
+            "slug-resolution read for %s returned HTTP %d, which says nothing "
+            "about indexing\nresponse=%r",
+            slug,
+            status,
+            body,
+        )
+        return None
+
+    async def wait_for_slug(
+        self,
+        slug: str,
+        *,
+        timeout_seconds: int = _SLUG_INDEX_TIMEOUT_SECONDS,
+        interval_seconds: int = _SLUG_INDEX_INTERVAL_SECONDS,
+    ) -> bool:
+        """Wait until AE resolves *slug*, so the version create is not a guess.
+
+        **Replaces an unconditional ``time.sleep(3)``** (FND-240), which both
+        full-DAG harnesses ran between :meth:`create_workflow` and
+        :meth:`create_version` because AE has a brief indexing window before a
+        fresh slug is queryable. A fixed sleep is wrong in both directions: it
+        charges every run three seconds it usually does not need, and it is no
+        help at all on the run where indexing takes four.
+
+        **Advisory, never a gate.** :meth:`create_version` retries on 404 for
+        exactly this reason, and that retry is what actually makes the sequence
+        safe. So this returns a bool for the log rather than raising, and a wait
+        that ends unresolved is *not* a failure — it hands over to the same
+        retry that carried the whole sequence before this method existed. The
+        rule that keeps it honest: a readiness read that replaces a guess must
+        not be stricter than the guess it replaced.
+
+        Args:
+            slug: The workflow slug :meth:`create_workflow` returned.
+            timeout_seconds: Total budget. Generous relative to the 3s it
+                replaces, because it costs nothing when the answer is already
+                yes — which is the usual case, and the first probe is at t=0.
+            interval_seconds: Gap between probes.
+
+        Returns:
+            ``True`` once AE resolved the slug. ``False`` if the budget ran out
+            with AE still answering 404, or if no read ever settled it — two
+            different things, distinguished in the log rather than in the return
+            type, because the caller does the same thing either way.
+        """
+
+        async def probe() -> bool | None:
+            return await self.slug_resolves(slug)
+
+        outcome = await poll_until(
+            probe,
+            # ``None`` is not ``False``: an unreadable probe must not end the
+            # wait as though AE had answered.
+            settled=lambda resolved: resolved is True,
+            budget=Budget(
+                timeout=timedelta(seconds=timeout_seconds),
+                poll_interval=timedelta(seconds=interval_seconds),
+                heartbeat=None,
+            ),
+            label=f"AE resolving workflow slug '{slug}'",
+        )
+        if isinstance(outcome, Settled):
+            logger.info(
+                "AE resolved slug %s after %d probe(s) in %.1fs",
+                slug,
+                outcome.attempts,
+                outcome.elapsed.total_seconds(),
+            )
+            return True
+        logger.warning(
+            "AE had not resolved slug %s after %d probe(s) in %.0fs (last read: "
+            "%r) — continuing to the version create, whose own 404 retry is what "
+            "makes this sequence safe either way",
+            slug,
+            outcome.attempts,
+            outcome.elapsed.total_seconds(),
+            getattr(outcome, "last", None),
+        )
+        return False
 
     async def create_version(
         self,

--- a/application_sdk/testing/harness/budgets.py
+++ b/application_sdk/testing/harness/budgets.py
@@ -119,9 +119,18 @@ class Budget:
             ``poll_native_status`` has today, pinned by
             ``test_gives_up_at_max_transient_failures``, and preserved here
             rather than corrected because a drift would change every connector's
-            tolerance the moment child D rewires the loop. ``0`` and ``1`` are
-            therefore the same instruction: end on the first error. Normalising
-            that degenerate pair is listed on FND-240.
+            tolerance the moment child D rewired the loop — which it has now
+            done, on this budget, with the same boundary.
+
+            ``0`` and ``1`` are therefore the same instruction: end on the first
+            error. FND-240 normalised that degenerate pair by *pinning* it rather
+            than by making them differ — ``0`` reads naturally as "no tolerance"
+            and already means exactly that, and the alternative (shifting the
+            boundary so ``N`` absorbs ``N``) would change every connector's
+            tolerance to buy a tidier arithmetic. Every reader of the field
+            handles the pair the same way, and
+            ``test_the_degenerate_pair_both_give_up_on_the_first_error`` is what
+            stops one of them quietly disagreeing.
 
             A streak, not a total: any successful probe resets it, so a wait
             spanning a twenty-minute VPN tunnel is not bounded by the *sum* of

--- a/application_sdk/testing/harness/waiting.py
+++ b/application_sdk/testing/harness/waiting.py
@@ -19,21 +19,35 @@ second deadline implementation; that private module moved here from
 ``testing/e2e/`` as part of child C, because the harness cannot import from the
 package child H is about to re-express over it.
 
-**Nothing in ``testing/e2e`` calls this yet.** Re-expressing its twelve bounded
-loops is child D (FND-240), and the client those loops live on is synchronous
-until child F converts it — routing a sync method through an async primitive on
-the loop bridge in the meantime would be a workaround built to be deleted. What
-stands in for that proof today is
-``tests/unit/testing/harness/test_waiting_equivalence.py``: it drives
-:func:`poll_until` with the AE-shaped probe, predicates, fingerprint and
-retry-after classifier over the *same* scripted readings ``poll_native_status``
-sees, and asserts both produce the same verdict, the same attempt count and the
-same sleep sequence. A differential test against the live loop is stronger
-evidence than "the 58 existing tests still pass", and it costs the connector
-path no diff at all.
+**Child D (FND-240) brought the bounded loops across**, one at a time. Which
+primitive each one reaches for is not uniform, and the split is not arbitrary:
 
-:func:`hold_stable` is **new**. All twelve bounded loops in ``testing/e2e/``
-today are "wait until"; not one is "assert stays". The negative assertion is
+* :func:`poll_until` where the probe is already ``async`` and there is a real
+  verdict to grade — ``poll_native_status`` (the loop these guards were
+  extracted from in the first place), ``atlas.poll_for_connection``,
+  ``workflows.wait_for_workflow``, ``AEClient.wait_for_slug``.
+* :func:`~application_sdk.testing.harness._poll.until_deadline` — the deadline
+  arithmetic alone — where the probe is *synchronous* and supplied by a
+  connector suite or a local test client. Reaching an async primitive from
+  there would mean blocking the bridge's loop inside someone else's write, or
+  offloading it to a thread: workarounds built to be deleted when child H moves
+  the sync boundary up to ``BaseE2ETest``'s public methods. Four loops in
+  ``testing/e2e/base.py`` and one in ``testing/integration/runner.py`` take that
+  shape.
+
+What is uniform is that no loop in the harness owns a deadline any more, and
+there is one clock rather than three.
+
+``tests/unit/testing/harness/test_waiting_equivalence.py`` is the evidence that
+the biggest of those conversions preserved behaviour. It was written *before* it,
+as a differential against the hand-rolled loop; the numbers that comparison
+produced — verdict, probe count and the exact sleep sequence for fifteen scripted
+runs — are now frozen there as a golden table, which is a claim a
+self-comparison could not make once both sides became one loop.
+
+:func:`hold_stable` is **new**, and still has no caller in this repo. Every
+bounded loop the harness has — the twelve child D brought across included — is
+"wait until"; not one is "assert stays". The negative assertion is
 what the runtime scaling scenarios turn on — "a busy pod is never scaled away",
 "it must not scale down while a long activity is still running", and the whole
 steady-state group — because most scaling bugs are wrong *actions* rather than

--- a/application_sdk/testing/integration/runner.py
+++ b/application_sdk/testing/integration/runner.py
@@ -40,6 +40,7 @@ import pytest
 import requests as http_requests
 
 from application_sdk.observability.logger_adaptor import get_logger
+from application_sdk.testing.harness._poll import until_deadline
 from application_sdk.validation import validate_transformed_dir
 
 from .client import IntegrationTestClient
@@ -1007,6 +1008,21 @@ class BaseIntegrationTest:
     ) -> str:
         """Poll the workflow status until completion or timeout.
 
+        The loop is
+        :func:`~application_sdk.testing.harness._poll.until_deadline` (FND-240),
+        which leaves the harness with **one** deadline idiom rather than three.
+        This was the last ``time.time()`` one, and moving it to the monotonic
+        clock is the point rather than a side effect: a wall-clock budget is
+        wrong in both directions — an NTP step forward expires a wait that had
+        time left, and a step backward extends one that should have ended.
+
+        The unbounded transient tolerance is deliberately **kept**: an
+        unsuccessful status response warns and polls on, for the whole budget,
+        exactly as before. FND-240 notes the missing cap; picking a number for it
+        needs evidence about how often a *local* Temporal answers unsuccessfully,
+        which this change has none of, and a cap guessed here would turn a slow
+        local server into a failed test.
+
         Args:
             workflow_id: The workflow ID.
             run_id: The run ID.
@@ -1019,9 +1035,11 @@ class BaseIntegrationTest:
         Raises:
             TimeoutError: If the workflow does not complete within the timeout.
         """
-        start_time = time.time()
-
-        while True:
+        for attempt in until_deadline(
+            timeout,
+            interval,
+            label=f"workflow {workflow_id}/{run_id}",
+        ):
             status_response = self.client.get_workflow_status(workflow_id, run_id)
 
             if not status_response.get("success", False):
@@ -1034,14 +1052,17 @@ class BaseIntegrationTest:
                 if current_status != "RUNNING":
                     return current_status
 
-            elapsed = time.time() - start_time
-            if elapsed > timeout:
+            if attempt.is_last:
                 raise TimeoutError(
                     f"Workflow {workflow_id}/{run_id} did not complete "
-                    f"within {timeout}s (elapsed: {elapsed:.0f}s)"
+                    f"within {timeout}s (elapsed: {attempt.elapsed:.0f}s, "
+                    f"{attempt.number} attempt(s))"
                 )
 
-            time.sleep(interval)
+        raise AssertionError(  # pragma: no cover — the is_last branch fires first
+            f"poll loop for workflow {workflow_id}/{run_id} ended without a "
+            "final attempt"
+        )
 
     def _get_nested_value(self, data: dict[str, Any], path: str) -> Any:
         """Get a value from a nested dictionary using dot notation.

--- a/tests/unit/testing/e2e/test_base_e2e.py
+++ b/tests/unit/testing/e2e/test_base_e2e.py
@@ -26,6 +26,7 @@ from application_sdk.testing.e2e._errors import (
     MissingHarnessClassAttrError,
     MissingHarnessEnvError,
     ProgressWatchdogUnreachableError,
+    WorkerNotHealthyError,
 )
 from application_sdk.testing.e2e.base import (
     _PURGE_BATCH_SIZE,
@@ -579,6 +580,55 @@ class TestWorkerUpTier:
         )
         with pytest.raises(AssertionError, match="did not become healthy"):
             harness.assert_worker_up()
+
+    def test_the_worker_failure_is_typed_and_still_an_assertion_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Both halves of the FND-240 change, in one raise.
+
+        The leaf is typed — ``last_error`` is a field a report can read rather
+        than a fragment of a sentence, and a refused connection and a 503 point
+        at different halves of a deployment. And it is still an
+        ``AssertionError``, because this method's docstring promised one since it
+        existed and out-of-repo connector suites are entitled to have written
+        ``except AssertionError`` against it. Typing the leaf is worth doing;
+        taking that clause away from the fleet to do it is not.
+        """
+        harness = self._harness()
+
+        def _unavailable(url: str, timeout: int = 10) -> _FakeHealthResponse:
+            return _FakeHealthResponse(503)
+
+        monkeypatch.setattr(
+            "application_sdk.testing.e2e.base.urllib.request.urlopen", _unavailable
+        )
+        with pytest.raises(WorkerNotHealthyError) as excinfo:
+            harness.assert_worker_up()
+
+        error = excinfo.value
+        assert isinstance(error, AssertionError)
+        assert error.code == "PRECONDITION_WORKER_NOT_HEALTHY"
+        assert error.url == harness.worker_health_url
+        assert error.last_error == "HTTP 503"
+        assert error.attempts is not None and error.attempts >= 1
+
+    def test_a_refused_connection_and_a_5xx_are_told_apart(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The reason ``last_error`` is a field. "Nothing is listening" and "it is
+        listening and unhappy" send an operator to different places."""
+        harness = self._harness()
+
+        def _refused(url: str, timeout: int = 10) -> _FakeHealthResponse:
+            raise urllib.error.URLError("connection refused")
+
+        monkeypatch.setattr(
+            "application_sdk.testing.e2e.base.urllib.request.urlopen", _refused
+        )
+        with pytest.raises(WorkerNotHealthyError) as excinfo:
+            harness.assert_worker_up()
+
+        assert "connection refused" in (excinfo.value.last_error or "")
 
 
 class TestStallGuardDirectModeWarning:

--- a/tests/unit/testing/e2e/test_non_publishing_entrypoint.py
+++ b/tests/unit/testing/e2e/test_non_publishing_entrypoint.py
@@ -39,6 +39,7 @@ from application_sdk.testing.e2e.client import (
     DAGRunResult,
     DAGRunStatus,
 )
+from application_sdk.testing.harness._poll import fake_clock
 
 
 def _node(name: str, status: DAGNodeStatus) -> DAGNodeResult:
@@ -419,6 +420,32 @@ class TestSeedConnection:
 
         with pytest.raises(PermissionError):
             harness.seed_connection(probe=_probe)
+
+    def test_the_probe_retry_stops_inside_its_stated_budget(
+        self, fake_pyatlan: MagicMock
+    ) -> None:
+        """The off-by-one FND-240 removed along with the hand-rolled deadline.
+
+        The old loop checked ``time.monotonic() >= deadline`` *after* the probe,
+        so a 30s budget at a 10s interval probed at 0, 10, 20 **and 30** — it
+        slept a whole interval past its own timeout to find out it had expired.
+        ``attempt.is_last`` moves that decision before the sleep: three probes,
+        20s of sleeping, and the failure raised at 20s rather than at 30s.
+        """
+        harness = _seeding_harness()
+        harness.atlas_poll_timeout_seconds = 30  # type: ignore[misc]
+        harness.atlas_poll_interval_seconds = 10  # type: ignore[misc]
+        attempts: list[int] = []
+
+        def _probe() -> None:
+            attempts.append(1)
+            raise PermissionError("403 forever")
+
+        with fake_clock() as clock, pytest.raises(PermissionError):
+            harness.seed_connection(probe=_probe)
+
+        assert len(attempts) == 3
+        assert clock.slept == [10, 10]
 
     @pytest.mark.parametrize("exc_type", [TypeError, ValueError])
     def test_a_non_transient_probe_error_fails_fast(

--- a/tests/unit/testing/e2e/test_workflows.py
+++ b/tests/unit/testing/e2e/test_workflows.py
@@ -1,10 +1,16 @@
 """Unit tests for the handler-service workflow helpers.
 
-This module had no test file before FND-241. The test that earns its keep is
-:func:`test_one_tunnel_serves_the_whole_wait`: the poll opened and tore down a
-``kubectl port-forward`` on *every* probe, and nothing pinned that it no longer
-does — a regression there is invisible in a unit suite and expensive in a live
-run.
+This module had no test file before FND-241. Two tests earn their keep:
+
+* :func:`test_one_tunnel_serves_the_whole_wait` — the poll opened and tore down a
+  ``kubectl port-forward`` on *every* probe, and nothing pinned that it no longer
+  does. A regression there is invisible in a unit suite and expensive in a live
+  run, and it is an easy one to reintroduce: the probe is the loop body, so a
+  context manager moved inside it is a tunnel per iteration.
+* :func:`test_a_handler_blip_is_polled_through` — the wait had no transient-error
+  policy at all until FND-240, so one 502 from a handler pod mid-restart ended a
+  five-minute wait on its first poll and ended it as a raw ``httpx`` error,
+  reading as a test failure rather than as an unreadable dependency.
 """
 
 from __future__ import annotations
@@ -17,6 +23,7 @@ import httpx
 import pytest
 
 from application_sdk.testing.e2e.workflows import run_workflow, wait_for_workflow
+from application_sdk.testing.harness._errors import WaitIndeterminateError
 
 
 def _response(payload: dict[str, Any], status: int = 200) -> MagicMock:
@@ -28,9 +35,16 @@ def _response(payload: dict[str, Any], status: int = 200) -> MagicMock:
 
 
 class _RecordingSession:
-    """A port-forward session that answers a scripted sequence of statuses."""
+    """A port-forward session answering a scripted sequence, repeating the last.
 
-    def __init__(self, *responses: MagicMock) -> None:
+    A scripted item may be an ``Exception``, in which case ``request`` raises it.
+    That matters because a dropped tunnel surfaces *from the request call*, not
+    from the response object — a fake that can only fail at ``response.json()``
+    forces a test to inject the failure one layer too late and then describe it
+    as something it is not.
+    """
+
+    def __init__(self, *responses: MagicMock | Exception) -> None:
         self._responses = list(responses)
         self.calls: list[tuple[str, str]] = []
 
@@ -38,7 +52,10 @@ class _RecordingSession:
         self, method: str, path: str, *, body: Any = None, headers: Any = None
     ) -> MagicMock:
         self.calls.append((method, path))
-        return self._responses[min(len(self.calls) - 1, len(self._responses) - 1)]
+        item = self._responses[min(len(self.calls) - 1, len(self._responses) - 1)]
+        if isinstance(item, Exception):
+            raise item
+        return item
 
 
 @asynccontextmanager
@@ -143,14 +160,79 @@ async def test_every_terminal_state_ends_the_wait(status: str):
     assert len(session.calls) == 1
 
 
-@pytest.mark.asyncio
-async def test_a_status_read_that_fails_is_not_swallowed():
-    """A 500 from the handler ends the wait; it is not polled through."""
-    response = _response({}, status=500)
+def _failing(status: int) -> MagicMock:
+    """A handler response whose ``raise_for_status`` raises, as ``httpx`` does.
+
+    The status is set on the *error's* response as well as the outer mock: the
+    transient classifier reads ``error.response.status_code``, and a bare
+    ``MagicMock`` there compares truthy against every threshold — which would
+    make this test pass whatever the classifier decided.
+    """
+    response = _response({}, status=status)
+    inner = MagicMock(spec=httpx.Response)
+    inner.status_code = status
     response.raise_for_status.side_effect = httpx.HTTPStatusError(
-        "boom", request=MagicMock(), response=MagicMock()
+        "boom", request=MagicMock(), response=inner
     )
-    session = _RecordingSession(response)
+    return response
+
+
+@pytest.mark.asyncio
+async def test_a_handler_blip_is_polled_through():
+    """The gap FND-240 closes: a 502 from a pod mid-restart used to end the wait
+    on its first poll, because ``raise_for_status()`` sat bare in the loop."""
+    session = _RecordingSession(
+        _failing(502),
+        _failing(502),
+        _response({"status": "COMPLETED", "workflow_id": "wf-42"}),
+    )
+    opens: list[int] = []
+
+    with patch(
+        "application_sdk.testing.e2e.workflows.port_forward",
+        lambda *args, **kwargs: _one_session(session, opens),
+    ):
+        result = await wait_for_workflow(
+            "conn", "handler", 8000, "wf-42", timeout=5.0, poll_interval=0.0
+        )
+
+    assert result["status"] == "COMPLETED"
+    assert len(session.calls) == 3
+
+
+@pytest.mark.asyncio
+async def test_an_unreadable_handler_is_indeterminate_not_a_timeout():
+    """A pod that never answers is not evidence about the workflow.
+
+    Reporting it as a timeout would say the workflow did not finish in time,
+    which is a claim about the thing under test that a wait which never read it
+    is not entitled to make.
+    """
+    session = _RecordingSession(_failing(503))
+    opens: list[int] = []
+
+    with (
+        patch(
+            "application_sdk.testing.e2e.workflows.port_forward",
+            lambda *args, **kwargs: _one_session(session, opens),
+        ),
+        pytest.raises(WaitIndeterminateError, match="workflow wf-42"),
+    ):
+        await wait_for_workflow(
+            "conn", "handler", 8000, "wf-42", timeout=60.0, poll_interval=0.0
+        )
+
+    # The streak, not the budget: five consecutive unreadable polls, well inside
+    # a 60-second window that would otherwise have allowed hundreds.
+    assert len(session.calls) == 5
+
+
+@pytest.mark.asyncio
+async def test_a_4xx_ends_the_wait_rather_than_being_polled_through():
+    """A 404 on a workflow id is a wrong id, and no amount of waiting turns it
+    into the right one. Absorbing it would spend the whole budget on a typo and
+    then report a timeout."""
+    session = _RecordingSession(_failing(404))
     opens: list[int] = []
 
     with (
@@ -161,5 +243,87 @@ async def test_a_status_read_that_fails_is_not_swallowed():
         pytest.raises(httpx.HTTPStatusError),
     ):
         await wait_for_workflow(
+            "conn", "handler", 8000, "wf-42", timeout=60.0, poll_interval=0.0
+        )
+
+    assert len(session.calls) == 1, "a 4xx must not be retried"
+
+
+@pytest.mark.asyncio
+async def test_a_transport_error_from_the_request_is_absorbed():
+    """The shape a dropped tunnel actually takes: ``session.request`` raises.
+
+    This replaces a test named ``test_a_dropped_tunnel_is_a_blip_not_an_answer``
+    whose body injected ``httpx.ReadError`` from ``response.json()`` — i.e. after
+    the request had already succeeded — and whose docstring claimed
+    ``PortForward.request`` rebuilds the tunnel and "the next poll gets a fresh
+    tunnel". Neither was observable here: the fake session has no rebuild logic,
+    and ``opens`` was never asserted. The name and the docstring described a
+    mechanism the body never reached. Rebuild-on-transport-error is
+    ``PortForward``'s own behaviour and is covered in
+    ``tests/unit/testing/harness/cluster/test_portforward.py``; what this file can
+    honestly assert is that the wait absorbs the error and carries on.
+    """
+    session = _RecordingSession(
+        httpx.ReadError("tunnel died"),
+        _response({"status": "COMPLETED", "workflow_id": "wf-42"}),
+    )
+    opens: list[int] = []
+
+    with patch(
+        "application_sdk.testing.e2e.workflows.port_forward",
+        lambda *args, **kwargs: _one_session(session, opens),
+    ):
+        result = await wait_for_workflow(
             "conn", "handler", 8000, "wf-42", timeout=5.0, poll_interval=0.0
+        )
+
+    assert result["status"] == "COMPLETED"
+    assert len(session.calls) == 2, "the failed request must have been retried"
+
+
+@pytest.mark.asyncio
+async def test_a_body_that_fails_to_decode_is_absorbed():
+    """A truncated read surfacing from ``response.json()`` rather than from the
+    request — a real second shape, and now named for what it is."""
+    truncated = MagicMock(spec=httpx.Response)
+    truncated.raise_for_status = MagicMock()
+    truncated.json = MagicMock(side_effect=httpx.ReadError("truncated"))
+    session = _RecordingSession(
+        truncated, _response({"status": "COMPLETED", "workflow_id": "wf-42"})
+    )
+    opens: list[int] = []
+
+    with patch(
+        "application_sdk.testing.e2e.workflows.port_forward",
+        lambda *args, **kwargs: _one_session(session, opens),
+    ):
+        result = await wait_for_workflow(
+            "conn", "handler", 8000, "wf-42", timeout=5.0, poll_interval=0.0
+        )
+
+    assert result["status"] == "COMPLETED"
+    assert len(session.calls) == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("payload", [{}, {"status": None}, {"status": 7}])
+async def test_a_status_field_that_is_not_a_string_keeps_the_wait_alive(
+    payload: dict[str, Any],
+):
+    """The predicate deciding whether to keep waiting must not be the thing that
+    crashes the wait. A missing or non-string ``status`` reads as "not terminal",
+    and the timeout message says ``unknown``."""
+    session = _RecordingSession(_response(payload))
+    opens: list[int] = []
+
+    with (
+        patch(
+            "application_sdk.testing.e2e.workflows.port_forward",
+            lambda *args, **kwargs: _one_session(session, opens),
+        ),
+        pytest.raises(TimeoutError, match="last status=unknown"),
+    ):
+        await wait_for_workflow(
+            "conn", "handler", 8000, "wf-42", timeout=0.05, poll_interval=0.0
         )

--- a/tests/unit/testing/full_dag/test_client.py
+++ b/tests/unit/testing/full_dag/test_client.py
@@ -7,10 +7,12 @@ sync ``AEWorkflowClient`` facade.
 
 from __future__ import annotations
 
+import warnings
 from typing import Any
 
 import pytest
 
+from application_sdk.testing.e2e.client import _FORBIDDEN_ATTEMPTS_REMOVAL_VERSION
 from application_sdk.testing.full_dag._errors import (
     AtlanApiHttpError,
     AtlanApiResponseInvariantError,
@@ -225,3 +227,77 @@ def test_poll_atlas_for_connection_bails_after_not_found_streak(
             )
             is False
         )
+
+
+def test_max_forbidden_attempts_says_it_does_nothing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The vestigial knob now announces itself rather than being ``del``'d unread.
+
+    The poll reads the search index, whose ACL is permissive, so a 403 never
+    surfaces and there is no 403 budget to bound. Deleting the argument unread is
+    the shape that lets a caller keep passing a number and believe it does
+    something; FND-240 makes it say so, with a named removal version so the
+    warning is something to act on.
+    """
+    client, _ = _make_client(monkeypatch, [])
+    monkeypatch.setattr(
+        client, "_atlas", lambda: fake_atlas(lambda _request: FakeSearchResult(count=1))
+    )
+    with fake_clock(), pytest.warns(DeprecationWarning, match="has no effect"):
+        assert (
+            client.poll_atlas_for_connection(
+                "default/mysql/test",
+                interval_seconds=1,
+                timeout_seconds=10,
+                max_forbidden_attempts=5,
+            )
+            is True
+        )
+
+
+def test_omitting_the_vestigial_knob_is_silent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Why the default became ``None`` rather than staying ``5``: with a real
+    default there is no way to tell "the caller asked for this" from "the
+    signature did", and every single call would warn."""
+    client, _ = _make_client(monkeypatch, [])
+    monkeypatch.setattr(
+        client, "_atlas", lambda: fake_atlas(lambda _request: FakeSearchResult(count=1))
+    )
+    with fake_clock(), warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        assert (
+            client.poll_atlas_for_connection(
+                "default/mysql/test", interval_seconds=1, timeout_seconds=10
+            )
+            is True
+        )
+
+
+def test_the_vestigial_knob_names_its_removal_version(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The notice spells "v4.0" literally; this is what stops that drifting.
+
+    Conformance rule B002 reads a deprecation notice as written in the source, so
+    interpolating ``_FORBIDDEN_ATTEMPTS_REMOVAL_VERSION`` would make a compliant
+    deprecation look like one that never named a removal version. Spelling it
+    twice needs one assertion tying them together — the same shape ``AppConfig``'s
+    own removal-version test uses.
+    """
+    client, _ = _make_client(monkeypatch, [])
+    monkeypatch.setattr(
+        client, "_atlas", lambda: fake_atlas(lambda _request: FakeSearchResult(count=1))
+    )
+    with fake_clock(), pytest.warns(DeprecationWarning) as caught:
+        client.poll_atlas_for_connection(
+            "default/mysql/test",
+            interval_seconds=1,
+            timeout_seconds=10,
+            max_forbidden_attempts=5,
+        )
+    message = str(caught[0].message)
+    assert f"removed in v{_FORBIDDEN_ATTEMPTS_REMOVAL_VERSION}" in message
+    assert "use max_not_found_attempts instead" in message

--- a/tests/unit/testing/harness/automation_engine/test_dag_verdict.py
+++ b/tests/unit/testing/harness/automation_engine/test_dag_verdict.py
@@ -1,0 +1,458 @@
+"""The AE shape ``poll_native_status`` hands the primitive, and the verdict back.
+
+``test_waiting_equivalence.py`` pins what the *whole* loop does, script in and
+verdict out, against the numbers the hand-rolled loop produced. That is the
+behaviour-preservation evidence, and it exercises only the states a scripted run
+can reach.
+
+This file covers the seams that survive underneath it: the three ways a caller
+spells "guard off", the classifier's rounding, the progress ledger the ``L006``
+per-poll line moved into, and — the reason the file exists — the branches of
+:func:`_dag_run_verdict` where the verdict carries **no reading**. Those are
+unreachable through the loop today, and that is exactly why they are asserted
+directly: an ``outcome.last`` guard whose ``else`` nothing exercises is a guard
+nobody has checked, and the first thing it would do on the day a verdict does
+arrive empty is raise ``AttributeError`` from inside a diagnostic.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from unittest.mock import patch
+
+import pytest
+
+from application_sdk.errors.base import AppError
+from application_sdk.testing.harness._poll import fake_clock, monotonic
+from application_sdk.testing.harness.automation_engine import client as _client_module
+from application_sdk.testing.harness.automation_engine._errors import (
+    AtlanApiHttpError,
+    AtlanApiTimeoutError,
+    AutomationEngineNotDispatchingError,
+    DAGProgressStalledError,
+    NoWorkerOnTaskQueueError,
+)
+from application_sdk.testing.harness.automation_engine.client import (
+    _absorb_ae_blip,
+    _any_node_started,
+    _armed,
+    _dag_run_verdict,
+    _DAGProgress,
+)
+from application_sdk.testing.harness.automation_engine.wire import (
+    DAGNodeResult,
+    DAGNodeStatus,
+    DAGRunResult,
+    DAGRunStatus,
+)
+from application_sdk.testing.harness.outcome import (
+    Expired,
+    Indeterminate,
+    NeverStarted,
+    Settled,
+    Stalled,
+)
+
+_RUN_ID = "run-1"
+
+
+def _result(
+    run_status: DAGRunStatus = DAGRunStatus.RUNNING,
+    *node_statuses: DAGNodeStatus,
+) -> DAGRunResult:
+    return DAGRunResult(
+        run_id=_RUN_ID,
+        workflow_slug="slug",
+        status=run_status,
+        nodes=[
+            DAGNodeResult(
+                name=f"node{index}",
+                status=status,
+                started_at_ms=None,
+                completed_at_ms=None,
+                error_message=None,
+            )
+            for index, status in enumerate(node_statuses)
+        ],
+    )
+
+
+def _verdict(outcome, **overrides):  # type: ignore[no-untyped-def]
+    """Call ``_dag_run_verdict`` with the AE_RUN-shaped defaults."""
+    kwargs = {
+        "run_id": _RUN_ID,
+        "progress": _DAGProgress(),
+        "stall_grace_seconds": 180,
+        "stall_task_queue": "",
+        "progress_stall_seconds": 300,
+        "timeout_seconds": 600,
+        "max_transient_failures": 5,
+    }
+    kwargs.update(overrides)
+    return _dag_run_verdict(outcome, **kwargs)  # type: ignore[arg-type]
+
+
+class TestArmed:
+    """Three spellings of "off" collapse to the one ``Budget`` uses."""
+
+    @pytest.mark.parametrize("seconds", [None, 0, -1, -300])
+    def test_non_positive_disables_the_guard(self, seconds: int | None) -> None:
+        """A negative is not a short window.
+
+        Left as a duration it would make ``elapsed >= grace`` true on the first
+        poll and fire the guard before anything could have started — which is
+        the whole reason the hand-rolled loop tested ``> 0`` rather than
+        ``is not None``.
+        """
+        assert _armed(seconds) is None
+
+    def test_a_positive_window_becomes_a_timedelta(self) -> None:
+        assert _armed(180) == timedelta(seconds=180)
+
+
+class TestAnyNodeStarted:
+    """The latch is node-level, and that is load-bearing."""
+
+    @pytest.mark.parametrize("status", [DAGNodeStatus.PENDING, DAGNodeStatus.SCHEDULED])
+    def test_the_not_started_set_is_not_a_start(self, status: DAGNodeStatus) -> None:
+        assert not _any_node_started(_result(DAGRunStatus.RUNNING, status))
+
+    def test_a_live_run_over_pending_nodes_has_not_started(self) -> None:
+        """The one case a run-level latch would get wrong.
+
+        The parent AE workflow runs on the always-on automation-engine queue, so
+        the top level flips to ``Running`` while the connector's own node sits
+        unpolled. Keying the latch on the run status would report every unpolled
+        task queue as started, and the no-worker verdict would be unreachable.
+        """
+        run = _result(
+            DAGRunStatus.RUNNING, DAGNodeStatus.PENDING, DAGNodeStatus.PENDING
+        )
+        assert run.status is DAGRunStatus.RUNNING
+        assert not _any_node_started(run)
+
+    def test_one_started_node_is_enough(self) -> None:
+        assert _any_node_started(
+            _result(DAGRunStatus.RUNNING, DAGNodeStatus.PENDING, DAGNodeStatus.RUNNING)
+        )
+
+    def test_a_run_with_no_nodes_has_not_started(self) -> None:
+        assert not _any_node_started(_result(DAGRunStatus.PENDING))
+
+
+class TestAbsorbAEBlip:
+    """What counts as a blip, and how long it buys."""
+
+    def test_a_non_apperror_is_terminal(self) -> None:
+        """A deterministic bug in the probe raises identically on every attempt,
+        so waiting out the budget only delays the failure."""
+        assert _absorb_ae_blip(TypeError("wrong signature")) is None
+
+    def test_a_plain_apperror_is_absorbed_with_no_backoff(self) -> None:
+        """Zero, not ``None``: absorb it, and the loop's own interval is the gap.
+        ``None`` would re-raise, which is the opposite instruction."""
+        assert _absorb_ae_blip(AppError(message="blip")) == timedelta(0)
+
+    @pytest.mark.parametrize("requested", [None, 0, -5])
+    def test_an_unusable_hint_leaves_the_interval_in_place(
+        self, requested: float | None
+    ) -> None:
+        error = AtlanApiHttpError(
+            message="500", target="native-status", retry_after_seconds=requested
+        )
+        assert _absorb_ae_blip(error) == timedelta(0)
+
+    def test_a_fractional_hint_rounds_up(self) -> None:
+        """A hint of 30.4s means "at least 30.4", so truncating to 30 would ask
+        for less than the origin did. Rounding is the classifier's job because
+        the primitive is handed a ``timedelta`` and has no business quantising
+        someone else's duration."""
+        error = AtlanApiHttpError(
+            message="500", target="native-status", retry_after_seconds=30.4
+        )
+        assert _absorb_ae_blip(error) == timedelta(seconds=31)
+
+
+class TestDAGProgress:
+    """The per-poll line, and the quiet-gap ledger behind it."""
+
+    def test_the_quiet_gap_grows_while_the_summary_is_unchanged(self) -> None:
+        """The number stamped onto a timed-out observation.
+        :class:`~application_sdk.testing.harness.outcome.Expired` does not carry
+        it, so the ledger is the only thing that can answer it."""
+        frozen = _result(DAGRunStatus.RUNNING, DAGNodeStatus.RUNNING)
+        with fake_clock() as clock:
+            progress = _DAGProgress()
+            progress.observe(frozen)
+            assert progress.quiet_seconds == 0.0
+            clock.sleep(70)
+            progress.observe(frozen)
+            assert progress.quiet_seconds == 70.0
+
+    def test_a_changed_summary_resets_the_gap(self) -> None:
+        with fake_clock() as clock:
+            progress = _DAGProgress()
+            progress.observe(_result(DAGRunStatus.RUNNING, DAGNodeStatus.PENDING))
+            clock.sleep(40)
+            progress.observe(_result(DAGRunStatus.RUNNING, DAGNodeStatus.RUNNING))
+            assert progress.quiet_seconds == 0.0
+
+    def test_the_line_is_logged_on_a_change_and_then_throttled(self) -> None:
+        """One line per node-state change, plus a heartbeat — not per poll.
+
+        The throttle is the ``L006`` waiver's whole justification, so it is
+        asserted rather than described: three identical readings inside the
+        heartbeat window produce one line.
+        """
+        frozen = _result(DAGRunStatus.RUNNING, DAGNodeStatus.RUNNING)
+        with fake_clock() as clock, patch.object(_client_module, "logger") as logged:
+            progress = _DAGProgress()
+            for _ in range(3):
+                progress.observe(frozen)
+                clock.sleep(1)
+        assert logged.info.call_count == 1
+
+    def test_a_frozen_summary_still_gets_a_heartbeat(self) -> None:
+        """A lineage stage sits unchanged for minutes; without this an operator
+        cannot tell "still polling" from "harness wedged"."""
+        frozen = _result(DAGRunStatus.RUNNING, DAGNodeStatus.RUNNING)
+        with fake_clock() as clock, patch.object(_client_module, "logger") as logged:
+            progress = _DAGProgress()
+            progress.observe(frozen)
+            clock.sleep(31)
+            progress.observe(frozen)
+        assert logged.info.call_count == 2
+        rendered = [call.args[0] % call.args[1:] for call in logged.info.call_args_list]
+        # The elapsed stamp is what makes the second line readable as a
+        # heartbeat rather than a repeat.
+        assert "[  0s]" in rendered[0] and "[ 31s]" in rendered[1]
+
+    def test_elapsed_comes_from_the_polls_own_clock(self) -> None:
+        """Read through :func:`monotonic`, so a ``fake_clock`` test sees one
+        timeline rather than a ledger that thinks no time has passed."""
+        with fake_clock(start=5.0) as clock:
+            assert monotonic() == 5.0
+            clock.sleep(2.5)
+            assert monotonic() == 7.5
+
+
+class TestVerdictMapping:
+    """Each generic verdict, and the AE answer it becomes."""
+
+    def test_settled_returns_the_reading_unstamped(self) -> None:
+        run = _result(DAGRunStatus.SUCCEEDED, DAGNodeStatus.SUCCEEDED)
+        returned = _verdict(
+            Settled(label="AE run", attempts=1, elapsed=timedelta(0), value=run)
+        )
+        assert returned is run
+        assert not returned.stopped_watching
+
+    def test_a_pending_run_that_never_started_blames_ae(self) -> None:
+        with pytest.raises(AutomationEngineNotDispatchingError, match="never dis"):
+            _verdict(
+                NeverStarted(
+                    label="AE run",
+                    attempts=19,
+                    elapsed=timedelta(seconds=180),
+                    grace=timedelta(seconds=180),
+                    last=_result(DAGRunStatus.PENDING, DAGNodeStatus.PENDING),
+                )
+            )
+
+    def test_a_live_run_that_never_started_names_the_queue(self) -> None:
+        with pytest.raises(NoWorkerOnTaskQueueError, match="atlan-openapi-e2e"):
+            _verdict(
+                NeverStarted(
+                    label="AE run",
+                    attempts=19,
+                    elapsed=timedelta(seconds=180),
+                    grace=timedelta(seconds=180),
+                    last=_result(DAGRunStatus.RUNNING, DAGNodeStatus.PENDING),
+                ),
+                stall_task_queue="atlan-openapi-e2e-full-ci",
+            )
+
+    def test_the_stall_verdict_stamps_the_observed_gap_on_the_reading(self) -> None:
+        """Two different numbers, and both belong on the result: the *configured*
+        window says which guard fired, the *observed* gap says how long it had
+        actually been frozen. They differ whenever a probe overran its interval.
+        """
+        run = _result(DAGRunStatus.RUNNING, DAGNodeStatus.RUNNING)
+        with pytest.raises(DAGProgressStalledError) as excinfo:
+            _verdict(
+                Stalled(
+                    label="AE run",
+                    attempts=31,
+                    elapsed=timedelta(seconds=310),
+                    stall_window=timedelta(seconds=307),
+                    fingerprint="🔄 node0",
+                    last=run,
+                )
+            )
+        stamped = excinfo.value.result
+        assert stamped is not None
+        assert stamped.progress_stalled_after_seconds == 300.0
+        assert stamped.seconds_since_last_progress == 307.0
+        assert stamped.progress_stalled and stamped.stopped_watching
+
+    def test_the_ceiling_returns_the_reading_stamped_not_raised(self) -> None:
+        """A caller needs the node breakdown to say which node was where when the
+        harness stopped watching, and ``timed_out`` is what stops it reading the
+        breakdown as a verdict."""
+        run = _result(DAGRunStatus.RUNNING, DAGNodeStatus.RUNNING)
+        progress = _DAGProgress()
+        with fake_clock() as clock:
+            progress.observe(run)
+            clock.sleep(120)
+            progress.observe(run)
+        returned = _verdict(
+            Expired(
+                label="AE run",
+                attempts=60,
+                elapsed=timedelta(seconds=590),
+                budget=timedelta(seconds=600),
+                last=run,
+            ),
+            progress=progress,
+        )
+        assert returned.timed_out_after_seconds == 600.0
+        assert returned.seconds_since_last_progress == 120.0
+
+
+class TestVerdictMappingWithoutAReading:
+    """The guards whose ``else`` the loop cannot reach today.
+
+    Every one of these is a verdict arriving with ``last=None``. They are
+    unreachable through ``poll_until`` as it stands — ``NeverStarted`` and
+    ``Stalled`` are only returned after a successful reading — which is the
+    reason to assert them here rather than to leave them to the loop: the
+    alternative to a tested fallback is an ``AttributeError`` raised from inside
+    a diagnostic, on the day the primitive grows a sixth caller.
+    """
+
+    def test_a_never_started_with_no_reading_says_so(self) -> None:
+        """No reading means the top-level status is unknown, and the message says
+        ``unknown`` rather than guessing ``Pending`` — which would blame AE for a
+        dispatch it may well have made."""
+        with pytest.raises(NoWorkerOnTaskQueueError, match="status=unknown"):
+            _verdict(
+                NeverStarted(
+                    label="AE run",
+                    attempts=1,
+                    elapsed=timedelta(seconds=180),
+                    grace=timedelta(seconds=180),
+                )
+            )
+
+    @pytest.mark.parametrize("configured", [None, 0])
+    def test_a_stall_with_no_configured_window_reports_the_observed_gap(
+        self, configured: int | None
+    ) -> None:
+        """Not zero. Unreachable today — ``_armed`` disarms the watchdog for a
+        non-positive window, so ``poll_until`` cannot return ``Stalled`` — but a
+        stamped 0 would claim the watchdog window was zero seconds, which is a
+        lie that sends the reader hunting a phantom. The observed quiet gap is
+        true whatever the configuration was.
+        """
+        run = _result(DAGRunStatus.RUNNING, DAGNodeStatus.RUNNING)
+        with pytest.raises(DAGProgressStalledError) as excinfo:
+            _verdict(
+                Stalled(
+                    label="AE run",
+                    attempts=31,
+                    elapsed=timedelta(seconds=310),
+                    stall_window=timedelta(seconds=307),
+                    fingerprint="🔄 node0",
+                    last=run,
+                ),
+                progress_stall_seconds=configured,
+            )
+        stamped = excinfo.value.result
+        assert stamped is not None
+        assert stamped.progress_stalled_after_seconds == 307.0
+
+    def test_a_stall_with_no_reading_has_nothing_to_attach(self) -> None:
+        with pytest.raises(AtlanApiTimeoutError, match="with no response"):
+            _verdict(
+                Stalled(
+                    label="AE run",
+                    attempts=31,
+                    elapsed=timedelta(seconds=310),
+                    stall_window=timedelta(seconds=300),
+                    fingerprint="",
+                )
+            )
+
+    def test_a_ceiling_with_no_reading_raises_rather_than_inventing_one(
+        self,
+    ) -> None:
+        with pytest.raises(AtlanApiTimeoutError, match="with no response") as excinfo:
+            _verdict(
+                Expired(
+                    label="AE run",
+                    attempts=60,
+                    elapsed=timedelta(seconds=590),
+                    budget=timedelta(seconds=600),
+                )
+            )
+        assert excinfo.value.timeout_seconds == 600.0
+
+
+class TestIndeterminateSplitsInTwo:
+    """One verdict, two failures — told apart by the streak length."""
+
+    def test_a_streak_that_gave_up_re_raises_the_origins_own_error(self) -> None:
+        """The operator sees AE's message, not a wrapper around it."""
+        cause = AtlanApiHttpError(
+            message="AE-COMMON-500-01: An unexpected error occurred",
+            target="native-status",
+        )
+        with pytest.raises(AtlanApiHttpError, match="AE-COMMON-500-01"):
+            _verdict(
+                Indeterminate(
+                    label="AE run",
+                    attempts=5,
+                    elapsed=timedelta(seconds=40),
+                    cause=cause,
+                    transient_failures=5,
+                )
+            )
+
+    def test_a_budget_that_expired_mid_streak_reports_the_timeout(self) -> None:
+        """The wait only gives up at ``max_transient_failures``, so a shorter
+        streak means the deadline ended the loop — and there is no observation to
+        stamp, which is a different thing to tell the operator."""
+        cause = AtlanApiHttpError(message="500", target="native-status")
+        with pytest.raises(AtlanApiTimeoutError, match="with no response"):
+            _verdict(
+                Indeterminate(
+                    label="AE run",
+                    attempts=3,
+                    elapsed=timedelta(seconds=20),
+                    cause=cause,
+                    transient_failures=3,
+                ),
+                max_transient_failures=99,
+            )
+
+    @pytest.mark.parametrize("configured", [0, 1])
+    def test_the_degenerate_pair_both_give_up_on_the_first_error(
+        self, configured: int
+    ) -> None:
+        """``max_transient_failures`` of 0 and 1 are the same instruction — end on
+        the first error — because the Nth consecutive error is the one that gives
+        up. The split keys on ``max(1, configured)`` so a caller passing 0 still
+        gets the origin's error rather than a timeout that never happened.
+        """
+        cause = AtlanApiHttpError(message="500", target="native-status")
+        with pytest.raises(AtlanApiHttpError):
+            _verdict(
+                Indeterminate(
+                    label="AE run",
+                    attempts=1,
+                    elapsed=timedelta(0),
+                    cause=cause,
+                    transient_failures=1,
+                ),
+                max_transient_failures=configured,
+            )

--- a/tests/unit/testing/harness/automation_engine/test_writes.py
+++ b/tests/unit/testing/harness/automation_engine/test_writes.py
@@ -249,6 +249,64 @@ class TestPublishVersion:
             await client.publish_version("slug", 1, retries=2)
 
 
+class TestRetriesMeansRetries:
+    """All four AE writes spend the same budget for the same ``retries=N``.
+
+    ``create_version`` and ``publish_version`` used to pass
+    ``total_attempts=retries``, so ``retries=5`` bought four while
+    ``create_workflow``'s and ``submit_workflow``'s identically-named parameter
+    bought five. FND-240 normalised them onto ``retries + 1``, the convention
+    ``_post_with_retry`` documents and the only one the parameter's name is true
+    under.
+
+    Asserted as a *cross-endpoint* equality rather than four separate counts:
+    the defect was never any single number, it was that two of them disagreed.
+    """
+
+    @pytest.mark.parametrize("retries", [0, 1, 3])
+    async def test_the_two_versions_endpoints_match_create_workflow(
+        self, retries: int
+    ) -> None:
+        counts: dict[str, int] = {}
+
+        async def _count(name: str, response: tuple[int, Any]) -> None:
+            client = _client()
+            with (
+                patch.object(client, "_request", return_value=response) as request,
+                patch(_SLEEP),
+                pytest.raises(AtlanApiHttpError),
+            ):
+                if name == "create_workflow":
+                    await client.create_workflow("n", retries=retries)
+                elif name == "create_version":
+                    await client.create_version("slug", {}, retries=retries)
+                else:
+                    await client.publish_version("slug", 1, retries=retries)
+            counts[name] = request.call_count
+
+        # Each endpoint gets a response its own ``retryable`` predicate keeps
+        # retrying, so the count is the budget rather than an early accept.
+        await _count("create_workflow", (503, {}))
+        await _count("create_version", (404, {}))
+        await _count("publish_version", (200, {"status": "queued"}))
+
+        assert counts["create_version"] == counts["create_workflow"]
+        assert counts["publish_version"] == counts["create_workflow"]
+        assert counts["create_workflow"] == retries + 1
+
+    async def test_the_publish_failure_names_the_attempts_it_made(self) -> None:
+        """The message said ``after {retries} attempts`` while making
+        ``retries + 1``, which is the kind of off-by-one that reads as broken
+        retry logic in a CI log."""
+        client = _client()
+        with (
+            patch.object(client, "_request", return_value=(200, {"status": "queued"})),
+            patch(_SLEEP),
+            pytest.raises(AtlanApiHttpError, match=r"after 3 attempt\(s\)"),
+        ):
+            await client.publish_version("slug", 1, retries=2)
+
+
 class TestGetNativeStatus:
     async def test_a_non_2xx_raises_with_the_origins_backoff(self) -> None:
         """The poll loop reads ``retry_after_seconds`` off this leaf to size its

--- a/tests/unit/testing/harness/automation_engine/test_writes.py
+++ b/tests/unit/testing/harness/automation_engine/test_writes.py
@@ -17,12 +17,14 @@ from __future__ import annotations
 from typing import Any
 from unittest.mock import patch
 
+import httpx
 import pytest
 
 from application_sdk.testing.harness._poll import fake_clock
 from application_sdk.testing.harness.automation_engine._errors import (
     AtlanApiHttpError,
     AtlanApiResponseInvariantError,
+    AtlanApiTimeoutError,
 )
 from application_sdk.testing.harness.automation_engine.client import AEClient
 from application_sdk.testing.harness.automation_engine.retry import (
@@ -101,6 +103,129 @@ class TestCreateVersion:
         ):
             assert await client.create_version("slug", {}) == 3
         assert request.call_count == 2
+
+
+class TestSlugResolves:
+    """The readiness read that replaced an unconditional ``time.sleep(3)``.
+
+    The narrowing is the whole content: a 2xx and a 404 are the two answers AE
+    actually gives about a slug, and everything else is *not* an answer. Reading
+    an overloaded AE as "not indexed" would poll out a budget over a fact the
+    read never learned.
+    """
+
+    async def test_a_2xx_means_ae_resolved_the_slug(self) -> None:
+        client = _client()
+        with patch.object(client, "_request", return_value=(200, {"data": []})):
+            assert await client.slug_resolves("s") is True
+
+    async def test_a_404_is_ae_saying_not_yet(self) -> None:
+        client = _client()
+        with patch.object(client, "_request", return_value=(404, {"error": "no"})):
+            assert await client.slug_resolves("s") is False
+
+    @pytest.mark.parametrize("status", [401, 403, 500, 503])
+    async def test_every_other_status_settles_nothing(self, status: int) -> None:
+        client = _client()
+        with patch.object(client, "_request", return_value=(status, {})):
+            assert await client.slug_resolves("s") is None
+
+    async def test_a_redirect_loop_is_not_absorbed(self) -> None:
+        """The hole the docstring names, pinned so the claim cannot go stale.
+
+        ``httpx.TooManyRedirects`` is a ``RequestError`` but not a
+        ``TransportError``, so ``_request``'s ``except (httpx.TransportError,
+        OSError)`` misses it — and the transport sets ``follow_redirects=True``,
+        which makes it reachable rather than theoretical. If someone later widens
+        that narrowing, this test fails and tells them the docstring's stated
+        residue is now wrong too.
+        """
+        client = _client()
+        with (
+            patch.object(
+                client, "_request", side_effect=httpx.TooManyRedirects("loop")
+            ),
+            pytest.raises(httpx.TooManyRedirects),
+        ):
+            await client.slug_resolves("s")
+
+    async def test_an_unreachable_ae_settles_nothing(self) -> None:
+        client = _client()
+        with patch.object(
+            client, "_request", side_effect=AtlanApiTimeoutError(message="down")
+        ):
+            assert await client.slug_resolves("s") is None
+
+    async def test_the_slug_is_url_quoted(self) -> None:
+        """A slug is AE-assigned, but it lands in a path segment, and a `/` in one
+        would silently address a different route."""
+        client = _client()
+        with patch.object(client, "_request", return_value=(200, {})) as request:
+            await client.slug_resolves("a/b c")
+        assert "a%2Fb%20c/versions" in request.call_args.args[1]
+
+
+class TestWaitForSlug:
+    async def test_an_already_indexed_slug_costs_one_call_and_no_sleep(self) -> None:
+        """The direction the fixed sleep was wrong in most often: it charged every
+        run three seconds, and the usual answer is already yes at t=0."""
+        client = _client()
+        with (
+            patch.object(client, "slug_resolves", return_value=True) as read,
+            fake_clock() as clock,
+        ):
+            assert await client.wait_for_slug("s") is True
+        assert read.await_count == 1
+        assert clock.slept == []
+
+    async def test_a_slow_index_is_polled_through(self) -> None:
+        """The other direction: a fixed 3s sleep is no help at all on the run
+        where indexing takes four."""
+        client = _client()
+        answers = [False, False, False, False, True]
+        with (
+            patch.object(client, "slug_resolves", side_effect=answers),
+            fake_clock() as clock,
+        ):
+            assert await client.wait_for_slug("s") is True
+        assert clock.slept == [1, 1, 1, 1]
+
+    async def test_an_unreadable_probe_does_not_end_the_wait(self) -> None:
+        """``None`` is not ``False``. A read that settled nothing must not be
+        taken as AE having answered — in either direction.
+
+        **The call count is the assertion, not the return value.** Returning
+        ``True`` does not distinguish a correct predicate from a broken one: with
+        ``settled=lambda r: r is not False`` the wait settles on the *first*
+        ``None`` and still returns ``True``, so an assertion on the result alone
+        passes either way. Confirmed mechanically — that mutation left all 37
+        tests in this file green. Three probes is what only the correct predicate
+        produces.
+        """
+        client = _client()
+        with (
+            patch.object(
+                client, "slug_resolves", side_effect=[None, None, True]
+            ) as read,
+            fake_clock(),
+        ):
+            assert await client.wait_for_slug("s") is True
+        assert read.await_count == 3, "an unreadable probe must not settle the wait"
+
+    async def test_an_unresolved_slug_is_reported_not_raised(self) -> None:
+        """Advisory, never a gate.
+
+        ``create_version`` retries on 404 for exactly this reason and is what
+        actually makes the sequence safe, so a readiness read that replaces a
+        guess must not be stricter than the guess it replaced. A wait that ends
+        unresolved hands over to that retry.
+        """
+        client = _client()
+        with (
+            patch.object(client, "slug_resolves", return_value=False),
+            fake_clock(),
+        ):
+            assert await client.wait_for_slug("s", timeout_seconds=5) is False
 
 
 class TestPublishVersion:

--- a/tests/unit/testing/harness/test_waiting_equivalence.py
+++ b/tests/unit/testing/harness/test_waiting_equivalence.py
@@ -1,36 +1,36 @@
-"""``poll_until`` against ``poll_native_status``, on identical scripted readings.
+"""``poll_native_status`` and ``poll_until``, on identical scripted readings.
 
-FND-227 is an *extraction*: the start-grace latch, the progress watchdog and the
-transient streak with its retry-after budget all already work — as interleaved
-statements inside ``AEWorkflowClient.poll_native_status``, coupled to the AE
-``native-status`` wire shape, the ``DAGNodeStatus`` vocabulary and a node-glyph
-summary string. Claiming the generic primitive preserves them needs evidence,
-and "the 58 existing client tests still pass" is not that evidence: those tests
-exercise the live loop, which this PR does not touch.
+FND-227 was an *extraction*: the start-grace latch, the progress watchdog and the
+transient streak with its retry-after budget all already worked — as interleaved
+statements inside ``poll_native_status``, coupled to the AE ``native-status``
+wire shape, the ``DAGNodeStatus`` vocabulary and a node-glyph summary string.
+This file was the differential evidence that the generic primitive preserved
+them, run before the live loop was touched.
 
-So the evidence is differential. Each scenario below is one script — a list of
-readings and errors — fed to *both* loops:
+**FND-240 consolidated the two, so this file changed job.** ``poll_native_status``
+*is* :func:`~application_sdk.testing.harness.waiting.poll_until` now, and a
+comparison of a loop against itself proves nothing. So the pre-conversion numbers
+were captured and are pinned here as :data:`_GOLDEN` — the same three observable
+things per scenario, **which verdict, after how many probes, having slept exactly
+which gaps**, as produced by the hand-rolled loop. That is what makes "behaviour
+preserving" a fact rather than a claim in a commit message, and it survives the
+conversion in a way a self-comparison would not.
 
-* the live one, through a patched ``get_native_status``;
-* :func:`~application_sdk.testing.harness.waiting.poll_until`, with the AE shape
-  supplied as the four callables the primitive takes in.
+The sleep sequence is the load-bearing column: it is what catches a retry-after
+clamp, an off-by-one in the budget accounting or a lost interval floor, none of
+which change the verdict.
 
-Both run under :func:`~application_sdk.testing.harness._poll.fake_clock`, so the
-comparison covers three observable things and not just the answer: **which
-verdict, after how many probes, having slept exactly which gaps.** The sleep
-sequence is the load-bearing one — it is what catches a retry-after clamp, an
-off-by-one in the budget accounting or a lost interval floor, none of which
-change the verdict.
+Two comparisons still run against ``poll_until`` directly, and both remain
+non-trivial after the conversion because :meth:`AEClient.poll_native_status`
+reaches the primitive through its *own* conversion — the keyword arguments into a
+:class:`~application_sdk.testing.harness.budgets.Budget`, the AE shape into four
+callables, the verdict back into an AE leaf:
 
-The budget both sides run on is ``CONNECTOR_CI[Wait.AE_RUN]``, converted back to
-the live loop's keyword arguments. That makes this a check on the profile too: if
-child B's lift of those numbers were wrong, the two loops would diverge here.
-
-Re-expressing the live loop *on* the primitive is child D (FND-240) — its client
-is synchronous until child F converts it, and bridging a sync method onto an
-async primitive in the meantime would be a workaround built to be deleted. This
-file is what stands in for that proof until then, and it costs the connector path
-no diff at all.
+* ``test_the_primitive_and_the_live_loop_agree`` pins that conversion against the
+  hand-written callables below. A ``stall_grace_seconds`` that stopped arming
+  ``start_grace``, or a classifier that stopped rounding, diverges here.
+* the budget both sides run on is ``CONNECTOR_CI[Wait.AE_RUN]``, converted back
+  to the live loop's keyword arguments — so this is a check on the profile too.
 """
 
 from __future__ import annotations
@@ -67,11 +67,14 @@ from application_sdk.testing.harness.waiting import poll_until
 _RUN_ID = "test-run-123"
 _AE = CONNECTOR_CI.budgets[Wait.AE_RUN]
 
-#: The two vocabularies, side by side. Every live outcome — a returned result or
-#: a raised leaf — has exactly one harness verdict, and the mapping is the
-#: extraction's actual claim: four connector-specific leaves collapse to the
-#: three generic verdicts that carry the *diagnosis*, while the remediation
-#: advice those leaves exist for stays with them.
+#: The two vocabularies, side by side — and since FND-240 this table *is* the
+#: independent statement of what
+#: :func:`~application_sdk.testing.harness.automation_engine.client._dag_run_verdict`
+#: implements. Every live outcome, returned result or raised leaf, has exactly one
+#: harness verdict: four connector-specific leaves collapse to the three generic
+#: verdicts that carry the *diagnosis*, while the remediation advice those leaves
+#: exist for stays with them. Written here rather than imported from the code
+#: under test, so an inverted branch in that mapping has somewhere to fail.
 _SAME_VERDICT = {
     "terminal": "Settled",
     "timed_out": "Expired",
@@ -321,9 +324,59 @@ _SCENARIOS: dict[str, Script] = {
 }
 
 
+#: What the **hand-rolled** loop did with each script, captured before FND-240
+#: replaced it with ``poll_until``. Not derived from the current code: these are
+#: transcribed from a run against the pre-conversion ``poll_native_status``, so
+#: they cannot drift with the implementation they exist to constrain.
+#:
+#: A change here is a change in what a connector's e2e run does — how many times
+#: it asks AE, and how long it waits between asks. That is reviewable on its own
+#: terms; silently absorbing it into a refactor is what this table prevents.
+_GOLDEN: dict[str, Observed] = {
+    "a-backoff-request-below-the-interval": Observed("Settled", 2, (10,)),
+    "a-blip-that-asks-for-a-backoff": Observed("Settled", 2, (30,)),
+    "a-blip-then-progress-then-more-blips": Observed("Settled", 6, (10,) * 5),
+    "a-fractional-backoff-request": Observed("Settled", 2, (31,)),
+    "a-pathological-backoff-request": Observed("Settled", 2, (120,)),
+    "blips-below-the-streak": Observed("Settled", 5, (10,) * 4),
+    "blips-that-each-ask-for-a-backoff": Observed("Settled", 4, (120, 120, 80)),
+    "no-node-ever-starts": Observed("NeverStarted", 19, (10,) * 18),
+    "progressing-past-the-ceiling": Observed("Expired", 60, (10,) * 59),
+    "settles-after-progress": Observed("Settled", 3, (10, 10)),
+    "settles-immediately": Observed("Settled", 1, ()),
+    "settles-on-a-failed-run": Observed("Settled", 2, (10,)),
+    "started-then-frozen": Observed("Stalled", 31, (10,) * 30),
+    "the-run-is-never-dispatched": Observed("NeverStarted", 19, (10,) * 18),
+    "the-streak-gives-up": Observed("Indeterminate", 5, (10,) * 4),
+}
+
+
+def test_every_scenario_has_a_golden() -> None:
+    """A script with no pinned numbers is a script this file does not constrain.
+
+    Cheap, and it is the failure mode the table invites: adding a scenario to
+    ``_SCENARIOS`` and forgetting the pin leaves it silently unchecked by the
+    only test that knows what the old loop did.
+    """
+    assert sorted(_GOLDEN) == sorted(_SCENARIOS)
+
+
+@pytest.mark.parametrize("name", sorted(_SCENARIOS))
+async def test_the_live_loop_still_does_what_it_did_before(name: str) -> None:
+    """Same verdict, same probe count, same sleep sequence as the old loop."""
+    assert await _live(_SCENARIOS[name]) == _GOLDEN[name]
+
+
 @pytest.mark.parametrize("name", sorted(_SCENARIOS))
 async def test_the_primitive_and_the_live_loop_agree(name: str) -> None:
-    """Same script, same verdict, same probe count, same sleep sequence."""
+    """The live loop's own conversion matches the hand-written one.
+
+    ``poll_native_status`` builds the :class:`Budget` and the four callables from
+    its keyword arguments; :func:`_harness` writes them out by hand. Same script
+    through both is what catches a guard that stopped being armed or a classifier
+    that stopped rounding — neither of which the golden table alone would find,
+    since it is the live loop's own output on both sides of that comparison.
+    """
     script = _SCENARIOS[name]
     assert await _harness(script) == await _live(script)
 
@@ -357,11 +410,69 @@ async def test_each_verdict_is_actually_reached(name: str, verdict: str) -> None
 async def test_a_non_apperror_propagates_from_both_loops() -> None:
     """The classifier absorbs ``AppError`` and nothing else, matching the live
     ``except AppError``: a deterministic bug in the probe must not be waited out.
+
+    **The probe count is what asserts "not waited out"**, and without it this
+    test passes on a broken classifier. Verified mechanically: with
+    ``_absorb_ae_blip``'s ``isinstance(error, AppError)`` narrowing removed, the
+    ``ValueError`` is absorbed, the streak runs to
+    ``max_transient_failures``, and ``_dag_run_verdict`` then re-raises
+    ``outcome.cause`` — which is the same ``ValueError``. So
+    ``pytest.raises(ValueError)`` alone is satisfied by the mutation it exists to
+    catch; only the attempt count distinguishes failing on the first probe from
+    waiting out five.
     """
-    with pytest.raises(ValueError):
-        await _harness([ValueError("a bug in the probe, not a blip")])
-    with pytest.raises(ValueError):
-        await _live([ValueError("a bug in the probe, not a blip")])
+    bug = ValueError("a bug in the probe, not a blip")
+
+    # The primitive, driven with the AE shape written out by hand.
+    primitive = _Replay([bug])
+
+    async def probe() -> DAGRunResult:
+        return primitive.next()
+
+    with fake_clock(), pytest.raises(ValueError):
+        await poll_until(
+            probe,
+            settled=_ae_settled,
+            started=_ae_started,
+            fingerprint=_ae_fingerprint,
+            transient=_ae_transient,
+            budget=_AE,
+            label=f"AE run {_RUN_ID}",
+        )
+    assert primitive.calls == 1, (
+        f"poll_until probed {primitive.calls} times; a deterministic probe bug "
+        "must fail on the first, not be waited out"
+    )
+
+    # The live loop, through its own Budget and classifier conversion.
+    live = _Replay([bug])
+    client = AEWorkflowClient(
+        tenant_url="https://tenant.example.com", api_token="tok-test"
+    )
+
+    async def _read(_run_id: str) -> DAGRunResult:
+        return live.next()
+
+    grace, stall = _AE.start_grace, _AE.stall_timeout
+    assert grace is not None and stall is not None
+    with (
+        patch.object(client._ae, "get_native_status", side_effect=_read),
+        fake_clock(),
+        pytest.raises(ValueError),
+    ):
+        await client._ae.poll_native_status(
+            _RUN_ID,
+            interval_seconds=int(_AE.poll_interval.total_seconds()),
+            timeout_seconds=int(_AE.timeout.total_seconds()),
+            max_transient_failures=_AE.max_transient_failures,
+            stall_grace_seconds=int(grace.total_seconds()),
+            progress_stall_seconds=int(stall.total_seconds()),
+        )
+    assert live.calls == 1, (
+        f"poll_native_status probed {live.calls} times; with the classifier's "
+        "AppError narrowing removed this reaches 5 and still raises ValueError, "
+        "which is why the count is the assertion and not the exception type"
+    )
 
 
 async def test_the_stall_verdict_names_the_summary_that_froze() -> None:

--- a/tests/unit/testing/integration/test_workflow_poll.py
+++ b/tests/unit/testing/integration/test_workflow_poll.py
@@ -1,0 +1,116 @@
+"""``_poll_workflow_completion``: the last wall-clock deadline in the harness.
+
+Untested before FND-240, which is how it kept a third deadline idiom
+(``time.time()``) after the other loops had moved to the monotonic one. The
+tests here are about the loop, not the runner: what it returns, when it stops,
+and what it does with a status read that failed.
+
+``testing/integration/**`` is omitted from the coverage gate — it runs against a
+local Temporal, not in the unit suite — so these are here because the behaviour
+is worth pinning, not because a percentage needs them.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from application_sdk.testing.harness._poll import fake_clock
+from application_sdk.testing.integration.runner import BaseIntegrationTest
+
+
+def _runner(*responses: dict[str, Any]) -> tuple[BaseIntegrationTest, MagicMock]:
+    """A runner whose status client answers a scripted sequence.
+
+    Built without ``__init__``: constructing a ``BaseIntegrationTest`` discovers
+    credentials and probes a server, and the loop under test needs neither.
+    """
+    runner = BaseIntegrationTest.__new__(BaseIntegrationTest)
+    client = MagicMock()
+    script = list(responses)
+    client.get_workflow_status.side_effect = lambda *_: script[
+        min(client.get_workflow_status.call_count - 1, len(script) - 1)
+    ]
+    runner.client = client  # type: ignore[attr-defined]
+    return runner, client
+
+
+def _status(status: str) -> dict[str, Any]:
+    return {"success": True, "data": {"status": status}}
+
+
+def test_a_terminal_status_is_returned_on_the_first_poll() -> None:
+    runner, client = _runner(_status("COMPLETED"))
+    with fake_clock():
+        assert (
+            runner._poll_workflow_completion("wf-1", "run-1", timeout=60, interval=5)
+            == "COMPLETED"
+        )
+    assert client.get_workflow_status.call_count == 1
+
+
+def test_running_is_polled_through_until_it_is_not() -> None:
+    runner, client = _runner(_status("RUNNING"), _status("RUNNING"), _status("FAILED"))
+    with fake_clock() as clock:
+        assert (
+            runner._poll_workflow_completion("wf-1", "run-1", timeout=60, interval=5)
+            == "FAILED"
+        )
+    assert client.get_workflow_status.call_count == 3
+    assert clock.slept == [5, 5]
+
+
+def test_an_unsuccessful_status_read_is_polled_through() -> None:
+    """Kept deliberately uncapped.
+
+    FND-240 notes the missing transient cap; choosing a number for it needs
+    evidence about how often a *local* Temporal answers unsuccessfully, and a cap
+    guessed here would turn a slow local server into a failed test.
+    """
+    runner, client = _runner({"success": False, "error": "boom"}, _status("COMPLETED"))
+    with fake_clock():
+        assert (
+            runner._poll_workflow_completion("wf-1", "run-1", timeout=60, interval=5)
+            == "COMPLETED"
+        )
+    assert client.get_workflow_status.call_count == 2
+
+
+def test_the_budget_stops_the_loop_inside_its_stated_timeout() -> None:
+    """The off-by-one the wall-clock version had.
+
+    ``elapsed > timeout`` was checked *after* the probe, so a 30s budget at a 10s
+    interval slept a whole interval past its own deadline before noticing. Three
+    probes and 20s of sleeping is the corrected shape, and it is the same shape
+    every other converted loop in the harness now has.
+    """
+    runner, client = _runner(_status("RUNNING"))
+    with fake_clock() as clock, pytest.raises(TimeoutError, match="did not complete"):
+        runner._poll_workflow_completion("wf-1", "run-1", timeout=30, interval=10)
+    assert client.get_workflow_status.call_count == 3
+    assert clock.slept == [10, 10]
+
+
+def test_the_timeout_names_the_run_and_what_it_spent() -> None:
+    """An operator reading a red leg needs which run, and how long it watched."""
+    runner, _ = _runner(_status("RUNNING"))
+    with fake_clock(), pytest.raises(TimeoutError) as excinfo:
+        runner._poll_workflow_completion("wf-1", "run-1", timeout=30, interval=10)
+    message = str(excinfo.value)
+    assert "wf-1/run-1" in message
+    assert "within 30s" in message
+    assert "3 attempt(s)" in message
+
+
+def test_a_status_read_that_raises_is_not_absorbed() -> None:
+    """No transient classifier here, and that is the pre-existing contract: a
+    client that raises is a bug in the client, not a blip in the workflow."""
+    runner = BaseIntegrationTest.__new__(BaseIntegrationTest)
+    client = MagicMock()
+    client.get_workflow_status.side_effect = RuntimeError("client is broken")
+    runner.client = client  # type: ignore[attr-defined]
+    with fake_clock(), pytest.raises(RuntimeError, match="client is broken"):
+        runner._poll_workflow_completion("wf-1", "run-1", timeout=60, interval=5)
+    assert client.get_workflow_status.call_count == 1


### PR DESCRIPTION
Child of [FND-224](https://linear.app/atlan-epd/issue/FND-224). Closes [FND-240](https://linear.app/atlan-epd/issue/FND-240). **Stacked on #3440** — review that first. Rebased onto its current head; all eight commits replay with zero conflicts. #3438 has since merged, so the chain below this is main → #3439 → #3440.

Child C built `poll_until` / `hold_stable`. This child brings the remaining bounded loops onto them, one commit each, and it was sequenced late on purpose: the per-loop triage decisions only make sense once the primitive's semantics are settled.

The property that is now true and was the point: **no bounded loop in the harness owns a deadline**, and there is one clock where three coexisted — the monotonic deadline, the elapsed accumulator (already gone), and `time.time()`.

## The one that named this issue

`poll_native_status`'s own docstring said *"Still a hand-rolled loop rather than a call to `poll_until`… Consolidating the two is child D (FND-240)"*. It is `poll_until` now. What is left in the method is the four AE-specific callables, the `Budget` its keyword arguments convert into, and `_dag_run_verdict`.

`_dag_run_verdict` is deliberately **not** `assert_settled`. That adapter raises the generic leaves; the four AE leaves exist for their remediation advice — `NoWorkerOnTaskQueueError` names the task queue to check and the `agent_spec()` mismatch that usually causes it — and a `WaitNeverStartedError` carrying a label cannot. Two verdicts are not raises at all, which is the other reason the function exists: `Expired` *returns* the last observation stamped, because a caller needs the node breakdown to say which node was where when the harness stopped watching; and `Indeterminate` splits in two.

### Behaviour preservation is a fact here, not a claim

`test_waiting_equivalence.py` changed job. It was written before the conversion as a differential against the hand-rolled loop, and a differential against a loop that is now the same loop proves nothing. So the pre-conversion numbers were captured and are frozen as `_GOLDEN`: **verdict, probe count and the exact sleep sequence for all fifteen scripted runs.** All fifteen match byte for byte. The sleep sequence is the load-bearing column — it is what catches a retry-after clamp, an off-by-one in the budget accounting or a lost interval floor, none of which change the verdict.

`test_every_scenario_has_a_golden` exists because the table invites exactly one failure mode: adding a scenario and forgetting the pin leaves it silently unchecked by the only test that knows what the old loop did.

Two comparisons still run against `poll_until` directly and remain non-trivial, because `poll_native_status` reaches the primitive through its *own* conversion — a `stall_grace_seconds` that stopped arming `start_grace`, or a classifier that stopped rounding, diverges there and nowhere else.

### Two log-only changes, both in the docstring

* the give-up-on-the-streak line is the primitive's WARNING rather than this loop's ERROR. The streak count is still on it, and the origin's error still propagates, which is what makes the run red.
* the throttled per-poll progress line moved into `_DAGProgress`. Not dropped: the `L006` waiver's whole justification is that throttling, and a lineage stage sits unchanged for minutes — an operator needs it to tell "still polling" from "harness wedged".

`_DAGProgress` also carries the one number the verdict vocabulary cannot. `Expired` does not know how long the fingerprint had been frozen — that window is on `Stalled`, the verdict where it fired — and `seconds_since_last_progress` is stamped onto the observation a timed-out poll returns. It reads elapsed through a new `_poll.monotonic()` so the ledger and the loop share one timeline under `fake_clock`; a ledger on the real clock inside a fake-clock test reports zero elapsed for a wait the loop believes ran ten minutes.

## `wait_for_workflow` had no transient-error policy at all

`raise_for_status()` sat bare inside the loop, so one 502 from a handler pod mid-restart ended a 300-second wait on its first poll — and ended it as a raw `httpx.HTTPStatusError`, which reads as a test failure rather than as a dependency that could not be read.

The narrowing is by *status class*, not by "any HTTP error": a transport error or a 5xx/429 is the handler being unreachable and the next poll is entitled to a different answer, while a 4xx is the handler answering. A 404 on a workflow id is a wrong id, and absorbing it would spend the whole budget on a typo before reporting a timeout.

`TimeoutError` is kept for the expired case rather than becoming `WaitExpiredError`: this is a public export with out-of-repo consumers and their `except TimeoutError` is not something a refactor gets to invalidate. The unreadable case has no such history, so it raises `WaitIndeterminateError` — the distinction that stops an unreachable pod being graded as a workflow that never finished.

Two smaller things the conversion forced out. The port-forward session is opened **outside** the probe: the probe is the loop body, so a context manager inside it would restore the per-poll `kubectl` process #3439 removed. And `_status_of` is total on its input, because the settled predicate, the debug line and the timeout message all read `status`, and a handler answering `{"status": null}` must not crash the wait inside the predicate deciding whether to keep waiting.

The test that asserted the old behaviour also set the error's response to a bare `MagicMock`, which compares truthy against every threshold — so it would have passed whatever a classifier decided. Its replacements set a real status.

## The off-by-one, twice more

Both remaining hand-rolled deadlines checked the budget *after* the probe, so each slept one whole interval past its stated timeout before noticing. `attempt.is_last` moves that decision before the sleep, and both conversions pin the corrected numbers under `fake_clock` rather than leaving the change to be inferred — a 30s budget at a 10s interval is three probes and 20s of sleeping, not four and 30s.

* **`seed_connection`'s probe retry** (`base.py`) — the last `time.monotonic() + timeout` in that file. Extracted to `_retry_seed_probe` on the way through, because `seed_connection` was doing three unrelated jobs in one 150-line body and the retry is the one with a contract worth documenting.
* **`integration/runner._poll_workflow_completion`** — the last `time.time()` one. Moving it off the wall clock is the point rather than a side effect: a wall-clock budget is wrong in both directions, since an NTP step forward expires a wait that had time left and a step backward extends one that should have ended.

Both take bare `until_deadline` rather than `poll_until`, for one reason worth stating: their probe is *synchronous* — a connector-supplied write, a local test client — and reaching an async primitive from there would mean blocking the bridge's loop inside someone else's code or offloading it to a thread. Both are workarounds built to be deleted when child H moves the sync boundary up to `BaseE2ETest`'s public methods. The three sibling loops in `base.py` already took this shape in child C.

`_poll_workflow_completion` had no tests at all, which is how it kept a third clock idiom after everything else had moved. Its unbounded transient tolerance is deliberately **kept**, and the test says so: FND-240 notes the missing cap, but choosing a number needs evidence about how often a *local* Temporal answers unsuccessfully, and a cap guessed here would turn a slow local server into a failed test.

## The unconditional `time.sleep(3)`, replaced with an observation

Both full-DAG harnesses slept three seconds between `create_workflow` and `create_version`, because AE has a brief indexing window before a fresh slug is queryable. A fixed sleep is wrong in both directions: it charged every run three seconds it usually did not need, and it was no help at all on the run where indexing took four.

`slug_resolves` reads the route family `get_published_version` already uses — so it exists and this client already authenticates against it — with the `is_published` filter dropped, which is what makes it answerable for a workflow that has no published version yet. That is every workflow at this point in a run.

The narrowing is the content: a 2xx means AE resolved the slug, a 404 is the same *"Workflow with slug 'X' not found"* that `create_version` already retries on, and **nothing else is interpreted**. A 5xx, a 403 and a dropped connection all answer `None`, because none of them says anything about indexing, and reading an overloaded AE as "not indexed" would poll out a budget over a fact the read never learned. `wait_for_slug`'s settled predicate is `is True`, so a `None` cannot end the wait in either direction.

**Advisory, never a gate.** `create_version`'s 404 retry is what actually makes the sequence safe, so `wait_for_slug` returns a bool for the log and an unresolved slug hands over to that retry. The rule that keeps this honest: *a readiness read that replaces a guess must not be stricter than the guess it replaced* — which also means that if the premise about the list route is wrong on some tenant, behaviour degrades to exactly today's, minus three seconds. `time.sleep` is now absent from both harnesses.

## The typed leaf, and why it is still an `AssertionError`

`assert_worker_up` raised a bare `AssertionError`. `WorkerNotHealthyError` is the leaf `_poll.py`'s own module docstring already used as its worked example, and it turns the last failure seen from a fragment of a sentence into a field: a refused connection and a 503 send an operator to different halves of a deployment.

It also subclasses `AssertionError`, deliberately and not as a hedge. Pytest reds on any exception, so that is not what it buys. What it buys is that this method's docstring has promised an `AssertionError` since the method existed, and out-of-repo connector suites are entitled to have written `except AssertionError` against it. Typing the leaf is worth doing; taking a documented `except` clause away from every connector in the fleet to do it is not, and the two are not in tension. **The existing test still passes unchanged**, which is the evidence.

## The inconsistencies, including the three I did not "fix"

**`retries` now means retries, on all four AE writes.** `create_version` and `publish_version` passed `total_attempts=retries`, so `retries=5` bought four while `create_workflow`'s and `submit_workflow`'s identically-named parameter bought five. Normalised onto `retries + 1` — the convention `_post_with_retry` documents and the only one the parameter's name is true under. That direction rather than the other because shortening the pair that was already right would shrink `cold_start_submit_kwargs`' budget, which divides a timeout by an interval and needs the attempt count it asked for. Two endpoints therefore get one more attempt; the test asserts it as a cross-endpoint *equality* rather than as four counts, because the defect was never any single number, it was that two of them disagreed. `publish_version`'s message also said "after {retries} attempts" while making `retries + 1`, which reads as broken retry logic in a CI log.

**`max_forbidden_attempts` says it does nothing.** It was `del`'d unread, which is the shape that lets a caller keep passing a number and believe it bounds something. It now warns with a named removal version (v4.0) rather than being removed outright, because this is a public signature with out-of-repo callers. Its default becomes `None` rather than `5` for the reason the second test states: with a real default there is no way to tell "the caller asked for this" from "the signature did", and every call would warn.

**`DAGRunResult.failed_nodes`** — already resolved in #3438, which documented it as the deliberate wide "not successful" set and added `not_started_nodes` as the narrow one. No change.

**`max_transient_failures`' 0/1 degenerate pair** — normalised by *pinning* it, not by making the two differ. `0` reads naturally as "no tolerance" and already means exactly that; the alternative (shifting the boundary so `N` absorbs `N`) would change every connector's tolerance to buy tidier arithmetic. `test_the_degenerate_pair_both_give_up_on_the_first_error` is what stops one reader of the field quietly disagreeing.

**`DAGProgressStalledError`'s PRECONDITION vs `WaitStalledError`'s TIMEOUT** — cross-referenced from `_errors.py` as "listed on FND-240", and **declined**, with the reason recorded on both leaves. `code` is the field a structured failure envelope carries and alert rules route on, so flipping this one's category silently re-routes every consumer's stall alert. That is an error-contract change and belongs at the next major, not inside a refactor whose whole constraint is that behaviour is preserved.

## Loops from the issue's table that no longer exist

`pods.wait_for_pods_ready` was deleted in #3439 (untested, zero callers). `portforward._wait_for_port` moved to the harness and onto `until_deadline_async` in the same PR. `poll_atlas_for_connection` went onto `poll_until` in #3438. The port-forward process-exit wait is an `asyncio.wait_for` around `proc.wait()`, not a poll loop with deadline arithmetic — there is nothing to consolidate, and it is called out here so its absence is not read as an omission.

The AE `_request` / `_post_with_retry` retries stay **attempt-bounded** rather than becoming wall-clock waits. They are retries around a single call, not bounded waits, and `RequestBudget` exists in child B precisely because folding them into `Budget` would make `timeout` mean two things. Only their attempt arithmetic was inconsistent, and that is fixed above.

## Verification

* **Full unit suite — 8,771 passed, 9 skipped, 0 failed** (`tests/unit`, on base `b280ef481`).
  The `test_config.py::test_it_stays_frozen` failure an earlier revision of this description reported as inherited from the base is **gone**, and it was never mine or #3440's to fix: main's merged `test_config.py` has no such test — it asserts `test_a_dead_field_can_be_deleted_as_well_as_set` — so the mutability question was already settled upstream, and taking main resolved it.
* **100% coverage on `application_sdk/testing/harness/**`** (2,073 statements, 0 missed), the AE client and `_poll` included.
* `atlan-application-sdk-conformance detect` — **258 unsuppressed findings against the base's 259**, and **zero new findings, suppressed or live, in any file this PR touches**. Raw SARIF totals are 564 against 566, but that pair is not the number to read and not the number to compare: suppressed findings stay in the SARIF carrying `suppressions: [{kind: inSource, status: accepted}]` and keep `kind: "fail"`, so a raw delta can be entirely suppression-side. This one nearly was. Split by `select((.suppressions // []) | length == 0)`:
  * **live −1**: `L006` in `testing/e2e/base.py`, 2 → 1. The seed-probe loop's per-attempt line was an *unwaived* per-iteration log on the base — the rule did not see the `while True` — and now carries an explicit directive. It is **waived, not fixed**: the line still fires once per poll, and whether a 30-second interval earns that is a review question, not something the count settles.
  * **suppressed −1** net, from three movements that cancel: `L006` in `e2e/base.py` 3 → 4 (the same line arriving), and `L006` 2 → 1 plus `L009` 1 → 0 in the AE client, where `poll_native_status`'s hand-rolled branches took their waiver comments with them. Those two were suppressed on **both** sides, so they changed nothing real — an earlier revision of this description cited them as the delta, which was suppressed-count movement described as finding movement.
  One `B002` finding was introduced and then removed rather than suppressed: the rule reads `warnings.warn`'s first argument statically, so a notice built into a local and passed by name reads as an empty notice. The notice is written inline, with the log twin carrying the value the caller passed in `%`-style.
* `uv run pre-commit run` on every touched file — clean (ruff, ruff-format, isort, pyright).
* **`docs/agents/sdk-capabilities.md` is deliberately unchanged.** `poe regen-capabilities` was run: the content is byte-identical and only the `source-sha` / `source-date` stamp moved, because nothing in the public surface changed — the new symbols are either private (`_armed`, `_absorb_ae_blip`, `_DAGProgress`, `_dag_run_verdict`, `_poll.monotonic`) or methods on already-listed classes, which the manifest does not enumerate. Committing a stamp-only diff would add a conflict point to a seven-PR stack for no information.
* **No dependency change**: `pyproject.toml` and `uv.lock` are untouched.

### Not verified here

The issue's "done when" asks that the connector e2e suite produce the same verdicts and comparable wall-clock durations on a real tenant. No VPN or vcluster session was available, so that half is unrun. What stands in for it: the golden table fixes the AE poll's verdict, probe count and sleep sequence against the pre-conversion loop, and the two off-by-one conversions pin their new probe counts and sleep sequences explicitly. The durations that *should* differ on a real run are (a) three seconds saved per run at the slug wait, and (b) one interval saved on any wait that expires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


