### PR TITLE
ci: upsert release bump PRs so title and body follow the branch

### DIFF
--- a/.github/scripts/tests/test_upsert_release_pr.py
+++ b/.github/scripts/tests/test_upsert_release_pr.py
@@ -1,0 +1,250 @@
+"""Tests for .github/scripts/upsert_release_pr.py.
+
+The behaviour under test is the one that broke atlanhq/atlan-oracle-app#258:
+a fixed bump branch is force-pushed on every re-fire, and the PR tracking it
+must follow the branch instead of staying frozen at its first title/body.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import upsert_release_pr as mod
+
+REPO = "atlanhq/atlan-oracle-app"
+BASE = "main"
+HEAD = "bump-version-main"
+
+
+def _ok(stdout: str = "") -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
+
+
+def _fail(stderr: str) -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr=stderr)
+
+
+class Gh:
+    """Stub for the `gh` seam: records every call, replies per subcommand."""
+
+    def __init__(self, list_replies: list[str]):
+        self._list_replies = list(list_replies)
+        self.calls: list[list[str]] = []
+        self.fail_on: str | None = None
+
+    def __call__(self, cmd, **kwargs):
+        self.calls.append(cmd)
+        joined = " ".join(cmd)
+        if self.fail_on and self.fail_on in joined:
+            return _fail("boom")
+        if cmd[1:3] == ["pr", "list"]:
+            return _ok(self._list_replies.pop(0) if self._list_replies else "[]")
+        return _ok()
+
+    def of(self, *subcommand: str) -> list[list[str]]:
+        n = len(subcommand)
+        return [c for c in self.calls if tuple(c[1 : 1 + n]) == subcommand]
+
+
+def _body_file(tmp_path: Path, text: str = "Version: 0.3.1 → 0.4.0\n") -> Path:
+    path = tmp_path / "body.md"
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _argv(
+    body_file: Path, title: str = "Bump version to 0.4.0", label: str = "release"
+):
+    return [
+        "--repo",
+        REPO,
+        "--base",
+        BASE,
+        "--head",
+        HEAD,
+        "--title",
+        title,
+        "--body-file",
+        str(body_file),
+        "--label",
+        label,
+    ]
+
+
+def test_creates_pr_with_label_when_none_open(tmp_path, monkeypatch, capsys):
+    gh = Gh(
+        ["[]", json.dumps([{"number": 258, "title": "x", "body": "", "labels": []}])]
+    )
+    monkeypatch.setattr(mod, "run", gh)
+    monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+
+    assert mod.main(_argv(_body_file(tmp_path))) == 0
+
+    create = gh.of("pr", "create")
+    assert len(create) == 1
+    assert "--title" in create[0]
+    assert create[0][create[0].index("--title") + 1] == "Bump version to 0.4.0"
+    assert "--label" in create[0]
+    # The label must exist before `gh pr create --label` can attach it.
+    assert gh.of("label", "create"), "expected the release label to be ensured"
+    assert not gh.of("pr", "edit")
+    assert "pr_action=created" in capsys.readouterr().out
+
+
+def test_stale_title_and_body_are_synced_not_skipped(tmp_path, monkeypatch, capsys):
+    """The oracle#258 regression: title says 0.3.2, branch is at 0.4.0."""
+    open_pr = [
+        {
+            "number": 258,
+            "title": "Bump version to 0.3.2",
+            "body": "Version: 0.3.1 → 0.3.2",
+            "labels": [{"name": "release"}],
+        }
+    ]
+    gh = Gh([json.dumps(open_pr)])
+    monkeypatch.setattr(mod, "run", gh)
+    monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+
+    assert mod.main(_argv(_body_file(tmp_path))) == 0
+
+    assert not gh.of("pr", "create"), "must not try to re-create an open PR"
+    edits = gh.of("pr", "edit")
+    assert len(edits) == 1
+    assert edits[0][3] == "258"
+    assert edits[0][edits[0].index("--title") + 1] == "Bump version to 0.4.0"
+    assert "--body-file" in edits[0]
+    assert "pr_action=updated" in capsys.readouterr().out
+
+
+def test_no_edit_when_pr_already_matches(tmp_path, monkeypatch, capsys):
+    """No spurious `pull_request: edited` webhook on an already-correct PR."""
+    body = "Version: 0.3.1 → 0.4.0\n"
+    open_pr = [
+        {
+            "number": 258,
+            "title": "Bump version to 0.4.0",
+            # GitHub hands back CRLF for bodies stored from a CRLF source.
+            "body": body.replace("\n", "\r\n"),
+            "labels": [{"name": "release"}],
+        }
+    ]
+    gh = Gh([json.dumps(open_pr)])
+    monkeypatch.setattr(mod, "run", gh)
+    monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+
+    assert mod.main(_argv(_body_file(tmp_path, body))) == 0
+
+    assert not gh.of("pr", "edit")
+    assert not gh.of("pr", "create")
+    assert "pr_action=unchanged" in capsys.readouterr().out
+
+
+def test_missing_label_is_re_added_on_the_update_path(tmp_path, monkeypatch):
+    """tag-and-release.yaml gates on the label; an unlabelled merge ships nothing."""
+    body = "Version: 0.3.1 → 0.4.0\n"
+    open_pr = [
+        {
+            "number": 258,
+            "title": "Bump version to 0.4.0",
+            "body": body,
+            "labels": [],
+        }
+    ]
+    gh = Gh([json.dumps(open_pr)])
+    monkeypatch.setattr(mod, "run", gh)
+    monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+
+    assert mod.main(_argv(_body_file(tmp_path, body))) == 0
+
+    edits = gh.of("pr", "edit")
+    assert len(edits) == 1
+    assert "--add-label" in edits[0]
+    assert edits[0][edits[0].index("--add-label") + 1] == "release"
+
+
+def test_empty_label_skips_all_label_work(tmp_path, monkeypatch):
+    gh = Gh(["[]", json.dumps([{"number": 9, "title": "", "body": "", "labels": []}])])
+    monkeypatch.setattr(mod, "run", gh)
+    monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+
+    assert mod.main(_argv(_body_file(tmp_path), label="")) == 0
+
+    assert not gh.of("label", "create")
+    assert "--label" not in " ".join(gh.of("pr", "create")[0])
+
+
+def test_edit_failure_is_loud(tmp_path, monkeypatch):
+    """A failed sync must fail the job, not leave a green run with a stale title."""
+    open_pr = [
+        {"number": 258, "title": "old", "body": "old", "labels": [{"name": "release"}]}
+    ]
+    gh = Gh([json.dumps(open_pr)])
+    gh.fail_on = "pr edit"
+    monkeypatch.setattr(mod, "run", gh)
+
+    with pytest.raises(SystemExit) as excinfo:
+        mod.main(_argv(_body_file(tmp_path)))
+    assert "::error::" in str(excinfo.value)
+
+
+def test_list_failure_is_loud(tmp_path, monkeypatch):
+    gh = Gh([])
+    gh.fail_on = "pr list"
+    monkeypatch.setattr(mod, "run", gh)
+
+    with pytest.raises(SystemExit) as excinfo:
+        mod.main(_argv(_body_file(tmp_path)))
+    assert "::error::" in str(excinfo.value)
+
+
+def test_label_create_failure_is_tolerated(tmp_path, monkeypatch):
+    """`gh label create` fails with "already exists" on every repo but the first."""
+    gh = Gh(["[]", json.dumps([{"number": 1, "title": "", "body": "", "labels": []}])])
+    gh.fail_on = "label create"
+    monkeypatch.setattr(mod, "run", gh)
+    monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+
+    assert mod.main(_argv(_body_file(tmp_path))) == 0
+    assert gh.of("pr", "create")
+
+
+def test_repo_defaults_to_github_repository(tmp_path, monkeypatch):
+    gh = Gh([json.dumps([{"number": 7, "title": "t", "body": "b", "labels": []}])])
+    monkeypatch.setattr(mod, "run", gh)
+    monkeypatch.setenv("GITHUB_REPOSITORY", REPO)
+    monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+
+    argv = [
+        "--base",
+        BASE,
+        "--head",
+        HEAD,
+        "--title",
+        "t",
+        "--body-file",
+        str(_body_file(tmp_path, "b")),
+        "--label",
+        "",
+    ]
+    assert mod.main(argv) == 0
+    assert gh.of("pr", "list")[0][gh.of("pr", "list")[0].index("--repo") + 1] == REPO
+
+
+def test_outputs_written_to_github_output(tmp_path, monkeypatch):
+    out = tmp_path / "gh_out"
+    gh = Gh([json.dumps([{"number": 42, "title": "old", "body": "old", "labels": []}])])
+    monkeypatch.setattr(mod, "run", gh)
+    monkeypatch.setenv("GITHUB_OUTPUT", str(out))
+
+    assert mod.main(_argv(_body_file(tmp_path))) == 0
+
+    written = out.read_text(encoding="utf-8")
+    assert "pr_number=42" in written
+    assert "pr_action=updated" in written

--- a/.github/scripts/upsert_release_pr.py
+++ b/.github/scripts/upsert_release_pr.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""Open a release/bump PR, or bring an already-open one back in sync.
+
+Every release automation in this repo pushes to a *fixed* branch
+(``bump-version-main``, ``release/conformance-vX``, …) and force-pushes fresh
+content onto it on each re-fire. The PR that tracks that branch is opened once
+and then reused. The bug this script exists to remove: the reuse path only
+logged "PR already exists, skipping creation", so the branch content moved on
+while the PR's title and body stayed frozen at whatever the *first* run wrote.
+
+Concretely, on atlanhq/atlan-oracle-app#258 the title and body said
+"0.3.1 → 0.3.2" while the diff bumped ``pyproject.toml`` to ``0.4.0``: the
+first run computed a patch bump, a later merge added a ``feat:`` commit that
+turned it into a minor bump, and only the files were updated. The tag itself is
+derived from ``pyproject.toml`` by tag-and-release.yaml, never from the title,
+so nothing mis-shipped — but the human approving the release PR was reading a
+version number that no longer matched what merging it would release.
+
+So: upsert, don't create-or-skip. Create when there is no open PR for the
+branch; otherwise edit the existing one back into agreement with the branch.
+
+Also ensures the release label on *both* paths. Previously the label was only
+applied at creation, and ``tag-and-release.yaml`` gates on
+``contains(labels.*.name, 'release')`` — an open bump PR that lost its label
+would merge with no tag and no GitHub Release.
+
+Usage::
+
+    python3 .github/scripts/upsert_release_pr.py \
+        --repo owner/name \
+        --base main \
+        --head bump-version-main \
+        --title "Bump version to 1.2.3" \
+        --body-file /tmp/body.md \
+        --label release
+
+Prints ``pr_number=<n>`` and ``pr_action=<created|updated|unchanged>`` to
+$GITHUB_OUTPUT (or stdout when unset), mirroring create_check_run.py.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def run(cmd: list[str], **kwargs) -> subprocess.CompletedProcess:
+    """Single seam so tests can stub the `gh` CLI."""
+    kwargs.setdefault("capture_output", True)
+    kwargs.setdefault("text", True)
+    kwargs.setdefault("check", False)
+    return subprocess.run(cmd, **kwargs)
+
+
+def _gh(cmd: list[str], what: str) -> str:
+    result = run(cmd)
+    if result.returncode != 0:
+        # Loud on failure by design. The push has already landed by the time we
+        # run, so a silent failure here leaves exactly the stale-title state
+        # this script exists to prevent — but green. A red job is the signal.
+        raise SystemExit(f"::error::failed to {what}: {result.stderr.strip()}")
+    return result.stdout
+
+
+def find_open_pr(repo: str, base: str, head: str) -> dict | None:
+    """Return the open PR for ``head`` -> ``base``, or None.
+
+    ``--head`` is matched without an ``owner:`` prefix because these branches
+    always live in the same repo (the automation pushes to origin), which is
+    what ``gh pr list`` assumes for a bare branch name.
+    """
+    stdout = _gh(
+        [
+            "gh",
+            "pr",
+            "list",
+            "--repo",
+            repo,
+            "--head",
+            head,
+            "--base",
+            base,
+            "--state",
+            "open",
+            "--json",
+            "number,title,body,labels",
+        ],
+        f"list open PRs for {head} -> {base} on {repo}",
+    )
+    prs = json.loads(stdout or "[]")
+    return prs[0] if prs else None
+
+
+def ensure_label_exists(repo: str, label: str) -> None:
+    """Create the label if the repo doesn't have it yet.
+
+    Best-effort: an "already exists" failure is the common case and is not an
+    error. A genuinely broken token surfaces on the create/edit call instead.
+    """
+    run(
+        [
+            "gh",
+            "label",
+            "create",
+            label,
+            "--repo",
+            repo,
+            "--color",
+            "0e8a16",
+            "--description",
+            "Release version-bump PR",
+        ]
+    )
+
+
+def create_pr(
+    repo: str, base: str, head: str, title: str, body_file: str, label: str | None
+) -> int:
+    cmd = [
+        "gh",
+        "pr",
+        "create",
+        "--repo",
+        repo,
+        "--base",
+        base,
+        "--head",
+        head,
+        "--title",
+        title,
+        "--body-file",
+        body_file,
+    ]
+    if label:
+        ensure_label_exists(repo, label)
+        cmd += ["--label", label]
+    _gh(cmd, f"create PR for {head} -> {base} on {repo}")
+    pr = find_open_pr(repo, base, head)
+    if pr is None:
+        raise SystemExit(
+            f"::error::created a PR for {head} -> {base} on {repo} but could not read it back"
+        )
+    return int(pr["number"])
+
+
+def sync_pr(
+    repo: str, pr: dict, title: str, body: str, body_file: str, label: str | None
+) -> str:
+    """Bring an open PR's title/body/label back in line with the branch.
+
+    Returns "updated" if anything was written, "unchanged" otherwise. The
+    no-op path matters: ``gh pr edit`` fires a ``pull_request: edited`` webhook,
+    and there is no reason to emit one on every merge to main when the bump is
+    already described correctly.
+    """
+    number = str(pr["number"])
+    changed = False
+
+    if pr.get("title") != title or _normalize(pr.get("body")) != _normalize(body):
+        _gh(
+            [
+                "gh",
+                "pr",
+                "edit",
+                number,
+                "--repo",
+                repo,
+                "--title",
+                title,
+                "--body-file",
+                body_file,
+            ],
+            f"update title/body on {repo}#{number}",
+        )
+        changed = True
+
+    if label and label not in {lbl.get("name") for lbl in pr.get("labels") or []}:
+        ensure_label_exists(repo, label)
+        _gh(
+            ["gh", "pr", "edit", number, "--repo", repo, "--add-label", label],
+            f"add label '{label}' to {repo}#{number}",
+        )
+        changed = True
+
+    return "updated" if changed else "unchanged"
+
+
+def _normalize(body: str | None) -> str:
+    """Compare bodies ignoring line-ending and trailing-whitespace noise.
+
+    GitHub returns CRLF line endings for bodies it stored from a CRLF source,
+    so a byte comparison against a locally-generated LF body would report a
+    difference on every run and edit forever.
+    """
+    if not body:
+        return ""
+    return "\n".join(
+        line.rstrip() for line in body.replace("\r\n", "\n").split("\n")
+    ).strip()
+
+
+def emit(**outputs: object) -> None:
+    lines = [f"{key}={value}" for key, value in outputs.items()]
+    out = os.environ.get("GITHUB_OUTPUT")
+    if out:
+        with open(out, "a", encoding="utf-8") as handle:
+            handle.write("\n".join(lines) + "\n")
+    else:
+        print("\n".join(lines))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo",
+        default=os.environ.get("GITHUB_REPOSITORY", ""),
+        help="owner/repo (defaults to $GITHUB_REPOSITORY)",
+    )
+    parser.add_argument("--base", required=True, help="base branch, e.g. main")
+    parser.add_argument("--head", required=True, help="bump branch to open the PR from")
+    parser.add_argument("--title", required=True, help="PR title")
+    parser.add_argument(
+        "--body-file", required=True, help="path to a file holding the PR body"
+    )
+    parser.add_argument(
+        "--label",
+        default="",
+        help="label to ensure on the PR (created if the repo lacks it). Empty to skip.",
+    )
+    args = parser.parse_args(argv)
+
+    if not args.repo:
+        parser.error("--repo is required when $GITHUB_REPOSITORY is unset")
+
+    body = Path(args.body_file).read_text(encoding="utf-8")
+    label = args.label or None
+
+    existing = find_open_pr(args.repo, args.base, args.head)
+    if existing is None:
+        number = create_pr(
+            args.repo, args.base, args.head, args.title, args.body_file, label
+        )
+        print(f"Opened {args.repo}#{number} for {args.head} -> {args.base}.")
+        emit(pr_number=number, pr_action="created")
+        return 0
+
+    action = sync_pr(args.repo, existing, args.title, body, args.body_file, label)
+    number = int(existing["number"])
+    if action == "updated":
+        print(f"Synced {args.repo}#{number} to match {args.head}: {args.title}")
+    else:
+        print(f"{args.repo}#{number} already matches {args.head}; nothing to update.")
+    emit(pr_number=number, pr_action=action)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/conformance-release.yml
+++ b/.github/workflows/conformance-release.yml
@@ -106,33 +106,29 @@ jobs:
           git commit -m "chore(conformance): release v${new_version}"
           git push origin "${BUMP_BRANCH}" --force-with-lease
 
-          existing="$(gh pr list \
-            --head "${BUMP_BRANCH}" \
+          body_file="$(mktemp)"
+          {
+            echo "Automated release PR for atlan-application-sdk-conformance v${new_version}."
+            echo
+            echo "Merging this PR triggers Publish Conformance Package, which builds"
+            echo "the wheel + sdist and publishes to PyPI, then creates the"
+            echo "conformance-v${new_version} tag."
+            echo
+            echo "## Release notes"
+            echo
+            cat /tmp/conformance-release-notes.md
+          } > "$body_file"
+
+          # Upsert rather than create-or-skip. The force-push above moves the
+          # branch to a newer version and a freshly generated release-notes
+          # block, but the previous `if` only logged that the PR existed — so a
+          # reused PR kept the *first* run's version in its title and the first
+          # run's release notes in its body. The script re-syncs both, ensures
+          # the release label, and no-ops when nothing changed.
+          python3 .github/scripts/upsert_release_pr.py \
+            --repo "${GITHUB_REPOSITORY}" \
             --base main \
-            --state open \
-            --json number \
-            --jq '.[0].number')"
-
-          if [ -n "$existing" ]; then
-            echo "PR #${existing} already exists for ${BUMP_BRANCH}; force-push updated it."
-          else
-            body_file="$(mktemp)"
-            {
-              echo "Automated release PR for atlan-application-sdk-conformance v${new_version}."
-              echo
-              echo "Merging this PR triggers Publish Conformance Package, which builds"
-              echo "the wheel + sdist and publishes to PyPI, then creates the"
-              echo "conformance-v${new_version} tag."
-              echo
-              echo "## Release notes"
-              echo
-              cat /tmp/conformance-release-notes.md
-            } > "$body_file"
-
-            gh pr create \
-              --base main \
-              --head "${BUMP_BRANCH}" \
-              --title "chore(conformance): release v${new_version}" \
-              --body-file "$body_file" \
-              --label "${RELEASE_LABEL}"
-          fi
+            --head "${BUMP_BRANCH}" \
+            --title "chore(conformance): release v${new_version}" \
+            --body-file "$body_file" \
+            --label "${RELEASE_LABEL}"

--- a/.github/workflows/contract-toolkit-release.yml
+++ b/.github/workflows/contract-toolkit-release.yml
@@ -110,33 +110,27 @@ jobs:
           git commit -m "chore(contract-toolkit): release v${new_version}"
           git push origin "${BUMP_BRANCH}" --force-with-lease
 
-          existing="$(gh pr list \
-            --head "${BUMP_BRANCH}" \
+          body_file="$(mktemp)"
+          {
+            echo "Automated release PR for app-contract-toolkit v${new_version}."
+            echo
+            echo "Merging this PR triggers Publish Contract Toolkit, which builds the"
+            echo "PKL package, publishes it under contracts/ on the gh-pages"
+            echo "branch, and creates the contract-toolkit-v${new_version} tag."
+            echo
+            echo "## Release notes"
+            echo
+            cat /tmp/contract-toolkit-release-notes.md
+          } > "$body_file"
+
+          # Upsert rather than create-or-skip — see the same block in
+          # conformance-release.yml and upsert_release_pr.py. A reused release
+          # PR otherwise advertises the version and release notes of whichever
+          # run happened to open it first.
+          python3 .github/scripts/upsert_release_pr.py \
+            --repo "${GITHUB_REPOSITORY}" \
             --base main \
-            --state open \
-            --json number \
-            --jq '.[0].number')"
-
-          if [ -n "$existing" ]; then
-            echo "PR #${existing} already exists for ${BUMP_BRANCH}; force-push updated it."
-          else
-            body_file="$(mktemp)"
-            {
-              echo "Automated release PR for app-contract-toolkit v${new_version}."
-              echo
-              echo "Merging this PR triggers Publish Contract Toolkit, which builds the"
-              echo "PKL package, publishes it under contracts/ on the gh-pages"
-              echo "branch, and creates the contract-toolkit-v${new_version} tag."
-              echo
-              echo "## Release notes"
-              echo
-              cat /tmp/contract-toolkit-release-notes.md
-            } > "$body_file"
-
-            gh pr create \
-              --base main \
-              --head "${BUMP_BRANCH}" \
-              --title "chore(contract-toolkit): release v${new_version}" \
-              --body-file "$body_file" \
-              --label "${RELEASE_LABEL}"
-          fi
+            --head "${BUMP_BRANCH}" \
+            --title "chore(contract-toolkit): release v${new_version}" \
+            --body-file "$body_file" \
+            --label "${RELEASE_LABEL}"

--- a/.github/workflows/release-version-bump.yaml
+++ b/.github/workflows/release-version-bump.yaml
@@ -179,42 +179,46 @@ jobs:
       - name: Commit and open PR
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.ORG_PAT_GITHUB }}
+          TARGET_BRANCH: ${{ inputs.target_branch }}
+          RELEASE_LABEL: ${{ inputs.release_label }}
+          CURRENT_VERSION: ${{ steps.versions.outputs.current }}
+          NEW_VERSION: ${{ steps.bump.outputs.new }}
         run: |
           set -euo pipefail
           git config --global user.name 'atlan-ci'
           git config --global user.email 'it@atlan.com'
 
-          BRANCH="bump-version-${{ inputs.target_branch }}"
+          BRANCH="bump-version-${TARGET_BRANCH}"
           git checkout -b "$BRANCH"
           git add pyproject.toml uv.lock CHANGELOG.md
-          git commit -m "chore: bump version to ${{ steps.bump.outputs.new }}"
+          git commit -m "chore: bump version to ${NEW_VERSION}"
           # --force-with-lease: safer than --force — fails if another CI run pushed
           # to this bot-owned bump branch concurrently, which is the correct behavior.
           git push origin "$BRANCH" --force-with-lease
 
-          EXISTING=$(gh pr list \
-            --head "$BRANCH" \
-            --base "${{ inputs.target_branch }}" \
-            --state open \
-            --json number \
-            --jq '.[0].number')
-
-          if [ -n "$EXISTING" ]; then
-            echo "PR #${EXISTING} already exists for ${BRANCH}, skipping creation."
-          else
-            gh label create "${{ inputs.release_label }}" \
-              --color 0e8a16 \
-              --description "Release version-bump PR" 2>/dev/null || true
-            gh pr create \
-              --base "${{ inputs.target_branch }}" \
-              --title "Bump version to ${{ steps.bump.outputs.new }}" \
-              --body "Automated version bump after merge to ${{ inputs.target_branch }}.
+          cat > "${RUNNER_TEMP}/bump-pr-body.md" <<EOF
+          Automated version bump after merge to ${TARGET_BRANCH}.
 
           This PR updates:
           - pyproject.toml
           - uv.lock
           - CHANGELOG.md
 
-          Version: ${{ steps.versions.outputs.current }} → ${{ steps.bump.outputs.new }}" \
-              --label "${{ inputs.release_label }}"
-          fi
+          Version: ${CURRENT_VERSION} → ${NEW_VERSION}
+          EOF
+
+          # Upsert rather than create-or-skip. This branch is fixed and gets
+          # force-pushed on every re-fire, so while the bump PR stays open the
+          # *content* keeps moving — an app that merges a `feat:` after a patch
+          # bump was computed ends up shipping a minor. The old `else` branch
+          # only created the PR, leaving the title and body frozen at the first
+          # run's version while the diff said something else
+          # (atlanhq/atlan-oracle-app#258). The script re-syncs title, body and
+          # the release label, and no-ops when they already match.
+          python3 .sdk-scripts/.github/scripts/upsert_release_pr.py \
+            --repo "${GITHUB_REPOSITORY}" \
+            --base "${TARGET_BRANCH}" \
+            --head "${BRANCH}" \
+            --title "Bump version to ${NEW_VERSION}" \
+            --body-file "${RUNNER_TEMP}/bump-pr-body.md" \
+            --label "${RELEASE_LABEL}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -99,25 +99,41 @@ jobs:
       - name: Commit version bump and changelog
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          TARGET_BRANCH: ${{ github.ref_name }}
         run: |
+          set -euo pipefail
           git config --global user.name 'atlan-ci'
           git config --global user.email 'it@atlan.com'
 
-          branch_name="bump-version-${{ github.ref_name }}"
-          git checkout -b $branch_name
+          branch_name="bump-version-${TARGET_BRANCH}"
+          git checkout -b "$branch_name"
 
           git add pyproject.toml uv.lock CHANGELOG.md application_sdk/version.py
-          git commit -m "chore: bump version to ${{ env.NEW_VERSION }}"
-          git push origin $branch_name --force
+          git commit -m "chore: bump version to ${NEW_VERSION}"
+          git push origin "$branch_name" --force
 
-          gh pr create --base ${{ github.ref_name }} --title "Bump version to ${{ env.NEW_VERSION }}" --body "Automated version bump after merge to main.
+          cat > "${RUNNER_TEMP}/bump-pr-body.md" <<EOF
+          Automated version bump after merge to ${TARGET_BRANCH}.
 
-            This PR updates:
-            - pyproject.toml
-            - application_sdk/version.py
-            - CHANGELOG.md
+          This PR updates:
+          - pyproject.toml
+          - uv.lock
+          - application_sdk/version.py
+          - CHANGELOG.md
 
-            Version: ${{ env.CURRENT_VERSION }} → ${{ env.NEW_VERSION }}" --label "release" || \
-            echo "PR already exists for bump-version-${{ github.ref_name }}, skipping creation."
+          Version: ${CURRENT_VERSION} → ${NEW_VERSION}
+          EOF
 
-          # gh pr merge --squash --admin
+          # Upsert rather than create-or-skip. The bump branch is fixed and
+          # force-pushed on each merge to main, so a bump PR that stays open
+          # keeps accumulating commits — and the old `|| echo "already exists"`
+          # left its title and body pinned to the first run's version while the
+          # diff moved on. See upsert_release_pr.py; it also re-attaches the
+          # `release` label, which tag-and-release.yaml gates on.
+          python3 .github/scripts/upsert_release_pr.py \
+            --repo "${GITHUB_REPOSITORY}" \
+            --base "${TARGET_BRANCH}" \
+            --head "$branch_name" \
+            --title "Bump version to ${NEW_VERSION}" \
+            --body-file "${RUNNER_TEMP}/bump-pr-body.md" \
+            --label "release"

--- a/docs/standards/release-flow.md
+++ b/docs/standards/release-flow.md
@@ -21,7 +21,18 @@ feat/fix commit merged to main
 - Analyses conventional commits since the last non-rc tag (`feat` → minor bump, `fix` → patch, `BREAKING CHANGE` / `!:` → major).
 - Updates `pyproject.toml` and regenerates `uv.lock`.
 - Prepends a new section to `CHANGELOG.md` with categorised commits.
-- Opens a PR from `bump-version-main` into `main` with the `release` label.
+- Opens a PR from `bump-version-main` into `main` with the `release` label — or, when
+  that PR is already open, re-syncs its title, body and label to the version this run
+  produced (`.github/scripts/upsert_release_pr.py`).
+
+`bump-version-main` is a *fixed* branch that is force-pushed on every merge to `main`, so
+while a bump PR sits unmerged its content keeps moving: a `feat:` merged after a patch bump
+was computed turns the pending release into a minor one. The PR must therefore be **upserted,
+not created-or-skipped**. The version the PR advertises always comes from the run that last
+touched the branch, never from the run that happened to open it.
+
+Note the tag itself is read from `pyproject.toml` in Stage 2 and never from the PR title, so
+a stale title misleads reviewers rather than mis-tagging a release.
 
 **Caller wiring** (`.github/workflows/release.yaml`):
 ```yaml


### PR DESCRIPTION
## What

Release bump PRs advertise a version that no longer matches their own diff. Reported on `atlanhq/atlan-oracle-app#258`: title and body said `0.3.1 → 0.3.2`, the diff bumped `pyproject.toml` to `0.4.0`.

## Why it happens

The bump branch is **fixed** (`bump-version-main`) and force-pushed on every re-fire, but the PR tracking it was only ever *created*. The reuse path just logged and moved on:

```sh
if [ -n "$EXISTING" ]; then
  echo "PR #${EXISTING} already exists for ${BRANCH}, skipping creation."
else
  gh pr create --title "Bump version to ${NEW}" ...
fi
```

So while a bump PR sits unmerged its content keeps moving — oracle's first run computed a patch bump, a later merge added a `feat:` that turned it into a minor — and only the files were updated.

## Impact

- **Nothing mis-shipped.** `tag-and-release.yaml` reads the version from `pyproject.toml`, never from the PR title, so the tag was always right.
- **It is a review-integrity bug.** The reviewer approving a release is shown a version number that doesn't match what merging it releases, and patch-vs-minor is exactly what they're signing off on.
- **18 of 76** currently-open bump PRs across the fleet carry a stale title (measured 2026-08-27), several off by a whole minor: `0.3.4` vs `0.4.0`, `2.1.1` vs `2.2.0`, `0.2.0` vs `1.0.0`.

## Fix

New `.github/scripts/upsert_release_pr.py` (+ 10 unit tests), called from **all four** sites that open a release PR — the same bug class was in three more places than the reported one:

| Site | Serves |
|---|---|
| `release-version-bump.yaml` | 81 app repos, all pinned `@main` |
| `release.yaml` | the SDK's own bump (`gh pr create ... \|\| echo "already exists"`) |
| `conformance-release.yml` | conformance package release |
| `contract-toolkit-release.yml` | contract-toolkit release |

Behaviour:

- **Upsert, not create-or-skip** — create when no open PR tracks the branch, otherwise edit the existing one back into agreement with it.
- **Ensures the release label on the update path too.** Previously it was applied only at creation, and `tag-and-release.yaml` gates on `contains(labels.*.name, 'release')` — an open bump PR that lost its label would merge with no tag and no GitHub Release.
- **No-ops when title and body already match**, so no spurious `pull_request: edited` on every merge to main.
- **Fails loudly** if the sync fails. The push has already landed by then, so a swallowed error reproduces this exact bug while staying green.
- Body now goes through `--body-file`, which also fixes the 12-space-indented body in the SDK's own bump PRs rendering as a Markdown code block.

Replacing the inlined `if`/`else` with a tested script is also what `docs/standards/ci.md` requires; all four steps were violating it.

> **Beyond the reported symptom:** `conformance-release.yml` and `contract-toolkit-release.yml` embed *generated release notes* in the PR body, so a reused release PR was advertising the notes of whichever run happened to open it first, not just the wrong version. Worth a look during review.

## Fleet rollout

No per-repo PRs needed — all 81 app repos call `release-version-bump.yaml@main`, so this propagates on each repo's next bump.

Because that means it goes live fleet-wide on merge, I checked the blast radius of `gh pr edit` first:

- **No app-repo workflow triggers on `pull_request: edited`.** `commits.yaml`, `checks.yml`, `conformance.yaml`, `tests.yaml`, `lint.yml` and the review agents all use `opened`/`synchronize`/`reopened`/`labeled`. No CI storm.
- **The title shape is preserved byte-identically.** `conventional_pr_title.py` exempts bump PRs by branch name *and* by the `^Bump version to ` prefix; only the version number changes.

## Deliberately not changed

`release.yaml` keeps `git push --force` rather than `--force-with-lease`. In this repo people merge `main` into the open bump PR, and a lease check turns that into a `stale info` failure on the bot's next re-fire.

## Not covered by this PR

The fix is prospective. Busy repos self-heal on their next merge to `main`; the handful of idle ones (`atlan-google-cloud-lineage-app#13`, `atlan-sdr-conformance-app#2`, …) will keep their stale titles until then. A one-off `gh pr edit` sweep of the 18 is cheap and the correct versions are known — happy to run it on request, but it's 18 outward-facing edits in other repos so it isn't bundled here.

## Testing

- `pytest .github/scripts/tests/test_upsert_release_pr.py` — 10 passed (create / sync-stale / no-op / label-re-add / empty-label / gh-failure / output paths)
- The workflow-reading cross-file guards — 229 passed
- `pre-commit run --files <changed>` — clean
- Heredoc bodies executed locally to confirm they render unindented

Linear: [FND-934](https://linear.app/atlan-epd/issue/FND-934/release-bump-prs-advertise-a-stale-version-upsert-the-pr-instead-of)
