### PR TITLE
ci(review): require preflight permission coverage for new source access

### DIFF
--- a/.mothership/review-rulesets/connector-app/MANIFEST.yaml
+++ b/.mothership/review-rulesets/connector-app/MANIFEST.yaml
@@ -15,4 +15,5 @@ rules:
   - rules/app-metadata-001.md
   - rules/app-staleness-001.md
   - rules/app-validation-001.md
+  - rules/app-preflight-001.md
   - rules/app-gates-001.md

--- a/.mothership/review-rulesets/connector-app/rules/app-preflight-001.md
+++ b/.mothership/review-rulesets/connector-app/rules/app-preflight-001.md
@@ -1,0 +1,43 @@
+---
+schema: 2
+id: APP-PREFLIGHT-001
+level: L2
+category: correctness
+globs: []
+severity: HIGH
+suppressible: false
+---
+# New source access needs preflight permission coverage
+
+A config or permission problem must be surfaced at preflight — where the
+gate reports it, and blocks for hard-mode apps — not discovered hours into
+extraction. Every new way the app reaches the source widens the grant it
+silently assumes.
+
+- TRIGGER: the diff adds or widens source access — a new API endpoint or
+  scope, a new SQL statement, system table/view or schema, a new client
+  method, a new credential/connection field the source authorizes against.
+- The app's `preflight_check` MUST verify the credential can perform that
+  access. Reaching the source only from an extraction activity, with no
+  preflight counterpart, is the finding.
+- "Already covered" is a valid answer, but MUST be stated: name the
+  existing check and why it exercises the same grant. An unnamed claim of
+  coverage IS the finding — same object, different privilege (SELECT vs
+  SHOW, read vs list, table vs view) is not coverage.
+- Weight the silent case hardest: a missing grant that returns an empty
+  result instead of erroring produces a green run with missing assets.
+  A loud mid-run auth failure is the lesser sibling — neither is
+  acceptable, but the empty one decides severity.
+- The check itself is still bound by APP-VALIDATION-001 — same oracle as
+  the real operation. A check that lists what extraction queries passes
+  while the run fails.
+- Do not review for a handler that blocks. Two separate axes: handler
+  control flow decides only the *verdict* — a required check
+  short-circuits to `NOT_READY`, an advisory one contributes `PARTIAL`.
+  Whether a `NOT_READY` verdict aborts the run is a gate property,
+  `App.preflight_gate_mode`, never the handler's. Requesting a raise or a
+  block inside the handler is the wrong fix; the missing check is the
+  finding.
+- Safe path: the check exists in the same PR, or the PR names the covering
+  check, or it states why the access needs no grant beyond one already
+  checked.

--- a/.mothership/review-rulesets/connector-app/rules/app-preflight-001.md
+++ b/.mothership/review-rulesets/connector-app/rules/app-preflight-001.md
@@ -24,6 +24,12 @@ silently assumes.
   existing check and why it exercises the same grant. An unnamed claim of
   coverage IS the finding — same object, different privilege (SELECT vs
   SHOW, read vs list, table vs view) is not coverage.
+- Ground the grant, do not guess it. Check official source documentation
+  for the exact endpoint, scope, SQL object, or client operation, and cite
+  the documented permission and its URL. If documentation is unavailable or
+  ambiguous, ask the author for an authoritative citation — never infer a
+  permission from a method or object name. Without a citation this rule
+  reports "unverified, author to confirm", not a HIGH finding.
 - Weight the silent case hardest: a missing grant that returns an empty
   result instead of erroring produces a green run with missing assets.
   A loud mid-run auth failure is the lesser sibling — neither is
@@ -31,13 +37,10 @@ silently assumes.
 - The check itself is still bound by APP-VALIDATION-001 — same oracle as
   the real operation. A check that lists what extraction queries passes
   while the run fails.
-- Do not review for a handler that blocks. Two separate axes: handler
-  control flow decides only the *verdict* — a required check
-  short-circuits to `NOT_READY`, an advisory one contributes `PARTIAL`.
-  Whether a `NOT_READY` verdict aborts the run is a gate property,
-  `App.preflight_gate_mode`, never the handler's. Requesting a raise or a
-  block inside the handler is the wrong fix; the missing check is the
-  finding.
+- Do not review for a handler that blocks. The handler returns an honest
+  `READY`, `PARTIAL`, or `NOT_READY` verdict; `App.preflight_gate_mode`
+  alone decides whether `NOT_READY` blocks. Requesting a raise or a block
+  inside the handler is the wrong fix; the missing check is the finding.
 - Safe path: the check exists in the same PR, or the PR names the covering
   check, or it states why the access needs no grant beyond one already
   checked.

--- a/.mothership/review-rulesets/connector-app/rules/app-preflight-001.md
+++ b/.mothership/review-rulesets/connector-app/rules/app-preflight-001.md
@@ -26,10 +26,11 @@ silently assumes.
   SHOW, read vs list, table vs view) is not coverage.
 - Ground the grant, do not guess it. Check official source documentation
   for the exact endpoint, scope, SQL object, or client operation, and cite
-  the documented permission and its URL. If documentation is unavailable or
-  ambiguous, ask the author for an authoritative citation — never infer a
-  permission from a method or object name. Without a citation this rule
-  reports "unverified, author to confirm", not a HIGH finding.
+  the documented permission and its URL. Never infer a permission from a
+  method or object name. If documentation is unavailable or ambiguous, do
+  not raise a finding on the guess: leave this rule `checked`, raise no
+  finding, and put the open question in the review summary — name the
+  operation and ask the author for an authoritative citation.
 - Weight the silent case hardest: a missing grant that returns an empty
   result instead of erroring produces a green run with missing assets.
   A loud mid-run auth failure is the lesser sibling — neither is


### PR DESCRIPTION
### Changelog
- Adds `APP-PREFLIGHT-001` to the connector-app review ruleset: when a diff adds or widens source access — a new API endpoint or scope, a new SQL statement / system table / schema, a new client method, a new credential field the source authorizes against — the app's `preflight_check` MUST verify the credential can perform that access.
- Registers the rule in `.mothership/review-rulesets/connector-app/MANIFEST.yaml`.

### Additional context (e.g. screenshots, logs, links)
- **Why this gap existed.** `APP-VALIDATION-001` governs whether an existing preflight check uses an honest oracle. Nothing governed *coverage* — a PR could add an entirely new way of reaching the source with no matching permission check and no rule would fire. The failure lands hours into extraction instead of at the gate.
- **"Already covered" is a valid answer, but must be stated.** The rule requires naming the covering check. Same object under a different privilege (`SELECT` vs `SHOW`, read vs list, table vs view) is not coverage, so an unnamed claim of coverage is itself the finding.
- **Severity is set by the silent case.** A missing grant that returns an empty result rather than erroring produces a green run with missing assets — that decides HIGH, not the loud mid-run auth failure. Consistent with `APP-CORRECTNESS-001` (silent loss outranks a loud crash).
- **Worded against the real gate contract.** The preflight gate is soft by default (`NOT_READY` blocks only for `preflight_gate_mode = "hard"`), so the rule says the problem is *surfaced* at preflight and blocks for hard-mode apps — not that the workflow fails there. Advisory-vs-blocking stays the app's call via handler control flow; having no check at all does not.
- **`APP-GATES-001` self-flag:** this diff touches `.mothership/review-rulesets/**`. It is additive — one new rule, no suppressions added, no rule deleted or narrowed, no required check removed.

### Checklist
- [ ] Additional tests added
- [ ] All CI checks passed
- [x] Relevant documentation updated

<!-- Verification: pre-commit run on both files passes, but every substantive hook is Python-scoped and check-yaml only covers GitHub composite-action manifests, so neither file was actually parsed by it. Separately confirmed the manifest YAML parses, all 17 listed rule paths resolve, and the new frontmatter parses with fields matching its siblings. There is no in-repo validator for these rulesets; mothership is the only consumer. -->

---

### Copyleft License Compliance

- [ ] Have you used any code that is subject to a Copyleft license (e.g., GPL, AGPL, LGPL)?
- [ ] If yes, have you modified the code in the context of this project? please share additional details.
