### PR TITLE
ci(test-performance): parallelise the unit suite with pytest-xdist (FND-961)

### DIFF
--- a/.github/actions/unit-tests/action.yaml
+++ b/.github/actions/unit-tests/action.yaml
@@ -59,10 +59,22 @@ runs:
         else
           SOCKET_FLAGS=""  # intentionally empty — see comment above
         fi
-        $UV_RUN coverage run -m pytest --import-mode=importlib --capture=no --log-cli-level=INFO tests/ $PYTEST_IGNORE -v --full-trace --hypothesis-show-statistics ${SOCKET_FLAGS}
-        $UV_RUN coverage xml
-        $UV_RUN coverage html
-        $UV_RUN coverage report --fail-under=${{ inputs.fail-under }}
+        # -n auto: the suite is ~8,700 tests and was single-threaded, so a leg
+        # took 6-10 minutes while the runner sat on 4 idle vCPUs. Roughly a
+        # third of that was tests sleeping on real clocks, which parallelism
+        # hides for free. See FND-961.
+        #
+        # --cov rather than `coverage run -m pytest`: coverage only traces the
+        # parent process, so under xdist the workers' coverage is silently lost
+        # and --fail-under reads well under half the true number.
+        #
+        # --capture=no is deliberately absent. xdist ignores it in workers, and
+        # leaving it on means a failing test's stdout is written to a worker
+        # process nobody reads instead of being replayed in the failure report.
+        $UV_RUN pytest --import-mode=importlib --log-cli-level=INFO tests/ $PYTEST_IGNORE \
+          -n auto --hypothesis-show-statistics ${SOCKET_FLAGS} \
+          --cov=application_sdk --cov-report=xml --cov-report=html \
+          --cov-report=term-missing --cov-fail-under=${{ inputs.fail-under }}
 
     - name: Comment Coverage Report on PR
       uses: orgoro/coverage@ca0c362dc1a4f100447309405e6dfea47e251495 # v3.3.1

--- a/.github/actions/unit-tests/action.yaml
+++ b/.github/actions/unit-tests/action.yaml
@@ -71,10 +71,18 @@ runs:
         # --capture=no is deliberately absent. xdist ignores it in workers, and
         # leaving it on means a failing test's stdout is written to a worker
         # process nobody reads instead of being replayed in the failure report.
-        $UV_RUN pytest --import-mode=importlib --log-cli-level=INFO tests/ $PYTEST_IGNORE \
+        # --log-cli-level is deliberately absent, and it is the single biggest
+        # remaining lever: it costs 42% of wall time under xdist (77.6s -> 45.3s
+        # locally) and 93s of CPU, because every worker formats each record and
+        # ships it over execnet. It also forces per-test verbose headers even
+        # without -v, which is what made a job log 20,000 lines. Under xdist the
+        # live stream is dropped for passing tests anyway; a failing test still
+        # gets its `Captured log call` section.
+        $UV_RUN pytest --import-mode=importlib tests/ $PYTEST_IGNORE \
           -n auto --hypothesis-show-statistics ${SOCKET_FLAGS} \
+          --durations=25 --durations-min=1.0 \
           --cov=application_sdk --cov-report=xml --cov-report=html \
-          --cov-report=term-missing --cov-fail-under=${{ inputs.fail-under }}
+          --cov-report=term --cov-fail-under=${{ inputs.fail-under }}
 
     - name: Comment Coverage Report on PR
       uses: orgoro/coverage@ca0c362dc1a4f100447309405e6dfea47e251495 # v3.3.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -180,6 +180,13 @@ test = [
     "pytest-timeout>=2.3.0,<3.0.0",
     "pytest-rerunfailures>=16.6,<16.7",
     "pytest-socket>=0.7.0,<1.0.0",
+    "pytest-xdist>=3.8.0,<4.0.0",
+    # pytest-cov, not bare `coverage run -m pytest`: `coverage run` only traces
+    # the parent process, so every xdist worker's coverage is lost and the
+    # --fail-under gate reads a number less than half the real one (measured on
+    # tests/unit/observability: 28.24% serial, 13.87% under `coverage run -n 4`,
+    # 28.24% under `pytest -n 4 --cov`). See FND-961.
+    "pytest-cov>=7.1.0,<8.0.0",
     "hypothesis>=6.114.0,<7.0.0",
     "trustme>=1.2.1,<2.0.0",
     "pyjwt[crypto]>=2.12.0",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,3 +7,20 @@ import os
 # (http://127.0.0.1:3500), which isn't running in unit test environments
 # and causes 60-second timeouts per test.
 os.environ.setdefault("ATLAN_ENABLE_OBSERVABILITY_DAPR_SINK", "false")
+
+# Import pyatlan eagerly, at session start, before any `pytest.Pytester` fixture
+# exists. Pytester snapshots `sys.modules` when it starts and restores it on
+# teardown, deleting everything the inner pytest run imported. pyatlan cannot
+# survive that: its models are pydantic-v1, and `pydantic.v1.class_validators`
+# keeps a process-global `_FUNCS` registry that is never cleared, so re-executing
+# a model module raises `ConfigError: duplicate validator function ...`. Being in
+# sys.modules before the snapshot is taken is what keeps it out of the purge.
+#
+# Serially this was luck — no pytester test happened to run before the tests that
+# touch pyatlan. Under xdist's default `--dist load`, worker assignment is
+# dynamic, so a worker could draw that pairing and fail while its siblings passed.
+# That is what made it look platform- and version-specific. See FND-961.
+#
+# The SDK itself imports pyatlan lazily (inside functions) and must keep doing so
+# — this is a test-session concern only.
+import pyatlan.model.fluent_search  # noqa: E402, F401

--- a/tests/unit/test_pyatlan_preload.py
+++ b/tests/unit/test_pyatlan_preload.py
@@ -1,0 +1,35 @@
+"""``tests/conftest.py`` must keep pyatlan loaded for the whole session.
+
+Why this is load-bearing, measured rather than assumed. After a
+``pytest.Pytester`` test runs an inner suite that imports pyatlan:
+
+    in sys.modules: False      <- Pytester restored its snapshot, purging it
+    in pydantic's _FUNCS: True <- the inner run executed in-process; the
+                                  registry is module-global and never cleared
+
+The next ``from pyatlan.model.fluent_search import FluentSearch`` anywhere in
+that process then re-executes the model modules and dies with
+``ConfigError: duplicate validator function ...``, taking every later test that
+touches pyatlan with it.
+
+Preloading in ``tests/conftest.py`` puts pyatlan inside every Pytester snapshot,
+so the restore keeps it and no module is ever executed twice.
+
+Asserted as a session invariant rather than by driving a Pytester run, because
+the failing path is only reachable when nothing has imported pyatlan yet — which
+is precisely the ordering the preload removes. A test of the path would pass for
+the wrong reason on any worker that happened to import pyatlan first, which is
+the non-determinism that made this look like a platform bug. See FND-961.
+"""
+
+from __future__ import annotations
+
+import sys
+
+
+def test_pyatlan_is_loaded_before_any_test_runs() -> None:
+    assert "pyatlan.model.fluent_search" in sys.modules
+    # The module whose validators actually collide. `fluent_search` pulls the
+    # asset models in eagerly through pyatlan's lazy_loader; asserting on it
+    # directly is what pins that behaviour rather than trusting it.
+    assert "pyatlan.model.assets.purpose" in sys.modules

--- a/tests/unit/testing/harness/test_fixtures.py
+++ b/tests/unit/testing/harness/test_fixtures.py
@@ -49,6 +49,14 @@ from application_sdk.testing.harness.teardown import PurgeReport
 
 pytest_plugins = ["pytester"]
 
+# These tests run pytest inside pytest (``pytest.Pytester``). Under xdist, the
+# unit lane's ``--disable-socket`` leaves the inner run unable to emit any output
+# at all, so ``assert_outcomes`` reads an empty summary and all of them fail. It
+# is the three-way combination that breaks: the file is green under xdist without
+# the flag, and green with the flag when run serially. The generated suites are
+# hermetic — they never open a real connection. See FND-961.
+pytestmark = pytest.mark.enable_socket
+
 #: Written into every generated project: the fixtures reach pytest's hooks only
 #: when the module is registered as a plugin, and ``asyncio_mode`` is what lets
 #: an ``async def`` fixture work with no decorator.

--- a/uv.lock
+++ b/uv.lock
@@ -349,9 +349,11 @@ test = [
     { name = "pyjwt", extra = ["crypto"] },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
     { name = "pytest-rerunfailures" },
     { name = "pytest-socket" },
     { name = "pytest-timeout" },
+    { name = "pytest-xdist" },
     { name = "semver" },
     { name = "trustme" },
 ]
@@ -439,9 +441,11 @@ test = [
     { name = "pyjwt", extras = ["crypto"], specifier = ">=2.12.0" },
     { name = "pytest", specifier = ">=8.3.3,<10.0.0" },
     { name = "pytest-asyncio", specifier = ">=1.4.0,<2.0.0" },
+    { name = "pytest-cov", specifier = ">=7.1.0,<8.0.0" },
     { name = "pytest-rerunfailures", specifier = ">=16.6,<16.7" },
     { name = "pytest-socket", specifier = ">=0.7.0,<1.0.0" },
     { name = "pytest-timeout", specifier = ">=2.3.0,<3.0.0" },
+    { name = "pytest-xdist", specifier = ">=3.8.0,<4.0.0" },
     { name = "semver", specifier = ">=3.0.2,<4.0.0" },
     { name = "trustme", specifier = ">=1.2.1,<2.0.0" },
 ]
@@ -1131,6 +1135,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b4/d9/e70c286c979378f061d8266e279b686ab0b0b688e1fe0af864684f23a77d/coverage-7.15.4-py3-none-any.whl", hash = "sha256:964730a1e9de9c0cf11be6a1a3c79ce419c34882842abd256086ba4698705e84", size = 214332, upload-time = "2026-08-06T13:50:22.192Z" },
 ]
 
+[package.optional-dependencies]
+toml = [
+    { name = "tomli", marker = "python_full_version <= '3.11'" },
+]
+
 [[package]]
 name = "cryptography"
 version = "50.0.0"
@@ -1329,6 +1338,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
 ]
 
 [[package]]
@@ -4332,6 +4350,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-cov"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage", extra = ["toml"] },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
 name = "pytest-order"
 version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4378,6 +4410,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]
@@ -5195,6 +5240,60 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30", size = 154704, upload-time = "2026-03-25T20:21:10.473Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/f7/675db52c7e46064a9aa928885a9b20f4124ecb9bc2e1ce74c9106648d202/tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a", size = 149454, upload-time = "2026-03-25T20:21:12.036Z" },
+    { url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076", size = 237561, upload-time = "2026-03-25T20:21:13.098Z" },
+    { url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9", size = 243824, upload-time = "2026-03-25T20:21:14.569Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e4/5a816ecdd1f8ca51fb756ef684b90f2780afc52fc67f987e3c61d800a46d/tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c", size = 242227, upload-time = "2026-03-25T20:21:15.712Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/49/2b2a0ef529aa6eec245d25f0c703e020a73955ad7edf73e7f54ddc608aa5/tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc", size = 247859, upload-time = "2026-03-25T20:21:17.001Z" },
+    { url = "https://files.pythonhosted.org/packages/83/bd/6c1a630eaca337e1e78c5903104f831bda934c426f9231429396ce3c3467/tomli-2.4.1-cp311-cp311-win32.whl", hash = "sha256:ff2983983d34813c1aeb0fa89091e76c3a22889ee83ab27c5eeb45100560c049", size = 97204, upload-time = "2026-03-25T20:21:18.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/59/71461df1a885647e10b6bb7802d0b8e66480c61f3f43079e0dcd315b3954/tomli-2.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e", size = 108084, upload-time = "2026-03-25T20:21:18.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/83/dceca96142499c069475b790e7913b1044c1a4337e700751f48ed723f883/tomli-2.4.1-cp311-cp311-win_arm64.whl", hash = "sha256:c2541745709bad0264b7d4705ad453b76ccd191e64aa6f0fc66b69a293a45ece", size = 95285, upload-time = "2026-03-25T20:21:20.309Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a", size = 155924, upload-time = "2026-03-25T20:21:21.626Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085", size = 150018, upload-time = "2026-03-25T20:21:23.002Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9", size = 244948, upload-time = "2026-03-25T20:21:24.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5", size = 253341, upload-time = "2026-03-25T20:21:25.177Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585", size = 248159, upload-time = "2026-03-25T20:21:26.364Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1", size = 253290, upload-time = "2026-03-25T20:21:27.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2f/4a3c322f22c5c66c4b836ec58211641a4067364f5dcdd7b974b4c5da300c/tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917", size = 98141, upload-time = "2026-03-25T20:21:28.492Z" },
+    { url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9", size = 108847, upload-time = "2026-03-25T20:21:29.386Z" },
+    { url = "https://files.pythonhosted.org/packages/68/fd/70e768887666ddd9e9f5d85129e84910f2db2796f9096aa02b721a53098d/tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257", size = 95088, upload-time = "2026-03-25T20:21:30.677Z" },
+    { url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54", size = 155866, upload-time = "2026-03-25T20:21:31.65Z" },
+    { url = "https://files.pythonhosted.org/packages/14/6f/12645cf7f08e1a20c7eb8c297c6f11d31c1b50f316a7e7e1e1de6e2e7b7e/tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a", size = 149887, upload-time = "2026-03-25T20:21:33.028Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897", size = 243704, upload-time = "2026-03-25T20:21:34.51Z" },
+    { url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f", size = 251628, upload-time = "2026-03-25T20:21:36.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f1/dbeeb9116715abee2485bf0a12d07a8f31af94d71608c171c45f64c0469d/tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d", size = 247180, upload-time = "2026-03-25T20:21:37.136Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/74/16336ffd19ed4da28a70959f92f506233bd7cfc2332b20bdb01591e8b1d1/tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5", size = 251674, upload-time = "2026-03-25T20:21:38.298Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f9/229fa3434c590ddf6c0aa9af64d3af4b752540686cace29e6281e3458469/tomli-2.4.1-cp313-cp313-win32.whl", hash = "sha256:2190f2e9dd7508d2a90ded5ed369255980a1bcdd58e52f7fe24b8162bf9fedbd", size = 97976, upload-time = "2026-03-25T20:21:39.316Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1e/71dfd96bcc1c775420cb8befe7a9d35f2e5b1309798f009dca17b7708c1e/tomli-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36", size = 108755, upload-time = "2026-03-25T20:21:40.248Z" },
+    { url = "https://files.pythonhosted.org/packages/83/7a/d34f422a021d62420b78f5c538e5b102f62bea616d1d75a13f0a88acb04a/tomli-2.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd", size = 95265, upload-time = "2026-03-25T20:21:41.219Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/fb/9a5c8d27dbab540869f7c1f8eb0abb3244189ce780ba9cd73f3770662072/tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf", size = 155726, upload-time = "2026-03-25T20:21:42.23Z" },
+    { url = "https://files.pythonhosted.org/packages/62/05/d2f816630cc771ad836af54f5001f47a6f611d2d39535364f148b6a92d6b/tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac", size = 149859, upload-time = "2026-03-25T20:21:43.386Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662", size = 244713, upload-time = "2026-03-25T20:21:44.474Z" },
+    { url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853", size = 252084, upload-time = "2026-03-25T20:21:45.62Z" },
+    { url = "https://files.pythonhosted.org/packages/00/71/3a69e86f3eafe8c7a59d008d245888051005bd657760e96d5fbfb0b740c2/tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15", size = 247973, upload-time = "2026-03-25T20:21:46.937Z" },
+    { url = "https://files.pythonhosted.org/packages/67/50/361e986652847fec4bd5e4a0208752fbe64689c603c7ae5ea7cb16b1c0ca/tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba", size = 256223, upload-time = "2026-03-25T20:21:48.467Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/9a/b4173689a9203472e5467217e0154b00e260621caa227b6fa01feab16998/tomli-2.4.1-cp314-cp314-win32.whl", hash = "sha256:3d48a93ee1c9b79c04bb38772ee1b64dcf18ff43085896ea460ca8dec96f35f6", size = 98973, upload-time = "2026-03-25T20:21:49.526Z" },
+    { url = "https://files.pythonhosted.org/packages/14/58/640ac93bf230cd27d002462c9af0d837779f8773bc03dee06b5835208214/tomli-2.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7", size = 109082, upload-time = "2026-03-25T20:21:50.506Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2f/702d5e05b227401c1068f0d386d79a589bb12bf64c3d2c72ce0631e3bc49/tomli-2.4.1-cp314-cp314-win_arm64.whl", hash = "sha256:b8c198f8c1805dc42708689ed6864951fd2494f924149d3e4bce7710f8eb5232", size = 96490, upload-time = "2026-03-25T20:21:51.474Z" },
+    { url = "https://files.pythonhosted.org/packages/45/4b/b877b05c8ba62927d9865dd980e34a755de541eb65fffba52b4cc495d4d2/tomli-2.4.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:d4d8fe59808a54658fcc0160ecfb1b30f9089906c50b23bcb4c69eddc19ec2b4", size = 164263, upload-time = "2026-03-25T20:21:52.543Z" },
+    { url = "https://files.pythonhosted.org/packages/24/79/6ab420d37a270b89f7195dec5448f79400d9e9c1826df982f3f8e97b24fd/tomli-2.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7008df2e7655c495dd12d2a4ad038ff878d4ca4b81fccaf82b714e07eae4402c", size = 160736, upload-time = "2026-03-25T20:21:53.674Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e0/3630057d8eb170310785723ed5adcdfb7d50cb7e6455f85ba8a3deed642b/tomli-2.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d8591993e228b0c930c4bb0db464bdad97b3289fb981255d6c9a41aedc84b2d", size = 270717, upload-time = "2026-03-25T20:21:55.129Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/b4/1613716072e544d1a7891f548d8f9ec6ce2faf42ca65acae01d76ea06bb0/tomli-2.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:734e20b57ba95624ecf1841e72b53f6e186355e216e5412de414e3c51e5e3c41", size = 278461, upload-time = "2026-03-25T20:21:56.228Z" },
+    { url = "https://files.pythonhosted.org/packages/05/38/30f541baf6a3f6df77b3df16b01ba319221389e2da59427e221ef417ac0c/tomli-2.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8a650c2dbafa08d42e51ba0b62740dae4ecb9338eefa093aa5c78ceb546fcd5c", size = 274855, upload-time = "2026-03-25T20:21:57.653Z" },
+    { url = "https://files.pythonhosted.org/packages/77/a3/ec9dd4fd2c38e98de34223b995a3b34813e6bdadf86c75314c928350ed14/tomli-2.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:504aa796fe0569bb43171066009ead363de03675276d2d121ac1a4572397870f", size = 283144, upload-time = "2026-03-25T20:21:59.089Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/be/605a6261cac79fba2ec0c9827e986e00323a1945700969b8ee0b30d85453/tomli-2.4.1-cp314-cp314t-win32.whl", hash = "sha256:b1d22e6e9387bf4739fbe23bfa80e93f6b0373a7f1b96c6227c32bef95a4d7a8", size = 108683, upload-time = "2026-03-25T20:22:00.214Z" },
+    { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes FND-961.

## Why

The `SDK Tests / Unit Tests` matrix takes 6–10 minutes per leg. The cause is not the number of tests.

1. **The suite was single-threaded.** `pytest-xdist` was absent from `pyproject.toml` and `uv.lock`. ~8,700 tests on one core, on a runner with 4.
2. **~50% of wall time is ~45 tests sleeping on real clocks.** The other ~8,950 average ~10ms each, which is normal. CPU utilisation during a serial run was 62–71% of a *single* core — about a third of wall time the process is simply asleep. Parallelism hides that for free.
3. Coverage and the verbose logging flags cost **~4%** (202s plain vs 211s with the full CI flag set). They were not the problem.

Windows runs ~37% slower than Ubuntu (process spawn, filesystem) — the same slow suite plus a constant platform tax, not a separate problem.

| Run | pytest time |
|---|---|
| Windows 3.14 (run 33098193429) | 491s (8:11) |
| Ubuntu 3.14 (same run) | 359s (5:59) |
| Local, identical CI flags | 211s |
| **Local, this branch's command** | **59s** |

Fixing the real-clock sleeps is worth a further ~50s and is deliberately **not** in this PR.

## What changed

**`pytest-cov` replaces `coverage run -m pytest`.** This is required, not cosmetic. `coverage run` only traces the parent process, so under xdist every worker's coverage is silently discarded and `--fail-under` gates on a false number. Measured on `tests/unit/observability`:

| Command | Coverage |
|---|---|
| `coverage run -m pytest` | 28.24% |
| `coverage run -m pytest -n 4` | **13.87%** ← would red the gate |
| `pytest -n 4 --cov` | 28.24% ✅ |

Full suite on this branch reports 93.6% line-rate, consistent with the serial baseline.

**`--capture=no` is dropped.** xdist ignores it in workers, and leaving it on means a *failing* test's stdout goes to a worker process nobody reads instead of being replayed. Without it, pytest replays both `Captured stdout call` and `Captured log call` on failure. `-v` and `--full-trace` go with it — under xdist the per-test stream is interleaved across workers, and the 69,000-line Windows job log was noise.

**`pytestmark = pytest.mark.enable_socket` on `tests/unit/testing/harness/test_fixtures.py`.** 17 tests there run pytest inside pytest (`pytest.Pytester`). It is a three-way interaction with `--disable-socket` that breaks them — the inner run emits no output at all in a socket-disabled xdist worker, so `assert_outcomes` reads an empty summary:

| Run | Result |
|---|---|
| `-n 4`, no socket flags | 41 passed |
| serial, `--disable-socket` | 41 passed |
| `-n 4`, `--allow-unix-socket` only | 41 passed |
| `-n 4`, **`--disable-socket`** | **17 failed** |

The generated suites are hermetic; they never open a real connection.

## Blast radius: SDK-only

`.github/actions/unit-tests` has **no callers outside this repo** (`gh search code --owner atlanhq`: 0 hits; the only in-repo caller is `sdk-tests-reusable.yaml`).

Connector repos run **`.github/actions/connector-unit-tests`**, which this PR does not touch — 43 repos use it, and none of them need to change anything. Doing the same there is a separate PR with a real blast radius; the transient `uv run --with pytest-xdist --with pytest-cov` pattern already used by `connector-integration-tests` is the precedent, so it would be self-contained with no connector-side dependency edits.

## What we give up

- Live INFO logs vanish for *passing* tests. Everything attached to a **failure** is still replayed in full.
- `--pdb` does not work under `-n`; drop to `-n 0` for interactive debugging.
- `-x`/`--maxfail` becomes approximate — in-flight workers finish.
- Per-test wall time is no longer derivable from log timestamps; use `--durations`.

## Risk this PR's own CI is the test for

All local numbers are from a 12-core machine; runners are 4 vCPU / 16 GB. Several tests spawn their own children — `test_run_fault_isolated.py` (process pools), `test_lazy_pandas.py` (subprocess interpreters), `test_writer_data_integrity.py` (real parquet writes). Four xdist workers each spawning subprocesses could oversubscribe CPU or memory in a way the local run hid. If the matrix reds or gets flaky, the fix is `-n 2` on Windows or an `xdist_group` pinning the process-pool tests.

Verified locally: `8993 passed, 9 skipped in 59.20s`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
