### PR TITLE
feat(testing): add a direct-to-task-queue workflow starter (FND-246)

### DIFF
--- a/application_sdk/testing/harness/__init__.py
+++ b/application_sdk/testing/harness/__init__.py
@@ -71,13 +71,21 @@ Module map:
     The async AE reader and the non-idempotent submit's retry, from the same
     split, plus the ``native-status`` wire types and the leaves they raise.
 ``starters``
-    Three ways to start a workflow; deliberately no shared signature.
+    Three ways to start a workflow; deliberately no shared signature. One of the
+    three is real: ``start_on_task_queue`` (FND-246) dispatches onto a Temporal
+    task queue, which is the runtime suite's first scenario and was unbuilt on
+    both sides — the Slack thread that scoped this project recorded it as already
+    existing, and ``testing/e2e/workflows.run_workflow`` is an HTTP POST to the
+    app's handler Service that never touches a queue. New work, so its tests are
+    claims rather than a differential; see the module's own note on provenance
+    below. The other two are stubs naming their child issue.
 ``teardown``
     Purge mechanics, including the batching that is a correctness bound.
 
 ``bridge``, ``waiting``, ``outcome``, ``spec``, ``budgets``, ``expectations``,
 ``identity``, ``atlas``, ``automation_engine``, ``cluster`` and ``temporal`` are
-real; the rest are typed stubs, each naming the child issue that fills it in.
+real, and so is one of ``starters``' three functions; the rest are typed stubs,
+each naming the child issue that fills it in.
 
 ``atlas`` and ``automation_engine`` are the first two that ``testing/e2e``
 actually calls: since child F, ``AEWorkflowClient`` is a set of one-line
@@ -97,6 +105,9 @@ pinned against **captured numbers** instead. ``cluster`` is the first kind — i
 retired ``testing/e2e/pods.py``, so there was an original to compare against.
 ``temporal`` is the second, and says so in its own entry above — so "pinned
 against the code they were lifted from" is not true of every module here.
+``starters``' queue dispatch is neither: there is no original anywhere, in this
+repo or the runtime suite, so its tests assert claims about the dispatch it makes
+and cannot borrow either kind of authority.
 
 ``waiting`` started as the first kind and became the second in child D, which is
 the case worth reading carefully because the change was not a choice: its pin

--- a/application_sdk/testing/harness/starters/__init__.py
+++ b/application_sdk/testing/harness/starters/__init__.py
@@ -7,124 +7,69 @@ new way to start work would widen both. As three functions, a base class simply
 calls the one it wants, and a fourth way to start work (a cluster mutation, a
 chaos injection) is a fourth function with nothing in the middle to widen.
 
-**Only one of the three exists today.** ``testing/e2e/workflows.run_workflow`` is
+**One of the three is real.** :func:`start_on_task_queue` dispatches straight
+onto a Temporal task queue (FND-246) — new work on both sides of this project,
+not a lift: nothing in this SDK or in ``atlanhq/app-runtime-test-suite`` started
+a workflow that way before, and it is the runtime suite's *first* scenario
+because everything else depends on it working. See
+:mod:`application_sdk.testing.harness.starters._queue` for the correction to the
+record that scoping it turned on.
+
+The other two are still stubs. ``testing/e2e/workflows.run_workflow`` is
 :func:`start_via_app_handler`: an HTTP ``POST /api/v1/workflows`` to the app's
-*handler Service* through an ephemeral ``kubectl port-forward``. It never touches
-a Temporal task queue. :func:`start_via_automation_engine` is the AE submit,
-lifting from ``testing/e2e/client.py``. :func:`start_on_task_queue` is **new work
-on both sides** — nothing in either repo starts a workflow by dispatching
-directly to a queue — and it is the runtime suite's *first* scenario, because
-everything else depends on it working.
+*handler Service* through an ephemeral ``kubectl port-forward``, which never
+touches a task queue. :func:`start_via_automation_engine` is the AE submit,
+lifting from ``testing/e2e/client.py``.
 
 :func:`start_via_automation_engine` lands in child G on FND-224.
 :func:`start_via_app_handler` moves with the cluster reader in child E.
-:func:`start_on_task_queue` is a separate issue, outside FND-224.
+
+Module map:
+
+``_specs``
+    The five specs and handles — three pairs, no shared base.
+``_queue``
+    :func:`start_on_task_queue`, and where its client comes from.
+``_errors``
+    The three leaves a dispatch can raise.
 """
 
 from __future__ import annotations
 
 from collections.abc import Mapping
-from dataclasses import dataclass, field
 
 from application_sdk.testing.harness._errors import HarnessNotBuiltError
-from application_sdk.testing.harness.cluster import ClusterReader, ServiceTarget
+from application_sdk.testing.harness.cluster import ClusterReader
+from application_sdk.testing.harness.starters._errors import (
+    UnusableTaskQueueError,
+    WorkflowStartConflictError,
+    WorkflowStartFailedError,
+)
+from application_sdk.testing.harness.starters._queue import start_on_task_queue
+from application_sdk.testing.harness.starters._specs import (
+    AERunHandle,
+    HttpRunHandle,
+    HttpWorkflowSpec,
+    QueueWorkflowSpec,
+    WorkflowRunHandle,
+)
 
 __all__ = [
+    # Specs and handles
     "AERunHandle",
     "HttpRunHandle",
     "HttpWorkflowSpec",
     "QueueWorkflowSpec",
     "WorkflowRunHandle",
+    # The three ways to start work
     "start_on_task_queue",
     "start_via_app_handler",
     "start_via_automation_engine",
+    # Leaves
+    "UnusableTaskQueueError",
+    "WorkflowStartConflictError",
+    "WorkflowStartFailedError",
 ]
-
-
-@dataclass(frozen=True, slots=True, kw_only=True)
-class AERunHandle:
-    """A run started through the Automation Engine.
-
-    Lives here with the other two run handles rather than in
-    :mod:`application_sdk.testing.harness.automation_engine`, where it was first
-    sketched. Child F moved the AE reader over and found no use for it: the
-    submit returns AE's run id, the slug is the caller's own, and giving that
-    pair a name inside the reader would have been a fourth vocabulary for the
-    same reading. It *is* a starter handle, and the module whose whole subject
-    is "three ways to start work, three unrelated handles" is where the third
-    one belongs.
-
-    Attributes:
-        workflow_slug: AE's slug for the workflow the run belongs to.
-        run_id: AE's identifier for this run.
-    """
-
-    workflow_slug: str
-    run_id: str
-
-
-@dataclass(frozen=True, slots=True, kw_only=True)
-class QueueWorkflowSpec:
-    """A workflow to dispatch straight onto a Temporal task queue.
-
-    Attributes:
-        workflow_type: Registered workflow type name.
-        task_queue: Queue to dispatch on. Not derived here: the derivation is
-            :func:`application_sdk.common.task_queue.derive_task_queue`, and
-            re-deriving it in the harness would add a sixth independent
-            derivation of the seam this project is trying to collapse.
-        workflow_id: Explicit workflow ID. ``None`` mints one.
-        argument: The workflow's single input argument.
-    """
-
-    workflow_type: str
-    task_queue: str
-    workflow_id: str | None = None
-    argument: Mapping[str, object] = field(default_factory=dict)
-
-
-@dataclass(frozen=True, slots=True, kw_only=True)
-class HttpWorkflowSpec:
-    """A workflow to start by calling the app's own handler Service.
-
-    Attributes:
-        target: Handler Service and port to POST to.
-        workflow_name: Workflow name the handler routes on.
-        body: Request body.
-    """
-
-    target: ServiceTarget
-    workflow_name: str
-    body: Mapping[str, object] = field(default_factory=dict)
-
-
-@dataclass(frozen=True, slots=True, kw_only=True)
-class WorkflowRunHandle:
-    """A run started directly on a task queue.
-
-    Attributes:
-        workflow_id: The workflow ID that was started.
-        run_id: Temporal's run ID for this execution.
-        task_queue: Queue it was dispatched on, echoed back so a caller can
-            assert the queue it *meant* to use is the queue it got.
-    """
-
-    workflow_id: str
-    run_id: str
-    task_queue: str
-
-
-@dataclass(frozen=True, slots=True, kw_only=True)
-class HttpRunHandle:
-    """A run started through the app's handler Service.
-
-    Attributes:
-        workflow_id: The workflow ID the handler reports. The handler's response
-            is the only identifier available on this path — there is no run ID
-            until the workflow is looked up in Temporal.
-    """
-
-    workflow_id: str
 
 
 async def start_via_automation_engine(spec: Mapping[str, object]) -> AERunHandle:
@@ -144,29 +89,6 @@ async def start_via_automation_engine(spec: Mapping[str, object]) -> AERunHandle
         message="start_via_automation_engine is not implemented yet",
         operation="start_via_automation_engine",
         reason="child G on FND-224",
-        issue="FND-224",
-        component="harness_starters",
-    )
-
-
-async def start_on_task_queue(spec: QueueWorkflowSpec) -> WorkflowRunHandle:
-    """Start a workflow by dispatching it directly onto a Temporal task queue.
-
-    Args:
-        spec: What to start, and where.
-
-    Returns:
-        The run handle.
-
-    Raises:
-        HarnessNotBuiltError: Always — new work, tracked as a separate issue
-            outside FND-224. Nothing in the SDK or the runtime suite starts a
-            workflow this way today.
-    """
-    raise HarnessNotBuiltError(
-        message="start_on_task_queue is not implemented yet",
-        operation="start_on_task_queue",
-        reason="new work on both sides, tracked as a separate issue outside FND-224",
         issue="FND-224",
         component="harness_starters",
     )

--- a/application_sdk/testing/harness/starters/_errors.py
+++ b/application_sdk/testing/harness/starters/_errors.py
@@ -1,0 +1,165 @@
+"""Typed error leaves for the workflow starters.
+
+Private module: the leaves that are public surface are re-exported from
+:mod:`application_sdk.testing.harness.starters`. Mirrors
+:mod:`application_sdk.testing.harness.temporal._errors`.
+
+Three leaves, and the split is the same shape as the reader's — with one
+difference worth being explicit about, because it is where a starter could
+plausibly have diverged from its sibling and did not.
+
+* the queue name is not one anything could ever poll
+  (:class:`UnusableTaskQueueError`), raised before a byte leaves the process;
+* the frontend accepted the dispatch and answered that this workflow id is
+  already running (:class:`WorkflowStartConflictError`);
+* everything else the dispatch could not get past
+  (:class:`WorkflowStartFailedError`).
+
+**The rule is the reader's rule, deliberately.**
+:mod:`application_sdk.testing.harness.temporal.client`'s reads are
+``DEPENDENCY_UNAVAILABLE`` for every gRPC status except the one that names a
+different fix, and the start follows it: one ``DEPENDENCY_UNAVAILABLE`` leaf
+carrying ``rpc_status``, plus one non-retryable leaf for the conflict. An
+``INVALID_ARGUMENT`` from a malformed workflow type therefore arrives in the
+same class as an ``UNAVAILABLE`` from a restarting frontend, with the status
+name on the leaf to tell them apart.
+
+That is a real trade, so here is why it is the right one. Splitting
+"request-side rejection" into its own non-retryable leaf would be more precise
+in isolation and would matter if a start sat inside a bounded wait, where
+absorbing a typo as transient burns the whole budget — the reasoning that earns
+:class:`~application_sdk.testing.harness.temporal.WorkflowNotFoundError` its own
+category. A start does not: it is a one-shot at the top of a scenario, and its
+failure is read by a person rather than classified by a poll loop. So the
+precision would buy nothing here, while a second classification rule over the
+same gRPC statuses is exactly the divergence FND-224 exists to remove. The
+status is on the leaf either way.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import ClassVar
+
+from application_sdk.errors.leaves import (
+    AlreadyExistsError,
+    DependencyUnavailableError,
+    InvalidInputError,
+)
+
+__all__ = [
+    "UnusableTaskQueueError",
+    "WorkflowStartConflictError",
+    "WorkflowStartFailedError",
+]
+
+
+@dataclass(kw_only=True)
+class UnusableTaskQueueError(InvalidInputError):
+    """The task-queue name could not name a queue any worker polls.
+
+    Raised at construction of
+    :class:`~application_sdk.testing.harness.starters.QueueWorkflowSpec`, not at
+    dispatch, because the failure mode it removes is *silence*: Temporal accepts
+    a dispatch to any well-formed queue name, so a workflow sent to an
+    unresolved ``atlan-{app_name}-{deployment_name}`` template — or to a blank
+    name — is accepted, sits unclaimed, and reports nothing until its 24-hour
+    heartbeat backstop. That is CONNECT-183, the precise failure
+    :mod:`application_sdk.common.task_queue` exists to prevent on the production
+    side; a harness that reproduced it would spend a whole scenario budget
+    learning that a template was never filled in.
+
+    ``INVALID_INPUT`` rather than ``PRECONDITION``: nothing about the cluster
+    has to change, the string handed in is wrong.
+
+    Attributes:
+        task_queue: The rejected queue name, or ``None`` when no name could be
+            derived at all. Carried verbatim — an unresolved template is only
+            diagnosable if the token is visible in the failure.
+    """
+
+    code: ClassVar[str] = "INVALID_INPUT_HARNESS_TASK_QUEUE"
+    component: str | None = "harness_starters"
+    field: str | None = "task_queue"
+    task_queue: str | None = None
+
+
+@dataclass(kw_only=True)
+class WorkflowStartConflictError(AlreadyExistsError):
+    """A run is already using this workflow id.
+
+    ``ALREADY_EXISTS`` is the category whose own definition is "the resource
+    exists and that is the problem", and ``default_retryable = False`` follows
+    from it: the id is taken until the run holding it closes, so the same
+    dispatch cannot succeed while nothing changes. The fixes are all caller-side
+    — pass a different :attr:`~QueueWorkflowSpec.workflow_id`, let the starter
+    mint one, or terminate the leftover run — which is why this is not folded
+    into :class:`WorkflowStartFailedError`.
+
+    Attributes:
+        workflow_id: The id that was already in use.
+        existing_run_id: Temporal's run id for the execution already holding it,
+            when the frontend named one. Named ``existing_`` rather than
+            ``run_id`` because :class:`~application_sdk.errors.base.AppError`
+            already carries a ``run_id`` meaning *this* app run, and a report
+            reading one for the other would send an operator to the wrong
+            execution.
+        task_queue: Queue the dispatch was aimed at.
+        temporal_namespace: Namespace the client is bound to. Named for Temporal
+            explicitly: an unqualified "namespace" beside a Kubernetes reader is
+            a genuine ambiguity.
+    """
+
+    code: ClassVar[str] = "ALREADY_EXISTS_TEMPORAL_WORKFLOW_RUN"
+    component: str | None = "harness_starters"
+    resource_type: str | None = "workflow_execution"
+    workflow_id: str | None = None
+    existing_run_id: str | None = None
+    task_queue: str | None = None
+    temporal_namespace: str | None = None
+
+
+@dataclass(kw_only=True)
+class WorkflowStartFailedError(DependencyUnavailableError):
+    """The dispatch did not come back with a started run.
+
+    ``DEPENDENCY_UNAVAILABLE`` for the reason
+    :class:`~application_sdk.testing.harness.temporal.TemporalReadFailedError`
+    is: an ``UNAVAILABLE`` from a restarting frontend or a ``DEADLINE_EXCEEDED``
+    over a VPN is neither a pass nor a regression in the thing under test. See
+    this module's docstring for why the request-side statuses arrive here too,
+    with :attr:`rpc_status` as the field that separates them.
+
+    Also raised — with no :attr:`rpc_status` — when the frontend reports a
+    *successful* start that carries no run id. That is not pedantry: without the
+    run id the caller can only ask about "the latest run of this id", so a
+    scenario that later re-dispatches, or an app that continues-as-new, would
+    grade a different execution than the one it started and never know. A handle
+    that cannot name its run is worse than a failure, because it reads as one
+    that can.
+
+    Attributes:
+        workflow_id: The id that was being dispatched.
+        task_queue: Queue the dispatch was aimed at. On the leaf because a
+            dispatch rejected for a malformed queue name is the failure this
+            field answers in one step.
+        temporal_namespace: Namespace the client is bound to.
+        address: ``host:port`` the dispatch went through, so a run pointed at
+            the wrong frontend — a stale tunnel, a kubeconfig context that was
+            not the one the cluster reads went through — is visible in the
+            failure rather than inferred.
+        rpc_status: gRPC status name the frontend returned, e.g.
+            ``"UNAVAILABLE"``. A name rather than a number because it is what
+            the reader of a report recognises, and ``None`` when no status came
+            back — either because the call failed before one did, or because the
+            call succeeded and the answer itself was unusable.
+    """
+
+    code: ClassVar[str] = "DEPENDENCY_UNAVAILABLE_TEMPORAL_START_FAILED"
+    component: str | None = "harness_starters"
+    service: str | None = "temporal"
+    workflow_id: str | None = None
+    task_queue: str | None = None
+    temporal_namespace: str | None = None
+    address: str | None = None
+    rpc_status: str | None = None

--- a/application_sdk/testing/harness/starters/_queue.py
+++ b/application_sdk/testing/harness/starters/_queue.py
@@ -1,0 +1,251 @@
+"""Dispatching a workflow straight onto a Temporal task queue (FND-246).
+
+**New work, not an extraction.** Nothing in this SDK or in
+``atlanhq/app-runtime-test-suite`` started a workflow this way before, and the
+Slack thread that scoped FND-224 was wrong about that in a way worth recording:
+it described ``testing/e2e/workflows.run_workflow`` as "a helper that puts a
+workflow straight onto a task queue". That function is an HTTP ``POST
+/api/v1/workflows`` to the app's *handler Service* through an ephemeral
+``kubectl port-forward`` — it never touches a queue, and the app's own handler
+decides the type, the id and the queue. So this leaf of the shared tree was
+unbuilt on both sides, which is why there is no original to run a differential
+against and why this module's tests are written as claims rather than as a
+comparison.
+
+**Why it is first.** The runtime scenario doc puts it at the top explicitly:
+*"Submit a workflow to the app's task queue and check it reaches Completed.
+Everything else depends on this working, so it runs first."* Every scaling,
+version-rollout and eviction scenario needs work on a queue before there is
+anything to observe, and the two paths that already exist cannot supply it — the
+AE submit needs a published DAG and an indexed slug, and the handler POST proves
+the handler works rather than that the queue does.
+
+**The mutation lives here, not on the reader.**
+:class:`~application_sdk.testing.harness.temporal.TemporalReader` is read-only by
+decision, so that no probe inside a bounded wait can change the thing it is
+measuring. This module is the other side of that decision: it takes a connection
+someone else opened and does exactly one thing with it.
+
+**A** :class:`~application_sdk.testing.harness.temporal.TemporalConnection`
+**, not a raw client.** FND-246 sketched the signature as ``client:
+TemporalClient``, which predates the reader landing (FND-247) and does not
+survive contact with it, for two reasons that point the same way. The harness
+already has a type meaning "one loop's client plus whatever transport is holding
+it up", built by the same two factories the reader is built over
+(:func:`~application_sdk.testing.harness.temporal.frontend_connection`,
+:func:`~application_sdk.testing.harness.temporal.port_forwarded_connection`); a
+starter taking the bare client would be reaching *through* that type and then
+re-deriving the namespace from the client and the address from nowhere, so its
+failures could not name the frontend they went to. And it is what keeps the
+engine out of this module's public signature — the coupling P007 is about — while
+the reader's own factories keep owning how the frontend is reached.
+
+What it deliberately does **not** take is a connection *factory*. The transport's
+lifetime stays with whoever opened it: a port-forwarded connection holds a
+``kubectl`` child process, and a one-shot function that opened its own would
+either leak that child or close a tunnel the caller's reader is still reading
+through. A caller that wants one tunnel for both hands the same connection to
+this function and to the reader's ``connect`` — and then owns closing it, since
+the reader's ``aclose`` would otherwise do it on the caller's behalf.
+
+**No correlation memo, and that is a decision.** The production start path
+stamps ``memo={"correlation_id": ...}`` so a run's logs are findable by that id.
+Omitting it is safe — ``CorrelationContext.from_temporal_memo`` answers ``None``
+for an absent memo and the app's inbound interceptor mints its own — so the only
+thing lost is the harness *choosing* the id it will later grep for. That belongs
+with evidence collection (child G, FND-243), where the id has a consumer;
+stamping one here with nothing reading it would be a field on a handle that
+means "someone might want this".
+"""
+
+from __future__ import annotations
+
+import os
+
+# P006 asks that ``temporalio`` stay behind ``execution/_temporal/``. Same
+# exception, same reasoning, and the same hand-sorted layout as
+# :mod:`application_sdk.testing.harness.temporal.client` — read the long note
+# there for both. In short: the contract is about the *worker* adapter's
+# workflow and activity API on a production path, and these two names are the
+# error types an out-of-cluster test dispatch has to catch. The adapter does not
+# offer a "start an arbitrary registered type on an arbitrary queue" verb and
+# should not grow one to satisfy a lint rule — a harness-shaped start on a
+# production path is a worse coupling than the one the rule prevents.
+#
+# The directives sit ABOVE each import rather than trailing it, and ``isort`` is
+# off across the block: a trailing directive gets wrapped onto the name line by
+# ``ruff-format`` and stops matching, and a re-sort that lifts an import out from
+# under its own comment silently un-suppresses it.
+# isort: off
+# conformance: ignore[P006] harness control-plane dispatch — see the note above
+from temporalio.exceptions import WorkflowAlreadyStartedError
+
+# conformance: ignore[P006] harness control-plane dispatch — see the note above
+from temporalio.service import RPCError
+# isort: on
+
+from application_sdk.observability.logger_adaptor import get_logger
+from application_sdk.testing.harness.identity import Minter
+from application_sdk.testing.harness.starters._errors import (
+    WorkflowStartConflictError,
+    WorkflowStartFailedError,
+)
+from application_sdk.testing.harness.starters._specs import (
+    QueueWorkflowSpec,
+    WorkflowRunHandle,
+)
+from application_sdk.testing.harness.temporal import TemporalConnection
+
+logger = get_logger(__name__)
+
+__all__ = ["start_on_task_queue"]
+
+
+async def start_on_task_queue(
+    spec: QueueWorkflowSpec,
+    *,
+    connection: TemporalConnection,
+    minter: Minter | None = None,
+) -> WorkflowRunHandle:
+    """Start a workflow by dispatching it directly onto a Temporal task queue.
+
+    Deliberately shares no signature with
+    :func:`~application_sdk.testing.harness.starters.start_via_automation_engine`
+    or
+    :func:`~application_sdk.testing.harness.starters.start_via_app_handler`:
+    different inputs, different handles, nothing in the middle to widen.
+
+    Args:
+        spec: What to start, and where. Its queue name was already validated
+            when it was constructed.
+        connection: An open connection to the frontend, on *this* event loop — a
+            ``temporalio`` client is bound to the loop that created it. Not
+            closed here: see the module docstring on why the transport's lifetime
+            stays with whoever opened it.
+        minter: Supplies the unique half of a minted workflow id, when
+            ``spec.workflow_id`` is ``None``. Injected for the reason
+            :mod:`application_sdk.testing.harness.identity` exists at all: a
+            name built from an unseeded clock is a name no test can predict, and
+            the workflow id is what a scenario later describes, grades and (on a
+            failed run) terminates. ``None`` builds one over the real clock.
+
+    Returns:
+        The run handle, carrying the workflow id, the run id of the execution
+        this call started, and the queue it was dispatched on.
+
+    Raises:
+        WorkflowStartConflictError: If a run is already using this workflow id.
+        WorkflowStartFailedError: If the dispatch failed, or succeeded without
+            naming a run.
+        BaseException: Anything that is not ``temporalio``'s own error type
+            propagates unconverted. A ``TypeError`` from a wiring bug is a bug,
+            and dressing it as a dependency failure would let a caller grading a
+            scenario read it as "Temporal was down".
+
+    Example:
+        >>> connection = await port_forwarded_connection(  # doctest: +SKIP
+        ...     target=frontend, namespace="default"
+        ... )
+        >>> handle = await start_on_task_queue(  # doctest: +SKIP
+        ...     QueueWorkflowSpec.for_deployment(
+        ...         workflow_type="HelloWorldWorkflow",
+        ...         app_name="hello-world",
+        ...         deployment_name="default",
+        ...     ),
+        ...     connection=connection,
+        ... )
+    """
+    workflow_id = spec.workflow_id or _minted_workflow_id(spec.workflow_type, minter)
+    try:
+        started = await connection.client.start_workflow(
+            spec.workflow_type,
+            args=[dict(spec.argument)],
+            id=workflow_id,
+            task_queue=spec.task_queue,
+        )
+    # conformance: ignore[E004] re-raised immediately as a typed leaf carrying the id, the queue and the frontend; logging here would report the same failure twice
+    except WorkflowAlreadyStartedError as error:
+        raise WorkflowStartConflictError(
+            message=(
+                f"Workflow id {workflow_id!r} is already in use in namespace "
+                f"{connection.namespace!r}, so nothing was dispatched onto "
+                f"{spec.task_queue}. Let the starter mint an id, pass a "
+                "different one, or terminate the run holding it"
+            ),
+            resource_identifier=workflow_id,
+            workflow_id=workflow_id,
+            existing_run_id=error.run_id,
+            task_queue=spec.task_queue,
+            temporal_namespace=connection.namespace,
+            cause=error,
+        ) from error
+    except RPCError as error:
+        raise WorkflowStartFailedError(
+            message=(
+                f"Could not dispatch {spec.workflow_type} as {workflow_id!r} "
+                f"onto {spec.task_queue} ({error.status.name})"
+            ),
+            target=spec.task_queue,
+            workflow_id=workflow_id,
+            task_queue=spec.task_queue,
+            temporal_namespace=connection.namespace,
+            address=connection.address,
+            rpc_status=error.status.name,
+            cause=error,
+        ) from error
+
+    # `result_run_id`, never `run_id`: a handle from `start_workflow` leaves
+    # `run_id` as None by documented design — it is only set by
+    # `get_workflow_handle` — so reading it would make every started run
+    # unidentifiable while the code looked right. `first_execution_run_id` is
+    # the same value for a plain start and is read as a fallback rather than as
+    # a second source of truth.
+    run_id = started.result_run_id or started.first_execution_run_id
+    if not run_id:
+        raise WorkflowStartFailedError(
+            message=(
+                f"Temporal reported {workflow_id!r} started on "
+                f"{spec.task_queue} but named no run. Without a run id every "
+                "later read describes 'the latest run of this id', which is a "
+                "different execution as soon as anything re-dispatches or "
+                "continues-as-new"
+            ),
+            target=spec.task_queue,
+            workflow_id=workflow_id,
+            task_queue=spec.task_queue,
+            temporal_namespace=connection.namespace,
+            address=connection.address,
+        )
+
+    logger.info(
+        "dispatched %s as %s run %s onto task queue %s in namespace %s",
+        spec.workflow_type,
+        workflow_id,
+        run_id,
+        spec.task_queue,
+        connection.namespace,
+    )
+    return WorkflowRunHandle(
+        workflow_id=started.id, run_id=run_id, task_queue=spec.task_queue
+    )
+
+
+def _minted_workflow_id(workflow_type: str, minter: Minter | None) -> str:
+    """Mint a workflow id for a spec that did not carry one.
+
+    The type is the prefix so a run is recognisable in the Temporal UI without
+    cross-referencing anything, and
+    :meth:`~application_sdk.testing.harness.identity.Minter.unique_suffix` is the
+    unique half — the same "clock second plus six padded random digits" the
+    ephemeral connection names use, chosen there because two parallel e2e legs
+    landing in the same second must not collide. The collision here is worse
+    than a name clash: two runs on one id means the second dispatch raises, and
+    a scenario that re-read "the latest run" would grade the wrong execution.
+
+    Only ``unique_suffix`` is used, so the ambient ``GITHUB_RUN_ID`` that
+    :meth:`~application_sdk.testing.harness.identity.Minter.from_environment`
+    reads has no effect on the result; the factory is used anyway so there is one
+    construction path for a real-clock minter rather than two.
+    """
+    resolved = Minter.from_environment(os.environ) if minter is None else minter
+    return f"{workflow_type}-{resolved.unique_suffix()}"

--- a/application_sdk/testing/harness/starters/_specs.py
+++ b/application_sdk/testing/harness/starters/_specs.py
@@ -1,0 +1,256 @@
+"""What each of the three starters takes, and what each hands back.
+
+Split out of the package ``__init__`` when the queue starter landed (FND-246),
+for the reason :mod:`application_sdk.testing.harness.temporal._states` was split
+out of *its* package init: the implementation module has to import the spec it
+takes, and a package whose ``__init__`` both defines the spec and imports the
+implementation is a cycle. Every name here is re-exported from
+:mod:`application_sdk.testing.harness.starters`, which stays the import path.
+
+Five types, three pairs, no shared base and no shared verb — see the package
+docstring for why that is the design rather than an omission.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+
+from application_sdk.common.task_queue import (
+    APP_NAME_TOKEN,
+    DEPLOYMENT_NAME_TOKEN,
+    derive_task_queue,
+)
+from application_sdk.testing.harness.cluster import ServiceTarget
+from application_sdk.testing.harness.starters._errors import UnusableTaskQueueError
+
+__all__ = [
+    "AERunHandle",
+    "HttpRunHandle",
+    "HttpWorkflowSpec",
+    "QueueWorkflowSpec",
+    "WorkflowRunHandle",
+]
+
+#: Template fragments that must not survive into a dispatched queue name. A
+#: queue still carrying one is a manifest whose tokens were never resolved, and
+#: dispatching to it is accepted by Temporal and then never claimed.
+_UNRESOLVED_TOKENS = (APP_NAME_TOKEN, DEPLOYMENT_NAME_TOKEN)
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class AERunHandle:
+    """A run started through the Automation Engine.
+
+    Lives here with the other two run handles rather than in
+    :mod:`application_sdk.testing.harness.automation_engine`, where it was first
+    sketched. Child F moved the AE reader over and found no use for it: the
+    submit returns AE's run id, the slug is the caller's own, and giving that
+    pair a name inside the reader would have been a fourth vocabulary for the
+    same reading. It *is* a starter handle, and the module whose whole subject
+    is "three ways to start work, three unrelated handles" is where the third
+    one belongs.
+
+    Attributes:
+        workflow_slug: AE's slug for the workflow the run belongs to.
+        run_id: AE's identifier for this run.
+    """
+
+    workflow_slug: str
+    run_id: str
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class QueueWorkflowSpec:
+    """A workflow to dispatch straight onto a Temporal task queue.
+
+    The queue name is **validated at construction**, and that placement is the
+    point rather than a convenience: Temporal accepts a dispatch to any
+    well-formed queue name, so an unusable one fails by silence — the execution
+    is created, nothing polls for it, and the run reports nothing until its
+    24-hour heartbeat backstop. Refusing here turns a whole spent scenario
+    budget into an immediate typed failure. See
+    :class:`~application_sdk.testing.harness.starters.UnusableTaskQueueError`.
+
+    Attributes:
+        workflow_type: Registered workflow type name. For a multi-entrypoint app
+            this is the canonical ``{app_name}:{entry_point}`` type the worker
+            registers, not a ``legacy_workflow_types`` alias.
+        task_queue: Queue to dispatch on. Not derived by this class in the
+            general case: the derivation is
+            :func:`application_sdk.common.task_queue.derive_task_queue`, and
+            re-deriving it in the harness would add a sixth independent
+            derivation of the seam this project is trying to collapse.
+            :meth:`for_deployment` is the way to *call* that derivation.
+        workflow_id: Explicit workflow ID. ``None`` mints one at dispatch — see
+            :func:`~application_sdk.testing.harness.starters.start_on_task_queue`.
+        argument: The workflow's single input argument. One argument rather than
+            a list because that is this SDK's own convention on the production
+            path (``args=[input_data]`` in
+            :mod:`application_sdk.execution._temporal.backend`), and a harness
+            that dispatched a different arity would be testing a shape no
+            deployed app is started with.
+
+    Raises:
+        UnusableTaskQueueError: If ``task_queue`` is blank or still carries an
+            unresolved ``{app_name}`` / ``{deployment_name}`` token.
+    """
+
+    workflow_type: str
+    task_queue: str
+    workflow_id: str | None = None
+    argument: Mapping[str, object] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        """Refuse a queue name nothing could poll.
+
+        Two shapes, one leaf. A blank name is a config value that never
+        resolved; a surviving template token is a manifest the contract
+        toolkit's bake did not reach (the case
+        :func:`application_sdk.common.task_queue.resolve_manifest_tokens` leaves
+        visible on purpose, precisely so it is greppable rather than filled with
+        a manufactured name).
+        """
+        if not self.task_queue.strip():
+            raise UnusableTaskQueueError(
+                message=(
+                    "A workflow cannot be dispatched onto a blank task queue. "
+                    "Derive the name with "
+                    "application_sdk.common.task_queue.derive_task_queue, or "
+                    "use QueueWorkflowSpec.for_deployment"
+                ),
+                task_queue=self.task_queue,
+                constraint="non-blank",
+            )
+        unresolved = [token for token in _UNRESOLVED_TOKENS if token in self.task_queue]
+        if unresolved:
+            raise UnusableTaskQueueError(
+                message=(
+                    f"Task queue {self.task_queue!r} still carries the "
+                    f"unresolved template token(s) {', '.join(unresolved)}. "
+                    "Temporal would accept this dispatch and no worker would "
+                    "ever claim it, so the run would report nothing until its "
+                    "24h heartbeat backstop. The served manifest this came "
+                    "from was not reached by the contract toolkit's bake — "
+                    "regenerate it, or derive the queue with "
+                    "application_sdk.common.task_queue.derive_task_queue"
+                ),
+                task_queue=self.task_queue,
+                constraint="no unresolved template tokens",
+            )
+
+    @classmethod
+    def for_deployment(
+        cls,
+        *,
+        workflow_type: str,
+        app_name: str | None,
+        deployment_name: str | None,
+        workflow_id: str | None = None,
+        argument: Mapping[str, object] | None = None,
+    ) -> QueueWorkflowSpec:
+        """Build a spec whose queue comes from the canonical derivation.
+
+        The one place the harness touches queue naming, and it touches it by
+        *calling* :func:`application_sdk.common.task_queue.derive_task_queue`
+        rather than by reproducing the rule. That distinction is the whole
+        reason this constructor exists: FND-195 collapsed five independent
+        ``atlan-{app}-{deployment}`` derivations into one, and a harness that
+        hand-built the string would be the sixth — agreeing today and diverging
+        the first time the rule changes, in the direction that fails silently
+        (AE submits to one queue, the worker polls another; CONNECT-183).
+
+        Args:
+            workflow_type: Registered workflow type name.
+            app_name: Bare app name, **without** the ``atlan-`` prefix — the
+                convention both ``ATLAN_APPLICATION_NAME`` and the contract
+                toolkit's bake use. Prefixing an already-prefixed value is how
+                DISTR-834 shipped a queue no worker polled, which is why the
+                prefix is the derivation's to add.
+            deployment_name: Deployment name. Blank counts as unset, and the
+                derivation's answer for that is a bare, unprefixed queue — the
+                same one a local worker polls.
+            workflow_id: Explicit workflow ID, or ``None`` to mint one.
+            argument: The workflow's single input argument.
+
+        Returns:
+            The spec, with :attr:`task_queue` set to the derived name.
+
+        Raises:
+            UnusableTaskQueueError: If no queue name is derivable, which happens
+                exactly when there is no app name. The derivation answers
+                ``None`` there rather than inventing a segment, and this is the
+                caller for which there is nothing sensible to do with that: a
+                dispatch needs a queue.
+        """
+        derived = derive_task_queue(app_name, deployment_name)
+        if derived is None:
+            raise UnusableTaskQueueError(
+                message=(
+                    "No task queue is derivable without an app name "
+                    f"(app_name={app_name!r}, "
+                    f"deployment_name={deployment_name!r}). Set "
+                    "ATLAN_APPLICATION_NAME on the run, or pass the app's "
+                    "registered name — derive_task_queue answers None here "
+                    "rather than manufacturing a segment, because "
+                    "'atlan-default-prod' looks entirely legitimate and no "
+                    "worker polls it"
+                ),
+                task_queue=None,
+                constraint="an app name is required",
+            )
+        return cls(
+            workflow_type=workflow_type,
+            task_queue=derived,
+            workflow_id=workflow_id,
+            argument={} if argument is None else argument,
+        )
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class HttpWorkflowSpec:
+    """A workflow to start by calling the app's own handler Service.
+
+    Attributes:
+        target: Handler Service and port to POST to.
+        workflow_name: Workflow name the handler routes on.
+        body: Request body.
+    """
+
+    target: ServiceTarget
+    workflow_name: str
+    body: Mapping[str, object] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class WorkflowRunHandle:
+    """A run started directly on a task queue.
+
+    Attributes:
+        workflow_id: The workflow ID that was started.
+        run_id: Temporal's run ID for this execution. Never absent and never
+            empty: a handle that cannot name its run can only ask about "the
+            latest run of this id", which is a different execution the moment
+            anything re-dispatches or continues-as-new. The starter raises
+            rather than hand one back — see
+            :class:`~application_sdk.testing.harness.starters.WorkflowStartFailedError`.
+        task_queue: Queue it was dispatched on, echoed back so a caller can
+            assert the queue it *meant* to use is the queue it got.
+    """
+
+    workflow_id: str
+    run_id: str
+    task_queue: str
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class HttpRunHandle:
+    """A run started through the app's handler Service.
+
+    Attributes:
+        workflow_id: The workflow ID the handler reports. The handler's response
+            is the only identifier available on this path — there is no run ID
+            until the workflow is looked up in Temporal.
+    """
+
+    workflow_id: str

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -1,8 +1,8 @@
 <!--
 generated-by:  capability-manifest skill (.claude/skills/capability-manifest)
 sdk-version:   3.29.0
-source-sha:    faf9b47620aa53af11cf7d017255c8cb5e92ae55
-source-date:   2026-08-27T02:55:32+01:00
+source-sha:    d2a955a22aa3bd7c18224814b7ad80b688368786
+source-date:   2026-08-27T13:42:01+01:00
 do-not-edit:   re-run the skill instead of hand-editing
 -->
 
@@ -34,7 +34,7 @@ do-not-edit:   re-run the skill instead of hand-editing
 | `application_sdk.server` | FastAPI server, MCP integration, middleware, health endpoint | 4 |
 | `application_sdk.storage` | Object-store abstraction — factory, formats, batch, transfer, cloud bindings | 42 |
 | `application_sdk.templates` | SQL metadata extractor templates and their contracts | 6 |
-| `application_sdk.testing` | Test infrastructure — mocks, fixtures, hypothesis strategies, integration helpers | 209 |
+| `application_sdk.testing` | Test infrastructure — mocks, fixtures, hypothesis strategies, integration helpers | 212 |
 | `application_sdk.validation` | Offline artifact & asset validation — format-agnostic wrapper (ADR-0020) plus pyatlan_v9 .validate() wrappers, no network call | 78 |
 
 ## Subpackage Details
@@ -3091,9 +3091,9 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 #### `AERunHandle`
 
 - **Import:** `from application_sdk.testing.harness.starters import AERunHandle`
-- **Signature:** `class AERunHandle(*, workflow_slug: str, run_id: str) -> None`
+- **Signature:** `class AERunHandle(*, workflow_slug: str, run_id: str)`
 - **Summary:** A run started through the Automation Engine.
-- **Defined in:** `application_sdk/testing/harness/starters/__init__.py`
+- **Defined in:** `application_sdk/testing/harness/starters/_specs.py`
 
 #### `AEWorkflowClient`
 
@@ -3432,16 +3432,16 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 #### `HttpRunHandle`
 
 - **Import:** `from application_sdk.testing.harness.starters import HttpRunHandle`
-- **Signature:** `class HttpRunHandle(*, workflow_id: str) -> None`
+- **Signature:** `class HttpRunHandle(*, workflow_id: str)`
 - **Summary:** A run started through the app's handler Service.
-- **Defined in:** `application_sdk/testing/harness/starters/__init__.py`
+- **Defined in:** `application_sdk/testing/harness/starters/_specs.py`
 
 #### `HttpWorkflowSpec`
 
 - **Import:** `from application_sdk.testing.harness.starters import HttpWorkflowSpec`
-- **Signature:** `class HttpWorkflowSpec(*, target: ServiceTarget, workflow_name: str, body: Mapping[str, object] = dict()) -> None`
+- **Signature:** `class HttpWorkflowSpec(*, target: ServiceTarget, workflow_name: str, body: Mapping[str, object] = dict())`
 - **Summary:** A workflow to start by calling the app's own handler Service.
-- **Defined in:** `application_sdk/testing/harness/starters/__init__.py`
+- **Defined in:** `application_sdk/testing/harness/starters/_specs.py`
 
 #### `Indeterminate`
 
@@ -3629,7 +3629,7 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Import:** `from application_sdk.testing.harness.starters import QueueWorkflowSpec`
 - **Signature:** `class QueueWorkflowSpec(*, ...)`
 - **Summary:** A workflow to dispatch straight onto a Temporal task queue.
-- **Defined in:** `application_sdk/testing/harness/starters/__init__.py`
+- **Defined in:** `application_sdk/testing/harness/starters/_specs.py`
 
 #### `ReferentialFailure`
 
@@ -3799,6 +3799,13 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Summary:** A reading that could not be taken.
 - **Defined in:** `application_sdk/testing/harness/expectations.py`
 
+#### `UnusableTaskQueueError`
+
+- **Import:** `from application_sdk.testing.harness.starters import UnusableTaskQueueError`
+- **Signature:** `class UnusableTaskQueueError(*, ...)`
+- **Summary:** The task-queue name could not name a queue any worker polls.
+- **Defined in:** `application_sdk/testing/harness/starters/_errors.py`
+
 #### `Verdict`
 
 - **Import:** `from application_sdk.testing.harness import Verdict`
@@ -3860,9 +3867,23 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 #### `WorkflowRunHandle`
 
 - **Import:** `from application_sdk.testing.harness.starters import WorkflowRunHandle`
-- **Signature:** `class WorkflowRunHandle(*, workflow_id: str, run_id: str, task_queue: str) -> None`
+- **Signature:** `class WorkflowRunHandle(*, workflow_id: str, run_id: str, task_queue: str)`
 - **Summary:** A run started directly on a task queue.
-- **Defined in:** `application_sdk/testing/harness/starters/__init__.py`
+- **Defined in:** `application_sdk/testing/harness/starters/_specs.py`
+
+#### `WorkflowStartConflictError`
+
+- **Import:** `from application_sdk.testing.harness.starters import WorkflowStartConflictError`
+- **Signature:** `class WorkflowStartConflictError(*, ...)`
+- **Summary:** A run is already using this workflow id.
+- **Defined in:** `application_sdk/testing/harness/starters/_errors.py`
+
+#### `WorkflowStartFailedError`
+
+- **Import:** `from application_sdk.testing.harness.starters import WorkflowStartFailedError`
+- **Signature:** `class WorkflowStartFailedError(*, ...)`
+- **Summary:** The dispatch did not come back with a started run.
+- **Defined in:** `application_sdk/testing/harness/starters/_errors.py`
 
 #### `WorkflowStatus`
 
@@ -4463,9 +4484,9 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 #### `start_on_task_queue`
 
 - **Import:** `from application_sdk.testing.harness.starters import start_on_task_queue`
-- **Signature:** `start_on_task_queue(spec: QueueWorkflowSpec) -> WorkflowRunHandle`
+- **Signature:** `start_on_task_queue(spec: QueueWorkflowSpec, *, connection: TemporalConnection, minter: Minter | None = None)`
 - **Summary:** Start a workflow by dispatching it directly onto a Temporal task queue.
-- **Defined in:** `application_sdk/testing/harness/starters/__init__.py`
+- **Defined in:** `application_sdk/testing/harness/starters/_queue.py`
 
 #### `start_via_app_handler`
 

--- a/tests/unit/testing/_temporal_fakes.py
+++ b/tests/unit/testing/_temporal_fakes.py
@@ -1,4 +1,10 @@
-"""Test doubles for the ``temporalio`` Temporal reader (FND-247).
+"""Test doubles for the ``temporalio`` Temporal reader (FND-247) and the
+direct-to-task-queue starter (FND-246).
+
+One fake serves both, and that is load-bearing rather than tidy: the starter's
+own claim is that the run it dispatched is the run a later status read describes,
+and a test that started against one double and read against another could not
+check it — the two would agree by construction.
 
 The doubles hand back **real protobuf messages and a real
 ``WorkflowExecutionDescription``**, for the reason
@@ -13,14 +19,22 @@ The narrowing needs a *real* ``RPCError`` for the same reason: the backend
 converts only ``temporalio``'s error type and lets everything else through, so a
 stub exception would let a test pass against a narrowing that had stopped
 working.
+
+The start hands back a **real** ``WorkflowHandle`` for the sharpest version of
+that reasoning. ``run_id`` on a handle built by ``start_workflow`` is ``None`` by
+documented design and ``result_run_id`` carries the started run — a stub handle
+would happily expose whichever attribute the code under test read, so the bug
+the real object catches (reading ``run_id`` and finding every started run
+unidentifiable) is invisible against a mock.
 """
 
 from __future__ import annotations
 
 import asyncio
 from collections.abc import Awaitable, Callable, Sequence
+from dataclasses import dataclass
 from datetime import datetime
-from typing import Any
+from typing import Any, cast
 
 from temporalio.api.common.v1 import WorkerVersionCapabilities
 from temporalio.api.common.v1 import WorkflowExecution as WireWorkflowExecution
@@ -34,7 +48,7 @@ from temporalio.api.workflowservice.v1 import (
     DescribeTaskQueueResponse,
     DescribeWorkflowExecutionResponse,
 )
-from temporalio.client import WorkflowExecutionDescription
+from temporalio.client import Client, WorkflowExecutionDescription, WorkflowHandle
 from temporalio.converter import DataConverter
 from temporalio.service import RPCError, RPCStatusCode
 
@@ -47,7 +61,9 @@ __all__ = [
     "FakeTemporal",
     "RPCError",
     "RPCStatusCode",
+    "connection_over",
     "describe_response",
+    "started",
     "on_a_fresh_loop",
     "poller",
     "reader_over",
@@ -150,6 +166,47 @@ async def workflow_description(
     )
 
 
+def started(
+    *,
+    workflow_id: str = "wf-1",
+    result_run_id: str | None = "run-1",
+    first_execution_run_id: str | None = None,
+) -> _Start:
+    """What a scripted ``start_workflow`` answers with.
+
+    Args:
+        workflow_id: The id the handle reports back, which the starter echoes
+            onto its own handle rather than re-using the id it sent.
+        result_run_id: The started run, where ``start_workflow`` actually puts
+            it. ``None`` exercises the answer that names no run.
+        first_execution_run_id: The fallback field, left unset by default so a
+            reader of ``result_run_id`` is the only thing that passes.
+    """
+    return _Start(
+        workflow_id=workflow_id,
+        result_run_id=result_run_id,
+        first_execution_run_id=first_execution_run_id,
+    )
+
+
+@dataclass(frozen=True)
+class _Start:
+    """A scripted start answer, turned into a real handle at call time."""
+
+    workflow_id: str
+    result_run_id: str | None
+    first_execution_run_id: str | None
+
+    def handle(self, client: Any) -> WorkflowHandle[Any, Any]:
+        """A real ``WorkflowHandle``, shaped as ``start_workflow`` builds one."""
+        return WorkflowHandle(
+            client,
+            self.workflow_id,
+            result_run_id=self.result_run_id,
+            first_execution_run_id=self.first_execution_run_id,
+        )
+
+
 class _FakeWorkflowService:
     """The one ``workflow_service`` verb the poller read calls."""
 
@@ -179,16 +236,33 @@ class _FakeHandle:
 
 
 class _FakeClient:
-    """Shaped like the parts of ``temporalio.client.Client`` a read touches."""
+    """Shaped like the parts of ``temporalio.client.Client`` a read or a start touches."""
 
-    def __init__(self, fake: FakeTemporal) -> None:
+    def __init__(self, fake: FakeTemporal, *, namespace: str = "default") -> None:
         self.workflow_service = _FakeWorkflowService(fake)
+        self.namespace = namespace
         self._fake = fake
 
     def get_workflow_handle(
         self, workflow_id: str, *, run_id: str | None = None, **_: Any
     ) -> _FakeHandle:
         return _FakeHandle(self._fake, workflow_id, run_id)
+
+    async def start_workflow(
+        self, workflow: str, **kwargs: Any
+    ) -> WorkflowHandle[Any, Any]:
+        """Record the dispatch and answer with the next scripted start.
+
+        Every keyword is recorded rather than only the ones asserted on, so a
+        test can pin what the starter did *not* send as well as what it did — an
+        ``id_reuse_policy`` or a ``memo`` appearing here is a behaviour change
+        the recorded call makes visible.
+        """
+        self._fake.calls.append(("start_workflow", workflow, kwargs))
+        answer = _answer(self._fake.next_start())
+        if isinstance(answer, _Start):
+            return answer.handle(self)
+        raise AssertionError(f"scripted start answer is not a _Start: {answer!r}")
 
 
 class FakeTemporal:
@@ -203,6 +277,10 @@ class FakeTemporal:
         pollers: What each ``describe_task_queue`` answers with, in order. A
             ``BaseException`` is raised instead of returned.
         descriptions: What each ``describe`` answers with, in order.
+        starts: What each ``start_workflow`` answers with, in order — a
+            :func:`started` answer, or a ``BaseException`` to raise. Defaults to
+            one plain successful start, so a test about the reads never has to
+            mention the starter.
     """
 
     def __init__(
@@ -210,14 +288,17 @@ class FakeTemporal:
         *,
         pollers: Sequence[Answer] = (),
         descriptions: Sequence[Answer] = (),
+        starts: Sequence[Answer] = (),
     ) -> None:
         self.calls: list[tuple[str, Any, dict[str, Any]]] = []
         self.connects: list[str] = []
         self.closes = 0
         self._pollers = list(pollers) or [describe_response()]
         self._descriptions = list(descriptions)
+        self._starts = list(starts) or [started()]
         self._poller_index = 0
         self._description_index = 0
+        self._start_index = 0
 
     # -- the connection factory --------------------------------------------
 
@@ -260,6 +341,11 @@ class FakeTemporal:
         self._poller_index += 1
         return value
 
+    def next_start(self) -> Answer:
+        value = self._starts[min(self._start_index, len(self._starts) - 1)]
+        self._start_index += 1
+        return value
+
     def next_description(self) -> Answer:
         if not self._descriptions:
             raise AssertionError("no `descriptions` were scripted for this fake")
@@ -294,6 +380,33 @@ class FakeTemporal:
 def reader_over(fake: FakeTemporal, **kwargs: Any) -> TemporalServiceReader:
     """A reader wired to *fake* instead of to a real frontend."""
     return TemporalServiceReader(connect=fake.connect(), **kwargs)
+
+
+def connection_over(
+    fake: FakeTemporal,
+    *,
+    namespace: str = "default",
+    address: str = "127.0.0.1:7233",
+) -> TemporalConnection:
+    """A :class:`TemporalConnection` wired to *fake* instead of to a frontend.
+
+    A **real** ``TemporalConnection`` around a fake client, rather than a double
+    for the connection itself: it is the type the starter takes, it is a frozen
+    dataclass with no behaviour to fake, and building the real one is what keeps
+    a test honest about which of its fields the starter actually reads.
+
+    The ``cast`` is the honest spelling of the one thing that is not real. The
+    field's type is ``temporalio``'s own ``Client``, so pyright is right that
+    this is not one; a ``Protocol`` invented to make it one would be a second
+    declaration of ``start_workflow``'s signature, free to drift from the
+    engine's.
+    """
+    return TemporalConnection(
+        client=cast(Client, _FakeClient(fake, namespace=namespace)),
+        namespace=namespace,
+        address=address,
+        close=fake._close,
+    )
 
 
 def on_a_fresh_loop(work: Callable[[], Awaitable[Any]]) -> Any:

--- a/tests/unit/testing/harness/starters/__init__.py
+++ b/tests/unit/testing/harness/starters/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for the workflow starters (FND-246)."""

--- a/tests/unit/testing/harness/starters/test_queue_starter.py
+++ b/tests/unit/testing/harness/starters/test_queue_starter.py
@@ -1,0 +1,551 @@
+"""Unit tests for the direct-to-task-queue starter (FND-246).
+
+**These are claims, not a differential.** The other harness modules were lifted
+from something — ``cluster`` retired ``testing/e2e/pods.py``, ``waiting`` came
+out of ``poll_native_status`` — so their tests could compare against an original
+on identical inputs. Nothing in this SDK or in ``atlanhq/app-runtime-test-suite``
+dispatched a workflow onto a task queue before, so there is no original and no
+authority to borrow. What that changes is where the risk sits: with no baseline,
+the tests have to state what the dispatch *should* carry, and the two that carry
+the most weight are the two a plausible implementation gets wrong.
+
+The first is the run id. ``WorkflowHandle.run_id`` is ``None`` on a handle built
+by ``start_workflow`` — documented, and only set by ``get_workflow_handle`` — so
+a starter that read it would hand back an unidentifiable run while looking
+entirely correct. The handles here are *real* ``WorkflowHandle`` objects for that
+one reason.
+
+The second is the queue name. Temporal accepts a dispatch to any well-formed
+queue, so an unresolved ``atlan-{app_name}-{deployment_name}`` template fails by
+silence — accepted, never claimed, nothing reported until a 24-hour backstop.
+That is CONNECT-183, and a harness that reproduced it would spend a whole
+scenario budget learning that a manifest was stale.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import timedelta
+
+import pytest
+from temporalio.api.enums.v1 import WorkflowExecutionStatus as WireStatus
+from temporalio.exceptions import WorkflowAlreadyStartedError
+
+from application_sdk.common.task_queue import derive_task_queue
+from application_sdk.testing.harness import Budget, Settled, poll_until
+from application_sdk.testing.harness._poll import fake_clock
+from application_sdk.testing.harness.identity import Minter
+from application_sdk.testing.harness.starters import (
+    QueueWorkflowSpec,
+    UnusableTaskQueueError,
+    WorkflowRunHandle,
+    WorkflowStartConflictError,
+    WorkflowStartFailedError,
+    start_on_task_queue,
+)
+from application_sdk.testing.harness.temporal import (
+    WorkflowExecutionStatus,
+    WorkflowStatus,
+)
+from tests.unit.testing._temporal_fakes import (
+    FakeTemporal,
+    RPCStatusCode,
+    connection_over,
+    reader_over,
+    rpc_error,
+    started,
+    workflow_description,
+)
+
+_QUEUE = "atlan-hello-world-default"
+_WIRE_COMPLETED = WireStatus.WORKFLOW_EXECUTION_STATUS_COMPLETED
+
+
+def _minter(*, second: int = 1_700_000_000, random: int = 42) -> Minter:
+    """A minter whose names are a function of its inputs, so they can be pinned."""
+    return Minter(clock=lambda: second, randbelow=lambda _bound: random)
+
+
+def _spec(
+    *,
+    workflow_type: str = "HelloWorldWorkflow",
+    task_queue: str = _QUEUE,
+    workflow_id: str | None = None,
+    argument: Mapping[str, object] | None = None,
+) -> QueueWorkflowSpec:
+    return QueueWorkflowSpec(
+        workflow_type=workflow_type,
+        task_queue=task_queue,
+        workflow_id=workflow_id,
+        argument={} if argument is None else argument,
+    )
+
+
+# ---------------------------------------------------------------------------
+# What reaches Temporal
+# ---------------------------------------------------------------------------
+
+
+async def test_the_dispatch_carries_the_spec_verbatim():
+    fake = FakeTemporal()
+
+    await start_on_task_queue(
+        _spec(workflow_id="wf-explicit", argument={"credential_guid": "abc"}),
+        connection=connection_over(fake),
+    )
+
+    verb, workflow, kwargs = fake.calls[0]
+    assert verb == "start_workflow"
+    assert workflow == "HelloWorldWorkflow"
+    assert kwargs["id"] == "wf-explicit"
+    assert kwargs["task_queue"] == _QUEUE
+
+
+async def test_the_argument_arrives_as_the_single_positional_this_sdk_starts_with():
+    """``args=[input_data]`` is what
+    :mod:`application_sdk.execution._temporal.backend` dispatches on the
+    production path, so a workflow's ``run`` takes one argument. A harness that
+    spread the mapping into several would be exercising an arity no deployed app
+    is ever started with, and would fail against every real app rather than
+    against a bug."""
+    fake = FakeTemporal()
+
+    await start_on_task_queue(
+        _spec(argument={"connection": {"connection_qualified_name": "default/x/1"}}),
+        connection=connection_over(fake),
+    )
+
+    _verb, _workflow, kwargs = fake.calls[0]
+    assert kwargs["args"] == [
+        {"connection": {"connection_qualified_name": "default/x/1"}}
+    ]
+
+
+async def test_an_absent_argument_dispatches_an_empty_mapping_not_no_argument():
+    """The arity must not depend on whether the caller had anything to say: a
+    workflow whose signature takes one argument fails to be scheduled if it is
+    dispatched with none, which would make "start with defaults" a different
+    code path from "start with a config"."""
+    fake = FakeTemporal()
+
+    await start_on_task_queue(_spec(), connection=connection_over(fake))
+
+    _verb, _workflow, kwargs = fake.calls[0]
+    assert kwargs["args"] == [{}]
+
+
+async def test_nothing_else_is_sent():
+    """Pinned so a later addition — an ``id_reuse_policy``, a ``retry_policy``,
+    a correlation ``memo`` — is a visible decision rather than a default that
+    arrived with a refactor. The memo in particular is deliberately absent: see
+    the module docstring on ``_queue``."""
+    fake = FakeTemporal()
+
+    await start_on_task_queue(_spec(), connection=connection_over(fake))
+
+    _verb, _workflow, kwargs = fake.calls[0]
+    assert set(kwargs) == {"args", "id", "task_queue"}
+
+
+# ---------------------------------------------------------------------------
+# The handle
+# ---------------------------------------------------------------------------
+
+
+async def test_the_run_id_is_the_started_run_not_the_handles_own_run_id():
+    """The bug a real ``WorkflowHandle`` exists here to catch. ``start_workflow``
+    leaves ``run_id`` unset by documented design and puts the started run on
+    ``result_run_id``, so a starter reading the obvious attribute returns a
+    handle that names no run — and every later read silently describes "the
+    latest run of this id" instead."""
+    fake = FakeTemporal(starts=[started(result_run_id="run-abc")])
+
+    handle = await start_on_task_queue(_spec(), connection=connection_over(fake))
+
+    assert handle.run_id == "run-abc"
+
+
+async def test_the_first_execution_run_id_is_the_fallback():
+    """Same value as ``result_run_id`` for a plain start, read second rather than
+    as an independent source of truth."""
+    fake = FakeTemporal(
+        starts=[started(result_run_id=None, first_execution_run_id="run-first")]
+    )
+
+    handle = await start_on_task_queue(_spec(), connection=connection_over(fake))
+
+    assert handle.run_id == "run-first"
+
+
+async def test_a_start_that_names_no_run_is_a_failure_not_a_handle():
+    """A handle whose ``run_id`` were empty would be worse than an error,
+    because it reads like one that can name its run."""
+    fake = FakeTemporal(
+        starts=[started(result_run_id=None, first_execution_run_id=None)]
+    )
+
+    with pytest.raises(WorkflowStartFailedError) as caught:
+        await start_on_task_queue(_spec(), connection=connection_over(fake))
+
+    assert caught.value.rpc_status is None
+    assert caught.value.task_queue == _QUEUE
+
+
+async def test_the_handle_echoes_the_queue_it_dispatched_on():
+    """So a scenario can assert the queue it *meant* to use is the queue it got —
+    the check that catches an ``agent_spec()`` / worker mismatch at the start
+    rather than three minutes into a wait."""
+    fake = FakeTemporal()
+
+    handle = await start_on_task_queue(_spec(), connection=connection_over(fake))
+
+    assert handle == WorkflowRunHandle(
+        workflow_id="wf-1", run_id="run-1", task_queue=_QUEUE
+    )
+
+
+async def test_the_workflow_id_comes_back_from_temporal_not_from_the_request():
+    """They agree in practice; reading Temporal's answer is what makes a
+    server-side normalisation visible rather than assumed away."""
+    fake = FakeTemporal(starts=[started(workflow_id="wf-as-temporal-has-it")])
+
+    handle = await start_on_task_queue(
+        _spec(workflow_id="wf-as-sent"), connection=connection_over(fake)
+    )
+
+    assert handle.workflow_id == "wf-as-temporal-has-it"
+
+
+# ---------------------------------------------------------------------------
+# Minting an id
+# ---------------------------------------------------------------------------
+
+
+async def test_an_absent_id_is_minted_from_the_injected_minter():
+    fake = FakeTemporal()
+
+    await start_on_task_queue(
+        _spec(),
+        connection=connection_over(fake),
+        minter=_minter(second=1_700_000_000, random=7),
+    )
+
+    _verb, _workflow, kwargs = fake.calls[0]
+    assert kwargs["id"] == "HelloWorldWorkflow-1700000000000007"
+
+
+async def test_an_explicit_id_is_used_verbatim_and_the_minter_is_not_consulted():
+    fake = FakeTemporal()
+
+    def _refuse(_bound: int) -> int:
+        raise AssertionError("the minter must not be consulted for an explicit id")
+
+    await start_on_task_queue(
+        _spec(workflow_id="wf-mine"),
+        connection=connection_over(fake),
+        minter=Minter(clock=lambda: 0, randbelow=_refuse),
+    )
+
+    _verb, _workflow, kwargs = fake.calls[0]
+    assert kwargs["id"] == "wf-mine"
+
+
+async def test_two_minted_ids_in_the_same_second_do_not_collide():
+    """The collision here is not a cosmetic name clash: two runs on one workflow
+    id means the second dispatch raises, and a scenario re-reading "the latest
+    run" would grade the wrong execution. The random half is what separates two
+    parallel e2e legs whose setup lands in the same wall-clock second."""
+    fake = FakeTemporal()
+    randoms = iter((1, 2))
+
+    minter = Minter(clock=lambda: 1_700_000_000, randbelow=lambda _b: next(randoms))
+    for _ in range(2):
+        await start_on_task_queue(
+            _spec(), connection=connection_over(fake), minter=minter
+        )
+
+    ids = [kwargs["id"] for _verb, _workflow, kwargs in fake.calls]
+    assert ids == [
+        "HelloWorldWorkflow-1700000000000001",
+        "HelloWorldWorkflow-1700000000000002",
+    ]
+
+
+async def test_a_minted_id_is_prefixed_with_the_workflow_type():
+    """So a run is recognisable in the Temporal UI without cross-referencing the
+    harness's own log."""
+    fake = FakeTemporal()
+
+    await start_on_task_queue(
+        _spec(workflow_type="hello-world:sync"),
+        connection=connection_over(fake),
+        minter=_minter(),
+    )
+
+    _verb, _workflow, kwargs = fake.calls[0]
+    assert kwargs["id"].startswith("hello-world:sync-")
+
+
+# ---------------------------------------------------------------------------
+# The queue name, refused before a byte leaves the process
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "queue",
+    [
+        "atlan-{app_name}-{deployment_name}",
+        "atlan-hello-world-{deployment_name}",
+        "{app_name}",
+    ],
+)
+def test_an_unresolved_queue_template_is_refused_at_construction(queue: str):
+    """The failure this removes is silence, so it has to happen before the
+    dispatch — Temporal would accept every one of these."""
+    with pytest.raises(UnusableTaskQueueError) as caught:
+        QueueWorkflowSpec(workflow_type="w", task_queue=queue)
+
+    assert caught.value.task_queue == queue
+    assert not caught.value.effective_retryable
+
+
+@pytest.mark.parametrize("queue", ["", "   "])
+def test_a_blank_queue_is_refused(queue: str):
+    with pytest.raises(UnusableTaskQueueError):
+        QueueWorkflowSpec(workflow_type="w", task_queue=queue)
+
+
+def test_the_refusal_names_the_token_so_a_stale_manifest_is_diagnosable():
+    """``resolve_manifest_tokens`` leaves an un-derivable queue's template
+    *visible* on purpose, precisely so it is greppable rather than filled with a
+    manufactured name. A harness failure that swallowed the token would throw
+    that away."""
+    with pytest.raises(UnusableTaskQueueError) as caught:
+        QueueWorkflowSpec(
+            workflow_type="w", task_queue="atlan-{app_name}-{deployment_name}"
+        )
+
+    assert "{app_name}" in caught.value.message
+    assert "{deployment_name}" in caught.value.message
+
+
+@pytest.mark.parametrize(
+    ("app_name", "deployment_name"),
+    [
+        ("hello-world", "default"),
+        ("hello-world", ""),
+        ("hello-world", None),
+    ],
+)
+def test_for_deployment_takes_the_queue_from_the_canonical_derivation(
+    app_name: str, deployment_name: str | None
+):
+    """Asserted *against* ``derive_task_queue`` rather than against a literal, so
+    the test cannot pass while the harness has quietly grown a sixth independent
+    derivation of the rule — which is the failure mode FND-195 collapsed and
+    CONNECT-183 was caused by."""
+    spec = QueueWorkflowSpec.for_deployment(
+        workflow_type="w", app_name=app_name, deployment_name=deployment_name
+    )
+
+    assert spec.task_queue == derive_task_queue(app_name, deployment_name)
+
+
+def test_for_deployment_does_not_pre_prefix_the_app_name():
+    """DISTR-834 shipped ``atlan-atlan-dbt-production`` by prefixing an
+    already-prefixed value. The prefix is the derivation's to add, and this pins
+    that the constructor passes the bare name through."""
+    spec = QueueWorkflowSpec.for_deployment(
+        workflow_type="w", app_name="hello-world", deployment_name="default"
+    )
+
+    assert spec.task_queue == "atlan-hello-world-default"
+
+
+@pytest.mark.parametrize("app_name", [None, "", "   "])
+def test_for_deployment_refuses_when_no_queue_is_derivable(app_name: str | None):
+    """``derive_task_queue`` answers ``None`` without an app name rather than
+    manufacturing a segment, because ``atlan-default-prod`` looks entirely
+    legitimate and no worker polls it. A dispatch has nothing to do with that
+    answer but fail."""
+    with pytest.raises(UnusableTaskQueueError) as caught:
+        QueueWorkflowSpec.for_deployment(
+            workflow_type="w", app_name=app_name, deployment_name="default"
+        )
+
+    assert caught.value.task_queue is None
+
+
+def test_for_deployment_carries_the_rest_of_the_spec_through():
+    spec = QueueWorkflowSpec.for_deployment(
+        workflow_type="w",
+        app_name="hello-world",
+        deployment_name="default",
+        workflow_id="wf-mine",
+        argument={"k": "v"},
+    )
+
+    assert (spec.workflow_type, spec.workflow_id, dict(spec.argument)) == (
+        "w",
+        "wf-mine",
+        {"k": "v"},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Failures
+# ---------------------------------------------------------------------------
+
+
+async def test_an_id_collision_is_its_own_non_retryable_leaf():
+    """The one condition whose fix is caller-side — a different id, a minted
+    one, or terminating the run holding it — so it must not arrive in the same
+    class as an unreachable frontend."""
+    fake = FakeTemporal(
+        starts=[WorkflowAlreadyStartedError("wf-1", "HelloWorldWorkflow", run_id="r0")]
+    )
+
+    with pytest.raises(WorkflowStartConflictError) as caught:
+        await start_on_task_queue(
+            _spec(workflow_id="wf-1"), connection=connection_over(fake)
+        )
+
+    assert caught.value.existing_run_id == "r0"
+    assert caught.value.workflow_id == "wf-1"
+    assert caught.value.task_queue == _QUEUE
+    assert not caught.value.effective_retryable
+
+
+@pytest.mark.parametrize(
+    "status",
+    [
+        RPCStatusCode.UNAVAILABLE,
+        RPCStatusCode.DEADLINE_EXCEEDED,
+        RPCStatusCode.INVALID_ARGUMENT,
+        RPCStatusCode.PERMISSION_DENIED,
+    ],
+)
+async def test_every_other_grpc_status_is_one_leaf_carrying_the_status(
+    status: RPCStatusCode,
+):
+    """One classification rule, the reader's rule, with the status name on the
+    leaf to tell a restarting frontend from a malformed request. See
+    ``starters/_errors.py`` for why the more precise split is declined."""
+    fake = FakeTemporal(starts=[rpc_error(status)])
+
+    with pytest.raises(WorkflowStartFailedError) as caught:
+        await start_on_task_queue(_spec(), connection=connection_over(fake))
+
+    assert caught.value.rpc_status == status.name
+    assert caught.value.task_queue == _QUEUE
+    assert caught.value.temporal_namespace == "default"
+
+
+async def test_a_wiring_bug_is_not_dressed_as_a_dependency_failure():
+    """Only ``temporalio``'s own error types are converted. A ``TypeError`` from
+    a bad call is a bug, and reporting it as ``DEPENDENCY_UNAVAILABLE`` would let
+    a caller grading a scenario record it as "Temporal was down"."""
+    fake = FakeTemporal(starts=[TypeError("start_workflow() got an unexpected kwarg")])
+
+    with pytest.raises(TypeError):
+        await start_on_task_queue(_spec(), connection=connection_over(fake))
+
+
+async def test_the_failure_names_the_queue_the_namespace_and_the_frontend():
+    """The three fields that answer the most common wedges in one step rather
+    than from a gRPC message: a well-formed queue name that refers to nothing, a
+    client bound to the wrong namespace, and a run pointed at the wrong frontend
+    through a stale tunnel. The last of the three is the reason this takes a
+    connection rather than a bare client — a client cannot name its address."""
+    fake = FakeTemporal(starts=[rpc_error(RPCStatusCode.UNAVAILABLE)])
+
+    with pytest.raises(WorkflowStartFailedError) as caught:
+        await start_on_task_queue(
+            _spec(),
+            connection=connection_over(
+                fake, namespace="prod", address="127.0.0.1:41231"
+            ),
+        )
+
+    assert caught.value.temporal_namespace == "prod"
+    assert caught.value.address == "127.0.0.1:41231"
+    assert caught.value.target == _QUEUE
+
+
+async def test_the_starter_does_not_close_the_connection_it_was_handed():
+    """The transport's lifetime belongs to whoever opened it. A port-forwarded
+    connection holds a ``kubectl`` child process, and a starter that tidied up
+    after itself would tear down the tunnel the caller's reader is still reading
+    through — which is exactly the composition the scenario below relies on."""
+    fake = FakeTemporal()
+
+    await start_on_task_queue(_spec(), connection=connection_over(fake))
+
+    assert fake.closes == 0
+
+
+# ---------------------------------------------------------------------------
+# The other half of the runtime suite's first scenario
+# ---------------------------------------------------------------------------
+
+
+async def test_the_started_run_is_the_run_the_status_reader_describes():
+    """*"Submit a workflow to the app's task queue and check it reaches
+    Completed"* is one scenario, and it is only one if the two halves agree on
+    which execution they are talking about. The starter and the reader run
+    against the same double here for that reason — separate doubles would agree
+    by construction and prove nothing.
+
+    No new symbol carries this: the issue names the waiting primitive (FND-227)
+    and the status reader (FND-247) as the "reaches Completed" half, and both
+    already exist. What this pins is that the composition is available to a
+    scenario author without a third thing in the middle."""
+    fake = FakeTemporal(
+        starts=[started(workflow_id="wf-1", result_run_id="run-1")],
+        descriptions=[
+            await workflow_description(run_id="run-1", history_length=3),
+            await workflow_description(run_id="run-1", history_length=9),
+            await workflow_description(
+                run_id="run-1",
+                status=_WIRE_COMPLETED,
+                history_length=14,
+            ),
+        ],
+    )
+    handle = await start_on_task_queue(_spec(), connection=connection_over(fake))
+    reader = reader_over(fake)
+
+    async def probe() -> WorkflowStatus:
+        return await reader.workflow_status(handle.workflow_id, run_id=handle.run_id)
+
+    with fake_clock():
+        outcome = await poll_until(
+            probe,
+            settled=lambda status: status.status is WorkflowExecutionStatus.COMPLETED,
+            fingerprint=lambda status: str(status.history_length),
+            budget=Budget(
+                timeout=timedelta(seconds=60), poll_interval=timedelta(seconds=5)
+            ),
+            label=f"workflow {handle.workflow_id} reaching Completed",
+        )
+
+    assert isinstance(outcome, Settled)
+    assert outcome.value.run_id == "run-1"
+    assert outcome.value.task_queue == _QUEUE
+    assert outcome.attempts == 3
+
+
+async def test_the_status_read_is_pinned_to_the_run_that_was_started():
+    """Not "the latest run of this id". The distinction is invisible on a healthy
+    first run and decisive the moment anything re-dispatches or
+    continues-as-new, which is exactly what the version-rollout scenarios do."""
+    fake = FakeTemporal(
+        starts=[started(result_run_id="run-1")],
+        descriptions=[await workflow_description(run_id="run-1")],
+    )
+    handle = await start_on_task_queue(_spec(), connection=connection_over(fake))
+
+    await reader_over(fake).workflow_status(handle.workflow_id, run_id=handle.run_id)
+
+    describes = [payload for verb, payload, _kwargs in fake.calls if verb == "describe"]
+    assert describes == [("wf-1", "run-1")]

--- a/tests/unit/testing/harness/test_scaffold.py
+++ b/tests/unit/testing/harness/test_scaffold.py
@@ -456,6 +456,46 @@ async def test_the_temporal_readers_are_real() -> None:
     assert callable(temporal.TemporalServiceReader.find_workflow_status)
 
 
+async def test_the_queue_starter_is_real() -> None:
+    """FND-246 filled one of ``starters``' three stubs. Asserted here for the
+    reason the temporal and cluster landings are: what belongs in the scaffold's
+    own test file is the proof that the package no longer holds a stub under this
+    name, so a revert cannot quietly restore one.
+
+    The queue name is checked here too, because the spec is where the check
+    lives and a stub restored *behind* a still-validating spec would be the
+    confusing shape — the construction would fail the same way while nothing
+    dispatched.
+    """
+    from application_sdk.testing.harness import starters
+
+    with pytest.raises(starters.UnusableTaskQueueError):
+        starters.QueueWorkflowSpec(
+            workflow_type="w", task_queue="atlan-{app_name}-{deployment_name}"
+        )
+
+    spec = starters.QueueWorkflowSpec.for_deployment(
+        workflow_type="w", app_name="hello-world", deployment_name="default"
+    )
+    assert spec.task_queue == "atlan-hello-world-default"
+
+    # Reaches a real dispatch rather than a `HarnessNotBuiltError`: the
+    # connection's client is deliberately not one, so the failure proves the stub
+    # is gone without standing up a frontend. `HarnessNotBuiltError` is a
+    # `NotImplementedError`, which `AttributeError` is not.
+    from application_sdk.testing.harness.temporal import TemporalConnection
+
+    with pytest.raises(AttributeError):
+        await starters.start_on_task_queue(
+            spec,
+            connection=TemporalConnection(
+                client=object(),  # type: ignore[arg-type]
+                namespace="default",
+                address="127.0.0.1:7233",
+            ),
+        )
+
+
 def test_the_temporal_readers_need_no_extra() -> None:
     """FND-247's amendment expected ``temporalio`` behind the ``[workflows]``
     extra, with the readers import-guarded. It is a *core* dependency since v3.1
@@ -506,9 +546,6 @@ async def test_every_remaining_stub_names_its_child_issue() -> None:
     for coro in (
         purge_connection("default/x/1"),
         starters.start_via_automation_engine({}),
-        starters.start_on_task_queue(
-            starters.QueueWorkflowSpec(workflow_type="w", task_queue="q")
-        ),
         starters.start_via_app_handler(
             starters.HttpWorkflowSpec(
                 target=ServiceTarget(namespace="ns", service="svc", port=8000),


### PR DESCRIPTION
Child of [FND-224](https://linear.app/atlan-epd/issue/FND-224). Closes [FND-246](https://linear.app/atlan-epd/issue/FND-246/add-a-direct-to-task-queue-workflow-starter). **Not stacked any more — this is a plain PR against `main`.** It was opened on `chrishehim/fnd-240` a minute before #3445 squash-merged, so GitHub retargeted the base to `main` and left the branch conflicting: the squash replaced that branch's eight commits with one, so they stopped being ancestors of `main` while this branch still carried them. Rebased with `--onto`, which drops them; the diff below is the two commits of this issue and nothing else. The chain that led here — #3439 → #3440 → #3445 — is all on `main`.

The runtime scenario doc puts this first, explicitly: *"Submit a workflow to the app's task queue and check it reaches Completed. Everything else depends on this working, so it runs first."* Every scaling, version-rollout and eviction scenario needs work on a queue before there is anything to observe, and neither existing path can supply it — the AE submit needs a published DAG and an indexed slug, and the handler POST proves the handler works rather than that the queue does.

## The correction the issue was written to record

The Slack thread that scoped FND-224 said both starters already existed: "AE-orchestrated for connectors, and a `run_workflow()` helper that puts a workflow straight onto a task queue". The second half is not accurate. `testing/e2e/workflows.run_workflow` is an HTTP `POST /api/v1/workflows` to the app's **handler Service** through an ephemeral `kubectl port-forward` — it never touches a queue, and the app's own handler picks the type, the id and the queue. Nothing in `atlanhq/app-runtime-test-suite` dispatched one either.

That has a consequence for how this PR can be trusted, and it is worth stating plainly rather than leaving to be noticed. Every other module in `harness/` is pinned by a **differential** (`cluster` retired `testing/e2e/pods.py`) or by **captured numbers** from a loop that existed (`waiting`'s golden table, `temporal`'s lift from `suite/ports/temporal.py`). This one has no original in either repo, so its tests are **claims** — they state what the dispatch should carry. `harness/__init__.py`'s provenance paragraph now says so, because "pinned against the code they were lifted from" was already not true of every module there and is least true of this one.

## `TemporalConnection`, not the `client: TemporalClient` the issue sketched

The sketch predates FND-247 landing, and it does not survive contact with it. Two reasons pointing the same way:

* The harness already has a type meaning *"one loop's client plus whatever transport is holding it up"*, built by the two factories the reader is built over (`frontend_connection`, `port_forwarded_connection`). A starter taking the bare client would be reaching **through** that type and then re-deriving the namespace from the client and the address from nowhere — so `WorkflowStartFailedError` could not name the frontend the dispatch went to. A run pointed at the wrong frontend through a stale tunnel is a failure mode the address answers in one step and a gRPC message does not.
* It keeps the engine out of the public signature. `P007` fired on the raw-`Client` version — *"Public API exposes a raw Temporal type in its signature"* — and the SDK's own type satisfies the rule rather than waiving it. Worth noting because the alternative was a suppression, and a suppression here would have been the wrong answer to a rule that was right.

What it deliberately does **not** take is a connection *factory*. The transport's lifetime stays with whoever opened it: a port-forwarded connection holds a `kubectl` child process, so a one-shot function that opened its own would either leak that child or close a tunnel the caller's reader is still reading through. `test_the_starter_does_not_close_the_connection_it_was_handed` pins that, and it is the property the composition test below relies on.

The mutation living here at all is the other half of FND-247's read-only decision: `TemporalReader` has no mutating verb so that no probe inside a bounded wait can change the thing it is measuring, and `starters` is where starting work already lived.

## The run id, which is where a plausible implementation goes wrong

`WorkflowHandle.run_id` is `None` on a handle built by `start_workflow` — documented, and only set by `get_workflow_handle`. So the obvious attribute returns a handle that names no run while the code looks entirely correct, and every later read then describes *"the latest run of this id"* instead of the run that was started. Invisible on a healthy first run; decisive the moment anything re-dispatches or continues-as-new, which is exactly what the version-rollout scenarios do.

`result_run_id` is read, with `first_execution_run_id` as a fallback rather than a second source of truth. A start that reports success and names **no** run raises rather than handing back an empty string: a handle that cannot name its run is worse than a failure, because it reads like one that can.

The test doubles hand back **real** `WorkflowHandle` objects for this one reason. A stub would expose whichever attribute the code under test happened to read, so the bug would pass against it.

## Queue naming stays where FND-195 put it

Nothing is re-derived. `QueueWorkflowSpec.for_deployment` **calls** `derive_task_queue`, and `test_for_deployment_takes_the_queue_from_the_canonical_derivation` asserts against that function rather than against a literal — so it cannot pass while the harness has quietly grown a sixth independent derivation of `atlan-{app}-{deployment}`, which is the failure FND-195 collapsed and CONNECT-183 was caused by. A second test pins that the bare name is passed through unprefixed, since DISTR-834 shipped `atlan-atlan-dbt-production` by prefixing an already-prefixed value.

Beyond that the spec **refuses** two queue names at construction:

* blank, and
* one still carrying `{app_name}` / `{deployment_name}`.

The placement is the point. Temporal accepts a dispatch to any well-formed queue name, so an unusable one fails by *silence* — the execution is created, nothing polls for it, and the run reports nothing until its 24-hour heartbeat backstop. That is CONNECT-183 reproduced inside the harness, and it would cost a whole scenario budget to learn that a manifest was stale. The refusal names the surviving token, because `resolve_manifest_tokens` leaves an un-derivable queue's template *visible* on purpose — precisely so it is greppable rather than filled with a manufactured name — and a harness failure that swallowed it would throw that away.

## Two leaves, on the reader's rule rather than a second one

* `WorkflowStartConflictError` — ALREADY_EXISTS, non-retryable. The one condition whose fixes are all caller-side (a different id, a minted one, terminating the leftover run), so it must not arrive in the same class as an unreachable frontend. Carries `existing_run_id`, named that way because `AppError` already has a `run_id` meaning *this* app run and a report reading one for the other sends an operator to the wrong execution.
* `WorkflowStartFailedError` — DEPENDENCY_UNAVAILABLE, carrying `rpc_status`, the queue, the namespace and the address.

Splitting out "request-side rejection" (`INVALID_ARGUMENT`, `PERMISSION_DENIED`) into its own non-retryable leaf was considered and **declined**, with the reasoning recorded in `starters/_errors.py` rather than left in this description. It would be more precise in isolation and would matter if a start sat inside a bounded wait, where absorbing a typo as transient burns the whole budget — that is the reasoning that earns `WorkflowNotFoundError` its own category. A start does not: it is a one-shot at the top of a scenario, read by a person rather than classified by a poll loop. So the precision buys nothing here, while a second classification rule over the same gRPC statuses is exactly the divergence FND-224 exists to remove. The status is on the leaf either way, so `INVALID_ARGUMENT` is still distinguishable from `UNAVAILABLE` in a report.

Only `temporalio`'s own error types are converted; a `TypeError` from a wiring bug propagates, because dressing it as a dependency failure would let a caller grading a scenario record it as "Temporal was down".

## The "reaches Completed" half is not a new symbol

The issue names FND-227's waiting primitive and FND-247's status reader as that half, and both already exist and already compose. So no third thing was added in the middle. What is added is the *evidence* that the composition works, and specifically that the two halves agree on **which execution** they are discussing: `test_the_started_run_is_the_run_the_status_reader_describes` starts and then polls to `Completed` against **one** double, because separate doubles would agree by construction and prove nothing. A second test pins that the read is scoped to the started run rather than to "the latest run of this id".

The shared double is why `tests/unit/testing/_temporal_fakes.py` grew the start path rather than getting a sibling.

## Smaller decisions worth not re-litigating

**No correlation memo.** The production start path stamps `memo={"correlation_id": ...}`. Omitting it is safe — `from_temporal_memo` answers `None` for an absent memo and the app's inbound interceptor mints its own — so the only thing lost is the harness *choosing* the id it will later grep for. That belongs with evidence collection (child G, FND-243), where the id has a consumer; a field on a handle meaning "someone might want this" is not worth shipping. `test_nothing_else_is_sent` pins the exact kwarg set so a later `memo`, `id_reuse_policy` or `retry_policy` is a visible decision rather than a default that arrived with a refactor.

**The minted id goes through `identity.Minter`.** `{workflow_type}-{unique_suffix()}` — the type as prefix so a run is recognisable in the Temporal UI without cross-referencing anything, and the same "clock second plus six padded random digits" the ephemeral connection names use. Injected rather than read from the clock for the reason that module exists: a name built from an unseeded clock is a name no test can predict, and here the collision is worse than a name clash — two runs on one id means the second dispatch raises, and a scenario re-reading "the latest run" grades the wrong execution.

**One argument, as a list of one.** `args=[dict(spec.argument)]`, matching `execution/_temporal/backend.py`'s production dispatch. A harness that spread a mapping into several positionals would be exercising an arity no deployed app is started with, and an absent argument still dispatches `[{}]` so "start with defaults" is not a different code path from "start with a config".

**The specs and handles moved to `starters/_specs.py`.** `_queue.py` has to import the spec it takes, and a package `__init__` that both defines the spec and imports the implementation is a cycle — the same split `temporal/_states.py` took for the same reason. `start_via_automation_engine` and `start_via_app_handler` are untouched stubs still naming children G and E, and `test_every_remaining_stub_names_its_child_issue` still covers both.

## Verification

* **Full unit suite — 8,828 passed, 9 skipped, 0 failed** (`tests/unit`), on base `b093fb82e` — re-run after the rebase, and the same count `d500f8d87` gave before it.
* **100% coverage on `application_sdk/testing/harness/`** (2,175 statements, 0 missed) — the four new/changed starter modules included, each at 100%.
* `atlan-application-sdk-conformance detect` — **258 unsuppressed findings, identical to the base's 258, and zero new live findings in any file this PR touches.** Re-measured against `main` after the rebase, unchanged. Raw SARIF totals are 566 against 564: the delta is entirely suppression-side, two `P006` directives on the `temporalio` error imports, carrying the same waiver text and the same hand-sorted `# isort: off` layout `harness/temporal/client.py` established (a trailing directive gets wrapped onto the name line by `ruff-format` and stops matching; a re-sort lifts an import out from under its own comment). The raw-versus-live split is the reading that matters here, for the reason #3445 spelled out.
  One finding was **removed by design rather than suppressed**: `P007` fired on the first revision's `client: Client` signature, and the fix was to take the SDK's own `TemporalConnection` instead of waiving it. The rule was right.
* `uv run pre-commit run` on every touched file — clean (ruff, ruff-format, isort, pyright).
* **`docs/agents/sdk-capabilities.md` regenerated** (`poe regen-capabilities`, pinned griffe 2.1.0). Beyond the three new leaves and the new signature, four specs and handles render slightly differently because they *moved*: the extractor renders a symbol defined in the module listed under `__all__` through griffe (which keeps `__init__`'s `-> None`) and a re-exported one through `inspect.signature` with the return annotation stripped. Those four now render like every other re-exported harness type already does — `ServiceTarget`, `frontend_connection` and `stale_version_pollers` have carried that shape since their own modules landed. Existing extractor behaviour on a moved definition, not drift in the tool.
* **No dependency change**: `pyproject.toml` and `uv.lock` are untouched. `temporalio` has been a core dependency since v3.1, so there is no extra to declare and nothing to import-guard — the same correction FND-247 recorded.

### Not verified here

No VPN or vcluster session was available, so the dispatch has not been run against a live Temporal frontend. What stands in for it: the doubles are real protobuf messages and a real `WorkflowHandle` built the way `start_workflow` builds one, so every field-name assumption is checked against `temporalio`'s own definitions rather than against a stub written to agree. What that cannot cover is the frontend's behaviour — whether a dispatch to a well-formed queue with no poller is accepted as silently as expected, and whether `ALREADY_EXISTS` arrives as `WorkflowAlreadyStartedError` rather than as a raw `RPCError` under this server version. The first is the premise the queue-name refusal is built on; the second would show up as a `WorkflowStartFailedError` carrying `rpc_status="ALREADY_EXISTS"` instead of the conflict leaf, which is a wrong category rather than a lost failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
