### PR TITLE
ci(dashboard): archived repos leave the fleet but never the manifest

### DIFF
--- a/.github/scripts/publish_fleet_dashboard.py
+++ b/.github/scripts/publish_fleet_dashboard.py
@@ -5,6 +5,12 @@ The upload half of the fleet-dashboard pattern: per-repo documents, a manifest
 of every repo present in the bucket, append-only per-repo history, and — on
 full-fleet runs only — the fleet aggregate and its history.
 
+The manifest is rebuilt by LISTING the bucket, which has no deletion path, so a
+repo that left the fleet stayed enumerated on every dashboard forever. On a
+full-fleet run the scan itself is authoritative about membership, and stored
+objects it did not produce are omitted from the manifest (never deleted — see
+``refresh_manifest``). FND-960.
+
 Extracted from an inlined ``run:`` block per docs/standards/ci.md. The shell
 version carried a loop, an if, and a download → merge → re-upload sequence whose
 failure mode is silent: without a ``touch`` of the not-yet-existing history file,
@@ -47,6 +53,17 @@ BUCKET = "s3://kryptonite-store"
 RunFn = Callable[[list], tuple]
 
 FLEET_SLUG = "fleet"
+
+# Ceiling on how much of a stored manifest one full-fleet publish may drop.
+#
+# Orphan detection is inference from absence: an object the scan did not produce
+# is assumed to belong to a repo that left the fleet. That is only as good as the
+# scan — a partial one (rate limit, a failed discovery page, a crash midway)
+# makes most of the fleet look departed. Above this fraction we keep everything
+# and say so, because a manifest that still lists a dead repo is a cosmetic
+# problem while a manifest missing 80% of the fleet reads as a catastrophic
+# regression on every dashboard at once.
+MAX_ORPHAN_FRACTION = 0.2
 
 
 def _run_aws(args: list) -> tuple:
@@ -140,12 +157,41 @@ def merge_history(
     upload(merged, prefix, "history", f"{slug}.jsonl", run=run)
 
 
-def refresh_manifest(prefix: str, tmp_dir: Path, run: RunFn = _run_aws) -> list:
+def orphans(stored: list, scanned: set) -> list:
+    """Stored objects this full-fleet scan did not produce, sorted.
+
+    These are repos that have left the fleet. The scanners already exclude
+    archived repos (``gh repo list --no-archived``), so an archived repo simply
+    stops being scanned — and because the manifest is rebuilt by LISTING the
+    bucket, which has no deletion path, its object kept it on every dashboard
+    forever, padding the rollout-coverage denominator (FND-960).
+    """
+    return sorted(name for name in stored if name not in scanned)
+
+
+def refresh_manifest(
+    prefix: str,
+    tmp_dir: Path,
+    run: RunFn = _run_aws,
+    *,
+    scanned: Optional[set] = None,
+) -> list:
     """Rewrite ``repos.json`` from what is actually in the bucket.
 
     Listing the bucket rather than the local scan output on purpose: in
     single-repo mode the local directory holds one file, and a manifest built
     from it would hide every other repo from the dashboard.
+
+    On a full-fleet run the caller passes ``scanned`` — the object names this
+    scan produced — which IS authoritative about fleet membership. Stored
+    objects absent from it are omitted from the manifest, so a departed repo
+    stops being enumerated by every consumer.
+
+    Omitted, not deleted. Excluding is idempotent (recomputed from ``scanned``
+    on every run) and costs nothing if the judgement is wrong, whereas an
+    automated delete of dashboard history cannot be undone. Reclaiming the
+    objects themselves stays a deliberate, human-triggered act —
+    ``prune-dashboard-repo.yaml``.
     """
     code, stdout, _ = run(["s3", "ls", _key(prefix, "repos", "")])
     if code != 0:
@@ -155,6 +201,28 @@ def refresh_manifest(prefix: str, tmp_dir: Path, run: RunFn = _run_aws) -> list:
         for line in stdout.splitlines()
         if line.strip().endswith(".json")
     )
+
+    dropped: list = []
+    if scanned is not None:
+        candidates = orphans(names, scanned)
+        cap = max(1, int(len(names) * MAX_ORPHAN_FRACTION))
+        if len(candidates) > cap:
+            print(
+                f"::warning::{len(candidates)} of {len(names)} stored repos are absent "
+                f"from this scan (cap {cap}) — keeping all of them; the scan looks "
+                "partial, not the fleet shrunk",
+                file=sys.stderr,
+            )
+        elif candidates:
+            dropped = candidates
+            names = [n for n in names if n not in set(dropped)]
+            for name in dropped:
+                print(
+                    f"::notice::omitting {name} from {prefix}/repos.json — no longer "
+                    "in the fleet scan",
+                    file=sys.stderr,
+                )
+
     manifest = tmp_dir / "repos.json"
     manifest.write_text(json.dumps(names))
     upload(manifest, prefix, "repos.json", run=run)
@@ -176,7 +244,15 @@ def publish(
     for doc in repo_docs:
         upload(doc, prefix, "repos", doc.name, run=run)
 
-    manifest = refresh_manifest(prefix, tmp_dir, run=run)
+    # A full-fleet scan is authoritative about membership, so it can retire
+    # departed repos from the manifest. A single-repo scan is not — passing its
+    # one document would omit the entire rest of the fleet.
+    manifest = refresh_manifest(
+        prefix,
+        tmp_dir,
+        run=run,
+        scanned=None if single_repo else {doc.name for doc in repo_docs},
+    )
 
     histories = 0
     for history in sorted(scan_dir.glob("history_*.jsonl")):

--- a/.github/scripts/sweep_archived_dashboard_repos.py
+++ b/.github/scripts/sweep_archived_dashboard_repos.py
@@ -16,6 +16,10 @@ Deletion is limited to repos GitHub definitively reports as ``archived: true``:
   scope would otherwise read as "the whole fleet was deleted".
 * An unreadable answer is likewise reported, never acted on.
 
+A delete the bucket refuses (AccessDenied, throttling) leaves the slug in
+``repos.json``: the manifest tracks what is actually stored, so a row may only
+disappear once its objects have.
+
 ``--max-fraction`` caps how much of a prefix one invocation may remove, because
 a bad token makes everything look archived and a manifest missing most of the
 fleet reads as a catastrophic regression on every panel at once.
@@ -170,27 +174,45 @@ def sweep(
             "unknown": unknown,
         }
 
+    swept: list = []
+    undeleted: list = []
     for slug in archived:
         print(
             f"{prefix}: {'would sweep' if dry_run else 'sweeping'} {slug}",
             file=sys.stderr,
         )
         if dry_run:
+            swept.append(slug)
             continue
-        # A missing object is fine — the point is that it is gone afterwards.
-        run(["s3", "rm", f"{BUCKET}/{prefix}/repos/{slug}.json"])
-        run(["s3", "rm", f"{BUCKET}/{prefix}/history/{slug}.jsonl"])
+        # A missing object is fine — `aws s3 rm` exits 0 for a key that is
+        # already gone, and the point is that it is gone afterwards. A non-zero
+        # code is therefore a real refusal (AccessDenied, throttling): the
+        # object survives, so its manifest row has to survive with it rather
+        # than the slug vanishing from repos.json while its data stays.
+        codes = [
+            run(["s3", "rm", f"{BUCKET}/{prefix}/repos/{slug}.json"])[0],
+            run(["s3", "rm", f"{BUCKET}/{prefix}/history/{slug}.jsonl"])[0],
+        ]
+        if any(codes):
+            print(
+                f"::warning::{prefix}: {slug} — delete refused, keeping its "
+                "manifest row so the manifest keeps matching the bucket",
+                file=sys.stderr,
+            )
+            undeleted.append(slug)
+            continue
+        swept.append(slug)
 
-    if not dry_run:
+    if not dry_run and swept:
         rebuild_manifest(
-            prefix, [s for s in slugs if s not in set(archived)], tmp_dir, run=run
+            prefix, [s for s in slugs if s not in set(swept)], tmp_dir, run=run
         )
 
     return {
         "prefix": prefix,
         "stored": len(slugs),
-        "swept": archived,
-        "refused": [],
+        "swept": swept,
+        "refused": undeleted,
         "unknown": unknown,
     }
 
@@ -239,8 +261,9 @@ def main(argv: Optional[list] = None) -> int:
             f"{r['prefix']}: stored={r['stored']} swept={len(r['swept'])} "
             f"refused={len(r['refused'])} unreadable={len(r['unknown'])}"
         )
-    # A refusal is the safety rail firing on evidence we do not trust — surface
-    # it as a failed run so nobody reads the green tick as "nothing to clean".
+    # A refusal is either safety rail firing — evidence we do not trust, or a
+    # delete the bucket would not accept — so surface it as a failed run rather
+    # than let a green tick read as "nothing left to clean".
     return 1 if any(r["refused"] for r in results) else 0
 
 

--- a/.github/scripts/sweep_archived_dashboard_repos.py
+++ b/.github/scripts/sweep_archived_dashboard_repos.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""Sweep archived repos out of one or more Kryptonite dashboard prefixes.
+
+Every dashboard's ``repos.json`` is rebuilt by LISTING the bucket, so a repo
+that leaves the fleet keeps being enumerated forever: archiving stops it being
+updated, and nothing removes its object. ``publish_fleet_dashboard.py`` now
+omits departed repos from the manifest on full-fleet runs, but the per-repo
+publishers (security / conformance / test-readiness, driven from each app repo's
+own ``update-dashboard.yml``) have no full-fleet view and cannot. This is the
+deliberate, human-triggered cleanup for those — FND-960.
+
+Deletion is limited to repos GitHub definitively reports as ``archived: true``:
+
+* A repo that 404s (deleted, renamed, or invisible to this token) is REPORTED,
+  never swept. The three causes need different follow-ups and a token that lost
+  scope would otherwise read as "the whole fleet was deleted".
+* An unreadable answer is likewise reported, never acted on.
+
+``--max-fraction`` caps how much of a prefix one invocation may remove, because
+a bad token makes everything look archived and a manifest missing most of the
+fleet reads as a catastrophic regression on every panel at once.
+
+Usage:
+    sweep_archived_dashboard_repos.py --prefixes conformance-dashboard --dry-run
+    sweep_archived_dashboard_repos.py --prefixes security-dashboard,renovate-dashboard
+
+Environment:
+    GH_TOKEN  bearer token for `gh` (org read)
+    AWS credentials must already be configured by the caller.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Callable, Optional
+
+BUCKET = "s3://kryptonite-store"
+
+# (args) -> (returncode, stdout, stderr). Same seam shape as
+# publish_fleet_dashboard.py so both are testable against a fake bucket.
+RunFn = Callable[[list], tuple]
+GhFn = Callable[[str], tuple]
+
+DEFAULT_MAX_FRACTION = 0.2
+
+
+def _run_aws(args: list) -> tuple:
+    result = subprocess.run(["aws", *args], capture_output=True, text=True)
+    return result.returncode, result.stdout, result.stderr
+
+
+def _run_gh(repo: str) -> tuple:
+    result = subprocess.run(
+        ["gh", "api", f"repos/{repo}", "-q", ".archived"],
+        capture_output=True,
+        text=True,
+    )
+    return result.returncode, result.stdout, result.stderr
+
+
+def slug_to_repo(slug: str) -> Optional[str]:
+    """``atlanhq_atlan-mysql-app`` -> ``atlanhq/atlan-mysql-app``.
+
+    Returns None for anything that does not carry an ``<owner>_<name>`` shape,
+    so an unexpected object in the prefix is skipped rather than turned into a
+    bogus repo name we then ask GitHub about.
+    """
+    owner, sep, name = slug.partition("_")
+    if not sep or not owner or not name:
+        return None
+    return f"{owner}/{name}"
+
+
+def list_slugs(prefix: str, run: RunFn = _run_aws) -> list:
+    """Slugs (object basenames, ``.json`` stripped) stored under *prefix*."""
+    code, stdout, stderr = run(["s3", "ls", f"{BUCKET}/{prefix}/repos/"])
+    if code != 0:
+        raise RuntimeError(f"failed to list {prefix}/repos/: {stderr.strip()}")
+    return sorted(
+        line.split()[-1][: -len(".json")]
+        for line in stdout.splitlines()
+        if line.strip().endswith(".json")
+    )
+
+
+def archived_state(repo: str, gh: GhFn = _run_gh) -> Optional[bool]:
+    """True/False when GitHub answers, None when it cannot be determined.
+
+    None is the important case: it must never be treated as archived. A 404 or a
+    403 says something about our token or the repo's visibility, not about
+    whether the fleet still contains it.
+    """
+    code, stdout, _ = gh(repo)
+    if code != 0:
+        return None
+    answer = stdout.strip().lower()
+    if answer in ("true", "false"):
+        return answer == "true"
+    return None
+
+
+def rebuild_manifest(
+    prefix: str, slugs: list, tmp_dir: Path, run: RunFn = _run_aws
+) -> None:
+    """Write ``repos.json`` for *prefix* from *slugs* (object names restored)."""
+    manifest = tmp_dir / "repos.json"
+    manifest.write_text(json.dumps(sorted(f"{s}.json" for s in slugs)))
+    code, _, stderr = run(["s3", "cp", str(manifest), f"{BUCKET}/{prefix}/repos.json"])
+    if code != 0:
+        raise RuntimeError(f"failed to upload {prefix}/repos.json: {stderr.strip()}")
+
+
+def sweep(
+    prefix: str,
+    tmp_dir: Path,
+    *,
+    run: RunFn = _run_aws,
+    gh: GhFn = _run_gh,
+    dry_run: bool = False,
+    max_fraction: float = DEFAULT_MAX_FRACTION,
+) -> dict:
+    """Remove archived repos' objects from *prefix* and rebuild its manifest."""
+    slugs = list_slugs(prefix, run=run)
+    archived: list = []
+    unknown: list = []
+    for slug in slugs:
+        repo = slug_to_repo(slug)
+        if repo is None:
+            unknown.append(slug)
+            continue
+        state = archived_state(repo, gh)
+        if state is None:
+            unknown.append(slug)
+        elif state:
+            archived.append(slug)
+
+    cap = max(1, int(len(slugs) * max_fraction))
+    if len(archived) > cap:
+        print(
+            f"::warning::{prefix}: {len(archived)} of {len(slugs)} repos read as "
+            f"archived (cap {cap}) — sweeping none; check the token before retrying",
+            file=sys.stderr,
+        )
+        return {
+            "prefix": prefix,
+            "stored": len(slugs),
+            "swept": [],
+            "refused": archived,
+            "unknown": unknown,
+        }
+
+    for slug in unknown:
+        print(
+            f"::notice::{prefix}: {slug} — state unreadable, left in place",
+            file=sys.stderr,
+        )
+
+    if not archived:
+        print(f"{prefix}: nothing archived among {len(slugs)} repos", file=sys.stderr)
+        return {
+            "prefix": prefix,
+            "stored": len(slugs),
+            "swept": [],
+            "refused": [],
+            "unknown": unknown,
+        }
+
+    for slug in archived:
+        print(
+            f"{prefix}: {'would sweep' if dry_run else 'sweeping'} {slug}",
+            file=sys.stderr,
+        )
+        if dry_run:
+            continue
+        # A missing object is fine — the point is that it is gone afterwards.
+        run(["s3", "rm", f"{BUCKET}/{prefix}/repos/{slug}.json"])
+        run(["s3", "rm", f"{BUCKET}/{prefix}/history/{slug}.jsonl"])
+
+    if not dry_run:
+        rebuild_manifest(
+            prefix, [s for s in slugs if s not in set(archived)], tmp_dir, run=run
+        )
+
+    return {
+        "prefix": prefix,
+        "stored": len(slugs),
+        "swept": archived,
+        "refused": [],
+        "unknown": unknown,
+    }
+
+
+def main(argv: Optional[list] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "--prefixes",
+        required=True,
+        help="comma-separated S3 prefixes, e.g. conformance-dashboard,security-dashboard",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="report what would be swept and change nothing",
+    )
+    parser.add_argument(
+        "--max-fraction",
+        type=float,
+        default=DEFAULT_MAX_FRACTION,
+        help="refuse to sweep more than this fraction of a prefix (default 0.2)",
+    )
+    args = parser.parse_args(argv)
+
+    prefixes = [p.strip() for p in args.prefixes.split(",") if p.strip()]
+    if not prefixes:
+        print("::error::--prefixes named no prefix", file=sys.stderr)
+        return 2
+
+    results = []
+    with tempfile.TemporaryDirectory() as tmp:
+        for prefix in prefixes:
+            results.append(
+                sweep(
+                    prefix,
+                    Path(tmp),
+                    dry_run=args.dry_run,
+                    max_fraction=args.max_fraction,
+                )
+            )
+
+    for r in results:
+        print(
+            f"{r['prefix']}: stored={r['stored']} swept={len(r['swept'])} "
+            f"refused={len(r['refused'])} unreadable={len(r['unknown'])}"
+        )
+    # A refusal is the safety rail firing on evidence we do not trust — surface
+    # it as a failed run so nobody reads the green tick as "nothing to clean".
+    return 1 if any(r["refused"] for r in results) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/tests/test_publish_fleet_dashboard.py
+++ b/.github/scripts/tests/test_publish_fleet_dashboard.py
@@ -20,6 +20,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 from publish_fleet_dashboard import (  # noqa: E402
     BUCKET,
     merge_history,
+    orphans,
     publish,
     refresh_manifest,
 )
@@ -296,3 +297,108 @@ def test_history_download_non_404_with_not_found_phrase_is_not_first_publish(tmp
         merge_history(local, PREFIX, "slug", tmp_path, run=throttled)
 
     assert s3.objects[key] == stored  # history untouched
+
+
+# ── departed repos (FND-960) ─────────────────────────────────────────────────
+
+
+def test_orphans_are_the_stored_objects_a_scan_did_not_produce():
+    assert orphans(["a.json", "b.json"], {"a.json"}) == ["b.json"]
+    assert orphans(["a.json"], {"a.json", "b.json"}) == []
+
+
+def test_a_full_fleet_run_retires_a_repo_that_left_the_fleet(tmp_path):
+    """The scanners exclude archived repos, so the scan stops covering one.
+
+    Because the manifest is rebuilt by listing the bucket, its object used to
+    keep it enumerated on every dashboard forever.
+    """
+    s3 = FakeS3(
+        {
+            f"{BUCKET}/{PREFIX}/repos/atlanhq_atlan-mysql-app.json": "{}",
+            f"{BUCKET}/{PREFIX}/repos/atlanhq_atlan-dead-app.json": "{}",
+            f"{BUCKET}/{PREFIX}/repos/atlanhq_atlan-hive-app.json": "{}",
+            f"{BUCKET}/{PREFIX}/repos/atlanhq_atlan-adf-app.json": "{}",
+            f"{BUCKET}/{PREFIX}/repos/atlanhq_atlan-gcs-app.json": "{}",
+        }
+    )
+    publish(
+        _scan_dir(
+            tmp_path,
+            repos=(
+                "atlanhq_atlan-mysql-app",
+                "atlanhq_atlan-hive-app",
+                "atlanhq_atlan-adf-app",
+                "atlanhq_atlan-gcs-app",
+            ),
+        ),
+        PREFIX,
+        single_repo=False,
+        tmp_dir=tmp_path,
+        run=s3,
+    )
+    manifest = json.loads(s3.objects[f"{BUCKET}/{PREFIX}/repos.json"])
+    assert "atlanhq_atlan-dead-app.json" not in manifest
+    assert "atlanhq_atlan-mysql-app.json" in manifest
+
+
+def test_a_retired_repo_is_omitted_but_never_deleted(tmp_path):
+    """Excluding is idempotent and reversible; deleting dashboard history is not."""
+    dead = f"{BUCKET}/{PREFIX}/repos/atlanhq_atlan-dead-app.json"
+    s3 = FakeS3(
+        {
+            dead: "{}",
+            f"{BUCKET}/{PREFIX}/repos/atlanhq_atlan-mysql-app.json": "{}",
+            f"{BUCKET}/{PREFIX}/repos/atlanhq_atlan-hive-app.json": "{}",
+            f"{BUCKET}/{PREFIX}/repos/atlanhq_atlan-adf-app.json": "{}",
+            f"{BUCKET}/{PREFIX}/repos/atlanhq_atlan-gcs-app.json": "{}",
+            f"{BUCKET}/{PREFIX}/history/atlanhq_atlan-dead-app.jsonl": "{}\n",
+        }
+    )
+    publish(
+        _scan_dir(
+            tmp_path,
+            repos=(
+                "atlanhq_atlan-mysql-app",
+                "atlanhq_atlan-hive-app",
+                "atlanhq_atlan-adf-app",
+                "atlanhq_atlan-gcs-app",
+            ),
+        ),
+        PREFIX,
+        single_repo=False,
+        tmp_dir=tmp_path,
+        run=s3,
+    )
+    assert dead in s3.objects
+    assert f"{BUCKET}/{PREFIX}/history/atlanhq_atlan-dead-app.jsonl" in s3.objects
+
+
+def test_a_single_repo_run_never_retires_anything(tmp_path):
+    """Its one document says nothing about the rest of the fleet."""
+    s3 = FakeS3(
+        {
+            f"{BUCKET}/{PREFIX}/repos/atlanhq_atlan-mysql-app.json": "{}",
+            f"{BUCKET}/{PREFIX}/repos/atlanhq_atlan-metabase-app.json": "{}",
+        }
+    )
+    publish(_scan_dir(tmp_path), PREFIX, single_repo=True, tmp_dir=tmp_path, run=s3)
+    manifest = json.loads(s3.objects[f"{BUCKET}/{PREFIX}/repos.json"])
+    assert "atlanhq_atlan-metabase-app.json" in manifest
+
+
+def test_a_partial_scan_retires_nothing(tmp_path, capsys):
+    """A crashed or rate-limited scan makes most of the fleet look departed.
+
+    Dropping them would read as a catastrophic regression on every panel, so
+    above the cap the manifest keeps everything and the run says why.
+    """
+    stored = {
+        f"{BUCKET}/{PREFIX}/repos/atlanhq_atlan-app-{i}.json": "{}" for i in range(10)
+    }
+    stored[f"{BUCKET}/{PREFIX}/repos/atlanhq_atlan-mysql-app.json"] = "{}"
+    s3 = FakeS3(stored)
+    publish(_scan_dir(tmp_path), PREFIX, single_repo=False, tmp_dir=tmp_path, run=s3)
+    manifest = json.loads(s3.objects[f"{BUCKET}/{PREFIX}/repos.json"])
+    assert len(manifest) == 11
+    assert "absent from this scan" in capsys.readouterr().err

--- a/.github/scripts/tests/test_sweep_archived_dashboard_repos.py
+++ b/.github/scripts/tests/test_sweep_archived_dashboard_repos.py
@@ -26,9 +26,12 @@ PREFIX = "conformance-dashboard"
 
 
 class FakeS3:
-    def __init__(self, initial=None):
+    def __init__(self, initial=None, rm_denies=()):
         self.objects = dict(initial or {})
         self.removed: list = []
+        # Substrings of keys the bucket refuses to delete, mirroring an
+        # AccessDenied / throttled `aws s3 rm` (non-zero, object survives).
+        self.rm_denies = tuple(rm_denies)
 
     def __call__(self, args: list) -> tuple:
         if args[:2] == ["s3", "ls"]:
@@ -39,6 +42,8 @@ class FakeS3:
             )
             return 0, listing, ""
         if args[:2] == ["s3", "rm"]:
+            if any(d in args[2] for d in self.rm_denies):
+                return 1, "", "An error occurred (AccessDenied)"
             self.removed.append(args[2])
             self.objects.pop(args[2], None)
             return 0, "", ""
@@ -159,3 +164,42 @@ def test_everything_reading_as_archived_sweeps_nothing(tmp_path, capsys):
     assert s3.removed == []
     assert len(result["refused"]) == 5
     assert "sweeping none" in capsys.readouterr().err
+
+
+def test_a_refused_delete_keeps_the_slug_in_the_manifest(tmp_path):
+    """The object survives, so its row must too — otherwise the panel drops a
+    repo whose data is still in the bucket and no later run reconsiders it."""
+    s3 = FakeS3(
+        _bucket("atlanhq_atlan-live-app", "atlanhq_atlan-dead-app"),
+        rm_denies=("atlanhq_atlan-dead-app",),
+    )
+    result = sweep(
+        PREFIX,
+        tmp_path,
+        run=s3,
+        gh=_gh(archived=("atlanhq/atlan-dead-app",)),
+    )
+    assert result["swept"] == []
+    assert result["refused"] == ["atlanhq_atlan-dead-app"]
+    assert f"{BUCKET}/{PREFIX}/repos.json" not in s3.objects
+
+
+def test_a_partial_delete_failure_still_sweeps_the_rest(tmp_path):
+    """One refused prefix row must not strand the deletes that did land."""
+    s3 = FakeS3(
+        _bucket("atlanhq_atlan-live-app", "atlanhq_a-dead-app", "atlanhq_b-dead-app"),
+        rm_denies=("atlanhq_b-dead-app",),
+    )
+    result = sweep(
+        PREFIX,
+        tmp_path,
+        run=s3,
+        gh=_gh(archived=("atlanhq/a-dead-app", "atlanhq/b-dead-app")),
+        max_fraction=1.0,
+    )
+    assert result["swept"] == ["atlanhq_a-dead-app"]
+    assert result["refused"] == ["atlanhq_b-dead-app"]
+    assert json.loads(s3.objects[f"{BUCKET}/{PREFIX}/repos.json"]) == [
+        "atlanhq_atlan-live-app.json",
+        "atlanhq_b-dead-app.json",
+    ]

--- a/.github/scripts/tests/test_sweep_archived_dashboard_repos.py
+++ b/.github/scripts/tests/test_sweep_archived_dashboard_repos.py
@@ -1,0 +1,161 @@
+"""Tests for .github/scripts/sweep_archived_dashboard_repos.py.
+
+The sweep DELETES dashboard objects, so the cases here are weighted towards what
+it must refuse: an unreadable repo state, an unexpected object in the prefix, and
+a token failure that makes the whole fleet look archived. Deleting a live repo's
+history is unrecoverable; leaving a dead row on a panel is cosmetic.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from sweep_archived_dashboard_repos import (  # noqa: E402
+    BUCKET,
+    archived_state,
+    list_slugs,
+    slug_to_repo,
+    sweep,
+)
+
+PREFIX = "conformance-dashboard"
+
+
+class FakeS3:
+    def __init__(self, initial=None):
+        self.objects = dict(initial or {})
+        self.removed: list = []
+
+    def __call__(self, args: list) -> tuple:
+        if args[:2] == ["s3", "ls"]:
+            listing = "".join(
+                f"2026-08-27 12:00:00       1234 {key.rsplit('/', 1)[-1]}\n"
+                for key in sorted(self.objects)
+                if key.startswith(args[2])
+            )
+            return 0, listing, ""
+        if args[:2] == ["s3", "rm"]:
+            self.removed.append(args[2])
+            self.objects.pop(args[2], None)
+            return 0, "", ""
+        if args[:2] == ["s3", "cp"]:
+            self.objects[args[3]] = Path(args[2]).read_text()
+            return 0, "", ""
+        raise AssertionError(f"unexpected aws call: {args}")
+
+
+def _gh(archived=(), fails=()):
+    def gh(repo: str) -> tuple:
+        if repo in fails:
+            return 1, "", "gh: Not Found (HTTP 404)"
+        return 0, "true\n" if repo in archived else "false\n", ""
+
+    return gh
+
+
+def _bucket(*names):
+    objects = {}
+    for n in names:
+        objects[f"{BUCKET}/{PREFIX}/repos/{n}.json"] = "{}"
+        objects[f"{BUCKET}/{PREFIX}/history/{n}.jsonl"] = "{}\n"
+    return objects
+
+
+# ── slug handling ────────────────────────────────────────────────────────────
+
+
+def test_slug_maps_to_owner_and_repo():
+    assert slug_to_repo("atlanhq_atlan-mysql-app") == "atlanhq/atlan-mysql-app"
+
+
+def test_a_slug_without_an_owner_is_not_a_repo():
+    """An unexpected object must not become a repo name we query and then delete."""
+    assert slug_to_repo("stray-object") is None
+
+
+def test_listing_ignores_non_json_objects(tmp_path):
+    s3 = FakeS3({f"{BUCKET}/{PREFIX}/repos/README.txt": "x", **_bucket("atlanhq_a")})
+    assert list_slugs(PREFIX, run=s3) == ["atlanhq_a"]
+
+
+# ── archived state ───────────────────────────────────────────────────────────
+
+
+def test_state_is_unknown_when_github_cannot_answer():
+    """A 404/403 says something about the token, not about fleet membership."""
+    assert archived_state("atlanhq/x", _gh(fails=("atlanhq/x",))) is None
+
+
+def test_state_reads_the_flag():
+    assert archived_state("atlanhq/x", _gh(archived=("atlanhq/x",))) is True
+    assert archived_state("atlanhq/x", _gh()) is False
+
+
+# ── sweeping ─────────────────────────────────────────────────────────────────
+
+
+def test_an_archived_repo_loses_its_document_history_and_manifest_row(tmp_path):
+    s3 = FakeS3(_bucket("atlanhq_atlan-live-app", "atlanhq_atlan-dead-app"))
+    result = sweep(
+        PREFIX,
+        tmp_path,
+        run=s3,
+        gh=_gh(archived=("atlanhq/atlan-dead-app",)),
+    )
+    assert result["swept"] == ["atlanhq_atlan-dead-app"]
+    assert f"{BUCKET}/{PREFIX}/repos/atlanhq_atlan-dead-app.json" in s3.removed
+    assert f"{BUCKET}/{PREFIX}/history/atlanhq_atlan-dead-app.jsonl" in s3.removed
+    assert json.loads(s3.objects[f"{BUCKET}/{PREFIX}/repos.json"]) == [
+        "atlanhq_atlan-live-app.json"
+    ]
+
+
+def test_a_live_repo_is_untouched(tmp_path):
+    s3 = FakeS3(_bucket("atlanhq_atlan-live-app"))
+    sweep(PREFIX, tmp_path, run=s3, gh=_gh())
+    assert s3.removed == []
+
+
+def test_an_unreadable_repo_is_reported_not_swept(tmp_path):
+    """Deleted / renamed / invisible need different follow-ups than archived."""
+    s3 = FakeS3(_bucket("atlanhq_atlan-live-app", "atlanhq_atlan-mystery-app"))
+    result = sweep(
+        PREFIX,
+        tmp_path,
+        run=s3,
+        gh=_gh(fails=("atlanhq/atlan-mystery-app",)),
+    )
+    assert result["unknown"] == ["atlanhq_atlan-mystery-app"]
+    assert s3.removed == []
+
+
+def test_a_dry_run_deletes_nothing_and_rewrites_no_manifest(tmp_path):
+    s3 = FakeS3(_bucket("atlanhq_atlan-live-app", "atlanhq_atlan-dead-app"))
+    sweep(
+        PREFIX,
+        tmp_path,
+        run=s3,
+        gh=_gh(archived=("atlanhq/atlan-dead-app",)),
+        dry_run=True,
+    )
+    assert s3.removed == []
+    assert f"{BUCKET}/{PREFIX}/repos.json" not in s3.objects
+
+
+def test_everything_reading_as_archived_sweeps_nothing(tmp_path, capsys):
+    """A broken token must not be able to empty a dashboard."""
+    names = [f"atlanhq_atlan-app-{i}" for i in range(5)]
+    s3 = FakeS3(_bucket(*names))
+    result = sweep(
+        PREFIX,
+        tmp_path,
+        run=s3,
+        gh=_gh(archived=tuple(f"atlanhq/atlan-app-{i}" for i in range(5))),
+    )
+    assert s3.removed == []
+    assert len(result["refused"]) == 5
+    assert "sweeping none" in capsys.readouterr().err

--- a/.github/workflows/prune-dashboard-repo.yaml
+++ b/.github/workflows/prune-dashboard-repo.yaml
@@ -1,8 +1,19 @@
 # Prune Dashboard Repo — one-shot S3 cleanup for retired/renamed repos.
 #
-# Use when a repo is being removed from the central security dashboard
-# (k.atlan.dev/security-dashboard/). Triggered manually via workflow_dispatch
-# with the repo's dashboard slug (e.g. atlanhq_atlan-mongodb-app).
+# Use when a repo is being removed from a central dashboard
+# (k.atlan.dev/<dashboard_path>/). Triggered manually via workflow_dispatch.
+#
+# Two modes:
+#   Single slug (repo_slug set): remove exactly that repo from one prefix.
+#   Archived sweep (sweep_archived: true): find every repo in the named
+#     prefixes that GitHub reports as archived and remove those.
+#
+# The sweep exists because a manifest is rebuilt by LISTING the bucket, which has
+# no deletion path — so a repo that leaves the fleet keeps being enumerated
+# forever. publish_fleet_dashboard.py now omits departed repos on full-fleet
+# runs, but the per-repo publishers (security / conformance / test-readiness,
+# driven from each app repo's own update-dashboard.yml) have no full-fleet view
+# and cannot. FND-960.
 #
 # Removes:
 #   s3://kryptonite-store/security-dashboard/repos/<slug>.json
@@ -20,9 +31,25 @@ on:
   workflow_dispatch:
     inputs:
       repo_slug:
-        description: "Dashboard slug to remove (e.g. atlanhq_atlan-mongodb-app)"
-        required: true
+        description: "Dashboard slug to remove (e.g. atlanhq_atlan-mongodb-app). Leave empty when sweeping."
+        required: false
+        default: ""
         type: string
+      sweep_archived:
+        description: "Sweep every archived repo out of the prefixes named below (ignores repo_slug)"
+        required: false
+        default: false
+        type: boolean
+      sweep_prefixes:
+        description: "Prefixes to sweep, comma-separated. Only used when sweep_archived is true."
+        required: false
+        default: "conformance-dashboard,security-dashboard,test-readiness-dashboard,gate-enforcement-dashboard,renovate-dashboard"
+        type: string
+      sweep_dry_run:
+        description: "Sweep mode: report what would be removed and change nothing"
+        required: false
+        default: true
+        type: boolean
       dashboard_path:
         description: "S3 prefix under kryptonite-store"
         required: false
@@ -39,7 +66,16 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      # Mode selection lives entirely in `if:` expressions — no branching inside
+      # a run: block, per docs/standards/ci.md.
+      - name: Refuse a dispatch that names nothing to do
+        if: inputs.repo_slug == '' && !inputs.sweep_archived
+        run: |
+          echo "::error::pass repo_slug=<slug> for a single prune, or sweep_archived=true"
+          exit 1
+
       - name: Validate slug
+        if: inputs.repo_slug != ''
         env:
           SLUG: ${{ inputs.repo_slug }}
         run: |
@@ -59,6 +95,7 @@ jobs:
           role-to-assume: arn:aws:iam::733936409301:role/kryptonite-store_FullAccess
 
       - name: Delete per-repo data + history
+        if: inputs.repo_slug != '' && !inputs.sweep_archived
         env:
           SLUG: ${{ inputs.repo_slug }}
           PREFIX: ${{ inputs.dashboard_path }}
@@ -71,6 +108,7 @@ jobs:
           aws s3 rm "$HIST_KEY" || echo "(history JSONL was not present)"
 
       - name: Rebuild repos.json manifest
+        if: inputs.repo_slug != '' && !inputs.sweep_archived
         env:
           PREFIX: ${{ inputs.dashboard_path }}
         run: |
@@ -83,3 +121,26 @@ jobs:
             > /tmp/repos.json
           aws s3 cp /tmp/repos.json "s3://kryptonite-store/${PREFIX}/repos.json"
           echo "Manifest rebuilt — $(python3 -c 'import json; print(len(json.load(open("/tmp/repos.json"))))') repos remain"
+
+      # Org-wide read so the sweep can ask GitHub whether each stored repo is
+      # archived. No `repositories:` list — the manifest spans the whole fleet,
+      # and a token scoped to one repo would report every other repo as
+      # unreadable, which the script correctly refuses to act on.
+      - name: Mint fleet App token
+        id: app-token
+        if: inputs.sweep_archived
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          app-id: ${{ secrets.FLEET_APP_ID }}
+          private-key: ${{ secrets.FLEET_APP_PRIVATE_KEY }}
+          owner: atlanhq
+
+      - name: Sweep archived repos
+        if: inputs.sweep_archived
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PREFIXES: ${{ inputs.sweep_prefixes }}
+          DRY_RUN: ${{ inputs.sweep_dry_run && '--dry-run' || '' }}
+        run: |
+          python3 .github/scripts/sweep_archived_dashboard_repos.py \
+            --prefixes "$PREFIXES" $DRY_RUN

--- a/.github/workflows/prune-dashboard-repo.yaml
+++ b/.github/workflows/prune-dashboard-repo.yaml
@@ -64,7 +64,12 @@ jobs:
   prune:
     name: Prune
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    # Sweep mode walks every stored slug in every named prefix with one
+    # synchronous `gh api` call each (~630 repos across five prefixes), so it
+    # needs the same ceiling as the sibling fleet-wide dashboard jobs. A kill
+    # mid-prefix after sweep_dry_run=false leaves some prefixes mutated and
+    # others not.
+    timeout-minutes: 45
     steps:
       # Mode selection lives entirely in `if:` expressions — no branching inside
       # a run: block, per docs/standards/ci.md.
@@ -121,6 +126,12 @@ jobs:
             > /tmp/repos.json
           aws s3 cp /tmp/repos.json "s3://kryptonite-store/${PREFIX}/repos.json"
           echo "Manifest rebuilt — $(python3 -c 'import json; print(len(json.load(open("/tmp/repos.json"))))') repos remain"
+
+      # Sweep mode runs a script out of this repo; the single-slug path above
+      # only needs the AWS CLI, so the checkout is scoped to the sweep.
+      - name: Checkout application-sdk
+        if: inputs.sweep_archived
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # Org-wide read so the sweep can ask GitHub whether each stored repo is
       # archived. No `repositories:` list — the manifest spans the whole fleet,


### PR DESCRIPTION
Closes FND-960 (part 2 of 2 — connector-pulse half is atlanhq/connector-pulse#1018).

## The bug

Every dashboard `repos.json` is rebuilt by **listing the S3 bucket**, which has no deletion path. So a repo that leaves the fleet stays in the manifest forever: archiving stops it being *updated*, nothing removes it.

Discovery was never at fault — `gate_enforcement_scan.py` and `discover_org_consumers.py` both pass `gh repo list --no-archived`. The archived repo simply stops being scanned while its object keeps it enumerated.

Measured today — 2 archived `atlan-*-app` repos org-wide, present in 5 manifests:

| Prefix | Entries | Archived present |
|---|---|---|
| conformance-dashboard | 83 | workday-prism-analytics |
| security-dashboard | 115 | workday-prism-analytics, bigid |
| test-readiness-dashboard | 81 | workday-prism-analytics |
| gate-enforcement-dashboard | 168 | workday-prism-analytics |
| renovate-dashboard | 183 | workday-prism-analytics, bigid |

Consequences: `trackedFleetSize` overstated (so rollout-coverage denominators are wrong), a frozen panel that never clears, and — on the Pulse side — a fan-out that dispatches the tombstone and waits 420s for a `collectedAt` that can never move.

## What changed

**`publish_fleet_dashboard.py`** — a full-fleet scan *is* authoritative about membership, so its output is now passed to `refresh_manifest` as `scanned`, and stored objects absent from it are left out of the manifest. Single-repo runs pass nothing and keep listing-only behaviour, for the reason already in the docstring: a one-repo manifest would hide the fleet.

Omitted, **never deleted**. Exclusion is idempotent (recomputed every run) and reversible; an automated delete of dashboard history is not. `MAX_ORPHAN_FRACTION` (20%) is the rail — a partial scan makes most of the fleet look departed, and a manifest missing 80% of the fleet reads as a catastrophic regression on every panel at once.

This fixes **gate-enforcement** on its next scheduled run. It is the only prefix that routes through this script — `renovate-dashboard.yaml` is also a full-fleet publisher but writes its manifest with its **own inline** `aws s3 ls > repos.json` (lines 167-172), so it is a *fourth* site in this family and is deliberately not touched here. Consolidating it onto `publish_fleet_dashboard.py` is a genuine cleanup and belongs in its own PR; until then it relies on the sweep below.

**`sweep_archived_dashboard_repos.py` + `prune-dashboard-repo.yaml`** — the manifest fix only reaches the publisher that calls it. Security / conformance / test-readiness publish one repo at a time from each app repo's `update-dashboard.yml`, so they cannot distinguish a departed repo from one that just did not publish today; renovate-dashboard is full-fleet but writes its manifest inline. `sweep_archived: true` cleans all of them in one dispatch instead of a slug-per-prefix by hand.

It removes only repos GitHub reports as `archived: true`. A 404 (deleted / renamed / invisible to the token) is **reported and left alone** — the three causes need different follow-ups, and a token that lost scope would otherwise read as "the whole fleet was deleted". `sweep_dry_run` defaults to `true`, and a refusal exits nonzero so a green tick is never read as "nothing to clean".

## Verification

- `pytest .github/scripts/tests/` — **3391 passed**.
- `test_publish_fleet_dashboard.py` 14 → 19 cases; new `test_sweep_archived_dashboard_repos.py` with 10.
- `pre-commit run --files <changed>` — clean (ruff, ruff-format, isort, pyright).

## Note for review

- **Security-relevant control-plane change**: `.github/workflows/prune-dashboard-repo.yaml` gains inputs and a job step that deletes S3 objects, plus a fleet App token mint (`owner: atlanhq`, no `repositories:` list — the manifest spans the fleet, and a repo-scoped token would report every other repo as unreadable). Mode selection is entirely in `if:` expressions; no logic inside a `run:` block, per `docs/standards/ci.md`.
- `repo_slug` becomes optional; a dispatch naming neither a slug nor a sweep now fails fast rather than doing nothing.
- The weighting of the tests is deliberate — most cases pin what the sweep must *refuse*, since deleting a live repo's history is unrecoverable while a dead row on a panel is cosmetic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
