### PR TITLE
test(performance): remove the real-clock waits from the unit suite (FND-962)

### DIFF
--- a/application_sdk/execution/_temporal/worker.py
+++ b/application_sdk/execution/_temporal/worker.py
@@ -265,6 +265,14 @@ class AppWorker:
     ``PROMETHEUS_PUSHGATEWAY_URL``. Combined-mode deployments (FastAPI server
     in the same process) leave this off — ``/metrics`` already exposes the
     same series and pushing would double-count.
+
+    ``shutdown_drain_delay_seconds`` is the pre-teardown yield in
+    :meth:`__aexit__`, defaulting to :data:`SHUTDOWN_DRAIN_DELAY_SECONDS`. It is
+    a constructor parameter rather than a module constant read at the call site
+    so a test can set it to zero: three shutdown tests otherwise spent five real
+    seconds each asleep proving something about the *drain*, not about the
+    delay. The delay's own behaviour is asserted separately, by driving a worker
+    built with a non-zero value (FND-962).
     """
 
     def __init__(
@@ -275,12 +283,14 @@ class AppWorker:
         enable_pushgateway: bool = False,
         primary_app_name: str = "",
         task_queue: str = "",
+        shutdown_drain_delay_seconds: float = SHUTDOWN_DRAIN_DELAY_SECONDS,
     ) -> None:
         self._worker = worker
         self._start_event_params = start_event_params
         self._enable_pushgateway = enable_pushgateway
         self._primary_app_name = primary_app_name
         self._task_queue = task_queue
+        self._shutdown_drain_delay_seconds = shutdown_drain_delay_seconds
         self._pusher: PushGatewayClient | None = None
 
     async def _start_metrics_push(self) -> None:
@@ -386,7 +396,7 @@ class AppWorker:
             # the transport. Without this, a race between SIGTERM and
             # activity completion can leave orphaned task slots that block
             # shutdown for the entire graceful_shutdown_timeout.
-            await asyncio.sleep(SHUTDOWN_DRAIN_DELAY_SECONDS)
+            await asyncio.sleep(self._shutdown_drain_delay_seconds)
             await self._worker.__aexit__(exc_type, *args)
         finally:
             await self._drain_sizing()

--- a/application_sdk/infrastructure/_dapr/http.py
+++ b/application_sdk/infrastructure/_dapr/http.py
@@ -64,6 +64,12 @@ _DEFAULT_TIMEOUT = 30.0
 # wider than the credential fix it shipped with — see
 # https://github.com/atlanhq/application-sdk/issues/2995.
 _DEFAULT_RETRY_TOTAL = 3
+#: Base of the ladder above. A constructor parameter rather than a literal so a
+#: test can collapse the ladder to zero and still drive all
+#: ``_DEFAULT_RETRY_TOTAL + 1`` requests: the alternative is a unit test that
+#: sleeps out the real 2+4+8s budget to prove something about *propagation*
+#: (FND-962). Production never passes it.
+_DEFAULT_BACKOFF_FACTOR = 1.0
 
 # ---------------------------------------------------------------------------
 # Metrics
@@ -436,13 +442,14 @@ class AsyncDaprClient:
         base_url: str | None = None,
         timeout: float = _DEFAULT_TIMEOUT,
         retries: int = _DEFAULT_RETRY_TOTAL,
+        backoff_factor: float = _DEFAULT_BACKOFF_FACTOR,
     ):
         self._base_url = base_url or _dapr_base_url()
         transport = RetryTransport(
             transport=httpx.AsyncHTTPTransport(limits=_HTTP_POOL_LIMITS),
             retry=Retry(
                 total=retries,
-                backoff_factor=1.0,
+                backoff_factor=backoff_factor,
                 status_forcelist=[500, 502, 503, 504],
                 # Pin the retried transport errors to httpx-retries' own default
                 # set, stated explicitly so it can't silently narrow/widen if the

--- a/tests/unit/execution/test_worker.py
+++ b/tests/unit/execution/test_worker.py
@@ -13,6 +13,7 @@ from temporalio.exceptions import ActivityError
 from application_sdk.app.base import App
 from application_sdk.app.registry import AppRegistry, TaskRegistry
 from application_sdk.app.task import task
+from application_sdk.constants import SHUTDOWN_DRAIN_DELAY_SECONDS
 from application_sdk.contracts.base import Input, Output
 from application_sdk.errors.leaves import (
     AppTimeoutError,
@@ -31,10 +32,6 @@ from application_sdk.execution._temporal.worker import (
     create_worker,
     describe_exception_chain,
     read_core_poller_counts,
-)
-
-DRAIN_DELAY_PATCH = (
-    "application_sdk.execution._temporal.worker.SHUTDOWN_DRAIN_DELAY_SECONDS"
 )
 
 _MINIMAL_START_PARAMS = {
@@ -88,9 +85,15 @@ def _make_mock_client() -> mock.MagicMock:
     return client
 
 
-def _WorkerWrapperForDrain():
+def _WorkerWrapperForDrain(*, shutdown_drain_delay_seconds: float = 0.0):
     """A real ``AppWorker`` with its worker and pusher stubbed, so the test drives
     the production ``__aexit__`` — a fake would pass while shutdown stayed broken.
+
+    The drain delay defaults to zero here. These tests are about what
+    ``__aexit__`` flushes, not about the yield that precedes it, and the
+    production default of five seconds is five real seconds of sleep per test
+    (FND-962). The delay itself is asserted by
+    ``TestShutdownDrainDelay`` below, which is the only place that cares.
     """
     from application_sdk.execution._temporal.worker import AppWorker
 
@@ -103,6 +106,7 @@ def _WorkerWrapperForDrain():
     w._worker = _NullWorker()
     w._pusher = None
     w._start_event_params = {}
+    w._shutdown_drain_delay_seconds = shutdown_drain_delay_seconds
     return w
 
 
@@ -950,8 +954,20 @@ class TestShutdownDrainDelay:
     """
 
     @staticmethod
-    def _make_app_worker(inner: mock.AsyncMock) -> AppWorker:
-        return AppWorker(inner, start_event_params=_MINIMAL_START_PARAMS)
+    def _make_app_worker(inner: mock.AsyncMock, *, drain_delay: float) -> AppWorker:
+        """Build the wrapper with the delay under test.
+
+        Set through the constructor rather than by patching
+        ``SHUTDOWN_DRAIN_DELAY_SECONDS``: the delay is a parameter
+        ``AppWorker`` binds at construction (FND-962), so a patch of the module
+        constant would leave every one of these tests running on the production
+        five-second default.
+        """
+        return AppWorker(
+            inner,
+            start_event_params=_MINIMAL_START_PARAMS,
+            shutdown_drain_delay_seconds=drain_delay,
+        )
 
     @pytest.mark.asyncio
     async def test_without_drain_delay_activity_completion_preempted(self) -> None:
@@ -964,7 +980,7 @@ class TestShutdownDrainDelay:
         """
         inner = mock.AsyncMock()
         inner.__aexit__ = mock.AsyncMock(return_value=None)
-        app_worker = self._make_app_worker(inner)
+        app_worker = self._make_app_worker(inner, drain_delay=0)
 
         activity_completed = False
 
@@ -975,8 +991,7 @@ class TestShutdownDrainDelay:
 
         asyncio.create_task(inflight_activity())
 
-        with mock.patch(DRAIN_DELAY_PATCH, 0):
-            await app_worker.__aexit__(None, None, None)
+        await app_worker.__aexit__(None, None, None)
 
         # PROVES THE BUG: activity completion never ran before shutdown
         assert activity_completed is False
@@ -993,7 +1008,7 @@ class TestShutdownDrainDelay:
         """
         inner = mock.AsyncMock()
         inner.__aexit__ = mock.AsyncMock(return_value=None)
-        app_worker = self._make_app_worker(inner)
+        app_worker = self._make_app_worker(inner, drain_delay=0.01)
 
         activity_completed = False
 
@@ -1004,8 +1019,7 @@ class TestShutdownDrainDelay:
 
         asyncio.create_task(inflight_activity())
 
-        with mock.patch(DRAIN_DELAY_PATCH, 0.01):
-            await app_worker.__aexit__(None, None, None)
+        await app_worker.__aexit__(None, None, None)
 
         # PROVES THE FIX: activity completion ran before shutdown
         assert activity_completed is True
@@ -1017,7 +1031,7 @@ class TestShutdownDrainDelay:
         not just one."""
         inner = mock.AsyncMock()
         inner.__aexit__ = mock.AsyncMock(return_value=None)
-        app_worker = self._make_app_worker(inner)
+        app_worker = self._make_app_worker(inner, drain_delay=0.01)
 
         completions: list[str] = []
 
@@ -1029,8 +1043,7 @@ class TestShutdownDrainDelay:
         asyncio.create_task(inflight_activity("activity_2"))
         asyncio.create_task(inflight_activity("activity_3"))
 
-        with mock.patch(DRAIN_DELAY_PATCH, 0.01):
-            await app_worker.__aexit__(None, None, None)
+        await app_worker.__aexit__(None, None, None)
 
         assert set(completions) == {"activity_1", "activity_2", "activity_3"}
 
@@ -1040,12 +1053,23 @@ class TestShutdownDrainDelay:
         no pending completions."""
         inner = mock.AsyncMock()
         inner.__aexit__ = mock.AsyncMock(return_value=None)
-        app_worker = self._make_app_worker(inner)
+        app_worker = self._make_app_worker(inner, drain_delay=0)
 
-        with mock.patch(DRAIN_DELAY_PATCH, 0):
-            await app_worker.__aexit__(None, None, None)
+        await app_worker.__aexit__(None, None, None)
 
         inner.__aexit__.assert_called_once()
+
+    def test_the_default_delay_is_the_configured_one(self) -> None:
+        """Every test above sets the delay, so nothing else pins what a worker
+        built by ``create_worker`` actually waits. Without this, dropping the
+        default to zero would be invisible — and the deadlock this whole class
+        documents would be back with a green suite.
+        """
+        app_worker = AppWorker(
+            mock.AsyncMock(), start_event_params=_MINIMAL_START_PARAMS
+        )
+        assert app_worker._shutdown_drain_delay_seconds == SHUTDOWN_DRAIN_DELAY_SECONDS
+        assert SHUTDOWN_DRAIN_DELAY_SECONDS > 0
 
 
 class TestWorkerPoolQueueResolution:

--- a/tests/unit/infrastructure/test_connection_pool_config.py
+++ b/tests/unit/infrastructure/test_connection_pool_config.py
@@ -12,7 +12,10 @@ import pytest
 
 from application_sdk.clients.base import BaseClient
 from application_sdk.constants import _HTTP_POOL_LIMITS, _HTTP_POOL_TIMEOUT_SECONDS
-from application_sdk.infrastructure._dapr.http import AsyncDaprClient
+from application_sdk.infrastructure._dapr.http import (
+    _DEFAULT_RETRY_TOTAL,
+    AsyncDaprClient,
+)
 
 # ---------------------------------------------------------------------------
 # AsyncDaprClient pool configuration
@@ -102,11 +105,23 @@ class TestPoolTimeoutPropagation:
 
     @pytest.mark.asyncio
     async def test_dapr_client_pool_timeout_propagates(self):
-        """httpx.PoolTimeout must propagate up, not be swallowed."""
-        client = AsyncDaprClient(base_url="http://localhost:3500")
+        """httpx.PoolTimeout must propagate up, not be swallowed.
+
+        ``backoff_factor=0`` collapses the retry ladder without shortening it:
+        the client still makes ``_DEFAULT_RETRY_TOTAL + 1`` attempts and still
+        has to surface the last one, which is the property under test. On the
+        production factor of 1.0 the same assertion cost six real seconds of
+        sleep (FND-962); the ladder's own arithmetic is pinned by
+        ``test_retry_covers_connection_errors_with_widened_budget``.
+        """
+        client = AsyncDaprClient(base_url="http://localhost:3500", backoff_factor=0)
 
         # Inject a PoolTimeout-raising transport
+        attempts = 0
+
         async def always_pool_timeout(request: httpx.Request) -> httpx.Response:
+            nonlocal attempts
+            attempts += 1
             raise httpx.PoolTimeout("simulated pool exhaustion", request=request)
 
         try:
@@ -116,5 +131,10 @@ class TestPoolTimeoutPropagation:
         except AttributeError:
             pytest.skip("httpx internal structure changed; update test")
 
-        with pytest.raises(Exception):
+        with pytest.raises(httpx.PoolTimeout):
             await client._client.get("/v1.0/healthz")
+        # A PoolTimeout is a TimeoutException, so it is retried — the raise
+        # above is the exhausted ladder, not a first-attempt passthrough. Asserted
+        # so a future narrowing of retry_on_exceptions cannot make this test pass
+        # for the opposite reason.
+        assert attempts == _DEFAULT_RETRY_TOTAL + 1

--- a/tests/unit/testing/e2e/test_base_e2e.py
+++ b/tests/unit/testing/e2e/test_base_e2e.py
@@ -44,6 +44,7 @@ from application_sdk.testing.e2e.client import (
 from application_sdk.testing.e2e.credential import CredentialBody
 from application_sdk.testing.e2e.payload import AgentSpec, DatabaseSpec, RunMode
 from application_sdk.testing.e2e.substitutions import MustacheSubstitutions
+from application_sdk.testing.harness._poll import fake_clock
 
 
 def _make_connection_ref() -> ConnectionRef:
@@ -512,11 +513,30 @@ class TestSourceAvailabilityGate:
 class TestWorkerUpTier:
     """Worker-up-only assertions when no source is provisioned."""
 
+    @pytest.fixture(autouse=True)
+    def _fake_clock(self):
+        """Run the health-probe loop on a fake clock.
+
+        ``assert_worker_up`` polls through ``until_deadline``, so every test
+        below in which the worker never answers 2xx runs the budget out for
+        real. The old settings — interval ``0``, timeout ``1`` — turned that
+        into a one-second *spin* per test, four seconds across this class, and
+        interval ``0`` meant "poll once and give up" was never distinguishable
+        from "poll until the deadline" (FND-962).
+
+        The interval must stay above zero under the fake: its sleep advances the
+        clock, so a zero gap would never reach the deadline.
+        """
+        with fake_clock():
+            yield
+
     def _harness(self) -> _NoSourceTest:
         harness = _NoSourceTest()
         harness.source_available = False
-        harness.worker_health_poll_interval_seconds = 0
-        harness.worker_health_timeout_seconds = 1
+        # Three attempts, one interval apart: enough that a loop which gave up
+        # after the first probe would fail the attempt-count assertion below.
+        harness.worker_health_poll_interval_seconds = 1
+        harness.worker_health_timeout_seconds = 3
         return harness
 
     def test_test_method_runs_worker_up_only(
@@ -610,7 +630,10 @@ class TestWorkerUpTier:
         assert error.code == "PRECONDITION_WORKER_NOT_HEALTHY"
         assert error.url == harness.worker_health_url
         assert error.last_error == "HTTP 503"
-        assert error.attempts is not None and error.attempts >= 1
+        # It re-probed rather than giving up on the first 503: three attempts is
+        # the whole budget at this interval.
+        assert error.attempts == 3
+        assert error.elapsed_seconds == pytest.approx(2.0)
 
     def test_a_refused_connection_and_a_5xx_are_told_apart(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/testing/e2e/test_client.py
+++ b/tests/unit/testing/e2e/test_client.py
@@ -1631,7 +1631,15 @@ class TestFindRunCreatedSince:
     def test_polls_until_the_run_becomes_searchable(self):
         """AE serves this list from Elasticsearch, so a run committed just
         before the connection died can take a moment to appear. One empty
-        answer is not the end of the search."""
+        answer is not the end of the search.
+
+        Under ``fake_clock`` rather than ``patch(_SLEEP)``: this loop is a
+        *deadline* loop, so it sleeps through ``_poll``'s swappable default and
+        never touches ``sleep_async``. Patching the retry seam here left the two
+        ``interval_seconds`` gaps running on the real clock — twenty seconds of
+        the unit suite spent proving nothing the fake does not prove. See
+        FND-962.
+        """
         client = _make_client()
         late = {"data": [{"guid": "r-late", "created_at": "2026-08-20T13:58:46Z"}]}
         with (
@@ -1640,13 +1648,16 @@ class TestFindRunCreatedSince:
                 "_request",
                 side_effect=[(200, {"data": []}), (200, {"data": []}), (200, late)],
             ) as mock_req,
-            patch(_SLEEP),
+            fake_clock() as clock,
         ):
             lookup = client.find_run_created_since(
                 "slug-x", self._SINCE, timeout_seconds=60, interval_seconds=10
             )
         assert lookup.run_id == "r-late"
         assert mock_req.call_count == 3
+        # The cadence itself, which the inert patch could not see: two full
+        # intervals between the three reads.
+        assert clock.slept == [10, 10]
 
     def test_clock_skew_window_admits_a_slightly_earlier_run(self):
         """The runner's clock and the tenant's are compared directly, so a run

--- a/tests/unit/testing/e2e/test_deployed_manifest_identity.py
+++ b/tests/unit/testing/e2e/test_deployed_manifest_identity.py
@@ -11,6 +11,14 @@ Three layers, all tenant-free:
 
 The last group is the point of the ticket: a leg that asserts against the wrong
 app must go red, and every *unanswerable* outcome must not.
+
+The waiting ones run under
+:func:`~application_sdk.testing.harness._poll.fake_clock`. They used to patch
+``time.sleep``, which is inert here: ``_read_superseding_published_version``
+drives ``until_deadline``, and that sleeps through ``_poll``'s own swappable
+default, captured at import. So the patch silenced nothing and the retries ran
+on the real clock — five seconds across this file for gaps whose only job is to
+separate two mocked reads (FND-962).
 """
 
 from __future__ import annotations
@@ -30,6 +38,7 @@ from application_sdk.testing.e2e._manifest_identity import (
 )
 from application_sdk.testing.e2e.base import _supersedes
 from application_sdk.testing.e2e.client import AEWorkflowClient, PublishedVersion
+from application_sdk.testing.harness._poll import fake_clock
 from application_sdk.testing.harness.automation_engine.wire import (
     first_version_row as _first_version_row,
 )
@@ -342,7 +351,7 @@ class TestAssertDeployedManifestMatches:
             patch.object(
                 harness.client, "get_published_version", return_value=seed_echo
             ),
-            patch("time.sleep"),
+            fake_clock(),
         ):
             harness._assert_deployed_manifest_matches("mysql-abc")
 
@@ -353,7 +362,7 @@ class TestAssertDeployedManifestMatches:
         )
         with (
             patch.object(harness.client, "get_published_version", return_value=None),
-            patch("time.sleep"),
+            fake_clock(),
         ):
             harness._assert_deployed_manifest_matches("mysql-abc")
 
@@ -366,7 +375,7 @@ class TestAssertDeployedManifestMatches:
             patch.object(
                 harness.client, "get_published_version", return_value=_published({})
             ),
-            patch("time.sleep"),
+            fake_clock(),
         ):
             harness._assert_deployed_manifest_matches("mysql-abc")
 
@@ -384,7 +393,7 @@ class TestAssertDeployedManifestMatches:
         ]
         with (
             patch.object(harness.client, "get_published_version", side_effect=reads),
-            patch("time.sleep"),
+            fake_clock(),
             pytest.raises(DeployedManifestMismatchError),
         ):
             harness._assert_deployed_manifest_matches("mysql-abc")
@@ -403,7 +412,7 @@ class TestAssertDeployedManifestMatches:
             patch.object(
                 harness.client, "get_published_version", return_value=unnumbered
             ),
-            patch("time.sleep"),
+            fake_clock(),
         ):
             harness._assert_deployed_manifest_matches("mysql-abc")
 
@@ -420,7 +429,7 @@ class TestAssertDeployedManifestMatches:
         ]
         with (
             patch.object(harness.client, "get_published_version", side_effect=reads),
-            patch("time.sleep"),
+            fake_clock(),
             pytest.raises(DeployedManifestMismatchError),
         ):
             harness._assert_deployed_manifest_matches("mysql-abc")
@@ -435,7 +444,7 @@ class TestAssertDeployedManifestMatches:
         reads = [_published({}, version=1000), None]
         with (
             patch.object(harness.client, "get_published_version", side_effect=reads),
-            patch("time.sleep"),
+            fake_clock(),
         ):
             harness._assert_deployed_manifest_matches("mysql-abc")
 
@@ -450,7 +459,7 @@ class TestAssertDeployedManifestMatches:
         ]
         with (
             patch.object(harness.client, "get_published_version", side_effect=reads),
-            patch("time.sleep"),
+            fake_clock(),
             pytest.raises(DeployedManifestMismatchError),
         ):
             harness._assert_deployed_manifest_matches("mysql-abc")


### PR DESCRIPTION
Follow-up to FND-961 (#3479), which parallelised the unit suite. Parallelism cannot split a single test, so the ~48s the suite spent *asleep* stayed a hard floor — one test alone held 20s of a 50s local wall, two thirds of a CI worker's entire budget.

## Three of the waits were tests patching a sleep the code never calls

FND-962 called this out for the 20s test. It turned out to be the pattern, not the exception:

| Test | Patched | Actually sleeps through |
| -- | -- | -- |
| `test_polls_until_the_run_becomes_searchable` | `client.sleep_async` — the AE *retry* seam | `_poll._async_sleep`, via `until_deadline_async` |
| 8 tests in `test_deployed_manifest_identity.py` | `time.sleep` | `_poll._sleep`, via `until_deadline` — captured at import, so the patch cannot reach it |
| `TestWorkerUpTier` ×4 | nothing — interval `0`, timeout `1` | a one-second **spin**, not a sleep |

All now run under `_poll.fake_clock()`, the seam that already existed for exactly this. Two of them now prove *more* than they did:

- the AE poll asserts `clock.slept == [10, 10]` — the cadence the inert patch could not see;
- the worker-health probe asserts `attempts == 3` and `elapsed == 2.0`. Under interval `0` the old tests could not tell "polls once and gives up" from "polls to the deadline" at all.

## Two real constants became parameters

- **`AppWorker(shutdown_drain_delay_seconds=...)`**, defaulting to `SHUTDOWN_DRAIN_DELAY_SECONDS`. Three shutdown tests spent 5 real seconds each proving something about the *drain*, not the delay. The existing delay-behaviour tests now set it through the constructor rather than patching the module constant — which the parameter would have made inert, leaving them silently on the 5s production default. Added `test_the_default_delay_is_the_configured_one`: without it nothing pinned what a `create_worker`-built worker actually waits, and dropping the default to zero would reintroduce the ARUN deadlock with a green suite.
- **`AsyncDaprClient(backoff_factor=...)`**, defaulting to `_DEFAULT_BACKOFF_FACTOR` (1.0). The pool-timeout test collapses the ladder without shortening it: still `_DEFAULT_RETRY_TOTAL + 1` attempts, 0s instead of 6.3s. Also tightened `pytest.raises(Exception)` to `pytest.raises(httpx.PoolTimeout)` and asserted the attempt count, so a future narrowing of `retry_on_exceptions` cannot make the test pass for the opposite reason. The ladder's own arithmetic stays pinned by `test_retry_covers_connection_errors_with_widened_budget`, which reads the default.

## Verification

**Every rewritten test was checked by reverting the behaviour it claims to prove**, not by watching it pass. Six mutations, each turning the corresponding test(s) red:

1. `find_run_created_since` budget → `0` ⇒ the AE poll test fails
2. drop `_drain_sizing()` from `__aexit__` ⇒ `test_shutdown_drains_buffered_sizing_rows` fails
3. production drain default → `0` ⇒ `test_the_default_delay_is_the_configured_one` fails
4. `Retry(total=0)` ⇒ the pool-timeout test fails
5. manifest wait budget → `0` ⇒ all three "does not end the wait" tests fail
6. worker-health budget → `0` ⇒ the typed-error test fails on `attempts == 3`

**Durations** (`-n auto`, local, before → after): the `20.01s / 5.73s / 5.01s ×3 / 2.01s / ~1.0s ×7` block is gone. Nothing left above 1s is a wait — the remainder is parquet writes, subprocess spawns and import-cost probes, matching the ticket's explicit exemptions.

`9019 passed, 9 skipped` serially. Conformance `detect --scope sdk` before and after: the same four pre-existing WARNs on the two touched source files, no new findings.

## Notes for the reviewer

- **No CI change here.** #3479 already adds `--durations=25 --durations-min=1.0` to `.github/actions/unit-tests/action.yaml`, which is where FND-962's second acceptance criterion gets read.
- **Not stacked on #3479** — the file sets are disjoint, so the two merge in either order.
- Running this branch under `-n auto` *without* #3479's `tests/conftest.py` pyatlan preload reproduces that PR's documented `pydantic.v1 ConfigError: duplicate validator function` failure in `test_atlas_reads.py`. Pre-existing, dynamic in which worker draws it (18 failures on the base tree, 1 on this one), and fixed by #3479 rather than by anything here.
- The two remaining 1.01s `test_upload_asset_validation` entries are deliberately left alone: real subprocess spawns against a deliberately hung child, the same category as the exempted `test_run_fault_isolated.py`. Shaving their 1.0s timeout would trade sleep for flake on a loaded runner.

Closes FND-962.
