### PR TITLE
ci(sdr-e2e): stop the harness resolving an objectstore binding it cannot have

### DIFF
--- a/.github/actions/sdr-e2e/action.yaml
+++ b/.github/actions/sdr-e2e/action.yaml
@@ -752,6 +752,22 @@ runs:
         # Read by BaseE2ETest.setup_method(): "false" degrades the full-DAG
         # e2e to a worker-up-only check when no source is provisioned.
         E2E_SOURCE_AVAILABLE: ${{ inputs.source-available }}
+        # The host pytest harness is a test CLIENT: no daprd, and no components
+        # directory. `ObservabilityBase._components_dir()` resolves to
+        # `DAPR_COMPONENTS_PATH` or `./components`, and neither exists here --
+        # the CI components this action selects land in `ci-deploy/components`,
+        # which is mounted into the worker container, not the runner. So every
+        # observability flush resolved the `objectstore` binding, raised
+        # StorageBindingNotFoundError, and logged a full traceback at WARNING.
+        # Non-fatal by design, but pure noise: the harness has no deployment
+        # store to ship its own telemetry to, and pointing it at the CI
+        # component would not help either (bindings.localstorage, rootPath
+        # /tmp/atlan-data -- a path inside the container).
+        #
+        # Only connectors that set pytest's `log_cli` ever SAW it, because the
+        # SDK emits this one through stdlib `logging`, not loguru. The failing
+        # lookup happened on every connector regardless.
+        ATLAN_ENABLE_OBSERVABILITY_STORE_SINK: "false"
       run: |
         mkdir -p results
         set +e


### PR DESCRIPTION
## What

Adds `ATLAN_ENABLE_OBSERVABILITY_STORE_SINK: "false"` to the `env:` of the `Run SDR integration tests` step in `.github/actions/sdr-e2e/action.yaml`. One env var, one step, no logic change.

## Why

The host pytest harness runs on the GH runner, not in the worker container: no daprd, no components directory. `ObservabilityBase._components_dir()` resolves to `DAPR_COMPONENTS_PATH` or `./components`, and this action exports neither — the CI components it selects are written to `ci-deploy/components`, which is mounted into the container.

So every observability flush in the harness process resolved the `objectstore` binding, raised `StorageBindingNotFoundError`, and logged a full traceback at WARNING:

```
WARNING  root — Deployment objectstore upload failed (non-fatal)
Traceback (most recent call last):
  ...application_sdk/observability/observability.py:286 _upload_and_delete
  ...application_sdk/storage/binding.py:772 _create_store_core
application_sdk.storage.errors.StorageBindingNotFoundError: [AAF-STR-003]
No Dapr component named 'objectstore' found in components | binding_name=objectstore
```

Non-fatal by design (`_upload_and_delete` catches and warns), so e2e stayed green everywhere — but the lookup can never succeed, and the harness has no deployment store to ship its own telemetry to in the first place.

## Why not point DAPR_COMPONENTS_PATH at ci-deploy/components

That `objectstore.yaml` is `bindings.localstorage` with `rootPath: /tmp/atlan-data` — a path inside the worker container. Making the host harness write test-client telemetry to the runner's `/tmp/atlan-data` would silence the warning by doing something meaningless. Turning the sink off is the honest fix.

## Blast radius

Every connector calling this action, in the same form — the action has exactly one `uv run pytest` invocation, and `tests-reusable.yaml` has exactly one `sdr-e2e@main` invocation. Everything pins `@main`, so it lands without a per-repo bump.

Worth setting expectations: most connectors' logs will look **identical** after this. The failing lookup happened on every connector, but only ones that set pytest's `log_cli` ever *saw* it, because the SDK emits this warning through stdlib `logging` rather than loguru — everyone else had no handler attached to print it. `atlan-mysql-app` was the one with the lights on ([atlanhq/atlan-mysql-app#550](https://github.com/atlanhq/atlan-mysql-app/pull/550), which drops its `log_cli` separately). The win here is that the dead lookup stops happening, not visible noise reduction.

## Verification

- `action.yaml` parses; the step's `env` block resolves to the 4 expected keys.
- Observed on [atlan-mysql-app run 33119883541](https://github.com/atlanhq/atlan-mysql-app/actions/runs/33119883541/job/98684808435).

Refs: FND-964

🤖 Generated with [Claude Code](https://claude.com/claude-code)
