### PR TITLE
feat(testing): land the AE starter, evidence with redaction, and teardown (FND-243)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -193,3 +193,7 @@ remediation/runs/
 
 # Renovate setup
 renovate-config/README.md
+
+# CI scratch: the sdr-e2e composite writes test output, container logs and the
+# harness evidence bundle here, then uploads the directory as an artifact.
+results/

--- a/application_sdk/testing/e2e/base.py
+++ b/application_sdk/testing/e2e/base.py
@@ -53,6 +53,7 @@ from application_sdk.common.task_queue import (
     derive_task_queue,
 )
 from application_sdk.contracts.types import ConnectionRef
+from application_sdk.errors.base import safe_traceback
 from application_sdk.observability.logger_adaptor import get_logger
 from application_sdk.testing.e2e._errors import (
     DAGProgressStalledError,
@@ -89,6 +90,12 @@ from application_sdk.testing.e2e.payload import (
 )
 from application_sdk.testing.e2e.substitutions import MustacheSubstitutions
 from application_sdk.testing.harness._poll import until_deadline
+from application_sdk.testing.harness.evidence import (
+    EvidenceBundle,
+    secrets_from_environment,
+    write_bundle,
+)
+from application_sdk.testing.harness.expectations import Finding
 
 logger = get_logger(__name__)
 
@@ -457,6 +464,15 @@ class BaseE2ETest:
     # universal fields and the subclass's extra fields fall to their defaults,
     # so no ``_mustache_substitutions()`` override is needed just to add params.
     substitutions_class: ClassVar[type[MustacheSubstitutions]] = MustacheSubstitutions
+
+    # Where a failed run writes its redacted evidence bundle, relative to the
+    # pytest working directory. ``results/`` is deliberate rather than arbitrary:
+    # it is the directory the shared ``sdr-e2e`` composite already points
+    # ``upload-artifact`` at, so a bundle written here becomes a CI artifact with
+    # no workflow change and lands beside the container log that action dumps.
+    # A suite running outside that action gets a local directory and the same
+    # files. Set to "" to write nothing.
+    evidence_dir: ClassVar[str] = "results/e2e-evidence"
 
     ae_poll_interval_seconds: ClassVar[int] = 10
     ae_poll_timeout_seconds: ClassVar[int] = 600
@@ -2470,7 +2486,31 @@ class BaseE2ETest:
         # here, under this test's own ephemeral QN so teardown purges it.
         self.seed_prerequisites()
 
-        outcome = self.run_full_dag()
+        # One wrapper around the run and the whole assertion ladder, rather than
+        # a collection call at each of the six exits. The exits are what a
+        # future assertion is added *between*, and an evidence hook per exit is
+        # one a new assertion silently does not get.
+        outcome: FullDAGOutcome | None = None
+        try:
+            outcome = self.run_full_dag()
+            self._assert_full_dag_outcome(outcome)
+        # conformance: ignore[E004] re-raised unchanged on the next line; this collects evidence for a failure it does not handle, and swallowing it would replace a real verdict with a green run
+        except Exception as failure:
+            self._collect_failure_evidence(failure, outcome)
+            raise
+
+    def _assert_full_dag_outcome(self, outcome: FullDAGOutcome) -> None:
+        """The assertion ladder, split out so one wrapper can cover all of it.
+
+        Args:
+            outcome: What the run produced.
+
+        Raises:
+            AssertionError: On the first unmet expectation, in the documented
+                order. Split from :meth:`test_full_dag_runs_end_to_end` purely so
+                the evidence wrapper there has one body to guard; the sequence
+                and the messages are unchanged.
+        """
         # The Connection clause only applies to an entrypoint that publishes
         # inventory. With expect_connection False the Atlas probes never ran, so
         # consulting connection_in_atlas here would fail every such run.
@@ -2538,3 +2578,140 @@ class BaseE2ETest:
                 "lineage-app + lineage-publish nodes reported success but "
                 "no lineage rows reached Atlas."
             )
+
+    # ------------------------------------------------------------------
+    # Evidence
+    # ------------------------------------------------------------------
+
+    def _collect_failure_evidence(
+        self, failure: BaseException, outcome: FullDAGOutcome | None
+    ) -> None:
+        """Write a redacted evidence bundle for a failed run.
+
+        Called on every path out of :meth:`test_full_dag_runs_end_to_end` that is
+        not a pass, including the ones where ``run_full_dag`` itself raised and
+        there is no outcome to describe — which are the runs that most need the
+        AE identity recorded somewhere a person can find it after the job is
+        gone.
+
+        Best-effort by construction, and that is not a hedge: this runs inside an
+        ``except`` block whose job is to re-raise a real verdict. A collector
+        that raised here would replace the failure being diagnosed with its own,
+        which is the exact miscue :meth:`teardown_method` is written to avoid.
+
+        **No pod logs on this path, and that is not an omission.** The connector
+        CI leg has no ``kubectl`` route into the tenant vcluster — that is the
+        same constraint that makes the AE submit the only tenant-facing probe of
+        the installed app pod — so the pod half of an evidence bundle is not
+        collectable from here. The container that *is* local is dumped by the CI
+        action into the same ``results/`` directory this writes into
+        (``sdr-container.log``), so the two land in one artifact.
+
+        Args:
+            failure: What went wrong. Its formatted traceback is written as an
+                artifact, secret-redacted like everything else.
+            outcome: The run's outcome when there was one, else ``None``.
+        """
+        if not self.evidence_dir:
+            return
+        try:
+            bundle = self._failure_evidence(failure, outcome)
+            written = write_bundle(
+                bundle,
+                Path(self.evidence_dir) / type(self).__name__,
+                secrets=secrets_from_environment(
+                    os.environ,
+                    # Not credential-shaped by name and not a credential by
+                    # value, but a tenant hostname identifies a customer
+                    # environment and this bundle is uploaded and retained.
+                    also=("ATLAN_BASE_URL",),
+                ),
+            )
+            if written:
+                logger.info(
+                    "e2e evidence: wrote %d file(s) under %s",
+                    len(written),
+                    Path(self.evidence_dir) / type(self).__name__,
+                )
+        # conformance: ignore[E004] evidence boundary — this runs inside an except block re-raising the real verdict, and a collector failure must never replace it
+        except Exception:
+            logger.warning(
+                "e2e evidence: could not write the failure bundle — the run's own "
+                "verdict is unaffected",
+                exc_info=True,
+            )
+
+    def _failure_evidence(
+        self, failure: BaseException, outcome: FullDAGOutcome | None
+    ) -> EvidenceBundle:
+        """Build the bundle for *failure*, from whatever the run got as far as.
+
+        Args:
+            failure: What went wrong.
+            outcome: The run's outcome when there was one, else ``None``.
+
+        Returns:
+            The bundle, unredacted — redaction is :func:`write_bundle`'s, at the
+            boundary that ships it.
+        """
+        findings = [
+            Finding(
+                subject=type(failure).__name__,
+                detail=str(failure),
+                expectation="full-dag e2e",
+            )
+        ]
+        readings: dict[str, object] = {
+            "connector": self.connector_short_name,
+            "entrypoint": self._resolved_entrypoint(),
+            "mode": self.mode.value,
+            "run_id": self.run_id,
+            "connection_qualified_name": getattr(self, "connection_qualified_name", ""),
+            "extract_task_queue": self._extract_task_queue(),
+            "seed_version": self._seed_version,
+        }
+        if outcome is not None:
+            ae_result = outcome.ae_result
+            readings.update(
+                {
+                    "ae_run_id": ae_result.run_id,
+                    "ae_workflow_slug": ae_result.workflow_slug,
+                    "ae_status": ae_result.status.value,
+                    # The per-node table is the single most-read part of a failed
+                    # leg, so it goes in the machine-readable half rather than
+                    # only into the rendered text below.
+                    "dag_nodes": [
+                        {
+                            "name": node.name,
+                            "status": node.status.value,
+                            "error_message": node.error_message,
+                            "duration_seconds": node.duration_seconds,
+                            # The queue the *seed* asked for, not a guarantee of
+                            # what ran — Heracles re-fetches the tenant's own
+                            # manifest at submit. See :class:`NodeDispatch`.
+                            "dispatch_requested_to": (
+                                dispatch.task_queue
+                                if (dispatch := self._node_dispatch.get(node.name))
+                                else None
+                            ),
+                        }
+                        for node in ae_result.nodes
+                    ],
+                    "connection_in_atlas": outcome.connection_in_atlas,
+                    "asset_counts": dict(outcome.asset_counts),
+                    "total_assets": outcome.total_assets,
+                    "lineage_present": outcome.lineage_present,
+                }
+            )
+        artifacts = {"traceback.txt": safe_traceback(failure)}
+        if outcome is not None:
+            artifacts["dag-nodes.txt"] = (
+                f"{self._dag_outcome_headline(outcome.ae_result)}\n"
+                f"{self._describe_dag_nodes(outcome.ae_result)}"
+            )
+        return EvidenceBundle(
+            label=f"{type(self).__name__} — {self.connector_short_name}",
+            findings=tuple(findings),
+            readings=readings,
+            artifacts=artifacts,
+        )

--- a/application_sdk/testing/harness/__init__.py
+++ b/application_sdk/testing/harness/__init__.py
@@ -43,7 +43,12 @@ Module map:
 ``expectations``
     The two pure evaluators — asset counts and qualified-name locations.
 ``evidence``
-    Evidence bundle collection, and redaction at the boundary that ships it.
+    Evidence bundle collection, and redaction at the boundary that ships it —
+    two filters, because key-name matching alone cannot see a value a driver
+    echoed back with no key beside it. Child G (FND-243); wired into the
+    connector failure path, which writes into the directory the shared CI
+    composite already uploads, so a failed leg leaves a redacted bundle behind
+    with no workflow change.
 ``spec``
     ``AppUnderTest`` — where to find the app under test in a cluster.
 ``cluster``
@@ -71,21 +76,28 @@ Module map:
     The async AE reader and the non-idempotent submit's retry, from the same
     split, plus the ``native-status`` wire types and the leaves they raise.
 ``starters``
-    Three ways to start a workflow; deliberately no shared signature. One of the
-    three is real: ``start_on_task_queue`` (FND-246) dispatches onto a Temporal
-    task queue, which is the runtime suite's first scenario and was unbuilt on
-    both sides — the Slack thread that scoped this project recorded it as already
-    existing, and ``testing/e2e/workflows.run_workflow`` is an HTTP POST to the
-    app's handler Service that never touches a queue. New work, so its tests are
-    claims rather than a differential; see the module's own note on provenance
-    below. The other two are stubs naming their child issue.
+    Three ways to start a workflow; deliberately no shared signature. Two of the
+    three are real, and they are real in different ways. ``start_on_task_queue``
+    (FND-246) dispatches onto a Temporal task queue — the runtime suite's first
+    scenario, and unbuilt on both sides: the Slack thread that scoped this
+    project recorded it as already existing, and
+    ``testing/e2e/workflows.run_workflow`` is an HTTP POST to the app's handler
+    Service that never touches a queue. New work, so its tests are claims rather
+    than a differential; see the module's own note on provenance below.
+    ``start_via_automation_engine`` (child G, FND-243) is the opposite: a plain
+    lift of ``_bootstrap_workflow`` plus the submit half of ``run_full_dag``,
+    with an original to be pinned against. ``start_via_app_handler`` is still a
+    stub, naming child E.
 ``teardown``
-    Purge mechanics, including the batching that is a correctness bound.
+    Purge mechanics (child G, FND-243), including the batching that is a
+    correctness bound and the read-everything-before-deleting order that an
+    offset-paginated search makes mandatory.
 
 ``bridge``, ``waiting``, ``outcome``, ``spec``, ``budgets``, ``expectations``,
-``identity``, ``atlas``, ``automation_engine``, ``cluster`` and ``temporal`` are
-real, and so is one of ``starters``' three functions; the rest are typed stubs,
-each naming the child issue that fills it in.
+``identity``, ``atlas``, ``automation_engine``, ``cluster``, ``temporal``,
+``evidence`` and ``teardown`` are real, and so are two of ``starters``' three
+functions; the rest are typed stubs, each naming the child issue that fills it
+in.
 
 ``atlas`` and ``automation_engine`` are the first two that ``testing/e2e``
 actually calls: since child F, ``AEWorkflowClient`` is a set of one-line

--- a/application_sdk/testing/harness/evidence.py
+++ b/application_sdk/testing/harness/evidence.py
@@ -372,6 +372,14 @@ def write_bundle(
     relative path. Split rather than one blob because that is how they are read:
     a person opens one container's log, a script parses the report.
 
+    **Every file is UTF-8**, unconditionally and regardless of the writing
+    machine's locale — so anything reading one back must say so rather than
+    relying on the platform default, which is cp1252 on Windows. Worth stating
+    as a contract rather than leaving as an implementation detail: a bundle
+    routinely carries a connector name, a driver's error message and a pod's log
+    line, and a reader that decodes those with the wrong codec produces mojibake
+    in the one artefact whose whole job is to be trusted after the fact.
+
     Args:
         bundle: What to write.
         output_dir: Directory to write into. Created if absent.

--- a/application_sdk/testing/harness/evidence.py
+++ b/application_sdk/testing/harness/evidence.py
@@ -11,20 +11,151 @@ tenant hostname) and evidence is the one thing here that is *designed* to leave
 the process. Redaction therefore happens at this boundary, not by withholding
 fields from the types upstream: withholding makes the domain objects harder to
 debug locally while still leaking anything a future field forgets to withhold.
+:func:`write_bundle` redacts unconditionally, so there is no ordering a caller
+can get wrong.
 
-Implementation, and wiring it into the connector failure path, is child G on
-FND-224.
+**Two filters, because one of them cannot see enough.**
+
+*By key name.* A credential in structured data is a value under a
+credential-shaped key, so :data:`SECRET_KEY_FRAGMENTS` is matched as a
+case-insensitive substring of the key and the value is replaced wholesale. In
+text this is the ``key=value`` / ``key: value`` / ``"key": "value"`` forms, all
+three of which appear in the same container log.
+
+*By literal value.* The prior art in this repo is explicit about why the first
+filter is not enough on its own: ``resolve_e2e_tenant.py`` and
+``export_extra_env.py`` both run a two-pass ``--mask-only`` protocol precisely
+because registering a blob as a secret does not redact the values *inside* it.
+A token that a driver echoed back with no key beside it — in a URL path, in an
+exception message, as a bare header dump — is invisible to key matching. So
+:func:`redact` also takes the literal values the run is holding and blanks them
+wherever they appear. A caller that has the API key should pass it.
+
+**Over-redaction is the intended failure direction, with exactly one exception.**
+:func:`~application_sdk.errors.base.redact_secrets` — which this module also
+applies, for URL userinfo — argues the opposite for ``uid``: it is a user name,
+not a credential, and dropping it removes "which account failed to log in" from
+every auth failure. That reasoning holds *there*, on an error message whose
+blast radius is one string an on-call reads. It does not transfer here, where the
+output is uploaded and retained. So the fragment list is broad, and the one
+deliberate omission is a bare ``auth``: it would take ``auth_type`` with it, and
+``auth_type`` is the field that says which credential shape a connector was
+configured for — the first thing read on a credential-routing failure.
+``authorization`` and ``auth_token`` are matched explicitly instead.
+
+**A collector may fail open. Nothing else here may.** The ban on
+empty-result-on-error (FND-224's C4) is about readings that get *graded*: an
+unreadable count must not be scored as a low count. An evidence dump is never
+graded — it is read after the verdict — so a collector that raised would turn a
+diagnosable failure into an undiagnosable one. Every collection failure is
+logged and the rest of the collection still runs. Redaction is the opposite: it
+has no failure mode that is allowed to pass content through, so it is pure and
+total.
+
+**What this module does not do is decide when to collect.** A bundle is built by
+whoever knows the run failed. On the connector path that is the e2e base class,
+which writes into a directory the CI job already uploads — no workflow change,
+because ``results/`` is the path ``upload-artifact`` is already pointed at.
 """
 
 from __future__ import annotations
 
+import asyncio
+import re
 from collections.abc import Mapping, Sequence
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
+from pathlib import Path
 
-from application_sdk.testing.harness._errors import HarnessNotBuiltError
+import orjson
+
+from application_sdk.errors.base import redact_secrets
+from application_sdk.observability.logger_adaptor import get_logger
+from application_sdk.testing.harness.cluster.kube import KubernetesReader
 from application_sdk.testing.harness.expectations import Finding
 
-__all__ = ["EvidenceBundle", "redact"]
+logger = get_logger(__name__)
+
+__all__ = [
+    "PLACEHOLDER",
+    "SECRET_KEY_FRAGMENTS",
+    "EvidenceBundle",
+    "collect_pod_evidence",
+    "redact",
+    "redact_text",
+    "secrets_from_environment",
+    "write_bundle",
+]
+
+#: What a redacted value is replaced with. Matches
+#: :func:`~application_sdk.errors.base.redact_secrets`, so a string that passed
+#: through both carries one marker rather than two spellings of it.
+PLACEHOLDER = "***"
+
+#: Key-name substrings that make a value credential-shaped, matched
+#: case-insensitively. Substrings rather than whole words so ``x-api-key``,
+#: ``AWS_SECRET_ACCESS_KEY`` and ``clientSecret`` all hit without an entry each.
+#: See the module docstring for why a bare ``auth`` is deliberately absent.
+SECRET_KEY_FRAGMENTS: tuple[str, ...] = (
+    "access_key",
+    "accesskey",
+    "api_key",
+    "api-key",
+    "apikey",
+    "authorization",
+    "auth_token",
+    "certificate",
+    "client_secret",
+    "clientsecret",
+    "cookie",
+    "credential",
+    "passphrase",
+    "passwd",
+    "password",
+    "private_key",
+    "privatekey",
+    "pwd",
+    "secret",
+    "session_id",
+    "signature",
+    "token",
+)
+
+#: Shortest literal value worth blanking. A one- or two-character "secret" is
+#: either not one or is a substring of half the log, and blanking it would
+#: destroy the evidence to protect nothing. Three is where a value starts being
+#: specific enough that its appearance is not a coincidence.
+_MIN_LITERAL_LENGTH = 3
+
+#: HTTP authentication schemes whose *next* token is the credential. Without
+#: these, ``Authorization: Bearer eyJ...`` redacts the word ``Bearer`` and ships
+#: the token — the value class below stops at the first space, which is right for
+#: everything else and exactly wrong here.
+_AUTH_SCHEMES = ("Basic", "Bearer", "Digest", "Negotiate", "Token", "APIKey")
+
+#: ``key=value``, ``key: value`` and ``"key": "value"``. Three notes, each of
+#: which is a bug that was there before it:
+#:
+#: * The key is anchored on a non-word character (or the start), so ``run_id=``
+#:   is not matched by a fragment that is a substring of ``id`` and an operator
+#:   keeps the correlation ids a report is navigated by.
+#: * The separator absorbs a closing quote, so the JSON form is covered by the
+#:   same pattern as the bare one. They appear in the same container log.
+#: * The value stops at whitespace or a separator so the *next* pair in a
+#:   connection string stays readable, with three exceptions consumed whole: a
+#:   quoted value, an ODBC ``{braced}`` one whose ``;`` would otherwise end the
+#:   match early, and an auth scheme plus its token.
+#:
+#: The key's surrounding classes are bounded rather than ``*`` so the pattern
+#: cannot backtrack quadratically over a long unbroken run of word characters —
+#: a container log is exactly where one turns up.
+_KEYED_VALUE_RE = re.compile(
+    r"(?i)(?<![\w-])([\w.-]{0,64}(?:"
+    + "|".join(re.escape(fragment) for fragment in SECRET_KEY_FRAGMENTS)
+    + r")[\w.-]{0,64})([\"']?\s*[:=]\s*)"
+    + r"(\"[^\"]*\"|'[^']*'|\{[^}]*\}|(?:"
+    + "|".join(_AUTH_SCHEMES)
+    + r")\s+\S+|[^\s,;&#]+)"
+)
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)
@@ -50,24 +181,408 @@ class EvidenceBundle:
     artifacts: Mapping[str, str] = field(default_factory=dict)
 
 
-def redact(bundle: EvidenceBundle) -> EvidenceBundle:
+def redact_text(text: str, *, secrets: Sequence[str] = ()) -> str:
+    """Return *text* with credential-shaped and literally-known values blanked.
+
+    Three passes, in the order that matters: literal values first (they may sit
+    inside something a later pass would only partially rewrite), then the
+    keyed-value forms, then
+    :func:`~application_sdk.errors.base.redact_secrets` for URL userinfo and the
+    SDK's own secret query-params.
+
+    Args:
+        text: The text to sanitise.
+        secrets: Literal values to blank wherever they appear, regardless of
+            what surrounds them. Values shorter than three characters are
+            ignored — see :data:`_MIN_LITERAL_LENGTH`.
+
+    Returns:
+        The sanitised text. Idempotent: :data:`PLACEHOLDER` contains no key
+        fragment and no literal, so redacting twice changes nothing.
+    """
+    for literal in secrets:
+        if len(literal) >= _MIN_LITERAL_LENGTH:
+            text = text.replace(literal, PLACEHOLDER)
+    text = _KEYED_VALUE_RE.sub(_blank_keyed_value, text)
+    return redact_secrets(text)
+
+
+def _blank_keyed_value(match: re.Match[str]) -> str:
+    """Replace a matched value, keeping the quotes that made it a JSON string.
+
+    A quoted value comes back quoted. Without that, redacting an artifact that
+    happens to be JSON produces ``"apiKey": ***``, which no longer parses — and
+    a bundle whose machine-readable half stopped being machine-readable at the
+    redaction step is a strictly worse artefact than one with a masked value in
+    it.
+    """
+    key, separator, value = match.groups()
+    quoted = len(value) >= 2 and value[0] == value[-1] and value[0] in "\"'"
+    blanked = f"{value[0]}{PLACEHOLDER}{value[0]}" if quoted else PLACEHOLDER
+    return f"{key}{separator}{blanked}"
+
+
+def redact(bundle: EvidenceBundle, *, secrets: Sequence[str] = ()) -> EvidenceBundle:
     """Return *bundle* with credential-shaped values replaced by placeholders.
 
     Args:
         bundle: The bundle to sanitise.
+        secrets: Literal values to blank wherever they appear. The API key, the
+            source credentials, anything the run is holding — see the module
+            docstring on why key-name matching alone is not enough.
 
     Returns:
         A new bundle. Never mutates the input: a caller that logs locally and
         uploads remotely must be able to hold both, and an in-place scrub makes
         the local copy useless.
-
-    Raises:
-        HarnessNotBuiltError: Always — implementation is child G on FND-224.
     """
-    raise HarnessNotBuiltError(
-        message="redact is not implemented yet",
-        operation="redact",
-        reason="child G on FND-224",
-        issue="FND-224",
-        component="harness_evidence",
+    return replace(
+        bundle,
+        label=redact_text(bundle.label, secrets=secrets),
+        findings=tuple(
+            Finding(
+                subject=redact_text(finding.subject, secrets=secrets),
+                detail=redact_text(finding.detail, secrets=secrets),
+                # Not redacted: the expectation is one of a closed set of
+                # markers a report groups on, and passing it through the text
+                # filter would let a future marker named e.g. "token_shape"
+                # come out as "***" and stop matching UNREADABLE.
+                expectation=finding.expectation,
+            )
+            for finding in bundle.findings
+        ),
+        logs={
+            redact_text(source, secrets=secrets): tuple(
+                redact_text(line, secrets=secrets) for line in lines
+            )
+            for source, lines in bundle.logs.items()
+        },
+        readings=_redact_mapping(bundle.readings, secrets=secrets),
+        artifacts={
+            redact_text(path, secrets=secrets): redact_text(body, secrets=secrets)
+            for path, body in bundle.artifacts.items()
+        },
+    )
+
+
+def _redact_mapping(
+    mapping: Mapping[str, object], *, secrets: Sequence[str]
+) -> Mapping[str, object]:
+    """Blank every value under a credential-shaped key, recursively.
+
+    Whole-value replacement, not a text rewrite: in structured data the key
+    already establishes that the value is a credential, so there is nothing to
+    preserve inside it and every reason not to try. A nested mapping under such
+    a key is replaced entire — a credential *body* is exactly that shape, and
+    descending into it to redact key by key would pass through any sub-key the
+    fragment list has not seen.
+    """
+    redacted: dict[str, object] = {}
+    for key, value in mapping.items():
+        if _is_secret_key(key):
+            redacted[redact_text(key, secrets=secrets)] = PLACEHOLDER
+        else:
+            redacted[redact_text(key, secrets=secrets)] = _redact_value(
+                value, secrets=secrets
+            )
+    return redacted
+
+
+def _redact_value(value: object, *, secrets: Sequence[str]) -> object:
+    """Walk a reading, keeping its shape and sanitising its leaves.
+
+    Numbers and booleans pass through as themselves. That is deliberate: the
+    readings mapping is where asset counts and node states live, and stringifying
+    them here would make the bundle's own JSON unusable for the thing it exists
+    to answer. Anything that is not a container, a string, or a number is
+    rendered with :func:`repr` and then sanitised — an exception, an enum, a
+    dataclass all reach here, and a bundle that dropped them would be quieter and
+    less useful.
+    """
+    if isinstance(value, Mapping):
+        return _redact_mapping(
+            {str(key): item for key, item in value.items()}, secrets=secrets
+        )
+    if isinstance(value, str):
+        return redact_text(value, secrets=secrets)
+    if isinstance(value, bool) or value is None:
+        return value
+    if isinstance(value, (int, float)):
+        return value
+    if isinstance(value, Sequence):
+        return [_redact_value(item, secrets=secrets) for item in value]
+    return redact_text(repr(value), secrets=secrets)
+
+
+def _is_secret_key(key: str) -> bool:
+    """Is *key* credential-shaped? Case-insensitive substring match."""
+    lowered = key.lower()
+    return any(fragment in lowered for fragment in SECRET_KEY_FRAGMENTS)
+
+
+def secrets_from_environment(
+    environ: Mapping[str, str], *, also: Sequence[str] = ()
+) -> tuple[str, ...]:
+    """Collect the literal values a run is holding, for :func:`redact`'s ``secrets``.
+
+    The same move ``resolve_e2e_tenant.py`` and ``export_extra_env.py`` make with
+    ``::add-mask::``, and for the same reason: a value that appears in a log with
+    no key beside it — echoed inside a URL path, quoted in a driver's exception,
+    dumped as a bare header — is invisible to key-name matching, and the only
+    filter that catches it is one that knows the value.
+
+    Every variable whose *name* is credential-shaped contributes its *value*, so
+    the two filters share one definition of what looks like a credential and a
+    fragment added to :data:`SECRET_KEY_FRAGMENTS` strengthens both at once.
+
+    Args:
+        environ: Environment to read. Passed in rather than read from
+            :data:`os.environ` so a test can drive it without mutating process
+            state.
+        also: Extra variable names to contribute regardless of their shape. The
+            tenant base URL belongs here: its name is not credential-shaped and
+            its value is not a credential, but a tenant hostname identifies a
+            customer environment and an evidence bundle is retained and shared.
+
+    Returns:
+        The distinct non-blank values, longest first. Order is load-bearing:
+        :func:`redact_text` substitutes literally, so a value that is a prefix of
+        another must not be replaced first — doing so leaves the longer one's
+        tail behind, which is a partial secret in a file that claims to have
+        none.
+    """
+    names = [name for name in environ if _is_secret_key(name)] + list(also)
+    values = {environ[name].strip() for name in names if environ.get(name, "").strip()}
+    return tuple(sorted(values, key=len, reverse=True))
+
+
+def write_bundle(
+    bundle: EvidenceBundle, output_dir: Path, *, secrets: Sequence[str] = ()
+) -> Sequence[Path]:
+    """Redact *bundle* and write it under *output_dir*.
+
+    Redaction happens here rather than being asked of the caller, because this
+    is the boundary the bundle crosses: on the connector CI path *output_dir*
+    sits inside the directory ``upload-artifact`` is already pointed at, so
+    anything written here is published. Calling :func:`redact` first is safe —
+    the filters are idempotent.
+
+    Writes ``report.json`` (the label, findings and readings, machine-readable),
+    one ``logs/{source}.log`` per log source, and each artifact at its own
+    relative path. Split rather than one blob because that is how they are read:
+    a person opens one container's log, a script parses the report.
+
+    Args:
+        bundle: What to write.
+        output_dir: Directory to write into. Created if absent.
+        secrets: Literal values to blank — see :func:`redact`.
+
+    Returns:
+        The paths written, in the order they were written. Empty when the
+        directory could not be created, which is logged and not raised: an
+        evidence dump that failed must not become the failure being diagnosed.
+    """
+    sanitised = redact(bundle, secrets=secrets)
+    try:
+        output_dir.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        logger.warning(
+            "harness evidence: could not create %s — the bundle for %r is not "
+            "being written, but the run's own verdict is unaffected",
+            output_dir,
+            sanitised.label,
+            exc_info=True,
+        )
+        return ()
+
+    written: list[Path] = []
+    report = {
+        "label": sanitised.label,
+        "findings": [
+            {
+                "subject": finding.subject,
+                "detail": finding.detail,
+                "expectation": finding.expectation,
+            }
+            for finding in sanitised.findings
+        ],
+        "readings": sanitised.readings,
+    }
+    written.extend(
+        _write_one(
+            output_dir / "report.json",
+            # `default=str` rather than a raise: a reading that survived
+            # `_redact_value` as a non-JSON type would otherwise cost the whole
+            # report, and the report is the file a script reads.
+            orjson.dumps(
+                report,
+                default=str,
+                option=orjson.OPT_INDENT_2 | orjson.OPT_SORT_KEYS,
+            ).decode(),
+        )
+    )
+    for source, lines in sanitised.logs.items():
+        written.extend(
+            _write_one(
+                output_dir / "logs" / f"{_as_filename(source)}.log", "\n".join(lines)
+            )
+        )
+    for relative_path, body in sanitised.artifacts.items():
+        written.extend(_write_one(output_dir / _as_relative(relative_path), body))
+    logger.info(
+        "harness evidence: wrote %d file(s) for %r under %s",
+        len(written),
+        sanitised.label,
+        output_dir,
+    )
+    return tuple(written)
+
+
+def _write_one(path: Path, body: str) -> Sequence[Path]:
+    """Write one file, reporting rather than raising on failure.
+
+    Explicit UTF-8 with ``errors="replace"``: ``write_text`` otherwise uses the
+    locale encoding, which is cp1252 on Windows and cannot represent most of
+    what a container logs — and this is evidence, so one undecodable character
+    must not cost the whole file.
+    """
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(body, encoding="utf-8", errors="replace")
+    except OSError:
+        logger.warning(
+            "harness evidence: could not write %s — the rest of the bundle is "
+            "still being written",
+            path,
+            exc_info=True,
+        )
+        return ()
+    return (path,)
+
+
+def _as_filename(source: str) -> str:
+    """Flatten a log-source name into one path segment.
+
+    A source is a pod or container name and can legitimately carry a ``/``
+    (``pod/container``); left alone it would silently become a directory level,
+    so two sources differing only there would land on top of each other.
+    """
+    return source.replace("/", "-").replace("\\", "-") or "unnamed"
+
+
+def _as_relative(relative_path: str) -> Path:
+    """Confine an artifact path to *output_dir*.
+
+    An artifact's key is a relative path, and a caller assembling one from a pod
+    or container name can produce ``..`` or a leading ``/`` without meaning to.
+    Neither is rejected — an evidence write must not fail on a naming quirk —
+    but both are flattened, so a bundle can never write outside the directory it
+    was handed.
+    """
+    parts = [
+        part
+        for part in Path(relative_path).parts
+        if part not in ("..", "/", "\\") and not Path(part).is_absolute()
+    ]
+    return Path(*parts) if parts else Path("unnamed")
+
+
+async def collect_pod_evidence(
+    namespace: str,
+    *,
+    reader: KubernetesReader,
+    label_selector: str = "",
+    tail_lines: int = 10_000,
+) -> EvidenceBundle:
+    """Collect container logs and pod state from *namespace* into one bundle.
+
+    Every pod's current container output, plus the *previous* container's output
+    wherever ``restartCount > 0`` — which is where a crash loop's actual cause
+    is, and the one thing a merged log stream cannot express.
+
+    Typed as the concrete
+    :class:`~application_sdk.testing.harness.cluster.KubernetesReader` rather
+    than as :class:`~application_sdk.testing.harness.cluster.ClusterReader`
+    because it needs the per-container read that Protocol deliberately does not
+    carry, for exactly that reason.
+
+    Best-effort throughout: an unreadable listing yields an empty bundle rather
+    than an exception, and one unreadable container costs that container's log
+    and nothing else. See the module docstring for why this is the one thing
+    here allowed to fail open.
+
+    Args:
+        namespace: Namespace to collect from.
+        reader: Cluster reader to list pods and read their logs with.
+        label_selector: Narrows which pods are collected, in ``kubectl -l``
+            syntax. Empty collects every pod in the namespace.
+        tail_lines: Cap on lines per container.
+
+    Returns:
+        A bundle whose :attr:`~EvidenceBundle.logs` are keyed
+        ``{pod}/{container}`` (and ``{pod}/{container}/previous`` for a restarted
+        container's earlier output), and whose
+        :attr:`~EvidenceBundle.readings` carry one entry per pod: phase,
+        readiness, restart total and node. **Not yet redacted** — redaction is
+        :func:`write_bundle`'s, at the boundary that ships it.
+    """
+    label = f"pods in {namespace}" + (
+        f" matching {label_selector}" if label_selector else ""
+    )
+    try:
+        pods = list(await reader.pods(namespace, label_selector))
+    except Exception:
+        logger.warning(
+            "harness evidence: could not list pods in %s — returning an empty "
+            "bundle rather than raising, so the verdict this was collected for "
+            "survives",
+            namespace,
+            exc_info=True,
+        )
+        return EvidenceBundle(label=label)
+
+    reads = [
+        (f"{pod.name}/{container}", pod.name, container, False)
+        for pod in pods
+        for container in (pod.containers or {})
+    ] + [
+        (f"{pod.name}/{container}/previous", pod.name, container, True)
+        for pod in pods
+        for container, restarts in (pod.containers or {}).items()
+        if restarts > 0
+    ]
+
+    async def _read(pod: str, container: str, previous: bool) -> Sequence[str]:
+        try:
+            text = await reader.container_log(
+                namespace, pod, container, previous=previous, tail_lines=tail_lines
+            )
+        except Exception:
+            logger.warning(
+                "harness evidence: could not read %slogs for %s/%s/%s — the rest "
+                "of the collection continues",
+                "previous " if previous else "",
+                namespace,
+                pod,
+                container,
+                exc_info=True,
+            )
+            return ()
+        return tuple(text.splitlines())
+
+    collected = await asyncio.gather(
+        *(_read(pod, container, previous) for _, pod, container, previous in reads)
+    )
+    return EvidenceBundle(
+        label=label,
+        logs={key: lines for (key, *_), lines in zip(reads, collected, strict=True)},
+        readings={
+            pod.name: {
+                "phase": pod.phase.value,
+                "ready": pod.ready,
+                "restarts": pod.restarts,
+                "node": pod.node,
+            }
+            for pod in pods
+        },
     )

--- a/application_sdk/testing/harness/evidence.py
+++ b/application_sdk/testing/harness/evidence.py
@@ -145,14 +145,23 @@ _AUTH_SCHEMES = ("Basic", "Bearer", "Digest", "Negotiate", "Token", "APIKey")
 #:   quoted value, an ODBC ``{braced}`` one whose ``;`` would otherwise end the
 #:   match early, and an auth scheme plus its token.
 #:
-#: The key's surrounding classes are bounded rather than ``*`` so the pattern
-#: cannot backtrack quadratically over a long unbroken run of word characters —
-#: a container log is exactly where one turns up.
+#: The quoted alternatives consume backslash escapes (``(?:[^"\\]|\\.)*``)
+#: rather than stopping at the first quote. A plain ``"[^"]*"`` truncates at an
+#: **escaped** quote, so ``"password": "part\"secret"`` would redact to
+#: ``"password": "***"secret"`` — the tail written into an uploaded artifact.
+#: JSON is where this arrives: any credential containing a double quote is
+#: escaped by every serialiser that produced the log in the first place. The two
+#: branches are disjoint (the class excludes the backslash the other requires),
+#: so the alternation cannot backtrack catastrophically.
+#:
+#: The key's surrounding classes are bounded rather than ``*`` for the same
+#: reason: the pattern cannot backtrack quadratically over a long unbroken run
+#: of word characters, and a container log is exactly where one turns up.
 _KEYED_VALUE_RE = re.compile(
     r"(?i)(?<![\w-])([\w.-]{0,64}(?:"
     + "|".join(re.escape(fragment) for fragment in SECRET_KEY_FRAGMENTS)
     + r")[\w.-]{0,64})([\"']?\s*[:=]\s*)"
-    + r"(\"[^\"]*\"|'[^']*'|\{[^}]*\}|(?:"
+    + r"(\"(?:[^\"\\]|\\.)*\"|'(?:[^'\\]|\\.)*'|\{[^}]*\}|(?:"
     + "|".join(_AUTH_SCHEMES)
     + r")\s+\S+|[^\s,;&#]+)"
 )
@@ -200,7 +209,14 @@ def redact_text(text: str, *, secrets: Sequence[str] = ()) -> str:
         The sanitised text. Idempotent: :data:`PLACEHOLDER` contains no key
         fragment and no literal, so redacting twice changes nothing.
     """
-    for literal in secrets:
+    # Sorted here, not only in `secrets_from_environment`. Ordering is a
+    # *correctness* property of the substitution — replacing a short literal
+    # that prefixes a longer one turns `tok-abcdef` into `***-abcdef` and ships
+    # the tail — so it belongs in the function doing the replacing rather than
+    # in one of the several things that can produce the sequence. `redact` and
+    # `write_bundle` take any `Sequence[str]`, and a caller passing a plain list
+    # has no reason to know the order matters.
+    for literal in sorted(secrets, key=len, reverse=True):
         if len(literal) >= _MIN_LITERAL_LENGTH:
             text = text.replace(literal, PLACEHOLDER)
     text = _KEYED_VALUE_RE.sub(_blank_keyed_value, text)

--- a/application_sdk/testing/harness/identity.py
+++ b/application_sdk/testing/harness/identity.py
@@ -149,6 +149,24 @@ class Minter:
             return int(ambient)
         return self._clock()
 
+    def seed_version(self) -> int:
+        """Return the version number to publish a seed DAG under.
+
+        A bare clock reading, and deliberately **not** :meth:`run_id`. This
+        number is how the harness later tells its own seed apart from the
+        manifest AE published over it — ``BaseE2ETest._supersedes`` answers
+        "did the tenant replace my seed?" by comparing the two — so two seeds of
+        one workflow must not carry the same number. The ambient
+        ``GITHUB_RUN_ID`` that :meth:`run_id` prefers is constant across every
+        leg of one CI job, so seeding twice under it would report the second
+        seed as the tenant's own manifest.
+
+        Returns:
+            The clock reading, in whole seconds. Opaque to AE beyond its
+            ordering, which is why nothing here tries to make it meaningful.
+        """
+        return self._clock()
+
     def unique_suffix(self) -> str:
         """Return a suffix that makes a name unique within a tenant.
 

--- a/application_sdk/testing/harness/starters/__init__.py
+++ b/application_sdk/testing/harness/starters/__init__.py
@@ -7,7 +7,7 @@ new way to start work would widen both. As three functions, a base class simply
 calls the one it wants, and a fourth way to start work (a cluster mutation, a
 chaos injection) is a fourth function with nothing in the middle to widen.
 
-**One of the three is real.** :func:`start_on_task_queue` dispatches straight
+**Two of the three are real.** :func:`start_on_task_queue` dispatches straight
 onto a Temporal task queue (FND-246) — new work on both sides of this project,
 not a lift: nothing in this SDK or in ``atlanhq/app-runtime-test-suite`` started
 a workflow that way before, and it is the runtime suite's *first* scenario
@@ -15,31 +15,35 @@ because everything else depends on it working. See
 :mod:`application_sdk.testing.harness.starters._queue` for the correction to the
 record that scoping it turned on.
 
-The other two are still stubs. ``testing/e2e/workflows.run_workflow`` is
+:func:`start_via_automation_engine` is the opposite kind of module: a plain
+extraction (child G, FND-243) of ``BaseE2ETest._bootstrap_workflow`` plus the
+submit half of ``run_full_dag``, so it *can* be pinned against the code it came
+from. What it adds is nothing; what it removes is the last part of the AE path
+that only existed inside a base class.
+
+One is still a stub. ``testing/e2e/workflows.run_workflow`` is
 :func:`start_via_app_handler`: an HTTP ``POST /api/v1/workflows`` to the app's
 *handler Service* through an ephemeral ``kubectl port-forward``, which never
-touches a task queue. :func:`start_via_automation_engine` is the AE submit,
-lifting from ``testing/e2e/client.py``.
-
-:func:`start_via_automation_engine` lands in child G on FND-224.
-:func:`start_via_app_handler` moves with the cluster reader in child E.
+touches a task queue. It moves with the cluster reader in child E.
 
 Module map:
 
 ``_specs``
-    The five specs and handles — three pairs, no shared base.
+    The specs and handles — three pairs, no shared base, plus the submit
+    retry's typed sizing.
 ``_queue``
     :func:`start_on_task_queue`, and where its client comes from.
+``_ae``
+    :func:`start_via_automation_engine`, and the four-write sequence it owns.
 ``_errors``
     The three leaves a dispatch can raise.
 """
 
 from __future__ import annotations
 
-from collections.abc import Mapping
-
 from application_sdk.testing.harness._errors import HarnessNotBuiltError
 from application_sdk.testing.harness.cluster import ClusterReader
+from application_sdk.testing.harness.starters._ae import start_via_automation_engine
 from application_sdk.testing.harness.starters._errors import (
     UnusableTaskQueueError,
     WorkflowStartConflictError,
@@ -48,18 +52,22 @@ from application_sdk.testing.harness.starters._errors import (
 from application_sdk.testing.harness.starters._queue import start_on_task_queue
 from application_sdk.testing.harness.starters._specs import (
     AERunHandle,
+    AEWorkflowSpec,
     HttpRunHandle,
     HttpWorkflowSpec,
     QueueWorkflowSpec,
+    SubmitRetry,
     WorkflowRunHandle,
 )
 
 __all__ = [
     # Specs and handles
     "AERunHandle",
+    "AEWorkflowSpec",
     "HttpRunHandle",
     "HttpWorkflowSpec",
     "QueueWorkflowSpec",
+    "SubmitRetry",
     "WorkflowRunHandle",
     # The three ways to start work
     "start_on_task_queue",
@@ -70,28 +78,6 @@ __all__ = [
     "WorkflowStartConflictError",
     "WorkflowStartFailedError",
 ]
-
-
-async def start_via_automation_engine(spec: Mapping[str, object]) -> AERunHandle:
-    """Start a run through the Automation Engine.
-
-    Args:
-        spec: The AE submit payload, as
-            :func:`application_sdk.testing.e2e.payload.build_ae_payload` builds it.
-
-    Returns:
-        The AE run handle.
-
-    Raises:
-        HarnessNotBuiltError: Always — implementation is child G on FND-224.
-    """
-    raise HarnessNotBuiltError(
-        message="start_via_automation_engine is not implemented yet",
-        operation="start_via_automation_engine",
-        reason="child G on FND-224",
-        issue="FND-224",
-        component="harness_starters",
-    )
 
 
 async def start_via_app_handler(

--- a/application_sdk/testing/harness/starters/_ae.py
+++ b/application_sdk/testing/harness/starters/_ae.py
@@ -1,0 +1,186 @@
+"""Starting a run through the Automation Engine (FND-243).
+
+An extraction, not new work: this is ``BaseE2ETest._bootstrap_workflow`` plus
+the submit half of ``run_full_dag``, with the connector's class attributes taken
+as a :class:`~application_sdk.testing.harness.starters.AEWorkflowSpec` instead of
+read off ``self``. Everything it calls is already a method on
+:class:`~application_sdk.testing.harness.automation_engine.AEClient` — the four
+AE writes moved there in child F — so what lands here is the *sequence*, which
+was the last part of the AE path still trapped inside a base class.
+
+**The sequence is the subject.** Four writes in a fixed order, each of which is
+useless without the ones around it:
+
+1. ``create_workflow`` — AE does not auto-create on submit; a fresh slug answers
+   HTTP 404 with "Create the workflow first". Idempotent on the name.
+2. ``wait_for_slug`` — AE has a brief indexing window before a fresh slug is
+   queryable by ``/versions``. This *replaced* an unconditional ``time.sleep(3)``
+   in child D (FND-240), which was wrong in both directions: three seconds
+   charged to every run that did not need them, and no help at all on the run
+   where indexing took four. The read is advisory rather than a gate —
+   ``create_version`` retries on 404 for exactly this reason, and that retry is
+   what makes the sequence safe either way.
+3. ``create_version`` + ``publish_version`` — a workflow needs a *published*
+   version before a submit against it is accepted.
+4. ``submit_workflow`` — the one non-idempotent write in the harness.
+
+**No error translation, deliberately.** Every step already raises a typed leaf
+from :mod:`application_sdk.testing.harness.automation_engine`:
+``AtlanApiHttpError`` for a rejected write, ``AtlanAEWorkflowAlreadyActiveError``
+for the conflict Heracles masks as a 500, ``AppNotReadyError`` for a tenant pod
+that never started serving. Wrapping those in a starter-specific leaf would
+replace a category an operator already knows how to read with one that says only
+"the starter failed", and would give the AE path a second classification of the
+same responses — the divergence FND-224 exists to remove. The queue starter
+converts ``temporalio``'s errors because ``temporalio`` has no leaves of its own;
+this one has nothing to convert.
+
+**Nothing is retried around the sequence.** A caller that re-ran the whole
+function after a failed submit would re-enter that write's own inner retry, past
+the ``retry_after`` honouring and the credential-name rotation that make each
+re-POST safe — and the submit is the write where a duplicate is a *phantom run*
+AE marks Skipped and returns under a fresh id, which the harness then polls
+while the real run finishes elsewhere. The budget belongs inside the submit, and
+:class:`~application_sdk.testing.harness.starters.SubmitRetry` is how a caller
+widens it.
+
+**The seed DAG is a value, not a build.** Resolving a manifest's mustache
+tokens, picking the extract task queue, falling back to a legacy graph — those
+stay with the connector suite. They are policy, and they are the reason
+``BaseE2ETest`` exists at all. Taking the graph as a value is also what lets a
+runtime scenario supply one that never came from a ``manifest.json``.
+"""
+
+from __future__ import annotations
+
+import os
+
+from application_sdk.observability.logger_adaptor import get_logger
+from application_sdk.testing.harness.automation_engine.client import AEClient
+from application_sdk.testing.harness.identity import Minter
+from application_sdk.testing.harness.starters._specs import AERunHandle, AEWorkflowSpec
+
+logger = get_logger(__name__)
+
+__all__ = ["start_via_automation_engine"]
+
+
+async def start_via_automation_engine(
+    spec: AEWorkflowSpec, *, client: AEClient, minter: Minter | None = None
+) -> AERunHandle:
+    """Create, seed, publish and submit a workflow through the Automation Engine.
+
+    Deliberately shares no signature with
+    :func:`~application_sdk.testing.harness.starters.start_on_task_queue` or
+    :func:`~application_sdk.testing.harness.starters.start_via_app_handler`:
+    different inputs, different handles, nothing in the middle to widen.
+
+    Args:
+        spec: What to create, what to seed it with, and what to submit.
+        client: An open AE client, on *this* event loop. Not closed here — the
+            transport's lifetime stays with whoever opened it, the same rule the
+            queue starter follows, and for the same reason: a caller that goes
+            on to poll ``native-status`` through the same client would find it
+            shut.
+        minter: Supplies the seed version number when ``spec.version`` is
+            ``None``. Injected for the reason
+            :mod:`application_sdk.testing.harness.identity` exists: a number
+            built from an unseeded clock is a number no test can predict, and
+            this one is what later distinguishes the harness' own seed from the
+            manifest the tenant published over it. ``None`` builds one over the
+            real clock.
+
+    Returns:
+        The run handle, carrying AE's slug and the run id the submit reported.
+
+    Raises:
+        AtlanApiHttpError: If any of the four writes was rejected.
+        AtlanApiResponseInvariantError: If a write succeeded but its response
+            named no slug, version or run id.
+        AtlanAEWorkflowAlreadyActiveError: If a run for this workflow is already
+            active. Terminal, not retryable — a retry spawns a duplicate run AE
+            marks ``Skipped``.
+        AppNotReadyError: If the tenant app pod never accepted the submit across
+            the whole cold-start budget.
+
+    Example:
+        >>> handle = await start_via_automation_engine(  # doctest: +SKIP
+        ...     AEWorkflowSpec(
+        ...         name=f"{connector}-{run_id}",
+        ...         seed_dag=seed_dag,
+        ...         payload=payload,
+        ...         submit_retry=SubmitRetry.for_cold_start(
+        ...             timeout_seconds=600, poll_interval_seconds=10
+        ...         ),
+        ...     ),
+        ...     client=ae_client,
+        ... )
+    """
+    slug, seed_version = await _published_slug(spec, client=client, minter=minter)
+
+    logger.info("submitting AE run against slug %s", slug)
+    # ``slug=`` is what lets an ambiguous submit timeout be resolved by reading
+    # AE's own run list rather than failing the leg: AE writes the run record
+    # before it answers, so a response that never arrived is still recoverable.
+    retry = spec.submit_retry
+    if retry is None:
+        run_id = await client.submit_workflow(dict(spec.payload), slug=slug)
+    else:
+        run_id = await client.submit_workflow(
+            dict(spec.payload),
+            slug=slug,
+            retries=retry.retries,
+            retry_sleep_seconds=retry.sleep_seconds,
+        )
+    logger.info("AE accepted the submit: slug=%s run_id=%s", slug, run_id)
+    return AERunHandle(workflow_slug=slug, run_id=run_id, seed_version=seed_version)
+
+
+async def _published_slug(
+    spec: AEWorkflowSpec, *, client: AEClient, minter: Minter | None
+) -> tuple[str, int | None]:
+    """Return a slug with a published version, creating and seeding one if needed.
+
+    A pre-existing ``spec.slug`` returns immediately and *nothing is seeded over
+    it*. That is the point of the field rather than an optimisation: the workflow
+    belongs to whoever set it up, and publishing a version over it would replace
+    a DAG this run does not own — on a tenant where the next run to submit
+    against that slug is not necessarily this one.
+
+    Returns:
+        The slug, and the version this call published under it — ``None`` on the
+        pre-existing-slug path, where nothing was published and there is
+        therefore nothing for the tenant's manifest to have superseded.
+    """
+    if spec.slug:
+        logger.info("using the pre-existing AE workflow slug %s", spec.slug)
+        return spec.slug, None
+
+    slug = await client.create_workflow(name=spec.name, description=spec.description)
+    logger.info("created (or reused) AE workflow name=%s slug=%s", spec.name, slug)
+
+    # Advisory, not a gate — see the module docstring. ``create_version``'s own
+    # 404 retry is what makes the sequence safe whether or not this settles.
+    await client.wait_for_slug(slug)
+
+    version = spec.version if spec.version is not None else _minted_version(minter)
+    published = await client.create_version(
+        slug, {"version": version, "dag": dict(spec.seed_dag)}
+    )
+    # AE assigns the version, and the number it assigns is not required to be
+    # the one that was asked for. Publishing the requested number instead of the
+    # assigned one would 404 on a mismatch, and — worse — would leave the run
+    # comparing its seed against a version it never published.
+    logger.info("created seed version %d under slug %s", published, slug)
+    await client.publish_version(slug, published)
+    return slug, published
+
+
+def _minted_version(minter: Minter | None) -> int:
+    """Mint a seed version for a spec that did not carry one.
+
+    Uses the factory even though only the clock half matters, so there is one
+    construction path for a real-clock minter rather than two.
+    """
+    resolved = Minter.from_environment(os.environ) if minter is None else minter
+    return resolved.seed_version()

--- a/application_sdk/testing/harness/starters/_specs.py
+++ b/application_sdk/testing/harness/starters/_specs.py
@@ -21,14 +21,19 @@ from application_sdk.common.task_queue import (
     DEPLOYMENT_NAME_TOKEN,
     derive_task_queue,
 )
+from application_sdk.testing.harness.automation_engine.retry import (
+    cold_start_submit_kwargs,
+)
 from application_sdk.testing.harness.cluster import ServiceTarget
 from application_sdk.testing.harness.starters._errors import UnusableTaskQueueError
 
 __all__ = [
     "AERunHandle",
+    "AEWorkflowSpec",
     "HttpRunHandle",
     "HttpWorkflowSpec",
     "QueueWorkflowSpec",
+    "SubmitRetry",
     "WorkflowRunHandle",
 ]
 
@@ -54,10 +59,129 @@ class AERunHandle:
     Attributes:
         workflow_slug: AE's slug for the workflow the run belongs to.
         run_id: AE's identifier for this run.
+        seed_version: The version number the starter published this run's seed
+            DAG under, or ``None`` when it published none — which is the case
+            for a spec that named a pre-existing slug. Carried on the handle
+            rather than left with the starter because it is the only way a
+            caller can later tell the harness' own seed apart from the manifest
+            AE published over it at submit; ``BaseE2ETest._supersedes`` is the
+            reader, and its ``None`` branch is exactly this case ("nothing was
+            seeded, so nothing can have been superseded").
     """
 
     workflow_slug: str
     run_id: str
+    seed_version: int | None = None
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class SubmitRetry:
+    """How hard the AE submit tries before it gives up.
+
+    A typed pair rather than the ``dict[str, int]`` the lifted code threaded
+    through ``**kwargs``. Two reasons, and the second is the one that matters:
+    a mapping of ints is checked by nobody, so a rename on either side fails at
+    runtime inside a non-idempotent write; and the sizing is a *decision* about
+    what the harness is waiting for, which deserves a name.
+
+    :meth:`for_cold_start` is the only way to derive one. There is no second
+    derivation of the budget here — the arithmetic stays in
+    :func:`~application_sdk.testing.harness.automation_engine.cold_start_submit_kwargs`,
+    which carries the reasoning about why widening the submit's *existing* retry
+    loop is the only safe shape for a write that must not be re-entered.
+
+    Attributes:
+        retries: Retries on top of the initial attempt.
+        sleep_seconds: Fixed gap between attempts, before any ``retry_after``
+            the origin names.
+    """
+
+    retries: int
+    sleep_seconds: int
+
+    @classmethod
+    def for_cold_start(
+        cls, *, timeout_seconds: int, poll_interval_seconds: int
+    ) -> SubmitRetry | None:
+        """Size the submit's retry to a tenant-app cold start.
+
+        The AE submit is the only tenant-facing probe of the installed app pod
+        on the connector CI path, because the runner has no ``kubectl`` route
+        into the tenant vcluster. A pod minutes from serving arrives as a
+        generic retryable 5xx, so the budget has to cover a cold start rather
+        than transient AE overload.
+
+        Args:
+            timeout_seconds: Total cold-start budget. Zero or negative answers
+                ``None``, which leaves the submit's own defaults in place.
+            poll_interval_seconds: Gap between submit attempts.
+
+        Returns:
+            The sizing, or ``None`` when the cold-start budget is disabled.
+
+        Raises:
+            MissingHarnessClassAttrError: When *timeout_seconds* is positive but
+                *poll_interval_seconds* is not — the retry count divides by the
+                interval, so a zero would crash rather than gate the submit.
+        """
+        sizing = cold_start_submit_kwargs(timeout_seconds, poll_interval_seconds)
+        if not sizing:
+            return None
+        return cls(
+            retries=sizing["retries"], sleep_seconds=sizing["retry_sleep_seconds"]
+        )
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class AEWorkflowSpec:
+    """A workflow to start through the Automation Engine.
+
+    Four steps' worth of input in one value: create the AE workflow, seed a DAG
+    version under it, publish that version, submit a run against it. They are
+    one spec rather than four calls because they are one *decision* — a caller
+    that seeded a DAG and did not submit has left a published version on the
+    tenant that nothing will ever run.
+
+    What is deliberately not here is how the seed DAG was *built*. Resolving a
+    manifest's mustache tokens, choosing the extract task queue, falling back to
+    a legacy graph — those are the connector suite's, and they are what makes
+    ``BaseE2ETest`` a base class rather than a function. This spec takes the
+    graph as a value, which is also what lets a runtime scenario supply one that
+    never came from a ``manifest.json`` at all.
+
+    Attributes:
+        name: AE workflow name. The create endpoint is idempotent on it, so
+            re-running under the same name reuses the workflow rather than
+            accumulating one per run.
+        seed_dag: The DAG to publish as this workflow's seed version. Sent
+            verbatim: AE's submit is what makes Heracles fetch the tenant pod's
+            own manifest and publish it *over* this one, so the seed's job is to
+            make the workflow submittable, not to be the graph that runs.
+        payload: The AE submit body, as
+            :func:`application_sdk.testing.e2e.payload.build_ae_payload` builds
+            it.
+        description: Free text on the AE workflow.
+        slug: An AE slug that already exists. Non-empty **skips create, seed and
+            publish entirely** and submits against it — the escape hatch for a
+            suite pointed at a workflow someone else maintains. Not a
+            convenience: seeding over such a workflow would replace a DAG this
+            run does not own.
+        version: Explicit seed version number, or ``None`` to mint one. See
+            :meth:`~application_sdk.testing.harness.identity.Minter.seed_version`
+            for why the minted value is a bare clock reading.
+        submit_retry: How hard the submit tries. ``None`` leaves
+            :meth:`~application_sdk.testing.harness.automation_engine.AEClient.submit_workflow`'s
+            own defaults, which are sized for transient AE overload rather than
+            for a pod cold start.
+    """
+
+    name: str
+    seed_dag: Mapping[str, object] = field(default_factory=dict)
+    payload: Mapping[str, object] = field(default_factory=dict)
+    description: str = ""
+    slug: str = ""
+    version: int | None = None
+    submit_retry: SubmitRetry | None = None
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)

--- a/application_sdk/testing/harness/teardown.py
+++ b/application_sdk/testing/harness/teardown.py
@@ -5,7 +5,7 @@ harness with the least test coverage and the most consequence: assets a failed
 run leaves behind accumulate in a shared tenant, and a leftover half-set-up
 connection is exactly what greens a later run that should have failed.
 
-Two mechanics have to survive the lift, both non-obvious:
+Three mechanics have to survive the lift, and none of them is obvious.
 
 **Batching is a hard requirement, not a tuning knob.** ``pyatlan``'s
 ``purge_by_guid`` puts one ``guid=`` query parameter per asset into a single
@@ -16,19 +16,46 @@ deletes *nothing*. The batch stays well under the ceiling for a second reason:
 purge is expensive server-side, and a smaller batch means a failing chunk
 orphans less.
 
+**The whole listing is read before anything is deleted.** Atlas' default search
+pagination is offset-based (``from``/``size``), so purging between pages shifts
+the result window and silently skips assets — the run reports a clean teardown
+having deleted every other page. A list of GUID/qualified-name pairs is cheap
+even at six figures, and it is the only ordering under which the count in the
+report means what it says.
+
 **A failed purge is reported, never raised.** Teardown runs after the assertions
 have already decided the verdict. Raising here replaces a real failure with a
-cleanup error and loses the diagnosis.
+cleanup error and loses the diagnosis. Every path in this module returns a
+:class:`PurgeReport` — there is no exception a caller has to catch to stay
+correct, which is a stronger guarantee than "we remembered to wrap the call".
 
-Implementation is child G on FND-224.
+**Two independently-guarded phases**, and that is load-bearing rather than
+stylistic. Sharing one guard is what let a single child-purge failure orphan the
+connection as well: the raise jumped past the connection purge entirely, and
+because the teardown warning is post-verdict the leg still went green while
+leaking everything under it.
+
+What deliberately does *not* live here is the policy: which connection to purge,
+and whether to purge at all. This module takes a qualified name a run minted for
+itself. Pointing it at a long-lived shared connection would delete assets that
+are not the run's to delete, and no guard here can tell the two apart — which is
+why :mod:`application_sdk.testing.harness.identity` mints the ephemeral name in
+the first place, and why a test can predict it.
 """
 
 from __future__ import annotations
 
 from collections.abc import Sequence
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
 
-from application_sdk.testing.harness._errors import HarnessNotBuiltError
+from application_sdk.errors.base import sanitize_cause_repr
+from application_sdk.observability.logger_adaptor import get_logger
+
+if TYPE_CHECKING:  # pragma: no cover - typing only; pyatlan is a lazy import
+    from pyatlan.client.aio.client import AsyncAtlanClient
+
+logger = get_logger(__name__)
 
 __all__ = ["PURGE_BATCH_SIZE", "PurgeReport", "purge_connection"]
 
@@ -36,43 +63,244 @@ __all__ = ["PURGE_BATCH_SIZE", "PurgeReport", "purge_connection"]
 #: bound rather than a performance choice.
 PURGE_BATCH_SIZE = 50
 
+#: Assets per search page while listing what to purge. Matches the ``dsl.size =
+#: 200`` the lifted implementation used. Unrelated to :data:`PURGE_BATCH_SIZE`:
+#: this one bounds a GET's response, that one bounds a DELETE's URL.
+_LISTING_PAGE_SIZE = 200
+
 
 @dataclass(frozen=True, slots=True, kw_only=True)
 class PurgeReport:
     """What a purge managed to delete, and what it did not.
 
     Attributes:
-        purged: Count of assets successfully deleted.
+        purged: Count of assets successfully deleted, the connection included
+            when it was.
         orphaned: Qualified names of assets the purge could not delete. Named
             individually rather than counted: an operator cleaning up by hand
             needs the list, and a count tells them only that they have a problem.
-        errors: One line per failed batch, in order.
+        errors: One line per failed step, in order. Already secret-redacted —
+            a pyatlan error can quote the request URL, and a report that ships
+            with an evidence bundle is not the place to find out.
     """
 
     purged: int = 0
     orphaned: Sequence[str] = field(default_factory=tuple)
     errors: Sequence[str] = field(default_factory=tuple)
 
+    @property
+    def complete(self) -> bool:
+        """Did the purge finish with nothing left behind and nothing failing?
 
-async def purge_connection(connection_qualified_name: str) -> PurgeReport:
+        Returns:
+            ``True`` when no asset was orphaned and no step errored. A run that
+            created nothing purges nothing and is still complete — "there was
+            nothing to delete" and "everything was deleted" are the same
+            outcome for the tenant, and neither needs a person.
+        """
+        return not self.orphaned and not self.errors
+
+
+async def purge_connection(
+    client: AsyncAtlanClient, connection_qualified_name: str
+) -> PurgeReport:
     """Delete every asset under *connection_qualified_name*, then the connection.
 
     Args:
+        client: An open client from
+            :func:`~application_sdk.testing.harness.atlas.atlas_client`, held for
+            the whole purge. Taken as a parameter for the reason every Atlas read
+            in this harness takes one: a purge of a large crawl is hundreds of
+            round trips, and a function that opened its own would pay a TLS
+            handshake per call.
         connection_qualified_name: The ephemeral connection this run created.
             Must be a name the run minted itself — never a long-lived shared
             connection, whose assets are not this run's to delete.
 
     Returns:
         A :class:`PurgeReport`. Failures are reported here, not raised: see the
-        module docstring.
+        module docstring. The two phases are independent, so a child purge that
+        fails entirely still leaves the connection purge to run.
 
-    Raises:
-        HarnessNotBuiltError: Always — implementation is child G on FND-224.
+    Example:
+        >>> async with atlas_client(url, token) as client:  # doctest: +SKIP
+        ...     report = await purge_connection(client, identity.qualified_name)
+        >>> if not report.complete:  # doctest: +SKIP
+        ...     logger.warning("manual purge needed: %s", report.orphaned)
     """
-    raise HarnessNotBuiltError(
-        message="purge_connection is not implemented yet",
-        operation="purge_connection",
-        reason="child G on FND-224",
-        issue="FND-224",
-        component="harness_teardown",
+    assets, listing_errors = await _list_children(client, connection_qualified_name)
+    # An unreadable listing is the one failure that is not partial: nothing is
+    # known about what is under the connection, so nothing below it can be
+    # purged, and nothing can be *named* as left behind either — which is what
+    # the error line has to say instead. The connection purge still runs: it
+    # needs no listing, and a connection left behind is exactly the leftover
+    # that greens a later run.
+    child_report = (
+        PurgeReport(errors=listing_errors)
+        if listing_errors
+        else await _purge_children(client, connection_qualified_name, assets)
     )
+    connection_report = await _purge_connection_asset(client, connection_qualified_name)
+    report = PurgeReport(
+        purged=child_report.purged + connection_report.purged,
+        orphaned=(*child_report.orphaned, *connection_report.orphaned),
+        errors=(*child_report.errors, *connection_report.errors),
+    )
+    if report.complete:
+        logger.info(
+            "harness teardown: purged %d asset(s) under %s",
+            report.purged,
+            connection_qualified_name,
+        )
+    else:
+        logger.warning(
+            "harness teardown: purged %d asset(s) under %s but left %d behind — "
+            "manual purge may be needed. %s",
+            report.purged,
+            connection_qualified_name,
+            len(report.orphaned),
+            "; ".join(report.errors),
+        )
+    return report
+
+
+async def _list_children(
+    client: AsyncAtlanClient, connection_qualified_name: str
+) -> tuple[Sequence[tuple[str, str]], Sequence[str]]:
+    """Read every descendant's GUID and qualified name, in one pass.
+
+    Both fields, not just the GUID the DELETE needs: :attr:`PurgeReport.orphaned`
+    names what was left behind, and a list of GUIDs is not something an operator
+    can act on without a second round of lookups against a tenant they are
+    cleaning up by hand.
+
+    Returns:
+        The ``(guid, qualified_name)`` pairs and an empty error tuple, or an
+        empty pair list and one error line. Never both populated: an unreadable
+        listing establishes nothing, and a partial one would be a purge that
+        under-reports what it left behind.
+    """
+    from pyatlan.model.assets import Asset  # noqa: PLC0415
+    from pyatlan.model.fluent_search import FluentSearch  # noqa: PLC0415
+
+    prefix = f"{connection_qualified_name}/"
+    try:
+        request = (
+            FluentSearch()
+            .where(Asset.QUALIFIED_NAME.startswith(prefix))
+            .include_on_results(Asset.GUID)
+            .include_on_results(Asset.QUALIFIED_NAME)
+        ).to_request()
+        request.dsl.size = _LISTING_PAGE_SIZE
+        results = await client.asset.search(request)
+        assets: list[tuple[str, str]] = []
+        async for asset in results:
+            if asset.guid:
+                assets.append((asset.guid, asset.qualified_name or asset.guid))
+    except Exception as error:
+        logger.warning(
+            "harness teardown: could not list assets under %s — nothing below the "
+            "connection can be purged, and what is there is unknown rather than "
+            "absent",
+            connection_qualified_name,
+            exc_info=True,
+        )
+        return (), (
+            f"listing assets under {connection_qualified_name} failed: "
+            f"{sanitize_cause_repr(error)}",
+        )
+    return tuple(assets), ()
+
+
+async def _purge_children(
+    client: AsyncAtlanClient,
+    connection_qualified_name: str,
+    assets: Sequence[tuple[str, str]],
+) -> PurgeReport:
+    """DELETE the listed assets in :data:`PURGE_BATCH_SIZE` chunks.
+
+    One failing batch orphans that batch and no more. Per-batch errors are
+    collected rather than logged individually: a tenant-wide outage is hundreds
+    of failing batches, and one warning each buries the aggregate count that
+    actually says how much leaked.
+    """
+    purged = 0
+    orphaned: list[str] = []
+    errors: list[str] = []
+    for offset in range(0, len(assets), PURGE_BATCH_SIZE):
+        batch = assets[offset : offset + PURGE_BATCH_SIZE]
+        try:
+            await client.asset.purge_by_guid([guid for guid, _ in batch])
+        # conformance: ignore[E004] teardown boundary — a batch failure must never propagate and mask the test verdict; every batch is accounted for in the returned report and the aggregate is logged at WARNING by the caller
+        except Exception as error:
+            # DEBUG per batch, and the caller's single WARNING for the summary:
+            # see the docstring above on why the aggregate is the useful line.
+            logger.debug(
+                "harness teardown: purge batch at offset %d failed",
+                offset,
+                exc_info=True,
+            )
+            orphaned.extend(qualified_name for _, qualified_name in batch)
+            errors.append(
+                f"purge of {len(batch)} asset(s) at offset {offset} under "
+                f"{connection_qualified_name} failed: {sanitize_cause_repr(error)}"
+            )
+        else:
+            purged += len(batch)
+    return PurgeReport(purged=purged, orphaned=tuple(orphaned), errors=tuple(errors))
+
+
+async def _purge_connection_asset(
+    client: AsyncAtlanClient, connection_qualified_name: str
+) -> PurgeReport:
+    """Delete the connection itself, once its descendants are gone.
+
+    A connection that is not found is not an error and not an orphan. Teardown
+    is called on every path, including one where seeding failed before the
+    connection was created and one where a previous teardown already removed it;
+    reporting "nothing there" as a failure would make a clean run look dirty.
+    """
+    from pyatlan.model.assets import Asset  # noqa: PLC0415
+    from pyatlan.model.fluent_search import FluentSearch  # noqa: PLC0415
+
+    try:
+        request = (
+            FluentSearch()
+            .where(Asset.QUALIFIED_NAME.eq(connection_qualified_name))
+            .where(Asset.TYPE_NAME.eq("Connection"))
+            .include_on_results(Asset.GUID)
+        ).to_request()
+        request.dsl.size = 1
+        results = await client.asset.search(request)
+        guid: str | None = None
+        # Bounded to a single result via ``dsl.size = 1``, and to one purge event
+        # per connection. The lifted implementation carried an ``L006`` waiver
+        # saying exactly that, because its version logged from inside the loop;
+        # this one does not, so the rule no longer fires and the waiver would be
+        # an inert directive claiming to suppress something. The bound is the
+        # part that had to survive the lift, not the suppression.
+        async for asset in results:
+            guid = asset.guid or guid
+        if guid is None:
+            logger.info(
+                "harness teardown: no Connection at %s to purge",
+                connection_qualified_name,
+            )
+            return PurgeReport()
+        await client.asset.purge_by_guid(guid)
+    except Exception as error:
+        logger.warning(
+            "harness teardown: could not purge the connection %s — manual purge "
+            "may be needed",
+            connection_qualified_name,
+            exc_info=True,
+        )
+        return PurgeReport(
+            orphaned=(connection_qualified_name,),
+            errors=(
+                f"purge of connection {connection_qualified_name} failed: "
+                f"{sanitize_cause_repr(error)}",
+            ),
+        )
+    logger.info("harness teardown: purged connection %s", connection_qualified_name)
+    return PurgeReport(purged=1)

--- a/application_sdk/testing/harness/teardown.py
+++ b/application_sdk/testing/harness/teardown.py
@@ -128,17 +128,24 @@ async def purge_connection(
         >>> if not report.complete:  # doctest: +SKIP
         ...     logger.warning("manual purge needed: %s", report.orphaned)
     """
-    assets, listing_errors = await _list_children(client, connection_qualified_name)
+    listing = await _list_children(client, connection_qualified_name)
     # An unreadable listing is the one failure that is not partial: nothing is
     # known about what is under the connection, so nothing below it can be
     # purged, and nothing can be *named* as left behind either — which is what
     # the error line has to say instead. The connection purge still runs: it
     # needs no listing, and a connection left behind is exactly the leftover
     # that greens a later run.
-    child_report = (
-        PurgeReport(errors=listing_errors)
-        if listing_errors
-        else await _purge_children(client, connection_qualified_name, assets)
+    #
+    # A hit with no GUID is the other shape, and it is not the same one: the
+    # listing succeeded, the asset is known by name, and it simply cannot be
+    # deleted. It is folded in as orphaned so it appears on the report — a hit
+    # that is neither purged nor named would leave an asset on a shared tenant
+    # behind a report claiming the teardown was clean.
+    purged = await _purge_children(client, connection_qualified_name, listing.assets)
+    child_report = PurgeReport(
+        purged=purged.purged,
+        orphaned=(*listing.unusable, *purged.orphaned),
+        errors=(*listing.errors, *purged.errors),
     )
     connection_report = await _purge_connection_asset(client, connection_qualified_name)
     report = PurgeReport(
@@ -164,9 +171,34 @@ async def purge_connection(
     return report
 
 
+@dataclass(frozen=True, slots=True, kw_only=True)
+class _Listing:
+    """What one listing pass established about a connection's descendants.
+
+    Three fields rather than two because a hit can fail to be purgeable without
+    the *listing* having failed: see :attr:`unusable`. Every hit lands in exactly
+    one of them, which is what lets the caller build a report that accounts for
+    everything the search returned.
+
+    Attributes:
+        assets: ``(guid, qualified_name)`` for every hit that can be deleted.
+        unusable: Qualified names of hits Atlas returned with no GUID. Nothing
+            can delete these — ``purge_by_guid`` is the only verb available —
+            so they are orphaned from the moment they are read.
+        errors: One line per problem. Populated alongside :attr:`unusable`, or
+            alone when the search itself could not be read (in which case
+            nothing is known and both other fields are empty — a partial listing
+            would be a purge that under-reports what it left behind).
+    """
+
+    assets: Sequence[tuple[str, str]] = field(default_factory=tuple)
+    unusable: Sequence[str] = field(default_factory=tuple)
+    errors: Sequence[str] = field(default_factory=tuple)
+
+
 async def _list_children(
     client: AsyncAtlanClient, connection_qualified_name: str
-) -> tuple[Sequence[tuple[str, str]], Sequence[str]]:
+) -> _Listing:
     """Read every descendant's GUID and qualified name, in one pass.
 
     Both fields, not just the GUID the DELETE needs: :attr:`PurgeReport.orphaned`
@@ -175,10 +207,11 @@ async def _list_children(
     cleaning up by hand.
 
     Returns:
-        The ``(guid, qualified_name)`` pairs and an empty error tuple, or an
-        empty pair list and one error line. Never both populated: an unreadable
-        listing establishes nothing, and a partial one would be a purge that
-        under-reports what it left behind.
+        A :class:`_Listing`. **Every hit the search returned appears in exactly
+        one of its fields** — that is the invariant, and it is the one a purge
+        report depends on: a hit that is neither purged nor named as orphaned is
+        an asset left on a shared tenant behind a report that says the teardown
+        was clean.
     """
     from pyatlan.model.assets import Asset  # noqa: PLC0415
     from pyatlan.model.fluent_search import FluentSearch  # noqa: PLC0415
@@ -194,9 +227,18 @@ async def _list_children(
         request.dsl.size = _LISTING_PAGE_SIZE
         results = await client.asset.search(request)
         assets: list[tuple[str, str]] = []
+        unusable: list[str] = []
         async for asset in results:
             if asset.guid:
                 assets.append((asset.guid, asset.qualified_name or asset.guid))
+            else:
+                # Not skipped. `purge_by_guid` is the only delete available, so
+                # a hit Atlas could not attribute a GUID to cannot be deleted —
+                # but it exists, under this connection, and dropping it here
+                # would take it out of the report as well as out of the DELETE.
+                # The connection purge then succeeds and `complete` answers True
+                # over an asset still sitting on the tenant.
+                unusable.append(asset.qualified_name or "<asset with no GUID>")
     except Exception as error:
         logger.warning(
             "harness teardown: could not list assets under %s — nothing below the "
@@ -205,11 +247,19 @@ async def _list_children(
             connection_qualified_name,
             exc_info=True,
         )
-        return (), (
-            f"listing assets under {connection_qualified_name} failed: "
-            f"{sanitize_cause_repr(error)}",
+        return _Listing(
+            errors=(
+                f"listing assets under {connection_qualified_name} failed: "
+                f"{sanitize_cause_repr(error)}",
+            )
         )
-    return tuple(assets), ()
+    errors: tuple[str, ...] = ()
+    if unusable:
+        errors = (
+            f"{len(unusable)} listed asset(s) under {connection_qualified_name} "
+            "had no GUID and could not be purged",
+        )
+    return _Listing(assets=tuple(assets), unusable=tuple(unusable), errors=errors)
 
 
 async def _purge_children(

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -34,7 +34,7 @@ do-not-edit:   re-run the skill instead of hand-editing
 | `application_sdk.server` | FastAPI server, MCP integration, middleware, health endpoint | 4 |
 | `application_sdk.storage` | Object-store abstraction — factory, formats, batch, transfer, cloud bindings | 42 |
 | `application_sdk.templates` | SQL metadata extractor templates and their contracts | 6 |
-| `application_sdk.testing` | Test infrastructure — mocks, fixtures, hypothesis strategies, integration helpers | 212 |
+| `application_sdk.testing` | Test infrastructure — mocks, fixtures, hypothesis strategies, integration helpers | 220 |
 | `application_sdk.validation` | Offline artifact & asset validation — format-agnostic wrapper (ADR-0020) plus pyatlan_v9 .validate() wrappers, no network call | 78 |
 
 ## Subpackage Details
@@ -3091,7 +3091,7 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 #### `AERunHandle`
 
 - **Import:** `from application_sdk.testing.harness.starters import AERunHandle`
-- **Signature:** `class AERunHandle(*, workflow_slug: str, run_id: str)`
+- **Signature:** `class AERunHandle(*, workflow_slug: str, run_id: str, seed_version: int | None = None)`
 - **Summary:** A run started through the Automation Engine.
 - **Defined in:** `application_sdk/testing/harness/starters/_specs.py`
 
@@ -3102,6 +3102,13 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Signature:** `class AEWorkflowClient(tenant_url: str, ...)`
 - **Summary:** Thin sync wrapper over the harness's AE and Atlas readers.
 - **Defined in:** `application_sdk/testing/e2e/client.py`
+
+#### `AEWorkflowSpec`
+
+- **Import:** `from application_sdk.testing.harness.starters import AEWorkflowSpec`
+- **Signature:** `class AEWorkflowSpec(*, ...)`
+- **Summary:** A workflow to start through the Automation Engine.
+- **Defined in:** `application_sdk/testing/harness/starters/_specs.py`
 
 #### `APIType`
 
@@ -3727,6 +3734,13 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Summary:** Work started, then stopped making observable progress.
 - **Defined in:** `application_sdk/testing/harness/outcome.py`
 
+#### `SubmitRetry`
+
+- **Import:** `from application_sdk.testing.harness.starters import SubmitRetry`
+- **Signature:** `class SubmitRetry(*, retries: int, sleep_seconds: int)`
+- **Summary:** How hard the AE submit tries before it gives up.
+- **Defined in:** `application_sdk/testing/harness/starters/_specs.py`
+
 #### `SyncBridgeInAsyncContextError`
 
 - **Import:** `from application_sdk.testing.harness import SyncBridgeInAsyncContextError`
@@ -3988,6 +4002,13 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Signature:** `cold_start_submit_kwargs(timeout_seconds: int, poll_interval_seconds: int)`
 - **Summary:** Re-size the AE submit's retry to a cold start.
 - **Defined in:** `application_sdk/testing/harness/automation_engine/retry.py`
+
+#### `collect_pod_evidence`
+
+- **Import:** `from application_sdk.testing.harness.evidence import collect_pod_evidence`
+- **Signature:** `collect_pod_evidence(namespace: str, *, ...)`
+- **Summary:** Collect container logs and pod state from *namespace* into one bundle.
+- **Defined in:** `application_sdk/testing/harness/evidence.py`
 
 #### `compare_category`
 
@@ -4427,7 +4448,7 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 #### `purge_connection`
 
 - **Import:** `from application_sdk.testing.harness.teardown import purge_connection`
-- **Signature:** `purge_connection(connection_qualified_name: str) -> PurgeReport`
+- **Signature:** `purge_connection(client: AsyncAtlanClient, connection_qualified_name: str) -> PurgeReport`
 - **Summary:** Delete every asset under *connection_qualified_name*, then the connection.
 - **Defined in:** `application_sdk/testing/harness/teardown.py`
 
@@ -4441,8 +4462,15 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 #### `redact`
 
 - **Import:** `from application_sdk.testing.harness.evidence import redact`
-- **Signature:** `redact(bundle: EvidenceBundle) -> EvidenceBundle`
+- **Signature:** `redact(bundle: EvidenceBundle, *, secrets: Sequence[str] = ()) -> EvidenceBundle`
 - **Summary:** Return *bundle* with credential-shaped values replaced by placeholders.
+- **Defined in:** `application_sdk/testing/harness/evidence.py`
+
+#### `redact_text`
+
+- **Import:** `from application_sdk.testing.harness.evidence import redact_text`
+- **Signature:** `redact_text(text: str, *, secrets: Sequence[str] = ()) -> str`
+- **Summary:** Return *text* with credential-shaped and literally-known values blanked.
 - **Defined in:** `application_sdk/testing/harness/evidence.py`
 
 #### `run_comparison`
@@ -4474,6 +4502,13 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Summary:** Sample up to *per_type* qualified names per type under the connection.
 - **Defined in:** `application_sdk/testing/harness/atlas/__init__.py`
 
+#### `secrets_from_environment`
+
+- **Import:** `from application_sdk.testing.harness.evidence import secrets_from_environment`
+- **Signature:** `secrets_from_environment(environ: Mapping[str, str], *, also: Sequence[str] = ()) -> tuple[str, ...]`
+- **Summary:** Collect the literal values a run is holding, for :func:`redact`'s ``secrets``.
+- **Defined in:** `application_sdk/testing/harness/evidence.py`
+
 #### `stale_version_pollers`
 
 - **Import:** `from application_sdk.testing.harness.temporal import stale_version_pollers`
@@ -4498,9 +4533,9 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 #### `start_via_automation_engine`
 
 - **Import:** `from application_sdk.testing.harness.starters import start_via_automation_engine`
-- **Signature:** `start_via_automation_engine(spec: Mapping[str, object]) -> AERunHandle`
-- **Summary:** Start a run through the Automation Engine.
-- **Defined in:** `application_sdk/testing/harness/starters/__init__.py`
+- **Signature:** `start_via_automation_engine(spec: AEWorkflowSpec, *, client: AEClient, minter: Minter | None = None)`
+- **Summary:** Create, seed, publish and submit a workflow through the Automation Engine.
+- **Defined in:** `application_sdk/testing/harness/starters/_ae.py`
 
 #### `starts_with`
 
@@ -4536,6 +4571,13 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Signature:** `wait_for_workflow(namespace: str, ...)`
 - **Summary:** Poll GET /api/v1/workflows/{id} until the workflow reaches a terminal state.
 - **Defined in:** `application_sdk/testing/e2e/workflows.py`
+
+#### `write_bundle`
+
+- **Import:** `from application_sdk.testing.harness.evidence import write_bundle`
+- **Signature:** `write_bundle(bundle: EvidenceBundle, output_dir: Path, *, secrets: Sequence[str] = ()) -> Sequence[Path]`
+- **Summary:** Redact *bundle* and write it under *output_dir*.
+- **Defined in:** `application_sdk/testing/harness/evidence.py`
 
 ### Constants and Enums
 
@@ -4577,6 +4619,13 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Summary:** _(no docstring)_
 - **Defined in:** `application_sdk/testing/harness/outcome.py`
 
+#### `PLACEHOLDER`
+
+- **Import:** `from application_sdk.testing.harness.evidence import PLACEHOLDER`
+- **Signature:** `PLACEHOLDER`
+- **Summary:** _(no docstring)_
+- **Defined in:** `application_sdk/testing/harness/evidence.py`
+
 #### `Probe`
 
 - **Import:** `from application_sdk.testing.harness import Probe`
@@ -4605,6 +4654,13 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Signature:** `SampleRead: TypeAlias`
 - **Summary:** _(no docstring)_
 - **Defined in:** `application_sdk/testing/harness/expectations.py`
+
+#### `SECRET_KEY_FRAGMENTS`
+
+- **Import:** `from application_sdk.testing.harness.evidence import SECRET_KEY_FRAGMENTS`
+- **Signature:** `SECRET_KEY_FRAGMENTS: tuple[str, ...]`
+- **Summary:** _(no docstring)_
+- **Defined in:** `application_sdk/testing/harness/evidence.py`
 
 #### `UNREADABLE`
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -239,3 +239,30 @@ def mock_dapr_client():
     yield
     if ctx is not None:
         ctx.__exit__(None, None, None)
+
+
+@pytest.fixture(autouse=True)
+def e2e_evidence_stays_out_of_the_repo(tmp_path_factory, monkeypatch):
+    """Point the e2e evidence bundle at a temp directory for every unit test.
+
+    ``BaseE2ETest.evidence_dir`` defaults to ``results/e2e-evidence``, relative
+    to the working directory — which is right in CI, where ``results/`` is what
+    ``upload-artifact`` is pointed at, and wrong here, where the working
+    directory is the repo. Without this, any unit test that drives
+    ``test_full_dag_runs_end_to_end`` to a failure writes real files into the
+    checkout, and the first sign of it is an untracked directory in ``git
+    status`` rather than a failing assertion.
+
+    Autouse and class-level rather than a per-test opt-in, because the tests
+    that trip it are the ones *not* about evidence: they drive the failure path
+    for some unrelated reason and have no cause to know a bundle now exists. A
+    test that is about the bundle sets ``evidence_dir`` on its own instance,
+    which still wins.
+    """
+    from application_sdk.testing.e2e.base import BaseE2ETest
+
+    monkeypatch.setattr(
+        BaseE2ETest,
+        "evidence_dir",
+        str(tmp_path_factory.mktemp("e2e-evidence")),
+    )

--- a/tests/unit/testing/_atlas_fakes.py
+++ b/tests/unit/testing/_atlas_fakes.py
@@ -4,8 +4,13 @@ Only the network call is faked. ``FluentSearch`` still builds the real request,
 so a change to a filter, a page size or an ``include_on_results`` is still
 exercised — what the fake replaces is ``asset.search``, and nothing above it.
 
-Shared by the harness's own Atlas tests and by the tests of the sync
-``AEWorkflowClient`` adapter over them, so both drive the same seam.
+Shared by the harness's own Atlas tests, by the tests of the sync
+``AEWorkflowClient`` adapter over them, and by the teardown purge (child G) —
+so every consumer drives the same seam. The purge is why the result grew
+``__aiter__`` and why the asset API grew ``purge_by_guid``: a purge reads with
+the same ``asset.search`` the counts do and then writes through the one verb
+next to it, and a sibling double would let the two disagree about what a page
+looks like.
 """
 
 from __future__ import annotations
@@ -15,14 +20,28 @@ from typing import Any
 
 
 class FakeAsset:
-    """One search hit, carrying the single attribute the readers look at."""
+    """One search hit, carrying the attributes the readers look at.
 
-    def __init__(self, qualified_name: str) -> None:
+    ``guid`` defaults to one derived from the qualified name rather than to
+    ``None``: every existing caller constructs these positionally by name, and a
+    default of ``None`` would make them invisible to the purge — which skips a
+    hit with no GUID — turning a real regression into a passing test.
+    """
+
+    def __init__(self, qualified_name: str, guid: str | None = None) -> None:
         self.qualified_name = qualified_name
+        self.guid = f"guid-{qualified_name}" if guid is None else guid
 
 
 class FakeSearchResult:
-    """A search response: a ``count`` for the counting reads, a page for samples."""
+    """A search response: a ``count`` for the counting reads, a page for samples.
+
+    Iterable both ways. ``current_page`` is what the sampling reads call;
+    ``async for`` is what the purge's listing uses, and pyatlan's own
+    ``AsyncSearchResults.__aiter__`` pages until exhaustion — one page here,
+    because a fake that lied about pagination would hide the very bug the
+    read-everything-before-deleting order exists to prevent.
+    """
 
     def __init__(
         self, assets: list[FakeAsset] | None = None, *, count: int | None = None
@@ -33,24 +52,52 @@ class FakeSearchResult:
     def current_page(self) -> list[FakeAsset]:
         return self._assets
 
+    async def __aiter__(self):
+        for asset in self._assets:
+            yield asset
+
 
 class FakeAssetApi:
-    """``client.asset``, recording every request so a test can count the calls."""
+    """``client.asset``, recording every request so a test can count the calls.
 
-    def __init__(self, behavior: Callable[[Any], Any]) -> None:
+    Attributes:
+        requests: Every search request, in order.
+        purged: Every ``purge_by_guid`` argument, in order — a list of GUIDs or
+            a single GUID, recorded exactly as it was passed so a test can pin
+            the batch boundaries rather than only the total.
+    """
+
+    def __init__(
+        self,
+        behavior: Callable[[Any], Any],
+        *,
+        on_purge: Callable[[Any], None] | None = None,
+    ) -> None:
         self._behavior = behavior
+        self._on_purge = on_purge
         self.requests: list[Any] = []
+        self.purged: list[Any] = []
 
     async def search(self, request: Any) -> Any:
         self.requests.append(request)
         return self._behavior(request)
 
+    async def purge_by_guid(self, guid: Any) -> None:
+        self.purged.append(guid)
+        if self._on_purge is not None:
+            self._on_purge(guid)
+
 
 class FakeAtlasClient:
     """What :func:`~application_sdk.testing.harness.atlas.atlas_client` yields."""
 
-    def __init__(self, behavior: Callable[[Any], Any]) -> None:
-        self.asset = FakeAssetApi(behavior)
+    def __init__(
+        self,
+        behavior: Callable[[Any], Any],
+        *,
+        on_purge: Callable[[Any], None] | None = None,
+    ) -> None:
+        self.asset = FakeAssetApi(behavior, on_purge=on_purge)
 
     @property
     def searches(self) -> int:

--- a/tests/unit/testing/e2e/test_failure_evidence.py
+++ b/tests/unit/testing/e2e/test_failure_evidence.py
@@ -92,7 +92,11 @@ def _outcome(*, failed: bool = True) -> FullDAGOutcome:
 
 
 def _written(tmp_path: Path) -> str:
-    return "\n".join(path.read_text() for path in tmp_path.rglob("*") if path.is_file())
+    return "\n".join(
+        path.read_text(encoding="utf-8")
+        for path in tmp_path.rglob("*")
+        if path.is_file()
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -105,7 +109,9 @@ def test_a_failed_run_leaves_a_bundle_under_the_evidence_dir(tmp_path: Path) -> 
 
     suite._collect_failure_evidence(AssertionError("Full-DAG e2e failed"), _outcome())
 
-    report = json.loads((tmp_path / "_Suite" / "report.json").read_text())
+    report = json.loads(
+        (tmp_path / "_Suite" / "report.json").read_text(encoding="utf-8")
+    )
     assert report["readings"]["ae_run_id"] == "ae-run-1"
     assert report["readings"]["connector"] == "postgres"
     assert report["findings"][0]["subject"] == "AssertionError"
@@ -118,7 +124,9 @@ def test_the_per_node_table_lands_machine_readable(tmp_path: Path) -> None:
 
     suite._collect_failure_evidence(AssertionError("nope"), _outcome())
 
-    report = json.loads((tmp_path / "_Suite" / "report.json").read_text())
+    report = json.loads(
+        (tmp_path / "_Suite" / "report.json").read_text(encoding="utf-8")
+    )
     assert report["readings"]["dag_nodes"][0]["name"] == "extract"
     assert report["readings"]["dag_nodes"][0]["status"] == DAGNodeStatus.FAILED.value
 
@@ -134,7 +142,9 @@ def test_a_run_that_failed_before_the_outcome_still_leaves_the_identity(
 
     suite._collect_failure_evidence(RuntimeError("AE never answered"), None)
 
-    report = json.loads((tmp_path / "_Suite" / "report.json").read_text())
+    report = json.loads(
+        (tmp_path / "_Suite" / "report.json").read_text(encoding="utf-8")
+    )
     assert report["readings"]["seed_version"] == 1_700_000_099
     assert report["readings"]["connection_qualified_name"] == _CONN_QN
     assert "ae_run_id" not in report["readings"]
@@ -147,7 +157,9 @@ def test_the_traceback_ships_as_its_own_artifact(tmp_path: Path) -> None:
     except ValueError as error:
         suite._collect_failure_evidence(error, None)
 
-    assert "ValueError: boom" in (tmp_path / "_Suite" / "traceback.txt").read_text()
+    assert "ValueError: boom" in (tmp_path / "_Suite" / "traceback.txt").read_text(
+        encoding="utf-8"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/testing/e2e/test_failure_evidence.py
+++ b/tests/unit/testing/e2e/test_failure_evidence.py
@@ -1,0 +1,256 @@
+"""The connector failure path leaves a redacted evidence bundle behind (FND-243).
+
+``LogCollector`` has existed on ``testing/e2e/logs.py`` since the K8s harness
+landed and is called from nowhere, so until now a failed full-DAG run collected
+no evidence at all. FND-243 wires collection in — but not by calling that
+collector, and the correction is worth pinning rather than leaving in a PR
+description.
+
+**There is no cluster to collect from on this path.** The connector e2e leg runs
+a Docker-compose container on the runner against a remote tenant; nothing in
+``e2e-full-reusable.yaml`` or the shared ``sdr-e2e`` composite establishes a
+``kubectl`` route into the tenant vcluster. That is the same constraint that
+makes the AE submit the only tenant-facing probe of the installed app pod. So
+the pod half of an evidence bundle is not collectable here, and what a failed
+connector leg can leave behind is the AE run's identity, the per-node table, the
+Atlas readings and the traceback — which is what it now does. The local
+container's log is dumped into the same ``results/`` directory by the CI action,
+so the two arrive in one artifact.
+
+The directory is the other half of the wiring, and it is why this needs no
+workflow change: ``results/`` is already where ``upload-artifact`` is pointed.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from application_sdk.testing.e2e import BaseE2ETest
+from application_sdk.testing.e2e.base import FullDAGOutcome
+from application_sdk.testing.e2e.client import (
+    DAGNodeResult,
+    DAGNodeStatus,
+    DAGRunResult,
+    DAGRunStatus,
+)
+from application_sdk.testing.harness.evidence import PLACEHOLDER
+
+_CONN_QN = "default/postgres/1700000000042"
+
+
+class _Suite(BaseE2ETest):
+    connector_short_name = "postgres"
+    argo_package_name = "@atlan/postgres"
+    argo_template_name = "postgres"
+
+
+def _suite(tmp_path: Path) -> _Suite:
+    """A suite with just the attributes the evidence builder reads.
+
+    Built by hand rather than through ``setup_method``, which needs a tenant in
+    the environment. What is under test is what the builder puts in the bundle,
+    not how the suite got its identity.
+    """
+    suite = _Suite()
+    suite.evidence_dir = str(tmp_path)
+    suite.run_id = 1_700_000_000
+    suite.connection_qualified_name = _CONN_QN
+    suite._node_dispatch = {}
+    suite._expected_node_identities = {}
+    suite._seed_version = 1_700_000_099
+    return suite
+
+
+def _outcome(*, failed: bool = True) -> FullDAGOutcome:
+    return FullDAGOutcome(
+        ae_result=DAGRunResult(
+            run_id="ae-run-1",
+            workflow_slug="postgres-e2e-1",
+            status=DAGRunStatus.FAILED if failed else DAGRunStatus.SUCCEEDED,
+            nodes=[
+                DAGNodeResult(
+                    name="extract",
+                    status=DAGNodeStatus.FAILED,
+                    started_at_ms=1_000,
+                    completed_at_ms=3_000,
+                    error_message="auth failed for password=hunter2",
+                ),
+            ],
+        ),
+        connection_qualified_name=_CONN_QN,
+        connection_in_atlas=False,
+        asset_counts={"Table": 0},
+        total_assets=0,
+        lineage_present=False,
+        asset_qn_samples={},
+        connection_expected=True,
+    )
+
+
+def _written(tmp_path: Path) -> str:
+    return "\n".join(path.read_text() for path in tmp_path.rglob("*") if path.is_file())
+
+
+# ---------------------------------------------------------------------------
+# What lands
+# ---------------------------------------------------------------------------
+
+
+def test_a_failed_run_leaves_a_bundle_under_the_evidence_dir(tmp_path: Path) -> None:
+    suite = _suite(tmp_path)
+
+    suite._collect_failure_evidence(AssertionError("Full-DAG e2e failed"), _outcome())
+
+    report = json.loads((tmp_path / "_Suite" / "report.json").read_text())
+    assert report["readings"]["ae_run_id"] == "ae-run-1"
+    assert report["readings"]["connector"] == "postgres"
+    assert report["findings"][0]["subject"] == "AssertionError"
+
+
+def test_the_per_node_table_lands_machine_readable(tmp_path: Path) -> None:
+    """The single most-read part of a failed leg, so it goes in the half a script
+    can group on rather than only into the rendered text beside it."""
+    suite = _suite(tmp_path)
+
+    suite._collect_failure_evidence(AssertionError("nope"), _outcome())
+
+    report = json.loads((tmp_path / "_Suite" / "report.json").read_text())
+    assert report["readings"]["dag_nodes"][0]["name"] == "extract"
+    assert report["readings"]["dag_nodes"][0]["status"] == DAGNodeStatus.FAILED.value
+
+
+def test_a_run_that_failed_before_the_outcome_still_leaves_the_identity(
+    tmp_path: Path,
+) -> None:
+    """The runs that most need evidence are the ones where ``run_full_dag``
+    itself raised — a stalled DAG, a pod that never served — and there is no
+    outcome to describe. The connector, the queue and the seed version are still
+    knowable, and after the job is gone this file is where they exist."""
+    suite = _suite(tmp_path)
+
+    suite._collect_failure_evidence(RuntimeError("AE never answered"), None)
+
+    report = json.loads((tmp_path / "_Suite" / "report.json").read_text())
+    assert report["readings"]["seed_version"] == 1_700_000_099
+    assert report["readings"]["connection_qualified_name"] == _CONN_QN
+    assert "ae_run_id" not in report["readings"]
+
+
+def test_the_traceback_ships_as_its_own_artifact(tmp_path: Path) -> None:
+    suite = _suite(tmp_path)
+    try:
+        raise ValueError("boom")
+    except ValueError as error:
+        suite._collect_failure_evidence(error, None)
+
+    assert "ValueError: boom" in (tmp_path / "_Suite" / "traceback.txt").read_text()
+
+
+# ---------------------------------------------------------------------------
+# Redaction, which is the point
+# ---------------------------------------------------------------------------
+
+
+def test_a_credential_in_a_node_error_does_not_reach_the_artifact(
+    tmp_path: Path,
+) -> None:
+    """A driver's own message is where a connection-string password most often
+    surfaces, and the node error is that message quoted verbatim."""
+    suite = _suite(tmp_path)
+
+    suite._collect_failure_evidence(AssertionError("nope"), _outcome())
+
+    written = _written(tmp_path)
+    assert "hunter2" not in written
+    assert PLACEHOLDER in written
+
+
+def test_the_ambient_api_key_does_not_reach_the_artifact(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The value the harness is holding, blanked by literal rather than by key
+    name — it reaches a log with no key beside it, which is the shape key
+    matching cannot see."""
+    monkeypatch.setenv("ATLAN_API_KEY", "atlan-secret-token")
+    suite = _suite(tmp_path)
+
+    suite._collect_failure_evidence(
+        AssertionError("submit rejected: sent atlan-secret-token"), None
+    )
+
+    assert "atlan-secret-token" not in _written(tmp_path)
+
+
+def test_the_tenant_hostname_does_not_reach_the_artifact(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Not a credential, but it identifies a customer environment and the bundle
+    is uploaded and retained."""
+    monkeypatch.setenv("ATLAN_BASE_URL", "https://a-real-tenant.atlan.com")
+    suite = _suite(tmp_path)
+
+    suite._collect_failure_evidence(
+        AssertionError("GET https://a-real-tenant.atlan.com/api failed"), None
+    )
+
+    assert "a-real-tenant" not in _written(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# It cannot become the failure
+# ---------------------------------------------------------------------------
+
+
+def test_a_collector_failure_does_not_replace_the_verdict(tmp_path: Path) -> None:
+    """This runs inside an ``except`` block whose job is to re-raise a real
+    failure. A collector that raised would replace the thing being diagnosed —
+    the exact miscue ``teardown_method`` is written to avoid."""
+    suite = _suite(tmp_path)
+
+    def _explode(*_args: Any, **_kwargs: Any) -> None:
+        raise RuntimeError("evidence is broken")
+
+    suite._failure_evidence = _explode  # type: ignore[method-assign]
+
+    suite._collect_failure_evidence(AssertionError("the real failure"), None)
+
+
+def test_an_empty_evidence_dir_writes_nothing(tmp_path: Path) -> None:
+    """The documented opt-out, for a suite that has somewhere else to put it."""
+    suite = _suite(tmp_path)
+    suite.evidence_dir = ""
+
+    suite._collect_failure_evidence(AssertionError("nope"), _outcome())
+
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_a_passing_run_writes_nothing(tmp_path: Path) -> None:
+    """The wrapper only fires on the way out through an exception, so a green leg
+    does not pay for the bundle or ship one nobody asked for."""
+    suite = _suite(tmp_path)
+    suite.source_available = True
+    suite.expect_connection = False
+    suite.run_full_dag = lambda: _outcome(failed=False)  # type: ignore[method-assign]
+    suite._core_dag_ok = lambda _result: True  # type: ignore[method-assign]
+
+    suite.test_full_dag_runs_end_to_end()
+
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_the_assertion_failure_is_re_raised_after_collection(tmp_path: Path) -> None:
+    """Collect, then re-raise unchanged. Swallowing here would turn a red leg
+    green, which is a strictly worse bug than collecting nothing."""
+    suite = _suite(tmp_path)
+    suite.source_available = True
+    suite.run_full_dag = lambda: _outcome()  # type: ignore[method-assign]
+
+    with pytest.raises(AssertionError, match="Full-DAG e2e failed"):
+        suite.test_full_dag_runs_end_to_end()
+
+    assert (tmp_path / "_Suite" / "report.json").exists()

--- a/tests/unit/testing/harness/starters/test_ae_starter.py
+++ b/tests/unit/testing/harness/starters/test_ae_starter.py
@@ -1,0 +1,367 @@
+"""Unit tests for the AE starter (child G, FND-243).
+
+**A differential, unlike its sibling.** The queue starter's tests are claims,
+because nothing dispatched onto a task queue before it. This one lifts
+``BaseE2ETest._bootstrap_workflow`` plus the submit half of ``run_full_dag``, so
+the thing under test is a *sequence that already existed* and the tests can pin
+it against what that sequence did.
+
+Every step therefore goes through the real
+:class:`~application_sdk.testing.harness.automation_engine.AEClient` with only
+its ``_request`` scripted. That is deliberate rather than convenient: the
+starter's whole content is the order of four calls and what it does with their
+answers, so a double that replaced the client would assert the starter against a
+model of AE rather than against AE's own parsers — and every response-shape
+decision (which envelope the slug is read from, which field carries the version,
+what an empty ``run_id`` means) would stop being exercised.
+
+The two properties most worth having:
+
+* **The version that is published is the version AE assigned**, not the one the
+  starter asked for. AE's create returns the number it chose; publishing the
+  requested one 404s on a mismatch, and worse, leaves the run comparing its seed
+  against a version it never published — which is the read that decides whether
+  the tenant's own manifest superseded the harness'.
+* **A pre-existing slug is never seeded over.** The DAG under it belongs to
+  whoever set it up, and a run that replaced it would break the *next* run
+  against that slug rather than its own.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from application_sdk.testing.harness.automation_engine._errors import AtlanApiHttpError
+from application_sdk.testing.harness.automation_engine.client import AEClient
+from application_sdk.testing.harness.identity import Minter
+from application_sdk.testing.harness.starters import (
+    AERunHandle,
+    AEWorkflowSpec,
+    SubmitRetry,
+    start_via_automation_engine,
+)
+
+_SLEEP = "application_sdk.testing.harness.automation_engine.client.sleep_async"
+_SEED_DAG: dict[str, object] = {"nodes": {"extract": {"queue": "atlan-postgres-prod"}}}
+_PAYLOAD: dict[str, object] = {"metadata": {"entrypoint": "crawler"}}
+
+
+class _AE:
+    """Scripted AE, recording every request the starter makes.
+
+    Routes on the path rather than on call ordering, so a reordering of the
+    sequence changes what the recorder sees rather than passing by coincidence.
+    """
+
+    def __init__(
+        self,
+        *,
+        slug: str = "pg-e2e-1",
+        assigned_version: int = 1_700_000_099,
+        run_id: str = "run-abc",
+        overrides: dict[str, tuple[int, Any]] | None = None,
+    ) -> None:
+        self.slug = slug
+        self.assigned_version = assigned_version
+        self.run_id = run_id
+        self._overrides = overrides or {}
+        self.calls: list[tuple[str, str, Any]] = []
+
+    async def request(
+        self, method: str, path: str, *, body: Any = None, **_kwargs: Any
+    ) -> tuple[int, Any]:
+        self.calls.append((method, path, body))
+        for fragment, response in self._overrides.items():
+            if fragment in path:
+                return response
+        if path.endswith("/versions") and method == "POST":
+            return 200, {"data": {"version": self.assigned_version}}
+        if path.endswith("/publish"):
+            return 200, {"status": "success"}
+        if "/versions?" in path or path.endswith("/versions?page=0&page_size=1"):
+            return 200, {"data": [{"version": 1}]}
+        if "package-workflows" in path:
+            return 200, {"data": {"run_id": self.run_id}}
+        if path.endswith("/workflows"):
+            return 200, {"data": {"slug": self.slug}}
+        return 200, {"data": []}
+
+    @property
+    def paths(self) -> list[str]:
+        return [path for _method, path, _body in self.calls]
+
+    def body_for(self, fragment: str, *, method: str = "POST") -> Any:
+        """The body of the first *method* request whose path contains *fragment*.
+
+        The method filter is load-bearing rather than tidy: ``/versions`` is the
+        create *and* the slug-resolve GET beside it, and matching the GET returns
+        a ``None`` body that reads as "the starter sent nothing".
+        """
+        for called_method, path, body in self.calls:
+            if called_method == method and fragment in path:
+                return body
+        raise AssertionError(f"no {method} matched {fragment!r}: {self.paths}")
+
+
+def _minter(second: int = 1_700_000_000) -> Minter:
+    """A minter whose numbers are a function of its inputs, so they can be pinned."""
+    return Minter(clock=lambda: second, randbelow=lambda _bound: 42)
+
+
+def _spec(**overrides: Any) -> AEWorkflowSpec:
+    return AEWorkflowSpec(
+        **{
+            "name": "postgres-e2e-ci-1700000000",
+            "seed_dag": _SEED_DAG,
+            "payload": _PAYLOAD,
+            **overrides,
+        }
+    )
+
+
+async def _start(ae: _AE, spec: AEWorkflowSpec, **kwargs: Any) -> AERunHandle:
+    client = AEClient("https://tenant.example.com", "tok")
+    with patch.object(client, "_request", side_effect=ae.request):
+        return await start_via_automation_engine(spec, client=client, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# The sequence
+# ---------------------------------------------------------------------------
+
+
+async def test_the_four_writes_happen_in_the_order_ae_requires():
+    """Create, then resolve, then seed, then publish, then submit.
+
+    Not an arbitrary order: AE 404s a submit against a slug with no *published*
+    version, and 404s a version create against a slug it has not indexed yet.
+    """
+    ae = _AE()
+
+    await _start(ae, _spec(), minter=_minter())
+
+    assert ae.paths == [
+        "/automation/api/v1/workflows",
+        "/automation/api/v1/workflows/pg-e2e-1/versions?page=0&page_size=1",
+        "/automation/api/v1/workflows/pg-e2e-1/versions",
+        "/automation/api/v1/workflows/pg-e2e-1/versions/1700000099/publish",
+        "/api/service/package-workflows?submit=true",
+    ]
+
+
+async def test_the_handle_names_the_run_the_slug_and_the_seed():
+    ae = _AE()
+
+    handle = await _start(ae, _spec(), minter=_minter())
+
+    assert handle == AERunHandle(
+        workflow_slug="pg-e2e-1", run_id="run-abc", seed_version=1_700_000_099
+    )
+
+
+async def test_the_seed_dag_is_sent_verbatim():
+    """AE's submit republishes the tenant's own manifest over this, so the seed's
+    job is only to make the workflow submittable — which means the harness has no
+    business rewriting it on the way through."""
+    ae = _AE()
+
+    await _start(ae, _spec(), minter=_minter())
+
+    assert ae.body_for("/versions") == {"version": 1_700_000_000, "dag": _SEED_DAG}
+
+
+async def test_the_payload_is_sent_verbatim():
+    ae = _AE()
+
+    await _start(ae, _spec(), minter=_minter())
+
+    assert ae.body_for("package-workflows") == _PAYLOAD
+
+
+# ---------------------------------------------------------------------------
+# The version, which is where a plausible implementation goes wrong
+# ---------------------------------------------------------------------------
+
+
+async def test_the_published_version_is_the_one_ae_assigned():
+    """AE chooses the number; the request is a suggestion.
+
+    Publishing the *requested* number instead 404s whenever AE picked another —
+    and on the runs where it silently did not, the handle would name a version
+    the harness never published, so the supersede check would compare its seed
+    against a version that does not exist.
+    """
+    ae = _AE(assigned_version=1_700_000_555)
+
+    handle = await _start(ae, _spec(version=1_700_000_000), minter=_minter())
+
+    assert "/versions/1700000555/publish" in ae.paths[3]
+    assert handle.seed_version == 1_700_000_555
+
+
+async def test_an_explicit_version_is_what_gets_requested():
+    ae = _AE()
+
+    await _start(ae, _spec(version=99), minter=_minter())
+
+    assert ae.body_for("/versions")["version"] == 99
+
+
+async def test_the_minted_version_is_the_clock_not_the_ci_run_id():
+    """``GITHUB_RUN_ID`` is constant across every leg of one job, so minting from
+    it would make a second seed in that job indistinguishable from the first —
+    and the supersede check reads the second as the tenant's own manifest."""
+    ae = _AE()
+    minter = Minter(
+        clock=lambda: 1_700_000_000, randbelow=lambda _b: 42, run_id_env="42"
+    )
+
+    await _start(ae, _spec(), minter=minter)
+
+    assert ae.body_for("/versions")["version"] == 1_700_000_000
+
+
+async def test_no_minter_still_starts():
+    """The default builds one over the real clock, so a caller with no identity
+    concerns does not have to construct one to dispatch."""
+    ae = _AE()
+
+    handle = await _start(ae, _spec())
+
+    assert handle.run_id == "run-abc"
+    assert handle.seed_version == 1_700_000_099
+
+
+# ---------------------------------------------------------------------------
+# The pre-existing slug
+# ---------------------------------------------------------------------------
+
+
+async def test_a_pre_existing_slug_is_submitted_against_and_never_seeded_over():
+    """One request, and it is the submit. Nothing is created and nothing is
+    published: the DAG under that slug is not this run's to replace."""
+    ae = _AE()
+
+    handle = await _start(ae, _spec(slug="someone-elses"), minter=_minter())
+
+    assert ae.paths == ["/api/service/package-workflows?submit=true"]
+    assert handle.workflow_slug == "someone-elses"
+
+
+async def test_a_pre_existing_slug_reports_no_seed_version():
+    """``None`` rather than a number, because nothing was published — which is
+    exactly the branch ``_supersedes`` treats as "there is nothing for AE to have
+    superseded"."""
+    ae = _AE()
+
+    handle = await _start(ae, _spec(slug="someone-elses"), minter=_minter())
+
+    assert handle.seed_version is None
+
+
+# ---------------------------------------------------------------------------
+# The submit's budget
+# ---------------------------------------------------------------------------
+
+
+async def test_the_submit_retry_is_passed_through_when_one_is_given():
+    """Sized for a pod cold start rather than for AE overload, and applied to the
+    submit's *own* retry loop — a second loop around it would re-enter the
+    non-idempotent POST past the credential-name rotation that makes it safe."""
+    ae = _AE(overrides={"package-workflows": (503, {"error": "cold"})})
+    client = AEClient("https://tenant.example.com", "tok")
+
+    with (
+        patch.object(client, "_request", side_effect=ae.request),
+        patch(_SLEEP) as sleep,
+        pytest.raises(AtlanApiHttpError),
+    ):
+        await start_via_automation_engine(
+            _spec(submit_retry=SubmitRetry(retries=3, sleep_seconds=7)),
+            client=client,
+            minter=_minter(),
+        )
+
+    submits = [path for path in ae.paths if "package-workflows" in path]
+    assert len(submits) == 4  # the initial attempt plus three retries
+    assert [call.args[0] for call in sleep.call_args_list] == [7, 7, 7]
+
+
+async def test_without_a_submit_retry_the_clients_own_default_applies():
+    ae = _AE(overrides={"package-workflows": (503, {"error": "cold"})})
+    client = AEClient("https://tenant.example.com", "tok")
+
+    with (
+        patch.object(client, "_request", side_effect=ae.request),
+        patch(_SLEEP),
+        pytest.raises(AtlanApiHttpError),
+    ):
+        await start_via_automation_engine(_spec(), client=client, minter=_minter())
+
+    submits = [path for path in ae.paths if "package-workflows" in path]
+    assert len(submits) == 5  # submit_workflow's documented retries=4 default
+
+
+def test_the_cold_start_sizing_calls_the_canonical_derivation():
+    """Asserted against the shared function rather than against literals, so this
+    cannot pass while the harness has grown a second copy of the arithmetic."""
+    from application_sdk.testing.harness.automation_engine import (
+        cold_start_submit_kwargs,
+    )
+
+    sizing = cold_start_submit_kwargs(600, 10)
+    retry = SubmitRetry.for_cold_start(timeout_seconds=600, poll_interval_seconds=10)
+
+    assert retry is not None
+    assert retry.retries == sizing["retries"]
+    assert retry.sleep_seconds == sizing["retry_sleep_seconds"]
+
+
+def test_a_disabled_cold_start_budget_is_no_sizing_at_all():
+    """``None``, not ``SubmitRetry(0, 0)``: zero retries at a zero gap is a
+    *different* instruction from "leave the submit's own defaults alone", and the
+    lifted code spelled the second one as an empty kwargs dict."""
+    assert (
+        SubmitRetry.for_cold_start(timeout_seconds=0, poll_interval_seconds=10) is None
+    )
+
+
+# ---------------------------------------------------------------------------
+# What is deliberately not converted
+# ---------------------------------------------------------------------------
+
+
+async def test_an_ae_failure_arrives_as_ae_own_leaf():
+    """Not wrapped in a starter-specific error. An operator already knows how to
+    read ``AtlanApiHttpError``, and a second classification of the same responses
+    is the divergence this project exists to remove."""
+    ae = _AE(overrides={"/workflows": (500, {"error": "nope"})})
+    client = AEClient("https://tenant.example.com", "tok")
+
+    with (
+        patch.object(client, "_request", side_effect=ae.request),
+        patch(_SLEEP),
+        pytest.raises(AtlanApiHttpError) as caught,
+    ):
+        await start_via_automation_engine(_spec(), client=client, minter=_minter())
+
+    assert "create_workflow" in str(caught.value)
+
+
+async def test_the_client_is_not_closed():
+    """The transport's lifetime stays with whoever opened it — a caller that goes
+    on to poll ``native-status`` through the same client must not find it shut."""
+    ae = _AE()
+    client = AEClient("https://tenant.example.com", "tok")
+    closed: list[bool] = []
+
+    with (
+        patch.object(client, "_request", side_effect=ae.request),
+        patch.object(client, "aclose", side_effect=lambda: closed.append(True)),
+    ):
+        await start_via_automation_engine(_spec(), client=client, minter=_minter())
+
+    assert closed == []

--- a/tests/unit/testing/harness/test_evidence.py
+++ b/tests/unit/testing/harness/test_evidence.py
@@ -51,18 +51,18 @@ from application_sdk.testing.harness.expectations import UNREADABLE, Finding
 
 
 @pytest.mark.parametrize(
-    ("line", "leaked"),
+    ("line", "expected"),
     [
-        ("password=hunter2 host=db1", "hunter2"),
-        ('"apiKey": "abc123def"', "abc123def"),
-        ("'client_secret': 'shh-dont'", "shh-dont"),
-        ("Authorization: Bearer eyJhbGciOiJIUzI1NiJ9", "eyJhbGciOiJIUzI1NiJ9"),
-        ("DRIVER={x};UID=sa;PWD={se;cret};", "se;cret"),
-        ("X-Api-Key: zzz-top-secret", "zzz-top-secret"),
-        ("AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI", "wJalrXUtnFEMI"),
-        ("postgresql://svc:pa55@db.internal/x", "pa55"),
-        ("set-cookie: session=deadbeef", "deadbeef"),
-        ("private_key=-----BEGIN", "-----BEGIN"),
+        ("password=hunter2 host=db1", "password=*** host=db1"),
+        ('"apiKey": "abc123def"', '"apiKey": "***"'),
+        ("'client_secret': 'shh-dont'", "'client_secret': '***'"),
+        ("Authorization: Bearer eyJhbGciOiJIUzI1NiJ9", "Authorization: ***"),
+        ("DRIVER={x};UID=sa;PWD={se;cret};", "DRIVER={x};UID=sa;PWD=***;"),
+        ("X-Api-Key: zzz-top-secret", "X-Api-Key: ***"),
+        ("AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI", "AWS_SECRET_ACCESS_KEY=***"),
+        ("postgresql://svc:pa55@db.internal/x", "postgresql://***@db.internal/x"),
+        ("set-cookie: session=deadbeef", "set-cookie: ***"),
+        ("private_key=-----BEGIN", "private_key=***"),
     ],
     ids=[
         "bare key=value",
@@ -77,9 +77,22 @@ from application_sdk.testing.harness.expectations import UNREADABLE, Finding
         "PEM body",
     ],
 )
-def test_a_credential_shaped_value_does_not_survive(line: str, leaked: str) -> None:
-    assert leaked not in redact_text(line)
-    assert PLACEHOLDER in redact_text(line)
+def test_a_credential_shaped_value_does_not_survive(line: str, expected: str) -> None:
+    """Exact equality, not ``leaked not in redacted``.
+
+    The weaker form was here first and it cannot reject the failure that
+    actually happens. Partial redaction — the escaped-quote truncation, a value
+    class that stops one character early — leaves output that satisfies every
+    "the secret is gone"-shaped assertion you can write about it: the *whole*
+    literal is indeed absent, and a placeholder is indeed present. Only naming
+    the entire expected line rejects a residue.
+
+    It also pins the other half of the contract, which a negative assertion
+    cannot express at all: that the neighbouring host, the ODBC ``UID`` and the
+    next ``key=value`` pair **survive**. An over-redacting filter is a bundle
+    nobody can act on, and it would pass the weak form perfectly.
+    """
+    assert redact_text(line) == expected
 
 
 def test_the_neighbouring_pair_in_a_connection_string_survives() -> None:
@@ -130,7 +143,9 @@ def test_a_bare_literal_with_no_key_beside_it_is_blanked() -> None:
     prior art registers values rather than names."""
     line = "GET /api/meta/atlas?t=glpat-ABCDEF failed"
 
-    assert "glpat-ABCDEF" not in redact_text(line, secrets=["glpat-ABCDEF"])
+    assert redact_text(line, secrets=["glpat-ABCDEF"]) == (
+        f"GET /api/meta/atlas?t={PLACEHOLDER} failed"
+    )
 
 
 def test_a_two_character_literal_is_ignored() -> None:
@@ -140,15 +155,15 @@ def test_a_two_character_literal_is_ignored() -> None:
 
 
 @pytest.mark.parametrize(
-    "line",
+    ("line", "expected"),
     [
-        r'"password": "part\"secret"',
-        r"{'client_secret': 'a\'b'}",
+        (r'"password": "part\"secret"', '"password": "***"'),
+        (r"{'client_secret': 'a\'b'}", "{'client_secret': '***'}"),
     ],
     ids=["JSON with an escaped double quote", "escaped single quote"],
 )
 def test_an_escaped_quote_inside_a_value_does_not_truncate_the_match(
-    line: str,
+    line: str, expected: str
 ) -> None:
     """The tail after an escaped quote is the leak a naive ``"[^"]*"`` ships.
 
@@ -156,12 +171,17 @@ def test_an_escaped_quote_inside_a_value_does_not_truncate_the_match(
     the log, so this is the *normal* shape for such a value rather than an edge
     case — and truncating at the escape leaves the remainder in an uploaded
     artifact while the line still looks redacted.
-    """
-    redacted = redact_text(line)
 
-    assert "secret" not in redacted or "part" not in redacted
-    assert PLACEHOLDER in redacted
-    assert redacted.count(PLACEHOLDER) == 1
+    **Exact equality, and that is the point.** The first version of this test
+    asserted ``"secret" not in redacted or "part" not in redacted``, plus a
+    placeholder count — and all three of those hold for the *buggy* output
+    ``'"password": "***"secret"'``, because ``part`` is already gone and there
+    is still exactly one placeholder. A revert of ``_KEYED_VALUE_RE`` would have
+    gone green. A partial-redaction bug leaves output that satisfies every
+    "the secret is gone"-shaped assertion you can write about it; only naming
+    the whole expected line rejects it.
+    """
+    assert redact_text(line) == expected
 
 
 def test_the_replacement_order_is_enforced_where_the_replacing_happens() -> None:
@@ -292,7 +312,16 @@ def test_redaction_is_idempotent() -> None:
 
 def test_write_bundle_redacts_without_being_asked(tmp_path: Path) -> None:
     """This is the boundary the bundle crosses. Making redaction the caller's
-    responsibility is what leaves the one path that forgot."""
+    responsibility is what leaves the one path that forgot.
+
+    Absence over the whole written directory rather than exact equality, and
+    deliberately so: the question at *this* level is whether every file the
+    boundary produces went through the filter, not what the filter does to one
+    line. What the filter does is pinned exactly, line by line, above — so a
+    partial-redaction residue is rejected there, where the assertion can name a
+    whole expected output, rather than here, where it would have to name a
+    directory.
+    """
     write_bundle(_bundle(), tmp_path, secrets=["hunter2"])
 
     written = "\n".join(

--- a/tests/unit/testing/harness/test_evidence.py
+++ b/tests/unit/testing/harness/test_evidence.py
@@ -256,7 +256,9 @@ def test_write_bundle_redacts_without_being_asked(tmp_path: Path) -> None:
     write_bundle(_bundle(), tmp_path, secrets=["hunter2"])
 
     written = "\n".join(
-        path.read_text() for path in tmp_path.rglob("*") if path.is_file()
+        path.read_text(encoding="utf-8")
+        for path in tmp_path.rglob("*")
+        if path.is_file()
     )
     assert "hunter2" not in written
     assert "abc123" not in written
@@ -265,11 +267,43 @@ def test_write_bundle_redacts_without_being_asked(tmp_path: Path) -> None:
 def test_the_report_is_machine_readable(tmp_path: Path) -> None:
     write_bundle(_bundle(), tmp_path)
 
-    report = json.loads((tmp_path / "report.json").read_text())
+    report = json.loads((tmp_path / "report.json").read_text(encoding="utf-8"))
 
     assert report["label"] == "TestPostgresE2E — postgres"
     assert [finding["subject"] for finding in report["findings"]] == ["Table", "Column"]
     assert report["readings"]["asset_counts"] == {"Table": 0, "Column": 0}
+
+
+def test_the_bundle_round_trips_non_ascii(tmp_path: Path) -> None:
+    """Every file is UTF-8, and reading one back needs to say so.
+
+    This is a regression test with a specific history: the first revision's
+    assertions read with a bare ``read_text()``, which uses the *locale*
+    encoding — UTF-8 on Linux and macOS, cp1252 on Windows. The suite was green
+    on two platforms and red on the third, on a label carrying an em dash that
+    ``BaseE2ETest`` puts there. The bug was in the reads, not the writes, but it
+    is worth an assertion of its own either way: a connector name, a driver's
+    error message and a pod's log line are all places non-ASCII arrives in a
+    bundle, and evidence that mangles them is evidence someone mistrusts.
+    """
+    bundle = EvidenceBundle(
+        label="Suite — postgres",
+        logs={"pod/worker": ("café ✓",)},
+        readings={"note": "naïve"},
+        artifacts={"traceback.txt": "ValueError: ünicode"},
+    )
+
+    write_bundle(bundle, tmp_path)
+
+    report = json.loads((tmp_path / "report.json").read_text(encoding="utf-8"))
+    assert report["label"] == "Suite — postgres"
+    assert report["readings"]["note"] == "naïve"
+    assert (tmp_path / "logs" / "pod-worker.log").read_text(
+        encoding="utf-8"
+    ) == "café ✓"
+    assert (tmp_path / "traceback.txt").read_text(encoding="utf-8") == (
+        "ValueError: ünicode"
+    )
 
 
 def test_each_log_source_gets_its_own_file(tmp_path: Path) -> None:
@@ -277,9 +311,9 @@ def test_each_log_source_gets_its_own_file(tmp_path: Path) -> None:
     serves neither."""
     write_bundle(_bundle(), tmp_path)
 
-    assert (tmp_path / "logs" / "pod-a-worker.log").read_text().splitlines()[1] == (
-        "starting up"
-    )
+    assert (tmp_path / "logs" / "pod-a-worker.log").read_text(
+        encoding="utf-8"
+    ).splitlines()[1] == ("starting up")
 
 
 def test_a_log_source_stays_one_path_segment(tmp_path: Path) -> None:
@@ -319,7 +353,7 @@ def test_an_artifact_cannot_escape_the_output_directory(tmp_path: Path) -> None:
 def test_an_unwritable_directory_is_reported_not_raised(tmp_path: Path) -> None:
     """An evidence dump that failed must not become the failure being diagnosed."""
     blocker = tmp_path / "blocked"
-    blocker.write_text("i am a file, not a directory")
+    blocker.write_text("i am a file, not a directory", encoding="utf-8")
 
     assert write_bundle(_bundle(), blocker / "under") == ()
 
@@ -338,7 +372,7 @@ def test_one_unwritable_file_does_not_cost_the_rest_of_the_bundle(
         tmp_path,
     )
 
-    assert (tmp_path / "notes").read_text() == "first"
+    assert (tmp_path / "notes").read_text(encoding="utf-8") == "first"
     assert [path.name for path in written] == ["report.json", "notes"]
 
 

--- a/tests/unit/testing/harness/test_evidence.py
+++ b/tests/unit/testing/harness/test_evidence.py
@@ -1,0 +1,455 @@
+"""Unit tests for evidence collection and redaction (child G, FND-243).
+
+**These are claims, and the risk sits somewhere specific.** No redaction filter
+existed at this boundary before, so there is no original to run a differential
+against — but unlike the queue starter, the cost of a wrong claim here is not a
+failed test run. It is a credential in a retained CI artifact. So the tests are
+weighted accordingly: the ones that carry the most are the shapes a filter
+plausibly misses, not the ones it obviously catches.
+
+Four such shapes, each of which a key-name-only filter gets wrong:
+
+* the JSON form, ``"apiKey": "..."`` — the key is quoted, so a pattern anchored
+  on ``key=`` or ``key:`` never sees it, and the same log carries both forms;
+* ``Authorization: Bearer <token>`` — the value class stops at the first space,
+  which is right everywhere else and ships the token here;
+* an ODBC ``PWD={se;cret}`` — the value's own ``;`` ends a naive match early and
+  leaks the tail;
+* a bare literal with no key beside it — invisible to key matching by
+  construction, which is exactly why ``resolve_e2e_tenant.py`` runs a
+  ``--mask-only`` pass over the *values*.
+
+And one shape it must **not** touch: ``run_id`` and ``correlation_uuid``, which
+are what a person navigates a report by. Over-redaction is the intended failure
+direction, but a filter that redacted those would make the bundle unusable for
+the thing it exists to do.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from application_sdk.testing.harness.cluster import PodPhase, PodState
+from application_sdk.testing.harness.evidence import (
+    PLACEHOLDER,
+    EvidenceBundle,
+    collect_pod_evidence,
+    redact,
+    redact_text,
+    secrets_from_environment,
+    write_bundle,
+)
+from application_sdk.testing.harness.expectations import UNREADABLE, Finding
+
+# ---------------------------------------------------------------------------
+# The shapes a key-name filter misses
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("line", "leaked"),
+    [
+        ("password=hunter2 host=db1", "hunter2"),
+        ('"apiKey": "abc123def"', "abc123def"),
+        ("'client_secret': 'shh-dont'", "shh-dont"),
+        ("Authorization: Bearer eyJhbGciOiJIUzI1NiJ9", "eyJhbGciOiJIUzI1NiJ9"),
+        ("DRIVER={x};UID=sa;PWD={se;cret};", "se;cret"),
+        ("X-Api-Key: zzz-top-secret", "zzz-top-secret"),
+        ("AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI", "wJalrXUtnFEMI"),
+        ("postgresql://svc:pa55@db.internal/x", "pa55"),
+        ("set-cookie: session=deadbeef", "deadbeef"),
+        ("private_key=-----BEGIN", "-----BEGIN"),
+    ],
+    ids=[
+        "bare key=value",
+        "JSON string value",
+        "single-quoted value",
+        "auth scheme plus token",
+        "ODBC braced value with a semicolon",
+        "hyphenated header name",
+        "screaming-snake env name",
+        "URL userinfo",
+        "cookie",
+        "PEM body",
+    ],
+)
+def test_a_credential_shaped_value_does_not_survive(line: str, leaked: str) -> None:
+    assert leaked not in redact_text(line)
+    assert PLACEHOLDER in redact_text(line)
+
+
+def test_the_neighbouring_pair_in_a_connection_string_survives() -> None:
+    """Over-redaction is the safe direction, but not to the point of erasing the
+    host — a redacted bundle that cannot say which database was reached is a
+    bundle nobody can act on."""
+    assert redact_text("password=hunter2 host=db1 port=5432") == (
+        f"password={PLACEHOLDER} host=db1 port=5432"
+    )
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        "run_id=1700000000 correlation_uuid=abc-123",
+        "workflow_id=metadata-extraction-42 task_queue=atlan-postgres-prod",
+        "auth_type=basic",
+        "connected as uid=sa",
+    ],
+    ids=["ids", "workflow identity", "auth_type", "ODBC uid"],
+)
+def test_what_a_report_is_navigated_by_survives(line: str) -> None:
+    """The one deliberate non-over-redaction. ``auth_type`` is why a bare
+    ``auth`` is not in the fragment list, and ``uid`` is a user name rather than
+    a credential — the same call ``redact_secrets`` makes and for the same
+    reason."""
+    assert redact_text(line) == line
+
+
+def test_a_json_artifact_stays_parseable_after_redaction() -> None:
+    """A masked value inside valid JSON beats a valid secret inside broken JSON,
+    but a bundle whose machine-readable half stopped parsing at the redaction
+    step is strictly worse than either."""
+    body = json.dumps({"apiKey": "abc123", "host": "db1"})
+
+    parsed = json.loads(redact_text(body))
+
+    assert parsed == {"apiKey": PLACEHOLDER, "host": "db1"}
+
+
+# ---------------------------------------------------------------------------
+# The literal-value filter
+# ---------------------------------------------------------------------------
+
+
+def test_a_bare_literal_with_no_key_beside_it_is_blanked() -> None:
+    """The shape key-name matching cannot see, and the reason the ``--mask-only``
+    prior art registers values rather than names."""
+    line = "GET /api/meta/atlas?t=glpat-ABCDEF failed"
+
+    assert "glpat-ABCDEF" not in redact_text(line, secrets=["glpat-ABCDEF"])
+
+
+def test_a_two_character_literal_is_ignored() -> None:
+    """Blanking it would destroy the evidence to protect nothing — a value that
+    short is either not a secret or is a substring of half the log."""
+    assert redact_text("db1 is up", secrets=["db"]) == "db1 is up"
+
+
+def test_a_literal_that_prefixes_another_does_not_leave_a_tail() -> None:
+    """Longest first, and this is why. Substituting the prefix first turns
+    ``tok-abcdef`` into ``***-abcdef`` — a partial secret in a file that claims
+    to have none."""
+    secrets = secrets_from_environment(
+        {"API_TOKEN": "tok", "OTHER_TOKEN": "tok-abcdef"}
+    )
+
+    assert redact_text("saw tok-abcdef", secrets=secrets) == f"saw {PLACEHOLDER}"
+
+
+def test_secrets_are_collected_by_the_same_key_shape_the_text_filter_uses() -> None:
+    """One definition of "credential-shaped" for both filters, so a fragment
+    added to the list strengthens the value pass too."""
+    collected = secrets_from_environment(
+        {
+            "ATLAN_API_KEY": "key-value",
+            "SDR_CLIENT_SECRET": "secret-value",
+            "ATLAN_BASE_URL": "https://tenant.example.com",
+            "HOME": "/root",
+        }
+    )
+
+    assert set(collected) == {"key-value", "secret-value"}
+
+
+def test_the_tenant_url_is_contributed_on_request() -> None:
+    """Not credential-shaped by name and not a credential by value, but a tenant
+    hostname identifies a customer environment and the bundle is retained."""
+    collected = secrets_from_environment(
+        {"ATLAN_BASE_URL": "https://tenant.example.com"},
+        also=("ATLAN_BASE_URL",),
+    )
+
+    assert collected == ("https://tenant.example.com",)
+
+
+def test_a_blank_or_absent_variable_contributes_nothing() -> None:
+    """A blank literal would match everywhere and blank the whole file."""
+    assert secrets_from_environment({"API_TOKEN": "  "}, also=("NOT_SET",)) == ()
+
+
+# ---------------------------------------------------------------------------
+# The bundle
+# ---------------------------------------------------------------------------
+
+
+def _bundle() -> EvidenceBundle:
+    return EvidenceBundle(
+        label="TestPostgresE2E — postgres",
+        findings=(
+            Finding(
+                subject="Table",
+                detail="expected >= 10, saw 0 (password=hunter2)",
+                expectation="floor",
+            ),
+            Finding(subject="Column", detail="search failed", expectation=UNREADABLE),
+        ),
+        logs={"pod-a/worker": ("token=abc", "starting up")},
+        readings={
+            "asset_counts": {"Table": 0, "Column": 0},
+            "credential": {"username": "svc", "password": "hunter2"},
+            "run_id": 1_700_000_000,
+        },
+        artifacts={"traceback.txt": "AuthError: api_key=abc123"},
+    )
+
+
+def test_redact_never_mutates_its_input() -> None:
+    """A caller that logs locally and uploads remotely holds both; an in-place
+    scrub makes the local copy useless."""
+    bundle = _bundle()
+
+    redact(bundle)
+
+    assert bundle.readings["credential"] == {"username": "svc", "password": "hunter2"}
+
+
+def test_a_credential_body_is_replaced_whole_rather_than_descended_into() -> None:
+    """The key already says the value is a credential, so there is nothing to
+    preserve inside it — and descending would pass through any sub-key the
+    fragment list has not seen."""
+    assert redact(_bundle()).readings["credential"] == PLACEHOLDER
+
+
+def test_counts_stay_numbers() -> None:
+    """The readings mapping is where the asset counts live, and a bundle that
+    stringified them would be unusable for the question it exists to answer."""
+    assert redact(_bundle()).readings["asset_counts"] == {"Table": 0, "Column": 0}
+
+
+def test_the_expectation_marker_is_not_run_through_the_text_filter() -> None:
+    """It is one of a closed set a report groups on. A future marker containing
+    a fragment — ``token_shape``, say — would come out as ``***`` and stop
+    matching :data:`UNREADABLE`."""
+    assert redact(_bundle()).findings[1].expectation == UNREADABLE
+
+
+def test_redaction_is_idempotent() -> None:
+    """``write_bundle`` redacts unconditionally, so a caller that redacted first
+    must not end up with a doubly-mangled bundle."""
+    once = redact(_bundle())
+
+    assert redact(once) == once
+
+
+# ---------------------------------------------------------------------------
+# Writing it out
+# ---------------------------------------------------------------------------
+
+
+def test_write_bundle_redacts_without_being_asked(tmp_path: Path) -> None:
+    """This is the boundary the bundle crosses. Making redaction the caller's
+    responsibility is what leaves the one path that forgot."""
+    write_bundle(_bundle(), tmp_path, secrets=["hunter2"])
+
+    written = "\n".join(
+        path.read_text() for path in tmp_path.rglob("*") if path.is_file()
+    )
+    assert "hunter2" not in written
+    assert "abc123" not in written
+
+
+def test_the_report_is_machine_readable(tmp_path: Path) -> None:
+    write_bundle(_bundle(), tmp_path)
+
+    report = json.loads((tmp_path / "report.json").read_text())
+
+    assert report["label"] == "TestPostgresE2E — postgres"
+    assert [finding["subject"] for finding in report["findings"]] == ["Table", "Column"]
+    assert report["readings"]["asset_counts"] == {"Table": 0, "Column": 0}
+
+
+def test_each_log_source_gets_its_own_file(tmp_path: Path) -> None:
+    """A person opens one container's log; a script parses the report. One blob
+    serves neither."""
+    write_bundle(_bundle(), tmp_path)
+
+    assert (tmp_path / "logs" / "pod-a-worker.log").read_text().splitlines()[1] == (
+        "starting up"
+    )
+
+
+def test_a_log_source_stays_one_path_segment(tmp_path: Path) -> None:
+    """A source name carries ``pod/container``. Left alone the slash becomes a
+    directory level, so ``logs/`` would hold a tree of pod directories instead of
+    one file per source — and a reviewer scanning a downloaded artifact would
+    have to descend into each.
+
+    The flattening does mean a source literally named ``a-b`` and one named
+    ``a/b`` land on the same file. Not guarded: both names come from Kubernetes,
+    which does not allow a ``-``-for-``/`` substitution to produce a real
+    collision, and a uniquifying suffix would cost every normal file a name a
+    person has to decode.
+    """
+    write_bundle(EvidenceBundle(label="x", logs={"pod-a/worker": ("one",)}), tmp_path)
+
+    assert [path.name for path in (tmp_path / "logs").iterdir()] == ["pod-a-worker.log"]
+
+
+def test_an_artifact_cannot_escape_the_output_directory(tmp_path: Path) -> None:
+    """An artifact key is a relative path a caller may assemble from a pod name.
+    Neither ``..`` nor a leading ``/`` is rejected — an evidence write must not
+    fail on a naming quirk — but neither may write outside the directory."""
+    output = tmp_path / "bundle"
+
+    written = write_bundle(
+        EvidenceBundle(label="x", artifacts={"../../escaped.txt": "no"}), output
+    )
+
+    assert not (tmp_path.parent / "escaped.txt").exists()
+    # Non-empty first: `all()` over nothing is true, and "it wrote nothing" is a
+    # different outcome from "it wrote inside the directory".
+    assert written
+    assert all(output in path.parents for path in written)
+
+
+def test_an_unwritable_directory_is_reported_not_raised(tmp_path: Path) -> None:
+    """An evidence dump that failed must not become the failure being diagnosed."""
+    blocker = tmp_path / "blocked"
+    blocker.write_text("i am a file, not a directory")
+
+    assert write_bundle(_bundle(), blocker / "under") == ()
+
+
+def test_one_unwritable_file_does_not_cost_the_rest_of_the_bundle(
+    tmp_path: Path,
+) -> None:
+    """``notes`` is written as a file, so ``notes/detail`` cannot then be one —
+    an artifact key assembled from two names that happen to nest. The report and
+    the first artifact still land, which is the whole reason this reports rather
+    than raises."""
+    written = write_bundle(
+        EvidenceBundle(
+            label="x", artifacts={"notes": "first", "notes/detail": "second"}
+        ),
+        tmp_path,
+    )
+
+    assert (tmp_path / "notes").read_text() == "first"
+    assert [path.name for path in written] == ["report.json", "notes"]
+
+
+def test_a_reading_that_is_neither_container_nor_scalar_is_still_kept(
+    tmp_path: Path,
+) -> None:
+    """An exception, an enum, a dataclass all reach the readings mapping. A
+    bundle that dropped them would be quieter and less useful, so they are
+    rendered and then sanitised like everything else."""
+    bundle = EvidenceBundle(
+        label="x", readings={"cause": ValueError("auth failed: password=hunter2")}
+    )
+
+    rendered = redact(bundle).readings["cause"]
+
+    assert isinstance(rendered, str)
+    assert "ValueError" in rendered
+    assert "hunter2" not in rendered
+
+
+# ---------------------------------------------------------------------------
+# Pod collection
+# ---------------------------------------------------------------------------
+
+
+class _Reader:
+    """Just the two verbs the collector uses, plus a record of the calls."""
+
+    def __init__(self, pods: list[PodState], *, failing: str = "") -> None:
+        self._pods = pods
+        self._failing = failing
+        self.reads: list[tuple[str, str, bool]] = []
+
+    async def pods(self, namespace: str, selector: str) -> list[PodState]:
+        if self._failing == "pods":
+            raise RuntimeError("cluster unreachable")
+        return self._pods
+
+    async def container_log(
+        self,
+        namespace: str,
+        pod: str,
+        container: str,
+        *,
+        previous: bool = False,
+        tail_lines: int | None = -1,
+        **_kwargs: Any,
+    ) -> str:
+        self.reads.append((pod, container, previous))
+        if self._failing == container:
+            raise RuntimeError("no such container")
+        return f"line for {pod}/{container}{'/previous' if previous else ''}"
+
+
+def _pod(name: str, containers: dict[str, int]) -> PodState:
+    return PodState(
+        name=name,
+        namespace="ns",
+        phase=PodPhase.RUNNING,
+        ready=False,
+        restarts=sum(containers.values()),
+        node="node-1",
+        containers=containers,
+    )
+
+
+async def test_a_restarted_container_contributes_its_previous_output() -> None:
+    """Where a crash loop's actual cause is, and the one thing a merged stream
+    cannot express."""
+    reader = _Reader([_pod("worker-0", {"main": 2, "sidecar": 0})])
+
+    bundle = await collect_pod_evidence("ns", reader=reader)  # type: ignore[arg-type]
+
+    assert set(bundle.logs) == {
+        "worker-0/main",
+        "worker-0/sidecar",
+        "worker-0/main/previous",
+    }
+
+
+async def test_an_unreadable_listing_yields_an_empty_bundle_not_an_exception() -> None:
+    """The one thing here allowed to fail open: this is read after the verdict,
+    so a collector that raised would turn a diagnosable failure into an
+    undiagnosable one."""
+    reader = _Reader([], failing="pods")
+
+    bundle = await collect_pod_evidence("ns", reader=reader)  # type: ignore[arg-type]
+
+    assert bundle.logs == {}
+    assert bundle.label == "pods in ns"
+
+
+async def test_one_unreadable_container_costs_only_that_container() -> None:
+    reader = _Reader([_pod("worker-0", {"main": 0, "broken": 0})], failing="broken")
+
+    bundle = await collect_pod_evidence("ns", reader=reader)  # type: ignore[arg-type]
+
+    assert bundle.logs["worker-0/broken"] == ()
+    assert bundle.logs["worker-0/main"] == ("line for worker-0/main",)
+
+
+async def test_pod_state_is_recorded_beside_the_logs() -> None:
+    """A pod that is Running with a failing readiness probe is the exact shape a
+    "worker is up" assertion must not accept, so the bundle has to say so."""
+    reader = _Reader([_pod("worker-0", {"main": 3})])
+
+    bundle = await collect_pod_evidence("ns", reader=reader)  # type: ignore[arg-type]
+
+    assert bundle.readings["worker-0"] == {
+        "phase": "Running",
+        "ready": False,
+        "restarts": 3,
+        "node": "node-1",
+    }

--- a/tests/unit/testing/harness/test_evidence.py
+++ b/tests/unit/testing/harness/test_evidence.py
@@ -139,6 +139,46 @@ def test_a_two_character_literal_is_ignored() -> None:
     assert redact_text("db1 is up", secrets=["db"]) == "db1 is up"
 
 
+@pytest.mark.parametrize(
+    "line",
+    [
+        r'"password": "part\"secret"',
+        r"{'client_secret': 'a\'b'}",
+    ],
+    ids=["JSON with an escaped double quote", "escaped single quote"],
+)
+def test_an_escaped_quote_inside_a_value_does_not_truncate_the_match(
+    line: str,
+) -> None:
+    """The tail after an escaped quote is the leak a naive ``"[^"]*"`` ships.
+
+    Any credential containing a quote is escaped by whatever serialiser wrote
+    the log, so this is the *normal* shape for such a value rather than an edge
+    case — and truncating at the escape leaves the remainder in an uploaded
+    artifact while the line still looks redacted.
+    """
+    redacted = redact_text(line)
+
+    assert "secret" not in redacted or "part" not in redacted
+    assert PLACEHOLDER in redacted
+    assert redacted.count(PLACEHOLDER) == 1
+
+
+def test_the_replacement_order_is_enforced_where_the_replacing_happens() -> None:
+    """Unsorted input must be as safe as sorted input.
+
+    ``secrets_from_environment`` sorts longest-first, but ``redact`` and
+    ``write_bundle`` take any ``Sequence[str]`` — a caller assembling a plain
+    list has no reason to know the order carries a correctness property. Pinned
+    with a deliberately unsorted sequence, which the sorted-producer test below
+    cannot exercise.
+    """
+    redacted = redact_text("saw tok-abcdef", secrets=["tok", "tok-abcdef"])
+
+    assert redacted == f"saw {PLACEHOLDER}"
+    assert "abcdef" not in redacted
+
+
 def test_a_literal_that_prefixes_another_does_not_leave_a_tail() -> None:
     """Longest first, and this is why. Substituting the prefix first turns
     ``tok-abcdef`` into ``***-abcdef`` — a partial secret in a file that claims

--- a/tests/unit/testing/harness/test_scaffold.py
+++ b/tests/unit/testing/harness/test_scaffold.py
@@ -517,10 +517,17 @@ def test_the_temporal_readers_need_no_extra() -> None:
 
 
 async def test_every_remaining_stub_names_its_child_issue() -> None:
+    """One stub left, and it still names the child that fills it in.
+
+    Child G (FND-243) landed ``evidence.redact``, ``teardown.purge_connection``
+    and ``starters.start_via_automation_engine``, so those three moved out of
+    this list and into their own tests. ``start_via_app_handler`` moves with the
+    cluster reader in child E, and until then this is what keeps its
+    ``HarnessNotBuiltError`` carrying an issue rather than a bare
+    ``NotImplementedError`` an auditor would have to grep prose for.
+    """
     from application_sdk.testing.harness import starters
     from application_sdk.testing.harness.cluster import HttpRequest, HttpResponse
-    from application_sdk.testing.harness.evidence import EvidenceBundle, redact
-    from application_sdk.testing.harness.teardown import purge_connection
 
     class _Reader:
         """Shaped like a ClusterReader so the call is typed, not bypassed."""
@@ -537,15 +544,7 @@ async def test_every_remaining_stub_names_its_child_issue() -> None:
         async def http(self, target, request: HttpRequest) -> HttpResponse:
             raise AssertionError("the stub must raise before calling out")
 
-    for call in (lambda: redact(EvidenceBundle(label="x")),):
-        with pytest.raises(HarnessNotBuiltError) as caught:
-            call()
-        assert caught.value.issue == "FND-224"
-        assert caught.value.operation
-
     for coro in (
-        purge_connection("default/x/1"),
-        starters.start_via_automation_engine({}),
         starters.start_via_app_handler(
             starters.HttpWorkflowSpec(
                 target=ServiceTarget(namespace="ns", service="svc", port=8000),
@@ -558,6 +557,35 @@ async def test_every_remaining_stub_names_its_child_issue() -> None:
             await coro
         assert caught.value.issue == "FND-224"
         assert caught.value.operation
+
+
+async def test_child_g_left_no_stub_behind() -> None:
+    """The three child-G surfaces reach real work, not a ``HarnessNotBuiltError``.
+
+    Same shape as the queue starter's own check: each is driven with an argument
+    that cannot possibly work, so the failure proves the stub is gone without
+    standing up a tenant. ``HarnessNotBuiltError`` is a ``NotImplementedError``,
+    which none of these are — so a regression that reinstated a stub fails here
+    rather than passing as "it raised something".
+    """
+    from application_sdk.testing.harness import starters
+    from application_sdk.testing.harness.evidence import EvidenceBundle, redact
+    from application_sdk.testing.harness.teardown import PurgeReport, purge_connection
+
+    assert redact(EvidenceBundle(label="x")) == EvidenceBundle(label="x")
+
+    # `purge_connection` reports rather than raises, on every path — so "the stub
+    # is gone" is a *returned report*, not an exception. A reinstated stub would
+    # raise `HarnessNotBuiltError` out of this call and fail here.
+    report = await purge_connection(object(), "default/x/1")  # type: ignore[arg-type]
+    assert isinstance(report, PurgeReport)
+    assert report.errors and not report.complete
+
+    with pytest.raises(AttributeError):
+        await starters.start_via_automation_engine(
+            starters.AEWorkflowSpec(name="x"),
+            client=object(),  # type: ignore[arg-type]
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/testing/harness/test_teardown.py
+++ b/tests/unit/testing/harness/test_teardown.py
@@ -302,3 +302,5 @@ async def test_every_listed_hit_lands_somewhere_on_the_report():
 
     # -1 for the connection itself, which was not part of the child listing.
     assert (report.purged - 1) + len(report.orphaned) == len(listed)
+    assert report.orphaned == (f"{_QN}/noguid",)
+    assert not report.complete

--- a/tests/unit/testing/harness/test_teardown.py
+++ b/tests/unit/testing/harness/test_teardown.py
@@ -261,8 +261,17 @@ async def test_a_run_that_created_nothing_reports_a_complete_purge():
     assert report.complete
 
 
-async def test_an_asset_with_no_guid_is_not_sent_as_one():
-    """A hit pyatlan could not attribute a GUID to cannot be deleted by GUID."""
+async def test_an_asset_with_no_guid_is_reported_orphaned_not_dropped():
+    """A hit with no GUID cannot be deleted, so it must be *named*.
+
+    The first revision of this test asserted the opposite — that the hit is
+    simply skipped — which pinned a real bug rather than a behaviour. Dropping
+    it takes it out of the report as well as out of the DELETE, so the
+    connection purge then succeeds and `complete` answers True over an asset
+    still sitting on a shared tenant. Every hit the search returned has to land
+    somewhere on the report; `purge_by_guid` being the only delete available is
+    a reason it is orphaned, not a reason it is invisible.
+    """
     client = _client(
         children=[FakeAsset(f"{_QN}/t0", ""), FakeAsset(f"{_QN}/t1", "guid-1")]
     )
@@ -271,3 +280,25 @@ async def test_an_asset_with_no_guid_is_not_sent_as_one():
 
     assert client.asset.purged[0] == ["guid-1"]
     assert report.purged == 2  # one child plus the connection
+    assert report.orphaned == (f"{_QN}/t0",)
+    assert report.errors and not report.complete
+
+
+async def test_every_listed_hit_lands_somewhere_on_the_report():
+    """The invariant the accounting rests on: purged + orphaned covers the search.
+
+    Stated as a property over a mixed listing rather than as three separate
+    cases, because the failure it guards against is a hit falling through a gap
+    between them — which no single-case test sees.
+    """
+    listed = [
+        FakeAsset(f"{_QN}/ok0", "guid-0"),
+        FakeAsset(f"{_QN}/noguid", ""),
+        FakeAsset(f"{_QN}/ok1", "guid-1"),
+    ]
+    client = _client(children=listed)
+
+    report = await purge_connection(client, _QN)  # type: ignore[arg-type]
+
+    # -1 for the connection itself, which was not part of the child listing.
+    assert (report.purged - 1) + len(report.orphaned) == len(listed)

--- a/tests/unit/testing/harness/test_teardown.py
+++ b/tests/unit/testing/harness/test_teardown.py
@@ -1,0 +1,273 @@
+"""Unit tests for the purge mechanics (child G, FND-243).
+
+**A differential, where one is available.** This lifts
+``BaseE2ETest._purge_child_assets`` and ``_purge_connection``, so the properties
+worth pinning are the ones those two encoded — and every one of them is there
+because it went wrong once:
+
+* **Batching.** ``purge_by_guid`` puts one ``guid=`` query parameter per asset
+  into a single DELETE and ``httpx`` refuses a URL past ``MAX_URL_LENGTH``, so
+  an unbatched purge of a normal crawl deletes *nothing*. The batch-boundary
+  test is therefore a correctness test, not a performance one.
+* **Read everything, then delete.** Atlas' default pagination is offset-based,
+  so deleting between pages shifts the window and skips assets — silently, with
+  a clean-looking report.
+* **Two independent guards.** One shared guard is what let a failing child batch
+  orphan the connection too: the raise jumped the connection purge, and the
+  warning is post-verdict, so the leg went green while leaking everything.
+* **Nothing raises.** Teardown runs after the assertions decided the verdict.
+
+The one place this deliberately does *more* than the original is
+:attr:`PurgeReport.orphaned`: the lifted code counted failed batches, and a
+count tells an operator only that they have a problem. The names are what they
+can act on.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from application_sdk.testing.harness.teardown import (
+    PURGE_BATCH_SIZE,
+    PurgeReport,
+    purge_connection,
+)
+from tests.unit.testing._atlas_fakes import FakeAsset, FakeAtlasClient, FakeSearchResult
+
+_QN = "default/postgres/1700000000042"
+
+
+def _is_connection_search(request: Any) -> bool:
+    """Which of the two searches this is, read off the request the code built.
+
+    Off the real ``FluentSearch`` output rather than off call ordering, so a
+    reordering of the two phases cannot make a test pass by coincidence.
+    """
+    return "Connection" in str(request.dsl.query)
+
+
+def _client(
+    *,
+    children: list[FakeAsset] | None = None,
+    connection: list[FakeAsset] | None = None,
+    on_purge: Any = None,
+) -> FakeAtlasClient:
+    """A client answering the listing search and the connection search."""
+    resolved_connection = (
+        [FakeAsset(_QN, "guid-connection")] if connection is None else connection
+    )
+
+    def _behavior(request: Any) -> FakeSearchResult:
+        if _is_connection_search(request):
+            return FakeSearchResult(resolved_connection)
+        return FakeSearchResult(children or [])
+
+    return FakeAtlasClient(_behavior, on_purge=on_purge)
+
+
+def _children(count: int) -> list[FakeAsset]:
+    return [FakeAsset(f"{_QN}/t{index}", f"guid-{index}") for index in range(count)]
+
+
+# ---------------------------------------------------------------------------
+# Batching, which is a correctness bound
+# ---------------------------------------------------------------------------
+
+
+async def test_a_large_purge_is_chunked_under_the_url_ceiling():
+    """The property an unbatched purge fails: no single DELETE names them all.
+
+    Asserted as "every batch is at most PURGE_BATCH_SIZE" rather than as an
+    exact call count, so raising the constant stays a one-line change and
+    lowering it below the ceiling stays legal — what must never happen is one
+    call carrying 120 GUIDs, which is what the ceiling rejects.
+    """
+    client = _client(children=_children(120))
+
+    report = await purge_connection(client, _QN)  # type: ignore[arg-type]
+
+    child_batches = [call for call in client.asset.purged if isinstance(call, list)]
+    assert child_batches
+    assert all(len(batch) <= PURGE_BATCH_SIZE for batch in child_batches)
+    assert sum(len(batch) for batch in child_batches) == 120
+    assert report.purged == 121  # the 120 children plus the connection
+    assert report.complete
+
+
+async def test_every_listed_asset_is_purged_exactly_once():
+    """No GUID is dropped between batches and none is sent twice."""
+    client = _client(children=_children(PURGE_BATCH_SIZE * 2 + 7))
+
+    await purge_connection(client, _QN)  # type: ignore[arg-type]
+
+    sent = [
+        guid for call in client.asset.purged if isinstance(call, list) for guid in call
+    ]
+    assert sent == [f"guid-{index}" for index in range(PURGE_BATCH_SIZE * 2 + 7)]
+
+
+async def test_the_whole_listing_is_read_before_anything_is_deleted():
+    """Offset-based pagination shifts under a delete, so the order is the fix.
+
+    Pinned by watching the interleaving: if a single search preceded each
+    delete, this run would show ``search, purge, search, purge`` and a real
+    Atlas would skip a page per batch while reporting a clean teardown.
+    """
+    order: list[str] = []
+
+    def _record_purge(_guid: Any) -> None:
+        order.append("purge")
+
+    client = _client(children=_children(75), on_purge=_record_purge)
+    original_search = client.asset.search
+
+    async def _recording_search(request: Any) -> Any:
+        order.append("search")
+        return await original_search(request)
+
+    client.asset.search = _recording_search  # type: ignore[method-assign]
+
+    await purge_connection(client, _QN)  # type: ignore[arg-type]
+
+    # 75 children at a batch of 50: one listing search, two child DELETEs, then
+    # the connection's own search and DELETE. Pinned exactly rather than as a
+    # property, because the failure this guards against is a *reordering* and an
+    # exact sequence is the only assertion a reordering cannot satisfy.
+    assert order == ["search", "purge", "purge", "search", "purge"]
+
+
+# ---------------------------------------------------------------------------
+# Nothing raises, and one failure does not become two
+# ---------------------------------------------------------------------------
+
+
+async def test_a_failing_batch_orphans_only_that_batch():
+    """The rest still goes, and the report names what did not."""
+    calls = {"n": 0}
+
+    def _fail_second(guid: Any) -> None:
+        if isinstance(guid, list):
+            calls["n"] += 1
+            if calls["n"] == 2:
+                raise RuntimeError("atlas said no")
+
+    client = _client(children=_children(PURGE_BATCH_SIZE * 3), on_purge=_fail_second)
+
+    report = await purge_connection(client, _QN)  # type: ignore[arg-type]
+
+    assert report.purged == PURGE_BATCH_SIZE * 2 + 1  # two batches plus the connection
+    assert len(report.orphaned) == PURGE_BATCH_SIZE
+    # Qualified names, not GUIDs: the list has to be actionable by hand.
+    assert all(name.startswith(f"{_QN}/") for name in report.orphaned)
+    assert len(report.errors) == 1
+    assert not report.complete
+
+
+async def test_a_failing_child_purge_does_not_orphan_the_connection():
+    """The two phases are independently guarded, which is the FND fix.
+
+    Sharing one guard is what let a single batch failure jump past the
+    connection purge — and because the teardown warning is post-verdict, the leg
+    still went green while leaking the connection *and* everything under it.
+    """
+
+    def _fail_children(guid: Any) -> None:
+        if isinstance(guid, list):
+            raise RuntimeError("atlas said no")
+
+    client = _client(children=_children(10), on_purge=_fail_children)
+
+    report = await purge_connection(client, _QN)  # type: ignore[arg-type]
+
+    assert "guid-connection" in client.asset.purged
+    assert report.purged == 1
+    assert _QN not in report.orphaned
+
+
+async def test_an_unreadable_listing_still_purges_the_connection():
+    """Nothing is known about the children, so nothing below can be deleted.
+
+    The connection purge needs no listing and still runs — a connection left
+    behind is exactly the half-set-up leftover that greens a later run which
+    should have failed.
+    """
+
+    def _behavior(request: Any) -> FakeSearchResult:
+        if _is_connection_search(request):
+            return FakeSearchResult([FakeAsset(_QN, "guid-connection")])
+        raise RuntimeError("elasticsearch is unhappy")
+
+    client = FakeAtlasClient(_behavior)
+
+    report = await purge_connection(client, _QN)  # type: ignore[arg-type]
+
+    assert client.asset.purged == ["guid-connection"]
+    assert report.purged == 1
+    assert report.errors and not report.complete
+    # Nothing is *named* as orphaned: the listing established nothing, so the
+    # report must not claim to know what was left behind.
+    assert report.orphaned == ()
+
+
+@pytest.mark.parametrize(
+    "failing",
+    ["listing", "children", "connection"],
+    ids=["unreadable listing", "failed batch", "failed connection purge"],
+)
+async def test_no_failure_escapes_as_an_exception(failing: str):
+    """Teardown runs after the verdict; raising here replaces a real failure."""
+
+    def _behavior(request: Any) -> FakeSearchResult:
+        if failing == "listing" and not _is_connection_search(request):
+            raise RuntimeError("boom")
+        if _is_connection_search(request):
+            return FakeSearchResult([FakeAsset(_QN, "guid-connection")])
+        return FakeSearchResult(_children(3))
+
+    def _on_purge(guid: Any) -> None:
+        if failing == "children" and isinstance(guid, list):
+            raise RuntimeError("boom")
+        if failing == "connection" and not isinstance(guid, list):
+            raise RuntimeError("boom")
+
+    report = await purge_connection(  # type: ignore[arg-type]
+        FakeAtlasClient(_behavior, on_purge=_on_purge), _QN
+    )
+
+    assert isinstance(report, PurgeReport)
+    assert report.errors and not report.complete
+
+
+# ---------------------------------------------------------------------------
+# The nothing-to-do cases, which must not look like failures
+# ---------------------------------------------------------------------------
+
+
+async def test_a_run_that_created_nothing_reports_a_complete_purge():
+    """ "Nothing to delete" and "everything deleted" are one outcome for a tenant.
+
+    Reporting the first as incomplete would send an operator to a tenant to
+    clean up assets that were never created — most often after a run that failed
+    during seeding, which is when a false alarm is least welcome.
+    """
+    client = _client(children=[], connection=[])
+
+    report = await purge_connection(client, _QN)  # type: ignore[arg-type]
+
+    assert client.asset.purged == []
+    assert report == PurgeReport()
+    assert report.complete
+
+
+async def test_an_asset_with_no_guid_is_not_sent_as_one():
+    """A hit pyatlan could not attribute a GUID to cannot be deleted by GUID."""
+    client = _client(
+        children=[FakeAsset(f"{_QN}/t0", ""), FakeAsset(f"{_QN}/t1", "guid-1")]
+    )
+
+    report = await purge_connection(client, _QN)  # type: ignore[arg-type]
+
+    assert client.asset.purged[0] == ["guid-1"]
+    assert report.purged == 2  # one child plus the connection


### PR DESCRIPTION
Child of [FND-224](https://linear.app/atlan-epd/issue/FND-224). Closes [FND-243](https://linear.app/atlan-epd/issue/FND-243/child-g-extract-the-ae-starter-evidence-collection-with-redaction-and). Branched from #3460, rebased onto `main` once that squash-merged — so this is a plain PR against `main` carrying one commit and nothing else.

The three parts of `BaseE2ETest` that *do things to the world*. All three were typed stubs raising `HarnessNotBuiltError`; all three are now real, at 100% coverage. Two of them shipped a correction to the issue's own premises, and both corrections are in the code rather than only here.

## `harness/starters/_ae.py` — the AE starter

An extraction, not new work, which is the opposite of its sibling: nothing dispatched onto a task queue before #3460, so that module's tests are *claims*. This one lifts `_bootstrap_workflow` plus the submit half of `run_full_dag`, so there is an original and the tests are a **differential** against it. Every step it calls already moved to `AEClient` in child F, so what lands here is the *sequence* — the last part of the AE path still trapped inside a base class.

**Where a plausible implementation goes wrong: the version.** `create_version` returns the number **AE assigned**, which is not required to be the one that was asked for. Publishing the requested number 404s on a mismatch — and on the runs where it silently did not, the handle would name a version the harness never published, so `_supersedes` would compare its seed against something that does not exist. `test_the_published_version_is_the_one_ae_assigned` pins that, and `AERunHandle` grew `seed_version` so the check can read it off the handle instead of off the suite.

**No error translation, deliberately.** Every step already raises a typed leaf — `AtlanApiHttpError`, `AtlanAEWorkflowAlreadyActiveError`, `AppNotReadyError`. Wrapping those would replace a category an operator already knows how to read with one saying only "the starter failed", and would give the AE path a *second* classification of the same responses, which is the divergence FND-224 exists to remove. The queue starter converts `temporalio`'s errors because `temporalio` has no leaves of its own; this one has nothing to convert.

**Nothing is retried around the sequence.** A caller re-running the whole function after a failed submit would re-enter that write's own inner retry, past the `retry_after` honouring and the credential-name rotation that make each re-POST safe — and the submit is the write where a duplicate is a phantom run AE marks `Skipped` and returns under a *fresh* id, which the harness then polls while the real run finishes elsewhere. The budget belongs inside the submit; `SubmitRetry` is how a caller widens it. `SubmitRetry.for_cold_start` **calls** `cold_start_submit_kwargs` rather than reproducing the arithmetic — the same discipline as `QueueWorkflowSpec.for_deployment` calling `derive_task_queue` — and answers `None` when the budget is disabled, because "leave the submit's own defaults alone" is a different instruction from "zero retries at a zero gap".

A pre-existing `spec.slug` submits and **seeds nothing over it**. That is the point of the field rather than an optimisation: the DAG under that slug belongs to whoever set it up, and replacing it would break the *next* run against it rather than this one.

## `harness/evidence.py` — redaction at the boundary that ships

### Correction 1: `LogCollector` cannot be wired into the connector failure path

The issue frames this as "a win independent of the runtime side" — container logs, previous-container logs where `restartCount > 0`, pod describes, cluster events. It is not achievable. Nothing in `e2e-full-reusable.yaml` or the shared `sdr-e2e` composite establishes a `kubectl` route into the tenant vcluster: no `KUBECONFIG`, no vcluster login, no `kubectl` invocation anywhere on that path. That is the same constraint the AE module docstring already records as the reason the AE submit is the only tenant-facing probe of the installed app pod.

So what a failed connector leg *can* leave behind is what it now does: the AE run identity, the per-node DAG table with error messages and requested dispatch queues, the Atlas readings, the findings and the traceback. `collect_pod_evidence` exists for the in-cluster side (the runtime suite), which is where the `LogCollector` shape actually applies. `LogCollector` itself is untouched and stays deprecated.

### Correction 2: "a CI artifact" needed no workflow change

`results/` is already where `upload-artifact` points in `sdr-e2e/action.yaml`, and pytest runs with cwd at the repo root. `BaseE2ETest.evidence_dir` defaults to `results/e2e-evidence`, so the bundle lands in the existing artifact beside `sdr-container.log` with nothing touched under `.github/`.

### Two filters, because one cannot see enough

*By key name* — a credential in structured data is a value under a credential-shaped key, so `SECRET_KEY_FRAGMENTS` matches case-insensitively as a substring and the value is replaced wholesale. In text that is the `key=value`, `key: value` and `"key": "value"` forms, all three of which appear in the same container log. A credential *body* under such a key is replaced entire rather than descended into: descending would pass through any sub-key the fragment list has not seen.

*By literal value* — the prior art in this repo is explicit about why the first is not enough. `resolve_e2e_tenant.py` and `export_extra_env.py` both run a two-pass `--mask-only` protocol precisely because registering a blob as a secret does not redact the values *inside* it. A token a driver echoed back with no key beside it — in a URL path, quoted in an exception, dumped as a bare header — is invisible to key matching. `secrets_from_environment` is that move: every env var whose *name* is credential-shaped contributes its *value*, longest first (substituting a prefix first leaves the longer one's tail behind, which is a partial secret in a file claiming to have none).

### One deliberate non-over-redaction

The issue says over-redact rather than risk a value escaping, and the fragment list is broad accordingly. The exception is a bare `auth`: it would take `auth_type` with it, and `auth_type` is the first field read on a credential-routing failure (cf. FND-923). `authorization` and `auth_token` are matched explicitly instead. This mirrors `redact_secrets`' own reasoning for excluding `uid` — while noting that reasoning does **not** transfer wholesale: that function guards one error string an on-call reads, this one guards a retained upload, so the default tips the other way everywhere else.

`write_bundle` redacts **unconditionally**. Making it the caller's responsibility is what leaves the one path that forgot; the filters are idempotent, so a caller that redacts first loses nothing.

## `harness/teardown.py` — purge mechanics

Three properties survive the lift, each there because it went wrong once:

* **Batching is a correctness bound, not a tuning knob.** `purge_by_guid` puts one `guid=` query parameter per asset into a single DELETE and `httpx` refuses a URL past `MAX_URL_LENGTH` — at ~42 bytes per GUID that is a ceiling near 1,550, raised client-side, so an unbatched purge of a normal crawl deletes **nothing**.
* **The whole listing is read before anything is deleted.** Atlas' default pagination is offset-based, so purging between pages shifts the result window and silently skips assets — with a clean-looking report. `test_the_whole_listing_is_read_before_anything_is_deleted` pins the exact call sequence, because the failure it guards against is a *reordering* and only an exact sequence rejects one.
* **Two independently-guarded phases.** Sharing one guard is what let a single child-batch failure orphan the connection as well: the raise jumped past the connection purge, and the teardown warning is post-verdict, so the leg went green while leaking everything under it.

Nothing raises, on any path — listing failure, batch failure and connection-purge failure all come back on the report, so there is no exception a caller must catch to stay correct. One addition over the original: `PurgeReport.orphaned` carries **qualified names** where the lifted code counted failed batches. A count tells an operator only that they have a problem; the names are what they can act on.

### The `L006` waiver was removed by design, not carried across

The issue asks to preserve the waiver rationale at the connection purge. The lifted implementation logged from *inside* its loop, which is what made `L006` fire; this one logs after it, so the rule no longer fires and the directive would be inert — a suppression claiming to suppress something. The bound it described (one result via `dsl.size=1`, one purge event per connection) is kept as a plain comment. Same call #3460 made on `P007`: the rule was right, so remove the finding rather than waive it.

## A bug found en route

`git status` caught it, not an assertion. Every existing unit test that drives `test_full_dag_runs_end_to_end` to a failure was writing real evidence files into the checkout, because `evidence_dir` is relative to the working directory — right in CI, wrong under pytest. An autouse fixture in `tests/unit/conftest.py` points the class attribute at a temp directory for the whole unit suite; autouse and class-level rather than a per-test opt-in, because the tests that trip it are the ones *not* about evidence and have no cause to know a bundle now exists. `results/` is gitignored as CI scratch.

## Verification

* **Full unit suite — 8,907 passed, 9 skipped, 0 failed**, on base `7ff048f2a`.
* **100% coverage on `application_sdk/testing/harness/`** — 2,384 statements, 0 missed. All four new/changed modules at 100%.
* `atlan-application-sdk-conformance detect` — **258 unsuppressed findings, identical to the base's 258**, and zero live findings in any new module. One `O001` (`json.dumps` → `orjson.dumps`) was **fixed rather than suppressed**. Exactly one suppression is added: an `E004` on the purge-batch boundary, where a batch failure must never propagate and mask the verdict.
* `uv run pre-commit run --all-files` — clean (ruff, ruff-format, isort, pyright).
* **`docs/agents/sdk-capabilities.md` regenerated** (`poe regen-capabilities`).
* **No dependency change**: `pyproject.toml` and `uv.lock` untouched.

### Not verified here

No VPN or vcluster session was available, so neither the AE sequence nor a purge has run against a live tenant. What stands in for it: the AE starter drives a **real `AEClient`** with only its `_request` scripted, so every response-shape decision — which envelope the slug is read from, which field carries the version, what an empty `run_id` means — goes through AE's own parsers rather than through a model of them; the teardown tests build **real `FluentSearch`** requests and fake only the network call, so a change to a filter or a page size is still exercised.

What that cannot cover is whether a live `AsyncIndexSearchResults` pages the way the double does while a purge is deleting underneath it. That is precisely the hazard the read-everything-before-deleting order exists to remove, so the order is the mitigation rather than the thing under test — but a real-tenant run is what would confirm it.

## Coordination

FND-244 (`harness/fixtures.py`) consumes `purge_connection`, `write_bundle` and `secrets_from_environment` and is developed in parallel on `chrishehim/fnd-244`. Its call sites sit behind Protocols so either PR can land first, and the merge of the two has been run locally by both sides: **670 tests pass, pyright clean**.

Whoever merges second hits **two** conflicts, and they are resolved differently:

* `application_sdk/testing/harness/__init__.py` — one hunk, the "which modules are real" summary sentence only. Both PRs edit it deliberately: leaving the other's modules out would ship a stale sentence, which is invisible, where a conflict is loud and mechanical. The module map itself auto-merges — this PR's rewritten `evidence` / `starters` / `teardown` entries and FND-244's additions after `spec` never touch. Resolution is this PR's wording ("two of `starters`' three functions") with FND-244's `substrate`, `preconditions` and `fixtures` folded into the list.
* `docs/agents/sdk-capabilities.md` — two hunks, because both PRs regenerate it. **Must not be hand-resolved.** `capability-manifest-check` regenerates on the merged tree and compares, so the committed file has to be what the *merged source* renders — which is neither side's version nor any stitching of them. Resolution is `uv run poe regen-capabilities` on the merged tree; the task pins griffe at 2.1.0, so it is reproducible for whoever runs it. A hand-resolved manifest passes review with no conflict markers and then reds that check.

`tests/unit/testing/harness/test_scaffold.py` auto-merges clean despite both sides touching it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
