### PR TITLE
feat(testing): publish the harness lifecycle as async fixtures for composers (FND-244)

### DIFF
--- a/application_sdk/testing/harness/__init__.py
+++ b/application_sdk/testing/harness/__init__.py
@@ -46,6 +46,20 @@ Module map:
     Evidence bundle collection, and redaction at the boundary that ships it.
 ``spec``
     ``AppUnderTest`` — where to find the app under test in a cluster.
+``substrate``
+    Where the code driving the harness runs relative to the app, and the cluster
+    reader that follows from it. The fourth point of variance, which neither
+    source design document names (child I on FND-224).
+``preconditions``
+    The gate every scenario runs before it dispatches work — the two built-in
+    checks (a worker's health endpoint, and who is polling a task queue), the
+    runner that accumulates their outcomes, and the two leaves it raises for
+    "the starting state was wrong" and "the starting state could not be read".
+``fixtures``
+    The same lifecycle as async pytest fixtures, for a suite that inherits
+    nothing (child I). **Not imported here**: it imports ``pytest``, and this
+    package stays importable in a process with no test framework. Import it as
+    ``application_sdk.testing.harness.fixtures``, or register it as a plugin.
 ``cluster``
     Read-only Kubernetes Protocols, the states they return, and the typed
     ``kubeconfig`` backend behind them — which retired ``testing/e2e/pods.py``
@@ -82,10 +96,11 @@ Module map:
 ``teardown``
     Purge mechanics, including the batching that is a correctness bound.
 
-``bridge``, ``waiting``, ``outcome``, ``spec``, ``budgets``, ``expectations``,
-``identity``, ``atlas``, ``automation_engine``, ``cluster`` and ``temporal`` are
-real, and so is one of ``starters``' three functions; the rest are typed stubs,
-each naming the child issue that fills it in.
+``bridge``, ``waiting``, ``outcome``, ``spec``, ``substrate``, ``budgets``,
+``expectations``, ``identity``, ``preconditions``, ``fixtures``, ``atlas``,
+``automation_engine``, ``cluster`` and ``temporal`` are real, and so is one of
+``starters``' three functions; the rest are typed stubs, each naming the child
+issue that fills it in.
 
 ``atlas`` and ``automation_engine`` are the first two that ``testing/e2e``
 actually calls: since child F, ``AEWorkflowClient`` is a set of one-line
@@ -129,8 +144,12 @@ raises :class:`KubernetesExtraMissingError` naming the extra rather than an
 """
 
 from application_sdk.testing.harness._errors import (
+    FixtureNotConfiguredError,
     HarnessNotBuiltError,
     MissingTenantEnvError,
+    PreconditionsFailedError,
+    PreconditionsIndeterminateError,
+    SubstrateHasNoClusterError,
     SyncBridgeInAsyncContextError,
     WaitExpiredError,
     WaitIndeterminateError,
@@ -157,7 +176,18 @@ from application_sdk.testing.harness.outcome import (
     assert_settled,
     grade,
 )
+from application_sdk.testing.harness.preconditions import (
+    GateReport,
+    HealthReading,
+    PollerReading,
+    PreconditionCheck,
+    assert_gate,
+    check_no_stale_pollers,
+    check_worker_health,
+    run_preconditions,
+)
 from application_sdk.testing.harness.spec import AppUnderTest
+from application_sdk.testing.harness.substrate import Substrate, cluster_reader_for
 from application_sdk.testing.harness.waiting import (
     Classifier,
     Probe,
@@ -201,6 +231,22 @@ __all__ = [
     "Call",
     "RequestBudget",
     "Wait",
-    # App under test
+    # App under test, and where the harness is driving it from
     "AppUnderTest",
+    "Substrate",
+    "SubstrateHasNoClusterError",
+    "cluster_reader_for",
+    # The precondition gate, its two built-in checks and the readings they take
+    "GateReport",
+    "HealthReading",
+    "PollerReading",
+    "PreconditionCheck",
+    "PreconditionsFailedError",
+    "PreconditionsIndeterminateError",
+    "assert_gate",
+    "check_no_stale_pollers",
+    "check_worker_health",
+    "run_preconditions",
+    # Composing the fixtures in `harness.fixtures`
+    "FixtureNotConfiguredError",
 ]

--- a/application_sdk/testing/harness/_errors.py
+++ b/application_sdk/testing/harness/_errors.py
@@ -19,9 +19,13 @@ from application_sdk.errors.leaves import (
 )
 
 __all__ = [
+    "FixtureNotConfiguredError",
     "HarnessNotBuiltError",
     "MissingHarnessClassAttrError",
     "MissingTenantEnvError",
+    "PreconditionsFailedError",
+    "PreconditionsIndeterminateError",
+    "SubstrateHasNoClusterError",
     "SyncBridgeInAsyncContextError",
     "WaitExpiredError",
     "WaitIndeterminateError",
@@ -98,6 +102,95 @@ class MissingTenantEnvError(InvalidInputError):
 
     code: ClassVar[str] = "INVALID_INPUT_HARNESS_TENANT_ENV"
     field: str | None = "ATLAN_BASE_URL,ATLAN_API_KEY"
+
+
+@dataclass(kw_only=True)
+class FixtureNotConfiguredError(PreconditionError):
+    """A composer requested a harness fixture without declaring what it needs.
+
+    The three points of variance the harness deliberately does *not* assume are
+    shared — tenant wiring, app wiring and execution substrate (FND-244) — are
+    published as fixtures a composer overrides. Where there is no defensible
+    default, the default raises this instead of guessing: a fixture that guessed
+    would reach whichever cluster the developer's ``kubectl`` last pointed at, or
+    invent a connection type that teardown then purges under.
+
+    Raised only when the dependent fixture is actually requested, so a suite that
+    never asks for a connection identity never has to declare a connection type.
+
+    Attributes:
+        fixture: Name of the fixture to override, so the message names the fix
+            rather than describing it.
+    """
+
+    code: ClassVar[str] = "PRECONDITION_HARNESS_FIXTURE_NOT_CONFIGURED"
+    component: str | None = "harness_fixtures"
+    fixture: str | None = None
+
+
+@dataclass(kw_only=True)
+class SubstrateHasNoClusterError(PreconditionError):
+    """A cluster read was requested on a substrate that has no cluster.
+
+    The connector harness runs against a docker-compose worker on ``localhost``;
+    there is no Kubernetes API to read, and no kubeconfig that would be the right
+    one. Answering with a reader that fails on first use, or silently reading
+    whichever cluster the ambient kubeconfig names, are both worse than saying so
+    at the seam.
+
+    Attributes:
+        substrate: The declared substrate, so the message says which choice
+            produced the refusal.
+    """
+
+    code: ClassVar[str] = "PRECONDITION_HARNESS_SUBSTRATE_HAS_NO_CLUSTER"
+    component: str | None = "harness_fixtures"
+    substrate: str | None = None
+
+
+@dataclass(kw_only=True)
+class PreconditionsFailedError(PreconditionError):
+    """The scenario's starting state was read, and it was not fit to test on.
+
+    Deliberately **not** an ``AssertionError``: under pytest that makes an unmet
+    precondition an *error* rather than a *failure*, which is the whole point of
+    the gate — a red leg that reads as "the thing under test regressed" when the
+    environment was never prepared costs a diagnosis, and the gate exists to
+    split those two.
+
+    Attributes:
+        checks: Labels of the checks that were not met, comma-separated. A field
+            rather than only a message fragment so a report can group by check.
+        verdict: The graded verdict, for a caller routing on it without
+            re-grading.
+    """
+
+    code: ClassVar[str] = "PRECONDITION_HARNESS_PRECONDITIONS_FAILED"
+    component: str | None = "harness_preconditions"
+    checks: str | None = None
+    verdict: str | None = None
+
+
+@dataclass(kw_only=True)
+class PreconditionsIndeterminateError(DependencyUnavailableError):
+    """The scenario's starting state could not be read, so nothing was dispatched.
+
+    The gate's third answer, as a leaf. ``DEPENDENCY_UNAVAILABLE`` rather than
+    ``PRECONDITION`` for the same reason
+    :class:`WaitIndeterminateError` is: the category's own definition is "the
+    same call would work once the dependency recovers", so a CI lane that reruns
+    on infrastructure failure can act on the category without parsing prose — and
+    an expired vcluster token must never be graded as a regression.
+
+    Attributes:
+        checks: Labels of the checks that could not be read, comma-separated.
+        verdict: The graded verdict.
+    """
+
+    code: ClassVar[str] = "DEPENDENCY_UNAVAILABLE_HARNESS_PRECONDITIONS_INDETERMINATE"
+    component: str | None = "harness_preconditions"
+    checks: str | None = None
+    verdict: str | None = None
 
 
 # ---------------------------------------------------------------------------

--- a/application_sdk/testing/harness/fixtures.py
+++ b/application_sdk/testing/harness/fixtures.py
@@ -1,0 +1,958 @@
+"""The harness lifecycle as async pytest fixtures, for suites that inherit nothing.
+
+The second of the harness's three entry shapes (FND-244). All three drive the
+same functions:
+
+1. **xunit hooks** — ``setup_method`` / ``teardown_method`` on ``BaseE2ETest``,
+   one-line ``run_sync`` shims. A connector subclass that overrides
+   ``setup_method`` keeps working, because its public surface does not move.
+2. **async fixtures** — this module. ``asyncio_mode = "auto"`` is set for this
+   repo, so an ``async def`` fixture here needs no decorator beyond
+   ``@pytest.fixture``, and a composing suite's ``async def test_...`` is awaited
+   normally.
+3. :func:`~application_sdk.testing.harness.bridge.run_sync` — a synchronous
+   composer with no loop of its own.
+
+**Why fixtures dissolve the coupling.** ``BaseE2ETest`` carries a concrete test
+method, ``test_full_dag_runs_end_to_end``. Anything that inherits it to reach
+setup and teardown also *collects that test* — which is why the runtime scenario
+suite could not reuse the plumbing without also running a connector's full-DAG
+assertion. A suite that composes fixtures inherits nothing, so it collects
+exactly the tests it wrote. Nothing in this module defines a ``test_``-prefixed
+name or a ``Test``-prefixed class, and
+``tests/unit/testing/harness/test_fixtures.py`` asserts that as a property
+rather than trusting it.
+
+**Three variances stay declared, not assumed.** FND-224 was explicit that tenant
+wiring and app wiring are not shared, and building this found a third that
+neither source design document names: the execution substrate (see
+:mod:`application_sdk.testing.harness.substrate`). Each is an override-point
+fixture. Where no default is defensible the default *raises*
+:class:`~application_sdk.testing.harness._errors.FixtureNotConfiguredError`
+naming the fixture to override — and only when a suite actually requests it, so
+declaring a connection type is not a tax on a suite that never creates a
+connection.
+
+**Every fixture is function-scoped, deliberately.** A session-scoped async
+fixture binds its clients to one event loop while ``pytest-asyncio`` gives each
+test its own, which is the loop-mismatch class
+:class:`~application_sdk.testing.harness.temporal.TemporalReaderLoopMismatchError`
+exists to name; and a session-scoped connection identity would let one test's
+teardown purge the next test's assets. A composer that genuinely wants a
+session-scoped client overrides the fixture and owns the loop question.
+
+**Registration.** Fixtures work if you import them into a ``conftest.py``.
+Evidence-on-failure needs the module loaded as a *plugin*, because the only
+supported way to learn a test's verdict from a fixture is the
+``pytest_runtest_makereport`` hook below. Put this in the **root** ``conftest.py``
+(pytest 8 refuses ``pytest_plugins`` in a non-root one)::
+
+    pytest_plugins = ["application_sdk.testing.harness.fixtures"]
+
+Then compose only what a suite needs::
+
+    async def test_queue_has_only_current_pollers(
+        harness_preconditions, harness_cluster_reader
+    ) -> None:
+        assert harness_preconditions.verdict is Verdict.PASSED
+
+This module imports ``pytest``, which is why
+:mod:`application_sdk.testing.harness` does not import it: the harness package
+is importable in a process that has no test framework installed, and pytest is
+not one of this SDK's runtime dependencies.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import (
+    AsyncIterator,
+    Generator,
+    Iterator,
+    Mapping,
+    MutableMapping,
+    Sequence,
+)
+from pathlib import Path
+from typing import TYPE_CHECKING, Protocol, TypeVar, cast
+
+import pytest
+
+from application_sdk.observability.logger_adaptor import get_logger
+
+# ``teardown`` is aliased to ``teardown_api`` rather than the obvious
+# ``teardown_module``: that exact name is pytest's xunit module-teardown hook, so
+# any module holding it — this one, or a test module that imports from it — hands
+# pytest a module object to call at teardown, which fails with a baffling
+# ``AttributeError: ... has no attribute '__code__'``.
+from application_sdk.testing.harness import evidence as evidence_api
+from application_sdk.testing.harness import teardown as teardown_api
+from application_sdk.testing.harness._errors import FixtureNotConfiguredError
+from application_sdk.testing.harness.atlas import atlas_client
+from application_sdk.testing.harness.automation_engine import AEClient
+from application_sdk.testing.harness.bridge import close_loop
+from application_sdk.testing.harness.budgets import CONNECTOR_CI, BudgetProfile, Wait
+from application_sdk.testing.harness.cluster import ClusterReader
+from application_sdk.testing.harness.evidence import EvidenceBundle
+from application_sdk.testing.harness.expectations import Finding
+from application_sdk.testing.harness.identity import (
+    ConnectionIdentity,
+    Minter,
+    TenantAuth,
+    read_tenant_auth,
+)
+from application_sdk.testing.harness.preconditions import (
+    GateReport,
+    PreconditionCheck,
+    assert_gate,
+    check_worker_health,
+    run_preconditions,
+)
+from application_sdk.testing.harness.spec import AppUnderTest
+from application_sdk.testing.harness.substrate import Substrate, cluster_reader_for
+from application_sdk.testing.harness.teardown import PurgeReport
+
+if TYPE_CHECKING:  # pragma: no cover - typing only; pyatlan is a lazy import
+    from pyatlan.client.aio import AsyncAtlanClient
+
+logger = get_logger(__name__)
+
+__all__ = [
+    "EvidenceLog",
+    "harness_ae_client",
+    "harness_atlas_client",
+    "harness_budget_profile",
+    "harness_cluster_reader",
+    "harness_connection_identity",
+    "harness_connection_teardown",
+    "harness_environ",
+    "harness_evidence",
+    "harness_evidence_dir",
+    "harness_kube_context",
+    "harness_minter",
+    "harness_precondition_checks",
+    "harness_preconditions",
+    "harness_run_id",
+    "harness_substrate",
+    "harness_sync_bridge",
+    "harness_tenant_auth",
+    "harness_worker_health_url",
+]
+
+#: Prefix of the attribute the report hook leaves on the test item. One per
+#: phase, so a teardown-time reader can tell "the call failed" from "setup
+#: failed" without pytest's internals.
+_REPORT_ATTR = "_harness_phase_report_"
+
+#: Where an evidence bundle lands unless a composer says otherwise. ``results/``
+#: is already what the shared ``sdr-e2e`` CI action uploads as an artifact, and
+#: pytest runs with the repo root as its working directory, so the default needs
+#: no workflow change to survive a red leg.
+DEFAULT_EVIDENCE_DIR = Path("results/harness-evidence")
+
+
+# ---------------------------------------------------------------------------
+# The parallel-child seam
+# ---------------------------------------------------------------------------
+#
+# Child G (FND-243) owns the purge and the evidence writer; this child owns the
+# fixtures that call them, and the two are being built at the same time. So these
+# three functions are resolved **by name at call time** against the signatures
+# child G published, rather than imported at module scope:
+#
+# * whichever of the two lands first, this module still imports and every fixture
+#   that does not touch the other's surface still works;
+# * a call site that is one line and one Protocol is a cheap thing to correct if
+#   a signature moves, where a scattered set of direct calls is not.
+#
+# Each Protocol states the signature this module is coded against, so what has to
+# be re-checked when child G lands is three declarations in one place. Delete this
+# section then, and import the three names directly.
+#
+# The parameters are positional-*or*-keyword, matching child G's real signatures
+# rather than narrowing them: these are new public surface, and a composer calling
+# `purge_connection(client=..., connection_qualified_name=...)` is a legitimate
+# thing to want. Which makes the parameter *names* below part of the contract, not
+# just their order.
+
+
+class _PurgeConnection(Protocol):
+    """``teardown.purge_connection``, as this module calls it."""
+
+    async def __call__(
+        self, client: AsyncAtlanClient, connection_qualified_name: str
+    ) -> PurgeReport: ...
+
+
+class _BundleWriter(Protocol):
+    """``evidence.write_bundle``, as this module calls it. Redacts internally."""
+
+    def __call__(
+        self, bundle: EvidenceBundle, output_dir: Path, *, secrets: Sequence[str] = ()
+    ) -> Sequence[Path]: ...
+
+
+class _SecretsReader(Protocol):
+    """``evidence.secrets_from_environment``, as this module calls it."""
+
+    def __call__(
+        self, environ: Mapping[str, str], *, also: Sequence[str] = ()
+    ) -> tuple[str, ...]: ...
+
+
+_Resolved = TypeVar("_Resolved")
+
+
+def _child_g(name: str, signature: type[_Resolved]) -> _Resolved:
+    """Resolve one of child G's functions, or raise ``AttributeError``.
+
+    Args:
+        name: Attribute name on :mod:`application_sdk.testing.harness.evidence`.
+        signature: The Protocol declaring how this module calls it.
+
+    Returns:
+        The function. Both call sites are inside a broad ``except`` that reports
+        rather than raises, so a miss before child G lands costs a warning, not a
+        test result.
+    """
+    return cast(_Resolved, getattr(evidence_api, name))
+
+
+# ---------------------------------------------------------------------------
+# The report hook
+# ---------------------------------------------------------------------------
+
+
+@pytest.hookimpl(wrapper=True)
+def pytest_runtest_makereport(
+    item: pytest.Item, call: pytest.CallInfo[None]
+) -> Generator[None, pytest.TestReport, pytest.TestReport]:
+    """Stash each phase's report on the item so a fixture can read the verdict.
+
+    A fixture teardown cannot otherwise know whether its test passed — pytest
+    exposes no supported API for it — and evidence collection that fires on every
+    test rather than on failures is a different feature, one that fills a CI
+    artifact with the runs nobody needs.
+
+    Args:
+        item: The test item being reported on.
+        call: The phase pytest is reporting.
+
+    Yields:
+        Nothing of its own; forwards the report the rest of the hook chain built.
+
+    Returns:
+        The report, unchanged. This hook observes and never rewrites: a wrapper
+        that altered a report would make the harness able to change a suite's
+        verdict, which is exactly the authority a test harness must not hold.
+    """
+    report = yield
+    setattr(item, f"{_REPORT_ATTR}{report.when}", report)
+    return report
+
+
+def _phase_failed(item: pytest.Item, phase: str) -> bool | None:
+    """Whether *phase* failed, or ``None`` when the hook never ran.
+
+    Args:
+        item: The test item.
+        phase: ``"setup"`` or ``"call"``.
+
+    Returns:
+        True or False from the stashed report; ``None`` when there is none,
+        which means this module was imported for its fixtures but never
+        registered as a plugin.
+    """
+    report: pytest.TestReport | None = getattr(item, f"{_REPORT_ATTR}{phase}", None)
+    if report is None:
+        return None
+    return report.failed
+
+
+def _failed_in_any_phase(item: pytest.Item) -> bool | None:
+    """Whether the test failed in setup or in its body, or ``None`` if unknown.
+
+    Setup counts: a precondition that could not be read is exactly when evidence
+    is worth keeping, and it never reaches the body.
+
+    Args:
+        item: The test item.
+
+    Returns:
+        True, False, or ``None`` when neither phase left a report — which means
+        the hook never ran.
+    """
+    phases = [_phase_failed(item, phase) for phase in ("call", "setup")]
+    if all(phase is None for phase in phases):
+        return None
+    return any(phase for phase in phases)
+
+
+# ---------------------------------------------------------------------------
+# Override points: the variances the harness does not assume are shared
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def harness_environ() -> Mapping[str, str]:
+    """The environment this run reads, as one immutable snapshot.
+
+    A snapshot rather than :data:`os.environ` itself so every fixture in one test
+    reads the same values: identity minting, tenant auth and evidence redaction
+    each read the environment, and a test that mutates it half way through would
+    otherwise produce a connection whose name and whose purge disagree.
+
+    Returns:
+        A copy of the process environment. Override to drive a suite from a
+        config file, or to run two tenants in one session.
+    """
+    return dict(os.environ)
+
+
+@pytest.fixture
+def harness_budget_profile() -> BudgetProfile:
+    """Which timing tier this suite's waits run on.
+
+    Returns:
+        :data:`~application_sdk.testing.harness.budgets.CONNECTOR_CI`, whose
+        numbers are today's connector defaults verbatim. Override with another
+        profile for a local cluster or a shared tenant, rather than re-deriving
+        each budget at its call site.
+    """
+    return CONNECTOR_CI
+
+
+@pytest.fixture
+def harness_substrate() -> Substrate:
+    """Where this suite is running, relative to the app under test.
+
+    Returns:
+        :attr:`~application_sdk.testing.harness.substrate.Substrate.LOCAL` — the
+        substrate that needs no credentials. Defaulting to ``KUBECONFIG`` would
+        make a suite that forgot to declare its substrate reach for the ambient
+        kubeconfig, which on a developer's machine is whichever cluster
+        ``kubectl`` last pointed at.
+    """
+    return Substrate.LOCAL
+
+
+@pytest.fixture
+def harness_kube_context() -> str | None:
+    """Kubeconfig context cluster reads go through.
+
+    Returns:
+        ``None`` — the kubeconfig's current context. Override to pin a context so
+        a local run cannot silently follow ``kubectl config use-context``.
+    """
+    return None
+
+
+@pytest.fixture
+def harness_connection_type() -> str:
+    """Atlan catalog type segment for the connection this run creates.
+
+    The connector's ``connection_type`` where it differs from its short name
+    (OpenAPI publishes as ``api``), else the short name.
+
+    Returns:
+        Never returns by default.
+
+    Raises:
+        FixtureNotConfiguredError: Always, unless overridden. There is no
+            defensible default: this string is the second segment of the
+            qualified name teardown purges under, so a guessed value is a purge
+            aimed at the wrong prefix.
+    """
+    raise FixtureNotConfiguredError(
+        message=(
+            "harness_connection_type is not configured. Override it in your "
+            "conftest with the Atlan catalog type segment this suite publishes "
+            "under (e.g. 'postgres', or 'api' for OpenAPI) — it is the prefix "
+            "teardown purges, so the harness will not guess it."
+        ),
+        fixture="harness_connection_type",
+    )
+
+
+@pytest.fixture
+def harness_app_under_test() -> AppUnderTest:
+    """Where to find the app under test inside a cluster.
+
+    Returns:
+        Never returns by default.
+
+    Raises:
+        FixtureNotConfiguredError: Always, unless overridden. App wiring is one
+            of the variances FND-224 records as explicitly not shared: the
+            connector harness talks to a docker-compose worker on ``localhost``
+            and the runtime suite to a named Deployment in a namespace, so there
+            is no value that is right for both.
+    """
+    raise FixtureNotConfiguredError(
+        message=(
+            "harness_app_under_test is not configured. Override it in your "
+            "conftest with AppUnderTest(app_name=..., namespace=...) for the app "
+            "this suite drives."
+        ),
+        fixture="harness_app_under_test",
+    )
+
+
+@pytest.fixture
+def harness_worker_health_url(harness_environ: Mapping[str, str]) -> str | None:
+    """Health endpoint the default precondition polls, if there is one.
+
+    Args:
+        harness_environ: The environment snapshot.
+
+    Returns:
+        ``E2E_WORKER_HEALTH_URL`` when the ambient environment sets it — the
+        variable the shared ``sdr-e2e`` CI action already exports and
+        ``BaseE2ETest.assert_worker_up`` already reads, so the connector side
+        gets its precondition without declaring anything. ``None`` when it is
+        unset or blank, which is how a suite on another substrate opts out.
+    """
+    return harness_environ.get("E2E_WORKER_HEALTH_URL", "").strip() or None
+
+
+@pytest.fixture
+def harness_precondition_checks(
+    harness_worker_health_url: str | None, harness_budget_profile: BudgetProfile
+) -> Sequence[PreconditionCheck]:
+    """What must be true before this suite dispatches any work.
+
+    Args:
+        harness_worker_health_url: Endpoint to require, or ``None``.
+        harness_budget_profile: Supplies the
+            :attr:`~application_sdk.testing.harness.budgets.Wait.WORKER_HEALTH`
+            budget.
+
+    Returns:
+        The worker-health check when a URL is configured, else an empty tuple.
+        Override to declare the runtime side's gate — the poller check needs a
+        Temporal reader, a queue and a build id, none of which the harness can
+        derive, so it is composed by whoever knows them:
+
+        .. code-block:: python
+
+            @pytest.fixture
+            def harness_precondition_checks(temporal_reader, harness_budget_profile):
+                return (
+                    check_no_stale_pollers(
+                        reader=temporal_reader,
+                        queue="atlan-my-app",
+                        namespace="default",
+                        current_build_id="abc123",
+                        budget=harness_budget_profile.budgets[Wait.WORKER_HEALTH],
+                    ),
+                )
+    """
+    if harness_worker_health_url is None:
+        return ()
+    return (
+        check_worker_health(
+            harness_worker_health_url,
+            budget=harness_budget_profile.budgets[Wait.WORKER_HEALTH],
+        ),
+    )
+
+
+@pytest.fixture
+def harness_evidence_dir() -> Path | None:
+    """Directory a failed test's evidence bundle is written under.
+
+    Returns:
+        :data:`DEFAULT_EVIDENCE_DIR`. ``None`` opts out of writing entirely, for
+        a suite that ships its evidence somewhere else.
+    """
+    return DEFAULT_EVIDENCE_DIR
+
+
+# ---------------------------------------------------------------------------
+# Run identity
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def harness_minter(harness_environ: Mapping[str, str]) -> Minter:
+    """The per-run identifier minter, wired to the real clock and CI run id.
+
+    Args:
+        harness_environ: The environment snapshot, read for ``GITHUB_RUN_ID``.
+
+    Returns:
+        A :class:`~application_sdk.testing.harness.identity.Minter`. Override
+        with an injected clock to make a suite's minted names assertable.
+    """
+    return Minter.from_environment(harness_environ)
+
+
+@pytest.fixture
+def harness_run_id(harness_minter: Minter) -> int:
+    """Identifier scoping every name this run mints.
+
+    Args:
+        harness_minter: The minter.
+
+    Returns:
+        The ambient CI run id when there is a numeric one, else a clock reading.
+    """
+    return harness_minter.run_id()
+
+
+@pytest.fixture
+def harness_connection_identity(
+    harness_minter: Minter, harness_connection_type: str
+) -> ConnectionIdentity:
+    """The ephemeral connection this test creates, and teardown purges.
+
+    Args:
+        harness_minter: The minter.
+        harness_connection_type: Atlan catalog type segment.
+
+    Returns:
+        A qualified name and display name built from one suffix. Function-scoped
+        so two tests in one suite cannot share a connection — a shared qualified
+        name would let one test's teardown purge the other's assets and mix its
+        Atlas counts.
+    """
+    return harness_minter.connection_identity(harness_connection_type)
+
+
+# ---------------------------------------------------------------------------
+# Tenant and AE wiring
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def harness_tenant_auth(harness_environ: Mapping[str, str]) -> TenantAuth:
+    """How this run authenticates against the tenant under test.
+
+    Args:
+        harness_environ: The environment snapshot.
+
+    Returns:
+        The resolved credentials.
+
+    Raises:
+        MissingTenantEnvError: When ``ATLAN_BASE_URL`` or ``ATLAN_API_KEY`` is
+            absent. Raised rather than skipped: a tenant-facing suite that runs
+            green against no tenant is the failure mode this harness exists to
+            remove, and a suite that legitimately needs no tenant does not
+            request this fixture.
+    """
+    return read_tenant_auth(harness_environ)
+
+
+@pytest.fixture
+async def harness_atlas_client(
+    harness_tenant_auth: TenantAuth,
+) -> AsyncIterator[AsyncAtlanClient]:
+    """One ``AsyncAtlanClient`` for the whole test, closed at teardown.
+
+    One client per test rather than per call is the point: the five
+    ``asyncio.run`` sites this harness replaced stood up a fresh client, and so a
+    fresh TLS handshake, on every poll iteration.
+
+    Args:
+        harness_tenant_auth: Tenant credentials. OAuth identity is preferred when
+            configured, per
+            :func:`~application_sdk.testing.harness.atlas.atlas_client`.
+
+    Yields:
+        The open client.
+    """
+    async with atlas_client(
+        harness_tenant_auth.base_url,
+        harness_tenant_auth.api_key,
+        oauth_client_id=harness_tenant_auth.oauth_client_id,
+        oauth_client_secret=harness_tenant_auth.oauth_client_secret,
+    ) as client:
+        yield client
+
+
+@pytest.fixture
+async def harness_ae_client(harness_tenant_auth: TenantAuth) -> AsyncIterator[AEClient]:
+    """An Automation Engine client over one pooled connection, closed at teardown.
+
+    Args:
+        harness_tenant_auth: Tenant credentials. The API key rather than the
+            OAuth pair, because ``/automation/api/v1/*`` needs the realm-admin
+            ``resource_access`` role only that service account carries.
+
+    Yields:
+        The client. Its pool is bound to the loop that first used it, which is
+        the other reason this fixture is function-scoped.
+    """
+    client = AEClient(harness_tenant_auth.base_url, harness_tenant_auth.api_key)
+    try:
+        yield client
+    finally:
+        await client.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Cluster reader selection
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def harness_cluster_reader(
+    harness_substrate: Substrate, harness_kube_context: str | None
+) -> ClusterReader:
+    """A read-only cluster reader for the declared substrate.
+
+    Args:
+        harness_substrate: Where this suite is running.
+        harness_kube_context: Context to pin, or ``None``.
+
+    Returns:
+        The reader.
+
+    Raises:
+        SubstrateHasNoClusterError: On the local substrate, which has no
+            Kubernetes API to read.
+        HarnessNotBuiltError: On the in-cluster substrate, until FND-248.
+    """
+    return cluster_reader_for(harness_substrate, kube_context=harness_kube_context)
+
+
+# ---------------------------------------------------------------------------
+# The precondition gate
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def harness_preconditions(
+    harness_precondition_checks: Sequence[PreconditionCheck],
+) -> GateReport:
+    """Assert the starting state before the test dispatches any work.
+
+    Requesting this fixture is what runs the gate, so a scenario cannot forget
+    to: the checks run during setup, and an unmet one fails the test before its
+    body executes.
+
+    Args:
+        harness_precondition_checks: The checks to run.
+
+    Returns:
+        The passing report, so a test can put the readings into its own
+        evidence.
+
+    Raises:
+        PreconditionsFailedError: A readable precondition was not met.
+        PreconditionsIndeterminateError: A precondition could not be read.
+            Neither is an ``AssertionError``, so pytest reports an unfit
+            environment as an *error* rather than as a failure of the thing under
+            test.
+    """
+    report = await run_preconditions(harness_precondition_checks)
+    assert_gate(report)
+    return report
+
+
+# ---------------------------------------------------------------------------
+# Evidence
+# ---------------------------------------------------------------------------
+
+
+class EvidenceLog:
+    """A mutable builder for one test's :class:`EvidenceBundle`.
+
+    The bundle is frozen, which is right for the thing that ships and wrong for
+    the thing a running scenario accumulates into. This is the accumulating half:
+    a scenario records readings and findings as it makes them, and the fixture
+    freezes it into a bundle if the test fails.
+
+    Accumulate-don't-truncate is the same rule the outcome vocabulary follows: a
+    red leg should carry every finding the run produced, not the first one.
+
+    Args:
+        label: What the run was, for the report title.
+    """
+
+    def __init__(self, label: str) -> None:
+        self.label = label
+        self._findings: list[Finding] = []
+        self._logs: MutableMapping[str, Sequence[str]] = {}
+        self._readings: MutableMapping[str, object] = {}
+        self._artifacts: MutableMapping[str, str] = {}
+
+    def add_finding(self, finding: Finding) -> None:
+        """Record an unmet expectation.
+
+        Args:
+            finding: The finding to keep.
+        """
+        self._findings.append(finding)
+
+    def add_logs(self, source: str, lines: Sequence[str]) -> None:
+        """Record captured log lines.
+
+        Args:
+            source: Pod name, container name, or a synthetic name for a non-pod
+                source.
+            lines: The captured lines, in order.
+        """
+        self._logs[source] = tuple(lines)
+
+    def record(self, name: str, value: object) -> None:
+        """Record one named observation.
+
+        Args:
+            name: What was observed ("table_count", "poller_identities").
+            value: The observation.
+        """
+        self._readings[name] = value
+
+    def add_artifact(self, relative_path: str, contents: str) -> None:
+        """Record a file to write alongside the report.
+
+        Args:
+            relative_path: Path relative to the bundle's output directory.
+            contents: File contents.
+        """
+        self._artifacts[relative_path] = contents
+
+    def merge(self, bundle: EvidenceBundle) -> None:
+        """Fold another bundle's contents into this one.
+
+        The seam for evidence a scenario collects itself — pod logs from a
+        cluster reader, for instance — so this builder does not have to know how
+        to collect anything.
+
+        Args:
+            bundle: The bundle to fold in. Its ``label`` is not adopted; keys it
+                shares with this log overwrite.
+        """
+        self._findings.extend(bundle.findings)
+        self._logs.update(bundle.logs)
+        self._readings.update(bundle.readings)
+        self._artifacts.update(bundle.artifacts)
+
+    def bundle(self) -> EvidenceBundle:
+        """Freeze what has been accumulated.
+
+        Returns:
+            An :class:`EvidenceBundle` holding copies, so later additions to this
+            log cannot mutate a bundle already handed out.
+        """
+        return EvidenceBundle(
+            label=self.label,
+            findings=tuple(self._findings),
+            logs=dict(self._logs),
+            readings=dict(self._readings),
+            artifacts=dict(self._artifacts),
+        )
+
+    @property
+    def is_empty(self) -> bool:
+        """Whether anything at all has been accumulated.
+
+        Returns:
+            True when there is nothing worth writing.
+        """
+        return not (self._findings or self._logs or self._readings or self._artifacts)
+
+
+@pytest.fixture
+def harness_evidence(
+    request: pytest.FixtureRequest,
+    harness_environ: Mapping[str, str],
+    harness_evidence_dir: Path | None,
+) -> Iterator[EvidenceLog]:
+    """Accumulate evidence, and write it — redacted — if the test fails.
+
+    Args:
+        request: The test item, for its name and its verdict.
+        harness_environ: Environment snapshot, read for the credential-shaped
+            values that must not reach an artifact.
+        harness_evidence_dir: Where to write, or ``None`` to opt out.
+
+    Yields:
+        The :class:`EvidenceLog` to record into.
+    """
+    item: pytest.Item = request.node
+    log = EvidenceLog(item.name)
+    try:
+        yield log
+    finally:
+        _write_if_failed(
+            log,
+            name=item.name,
+            nodeid=item.nodeid,
+            failed=_failed_in_any_phase(item),
+            environ=harness_environ,
+            evidence_dir=harness_evidence_dir,
+        )
+
+
+def _write_if_failed(
+    log: EvidenceLog,
+    *,
+    name: str,
+    nodeid: str,
+    failed: bool | None,
+    environ: Mapping[str, str],
+    evidence_dir: Path | None,
+) -> None:
+    """Write *log*'s bundle when the test it belongs to failed.
+
+    Every failure here is swallowed with a warning, for the reason teardown's
+    are: this runs after the assertions have decided the verdict, so raising
+    would replace a real failure with a bookkeeping error and lose the
+    diagnosis. That covers the window before child G (FND-243) lands the writer
+    too — the persist functions are resolved by name at call time rather than
+    imported at module scope, so this module loads and every other fixture works
+    on a tree where they do not exist yet.
+
+    Args:
+        log: The accumulated evidence.
+        name: Test name, for the log lines.
+        nodeid: Test node id, which becomes the bundle's directory name.
+        failed: Whether the test failed, or ``None`` for "cannot tell".
+        environ: Environment snapshot, for the secret values to redact.
+        evidence_dir: Root to write under, or ``None``.
+    """
+    if evidence_dir is None or log.is_empty:
+        return
+    if failed is None:
+        logger.warning(
+            "harness_evidence cannot tell whether %s failed, so it wrote "
+            "nothing: add pytest_plugins = "
+            '["application_sdk.testing.harness.fixtures"] to your ROOT '
+            "conftest.py, which is what registers the report hook",
+            name,
+        )
+        return
+    if not failed:
+        return
+    try:
+        secrets = _child_g("secrets_from_environment", _SecretsReader)(
+            environ, also=("ATLAN_BASE_URL",)
+        )
+        written = _child_g("write_bundle", _BundleWriter)(
+            log.bundle(), evidence_dir / _slug(nodeid), secrets=secrets
+        )
+    except Exception:
+        logger.warning(
+            "could not write the evidence bundle for %s — the test result "
+            "stands; only the evidence is missing",
+            name,
+            exc_info=True,
+        )
+        return
+    logger.info("wrote %d evidence file(s) for failed test %s", len(written), name)
+
+
+def _slug(nodeid: str) -> str:
+    """Turn a pytest node id into one path segment.
+
+    Args:
+        nodeid: The node id, which carries ``/``, ``::`` and parametrisation
+            brackets.
+
+    Returns:
+        A single filesystem-safe segment. Every separator is replaced rather
+        than only ``/``, so a parametrised id cannot produce a nested path.
+    """
+    safe = "".join(
+        character if character.isalnum() or character in "-_" else "_"
+        for character in nodeid
+    )
+    return safe.strip("_") or "test"
+
+
+# ---------------------------------------------------------------------------
+# Teardown
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def harness_connection_teardown(
+    harness_connection_identity: ConnectionIdentity,
+    harness_atlas_client: AsyncAtlanClient,
+) -> AsyncIterator[ConnectionIdentity]:
+    """Yield this test's connection identity, and purge it afterwards.
+
+    Requesting this fixture is what guarantees the purge, so a scenario cannot
+    create a connection and forget to clean it up. It runs after every test —
+    pass, fail or error — because assets a failed run leaves behind accumulate in
+    a shared tenant, and a leftover half-set-up connection is exactly what greens
+    a later run that should have failed.
+
+    Args:
+        harness_connection_identity: The connection this test creates.
+        harness_atlas_client: The already-open client the purge reuses, so
+            teardown costs no second TLS handshake.
+
+    Yields:
+        The identity, so the test does not need both fixtures.
+    """
+    try:
+        yield harness_connection_identity
+    finally:
+        await _purge_quietly(
+            harness_atlas_client, harness_connection_identity.qualified_name
+        )
+
+
+async def _purge_quietly(client: AsyncAtlanClient, qualified_name: str) -> None:
+    """Purge *qualified_name*, reporting any failure rather than raising.
+
+    A failed purge is reported and never raised — teardown runs after the
+    assertions have decided the verdict, and raising here replaces a real failure
+    with a cleanup error. The broad ``except`` is that property, not laziness: it
+    also covers the window before child G (FND-243) lands the implementation,
+    where the scaffold raises
+    :class:`~application_sdk.testing.harness._errors.HarnessNotBuiltError` and a
+    suite composing these fixtures should still run.
+
+    Args:
+        client: Open tenant client.
+        qualified_name: The ephemeral connection to purge.
+    """
+    try:
+        purge = cast(_PurgeConnection, teardown_api.purge_connection)
+        report = await purge(client, qualified_name)
+    except Exception:
+        logger.warning(
+            "e2e cleanup: purge of %s did not run — manual purge may be needed",
+            qualified_name,
+            exc_info=True,
+        )
+        return
+    if report.orphaned or report.errors:
+        logger.warning(
+            "e2e cleanup: purged %d asset(s) under %s but left %d orphaned; "
+            "%d batch error(s): %s",
+            report.purged,
+            qualified_name,
+            len(report.orphaned),
+            len(report.errors),
+            "; ".join(report.errors),
+        )
+
+
+# ---------------------------------------------------------------------------
+# The sync bridge's loop
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def harness_sync_bridge() -> Iterator[None]:
+    """Close the sync bridge's event loop for this thread at teardown.
+
+    For a *synchronous* composer — the third entry shape — which reaches the
+    harness through :func:`~application_sdk.testing.harness.bridge.run_sync`
+    rather than through the async fixtures here. The bridge keeps one loop per
+    thread for the life of the thread; this is the fixture the bridge's own
+    documentation means when it says teardown belongs to the caller.
+
+    Yields:
+        Nothing. Request it for its teardown.
+    """
+    try:
+        yield
+    finally:
+        close_loop()

--- a/application_sdk/testing/harness/fixtures.py
+++ b/application_sdk/testing/harness/fixtures.py
@@ -120,10 +120,12 @@ logger = get_logger(__name__)
 __all__ = [
     "EvidenceLog",
     "harness_ae_client",
+    "harness_app_under_test",
     "harness_atlas_client",
     "harness_budget_profile",
     "harness_cluster_reader",
     "harness_connection_identity",
+    "harness_connection_type",
     "harness_connection_teardown",
     "harness_environ",
     "harness_evidence",

--- a/application_sdk/testing/harness/preconditions.py
+++ b/application_sdk/testing/harness/preconditions.py
@@ -1,0 +1,473 @@
+"""The precondition gate: what has to be true before a scenario dispatches work.
+
+Every scenario asserts its starting state before it does anything, because that
+is what splits one ambiguous failure into two distinct ones — *a bad starting
+state* versus *a real bug* — and because passing preconditions are the only
+available proof that the previous scenario cleaned up after itself.
+
+Both consumer sides arrived at the same requirement from opposite directions:
+
+* the connector suites have ``BaseE2ETest.assert_worker_up`` — the CI worker
+  container answers ``/server/health`` before the DAG is submitted;
+* the runtime scenario suite requires "the intended version is Current, **and no
+  stale-version workers are still polling**" before every scenario.
+
+Those are the same check in two substrates, so they are two builders over one
+gate rather than two gates. :func:`check_worker_health` and
+:func:`check_no_stale_pollers` each return a :class:`PreconditionCheck`;
+:func:`run_preconditions` runs a list of them and grades the result.
+
+**The gate may return "could not tell".** That is the whole reason it is a gate
+and not a pile of ``assert`` statements. A precondition read off a broken
+environment — an expired vcluster token, a Temporal frontend that will not answer
+— is neither "the starting state is good" nor "the starting state is bad", and
+reporting it as either is worse than reporting it as neither. So a check returns
+an :class:`~application_sdk.testing.harness.outcome.Outcome` rather than a bool,
+:func:`~application_sdk.testing.harness.outcome.grade` reduces the pile to one
+:class:`~application_sdk.testing.harness.outcome.Verdict`, and
+:func:`assert_gate` raises **two different leaves** for the two non-passing
+verdicts so a suite's own report can tell them apart on the type alone.
+
+**No pytest here.** The two shapes that consume this — the async fixtures in
+:mod:`application_sdk.testing.harness.fixtures` and a sync composer going
+through :func:`~application_sdk.testing.harness.bridge.run_sync` — both want the
+gate without importing a test framework, and the runtime scenario suite drives
+it from its own scenario format. Everything in this module is a plain async
+function over the primitives in
+:mod:`application_sdk.testing.harness.waiting`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Coroutine, Iterable
+from dataclasses import dataclass, field
+from datetime import timedelta
+from typing import Any
+
+import httpx
+
+from application_sdk.observability.logger_adaptor import get_logger
+from application_sdk.testing.harness._errors import (
+    PreconditionsFailedError,
+    PreconditionsIndeterminateError,
+)
+from application_sdk.testing.harness.budgets import Budget
+from application_sdk.testing.harness.outcome import (
+    Indeterminate,
+    Outcome,
+    Settled,
+    Verdict,
+    grade,
+)
+from application_sdk.testing.harness.temporal import (
+    PollerInfo,
+    TemporalConnectFailedError,
+    TemporalReader,
+    TemporalReadFailedError,
+    stale_version_pollers,
+)
+from application_sdk.testing.harness.waiting import poll_until
+
+logger = get_logger(__name__)
+
+__all__ = [
+    "GateReport",
+    "HealthReading",
+    "PollerReading",
+    "PreconditionCheck",
+    "assert_gate",
+    "check_no_stale_pollers",
+    "check_worker_health",
+    "run_preconditions",
+]
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class PreconditionCheck:
+    """One thing that must be true before a scenario starts.
+
+    Attributes:
+        label: Noun phrase naming what is being required, written for whoever
+            reads a red CI leg ("the openapi worker's /server/health"). Carried
+            here as well as inside the outcome so the gate can name a check that
+            raised before it produced one.
+        run: Takes the reading and returns the verdict. A zero-argument async
+            callable rather than a probe plus a budget plus predicates, because
+            a check is built once by whoever knows its substrate and then run by
+            a gate that knows none of it.
+    """
+
+    label: str
+    run: Callable[[], Coroutine[Any, Any, Outcome[Any]]]
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class GateReport:
+    """What the gate observed, and the one verdict it reduces to.
+
+    Attributes:
+        verdict: :func:`~application_sdk.testing.harness.outcome.grade` over
+            every outcome below.
+        outcomes: One outcome per check, in the order the checks were declared.
+            Kept whole rather than reduced to a pass/fail list because the
+            fields a reader needs — which poller identities were stale, what the
+            last HTTP status was — live on the outcome variants.
+    """
+
+    verdict: Verdict
+    outcomes: tuple[Outcome[Any], ...] = field(default_factory=tuple)
+
+    @property
+    def unmet(self) -> tuple[Outcome[Any], ...]:
+        """Every check that did not settle, unreadable ones included.
+
+        Returns:
+            The non-:class:`~application_sdk.testing.harness.outcome.Settled`
+            outcomes, in declaration order.
+        """
+        return tuple(
+            outcome for outcome in self.outcomes if not isinstance(outcome, Settled)
+        )
+
+    def summary(self) -> str:
+        """Render the unmet checks as one report line.
+
+        Returns:
+            A semicolon-separated rendering naming each unmet check, its variant
+            and how long it spent. Empty string when everything settled, so a
+            caller can put it straight into a message without a conditional.
+        """
+        return "; ".join(
+            f"{outcome.label}: {type(outcome).__name__} after "
+            f"{outcome.elapsed.total_seconds():.0f}s "
+            f"({outcome.attempts} probe(s))"
+            for outcome in self.unmet
+        )
+
+
+async def run_preconditions(checks: Iterable[PreconditionCheck]) -> GateReport:
+    """Run every check and grade what they observed.
+
+    Runs the checks **in order and to completion**, rather than stopping at the
+    first unmet one. Accumulation is the same choice
+    :mod:`application_sdk.testing.harness.outcome` makes and for the same
+    reason: a gate that reports only the first thing wrong with an environment
+    costs one CI run per fault to diagnose, and the faults an environment gate
+    catches arrive in groups — a tenant that was never prepared fails the worker
+    check *and* the poller check, and knowing both is what identifies it as one
+    cause rather than two.
+
+    A check that raises instead of returning a verdict is recorded as
+    :class:`~application_sdk.testing.harness.outcome.Indeterminate` rather than
+    propagating. The gate's contract is that it always produces a report: a
+    check whose own code broke has told us nothing about the environment, which
+    is exactly what that variant means, and letting it propagate would lose the
+    verdicts of the checks that already ran.
+
+    Args:
+        checks: The checks to run, in the order they should run.
+
+    Returns:
+        The report. An empty ``checks`` grades
+        :attr:`~application_sdk.testing.harness.outcome.Verdict.PASSED` — a
+        suite that declares no preconditions makes no claim about its starting
+        state, and inventing an ``INDETERMINATE`` there would force every
+        composer to declare a check before it could run a single test.
+    """
+    outcomes: list[Outcome[Any]] = []
+    for check in checks:
+        try:
+            outcomes.append(await check.run())
+        # Exception, not BaseException: a cancelled run is not a failed gate.
+        except Exception as error:
+            logger.warning(
+                "precondition check %r raised instead of returning a verdict — "
+                "recording it as indeterminate, so the gate reports every other "
+                "check rather than aborting on this one",
+                check.label,
+                exc_info=True,
+            )
+            outcomes.append(
+                Indeterminate(
+                    label=check.label,
+                    attempts=0,
+                    elapsed=timedelta(0),
+                    cause=error,
+                )
+            )
+    return GateReport(verdict=grade(outcomes=outcomes), outcomes=tuple(outcomes))
+
+
+def assert_gate(report: GateReport) -> None:
+    """Raise unless every precondition was met.
+
+    Two leaves rather than one, because the two non-passing verdicts route
+    differently and a suite that cannot tell them apart will treat a broken
+    environment as a regression:
+
+    * :attr:`~application_sdk.testing.harness.outcome.Verdict.FAILED` — the
+      starting state was read, and it was wrong. A ``PRECONDITION`` leaf: state
+      has to change before the scenario can run.
+    * :attr:`~application_sdk.testing.harness.outcome.Verdict.INDETERMINATE` —
+      the starting state could not be read. A ``DEPENDENCY_UNAVAILABLE`` leaf,
+      which is retryable by category, so a CI lane that reruns on infrastructure
+      failure can act on it without parsing a message.
+
+    Neither is an ``AssertionError``, and that is deliberate: under pytest an
+    unmet precondition is reported as an **error** rather than as a failure, so a
+    scenario suite's red does not read as "the thing under test regressed" when
+    the environment was never fit to test it.
+
+    Args:
+        report: What :func:`run_preconditions` produced.
+
+    Raises:
+        PreconditionsFailedError: A readable precondition was not met.
+        PreconditionsIndeterminateError: A precondition could not be read, and
+            none of the readable ones failed.
+    """
+    if report.verdict is Verdict.PASSED:
+        return
+    unmet = report.summary()
+    labels = ",".join(outcome.label for outcome in report.unmet)
+    if report.verdict is Verdict.FAILED:
+        raise PreconditionsFailedError(
+            message=(
+                "the scenario's preconditions were not met, so no work was "
+                f"dispatched: {unmet}. This is the starting state, not a "
+                "verdict on the thing under test."
+            ),
+            checks=labels,
+            verdict=str(report.verdict),
+        )
+    raise PreconditionsIndeterminateError(
+        message=(
+            "the scenario's preconditions could not be read, so no work was "
+            f"dispatched and there is no verdict: {unmet}"
+        ),
+        checks=labels,
+        verdict=str(report.verdict),
+    )
+
+
+# ---------------------------------------------------------------------------
+# The two built-in checks
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class HealthReading:
+    """One reading of an HTTP health endpoint.
+
+    A reading rather than an exception, which is the load-bearing choice in
+    :func:`check_worker_health`: while a worker is still starting, a refused
+    connection is the *expected* answer, not a failed read. Modelling it as a
+    probe error would make the health poll's first refused connection either an
+    absorbed transient (spending the wait's error streak on normal startup) or an
+    :class:`~application_sdk.testing.harness.outcome.Indeterminate` — and "the
+    worker never came up" is a genuine finding about the thing under test, never
+    an unreadable dependency.
+
+    Attributes:
+        status: HTTP status the endpoint answered, or ``None`` if it did not
+            answer at all.
+        error: Transport error as a string when ``status`` is ``None``, else
+            empty. Stringified rather than kept as an exception because this
+            value goes into a fingerprint and a report line, and the poll keeps
+            no per-attempt exception chain.
+    """
+
+    status: int | None = None
+    error: str = ""
+
+    @property
+    def healthy(self) -> bool:
+        """Whether this reading is a 2xx.
+
+        Returns:
+            True when the endpoint answered with a success status.
+        """
+        return self.status is not None and 200 <= self.status < 300
+
+    def __str__(self) -> str:
+        """Render the reading for a report line or a progress fingerprint."""
+        return f"HTTP {self.status}" if self.status is not None else self.error
+
+
+def check_worker_health(
+    url: str,
+    *,
+    budget: Budget,
+    label: str | None = None,
+    transport: httpx.AsyncBaseTransport | None = None,
+) -> PreconditionCheck:
+    """Require that a worker answers 2xx on its health endpoint.
+
+    The connector-side precondition, as a check the gate can run alongside the
+    runtime side's. It re-expresses ``BaseE2ETest.assert_worker_up`` over
+    :func:`~application_sdk.testing.harness.waiting.poll_until`: the same
+    bounded poll of the same endpoint, returning a verdict instead of raising, so
+    it can be graded with everything else the gate observed.
+
+    Args:
+        url: Health endpoint to poll. A fixed URL from configuration, never a
+            value from a payload — it is passed to an HTTP client as-is.
+        budget: The wait's allowance.
+            :attr:`~application_sdk.testing.harness.budgets.Wait.WORKER_HEALTH`
+            in a profile carries the connector-CI numbers.
+            ``start_grace`` splits the two diagnoses: with one set, an endpoint
+            that never answers at all returns
+            :class:`~application_sdk.testing.harness.outcome.NeverStarted` (the
+            worker did not deploy) rather than
+            :class:`~application_sdk.testing.harness.outcome.Expired` (it
+            answered, but never 2xx).
+        label: Override for the report line. Defaults to naming the URL.
+        transport: HTTP transport to use, or ``None`` for the real one. The seam
+            a test drives, so the poll's own behaviour — how a refused
+            connection is read, when the wait settles — is checked against a
+            real :class:`httpx.AsyncClient` over a scripted transport rather
+            than against a patched module global.
+
+    Returns:
+        The check. Nothing is polled until the gate runs it.
+    """
+    check_label = label or f"worker health at {url}"
+
+    async def _run() -> Outcome[HealthReading]:
+        # One client for the whole poll, closed when it ends: a fresh client per
+        # attempt is the per-iteration-handshake cost the sync bridge exists to
+        # avoid, and a health poll is the loop that runs most often.
+        async with httpx.AsyncClient(
+            follow_redirects=True, transport=transport
+        ) as http:
+
+            async def probe() -> HealthReading:
+                try:
+                    response = await http.get(url, timeout=10.0)
+                except (httpx.HTTPError, OSError) as error:
+                    # conformance: ignore[E007] the transport failure IS the reading — returned as HealthReading(error=...) and carried into the outcome the caller grades, so nothing is hidden; logging here would emit one line per poll for the normal case of a container still starting
+                    return HealthReading(error=f"{type(error).__name__}: {error}")
+                return HealthReading(status=response.status_code)
+
+            return await poll_until(
+                probe,
+                settled=lambda reading: reading.healthy,
+                started=lambda reading: reading.status is not None,
+                budget=budget,
+                label=check_label,
+            )
+
+    return PreconditionCheck(label=check_label, run=_run)
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class PollerReading:
+    """One reading of who is polling a task queue.
+
+    Attributes:
+        pollers: Every poller Temporal reported. Empty is a real answer — the
+            observed form of "nothing is polling this queue".
+        stale: The subset not on the intended build id, per
+            :func:`~application_sdk.testing.harness.temporal.stale_version_pollers`.
+    """
+
+    pollers: tuple[PollerInfo, ...] = field(default_factory=tuple)
+    stale: tuple[PollerInfo, ...] = field(default_factory=tuple)
+
+    def __str__(self) -> str:
+        """Render the reading for a report line or a progress fingerprint."""
+        if not self.pollers:
+            return "no pollers"
+        stale = ",".join(sorted(poller.identity for poller in self.stale))
+        return f"{len(self.pollers)} poller(s), stale: {stale or 'none'}"
+
+
+def check_no_stale_pollers(
+    *,
+    reader: TemporalReader,
+    queue: str,
+    namespace: str,
+    current_build_id: str | None,
+    budget: Budget,
+    label: str | None = None,
+) -> PreconditionCheck:
+    """Require that the queue is polled, and only by the intended build.
+
+    The runtime side's precondition. It is one check rather than two because the
+    two halves fail as one condition: a queue polled *only* by stale workers and
+    a queue polled by nobody are both "the version I am about to test is not the
+    version that will pick this up", and a scenario that dispatched work under
+    either would attribute the previous build's behaviour to this one.
+
+    The two halves still report differently, through the wait's own vocabulary:
+
+    * nothing ever polling gives
+      :class:`~application_sdk.testing.harness.outcome.NeverStarted` when the
+      budget carries a ``start_grace`` — the deployment never arrived;
+    * stale pollers that never drain give
+      :class:`~application_sdk.testing.harness.outcome.Stalled` when it carries a
+      ``stall_timeout``, with the stale identities as the frozen fingerprint —
+      the previous scenario did not clean up;
+    * an unreadable frontend gives
+      :class:`~application_sdk.testing.harness.outcome.Indeterminate`, which is
+      the verdict this whole gate exists to keep available.
+
+    Args:
+        reader: Read-only Temporal reader.
+        queue: Task queue the scenario is about to dispatch onto.
+        namespace: Temporal namespace the queue lives in.
+        current_build_id: Build id the deployment intends to be serving, or
+            ``None`` when versioning is not in use — in which case no poller can
+            be stale and the check reduces to "something is polling".
+        budget: The wait's allowance. Poll interval, grace and stall window all
+            come from here.
+        label: Override for the report line. Defaults to naming the queue.
+
+    Returns:
+        The check. Nothing is read until the gate runs it.
+    """
+    check_label = label or f"pollers on task queue {queue}"
+
+    async def probe() -> PollerReading:
+        pollers = tuple(await reader.task_queue_pollers(queue, namespace=namespace))
+        return PollerReading(
+            pollers=pollers,
+            stale=tuple(
+                stale_version_pollers(pollers, current_build_id=current_build_id)
+            ),
+        )
+
+    async def _run() -> Outcome[PollerReading]:
+        return await poll_until(
+            probe,
+            settled=lambda reading: bool(reading.pollers) and not reading.stale,
+            started=lambda reading: bool(reading.pollers),
+            fingerprint=str,
+            transient=_temporal_read_is_transient,
+            budget=budget,
+            label=check_label,
+        )
+
+    return PreconditionCheck(label=check_label, run=_run)
+
+
+def _temporal_read_is_transient(error: BaseException) -> timedelta | None:
+    """Classify a Temporal read failure for the poller poll.
+
+    A frontend that could not be reached or could not answer is absorbed as
+    transient — out-of-cluster scenarios reach it over a VPN and a vcluster
+    tunnel, where a reset connection mid-poll is routine. Nothing else is: a
+    ``WorkflowNotFoundError`` or a wrong call signature raises the same
+    exception on every attempt, so absorbing it would spend the whole budget
+    confirming a bug in the probe.
+
+    Args:
+        error: The exception the probe raised.
+
+    Returns:
+        Zero backoff (honour the poll's own cadence) for a reachability failure;
+        ``None`` for anything else, which propagates.
+    """
+    if isinstance(error, (TemporalConnectFailedError, TemporalReadFailedError)):
+        return timedelta(0)
+    return None

--- a/application_sdk/testing/harness/substrate.py
+++ b/application_sdk/testing/harness/substrate.py
@@ -1,0 +1,111 @@
+"""Where the harness is running from — the fourth point of variance, named.
+
+FND-224 catalogued three things the two source design documents disagreed about
+and therefore could not be assumed shared: tenant wiring, app wiring, and how a
+run starts work. Building the fixtures found a fourth that **neither document
+names**: the execution substrate.
+
+The connector harness drives a docker-compose worker on ``localhost:8000``,
+gated on ``/server/health``, on a per-leg task queue. There is no Kubernetes API
+in that picture at all — the CI runner has no route into the tenant vcluster,
+which is also why the AE submit is the only tenant-facing probe of the installed
+app pod. The runtime scenario suite wants the opposite: an in-cluster or
+kubeconfig-driven reader against a dev tenant, where cluster reads are the
+primary evidence.
+
+So substrate is a *declared* input, not a detected one. Detection is the tempting
+alternative and it is wrong in a specific way: "is there a kubeconfig?" is almost
+always yes on a developer's machine, and answering it by reaching for whichever
+cluster ``kubectl`` last pointed at is how a local test run reads a production
+tenant. A suite says which substrate it is on, and a substrate that cannot
+support a read refuses it by name.
+
+Kept out of :mod:`application_sdk.testing.harness.fixtures` so a composer that
+does not use pytest — the runtime suite drives the harness from sync scenario
+code through :func:`~application_sdk.testing.harness.bridge.run_sync` — can
+select a reader without importing a test framework.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+from application_sdk.testing.harness._errors import (
+    HarnessNotBuiltError,
+    SubstrateHasNoClusterError,
+)
+from application_sdk.testing.harness.cluster import ClusterReader, KubernetesReader
+
+__all__ = ["Substrate", "cluster_reader_for"]
+
+
+class Substrate(StrEnum):
+    """Where the code driving the harness is running, relative to the app.
+
+    Three values because the credential source differs three ways, which is the
+    only thing the harness has to know: a local process has none, an
+    out-of-cluster driver reads a kubeconfig, and an in-cluster driver reads its
+    own ServiceAccount.
+    """
+
+    #: A worker reachable over ``localhost`` — the connector CI substrate. There
+    #: is no cluster to read, and saying so is the point: see
+    #: :class:`~application_sdk.testing.harness._errors.SubstrateHasNoClusterError`.
+    LOCAL = "local"
+    #: An out-of-cluster driver, credentials from the ambient kubeconfig. What
+    #: the runtime scenario suite runs on today, over a VPN and a vcluster
+    #: tunnel.
+    KUBECONFIG = "kubeconfig"
+    #: A driver running inside the cluster it reads, credentials from its own
+    #: ServiceAccount. FND-248; the reader is the same class, with a different
+    #: API-bundle factory.
+    IN_CLUSTER = "in_cluster"
+
+
+def cluster_reader_for(
+    substrate: Substrate, *, kube_context: str | None = None
+) -> ClusterReader:
+    """Build the cluster reader *substrate* implies.
+
+    Args:
+        substrate: The declared substrate.
+        kube_context: Kubeconfig context for
+            :attr:`Substrate.KUBECONFIG`, or ``None`` for the kubeconfig's
+            current one. Ignored by the other substrates.
+
+    Returns:
+        A reader. Nothing is connected here — :class:`KubernetesReader` builds
+        its API bundle per thread on first read, so an unusable kubeconfig
+        surfaces at the read rather than at construction.
+
+    Raises:
+        SubstrateHasNoClusterError: On :attr:`Substrate.LOCAL`. A composer that
+            reached here on the local substrate wants either a different
+            substrate or no cluster read; both are better than a reader that
+            fails on first use, and far better than one that silently reads
+            whichever cluster the ambient kubeconfig names.
+        HarnessNotBuiltError: On :attr:`Substrate.IN_CLUSTER`, until FND-248
+            lands the in-cluster API-bundle factory.
+    """
+    if substrate is Substrate.KUBECONFIG:
+        return KubernetesReader(kube_context=kube_context)
+    if substrate is Substrate.IN_CLUSTER:
+        raise HarnessNotBuiltError(
+            message=(
+                "the in-cluster credential factory is not implemented yet — run "
+                "with Substrate.KUBECONFIG, or supply your own ClusterReader"
+            ),
+            operation="cluster_reader_for",
+            reason="FND-248 lands the in-cluster API-bundle factory",
+            issue="FND-248",
+            component="harness_substrate",
+        )
+    raise SubstrateHasNoClusterError(
+        message=(
+            f"substrate {substrate} has no Kubernetes API to read: the connector "
+            "harness drives a worker on localhost and the CI runner has no route "
+            "into a cluster. Declare Substrate.KUBECONFIG (or IN_CLUSTER) if this "
+            "suite really does read a cluster, or drop the cluster read."
+        ),
+        substrate=str(substrate),
+    )

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -1,8 +1,8 @@
 <!--
 generated-by:  capability-manifest skill (.claude/skills/capability-manifest)
 sdk-version:   3.29.0
-source-sha:    3b44c0a39767080d6dffccf48dc9a9efbb5d3e27
-source-date:   2026-08-27T13:23:09Z
+source-sha:    4eb964f4230ca77522a4edbb19abd8bcf6e8acda
+source-date:   2026-08-27T15:27:14+01:00
 do-not-edit:   re-run the skill instead of hand-editing
 -->
 
@@ -34,7 +34,7 @@ do-not-edit:   re-run the skill instead of hand-editing
 | `application_sdk.server` | FastAPI server, MCP integration, middleware, health endpoint | 4 |
 | `application_sdk.storage` | Object-store abstraction — factory, formats, batch, transfer, cloud bindings | 42 |
 | `application_sdk.templates` | SQL metadata extractor templates and their contracts | 6 |
-| `application_sdk.testing` | Test infrastructure — mocks, fixtures, hypothesis strategies, integration helpers | 245 |
+| `application_sdk.testing` | Test infrastructure — mocks, fixtures, hypothesis strategies, integration helpers | 247 |
 | `application_sdk.validation` | Offline artifact & asset validation — format-agnostic wrapper (ADR-0020) plus pyatlan_v9 .validate() wrappers, no network call | 78 |
 
 ## Subpackage Details
@@ -4280,6 +4280,13 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Summary:** An Automation Engine client over one pooled connection, closed at teardown.
 - **Defined in:** `application_sdk/testing/harness/fixtures.py`
 
+#### `harness_app_under_test`
+
+- **Import:** `from application_sdk.testing.harness.fixtures import harness_app_under_test`
+- **Signature:** `harness_app_under_test() -> AppUnderTest`
+- **Summary:** Where to find the app under test inside a cluster.
+- **Defined in:** `application_sdk/testing/harness/fixtures.py`
+
 #### `harness_atlas_client`
 
 - **Import:** `from application_sdk.testing.harness.fixtures import harness_atlas_client`
@@ -4313,6 +4320,13 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Import:** `from application_sdk.testing.harness.fixtures import harness_connection_teardown`
 - **Signature:** `harness_connection_teardown(harness_connection_identity: ConnectionIdentity, ...)`
 - **Summary:** Yield this test's connection identity, and purge it afterwards.
+- **Defined in:** `application_sdk/testing/harness/fixtures.py`
+
+#### `harness_connection_type`
+
+- **Import:** `from application_sdk.testing.harness.fixtures import harness_connection_type`
+- **Signature:** `harness_connection_type() -> str`
+- **Summary:** Atlan catalog type segment for the connection this run creates.
 - **Defined in:** `application_sdk/testing/harness/fixtures.py`
 
 #### `harness_environ`

--- a/docs/agents/sdk-capabilities.md
+++ b/docs/agents/sdk-capabilities.md
@@ -1,8 +1,8 @@
 <!--
 generated-by:  capability-manifest skill (.claude/skills/capability-manifest)
 sdk-version:   3.29.0
-source-sha:    d2a955a22aa3bd7c18224814b7ad80b688368786
-source-date:   2026-08-27T13:42:01+01:00
+source-sha:    3b44c0a39767080d6dffccf48dc9a9efbb5d3e27
+source-date:   2026-08-27T13:23:09Z
 do-not-edit:   re-run the skill instead of hand-editing
 -->
 
@@ -34,7 +34,7 @@ do-not-edit:   re-run the skill instead of hand-editing
 | `application_sdk.server` | FastAPI server, MCP integration, middleware, health endpoint | 4 |
 | `application_sdk.storage` | Object-store abstraction — factory, formats, batch, transfer, cloud bindings | 42 |
 | `application_sdk.templates` | SQL metadata extractor templates and their contracts | 6 |
-| `application_sdk.testing` | Test infrastructure — mocks, fixtures, hypothesis strategies, integration helpers | 212 |
+| `application_sdk.testing` | Test infrastructure — mocks, fixtures, hypothesis strategies, integration helpers | 245 |
 | `application_sdk.validation` | Offline artifact & asset validation — format-agnostic wrapper (ADR-0020) plus pyatlan_v9 .validate() wrappers, no network call | 78 |
 
 ## Subpackage Details
@@ -3372,6 +3372,13 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Summary:** Everything worth keeping about one harness run.
 - **Defined in:** `application_sdk/testing/harness/evidence.py`
 
+#### `EvidenceLog`
+
+- **Import:** `from application_sdk.testing.harness.fixtures import EvidenceLog`
+- **Signature:** `class EvidenceLog(label: str) -> None`
+- **Summary:** A mutable builder for one test's :class:`EvidenceBundle`.
+- **Defined in:** `application_sdk/testing/harness/fixtures.py`
+
 #### `Expired`
 
 - **Import:** `from application_sdk.testing.harness import Expired`
@@ -3394,6 +3401,13 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Summary:** One unmet expectation, in a form a report can render without re-parsing.
 - **Defined in:** `application_sdk/testing/harness/expectations.py`
 
+#### `FixtureNotConfiguredError`
+
+- **Import:** `from application_sdk.testing.harness import FixtureNotConfiguredError`
+- **Signature:** `class FixtureNotConfiguredError(*, ...)`
+- **Summary:** A composer requested a harness fixture without declaring what it needs.
+- **Defined in:** `application_sdk/testing/harness/_errors.py`
+
 #### `FullDAGOutcome`
 
 - **Import:** `from application_sdk.testing.e2e import FullDAGOutcome`
@@ -3408,12 +3422,28 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Summary:** Summary of all differences between expected and actual metadata.
 - **Defined in:** `application_sdk/testing/integration/comparison.py`
 
+#### `GateReport`
+
+- **Import:** `from application_sdk.testing.harness import GateReport`
+- **Also importable from:** `application_sdk.testing.harness.preconditions`
+- **Signature:** `class GateReport(*, verdict: Verdict, outcomes: tuple[Outcome[Any], ...] = tuple())`
+- **Summary:** What the gate observed, and the one verdict it reduces to.
+- **Defined in:** `application_sdk/testing/harness/preconditions.py`
+
 #### `HarnessNotBuiltError`
 
 - **Import:** `from application_sdk.testing.harness import HarnessNotBuiltError`
 - **Signature:** `class HarnessNotBuiltError(*, ...)`
 - **Summary:** A scaffolded harness function whose implementation has not landed yet.
 - **Defined in:** `application_sdk/testing/harness/_errors.py`
+
+#### `HealthReading`
+
+- **Import:** `from application_sdk.testing.harness import HealthReading`
+- **Also importable from:** `application_sdk.testing.harness.preconditions`
+- **Signature:** `class HealthReading(*, status: int | None = None, error: str = '')`
+- **Summary:** One reading of an HTTP health endpoint.
+- **Defined in:** `application_sdk/testing/harness/preconditions.py`
 
 #### `HttpRequest`
 
@@ -3601,6 +3631,14 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Summary:** One worker seen polling a task queue.
 - **Defined in:** `application_sdk/testing/harness/temporal/_states.py`
 
+#### `PollerReading`
+
+- **Import:** `from application_sdk.testing.harness import PollerReading`
+- **Also importable from:** `application_sdk.testing.harness.preconditions`
+- **Signature:** `class PollerReading(*, pollers: tuple[PollerInfo, ...] = tuple(), stale: tuple[PollerInfo, ...] = tuple())`
+- **Summary:** One reading of who is polling a task queue.
+- **Defined in:** `application_sdk/testing/harness/preconditions.py`
+
 #### `PortForward`
 
 - **Import:** `from application_sdk.testing.e2e.portforward import PortForward`
@@ -3608,6 +3646,28 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Signature:** `class PortForward(namespace: str, service: str, port: int, *, timeout: float = 30.0, kube_context: str | None = None)`
 - **Summary:** One ``kubectl port-forward`` tunnel to a Service, and calls over it.
 - **Defined in:** `application_sdk/testing/harness/cluster/_portforward.py`
+
+#### `PreconditionCheck`
+
+- **Import:** `from application_sdk.testing.harness import PreconditionCheck`
+- **Also importable from:** `application_sdk.testing.harness.preconditions`
+- **Signature:** `class PreconditionCheck(*, label: str, run: Callable[[], Coroutine[Any, Any, Outcome[Any]]])`
+- **Summary:** One thing that must be true before a scenario starts.
+- **Defined in:** `application_sdk/testing/harness/preconditions.py`
+
+#### `PreconditionsFailedError`
+
+- **Import:** `from application_sdk.testing.harness import PreconditionsFailedError`
+- **Signature:** `class PreconditionsFailedError(*, ...)`
+- **Summary:** The scenario's starting state was read, and it was not fit to test on.
+- **Defined in:** `application_sdk/testing/harness/_errors.py`
+
+#### `PreconditionsIndeterminateError`
+
+- **Import:** `from application_sdk.testing.harness import PreconditionsIndeterminateError`
+- **Signature:** `class PreconditionsIndeterminateError(*, ...)`
+- **Summary:** The scenario's starting state could not be read, so nothing was dispatched.
+- **Defined in:** `application_sdk/testing/harness/_errors.py`
 
 #### `PublishedVersion`
 
@@ -3726,6 +3786,21 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Signature:** `class Stalled(*, ...)`
 - **Summary:** Work started, then stopped making observable progress.
 - **Defined in:** `application_sdk/testing/harness/outcome.py`
+
+#### `Substrate`
+
+- **Import:** `from application_sdk.testing.harness import Substrate`
+- **Also importable from:** `application_sdk.testing.harness.substrate`
+- **Signature:** `class Substrate`
+- **Summary:** Where the code driving the harness is running, relative to the app.
+- **Defined in:** `application_sdk/testing/harness/substrate.py`
+
+#### `SubstrateHasNoClusterError`
+
+- **Import:** `from application_sdk.testing.harness import SubstrateHasNoClusterError`
+- **Signature:** `class SubstrateHasNoClusterError(*, ...)`
+- **Summary:** A cluster read was requested on a substrate that has no cluster.
+- **Defined in:** `application_sdk/testing/harness/_errors.py`
 
 #### `SyncBridgeInAsyncContextError`
 
@@ -3923,6 +3998,14 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Summary:** AppContext wired with MockStateStore and MockSecretStore.
 - **Defined in:** `application_sdk/testing/fixtures.py`
 
+#### `assert_gate`
+
+- **Import:** `from application_sdk.testing.harness import assert_gate`
+- **Also importable from:** `application_sdk.testing.harness.preconditions`
+- **Signature:** `assert_gate(report: GateReport)`
+- **Summary:** Raise unless every precondition was met.
+- **Defined in:** `application_sdk/testing/harness/preconditions.py`
+
 #### `assert_settled`
 
 - **Import:** `from application_sdk.testing.harness import assert_settled`
@@ -3959,6 +4042,22 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Summary:** Deprecated (v4.0) — seed-version DAG; use ``application_sdk.testing.e2e.payload``.
 - **Defined in:** `application_sdk/testing/full_dag/payload.py`
 
+#### `check_no_stale_pollers`
+
+- **Import:** `from application_sdk.testing.harness import check_no_stale_pollers`
+- **Also importable from:** `application_sdk.testing.harness.preconditions`
+- **Signature:** `check_no_stale_pollers(*, *, ...)`
+- **Summary:** Require that the queue is polled, and only by the intended build.
+- **Defined in:** `application_sdk/testing/harness/preconditions.py`
+
+#### `check_worker_health`
+
+- **Import:** `from application_sdk.testing.harness import check_worker_health`
+- **Also importable from:** `application_sdk.testing.harness.preconditions`
+- **Signature:** `check_worker_health(url: str, *, ...)`
+- **Summary:** Require that a worker answers 2xx on its health endpoint.
+- **Defined in:** `application_sdk/testing/harness/preconditions.py`
+
 #### `clean_app_registry`
 
 - **Import:** `from application_sdk.testing import clean_app_registry`
@@ -3980,6 +4079,14 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Signature:** `close_loop()`
 - **Summary:** Close this thread's bridge loop, if it has one. Idempotent.
 - **Defined in:** `application_sdk/testing/harness/bridge.py`
+
+#### `cluster_reader_for`
+
+- **Import:** `from application_sdk.testing.harness import cluster_reader_for`
+- **Also importable from:** `application_sdk.testing.harness.substrate`
+- **Signature:** `cluster_reader_for(substrate: Substrate, *, kube_context: str | None = None)`
+- **Summary:** Build the cluster reader *substrate* implies.
+- **Defined in:** `application_sdk/testing/harness/substrate.py`
 
 #### `cold_start_submit_kwargs`
 
@@ -4165,6 +4272,132 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Signature:** `greater_than_or_equal(value: float, *, description: str | None = None)`
 - **Summary:** Assert that the actual value is greater than or equal to the given value.
 - **Defined in:** `application_sdk/testing/integration/assertions.py`
+
+#### `harness_ae_client`
+
+- **Import:** `from application_sdk.testing.harness.fixtures import harness_ae_client`
+- **Signature:** `harness_ae_client(harness_tenant_auth: TenantAuth) -> AsyncIterator[AEClient]`
+- **Summary:** An Automation Engine client over one pooled connection, closed at teardown.
+- **Defined in:** `application_sdk/testing/harness/fixtures.py`
+
+#### `harness_atlas_client`
+
+- **Import:** `from application_sdk.testing.harness.fixtures import harness_atlas_client`
+- **Signature:** `harness_atlas_client(harness_tenant_auth: TenantAuth) -> AsyncIterator[AsyncAtlanClient]`
+- **Summary:** One ``AsyncAtlanClient`` for the whole test, closed at teardown.
+- **Defined in:** `application_sdk/testing/harness/fixtures.py`
+
+#### `harness_budget_profile`
+
+- **Import:** `from application_sdk.testing.harness.fixtures import harness_budget_profile`
+- **Signature:** `harness_budget_profile() -> BudgetProfile`
+- **Summary:** Which timing tier this suite's waits run on.
+- **Defined in:** `application_sdk/testing/harness/fixtures.py`
+
+#### `harness_cluster_reader`
+
+- **Import:** `from application_sdk.testing.harness.fixtures import harness_cluster_reader`
+- **Signature:** `harness_cluster_reader(harness_substrate: Substrate, harness_kube_context: str | None) -> ClusterReader`
+- **Summary:** A read-only cluster reader for the declared substrate.
+- **Defined in:** `application_sdk/testing/harness/fixtures.py`
+
+#### `harness_connection_identity`
+
+- **Import:** `from application_sdk.testing.harness.fixtures import harness_connection_identity`
+- **Signature:** `harness_connection_identity(harness_minter: Minter, harness_connection_type: str) -> ConnectionIdentity`
+- **Summary:** The ephemeral connection this test creates, and teardown purges.
+- **Defined in:** `application_sdk/testing/harness/fixtures.py`
+
+#### `harness_connection_teardown`
+
+- **Import:** `from application_sdk.testing.harness.fixtures import harness_connection_teardown`
+- **Signature:** `harness_connection_teardown(harness_connection_identity: ConnectionIdentity, ...)`
+- **Summary:** Yield this test's connection identity, and purge it afterwards.
+- **Defined in:** `application_sdk/testing/harness/fixtures.py`
+
+#### `harness_environ`
+
+- **Import:** `from application_sdk.testing.harness.fixtures import harness_environ`
+- **Signature:** `harness_environ() -> Mapping[str, str]`
+- **Summary:** The environment this run reads, as one immutable snapshot.
+- **Defined in:** `application_sdk/testing/harness/fixtures.py`
+
+#### `harness_evidence`
+
+- **Import:** `from application_sdk.testing.harness.fixtures import harness_evidence`
+- **Signature:** `harness_evidence(request: pytest.FixtureRequest, ...)`
+- **Summary:** Accumulate evidence, and write it — redacted — if the test fails.
+- **Defined in:** `application_sdk/testing/harness/fixtures.py`
+
+#### `harness_evidence_dir`
+
+- **Import:** `from application_sdk.testing.harness.fixtures import harness_evidence_dir`
+- **Signature:** `harness_evidence_dir() -> Path | None`
+- **Summary:** Directory a failed test's evidence bundle is written under.
+- **Defined in:** `application_sdk/testing/harness/fixtures.py`
+
+#### `harness_kube_context`
+
+- **Import:** `from application_sdk.testing.harness.fixtures import harness_kube_context`
+- **Signature:** `harness_kube_context() -> str | None`
+- **Summary:** Kubeconfig context cluster reads go through.
+- **Defined in:** `application_sdk/testing/harness/fixtures.py`
+
+#### `harness_minter`
+
+- **Import:** `from application_sdk.testing.harness.fixtures import harness_minter`
+- **Signature:** `harness_minter(harness_environ: Mapping[str, str]) -> Minter`
+- **Summary:** The per-run identifier minter, wired to the real clock and CI run id.
+- **Defined in:** `application_sdk/testing/harness/fixtures.py`
+
+#### `harness_precondition_checks`
+
+- **Import:** `from application_sdk.testing.harness.fixtures import harness_precondition_checks`
+- **Signature:** `harness_precondition_checks(harness_worker_health_url: str | None, ...)`
+- **Summary:** What must be true before this suite dispatches any work.
+- **Defined in:** `application_sdk/testing/harness/fixtures.py`
+
+#### `harness_preconditions`
+
+- **Import:** `from application_sdk.testing.harness.fixtures import harness_preconditions`
+- **Signature:** `harness_preconditions(harness_precondition_checks: Sequence[PreconditionCheck]) -> GateReport`
+- **Summary:** Assert the starting state before the test dispatches any work.
+- **Defined in:** `application_sdk/testing/harness/fixtures.py`
+
+#### `harness_run_id`
+
+- **Import:** `from application_sdk.testing.harness.fixtures import harness_run_id`
+- **Signature:** `harness_run_id(harness_minter: Minter) -> int`
+- **Summary:** Identifier scoping every name this run mints.
+- **Defined in:** `application_sdk/testing/harness/fixtures.py`
+
+#### `harness_substrate`
+
+- **Import:** `from application_sdk.testing.harness.fixtures import harness_substrate`
+- **Signature:** `harness_substrate() -> Substrate`
+- **Summary:** Where this suite is running, relative to the app under test.
+- **Defined in:** `application_sdk/testing/harness/fixtures.py`
+
+#### `harness_sync_bridge`
+
+- **Import:** `from application_sdk.testing.harness.fixtures import harness_sync_bridge`
+- **Signature:** `harness_sync_bridge() -> Iterator[None]`
+- **Summary:** Close the sync bridge's event loop for this thread at teardown.
+- **Defined in:** `application_sdk/testing/harness/fixtures.py`
+
+#### `harness_tenant_auth`
+
+- **Import:** `from application_sdk.testing.harness.fixtures import harness_tenant_auth`
+- **Signature:** `harness_tenant_auth(harness_environ: Mapping[str, str]) -> TenantAuth`
+- **Summary:** How this run authenticates against the tenant under test.
+- **Defined in:** `application_sdk/testing/harness/fixtures.py`
+
+#### `harness_worker_health_url`
+
+- **Import:** `from application_sdk.testing.harness.fixtures import harness_worker_health_url`
+- **Signature:** `harness_worker_health_url(harness_environ: Mapping[str, str]) -> str | None`
+- **Summary:** Health endpoint the default precondition polls, if there is one.
+- **Defined in:** `application_sdk/testing/harness/fixtures.py`
 
 #### `has_length`
 
@@ -4451,6 +4684,14 @@ Test infrastructure — mocks, fixtures, hypothesis strategies, integration help
 - **Signature:** `run_comparison(baseline_dir: Path, candidate_dir: Path)`
 - **Summary:** Run full parity comparison across all categories.
 - **Defined in:** `application_sdk/testing/parity/comparator.py`
+
+#### `run_preconditions`
+
+- **Import:** `from application_sdk.testing.harness import run_preconditions`
+- **Also importable from:** `application_sdk.testing.harness.preconditions`
+- **Signature:** `run_preconditions(checks: Iterable[PreconditionCheck])`
+- **Summary:** Run every check and grade what they observed.
+- **Defined in:** `application_sdk/testing/harness/preconditions.py`
 
 #### `run_sync`
 

--- a/tests/unit/testing/harness/test_fixtures.py
+++ b/tests/unit/testing/harness/test_fixtures.py
@@ -885,3 +885,19 @@ def test_the_tenant_clients_are_built_and_closed_around_the_test(
         """
     )
     suite.runpytest().assert_outcomes(passed=1)
+
+
+def test_every_fixture_is_exported() -> None:
+    """``__all__`` is what the capability manifest renders, so a fixture missing
+    from it is one a composer cannot discover without reading the source.
+
+    An invariant rather than a one-off fix, because pytest discovers a fixture
+    whether or not it is exported — so nothing else in the tree notices. The two
+    that were missing were ``harness_connection_type`` and
+    ``harness_app_under_test``: the only two a composer *must* declare, and so
+    exactly the two worst to leave out of the manifest.
+    """
+    exported = set(fixtures_api.__all__)
+    defined = {name for name in dir(fixtures_api) if name.startswith("harness_")}
+    assert defined - exported == set()
+    assert all(hasattr(fixtures_api, name) for name in exported)

--- a/tests/unit/testing/harness/test_fixtures.py
+++ b/tests/unit/testing/harness/test_fixtures.py
@@ -1,0 +1,887 @@
+"""Unit tests for the harness's async fixtures (child I on FND-224).
+
+Two kinds of test, for two kinds of claim.
+
+The fixture contracts are checked by **running pytest inside pytest**
+(``pytester``), because that is the only way to check what a fixture actually
+does: that requesting it is what runs the gate, that an unconfigured override
+point errors rather than guessing, that teardown fires on a failing test, and —
+the issue's own acceptance criterion — that a suite composing these fixtures
+*collects zero tests it did not write*. Asserting that last one by reading the
+module's namespace would only prove this module is tidy today; asserting it
+through a real collection proves the property the runtime suite needs.
+
+The plain helpers — the evidence accumulator, the node-id slug, the quiet purge —
+are tested directly.
+
+One seam is stubbed rather than driven: ``evidence.write_bundle`` and
+``evidence.secrets_from_environment`` land in child G (FND-243) and do not exist
+on this tree yet, so the tests that cover the write path assert the *call* this
+module makes against the signature child G published. That is a claim, not a
+differential, and it agrees with a wrong signature by construction — the reason
+it is written this way is that the alternative is no coverage of the write path
+at all. Once child G lands, these become assertions against a real writer.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from application_sdk.testing.harness import evidence as evidence_api
+from application_sdk.testing.harness import fixtures as fixtures_api
+from application_sdk.testing.harness import teardown as teardown_api
+from application_sdk.testing.harness.evidence import EvidenceBundle
+from application_sdk.testing.harness.expectations import Finding
+from application_sdk.testing.harness.fixtures import (
+    DEFAULT_EVIDENCE_DIR,
+    EvidenceLog,
+    _failed_in_any_phase,
+    _phase_failed,
+    _purge_quietly,
+    _slug,
+    _write_if_failed,
+)
+from application_sdk.testing.harness.teardown import PurgeReport
+
+pytest_plugins = ["pytester"]
+
+#: Written into every generated project: the fixtures reach pytest's hooks only
+#: when the module is registered as a plugin, and ``asyncio_mode`` is what lets
+#: an ``async def`` fixture work with no decorator.
+CONFTEST = 'pytest_plugins = ["application_sdk.testing.harness.fixtures"]\n'
+INI = "[pytest]\nasyncio_mode = auto\nasyncio_default_fixture_loop_scope = function\n"
+
+
+class RecordingLogger:
+    """Captures this module's own log calls, rendered.
+
+    ``caplog`` cannot see them: the SDK's logger is loguru-backed and does not
+    propagate to stdlib logging. Substituting the module's logger object is what
+    keeps the message assertable — which matters for the unregistered-plugin
+    path, where the warning *is* the behaviour rather than a note about it.
+    """
+
+    def __init__(self) -> None:
+        self.messages: list[str] = []
+
+    def _record(self, message: str, *args: object, **kwargs: object) -> None:
+        self.messages.append(message % args if args else message)
+
+    warning = _record
+    info = _record
+    error = _record
+    debug = _record
+
+    @property
+    def text(self) -> str:
+        return "\n".join(self.messages)
+
+
+@pytest.fixture
+def recorded_logs(monkeypatch: pytest.MonkeyPatch) -> RecordingLogger:
+    """Substitute the fixtures module's logger, and hand back what it recorded."""
+    recorder = RecordingLogger()
+    monkeypatch.setattr(fixtures_api, "logger", recorder)
+    return recorder
+
+
+@pytest.fixture
+def suite(pytester: pytest.Pytester) -> pytest.Pytester:
+    """A generated pytest project with the harness fixtures registered."""
+    pytester.makeini(INI)
+    pytester.makeconftest(CONFTEST)
+    return pytester
+
+
+# ---------------------------------------------------------------------------
+# The acceptance criterion: a composing suite collects only its own tests
+# ---------------------------------------------------------------------------
+
+
+def test_a_composing_suite_collects_only_the_tests_it_wrote(
+    suite: pytest.Pytester,
+) -> None:
+    """The whole reason fixtures exist alongside the base class. Inheriting
+    ``BaseE2ETest`` to reach setup and teardown also collects its concrete
+    ``test_full_dag_runs_end_to_end``; composing fixtures collects nothing."""
+    suite.makepyfile(
+        test_composed="""
+        def test_only_mine(harness_run_id, harness_budget_profile):
+            assert isinstance(harness_run_id, int)
+        """
+    )
+    collected = suite.runpytest("--collect-only", "-q")
+    ids = [line for line in collected.outlines if "::" in line]
+    assert ids == ["test_composed.py::test_only_mine"]
+    collected.assert_outcomes()
+
+
+def test_the_module_contributes_no_collectible_names(suite: pytest.Pytester) -> None:
+    """Registering the plugin must not add a test to the composer's suite, so a
+    ``test_``-prefixed helper can never be introduced here by accident."""
+    suite.makepyfile(test_empty="")
+    result = suite.runpytest("--collect-only", "-q")
+    assert not [line for line in result.outlines if "::" in line]
+
+
+# ---------------------------------------------------------------------------
+# Override points
+# ---------------------------------------------------------------------------
+
+
+def test_an_unconfigured_connection_type_errors_and_names_the_fixture(
+    suite: pytest.Pytester,
+) -> None:
+    """No defensible default: this string is the prefix teardown purges under."""
+    suite.makepyfile(
+        test_identity="""
+        def test_needs_a_connection_type(harness_connection_identity):
+            raise AssertionError("the body must never run")
+        """
+    )
+    result = suite.runpytest()
+    result.assert_outcomes(errors=1)
+    result.stdout.fnmatch_lines(["*harness_connection_type*"])
+
+
+def test_an_unconfigured_app_under_test_errors(suite: pytest.Pytester) -> None:
+    suite.makepyfile(
+        test_app="""
+        def test_needs_an_app(harness_app_under_test):
+            raise AssertionError("the body must never run")
+        """
+    )
+    result = suite.runpytest()
+    result.assert_outcomes(errors=1)
+    result.stdout.fnmatch_lines(["*harness_app_under_test*"])
+
+
+def test_a_suite_that_declares_nothing_still_runs(suite: pytest.Pytester) -> None:
+    """The raising defaults fire only when the dependent fixture is requested:
+    declaring a connection type is not a tax on a suite with no connection."""
+    suite.makepyfile(
+        test_plain="""
+        def test_no_declarations_needed(harness_environ, harness_substrate):
+            assert harness_substrate == "local"
+        """
+    )
+    suite.runpytest().assert_outcomes(passed=1)
+
+
+def test_an_overridden_minter_makes_the_purged_name_assertable(
+    suite: pytest.Pytester,
+) -> None:
+    """The identity module puts the clock behind a seam so a test can predict the
+    qualified name teardown will purge. This is that promise, through fixtures."""
+    suite.makepyfile(
+        test_minted="""
+        import pytest
+        from application_sdk.testing.harness.identity import Minter
+
+        @pytest.fixture
+        def harness_connection_type():
+            return "postgres"
+
+        @pytest.fixture
+        def harness_minter():
+            return Minter(clock=lambda: 1700000000, randbelow=lambda _: 42)
+
+        def test_exact_qualified_name(harness_connection_identity):
+            assert harness_connection_identity.qualified_name == (
+                "default/postgres/1700000000000042"
+            )
+        """
+    )
+    suite.runpytest().assert_outcomes(passed=1)
+
+
+def test_the_local_substrate_refuses_a_cluster_read(suite: pytest.Pytester) -> None:
+    suite.makepyfile(
+        test_cluster="""
+        def test_no_cluster_here(harness_cluster_reader):
+            raise AssertionError("the body must never run")
+        """
+    )
+    result = suite.runpytest()
+    result.assert_outcomes(errors=1)
+    result.stdout.fnmatch_lines(["*has no Kubernetes API*"])
+
+
+def test_a_declared_kubeconfig_substrate_builds_a_reader(
+    suite: pytest.Pytester,
+) -> None:
+    """Selection follows the declaration, and building the reader connects
+    nothing — an unusable kubeconfig surfaces at the read, not at setup."""
+    suite.makepyfile(
+        test_cluster_ok="""
+        import pytest
+        from application_sdk.testing.harness.cluster import ClusterReader
+        from application_sdk.testing.harness.substrate import Substrate
+
+        @pytest.fixture
+        def harness_substrate():
+            return Substrate.KUBECONFIG
+
+        @pytest.fixture
+        def harness_kube_context():
+            return "e2e-gcp"
+
+        def test_reader_is_built(harness_cluster_reader):
+            assert isinstance(harness_cluster_reader, ClusterReader)
+            assert harness_cluster_reader.kube_context == "e2e-gcp"
+        """
+    )
+    suite.runpytest().assert_outcomes(passed=1)
+
+
+def test_a_missing_tenant_raises_rather_than_skipping(suite: pytest.Pytester) -> None:
+    """A tenant-facing suite that runs green against no tenant is the failure
+    mode this harness exists to remove."""
+    suite.makepyfile(
+        test_tenant="""
+        import pytest
+
+        @pytest.fixture
+        def harness_environ():
+            return {}
+
+        def test_needs_a_tenant(harness_tenant_auth):
+            raise AssertionError("the body must never run")
+        """
+    )
+    result = suite.runpytest()
+    result.assert_outcomes(errors=1)
+    result.stdout.fnmatch_lines(["*ATLAN_BASE_URL*"])
+
+
+def test_tenant_auth_is_read_from_the_environ_snapshot(
+    suite: pytest.Pytester,
+) -> None:
+    suite.makepyfile(
+        test_tenant_ok="""
+        import pytest
+
+        @pytest.fixture
+        def harness_environ():
+            return {
+                "ATLAN_BASE_URL": "https://tenant.example.com/",
+                "ATLAN_API_KEY": "  token  ",
+            }
+
+        def test_auth(harness_tenant_auth):
+            assert harness_tenant_auth.base_url == "https://tenant.example.com"
+            assert harness_tenant_auth.api_key == "token"
+            assert harness_tenant_auth.oauth_client_id is None
+        """
+    )
+    suite.runpytest().assert_outcomes(passed=1)
+
+
+# ---------------------------------------------------------------------------
+# The precondition gate, as a fixture
+# ---------------------------------------------------------------------------
+
+
+def test_requesting_the_gate_is_what_runs_it(suite: pytest.Pytester) -> None:
+    """So a scenario cannot forget to assert its starting state."""
+    suite.makepyfile(
+        test_gate="""
+        import pytest
+        from datetime import timedelta
+
+        from application_sdk.testing.harness import Settled
+        from application_sdk.testing.harness.preconditions import PreconditionCheck
+
+        ran = []
+
+        @pytest.fixture
+        def harness_precondition_checks():
+            async def _run():
+                ran.append("checked")
+                return Settled(
+                    label="mine", attempts=1, elapsed=timedelta(0), value=True
+                )
+            return (PreconditionCheck(label="mine", run=_run),)
+
+        def test_gate_ran_before_me(harness_preconditions):
+            assert ran == ["checked"]
+            assert harness_preconditions.verdict == "passed"
+        """
+    )
+    suite.runpytest().assert_outcomes(passed=1)
+
+
+def test_an_unmet_precondition_errors_before_the_body_runs(
+    suite: pytest.Pytester,
+) -> None:
+    """An error, not a failure: the environment was never fit to test, so the red
+    must not read as a regression in the thing under test."""
+    suite.makepyfile(
+        test_gate_fails="""
+        import pytest
+        from datetime import timedelta
+
+        from application_sdk.testing.harness import Expired
+        from application_sdk.testing.harness.preconditions import PreconditionCheck
+
+        @pytest.fixture
+        def harness_precondition_checks():
+            async def _run():
+                return Expired(
+                    label="worker health",
+                    attempts=3,
+                    elapsed=timedelta(seconds=9),
+                    budget=timedelta(seconds=9),
+                )
+            return (PreconditionCheck(label="worker health", run=_run),)
+
+        def test_never_runs(harness_preconditions):
+            raise AssertionError("the body must never run")
+        """
+    )
+    result = suite.runpytest()
+    result.assert_outcomes(errors=1, failed=0)
+    result.stdout.fnmatch_lines(["*PreconditionsFailedError*"])
+
+
+def test_the_default_gate_polls_the_ambient_health_url(
+    suite: pytest.Pytester,
+) -> None:
+    """The connector side gets its precondition from the variable the shared CI
+    action already exports, without declaring anything."""
+    suite.makepyfile(
+        test_default_gate="""
+        import pytest
+
+        @pytest.fixture
+        def harness_environ():
+            return {"E2E_WORKER_HEALTH_URL": "http://127.0.0.1:1/server/health"}
+
+        def test_checks_are_declared(harness_precondition_checks):
+            assert len(harness_precondition_checks) == 1
+            assert "127.0.0.1:1" in harness_precondition_checks[0].label
+
+        def test_no_url_means_no_checks(harness_precondition_checks, harness_environ):
+            pass
+        """
+    )
+    result = suite.runpytest("-k", "checks_are_declared")
+    result.assert_outcomes(passed=1)
+
+
+def test_no_health_url_declares_no_checks(suite: pytest.Pytester) -> None:
+    suite.makepyfile(
+        test_no_gate="""
+        import pytest
+
+        @pytest.fixture
+        def harness_environ():
+            return {"E2E_WORKER_HEALTH_URL": "   "}
+
+        def test_empty(harness_precondition_checks, harness_preconditions):
+            assert harness_precondition_checks == ()
+            assert harness_preconditions.verdict == "passed"
+        """
+    )
+    suite.runpytest().assert_outcomes(passed=1)
+
+
+# ---------------------------------------------------------------------------
+# Teardown
+# ---------------------------------------------------------------------------
+
+
+def test_the_connection_is_purged_even_when_the_test_fails(
+    suite: pytest.Pytester,
+) -> None:
+    """Assets a failed run leaves behind are what green a later run that should
+    have failed."""
+    suite.makepyfile(
+        test_purge="""
+        import pytest
+
+        from application_sdk.testing.harness import teardown as teardown_api
+        from application_sdk.testing.harness.teardown import PurgeReport
+
+        purged = []
+
+        @pytest.fixture
+        def harness_connection_type():
+            return "postgres"
+
+        @pytest.fixture
+        async def harness_atlas_client():
+            yield object()
+
+        @pytest.fixture(autouse=True)
+        def _capture_purges(monkeypatch):
+            async def _fake(client, qualified_name):
+                purged.append(qualified_name)
+                return PurgeReport(purged=3)
+            monkeypatch.setattr(teardown_api, "purge_connection", _fake)
+
+        async def test_fails_on_purpose(harness_connection_teardown):
+            assert harness_connection_teardown.qualified_name.startswith(
+                "default/postgres/"
+            )
+            raise AssertionError("deliberate")
+
+        def test_the_purge_happened():
+            assert len(purged) == 1
+        """
+    )
+    result = suite.runpytest()
+    result.assert_outcomes(passed=1, failed=1)
+
+
+async def test_a_purge_failure_is_warned_not_raised(
+    recorded_logs: RecordingLogger, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Teardown runs after the assertions decided the verdict: raising here
+    replaces a real failure with a cleanup error and loses the diagnosis."""
+
+    async def _boom(client: object, qualified_name: str) -> PurgeReport:
+        raise RuntimeError("tenant said no")
+
+    monkeypatch.setattr(teardown_api, "purge_connection", _boom)
+    await _purge_quietly(object(), "default/postgres/1")  # type: ignore[arg-type]
+    assert "manual purge may be needed" in recorded_logs.text
+
+
+async def test_an_incomplete_purge_names_what_it_left_behind(
+    recorded_logs: RecordingLogger, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An operator cleaning up by hand needs the qualified names; a count tells
+    them only that they have a problem."""
+
+    async def _partial(client: object, qualified_name: str) -> PurgeReport:
+        return PurgeReport(
+            purged=2, orphaned=("default/postgres/1/db",), errors=("batch 2 failed",)
+        )
+
+    monkeypatch.setattr(teardown_api, "purge_connection", _partial)
+    await _purge_quietly(object(), "default/postgres/1")  # type: ignore[arg-type]
+    assert "1 orphaned" in recorded_logs.text
+    assert "batch 2 failed" in recorded_logs.text
+
+
+async def test_a_clean_purge_says_nothing(
+    recorded_logs: RecordingLogger, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    async def _clean(client: object, qualified_name: str) -> PurgeReport:
+        return PurgeReport(purged=7)
+
+    monkeypatch.setattr(teardown_api, "purge_connection", _clean)
+    await _purge_quietly(object(), "default/postgres/1")  # type: ignore[arg-type]
+    assert recorded_logs.text == ""
+
+
+# ---------------------------------------------------------------------------
+# The sync bridge's loop
+# ---------------------------------------------------------------------------
+
+
+def test_the_bridge_fixture_closes_the_loop_per_test(suite: pytest.Pytester) -> None:
+    """The bridge keeps one loop per thread for the life of the thread; this is
+    the teardown its own documentation says belongs to the caller."""
+    suite.makepyfile(
+        test_bridge_fixture="""
+        import asyncio
+
+        from application_sdk.testing.harness import run_sync
+
+        loops = []
+
+        async def _current_loop():
+            return asyncio.get_running_loop()
+
+        def test_first(harness_sync_bridge):
+            loops.append(run_sync(_current_loop()))
+
+        def test_second(harness_sync_bridge):
+            loops.append(run_sync(_current_loop()))
+
+        def test_each_test_had_its_own_closed_loop():
+            assert loops[0] is not loops[1]
+            assert loops[0].is_closed()
+            assert loops[1].is_closed()
+        """
+    )
+    suite.runpytest().assert_outcomes(passed=3)
+
+
+# ---------------------------------------------------------------------------
+# The evidence accumulator
+# ---------------------------------------------------------------------------
+
+
+def _finding(label: str = "table count") -> Finding:
+    return Finding(
+        subject=label, detail="expected at least 1, saw 0", expectation="floor"
+    )
+
+
+def test_an_empty_log_is_empty() -> None:
+    assert EvidenceLog("run").is_empty
+
+
+def test_the_log_accumulates_rather_than_truncating() -> None:
+    log = EvidenceLog("run")
+    log.add_finding(_finding("first"))
+    log.add_finding(_finding("second"))
+    bundle = log.bundle()
+    assert [finding.subject for finding in bundle.findings] == ["first", "second"]
+
+
+def test_the_log_carries_logs_readings_and_artifacts() -> None:
+    log = EvidenceLog("run")
+    log.add_logs("worker-0", ["line one", "line two"])
+    log.record("table_count", 12)
+    log.add_artifact("manifest.json", "{}")
+    bundle = log.bundle()
+    assert bundle.logs == {"worker-0": ("line one", "line two")}
+    assert bundle.readings == {"table_count": 12}
+    assert bundle.artifacts == {"manifest.json": "{}"}
+    assert bundle.label == "run"
+
+
+def test_a_frozen_bundle_does_not_change_underneath_its_holder() -> None:
+    """A caller that logs locally and uploads remotely holds two bundles; a
+    builder that handed out live views would make the first one lie."""
+    log = EvidenceLog("run")
+    log.record("first", 1)
+    bundle = log.bundle()
+    log.record("second", 2)
+    assert dict(bundle.readings) == {"first": 1}
+
+
+def test_merge_folds_in_evidence_the_scenario_collected_itself() -> None:
+    """The seam for pod logs and anything else a composer collects, so the
+    accumulator does not have to know how to collect anything."""
+    log = EvidenceLog("run")
+    log.record("mine", 1)
+    log.merge(
+        EvidenceBundle(
+            label="ignored",
+            findings=(_finding("theirs"),),
+            logs={"pod-a": ("log",)},
+            readings={"theirs": 2},
+            artifacts={"describe.txt": "..."},
+        )
+    )
+    bundle = log.bundle()
+    assert bundle.label == "run"
+    assert dict(bundle.readings) == {"mine": 1, "theirs": 2}
+    assert [finding.subject for finding in bundle.findings] == ["theirs"]
+    assert "pod-a" in bundle.logs
+
+
+# ---------------------------------------------------------------------------
+# Writing evidence on failure
+# ---------------------------------------------------------------------------
+
+
+class FakeReport:
+    """Stands in for a ``pytest.TestReport`` the hook stashed."""
+
+    def __init__(self, *, failed: bool) -> None:
+        self.failed = failed
+
+
+class FakeNode:
+    """A test item carrying whichever phase reports a scenario needs."""
+
+    NODEID = "tests/e2e/test_x.py::TestSuite::test_something[gcp]"
+
+    def __init__(self, **phases: bool) -> None:
+        self.name = "test_something"
+        self.nodeid = self.NODEID
+        for phase, failed in phases.items():
+            setattr(self, f"_harness_phase_report_{phase}", FakeReport(failed=failed))
+
+
+def _log_with_content() -> EvidenceLog:
+    log = EvidenceLog("test_something")
+    log.record("table_count", 0)
+    return log
+
+
+def _install_fake_writer(
+    monkeypatch: pytest.MonkeyPatch, calls: list[dict[str, Any]]
+) -> None:
+    """Stub child G's persist surface. See this module's docstring on why."""
+
+    def _write_bundle(
+        bundle: EvidenceBundle, output_dir: Path, *, secrets: Sequence[str] = ()
+    ) -> Sequence[Path]:
+        calls.append({"bundle": bundle, "output_dir": output_dir, "secrets": secrets})
+        return (output_dir / "report.md",)
+
+    def _secrets_from_environment(
+        environ: Mapping[str, str], *, also: Sequence[str] = ()
+    ) -> tuple[str, ...]:
+        return tuple(environ[name] for name in also if name in environ)
+
+    monkeypatch.setattr(evidence_api, "write_bundle", _write_bundle, raising=False)
+    monkeypatch.setattr(
+        evidence_api,
+        "secrets_from_environment",
+        _secrets_from_environment,
+        raising=False,
+    )
+
+
+def test_evidence_is_written_when_the_call_phase_failed(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    calls: list[dict[str, Any]] = []
+    _install_fake_writer(monkeypatch, calls)
+
+    _write_if_failed(
+        _log_with_content(),
+        name="test_something",
+        nodeid=FakeNode.NODEID,
+        failed=_failed_in_any_phase(FakeNode(call=True)),  # type: ignore[arg-type]
+        environ={"ATLAN_BASE_URL": "https://tenant.example.com"},
+        evidence_dir=tmp_path,
+    )
+
+    assert len(calls) == 1
+    assert calls[0]["output_dir"].parent == tmp_path
+    # One path segment, whatever the node id contained.
+    assert calls[0]["output_dir"].name.count("_") >= 1
+    assert "/" not in calls[0]["output_dir"].name
+
+
+def test_the_tenant_url_is_passed_as_a_value_to_redact(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Key-name matching cannot see a hostname a driver echoed back with no key
+    beside it, and a tenant hostname identifies a customer environment."""
+    calls: list[dict[str, Any]] = []
+    _install_fake_writer(monkeypatch, calls)
+
+    _write_if_failed(
+        _log_with_content(),
+        name="test_something",
+        nodeid=FakeNode.NODEID,
+        failed=_failed_in_any_phase(FakeNode(call=True)),  # type: ignore[arg-type]
+        environ={"ATLAN_BASE_URL": "https://tenant.example.com"},
+        evidence_dir=tmp_path,
+    )
+
+    assert calls[0]["secrets"] == ("https://tenant.example.com",)
+
+
+def test_a_setup_failure_also_produces_evidence(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A precondition that could not be read is exactly when evidence matters."""
+    calls: list[dict[str, Any]] = []
+    _install_fake_writer(monkeypatch, calls)
+
+    _write_if_failed(
+        _log_with_content(),
+        name="test_something",
+        nodeid=FakeNode.NODEID,
+        failed=_failed_in_any_phase(FakeNode(call=False, setup=True)),  # type: ignore[arg-type]
+        environ={},
+        evidence_dir=tmp_path,
+    )
+
+    assert len(calls) == 1
+
+
+def test_a_passing_test_writes_nothing(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    calls: list[dict[str, Any]] = []
+    _install_fake_writer(monkeypatch, calls)
+
+    _write_if_failed(
+        _log_with_content(),
+        name="test_something",
+        nodeid=FakeNode.NODEID,
+        failed=_failed_in_any_phase(FakeNode(call=False, setup=False)),  # type: ignore[arg-type]
+        environ={},
+        evidence_dir=tmp_path,
+    )
+
+    assert calls == []
+
+
+def test_an_empty_log_writes_nothing(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    calls: list[dict[str, Any]] = []
+    _install_fake_writer(monkeypatch, calls)
+
+    _write_if_failed(
+        EvidenceLog("test_something"),
+        name="test_something",
+        nodeid=FakeNode.NODEID,
+        failed=_failed_in_any_phase(FakeNode(call=True)),  # type: ignore[arg-type]
+        environ={},
+        evidence_dir=tmp_path,
+    )
+
+    assert calls == []
+
+
+def test_opting_out_of_the_directory_writes_nothing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[dict[str, Any]] = []
+    _install_fake_writer(monkeypatch, calls)
+
+    _write_if_failed(
+        _log_with_content(),
+        name="test_something",
+        nodeid=FakeNode.NODEID,
+        failed=_failed_in_any_phase(FakeNode(call=True)),  # type: ignore[arg-type]
+        environ={},
+        evidence_dir=None,
+    )
+
+    assert calls == []
+
+
+def test_an_unregistered_plugin_warns_and_names_the_fix(
+    recorded_logs: RecordingLogger, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Without the hook a fixture cannot know the verdict. Writing on every test
+    would fill the artifact with passing runs, so it writes nothing — but the
+    reason is a one-line config fix, and the warning has to say so."""
+    calls: list[dict[str, Any]] = []
+    _install_fake_writer(monkeypatch, calls)
+
+    _write_if_failed(
+        _log_with_content(),
+        name="test_something",
+        nodeid=FakeNode.NODEID,
+        failed=_failed_in_any_phase(FakeNode()),  # type: ignore[arg-type]
+        environ={},
+        evidence_dir=tmp_path,
+    )
+
+    assert calls == []
+    assert "pytest_plugins" in recorded_logs.text
+
+
+def test_a_writer_failure_never_masks_the_test_result(
+    recorded_logs: RecordingLogger, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Including the window before child G lands the writer at all, where the
+    attribute does not exist."""
+    monkeypatch.delattr(evidence_api, "write_bundle", raising=False)
+
+    _write_if_failed(
+        _log_with_content(),
+        name="test_something",
+        nodeid=FakeNode.NODEID,
+        failed=_failed_in_any_phase(FakeNode(call=True)),  # type: ignore[arg-type]
+        environ={},
+        evidence_dir=tmp_path,
+    )
+
+    assert "only the evidence is missing" in recorded_logs.text
+
+
+def test_the_default_evidence_dir_is_under_the_uploaded_results_root() -> None:
+    """``results/`` is what the shared CI action uploads, so a red leg keeps its
+    bundle with no workflow change."""
+    assert DEFAULT_EVIDENCE_DIR.parts[0] == "results"
+
+
+# ---------------------------------------------------------------------------
+# Small helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "nodeid",
+    [
+        "tests/e2e/test_x.py::test_y",
+        "tests/e2e/test_x.py::TestSuite::test_y[gcp-3]",
+        "a/b/c.py::t",
+    ],
+)
+def test_a_slug_is_always_one_path_segment(nodeid: str) -> None:
+    """A parametrised node id carries ``/`` and ``::``; a bundle path must not
+    fan out into directories named after them."""
+    slug = _slug(nodeid)
+    assert "/" not in slug
+    assert ":" not in slug
+    assert slug
+
+
+def test_a_slug_never_ends_up_empty() -> None:
+    assert _slug("///") == "test"
+
+
+def test_a_missing_phase_report_reads_as_unknown_not_as_passing() -> None:
+    assert _phase_failed(FakeNode(), "call") is None  # type: ignore[arg-type]
+    assert _phase_failed(FakeNode(call=True), "call") is True  # type: ignore[arg-type]
+    assert _phase_failed(FakeNode(call=False), "call") is False  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# The remaining fixtures, exercised as fixtures
+# ---------------------------------------------------------------------------
+
+
+def test_the_evidence_log_is_composable_and_silent_on_a_pass(
+    suite: pytest.Pytester,
+) -> None:
+    """A passing test must leave no bundle behind: the artifact is for red legs,
+    and one file per green test is how an artifact stops being read."""
+    suite.makepyfile(
+        test_evidence="""
+        from pathlib import Path
+
+        def test_records_into_the_log(harness_evidence, harness_evidence_dir):
+            harness_evidence.record("table_count", 12)
+            harness_evidence.add_logs("worker-0", ["started"])
+            assert harness_evidence_dir == Path("results/harness-evidence")
+
+        def test_nothing_was_written():
+            assert not Path("results").exists()
+        """
+    )
+    suite.runpytest().assert_outcomes(passed=2)
+
+
+def test_the_tenant_clients_are_built_and_closed_around_the_test(
+    suite: pytest.Pytester,
+) -> None:
+    """Both wirings are one client per *test* — not per call, which is the
+    fresh-loop-and-handshake cost D1 found, and not per session, which would bind
+    a pooled connection to a loop later tests do not run on."""
+    suite.makepyfile(
+        test_clients="""
+        import pytest
+
+        from application_sdk.testing.harness.automation_engine import AEClient
+
+        @pytest.fixture
+        def harness_environ():
+            return {
+                "ATLAN_BASE_URL": "https://tenant.example.com",
+                "ATLAN_API_KEY": "not-a-real-key",
+                "GITHUB_RUN_ID": "4242",
+            }
+
+        async def test_clients_are_wired(
+            harness_atlas_client, harness_ae_client, harness_run_id
+        ):
+            assert isinstance(harness_ae_client, AEClient)
+            assert harness_ae_client.tenant_url == "https://tenant.example.com"
+            assert harness_atlas_client is not None
+            assert harness_run_id == 4242
+        """
+    )
+    suite.runpytest().assert_outcomes(passed=1)

--- a/tests/unit/testing/harness/test_preconditions.py
+++ b/tests/unit/testing/harness/test_preconditions.py
@@ -1,0 +1,498 @@
+"""Unit tests for the precondition gate (child I on FND-224).
+
+The property under test throughout is the third answer: a precondition read off a
+broken environment must reach the caller as *neither* met *nor* unmet. Every test
+here that scripts a failing read asserts on which of the three verdicts came
+back, not merely that something went wrong — a gate that collapsed
+``INDETERMINATE`` into ``FAILED`` would still pass a test that only checked for a
+raise.
+
+The HTTP checks go through a **real** ``httpx.AsyncClient`` over a scripted
+``MockTransport`` rather than a patched module global, for the reason the cluster
+and Temporal doubles hand back real objects: what is being checked is how the
+poll reads a refused connection versus a 503, and a stub that returned whatever
+the code asked for could not tell those apart.
+
+Budgets here are deliberately tiny (sub-second) and real. Patching a global clock
+in an async test hands the same mock to the event loop's own timer, which
+produces flaky ``StopIteration`` failures that read as a bug in the code under
+test.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from datetime import UTC, datetime, timedelta
+
+import httpx
+import pytest
+
+from application_sdk.testing.harness import (
+    Budget,
+    Expired,
+    Indeterminate,
+    NeverStarted,
+    PreconditionsFailedError,
+    PreconditionsIndeterminateError,
+    Settled,
+    Stalled,
+    Verdict,
+)
+from application_sdk.testing.harness.preconditions import (
+    GateReport,
+    HealthReading,
+    PollerReading,
+    PreconditionCheck,
+    assert_gate,
+    check_no_stale_pollers,
+    check_worker_health,
+    run_preconditions,
+)
+from application_sdk.testing.harness.temporal import (
+    PollerInfo,
+    TaskQueueType,
+    TemporalConnectFailedError,
+    TemporalReadFailedError,
+    WorkflowNotFoundError,
+    WorkflowStatus,
+)
+
+# A budget small enough that a failing wait finishes inside a unit test, with a
+# real monotonic clock.
+FAST = Budget(timeout=timedelta(seconds=0.12), poll_interval=timedelta(seconds=0.02))
+
+
+def _outcome(variant: type, label: str = "check") -> object:
+    """Build one outcome of *variant* with the fields that variant requires."""
+    common = {"label": label, "attempts": 1, "elapsed": timedelta(seconds=1)}
+    if variant is Settled:
+        return Settled(value=True, **common)
+    if variant is NeverStarted:
+        return NeverStarted(grace=timedelta(seconds=1), **common)
+    if variant is Stalled:
+        return Stalled(
+            stall_window=timedelta(seconds=1), fingerprint="frozen", **common
+        )
+    if variant is Expired:
+        return Expired(budget=timedelta(seconds=1), **common)
+    return Indeterminate(cause=RuntimeError("tunnel dropped"), **common)
+
+
+def _check(label: str, outcome: object) -> PreconditionCheck:
+    """A check that returns *outcome* without doing any work."""
+
+    async def _run():
+        return outcome
+
+    return PreconditionCheck(label=label, run=_run)
+
+
+# ---------------------------------------------------------------------------
+# run_preconditions
+# ---------------------------------------------------------------------------
+
+
+async def test_no_checks_grades_passed() -> None:
+    """A suite that declares no preconditions makes no claim, rather than being
+    forced to declare one before it can run a single test."""
+    report = await run_preconditions(())
+    assert report.verdict is Verdict.PASSED
+    assert report.outcomes == ()
+
+
+async def test_every_check_runs_even_after_one_fails() -> None:
+    """Accumulation, not short-circuit: one CI run should diagnose every fault in
+    an environment, because they arrive in groups."""
+    ran: list[str] = []
+
+    def _recording(label: str, outcome: object) -> PreconditionCheck:
+        async def _run():
+            ran.append(label)
+            return outcome
+
+        return PreconditionCheck(label=label, run=_run)
+
+    report = await run_preconditions(
+        (
+            _recording("first", _outcome(Expired, "first")),
+            _recording("second", _outcome(Settled, "second")),
+            _recording("third", _outcome(Indeterminate, "third")),
+        )
+    )
+
+    assert ran == ["first", "second", "third"]
+    assert len(report.outcomes) == 3
+
+
+async def test_a_failed_check_outranks_an_unreadable_one() -> None:
+    """A confirmed bad starting state is never softened into "could not tell"."""
+    report = await run_preconditions(
+        (
+            _check("unreadable", _outcome(Indeterminate)),
+            _check("failed", _outcome(Expired)),
+        )
+    )
+    assert report.verdict is Verdict.FAILED
+
+
+async def test_an_unreadable_check_alone_grades_indeterminate() -> None:
+    report = await run_preconditions((_check("unreadable", _outcome(Indeterminate)),))
+    assert report.verdict is Verdict.INDETERMINATE
+
+
+async def test_a_check_that_raises_is_recorded_as_indeterminate() -> None:
+    """A check whose own code broke has said nothing about the environment — and
+    it must not discard the verdicts of the checks that already ran."""
+
+    async def _boom():
+        raise RuntimeError("the check itself is broken")
+
+    report = await run_preconditions(
+        (
+            _check("readable", _outcome(Settled)),
+            PreconditionCheck(label="broken", run=_boom),
+        )
+    )
+
+    assert report.verdict is Verdict.INDETERMINATE
+    broken = report.outcomes[1]
+    assert isinstance(broken, Indeterminate)
+    assert isinstance(broken.cause, RuntimeError)
+    assert broken.label == "broken"
+
+
+async def test_the_report_names_only_the_unmet_checks() -> None:
+    report = await run_preconditions(
+        (
+            _check("healthy", _outcome(Settled, "healthy")),
+            _check("wedged", _outcome(Stalled, "wedged")),
+        )
+    )
+    assert [outcome.label for outcome in report.unmet] == ["wedged"]
+    assert "wedged" in report.summary()
+    assert "healthy" not in report.summary()
+
+
+def test_an_all_settled_report_summarises_to_empty_string() -> None:
+    """So a caller can interpolate the summary without a conditional."""
+    report = GateReport(verdict=Verdict.PASSED, outcomes=(_outcome(Settled),))
+    assert report.summary() == ""
+
+
+# ---------------------------------------------------------------------------
+# assert_gate
+# ---------------------------------------------------------------------------
+
+
+def test_assert_gate_is_silent_on_a_pass() -> None:
+    assert_gate(GateReport(verdict=Verdict.PASSED, outcomes=(_outcome(Settled),)))
+
+
+def test_assert_gate_raises_a_precondition_leaf_on_failure() -> None:
+    report = GateReport(
+        verdict=Verdict.FAILED, outcomes=(_outcome(Expired, "worker health"),)
+    )
+    with pytest.raises(PreconditionsFailedError) as caught:
+        assert_gate(report)
+    assert caught.value.checks == "worker health"
+    assert "starting state" in str(caught.value)
+
+
+def test_assert_gate_raises_a_dependency_leaf_on_indeterminate() -> None:
+    """The two non-passing verdicts must be separable on the type alone: a lane
+    that reruns on infrastructure failure acts on the category, not on prose."""
+    report = GateReport(
+        verdict=Verdict.INDETERMINATE, outcomes=(_outcome(Indeterminate, "pollers"),)
+    )
+    with pytest.raises(PreconditionsIndeterminateError) as caught:
+        assert_gate(report)
+    assert caught.value.checks == "pollers"
+
+
+@pytest.mark.parametrize(
+    "verdict, leaf",
+    [
+        (Verdict.FAILED, PreconditionsFailedError),
+        (Verdict.INDETERMINATE, PreconditionsIndeterminateError),
+    ],
+)
+def test_neither_leaf_is_an_assertion_error(verdict: Verdict, leaf: type) -> None:
+    """Under pytest that is the difference between an ERROR and a FAILURE — a red
+    leg that reads as a regression when the environment was never fit to test."""
+    report = GateReport(verdict=verdict, outcomes=(_outcome(Expired),))
+    with pytest.raises(leaf) as caught:
+        assert_gate(report)
+    assert not isinstance(caught.value, AssertionError)
+
+
+# ---------------------------------------------------------------------------
+# check_worker_health
+# ---------------------------------------------------------------------------
+
+
+def _scripted_http(*responses: object) -> httpx.MockTransport:
+    """A transport that answers with each item in turn, repeating the last.
+
+    An item is either an ``int`` status or an exception to raise, so one script
+    can mix "answered 503" with "refused the connection".
+    """
+    script = list(responses)
+
+    def _handle(request: httpx.Request) -> httpx.Response:
+        item = script.pop(0) if len(script) > 1 else script[0]
+        if isinstance(item, BaseException):
+            raise item
+        return httpx.Response(int(item), request=request)
+
+    return httpx.MockTransport(_handle)
+
+
+async def test_worker_health_settles_on_a_2xx() -> None:
+    check = check_worker_health(
+        "http://localhost:8000/server/health",
+        budget=FAST,
+        transport=_scripted_http(200),
+    )
+    outcome = await check.run()
+    assert isinstance(outcome, Settled)
+    assert outcome.value.healthy
+
+
+async def test_worker_health_settles_after_a_slow_start() -> None:
+    """The normal shape: connection refused while the container boots, then 200."""
+    check = check_worker_health(
+        "http://localhost:8000/server/health",
+        budget=FAST,
+        transport=_scripted_http(
+            httpx.ConnectError("connection refused"),
+            httpx.ConnectError("connection refused"),
+            200,
+        ),
+    )
+    outcome = await check.run()
+    assert isinstance(outcome, Settled)
+    assert outcome.attempts == 3
+
+
+async def test_a_refused_connection_is_a_reading_not_an_unreadable_probe() -> None:
+    """A worker that never comes up is a finding about the thing under test, not
+    an unavailable dependency — so this expires, it does not go indeterminate."""
+    check = check_worker_health(
+        "http://localhost:8000/server/health",
+        budget=FAST,
+        transport=_scripted_http(httpx.ConnectError("connection refused")),
+    )
+    outcome = await check.run()
+    assert isinstance(outcome, Expired)
+    assert outcome.last is not None
+    assert outcome.last.status is None
+    assert "ConnectError" in outcome.last.error
+
+
+async def test_a_non_2xx_expires_and_keeps_the_last_status() -> None:
+    check = check_worker_health(
+        "http://localhost:8000/server/health",
+        budget=FAST,
+        transport=_scripted_http(503),
+    )
+    outcome = await check.run()
+    assert isinstance(outcome, Expired)
+    assert outcome.last == HealthReading(status=503)
+    assert str(outcome.last) == "HTTP 503"
+
+
+async def test_never_answering_is_never_started_when_the_budget_has_a_grace() -> None:
+    """Two diagnoses, not one: an endpoint that never answers points at the
+    deployment; one that answers 503 forever points at the app."""
+    budget = Budget(
+        timeout=timedelta(seconds=0.5),
+        poll_interval=timedelta(seconds=0.02),
+        start_grace=timedelta(seconds=0.04),
+    )
+    check = check_worker_health(
+        "http://localhost:8000/server/health",
+        budget=budget,
+        transport=_scripted_http(httpx.ConnectError("connection refused")),
+    )
+    outcome = await check.run()
+    assert isinstance(outcome, NeverStarted)
+
+
+async def test_answering_badly_expires_rather_than_never_starting() -> None:
+    budget = Budget(
+        timeout=timedelta(seconds=0.12),
+        poll_interval=timedelta(seconds=0.02),
+        start_grace=timedelta(seconds=0.04),
+    )
+    check = check_worker_health(
+        "http://localhost:8000/server/health",
+        budget=budget,
+        transport=_scripted_http(500),
+    )
+    outcome = await check.run()
+    assert isinstance(outcome, Expired)
+
+
+def test_the_health_check_label_names_the_url_by_default() -> None:
+    check = check_worker_health("http://localhost:8000/server/health", budget=FAST)
+    assert "http://localhost:8000/server/health" in check.label
+    assert check_worker_health("http://x/health", budget=FAST, label="mine").label == (
+        "mine"
+    )
+
+
+# ---------------------------------------------------------------------------
+# check_no_stale_pollers
+# ---------------------------------------------------------------------------
+
+
+def _poller(identity: str, build_id: str | None) -> PollerInfo:
+    return PollerInfo(
+        identity=identity,
+        last_access=datetime(2026, 8, 27, 12, 0, tzinfo=UTC),
+        task_queue_type=TaskQueueType.WORKFLOW,
+        build_id=build_id,
+    )
+
+
+class ScriptedTemporalReader:
+    """A reader that answers each ``task_queue_pollers`` call from a script.
+
+    Only the two Protocol methods, so it satisfies ``TemporalReader`` without
+    inheriting anything: the same composition property the fixtures exist for.
+    """
+
+    def __init__(self, *readings: object) -> None:
+        self._script = list(readings)
+        self.calls: list[tuple[str, str]] = []
+
+    async def task_queue_pollers(
+        self, queue: str, *, namespace: str
+    ) -> Sequence[PollerInfo]:
+        self.calls.append((queue, namespace))
+        item = self._script.pop(0) if len(self._script) > 1 else self._script[0]
+        if isinstance(item, BaseException):
+            raise item
+        return tuple(item)  # type: ignore[arg-type]
+
+    async def workflow_status(
+        self, workflow_id: str, *, run_id: str | None = None
+    ) -> WorkflowStatus:
+        raise NotImplementedError
+
+
+def _poller_check(reader: object, *, budget: Budget = FAST, build: str | None = "v2"):
+    return check_no_stale_pollers(
+        reader=reader,  # type: ignore[arg-type]
+        queue="atlan-app-e2e",
+        namespace="default",
+        current_build_id=build,
+        budget=budget,
+    )
+
+
+async def test_only_current_pollers_settles() -> None:
+    reader = ScriptedTemporalReader([_poller("1@a", "v2"), _poller("2@b", "v2")])
+    outcome = await _poller_check(reader).run()
+    assert isinstance(outcome, Settled)
+    assert outcome.value.stale == ()
+    assert reader.calls[0] == ("atlan-app-e2e", "default")
+
+
+async def test_a_stale_poller_that_drains_settles() -> None:
+    """The precondition is allowed to *wait* for the previous scenario's worker
+    to go away — that is why it is a bounded poll and not one read."""
+    reader = ScriptedTemporalReader(
+        [_poller("old@a", "v1"), _poller("new@b", "v2")],
+        [_poller("new@b", "v2")],
+    )
+    outcome = await _poller_check(reader).run()
+    assert isinstance(outcome, Settled)
+
+
+async def test_a_stale_poller_that_never_drains_does_not_settle() -> None:
+    reader = ScriptedTemporalReader([_poller("old@a", "v1"), _poller("new@b", "v2")])
+    outcome = await _poller_check(reader).run()
+    assert not isinstance(outcome, Settled)
+    assert outcome.last is not None
+    assert [poller.identity for poller in outcome.last.stale] == ["old@a"]
+
+
+async def test_a_frozen_stale_set_reports_the_stale_identities() -> None:
+    """The fingerprint is the one line that says *what* is wrong, so the stale
+    worker's identity has to be in it."""
+    budget = Budget(
+        timeout=timedelta(seconds=0.5),
+        poll_interval=timedelta(seconds=0.02),
+        stall_timeout=timedelta(seconds=0.05),
+    )
+    reader = ScriptedTemporalReader([_poller("old@a", "v1"), _poller("new@b", "v2")])
+    outcome = await _poller_check(reader, budget=budget).run()
+    assert isinstance(outcome, Stalled)
+    assert "old@a" in outcome.fingerprint
+
+
+async def test_an_empty_queue_never_started_rather_than_passing() -> None:
+    """Empty is a real answer, and it is the *failing* one: a queue nobody polls
+    means the version about to be tested will not pick the work up."""
+    budget = Budget(
+        timeout=timedelta(seconds=0.5),
+        poll_interval=timedelta(seconds=0.02),
+        start_grace=timedelta(seconds=0.04),
+    )
+    outcome = await _poller_check(ScriptedTemporalReader([]), budget=budget).run()
+    assert isinstance(outcome, NeverStarted)
+
+
+async def test_no_versioning_reduces_to_something_is_polling() -> None:
+    """``current_build_id=None`` must not report every poller as stale — that
+    would red every unversioned deployment."""
+    reader = ScriptedTemporalReader([_poller("only@a", None)])
+    outcome = await _poller_check(reader, build=None).run()
+    assert isinstance(outcome, Settled)
+
+
+async def test_an_unversioned_poller_is_stale_when_versioning_is_in_use() -> None:
+    """The quiet-direction bug ``stale_version_pollers`` exists to prevent: a
+    worker with no build id predates versioning, or its config did not take."""
+    reader = ScriptedTemporalReader([_poller("ghost@a", None)])
+    outcome = await _poller_check(reader).run()
+    assert not isinstance(outcome, Settled)
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        TemporalConnectFailedError(message="tunnel dropped"),
+        TemporalReadFailedError(message="frontend said no"),
+    ],
+)
+async def test_an_unreadable_frontend_is_indeterminate(error: Exception) -> None:
+    """The verdict this whole gate exists to keep available: an expired vcluster
+    token is not an empty poller list, and empty is *the* diagnosis here."""
+    outcome = await _poller_check(ScriptedTemporalReader(error)).run()
+    assert isinstance(outcome, Indeterminate)
+    assert isinstance(outcome.cause, type(error))
+
+
+async def test_a_non_transport_error_propagates() -> None:
+    """An error that repeats on every attempt is a bug in the probe: absorbing it
+    would spend the whole budget confirming a typo."""
+    with pytest.raises(WorkflowNotFoundError):
+        await _poller_check(
+            ScriptedTemporalReader(WorkflowNotFoundError(message="no such thing"))
+        ).run()
+
+
+def test_the_poller_check_label_names_the_queue_by_default() -> None:
+    check = _poller_check(ScriptedTemporalReader([]))
+    assert "atlan-app-e2e" in check.label
+
+
+def test_a_poller_reading_renders_for_a_report_line() -> None:
+    assert str(PollerReading()) == "no pollers"
+    reading = PollerReading(
+        pollers=(_poller("a@1", "v1"), _poller("b@2", "v2")),
+        stale=(_poller("a@1", "v1"),),
+    )
+    assert str(reading) == "2 poller(s), stale: a@1"

--- a/tests/unit/testing/harness/test_scaffold.py
+++ b/tests/unit/testing/harness/test_scaffold.py
@@ -600,3 +600,31 @@ def test_the_package_declares_all_so_the_manifest_extractor_finds_it() -> None:
 
     assert "run_sync" in harness.__all__
     assert all(hasattr(harness, name) for name in harness.__all__)
+
+
+def test_importing_the_harness_does_not_require_pytest() -> None:
+    """``fixtures`` is child I's pytest layer, and the package must not import it.
+
+    Static, not a runtime probe, because a runtime one cannot see the difference
+    once this test module has already imported ``fixtures`` itself. The property
+    is worth pinning rather than trusting: pytest is not a runtime dependency of
+    this SDK, so a convenience re-export from the package ``__init__`` would make
+    ``import application_sdk.testing.harness`` fail in a production process — and
+    the failure would surface as an ``ImportError`` naming a module nobody asked
+    for.
+    """
+    import ast
+    from pathlib import Path
+
+    import application_sdk.testing.harness as harness_pkg
+
+    source = Path(str(harness_pkg.__file__)).read_text(encoding="utf-8")
+    imported = {
+        node.module
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.ImportFrom) and node.module
+    }
+    assert "application_sdk.testing.harness.fixtures" not in imported
+    # The one entry point a composer registers, named in the module map so the
+    # import path is discoverable without reading this test.
+    assert "harness.fixtures" in (harness_pkg.__doc__ or "")

--- a/tests/unit/testing/harness/test_substrate.py
+++ b/tests/unit/testing/harness/test_substrate.py
@@ -1,0 +1,62 @@
+"""Unit tests for substrate selection (child I on FND-224).
+
+The property under test is that substrate is **declared, never detected**. The
+tempting alternative — "is there a usable kubeconfig?" — is almost always yes on
+a developer's machine, so a harness that answered it by reaching for the ambient
+context would read whichever cluster ``kubectl`` last pointed at. Every test here
+therefore asserts on what the declaration produced, and the local substrate's
+test asserts a *refusal* rather than a fallback.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from application_sdk.testing.harness import (
+    HarnessNotBuiltError,
+    Substrate,
+    SubstrateHasNoClusterError,
+    cluster_reader_for,
+)
+from application_sdk.testing.harness.cluster import ClusterReader, CustomResourceReader
+
+
+def test_the_kubeconfig_substrate_builds_a_reader_without_connecting() -> None:
+    """Construction reads no kubeconfig: the API bundle is built per thread on
+    first read, so an unusable context surfaces at the read that needed it."""
+    reader = cluster_reader_for(Substrate.KUBECONFIG, kube_context="e2e-gcp")
+    assert isinstance(reader, ClusterReader)
+    assert isinstance(reader, CustomResourceReader)
+    assert reader.kube_context == "e2e-gcp"
+
+
+def test_no_context_means_the_kubeconfigs_current_one() -> None:
+    assert cluster_reader_for(Substrate.KUBECONFIG).kube_context is None
+
+
+def test_the_local_substrate_refuses_rather_than_falling_back() -> None:
+    """A reader that failed on first use, or one that quietly read the ambient
+    cluster, are both worse than a refusal at the seam."""
+    with pytest.raises(SubstrateHasNoClusterError) as caught:
+        cluster_reader_for(Substrate.LOCAL)
+    assert caught.value.substrate == "local"
+    assert "Substrate.KUBECONFIG" in str(caught.value)
+
+
+def test_the_in_cluster_substrate_names_its_child_issue() -> None:
+    """An unbuilt backend is an ``UNIMPLEMENTED`` leaf carrying the issue as a
+    field, so an audit of what is left can enumerate it rather than grep prose."""
+    with pytest.raises(HarnessNotBuiltError) as caught:
+        cluster_reader_for(Substrate.IN_CLUSTER)
+    assert caught.value.issue == "FND-248"
+    assert isinstance(caught.value, NotImplementedError)
+
+
+def test_the_substrate_values_are_stable_strings() -> None:
+    """A scenario suite reads its substrate out of a config file, so the wire
+    values are part of the contract, not just the member names."""
+    assert [member.value for member in Substrate] == [
+        "local",
+        "kubeconfig",
+        "in_cluster",
+    ]


### PR DESCRIPTION
Closes FND-244 (child I on FND-224).

The second of the harness's three entry shapes. `BaseE2ETest` carries a concrete test method, so anything that inherits it to reach setup and teardown also collects `test_full_dag_runs_end_to_end` — which is why the runtime scenario suite could not reuse the plumbing. A suite that composes fixtures inherits nothing, and collects exactly the tests it wrote.

```python
# conftest.py (root — pytest refuses `pytest_plugins` in a non-root one)
pytest_plugins = ["application_sdk.testing.harness.fixtures"]

async def test_my_scenario(harness_preconditions, harness_connection_teardown, harness_evidence):
    ...  # gate ran during setup; the connection is purged after; evidence lands only on red
```

## What lands

**`harness/fixtures.py`** — 19 function-scoped async fixtures over the same functions the xunit shims call. Override points (`harness_environ`, `harness_budget_profile`, `harness_substrate`, `harness_kube_context`, `harness_connection_type`, `harness_app_under_test`, `harness_worker_health_url`, `harness_precondition_checks`, `harness_evidence_dir`), identity (`harness_minter`, `harness_run_id`, `harness_connection_identity`), tenant + AE wiring (`harness_tenant_auth`, `harness_atlas_client`, `harness_ae_client`), plus `harness_cluster_reader`, `harness_preconditions`, `harness_evidence`, `harness_connection_teardown`, `harness_sync_bridge`. Every fixture is a one-liner over a plain function, so the pytest layer cannot grow logic of its own.

**`harness/preconditions.py`** — the gate both sides asked for, pytest-free so a sync composer can drive it through `run_sync`. `check_worker_health` (the `assert_worker_up` analogue, re-expressed over `poll_until`) and `check_no_stale_pollers` (the runtime side's, over `stale_version_pollers`), with `run_preconditions` and `assert_gate`.

**`harness/substrate.py`** — `Substrate` and `cluster_reader_for`.

## Decisions worth reviewing

**The gate raises two leaves, neither an `AssertionError`.** `PreconditionsFailedError` (PRECONDITION) and `PreconditionsIndeterminateError` (DEPENDENCY_UNAVAILABLE). Under pytest that makes an unfit environment an **error** rather than a **failure**, which is the split the issue asked for; and a lane that reruns on infrastructure failure can act on the category without parsing prose.

**The gate accumulates rather than short-circuits.** A tenant that was never prepared fails the worker check *and* the poller check; reporting only the first costs one CI run per fault. A check that *raises* instead of returning a verdict is recorded as `Indeterminate` rather than propagating, so it cannot discard the verdicts of the checks that already ran.

**The health probe returns a reading, never raises.** While a worker is starting, a refused connection is the *expected* answer. Modelling it as a probe error would either spend the wait's transient streak on normal startup or report `Indeterminate` — and "the worker never came up" is a genuine finding about the thing under test. `start_grace` then splits never-answered (`NeverStarted`, the deployment) from answered-badly (`Expired`, the app).

**A fourth point of variance, named: execution substrate.** Neither source design document names it and it is not derivable — the connector side has no cluster at all, the runtime side reads one. `Substrate.LOCAL` is the default because it needs no credentials: defaulting to `KUBECONFIG` would make a suite that forgot to declare reach for whichever cluster `kubectl` last pointed at. `LOCAL` refuses a cluster read by name rather than handing back a reader that fails on first use.

**Every fixture is function-scoped.** A session-scoped async fixture binds its clients to one event loop while `pytest-asyncio` hands each test another (the `TemporalReaderLoopMismatchError` class), and a session-scoped connection identity would let one test's teardown purge the next test's assets.

**Override defaults raise and name themselves**, and only when the dependent fixture is actually requested — so declaring a connection type is not a tax on a suite that never creates a connection. No guessed connection type: that string is the prefix teardown purges under.

**Evidence-on-failure needs plugin registration**, because `pytest_runtest_makereport` is the only supported way for a fixture to learn its test's verdict. When the hook did not run, the fixture writes nothing and warns naming the one-line fix — writing on every test would fill the artifact with the green runs nobody reads.

**`fixtures` is deliberately not imported from `harness/__init__`**: it imports `pytest`, which is not a runtime dependency, so a convenience re-export would break `import application_sdk.testing.harness` in a production process. Pinned by a static assertion in `test_scaffold.py` rather than trusted.

## Relationship to #3462 (FND-243, child G)

Signatures were agreed directly with that branch: `purge_connection(client, connection_qualified_name)`, `write_bundle(bundle, output_dir, *, secrets=())`, `secrets_from_environment(environ, *, also=())` — plus the correction that there is no async collector on the connector path, since nothing establishes a kubectl route into the tenant vcluster.

Because the two were built in parallel, those three call sites resolve **by name at call time** behind three Protocols in one place, so whichever PR merges first the other still imports and runs. Both sites already report rather than raise, because teardown and evidence may never mask a test result. **When #3462 lands, that section is deleted and the three names imported directly** — a follow-up on this file, keeping one author per file under review.

Verified in advance, not assumed:

* **Differential against the real modules.** With #3462's `teardown.py` and `evidence.py` dropped onto this branch, 602/603 harness tests pass — the one failure being the pre-existing stub test that #3462's own commit updates. So the fixtures bind to the real purge and the real writer, not only to the Protocols.
* **The merge itself.** `git merge --no-commit --no-ff` of the two branches, resolved and run: **670 tests pass**, pre-commit clean. `test_scaffold.py` auto-merges. `harness/__init__.py` conflicts in exactly one hunk, the "which modules are real" summary sentence — resolution is #3462's wording plus this branch's three module names. `docs/agents/sdk-capabilities.md` conflicts in two hunks and **must not be hand-resolved**: `capability-manifest-check` regenerates and compares, so the merged file has to be what the merged *source* renders. Run `uv run poe regen-capabilities` on the merged tree.

## Testing

* `tests/unit/testing/harness/test_fixtures.py` — the fixture contracts, checked by running pytest inside pytest (`pytester`), because that is the only way to check what a fixture does. Includes the issue's own acceptance criterion as a real collection: a composing suite collects only the tests it wrote.
* `tests/unit/testing/harness/test_preconditions.py` — the three verdicts, over a real `httpx.AsyncClient` on a scripted `MockTransport` and a scripted Temporal reader. Every failing-read test asserts *which* verdict came back, so a gate that collapsed INDETERMINATE into FAILED would not pass.
* `tests/unit/testing/harness/test_substrate.py` — declared-never-detected, including the local substrate's refusal.
* 100% line coverage on all three new modules; full unit suite green (8,906 passed); conformance clean; capability manifest regenerated.

## Follow-up not in this change

The optional conformance rule flagging `run_sync` imports from non-test code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
