### PR TITLE
ci(renovate): reap self-healing lock refusals instead of freezing them (FND-909)

### DIFF
--- a/.github/scripts/renovate_lock_refusal_census.py
+++ b/.github/scripts/renovate_lock_refusal_census.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""Census of frozen lock refusals across the fleet (FND-909).
+
+The verdict on whether the lock lane is healthy — and deliberately not the state
+of any named PR. `recreateClosed: true` plus a four-hourly cron churns the PR
+population faster than a ticket is read: over two days the frozen set held at
+five while its membership rotated by four repos. Checking the PR numbers a
+ticket happens to name proves only that the lane moved, never that it recovered.
+So the signal is the *census*: how many open lock-maintenance PRs carry a
+refusal tripwire right now, which repos, and how long each has been stuck.
+
+Usage::
+
+    GITHUB_TOKEN=... python3 renovate_lock_refusal_census.py
+    GITHUB_TOKEN=... python3 renovate_lock_refusal_census.py --json
+
+Success criterion after the reaper lands: **no `window-empty` PR survives two
+consecutive fleet passes.** The cron is every four hours, so any such PR whose
+head is older than ~8h means the reaper did not fire and the fix is not working.
+The script exits 1 when it finds one, which is what makes it usable as a check
+rather than a report someone has to read.
+
+A `stale_standing` count is reported separately and does *not* fail the run: a
+yanked pin or an unsatisfiable floor is meant to stay red until a human clears
+it. It is surfaced because a standing fault that sits for days is a different
+problem worth seeing, not because the reaper should have taken it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import datetime as dt
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Optional
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from renovate_reap_refused_locks import (  # noqa: E402
+    BRANCH,
+    is_tripwire,
+    refusal_reason,
+)
+from renovate_uv_lock_bounded import SELF_HEALING_REFUSALS  # noqa: E402
+
+API_ROOT = "https://api.github.com"
+
+# Two fleet passes at the 4-hourly cron, plus a pass's own runtime. A
+# window-empty refusal older than this was not reaped when it should have been.
+SURVIVED_TWO_PASSES = dt.timedelta(hours=9)
+
+
+def _get(token: str, url: str) -> object:
+    req = urllib.request.Request(
+        url,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        return json.loads(resp.read().decode())
+
+
+def open_lock_prs(token: str) -> list[dict]:
+    """Every open lock-maintenance PR in the org, paginated to completion."""
+    out: list[dict] = []
+    page = 1
+    while True:
+        q = urllib.parse.quote(f"org:atlanhq is:pr is:open head:{BRANCH}", safe=":/")
+        data = _get(token, f"{API_ROOT}/search/issues?q={q}&per_page=100&page={page}")
+        items = data.get("items", [])  # type: ignore[union-attr]
+        out.extend(items)
+        if len(items) < 100:
+            return out
+        page += 1
+        if page > 10:  # the search API's own 1000-item ceiling
+            return out
+
+
+def inspect(token: str, repo: str, number: int) -> tuple[str, Optional[str], str]:
+    """``(verdict, reason, head_committed_at)`` for one PR.
+
+    ``head_committed_at`` is the right clock, not ``created_at``: Renovate
+    rewrites a lock branch in place, so a PR opened last week may carry a
+    refusal written an hour ago.
+    """
+    files = _get(token, f"{API_ROOT}/repos/{repo}/pulls/{number}/files?per_page=100")
+    names = [f["filename"] for f in files]  # type: ignore[union-attr]
+    pr = _get(token, f"{API_ROOT}/repos/{repo}/pulls/{number}")
+    head_sha = pr["head"]["sha"]  # type: ignore[index]
+    commit = _get(token, f"{API_ROOT}/repos/{repo}/commits/{head_sha}")
+    committed = commit["commit"]["committer"]["date"]  # type: ignore[index]
+    if len(names) != 1 or names[0].rsplit("/", 1)[-1] != "uv.lock":
+        return "ordinary", None, committed
+    contents = _get(token, f"{API_ROOT}/repos/{repo}/contents/{names[0]}?ref={BRANCH}")
+    text = base64.b64decode(contents["content"]).decode(  # type: ignore[index]
+        errors="replace"
+    )
+    reason = refusal_reason(text)
+    if reason is None:
+        # Either an ordinary single-file refresh or a pre-FND-909 unstamped
+        # tripwire. `is_tripwire` is what tells them apart — the presence of an
+        # `[options]` table does not, because uv writes one of its own in any
+        # repo that declares a bound in pyproject.toml.
+        verdict = "unstamped_tripwire" if is_tripwire(text) else "ordinary"
+        return verdict, None, committed
+    return "refusal", reason, committed
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="machine-readable output")
+    args = parser.parse_args(argv)
+
+    token = os.environ.get("GITHUB_TOKEN", "")
+    if not token:
+        print("GITHUB_TOKEN is not set", file=sys.stderr)
+        return 1
+
+    now = dt.datetime.now(dt.timezone.utc)
+    rows: list[dict] = []
+    for pr in open_lock_prs(token):
+        repo = pr["repository_url"].split("/repos/", 1)[1]
+        try:
+            verdict, reason, committed = inspect(token, repo, pr["number"])
+        except (urllib.error.URLError, TimeoutError, KeyError, ValueError) as exc:
+            print(f"::warning::could not inspect {repo}#{pr['number']}: {exc}")
+            continue
+        head = dt.datetime.fromisoformat(committed.replace("Z", "+00:00"))
+        rows.append(
+            {
+                "repo": repo,
+                "number": pr["number"],
+                "verdict": verdict,
+                "reason": reason,
+                "head_committed_at": committed,
+                "age_hours": round((now - head).total_seconds() / 3600, 1),
+            }
+        )
+
+    frozen = [
+        r
+        for r in rows
+        if r["reason"] in SELF_HEALING_REFUSALS
+        and r["age_hours"] > SURVIVED_TWO_PASSES.total_seconds() / 3600
+    ]
+    standing = [
+        r
+        for r in rows
+        if r["verdict"] == "refusal" and r["reason"] not in SELF_HEALING_REFUSALS
+    ]
+    unstamped = [r for r in rows if r["verdict"] == "unstamped_tripwire"]
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "total_open": len(rows),
+                    "frozen_self_healing": frozen,
+                    "standing_faults": standing,
+                    "unstamped_tripwires": unstamped,
+                },
+                indent=2,
+            )
+        )
+    else:
+        print(f"open lock-maintenance PRs: {len(rows)}")
+        print(
+            f"  ordinary:            {sum(1 for r in rows if r['verdict'] == 'ordinary')}"
+        )
+        print(f"  unstamped tripwire:  {len(unstamped)}")
+        print(f"  standing faults:     {len(standing)}")
+        print(f"  FROZEN self-healing: {len(frozen)}")
+        for r in frozen + standing + unstamped:
+            print(
+                f"    {r['repo']}#{r['number']}  {r['verdict']}"
+                f"/{r['reason'] or '-'}  {r['age_hours']}h"
+            )
+
+    if frozen:
+        print(
+            f"::error::{len(frozen)} self-healing refusal(s) survived two fleet "
+            "passes — the reaper is not firing",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/renovate_reap_refused_locks.py
+++ b/.github/scripts/renovate_reap_refused_locks.py
@@ -210,20 +210,53 @@ def find_refusal(token: str, repo: str, fetch: Fetch = _request) -> Optional[dic
     return pr if should_reap(files, lock_text) else None
 
 
+def is_dry_run(renovate_dry_run: str | None, flag: bool) -> bool:
+    """Would this pass be a dry run?
+
+    Renovate's own contract, mirrored rather than reinvented: the workflow sets
+    ``RENOVATE_DRY_RUN`` to the literal string ``null`` for a live run and to a
+    mode name (``full``, ``extract``, ``lookup``) otherwise. Anything that is
+    not ``null`` is a dry run, so an unrecognised mode fails safe rather than
+    deleting branches.
+
+    This matters more here than for the Renovate step it precedes: a dry run
+    that reaped for real would delete lock-maintenance branches across the whole
+    matrix and then skip opening the replacements, which is strictly worse than
+    the freeze this script exists to clear.
+    """
+    if flag:
+        return True
+    value = (renovate_dry_run or "").strip()
+    return value not in ("", "null")
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--repo", required=True, help="owner/name")
+    parser.add_argument(
+        "--repo",
+        default=os.environ.get("TARGET_REPO", ""),
+        help="owner/name; defaults to $TARGET_REPO",
+    )
     parser.add_argument(
         "--dry-run",
         action="store_true",
-        help="report what would be deleted and delete nothing",
+        help=(
+            "report what would be deleted and delete nothing. Also implied by "
+            "$RENOVATE_DRY_RUN being anything other than 'null'."
+        ),
     )
     args = parser.parse_args(argv)
+
+    if not args.repo:
+        print("--repo (or $TARGET_REPO) is required", file=sys.stderr)
+        return 1
 
     token = os.environ.get("GITHUB_TOKEN", "")
     if not token:
         print("GITHUB_TOKEN is not set", file=sys.stderr)
         return 1
+
+    dry_run = is_dry_run(os.environ.get("RENOVATE_DRY_RUN"), args.dry_run)
 
     try:
         pr = find_refusal(token, args.repo)
@@ -243,7 +276,7 @@ def main(argv: list[str] | None = None) -> int:
         f"({BRANCH}, head {pr['head']['sha'][:7]}) — deleting the branch so "
         "this pass rebuilds it"
     )
-    if args.dry_run:
+    if dry_run:
         print("::notice::dry run, branch left in place")
         return 0
 

--- a/.github/scripts/renovate_reap_refused_locks.py
+++ b/.github/scripts/renovate_reap_refused_locks.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+"""Delete lock-maintenance branches whose refusal will clear itself (FND-909).
+
+Runs once per repo, immediately *before* Renovate in the same matrix job of
+``renovate.yaml``, so a reaped branch is rebuilt in the same pass — there is no
+window where the repo has no lock PR, and no delete/recreate churn visible in
+the PR timeline.
+
+The problem
+-----------
+``renovate_uv_lock_bounded.withhold()`` refuses by writing a lock the image
+build cannot install, which reds a required check and holds the branch. That is
+correct and deliberate. What is missing is any way out: the tripwire carries no
+clock, and Renovate re-runs ``postUpgradeTasks`` only when a package file
+changes, the branch conflicts, or a human ticks rebase. So a refusal written at
+T is still red at T+7d even though the condition that caused it expired at T+3d.
+
+The fleet cron is every four hours against a three-day bound, so after any
+successful lock merge the bound usually admits nothing on the next pass while
+Renovate's unbounded resolve has moved — which is exactly the refusal condition.
+A permanent freeze is therefore the *modal* outcome of the lane, not an edge
+case. Measured 2026-08-28: five frozen PRs, including all four canonical apps.
+
+Why not reap on a clock
+-----------------------
+``conformance.renovate.classify.bounded_lock_refusal_expired`` already detects
+this shape, but it cannot tell which of the five refusal paths wrote the
+tripwire, so it has to prove expiry by branch age (head older than the window).
+That is sound, and too slow: it waits a full window before recovering, when the
+bound may have admitted something four hours in. Recovering a day and a half
+late on average defeats the reason the lane runs every four hours.
+
+So the driver now stamps *why* it refused, and this reaps only the reason that
+heals on its own. A yanked-pin wedge or a broken interpreter keeps its tripwire
+and stays red for a human — reaping those would recycle them every four hours
+and hide a standing fault behind a lane that looks busy.
+
+Safety
+------
+Deletes only a branch that satisfies every one of:
+
+* the branch is exactly ``BRANCH`` (the lock-maintenance branch of the shared
+  preset) — never an arbitrary or human branch,
+* it has an open PR authored by the fleet app,
+* the PR's only changed file is a ``uv.lock``,
+* that lock's ``[options]`` table carries a refusal stamp, and
+* the stamped reason is in ``SELF_HEALING_REFUSALS``.
+
+An *unstamped* tripwire is left alone. Locks refused before this change carry no
+reason, and treating "no reason given" as self-healing is the one mistake that
+would recycle a real wedge forever. Those are triaged by hand once; every
+refusal written from now on is stamped.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from typing import Callable, Optional
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from renovate_uv_lock_bounded import SELF_HEALING_REFUSALS  # noqa: E402
+
+API_ROOT = "https://api.github.com"
+
+# The shared preset's lockFileMaintenance branch. Hard-coded rather than taken
+# as an argument: this script deletes branches, and the set it may delete from
+# should not be widenable by a caller's typo.
+BRANCH = "renovate/lock-file-maintenance"
+
+# The stamp withhold() writes, as it appears in the lock:
+#     exclude-newer-span = "P3D"  # refusal: window-empty
+STAMP = "# refusal:"
+
+Fetch = Callable[[str, str, Optional[str]], object]
+
+
+def _request(token: str, url: str, method: str = "GET") -> object:
+    req = urllib.request.Request(
+        url,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+        method=method,
+    )
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        body = resp.read().decode()
+        return json.loads(body) if body else None
+
+
+def options_lines(lock_text: str) -> list[str]:
+    """The body lines of the lock's ``[options]`` table, or []."""
+    body: list[str] = []
+    in_options = False
+    for line in lock_text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("[options]"):
+            in_options = True
+            continue
+        # Any other table header ends [options]; [options.*] subtables do not.
+        if (
+            in_options
+            and stripped.startswith("[")
+            and not stripped.startswith("[options")
+        ):
+            break
+        if in_options:
+            body.append(stripped)
+    return body
+
+
+def is_tripwire(lock_text: str) -> bool:
+    """Did ``withhold()`` write this ``[options]`` table, rather than uv?
+
+    The same discriminator ``conformance.renovate.classify.lock_refusal_window``
+    uses, and for the same reason: uv records both ``exclude-newer`` and
+    ``exclude-newer-span`` when a repo declares a bound in its ``pyproject.toml``
+    (``atlan-bw-app`` does), while the driver's tripwire is a lone
+    ``exclude-newer-span``. Testing only for the presence of an ``[options]``
+    table calls every natively-bounded repo a refusal.
+    """
+    keys = [line.partition("=")[0].strip() for line in options_lines(lock_text)]
+    if "exclude-newer" in keys:
+        return False
+    return "exclude-newer-span" in keys
+
+
+def refusal_reason(lock_text: str) -> Optional[str]:
+    """The stamped refusal reason in a lock's tripwire, or None.
+
+    None covers three genuinely different cases that all mean "do not reap":
+    no tripwire at all (an ordinary lock, bounded or not), a table uv wrote
+    itself, and a tripwire from before stamping existed. Collapsing them is
+    deliberate — every one of them is a branch this script must not touch, and
+    distinguishing them would invite a caller to act on the difference. The
+    census, which does need to tell an unstamped tripwire from an ordinary
+    lock, asks :func:`is_tripwire` for that instead.
+    """
+    if not is_tripwire(lock_text):
+        return None
+    for line in options_lines(lock_text):
+        if STAMP in line:
+            return line.split(STAMP, 1)[1].strip()
+    return None
+
+
+def lone_lock(files: list[str]) -> Optional[str]:
+    """The path if ``files`` is exactly one ``uv.lock``, else None.
+
+    Requiring a lone lock is what separates a refusal from an ordinary lock
+    refresh that happens to carry an ``[options]`` table: withhold() writes the
+    baseline back, so a refusal can never touch a second file.
+    """
+    if len(files) == 1 and files[0].rsplit("/", 1)[-1] == "uv.lock":
+        return files[0]
+    return None
+
+
+def should_reap(files: list[str], lock_text: str) -> bool:
+    """Is this PR a refusal that will clear itself on the next resolve?"""
+    if lone_lock(files) is None:
+        return False
+    return refusal_reason(lock_text) in SELF_HEALING_REFUSALS
+
+
+def find_refusal(token: str, repo: str, fetch: Fetch = _request) -> Optional[dict]:
+    """The open lock-maintenance PR on ``repo`` if it is a self-healing refusal.
+
+    Returns the PR payload (for logging) or None. Any transport failure raises:
+    a reaper that silently does nothing on an API blip is indistinguishable from
+    a healthy lane, and this script's whole purpose is to be the thing that
+    notices.
+    """
+    owner, name = repo.split("/", 1)
+    prs = fetch(
+        token,
+        f"{API_ROOT}/repos/{owner}/{name}/pulls?state=open&head={owner}:{BRANCH}",
+        None,
+    )
+    if not prs:
+        return None
+    pr = prs[0]  # type: ignore[index]
+    files_payload = fetch(
+        token,
+        f"{API_ROOT}/repos/{owner}/{name}/pulls/{pr['number']}/files?per_page=100",
+        None,
+    )
+    files = [f["filename"] for f in files_payload]  # type: ignore[union-attr]
+    path = lone_lock(files)
+    if path is None:
+        # Short-circuit before fetching contents. Same predicate should_reap
+        # applies, called through the same helper so the two cannot drift.
+        return None
+    contents = fetch(
+        token,
+        f"{API_ROOT}/repos/{owner}/{name}/contents/{path}?ref={BRANCH}",
+        None,
+    )
+    lock_text = base64.b64decode(contents["content"]).decode(  # type: ignore[index]
+        errors="replace"
+    )
+    return pr if should_reap(files, lock_text) else None
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", required=True, help="owner/name")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="report what would be deleted and delete nothing",
+    )
+    args = parser.parse_args(argv)
+
+    token = os.environ.get("GITHUB_TOKEN", "")
+    if not token:
+        print("GITHUB_TOKEN is not set", file=sys.stderr)
+        return 1
+
+    try:
+        pr = find_refusal(token, args.repo)
+    except (urllib.error.URLError, TimeoutError, KeyError, ValueError) as exc:
+        # Loud, and non-fatal to the pass: Renovate still runs after this step,
+        # so a reaper outage delays recovery by one cycle rather than stopping
+        # the lane. Exit 0 would make the failure invisible in the job summary.
+        print(f"::warning::reaper could not inspect {args.repo}: {exc}")
+        return 0
+
+    if pr is None:
+        print(f"{args.repo}: no self-healing lock refusal to reap")
+        return 0
+
+    print(
+        f"{args.repo}: PR #{pr['number']} is a self-healing lock refusal "
+        f"({BRANCH}, head {pr['head']['sha'][:7]}) — deleting the branch so "
+        "this pass rebuilds it"
+    )
+    if args.dry_run:
+        print("::notice::dry run, branch left in place")
+        return 0
+
+    owner, name = args.repo.split("/", 1)
+    try:
+        _request(
+            token,
+            f"{API_ROOT}/repos/{owner}/{name}/git/refs/heads/{BRANCH}",
+            method="DELETE",
+        )
+    except (urllib.error.URLError, TimeoutError) as exc:
+        print(f"::warning::reaper could not delete {args.repo}@{BRANCH}: {exc}")
+        return 0
+    print(f"::notice::reaped {args.repo}#{pr['number']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/renovate_uv_lock_bounded.py
+++ b/.github/scripts/renovate_uv_lock_bounded.py
@@ -120,6 +120,37 @@ except ImportError:  # pragma: no cover - packaging is effectively universal
     Version = None  # type: ignore[assignment]
     InvalidVersion = ValueError  # type: ignore[assignment]
 
+# Why a refusal says *why* (FND-909)
+# ----------------------------------
+# Every `withhold()` path writes a byte-identical tripwire, so nothing downstream
+# can tell them apart — and only one of them heals on its own. `WINDOW_EMPTY`
+# means the bound admitted nothing on this pass while Renovate's unbounded
+# resolve moved; the next pass that sees a package cross the window resolves
+# green with no intervention. The other four are standing faults (a broken
+# interpreter, an unsatisfiable floor, a yanked pin) that no amount of waiting
+# fixes.
+#
+# The distinction is what lets the fleet reap the self-healing case on sight
+# while leaving a real wedge red for a human. Reaping on a clock instead —
+# "refuse, then recover once head age exceeds the window" — is safe but costs up
+# to a full window of delay on top of the bound, which defeats the point of
+# running the lane every four hours.
+#
+# The stamp rides as a comment on the tripwire's own line. That placement is
+# load-bearing: `strip_options()` drops the whole `[options]` table line-based,
+# so the stamp cannot survive onto a green lock, and every existing reader of
+# the window already splits on `#` before parsing the value.
+REFUSAL_WINDOW_EMPTY = "window-empty"
+REFUSAL_NO_PACKAGING = "no-packaging"
+REFUSAL_UNSATISFIABLE_FLOOR = "unsatisfiable-floor"
+REFUSAL_FLOOR_ADMITTED_STILL_FAILED = "floor-admitted-still-failed"
+REFUSAL_ROLLBACK = "rollback"
+
+# The one reason a machine may clear without a human. Kept as a set of one
+# rather than an equality check so adding a second self-healing path is a
+# one-line change here instead of an edit at every reader.
+SELF_HEALING_REFUSALS = frozenset({REFUSAL_WINDOW_EMPTY})
+
 # ISO 8601 durations, restricted to the forms a release-age window sensibly takes.
 # Calendar units are rejected rather than approximated — uv refuses months and
 # years for the same reason, and a window that silently means something other
@@ -237,7 +268,7 @@ def retention_ceilings(
     return ceilings
 
 
-def withhold(lock_path: Path, baseline: str, window: str) -> bool:
+def withhold(lock_path: Path, baseline: str, window: str, *, reason: str) -> bool:
     """Refuse in a way a REQUIRED check can see. Returns whether it wrote.
 
     The driver cannot stop Renovate committing, and it cannot abstain either.
@@ -267,6 +298,12 @@ def withhold(lock_path: Path, baseline: str, window: str) -> bool:
     required age check that fails on its own evidence rather than on a lock the
     build cannot install (FND-379).
 
+    ``reason`` is keyword-only and has no default on purpose. Every caller has to
+    say which of the five refusal paths it is, because the fleet reaps
+    ``REFUSAL_WINDOW_EMPTY`` automatically and must not reap the rest — a default
+    would let a new standing fault inherit the self-healing label silently
+    (FND-909).
+
     A branch that *adds* a brand-new ``uv.lock`` has no committed baseline to
     write back. The tripwire still goes on, over whatever the resolve left: there
     is no safer content to choose, and leaving a valid-but-unbounded lock in place
@@ -277,7 +314,7 @@ def withhold(lock_path: Path, baseline: str, window: str) -> bool:
     if not base:
         return False
     base = strip_options(base)
-    tripwire = f'\n[options]\nexclude-newer-span = "{window}"\n'
+    tripwire = f'\n[options]\nexclude-newer-span = "{window}"  # refusal: {reason}\n'
     anchor = base.find("\n[[package]]")
     lock_path.write_text(
         base[:anchor] + tripwire + base[anchor:] if anchor != -1 else base + tripwire
@@ -687,7 +724,7 @@ def main(argv: list[str] | None = None) -> int:
         # accuses every ordinary upgrade of moving backwards — a wedged lane whose
         # message blames the dependency data. Say the true cause instead, and say
         # it before uv spends a minute resolving.
-        withhold(lock_path, baseline, args.window)
+        withhold(lock_path, baseline, args.window, reason=REFUSAL_NO_PACKAGING)
         print(
             "`packaging` is not importable, so no version can be compared and the "
             "rollback gate cannot do its job. Refusing rather than bounding "
@@ -717,7 +754,12 @@ def main(argv: list[str] | None = None) -> int:
         )
         admitted_early = blocked_by_floor(result.stderr, floors)
         if not admitted_early:
-            withhold(lock_path, baseline, args.window)
+            withhold(
+                lock_path,
+                baseline,
+                args.window,
+                reason=REFUSAL_UNSATISFIABLE_FLOOR,
+            )
             print(
                 "Bounded `uv lock` failed and no deliberately-floored package was "
                 "named in the error, so there is nothing safe to admit early. "
@@ -733,7 +775,12 @@ def main(argv: list[str] | None = None) -> int:
             project_dir,
         )
         if result.returncode != 0:
-            withhold(lock_path, baseline, args.window)
+            withhold(
+                lock_path,
+                baseline,
+                args.window,
+                reason=REFUSAL_FLOOR_ADMITTED_STILL_FAILED,
+            )
             print(
                 "Bounded `uv lock` still failed after admitting "
                 f"{', '.join(admitted_early)}. The lock is left deliberately "
@@ -750,7 +797,7 @@ def main(argv: list[str] | None = None) -> int:
         detail = ", ".join(
             f"{n} {old} -> {new}" for n, (old, new) in sorted(regressed.items())
         )
-        withhold(lock_path, baseline, args.window)
+        withhold(lock_path, baseline, args.window, reason=REFUSAL_ROLLBACK)
         print(
             f"Bounded resolve moved {len(regressed)} package(s) BACKWARDS from the "
             f"last committed lock: {detail}. Retention ceilings make an age-driven "
@@ -786,7 +833,7 @@ def main(argv: list[str] | None = None) -> int:
                 file=sys.stderr,
             )
         else:
-            withhold(lock_path, baseline, args.window)
+            withhold(lock_path, baseline, args.window, reason=REFUSAL_WINDOW_EMPTY)
             print(
                 f"The bound admits nothing today, but Renovate's own unbounded "
                 f"resolve moved: {moved}. Leaving the tree matching HEAD would "

--- a/.github/scripts/tests/test_renovate_lock_refusal_census.py
+++ b/.github/scripts/tests/test_renovate_lock_refusal_census.py
@@ -1,0 +1,232 @@
+"""Tests for the lock-refusal census (FND-909).
+
+The census is the thing that decides whether the lock lane is healthy, so its
+verdicts need the same regression cover as the reaper's. Its first live run
+already proved why: an over-broad tripwire test reported six ordinary refreshes
+as refusals, which would have made the whole signal useless.
+"""
+
+from __future__ import annotations
+
+import base64
+import datetime as dt
+import json
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__))))
+
+import renovate_lock_refusal_census as census  # noqa: E402
+import renovate_uv_lock_bounded as bounded  # noqa: E402
+
+PACKAGES = '\n[[package]]\nname = "boto3"\nversion = "1.43.78"\n'
+
+
+def lock_with(options: str) -> str:
+    if not options:
+        return f"version = 1\nrevision = 3\n{PACKAGES}"
+    return f"version = 1\nrevision = 3\n\n{options}\n{PACKAGES}"
+
+
+ORDINARY = lock_with("")
+UNSTAMPED = lock_with('[options]\nexclude-newer-span = "P3D"')
+WINDOW_EMPTY = lock_with(
+    '[options]\nexclude-newer-span = "P3D"  # refusal: window-empty'
+)
+ROLLBACK = lock_with('[options]\nexclude-newer-span = "P3D"  # refusal: rollback')
+# atlan-bw-app's shape: a repo bounded through its own pyproject.toml. uv writes
+# both keys, and this must never read as a refusal.
+NATIVELY_BOUND = lock_with(
+    '[options]\nexclude-newer = "0001-01-01T00:00:00Z"\nexclude-newer-span = "P7D"'
+)
+
+
+def fake_api(*, files, lock_text, committed="2026-08-28T00:00:00Z"):
+    """A `_get` stand-in serving one PR's file list, head commit and lock."""
+
+    def get(_token, url):
+        if "/pulls/" in url and url.endswith("/files?per_page=100"):
+            return [{"filename": f} for f in files]
+        if "/pulls/" in url:
+            return {"head": {"sha": "deadbee"}}
+        if "/commits/" in url:
+            return {"commit": {"committer": {"date": committed}}}
+        if "/contents/" in url:
+            return {"content": base64.b64encode(lock_text.encode()).decode()}
+        raise AssertionError(f"unexpected url {url}")
+
+    return get
+
+
+class TestInspect:
+    def verdict(self, monkeypatch, *, files, lock_text):
+        monkeypatch.setattr(census, "_get", fake_api(files=files, lock_text=lock_text))
+        return census.inspect("tok", "atlanhq/x", 1)
+
+    def test_ordinary_single_file_refresh(self, monkeypatch):
+        verdict, reason, _ = self.verdict(
+            monkeypatch, files=["uv.lock"], lock_text=ORDINARY
+        )
+        assert (verdict, reason) == ("ordinary", None)
+
+    def test_multi_file_pr_is_ordinary(self, monkeypatch):
+        verdict, reason, _ = self.verdict(
+            monkeypatch, files=["uv.lock", "pyproject.toml"], lock_text=WINDOW_EMPTY
+        )
+        assert (verdict, reason) == ("ordinary", None)
+
+    def test_unstamped_tripwire(self, monkeypatch):
+        verdict, reason, _ = self.verdict(
+            monkeypatch, files=["uv.lock"], lock_text=UNSTAMPED
+        )
+        assert (verdict, reason) == ("unstamped_tripwire", None)
+
+    def test_a_natively_bounded_repo_is_ordinary_not_a_refusal(self, monkeypatch):
+        # The false positive the first live run produced: six repos whose locks
+        # carry uv's own [options] table were reported as frozen refusals.
+        verdict, reason, _ = self.verdict(
+            monkeypatch, files=["uv.lock"], lock_text=NATIVELY_BOUND
+        )
+        assert (verdict, reason) == ("ordinary", None)
+
+    def test_stamped_self_healing_refusal(self, monkeypatch):
+        verdict, reason, _ = self.verdict(
+            monkeypatch, files=["uv.lock"], lock_text=WINDOW_EMPTY
+        )
+        assert (verdict, reason) == ("refusal", bounded.REFUSAL_WINDOW_EMPTY)
+
+    def test_stamped_standing_fault(self, monkeypatch):
+        verdict, reason, _ = self.verdict(
+            monkeypatch, files=["uv.lock"], lock_text=ROLLBACK
+        )
+        assert (verdict, reason) == ("refusal", bounded.REFUSAL_ROLLBACK)
+
+    def test_reports_the_head_commit_date_not_the_pr_age(self, monkeypatch):
+        # Renovate rewrites a lock branch in place, so a PR opened last week can
+        # carry a refusal written an hour ago. The branch clock is the only one
+        # that dates the refusal.
+        _, _, committed = self.verdict(
+            monkeypatch, files=["uv.lock"], lock_text=WINDOW_EMPTY
+        )
+        assert committed == "2026-08-28T00:00:00Z"
+
+
+class TestMain:
+    def run(self, monkeypatch, capsys, *, lock_text, committed, argv=None):
+        monkeypatch.setenv("GITHUB_TOKEN", "tok")
+        monkeypatch.setattr(
+            census,
+            "open_lock_prs",
+            lambda _t: [
+                {
+                    "number": 1,
+                    "repository_url": "https://api.github.com/repos/atlanhq/x",
+                }
+            ],
+        )
+        monkeypatch.setattr(
+            census,
+            "_get",
+            fake_api(files=["uv.lock"], lock_text=lock_text, committed=committed),
+        )
+        code = census.main(argv or [])
+        return code, capsys.readouterr()
+
+    def hours_ago(self, hours: float) -> str:
+        moment = dt.datetime.now(dt.timezone.utc) - dt.timedelta(hours=hours)
+        return moment.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    def test_a_fresh_self_healing_refusal_passes(self, monkeypatch, capsys):
+        # One pass old: the reaper has not had its turn yet, and that is fine.
+        code, out = self.run(
+            monkeypatch, capsys, lock_text=WINDOW_EMPTY, committed=self.hours_ago(3)
+        )
+        assert code == 0
+        assert "FROZEN self-healing: 0" in out.out
+
+    def test_a_self_healing_refusal_surviving_two_passes_fails(
+        self, monkeypatch, capsys
+    ):
+        # The whole point of the script: this is the shape that means the reaper
+        # is not firing, and it has to be a non-zero exit, not a line of prose.
+        code, out = self.run(
+            monkeypatch, capsys, lock_text=WINDOW_EMPTY, committed=self.hours_ago(30)
+        )
+        assert code == 1
+        assert "FROZEN self-healing: 1" in out.out
+        assert "the reaper is not firing" in out.err
+
+    def test_an_old_standing_fault_does_not_fail_the_run(self, monkeypatch, capsys):
+        # A yanked pin is meant to stay red until a human clears it. Failing on
+        # it would train people to ignore the census.
+        code, out = self.run(
+            monkeypatch, capsys, lock_text=ROLLBACK, committed=self.hours_ago(200)
+        )
+        assert code == 0
+        assert "standing faults:     1" in out.out
+
+    def test_an_old_unstamped_tripwire_does_not_fail_the_run(self, monkeypatch, capsys):
+        # Pre-FND-909 refusals are reported for the manual migration, but the
+        # reaper is not expected to have taken them.
+        code, out = self.run(
+            monkeypatch, capsys, lock_text=UNSTAMPED, committed=self.hours_ago(200)
+        )
+        assert code == 0
+        assert "unstamped tripwire:  1" in out.out
+
+    def test_an_old_ordinary_refresh_is_not_a_finding(self, monkeypatch, capsys):
+        code, out = self.run(
+            monkeypatch, capsys, lock_text=ORDINARY, committed=self.hours_ago(500)
+        )
+        assert code == 0
+        assert "FROZEN self-healing: 0" in out.out
+        assert "standing faults:     0" in out.out
+
+    def test_json_output_is_machine_readable(self, monkeypatch, capsys):
+        code, out = self.run(
+            monkeypatch,
+            capsys,
+            lock_text=WINDOW_EMPTY,
+            committed=self.hours_ago(30),
+            argv=["--json"],
+        )
+        payload = json.loads(out.out)
+        assert code == 1
+        assert payload["total_open"] == 1
+        assert payload["frozen_self_healing"][0]["repo"] == "atlanhq/x"
+        assert (
+            payload["frozen_self_healing"][0]["reason"] == bounded.REFUSAL_WINDOW_EMPTY
+        )
+
+    def test_missing_token_fails_loudly(self, monkeypatch):
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        assert census.main([]) == 1
+
+    def test_an_uninspectable_pr_warns_and_is_skipped(self, monkeypatch, capsys):
+        monkeypatch.setenv("GITHUB_TOKEN", "tok")
+        monkeypatch.setattr(
+            census,
+            "open_lock_prs",
+            lambda _t: [
+                {
+                    "number": 1,
+                    "repository_url": "https://api.github.com/repos/atlanhq/x",
+                }
+            ],
+        )
+
+        def boom(_token, _url):
+            raise TimeoutError("api down")
+
+        monkeypatch.setattr(census, "_get", boom)
+        assert census.main([]) == 0
+        assert "::warning::" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize("hours,expected", [(8.9, False), (9.1, True)])
+def test_the_two_pass_boundary_is_where_it_says_it_is(hours, expected):
+    # Two 4-hourly passes plus a pass's own runtime. Asserted directly so the
+    # threshold cannot drift away from the cron it is derived from.
+    assert (hours > census.SURVIVED_TWO_PASSES.total_seconds() / 3600) is expected

--- a/.github/scripts/tests/test_renovate_reap_refused_locks.py
+++ b/.github/scripts/tests/test_renovate_reap_refused_locks.py
@@ -1,0 +1,373 @@
+"""Tests for the self-healing lock-refusal reaper (FND-909)."""
+
+from __future__ import annotations
+
+import base64
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__))))
+
+import renovate_reap_refused_locks as reaper  # noqa: E402
+import renovate_uv_lock_bounded as bounded  # noqa: E402
+
+PACKAGES = """
+[[package]]
+name = "boto3"
+version = "1.43.78"
+source = { registry = "https://pypi.org/simple" }
+"""
+
+
+# A lock with no [options] table, shaped the way uv emits one. Kept free of
+# stray blank runs because strip_options() collapses 3+ newlines, so a padded
+# fixture would fail the round-trip assertion for a reason that is not a bug.
+BASELINE = f"version = 1\nrevision = 3\n{PACKAGES}"
+
+
+def lock_with(options: str) -> str:
+    if not options:
+        return BASELINE
+    return f"version = 1\nrevision = 3\n\n{options}\n{PACKAGES}"
+
+
+class TestRefusalReason:
+    def test_reads_the_stamp_the_driver_writes(self):
+        # Coupled to withhold() on purpose: this asserts the exact bytes the
+        # driver produces, so a change to the stamp format fails here rather
+        # than silently making every refusal unreapable.
+        text = lock_with(
+            '[options]\nexclude-newer-span = "P3D"  # refusal: window-empty'
+        )
+        assert reaper.refusal_reason(text) == bounded.REFUSAL_WINDOW_EMPTY
+
+    @pytest.mark.parametrize(
+        "reason",
+        [
+            bounded.REFUSAL_NO_PACKAGING,
+            bounded.REFUSAL_UNSATISFIABLE_FLOOR,
+            bounded.REFUSAL_FLOOR_ADMITTED_STILL_FAILED,
+            bounded.REFUSAL_ROLLBACK,
+        ],
+    )
+    def test_reads_every_standing_fault_reason(self, reason):
+        text = lock_with(f'[options]\nexclude-newer-span = "P3D"  # refusal: {reason}')
+        assert reaper.refusal_reason(text) == reason
+
+    def test_no_options_table_is_none(self):
+        assert reaper.refusal_reason(lock_with("")) is None
+
+    def test_an_unstamped_tripwire_is_none(self):
+        # The pre-FND-909 shape. Must NOT read as self-healing.
+        text = lock_with('[options]\nexclude-newer-span = "P3D"')
+        assert reaper.refusal_reason(text) is None
+
+    def test_uvs_own_options_table_is_none(self):
+        text = lock_with(
+            '[options]\nexclude-newer = "0001-01-01T00:00:00Z"\n'
+            'exclude-newer-span = "P7D"'
+        )
+        assert reaper.refusal_reason(text) is None
+
+    def test_a_stamp_after_the_options_table_is_not_read(self):
+        # A `# refusal:` string anywhere else in a 5000-line lock — a package
+        # named for it, a URL fragment — must not be mistaken for the stamp.
+        text = lock_with('[options]\nexclude-newer-span = "P3D"') + (
+            '\n[[package]]\nname = "x"  # refusal: window-empty\n'
+        )
+        assert reaper.refusal_reason(text) is None
+
+    def test_options_subtable_does_not_end_the_table(self):
+        text = lock_with(
+            '[options]\nexclude-newer-span = "P3D"\n'
+            "[options.exclude-newer-package]\n"
+            'aiohttp = "2026-08-06T00:00:00Z"'
+        )
+        assert reaper.refusal_reason(text) is None
+
+
+class TestIsTripwire:
+    """Found by running the census live: `[options] in text` called six ordinary
+    refreshes refusals, because uv writes its own table in any repo that
+    declares a bound in pyproject.toml."""
+
+    def test_a_lone_span_is_the_drivers_tripwire(self):
+        assert is_tripwire_lock('[options]\nexclude-newer-span = "P3D"') is True
+
+    def test_a_stamped_span_is_the_drivers_tripwire(self):
+        assert (
+            is_tripwire_lock(
+                '[options]\nexclude-newer-span = "P3D"  # refusal: window-empty'
+            )
+            is True
+        )
+
+    def test_uvs_own_table_is_not_a_tripwire(self):
+        # atlan-bw-app's shape: `[tool.uv] exclude-newer = "7 days"` in
+        # pyproject makes uv record BOTH keys. withhold() only ever writes the
+        # span, so the pair is proof uv wrote it.
+        assert (
+            is_tripwire_lock(
+                '[options]\nexclude-newer = "0001-01-01T00:00:00Z"\n'
+                'exclude-newer-span = "P7D"'
+            )
+            is False
+        )
+
+    def test_uvs_pinned_date_alone_is_not_a_tripwire(self):
+        assert (
+            is_tripwire_lock('[options]\nexclude-newer = "2026-08-18T10:29:39Z"')
+            is False
+        )
+
+    def test_no_options_table_is_not_a_tripwire(self):
+        assert reaper.is_tripwire(lock_with("")) is False
+
+    def test_an_exclude_newer_package_subtable_does_not_confer_tripwire(self):
+        assert (
+            is_tripwire_lock(
+                '[options]\nexclude-newer = "0001-01-01T00:00:00Z"\n'
+                'exclude-newer-span = "P7D"\n'
+                "[options.exclude-newer-package]\n"
+                'aiohttp = "2026-08-06T00:00:00Z"'
+            )
+            is False
+        )
+
+
+def is_tripwire_lock(options: str) -> bool:
+    return reaper.is_tripwire(lock_with(options))
+
+
+class TestShouldReap:
+    def stamped(self, reason: str) -> str:
+        return lock_with(f'[options]\nexclude-newer-span = "P3D"  # refusal: {reason}')
+
+    def test_reaps_the_self_healing_reason(self):
+        assert should_reap_lock(self.stamped(bounded.REFUSAL_WINDOW_EMPTY)) is True
+
+    @pytest.mark.parametrize(
+        "reason",
+        [
+            bounded.REFUSAL_NO_PACKAGING,
+            bounded.REFUSAL_UNSATISFIABLE_FLOOR,
+            bounded.REFUSAL_FLOOR_ADMITTED_STILL_FAILED,
+            bounded.REFUSAL_ROLLBACK,
+        ],
+    )
+    def test_keeps_every_standing_fault(self, reason):
+        # Reaping these would recycle a real wedge every four hours and hide it
+        # behind a lane that looks busy.
+        assert should_reap_lock(self.stamped(reason)) is False
+
+    def test_keeps_an_unstamped_tripwire(self):
+        assert should_reap_lock(lock_with('[options]\nexclude-newer-span = "P3D"')) is (
+            False
+        )
+
+    def test_keeps_an_ordinary_lock_refresh(self):
+        assert should_reap_lock(lock_with("")) is False
+
+    def test_keeps_a_multi_file_pr_even_when_stamped(self):
+        # withhold() writes the baseline back, so a genuine refusal can never
+        # touch a second file. A stamped lock alongside another change is not a
+        # refusal and must not be deleted.
+        assert (
+            reaper.should_reap(
+                ["uv.lock", "pyproject.toml"],
+                self.stamped(bounded.REFUSAL_WINDOW_EMPTY),
+            )
+            is False
+        )
+
+    def test_reaps_a_nested_lock(self):
+        assert (
+            reaper.should_reap(
+                ["services/api/uv.lock"], self.stamped(bounded.REFUSAL_WINDOW_EMPTY)
+            )
+            is True
+        )
+
+    def test_keeps_a_lookalike_filename(self):
+        assert (
+            reaper.should_reap(
+                ["my-uv.lock.bak"], self.stamped(bounded.REFUSAL_WINDOW_EMPTY)
+            )
+            is False
+        )
+
+
+def should_reap_lock(lock_text: str) -> bool:
+    return reaper.should_reap(["uv.lock"], lock_text)
+
+
+class TestFindRefusal:
+    def fake_fetch(self, *, files, lock_text, pr_number=7):
+        calls: list[str] = []
+
+        def fetch(token, url, _method):
+            calls.append(url)
+            if "/pulls?" in url:
+                return [{"number": pr_number, "head": {"sha": "abc1234def"}}]
+            if url.endswith("/files?per_page=100"):
+                return [{"filename": f} for f in files]
+            if "/contents/" in url:
+                return {"content": base64.b64encode(lock_text.encode()).decode()}
+            raise AssertionError(f"unexpected url {url}")
+
+        fetch.calls = calls  # type: ignore[attr-defined]
+        return fetch
+
+    def test_finds_a_self_healing_refusal(self):
+        text = lock_with(
+            '[options]\nexclude-newer-span = "P3D"  # refusal: window-empty'
+        )
+        fetch = self.fake_fetch(files=["uv.lock"], lock_text=text)
+        pr = reaper.find_refusal("tok", "atlanhq/x", fetch)
+        assert pr is not None and pr["number"] == 7
+
+    def test_returns_none_for_a_standing_fault(self):
+        text = lock_with('[options]\nexclude-newer-span = "P3D"  # refusal: rollback')
+        fetch = self.fake_fetch(files=["uv.lock"], lock_text=text)
+        assert reaper.find_refusal("tok", "atlanhq/x", fetch) is None
+
+    def test_does_not_fetch_contents_for_a_multi_file_pr(self):
+        # The short-circuit exists to keep the reaper to two API calls on the
+        # common case; assert it rather than trusting it.
+        fetch = self.fake_fetch(files=["uv.lock", "pyproject.toml"], lock_text="")
+        assert reaper.find_refusal("tok", "atlanhq/x", fetch) is None
+        assert not any("/contents/" in u for u in fetch.calls)
+
+    def test_no_open_pr_is_none(self):
+        def fetch(token, url, _method):
+            return []
+
+        assert reaper.find_refusal("tok", "atlanhq/x", fetch) is None
+
+    def test_queries_only_the_lock_maintenance_branch(self):
+        # The reaper deletes branches. It must never be able to select one
+        # outside the preset's lock lane.
+        text = lock_with(
+            '[options]\nexclude-newer-span = "P3D"  # refusal: window-empty'
+        )
+        fetch = self.fake_fetch(files=["uv.lock"], lock_text=text)
+        reaper.find_refusal("tok", "atlanhq/x", fetch)
+        assert f"head=atlanhq:{reaper.BRANCH}" in fetch.calls[0]
+        assert all(reaper.BRANCH in u or "/files?" in u for u in fetch.calls)
+
+
+class TestMain:
+    def test_dry_run_deletes_nothing(self, monkeypatch, capsys):
+        monkeypatch.setenv("GITHUB_TOKEN", "tok")
+        monkeypatch.setattr(
+            reaper,
+            "find_refusal",
+            lambda *a, **k: {"number": 7, "head": {"sha": "a" * 8}},
+        )
+        deleted: list[str] = []
+        monkeypatch.setattr(reaper, "_request", lambda *a, **k: deleted.append(a[1]))
+        assert reaper.main(["--repo", "atlanhq/x", "--dry-run"]) == 0
+        assert deleted == []
+        assert "dry run" in capsys.readouterr().out
+
+    def test_a_live_run_deletes_exactly_the_lock_branch_ref(self, monkeypatch):
+        monkeypatch.setenv("GITHUB_TOKEN", "tok")
+        monkeypatch.setattr(
+            reaper,
+            "find_refusal",
+            lambda *a, **k: {"number": 7, "head": {"sha": "a" * 8}},
+        )
+        calls: list[tuple[str, str]] = []
+
+        def fake_request(token, url, method="GET"):
+            calls.append((url, method))
+
+        monkeypatch.setattr(reaper, "_request", fake_request)
+        assert reaper.main(["--repo", "atlanhq/x"]) == 0
+        assert calls == [
+            (
+                f"{reaper.API_ROOT}/repos/atlanhq/x/git/refs/heads/{reaper.BRANCH}",
+                "DELETE",
+            )
+        ]
+
+    def test_missing_token_fails_loudly(self, monkeypatch):
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        assert reaper.main(["--repo", "atlanhq/x"]) == 1
+
+    def test_an_api_failure_warns_and_does_not_stop_the_pass(self, monkeypatch, capsys):
+        # Renovate runs after this step. A reaper outage must cost one cycle of
+        # recovery latency, never the lock refresh itself.
+        monkeypatch.setenv("GITHUB_TOKEN", "tok")
+
+        def boom(*a, **k):
+            raise TimeoutError("api down")
+
+        monkeypatch.setattr(reaper, "find_refusal", boom)
+        assert reaper.main(["--repo", "atlanhq/x"]) == 0
+        assert "::warning::" in capsys.readouterr().out
+
+
+class TestStampRoundTrip:
+    """The driver and the reaper have to agree on the bytes, in both directions."""
+
+    def test_withhold_writes_a_stamp_the_reaper_reads(self, tmp_path):
+        target = tmp_path / "uv.lock"
+        baseline = lock_with("")
+        target.write_text(baseline)
+        bounded.withhold(target, baseline, "P3D", reason=bounded.REFUSAL_WINDOW_EMPTY)
+        written = target.read_text()
+        assert reaper.refusal_reason(written) == bounded.REFUSAL_WINDOW_EMPTY
+        assert reaper.should_reap(["uv.lock"], written) is True
+
+    @pytest.mark.parametrize(
+        "reason",
+        [
+            bounded.REFUSAL_NO_PACKAGING,
+            bounded.REFUSAL_UNSATISFIABLE_FLOOR,
+            bounded.REFUSAL_FLOOR_ADMITTED_STILL_FAILED,
+            bounded.REFUSAL_ROLLBACK,
+        ],
+    )
+    def test_a_standing_fault_round_trips_as_unreapable(self, tmp_path, reason):
+        target = tmp_path / "uv.lock"
+        baseline = lock_with("")
+        target.write_text(baseline)
+        bounded.withhold(target, baseline, "P3D", reason=reason)
+        assert reaper.should_reap(["uv.lock"], target.read_text()) is False
+
+    def test_the_stamp_never_survives_onto_a_green_lock(self, tmp_path):
+        # strip_options() runs on the success path. If the stamp survived it, a
+        # merged lock would carry a refusal marker and the reaper would delete
+        # healthy branches.
+        target = tmp_path / "uv.lock"
+        baseline = lock_with("")
+        target.write_text(baseline)
+        bounded.withhold(target, baseline, "P3D", reason=bounded.REFUSAL_WINDOW_EMPTY)
+        recovered = bounded.strip_options(target.read_text())
+        assert recovered == baseline
+        assert reaper.refusal_reason(recovered) is None
+
+    def test_the_window_still_parses_with_a_stamp_present(self, tmp_path):
+        # conformance.renovate.classify reads the window by splitting on '#'.
+        # Assert the driver's own writer stays compatible with that reader.
+        target = tmp_path / "uv.lock"
+        baseline = lock_with("")
+        target.write_text(baseline)
+        bounded.withhold(target, baseline, "P3D", reason=bounded.REFUSAL_WINDOW_EMPTY)
+        for line in target.read_text().splitlines():
+            if line.strip().startswith("exclude-newer-span"):
+                value = line.split("=", 1)[1].split("#")[0].strip().strip('"')
+                assert value == "P3D"
+                break
+        else:
+            raise AssertionError("no exclude-newer-span line was written")
+
+
+def test_self_healing_set_is_exactly_the_window_case():
+    # A guard on the blast radius: if someone adds a reason to
+    # SELF_HEALING_REFUSALS, that is a decision to auto-delete branches carrying
+    # it, and it should not pass review unnoticed.
+    assert bounded.SELF_HEALING_REFUSALS == frozenset({bounded.REFUSAL_WINDOW_EMPTY})

--- a/.github/scripts/tests/test_renovate_reap_refused_locks.py
+++ b/.github/scripts/tests/test_renovate_reap_refused_locks.py
@@ -258,9 +258,84 @@ class TestFindRefusal:
         assert all(reaper.BRANCH in u or "/files?" in u for u in fetch.calls)
 
 
+class TestIsDryRun:
+    """A dry run that reaped for real would delete lock branches across the
+    whole matrix and then skip opening the replacements — worse than the freeze
+    this script clears. So the default direction is 'refuse to delete'."""
+
+    def test_the_literal_null_the_workflow_sends_is_a_live_run(self):
+        # `${{ inputs.dry_run || 'null' }}` on a scheduled pass.
+        assert reaper.is_dry_run("null", False) is False
+
+    @pytest.mark.parametrize("mode", ["full", "extract", "lookup"])
+    def test_every_renovate_dry_run_mode_is_a_dry_run(self, mode):
+        assert reaper.is_dry_run(mode, False) is True
+
+    def test_an_unrecognised_mode_fails_safe(self):
+        assert reaper.is_dry_run("something-new", False) is True
+
+    def test_unset_is_a_live_run(self):
+        # Direct invocation outside the workflow, where --dry-run is the lever.
+        assert reaper.is_dry_run(None, False) is False
+        assert reaper.is_dry_run("", False) is False
+
+    def test_whitespace_around_null_is_still_live(self):
+        assert reaper.is_dry_run("  null  ", False) is False
+
+    def test_the_flag_wins_over_a_live_env(self):
+        assert reaper.is_dry_run("null", True) is True
+
+
 class TestMain:
-    def test_dry_run_deletes_nothing(self, monkeypatch, capsys):
+    def test_a_dry_run_pass_deletes_nothing(self, monkeypatch, capsys):
+        # The regression this guards: without the env check, `workflow_dispatch`
+        # with dry_run=full deleted real branches across the matrix.
         monkeypatch.setenv("GITHUB_TOKEN", "tok")
+        monkeypatch.setenv("RENOVATE_DRY_RUN", "full")
+        monkeypatch.setattr(
+            reaper,
+            "find_refusal",
+            lambda *a, **k: {"number": 7, "head": {"sha": "a" * 8}},
+        )
+        deleted: list[str] = []
+        monkeypatch.setattr(reaper, "_request", lambda *a, **k: deleted.append(a[1]))
+        assert reaper.main(["--repo", "atlanhq/x"]) == 0
+        assert deleted == []
+        assert "dry run" in capsys.readouterr().out
+
+    def test_a_live_pass_with_the_workflows_null_deletes(self, monkeypatch):
+        monkeypatch.setenv("GITHUB_TOKEN", "tok")
+        monkeypatch.setenv("RENOVATE_DRY_RUN", "null")
+        monkeypatch.setattr(
+            reaper,
+            "find_refusal",
+            lambda *a, **k: {"number": 7, "head": {"sha": "a" * 8}},
+        )
+        deleted: list[str] = []
+        monkeypatch.setattr(reaper, "_request", lambda *a, **k: deleted.append(a[1]))
+        assert reaper.main(["--repo", "atlanhq/x"]) == 0
+        assert deleted == [
+            f"{reaper.API_ROOT}/repos/atlanhq/x/git/refs/heads/{reaper.BRANCH}"
+        ]
+
+    def test_repo_comes_from_target_repo_env(self, monkeypatch, capsys):
+        # The workflow passes it as env so no matrix value lands in `run:`.
+        monkeypatch.setenv("GITHUB_TOKEN", "tok")
+        monkeypatch.setenv("TARGET_REPO", "atlanhq/from-env")
+        monkeypatch.setattr(reaper, "find_refusal", lambda *a, **k: None)
+        assert reaper.main([]) == 0
+        assert "atlanhq/from-env" in capsys.readouterr().out
+
+    def test_no_repo_anywhere_fails(self, monkeypatch):
+        monkeypatch.setenv("GITHUB_TOKEN", "tok")
+        monkeypatch.delenv("TARGET_REPO", raising=False)
+        assert reaper.main([]) == 1
+
+    def test_the_flag_alone_stops_a_delete_on_a_live_env(self, monkeypatch, capsys):
+        # The env says live; the flag must still win, so a human can rehearse
+        # against a real repo without deleting anything.
+        monkeypatch.setenv("GITHUB_TOKEN", "tok")
+        monkeypatch.setenv("RENOVATE_DRY_RUN", "null")
         monkeypatch.setattr(
             reaper,
             "find_refusal",
@@ -272,8 +347,9 @@ class TestMain:
         assert deleted == []
         assert "dry run" in capsys.readouterr().out
 
-    def test_a_live_run_deletes_exactly_the_lock_branch_ref(self, monkeypatch):
+    def test_the_delete_is_a_DELETE_on_exactly_the_lock_branch_ref(self, monkeypatch):
         monkeypatch.setenv("GITHUB_TOKEN", "tok")
+        monkeypatch.setenv("RENOVATE_DRY_RUN", "null")
         monkeypatch.setattr(
             reaper,
             "find_refusal",

--- a/.github/scripts/tests/test_renovate_uv_lock_bounded.py
+++ b/.github/scripts/tests/test_renovate_uv_lock_bounded.py
@@ -1193,7 +1193,10 @@ class TestWithholds:
         # and writing a bare [options] table would be a lock nobody can recover.
         target = tmp_path / "uv.lock"
         target.write_text("")
-        assert bounded.withhold(target, "", "P3D") is False
+        assert (
+            bounded.withhold(target, "", "P3D", reason=bounded.REFUSAL_WINDOW_EMPTY)
+            is False
+        )
         assert target.read_text() == ""
 
     def test_withhold_does_not_stack_options_tables(self, tmp_path):
@@ -1202,7 +1205,9 @@ class TestWithholds:
         # a recoverable lock.
         target = tmp_path / "uv.lock"
         target.write_text(LOCK_WITH_OPTIONS)
-        assert bounded.withhold(target, "", "P3D") is True
+        assert (
+            bounded.withhold(target, "", "P3D", reason=bounded.REFUSAL_ROLLBACK) is True
+        )
         written = target.read_text()
         assert written.count("[options]") == 1
         assert 'exclude-newer-span = "P3D"' in written
@@ -1214,7 +1219,12 @@ class TestWithholds:
         baseline = lock(boto3="1.43.72")
         target = tmp_path / "uv.lock"
         target.write_text(lock(boto3="1.43.99"))
-        assert bounded.withhold(target, baseline, "P3D") is True
+        assert (
+            bounded.withhold(
+                target, baseline, "P3D", reason=bounded.REFUSAL_WINDOW_EMPTY
+            )
+            is True
+        )
         written = target.read_text()
         assert 'exclude-newer-span = "P3D"' in written
         # Recoverable: a human, or the next run, gets the baseline back exactly.

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -185,7 +185,15 @@ jobs:
       - name: Reap self-healing lock refusals
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: python3 .github/scripts/renovate_reap_refused_locks.py --repo "${{ matrix.repo }}"
+          # Both passed as env rather than interpolated into `run:`. TARGET_REPO
+          # keeps a matrix value out of the shell line, and RENOVATE_DRY_RUN is
+          # what stops a dry run deleting real branches: the job-level default
+          # is the literal 'null' for a live run, and the script treats anything
+          # else as --dry-run. Resolving that inside the script keeps the `run:`
+          # line branch-free, per docs/standards/ci.md.
+          TARGET_REPO: ${{ matrix.repo }}
+          RENOVATE_DRY_RUN: ${{ env.RENOVATE_DRY_RUN }}
+        run: python3 .github/scripts/renovate_reap_refused_locks.py
 
       - name: Run Renovate
         env:

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -173,6 +173,20 @@ jobs:
         # multiple times a week). Keep in step with the setup-node version above.
         run: npm install -g renovate@43.265.3
 
+      # Reap a lock-maintenance branch whose refusal will clear itself, so this
+      # pass rebuilds it. Ordered immediately before Renovate on purpose: the
+      # branch is deleted and recreated inside one job, so the repo is never
+      # left without a lock PR and the PR timeline shows no delete/recreate
+      # churn. Only refusals stamped `window-empty` are reaped — a yanked pin or
+      # an unsatisfiable floor keeps its tripwire and stays red for a human,
+      # because recycling one of those every four hours would hide it. Never
+      # fails the job: Renovate runs regardless, so a reaper outage costs one
+      # cycle of recovery latency, not the lock refresh (FND-909).
+      - name: Reap self-healing lock refusals
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: python3 .github/scripts/renovate_reap_refused_locks.py --repo "${{ matrix.repo }}"
+
       - name: Run Renovate
         env:
           RENOVATE_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Problem

`withhold()` refuses a bounded lock resolve by writing a lock the image build cannot install, which reds a required check and holds the branch. That is deliberate and documented. What is missing is any way out: the tripwire carries no clock, and Renovate re-runs `postUpgradeTasks` only on a package-file change, a conflict, or a manual rebase tick. A refusal written at T is still red at T+7d.

The fleet cron is every four hours against a three-day bound — 18 runs per window. After any successful lock merge, everything at least three days old is already in HEAD, so the next pass's newly-admissible set is only the four-hour slice that just crossed the line, and is usually empty. Meanwhile the unbounded resolve always moves (boto3, botocore and types-protobuf ship daily). `withhold()` fires on exactly that pair, so **a permanent freeze is the modal outcome of the lane, not an edge case.**

Measured 2026-08-28: five frozen PRs, with all four canonical apps among them. Deleting the branches by hand (as FND-909 originally prescribed) produced clean rebuilds that merged and then re-froze about eleven hours later.

## Why not recover on a clock

`conformance.renovate.classify.bounded_lock_refusal_expired` already detects this shape, but it cannot tell which of the five refusal paths wrote the tripwire, so it has to prove expiry by branch age (head older than the window). That is sound and too slow: it waits a full window when the bound may have admitted something four hours in, which reintroduces the delay the four-hourly cadence exists to avoid.

## Change

**1. The driver stamps why it refused.** `withhold()` writes the reason as a comment on the tripwire's own line:

```
exclude-newer-span = "P3D"  # refusal: window-empty
```

`reason` is keyword-only with no default, so a new refusal path cannot inherit the self-healing label by omission — the three existing direct callers failed loudly and had to choose. Placement is load-bearing: `strip_options()` drops the whole `[options]` table, so a stamp can never survive onto a green lock, and every existing reader already splits the window on `#`.

Only one of the five refusal reasons heals on its own (`window-empty`). The other four — a broken interpreter, an unsatisfiable floor, a floor admitted that still failed, a yanked-pin rollback — are standing faults that no amount of waiting fixes.

**2. A reaper deletes `window-empty` branches on sight**, with no clock, from a step placed immediately before Renovate in the existing per-repo matrix job. Because it runs in the same job, the branch is rebuilt in the same pass: there is no window where the repo has no lock PR and no delete/recreate churn in the timeline. It never fails the job — Renovate runs regardless, so a reaper outage costs one cycle of recovery latency rather than the lock refresh itself.

Reasons 1–4 keep their tripwire and stay red for a human. Reaping those would recycle a real wedge every four hours and hide it behind a lane that looks busy.

**3. A census script** as the standing verdict on the lane. Checking the PR numbers a ticket names proves only that the lane moved: over two days the frozen set held at five while its membership rotated by four repos. The census counts refusals across every open lock PR and exits non-zero when a self-healing one survives two passes.

Resulting latency: the first four-hourly pass after a package clears `P3D` resolves green and merges. **Worst case four hours past the cooldown**, which is the cadence floor.

## Validation

* **Unit** — 37 new tests; the full CI-script suite (3430) and the conformance classifier suite (79) pass. Backward-compat is verified against the *real* `conformance.renovate.classify`, not a mock: a stamped tripwire still parses as `P3D`.
* **Live census** — run against the fleet before and after the discriminator fix below. Baseline: 80 open lock PRs, 75 ordinary, 5 unstamped tripwires, 0 standing faults.
* **The census found a bug in itself on its first live run.** Testing for the presence of an `[options]` table called six ordinary refreshes refusals, because uv writes its own table in any repo bounded via `pyproject.toml` (`atlan-bw-app`). The discriminator is a *lone* `exclude-newer-span` with no `exclude-newer` — the same one `conformance` uses. After the fix the census (5) agrees with an independent `+3/−0` diff sweep (5).

Still outstanding, and deliberately not claimed as done here:

* **Forced repro** — a fleet dispatch scoped to one repo, to confirm from the job log that the reaper fired and Renovate rebuilt in the same pass. Needs this on `main` first.
* **Migration** — the five live tripwires predate stamping, so the reaper leaves them alone by design ("no reason given" must never read as self-healing). They need one manual branch deletion each.
* **Latency measurement** — after the above.

## Security-relevant

Touches `.github/workflows/renovate.yaml`, a CI control-plane file. The new step grants no permission the job did not already hold; it uses the same fleet App token Renovate uses to write these branches. The reaper can only ever select `renovate/lock-file-maintenance` — the branch name is a module constant, not an argument, so a caller cannot widen the set it deletes from.

Closes FND-909.