### PR TITLE
fix(conformance): P003 reads codes held in a module-level constant

### DIFF
--- a/packages/conformance/conformance/suite/checks/prescriptions/__init__.py
+++ b/packages/conformance/conformance/suite/checks/prescriptions/__init__.py
@@ -89,6 +89,8 @@ from ._error_code_prefix import (
     collect_classes,
     collect_import_aliases,
     emit_p003,
+    module_code_constants,
+    resolve_indirect_codes,
     resolve_leaf_prefix,
 )
 from ._file_reference import check_p010
@@ -204,6 +206,7 @@ def scan_all(paths: list[Path], root: Path) -> list[Finding]:
     file_records: dict[Path, list[ClassRecord]] = {}
     file_trees: dict[Path, ast.AST] = {}
     by_name: dict[str, ClassRecord] = {}
+    code_consts: dict[str, str] = {}
 
     for path in paths:
         try:
@@ -258,10 +261,18 @@ def scan_all(paths: list[Path], root: Path) -> list[Finding]:
         aliases = collect_import_aliases(tree) if isinstance(tree, ast.Module) else {}
         records = collect_classes(tree, rel_str, aliases)
         file_records[path] = records
+        # App-wide, because the codes module is a different file from the
+        # exception classes that reference it (`code = codes.X.code`).
+        code_consts.update(module_code_constants(tree))
         for rec in records:
             by_name.setdefault(rec.name, rec)
 
     # Pass 2 + 3 — resolve and emit P003
+    # Codes reached through a module-level constant are declared, just not
+    # inline; resolve them before emitting so the finding says what is
+    # actually wrong (the prefix) instead of "does not declare".
+    for records in file_records.values():
+        resolve_indirect_codes(records, code_consts)
     cache: dict[str, str | None] = {}
     for path, records in file_records.items():
         directives = file_directives[path]

--- a/packages/conformance/conformance/suite/checks/prescriptions/_error_code_prefix.py
+++ b/packages/conformance/conformance/suite/checks/prescriptions/_error_code_prefix.py
@@ -91,6 +91,99 @@ def _extract_code(cls_node: ast.ClassDef) -> tuple[str | None, ast.AST | None]:
     return None, None
 
 
+def module_code_constants(tree: ast.AST) -> dict[str, str]:
+    """Map module-level code constants to their string value.
+
+    Two shapes, both used by connector apps to keep their codes in one
+    module and reference them from the exception classes:
+
+    * ``NAME = "literal"``            -> ``{"NAME": "literal"}``
+    * ``NAME = Code(code="literal")`` -> ``{"NAME.code": "literal"}``
+
+    Only module-level assignments with a literal ``str`` are recorded, so a
+    value the scanner cannot prove stays unresolved (and P003 keeps firing
+    conservatively).
+    """
+    consts: dict[str, str] = {}
+    if not isinstance(tree, ast.Module):
+        return consts
+    for stmt in tree.body:
+        target: ast.expr | None = None
+        value: ast.expr | None = None
+        if isinstance(stmt, ast.Assign) and len(stmt.targets) == 1:
+            target, value = stmt.targets[0], stmt.value
+        elif isinstance(stmt, ast.AnnAssign) and stmt.value is not None:
+            target, value = stmt.target, stmt.value
+        if not isinstance(target, ast.Name) or value is None:
+            continue
+        if isinstance(value, ast.Constant) and isinstance(value.value, str):
+            consts.setdefault(target.id, value.value)
+        elif isinstance(value, ast.Call):
+            for kw in value.keywords:
+                if (
+                    kw.arg == "code"
+                    and isinstance(kw.value, ast.Constant)
+                    and isinstance(kw.value.value, str)
+                ):
+                    consts.setdefault(f"{target.id}.code", kw.value.value)
+    return consts
+
+
+def _indirect_code_key(value: ast.expr) -> str | None:
+    """Lookup key for a non-literal ``code`` value, or None if unsupported.
+
+    ``codes.FT_AUTH_NO_TOKEN.code`` and ``FT_AUTH_NO_TOKEN.code`` both key on
+    ``FT_AUTH_NO_TOKEN.code``; a bare ``CODE`` keys on ``CODE``. The module
+    path in front is ignored on purpose: the constant map is app-wide, and
+    the constant name alone is what identifies it.
+    """
+    if isinstance(value, ast.Name):
+        return value.id
+    if isinstance(value, ast.Attribute):
+        owner = value.value
+        if isinstance(owner, ast.Name):
+            return f"{owner.id}.{value.attr}"
+        if isinstance(owner, ast.Attribute):
+            return f"{owner.attr}.{value.attr}"
+    return None
+
+
+def resolve_indirect_codes(records: list[ClassRecord], consts: dict[str, str]) -> None:
+    """Fill in ``code_value`` for classes whose ``code`` is an indirection.
+
+    A class that writes ``code: ClassVar[str] = codes.X.code`` DOES declare
+    its code — the scanner simply could not read it, so P003 reported "does
+    not declare" and, worse, would keep firing after the app fixed the string.
+    Resolving the indirection turns those into an accurate wrong-prefix
+    finding, or silence when the prefix is right. Values that stay
+    unresolvable are left alone and keep firing conservatively.
+    """
+    for rec in records:
+        if rec.code_value is not None:
+            continue
+        for stmt in rec.node.body:
+            value: ast.expr | None = None
+            if (
+                isinstance(stmt, ast.AnnAssign)
+                and isinstance(stmt.target, ast.Name)
+                and stmt.target.id == "code"
+                and _is_classvar_annotation(stmt.annotation)
+            ):
+                value = stmt.value
+            elif isinstance(stmt, ast.Assign) and any(
+                isinstance(t, ast.Name) and t.id == "code" for t in stmt.targets
+            ):
+                value = stmt.value
+            if value is None or isinstance(value, ast.Constant):
+                continue
+            key = _indirect_code_key(value)
+            resolved = consts.get(key) if key else None
+            if resolved is not None:
+                rec.code_value = resolved
+                rec.code_node = stmt
+            break
+
+
 def collect_import_aliases(tree: ast.Module) -> dict[str, str]:
     """Return per-file ``{local_name: original_name}`` for ``from X import Y [as Z]``.
 

--- a/packages/conformance/tests/test_prescriptions.py
+++ b/packages/conformance/tests/test_prescriptions.py
@@ -365,12 +365,96 @@ def test_p003_silent_on_non_string_code_constant(tmp_path: Path) -> None:
 
 
 def test_p003_silent_on_dynamic_code_value(tmp_path: Path) -> None:
-    """``code = SOME_VAR`` (non-Constant) is not extracted — must not crash."""
+    """``code = SOME_VAR`` resolves through the module-level constant.
+
+    The class DOES declare a code; it just isn't inline. With ``CODE`` set to
+    a correctly-prefixed literal there is nothing to report."""
     src = "CODE = 'INTERNAL_X'\nclass DynCode(InternalError):\n    code = CODE\n"
     findings = _scan_one(tmp_path, src)
-    # Treated as missing code declaration; still fires P003 but must not crash.
+    assert [f.rule_id for f in findings] == []
+
+
+def test_p003_fires_on_dynamic_code_value_with_wrong_prefix(tmp_path: Path) -> None:
+    """Resolving the indirection makes the finding accurate: the code exists
+    and its PREFIX is wrong — not "does not declare"."""
+    src = "CODE = 'Atlan-X-500-01'\nclass DynCode(InternalError):\n    code = CODE\n"
+    findings = _scan_one(tmp_path, src)
+    assert [f.rule_id for f in findings] == ["P003"]
+    assert "Atlan-X-500-01" in findings[0].message
+    assert "does not declare" not in findings[0].message
+
+
+def test_p003_unresolvable_code_still_fires(tmp_path: Path) -> None:
+    """A value the scanner cannot prove (a call result) keeps today's
+    conservative behaviour — resolution narrows nothing it cannot read."""
+    src = (
+        "def build() -> str:\n    return 'INTERNAL_X'\n\n"
+        "class DynCode(InternalError):\n    code = build()\n"
+    )
+    findings = _scan_one(tmp_path, src)
     assert [f.rule_id for f in findings] == ["P003"]
     assert "does not declare" in findings[0].message
+
+
+_CODES_MODULE_OK = """\
+class AppErrorCode:
+    def __init__(self, code: str) -> None:
+        self.code = code
+
+FT_INTERNAL_DUCKDB_INIT = AppErrorCode(code="INTERNAL_FT_DUCKDB_INIT")
+"""
+
+_CODES_MODULE_LEGACY = """\
+class AppErrorCode:
+    def __init__(self, code: str) -> None:
+        self.code = code
+
+FT_INTERNAL_DUCKDB_INIT = AppErrorCode(code="Atlan-FT-INTERNAL-500-01")
+"""
+
+_FAILURES_MODULE = """\
+from typing import ClassVar
+
+from app.errors import codes
+
+
+class DuckDbInitError(InternalError):
+    code: ClassVar[str] = codes.FT_INTERNAL_DUCKDB_INIT.code
+"""
+
+
+def test_p003_silent_on_cross_file_code_constant(tmp_path: Path) -> None:
+    """The fleet's connector apps keep codes in their own module and
+    reference them as ``codes.X.code``. That indirection is a declaration —
+    with the prescribed prefix it must be silent."""
+    findings = _scan_files(
+        tmp_path,
+        {
+            "app/errors/codes.py": _CODES_MODULE_OK,
+            "app/errors/failures.py": _FAILURES_MODULE,
+        },
+    )
+    assert [f.rule_id for f in findings] == []
+
+
+def test_p003_fires_on_cross_file_code_constant_with_wrong_prefix(
+    tmp_path: Path,
+) -> None:
+    """Same shape carrying a legacy ``Atlan-*`` code fires — and names the
+    code, so the app can see what to rename. Live: atlan-fivetran-app, 23
+    findings that all read 'does not declare' while every class declared
+    one."""
+    findings = _scan_files(
+        tmp_path,
+        {
+            "app/errors/codes.py": _CODES_MODULE_LEGACY,
+            "app/errors/failures.py": _FAILURES_MODULE,
+        },
+    )
+    assert [f.rule_id for f in findings] == ["P003"]
+    assert "Atlan-FT-INTERNAL-500-01" in findings[0].message
+    assert "INTERNAL_" in findings[0].message
+    assert "does not declare" not in findings[0].message
 
 
 def test_p003_silent_on_abstract_intermediate_with_directive(tmp_path: Path) -> None:


### PR DESCRIPTION
Connector apps keep their error codes in one module and reference them from the exception classes:

```python
# app/errors/codes.py
FT_AUTH_ENTRA_NO_TOKEN = FivetranErrorCode(code="Atlan-FT-AUTH-401-01", ...)

# app/errors/failures.py
class FivetranEntraTokenMissingError(AuthError):
    code: ClassVar[str] = codes.FT_AUTH_ENTRA_NO_TOKEN.code
```

`_extract_code` only accepted an inline `ast.Constant`, so `code_value` came back `None` and every one of these classes fell into the **missing-code** branch.

## Two real defects, both live on `atlan-fivetran-app` (23 findings)

**1. The message was factually false.** Every finding read *"does not declare its own `code: ClassVar[str]`"* — but all 23 classes declare exactly that. A reader, or a remediation agent, is told to add a declaration that is already there. (Confirmed by the SARIF regions: they point at the `class` line, not the `code` line.)

**2. The app could never clear the gate.** The indirection is invisible *whatever string it holds*. Renaming the codes to the prescribed prefixes would have left all 23 firing — at that point as genuine false positives, with no app-side action able to fix them.

## Fix

P003 now resolves module-level code constants app-wide — `NAME = "literal"` and `NAME = Code(code="literal")` — keyed by the constant name, so the `codes.` module prefix in front does not matter. The resolved value goes through the normal prefix comparison.

A value the scanner **cannot prove** (a call result, an f-string, a computed value) stays unresolved and keeps today's conservative firing. This change reads more; it narrows nothing it cannot read.

## Effect on the real repo

`atlan-fivetran-app`, before → after:

| | before | after |
|---|---|---|
| findings | 23 | 23 (they are real legacy `Atlan-*` codes) |
| say "does not declare" | 23 | **0** |
| name the offending code + required prefix | 0 | **23** |

```
Error code 'Atlan-FT-AUTH-401-01' on class 'FivetranEntraTokenMissingError' must start
with the parent leaf's category prefix 'AUTH_' (subclass of 'AuthError'). …
```

The app-side rename remains that team's call — these codes are wire-visible via `AppError.error_code` — but it will now actually clear the rule.

## Tests

- Full conformance suite: **3154 passed, 1 xfailed**; `gen-rule-docs --check` up to date.
- New: cross-file `codes.X.code` silent with the right prefix / fires naming the code with a legacy one; single-file dynamic value fires with the accurate message; an unresolvable value still fires with "does not declare".
- `test_p003_silent_on_dynamic_code_value` flipped to assert silence — its name always said "silent" while it asserted a fire, because the value it uses (`CODE = 'INTERNAL_X'`) is correctly prefixed and now resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)