### PR TITLE
fix(security): drop pip/setuptools bootstrap wheels from the base image (4 High, 1 Medium)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,37 @@ RUN mkdir -p /app /home/appuser/.local/bin && \
 # Remove curl and bash (not needed at runtime) and clean apk cache
 RUN apk del curl bash && rm -rf /var/cache/apk/*
 
+# Drop the pip/setuptools bootstrap wheels.
+#
+# `py3-pip-wheel` and `py3-setuptools-wheel` are hard dependencies of the
+# python-3.x-base packages, so `apk del` refuses them (verified: it removes 0
+# packages and leaves Python intact). The wheel FILES, however, are only read by
+# `ensurepip` when bootstrapping a virtual environment -- and nothing here does
+# that. Dependencies are installed by `uv`, which is self-contained and never
+# touches these files.
+#
+# Removing them clears five findings that customer scanners report against this
+# base, all of which resolve to the wheel file or to a manifest inside it rather
+# than to anything installed:
+#   CVE-2018-20225   pip         -> the wheel file itself
+#   CVE-2026-57585   msgpack     -> pip/_vendor/bom.cdx.json inside the wheel
+#   CVE-2026-23949   setuptools  -> same manifest
+#   CVE-2025-47273   setuptools  -> same manifest
+#   CVE-2026-59890   setuptools  -> same manifest
+# The manifest lists pip's vendored dependency versions (setuptools 70.3.0,
+# msgpack 1.1.2); neither is installed anywhere in the image.
+#
+# Caveat: this removes the files, not the apk package records. A scanner that
+# reads the apk database rather than file contents will still report
+# py3-pip-wheel. That is a known limit of this change, not an oversight -- the
+# records cannot be removed without taking Python with them.
+#
+# Trade-off: `python -m venv` and `python -m ensurepip` no longer work inside the
+# image. Nothing in the SDK or any connector app uses either (the one `-m venv`
+# in this repo runs on a GitHub runner, not in the container).
+RUN rm -f /usr/share/python-wheels/pip-*.whl \
+          /usr/share/python-wheels/setuptools-*.whl
+
 # Switch to appuser before venv creation
 USER appuser
 


### PR DESCRIPTION
## Why

Security Scanner reports five findings against images built on this base. All five resolve to a **wheel file, or to a manifest inside one** — not to anything installed:

| Finding | Sev | Component | Scanner's own path |
|---|---|---|---|
| CVE-2018-20225 | High | `pip` | the wheel file itself |
| CVE-2026-57585 | High | `msgpack` | `pip/_vendor/bom.cdx.json` **inside** the wheel |
| CVE-2026-23949 | High | `setuptools` | same manifest |
| CVE-2025-47273 | High | `setuptools` | same manifest |
| CVE-2026-59890 | Medium | `setuptools` | same manifest |

That manifest records pip's *vendored* dependency versions — `setuptools 70.3.0`, `msgpack 1.1.2`. Neither is installed anywhere in the image, and the setuptools distribution actually shipped is **84.0.0**, newer than the fix version for all three setuptools advisories.

So these are not exploitable. But the customer has reasonably declined to carry them as *permanent* false positives and asked for either remediation or a dated plan. Removing the artefact is the durable answer, and it clears the finding for every connector image at once.

## Why `apk del` isn't the fix

`py3-pip-wheel` and `py3-setuptools-wheel` are hard dependencies of the `python-3.x-base` packages. I verified in a throwaway container that `apk del py3-pip-wheel` **refuses safely** — 0 packages removed, Python 3.13.15 and `uv` still working — rather than cascading. So the files go, and the package records stay.

## Why nothing breaks

The wheels are read only by `ensurepip`, when bootstrapping a virtual environment. Nothing here does that: dependencies are installed by `uv`, which is self-contained and never touches them.

I checked the fleet for `python -m venv` / `ensurepip`:

| Repo | `-m venv` | `ensurepip` |
|---|---|---|
| `application-sdk` | **1** | 0 |
| `atlan-hive-app` | 0 | 0 |
| `atlan-teradata-app` | 0 | 0 |
| `atlan-local-marketplace-app` | 0 | 0 |

The single hit is `.github/workflows/release-version-bump.yaml`, which runs on a **GitHub runner, not in the container**. Unaffected.

## Validation

Run against the published `app-runtime-base:3` (`sha256:93631fac1280fc1f50c51da0e101ceaaec74aba83dcb4231a6e182e10dfcd33f`), which is this Dockerfile's output:

```
FROM registry.atlan.com/public/app-runtime-base:3
RUN rm -f /usr/share/python-wheels/pip-*.whl /usr/share/python-wheels/setuptools-*.whl
RUN uv venv .venv \
 && uv pip install --python /app/.venv/bin/python 'requests==2.32.5' \
 && /app/.venv/bin/python -c "import requests; print('IMPORT-OK', requests.__version__)"

  -> IMPORT-OK 2.32.5          build succeeded
  -> /usr/share/python-wheels  empty afterwards
  -> python -m venv            fails (expected, unused)
  -> python -m ensurepip       fails (expected, unused)
  -> uv venv                   still OK
```

**What I could not test:** building this Dockerfile from its own source — `cgr.dev/atlan.com/app-framework-golden:3.13` returns 401 without Chainguard credentials. The validation above is therefore against the *published output* of this Dockerfile rather than a local rebuild of it. The change is a single `rm` in a layer after the base is assembled, so the effect is the same, but a CI build is the real confirmation.

## Known limit — stated, not glossed

This removes the **files**, not the **apk package records**. A scanner that reads the apk database rather than file contents will still report `py3-pip-wheel`; `syft` does exactly that, and I confirmed the component persists in its SBOM after the change.

All five findings above are file-path-based in the customer's scanner, so they clear. A package-database scanner would not. The records cannot be removed without taking Python with them, so this is the ceiling of what's achievable here — worth knowing before anyone promises a different scanner a clean result.

## Blast radius

This changes the shared base for roughly fifteen connector images. Worth the usual base-image validation before merge — in particular a conformance run and one full connector build, since every app's `uv venv` + `uv sync` step runs on top of this.
